### PR TITLE
BLOCKED(bberg): Remove path argument to compute_verification_key

### DIFF
--- a/circuits/cpp/src/aztec3/circuits/kernel/private/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/.test.cpp
@@ -154,7 +154,7 @@ std::shared_ptr<NT::VK> gen_func_vk(bool is_constructor, private_function const&
     }
 
     // Now we can derive the vk:
-    return dummy_composer.compute_verification_key("../barretenberg/cpp/srs_db/ignition");
+    return dummy_composer.compute_verification_key();
 }
 
 std::pair<PrivateCallData<NT>, ContractDeploymentData<NT>> create_private_call_deploy_data(

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/utils.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/utils.cpp
@@ -57,8 +57,7 @@ PreviousKernelData<NT> dummy_previous_kernel(bool real_vk_proof = false)
         real_vk_proof ? mock_kernel_prover.construct_proof() : NT::Proof{ .proof_data = std::vector<uint8_t>(64, 0) };
 
     std::shared_ptr<NT::VK> const mock_kernel_vk =
-        real_vk_proof ? mock_kernel_composer.compute_verification_key("../barretenberg/cpp/srs_db/ignition")
-                      : fake_vk();
+        real_vk_proof ? mock_kernel_composer.compute_verification_key() : fake_vk();
 
     PreviousKernelData<NT> previous_kernel = {
         .public_inputs = mock_kernel_public_inputs,

--- a/circuits/cpp/src/aztec3/circuits/recursion/play.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/recursion/play.test.cpp
@@ -58,8 +58,7 @@ TEST(play_tests, circuit_play_recursive_proof_gen)
     proof const app_proof = app_prover.construct_proof();
     info("app_proof: ", app_proof.proof_data);
 
-    std::shared_ptr<plonk::verification_key> const app_vk =
-        app_composer.compute_verification_key("../barretenberg/cpp/srs_db/ignition");
+    std::shared_ptr<plonk::verification_key> const app_vk = app_composer.compute_verification_key();
 
     Composer recursive_composer = Composer("../barretenberg/cpp/srs_db/ignition");
     auto aggregation_output = play_recursive_circuit(recursive_composer, app_vk, app_proof);
@@ -80,8 +79,7 @@ TEST(play_tests, circuit_play_recursive_2_proof_gen)
 
     auto app_prover = app_composer.create_prover();
     proof const app_proof = app_prover.construct_proof();
-    std::shared_ptr<plonk::verification_key> const app_vk =
-        app_composer.compute_verification_key("../barretenberg/cpp/srs_db/ignition");
+    std::shared_ptr<plonk::verification_key> const app_vk = app_composer.compute_verification_key();
 
     //*******************************************************************************
 
@@ -94,8 +92,7 @@ TEST(play_tests, circuit_play_recursive_2_proof_gen)
 
     auto dummy_circuit_prover = dummy_circuit_composer.create_prover();
     proof const dummy_circuit_proof = dummy_circuit_prover.construct_proof();
-    std::shared_ptr<plonk::verification_key> const dummy_circuit_vk =
-        dummy_circuit_composer.compute_verification_key("../barretenberg/cpp/srs_db/ignition");
+    std::shared_ptr<plonk::verification_key> const dummy_circuit_vk = dummy_circuit_composer.compute_verification_key();
 
     //*******************************************************************************
 
@@ -111,8 +108,7 @@ TEST(play_tests, circuit_play_recursive_2_proof_gen)
 
     proof const recursion_1_proof = recursion_1_prover.construct_proof();
 
-    std::shared_ptr<plonk::verification_key> const recursion_1_vk =
-        recursion_1_composer.compute_verification_key("../barretenberg/cpp/srs_db/ignition");
+    std::shared_ptr<plonk::verification_key> const recursion_1_vk = recursion_1_composer.compute_verification_key();
 
     //*******************************************************************************
 
@@ -127,7 +123,7 @@ TEST(play_tests, circuit_play_recursive_2_proof_gen)
     // Prover recursion_2_prover = recursion_2_composer.create_prover();
     // proof recursion_2_proof = recursion_2_prover.construct_proof();
     // std::shared_ptr<plonk::verification_key> recursion_2_vk =
-    // recursion_2_composer.compute_verification_key("../barretenberg/cpp/srs_db/ignition");
+    // recursion_2_composer.compute_verification_key();
 }
 
 }  // namespace aztec3::circuits::recursion


### PR DESCRIPTION
# Description

NOTE: The corresponding bberg PR will be merged prior to this one and the bberg hash will be updated here accordingly. PR will not be merged until after Charlie's major PR has been merged.

Removes unnecessary path input to `compute_verification_key` to reflect corresponding update in barrentenberg.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
