### PR TITLE
Fix formatting of fields in ACIR simulator callback

### DIFF
--- a/yarn-project/acir-simulator/src/public/executor.ts
+++ b/yarn-project/acir-simulator/src/public/executor.ts
@@ -72,7 +72,7 @@ export class PublicExecutor {
 
         nestedExecutions.push(childExecutionResult);
         this.log(`Returning from nested call: ret=${childExecutionResult.returnValues.join(', ')}`);
-        return padArrayEnd(childExecutionResult.returnValues, Fr.ZERO, NOIR_MAX_RETURN_VALUES).map(fr => fr.toString());
+        return padArrayEnd(childExecutionResult.returnValues, Fr.ZERO, NOIR_MAX_RETURN_VALUES).map(toACVMField);
       },
     });
 


### PR DESCRIPTION
Use the toACVMField function to format fields as the ACVM expects, instead of the generic toString field method. 

Found by @sirassistant.