### PR TITLE
use archiver for ContractDataSource in sequencer

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/aztec-node.ts
+++ b/yarn-project/aztec-node/src/aztec-node/aztec-node.ts
@@ -55,7 +55,7 @@ export class AztecNode {
     await Promise.all([p2pClient.start(), worldStateSynchroniser.start()]);
 
     // now create the sequencer
-    const sequencer = await SequencerClient.new(config, p2pClient, worldStateSynchroniser);
+    const sequencer = await SequencerClient.new(config, p2pClient, worldStateSynchroniser, archiver);
     return new AztecNode(p2pClient, archiver, archiver, archiver, merkleTreeDB, worldStateSynchroniser, sequencer);
   }
 

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -5,10 +5,11 @@ import { CircuitBlockBuilder } from '../block_builder/circuit_block_builder.js';
 import { SequencerClientConfig } from '../config.js';
 import { getL1Publisher, getVerificationKeys, Sequencer } from '../index.js';
 import { EmptyPublicProver, EmptyRollupProver } from '../prover/empty.js';
-import { MockContractDataSource, MockPublicProcessor } from '../sequencer/public_processor.js';
+import { MockPublicProcessor } from '../sequencer/public_processor.js';
 import { FakePublicCircuitSimulator } from '../simulator/fake_public.js';
 import { MockPublicKernelCircuitSimulator } from '../simulator/mock_public_kernel.js';
 import { WasmCircuitSimulator } from '../simulator/wasm.js';
+import { ContractDataSource } from '@aztec/types';
 
 /**
  * Encapsulates the full sequencer and publisher.
@@ -20,6 +21,7 @@ export class SequencerClient {
     config: SequencerClientConfig,
     p2pClient: P2P,
     worldStateSynchroniser: WorldStateSynchroniser,
+    contractDataSource: ContractDataSource,
   ) {
     const publisher = getL1Publisher(config);
     const merkleTreeDb = worldStateSynchroniser.getLatest();
@@ -37,7 +39,7 @@ export class SequencerClient {
       new FakePublicCircuitSimulator(merkleTreeDb),
       new MockPublicKernelCircuitSimulator(),
       new EmptyPublicProver(),
-      new MockContractDataSource(),
+      contractDataSource,
     );
 
     const sequencer = new Sequencer(

--- a/yarn-project/sequencer-client/src/sequencer/public_processor.ts
+++ b/yarn-project/sequencer-client/src/sequencer/public_processor.ts
@@ -9,36 +9,14 @@ import {
   PublicKernelPublicInputs,
   TxRequest,
 } from '@aztec/circuits.js';
-import {
-  CompleteContractData,
-  ContractData,
-  ContractDataSource,
-  EncodedContractFunction,
-  PublicTx,
-  Tx,
-} from '@aztec/types';
+import { ContractDataSource, PublicTx, Tx } from '@aztec/types';
 import { MerkleTreeOperations } from '@aztec/world-state';
 import { pedersenGetHash } from '@aztec/barretenberg.js/crypto';
-import { AztecAddress, createDebugLogger } from '@aztec/foundation';
+import { createDebugLogger } from '@aztec/foundation';
 import times from 'lodash.times';
 import { Proof, PublicProver } from '../prover/index.js';
 import { PublicCircuitSimulator, PublicKernelCircuitSimulator } from '../simulator/index.js';
 import { ProcessedTx, makeEmptyProcessedTx, makeProcessedTx } from './processed_tx.js';
-
-export class MockContractDataSource implements ContractDataSource {
-  getL2ContractDataInBlock(blockNum: number): Promise<ContractData[]> {
-    return Promise.resolve([]);
-  }
-  getL2ContractData(_address: AztecAddress): Promise<CompleteContractData | undefined> {
-    return Promise.resolve(undefined);
-  }
-  getL2ContractInfo(_address: AztecAddress): Promise<ContractData | undefined> {
-    return Promise.resolve(undefined);
-  }
-  getPublicFunction(_address: AztecAddress, _selector: Buffer): Promise<EncodedContractFunction | undefined> {
-    return Promise.resolve(undefined);
-  }
-}
 
 export class PublicProcessor {
   constructor(


### PR DESCRIPTION
# Description

- Remove previous `MockContractDataSource` from sequencer
- Use the archiver module as `ContractDataSource`

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
