### PR TITLE
Add constant historic tree roots to public kernel inputs

### DIFF
--- a/circuits/cpp/src/aztec3/circuits/abis/public_kernel/public_kernel_inputs_no_previous_kernel.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/public_kernel/public_kernel_inputs_no_previous_kernel.hpp
@@ -4,6 +4,7 @@
 #include "../previous_kernel_data.hpp"
 #include "../signed_tx_request.hpp"
 
+#include "aztec3/circuits/abis/combined_historic_tree_roots.hpp"
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/convert.hpp>
 #include <aztec3/utils/types/native_types.hpp>
@@ -22,6 +23,7 @@ template <typename NCT> struct PublicKernelInputsNoPreviousKernel {
 
     SignedTxRequest<NCT> signed_tx_request{};
     PublicCallData<NCT> public_call{};
+    CombinedHistoricTreeRoots<NCT> historic_tree_roots{};
 
     boolean operator==(PublicKernelInputsNoPreviousKernel<NCT> const& other) const
     {
@@ -37,6 +39,7 @@ template <typename NCT> struct PublicKernelInputsNoPreviousKernel {
             // TODO to_ct(signature),
             signed_tx_request.to_circuit_type(composer),
             public_call.to_circuit_type(composer),
+            historic_tree_roots.to_circuit_type(composer)
         };
 
         return public_kernel_inputs;
@@ -49,6 +52,7 @@ template <typename NCT> void read(uint8_t const*& it, PublicKernelInputsNoPrevio
 
     read(it, public_kernel_inputs.signed_tx_request);
     read(it, public_kernel_inputs.public_call);
+    read(it, public_kernel_inputs.historic_tree_roots);
 };
 
 template <typename NCT>
@@ -58,6 +62,7 @@ void write(std::vector<uint8_t>& buf, PublicKernelInputsNoPreviousKernel<NCT> co
 
     write(buf, public_kernel_inputs.signed_tx_request);
     write(buf, public_kernel_inputs.public_call);
+    write(buf, public_kernel_inputs.historic_tree_roots);
 };
 
 template <typename NCT>
@@ -66,7 +71,9 @@ std::ostream& operator<<(std::ostream& os, PublicKernelInputsNoPreviousKernel<NC
     return os << "signed_tx_request:\n"
               << public_kernel_inputs.signed_tx_request << "\n"
               << "public_call:\n"
-              << public_kernel_inputs.public_call << "\n";
+              << public_kernel_inputs.public_call << "\n"
+              << "historic_tree_roots:\n"
+              << public_kernel_inputs.historic_tree_roots << "\n";
 }
 
 }  // namespace aztec3::circuits::abis::public_kernel

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/.test.cpp
@@ -3,6 +3,7 @@
 #include "native_public_kernel_circuit_private_previous_kernel.hpp"
 #include "native_public_kernel_circuit_public_previous_kernel.hpp"
 
+#include "aztec3/circuits/abis/combined_historic_tree_roots.hpp"
 #include <aztec3/circuits/abis/call_context.hpp>
 #include <aztec3/circuits/abis/call_stack_item.hpp>
 #include <aztec3/circuits/abis/combined_accumulated_data.hpp>
@@ -270,12 +271,20 @@ PublicKernelInputsNoPreviousKernel<NT> get_kernel_inputs_no_previous_kernel()
         .bytecode_hash = 1234567,
     };
 
+    CombinedHistoricTreeRoots<NT> historic_tree_roots = { .private_historic_tree_roots = {
+                                                              .private_data_tree_root = 1000,
+                                                              .contract_tree_root = 2000,
+                                                              .l1_to_l2_messages_tree_root = 3000,
+                                                              .private_kernel_vk_tree_root = 4000,
+                                                          } };
+
     //***************************************************************************
     // Now we can construct the full inputs to the kernel circuit
     //***************************************************************************
     PublicKernelInputsNoPreviousKernel<NT> public_kernel_inputs = {
         .signed_tx_request = signed_tx_request,
         .public_call = { public_call_data },
+        .historic_tree_roots = historic_tree_roots,
     };
 
     return public_kernel_inputs;
@@ -473,6 +482,7 @@ TEST(public_kernel_tests, circuit_outputs_should_be_correctly_populated)
 
     ASSERT_FALSE(public_inputs.is_private);
     ASSERT_EQ(public_inputs.constants.tx_context, inputs.signed_tx_request.tx_request.tx_context);
+    ASSERT_EQ(public_inputs.constants.historic_tree_roots, inputs.historic_tree_roots);
 
     validate_public_kernel_outputs_correctly_propagated(inputs, public_inputs);
 }

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/.test.cpp
@@ -271,12 +271,12 @@ PublicKernelInputsNoPreviousKernel<NT> get_kernel_inputs_no_previous_kernel()
         .bytecode_hash = 1234567,
     };
 
-    CombinedHistoricTreeRoots<NT> historic_tree_roots = { .private_historic_tree_roots = {
-                                                              .private_data_tree_root = 1000,
-                                                              .contract_tree_root = 2000,
-                                                              .l1_to_l2_messages_tree_root = 3000,
-                                                              .private_kernel_vk_tree_root = 4000,
-                                                          } };
+    CombinedHistoricTreeRoots<NT> const historic_tree_roots = { .private_historic_tree_roots = {
+                                                                    .private_data_tree_root = 1000,
+                                                                    .contract_tree_root = 2000,
+                                                                    .l1_to_l2_messages_tree_root = 3000,
+                                                                    .private_kernel_vk_tree_root = 4000,
+                                                                } };
 
     //***************************************************************************
     // Now we can construct the full inputs to the kernel circuit

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_no_previous_kernel.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/native_public_kernel_circuit_no_previous_kernel.cpp
@@ -22,6 +22,7 @@ void initialise_end_values(PublicKernelInputsNoPreviousKernel<NT> const& public_
                            KernelCircuitPublicInputs<NT>& circuit_outputs)
 {
     circuit_outputs.constants.tx_context = public_kernel_inputs.signed_tx_request.tx_request.tx_context;
+    circuit_outputs.constants.historic_tree_roots = public_kernel_inputs.historic_tree_roots;
 }
 
 /**

--- a/yarn-project/circuits.js/src/structs/kernel/__snapshots__/index.test.ts.snap
+++ b/yarn-project/circuits.js/src/structs/kernel/__snapshots__/index.test.ts.snap
@@ -1412,5 +1412,13 @@ proof:
 portal_contract_address: 0x102
 bytecode_hash: 0x103
 
+historic_tree_roots:
+private_historic_tree_roots: private_data_tree_root: 0x201
+nullifier_tree_root: 0x202
+contract_tree_root: 0x203
+l1_to_l2_messages_tree_root: 0x204
+private_kernel_vk_tree_root: 0x205
+
+
 "
 `;

--- a/yarn-project/circuits.js/src/structs/kernel/public_kernel.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/public_kernel.ts
@@ -12,6 +12,7 @@ import { MembershipWitness } from '../membership_witness.js';
 import { UInt8Vector } from '../shared.js';
 import { SignedTxRequest } from '../tx_request.js';
 import { PreviousKernelData } from './previous_kernel_data.js';
+import { CombinedHistoricTreeRoots } from './combined_constant_data.js';
 
 /**
  * Inputs to the public kernel circuit.
@@ -51,10 +52,14 @@ export class PublicKernelInputsNoPreviousKernel {
      * Public calldata assembled from the kernel execution result and proof.
      */
     public readonly publicCallData: PublicCallData,
+    /**
+     * Constant data historic tree roots.
+     */
+    public readonly historicTreeRoots: CombinedHistoricTreeRoots,
   ) {}
 
   toBuffer() {
-    return serializeToBuffer(this.signedTxRequest, this.publicCallData);
+    return serializeToBuffer(this.signedTxRequest, this.publicCallData, this.historicTreeRoots);
   }
 }
 

--- a/yarn-project/circuits.js/src/tests/factories.ts
+++ b/yarn-project/circuits.js/src/tests/factories.ts
@@ -1,8 +1,8 @@
-import { Fr } from '@aztec/foundation/fields';
-import { Fq } from '@aztec/foundation/fields';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { EthAddress } from '@aztec/foundation/eth-address';
+import { Fq, Fr } from '@aztec/foundation/fields';
 
+import { computeCallStackItemHash } from '../abis/abis.js';
 import {
   BaseOrMergeRollupPublicInputs,
   BaseRollupInputs,
@@ -12,6 +12,8 @@ import {
   CombinedConstantData,
   CombinedHistoricTreeRoots,
   ConstantBaseRollupData,
+  ContractStorageRead,
+  ContractStorageUpdateRequest,
   KernelCircuitPublicInputs,
   MergeRollupInputs,
   NewContractData,
@@ -31,8 +33,6 @@ import {
   PublicKernelInputsNoPreviousKernel,
   RootRollupInputs,
   RootRollupPublicInputs,
-  ContractStorageRead,
-  ContractStorageUpdateRequest,
   WitnessedPublicCallData,
   PublicCallRequest,
 } from '../index.js';
@@ -44,16 +44,19 @@ import {
   CONTRACT_TREE_ROOTS_TREE_HEIGHT,
   EMITTED_EVENTS_LENGTH,
   FUNCTION_TREE_HEIGHT,
-  KERNEL_NEW_L2_TO_L1_MSGS_LENGTH,
   KERNEL_NEW_COMMITMENTS_LENGTH,
   KERNEL_NEW_CONTRACTS_LENGTH,
+  KERNEL_NEW_L2_TO_L1_MSGS_LENGTH,
   KERNEL_NEW_NULLIFIERS_LENGTH,
   KERNEL_OPTIONALLY_REVEALED_DATA_LENGTH,
   KERNEL_PRIVATE_CALL_STACK_LENGTH,
   KERNEL_PUBLIC_CALL_STACK_LENGTH,
+  KERNEL_PUBLIC_DATA_READS_LENGTH,
+  KERNEL_PUBLIC_DATA_UPDATE_REQUESTS_LENGTH,
   L1_TO_L2_MESSAGES_ROOTS_TREE_HEIGHT,
-  NEW_L2_TO_L1_MSGS_LENGTH,
+  L1_TO_L2_MESSAGES_SIBLING_PATH_LENGTH,
   NEW_COMMITMENTS_LENGTH,
+  NEW_L2_TO_L1_MSGS_LENGTH,
   NEW_NULLIFIERS_LENGTH,
   NULLIFIER_TREE_HEIGHT,
   NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
@@ -64,10 +67,7 @@ import {
   PUBLIC_DATA_TREE_HEIGHT,
   RETURN_VALUES_LENGTH,
   ROLLUP_VK_TREE_HEIGHT,
-  KERNEL_PUBLIC_DATA_READS_LENGTH,
-  KERNEL_PUBLIC_DATA_UPDATE_REQUESTS_LENGTH,
   VK_TREE_HEIGHT,
-  L1_TO_L2_MESSAGES_SIBLING_PATH_LENGTH,
 } from '../structs/constants.js';
 import { FunctionData } from '../structs/function_data.js';
 import { MembershipWitness } from '../structs/membership_witness.js';
@@ -78,7 +78,6 @@ import { SignedTxRequest, TxRequest } from '../structs/tx_request.js';
 import { CommitmentMap, G1AffineElement, VerificationKey } from '../structs/verification_key.js';
 import { range } from '../utils/jsUtils.js';
 import { numToUInt32BE } from '../utils/serialize.js';
-import { computeCallStackItemHash } from '../abis/abis.js';
 
 /**
  * Creates an arbitrary tx context with the given seed.
@@ -514,7 +513,11 @@ export async function makePublicKernelInputsWithEmptyOutput(seed = 1): Promise<P
  * @returns Public kernel inputs.
  */
 export async function makePublicKernelInputsNoKernelInput(seed = 1): Promise<PublicKernelInputsNoPreviousKernel> {
-  return new PublicKernelInputsNoPreviousKernel(makeSignedTxRequest(seed), await makePublicCallData(seed + 0x100));
+  return new PublicKernelInputsNoPreviousKernel(
+    makeSignedTxRequest(seed),
+    await makePublicCallData(seed + 0x100),
+    makeCombinedHistoricTreeRoots(seed + 0x200),
+  );
 }
 
 /**


### PR DESCRIPTION
Adds constant data to the "public kernel with no previous kernel" circuit, so it can be forwarded to the outputs. Instead of adding the full `CombinedConstantData` struct, we're adding just the historic tree roots, since the tx context can be obtained from the signed tx request.

Fixes #482 