### PR TITLE
refactor(l1-artifacts): cleanup generate-artifact script

### DIFF
--- a/build_manifest.json
+++ b/build_manifest.json
@@ -54,6 +54,7 @@
     "rebuildPatterns": [
       "^circuits/",
       "^l1-contracts/",
+      "^yarn-project/l1-contracts/",
       "^yarn-project/yarn-project-base/",
       "^yarn-project/yarn.lock"
     ],
@@ -172,12 +173,8 @@
     "buildDir": "yarn-project",
     "projectDir": "yarn-project/noir-compiler",
     "dockerfile": "noir-compiler/Dockerfile",
-    "rebuildPatterns": [
-      "^yarn-project/noir-compiler/"
-    ],
-    "dependencies": [
-      "foundation"
-    ]
+    "rebuildPatterns": ["^yarn-project/noir-compiler/"],
+    "dependencies": ["foundation"]
   },
   "p2p": {
     "buildDir": "yarn-project",

--- a/build_manifest.json
+++ b/build_manifest.json
@@ -54,7 +54,7 @@
     "rebuildPatterns": [
       "^circuits/",
       "^l1-contracts/",
-      "^yarn-project/l1-contracts/",
+      "^yarn-project/l1-artifacts/",
       "^yarn-project/yarn-project-base/",
       "^yarn-project/yarn.lock"
     ],

--- a/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
+++ b/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
@@ -19,6 +19,8 @@ CONTRACTS=(
 # create target dir if it doesn't exist
 mkdir -p "$target_dir";
 
+echo -ne "// Auto generated module\n" > "$target_dir/index.ts";
+
 for E in "${CONTRACTS[@]}"; do
     ARR=(${E//:/ })
     ROOT="${ARR[0]}";

--- a/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
+++ b/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
@@ -1,35 +1,37 @@
+#!/bin/bash
 set -euo pipefail;
 
 target_dir=./generated
 
+
+# CONTRACT elements have structure PROJECT_DIR_NAME:CONTRACT_NAME.
+#   This will generate the following artifacts for the contracts within the target_dir{./generated} directory.
+#   - a .{CONTRACT_NAME}Bytecode.ts containing the contract bytecode.
+#   - a .{CONTRACT_NAME}Abi.ts containing the contract ABI.
+
+CONTRACTS=(
+  "l1-contracts:DecoderHelper"
+  "l1-contracts:Rollup"
+  "l1-contracts:UnverifiedDataEmitter"
+)
+
+
 # create target dir if it doesn't exist
 mkdir -p "$target_dir";
 
-echo -ne "/**\n * DecoderHelper ABI.\n */\nexport const DecoderHelperAbi = " > "$target_dir/DecoderHelperAbi.ts";
-jq -j '.abi' ../../l1-contracts/out/DecoderHelper.sol/DecoderHelper.json >> "$target_dir/DecoderHelperAbi.ts";
-echo " as const;" >> "$target_dir/DecoderHelperAbi.ts";
-echo -ne "/**\n * DecoderHelper bytecode.\n */\nexport const DecoderHelperBytecode = \"" > "$target_dir/DecoderHelperBytecode.ts";
-jq -j '.bytecode.object' ../../l1-contracts/out/DecoderHelper.sol/DecoderHelper.json >> "$target_dir/DecoderHelperBytecode.ts";
-echo "\";" >> "$target_dir/DecoderHelperBytecode.ts";
+for E in "${CONTRACTS[@]}"; do
+    ARR=(${E//:/ })
+    ROOT="${ARR[0]}";
+    CONTRACT_NAME="${ARR[1]}";
 
-echo -ne "/**\n * Rollup ABI.\n */\nexport const RollupAbi = " > "$target_dir/RollupAbi.ts";
-jq -j '.abi' ../../l1-contracts/out/Rollup.sol/Rollup.json >> "$target_dir/RollupAbi.ts";
-echo " as const;" >> "$target_dir/RollupAbi.ts";
+    echo -ne "/**\n * $CONTRACT_NAME ABI.\n */\nexport const ${CONTRACT_NAME}Abi = " > "$target_dir/${CONTRACT_NAME}Abi.ts";
+    jq -j '.abi' ../../$ROOT/out/$CONTRACT_NAME.sol/$CONTRACT_NAME.json >> "$target_dir/${CONTRACT_NAME}Abi.ts";
+    echo " as const;" >> "$target_dir/${CONTRACT_NAME}Abi.ts";
+    echo -ne "/**\n * $CONTRACT_NAME bytecode.\n */\nexport const ${CONTRACT_NAME}Bytecode = \"" > "$target_dir/${CONTRACT_NAME}Bytecode.ts";
+    jq -j '.bytecode.object' ../../$ROOT/out/$CONTRACT_NAME.sol/$CONTRACT_NAME.json >> "$target_dir/${CONTRACT_NAME}Bytecode.ts";
+    echo "\";" >> "$target_dir/${CONTRACT_NAME}Bytecode.ts";
 
-echo -ne "/**\n * Rollup bytecode.\n */\nexport const RollupBytecode = '" > "$target_dir/RollupBytecode.ts";
-jq -j '.bytecode.object' ../../l1-contracts/out/Rollup.sol/Rollup.json >> "$target_dir/RollupBytecode.ts";
-echo "' as const;" >> "$target_dir/RollupBytecode.ts";
-
-echo -ne "/**\n * UnverifiedDataEmitter ABI.\n */\nexport const UnverifiedDataEmitterAbi = " > "$target_dir/UnverifiedDataEmitterAbi.ts";
-jq -j '.abi' ../../l1-contracts/out/UnverifiedDataEmitter.sol/UnverifiedDataEmitter.json >> "$target_dir/UnverifiedDataEmitterAbi.ts";
-echo " as const;" >> "$target_dir/UnverifiedDataEmitterAbi.ts";
-
-echo -ne "/**\n * UnverifiedDataEmitter bytecode.\n */\nexport const UnverifiedDataEmitterBytecode = '" > "$target_dir/UnverifiedDataEmitterBytecode.ts";
-jq -j '.bytecode.object' ../../l1-contracts/out/UnverifiedDataEmitter.sol/UnverifiedDataEmitter.json >> "$target_dir/UnverifiedDataEmitterBytecode.ts";
-echo "' as const;" >> "$target_dir/UnverifiedDataEmitterBytecode.ts";
-
-echo -ne "export * from './DecoderHelperAbi.js';\nexport * from './DecoderHelperBytecode.js';\n" > "$target_dir/index.ts";
-echo -ne "export * from './RollupAbi.js';\nexport * from './RollupBytecode.js';\n" >> "$target_dir/index.ts";
-echo -ne "export * from './UnverifiedDataEmitterAbi.js';\nexport * from './UnverifiedDataEmitterBytecode.js';" >> "$target_dir/index.ts";
+    echo -ne "export * from './${CONTRACT_NAME}Abi.js';\nexport * from './${CONTRACT_NAME}Bytecode.js';\n" > "$target_dir/index.ts";
+done;
 
 echo "Successfully generated TS artifacts!";

--- a/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
+++ b/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
@@ -31,7 +31,7 @@ for E in "${CONTRACTS[@]}"; do
     jq -j '.bytecode.object' ../../$ROOT/out/$CONTRACT_NAME.sol/$CONTRACT_NAME.json >> "$target_dir/${CONTRACT_NAME}Bytecode.ts";
     echo "\";" >> "$target_dir/${CONTRACT_NAME}Bytecode.ts";
 
-    echo -ne "export * from './${CONTRACT_NAME}Abi.js';\nexport * from './${CONTRACT_NAME}Bytecode.js';\n" > "$target_dir/index.ts";
+    echo -ne "export * from './${CONTRACT_NAME}Abi.js';\nexport * from './${CONTRACT_NAME}Bytecode.js';\n" >> "$target_dir/index.ts";
 done;
 
 echo "Successfully generated TS artifacts!";

--- a/yarn-project/yarn-project-base/Dockerfile
+++ b/yarn-project/yarn-project-base/Dockerfile
@@ -97,6 +97,7 @@ COPY world-state/tsconfig.json world-state/tsconfig.json
 COPY yarn-project-base/scripts yarn-project-base/scripts
 RUN yarn prepare:check
 
+
 # Generate TS-importable contract artifacts
 COPY l1-artifacts/scripts/generate-artifacts.sh l1-artifacts/scripts/generate-artifacts.sh
 WORKDIR /usr/src/yarn-project/l1-artifacts


### PR DESCRIPTION
# Description

When adding some contracts to the generate artifacts script I found it has alot of repeated declarations. 
This version borrows from the previous ./bootstrap.sh scripts and allows you to define paths to contracts in an array at the top of the file, the rest is done for you.

Usage:
```
CONTRACTS=(
    "DIRECTORY:CONTRACT"
)
```


# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
