### PR TITLE
archiver stores confirmed messages, separate store for L2ToL1Messages, remove pending messages

### DIFF
--- a/yarn-project/archiver/src/archiver/l1_to_l2_message_store.test.ts
+++ b/yarn-project/archiver/src/archiver/l1_to_l2_message_store.test.ts
@@ -1,0 +1,85 @@
+import { Fr } from '@aztec/foundation/fields';
+import { L1ToL2MessageStore } from './l1_to_l2_message_store.js';
+import { L1Actor, L1ToL2Message, L2Actor } from '@aztec/types';
+
+describe('l1_to_l2_message_store', () => {
+  let store: L1ToL2MessageStore;
+  let entryKey: Fr;
+  let msg: L1ToL2Message;
+
+  beforeEach(() => {
+    // already adds a message to the store
+    store = new L1ToL2MessageStore();
+    entryKey = Fr.random();
+    msg = L1ToL2Message.random();
+  });
+
+  it('addMessage adds a message', () => {
+    store.addMessage(entryKey, msg);
+    expect(store.getMessage(entryKey)).toEqual(msg);
+  });
+
+  it('addMessage increments the count if the message is already in the store', () => {
+    store.addMessage(entryKey, msg);
+    store.addMessage(entryKey, msg);
+    expect(store.getMessageAndCount(entryKey)).toEqual({ message: msg, count: 2 });
+  });
+
+  it('removeMessage removes the message if the count is 1', () => {
+    store.addMessage(entryKey, msg);
+    store.removeMessage(entryKey);
+    expect(store.getMessage(entryKey)).toBeUndefined();
+  });
+
+  it("handles case when removing a message that doesn't exist", () => {
+    expect(() => store.removeMessage(new Fr(0))).not.toThrow();
+  });
+
+  it('removeMessage decrements the count if the message is already in the store', () => {
+    store.addMessage(entryKey, msg);
+    store.addMessage(entryKey, msg);
+    store.addMessage(entryKey, msg);
+    store.removeMessage(entryKey);
+    expect(store.getMessageAndCount(entryKey)).toEqual({ message: msg, count: 2 });
+  });
+
+  it('get messages for an empty store', () => {
+    const store = new L1ToL2MessageStore();
+    expect(store.getMessages(10)).toEqual([]);
+  });
+
+  it('getMessages returns an empty array if take is 0', () => {
+    store.addMessage(entryKey, msg);
+    expect(store.getMessages(0)).toEqual([]);
+  });
+
+  it('get messages for a non-empty store when take > number of messages in store', () => {
+    const store = new L1ToL2MessageStore();
+    const entryKeys = [1, 2, 3, 4, 5].map(x => new Fr(x));
+    entryKeys.forEach(entryKey => {
+      store.addMessage(entryKey, L1ToL2Message.random());
+    });
+    expect(store.getMessages(10).length).toEqual(5);
+  });
+
+  it('get messages returns messages sorted by fees and also includes multiple of the same message', () => {
+    const store = new L1ToL2MessageStore();
+    const entryKeys = [1, 2, 3, 3, 3, 4].map(x => new Fr(x));
+    entryKeys.forEach(entryKey => {
+      // set msg.fee to entryKey to test the sort.
+      const msg = new L1ToL2Message(
+        L1Actor.random(),
+        L2Actor.random(),
+        Fr.random(),
+        Fr.random(),
+        100,
+        Number(entryKey.value),
+        entryKey,
+      );
+      store.addMessage(entryKey, msg);
+    });
+    const expectedMessgeFees = [4, 3, 3, 3]; // the top 4.
+    const receivedMessageFees = store.getMessages(4).map(msg => msg.fee);
+    expect(receivedMessageFees).toEqual(expectedMessgeFees);
+  });
+});

--- a/yarn-project/archiver/src/archiver/l1_to_l2_message_store.ts
+++ b/yarn-project/archiver/src/archiver/l1_to_l2_message_store.ts
@@ -1,0 +1,79 @@
+import { Fr } from '@aztec/foundation/fields';
+import { L1ToL2Message } from '@aztec/types';
+
+/**
+ * A simple in-memory implementation of an L1 to L2 message store
+ * that handles message duplication.
+ */
+export class L1ToL2MessageStore {
+  /**
+   * A map containing the message key to the corresponding L1 to L2
+   * messages (and the number of times the message has been seen).
+   */
+  private store: Map<string, L1ToL2MessageAndCount> = new Map();
+
+  constructor() {}
+
+  addMessage(messageKey: Fr, msg: L1ToL2Message) {
+    const messageKeyStr = messageKey.toString();
+    if (this.store.has(messageKeyStr)) {
+      this.store.get(messageKeyStr)!.count++;
+    } else {
+      this.store.set(messageKeyStr, { message: msg, count: 1 });
+    }
+  }
+
+  removeMessage(messageKey: Fr) {
+    const messageKeyStr = messageKey.toString();
+    if (!this.store.has(messageKeyStr)) {
+      return;
+    }
+    const count = this.store.get(messageKeyStr)!.count;
+    if (count > 1) {
+      this.store.get(messageKeyStr)!.count--;
+    } else {
+      this.store.delete(messageKeyStr);
+    }
+  }
+
+  getMessage(messageKey: Fr): L1ToL2Message | undefined {
+    return this.store.get(messageKey.toString())?.message;
+  }
+
+  getMessageAndCount(messageKey: Fr): L1ToL2MessageAndCount | undefined {
+    return this.store.get(messageKey.toString());
+  }
+
+  getMessages(take: number): L1ToL2Message[] {
+    if (take < 1) {
+      return [];
+    }
+    // fetch `take` number of messages from the store with the highest fee.
+    // Note the store has multiple of the same message. So if a message has count 2, include both of them in the result:
+    const messages: L1ToL2Message[] = [];
+    const sortedMessages = Array.from(this.store.values()).sort((a, b) => b.message.fee - a.message.fee);
+    for (const messageAndCount of sortedMessages) {
+      for (let i = 0; i < messageAndCount.count; i++) {
+        messages.push(messageAndCount.message);
+        if (messages.length === take) {
+          return messages;
+        }
+      }
+    }
+    return messages;
+  }
+}
+
+/**
+ * Useful to keep track of the number of times a message has been seen.
+ */
+type L1ToL2MessageAndCount = {
+  /**
+   * The message.
+   */
+  message: L1ToL2Message;
+  /**
+   * The number of times the message has been seen.
+   */
+  count: number;
+};

--- a/yarn-project/archiver/src/archiver/l1_to_l2_message_store.ts
+++ b/yarn-project/archiver/src/archiver/l1_to_l2_message_store.ts
@@ -16,8 +16,10 @@ export class L1ToL2MessageStore {
 
   addMessage(messageKey: Fr, msg: L1ToL2Message) {
     const messageKeyBigInt = messageKey.value;
-    if (this.store.has(messageKeyBigInt)) {
-      this.store.get(messageKeyBigInt)!.count++;
+    const msgAndCount = this.store.get(messageKeyBigInt);
+    if (msgAndCount) {
+      msgAndCount.count++;
+      this.store.set(messageKeyBigInt, msgAndCount);
     } else {
       this.store.set(messageKeyBigInt, { message: msg, count: 1 });
     }
@@ -25,12 +27,13 @@ export class L1ToL2MessageStore {
 
   removeMessage(messageKey: Fr) {
     const messageKeyBigInt = messageKey.value;
-    if (!this.store.has(messageKeyBigInt)) {
+    const msgAndCount = this.store.get(messageKeyBigInt);
+    if (!msgAndCount) {
       return;
     }
-    const count = this.store.get(messageKeyBigInt)!.count;
-    if (count > 1) {
-      this.store.get(messageKeyBigInt)!.count--;
+    if (msgAndCount.count > 1) {
+      msgAndCount.count--;
+      this.store.set(messageKeyBigInt, msgAndCount);
     } else {
       this.store.delete(messageKeyBigInt);
     }

--- a/yarn-project/archiver/src/archiver/l1_to_l2_message_store.ts
+++ b/yarn-project/archiver/src/archiver/l1_to_l2_message_store.ts
@@ -19,7 +19,6 @@ export class L1ToL2MessageStore {
     const msgAndCount = this.store.get(messageKeyBigInt);
     if (msgAndCount) {
       msgAndCount.count++;
-      this.store.set(messageKeyBigInt, msgAndCount);
     } else {
       this.store.set(messageKeyBigInt, { message: msg, count: 1 });
     }
@@ -33,7 +32,6 @@ export class L1ToL2MessageStore {
     }
     if (msgAndCount.count > 1) {
       msgAndCount.count--;
-      this.store.set(messageKeyBigInt, msgAndCount);
     } else {
       this.store.delete(messageKeyBigInt);
     }

--- a/yarn-project/archiver/src/archiver/l1_to_l2_message_store.ts
+++ b/yarn-project/archiver/src/archiver/l1_to_l2_message_store.ts
@@ -10,38 +10,38 @@ export class L1ToL2MessageStore {
    * A map containing the message key to the corresponding L1 to L2
    * messages (and the number of times the message has been seen).
    */
-  private store: Map<string, L1ToL2MessageAndCount> = new Map();
+  private store: Map<bigint, L1ToL2MessageAndCount> = new Map();
 
   constructor() {}
 
   addMessage(messageKey: Fr, msg: L1ToL2Message) {
-    const messageKeyStr = messageKey.toString();
-    if (this.store.has(messageKeyStr)) {
-      this.store.get(messageKeyStr)!.count++;
+    const messageKeyBigInt = messageKey.value;
+    if (this.store.has(messageKeyBigInt)) {
+      this.store.get(messageKeyBigInt)!.count++;
     } else {
-      this.store.set(messageKeyStr, { message: msg, count: 1 });
+      this.store.set(messageKeyBigInt, { message: msg, count: 1 });
     }
   }
 
   removeMessage(messageKey: Fr) {
-    const messageKeyStr = messageKey.toString();
-    if (!this.store.has(messageKeyStr)) {
+    const messageKeyBigInt = messageKey.value;
+    if (!this.store.has(messageKeyBigInt)) {
       return;
     }
-    const count = this.store.get(messageKeyStr)!.count;
+    const count = this.store.get(messageKeyBigInt)!.count;
     if (count > 1) {
-      this.store.get(messageKeyStr)!.count--;
+      this.store.get(messageKeyBigInt)!.count--;
     } else {
-      this.store.delete(messageKeyStr);
+      this.store.delete(messageKeyBigInt);
     }
   }
 
   getMessage(messageKey: Fr): L1ToL2Message | undefined {
-    return this.store.get(messageKey.toString())?.message;
+    return this.store.get(messageKey.value)?.message;
   }
 
   getMessageAndCount(messageKey: Fr): L1ToL2MessageAndCount | undefined {
-    return this.store.get(messageKey.toString());
+    return this.store.get(messageKey.value);
   }
 
   getMessages(take: number): L1ToL2Message[] {

--- a/yarn-project/types/src/l1_to_l2_message.ts
+++ b/yarn-project/types/src/l1_to_l2_message.ts
@@ -15,6 +15,14 @@ export interface L1ToL2MessageSource {
    * @returns The requested L1 to L2 messages.
    */
   getPendingL1ToL2Messages(take: number): Promise<L1ToL2Message[]>;
+
+  /**
+   * Gets the confirmed L1 to L2 message with the given message key.
+   * i.e. message that has already been consumed by the sequencer and published in an L2 Block
+   * @param messageKey - The message key.
+   * @returns The confirmed L1 to L2 message (throws if not found)
+   */
+  getConfirmedL1ToL2Message(messageKey: Fr): Promise<L1ToL2Message>;
 }
 
 /**
@@ -48,14 +56,9 @@ export class L1ToL2Message {
     public readonly fee: number,
     /**
      * The entry key for the message - optional.
-     * If not provided, it will be calculated by hashing the message (similar to the Inbox contract)
      */
     public readonly entryKey?: Fr,
-  ) {
-    if (!entryKey) {
-      this.entryKey = this.hash();
-    }
-  }
+  ) {}
 
   // TODO: (#646) - sha256 hash of the message packed the same as solidity
   hash(): Fr {
@@ -86,6 +89,17 @@ export class L1ToL2Message {
   static empty(): L1ToL2Message {
     return new L1ToL2Message(L1Actor.empty(), L2Actor.empty(), Fr.ZERO, Fr.ZERO, 0, 0);
   }
+
+  static random(): L1ToL2Message {
+    return new L1ToL2Message(
+      L1Actor.random(),
+      L2Actor.random(),
+      Fr.random(),
+      Fr.random(),
+      Math.floor(Math.random() * 1000),
+      Math.floor(Math.random() * 1000),
+    );
+  }
 }
 
 /**
@@ -114,6 +128,10 @@ export class L1Actor {
   toBuffer(): Buffer {
     return serializeToBuffer(this.sender, this.chainId);
   }
+
+  static random(): L1Actor {
+    return new L1Actor(EthAddress.random(), Math.floor(Math.random() * 1000));
+  }
 }
 
 /**
@@ -141,5 +159,9 @@ export class L2Actor {
 
   toBuffer(): Buffer {
     return serializeToBuffer(this.recipient, this.version);
+  }
+
+  static random(): L2Actor {
+    return new L2Actor(AztecAddress.random(), Math.floor(Math.random() * 1000));
   }
 }


### PR DESCRIPTION
# Description

* Fix #691
* Fix #520
* Separate storage for pending and confirmed messages and create getter functions for these
* Also create a simple storage class for l2 to l1 messages
* tests

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
