### PR TITLE
remove manual cp from Dockerfiles

### DIFF
--- a/yarn-project/barretenberg.js/package.json
+++ b/yarn-project/barretenberg.js/package.json
@@ -13,8 +13,9 @@
     "tsconfig": "./tsconfig.dest.json"
   },
   "scripts": {
-    "build": "tsc -b tsconfig.dest.json && cp ./src/wasm/barretenberg.wasm ./dest/wasm",
+    "build": "tsc -b tsconfig.dest.json && yarn build:link",
     "build:dev": "tsc -b tsconfig.dest.json --watch",
+    "build:link": "ln -nf src/wasm/barretenberg.wasm dest/wasm/barretenberg.wasm",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "prettier --check ./src && eslint --max-warnings 0 ./src",
     "formatting:fix": "prettier -w ./src",

--- a/yarn-project/circuits.js/Dockerfile
+++ b/yarn-project/circuits.js/Dockerfile
@@ -7,17 +7,14 @@ COPY . .
 WORKDIR /usr/src/yarn-project/circuits.js
 RUN yarn build && yarn formatting
 
-# (3) copy bb.js wasm binaries
-RUN cp /usr/src/circuits/cpp/build-wasm/bin/aztec3-circuits.wasm /usr/src/yarn-project/circuits.js/dest/wasm/aztec3-circuits.wasm
-
-# (3.5) test
+# (2.5) test
 RUN yarn test
 
-# (4) Prune dev dependencies. See comment in base image.
+# (3) Prune dev dependencies. See comment in base image.
 RUN yarn cache clean
 RUN yarn workspaces focus --production > /dev/null
 
-# (5) set up entry point
+# (4) set up entry point
 FROM node:18-alpine
 COPY --from=builder /usr/src/yarn-project /usr/src/yarn-project
 WORKDIR /usr/src/yarn-project/circuits.js

--- a/yarn-project/merkle-tree/Dockerfile
+++ b/yarn-project/merkle-tree/Dockerfile
@@ -8,7 +8,6 @@ WORKDIR /usr/src/yarn-project/foundation
 RUN yarn build
 WORKDIR /usr/src/yarn-project/barretenberg.js
 RUN yarn build
-RUN cp /usr/src/circuits/cpp/build-wasm/bin/aztec3-circuits.wasm dest/wasm/barretenberg.wasm
 
 WORKDIR /usr/src/yarn-project/merkle-tree
 RUN yarn build && yarn formatting && yarn test

--- a/yarn-project/sequencer-client/Dockerfile
+++ b/yarn-project/sequencer-client/Dockerfile
@@ -5,6 +5,7 @@ COPY sequencer-client sequencer-client
 
 # (2) dependencies
 COPY circuits.js circuits.js
+COPY barretenberg.js barretenberg.js
 COPY ethereum.js ethereum.js
 COPY foundation foundation
 COPY l1-contracts l1-contracts

--- a/yarn-project/sequencer-client/Dockerfile
+++ b/yarn-project/sequencer-client/Dockerfile
@@ -7,18 +7,14 @@ COPY . .
 WORKDIR /usr/src/yarn-project/sequencer-client
 RUN yarn build && yarn formatting
 
-# (3) copy bb.js wasm binaries
-RUN cp /usr/src/circuits/cpp/build-wasm/bin/aztec3-circuits.wasm /usr/src/yarn-project/circuits.js/dest/wasm/aztec3-circuits.wasm
-RUN cp /usr/src/circuits/cpp/build-wasm/bin/aztec3-circuits.wasm /usr/src/yarn-project/barretenberg.js/dest/wasm/barretenberg.wasm
-
-# (3.5) test
+# (2.5) test
 RUN yarn test
 
-# (4) Prune dev dependencies. See comment in base image.
+# (3) Prune dev dependencies. See comment in base image.
 RUN yarn cache clean
 RUN yarn workspaces focus --production > /dev/null
 
-# (5) set up entry point
+# (4) set up entry point
 FROM node:18-alpine
 COPY --from=builder /usr/src/yarn-project /usr/src/yarn-project
 WORKDIR /usr/src/yarn-project/sequencer-client

--- a/yarn-project/sequencer-client/Dockerfile
+++ b/yarn-project/sequencer-client/Dockerfile
@@ -5,19 +5,27 @@ COPY sequencer-client sequencer-client
 
 # (2) dependencies
 COPY circuits.js circuits.js
+COPY ethereum.js ethereum.js
+COPY foundation foundation
+COPY l1-contracts l1-contracts
+COPY l2-block l2-block
+COPY merkle-tree merkle-tree
+COPY p2p p2p
+COPY tx tx
+COPY world-state world-state
 
-# (2) build
+# (3) build
 WORKDIR /usr/src/yarn-project/sequencer-client
 RUN yarn build && yarn formatting
 
-# (2.5) test
+# (3.5) test
 RUN yarn test
 
-# (3) Prune dev dependencies. See comment in base image.
+# (4) Prune dev dependencies. See comment in base image.
 RUN yarn cache clean
 RUN yarn workspaces focus --production > /dev/null
 
-# (4) set up entry point
+# (5) set up entry point
 FROM node:18-alpine
 COPY --from=builder /usr/src/yarn-project /usr/src/yarn-project
 WORKDIR /usr/src/yarn-project/sequencer-client

--- a/yarn-project/sequencer-client/Dockerfile
+++ b/yarn-project/sequencer-client/Dockerfile
@@ -1,7 +1,10 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 
 # (1) project
-COPY . .
+COPY sequencer-client sequencer-client
+
+# (2) dependencies
+COPY circuits.js circuits.js
 
 # (2) build
 WORKDIR /usr/src/yarn-project/sequencer-client

--- a/yarn-project/world-state/Dockerfile
+++ b/yarn-project/world-state/Dockerfile
@@ -18,14 +18,11 @@ RUN yarn build && yarn formatting
 # (3.5) test
 RUN yarn test
 
-# (4) copy bb.js wasm binaries
-RUN cp /usr/src/circuits/cpp/build-wasm/bin/aztec3-circuits.wasm /usr/src/yarn-project/barretenberg.js/dest/wasm/barretenberg.wasm
-
-# (5) Prune dev dependencies. See comment in base image.
+# (4) Prune dev dependencies. See comment in base image.
 RUN yarn cache clean
 RUN yarn workspaces focus --production > /dev/null
 
-# (6) set up entry point
+# (5) set up entry point
 FROM node:18-alpine
 COPY --from=builder /usr/src/yarn-project/world-state /usr/src/yarn-project/world-state
 WORKDIR /usr/src/yarn-project/world-state


### PR DESCRIPTION
# Description

- add `build:link` as part of building bb.js and circuits.js so no manual `cp` step is needed in Dockerfiles that depend on them

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] The branch has been merged or rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
