### PR TITLE
Make fields friendlier when serializing to friendly json

### DIFF
--- a/yarn-project/circuits.js/src/utils/serialize.ts
+++ b/yarn-project/circuits.js/src/utils/serialize.ts
@@ -175,6 +175,8 @@ export function toFriendlyJSON(obj: object): string {
         return '0x' + Buffer.from(value.data).toString('hex');
       } else if (typeof value === 'bigint') {
         return value.toString();
+      } else if ((value as { toFriendlyJSON: () => string }).toFriendlyJSON) {
+        return value.toFriendlyJSON();
       } else {
         return value;
       }

--- a/yarn-project/foundation/src/fields/fields.ts
+++ b/yarn-project/foundation/src/fields/fields.ts
@@ -48,6 +48,10 @@ export class Fr {
   isZero() {
     return this.value === 0n;
   }
+
+  toFriendlyJSON() {
+    return this.toString();
+  }
 }
 
 export class Fq {
@@ -81,5 +85,9 @@ export class Fq {
 
   isZero() {
     return this.value === 0n;
+  }
+
+  toFriendlyJSON() {
+    return this.toString();
   }
 }


### PR DESCRIPTION
Adds a toFriendlyJSON method to field elements, so they are serialized directly as their value, as opposed to an object with a value field. Makes inspection easier when debugging.

Before:

```
      "endAggregationObject": {
        "p0": {
          "x": {
            "value": "256"
          },
          "y": {
            "value": "257"
          }
        },
        "p1": {
          "x": {
            "value": "512"
          },
          "y": {
            "value": "513"
          }
        },
        "hasData": false,
        "publicInputs": {
          "items": [
            {
              "value": "258"
            },
            {
              "value": "259"
            },
            {
              "value": "260"
            },
            {
              "value": "261"
            }
          ]
        },
        "proofWitnessIndices": {
          "items": [
            262,
            263,
            264,
            265,
            266,
            267
          ]
        }
      },
```

After:

```
      "endAggregationObject": {
        "p0": {
          "x": "0x100",
          "y": "0x101"
        },
        "p1": {
          "x": "0x200",
          "y": "0x201"
        },
        "hasData": false,
        "publicInputs": {
          "items": [
            "0x102",
            "0x103",
            "0x104",
            "0x105"
          ]
        },
        "proofWitnessIndices": {
          "items": [
            262,
            263,
            264,
            265,
            266,
            267
          ]
        }
      },
```