### PR TITLE
Add missing dependency on yarn.lock

### DIFF
--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -402,6 +402,7 @@ __metadata:
   dependencies:
     "@aztec/circuits.js": "workspace:^"
     "@aztec/foundation": "workspace:^"
+    "@aztec/l1-contracts": "workspace:^"
     "@jest/globals": ^29.4.3
     "@rushstack/eslint-patch": ^1.1.4
     "@types/jest": ^29.4.0


### PR DESCRIPTION
Fixes build on master. See https://app.circleci.com/pipelines/github/AztecProtocol/aztec3-packages/1032/workflows/d53151e8-2bb9-4c74-94e8-d591ca6e3661/jobs/7134.