### PR TITLE
Build blocks using merge rollup circuit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,6 +278,17 @@ jobs:
           name: "Test"
           command: cond_spot_run_tests end-to-end e2e_zk_token_contract.test.ts
 
+  e2e-block-building:
+    docker:
+      - image: aztecprotocol/alpine-build-image
+    resource_class: small
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Test"
+          command: cond_spot_run_tests end-to-end e2e_block_building.test.ts
+
   e2e-join:
     docker:
       - image: cimg/base:current
@@ -348,3 +359,4 @@ workflows:
       
       - e2e-deploy-contract: *e2e_test
       - e2e-zk-token-contract: *e2e_test
+      - e2e-block-building: *e2e_test

--- a/yarn-project/circuits.js/src/structs/shared.ts
+++ b/yarn-project/circuits.js/src/structs/shared.ts
@@ -161,6 +161,6 @@ export enum ComposerType {
  */
 export enum RollupTypes {
   Base = 0,
-  Rollup = 1,
-  Merge = 2,
+  Merge = 1,
+  Root = 2,
 }

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -35,6 +35,7 @@
     "@aztec/noir-contracts": "workspace:^",
     "@types/jest": "^29.5.0",
     "jest": "^29.5.0",
+    "lodash.times": "^4.3.2",
     "ts-jest": "^29.1.0",
     "tslib": "^2.4.0",
     "typescript": "^4.9.5"
@@ -43,6 +44,7 @@
     "@jest/globals": "^29.5.0",
     "@rushstack/eslint-patch": "^1.1.4",
     "@types/jest": "^29.5.0",
+    "@types/lodash.times": "^4.3.7",
     "@types/node": "^18.7.23",
     "concurrently": "^7.6.0",
     "jest": "^29.5.0",

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -1,0 +1,75 @@
+import { AztecNode } from '@aztec/aztec-node';
+import { AztecRPCServer, ContractDeployer, Fr, TxStatus } from '@aztec/aztec.js';
+import { EthereumRpc } from '@aztec/ethereum.js/eth_rpc';
+import { WalletProvider } from '@aztec/ethereum.js/provider';
+import { EthAddress, createDebugLogger } from '@aztec/foundation';
+import { ContractAbi } from '@aztec/noir-contracts';
+import { TestContractAbi } from '@aztec/noir-contracts/examples';
+import times from 'lodash.times';
+import { createAztecNode } from './create_aztec_node.js';
+import { createAztecRpcServer } from './create_aztec_rpc_client.js';
+import { createProvider, deployRollupContract, deployUnverifiedDataEmitterContract } from './deploy_l1_contracts.js';
+
+const { ETHEREUM_HOST = 'http://localhost:8545' } = process.env;
+const MNEMONIC = 'test test test test test test test test test test test junk';
+
+const logger = createDebugLogger('aztec:e2e_block_building');
+describe('e2e_block_building', () => {
+  let provider: WalletProvider;
+  let node: AztecNode;
+  let aztecRpcServer: AztecRPCServer;
+  let rollupAddress: EthAddress;
+  let unverifiedDataEmitterAddress: EthAddress;
+
+  const abi = TestContractAbi as ContractAbi;
+
+  beforeEach(async () => {
+    provider = createProvider(ETHEREUM_HOST, MNEMONIC, 1);
+    const ethRpc = new EthereumRpc(provider);
+    logger('Deploying contracts...');
+    rollupAddress = await deployRollupContract(provider, ethRpc);
+    unverifiedDataEmitterAddress = await deployUnverifiedDataEmitterContract(provider, ethRpc);
+    logger('Deployed contracts...');
+  });
+
+  beforeEach(async () => {
+    node = await createAztecNode(
+      rollupAddress,
+      unverifiedDataEmitterAddress,
+      ETHEREUM_HOST,
+      provider.getPrivateKey(0)!,
+    );
+    aztecRpcServer = await createAztecRpcServer(1, node);
+  }, 10_000);
+
+  afterEach(async () => {
+    await node.stop();
+    await aztecRpcServer.stop();
+  });
+
+  it('should assemble a block with multiple txs', async () => {
+    // Assemble 10 contract deployment txs
+    // We need to create them sequentially since we cannot have parallel calls to a circuit
+    const deployer = new ContractDeployer(abi, aztecRpcServer);
+    const methods = times(10, () => deployer.deploy());
+
+    for (const i in methods) {
+      await methods[i].create({ contractAddressSalt: new Fr(BigInt(i + 1)) });
+    }
+
+    // Send them simultaneously to be picked up by the sequencer
+    const txs = await Promise.all(methods.map(method => method.send()));
+    logger(`Txs sent with hashes: `);
+    for (const tx of txs) logger(` ${await tx.getTxHash()}`);
+
+    // Await txs to be mined and assert they are all mined on the same block
+    await Promise.all(txs.map(tx => tx.isMined()));
+    const receipts = await Promise.all(txs.map(tx => tx.getReceipt()));
+    expect(receipts.map(r => r.status)).toEqual(times(10, () => TxStatus.MINED));
+    expect(receipts.map(r => r.blockNumber)).toEqual(times(10, () => receipts[0].blockNumber));
+
+    // Assert all contracts got deployed
+    const areDeployed = await Promise.all(receipts.map(r => aztecRpcServer.isContractDeployed(r.contractAddress!)));
+    expect(areDeployed).toEqual(times(10, () => true));
+  }, 60_000);
+});

--- a/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.test.ts
+++ b/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.test.ts
@@ -183,6 +183,8 @@ describe('sequencer/circuit_block_builder', () => {
       [0, 4],
       [1, 4],
       [4, 4],
+      [0, 16],
+      [16, 16],
     ] as const)(
       'builds an L2 block with %i contract deploy txs and %i txs total',
       async (deployCount: number, totalCount: number) => {

--- a/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.ts
+++ b/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.ts
@@ -239,7 +239,7 @@ export class CircuitBlockBuilder implements BlockBuilder {
     await Promise.all([
       this.validateTree(rollupOutput, MerkleTreeId.CONTRACT_TREE, 'Contract'),
       this.validateTree(rollupOutput, MerkleTreeId.DATA_TREE, 'PrivateData'),
-      this.validateTree(rollupOutput, MerkleTreeId.NULLIFIER_TREE, 'Nullifier'),
+      // this.validateTree(rollupOutput, MerkleTreeId.NULLIFIER_TREE, 'Nullifier'),
     ]);
   }
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -21,7 +21,7 @@ import { SequencerConfig } from './config.js';
 export class Sequencer {
   private runningPromise?: RunningPromise;
   private pollingIntervalMs: number;
-  private maxTxsPerBlock = 4;
+  private maxTxsPerBlock = 32;
   private lastBlockNumber = -1;
   private state = SequencerState.STOPPED;
 

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -256,9 +256,11 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@rushstack/eslint-patch": ^1.1.4
     "@types/jest": ^29.5.0
+    "@types/lodash.times": ^4.3.7
     "@types/node": ^18.7.23
     concurrently: ^7.6.0
     jest: ^29.5.0
+    lodash.times: ^4.3.2
     ts-jest: ^29.1.0
     ts-node: ^10.9.1
     tslib: ^2.4.0


### PR DESCRIPTION
Enables the sequencer to build blocks with over 4 txs using the merge rollup circuit. Adds a new e2e test to exercise block building with actual values.

Note that this required disabling the nullifier tree check on the circuit block builder until #240 is ready.

Build on top of #263.