### PR TITLE
Circuit-powered block builder

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/fixtures.ts
+++ b/yarn-project/aztec-node/src/aztec-node/fixtures.ts
@@ -21,6 +21,7 @@ import {
   OptionallyRevealedData,
   PrivateKernelPublicInputs,
   TxContext,
+  UInt8Vector,
 } from '@aztec/circuits.js';
 import { EthereumRpc } from '@aztec/ethereum.js/eth_rpc';
 import { WalletProvider } from '@aztec/ethereum.js/provider';
@@ -120,5 +121,5 @@ export const createTx = () => {
     createOptionallyRetrievedDatas(KERNEL_OPTIONALLY_REVEALED_DATA_LENGTH),
   );
   const kernelInputs = new PrivateKernelPublicInputs(accumulatedData, constantData, true);
-  return new Tx(kernelInputs);
+  return new Tx(kernelInputs, new UInt8Vector(Buffer.alloc(0)));
 };

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -1,5 +1,6 @@
 import { AcirSimulator } from '@aztec/acir-simulator';
 import { AztecNode } from '@aztec/aztec-node';
+import { UInt8Vector } from '@aztec/circuits.js';
 import { KernelProver } from '@aztec/kernel-prover';
 import { Tx } from '@aztec/p2p';
 import { generateFunctionSelector } from '../abi_coder/index.js';
@@ -157,7 +158,7 @@ export class AztecRPCServer implements AztecRPCClient {
       oldRoots as any, // TODO - remove `as any`
     );
     // TODO I think the TX should include all the data from the publicInputs + proof
-    return new Tx(publicInputs);
+    return new Tx(publicInputs, new UInt8Vector(Buffer.alloc(0)));
   }
 
   public async sendTx(tx: Tx) {

--- a/yarn-project/merkle-tree/package.json
+++ b/yarn-project/merkle-tree/package.json
@@ -8,6 +8,7 @@
     "build:dev": "tsc -b tsconfig.dest.json --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint --max-warnings 0 ./src",
+    "formatting:fix": "run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --no-cache --passWithNoTests"
   },
   "jest": {

--- a/yarn-project/merkle-tree/src/indexed_tree/indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/indexed_tree/indexed_tree.ts
@@ -12,7 +12,7 @@ const indexToKeyLeaf = (name: string, index: bigint) => {
 /**
  * A leaf of a tree.
  */
-interface LeafData {
+export interface LeafData {
   /**
    * A value of the leaf.
    */
@@ -191,7 +191,7 @@ export class IndexedTree implements MerkleTree {
    * @param newValue - The new value to be inserted into the tree.
    * @returns Tuple containing the leaf index and a flag to say if the value is a duplicate.
    */
-  private findIndexOfPreviousValue(newValue: bigint) {
+  public findIndexOfPreviousValue(newValue: bigint) {
     const numLeaves = this.underlying.getNumLeaves();
     const diff: bigint[] = [];
     for (let i = 0; i < numLeaves; i++) {
@@ -298,7 +298,7 @@ export class IndexedTree implements MerkleTree {
    * @param index - Index of the leaf of which to obtain the LeafData copy.
    * @returns A copy of the leaf data at the given index or undefined if the leaf was not found.
    */
-  private getLatestLeafDataCopy(index: number): LeafData | undefined {
+  public getLatestLeafDataCopy(index: number): LeafData | undefined {
     const leaf = this.cachedLeaves[index] ?? this.leaves[index];
     return leaf
       ? ({

--- a/yarn-project/merkle-tree/src/indexed_tree/indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/indexed_tree/indexed_tree.ts
@@ -308,4 +308,10 @@ export class IndexedTree implements MerkleTree {
         } as LeafData)
       : undefined;
   }
+
+  public async getLeafValue(index: bigint): Promise<Buffer | undefined> {
+    const leaf = this.getLatestLeafDataCopy(Number(index));
+    if (!leaf) return undefined;
+    return toBufferBE(leaf.value, 32);
+  }
 }

--- a/yarn-project/merkle-tree/src/merkle_tree.ts
+++ b/yarn-project/merkle-tree/src/merkle_tree.ts
@@ -16,4 +16,5 @@ export interface MerkleTree extends SiblingPathSource {
   appendLeaves(leaves: Buffer[]): Promise<void>;
   commit(): Promise<void>;
   rollback(): Promise<void>;
+  getLeafValue(index: bigint): Promise<Buffer | undefined>;
 }

--- a/yarn-project/merkle-tree/src/standard_tree/standard_tree.ts
+++ b/yarn-project/merkle-tree/src/standard_tree/standard_tree.ts
@@ -214,6 +214,10 @@ export class StandardMerkleTree implements MerkleTree {
     return Promise.resolve();
   }
 
+  public async getLeafValue(index: bigint): Promise<Buffer | undefined> {
+    return this.getLatestValueAtIndex(this.depth, index);
+  }
+
   /**
    * Clears the catch.
    */

--- a/yarn-project/p2p/src/client/mocks.ts
+++ b/yarn-project/p2p/src/client/mocks.ts
@@ -1,9 +1,10 @@
 import { L2Block, L2BlockSource } from '@aztec/l2-block';
+import { UInt8Vector } from '@aztec/circuits.js';
 import { makePrivateKernelPublicInputs } from '@aztec/circuits.js/factories';
 import { Tx } from './tx.js';
 
 export const MockTx = () => {
-  return new Tx(makePrivateKernelPublicInputs());
+  return new Tx(makePrivateKernelPublicInputs(), new UInt8Vector(Buffer.alloc(0)));
 };
 
 export class MockBlockSource implements L2BlockSource {

--- a/yarn-project/p2p/src/client/tx.ts
+++ b/yarn-project/p2p/src/client/tx.ts
@@ -4,6 +4,7 @@ import {
   KERNEL_NEW_CONTRACTS_LENGTH,
   KERNEL_NEW_NULLIFIERS_LENGTH,
   PrivateKernelPublicInputs,
+  UInt8Vector,
 } from '@aztec/circuits.js';
 import { Keccak } from 'sha3';
 
@@ -14,7 +15,7 @@ const hash = new Keccak(256);
  */
 export class Tx {
   private _id?: Buffer;
-  constructor(private txData: PrivateKernelPublicInputs) {}
+  constructor(public readonly data: PrivateKernelPublicInputs, public readonly proof: UInt8Vector) {}
 
   /**
    * Construct & return transaction ID.
@@ -28,10 +29,6 @@ export class Tx {
     return this._id;
   }
 
-  get data() {
-    return this.txData;
-  }
-
   /**
    * Utility function to generate tx ID.
    * @param tx - The transaction from which to generate the id.
@@ -41,9 +38,9 @@ export class Tx {
     hash.reset();
     const dataToHash = Buffer.concat(
       [
-        tx.txData.end.newCommitments.map(x => x.toBuffer()),
-        tx.txData.end.newNullifiers.map(x => x.toBuffer()),
-        tx.txData.end.newContracts.map(x => x.functionTreeRoot.toBuffer()),
+        tx.data.end.newCommitments.map(x => x.toBuffer()),
+        tx.data.end.newNullifiers.map(x => x.toBuffer()),
+        tx.data.end.newContracts.map(x => x.functionTreeRoot.toBuffer()),
       ].flat(),
     );
     return hash.update(dataToHash).digest();

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -39,12 +39,14 @@
     "@aztec/l2-block": "workspace:^",
     "@aztec/p2p": "workspace:^",
     "@aztec/world-state": "workspace:^",
+    "lodash.times": "^4.3.2",
     "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.4.3",
     "@rushstack/eslint-patch": "^1.1.4",
     "@types/jest": "^29.4.0",
+    "@types/lodash.times": "^4.3.7",
     "@types/node": "^18.7.23",
     "concurrently": "^7.6.0",
     "jest": "^28.1.3",

--- a/yarn-project/sequencer-client/src/deps/tx.ts
+++ b/yarn-project/sequencer-client/src/deps/tx.ts
@@ -1,0 +1,15 @@
+import { UInt8Vector } from '@aztec/circuits.js';
+import { Tx } from '@aztec/p2p';
+
+function makeEmptyProof() {
+  return new UInt8Vector(Buffer.alloc(0));
+}
+
+function makeEmptyPrivateKernelPublicInputs() {
+  // TODO: Implement me
+  return {} as any;
+}
+
+export function makeEmptyTx(): Tx {
+  return new Tx(makeEmptyPrivateKernelPublicInputs(), makeEmptyProof());
+}

--- a/yarn-project/sequencer-client/src/deps/tx.ts
+++ b/yarn-project/sequencer-client/src/deps/tx.ts
@@ -1,13 +1,103 @@
+import {
+  AffineElement,
+  AggregationObject,
+  ConstantData,
+  ContractDeploymentData,
+  EMITTED_EVENTS_LENGTH,
+  EthAddress,
+  Fq,
+  Fr,
+  FunctionData,
+  KERNEL_L1_MSG_STACK_LENGTH,
+  KERNEL_NEW_COMMITMENTS_LENGTH,
+  KERNEL_NEW_CONTRACTS_LENGTH,
+  KERNEL_NEW_NULLIFIERS_LENGTH,
+  KERNEL_OPTIONALLY_REVEALED_DATA_LENGTH,
+  KERNEL_PRIVATE_CALL_STACK_LENGTH,
+  KERNEL_PUBLIC_CALL_STACK_LENGTH,
+  NewContractData,
+  OldTreeRoots,
+  OptionallyRevealedData,
+  PrivateKernelPublicInputs,
+  TxContext,
+} from '@aztec/circuits.js';
+import { AccumulatedData } from '@aztec/circuits.js';
 import { UInt8Vector } from '@aztec/circuits.js';
 import { Tx } from '@aztec/p2p';
+import times from 'lodash.times';
+
+function frZero() {
+  return new Fr(Buffer.alloc(32, 0));
+}
+
+function fqZero() {
+  return new Fq(Buffer.alloc(32, 0));
+}
+
+function makeEmptyEthAddress() {
+  return new EthAddress(Buffer.alloc(20, 0));
+}
+
+export function makeEmptyNewContractData(): NewContractData {
+  return new NewContractData(frZero(), makeEmptyEthAddress(), frZero());
+}
+
+export function makeEmptyAggregationObject(): AggregationObject {
+  return new AggregationObject(
+    new AffineElement(fqZero(), fqZero()),
+    new AffineElement(fqZero(), fqZero()),
+    times(4, frZero),
+    times(6, () => 0),
+  );
+}
+
+export function makeEmptyTxContext(): TxContext {
+  const deploymentData = new ContractDeploymentData(frZero(), frZero(), frZero(), makeEmptyEthAddress());
+  return new TxContext(false, false, true, deploymentData);
+}
+
+export function makeEmptyOldTreeRoots(): OldTreeRoots {
+  return new OldTreeRoots(frZero(), frZero(), frZero(), frZero());
+}
+
+export function makeEmptyConstantData(): ConstantData {
+  return new ConstantData(makeEmptyOldTreeRoots(), makeEmptyTxContext());
+}
+
+export function makeEmptyOptionallyRevealedData(): OptionallyRevealedData {
+  return new OptionallyRevealedData(
+    frZero(),
+    new FunctionData(0, true, true),
+    times(EMITTED_EVENTS_LENGTH, frZero),
+    frZero(),
+    makeEmptyEthAddress(),
+    false,
+    false,
+    false,
+    false,
+  );
+}
+
+export function makeEmptyAccumulatedData(): AccumulatedData {
+  return new AccumulatedData(
+    makeEmptyAggregationObject(),
+    frZero(),
+    times(KERNEL_NEW_COMMITMENTS_LENGTH, frZero),
+    times(KERNEL_NEW_NULLIFIERS_LENGTH, frZero),
+    times(KERNEL_PRIVATE_CALL_STACK_LENGTH, frZero),
+    times(KERNEL_PUBLIC_CALL_STACK_LENGTH, frZero),
+    times(KERNEL_L1_MSG_STACK_LENGTH, frZero),
+    times(KERNEL_NEW_CONTRACTS_LENGTH, makeEmptyNewContractData),
+    times(KERNEL_OPTIONALLY_REVEALED_DATA_LENGTH, makeEmptyOptionallyRevealedData),
+  );
+}
 
 function makeEmptyProof() {
   return new UInt8Vector(Buffer.alloc(0));
 }
 
 function makeEmptyPrivateKernelPublicInputs() {
-  // TODO: Implement me
-  return {} as any;
+  return new PrivateKernelPublicInputs(makeEmptyAccumulatedData(), makeEmptyConstantData(), true);
 }
 
 export function makeEmptyTx(): Tx {

--- a/yarn-project/sequencer-client/src/prover/index.ts
+++ b/yarn-project/sequencer-client/src/prover/index.ts
@@ -5,10 +5,12 @@ import {
   MergeRollupPublicInputs,
   RootRollupInputs,
   RootRollupPublicInputs,
+  UInt8Vector,
 } from '@aztec/circuits.js';
 
+export type Proof = UInt8Vector;
 export interface Prover {
-  baseRollupCircuit(input: BaseRollupInputs): Promise<BaseRollupPublicInputs>;
-  mergeRollupCircuit(input: MergeRollupInputs): Promise<MergeRollupPublicInputs>;
-  rootRollupCircuit(input: RootRollupInputs): Promise<RootRollupPublicInputs>;
+  getBaseRollupProof(input: BaseRollupInputs, publicInputs: BaseRollupPublicInputs): Promise<Proof>;
+  getMergeRollupProof(input: MergeRollupInputs, publicInputs: MergeRollupPublicInputs): Promise<Proof>;
+  getRootRollupProof(input: RootRollupInputs, publicInputs: RootRollupPublicInputs): Promise<Proof>;
 }

--- a/yarn-project/sequencer-client/src/prover/mock.ts
+++ b/yarn-project/sequencer-client/src/prover/mock.ts
@@ -5,19 +5,20 @@ import {
   MergeRollupPublicInputs,
   RootRollupInputs,
   RootRollupPublicInputs,
+  UInt8Vector,
 } from '@aztec/circuits.js';
 import { Prover } from './index.js';
 
 /* eslint-disable */
 
 export class MockProver implements Prover {
-  baseRollupCircuit(input: BaseRollupInputs): Promise<BaseRollupPublicInputs> {
-    throw new Error('Method not implemented.');
+  async getBaseRollupProof(input: BaseRollupInputs, publicInputs: BaseRollupPublicInputs): Promise<UInt8Vector> {
+    return new UInt8Vector(Buffer.alloc(0));
   }
-  mergeRollupCircuit(input: MergeRollupInputs): Promise<MergeRollupPublicInputs> {
-    throw new Error('Method not implemented.');
+  async getMergeRollupProof(input: MergeRollupInputs, publicInputs: MergeRollupPublicInputs): Promise<UInt8Vector> {
+    return new UInt8Vector(Buffer.alloc(0));
   }
-  rootRollupCircuit(input: RootRollupInputs): Promise<RootRollupPublicInputs> {
-    throw new Error('Method not implemented.');
+  async getRootRollupProof(input: RootRollupInputs, publicInputs: RootRollupPublicInputs): Promise<UInt8Vector> {
+    return new UInt8Vector(Buffer.alloc(0));
   }
 }

--- a/yarn-project/sequencer-client/src/sequencer/circuit_powered_block_builder.ts
+++ b/yarn-project/sequencer-client/src/sequencer/circuit_powered_block_builder.ts
@@ -23,21 +23,18 @@ import { Proof, Prover } from '../prover/index.js';
 import { Simulator } from '../simulator/index.js';
 import { VerificationKeys } from './vks.js';
 
-// Convert Fr to and from bigint.
 // REFACTOR: Move this somewhere generic, and do something less horrible without going through hex strings.
 const frToBigInt = (fr: Fr) => BigInt(`0x${fr.toBuffer().toString('hex')}`);
-
 const bigintToFr = (num: bigint) => new Fr(Buffer.from(num.toString(16), 'hex'));
-
 const bigintToNum = (num: bigint) => Number(num);
 
+// Denotes fields that are not used now, but will be in the future
 const FUTURE_FR = new Fr(0);
 const FUTURE_NUM = 0;
+
+// Denotes fields that should be deleted
 const DELETE_FR = new Fr(0);
 const DELETE_ANY: any = {};
-const TODO_FR = new Fr(0);
-const TODO_NUM = 0;
-const TODO: any = {};
 
 export class CircuitPoweredBlockBuilder {
   constructor(

--- a/yarn-project/sequencer-client/src/sequencer/circuit_powered_block_builder.ts
+++ b/yarn-project/sequencer-client/src/sequencer/circuit_powered_block_builder.ts
@@ -1,0 +1,268 @@
+import { ContractData, L2Block } from '@aztec/archiver';
+import {
+  AppendOnlyTreeSnapshot,
+  BaseRollupInputs,
+  BaseRollupPublicInputs,
+  ConstantBaseRollupData,
+  CONTRACT_TREE_ROOTS_TREE_HEIGHT,
+  Fr,
+  MembershipWitness,
+  NullifierLeafPreimage,
+  NULLIFIER_TREE_HEIGHT,
+  PreviousKernelData,
+  PreviousRollupData,
+  PRIVATE_DATA_TREE_ROOTS_TREE_HEIGHT,
+  RootRollupInputs,
+  RootRollupPublicInputs,
+  VK_TREE_HEIGHT,
+} from '@aztec/circuits.js';
+import { Tx } from '@aztec/p2p';
+import { MerkleTreeId, MerkleTreeOperations } from '@aztec/world-state';
+import { makeEmptyTx } from '../deps/tx.js';
+import { Proof, Prover } from '../prover/index.js';
+import { Simulator } from '../simulator/index.js';
+import { VerificationKeys } from './vks.js';
+
+// Convert Fr to and from bigint.
+// REFACTOR: Move this somewhere generic, and do something less horrible without going through hex strings.
+const frToBigInt = (fr: Fr) => BigInt(`0x${fr.toBuffer().toString('hex')}`);
+
+const bigintToFr = (num: bigint) => new Fr(Buffer.from(num.toString(16), 'hex'));
+
+const bigintToNum = (num: bigint) => Number(num);
+
+const FUTURE_FR = new Fr(0);
+const FUTURE_NUM = 0;
+const DELETE_FR = new Fr(0);
+const DELETE_ANY: any = {};
+const TODO_FR = new Fr(0);
+const TODO_NUM = 0;
+const TODO: any = {};
+
+export class CircuitPoweredBlockBuilder {
+  constructor(
+    private db: MerkleTreeOperations,
+    private nextRollupId: number,
+    private vks: VerificationKeys,
+    private simulator: Simulator,
+    private prover: Prover,
+  ) {}
+
+  public async buildL2Block(tx: Tx) {
+    const [
+      startPrivateDataTreeSnapshot,
+      startNullifierTreeSnapshot,
+      startContractTreeSnapshot,
+      startTreeOfHistoricPrivateDataTreeRootsSnapshot,
+      startTreeOfHistoricContractTreeRootsSnapshot,
+    ] = await Promise.all(
+      [
+        MerkleTreeId.DATA_TREE,
+        MerkleTreeId.NULLIFIER_TREE,
+        MerkleTreeId.CONTRACT_TREE,
+        MerkleTreeId.DATA_TREE_ROOTS_TREE,
+        MerkleTreeId.CONTRACT_TREE_ROOTS_TREE,
+      ].map(tree => this.getTreeSnapshot(tree)),
+    );
+
+    const [circuitsOutput, _circuitsProof] = await this.runCircuits(tx);
+
+    const {
+      endPrivateDataTreeSnapshot,
+      endNullifierTreeSnapshot,
+      endContractTreeSnapshot,
+      endTreeOfHistoricPrivateDataTreeRootsSnapshot,
+      endTreeOfHistoricContractTreeRootsSnapshot,
+    } = circuitsOutput;
+
+    const l2block = L2Block.fromFields({
+      number: this.nextRollupId,
+      startPrivateDataTreeSnapshot,
+      endPrivateDataTreeSnapshot,
+      startNullifierTreeSnapshot,
+      endNullifierTreeSnapshot,
+      startContractTreeSnapshot,
+      endContractTreeSnapshot,
+      startTreeOfHistoricPrivateDataTreeRootsSnapshot,
+      endTreeOfHistoricPrivateDataTreeRootsSnapshot,
+      startTreeOfHistoricContractTreeRootsSnapshot,
+      endTreeOfHistoricContractTreeRootsSnapshot,
+      newCommitments: tx.data.end.newCommitments,
+      newNullifiers: tx.data.end.newNullifiers,
+      newContracts: tx.data.end.newContracts.map(x => x.functionTreeRoot),
+      newContractData: tx.data.end.newContracts.map(n => new ContractData(n.contractAddress, n.portalContractAddress)),
+    });
+    return l2block;
+  }
+
+  private async getTreeSnapshot(id: MerkleTreeId): Promise<AppendOnlyTreeSnapshot> {
+    const treeInfo = await this.db.getTreeInfo(id);
+    return new AppendOnlyTreeSnapshot(new Fr(treeInfo.root), Number(treeInfo.size));
+  }
+
+  private async runCircuits(tx: Tx): Promise<[RootRollupPublicInputs, Proof]> {
+    const emptyTx = makeEmptyTx();
+
+    const [_baseRollupInputLeft, baseRollupOutputLeft, baseRollupProofLeft] = await this.baseRollupCircuit(tx, emptyTx);
+
+    const [_baseRollupInputRight, baseRollupOutputRight, baseRollupProofRight] = await this.baseRollupCircuit(
+      emptyTx,
+      emptyTx,
+    );
+
+    const rootInput = await this.getRootRollupInput(
+      baseRollupOutputLeft,
+      baseRollupProofLeft,
+      baseRollupOutputRight,
+      baseRollupProofRight,
+    );
+    const rootOutput = await this.simulator.rootRollupCircuit(rootInput);
+    const rootProof = await this.prover.getRootRollupProof(rootInput, rootOutput);
+
+    return [rootOutput, rootProof];
+  }
+
+  private async baseRollupCircuit(tx1: Tx, tx2: Tx) {
+    const rollupInput = await this.getBaseRollupInput(tx1, tx2);
+    const rollupOutput = await this.simulator.baseRollupCircuit(rollupInput);
+    const rollupProof = await this.prover.getBaseRollupProof(rollupInput, rollupOutput);
+    return [rollupInput, rollupOutput, rollupProof] as const;
+  }
+
+  private async getRootRollupInput(
+    rollupOutputLeft: BaseRollupPublicInputs,
+    rollupProofLeft: Proof,
+    rollupOutputRight: BaseRollupPublicInputs,
+    rollupProofRight: Proof,
+  ) {
+    const previousRollupData: RootRollupInputs['previousRollupData'] = [
+      this.getPreviousRollupDataFromBaseRollup(rollupOutputLeft, rollupProofLeft),
+      this.getPreviousRollupDataFromBaseRollup(rollupOutputRight, rollupProofRight),
+    ];
+
+    return new RootRollupInputs(
+      previousRollupData,
+      await this.getTreeSnapshot(MerkleTreeId.DATA_TREE),
+      await this.getTreeSnapshot(MerkleTreeId.CONTRACT_TREE),
+      DELETE_ANY,
+      DELETE_ANY,
+      DELETE_ANY,
+      DELETE_ANY,
+    );
+  }
+
+  private getPreviousRollupDataFromBaseRollup(rollupOutput: BaseRollupPublicInputs, rollupProof: Proof) {
+    return new PreviousRollupData(
+      rollupOutput,
+      rollupProof,
+      this.vks.baseRollupCircuit,
+
+      // MembershipWitness for a VK tree to be implemented in the future
+      FUTURE_NUM,
+      Array(VK_TREE_HEIGHT).fill(FUTURE_FR),
+    );
+  }
+
+  private getKernelDataFor(tx: Tx) {
+    return new PreviousKernelData(
+      tx.data,
+      tx.proof,
+
+      // VK for the kernel circuit
+      this.vks.kernelCircuit,
+
+      // MembershipWitness for a VK tree to be implemented in the future
+      FUTURE_NUM,
+      Array(VK_TREE_HEIGHT).fill(FUTURE_FR),
+    );
+  }
+
+  // Scan a tree searching for a specific value and return a membership witness proof for it
+  private async getMembershipWitnessFor<N extends number>(
+    value: Fr,
+    treeId: MerkleTreeId,
+    height: N,
+  ): Promise<MembershipWitness<N>> {
+    const index = await this.db.findLeafIndex(treeId, value.toBuffer());
+    if (!index) throw new Error(`Leaf with value ${value} not found in tree ${treeId}`);
+    const path = await this.db.getSiblingPath(treeId, index);
+    // TODO: Check conversion from bigint to number
+    return new MembershipWitness(
+      height,
+      Number(index),
+      path.data.map(b => new Fr(b)),
+    );
+  }
+
+  private async getConstantBaseRollupData(): Promise<ConstantBaseRollupData> {
+    return ConstantBaseRollupData.from({
+      baseRollupVkHash: DELETE_FR,
+      mergeRollupVkHash: DELETE_FR,
+      privateKernelVkTreeRoot: FUTURE_FR,
+      publicKernelVkTreeRoot: FUTURE_FR,
+      startTreeOfHistoricContractTreeRootsSnapshot: await this.getTreeSnapshot(MerkleTreeId.CONTRACT_TREE_ROOTS_TREE),
+      startTreeOfHistoricPrivateDataTreeRootsSnapshot: await this.getTreeSnapshot(MerkleTreeId.DATA_TREE_ROOTS_TREE),
+      treeOfHistoricL1ToL2MsgTreeRootsSnapshot: DELETE_ANY,
+    });
+  }
+
+  private async getLowNullifierInfo(nullifier: Fr) {
+    const tree = MerkleTreeId.NULLIFIER_TREE;
+    const prevValueIndex = await this.db.getPreviousValueIndex(tree, frToBigInt(nullifier));
+    const prevValueInfo = this.db.getLeafData(tree, prevValueIndex.index);
+    if (!prevValueInfo) throw new Error(`Nullifier tree should have one initial leaf`);
+    const prevValueSiblingPath = await this.db.getSiblingPath(tree, BigInt(prevValueIndex.index));
+    return {
+      index: prevValueIndex,
+      leafPreimage: new NullifierLeafPreimage(
+        bigintToFr(prevValueInfo.value),
+        bigintToFr(prevValueInfo.nextValue),
+        bigintToNum(prevValueInfo.nextIndex),
+      ),
+      witness: new MembershipWitness(
+        NULLIFIER_TREE_HEIGHT,
+        prevValueIndex.index,
+        prevValueSiblingPath.data.map(b => new Fr(b)),
+      ),
+    };
+  }
+
+  private async getBaseRollupInput(tx1: Tx, tx2: Tx) {
+    // Concatenate the new nullifiers of each tx being rolled up
+    // and get the previous node for each of them, along with the sibling path
+    const lowNullifierInfos = await Promise.all(
+      [...tx1.data.end.newNullifiers, ...tx2.data.end.newNullifiers].map(fr => this.getLowNullifierInfo(fr)),
+    );
+
+    const getContractMembershipWitnessFor = (tx: Tx) =>
+      this.getMembershipWitnessFor(
+        tx.data.constants.oldTreeRoots.contractTreeRoot,
+        MerkleTreeId.CONTRACT_TREE_ROOTS_TREE,
+        CONTRACT_TREE_ROOTS_TREE_HEIGHT,
+      );
+
+    const getDataMembershipWitnessFor = (tx: Tx) =>
+      this.getMembershipWitnessFor(
+        tx.data.constants.oldTreeRoots.privateDataTreeRoot,
+        MerkleTreeId.DATA_TREE_ROOTS_TREE,
+        PRIVATE_DATA_TREE_ROOTS_TREE_HEIGHT,
+      );
+
+    return BaseRollupInputs.from({
+      proverId: DELETE_FR,
+      constants: await this.getConstantBaseRollupData(),
+      startNullifierTreeSnapshot: await this.getTreeSnapshot(MerkleTreeId.NULLIFIER_TREE),
+      lowNullifierLeafPreimages: lowNullifierInfos.map(i => i.leafPreimage),
+      lowNullifierMembershipWitness: lowNullifierInfos.map(i => i.witness),
+      kernelData: [this.getKernelDataFor(tx1), this.getKernelDataFor(tx2)],
+      historicContractsTreeRootMembershipWitnesses: [
+        await getContractMembershipWitnessFor(tx1),
+        await getContractMembershipWitnessFor(tx2),
+      ],
+      historicPrivateDataTreeRootMembershipWitnesses: [
+        await getDataMembershipWitnessFor(tx1),
+        await getDataMembershipWitnessFor(tx2),
+      ],
+    });
+  }
+}

--- a/yarn-project/sequencer-client/src/sequencer/vks.ts
+++ b/yarn-project/sequencer-client/src/sequencer/vks.ts
@@ -1,0 +1,28 @@
+import { VerificationKey } from '@aztec/circuits.js';
+import { makeVerificationKey } from '@aztec/circuits.js/factories';
+
+/**
+ * Well-known verification keys
+ */
+export interface VerificationKeys {
+  /**
+   * Verification key for the default private kernel circuit
+   */
+  kernelCircuit: VerificationKey;
+  /**
+   * Verification key for the default base rollup circuit
+   */
+  baseRollupCircuit: VerificationKey;
+}
+
+/**
+ * Returns verification keys for each well known circuit.
+ * TODO: Actually fetch real values.
+ * @returns a VerificationKeys object.
+ */
+export function getVerificationKeys(): VerificationKeys {
+  return {
+    kernelCircuit: makeVerificationKey(),
+    baseRollupCircuit: makeVerificationKey(),
+  };
+}

--- a/yarn-project/sequencer-client/src/simulator/index.ts
+++ b/yarn-project/sequencer-client/src/simulator/index.ts
@@ -1,0 +1,14 @@
+import {
+  BaseRollupInputs,
+  BaseRollupPublicInputs,
+  MergeRollupInputs,
+  MergeRollupPublicInputs,
+  RootRollupInputs,
+  RootRollupPublicInputs,
+} from '@aztec/circuits.js';
+
+export interface Simulator {
+  baseRollupCircuit(input: BaseRollupInputs): Promise<BaseRollupPublicInputs>;
+  mergeRollupCircuit(input: MergeRollupInputs): Promise<MergeRollupPublicInputs>;
+  rootRollupCircuit(input: RootRollupInputs): Promise<RootRollupPublicInputs>;
+}

--- a/yarn-project/sequencer-client/src/simulator/mock.ts
+++ b/yarn-project/sequencer-client/src/simulator/mock.ts
@@ -1,0 +1,23 @@
+import {
+  BaseRollupInputs,
+  BaseRollupPublicInputs,
+  MergeRollupInputs,
+  MergeRollupPublicInputs,
+  RootRollupInputs,
+  RootRollupPublicInputs,
+} from '@aztec/circuits.js';
+import { Simulator } from './index.js';
+
+/* eslint-disable */
+
+export class MockSimulator implements Simulator {
+  baseRollupCircuit(input: BaseRollupInputs): Promise<BaseRollupPublicInputs> {
+    throw new Error('Method not implemented.');
+  }
+  mergeRollupCircuit(input: MergeRollupInputs): Promise<MergeRollupPublicInputs> {
+    throw new Error('Method not implemented.');
+  }
+  rootRollupCircuit(input: RootRollupInputs): Promise<RootRollupPublicInputs> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.ts
+++ b/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.ts
@@ -1,8 +1,8 @@
 import { createDebugLogger } from '@aztec/foundation';
 import { L2Block, L2BlockDownloader, L2BlockSource } from '@aztec/l2-block';
-import { SiblingPath } from '@aztec/merkle-tree';
-import { MerkleTreeDb, MerkleTreeId, TreeInfo } from '../index.js';
 import { WorldStateRunningState, WorldStateStatus, WorldStateSynchroniser } from './world_state_synchroniser.js';
+import { MerkleTreeDb, MerkleTreeId, TreeInfo } from '../index.js';
+import { LeafData, SiblingPath } from '@aztec/merkle-tree';
 
 /**
  * Synchronises the world state with the L2 blocks from a L2BlockSource.
@@ -25,6 +25,21 @@ export class ServerWorldStateSynchroniser implements WorldStateSynchroniser {
     private log = createDebugLogger('aztec:world_state'),
   ) {
     this.l2BlockDownloader = new L2BlockDownloader(l2BlockSource, 1000, 100);
+  }
+
+  public getPreviousValueIndex(
+    treeId: MerkleTreeId.NULLIFIER_TREE,
+    value: bigint,
+  ): Promise<{ index: number; alreadyPresent: boolean }> {
+    return this.merkleTreeDb.getPreviousValueIndex(treeId, value);
+  }
+
+  public getLeafData(treeId: MerkleTreeId.NULLIFIER_TREE, index: number): LeafData | undefined {
+    return this.merkleTreeDb.getLeafData(treeId, index);
+  }
+
+  public findLeafIndex(treeId: MerkleTreeId, value: Buffer): Promise<bigint | undefined> {
+    return this.merkleTreeDb.findLeafIndex(treeId, value);
   }
 
   /**

--- a/yarn-project/world-state/src/world-state-db/index.ts
+++ b/yarn-project/world-state/src/world-state-db/index.ts
@@ -1,6 +1,7 @@
-import { SiblingPath } from '@aztec/merkle-tree';
+import { LeafData, SiblingPath } from '@aztec/merkle-tree';
 
 export * from './memory_world_state_db.js';
+export { LeafData } from '@aztec/merkle-tree';
 
 /**
  * Defines the possible Merkle tree IDs.
@@ -12,6 +13,8 @@ export enum MerkleTreeId {
   DATA_TREE = 3,
   DATA_TREE_ROOTS_TREE = 4,
 }
+
+export type IndexedMerkleTreeId = MerkleTreeId.NULLIFIER_TREE;
 
 /**
  *  Defines tree information.
@@ -38,6 +41,9 @@ export interface MerkleTreeOperations {
   getTreeInfo(treeId: MerkleTreeId): Promise<TreeInfo>;
   appendLeaves(treeId: MerkleTreeId, leaves: Buffer[]): Promise<void>;
   getSiblingPath(treeId: MerkleTreeId, index: bigint): Promise<SiblingPath>;
+  getPreviousValueIndex(treeId: IndexedMerkleTreeId, value: bigint): Promise<{ index: number, alreadyPresent: boolean }>;
+  getLeafData(treeId: IndexedMerkleTreeId, index: number): LeafData | undefined;
+  findLeafIndex(treeId: MerkleTreeId, value: Buffer): Promise<bigint | undefined>;
 }
 
 /**

--- a/yarn-project/world-state/src/world-state-db/index.ts
+++ b/yarn-project/world-state/src/world-state-db/index.ts
@@ -41,7 +41,10 @@ export interface MerkleTreeOperations {
   getTreeInfo(treeId: MerkleTreeId): Promise<TreeInfo>;
   appendLeaves(treeId: MerkleTreeId, leaves: Buffer[]): Promise<void>;
   getSiblingPath(treeId: MerkleTreeId, index: bigint): Promise<SiblingPath>;
-  getPreviousValueIndex(treeId: IndexedMerkleTreeId, value: bigint): Promise<{ index: number, alreadyPresent: boolean }>;
+  getPreviousValueIndex(
+    treeId: IndexedMerkleTreeId,
+    value: bigint,
+  ): Promise<{ index: number; alreadyPresent: boolean }>;
   getLeafData(treeId: IndexedMerkleTreeId, index: number): LeafData | undefined;
   findLeafIndex(treeId: MerkleTreeId, value: Buffer): Promise<bigint | undefined>;
 }

--- a/yarn-project/world-state/src/world-state-db/memory_world_state_db.ts
+++ b/yarn-project/world-state/src/world-state-db/memory_world_state_db.ts
@@ -1,6 +1,3 @@
-import { default as levelup } from 'levelup';
-import { StandardMerkleTree, Pedersen, SiblingPath, IndexedTree, MerkleTree, LeafData } from '@aztec/merkle-tree';
-import { SerialQueue } from '@aztec/foundation';
 import {
   CONTRACT_TREE_HEIGHT,
   CONTRACT_TREE_ROOTS_TREE_HEIGHT,
@@ -8,6 +5,9 @@ import {
   PRIVATE_DATA_TREE_HEIGHT,
   PRIVATE_DATA_TREE_ROOTS_TREE_HEIGHT,
 } from '@aztec/circuits.js';
+import { SerialQueue } from '@aztec/foundation';
+import { IndexedTree, LeafData, MerkleTree, Pedersen, SiblingPath, StandardMerkleTree } from '@aztec/merkle-tree';
+import { default as levelup } from 'levelup';
 import { IndexedMerkleTreeId, MerkleTreeDb, MerkleTreeId, TreeInfo } from './index.js';
 
 /**
@@ -121,12 +121,32 @@ export class MerkleTrees implements MerkleTreeDb {
     return await this.synchronise(() => this._rollback());
   }
 
-  public async getPreviousValueIndex(treeId: IndexedMerkleTreeId, value: bigint): Promise<{ index: number, alreadyPresent: boolean }> {
+  public async getPreviousValueIndex(
+    treeId: IndexedMerkleTreeId,
+    value: bigint,
+  ): Promise<{ index: number; alreadyPresent: boolean }> {
     return this._getIndexedTree(treeId).findIndexOfPreviousValue(value);
   }
-  
+
   public getLeafData(treeId: IndexedMerkleTreeId, index: number): LeafData | undefined {
     return this._getIndexedTree(treeId).getLatestLeafDataCopy(index);
+  }
+
+  /**
+   * Returns the index of a leaf given its value, or undefined if no leaf with that value is found.
+   * @param treeId - The ID of the tree.
+   * @param needle - The value to look for.
+   * @returns The index of the first leaf found with that value, or undefined is not found.
+   */
+  public async findLeafIndex(treeId: MerkleTreeId, needle: Buffer): Promise<bigint | undefined> {
+    const tree = this.trees[treeId];
+    for (let i = 0n; i < tree.getNumLeaves(); i++) {
+      const value = await tree.getLeafValue(i);
+      if (value && needle.equals(value)) {
+        return i;
+      }
+    }
+    return undefined;
   }
 
   /**

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -490,10 +490,12 @@ __metadata:
     "@jest/globals": ^29.4.3
     "@rushstack/eslint-patch": ^1.1.4
     "@types/jest": ^29.4.0
+    "@types/lodash.times": ^4.3.7
     "@types/node": ^18.7.23
     concurrently: ^7.6.0
     jest: ^28.1.3
     jest-mock-extended: ^3.0.3
+    lodash.times: ^4.3.2
     ts-jest: ^28.0.7
     ts-node: ^10.9.1
     tslib: ^2.4.0
@@ -2258,6 +2260,22 @@ __metadata:
     "@types/level-errors": "*"
     "@types/node": "*"
   checksum: 6740284488b6806ba398bc38842fa789edd5667a342830c544a6b3611ebeed957a08d03dc8bde1e32fe03ac9c439341647c044c1ff0f73a26bcded9ca302a009
+  languageName: node
+  linkType: hard
+
+"@types/lodash.times@npm:^4.3.7":
+  version: 4.3.7
+  resolution: "@types/lodash.times@npm:4.3.7"
+  dependencies:
+    "@types/lodash": "*"
+  checksum: f31e67c17124614afd392b10e26a5af38f0975edbe4e128c60affa0890a1f2fea502daa4839aee4b1f66b690f925254eff3e9dfcea5d7d3ace7315dba430335f
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:*":
+  version: 4.14.192
+  resolution: "@types/lodash@npm:4.14.192"
+  checksum: 31e1f0543a04158d2c429c45efd7c77882736630d0652f82eb337d6159ec0c249c5d175c0af731537b53271e665ff8d76f43221d75d03646d31cb4bd6f0056b1
   languageName: node
   linkType: hard
 
@@ -6085,6 +6103,13 @@ __metadata:
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
+  languageName: node
+  linkType: hard
+
+"lodash.times@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "lodash.times@npm:4.3.2"
+  checksum: d26a9022e025d6061d356d3098fd80cdc062e7bf896bbbb56e643b2ae39156bf19b6167a4b046aa924b6d572a1e717853e552342ce34016fc5183308e329b575
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Sequencer block builder that runs (mocked) circuit simulators for producing new blocks. There are still a few changes pending in the structs (coordinating with circuits team), and the actual cbinds for the simulator are missing, but this gathers all the data we need to pass to the rollup and root circuits for assembling an L2 block.

Since the sequencer is mocked out and doesn't do anything, it's not yet connected to the sequencer.