### PR TITLE
Use cci build context. Remove unneeded options from eip712.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,17 +130,20 @@ jobs:
 
 # Repeatable config for defining the workflow below.
 tag_regex: &tag_regex /v[0-9]+(\.[0-9]+)*(-[a-zA-Z-]+\.[0-9]+)?/
-tag_filter: &tag_filter
-  tags:
-    only: *tag_regex
+defaults: &defaults
+  filters:
+    tags:
+      only: *tag_regex
+  context:
+    - build
 yarn_project: &yarn_project
   requires:
     - yarn-project-base
-  filters: *tag_filter
+  <<: *defaults
 e2e_test: &e2e_test
   requires:
     - e2e-join
-  filters: *tag_filter
+  <<: *defaults
 
 workflows:
   system:
@@ -148,7 +151,7 @@ workflows:
       equal: [system, << pipeline.parameters.workflow >>]
     jobs:
       - yarn-project-base:
-          filters: *tag_filter
+          <<: *defaults
       - ethereum-js: *yarn_project
       - aztec-js: *yarn_project
       - end-to-end: *yarn_project
@@ -157,5 +160,5 @@ workflows:
             - ethereum-js
             - aztec-js
             - end-to-end
-          filters: *tag_filter
+          <<: *defaults
       - e2e-deploy-contract: *e2e_test

--- a/yarn-project/ethereum.js/src/contract/contract.ts
+++ b/yarn-project/ethereum.js/src/contract/contract.ts
@@ -120,12 +120,6 @@ export class Contract<T extends ContractDefinition | void = void> {
     return this.executorFactory([new ContractFunctionEntry(abiEntry)]);
   }
 
-  // public async getTransactionReceipt(txHash: TxHash)
-
-  // public async getError(txHash: TxHash) {
-  //   return await decodeErrorFromContractByTxHash(this.contractAbi, txHash, this.eth);
-  // }
-
   // PRIVATE METHODS
 
   private executorFactory(functions: ContractFunctionEntry[]): TxFactory {

--- a/yarn-project/ethereum.js/src/eth_typed_data/eip-712.test.ts
+++ b/yarn-project/ethereum.js/src/eth_typed_data/eip-712.test.ts
@@ -29,9 +29,7 @@ describe('getDependencies', () => {
     expect(getDependencies(arrayTypedData, 'Person')).toStrictEqual(['Person']);
     expect(getDependencies(arrayTypedData, 'Mail')).toStrictEqual(['Mail', 'Person']);
 
-    expect(getDependencies(customTypedData, 'FooBarDomain', { domain: 'FooBarDomain' })).toStrictEqual([
-      'FooBarDomain',
-    ]);
+    expect(getDependencies(customTypedData, 'FooBarDomain')).toStrictEqual(['FooBarDomain']);
   });
 
   it.skip('throws for invalid JSON data', () => {
@@ -65,7 +63,7 @@ describe('encodeType', () => {
       'TransactionApproval(address owner,Transaction transaction)Transaction(address to,uint256 amount,bytes data,uint256 nonce)',
     );
 
-    expect(encodeType(customTypedData, 'FooBarDomain', { domain: 'FooBarDomain' })).toBe(
+    expect(encodeType(customTypedData, 'FooBarDomain')).toBe(
       'FooBarDomain(string name,string version,uint256 chainId,address verifyingContract)',
     );
   });
@@ -113,7 +111,7 @@ describe('getTypeHash', () => {
       'b9d8c78acf9b987311de6c7b45bb6a9c8e1bf361fa7fd3467a2163f994c79500',
     );
 
-    expect(bytesToHex(getTypeHash(customTypedData, 'FooBarDomain', { domain: 'FooBarDomain' }))).toBe(
+    expect(bytesToHex(getTypeHash(customTypedData, 'FooBarDomain'))).toBe(
       '85b412c5db9e26aa4f6bf794e72b1557f463a0978ceef9acaff7f6ff1eb24e57',
     );
   });
@@ -149,9 +147,7 @@ describe('encodeData', () => {
       'c81112a69b6596b8bc0678e67d97fbf9bed619811fc781419323ec02d1c7290dafd2599280d009dcb3e261f4bccebec901d67c3f54b56d49bf8327359fc69cd7392bb8ab5338a9075ce8fec1b431e334007d4de1e5e83201ca35762e24428e24b7c4150525d88db452c5f08f93f4593daa458ab6280b012532183aed3a8e4a01',
     );
 
-    expect(
-      bytesToHex(encodeData(customTypedData, 'FooBarDomain', customTypedData.domain, { domain: 'FooBarDomain' })),
-    ).toBe(
+    expect(bytesToHex(encodeData(customTypedData, 'FooBarDomain', customTypedData.domain))).toBe(
       '85b412c5db9e26aa4f6bf794e72b1557f463a0978ceef9acaff7f6ff1eb24e57c70ef06638535b4881fafcac8287e210e3769ff1a8e91f1b95d6246e61e4d3c6c89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc60000000000000000000000000000000000000000000000000000000000000001000000000000000000000000cccccccccccccccccccccccccccccccccccccccc',
     );
   });
@@ -228,7 +224,7 @@ describe('getMessage', () => {
     expect(bytesToHex(getMessage(arrayTypedData))).toBe(
       '1901f2cee375fa42b42143804025fc449deafd50cc031ca257e0b194a650a912090f6757567025d2ba15d5ebb228ea677055b8b601007e60e9463f6ed7c68f918189',
     );
-    expect(bytesToHex(getMessage(customTypedData, false, { domain: 'FooBarDomain' }))).toBe(
+    expect(bytesToHex(getMessage(customTypedData, false, 'FooBarDomain'))).toBe(
       '19016ff4505ed33bedaadf3491aa039d9ccb91a3114eeab940e69fdecb809fb268826757567025d2ba15d5ebb228ea677055b8b601007e60e9463f6ed7c68f918189',
     );
   });
@@ -243,7 +239,7 @@ describe('getMessage', () => {
     expect(bytesToHex(getMessage(arrayTypedData, true))).toBe(
       'c6f6c8028eadb17bc5c9e2ea2f738e92e49cfa627d19896c250fd2eac653e4e0',
     );
-    expect(bytesToHex(getMessage(customTypedData, true, { domain: 'FooBarDomain' }))).toBe(
+    expect(bytesToHex(getMessage(customTypedData, true, 'FooBarDomain'))).toBe(
       'e028c0622beef9bde70e78a98c1d09a95ffe0cd9cfa5ff6a99f7db7c9245e103',
     );
   });

--- a/yarn-project/ethereum.js/src/eth_typed_data/eip-712.ts
+++ b/yarn-project/ethereum.js/src/eth_typed_data/eip-712.ts
@@ -4,18 +4,11 @@ import { abiCoder } from '../contract/index.js';
 
 const EIP_191_PREFIX = Buffer.from('1901', 'hex');
 
-type Options = any;
-
 /**
  * Get the dependencies of a struct type. If a struct has the same dependency multiple times, it's only included once
  * in the resulting array.
  */
-export const getDependencies = (
-  typedData: TypedData,
-  type: string,
-  options?: Options,
-  dependencies: string[] = [],
-): string[] => {
+export const getDependencies = (typedData: TypedData, type: string, dependencies: string[] = []): string[] => {
   const TYPE_REGEX = /^\w+/;
   const match = type.match(TYPE_REGEX)!;
   const actualType = match[0];
@@ -32,9 +25,7 @@ export const getDependencies = (
     ...typedData.types[actualType].reduce<string[]>(
       (previous, type) => [
         ...previous,
-        ...getDependencies(typedData, type.type, options, previous).filter(
-          dependency => !previous.includes(dependency),
-        ),
+        ...getDependencies(typedData, type.type, previous).filter(dependency => !previous.includes(dependency)),
       ],
       [],
     ),
@@ -49,8 +40,8 @@ export const getDependencies = (
  * @param {Options} [options]
  * @return {string}
  */
-export const encodeType = (typedData: TypedData, type: string, options?: Options): string => {
-  const [primary, ...dependencies] = getDependencies(typedData, type, options);
+export const encodeType = (typedData: TypedData, type: string): string => {
+  const [primary, ...dependencies] = getDependencies(typedData, type);
   const types = [primary, ...dependencies.sort()];
 
   return types
@@ -63,20 +54,15 @@ export const encodeType = (typedData: TypedData, type: string, options?: Options
 /**
  * Get a type string as hash.
  */
-export const getTypeHash = (typedData: TypedData, type: string, options?: Options) => {
-  return keccak256(Buffer.from(encodeType(typedData, type, options)));
+export const getTypeHash = (typedData: TypedData, type: string) => {
+  return keccak256(Buffer.from(encodeType(typedData, type)));
 };
 
 /**
  * Encodes a single value to an ABI serialisable string, number or Buffer. Returns the data as tuple, which consists of
  * an array of ABI compatible types, and an array of corresponding values.
  */
-const encodeValue = (
-  typedData: TypedData,
-  type: string,
-  data: unknown,
-  options?: Options,
-): [string, Buffer | string] => {
+const encodeValue = (typedData: TypedData, type: string, data: unknown): [string, Buffer | string] => {
   // Checks for array types
   const ARRAY_REGEX = /^(.*)\[([0-9]*?)]$/;
   const match = type.match(ARRAY_REGEX);
@@ -92,7 +78,7 @@ const encodeValue = (
       throw new Error(`Cannot encode data: expected length of ${length}, but got ${data.length}`);
     }
 
-    const encodedData = data.map(item => encodeValue(typedData, arrayType, item, options));
+    const encodedData = data.map(item => encodeValue(typedData, arrayType, item));
     const types = encodedData.map(item => item[0]);
     const values = encodedData.map(item => item[1]);
 
@@ -100,7 +86,7 @@ const encodeValue = (
   }
 
   if (typedData.types[type]) {
-    return ['bytes32', getStructHash(typedData, type, data as Record<string, unknown>, options)];
+    return ['bytes32', getStructHash(typedData, type, data as Record<string, unknown>)];
   }
 
   // Strings and arbitrary byte arrays are hashed to bytes32
@@ -119,12 +105,7 @@ const encodeValue = (
  * Encode the data to an ABI encoded Buffer. The data should be a key -> value object with all the required values. All
  * dependant types are automatically encoded.
  */
-export const encodeData = (
-  typedData: TypedData,
-  type: string,
-  data: Record<string, unknown>,
-  options?: Options,
-): Buffer => {
+export const encodeData = (typedData: TypedData, type: string, data: Record<string, unknown>): Buffer => {
   const [types, values] = typedData.types[type].reduce<[string[], unknown[]]>(
     ([types, values], field) => {
       if (data[field.name] === undefined || data[field.name] === null) {
@@ -132,14 +113,14 @@ export const encodeData = (
       }
 
       const value = data[field.name];
-      const [type, encodedValue] = encodeValue(typedData, field.type, value, options);
+      const [type, encodedValue] = encodeValue(typedData, field.type, value);
 
       return [
         [...types, type],
         [...values, encodedValue],
       ];
     },
-    [['bytes32'], [getTypeHash(typedData, type, options)]],
+    [['bytes32'], [getTypeHash(typedData, type)]],
   );
 
   return abiCoder.encodeParameters(types, values);
@@ -149,20 +130,19 @@ export const encodeData = (
  * Get encoded data as a hash. The data should be a key -> value object with all the required values. All dependant
  * types are automatically encoded.
  */
-export const getStructHash = (typedData: TypedData, type: string, data: Record<string, unknown>, options?: Options) => {
-  return keccak256(encodeData(typedData, type, data, options));
+export const getStructHash = (typedData: TypedData, type: string, data: Record<string, unknown>) => {
+  return keccak256(encodeData(typedData, type, data));
 };
 
 /**
  * Get the EIP-191 encoded message to sign, from the typedData object. If `hash` is enabled, the message will be hashed
  * with Keccak256.
  */
-export const getMessage = (typedData: TypedData, hash?: boolean, options?: Options) => {
-  const { domain } = options || { domain: 'EIP712Domain', verifyDomain: true };
+export const getMessage = (typedData: TypedData, hash?: boolean, domain = 'EIP712Domain') => {
   const message = Buffer.concat([
     EIP_191_PREFIX,
-    getStructHash(typedData, domain, typedData.domain as Record<string, unknown>, options),
-    getStructHash(typedData, typedData.primaryType, typedData.message, options),
+    getStructHash(typedData, domain, typedData.domain as Record<string, unknown>),
+    getStructHash(typedData, typedData.primaryType, typedData.message),
   ]);
 
   if (hash) {
@@ -179,7 +159,6 @@ export const asArray = (
   typedData: TypedData,
   type: string = typedData.primaryType,
   data: Record<string, unknown> = typedData.message,
-  options?: Options,
 ): unknown[] => {
   if (!typedData.types[type]) {
     throw new Error('Cannot get data as array: type does not exist');
@@ -191,7 +170,7 @@ export const asArray = (
         throw new Error(`Cannot get data as array: missing data for '${name}'`);
       }
 
-      return [...array, asArray(typedData, type, data[name] as Record<string, unknown>, options)];
+      return [...array, asArray(typedData, type, data[name] as Record<string, unknown>)];
     }
 
     const value = data[name];

--- a/yarn-project/ethereum.js/tsconfig.json
+++ b/yarn-project/ethereum.js/tsconfig.json
@@ -6,5 +6,5 @@
     "rootDir": "src",
     "tsBuildInfoFile": ".tsbuildinfo"
   },
-  "include": ["src"]
+  "include": ["src", "src/eth_typed_data/fixtures/*.json"]
 }


### PR DESCRIPTION
# Description

We've moved common environment variables to a cii build context that can be reused across repos.
This also removes a some unused options from the eip712 code in ethereum.js

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
