### PR TITLE
Output more debug info when txs fail to get sent

### DIFF
--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -42,8 +42,8 @@ describe('e2e_block_building', () => {
   }, 10_000);
 
   afterEach(async () => {
-    await node.stop();
-    await aztecRpcServer.stop();
+    await node?.stop();
+    await aztecRpcServer?.stop();
   });
 
   it('should assemble a block with multiple txs', async () => {

--- a/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
@@ -43,8 +43,8 @@ describe('e2e_deploy_contract', () => {
   }, 10_000);
 
   afterEach(async () => {
-    await node.stop();
-    await aztecRpcServer.stop();
+    await node?.stop();
+    await aztecRpcServer?.stop();
   });
 
   /**

--- a/yarn-project/end-to-end/src/e2e_zk_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_zk_token_contract.test.ts
@@ -49,8 +49,8 @@ describe('e2e_zk_token_contract', () => {
   });
 
   afterEach(async () => {
-    await node.stop();
-    await aztecRpcServer.stop();
+    await node?.stop();
+    await aztecRpcServer?.stop();
   });
 
   const calculateStorageSlot = async (accountIdx: number) => {

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -135,7 +135,7 @@ export class L1Publisher implements L2BlockReceiver {
       try {
         return await this.txSender.sendProcessTx(encodedData);
       } catch (err) {
-        this.log(`Error sending tx to L1`, err);
+        this.log(`Error sending L2 block tx to L1`, err);
         await this.sleepOrInterrupted();
       }
     }
@@ -149,7 +149,7 @@ export class L1Publisher implements L2BlockReceiver {
       try {
         return await this.txSender.sendEmitUnverifiedDataTx(l2BlockNum, unverifiedData);
       } catch (err) {
-        this.log(`Error sending tx to L1`, err);
+        this.log(`Error sending unverified data tx to L1`, err);
         await this.sleepOrInterrupted();
       }
     }


### PR DESCRIPTION
We're getting a lot of `Failed to decode transaction` errors in the e2e tests. This changeset tries to catch those errors and output the raw tx that we're trying to send, to see if we can get more info about the root cause.