### PR TITLE
Fix Rollup Tests (for Local testing)

### DIFF
--- a/circuits/cpp/src/aztec3/circuits/rollup/base/native_base_rollup_circuit.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/base/native_base_rollup_circuit.cpp
@@ -21,8 +21,17 @@
 
 namespace aztec3::circuits::rollup::native_base_rollup {
 
-const NT::fr EMPTY_COMMITMENTS_SUBTREE_ROOT = MerkleTree(PRIVATE_DATA_SUBTREE_DEPTH).root();
-const NT::fr EMPTY_CONTRACTS_SUBTREE_ROOT = MerkleTree(CONTRACT_SUBTREE_DEPTH).root();
+NT::fr calculate_empty_commitments_tree_root()
+{
+    MerkleTree empty_commitments_tree = MerkleTree(PRIVATE_DATA_SUBTREE_DEPTH);
+    return empty_commitments_tree.root();
+}
+
+NT::fr calculate_empty_contracts_tree_root()
+{
+    MerkleTree empty_contracts_tree = MerkleTree(CONTRACT_SUBTREE_DEPTH);
+    return empty_contracts_tree.root();
+}
 
 // Note: this is temporary until I work out how to encode a large fr in a constant
 NT::fr calculate_empty_nullifier_subtree_root()
@@ -424,11 +433,12 @@ BaseOrMergeRollupPublicInputs base_rollup_circuit(DummyComposer& composer, BaseR
     NT::fr commitments_tree_subroot = calculate_commitments_subtree(composer, baseRollupInputs);
 
     // Insert commitment subtrees:
+    const auto empty_commitments_tree_root = calculate_empty_commitments_tree_root();
     auto end_private_data_tree_snapshot =
         components::insert_subtree_to_snapshot_tree(composer,
                                                     baseRollupInputs.start_private_data_tree_snapshot,
                                                     baseRollupInputs.new_commitments_subtree_sibling_path,
-                                                    EMPTY_COMMITMENTS_SUBTREE_ROOT,
+                                                    empty_commitments_tree_root,
                                                     commitments_tree_subroot,
                                                     PRIVATE_DATA_SUBTREE_DEPTH);
 
@@ -437,7 +447,7 @@ BaseOrMergeRollupPublicInputs base_rollup_circuit(DummyComposer& composer, BaseR
         components::insert_subtree_to_snapshot_tree(composer,
                                                     baseRollupInputs.start_contract_tree_snapshot,
                                                     baseRollupInputs.new_contracts_subtree_sibling_path,
-                                                    EMPTY_CONTRACTS_SUBTREE_ROOT,
+                                                    empty_commitments_tree_root,
                                                     contracts_tree_subroot,
                                                     CONTRACT_SUBTREE_DEPTH);
 


### PR DESCRIPTION
# Description

(Ported from https://github.com/AztecProtocol/aztec3-circuits/pull/250)

The constants EMPTY_COMMITMENTS_SUBTREE_ROOT, EMPTY_CONTRACTS_SUBTREE_ROOT were being computed at compile-time (which itself is mysterious, it shouldn't have been computed at compile-time). As a result, the pedersen lookup tables were being filled at compile time, setting the variable inited to true. But when you start the actual execution, the variable inited = true but the tables are now empty. This PR fixes this only at a high-level: avoid using those two variables.

(Edit: This was a problem only with ultra-plonk because we use lookup tables.)

Longer term, we would like to instantiate the tables only once so we should store them on disc and load them as necessary. Issue https://github.com/AztecProtocol/barretenberg/issues/362 explains this in a bit more detail.

Resolves https://github.com/AztecProtocol/aztec3-circuits/issues/187

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
