### PR TITLE
Use lighter primitives.wasm for merkle trees by default

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/aztec-node.ts
+++ b/yarn-project/aztec-node/src/aztec-node/aztec-node.ts
@@ -10,6 +10,7 @@ import { MerkleTreeId, MerkleTrees, ServerWorldStateSynchroniser, WorldStateSync
 import { default as levelup } from 'levelup';
 import { default as memdown } from 'memdown';
 import { AztecNodeConfig } from './config.js';
+import { CircuitsWasm } from '@aztec/circuits.js';
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
@@ -41,7 +42,7 @@ export class AztecNode {
     const p2pClient = new P2PClient(archiver);
 
     // now create the merkle trees and the world state syncher
-    const merkleTreeDB = await MerkleTrees.new(levelup(createMemDown()));
+    const merkleTreeDB = await MerkleTrees.new(levelup(createMemDown()), await CircuitsWasm.get());
     const worldStateSynchroniser = new ServerWorldStateSynchroniser(merkleTreeDB, archiver);
 
     // start both and wait for them to sync from the block source

--- a/yarn-project/merkle-tree/src/pedersen.ts
+++ b/yarn-project/merkle-tree/src/pedersen.ts
@@ -4,12 +4,12 @@ import {
   pedersenGetHash,
   pedersenGetHashTree,
 } from '@aztec/barretenberg.js/crypto';
-import { BarretenbergWasm } from '@aztec/barretenberg.js/wasm';
 
+import { WasmWrapper } from '@aztec/foundation/wasm';
 import { Hasher } from './hasher.js';
 
 export class Pedersen implements Hasher {
-  constructor(private wasm: BarretenbergWasm) {}
+  constructor(private wasm: WasmWrapper) {}
 
   public compress(lhs: Uint8Array, rhs: Uint8Array): Buffer {
     return pedersenCompress(this.wasm, lhs, rhs);

--- a/yarn-project/merkle-tree/src/test/test_suite.ts
+++ b/yarn-project/merkle-tree/src/test/test_suite.ts
@@ -1,4 +1,5 @@
-import { BarretenbergWasm } from '@aztec/barretenberg.js/wasm';
+import { PrimitivesWasm } from '@aztec/barretenberg.js/wasm';
+import { WasmWrapper } from '@aztec/foundation/wasm';
 import { default as levelup } from 'levelup';
 import { default as memdown } from 'memdown';
 import { Hasher, MerkleTree, Pedersen, SiblingPath } from '../index.js';
@@ -26,7 +27,7 @@ export const merkleTreeTestSuite = (
 ) => {
   describe(testName, () => {
     const values: Buffer[] = [];
-    let wasm: BarretenbergWasm;
+    let wasm: WasmWrapper;
     let pedersen: Pedersen;
 
     beforeAll(() => {
@@ -38,7 +39,7 @@ export const merkleTreeTestSuite = (
     });
 
     beforeEach(async () => {
-      wasm = await BarretenbergWasm.get();
+      wasm = await PrimitivesWasm.get();
       pedersen = new Pedersen(wasm);
     });
 

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -5,7 +5,7 @@ import {
   PRIVATE_DATA_TREE_HEIGHT,
   PRIVATE_DATA_TREE_ROOTS_TREE_HEIGHT,
 } from '@aztec/circuits.js';
-import { BarretenbergWasm } from '@aztec/barretenberg.js/wasm';
+import { BarretenbergWasm, PrimitivesWasm } from '@aztec/barretenberg.js/wasm';
 import { SerialQueue } from '@aztec/foundation';
 import { IndexedTree, LeafData, MerkleTree, Pedersen, SiblingPath, StandardMerkleTree } from '@aztec/merkle-tree';
 import { default as levelup } from 'levelup';
@@ -18,6 +18,7 @@ import {
   MerkleTreeOperations,
   TreeInfo,
 } from './index.js';
+import { WasmWrapper } from '@aztec/foundation/wasm';
 
 /**
  * A convenience class for managing multiple merkle trees.
@@ -31,8 +32,8 @@ export class MerkleTrees implements MerkleTreeDb {
   /**
    * Initialises the collection of Merkle Trees.
    */
-  public async init() {
-    const wasm = await BarretenbergWasm.get();
+  public async init(optionalWasm?: WasmWrapper) {
+    const wasm = optionalWasm ?? (await PrimitivesWasm.get());
     const hasher = new Pedersen(wasm);
     const contractTree = await StandardMerkleTree.new(
       this.db,
@@ -74,9 +75,9 @@ export class MerkleTrees implements MerkleTreeDb {
    * @param db - The db instance to use for data persistance.
    * @returns - A fully initialised MerkleTrees instance.
    */
-  public static async new(db: levelup.LevelUp) {
+  public static async new(db: levelup.LevelUp, wasm?: WasmWrapper) {
     const merkleTrees = new MerkleTrees(db);
-    await merkleTrees.init();
+    await merkleTrees.init(wasm);
     return merkleTrees;
   }
 

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -1,3 +1,4 @@
+import { PrimitivesWasm } from '@aztec/barretenberg.js/wasm';
 import {
   CONTRACT_TREE_HEIGHT,
   CONTRACT_TREE_ROOTS_TREE_HEIGHT,
@@ -5,8 +6,8 @@ import {
   PRIVATE_DATA_TREE_HEIGHT,
   PRIVATE_DATA_TREE_ROOTS_TREE_HEIGHT,
 } from '@aztec/circuits.js';
-import { BarretenbergWasm, PrimitivesWasm } from '@aztec/barretenberg.js/wasm';
 import { SerialQueue } from '@aztec/foundation';
+import { WasmWrapper } from '@aztec/foundation/wasm';
 import { IndexedTree, LeafData, MerkleTree, Pedersen, SiblingPath, StandardMerkleTree } from '@aztec/merkle-tree';
 import { default as levelup } from 'levelup';
 import { MerkleTreeOperationsFacade } from '../merkle-tree/merkle_tree_operations_facade.js';
@@ -18,7 +19,6 @@ import {
   MerkleTreeOperations,
   TreeInfo,
 } from './index.js';
-import { WasmWrapper } from '@aztec/foundation/wasm';
 
 /**
  * A convenience class for managing multiple merkle trees.


### PR DESCRIPTION
Merkle trees only require access to pedersen hashes, which are available on the primitives.wasm, a smaller version of bb.wasm. This PR changes merkle tree initialization to pick up that library by default.  Still, when creating them from an aztec node, which will require the full circuits.wasm (since it runs rollup circuits), we use the circuits wasm to avoid loading multiple wasms unnecessarily.

Fixes #180 