### PR TITLE
Enable jsdoc enforcement for sequencer

### DIFF
--- a/yarn-project/foundation/.eslintrc.cjs
+++ b/yarn-project/foundation/.eslintrc.cjs
@@ -1,8 +1,8 @@
 const fs = require('fs');
 
 const contexts = [
-  'TSMethodDefinition',
-  'MethodDefinition',
+  'TSMethodDefinition[accessibility=public]',
+  'MethodDefinition[accessibility=public]',
   'TSParameterProperty[accessibility=public]',
   'TSPropertySignature',
   'PropertySignature',
@@ -55,6 +55,12 @@ module.exports = {
         ]),
       },
     },
+    {
+      files: '*.test.ts',
+      rules: {
+        'jsdoc/require-jsdoc': 'off',
+      }
+    }
   ],
   env: {
     node: true,

--- a/yarn-project/sequencer-client/.eslintrc.cjs
+++ b/yarn-project/sequencer-client/.eslintrc.cjs
@@ -1,1 +1,1 @@
-module.exports = require('@aztec/foundation/eslint-legacy');
+module.exports = require('@aztec/foundation/eslint');

--- a/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.ts
+++ b/yarn-project/sequencer-client/src/block_builder/circuit_block_builder.ts
@@ -53,19 +53,19 @@ const DELETE_FR = new Fr(0n);
 const DELETE_NUM = 0;
 
 /**
- * All of the data required for the circuit compute and verify nullifiers
+ * All of the data required for the circuit compute and verify nullifiers.
  */
 export interface LowNullifierWitnessData {
   /**
-   * Preimage of the low nullifier that proves non membership
+   * Preimage of the low nullifier that proves non membership.
    */
   preimage: NullifierLeafPreimage;
   /**
-   * Sibling path to prove membership of low nullifier
+   * Sibling path to prove membership of low nullifier.
    */
   siblingPath: SiblingPath;
   /**
-   * The index of low nullifier
+   * The index of low nullifier.
    */
   index: bigint;
 }
@@ -77,6 +77,10 @@ const EMPTY_LOW_NULLIFIER_WITNESS: LowNullifierWitnessData = {
   siblingPath: new SiblingPath(Array(NULLIFIER_TREE_HEIGHT).fill(toBufferBE(0n, 32))),
 };
 
+/**
+ * Builds an L2 block out of a set of ProcessedTx's,
+ * using the base, merge, and root rollup circuits.
+ */
 export class CircuitBlockBuilder implements BlockBuilder {
   constructor(
     protected db: MerkleTreeOperations,
@@ -86,6 +90,13 @@ export class CircuitBlockBuilder implements BlockBuilder {
     protected debug = createDebugLogger('aztec:sequencer'),
   ) {}
 
+  /**
+   * Builds an L2 block with the given number containing the given txs, updating state trees.
+   * @param blockNumber - Number of the block to create.
+   * @param txs - Processed transactions to include in the block.
+   * @param newL1ToL2Messages - L1 to L2 messages to be part of the block.
+   * @returns The new L2 block and a correctness proof as returned by the root rollup circuit.
+   */
   public async buildL2Block(
     blockNumber: number,
     txs: ProcessedTx[],
@@ -325,7 +336,7 @@ export class CircuitBlockBuilder implements BlockBuilder {
 
   /**
    * Validates that the root of the public data tree matches the output of the circuit simulation.
-   * @param output The output of the circuit simulation.
+   * @param output - The output of the circuit simulation.
    * Note: Public data tree is sparse, so the "next available leaf index" doesn't make sense there.
    *       For this reason we only validate root.
    */
@@ -548,7 +559,11 @@ export class CircuitBlockBuilder implements BlockBuilder {
     return fullSiblingPath.data.slice(subtreeHeight).map(b => Fr.fromBuffer(b));
   }
 
+  /* eslint-disable jsdoc/require-description-complete-sentence */
+  /* The following doc block messes up with complete-sentence, so we just disable it */
+
   /**
+   *
    * Each base rollup needs to provide non membership / inclusion proofs for each of the nullifier.
    * This method will return membership proofs and perform partial node updates that will
    * allow the circuit to incrementally update the tree and perform a batch insertion.
@@ -653,10 +668,12 @@ export class CircuitBlockBuilder implements BlockBuilder {
    *  nextVal   2      10      15      19       3       5       0       20
    *
    * TODO: this implementation will change once the zero value is changed from h(0,0,0). Changes incoming over the next sprint
-   * @param leaves Values to insert into the tree
-   * @returns
+   * @param leaves - Values to insert into the tree
+   * @returns The witness data for the leaves to be updated when inserting the new ones.
    */
   public async performBaseRollupBatchInsertionProofs(leaves: Buffer[]): Promise<LowNullifierWitnessData[] | undefined> {
+    /* eslint-enable */
+
     // Keep track of touched low nullifiers
     const touched = new Map<number, bigint[]>();
 

--- a/yarn-project/sequencer-client/src/block_builder/index.ts
+++ b/yarn-project/sequencer-client/src/block_builder/index.ts
@@ -3,6 +3,17 @@ import { Proof } from '../prover/index.js';
 import { ProcessedTx } from '../sequencer/processed_tx.js';
 import { Fr } from '@aztec/foundation';
 
+/**
+ * Assembles an L2Block from a set of processed transactions.
+ */
 export interface BlockBuilder {
+  /**
+   * Creates a new L2Block with the given number, containing the set of processed txs.
+   * Note that the number of txs need to be a power of two.
+   * @param blockNumber - Number of the block to assemble.
+   * @param txs - Processed txs to include.
+   * @param newL1ToL2Messages - L1 to L2 messages to be part of the block.
+   * @returns The new L2 block along with its proof from the root circuit.
+   */
   buildL2Block(blockNumber: number, txs: ProcessedTx[], newL1ToL2Messages: Fr[]): Promise<[L2Block, Proof]>;
 }

--- a/yarn-project/sequencer-client/src/block_builder/standalone_block_builder.ts
+++ b/yarn-project/sequencer-client/src/block_builder/standalone_block_builder.ts
@@ -1,12 +1,4 @@
-import {
-  AppendOnlyTreeSnapshot,
-  CircuitsWasm,
-  KERNEL_NEW_COMMITMENTS_LENGTH,
-  KERNEL_NEW_CONTRACTS_LENGTH,
-  KERNEL_NEW_NULLIFIERS_LENGTH,
-  NewContractData,
-  makeEmptyProof,
-} from '@aztec/circuits.js';
+import { AppendOnlyTreeSnapshot, CircuitsWasm, NewContractData, makeEmptyProof } from '@aztec/circuits.js';
 import { computeContractLeaf } from '@aztec/circuits.js/abis';
 import { AztecAddress, Fr, createDebugLogger } from '@aztec/foundation';
 import { ContractData, L2Block, PublicDataWrite } from '@aztec/types';
@@ -31,6 +23,13 @@ export class StandaloneBlockBuilder implements BlockBuilder {
 
   constructor(private db: MerkleTreeOperations, private log = createDebugLogger('aztec:block_builder')) {}
 
+  /**
+   * Creates a new L2Block with the given number, containing the set of processed txs, without calling any circuit.
+   * @param blockNumber - Number of the block to assemble.
+   * @param txs - Processed txs to include.
+   * @param newL1ToL2Messages - L1 to L2 messages to be part of the block.
+   * @returns The new L2 block along with an empty proof.
+   */
   async buildL2Block(blockNumber: number, txs: ProcessedTx[], newL1ToL2Messages: Fr[]): Promise<[L2Block, Proof]> {
     const startPrivateDataTreeSnapshot = await this.getTreeSnapshot(MerkleTreeId.PRIVATE_DATA_TREE);
     const startNullifierTreeSnapshot = await this.getTreeSnapshot(MerkleTreeId.NULLIFIER_TREE);

--- a/yarn-project/sequencer-client/src/block_builder/types.ts
+++ b/yarn-project/sequencer-client/src/block_builder/types.ts
@@ -1,7 +1,7 @@
 import { AppendOnlyTreeSnapshot, BaseOrMergeRollupPublicInputs, RootRollupPublicInputs } from '@aztec/circuits.js';
 
 /**
- * Type to assert that only the correct trees are checked when validating rollup tree outputs
+ * Type to assert that only the correct trees are checked when validating rollup tree outputs.
  */
 export type AllowedTreeNames<T extends BaseOrMergeRollupPublicInputs | RootRollupPublicInputs> =
   T extends RootRollupPublicInputs
@@ -9,7 +9,7 @@ export type AllowedTreeNames<T extends BaseOrMergeRollupPublicInputs | RootRollu
     : 'PrivateData' | 'Contract' | 'Nullifier';
 
 /**
- * Type to assert the correct object field is indexed when validating rollup tree outputs
+ * Type to assert the correct object field is indexed when validating rollup tree outputs.
  */
 export type OutputWithTreeSnapshot<T extends BaseOrMergeRollupPublicInputs | RootRollupPublicInputs> = {
   [K in `end${AllowedTreeNames<T>}TreeSnapshot`]: AppendOnlyTreeSnapshot;

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -17,6 +17,14 @@ import { WasmRollupCircuitSimulator } from '../simulator/rollup.js';
 export class SequencerClient {
   constructor(private sequencer: Sequencer) {}
 
+  /**
+   * Initializes and starts a new instance.
+   * @param config - Configuration for the sequencer, publisher, and L1 tx sender.
+   * @param p2pClient - P2P client that provides the txs to be sequenced.
+   * @param worldStateSynchroniser - Provides access to world state.
+   * @param contractDataSource - Provides access to contract bytecode for public executions.
+   * @returns A new running instance.
+   */
   public static async new(
     config: SequencerClientConfig,
     p2pClient: P2P,
@@ -54,10 +62,16 @@ export class SequencerClient {
     return new SequencerClient(sequencer);
   }
 
+  /**
+   * Stops the sequencer from processing new txs.
+   */
   public async stop() {
     await this.sequencer.stop();
   }
 
+  /**
+   * Restarts the sequencer after being stopped.
+   */
   public restart() {
     this.sequencer.restart();
   }

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -2,8 +2,14 @@ import { SequencerConfig } from './sequencer/config.js';
 import { PublisherConfig, TxSenderConfig } from './publisher/config.js';
 import { EthAddress } from '@aztec/foundation';
 
+/**
+ * Configuration settings for the SequencerClient.
+ */
 export type SequencerClientConfig = PublisherConfig & TxSenderConfig & SequencerConfig;
 
+/**
+ * Creates an instance of SequencerClientConfig out of environment variables using sensible defaults for integration testing if not set.
+ */
 export function getConfigEnvVars(): SequencerClientConfig {
   const {
     SEQ_PUBLISHER_PRIVATE_KEY,

--- a/yarn-project/sequencer-client/src/mocks/tx.ts
+++ b/yarn-project/sequencer-client/src/mocks/tx.ts
@@ -2,23 +2,38 @@ import { KernelCircuitPublicInputs, UInt8Vector } from '@aztec/circuits.js';
 import { makeKernelPublicInputs, makeSignedTxRequest } from '@aztec/circuits.js/factories';
 import { PrivateTx, PublicTx, Tx, UnverifiedData } from '@aztec/types';
 
+/**
+ * Creates an empty proof.
+ */
 function makeEmptyProof() {
   return new UInt8Vector(Buffer.alloc(0));
 }
 
+/**
+ * Testing utility to create empty unverified data composed by a single empty chunk.
+ */
 export function makeEmptyUnverifiedData(): UnverifiedData {
   const chunks = [Buffer.alloc(0)];
   return new UnverifiedData(chunks);
 }
 
+/**
+ * Testing utility to create a tx with an empty kernel circuit output, empty proof, and empty unverified data.
+ */
 export function makeEmptyPrivateTx(): PrivateTx {
   return Tx.createPrivate(KernelCircuitPublicInputs.empty(), makeEmptyProof(), makeEmptyUnverifiedData());
 }
 
+/**
+ * Testing utility to create a tx with gibberish kernel circuit output, random unverified data, and an empty proof.
+ */
 export function makePrivateTx(seed = 0): PrivateTx {
   return Tx.createPrivate(makeKernelPublicInputs(seed), makeEmptyProof(), UnverifiedData.random(2));
 }
 
+/**
+ * Testing utility to create a tx with a request to execute a public function.
+ */
 export function makePublicTx(seed = 0): PublicTx {
   return Tx.createPublic(makeSignedTxRequest(seed));
 }

--- a/yarn-project/sequencer-client/src/mocks/verification_keys.ts
+++ b/yarn-project/sequencer-client/src/mocks/verification_keys.ts
@@ -1,26 +1,26 @@
 import { VerificationKey } from '@aztec/circuits.js';
 
 /**
- * Well-known verification keys
+ * Well-known verification keys.
  */
 export interface VerificationKeys {
   /**
-   * Verification key for the default private kernel circuit
+   * Verification key for the default private kernel circuit.
    */
   kernelCircuit: VerificationKey;
   /**
-   * Verification key for the default base rollup circuit
+   * Verification key for the default base rollup circuit.
    */
   baseRollupCircuit: VerificationKey;
   /**
-   * Verification key for the default merge rollup circuit
+   * Verification key for the default merge rollup circuit.
    */
   mergeRollupCircuit: VerificationKey;
 }
 
 /**
  * Returns mock verification keys for each well known circuit.
- * @returns a VerificationKeys object.
+ * @returns A VerificationKeys object with fake values.
  */
 export function getVerificationKeys(): VerificationKeys {
   return {

--- a/yarn-project/sequencer-client/src/prover/empty.ts
+++ b/yarn-project/sequencer-client/src/prover/empty.ts
@@ -16,7 +16,16 @@ const EMPTY_PROOF_SIZE = 42;
 
 // TODO: Silently modifying one of the inputs to inject the aggregation object is horrible.
 // We should rethink these interfaces.
+
+/**
+ * Prover implementation that returns empty proofs and overrides aggregation objects.
+ */
 export class EmptyRollupProver implements RollupProver {
+  /**
+   * Creates an empty proof for the given input.
+   * @param _input - Input to the circuit.
+   * @param publicInputs - Public inputs of the circuit obtained via simulation, modified by this call.
+   */
   async getBaseRollupProof(
     _input: BaseRollupInputs,
     publicInputs: BaseOrMergeRollupPublicInputs,
@@ -24,6 +33,12 @@ export class EmptyRollupProver implements RollupProver {
     publicInputs.endAggregationObject = AggregationObject.makeFake();
     return new UInt8Vector(Buffer.alloc(EMPTY_PROOF_SIZE, 0));
   }
+
+  /**
+   * Creates an empty proof for the given input.
+   * @param _input - Input to the circuit.
+   * @param publicInputs - Public inputs of the circuit obtained via simulation, modified by this call.
+   */
   async getMergeRollupProof(
     _input: MergeRollupInputs,
     publicInputs: BaseOrMergeRollupPublicInputs,
@@ -31,16 +46,34 @@ export class EmptyRollupProver implements RollupProver {
     publicInputs.endAggregationObject = AggregationObject.makeFake();
     return new UInt8Vector(Buffer.alloc(EMPTY_PROOF_SIZE, 0));
   }
+
+  /**
+   * Creates an empty proof for the given input.
+   * @param _input - Input to the circuit.
+   * @param publicInputs - Public inputs of the circuit obtained via simulation, modified by this call.
+   */
   async getRootRollupProof(_input: RootRollupInputs, publicInputs: RootRollupPublicInputs): Promise<UInt8Vector> {
     publicInputs.endAggregationObject = AggregationObject.makeFake();
     return new UInt8Vector(Buffer.alloc(EMPTY_PROOF_SIZE, 0));
   }
 }
 
+/**
+ * Prover implementation that returns empty proofs.
+ */
 export class EmptyPublicProver implements PublicProver {
+  /**
+   * Creates an empty proof for the given input.
+   * @param _publicInputs - Public inputs obtained via simulation.
+   */
   async getPublicCircuitProof(_publicInputs: PublicCircuitPublicInputs): Promise<UInt8Vector> {
     return new UInt8Vector(Buffer.alloc(EMPTY_PROOF_SIZE, 0));
   }
+
+  /**
+   * Creates an empty proof for the given input.
+   * @param _publicInputs - Public inputs obtained via simulation.
+   */
   async getPublicKernelCircuitProof(_publicInputs: PublicKernelPublicInputs): Promise<UInt8Vector> {
     return new UInt8Vector(Buffer.alloc(EMPTY_PROOF_SIZE, 0));
   }

--- a/yarn-project/sequencer-client/src/prover/index.ts
+++ b/yarn-project/sequencer-client/src/prover/index.ts
@@ -9,13 +9,23 @@ import {
   UInt8Vector,
 } from '@aztec/circuits.js';
 
+/**
+ * Type definition for a circuit proof.
+ */
 export type Proof = UInt8Vector;
+
+/**
+ * Generates proofs for the base, merge, and root rollup circuits.
+ */
 export interface RollupProver {
   getBaseRollupProof(input: BaseRollupInputs, publicInputs: BaseOrMergeRollupPublicInputs): Promise<Proof>;
   getMergeRollupProof(input: MergeRollupInputs, publicInputs: BaseOrMergeRollupPublicInputs): Promise<Proof>;
   getRootRollupProof(input: RootRollupInputs, publicInputs: RootRollupPublicInputs): Promise<Proof>;
 }
 
+/**
+ * Generates proofs for the public and public kernel circuits.
+ */
 export interface PublicProver {
   getPublicCircuitProof(publicInputs: PublicCircuitPublicInputs): Promise<Proof>;
   getPublicKernelCircuitProof(publicInputs: PublicKernelPublicInputs): Promise<Proof>;

--- a/yarn-project/sequencer-client/src/publisher/config.ts
+++ b/yarn-project/sequencer-client/src/publisher/config.ts
@@ -25,6 +25,9 @@ export interface TxSenderConfig extends L1Addresses {
   requiredConfirmations: number;
 }
 
+/**
+ * Configuration of the L1Publisher.
+ */
 export interface PublisherConfig {
   /**
    * The interval to wait between publish retries.

--- a/yarn-project/sequencer-client/src/publisher/index.ts
+++ b/yarn-project/sequencer-client/src/publisher/index.ts
@@ -1,11 +1,14 @@
 import { PublisherConfig, TxSenderConfig } from './config.js';
-// import { EthereumjsTxSender } from './ethereumjs-tx-sender.js';
 import { L1Publisher } from './l1-publisher.js';
 import { ViemTxSender } from './viem-tx-sender.js';
 
 export { L1Publisher } from './l1-publisher.js';
 export { PublisherConfig } from './config.js';
 
+/**
+ * Returns a new instance of the L1Publisher.
+ * @param config - Configuration to initialize the new instance.
+ */
 export function getL1Publisher(config: PublisherConfig & TxSenderConfig): L1Publisher {
   return new L1Publisher(new ViemTxSender(config), config);
 }

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.test.ts
@@ -1,13 +1,13 @@
-import { L2Block } from '@aztec/types';
 import { TxHash } from '@aztec/ethereum.js/eth_rpc';
+import { L2Block } from '@aztec/types';
 import { mock, MockProxy } from 'jest-mock-extended';
 import { sleep } from '../utils.js';
-import { L1Publisher, L1PublisherTxSender } from './l1-publisher.js';
+import { L1Publisher, L1PublisherTxSender, MinimalTransactionReceipt } from './l1-publisher.js';
 
 describe('L1Publisher', () => {
   let txSender: MockProxy<L1PublisherTxSender>;
   let txHash: string;
-  let txReceipt: { transactionHash: string; status: boolean };
+  let txReceipt: MinimalTransactionReceipt;
   let l2Block: L2Block;
   let l2Inputs: Buffer;
   let l2Proof: Buffer;

--- a/yarn-project/sequencer-client/src/receiver.ts
+++ b/yarn-project/sequencer-client/src/receiver.ts
@@ -5,5 +5,9 @@ import { L2Block } from '@aztec/types';
  * See https://hackmd.io/ouVCnacHQRq2o1oRc5ksNA#RollupReceiver.
  */
 export interface L2BlockReceiver {
+  /**
+   * Receive and L2 block and process it, returns true if successful.
+   * @param l2BlockData - L2 block to process.
+   */
   processL2Block(l2BlockData: L2Block): Promise<boolean>;
 }

--- a/yarn-project/sequencer-client/src/sequencer/processed_tx.ts
+++ b/yarn-project/sequencer-client/src/sequencer/processed_tx.ts
@@ -16,15 +16,15 @@ export type ProcessedTx = Pick<Tx, 'txRequest' | 'unverifiedData'> &
 
 /**
  * Makes a processed tx out of a private only tx that has its proof already set.
- * @param tx - source tx that doesn't need further processing
+ * @param tx - Source tx that doesn't need further processing.
  */
 export async function makeProcessedTx(tx: PrivateTx): Promise<ProcessedTx>;
 
 /**
  * Makes a processed tx out of a tx with a public component that needs processing.
- * @param tx - source tx
- * @param kernelOutput - output of the public kernel circuit simulation for this tx
- * @param proof - proof of the public kernel circuit for this tx
+ * @param tx - Source tx.
+ * @param kernelOutput - Output of the public kernel circuit simulation for this tx.
+ * @param proof - Proof of the public kernel circuit for this tx.
  */
 export async function makeProcessedTx(
   tx: PublicTx,
@@ -32,6 +32,12 @@ export async function makeProcessedTx(
   proof: Proof,
 ): Promise<ProcessedTx>;
 
+/**
+ * Makes a processed tx out of a private or public tx.
+ * @param tx - Source tx.
+ * @param kernelOutput - Output of the public kernel circuit simulation for this tx if private.
+ * @param proof - Proof of the public kernel circuit for this tx if private.
+ */
 export async function makeProcessedTx(
   tx: Tx,
   kernelOutput?: KernelCircuitPublicInputs,

--- a/yarn-project/sequencer-client/src/sequencer/public_processor.ts
+++ b/yarn-project/sequencer-client/src/sequencer/public_processor.ts
@@ -19,6 +19,10 @@ import { PublicCircuitSimulator, PublicKernelCircuitSimulator } from '../simulat
 import { ProcessedTx, makeEmptyProcessedTx, makeProcessedTx } from './processed_tx.js';
 import { getCombinedHistoricTreeRoots } from './utils.js';
 
+/**
+ * Converts Txs lifted from the P2P module into ProcessedTx objects by executing
+ * any public function calls in them. Txs with private calls only are unaffected.
+ */
 export class PublicProcessor {
   constructor(
     protected db: MerkleTreeOperations,
@@ -32,8 +36,8 @@ export class PublicProcessor {
 
   /**
    * Run each tx through the public circuit and the public kernel circuit if needed.
-   * @param txs - txs to process
-   * @returns the list of processed txs with their circuit simulation outputs.
+   * @param txs - Txs to process.
+   * @returns The list of processed txs with their circuit simulation outputs.
    */
   public async process(txs: Tx[]): Promise<[ProcessedTx[], Tx[]]> {
     const result: ProcessedTx[] = [];
@@ -51,6 +55,10 @@ export class PublicProcessor {
     return [result, failed];
   }
 
+  /**
+   * Makes an empty processed tx. Useful for padding a block to a power of two number of txs.
+   * @returns A processed tx with empty data.
+   */
   public async makeEmptyProcessedTx() {
     const historicTreeRoots = await getCombinedHistoricTreeRoots(this.db);
     return makeEmptyProcessedTx(historicTreeRoots);
@@ -117,11 +125,5 @@ export class PublicProcessor {
       portalContractAddress,
       bytecodeHash,
     );
-  }
-}
-
-export class MockPublicProcessor extends PublicProcessor {
-  protected processPublicTx(_tx: PublicTx): Promise<[PublicKernelPublicInputs, Proof]> {
-    throw new Error('Public tx not supported by mock public processor');
   }
 }

--- a/yarn-project/sequencer-client/src/sequencer/utils.ts
+++ b/yarn-project/sequencer-client/src/sequencer/utils.ts
@@ -1,6 +1,9 @@
 import { CombinedHistoricTreeRoots, Fr, PrivateHistoricTreeRoots } from '@aztec/circuits.js';
 import { MerkleTreeId, MerkleTreeOperations } from '@aztec/world-state';
 
+/**
+ * Fetches the private, nullifier, and contract tree roots from a given db and assembles a CombinedHistoricTreeRoots object.
+ */
 export async function getCombinedHistoricTreeRoots(db: MerkleTreeOperations) {
   return new CombinedHistoricTreeRoots(
     new PrivateHistoricTreeRoots(

--- a/yarn-project/sequencer-client/src/simulator/fake_public.ts
+++ b/yarn-project/sequencer-client/src/simulator/fake_public.ts
@@ -4,13 +4,23 @@ import { AztecAddress, EthAddress, Fr, PublicCircuitPublicInputs, TxRequest } fr
 import { MerkleTreeId, MerkleTreeOperations, computePublicDataTreeLeafIndex } from '@aztec/world-state';
 import { PublicCircuitSimulator } from './index.js';
 
+/**
+ * Emulates the PublicCircuit simulator by executing ACIR as if it were Brillig opcodes.
+ */
 export class FakePublicCircuitSimulator implements PublicCircuitSimulator {
-  public readonly db: WorldStatePublicDB;
+  private readonly db: WorldStatePublicDB;
 
   constructor(private readonly merkleTree: MerkleTreeOperations) {
     this.db = new WorldStatePublicDB(this.merkleTree);
   }
 
+  /**
+   * Emulates a simulation of the public circuit for the given tx.
+   * @param tx - Transaction request to execute.
+   * @param functionBytecode - Bytecode (ACIR for now) of the function to run.
+   * @param portalAddress - Corresponding portal address of the contract being run.
+   * @returns The resulting PublicCircuitPublicInputs as if the circuit had been simulated.
+   */
   public async publicCircuit(
     tx: TxRequest,
     functionBytecode: Buffer,
@@ -36,9 +46,18 @@ export class FakePublicCircuitSimulator implements PublicCircuitSimulator {
   }
 }
 
+/**
+ * Implements the PublicDB using a world-state database.
+ */
 class WorldStatePublicDB implements PublicDB {
   constructor(private db: MerkleTreeOperations) {}
 
+  /**
+   * Reads a value from public storage, returning zero if none.
+   * @param contract - Owner of the storage.
+   * @param slot - Slot to read in the contract storage.
+   * @returns The current value in the storage slot.
+   */
   public async storageRead(contract: AztecAddress, slot: Fr): Promise<Fr> {
     const index = computePublicDataTreeLeafIndex(contract, slot, await BarretenbergWasm.get());
     const value = await this.db.getLeafValue(MerkleTreeId.PUBLIC_DATA_TREE, index);

--- a/yarn-project/sequencer-client/src/simulator/index.ts
+++ b/yarn-project/sequencer-client/src/simulator/index.ts
@@ -12,18 +12,64 @@ import {
   TxRequest,
 } from '@aztec/circuits.js';
 
+/**
+ * Circuit simulator for the rollup circuits.
+ */
 export interface RollupSimulator {
+  /**
+   * Simulates the base rollup circuit from its inputs.
+   * @param input - Inputs to the circuit.
+   * @returns The public inputs as outputs of the simulation.
+   */
   baseRollupCircuit(input: BaseRollupInputs): Promise<BaseOrMergeRollupPublicInputs>;
+  /**
+   * Simulates the merge rollup circuit from its inputs.
+   * @param input - Inputs to the circuit.
+   * @returns The public inputs as outputs of the simulation.
+   */
   mergeRollupCircuit(input: MergeRollupInputs): Promise<BaseOrMergeRollupPublicInputs>;
+  /**
+   * Simulates the root rollup circuit from its inputs.
+   * @param input - Inputs to the circuit.
+   * @returns The public inputs as outputs of the simulation.
+   */
   rootRollupCircuit(input: RootRollupInputs): Promise<RootRollupPublicInputs>;
 }
 
+/**
+ * Circuit simulator for the public circuit.
+ */
 export interface PublicCircuitSimulator {
+  /**
+   * Simulates the public circuit given a public tx and bytecode to execute.
+   * @param tx - Transaction request to execute.
+   * @param functionBytecode - Corresponding bytecode to run.
+   * @param portalAddress - Portal contract address for the contract being run.
+   * @returns The public inputs as outputs of the simulation.
+   */
   publicCircuit(tx: TxRequest, functionBytecode: Buffer, portalAddress: EthAddress): Promise<PublicCircuitPublicInputs>;
 }
 
+/**
+ * Circuit simulator for the public kernel circuits.
+ */
 export interface PublicKernelCircuitSimulator {
+  /**
+   * Simulates the public kernel circuit (with no previous kernel circuit run) from its inputs.
+   * @param input - Inputs to the circuit.
+   * @returns The public inputs as outputs of the simulation.
+   */
   publicKernelCircuitNoInput(inputs: PublicKernelInputsNoPreviousKernel): Promise<PublicKernelPublicInputs>;
+  /**
+   * Simulates the public kernel circuit (with a previous private kernel circuit run) from its inputs.
+   * @param input - Inputs to the circuit.
+   * @returns The public inputs as outputs of the simulation.
+   */
   publicKernelCircuitPrivateInput(inputs: PublicKernelInputs): Promise<PublicKernelPublicInputs>;
+  /**
+   * Simulates the public kernel circuit (with no previous public kernel circuit run) from its inputs.
+   * @param input - Inputs to the circuit.
+   * @returns The public inputs as outputs of the simulation.
+   */
   publicKernelCircuitNonFirstIteration(inputs: PublicKernelInputs): Promise<PublicKernelPublicInputs>;
 }

--- a/yarn-project/sequencer-client/src/simulator/public_kernel.ts
+++ b/yarn-project/sequencer-client/src/simulator/public_kernel.ts
@@ -7,16 +7,36 @@ import {
 } from '@aztec/circuits.js';
 import { PublicKernelCircuitSimulator } from './index.js';
 
+/**
+ * Implements the PublicKernelCircuitSimulator by calling the wasm implementations of the circuits.
+ */
 export class WasmPublicKernelCircuitSimulator implements PublicKernelCircuitSimulator {
-  publicKernelCircuitNoInput(inputs: PublicKernelInputsNoPreviousKernel): Promise<PublicKernelPublicInputs> {
-    return simulatePublicKernelCircuitNoPreviousKernel(inputs);
+  /**
+   * Simulates the public kernel circuit (with no previous kernel circuit run) from its inputs.
+   * @param input - Inputs to the circuit.
+   * @returns The public inputs as outputs of the simulation.
+   */
+  public publicKernelCircuitNoInput(input: PublicKernelInputsNoPreviousKernel): Promise<PublicKernelPublicInputs> {
+    return simulatePublicKernelCircuitNoPreviousKernel(input);
   }
-  publicKernelCircuitPrivateInput(inputs: PublicKernelInputs): Promise<PublicKernelPublicInputs> {
-    if (!inputs.previousKernel.publicInputs.isPrivateKernel) throw new Error(`Expected private kernel previous inputs`);
-    return simulatePublicKernelCircuit(inputs);
+
+  /**
+   * Simulates the public kernel circuit (with a previous private kernel circuit run) from its inputs.
+   * @param input - Inputs to the circuit.
+   * @returns The public inputs as outputs of the simulation.
+   */
+  public publicKernelCircuitPrivateInput(input: PublicKernelInputs): Promise<PublicKernelPublicInputs> {
+    if (!input.previousKernel.publicInputs.isPrivateKernel) throw new Error(`Expected private kernel previous inputs`);
+    return simulatePublicKernelCircuit(input);
   }
-  publicKernelCircuitNonFirstIteration(inputs: PublicKernelInputs): Promise<PublicKernelPublicInputs> {
-    if (inputs.previousKernel.publicInputs.isPrivateKernel) throw new Error(`Expected public kernel previous inputs`);
-    return simulatePublicKernelCircuit(inputs);
+
+  /**
+   * Simulates the public kernel circuit (with no previous public kernel circuit run) from its inputs.
+   * @param input - Inputs to the circuit.
+   * @returns The public inputs as outputs of the simulation.
+   */
+  publicKernelCircuitNonFirstIteration(input: PublicKernelInputs): Promise<PublicKernelPublicInputs> {
+    if (input.previousKernel.publicInputs.isPrivateKernel) throw new Error(`Expected public kernel previous inputs`);
+    return simulatePublicKernelCircuit(input);
   }
 }

--- a/yarn-project/sequencer-client/src/simulator/rollup.ts
+++ b/yarn-project/sequencer-client/src/simulator/rollup.ts
@@ -9,6 +9,9 @@ import {
 } from '@aztec/circuits.js';
 import { RollupSimulator } from './index.js';
 
+/**
+ * Implements the rollup circuit simulator using the wasm circuits implementation.
+ */
 export class WasmRollupCircuitSimulator implements RollupSimulator {
   private rollupWasmWrapper: RollupWasmWrapper;
 
@@ -16,16 +19,35 @@ export class WasmRollupCircuitSimulator implements RollupSimulator {
     this.rollupWasmWrapper = new RollupWasmWrapper(wasm);
   }
 
+  /**
+   * Creates a new instance using the default CircuitsWasm module.
+   * @returns A new instance.
+   */
   public static async new() {
     return new this(await CircuitsWasm.get());
   }
 
+  /**
+   * Simulates the base rollup circuit from its inputs.
+   * @param input - Inputs to the circuit.
+   * @returns The public inputs as outputs of the simulation.
+   */
   baseRollupCircuit(input: BaseRollupInputs): Promise<BaseOrMergeRollupPublicInputs> {
     return this.rollupWasmWrapper.simulateBaseRollup(input);
   }
+  /**
+   * Simulates the merge rollup circuit from its inputs.
+   * @param input - Inputs to the circuit.
+   * @returns The public inputs as outputs of the simulation.
+   */
   mergeRollupCircuit(input: MergeRollupInputs): Promise<BaseOrMergeRollupPublicInputs> {
     return this.rollupWasmWrapper.simulateMergeRollup(input);
   }
+  /**
+   * Simulates the root rollup circuit from its inputs.
+   * @param input - Inputs to the circuit.
+   * @returns The public inputs as outputs of the simulation.
+   */
   rootRollupCircuit(input: RootRollupInputs): Promise<RootRollupPublicInputs> {
     return this.rollupWasmWrapper.simulateRootRollup(input);
   }

--- a/yarn-project/sequencer-client/src/utils.ts
+++ b/yarn-project/sequencer-client/src/utils.ts
@@ -1,9 +1,17 @@
+/**
+ * Converts a hex string into a buffer. String may be 0x-prefixed or not.
+ */
 export function hexStringToBuffer(hex: string): Buffer {
   if (!/^(0x)?[a-fA-F0-9]+$/.test(hex)) throw new Error(`Invalid format for hex string: "${hex}"`);
   if (hex.length % 2 === 1) throw new Error(`Invalid length for hex string: "${hex}"`);
   return Buffer.from(hex.replace(/^0x/, ''), 'hex');
 }
 
+/**
+ * Returns a promise that resolves after ms milliseconds, returning retval.
+ * @param ms - How many milliseconds to sleep.
+ * @param retval - The return value of the promise.
+ */
 export function sleep<T>(ms: number, retval: T): Promise<T> {
   return new Promise(resolve => setTimeout(() => resolve(retval), ms));
 }


### PR DESCRIPTION
- Enables jsdoc for the sequencer package
- Changes jsdoc rules so enforcement is only for public methods in functions and test files are skipped