### PR TITLE
fix: naming consistency in messaging (messageHash -> message)

### DIFF
--- a/yarn-project/acir-simulator/src/client/db_oracle.ts
+++ b/yarn-project/acir-simulator/src/client/db_oracle.ts
@@ -27,7 +27,7 @@ export interface NoteLoadOracleInputs {
 export interface MessageLoadOracleInputs {
   /**
    * An collapsed array of fields containing all of the l1 to l2 message components.
-   * `l1ToL2Message.toFieldArray()` -\> [sender, chainId, recipient, version, contentHash, secretHash, deadline, fee]
+   * `l1ToL2Message.toFieldArray()` -\> [sender, chainId, recipient, version, content, secretHash, deadline, fee]
    */
   message: Fr[];
   /**

--- a/yarn-project/acir-simulator/src/client/private_execution.test.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.test.ts
@@ -357,16 +357,16 @@ describe('Private Execution test suite', () => {
     let recipientPk: Buffer;
     let recipient: NoirPoint;
 
-    const buildL1ToL2Message = async (content: Fr[], targetContract: AztecAddress, secret: Fr) => {
+    const buildL1ToL2Message = async (contentArray: Fr[], targetContract: AztecAddress, secret: Fr) => {
       const wasm = await CircuitsWasm.get();
 
       // Function selector: 0x1801fbe5 keccak256('mint(uint256,bytes32)')
       const contentBuf = Buffer.concat([
         Buffer.from([0x18, 0x01, 0xfb, 0xe5]),
-        ...content.map(field => field.toBuffer()),
+        ...contentArray.map(field => field.toBuffer()),
       ]);
       const temp = toBigIntBE(sha256(contentBuf));
-      const contentHash = Fr.fromBuffer(toBufferBE(temp % Fr.MODULUS, 32));
+      const content = Fr.fromBuffer(toBufferBE(temp % Fr.MODULUS, 32));
 
       const secretHash = computeSecretMessageHash(wasm, secret);
 
@@ -375,7 +375,7 @@ describe('Private Execution test suite', () => {
       return new L1ToL2Message(
         new L1Actor(EthAddress.random(), 1),
         new L2Actor(targetContract, 1),
-        contentHash,
+        content,
         secretHash,
         0,
         0,

--- a/yarn-project/acir-simulator/src/client/private_execution.test.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.test.ts
@@ -357,13 +357,13 @@ describe('Private Execution test suite', () => {
     let recipientPk: Buffer;
     let recipient: NoirPoint;
 
-    const buildL1ToL2Message = async (contentArray: Fr[], targetContract: AztecAddress, secret: Fr) => {
+    const buildL1ToL2Message = async (contentPreimage: Fr[], targetContract: AztecAddress, secret: Fr) => {
       const wasm = await CircuitsWasm.get();
 
       // Function selector: 0x1801fbe5 keccak256('mint(uint256,bytes32)')
       const contentBuf = Buffer.concat([
         Buffer.from([0x18, 0x01, 0xfb, 0xe5]),
-        ...contentArray.map(field => field.toBuffer()),
+        ...contentPreimage.map(field => field.toBuffer()),
       ]);
       const temp = toBigIntBE(sha256(contentBuf));
       const content = Fr.fromBuffer(toBufferBE(temp % Fr.MODULUS, 32));

--- a/yarn-project/noir-contracts/src/contracts/noir-aztec3/src/context.nr
+++ b/yarn-project/noir-contracts/src/contracts/noir-aztec3/src/context.nr
@@ -79,7 +79,7 @@ impl PrivateFunctionContext {
 
     // Inputs must be temporarily passed in to prevent too many unknowns
     // Note this returns self to get around an issue where mutable structs do not maintain mutations unless reassigned
-    fn consume_l1_to_l2_message(mut self: Self, inputs: abi::Inputs, msg_key: Field, content_hash: Field, secret: Field) -> PrivateFunctionContext {
+    fn consume_l1_to_l2_message(mut self: Self, inputs: abi::Inputs, msg_key: Field, content: Field, secret: Field) -> PrivateFunctionContext {
         let returned_message = get_l1_to_l2_message_call(msg_key);
         let l1_to_l2_message_data = make_l1_to_l2_message_getter_data(returned_message, 0, secret);
 
@@ -90,7 +90,7 @@ impl PrivateFunctionContext {
         constrain l1_to_l2_message_data.message.recipient == inputs.call_context.storage_contract_address;
 
         // Validate the message hash is correct
-        constrain l1_to_l2_message_data.message.content_hash == content_hash;
+        constrain l1_to_l2_message_data.message.content == content;
 
         // Validate the message secret is correct
         l1_to_l2_message_data.message.validate_message_secret();

--- a/yarn-project/noir-contracts/src/contracts/noir-aztec3/src/messaging/l1_to_l2_message.nr
+++ b/yarn-project/noir-contracts/src/contracts/noir-aztec3/src/messaging/l1_to_l2_message.nr
@@ -14,7 +14,7 @@ struct L1ToL2Message {
     chainId: Field,
     recipient: Field,
     version: Field,
-    content_hash: Field,
+    content: Field,
     secret: Field,
     secret_hash: Field,
     deadline: u32,
@@ -29,7 +29,7 @@ impl L1ToL2Message {
             chainId: 0,
             recipient: 0,
             version: 0,
-            content_hash: 0,
+            content: 0,
             secret: 0,
             secret_hash: 0,
             deadline: 0 as u32,
@@ -49,7 +49,7 @@ impl L1ToL2Message {
             chainId: fields[1],
             recipient: fields[2],
             version: fields[3],
-            content_hash: fields[4],
+            content: fields[4],
             secret: secret,
             secret_hash: fields[5],
             deadline: fields[6] as u32,
@@ -70,7 +70,7 @@ impl L1ToL2Message {
         let chainId_bytes = self.chainId.to_be_bytes(32);
         let recipient_bytes = self.recipient.to_be_bytes(32);
         let version_bytes = self.version.to_be_bytes(32);
-        let content_hash_bytes = self.content_hash.to_be_bytes(32);
+        let content_bytes = self.content.to_be_bytes(32);
         let secret_hash_bytes = self.secret_hash.to_be_bytes(32);
         let deadline_bytes = (self.deadline as Field).to_be_bytes(32);
         let fee_bytes = (self.fee as Field).to_be_bytes(32);
@@ -213,38 +213,38 @@ impl L1ToL2Message {
         hash_bytes[30 + 96] = version_bytes[30];
         hash_bytes[31 + 96] = version_bytes[31];
 
-        hash_bytes[0 + 128] = content_hash_bytes[0];
-        hash_bytes[1 + 128] = content_hash_bytes[1];
-        hash_bytes[2 + 128] = content_hash_bytes[2];
-        hash_bytes[3 + 128] = content_hash_bytes[3];
-        hash_bytes[4 + 128] = content_hash_bytes[4];
-        hash_bytes[5 + 128] = content_hash_bytes[5];
-        hash_bytes[6 + 128] = content_hash_bytes[6];
-        hash_bytes[7 + 128] = content_hash_bytes[7];
-        hash_bytes[8 + 128] = content_hash_bytes[8];
-        hash_bytes[9 + 128] = content_hash_bytes[9];
-        hash_bytes[10 + 128] = content_hash_bytes[10];
-        hash_bytes[11 + 128] = content_hash_bytes[11];
-        hash_bytes[12 + 128] = content_hash_bytes[12];
-        hash_bytes[13 + 128] = content_hash_bytes[13];
-        hash_bytes[14 + 128] = content_hash_bytes[14];
-        hash_bytes[15 + 128] = content_hash_bytes[15];
-        hash_bytes[16 + 128] = content_hash_bytes[16];
-        hash_bytes[17 + 128] = content_hash_bytes[17];
-        hash_bytes[18 + 128] = content_hash_bytes[18];
-        hash_bytes[19 + 128] = content_hash_bytes[19];
-        hash_bytes[20 + 128] = content_hash_bytes[20];
-        hash_bytes[21 + 128] = content_hash_bytes[21];
-        hash_bytes[22 + 128] = content_hash_bytes[22];
-        hash_bytes[23 + 128] = content_hash_bytes[23];
-        hash_bytes[24 + 128] = content_hash_bytes[24];
-        hash_bytes[25 + 128] = content_hash_bytes[25];
-        hash_bytes[26 + 128] = content_hash_bytes[26];
-        hash_bytes[27 + 128] = content_hash_bytes[27];
-        hash_bytes[28 + 128] = content_hash_bytes[28];
-        hash_bytes[29 + 128] = content_hash_bytes[29];
-        hash_bytes[30 + 128] = content_hash_bytes[30];
-        hash_bytes[31 + 128] = content_hash_bytes[31];
+        hash_bytes[0 + 128] = content_bytes[0];
+        hash_bytes[1 + 128] = content_bytes[1];
+        hash_bytes[2 + 128] = content_bytes[2];
+        hash_bytes[3 + 128] = content_bytes[3];
+        hash_bytes[4 + 128] = content_bytes[4];
+        hash_bytes[5 + 128] = content_bytes[5];
+        hash_bytes[6 + 128] = content_bytes[6];
+        hash_bytes[7 + 128] = content_bytes[7];
+        hash_bytes[8 + 128] = content_bytes[8];
+        hash_bytes[9 + 128] = content_bytes[9];
+        hash_bytes[10 + 128] = content_bytes[10];
+        hash_bytes[11 + 128] = content_bytes[11];
+        hash_bytes[12 + 128] = content_bytes[12];
+        hash_bytes[13 + 128] = content_bytes[13];
+        hash_bytes[14 + 128] = content_bytes[14];
+        hash_bytes[15 + 128] = content_bytes[15];
+        hash_bytes[16 + 128] = content_bytes[16];
+        hash_bytes[17 + 128] = content_bytes[17];
+        hash_bytes[18 + 128] = content_bytes[18];
+        hash_bytes[19 + 128] = content_bytes[19];
+        hash_bytes[20 + 128] = content_bytes[20];
+        hash_bytes[21 + 128] = content_bytes[21];
+        hash_bytes[22 + 128] = content_bytes[22];
+        hash_bytes[23 + 128] = content_bytes[23];
+        hash_bytes[24 + 128] = content_bytes[24];
+        hash_bytes[25 + 128] = content_bytes[25];
+        hash_bytes[26 + 128] = content_bytes[26];
+        hash_bytes[27 + 128] = content_bytes[27];
+        hash_bytes[28 + 128] = content_bytes[28];
+        hash_bytes[29 + 128] = content_bytes[29];
+        hash_bytes[30 + 128] = content_bytes[30];
+        hash_bytes[31 + 128] = content_bytes[31];
 
         hash_bytes[0 + 160] = secret_hash_bytes[0];
         hash_bytes[1 + 160] = secret_hash_bytes[1];
@@ -406,8 +406,8 @@ impl L1ToL2Message {
         low = low + (content_sha256[16 + 0] as Field) * v;
         v = v * 256;
 
-        let content_hash = low + high * v;
-        content_hash        
+        let content = low + high * v;
+        content        
     }
 
     // The nullifier of a l1 to l2 message is the hash of the message salted with the secret and tree index

--- a/yarn-project/noir-contracts/src/contracts/noir-aztec3/src/messaging/l1_to_l2_message.nr
+++ b/yarn-project/noir-contracts/src/contracts/noir-aztec3/src/messaging/l1_to_l2_message.nr
@@ -345,69 +345,69 @@ impl L1ToL2Message {
         hash_bytes[30 + 224] = fee_bytes[30];
         hash_bytes[31 + 224] = fee_bytes[31];
 
-        let content_sha256 = dep::std::hash::sha256(hash_bytes);
+        let message_sha256 = dep::std::hash::sha256(hash_bytes);
 
-        // // Convert the content_sha256 to a field element
+        // // Convert the message_sha256 to a field element
         let mut v = 1;
         let mut high = 0 as Field;
         let mut low = 0 as Field;
 
         // Unroll loops because otherwise takes forever to compile
         // for i in [15 - i for i in range(16)]:
-        //     print('high = high + (content_sha256[{0}] as Field) * v;'.format(i))
-        //     print('low = low + (content_sha256[16 + {0}] as Field) * v;'.format(i))
+        //     print('high = high + (message_sha256[{0}] as Field) * v;'.format(i))
+        //     print('low = low + (message_sha256[16 + {0}] as Field) * v;'.format(i))
         //     print('v = v * 256;');
-        high = high + (content_sha256[15] as Field) * v;
-        low = low + (content_sha256[16 + 15] as Field) * v;
+        high = high + (message_sha256[15] as Field) * v;
+        low = low + (message_sha256[16 + 15] as Field) * v;
         v = v * 256;
-        high = high + (content_sha256[14] as Field) * v;
-        low = low + (content_sha256[16 + 14] as Field) * v;
+        high = high + (message_sha256[14] as Field) * v;
+        low = low + (message_sha256[16 + 14] as Field) * v;
         v = v * 256;
-        high = high + (content_sha256[13] as Field) * v;
-        low = low + (content_sha256[16 + 13] as Field) * v;
+        high = high + (message_sha256[13] as Field) * v;
+        low = low + (message_sha256[16 + 13] as Field) * v;
         v = v * 256;
-        high = high + (content_sha256[12] as Field) * v;
-        low = low + (content_sha256[16 + 12] as Field) * v;
+        high = high + (message_sha256[12] as Field) * v;
+        low = low + (message_sha256[16 + 12] as Field) * v;
         v = v * 256;
-        high = high + (content_sha256[11] as Field) * v;
-        low = low + (content_sha256[16 + 11] as Field) * v;
+        high = high + (message_sha256[11] as Field) * v;
+        low = low + (message_sha256[16 + 11] as Field) * v;
         v = v * 256;
-        high = high + (content_sha256[10] as Field) * v;
-        low = low + (content_sha256[16 + 10] as Field) * v;
+        high = high + (message_sha256[10] as Field) * v;
+        low = low + (message_sha256[16 + 10] as Field) * v;
         v = v * 256;
-        high = high + (content_sha256[9] as Field) * v;
-        low = low + (content_sha256[16 + 9] as Field) * v;
+        high = high + (message_sha256[9] as Field) * v;
+        low = low + (message_sha256[16 + 9] as Field) * v;
         v = v * 256;
-        high = high + (content_sha256[8] as Field) * v;
-        low = low + (content_sha256[16 + 8] as Field) * v;
+        high = high + (message_sha256[8] as Field) * v;
+        low = low + (message_sha256[16 + 8] as Field) * v;
         v = v * 256;
-        high = high + (content_sha256[7] as Field) * v;
-        low = low + (content_sha256[16 + 7] as Field) * v;
+        high = high + (message_sha256[7] as Field) * v;
+        low = low + (message_sha256[16 + 7] as Field) * v;
         v = v * 256;
-        high = high + (content_sha256[6] as Field) * v;
-        low = low + (content_sha256[16 + 6] as Field) * v;
+        high = high + (message_sha256[6] as Field) * v;
+        low = low + (message_sha256[16 + 6] as Field) * v;
         v = v * 256;
-        high = high + (content_sha256[5] as Field) * v;
-        low = low + (content_sha256[16 + 5] as Field) * v;
+        high = high + (message_sha256[5] as Field) * v;
+        low = low + (message_sha256[16 + 5] as Field) * v;
         v = v * 256;
-        high = high + (content_sha256[4] as Field) * v;
-        low = low + (content_sha256[16 + 4] as Field) * v;
+        high = high + (message_sha256[4] as Field) * v;
+        low = low + (message_sha256[16 + 4] as Field) * v;
         v = v * 256;
-        high = high + (content_sha256[3] as Field) * v;
-        low = low + (content_sha256[16 + 3] as Field) * v;
+        high = high + (message_sha256[3] as Field) * v;
+        low = low + (message_sha256[16 + 3] as Field) * v;
         v = v * 256;
-        high = high + (content_sha256[2] as Field) * v;
-        low = low + (content_sha256[16 + 2] as Field) * v;
+        high = high + (message_sha256[2] as Field) * v;
+        low = low + (message_sha256[16 + 2] as Field) * v;
         v = v * 256;
-        high = high + (content_sha256[1] as Field) * v;
-        low = low + (content_sha256[16 + 1] as Field) * v;
+        high = high + (message_sha256[1] as Field) * v;
+        low = low + (message_sha256[16 + 1] as Field) * v;
         v = v * 256;
-        high = high + (content_sha256[0] as Field) * v;
-        low = low + (content_sha256[16 + 0] as Field) * v;
+        high = high + (message_sha256[0] as Field) * v;
+        low = low + (message_sha256[16 + 0] as Field) * v;
         v = v * 256;
 
-        let content = low + high * v;
-        content        
+        let message_hash = low + high * v;
+        message_hash        
     }
 
     // The nullifier of a l1 to l2 message is the hash of the message salted with the secret and tree index

--- a/yarn-project/types/src/l1_to_l2_message.ts
+++ b/yarn-project/types/src/l1_to_l2_message.ts
@@ -19,7 +19,7 @@ export class L1ToL2Message {
      */
     public readonly recipient: L2Actor,
     /**
-     * The hash of the message content.
+     * The message content.
      */
     public readonly content: Fr,
     /**

--- a/yarn-project/types/src/l1_to_l2_message.ts
+++ b/yarn-project/types/src/l1_to_l2_message.ts
@@ -21,7 +21,7 @@ export class L1ToL2Message {
     /**
      * The hash of the message content.
      */
-    public readonly contentHash: Fr,
+    public readonly content: Fr,
     /**
      * The hash of the spending secret.
      */
@@ -51,7 +51,7 @@ export class L1ToL2Message {
     return [
       ...this.sender.toFieldArray(),
       ...this.recipient.toFieldArray(),
-      this.contentHash,
+      this.content,
       this.secretHash,
       new Fr(BigInt(this.deadline)),
       new Fr(BigInt(this.fee)),
@@ -59,7 +59,7 @@ export class L1ToL2Message {
   }
 
   toBuffer(): Buffer {
-    return serializeToBuffer(this.sender, this.recipient, this.contentHash, this.secretHash, this.deadline, this.fee);
+    return serializeToBuffer(this.sender, this.recipient, this.content, this.secretHash, this.deadline, this.fee);
   }
 
   static empty(): L1ToL2Message {


### PR DESCRIPTION
# Description

closes: https://github.com/AztecProtocol/aztec-packages/issues/632

Very small pr correcting use of contentHash in L1ToL2 data types to make it consistent with uses elsewhere. ( referring to it as a hash is incorrect as in some instances, where the value fits within a field, it will not need to be hashed ).

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] The branch has been merged or rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
