### PR TITLE
chore: Wrap acvm-simulator's raw error string in new Error

### DIFF
--- a/yarn-project/aztec-rpc/src/account_state/account_state.ts
+++ b/yarn-project/aztec-rpc/src/account_state/account_state.ts
@@ -200,11 +200,16 @@ export class AccountState {
     );
 
     const simulator = await this.getAcirSimulator(contractDataOracle);
-    this.log('Executing simulator...');
-    const result = await simulator.run(txRequest, functionAbi, contractAddress, portalContract, historicRoots);
-    this.log('Simulation completed!');
 
-    return result;
+    try {
+      this.log('Executing simulator...');
+      const result = await simulator.run(txRequest, functionAbi, contractAddress, portalContract, historicRoots);
+      this.log('Simulation completed!');
+
+      return result;
+    } catch (err: any) {
+      throw typeof err === 'string' ? new Error(err) : err; // Work around raw string being thrown
+    }
   }
 
   /**

--- a/yarn-project/end-to-end/src/e2e_account_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_account_contract.test.ts
@@ -182,7 +182,7 @@ describe('e2e_account_contract', () => {
       await schnorrWallet.getAccountPublicKey(schnorrAccountContractAddress),
       schnorrWallet,
     );
-    await expect(child.methods.value(42).simulate({ from: schnorrAccountContractAddress })).rejects.toMatch(
+    await expect(child.methods.value(42).simulate({ from: schnorrAccountContractAddress })).rejects.toThrowError(
       /could not satisfy all constraints/,
     );
   }, 60_000);
@@ -198,7 +198,7 @@ describe('e2e_account_contract', () => {
     );
     logger('Deploying child contract...');
     child = await deployChildContract(await ecdsaWallet.getAccountPublicKey(ecdsaAccountContractAddress), ecdsaWallet);
-    await expect(child.methods.value(42).simulate({ from: ecdsaAccountContractAddress })).rejects.toMatch(
+    await expect(child.methods.value(42).simulate({ from: ecdsaAccountContractAddress })).rejects.toThrowError(
       /could not satisfy all constraints/,
     );
   }, 60_000);


### PR DESCRIPTION
acvm-simulator via acvm.js seems to throw a raw string, this is somewhat of an anti-pattern for error handling as there is no stack trace. Barring a better fix, doing this
Now
```
  ● e2e_c_gam_contract › should call join_game and queue a public call

    could not satisfy all constraints

      209 |       return result;
      210 |     } catch (err: any) {
    > 211 |       throw typeof err === 'string' ? new Error(err) : err; // Work around raw string being thrown
          |                                       ^
      212 |     }
      213 |   }
      214 |

      at AccountState.simulate (../../aztec-rpc/src/account_state/account_state.ts:211:39)
      at AccountState.simulateAndProve (../../aztec-rpc/src/account_state/account_state.ts:267:29)
      at AztecRPCServer.simulateTx (../../aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts:167:16)
      at ContractFunctionInteraction.simulate (../../aztec.js/src/contract/contract_function_interaction.ts:81:15)
      at ../../aztec.js/src/contract/contract_function_interaction.ts:118:30
      at SentTx.getTxHash (../../aztec.js/src/contract/sent_tx.ts:18:12)
      at SentTx.isMined (../../aztec.js/src/contract/sent_tx
 ```
before: no stack trace   
