### PR TITLE
Sp/fix hanging Aztec node

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/aztec-node.ts
+++ b/yarn-project/aztec-node/src/aztec-node/aztec-node.ts
@@ -142,11 +142,11 @@ export class AztecNode {
    * Method to stop the aztec node.
    */
   public async stop() {
+    await this.sequencer.stop();
     await this.p2pClient.stop();
     await this.worldStateSynchroniser.stop();
-    await this.merkleTreeDB.stop();
-    await this.sequencer.stop();
     await this.blockSource.stop();
+    await this.merkleTreeDB.stop();
   }
 
   /**

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -11,7 +11,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --runInBand --passWithNoTests --testTimeout=15000",
+    "test": "DEBUG='aztec:' NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --runInBand --passWithNoTests --testTimeout=15000",
     "test:integration": "concurrently -k -s first -c reset,dim -n test,anvil \"yarn test:integration:run\" \"anvil\"",
     "test:integration:run": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --no-cache --runInBand --config jest.integration.config.json"
   },

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -127,6 +127,11 @@ export class Sequencer {
         await this.p2pClient.deleteTxs(await Tx.getHashes(failedTxs));
       }
 
+      if (processedTxs.length === 0) {
+        this.log('No txs processed correctly to build block. Exiting');
+        return;
+      }
+
       // Get l1 to l2 messages from the contract
       this.log('Requesting L1 to L2 messages from contract');
       const l1ToL2Messages = this.takeL1ToL2MessagesFromContract();


### PR DESCRIPTION
# Description

- Node process would hang sometimes because the db would be stopped before the sequencer, and it got stuck while building a block
- Exit sequencer loop when no `processedTxs` were outputed
- Fixes #445 

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] The branch has been merged or rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
