### PR TITLE
Fix ordering of projects in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,8 +48,8 @@ cd ../..
 # We only bootstrap projects that produce artefacts needed for running end-to-end tests.
 PROJECTS=(
   "yarn-project/foundation:yarn build"
-  "yarn-project/l1-contracts:yarn build"
   "yarn-project/ethereum.js:yarn build"
+  "yarn-project/l1-contracts:yarn build"
   "yarn-project/merkle-tree:yarn build"
   "yarn-project/archiver:yarn build"
   "yarn-project/world-state:yarn build"


### PR DESCRIPTION
Running `bootstrap.sh` in a clean repo would fail, as `yarn-project/l1-contracts` depends on `yarn-project/ethereum.js`. We want to build the dependency before. Note that adding ethereum.js as a project reference in tsconfig didn't make the trick.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
