### PR TITLE
chore: add tests for public processor in sequencer client

### DIFF
--- a/yarn-project/acir-simulator/src/index.test.ts
+++ b/yarn-project/acir-simulator/src/index.test.ts
@@ -5,14 +5,13 @@ import {
   ContractDeploymentData,
   FunctionData,
   NEW_COMMITMENTS_LENGTH,
-  PrivateHistoricTreeRoots,
   PRIVATE_DATA_TREE_HEIGHT,
+  PrivateHistoricTreeRoots,
   TxContext,
   TxRequest,
 } from '@aztec/circuits.js';
 import { AztecAddress, EthAddress, Fr } from '@aztec/foundation';
 import { AppendOnlyTree, Pedersen, StandardTree, newTree } from '@aztec/merkle-tree';
-import { FunctionAbi } from '@aztec/noir-contracts';
 import { ChildAbi, ParentAbi, TestContractAbi, ZkTokenContractAbi } from '@aztec/noir-contracts/examples';
 import { mock } from 'jest-mock-extended';
 import { default as levelup } from 'levelup';

--- a/yarn-project/acir-simulator/src/public/execution.ts
+++ b/yarn-project/acir-simulator/src/public/execution.ts
@@ -1,15 +1,16 @@
 import { CallContext, FunctionData, StateRead, StateTransition, TxRequest } from '@aztec/circuits.js';
 import { AztecAddress, EthAddress, Fr } from '@aztec/foundation';
 import { createDebugLogger } from '@aztec/foundation/log';
-import { FunctionAbi } from '@aztec/noir-contracts';
+import { select_return_flattened as selectPublicWitnessFlattened } from '@noir-lang/noir_util_wasm';
 import { acvm, fromACVMField, toACVMField, toACVMWitness } from '../acvm/index.js';
 import { PublicDB } from './db.js';
-import { select_return_flattened as selectPublicWitnessFlattened } from '@noir-lang/noir_util_wasm';
 import { StateActionsCollector } from './state_actions.js';
 
+export interface PublicFunctionBytecode {
+  bytecode: Buffer;
+}
+
 export interface PublicExecutionResult {
-  acir: Buffer;
-  vk: Buffer;
   returnValues: Fr[];
   stateReads: StateRead[];
   stateTransitions: StateTransition[];
@@ -31,7 +32,7 @@ function getInitialWitness(args: Fr[], callContext: CallContext, witnessStartInd
 export class PublicExecution {
   constructor(
     public readonly db: PublicDB,
-    public readonly abi: FunctionAbi,
+    public readonly publicFunction: PublicFunctionBytecode,
     public readonly contractAddress: AztecAddress,
     public readonly functionData: FunctionData,
     public readonly args: Fr[],
@@ -43,7 +44,7 @@ export class PublicExecution {
   static fromTransactionRequest(
     db: PublicDB,
     request: TxRequest,
-    entryPointABI: FunctionAbi,
+    bytecode: PublicFunctionBytecode,
     portalContractAddress: EthAddress,
   ) {
     const contractAddress = request.to;
@@ -55,14 +56,14 @@ export class PublicExecution {
       false,
       false,
     );
-    return new this(db, entryPointABI, contractAddress, request.functionData, request.args, callContext);
+    return new this(db, bytecode, contractAddress, request.functionData, request.args, callContext);
   }
 
   public async run(): Promise<PublicExecutionResult> {
     const selectorHex = this.functionData.functionSelector.toString('hex');
     this.log(`Executing public external function ${this.contractAddress.toShortString()}:${selectorHex}`);
 
-    const acir = Buffer.from(this.abi.bytecode, 'hex');
+    const acir = this.publicFunction.bytecode;
     const initialWitness = getInitialWitness(this.args, this.callContext);
     const stateActions = new StateActionsCollector(this.db, this.contractAddress);
 
@@ -92,12 +93,9 @@ export class PublicExecution {
     });
 
     const returnValues = selectPublicWitnessFlattened(acir, partialWitness).map(fromACVMField);
-    const vk = Buffer.from(this.abi.verificationKey!, 'hex');
     const [stateReads, stateTransitions] = stateActions.collect();
 
     return {
-      acir,
-      vk,
       stateReads,
       stateTransitions,
       returnValues,

--- a/yarn-project/acir-simulator/src/public/index.test.ts
+++ b/yarn-project/acir-simulator/src/public/index.test.ts
@@ -56,7 +56,8 @@ describe('ACIR public execution simulator', () => {
         const previousBalance = new Fr(20n);
         oracle.storageRead.mockResolvedValue(previousBalance);
 
-        const execution = new PublicExecution(oracle, abi, contractAddress, functionData, args, callContext);
+        const bytecode = { bytecode: Buffer.from(abi.bytecode, 'hex') };
+        const execution = new PublicExecution(oracle, bytecode, contractAddress, functionData, args, callContext);
         const result = await execution.run();
 
         const expectedBalance = new Fr(160n);
@@ -119,7 +120,8 @@ describe('ACIR public execution simulator', () => {
         const recipientBalance = new Fr(20n);
         mockStore(senderBalance, recipientBalance);
 
-        const execution = new PublicExecution(oracle, abi, contractAddress, functionData, args, callContext);
+        const bytecode = { bytecode: Buffer.from(abi.bytecode, 'hex') };
+        const execution = new PublicExecution(oracle, bytecode, contractAddress, functionData, args, callContext);
         const result = await execution.run();
 
         const expectedRecipientBalance = new Fr(160n);
@@ -143,7 +145,8 @@ describe('ACIR public execution simulator', () => {
         const recipientBalance = new Fr(20n);
         mockStore(senderBalance, recipientBalance);
 
-        const execution = new PublicExecution(oracle, abi, contractAddress, functionData, args, callContext);
+        const bytecode = { bytecode: Buffer.from(abi.bytecode, 'hex') };
+        const execution = new PublicExecution(oracle, bytecode, contractAddress, functionData, args, callContext);
         const result = await execution.run();
 
         expect(result.returnValues).toEqual([recipientBalance]);

--- a/yarn-project/circuits.js/src/tests/factories.ts
+++ b/yarn-project/circuits.js/src/tests/factories.ts
@@ -16,14 +16,15 @@ import {
   PreviousRollupData,
   PrivateCallData,
   PrivateCircuitPublicInputs,
-  PrivateKernelInputs,
   PrivateHistoricTreeRoots,
+  PrivateKernelInputs,
+  PublicCircuitPublicInputs,
+  PublicDataRead,
+  PublicDataWrite,
   RootRollupInputs,
   RootRollupPublicInputs,
   StateRead,
   StateTransition,
-  PublicDataWrite,
-  PublicDataRead,
 } from '../index.js';
 import { AggregationObject } from '../structs/aggregation_object.js';
 import { PrivateCallStackItem } from '../structs/call_stack_item.js';
@@ -144,6 +145,33 @@ export function makeAggregationObject(seed = 1): AggregationObject {
     new AffineElement(new Fq(BigInt(seed + 0x100)), new Fq(BigInt(seed + 0x101))),
     range(4, seed + 2).map(fr),
     range(6, seed + 6),
+  );
+}
+
+export function makeCallContext(seed = 0): CallContext {
+  return new CallContext(
+    makeAztecAddress(seed),
+    makeAztecAddress(seed + 1),
+    makeEthAddress(seed + 2),
+    false,
+    false,
+    false,
+  );
+}
+
+export function makePublicCircuitPublicInputs(seed = 0): PublicCircuitPublicInputs {
+  const frArray = (num: number, seed: number) => range(num, seed).map(fr);
+  return new PublicCircuitPublicInputs(
+    makeCallContext(seed),
+    frArray(ARGS_LENGTH, seed + 0x100),
+    frArray(RETURN_VALUES_LENGTH, seed + 0x200),
+    frArray(EMITTED_EVENTS_LENGTH, seed + 0x300),
+    range(STATE_TRANSITIONS_LENGTH, seed + 0x400).map(makeStateTransition),
+    range(STATE_READS_LENGTH, seed + 0x500).map(makeStateRead),
+    frArray(PUBLIC_CALL_STACK_LENGTH, seed + 0x600),
+    frArray(L1_MSG_STACK_LENGTH, seed + 0x700),
+    fr(seed + 0x800),
+    makeAztecAddress(seed + 0x801),
   );
 }
 

--- a/yarn-project/foundation/src/eth-address/index.ts
+++ b/yarn-project/foundation/src/eth-address/index.ts
@@ -1,5 +1,5 @@
 import { keccak256String, randomBytes } from '../crypto/index.js';
-import { BufferReader } from '../index.js';
+import { BufferReader, Fr } from '../index.js';
 
 /**
  * Represents an Ethereum address as a 20-byte buffer and provides various utility methods
@@ -195,6 +195,15 @@ export class EthAddress {
     const buffer = Buffer.alloc(32);
     this.buffer.copy(buffer, 12);
     return buffer;
+  }
+
+  /**
+   * Returns a new field with the same contents as this EthAddress.
+   *
+   * @returns An Fr instance.
+   */
+  public toField() {
+    return Fr.fromBuffer(this.toBuffer32());
   }
 
   /**

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -43,6 +43,7 @@
     "@aztec/world-state": "workspace:^",
     "lodash.chunk": "^4.2.0",
     "lodash.flatmap": "^4.5.0",
+    "lodash.pick": "^4.4.0",
     "lodash.times": "^4.3.2",
     "tslib": "^2.4.0"
   },
@@ -52,6 +53,7 @@
     "@types/jest": "^29.5.0",
     "@types/lodash.chunk": "^4.2.7",
     "@types/lodash.flatmap": "^4.5.7",
+    "@types/lodash.pick": "^4.4.7",
     "@types/lodash.times": "^4.3.7",
     "@types/node": "^18.7.23",
     "concurrently": "^7.6.0",

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -5,7 +5,7 @@ import { CircuitBlockBuilder } from '../block_builder/circuit_block_builder.js';
 import { SequencerClientConfig } from '../config.js';
 import { getL1Publisher, getVerificationKeys, Sequencer } from '../index.js';
 import { EmptyPublicProver, EmptyRollupProver } from '../prover/empty.js';
-import { MockPublicProcessor } from '../sequencer/public_processor.js';
+import { MockContractDataSource, MockPublicProcessor } from '../sequencer/public_processor.js';
 import { FakePublicCircuitSimulator } from '../simulator/fake_public.js';
 import { MockPublicKernelCircuitSimulator } from '../simulator/mock_public_kernel.js';
 import { WasmCircuitSimulator } from '../simulator/wasm.js';
@@ -37,6 +37,7 @@ export class SequencerClient {
       new FakePublicCircuitSimulator(merkleTreeDb),
       new MockPublicKernelCircuitSimulator(),
       new EmptyPublicProver(),
+      new MockContractDataSource(),
     );
 
     const sequencer = new Sequencer(

--- a/yarn-project/sequencer-client/src/mocks/tx.ts
+++ b/yarn-project/sequencer-client/src/mocks/tx.ts
@@ -1,6 +1,6 @@
 import { KernelCircuitPublicInputs, UInt8Vector } from '@aztec/circuits.js';
-import { makeKernelPublicInputs } from '@aztec/circuits.js/factories';
-import { PrivateTx, Tx, UnverifiedData } from '@aztec/types';
+import { makeKernelPublicInputs, makeSignedTxRequest } from '@aztec/circuits.js/factories';
+import { PrivateTx, PublicTx, Tx, UnverifiedData } from '@aztec/types';
 
 function makeEmptyProof() {
   return new UInt8Vector(Buffer.alloc(0));
@@ -17,4 +17,8 @@ export function makeEmptyPrivateTx(): PrivateTx {
 
 export function makePrivateTx(seed = 0): PrivateTx {
   return Tx.createPrivate(makeKernelPublicInputs(seed), makeEmptyProof(), UnverifiedData.random(2));
+}
+
+export function makePublicTx(seed = 0): PublicTx {
+  return Tx.createPublic(makeSignedTxRequest(seed));
 }

--- a/yarn-project/sequencer-client/src/sequencer/public_processor.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/public_processor.test.ts
@@ -1,0 +1,88 @@
+import { PUBLIC_DATA_TREE_HEIGHT, makeEmptyProof } from '@aztec/circuits.js';
+import { makeEthAddress, makeKernelPublicInputs, makePublicCircuitPublicInputs } from '@aztec/circuits.js/factories';
+import { EthAddress } from '@aztec/foundation';
+import { SiblingPath } from '@aztec/merkle-tree';
+import { MerkleTreeOperations, TreeInfo } from '@aztec/world-state';
+import { MockProxy, mock } from 'jest-mock-extended';
+import pick from 'lodash.pick';
+import times from 'lodash.times';
+import { makePrivateTx, makePublicTx } from '../index.js';
+import { Proof, PublicProver } from '../prover/index.js';
+import { PublicCircuitSimulator, PublicKernelCircuitSimulator } from '../simulator/index.js';
+import { ContractDataSource, PublicProcessor } from './public_processor.js';
+
+describe('public_processor', () => {
+  let db: MockProxy<MerkleTreeOperations>;
+  let publicCircuit: MockProxy<PublicCircuitSimulator>;
+  let publicKernel: MockProxy<PublicKernelCircuitSimulator>;
+  let publicProver: MockProxy<PublicProver>;
+  let contractDataSource: MockProxy<ContractDataSource>;
+
+  let proof: Proof;
+  let root: Buffer;
+  let bytecode: Buffer;
+  let portalAddress: EthAddress;
+
+  let processor: PublicProcessor;
+
+  beforeEach(() => {
+    db = mock<MerkleTreeOperations>();
+    publicCircuit = mock<PublicCircuitSimulator>();
+    publicKernel = mock<PublicKernelCircuitSimulator>();
+    publicProver = mock<PublicProver>();
+    contractDataSource = mock<ContractDataSource>();
+
+    proof = makeEmptyProof();
+    root = Buffer.alloc(32, 5);
+    bytecode = Buffer.alloc(128, 10);
+    portalAddress = makeEthAddress();
+
+    publicProver.getPublicCircuitProof.mockResolvedValue(proof);
+    publicProver.getPublicKernelCircuitProof.mockResolvedValue(proof);
+    db.getTreeInfo.mockResolvedValue({ root } as TreeInfo);
+    contractDataSource.getPortalContractAddress.mockResolvedValue(portalAddress);
+    contractDataSource.getPublicFunction.mockResolvedValue({ bytecode });
+
+    processor = new PublicProcessor(db, publicCircuit, publicKernel, publicProver, contractDataSource);
+  });
+
+  it('skips non-public txs', async function () {
+    const tx = makePrivateTx();
+    const hash = await tx.getTxHash();
+    const [processed, failed] = await processor.process([tx]);
+
+    expect(processed).toEqual([{ hash, ...pick(tx, 'data', 'proof', 'unverifiedData') }]);
+    expect(failed).toEqual([]);
+  });
+
+  it('returns failed txs without aborting entire operation', async function () {
+    publicCircuit.publicCircuit.mockRejectedValue(new Error(`Failed`));
+
+    const tx = makePublicTx();
+    const [processed, failed] = await processor.process([tx]);
+
+    expect(processed).toEqual([]);
+    expect(failed).toEqual([tx]);
+  });
+
+  it('runs a public tx through the public and public kernel circuits', async function () {
+    const publicCircuitOutput = makePublicCircuitPublicInputs();
+    publicCircuit.publicCircuit.mockResolvedValue(publicCircuitOutput);
+
+    const path = times(PUBLIC_DATA_TREE_HEIGHT, i => Buffer.alloc(32, i));
+    db.getSiblingPath.mockResolvedValue(new SiblingPath(path));
+
+    const output = makeKernelPublicInputs();
+    publicKernel.publicKernelCircuitNoInput.mockResolvedValue(output);
+
+    const tx = makePublicTx();
+    const hash = await tx.getTxHash();
+    const [processed, failed] = await processor.process([tx]);
+
+    expect(processed).toEqual([{ hash, data: output, proof, ...pick(tx, 'txRequest') }]);
+    expect(failed).toEqual([]);
+
+    expect(publicCircuit.publicCircuit).toHaveBeenCalled();
+    expect(publicKernel.publicKernelCircuitNoInput).toHaveBeenCalled();
+  });
+});

--- a/yarn-project/sequencer-client/src/simulator/fake_public.ts
+++ b/yarn-project/sequencer-client/src/simulator/fake_public.ts
@@ -1,7 +1,6 @@
-import { PublicDB, PublicExecution } from '@aztec/acir-simulator';
+import { PublicDB, PublicExecution, PublicFunctionBytecode } from '@aztec/acir-simulator';
 import { BarretenbergWasm } from '@aztec/barretenberg.js/wasm';
 import { AztecAddress, EthAddress, Fr, PublicCircuitPublicInputs, TxRequest } from '@aztec/circuits.js';
-import { FunctionAbi } from '@aztec/noir-contracts';
 import { MerkleTreeId, MerkleTreeOperations, computePublicDataTreeLeafIndex } from '@aztec/world-state';
 import { PublicCircuitSimulator } from './index.js';
 
@@ -12,14 +11,15 @@ export class FakePublicCircuitSimulator implements PublicCircuitSimulator {
     this.db = new WorldStatePublicDB(this.merkleTree);
   }
 
-  public async publicCircuit(tx: TxRequest): Promise<PublicCircuitPublicInputs> {
-    const functionAbi: FunctionAbi = undefined as any;
-    const portalAddress: EthAddress = undefined as any;
-
+  public async publicCircuit(
+    tx: TxRequest,
+    functionBytecode: PublicFunctionBytecode,
+    portalAddress: EthAddress,
+  ): Promise<PublicCircuitPublicInputs> {
     const publicDataTreeInfo = await this.merkleTree.getTreeInfo(MerkleTreeId.PUBLIC_DATA_TREE);
     const historicPublicDataTreeRoot = Fr.fromBuffer(publicDataTreeInfo.root);
 
-    const execution = PublicExecution.fromTransactionRequest(this.db, tx, functionAbi, portalAddress);
+    const execution = PublicExecution.fromTransactionRequest(this.db, tx, functionBytecode, portalAddress);
     const result = await execution.run();
     return PublicCircuitPublicInputs.from({
       args: tx.args,

--- a/yarn-project/sequencer-client/src/simulator/index.ts
+++ b/yarn-project/sequencer-client/src/simulator/index.ts
@@ -1,6 +1,8 @@
+import { PublicFunctionBytecode } from '@aztec/acir-simulator';
 import {
   BaseOrMergeRollupPublicInputs,
   BaseRollupInputs,
+  EthAddress,
   MergeRollupInputs,
   PublicCircuitPublicInputs,
   PublicKernelInputsNoKernelInput,
@@ -19,7 +21,11 @@ export interface RollupSimulator {
 }
 
 export interface PublicCircuitSimulator {
-  publicCircuit(tx: TxRequest): Promise<PublicCircuitPublicInputs>;
+  publicCircuit(
+    tx: TxRequest,
+    functionBytecode: PublicFunctionBytecode,
+    portalAddress: EthAddress,
+  ): Promise<PublicCircuitPublicInputs>;
 }
 
 export interface PublicKernelCircuitSimulator {

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -522,6 +522,7 @@ __metadata:
     "@types/jest": ^29.5.0
     "@types/lodash.chunk": ^4.2.7
     "@types/lodash.flatmap": ^4.5.7
+    "@types/lodash.pick": ^4.4.7
     "@types/lodash.times": ^4.3.7
     "@types/node": ^18.7.23
     concurrently: ^7.6.0
@@ -530,6 +531,7 @@ __metadata:
     jest-mock-extended: ^3.0.3
     lodash.chunk: ^4.2.0
     lodash.flatmap: ^4.5.0
+    lodash.pick: ^4.4.0
     lodash.times: ^4.3.2
     prettier: ^2.8.7
     ts-jest: ^29.1.0
@@ -2164,6 +2166,15 @@ __metadata:
   dependencies:
     "@types/lodash": "*"
   checksum: 2bcccdd30bcb06a400b37a2b731f194f6b11ae49467a98828d86e25dbd10055f8b033c7741755a41de7bc50f49e387ecec952f9871863f77c79582e891945486
+  languageName: node
+  linkType: hard
+
+"@types/lodash.pick@npm:^4.4.7":
+  version: 4.4.7
+  resolution: "@types/lodash.pick@npm:4.4.7"
+  dependencies:
+    "@types/lodash": "*"
+  checksum: 78428a83b5d85e75bd13fb632030f9adb08dfc5bde3a9b6a302434fe7ac98e62919f87a7337e0ba674017d63bc57a8855ef863f5fcecd25e63b1d39eba2e4697
   languageName: node
   linkType: hard
 
@@ -5718,6 +5729,13 @@ __metadata:
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
+  languageName: node
+  linkType: hard
+
+"lodash.pick@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "lodash.pick@npm:4.4.0"
+  checksum: 2c36cab7da6b999a20bd3373b40e31a3ef81fa264f34a6979c852c5bc8ac039379686b27380f0cb8e3781610844fafec6949c6fbbebc059c98f8fa8570e3675f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Simplify API of the public executor in the acir simulator
- Introduce temporary contract data source interface and uses it to retrieve bytecode when needed
- Add simple tests for the public processor in the sequencer client