### PR TITLE
Notify slack on master CI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,10 @@
 # There are some `join` steps that are just noops. They are just used to produce cleaner graph rendering in CCI.
 
 version: 2.1
+
+orbs:
+  slack: circleci/slack@4.12.1
+
 parameters:
   workflow:
     type: string
@@ -291,6 +295,11 @@ defaults: &defaults
       only: *tag_regex
   context:
     - build
+    - slack
+  post-steps:
+    - slack/notify:
+        event: fail
+        branch_pattern: "master,chore/slack-notification"
 yarn_project: &yarn_project
   requires:
     - yarn-project-base
@@ -311,20 +320,11 @@ workflows:
           requires:
             - wasm-linux-clang
           <<: *defaults
+
       - ethereum-js: *yarn_project
       - aztec-js: *yarn_project
       - end-to-end: *yarn_project
       - foundation: *yarn_project
-      - e2e-join:
-          requires:
-            - ethereum-js
-            - aztec-js
-            - end-to-end
-            - noir-contracts
-            - foundation
-          <<: *defaults
-      - e2e-deploy-contract: *e2e_test
-      - e2e-zk-token-contract: *e2e_test
       - world-state: *yarn_project
       - acir-simulator: *yarn_project
       - archiver: *yarn_project
@@ -336,3 +336,15 @@ workflows:
       - sequencer-client: *yarn_project
       - types: *yarn_project
       - circuits-js: *yarn_project
+
+      - e2e-join:
+          requires:
+            - ethereum-js
+            - aztec-js
+            - end-to-end
+            - noir-contracts
+            - foundation
+          <<: *defaults
+      
+      - e2e-deploy-contract: *e2e_test
+      - e2e-zk-token-contract: *e2e_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ defaults: &defaults
   post-steps:
     - slack/notify:
         event: fail
-        branch_pattern: "master,chore/slack-notification"
+        branch_pattern: "master"
 yarn_project: &yarn_project
   requires:
     - yarn-project-base

--- a/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.test.ts
+++ b/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.test.ts
@@ -119,7 +119,6 @@ describe('sequencer/circuit_block_builder', () => {
   };
 
   it('builds an L2 block using mock simulator', async () => {
-    throw new Error(`Foo!`);
     // Create instance to test
     builder = new TestSubject(builderDb, vks, simulator, prover);
     await builder.updateRootTrees();

--- a/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.test.ts
+++ b/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.test.ts
@@ -119,6 +119,7 @@ describe('sequencer/circuit_block_builder', () => {
   };
 
   it('builds an L2 block using mock simulator', async () => {
+    throw new Error(`Foo!`);
     // Create instance to test
     builder = new TestSubject(builderDb, vks, simulator, prover);
     await builder.updateRootTrees();


### PR DESCRIPTION
Sends a Slack notification to the channel `aztec3-ci` when the CI fails on master. Note that, due to limitations on CircleCI (wen github actions?), we cannot alert at the end of the workflow, so we need to alert on each individual job that fails. See [this article](https://support.circleci.com/hc/en-us/articles/360047082992-How-to-send-a-slack-notification-at-end-of-workflow) and [this discussion](https://github.com/CircleCI-Public/slack-orb/issues/305) for more info.

![Screenshot from 2023-04-11 16-45-00](https://user-images.githubusercontent.com/429604/231272082-c7beb9d2-6923-432e-b5d4-af4f45fa7fb3.png)

Share the channel in `aztec3` on Slack so people can subscribe.

Fixes #205 