### PR TITLE
Remove msg sender from call stack items in public processor

### DIFF
--- a/circuits/cpp/src/aztec3/circuits/kernel/public/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/.test.cpp
@@ -971,7 +971,7 @@ TEST(public_kernel_tests, public_previous_kernel_empty_public_call_stack_should_
 {
     DummyComposer dummyComposer;
     PublicKernelInputs<NT> inputs = get_kernel_inputs_with_previous_kernel(false);
-    inputs.public_call.call_stack_item.public_inputs.public_call_stack = zero_array<NT::fr, PUBLIC_CALL_STACK_LENGTH>();
+    inputs.previous_kernel.public_inputs.end.public_call_stack = zero_array<NT::fr, KERNEL_PUBLIC_CALL_STACK_LENGTH>();
     auto public_inputs = native_public_kernel_circuit_public_previous_kernel(dummyComposer, inputs);
     ASSERT_TRUE(dummyComposer.failed());
     ASSERT_EQ(dummyComposer.get_first_failure().code, CircuitErrorCode::PUBLIC_KERNEL__EMPTY_PUBLIC_CALL_STACK);

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/common.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/common.cpp
@@ -37,6 +37,13 @@ void validate_this_public_call_hash(DummyComposer& composer,
                                     PublicKernelInputs<NT> const& public_kernel_inputs,
                                     KernelCircuitPublicInputs<NT>& public_inputs)
 {
+    // If public call stack is empty, we bail so array_pop doesn't throw_or_abort
+    if (array_length(public_inputs.end.public_call_stack) == 0) {
+        composer.do_assert(
+            false, "Public call stack can't be empty", CircuitErrorCode::PUBLIC_KERNEL__EMPTY_PUBLIC_CALL_STACK);
+        return;
+    }
+
     // Pops the current function execution from the stack and validates it against the call stack item
 
     // TODO: this logic might need to change to accommodate the weird edge 3 initial txs (the 'main' tx, the 'fee' tx,

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_public_previous_kernel.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_public_previous_kernel.cpp
@@ -3,7 +3,6 @@
 #include "common.hpp"
 #include "init.hpp"
 
-#include "aztec3/constants.hpp"
 #include <aztec3/circuits/abis/kernel_circuit_public_inputs.hpp>
 #include <aztec3/circuits/abis/public_kernel/public_kernel_inputs.hpp>
 #include <aztec3/utils/array.hpp>
@@ -18,14 +17,11 @@ using CircuitErrorCode = aztec3::utils::CircuitErrorCode;
  */
 void validate_inputs(DummyComposer& composer, PublicKernelInputs<NT> const& public_kernel_inputs)
 {
-    const auto& this_call_stack_item = public_kernel_inputs.public_call.call_stack_item;
-    composer.do_assert(array_length(this_call_stack_item.public_inputs.public_call_stack) > 0,
-                       "Public call stack can't be empty",
-                       CircuitErrorCode::PUBLIC_KERNEL__EMPTY_PUBLIC_CALL_STACK);
-    composer.do_assert(public_kernel_inputs.previous_kernel.public_inputs.end.public_call_count > 0,
+    const auto& previous_kernel = public_kernel_inputs.previous_kernel.public_inputs;
+    composer.do_assert(previous_kernel.end.public_call_count > 0,
                        "Public call count can't be zero",
                        CircuitErrorCode::PUBLIC_KERNEL__ZERO_PUBLIC_CALL_COUNT);
-    composer.do_assert(public_kernel_inputs.previous_kernel.public_inputs.is_private == false,
+    composer.do_assert(previous_kernel.is_private == false,
                        "Previous kernel must be public",
                        CircuitErrorCode::PUBLIC_KERNEL__PREVIOUS_KERNEL_NOT_PUBLIC);
 }

--- a/yarn-project/.prettierignore
+++ b/yarn-project/.prettierignore
@@ -1,4 +1,5 @@
 .yarn
 node_modules/
 dest/
+noir-contracts/**/*.json
 *.md

--- a/yarn-project/circuits.js/src/structs/call_context.ts
+++ b/yarn-project/circuits.js/src/structs/call_context.ts
@@ -21,6 +21,10 @@ export class CallContext {
     return new CallContext(AztecAddress.ZERO, AztecAddress.ZERO, EthAddress.ZERO, false, false, false);
   }
 
+  isEmpty() {
+    return this.msgSender.isZero() && this.storageContractAddress.isZero() && this.portalContractAddress.isZero();
+  }
+
   static from(fields: FieldsOf<CallContext>): CallContext {
     return new CallContext(...CallContext.getFields(fields));
   }

--- a/yarn-project/circuits.js/src/structs/call_stack_item.ts
+++ b/yarn-project/circuits.js/src/structs/call_stack_item.ts
@@ -50,4 +50,8 @@ export class PublicCallStackItem {
       PublicCircuitPublicInputs.empty(),
     );
   }
+
+  isEmpty() {
+    return this.contractAddress.isZero() && this.functionData.isEmpty() && this.publicInputs.isEmpty();
+  }
 }

--- a/yarn-project/circuits.js/src/structs/function_data.ts
+++ b/yarn-project/circuits.js/src/structs/function_data.ts
@@ -1,14 +1,18 @@
 import { BufferReader } from '@aztec/foundation/serialize';
 import { serializeToBuffer } from '../utils/serialize.js';
 
+const FUNCTION_SELECTOR_LENGTH = 4;
+
 /**
  * Function description for circuit.
  * @see abis/function_data.hpp
  */
 export class FunctionData {
   constructor(public functionSelector: Buffer, public isPrivate = true, public isConstructor = false) {
-    if (functionSelector.byteLength !== 4) {
-      throw new Error(`Function selector must be 4 bytes long, got ${functionSelector.byteLength} bytes.`);
+    if (functionSelector.byteLength !== FUNCTION_SELECTOR_LENGTH) {
+      throw new Error(
+        `Function selector must be ${FUNCTION_SELECTOR_LENGTH} bytes long, got ${functionSelector.byteLength} bytes.`,
+      );
     }
   }
   /**
@@ -19,8 +23,16 @@ export class FunctionData {
     return serializeToBuffer(this.functionSelector, this.isPrivate, this.isConstructor);
   }
 
+  /**
+   * Returns whether this instance is empty.
+   * @returns True if the function selector is zero.
+   */
+  isEmpty() {
+    return this.functionSelector.equals(Buffer.alloc(FUNCTION_SELECTOR_LENGTH, 0));
+  }
+
   public static empty(args?: { isPrivate?: boolean; isConstructor?: boolean }) {
-    return new FunctionData(Buffer.alloc(4, 0), args?.isPrivate, args?.isConstructor);
+    return new FunctionData(Buffer.alloc(FUNCTION_SELECTOR_LENGTH, 0), args?.isPrivate, args?.isConstructor);
   }
 
   /**
@@ -29,6 +41,6 @@ export class FunctionData {
    */
   static fromBuffer(buffer: Buffer | BufferReader): FunctionData {
     const reader = BufferReader.asReader(buffer);
-    return new FunctionData(reader.readBytes(4), reader.readBoolean(), reader.readBoolean());
+    return new FunctionData(reader.readBytes(FUNCTION_SELECTOR_LENGTH), reader.readBoolean(), reader.readBoolean());
   }
 }

--- a/yarn-project/circuits.js/src/structs/public_circuit_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/public_circuit_public_inputs.ts
@@ -14,6 +14,7 @@ import { serializeToBuffer } from '../utils/serialize.js';
 import { Fr } from '@aztec/foundation/fields';
 import { BufferReader } from '@aztec/foundation/serialize';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
+import { isArrayEmpty } from '@aztec/foundation/collection';
 
 /**
  * Public state read operation on a specific contract.
@@ -36,6 +37,10 @@ export class StateRead {
 
   static empty() {
     return new StateRead(Fr.ZERO, Fr.ZERO);
+  }
+
+  isEmpty() {
+    return this.storageSlot.isZero() && this.value.isZero();
   }
 
   toFriendlyJSON() {
@@ -64,6 +69,10 @@ export class StateTransition {
 
   static empty() {
     return new StateTransition(Fr.ZERO, Fr.ZERO, Fr.ZERO);
+  }
+
+  isEmpty() {
+    return this.storageSlot.isZero() && this.oldValue.isZero() && this.newValue.isZero();
   }
 
   toFriendlyJSON() {
@@ -124,6 +133,23 @@ export class PublicCircuitPublicInputs {
       AztecAddress.ZERO,
     );
   }
+
+  isEmpty() {
+    const isFrArrayEmpty = (arr: Fr[]) => isArrayEmpty(arr, item => item.isZero());
+    return (
+      this.callContext.isEmpty() &&
+      isFrArrayEmpty(this.args) &&
+      isFrArrayEmpty(this.returnValues) &&
+      isFrArrayEmpty(this.emittedEvents) &&
+      isArrayEmpty(this.stateTransitions, item => item.isEmpty()) &&
+      isArrayEmpty(this.stateReads, item => item.isEmpty()) &&
+      isFrArrayEmpty(this.publicCallStack) &&
+      isFrArrayEmpty(this.newL2ToL1Msgs) &&
+      this.historicPublicDataTreeRoot.isZero() &&
+      this.proverAddress.isZero()
+    );
+  }
+
   /**
    * Serialize into a field array. Low-level utility.
    * @param fields - Object with fields.

--- a/yarn-project/circuits.js/src/structs/shared.ts
+++ b/yarn-project/circuits.js/src/structs/shared.ts
@@ -10,6 +10,10 @@ export class Vector<T extends Bufferable> {
   toBuffer() {
     return serializeToBuffer(this.items.length, this.items);
   }
+
+  toFriendlyJSON() {
+    return this.items;
+  }
 }
 
 export class UInt8Vector {
@@ -50,6 +54,10 @@ export class AffineElement {
   static fromBuffer(buffer: Buffer | BufferReader): AffineElement {
     const reader = BufferReader.asReader(buffer);
     return new AffineElement(reader.readFq(), reader.readFq());
+  }
+
+  toFriendlyJSON() {
+    return `(${this.x.toString()}, ${this.y.toString()})`;
   }
 }
 

--- a/yarn-project/foundation/src/collection/array.ts
+++ b/yarn-project/foundation/src/collection/array.ts
@@ -21,3 +21,15 @@ export function padArrayStart<T>(arr: T[], elem: T, length: number): T[] {
   if (arr.length > length) throw new Error(`Array size exceeds target length`);
   return [...Array(length - arr.length).fill(elem), ...arr];
 }
+
+/**
+ * Returns if an array is composed of empty items.
+ * @param arr - Array to check.
+ * @returns True if every item in the array isEmpty.
+ */
+export function isArrayEmpty<T>(arr: T[], isEmpty: (item: T) => boolean): boolean {
+  for (const item of arr) {
+    if (!isEmpty(item)) return false;
+  }
+  return true;
+}

--- a/yarn-project/sequencer-client/src/sequencer/public_processor.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/public_processor.test.ts
@@ -170,13 +170,6 @@ describe('public_processor', () => {
       const publicCallStack = processed[0].data.end.publicCallStack;
       expect(publicCallStack).toEqual(times(KERNEL_PUBLIC_CALL_STACK_LENGTH, () => expect.any(Fr)));
 
-      const callStackTop = publicCallStack[publicCallStack.length - 1];
-      const callStackNext = publicCallStack[publicCallStack.length - 2];
-      expect(callStackTop).not.toEqual(callStackNext);
-      expect(publicCallStack.slice(0, KERNEL_PUBLIC_CALL_STACK_LENGTH - 1)).toEqual(
-        times(KERNEL_PUBLIC_CALL_STACK_LENGTH - 1, () => callStackNext),
-      );
-
       expect(failed).toEqual([]);
       expect(publicExecutor.execute).toHaveBeenCalled();
     });


### PR DESCRIPTION
The public processor was manually setting msg.sender in empty call stack items, since these were checked by the public kernel circuit. The issue here was that the circuit ignores the call stack items if their hash is zero. So we now test if the call stack item is empty, and in tha case we just set the hash to zero.

However, this uncovered another issue: the circuit started complaining that the public call stack was empty. This seemed to be an error, since the circuit was checking the call stack of the current call, and not of the previous kernel. Changing the target stack being checked solved the issue.

And for some reason, `yarn format` in `yarn-project` root started hanging when trying to format noir compilation artifacts, so I added them to prettierignore, hence the unrelated 3rd commit.

Built on top of #533 

Fixes #494 