### PR TITLE
use separate ContractPublicData type

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -1,6 +1,6 @@
 import { AztecAddress, EthAddress, randomBytes, sleep, toBufferBE } from '@aztec/foundation';
 import { RollupAbi, UnverifiedDataEmitterAbi } from '@aztec/l1-contracts/viem';
-import { ContractData, EncodedContractFunction, L2Block } from '@aztec/types';
+import { ContractPublicData, EncodedContractFunction, L2Block } from '@aztec/types';
 import { MockProxy, mock } from 'jest-mock-extended';
 import { Chain, HttpTransport, Log, PublicClient, Transaction, encodeFunctionData, toHex } from 'viem';
 import { Archiver } from './archiver.js';
@@ -104,7 +104,7 @@ function makeContractDeployedEvent(l1BlockNum: bigint, l2BlockNum: bigint) {
   // const contractData = ContractData.random();
   const aztecAddress = AztecAddress.random();
   const portalAddress = EthAddress.random();
-  const contractData = new ContractData(aztecAddress, portalAddress, [
+  const contractData = new ContractPublicData(aztecAddress, portalAddress, [
     EncodedContractFunction.random(),
     EncodedContractFunction.random(),
   ]);

--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -1,6 +1,6 @@
 import { AztecAddress, EthAddress, randomBytes, sleep, toBufferBE } from '@aztec/foundation';
 import { RollupAbi, UnverifiedDataEmitterAbi } from '@aztec/l1-contracts/viem';
-import { ContractPublicData, EncodedContractFunction, L2Block } from '@aztec/types';
+import { ContractData, ContractPublicData, EncodedContractFunction, L2Block } from '@aztec/types';
 import { MockProxy, mock } from 'jest-mock-extended';
 import { Chain, HttpTransport, Log, PublicClient, Transaction, encodeFunctionData, toHex } from 'viem';
 import { Archiver } from './archiver.js';
@@ -104,7 +104,7 @@ function makeContractDeployedEvent(l1BlockNum: bigint, l2BlockNum: bigint) {
   // const contractData = ContractData.random();
   const aztecAddress = AztecAddress.random();
   const portalAddress = EthAddress.random();
-  const contractData = new ContractPublicData(aztecAddress, portalAddress, [
+  const contractData = new ContractPublicData(new ContractData(aztecAddress, portalAddress), [
     EncodedContractFunction.random(),
     EncodedContractFunction.random(),
   ]);

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -65,7 +65,7 @@ export class Archiver implements L2BlockSource, UnverifiedDataSource, ContractDa
   private nextUnverifiedDataFromBlock = 0n;
 
   /**
-   * Next L1 block number to fetch `NewContractData` logs from (i.e. `fromBlock` in eth_getLogs)
+   * Next L1 block number to fetch `ContractPublicData` logs from (i.e. `fromBlock` in eth_getLogs)
    */
   private nextContractDataFromBlock = 0n;
 

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -296,8 +296,7 @@ export class Archiver implements L2BlockSource, UnverifiedDataSource, ContractDa
       const l2BlockNum = log.args.l2BlockNum;
       const publicFnsReader = BufferReader.asReader(Buffer.from(log.args.acir.slice(2), 'hex'));
       const contractData = new ContractPublicData(
-        AztecAddress.fromString(log.args.aztecAddress),
-        EthAddress.fromString(log.args.portalAddress),
+        new ContractData(AztecAddress.fromString(log.args.aztecAddress), EthAddress.fromString(log.args.portalAddress)),
         publicFnsReader.readVector(EncodedContractFunction),
       );
       (this.contractPublicData[Number(l2BlockNum)] || []).push(contractData);
@@ -370,7 +369,7 @@ export class Archiver implements L2BlockSource, UnverifiedDataSource, ContractDa
     let result;
     for (let i = INITIAL_L2_BLOCK_NUM; i < this.contractPublicData.length; i++) {
       const contracts = this.contractPublicData[i];
-      const contract = contracts?.find(c => c.contractAddress.equals(contractAddress));
+      const contract = contracts?.find(c => c.contractData.contractAddress.equals(contractAddress));
       if (contract) {
         result = contract;
         break;
@@ -416,6 +415,9 @@ export class Archiver implements L2BlockSource, UnverifiedDataSource, ContractDa
    * @returns ContractData with the portal address (if we didn't throw an error).
    */
   public getL2ContractInfoInBlock(blockNum: number): Promise<ContractData[] | undefined> {
+    if (blockNum > this.l2Blocks.length) {
+      return Promise.resolve([]);
+    }
     const block = this.l2Blocks[blockNum];
     return Promise.resolve(block.newContractData);
   }

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -2,8 +2,8 @@ import { AztecAddress, BufferReader, EthAddress, RunningPromise, createDebugLogg
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/l1-contracts';
 import { RollupAbi, UnverifiedDataEmitterAbi } from '@aztec/l1-contracts/viem';
 import {
-  CompleteContractData,
   ContractData,
+  ContractPublicData,
   ContractDataSource,
   EncodedContractFunction,
   L2Block,
@@ -52,7 +52,7 @@ export class Archiver implements L2BlockSource, UnverifiedDataSource, ContractDa
   /**
    * A sparse array containing all the contract data that have been fetched so far.
    */
-  private contractData: (CompleteContractData[] | undefined)[] = [];
+  private contractPublicData: (ContractPublicData[] | undefined)[] = [];
 
   /**
    * Next L1 block number to fetch `L2BlockProcessed` logs from (i.e. `fromBlock` in eth_getLogs).
@@ -295,12 +295,12 @@ export class Archiver implements L2BlockSource, UnverifiedDataSource, ContractDa
     for (const log of logs) {
       const l2BlockNum = log.args.l2BlockNum;
       const publicFnsReader = BufferReader.asReader(Buffer.from(log.args.acir.slice(2), 'hex'));
-      const contractData = ContractData.createCompleteContractData(
+      const contractData = new ContractPublicData(
         AztecAddress.fromString(log.args.aztecAddress),
         EthAddress.fromString(log.args.portalAddress),
         publicFnsReader.readVector(EncodedContractFunction),
       );
-      (this.contractData[Number(l2BlockNum)] || []).push(contractData);
+      (this.contractPublicData[Number(l2BlockNum)] || []).push(contractData);
     }
     this.log('Processed contractData corresponding to ' + logs.length + ' blocks.');
   }
@@ -365,11 +365,11 @@ export class Archiver implements L2BlockSource, UnverifiedDataSource, ContractDa
    * @param contractAddress - The contract data address.
    * @returns The contract data.
    */
-  public getL2ContractData(contractAddress: AztecAddress): Promise<CompleteContractData | undefined> {
+  public getL2ContractPublicData(contractAddress: AztecAddress): Promise<ContractPublicData | undefined> {
     // TODO: perhaps store contract data by address as well? to make this more efficient
     let result;
-    for (let i = INITIAL_L2_BLOCK_NUM; i < this.contractData.length; i++) {
-      const contracts = this.contractData[i];
+    for (let i = INITIAL_L2_BLOCK_NUM; i < this.contractPublicData.length; i++) {
+      const contracts = this.contractPublicData[i];
       const contract = contracts?.find(c => c.contractAddress.equals(contractAddress));
       if (contract) {
         result = contract;
@@ -377,6 +377,19 @@ export class Archiver implements L2BlockSource, UnverifiedDataSource, ContractDa
       }
     }
     return Promise.resolve(result);
+  }
+
+  /**
+   * Lookup all contract data in an L2 block.
+   * @param blockNumber - The block number to get all contract data from.
+   * @returns All new contract data in the block (if found)
+   */
+  public getL2ContractPublicDataInBlock(blockNum: number): Promise<ContractPublicData[]> {
+    if (blockNum > this.l2Blocks.length) {
+      return Promise.resolve([]);
+    }
+    const contractData = this.contractPublicData[blockNum];
+    return Promise.resolve(contractData || []);
   }
 
   /**
@@ -396,26 +409,24 @@ export class Archiver implements L2BlockSource, UnverifiedDataSource, ContractDa
     return Promise.resolve(undefined);
   }
 
+  /**
+   * Lookup the L2 contract info inside a block.
+   * Contains contract address & the ethereum portal address.
+   * @param contractAddress - The contract data address.
+   * @returns ContractData with the portal address (if we didn't throw an error).
+   */
+  public getL2ContractInfoInBlock(blockNum: number): Promise<ContractData[] | undefined> {
+    const block = this.l2Blocks[blockNum];
+    return Promise.resolve(block.newContractData);
+  }
+
   public async getPublicFunction(
     address: AztecAddress,
     functionSelector: Buffer,
   ): Promise<EncodedContractFunction | undefined> {
-    const contractData = await this.getL2ContractData(address);
+    const contractData = await this.getL2ContractPublicData(address);
     const result = contractData?.publicFunctions?.find(fn => fn.functionSelector.equals(functionSelector));
     return result;
-  }
-
-  /**
-   * Lookup all contract data in an L2 block.
-   * @param blockNumber - The block number to get all contract data from.
-   * @returns All new contract data in the block (if found)
-   */
-  public getL2ContractDataInBlock(blockNum: number): Promise<ContractData[]> {
-    if (blockNum > this.l2Blocks.length) {
-      return Promise.resolve([]);
-    }
-    const contractData = this.contractData[blockNum];
-    return Promise.resolve(contractData || []);
   }
 
   /**

--- a/yarn-project/aztec-node/src/aztec-node/aztec-node.ts
+++ b/yarn-project/aztec-node/src/aztec-node/aztec-node.ts
@@ -1,6 +1,6 @@
 import { Archiver } from '@aztec/archiver';
 import { AztecAddress, Fr } from '@aztec/foundation';
-import { CompleteContractData, ContractData, ContractDataSource, L2Block, L2BlockSource } from '@aztec/types';
+import { ContractPublicData, ContractData, ContractDataSource, L2Block, L2BlockSource } from '@aztec/types';
 import { SiblingPath } from '@aztec/merkle-tree';
 import { P2P, P2PClient } from '@aztec/p2p';
 import { SequencerClient } from '@aztec/sequencer-client';
@@ -91,8 +91,8 @@ export class AztecNode {
    * @param contractAddress - The contract data address.
    * @returns The complete contract data including portal address & bytecode (if we didn't throw an error).
    */
-  public async getContractData(contractAddress: AztecAddress): Promise<CompleteContractData | undefined> {
-    return await this.contractDataSource.getL2ContractData(contractAddress);
+  public async getContractData(contractAddress: AztecAddress): Promise<ContractPublicData | undefined> {
+    return await this.contractDataSource.getL2ContractPublicData(contractAddress);
   }
 
   /**

--- a/yarn-project/sequencer-client/src/publisher/ethereumjs-tx-sender.ts
+++ b/yarn-project/sequencer-client/src/publisher/ethereumjs-tx-sender.ts
@@ -7,7 +7,7 @@ import {
 } from '@aztec/ethereum.js/eth_rpc';
 import { WalletProvider } from '@aztec/ethereum.js/provider';
 import { Rollup, UnverifiedDataEmitter } from '@aztec/l1-contracts';
-import { CompleteContractData, UnverifiedData } from '@aztec/types';
+import { ContractPublicData, UnverifiedData } from '@aztec/types';
 import { createDebugLogger } from '@aztec/foundation';
 
 import { L1ProcessArgs as ProcessTxArgs, L1PublisherTxSender } from './l1-publisher.js';
@@ -88,7 +88,7 @@ export class EthereumjsTxSender implements L1PublisherTxSender {
 
   async sendEmitContractDeploymentTx(
     l2BlockNum: number,
-    newContractData: CompleteContractData[],
+    newContractData: ContractPublicData[],
   ): Promise<string | undefined> {
     for (let i = 0; i < newContractData.length; i++) {
       const newContract = newContractData[i];

--- a/yarn-project/sequencer-client/src/publisher/ethereumjs-tx-sender.ts
+++ b/yarn-project/sequencer-client/src/publisher/ethereumjs-tx-sender.ts
@@ -94,8 +94,8 @@ export class EthereumjsTxSender implements L1PublisherTxSender {
       const newContract = newContractData[i];
       const methodCall = this.unverifiedDataEmitterContract.methods.emitContractDeployment(
         BigInt(l2BlockNum),
-        newContract.contractAddress.toBuffer(),
-        newContract.portalContractAddress,
+        newContract.contractData.contractAddress.toBuffer(),
+        newContract.contractData.portalContractAddress,
         newContract.bytecode,
       );
       const gas = await methodCall.estimateGas();

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -1,4 +1,4 @@
-import { CompleteContractData, L2Block } from '@aztec/types';
+import { ContractPublicData, L2Block } from '@aztec/types';
 import { createDebugLogger, InterruptableSleep } from '@aztec/foundation';
 import { L2BlockReceiver } from '../receiver.js';
 import { PublisherConfig } from './config.js';
@@ -10,7 +10,7 @@ import { UnverifiedData } from '@aztec/types';
 export interface L1PublisherTxSender {
   sendProcessTx(encodedData: L1ProcessArgs): Promise<string | undefined>;
   sendEmitUnverifiedDataTx(l2BlockNum: number, unverifiedData: UnverifiedData): Promise<string | undefined>;
-  sendEmitContractDeploymentTx(l2BlockNum: number, contractData: CompleteContractData[]): Promise<string | undefined>;
+  sendEmitContractDeploymentTx(l2BlockNum: number, contractData: ContractPublicData[]): Promise<string | undefined>;
   getTransactionReceipt(txHash: string): Promise<{ status: boolean; transactionHash: string } | undefined>;
 }
 
@@ -115,7 +115,7 @@ export class L1Publisher implements L2BlockReceiver {
    * @param newContractData The new contract data to publish.
    * @returns True once the tx has been confirmed and is successful, false on revert or interrupt, blocks otherwise.
    */
-  public async processNewContractData(l2BlockNum: number, contractData: CompleteContractData[]) {
+  public async processNewContractData(l2BlockNum: number, contractData: ContractPublicData[]) {
     while (!this.interrupted) {
       if (!(await this.checkFeeDistributorBalance())) {
         this.log(`Fee distributor ETH balance too low, awaiting top up...`);
@@ -187,7 +187,7 @@ export class L1Publisher implements L2BlockReceiver {
     }
   }
 
-  private async sendEmitNewContractDataTx(l2BlockNum: number, contractData: CompleteContractData[]) {
+  private async sendEmitNewContractDataTx(l2BlockNum: number, contractData: ContractPublicData[]) {
     while (!this.interrupted) {
       try {
         return await this.txSender.sendEmitContractDeploymentTx(l2BlockNum, contractData);

--- a/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
+++ b/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
@@ -121,12 +121,12 @@ export class ViemTxSender implements L1PublisherTxSender {
     l2BlockNum: number,
     newContractData: ContractPublicData[],
   ): Promise<string | undefined> {
-    for (const contractData of newContractData) {
+    for (const contractPublicData of newContractData) {
       const args = [
         BigInt(l2BlockNum),
-        contractData.contractAddress.toString() as Hex,
-        contractData.portalContractAddress.toString() as Hex,
-        `0x${contractData.bytecode.toString('hex')}`,
+        contractPublicData.contractData.contractAddress.toString() as Hex,
+        contractPublicData.contractData.portalContractAddress.toString() as Hex,
+        `0x${contractPublicData.bytecode.toString('hex')}`,
       ] as const;
 
       const gas = await this.unverifiedDataEmitterContract.estimateGas.emitContractDeployment(args, {

--- a/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
+++ b/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
@@ -1,6 +1,6 @@
 import { TxSenderConfig } from './config.js';
 import { L1ProcessArgs as ProcessTxArgs, L1PublisherTxSender } from './l1-publisher.js';
-import { CompleteContractData, UnverifiedData } from '@aztec/types';
+import { ContractPublicData, UnverifiedData } from '@aztec/types';
 import { createDebugLogger } from '@aztec/foundation';
 import {
   GetContractReturnType,
@@ -119,7 +119,7 @@ export class ViemTxSender implements L1PublisherTxSender {
 
   async sendEmitContractDeploymentTx(
     l2BlockNum: number,
-    newContractData: CompleteContractData[],
+    newContractData: ContractPublicData[],
   ): Promise<string | undefined> {
     for (const contractData of newContractData) {
       const args = [

--- a/yarn-project/sequencer-client/src/sequencer/public_processor.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/public_processor.test.ts
@@ -1,7 +1,7 @@
 import { PUBLIC_DATA_TREE_HEIGHT, makeEmptyProof } from '@aztec/circuits.js';
 import { makeKernelPublicInputs, makePublicCircuitPublicInputs } from '@aztec/circuits.js/factories';
 import { SiblingPath } from '@aztec/merkle-tree';
-import { CompleteContractData, ContractData, ContractDataSource, EncodedContractFunction } from '@aztec/types';
+import { ContractPublicData, ContractDataSource, EncodedContractFunction } from '@aztec/types';
 import { MerkleTreeOperations, TreeInfo } from '@aztec/world-state';
 import { jest } from '@jest/globals';
 import { MockProxy, mock } from 'jest-mock-extended';
@@ -21,7 +21,7 @@ describe('public_processor', () => {
   let contractDataSource: MockProxy<ContractDataSource>;
 
   let publicFunction: EncodedContractFunction;
-  let contractData: CompleteContractData;
+  let contractData: ContractPublicData;
   let proof: Proof;
   let root: Buffer;
 
@@ -34,7 +34,7 @@ describe('public_processor', () => {
     publicProver = mock<PublicProver>();
     contractDataSource = mock<ContractDataSource>();
 
-    contractData = ContractData.random();
+    contractData = ContractPublicData.random();
     publicFunction = EncodedContractFunction.random();
     proof = makeEmptyProof();
     root = Buffer.alloc(32, 5);
@@ -42,7 +42,7 @@ describe('public_processor', () => {
     publicProver.getPublicCircuitProof.mockResolvedValue(proof);
     publicProver.getPublicKernelCircuitProof.mockResolvedValue(proof);
     db.getTreeInfo.mockResolvedValue({ root } as TreeInfo);
-    contractDataSource.getL2ContractData.mockResolvedValue(contractData);
+    contractDataSource.getL2ContractPublicData.mockResolvedValue(contractData);
     contractDataSource.getPublicFunction.mockResolvedValue(publicFunction);
 
     processor = new PublicProcessor(db, publicCircuit, publicKernel, publicProver, contractDataSource);

--- a/yarn-project/sequencer-client/src/sequencer/public_processor.ts
+++ b/yarn-project/sequencer-client/src/sequencer/public_processor.ts
@@ -73,9 +73,9 @@ export class PublicProcessor {
     );
     const functionSelector = txRequest.functionData.functionSelector;
     if (!fn) throw new Error(`Bytecode not found for ${functionSelector}@${contractAddress}`);
-    const contractData = await this.contractDataSource.getL2ContractPublicData(contractAddress);
-    if (!contractData) throw new Error(`Portal contract address not found for contract ${contractAddress}`);
-    const { portalContractAddress } = contractData;
+    const contractPublicData = await this.contractDataSource.getL2ContractPublicData(contractAddress);
+    if (!contractPublicData) throw new Error(`Portal contract address not found for contract ${contractAddress}`);
+    const { portalContractAddress } = contractPublicData.contractData;
 
     const circuitOutput = await this.publicCircuit.publicCircuit(txRequest, fn.bytecode, portalContractAddress);
     const circuitProof = await this.publicProver.getPublicCircuitProof(circuitOutput);

--- a/yarn-project/sequencer-client/src/sequencer/public_processor.ts
+++ b/yarn-project/sequencer-client/src/sequencer/public_processor.ts
@@ -73,7 +73,7 @@ export class PublicProcessor {
     );
     const functionSelector = txRequest.functionData.functionSelector;
     if (!fn) throw new Error(`Bytecode not found for ${functionSelector}@${contractAddress}`);
-    const contractData = await this.contractDataSource.getL2ContractData(contractAddress);
+    const contractData = await this.contractDataSource.getL2ContractPublicData(contractAddress);
     if (!contractData) throw new Error(`Portal contract address not found for contract ${contractAddress}`);
     const { portalContractAddress } = contractData;
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -1,6 +1,6 @@
 import { RunningPromise, createDebugLogger } from '@aztec/foundation';
 import { P2P } from '@aztec/p2p';
-import { ContractData, PrivateTx, PublicTx, Tx, UnverifiedData, isPrivateTx } from '@aztec/types';
+import { ContractPublicData, PrivateTx, PublicTx, Tx, UnverifiedData, isPrivateTx } from '@aztec/types';
 import { MerkleTreeId, WorldStateStatus, WorldStateSynchroniser } from '@aztec/world-state';
 import times from 'lodash.times';
 import { BlockBuilder } from '../block_builder/index.js';
@@ -135,7 +135,7 @@ export class Sequencer {
           // Currently can only have 1 new contract per tx
           const newContract = tx.data?.end.newContracts[0];
           if (newContract && tx.newContractPublicFunctions?.length) {
-            return ContractData.createCompleteContractData(
+            return new ContractPublicData(
               newContract.contractAddress,
               newContract.portalContractAddress,
               tx.newContractPublicFunctions,

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -1,6 +1,6 @@
 import { RunningPromise, createDebugLogger } from '@aztec/foundation';
 import { P2P } from '@aztec/p2p';
-import { ContractPublicData, PrivateTx, PublicTx, Tx, UnverifiedData, isPrivateTx } from '@aztec/types';
+import { ContractData, ContractPublicData, PrivateTx, PublicTx, Tx, UnverifiedData, isPrivateTx } from '@aztec/types';
 import { MerkleTreeId, WorldStateStatus, WorldStateSynchroniser } from '@aztec/world-state';
 import times from 'lodash.times';
 import { BlockBuilder } from '../block_builder/index.js';
@@ -136,8 +136,7 @@ export class Sequencer {
           const newContract = tx.data?.end.newContracts[0];
           if (newContract && tx.newContractPublicFunctions?.length) {
             return new ContractPublicData(
-              newContract.contractAddress,
-              newContract.portalContractAddress,
+              new ContractData(newContract.contractAddress, newContract.portalContractAddress),
               tx.newContractPublicFunctions,
             );
           }

--- a/yarn-project/types/src/contract_data.test.ts
+++ b/yarn-project/types/src/contract_data.test.ts
@@ -6,15 +6,19 @@ describe('ContractData', () => {
   const portalAddress = EthAddress.random();
 
   it('serializes / deserializes correctly', () => {
-    const contractData = new ContractPublicData(aztecAddress, portalAddress, [
+    const contractPublicData = new ContractPublicData(new ContractData(aztecAddress, portalAddress), [
       EncodedContractFunction.random(),
       EncodedContractFunction.random(),
     ]);
-    const buf = contractData.toBuffer();
+    const buf = contractPublicData.toBuffer();
     const serContractData = ContractPublicData.fromBuffer(buf);
-    expect(contractData.contractAddress.equals(serContractData.contractAddress)).toBe(true);
-    expect(contractData.portalContractAddress.equals(serContractData.portalContractAddress)).toBe(true);
-    expect(contractData.bytecode?.equals(serContractData?.bytecode || Buffer.alloc(0))).toBe(true);
+    expect(contractPublicData.contractData.contractAddress.equals(serContractData.contractData.contractAddress)).toBe(
+      true,
+    );
+    expect(
+      contractPublicData.contractData.portalContractAddress.equals(serContractData.contractData.portalContractAddress),
+    ).toBe(true);
+    expect(contractPublicData.bytecode?.equals(serContractData?.bytecode || Buffer.alloc(0))).toBe(true);
   });
 
   it('serializes / deserializes correctly without bytecode', () => {

--- a/yarn-project/types/src/contract_data.test.ts
+++ b/yarn-project/types/src/contract_data.test.ts
@@ -1,17 +1,17 @@
 import { AztecAddress, EthAddress } from '@aztec/foundation';
-import { ContractData, EncodedContractFunction } from './contract_data.js';
+import { ContractData, ContractPublicData, EncodedContractFunction } from './contract_data.js';
 
 describe('ContractData', () => {
   const aztecAddress = AztecAddress.random();
   const portalAddress = EthAddress.random();
 
   it('serializes / deserializes correctly', () => {
-    const contractData = new ContractData(aztecAddress, portalAddress, [
+    const contractData = new ContractPublicData(aztecAddress, portalAddress, [
       EncodedContractFunction.random(),
       EncodedContractFunction.random(),
     ]);
     const buf = contractData.toBuffer();
-    const serContractData = ContractData.fromBuffer(buf);
+    const serContractData = ContractPublicData.fromBuffer(buf);
     expect(contractData.contractAddress.equals(serContractData.contractAddress)).toBe(true);
     expect(contractData.portalContractAddress.equals(serContractData.portalContractAddress)).toBe(true);
     expect(contractData.bytecode?.equals(serContractData?.bytecode || Buffer.alloc(0))).toBe(true);

--- a/yarn-project/types/src/contract_data.ts
+++ b/yarn-project/types/src/contract_data.ts
@@ -117,7 +117,7 @@ export class ContractPublicData {
 
   /**
    * Generate ContractData with random addresses.
-   * @returns ContractData.
+   * @returns A random ContractPublicData object.
    */
   static random(): ContractPublicData {
     return new ContractPublicData(AztecAddress.random(), EthAddress.random(), [
@@ -139,7 +139,7 @@ export class ContractData {
     /**
      * The L1 address of the contract, (20 bytes).
      */
-    public portalContractAddress: EthAddress, // public publicFunctions?: EncodedContractFunction[],
+    public portalContractAddress: EthAddress,
   ) {}
 
   /**

--- a/yarn-project/types/src/contract_data.ts
+++ b/yarn-project/types/src/contract_data.ts
@@ -26,14 +26,16 @@ export interface ContractDataSource {
   getL2ContractInfo(contractAddress: AztecAddress): Promise<ContractData | undefined>;
 
   /**
-   * Lookup all contract data in an L2 block.
+   * Lookup all contract public data in an L2 block.
    * @param blockNumber - The block number
+   * @returns Public data of contracts deployed in L2 block, including public function bytecode.
    */
   getL2ContractPublicDataInBlock(blockNumber: number): Promise<ContractPublicData[]>;
 
   /**
-   * Lookup all contract data in an L2 block.
+   * Lookup contract info in an L2 block.
    * @param blockNumber - The block number
+   * @returns Portal contract address info of contracts deployed in L2 block.
    */
   getL2ContractInfoInBlock(blockNumber: number): Promise<ContractData[] | undefined>;
 

--- a/yarn-project/types/src/contract_data.ts
+++ b/yarn-project/types/src/contract_data.ts
@@ -77,13 +77,9 @@ export class ContractPublicData {
   public bytecode: Buffer;
   constructor(
     /**
-     * The L2 address of the contract, as a field element (32 bytes).
+     * The base contract data: aztec & portal addresses.
      */
-    public contractAddress: AztecAddress,
-    /**
-     * The L1 address of the contract, (20 bytes).
-     */
-    public portalContractAddress: EthAddress,
+    public contractData: ContractData,
 
     /**
      * ABIs of public functions
@@ -101,7 +97,8 @@ export class ContractPublicData {
    * @returns Encoded buffer.
    */
   public toBuffer(): Buffer {
-    return serializeToBuffer(this.contractAddress, this.portalContractAddress.toBuffer(), this.bytecode);
+    const contractDataBuf = this.contractData.toBuffer();
+    return serializeToBuffer(contractDataBuf, this.bytecode);
   }
 
   /**
@@ -111,10 +108,11 @@ export class ContractPublicData {
    */
   static fromBuffer(buffer: Buffer | BufferReader) {
     const reader = BufferReader.asReader(buffer);
-    const aztecAddr = AztecAddress.fromBuffer(reader);
-    const ethAddr = new EthAddress(reader.readBytes(EthAddress.SIZE_IN_BYTES));
+    // const aztecAddr = AztecAddress.fromBuffer(reader);
+    // const ethAddr = new EthAddress(reader.readBytes(EthAddress.SIZE_IN_BYTES));
+    const contractData = reader.readObject(ContractData);
     const publicFns = reader.readVector(EncodedContractFunction);
-    return new ContractPublicData(aztecAddr, ethAddr, publicFns);
+    return new ContractPublicData(contractData, publicFns);
   }
 
   /**
@@ -122,7 +120,7 @@ export class ContractPublicData {
    * @returns A random ContractPublicData object.
    */
   static random(): ContractPublicData {
-    return new ContractPublicData(AztecAddress.random(), EthAddress.random(), [
+    return new ContractPublicData(ContractData.random(), [
       EncodedContractFunction.random(),
       EncodedContractFunction.random(),
     ]);


### PR DESCRIPTION
# Description

New `ContractPublicData` type to be used for public fn data inscribed on L1

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
