### PR TITLE
chore: simplify build commands for noir-contracts

### DIFF
--- a/yarn-project/noir-contracts/README.md
+++ b/yarn-project/noir-contracts/README.md
@@ -1,6 +1,6 @@
 # Noir contracts
 
-This package contains the source code and the Aztec ABIs for the example contracts used in the e2e tests.
+This package contains the source code and the Aztec ABIs for the example contracts used in tests.
 
 ## Building the contracts
 
@@ -12,15 +12,17 @@ This package contains the source code and the Aztec ABIs for the example contrac
   ```
   noirup --branch aztec3-hacky
   ```
-- Move to the circuit you want to build
+- Use the `noir:build:all` script to compile the contracts you want and prepare the ABI for consumption
   ```
-  cd src/contracts/test_contract
-  ```
-- Build using nargo
-  ```
-  nargo compile main --contracts
+  yarn noir:build:all
   ```
 
-### Examples folder
+Alternatively you can run `yarn noir:build CONTRACT1 CONTRACT2...` to build a subset of contracts:
+```
+yarn noir:build zk_token public_token
+```
 
-The examples folder has friendly ABIs to be consumed from aztec3-client. They can be generated from the nargo build output using the `scripts/copy_output.ts`.
+To view compilation output, including errors, run with the `VERBOSE=1` flag:
+```
+VERBOSE=1 yarn noir:build zk_token public_token
+```

--- a/yarn-project/noir-contracts/package.json
+++ b/yarn-project/noir-contracts/package.json
@@ -20,14 +20,8 @@
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests",
-    "noir:build": "yarn noir:build:test && yarn noir:build:parent && yarn noir:build:child && yarn noir:build:zk_token && yarn noir:build:pub_token && yarn noir:build:non_native_token && yarn noir:build:rollup_native_token",
-    "noir:build:test": "(cd src/contracts/test_contract && nargo compile main --contracts) && ts-node --esm src/scripts/copy_output.ts test",
-    "noir:build:parent": "(cd src/contracts/parent_contract && nargo compile main --contracts && ../../scripts/trim_noir_output.sh Parent ) && ts-node --esm src/scripts/copy_output.ts parent",
-    "noir:build:child": "(cd src/contracts/child_contract && nargo compile main --contracts) && ts-node --esm src/scripts/copy_output.ts child",
-    "noir:build:zk_token": "(cd src/contracts/zk_token_contract && nargo compile main --contracts) && ts-node --esm src/scripts/copy_output.ts zk_token",
-    "noir:build:non_native_token": "(cd src/contracts/non_native_token_contract && nargo compile main --contracts && ../../scripts/trim_noir_output.sh NonNativeToken ) && ts-node --esm src/scripts/copy_output.ts non_native_token",
-    "noir:build:rollup_native_token": "(cd src/contracts/rollup_native_asset_contract && nargo compile main --contracts && ../../scripts/trim_noir_output.sh RollupNativeAsset) && ts-node --esm src/scripts/copy_output.ts rollup_native_asset",
-    "noir:build:pub_token": "(cd src/contracts/public_token_contract && nargo compile main --contracts) && ts-node --esm src/scripts/copy_output.ts public_token"
+    "noir:build": "./src/scripts/compile.sh",
+    "noir:build:all": "./src/scripts/compile.sh $(ls -d src/contracts/*_contract | sed -r 's/src\\/contracts\\/(.+)_contract/\\1/')"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/noir-contracts/src/scripts/compile.sh
+++ b/yarn-project/noir-contracts/src/scripts/compile.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail;
+
+ROOT=$(pwd)
+for CONTRACT_NAME in "$@"; do
+  CONTRACT_FOLDER="${CONTRACT_NAME}_contract"
+  echo "Compiling $CONTRACT_NAME..."
+  cd src/contracts/$CONTRACT_FOLDER
+  rm -f target/*
+  if [[ -z "${VERBOSE:-}" ]]; then
+    nargo compile main --contracts 2> /dev/null > /dev/null
+  else
+    nargo compile main --contracts
+  fi
+
+  # Trim the output of the noir json, removing unneeded fields to make it small enough to be processed by copy_output.ts
+  # This is a workaround until noir output files get smaller
+  FILENAME=$(ls target/*.json)
+  echo "Trimming output for $FILENAME"
+  jq -c '.functions[] |= del(.proving_key, .verification_key)' $FILENAME > temp.json 
+  mv temp.json $FILENAME
+
+  cd $ROOT
+  echo "Copying output for $CONTRACT_NAME"
+  NODE_OPTIONS=--no-warnings yarn ts-node --esm src/scripts/copy_output.ts $CONTRACT_NAME
+  echo -e "Done\n"
+done


### PR DESCRIPTION
Removes package.json pollution by reducing all scripts to build contracts to just two: one to build a specific set of contracts, one to build all of them. By default, redirects all stdout and stderr to dev/null, since the noir compiler is ridiculously verbose.