### PR TITLE
fix: Fix ABI array/struct decoding

### DIFF
--- a/yarn-project/acir-simulator/src/abi_coder/decoder.ts
+++ b/yarn-project/acir-simulator/src/abi_coder/decoder.ts
@@ -32,7 +32,7 @@ class ReturnValuesDecoder {
         return array;
       }
       case 'struct': {
-        const struct: Record<string, DecodedReturn> = {};
+        const struct: { [key: string]: DecodedReturn } = {};
         for (const field of abiType.fields) {
           struct[field.name] = this.decodeReturn(field.type);
         }

--- a/yarn-project/acir-simulator/src/abi_coder/decoder.ts
+++ b/yarn-project/acir-simulator/src/abi_coder/decoder.ts
@@ -2,6 +2,11 @@ import { Fr } from '@aztec/foundation/fields';
 import { ABIType, FunctionAbi } from '@aztec/foundation/abi';
 
 /**
+ * The type of our decoded ABI.
+ */
+type DecodedReturn = bigint | boolean | DecodedReturn[];
+
+/**
  * Decodes return values from a function call.
  * Missing support for integer and string.
  */
@@ -13,7 +18,7 @@ class ReturnValuesDecoder {
    * @param abiType - The type of the return value.
    * @returns The decoded return value.
    */
-  private decodeReturn(abiType: ABIType): any {
+  private decodeReturn(abiType: ABIType): DecodedReturn {
     switch (abiType.kind) {
       case 'field':
         return this.getNextField().value;
@@ -24,7 +29,7 @@ class ReturnValuesDecoder {
         for (let i = 0; i < abiType.length; i += 1) {
           array.push(this.decodeReturn(abiType.type));
         }
-        break;
+        return array;
       }
       case 'struct': {
         const struct: any = {};
@@ -33,9 +38,8 @@ class ReturnValuesDecoder {
         }
         break;
       }
-      default:
-        throw new Error(`Unsupported type: ${abiType.kind}`);
     }
+    throw new Error(`Unsupported type: ${abiType.kind}`);
   }
 
   /**

--- a/yarn-project/acir-simulator/src/abi_coder/decoder.ts
+++ b/yarn-project/acir-simulator/src/abi_coder/decoder.ts
@@ -36,10 +36,11 @@ class ReturnValuesDecoder {
         for (const field of abiType.fields) {
           struct[field.name] = this.decodeReturn(field.type);
         }
-        break;
+        return struct;
       }
+      default:
+        throw new Error(`Unsupported type: ${abiType.kind}`);
     }
-    throw new Error(`Unsupported type: ${abiType.kind}`);
   }
 
   /**

--- a/yarn-project/acir-simulator/src/abi_coder/decoder.ts
+++ b/yarn-project/acir-simulator/src/abi_coder/decoder.ts
@@ -4,7 +4,7 @@ import { ABIType, FunctionAbi } from '@aztec/foundation/abi';
 /**
  * The type of our decoded ABI.
  */
-type DecodedReturn = bigint | boolean | DecodedReturn[] | Record<string, DecodedReturn>;
+type DecodedReturn = bigint | boolean | DecodedReturn[] | { [key: string]: DecodedReturn };
 
 /**
  * Decodes return values from a function call.

--- a/yarn-project/acir-simulator/src/abi_coder/decoder.ts
+++ b/yarn-project/acir-simulator/src/abi_coder/decoder.ts
@@ -4,7 +4,7 @@ import { ABIType, FunctionAbi } from '@aztec/foundation/abi';
 /**
  * The type of our decoded ABI.
  */
-type DecodedReturn = bigint | boolean | DecodedReturn[];
+type DecodedReturn = bigint | boolean | DecodedReturn[] | Record<string, DecodedReturn>;
 
 /**
  * Decodes return values from a function call.
@@ -32,7 +32,7 @@ class ReturnValuesDecoder {
         return array;
       }
       case 'struct': {
-        const struct: any = {};
+        const struct: Record<string, DecodedReturn> = {};
         for (const field of abiType.fields) {
           struct[field.name] = this.decodeReturn(field.type);
         }


### PR DESCRIPTION
# Description

Came out of Noir/aztec dogfooding. Could not return an array from a view function. Gets rid of `any`'s

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
