### PR TITLE
pull_request_template.md: specify merges are OK

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,5 +8,5 @@ Please provide a paragraph or two giving a summary of the change, including rele
 - [ ] Every change is related to the PR description.
 - [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
 - [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
-- [ ] The branch has been rebased against the head of its merge target.
+- [ ] The branch has been merged or rebased against the head of its merge target.
 - [ ] I'm happy for the PR to be merged at the reviewer's next convenience.


### PR DESCRIPTION
# Description

More realistic PR message. Rebases can waste time for squashed PRs

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
