### PR TITLE
chore(circuits): remove dummy kernels

### DIFF
--- a/circuits/cpp/src/aztec3/CMakeLists.txt
+++ b/circuits/cpp/src/aztec3/CMakeLists.txt
@@ -13,6 +13,7 @@ if (WASM)
         aztec3-circuits.wasm
         $<TARGET_OBJECTS:aztec3_circuits_apps_objects>
         $<TARGET_OBJECTS:aztec3_circuits_abis_objects>
+        $<TARGET_OBJECTS:aztec3_circuits_mock_objects>
         $<TARGET_OBJECTS:aztec3_circuits_kernel_objects>        
         $<TARGET_OBJECTS:aztec3_circuits_rollup_objects>
     )

--- a/circuits/cpp/src/aztec3/circuits/CMakeLists.txt
+++ b/circuits/cpp/src/aztec3/circuits/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(apps)
 add_subdirectory(abis)
+add_subdirectory(mock)
 add_subdirectory(kernel)
 add_subdirectory(rollup)
 add_subdirectory(recursion)

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/c_bind.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/c_bind.cpp
@@ -66,10 +66,17 @@ WASM_EXPORT size_t private_kernel__init_verification_key(uint8_t const* pk_buf, 
     return vk_vec.size();
 }
 
-WASM_EXPORT size_t private_kernel__dummy_previous_kernel(uint8_t const** previous_kernel_buf,
-                                                         bool real_vk_proof = false)
+/**
+ * @brief Get a dummy previous kernel
+ *
+ * @details Only usable for native kernel. Will not be usable with real circuit until we have an
+ * option to pass `real_vk_proof=true` to `dummy_previous_kernel`.
+ * @param previous_kernel_buf output buffer for serialized previous kernel
+ * @return size in bytes of output
+ */
+WASM_EXPORT size_t private_kernel__dummy_previous_kernel(uint8_t const** previous_kernel_buf)
 {
-    PreviousKernelData<NT> const previous_kernel = dummy_previous_kernel(real_vk_proof);
+    PreviousKernelData<NT> const previous_kernel = dummy_previous_kernel(false /* fake vk and proof */);
 
     std::vector<uint8_t> previous_kernel_vec;
     write(previous_kernel_vec, previous_kernel);

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/c_bind.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/c_bind.cpp
@@ -66,9 +66,10 @@ WASM_EXPORT size_t private_kernel__init_verification_key(uint8_t const* pk_buf, 
     return vk_vec.size();
 }
 
-WASM_EXPORT size_t private_kernel__dummy_previous_kernel(uint8_t const** previous_kernel_buf)
+WASM_EXPORT size_t private_kernel__dummy_previous_kernel(uint8_t const** previous_kernel_buf,
+                                                         bool real_vk_proof = false)
 {
-    PreviousKernelData<NT> const previous_kernel = dummy_previous_kernel();
+    PreviousKernelData<NT> const previous_kernel = dummy_previous_kernel(real_vk_proof);
 
     std::vector<uint8_t> previous_kernel_vec;
     write(previous_kernel_vec, previous_kernel);

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/c_bind.h
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/c_bind.h
@@ -8,7 +8,7 @@ extern "C" {
 
 WASM_EXPORT size_t private_kernel__init_proving_key(uint8_t const** pk_buf);
 WASM_EXPORT size_t private_kernel__init_verification_key(uint8_t const* pk_buf, uint8_t const** vk_buf);
-WASM_EXPORT size_t private_kernel__dummy_previous_kernel(uint8_t const** previous_kernel_buf);
+WASM_EXPORT size_t private_kernel__dummy_previous_kernel(uint8_t const** previous_kernel_buf, bool real_vk_proof);
 WASM_EXPORT size_t private_kernel__sim(uint8_t const* signed_tx_request_buf,
                                        uint8_t const* previous_kernel_buf,
                                        uint8_t const* private_call_buf,

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/c_bind.h
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/c_bind.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 
 #define WASM_EXPORT __attribute__((visibility("default")))
 
@@ -8,7 +8,7 @@ extern "C" {
 
 WASM_EXPORT size_t private_kernel__init_proving_key(uint8_t const** pk_buf);
 WASM_EXPORT size_t private_kernel__init_verification_key(uint8_t const* pk_buf, uint8_t const** vk_buf);
-WASM_EXPORT size_t private_kernel__dummy_previous_kernel(uint8_t const** previous_kernel_buf, bool real_vk_proof);
+WASM_EXPORT size_t private_kernel__dummy_previous_kernel(uint8_t const** previous_kernel_buf);
 WASM_EXPORT size_t private_kernel__sim(uint8_t const* signed_tx_request_buf,
                                        uint8_t const* previous_kernel_buf,
                                        uint8_t const* private_call_buf,
@@ -20,8 +20,5 @@ WASM_EXPORT size_t private_kernel__prove(uint8_t const* signed_tx_request_buf,
                                          uint8_t const* pk_buf,
                                          bool first,
                                          uint8_t const** proof_data_buf);
-WASM_EXPORT size_t private_kernel__verify_proof(uint8_t const* vk_buf,
-                                                uint8_t const* proof,
-                                                uint32_t length);
-
+WASM_EXPORT size_t private_kernel__verify_proof(uint8_t const* vk_buf, uint8_t const* proof, uint32_t length);
 }

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit.cpp
@@ -1,6 +1,5 @@
 #include "init.hpp"
 
-#include "aztec3/circuits/abis/function_leaf_preimage.hpp"
 #include "aztec3/constants.hpp"
 #include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
 #include <aztec3/circuits/abis/new_contract_data.hpp>

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/utils.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/utils.cpp
@@ -50,10 +50,10 @@ std::shared_ptr<NT::VK> fake_vk()
  */
 PreviousKernelData<NT> dummy_previous_kernel(bool real_vk_proof = false)
 {
-    PreviousKernelData<NT> const init_previous_kernel{};
-
     PreviousKernelData<NT> previous_kernel{};
     if (real_vk_proof) {
+        // prev kernel can be const since it is immediately converted to circuit type
+        PreviousKernelData<NT> const init_previous_kernel{};
         auto crs_factory = std::make_shared<EnvReferenceStringFactory>();
         auto mock_kernel_composer = Composer(crs_factory);
 
@@ -66,6 +66,8 @@ PreviousKernelData<NT> dummy_previous_kernel(bool real_vk_proof = false)
 
         assert(!mock_kernel_composer.failed());
     } else {
+        // prev kernel cannot be const as its members are modified in native circuit
+        PreviousKernelData<NT> init_previous_kernel{};  //
         auto dummy_composer = DummyComposer();
 
         previous_kernel.public_inputs = native_mock_kernel_circuit(dummy_composer, init_previous_kernel.public_inputs);

--- a/circuits/cpp/src/aztec3/circuits/mock/CMakeLists.txt
+++ b/circuits/cpp/src/aztec3/circuits/mock/CMakeLists.txt
@@ -1,8 +1,4 @@
 barretenberg_module(
-    aztec3_circuits_kernel
-
-    aztec3_circuits_apps
     aztec3_circuits_mock
-
     barretenberg
 )

--- a/circuits/cpp/src/aztec3/circuits/mock/mock_kernel_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/mock/mock_kernel_circuit.hpp
@@ -4,15 +4,9 @@
 #include <aztec3/utils/types/native_types.hpp>
 
 #include <barretenberg/common/map.hpp>
-#include <barretenberg/numeric/random/engine.hpp>
 #include <barretenberg/stdlib/commitment/pedersen/pedersen.hpp>
 #include <barretenberg/stdlib/primitives/field/field.hpp>
 #include <barretenberg/stdlib/primitives/witness/witness.hpp>
-// #include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
-
-namespace {
-auto& engine = numeric::random::get_debug_engine();
-}
 
 namespace aztec3::circuits::mock {
 
@@ -27,15 +21,15 @@ KernelCircuitPublicInputs<NT> mock_kernel_circuit(Composer& composer,
                                                   KernelCircuitPublicInputs<NT> const& _public_inputs)
 {
     typedef CircuitTypes<Composer> CT;
-    typedef typename CT::fr fr;
 
     auto public_inputs = _public_inputs.to_circuit_type(composer);
 
     {
         std::vector<uint32_t> dummy_witness_indices;
         // 16 is the number of values added to `proof_witness_indices` at the end of `verify_proof`.
-        for (size_t i = 0; i < 16; ++i) {
-            fr const witness = fr(witness_t(&composer, i));
+        constexpr size_t num_witness_indices = 16;
+        for (size_t i = 0; i < num_witness_indices; ++i) {
+            auto const witness = CT::fr(witness_t(&composer, i));
             uint32_t const witness_index = witness.get_witness_index();
             dummy_witness_indices.push_back(witness_index);
         }
@@ -50,7 +44,8 @@ KernelCircuitPublicInputs<NT> mock_kernel_circuit(Composer& composer,
     // contains_recursive_proof to be false.
     composer.contains_recursive_proof = false;
 
-    plonk::stdlib::pedersen_commitment<Composer>::compress(fr(witness_t(&composer, 1)), fr(witness_t(&composer, 1)));
+    plonk::stdlib::pedersen_commitment<Composer>::compress(CT::fr(witness_t(&composer, 1)),
+                                                           CT::fr(witness_t(&composer, 1)));
     return public_inputs.template to_native_type<Composer>();
 }
 

--- a/circuits/cpp/src/aztec3/circuits/mock/mock_kernel_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/mock/mock_kernel_circuit.hpp
@@ -21,6 +21,7 @@ KernelCircuitPublicInputs<NT> mock_kernel_circuit(Composer& composer,
                                                   KernelCircuitPublicInputs<NT> const& _public_inputs)
 {
     using CT = CircuitTypes<Composer>;
+    using fr = typename CT::fr;
 
     auto public_inputs = _public_inputs.to_circuit_type(composer);
 
@@ -29,7 +30,7 @@ KernelCircuitPublicInputs<NT> mock_kernel_circuit(Composer& composer,
         // 16 is the number of values added to `proof_witness_indices` at the end of `verify_proof`.
         constexpr size_t num_witness_indices = 16;
         for (size_t i = 0; i < num_witness_indices; ++i) {
-            auto const witness = CT::fr(witness_t(&composer, i));
+            auto const witness = typename CT::fr(witness_t(&composer, i));
             uint32_t const witness_index = witness.get_witness_index();
             dummy_witness_indices.push_back(witness_index);
         }

--- a/circuits/cpp/src/aztec3/circuits/mock/mock_kernel_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/mock/mock_kernel_circuit.hpp
@@ -30,7 +30,7 @@ KernelCircuitPublicInputs<NT> mock_kernel_circuit(Composer& composer,
         // 16 is the number of values added to `proof_witness_indices` at the end of `verify_proof`.
         constexpr size_t num_witness_indices = 16;
         for (size_t i = 0; i < num_witness_indices; ++i) {
-            auto const witness = typename CT::fr(witness_t(&composer, i));
+            auto const witness = fr(witness_t(&composer, i));
             uint32_t const witness_index = witness.get_witness_index();
             dummy_witness_indices.push_back(witness_index);
         }
@@ -45,8 +45,7 @@ KernelCircuitPublicInputs<NT> mock_kernel_circuit(Composer& composer,
     // contains_recursive_proof to be false.
     composer.contains_recursive_proof = false;
 
-    plonk::stdlib::pedersen_commitment<Composer>::compress(CT::fr(witness_t(&composer, 1)),
-                                                           CT::fr(witness_t(&composer, 1)));
+    plonk::stdlib::pedersen_commitment<Composer>::compress(fr(witness_t(&composer, 1)), fr(witness_t(&composer, 1)));
     return public_inputs.template to_native_type<Composer>();
 }
 

--- a/circuits/cpp/src/aztec3/circuits/mock/mock_kernel_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/mock/mock_kernel_circuit.hpp
@@ -20,7 +20,7 @@ template <typename Composer>
 KernelCircuitPublicInputs<NT> mock_kernel_circuit(Composer& composer,
                                                   KernelCircuitPublicInputs<NT> const& _public_inputs)
 {
-    typedef CircuitTypes<Composer> CT;
+    using CT = CircuitTypes<Composer>;
 
     auto public_inputs = _public_inputs.to_circuit_type(composer);
 

--- a/circuits/cpp/src/aztec3/circuits/mock/native_mock_kernel_circuit.cpp
+++ b/circuits/cpp/src/aztec3/circuits/mock/native_mock_kernel_circuit.cpp
@@ -1,0 +1,29 @@
+#pragma once
+#include "native_mock_kernel_circuit.hpp"
+
+#include "aztec3/circuits/abis/kernel_circuit_public_inputs.hpp"
+#include "aztec3/utils/dummy_composer.hpp"
+#include "aztec3/utils/types/native_types.hpp"
+
+namespace aztec3::circuits::mock {
+
+using aztec3::circuits::abis::KernelCircuitPublicInputs;
+using NT = aztec3::utils::types::NativeTypes;
+using DummyComposer = aztec3::utils::DummyComposer;
+
+KernelCircuitPublicInputs<NT> native_mock_kernel_circuit(DummyComposer& /* dummycomposer */,
+                                                         KernelCircuitPublicInputs<NT>& public_inputs)
+{
+    {
+        // 16 is the number of values added to `proof_witness_indices` at the end of `verify_proof`.
+        constexpr uint32_t num_witness_indices = 16;
+        for (uint32_t i = 0; i < num_witness_indices; ++i) {
+            public_inputs.end.aggregation_object.proof_witness_indices.push_back(i);
+        }
+    }
+    public_inputs.set_public();
+
+    return public_inputs;
+}
+
+}  // namespace aztec3::circuits::mock

--- a/circuits/cpp/src/aztec3/circuits/mock/native_mock_kernel_circuit.cpp
+++ b/circuits/cpp/src/aztec3/circuits/mock/native_mock_kernel_circuit.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "native_mock_kernel_circuit.hpp"
 
 #include "aztec3/circuits/abis/kernel_circuit_public_inputs.hpp"
@@ -21,7 +20,6 @@ KernelCircuitPublicInputs<NT> native_mock_kernel_circuit(DummyComposer& /* dummy
             public_inputs.end.aggregation_object.proof_witness_indices.push_back(i);
         }
     }
-    public_inputs.set_public();
 
     return public_inputs;
 }

--- a/circuits/cpp/src/aztec3/circuits/mock/native_mock_kernel_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/mock/native_mock_kernel_circuit.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
+#include <aztec3/utils/dummy_composer.hpp>
+#include <aztec3/utils/types/circuit_types.hpp>
+#include <aztec3/utils/types/native_types.hpp>
+
+namespace aztec3::circuits::mock {
+
+using aztec3::circuits::abis::KernelCircuitPublicInputs;
+using NT = aztec3::utils::types::NativeTypes;
+using DummyComposer = aztec3::utils::DummyComposer;
+
+KernelCircuitPublicInputs<NT> native_mock_kernel_circuit(DummyComposer&,
+                                                         KernelCircuitPublicInputs<NT> const& public_inputs)
+{
+    {
+        std::vector<uint32_t> dummy_witness_indices;
+        // 16 is the number of values added to `proof_witness_indices` at the end of `verify_proof`.
+        constexpr size_t num_witness_indices = 16;
+        for (size_t i = 0; i < num_witness_indices; ++i) {
+            dummy_witness_indices.push_back(i);
+        }
+        public_inputs.end.aggregation_object.proof_witness_indices = dummy_witness_indices;
+    }
+    public_inputs.set_public();
+
+    return public_inputs;
+}
+
+}  // namespace aztec3::circuits::mock

--- a/circuits/cpp/src/aztec3/circuits/mock/native_mock_kernel_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/mock/native_mock_kernel_circuit.hpp
@@ -14,13 +14,11 @@ KernelCircuitPublicInputs<NT> native_mock_kernel_circuit(DummyComposer&,
                                                          KernelCircuitPublicInputs<NT> const& public_inputs)
 {
     {
-        std::vector<uint32_t> dummy_witness_indices;
         // 16 is the number of values added to `proof_witness_indices` at the end of `verify_proof`.
-        constexpr size_t num_witness_indices = 16;
-        for (size_t i = 0; i < num_witness_indices; ++i) {
-            dummy_witness_indices.push_back(i);
+        constexpr uint32_t num_witness_indices = 16;
+        for (uint32_t i = 0; i < num_witness_indices; ++i) {
+            public_inputs.end.aggregation_object.proof_witness_indices.push_back(i);
         }
-        public_inputs.end.aggregation_object.proof_witness_indices = dummy_witness_indices;
     }
     public_inputs.set_public();
 

--- a/circuits/cpp/src/aztec3/circuits/mock/native_mock_kernel_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/mock/native_mock_kernel_circuit.hpp
@@ -1,8 +1,7 @@
 #pragma once
-#include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
-#include <aztec3/utils/dummy_composer.hpp>
-#include <aztec3/utils/types/circuit_types.hpp>
-#include <aztec3/utils/types/native_types.hpp>
+#include "aztec3/circuits/abis/kernel_circuit_public_inputs.hpp"
+#include "aztec3/utils/dummy_composer.hpp"
+#include "aztec3/utils/types/native_types.hpp"
 
 namespace aztec3::circuits::mock {
 
@@ -10,19 +9,7 @@ using aztec3::circuits::abis::KernelCircuitPublicInputs;
 using NT = aztec3::utils::types::NativeTypes;
 using DummyComposer = aztec3::utils::DummyComposer;
 
-KernelCircuitPublicInputs<NT> native_mock_kernel_circuit(DummyComposer&,
-                                                         KernelCircuitPublicInputs<NT> const& public_inputs)
-{
-    {
-        // 16 is the number of values added to `proof_witness_indices` at the end of `verify_proof`.
-        constexpr uint32_t num_witness_indices = 16;
-        for (uint32_t i = 0; i < num_witness_indices; ++i) {
-            public_inputs.end.aggregation_object.proof_witness_indices.push_back(i);
-        }
-    }
-    public_inputs.set_public();
-
-    return public_inputs;
-}
+KernelCircuitPublicInputs<NT> native_mock_kernel_circuit(DummyComposer& dummycomposer,
+                                                         KernelCircuitPublicInputs<NT>& public_inputs);
 
 }  // namespace aztec3::circuits::mock

--- a/circuits/cpp/src/aztec3/circuits/rollup/base/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/base/.test.cpp
@@ -7,7 +7,6 @@
 #include "aztec3/circuits/abis/new_contract_data.hpp"
 #include "aztec3/circuits/abis/previous_kernel_data.hpp"
 #include "aztec3/circuits/abis/public_data_read.hpp"
-#include "aztec3/circuits/abis/rollup/nullifier_leaf_preimage.hpp"
 #include "aztec3/circuits/kernel/private/utils.hpp"
 #include "aztec3/circuits/rollup/components/components.hpp"
 #include "aztec3/circuits/rollup/test_utils/utils.hpp"

--- a/circuits/cpp/src/aztec3/circuits/rollup/base/c_bind.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/base/c_bind.cpp
@@ -3,9 +3,7 @@
 #include "index.hpp"
 #include "init.hpp"
 
-#include "aztec3/circuits/abis/private_kernel/private_call_data.hpp"
 #include "aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp"
-#include "aztec3/circuits/abis/signed_tx_request.hpp"
 #include "aztec3/utils/dummy_composer.hpp"
 #include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
 #include <aztec3/circuits/abis/private_kernel/private_inputs.hpp>
@@ -13,8 +11,6 @@
 #include <aztec3/constants.hpp>
 #include <aztec3/utils/types/native_types.hpp>
 
-#include "barretenberg/common/serialize.hpp"
-#include "barretenberg/plonk/composer/turbo_composer.hpp"
 #include "barretenberg/srs/reference_string/env_reference_string.hpp"
 
 namespace {


### PR DESCRIPTION
# Description

Modified dummy kernel cbind to no longer use a real circuit (with a real composer and constraints) to generate the dummy previous kernel. This should speed up simulation testing in TS.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
