### PR TITLE
fix(foundation): should error on attempt to convert negative bigint to buffer

### DIFF
--- a/yarn-project/foundation/src/bigint-buffer/index.ts
+++ b/yarn-project/foundation/src/bigint-buffer/index.ts
@@ -33,6 +33,9 @@ export function toBigIntBE(buf: Buffer): bigint {
  * @returns A little-endian buffer representation of num.
  */
 export function toBufferLE(num: bigint, width: number): Buffer {
+  if (num < BigInt(0)) {
+    throw new Error(`Cannot convert negative bigint ${num.toString()} to buffer with toBufferLE.`);
+  }
   const hex = num.toString(16);
   const buffer = Buffer.from(hex.padStart(width * 2, '0').slice(0, width * 2), 'hex');
   buffer.reverse();
@@ -46,6 +49,9 @@ export function toBufferLE(num: bigint, width: number): Buffer {
  * @returns A big-endian buffer representation of num.
  */
 export function toBufferBE(num: bigint, width: number): Buffer {
+  if (num < BigInt(0)) {
+    throw new Error(`Cannot convert negative bigint ${num.toString()} to buffer with toBufferBE.`);
+  }
   const hex = num.toString(16);
   const buffer = Buffer.from(hex.padStart(width * 2, '0').slice(0, width * 2), 'hex');
   if (buffer.length > width) throw new Error(`Number ${num.toString(16)} does not fit in ${width}`);

--- a/yarn-project/foundation/src/bigint-buffer/index.ts
+++ b/yarn-project/foundation/src/bigint-buffer/index.ts
@@ -33,9 +33,7 @@ export function toBigIntBE(buf: Buffer): bigint {
  * @returns A little-endian buffer representation of num.
  */
 export function toBufferLE(num: bigint, width: number): Buffer {
-  if (num < BigInt(0)) {
-    throw new Error(`Cannot convert negative bigint ${num.toString()} to buffer with toBufferLE.`);
-  }
+  if (num < BigInt(0)) throw new Error(`Cannot convert negative bigint ${num.toString()} to buffer with toBufferLE.`);
   const hex = num.toString(16);
   const buffer = Buffer.from(hex.padStart(width * 2, '0').slice(0, width * 2), 'hex');
   buffer.reverse();
@@ -49,9 +47,7 @@ export function toBufferLE(num: bigint, width: number): Buffer {
  * @returns A big-endian buffer representation of num.
  */
 export function toBufferBE(num: bigint, width: number): Buffer {
-  if (num < BigInt(0)) {
-    throw new Error(`Cannot convert negative bigint ${num.toString()} to buffer with toBufferBE.`);
-  }
+  if (num < BigInt(0)) throw new Error(`Cannot convert negative bigint ${num.toString()} to buffer with toBufferBE.`);
   const hex = num.toString(16);
   const buffer = Buffer.from(hex.padStart(width * 2, '0').slice(0, width * 2), 'hex');
   if (buffer.length > width) throw new Error(`Number ${num.toString(16)} does not fit in ${width}`);


### PR DESCRIPTION
# Description

Should error on attempt to convert negative bigint to buffer. Encountered this in a branch when intentionally using leafIndex -1 to flag commitments as transient.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
