### PR TITLE
feat: clang format & tidy + CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,17 @@ jobs:
           name: "Build"
           command: cond_spot_run_build circuits-wasm-linux-clang-assert 64
 
+  circuits-x86_64-linux-clang-tidy:
+    docker:
+      - image: aztecprotocol/alpine-build-image
+    resource_class: small
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Build"
+          command: cond_spot_run_build circuits-x86_64-linux-clang-tidy 64
+
   circuits-x86_64-linux-clang:
     docker:
       - image: aztecprotocol/alpine-build-image
@@ -420,6 +431,7 @@ workflows:
     jobs:
       - circuits-wasm-linux-clang: *defaults
       - circuits-wasm-linux-clang-assert: *defaults
+      - circuits-x86_64-linux-clang-tidy: *defaults
       - circuits-x86_64-linux-clang: *defaults
       - circuits-x86_64-linux-clang-assert: *defaults
       - circuits-wasm-tests:

--- a/build_manifest.json
+++ b/build_manifest.json
@@ -15,6 +15,14 @@
     ],
     "dependencies": []
   },
+  "circuits-x86_64-linux-clang-tidy": {
+    "buildDir": "circuits/cpp",
+    "dockerfile": "dockerfiles/Dockerfile.x86_64-linux-clang-tidy",
+    "rebuildPatterns": [
+      "^circuits/"
+    ],
+    "dependencies": []
+  },
   "circuits-x86_64-linux-clang": {
     "buildDir": "circuits/cpp",
     "dockerfile": "dockerfiles/Dockerfile.x86_64-linux-clang",

--- a/circuits/CODING_STANDARD.md
+++ b/circuits/CODING_STANDARD.md
@@ -1,0 +1,295 @@
+## C++ Standard for Aztec Circuits
+
+### Sticking to the Standard
+
+Read the standards and stick to them! There is some automation to help with this, but the automation is far from comprehensive.
+
+Here are the types of automation that should help stick to the standard:
+1. The VSCode workspace file `circuits.code-workspace` is configured to automatically format your code nicely when you save a C++ file.
+    * It uses `cpp/.clang-format` for this
+2. These workspace settings are also configured to warn you (with yellow squiggles) when something does not follow some of the rules.
+    * It uses `cpp/.clangd` for this
+3. To perform some auto-tidying of your code, run `./scripts/tidy.sh fix && ./format.sh` from `cpp/`
+    * This will run `clang-tidy` and `clang-format` on all C++ source files
+    * It uses `cpp/.clang-tidy` and `cpp/.clang-format`
+    * This will take a while
+
+### The Standard
+
+1. **general**
+    * when something is not covered below, fall back to [Google's style guide](https://google.github.io/styleguide
+/cppguide.html)
+    *  all TODOs should mention a username, email or bug number
+        ```
+        // TODO(dbanks12)
+        // TODO(david@aztecprotocol.com)
+        // TODO(bug 12345)
+        ```
+1. **spacing**
+    *  4 spaces except for access-specifiers (`public`/`protected`/`private`) which can use 2
+    *  namespaces are not indented
+    *  for continued indentation, just be sane
+    *  remove trailing spaces at end of line (use a plugin)
+    *  include a newline at the end of a file
+        ```
+        namespace my_namespace {
+        class MyClass {
+          public:
+            // ... public stuff
+
+          protected:
+            // ... protected stuff
+
+          private:
+            // ... private stuff
+
+            void my_private_function0(int arg0,
+                                      int arg1)
+            {
+                // ...
+            }
+
+            void my_private_function1(
+                int arg0,
+                int arg1)
+            {
+                // ...
+            }
+        }
+        } // namespace my_namespace
+
+        ```
+1. **braces**
+    *  functions use curly brace alone on newline
+    *  namespaces, classes, structs, enums, ifs, and loops use curely brace on same line
+    * examples
+        ```
+        void my_function()
+        {
+            // ...
+        }
+
+        for (int i = 0; i < max; i++) {
+            // ...
+        }
+
+        if (something_is_true) {
+            // ...
+        }
+
+        struct MyStruct {
+            // ...
+        }
+        ```
+1.  **naming**
+    *  `snake_case` for files, namespaces and local variables/members
+    *  `CamelCase` for classes, structs, enums, types
+        *  exceptions types can be made for types if trying to mimic a std type's name like `uint` or `field_ct`
+    *  `ALL_CAPS` for `constexpr`s, global constants, and macros
+    *  do use
+        *  Clear names
+        *  Descriptive names
+    *  don't use
+        *  abbreviations
+        *  words with letters removed
+        *  acronyms
+        *  single letter names
+            *  Unless writing maths, in which case use your best judgement and follow the naming of a _linked_ paper
+1.  `auto`
+    *  include `*`, `&`, and/or `const` even when using `auto`
+    *  use when type is evident
+    *  use when type should be deduced automatically based on expr
+    *  use in loops to iterate over members of a container
+    *  don't use if it makes type unclear
+    *  don't use you need to enforce a type
+    * examples
+        ```
+        auto my_var = my_function_with_unclear_return_type(); // BAD
+        auto my_var = get_new_of_type_a(); // GOOD
+        ```
+1.  `const` and `constexpr`
+    *  use `const` whenever possible to express immutability
+    *  use `constexpr` whenever a `const` can be computed at compile-time
+    *  place `const`/`constexpr` BEFORE the core type as is done in bberg stdlib
+    * examples
+        ```
+        const int my_const = 0;
+        constexpr int MY_CONST = 0;
+        ```
+1.  `namespace` and `using`
+    *  never do `using namespace my_namespace;` which causes namespace pollution and reduces readability
+        *  [see here for google's corresponding rule](https://clang.llvm.org/extra/clang-tidy/checks/google/build-using-namespace.html)
+    *  avoid doing `typedef my::OldType NewType` and instead do `using NewType = my::OldType`
+    *  namespaces should exactly match directory structure. If you create a nested namespace, create a nested directory for it
+    *  example for directory `aztec3/circuits/abis/private_kernel`:
+        ```
+        namespace aztec3::circuits::abis::private_kernel {
+            // ...
+        } // namespace aztec3::circuits::abis::private_kernel
+        ```
+    *  use`init.hpp` *only* for core/critical renames like `NT/CT` and for toggling core types like `Composer`
+    *  use unnamed/anonymous namespaces to import and shorten external names into *just this one file*
+        *  all of a file's external imports belong in a single anonymous namespace `namespace { ...\n } // namespace` at the very top of the file directly after `#include`s
+        *  use `using Rename = old::namespace::prefix::Name;` to import and shorten names from external namespaces
+        *  avoid using renames to obscure template params (`using A = A<NT>;`)
+        *  never use renames to remove the `std::` prefix
+        *  never use renames to remove a `NT::` or `CT::` prefix
+    *  `test.cpp` tests must always explicitly import every single name they intend to use
+        *  they might want to test over multiple namespaces, native and circuit types, and composer types
+    *  avoid calling barretenberg's functions directly and instead go through interface files like `circuit_types` and 
+`native_types`
+    *  `using` statements should be sorted case according to the `LexicographicNumeric` rules
+        *   see the `SortUsingDeclarations` section of the [LLVM Clang Format Style Options document](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)
+    *  if your IDE is telling you that an include or name is unused in a file, remove it!
+1.  **includes**
+    * start every header with `#pragma once`
+    * `index.hpp` should include common headers that will be referenced by most cpp/hpp files in the current directory
+    * `init.hpp` should inject ONLY critical renames (like `NT`/`CT`) and type toggles (like Composer)
+        * example `using NT = aztec3::utils::types::NativeTypes;`
+    *  avoid including headers via relative paths (`../../other_dir`) unless they are a subdir (`subdir/header.hpp`)
+        *  use full path like `aztec3/circuits/hash.hpp`
+    * ordering of includes
+        * this source file's header
+        * essentials (if present)
+          * `"index.hpp"`
+          * `"init.hpp"`
+        * headers nearby
+            * headers from this directory (no `/`)
+            * headers from this project using relative path (`"private/private_kernel_inputs.hpp"`)
+            * Note: headers in this group are sorted in the above order (no `/` first, relative paths second)
+        * headers from this project using full path (starts with aztec3: `"aztec3/constants.hpp"`)
+        * barretenberg headers
+        * `<gtest>` or other third party headers specified in `.clang-format`
+        * C++ standard library headers
+    * use quotes internal headers
+    * use angle braces for std library and external library headers
+        * this includes barretenberg
+    * each group of includes should be sorted case sensitive alphabetically
+    * each group of includes should be newline-separated
+    * example:
+        ```
+        #include "this_file.hpp"
+
+        #include "index.hpp"
+        #include "init.hpp"
+
+        #include "my_file_a_in_this_dir.hpp"
+        #include "my_file_b_in_this_dir.hpp"
+        #include "other_dir/file_a_nearby.hpp"
+        #include "other_dir/file_b_nearby.hpp"
+
+        #include "aztec3/file_a_in_project.hpp"
+        #include "aztec3/file_b_in_project.hpp"
+
+        #include <barretenberg/file_a.hpp>
+        #include <barretenberg/file_b.hpp>
+
+        #include <gtest>
+
+        #include <vector>
+        #include <iostream>
+        ``` 
+1.  **access specifiers**
+    *  order them `public`, `protected`, `private`
+1.  **struct and array initialization**
+    *  use `MyStruct my_inst{};`
+        *  will call default constructor if exists and otherwise will value-initialize members to zero (or will call *their* default constructors if they exist)
+    *  explicitly initialize struct members with default values: `NT::fr my_fr = 0;`
+    *  initialize arrays using `std::array<T, 8> my_arr{};`
+        *  this value-initializes all entries to 0 if T has no default constructor, otherwise calls default constructor for each
+    *  arrays of fields/`fr` are different! Use `zero_array` helper function for initialization
+        *  `std::array<fr, VK_TREE_HEIGHT> vk_path = zero_array<fr, VK_TREE_HEIGHT>();`
+        *  This is necessary because `fr` *does* have a default constructor that intentionally does *not* intialize its members to 0
+1.  **references**
+    *  use them whenever possible for function arguments since pass by reference is cheaper
+    *  make arg references "const" if they should not be modified inside a function
+1.  **avoid C-style coding**
+    *  avoid `malloc/free`
+    *  use `std::array/vector` instead of `int[]`
+    *  use references instead of pointers when possible
+    *  if pointers are necessary, use smart pointers (`std::unique_ptr/shared_ptr`) instead of raw pointers
+    *  avoid C-style casts (use `static_cast` or `reinterpret_cast`)
+1.  **comments**
+    * use doxygen docstrings (will include format example)
+        ```
+        /**
+         * @brief Brief description
+         * @details more details
+         * @tparam mytemplateparam description
+         * @param myfunctionarg description
+         * @return describe return value
+         * @see otherRelevantFunction()
+         * @see [mylink](url)
+         */
+        ```
+    *  every file should have a meaningful comment
+    *  every class/struct/function/test should have a meaningful comment
+        *  class/struct comment might == file comment
+    *  comment function preconditions ("arg x must be < 100")
+1.  **side-effects**
+    *  avoid functions with side effects when it is easy enough to just have pure functions
+    *  if a function modifies its arguments, it should be made very clear that this is happening
+        *  same with class methods that modify members
+    *  function arguments should be `const` when they will not be modified
+1. **global state**
+    * no
+1.  **docs**
+    *  every subdir should have a readme
+1.  **functions**
+    *  use `[[nodiscard]]` if it makes no sense to call this function and discard return value
+        ```
+        [[nodiscard] int my_function()
+        {
+            // ...
+            return some_int;
+        }
+
+        // later can't do
+        my_function();
+
+        // can only do
+        int capture_ret = my_function();
+        ```
+    *  if there is a name clash, prefix parameter with underscore like `_myparam`
+        ```
+        void my_function(int _my_var)
+        {
+            my_var = _my_var;
+        }
+        ```
+1.  **macros**
+    *  avoid macros as much as possible with exceptions for
+        *  testing
+        *  debug utilities
+        *  agreed upon macro infrastructure (like cbinds)
+1.  **misc**
+    *  use `uintN_t` instead of a primitive type (e.g. `size_t`) when a specific type width must be guaranteed
+    *  avoid signed types (`int`, `long`, `char` etc) unless signedness is required
+        *  signed types are susceptible to undefined behavior on overflow/underflow
+    *  initialize pointers to `nullptr`
+    *  constructors with single arguments should be marked `explicit` to prevent unwanted conversions
+    *  if a constructor is meant to do nothing, do `A() = default;` instead of `A(){}` ([explanation here](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-default.html))
+        *  definitely don't do `A(){};` (with semicolon) which can't even be auto-fixed by `clang-tidy`
+    *  explicitly use `override` when overriding a parent class' member ([explanation here](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-override.html))
+    *  avoid multiple declarations on the same line
+        *  do:
+            ```
+            int a = 0;
+            int b = 0;
+            ```
+        *  dont:
+            ```
+            int a, b = 0, 0;
+            ```
+    *  use `std::vector::emplace_back` instead of `push_back`
+        *  don't use `std::make_pair` when using `emplace_back` ([unnecessary as explained here](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-emplace.html))
+    *  **no magic numbers** even if there is a comment explaining them
+
+
+## References
+
+1. [Mike's Draft C++ Standard](https://hackmd.io/@aztec-network/B1r36lhmj?type=view)
+2. [Barretenberg's `.clangd`](https://github.com/AztecProtocol/barretenberg/blob/master/cpp/.clangd)
+3. [Barretenberg's `.clang-format`](https://github.com/AztecProtocol/barretenberg/blob/master/cpp/.clang-format)
+4. [LLVM's Clang Format Style Options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)
+5. [Google's Style Guide](https://google.github.io/styleguide/cppguide.html)

--- a/circuits/CODING_STANDARD.md
+++ b/circuits/CODING_STANDARD.md
@@ -2,29 +2,40 @@
 
 ### Sticking to the Standard
 
-Read the standards and stick to them! There is some automation to help with this, but the automation is far from comprehensive.
+Read the standards and stick to them! There is some automation to help with this, but **the automation is far from comprehensive**.
 
 Here are the types of automation that should help stick to the standard:
 1. The VSCode workspace file `circuits.code-workspace` is configured to automatically format your code nicely when you save a C++ file.
     * It uses `cpp/.clang-format` for this
 2. These workspace settings are also configured to warn you (with yellow squiggles) when something does not follow some of the rules.
     * It uses `cpp/.clangd` for this
-3. To perform some auto-tidying of your code, run `./scripts/tidy.sh fix && ./format.sh` from `cpp/`
-    * This will run `clang-tidy` and `clang-format` on all C++ source files
-    * It uses `cpp/.clang-tidy` and `cpp/.clang-format`
-    * This will take a while
+3. A tidy check is run in CI
+    * Job fails if your code would be changed by `./scripts/tidy.sh fix`
+4. To perform some auto-tidying of your code, run `./scripts/tidy.sh fix` from `cpp/`
+    * **Commit your code first** since tidying will occasionally mess up your code!
+    * This will run `clang-tidy` on all C++ source files
+        * It uses `cpp/.clang-tidy` * and formats tidied code with `cpp/.clang-format`
+    * **Manually review any fixes to your code!**
+        * If you disagree with an auto-fix or if it is buggy, use `// NOLINT...` ([more here](https://clang.llvm.org/extra/clang-tidy/#suppressing-undesired-diagnostics))
+        * If you believe we should reject an entire class of tidy fixes, consider explicitly omitting from our checks or errors in `./clang-tidy`
+            * Discuss with others first
+    * _Note:_ tidying takes a while!
+    * **You may need to run this multiple times!**
+        * An error (with an auto-fix) in one round may prevent certain subsequent fixes
+        * A fix in the one round may introduce more potential for fixes
 
 ### The Standard
 
 1. **general**
-    * when something is not covered below, fall back to [Google's style guide](https://google.github.io/styleguide
-/cppguide.html)
+    *  when something is not covered below, fall back to [Google's style guide](https://google.github.io/styleguide/cppguide.html)
     *  all TODOs should mention a username, email or bug number
         ```
         // TODO(dbanks12)
         // TODO(david@aztecprotocol.com)
         // TODO(bug 12345)
         ```
+    *  if your editor warns you about a line of code fix it!
+        * consider doing so even if you didn't write that code
 1. **spacing**
     *  4 spaces except for access-specifiers (`public`/`protected`/`private`) which can use 2
     *  namespaces are not indented

--- a/circuits/README.md
+++ b/circuits/README.md
@@ -2,6 +2,10 @@
 
 ###### tags: `aztec-3, circuits`
 
+## Contributing
+
+See [CODING_STANDARD.md](./CODING_STANDARD.md)** before contributing!
+
 ## Repository Overview
 
 The [`aztec3-circpuits`](https://github.com/AztecProtocol/aztec3-packages) circuits folder contains circuits and related C++ code (`cpp/`) for Aztec3 along with Typescript wrappers (`ts/`).

--- a/circuits/circuits.code-workspace
+++ b/circuits/circuits.code-workspace
@@ -108,6 +108,10 @@
     //
     "clangd.path": "clangd-15",
     //
+    // LLDB
+    //
+    "lldb.dereferencePointers": true,
+    //
     // CMake
     //
     // Location of base CMakeLists file
@@ -161,11 +165,9 @@
         }
       ]
     },
-    //
-    // GTest adapter (not currently used)
-    //
     "[cpp]": {
-      "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
-    }
+      "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd",
+      "editor.formatOnSave": true,
+    },
   }
 }

--- a/circuits/cpp/.clang-format
+++ b/circuits/cpp/.clang-format
@@ -1,15 +1,81 @@
-PointerAlignment: Left
+Language: Cpp
+BasedOnStyle: Google
 ColumnLimit: 120
-BreakBeforeBraces: Allman
+
+# Whitespace
 IndentWidth: 4
-BinPackArguments: false
-BinPackParameters: false
-AllowShortFunctionsOnASingleLine: None
-Cpp11BracedListStyle: false
+UseTab: Never
+#LineEnding: LF
+MaxEmptyLinesToKeep: 2
+
+# Auto-insertions
+#InsertNewlineAtEOF: true
+#InsertTrailingCommas: true
+#InsertBraces: true
+
+# Alignment
+#ReferenceAlignment: Left
+PointerAlignment: Left
+#QualifierAlignment: Left # only in clang-format 14+
+
+# Misc spacing/linebreaks
+AccessModifierOffset: -2
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
 AlwaysBreakAfterReturnType: None
 AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakTemplateDeclarations: No
 PenaltyReturnTypeOnItsOwnLine: 1000000
 BreakConstructorInitializers: BeforeComma
+
+# Includes
+SortIncludes: true # Consider CaseSensitive in clang-format 13+
+IncludeBlocks: Regroup
+IncludeCategories:
+  # 1. Special headers
+  - Regex:           '"\(index\.hpp\)|\(init\.hpp\)"'
+    Priority:     1
+  # 2. Headers in "" with no '/' (current dir).
+  - Regex:           '"([A-Za-z0-9.\Q-_\E])+"'
+    Priority:     2
+    SortPriority: 2
+  # 2. Headers in "" that start with '../'.
+  - Regex:           '"\.\./([A-Za-z0-9.\Q-_\E])+"'
+    Priority:     2
+    SortPriority: 4 # same priority/group as 2, but sorted to bottom.
+  # 5. Aztec3 headers in "".
+  - Regex:           '["<]aztec3/([A-Za-z0-9.\Q/-_\E])+[">]'
+    Priority:     5
+  # 6. Barretenberg headers in ""
+  - Regex:           '["<]barretenberg/.*[">]'
+    Priority:     6
+  # 2. All other headers in "".
+  # Note: Must be below aztec3/barretenberg groups or it captures them too.
+  - Regex:           '"([A-Za-z0-9.\Q/-_\E])+"'
+    Priority:     2
+    SortPriority: 3 # same priority/group as 2, but sorted to middle.
+  # 6. Headers in <> with extension.
+  - Regex:           '<([A-Za-z0-9\Q/-_\E])+\.[A-Za-z0-9.\Q/-_\E]>'
+    Priority:     7
+  # 7. Headers in <> from specific external libraries.
+  - Regex:           '<(gtest|placeHolderForOthers)>'
+    Priority:     8
+  # 8. Headers in <> without extension.
+  - Regex:           '<([A-Za-z0-9\Q/-_\E])+>'
+    Priority:     9
+
+# Namespaces and using
+FixNamespaceComments: true
+NamespaceIndentation: None
+SortUsingDeclarations: true # LexicographicNumeric
+
+# Bin packing
+BinPackArguments: false
+BinPackParameters: false
+
+# Braces
+Cpp11BracedListStyle: false
+#BreakBeforeBraces: Allman
 BreakBeforeBraces: Custom
 BraceWrapping:
   AfterClass: false
@@ -24,5 +90,3 @@ BraceWrapping:
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
-AllowShortFunctionsOnASingleLine : Inline
-SortIncludes: false

--- a/circuits/cpp/.clang-tidy
+++ b/circuits/cpp/.clang-tidy
@@ -1,0 +1,137 @@
+# Note there is some overlap between this file and .clangd
+# .clangd has no concept of warnings versus errors, but since it
+# won't actually fail/error (since its really just an LSP for
+# showing issues in an editor), it is acceptable to treat most
+# .clang-tidy warnings as .clangd errors. Also, some error codes
+# with buggy-autofixes need to be omitted from checks in .clang-tidy
+# but can be included in .clangd since it won't change code without
+# a user action.
+#
+# .clang-tidy on the other hand will error in CI for any check that
+# is flagged (not explicitly omitted after '*') in WarningsAsErrors.
+# So, it needs to omit certain checks or keep them as warnings only
+# if they are too strict.
+
+Checks: '
+    cert-*,
+    google-*,
+    cppcoreguidelines-*,
+    readability-*,
+    modernize-*,
+    bugprone-*,
+    misc-*,
+    performance-*,
+    clang-analyzer-*,
+    concurrency-*,
+    portability-*,
+    -bugprone-easily-swappable-parameters,
+    -bugprone-reserved-identifier,
+    -cppcoreguidelines-non-private-member-variables-in-classes,
+    -cppcoreguidelines-pro-bounds-constant-array-index,
+    -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+    -cppcoreguidelines-pro-type-member-init,
+    -cert-dcl37-c,
+    -cert-dcl51-cpp,
+    -cert-dcl59-cpp,
+    -google-build-namespaces,
+    -google-readability-avoid-underscore-in-googletest-name,
+    -google-readability-todo,
+    -misc-non-private-member-variables-in-classes,
+    -modernize-avoid-c-arrays,
+    -modernize-pass-by-value,
+    -modernize-use-nodiscard,
+    -modernize-use-trailing-return-type,
+    -readability-identifier-length,
+    -readability-simplify-boolean-expr,
+    -readability-use-anyofallof,
+'
+
+# We treat all warnings as errors except for these few.
+# Some of these exceptions like 'google-build-using-namespace'
+# we should be able to manually fix project-wide and then
+# remove from the omissions list.
+WarningsAsErrors: '
+    *,
+    -bugprone-unchecked-optional-access,
+    -bugprone-unhandled-self-assignment,
+    -clang-analyzer-core.UndefinedBinaryOperatorResult,
+    -clang-analyzer-cplusplus.NewDeleteLeaks,
+    -clang-analyzer-optin.performance.Padding,
+    -cert-err58-cpp,
+    -cert-oop54-cpp,
+    -cppcoreguidelines-avoid-non-const-global-variables,
+    -cppcoreguidelines-avoid-magic-numbers,
+    -cppcoreguidelines-c-copy-assignment-signature,
+    -cppcoreguidelines-no-malloc,
+    -cppcoreguidelines-owning-memory,
+    -cppcoreguidelines-pro-type-cstyle-cast,
+    -cppcoreguidelines-pro-type-reinterpret-cast,
+    -cppcoreguidelines-special-member-functions,
+    -google-build-using-namespace,
+    -google-global-names-in-headers,
+    -google-readability-casting,
+    -misc-definitions-in-headers,
+    -misc-no-recursion,
+    -misc-unconventional-assign-operator,
+    -modernize-return-braced-init-list,
+    -performance-unnecessary-value-param,
+    -readability-function-cognitive-complexity,
+    -readability-magic-numbers,
+'
+
+# Notes on specific Checks and WarningsAsErrors
+#
+# These checks rename our cbinds and consts that have `__` in the name:
+#    -bugprone-reserved-identifier,
+#    -cert-dcl37-c,
+#    -cert-dcl51-cpp,
+# `any_of/all_of` loops are not objectively more readable:
+#    -readability-use-anyofallof,
+# Will need to refactor our usage of `malloc/free` with `gsl::owner`:
+#    -cppcoreguidelines-owning-memory,
+# Flags way too many functions:
+#    -bugprone-easily-swappable-parameters,
+# We use anon namespaces to import types:
+#    -google-build-namespaces,
+#    -cert-dcl59-cpp,
+# Not sure we want to use trailing return type:
+#    -modernize-use-trailing-return-type,
+# Buggy in clang-tidy 15.0.6:
+#    -modernize-use-nodiscard,
+#    ^ TODO(david): re-enable if we move to newer clang version
+# We use c-arrays in low-level code logic relating to c_bind:
+#    -modernize-avoid-c-arrays,
+# This was changing code in ways that made it harder to follow:
+#    -modernize-pass-by-value,
+#    ^ TODO(david) we probably want to re-enable this one
+# We like (a == true) in circuits:
+#    -readability-simplify-boolean-expr,
+# We have a lot of one-letter variable names...:
+#    -readability-identifier-length,
+# All of our tests use underscores in names:
+#    -google-readability-avoid-underscore-in-googletest-name,
+# All of our circuit structs have non-private members:
+#    -misc-non-private-member-variables-in-classes,
+#    -cppcoreguidelines-non-private-member-variables-in-classes,
+# We have many `for` loops that violate this part of the bounds safety profile
+#    -cppcoreguidelines-pro-bounds-constant-array-index,
+# Many hits potential for false positives:
+#    -cppcoreguidelines-pro-type-member-init,
+# Triggers on some tests that are not complex. We should re-enable this for tests:
+#    -readability-function-cognitive-complexity,
+# Triggers for globals in tests and TEST macros
+#     -cert-err58-cpp,
+# Useful but check is buggy in clang-tidy 15.0.6:
+#    -misc-const-correctness,
+#    ^ TODO(david): re-evaluate whether this one should be included here
+#                   its auto-fixes are buggy
+#                   if disabled, re-enable if fixed in newer clang version
+#
+# We should be able to fix:
+#    -google-global-names-in-headers, # using whole::namespace; is bad
+#    -google-readability-todo,  # the auto-fix for this inputs current user's name for all
+#    -cppcoreguidelines-avoid-magic-numbers, # we shouldn't use magic numbers!
+#    -readability-magic-numbers,
+
+HeaderFilterRegex: 'src/aztec3/'
+FormatStyle: file

--- a/circuits/cpp/.clang-tidy
+++ b/circuits/cpp/.clang-tidy
@@ -128,7 +128,7 @@ WarningsAsErrors: '
 #                   if disabled, re-enable if fixed in newer clang version
 #
 # We should be able to fix:
-#    -google-global-names-in-headers, # using whole::namespace; is bad
+#    -google-build-using-namespace, # using whole::namespace; is bad
 #    -google-readability-todo,  # the auto-fix for this inputs current user's name for all
 #    -cppcoreguidelines-avoid-magic-numbers, # we shouldn't use magic numbers!
 #    -readability-magic-numbers,

--- a/circuits/cpp/.clangd
+++ b/circuits/cpp/.clangd
@@ -1,0 +1,73 @@
+# Language Server Protocol for showing code problems
+# and suggesting fixes in an editor.
+#
+# See .clang-tidy comments for more information.
+
+CompileFlags:                     # Tweak the parse settings
+  Remove: -fconstexpr-ops-limit=*
+---
+# Applies all barretenberg source files
+If:
+  PathMatch: [src/.*\.hpp, src/.*\.cpp, src/.*\.tcc, src/.*\.h]
+Diagnostics:
+  # Checks whether we are including unused header files
+  # Note that some headers may be _implicitly_ used and still
+  # need to be included, so be careful before removing them.
+  UnusedIncludes: Strict
+
+  # Static analysis configuration
+  ClangTidy:
+    Add:
+      - cert-*
+      - google-*
+      - cppcoreguidelines-*
+      - readability-*
+      - modernize-*
+      - bugprone-*
+      - misc-*
+      - performance-*
+      - clang-analyzer-*
+      - concurrency-*
+      - portability-*
+    Remove:
+      # Fixing this would be a lot of work.
+      - bugprone-easily-swappable-parameters
+      # These checks rename our cbinds and consts that have `__` in the name
+      - bugprone-reserved-identifier
+      # All of our circuit structs have non-private members
+      - cppcoreguidelines-non-private-member-variables-in-classes
+      # We have many `for` loops that violate this part of the bounds safety profile
+      - cppcoreguidelines-pro-bounds-constant-array-index
+      # These checks rename our cbinds and consts that have `__` in the name
+      - cert-dcl37-c
+      - cert-dcl51-cpp
+      # We use anon namespaces to import types
+      - cert-dcl59-cpp
+      # We use anon namespaces to import types
+      - google-build-namespaces
+      # Large diff; we often `use` an entire namespace
+      - google-readability-avoid-underscore-in-googletest-name
+      # All of our circuit structs have non-private members
+      - misc-non-private-member-variables-in-classes
+      # Huge diff. Not sure we want to use trailing return type
+      - modernize-use-trailing-return-type
+      # We like (a == true) in circuits
+      - readability-simplify-boolean-expr
+      # `any_of/all_of` loops are not objectively more readable
+      - readability-use-anyofallof
+
+--- # this divider is necessary
+# Disable some checks for Google Test/Bench
+If:
+  PathMatch: [src/.*\.test\.cpp, src/.*\.bench\.cpp]
+Diagnostics:
+  ClangTidy:
+    # these checks get triggered by the Google macros
+    Remove:
+      # Triggers for globals in tests and TEST macros
+      - cert-err58-cpp
+      - cppcoreguidelines-avoid-non-const-global-variables
+      - cppcoreguidelines-owning-memory
+      - cppcoreguidelines-special-member-functions
+      # Triggers on some tests that are not complex
+      #- readability-function-cognitive-complexity

--- a/circuits/cpp/.dockerignore
+++ b/circuits/cpp/.dockerignore
@@ -2,6 +2,8 @@ build
 build-wasm
 docker*
 .*
+!.clang-format
+!.clang-tidy
 src/wasi-sdk*
 barretenberg/cpp/build*
 barretenberg/cpp/docker*

--- a/circuits/cpp/.gitignore
+++ b/circuits/cpp/.gitignore
@@ -2,8 +2,6 @@
 build*/
 src/wasi-sdk-*
 CMakeUserPresets.json
-# to be unignored when we agree on clang-tidy rules
-.clangd
 
 # ctest log output dir
 **/Testing/*

--- a/circuits/cpp/dockerfiles/Dockerfile.x86_64-linux-clang-tidy
+++ b/circuits/cpp/dockerfiles/Dockerfile.x86_64-linux-clang-tidy
@@ -1,0 +1,23 @@
+FROM alpine:3.17 AS builder
+RUN apk update \
+    && apk upgrade \
+    && apk add --no-cache \
+        build-base \
+        clang15 \
+        clang15-extra-tools \
+        openmp-dev \
+        cmake \
+        ninja \
+        git \
+        curl \
+        perl \
+        bash \
+        python3
+
+WORKDIR /usr/src/circuits/cpp
+
+COPY . .
+
+# Configure cmake and check if code is tidy
+RUN cmake --preset default
+RUN ./scripts/tidy.sh fix

--- a/circuits/cpp/scripts/run_tests_local
+++ b/circuits/cpp/scripts/run_tests_local
@@ -59,6 +59,7 @@ echo "*** Running $ARCH tests${GTEST_FILTER:+ (with filter: $GTEST_FILTER)}: $TE
 
 cd $BUILD_DIR;
 for BIN in $TESTS; do
+  echo "Running tests from executable '$BIN'"
   if [ "$ARCH" != "wasm" ]; then
     # run test executables directly
     # if gtest filter is non-empty, use it

--- a/circuits/cpp/scripts/tidy.sh
+++ b/circuits/cpp/scripts/tidy.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+set -e
+
+# Run clang-tidy on all C++ source files
+#
+# CMake must be configured for clang15 before running this script:
+#     cmake --preset clang15
+#
+# Run examples (from circuits/cpp)
+# ./scripts/tidy.sh
+# or
+# ./scripts/tidy.sh fix
+
+###############################################################################
+# ARGS
+###############################################################################
+# FIX: <empty> or fix (MUST BE LOWERCASE)
+#      if 'fix', apply fixes to actual source file
+#      else, print warnings
+FIX=$1
+# END ARGS
+###############################################################################
+
+# CMake build dir which should contain `compile_commands.json`
+BUILD_DIR=build
+echo "*************************************************************************"
+if [ "$FIX" == "fix" ]; then
+  echo "Tidy all source files - fix and format the files themselves"
+  FIX_OPT="-fix -format"
+else
+  EXPORT_DIR=$BUILD_DIR/tidy-fixes
+  # Clean old tidy fixes
+  rm -f $EXPORT_DIR/*
+  mkdir -p $EXPORT_DIR
+  YAML_FILE=$EXPORT_DIR/tidy-all.yaml
+
+  # run tidy on each source file and export fixes to yaml files
+  echo "Checking tidy on all source files and exporting fixes to directory: $EXPORT_DIR"
+  FIX_OPT="-export-fixes $YAML_FILE"
+  echo "To apply these fixes later, run the following from circuits/cpp:"
+  echo "    clang-apply-replacements --format --style file $EXPORT_DIR"
+fi
+
+
+# find all C++ source files to tidy up
+SOURCES=$(\
+  find src/aztec3/ \
+     -name *.cpp \
+  -o -name *.hpp \
+  -o -name *.cxx \
+  -o -name *.hxx \
+  -o -name *.tpp \
+  -o -name *.cc  \
+  -o -name *.hh  \
+  -o -name *.c   \
+  -o -name *.h   \
+  | LC_ALL=C sort \
+)
+
+# MD5 of all source files before running clang-tidy
+BEFORE_MD5=$(
+  for src in ${SOURCES[@]}; do
+    md5sum $src
+  done | md5sum)
+echo "Before running clang-tidy, MD5 of all C++ files was: $BEFORE_MD5"
+echo "*************************************************************************"
+
+# Need run-clang-tidy version 15, but it doesn't have a --version flag
+RUN_TIDY=$(which run-clang-tidy-15 || which run-clang-tidy)
+# tidy all sources
+$RUN_TIDY -p $BUILD_DIR $SOURCES $FIX_OPT -use-color || {\
+  echo "Errors encountered when running clang-tidy!" &&
+  echo "Check the output above before trying again." && \
+  exit 1;
+}
+
+echo "*************************************************************************"
+if [ "$FIX" == "fix" ]; then
+  # MD5 of all source files after running clang-tidy
+  AFTER_MD5=$(
+    for src in ${SOURCES[@]}; do
+      md5sum $src
+    done | md5sum)
+  echo "AFTER running clang-tidy, MD5 of all C++ files was: $AFTER_MD5"
+
+  echo "$BEFORE_MD5 ?= $AFTER_MD5"
+  if [ "$BEFORE_MD5" == "$AFTER_MD5" ]; then
+    echo "No tidying necessary!"
+    exit 0
+  else
+    echo "WARNING: Some tidying was necessary!"
+    echo "If you are seeing this in CI, run the following"
+    echo "in circuits/cpp to tidy up the C++:"
+    echo "    ./scripts/tidy.sh fix"
+    exit 1
+  fi
+else
+  echo "Reminder!"
+  echo "To apply these fixes later, run the following from circuits/cpp:"
+  echo "    clang-apply-replacements --format --style file $EXPORT_DIR"
+fi
+echo "*************************************************************************"

--- a/circuits/cpp/src/aztec3/circuits/abis/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/.test.cpp
@@ -1,10 +1,11 @@
-#include <gtest/gtest.h>
-#include <barretenberg/common/test.hpp>
-#include <barretenberg/common/serialize.hpp>
 #include "index.hpp"
-
 #include "previous_kernel_data.hpp"
 #include "private_kernel/private_inputs.hpp"
+
+#include <barretenberg/common/serialize.hpp>
+#include <barretenberg/common/test.hpp>
+
+#include <gtest/gtest.h>
 
 namespace {
 // Composer
@@ -13,7 +14,7 @@ using Composer = plonk::UltraComposer;
 // Types
 using CT = aztec3::utils::types::CircuitTypes<Composer>;
 using NT = aztec3::utils::types::NativeTypes;
-} // namespace
+}  // namespace
 
 namespace aztec3::circuits::abis {
 
@@ -21,7 +22,7 @@ class abi_tests : public ::testing::Test {};
 
 TEST(abi_tests, native_read_write_call_context)
 {
-    CallContext<NT> call_context = {
+    CallContext<NT> const call_context = {
         .msg_sender = 1,
         .storage_contract_address = 2,
         .portal_contract_address = 3,
@@ -40,7 +41,7 @@ TEST(abi_tests, native_read_write_call_context)
 
 TEST(abi_tests, native_read_write_function_data)
 {
-    FunctionData<NT> function_data = {
+    FunctionData<NT> const function_data = {
         .function_selector = 11,
         .is_private = false,
         .is_constructor = false,
@@ -73,7 +74,7 @@ TEST(abi_tests, native_read_write_function_data)
 
 TEST(abi_tests, native_to_circuit_function_data)
 {
-    FunctionData<NT> native_function_data = {
+    FunctionData<NT> const native_function_data = {
         .function_selector = 11,
         .is_private = false,
         .is_constructor = false,
@@ -82,14 +83,14 @@ TEST(abi_tests, native_to_circuit_function_data)
     info("function data: ", native_function_data);
 
     Composer composer = Composer("../barretenberg/cpp/srs_db/ignition");
-    FunctionData<CT> circuit_function_data = native_function_data.to_circuit_type(composer);
+    FunctionData<CT> const circuit_function_data = native_function_data.to_circuit_type(composer);
 
     info("function data: ", circuit_function_data);
 }
 
 TEST(abi_tests, native_call_context)
 {
-    CallContext<NT> call_context = {
+    CallContext<NT> const call_context = {
         .msg_sender = 10,
         .storage_contract_address = 11,
         .portal_contract_address = 12,
@@ -102,7 +103,7 @@ TEST(abi_tests, native_call_context)
 
 TEST(abi_tests, native_to_circuit_call_context)
 {
-    CallContext<NT> native_call_context = {
+    CallContext<NT> const native_call_context = {
         .msg_sender = 10,
         .storage_contract_address = 11,
         .portal_contract_address = 12,
@@ -113,9 +114,9 @@ TEST(abi_tests, native_to_circuit_call_context)
     info("call context: ", native_call_context);
 
     Composer composer = Composer("../barretenberg/cpp/srs_db/ignition");
-    CallContext<CT> circuit_call_context = native_call_context.to_circuit_type(composer);
+    CallContext<CT> const circuit_call_context = native_call_context.to_circuit_type(composer);
 
     info("call context: ", circuit_call_context);
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/append_only_tree_snapshot.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/append_only_tree_snapshot.hpp
@@ -8,9 +8,8 @@ using aztec3::utils::types::NativeTypes;
 using std::is_same;
 
 template <typename NCT> struct AppendOnlyTreeSnapshot {
-
-    typedef typename NCT::fr fr;
-    typedef typename NCT::uint32 uint32;
+    using fr = typename NCT::fr;
+    using uint32 = typename NCT::uint32;
 
     fr root = 0;
     uint32 next_available_leaf_index;
@@ -40,4 +39,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, AppendOnlyTre
               << "next_available_leaf_index: " << obj.next_available_leaf_index << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/call_context.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/call_context.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <barretenberg/crypto/generators/generator_data.hpp>
-#include <barretenberg/stdlib/hash/pedersen/pedersen.hpp>
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
+#include <aztec3/constants.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/native_types.hpp>
-#include <aztec3/constants.hpp>
+
+#include <barretenberg/crypto/generators/generator_data.hpp>
+#include <barretenberg/stdlib/hash/pedersen/pedersen.hpp>
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -14,9 +15,9 @@ using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
 
 template <typename NCT> struct CallContext {
-    typedef typename NCT::address address;
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using address = typename NCT::address;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     address msg_sender = 0;
     address storage_contract_address = 0;
@@ -64,7 +65,7 @@ template <typename NCT> struct CallContext {
 
     fr hash() const
     {
-        std::vector<fr> inputs = {
+        std::vector<fr> const inputs = {
             msg_sender.to_field(), storage_contract_address.to_field(), portal_contract_address, fr(is_delegate_call),
             fr(is_static_call),    fr(is_contract_deployment),
         };
@@ -131,4 +132,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, CallContext<N
               << "is_contract_deployment: " << call_context.is_contract_deployment << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/call_stack_item.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/call_stack_item.hpp
@@ -18,9 +18,9 @@ using std::conditional;
 using std::is_same;
 
 template <typename NCT, template <class> typename PrivatePublic> struct CallStackItem {
-    typedef typename NCT::address address;
-    typedef typename NCT::boolean boolean;
-    typedef typename NCT::fr fr;
+    using address = typename NCT::address;
+    using boolean = typename NCT::boolean;
+    using fr = typename NCT::fr;
 
     // This is the _actual_ contract address relating to where this function's code resides in the
     // contract tree. Regardless of whether this is a call or delegatecall, this

--- a/circuits/cpp/src/aztec3/circuits/abis/call_stack_item.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/call_stack_item.hpp
@@ -1,13 +1,14 @@
 #pragma once
 #include "function_data.hpp"
+#include "kernel_circuit_public_inputs.hpp"
 #include "private_circuit_public_inputs.hpp"
 #include "public_circuit_public_inputs.hpp"
-#include "kernel_circuit_public_inputs.hpp"
 
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -55,7 +56,7 @@ template <typename NCT, template <class> typename PrivatePublic> struct CallStac
 
     fr hash() const
     {
-        std::vector<fr> inputs = {
+        const std::vector<fr> inputs = {
             contract_address.to_field(),
             function_data.hash(),
             public_inputs.hash(),
@@ -66,7 +67,7 @@ template <typename NCT, template <class> typename PrivatePublic> struct CallStac
 
         return call_stack_item_hash;
     }
-}; // namespace aztec3::circuits::abis
+};  // namespace aztec3::circuits::abis
 
 template <typename NCT, template <class> typename PrivatePublic>
 void read(uint8_t const*& it, CallStackItem<NCT, PrivatePublic>& call_stack_item)
@@ -96,4 +97,4 @@ std::ostream& operator<<(std::ostream& os, CallStackItem<NCT, PrivatePublic> con
               << "public_inputs: " << call_stack_item.public_inputs << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/call_stack_item.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/call_stack_item.hpp
@@ -61,6 +61,7 @@ template <typename NCT, template <class> typename PrivatePublic> struct CallStac
             public_inputs.hash(),
         };
 
+        // NOLINTNEXTLINE(misc-const-correctness)
         fr call_stack_item_hash = NCT::compress(inputs, GeneratorIndex::CALL_STACK_ITEM);
 
         return call_stack_item_hash;

--- a/circuits/cpp/src/aztec3/circuits/abis/combined_accumulated_data.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/combined_accumulated_data.hpp
@@ -1,16 +1,18 @@
 #pragma once
-#include "optionally_revealed_data.hpp"
 #include "new_contract_data.hpp"
-#include "public_data_transition.hpp"
+#include "optionally_revealed_data.hpp"
 #include "public_data_read.hpp"
+#include "public_data_transition.hpp"
+
 #include "aztec3/constants.hpp"
-#include <barretenberg/stdlib/recursion/aggregation_state/aggregation_state.hpp>
-#include <barretenberg/common/map.hpp>
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 #include <aztec3/utils/array.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/common/map.hpp>
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
+#include <barretenberg/stdlib/recursion/aggregation_state/aggregation_state.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -20,9 +22,9 @@ using aztec3::utils::types::NativeTypes;
 using std::is_same;
 
 template <typename NCT> struct CombinedAccumulatedData {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
-    typedef typename NCT::AggregationObject AggregationObject;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
+    using AggregationObject = typename NCT::AggregationObject;
 
     AggregationObject aggregation_object{};
 
@@ -251,4 +253,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, CombinedAccum
               << accum_data.state_reads << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/combined_constant_data.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/combined_constant_data.hpp
@@ -3,10 +3,11 @@
 #include "combined_historic_tree_roots.hpp"
 #include "tx_context.hpp"
 
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -17,8 +18,8 @@ using plonk::stdlib::witness_t;
 using std::is_same;
 
 template <typename NCT> struct CombinedConstantData {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     CombinedHistoricTreeRoots<NCT> historic_tree_roots{};
     TxContext<NCT> tx_context{};
@@ -85,4 +86,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, CombinedConst
               << "tx_context: " << constant_data.tx_context << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/combined_historic_tree_roots.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/combined_historic_tree_roots.hpp
@@ -1,9 +1,11 @@
 #pragma once
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
+#include "private_historic_tree_roots.hpp"
+
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
-#include "private_historic_tree_roots.hpp"
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -14,8 +16,8 @@ using plonk::stdlib::witness_t;
 using std::is_same;
 
 template <typename NCT> struct CombinedHistoricTreeRoots {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     PrivateHistoricTreeRoots<NCT> private_historic_tree_roots{};
 
@@ -79,4 +81,4 @@ std::ostream& operator<<(std::ostream& os, CombinedHistoricTreeRoots<NCT> const&
     return os << "private_historic_tree_roots: " << historic_tree_roots.private_historic_tree_roots << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/contract_deployment_data.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/contract_deployment_data.hpp
@@ -1,10 +1,11 @@
 #pragma once
-#include <barretenberg/crypto/generators/generator_data.hpp>
-#include <barretenberg/stdlib/hash/pedersen/pedersen.hpp>
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/crypto/generators/generator_data.hpp>
+#include <barretenberg/stdlib/hash/pedersen/pedersen.hpp>
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -14,9 +15,9 @@ using plonk::stdlib::witness_t;
 using std::is_same;
 
 template <typename NCT> struct ContractDeploymentData {
-    typedef typename NCT::address address;
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using address = typename NCT::address;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     fr constructor_vk_hash = 0;
     fr function_tree_root = 0;
@@ -85,7 +86,7 @@ template <typename NCT> struct ContractDeploymentData {
 
     fr hash() const
     {
-        std::vector<fr> inputs = {
+        std::vector<fr> const inputs = {
             constructor_vk_hash,
             function_tree_root,
             contract_address_salt,
@@ -124,4 +125,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, ContractDeplo
               << "portal_contract_address: " << data.portal_contract_address << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/function_data.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/function_data.hpp
@@ -1,8 +1,8 @@
 #pragma once
+#include <aztec3/constants.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/native_types.hpp>
-#include <aztec3/constants.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -12,11 +12,11 @@ using aztec3::utils::types::NativeTypes;
 using std::is_same;
 
 template <typename NCT> struct FunctionData {
-    typedef typename NCT::uint32 uint32;
-    typedef typename NCT::boolean boolean;
-    typedef typename NCT::fr fr;
+    using uint32 = typename NCT::uint32;
+    using boolean = typename NCT::boolean;
+    using fr = typename NCT::fr;
 
-    uint32 function_selector; // e.g. 1st 4-bytes of abi-encoding of function.
+    uint32 function_selector;  // e.g. 1st 4-bytes of abi-encoding of function.
     boolean is_private = false;
     boolean is_constructor = false;
 
@@ -68,7 +68,7 @@ template <typename NCT> struct FunctionData {
     // TODO: this can all be packed into 1 field element, so this `hash` function should just return that field element.
     fr hash() const
     {
-        std::vector<fr> inputs = {
+        std::vector<fr> const inputs = {
             fr(function_selector),
             fr(is_private),
             fr(is_constructor),
@@ -103,4 +103,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, FunctionData<
               << "is_constructor: " << function_data.is_constructor << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/function_leaf_preimage.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/function_leaf_preimage.hpp
@@ -1,8 +1,8 @@
 #pragma once
+#include <aztec3/constants.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/native_types.hpp>
-#include <aztec3/constants.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -26,10 +26,9 @@ using std::is_same;
  * - writing a preimage to an ostream
  */
 template <typename NCT> struct FunctionLeafPreimage {
-
-    typedef typename NCT::boolean boolean;
-    typedef typename NCT::fr fr;
-    typedef typename NCT::uint32 uint32;
+    using boolean = typename NCT::boolean;
+    using fr = typename NCT::fr;
+    using uint32 = typename NCT::uint32;
 
     uint32 function_selector = 0;
     boolean is_private = false;
@@ -86,7 +85,7 @@ template <typename NCT> struct FunctionLeafPreimage {
 
     fr hash() const
     {
-        std::vector<fr> inputs = {
+        std::vector<fr> const inputs = {
             function_selector,
             fr(is_private),
             vk_hash,
@@ -124,4 +123,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, FunctionLeafP
               << "acir_hash: " << preimage.acir_hash << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/index.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/index.hpp
@@ -2,6 +2,5 @@
 #include "call_stack_item.hpp"
 #include "function_data.hpp"
 #include "private_circuit_public_inputs.hpp"
-#include "private_circuit_public_inputs.hpp"
 #include "state_read.hpp"
 #include "state_transition.hpp"

--- a/circuits/cpp/src/aztec3/circuits/abis/kernel_circuit_public_inputs.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/kernel_circuit_public_inputs.hpp
@@ -1,10 +1,12 @@
 #pragma once
 #include "combined_accumulated_data.hpp"
 #include "combined_constant_data.hpp"
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
+
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -15,13 +17,13 @@ using std::conditional;
 using std::is_same;
 
 template <typename NCT> struct KernelCircuitPublicInputs {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     CombinedAccumulatedData<NCT> end{};
     CombinedConstantData<NCT> constants{};
 
-    boolean is_private = true; // TODO: might need to instantiate from witness!
+    boolean is_private = true;  // TODO: might need to instantiate from witness!
 
     boolean operator==(KernelCircuitPublicInputs<NCT> const& other) const
     {
@@ -100,4 +102,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, KernelCircuit
               << "is_private: " << public_inputs.is_private << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/membership_witness.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/membership_witness.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <aztec3/utils/array.hpp>
 #include "aztec3/utils/types/circuit_types.hpp"
 #include "aztec3/utils/types/convert.hpp"
+#include <aztec3/utils/array.hpp>
 namespace aztec3::circuits::abis {
 
 using aztec3::utils::zero_array;
@@ -11,9 +11,8 @@ using aztec3::utils::types::NativeTypes;
 using std::is_same;
 
 template <typename NCT, unsigned int N> struct MembershipWitness {
-
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     fr leaf_index;
     std::array<fr, N> sibling_path = zero_array<fr, N>();
@@ -61,4 +60,4 @@ template <typename NCT, unsigned int N> std::ostream& operator<<(std::ostream& o
               << "sibling_path: " << obj.sibling_path << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/new_contract_data.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/new_contract_data.hpp
@@ -3,6 +3,7 @@
 #include "aztec3/constants.hpp"
 #include "aztec3/utils/types/circuit_types.hpp"
 #include "aztec3/utils/types/convert.hpp"
+
 #include "barretenberg/stdlib/primitives/witness/witness.hpp"
 namespace aztec3::circuits::abis {
 
@@ -12,9 +13,9 @@ using plonk::stdlib::witness_t;
 using std::is_same;
 
 template <typename NCT> struct NewContractData {
-    typedef typename NCT::address address;
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using address = typename NCT::address;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     address contract_address = 0;
     address portal_contract_address = 0;
@@ -69,7 +70,7 @@ template <typename NCT> struct NewContractData {
 
     fr hash() const
     {
-        std::vector<fr> inputs = {
+        std::vector<fr> const inputs = {
             fr(contract_address),
             fr(portal_contract_address),
             fr(function_tree_root),
@@ -114,4 +115,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, NewContractDa
 
 template <typename NCT> using ContractLeafPreimage = NewContractData<NCT>;
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/optionally_revealed_data.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/optionally_revealed_data.hpp
@@ -1,10 +1,12 @@
 #pragma once
 #include "function_data.hpp"
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
+
 #include <aztec3/utils/array.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 namespace aztec3::circuits::abis {
 
 using aztec3::utils::zero_array;
@@ -12,9 +14,9 @@ using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
 
 template <typename NCT> struct OptionallyRevealedData {
-    typedef typename NCT::address address;
-    typedef typename NCT::boolean boolean;
-    typedef typename NCT::fr fr;
+    using address = typename NCT::address;
+    using boolean = typename NCT::boolean;
+    using fr = typename NCT::fr;
 
     fr call_stack_item_hash = 0;
     FunctionData<NCT> function_data{};
@@ -140,4 +142,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, OptionallyRev
               << "called_from_public_l2: " << data.called_from_public_l2 << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/previous_kernel_data.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/previous_kernel_data.hpp
@@ -1,11 +1,12 @@
 #pragma once
 #include "aztec3/circuits/abis/kernel_circuit_public_inputs.hpp"
-#include <barretenberg/plonk/proof_system/types/proof.hpp>
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <barretenberg/srs/reference_string/env_reference_string.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/plonk/proof_system/types/proof.hpp>
+#include <barretenberg/srs/reference_string/env_reference_string.hpp>
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -15,13 +16,13 @@ using std::is_same;
 
 // @todo Naming should not be previous. Annoying.
 template <typename NCT> struct PreviousKernelData {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
-    typedef typename NCT::VK VK;
-    typedef typename NCT::uint32 uint32;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
+    using VK = typename NCT::VK;
+    using uint32 = typename NCT::uint32;
 
-    KernelCircuitPublicInputs<NCT> public_inputs{}; // TODO: not needed as already contained in proof?
-    NativeTypes::Proof proof{}; // TODO: how to express proof as native/circuit type when it gets used as a buffer?
+    KernelCircuitPublicInputs<NCT> public_inputs{};  // TODO: not needed as already contained in proof?
+    NativeTypes::Proof proof{};  // TODO: how to express proof as native/circuit type when it gets used as a buffer?
     std::shared_ptr<VK> vk;
 
     // TODO: this index and path are meant to be those of a leaf within the tree of _kernel circuit_ vks; not the tree
@@ -48,7 +49,7 @@ template <typename NCT> struct PreviousKernelData {
 
         PreviousKernelData<CircuitTypes<Composer>> data = {
             public_inputs.to_circuit_type(composer),
-            proof, // Notice: not converted! Stays as native.
+            proof,  // Notice: not converted! Stays as native.
             CT::VK::from_witness(&composer, vk),
             to_ct(vk_index),
             to_ct(vk_path),
@@ -57,7 +58,7 @@ template <typename NCT> struct PreviousKernelData {
         return data;
     };
 
-}; // namespace aztec3::circuits::abis::private_kernel
+};  // namespace aztec3::circuits::abis::private_kernel
 
 template <typename B> inline void read(B& buf, verification_key& key)
 {
@@ -103,4 +104,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, PreviousKerne
               << "vk_path: " << kernel_data.vk_path << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/private_circuit_public_inputs.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/private_circuit_public_inputs.hpp
@@ -2,16 +2,17 @@
 
 #include "call_context.hpp"
 #include "contract_deployment_data.hpp"
+
 #include <aztec3/constants.hpp>
+#include <aztec3/utils/array.hpp>
+#include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 #include <barretenberg/common/map.hpp>
 #include <barretenberg/crypto/generators/generator_data.hpp>
 #include <barretenberg/stdlib/hash/pedersen/pedersen.hpp>
 #include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/array.hpp>
-#include <aztec3/utils/types/circuit_types.hpp>
-#include <aztec3/utils/types/convert.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -20,8 +21,8 @@ using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
 
 template <typename NCT> class PrivateCircuitPublicInputs {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
   public:
     CallContext<NCT> call_context{};
@@ -153,7 +154,7 @@ template <typename NCT> class PrivateCircuitPublicInputs {
     template <size_t SIZE> void spread_arr_into_vec(std::array<fr, SIZE> const& arr, std::vector<fr>& vec) const
     {
         const auto arr_size = sizeof(arr) / sizeof(fr);
-        vec.insert(vec.end(), &arr[0], &arr[0] + arr_size);
+        vec.insert(vec.end(), arr.data(), arr.data() + arr_size);
     }
 };
 
@@ -225,8 +226,8 @@ std::ostream& operator<<(std::ostream& os, PrivateCircuitPublicInputs<NCT> const
 // which aren't set by the circuit can then be safely set to zero when calling `set_public` (by checking for
 // std::nullopt)
 template <typename NCT> class OptionalPrivateCircuitPublicInputs {
-    typedef typename NCT::fr fr;
-    typedef typename std::optional<fr> opt_fr;
+    using fr = typename NCT::fr;
+    using opt_fr = typename std::optional<fr>;
 
   public:
     std::optional<CallContext<NCT>> call_context;
@@ -249,7 +250,7 @@ template <typename NCT> class OptionalPrivateCircuitPublicInputs {
 
     std::optional<ContractDeploymentData<NCT>> contract_deployment_data;
 
-    OptionalPrivateCircuitPublicInputs<NCT>() {}
+    OptionalPrivateCircuitPublicInputs<NCT>() = default;
 
     OptionalPrivateCircuitPublicInputs<NCT>(std::optional<CallContext<NCT>> const& call_context,
 
@@ -288,7 +289,6 @@ template <typename NCT> class OptionalPrivateCircuitPublicInputs {
 
     static OptionalPrivateCircuitPublicInputs<NCT> create()
     {
-
         auto new_inputs = OptionalPrivateCircuitPublicInputs<NCT>();
 
         new_inputs.call_context = std::nullopt;
@@ -537,13 +537,13 @@ template <typename NCT> class OptionalPrivateCircuitPublicInputs {
 
         std::array<fr, SIZE> arr_values = map(arr, get_opt_value);
         const auto arr_size = sizeof(arr_values) / sizeof(fr);
-        vec.insert(vec.end(), &arr_values[0], &arr_values[0] + arr_size);
+        vec.insert(vec.end(), arr_values.data(), arr_values.data() + arr_size);
     }
 
     template <size_t SIZE> void spread_arr_into_vec(std::array<fr, SIZE> const& arr, std::vector<fr>& vec) const
     {
         const auto arr_size = sizeof(arr) / sizeof(fr);
-        vec.insert(vec.end(), &arr[0], &arr[0] + arr_size);
+        vec.insert(vec.end(), arr.data(), arr.data() + arr_size);
     }
 
     template <typename Composer, typename T, size_t SIZE>
@@ -563,7 +563,7 @@ template <typename NCT> class OptionalPrivateCircuitPublicInputs {
 
         if (!element) {
             element =
-                T(witness_t<Composer>(&composer, 0)); // convert the nullopt value to a circuit witness value of `0`
+                T(witness_t<Composer>(&composer, 0));  // convert the nullopt value to a circuit witness value of `0`
             fr(*element).assert_is_zero();
         }
     }
@@ -576,7 +576,7 @@ template <typename NCT> class OptionalPrivateCircuitPublicInputs {
 
         if (!element) {
             element = ABIStruct<NativeTypes>().to_circuit_type(
-                composer); // convert the nullopt value to a circuit witness value of `0`
+                composer);  // convert the nullopt value to a circuit witness value of `0`
             (*element).template assert_is_zero<Composer>();
         }
     }
@@ -588,7 +588,7 @@ template <typename NCT> class OptionalPrivateCircuitPublicInputs {
             fr(*e).set_public();
         }
     }
-}; // namespace aztec3::circuits::abis
+};  // namespace aztec3::circuits::abis
 
 template <typename NCT>
 void read(uint8_t const*& it, OptionalPrivateCircuitPublicInputs<NCT>& private_circuit_public_inputs)
@@ -653,4 +653,4 @@ std::ostream& operator<<(std::ostream& os, OptionalPrivateCircuitPublicInputs<NC
               << "contract_deployment_data: " << pis.contract_deployment_data << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/private_circuit_public_inputs.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/private_circuit_public_inputs.hpp
@@ -249,7 +249,7 @@ template <typename NCT> class OptionalPrivateCircuitPublicInputs {
 
     std::optional<ContractDeploymentData<NCT>> contract_deployment_data;
 
-    OptionalPrivateCircuitPublicInputs<NCT>(){};
+    OptionalPrivateCircuitPublicInputs<NCT>() {}
 
     OptionalPrivateCircuitPublicInputs<NCT>(std::optional<CallContext<NCT>> const& call_context,
 

--- a/circuits/cpp/src/aztec3/circuits/abis/private_historic_tree_roots.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/private_historic_tree_roots.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -12,13 +13,13 @@ using plonk::stdlib::witness_t;
 using std::is_same;
 
 template <typename NCT> struct PrivateHistoricTreeRoots {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     fr private_data_tree_root = 0;
     fr nullifier_tree_root = 0;
     fr contract_tree_root = 0;
-    fr private_kernel_vk_tree_root = 0; // TODO: future enhancement
+    fr private_kernel_vk_tree_root = 0;  // TODO: future enhancement
 
     boolean operator==(PrivateHistoricTreeRoots<NCT> const& other) const
     {
@@ -100,4 +101,4 @@ std::ostream& operator<<(std::ostream& os, PrivateHistoricTreeRoots<NCT> const& 
               << "private_kernel_vk_tree_root: " << historic_tree_roots.private_kernel_vk_tree_root << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/private_kernel/globals.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/private_kernel/globals.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis::private_kernel {
 
@@ -11,8 +12,8 @@ using aztec3::utils::types::NativeTypes;
 using std::is_same;
 
 template <typename NCT> struct Globals {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     fr min_timestamp = 0;
 
@@ -38,4 +39,4 @@ template <typename NCT> struct Globals {
     }
 };
 
-} // namespace aztec3::circuits::abis::private_kernel
+}  // namespace aztec3::circuits::abis::private_kernel

--- a/circuits/cpp/src/aztec3/circuits/abis/private_kernel/private_call_data.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/private_kernel/private_call_data.hpp
@@ -1,17 +1,18 @@
 #pragma once
 
-#include "aztec3/constants.hpp"
-#include "aztec3/utils/array.hpp"
 #include "call_context_reconciliation_data.hpp"
 #include "../call_stack_item.hpp"
 #include "../membership_witness.hpp"
 #include "../types.hpp"
 
-#include <barretenberg/common/map.hpp>
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
+#include "aztec3/constants.hpp"
+#include "aztec3/utils/array.hpp"
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/common/map.hpp>
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis::private_kernel {
 
@@ -21,10 +22,10 @@ using plonk::stdlib::witness_t;
 using std::is_same;
 
 template <typename NCT> struct PrivateCallData {
-    typedef typename NCT::address address;
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
-    typedef typename NCT::VK VK;
+    using address = typename NCT::address;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
+    using VK = typename NCT::VK;
 
     CallStackItem<NCT, PrivateTypes> call_stack_item{};
 
@@ -32,13 +33,13 @@ template <typename NCT> struct PrivateCallData {
 
     // std::array<CallStackItem<NCT, CallType::Public>, PUBLIC_CALL_STACK_LENGTH> public_call_stack_preimages;
 
-    NativeTypes::Proof proof{}; // TODO: how to express proof as native/circuit type when it gets used as a buffer?
+    NativeTypes::Proof proof{};  // TODO: how to express proof as native/circuit type when it gets used as a buffer?
     std::shared_ptr<VK> vk;
 
     MembershipWitness<NCT, FUNCTION_TREE_HEIGHT> function_leaf_membership_witness{};
     MembershipWitness<NCT, CONTRACT_TREE_HEIGHT> contract_leaf_membership_witness{};
 
-    fr portal_contract_address = 0; // an ETH address
+    fr portal_contract_address = 0;  // an ETH address
     fr acir_hash = 0;
 
     boolean operator==(PrivateCallData<NCT> const& other) const
@@ -67,8 +68,8 @@ template <typename NCT> struct PrivateCallData {
 
             map(private_call_stack_preimages, to_circuit_type),
 
-            proof, // Notice: not converted! Stays as native. This is because of how the verify_proof function
-                   // currently works.
+            proof,  // Notice: not converted! Stays as native. This is because of how the verify_proof function
+                    // currently works.
             CT::VK::from_witness(&composer, vk),
 
             to_circuit_type(function_leaf_membership_witness),
@@ -80,7 +81,7 @@ template <typename NCT> struct PrivateCallData {
 
         return data;
     };
-}; // namespace aztec3::circuits::abis::private_kernel
+};  // namespace aztec3::circuits::abis::private_kernel
 
 template <typename NCT> void read(uint8_t const*& it, PrivateCallData<NCT>& obj)
 {
@@ -128,4 +129,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, PrivateCallDa
               << "acir_hash: " << obj.acir_hash << "\n";
 }
 
-} // namespace aztec3::circuits::abis::private_kernel
+}  // namespace aztec3::circuits::abis::private_kernel

--- a/circuits/cpp/src/aztec3/circuits/abis/private_kernel/private_inputs.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/private_kernel/private_inputs.hpp
@@ -1,14 +1,15 @@
 #pragma once
 
+#include "private_call_data.hpp"
 #include "../combined_accumulated_data.hpp"
 #include "../previous_kernel_data.hpp"
-#include "private_call_data.hpp"
 #include "../signed_tx_request.hpp"
 
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis::private_kernel {
 
@@ -17,8 +18,8 @@ using aztec3::utils::types::NativeTypes;
 using std::is_same;
 
 template <typename NCT> struct PrivateInputs {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     SignedTxRequest<NCT> signed_tx_request{};
     PreviousKernelData<NCT> previous_kernel{};
@@ -73,4 +74,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, PrivateInputs
               << private_inputs.private_call << "\n";
 }
 
-} // namespace aztec3::circuits::abis::private_kernel
+}  // namespace aztec3::circuits::abis::private_kernel

--- a/circuits/cpp/src/aztec3/circuits/abis/public_circuit_public_inputs.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/public_circuit_public_inputs.hpp
@@ -1,15 +1,16 @@
 #pragma once
 
 #include "call_context.hpp"
-#include "state_transition.hpp"
 #include "state_read.hpp"
+#include "state_transition.hpp"
 #include "../../constants.hpp"
+
+#include <aztec3/utils/array.hpp>
+#include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 #include <barretenberg/common/map.hpp>
 #include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/array.hpp>
-#include <aztec3/utils/types/native_types.hpp>
-#include <aztec3/utils/types/circuit_types.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -18,9 +19,9 @@ using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
 
 template <typename NCT> struct PublicCircuitPublicInputs {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
-    typedef typename NCT::address address;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
+    using address = typename NCT::address;
 
     CallContext<NCT> call_context{};
 
@@ -109,9 +110,9 @@ template <typename NCT> struct PublicCircuitPublicInputs {
     template <size_t SIZE> void spread_arr_into_vec(std::array<fr, SIZE> const& arr, std::vector<fr>& vec) const
     {
         const auto arr_size = sizeof(arr) / sizeof(fr);
-        vec.insert(vec.end(), &arr[0], &arr[0] + arr_size);
+        vec.insert(vec.end(), arr.data(), arr.data() + arr_size);
     }
-}; // namespace aztec3::circuits::abis
+};  // namespace aztec3::circuits::abis
 
 template <typename NCT> void read(uint8_t const*& it, PublicCircuitPublicInputs<NCT>& public_circuit_public_inputs)
 {
@@ -177,4 +178,4 @@ std::ostream& operator<<(std::ostream& os, PublicCircuitPublicInputs<NCT> const&
 
               << "prover_address: " << pis.prover_address << "\n";
 }
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/public_data_read.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/public_data_read.hpp
@@ -1,9 +1,10 @@
 #pragma once
 #include "aztec3/constants.hpp"
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
-#include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -12,8 +13,8 @@ using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
 
 template <typename NCT> struct PublicDataRead {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     fr leaf_index = 0;
     fr value = 0;
@@ -92,4 +93,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, PublicDataRea
               << "value: " << state_transition.value << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/public_data_transition.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/public_data_transition.hpp
@@ -1,9 +1,10 @@
 #pragma once
 #include "aztec3/constants.hpp"
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
-#include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -12,8 +13,8 @@ using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
 
 template <typename NCT> struct PublicDataTransition {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     fr leaf_index = 0;
     fr old_value = 0;
@@ -100,4 +101,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, PublicDataTra
               << "new_value: " << state_transition.new_value << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/public_kernel/public_call_data.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/public_kernel/public_call_data.hpp
@@ -1,15 +1,16 @@
 #pragma once
 
-#include "aztec3/constants.hpp"
-#include "aztec3/utils/array.hpp"
 #include "../call_stack_item.hpp"
 #include "../types.hpp"
 
-#include <barretenberg/common/map.hpp>
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
+#include "aztec3/constants.hpp"
+#include "aztec3/utils/array.hpp"
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/common/map.hpp>
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis::public_kernel {
 
@@ -19,18 +20,18 @@ using plonk::stdlib::witness_t;
 using std::is_same;
 
 template <typename NCT> struct PublicCallData {
-    typedef typename NCT::address address;
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
-    typedef typename NCT::VK VK;
+    using address = typename NCT::address;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
+    using VK = typename NCT::VK;
 
     CallStackItem<NCT, PublicTypes> call_stack_item{};
 
     std::array<CallStackItem<NCT, PublicTypes>, PUBLIC_CALL_STACK_LENGTH> public_call_stack_preimages{};
 
-    NativeTypes::Proof proof{}; // TODO: how to express proof as native/circuit type when it gets used as a buffer?
+    NativeTypes::Proof proof{};  // TODO: how to express proof as native/circuit type when it gets used as a buffer?
 
-    fr portal_contract_address = 0; // an ETH address
+    fr portal_contract_address = 0;  // an ETH address
     fr bytecode_hash = 0;
 
     boolean operator==(PublicCallData<NCT> const& other) const
@@ -57,8 +58,8 @@ template <typename NCT> struct PublicCallData {
 
             map(public_call_stack_preimages, to_circuit_type),
 
-            proof, // Notice: not converted! Stays as native. This is because of how the verify_proof function
-                   // currently works.
+            proof,  // Notice: not converted! Stays as native. This is because of how the verify_proof function
+                    // currently works.
             // CT::VK::from_witness(&composer, vk),
 
             // to_circuit_type(function_leaf_membership_witness),
@@ -106,4 +107,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, PublicCallDat
               << "bytecode_hash: " << obj.bytecode_hash << "\n";
 }
 
-} // namespace aztec3::circuits::abis::public_kernel
+}  // namespace aztec3::circuits::abis::public_kernel

--- a/circuits/cpp/src/aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
-#include "../previous_kernel_data.hpp"
 #include "public_call_data.hpp"
+#include "../previous_kernel_data.hpp"
 #include "../signed_tx_request.hpp"
 
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis::public_kernel {
 
@@ -16,8 +17,8 @@ using aztec3::utils::types::NativeTypes;
 using std::is_same;
 
 template <typename NCT> struct PublicKernelInputs {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     PreviousKernelData<NCT> previous_kernel{};
     PublicCallData<NCT> public_call{};
@@ -64,4 +65,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, PublicKernelI
               << public_kernel_inputs.public_call << "\n";
 }
 
-} // namespace aztec3::circuits::abis::public_kernel
+}  // namespace aztec3::circuits::abis::public_kernel

--- a/circuits/cpp/src/aztec3/circuits/abis/public_kernel/public_kernel_inputs_no_previous_kernel.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/public_kernel/public_kernel_inputs_no_previous_kernel.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
+#include "public_call_data.hpp"
 #include "../previous_kernel_data.hpp"
 #include "../signed_tx_request.hpp"
-#include "public_call_data.hpp"
 
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis::public_kernel {
 
@@ -16,8 +17,8 @@ using aztec3::utils::types::NativeTypes;
 using std::is_same;
 
 template <typename NCT> struct PublicKernelInputsNoPreviousKernel {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     SignedTxRequest<NCT> signed_tx_request{};
     PublicCallData<NCT> public_call{};
@@ -68,4 +69,4 @@ std::ostream& operator<<(std::ostream& os, PublicKernelInputsNoPreviousKernel<NC
               << public_kernel_inputs.public_call << "\n";
 }
 
-} // namespace aztec3::circuits::abis::public_kernel
+}  // namespace aztec3::circuits::abis::public_kernel

--- a/circuits/cpp/src/aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp
@@ -1,11 +1,12 @@
 #pragma once
-#include <barretenberg/stdlib/recursion/aggregation_state/aggregation_state.hpp>
-#include <aztec3/utils/types/native_types.hpp>
-#include <aztec3/utils/types/circuit_types.hpp>
-#include <aztec3/utils/types/convert.hpp>
-#include "../../append_only_tree_snapshot.hpp"
 #include "../../append_only_tree_snapshot.hpp"
 #include "../constant_rollup_data.hpp"
+
+#include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/recursion/aggregation_state/aggregation_state.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -17,8 +18,8 @@ const uint32_t BASE_ROLLUP_TYPE = 0;
 const uint32_t MERGE_ROLLUP_TYPE = 1;
 
 template <typename NCT> struct BaseOrMergeRollupPublicInputs {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::AggregationObject AggregationObject;
+    using fr = typename NCT::fr;
+    using AggregationObject = typename NCT::AggregationObject;
 
     uint32_t rollup_type;
     // subtree  height is always 0 for base.
@@ -125,4 +126,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, BaseOrMergeRo
               << obj.calldata_hash << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/rollup/base/base_rollup_inputs.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/rollup/base/base_rollup_inputs.hpp
@@ -1,10 +1,12 @@
 #pragma once
 #include "../../append_only_tree_snapshot.hpp"
-#include "../../previous_kernel_data.hpp"
 #include "../../membership_witness.hpp"
-#include "../nullifier_leaf_preimage.hpp"
+#include "../../previous_kernel_data.hpp"
 #include "../constant_rollup_data.hpp"
+#include "../nullifier_leaf_preimage.hpp"
+
 #include "aztec3/constants.hpp"
+
 #include <math.h>
 
 namespace aztec3::circuits::abis {
@@ -14,8 +16,7 @@ using aztec3::utils::types::NativeTypes;
 using std::is_same;
 
 template <typename NCT> struct BaseRollupInputs {
-
-    typedef typename NCT::fr fr;
+    using fr = typename NCT::fr;
 
     std::array<PreviousKernelData<NCT>, 2> kernel_data;
 
@@ -123,4 +124,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, BaseRollupInp
               << obj.constants << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/rollup/constant_rollup_data.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/rollup/constant_rollup_data.hpp
@@ -8,8 +8,7 @@ using aztec3::utils::types::NativeTypes;
 using std::is_same;
 
 template <typename NCT> struct ConstantRollupData {
-
-    typedef typename NCT::fr fr;
+    using fr = typename NCT::fr;
 
     // The very latest roots as at the very beginning of the entire rollup:
     AppendOnlyTreeSnapshot<NCT> start_tree_of_historic_private_data_tree_roots_snapshot{};
@@ -65,4 +64,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, ConstantRollu
               << "merge_rollup_vk_hash: " << obj.merge_rollup_vk_hash << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/rollup/merge/merge_rollup_inputs.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/rollup/merge/merge_rollup_inputs.hpp
@@ -1,9 +1,10 @@
 #pragma once
 #include "aztec3/circuits/abis/append_only_tree_snapshot.hpp"
 #include <aztec3/circuits/abis/rollup/merge/previous_rollup_data.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
 #include <type_traits>
 
 namespace aztec3::circuits::abis {
@@ -37,4 +38,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, MergeRollupIn
     return os << "previous_rollup_data: " << obj.previous_rollup_data << "\n";
 };
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/rollup/merge/previous_rollup_data.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/rollup/merge/previous_rollup_data.hpp
@@ -3,9 +3,10 @@
 #include "aztec3/circuits/abis/membership_witness.hpp"
 #include "aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp"
 #include "aztec3/constants.hpp"
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
 #include <type_traits>
 
 namespace aztec3::circuits::abis {
@@ -56,4 +57,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, PreviousRollu
               << "vk_sibling_path: " << obj.vk_sibling_path << "\n";
 };
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/rollup/nullifier_leaf_preimage.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/rollup/nullifier_leaf_preimage.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "aztec3/utils/types/circuit_types.hpp"
+
 #include "barretenberg/stdlib/merkle_tree/hash.hpp"
 #include "barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_leaf.hpp"
 namespace aztec3::circuits::abis {
@@ -10,9 +11,8 @@ using aztec3::utils::types::NativeTypes;
 using std::is_same;
 
 template <typename NCT> struct NullifierLeafPreimage {
-
-    typedef typename NCT::fr fr;
-    typedef typename NCT::uint32 uint32;
+    using fr = typename NCT::fr;
+    using uint32 = typename NCT::uint32;
 
     fr leaf_value = 0;
     uint32 next_index;
@@ -48,4 +48,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, NullifierLeaf
               << "next_index: " << obj.next_index << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/rollup/root/root_rollup_inputs.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/rollup/root/root_rollup_inputs.hpp
@@ -4,9 +4,10 @@
 #include "aztec3/circuits/abis/append_only_tree_snapshot.hpp"
 #include "aztec3/circuits/abis/rollup/merge/previous_rollup_data.hpp"
 #include "aztec3/constants.hpp"
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
 #include <ostream>
 
 namespace aztec3::circuits::abis {
@@ -18,7 +19,7 @@ using aztec3::utils::types::NativeTypes;
 // Hit when running aztec3-packages/yarn-project/circuits.js/src/rollup/rollup_wasm_wrapper.test.ts."calls
 // root_rollup__sim"
 template <typename NCT> struct RootRollupInputs {
-    typedef typename NCT::fr fr;
+    using fr = typename NCT::fr;
 
     // All below are shared between the base and merge rollups
     std::array<PreviousRollupData<NCT>, 2> previous_rollup_data;
@@ -55,4 +56,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, RootRollupInp
               << "new_historic_contract_tree_roots: " << obj.new_historic_contract_tree_root_sibling_path << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/rollup/root/root_rollup_public_inputs.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/rollup/root/root_rollup_public_inputs.hpp
@@ -1,12 +1,13 @@
 
 #pragma once
 
-#include "barretenberg/crypto/sha256/sha256.hpp"
-
 #include "aztec3/circuits/abis/append_only_tree_snapshot.hpp"
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include "barretenberg/crypto/sha256/sha256.hpp"
+
 #include <ostream>
 
 namespace aztec3::circuits::abis {
@@ -15,8 +16,8 @@ using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
 
 template <typename NCT> struct RootRollupPublicInputs {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::AggregationObject AggregationObject;
+    using fr = typename NCT::fr;
+    using AggregationObject = typename NCT::AggregationObject;
 
     // All below are shared between the base and merge rollups
     AggregationObject end_aggregation_object;
@@ -135,4 +136,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, RootRollupPub
               << "calldata_hash: " << obj.calldata_hash << "\n";
 };
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/signed_tx_request.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/signed_tx_request.hpp
@@ -2,10 +2,11 @@
 
 #include "tx_request.hpp"
 
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -13,8 +14,8 @@ using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
 
 template <typename NCT> struct SignedTxRequest {
-    typedef typename NCT::boolean boolean;
-    typedef typename NCT::ecdsa_signature Signature;
+    using boolean = typename NCT::boolean;
+    using Signature = typename NCT::ecdsa_signature;
 
     TxRequest<NCT> tx_request{};
     Signature signature{};
@@ -80,4 +81,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, SignedTxReque
               << "signature: " << signed_tx_request.signature << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/state_read.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/state_read.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -11,8 +12,8 @@ using aztec3::utils::types::NativeTypes;
 using plonk::stdlib::witness_t;
 
 template <typename NCT> struct StateRead {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     fr storage_slot = 0;
     fr current_value = 0;
@@ -50,7 +51,7 @@ template <typename NCT> struct StateRead {
 
     fr hash() const
     {
-        std::vector<fr> inputs = {
+        std::vector<fr> const inputs = {
             storage_slot,
             current_value,
         };
@@ -91,4 +92,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, StateRead<NCT
               << "current_value: " << state_read.current_value << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/state_transition.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/state_transition.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
-#include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -11,8 +12,8 @@ using aztec3::utils::types::NativeTypes;
 using plonk::stdlib::witness_t;
 
 template <typename NCT> struct StateTransition {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     fr storage_slot = 0;
     fr old_value = 0;
@@ -53,7 +54,7 @@ template <typename NCT> struct StateTransition {
 
     fr hash() const
     {
-        std::vector<fr> inputs = {
+        std::vector<fr> const inputs = {
             storage_slot,
             old_value,
             new_value,
@@ -99,4 +100,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, StateTransiti
               << "new_value: " << state_transition.new_value << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/tx_context.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/tx_context.hpp
@@ -1,12 +1,14 @@
 #pragma once
 #include "contract_deployment_data.hpp"
 #include "function_data.hpp"
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
+
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
 #include <barretenberg/crypto/generators/generator_data.hpp>
 #include <barretenberg/stdlib/hash/pedersen/pedersen.hpp>
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -14,9 +16,9 @@ using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
 
 template <typename NCT> struct TxContext {
-    typedef typename NCT::address address;
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using address = typename NCT::address;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     boolean is_fee_payment_tx = false;
     boolean is_rebate_payment_tx = false;
@@ -77,7 +79,7 @@ template <typename NCT> struct TxContext {
 
     fr hash() const
     {
-        std::vector<fr> inputs = {
+        std::vector<fr> const inputs = {
             fr(is_fee_payment_tx),
             fr(is_rebate_payment_tx),
             fr(is_contract_deployment_tx),
@@ -118,4 +120,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, TxContext<NCT
               << tx_context.contract_deployment_data;
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/tx_request.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/tx_request.hpp
@@ -1,11 +1,13 @@
 #pragma once
 #include "function_data.hpp"
 #include "tx_context.hpp"
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
+
 #include <aztec3/utils/array.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
@@ -14,9 +16,9 @@ using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
 
 template <typename NCT> struct TxRequest {
-    typedef typename NCT::address address;
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using address = typename NCT::address;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     address from = 0;
     address to = 0;
@@ -65,7 +67,7 @@ template <typename NCT> struct TxRequest {
     template <size_t SIZE> void spread_arr_into_vec(std::array<fr, SIZE> const& arr, std::vector<fr>& vec) const
     {
         const auto arr_size = sizeof(arr) / sizeof(fr);
-        vec.insert(vec.end(), &arr[0], &arr[0] + arr_size);
+        vec.insert(vec.end(), arr.data(), arr.data() + arr_size);
     }
 };
 
@@ -106,4 +108,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, TxRequest<NCT
               << "chain_id: " << tx_request.chain_id << "\n";
 }
 
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/abis/types.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/types.hpp
@@ -1,25 +1,25 @@
 #pragma once
-#include <aztec3/constants.hpp>
+#include "private_circuit_public_inputs.hpp"
+#include "public_circuit_public_inputs.hpp"
 
-#include <barretenberg/common/map.hpp>
-#include <barretenberg/crypto/generators/generator_data.hpp>
-#include <barretenberg/stdlib/hash/pedersen/pedersen.hpp>
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
+#include <aztec3/constants.hpp>
 #include <aztec3/utils/array.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/native_types.hpp>
 
-#include "private_circuit_public_inputs.hpp"
-#include "public_circuit_public_inputs.hpp"
+#include <barretenberg/common/map.hpp>
+#include <barretenberg/crypto/generators/generator_data.hpp>
+#include <barretenberg/stdlib/hash/pedersen/pedersen.hpp>
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::abis {
 
 template <typename NCT> struct PrivateTypes {
-    typedef PrivateCircuitPublicInputs<NCT> AppCircuitPublicInputs;
+    using AppCircuitPublicInputs = PrivateCircuitPublicInputs<NCT>;
 };
 
 template <typename NCT> struct PublicTypes {
-    typedef PublicCircuitPublicInputs<NCT> AppCircuitPublicInputs;
+    using AppCircuitPublicInputs = PublicCircuitPublicInputs<NCT>;
 };
-} // namespace aztec3::circuits::abis
+}  // namespace aztec3::circuits::abis

--- a/circuits/cpp/src/aztec3/circuits/apps/contract.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/contract.hpp
@@ -18,8 +18,8 @@ using NT = aztec3::utils::types::NativeTypes;
 // template <typename Composer> class FunctionExecutionContext;
 
 template <typename NCT> class Contract {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::uint32 uint32;
+    using fr = typename NCT::fr;
+    using uint32 = typename NCT::uint32;
 
   public:
     const std::string contract_name;
@@ -36,15 +36,14 @@ template <typename NCT> class Contract {
 
     std::map<std::string, Contract<NCT>> imported_contracts;
 
-    Contract<NCT>(std::string const& contract_name)
-        : contract_name(contract_name)
+    explicit Contract<NCT>(std::string const& contract_name) : contract_name(contract_name)
     {
         // exec_ctx.register_contract(this);
     }
 
     void set_functions(std::vector<FunctionDeclaration<NCT>> const& functions);
 
-    void import_contracts(std::vector<std::pair<std::string, Contract<NCT>>> const import_declarations);
+    void import_contracts(std::vector<std::pair<std::string, Contract<NCT>>> import_declarations);
 
     Contract<NCT>& get_imported_contract(std::string const& name)
     {
@@ -101,7 +100,7 @@ template <typename NCT> class Contract {
     }
 };
 
-} // namespace aztec3::circuits::apps
+}  // namespace aztec3::circuits::apps
 
 // Importing in this way (rather than explicit instantiation of a template class at the bottom of a .cpp file) preserves
 // the following:

--- a/circuits/cpp/src/aztec3/circuits/apps/contract.tpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/contract.tpp
@@ -27,7 +27,7 @@ template <typename NCT> void Contract<NCT>::set_functions(std::vector<FunctionDe
             throw_or_abort("Name already exists");
         }
         function_datas[function.name] = FunctionData<NCT>{
-            .function_selector = uint32(i),
+            .function_selector = static_cast<uint32>(i),
             .is_private = function.is_private,
             .is_constructor = function.is_constructor,
         };
@@ -65,7 +65,7 @@ template <typename NCT> FunctionData<NCT> Contract<NCT>::get_function_data_by_na
 
 template <typename NCT> void Contract<NCT>::import_l1_function(L1FunctionInterfaceStruct<NCT> const& l1_function_struct)
 {
-    L1FunctionInterface<NCT> l1_function = L1FunctionInterface<NCT>(this, l1_function_struct);
+    L1FunctionInterface<NCT> const l1_function = L1FunctionInterface<NCT>(this, l1_function_struct);
     l1_functions.insert(std::make_pair(l1_function_struct.function_name, l1_function));
 };
 

--- a/circuits/cpp/src/aztec3/circuits/apps/function_declaration.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/function_declaration.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::apps {
 
@@ -12,11 +13,11 @@ using plonk::stdlib::witness_t;
 
 // This exists just so that designated initialisers can be used when passing this info to a function, for readability.
 template <typename NCT> struct FunctionDeclaration {
-    typedef typename NCT::boolean boolean;
+    using boolean = typename NCT::boolean;
 
     std::string name;
     boolean is_private = false;
     boolean is_constructor = false;
 };
 
-} // namespace aztec3::circuits::apps
+}  // namespace aztec3::circuits::apps

--- a/circuits/cpp/src/aztec3/circuits/apps/function_execution_context.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/function_execution_context.hpp
@@ -2,23 +2,18 @@
 
 #include "contract.hpp"
 #include "oracle_wrapper.hpp"
-
 #include "notes/note_interface.hpp"
-
 #include "opcodes/opcodes.hpp"
-
-#include <aztec3/constants.hpp>
 
 #include <aztec3/circuits/abis/call_stack_item.hpp>
 #include <aztec3/circuits/abis/function_data.hpp>
 #include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
 #include <aztec3/circuits/abis/types.hpp>
-
-#include <barretenberg/stdlib/primitives/field/array.hpp>
+#include <aztec3/constants.hpp>
+#include <aztec3/utils/types/convert.hpp>
 
 #include <barretenberg/common/container.hpp>
-
-#include <aztec3/utils/types/convert.hpp>
+#include <barretenberg/stdlib/primitives/field/array.hpp>
 
 namespace aztec3::circuits::apps {
 
@@ -40,10 +35,10 @@ using aztec3::utils::types::to_ct;
 using aztec3::utils::types::to_nt;
 
 template <typename Composer> class FunctionExecutionContext {
-    typedef NativeTypes NT;
-    typedef CircuitTypes<Composer> CT;
-    typedef typename CT::fr fr;
-    typedef typename CT::address address;
+    using NT = NativeTypes;
+    using CT = CircuitTypes<Composer>;
+    using fr = typename CT::fr;
+    using address = typename CT::address;
 
     // We restrict only the opcodes to be able to push to the private members of the exec_ctx.
     // This will just help us build better separation of concerns.
@@ -168,7 +163,7 @@ template <typename Composer> class FunctionExecutionContext {
         // Convert function name to bytes and use the first 4 bytes as the function encoding, for now:
         std::vector<uint8_t> f_name_bytes(f_name.begin(), f_name.end());
         std::vector<uint8_t> f_encoding_bytes(f_name_bytes.begin(), f_name_bytes.begin() + 4);
-        uint32_t f_encoding;
+        uint32_t f_encoding = 0;
         memcpy(&f_encoding, f_encoding_bytes.data(), sizeof(f_encoding));
 
         fr f_encoding_ct = fr(f_encoding);
@@ -188,9 +183,9 @@ template <typename Composer> class FunctionExecutionContext {
         };
 
         const CallContext<CT> f_call_context_ct{
-            .msg_sender = oracle.get_this_contract_address(), // the sender is `this` contract!
+            .msg_sender = oracle.get_this_contract_address(),  // the sender is `this` contract!
             .storage_contract_address = f_contract_address,
-            .portal_contract_address = 0, // TODO
+            .portal_contract_address = 0,  // TODO
             .is_delegate_call = false,
             .is_static_call = false,
             .is_contract_deployment = false,
@@ -201,9 +196,9 @@ template <typename Composer> class FunctionExecutionContext {
                               f_function_data_ct.template to_native_type<Composer>(),
                               f_call_context_ct.template to_native_type<Composer>(),
                               oracle.get_msg_sender_private_key()
-                                  .get_value() // TODO: consider whether a nested function should even be able to access
-                                               // a private key, given that the call is now coming from a contract
-                                               // (which cannot own a secret), rather than a human.
+                                  .get_value()  // TODO: consider whether a nested function should even be able to
+                                                // access a private key, given that the call is now coming from a
+                                                // contract (which cannot own a secret), rather than a human.
         );
 
         Composer f_composer = Composer("../barretenberg/cpp/srs_db/ignition");
@@ -240,7 +235,7 @@ template <typename Composer> class FunctionExecutionContext {
             args[i].assert_equal(f_public_inputs_ct.args[i]);
         }
 
-        CallStackItem<CT, PrivateTypes> f_call_stack_item_ct{
+        CallStackItem<CT, PrivateTypes> const f_call_stack_item_ct{
             .contract_address = f_contract_address,
             .function_data = f_function_data_ct,
             .public_inputs = f_public_inputs_ct,
@@ -333,4 +328,4 @@ template <typename Composer> class FunctionExecutionContext {
     }
 };
 
-} // namespace aztec3::circuits::apps
+}  // namespace aztec3::circuits::apps

--- a/circuits/cpp/src/aztec3/circuits/apps/l1_call.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/l1_call.hpp
@@ -2,10 +2,11 @@
 
 #include "l1_function_interface.hpp"
 
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::apps {
 
@@ -20,19 +21,17 @@ template <typename Composer> class L1Call {
     L1FunctionInterface& l1_function;
     std::vector<fr> args;
     fr hash_of_argument_encodings = 0;
-    fr partial_l1_call_stack_item = 0; // keccak(function_selector, hash_of_argument_encodings)
+    fr partial_l1_call_stack_item = 0;  // keccak(function_selector, hash_of_argument_encodings)
 
-    L1Call(L1FunctionInterface const& l1_function, std::vector<fr> const& args)
-        : l1_function(l1_function)
-        , args(args)
+    L1Call(L1FunctionInterface const& l1_function, std::vector<fr> const& args) : l1_function(l1_function), args(args)
     {
         /// TODO: in reality, we'll need to use keccak hash here, as this will need to be replecated on-chain.
         if (args.size() == 0) {
             hash_of_argument_encodings = 0;
         } else {
-            hash_of_argument_encodings = args[0]; // lazy stub for a hash!
+            hash_of_argument_encodings = args[0];  // lazy stub for a hash!
         }
-        partial_l1_call_stack_item = function_selector; // lazy stub for a hash!
+        partial_l1_call_stack_item = function_selector;  // lazy stub for a hash!
     }
 
     bool operator==(L1Call<NCT> const&) const = default;
@@ -81,4 +80,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, L1Call<NCT> c
               << "partial_l1_call_stack_item: " << l1_call.partial_l1_call_stack_item << "\n";
 }
 
-} // namespace aztec3::circuits::apps
+}  // namespace aztec3::circuits::apps

--- a/circuits/cpp/src/aztec3/circuits/apps/l1_function_interface.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/l1_function_interface.hpp
@@ -30,7 +30,7 @@ template <typename NCT> class L1FunctionInterface {
     fr function_selector = 0;
     size_t num_params = 0;
 
-    L1FunctionInterface(){};
+    L1FunctionInterface() {}
 
     L1FunctionInterface(Contract<NCT>* contract, L1FunctionInterfaceStruct<NCT> const& l1_fn_struct)
         : contract(contract)

--- a/circuits/cpp/src/aztec3/circuits/apps/l1_function_interface.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/l1_function_interface.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::apps {
 
@@ -14,7 +15,7 @@ template <typename NCT> class Contract;
 
 // We use the struct to retain designated initialisation, to make contract creation more readable.
 template <typename NCT> struct L1FunctionInterfaceStruct {
-    typedef typename NCT::fr fr;
+    using fr = typename NCT::fr;
 
     std::string function_name;
     fr function_selector = 0;
@@ -22,7 +23,7 @@ template <typename NCT> struct L1FunctionInterfaceStruct {
 };
 
 template <typename NCT> class L1FunctionInterface {
-    typedef typename NCT::fr fr;
+    using fr = typename NCT::fr;
 
   public:
     Contract<NCT>* contract;
@@ -30,7 +31,7 @@ template <typename NCT> class L1FunctionInterface {
     fr function_selector = 0;
     size_t num_params = 0;
 
-    L1FunctionInterface() {}
+    L1FunctionInterface() = default;
 
     L1FunctionInterface(Contract<NCT>* contract, L1FunctionInterfaceStruct<NCT> const& l1_fn_struct)
         : contract(contract)
@@ -49,10 +50,10 @@ template <typename NCT> class L1FunctionInterface {
     void call(std::vector<fr> args)
     {
         // TODO: implement this function.
-        (void)args; // So the compiler doesn't complain about an unused var.
+        (void)args;  // So the compiler doesn't complain about an unused var.
     }
 };
 
-} // namespace aztec3::circuits::apps
+}  // namespace aztec3::circuits::apps
 
 // #include "l1_function_interface.tpp"

--- a/circuits/cpp/src/aztec3/circuits/apps/notes/default_private_note/note.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/notes/default_private_note/note.hpp
@@ -1,37 +1,36 @@
 #pragma once
 
-#include "../note_interface.hpp"
-
 #include "note_preimage.hpp"
 #include "nullifier_preimage.hpp"
+#include "../note_interface.hpp"
 
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 // Forward-declare from this namespace in particular:
 namespace aztec3::circuits::apps::state_vars {
 template <typename Composer> class StateVar;
-} // namespace aztec3::circuits::apps::state_vars
+}  // namespace aztec3::circuits::apps::state_vars
 
 namespace aztec3::circuits::apps::notes {
 
-using aztec3::circuits::apps::state_vars::StateVar; // Don't #include it!
+using aztec3::circuits::apps::state_vars::StateVar;  // Don't #include it!
 
 using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
 
 template <typename Composer, typename ValueType> class DefaultPrivateNote : public NoteInterface<Composer> {
   public:
-    typedef CircuitTypes<Composer> CT;
-    typedef typename CT::fr fr;
-    typedef typename CT::grumpkin_point grumpkin_point;
-    typedef typename CT::address address;
-    typedef typename CT::boolean boolean;
+    using CT = CircuitTypes<Composer>;
+    using fr = typename CT::fr;
+    using grumpkin_point = typename CT::grumpkin_point;
+    using address = typename CT::address;
+    using boolean = typename CT::boolean;
 
     using NotePreimage = DefaultPrivateNotePreimage<CircuitTypes<Composer>, ValueType>;
     using NullifierPreimage = DefaultPrivateNoteNullifierPreimage<CircuitTypes<Composer>>;
 
-  public:
+
     StateVar<Composer>* state_var;
 
   private:
@@ -44,10 +43,9 @@ template <typename Composer, typename ValueType> class DefaultPrivateNote : publ
 
   public:
     DefaultPrivateNote(StateVar<Composer>* state_var, NotePreimage note_preimage)
-        : state_var(state_var)
-        , note_preimage(note_preimage){};
+        : state_var(state_var), note_preimage(note_preimage){};
 
-    ~DefaultPrivateNote() {}
+    ~DefaultPrivateNote() override = default;
 
     // OVERRIDE METHODS:
 
@@ -116,7 +114,7 @@ template <typename Composer, typename ValueType> class DefaultPrivateNote : publ
     bool is_partial() const;
 };
 
-} // namespace aztec3::circuits::apps::notes
+}  // namespace aztec3::circuits::apps::notes
 
 // Importing in this way (rather than explicit instantiation of a template class at the bottom of a .cpp file) preserves
 // the following:

--- a/circuits/cpp/src/aztec3/circuits/apps/notes/default_private_note/note.tpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/notes/default_private_note/note.tpp
@@ -68,10 +68,10 @@ typename CircuitTypes<Composer>::fr DefaultPrivateNote<Composer, V>::compute_com
         return *commitment;
     }
 
-    grumpkin_point storage_slot_point = state_var->storage_slot_point;
+    grumpkin_point const storage_slot_point = state_var->storage_slot_point;
 
-    std::vector<fr> inputs;
-    std::vector<generator_index_t> generators;
+    std::vector<fr> const inputs;
+    std::vector<generator_index_t> const generators;
 
     auto gen_pair_address = [&](std::optional<address> const& input, size_t const hash_sub_index) {
         if (!input) {
@@ -127,7 +127,7 @@ typename CircuitTypes<Composer>::grumpkin_point DefaultPrivateNote<Composer, V>:
     grumpkin_point storage_slot_point = state_var->storage_slot_point;
 
     std::vector<fr> inputs;
-    std::vector<generator_index_t> generators;
+    std::vector<generator_index_t> const generators;
 
     auto gen_pair_address = [&](std::optional<address> const& input, size_t const hash_sub_index) {
         return input ? std::make_pair((*input).to_field(),
@@ -180,7 +180,7 @@ typename CircuitTypes<Composer>::fr DefaultPrivateNote<Composer, V>::compute_nul
         compute_commitment();
     }
 
-    fr& owner_private_key = get_oracle().get_msg_sender_private_key();
+    fr const& owner_private_key = get_oracle().get_msg_sender_private_key();
 
     nullifier =
         DefaultPrivateNote<Composer, V>::compute_nullifier(*commitment, owner_private_key, note_preimage.is_dummy);
@@ -196,8 +196,8 @@ template <typename Composer, typename V>
 typename CircuitTypes<Composer>::fr DefaultPrivateNote<Composer, V>::compute_dummy_nullifier()
 {
     auto& oracle = get_oracle();
-    fr dummy_commitment = oracle.generate_random_element();
-    fr& owner_private_key = oracle.get_msg_sender_private_key();
+    fr const dummy_commitment = oracle.generate_random_element();
+    fr const& owner_private_key = oracle.get_msg_sender_private_key();
     const boolean is_dummy_commitment = true;
 
     return DefaultPrivateNote<Composer, V>::compute_nullifier(dummy_commitment, owner_private_key, is_dummy_commitment);
@@ -246,8 +246,7 @@ template <typename Composer, typename V>
 void DefaultPrivateNote<Composer, V>::constrain_against_advice(NoteInterface<Composer> const& advice_note)
 {
     // Cast from a ref to the base (interface) type to a ref to this derived type:
-    const DefaultPrivateNote<Composer, V>& advice_note_ref =
-        dynamic_cast<const DefaultPrivateNote<Composer, V>&>(advice_note);
+    const auto& advice_note_ref = dynamic_cast<const DefaultPrivateNote<Composer, V>&>(advice_note);
 
     auto assert_equal = []<typename T>(std::optional<T>& this_member, std::optional<T> const& advice_member) {
         if (advice_member) {

--- a/circuits/cpp/src/aztec3/circuits/apps/notes/default_private_note/note_preimage.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/notes/default_private_note/note_preimage.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <barretenberg/common/map.hpp>
-#include <barretenberg/common/streams.hpp>
-
-#include <barretenberg/crypto/generators/generator_data.hpp>
-
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/common/map.hpp>
+#include <barretenberg/common/streams.hpp>
+#include <barretenberg/crypto/generators/generator_data.hpp>
 
 namespace aztec3::circuits::apps::notes {
 
@@ -16,16 +15,16 @@ using aztec3::utils::types::NativeTypes;
 using crypto::generators::generator_index_t;
 
 template <typename NCT, typename V> struct DefaultPrivateNotePreimage {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::address address;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using address = typename NCT::address;
+    using boolean = typename NCT::boolean;
 
     // No custom constructors so that designated initializers can be used (for readability of test circuits).
 
     std::optional<V> value;
     std::optional<address> owner;
     std::optional<address> creator_address;
-    std::optional<fr> memo; // numerical representation of a string
+    std::optional<fr> memo;  // numerical representation of a string
 
     std::optional<fr> salt;
     std::optional<fr> nonce;
@@ -73,7 +72,6 @@ template <typename NCT, typename V> struct DefaultPrivateNotePreimage {
 
     template <typename Composer> auto to_native_type() const
     {
-
         static_assert(!std::is_same<NativeTypes, NCT>::value);
 
         auto to_nt = [&](auto& e) { return aztec3::utils::types::to_nt<Composer>(e); };
@@ -141,4 +139,4 @@ std::ostream& operator<<(std::ostream& os, DefaultPrivateNotePreimage<NCT, V> co
               << "is_dummy: " << preimage.is_dummy << "\n";
 }
 
-} // namespace aztec3::circuits::apps::notes
+}  // namespace aztec3::circuits::apps::notes

--- a/circuits/cpp/src/aztec3/circuits/apps/notes/default_private_note/nullifier_preimage.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/notes/default_private_note/nullifier_preimage.hpp
@@ -1,12 +1,11 @@
 #pragma once
-#include <barretenberg/common/map.hpp>
-#include <barretenberg/common/streams.hpp>
-
-#include <barretenberg/crypto/generators/generator_data.hpp>
-
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/common/map.hpp>
+#include <barretenberg/common/streams.hpp>
+#include <barretenberg/crypto/generators/generator_data.hpp>
 
 namespace aztec3::circuits::apps::notes {
 
@@ -15,8 +14,8 @@ using aztec3::utils::types::NativeTypes;
 using crypto::generators::generator_index_t;
 
 template <typename NCT> struct DefaultPrivateNoteNullifierPreimage {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     fr commitment;
     fr owner_private_key;
@@ -68,4 +67,4 @@ std::ostream& operator<<(std::ostream& os, DefaultPrivateNoteNullifierPreimage<N
               << "is_dummy: " << preimage.is_dummy << "\n";
 }
 
-} // namespace aztec3::circuits::apps::notes
+}  // namespace aztec3::circuits::apps::notes

--- a/circuits/cpp/src/aztec3/circuits/apps/notes/default_singleton_private_note/note.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/notes/default_singleton_private_note/note.hpp
@@ -1,37 +1,36 @@
 #pragma once
 
-#include "../note_interface.hpp"
-
 #include "note_preimage.hpp"
 #include "nullifier_preimage.hpp"
+#include "../note_interface.hpp"
 
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 // Forward-declare from this namespace in particular:
 namespace aztec3::circuits::apps::state_vars {
 template <typename Composer> class StateVar;
-} // namespace aztec3::circuits::apps::state_vars
+}  // namespace aztec3::circuits::apps::state_vars
 
 namespace aztec3::circuits::apps::notes {
 
-using aztec3::circuits::apps::state_vars::StateVar; // Don't #include it!
+using aztec3::circuits::apps::state_vars::StateVar;  // Don't #include it!
 
 using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
 
 template <typename Composer, typename ValueType> class DefaultSingletonPrivateNote : public NoteInterface<Composer> {
   public:
-    typedef CircuitTypes<Composer> CT;
-    typedef typename CT::fr fr;
-    typedef typename CT::grumpkin_point grumpkin_point;
-    typedef typename CT::address address;
-    typedef typename CT::boolean boolean;
+    using CT = CircuitTypes<Composer>;
+    using fr = typename CT::fr;
+    using grumpkin_point = typename CT::grumpkin_point;
+    using address = typename CT::address;
+    using boolean = typename CT::boolean;
 
     using NotePreimage = DefaultSingletonPrivateNotePreimage<CircuitTypes<Composer>, ValueType>;
     using NullifierPreimage = DefaultSingletonPrivateNoteNullifierPreimage<CircuitTypes<Composer>>;
 
-  public:
+
     StateVar<Composer>* state_var;
 
   private:
@@ -43,10 +42,9 @@ template <typename Composer, typename ValueType> class DefaultSingletonPrivateNo
 
   public:
     DefaultSingletonPrivateNote(StateVar<Composer>* state_var, NotePreimage note_preimage)
-        : state_var(state_var)
-        , note_preimage(note_preimage){};
+        : state_var(state_var), note_preimage(note_preimage){};
 
-    ~DefaultSingletonPrivateNote() {}
+    ~DefaultSingletonPrivateNote() override = default;
 
     // OVERRIDE METHODS:
 
@@ -101,7 +99,7 @@ template <typename Composer, typename ValueType> class DefaultSingletonPrivateNo
     bool is_partial() const;
 };
 
-} // namespace aztec3::circuits::apps::notes
+}  // namespace aztec3::circuits::apps::notes
 
 // Importing in this way (rather than explicit instantiation of a template class at the bottom of a .cpp file) preserves
 // the following:

--- a/circuits/cpp/src/aztec3/circuits/apps/notes/default_singleton_private_note/note.tpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/notes/default_singleton_private_note/note.tpp
@@ -68,10 +68,10 @@ typename CircuitTypes<Composer>::fr DefaultSingletonPrivateNote<Composer, V>::co
         return *commitment;
     }
 
-    grumpkin_point storage_slot_point = state_var->storage_slot_point;
+    grumpkin_point const storage_slot_point = state_var->storage_slot_point;
 
-    std::vector<fr> inputs;
-    std::vector<generator_index_t> generators;
+    std::vector<fr> const inputs;
+    std::vector<generator_index_t> const generators;
 
     auto gen_pair_address = [&](std::optional<address> const& input, size_t const hash_sub_index) {
         if (!input) {
@@ -119,7 +119,7 @@ typename CircuitTypes<Composer>::fr DefaultSingletonPrivateNote<Composer, V>::co
         compute_commitment();
     }
 
-    fr& owner_private_key = get_oracle().get_msg_sender_private_key();
+    fr const& owner_private_key = get_oracle().get_msg_sender_private_key();
 
     nullifier = DefaultSingletonPrivateNote<Composer, V>::compute_nullifier(*commitment, owner_private_key);
     nullifier_preimage = {
@@ -133,8 +133,8 @@ template <typename Composer, typename V>
 typename CircuitTypes<Composer>::fr DefaultSingletonPrivateNote<Composer, V>::compute_dummy_nullifier()
 {
     auto& oracle = get_oracle();
-    fr dummy_commitment = oracle.generate_random_element();
-    fr& owner_private_key = oracle.get_msg_sender_private_key();
+    fr const dummy_commitment = oracle.generate_random_element();
+    fr const& owner_private_key = oracle.get_msg_sender_private_key();
     const boolean is_dummy_commitment = true;
 
     return DefaultSingletonPrivateNote<Composer, V>::compute_nullifier(
@@ -184,8 +184,7 @@ template <typename Composer, typename V>
 void DefaultSingletonPrivateNote<Composer, V>::constrain_against_advice(NoteInterface<Composer> const& advice_note)
 {
     // Cast from a ref to the base (interface) type to a ref to this derived type:
-    const DefaultSingletonPrivateNote<Composer, V>& advice_note_ref =
-        dynamic_cast<const DefaultSingletonPrivateNote<Composer, V>&>(advice_note);
+    const auto& advice_note_ref = dynamic_cast<const DefaultSingletonPrivateNote<Composer, V>&>(advice_note);
 
     auto assert_equal = []<typename T>(std::optional<T>& this_member, std::optional<T> const& advice_member) {
         if (advice_member) {

--- a/circuits/cpp/src/aztec3/circuits/apps/notes/default_singleton_private_note/note_preimage.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/notes/default_singleton_private_note/note_preimage.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <barretenberg/common/map.hpp>
-#include <barretenberg/common/streams.hpp>
-
-#include <barretenberg/crypto/generators/generator_data.hpp>
-
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/common/map.hpp>
+#include <barretenberg/common/streams.hpp>
+#include <barretenberg/crypto/generators/generator_data.hpp>
 
 namespace aztec3::circuits::apps::notes {
 
@@ -16,10 +15,10 @@ using aztec3::utils::types::NativeTypes;
 using crypto::generators::generator_index_t;
 
 template <typename NCT, typename V> struct DefaultSingletonPrivateNotePreimage {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::grumpkin_point grumpkin_point;
-    typedef typename NCT::address address;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using grumpkin_point = typename NCT::grumpkin_point;
+    using address = typename NCT::address;
+    using boolean = typename NCT::boolean;
 
     // No custom constructors so that designated initializers can be used (for readability of test circuits).
 
@@ -73,7 +72,6 @@ template <typename NCT, typename V> struct DefaultSingletonPrivateNotePreimage {
 
     template <typename Composer> auto to_native_type() const
     {
-
         static_assert(!std::is_same<NativeTypes, NCT>::value);
 
         auto to_nt = [&](auto& e) { return aztec3::utils::types::to_nt<Composer>(e); };
@@ -135,4 +133,4 @@ std::ostream& operator<<(std::ostream& os, DefaultSingletonPrivateNotePreimage<N
               << "nonce: " << preimage.nonce << "\n";
 }
 
-} // namespace aztec3::circuits::apps::notes
+}  // namespace aztec3::circuits::apps::notes

--- a/circuits/cpp/src/aztec3/circuits/apps/notes/default_singleton_private_note/nullifier_preimage.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/notes/default_singleton_private_note/nullifier_preimage.hpp
@@ -1,12 +1,11 @@
 #pragma once
-#include <barretenberg/common/map.hpp>
-#include <barretenberg/common/streams.hpp>
-
-#include <barretenberg/crypto/generators/generator_data.hpp>
-
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/common/map.hpp>
+#include <barretenberg/common/streams.hpp>
+#include <barretenberg/crypto/generators/generator_data.hpp>
 
 namespace aztec3::circuits::apps::notes {
 
@@ -15,8 +14,8 @@ using aztec3::utils::types::NativeTypes;
 using crypto::generators::generator_index_t;
 
 template <typename NCT> struct DefaultSingletonPrivateNoteNullifierPreimage {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::boolean boolean;
+    using fr = typename NCT::fr;
+    using boolean = typename NCT::boolean;
 
     fr commitment;
     fr owner_private_key;
@@ -69,4 +68,4 @@ std::ostream& operator<<(std::ostream& os, DefaultSingletonPrivateNoteNullifierP
               << "is_dummy: " << preimage.is_dummy << "\n";
 }
 
-} // namespace aztec3::circuits::apps::notes
+}  // namespace aztec3::circuits::apps::notes

--- a/circuits/cpp/src/aztec3/circuits/apps/notes/note_interface.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/notes/note_interface.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 namespace aztec3::circuits::apps::notes {
 
@@ -17,16 +17,16 @@ using aztec3::utils::types::NativeTypes;
  */
 template <typename Composer> class NoteInterface {
   public:
-    typedef CircuitTypes<Composer> CT;
-    typedef typename CT::fr fr;
-    typedef typename CT::grumpkin_point grumpkin_point;
-    typedef typename CT::address address;
-    typedef typename CT::boolean boolean;
+    using CT = CircuitTypes<Composer>;
+    using fr = typename CT::fr;
+    using grumpkin_point = typename CT::grumpkin_point;
+    using address = typename CT::address;
+    using boolean = typename CT::boolean;
 
     // Destructor explicitly made virtual, to ensure that the destructor of the derived class is called if the derived
     // object is deleted through a pointer to this base class. (In many places in the code, files handle
     // `NoteInterface*` pointers instead of the derived class).
-    virtual ~NoteInterface() {}
+    virtual ~NoteInterface() = default;
 
     // TODO: maybe rather than have this be a pure interface, we should have a constructor and the `state_var*` and
     // `note_preimage` members here (although that would require a NotePreimage template param).
@@ -51,4 +51,4 @@ template <typename Composer> class NoteInterface {
     virtual fr generate_nonce() = 0;
 };
 
-} // namespace aztec3::circuits::apps::notes
+}  // namespace aztec3::circuits::apps::notes

--- a/circuits/cpp/src/aztec3/circuits/apps/opcodes/opcodes.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/opcodes/opcodes.hpp
@@ -1,20 +1,21 @@
 #pragma once
 
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::apps::state_vars {
 template <typename Composer> class StateVar;
 template <typename Composer, typename Note> class UTXOStateVar;
 template <typename Composer, typename Note> class UTXOSetStateVar;
-} // namespace aztec3::circuits::apps::state_vars
+}  // namespace aztec3::circuits::apps::state_vars
 
 namespace aztec3::circuits::apps::opcodes {
 
-using aztec3::circuits::apps::state_vars::StateVar;        // Don't #include it!
-using aztec3::circuits::apps::state_vars::UTXOSetStateVar; // Don't #include it!
-using aztec3::circuits::apps::state_vars::UTXOStateVar;    // Don't #include it!
+using aztec3::circuits::apps::state_vars::StateVar;         // Don't #include it!
+using aztec3::circuits::apps::state_vars::UTXOSetStateVar;  // Don't #include it!
+using aztec3::circuits::apps::state_vars::UTXOStateVar;     // Don't #include it!
 
 using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
@@ -32,8 +33,8 @@ using plonk::stdlib::witness_t;
  */
 template <typename Composer> class Opcodes {
   public:
-    typedef CircuitTypes<Composer> CT;
-    typedef typename CT::address address;
+    using CT = CircuitTypes<Composer>;
+    using address = typename CT::address;
 
     /**
      * @brief
@@ -50,10 +51,9 @@ template <typename Composer> class Opcodes {
      * - Generate constraints to prove each datum's existence in the tree
      * - Validate the data
      */
-    template <typename Note>
-    static std::vector<Note> UTXO_SLOAD(UTXOSetStateVar<Composer, Note>* utxo_set_state_var,
-                                        size_t const& num_notes,
-                                        typename Note::NotePreimage const& advice);
+    template <typename Note> static std::vector<Note> UTXO_SLOAD(UTXOSetStateVar<Composer, Note>* utxo_set_state_var,
+                                                                 size_t const& num_notes,
+                                                                 typename Note::NotePreimage const& advice);
 
     /**
      * @brief Compute and push a new nullifier to the public inputs of this exec_ctx.
@@ -73,7 +73,7 @@ template <typename Composer> class Opcodes {
     static void UTXO_SSTORE(StateVar<Composer>* state_var, typename Note::NotePreimage new_note_preimage);
 };
 
-} // namespace aztec3::circuits::apps::opcodes
+}  // namespace aztec3::circuits::apps::opcodes
 
 // Importing in this way (rather than explicit instantiation of a template class at the bottom of a .cpp file) preserves
 // the following:

--- a/circuits/cpp/src/aztec3/circuits/apps/opcodes/opcodes.tpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/opcodes/opcodes.tpp
@@ -33,10 +33,10 @@ Note Opcodes<Composer>::UTXO_SLOAD(UTXOStateVar<Composer, Note>* utxo_state_var,
 {
     auto& oracle = utxo_state_var->exec_ctx->oracle;
 
-    typename CT::grumpkin_point& storage_slot_point = utxo_state_var->storage_slot_point;
+    typename CT::grumpkin_point const& storage_slot_point = utxo_state_var->storage_slot_point;
 
     // Retrieve UTXO witness datum from the DB:
-    UTXOSLoadDatum<CT, typename Note::NotePreimage> utxo_datum =
+    UTXOSLoadDatum<CT, typename Note::NotePreimage> const utxo_datum =
         oracle.template get_utxo_sload_datum<typename Note::NotePreimage>(storage_slot_point, advice);
 
     Note new_note{ utxo_state_var, utxo_datum.preimage };
@@ -68,7 +68,7 @@ std::vector<Note> Opcodes<Composer>::UTXO_SLOAD(UTXOSetStateVar<Composer, Note>*
 {
     auto& oracle = utxo_set_state_var->exec_ctx->oracle;
 
-    typename CT::grumpkin_point& storage_slot_point = utxo_set_state_var->storage_slot_point;
+    typename CT::grumpkin_point const& storage_slot_point = utxo_set_state_var->storage_slot_point;
 
     // Retrieve multiple UTXO witness datum's from the DB:
     std::vector<UTXOSLoadDatum<CT, typename Note::NotePreimage>> utxo_data =
@@ -109,13 +109,13 @@ template <typename Composer>
 template <typename Note>
 void Opcodes<Composer>::UTXO_NULL(StateVar<Composer>* state_var, Note& note_to_nullify)
 {
-    typename CT::fr nullifier = note_to_nullify.get_nullifier();
+    typename CT::fr const nullifier = note_to_nullify.get_nullifier();
 
     auto& exec_ctx = state_var->exec_ctx;
 
     exec_ctx->new_nullifiers.push_back(nullifier);
 
-    std::shared_ptr<Note> nullified_note_ptr = std::make_shared<Note>(note_to_nullify);
+    std::shared_ptr<Note> const nullified_note_ptr = std::make_shared<Note>(note_to_nullify);
 
     exec_ctx->nullified_notes.push_back(nullified_note_ptr);
 };
@@ -124,13 +124,13 @@ template <typename Composer>
 template <typename Note>
 void Opcodes<Composer>::UTXO_INIT(StateVar<Composer>* state_var, Note& note_to_initialise)
 {
-    typename CT::fr init_nullifier = note_to_initialise.get_initialisation_nullifier();
+    typename CT::fr const init_nullifier = note_to_initialise.get_initialisation_nullifier();
 
     auto& exec_ctx = state_var->exec_ctx;
 
     exec_ctx->new_nullifiers.push_back(init_nullifier);
 
-    std::shared_ptr<Note> init_note_ptr = std::make_shared<Note>(note_to_initialise);
+    std::shared_ptr<Note> const init_note_ptr = std::make_shared<Note>(note_to_initialise);
 
     // TODO: consider whether this should actually be pushed-to...
     exec_ctx->nullified_notes.push_back(init_note_ptr);
@@ -146,7 +146,7 @@ void Opcodes<Composer>::UTXO_SSTORE(StateVar<Composer>* state_var, typename Note
 
     // Make a shared pointer, so we don't end up with a dangling pointer in the exec_ctx when this `new_note`
     // immediately goes out of scope.
-    std::shared_ptr<Note> new_note_ptr = std::make_shared<Note>(state_var, new_note_preimage);
+    std::shared_ptr<Note> const new_note_ptr = std::make_shared<Note>(state_var, new_note_preimage);
 
     exec_ctx->new_notes.push_back(new_note_ptr);
 };

--- a/circuits/cpp/src/aztec3/circuits/apps/oracle_wrapper.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/oracle_wrapper.hpp
@@ -2,12 +2,11 @@
 #include <aztec3/circuits/abis/call_context.hpp>
 #include <aztec3/circuits/abis/contract_deployment_data.hpp>
 #include <aztec3/oracle/oracle.hpp>
-
-#include <barretenberg/common/map.hpp>
-
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/common/map.hpp>
 
 namespace aztec3::circuits::apps {
 
@@ -38,8 +37,7 @@ template <typename Composer> class OracleWrapperInterface {
     // Initialise from Native.
     // Used when initialising for a user's first call.
     OracleWrapperInterface(Composer& composer, NativeOracle& native_oracle)
-        : composer(composer)
-        , native_oracle(native_oracle){};
+        : composer(composer), native_oracle(native_oracle){};
 
     fr& get_msg_sender_private_key()
     {
@@ -96,10 +94,9 @@ template <typename Composer> class OracleWrapperInterface {
         return native_utxo_sload_datum.to_circuit_type(composer);
     }
 
-    template <typename NotePreimage>
-    auto get_utxo_sload_data(grumpkin_point const& storage_slot_point,
-                             size_t const& num_notes,
-                             NotePreimage const& advice)
+    template <typename NotePreimage> auto get_utxo_sload_data(grumpkin_point const& storage_slot_point,
+                                                              size_t const& num_notes,
+                                                              NotePreimage const& advice)
     {
         auto native_storage_slot_point = aztec3::utils::types::to_nt<Composer>(storage_slot_point);
 
@@ -120,8 +117,8 @@ template <typename Composer> class OracleWrapperInterface {
 
     void validate_msg_sender_private_key()
     {
-        address msg_sender = get_msg_sender();
-        address derived_msg_sender = address::derive_from_private_key(*msg_sender_private_key);
+        const address msg_sender = get_msg_sender();
+        const address derived_msg_sender = address::derive_from_private_key(*msg_sender_private_key);
         msg_sender.assert_equal(derived_msg_sender,
                                 format("msg_sender validation failed.\nmsg_sender_private_key: ",
                                        msg_sender_private_key,
@@ -132,4 +129,4 @@ template <typename Composer> class OracleWrapperInterface {
     }
 };
 
-} // namespace aztec3::circuits::apps
+}  // namespace aztec3::circuits::apps

--- a/circuits/cpp/src/aztec3/circuits/apps/oracle_wrapper.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/oracle_wrapper.hpp
@@ -25,10 +25,10 @@ using aztec3::utils::types::CircuitTypes;
  * certain information.
  */
 template <typename Composer> class OracleWrapperInterface {
-    typedef CircuitTypes<Composer> CT;
-    typedef typename CT::fr fr;
-    typedef typename CT::grumpkin_point grumpkin_point;
-    typedef typename CT::address address;
+    using CT = CircuitTypes<Composer>;
+    using fr = typename CT::fr;
+    using grumpkin_point = typename CT::grumpkin_point;
+    using address = typename CT::address;
 
   public:
     Composer& composer;

--- a/circuits/cpp/src/aztec3/circuits/apps/state_vars/field_state_var.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/state_vars/field_state_var.hpp
@@ -27,7 +27,7 @@ template <typename Composer> class FieldStateVar : public StateVar<Composer> {
         return *this;
     }
 
-    FieldStateVar(){};
+    FieldStateVar() {}
 
     // Instantiate a top-level var:
     FieldStateVar(FunctionExecutionContext<Composer>* exec_ctx, std::string const& state_var_name, fr const& start_slot)

--- a/circuits/cpp/src/aztec3/circuits/apps/state_vars/field_state_var.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/state_vars/field_state_var.hpp
@@ -3,8 +3,8 @@
 #include "state_var_base.hpp"
 #include "../function_execution_context.hpp"
 
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 namespace aztec3::circuits::apps::state_vars {
 
@@ -14,10 +14,10 @@ using aztec3::utils::types::NativeTypes;
 // TODO: we can probably generalise this to be a PrimitiveStateVar for any stdlib primitive.
 template <typename Composer> class FieldStateVar : public StateVar<Composer> {
   public:
-    typedef CircuitTypes<Composer> CT;
-    typedef NativeTypes NT;
-    typedef typename CT::fr fr;
-    typedef typename CT::grumpkin_point grumpkin_point;
+    using CT = CircuitTypes<Composer>;
+    using NT = NativeTypes;
+    using fr = typename CT::fr;
+    using grumpkin_point = typename CT::grumpkin_point;
 
     fr value = 0;
 
@@ -27,7 +27,7 @@ template <typename Composer> class FieldStateVar : public StateVar<Composer> {
         return *this;
     }
 
-    FieldStateVar() {}
+    FieldStateVar() = default;
 
     // Instantiate a top-level var:
     FieldStateVar(FunctionExecutionContext<Composer>* exec_ctx, std::string const& state_var_name, fr const& start_slot)
@@ -50,4 +50,4 @@ template <typename Composer> inline std::ostream& operator<<(std::ostream& os, F
     return os << v.value;
 }
 
-} // namespace aztec3::circuits::apps::state_vars
+}  // namespace aztec3::circuits::apps::state_vars

--- a/circuits/cpp/src/aztec3/circuits/apps/state_vars/mapping_state_var.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/state_vars/mapping_state_var.hpp
@@ -35,7 +35,7 @@ template <typename Composer, typename V> class MappingStateVar : public StateVar
     // native_storage_slot.x => value cache, to prevent creating constraints with each `at()` call.
     std::map<NT::fr, V> value_cache;
 
-    MappingStateVar(){};
+    MappingStateVar() {}
 
     // Instantiate a top-level mapping:
     MappingStateVar(FunctionExecutionContext<Composer>* exec_ctx, std::string const& state_var_name)

--- a/circuits/cpp/src/aztec3/circuits/apps/state_vars/mapping_state_var.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/state_vars/mapping_state_var.hpp
@@ -3,8 +3,8 @@
 #include "state_var_base.hpp"
 // #include "../function_execution_context.hpp"
 
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 // Forward-declare from this namespace in particular:
 namespace aztec3::circuits::apps {
@@ -13,7 +13,7 @@ template <typename Composer> class FunctionExecutionContext;
 
 namespace aztec3::circuits::apps::state_vars {
 
-using aztec3::circuits::apps::FunctionExecutionContext; // Don't #include it!
+using aztec3::circuits::apps::FunctionExecutionContext;  // Don't #include it!
 
 using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
@@ -27,15 +27,15 @@ using aztec3::utils::types::NativeTypes;
  */
 template <typename Composer, typename V> class MappingStateVar : public StateVar<Composer> {
   public:
-    typedef CircuitTypes<Composer> CT;
-    typedef NativeTypes NT;
-    typedef typename CT::fr fr;
-    typedef typename CT::grumpkin_point grumpkin_point;
+    using CT = CircuitTypes<Composer>;
+    using NT = NativeTypes;
+    using fr = typename CT::fr;
+    using grumpkin_point = typename CT::grumpkin_point;
 
     // native_storage_slot.x => value cache, to prevent creating constraints with each `at()` call.
     std::map<NT::fr, V> value_cache;
 
-    MappingStateVar() {}
+    MappingStateVar() = default;
 
     // Instantiate a top-level mapping:
     MappingStateVar(FunctionExecutionContext<Composer>* exec_ctx, std::string const& state_var_name)
@@ -71,7 +71,7 @@ template <typename Composer, typename V> class MappingStateVar : public StateVar
     std::tuple<grumpkin_point, bool> compute_slot_point_at_mapping_key(std::optional<fr> const& key);
 };
 
-} // namespace aztec3::circuits::apps::state_vars
+}  // namespace aztec3::circuits::apps::state_vars
 
 // Importing in this way (rather than explicit instantiation of a template class at the bottom of a .cpp file) preserves
 // the following:

--- a/circuits/cpp/src/aztec3/circuits/apps/state_vars/state_var_base.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/state_vars/state_var_base.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 // Forward-declare from this namespace in particular:
 namespace aztec3::circuits::apps {
@@ -10,7 +10,7 @@ template <typename Composer> class FunctionExecutionContext;
 
 namespace aztec3::circuits::apps::state_vars {
 
-using aztec3::circuits::apps::FunctionExecutionContext; // Don't #include it!
+using aztec3::circuits::apps::FunctionExecutionContext;  // Don't #include it!
 
 using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
@@ -22,10 +22,10 @@ using aztec3::utils::types::NativeTypes;
  */
 template <typename Composer> class StateVar {
   public:
-    typedef CircuitTypes<Composer> CT;
-    typedef NativeTypes NT;
-    typedef typename CT::fr fr;
-    typedef typename CT::grumpkin_point grumpkin_point;
+    using CT = CircuitTypes<Composer>;
+    using NT = NativeTypes;
+    using fr = typename CT::fr;
+    using grumpkin_point = typename CT::grumpkin_point;
 
     // The execution context of the function currently being executed.
     FunctionExecutionContext<Composer>* exec_ctx;
@@ -54,7 +54,7 @@ template <typename Composer> class StateVar {
     // Optionally informs custom notes whether they should commit or partially-commit to this state.
     bool is_partial_slot = false;
 
-    StateVar() {}
+    StateVar() = default;
 
     // Instantiate a top-level state:
     StateVar(FunctionExecutionContext<Composer>* exec_ctx, std::string const& state_var_name);
@@ -63,8 +63,8 @@ template <typename Composer> class StateVar {
     StateVar(
         FunctionExecutionContext<Composer>* exec_ctx,
         std::string const& state_var_name,
-        grumpkin_point const& storage_slot_point, // the parent always calculates the storage_slot_point of its child.
-        size_t level_of_container_nesting,        // the parent always calculates the level of nesting of its child.
+        grumpkin_point const& storage_slot_point,  // the parent always calculates the storage_slot_point of its child.
+        size_t level_of_container_nesting,         // the parent always calculates the level of nesting of its child.
         bool is_partial_slot = false)
         : exec_ctx(exec_ctx)
         , state_var_name(state_var_name)
@@ -89,7 +89,7 @@ template <typename Composer> class StateVar {
     grumpkin_point compute_slot_point();
 };
 
-} // namespace aztec3::circuits::apps::state_vars
+}  // namespace aztec3::circuits::apps::state_vars
 
 // Importing in this way (rather than explicit instantiation of a template class at the bottom of a .cpp file) preserves
 // the following:

--- a/circuits/cpp/src/aztec3/circuits/apps/state_vars/state_var_base.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/state_vars/state_var_base.hpp
@@ -54,7 +54,7 @@ template <typename Composer> class StateVar {
     // Optionally informs custom notes whether they should commit or partially-commit to this state.
     bool is_partial_slot = false;
 
-    StateVar(){};
+    StateVar() {}
 
     // Instantiate a top-level state:
     StateVar(FunctionExecutionContext<Composer>* exec_ctx, std::string const& state_var_name);

--- a/circuits/cpp/src/aztec3/circuits/apps/state_vars/state_var_base.tpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/state_vars/state_var_base.tpp
@@ -23,8 +23,11 @@ StateVar<Composer>::StateVar(FunctionExecutionContext<Composer>* exec_ctx, std::
     : exec_ctx(exec_ctx)
     , state_var_name(state_var_name)
 {
+    // NOLINTBEGIN(cppcoreguidelines-prefer-member-initializer)
+    // this ^ linter rule breaks things here here
     start_slot = exec_ctx->contract->get_start_slot(state_var_name);
     storage_slot_point = compute_slot_point();
+    // NOLINTEND(cppcoreguidelines-prefer-member-initializer)
 }
 
 template <typename Composer> typename CircuitTypes<Composer>::grumpkin_point StateVar<Composer>::compute_slot_point()

--- a/circuits/cpp/src/aztec3/circuits/apps/state_vars/utxo_set_state_var.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/state_vars/utxo_set_state_var.hpp
@@ -34,7 +34,7 @@ template <typename Composer, typename Note> class UTXOSetStateVar : public State
 
     typedef typename Note::NotePreimage NotePreimage;
 
-    UTXOSetStateVar(){};
+    UTXOSetStateVar() {}
 
     // Instantiate a top-level var:
     UTXOSetStateVar(FunctionExecutionContext<Composer>* exec_ctx, std::string const& state_var_name)

--- a/circuits/cpp/src/aztec3/circuits/apps/state_vars/utxo_set_state_var.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/state_vars/utxo_set_state_var.hpp
@@ -2,8 +2,8 @@
 
 #include "state_var_base.hpp"
 
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 // Forward-declare from this namespace in particular:
 namespace aztec3::circuits::apps {
@@ -12,7 +12,7 @@ template <typename Composer> class FunctionExecutionContext;
 
 namespace aztec3::circuits::apps::state_vars {
 
-using aztec3::circuits::apps::FunctionExecutionContext; // Don't #include it!
+using aztec3::circuits::apps::FunctionExecutionContext;  // Don't #include it!
 
 using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
@@ -27,14 +27,14 @@ using aztec3::utils::types::NativeTypes;
  */
 template <typename Composer, typename Note> class UTXOSetStateVar : public StateVar<Composer> {
   public:
-    typedef CircuitTypes<Composer> CT;
-    typedef NativeTypes NT;
-    typedef typename CT::fr fr;
-    typedef typename CT::grumpkin_point grumpkin_point;
+    using CT = CircuitTypes<Composer>;
+    using NT = NativeTypes;
+    using fr = typename CT::fr;
+    using grumpkin_point = typename CT::grumpkin_point;
 
-    typedef typename Note::NotePreimage NotePreimage;
+    using NotePreimage = typename Note::NotePreimage;
 
-    UTXOSetStateVar() {}
+    UTXOSetStateVar() = default;
 
     // Instantiate a top-level var:
     UTXOSetStateVar(FunctionExecutionContext<Composer>* exec_ctx, std::string const& state_var_name)
@@ -59,6 +59,6 @@ template <typename Composer, typename Note> class UTXOSetStateVar : public State
     void insert(NotePreimage new_note_preimage);
 };
 
-} // namespace aztec3::circuits::apps::state_vars
+}  // namespace aztec3::circuits::apps::state_vars
 
 #include "utxo_set_state_var.tpp"

--- a/circuits/cpp/src/aztec3/circuits/apps/state_vars/utxo_state_var.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/state_vars/utxo_state_var.hpp
@@ -36,7 +36,7 @@ template <typename Composer, typename Note> class UTXOStateVar : public StateVar
 
     typedef typename Note::NotePreimage NotePreimage;
 
-    UTXOStateVar(){};
+    UTXOStateVar() {}
 
     // Instantiate a top-level var:
     UTXOStateVar(FunctionExecutionContext<Composer>* exec_ctx, std::string const& state_var_name)

--- a/circuits/cpp/src/aztec3/circuits/apps/state_vars/utxo_state_var.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/state_vars/utxo_state_var.hpp
@@ -2,8 +2,8 @@
 
 #include "state_var_base.hpp"
 
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 // Forward-declare from this namespace in particular:
 namespace aztec3::circuits::apps {
@@ -12,7 +12,7 @@ template <typename Composer> class FunctionExecutionContext;
 
 namespace aztec3::circuits::apps::state_vars {
 
-using aztec3::circuits::apps::FunctionExecutionContext; // Don't #include it!
+using aztec3::circuits::apps::FunctionExecutionContext;  // Don't #include it!
 
 using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
@@ -28,15 +28,15 @@ using aztec3::utils::types::NativeTypes;
  */
 template <typename Composer, typename Note> class UTXOStateVar : public StateVar<Composer> {
   public:
-    typedef CircuitTypes<Composer> CT;
-    typedef NativeTypes NT;
-    typedef typename CT::fr fr;
-    typedef typename CT::grumpkin_point grumpkin_point;
-    typedef typename CT::address address;
+    using CT = CircuitTypes<Composer>;
+    using NT = NativeTypes;
+    using fr = typename CT::fr;
+    using grumpkin_point = typename CT::grumpkin_point;
+    using address = typename CT::address;
 
-    typedef typename Note::NotePreimage NotePreimage;
+    using NotePreimage = typename Note::NotePreimage;
 
-    UTXOStateVar() {}
+    UTXOStateVar() = default;
 
     // Instantiate a top-level var:
     UTXOStateVar(FunctionExecutionContext<Composer>* exec_ctx, std::string const& state_var_name)
@@ -68,6 +68,6 @@ template <typename Composer, typename Note> class UTXOStateVar : public StateVar
     void insert(NotePreimage new_note_preimage);
 };
 
-} // namespace aztec3::circuits::apps::state_vars
+}  // namespace aztec3::circuits::apps::state_vars
 
 #include "utxo_state_var.tpp"

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/basic_contract_deployment/basic_contract_deployment.cpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/basic_contract_deployment/basic_contract_deployment.cpp
@@ -22,9 +22,9 @@ OptionalPrivateCircuitPublicInputs<NT> constructor(FunctionExecutionContext& exe
     // Convert params into circuit types:
     auto& composer = exec_ctx.composer;
 
-    CT::fr arg0 = to_ct(composer, args[0]);
-    CT::fr arg1 = to_ct(composer, args[1]);
-    CT::fr arg2 = to_ct(composer, args[2]);
+    CT::fr const arg0 = to_ct(composer, args[0]);
+    CT::fr const arg1 = to_ct(composer, args[1]);
+    CT::fr const arg2 = to_ct(composer, args[2]);
 
     auto& oracle = exec_ctx.oracle;
     const CT::address msg_sender = oracle.get_msg_sender();
@@ -53,4 +53,4 @@ OptionalPrivateCircuitPublicInputs<NT> constructor(FunctionExecutionContext& exe
     return public_inputs.to_native_type<C>();
 }
 
-} // namespace aztec3::circuits::apps::test_apps::basic_contract_deployment
+}  // namespace aztec3::circuits::apps::test_apps::basic_contract_deployment

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/basic_contract_deployment/basic_contract_deployment.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/basic_contract_deployment/basic_contract_deployment.hpp
@@ -12,4 +12,4 @@ using aztec3::circuits::abis::OptionalPrivateCircuitPublicInputs;
 OptionalPrivateCircuitPublicInputs<NT> constructor(FunctionExecutionContext& exec_ctx,
                                                    std::array<NT::fr, ARGS_LENGTH> const& args);
 
-} // namespace aztec3::circuits::apps::test_apps::basic_contract_deployment
+}  // namespace aztec3::circuits::apps::test_apps::basic_contract_deployment

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/basic_contract_deployment/contract.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/basic_contract_deployment/contract.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "init.hpp"
-
 #include "contract.hpp"
+#include "init.hpp"
 
 #include <aztec3/circuits/apps/contract.hpp>
 #include <aztec3/circuits/apps/function_declaration.hpp>
@@ -21,4 +20,4 @@ inline Contract init_contract()
     return contract;
 }
 
-} // namespace aztec3::circuits::apps::test_apps::basic_contract_deployment
+}  // namespace aztec3::circuits::apps::test_apps::basic_contract_deployment

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/basic_contract_deployment/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/basic_contract_deployment/init.hpp
@@ -3,14 +3,12 @@
 #include <aztec3/circuits/apps/contract.hpp>
 #include <aztec3/circuits/apps/function_execution_context.hpp>
 #include <aztec3/circuits/apps/notes/default_private_note/note.hpp>
+#include <aztec3/circuits/apps/oracle_wrapper.hpp>
 #include <aztec3/circuits/apps/state_vars/mapping_state_var.hpp>
 #include <aztec3/circuits/apps/state_vars/utxo_set_state_var.hpp>
-
-#include <aztec3/circuits/apps/oracle_wrapper.hpp>
 #include <aztec3/oracle/oracle.hpp>
-
-#include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/native_types.hpp>
 
 namespace aztec3::circuits::apps::test_apps::basic_contract_deployment {
@@ -38,8 +36,8 @@ using apps::state_vars::UTXOSetStateVar;
 
 // Get rid of ugle `Composer` template arg from our state var types:
 template <typename T> struct SpecialisedTypes {
-    typedef MappingStateVar<C, T> mapping;
-    typedef UTXOSetStateVar<C, T> utxo_set;
+    using mapping = MappingStateVar<C, T>;
+    using utxo_set = UTXOSetStateVar<C, T>;
 };
 
 template <typename V> using Mapping = typename SpecialisedTypes<V>::mapping;
@@ -47,4 +45,4 @@ template <typename Note> using UTXOSet = typename SpecialisedTypes<Note>::utxo_s
 
 using DefaultNote = apps::notes::DefaultPrivateNote<C, CT::fr>;
 
-} // namespace aztec3::circuits::apps::test_apps::basic_contract_deployment
+}  // namespace aztec3::circuits::apps::test_apps::basic_contract_deployment

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/.test.cpp
@@ -1,13 +1,14 @@
-#include "index.hpp"
 #include "contract.hpp"
+#include "index.hpp"
 
 // #include <aztec3/circuits/abis/call_context.hpp>
 // #include <aztec3/circuits/abis/function_data.hpp>
 
 // #include <aztec3/circuits/apps/function_execution_context.hpp>
 
-#include <gtest/gtest.h>
 #include <barretenberg/common/test.hpp>
+
+#include <gtest/gtest.h>
 // #include <barretenberg/common/serialize.hpp>
 // #include <barretenberg/stdlib/types/types.hpp>
 // #include <barretenberg/numeric/random/engine.hpp>
@@ -16,20 +17,20 @@ namespace aztec3::circuits::apps::test_apps::escrow {
 
 class escrow_tests : public ::testing::Test {
   protected:
-    NativeOracle get_test_native_oracle(DB& db)
+    static NativeOracle get_test_native_oracle(DB& db)
     {
         const NT::address contract_address = 12345;
         const NT::fr msg_sender_private_key = 123456789;
         const NT::address msg_sender = NT::fr(
             uint256_t(0x01071e9a23e0f7edULL, 0x5d77b35d1830fa3eULL, 0xc6ba3660bb1f0c0bULL, 0x2ef9f7f09867fd6eULL));
 
-        FunctionData<NT> function_data{
-            .function_selector = 1, // TODO: deduce this from the contract, somehow.
+        FunctionData<NT> const function_data{
+            .function_selector = 1,  // TODO: deduce this from the contract, somehow.
             .is_private = true,
             .is_constructor = false,
         };
 
-        CallContext<NT> call_context{
+        CallContext<NT> const call_context{
             .msg_sender = msg_sender,
             .storage_contract_address = contract_address,
             .portal_contract_address = 0,
@@ -121,4 +122,4 @@ TEST_F(escrow_tests, circuit_withdraw)
     info("n: ", composer.num_gates);
 }
 
-} // namespace aztec3::circuits::apps::test_apps::escrow
+}  // namespace aztec3::circuits::apps::test_apps::escrow

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/contract.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/contract.hpp
@@ -30,4 +30,4 @@ inline Contract init_contract()
     return contract;
 }
 
-} // namespace aztec3::circuits::apps::test_apps::escrow
+}  // namespace aztec3::circuits::apps::test_apps::escrow

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/deposit.cpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/deposit.cpp
@@ -67,4 +67,4 @@ OptionalPrivateCircuitPublicInputs<NT> deposit(FunctionExecutionContext& exec_ct
     // TODO: or, we'll be collecting this data in the exec_ctx.
 };
 
-} // namespace aztec3::circuits::apps::test_apps::escrow
+}  // namespace aztec3::circuits::apps::test_apps::escrow

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/deposit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/deposit.hpp
@@ -12,4 +12,4 @@ using aztec3::circuits::abis::OptionalPrivateCircuitPublicInputs;
 OptionalPrivateCircuitPublicInputs<NT> deposit(FunctionExecutionContext& exec_ctx,
                                                std::array<NT::fr, ARGS_LENGTH> const& args);
 
-} // namespace aztec3::circuits::apps::test_apps::escrow
+}  // namespace aztec3::circuits::apps::test_apps::escrow

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/index.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/index.hpp
@@ -1,5 +1,5 @@
-#include "init.hpp"
 #include "contract.hpp"
 #include "deposit.hpp"
+#include "init.hpp"
 #include "transfer.hpp"
 #include "withdraw.hpp"

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/init.hpp
@@ -3,14 +3,12 @@
 #include <aztec3/circuits/apps/contract.hpp>
 #include <aztec3/circuits/apps/function_execution_context.hpp>
 #include <aztec3/circuits/apps/notes/default_private_note/note.hpp>
+#include <aztec3/circuits/apps/oracle_wrapper.hpp>
 #include <aztec3/circuits/apps/state_vars/mapping_state_var.hpp>
 #include <aztec3/circuits/apps/state_vars/utxo_set_state_var.hpp>
-
-#include <aztec3/circuits/apps/oracle_wrapper.hpp>
 #include <aztec3/oracle/oracle.hpp>
-
-#include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/native_types.hpp>
 
 namespace aztec3::circuits::apps::test_apps::escrow {
@@ -38,8 +36,8 @@ using apps::state_vars::UTXOSetStateVar;
 
 // Get rid of ugle `Composer` template arg from our state var types:
 template <typename T> struct SpecialisedTypes {
-    typedef MappingStateVar<C, T> mapping;
-    typedef UTXOSetStateVar<C, T> utxo_set;
+    using mapping = MappingStateVar<C, T>;
+    using utxo_set = UTXOSetStateVar<C, T>;
 };
 
 template <typename V> using Mapping = typename SpecialisedTypes<V>::mapping;
@@ -47,4 +45,4 @@ template <typename Note> using UTXOSet = typename SpecialisedTypes<Note>::utxo_s
 
 using DefaultNote = apps::notes::DefaultPrivateNote<C, CT::fr>;
 
-} // namespace aztec3::circuits::apps::test_apps::escrow
+}  // namespace aztec3::circuits::apps::test_apps::escrow

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/transfer.cpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/transfer.cpp
@@ -31,8 +31,8 @@ OptionalPrivateCircuitPublicInputs<NT> transfer(FunctionExecutionContext& exec_c
     CT::address to = to_ct(composer, _to);
     CT::fr asset_id = to_ct(composer, _asset_id);
     CT::fr memo = to_ct(composer, _memo);
-    CT::boolean reveal_msg_sender_to_recipient = to_ct(composer, _reveal_msg_sender_to_recipient);
-    CT::fr fee = to_ct(composer, _fee);
+    CT::boolean const reveal_msg_sender_to_recipient = to_ct(composer, _reveal_msg_sender_to_recipient);
+    CT::fr const fee = to_ct(composer, _fee);
 
     /****************************************************************
      * Get States & Globals used by the function
@@ -57,8 +57,8 @@ OptionalPrivateCircuitPublicInputs<NT> transfer(FunctionExecutionContext& exec_c
     std::vector<DefaultNote> old_balance_notes =
         balances[asset_id][msg_sender.to_field()].get(2, { .owner = msg_sender });
 
-    CT::fr old_value_1 = *(old_balance_notes[0].get_preimage().value);
-    CT::fr old_value_2 = *(old_balance_notes[1].get_preimage().value);
+    CT::fr const old_value_1 = *(old_balance_notes[0].get_preimage().value);
+    CT::fr const old_value_2 = *(old_balance_notes[1].get_preimage().value);
 
     // MISSING: overflow & underflow checks, but I can't be bothered with safe_uint or range checks yet.
     CT::fr change = (old_value_1 + old_value_2) - (amount + fee);
@@ -110,4 +110,4 @@ OptionalPrivateCircuitPublicInputs<NT> transfer(FunctionExecutionContext& exec_c
     return public_inputs.to_native_type<C>();
 };
 
-} // namespace aztec3::circuits::apps::test_apps::escrow
+}  // namespace aztec3::circuits::apps::test_apps::escrow

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/transfer.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/transfer.hpp
@@ -17,4 +17,4 @@ OptionalPrivateCircuitPublicInputs<NT> transfer(FunctionExecutionContext& exec_c
                                                 NT::boolean const& _reveal_msg_sender_to_recipient,
                                                 NT::fr const& _fee);
 
-} // namespace aztec3::circuits::apps::test_apps::escrow
+}  // namespace aztec3::circuits::apps::test_apps::escrow

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/withdraw.cpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/withdraw.cpp
@@ -26,11 +26,11 @@ OptionalPrivateCircuitPublicInputs<NT> withdraw(FunctionExecutionContext& exec_c
     // Convert arguments into circuit types:
     auto& composer = exec_ctx.composer;
 
-    CT::fr amount = to_ct(composer, _amount);
+    CT::fr const amount = to_ct(composer, _amount);
     CT::fr asset_id = to_ct(composer, _asset_id);
     CT::fr memo = to_ct(composer, _memo);
-    CT::fr l1_withdrawal_address = to_ct(composer, _l1_withdrawal_address);
-    CT::fr fee = to_ct(composer, _fee);
+    CT::fr const l1_withdrawal_address = to_ct(composer, _l1_withdrawal_address);
+    CT::fr const fee = to_ct(composer, _fee);
 
     /****************************************************************
      * Get States & Globals used by the function
@@ -52,8 +52,8 @@ OptionalPrivateCircuitPublicInputs<NT> withdraw(FunctionExecutionContext& exec_c
     std::vector<DefaultNote> old_balance_notes =
         balances[asset_id][msg_sender.to_field()].get(2, { .owner = msg_sender });
 
-    CT::fr old_value_1 = *(old_balance_notes[0].get_preimage().value);
-    CT::fr old_value_2 = *(old_balance_notes[1].get_preimage().value);
+    CT::fr const old_value_1 = *(old_balance_notes[0].get_preimage().value);
+    CT::fr const old_value_2 = *(old_balance_notes[1].get_preimage().value);
 
     // MISSING: overflow & underflow checks, but I can't be bothered with safe_uint or range checks yet.
     CT::fr change = (old_value_1 + old_value_2) - (amount + fee);
@@ -102,4 +102,4 @@ OptionalPrivateCircuitPublicInputs<NT> withdraw(FunctionExecutionContext& exec_c
     return public_inputs.to_native_type<C>();
 };
 
-} // namespace aztec3::circuits::apps::test_apps::escrow
+}  // namespace aztec3::circuits::apps::test_apps::escrow

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/withdraw.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/withdraw.hpp
@@ -16,4 +16,4 @@ OptionalPrivateCircuitPublicInputs<NT> withdraw(FunctionExecutionContext& exec_c
                                                 NT::fr const& _l1_withdrawal_address,
                                                 NT::fr const& _fee);
 
-} // namespace aztec3::circuits::apps::test_apps::escrow
+}  // namespace aztec3::circuits::apps::test_apps::escrow

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/.test.cpp
@@ -5,8 +5,9 @@
 
 // #include <aztec3/circuits/apps/function_execution_context.hpp>
 
-#include <gtest/gtest.h>
 #include <barretenberg/common/test.hpp>
+
+#include <gtest/gtest.h>
 
 namespace aztec3::circuits::apps::test_apps::private_to_private_function_call {
 
@@ -14,7 +15,6 @@ class private_to_private_function_call_tests : public ::testing::Test {};
 
 TEST(private_to_private_function_call_tests, circuit_private_to_private_function_call)
 {
-
     C fn1_composer = C("../barretenberg/cpp/srs_db/ignition");
     DB db;
 
@@ -24,7 +24,7 @@ TEST(private_to_private_function_call_tests, circuit_private_to_private_function
         uint256_t(0x01071e9a23e0f7edULL, 0x5d77b35d1830fa3eULL, 0xc6ba3660bb1f0c0bULL, 0x2ef9f7f09867fd6eULL);
 
     const FunctionData<NT> function_data{
-        .function_selector = 1, // TODO: deduce this from the contract, somehow.
+        .function_selector = 1,  // TODO: deduce this from the contract, somehow.
         .is_private = true,
         .is_constructor = false,
     };
@@ -62,4 +62,4 @@ TEST(private_to_private_function_call_tests, circuit_private_to_private_function
     info("n: ", fn1_composer.num_gates);
 }
 
-} // namespace aztec3::circuits::apps::test_apps::private_to_private_function_call
+}  // namespace aztec3::circuits::apps::test_apps::private_to_private_function_call

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/contract.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/contract.hpp
@@ -40,4 +40,4 @@ inline Contract init_contract_2()
     return contract_2;
 }
 
-} // namespace aztec3::circuits::apps::test_apps::private_to_private_function_call
+}  // namespace aztec3::circuits::apps::test_apps::private_to_private_function_call

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/function_1_1.cpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/function_1_1.cpp
@@ -1,7 +1,7 @@
 #include "function_1_1.hpp"
-#include "function_2_1.hpp"
 
 #include "contract.hpp"
+#include "function_2_1.hpp"
 
 #include <aztec3/circuits/apps/function_execution_context.hpp>
 
@@ -85,4 +85,4 @@ void function_1_1(FunctionExecutionContext& exec_ctx, std::array<NT::fr, ARGS_LE
     exec_ctx.finalise();
 };
 
-} // namespace aztec3::circuits::apps::test_apps::private_to_private_function_call
+}  // namespace aztec3::circuits::apps::test_apps::private_to_private_function_call

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/function_1_1.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/function_1_1.hpp
@@ -8,4 +8,4 @@ namespace aztec3::circuits::apps::test_apps::private_to_private_function_call {
 
 void function_1_1(FunctionExecutionContext& exec_ctx, std::array<NT::fr, ARGS_LENGTH> const& _args);
 
-} // namespace aztec3::circuits::apps::test_apps::private_to_private_function_call
+}  // namespace aztec3::circuits::apps::test_apps::private_to_private_function_call

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/function_2_1.cpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/function_2_1.cpp
@@ -6,7 +6,6 @@
 
 namespace aztec3::circuits::apps::test_apps::private_to_private_function_call {
 
-using aztec3::circuits::abis::OptionalPrivateCircuitPublicInputs;
 
 void function_2_1(FunctionExecutionContext& exec_ctx, std::array<NT::fr, ARGS_LENGTH> const& _args)
 {
@@ -41,7 +40,7 @@ void function_2_1(FunctionExecutionContext& exec_ctx, std::array<NT::fr, ARGS_LE
 
     auto product = a * b * c;
 
-    CT::address unique_person_who_may_initialise = 999999;
+    CT::address const unique_person_who_may_initialise = 999999;
 
     unique_person_who_may_initialise.assert_equal(msg_sender);
 
@@ -73,4 +72,4 @@ void function_2_1(FunctionExecutionContext& exec_ctx, std::array<NT::fr, ARGS_LE
     // TODO: also return note preimages and nullifier preimages.
 };
 
-} // namespace aztec3::circuits::apps::test_apps::private_to_private_function_call
+}  // namespace aztec3::circuits::apps::test_apps::private_to_private_function_call

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/function_2_1.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/function_2_1.hpp
@@ -10,4 +10,4 @@ using aztec3::circuits::abis::OptionalPrivateCircuitPublicInputs;
 
 void function_2_1(FunctionExecutionContext& exec_ctx, std::array<NT::fr, ARGS_LENGTH> const& _args);
 
-} // namespace aztec3::circuits::apps::test_apps::private_to_private_function_call
+}  // namespace aztec3::circuits::apps::test_apps::private_to_private_function_call

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/index.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/index.hpp
@@ -1,4 +1,4 @@
-#include "init.hpp"
 #include "contract.hpp"
 #include "function_1_1.hpp"
 #include "function_2_1.hpp"
+#include "init.hpp"

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/init.hpp
@@ -5,11 +5,9 @@
 #include <aztec3/circuits/apps/notes/default_singleton_private_note/note.hpp>
 #include <aztec3/circuits/apps/oracle_wrapper.hpp>
 #include <aztec3/circuits/apps/state_vars/utxo_state_var.hpp>
-
 #include <aztec3/oracle/oracle.hpp>
-
-#include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/native_types.hpp>
 
 namespace aztec3::circuits::apps::test_apps::private_to_private_function_call {
@@ -36,11 +34,11 @@ using apps::state_vars::UTXOStateVar;
 
 // Get rid of ugle `Composer` template arg from our state var types:
 template <typename T> struct SpecialisedTypes {
-    typedef UTXOStateVar<C, T> utxo;
+    using utxo = UTXOStateVar<C, T>;
 };
 
 template <typename Note> using UTXO = typename SpecialisedTypes<Note>::utxo;
 
 using Note = apps::notes::DefaultSingletonPrivateNote<C, CT::fr>;
 
-} // namespace aztec3::circuits::apps::test_apps::private_to_private_function_call
+}  // namespace aztec3::circuits::apps::test_apps::private_to_private_function_call

--- a/circuits/cpp/src/aztec3/circuits/apps/utxo_datum.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/utxo_datum.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
 
 namespace aztec3::circuits::apps {
 
@@ -15,9 +16,9 @@ using plonk::stdlib::witness_t;
  * @tparam NotePreimage
  */
 template <typename NCT, typename NotePreimage> struct UTXOSLoadDatum {
-    typedef typename NCT::fr fr;
-    typedef typename NCT::address address;
-    typedef typename NCT::uint32 uint32;
+    using fr = typename NCT::fr;
+    using address = typename NCT::address;
+    using uint32 = typename NCT::uint32;
 
     fr commitment = 0;
     address contract_address = 0;
@@ -45,4 +46,4 @@ template <typename NCT, typename NotePreimage> struct UTXOSLoadDatum {
     };
 };
 
-} // namespace aztec3::circuits::apps
+}  // namespace aztec3::circuits::apps

--- a/circuits/cpp/src/aztec3/circuits/hash.hpp
+++ b/circuits/cpp/src/aztec3/circuits/hash.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <array>
-#include <aztec3/circuits/abis/function_data.hpp>
 #include "aztec3/circuits/abis/function_leaf_preimage.hpp"
+#include <aztec3/circuits/abis/function_data.hpp>
 #include <aztec3/circuits/abis/new_contract_data.hpp>
 #include <aztec3/constants.hpp>
 #include <aztec3/utils/circuit_errors.hpp>
+
+#include <array>
 
 namespace aztec3::circuits {
 
@@ -18,17 +19,16 @@ template <typename NCT> typename NCT::fr compute_args_hash(std::array<typename N
     return NCT::compress(args, CONSTRUCTOR_ARGS);
 }
 
-template <typename NCT>
-typename NCT::fr compute_constructor_hash(FunctionData<NCT> function_data,
-                                          std::array<typename NCT::fr, ARGS_LENGTH> args,
-                                          typename NCT::fr constructor_vk_hash)
+template <typename NCT> typename NCT::fr compute_constructor_hash(FunctionData<NCT> function_data,
+                                                                  std::array<typename NCT::fr, ARGS_LENGTH> args,
+                                                                  typename NCT::fr constructor_vk_hash)
 {
     using fr = typename NCT::fr;
 
-    fr function_data_hash = function_data.hash();
-    fr args_hash = compute_args_hash<NCT>(args);
+    fr const function_data_hash = function_data.hash();
+    fr const args_hash = compute_args_hash<NCT>(args);
 
-    std::vector<fr> inputs = {
+    std::vector<fr> const inputs = {
         function_data_hash,
         args_hash,
         constructor_vk_hash,
@@ -37,16 +37,15 @@ typename NCT::fr compute_constructor_hash(FunctionData<NCT> function_data,
     return NCT::compress(inputs, aztec3::GeneratorIndex::CONSTRUCTOR);
 }
 
-template <typename NCT>
-typename NCT::address compute_contract_address(typename NCT::address deployer_address,
-                                               typename NCT::fr contract_address_salt,
-                                               typename NCT::fr function_tree_root,
-                                               typename NCT::fr constructor_hash)
+template <typename NCT> typename NCT::address compute_contract_address(typename NCT::address deployer_address,
+                                                                       typename NCT::fr contract_address_salt,
+                                                                       typename NCT::fr function_tree_root,
+                                                                       typename NCT::fr constructor_hash)
 {
     using fr = typename NCT::fr;
     using address = typename NCT::address;
 
-    std::vector<fr> inputs = {
+    std::vector<fr> const inputs = {
         deployer_address.to_field(),
         contract_address_salt,
         function_tree_root,
@@ -61,7 +60,7 @@ typename NCT::fr add_contract_address_to_commitment(typename NCT::address contra
 {
     using fr = typename NCT::fr;
 
-    std::vector<fr> inputs = {
+    std::vector<fr> const inputs = {
         contract_address.to_field(),
         commitment,
     };
@@ -74,7 +73,7 @@ typename NCT::fr add_contract_address_to_nullifier(typename NCT::address contrac
 {
     using fr = typename NCT::fr;
 
-    std::vector<fr> inputs = {
+    std::vector<fr> const inputs = {
         contract_address.to_field(),
         nullifier,
     };
@@ -112,7 +111,7 @@ typename NCT::fr root_from_sibling_path(typename NCT::fr const& leaf,
             node = NCT::merkle_hash(node, siblingPath[i]);
         }
     }
-    return node; // root
+    return node;  // root
 }
 
 /**
@@ -147,7 +146,7 @@ typename NCT::fr root_from_sibling_path(typename NCT::fr const& leaf,
         }
         index >>= uint256_t(1);
     }
-    return node; // root
+    return node;  // root
 }
 
 template <typename NCT, typename Composer, size_t SIZE>
@@ -176,8 +175,7 @@ void check_membership(Composer& composer,
  * @param function_leaf_sibling_path
  * @return NCT::fr
  */
-template <typename NCT>
-typename NCT::fr function_tree_root_from_siblings(
+template <typename NCT> typename NCT::fr function_tree_root_from_siblings(
     typename NCT::uint32 const& function_selector,
     typename NCT::boolean const& is_private,
     typename NCT::fr const& vk_hash,
@@ -210,8 +208,7 @@ typename NCT::fr function_tree_root_from_siblings(
  * @param contract_leaf_sibling_path
  * @return NCT::fr
  */
-template <typename NCT>
-typename NCT::fr contract_tree_root_from_siblings(
+template <typename NCT> typename NCT::fr contract_tree_root_from_siblings(
     typename NCT::fr const& function_tree_root,
     typename NCT::address const& storage_contract_address,
     typename NCT::address const& portal_contract_address,
@@ -266,11 +263,10 @@ template <typename NCT> typename NCT::fr compute_public_data_tree_value(typename
  * @param storage_slot The storage slot to which the inserted element belongs
  * @return The index for insertion into the public data tree
  */
-template <typename NCT>
-typename NCT::fr compute_public_data_tree_index(typename NCT::fr const& contract_address,
-                                                typename NCT::fr const& storage_slot)
+template <typename NCT> typename NCT::fr compute_public_data_tree_index(typename NCT::fr const& contract_address,
+                                                                        typename NCT::fr const& storage_slot)
 {
     return NCT::compress({ contract_address, storage_slot }, GeneratorIndex::PUBLIC_LEAF_INDEX);
 }
 
-} // namespace aztec3::circuits
+}  // namespace aztec3::circuits

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/.test.cpp
@@ -1,36 +1,34 @@
+#include "c_bind.h"
 #include "index.hpp"
 #include "init.hpp"
-#include "c_bind.h"
 
+#include "aztec3/circuits/kernel/private/utils.hpp"
 #include "aztec3/constants.hpp"
-#include <aztec3/circuits/hash.hpp>
-
-#include <aztec3/circuits/apps/function_execution_context.hpp>
-#include <aztec3/circuits/apps/test_apps/escrow/deposit.hpp>
-#include <aztec3/circuits/apps/test_apps/basic_contract_deployment/basic_contract_deployment.hpp>
-
 #include <aztec3/circuits/abis/call_context.hpp>
 #include <aztec3/circuits/abis/call_stack_item.hpp>
+#include <aztec3/circuits/abis/combined_accumulated_data.hpp>
+#include <aztec3/circuits/abis/combined_constant_data.hpp>
 #include <aztec3/circuits/abis/contract_deployment_data.hpp>
 #include <aztec3/circuits/abis/function_data.hpp>
+#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
+#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
+#include <aztec3/circuits/abis/private_historic_tree_roots.hpp>
+#include <aztec3/circuits/abis/private_kernel/globals.hpp>
+#include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
 #include <aztec3/circuits/abis/signed_tx_request.hpp>
 #include <aztec3/circuits/abis/tx_context.hpp>
 #include <aztec3/circuits/abis/tx_request.hpp>
-#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
-#include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
-#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
-#include <aztec3/circuits/abis/combined_accumulated_data.hpp>
-#include <aztec3/circuits/abis/combined_constant_data.hpp>
-#include <aztec3/circuits/abis/private_historic_tree_roots.hpp>
-#include <aztec3/circuits/abis/private_kernel/globals.hpp>
 #include <aztec3/circuits/abis/types.hpp>
-
-#include "aztec3/circuits/kernel/private/utils.hpp"
+#include <aztec3/circuits/apps/function_execution_context.hpp>
+#include <aztec3/circuits/apps/test_apps/basic_contract_deployment/basic_contract_deployment.hpp>
+#include <aztec3/circuits/apps/test_apps/escrow/deposit.hpp>
+#include <aztec3/circuits/hash.hpp>
 #include <aztec3/circuits/mock/mock_kernel_circuit.hpp>
 
 #include <barretenberg/common/map.hpp>
 #include <barretenberg/common/test.hpp>
 #include <barretenberg/stdlib/merkle_tree/membership.hpp>
+
 #include <gtest/gtest.h>
 
 namespace {
@@ -49,11 +47,9 @@ using aztec3::circuits::abis::SignedTxRequest;
 using aztec3::circuits::abis::TxContext;
 using aztec3::circuits::abis::TxRequest;
 
-using aztec3::circuits::abis::CombinedAccumulatedData;
 using aztec3::circuits::abis::CombinedConstantData;
 using aztec3::circuits::abis::CombinedHistoricTreeRoots;
 using aztec3::circuits::abis::KernelCircuitPublicInputs;
-using aztec3::circuits::abis::PreviousKernelData;
 using aztec3::circuits::abis::PrivateHistoricTreeRoots;
 using aztec3::circuits::abis::private_kernel::PrivateCallData;
 using aztec3::circuits::abis::private_kernel::PrivateInputs;
@@ -63,7 +59,6 @@ using aztec3::circuits::apps::test_apps::escrow::deposit;
 
 using DummyComposer = aztec3::utils::DummyComposer;
 
-using aztec3::circuits::mock::mock_kernel_circuit;
 
 // A type representing any private circuit function
 // (for now it works for deposit and constructor)
@@ -73,8 +68,8 @@ using private_function = std::function<OptionalPrivateCircuitPublicInputs<NT>(
 
 // Some helper constants for trees
 constexpr size_t MAX_FUNCTION_LEAVES = 2 << (aztec3::FUNCTION_TREE_HEIGHT - 1);
-const NT::fr EMPTY_FUNCTION_LEAF = FunctionLeafPreimage<NT>{}.hash(); // hash of empty/0 preimage
-const NT::fr EMPTY_CONTRACT_LEAF = NewContractData<NT>{}.hash();      // hash of empty/0 preimage
+const NT::fr EMPTY_FUNCTION_LEAF = FunctionLeafPreimage<NT>{}.hash();  // hash of empty/0 preimage
+const NT::fr EMPTY_CONTRACT_LEAF = NewContractData<NT>{}.hash();       // hash of empty/0 preimage
 
 const auto& get_empty_function_siblings()
 {
@@ -94,7 +89,7 @@ const auto& get_empty_contract_siblings()
     return EMPTY_CONTRACT_SIBLINGS;
 }
 
-} // namespace
+}  // namespace
 
 namespace aztec3::circuits::kernel::private_kernel {
 
@@ -114,7 +109,7 @@ void debugComposer(Composer const& composer)
     info("err: ", composer.err());
     info("n: ", composer.get_num_gates());
 #else
-    (void)composer; // only used in debug mode
+    (void)composer;  // only used in debug mode
 #endif
 }
 
@@ -131,12 +126,12 @@ void debugComposer(Composer const& composer)
 std::shared_ptr<NT::VK> gen_func_vk(bool is_constructor, private_function const& func, size_t const num_args)
 {
     // Some dummy inputs to get the circuit to compile and get a VK
-    FunctionData<NT> dummy_function_data{
+    FunctionData<NT> const dummy_function_data{
         .is_private = true,
         .is_constructor = is_constructor,
     };
 
-    CallContext<NT> dummy_call_context{
+    CallContext<NT> const dummy_call_context{
         .is_contract_deployment = is_constructor,
     };
 
@@ -182,7 +177,7 @@ PrivateInputs<NT> do_private_call_get_kernel_inputs(bool const is_constructor,
     // Initialize some inputs to private call and kernel circuits
     //***************************************************************************
     // TODO randomize inputs
-    NT::address contract_address = is_constructor ? 0 : 12345; // updated later if in constructor
+    NT::address contract_address = is_constructor ? 0 : 12345;  // updated later if in constructor
     const NT::uint32 contract_leaf_index = 1;
     const NT::uint32 function_leaf_index = 1;
     const NT::fr portal_contract_address = 23456;
@@ -192,10 +187,10 @@ PrivateInputs<NT> do_private_call_get_kernel_inputs(bool const is_constructor,
     const NT::fr msg_sender_private_key = 123456789;
     const NT::address msg_sender =
         NT::fr(uint256_t(0x01071e9a23e0f7edULL, 0x5d77b35d1830fa3eULL, 0xc6ba3660bb1f0c0bULL, 0x2ef9f7f09867fd6eULL));
-    const NT::address tx_origin = msg_sender;
+    const NT::address& tx_origin = msg_sender;
 
-    FunctionData<NT> function_data{
-        .function_selector = 1, // TODO: deduce this from the contract, somehow.
+    FunctionData<NT> const function_data{
+        .function_selector = 1,  // TODO: deduce this from the contract, somehow.
         .is_private = true,
         .is_constructor = is_constructor,
     };
@@ -230,7 +225,7 @@ PrivateInputs<NT> do_private_call_get_kernel_inputs(bool const is_constructor,
         stdlib::recursion::verification_key<CT::bn254>::compress_native(private_circuit_vk, GeneratorIndex::VK);
 
     ContractDeploymentData<NT> contract_deployment_data{};
-    NT::fr contract_tree_root = 0; // TODO set properly for constructor?
+    NT::fr contract_tree_root = 0;  // TODO set properly for constructor?
     if (is_constructor) {
         // TODO compute function tree root from leaves
         // create leaf preimage for each function and hash all into tree
@@ -242,7 +237,7 @@ PrivateInputs<NT> do_private_call_get_kernel_inputs(bool const is_constructor,
         //    .vk_hash = private_circuit_vk_hash,
         //    .acir_hash = acir_hash,
         //};
-        std::vector<NT::fr> function_leaves(MAX_FUNCTION_LEAVES, EMPTY_FUNCTION_LEAF);
+        std::vector<NT::fr> const function_leaves(MAX_FUNCTION_LEAVES, EMPTY_FUNCTION_LEAF);
         // const NT::fr& function_tree_root = plonk::stdlib::merkle_tree::compute_tree_root_native(function_leaves);
 
         // TODO use actual function tree root computed from leaves
@@ -295,21 +290,21 @@ PrivateInputs<NT> do_private_call_get_kernel_inputs(bool const is_constructor,
 
     FunctionExecutionContext ctx(private_circuit_composer, oracle_wrapper);
 
-    OptionalPrivateCircuitPublicInputs<NT> opt_private_circuit_public_inputs = func(ctx, args);
+    OptionalPrivateCircuitPublicInputs<NT> const opt_private_circuit_public_inputs = func(ctx, args);
     PrivateCircuitPublicInputs<NT> private_circuit_public_inputs =
         opt_private_circuit_public_inputs.remove_optionality();
     // TODO this should likely be handled as part of the DB/Oracle/Context infrastructure
     private_circuit_public_inputs.historic_contract_tree_root = contract_tree_root;
 
     auto private_circuit_prover = private_circuit_composer.create_prover();
-    NT::Proof private_circuit_proof = private_circuit_prover.construct_proof();
+    NT::Proof const private_circuit_proof = private_circuit_prover.construct_proof();
     // info("\nproof: ", private_circuit_proof.proof_data);
 
     //***************************************************************************
     // We can create a TxRequest from some of the above data. Users must sign a TxRequest in order to give permission
     // for a tx to take place - creating a SignedTxRequest.
     //***************************************************************************
-    TxRequest<NT> tx_request = TxRequest<NT>{
+    auto const tx_request = TxRequest<NT>{
         .from = tx_origin,
         .to = contract_address,
         .function_data = function_data,
@@ -325,7 +320,7 @@ PrivateInputs<NT> do_private_call_get_kernel_inputs(bool const is_constructor,
         .chain_id = 1,
     };
 
-    SignedTxRequest<NT> signed_tx_request = SignedTxRequest<NT>{
+    auto const signed_tx_request = SignedTxRequest<NT>{
         .tx_request = tx_request,
 
         //.signature = TODO: need a method for signing a TxRequest.
@@ -411,7 +406,6 @@ PrivateInputs<NT> do_private_call_get_kernel_inputs(bool const is_constructor,
 void validate_deployed_contract_address(PrivateInputs<NT> const& private_inputs,
                                         KernelCircuitPublicInputs<NT> const& public_inputs)
 {
-
     auto tx_request = private_inputs.signed_tx_request.tx_request;
     auto cdd = private_inputs.signed_tx_request.tx_request.tx_context.contract_deployment_data;
 
@@ -421,7 +415,7 @@ void validate_deployed_contract_address(PrivateInputs<NT> const& private_inputs,
                                                     NT::compress<ARGS_LENGTH>(tx_request.args, CONSTRUCTOR_ARGS),
                                                     private_circuit_vk_hash },
                                                   CONSTRUCTOR);
-    NT::fr expected_contract_address =
+    NT::fr const expected_contract_address =
         NT::compress({ tx_request.from, cdd.contract_address_salt, cdd.function_tree_root, expected_constructor_hash },
                      CONTRACT_ADDRESS);
     EXPECT_EQ(public_inputs.end.new_contracts[0].contract_address.to_field(), expected_contract_address);
@@ -539,7 +533,7 @@ TEST(private_kernel_tests, circuit_create_proof_cbinds)
     // Now run the simulate/prove cbinds to make sure their outputs match
     //***************************************************************************
     // TODO might be able to get rid of proving key buffer
-    uint8_t const* pk_buf;
+    uint8_t const* pk_buf = nullptr;
     private_kernel__init_proving_key(&pk_buf);
     // info("Proving key size: ", pk_size);
 
@@ -554,14 +548,14 @@ TEST(private_kernel_tests, circuit_create_proof_cbinds)
     std::vector<uint8_t> private_constructor_call_vec;
     write(private_constructor_call_vec, private_inputs.private_call);
 
-    uint8_t const* proof_data_buf;
-    uint8_t const* public_inputs_buf;
+    uint8_t const* proof_data_buf = nullptr;
+    uint8_t const* public_inputs_buf = nullptr;
     // info("Simulating to generate public inputs...");
-    size_t public_inputs_size = private_kernel__sim(signed_constructor_tx_request_vec.data(),
-                                                    nullptr, // no previous kernel on first iteration
-                                                    private_constructor_call_vec.data(),
-                                                    true, // first iteration
-                                                    &public_inputs_buf);
+    size_t const public_inputs_size = private_kernel__sim(signed_constructor_tx_request_vec.data(),
+                                                          nullptr,  // no previous kernel on first iteration
+                                                          private_constructor_call_vec.data(),
+                                                          true,  // first iteration
+                                                          &public_inputs_buf);
 
     // TODO better equality check
     // for (size_t i = 0; i < public_inputs_size; i++)
@@ -570,12 +564,12 @@ TEST(private_kernel_tests, circuit_create_proof_cbinds)
     }
     (void)public_inputs_size;
     // info("Proving");
-    size_t proof_data_size = private_kernel__prove(signed_constructor_tx_request_vec.data(),
-                                                   nullptr, // no previous kernel on first iteration
-                                                   private_constructor_call_vec.data(),
-                                                   pk_buf,
-                                                   true, // first iteration
-                                                   &proof_data_buf);
+    size_t const proof_data_size = private_kernel__prove(signed_constructor_tx_request_vec.data(),
+                                                         nullptr,  // no previous kernel on first iteration
+                                                         private_constructor_call_vec.data(),
+                                                         pk_buf,
+                                                         true,  // first iteration
+                                                         &proof_data_buf);
     (void)proof_data_size;
     // info("Proof size: ", proof_data_size);
     // info("PublicInputs size: ", public_inputs_size);
@@ -591,7 +585,7 @@ TEST(private_kernel_tests, circuit_create_proof_cbinds)
  */
 TEST(private_kernel_tests, native_dummy_previous_kernel_cbind)
 {
-    uint8_t const* cbind_previous_kernel_buf;
+    uint8_t const* cbind_previous_kernel_buf = nullptr;
     size_t const cbind_buf_size = private_kernel__dummy_previous_kernel(&cbind_previous_kernel_buf);
 
     auto const& previous_kernel = utils::dummy_previous_kernel();
@@ -611,4 +605,4 @@ TEST(private_kernel_tests, native_dummy_previous_kernel_cbind)
     (void)cbind_buf_size;
 }
 
-} // namespace aztec3::circuits::kernel::private_kernel
+}  // namespace aztec3::circuits::kernel::private_kernel

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/index.hpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/index.hpp
@@ -1,3 +1,3 @@
 #include "init.hpp"
-#include "private_kernel_circuit.hpp"
 #include "native_private_kernel_circuit.hpp"
+#include "private_kernel_circuit.hpp"

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/init.hpp
@@ -1,14 +1,11 @@
 #pragma once
-#include <aztec3/oracle/oracle.hpp>
-#include <aztec3/circuits/apps/oracle_wrapper.hpp>
-#include <aztec3/circuits/apps/function_execution_context.hpp>
-
-#include <aztec3/circuits/recursion/aggregator.hpp>
-
 #include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
-
-#include <aztec3/utils/types/convert.hpp>
+#include <aztec3/circuits/apps/function_execution_context.hpp>
+#include <aztec3/circuits/apps/oracle_wrapper.hpp>
+#include <aztec3/circuits/recursion/aggregator.hpp>
+#include <aztec3/oracle/oracle.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/native_types.hpp>
 
 namespace aztec3::circuits::kernel::private_kernel {
@@ -28,4 +25,4 @@ using OracleWrapper = aztec3::circuits::apps::OracleWrapperInterface<Composer>;
 
 using FunctionExecutionContext = aztec3::circuits::apps::FunctionExecutionContext<Composer>;
 
-} // namespace aztec3::circuits::kernel::private_kernel
+}  // namespace aztec3::circuits::kernel::private_kernel

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit.hpp
@@ -2,8 +2,8 @@
 
 #include "init.hpp"
 
-#include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
 #include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
+#include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
 #include <aztec3/utils/dummy_composer.hpp>
 
 namespace aztec3::circuits::kernel::private_kernel {
@@ -17,4 +17,4 @@ using DummyComposer = aztec3::utils::DummyComposer;
 KernelCircuitPublicInputs<NT> native_private_kernel_circuit(DummyComposer& composer,
                                                             PrivateInputs<NT> const& _private_inputs);
 
-} // namespace aztec3::circuits::kernel::private_kernel
+}  // namespace aztec3::circuits::kernel::private_kernel

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/private_kernel_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/private_kernel_circuit.hpp
@@ -2,8 +2,8 @@
 
 #include "init.hpp"
 
-#include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
 #include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
+#include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
 
 namespace aztec3::circuits::kernel::private_kernel {
 
@@ -13,4 +13,4 @@ using aztec3::circuits::abis::private_kernel::PrivateInputs;
 KernelCircuitPublicInputs<NT> private_kernel_circuit(Composer& composer, PrivateInputs<NT> const& _private_inputs);
 KernelCircuitPublicInputs<NT> private_kernel_native(PrivateInputs<NT> const& private_inputs);
 
-} // namespace aztec3::circuits::kernel::private_kernel
+}  // namespace aztec3::circuits::kernel::private_kernel

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/utils.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/utils.cpp
@@ -1,9 +1,10 @@
 #include "index.hpp"
 #include "init.hpp"
 
-#include "barretenberg/proof_system/types/composer_type.hpp"
-#include <aztec3/circuits/mock/mock_kernel_circuit.hpp>
 #include "aztec3/circuits/abis/new_contract_data.hpp"
+#include <aztec3/circuits/mock/mock_kernel_circuit.hpp>
+
+#include "barretenberg/proof_system/types/composer_type.hpp"
 
 namespace {
 using NT = aztec3::utils::types::NativeTypes;
@@ -11,7 +12,7 @@ using AggregationObject = aztec3::utils::types::NativeTypes::AggregationObject;
 using aztec3::circuits::abis::PreviousKernelData;
 using aztec3::circuits::mock::mock_kernel_circuit;
 
-} // namespace
+}  // namespace
 
 namespace aztec3::circuits::kernel::private_kernel::utils {
 
@@ -46,17 +47,17 @@ std::shared_ptr<NT::VK> fake_vk()
  */
 PreviousKernelData<NT> dummy_previous_kernel(bool real_vk_proof = false)
 {
-    PreviousKernelData<NT> init_previous_kernel{};
+    PreviousKernelData<NT> const init_previous_kernel{};
 
     auto crs_factory = std::make_shared<EnvReferenceStringFactory>();
     Composer mock_kernel_composer = Composer(crs_factory);
     auto mock_kernel_public_inputs = mock_kernel_circuit(mock_kernel_composer, init_previous_kernel.public_inputs);
 
     auto mock_kernel_prover = mock_kernel_composer.create_prover();
-    NT::Proof mock_kernel_proof =
+    NT::Proof const mock_kernel_proof =
         real_vk_proof ? mock_kernel_prover.construct_proof() : NT::Proof{ .proof_data = std::vector<uint8_t>(64, 0) };
 
-    std::shared_ptr<NT::VK> mock_kernel_vk =
+    std::shared_ptr<NT::VK> const mock_kernel_vk =
         real_vk_proof ? mock_kernel_composer.compute_verification_key() : fake_vk();
 
     PreviousKernelData<NT> previous_kernel = {
@@ -70,4 +71,4 @@ PreviousKernelData<NT> dummy_previous_kernel(bool real_vk_proof = false)
     return previous_kernel;
 }
 
-} // namespace aztec3::circuits::kernel::private_kernel::utils
+}  // namespace aztec3::circuits::kernel::private_kernel::utils

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/utils.hpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/utils.hpp
@@ -5,10 +5,10 @@
 namespace {
 using NT = aztec3::utils::types::NativeTypes;
 using aztec3::circuits::abis::PreviousKernelData;
-} // namespace
+}  // namespace
 
 namespace aztec3::circuits::kernel::private_kernel::utils {
 
 PreviousKernelData<NT> dummy_previous_kernel(bool real_vk_proof = false);
 
-} // namespace aztec3::circuits::kernel::private_kernel::utils
+}  // namespace aztec3::circuits::kernel::private_kernel::utils

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/.test.cpp
@@ -48,15 +48,13 @@ using aztec3::circuits::abis::SignedTxRequest;
 using aztec3::circuits::abis::TxContext;
 using aztec3::circuits::abis::TxRequest;
 using aztec3::circuits::abis::public_kernel::PublicCallData;
-using aztec3::circuits::apps::FunctionExecutionContext;
-using aztec3::utils::CircuitErrorCode;
 using aztec3::utils::source_arrays_are_in_target;
 using aztec3::utils::zero_array;
 }  // namespace
 
 namespace aztec3::circuits::kernel::public_kernel {
 
-typedef CallStackItem<NT, PublicTypes> PublicCallStackItem;
+using PublicCallStackItem = CallStackItem<NT, aztec3::circuits::abis::PublicTypes>;
 
 template <size_t SIZE>
 std::array<NT::fr, SIZE> array_of_values(NT::uint32& count, NT::uint32 num_values_required = SIZE)
@@ -109,12 +107,12 @@ PublicCallStackItem generate_call_stack_item(NT::fr contract_address,
                                              NT::uint32 seed = 0)
 {
     NT::uint32 count = seed + 1;
-    FunctionData<NT> function_data{
+    FunctionData<NT> const function_data{
         .function_selector = count,
         .is_private = false,
         .is_constructor = false,
     };
-    CallContext<NT> call_context{
+    CallContext<NT> const call_context{
         .msg_sender = msg_sender,
         .storage_contract_address = storage_contract_address,
         .portal_contract_address = portal_contract_address,
@@ -122,16 +120,17 @@ PublicCallStackItem generate_call_stack_item(NT::fr contract_address,
         .is_static_call = false,
         .is_contract_deployment = false,
     };
-    std::array<NT::fr, ARGS_LENGTH> args = array_of_values<ARGS_LENGTH>(count);
-    std::array<NT::fr, RETURN_VALUES_LENGTH> return_values = array_of_values<RETURN_VALUES_LENGTH>(count);
-    std::array<NT::fr, EMITTED_EVENTS_LENGTH> emitted_events = array_of_values<EMITTED_EVENTS_LENGTH>(count);
-    std::array<NT::fr, PUBLIC_CALL_STACK_LENGTH> public_call_stack = array_of_values<PUBLIC_CALL_STACK_LENGTH>(count);
-    std::array<NT::fr, L1_MSG_STACK_LENGTH> l1_msg_stack = array_of_values<L1_MSG_STACK_LENGTH>(count);
-    std::array<StateRead<NT>, STATE_READS_LENGTH> reads = generate_state_reads(count);
-    std::array<StateTransition<NT>, STATE_TRANSITIONS_LENGTH> transitions = generate_state_transitions(count);
+    std::array<NT::fr, ARGS_LENGTH> const args = array_of_values<ARGS_LENGTH>(count);
+    std::array<NT::fr, RETURN_VALUES_LENGTH> const return_values = array_of_values<RETURN_VALUES_LENGTH>(count);
+    std::array<NT::fr, EMITTED_EVENTS_LENGTH> const emitted_events = array_of_values<EMITTED_EVENTS_LENGTH>(count);
+    std::array<NT::fr, PUBLIC_CALL_STACK_LENGTH> const public_call_stack =
+        array_of_values<PUBLIC_CALL_STACK_LENGTH>(count);
+    std::array<NT::fr, L1_MSG_STACK_LENGTH> const l1_msg_stack = array_of_values<L1_MSG_STACK_LENGTH>(count);
+    std::array<StateRead<NT>, STATE_READS_LENGTH> const reads = generate_state_reads(count);
+    std::array<StateTransition<NT>, STATE_TRANSITIONS_LENGTH> const transitions = generate_state_transitions(count);
 
     // create the public circuit public inputs
-    PublicCircuitPublicInputs<NT> public_circuit_public_inputs = PublicCircuitPublicInputs<NT>{
+    auto const public_circuit_public_inputs = PublicCircuitPublicInputs<NT>{
         .call_context = call_context,
         .args = args,
         .return_values = return_values,
@@ -142,7 +141,7 @@ PublicCallStackItem generate_call_stack_item(NT::fr contract_address,
         .l1_msg_stack = l1_msg_stack,
 
     };
-    PublicCallStackItem call_stack_item = PublicCallStackItem{
+    auto call_stack_item = PublicCallStackItem{
         .contract_address = contract_address,
         .function_data = function_data,
         .public_inputs = public_circuit_public_inputs,
@@ -163,15 +162,15 @@ PublicKernelInputsNoPreviousKernel<NT> get_kernel_inputs_no_previous_kernel()
     const NT::fr portal_contract_address = 23456;
 
     const NT::address msg_sender = NT::fr(1);
-    const NT::address tx_origin = msg_sender;
+    const NT::address& tx_origin = msg_sender;
 
-    FunctionData<NT> function_data{
+    FunctionData<NT> const function_data{
         .function_selector = 1,
         .is_private = false,
         .is_constructor = false,
     };
 
-    CallContext<NT> call_context{
+    CallContext<NT> const call_context{
         .msg_sender = msg_sender,
         .storage_contract_address = contract_address,
         .portal_contract_address = portal_contract_address,
@@ -190,7 +189,7 @@ PublicKernelInputsNoPreviousKernel<NT> get_kernel_inputs_no_previous_kernel()
     // We can create a TxRequest from some of the above data. Users must sign a TxRequest in order to give permission
     // for a tx to take place - creating a SignedTxRequest.
     //***************************************************************************
-    TxRequest<NT> tx_request = TxRequest<NT>{
+    auto const tx_request = TxRequest<NT>{
         .from = tx_origin,
         .to = contract_address,
         .function_data = function_data,
@@ -206,7 +205,7 @@ PublicKernelInputsNoPreviousKernel<NT> get_kernel_inputs_no_previous_kernel()
         .chain_id = 1,
     };
 
-    SignedTxRequest<NT> signed_tx_request = SignedTxRequest<NT>{
+    auto const signed_tx_request = SignedTxRequest<NT>{
         .tx_request = tx_request,
 
         //.signature = TODO: need a method for signing a TxRequest.
@@ -230,19 +229,20 @@ PublicKernelInputsNoPreviousKernel<NT> get_kernel_inputs_no_previous_kernel()
         child_portal_contract_address++;
     }
 
-    std::array<fr, RETURN_VALUES_LENGTH> return_values =
+    std::array<fr, RETURN_VALUES_LENGTH> const return_values =
         array_of_values<RETURN_VALUES_LENGTH>(seed, RETURN_VALUES_LENGTH / 2);
-    std::array<fr, EMITTED_EVENTS_LENGTH> emitted_events =
+    std::array<fr, EMITTED_EVENTS_LENGTH> const emitted_events =
         array_of_values<EMITTED_EVENTS_LENGTH>(seed, EMITTED_EVENTS_LENGTH / 2);
-    std::array<StateTransition<NT>, STATE_TRANSITIONS_LENGTH> state_transitions =
+    std::array<StateTransition<NT>, STATE_TRANSITIONS_LENGTH> const state_transitions =
         generate_state_transitions(seed, STATE_TRANSITIONS_LENGTH / 2);
-    std::array<StateRead<NT>, STATE_READS_LENGTH> state_reads = generate_state_reads(seed, STATE_READS_LENGTH / 2);
-    std::array<fr, L1_MSG_STACK_LENGTH> l1_msg_stack =
+    std::array<StateRead<NT>, STATE_READS_LENGTH> const state_reads =
+        generate_state_reads(seed, STATE_READS_LENGTH / 2);
+    std::array<fr, L1_MSG_STACK_LENGTH> const l1_msg_stack =
         array_of_values<L1_MSG_STACK_LENGTH>(seed, L1_MSG_STACK_LENGTH / 2);
-    fr historic_public_data_tree_root = ++seed;
+    fr const historic_public_data_tree_root = ++seed;
 
     // create the public circuit public inputs
-    PublicCircuitPublicInputs<NT> public_circuit_public_inputs = PublicCircuitPublicInputs<NT>{
+    auto const public_circuit_public_inputs = PublicCircuitPublicInputs<NT>{
         .call_context = call_context,
         .args = args,
         .return_values = return_values,
@@ -335,7 +335,7 @@ PublicKernelInputs<NT> get_kernel_inputs_with_previous_kernel(NT::boolean privat
 {
     NT::uint32 seed = 1000000;
     const auto kernel_inputs_no_previous = get_kernel_inputs_no_previous_kernel();
-    CombinedConstantData<NT> end_constants = {
+    CombinedConstantData<NT> const end_constants = {
         .historic_tree_roots =
             CombinedHistoricTreeRoots<NT>{ .private_historic_tree_roots =
                                                PrivateHistoricTreeRoots<NT>{ .private_data_tree_root = ++seed,
@@ -355,7 +355,7 @@ PublicKernelInputs<NT> get_kernel_inputs_with_previous_kernel(NT::boolean privat
         zero_array<NT::fr, KERNEL_PUBLIC_CALL_STACK_LENGTH>();
     public_call_stack[0] = kernel_inputs_no_previous.public_call.call_stack_item.hash();
 
-    CombinedAccumulatedData<NT> end_accumulated_data = {
+    CombinedAccumulatedData<NT> const end_accumulated_data = {
         .private_call_count = private_previous ? 1 : 0,
         .public_call_count = private_previous ? 0 : 1,
         .new_commitments = array_of_values<KERNEL_NEW_COMMITMENTS_LENGTH>(seed, private_previous ? 2 : 0),
@@ -448,7 +448,7 @@ void validate_private_data_propagation(const PublicKernelInputs<NT>& inputs,
 TEST(public_kernel_tests, no_previous_kernel_public_call_should_succeed)
 {
     DummyComposer dc;
-    PublicKernelInputsNoPreviousKernel<NT> inputs = get_kernel_inputs_no_previous_kernel();
+    PublicKernelInputsNoPreviousKernel<NT> const inputs = get_kernel_inputs_no_previous_kernel();
     auto public_inputs = native_public_kernel_circuit_no_previous_kernel(dc, inputs);
     ASSERT_FALSE(dc.failed());
 }
@@ -456,7 +456,7 @@ TEST(public_kernel_tests, no_previous_kernel_public_call_should_succeed)
 TEST(public_kernel_tests, circuit_outputs_should_be_correctly_populated)
 {
     DummyComposer dc;
-    PublicKernelInputsNoPreviousKernel<NT> inputs = get_kernel_inputs_no_previous_kernel();
+    PublicKernelInputsNoPreviousKernel<NT> const inputs = get_kernel_inputs_no_previous_kernel();
     auto public_inputs = native_public_kernel_circuit_no_previous_kernel(dc, inputs);
     ASSERT_FALSE(dc.failed());
 
@@ -703,7 +703,7 @@ TEST(public_kernel_tests, public_kernel_circuit_succeeds_for_mixture_of_regular_
 
     // redefine the child calls/stacks to use some delegate calls
     std::array<PublicCallStackItem, PUBLIC_CALL_STACK_LENGTH> child_call_stacks;
-    NT::uint32 seed = 1000;
+    NT::uint32 const seed = 1000;
     NT::fr child_contract_address = 100000;
     NT::fr child_portal_contract_address = 200000;
     NT::boolean is_delegate_call = false;
@@ -741,8 +741,8 @@ TEST(public_kernel_tests, public_kernel_circuit_fails_on_incorrect_msg_sender_in
 
     // set the first call stack item to be a delegate call
     std::array<PublicCallStackItem, PUBLIC_CALL_STACK_LENGTH> child_call_stacks;
-    NT::uint32 seed = 1000;
-    NT::fr child_contract_address = 100000;
+    NT::uint32 const seed = 1000;
+    NT::fr const child_contract_address = 100000;
     std::array<NT::fr, PUBLIC_CALL_STACK_LENGTH> call_stack_hashes;
     child_call_stacks[0] =
         // NOLINTNEXTLINE(readability-suspicious-call-argument)
@@ -772,8 +772,8 @@ TEST(public_kernel_tests, public_kernel_circuit_fails_on_incorrect_storage_contr
 
     // set the first call stack item to be a delegate call
     std::array<PublicCallStackItem, PUBLIC_CALL_STACK_LENGTH> child_call_stacks;
-    NT::uint32 seed = 1000;
-    NT::fr child_contract_address = 100000;
+    NT::uint32 const seed = 1000;
+    NT::fr const child_contract_address = 100000;
     std::array<NT::fr, PUBLIC_CALL_STACK_LENGTH> call_stack_hashes;
     child_call_stacks[0] = generate_call_stack_item(child_contract_address,
                                                     origin_msg_sender,
@@ -801,9 +801,9 @@ TEST(public_kernel_tests, public_kernel_circuit_fails_on_incorrect_portal_contra
 
     // set the first call stack item to be a delegate call
     std::array<PublicCallStackItem, PUBLIC_CALL_STACK_LENGTH> child_call_stacks;
-    NT::uint32 seed = 1000;
-    NT::fr child_contract_address = 100000;
-    NT::fr child_portal_contract = 200000;
+    NT::uint32 const seed = 1000;
+    NT::fr const child_contract_address = 100000;
+    NT::fr const child_portal_contract = 200000;
     std::array<NT::fr, PUBLIC_CALL_STACK_LENGTH> call_stack_hashes;
     // NOLINTNEXTLINE(readability-suspicious-call-argument)
     child_call_stacks[0] = generate_call_stack_item(child_contract_address,
@@ -824,7 +824,7 @@ TEST(public_kernel_tests, public_kernel_circuit_fails_on_incorrect_portal_contra
 TEST(public_kernel_tests, public_kernel_circuit_with_private_previous_kernel_should_succeed)
 {
     DummyComposer dc;
-    PublicKernelInputs<NT> inputs = get_kernel_inputs_with_previous_kernel(true);
+    PublicKernelInputs<NT> const inputs = get_kernel_inputs_with_previous_kernel(true);
     auto public_inputs = native_public_kernel_circuit_private_previous_kernel(dc, inputs);
     ASSERT_FALSE(dc.failed());
 }
@@ -832,7 +832,7 @@ TEST(public_kernel_tests, public_kernel_circuit_with_private_previous_kernel_sho
 TEST(public_kernel_tests, circuit_outputs_should_be_correctly_populated_with_previous_private_kernel)
 {
     DummyComposer dc;
-    PublicKernelInputs<NT> inputs = get_kernel_inputs_with_previous_kernel(true);
+    PublicKernelInputs<NT> const inputs = get_kernel_inputs_with_previous_kernel(true);
     auto public_inputs = native_public_kernel_circuit_private_previous_kernel(dc, inputs);
 
     // test that the prior set of private kernel public inputs were copied to the outputs
@@ -924,7 +924,7 @@ TEST(public_kernel_tests, previous_private_kernel_fails_if_incorrect_storage_con
 TEST(public_kernel_tests, public_kernel_circuit_with_public_previous_kernel_should_succeed)
 {
     DummyComposer dc;
-    PublicKernelInputs<NT> inputs = get_kernel_inputs_with_previous_kernel(false);
+    PublicKernelInputs<NT> const inputs = get_kernel_inputs_with_previous_kernel(false);
     auto public_inputs = native_public_kernel_circuit_public_previous_kernel(dc, inputs);
     ASSERT_FALSE(dc.failed());
 }
@@ -1016,7 +1016,7 @@ TEST(public_kernel_tests, circuit_outputs_should_be_correctly_populated_with_pre
                   array_length(inputs.public_call.call_stack_item.public_inputs.state_transitions));
 
     const auto contract_address = inputs.public_call.call_stack_item.contract_address;
-    std::array<PublicDataTransition<NT>, STATE_TRANSITIONS_LENGTH> expected_new_writes =
+    std::array<PublicDataTransition<NT>, STATE_TRANSITIONS_LENGTH> const expected_new_writes =
         public_data_writes_from_state_transitions(inputs.public_call.call_stack_item.public_inputs.state_transitions,
                                                   contract_address);
 
@@ -1024,7 +1024,7 @@ TEST(public_kernel_tests, circuit_outputs_should_be_correctly_populated_with_pre
                                             expected_new_writes,
                                             public_inputs.end.state_transitions));
 
-    std::array<PublicDataRead<NT>, STATE_READS_LENGTH> expected_new_reads = public_data_reads_from_state_reads(
+    std::array<PublicDataRead<NT>, STATE_READS_LENGTH> const expected_new_reads = public_data_reads_from_state_reads(
         inputs.public_call.call_stack_item.public_inputs.state_reads, contract_address);
 
     ASSERT_TRUE(source_arrays_are_in_target(

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/.test.cpp
@@ -1,31 +1,31 @@
 #include "init.hpp"
 #include "native_public_kernel_circuit_no_previous_kernel.hpp"
-#include "native_public_kernel_circuit_public_previous_kernel.hpp"
 #include "native_public_kernel_circuit_private_previous_kernel.hpp"
-#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp>
-#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
-#include <aztec3/circuits/abis/public_kernel/public_call_data.hpp>
-#include <gtest/gtest.h>
+#include "native_public_kernel_circuit_public_previous_kernel.hpp"
 
 #include <aztec3/circuits/abis/call_context.hpp>
 #include <aztec3/circuits/abis/call_stack_item.hpp>
+#include <aztec3/circuits/abis/combined_accumulated_data.hpp>
+#include <aztec3/circuits/abis/combined_constant_data.hpp>
 #include <aztec3/circuits/abis/contract_deployment_data.hpp>
 #include <aztec3/circuits/abis/function_data.hpp>
+#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
+#include <aztec3/circuits/abis/previous_kernel_data.hpp>
+#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
+#include <aztec3/circuits/abis/private_historic_tree_roots.hpp>
+#include <aztec3/circuits/abis/private_kernel/globals.hpp>
+#include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
+#include <aztec3/circuits/abis/public_kernel/public_call_data.hpp>
+#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp>
 #include <aztec3/circuits/abis/signed_tx_request.hpp>
 #include <aztec3/circuits/abis/tx_context.hpp>
 #include <aztec3/circuits/abis/tx_request.hpp>
-#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
-#include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
-#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
-#include <aztec3/circuits/abis/combined_accumulated_data.hpp>
-#include <aztec3/circuits/abis/combined_constant_data.hpp>
-#include <aztec3/circuits/abis/private_historic_tree_roots.hpp>
-#include <aztec3/circuits/abis/private_kernel/globals.hpp>
 #include <aztec3/circuits/abis/types.hpp>
 #include <aztec3/circuits/apps/function_execution_context.hpp>
-#include <aztec3/circuits/abis/previous_kernel_data.hpp>
 #include <aztec3/utils/array.hpp>
 #include <aztec3/utils/circuit_errors.hpp>
+
+#include <gtest/gtest.h>
 
 namespace {
 using DummyComposer = aztec3::utils::DummyComposer;
@@ -52,7 +52,7 @@ using aztec3::circuits::apps::FunctionExecutionContext;
 using aztec3::utils::CircuitErrorCode;
 using aztec3::utils::source_arrays_are_in_target;
 using aztec3::utils::zero_array;
-} // namespace
+}  // namespace
 
 namespace aztec3::circuits::kernel::public_kernel {
 
@@ -378,12 +378,13 @@ PublicKernelInputs<NT> get_kernel_inputs_with_previous_kernel(NT::boolean privat
         .public_inputs = public_inputs,
     };
 
-    const PublicKernelInputs<NT> kernel_inputs = {
+    // NOLINTNEXTLINE(misc-const-correctness)
+    PublicKernelInputs<NT> kernel_inputs = {
         .previous_kernel = previous_kernel,
         .public_call = kernel_inputs_no_previous.public_call,
     };
     return kernel_inputs;
-} // namespace aztec3::circuits::kernel::public_kernel
+}  // namespace aztec3::circuits::kernel::public_kernel
 
 template <typename KernelInput>
 void validate_public_kernel_outputs_correctly_propagated(const KernelInput& inputs,
@@ -743,7 +744,7 @@ TEST(public_kernel_tests, public_kernel_circuit_fails_on_incorrect_msg_sender_in
     std::array<NT::fr, PUBLIC_CALL_STACK_LENGTH> call_stack_hashes;
     child_call_stacks[0] =
         generate_call_stack_item(child_contract_address,
-                                 contract_address, // this should be the origin_msg_sender, not the contract address
+                                 contract_address,  // this should be the origin_msg_sender, not the contract address
                                  contract_address,
                                  contract_portal_address,
                                  true,
@@ -773,7 +774,7 @@ TEST(public_kernel_tests, public_kernel_circuit_fails_on_incorrect_storage_contr
     std::array<NT::fr, PUBLIC_CALL_STACK_LENGTH> call_stack_hashes;
     child_call_stacks[0] = generate_call_stack_item(child_contract_address,
                                                     origin_msg_sender,
-                                                    child_contract_address, // this should be contract_address
+                                                    child_contract_address,  // this should be contract_address
                                                     contract_portal_address,
                                                     true,
                                                     seed);
@@ -804,7 +805,7 @@ TEST(public_kernel_tests, public_kernel_circuit_fails_on_incorrect_portal_contra
     child_call_stacks[0] = generate_call_stack_item(child_contract_address,
                                                     origin_msg_sender,
                                                     contract_address,
-                                                    child_portal_contract, // this should be contract_portal_address
+                                                    child_portal_contract,  // this should be contract_portal_address
                                                     true,
                                                     seed);
     call_stack_hashes[0] = child_call_stacks[0].hash();
@@ -1056,4 +1057,4 @@ TEST(public_kernel_tests, previous_public_kernel_fails_if_incorrect_storage_cont
     ASSERT_EQ(dc.get_first_failure().code,
               CircuitErrorCode::PUBLIC_KERNEL__CALL_CONTEXT_INVALID_STORAGE_ADDRESS_FOR_DELEGATE_CALL);
 }
-} // namespace aztec3::circuits::kernel::public_kernel
+}  // namespace aztec3::circuits::kernel::public_kernel

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/.test.cpp
@@ -218,6 +218,7 @@ PublicKernelInputsNoPreviousKernel<NT> get_kernel_inputs_no_previous_kernel()
     NT::fr child_portal_contract_address = 200000;
     std::array<NT::fr, PUBLIC_CALL_STACK_LENGTH> call_stack_hashes;
     for (size_t i = 0; i < PUBLIC_CALL_STACK_LENGTH; i++) {
+        // NOLINTNEXTLINE(readability-suspicious-call-argument)
         child_call_stacks[i] = generate_call_stack_item(child_contract_address,
                                                         contract_address,
                                                         child_contract_address,
@@ -709,6 +710,7 @@ TEST(public_kernel_tests, public_kernel_circuit_succeeds_for_mixture_of_regular_
     std::array<NT::fr, PUBLIC_CALL_STACK_LENGTH> call_stack_hashes;
     for (size_t i = 0; i < PUBLIC_CALL_STACK_LENGTH; i++) {
         child_call_stacks[i] =
+            // NOLINTNEXTLINE(readability-suspicious-call-argument)
             generate_call_stack_item(child_contract_address,
                                      is_delegate_call ? origin_msg_sender : contract_address,
                                      is_delegate_call ? contract_address : child_contract_address,
@@ -743,6 +745,7 @@ TEST(public_kernel_tests, public_kernel_circuit_fails_on_incorrect_msg_sender_in
     NT::fr child_contract_address = 100000;
     std::array<NT::fr, PUBLIC_CALL_STACK_LENGTH> call_stack_hashes;
     child_call_stacks[0] =
+        // NOLINTNEXTLINE(readability-suspicious-call-argument)
         generate_call_stack_item(child_contract_address,
                                  contract_address,  // this should be the origin_msg_sender, not the contract address
                                  contract_address,
@@ -802,6 +805,7 @@ TEST(public_kernel_tests, public_kernel_circuit_fails_on_incorrect_portal_contra
     NT::fr child_contract_address = 100000;
     NT::fr child_portal_contract = 200000;
     std::array<NT::fr, PUBLIC_CALL_STACK_LENGTH> call_stack_hashes;
+    // NOLINTNEXTLINE(readability-suspicious-call-argument)
     child_call_stacks[0] = generate_call_stack_item(child_contract_address,
                                                     origin_msg_sender,
                                                     contract_address,

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/c_bind.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/c_bind.cpp
@@ -1,17 +1,17 @@
-#include "aztec3/utils/dummy_composer.hpp"
-#include "index.hpp"
-#include "init.hpp"
 #include "c_bind.h"
 
-#include <aztec3/constants.hpp>
-#include <aztec3/utils/types/native_types.hpp>
+#include "index.hpp"
+#include "init.hpp"
+
+#include "aztec3/utils/dummy_composer.hpp"
 #include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
 #include <aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp>
 #include <aztec3/circuits/abis/public_kernel/public_kernel_inputs_no_previous_kernel.hpp>
-
-#include "barretenberg/srs/reference_string/env_reference_string.hpp"
+#include <aztec3/constants.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 #include "barretenberg/common/serialize.hpp"
+#include "barretenberg/srs/reference_string/env_reference_string.hpp"
 
 namespace {
 using Composer = plonk::UltraComposer;
@@ -23,7 +23,7 @@ using aztec3::circuits::abis::public_kernel::PublicKernelInputsNoPreviousKernel;
 using aztec3::circuits::kernel::public_kernel::native_public_kernel_circuit_no_previous_kernel;
 using aztec3::circuits::kernel::public_kernel::native_public_kernel_circuit_private_previous_kernel;
 using aztec3::circuits::kernel::public_kernel::native_public_kernel_circuit_public_previous_kernel;
-} // namespace
+}  // namespace
 
 #define WASM_EXPORT __attribute__((visibility("default")))
 // WASM Cbinds
@@ -33,7 +33,7 @@ WASM_EXPORT size_t public_kernel__init_proving_key(uint8_t const** pk_buf)
 {
     std::vector<uint8_t> pk_vec(42, 0);
 
-    auto raw_buf = (uint8_t*)malloc(pk_vec.size());
+    auto* raw_buf = (uint8_t*)malloc(pk_vec.size());
     memcpy(raw_buf, (void*)pk_vec.data(), pk_vec.size());
     *pk_buf = raw_buf;
 
@@ -44,9 +44,9 @@ WASM_EXPORT size_t public_kernel__init_verification_key(uint8_t const* pk_buf, u
 {
     std::vector<uint8_t> vk_vec(42, 0);
     // TODO remove when proving key is used
-    (void)pk_buf; // unused
+    (void)pk_buf;  // unused
 
-    auto raw_buf = (uint8_t*)malloc(vk_vec.size());
+    auto* raw_buf = (uint8_t*)malloc(vk_vec.size());
     memcpy(raw_buf, (void*)vk_vec.data(), vk_vec.size());
     *vk_buf = raw_buf;
 
@@ -60,7 +60,7 @@ WASM_EXPORT size_t public_kernel__sim(uint8_t const* public_kernel_inputs_buf, u
     PublicKernelInputs<NT> public_kernel_inputs;
     read(public_kernel_inputs_buf, public_kernel_inputs);
 
-    KernelCircuitPublicInputs<NT> public_inputs =
+    KernelCircuitPublicInputs<NT> const public_inputs =
         public_kernel_inputs.previous_kernel.public_inputs.is_private
             ? native_public_kernel_circuit_private_previous_kernel(composer, public_kernel_inputs)
             : native_public_kernel_circuit_public_previous_kernel(composer, public_kernel_inputs);
@@ -69,7 +69,7 @@ WASM_EXPORT size_t public_kernel__sim(uint8_t const* public_kernel_inputs_buf, u
     std::vector<uint8_t> public_inputs_vec;
     write(public_inputs_vec, public_inputs);
     // copy public inputs to output buffer
-    auto raw_public_inputs_buf = (uint8_t*)malloc(public_inputs_vec.size());
+    auto* raw_public_inputs_buf = (uint8_t*)malloc(public_inputs_vec.size());
     memcpy(raw_public_inputs_buf, (void*)public_inputs_vec.data(), public_inputs_vec.size());
     *public_inputs_buf = raw_public_inputs_buf;
 
@@ -84,18 +84,18 @@ WASM_EXPORT size_t public_kernel_no_previous_kernel__sim(uint8_t const* public_k
     PublicKernelInputsNoPreviousKernel<NT> public_kernel_inputs;
     read(public_kernel_inputs_buf, public_kernel_inputs);
 
-    KernelCircuitPublicInputs<NT> public_inputs =
+    KernelCircuitPublicInputs<NT> const public_inputs =
         native_public_kernel_circuit_no_previous_kernel(composer, public_kernel_inputs);
 
     // serialize public inputs to bytes vec
     std::vector<uint8_t> public_inputs_vec;
     write(public_inputs_vec, public_inputs);
     // copy public inputs to output buffer
-    auto raw_public_inputs_buf = (uint8_t*)malloc(public_inputs_vec.size());
+    auto* raw_public_inputs_buf = (uint8_t*)malloc(public_inputs_vec.size());
     memcpy(raw_public_inputs_buf, (void*)public_inputs_vec.data(), public_inputs_vec.size());
     *public_inputs_buf = raw_public_inputs_buf;
 
     return public_inputs_vec.size();
 }
 
-} // extern "C"
+}  // extern "C"

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/common.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/common.cpp
@@ -1,5 +1,6 @@
-#include "init.hpp"
 #include "common.hpp"
+
+#include "init.hpp"
 
 namespace aztec3::circuits::kernel::public_kernel {
 
@@ -48,4 +49,4 @@ void validate_this_public_call_hash(DummyComposer& composer,
         "calculated public_call_hash does not match provided public_call_hash at the top of the call stack",
         CircuitErrorCode::PUBLIC_KERNEL__CALCULATED_PRIVATE_CALL_HASH_AND_PROVIDED_PRIVATE_CALL_HASH_MISMATCH);
 };
-} // namespace aztec3::circuits::kernel::public_kernel
+}  // namespace aztec3::circuits::kernel::public_kernel

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/common.hpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/common.hpp
@@ -2,15 +2,15 @@
 
 #include "init.hpp"
 
-#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs_no_previous_kernel.hpp>
-#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp>
 #include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
+#include <aztec3/circuits/abis/public_data_transition.hpp>
+#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp>
+#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs_no_previous_kernel.hpp>
 #include <aztec3/circuits/abis/state_read.hpp>
 #include <aztec3/circuits/abis/state_transition.hpp>
-#include <aztec3/circuits/abis/public_data_transition.hpp>
-#include <aztec3/utils/dummy_composer.hpp>
-#include <aztec3/utils/array.hpp>
 #include <aztec3/circuits/hash.hpp>
+#include <aztec3/utils/array.hpp>
+#include <aztec3/utils/dummy_composer.hpp>
 
 using NT = aztec3::utils::types::NativeTypes;
 using aztec3::circuits::abis::KernelCircuitPublicInputs;
@@ -193,9 +193,8 @@ void common_validate_inputs(DummyComposer& composer, KernelInput const& public_k
  * @param public_kernel_inputs The inputs to this iteration of the kernel circuit
  * @param circuit_outputs The circuit outputs to be populated
  */
-template <typename KernelInput>
-void propagate_valid_state_transitions(KernelInput const& public_kernel_inputs,
-                                       KernelCircuitPublicInputs<NT>& circuit_outputs)
+template <typename KernelInput> void propagate_valid_state_transitions(KernelInput const& public_kernel_inputs,
+                                                                       KernelCircuitPublicInputs<NT>& circuit_outputs)
 {
     const auto& contract_address = public_kernel_inputs.public_call.call_stack_item.contract_address;
     const auto& transitions = public_kernel_inputs.public_call.call_stack_item.public_inputs.state_transitions;
@@ -219,9 +218,8 @@ void propagate_valid_state_transitions(KernelInput const& public_kernel_inputs,
  * @param public_kernel_inputs The inputs to this iteration of the kernel circuit
  * @param circuit_outputs The circuit outputs to be populated
  */
-template <typename KernelInput>
-void propagate_valid_state_reads(KernelInput const& public_kernel_inputs,
-                                 KernelCircuitPublicInputs<NT>& circuit_outputs)
+template <typename KernelInput> void propagate_valid_state_reads(KernelInput const& public_kernel_inputs,
+                                                                 KernelCircuitPublicInputs<NT>& circuit_outputs)
 {
     const auto& contract_address = public_kernel_inputs.public_call.call_stack_item.contract_address;
     const auto& reads = public_kernel_inputs.public_call.call_stack_item.public_inputs.state_reads;
@@ -275,4 +273,4 @@ void common_initialise_end_values(PublicKernelInputs<NT> const& public_kernel_in
 void validate_this_public_call_hash(DummyComposer& composer,
                                     PublicKernelInputs<NT> const& public_kernel_inputs,
                                     KernelCircuitPublicInputs<NT>& public_inputs);
-} // namespace aztec3::circuits::kernel::public_kernel
+}  // namespace aztec3::circuits::kernel::public_kernel

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/index.hpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/index.hpp
@@ -1,4 +1,4 @@
 #include "init.hpp"
 #include "native_public_kernel_circuit_no_previous_kernel.hpp"
-#include "native_public_kernel_circuit_public_previous_kernel.hpp"
 #include "native_public_kernel_circuit_private_previous_kernel.hpp"
+#include "native_public_kernel_circuit_public_previous_kernel.hpp"

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/init.hpp
@@ -1,15 +1,12 @@
 #pragma once
-#include <aztec3/oracle/oracle.hpp>
-#include <aztec3/circuits/apps/oracle_wrapper.hpp>
-
-#include <aztec3/circuits/recursion/aggregator.hpp>
-
 #include <aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp>
-
-#include <aztec3/utils/types/convert.hpp>
-#include <aztec3/utils/types/circuit_types.hpp>
-#include <aztec3/utils/types/native_types.hpp>
+#include <aztec3/circuits/apps/oracle_wrapper.hpp>
+#include <aztec3/circuits/recursion/aggregator.hpp>
+#include <aztec3/oracle/oracle.hpp>
 #include <aztec3/utils/dummy_composer.hpp>
+#include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 namespace aztec3::circuits::kernel::public_kernel {
 
@@ -27,4 +24,4 @@ using DB = oracle::FakeDB;
 using oracle::NativeOracle;
 using OracleWrapper = aztec3::circuits::apps::OracleWrapperInterface<Composer>;
 
-} // namespace aztec3::circuits::kernel::public_kernel
+}  // namespace aztec3::circuits::kernel::public_kernel

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_no_previous_kernel.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_no_previous_kernel.cpp
@@ -1,15 +1,15 @@
-#include "aztec3/utils/circuit_errors.hpp"
+#include "native_public_kernel_circuit_no_previous_kernel.hpp"
+
+#include "common.hpp"
 #include "init.hpp"
 
-#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs_no_previous_kernel.hpp>
+#include "aztec3/constants.hpp"
+#include "aztec3/utils/circuit_errors.hpp"
 #include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
-#include "native_public_kernel_circuit_no_previous_kernel.hpp"
-#include "common.hpp"
-
+#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs_no_previous_kernel.hpp>
+#include <aztec3/circuits/hash.hpp>
 #include <aztec3/utils/array.hpp>
 #include <aztec3/utils/dummy_composer.hpp>
-#include <aztec3/circuits/hash.hpp>
-#include "aztec3/constants.hpp"
 
 namespace {
 
@@ -43,7 +43,7 @@ void validate_inputs(DummyComposer& composer, PublicKernelInputsNoPreviousKernel
                        "Storage contract address must be that of the called contract",
                        aztec3::utils::CircuitErrorCode::PUBLIC_KERNEL__CONTRACT_ADDRESS_MISMATCH);
 }
-} // namespace
+}  // namespace
 
 namespace aztec3::circuits::kernel::public_kernel {
 
@@ -85,4 +85,4 @@ KernelCircuitPublicInputs<NT> native_public_kernel_circuit_no_previous_kernel(
     return public_inputs;
 };
 
-} // namespace aztec3::circuits::kernel::public_kernel
+}  // namespace aztec3::circuits::kernel::public_kernel

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_no_previous_kernel.hpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_no_previous_kernel.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "init.hpp"
 #include "common.hpp"
+#include "init.hpp"
 
-#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs_no_previous_kernel.hpp>
 #include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
+#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs_no_previous_kernel.hpp>
 #include <aztec3/utils/dummy_composer.hpp>
 
 namespace aztec3::circuits::kernel::public_kernel {
@@ -15,4 +15,4 @@ using DummyComposer = aztec3::utils::DummyComposer;
 
 KernelCircuitPublicInputs<NT> native_public_kernel_circuit_no_previous_kernel(
     DummyComposer& composer, PublicKernelInputsNoPreviousKernel<NT> const& public_kernel_inputs);
-} // namespace aztec3::circuits::kernel::public_kernel
+}  // namespace aztec3::circuits::kernel::public_kernel

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_private_previous_kernel.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_private_previous_kernel.cpp
@@ -1,14 +1,13 @@
-#include "aztec3/utils/circuit_errors.hpp"
-#include "init.hpp"
-
-#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp>
-#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
-#include "native_public_kernel_circuit_public_previous_kernel.hpp"
 #include "common.hpp"
+#include "init.hpp"
+#include "native_public_kernel_circuit_public_previous_kernel.hpp"
 
+#include "aztec3/constants.hpp"
+#include "aztec3/utils/circuit_errors.hpp"
+#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
+#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp>
 #include <aztec3/utils/array.hpp>
 #include <aztec3/utils/dummy_composer.hpp>
-#include "aztec3/constants.hpp"
 
 namespace {
 using CircuitErrorCode = aztec3::utils::CircuitErrorCode;
@@ -37,7 +36,7 @@ void validate_inputs(DummyComposer& composer, PublicKernelInputs<NT> const& publ
                        "Previous kernel must be private",
                        CircuitErrorCode::PUBLIC_KERNEL__PREVIOUS_KERNEL_NOT_PRIVATE);
 }
-} // namespace
+}  // namespace
 
 namespace aztec3::circuits::kernel::public_kernel {
 
@@ -81,4 +80,4 @@ KernelCircuitPublicInputs<NT> native_public_kernel_circuit_private_previous_kern
     return public_inputs;
 };
 
-} // namespace aztec3::circuits::kernel::public_kernel
+}  // namespace aztec3::circuits::kernel::public_kernel

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_private_previous_kernel.hpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_private_previous_kernel.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "init.hpp"
 #include "common.hpp"
+#include "init.hpp"
 
-#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp>
 #include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
+#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp>
 #include <aztec3/utils/dummy_composer.hpp>
 
 namespace aztec3::circuits::kernel::public_kernel {
@@ -15,4 +15,4 @@ using DummyComposer = aztec3::utils::DummyComposer;
 
 KernelCircuitPublicInputs<NT> native_public_kernel_circuit_private_previous_kernel(
     DummyComposer& composer, PublicKernelInputs<NT> const& public_kernel_inputs);
-} // namespace aztec3::circuits::kernel::public_kernel
+}  // namespace aztec3::circuits::kernel::public_kernel

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_public_previous_kernel.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_public_previous_kernel.cpp
@@ -1,17 +1,16 @@
+#include "native_public_kernel_circuit_public_previous_kernel.hpp"
+
+#include "common.hpp"
 #include "init.hpp"
 
-#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp>
+#include "aztec3/constants.hpp"
 #include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
-#include "native_public_kernel_circuit_public_previous_kernel.hpp"
-#include "common.hpp"
-
+#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp>
 #include <aztec3/utils/array.hpp>
 #include <aztec3/utils/dummy_composer.hpp>
-#include "aztec3/constants.hpp"
 
 namespace {
 using CircuitErrorCode = aztec3::utils::CircuitErrorCode;
-using aztec3::utils::array_pop;
 /**
  * @brief Validates the kernel circuit inputs specific to having a public previous kernel
  * @param composer The circuit composer
@@ -30,7 +29,7 @@ void validate_inputs(DummyComposer& composer, PublicKernelInputs<NT> const& publ
                        "Previous kernel must be public",
                        CircuitErrorCode::PUBLIC_KERNEL__PREVIOUS_KERNEL_NOT_PUBLIC);
 }
-} // namespace
+}  // namespace
 
 namespace aztec3::circuits::kernel::public_kernel {
 
@@ -73,4 +72,4 @@ KernelCircuitPublicInputs<NT> native_public_kernel_circuit_public_previous_kerne
     return public_inputs;
 };
 
-} // namespace aztec3::circuits::kernel::public_kernel
+}  // namespace aztec3::circuits::kernel::public_kernel

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_public_previous_kernel.hpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_public_previous_kernel.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "init.hpp"
 #include "common.hpp"
+#include "init.hpp"
 
-#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp>
 #include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
+#include <aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp>
 #include <aztec3/utils/dummy_composer.hpp>
 
 namespace aztec3::circuits::kernel::public_kernel {
@@ -15,4 +15,4 @@ using DummyComposer = aztec3::utils::DummyComposer;
 
 KernelCircuitPublicInputs<NT> native_public_kernel_circuit_public_previous_kernel(
     DummyComposer& composer, PublicKernelInputs<NT> const& public_kernel_inputs);
-} // namespace aztec3::circuits::kernel::public_kernel
+}  // namespace aztec3::circuits::kernel::public_kernel

--- a/circuits/cpp/src/aztec3/circuits/mock/mock_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/mock/mock_circuit.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <barretenberg/common/map.hpp>
-#include <barretenberg/stdlib/primitives/field/field.hpp>
 #include <barretenberg/stdlib/hash/pedersen/pedersen.hpp>
+#include <barretenberg/stdlib/primitives/field/field.hpp>
 
 namespace aztec3::circuits::mock {
 
@@ -16,4 +16,4 @@ template <typename Composer> void mock_circuit(Composer& composer, std::vector<f
     plonk::stdlib::pedersen<Composer>::compress(field_t(witness_t(&composer, 1)), field_t(witness_t(&composer, 1)));
 }
 
-} // namespace aztec3::circuits::mock
+}  // namespace aztec3::circuits::mock

--- a/circuits/cpp/src/aztec3/circuits/mock/mock_kernel_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/mock/mock_kernel_circuit.hpp
@@ -1,12 +1,13 @@
 #pragma once
+#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
+#include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
 #include <barretenberg/common/map.hpp>
 #include <barretenberg/numeric/random/engine.hpp>
+#include <barretenberg/stdlib/commitment/pedersen/pedersen.hpp>
 #include <barretenberg/stdlib/primitives/field/field.hpp>
 #include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <barretenberg/stdlib/commitment/pedersen/pedersen.hpp>
-#include <aztec3/utils/types/native_types.hpp>
-#include <aztec3/utils/types/circuit_types.hpp>
-#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
 // #include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
 
 namespace {
@@ -34,8 +35,8 @@ KernelCircuitPublicInputs<NT> mock_kernel_circuit(Composer& composer,
         std::vector<uint32_t> dummy_witness_indices;
         // 16 is the number of values added to `proof_witness_indices` at the end of `verify_proof`.
         for (size_t i = 0; i < 16; ++i) {
-            fr witness = fr(witness_t(&composer, i));
-            uint32_t witness_index = witness.get_witness_index();
+            fr const witness = fr(witness_t(&composer, i));
+            uint32_t const witness_index = witness.get_witness_index();
             dummy_witness_indices.push_back(witness_index);
         }
         public_inputs.end.aggregation_object.proof_witness_indices = dummy_witness_indices;
@@ -53,4 +54,4 @@ KernelCircuitPublicInputs<NT> mock_kernel_circuit(Composer& composer,
     return public_inputs.template to_native_type<Composer>();
 }
 
-} // namespace aztec3::circuits::mock
+}  // namespace aztec3::circuits::mock

--- a/circuits/cpp/src/aztec3/circuits/recursion/aggregator.hpp
+++ b/circuits/cpp/src/aztec3/circuits/recursion/aggregator.hpp
@@ -1,9 +1,11 @@
 #pragma once
 #include "init.hpp"
-#include <aztec3/utils/types/native_types.hpp>
+
 #include <aztec3/utils/types/circuit_types.hpp>
-#include <barretenberg/stdlib/recursion/verifier/verifier.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
 #include <barretenberg/stdlib/recursion/verifier/program_settings.hpp>
+#include <barretenberg/stdlib/recursion/verifier/verifier.hpp>
 #include <barretenberg/transcript/manifest.hpp>
 
 namespace aztec3::circuits::recursion {
@@ -15,7 +17,7 @@ class Aggregator {
         const std::shared_ptr<CT::VK>& vk,
         const NT::Proof& proof,
         const size_t& num_public_inputs,
-        const CT::AggregationObject previous_aggregation_output = CT::AggregationObject())
+        const CT::AggregationObject& previous_aggregation_output = CT::AggregationObject())
     {
         const Manifest recursive_manifest = Composer::create_manifest(num_public_inputs);
 
@@ -25,4 +27,4 @@ class Aggregator {
         return result;
     }
 };
-} // namespace aztec3::circuits::recursion
+}  // namespace aztec3::circuits::recursion

--- a/circuits/cpp/src/aztec3/circuits/recursion/index.hpp
+++ b/circuits/cpp/src/aztec3/circuits/recursion/index.hpp
@@ -1,4 +1,4 @@
-#include "init.hpp"
 #include "aggregator.hpp"
+#include "init.hpp"
 #include "play_app_circuit.hpp"
 #include "play_recursive_circuit.hpp"

--- a/circuits/cpp/src/aztec3/circuits/recursion/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/recursion/init.hpp
@@ -1,10 +1,10 @@
 #pragma once
-#include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/native_types.hpp>
 
-#include <barretenberg/stdlib/recursion/verifier/verifier.hpp>
 #include <barretenberg/stdlib/recursion/verifier/program_settings.hpp>
+#include <barretenberg/stdlib/recursion/verifier/verifier.hpp>
 
 namespace aztec3::circuits::recursion {
 // Composer
@@ -19,4 +19,4 @@ using aztec3::utils::types::to_ct;
 using plonk::stdlib::recursion::verify_proof;
 using transcript::Manifest;
 
-} // namespace aztec3::circuits::recursion
+}  // namespace aztec3::circuits::recursion

--- a/circuits/cpp/src/aztec3/circuits/recursion/play.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/recursion/play.test.cpp
@@ -1,4 +1,5 @@
 #include "index.hpp"
+
 #include <barretenberg/common/test.hpp>
 // #include <barretenberg/numeric/random/engine.hpp>
 
@@ -39,7 +40,7 @@ TEST(play_tests, circuit_play_app_proof_gen)
     }
 
     auto app_prover = app_composer.create_prover();
-    proof app_proof = app_prover.construct_proof();
+    proof const app_proof = app_prover.construct_proof();
     info("app_proof: ", app_proof.proof_data);
 }
 
@@ -53,10 +54,10 @@ TEST(play_tests, circuit_play_recursive_proof_gen)
     }
 
     auto app_prover = app_composer.create_prover();
-    proof app_proof = app_prover.construct_proof();
+    proof const app_proof = app_prover.construct_proof();
     info("app_proof: ", app_proof.proof_data);
 
-    std::shared_ptr<plonk::verification_key> app_vk = app_composer.compute_verification_key();
+    std::shared_ptr<plonk::verification_key> const app_vk = app_composer.compute_verification_key();
 
     Composer recursive_composer = Composer("../barretenberg/cpp/srs_db/ignition");
     auto aggregation_output = play_recursive_circuit(recursive_composer, app_vk, app_proof);
@@ -76,8 +77,8 @@ TEST(play_tests, circuit_play_recursive_2_proof_gen)
     }
 
     auto app_prover = app_composer.create_prover();
-    proof app_proof = app_prover.construct_proof();
-    std::shared_ptr<plonk::verification_key> app_vk = app_composer.compute_verification_key();
+    proof const app_proof = app_prover.construct_proof();
+    std::shared_ptr<plonk::verification_key> const app_vk = app_composer.compute_verification_key();
 
     //*******************************************************************************
 
@@ -89,8 +90,8 @@ TEST(play_tests, circuit_play_recursive_2_proof_gen)
     }
 
     auto dummy_circuit_prover = dummy_circuit_composer.create_prover();
-    proof dummy_circuit_proof = dummy_circuit_prover.construct_proof();
-    std::shared_ptr<plonk::verification_key> dummy_circuit_vk = dummy_circuit_composer.compute_verification_key();
+    proof const dummy_circuit_proof = dummy_circuit_prover.construct_proof();
+    std::shared_ptr<plonk::verification_key> const dummy_circuit_vk = dummy_circuit_composer.compute_verification_key();
 
     //*******************************************************************************
 
@@ -104,9 +105,9 @@ TEST(play_tests, circuit_play_recursive_2_proof_gen)
 
     auto recursion_1_prover = recursion_1_composer.create_prover();
 
-    proof recursion_1_proof = recursion_1_prover.construct_proof();
+    proof const recursion_1_proof = recursion_1_prover.construct_proof();
 
-    std::shared_ptr<plonk::verification_key> recursion_1_vk = recursion_1_composer.compute_verification_key();
+    std::shared_ptr<plonk::verification_key> const recursion_1_vk = recursion_1_composer.compute_verification_key();
 
     //*******************************************************************************
 
@@ -123,4 +124,4 @@ TEST(play_tests, circuit_play_recursive_2_proof_gen)
     // std::shared_ptr<plonk::verification_key> recursion_2_vk = recursion_2_composer.compute_verification_key();
 }
 
-} // namespace aztec3::circuits::recursion
+}  // namespace aztec3::circuits::recursion

--- a/circuits/cpp/src/aztec3/circuits/recursion/play_app_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/recursion/play_app_circuit.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "init.hpp"
+
 #include "aztec3/utils/types/circuit_types.hpp"
 #include "aztec3/utils/types/native_types.hpp"
 
@@ -7,13 +8,13 @@ namespace aztec3::circuits::recursion {
 
 template <typename Composer> void play_app_circuit(Composer& composer, NT::fr const& a_in, NT::fr const& b_in)
 {
-    CT::fr a = CT::witness(&composer, a_in);
-    CT::fr b = CT::witness(&composer, b_in);
-    CT::fr c = a * b;
-    CT::fr d = a + b + c;
+    CT::fr const a = CT::witness(&composer, a_in);
+    CT::fr const b = CT::witness(&composer, b_in);
+    CT::fr const c = a * b;
+    CT::fr const d = a + b + c;
 
     a.set_public();
     d.set_public();
 };
 
-} // namespace aztec3::circuits::recursion
+}  // namespace aztec3::circuits::recursion

--- a/circuits/cpp/src/aztec3/circuits/recursion/play_recursive_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/recursion/play_recursive_circuit.hpp
@@ -3,11 +3,11 @@
 
 namespace aztec3::circuits::recursion {
 
-CT::AggregationObject play_recursive_circuit(Composer& composer,
-                                             std::shared_ptr<NT::VK> const& app_vk,
-                                             NT::Proof const& app_proof)
+inline CT::AggregationObject play_recursive_circuit(Composer& composer,
+                                                    std::shared_ptr<NT::VK> const& app_vk,
+                                                    NT::Proof const& app_proof)
 {
-    std::shared_ptr<CT::VK> app_vk_ct = CT::VK::from_witness(&composer, app_vk);
+    std::shared_ptr<CT::VK> const app_vk_ct = CT::VK::from_witness(&composer, app_vk);
 
     CT::AggregationObject aggregation_output =
         Aggregator::aggregate(&composer, app_vk_ct, app_proof, app_vk->num_public_inputs);
@@ -17,23 +17,23 @@ CT::AggregationObject play_recursive_circuit(Composer& composer,
     return aggregation_output;
 };
 
-void dummy_circuit(Composer& composer, NT::fr const& a_in, NT::fr const& b_in)
+inline void dummy_circuit(Composer& composer, NT::fr const& a_in, NT::fr const& b_in)
 {
-    CT::fr a = CT::witness(&composer, a_in);
-    CT::fr b = CT::witness(&composer, b_in);
-    CT::fr c = a * b;
+    CT::fr const a = CT::witness(&composer, a_in);
+    CT::fr const b = CT::witness(&composer, b_in);
+    CT::fr const c = a * b;
 
     c.set_public();
 };
 
-CT::AggregationObject play_recursive_circuit_2(Composer& composer,
-                                               std::shared_ptr<NT::VK> const& app_vk,
-                                               NT::Proof const& app_proof,
-                                               std::shared_ptr<NT::VK> const& prev_recursive_vk,
-                                               NT::Proof const& prev_recursive_proof)
+inline CT::AggregationObject play_recursive_circuit_2(Composer& composer,
+                                                      std::shared_ptr<NT::VK> const& app_vk,
+                                                      NT::Proof const& app_proof,
+                                                      std::shared_ptr<NT::VK> const& prev_recursive_vk,
+                                                      NT::Proof const& prev_recursive_proof)
 {
-    std::shared_ptr<CT::VK> app_vk_ct = CT::VK::from_witness(&composer, app_vk);
-    std::shared_ptr<CT::VK> prev_recursive_vk_ct = CT::VK::from_witness(&composer, prev_recursive_vk);
+    std::shared_ptr<CT::VK> const app_vk_ct = CT::VK::from_witness(&composer, app_vk);
+    std::shared_ptr<CT::VK> const prev_recursive_vk_ct = CT::VK::from_witness(&composer, prev_recursive_vk);
 
     info("composer failed 1? ", composer.failed());
 
@@ -60,4 +60,4 @@ CT::AggregationObject play_recursive_circuit_2(Composer& composer,
     return aggregation_object;
 };
 
-} // namespace aztec3::circuits::recursion
+}  // namespace aztec3::circuits::recursion

--- a/circuits/cpp/src/aztec3/circuits/rollup/base/c_bind.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/base/c_bind.cpp
@@ -1,21 +1,21 @@
-#include "aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp"
-#include "aztec3/utils/dummy_composer.hpp"
-#include "index.hpp"
-#include "init.hpp"
 #include "c_bind.h"
 
+#include "index.hpp"
+#include "init.hpp"
+
+#include "aztec3/circuits/abis/private_kernel/private_call_data.hpp"
+#include "aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp"
+#include "aztec3/circuits/abis/signed_tx_request.hpp"
+#include "aztec3/utils/dummy_composer.hpp"
+#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
+#include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
+#include <aztec3/circuits/mock/mock_kernel_circuit.hpp>
 #include <aztec3/constants.hpp>
 #include <aztec3/utils/types/native_types.hpp>
-#include "aztec3/circuits/abis/signed_tx_request.hpp"
-#include "aztec3/circuits/abis/private_kernel/private_call_data.hpp"
-#include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
-#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
-#include <aztec3/circuits/mock/mock_kernel_circuit.hpp>
-
-#include "barretenberg/srs/reference_string/env_reference_string.hpp"
 
 #include "barretenberg/common/serialize.hpp"
 #include "barretenberg/plonk/composer/turbo_composer.hpp"
+#include "barretenberg/srs/reference_string/env_reference_string.hpp"
 
 namespace {
 using Composer = plonk::UltraComposer;
@@ -25,7 +25,7 @@ using aztec3::circuits::abis::BaseOrMergeRollupPublicInputs;
 using aztec3::circuits::abis::BaseRollupInputs;
 using aztec3::circuits::rollup::native_base_rollup::base_rollup_circuit;
 
-} // namespace
+}  // namespace
 
 #define WASM_EXPORT __attribute__((visibility("default")))
 // WASM Cbinds
@@ -35,7 +35,7 @@ WASM_EXPORT size_t base_rollup__init_proving_key(uint8_t const** pk_buf)
 {
     std::vector<uint8_t> pk_vec(42, 0);
 
-    auto raw_buf = (uint8_t*)malloc(pk_vec.size());
+    auto* raw_buf = (uint8_t*)malloc(pk_vec.size());
     memcpy(raw_buf, (void*)pk_vec.data(), pk_vec.size());
     *pk_buf = raw_buf;
 
@@ -46,9 +46,9 @@ WASM_EXPORT size_t base_rollup__init_verification_key(uint8_t const* pk_buf, uin
 {
     std::vector<uint8_t> vk_vec(42, 0);
     // TODO remove when proving key is used
-    (void)pk_buf; // unused
+    (void)pk_buf;  // unused
 
-    auto raw_buf = (uint8_t*)malloc(vk_vec.size());
+    auto* raw_buf = (uint8_t*)malloc(vk_vec.size());
     memcpy(raw_buf, (void*)vk_vec.data(), vk_vec.size());
     *vk_buf = raw_buf;
 
@@ -67,7 +67,7 @@ WASM_EXPORT size_t base_rollup__sim(uint8_t const* base_rollup_inputs_buf,
     BaseRollupInputs<NT> base_rollup_inputs;
     read(base_rollup_inputs_buf, base_rollup_inputs);
 
-    BaseOrMergeRollupPublicInputs<NT> public_inputs = base_rollup_circuit(composer, base_rollup_inputs);
+    BaseOrMergeRollupPublicInputs<NT> const public_inputs = base_rollup_circuit(composer, base_rollup_inputs);
 
     // TODO for circuit proof version of this function
     // NT::Proof base_rollup_proof;
@@ -80,7 +80,7 @@ WASM_EXPORT size_t base_rollup__sim(uint8_t const* base_rollup_inputs_buf,
     std::vector<uint8_t> public_inputs_vec;
     write(public_inputs_vec, public_inputs);
     // copy public inputs to output buffer
-    auto raw_public_inputs_buf = (uint8_t*)malloc(public_inputs_vec.size());
+    auto* raw_public_inputs_buf = (uint8_t*)malloc(public_inputs_vec.size());
     memcpy(raw_public_inputs_buf, (void*)public_inputs_vec.data(), public_inputs_vec.size());
     *base_or_merge_rollup_public_inputs_buf = raw_public_inputs_buf;
 
@@ -139,4 +139,4 @@ WASM_EXPORT size_t base_rollup__sim(uint8_t const* base_rollup_inputs_buf,
 //     return true;
 // }
 
-} // extern "C"
+}  // extern "C"

--- a/circuits/cpp/src/aztec3/circuits/rollup/base/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/base/init.hpp
@@ -2,25 +2,25 @@
 #pragma once
 
 #include "aztec3/circuits/abis/append_only_tree_snapshot.hpp"
-#include "aztec3/circuits/abis/rollup/constant_rollup_data.hpp"
-#include "aztec3/circuits/abis/rollup/base/base_rollup_inputs.hpp"
 #include "aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp"
+#include "aztec3/circuits/abis/rollup/base/base_rollup_inputs.hpp"
+#include "aztec3/circuits/abis/rollup/constant_rollup_data.hpp"
 #include "aztec3/utils/circuit_errors.hpp"
+#include "aztec3/utils/dummy_composer.hpp"
+#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
+#include <aztec3/circuits/hash.hpp>
+#include <aztec3/circuits/recursion/aggregator.hpp>
+#include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
 #include "barretenberg/stdlib/merkle_tree/memory_store.hpp"
 #include "barretenberg/stdlib/merkle_tree/memory_tree.hpp"
 #include "barretenberg/stdlib/merkle_tree/merkle_tree.hpp"
 #include "barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp"
-#include <aztec3/circuits/recursion/aggregator.hpp>
-#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
-#include "aztec3/utils/dummy_composer.hpp"
-
 #include <barretenberg/crypto/sha256/sha256.hpp>
-#include <barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.hpp>
 #include <barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_leaf.hpp>
-#include <aztec3/utils/types/convert.hpp>
-#include <aztec3/utils/types/circuit_types.hpp>
-#include <aztec3/utils/types/native_types.hpp>
-#include <aztec3/circuits/hash.hpp>
+#include <barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.hpp>
 
 namespace aztec3::circuits::rollup::native_base_rollup {
 
@@ -43,4 +43,4 @@ using NullifierTree = stdlib::merkle_tree::NullifierMemoryTree;
 using NullifierLeaf = stdlib::merkle_tree::nullifier_leaf;
 using SparseTree = stdlib::merkle_tree::MerkleTree<stdlib::merkle_tree::MemoryStore>;
 
-} // namespace aztec3::circuits::rollup::native_base_rollup
+}  // namespace aztec3::circuits::rollup::native_base_rollup

--- a/circuits/cpp/src/aztec3/circuits/rollup/base/native_base_rollup_circuit.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/base/native_base_rollup_circuit.cpp
@@ -170,7 +170,8 @@ std::array<NT::fr, 2> calculate_calldata_hash(BaseRollupInputs const& baseRollup
     // FIXME
     // Calculate sha256 hash of calldata; TODO: work out typing here
     // 22 * 32 = 22 fields, each 32 bytes
-    std::array<uint8_t, 22 * 32> calldata_hash_inputs_bytes;
+    constexpr auto num_bytes = 22 * 32;
+    std::array<uint8_t, num_bytes> calldata_hash_inputs_bytes;
     // Convert all into a buffer, then copy into the array, then hash
     for (size_t i = 0; i < calldata_hash_inputs.size(); i++) {
         auto as_bytes = calldata_hash_inputs[i].to_buffer();

--- a/circuits/cpp/src/aztec3/circuits/rollup/base/native_base_rollup_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/base/native_base_rollup_circuit.hpp
@@ -3,17 +3,16 @@
 #include "init.hpp"
 
 // TODO: not needed right at this moment for native impl
-#include <aztec3/utils/types/convert.hpp>
-#include <aztec3/utils/types/circuit_types.hpp>
-#include <aztec3/utils/types/native_types.hpp>
-
-#include <aztec3/circuits/abis/rollup/base/base_rollup_inputs.hpp>
 #include <aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp>
-#include <aztec3/circuits/abis/rollup/nullifier_leaf_preimage.hpp>
+#include <aztec3/circuits/abis/rollup/base/base_rollup_inputs.hpp>
 #include <aztec3/circuits/abis/rollup/constant_rollup_data.hpp>
+#include <aztec3/circuits/abis/rollup/nullifier_leaf_preimage.hpp>
+#include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 namespace aztec3::circuits::rollup::native_base_rollup {
 
 BaseOrMergeRollupPublicInputs base_rollup_circuit(DummyComposer& composer, BaseRollupInputs const& baseRollupInputs);
 
-} // namespace aztec3::circuits::rollup::native_base_rollup
+}  // namespace aztec3::circuits::rollup::native_base_rollup

--- a/circuits/cpp/src/aztec3/circuits/rollup/components/components.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/components/components.cpp
@@ -85,7 +85,8 @@ void assert_equal_constants(DummyComposer& composer,
 std::array<fr, 2> compute_calldata_hash(std::array<abis::PreviousRollupData<NT>, 2> previous_rollup_data)
 {
     // Generate a 512 bit input from right and left 256 bit hashes
-    std::array<uint8_t, 2 * 32> calldata_hash_input_bytes;
+    constexpr auto num_bytes = 2 * 32;
+    std::array<uint8_t, num_bytes> calldata_hash_input_bytes;
     for (uint8_t i = 0; i < 2; i++) {
         std::array<fr, 2> calldata_hash_fr = previous_rollup_data[i].base_or_merge_rollup_public_inputs.calldata_hash;
 

--- a/circuits/cpp/src/aztec3/circuits/rollup/components/components.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/components/components.cpp
@@ -1,11 +1,13 @@
+#include "init.hpp"
+
 #include "aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp"
 #include "aztec3/constants.hpp"
 #include "aztec3/utils/circuit_errors.hpp"
+
 #include "barretenberg/crypto/pedersen_hash/pedersen.hpp"
 #include "barretenberg/crypto/sha256/sha256.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barretenberg/stdlib/hash/pedersen/pedersen.hpp"
-#include "init.hpp"
 
 #include <algorithm>
 #include <array>
@@ -100,12 +102,13 @@ std::array<fr, 2> compute_calldata_hash(std::array<abis::PreviousRollupData<NT>,
     }
 
     // Compute the sha256
-    std::vector<uint8_t> calldata_hash_input_bytes_vec(calldata_hash_input_bytes.begin(),
-                                                       calldata_hash_input_bytes.end());
+    std::vector<uint8_t> const calldata_hash_input_bytes_vec(calldata_hash_input_bytes.begin(),
+                                                             calldata_hash_input_bytes.end());
     auto h = sha256::sha256(calldata_hash_input_bytes_vec);
 
     // Split the hash into two fields, a high and a low
-    std::array<uint8_t, 32> buf_1, buf_2;
+    std::array<uint8_t, 32> buf_1;
+    std::array<uint8_t, 32> buf_2;
     for (uint8_t i = 0; i < 16; i++) {
         buf_1[i] = 0;
         buf_1[16 + i] = h[i];
@@ -138,4 +141,4 @@ void assert_prev_rollups_follow_on_from_each_other(DummyComposer& composer,
                        utils::CircuitErrorCode::CONTRACT_TREE_SNAPSHOT_MISMATCH);
 }
 
-} // namespace aztec3::circuits::rollup::components
+}  // namespace aztec3::circuits::rollup::components

--- a/circuits/cpp/src/aztec3/circuits/rollup/components/components.hpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/components/components.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "aztec3/utils/circuit_errors.hpp"
 #include "init.hpp"
+
+#include "aztec3/utils/circuit_errors.hpp"
 
 using aztec3::circuits::check_membership;
 using aztec3::circuits::root_from_sibling_path;
@@ -24,14 +25,13 @@ void assert_equal_constants(DummyComposer& composer,
 AggregationObject aggregate_proofs(BaseOrMergeRollupPublicInputs const& left,
                                    BaseOrMergeRollupPublicInputs const& right);
 
-template <size_t N>
-AppendOnlySnapshot insert_subtree_to_snapshot_tree(DummyComposer& composer,
-                                                   AppendOnlySnapshot snapshot,
-                                                   std::array<NT::fr, N> siblingPath,
-                                                   NT::fr emptySubtreeRoot,
-                                                   NT::fr subtreeRootToInsert,
-                                                   uint8_t subtreeDepth,
-                                                   std::string const& message)
+template <size_t N> AppendOnlySnapshot insert_subtree_to_snapshot_tree(DummyComposer& composer,
+                                                                       AppendOnlySnapshot snapshot,
+                                                                       std::array<NT::fr, N> siblingPath,
+                                                                       NT::fr emptySubtreeRoot,
+                                                                       NT::fr subtreeRootToInsert,
+                                                                       uint8_t subtreeDepth,
+                                                                       std::string const& message)
 {
     // TODO: Sanity check len of siblingPath > height of subtree
     // TODO: Ensure height of subtree is correct (eg 3 for commitments, 1 for contracts)
@@ -44,10 +44,10 @@ AppendOnlySnapshot insert_subtree_to_snapshot_tree(DummyComposer& composer,
     auto new_root = root_from_sibling_path<NT>(subtreeRootToInsert, leafIndexAtDepth, siblingPath);
 
     // 2^subtreeDepth is the number of leaves added. 2^x = 1 << x
-    auto new_next_available_leaf_index = snapshot.next_available_leaf_index + (uint8_t(1) << subtreeDepth);
+    auto new_next_available_leaf_index = snapshot.next_available_leaf_index + (static_cast<uint8_t>(1) << subtreeDepth);
 
     AppendOnlySnapshot newTreeSnapshot = { .root = new_root,
                                            .next_available_leaf_index = new_next_available_leaf_index };
     return newTreeSnapshot;
 }
-} // namespace aztec3::circuits::rollup::components
+}  // namespace aztec3::circuits::rollup::components

--- a/circuits/cpp/src/aztec3/circuits/rollup/components/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/components/init.hpp
@@ -2,18 +2,18 @@
 #pragma once
 
 #include "aztec3/circuits/abis/append_only_tree_snapshot.hpp"
-#include "aztec3/circuits/abis/rollup/constant_rollup_data.hpp"
 #include "aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp"
+#include "aztec3/circuits/abis/rollup/constant_rollup_data.hpp"
 #include "aztec3/circuits/abis/rollup/merge/merge_rollup_inputs.hpp"
-#include <aztec3/circuits/recursion/aggregator.hpp>
-#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
 #include "aztec3/utils/dummy_composer.hpp"
+#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
 #include <aztec3/circuits/hash.hpp>
+#include <aztec3/circuits/recursion/aggregator.hpp>
+#include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 #include <barretenberg/crypto/sha256/sha256.hpp>
-#include <aztec3/utils/types/convert.hpp>
-#include <aztec3/utils/types/circuit_types.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 
 namespace aztec3::circuits::rollup::components {
 
@@ -26,4 +26,4 @@ using BaseOrMergeRollupPublicInputs = aztec3::circuits::abis::BaseOrMergeRollupP
 using AppendOnlySnapshot = abis::AppendOnlyTreeSnapshot<NT>;
 using DummyComposer = aztec3::utils::DummyComposer;
 
-} // namespace aztec3::circuits::rollup::components
+}  // namespace aztec3::circuits::rollup::components

--- a/circuits/cpp/src/aztec3/circuits/rollup/merge/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/merge/.test.cpp
@@ -1,46 +1,43 @@
-#include <gtest/gtest-death-test.h>
-#include <gtest/gtest.h>
-#include "aztec3/circuits/rollup/merge/init.hpp"
 #include "c_bind.h"
-#include "aztec3/circuits/rollup/test_utils/utils.hpp"
 #include "index.hpp"
 #include "init.hpp"
 
+#include "aztec3/circuits/rollup/merge/init.hpp"
+#include "aztec3/circuits/rollup/test_utils/utils.hpp"
+
+#include <gtest/gtest.h>
+
+#include <gtest/gtest-death-test.h>
+
 namespace {
-using aztec3::circuits::abis::BaseOrMergeRollupPublicInputs;
-using aztec3::circuits::rollup::merge::merge_rollup_circuit;
 using aztec3::circuits::rollup::merge::MergeRollupInputs;
 using DummyComposer = aztec3::utils::DummyComposer;
 
-using aztec3::circuits::rollup::test_utils::utils::base_rollup_inputs_from_kernels;
 using aztec3::circuits::rollup::test_utils::utils::get_empty_kernel;
-using aztec3::circuits::rollup::test_utils::utils::get_initial_nullifier_tree;
 using aztec3::circuits::rollup::test_utils::utils::get_merge_rollup_inputs;
-using aztec3::circuits::rollup::test_utils::utils::set_kernel_commitments;
-using aztec3::circuits::rollup::test_utils::utils::set_kernel_nullifiers;
 
 using NT = aztec3::utils::types::NativeTypes;
 
 using KernelData = aztec3::circuits::abis::PreviousKernelData<NT>;
 
-} // namespace
+}  // namespace
 namespace aztec3::circuits::rollup::merge::native_merge_rollup_circuit {
 
 class merge_rollup_tests : public ::testing::Test {
   protected:
-    void run_cbind(MergeRollupInputs& merge_rollup_inputs,
-                   BaseOrMergeRollupPublicInputs& expected_public_inputs,
-                   bool compare_pubins = true)
+    static void run_cbind(MergeRollupInputs& merge_rollup_inputs,
+                          BaseOrMergeRollupPublicInputs& expected_public_inputs,
+                          bool compare_pubins = true)
     {
         info("Retesting via cbinds....");
         std::vector<uint8_t> merge_rollup_inputs_vec;
         write(merge_rollup_inputs_vec, merge_rollup_inputs);
 
-        uint8_t const* public_inputs_buf;
+        uint8_t const* public_inputs_buf = nullptr;
         // info("simulating circuit via cbind");
-        size_t public_inputs_size;
+        size_t public_inputs_size = 0;
         info("creating proof");
-        auto circuit_failure_ptr =
+        auto* circuit_failure_ptr =
             merge_rollup__sim(merge_rollup_inputs_vec.data(), &public_inputs_size, &public_inputs_buf);
         ASSERT_TRUE(circuit_failure_ptr == nullptr);
         // info("PublicInputs size: ", public_inputs_size);
@@ -73,7 +70,7 @@ class merge_rollup_tests : public ::testing::Test {
 TEST_F(merge_rollup_tests, native_different_rollup_type_fails)
 {
     DummyComposer composer = DummyComposer();
-    std::array<KernelData, 4> kernels = {
+    std::array<KernelData, 4> const kernels = {
         get_empty_kernel(), get_empty_kernel(), get_empty_kernel(), get_empty_kernel()
     };
     MergeRollupInputs mergeInput = get_merge_rollup_inputs(composer, kernels);
@@ -87,7 +84,7 @@ TEST_F(merge_rollup_tests, native_different_rollup_type_fails)
 TEST_F(merge_rollup_tests, native_different_rollup_height_fails)
 {
     DummyComposer composer = DummyComposer();
-    std::array<KernelData, 4> kernels = {
+    std::array<KernelData, 4> const kernels = {
         get_empty_kernel(), get_empty_kernel(), get_empty_kernel(), get_empty_kernel()
     };
     MergeRollupInputs mergeInput = get_merge_rollup_inputs(composer, kernels);
@@ -101,7 +98,7 @@ TEST_F(merge_rollup_tests, native_different_rollup_height_fails)
 TEST_F(merge_rollup_tests, native_constants_different_failure)
 {
     DummyComposer composer = DummyComposer();
-    std::array<KernelData, 4> kernels = {
+    std::array<KernelData, 4> const kernels = {
         get_empty_kernel(), get_empty_kernel(), get_empty_kernel(), get_empty_kernel()
     };
     MergeRollupInputs inputs = get_merge_rollup_inputs(composer, kernels);
@@ -115,10 +112,10 @@ TEST_F(merge_rollup_tests, native_constants_different_failure)
 TEST_F(merge_rollup_tests, native_fail_if_previous_rollups_dont_follow_on)
 {
     DummyComposer composerA = DummyComposer();
-    std::array<KernelData, 4> kernels = {
+    std::array<KernelData, 4> const kernels = {
         get_empty_kernel(), get_empty_kernel(), get_empty_kernel(), get_empty_kernel()
     };
-    MergeRollupInputs inputs = get_merge_rollup_inputs(composerA, kernels);
+    MergeRollupInputs const inputs = get_merge_rollup_inputs(composerA, kernels);
     auto inputA = inputs;
     inputA.previous_rollup_data[0].base_or_merge_rollup_public_inputs.end_private_data_tree_snapshot = {
         .root = fr(0), .next_available_leaf_index = 0
@@ -162,7 +159,7 @@ TEST_F(merge_rollup_tests, native_fail_if_previous_rollups_dont_follow_on)
 TEST_F(merge_rollup_tests, native_rollup_fields_are_set_correctly)
 {
     DummyComposer composer = DummyComposer();
-    std::array<KernelData, 4> kernels = {
+    std::array<KernelData, 4> const kernels = {
         get_empty_kernel(), get_empty_kernel(), get_empty_kernel(), get_empty_kernel()
     };
     MergeRollupInputs inputs = get_merge_rollup_inputs(composer, kernels);
@@ -189,11 +186,11 @@ TEST_F(merge_rollup_tests, native_rollup_fields_are_set_correctly)
 TEST_F(merge_rollup_tests, native_start_and_end_snapshots)
 {
     DummyComposer composer = DummyComposer();
-    std::array<KernelData, 4> kernels = {
+    std::array<KernelData, 4> const kernels = {
         get_empty_kernel(), get_empty_kernel(), get_empty_kernel(), get_empty_kernel()
     };
     MergeRollupInputs inputs = get_merge_rollup_inputs(composer, kernels);
-    BaseOrMergeRollupPublicInputs outputs = merge_rollup_circuit(composer, inputs);
+    BaseOrMergeRollupPublicInputs const outputs = merge_rollup_circuit(composer, inputs);
     // check that start and end snapshots are set correctly
     ASSERT_EQ(outputs.start_private_data_tree_snapshot,
               inputs.previous_rollup_data[0].base_or_merge_rollup_public_inputs.start_private_data_tree_snapshot);
@@ -221,7 +218,7 @@ TEST_F(merge_rollup_tests, native_start_and_end_snapshots)
 TEST_F(merge_rollup_tests, native_calldata_hash)
 {
     DummyComposer composer = DummyComposer();
-    std::vector<uint8_t> zero_bytes_vec(704, 0);
+    std::vector<uint8_t> const zero_bytes_vec(704, 0);
     auto call_data_hash_inner = sha256::sha256(zero_bytes_vec);
 
     std::array<uint8_t, 64> hash_input;
@@ -230,16 +227,16 @@ TEST_F(merge_rollup_tests, native_calldata_hash)
         hash_input[32 + i] = call_data_hash_inner[i];
     }
 
-    std::vector<uint8_t> calldata_hash_input_bytes_vec(hash_input.begin(), hash_input.end());
+    std::vector<uint8_t> const calldata_hash_input_bytes_vec(hash_input.begin(), hash_input.end());
 
     auto expected_calldata_hash = sha256::sha256(calldata_hash_input_bytes_vec);
 
-    std::array<KernelData, 4> kernels = {
+    std::array<KernelData, 4> const kernels = {
         get_empty_kernel(), get_empty_kernel(), get_empty_kernel(), get_empty_kernel()
     };
-    MergeRollupInputs inputs = get_merge_rollup_inputs(composer, kernels);
+    MergeRollupInputs const inputs = get_merge_rollup_inputs(composer, kernels);
 
-    BaseOrMergeRollupPublicInputs outputs = merge_rollup_circuit(composer, inputs);
+    BaseOrMergeRollupPublicInputs const outputs = merge_rollup_circuit(composer, inputs);
 
     std::array<fr, 2> actual_calldata_hash_fr = outputs.calldata_hash;
     auto high_buffer = actual_calldata_hash_fr[0].to_buffer();
@@ -258,12 +255,12 @@ TEST_F(merge_rollup_tests, native_calldata_hash)
 TEST_F(merge_rollup_tests, native_constants_dont_change)
 {
     DummyComposer composer = DummyComposer();
-    std::array<KernelData, 4> kernels = {
+    std::array<KernelData, 4> const kernels = {
         get_empty_kernel(), get_empty_kernel(), get_empty_kernel(), get_empty_kernel()
     };
     MergeRollupInputs inputs = get_merge_rollup_inputs(composer, kernels);
 
-    BaseOrMergeRollupPublicInputs outputs = merge_rollup_circuit(composer, inputs);
+    BaseOrMergeRollupPublicInputs const outputs = merge_rollup_circuit(composer, inputs);
     ASSERT_EQ(inputs.previous_rollup_data[0].base_or_merge_rollup_public_inputs.constants, outputs.constants);
     ASSERT_EQ(inputs.previous_rollup_data[1].base_or_merge_rollup_public_inputs.constants, outputs.constants);
 }
@@ -272,12 +269,12 @@ TEST_F(merge_rollup_tests, native_aggregate)
 {
     // TODO: Fix this when aggregation works
     DummyComposer composer = DummyComposer();
-    std::array<KernelData, 4> kernels = {
+    std::array<KernelData, 4> const kernels = {
         get_empty_kernel(), get_empty_kernel(), get_empty_kernel(), get_empty_kernel()
     };
     MergeRollupInputs inputs = get_merge_rollup_inputs(composer, kernels);
 
-    BaseOrMergeRollupPublicInputs outputs = merge_rollup_circuit(composer, inputs);
+    BaseOrMergeRollupPublicInputs const outputs = merge_rollup_circuit(composer, inputs);
     ASSERT_EQ(inputs.previous_rollup_data[0].base_or_merge_rollup_public_inputs.end_aggregation_object.public_inputs,
               outputs.end_aggregation_object.public_inputs);
     ASSERT_FALSE(composer.failed());
@@ -286,7 +283,7 @@ TEST_F(merge_rollup_tests, native_aggregate)
 TEST_F(merge_rollup_tests, native_merge_cbind)
 {
     DummyComposer composer = DummyComposer();
-    std::array<KernelData, 4> kernels = {
+    std::array<KernelData, 4> const kernels = {
         get_empty_kernel(), get_empty_kernel(), get_empty_kernel(), get_empty_kernel()
     };
     MergeRollupInputs inputs = get_merge_rollup_inputs(composer, kernels);
@@ -295,4 +292,4 @@ TEST_F(merge_rollup_tests, native_merge_cbind)
     BaseOrMergeRollupPublicInputs ignored_public_inputs;
     run_cbind(inputs, ignored_public_inputs, false);
 }
-} // namespace aztec3::circuits::rollup::merge::native_merge_rollup_circuit
+}  // namespace aztec3::circuits::rollup::merge::native_merge_rollup_circuit

--- a/circuits/cpp/src/aztec3/circuits/rollup/merge/c_bind.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/merge/c_bind.cpp
@@ -1,6 +1,8 @@
-#include "aztec3/utils/dummy_composer.hpp"
-#include "index.hpp"
 #include "c_bind.h"
+
+#include "index.hpp"
+
+#include "aztec3/utils/dummy_composer.hpp"
 
 namespace {
 using NT = aztec3::utils::types::NativeTypes;
@@ -9,7 +11,7 @@ using aztec3::circuits::abis::BaseOrMergeRollupPublicInputs;
 using aztec3::circuits::abis::MergeRollupInputs;
 using aztec3::circuits::rollup::merge::merge_rollup_circuit;
 
-} // namespace
+}  // namespace
 #define WASM_EXPORT __attribute__((visibility("default")))
 // WASM Cbinds
 extern "C" {
@@ -22,13 +24,13 @@ WASM_EXPORT uint8_t* merge_rollup__sim(uint8_t const* merge_rollup_inputs_buf,
     MergeRollupInputs<NT> merge_rollup_inputs;
     read(merge_rollup_inputs_buf, merge_rollup_inputs);
 
-    BaseOrMergeRollupPublicInputs public_inputs = merge_rollup_circuit(composer, merge_rollup_inputs);
+    BaseOrMergeRollupPublicInputs const public_inputs = merge_rollup_circuit(composer, merge_rollup_inputs);
 
     // serialize public inputs to bytes vec
     std::vector<uint8_t> public_inputs_vec;
     write(public_inputs_vec, public_inputs);
     // copy public inputs to output buffer
-    auto raw_public_inputs_buf = (uint8_t*)malloc(public_inputs_vec.size());
+    auto* raw_public_inputs_buf = (uint8_t*)malloc(public_inputs_vec.size());
     memcpy(raw_public_inputs_buf, (void*)public_inputs_vec.data(), public_inputs_vec.size());
     *merge_rollup_public_inputs_buf = raw_public_inputs_buf;
     *merge_rollup_public_inputs_size_out = public_inputs_vec.size();
@@ -38,4 +40,4 @@ WASM_EXPORT uint8_t* merge_rollup__sim(uint8_t const* merge_rollup_inputs_buf,
     }
     return composer.alloc_and_serialize_first_failure();
 }
-} // extern "C"
+}  // extern "C"

--- a/circuits/cpp/src/aztec3/circuits/rollup/merge/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/merge/init.hpp
@@ -2,17 +2,17 @@
 #pragma once
 
 #include "aztec3/circuits/abis/append_only_tree_snapshot.hpp"
-#include "aztec3/circuits/abis/rollup/constant_rollup_data.hpp"
 #include "aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp"
+#include "aztec3/circuits/abis/rollup/constant_rollup_data.hpp"
 #include "aztec3/circuits/abis/rollup/merge/merge_rollup_inputs.hpp"
-#include <aztec3/circuits/recursion/aggregator.hpp>
-#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
 #include "aztec3/utils/dummy_composer.hpp"
+#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
+#include <aztec3/circuits/recursion/aggregator.hpp>
+#include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 #include <barretenberg/crypto/sha256/sha256.hpp>
-#include <aztec3/utils/types/convert.hpp>
-#include <aztec3/utils/types/circuit_types.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 
 namespace aztec3::circuits::rollup::merge {
 
@@ -29,4 +29,4 @@ using Aggregator = aztec3::circuits::recursion::Aggregator;
 using AggregationObject = utils::types::NativeTypes::AggregationObject;
 using AppendOnlySnapshot = abis::AppendOnlyTreeSnapshot<NT>;
 
-} // namespace aztec3::circuits::rollup::merge
+}  // namespace aztec3::circuits::rollup::merge

--- a/circuits/cpp/src/aztec3/circuits/rollup/merge/native_merge_rollup_circuit.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/merge/native_merge_rollup_circuit.cpp
@@ -1,10 +1,11 @@
 #include "init.hpp"
+
+#include <aztec3/circuits/rollup/components/components.hpp>
+
 #include "barretenberg/crypto/pedersen_hash/pedersen.hpp"
 #include "barretenberg/crypto/sha256/sha256.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barretenberg/stdlib/hash/pedersen/pedersen.hpp"
-
-#include <aztec3/circuits/rollup/components/components.hpp>
 
 #include <algorithm>
 #include <array>
@@ -26,7 +27,7 @@ BaseOrMergeRollupPublicInputs merge_rollup_circuit(DummyComposer& composer, Merg
 
     // check that both input proofs are either both "BASE" or "MERGE" and not a mix!
     // this prevents having wonky commitment, nullifier and contract subtrees.
-    AggregationObject aggregation_object = components::aggregate_proofs(left, right);
+    AggregationObject const aggregation_object = components::aggregate_proofs(left, right);
     components::assert_both_input_proofs_of_same_rollup_type(composer, left, right);
     auto current_height = components::assert_both_input_proofs_of_same_height_and_return(composer, left, right);
     components::assert_equal_constants(composer, left, right);
@@ -54,4 +55,4 @@ BaseOrMergeRollupPublicInputs merge_rollup_circuit(DummyComposer& composer, Merg
     return public_inputs;
 }
 
-} // namespace aztec3::circuits::rollup::merge
+}  // namespace aztec3::circuits::rollup::merge

--- a/circuits/cpp/src/aztec3/circuits/rollup/merge/native_merge_rollup_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/merge/native_merge_rollup_circuit.hpp
@@ -4,4 +4,4 @@
 
 namespace aztec3::circuits::rollup::merge {
 BaseOrMergeRollupPublicInputs merge_rollup_circuit(DummyComposer& composer, MergeRollupInputs const& mergeRollupInputs);
-} // namespace aztec3::circuits::rollup::merge
+}  // namespace aztec3::circuits::rollup::merge

--- a/circuits/cpp/src/aztec3/circuits/rollup/root/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/root/.test.cpp
@@ -1,126 +1,98 @@
+#include "c_bind.h"
+#include "index.hpp"
+#include "init.hpp"
+
 #include "aztec3/circuits/abis/append_only_tree_snapshot.hpp"
 #include "aztec3/circuits/abis/membership_witness.hpp"
 #include "aztec3/circuits/abis/new_contract_data.hpp"
 #include "aztec3/circuits/abis/previous_kernel_data.hpp"
 #include "aztec3/circuits/abis/rollup/merge/previous_rollup_data.hpp"
 #include "aztec3/circuits/abis/rollup/nullifier_leaf_preimage.hpp"
-#include "aztec3/circuits/rollup/base/init.hpp"
-#include "aztec3/circuits/rollup/test_utils/utils.hpp"
-#include "aztec3/circuits/rollup/base/native_base_rollup_circuit.hpp"
 #include "aztec3/circuits/kernel/private/utils.hpp"
+#include "aztec3/circuits/rollup/base/init.hpp"
+#include "aztec3/circuits/rollup/base/native_base_rollup_circuit.hpp"
+#include "aztec3/circuits/rollup/test_utils/utils.hpp"
 #include "aztec3/constants.hpp"
 #include "aztec3/utils/dummy_composer.hpp"
-#include "barretenberg/crypto/sha256/sha256.hpp"
-#include "barretenberg/ecc/curves/bn254/fr.hpp"
-#include "barretenberg/stdlib/merkle_tree/memory_tree.hpp"
-#include "index.hpp"
-#include "init.hpp"
-#include "c_bind.h"
-
-#include <aztec3/circuits/apps/test_apps/escrow/deposit.hpp>
-#include <aztec3/circuits/apps/test_apps/basic_contract_deployment/basic_contract_deployment.hpp>
-
 #include <aztec3/circuits/abis/call_context.hpp>
 #include <aztec3/circuits/abis/call_stack_item.hpp>
+#include <aztec3/circuits/abis/combined_accumulated_data.hpp>
+#include <aztec3/circuits/abis/combined_constant_data.hpp>
+#include <aztec3/circuits/abis/combined_historic_tree_roots.hpp>
 #include <aztec3/circuits/abis/contract_deployment_data.hpp>
 #include <aztec3/circuits/abis/function_data.hpp>
+#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
+#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
+#include <aztec3/circuits/abis/private_historic_tree_roots.hpp>
+#include <aztec3/circuits/abis/private_kernel/globals.hpp>
+#include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
 #include <aztec3/circuits/abis/signed_tx_request.hpp>
 #include <aztec3/circuits/abis/tx_context.hpp>
 #include <aztec3/circuits/abis/tx_request.hpp>
-#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
-#include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
-#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
-#include <aztec3/circuits/abis/combined_accumulated_data.hpp>
-#include <aztec3/circuits/abis/combined_constant_data.hpp>
-#include <aztec3/circuits/abis/private_historic_tree_roots.hpp>
-#include <aztec3/circuits/abis/combined_historic_tree_roots.hpp>
-#include <aztec3/circuits/abis/private_kernel/globals.hpp>
-
 #include <aztec3/circuits/apps/function_execution_context.hpp>
-
+#include <aztec3/circuits/apps/test_apps/basic_contract_deployment/basic_contract_deployment.hpp>
+#include <aztec3/circuits/apps/test_apps/escrow/deposit.hpp>
 #include <aztec3/circuits/mock/mock_kernel_circuit.hpp>
 
+#include "barretenberg/crypto/sha256/sha256.hpp"
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "barretenberg/stdlib/merkle_tree/memory_tree.hpp"
 #include <barretenberg/common/map.hpp>
 #include <barretenberg/common/test.hpp>
-#include <cstdint>
+
 #include <gtest/gtest.h>
+
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <vector>
 
 namespace {
 
-using aztec3::circuits::abis::CallContext;
-using aztec3::circuits::abis::CallStackItem;
-using aztec3::circuits::abis::ContractDeploymentData;
-using aztec3::circuits::abis::FunctionData;
-using aztec3::circuits::abis::OptionalPrivateCircuitPublicInputs;
-using aztec3::circuits::abis::PrivateCircuitPublicInputs;
-using aztec3::circuits::abis::SignedTxRequest;
-using aztec3::circuits::abis::TxContext;
-using aztec3::circuits::abis::TxRequest;
 
-using aztec3::circuits::abis::CombinedAccumulatedData;
-using aztec3::circuits::abis::CombinedConstantData;
-using aztec3::circuits::abis::CombinedHistoricTreeRoots;
-using aztec3::circuits::abis::KernelCircuitPublicInputs;
 using aztec3::circuits::abis::PreviousKernelData;
-using aztec3::circuits::abis::PrivateHistoricTreeRoots;
-using aztec3::circuits::abis::private_kernel::Globals;
-using aztec3::circuits::abis::private_kernel::PrivateCallData;
-using aztec3::circuits::abis::private_kernel::PrivateInputs;
 
-using aztec3::circuits::apps::test_apps::basic_contract_deployment::constructor;
-using aztec3::circuits::apps::test_apps::escrow::deposit;
 
 // using aztec3::circuits::mock::mock_circuit;
-using aztec3::circuits::kernel::private_kernel::utils::dummy_previous_kernel;
-using aztec3::circuits::mock::mock_kernel_circuit;
 using aztec3::circuits::rollup::test_utils::utils::get_empty_kernel;
 using aztec3::circuits::rollup::test_utils::utils::get_root_rollup_inputs;
 using aztec3::circuits::rollup::test_utils::utils::set_kernel_commitments;
-using aztec3::circuits::rollup::test_utils::utils::set_kernel_nullifiers;
 // using aztec3::circuits::mock::mock_kernel_inputs;
 
 using aztec3::circuits::abis::AppendOnlyTreeSnapshot;
 
-using aztec3::circuits::abis::MembershipWitness;
-using aztec3::circuits::abis::NullifierLeafPreimage;
 using aztec3::circuits::rollup::native_base_rollup::BaseOrMergeRollupPublicInputs;
 using aztec3::circuits::rollup::native_base_rollup::BaseRollupInputs;
 using aztec3::circuits::rollup::native_base_rollup::ConstantRollupData;
 using aztec3::circuits::rollup::native_base_rollup::NT;
 
-using aztec3::circuits::abis::PreviousRollupData;
 using aztec3::circuits::rollup::native_root_rollup::RootRollupInputs;
 using aztec3::circuits::rollup::native_root_rollup::RootRollupPublicInputs;
 
-using aztec3::circuits::abis::FunctionData;
 using aztec3::circuits::abis::NewContractData;
-using aztec3::circuits::abis::OptionallyRevealedData;
 
 using MemoryTree = proof_system::plonk::stdlib::merkle_tree::MemoryTree;
 using KernelData = aztec3::circuits::abis::PreviousKernelData<NT>;
-} // namespace
+}  // namespace
 
 namespace aztec3::circuits::rollup::root::native_root_rollup_circuit {
 
 class root_rollup_tests : public ::testing::Test {
   protected:
-    void run_cbind(RootRollupInputs& root_rollup_inputs,
-                   RootRollupPublicInputs& expected_public_inputs,
-                   bool compare_pubins = true)
+    static void run_cbind(RootRollupInputs& root_rollup_inputs,
+                          RootRollupPublicInputs& expected_public_inputs,
+                          bool compare_pubins = true)
     {
         info("Retesting via cbinds....");
         // TODO might be able to get rid of proving key buffer
-        uint8_t const* pk_buf;
-        size_t pk_size = root_rollup__init_proving_key(&pk_buf);
+        uint8_t const* pk_buf = nullptr;
+        size_t const pk_size = root_rollup__init_proving_key(&pk_buf);
         (void)pk_size;
         // info("Proving key size: ", pk_size);
 
         // TODO might be able to get rid of verification key buffer
-        uint8_t const* vk_buf;
-        size_t vk_size = root_rollup__init_verification_key(pk_buf, &vk_buf);
+        uint8_t const* vk_buf = nullptr;
+        size_t const vk_size = root_rollup__init_verification_key(pk_buf, &vk_buf);
         (void)vk_size;
         // info("Verification key size: ", vk_size);
 
@@ -129,9 +101,9 @@ class root_rollup_tests : public ::testing::Test {
 
         // uint8_t const* proof_data;
         // size_t proof_data_size;
-        uint8_t const* public_inputs_buf;
+        uint8_t const* public_inputs_buf = nullptr;
         // info("simulating circuit via cbind");
-        size_t public_inputs_size = root_rollup__sim(root_rollup_inputs_vec.data(), &public_inputs_buf);
+        size_t const public_inputs_size = root_rollup__sim(root_rollup_inputs_vec.data(), &public_inputs_buf);
         // info("Proof size: ", proof_data_size);
         // info("PublicInputs size: ", public_inputs_size);
 
@@ -166,7 +138,7 @@ class root_rollup_tests : public ::testing::Test {
 
 TEST_F(root_rollup_tests, native_calldata_hash_empty_blocks)
 {
-    std::vector<uint8_t> zero_bytes_vec(704, 0);
+    std::vector<uint8_t> const zero_bytes_vec(704, 0);
     auto call_data_hash_inner = sha256::sha256(zero_bytes_vec);
 
     std::array<uint8_t, 64> hash_input;
@@ -175,12 +147,12 @@ TEST_F(root_rollup_tests, native_calldata_hash_empty_blocks)
         hash_input[32 + i] = call_data_hash_inner[i];
     }
 
-    std::vector<uint8_t> calldata_hash_input_bytes_vec(hash_input.begin(), hash_input.end());
+    std::vector<uint8_t> const calldata_hash_input_bytes_vec(hash_input.begin(), hash_input.end());
 
     auto hash = sha256::sha256(calldata_hash_input_bytes_vec);
 
     utils::DummyComposer composer = utils::DummyComposer();
-    std::array<KernelData, 4> kernels = {
+    std::array<KernelData, 4> const kernels = {
         get_empty_kernel(), get_empty_kernel(), get_empty_kernel(), get_empty_kernel()
     };
     RootRollupInputs inputs = get_root_rollup_inputs(composer, kernels);
@@ -201,7 +173,7 @@ TEST_F(root_rollup_tests, native_calldata_hash_empty_blocks)
     EXPECT_FALSE(composer.failed());
 
     // Expected hash of public inputs for an empty L2 block. Also used in the contract tests.
-    fr expected_hash = uint256_t("0013b2202a3e48b039cda7eef0976060d86e610d77fc9bb8cd5b0f1b561df48c");
+    fr const expected_hash = uint256_t("0013b2202a3e48b039cda7eef0976060d86e610d77fc9bb8cd5b0f1b561df48c");
     ASSERT_EQ(outputs.hash(), expected_hash);
 
     run_cbind(inputs, outputs, true);
@@ -256,23 +228,23 @@ TEST_F(root_rollup_tests, native_root_missing_nullifier_logic)
     kernels[2].public_inputs.end.new_contracts[0] = new_contract;
 
     // The start historic data snapshot
-    AppendOnlyTreeSnapshot<NT> start_historic_data_tree_snapshot = { .root = historic_data_tree.root(),
-                                                                     .next_available_leaf_index = 1 };
-    AppendOnlyTreeSnapshot<NT> start_historic_contract_tree_snapshot = { .root = historic_contract_tree.root(),
-                                                                         .next_available_leaf_index = 1 };
+    AppendOnlyTreeSnapshot<NT> const start_historic_data_tree_snapshot = { .root = historic_data_tree.root(),
+                                                                           .next_available_leaf_index = 1 };
+    AppendOnlyTreeSnapshot<NT> const start_historic_contract_tree_snapshot = { .root = historic_contract_tree.root(),
+                                                                               .next_available_leaf_index = 1 };
 
     // Insert the newest data root into the historic tree
     historic_data_tree.update_element(1, data_tree.root());
     historic_contract_tree.update_element(1, contract_tree.root());
 
     // Compute the end snapshot
-    AppendOnlyTreeSnapshot<NT> end_historic_data_tree_snapshot = { .root = historic_data_tree.root(),
-                                                                   .next_available_leaf_index = 2 };
-    AppendOnlyTreeSnapshot<NT> end_historic_contract_tree_snapshot = { .root = historic_contract_tree.root(),
-                                                                       .next_available_leaf_index = 2 };
+    AppendOnlyTreeSnapshot<NT> const end_historic_data_tree_snapshot = { .root = historic_data_tree.root(),
+                                                                         .next_available_leaf_index = 2 };
+    AppendOnlyTreeSnapshot<NT> const end_historic_contract_tree_snapshot = { .root = historic_contract_tree.root(),
+                                                                             .next_available_leaf_index = 2 };
 
     RootRollupInputs rootRollupInputs = get_root_rollup_inputs(composer, kernels);
-    RootRollupPublicInputs outputs =
+    RootRollupPublicInputs const outputs =
         aztec3::circuits::rollup::native_root_rollup::root_rollup_circuit(composer, rootRollupInputs);
 
     // Check private data trees
@@ -282,8 +254,8 @@ TEST_F(root_rollup_tests, native_root_missing_nullifier_logic)
     ASSERT_EQ(
         outputs.end_private_data_tree_snapshot,
         rootRollupInputs.previous_rollup_data[1].base_or_merge_rollup_public_inputs.end_private_data_tree_snapshot);
-    AppendOnlyTreeSnapshot<NT> expected_private_data_tree_snapshot = { .root = data_tree.root(),
-                                                                       .next_available_leaf_index = 16 };
+    AppendOnlyTreeSnapshot<NT> const expected_private_data_tree_snapshot = { .root = data_tree.root(),
+                                                                             .next_available_leaf_index = 16 };
     ASSERT_EQ(outputs.end_private_data_tree_snapshot, expected_private_data_tree_snapshot);
 
     // Check public data trees
@@ -297,8 +269,8 @@ TEST_F(root_rollup_tests, native_root_missing_nullifier_logic)
               rootRollupInputs.previous_rollup_data[0].base_or_merge_rollup_public_inputs.start_contract_tree_snapshot);
     ASSERT_EQ(outputs.end_contract_tree_snapshot,
               rootRollupInputs.previous_rollup_data[1].base_or_merge_rollup_public_inputs.end_contract_tree_snapshot);
-    AppendOnlyTreeSnapshot<NT> expected_contract_tree_snapshot{ .root = contract_tree.root(),
-                                                                .next_available_leaf_index = 4 };
+    AppendOnlyTreeSnapshot<NT> const expected_contract_tree_snapshot{ .root = contract_tree.root(),
+                                                                      .next_available_leaf_index = 4 };
     ASSERT_EQ(outputs.end_contract_tree_snapshot, expected_contract_tree_snapshot);
 
     // TODO: Check nullifier trees
@@ -314,4 +286,4 @@ TEST_F(root_rollup_tests, native_root_missing_nullifier_logic)
     EXPECT_FALSE(composer.failed());
 }
 
-} // namespace aztec3::circuits::rollup::root::native_root_rollup_circuit
+}  // namespace aztec3::circuits::rollup::root::native_root_rollup_circuit

--- a/circuits/cpp/src/aztec3/circuits/rollup/root/c_bind.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/root/c_bind.cpp
@@ -1,19 +1,19 @@
-#include "index.hpp"
-#include "init.hpp"
 #include "c_bind.h"
 
+#include "index.hpp"
+#include "init.hpp"
+
+#include "aztec3/circuits/abis/private_kernel/private_call_data.hpp"
+#include "aztec3/circuits/abis/signed_tx_request.hpp"
+#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
+#include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
+#include <aztec3/circuits/mock/mock_kernel_circuit.hpp>
 #include <aztec3/constants.hpp>
 #include <aztec3/utils/types/native_types.hpp>
-#include "aztec3/circuits/abis/signed_tx_request.hpp"
-#include "aztec3/circuits/abis/private_kernel/private_call_data.hpp"
-#include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
-#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
-#include <aztec3/circuits/mock/mock_kernel_circuit.hpp>
-
-#include "barretenberg/srs/reference_string/env_reference_string.hpp"
 
 #include "barretenberg/common/serialize.hpp"
 #include "barretenberg/plonk/composer/turbo_composer.hpp"
+#include "barretenberg/srs/reference_string/env_reference_string.hpp"
 
 namespace {
 using Composer = plonk::UltraComposer;
@@ -23,7 +23,7 @@ using aztec3::circuits::rollup::native_root_rollup::root_rollup_circuit;
 using aztec3::circuits::rollup::native_root_rollup::RootRollupInputs;
 using aztec3::circuits::rollup::native_root_rollup::RootRollupPublicInputs;
 
-} // namespace
+}  // namespace
 
 #define WASM_EXPORT __attribute__((visibility("default")))
 // WASM Cbinds
@@ -33,7 +33,7 @@ WASM_EXPORT size_t root_rollup__init_proving_key(uint8_t const** pk_buf)
 {
     std::vector<uint8_t> pk_vec(42, 0);
 
-    auto raw_buf = (uint8_t*)malloc(pk_vec.size());
+    auto* raw_buf = (uint8_t*)malloc(pk_vec.size());
     memcpy(raw_buf, (void*)pk_vec.data(), pk_vec.size());
     *pk_buf = raw_buf;
 
@@ -44,9 +44,9 @@ WASM_EXPORT size_t root_rollup__init_verification_key(uint8_t const* pk_buf, uin
 {
     std::vector<uint8_t> vk_vec(42, 0);
     // TODO remove when proving key is used
-    (void)pk_buf; // unused
+    (void)pk_buf;  // unused
 
-    auto raw_buf = (uint8_t*)malloc(vk_vec.size());
+    auto* raw_buf = (uint8_t*)malloc(vk_vec.size());
     memcpy(raw_buf, (void*)vk_vec.data(), vk_vec.size());
     *vk_buf = raw_buf;
 
@@ -60,13 +60,13 @@ WASM_EXPORT size_t root_rollup__sim(uint8_t const* root_rollup_inputs_buf,
     read(root_rollup_inputs_buf, root_rollup_inputs);
 
     DummyComposer composer = DummyComposer();
-    RootRollupPublicInputs public_inputs = root_rollup_circuit(composer, root_rollup_inputs);
+    RootRollupPublicInputs const public_inputs = root_rollup_circuit(composer, root_rollup_inputs);
 
     // serialize public inputs to bytes vec
     std::vector<uint8_t> public_inputs_vec;
     write(public_inputs_vec, public_inputs);
     // copy public inputs to output buffer
-    auto raw_public_inputs_buf = (uint8_t*)malloc(public_inputs_vec.size());
+    auto* raw_public_inputs_buf = (uint8_t*)malloc(public_inputs_vec.size());
     memcpy(raw_public_inputs_buf, (void*)public_inputs_vec.data(), public_inputs_vec.size());
     *root_rollup_public_inputs_buf = raw_public_inputs_buf;
 
@@ -75,10 +75,10 @@ WASM_EXPORT size_t root_rollup__sim(uint8_t const* root_rollup_inputs_buf,
 
 WASM_EXPORT size_t root_rollup__verify_proof(uint8_t const* vk_buf, uint8_t const* proof, uint32_t length)
 {
-    (void)vk_buf; // unused
-    (void)proof;  // unused
-    (void)length; // unused
-    return true;
+    (void)vk_buf;  // unused
+    (void)proof;   // unused
+    (void)length;  // unused
+    return 1U;
 }
 
-} // extern "C"
+}  // extern "C"

--- a/circuits/cpp/src/aztec3/circuits/rollup/root/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/root/init.hpp
@@ -2,17 +2,17 @@
 #pragma once
 
 #include "aztec3/circuits/abis/append_only_tree_snapshot.hpp"
-#include "aztec3/circuits/abis/rollup/root/root_rollup_inputs.hpp"
 #include "aztec3/circuits/abis/rollup/constant_rollup_data.hpp"
+#include "aztec3/circuits/abis/rollup/root/root_rollup_inputs.hpp"
 #include "aztec3/circuits/abis/rollup/root/root_rollup_public_inputs.hpp"
-#include <aztec3/circuits/recursion/aggregator.hpp>
-#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
 #include "aztec3/utils/dummy_composer.hpp"
+#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
+#include <aztec3/circuits/recursion/aggregator.hpp>
+#include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 #include <barretenberg/crypto/sha256/sha256.hpp>
-#include <aztec3/utils/types/convert.hpp>
-#include <aztec3/utils/types/circuit_types.hpp>
-#include <aztec3/utils/types/native_types.hpp>
 
 namespace aztec3::circuits::rollup::native_root_rollup {
 
@@ -26,4 +26,4 @@ using RootRollupPublicInputs = abis::RootRollupPublicInputs<NT>;
 
 using Aggregator = aztec3::circuits::recursion::Aggregator;
 
-} // namespace aztec3::circuits::rollup::native_root_rollup
+}  // namespace aztec3::circuits::rollup::native_root_rollup

--- a/circuits/cpp/src/aztec3/circuits/rollup/root/native_root_rollup_circuit.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/root/native_root_rollup_circuit.cpp
@@ -1,4 +1,11 @@
+#include "init.hpp"
+
 #include "aztec3/constants.hpp"
+#include <aztec3/circuits/abis/rollup/nullifier_leaf_preimage.hpp>
+#include <aztec3/circuits/abis/rollup/root/root_rollup_inputs.hpp>
+#include <aztec3/circuits/abis/rollup/root/root_rollup_public_inputs.hpp>
+#include <aztec3/circuits/rollup/components/components.hpp>
+
 #include "barretenberg/crypto/pedersen_hash/pedersen.hpp"
 #include "barretenberg/crypto/sha256/sha256.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
@@ -6,14 +13,9 @@
 #include "barretenberg/stdlib/merkle_tree/membership.hpp"
 #include "barretenberg/stdlib/merkle_tree/memory_tree.hpp"
 #include "barretenberg/stdlib/merkle_tree/merkle_tree.hpp"
-#include "init.hpp"
 
 #include <algorithm>
 #include <array>
-#include <aztec3/circuits/abis/rollup/root/root_rollup_inputs.hpp>
-#include <aztec3/circuits/abis/rollup/root/root_rollup_public_inputs.hpp>
-#include <aztec3/circuits/abis/rollup/nullifier_leaf_preimage.hpp>
-#include <aztec3/circuits/rollup/components/components.hpp>
 #include <cstdint>
 #include <iostream>
 #include <tuple>
@@ -83,4 +85,4 @@ RootRollupPublicInputs root_rollup_circuit(DummyComposer& composer, RootRollupIn
     return public_inputs;
 }
 
-} // namespace aztec3::circuits::rollup::native_root_rollup
+}  // namespace aztec3::circuits::rollup::native_root_rollup

--- a/circuits/cpp/src/aztec3/circuits/rollup/root/native_root_rollup_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/root/native_root_rollup_circuit.hpp
@@ -3,15 +3,14 @@
 #include "init.hpp"
 
 // TODO: not needed right at this moment for native impl
-#include <aztec3/utils/types/convert.hpp>
-#include <aztec3/utils/types/circuit_types.hpp>
-#include <aztec3/utils/types/native_types.hpp>
-
 #include <aztec3/circuits/abis/rollup/root/root_rollup_inputs.hpp>
 #include <aztec3/circuits/abis/rollup/root/root_rollup_public_inputs.hpp>
+#include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
 
 namespace aztec3::circuits::rollup::native_root_rollup {
 
 RootRollupPublicInputs root_rollup_circuit(DummyComposer& composer, RootRollupInputs const& rootRollupInputs);
 
-} // namespace aztec3::circuits::rollup::native_root_rollup
+}  // namespace aztec3::circuits::rollup::native_root_rollup

--- a/circuits/cpp/src/aztec3/circuits/rollup/test_utils/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/test_utils/init.hpp
@@ -2,25 +2,25 @@
 #pragma once
 
 #include "aztec3/circuits/abis/append_only_tree_snapshot.hpp"
-#include "aztec3/circuits/abis/rollup/constant_rollup_data.hpp"
-#include "aztec3/circuits/abis/rollup/base/base_rollup_inputs.hpp"
 #include "aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp"
+#include "aztec3/circuits/abis/rollup/base/base_rollup_inputs.hpp"
+#include "aztec3/circuits/abis/rollup/constant_rollup_data.hpp"
+#include "aztec3/circuits/abis/rollup/merge/merge_rollup_inputs.hpp"
+#include "aztec3/circuits/abis/rollup/merge/previous_rollup_data.hpp"
+#include "aztec3/circuits/abis/rollup/root/root_rollup_inputs.hpp"
+#include "aztec3/circuits/rollup/base/native_base_rollup_circuit.hpp"
+#include "aztec3/utils/dummy_composer.hpp"
+#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
+#include <aztec3/circuits/recursion/aggregator.hpp>
+#include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/convert.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
 #include "barretenberg/stdlib/merkle_tree/memory_tree.hpp"
 #include "barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp"
-#include <aztec3/circuits/recursion/aggregator.hpp>
-#include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
-#include "aztec3/utils/dummy_composer.hpp"
-
-#include "aztec3/circuits/rollup/base/native_base_rollup_circuit.hpp"
-#include "aztec3/circuits/abis/rollup/merge/previous_rollup_data.hpp"
-#include "aztec3/circuits/abis/rollup/merge/merge_rollup_inputs.hpp"
 #include <barretenberg/crypto/sha256/sha256.hpp>
-#include <barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.hpp>
 #include <barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_leaf.hpp>
-#include <aztec3/utils/types/convert.hpp>
-#include <aztec3/utils/types/circuit_types.hpp>
-#include <aztec3/utils/types/native_types.hpp>
-#include "aztec3/circuits/abis/rollup/root/root_rollup_inputs.hpp"
+#include <barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.hpp>
 
 namespace aztec3::circuits::rollup::test_utils {
 
@@ -45,4 +45,4 @@ using NullifierLeaf = stdlib::merkle_tree::nullifier_leaf;
 
 using aztec3::circuits::abis::MembershipWitness;
 
-} // namespace aztec3::circuits::rollup::test_utils
+}  // namespace aztec3::circuits::rollup::test_utils

--- a/circuits/cpp/src/aztec3/circuits/rollup/test_utils/nullifier_tree_testing_harness.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/test_utils/nullifier_tree_testing_harness.cpp
@@ -1,22 +1,21 @@
 #include "nullifier_tree_testing_harness.hpp"
-#include <barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp>
+
 #include <barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_leaf.hpp>
+#include <barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp>
+
 #include <cstdint>
 #include <tuple>
 
 using NullifierMemoryTree = proof_system::plonk::stdlib::merkle_tree::NullifierMemoryTree;
 using nullifier_leaf = proof_system::plonk::stdlib::merkle_tree::nullifier_leaf;
 
-NullifierMemoryTreeTestingHarness::NullifierMemoryTreeTestingHarness(size_t depth)
-    : NullifierMemoryTree(depth)
-{}
+NullifierMemoryTreeTestingHarness::NullifierMemoryTreeTestingHarness(size_t depth) : NullifierMemoryTree(depth) {}
 
 // Check for a larger value in an array
 bool check_has_less_than(std::vector<fr> const& values, fr const& value)
 {
-
     // Must perform comparisons on integers
-    uint256_t value_as_uint = uint256_t(value);
+    auto const value_as_uint = uint256_t(value);
     for (auto const& v : values) {
         // info(v, " ", uint256_t(v) < value_as_uint);
         if (uint256_t(v) < value_as_uint) {
@@ -31,7 +30,7 @@ std::tuple<std::vector<nullifier_leaf>, std::vector<std::vector<fr>>, std::vecto
 NullifierMemoryTreeTestingHarness::circuit_prep_batch_insert(std::vector<fr> const& values)
 {
     // Start insertion index
-    fr start_insertion_index = this->size();
+    fr const start_insertion_index = this->size();
 
     // Low nullifiers
     std::vector<nullifier_leaf> low_nullifiers;
@@ -47,17 +46,17 @@ NullifierMemoryTreeTestingHarness::circuit_prep_batch_insert(std::vector<fr> con
     std::map<size_t, std::vector<fr>> touched_nodes;
 
     // Keep track of 0 values
-    std::vector<fr> empty_sp(depth_, 0);
-    nullifier_leaf empty_leaf = { 0, 0, 0 };
-    uint32_t empty_index = 0;
+    std::vector<fr> const empty_sp(depth_, 0);
+    nullifier_leaf const empty_leaf = { 0, 0, 0 };
+    uint32_t const empty_index = 0;
 
     // Find the leaf with the value closest and less than `value` for each value
     for (size_t i = 0; i < values.size(); ++i) {
         auto new_value = values[i];
         auto insertion_index = start_insertion_index + i;
 
-        size_t current;
-        bool is_already_present;
+        size_t current = 0;
+        bool is_already_present = false;
         std::tie(current, is_already_present) = find_closest_leaf(leaves_, new_value);
 
         // If the inserted value is 0, then we ignore and provide a dummy low nullifier
@@ -88,9 +87,9 @@ NullifierMemoryTreeTestingHarness::circuit_prep_batch_insert(std::vector<fr> con
                 if (pending_insertion_tree[j].value < new_value &&
                     (pending_insertion_tree[j].nextValue > new_value || pending_insertion_tree[j].nextValue == 0)) {
                     // Add a new pending low nullifier for this value
-                    nullifier_leaf new_leaf = { .value = new_value,
-                                                .nextIndex = pending_insertion_tree[j].nextIndex,
-                                                .nextValue = pending_insertion_tree[j].nextValue };
+                    nullifier_leaf const new_leaf = { .value = new_value,
+                                                      .nextIndex = pending_insertion_tree[j].nextIndex,
+                                                      .nextValue = pending_insertion_tree[j].nextValue };
                     pending_insertion_tree.push_back(new_leaf);
 
                     // Update the pending low nullifier to point at the new value
@@ -108,23 +107,23 @@ NullifierMemoryTreeTestingHarness::circuit_prep_batch_insert(std::vector<fr> con
         } else {
             // Update the touched mapping
             if (prev_nodes == touched_nodes.end()) {
-                std::vector<fr> new_touched_values = { new_value };
+                std::vector<fr> const new_touched_values = { new_value };
                 touched_nodes[current] = new_touched_values;
             } else {
                 prev_nodes->second.push_back(new_value);
             }
 
-            nullifier_leaf low_nullifier = leaves_[current].unwrap();
-            std::vector<fr> sibling_path = this->get_sibling_path(current);
+            nullifier_leaf const low_nullifier = leaves_[current].unwrap();
+            std::vector<fr> const sibling_path = this->get_sibling_path(current);
 
             sibling_paths.push_back(sibling_path);
             low_nullifier_indexes.push_back(static_cast<uint32_t>(current));
             low_nullifiers.push_back(low_nullifier);
 
             // Update the current low nullifier
-            nullifier_leaf new_leaf = { .value = low_nullifier.value,
-                                        .nextIndex = insertion_index,
-                                        .nextValue = new_value };
+            nullifier_leaf const new_leaf = { .value = low_nullifier.value,
+                                              .nextIndex = insertion_index,
+                                              .nextValue = new_value };
 
             // Update the old leaf in the tree
             // update old value in tree
@@ -136,7 +135,7 @@ NullifierMemoryTreeTestingHarness::circuit_prep_batch_insert(std::vector<fr> con
     return std::make_tuple(low_nullifiers, sibling_paths, low_nullifier_indexes);
 }
 
-void NullifierMemoryTreeTestingHarness::update_element_in_place(size_t index, nullifier_leaf leaf)
+void NullifierMemoryTreeTestingHarness::update_element_in_place(size_t index, const nullifier_leaf& leaf)
 {
     // Find the leaf with the value closest and less than `value`
     this->leaves_[index].set(leaf);
@@ -145,14 +144,13 @@ void NullifierMemoryTreeTestingHarness::update_element_in_place(size_t index, nu
 
 std::pair<nullifier_leaf, size_t> NullifierMemoryTreeTestingHarness::find_lower(fr const& value)
 {
-    size_t current;
-    bool is_already_present;
+    size_t current = 0;
+    bool is_already_present = false;
     std::tie(current, is_already_present) = find_closest_leaf(leaves_, value);
 
     // TODO: handle is already present case
     if (!is_already_present) {
         return std::make_pair(leaves_[current].unwrap(), current);
-    } else {
-        return std::make_pair(leaves_[current].unwrap(), current);
     }
+    return std::make_pair(leaves_[current].unwrap(), current);
 }

--- a/circuits/cpp/src/aztec3/circuits/rollup/test_utils/nullifier_tree_testing_harness.hpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/test_utils/nullifier_tree_testing_harness.hpp
@@ -1,10 +1,12 @@
 #pragma once
+#include "aztec3/circuits/abis/append_only_tree_snapshot.hpp"
+
 #include "barretenberg/stdlib/merkle_tree/hash.hpp"
 #include "barretenberg/stdlib/merkle_tree/memory_tree.hpp"
 #include "barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_leaf.hpp"
 #include "barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp"
+
 #include <tuple>
-#include "aztec3/circuits/abis/append_only_tree_snapshot.hpp"
 
 /**
  * A version of the nullifier memory tree with extra methods specific to testing our rollup circuits.
@@ -13,7 +15,7 @@ class NullifierMemoryTreeTestingHarness : public proof_system::plonk::stdlib::me
     using nullifier_leaf = proof_system::plonk::stdlib::merkle_tree::nullifier_leaf;
 
   public:
-    NullifierMemoryTreeTestingHarness(size_t depth);
+    explicit NullifierMemoryTreeTestingHarness(size_t depth);
 
     using MemoryTree::get_hash_path;
     using MemoryTree::root;
@@ -40,7 +42,7 @@ class NullifierMemoryTreeTestingHarness : public proof_system::plonk::stdlib::me
         return { .root = root(), .next_available_leaf_index = static_cast<unsigned int>(leaves_.size()) };
     }
 
-    void update_element_in_place(size_t index, nullifier_leaf leaf);
+    void update_element_in_place(size_t index, const nullifier_leaf& leaf);
 
     // Get all of the sibling paths and low nullifier values required to craft an non membership / inclusion proofs
     std::tuple<std::vector<nullifier_leaf>, std::vector<std::vector<fr>>, std::vector<uint32_t>>

--- a/circuits/cpp/src/aztec3/circuits/rollup/test_utils/utils.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/test_utils/utils.cpp
@@ -328,7 +328,7 @@ RootRollupInputs get_root_rollup_inputs(utils::DummyComposer& composer, std::arr
  * @param initial_values values to pre-populate the tree
  * @return NullifierMemoryTreeTestingHarness
  */
-NullifierMemoryTreeTestingHarness get_initial_nullifier_tree(std::vector<fr> initial_values)
+NullifierMemoryTreeTestingHarness get_initial_nullifier_tree(const std::vector<fr> initial_values)
 {
     NullifierMemoryTreeTestingHarness nullifier_tree = NullifierMemoryTreeTestingHarness(NULLIFIER_TREE_HEIGHT);
     for (size_t i = 0; i < initial_values.size(); ++i) {

--- a/circuits/cpp/src/aztec3/circuits/rollup/test_utils/utils.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/test_utils/utils.cpp
@@ -1,18 +1,22 @@
+#include "utils.hpp"
+
+#include "init.hpp"
+#include "nullifier_tree_testing_harness.hpp"
+
 #include "aztec3/circuits/abis/membership_witness.hpp"
+#include "aztec3/circuits/abis/new_contract_data.hpp"
+#include "aztec3/circuits/abis/rollup/root/root_rollup_public_inputs.hpp"
 #include "aztec3/circuits/rollup/base/init.hpp"
+#include "aztec3/constants.hpp"
+#include <aztec3/circuits/kernel/private/utils.hpp>
+#include <aztec3/circuits/mock/mock_kernel_circuit.hpp>
+
 #include "barretenberg/numeric/uint256/uint256.hpp"
 #include "barretenberg/stdlib/merkle_tree/memory_store.hpp"
 #include "barretenberg/stdlib/merkle_tree/merkle_tree.hpp"
-#include "nullifier_tree_testing_harness.hpp"
-#include "utils.hpp"
-#include "aztec3/constants.hpp"
-#include "init.hpp"
 
-#include <aztec3/circuits/kernel/private/utils.hpp>
-#include <aztec3/circuits/mock/mock_kernel_circuit.hpp>
 #include <set>
-#include "aztec3/circuits/abis/new_contract_data.hpp"
-#include "aztec3/circuits/abis/rollup/root/root_rollup_public_inputs.hpp"
+#include <utility>
 namespace {
 using NT = aztec3::utils::types::NativeTypes;
 
@@ -34,7 +38,6 @@ using NullifierLeaf = stdlib::merkle_tree::nullifier_leaf;
 using MemoryStore = stdlib::merkle_tree::MemoryStore;
 using SparseTree = stdlib::merkle_tree::MerkleTree<MemoryStore>;
 
-using aztec3::circuits::abis::BaseOrMergeRollupPublicInputs;
 using aztec3::circuits::abis::MembershipWitness;
 using MergeRollupInputs = aztec3::circuits::abis::MergeRollupInputs<NT>;
 using aztec3::circuits::abis::PreviousRollupData;
@@ -42,7 +45,7 @@ using aztec3::circuits::abis::PreviousRollupData;
 using nullifier_tree_testing_values = std::tuple<BaseRollupInputs, AppendOnlyTreeSnapshot, AppendOnlyTreeSnapshot>;
 
 using aztec3::circuits::kernel::private_kernel::utils::dummy_previous_kernel;
-} // namespace
+}  // namespace
 
 namespace aztec3::circuits::rollup::test_utils::utils {
 
@@ -83,7 +86,7 @@ BaseRollupInputs base_rollup_inputs_from_kernels(std::array<KernelData, 2> kerne
     historic_contract_tree.update_element(0, contract_tree.root());
     historic_l1_to_l2_msg_tree.update_element(0, MerkleTree(L1_TO_L2_MSG_TREE_HEIGHT).root());
 
-    ConstantRollupData constantRollupData = {
+    ConstantRollupData const constantRollupData = {
         .start_tree_of_historic_private_data_tree_roots_snapshot = {
             .root = historic_private_data_tree.root(),
             .next_available_leaf_index = 1,
@@ -118,7 +121,7 @@ BaseRollupInputs base_rollup_inputs_from_kernels(std::array<KernelData, 2> kerne
                                               .constants = constantRollupData };
 
     // Initialise nullifier tree with 0..7
-    std::vector<fr> initial_values = { 1, 2, 3, 4, 5, 6, 7 };
+    std::vector<fr> const initial_values = { 1, 2, 3, 4, 5, 6, 7 };
 
     std::array<fr, KERNEL_NEW_NULLIFIERS_LENGTH * 2> nullifiers;
     for (size_t i = 0; i < 2; i++) {
@@ -145,16 +148,18 @@ BaseRollupInputs base_rollup_inputs_from_kernels(std::array<KernelData, 2> kerne
     for (size_t i = 0; i < 2; i++) {
         for (auto state_read : kernel_data[i].public_inputs.end.state_reads) {
             auto leaf_index = uint256_t(state_read.leaf_index);
-            if (state_read.is_empty() || visited_indices.contains(leaf_index))
+            if (state_read.is_empty() || visited_indices.contains(leaf_index)) {
                 continue;
+            }
             visited_indices.insert(leaf_index);
             public_data_tree.update_element(leaf_index, state_read.value);
         }
 
         for (auto state_write : kernel_data[i].public_inputs.end.state_transitions) {
             auto leaf_index = uint256_t(state_write.leaf_index);
-            if (state_write.is_empty() || visited_indices.contains(leaf_index))
+            if (state_write.is_empty() || visited_indices.contains(leaf_index)) {
                 continue;
+            }
             visited_indices.insert(leaf_index);
             public_data_tree.update_element(leaf_index, state_write.old_value);
         }
@@ -167,8 +172,9 @@ BaseRollupInputs base_rollup_inputs_from_kernels(std::array<KernelData, 2> kerne
     for (size_t i = 0; i < 2; i++) {
         for (size_t j = 0; j < STATE_READS_LENGTH; j++) {
             auto state_read = kernel_data[i].public_inputs.end.state_reads[j];
-            if (state_read.is_empty())
+            if (state_read.is_empty()) {
                 continue;
+            }
             auto leaf_index = uint256_t(state_read.leaf_index);
             baseRollupInputs.new_state_reads_sibling_paths[i * STATE_READS_LENGTH + j] =
                 MembershipWitness<NT, PUBLIC_DATA_TREE_HEIGHT>{
@@ -179,8 +185,9 @@ BaseRollupInputs base_rollup_inputs_from_kernels(std::array<KernelData, 2> kerne
 
         for (size_t j = 0; j < STATE_TRANSITIONS_LENGTH; j++) {
             auto state_write = kernel_data[i].public_inputs.end.state_transitions[j];
-            if (state_write.is_empty())
+            if (state_write.is_empty()) {
                 continue;
+            }
             auto leaf_index = uint256_t(state_write.leaf_index);
             public_data_tree.update_element(leaf_index, state_write.new_value);
             baseRollupInputs.new_state_transitions_sibling_paths[i * STATE_TRANSITIONS_LENGTH + j] =
@@ -216,7 +223,7 @@ BaseRollupInputs base_rollup_inputs_from_kernels(std::array<KernelData, 2> kerne
     MemoryStore public_data_tree_store;
     SparseTree public_data_tree(public_data_tree_store, PUBLIC_DATA_TREE_HEIGHT);
 
-    return base_rollup_inputs_from_kernels(kernel_data, private_data_tree, contract_tree, public_data_tree);
+    return base_rollup_inputs_from_kernels(std::move(kernel_data), private_data_tree, contract_tree, public_data_tree);
 }
 
 std::array<PreviousRollupData<NT>, 2> get_previous_rollup_data(DummyComposer& composer,
@@ -267,14 +274,14 @@ std::array<PreviousRollupData<NT>, 2> get_previous_rollup_data(DummyComposer& co
     auto base_public_input_2 =
         aztec3::circuits::rollup::native_base_rollup::base_rollup_circuit(composer, base_rollup_input_2);
 
-    PreviousRollupData<NT> previous_rollup1 = {
+    PreviousRollupData<NT> const previous_rollup1 = {
         .base_or_merge_rollup_public_inputs = base_public_input_1,
         .proof = kernel_data[0].proof,
         .vk = kernel_data[0].vk,
         .vk_index = 0,
         .vk_sibling_path = MembershipWitness<NT, ROLLUP_VK_TREE_HEIGHT>(),
     };
-    PreviousRollupData<NT> previous_rollup2 = {
+    PreviousRollupData<NT> const previous_rollup2 = {
         .base_or_merge_rollup_public_inputs = base_public_input_2,
         .proof = kernel_data[2].proof,
         .vk = kernel_data[2].vk,
@@ -287,7 +294,7 @@ std::array<PreviousRollupData<NT>, 2> get_previous_rollup_data(DummyComposer& co
 
 MergeRollupInputs get_merge_rollup_inputs(utils::DummyComposer& composer, std::array<KernelData, 4> kernel_data)
 {
-    MergeRollupInputs inputs = { .previous_rollup_data = get_previous_rollup_data(composer, kernel_data) };
+    MergeRollupInputs inputs = { .previous_rollup_data = get_previous_rollup_data(composer, std::move(kernel_data)) };
     return inputs;
 }
 
@@ -297,8 +304,8 @@ RootRollupInputs get_root_rollup_inputs(utils::DummyComposer& composer, std::arr
     MerkleTree historic_contract_tree = MerkleTree(CONTRACT_TREE_ROOTS_TREE_HEIGHT);
     MerkleTree historic_l1_to_l2_msg_tree = MerkleTree(L1_TO_L2_MSG_TREE_ROOTS_TREE_HEIGHT);
 
-    MerkleTree private_data_tree = MerkleTree(PRIVATE_DATA_TREE_HEIGHT);
-    MerkleTree contract_tree = MerkleTree(CONTRACT_TREE_HEIGHT);
+    MerkleTree const private_data_tree = MerkleTree(PRIVATE_DATA_TREE_HEIGHT);
+    MerkleTree const contract_tree = MerkleTree(CONTRACT_TREE_HEIGHT);
 
     // Historic trees are initialised with an empty root at position 0.
     historic_private_data_tree.update_element(0, private_data_tree.root());
@@ -311,7 +318,7 @@ RootRollupInputs get_root_rollup_inputs(utils::DummyComposer& composer, std::arr
         get_sibling_path<CONTRACT_TREE_ROOTS_TREE_HEIGHT>(historic_contract_tree, 1, 0);
 
     RootRollupInputs rootRollupInputs = {
-        .previous_rollup_data = get_previous_rollup_data(composer, kernel_data),
+        .previous_rollup_data = get_previous_rollup_data(composer, std::move(kernel_data)),
         .new_historic_private_data_tree_root_sibling_path = historic_data_sibling_path,
         .new_historic_contract_tree_root_sibling_path = historic_contract_sibling_path,
     };
@@ -328,11 +335,11 @@ RootRollupInputs get_root_rollup_inputs(utils::DummyComposer& composer, std::arr
  * @param initial_values values to pre-populate the tree
  * @return NullifierMemoryTreeTestingHarness
  */
-NullifierMemoryTreeTestingHarness get_initial_nullifier_tree(const std::vector<fr> initial_values)
+NullifierMemoryTreeTestingHarness get_initial_nullifier_tree(const std::vector<fr>& initial_values)
 {
     NullifierMemoryTreeTestingHarness nullifier_tree = NullifierMemoryTreeTestingHarness(NULLIFIER_TREE_HEIGHT);
-    for (size_t i = 0; i < initial_values.size(); ++i) {
-        nullifier_tree.update_element(initial_values[i]);
+    for (const auto& initial_value : initial_values) {
+        nullifier_tree.update_element(initial_value);
     }
     return nullifier_tree;
 }
@@ -351,10 +358,10 @@ nullifier_tree_testing_values generate_nullifier_tree_testing_values(BaseRollupI
     // Generate initial values lin spaved
     std::vector<fr> initial_values;
     for (size_t i = 1; i < 8; ++i) {
-        initial_values.push_back(i * spacing);
+        initial_values.emplace_back(i * spacing);
     }
 
-    return utils::generate_nullifier_tree_testing_values_explicit(inputs, nullifiers, initial_values);
+    return utils::generate_nullifier_tree_testing_values_explicit(std::move(inputs), nullifiers, initial_values);
 }
 
 nullifier_tree_testing_values generate_nullifier_tree_testing_values(
@@ -363,30 +370,30 @@ nullifier_tree_testing_values generate_nullifier_tree_testing_values(
     // Generate initial values lin spaced
     std::vector<fr> initial_values;
     for (size_t i = 1; i < 8; ++i) {
-        initial_values.push_back(i * spacing);
+        initial_values.emplace_back(i * spacing);
     }
 
-    return utils::generate_nullifier_tree_testing_values_explicit(inputs, new_nullifiers, initial_values);
+    return utils::generate_nullifier_tree_testing_values_explicit(std::move(inputs), new_nullifiers, initial_values);
 }
 
 nullifier_tree_testing_values generate_nullifier_tree_testing_values_explicit(
     BaseRollupInputs rollupInputs,
     std::array<fr, KERNEL_NEW_NULLIFIERS_LENGTH * 2> new_nullifiers,
-    std::vector<fr> initial_values)
+    const std::vector<fr>& initial_values)
 {
-    size_t start_tree_size = initial_values.size() + 1;
+    size_t const start_tree_size = initial_values.size() + 1;
     // Generate nullifier tree testing values
     NullifierMemoryTreeTestingHarness nullifier_tree = get_initial_nullifier_tree(initial_values);
     NullifierMemoryTreeTestingHarness reference_tree = get_initial_nullifier_tree(initial_values);
 
-    AppendOnlyTreeSnapshot nullifier_tree_start_snapshot = {
+    AppendOnlyTreeSnapshot const nullifier_tree_start_snapshot = {
         .root = nullifier_tree.root(),
-        .next_available_leaf_index = uint32_t(start_tree_size),
+        .next_available_leaf_index = static_cast<uint32_t>(start_tree_size),
     };
 
     const size_t NUMBER_OF_NULLIFIERS = KERNEL_NEW_NULLIFIERS_LENGTH * 2;
     std::array<NullifierLeafPreimage, NUMBER_OF_NULLIFIERS> new_nullifier_leaves;
-    std::array<MembershipWitness<NT, NULLIFIER_TREE_HEIGHT>, NUMBER_OF_NULLIFIERS>
+    std::array<MembershipWitness<NT, NULLIFIER_TREE_HEIGHT>, NUMBER_OF_NULLIFIERS> const
         low_nullifier_leaves_preimages_witnesses;
 
     // Calculate the predecessor nullifier pre-images
@@ -422,14 +429,14 @@ nullifier_tree_testing_values generate_nullifier_tree_testing_values_explicit(
                   new_nullifier_leaves_sibling_paths[i].end(),
                   witness_array.begin());
 
-        MembershipWitness<NT, NULLIFIER_TREE_HEIGHT> witness = {
-            .leaf_index = NT::uint32(new_nullifier_leave_indexes[i]),
+        MembershipWitness<NT, NULLIFIER_TREE_HEIGHT> const witness = {
+            .leaf_index = static_cast<NT::uint32>(new_nullifier_leave_indexes[i]),
             .sibling_path = witness_array,
         };
         new_membership_witnesses[i] = witness;
 
         // Create circuit compatible preimages - issue created to remove this step
-        NullifierLeafPreimage preimage = {
+        NullifierLeafPreimage const preimage = {
             .leaf_value = new_nullifier_leaves_preimages[i].value,
             .next_index = NT::uint32(new_nullifier_leaves_preimages[i].nextIndex),
             .next_value = new_nullifier_leaves_preimages[i].nextValue,
@@ -439,7 +446,7 @@ nullifier_tree_testing_values generate_nullifier_tree_testing_values_explicit(
 
     // Get expected root with subtrees inserted correctly
     // Expected end state
-    AppendOnlyTreeSnapshot nullifier_tree_end_snapshot = {
+    AppendOnlyTreeSnapshot const nullifier_tree_end_snapshot = {
         .root = reference_tree.root(),
         .next_available_leaf_index = uint32_t(reference_tree.size()),
     };
@@ -465,4 +472,4 @@ nullifier_tree_testing_values generate_nullifier_tree_testing_values_explicit(
     return std::make_tuple(rollupInputs, nullifier_tree_start_snapshot, nullifier_tree_end_snapshot);
 }
 
-} // namespace aztec3::circuits::rollup::test_utils::utils
+}  // namespace aztec3::circuits::rollup::test_utils::utils

--- a/circuits/cpp/src/aztec3/circuits/rollup/test_utils/utils.hpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/test_utils/utils.hpp
@@ -82,7 +82,7 @@ abis::AppendOnlyTreeSnapshot<NT> get_snapshot_of_tree_state(NullifierMemoryTreeT
 nullifier_tree_testing_values generate_nullifier_tree_testing_values_explicit(
     BaseRollupInputs inputs,
     std::array<fr, KERNEL_NEW_NULLIFIERS_LENGTH * 2> new_nullifiers,
-    std::vector<fr> initial_values);
+    const std::vector<fr>& initial_values);
 
 nullifier_tree_testing_values generate_nullifier_tree_testing_values(BaseRollupInputs inputs,
                                                                      size_t starting_insertion_value,
@@ -91,7 +91,7 @@ nullifier_tree_testing_values generate_nullifier_tree_testing_values(BaseRollupI
 nullifier_tree_testing_values generate_nullifier_tree_testing_values(
     BaseRollupInputs inputs, std::array<fr, KERNEL_NEW_NULLIFIERS_LENGTH * 2> new_nullifiers, size_t spacing);
 
-NullifierMemoryTreeTestingHarness get_initial_nullifier_tree(std::vector<fr> initial_values);
+NullifierMemoryTreeTestingHarness get_initial_nullifier_tree(const std::vector<fr>& initial_values);
 
 KernelData get_empty_kernel();
 

--- a/circuits/cpp/src/aztec3/circuits/rollup/test_utils/utils.hpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/test_utils/utils.hpp
@@ -1,8 +1,10 @@
 #pragma once
-#include "aztec3/circuits/abis/public_data_transition.hpp"
-#include "barretenberg/numeric/uint256/uint256.hpp"
-#include "nullifier_tree_testing_harness.hpp"
 #include "init.hpp"
+#include "nullifier_tree_testing_harness.hpp"
+
+#include "aztec3/circuits/abis/public_data_transition.hpp"
+
+#include "barretenberg/numeric/uint256/uint256.hpp"
 
 namespace aztec3::circuits::rollup::test_utils::utils {
 
@@ -35,7 +37,7 @@ using aztec3::circuits::abis::MembershipWitness;
 using aztec3::circuits::abis::PreviousRollupData;
 
 using nullifier_tree_testing_values = std::tuple<BaseRollupInputs, AppendOnlyTreeSnapshot, AppendOnlyTreeSnapshot>;
-} // namespace
+}  // namespace
 
 BaseRollupInputs base_rollup_inputs_from_kernels(std::array<KernelData, 2> kernel_data);
 
@@ -89,7 +91,7 @@ nullifier_tree_testing_values generate_nullifier_tree_testing_values(BaseRollupI
 nullifier_tree_testing_values generate_nullifier_tree_testing_values(
     BaseRollupInputs inputs, std::array<fr, KERNEL_NEW_NULLIFIERS_LENGTH * 2> new_nullifiers, size_t spacing);
 
-NullifierMemoryTreeTestingHarness get_initial_nullifier_tree(const std::vector<fr> initial_values);
+NullifierMemoryTreeTestingHarness get_initial_nullifier_tree(std::vector<fr> initial_values);
 
 KernelData get_empty_kernel();
 
@@ -118,4 +120,4 @@ inline abis::PublicDataRead<NT> make_public_read(fr leaf_index, fr value)
     };
 }
 
-} // namespace aztec3::circuits::rollup::test_utils::utils
+}  // namespace aztec3::circuits::rollup::test_utils::utils

--- a/circuits/cpp/src/aztec3/circuits/rollup/test_utils/utils.hpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/test_utils/utils.hpp
@@ -89,7 +89,7 @@ nullifier_tree_testing_values generate_nullifier_tree_testing_values(BaseRollupI
 nullifier_tree_testing_values generate_nullifier_tree_testing_values(
     BaseRollupInputs inputs, std::array<fr, KERNEL_NEW_NULLIFIERS_LENGTH * 2> new_nullifiers, size_t spacing);
 
-NullifierMemoryTreeTestingHarness get_initial_nullifier_tree(std::vector<fr> initial_values);
+NullifierMemoryTreeTestingHarness get_initial_nullifier_tree(const std::vector<fr> initial_values);
 
 KernelData get_empty_kernel();
 

--- a/circuits/cpp/src/aztec3/constants.hpp
+++ b/circuits/cpp/src/aztec3/constants.hpp
@@ -46,15 +46,15 @@ constexpr size_t NULLIFIER_SUBTREE_INCLUSION_CHECK_DEPTH = NULLIFIER_TREE_HEIGHT
 constexpr size_t PRIVATE_DATA_TREE_ROOTS_TREE_HEIGHT = 8;
 constexpr size_t CONTRACT_TREE_ROOTS_TREE_HEIGHT = 8;
 constexpr size_t L1_TO_L2_MSG_TREE_ROOTS_TREE_HEIGHT = 8;
-constexpr size_t ROLLUP_VK_TREE_HEIGHT = 8; // TODO: update
+constexpr size_t ROLLUP_VK_TREE_HEIGHT = 8;  // TODO: update
 
-constexpr size_t FUNCTION_SELECTOR_NUM_BYTES = 4; // must be <= 31
+constexpr size_t FUNCTION_SELECTOR_NUM_BYTES = 4;  // must be <= 31
 
 // Enumerate the hash_indices which are used for pedersen hashing
 // Start from 1 to avoid the default generators.
 enum GeneratorIndex {
     COMMITMENT = 1,
-    COMMITMENT_PLACEHOLDER, // for omitting some elements of the commitment when partially committing.
+    COMMITMENT_PLACEHOLDER,  // for omitting some elements of the commitment when partially committing.
     OUTER_COMMITMENT,
     NULLIFIER_HASHED_PRIVATE_KEY,
     NULLIFIER,
@@ -72,7 +72,7 @@ enum GeneratorIndex {
     CONTRACT_LEAF,
     CALL_CONTEXT,
     CALL_STACK_ITEM,
-    CALL_STACK_ITEM_2, // see function where it's used for explanation
+    CALL_STACK_ITEM_2,  // see function where it's used for explanation
     L1_MSG_STACK_ITEM,
     PRIVATE_CIRCUIT_PUBLIC_INPUTS,
     PUBLIC_CIRCUIT_PUBLIC_INPUTS,
@@ -102,4 +102,4 @@ enum PrivateStateNoteGeneratorIndex {
 
 enum PrivateStateType { PARTITIONED = 1, WHOLE };
 
-} // namespace aztec3
+}  // namespace aztec3

--- a/circuits/cpp/src/aztec3/oracle/fake_db.hpp
+++ b/circuits/cpp/src/aztec3/oracle/fake_db.hpp
@@ -1,12 +1,9 @@
 #pragma once
 
 #include <aztec3/circuits/abis/call_context.hpp>
-
-#include <aztec3/circuits/apps/utxo_datum.hpp>
-
 #include <aztec3/circuits/apps/notes/default_private_note/note_preimage.hpp>
 #include <aztec3/circuits/apps/notes/default_singleton_private_note/note_preimage.hpp>
-
+#include <aztec3/circuits/apps/utxo_datum.hpp>
 #include <aztec3/utils/types/native_types.hpp>
 
 namespace aztec3::oracle {
@@ -25,7 +22,7 @@ using NT = aztec3::utils::types::NativeTypes;
 // A temporary stub, whilst building other things first.
 class FakeDB {
   public:
-    FakeDB() {}
+    FakeDB() = default;
 
     /**
      * For getting a singleton UTXO (not a set).
@@ -34,7 +31,7 @@ class FakeDB {
      * type being a field.
      * So if you want to test other note types against this stub DB, you'll need to write your own stub DB entry.
      */
-    UTXOSLoadDatum<NT, DefaultPrivateNotePreimage<NT, typename NT::fr>> get_utxo_sload_datum(
+    static UTXOSLoadDatum<NT, DefaultPrivateNotePreimage<NT, typename NT::fr>> get_utxo_sload_datum(
         NT::address const& contract_address,
         NT::grumpkin_point const& storage_slot_point,
         DefaultPrivateNotePreimage<NT, typename NT::fr> const& advice)
@@ -42,9 +39,9 @@ class FakeDB {
     // NT::fr required_utxo_tree_root,
     // size_t utxo_tree_depth)
     {
-        (void)storage_slot_point; // Not used in this 'fake' implementation.
+        (void)storage_slot_point;  // Not used in this 'fake' implementation.
 
-        DefaultPrivateNotePreimage<NT, NT::fr> preimage{
+        DefaultPrivateNotePreimage<NT, NT::fr> const preimage{
             .value = 100,
             .owner = advice.owner,
             .creator_address = 0,
@@ -58,7 +55,7 @@ class FakeDB {
         const NT::fr required_utxo_tree_root = 2468;
 
         std::vector<NT::fr> sibling_path(utxo_tree_depth);
-        std::fill(sibling_path.begin(), sibling_path.end(), 1); // Fill with 1's to be lazy. TODO: return a valid path.
+        std::fill(sibling_path.begin(), sibling_path.end(), 1);  // Fill with 1's to be lazy. TODO: return a valid path.
 
         return {
             .commitment = 1,
@@ -78,7 +75,7 @@ class FakeDB {
      * value type being a field.
      * So if you want to test other note types against this stub DB, you'll need to write your own stub DB entry.
      */
-    std::vector<UTXOSLoadDatum<NT, DefaultPrivateNotePreimage<NT, typename NT::fr>>> get_utxo_sload_data(
+    static std::vector<UTXOSLoadDatum<NT, DefaultPrivateNotePreimage<NT, typename NT::fr>>> get_utxo_sload_data(
         NT::address const& contract_address,
         NT::grumpkin_point const& storage_slot_point,
         size_t const& num_notes,
@@ -87,7 +84,7 @@ class FakeDB {
     // NT::fr required_utxo_tree_root,
     // size_t utxo_tree_depth)
     {
-        (void)storage_slot_point; // Not used in this 'fake' implementation.
+        (void)storage_slot_point;  // Not used in this 'fake' implementation.
 
         std::vector<UTXOSLoadDatum<NT, DefaultPrivateNotePreimage<NT, typename NT::fr>>> data;
 
@@ -95,10 +92,10 @@ class FakeDB {
         const NT::fr required_utxo_tree_root = 2468;
 
         std::vector<NT::fr> sibling_path(utxo_tree_depth);
-        std::fill(sibling_path.begin(), sibling_path.end(), 1); // Fill with 1's to be lazy. TODO: return a valid path.
+        std::fill(sibling_path.begin(), sibling_path.end(), 1);  // Fill with 1's to be lazy. TODO: return a valid path.
 
         for (size_t i = 0; i < num_notes; i++) {
-            DefaultPrivateNotePreimage<NT, NT::fr> preimage{
+            DefaultPrivateNotePreimage<NT, NT::fr> const preimage{
                 .value = 100 + i,
                 .owner = advice.owner,
                 .creator_address = 0,
@@ -129,7 +126,7 @@ class FakeDB {
      * the value type being a field. So if you want to test other note types against this stub DB, you'll need to write
      * your own stub DB entry.
      */
-    UTXOSLoadDatum<NT, DefaultSingletonPrivateNotePreimage<NT, typename NT::fr>> get_utxo_sload_datum(
+    static UTXOSLoadDatum<NT, DefaultSingletonPrivateNotePreimage<NT, typename NT::fr>> get_utxo_sload_datum(
         NT::address const& contract_address,
         NT::grumpkin_point const& storage_slot_point,
         DefaultSingletonPrivateNotePreimage<NT, typename NT::fr> const& advice)
@@ -137,9 +134,9 @@ class FakeDB {
     // NT::fr required_utxo_tree_root,
     // size_t utxo_tree_depth)
     {
-        (void)storage_slot_point; // Not used in this 'fake' implementation.
+        (void)storage_slot_point;  // Not used in this 'fake' implementation.
 
-        DefaultSingletonPrivateNotePreimage<NT, NT::fr> preimage{
+        DefaultSingletonPrivateNotePreimage<NT, NT::fr> const preimage{
             .value = 100,
             .owner = advice.owner,
             .salt = 1234,
@@ -150,7 +147,7 @@ class FakeDB {
         const NT::fr required_utxo_tree_root = 2468;
 
         std::vector<NT::fr> sibling_path(utxo_tree_depth);
-        std::fill(sibling_path.begin(), sibling_path.end(), 1); // Fill with 1's to be lazy. TODO: return a valid path.
+        std::fill(sibling_path.begin(), sibling_path.end(), 1);  // Fill with 1's to be lazy. TODO: return a valid path.
 
         return {
             .commitment = 1,
@@ -164,4 +161,4 @@ class FakeDB {
     };
 };
 
-} // namespace aztec3::oracle
+}  // namespace aztec3::oracle

--- a/circuits/cpp/src/aztec3/oracle/fake_db.hpp
+++ b/circuits/cpp/src/aztec3/oracle/fake_db.hpp
@@ -25,7 +25,7 @@ using NT = aztec3::utils::types::NativeTypes;
 // A temporary stub, whilst building other things first.
 class FakeDB {
   public:
-    FakeDB(){};
+    FakeDB() {}
 
     /**
      * For getting a singleton UTXO (not a set).

--- a/circuits/cpp/src/aztec3/oracle/oracle.hpp
+++ b/circuits/cpp/src/aztec3/oracle/oracle.hpp
@@ -3,14 +3,11 @@
 #include "fake_db.hpp"
 
 #include <aztec3/circuits/abis/call_context.hpp>
-#include <aztec3/circuits/abis/function_data.hpp>
 #include <aztec3/circuits/abis/contract_deployment_data.hpp>
-
-#include <aztec3/circuits/apps/utxo_datum.hpp>
-
+#include <aztec3/circuits/abis/function_data.hpp>
 #include <aztec3/circuits/apps/notes/default_private_note/note_preimage.hpp>
 #include <aztec3/circuits/apps/notes/default_singleton_private_note/note_preimage.hpp>
-
+#include <aztec3/circuits/apps/utxo_datum.hpp>
 #include <aztec3/utils/types/native_types.hpp>
 
 namespace aztec3::oracle {
@@ -130,7 +127,7 @@ template <typename DB> class NativeOracleInterface {
 
     // Note: actual_contract_address and function_data are NOT to be provided to the circuit, so don't include
     // getter methods for these in the OracleWrapper.
-    NT::address actual_contract_address; // not to be confused with call_context.storage_contract_address;
+    NT::address actual_contract_address;  // not to be confused with call_context.storage_contract_address;
     FunctionData<NT> function_data;
 
     CallContext<NT> call_context;
@@ -145,10 +142,11 @@ template <typename DB> class NativeOracleInterface {
     bool contract_deployment_data_already_got = false;
     // bool portal_contract_address_already_got = false;
     bool msg_sender_private_key_already_got = false;
-    std::string already_got_error = "Your circuit has already accessed this value. Don't ask the oracle twice, since "
-                                    "it shouldn't be trusted, and could lead to circuit bugs";
+    std::string already_got_error =
+        "Your circuit has already accessed this value. Don't ask the oracle twice, since "
+        "it shouldn't be trusted, and could lead to circuit bugs";
 };
 
-typedef NativeOracleInterface<FakeDB> NativeOracle;
+using NativeOracle = NativeOracleInterface<FakeDB>;
 
-} // namespace aztec3::oracle
+}  // namespace aztec3::oracle

--- a/circuits/cpp/src/aztec3/utils/array.hpp
+++ b/circuits/cpp/src/aztec3/utils/array.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "./types/native_types.hpp"
+
 #include "barretenberg/common/throw_or_abort.hpp"
 
 /**
@@ -22,7 +23,7 @@ using NT = types::NativeTypes;
 template <typename ELEMS_TYPE, size_t ARRAY_LEN> std::array<ELEMS_TYPE, ARRAY_LEN> zero_array()
 {
     std::array<ELEMS_TYPE, ARRAY_LEN> arr;
-    arr.fill(ELEMS_TYPE(0)); // Assumes that integer type can be used here in initialization
+    arr.fill(ELEMS_TYPE(0));  // Assumes that integer type can be used here in initialization
     return arr;
 }
 
@@ -83,7 +84,7 @@ template <typename T, size_t SIZE> size_t array_length(std::array<T, SIZE> const
  */
 template <typename T, size_t SIZE> T array_pop(std::array<T, SIZE>& arr)
 {
-    for (size_t i = arr.max_size() - 1; i != (size_t)-1; i--) {
+    for (size_t i = arr.max_size() - 1; i != static_cast<size_t>(-1); i--) {
         if (!is_empty(arr[i])) {
             const auto temp = arr[i];
             arr[i] = empty_value<T>();
@@ -119,8 +120,9 @@ template <typename T, size_t SIZE> void array_push(std::array<T, SIZE>& arr, T c
 template <typename T, size_t SIZE> NT::boolean is_array_empty(std::array<T, SIZE> const& arr)
 {
     for (size_t i = 0; i < arr.size(); ++i) {
-        if (!is_empty(arr[i]))
+        if (!is_empty(arr[i])) {
             return false;
+        }
     }
     return true;
 };
@@ -139,8 +141,8 @@ template <size_t size_1, size_t size_2, typename T>
 void push_array_to_array(std::array<T, size_1> const& source, std::array<T, size_2>& target)
 {
     // Check if the `source` array is too large vs the remaining capacity of the `target` array
-    size_t source_size = static_cast<size_t>(uint256_t(array_length(source)));
-    size_t target_size = static_cast<size_t>(uint256_t(array_length(target)));
+    size_t const source_size = static_cast<size_t>(uint256_t(array_length(source)));
+    size_t const target_size = static_cast<size_t>(uint256_t(array_length(target)));
     ASSERT(source_size <= size_2 - target_size);
 
     // Ensure that there are no non-zero values in the `target` array after the first zero-valued index
@@ -176,8 +178,8 @@ bool source_arrays_are_in_target(std::array<T, size_1> const& source1,
                                  std::array<T, size_3> const& target)
 {
     // Check if the `source` arrays are too large vs the size of the `target` array
-    size_t source1_size = static_cast<size_t>(uint256_t(array_length(source1)));
-    size_t source2_size = static_cast<size_t>(uint256_t(array_length(source2)));
+    size_t const source1_size = static_cast<size_t>(uint256_t(array_length(source1)));
+    size_t const source2_size = static_cast<size_t>(uint256_t(array_length(source2)));
     ASSERT(source1_size + source2_size <= size_3);
 
     // first ensure that all non-empty items in the first source are in the target
@@ -205,4 +207,4 @@ bool source_arrays_are_in_target(std::array<T, size_1> const& source1,
     return true;
 }
 
-} // namespace aztec3::utils
+}  // namespace aztec3::utils

--- a/circuits/cpp/src/aztec3/utils/circuit_errors.hpp
+++ b/circuits/cpp/src/aztec3/utils/circuit_errors.hpp
@@ -77,7 +77,7 @@ enum CircuitErrorCode : uint16_t {
 
 struct CircuitError {
     CircuitErrorCode code = CircuitErrorCode::NO_ERROR;
-    std::string message = "";
+    std::string message;
 
     static CircuitError no_error() { return { CircuitErrorCode::NO_ERROR, "" }; }
 };
@@ -107,4 +107,4 @@ inline std::ostream& operator<<(std::ostream& os, CircuitError const& obj)
     return os << "code: " << as_uint16_t(obj.code) << "\n"
               << "message: " << obj.message << "\n";
 }
-} // namespace aztec3::utils
+}  // namespace aztec3::utils

--- a/circuits/cpp/src/aztec3/utils/dummy_composer.hpp
+++ b/circuits/cpp/src/aztec3/utils/dummy_composer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "aztec3/utils/circuit_errors.hpp"
+
 #include <iostream>
 #include <string>
 #include <vector>
@@ -17,7 +18,7 @@ class DummyComposer {
         }
     }
 
-    bool failed() { return failure_msgs.size() > 0; }
+    bool failed() const { return !failure_msgs.empty(); }
 
     CircuitError get_first_failure()
     {
@@ -29,7 +30,7 @@ class DummyComposer {
 
     uint8_t* alloc_and_serialize_first_failure()
     {
-        CircuitError failure = get_first_failure();
+        CircuitError const failure = get_first_failure();
         if (failure.code == CircuitErrorCode::NO_ERROR) {
             return nullptr;
         }
@@ -39,10 +40,10 @@ class DummyComposer {
         write(circuit_failure_vec, failure);
 
         // copy to output buffer
-        auto raw_failure_buf = (uint8_t*)malloc(circuit_failure_vec.size());
+        auto* raw_failure_buf = static_cast<uint8_t*>(malloc(circuit_failure_vec.size()));
         memcpy(raw_failure_buf, (void*)circuit_failure_vec.data(), circuit_failure_vec.size());
         return raw_failure_buf;
     }
 };
 
-} // namespace aztec3::utils
+}  // namespace aztec3::utils

--- a/circuits/cpp/src/aztec3/utils/types/circuit_types.hpp
+++ b/circuits/cpp/src/aztec3/utils/types/circuit_types.hpp
@@ -1,68 +1,68 @@
 #pragma once
-#include <barretenberg/stdlib/primitives/address/address.hpp>
-#include <barretenberg/stdlib/encryption/schnorr/schnorr.hpp>
+#include "native_types.hpp"
+
+#include <barretenberg/stdlib/commitment/pedersen/pedersen.hpp>
 #include <barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp>
+#include <barretenberg/stdlib/encryption/schnorr/schnorr.hpp>
+#include <barretenberg/stdlib/hash/blake2s/blake2s.hpp>
+#include <barretenberg/stdlib/hash/pedersen/pedersen.hpp>
+#include <barretenberg/stdlib/primitives/address/address.hpp>
 #include <barretenberg/stdlib/primitives/bigfield/bigfield.hpp>
 #include <barretenberg/stdlib/primitives/biggroup/biggroup.hpp>
 #include <barretenberg/stdlib/primitives/bit_array/bit_array.hpp>
 #include <barretenberg/stdlib/primitives/bool/bool.hpp>
 #include <barretenberg/stdlib/primitives/byte_array/byte_array.hpp>
-#include <barretenberg/stdlib/primitives/packed_byte_array/packed_byte_array.hpp>
-#include <barretenberg/stdlib/primitives/uint/uint.hpp>
-#include <barretenberg/stdlib/primitives/point/point.hpp>
-#include <barretenberg/stdlib/primitives/group/group.hpp>
 #include <barretenberg/stdlib/primitives/curves/bn254.hpp>
-#include <barretenberg/stdlib/recursion/verifier/verifier.hpp>
+#include <barretenberg/stdlib/primitives/group/group.hpp>
+#include <barretenberg/stdlib/primitives/packed_byte_array/packed_byte_array.hpp>
+#include <barretenberg/stdlib/primitives/point/point.hpp>
+#include <barretenberg/stdlib/primitives/uint/uint.hpp>
 #include <barretenberg/stdlib/recursion/verification_key/verification_key.hpp>
 #include <barretenberg/stdlib/recursion/verifier/program_settings.hpp>
-#include <barretenberg/stdlib/commitment/pedersen/pedersen.hpp>
-#include <barretenberg/stdlib/hash/pedersen/pedersen.hpp>
-#include <barretenberg/stdlib/hash/blake2s/blake2s.hpp>
-#include "native_types.hpp"
+#include <barretenberg/stdlib/recursion/verifier/verifier.hpp>
 
 using namespace proof_system::plonk;
 
 namespace aztec3::utils::types {
 
 template <typename Composer> struct CircuitTypes {
-
     // Basic uint types
-    typedef stdlib::bool_t<Composer> boolean;
-    typedef stdlib::uint8<Composer> uint8;
-    typedef stdlib::uint16<Composer> uint16;
-    typedef stdlib::uint32<Composer> uint32;
-    typedef stdlib::uint64<Composer> uint64;
+    using boolean = stdlib::bool_t<Composer>;
+    using uint8 = stdlib::uint8<Composer>;
+    using uint16 = stdlib::uint16<Composer>;
+    using uint32 = stdlib::uint32<Composer>;
+    using uint64 = stdlib::uint64<Composer>;
 
     // Types related to the bn254 curve
-    typedef stdlib::field_t<Composer> fr;
-    typedef stdlib::safe_uint_t<Composer> safe_fr;
-    typedef stdlib::address_t<Composer> address;
-    typedef stdlib::bigfield<Composer, barretenberg::Bn254FqParams> fq;
+    using fr = stdlib::field_t<Composer>;
+    using safe_fr = stdlib::safe_uint_t<Composer>;
+    using address = stdlib::address_t<Composer>;
+    using fq = stdlib::bigfield<Composer, barretenberg::Bn254FqParams>;
 
-    typedef stdlib::witness_t<Composer> witness;
+    using witness = stdlib::witness_t<Composer>;
 
     // typedef fq grumpkin_fr;
     // typedef fr grumpkin_fq;
-    typedef stdlib::point<Composer> grumpkin_point; // affine
-    typedef stdlib::group<Composer> grumpkin_group;
+    using grumpkin_point = stdlib::point<Composer>;  // affine
+    using grumpkin_group = stdlib::group<Composer>;
 
-    typedef stdlib::bn254<Composer> bn254;
+    using bn254 = stdlib::bn254<Composer>;
     // typedef bn254::g1_ct bn254_point;
-    typedef stdlib::element<Composer, fq, fr, barretenberg::g1> bn254_point; // affine
+    using bn254_point = stdlib::element<Composer, fq, fr, barretenberg::g1>;  // affine
 
-    typedef stdlib::bit_array<Composer> bit_array;
-    typedef stdlib::byte_array<Composer> byte_array;
-    typedef stdlib::packed_byte_array<Composer> packed_byte_array;
+    using bit_array = stdlib::bit_array<Composer>;
+    using byte_array = stdlib::byte_array<Composer>;
+    using packed_byte_array = stdlib::packed_byte_array<Composer>;
 
-    typedef stdlib::schnorr::signature_bits<Composer> schnorr_signature;
-    typedef stdlib::ecdsa::signature<Composer> ecdsa_signature;
+    using schnorr_signature = stdlib::schnorr::signature_bits<Composer>;
+    using ecdsa_signature = stdlib::ecdsa::signature<Composer>;
 
-    typedef stdlib::recursion::aggregation_state<bn254> AggregationObject;
-    typedef std::conditional_t<std::same_as<Composer, plonk::TurboComposer>,
-                               stdlib::recursion::recursive_turbo_verifier_settings<bn254>,
-                               stdlib::recursion::recursive_ultra_verifier_settings<bn254>>
-        recursive_inner_verifier_settings;
-    typedef stdlib::recursion::verification_key<bn254> VK;
+    using AggregationObject = stdlib::recursion::aggregation_state<bn254>;
+    using recursive_inner_verifier_settings =
+        std::conditional_t<std::same_as<Composer, plonk::TurboComposer>,
+                           stdlib::recursion::recursive_turbo_verifier_settings<bn254>,
+                           stdlib::recursion::recursive_ultra_verifier_settings<bn254>>;
+    using VK = stdlib::recursion::verification_key<bn254>;
     // Notice: no CircuitType for a Proof: we only ever handle native; the verify_proof() function swallows the
     // 'circuit-type-ness' of the proof.
 
@@ -76,7 +76,7 @@ template <typename Composer> struct CircuitTypes {
 
     template <size_t SIZE> static fr compress(std::array<fr, SIZE> const& inputs, const size_t hash_index = 0)
     {
-        std::vector<fr> inputs_vec(std::begin(inputs), std::end(inputs));
+        std::vector<fr> const inputs_vec(std::begin(inputs), std::end(inputs));
         return plonk::stdlib::pedersen_commitment<Composer>::compress(inputs_vec, hash_index);
     }
 
@@ -123,4 +123,4 @@ template <typename Composer> struct CircuitTypes {
     static byte_array blake3s(const byte_array& input) { return plonk::stdlib::blake3s(input); }
 };
 
-} // namespace aztec3::utils::types
+}  // namespace aztec3::utils::types

--- a/circuits/cpp/src/aztec3/utils/types/convert.hpp
+++ b/circuits/cpp/src/aztec3/utils/types/convert.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
-#include <array>
-#include <barretenberg/common/map.hpp>
-#include <barretenberg/stdlib/primitives/witness/witness.hpp>
-#include <barretenberg/stdlib/primitives/point/point.hpp>
-#include "native_types.hpp"
 #include "circuit_types.hpp"
+#include "native_types.hpp"
+
+#include <barretenberg/common/map.hpp>
+#include <barretenberg/stdlib/primitives/point/point.hpp>
+#include <barretenberg/stdlib/primitives/witness/witness.hpp>
+
+#include <array>
 
 namespace aztec3::utils::types {
 
@@ -16,7 +18,7 @@ namespace {
 template <typename Composer> using CT = aztec3::utils::types::CircuitTypes<Composer>;
 using NT = aztec3::utils::types::NativeTypes;
 
-} // namespace
+}  // namespace
 
 /// TODO: Lots of identical functions here (but for their in/out types). Can we use templates? I couldn't figure out how
 /// to keep the NT:: or CT:: prefixes with templates.
@@ -120,8 +122,7 @@ std::array<typename CT<Composer>::fr, SIZE> to_ct(Composer& composer, std::array
     return map(arr, ref_to_ct);
 };
 
-template <typename Composer, std::size_t SIZE>
-std::array<std::optional<typename CT<Composer>::fr>, SIZE> to_ct(
+template <typename Composer, std::size_t SIZE> std::array<std::optional<typename CT<Composer>::fr>, SIZE> to_ct(
     Composer& composer, std::array<std::optional<typename NT::fr>, SIZE> const& arr)
 {
     auto ref_to_ct = [&](std::optional<typename NT::fr> const& e) { return to_ct(composer, e); };
@@ -148,14 +149,14 @@ template <typename Composer> typename NT::fq to_nt(typename CT<Composer>::fq con
 
 template <typename Composer> typename NT::address to_nt(typename CT<Composer>::address const& e)
 {
-    return NT::address(e.address_.get_value()); // TODO: add get_value() method to address types.
+    return NT::address(e.address_.get_value());  // TODO: add get_value() method to address types.
 };
 
 template <typename Composer> typename NT::uint32 to_nt(typename CT<Composer>::uint32 const& e)
 {
-    NT::uint256 e_256 = e.get_value();
-    NT::uint64 e_64 = e_256.data[0]; // TODO: check that this endianness is correct!
-    NT::uint32 e_32 = static_cast<NT::uint32>(e_64);
+    NT::uint256 const e_256 = e.get_value();
+    NT::uint64 const e_64 = e_256.data[0];  // TODO: check that this endianness is correct!
+    auto const e_32 = static_cast<NT::uint32>(e_64);
     return e_32;
 };
 
@@ -243,8 +244,7 @@ std::array<typename NT::fr, SIZE> to_nt(std::array<typename CT<Composer>::fr, SI
 //     return arr ? std::make_optional<std::array<typename NT::fr, SIZE>>(map(arr, ref_to_nt)) : std::nullopt;
 // };
 
-template <typename Composer, std::size_t SIZE>
-std::array<std::optional<typename NT::fr>, SIZE> to_nt(
+template <typename Composer, std::size_t SIZE> std::array<std::optional<typename NT::fr>, SIZE> to_nt(
     std::array<std::optional<typename CT<Composer>::fr>, SIZE> const& arr)
 {
     auto ref_to_nt = [&](std::optional<typename CT<Composer>::fr> const& e) { return to_nt<Composer>(e); };
@@ -252,4 +252,4 @@ std::array<std::optional<typename NT::fr>, SIZE> to_nt(
     return map(arr, ref_to_nt);
 };
 
-} // namespace aztec3::utils::types
+}  // namespace aztec3::utils::types

--- a/circuits/cpp/src/aztec3/utils/types/native_types.hpp
+++ b/circuits/cpp/src/aztec3/utils/types/native_types.hpp
@@ -1,57 +1,57 @@
 #pragma once
-#include <barretenberg/stdlib/primitives/address/address.hpp>
-#include <barretenberg/crypto/pedersen_commitment/pedersen.hpp>
-#include <barretenberg/crypto/generators/generator_data.hpp>
-#include <barretenberg/crypto/schnorr/schnorr.hpp>
+#include <barretenberg/crypto/blake3s/blake3s.hpp>
 #include <barretenberg/crypto/ecdsa/ecdsa.hpp>
+#include <barretenberg/crypto/generators/generator_data.hpp>
+#include <barretenberg/crypto/pedersen_commitment/pedersen.hpp>
+#include <barretenberg/crypto/schnorr/schnorr.hpp>
 #include <barretenberg/ecc/curves/bn254/fq.hpp>
 #include <barretenberg/ecc/curves/bn254/fr.hpp>
 #include <barretenberg/ecc/curves/bn254/g1.hpp>
 #include <barretenberg/ecc/curves/grumpkin/grumpkin.hpp>
 #include <barretenberg/numeric/uint256/uint256.hpp>
-#include <barretenberg/plonk/proof_system/verification_key/verification_key.hpp>
 #include <barretenberg/plonk/proof_system/types/proof.hpp>
-#include <barretenberg/stdlib/recursion/verifier/verifier.hpp>
+#include <barretenberg/plonk/proof_system/verification_key/verification_key.hpp>
+#include <barretenberg/stdlib/primitives/address/address.hpp>
 #include <barretenberg/stdlib/recursion/aggregation_state/native_aggregation_state.hpp>
-#include <barretenberg/crypto/blake3s/blake3s.hpp>
+#include <barretenberg/stdlib/recursion/verifier/verifier.hpp>
 
 namespace aztec3::utils::types {
 
 struct NativeTypes {
-    typedef bool boolean;
+    using boolean = bool;
 
-    typedef uint8_t uint8;
-    typedef uint16_t uint16;
-    typedef uint32_t uint32;
-    typedef uint64_t uint64;
-    typedef uint256_t uint256;
+    using uint8 = uint8_t;
+    using uint16 = uint16_t;
+    using uint32 = uint32_t;
+    using uint64 = uint64_t;
+    using uint256 = uint256_t;
 
-    typedef barretenberg::fr fr;
-    typedef proof_system::plonk::stdlib::address address;
+    using fr = barretenberg::fr;
+    using address = proof_system::plonk::stdlib::address;
 
-    typedef barretenberg::fq fq;
+    using fq = barretenberg::fq;
 
     // typedef fq grumpkin_fr;
     // typedef fr grumpkin_fq;
-    typedef grumpkin::g1::affine_element grumpkin_point;
+    using grumpkin_point = grumpkin::g1::affine_element;
     // typedef grumpkin::g1::element grumpkin_jac_point;
-    typedef grumpkin::g1 grumpkin_group;
+    using grumpkin_group = grumpkin::g1;
 
-    typedef barretenberg::g1::affine_element bn254_point;
+    using bn254_point = barretenberg::g1::affine_element;
     // typedef barretenberg::g1::element bn254_jac_point;
     // typedef barretenberg::g1 bn254_group;
 
-    typedef std::vector<bool> bit_array;
-    typedef std::vector<uint8_t> byte_array;
-    typedef std::string packed_byte_array;
+    using bit_array = std::vector<bool>;
+    using byte_array = std::vector<uint8_t>;
+    using packed_byte_array = std::string;
 
-    typedef crypto::schnorr::signature schnorr_signature;
-    typedef crypto::ecdsa::signature ecdsa_signature;
+    using schnorr_signature = crypto::schnorr::signature;
+    using ecdsa_signature = crypto::ecdsa::signature;
 
-    typedef proof_system::plonk::stdlib::recursion::native_aggregation_state AggregationObject;
-    typedef plonk::verification_key_data VKData;
-    typedef plonk::verification_key VK;
-    typedef plonk::proof Proof;
+    using AggregationObject = proof_system::plonk::stdlib::recursion::native_aggregation_state;
+    using VKData = plonk::verification_key_data;
+    using VK = plonk::verification_key;
+    using Proof = plonk::proof;
 
     /// TODO: lots of these compress / commit functions aren't actually used: remove them.
 
@@ -63,7 +63,7 @@ struct NativeTypes {
 
     template <size_t SIZE> static fr compress(std::array<fr, SIZE> const& inputs, const size_t hash_index = 0)
     {
-        std::vector<fr> inputs_vec(std::begin(inputs), std::end(inputs));
+        std::vector<fr> const inputs_vec(std::begin(inputs), std::end(inputs));
         return crypto::pedersen_commitment::compress_native(inputs_vec, hash_index);
     }
 
@@ -104,4 +104,4 @@ struct NativeTypes {
     static byte_array blake3s(const byte_array& input) { return blake3::blake3s(input); }
 };
 
-} // namespace aztec3::utils::types
+}  // namespace aztec3::utils::types


### PR DESCRIPTION
# Description

* Blocked by https://github.com/AztecProtocol/aztec3-packages/pull/415
    * Once that ^ PR is merged into master, update this branch

This PR does the following:
* Establishes a documented coding standard
* Updates VSCode settings to auto-format code on filesave
    * uses `.clang-format`
    * includes header grouping & sorting
* Adds `.clangd` settings to provide more VSCode warnings for bad code
* Adds CI job to enforce coding standards via clang-tidy
    * CI job fails if `./scripts/tidy.sh fix` would change code
* Tidys entire codebase (`.clang-tidy`)
* Formats entire codebase (updated `.clang-format`)

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
