### PR TITLE
Ignore unused args if they start with underscore

### DIFF
--- a/yarn-project/foundation/.eslintrc.cjs
+++ b/yarn-project/foundation/.eslintrc.cjs
@@ -66,6 +66,7 @@ module.exports = {
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/await-thenable': 'error',
     '@typescript-eslint/no-floating-promises': 2,
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
     'require-await': 2,
     'no-constant-condition': 'off',
     camelcase: 2,

--- a/yarn-project/foundation/.eslintrc.legacy.cjs
+++ b/yarn-project/foundation/.eslintrc.legacy.cjs
@@ -41,6 +41,7 @@ module.exports = {
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/await-thenable': 'error',
     '@typescript-eslint/no-floating-promises': 2,
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
     'require-await': 2,
     'no-constant-condition': 'off',
     camelcase: 2,

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -127,9 +127,8 @@ export class L1Publisher implements L2BlockReceiver {
   }
 
   // TODO: Fail if blockchainStatus.nextBlockNum > thisBlockNum.
-  // eslint-disable-next-line require-await, @typescript-eslint/no-unused-vars
-  private async checkNextL2BlockNum(thisBlockNum: number): Promise<boolean> {
-    return true;
+  private checkNextL2BlockNum(_thisBlockNum: number): Promise<boolean> {
+    return Promise.resolve(true);
   }
 
   private async sendProcessTx(encodedData: L1ProcessArgs): Promise<string | undefined> {

--- a/yarn-project/sequencer-client/src/simulator/wasm.ts
+++ b/yarn-project/sequencer-client/src/simulator/wasm.ts
@@ -20,8 +20,7 @@ export class WasmCircuitSimulator implements Simulator {
   baseRollupCircuit(input: BaseRollupInputs): Promise<BaseOrMergeRollupPublicInputs> {
     return this.rollupWasmWrapper.simulateBaseRollup(input);
   }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  mergeRollupCircuit(input: MergeRollupInputs): Promise<MergeRollupPublicInputs> {
+  mergeRollupCircuit(_input: MergeRollupInputs): Promise<MergeRollupPublicInputs> {
     throw new Error('Method not implemented.');
   }
   rootRollupCircuit(input: RootRollupInputs): Promise<RootRollupPublicInputs> {


### PR DESCRIPTION
It's a convention that unused args can be denoted by prefixing them with underscore, but eslint does not implement it by default.

See https://eslint.org/docs/latest/rules/no-unused-vars#argsignorepattern
