### PR TITLE
fix: use tuple alias for fixed length arrays

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -9,6 +9,8 @@ import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { randomBytes } from '@aztec/foundation/crypto';
 import { ArchiverDataStore, MemoryArchiverStore } from './archiver_store.js';
 import { Fr } from '@aztec/foundation/fields';
+import { padArrayEnd } from '@aztec/foundation/collection';
+import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/circuits.js';
 
 describe('Archiver', () => {
   const rollupAddress = '0x0000000000000000000000000000000000000000';
@@ -96,11 +98,13 @@ describe('Archiver', () => {
 
     // Check that only 2 messages (l1ToL2MessageAddedEvents[3][2] and l1ToL2MessageAddedEvents[3][3]) are pending.
     // Other two (l1ToL2MessageAddedEvents[3][0..2]) were cancelled. And the previous messages were confirmed.
-    const expectedPendingMessageKeys = [
-      l1ToL2MessageAddedEvents[3][2].args.entryKey,
-      l1ToL2MessageAddedEvents[3][3].args.entryKey,
-    ];
-    const actualPendingMessageKeys = (await archiver.getPendingL1ToL2Messages(10)).map(key => key.toString(true));
+    const expectedPendingMessageKeys = padArrayEnd(
+      [l1ToL2MessageAddedEvents[3][2].args.entryKey, l1ToL2MessageAddedEvents[3][3].args.entryKey],
+      Fr.ZERO.toString(true),
+      NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
+    );
+
+    const actualPendingMessageKeys = (await archiver.getPendingL1ToL2Messages()).map(key => key.toString(true));
     expect(expectedPendingMessageKeys).toEqual(actualPendingMessageKeys);
 
     // Expect logs to correspond to what is set by L2Block.random(...)

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -3,7 +3,7 @@ import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
-import { INITIAL_L2_BLOCK_NUM, L1ToL2Message, L1ToL2MessageSource, L2BlockL2Logs } from '@aztec/types';
+import { INITIAL_L2_BLOCK_NUM, L1ToL2Message, L1ToL2MessageSource, L2BlockL2Logs, NewL1ToL2Messages } from '@aztec/types';
 import {
   ContractData,
   ContractPublicData,
@@ -25,6 +25,8 @@ import {
   retrieveNewCancelledL1ToL2Messages,
 } from './data_retrieval.js';
 import { ArchiverDataStore, MemoryArchiverStore } from './archiver_store.js';
+import { padArrayEnd } from '@aztec/foundation/collection';
+import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/circuits.js';
 
 /**
  * Pulls L2 blocks in a non-blocking manner and provides interface for their retrieval.
@@ -336,11 +338,14 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
 
   /**
    * Gets the `take` amount of pending L1 to L2 messages.
+   * Note: The returned array will be padded to `NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP`.
    * @param take - The number of messages to return.
    * @returns The requested L1 to L2 messages' keys.
    */
-  getPendingL1ToL2Messages(take: number): Promise<Fr[]> {
-    return this.store.getPendingL1ToL2MessageKeys(take);
+  // TODO: remove the take from there? Does it make sense to stay?
+  async getPendingL1ToL2Messages(take: number): Promise<NewL1ToL2Messages> {
+    const messages = await this.store.getPendingL1ToL2MessageKeys(take);
+    return padArrayEnd(messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
   }
 
   /**

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -3,7 +3,13 @@ import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
-import { INITIAL_L2_BLOCK_NUM, L1ToL2Message, L1ToL2MessageSource, L2BlockL2Logs, NewL1ToL2Messages } from '@aztec/types';
+import {
+  INITIAL_L2_BLOCK_NUM,
+  L1ToL2Message,
+  L1ToL2MessageSource,
+  L2BlockL2Logs,
+  NewL1ToL2Messages,
+} from '@aztec/types';
 import {
   ContractData,
   ContractPublicData,

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -343,14 +343,12 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
   }
 
   /**
-   * Gets the `take` amount of pending L1 to L2 messages.
-   * Note: The returned array will be padded to `NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP`.
-   * @param take - The number of messages to return.
+   * Gets the `NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP` amount of pending L1 to L2 messages.
+   * If there are not enough messages, it will be padded to `NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP`.
    * @returns The requested L1 to L2 messages' keys.
    */
-  // TODO: remove the take from there? Does it make sense to stay?
-  async getPendingL1ToL2Messages(take: number): Promise<NewL1ToL2Messages> {
-    const messages = await this.store.getPendingL1ToL2MessageKeys(take);
+  async getPendingL1ToL2Messages(): Promise<NewL1ToL2Messages> {
+    const messages = await this.store.getPendingL1ToL2MessageKeys();
     return padArrayEnd(messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
   }
 

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -67,11 +67,11 @@ export interface ArchiverDataStore {
   confirmL1ToL2Messages(messageKeys: Fr[]): Promise<boolean>;
 
   /**
-   * Gets the `take` amount of pending L1 to L2 messages, sorted by fee
-   * @param take - The number of messages to return (by default NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).
-   * @returns The requested L1 to L2 message keys.
+   * Gets the `NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP` amount of pending L1 to L2 messages.
+   * If there are not enough messages, it will be padded to `NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP`.
+   * @returns The requested L1 to L2 messages' keys.
    */
-  getPendingL1ToL2MessageKeys(take: number): Promise<Fr[]>;
+  getPendingL1ToL2MessageKeys(): Promise<Fr[]>;
 
   /**
    * Gets the confirmed L1 to L2 message corresponding to the given message key.

--- a/yarn-project/end-to-end/src/integration_archiver_l1_to_l2.test.ts
+++ b/yarn-project/end-to-end/src/integration_archiver_l1_to_l2.test.ts
@@ -118,7 +118,8 @@ describe('archiver integration with l1 to l2 messages', () => {
     await delay(5000);
 
     // archiver shouldn't have any pending messages.
-    expect((await archiver.getPendingL1ToL2Messages(10)).length).toEqual(0);
+    const pendingMessages = await archiver.getPendingL1ToL2Messages();
+    pendingMessages.forEach(e => expect(e).toEqual(Fr.ZERO));
   }, 80_000);
 
   it('archiver handles l1 to l2 message correctly even when l2block has no such messages', async () => {
@@ -132,7 +133,8 @@ describe('archiver integration with l1 to l2 messages', () => {
       )
       .send({ from: accounts[0] });
 
-    expect((await archiver.getPendingL1ToL2Messages(10)).length).toEqual(0);
+    const pendingMessages = await archiver.getPendingL1ToL2Messages();
+    pendingMessages.forEach(e => expect(e).toEqual(Fr.ZERO));
     expect(() => archiver.getConfirmedL1ToL2Message(Fr.ZERO)).toThrow();
   });
 });

--- a/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
@@ -48,6 +48,7 @@ import {
 import { PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
 import { localAnvil } from './fixtures.js';
 import { to2Fields } from '@aztec/foundation/serialize';
+import { padArrayEnd } from '@aztec/foundation/collection';
 
 // Accounts 4 and 5 of Anvil default startup with mnemonic: 'test test test test test test test test test test test junk'
 const sequencerPK = '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a';
@@ -266,7 +267,11 @@ describe('L1Publisher integration', () => {
         await makeBloatedProcessedTx(128 * i + 96),
         await makeBloatedProcessedTx(128 * i + 128),
       ];
-      const [block] = await builder.buildL2Block(1 + i, txs, l1ToL2Messages);
+
+      // L1 to L2 messages must be of length `NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP`.
+      const paddedL1ToL2Messages = padArrayEnd(l1ToL2Messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
+
+      const [block] = await builder.buildL2Block(1 + i, txs, paddedL1ToL2Messages);
 
       // check that values are in the inbox
       for (let j = 0; j < l1ToL2Messages.length; j++) {
@@ -344,7 +349,7 @@ describe('L1Publisher integration', () => {
     const blockNumber = await publicClient.getBlockNumber();
 
     for (let i = 0; i < numberOfConsecutiveBlocks; i++) {
-      const l1ToL2Messages = new Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n));
+      const l1ToL2Messages = makeTuple(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, () => Fr.ZERO);
       const txs = [
         await makeEmptyProcessedTx(),
         await makeEmptyProcessedTx(),

--- a/yarn-project/foundation/src/serialize/buffer_reader.ts
+++ b/yarn-project/foundation/src/serialize/buffer_reader.ts
@@ -1,5 +1,5 @@
 import { Fr, Fq } from '../fields/fields.js';
-import { Tuple } from './types.js';
+import { Tuple, mapTuple } from './types.js';
 
 /**
  * The BufferReader class provides a utility for reading various data types from a buffer.
@@ -138,6 +138,32 @@ export class BufferReader {
     }
     return result;
   }
+
+  /**
+   * Reads a vector of fixed size from the buffer and deserializes its elements into a fixed size tuple object using the provided
+   * itemDeserializer object.
+   * The 'itemDeserializer' object should have a 'fromBuffer' method that takes a BufferReader instance and returns the deserialized element.
+   * The method first reads the size of the vector (a number) from the buffer, then iterates through its elements,
+   * deserializing each one using the 'fromBuffer' method of 'itemDeserializer'.
+   *
+   * @param itemDeserializer - Object with 'fromBuffer' method to deserialize vector elements.
+   * @returns An array of deserialized elements of type T.
+   */
+  public readTuple<T, N extends number>(
+    itemDeserializer: {
+    /**
+     * A method to deserialize data from a buffer.
+     */
+    fromBuffer: (reader: BufferReader) => T;
+  }): Tuple<T, N> {
+    const size = this.readNumber();
+    const result = new Array<T>(size as N);
+    for (let i = 0; i < size; i++) {
+      result[i] = itemDeserializer.fromBuffer(this);
+    }
+    return result as Tuple<T, N>;
+  }
+
 
   /**
    * Read an array of a fixed size with elements of type T from the buffer.

--- a/yarn-project/foundation/src/serialize/buffer_reader.ts
+++ b/yarn-project/foundation/src/serialize/buffer_reader.ts
@@ -1,5 +1,5 @@
 import { Fr, Fq } from '../fields/fields.js';
-import { Tuple, mapTuple } from './types.js';
+import { Tuple } from './types.js';
 
 /**
  * The BufferReader class provides a utility for reading various data types from a buffer.
@@ -149,8 +149,7 @@ export class BufferReader {
    * @param itemDeserializer - Object with 'fromBuffer' method to deserialize vector elements.
    * @returns An array of deserialized elements of type T.
    */
-  public readTuple<T, N extends number>(
-    itemDeserializer: {
+  public readTuple<T, N extends number>(itemDeserializer: {
     /**
      * A method to deserialize data from a buffer.
      */
@@ -163,7 +162,6 @@ export class BufferReader {
     }
     return result as Tuple<T, N>;
   }
-
 
   /**
    * Read an array of a fixed size with elements of type T from the buffer.

--- a/yarn-project/sequencer-client/src/block_builder/solo_block_builder.test.ts
+++ b/yarn-project/sequencer-client/src/block_builder/solo_block_builder.test.ts
@@ -16,7 +16,6 @@ import {
   PublicDataUpdateRequest,
   RootRollupPublicInputs,
   makeTuple,
-  range,
 } from '@aztec/circuits.js';
 import { computeContractLeaf } from '@aztec/circuits.js/abis';
 import {
@@ -29,7 +28,16 @@ import {
   makeRootRollupPublicInputs,
 } from '@aztec/circuits.js/factories';
 import { toBufferBE } from '@aztec/foundation/bigint-buffer';
-import { ContractData, L2Block, L2BlockL2Logs, MerkleTreeId, NewL1ToL2Messages, PublicDataWrite, Tx, TxL2Logs } from '@aztec/types';
+import {
+  ContractData,
+  L2Block,
+  L2BlockL2Logs,
+  MerkleTreeId,
+  NewL1ToL2Messages,
+  PublicDataWrite,
+  Tx,
+  TxL2Logs,
+} from '@aztec/types';
 import { MerkleTreeOperations, MerkleTrees } from '@aztec/world-state';
 import { MockProxy, mock } from 'jest-mock-extended';
 import { default as levelup } from 'levelup';

--- a/yarn-project/sequencer-client/src/block_builder/solo_block_builder.test.ts
+++ b/yarn-project/sequencer-client/src/block_builder/solo_block_builder.test.ts
@@ -29,7 +29,7 @@ import {
   makeRootRollupPublicInputs,
 } from '@aztec/circuits.js/factories';
 import { toBufferBE } from '@aztec/foundation/bigint-buffer';
-import { ContractData, L2Block, L2BlockL2Logs, MerkleTreeId, PublicDataWrite, Tx, TxL2Logs } from '@aztec/types';
+import { ContractData, L2Block, L2BlockL2Logs, MerkleTreeId, NewL1ToL2Messages, PublicDataWrite, Tx, TxL2Logs } from '@aztec/types';
 import { MerkleTreeOperations, MerkleTrees } from '@aztec/world-state';
 import { MockProxy, mock } from 'jest-mock-extended';
 import { default as levelup } from 'levelup';
@@ -66,7 +66,7 @@ describe('sequencer/solo_block_builder', () => {
   let baseRollupOutputLeft: BaseOrMergeRollupPublicInputs;
   let baseRollupOutputRight: BaseOrMergeRollupPublicInputs;
   let rootRollupOutput: RootRollupPublicInputs;
-  let mockL1ToL2Messages: Fr[];
+  let mockL1ToL2Messages: NewL1ToL2Messages;
 
   let wasm: CircuitsWasm;
 
@@ -89,7 +89,7 @@ describe('sequencer/solo_block_builder', () => {
     builder = new SoloBlockBuilder(builderDb, vks, simulator, prover, chainId, version);
 
     // Create mock l1 to L2 messages
-    mockL1ToL2Messages = new Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n));
+    mockL1ToL2Messages = makeTuple(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, () => Fr.ZERO);
 
     // Create mock outputs for simulator
     baseRollupOutputLeft = makeBaseOrMergeRollupPublicInputs();
@@ -279,14 +279,6 @@ describe('sequencer/solo_block_builder', () => {
       const actual = await builderDb.getTreeInfo(MerkleTreeId.NULLIFIER_TREE);
       expect(actual).toEqual(expected);
     });
-
-    it('rejects if too many l1 to l2 messages are provided', async () => {
-      // Assemble a fake transaction
-      const txs = await buildMockSimulatorInputs();
-      const l1ToL2Messages = new Array(100).fill(new Fr(0n));
-
-      await expect(builder.buildL2Block(blockNumber, txs, l1ToL2Messages)).rejects.toThrow();
-    });
   });
 
   describe('circuits simulator', () => {
@@ -378,7 +370,7 @@ describe('sequencer/solo_block_builder', () => {
         makeBloatedProcessedTx(128),
       ]);
 
-      const l1ToL2Messages = range(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, 1 + 0x400).map(fr);
+      const l1ToL2Messages = makeTuple(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, () => fr(1 + 0x400));
 
       const [l2Block] = await builder.buildL2Block(1, txs, l1ToL2Messages);
       expect(l2Block.number).toEqual(1);

--- a/yarn-project/sequencer-client/src/block_builder/solo_block_builder.ts
+++ b/yarn-project/sequencer-client/src/block_builder/solo_block_builder.ts
@@ -26,7 +26,15 @@ import {
   makeTuple,
 } from '@aztec/circuits.js';
 import { computeContractLeaf } from '@aztec/circuits.js/abis';
-import { MerkleTreeId, ContractData, L2Block, PublicDataWrite, TxL2Logs, L2BlockL2Logs, NewL1ToL2Messages } from '@aztec/types';
+import {
+  MerkleTreeId,
+  ContractData,
+  L2Block,
+  PublicDataWrite,
+  TxL2Logs,
+  L2BlockL2Logs,
+  NewL1ToL2Messages,
+} from '@aztec/types';
 import { MerkleTreeOperations } from '@aztec/world-state';
 import chunk from 'lodash.chunk';
 import flatMap from 'lodash.flatmap';

--- a/yarn-project/sequencer-client/src/block_builder/solo_block_builder.ts
+++ b/yarn-project/sequencer-client/src/block_builder/solo_block_builder.ts
@@ -26,7 +26,7 @@ import {
   makeTuple,
 } from '@aztec/circuits.js';
 import { computeContractLeaf } from '@aztec/circuits.js/abis';
-import { MerkleTreeId, ContractData, L2Block, PublicDataWrite, TxL2Logs, L2BlockL2Logs } from '@aztec/types';
+import { MerkleTreeId, ContractData, L2Block, PublicDataWrite, TxL2Logs, L2BlockL2Logs, NewL1ToL2Messages } from '@aztec/types';
 import { MerkleTreeOperations } from '@aztec/world-state';
 import chunk from 'lodash.chunk';
 import flatMap from 'lodash.flatmap';
@@ -85,7 +85,7 @@ export class SoloBlockBuilder implements BlockBuilder {
   public async buildL2Block(
     blockNumber: number,
     txs: ProcessedTx[],
-    newL1ToL2Messages: Fr[],
+    newL1ToL2Messages: NewL1ToL2Messages,
     timestamp = 0,
   ): Promise<[L2Block, Proof]> {
     this.globalVariables = new GlobalVariables(this.chainId, this.version, new Fr(blockNumber), new Fr(timestamp));

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -1,6 +1,6 @@
-import { CombinedHistoricTreeRoots, Fr, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, makeEmptyProof } from '@aztec/circuits.js';
+import { CombinedHistoricTreeRoots, Fr, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, makeEmptyProof, makeTuple } from '@aztec/circuits.js';
 import { P2P, P2PClientState } from '@aztec/p2p';
-import { L1ToL2MessageSource, L2Block, L2BlockSource, MerkleTreeId, Tx, TxHash } from '@aztec/types';
+import { L1ToL2MessageSource, L2Block, L2BlockSource, MerkleTreeId, NewL1ToL2Messages, Tx, TxHash } from '@aztec/types';
 import { MerkleTreeOperations, WorldStateRunningState, WorldStateSynchroniser } from '@aztec/world-state';
 import { MockProxy, mock } from 'jest-mock-extended';
 import times from 'lodash.times';
@@ -55,7 +55,7 @@ describe('sequencer', () => {
     });
 
     l1ToL2MessageSource = mock<L1ToL2MessageSource>({
-      getPendingL1ToL2Messages: () => Promise.resolve(Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(Fr.ZERO)),
+      getPendingL1ToL2Messages: () => Promise.resolve(makeTuple(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, () => Fr.ZERO)),
     });
 
     sequencer = new TestSubject(

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -1,6 +1,12 @@
-import { CombinedHistoricTreeRoots, Fr, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, makeEmptyProof, makeTuple } from '@aztec/circuits.js';
+import {
+  CombinedHistoricTreeRoots,
+  Fr,
+  NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
+  makeEmptyProof,
+  makeTuple,
+} from '@aztec/circuits.js';
 import { P2P, P2PClientState } from '@aztec/p2p';
-import { L1ToL2MessageSource, L2Block, L2BlockSource, MerkleTreeId, NewL1ToL2Messages, Tx, TxHash } from '@aztec/types';
+import { L1ToL2MessageSource, L2Block, L2BlockSource, MerkleTreeId, Tx, TxHash } from '@aztec/types';
 import { MerkleTreeOperations, WorldStateRunningState, WorldStateSynchroniser } from '@aztec/world-state';
 import { MockProxy, mock } from 'jest-mock-extended';
 import times from 'lodash.times';

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -9,6 +9,7 @@ import {
   L2Block,
   L2BlockSource,
   MerkleTreeId,
+  NewL1ToL2Messages,
   Tx,
 } from '@aztec/types';
 import { WorldStateStatus, WorldStateSynchroniser } from '@aztec/world-state';
@@ -284,7 +285,7 @@ export class Sequencer {
    * (archiver returns the top messages sorted by fees)
    * @returns An array of L1 to L2 messages' messageKeys
    */
-  protected async getPendingL1ToL2Messages(): Promise<Fr[]> {
+  protected async getPendingL1ToL2Messages(): Promise<NewL1ToL2Messages> {
     return await this.l1ToL2MessageSource.getPendingL1ToL2Messages();
   }
 

--- a/yarn-project/types/src/l1_to_l2_message.ts
+++ b/yarn-project/types/src/l1_to_l2_message.ts
@@ -2,6 +2,13 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, serializeToBuffer } from '@aztec/circuits.js/utils';
+import { Tuple } from '@aztec/foundation/serialize';
+import {NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP} from "@aztec/circuits.js"
+
+/**
+ * An array containing the `NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP` field elements.
+ */
+export type NewL1ToL2Messages = Tuple<Fr, typeof NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP>;
 
 /**
  * Interface of classes allowing for the retrieval of L1 to L2 messages.
@@ -12,7 +19,7 @@ export interface L1ToL2MessageSource {
    * @param take - The number of messages to return (by default NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).
    * @returns The requested L1 to L2 messages' keys.
    */
-  getPendingL1ToL2Messages(take?: number): Promise<Fr[]>;
+  getPendingL1ToL2Messages(take?: number): Promise<NewL1ToL2Messages>;
 
   /**
    * Gets the confirmed L1 to L2 message with the given message key.

--- a/yarn-project/types/src/l1_to_l2_message.ts
+++ b/yarn-project/types/src/l1_to_l2_message.ts
@@ -3,7 +3,7 @@ import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, serializeToBuffer } from '@aztec/circuits.js/utils';
 import { Tuple } from '@aztec/foundation/serialize';
-import {NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP} from "@aztec/circuits.js"
+import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/circuits.js';
 
 /**
  * An array containing the `NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP` field elements.

--- a/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.test.ts
+++ b/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.test.ts
@@ -3,6 +3,7 @@ import {
   CircuitsWasm,
   GlobalVariables,
   NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
+  makeTuple,
 } from '@aztec/circuits.js';
 import { INITIAL_LEAF, Pedersen, SiblingPath } from '@aztec/merkle-tree';
 import { ContractData, L2Block, L2BlockL2Logs, L2BlockSource, MerkleTreeId, PublicDataWrite } from '@aztec/types';
@@ -48,7 +49,7 @@ const getMockGlobalVariables = () => {
 };
 
 const getMockL1ToL2MessagesData = () => {
-  return new Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).map(() => Fr.random());
+  return makeTuple(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, Fr.random);
 };
 
 const getMockBlock = (blockNumber: number, newContractsCommitments?: Buffer[]) => {


### PR DESCRIPTION
# Description

Take 2 on #645 

This changes the L1 to L2 messages type from a `Fr[]` to the type `NewL1ToL2Messages` which is an alias for `tuple<Fr, NewL1ToL2Messages>`.  

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
