### PR TITLE
fix(noir): remove jq command, as aztec3-hacky no longer outputs pk-vk

### DIFF
--- a/yarn-project/noir-contracts/src/scripts/compile.sh
+++ b/yarn-project/noir-contracts/src/scripts/compile.sh
@@ -13,13 +13,6 @@ for CONTRACT_NAME in "$@"; do
     nargo compile main --contracts
   fi
 
-  # Trim the output of the noir json, removing unneeded fields to make it small enough to be processed by copy_output.ts
-  # This is a workaround until noir output files get smaller
-  FILENAME=$(ls target/*.json)
-  echo "Trimming output for $FILENAME"
-  jq -c '.functions[] |= del(.proving_key, .verification_key)' $FILENAME > temp.json 
-  mv temp.json $FILENAME
-
   cd $ROOT
   echo "Copying output for $CONTRACT_NAME"
   NODE_OPTIONS=--no-warnings yarn ts-node --esm src/scripts/copy_output.ts $CONTRACT_NAME


### PR DESCRIPTION
# Description

Tiny pr to remove jq from `compile.sh` -> see https://github.com/noir-lang/noir/pull/1710

Please provide a paragraph or two giving a summary of the change, including relevant motivation and context.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
