### PR TITLE
Naming consistency in circuits

### DIFF
--- a/circuits/cpp/src/aztec3/circuits/abis/private_kernel/constant_data.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/private_kernel/constant_data.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "old_tree_roots.hpp"
+#include "historic_tree_roots.hpp"
 #include "../tx_context.hpp"
 
 #include <barretenberg/stdlib/primitives/witness/witness.hpp>
@@ -19,12 +19,12 @@ template <typename NCT> struct ConstantData {
     typedef typename NCT::fr fr;
     typedef typename NCT::boolean boolean;
 
-    OldTreeRoots<NCT> old_tree_roots{};
+    HistoricTreeRoots<NCT> historic_tree_roots{};
     TxContext<NCT> tx_context{};
 
     boolean operator==(ConstantData<NCT> const& other) const
     {
-        return old_tree_roots == other.old_tree_roots && tx_context == other.tx_context;
+        return historic_tree_roots == other.historic_tree_roots && tx_context == other.tx_context;
     };
 
     template <typename Composer> ConstantData<CircuitTypes<Composer>> to_circuit_type(Composer& composer) const
@@ -32,7 +32,7 @@ template <typename NCT> struct ConstantData {
         static_assert((std::is_same<NativeTypes, NCT>::value));
 
         ConstantData<CircuitTypes<Composer>> constant_data = {
-            old_tree_roots.to_circuit_type(composer),
+            historic_tree_roots.to_circuit_type(composer),
             tx_context.to_circuit_type(composer),
         };
 
@@ -46,7 +46,7 @@ template <typename NCT> struct ConstantData {
         auto to_native_type = []<typename T>(T& e) { return e.template to_native_type<Composer>(); };
 
         ConstantData<NativeTypes> constant_data = {
-            to_native_type(old_tree_roots),
+            to_native_type(historic_tree_roots),
             to_native_type(tx_context),
         };
 
@@ -57,7 +57,7 @@ template <typename NCT> struct ConstantData {
     {
         static_assert(!(std::is_same<NativeTypes, NCT>::value));
 
-        old_tree_roots.set_public();
+        historic_tree_roots.set_public();
         tx_context.set_public();
     }
 };
@@ -66,7 +66,7 @@ template <typename NCT> void read(uint8_t const*& it, ConstantData<NCT>& constan
 {
     using serialize::read;
 
-    read(it, constant_data.old_tree_roots);
+    read(it, constant_data.historic_tree_roots);
     read(it, constant_data.tx_context);
 };
 
@@ -74,13 +74,13 @@ template <typename NCT> void write(std::vector<uint8_t>& buf, ConstantData<NCT> 
 {
     using serialize::write;
 
-    write(buf, constant_data.old_tree_roots);
+    write(buf, constant_data.historic_tree_roots);
     write(buf, constant_data.tx_context);
 };
 
 template <typename NCT> std::ostream& operator<<(std::ostream& os, ConstantData<NCT> const& constant_data)
 {
-    return os << "old_tree_roots: " << constant_data.old_tree_roots << "\n"
+    return os << "historic_tree_roots: " << constant_data.historic_tree_roots << "\n"
               << "tx_context: " << constant_data.tx_context << "\n";
 }
 

--- a/circuits/cpp/src/aztec3/circuits/abis/private_kernel/historic_tree_roots.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/private_kernel/historic_tree_roots.hpp
@@ -11,7 +11,7 @@ using aztec3::utils::types::NativeTypes;
 using plonk::stdlib::witness_t;
 using std::is_same;
 
-template <typename NCT> struct OldTreeRoots {
+template <typename NCT> struct HistoricTreeRoots {
     typedef typename NCT::fr fr;
     typedef typename NCT::boolean boolean;
 
@@ -20,21 +20,21 @@ template <typename NCT> struct OldTreeRoots {
     fr contract_tree_root = 0;
     fr private_kernel_vk_tree_root = 0; // TODO: future enhancement
 
-    boolean operator==(OldTreeRoots<NCT> const& other) const
+    boolean operator==(HistoricTreeRoots<NCT> const& other) const
     {
         return private_data_tree_root == other.private_data_tree_root &&
                nullifier_tree_root == other.nullifier_tree_root && contract_tree_root == other.contract_tree_root &&
                private_kernel_vk_tree_root == other.private_kernel_vk_tree_root;
     };
 
-    template <typename Composer> OldTreeRoots<CircuitTypes<Composer>> to_circuit_type(Composer& composer) const
+    template <typename Composer> HistoricTreeRoots<CircuitTypes<Composer>> to_circuit_type(Composer& composer) const
     {
         static_assert((std::is_same<NativeTypes, NCT>::value));
 
         // Capture the composer:
         auto to_ct = [&](auto& e) { return aztec3::utils::types::to_ct(composer, e); };
 
-        OldTreeRoots<CircuitTypes<Composer>> data = {
+        HistoricTreeRoots<CircuitTypes<Composer>> data = {
             to_ct(private_data_tree_root),
             to_ct(nullifier_tree_root),
             to_ct(contract_tree_root),
@@ -44,12 +44,12 @@ template <typename NCT> struct OldTreeRoots {
         return data;
     };
 
-    template <typename Composer> OldTreeRoots<NativeTypes> to_native_type() const
+    template <typename Composer> HistoricTreeRoots<NativeTypes> to_native_type() const
     {
         static_assert(std::is_same<CircuitTypes<Composer>, NCT>::value);
         auto to_nt = [&](auto& e) { return aztec3::utils::types::to_nt<Composer>(e); };
 
-        OldTreeRoots<NativeTypes> data = {
+        HistoricTreeRoots<NativeTypes> data = {
             to_nt(private_data_tree_root),
             to_nt(nullifier_tree_root),
             to_nt(contract_tree_root),
@@ -70,32 +70,32 @@ template <typename NCT> struct OldTreeRoots {
     }
 };
 
-template <typename NCT> void read(uint8_t const*& it, OldTreeRoots<NCT>& old_tree_roots)
+template <typename NCT> void read(uint8_t const*& it, HistoricTreeRoots<NCT>& historic_tree_roots)
 {
     using serialize::read;
 
-    read(it, old_tree_roots.private_data_tree_root);
-    read(it, old_tree_roots.nullifier_tree_root);
-    read(it, old_tree_roots.contract_tree_root);
-    read(it, old_tree_roots.private_kernel_vk_tree_root);
+    read(it, historic_tree_roots.private_data_tree_root);
+    read(it, historic_tree_roots.nullifier_tree_root);
+    read(it, historic_tree_roots.contract_tree_root);
+    read(it, historic_tree_roots.private_kernel_vk_tree_root);
 };
 
-template <typename NCT> void write(std::vector<uint8_t>& buf, OldTreeRoots<NCT> const& old_tree_roots)
+template <typename NCT> void write(std::vector<uint8_t>& buf, HistoricTreeRoots<NCT> const& historic_tree_roots)
 {
     using serialize::write;
 
-    write(buf, old_tree_roots.private_data_tree_root);
-    write(buf, old_tree_roots.nullifier_tree_root);
-    write(buf, old_tree_roots.contract_tree_root);
-    write(buf, old_tree_roots.private_kernel_vk_tree_root);
+    write(buf, historic_tree_roots.private_data_tree_root);
+    write(buf, historic_tree_roots.nullifier_tree_root);
+    write(buf, historic_tree_roots.contract_tree_root);
+    write(buf, historic_tree_roots.private_kernel_vk_tree_root);
 };
 
-template <typename NCT> std::ostream& operator<<(std::ostream& os, OldTreeRoots<NCT> const& old_tree_roots)
+template <typename NCT> std::ostream& operator<<(std::ostream& os, HistoricTreeRoots<NCT> const& historic_tree_roots)
 {
-    return os << "private_data_tree_root: " << old_tree_roots.private_data_tree_root << "\n"
-              << "nullifier_tree_root: " << old_tree_roots.nullifier_tree_root << "\n"
-              << "contract_tree_root: " << old_tree_roots.contract_tree_root << "\n"
-              << "private_kernel_vk_tree_root: " << old_tree_roots.private_kernel_vk_tree_root << "\n";
+    return os << "private_data_tree_root: " << historic_tree_roots.private_data_tree_root << "\n"
+              << "nullifier_tree_root: " << historic_tree_roots.nullifier_tree_root << "\n"
+              << "contract_tree_root: " << historic_tree_roots.contract_tree_root << "\n"
+              << "private_kernel_vk_tree_root: " << historic_tree_roots.private_kernel_vk_tree_root << "\n";
 }
 
 } // namespace aztec3::circuits::abis::private_kernel

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/.test.cpp
@@ -21,7 +21,7 @@
 #include <aztec3/circuits/abis/private_kernel/public_inputs.hpp>
 #include <aztec3/circuits/abis/private_kernel/accumulated_data.hpp>
 #include <aztec3/circuits/abis/private_kernel/constant_data.hpp>
-#include <aztec3/circuits/abis/private_kernel/old_tree_roots.hpp>
+#include <aztec3/circuits/abis/private_kernel/historic_tree_roots.hpp>
 #include <aztec3/circuits/abis/private_kernel/globals.hpp>
 
 #include "aztec3/circuits/kernel/private/utils.hpp"
@@ -50,7 +50,7 @@ using aztec3::circuits::abis::private_kernel::NewContractData;
 
 using aztec3::circuits::abis::private_kernel::AccumulatedData;
 using aztec3::circuits::abis::private_kernel::ConstantData;
-using aztec3::circuits::abis::private_kernel::OldTreeRoots;
+using aztec3::circuits::abis::private_kernel::HistoricTreeRoots;
 using aztec3::circuits::abis::private_kernel::PreviousKernelData;
 using aztec3::circuits::abis::private_kernel::PrivateCallData;
 using aztec3::circuits::abis::private_kernel::PrivateInputs;
@@ -336,8 +336,8 @@ PrivateInputs<NT> do_private_call_get_kernel_inputs(bool const is_constructor,
     // Fill in some important fields in public inputs
     mock_previous_kernel.public_inputs.end.private_call_stack = initial_kernel_private_call_stack;
     mock_previous_kernel.public_inputs.constants = ConstantData<NT>{
-        .old_tree_roots =
-            OldTreeRoots<NT>{
+        .historic_tree_roots =
+            HistoricTreeRoots<NT>{
                 .private_data_tree_root = private_circuit_public_inputs.historic_private_data_tree_root,
                 // .nullifier_tree_root =
                 .contract_tree_root = private_circuit_public_inputs.historic_contract_tree_root,

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/c_bind.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/c_bind.cpp
@@ -110,10 +110,10 @@ WASM_EXPORT size_t private_kernel__sim(uint8_t const* signed_tx_request_buf,
         previous_kernel.public_inputs.end.private_call_stack[0] = private_call_data.call_stack_item.hash();
         previous_kernel.public_inputs.constants.historic_tree_roots.private_data_tree_root =
             private_call_data.call_stack_item.public_inputs.historic_private_data_tree_root;
-        // previous_kernel.public_inputs.constants.old_tree_roots.nullifier_tree_root =
-        previous_kernel.public_inputs.constants.old_tree_roots.contract_tree_root =
+        // previous_kernel.public_inputs.constants.historic_tree_roots.nullifier_tree_root =
+        previous_kernel.public_inputs.constants.historic_tree_roots.contract_tree_root =
             private_call_data.call_stack_item.public_inputs.historic_contract_tree_root;
-        // previous_kernel.public_inputs.constants.old_tree_roots.private_kernel_vk_tree_root =
+        // previous_kernel.public_inputs.constants.historic_tree_roots.private_kernel_vk_tree_root =
         previous_kernel.public_inputs.constants.tx_context = signed_tx_request.tx_request.tx_context;
         previous_kernel.public_inputs.is_private = true;
     } else {
@@ -165,7 +165,7 @@ WASM_EXPORT size_t private_kernel__prove(uint8_t const* signed_tx_request_buf,
         previous_kernel.public_inputs.end.private_call_stack[0] = private_call_data.call_stack_item.hash();
         previous_kernel.public_inputs.constants.historic_tree_roots.private_data_tree_root =
             private_call_data.call_stack_item.public_inputs.historic_private_data_tree_root;
-        previous_kernel.public_inputs.constants.old_tree_roots.contract_tree_root =
+        previous_kernel.public_inputs.constants.historic_tree_roots.contract_tree_root =
             private_call_data.call_stack_item.public_inputs.historic_contract_tree_root;
         previous_kernel.public_inputs.constants.tx_context = signed_tx_request.tx_request.tx_context;
         previous_kernel.public_inputs.is_private = true;

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/c_bind.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/c_bind.cpp
@@ -25,7 +25,7 @@ using aztec3::circuits::abis::SignedTxRequest;
 using aztec3::circuits::abis::TxContext;
 using aztec3::circuits::abis::private_kernel::AccumulatedData;
 using aztec3::circuits::abis::private_kernel::ConstantData;
-using aztec3::circuits::abis::private_kernel::OldTreeRoots;
+using aztec3::circuits::abis::private_kernel::HistoricTreeRoots;
 using aztec3::circuits::abis::private_kernel::PreviousKernelData;
 using aztec3::circuits::abis::private_kernel::PrivateCallData;
 using aztec3::circuits::abis::private_kernel::PrivateInputs;
@@ -108,7 +108,7 @@ WASM_EXPORT size_t private_kernel__sim(uint8_t const* signed_tx_request_buf,
         previous_kernel = dummy_previous_kernel();
 
         previous_kernel.public_inputs.end.private_call_stack[0] = private_call_data.call_stack_item.hash();
-        previous_kernel.public_inputs.constants.old_tree_roots.private_data_tree_root =
+        previous_kernel.public_inputs.constants.historic_tree_roots.private_data_tree_root =
             private_call_data.call_stack_item.public_inputs.historic_private_data_tree_root;
         // previous_kernel.public_inputs.constants.old_tree_roots.nullifier_tree_root =
         previous_kernel.public_inputs.constants.old_tree_roots.contract_tree_root =
@@ -163,7 +163,7 @@ WASM_EXPORT size_t private_kernel__prove(uint8_t const* signed_tx_request_buf,
         previous_kernel = dummy_previous_kernel(true);
 
         previous_kernel.public_inputs.end.private_call_stack[0] = private_call_data.call_stack_item.hash();
-        previous_kernel.public_inputs.constants.old_tree_roots.private_data_tree_root =
+        previous_kernel.public_inputs.constants.historic_tree_roots.private_data_tree_root =
             private_call_data.call_stack_item.public_inputs.historic_private_data_tree_root;
         previous_kernel.public_inputs.constants.old_tree_roots.contract_tree_root =
             private_call_data.call_stack_item.public_inputs.historic_contract_tree_root;

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit.cpp
@@ -142,7 +142,7 @@ void contract_logic(DummyComposer& composer, PrivateInputs<NT> const& private_in
     auto const& purported_contract_tree_root =
         private_inputs.private_call.call_stack_item.public_inputs.historic_contract_tree_root;
     auto const& previous_kernel_contract_tree_root =
-        private_inputs.previous_kernel.public_inputs.constants.old_tree_roots.contract_tree_root;
+        private_inputs.previous_kernel.public_inputs.constants.historic_tree_roots.contract_tree_root;
     composer.do_assert(purported_contract_tree_root == previous_kernel_contract_tree_root,
                        "purported_contract_tree_root doesn't match previous_kernel_contract_tree_root");
 

--- a/circuits/cpp/src/aztec3/circuits/rollup/base/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/base/.test.cpp
@@ -29,7 +29,7 @@
 #include <aztec3/circuits/abis/private_kernel/public_inputs.hpp>
 #include <aztec3/circuits/abis/private_kernel/accumulated_data.hpp>
 #include <aztec3/circuits/abis/private_kernel/constant_data.hpp>
-#include <aztec3/circuits/abis/private_kernel/old_tree_roots.hpp>
+#include <aztec3/circuits/abis/private_kernel/historic_tree_roots.hpp>
 #include <aztec3/circuits/abis/private_kernel/globals.hpp>
 
 #include <aztec3/circuits/apps/function_execution_context.hpp>
@@ -69,7 +69,7 @@ using aztec3::circuits::abis::TxRequest;
 using aztec3::circuits::abis::private_kernel::AccumulatedData;
 using aztec3::circuits::abis::private_kernel::ConstantData;
 using aztec3::circuits::abis::private_kernel::Globals;
-using aztec3::circuits::abis::private_kernel::OldTreeRoots;
+using aztec3::circuits::abis::private_kernel::HistoricTreeRoots;
 using aztec3::circuits::abis::private_kernel::PreviousKernelData;
 using aztec3::circuits::abis::private_kernel::PrivateCallData;
 using aztec3::circuits::abis::private_kernel::PrivateInputs;
@@ -693,7 +693,7 @@ TEST_F(base_rollup_tests, native_compute_membership_historic_private_data)
         .root = tree.root(),
         .next_available_leaf_index = 0,
     };
-    inputs.kernel_data[0].public_inputs.constants.old_tree_roots.private_data_tree_root = fr(0);
+    inputs.kernel_data[0].public_inputs.constants.historic_tree_roots.private_data_tree_root = fr(0);
 
     // fetch sibling path from hash path (only get the second half of the hash path)
     auto hash_path = tree.get_hash_path(0);

--- a/circuits/cpp/src/aztec3/circuits/rollup/base/native_base_rollup_circuit.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/base/native_base_rollup_circuit.cpp
@@ -201,7 +201,7 @@ void perform_historical_private_data_tree_membership_checks(DummyComposer& compo
     auto historic_root = baseRollupInputs.constants.start_tree_of_historic_private_data_tree_roots_snapshot.root;
 
     for (size_t i = 0; i < 2; i++) {
-        NT::fr leaf = baseRollupInputs.kernel_data[i].public_inputs.constants.old_tree_roots.private_data_tree_root;
+        NT::fr leaf = baseRollupInputs.kernel_data[i].public_inputs.constants.historic_tree_roots.private_data_tree_root;
         abis::MembershipWitness<NT, PRIVATE_DATA_TREE_ROOTS_TREE_HEIGHT> historic_root_witness =
             baseRollupInputs.historic_private_data_tree_root_membership_witnesses[i];
 
@@ -216,7 +216,7 @@ void perform_historical_contract_data_tree_membership_checks(DummyComposer& comp
     auto historic_root = baseRollupInputs.constants.start_tree_of_historic_contract_tree_roots_snapshot.root;
 
     for (size_t i = 0; i < 2; i++) {
-        NT::fr leaf = baseRollupInputs.kernel_data[i].public_inputs.constants.old_tree_roots.contract_tree_root;
+        NT::fr leaf = baseRollupInputs.kernel_data[i].public_inputs.constants.historic_tree_roots.contract_tree_root;
         abis::MembershipWitness<NT, PRIVATE_DATA_TREE_ROOTS_TREE_HEIGHT> historic_root_witness =
             baseRollupInputs.historic_contract_tree_root_membership_witnesses[i];
 

--- a/circuits/cpp/src/aztec3/circuits/rollup/root/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/root/.test.cpp
@@ -32,7 +32,7 @@
 #include <aztec3/circuits/abis/private_kernel/public_inputs.hpp>
 #include <aztec3/circuits/abis/private_kernel/accumulated_data.hpp>
 #include <aztec3/circuits/abis/private_kernel/constant_data.hpp>
-#include <aztec3/circuits/abis/private_kernel/old_tree_roots.hpp>
+#include <aztec3/circuits/abis/private_kernel/historic_tree_roots.hpp>
 #include <aztec3/circuits/abis/private_kernel/globals.hpp>
 
 #include <aztec3/circuits/apps/function_execution_context.hpp>
@@ -63,7 +63,7 @@ using aztec3::circuits::abis::TxRequest;
 using aztec3::circuits::abis::private_kernel::AccumulatedData;
 using aztec3::circuits::abis::private_kernel::ConstantData;
 using aztec3::circuits::abis::private_kernel::Globals;
-using aztec3::circuits::abis::private_kernel::OldTreeRoots;
+using aztec3::circuits::abis::private_kernel::HistoricTreeRoots;
 using aztec3::circuits::abis::private_kernel::PreviousKernelData;
 using aztec3::circuits::abis::private_kernel::PrivateCallData;
 using aztec3::circuits::abis::private_kernel::PrivateInputs;

--- a/yarn-project/acir-simulator/src/acvm/serialize.ts
+++ b/yarn-project/acir-simulator/src/acvm/serialize.ts
@@ -4,7 +4,7 @@ import {
   CallContext,
   ContractDeploymentData,
   FunctionData,
-  OldTreeRoots,
+  HistoricTreeRoots,
   PrivateCallStackItem,
   PrivateCircuitPublicInputs,
   TxContext,
@@ -89,7 +89,7 @@ export function writeInputs(
   args: Fr[],
   callContext: CallContext,
   txContext: TxContext,
-  oldRoots: OldTreeRoots,
+  oldRoots: HistoricTreeRoots,
   witnessStartIndex = 1,
 ) {
   const fields = [

--- a/yarn-project/acir-simulator/src/acvm/serialize.ts
+++ b/yarn-project/acir-simulator/src/acvm/serialize.ts
@@ -89,7 +89,7 @@ export function writeInputs(
   args: Fr[],
   callContext: CallContext,
   txContext: TxContext,
-  oldRoots: HistoricTreeRoots,
+  historicRoots: HistoricTreeRoots,
   witnessStartIndex = 1,
 ) {
   const fields = [
@@ -107,9 +107,9 @@ export function writeInputs(
     txContext.contractDeploymentData.functionTreeRoot,
     txContext.contractDeploymentData.portalContractAddress,
 
-    oldRoots.contractTreeRoot,
-    oldRoots.nullifierTreeRoot,
-    oldRoots.privateDataTreeRoot,
+    historicRoots.contractTreeRoot,
+    historicRoots.nullifierTreeRoot,
+    historicRoots.privateDataTreeRoot,
   ];
 
   return toACVMWitness(witnessStartIndex, ...fields);

--- a/yarn-project/acir-simulator/src/execution.ts
+++ b/yarn-project/acir-simulator/src/execution.ts
@@ -58,7 +58,7 @@ export class Execution {
     // Global to the tx
     private db: DBOracle,
     private request: TxRequest,
-    private oldRoots: HistoricTreeRoots,
+    private historicRoots: HistoricTreeRoots,
     // Concrete to this execution
     private abi: FunctionAbi,
     private contractAddress: AztecAddress,
@@ -77,7 +77,7 @@ export class Execution {
     );
 
     const acir = Buffer.from(this.abi.bytecode, 'hex');
-    const initialWitness = writeInputs(this.args, this.callContext, this.request.txContext, this.oldRoots);
+    const initialWitness = writeInputs(this.args, this.callContext, this.request.txContext, this.historicRoots);
     const newNotePreimages: NewNoteData[] = [];
     const newNullifiers: NewNullifierData[] = [];
     const nestedExecutionContexts: ExecutionResult[] = [];
@@ -157,7 +157,7 @@ export class Execution {
 
     return notes
       .concat(dummyNotes)
-      .flatMap(noteGetData => toAcvmNoteLoadOracleInputs(noteGetData, this.oldRoots.privateDataTreeRoot));
+      .flatMap(noteGetData => toAcvmNoteLoadOracleInputs(noteGetData, this.historicRoots.privateDataTreeRoot));
   }
 
   private async getSecretKey(contractAddress: AztecAddress, address: ACVMField) {
@@ -189,7 +189,7 @@ export class Execution {
     const nestedExecution = new Execution(
       this.db,
       this.request,
-      this.oldRoots,
+      this.historicRoots,
       targetAbi,
       targetContractAddress,
       targetFunctionData,

--- a/yarn-project/acir-simulator/src/execution.ts
+++ b/yarn-project/acir-simulator/src/execution.ts
@@ -12,7 +12,7 @@ import {
 import { AztecAddress, EthAddress, Fr } from '@aztec/foundation';
 import {
   CallContext,
-  OldTreeRoots,
+  HistoricTreeRoots,
   TxRequest,
   PrivateCallStackItem,
   FunctionData,
@@ -58,7 +58,7 @@ export class Execution {
     // Global to the tx
     private db: DBOracle,
     private request: TxRequest,
-    private oldRoots: OldTreeRoots,
+    private oldRoots: HistoricTreeRoots,
     // Concrete to this execution
     private abi: FunctionAbi,
     private contractAddress: AztecAddress,

--- a/yarn-project/acir-simulator/src/index.test.ts
+++ b/yarn-project/acir-simulator/src/index.test.ts
@@ -39,7 +39,7 @@ describe('ACIR simulator', () => {
   });
 
   describe('empty constructor', () => {
-    const oldRoots = new HistoricTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
+    const historicRoots = new HistoricTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
     const contractDeploymentData = new ContractDeploymentData(Fr.random(), Fr.random(), Fr.random(), EthAddress.ZERO);
     const txContext = new TxContext(false, false, true, contractDeploymentData);
 
@@ -58,7 +58,7 @@ describe('ACIR simulator', () => {
         TestContractAbi.functions[0] as FunctionAbi,
         AztecAddress.ZERO,
         EthAddress.ZERO,
-        oldRoots,
+        historicRoots,
       );
 
       expect(result.callStackItem.publicInputs.newCommitments).toEqual(
@@ -92,7 +92,7 @@ describe('ACIR simulator', () => {
     });
 
     it('should a constructor with arguments that creates notes', async () => {
-      const oldRoots = new HistoricTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
+      const historicRoots = new HistoricTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
       const contractAddress = AztecAddress.random();
       const abi = ZkTokenContractAbi.functions.find(f => f.name === 'constructor') as unknown as FunctionAbi;
 
@@ -105,7 +105,7 @@ describe('ACIR simulator', () => {
         txContext,
         new Fr(0n),
       );
-      const result = await acirSimulator.run(txRequest, abi, contractAddress, EthAddress.ZERO, oldRoots);
+      const result = await acirSimulator.run(txRequest, abi, contractAddress, EthAddress.ZERO, historicRoots);
 
       expect(result.preimages.newNotes).toHaveLength(1);
       const newNote = result.preimages.newNotes[0];
@@ -119,7 +119,7 @@ describe('ACIR simulator', () => {
     });
 
     it('should run the mint function', async () => {
-      const oldRoots = new HistoricTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
+      const historicRoots = new HistoricTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
       const contractAddress = AztecAddress.random();
       const abi = ZkTokenContractAbi.functions.find(f => f.name === 'mint') as unknown as FunctionAbi;
 
@@ -132,7 +132,7 @@ describe('ACIR simulator', () => {
         txContext,
         new Fr(0n),
       );
-      const result = await acirSimulator.run(txRequest, abi, AztecAddress.ZERO, EthAddress.ZERO, oldRoots);
+      const result = await acirSimulator.run(txRequest, abi, AztecAddress.ZERO, EthAddress.ZERO, historicRoots);
 
       expect(result.preimages.newNotes).toHaveLength(1);
       const newNote = result.preimages.newNotes[0];
@@ -158,7 +158,7 @@ describe('ACIR simulator', () => {
       // TODO for this we need that noir siloes the commitment the same way as the kernel does, to do merkle membership
       await tree.appendLeaves(preimages.map(preimage => acirSimulator.computeNoteHash(preimage, bbWasm)));
 
-      const oldRoots = new HistoricTreeRoots(Fr.fromBuffer(tree.getRoot()), new Fr(0n), new Fr(0n), new Fr(0n));
+      const historicRoots = new HistoricTreeRoots(Fr.fromBuffer(tree.getRoot()), new Fr(0n), new Fr(0n), new Fr(0n));
 
       oracle.getNotes.mockImplementation(() => {
         return Promise.all(
@@ -182,7 +182,7 @@ describe('ACIR simulator', () => {
         new Fr(0n),
       );
 
-      const result = await acirSimulator.run(txRequest, abi, AztecAddress.random(), EthAddress.ZERO, oldRoots);
+      const result = await acirSimulator.run(txRequest, abi, AztecAddress.random(), EthAddress.ZERO, historicRoots);
 
       // The two notes were nullified
       const newNullifiers = result.callStackItem.publicInputs.newNullifiers.filter(field => !field.equals(Fr.ZERO));
@@ -224,7 +224,7 @@ describe('ACIR simulator', () => {
       // TODO for this we need that noir siloes the commitment the same way as the kernel does, to do merkle membership
       await tree.appendLeaves(preimages.map(preimage => acirSimulator.computeNoteHash(preimage, bbWasm)));
 
-      const oldRoots = new HistoricTreeRoots(Fr.fromBuffer(tree.getRoot()), new Fr(0n), new Fr(0n), new Fr(0n));
+      const historicRoots = new HistoricTreeRoots(Fr.fromBuffer(tree.getRoot()), new Fr(0n), new Fr(0n), new Fr(0n));
 
       oracle.getNotes.mockImplementation(() => {
         return Promise.all(
@@ -248,7 +248,7 @@ describe('ACIR simulator', () => {
         new Fr(0n),
       );
 
-      const result = await acirSimulator.run(txRequest, abi, AztecAddress.random(), EthAddress.ZERO, oldRoots);
+      const result = await acirSimulator.run(txRequest, abi, AztecAddress.random(), EthAddress.ZERO, historicRoots);
 
       const newNullifiers = result.callStackItem.publicInputs.newNullifiers.filter(field => !field.equals(Fr.ZERO));
       expect(newNullifiers).toHaveLength(2);
@@ -263,7 +263,7 @@ describe('ACIR simulator', () => {
   });
 
   describe('nested calls', () => {
-    const oldRoots = new HistoricTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
+    const historicRoots = new HistoricTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
     const contractDeploymentData = new ContractDeploymentData(Fr.random(), Fr.random(), Fr.random(), EthAddress.ZERO);
     const txContext = new TxContext(false, false, true, contractDeploymentData);
 
@@ -279,7 +279,7 @@ describe('ACIR simulator', () => {
         txContext,
         new Fr(0n),
       );
-      const result = await acirSimulator.run(txRequest, abi, AztecAddress.ZERO, EthAddress.ZERO, oldRoots);
+      const result = await acirSimulator.run(txRequest, abi, AztecAddress.ZERO, EthAddress.ZERO, historicRoots);
 
       expect(result.callStackItem.publicInputs.returnValues[0]).toEqual(new Fr(142n));
     });
@@ -302,7 +302,7 @@ describe('ACIR simulator', () => {
         txContext,
         new Fr(0n),
       );
-      const result = await acirSimulator.run(txRequest, parentAbi, AztecAddress.random(), EthAddress.ZERO, oldRoots);
+      const result = await acirSimulator.run(txRequest, parentAbi, AztecAddress.random(), EthAddress.ZERO, historicRoots);
 
       expect(result.callStackItem.publicInputs.returnValues[0]).toEqual(new Fr(42n));
       expect(oracle.getFunctionABI.mock.calls[0]).toEqual([childAddress, childSelector]);

--- a/yarn-project/acir-simulator/src/index.test.ts
+++ b/yarn-project/acir-simulator/src/index.test.ts
@@ -302,7 +302,13 @@ describe('ACIR simulator', () => {
         txContext,
         new Fr(0n),
       );
-      const result = await acirSimulator.run(txRequest, parentAbi, AztecAddress.random(), EthAddress.ZERO, historicRoots);
+      const result = await acirSimulator.run(
+        txRequest,
+        parentAbi,
+        AztecAddress.random(),
+        EthAddress.ZERO,
+        historicRoots,
+      );
 
       expect(result.callStackItem.publicInputs.returnValues[0]).toEqual(new Fr(42n));
       expect(oracle.getFunctionABI.mock.calls[0]).toEqual([childAddress, childSelector]);

--- a/yarn-project/acir-simulator/src/index.test.ts
+++ b/yarn-project/acir-simulator/src/index.test.ts
@@ -5,7 +5,7 @@ import {
   ContractDeploymentData,
   FunctionData,
   NEW_COMMITMENTS_LENGTH,
-  OldTreeRoots,
+  HistoricTreeRoots,
   PRIVATE_DATA_TREE_HEIGHT,
   TxContext,
   TxRequest,
@@ -39,7 +39,7 @@ describe('ACIR simulator', () => {
   });
 
   describe('empty constructor', () => {
-    const oldRoots = new OldTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
+    const oldRoots = new HistoricTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
     const contractDeploymentData = new ContractDeploymentData(Fr.random(), Fr.random(), Fr.random(), EthAddress.ZERO);
     const txContext = new TxContext(false, false, true, contractDeploymentData);
 
@@ -92,7 +92,7 @@ describe('ACIR simulator', () => {
     });
 
     it('should a constructor with arguments that creates notes', async () => {
-      const oldRoots = new OldTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
+      const oldRoots = new HistoricTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
       const contractAddress = AztecAddress.random();
       const abi = ZkTokenContractAbi.functions.find(f => f.name === 'constructor') as unknown as FunctionAbi;
 
@@ -119,7 +119,7 @@ describe('ACIR simulator', () => {
     });
 
     it('should run the mint function', async () => {
-      const oldRoots = new OldTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
+      const oldRoots = new HistoricTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
       const contractAddress = AztecAddress.random();
       const abi = ZkTokenContractAbi.functions.find(f => f.name === 'mint') as unknown as FunctionAbi;
 
@@ -158,7 +158,7 @@ describe('ACIR simulator', () => {
       // TODO for this we need that noir siloes the commitment the same way as the kernel does, to do merkle membership
       await tree.appendLeaves(preimages.map(preimage => acirSimulator.computeNoteHash(preimage, bbWasm)));
 
-      const oldRoots = new OldTreeRoots(Fr.fromBuffer(tree.getRoot()), new Fr(0n), new Fr(0n), new Fr(0n));
+      const oldRoots = new HistoricTreeRoots(Fr.fromBuffer(tree.getRoot()), new Fr(0n), new Fr(0n), new Fr(0n));
 
       oracle.getNotes.mockImplementation(() => {
         return Promise.all(
@@ -224,7 +224,7 @@ describe('ACIR simulator', () => {
       // TODO for this we need that noir siloes the commitment the same way as the kernel does, to do merkle membership
       await tree.appendLeaves(preimages.map(preimage => acirSimulator.computeNoteHash(preimage, bbWasm)));
 
-      const oldRoots = new OldTreeRoots(Fr.fromBuffer(tree.getRoot()), new Fr(0n), new Fr(0n), new Fr(0n));
+      const oldRoots = new HistoricTreeRoots(Fr.fromBuffer(tree.getRoot()), new Fr(0n), new Fr(0n), new Fr(0n));
 
       oracle.getNotes.mockImplementation(() => {
         return Promise.all(
@@ -263,7 +263,7 @@ describe('ACIR simulator', () => {
   });
 
   describe('nested calls', () => {
-    const oldRoots = new OldTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
+    const oldRoots = new HistoricTreeRoots(new Fr(0n), new Fr(0n), new Fr(0n), new Fr(0n));
     const contractDeploymentData = new ContractDeploymentData(Fr.random(), Fr.random(), Fr.random(), EthAddress.ZERO);
     const txContext = new TxContext(false, false, true, contractDeploymentData);
 

--- a/yarn-project/acir-simulator/src/simulator.ts
+++ b/yarn-project/acir-simulator/src/simulator.ts
@@ -20,7 +20,7 @@ export class AcirSimulator {
     entryPointABI: FunctionAbi,
     contractAddress: AztecAddress,
     portalContractAddress: EthAddress,
-    oldRoots: HistoricTreeRoots,
+    historicRoots: HistoricTreeRoots,
   ): Promise<ExecutionResult> {
     const callContext = new CallContext(
       request.from,
@@ -34,7 +34,7 @@ export class AcirSimulator {
     const execution = new Execution(
       this.db,
       request,
-      oldRoots,
+      historicRoots,
       entryPointABI,
       contractAddress,
       request.functionData,

--- a/yarn-project/acir-simulator/src/simulator.ts
+++ b/yarn-project/acir-simulator/src/simulator.ts
@@ -1,5 +1,5 @@
 import { AztecAddress, EthAddress, Fr } from '@aztec/foundation';
-import { CallContext, OldTreeRoots, TxRequest } from '@aztec/circuits.js';
+import { CallContext, HistoricTreeRoots, TxRequest } from '@aztec/circuits.js';
 import { FunctionAbi } from '@aztec/noir-contracts';
 import { DBOracle } from './db_oracle.js';
 import { Execution, ExecutionResult } from './execution.js';
@@ -20,7 +20,7 @@ export class AcirSimulator {
     entryPointABI: FunctionAbi,
     contractAddress: AztecAddress,
     portalContractAddress: EthAddress,
-    oldRoots: OldTreeRoots,
+    oldRoots: HistoricTreeRoots,
   ): Promise<ExecutionResult> {
     const callContext = new CallContext(
       request.from,

--- a/yarn-project/aztec-rpc/src/account_state/account_state.ts
+++ b/yarn-project/aztec-rpc/src/account_state/account_state.ts
@@ -1,7 +1,7 @@
 import { AcirSimulator } from '@aztec/acir-simulator';
 import { AztecNode } from '@aztec/aztec-node';
 import { Grumpkin } from '@aztec/barretenberg.js/crypto';
-import { EcdsaSignature, KERNEL_NEW_COMMITMENTS_LENGTH, OldTreeRoots, TxRequest } from '@aztec/circuits.js';
+import { EcdsaSignature, KERNEL_NEW_COMMITMENTS_LENGTH, HistoricTreeRoots, TxRequest } from '@aztec/circuits.js';
 import { AztecAddress, Fr, Point, createDebugLogger } from '@aztec/foundation';
 import { KernelProver, OutputNoteData } from '@aztec/kernel-prover';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/l1-contracts';
@@ -69,7 +69,7 @@ export class AccountState {
       txRequest.functionData.functionSelector,
     );
     const portalContract = await contractDataOracle.getPortalContractAddress(contractAddress);
-    const oldRoots = new OldTreeRoots(Fr.ZERO, Fr.ZERO, Fr.ZERO, Fr.ZERO); // TODO - get old roots from the database/node
+    const oldRoots = new HistoricTreeRoots(Fr.ZERO, Fr.ZERO, Fr.ZERO, Fr.ZERO); // TODO - get old roots from the database/node
 
     const simulatorOracle = new SimulatorOracle(contractDataOracle, this.db, this.keyPair, this.node);
     const simulator = new AcirSimulator(simulatorOracle);

--- a/yarn-project/aztec-rpc/src/account_state/account_state.ts
+++ b/yarn-project/aztec-rpc/src/account_state/account_state.ts
@@ -69,12 +69,12 @@ export class AccountState {
       txRequest.functionData.functionSelector,
     );
     const portalContract = await contractDataOracle.getPortalContractAddress(contractAddress);
-    const oldRoots = new HistoricTreeRoots(Fr.ZERO, Fr.ZERO, Fr.ZERO, Fr.ZERO); // TODO - get old roots from the database/node
+    const historicRoots = new HistoricTreeRoots(Fr.ZERO, Fr.ZERO, Fr.ZERO, Fr.ZERO); // TODO - get old roots from the database/node
 
     const simulatorOracle = new SimulatorOracle(contractDataOracle, this.db, this.keyPair, this.node);
     const simulator = new AcirSimulator(simulatorOracle);
     this.log('Executing simulator...');
-    const result = await simulator.run(txRequest, functionAbi, contractAddress, portalContract, oldRoots);
+    const result = await simulator.run(txRequest, functionAbi, contractAddress, portalContract, historicRoots);
     this.log('Simulation completed!');
 
     return result;

--- a/yarn-project/circuits.js/src/structs/__snapshots__/base_rollup.test.ts.snap
+++ b/yarn-project/circuits.js/src/structs/__snapshots__/base_rollup.test.ts.snap
@@ -91,7 +91,7 @@ called_from_public_l2: 0
  ]
 
 constants:
-old_tree_roots: private_data_tree_root: 0x200
+historic_tree_roots: private_data_tree_root: 0x200
 nullifier_tree_root: 0x201
 contract_tree_root: 0x202
 private_kernel_vk_tree_root: 0x203
@@ -210,7 +210,7 @@ called_from_public_l2: 0
  ]
 
 constants:
-old_tree_roots: private_data_tree_root: 0x300
+historic_tree_roots: private_data_tree_root: 0x300
 nullifier_tree_root: 0x301
 contract_tree_root: 0x302
 private_kernel_vk_tree_root: 0x303

--- a/yarn-project/circuits.js/src/structs/__snapshots__/private_kernel.test.ts.snap
+++ b/yarn-project/circuits.js/src/structs/__snapshots__/private_kernel.test.ts.snap
@@ -90,7 +90,7 @@ called_from_public_l2: 0
  ]
 
 constants:
-old_tree_roots: private_data_tree_root: 0x101
+historic_tree_roots: private_data_tree_root: 0x101
 nullifier_tree_root: 0x102
 contract_tree_root: 0x103
 private_kernel_vk_tree_root: 0x104
@@ -237,7 +237,7 @@ called_from_public_l2: 0
  ]
 
 constants:
-old_tree_roots: private_data_tree_root: 0x1101
+historic_tree_roots: private_data_tree_root: 0x1101
 nullifier_tree_root: 0x1102
 contract_tree_root: 0x1103
 private_kernel_vk_tree_root: 0x1104
@@ -554,7 +554,7 @@ called_from_public_l2: 0
  ]
 
 constants:
-old_tree_roots: private_data_tree_root: 0x101
+historic_tree_roots: private_data_tree_root: 0x101
 nullifier_tree_root: 0x102
 contract_tree_root: 0x103
 private_kernel_vk_tree_root: 0x104

--- a/yarn-project/circuits.js/src/structs/private_kernel.ts
+++ b/yarn-project/circuits.js/src/structs/private_kernel.ts
@@ -23,7 +23,7 @@ import { VerificationKey } from './verification_key.js';
 import { AztecAddress, EthAddress, Fr, BufferReader } from '@aztec/foundation';
 import times from 'lodash.times';
 
-export class OldTreeRoots {
+export class HistoricTreeRoots {
   constructor(
     public privateDataTreeRoot: Fr,
     public nullifierTreeRoot: Fr,
@@ -44,17 +44,17 @@ export class OldTreeRoots {
    * Deserializes from a buffer or reader, corresponding to a write in cpp.
    * @param buffer - Buffer to read from.
    */
-  static fromBuffer(buffer: Buffer | BufferReader): OldTreeRoots {
+  static fromBuffer(buffer: Buffer | BufferReader): HistoricTreeRoots {
     const reader = BufferReader.asReader(buffer);
-    return new OldTreeRoots(reader.readFr(), reader.readFr(), reader.readFr(), reader.readFr());
+    return new HistoricTreeRoots(reader.readFr(), reader.readFr(), reader.readFr(), reader.readFr());
   }
 }
 
 export class ConstantData {
-  constructor(public oldTreeRoots: OldTreeRoots, public txContext: TxContext) {}
+  constructor(public historicTreeRoots: HistoricTreeRoots, public txContext: TxContext) {}
 
   toBuffer() {
-    return serializeToBuffer(this.oldTreeRoots, this.txContext);
+    return serializeToBuffer(this.historicTreeRoots, this.txContext);
   }
 
   /**
@@ -63,7 +63,7 @@ export class ConstantData {
    */
   static fromBuffer(buffer: Buffer | BufferReader): ConstantData {
     const reader = BufferReader.asReader(buffer);
-    return new ConstantData(reader.readObject(OldTreeRoots), reader.readObject(TxContext));
+    return new ConstantData(reader.readObject(HistoricTreeRoots), reader.readObject(TxContext));
   }
 }
 
@@ -375,12 +375,12 @@ function makeEmptyTxContext(): TxContext {
   return new TxContext(false, false, true, deploymentData);
 }
 
-function makeEmptyOldTreeRoots(): OldTreeRoots {
-  return new OldTreeRoots(frZero(), frZero(), frZero(), frZero());
+function makeEmptyHistoricTreeRoots(): HistoricTreeRoots {
+  return new HistoricTreeRoots(frZero(), frZero(), frZero(), frZero());
 }
 
 function makeEmptyConstantData(): ConstantData {
-  return new ConstantData(makeEmptyOldTreeRoots(), makeEmptyTxContext());
+  return new ConstantData(makeEmptyHistoricTreeRoots(), makeEmptyTxContext());
 }
 
 function makeEmptyOptionallyRevealedData(): OptionallyRevealedData {

--- a/yarn-project/circuits.js/src/tests/factories.ts
+++ b/yarn-project/circuits.js/src/tests/factories.ts
@@ -44,7 +44,7 @@ import {
   AccumulatedData,
   ConstantData,
   NewContractData,
-  OldTreeRoots,
+  HistoricTreeRoots,
   OptionallyRevealedData,
   PreviousKernelData,
   PrivateCallData,
@@ -71,12 +71,12 @@ export function makeTxContext(seed: number): TxContext {
   return new TxContext(false, false, true, deploymentData);
 }
 
-export function makeOldTreeRoots(seed: number): OldTreeRoots {
-  return new OldTreeRoots(fr(seed), fr(seed + 1), fr(seed + 2), fr(seed + 3));
+export function makeHistoricTreeRoots(seed: number): HistoricTreeRoots {
+  return new HistoricTreeRoots(fr(seed), fr(seed + 1), fr(seed + 2), fr(seed + 3));
 }
 
 export function makeConstantData(seed = 1): ConstantData {
-  return new ConstantData(makeOldTreeRoots(seed), makeTxContext(seed + 4));
+  return new ConstantData(makeHistoricTreeRoots(seed), makeTxContext(seed + 4));
 }
 
 export function makeSelector(seed: number) {

--- a/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.test.ts
+++ b/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.test.ts
@@ -108,13 +108,13 @@ describe('sequencer/circuit_block_builder', () => {
     return new AppendOnlyTreeSnapshot(Fr.fromBuffer(treeInfo.root), Number(treeInfo.size));
   };
 
-  const setTxOldTreeRoots = async (tx: PrivateTx) => {
+  const setHistoricTreeRoots = async (tx: PrivateTx) => {
     for (const [name, id] of [
       ['privateDataTreeRoot', MerkleTreeId.DATA_TREE],
       ['contractTreeRoot', MerkleTreeId.CONTRACT_TREE],
       ['nullifierTreeRoot', MerkleTreeId.NULLIFIER_TREE],
     ] as const) {
-      tx.data.constants.oldTreeRoots[name] = Fr.fromBuffer((await builderDb.getTreeInfo(id)).root);
+      tx.data.constants.historicTreeRoots[name] = Fr.fromBuffer((await builderDb.getTreeInfo(id)).root);
     }
   };
 
@@ -130,7 +130,7 @@ describe('sequencer/circuit_block_builder', () => {
       const txsRight = [makeEmptyPrivateTx(), makeEmptyPrivateTx()];
 
       // Set tree roots to proper values in the tx
-      await setTxOldTreeRoots(tx);
+      await setTxHistoricTreeRoots(tx);
 
       // Calculate what would be the tree roots after the txs from the first base rollup land and update mock circuit output
       await updateExpectedTreesFromTxs(txsLeft);
@@ -195,7 +195,7 @@ describe('sequencer/circuit_block_builder', () => {
 
     const makeContractDeployTx = async (seed = 0x1) => {
       const tx = makeEmptyPrivateTx();
-      await setTxOldTreeRoots(tx);
+      await setHistoricTreeRoots(tx);
       tx.data.end.newContracts = [makeNewContractData(seed + 0x1000)];
       return tx;
     };

--- a/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.test.ts
+++ b/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.test.ts
@@ -108,7 +108,7 @@ describe('sequencer/circuit_block_builder', () => {
     return new AppendOnlyTreeSnapshot(Fr.fromBuffer(treeInfo.root), Number(treeInfo.size));
   };
 
-  const setHistoricTreeRoots = async (tx: PrivateTx) => {
+  const setTxHistoricTreeRoots = async (tx: PrivateTx) => {
     for (const [name, id] of [
       ['privateDataTreeRoot', MerkleTreeId.DATA_TREE],
       ['contractTreeRoot', MerkleTreeId.CONTRACT_TREE],
@@ -195,7 +195,7 @@ describe('sequencer/circuit_block_builder', () => {
 
     const makeContractDeployTx = async (seed = 0x1) => {
       const tx = makeEmptyPrivateTx();
-      await setHistoricTreeRoots(tx);
+      await setTxHistoricTreeRoots(tx);
       tx.data.end.newContracts = [makeNewContractData(seed + 0x1000)];
       return tx;
     };

--- a/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.ts
+++ b/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.ts
@@ -389,7 +389,7 @@ export class CircuitBlockBuilder implements BlockBuilder {
 
   protected getContractMembershipWitnessFor(tx: PrivateTx) {
     return this.getMembershipWitnessFor(
-      tx.data.constants.oldTreeRoots.contractTreeRoot,
+      tx.data.constants.historicTreeRoots.contractTreeRoot,
       MerkleTreeId.CONTRACT_TREE_ROOTS_TREE,
       CONTRACT_TREE_ROOTS_TREE_HEIGHT,
     );
@@ -397,7 +397,7 @@ export class CircuitBlockBuilder implements BlockBuilder {
 
   protected getDataMembershipWitnessFor(tx: PrivateTx) {
     return this.getMembershipWitnessFor(
-      tx.data.constants.oldTreeRoots.privateDataTreeRoot,
+      tx.data.constants.historicTreeRoots.privateDataTreeRoot,
       MerkleTreeId.DATA_TREE_ROOTS_TREE,
       PRIVATE_DATA_TREE_ROOTS_TREE_HEIGHT,
     );


### PR DESCRIPTION
# Description

Fixes https://github.com/AztecProtocol/aztec3-circuits/issues/162.

- Replaces use of `old` root with `historic` for greater consistency.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] The branch has been merged or rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
