### PR TITLE
sequencer, oracle integration with L1 to L2 messages

### DIFF
--- a/yarn-project/archiver/package.json
+++ b/yarn-project/archiver/package.json
@@ -44,6 +44,7 @@
     "ws": "^8.13.0"
   },
   "devDependencies": {
+    "@datastructures-js/heap": "^4.3.1",
     "@jest/globals": "^29.5.0",
     "@rushstack/eslint-patch": "^1.2.0",
     "@types/debug": "^4.1.7",

--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -72,7 +72,7 @@ describe('Archiver', () => {
     expect(latestUnverifiedDataBlockNum).toEqual(2);
 
     // there are only 2 l1ToL2 messages in the store
-    expect((await archiver.getPendingL1ToL2Messages(10)).length).toEqual(2);
+    expect((await archiver.consumePendingL1ToL2Messages(10)).length).toEqual(2);
 
     await archiver.stop();
   }, 10_000);

--- a/yarn-project/aztec-node/src/aztec-node/aztec-node.ts
+++ b/yarn-project/aztec-node/src/aztec-node/aztec-node.ts
@@ -15,6 +15,8 @@ import {
   ContractData,
   ContractDataSource,
   ContractPublicData,
+  L1ToL2Message,
+  L1ToL2MessageReaderSource,
   L2Block,
   L2BlockSource,
   MerkleTreeId,
@@ -44,6 +46,7 @@ export class AztecNode {
     protected blockSource: L2BlockSource,
     protected unverifiedDataSource: UnverifiedDataSource,
     protected contractDataSource: ContractDataSource,
+    protected l1ToL2MessageReaderSource: L1ToL2MessageReaderSource,
     protected merkleTreeDB: MerkleTrees,
     protected worldStateSynchroniser: WorldStateSynchroniser,
     protected sequencer: SequencerClient,
@@ -70,8 +73,17 @@ export class AztecNode {
     await Promise.all([p2pClient.start(), worldStateSynchroniser.start()]);
 
     // now create the sequencer
-    const sequencer = await SequencerClient.new(config, p2pClient, worldStateSynchroniser, archiver);
-    return new AztecNode(p2pClient, archiver, archiver, archiver, merkleTreeDB, worldStateSynchroniser, sequencer);
+    const sequencer = await SequencerClient.new(config, p2pClient, worldStateSynchroniser, archiver, archiver);
+    return new AztecNode(
+      p2pClient,
+      archiver,
+      archiver,
+      archiver,
+      archiver,
+      merkleTreeDB,
+      worldStateSynchroniser,
+      sequencer,
+    );
   }
 
   /**
@@ -128,6 +140,15 @@ export class AztecNode {
    */
   public getUnverifiedData(from: number, take: number): Promise<UnverifiedData[]> {
     return this.unverifiedDataSource.getUnverifiedData(from, take);
+  }
+
+  /**
+   * Gets a L1 to L2 message for the given message key - useful for the db oracle.
+   * @param messageKey - The message key.
+   * @returns the message (or throws if not found)
+   */
+  public getL1ToL2Message(messageKey: Fr): Promise<L1ToL2Message> {
+    return this.l1ToL2MessageReaderSource.getL1ToL2Message(messageKey);
   }
 
   /**

--- a/yarn-project/aztec-rpc/src/simulator_oracle/index.ts
+++ b/yarn-project/aztec-rpc/src/simulator_oracle/index.ts
@@ -5,7 +5,6 @@ import { KeyPair } from '@aztec/key-store';
 import { FunctionAbi } from '@aztec/foundation/abi';
 import { ContractDataOracle } from '../contract_data_oracle/index.js';
 import { Database } from '../database/index.js';
-import { L1ToL2Message } from '@aztec/types';
 
 /**
  * A data oracle that provides information needed for simulating a transaction.
@@ -87,9 +86,9 @@ export class SimulatorOracle implements DBOracle {
     return await this.contractDataOracle.getPortalContractAddress(contractAddress);
   }
 
-  // TODO: currently stubbed will be implemented in: https://github.com/AztecProtocol/aztec-packages/issues/529
   /**
    * Retreives the L1ToL2Message associated with a specific message key
+   * Throws an error if the message key is not found
    *
    * @param msgKey - The key of the message to be retreived
    * @returns A promise that resolves to the message data, a sibling path and the
@@ -97,7 +96,7 @@ export class SimulatorOracle implements DBOracle {
    */
   async getL1ToL2Message(msgKey: Fr): Promise<MessageLoadOracleInputs> {
     void msgKey; // this line can be removed its to appease the linter on this stub
-    const message = L1ToL2Message.empty().toFieldArray();
+    const message = (await this.node.getL1ToL2Message(msgKey)).toFieldArray();
     // TODO: note index will be requested from the database, stubbed as 0 for the meantime
     const index = 0n;
     const siblingPath = await this.node.getL1ToL2MessagesTreePath(index);

--- a/yarn-project/sequencer-client/src/block_builder/solo_block_builder.ts
+++ b/yarn-project/sequencer-client/src/block_builder/solo_block_builder.ts
@@ -41,6 +41,7 @@ import { assertLength } from '@aztec/foundation/serialize';
 import { ProcessedTx } from '../sequencer/processed_tx.js';
 import { BlockBuilder } from './index.js';
 import { AllowedTreeNames, OutputWithTreeSnapshot } from './types.js';
+import { padArrayEnd } from '@aztec/foundation/collection';
 
 const frToBigInt = (fr: Fr) => toBigIntBE(fr.toBuffer());
 const bigintToFr = (num: bigint) => new Fr(num);
@@ -195,12 +196,8 @@ export class SoloBlockBuilder implements BlockBuilder {
       throw new Error(`Length of txs for the block should be a power of two and at least four (got ${txs.length})`);
     }
 
-    // Check that the number of new L1 to L2 messages is the same as the max
-    if (newL1ToL2Messages.length !== NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP) {
-      throw new Error(
-        `Length of the l1 to l2 messages per block should be a constant ${NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP} (got ${newL1ToL2Messages.length})`,
-      );
-    }
+    // padArrayEnd throws if the array is already full. Otherwise it pads till we reach the required size
+    newL1ToL2Messages = padArrayEnd(newL1ToL2Messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
 
     // Run the base rollup circuits for the txs
     const baseRollupOutputs: [BaseOrMergeRollupPublicInputs, Proof][] = [];

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -1,7 +1,7 @@
 import { P2P } from '@aztec/p2p';
 import { WorldStateSynchroniser } from '@aztec/world-state';
 
-import { ContractDataSource } from '@aztec/types';
+import { ContractDataSource, L1ToL2MessageConsumer } from '@aztec/types';
 import { SoloBlockBuilder } from '../block_builder/solo_block_builder.js';
 import { SequencerClientConfig } from '../config.js';
 import { getL1Publisher, getVerificationKeys, Sequencer } from '../index.js';
@@ -21,6 +21,7 @@ export class SequencerClient {
    * @param p2pClient - P2P client that provides the txs to be sequenced.
    * @param worldStateSynchroniser - Provides access to world state.
    * @param contractDataSource - Provides access to contract bytecode for public executions.
+   * @param l1ToL2MessageConsumer - Provides access to consume L1 to L2 messages.
    * @returns A new running instance.
    */
   public static async new(
@@ -28,6 +29,7 @@ export class SequencerClient {
     p2pClient: P2P,
     worldStateSynchroniser: WorldStateSynchroniser,
     contractDataSource: ContractDataSource,
+    l1ToL2MessageConsumer: L1ToL2MessageConsumer,
   ) {
     const publisher = getL1Publisher(config);
     const merkleTreeDb = worldStateSynchroniser.getLatest();
@@ -47,6 +49,7 @@ export class SequencerClient {
       worldStateSynchroniser,
       blockBuilder,
       publicProcessorFactory,
+      l1ToL2MessageConsumer,
       config,
     );
 

--- a/yarn-project/types/src/l2_block.ts
+++ b/yarn-project/types/src/l2_block.ts
@@ -115,7 +115,7 @@ export class L2Block {
      */
     public newContractData: ContractData[],
     /**
-     * The L1 to L2 messages to be inserted into the L2 toL2 message tree.
+     * The L1 to L2 message keys to be inserted into the L2 message tree.
      */
     public newL1ToL2Messages: Fr[] = [],
   ) {}

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -57,6 +57,7 @@ __metadata:
     "@aztec/foundation": "workspace:^"
     "@aztec/l1-artifacts": "workspace:^"
     "@aztec/types": "workspace:^"
+    "@datastructures-js/heap": ^4.3.1
     "@jest/globals": ^29.5.0
     "@rushstack/eslint-patch": ^1.2.0
     "@types/debug": ^4.1.7
@@ -960,6 +961,13 @@ __metadata:
   dependencies:
     "@jridgewell/trace-mapping": 0.3.9
   checksum: 5718f267085ed8edb3e7ef210137241775e607ee18b77d95aa5bd7514f47f5019aa2d82d96b3bf342ef7aa890a346fa1044532ff7cc3009e7d24fce3ce6200fa
+  languageName: node
+  linkType: hard
+
+"@datastructures-js/heap@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@datastructures-js/heap@npm:4.3.1"
+  checksum: 1e526850094af5c4292181ca92e38b652361f28d5a2b50a49cd21c5717bcc65d22f87d61096bfa11803ab4d7391b51a568e87d7044651a7bc2a7522b14380ac4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
Fixes #529:
Builds on from #642 
* Archiver now stores a map of message key to the message (for all messages ever sent to inbox)
* Archiver also stores these in a max heap (sorted by fees) so that sequencer can pull an arbitrary amount of messages quickly.
* Once the sequencer requests messages, they are removed from the heap. Sequencer inserts these messages into the block (& sends to the circuits). If the block publishes, nothing needs to be done (since the messages were already removed from the heap). If the block fails to publish then the messages would need to be added back to the archiver store. 
* Archiver also implements a getter for a message - useful for oracle calls from noir
* Call this getter from the RPC Server (which responds to oracle queries)

TODO: Add some tests around the archiver, fix the l1 publisher integration 
**Please sanity check that there are no other places I have missed**
Also any test suggestions are welcome!

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
