### PR TITLE
Extract function to update roots trees

### DIFF
--- a/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.ts
+++ b/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.ts
@@ -252,21 +252,10 @@ export class CircuitBlockBuilder implements BlockBuilder {
     // Update the root trees with the latest data and contract tree roots,
     // and validate them against the output of the root circuit simulation
     this.debug(`Updating and validating root trees`);
-    await this.updateRootTrees();
+    await this.db.updateRootsTrees();
     await this.validateRootOutput(rootOutput);
 
     return [rootOutput, rootProof];
-  }
-
-  // Updates our roots trees with the new generated trees after the rollup updates
-  protected async updateRootTrees() {
-    for (const [newTree, rootTree] of [
-      [MerkleTreeId.PRIVATE_DATA_TREE, MerkleTreeId.PRIVATE_DATA_TREE_ROOTS_TREE],
-      [MerkleTreeId.CONTRACT_TREE, MerkleTreeId.CONTRACT_TREE_ROOTS_TREE],
-    ] as const) {
-      const newTreeInfo = await this.db.getTreeInfo(newTree);
-      await this.db.appendLeaves(rootTree, [newTreeInfo.root]);
-    }
   }
 
   // Validate that the new roots we calculated from manual insertions match the outputs of the simulation

--- a/yarn-project/sequencer-client/src/test/l2-block-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/test/l2-block-publisher.test.ts
@@ -1,40 +1,39 @@
+import {
+  AppendOnlyTreeSnapshot,
+  BaseOrMergeRollupPublicInputs,
+  CircuitsWasm,
+  Fr,
+  RootRollupPublicInputs,
+  UInt8Vector,
+} from '@aztec/circuits.js';
+import { computeContractLeaf } from '@aztec/circuits.js/abis';
+import {
+  makeBaseRollupPublicInputs,
+  makeKernelPublicInputs,
+  makeRootRollupPublicInputs,
+} from '@aztec/circuits.js/factories';
 import { EthereumRpc } from '@aztec/ethereum.js/eth_rpc';
 import { WalletProvider } from '@aztec/ethereum.js/provider';
 import { DecoderHelper, Rollup, UnverifiedDataEmitter } from '@aztec/l1-contracts';
+import { Tx } from '@aztec/types';
+import { MerkleTreeId, MerkleTreeOperations, MerkleTrees } from '@aztec/world-state';
 import { beforeAll, describe, expect, it } from '@jest/globals';
+import { default as levelup } from 'levelup';
+import flatMap from 'lodash.flatmap';
+import { CircuitBlockBuilder } from '../block_builder/circuit_block_builder.js';
+import { createMemDown } from '../block_builder/circuit_block_builder.test.js';
+import { getVerificationKeys, makeEmptyUnverifiedData } from '../index.js';
+import { EmptyRollupProver } from '../prover/empty.js';
 import { EthereumjsTxSender } from '../publisher/ethereumjs-tx-sender.js';
 import { L1Publisher } from '../publisher/l1-publisher.js';
-import { hexStringToBuffer } from '../utils.js';
-import { Tx } from '@aztec/types';
 import {
   ProcessedTx,
   makeEmptyProcessedTx as makeEmptyProcessedTxFromHistoricTreeRoots,
   makeProcessedTx,
 } from '../sequencer/processed_tx.js';
 import { getCombinedHistoricTreeRoots } from '../sequencer/utils.js';
-import {
-  makeBaseRollupPublicInputs,
-  makeKernelPublicInputs,
-  makeRootRollupPublicInputs,
-} from '@aztec/circuits.js/factories';
-import {
-  AppendOnlyTreeSnapshot,
-  BaseOrMergeRollupPublicInputs,
-  BaseRollupInputs,
-  CircuitsWasm,
-  Fr,
-  RootRollupPublicInputs,
-  UInt8Vector,
-} from '@aztec/circuits.js';
-import { getVerificationKeys, makeEmptyUnverifiedData } from '../index.js';
-import { MerkleTreeId, MerkleTreeOperations, MerkleTrees } from '@aztec/world-state';
-import { createMemDown } from '../block_builder/circuit_block_builder.test.js';
-import { default as levelup } from 'levelup';
-import { CircuitBlockBuilder } from '../block_builder/circuit_block_builder.js';
-import { computeContractLeaf } from '@aztec/circuits.js/abis';
-import flatMap from 'lodash.flatmap';
-import { EmptyRollupProver } from '../prover/empty.js';
 import { WasmRollupCircuitSimulator } from '../simulator/rollup.js';
+import { hexStringToBuffer } from '../utils.js';
 
 // Accounts 4 and 5 of Anvil default startup with mnemonic: 'test test test test test test test test test test test junk'
 const sequencerPK = '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a';
@@ -54,7 +53,7 @@ describe.skip('L1Publisher integration', () => {
   let baseRollupOutputLeft: BaseOrMergeRollupPublicInputs;
   let baseRollupOutputRight: BaseOrMergeRollupPublicInputs;
   let rootRollupOutput: RootRollupPublicInputs;
-  let builder: TestSubject;
+  let builder: CircuitBlockBuilder;
   let builderDb: MerkleTreeOperations;
   let expectsDb: MerkleTreeOperations;
   let wasm: CircuitsWasm;
@@ -68,9 +67,9 @@ describe.skip('L1Publisher integration', () => {
     const vks = getVerificationKeys();
     const simulator = await WasmRollupCircuitSimulator.new();
     const prover = new EmptyRollupProver();
-    builder = new TestSubject(builderDb, vks, simulator, prover);
-    await updateRootTrees();
-    await builder.updateRootTrees();
+    builder = new CircuitBlockBuilder(builderDb, vks, simulator, prover);
+    await expectsDb.updateRootsTrees();
+    await builderDb.updateRootsTrees();
 
     baseRollupOutputLeft = makeBaseRollupPublicInputs();
     baseRollupOutputRight = makeBaseRollupPublicInputs();
@@ -125,7 +124,7 @@ describe.skip('L1Publisher integration', () => {
       baseRollupOutputRight.endPrivateDataTreeSnapshot = await getTreeSnapshot(MerkleTreeId.PRIVATE_DATA_TREE);
 
       // And update the root trees now to create proper output to the root rollup circuit
-      await updateRootTrees();
+      await expectsDb.updateRootsTrees();
       rootRollupOutput.endContractTreeSnapshot = await getTreeSnapshot(MerkleTreeId.CONTRACT_TREE);
       rootRollupOutput.endNullifierTreeSnapshot = await getTreeSnapshot(MerkleTreeId.NULLIFIER_TREE);
       rootRollupOutput.endPrivateDataTreeSnapshot = await getTreeSnapshot(MerkleTreeId.PRIVATE_DATA_TREE);
@@ -167,16 +166,6 @@ describe.skip('L1Publisher integration', () => {
   }, 60_000);
 
   // BELOW IS FUNCTIONS STOLEN FROM `circuit_block_builder.test.ts`.
-
-  const updateRootTrees = async () => {
-    for (const [newTree, rootTree] of [
-      [MerkleTreeId.PRIVATE_DATA_TREE, MerkleTreeId.PRIVATE_DATA_TREE_ROOTS_TREE],
-      [MerkleTreeId.CONTRACT_TREE, MerkleTreeId.CONTRACT_TREE_ROOTS_TREE],
-    ] as const) {
-      const newTreeInfo = await expectsDb.getTreeInfo(newTree);
-      await expectsDb.appendLeaves(rootTree, [newTreeInfo.root]);
-    }
-  };
 
   // Updates the expectedDb trees based on the new commitments, contracts, and nullifiers from these txs
   const updateExpectedTreesFromTxs = async (txs: ProcessedTx[]) => {
@@ -236,15 +225,4 @@ async function deployRollup() {
   });
 
   return { decoderHelper, rollup, deployer, unverifiedDataEmitter, sequencer, ethRpc };
-}
-
-// Test subject class that exposes internal functions for testing
-class TestSubject extends CircuitBlockBuilder {
-  public buildBaseRollupInput(tx1: ProcessedTx, tx2: ProcessedTx): Promise<BaseRollupInputs> {
-    return super.buildBaseRollupInput(tx1, tx2);
-  }
-
-  public updateRootTrees(): Promise<void> {
-    return super.updateRootTrees();
-  }
 }

--- a/yarn-project/world-state/src/merkle-tree/merkle_tree_operations_facade.ts
+++ b/yarn-project/world-state/src/merkle-tree/merkle_tree_operations_facade.ts
@@ -101,4 +101,13 @@ export class MerkleTreeOperationsFacade implements MerkleTreeOperations {
   getLeafValue(treeId: MerkleTreeId, index: bigint): Promise<Buffer | undefined> {
     return this.trees.getLeafValue(treeId, index, this.includeUncommitted);
   }
+
+  /**
+   * Inserts into the roots trees (CONTRACT_TREE_ROOTS_TREE, PRIVATE_DATA_TREE_ROOTS_TREE)
+   * the current roots of the corresponding trees (CONTRACT_TREE, PRIVATE_DATA_TREE).
+   * @returns Empty promise.
+   */
+  public updateRootsTrees(): Promise<void> {
+    return this.trees.updateRootsTrees(this.includeUncommitted);
+  }
 }

--- a/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.test.ts
+++ b/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.test.ts
@@ -81,6 +81,7 @@ describe('server_world_state_synchroniser', () => {
         SiblingPath.ZERO(32, INITIAL_LEAF, pedersen);
       }; //Promise.resolve();
     }),
+    updateRootsTrees: jest.fn().mockImplementation(() => Promise.resolve()),
     commit: jest.fn().mockImplementation(() => Promise.resolve()),
     rollback: jest.fn().mockImplementation(() => Promise.resolve()),
   } as any;
@@ -230,6 +231,7 @@ describe('server_world_state_synchroniser', () => {
 
   it('updates the contract tree', async () => {
     merkleTreeDb.appendLeaves.mockReset();
+    merkleTreeDb.updateRootsTrees.mockReset();
     const server = createSynchroniser(merkleTreeDb, rollupSource);
     const totalBlocks = LATEST_BLOCK_NUMBER + 1;
     nextBlocks = Array(totalBlocks)
@@ -237,8 +239,10 @@ describe('server_world_state_synchroniser', () => {
       .map((_, index) => getMockBlock(index, [Buffer.alloc(32, index)]));
     // sync the server
     await server.start();
-    // there are 5 trees updated
-    expect(merkleTreeDb.appendLeaves).toHaveBeenCalledTimes(totalBlocks * 5);
+    // there are 3 data trees updated
+    expect(merkleTreeDb.appendLeaves).toHaveBeenCalledTimes(totalBlocks * 3);
+    // and 2 root trees
+    expect(merkleTreeDb.updateRootsTrees).toHaveBeenCalledTimes(totalBlocks);
     // there should be a call to append to the contract tree for each block
     for (let i = 0; i < totalBlocks; i++) {
       expect(

--- a/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.ts
+++ b/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.ts
@@ -167,14 +167,7 @@ export class ServerWorldStateSynchroniser implements WorldStateSynchroniser {
         await this.merkleTreeDb.updateLeaf(MerkleTreeId.PUBLIC_DATA_TREE, newValue.toBuffer(), leafIndex.value);
       }
 
-      for (const [newTree, rootTree] of [
-        [MerkleTreeId.PRIVATE_DATA_TREE, MerkleTreeId.PRIVATE_DATA_TREE_ROOTS_TREE],
-        [MerkleTreeId.CONTRACT_TREE, MerkleTreeId.CONTRACT_TREE_ROOTS_TREE],
-      ] as const) {
-        const newTreeInfo = await this.merkleTreeDb.getTreeInfo(newTree, true);
-        await this.merkleTreeDb.appendLeaves(rootTree, [newTreeInfo.root]);
-      }
-
+      await this.merkleTreeDb.updateRootsTrees(true);
       await this.merkleTreeDb.commit();
     }
     this.currentL2BlockNum = l2Block.number;

--- a/yarn-project/world-state/src/world-state-db/index.ts
+++ b/yarn-project/world-state/src/world-state-db/index.ts
@@ -147,6 +147,12 @@ export interface MerkleTreeOperations {
    * @param index - The index of the leaf.
    */
   getLeafValue(treeId: MerkleTreeId, index: bigint): Promise<Buffer | undefined>;
+
+  /**
+   * Inserts into the roots trees (CONTRACT_TREE_ROOTS_TREE, PRIVATE_DATA_TREE_ROOTS_TREE)
+   * the current roots of the corresponding trees (CONTRACT_TREE, PRIVATE_DATA_TREE).
+   */
+  updateRootsTrees(): Promise<void>;
 }
 
 /**

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -92,6 +92,7 @@ export class MerkleTrees implements MerkleTreeDb {
       `${MerkleTreeId[MerkleTreeId.PUBLIC_DATA_TREE]}`,
       PUBLIC_DATA_TREE_HEIGHT,
     );
+
     this.trees = [
       contractTree,
       contractTreeRootsTree,
@@ -100,7 +101,10 @@ export class MerkleTrees implements MerkleTreeDb {
       privateDataTreeRootsTree,
       publicDataTree,
     ];
+
     this.jobQueue.start();
+
+    await this.updateRootsTrees(true);
   }
 
   /**
@@ -136,6 +140,21 @@ export class MerkleTrees implements MerkleTreeDb {
    */
   public asCommitted(): MerkleTreeOperations {
     return new MerkleTreeOperationsFacade(this, false);
+  }
+
+  /**
+   * Inserts into the roots trees (CONTRACT_TREE_ROOTS_TREE, PRIVATE_DATA_TREE_ROOTS_TREE)
+   * the current roots of the corresponding trees (CONTRACT_TREE, PRIVATE_DATA_TREE).
+   * @param includeUncommitted - Indicates whether to include uncommitted data.
+   */
+  public async updateRootsTrees(includeUncommitted: boolean) {
+    for (const [newTree, rootTree] of [
+      [MerkleTreeId.PRIVATE_DATA_TREE, MerkleTreeId.PRIVATE_DATA_TREE_ROOTS_TREE],
+      [MerkleTreeId.CONTRACT_TREE, MerkleTreeId.CONTRACT_TREE_ROOTS_TREE],
+    ] as const) {
+      const newTreeInfo = await this.getTreeInfo(newTree, includeUncommitted);
+      await this.appendLeaves(rootTree, [newTreeInfo.root]);
+    }
   }
 
   /**


### PR DESCRIPTION
Adds a new function to the merkle tree db to update the roots trees by inserting the current roots of the corresponding data trees (ie inserts the current contracts tree root into the contract roots tree, same for private data), and calls it when a new db is initialized.