### PR TITLE
sequencer integration with L1 -> L2

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -302,10 +302,10 @@ export class Archiver implements L2BlockSource, UnverifiedDataSource, ContractDa
   /**
    * Gets the `take` amount of pending L1 to L2 messages.
    * @param take - The number of messages to return.
-   * @returns The requested L1 to L2 messages.
+   * @returns The requested L1 to L2 messages' keys.
    */
-  getPendingL1ToL2Messages(take: number): Promise<L1ToL2Message[]> {
-    return this.store.getPendingL1ToL2Messages(take);
+  getPendingL1ToL2Messages(take: number): Promise<Fr[]> {
+    return this.store.getPendingL1ToL2MessageKeys(take);
   }
 
   /**

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -20,7 +20,7 @@ export interface ArchiverDataStore {
   addUnverifiedData(data: UnverifiedData[]): Promise<boolean>;
   addPendingL1ToL2Messages(messages: L1ToL2Message[]): Promise<boolean>;
   confirmL1ToL2Messages(messageKeys: Fr[]): Promise<boolean>;
-  getPendingL1ToL2Messages(take: number): Promise<L1ToL2Message[]>;
+  getPendingL1ToL2MessageKeys(take: number): Promise<Fr[]>;
   getConfirmedL1ToL2Message(messageKey: Fr): Promise<L1ToL2Message>;
   getUnverifiedData(from: number, take: number): Promise<UnverifiedData[]>;
   addL2ContractPublicData(data: ContractPublicData[], blockNum: number): Promise<boolean>;
@@ -142,12 +142,12 @@ export class MemoryArchiverStore implements ArchiverDataStore {
   }
 
   /**
-   * Gets the `take` amount of pending L1 to L2 messages.
+   * Gets the `take` amount of pending L1 to L2 messages, sorted by fee
    * @param take - The number of messages to return (by default NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).
-   * @returns The requested L1 to L2 messages.
+   * @returns The requested L1 to L2 message keys.
    */
-  public getPendingL1ToL2Messages(take: number = NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP): Promise<L1ToL2Message[]> {
-    return Promise.resolve(this.pendingL1ToL2Messages.getMessages(take));
+  public getPendingL1ToL2MessageKeys(take: number = NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP): Promise<Fr[]> {
+    return Promise.resolve(this.pendingL1ToL2Messages.getMessageKeys(take));
   }
 
   /**

--- a/yarn-project/archiver/src/archiver/l1_to_l2_message_store.test.ts
+++ b/yarn-project/archiver/src/archiver/l1_to_l2_message_store.test.ts
@@ -45,12 +45,12 @@ describe('l1_to_l2_message_store', () => {
 
   it('get messages for an empty store', () => {
     const store = new L1ToL2MessageStore();
-    expect(store.getMessages(10)).toEqual([]);
+    expect(store.getMessageKeys(10)).toEqual([]);
   });
 
-  it('getMessages returns an empty array if take is 0', () => {
+  it('getMessageKeys returns an empty array if take is 0', () => {
     store.addMessage(entryKey, msg);
-    expect(store.getMessages(0)).toEqual([]);
+    expect(store.getMessageKeys(0)).toEqual([]);
   });
 
   it('get messages for a non-empty store when take > number of messages in store', () => {
@@ -59,7 +59,7 @@ describe('l1_to_l2_message_store', () => {
     entryKeys.forEach(entryKey => {
       store.addMessage(entryKey, L1ToL2Message.random());
     });
-    expect(store.getMessages(10).length).toEqual(5);
+    expect(store.getMessageKeys(10).length).toEqual(5);
   });
 
   it('get messages returns messages sorted by fees and also includes multiple of the same message', () => {
@@ -78,8 +78,8 @@ describe('l1_to_l2_message_store', () => {
       );
       store.addMessage(entryKey, msg);
     });
-    const expectedMessgeFees = [4, 3, 3, 3]; // the top 4.
-    const receivedMessageFees = store.getMessages(4).map(msg => msg.fee);
+    const expectedMessgeFees = [4n, 3n, 3n, 3n]; // the top 4.
+    const receivedMessageFees = store.getMessageKeys(4).map(key => key.value);
     expect(receivedMessageFees).toEqual(expectedMessgeFees);
   });
 });

--- a/yarn-project/archiver/src/archiver/l1_to_l2_message_store.ts
+++ b/yarn-project/archiver/src/archiver/l1_to_l2_message_store.ts
@@ -45,17 +45,17 @@ export class L1ToL2MessageStore {
     return this.store.get(messageKey.value);
   }
 
-  getMessages(take: number): L1ToL2Message[] {
+  getMessageKeys(take: number): Fr[] {
     if (take < 1) {
       return [];
     }
     // fetch `take` number of messages from the store with the highest fee.
     // Note the store has multiple of the same message. So if a message has count 2, include both of them in the result:
-    const messages: L1ToL2Message[] = [];
+    const messages: Fr[] = [];
     const sortedMessages = Array.from(this.store.values()).sort((a, b) => b.message.fee - a.message.fee);
     for (const messageAndCount of sortedMessages) {
       for (let i = 0; i < messageAndCount.count; i++) {
-        messages.push(messageAndCount.message);
+        messages.push(messageAndCount.message.entryKey!);
         if (messages.length === take) {
           return messages;
         }

--- a/yarn-project/aztec-node/src/aztec-node/aztec-node.ts
+++ b/yarn-project/aztec-node/src/aztec-node/aztec-node.ts
@@ -1,6 +1,6 @@
 import { CONTRACT_TREE_HEIGHT, L1_TO_L2_MESSAGES_TREE_HEIGHT, PRIVATE_DATA_TREE_HEIGHT } from '@aztec/circuits.js';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
-import { ContractPublicData, ContractData, L2Block, MerkleTreeId } from '@aztec/types';
+import { ContractPublicData, ContractData, L2Block, MerkleTreeId, L1ToL2Message } from '@aztec/types';
 import { SiblingPath } from '@aztec/merkle-tree';
 import { Tx, TxHash } from '@aztec/types';
 import { UnverifiedData } from '@aztec/types';
@@ -93,6 +93,20 @@ export interface AztecNode {
    * @returns The sibling path for the leaf index.
    */
   getDataTreePath(leafIndex: bigint): Promise<SiblingPath<typeof PRIVATE_DATA_TREE_HEIGHT>>;
+
+  /**
+   * Find the index of the relevant l1 to l2 message.
+   * @param leafValue - The value to search for.
+   * @returns The index of the given leaf in the l1 to l2 message tree or undefined if not found.
+   */
+  findL1ToL2MessageIndex(leafValue: Buffer): Promise<bigint | undefined>;
+
+  /**
+   * Gets a consumed/confirmed L1 to L2 message for the given message key.
+   * @param messageKey - The message key.
+   * @returns the message (or throws if not found)
+   */
+  getL1ToL2Message(messageKey: Fr): Promise<L1ToL2Message>;
 
   /**
    * Returns the sibling path for a leaf in the committed l1 to l2 data tree.

--- a/yarn-project/aztec-node/src/aztec-node/aztec-node.ts
+++ b/yarn-project/aztec-node/src/aztec-node/aztec-node.ts
@@ -95,18 +95,12 @@ export interface AztecNode {
   getDataTreePath(leafIndex: bigint): Promise<SiblingPath<typeof PRIVATE_DATA_TREE_HEIGHT>>;
 
   /**
-   * Find the index of the relevant l1 to l2 message.
-   * @param leafValue - The value to search for.
-   * @returns The index of the given leaf in the l1 to l2 message tree or undefined if not found.
-   */
-  findL1ToL2MessageIndex(leafValue: Buffer): Promise<bigint | undefined>;
-
-  /**
-   * Gets a consumed/confirmed L1 to L2 message for the given message key.
+   * Gets a confirmed/consumed L1 to L2 message for the given message key (throws if not found).
+   * and its index in the merkle tree
    * @param messageKey - The message key.
-   * @returns the message (or throws if not found)
+   * @returns The map containing the message and index.
    */
-  getL1ToL2Message(messageKey: Fr): Promise<L1ToL2Message>;
+  getL1ToL2MessageAndIndex(messageKey: Fr): Promise<L1ToL2MessageAndIndex>;
 
   /**
    * Returns the sibling path for a leaf in the committed l1 to l2 data tree.
@@ -129,3 +123,17 @@ export interface AztecNode {
    */
   getTreeRoots(): Promise<Record<MerkleTreeId, Fr>>;
 }
+
+/**
+ * L1AndL2Message and Index (in the merkle tree) as one type
+ */
+export type L1ToL2MessageAndIndex = {
+  /**
+   * The message.
+   */
+  message: L1ToL2Message;
+  /**
+   * the index in the L1 to L2 Message tree.
+   */
+  index: bigint;
+};

--- a/yarn-project/aztec-node/src/aztec-node/http-node.ts
+++ b/yarn-project/aztec-node/src/aztec-node/http-node.ts
@@ -1,4 +1,4 @@
-import { AztecNode } from '@aztec/aztec-node';
+import { AztecNode, L1ToL2MessageAndIndex } from '@aztec/aztec-node';
 import {
   AztecAddress,
   CONTRACT_TREE_HEIGHT,
@@ -15,6 +15,7 @@ import {
   ContractData,
   ContractPublicData,
   EncodedContractFunction,
+  L1ToL2Message,
   L2Block,
   MerkleTreeId,
   Tx,
@@ -238,6 +239,21 @@ export class HttpNode implements AztecNode {
     const response = await (await fetch(url.toString())).json();
     const path = response.path as string;
     return Promise.resolve(SiblingPath.fromString(path));
+  }
+
+  /**
+   * Gets a consumed/confirmed L1 to L2 message for the given message key and its index in the merkle tree.
+   * @param messageKey - The message key.
+   * @returns the message (or throws if not found)
+   */
+  async getL1ToL2MessageAndIndex(messageKey: Fr): Promise<L1ToL2MessageAndIndex> {
+    const url = new URL(`${this.baseUrl}/l1-l2-message-and-index`);
+    url.searchParams.append('messageKey', messageKey.toString());
+    const response = await (await fetch(url.toString())).json();
+    return Promise.resolve({
+      message: L1ToL2Message.fromBuffer(Buffer.from(response.message as string, 'hex')),
+      index: BigInt(response.index as string),
+    });
   }
 
   /**

--- a/yarn-project/aztec-rpc/src/simulator_oracle/index.ts
+++ b/yarn-project/aztec-rpc/src/simulator_oracle/index.ts
@@ -5,7 +5,6 @@ import { KeyPair } from '@aztec/key-store';
 import { FunctionAbi } from '@aztec/foundation/abi';
 import { ContractDataOracle } from '../contract_data_oracle/index.js';
 import { Database } from '../database/index.js';
-import { L1ToL2Message } from '@aztec/types';
 
 /**
  * A data oracle that provides information needed for simulating a transaction.
@@ -87,19 +86,17 @@ export class SimulatorOracle implements DBOracle {
     return await this.contractDataOracle.getPortalContractAddress(contractAddress);
   }
 
-  // TODO: currently stubbed will be implemented in: https://github.com/AztecProtocol/aztec-packages/issues/529
   /**
    * Retreives the L1ToL2Message associated with a specific message key
+   * Throws an error if the message key is not found
    *
    * @param msgKey - The key of the message to be retreived
    * @returns A promise that resolves to the message data, a sibling path and the
    *          index of the message in the the l1ToL2MessagesTree
    */
   async getL1ToL2Message(msgKey: Fr): Promise<MessageLoadOracleInputs> {
-    void msgKey; // this line can be removed its to appease the linter on this stub
-    const message = L1ToL2Message.empty().toFieldArray();
-    // TODO: note index will be requested from the database, stubbed as 0 for the meantime
-    const index = 0n;
+    const message = (await this.node.getL1ToL2Message(msgKey)).toFieldArray();
+    const index = (await this.node.findL1ToL2MessageIndex(msgKey.toBuffer()))!;
     const siblingPath = await this.node.getL1ToL2MessagesTreePath(index);
     return {
       message,

--- a/yarn-project/aztec-rpc/src/simulator_oracle/index.ts
+++ b/yarn-project/aztec-rpc/src/simulator_oracle/index.ts
@@ -95,8 +95,9 @@ export class SimulatorOracle implements DBOracle {
    *          index of the message in the the l1ToL2MessagesTree
    */
   async getL1ToL2Message(msgKey: Fr): Promise<MessageLoadOracleInputs> {
-    const message = (await this.node.getL1ToL2Message(msgKey)).toFieldArray();
-    const index = (await this.node.findL1ToL2MessageIndex(msgKey.toBuffer()))!;
+    const messageAndIndex = await this.node.getL1ToL2MessageAndIndex(msgKey);
+    const message = messageAndIndex.message.toFieldArray();
+    const index = messageAndIndex.index;
     const siblingPath = await this.node.getL1ToL2MessagesTreePath(index);
     return {
       message,

--- a/yarn-project/end-to-end/src/e2e_consume_l1_to_l2_msg.test.ts
+++ b/yarn-project/end-to-end/src/e2e_consume_l1_to_l2_msg.test.ts
@@ -50,6 +50,7 @@ describe.skip('e2e_l1_to_l2_msg', () => {
     const privKey = account.getHdKey().privateKey;
     const {
       rollupAddress,
+      inboxAddress,
       registryAddress: registryAddress_,
       unverifiedDataEmitterAddress,
       walletClient,
@@ -60,6 +61,7 @@ describe.skip('e2e_l1_to_l2_msg', () => {
 
     config.publisherPrivateKey = Buffer.from(privKey!);
     config.rollupContract = rollupAddress;
+    config.inboxContract = inboxAddress;
     config.unverifiedDataEmitterContract = unverifiedDataEmitterAddress;
 
     // Deploy portal contracts

--- a/yarn-project/rollup-provider/src/app.ts
+++ b/yarn-project/rollup-provider/src/app.ts
@@ -151,6 +151,17 @@ export function appFactory(node: AztecNode, prefix: string) {
     ctx.status = 200;
   });
 
+  router.get('/l1-l2-message-and-index', async (ctx: Koa.Context) => {
+    const key = ctx.query.messageKey!;
+    const messageAndindex = await node.getL1ToL2MessageAndIndex(Fr.fromString(key as string));
+    ctx.set('content-type', 'application/json');
+    ctx.body = {
+      message: messageAndindex.message.toBuffer().toString('hex'),
+      index: messageAndindex.index,
+    };
+    ctx.status = 200;
+  });
+
   router.get('/l1-l2-path', async (ctx: Koa.Context) => {
     const leaf = ctx.query.leaf!;
     const path = await node.getL1ToL2MessagesTreePath(BigInt(leaf as string));

--- a/yarn-project/sequencer-client/src/block_builder/solo_block_builder.ts
+++ b/yarn-project/sequencer-client/src/block_builder/solo_block_builder.ts
@@ -41,6 +41,7 @@ import { assertLength } from '@aztec/foundation/serialize';
 import { ProcessedTx } from '../sequencer/processed_tx.js';
 import { BlockBuilder } from './index.js';
 import { AllowedTreeNames, OutputWithTreeSnapshot } from './types.js';
+import { padArrayEnd } from '@aztec/foundation/collection';
 
 const frToBigInt = (fr: Fr) => toBigIntBE(fr.toBuffer());
 const bigintToFr = (num: bigint) => new Fr(num);
@@ -195,12 +196,8 @@ export class SoloBlockBuilder implements BlockBuilder {
       throw new Error(`Length of txs for the block should be a power of two and at least four (got ${txs.length})`);
     }
 
-    // Check that the number of new L1 to L2 messages is the same as the max
-    if (newL1ToL2Messages.length !== NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP) {
-      throw new Error(
-        `Length of the l1 to l2 messages per block should be a constant ${NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP} (got ${newL1ToL2Messages.length})`,
-      );
-    }
+    // padArrayEnd throws if the array is already full. Otherwise it pads till we reach the required size
+    newL1ToL2Messages = padArrayEnd(newL1ToL2Messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
 
     // Run the base rollup circuits for the txs
     const baseRollupOutputs: [BaseOrMergeRollupPublicInputs, Proof][] = [];

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -1,7 +1,7 @@
 import { P2P } from '@aztec/p2p';
 import { WorldStateSynchroniser } from '@aztec/world-state';
 
-import { ContractDataSource, L2BlockSource } from '@aztec/types';
+import { ContractDataSource, L1ToL2MessageSource, L2BlockSource } from '@aztec/types';
 import { SoloBlockBuilder } from '../block_builder/solo_block_builder.js';
 import { SequencerClientConfig } from '../config.js';
 import { getL1Publisher, getVerificationKeys, Sequencer } from '../index.js';
@@ -22,6 +22,7 @@ export class SequencerClient {
    * @param worldStateSynchroniser - Provides access to world state.
    * @param contractDataSource - Provides access to contract bytecode for public executions.
    * @param l2BlockSource - Provides information about the previously published blocks.
+   * @param l1ToL2MessageSource - Provides access to L1 to L2 messages.
    * @returns A new running instance.
    */
   public static async new(
@@ -30,6 +31,7 @@ export class SequencerClient {
     worldStateSynchroniser: WorldStateSynchroniser,
     contractDataSource: ContractDataSource,
     l2BlockSource: L2BlockSource,
+    l1ToL2MessageSource: L1ToL2MessageSource,
   ) {
     const publisher = getL1Publisher(config);
     const merkleTreeDb = worldStateSynchroniser.getLatest();
@@ -49,6 +51,7 @@ export class SequencerClient {
       worldStateSynchroniser,
       blockBuilder,
       l2BlockSource,
+      l1ToL2MessageSource,
       publicProcessorFactory,
       config,
     );

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -1,6 +1,6 @@
 import { CombinedHistoricTreeRoots, Fr, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, makeEmptyProof } from '@aztec/circuits.js';
 import { P2P, P2PClientState } from '@aztec/p2p';
-import { L2Block, L2BlockSource, MerkleTreeId, PrivateTx, Tx, UnverifiedData } from '@aztec/types';
+import { L1ToL2MessageSource, L2Block, L2BlockSource, MerkleTreeId, PrivateTx, Tx, UnverifiedData } from '@aztec/types';
 import { MerkleTreeOperations, WorldStateRunningState, WorldStateSynchroniser } from '@aztec/world-state';
 import { MockProxy, mock } from 'jest-mock-extended';
 import times from 'lodash.times';
@@ -18,6 +18,7 @@ describe('sequencer', () => {
   let merkleTreeOps: MockProxy<MerkleTreeOperations>;
   let publicProcessor: MockProxy<PublicProcessor>;
   let l2BlockSource: MockProxy<L2BlockSource>;
+  let l1ToL2MessageSource: MockProxy<L1ToL2MessageSource>;
   let publicProcessorFactory: MockProxy<PublicProcessorFactory>;
 
   let lastBlockNumber: number;
@@ -53,7 +54,19 @@ describe('sequencer', () => {
       getBlockHeight: () => Promise.resolve(lastBlockNumber),
     });
 
-    sequencer = new TestSubject(publisher, p2p, worldState, blockBuilder, l2BlockSource, publicProcessorFactory);
+    l1ToL2MessageSource = mock<L1ToL2MessageSource>({
+      getPendingL1ToL2Messages: () => Promise.resolve(Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(Fr.ZERO)),
+    });
+
+    sequencer = new TestSubject(
+      publisher,
+      p2p,
+      worldState,
+      blockBuilder,
+      l2BlockSource,
+      l1ToL2MessageSource,
+      publicProcessorFactory,
+    );
   });
 
   it('builds a block out of a single tx', async () => {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -1,4 +1,3 @@
-import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/circuits.js';
 import { Fr } from '@aztec/foundation/fields';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
@@ -6,13 +5,14 @@ import { P2P } from '@aztec/p2p';
 import {
   ContractData,
   ContractPublicData,
+  L1ToL2MessageSource,
+  L2Block,
   MerkleTreeId,
   PrivateTx,
   PublicTx,
   Tx,
   UnverifiedData,
   isPrivateTx,
-  L2Block,
   L2BlockSource,
 } from '@aztec/types';
 import { WorldStateStatus, WorldStateSynchroniser } from '@aztec/world-state';
@@ -47,6 +47,7 @@ export class Sequencer {
     private worldState: WorldStateSynchroniser,
     private blockBuilder: BlockBuilder,
     private l2BlockSource: L2BlockSource,
+    private l1ToL2MessageSource: L1ToL2MessageSource,
     private publicProcessorFactory: PublicProcessorFactory,
     config?: SequencerConfig,
     private log = createDebugLogger('aztec:sequencer'),
@@ -150,7 +151,7 @@ export class Sequencer {
 
       // Get l1 to l2 messages from the contract
       this.log('Requesting L1 to L2 messages from contract');
-      const l1ToL2Messages = this.takeL1ToL2MessagesFromContract();
+      const l1ToL2Messages = await this.consumePendingL1ToL2Messages();
       this.log('Successfully retrieved L1 to L2 messages from contract');
 
       // Build the new block by running the rollup circuits
@@ -296,12 +297,12 @@ export class Sequencer {
   }
 
   /**
-   * Checks on chain messages inbox and selects messages to inlcude within the next rollup block.
-   * TODO: This is a stubbed method.
-   * @returns An array of L1 to L2 messages.
+   * Calls the archiver to pull upto `NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP` message keys
+   * (archiver returns the top messages sorted by fees)
+   * @returns An array of L1 to L2 messages' messageKeys
    */
-  protected takeL1ToL2MessagesFromContract(): Fr[] {
-    return new Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n));
+  protected async consumePendingL1ToL2Messages(): Promise<Fr[]> {
+    return await this.l1ToL2MessageSource.getPendingL1ToL2Messages();
   }
 
   /**

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -151,7 +151,7 @@ export class Sequencer {
 
       // Get l1 to l2 messages from the contract
       this.log('Requesting L1 to L2 messages from contract');
-      const l1ToL2Messages = await this.consumePendingL1ToL2Messages();
+      const l1ToL2Messages = await this.getPendingL1ToL2Messages();
       this.log('Successfully retrieved L1 to L2 messages from contract');
 
       // Build the new block by running the rollup circuits
@@ -301,7 +301,7 @@ export class Sequencer {
    * (archiver returns the top messages sorted by fees)
    * @returns An array of L1 to L2 messages' messageKeys
    */
-  protected async consumePendingL1ToL2Messages(): Promise<Fr[]> {
+  protected async getPendingL1ToL2Messages(): Promise<Fr[]> {
     return await this.l1ToL2MessageSource.getPendingL1ToL2Messages();
   }
 

--- a/yarn-project/types/src/l1_to_l2_message.test.ts
+++ b/yarn-project/types/src/l1_to_l2_message.test.ts
@@ -1,0 +1,10 @@
+import { L1ToL2Message } from './l1_to_l2_message.js';
+
+describe('L1 to L2 message', () => {
+  it('can encode an L1 to L2 message to buffer and back', () => {
+    const msg = L1ToL2Message.random();
+    const buffer = msg.toBuffer();
+    const recovered = L1ToL2Message.fromBuffer(buffer);
+    expect(recovered).toEqual(msg);
+  });
+});

--- a/yarn-project/types/src/l1_to_l2_message.ts
+++ b/yarn-project/types/src/l1_to_l2_message.ts
@@ -10,11 +10,11 @@ import { toBigIntBE, toBufferBE } from '@aztec/foundation/bigint-buffer';
  */
 export interface L1ToL2MessageSource {
   /**
-   * Gets the `take` amount of pending L1 to L2 messages.
-   * @param take - The number of messages to return.
-   * @returns The requested L1 to L2 messages.
+   * Gets the `take` amount of pending L1 to L2 messages, sorted by fee
+   * @param take - The number of messages to return (by default NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).
+   * @returns The requested L1 to L2 messages' keys.
    */
-  getPendingL1ToL2Messages(take: number): Promise<L1ToL2Message[]>;
+  getPendingL1ToL2Messages(take?: number): Promise<Fr[]>;
 
   /**
    * Gets the confirmed L1 to L2 message with the given message key.

--- a/yarn-project/types/src/l1_to_l2_message.ts
+++ b/yarn-project/types/src/l1_to_l2_message.ts
@@ -1,7 +1,7 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
-import { serializeToBuffer } from '@aztec/circuits.js/utils';
+import { BufferReader, serializeToBuffer } from '@aztec/circuits.js/utils';
 import { sha256 } from '@aztec/foundation/crypto';
 import { toBigIntBE, toBufferBE } from '@aztec/foundation/bigint-buffer';
 
@@ -86,6 +86,17 @@ export class L1ToL2Message {
     return serializeToBuffer(this.sender, this.recipient, this.content, this.secretHash, this.deadline, this.fee);
   }
 
+  static fromBuffer(buffer: Buffer | BufferReader): L1ToL2Message {
+    const reader = BufferReader.asReader(buffer);
+    const sender = reader.readObject(L1Actor);
+    const recipient = reader.readObject(L2Actor);
+    const content = reader.readFr();
+    const secretHash = reader.readFr();
+    const deadline = reader.readNumber();
+    const fee = reader.readNumber();
+    return new L1ToL2Message(sender, recipient, content, secretHash, deadline, fee);
+  }
+
   static empty(): L1ToL2Message {
     return new L1ToL2Message(L1Actor.empty(), L2Actor.empty(), Fr.ZERO, Fr.ZERO, 0, 0);
   }
@@ -129,6 +140,13 @@ export class L1Actor {
     return serializeToBuffer(this.sender, this.chainId);
   }
 
+  static fromBuffer(buffer: Buffer | BufferReader): L1Actor {
+    const reader = BufferReader.asReader(buffer);
+    const ethAddr = new EthAddress(reader.readBytes(32));
+    const chainId = reader.readNumber();
+    return new L1Actor(ethAddr, chainId);
+  }
+
   static random(): L1Actor {
     return new L1Actor(EthAddress.random(), Math.floor(Math.random() * 1000));
   }
@@ -159,6 +177,13 @@ export class L2Actor {
 
   toBuffer(): Buffer {
     return serializeToBuffer(this.recipient, this.version);
+  }
+
+  static fromBuffer(buffer: Buffer | BufferReader): L2Actor {
+    const reader = BufferReader.asReader(buffer);
+    const aztecAddr = AztecAddress.fromBuffer(reader);
+    const version = reader.readNumber();
+    return new L2Actor(aztecAddr, version);
   }
 
   static random(): L2Actor {


### PR DESCRIPTION
# Description
Fixes #529  (builds on #520 and #691)
* Archiver returns a list of pending message keys sorted by fees
* Archiver can also return a confirmed message given a key (useful for noir oracle calls)
* To implement the noir oracle call, aztec node has appropriate getter functions
* oracle call now fetches the appropriate message and the message index in the L1_TO_L2_MESSAGE_TREE
* Sequencer now calls the archiver to fetch pending messages to consume them in a l2 block (appropriate L1ToL2MessageSource interface was implemented)

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
