### PR TITLE
fix #741 and #646

### DIFF
--- a/yarn-project/acir-simulator/src/client/private_execution.test.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.test.ts
@@ -400,7 +400,8 @@ describe('Private Execution test suite', () => {
       const secret = new Fr(1n);
       const preimage = await buildL1ToL2Message([new Fr(bridgedAmount), new Fr(recipient.x)], contractAddress, secret);
 
-      const messageKey = preimage.hash();
+      // stub message key
+      const messageKey = Fr.random();
 
       const tree: AppendOnlyTree = await newTree(
         StandardTree,

--- a/yarn-project/aztec.js/src/index.ts
+++ b/yarn-project/aztec.js/src/index.ts
@@ -1,5 +1,6 @@
 export * from './contract/index.js';
 export * from './contract_deployer/index.js';
+export * from './utils/index.js';
 
 // TODO - only export necessary stuffs
 export * from '@aztec/aztec-rpc';

--- a/yarn-project/aztec.js/src/utils/index.ts
+++ b/yarn-project/aztec.js/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './utils.js';

--- a/yarn-project/aztec.js/src/utils/index.ts
+++ b/yarn-project/aztec.js/src/utils/index.ts
@@ -1,1 +1,1 @@
-export * from './utils.js';
+export * from './secrets.js';

--- a/yarn-project/aztec.js/src/utils/secrets.ts
+++ b/yarn-project/aztec.js/src/utils/secrets.ts
@@ -4,11 +4,9 @@ import { computeSecretMessageHash } from '@aztec/circuits.js/abis';
 /**
  * Given a secret, it computes its pederson hash - used to send l1 to l2 messages
  * @param secret - the secret to hash (defaults to a random field element)
- * @returns secret and its pederson hash (in hex).
+ * @returns the hash
  */
-export async function createMessageSecretAndHash(secret = Fr.random()) {
+export async function computeMessageSecretHash(secret = Fr.random()): Promise<Fr> {
   const wasm = await CircuitsWasm.get();
-  const secretHash = computeSecretMessageHash(wasm, secret);
-  const secretHashHex = `0x${secretHash.toBuffer().toString('hex')}` as `0x${string}`;
-  return secretHashHex;
+  return computeSecretMessageHash(wasm, secret);
 }

--- a/yarn-project/aztec.js/src/utils/secrets.ts
+++ b/yarn-project/aztec.js/src/utils/secrets.ts
@@ -2,11 +2,11 @@ import { CircuitsWasm, Fr } from '@aztec/circuits.js';
 import { computeSecretMessageHash } from '@aztec/circuits.js/abis';
 
 /**
- * Given a secret, it computes its pederson hash - used to send l1 to l2 messages
- * @param secret - the secret to hash (defaults to a random field element)
+ * Given a secret, it computes its pedersen hash - used to send l1 to l2 messages
+ * @param secret - the secret to hash - secret could be generated however you want e.g. `Fr.random()`
  * @returns the hash
  */
-export async function computeMessageSecretHash(secret = Fr.random()): Promise<Fr> {
+export async function computeMessageSecretHash(secret: Fr): Promise<Fr> {
   const wasm = await CircuitsWasm.get();
   return computeSecretMessageHash(wasm, secret);
 }

--- a/yarn-project/aztec.js/src/utils/utils.ts
+++ b/yarn-project/aztec.js/src/utils/utils.ts
@@ -1,0 +1,14 @@
+import { CircuitsWasm, Fr } from '@aztec/circuits.js';
+import { computeSecretMessageHash } from '@aztec/circuits.js/abis';
+
+/**
+ * Given a secret, it computes its pederson hash - used to send l1 to l2 messages
+ * @param secret - the secret to hash (defaults to a random field element)
+ * @returns secret and its pederson hash (in hex).
+ */
+export async function createMessageSecretAndHash(secret = Fr.random()) {
+  const wasm = await CircuitsWasm.get();
+  const secretHash = computeSecretMessageHash(wasm, secret);
+  const secretHashHex = `0x${secretHash.toBuffer().toString('hex')}` as `0x${string}`;
+  return secretHashHex;
+}

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
@@ -1,5 +1,5 @@
 import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecAddress, AztecRPCServer, Contract, TxStatus, createMessageSecretAndHash } from '@aztec/aztec.js';
+import { AztecAddress, AztecRPCServer, Contract, TxStatus, computeMessageSecretHash } from '@aztec/aztec.js';
 import { EthAddress } from '@aztec/foundation/eth-address';
 
 import { DeployL1Contracts } from '@aztec/ethereum';
@@ -88,7 +88,8 @@ describe('e2e_cross_chain_messaging', () => {
     // Generate a claim secret using pedersen
     logger("Generating a claim secret using pedersen's hash function");
     const secret = Fr.random();
-    const secretString = await createMessageSecretAndHash(secret);
+    const secretHash = await computeMessageSecretHash(secret);
+    const secretString = `0x${secretHash.toBuffer().toString('hex')}` as `0x${string}`;
     logger('Generated claim secret: ', secretString);
 
     logger('Minting tokens on L1');

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
@@ -1,9 +1,7 @@
 import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecAddress, AztecRPCServer, Contract, TxStatus } from '@aztec/aztec.js';
+import { AztecAddress, AztecRPCServer, Contract, TxStatus, createMessageSecretAndHash } from '@aztec/aztec.js';
 import { EthAddress } from '@aztec/foundation/eth-address';
 
-import { CircuitsWasm } from '@aztec/circuits.js';
-import { computeSecretMessageHash } from '@aztec/circuits.js/abis';
 import { DeployL1Contracts } from '@aztec/ethereum';
 import { toBigIntBE, toBufferBE } from '@aztec/foundation/bigint-buffer';
 import { Fr } from '@aztec/foundation/fields';
@@ -88,12 +86,10 @@ describe('e2e_cross_chain_messaging', () => {
 
   it('Milestone 2: Deposit funds from L1 -> L2 and withdraw back to L1', async () => {
     // Generate a claim secret using pedersen
-    // TODO (#741): make this into an aztec.js utility function
     logger("Generating a claim secret using pedersen's hash function");
-    const wasm = await CircuitsWasm.get();
     const secret = Fr.random();
-    const claimSecretHash = computeSecretMessageHash(wasm, secret);
-    logger('Generated claim secret: ', claimSecretHash.toString());
+    const secretString = await createMessageSecretAndHash(secret);
+    logger('Generated claim secret: ', secretString);
 
     logger('Minting tokens on L1');
     await underlyingERC20.write.mint([ethAccount.toString(), 1000000n], {} as any);
@@ -102,7 +98,6 @@ describe('e2e_cross_chain_messaging', () => {
     expect(await underlyingERC20.read.balanceOf([ethAccount.toString()])).toBe(1000000n);
 
     // Deposit tokens to the TokenPortal
-    const secretString = `0x${claimSecretHash.toBuffer().toString('hex')}` as `0x${string}`;
     const deadline = 2 ** 32 - 1; // max uint32 - 1
 
     const mintAmount = 100n;

--- a/yarn-project/end-to-end/src/integration_archiver_l1_to_l2.test.ts
+++ b/yarn-project/end-to-end/src/integration_archiver_l1_to_l2.test.ts
@@ -83,7 +83,8 @@ describe('archiver integration with l1 to l2 messages', () => {
 
     // Generate a claim secret using pedersen
     logger("Generating a claim secret using pedersen's hash function");
-    const secretHash = await computeMessageSecretHash();
+    const secret = Fr.random();
+    const secretHash = await computeMessageSecretHash(secret);
     const secretString = `0x${secretHash.toBuffer().toString('hex')}` as `0x${string}`;
     logger('Generated claim secret: ', secretString);
 

--- a/yarn-project/end-to-end/src/integration_archiver_l1_to_l2.test.ts
+++ b/yarn-project/end-to-end/src/integration_archiver_l1_to_l2.test.ts
@@ -1,9 +1,7 @@
 import { AztecNodeConfig, AztecNodeService } from '@aztec/aztec-node';
-import { AztecAddress, AztecRPCServer, Contract } from '@aztec/aztec.js';
+import { AztecAddress, AztecRPCServer, Contract, createMessageSecretAndHash } from '@aztec/aztec.js';
 import { EthAddress } from '@aztec/foundation/eth-address';
 
-import { CircuitsWasm } from '@aztec/circuits.js';
-import { computeSecretMessageHash } from '@aztec/circuits.js/abis';
 import { DeployL1Contracts } from '@aztec/ethereum';
 import { Fr } from '@aztec/foundation/fields';
 import { DebugLogger } from '@aztec/foundation/log';
@@ -84,12 +82,10 @@ describe('archiver integration with l1 to l2 messages', () => {
     // create a message, then cancel it
 
     // Generate a claim secret using pedersen
-    // TODO (#741): make this into an aztec.js utility function
     logger("Generating a claim secret using pedersen's hash function");
-    const wasm = await CircuitsWasm.get();
     const secret = Fr.random();
-    const claimSecretHash = computeSecretMessageHash(wasm, secret);
-    logger('Generated claim secret: ', claimSecretHash.toString());
+    const secretString = await createMessageSecretAndHash(secret);
+    logger('Generated claim secret: ', secretString);
 
     logger('Minting tokens on L1');
     await underlyingERC20.write.mint([ethAccount.toString(), 1000000n], {} as any);
@@ -98,7 +94,6 @@ describe('archiver integration with l1 to l2 messages', () => {
     expect(await underlyingERC20.read.balanceOf([ethAccount.toString()])).toBe(1000000n);
 
     // Deposit tokens to the TokenPortal
-    const secretString = `0x${claimSecretHash.toBuffer().toString('hex')}` as `0x${string}`;
     const deadline = Number((await publicClient.getBlock()).timestamp + 1000n);
     const mintAmount = 100n;
 

--- a/yarn-project/end-to-end/src/integration_archiver_l1_to_l2.test.ts
+++ b/yarn-project/end-to-end/src/integration_archiver_l1_to_l2.test.ts
@@ -1,5 +1,5 @@
 import { AztecNodeConfig, AztecNodeService } from '@aztec/aztec-node';
-import { AztecAddress, AztecRPCServer, Contract, createMessageSecretAndHash } from '@aztec/aztec.js';
+import { AztecAddress, AztecRPCServer, Contract, computeMessageSecretHash } from '@aztec/aztec.js';
 import { EthAddress } from '@aztec/foundation/eth-address';
 
 import { DeployL1Contracts } from '@aztec/ethereum';
@@ -83,8 +83,8 @@ describe('archiver integration with l1 to l2 messages', () => {
 
     // Generate a claim secret using pedersen
     logger("Generating a claim secret using pedersen's hash function");
-    const secret = Fr.random();
-    const secretString = await createMessageSecretAndHash(secret);
+    const secretHash = await computeMessageSecretHash();
+    const secretString = `0x${secretHash.toBuffer().toString('hex')}` as `0x${string}`;
     logger('Generated claim secret: ', secretString);
 
     logger('Minting tokens on L1');

--- a/yarn-project/types/src/l1_to_l2_message.ts
+++ b/yarn-project/types/src/l1_to_l2_message.ts
@@ -2,8 +2,6 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, serializeToBuffer } from '@aztec/circuits.js/utils';
-import { sha256 } from '@aztec/foundation/crypto';
-import { toBigIntBE, toBufferBE } from '@aztec/foundation/bigint-buffer';
 
 /**
  * Interface of classes allowing for the retrieval of L1 to L2 messages.
@@ -73,13 +71,6 @@ export class L1ToL2Message {
      */
     public readonly entryKey?: Fr,
   ) {}
-
-  // TODO: (#646) - sha256 hash of the message packed the same as solidity
-  hash(): Fr {
-    const buf = this.toBuffer();
-    const temp = toBigIntBE(sha256(buf));
-    return Fr.fromBuffer(toBufferBE(temp % Fr.MODULUS, 32));
-  }
 
   /**
    * Returns each element within its own field so that it can be consumed by an acvm oracle call.


### PR DESCRIPTION
# Description
* fix #741  - create a utils in aztec.js for generating secret hash given a secret.
* fix #646 - `hash()` is not used anywhere
# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
