### PR TITLE
only use leafPreimage in circuit and add isempty()

### DIFF
--- a/circuits/cpp/src/aztec3/circuits/abis/new_contract_data.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/new_contract_data.hpp
@@ -58,8 +58,8 @@ template <typename NCT> struct NewContractData {
 
     boolean is_empty() const
     {
-        return ((contract_address.to_field() == fr(0)) && (portal_contract_address.to_field() == fr(0)) &&
-                (function_tree_root == fr(0)));
+        return ((contract_address.to_field().is_zero()) && (portal_contract_address.to_field().is_zero()) &&
+                (function_tree_root.is_zero()));
     }
 
     void set_public()
@@ -75,7 +75,7 @@ template <typename NCT> struct NewContractData {
     {
         // as per the circuit implementation, if contract address == zero then return a zero leaf
         if (is_empty()) {
-            return fr(0);
+            return fr::zero();
         }
         std::vector<fr> const inputs = {
             fr(contract_address),

--- a/circuits/cpp/src/aztec3/circuits/abis/rollup/nullifier_leaf_preimage.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/rollup/nullifier_leaf_preimage.hpp
@@ -21,7 +21,12 @@ template <typename NCT> struct NullifierLeafPreimage {
     MSGPACK_FIELDS(leaf_value, next_index, next_value);
     bool operator==(NullifierLeafPreimage<NCT> const&) const = default;
 
-    fr hash() const { return stdlib::merkle_tree::hash_multiple_native({ leaf_value, next_index, next_value }); }
+    bool is_empty() const { return leaf_value == fr(0) && next_index == fr(0) && next_value == fr(0); }
+
+    fr hash() const
+    {
+        return is_empty() ? fr(0) : stdlib::merkle_tree::hash_multiple_native({ leaf_value, next_index, next_value });
+    }
 };
 
 template <typename NCT> void read(uint8_t const*& it, NullifierLeafPreimage<NCT>& obj)

--- a/circuits/cpp/src/aztec3/circuits/abis/rollup/nullifier_leaf_preimage.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/rollup/nullifier_leaf_preimage.hpp
@@ -21,11 +21,12 @@ template <typename NCT> struct NullifierLeafPreimage {
     MSGPACK_FIELDS(leaf_value, next_index, next_value);
     bool operator==(NullifierLeafPreimage<NCT> const&) const = default;
 
-    bool is_empty() const { return leaf_value == fr(0) && next_index == fr(0) && next_value == fr(0); }
+    bool is_empty() const { return leaf_value.is_zero() && next_index == 0 && next_value.is_zero(); }
 
     fr hash() const
     {
-        return is_empty() ? fr(0) : stdlib::merkle_tree::hash_multiple_native({ leaf_value, next_index, next_value });
+        return is_empty() ? fr::zero()
+                          : stdlib::merkle_tree::hash_multiple_native({ leaf_value, next_index, next_value });
     }
 };
 

--- a/circuits/cpp/src/aztec3/circuits/rollup/base/init.hpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/base/init.hpp
@@ -35,7 +35,7 @@ using AppendOnlySnapshot = abis::AppendOnlyTreeSnapshot<NT>;
 // Nullifier Tree Alias
 using MerkleTree = stdlib::merkle_tree::MemoryTree;
 using NullifierTree = stdlib::merkle_tree::NullifierMemoryTree;
-using NullifierLeaf = stdlib::merkle_tree::nullifier_leaf;
+using NullifierLeafPreimage = abis::NullifierLeafPreimage<NT>;
 using SparseTree = stdlib::merkle_tree::MerkleTree<stdlib::merkle_tree::MemoryStore>;
 
 }  // namespace aztec3::circuits::rollup::native_base_rollup

--- a/circuits/cpp/src/aztec3/circuits/rollup/base/native_base_rollup_circuit.hpp
+++ b/circuits/cpp/src/aztec3/circuits/rollup/base/native_base_rollup_circuit.hpp
@@ -6,7 +6,6 @@
 #include "aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp"
 #include "aztec3/circuits/abis/rollup/base/base_rollup_inputs.hpp"
 #include "aztec3/circuits/abis/rollup/constant_rollup_data.hpp"
-#include "aztec3/circuits/abis/rollup/nullifier_leaf_preimage.hpp"
 #include "aztec3/utils/types/circuit_types.hpp"
 #include "aztec3/utils/types/convert.hpp"
 #include "aztec3/utils/types/native_types.hpp"


### PR DESCRIPTION
# Description
Fix #710. 
Also, noticed that we used bberg's NullifierLeaf type even in the native circuit so refactored to use the circuit's type.
# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
