### PR TITLE
Resolve issues relating to Bb::is/one_more_split

### DIFF
--- a/circuits/cpp/src/aztec3/circuits/abis/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/.test.cpp
@@ -10,7 +10,7 @@
 
 namespace {
 // Composer
-using Composer = plonk::UltraComposer;
+using Composer = plonk::UltraPlonkComposer;
 
 // Types
 using CT = aztec3::utils::types::CircuitTypes<Composer>;

--- a/circuits/cpp/src/aztec3/circuits/apps/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/.test.cpp
@@ -30,7 +30,7 @@
 
 namespace {
 // Composer
-using C = plonk::UltraComposer;
+using C = plonk::UltraPlonkComposer;
 
 // Types
 using CT = aztec3::utils::types::CircuitTypes<C>;

--- a/circuits/cpp/src/aztec3/circuits/apps/notes/default_private_note/note.tpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/notes/default_private_note/note.tpp
@@ -10,7 +10,7 @@
 
 #include <barretenberg/crypto/generators/generator_data.hpp>
 
-#include <barretenberg/plonk/composer/turbo_composer.hpp>
+#include <barretenberg/plonk/composer/turbo_plonk_composer.hpp>
 
 #include <barretenberg/stdlib/hash/pedersen/pedersen.hpp>
 #include <barretenberg/stdlib/hash/blake2s/blake2s.hpp>

--- a/circuits/cpp/src/aztec3/circuits/apps/notes/default_singleton_private_note/note.tpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/notes/default_singleton_private_note/note.tpp
@@ -10,7 +10,7 @@
 
 #include <barretenberg/crypto/generators/generator_data.hpp>
 
-#include <barretenberg/plonk/composer/turbo_composer.hpp>
+#include <barretenberg/plonk/composer/turbo_plonk_composer.hpp>
 
 #include <barretenberg/stdlib/hash/pedersen/pedersen.hpp>
 #include <barretenberg/stdlib/hash/blake2s/blake2s.hpp>

--- a/circuits/cpp/src/aztec3/circuits/apps/state_vars/mapping_state_var.tpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/state_vars/mapping_state_var.tpp
@@ -7,7 +7,7 @@
 
 #include "../function_execution_context.hpp"
 
-#include <barretenberg/plonk/composer/turbo_composer.hpp>
+#include <barretenberg/plonk/composer/turbo_plonk_composer.hpp>
 
 #include <barretenberg/common/streams.hpp>
 #include <barretenberg/common/map.hpp>

--- a/circuits/cpp/src/aztec3/circuits/apps/state_vars/state_var_base.tpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/state_vars/state_var_base.tpp
@@ -2,7 +2,7 @@
 
 #include "../function_execution_context.hpp"
 
-#include <barretenberg/plonk/composer/turbo_composer.hpp>
+#include <barretenberg/plonk/composer/turbo_plonk_composer.hpp>
 
 #include <barretenberg/crypto/generators/generator_data.hpp>
 

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/basic_contract_deployment/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/basic_contract_deployment/init.hpp
@@ -14,7 +14,7 @@
 namespace aztec3::circuits::apps::test_apps::basic_contract_deployment {
 
 // Composer
-using C = plonk::UltraComposer;
+using C = plonk::UltraPlonkComposer;
 
 // Native and circuit types
 using CT = aztec3::utils::types::CircuitTypes<C>;

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/.test.cpp
@@ -62,7 +62,7 @@ TEST_F(escrow_tests, circuit_deposit)
     auto result = deposit(exec_ctx, { amount, asset_id, memo });
     info("result: ", result);
 
-    info("computed witness: ", composer.computed_witness);
+    info("computed witness: ", composer.composer_helper.computed_witness);
     // info("witness: ", composer.witness);
     // info("constant variables: ", composer.constant_variables);
     // info("variables: ", composer.variables);
@@ -88,7 +88,7 @@ TEST_F(escrow_tests, circuit_transfer)
 
     transfer(exec_ctx, amount, to, asset_id, memo, reveal_msg_sender_to_recipient, fee);
 
-    info("computed witness: ", composer.computed_witness);
+    info("computed witness: ", composer.composer_helper.computed_witness);
     // info("witness: ", composer.witness);
     // info("constant variables: ", composer.constant_variables);
     // info("variables: ", composer.variables);
@@ -113,7 +113,7 @@ TEST_F(escrow_tests, circuit_withdraw)
 
     withdraw(exec_ctx, amount, asset_id, memo, l1_withdrawal_address, fee);
 
-    info("computed witness: ", composer.computed_witness);
+    info("computed witness: ", composer.composer_helper.computed_witness);
     // info("witness: ", composer.witness);
     // info("constant variables: ", composer.constant_variables);
     // info("variables: ", composer.variables);

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/init.hpp
@@ -14,7 +14,7 @@
 namespace aztec3::circuits::apps::test_apps::escrow {
 
 // Composer
-using C = plonk::UltraComposer;
+using C = plonk::UltraPlonkComposer;
 
 // Native and circuit types
 using CT = aztec3::utils::types::CircuitTypes<C>;

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/.test.cpp
@@ -53,7 +53,7 @@ TEST(private_to_private_function_call_tests, circuit_private_to_private_function
 
     info("function_1_1_public_inputs: ", function_1_1_public_inputs);
 
-    info("computed witness: ", fn1_composer.computed_witness);
+    info("computed witness: ", fn1_composer.composer_helper.computed_witness);
     // info("witness: ", fn1_composer.witness);
     // info("constant variables: ", fn1_composer.constant_variables);
     // info("variables: ", fn1_composer.variables);

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/init.hpp
@@ -13,7 +13,7 @@
 namespace aztec3::circuits::apps::test_apps::private_to_private_function_call {
 
 // Composer
-using C = plonk::UltraComposer;
+using C = plonk::UltraPlonkComposer;
 
 // Native and circuit types
 using CT = aztec3::utils::types::CircuitTypes<C>;

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/.test.cpp
@@ -103,7 +103,7 @@ namespace aztec3::circuits::kernel::private_kernel {
 void debugComposer(Composer const& composer)
 {
 #ifdef DEBUG_PRINTS
-    info("computed witness: ", composer.computed_witness);
+    info("computed witness: ", composer.composer_helper.computed_witness);
     // info("witness: ", private_kernel_composer.witness);
     // info("constant variables: ", private_kernel_composer.constant_variables);
     // info("variables: ", composer.variables);

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/.test.cpp
@@ -159,7 +159,7 @@ std::shared_ptr<NT::VK> gen_func_vk(bool is_constructor, private_function const&
     }
 
     // Now we can derive the vk:
-    return dummy_composer.compute_verification_key();
+    return dummy_composer.compute_verification_key("../barretenberg/cpp/srs_db/ignition");
 }
 
 std::pair<PrivateCallData<NT>, ContractDeploymentData<NT>> create_private_call_deploy_data(

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/c_bind.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/c_bind.cpp
@@ -10,7 +10,7 @@
 #include <barretenberg/serialize/cbind.hpp>
 
 namespace {
-using Composer = plonk::UltraComposer;
+using Composer = plonk::UltraPlonkComposer;
 using NT = aztec3::utils::types::NativeTypes;
 using DummyComposer = aztec3::utils::DummyComposer;
 using aztec3::circuits::abis::KernelCircuitPublicInputs;

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/init.hpp
@@ -9,7 +9,7 @@
 
 namespace aztec3::circuits::kernel::private_kernel {
 
-using Composer = plonk::UltraComposer;
+using Composer = plonk::UltraPlonkComposer;
 
 using Aggregator = aztec3::circuits::recursion::Aggregator;
 

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/utils.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/utils.cpp
@@ -58,7 +58,8 @@ PreviousKernelData<NT> dummy_previous_kernel(bool real_vk_proof = false)
         real_vk_proof ? mock_kernel_prover.construct_proof() : NT::Proof{ .proof_data = std::vector<uint8_t>(64, 0) };
 
     std::shared_ptr<NT::VK> const mock_kernel_vk =
-        real_vk_proof ? mock_kernel_composer.compute_verification_key() : fake_vk();
+        real_vk_proof ? mock_kernel_composer.compute_verification_key("../barretenberg/cpp/srs_db/ignition")
+                      : fake_vk();
 
     PreviousKernelData<NT> previous_kernel = {
         .public_inputs = mock_kernel_public_inputs,

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/c_bind.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/c_bind.cpp
@@ -15,7 +15,7 @@
 #include <barretenberg/srs/reference_string/env_reference_string.hpp>
 
 namespace {
-using Composer = plonk::UltraComposer;
+using Composer = plonk::UltraPlonkComposer;
 using NT = aztec3::utils::types::NativeTypes;
 using DummyComposer = aztec3::utils::DummyComposer;
 using aztec3::circuits::abis::KernelCircuitPublicInputs;

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/init.hpp
@@ -10,7 +10,7 @@
 
 namespace aztec3::circuits::kernel::public_kernel {
 
-using Composer = plonk::UltraComposer;
+using Composer = plonk::UltraPlonkComposer;
 
 using Aggregator = aztec3::circuits::recursion::Aggregator;
 

--- a/circuits/cpp/src/aztec3/circuits/recursion/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/recursion/init.hpp
@@ -8,7 +8,7 @@
 
 namespace aztec3::circuits::recursion {
 // Composer
-using Composer = plonk::UltraComposer;
+using Composer = plonk::UltraPlonkComposer;
 
 // Generic types:
 using CT = aztec3::utils::types::CircuitTypes<Composer>;

--- a/circuits/cpp/src/aztec3/circuits/recursion/play.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/recursion/play.test.cpp
@@ -57,7 +57,8 @@ TEST(play_tests, circuit_play_recursive_proof_gen)
     proof const app_proof = app_prover.construct_proof();
     info("app_proof: ", app_proof.proof_data);
 
-    std::shared_ptr<plonk::verification_key> const app_vk = app_composer.compute_verification_key();
+    std::shared_ptr<plonk::verification_key> const app_vk =
+        app_composer.compute_verification_key("../barretenberg/cpp/srs_db/ignition");
 
     Composer recursive_composer = Composer("../barretenberg/cpp/srs_db/ignition");
     auto aggregation_output = play_recursive_circuit(recursive_composer, app_vk, app_proof);
@@ -78,7 +79,8 @@ TEST(play_tests, circuit_play_recursive_2_proof_gen)
 
     auto app_prover = app_composer.create_prover();
     proof const app_proof = app_prover.construct_proof();
-    std::shared_ptr<plonk::verification_key> const app_vk = app_composer.compute_verification_key();
+    std::shared_ptr<plonk::verification_key> const app_vk =
+        app_composer.compute_verification_key("../barretenberg/cpp/srs_db/ignition");
 
     //*******************************************************************************
 
@@ -91,7 +93,8 @@ TEST(play_tests, circuit_play_recursive_2_proof_gen)
 
     auto dummy_circuit_prover = dummy_circuit_composer.create_prover();
     proof const dummy_circuit_proof = dummy_circuit_prover.construct_proof();
-    std::shared_ptr<plonk::verification_key> const dummy_circuit_vk = dummy_circuit_composer.compute_verification_key();
+    std::shared_ptr<plonk::verification_key> const dummy_circuit_vk =
+        dummy_circuit_composer.compute_verification_key("../barretenberg/cpp/srs_db/ignition");
 
     //*******************************************************************************
 
@@ -107,7 +110,8 @@ TEST(play_tests, circuit_play_recursive_2_proof_gen)
 
     proof const recursion_1_proof = recursion_1_prover.construct_proof();
 
-    std::shared_ptr<plonk::verification_key> const recursion_1_vk = recursion_1_composer.compute_verification_key();
+    std::shared_ptr<plonk::verification_key> const recursion_1_vk =
+        recursion_1_composer.compute_verification_key("../barretenberg/cpp/srs_db/ignition");
 
     //*******************************************************************************
 
@@ -121,7 +125,8 @@ TEST(play_tests, circuit_play_recursive_2_proof_gen)
 
     // Prover recursion_2_prover = recursion_2_composer.create_prover();
     // proof recursion_2_proof = recursion_2_prover.construct_proof();
-    // std::shared_ptr<plonk::verification_key> recursion_2_vk = recursion_2_composer.compute_verification_key();
+    // std::shared_ptr<plonk::verification_key> recursion_2_vk =
+    // recursion_2_composer.compute_verification_key("../barretenberg/cpp/srs_db/ignition");
 }
 
 }  // namespace aztec3::circuits::recursion

--- a/circuits/cpp/src/aztec3/circuits/recursion/play_recursive_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/recursion/play_recursive_circuit.hpp
@@ -42,10 +42,10 @@ inline CT::AggregationObject play_recursive_circuit_2(Composer& composer,
 
     info("composer failed 2? ", composer.failed());
 
-    info("\npublic inputs before: ", composer.public_inputs.size());
+    info("\npublic inputs before: ", composer.circuit_constructor.public_inputs.size());
     aggregation_object =
         Aggregator::aggregate(&composer, app_vk_ct, app_proof, app_vk->num_public_inputs, aggregation_object);
-    info("\npublic inputs after: ", composer.public_inputs.size());
+    info("\npublic inputs after: ", composer.circuit_constructor.public_inputs.size());
 
     info("composer failed 3? ", composer.failed());
 
@@ -53,7 +53,7 @@ inline CT::AggregationObject play_recursive_circuit_2(Composer& composer,
 
     info("composer failed 4? ", composer.failed());
 
-    info("\npublic inputs after after: ", composer.public_inputs.size());
+    info("\npublic inputs after after: ", composer.circuit_constructor.public_inputs.size());
 
     info("composer failed 5? ", composer.failed());
 

--- a/circuits/cpp/src/aztec3/circuits/rollup/base/c_bind.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/base/c_bind.cpp
@@ -13,11 +13,11 @@
 #include <aztec3/utils/types/native_types.hpp>
 
 #include "barretenberg/common/serialize.hpp"
-#include "barretenberg/plonk/composer/turbo_composer.hpp"
+#include "barretenberg/plonk/composer/turbo_plonk_composer.hpp"
 #include "barretenberg/srs/reference_string/env_reference_string.hpp"
 
 namespace {
-using Composer = plonk::UltraComposer;
+using Composer = plonk::UltraPlonkComposer;
 using NT = aztec3::utils::types::NativeTypes;
 using DummyComposer = aztec3::utils::DummyComposer;
 using aztec3::circuits::abis::BaseOrMergeRollupPublicInputs;

--- a/circuits/cpp/src/aztec3/circuits/rollup/root/c_bind.cpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/root/c_bind.cpp
@@ -11,11 +11,11 @@
 #include <aztec3/utils/types/native_types.hpp>
 
 #include "barretenberg/common/serialize.hpp"
-#include "barretenberg/plonk/composer/turbo_composer.hpp"
+#include "barretenberg/plonk/composer/turbo_plonk_composer.hpp"
 #include "barretenberg/srs/reference_string/env_reference_string.hpp"
 
 namespace {
-using Composer = plonk::UltraComposer;
+using Composer = plonk::UltraPlonkComposer;
 using NT = aztec3::utils::types::NativeTypes;
 using DummyComposer = aztec3::utils::DummyComposer;
 using aztec3::circuits::rollup::native_root_rollup::root_rollup_circuit;

--- a/circuits/cpp/src/aztec3/utils/types/circuit_types.hpp
+++ b/circuits/cpp/src/aztec3/utils/types/circuit_types.hpp
@@ -61,7 +61,7 @@ template <typename Composer> struct CircuitTypes {
 
     using AggregationObject = stdlib::recursion::aggregation_state<bn254>;
     using recursive_inner_verifier_settings =
-        std::conditional_t<std::same_as<Composer, plonk::TurboComposer>,
+        std::conditional_t<std::same_as<Composer, plonk::TurboPlonkComposer>,
                            stdlib::recursion::recursive_turbo_verifier_settings<bn254>,
                            stdlib::recursion::recursive_ultra_verifier_settings<bn254>>;
     using VK = stdlib::recursion::verification_key<bn254>;


### PR DESCRIPTION
# Description

This is paired with the PR https://github.com/AztecProtocol/barretenberg/pull/487. The PR reflects the removal of `UltraComposer` and its replacement by `UltraPlonkComposer`, and updates a chain of functions calls to accept an SRS location code string that was hard coded in the commitment key structure, which was not used by `UltraComposer`.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] The branch has been merged or rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
