### PR TITLE
use c_bind for getDummyPreviousKernelData

### DIFF
--- a/yarn-project/circuits.js/src/structs/kernel.ts
+++ b/yarn-project/circuits.js/src/structs/kernel.ts
@@ -1,3 +1,4 @@
+import { CircuitsWasm, getDummyPreviousKernelData } from '../index.js';
 import { assertLength, FieldsOf } from '../utils/jsUtils.js';
 import { serializeToBuffer } from '../utils/serialize.js';
 import {
@@ -263,6 +264,25 @@ export class PreviousKernelData {
       0,
       Array(VK_TREE_HEIGHT).fill(frZero()),
     );
+  }
+}
+
+export class DummyPreviousKernelData {
+  private static instance: DummyPreviousKernelData;
+
+  private constructor(private data: PreviousKernelData) {}
+
+  public static async getDummyPreviousKernelData(wasm: CircuitsWasm) {
+    if (!DummyPreviousKernelData.instance) {
+      const data = await getDummyPreviousKernelData(wasm);
+      DummyPreviousKernelData.instance = new DummyPreviousKernelData(data);
+    }
+
+    return DummyPreviousKernelData.instance.getData();
+  }
+
+  public getData() {
+    return this.data;
   }
 }
 

--- a/yarn-project/kernel-prover/src/index.ts
+++ b/yarn-project/kernel-prover/src/index.ts
@@ -18,6 +18,7 @@ import {
   VerificationKey,
   makeEmptyProof,
   NewContractData,
+  DummyPreviousKernelData,
 } from '@aztec/circuits.js';
 import { computeContractLeaf } from '@aztec/circuits.js/abis';
 import { createDebugLogger, Fr } from '@aztec/foundation';
@@ -64,7 +65,8 @@ export class KernelProver {
       txRequest.txContext.contractDeploymentData.portalContractAddress,
     );
 
-    const previousKernelData: PreviousKernelData = PreviousKernelData.makeEmpty();
+    const previousKernelData: PreviousKernelData = await DummyPreviousKernelData.getDummyPreviousKernelData(wasm);
+
     this.log(`Executing private kernel simulation...`);
     const publicInputs = await privateKernelSim(wasm, signedTxRequest, previousKernelData, privateCallData);
     this.log(`Skipping private kernel proving...`);


### PR DESCRIPTION
# Description

- Use C++ method for dummy previous kernel data
- NOTE: created singleton-like implementation for DummyPreviousKernelData to work around bug which breaks `private_kernel__dummy_previous_kernel` when called twice on the same wasm instance
# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
