### PR TITLE
add L1->L2 msg store, fix #520

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -166,8 +166,12 @@ export class Archiver implements L2BlockSource, UnverifiedDataSource, ContractDa
       }
     });
 
-    // store l1 to l2 messages for which we have retrieved rollups
+    // store new pending l1 to l2 messages for which we have retrieved rollups
     await this.store.addPendingL1ToL2Messages(retrievedPendingL1ToL2Messages.retrievedData);
+    // from retrieved L2Blocks, remove L1 to L2 messages that have been published
+    // from each l2block fetch all messageKeys in a flattened array:
+    const messageKeysToRemove = retrievedBlocks.retrievedData.map(l2block => l2block.newL2ToL1Msgs).flat();
+    await this.store.removeFromPendingL1ToL2Messages(messageKeysToRemove);
 
     // store retrieved rollup blocks
     await this.store.addL2Blocks(retrievedBlocks.retrievedData);

--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -10,7 +10,7 @@ import {
   processUnverifiedDataLogs,
 } from './eth_log_handlers.js';
 import { EthAddress } from '@aztec/foundation/eth-address';
-import { ContractPublicData, L1ToL2Message, L2Block, UnverifiedData } from '@aztec/types';
+import { ContractPublicData, L1ToL2MessageStore, L2Block, UnverifiedData } from '@aztec/types';
 
 /**
  * Data retreived from logs
@@ -23,7 +23,7 @@ type DataRetrieval<T> = {
   /**
    * The data returned.
    */
-  retrievedData: T[];
+  retrievedData: T;
 };
 
 /**
@@ -43,7 +43,7 @@ export async function retrieveBlocks(
   currentBlockNumber: bigint,
   searchStartBlock: bigint,
   expectedNextRollupNumber: bigint,
-): Promise<DataRetrieval<L2Block>> {
+): Promise<DataRetrieval<L2Block[]>> {
   const retrievedBlocks: L2Block[] = [];
   do {
     if (searchStartBlock > currentBlockNumber) {
@@ -81,7 +81,7 @@ export async function retrieveUnverifiedData(
   currentBlockNumber: bigint,
   searchStartBlock: bigint,
   expectedNextRollupNumber: bigint,
-): Promise<DataRetrieval<UnverifiedData>> {
+): Promise<DataRetrieval<UnverifiedData[]>> {
   const newUnverifiedDataChunks: UnverifiedData[] = [];
   do {
     if (searchStartBlock > currentBlockNumber) {
@@ -121,7 +121,7 @@ export async function retrieveNewContractData(
   blockUntilSynced: boolean,
   currentBlockNumber: bigint,
   searchStartBlock: bigint,
-): Promise<DataRetrieval<[ContractPublicData[], number]>> {
+): Promise<DataRetrieval<[ContractPublicData[], number][]>> {
   let retrievedNewContracts: [ContractPublicData[], number][] = [];
   do {
     if (searchStartBlock > currentBlockNumber) {
@@ -148,7 +148,7 @@ export async function retrieveNewContractData(
  * @param blockUntilSynced - If true, blocks until the archiver has fully synced.
  * @param currentBlockNumber - Latest available block number in the ETH node.
  * @param searchStartBlock - The block number to use for starting the search.
- * @returns An array of L1ToL2Message and next eth block to search from.
+ * @returns A map of messageKeys to the L1ToL2Message fetched and next eth block to search from.
  */
 export async function retrieveNewPendingL1ToL2Messages(
   publicClient: PublicClient,
@@ -156,15 +156,16 @@ export async function retrieveNewPendingL1ToL2Messages(
   blockUntilSynced: boolean,
   currentBlockNumber: bigint,
   searchStartBlock: bigint,
-): Promise<DataRetrieval<L1ToL2Message>> {
-  const retrievedNewL1ToL2Messages: L1ToL2Message[] = [];
+): Promise<DataRetrieval<L1ToL2MessageStore>> {
+  const retrievedNewL1ToL2Messages: L1ToL2MessageStore = new L1ToL2MessageStore();
   do {
     if (searchStartBlock > currentBlockNumber) {
       break;
     }
     const newL1ToL2MessageLogs = await getPendingL1ToL2MessageLogs(publicClient, inboxAddress, searchStartBlock);
     const newL1ToL2Messages = processPendingL1ToL2MessageAddedLogs(newL1ToL2MessageLogs);
-    retrievedNewL1ToL2Messages.push(...newL1ToL2Messages);
+    // combine the new messages with the existing ones
+    retrievedNewL1ToL2Messages.combineWith(newL1ToL2Messages);
     // handles the case when there are no new messages:
     searchStartBlock = (newL1ToL2MessageLogs.findLast(msgLog => !!msgLog)?.blockNumber || searchStartBlock) + 1n;
   } while (blockUntilSynced && searchStartBlock <= currentBlockNumber);


### PR DESCRIPTION
# Description
* Create a L1 to L2 Message Store 
* Store all messages
* Also store a pending list that gets removed when an L2 block is published

todo: add test for the message store

Fixes #520 and is forward compatible with how the sequencer would integrate with these messages.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
