### PR TITLE
Fixed docs in Merkle Tree, Foundation, Barretenberg.js and WorldStateDb

### DIFF
--- a/yarn-project/barretenberg.js/.eslintrc.cjs
+++ b/yarn-project/barretenberg.js/.eslintrc.cjs
@@ -1,1 +1,1 @@
-module.exports = require('@aztec/foundation/eslint-legacy');
+module.exports = require('@aztec/foundation/eslint');

--- a/yarn-project/barretenberg.js/src/crypto/aes128/index.ts
+++ b/yarn-project/barretenberg.js/src/crypto/aes128/index.ts
@@ -1,8 +1,18 @@
 import { WasmWrapper } from '@aztec/foundation/wasm';
 
+/**
+ * AES-128-CBC encryption/decryption.
+ */
 export class Aes128 {
   constructor(private wasm: WasmWrapper) {}
 
+  /**
+   * Encrypt a buffer using AES-128-CBC.
+   * @param data - Data to encrypt.
+   * @param iv - AES initialisation vector.
+   * @param key - Key to encrypt with.
+   * @returns Encrypted data.
+   */
   public encryptBufferCBC(data: Uint8Array, iv: Uint8Array, key: Uint8Array) {
     const rawLength = data.length;
     const numPaddingBytes = rawLength % 16 != 0 ? 16 - (rawLength % 16) : 0;
@@ -35,6 +45,13 @@ export class Aes128 {
     return result;
   }
 
+  /**
+   * Decrypt a buffer using AES-128-CBC.
+   * @param data - Data to decrypt.
+   * @param iv - AES initialisation vector.
+   * @param key - Key to decrypt with.
+   * @returns Decrypted data.
+   */
   public decryptBufferCBC(data: Uint8Array, iv: Uint8Array, key: Uint8Array) {
     const mem = this.wasm.call('bbmalloc', data.length + key.length + iv.length + data.length);
     this.wasm.writeMemory(mem, data);

--- a/yarn-project/barretenberg.js/src/crypto/grumpkin/index.ts
+++ b/yarn-project/barretenberg.js/src/crypto/grumpkin/index.ts
@@ -67,7 +67,7 @@ export class Grumpkin {
   }
 
   /**
-   * Converts a 512 bytes long buffer to a field.
+   * Converts a 512 bits long buffer to a field.
    * @param uint512Buf - The buffer to convert.
    * @returns Buffer representation of the field element.
    */

--- a/yarn-project/barretenberg.js/src/crypto/grumpkin/index.ts
+++ b/yarn-project/barretenberg.js/src/crypto/grumpkin/index.ts
@@ -1,7 +1,14 @@
 import { WasmWrapper } from '@aztec/foundation/wasm';
 import { BarretenbergWasm } from '../../index.js';
 
+/**
+ * Grumpkin elliptic curve operations.
+ */
 export class Grumpkin {
+  /**
+   * Creates a new Grumpkin instance.
+   * @returns New Grumpkin instance.
+   */
   public static async new() {
     return new this(await BarretenbergWasm.get());
   }
@@ -16,6 +23,12 @@ export class Grumpkin {
     0x2d, 0x27, 0x0d, 0x45, 0xf1, 0x18, 0x12, 0x94, 0x83, 0x3f, 0xc4, 0x8d, 0x82, 0x3f, 0x27, 0x2c,
   ]);
 
+  /**
+   * Multiplies a point by a scalar (adds the point `scalar` amount of time).
+   * @param point - Point to multiply.
+   * @param scalar - Scalar to multiply by.
+   * @returns Result of the multiplication.
+   */
   public mul(point: Uint8Array, scalar: Uint8Array) {
     this.wasm.writeMemory(0, point);
     this.wasm.writeMemory(64, scalar);
@@ -23,6 +36,13 @@ export class Grumpkin {
     return Buffer.from(this.wasm.getMemorySlice(96, 160));
   }
 
+  /**
+   * Multiplies a set of points by a scalar.
+   * @param points - Points to multiply.
+   * @param scalar - Scalar to multiply by.
+   * @param numPoints - Number of points in the points array.
+   * @returns Points multiplied by the scalar.
+   */
   public batchMul(points: Uint8Array, scalar: Uint8Array, numPoints: number) {
     const mem = this.wasm.call('bbmalloc', points.length * 2);
 
@@ -37,11 +57,20 @@ export class Grumpkin {
     return result;
   }
 
+  /**
+   * Gets a random field element.
+   * @returns Random field element.
+   */
   public getRandomFr() {
     this.wasm.call('ecc_grumpkin__get_random_scalar_mod_circuit_modulus', 0);
     return Buffer.from(this.wasm.getMemorySlice(0, 32));
   }
 
+  /**
+   * Converts a 512 bytes long buffer to a field.
+   * @param uint512Buf - The buffer to convert.
+   * @returns Buffer representation of the field element.
+   */
   public reduce512BufferToFr(uint512Buf: Buffer) {
     this.wasm.writeMemory(0, uint512Buf);
     this.wasm.call('ecc_grumpkin__reduce512_buffer_mod_circuit_modulus', 0, 64);

--- a/yarn-project/barretenberg.js/src/crypto/pedersen/pedersen.ts
+++ b/yarn-project/barretenberg.js/src/crypto/pedersen/pedersen.ts
@@ -3,7 +3,7 @@ import { Buffer } from 'buffer';
 import { deserializeArrayFromVector, deserializeField, serializeBufferArrayToVector } from '../../wasm/serialize.js';
 
 /**
- * Combines two 32-byte hashes.
+ * Compresses two 32-byte hashes.
  * @param wasm - The barretenberg module.
  * @param lhs - The first hash.
  * @param rhs - The second hash.
@@ -22,11 +22,10 @@ export function pedersenCompress(wasm: WasmWrapper, lhs: Uint8Array, rhs: Uint8A
 }
 
 /**
- * Combine an array of hashes.
+ * Compresses an array of buffers.
  * @param wasm - The barretenberg module.
- * @param lhs - The first hash.
- * @param rhs - The second hash.
- * @returns The new 32-byte hash.
+ * @param inputs - The array of buffers to compress.
+ * @returns The resulting 32-byte hash.
  */
 export function pedersenCompressInputs(wasm: WasmWrapper, inputs: Buffer[]): Buffer {
   // If not done already, precompute constants.
@@ -38,11 +37,11 @@ export function pedersenCompressInputs(wasm: WasmWrapper, inputs: Buffer[]): Buf
 }
 
 /**
- * Combine an array of hashes.
+ * Compresses an array of buffers.
  * @param wasm - The barretenberg module.
- * @param lhs - The first hash.
- * @param rhs - The second hash.
- * @returns The new 32-byte hash.
+ * @param inputs - The array of buffers to compress.
+ * @param hashIndex - Hash index of the generator to use (See GeneratorIndex enum).
+ * @returns The resulting 32-byte hash.
  */
 export function pedersenCompressWithHashIndex(wasm: WasmWrapper, inputs: Buffer[], hashIndex: number): Buffer {
   // If not done already, precompute constants.
@@ -70,10 +69,13 @@ export function pedersenGetHash(wasm: WasmWrapper, data: Buffer): Buffer {
 }
 
 /**
- * Given a buffer containing 32 byte pedersen leaves, return a new buffer containing the leaves and all pairs of nodes that define a merkle tree.
+ * Given a buffer containing 32 byte pedersen leaves, return a new buffer containing the leaves and all pairs of nodes
+ * that define a merkle tree.
+ * 
  * E.g.
  * Input:  [1][2][3][4]
  * Output: [1][2][3][4][compress(1,2)][compress(3,4)][compress(5,6)].
+ * 
  * @param wasm - The barretenberg module.
  * @param values - The 32 byte pedersen leaves.
  * @returns A tree represented by an array.

--- a/yarn-project/barretenberg.js/src/crypto/pedersen/pedersen.ts
+++ b/yarn-project/barretenberg.js/src/crypto/pedersen/pedersen.ts
@@ -71,11 +71,11 @@ export function pedersenGetHash(wasm: WasmWrapper, data: Buffer): Buffer {
 /**
  * Given a buffer containing 32 byte pedersen leaves, return a new buffer containing the leaves and all pairs of nodes
  * that define a merkle tree.
- * 
+ *
  * E.g.
  * Input:  [1][2][3][4]
  * Output: [1][2][3][4][compress(1,2)][compress(3,4)][compress(5,6)].
- * 
+ *
  * @param wasm - The barretenberg module.
  * @param values - The 32 byte pedersen leaves.
  * @returns A tree represented by an array.

--- a/yarn-project/barretenberg.js/src/wasm/barretenberg_wasm.ts
+++ b/yarn-project/barretenberg.js/src/wasm/barretenberg_wasm.ts
@@ -28,6 +28,11 @@ export class BarretenbergWasm extends AsyncWasmWrapper {
     super(loggerName);
   }
 
+  /**
+   * Get the import functions for the WASM module and the prover and verifier CRS.
+   * @param wasm - The WASM module.
+   * @returns The import functions and the prover and verifier CRS.
+   */
   protected getImportFns(wasm: WasmModule) {
     return {
       ...super.getImportFns(wasm),

--- a/yarn-project/barretenberg.js/src/wasm/load_crs.ts
+++ b/yarn-project/barretenberg.js/src/wasm/load_crs.ts
@@ -1,6 +1,11 @@
 import { WasmModule } from '@aztec/foundation/wasm';
 import { Crs } from '../crs/index.js';
 
+/**
+ * Loads the verifier CRS into WASM memory and returns a pointer to it.
+ * @param wasm - WASM module.
+ * @returns A pointer to the verifier CRS in WASM memory.
+ */
 export async function loadVerifierCrs(wasm: WasmModule) {
   // TODO optimize
   const crs = new Crs(0);
@@ -10,6 +15,12 @@ export async function loadVerifierCrs(wasm: WasmModule) {
   return crsPtr;
 }
 
+/**
+ * Loads the prover CRS into WASM memory and returns a pointer to it.
+ * @param wasm - WASM module.
+ * @param numPoints - The number of circuit gates.
+ * @returns A pointer to the prover CRS in WASM memory.
+ */
 export async function loadProverCrs(wasm: WasmModule, numPoints: number) {
   const crs = new Crs(numPoints);
   await crs.init();

--- a/yarn-project/ethereum.js/.eslintrc.cjs
+++ b/yarn-project/ethereum.js/.eslintrc.cjs
@@ -1,1 +1,6 @@
-module.exports = require('@aztec/foundation/eslint');
+// module.exports = require('@aztec/foundation/eslint');
+
+// Uncomment line 1 and remove the following to reenable the rule
+const config = require('@aztec/foundation/eslint');
+config.rules['jsdoc/require-param'] = 'off';
+module.exports = config;

--- a/yarn-project/foundation/.eslintrc.cjs
+++ b/yarn-project/foundation/.eslintrc.cjs
@@ -98,8 +98,7 @@ module.exports = {
     'jsdoc/require-description': ['warn', { contexts }],
     'jsdoc/require-description-complete-sentence': ['warn'],
     'jsdoc/require-hyphen-before-param-description': ['warn'],
-    // TODO(AD): we can reevaluate this - seemed low value
-    // 'jsdoc/require-param': ['warn', { contexts, checkDestructured: false }],
+    'jsdoc/require-param': ['error', { contexts, checkDestructured: false }],
     'jsdoc/require-param-description': ['warn', { contexts }],
     'jsdoc/require-param-name': ['warn', { contexts }],
     'jsdoc/require-property': ['warn', { contexts }],

--- a/yarn-project/foundation/src/wasm/wasm/async_wasm_wrapper.ts
+++ b/yarn-project/foundation/src/wasm/wasm/async_wasm_wrapper.ts
@@ -12,6 +12,7 @@ export abstract class AsyncWasmWrapper extends WasmWrapper {
    * 8192 maximum by default. 512mb.
    * @param initial - Initial memory pages.
    * @param maximum - Max memory pages.
+   * @returns The wrapper.
    */
   public async init(initial = 20, maximum = 8192): Promise<this> {
     await super.init(initial, maximum);
@@ -22,7 +23,7 @@ export abstract class AsyncWasmWrapper extends WasmWrapper {
   /**
    * These are functions implementations for imports we've defined are needed.
    * The native C++ build defines these in a module called "env". We must implement TypeScript versions here.
-   * @param module - The wasm module.
+   * @param wasm - The wasm module.
    * @returns An object of functions called from cpp that need to be answered by ts.
    */
   protected getImportFns(wasm: WasmModule): any {
@@ -83,7 +84,13 @@ export abstract class AsyncWasmWrapper extends WasmWrapper {
   }
 }
 
-// REFACTOR: Copied from bb serialize, move to a set of serialization fns here in foundation
+/**
+ * Convert a number to a little-endian uint32 buffer.
+ * @param n - The number to convert.
+ * @param bufferSize - Size of the returned buffer.
+ * @returns Resulting buffer.
+ * TODO: REFACTOR: Copied from bb serialize, move to a set of serialization fns here in foundation.
+ */
 function numToUInt32LE(n: number, bufferSize = 4) {
   const buf = Buffer.alloc(bufferSize);
   buf.writeUInt32LE(n, bufferSize - 4);

--- a/yarn-project/foundation/src/wasm/wasm/wasm_wrapper.ts
+++ b/yarn-project/foundation/src/wasm/wasm/wasm_wrapper.ts
@@ -5,7 +5,7 @@ import { readFile } from 'fs/promises';
 
 /**
  * Get the WASM binary.
- * @param path - Path to the code
+ * @param path - Path to the WASM binary.
  * @returns The binary buffer.
  */
 export async function fetchCode(path: string) {
@@ -33,7 +33,7 @@ export abstract class WasmWrapper {
    * 8192 maximum by default. 512mb.
    * @param initial - Initial memory pages.
    * @param maximum - Max memory pages.
-   * @returns Self
+   * @returns The original instance of the wrapper.
    */
   public async init(initial = 20, maximum = 8192): Promise<WasmWrapper> {
     let wasm: WasmModule;

--- a/yarn-project/merkle-tree/.eslintrc.cjs
+++ b/yarn-project/merkle-tree/.eslintrc.cjs
@@ -1,7 +1,1 @@
-// module.exports = require('@aztec/foundation/eslint-legacy');
-
-// TODO: uncomment first line and remove the following once docs are re-enabled globally
-const config = require('@aztec/foundation/eslint-legacy');
-config.plugins.push('eslint-plugin-tsdoc', 'jsdoc');
-config.rules['tsdoc/syntax'] = 'error';
-module.exports = config;
+module.exports = require('@aztec/foundation/eslint');

--- a/yarn-project/merkle-tree/.eslintrc.cjs
+++ b/yarn-project/merkle-tree/.eslintrc.cjs
@@ -1,1 +1,7 @@
-module.exports = require('@aztec/foundation/eslint-legacy');
+// module.exports = require('@aztec/foundation/eslint-legacy');
+
+// TODO: uncomment first line and remove the following once docs are re-enabled globally
+const config = require('@aztec/foundation/eslint-legacy');
+config.plugins.push('eslint-plugin-tsdoc', 'jsdoc');
+config.rules['tsdoc/syntax'] = 'error';
+module.exports = config;

--- a/yarn-project/merkle-tree/src/interfaces/append_only_tree.ts
+++ b/yarn-project/merkle-tree/src/interfaces/append_only_tree.ts
@@ -1,9 +1,12 @@
 import { MerkleTree } from './merkle_tree.js';
 
+/**
+ * A Merkle tree that supports only appending leaves and not updating existing leaves.
+ */
 export interface AppendOnlyTree extends MerkleTree {
   /**
-   * Appends a set of leaf values to the tree
-   * @param leaves - The set of leaves to be appended
+   * Appends a set of leaf values to the tree.
+   * @param leaves - The set of leaves to be appended.
    */
   appendLeaves(leaves: Buffer[]): Promise<void>;
 }

--- a/yarn-project/merkle-tree/src/interfaces/indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/interfaces/indexed_tree.ts
@@ -18,14 +18,29 @@ export interface LeafData {
   nextValue: bigint;
 }
 
+/**
+ * A Merkle tree that supports efficient lookup of leaves by value.
+ */
 export interface IndexedTree extends AppendOnlyTree {
   /**
    * Finds the index of the largest leaf whose value is less than or equal to the provided value.
    * @param newValue - The new value to be inserted into the tree.
    * @param includeUncommitted - If true, the uncommitted changes are included in the search.
-   * @returns Tuple containing the leaf index and a flag to say if the value is a duplicate.
+   * @returns The found leaf index and a flag indicating if the corresponding leaf's value is equal to `newValue`.
    */
-  findIndexOfPreviousValue(newValue: bigint, includeUncommitted: boolean): { index: number; alreadyPresent: boolean };
+  findIndexOfPreviousValue(
+    newValue: bigint,
+    includeUncommitted: boolean,
+  ): {
+    /**
+     * The index of the found leaf.
+     */
+    index: number;
+    /**
+     * A flag indicating if the corresponding leaf's value is equal to `newValue`.
+     */
+    alreadyPresent: boolean;
+  };
 
   /**
    * Gets the latest LeafData copy.
@@ -36,9 +51,9 @@ export interface IndexedTree extends AppendOnlyTree {
   getLatestLeafDataCopy(index: number, includeUncommitted: boolean): LeafData | undefined;
 
   /**
-   * Exposes the underlying tree's update leaf method
-   * @param leaf - The hash to set at the leaf
-   * @param index - The index of the element
+   * Exposes the underlying tree's update leaf method.
+   * @param leaf - The hash to set at the leaf.
+   * @param index - The index of the element.
    */
   // TODO: remove once the batch insertion functionality is moved to StandardIndexedTree from circuit_block_builder.ts
   updateLeaf(leaf: LeafData, index: bigint): Promise<void>;

--- a/yarn-project/merkle-tree/src/interfaces/indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/interfaces/indexed_tree.ts
@@ -19,7 +19,7 @@ export interface LeafData {
 }
 
 /**
- * A Merkle tree that supports efficient lookup of leaves by value.
+ * Indexed merkle tree.
  */
 export interface IndexedTree extends AppendOnlyTree {
   /**

--- a/yarn-project/merkle-tree/src/interfaces/merkle_tree.ts
+++ b/yarn-project/merkle-tree/src/interfaces/merkle_tree.ts
@@ -5,9 +5,9 @@ import { SiblingPath } from '../sibling_path/sibling_path.js';
  */
 export interface SiblingPathSource {
   /**
-   * Returns the sibling path for a requested leaf index
-   * @param index - The index of the leaf for which a sibling path is required
-   * @param includeUncommitted - Set to true to include uncommitted updates in the sibling path
+   * Returns the sibling path for a requested leaf index.
+   * @param index - The index of the leaf for which a sibling path is required.
+   * @param includeUncommitted - Set to true to include uncommitted updates in the sibling path.
    */
   getSiblingPath(index: bigint, includeUncommitted: boolean): Promise<SiblingPath>;
 }
@@ -17,36 +17,36 @@ export interface SiblingPathSource {
  */
 export interface MerkleTree extends SiblingPathSource {
   /**
-   * Returns the current root of the tree
-   * @param includeUncommitted - Set to true to include uncommitted updates in the calculated root
+   * Returns the current root of the tree.
+   * @param includeUncommitted - Set to true to include uncommitted updates in the calculated root.
    */
   getRoot(includeUncommitted: boolean): Buffer;
 
   /**
-   * Returns the number of leaves in the tree
-   * @param includeUncommitted - Set to true to include uncommitted updates in the returned value
+   * Returns the number of leaves in the tree.
+   * @param includeUncommitted - Set to true to include uncommitted updates in the returned value.
    */
   getNumLeaves(includeUncommitted: boolean): bigint;
 
   /**
-   * Commit pending updates to the tree
+   * Commit pending updates to the tree.
    */
   commit(): Promise<void>;
 
   /**
-   * Returns the depth of the tree
+   * Returns the depth of the tree.
    */
   getDepth(): number;
 
   /**
-   * Rollback pending update to the tree
+   * Rollback pending update to the tree.
    */
   rollback(): Promise<void>;
 
   /**
-   * Returns the value of a leaf at the specified index
-   * @param index - The index of the leaf value to be returned
-   * @param includeUncommitted - Set to true to include uncommitted updates in the data set
+   * Returns the value of a leaf at the specified index.
+   * @param index - The index of the leaf value to be returned.
+   * @param includeUncommitted - Set to true to include uncommitted updates in the data set.
    */
   getLeafValue(index: bigint, includeUncommitted: boolean): Promise<Buffer | undefined>;
 }

--- a/yarn-project/merkle-tree/src/interfaces/update_only_tree.ts
+++ b/yarn-project/merkle-tree/src/interfaces/update_only_tree.ts
@@ -1,11 +1,14 @@
 import { LeafData } from '../index.js';
 import { MerkleTree } from './merkle_tree.js';
 
+/**
+ * A Merkle tree that supports updates at arbitrary indices but not appending.
+ */
 export interface UpdateOnlyTree extends MerkleTree {
   /**
-   * Updates a leaf at a given index in the tree
-   * @param leaf The leaf value to be updated
-   * @param index The leaf to be updated
+   * Updates a leaf at a given index in the tree.
+   * @param leaf - The leaf value to be updated.
+   * @param index - The leaf to be updated.
    */
   // TODO: Make this strictly a Buffer
   updateLeaf(leaf: Buffer | LeafData, index: bigint): Promise<void>;

--- a/yarn-project/merkle-tree/src/new_tree.ts
+++ b/yarn-project/merkle-tree/src/new_tree.ts
@@ -9,7 +9,7 @@ import { TreeBase } from './tree_base.js';
  * @param hasher - A hasher used to compute hash paths.
  * @param name - Name of the tree.
  * @param depth - Depth of the tree.
- * @param prefilledSize - {optional} A number of leaves that are prefilled with values.
+ * @param prefilledSize - A number of leaves that are prefilled with values.
  * @returns The newly created tree.
  */
 export async function newTree<T extends TreeBase>(

--- a/yarn-project/merkle-tree/src/pedersen.ts
+++ b/yarn-project/merkle-tree/src/pedersen.ts
@@ -50,7 +50,7 @@ export class Pedersen implements Hasher {
    * Input:  [1][2][3][4]
    * Output: [1][2][3][4][compress(1,2)][compress(3,4)][compress(5,6)].
    *
-   * @param values - The 32 byte pedersen leaves.
+   * @param leaves - The 32 byte pedersen leaves.
    * @returns A tree represented by an array.
    */
   public hashToTree(leaves: Buffer[]): Promise<Buffer[]> {

--- a/yarn-project/merkle-tree/src/pedersen.ts
+++ b/yarn-project/merkle-tree/src/pedersen.ts
@@ -8,18 +8,51 @@ import {
 import { WasmWrapper } from '@aztec/foundation/wasm';
 import { Hasher } from './hasher.js';
 
+/**
+ * A helper class encapsulating Pedersen hash functionality.
+ */
 export class Pedersen implements Hasher {
   constructor(private wasm: WasmWrapper) {}
 
+  /**
+   * Compresses two 32-byte hashes.
+   * @param lhs - The first hash.
+   * @param rhs - The second hash.
+   * @returns The new 32-byte hash.
+   */
   public compress(lhs: Uint8Array, rhs: Uint8Array): Buffer {
     return pedersenCompress(this.wasm, lhs, rhs);
   }
+
+  /**
+   * Compresses an array of buffers.
+   * @param inputs - The array of buffers to compress.
+   * @returns The resulting 32-byte hash.
+   */
   public compressInputs(inputs: Buffer[]): Buffer {
     return pedersenCompressInputs(this.wasm, inputs);
   }
+
+  /**
+   * Get a 32-byte pedersen hash from a buffer.
+   * @param data - The data buffer.
+   * @returns The resulting hash buffer.
+   */
   public hashToField(data: Uint8Array): Buffer {
     return pedersenGetHash(this.wasm, Buffer.from(data));
   }
+
+  /**
+   * Given a buffer containing 32 byte pedersen leaves, return a new buffer containing the leaves and all pairs of
+   * nodes that define a merkle tree.
+   *
+   * E.g.
+   * Input:  [1][2][3][4]
+   * Output: [1][2][3][4][compress(1,2)][compress(3,4)][compress(5,6)].
+   *
+   * @param values - The 32 byte pedersen leaves.
+   * @returns A tree represented by an array.
+   */
   public hashToTree(leaves: Buffer[]): Promise<Buffer[]> {
     return Promise.resolve(pedersenGetHashTree(this.wasm, leaves));
   }

--- a/yarn-project/merkle-tree/src/sibling_path/sibling_path.ts
+++ b/yarn-project/merkle-tree/src/sibling_path/sibling_path.ts
@@ -3,13 +3,13 @@ import { deserializeArrayFromVector, serializeBufferArrayToVector } from '@aztec
 
 /**
  * Contains functionality to compute and serialize/deserialize a sibling path.
- * e.g. Sibling path for a leaf at index 3 in a tree of depth 3 consists of:
+ * E.g. Sibling path for a leaf at index 3 in a tree of depth 3 consists of:
  *      d0:                                            [ root ]
  *      d1:                      [ ]                                               [*]
  *      d2:         [*]                      [ ]                       [ ]                     [ ]
- *      d3:   [ ]         [ ]          [*]         [ ]           [ ]         [ ]          [ ]        [ ]
+ *      d3:   [ ]         [ ]          [*]         [ ]           [ ]         [ ]          [ ]        [ ].
  *
- *      And the elements would be ordered as: [ leaf_at_index_2, node_at_level_2_index_0, node_at_level_1_index_1 ]
+ *      And the elements would be ordered as: [ leaf_at_index_2, node_at_level_2_index_0, node_at_level_1_index_1 ].
  */
 export class SiblingPath {
   /**

--- a/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.test.ts
+++ b/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.test.ts
@@ -340,7 +340,7 @@ describe('StandardIndexedTreeSpecific', () => {
      *  --------------------------------------------------------------------
      *  val       0       30      10      20       0       0       50      0
      *  nextIdx   2       6       3       1        0       0       0       0
-     *  nextVal   10      50      20      30       0       0       0       0
+     *  nextVal   10      50      20      30       0       0       0       0.
      */
     index1Hash = pedersen.compressInputs(createIndexedTreeLeaf(30, 6, 50));
     const index6Hash = pedersen.compressInputs(createIndexedTreeLeaf(50, 0, 0));

--- a/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
@@ -37,7 +37,7 @@ const initialLeaf: LeafData = {
 };
 
 /**
- * A Merkle tree that supports efficient lookup of leaves by value.
+ * Indexed merkle tree.
  */
 export class StandardIndexedTree extends TreeBase implements IndexedTree {
   private leaves: LeafData[] = [];

--- a/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
@@ -75,7 +75,7 @@ export class StandardIndexedTree extends TreeBase implements IndexedTree {
   /**
    * Gets the value of the leaf at the given index.
    * @param index - Index of the leaf of which to obtain the value.
-   * @param includeUncommitted include uncommitted leaves in the computation.
+   * @param includeUncommitted - Indicates whether to include uncommitted leaves in the computation.
    * @returns The value of the leaf at the given index or undefined if the leaf is empty.
    */
   public getLeafValue(index: bigint, includeUncommitted: boolean): Promise<Buffer | undefined> {
@@ -88,12 +88,21 @@ export class StandardIndexedTree extends TreeBase implements IndexedTree {
    * Finds the index of the largest leaf whose value is less than or equal to the provided value.
    * @param newValue - The new value to be inserted into the tree.
    * @param includeUncommitted - If true, the uncommitted changes are included in the search.
-   * @returns Tuple containing the leaf index and a flag to say if the value is a duplicate.
+   * @returns The found leaf index and a flag indicating if the corresponding leaf's value is equal to `newValue`.
    */
-  public findIndexOfPreviousValue(
+  findIndexOfPreviousValue(
     newValue: bigint,
     includeUncommitted: boolean,
-  ): { index: number; alreadyPresent: boolean } {
+  ): {
+    /**
+     * The index of the found leaf.
+     */
+    index: number;
+    /**
+     * A flag indicating if the corresponding leaf's value is equal to `newValue`.
+     */
+    alreadyPresent: boolean;
+  } {
     const numLeaves = this.getNumLeaves(includeUncommitted);
     const diff: bigint[] = [];
 
@@ -278,9 +287,9 @@ export class StandardIndexedTree extends TreeBase implements IndexedTree {
   }
 
   /**
-   * Exposes the underlying tree's update leaf method
-   * @param leaf - The hash to set at the leaf
-   * @param index - The index of the element
+   * Exposes the underlying tree's update leaf method.
+   * @param leaf - The hash to set at the leaf.
+   * @param index - The index of the element.
    */
   // TODO: remove once the batch insertion functionality is moved here from circuit_block_builder.ts
   public async updateLeaf(leaf: LeafData, index: bigint): Promise<void> {

--- a/yarn-project/merkle-tree/src/tree_base.ts
+++ b/yarn-project/merkle-tree/src/tree_base.ts
@@ -61,6 +61,7 @@ export abstract class TreeBase implements MerkleTree {
 
   /**
    * Returns the root of the tree.
+   * @param includeUncommitted - If true, root incorporating uncomitted changes is returned.
    * @returns The root of the tree.
    */
   public getRoot(includeUncommitted: boolean): Buffer {
@@ -69,6 +70,7 @@ export abstract class TreeBase implements MerkleTree {
 
   /**
    * Returns the number of leaves in the tree.
+   * @param includeUncommitted - If true, the returned number of leaves includes uncomitted changes.
    * @returns The number of leaves in the tree.
    */
   public getNumLeaves(includeUncommitted: boolean) {
@@ -94,6 +96,7 @@ export abstract class TreeBase implements MerkleTree {
   /**
    * Returns a sibling path for the element at the given index.
    * @param index - The index of the element.
+   * @param includeUncommitted - Indicates whether to get a sibling path incorporating uncomitted changes.
    * @returns A sibling path for the element at the given index.
    * Note: The sibling path is an array of sibling hashes, with the lowest hash (leaf hash) first, and the highest hash last.
    */
@@ -181,6 +184,7 @@ export abstract class TreeBase implements MerkleTree {
    * Returns the latest value at the given index.
    * @param level - The level of the tree.
    * @param index - The index of the element.
+   * @param includeUncommitted - Indicates, whether to get include uncomitted changes.
    * @returns The latest value at the given index.
    * Note: If the value is not in the cache, it will be fetched from the database.
    */

--- a/yarn-project/merkle-tree/src/tree_base.ts
+++ b/yarn-project/merkle-tree/src/tree_base.ts
@@ -136,6 +136,12 @@ export abstract class TreeBase implements MerkleTree {
     return Promise.resolve();
   }
 
+  /**
+   * Gets the value at the given index.
+   * @param index - The index of the leaf.
+   * @param includeUncommitted - Indicates whether to include uncommitted changes.
+   * @returns Leaf value at the given index or undefined.
+   */
   public getLeafValue(index: bigint, includeUncommitted: boolean): Promise<Buffer | undefined> {
     return this.getLatestValueAtIndex(this.depth, index, includeUncommitted);
   }
@@ -201,7 +207,7 @@ export abstract class TreeBase implements MerkleTree {
 
   /**
    * Initializes the tree.
-   * @param prefilledSize - {optional} A number of leaves that are prefilled with values.
+   * @param prefilledSize - A number of leaves that are prefilled with values.
    * @returns Empty promise.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/yarn-project/world-state/.eslintrc.cjs
+++ b/yarn-project/world-state/.eslintrc.cjs
@@ -1,1 +1,1 @@
-module.exports = require('@aztec/foundation/eslint-legacy');
+module.exports = require('@aztec/foundation/eslint');

--- a/yarn-project/world-state/src/merkle-tree/merkle_tree_operations_facade.ts
+++ b/yarn-project/world-state/src/merkle-tree/merkle_tree_operations_facade.ts
@@ -6,30 +6,98 @@ import { LeafData, MerkleTreeDbOperations, MerkleTreeId, MerkleTreeOperations, T
  */
 export class MerkleTreeOperationsFacade implements MerkleTreeOperations {
   constructor(private trees: MerkleTreeDbOperations, private includeUncommitted: boolean) {}
+
+  /**
+   * Returns the tree info for the specified tree id.
+   * @param treeId - Id of the tree to get information from.
+   * @param includeUncommitted - Indicates whether to include uncommitted data.
+   * @returns The tree info for the specified tree.
+   */
   getTreeInfo(treeId: MerkleTreeId): Promise<TreeInfo> {
     return this.trees.getTreeInfo(treeId, this.includeUncommitted);
   }
+
+  /**
+   * Appends a set of leaf values to the tree.
+   * @param treeId - Id of the tree to append leaves to.
+   * @param leaves - The set of leaves to be appended.
+   * @returns The tree info of the specified tree.
+   */
   appendLeaves(treeId: MerkleTreeId, leaves: Buffer[]): Promise<void> {
     return this.trees.appendLeaves(treeId, leaves);
   }
+
+  /**
+   * Returns the sibling path for a requested leaf index.
+   * @param treeId - Id of the tree to get the sibling path from.
+   * @param index - The index of the leaf for which a sibling path is required.
+   * @returns A promise with the sibling path of the specified leaf index.
+   */
   getSiblingPath(treeId: MerkleTreeId, index: bigint): Promise<SiblingPath> {
     return this.trees.getSiblingPath(treeId, index, this.includeUncommitted);
   }
+
+  /**
+   * Finds the index of the largest leaf whose value is less than or equal to the provided value.
+   * @param treeId - The ID of the tree to search.
+   * @param value - The value to be inserted into the tree.
+   * @param includeUncommitted - If true, the uncommitted changes are included in the search.
+   * @returns The found leaf index and a flag indicating if the corresponding leaf's value is equal to `newValue`.
+   */
   getPreviousValueIndex(
     treeId: MerkleTreeId.NULLIFIER_TREE,
     value: bigint,
-  ): Promise<{ index: number; alreadyPresent: boolean }> {
+  ): Promise<{
+    /**
+     * The index of the found leaf.
+     */
+    index: number;
+    /**
+     * A flag indicating if the corresponding leaf's value is equal to `newValue`.
+     */
+    alreadyPresent: boolean;
+  }> {
     return this.trees.getPreviousValueIndex(treeId, value, this.includeUncommitted);
   }
+
+  /**
+   * Updates a leaf in a tree at a given index.
+   * @param treeId - The ID of the tree.
+   * @param leaf - The new leaf value.
+   * @param index - The index to insert into.
+   * @returns Empty promise.
+   */
   updateLeaf(treeId: MerkleTreeId.NULLIFIER_TREE, leaf: LeafData, index: bigint): Promise<void> {
     return this.trees.updateLeaf(treeId, leaf, index, this.includeUncommitted);
   }
+
+  /**
+   * Gets the leaf data at a given index and tree.
+   * @param treeId - The ID of the tree get the leaf from.
+   * @param index - The index of the leaf to get.
+   * @returns Leaf data.
+   */
   getLeafData(treeId: MerkleTreeId.NULLIFIER_TREE, index: number): Promise<LeafData | undefined> {
     return this.trees.getLeafData(treeId, index, this.includeUncommitted);
   }
+
+  /**
+   * Returns the index of a leaf given its value, or undefined if no leaf with that value is found.
+   * @param treeId - The ID of the tree.
+   * @param value - The leaf value to look for.
+   * @returns The index of the first leaf found with a given value (undefined if not found).
+   */
   findLeafIndex(treeId: MerkleTreeId, value: Buffer): Promise<bigint | undefined> {
     return this.trees.findLeafIndex(treeId, value, this.includeUncommitted);
   }
+
+  /**
+   * Gets the value at the given index.
+   * @param treeId - The ID of the tree to get the leaf value from.
+   * @param index - The index of the leaf.
+   * @param includeUncommitted - Indicates whether to include uncommitted changes.
+   * @returns Leaf value at the given index (undefined if not found).
+   */
   getLeafValue(treeId: MerkleTreeId, index: bigint): Promise<Buffer | undefined> {
     return this.trees.getLeafValue(treeId, index, this.includeUncommitted);
   }

--- a/yarn-project/world-state/src/synchroniser/config.ts
+++ b/yarn-project/world-state/src/synchroniser/config.ts
@@ -1,9 +1,9 @@
 /**
- * World State synchroniser configuration values
+ * World State synchroniser configuration values.
  */
 export interface WorldStateConfig {
   /**
-   * The frequency in which to check
+   * The frequency in which to check.
    */
   checkInterval: number;
 
@@ -13,6 +13,10 @@ export interface WorldStateConfig {
   l2QueueSize: number;
 }
 
+/**
+ * Returns the configuration values for the world state synchroniser.
+ * @returns The configuration values for the world state synchroniser.
+ */
 export function getConfigEnvVars(): WorldStateConfig {
   const { WS_CHECK_INTERVAL, WS_L2_BLOCK_QUEUE_SIZE } = process.env;
   const envVars: WorldStateConfig = {

--- a/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.ts
+++ b/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.ts
@@ -29,10 +29,18 @@ export class ServerWorldStateSynchroniser implements WorldStateSynchroniser {
     this.l2BlockDownloader = new L2BlockDownloader(l2BlockSource, config.l2QueueSize, config.checkInterval);
   }
 
+  /**
+   * Returns an instance of MerkleTreeOperations that will include uncommitted data.
+   * @returns An instance of MerkleTreeOperations that will include uncommitted data.
+   */
   public getLatest(): MerkleTreeOperations {
     return new MerkleTreeOperationsFacade(this.merkleTreeDb, true);
   }
 
+  /**
+   * Returns an instance of MerkleTreeOperations that will not include uncommitted data.
+   * @returns An instance of MerkleTreeOperations that will not include uncommitted data.
+   */
   public getCommitted(): MerkleTreeOperations {
     return new MerkleTreeOperationsFacade(this.merkleTreeDb, false);
   }

--- a/yarn-project/world-state/src/utils.ts
+++ b/yarn-project/world-state/src/utils.ts
@@ -5,10 +5,10 @@ import { WasmWrapper } from '@aztec/foundation/wasm';
 
 /**
  * Computes the index in the public data tree for a given contract and storage slot.
- * @param contract - address of the contract who owns the storage
- * @param slot - slot within the contract storage
- * @param bbWasm - wasm module for computing the hash
- * @returns The leaf index of the public data tree that maps to this storage slot
+ * @param contract - Address of the contract who owns the storage.
+ * @param slot - Slot within the contract storage.
+ * @param bbWasm - Wasm module for computing the hash.
+ * @returns The leaf index of the public data tree that maps to this storage slot.
  */
 export function computePublicDataTreeLeafIndex(contract: AztecAddress, slot: Fr, wasm: WasmWrapper): bigint {
   return toBigInt(

--- a/yarn-project/world-state/src/world-state-db/index.ts
+++ b/yarn-project/world-state/src/world-state-db/index.ts
@@ -15,7 +15,14 @@ export enum MerkleTreeId {
   PUBLIC_DATA_TREE = 5,
 }
 
+/**
+ * Type alias for the nullifier tree ID.
+ */
 export type IndexedTreeId = MerkleTreeId.NULLIFIER_TREE;
+
+/**
+ * Type alias for the public data tree ID.
+ */
 export type PublicTreeId = MerkleTreeId.PUBLIC_DATA_TREE;
 
 /**
@@ -55,6 +62,9 @@ type WithIncludeUncommitted<F> = F extends (...args: [...infer Rest]) => infer R
   ? (...args: [...Rest, boolean]) => Return
   : F;
 
+/**
+ * Defines the names of the setters on an append only set of Merkle Trees.
+ */
 type MerkleTreeSetters = 'appendLeaves';
 
 /**
@@ -71,51 +81,70 @@ export type MerkleTreeDbOperations = {
  */
 export interface MerkleTreeOperations {
   /**
-   * Appends leaves to a given tree
-   * @param treeId - The tree to be updated
-   * @param leaves - The set of leaves to be appended
+   * Appends leaves to a given tree.
+   * @param treeId - The tree to be updated.
+   * @param leaves - The set of leaves to be appended.
    */
   appendLeaves(treeId: MerkleTreeId, leaves: Buffer[]): Promise<void>;
+
   /**
-   * Returns information about the given tree
-   * @param treeId - The tree to be queried
+   * Returns information about the given tree.
+   * @param treeId - The tree to be queried.
    */
   getTreeInfo(treeId: MerkleTreeId): Promise<TreeInfo>;
+
   /**
    * Gets sibling path for a leaf.
-   * @param treeId - The tree to be queried for a sibling path
-   * @param index - The index of the leaf for which a sibling path should be returned
+   * @param treeId - The tree to be queried for a sibling path.
+   * @param index - The index of the leaf for which a sibling path should be returned.
    */
   getSiblingPath(treeId: MerkleTreeId, index: bigint): Promise<SiblingPath>;
+
   /**
-   * Returns the previous index for a given value in an indexed tree
-   * @param treeId - The tree for which the previous value index is required
-   * @param value - The value to be queried
+   * Returns the previous index for a given value in an indexed tree.
+   * @param treeId - The tree for which the previous value index is required.
+   * @param value - The value to be queried.
    */
-  getPreviousValueIndex(treeId: IndexedTreeId, value: bigint): Promise<{ index: number; alreadyPresent: boolean }>;
+  getPreviousValueIndex(
+    treeId: IndexedTreeId,
+    value: bigint,
+  ): Promise<{
+    /**
+     * The index of the found leaf.
+     */
+    index: number;
+    /**
+     * A flag indicating if the corresponding leaf's value is equal to `newValue`.
+     */
+    alreadyPresent: boolean;
+  }>;
+
   /**
-   * Returns the data at a specific leaf
-   * @param treeId - The tree for which leaf data should be returned
-   * @param index - The index of the leaf required
+   * Returns the data at a specific leaf.
+   * @param treeId - The tree for which leaf data should be returned.
+   * @param index - The index of the leaf required.
    */
   getLeafData(treeId: IndexedTreeId, index: number): Promise<LeafData | undefined>;
+
   /**
-   * Update the leaf data at the given index
-   * @param treeId - The tree for which leaf data should be edited
-   * @param leaf - The updated leaf value
-   * @param index - The index of the leaf to be updated
+   * Update the leaf data at the given index.
+   * @param treeId - The tree for which leaf data should be edited.
+   * @param leaf - The updated leaf value.
+   * @param index - The index of the leaf to be updated.
    */
   updateLeaf(treeId: IndexedTreeId | PublicTreeId, leaf: LeafData | Buffer, index: bigint): Promise<void>;
+
   /**
-   * Returns the index containing a leaf value
-   * @param treeId - The tree for which the index should be returned
-   * @param value - The value to search for in the tree
+   * Returns the index containing a leaf value.
+   * @param treeId - The tree for which the index should be returned.
+   * @param value - The value to search for in the tree.
    */
   findLeafIndex(treeId: MerkleTreeId, value: Buffer): Promise<bigint | undefined>;
+
   /**
    * Gets the value for a leaf in the tree.
-   * @param treeId - The tree for which the index should be returned
-   * @param index - The index of the leaf
+   * @param treeId - The tree for which the index should be returned.
+   * @param index - The index of the leaf.
    */
   getLeafValue(treeId: MerkleTreeId, index: bigint): Promise<Buffer | undefined>;
 }
@@ -125,11 +154,12 @@ export interface MerkleTreeOperations {
  */
 export interface MerkleTreeDb extends MerkleTreeDbOperations {
   /**
-   * Commits pending changes to the underlying store
+   * Commits pending changes to the underlying store.
    */
   commit(): Promise<void>;
+
   /**
-   * Rolls back pending changes
+   * Rolls back pending changes.
    */
   rollback(): Promise<void>;
 }

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -258,8 +258,8 @@ export class MerkleTrees implements MerkleTreeDb {
     return await this.synchronise(async () => {
       const tree = this.trees[treeId];
       for (let i = 0n; i < tree.getNumLeaves(includeUncommitted); i++) {
-        const value = await tree.getLeafValue(i, includeUncommitted);
-        if (value && value.equals(value)) {
+        const currentValue = await tree.getLeafValue(i, includeUncommitted);
+        if (currentValue && currentValue.equals(value)) {
           return i;
         }
       }

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -44,6 +44,7 @@ export class MerkleTrees implements MerkleTreeDb {
 
   /**
    * Initialises the collection of Merkle Trees.
+   * @param optionalWasm - WASM instance to use for hashing (if not provided PrimitivesWasm will be used).
    */
   public async init(optionalWasm?: WasmWrapper) {
     const wasm = optionalWasm ?? (await PrimitivesWasm.get());
@@ -105,6 +106,7 @@ export class MerkleTrees implements MerkleTreeDb {
   /**
    * Method to asynchronously create and initialise a MerkleTrees instance.
    * @param db - The db instance to use for data persistance.
+   * @param wasm - WASM instance to use for hashing (if not provided PrimitivesWasm will be used).
    * @returns - A fully initialised MerkleTrees instance.
    */
   public static async new(db: levelup.LevelUp, wasm?: WasmWrapper) {
@@ -139,12 +141,20 @@ export class MerkleTrees implements MerkleTreeDb {
   /**
    * Gets the tree info for the specified tree.
    * @param treeId - Id of the tree to get information from.
+   * @param includeUncommitted - Indicates whether to include uncommitted data.
    * @returns The tree info for the specified tree.
    */
   public async getTreeInfo(treeId: MerkleTreeId, includeUncommitted: boolean): Promise<TreeInfo> {
     return await this.synchronise(() => this._getTreeInfo(treeId, includeUncommitted));
   }
 
+  /**
+   * Gets the value at the given index.
+   * @param treeId - The ID of the tree to get the leaf value from.
+   * @param index - The index of the leaf.
+   * @param includeUncommitted - Indicates whether to include uncommitted changes.
+   * @returns Leaf value at the given index (undefined if not found).
+   */
   public async getLeafValue(
     treeId: MerkleTreeId,
     index: bigint,
@@ -157,6 +167,7 @@ export class MerkleTrees implements MerkleTreeDb {
    * Gets the sibling path for a leaf in a tree.
    * @param treeId - The ID of the tree.
    * @param index - The index of the leaf.
+   * @param includeUncommitted - Indicates whether the sibling path should incro include uncommitted data.
    * @returns The sibling path for the leaf.
    */
   public async getSiblingPath(treeId: MerkleTreeId, index: bigint, includeUncommitted: boolean): Promise<SiblingPath> {
@@ -189,16 +200,39 @@ export class MerkleTrees implements MerkleTreeDb {
     return await this.synchronise(() => this._rollback());
   }
 
+  /**
+   * Finds the index of the largest leaf whose value is less than or equal to the provided value.
+   * @param treeId - The ID of the tree to search.
+   * @param value - The value to be inserted into the tree.
+   * @param includeUncommitted - If true, the uncommitted changes are included in the search.
+   * @returns The found leaf index and a flag indicating if the corresponding leaf's value is equal to `newValue`.
+   */
   public async getPreviousValueIndex(
     treeId: IndexedTreeId,
     value: bigint,
     includeUncommitted: boolean,
-  ): Promise<{ index: number; alreadyPresent: boolean }> {
+  ): Promise<{
+    /**
+     * The index of the found leaf.
+     */
+    index: number;
+    /**
+     * A flag indicating if the corresponding leaf's value is equal to `newValue`.
+     */
+    alreadyPresent: boolean;
+  }> {
     return await this.synchronise(() =>
       Promise.resolve(this._getIndexedTree(treeId).findIndexOfPreviousValue(value, includeUncommitted)),
     );
   }
 
+  /**
+   * Gets the leaf data at a given index and tree.
+   * @param treeId - The ID of the tree get the leaf from.
+   * @param index - The index of the leaf to get.
+   * @param includeUncommitted - Indicates whether to include uncommitted data.
+   * @returns Leaf data.
+   */
   public async getLeafData(
     treeId: IndexedTreeId,
     index: number,
@@ -212,19 +246,20 @@ export class MerkleTrees implements MerkleTreeDb {
   /**
    * Returns the index of a leaf given its value, or undefined if no leaf with that value is found.
    * @param treeId - The ID of the tree.
-   * @param needle - The value to look for.
-   * @returns The index of the first leaf found with that value, or undefined is not found.
+   * @param value - The leaf value to look for.
+   * @param includeUncommitted - Indicates whether to include uncommitted data.
+   * @returns The index of the first leaf found with a given value (undefined if not found).
    */
   public async findLeafIndex(
     treeId: MerkleTreeId,
-    needle: Buffer,
+    value: Buffer,
     includeUncommitted: boolean,
   ): Promise<bigint | undefined> {
     return await this.synchronise(async () => {
       const tree = this.trees[treeId];
       for (let i = 0n; i < tree.getNumLeaves(includeUncommitted); i++) {
         const value = await tree.getLeafValue(i, includeUncommitted);
-        if (value && needle.equals(value)) {
+        if (value && value.equals(value)) {
           return i;
         }
       }
@@ -234,9 +269,10 @@ export class MerkleTrees implements MerkleTreeDb {
 
   /**
    * Updates a leaf in a tree at a given index.
-   * @param treeId - The ID of the tree
-   * @param leaf - The new leaf value
-   * @param index - The index to insert into
+   * @param treeId - The ID of the tree.
+   * @param leaf - The new leaf value.
+   * @param index - The index to insert into.
+   * @returns Empty promise.
    */
   public async updateLeaf(treeId: IndexedTreeId | PublicTreeId, leaf: LeafData | Buffer, index: bigint): Promise<void> {
     const tree = this.trees[treeId];
@@ -256,8 +292,9 @@ export class MerkleTrees implements MerkleTreeDb {
   }
 
   /**
-   * Returns the tree info for the specified tree.
+   * Returns the tree info for the specified tree id.
    * @param treeId - Id of the tree to get information from.
+   * @param includeUncommitted - Indicates whether to include uncommitted data.
    * @returns The tree info for the specified tree.
    */
   private _getTreeInfo(treeId: MerkleTreeId, includeUncommitted: boolean): Promise<TreeInfo> {
@@ -270,6 +307,11 @@ export class MerkleTrees implements MerkleTreeDb {
     return Promise.resolve(treeInfo);
   }
 
+  /**
+   * Returns an instance of an indexed tree.
+   * @param treeId - Id of the tree to get an instance of.
+   * @returns The indexed tree for the specified tree id.
+   */
   private _getIndexedTree(treeId: IndexedTreeId): IndexedTree {
     return this.trees[treeId] as IndexedTree;
   }
@@ -278,6 +320,7 @@ export class MerkleTrees implements MerkleTreeDb {
    * Returns the sibling path for a leaf in a tree.
    * @param treeId - Id of the tree to get the sibling path from.
    * @param index - Index of the leaf to get the sibling path for.
+   * @param includeUncommitted - Indicates whether to include uncommitted updates in the sibling path.
    * @returns Promise containing the sibling path for the leaf.
    */
   private _getSiblingPath(treeId: MerkleTreeId, index: bigint, includeUncommitted: boolean): Promise<SiblingPath> {


### PR DESCRIPTION
# Description

Fixes #328 #329 #330 #331

I re-enabled the `require-param` rule because it felt like the most important one.
I disabled it in `ethereum.js` because it's likely we will use `viem` moving forward hence it would most likely be a waste of time.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
