### PR TITLE
Added checks for lhs and rhs in pedersen.ts

### DIFF
--- a/yarn-project/barretenberg.js/src/crypto/pedersen/pedersen.ts
+++ b/yarn-project/barretenberg.js/src/crypto/pedersen/pedersen.ts
@@ -12,7 +12,11 @@ import { Buffer } from 'buffer';
 export function pedersenCompress(wasm: BarretenbergWasm, lhs: Uint8Array, rhs: Uint8Array): Buffer {
   // If not done already, precompute constants.
   wasm.call('pedersen__init');
-  // TODO check if lhs and rhs are <= 32 bytes?
+  
+  if (lhs.length > 32 || rhs.length > 32) {
+    throw new Error('lhs and rhs must not be greater than 32')
+  }
+  
   wasm.writeMemory(0, lhs);
   wasm.writeMemory(32, rhs);
   wasm.call('pedersen__hash_pair', 0, 32, 64);

--- a/yarn-project/barretenberg.js/src/crypto/pedersen/pedersen.ts
+++ b/yarn-project/barretenberg.js/src/crypto/pedersen/pedersen.ts
@@ -12,11 +12,9 @@ import { Buffer } from 'buffer';
 export function pedersenCompress(wasm: BarretenbergWasm, lhs: Uint8Array, rhs: Uint8Array): Buffer {
   // If not done already, precompute constants.
   wasm.call('pedersen__init');
-  
   if (lhs.length > 32 || rhs.length > 32) {
     throw new Error('lhs and rhs must not be greater than 32 bytes')
   }
-  
   wasm.writeMemory(0, lhs);
   wasm.writeMemory(32, rhs);
   wasm.call('pedersen__hash_pair', 0, 32, 64);

--- a/yarn-project/barretenberg.js/src/crypto/pedersen/pedersen.ts
+++ b/yarn-project/barretenberg.js/src/crypto/pedersen/pedersen.ts
@@ -12,11 +12,9 @@ import { Buffer } from 'buffer';
 export function pedersenCompress(wasm: BarretenbergWasm, lhs: Uint8Array, rhs: Uint8Array): Buffer {
   // If not done already, precompute constants.
   wasm.call('pedersen__init');
-  
-  if (lhs.length > 32 || rhs.length > 32) {
-    throw new Error('lhs and rhs must not be greater than 32')
+  if (lhs.length !== 32 || rhs.length !== 32) {
+    throw new Error('lhs and rhs must be equal to 32 bytes')
   }
-  
   wasm.writeMemory(0, lhs);
   wasm.writeMemory(32, rhs);
   wasm.call('pedersen__hash_pair', 0, 32, 64);

--- a/yarn-project/barretenberg.js/src/crypto/pedersen/pedersen.ts
+++ b/yarn-project/barretenberg.js/src/crypto/pedersen/pedersen.ts
@@ -14,7 +14,7 @@ export function pedersenCompress(wasm: BarretenbergWasm, lhs: Uint8Array, rhs: U
   wasm.call('pedersen__init');
   
   if (lhs.length > 32 || rhs.length > 32) {
-    throw new Error('lhs and rhs must not be greater than 32')
+    throw new Error('lhs and rhs must not be greater than 32 bytes')
   }
   
   wasm.writeMemory(0, lhs);


### PR DESCRIPTION
Fixed https://github.com/AztecProtocol/aztec3-packages/issues/149

Added a check to ensure that the length of lhs and rhs do not exceed 32 bytes.