### PR TITLE
chore(circuits): better cpp error message for read_requests that hash to wrong root

### DIFF
--- a/circuits/cpp/src/aztec3/circuits/kernel/private/common.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/common.cpp
@@ -93,21 +93,22 @@ void common_validate_read_requests(DummyBuilder& builder,
         if (read_request != 0 && !is_transient_read) {
             const auto& root_for_read_request =
                 root_from_sibling_path<NT>(leaf, witness.leaf_index, witness.sibling_path);
-            builder.do_assert(root_for_read_request == historic_private_data_tree_root,
-                              format("private data root mismatch at read_request[",
-                                     rr_idx,
-                                     "]",
-                                     "\n\texpected root:    ",
-                                     historic_private_data_tree_root,
-                                     "\n\tbut got root*:    ",
-                                     root_for_read_request,
-                                     "\n\tread_request:     ",
-                                     read_request,
-                                     "\n\tsiloed-rr (leaf): ",
-                                     leaf,
-                                     "\n\t* got root by siloing read_request with contract address (to get leaf) and "
-                                     "merkle-hashing to a root using membership witness"),
-                              CircuitErrorCode::PRIVATE_KERNEL__READ_REQUEST_PRIVATE_DATA_ROOT_MISMATCH);
+            builder.do_assert(
+                root_for_read_request == historic_private_data_tree_root,
+                format("private data tree root mismatch at read_request[",
+                       rr_idx,
+                       "]",
+                       "\n\texpected root:    ",
+                       historic_private_data_tree_root,
+                       "\n\tbut got root*:    ",
+                       root_for_read_request,
+                       "\n\tread_request:     ",
+                       read_request,
+                       "\n\tsiloed-rr (leaf): ",
+                       leaf,
+                       "\n\t* got root by siloing read_request (compressing with storage_contract_address to get leaf) "
+                       "and merkle-hashing to a root using membership witness"),
+                CircuitErrorCode::PRIVATE_KERNEL__READ_REQUEST_PRIVATE_DATA_ROOT_MISMATCH);
         }
     }
 }

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/common.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/common.cpp
@@ -96,11 +96,17 @@ void common_validate_read_requests(DummyBuilder& builder,
             builder.do_assert(root_for_read_request == historic_private_data_tree_root,
                               format("private data root mismatch at read_request[",
                                      rr_idx,
-                                     "] - ",
-                                     "Expected root: ",
+                                     "]",
+                                     "\n\texpected root:    ",
                                      historic_private_data_tree_root,
-                                     ", Read request gave root: ",
-                                     root_for_read_request),
+                                     "\n\tbut got root*:    ",
+                                     root_for_read_request,
+                                     "\n\tread_request:     ",
+                                     read_request,
+                                     "\n\tsiloed-rr (leaf): ",
+                                     leaf,
+                                     "\n\t* got root by siloing read_request with contract address (to get leaf) and "
+                                     "merkle-hashing to a root using membership witness"),
                               CircuitErrorCode::PRIVATE_KERNEL__READ_REQUEST_PRIVATE_DATA_ROOT_MISMATCH);
         }
     }


### PR DESCRIPTION
# Description

Better cpp error message for read_requests that hash to wrong root. Helped me in debugging multiple times.

![image](https://github.com/AztecProtocol/aztec-packages/assets/47112877/1eec16c7-8718-4b6d-91ec-81fb6f0f1946)


# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
