### PR TITLE
Include public data tree in world state synchronizer

### DIFF
--- a/yarn-project/types/src/public_data_write.ts
+++ b/yarn-project/types/src/public_data_write.ts
@@ -15,6 +15,10 @@ export class PublicDataWrite {
     return serializeToBuffer(this.leafIndex, this.newValue);
   }
 
+  isEmpty() {
+    return this.leafIndex.isZero() && this.newValue.isZero();
+  }
+
   static fromBuffer(buffer: Buffer | BufferReader) {
     const reader = BufferReader.asReader(buffer);
     return new PublicDataWrite(reader.readFr(), reader.readFr());

--- a/yarn-project/world-state/src/merkle-tree/merkle_tree_operations_facade.ts
+++ b/yarn-project/world-state/src/merkle-tree/merkle_tree_operations_facade.ts
@@ -68,7 +68,7 @@ export class MerkleTreeOperationsFacade implements MerkleTreeOperations {
    * @returns Empty promise.
    */
   updateLeaf(treeId: MerkleTreeId.NULLIFIER_TREE, leaf: LeafData, index: bigint): Promise<void> {
-    return this.trees.updateLeaf(treeId, leaf, index, this.includeUncommitted);
+    return this.trees.updateLeaf(treeId, leaf, index);
   }
 
   /**

--- a/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.test.ts
+++ b/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.test.ts
@@ -1,13 +1,13 @@
-import { ServerWorldStateSynchroniser } from './server_world_state_synchroniser.js';
-import { L2BlockSource, L2Block, ContractData, PublicDataWrite } from '@aztec/types';
-import { WorldStateRunningState } from './world_state_synchroniser.js';
-import { INITIAL_LEAF, Pedersen, SiblingPath } from '@aztec/merkle-tree';
-import { sleep } from '@aztec/foundation';
-import { jest } from '@jest/globals';
-import { Fr } from '@aztec/foundation';
-import { AppendOnlyTreeSnapshot } from '@aztec/circuits.js';
-import { MerkleTreeDb, MerkleTreeId } from '../index.js';
 import { BarretenbergWasm } from '@aztec/barretenberg.js/wasm';
+import { AppendOnlyTreeSnapshot } from '@aztec/circuits.js';
+import { fr } from '@aztec/circuits.js/factories';
+import { Fr, sleep } from '@aztec/foundation';
+import { INITIAL_LEAF, Pedersen, SiblingPath } from '@aztec/merkle-tree';
+import { ContractData, L2Block, L2BlockSource, PublicDataWrite } from '@aztec/types';
+import { jest } from '@jest/globals';
+import { MerkleTreeDb, MerkleTreeId } from '../index.js';
+import { ServerWorldStateSynchroniser } from './server_world_state_synchroniser.js';
+import { WorldStateRunningState } from './world_state_synchroniser.js';
 
 /**
  * Generic mock implementation.
@@ -73,6 +73,7 @@ describe('server_world_state_synchroniser', () => {
         Promise.resolve({ treeId: MerkleTreeId.CONTRACT_TREE, root: Buffer.alloc(32, 0), size: 0n }),
       ),
     appendLeaves: jest.fn().mockImplementation(() => Promise.resolve()),
+    updateLeaf: jest.fn().mockImplementation(() => Promise.resolve()),
     getSiblingPath: jest.fn().mockImplementation(() => {
       return async () => {
         const wasm = await BarretenbergWasm.get();
@@ -250,6 +251,18 @@ describe('server_world_state_synchroniser', () => {
         }),
       ).not.toBe(-1);
     }
+    await server.stop();
+  });
+
+  it('updates the public data tree', async () => {
+    merkleTreeDb.appendLeaves.mockReset();
+    const server = createSynchroniser(merkleTreeDb, rollupSource);
+    const block = getMockBlock(LATEST_BLOCK_NUMBER + 1);
+    block.newPublicDataWrites[0] = new PublicDataWrite(fr(1), fr(2));
+    nextBlocks = [block];
+
+    await server.start();
+    expect(merkleTreeDb.updateLeaf).toHaveBeenCalledWith(MerkleTreeId.PUBLIC_DATA_TREE, fr(2).toBuffer(), fr(1).value);
     await server.stop();
   });
 });

--- a/yarn-project/world-state/src/world-state-db/index.ts
+++ b/yarn-project/world-state/src/world-state-db/index.ts
@@ -63,7 +63,7 @@ type WithIncludeUncommitted<F> = F extends (...args: [...infer Rest]) => infer R
   : F;
 
 /**
- * Defines the names of the setters on an append only set of Merkle Trees.
+ * Defines the names of the setters on Merkle Trees.
  */
 type MerkleTreeSetters = 'appendLeaves' | 'updateLeaf';
 

--- a/yarn-project/world-state/src/world-state-db/index.ts
+++ b/yarn-project/world-state/src/world-state-db/index.ts
@@ -65,7 +65,7 @@ type WithIncludeUncommitted<F> = F extends (...args: [...infer Rest]) => infer R
 /**
  * Defines the names of the setters on an append only set of Merkle Trees.
  */
-type MerkleTreeSetters = 'appendLeaves';
+type MerkleTreeSetters = 'appendLeaves' | 'updateLeaf';
 
 /**
  * Defines the interface for operations on a set of Merkle Trees configuring whether to return committed or uncommitted data.


### PR DESCRIPTION
World state synchronizer now checks public data tree root to determine if it should commit its pending data or not, and if not, processes all public data writes to update its own public data tree.

Built on top of #360 

Fixes #395 