### PR TITLE
Link barretenberg.wasm in the ts dest folder

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -46,6 +46,7 @@ cd ..
 
 # We only bootstrap projects that produce artefacts needed for running end-to-end tests.
 PROJECTS=(
+  "yarn-project/barretenberg.js:yarn build"
   "yarn-project/foundation:yarn build"
   "yarn-project/ethereum.js:yarn build"
   "yarn-project/l1-contracts:yarn build"

--- a/yarn-project/barretenberg.js/package.json
+++ b/yarn-project/barretenberg.js/package.json
@@ -13,8 +13,9 @@
     "tsconfig": "./tsconfig.dest.json"
   },
   "scripts": {
-    "build": "tsc -b tsconfig.dest.json",
-    "build:dev": "tsc -b tsconfig.dest.json --watch",
+    "build": "yarn build:link && tsc -b tsconfig.dest.json",
+    "build:dev": "yarn build:link && tsc -b tsconfig.dest.json --watch",
+    "build:link": "ln -fs ../../src/wasm/barretenberg.wasm dest/wasm/barretenberg.wasm",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "prettier --check ./src && eslint --max-warnings 0 ./src",
     "formatting:fix": "prettier -w ./src",


### PR DESCRIPTION
Dependents of barretenberg.js were failing to load the wasm since its location is relative to the source file that loads it, and the wasm binary is only present in src, not dest.

This should fix the error in the `e2e-deploy-contract` job in the CI about `end-to-end_1  |     ENOENT: no such file or directory, open '/usr/src/yarn-project/barretenberg.js/dest/wasm/barretenberg.wasm'`.