### PR TITLE
Move deployment contract logic in Private Kernel Circuit

### DIFF
--- a/circuits/cpp/src/aztec3/circuits/hash.hpp
+++ b/circuits/cpp/src/aztec3/circuits/hash.hpp
@@ -58,7 +58,7 @@ template <typename NCT> typename NCT::address compute_contract_address(typename 
 }
 
 template <typename NCT>
-typename NCT::fr add_contract_address_to_commitment(typename NCT::address contract_address, typename NCT::fr commitment)
+typename NCT::fr silo_commitment(typename NCT::address contract_address, typename NCT::fr commitment)
 {
     using fr = typename NCT::fr;
 
@@ -71,7 +71,7 @@ typename NCT::fr add_contract_address_to_commitment(typename NCT::address contra
 }
 
 template <typename NCT>
-typename NCT::fr add_contract_address_to_nullifier(typename NCT::address contract_address, typename NCT::fr nullifier)
+typename NCT::fr silo_nullifier(typename NCT::address contract_address, typename NCT::fr nullifier)
 {
     using fr = typename NCT::fr;
 

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/.test.cpp
@@ -37,21 +37,21 @@ namespace {
 using aztec3::circuits::compute_empty_sibling_path;
 using aztec3::circuits::abis::CallContext;
 using aztec3::circuits::abis::CallStackItem;
+using aztec3::circuits::abis::CombinedAccumulatedData;
+using aztec3::circuits::abis::CombinedConstantData;
+using aztec3::circuits::abis::CombinedHistoricTreeRoots;
 using aztec3::circuits::abis::ContractDeploymentData;
 using aztec3::circuits::abis::FunctionData;
 using aztec3::circuits::abis::FunctionLeafPreimage;
+using aztec3::circuits::abis::KernelCircuitPublicInputs;
 using aztec3::circuits::abis::NewContractData;
 using aztec3::circuits::abis::OptionalPrivateCircuitPublicInputs;
 using aztec3::circuits::abis::PrivateCircuitPublicInputs;
+using aztec3::circuits::abis::PrivateHistoricTreeRoots;
 using aztec3::circuits::abis::PrivateTypes;
 using aztec3::circuits::abis::SignedTxRequest;
 using aztec3::circuits::abis::TxContext;
 using aztec3::circuits::abis::TxRequest;
-
-using aztec3::circuits::abis::CombinedConstantData;
-using aztec3::circuits::abis::CombinedHistoricTreeRoots;
-using aztec3::circuits::abis::KernelCircuitPublicInputs;
-using aztec3::circuits::abis::PrivateHistoricTreeRoots;
 using aztec3::circuits::abis::private_kernel::PrivateCallData;
 using aztec3::circuits::abis::private_kernel::PrivateKernelInputsInner;
 
@@ -491,6 +491,11 @@ void validate_deployed_contract_address(PrivateKernelInputsInit<NT> const& priva
     EXPECT_EQ(public_inputs.end.new_contracts[0].contract_address.to_field(), expected_contract_address);
 }
 
+void validate_no_new_deployed_contract(KernelCircuitPublicInputs<NT> const& public_inputs)
+{
+    ASSERT_TRUE(public_inputs.end.new_contracts == CombinedAccumulatedData<NT>{}.new_contracts);
+}
+
 /**
  * @brief Some private circuit proof (`deposit`, in this case)
  */
@@ -513,6 +518,12 @@ TEST(private_kernel_tests, circuit_deposit)
     auto const& private_inputs_init =
         do_private_call_get_kernel_inputs_init(false, deposit, { amount, asset_id, memo });
 
+    // TODO(jeanmon): Once we have an inner/init private kernel circuit,
+    // there should not be any new deployed contract address in public_inputs
+    // and the following assertion can be uncommented:
+    // validate_no_new_deployed_contract(public_inputs);
+
+    // TODO(jeanmon): Remove once we have an inner/innit private kernel circuit
     // Check contract address was correctly computed by the circuit
     validate_deployed_contract_address(private_inputs_init, public_inputs);
 
@@ -540,7 +551,7 @@ TEST(private_kernel_tests, native_deposit)
     DummyComposer composer = DummyComposer("private_kernel_tests__native_deposit");
     auto const& public_inputs = native_private_kernel_circuit_initial(composer, private_inputs);
 
-    validate_deployed_contract_address(private_inputs, public_inputs);
+    validate_no_new_deployed_contract(public_inputs);
 
     // Check the first nullifier is hash of the signed tx request
     ASSERT_EQ(public_inputs.end.new_nullifiers[0], private_inputs.signed_tx_request.hash());

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/.test.cpp
@@ -413,14 +413,14 @@ PrivateKernelInputsInner<NT> do_private_call_get_kernel_inputs_inner(bool const 
     const NT::address msg_sender =
         NT::fr(uint256_t(0x01071e9a23e0f7edULL, 0x5d77b35d1830fa3eULL, 0xc6ba3660bb1f0c0bULL, 0x2ef9f7f09867fd6eULL));
 
-    auto const& private_call_deploy = create_private_call_deploy_data(is_constructor, func, args_vec, msg_sender);
+    auto const& [private_call_data, contract_deployment_data] =
+        create_private_call_deploy_data(is_constructor, func, args_vec, msg_sender);
 
-    auto const& private_call_data = private_call_deploy.first;
     const TxContext<NT> tx_context = TxContext<NT>{
         .is_fee_payment_tx = false,
         .is_rebate_payment_tx = false,
         .is_contract_deployment_tx = is_constructor,
-        .contract_deployment_data = private_call_deploy.second,
+        .contract_deployment_data = contract_deployment_data,
     };
 
     //***************************************************************************

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/common.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/common.cpp
@@ -71,16 +71,14 @@ void common_update_end_values(DummyComposer& composer,
     {  // commitments & nullifiers
         std::array<NT::fr, NEW_COMMITMENTS_LENGTH> siloed_new_commitments;
         for (size_t i = 0; i < new_commitments.size(); ++i) {
-            siloed_new_commitments[i] = new_commitments[i] == 0 ? 0
-                                                                : add_contract_address_to_commitment<NT>(
-                                                                      storage_contract_address, new_commitments[i]);
+            siloed_new_commitments[i] =
+                new_commitments[i] == 0 ? 0 : silo_commitment<NT>(storage_contract_address, new_commitments[i]);
         }
 
         std::array<NT::fr, NEW_NULLIFIERS_LENGTH> siloed_new_nullifiers;
         for (size_t i = 0; i < new_nullifiers.size(); ++i) {
-            siloed_new_nullifiers[i] = new_nullifiers[i] == 0 ? 0
-                                                              : add_contract_address_to_nullifier<NT>(
-                                                                    storage_contract_address, new_nullifiers[i]);
+            siloed_new_nullifiers[i] =
+                new_nullifiers[i] == 0 ? 0 : silo_nullifier<NT>(storage_contract_address, new_nullifiers[i]);
         }
 
         push_array_to_array(siloed_new_commitments, public_inputs.end.new_commitments);

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/common.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/common.cpp
@@ -126,29 +126,28 @@ void common_contract_logic(DummyComposer& composer,
     const auto& portal_contract_address = private_call.portal_contract_address;
     const auto& deployer_address = private_call_public_inputs.call_context.msg_sender;
 
-    auto private_call_vk_hash =
+    const auto private_call_vk_hash =
         stdlib::recursion::verification_key<CT::bn254>::compress_native(private_call.vk, GeneratorIndex::VK);
 
-    auto constructor_hash =
-        compute_constructor_hash(function_data, private_call_public_inputs.args, private_call_vk_hash);
-
-    auto const new_contract_address = compute_contract_address<NT>(deployer_address,
-                                                                   contract_dep_data.contract_address_salt,
-                                                                   contract_dep_data.function_tree_root,
-                                                                   constructor_hash);
-
-    // Add new contract data if its a contract deployment function
-    NewContractData<NT> const native_new_contract_data{ new_contract_address,
-                                                        portal_contract_address,
-                                                        contract_dep_data.function_tree_root };
-
-    array_push<NewContractData<NT>, KERNEL_NEW_CONTRACTS_LENGTH>(public_inputs.end.new_contracts,
-                                                                 native_new_contract_data);
-
-    auto is_contract_deployment = public_inputs.constants.tx_context.is_contract_deployment_tx;
+    const auto is_contract_deployment = public_inputs.constants.tx_context.is_contract_deployment_tx;
 
     // input storage contract address must be 0 if its a constructor call and non-zero otherwise
     if (is_contract_deployment) {
+        auto constructor_hash =
+            compute_constructor_hash(function_data, private_call_public_inputs.args, private_call_vk_hash);
+
+        auto const new_contract_address = compute_contract_address<NT>(deployer_address,
+                                                                       contract_dep_data.contract_address_salt,
+                                                                       contract_dep_data.function_tree_root,
+                                                                       constructor_hash);
+
+        // Add new contract data if its a contract deployment function
+        NewContractData<NT> const native_new_contract_data{ new_contract_address,
+                                                            portal_contract_address,
+                                                            contract_dep_data.function_tree_root };
+
+        array_push<NewContractData<NT>, KERNEL_NEW_CONTRACTS_LENGTH>(public_inputs.end.new_contracts,
+                                                                     native_new_contract_data);
         composer.do_assert(contract_dep_data.constructor_vk_hash == private_call_vk_hash,
                            "constructor_vk_hash doesn't match private_call_vk_hash",
                            CircuitErrorCode::PRIVATE_KERNEL__INVALID_CONSTRUCTOR_VK_HASH);

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/private_kernel_circuit.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/private_kernel_circuit.cpp
@@ -20,10 +20,10 @@ using plonk::stdlib::array_push;
 using plonk::stdlib::is_array_empty;
 using plonk::stdlib::push_array_to_array;
 
-using aztec3::circuits::add_contract_address_to_commitment;
-using aztec3::circuits::add_contract_address_to_nullifier;
 using aztec3::circuits::compute_constructor_hash;
 using aztec3::circuits::compute_contract_address;
+using aztec3::circuits::silo_commitment;
+using aztec3::circuits::silo_nullifier;
 
 // TODO: NEED TO RECONCILE THE `proof`'s public inputs (which are uint8's) with the
 // private_call.call_stack_item.public_inputs!
@@ -159,16 +159,12 @@ void update_end_values(PrivateKernelInputsInner<CT> const& private_inputs, Kerne
         std::array<CT::fr, NEW_COMMITMENTS_LENGTH> siloed_new_commitments;
         for (size_t i = 0; i < new_commitments.size(); ++i) {
             siloed_new_commitments[i] = CT::fr::conditional_assign(
-                new_commitments[i] == 0,
-                0,
-                add_contract_address_to_commitment<CT>(storage_contract_address, new_commitments[i]));
+                new_commitments[i] == 0, 0, silo_commitment<CT>(storage_contract_address, new_commitments[i]));
         }
         std::array<CT::fr, NEW_NULLIFIERS_LENGTH> siloed_new_nullifiers;
         for (size_t i = 0; i < new_nullifiers.size(); ++i) {
             siloed_new_nullifiers[i] = CT::fr::conditional_assign(
-                new_nullifiers[i] == 0,
-                0,
-                add_contract_address_to_nullifier<CT>(storage_contract_address, new_nullifiers[i]));
+                new_nullifiers[i] == 0, 0, silo_nullifier<CT>(storage_contract_address, new_nullifiers[i]));
         }
 
         // Add new commitments/etc to AggregatedData


### PR DESCRIPTION
# Description

This resolves #684 

In common_contract_logic() method, we should create new contract data in public_inputs only when the boolean 
public_inputs.constants.tx_context.is_contract_deployment_tx is true.

As a consequence, one unit test is failing due to the expectation that there must be some contract data even though the underlying transaction request does not deploy any contract. This was replaced by an assertion that no new contract data
is present in public_inputs.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] The branch has been merged or rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
