### PR TITLE
use .reverse() + do same for public calls + unit tests

### DIFF
--- a/yarn-project/acir-simulator/src/client/execution_result.test.ts
+++ b/yarn-project/acir-simulator/src/client/execution_result.test.ts
@@ -1,0 +1,137 @@
+import { FunctionL2Logs } from '@aztec/types';
+import { ExecutionResult, collectEncryptedLogs } from './execution_result.js';
+import { PrivateCallStackItem } from '@aztec/circuits.js';
+
+describe('Execution Result test suite - collect encrypted logs', () => {
+  function emptyExecutionResultWithEncryptedLogs(encryptedLogs = FunctionL2Logs.empty()): ExecutionResult {
+    return {
+      acir: Buffer.from(''),
+      vk: Buffer.from(''),
+      partialWitness: new Map(),
+      callStackItem: PrivateCallStackItem.empty(),
+      readRequestCommitmentIndices: [],
+      preimages: {
+        newNotes: [],
+        nullifiedNotes: [],
+      },
+      returnValues: [],
+      nestedExecutions: [],
+      enqueuedPublicFunctionCalls: [],
+      encryptedLogs: encryptedLogs,
+      unencryptedLogs: FunctionL2Logs.empty(),
+    };
+  }
+
+  it('collect encrypted logs with nested fn calls', () => {
+    /*
+    Create the following executionResult object: 
+    fnA (log1) 
+        |---------->fnB (log2) 
+        |---------->fnC (log3) -> fnD (log4)
+        |---------->fnE (log5) 
+                     |-------->fnF (log6)
+                     |-------->fnG (log7) 
+    Circuits and ACVM process in a DFS + stack like format: [fnA, fnE, fnF, fnG fnC, fnD, fnB]
+    */
+    const executionResult: ExecutionResult = emptyExecutionResultWithEncryptedLogs(
+      new FunctionL2Logs([Buffer.from('Log 1')]),
+    );
+    const fnB = emptyExecutionResultWithEncryptedLogs(new FunctionL2Logs([Buffer.from('Log 2')]));
+    const fnC = emptyExecutionResultWithEncryptedLogs(new FunctionL2Logs([Buffer.from('Log 3')]));
+    const fnD = emptyExecutionResultWithEncryptedLogs(new FunctionL2Logs([Buffer.from('Log 4')]));
+    const fnE = emptyExecutionResultWithEncryptedLogs(new FunctionL2Logs([Buffer.from('Log 5')]));
+    const fnF = emptyExecutionResultWithEncryptedLogs(new FunctionL2Logs([Buffer.from('Log 6')]));
+    const fnG = emptyExecutionResultWithEncryptedLogs(new FunctionL2Logs([Buffer.from('Log 7')]));
+
+    fnE.nestedExecutions.push(fnF, fnG);
+
+    fnC.nestedExecutions.push(fnD);
+
+    executionResult.nestedExecutions.push(fnB, fnC, fnE);
+
+    const encryptedLogs = collectEncryptedLogs(executionResult);
+    expect(encryptedLogs).toEqual([
+      new FunctionL2Logs([Buffer.from('Log 1')]),
+      new FunctionL2Logs([Buffer.from('Log 5')]),
+      new FunctionL2Logs([Buffer.from('Log 7')]),
+      new FunctionL2Logs([Buffer.from('Log 6')]),
+      new FunctionL2Logs([Buffer.from('Log 3')]),
+      new FunctionL2Logs([Buffer.from('Log 4')]),
+      new FunctionL2Logs([Buffer.from('Log 2')]),
+    ]);
+  });
+
+  it('collect encrypted logs with multiple logs each function call', () => {
+    /*
+    Create the following executionResult object: 
+    fnA (log1, log2) 
+        |---------->fnB (log3, log4) 
+        |---------->fnC (log5) -> fnD (log6)
+    Circuits and ACVM process in a DFS + stack like format: [fnA, fnC, fnD, fnB]
+    */
+    const executionResult: ExecutionResult = emptyExecutionResultWithEncryptedLogs(
+      new FunctionL2Logs([Buffer.from('Log 1'), Buffer.from('Log 2')]),
+    );
+    const fnB = emptyExecutionResultWithEncryptedLogs(new FunctionL2Logs([Buffer.from('Log 3'), Buffer.from('Log 4')]));
+    const fnC = emptyExecutionResultWithEncryptedLogs(new FunctionL2Logs([Buffer.from('Log 5')]));
+    const fnD = emptyExecutionResultWithEncryptedLogs(new FunctionL2Logs([Buffer.from('Log 6')]));
+    fnC.nestedExecutions.push(fnD);
+    executionResult.nestedExecutions.push(fnB, fnC);
+    const encryptedLogs = collectEncryptedLogs(executionResult);
+    expect(encryptedLogs).toEqual([
+      new FunctionL2Logs([Buffer.from('Log 1'), Buffer.from('Log 2')]),
+      new FunctionL2Logs([Buffer.from('Log 5')]),
+      new FunctionL2Logs([Buffer.from('Log 6')]),
+      new FunctionL2Logs([Buffer.from('Log 3'), Buffer.from('Log 4')]),
+    ]);
+  });
+
+  it('collect encrypted logs with nested functions where some have no logs', () => {
+    /*
+    Create the following executionResult object: 
+    fnA () 
+        |----------> fnB (log1) -> fnC ()
+    Circuits and ACVM process in a DFS + stack like format: [fnA, fnB, fnC]
+    */
+    const executionResult: ExecutionResult = emptyExecutionResultWithEncryptedLogs();
+    const fnB = emptyExecutionResultWithEncryptedLogs(new FunctionL2Logs([Buffer.from('Log 1')]));
+    const fnC = emptyExecutionResultWithEncryptedLogs();
+    fnB.nestedExecutions.push(fnC);
+    executionResult.nestedExecutions.push(fnB);
+    const encryptedLogs = collectEncryptedLogs(executionResult);
+    expect(encryptedLogs).toEqual([
+      FunctionL2Logs.empty(),
+      new FunctionL2Logs([Buffer.from('Log 1')]),
+      FunctionL2Logs.empty(),
+    ]);
+  });
+
+  it('collect encrypted logs with no logs in any nested calls', () => {
+    /*
+    Create the following executionResult object:
+    fnA ()
+      |----------> fnB () -> fnC ()
+      |----------> fnD () -> fnE ()
+    Circuits and ACVM process in a DFS + stack like format: [fnA, fnB, fnC]
+    */
+    const executionResult: ExecutionResult = emptyExecutionResultWithEncryptedLogs();
+    const fnB = emptyExecutionResultWithEncryptedLogs();
+    const fnC = emptyExecutionResultWithEncryptedLogs();
+    const fnD = emptyExecutionResultWithEncryptedLogs();
+    const fnE = emptyExecutionResultWithEncryptedLogs();
+
+    fnB.nestedExecutions.push(fnC);
+    fnD.nestedExecutions.push(fnE);
+
+    executionResult.nestedExecutions.push(fnB, fnD);
+
+    const encryptedLogs = collectEncryptedLogs(executionResult);
+    expect(encryptedLogs).toEqual([
+      FunctionL2Logs.empty(),
+      FunctionL2Logs.empty(),
+      FunctionL2Logs.empty(),
+      FunctionL2Logs.empty(),
+      FunctionL2Logs.empty(),
+    ]);
+  });
+});

--- a/yarn-project/acir-simulator/src/client/execution_result.ts
+++ b/yarn-project/acir-simulator/src/client/execution_result.ts
@@ -78,15 +78,8 @@ export interface ExecutionResult {
  * @returns All encrypted logs.
  */
 export function collectEncryptedLogs(execResult: ExecutionResult): FunctionL2Logs[] {
-  const logs: FunctionL2Logs[] = [];
-  // traverse through the stack of nested executions
-  const executionStack = [execResult];
-  while (executionStack.length) {
-    const currentExecution = executionStack.pop()!;
-    executionStack.push(...currentExecution.nestedExecutions);
-    logs.push(currentExecution.encryptedLogs);
-  }
-  return logs;
+  // without the .reverse(), the logs will be in a queue like fashion which is wrong as the kernel processes it like a stack.
+  return [execResult.encryptedLogs, ...execResult.nestedExecutions.reverse().flatMap(collectEncryptedLogs)];
 }
 
 /**
@@ -95,15 +88,8 @@ export function collectEncryptedLogs(execResult: ExecutionResult): FunctionL2Log
  * @returns All unencrypted logs.
  */
 export function collectUnencryptedLogs(execResult: ExecutionResult): FunctionL2Logs[] {
-  const logs: FunctionL2Logs[] = [];
-  // traverse through the stack of nested executions
-  const executionStack = [execResult];
-  while (executionStack.length) {
-    const currentExecution = executionStack.pop()!;
-    executionStack.push(...currentExecution.nestedExecutions);
-    logs.push(currentExecution.unencryptedLogs);
-  }
-  return logs;
+  // without the .reverse(), the logs will be in a queue like fashion which is wrong as the kernel processes it like a stack.
+  return [execResult.unencryptedLogs, ...execResult.nestedExecutions.reverse().flatMap(collectUnencryptedLogs)];
 }
 
 /**
@@ -112,8 +98,9 @@ export function collectUnencryptedLogs(execResult: ExecutionResult): FunctionL2L
  * @returns All enqueued public function calls.
  */
 export function collectEnqueuedPublicFunctionCalls(execResult: ExecutionResult): PublicCallRequest[] {
+  // without the .reverse(), the logs will be in a queue like fashion which is wrong as the kernel processes it like a stack.
   return [
     ...execResult.enqueuedPublicFunctionCalls,
-    ...execResult.nestedExecutions.flatMap(collectEnqueuedPublicFunctionCalls),
+    ...execResult.nestedExecutions.reverse().flatMap(collectEnqueuedPublicFunctionCalls),
   ];
 }

--- a/yarn-project/types/src/logs/function_l2_logs.ts
+++ b/yarn-project/types/src/logs/function_l2_logs.ts
@@ -72,4 +72,12 @@ export class FunctionL2Logs {
     }
     return new FunctionL2Logs(logs);
   }
+
+  /**
+   * Creates an empty L2Logs object with no logs.
+   * @returns A new FunctionL2Logs object with no logs.
+   */
+  public static empty(): FunctionL2Logs {
+    return new FunctionL2Logs([]);
+  }
 }


### PR DESCRIPTION
# Description
Stack is basically a queue in a reverse order. So doing what santiago originally did but adding a `.reverse()` would work.
Added some tests

**Please sanity check that the ordering I have written in the tests are similar to what you would expect from ACVM or kernel**


# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
