### PR TITLE
Move wasms to shared resources folder and clean up dockerfiles

### DIFF
--- a/yarn-project/acir-simulator/Dockerfile
+++ b/yarn-project/acir-simulator/Dockerfile
@@ -1,8 +1,5 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 COPY . .
-# Build barretenberg.js to ensure wasm is in the dest folder.
-WORKDIR /usr/src/yarn-project/barretenberg.js
-RUN yarn build
 
 WORKDIR /usr/src/yarn-project/acir-simulator
 RUN yarn build && yarn formatting && yarn test

--- a/yarn-project/aztec-cli/Dockerfile
+++ b/yarn-project/aztec-cli/Dockerfile
@@ -1,6 +1,7 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 
-COPY aztec-cli aztec-cli
+COPY . .
+
 WORKDIR /usr/src/yarn-project/aztec-cli
 RUN yarn build && yarn formatting && yarn test
 

--- a/yarn-project/aztec-node/Dockerfile
+++ b/yarn-project/aztec-node/Dockerfile
@@ -1,6 +1,7 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 
-COPY aztec-node aztec-node
+COPY . .
+
 WORKDIR /usr/src/yarn-project/aztec-node
 RUN yarn build && yarn formatting && yarn test
 

--- a/yarn-project/aztec-rpc/Dockerfile
+++ b/yarn-project/aztec-rpc/Dockerfile
@@ -1,14 +1,7 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
+
 COPY . .
-# Build barretenberg.js to ensure wasm is in the dest folder.
-WORKDIR /usr/src/yarn-project/barretenberg.js
-RUN yarn build
 
-# dependencies
-WORKDIR /usr/src/yarn-project
-COPY barretenberg.js barretenberg.js
-
-RUN cd aztec-node && yarn build
 WORKDIR /usr/src/yarn-project/aztec-rpc
 RUN yarn build && yarn formatting && yarn test
 

--- a/yarn-project/aztec.js/Dockerfile
+++ b/yarn-project/aztec.js/Dockerfile
@@ -1,5 +1,7 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
+
 COPY . .
+
 WORKDIR /usr/src/yarn-project/aztec.js
 RUN yarn build && yarn formatting && yarn test
 

--- a/yarn-project/barretenberg.js/Dockerfile
+++ b/yarn-project/barretenberg.js/Dockerfile
@@ -1,6 +1,7 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
-COPY foundation foundation
-COPY barretenberg.js barretenberg.js
+
+COPY . .
+
 WORKDIR /usr/src/yarn-project/barretenberg.js
 RUN yarn build && yarn formatting && yarn test
 

--- a/yarn-project/barretenberg.js/package.json
+++ b/yarn-project/barretenberg.js/package.json
@@ -13,7 +13,7 @@
     "tsconfig": "./tsconfig.dest.json"
   },
   "scripts": {
-    "build": "tsc -b tsconfig.dest.json && cp ./src/wasm/*.wasm ./dest/wasm",
+    "build": "tsc -b tsconfig.dest.json",
     "build:dev": "tsc -b tsconfig.dest.json --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "prettier --check ./src && eslint --max-warnings 0 ./src",

--- a/yarn-project/barretenberg.js/resources/barretenberg.wasm
+++ b/yarn-project/barretenberg.js/resources/barretenberg.wasm
@@ -1,0 +1,1 @@
+../../../circuits/cpp/build-wasm/bin/aztec3-circuits.wasm

--- a/yarn-project/barretenberg.js/resources/primitives.wasm
+++ b/yarn-project/barretenberg.js/resources/primitives.wasm
@@ -1,0 +1,1 @@
+../../../circuits/cpp/barretenberg/cpp/build-wasm/bin/primitives.wasm

--- a/yarn-project/barretenberg.js/src/wasm/barretenberg.wasm
+++ b/yarn-project/barretenberg.js/src/wasm/barretenberg.wasm
@@ -1,1 +1,0 @@
-../../../../circuits/cpp/build-wasm/bin/aztec3-circuits.wasm

--- a/yarn-project/barretenberg.js/src/wasm/barretenberg_wasm.ts
+++ b/yarn-project/barretenberg.js/src/wasm/barretenberg_wasm.ts
@@ -11,7 +11,7 @@ const NAME = 'barretenberg';
  * A low-level wrapper for an instance of Barretenberg WASM.
  */
 export class BarretenbergWasm extends AsyncWasmWrapper {
-  codePath = isNode ? join(dirname(fileURLToPath(import.meta.url)), `${NAME}.wasm`) : `${NAME}.wasm`;
+  codePath = isNode ? join(dirname(fileURLToPath(import.meta.url)), `../../resources/${NAME}.wasm`) : `${NAME}.wasm`;
 
   static instance: Promise<BarretenbergWasm>;
 

--- a/yarn-project/barretenberg.js/src/wasm/primitives.wasm
+++ b/yarn-project/barretenberg.js/src/wasm/primitives.wasm
@@ -1,1 +1,0 @@
-../../../../circuits/cpp/barretenberg/cpp/build-wasm/bin/primitives.wasm

--- a/yarn-project/barretenberg.js/src/wasm/primitives_wasm.ts
+++ b/yarn-project/barretenberg.js/src/wasm/primitives_wasm.ts
@@ -9,7 +9,7 @@ const NAME = 'primitives';
  * A low-level wrapper for an instance of the barretenberg primitives wasm.
  */
 export class PrimitivesWasm extends WasmWrapper {
-  codePath = isNode ? join(dirname(fileURLToPath(import.meta.url)), `${NAME}.wasm`) : `${NAME}.wasm`;
+  codePath = isNode ? join(dirname(fileURLToPath(import.meta.url)), `../../resources/${NAME}.wasm`) : `${NAME}.wasm`;
 
   static instance: Promise<PrimitivesWasm>;
 

--- a/yarn-project/circuits.js/Dockerfile
+++ b/yarn-project/circuits.js/Dockerfile
@@ -7,10 +7,7 @@ COPY . .
 WORKDIR /usr/src/yarn-project/circuits.js
 RUN yarn build && yarn formatting
 
-# (3) copy bb.js wasm binaries
-RUN cp /usr/src/circuits/cpp/build-wasm/bin/aztec3-circuits.wasm /usr/src/yarn-project/circuits.js/dest/wasm/aztec3-circuits.wasm
-
-# (3.5) test
+# (3) test
 RUN yarn test
 
 # (4) Prune dev dependencies. See comment in base image.

--- a/yarn-project/circuits.js/package.json
+++ b/yarn-project/circuits.js/package.json
@@ -15,9 +15,8 @@
     "tsconfig": "./tsconfig.dest.json"
   },
   "scripts": {
-    "build": "tsc -b tsconfig.dest.json && yarn build:link",
+    "build": "tsc -b tsconfig.dest.json",
     "build:dev": "tsc -b tsconfig.dest.json --watch",
-    "build:link": "ln -nf src/wasm/aztec3-circuits.wasm dest/wasm/aztec3-circuits.wasm",
     "redo-ts-refs": "../../scripts/update-tsconfig-references tsconfig.dest.json",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "prettier --check ./src && eslint --max-warnings 278 ./src",

--- a/yarn-project/circuits.js/resources/aztec3-circuits.wasm
+++ b/yarn-project/circuits.js/resources/aztec3-circuits.wasm
@@ -1,0 +1,1 @@
+../../../circuits/cpp/build-wasm/bin/aztec3-circuits.wasm

--- a/yarn-project/circuits.js/src/wasm/aztec3-circuits.wasm
+++ b/yarn-project/circuits.js/src/wasm/aztec3-circuits.wasm
@@ -1,1 +1,0 @@
-../../../../circuits/cpp/build-wasm/bin/aztec3-circuits.wasm

--- a/yarn-project/circuits.js/src/wasm/circuits_wasm.ts
+++ b/yarn-project/circuits.js/src/wasm/circuits_wasm.ts
@@ -11,7 +11,7 @@ const NAME = '/aztec3-circuits';
  * A low-level wrapper for an instance of Aztec3 Circuits WASM.
  */
 export class CircuitsWasm extends AsyncWasmWrapper {
-  codePath = isNode ? join(dirname(fileURLToPath(import.meta.url)), `${NAME}.wasm`) : `${NAME}.wasm`;
+  codePath = isNode ? join(dirname(fileURLToPath(import.meta.url)), `../../resources/${NAME}.wasm`) : `${NAME}.wasm`;
 
   static instance: Promise<CircuitsWasm>;
 

--- a/yarn-project/end-to-end/Dockerfile
+++ b/yarn-project/end-to-end/Dockerfile
@@ -3,14 +3,6 @@ FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 # Copy in the whole of yarn-project.
 COPY . .
 
-# Build circuits.js to ensure wasm is in the dest folder.
-WORKDIR /usr/src/yarn-project/circuits.js
-RUN yarn build
-
-# Build barretenberg.js to ensure wasm is in the dest folder.
-WORKDIR /usr/src/yarn-project/barretenberg.js
-RUN yarn build
-
 # Build end-to-end.
 WORKDIR /usr/src/yarn-project/end-to-end
 RUN yarn build && yarn formatting

--- a/yarn-project/kernel-prover/Dockerfile
+++ b/yarn-project/kernel-prover/Dockerfile
@@ -1,6 +1,7 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 
-COPY kernel-prover kernel-prover
+COPY . .
+
 WORKDIR /usr/src/yarn-project/kernel-prover
 RUN yarn build && yarn formatting && yarn test
 

--- a/yarn-project/key-store/Dockerfile
+++ b/yarn-project/key-store/Dockerfile
@@ -1,6 +1,7 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 
-COPY key-store key-store
+COPY . .
+
 WORKDIR /usr/src/yarn-project/key-store
 RUN yarn build && yarn formatting && yarn test
 

--- a/yarn-project/l1-contracts/Dockerfile
+++ b/yarn-project/l1-contracts/Dockerfile
@@ -1,6 +1,7 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 
-COPY l1-contracts l1-contracts
+COPY . .
+
 WORKDIR /usr/src/yarn-project/l1-contracts
 RUN yarn build && yarn formatting && yarn test
 

--- a/yarn-project/merkle-tree/Dockerfile
+++ b/yarn-project/merkle-tree/Dockerfile
@@ -1,14 +1,6 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 
-COPY foundation foundation
-COPY merkle-tree merkle-tree
-COPY barretenberg.js barretenberg.js
-
-WORKDIR /usr/src/yarn-project/foundation
-RUN yarn build
-WORKDIR /usr/src/yarn-project/barretenberg.js
-RUN yarn build
-RUN cp /usr/src/circuits/cpp/build-wasm/bin/aztec3-circuits.wasm dest/wasm/barretenberg.wasm
+COPY . .
 
 WORKDIR /usr/src/yarn-project/merkle-tree
 RUN yarn build && yarn formatting && yarn test

--- a/yarn-project/noir-contracts/Dockerfile
+++ b/yarn-project/noir-contracts/Dockerfile
@@ -1,7 +1,7 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 
-COPY foundation foundation
-COPY noir-contracts noir-contracts
+COPY . .
+
 WORKDIR /usr/src/yarn-project/noir-contracts
 RUN yarn build && yarn formatting && yarn test
 

--- a/yarn-project/p2p/Dockerfile
+++ b/yarn-project/p2p/Dockerfile
@@ -2,14 +2,6 @@ FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 
 COPY . .
 
-# Manually run bb so we get the wasm in dest
-WORKDIR /usr/src/yarn-project/barretenberg.js
-RUN yarn build
-
-# Manually run circuits so we get the wasm in dest
-WORKDIR /usr/src/yarn-project/circuits.js
-RUN yarn build
-
 WORKDIR /usr/src/yarn-project/p2p
 RUN yarn build && yarn formatting
 

--- a/yarn-project/prover-client/Dockerfile
+++ b/yarn-project/prover-client/Dockerfile
@@ -1,6 +1,7 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 
-COPY prover-client prover-client
+COPY . .
+
 WORKDIR /usr/src/yarn-project/prover-client
 RUN yarn build && yarn formatting && yarn test
 

--- a/yarn-project/sequencer-client/Dockerfile
+++ b/yarn-project/sequencer-client/Dockerfile
@@ -7,11 +7,7 @@ COPY . .
 WORKDIR /usr/src/yarn-project/sequencer-client
 RUN yarn build && yarn formatting
 
-# (3) copy bb.js wasm binaries
-RUN cp /usr/src/circuits/cpp/build-wasm/bin/aztec3-circuits.wasm /usr/src/yarn-project/circuits.js/dest/wasm/aztec3-circuits.wasm
-RUN cp /usr/src/circuits/cpp/build-wasm/bin/aztec3-circuits.wasm /usr/src/yarn-project/barretenberg.js/dest/wasm/barretenberg.wasm
-
-# (3.5) test
+# (3) test
 RUN yarn test
 
 # (4) Prune dev dependencies. See comment in base image.

--- a/yarn-project/tx/Dockerfile
+++ b/yarn-project/tx/Dockerfile
@@ -1,6 +1,7 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 
-COPY tx tx
+COPY . .
+
 WORKDIR /usr/src/yarn-project/tx
 RUN yarn build && yarn formatting && yarn test
 

--- a/yarn-project/unverified-data/Dockerfile
+++ b/yarn-project/unverified-data/Dockerfile
@@ -1,7 +1,7 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
-COPY unverified-data unverified-data
-# dependencies
-COPY foundation foundation
+
+COPY . .
+
 WORKDIR /usr/src/yarn-project/unverified-data
 RUN yarn build && yarn formatting && yarn test
 

--- a/yarn-project/world-state/Dockerfile
+++ b/yarn-project/world-state/Dockerfile
@@ -1,33 +1,17 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 
-# (1) project
-COPY world-state world-state
-# (2) dependencies
-COPY foundation foundation
-COPY ethereum.js ethereum.js
-COPY barretenberg.js barretenberg.js
-COPY l1-contracts l1-contracts
-COPY circuits.js circuits.js
-COPY l2-block l2-block
-COPY tx tx
-COPY unverified-data unverified-data
-COPY merkle-tree merkle-tree
+COPY . .
 
-# (3) build
 WORKDIR /usr/src/yarn-project/world-state
 RUN yarn build && yarn formatting
 
-# (3.5) test
 RUN yarn test
 
-# (4) copy bb.js wasm binaries
-RUN cp /usr/src/circuits/cpp/build-wasm/bin/aztec3-circuits.wasm /usr/src/yarn-project/barretenberg.js/dest/wasm/barretenberg.wasm
-
-# (5) Prune dev dependencies. See comment in base image.
+# Prune dev dependencies. See comment in base image.
 RUN yarn cache clean
 RUN yarn workspaces focus --production > /dev/null
 
-# (6) set up entry point
+# set up entry point
 FROM node:18-alpine
 COPY --from=builder /usr/src/yarn-project/world-state /usr/src/yarn-project/world-state
 WORKDIR /usr/src/yarn-project/world-state


### PR DESCRIPTION
- Moves wasm files from `src` (in both bb and circuits) to a `resources` folder, to be accessed from both `src` and `dist`. This removes the need for a manual post-build step to copy or symlink the wasm, which was required also when building a package that depended on these. Cleans up dockerfiles to remove these build steps. Fixes #206.
- Copies entire project to each dockerfile, so we don't need to keep dependencies in sync with each dockerfile as well. If performance becomes an issue here, we can change the prepare root script to also update dockerfiles. Fixes #224.