### PR TITLE
bug: support multiple contract public data deployed in a block

### DIFF
--- a/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
+++ b/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
@@ -143,7 +143,8 @@ export class ViemTxSender implements L1PublisherTxSender {
   async sendEmitContractDeploymentTx(
     l2BlockNum: number,
     newContractData: ContractPublicData[],
-  ): Promise<string | undefined> {
+  ): Promise<(string | undefined)[]> {
+    const hashes: string[] = [];
     for (const contractPublicData of newContractData) {
       const args = [
         BigInt(l2BlockNum),
@@ -159,8 +160,9 @@ export class ViemTxSender implements L1PublisherTxSender {
         gas,
         account: this.account,
       });
-      return hash;
+      hashes.push(hash);
     }
+    return hashes;
   }
 
   /**


### PR DESCRIPTION
# Description

We need to send multiple tx to ethereum when multiple contracts with public data were deployed in a block.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
