### PR TITLE
e2e test that sends notes from 1 rpc server to another

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,6 +429,17 @@ jobs:
           name: "Build"
           command: build rollup-provider
 
+  e2e-2-rpc-servers:
+    docker:
+      - image: aztecprotocol/alpine-build-image
+    resource_class: small
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Test"
+          command: cond_spot_run_tests end-to-end e2e_2_rpc_servers.test.ts
+
   e2e-deploy-contract:
     docker:
       - image: aztecprotocol/alpine-build-image
@@ -797,6 +808,7 @@ workflows:
             - rollup-provider
           <<: *defaults
 
+      - e2e-2-rpc-servers: *e2e_test
       - e2e-deploy-contract: *e2e_test
       - e2e-zk-token-contract: *e2e_test
       - e2e-block-building: *e2e_test
@@ -814,6 +826,7 @@ workflows:
 
       - e2e-end:
           requires:
+            - e2e-2-rpc-servers
             - e2e-deploy-contract
             - e2e-zk-token-contract
             - e2e-block-building

--- a/yarn-project/aztec-cli/src/index.ts
+++ b/yarn-project/aztec-cli/src/index.ts
@@ -100,7 +100,7 @@ async function main() {
         1,
       );
       const accounts = await wallet.getAccounts();
-      const pubKeys = await Promise.all(accounts.map(acc => wallet.getAccountPublicKey(acc)));
+      const pubKeys = await Promise.all(accounts.map(acc => wallet.getPublicKey(acc)));
       log(`\nCreated account(s).`);
       accounts.map((acc, i) => log(`\nAddress: ${acc.toString()}\nPublic Key: ${pubKeys[i].toString()}\n`));
     });
@@ -129,7 +129,7 @@ async function main() {
         if (!accounts) {
           throw new Error('No public key provided or found in Aztec RPC.');
         }
-        publicKey = await client.getAccountPublicKey(accounts[0]);
+        publicKey = await client.getPublicKey(accounts[0]);
       }
 
       log(`Using Public Key: ${publicKey.toString()}`);
@@ -238,7 +238,7 @@ async function main() {
         log('No accounts found.');
       } else {
         log(`Accounts found: \n`);
-        accounts.forEach(async acc => log(`Address: ${acc}\nPublic Key: ${await client.getAccountPublicKey(acc)}\n`));
+        accounts.forEach(async acc => log(`Address: ${acc}\nPublic Key: ${await client.getPublicKey(acc)}\n`));
       }
     });
 
@@ -250,7 +250,7 @@ async function main() {
     .action(async (_address, options) => {
       const client = createAztecRpcClient(options.rpcUrl);
       const address = AztecAddress.fromString(_address);
-      const pk = await client.getAccountPublicKey(address);
+      const pk = await client.getPublicKey(address);
       if (!pk) {
         log(`Unkown account ${_address}`);
       } else {

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.test.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.test.ts
@@ -36,7 +36,7 @@ describe('AztecRpcServer', function () {
     const address = computeContractAddressFromPartial(wasm, pubKey, partialAddress);
 
     await rpcServer.addAccount(await keyPair.getPrivateKey(), address, partialAddress);
-    expect(await db.getPublicKey(address)).toEqual([pubKey, partialAddress]);
+    expect(await db.getPublicKeyAndPartialAddress(address)).toEqual([pubKey, partialAddress]);
   });
 
   // TODO(#1007)

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -151,11 +151,11 @@ export class AztecRPCServer implements AztecRPC {
    * Retrieve the public key associated with an address.
    * Throws an error if the account is not found in the key store.
    *
-   * @param address - The AztecAddress instance representing the account.
+   * @param address - The AztecAddress instance representing the account to get public key for.
    * @returns A Promise resolving to the Point instance representing the public key.
    */
-  public async getAccountPublicKey(address: AztecAddress): Promise<Point> {
-    const result = await this.db.getPublicKey(address);
+  public async getPublicKey(address: AztecAddress): Promise<Point> {
+    const result = await this.db.getPublicKeyAndPartialAddress(address);
     if (!result) {
       throw new Error(`Unable to public key for address ${address.toString()}`);
     }

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -12,7 +12,7 @@ import {
 } from '@aztec/circuits.js';
 import { FunctionType, encodeArguments } from '@aztec/foundation/abi';
 import { Fr, Point } from '@aztec/foundation/fields';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import {
   AztecNode,
   AztecRPC,
@@ -49,15 +49,17 @@ import { Synchroniser } from '../synchroniser/index.js';
  */
 export class AztecRPCServer implements AztecRPC {
   private synchroniser: Synchroniser;
+  private log: DebugLogger;
 
   constructor(
     private keyStore: KeyStore,
     private node: AztecNode,
     private db: Database,
     private config: RpcServerConfig,
-    private log = createDebugLogger('aztec:rpc_server'),
+    logSuffix = '0',
   ) {
-    this.synchroniser = new Synchroniser(node, db);
+    this.log = createDebugLogger('aztec:rpc_server_' + logSuffix);
+    this.synchroniser = new Synchroniser(node, db, logSuffix);
   }
 
   /**

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -100,24 +100,24 @@ export class AztecRPCServer implements AztecRPC {
     //     `Address cannot be derived from pubkey and partial address (received ${address.toString()}, derived ${expectedAddress.toString()})`,
     //   );
     // }
-    await this.db.addPublicKey(address, pubKey, partialContractAddress);
+    await this.db.addPublicKeyAndPartialAddress(address, pubKey, partialContractAddress);
     this.synchroniser.addAccount(pubKey, address, this.keyStore);
     return address;
   }
 
   /**
-   * Adds public key to database.
-   * @param address - Address of the account contract.
-   * @param publicKey - Public key of the corresponding user master public key.
+   * Adds public key and partial address to a database.
+   * @param address - Address of the account to add public key and partial address for.
+   * @param publicKey - Public key of the corresponding user.
    * @param partialAddress - The partially computed address of the account contract.
    * @returns A Promise that resolves once the public key has been added to the database.
    */
-  public async addPublicKey(
+  public async addPublicKeyAndPartialAddress(
     address: AztecAddress,
     publicKey: PublicKey,
     partialAddress: PartialContractAddress,
   ): Promise<void> {
-    await this.db.addPublicKey(address, publicKey, partialAddress);
+    await this.db.addPublicKeyAndPartialAddress(address, publicKey, partialAddress);
   }
 
   /**
@@ -160,6 +160,23 @@ export class AztecRPCServer implements AztecRPC {
       throw new Error(`Unable to public key for address ${address.toString()}`);
     }
     return Promise.resolve(result[0]);
+  }
+
+  /**
+   * Retrieve the public key and partial contract address associated with an address.
+   * Throws an error if the account is not found in the key store.
+   *
+   * @param address - The AztecAddress instance representing the account to get public key and partial address for.
+   * @returns A Promise resolving to the Point instance representing the public key.
+   */
+  public async getPublicKeyAndPartialAddress(
+    address: AztecAddress,
+  ): Promise<[Point, PartialContractAddress] | undefined> {
+    const result = await this.db.getPublicKeyAndPartialAddress(address);
+    if (!result) {
+      throw new Error(`Unable to get public key for address ${address.toString()}`);
+    }
+    return Promise.resolve(result);
   }
 
   /**

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -557,4 +557,13 @@ export class AztecRPCServer implements AztecRPC {
       enqueuedPublicFunctions,
     );
   }
+
+  /**
+   * Returns true if the account specified by the given address is synched to the latest block
+   * @param account - The aztec address for which to query the sync status
+   * @returns True if the account is fully synched, false otherwise
+   */
+  public async isAccountSynchronised(account: AztecAddress) {
+    return await this.synchroniser.isAccountSynchronised(account);
+  }
 }

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -171,9 +171,7 @@ export class AztecRPCServer implements AztecRPC {
    * @param address - The AztecAddress instance representing the account to get public key and partial address for.
    * @returns A Promise resolving to the Point instance representing the public key.
    */
-  public async getPublicKeyAndPartialAddress(
-    address: AztecAddress,
-  ): Promise<[Point, PartialContractAddress] | undefined> {
+  public async getPublicKeyAndPartialAddress(address: AztecAddress): Promise<[Point, PartialContractAddress]> {
     const result = await this.db.getPublicKeyAndPartialAddress(address);
     if (!result) {
       throw new Error(`Unable to get public key for address ${address.toString()}`);

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -3,7 +3,7 @@ import {
   collectEnqueuedPublicFunctionCalls,
   collectUnencryptedLogs,
 } from '@aztec/acir-simulator';
-import { AztecAddress, FunctionData, PartialContractAddress, PrivateHistoricTreeRoots } from '@aztec/circuits.js';
+import { AztecAddress, FunctionData, PartialContractAddress, PrivateHistoricTreeRoots, PublicKey } from '@aztec/circuits.js';
 import { FunctionType, encodeArguments } from '@aztec/foundation/abi';
 import { Fr, Point } from '@aztec/foundation/fields';
 import { createDebugLogger } from '@aztec/foundation/log';
@@ -97,6 +97,17 @@ export class AztecRPCServer implements AztecRPC {
     await this.db.addPublicKey(address, pubKey, partialContractAddress);
     this.synchroniser.addAccount(pubKey, address, this.keyStore);
     return address;
+  }
+
+  /**
+   * Adds public key to database.
+   * @param address - Address of the account contract.
+   * @param publicKey - Public key of the corresponding user master public key.
+   * @param partialAddress - The partially computed address of the account contract.
+   * @returns A Promise that resolves once the public key has been added to the database.
+   */
+  public async addPublicKey(address: AztecAddress, publicKey: PublicKey, partialAddress: PartialContractAddress): Promise<void> {
+    await this.db.addPublicKey(address, publicKey, partialAddress);
   }
 
   /**

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -3,7 +3,13 @@ import {
   collectEnqueuedPublicFunctionCalls,
   collectUnencryptedLogs,
 } from '@aztec/acir-simulator';
-import { AztecAddress, FunctionData, PartialContractAddress, PrivateHistoricTreeRoots, PublicKey } from '@aztec/circuits.js';
+import {
+  AztecAddress,
+  FunctionData,
+  PartialContractAddress,
+  PrivateHistoricTreeRoots,
+  PublicKey,
+} from '@aztec/circuits.js';
 import { FunctionType, encodeArguments } from '@aztec/foundation/abi';
 import { Fr, Point } from '@aztec/foundation/fields';
 import { createDebugLogger } from '@aztec/foundation/log';
@@ -106,7 +112,11 @@ export class AztecRPCServer implements AztecRPC {
    * @param partialAddress - The partially computed address of the account contract.
    * @returns A Promise that resolves once the public key has been added to the database.
    */
-  public async addPublicKey(address: AztecAddress, publicKey: PublicKey, partialAddress: PartialContractAddress): Promise<void> {
+  public async addPublicKey(
+    address: AztecAddress,
+    publicKey: PublicKey,
+    partialAddress: PartialContractAddress,
+  ): Promise<void> {
     await this.db.addPublicKey(address, publicKey, partialAddress);
   }
 

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/create_aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/create_aztec_rpc_server.ts
@@ -35,10 +35,11 @@ export async function createAztecRPCServer(
   config: RpcServerConfig,
   { keyStore, db }: CreateAztecRPCServerOptions = {},
 ) {
+  const logSuffix = Math.random().toString(16).slice(2, 8);
   keyStore = keyStore || new TestKeyStore(await Grumpkin.new());
-  db = db || new MemoryDB();
+  db = db || new MemoryDB(logSuffix);
 
-  const server = new AztecRPCServer(keyStore, aztecNode, db, config);
+  const server = new AztecRPCServer(keyStore, aztecNode, db, config, logSuffix);
   await server.start();
   return server;
 }

--- a/yarn-project/aztec-rpc/src/contract_database/memory_contract_database.ts
+++ b/yarn-project/aztec-rpc/src/contract_database/memory_contract_database.ts
@@ -1,4 +1,5 @@
 import { AztecAddress } from '@aztec/foundation/aztec-address';
+import { DebugLogger } from '@aztec/foundation/log';
 import { ContractDao, ContractDatabase } from '@aztec/types';
 
 /**
@@ -10,6 +11,8 @@ import { ContractDao, ContractDatabase } from '@aztec/types';
 export class MemoryContractDatabase implements ContractDatabase {
   private contracts: ContractDao[] = [];
 
+  constructor(protected log: DebugLogger) {}
+
   /**
    * Adds a new ContractDao instance to the memory-based contract database.
    * The function stores the contract in an array and returns a resolved promise indicating successful addition.
@@ -18,6 +21,7 @@ export class MemoryContractDatabase implements ContractDatabase {
    * @returns A Promise that resolves when the contract is successfully added.
    */
   public addContract(contract: ContractDao) {
+    this.log(`Adding contract ${contract.address.toString()}`);
     this.contracts.push(contract);
     return Promise.resolve();
   }

--- a/yarn-project/aztec-rpc/src/database/database.ts
+++ b/yarn-project/aztec-rpc/src/database/database.ts
@@ -25,7 +25,11 @@ export interface Database extends ContractDatabase {
   getTreeRoots(): Record<MerkleTreeId, Fr>;
   setTreeRoots(roots: Record<MerkleTreeId, Fr>): Promise<void>;
 
-  addPublicKey(address: AztecAddress, publicKey: PublicKey, partialAddress: PartialContractAddress): Promise<void>;
-  getPublicKey(address: AztecAddress): Promise<[Point, PartialContractAddress] | undefined>;
+  addPublicKeyAndPartialAddress(
+    address: AztecAddress,
+    publicKey: PublicKey,
+    partialAddress: PartialContractAddress,
+  ): Promise<void>;
+  getPublicKeyAndPartialAddress(address: AztecAddress): Promise<[Point, PartialContractAddress] | undefined>;
   getAccounts(): Promise<AztecAddress[]>;
 }

--- a/yarn-project/aztec-rpc/src/database/memory_db.ts
+++ b/yarn-project/aztec-rpc/src/database/memory_db.ts
@@ -1,6 +1,7 @@
 import { PartialContractAddress } from '@aztec/circuits.js';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr, Point } from '@aztec/foundation/fields';
+import { createDebugLogger } from '@aztec/foundation/log';
 import { MerkleTreeId, PublicKey, TxHash } from '@aztec/types';
 
 import { MemoryContractDatabase } from '../contract_database/index.js';
@@ -19,6 +20,10 @@ export class MemoryDB extends MemoryContractDatabase implements Database {
   private noteSpendingInfoTable: NoteSpendingInfoDao[] = [];
   private treeRoots: Record<MerkleTreeId, Fr> | undefined;
   private publicKeys: Map<bigint, [PublicKey, PartialContractAddress]> = new Map();
+
+  constructor(logSuffix = '0') {
+    super(createDebugLogger('aztec:memory_db_' + logSuffix));
+  }
 
   /**
    * Retrieve a transaction from the MemoryDB using its transaction hash.

--- a/yarn-project/aztec-rpc/src/database/memory_db.ts
+++ b/yarn-project/aztec-rpc/src/database/memory_db.ts
@@ -173,12 +173,16 @@ export class MemoryDB extends MemoryContractDatabase implements Database {
     return Promise.resolve();
   }
 
-  addPublicKey(address: AztecAddress, publicKey: Point, partialAddress: PartialContractAddress): Promise<void> {
+  addPublicKeyAndPartialAddress(
+    address: AztecAddress,
+    publicKey: Point,
+    partialAddress: PartialContractAddress,
+  ): Promise<void> {
     this.publicKeys.set(address.toBigInt(), [publicKey, partialAddress]);
     return Promise.resolve();
   }
 
-  getPublicKey(address: AztecAddress): Promise<[Point, Fr] | undefined> {
+  getPublicKeyAndPartialAddress(address: AztecAddress): Promise<[Point, Fr] | undefined> {
     return Promise.resolve(this.publicKeys.get(address.toBigInt()));
   }
 

--- a/yarn-project/aztec-rpc/src/simulator_oracle/index.ts
+++ b/yarn-project/aztec-rpc/src/simulator_oracle/index.ts
@@ -48,7 +48,7 @@ export class SimulatorOracle implements DBOracle {
    * @returns A public key and the corresponding partial contract address, such that the hash of the two resolves to the input address.
    */
   async getPublicKey(address: AztecAddress): Promise<[Point, PartialContractAddress]> {
-    const result = await this.db.getPublicKey(address);
+    const result = await this.db.getPublicKeyAndPartialAddress(address);
     if (!result) throw new Error(`Unknown public key for address ${address.toString()}`);
     return result;
   }

--- a/yarn-project/aztec-rpc/src/synchroniser/synchroniser.ts
+++ b/yarn-project/aztec-rpc/src/synchroniser/synchroniser.ts
@@ -1,5 +1,5 @@
 import { AztecAddress, Fr, PublicKey } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import { InterruptableSleep } from '@aztec/foundation/sleep';
 import { AztecNode, KeyStore, L2BlockContext, LogType, MerkleTreeId } from '@aztec/types';
 
@@ -20,12 +20,11 @@ export class Synchroniser {
   private running = false;
   private initialSyncBlockHeight = 0;
   private synchedToBlock = 0;
+  private log: DebugLogger;
 
-  constructor(
-    private node: AztecNode,
-    private db: Database,
-    private log = createDebugLogger('aztec:aztec_rpc_synchroniser'),
-  ) {}
+  constructor(private node: AztecNode, private db: Database, logSuffix = '') {
+    this.log = createDebugLogger('aztec:aztec_rpc_synchroniser_' + logSuffix);
+  }
 
   /**
    * Starts the synchronisation process by fetching encrypted logs and blocks from a specified position.

--- a/yarn-project/aztec-rpc/src/synchroniser/synchroniser.ts
+++ b/yarn-project/aztec-rpc/src/synchroniser/synchroniser.ts
@@ -180,7 +180,7 @@ export class Synchroniser {
    * @returns True if the account is fully synched, false otherwise
    */
   public async isAccountSynchronised(account: AztecAddress) {
-    const result = await this.db.getPublicKey(account);
+    const result = await this.db.getPublicKeyAndPartialAddress(account);
     if (!result) {
       return false;
     }

--- a/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
+++ b/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
@@ -88,7 +88,7 @@ export abstract class BaseWallet implements Wallet {
   getNodeInfo(): Promise<NodeInfo> {
     return this.rpc.getNodeInfo();
   }
-  getPublicKeyAndPartialAddress(address: AztecAddress): Promise<[Point, PartialContractAddress] | undefined> {
+  getPublicKeyAndPartialAddress(address: AztecAddress): Promise<[Point, PartialContractAddress]> {
     return this.rpc.getPublicKeyAndPartialAddress(address);
   }
 }

--- a/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
+++ b/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
@@ -1,4 +1,4 @@
-import { AztecAddress, Fr, Point, TxContext } from '@aztec/circuits.js';
+import { AztecAddress, Fr, PartialContractAddress, Point, PublicKey, TxContext } from '@aztec/circuits.js';
 import { ContractAbi } from '@aztec/foundation/abi';
 import {
   AztecRPC,
@@ -38,6 +38,11 @@ export abstract class BaseWallet implements Wallet {
     abi?: ContractAbi | undefined,
   ): Promise<AztecAddress> {
     return this.rpc.addAccount(privKey, address, partialContractAddress, abi);
+  }
+  addPublicKey(
+    address: AztecAddress, publicKey: PublicKey, partialAddress: PartialContractAddress
+  ): Promise<void> {
+    return this.rpc.addPublicKey(address, publicKey, partialAddress);
   }
   getAccounts(): Promise<AztecAddress[]> {
     return this.rpc.getAccounts();

--- a/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
+++ b/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
@@ -45,8 +45,8 @@ export abstract class BaseWallet implements Wallet {
   getAccounts(): Promise<AztecAddress[]> {
     return this.rpc.getAccounts();
   }
-  getAccountPublicKey(address: AztecAddress): Promise<Point> {
-    return this.rpc.getAccountPublicKey(address);
+  getPublicKey(address: AztecAddress): Promise<Point> {
+    return this.rpc.getPublicKey(address);
   }
   addContracts(contracts: DeployedContract[]): Promise<void> {
     return this.rpc.addContracts(contracts);

--- a/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
+++ b/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
@@ -39,8 +39,12 @@ export abstract class BaseWallet implements Wallet {
   ): Promise<AztecAddress> {
     return this.rpc.addAccount(privKey, address, partialContractAddress, abi);
   }
-  addPublicKey(address: AztecAddress, publicKey: PublicKey, partialAddress: PartialContractAddress): Promise<void> {
-    return this.rpc.addPublicKey(address, publicKey, partialAddress);
+  addPublicKeyAndPartialAddress(
+    address: AztecAddress,
+    publicKey: PublicKey,
+    partialAddress: PartialContractAddress,
+  ): Promise<void> {
+    return this.rpc.addPublicKeyAndPartialAddress(address, publicKey, partialAddress);
   }
   getAccounts(): Promise<AztecAddress[]> {
     return this.rpc.getAccounts();
@@ -83,6 +87,9 @@ export abstract class BaseWallet implements Wallet {
   }
   getNodeInfo(): Promise<NodeInfo> {
     return this.rpc.getNodeInfo();
+  }
+  getPublicKeyAndPartialAddress(address: AztecAddress): Promise<[Point, PartialContractAddress] | undefined> {
+    return this.rpc.getPublicKeyAndPartialAddress(address);
   }
 }
 

--- a/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
+++ b/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
@@ -91,6 +91,9 @@ export abstract class BaseWallet implements Wallet {
   getPublicKeyAndPartialAddress(address: AztecAddress): Promise<[Point, PartialContractAddress]> {
     return this.rpc.getPublicKeyAndPartialAddress(address);
   }
+  isAccountSynchronised(account: AztecAddress) {
+    return this.rpc.isAccountSynchronised(account);
+  }
 }
 
 /**

--- a/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
+++ b/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
@@ -39,9 +39,7 @@ export abstract class BaseWallet implements Wallet {
   ): Promise<AztecAddress> {
     return this.rpc.addAccount(privKey, address, partialContractAddress, abi);
   }
-  addPublicKey(
-    address: AztecAddress, publicKey: PublicKey, partialAddress: PartialContractAddress
-  ): Promise<void> {
+  addPublicKey(address: AztecAddress, publicKey: PublicKey, partialAddress: PartialContractAddress): Promise<void> {
     return this.rpc.addPublicKey(address, publicKey, partialAddress);
   }
   getAccounts(): Promise<AztecAddress[]> {

--- a/yarn-project/end-to-end/src/cross_chain/test_harness.ts
+++ b/yarn-project/end-to-end/src/cross_chain/test_harness.ts
@@ -33,7 +33,7 @@ export class CrossChainTestHarness {
 
     const ethAccount = EthAddress.fromString((await walletClient.getAddresses())[0]);
     const [ownerAddress, receiver] = accounts;
-    const ownerPub = await aztecRpcServer.getAccountPublicKey(ownerAddress);
+    const ownerPub = await aztecRpcServer.getPublicKey(ownerAddress);
 
     const outbox = getContract({
       address: deployL1ContractsValues.outboxAddress.toString(),

--- a/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
@@ -5,7 +5,7 @@ import { DebugLogger } from '@aztec/foundation/log';
 import { ZkTokenContract } from '@aztec/noir-contracts/types';
 import { L2BlockL2Logs, LogType, TxStatus } from '@aztec/types';
 
-import { setup, setupWithoutDeployingContractsAndAztecNode } from './utils.js';
+import { setup, setupAztecRPCServer } from './utils.js';
 
 describe('e2e_2_rpc_servers', () => {
   let aztecNode: AztecNodeService;
@@ -33,7 +33,7 @@ describe('e2e_2_rpc_servers', () => {
       aztecRpcServer: aztecRpcServerB,
       accounts: accounts,
       wallet: walletB,
-    } = await setupWithoutDeployingContractsAndAztecNode(1, aztecNode));
+    } = await setupAztecRPCServer(1, aztecNode));
     [userB] = accounts;
 
     logger(`Deploying L2 contract...`);

--- a/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
@@ -78,7 +78,8 @@ describe('e2e_2_rpc_servers', () => {
     const [owner] = accounts1;
     const [receiver] = accounts2;
 
-    // aztecRpcServer1.addAccount()
+    const [receiverPubKey, receiverPartialAddress] = (await aztecRpcServer2.getPublicKeyAndPartialAddress(receiver))!;
+    aztecRpcServer1.addPublicKeyAndPartialAddress(receiver, receiverPubKey, receiverPartialAddress);
 
     await deployContract(initialBalance, (await aztecRpcServer1.getAccountPublicKey(owner)).toBigInts());
 

--- a/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
@@ -79,10 +79,10 @@ describe('e2e_2_rpc_servers', () => {
 
   it('transfers fund from user A to B via RPC Server A followed by transfer from B to A via RPC Server B', async () => {
     // Add account B pub key and partial address to wallet A
-    const [accountBPubKey, accountBPartialAddress] = (await aztecRpcServerB.getPublicKeyAndPartialAddress(userB))!;
+    const [accountBPubKey, accountBPartialAddress] = await aztecRpcServerB.getPublicKeyAndPartialAddress(userB);
     await aztecRpcServerA.addPublicKeyAndPartialAddress(userB, accountBPubKey, accountBPartialAddress);
     // Add account A pub key and partial address to wallet B
-    const [accountAPubKey, accountAPartialAddress] = (await aztecRpcServerA.getPublicKeyAndPartialAddress(userA))!;
+    const [accountAPubKey, accountAPartialAddress] = await aztecRpcServerA.getPublicKeyAndPartialAddress(userA);
     await aztecRpcServerB.addPublicKeyAndPartialAddress(userA, accountAPubKey, accountAPartialAddress);
 
     // Add zkToken to rpc server B

--- a/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
@@ -35,7 +35,7 @@ describe('e2e_2_rpc_servers', () => {
   });
 
   const expectBalance = async (owner: AztecAddress, expectedBalance: bigint) => {
-    const ownerPublicKey = await aztecRpcServer1.getAccountPublicKey(owner);
+    const ownerPublicKey = await aztecRpcServer1.getPublicKey(owner);
     const [balance] = await contract.methods.getBalance(ownerPublicKey.toBigInts()).view({ from: owner });
     logger(`Account ${owner} balance: ${balance}`);
     expect(balance).toBe(expectedBalance);
@@ -91,8 +91,8 @@ describe('e2e_2_rpc_servers', () => {
     const tx = contract.methods
       .transfer(
         transferAmount,
-        (await aztecRpcServer1.getAccountPublicKey(owner)).toBigInts(),
-        (await aztecRpcServer2.getAccountPublicKey(receiver)).toBigInts(),
+        (await aztecRpcServer1.getPublicKey(owner)).toBigInts(),
+        (await aztecRpcServer1.getPublicKey(receiver)).toBigInts(),
       )
       .send({ origin: accounts1[0] });
 

--- a/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
@@ -106,13 +106,7 @@ describe('e2e_2_rpc_servers', () => {
     await expectUnencryptedLogsFromLastBlockToBe(['Balance set in constructor']);
 
     // Transfer funds from A to B via rpc server A
-    const txAToB = contractWithWalletA.methods
-      .transfer(
-        transferAmount1,
-        userA,
-        userB,
-      )
-      .send({ origin: userA });
+    const txAToB = contractWithWalletA.methods.transfer(transferAmount1, userA, userB).send({ origin: userA });
 
     await txAToB.isMined(0, 0.1);
     const receiptAToB = await txAToB.getReceipt();
@@ -126,13 +120,7 @@ describe('e2e_2_rpc_servers', () => {
     await expectUnencryptedLogsFromLastBlockToBe(['Coins transferred']);
 
     // Transfer funds from B to A via rpc server B
-    const txBToA = contractWithWalletB.methods
-      .transfer(
-        transferAmount2,
-        userB,
-        userA,
-      )
-      .send({ origin: userB });
+    const txBToA = contractWithWalletB.methods.transfer(transferAmount2, userB, userA).send({ origin: userB });
 
     await txBToA.isMined(0, 0.1);
     const receiptBToA = await txBToA.getReceipt();

--- a/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
@@ -86,10 +86,10 @@ describe('e2e_2_rpc_servers', () => {
 
     // Add account B pub key and partial address to wallet A
     const [accountBPubKey, accountBPartialAddress] = (await aztecRpcServerB.getPublicKeyAndPartialAddress(userB))!;
-    aztecRpcServerA.addPublicKeyAndPartialAddress(userB, accountBPubKey, accountBPartialAddress);
+    await aztecRpcServerA.addPublicKeyAndPartialAddress(userB, accountBPubKey, accountBPartialAddress);
     // Add account A pub key and partial address to wallet B
     const [accountAPubKey, accountAPartialAddress] = (await aztecRpcServerA.getPublicKeyAndPartialAddress(userA))!;
-    aztecRpcServerB.addPublicKeyAndPartialAddress(userA, accountAPubKey, accountAPartialAddress);
+    await aztecRpcServerB.addPublicKeyAndPartialAddress(userA, accountAPubKey, accountAPartialAddress);
 
     // Add zkToken to rpc server B
     await aztecRpcServerB.addContracts([

--- a/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
@@ -1,0 +1,114 @@
+import { AztecNodeConfig, AztecNodeService } from '@aztec/aztec-node';
+import { AztecRPCServer } from '@aztec/aztec-rpc';
+import { AztecAddress, Wallet } from '@aztec/aztec.js';
+import { DebugLogger } from '@aztec/foundation/log';
+import { ZkTokenContract } from '@aztec/noir-contracts/types';
+import { L2BlockL2Logs, LogType, TxStatus } from '@aztec/types';
+
+import { setup, setupWithoutDeployingContracts } from './utils.js';
+
+describe('e2e_2_rpc_servers', () => {
+  let aztecNode1: AztecNodeService;
+  let aztecNode2: AztecNodeService;
+  let aztecRpcServer1: AztecRPCServer;
+  let aztecRpcServer2: AztecRPCServer;
+  let wallet1: Wallet;
+  let wallet2: Wallet;
+  let accounts1: AztecAddress[];
+  let accounts2: AztecAddress[];
+  let logger: DebugLogger;
+
+  let contract: ZkTokenContract;
+
+  beforeEach(async () => {
+    let config: AztecNodeConfig;
+    ({ aztecNode: aztecNode1, aztecRpcServer: aztecRpcServer1, accounts: accounts1, config, wallet: wallet1, logger } = await setup(1));
+    ({
+      aztecNode: aztecNode2,
+      aztecRpcServer: aztecRpcServer2,
+      accounts: accounts2,
+      wallet: wallet2,
+    } = await setupWithoutDeployingContracts(1, config));
+  }, 100_000);
+
+  afterEach(async () => {
+    await aztecNode1?.stop();
+    // await aztecNode2?.stop();
+    await aztecRpcServer1?.stop();
+    // await aztecRpcServer2?.stop();
+  });
+
+  const expectBalance = async (owner: AztecAddress, expectedBalance: bigint) => {
+    const ownerPublicKey = await aztecRpcServer1.getAccountPublicKey(owner);
+    const [balance] = await contract.methods.getBalance(ownerPublicKey.toBigInts()).view({ from: owner });
+    logger(`Account ${owner} balance: ${balance}`);
+    expect(balance).toBe(expectedBalance);
+  };
+
+  const expectsNumOfEncryptedLogsInTheLastBlockToBe = async (numEncryptedLogs: number) => {
+    const l2BlockNum = await aztecNode1.getBlockHeight();
+    const encryptedLogs = await aztecNode1.getLogs(l2BlockNum, 1, LogType.ENCRYPTED);
+    const unrolledLogs = L2BlockL2Logs.unrollLogs(encryptedLogs);
+    expect(unrolledLogs.length).toBe(numEncryptedLogs);
+  };
+
+  const expectUnencryptedLogsFromLastBlockToBe = async (logMessages: string[]) => {
+    const l2BlockNum = await aztecNode1.getBlockHeight();
+    const unencryptedLogs = await aztecNode1.getLogs(l2BlockNum, 1, LogType.UNENCRYPTED);
+    const unrolledLogs = L2BlockL2Logs.unrollLogs(unencryptedLogs);
+    const asciiLogs = unrolledLogs.map(log => log.toString('ascii'));
+
+    expect(asciiLogs).toStrictEqual(logMessages);
+  };
+
+  const deployContract = async (initialBalance = 0n, owner = { x: 0n, y: 0n }) => {
+    logger(`Deploying L2 contract...`);
+    const tx = ZkTokenContract.deploy(aztecRpcServer1, initialBalance, owner).send();
+    const receipt = await tx.getReceipt();
+    contract = new ZkTokenContract(receipt.contractAddress!, wallet1);
+    await tx.isMined(0, 0.1);
+    const minedReceipt = await tx.getReceipt();
+    expect(minedReceipt.status).toEqual(TxStatus.MINED);
+    logger('L2 contract deployed');
+    return contract;
+  };
+
+  /**
+   * Milestone 1.5.
+   */
+  it('1.5 should call transfer and increase balance of another account', async () => {
+    const initialBalance = 987n;
+    const transferAmount = 654n;
+    const [owner] = accounts1;
+    const [receiver] = accounts2;
+
+    aztecRpcServer1.addAccount()
+
+    await deployContract(initialBalance, (await aztecRpcServer1.getAccountPublicKey(owner)).toBigInts());
+
+    await expectBalance(owner, initialBalance);
+    await expectBalance(receiver, 0n);
+
+    await expectsNumOfEncryptedLogsInTheLastBlockToBe(1);
+    await expectUnencryptedLogsFromLastBlockToBe(['Balance set in constructor']);
+
+    const tx = contract.methods
+      .transfer(
+        transferAmount,
+        (await aztecRpcServer1.getAccountPublicKey(owner)).toBigInts(),
+        (await aztecRpcServer1.getAccountPublicKey(receiver)).toBigInts(),
+      )
+      .send({ origin: accounts1[0] });
+
+    await tx.isMined(0, 0.1);
+    const receipt = await tx.getReceipt();
+
+    expect(receipt.status).toBe(TxStatus.MINED);
+
+    await expectBalance(owner, initialBalance - transferAmount);
+    await expectBalance(receiver, transferAmount);
+
+    await expectsNumOfEncryptedLogsInTheLastBlockToBe(2);
+    await expectUnencryptedLogsFromLastBlockToBe(['Coins transferred']);
+  }, 60_000);
+});

--- a/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
@@ -28,7 +28,7 @@ describe('e2e_deploy_contract', () => {
    * https://hackmd.io/ouVCnacHQRq2o1oRc5ksNA#Interfaces-and-Responsibilities
    */
   it('should deploy a contract', async () => {
-    const publicKey = await aztecRpcServer.getAccountPublicKey(accounts[0]);
+    const publicKey = await aztecRpcServer.getPublicKey(accounts[0]);
     const salt = Fr.random();
     const deploymentData = await getContractDeploymentInfo(TestContractAbi, [], salt, publicKey);
     const deployer = new ContractDeployer(TestContractAbi, aztecRpcServer, publicKey);

--- a/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
+++ b/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
@@ -58,7 +58,7 @@ describe('uniswap_trade_on_l1_from_l2', () => {
 
     ethAccount = EthAddress.fromString((await walletClient.getAddresses())[0]);
     [ownerAddress, receiver] = accounts;
-    const ownerPubPoint = await aztecRpcServer.getAccountPublicKey(ownerAddress);
+    const ownerPubPoint = await aztecRpcServer.getPublicKey(ownerAddress);
 
     logger('Deploying DAI Portal, initializing and deploying l2 contract...');
     const daiContracts = await deployAndInitializeNonNativeL2TokenContracts(

--- a/yarn-project/end-to-end/src/utils.ts
+++ b/yarn-project/end-to-end/src/utils.ts
@@ -62,13 +62,14 @@ type TxContext = {
 };
 
 /**
- * Sets up the environment for the end-to-end tests without deploying contracts.
+ * Sets up Aztec RPC Server.
  * @param numberOfAccounts - The number of new accounts to be created once the RPC server is initiated.
  * @param aztecNode - Instance of AztecNode implementation.
  * @param firstPrivKey - The private key of the first account to be created.
  * @param logger - The logger to be used.
+ * @returns Aztec RPC server, accounts, wallets and logger.
  */
-export async function setupWithoutDeployingContractsAndAztecNode(
+export async function setupAztecRPCServer(
   numberOfAccounts: number,
   aztecNode: AztecNode,
   firstPrivKey: Uint8Array | null = null,
@@ -214,12 +215,7 @@ export async function setup(numberOfAccounts = 1): Promise<{
 
   const aztecNode = await AztecNodeService.createAndSync(config);
 
-  const { aztecRpcServer, accounts, wallet } = await setupWithoutDeployingContractsAndAztecNode(
-    numberOfAccounts,
-    aztecNode,
-    privKey,
-    logger,
-  );
+  const { aztecRpcServer, accounts, wallet } = await setupAztecRPCServer(numberOfAccounts, aztecNode, privKey, logger);
 
   return {
     aztecNode,

--- a/yarn-project/types/src/interfaces/aztec-node.ts
+++ b/yarn-project/types/src/interfaces/aztec-node.ts
@@ -17,7 +17,7 @@ import {
 
 /**
  * The aztec node.
- * We will probably implemement the additional interfaces by means other than Aztec Node as it's currently a privacy leak
+ * We will probably implement the additional interfaces by means other than Aztec Node as it's currently a privacy leak
  */
 export interface AztecNode extends DataCommitmentProvider, L1ToL2MessageProvider, ContractCommitmentProvider {
   /**

--- a/yarn-project/types/src/interfaces/aztec_rpc.ts
+++ b/yarn-project/types/src/interfaces/aztec_rpc.ts
@@ -1,4 +1,4 @@
-import { AztecAddress, EthAddress, Fr, PartialContractAddress } from '@aztec/circuits.js';
+import { AztecAddress, EthAddress, Fr, PartialContractAddress, PublicKey } from '@aztec/circuits.js';
 import { ContractAbi } from '@aztec/foundation/abi';
 import { Point } from '@aztec/foundation/fields';
 import {
@@ -76,4 +76,5 @@ export interface AztecRPC {
   getUnencryptedLogs(from: number, take: number): Promise<L2BlockL2Logs[]>;
   getBlockNum(): Promise<number>;
   getNodeInfo(): Promise<NodeInfo>;
+  addPublicKey(address: AztecAddress, publicKey: PublicKey, partialAddress: PartialContractAddress): Promise<void>;
 }

--- a/yarn-project/types/src/interfaces/aztec_rpc.ts
+++ b/yarn-project/types/src/interfaces/aztec_rpc.ts
@@ -76,5 +76,10 @@ export interface AztecRPC {
   getUnencryptedLogs(from: number, take: number): Promise<L2BlockL2Logs[]>;
   getBlockNum(): Promise<number>;
   getNodeInfo(): Promise<NodeInfo>;
-  addPublicKey(address: AztecAddress, publicKey: PublicKey, partialAddress: PartialContractAddress): Promise<void>;
+  addPublicKeyAndPartialAddress(
+    address: AztecAddress,
+    publicKey: PublicKey,
+    partialAddress: PartialContractAddress,
+  ): Promise<void>;
+  getPublicKeyAndPartialAddress(address: AztecAddress): Promise<[Point, PartialContractAddress] | undefined>;
 }

--- a/yarn-project/types/src/interfaces/aztec_rpc.ts
+++ b/yarn-project/types/src/interfaces/aztec_rpc.ts
@@ -82,4 +82,5 @@ export interface AztecRPC {
     partialAddress: PartialContractAddress,
   ): Promise<void>;
   getPublicKeyAndPartialAddress(address: AztecAddress): Promise<[Point, PartialContractAddress]>;
+  isAccountSynchronised(account: AztecAddress): Promise<boolean>;
 }

--- a/yarn-project/types/src/interfaces/aztec_rpc.ts
+++ b/yarn-project/types/src/interfaces/aztec_rpc.ts
@@ -81,5 +81,5 @@ export interface AztecRPC {
     publicKey: PublicKey,
     partialAddress: PartialContractAddress,
   ): Promise<void>;
-  getPublicKeyAndPartialAddress(address: AztecAddress): Promise<[Point, PartialContractAddress] | undefined>;
+  getPublicKeyAndPartialAddress(address: AztecAddress): Promise<[Point, PartialContractAddress]>;
 }

--- a/yarn-project/types/src/interfaces/aztec_rpc.ts
+++ b/yarn-project/types/src/interfaces/aztec_rpc.ts
@@ -58,7 +58,7 @@ export interface AztecRPC {
     abi?: ContractAbi,
   ): Promise<AztecAddress>;
   getAccounts(): Promise<AztecAddress[]>;
-  getAccountPublicKey(address: AztecAddress): Promise<Point>;
+  getPublicKey(address: AztecAddress): Promise<Point>;
   addContracts(contracts: DeployedContract[]): Promise<void>;
   /**
    * Is an L2 contract deployed at this address?

--- a/yarn-project/types/src/l2_block.ts
+++ b/yarn-project/types/src/l2_block.ts
@@ -12,7 +12,7 @@ import { makeAppendOnlyTreeSnapshot, makeGlobalVariables } from '@aztec/circuits
 import { BufferReader, serializeToBuffer } from '@aztec/circuits.js/utils';
 import { sha256, sha256ToField } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
-import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { createDebugLogger } from '@aztec/foundation/log';
 
 import times from 'lodash.times';
 
@@ -24,6 +24,9 @@ import { L2BlockL2Logs } from './logs/l2_block_l2_logs.js';
  * TODO: Reuse data types and serialization functions from circuits package.
  */
 export class L2Block {
+  /* Having logger static to avoid issues with comparing 2 block */
+  private static logger = createDebugLogger('aztec:l2_block');
+
   /**
    * Encrypted logs emitted by txs in this block.
    * @remarks `L2BlockL2Logs.txLogs` array has to match number of txs in this block and has to be in the same order
@@ -41,8 +44,6 @@ export class L2Block {
    *          `newUnencryptedLogs.txLogs.functionLogs` is equal to the number of all function invocations in the tx.
    */
   public newUnencryptedLogs?: L2BlockL2Logs;
-
-  private logger: DebugLogger;
 
   constructor(
     /**
@@ -151,8 +152,6 @@ export class L2Block {
     if (newCommitments.length % MAX_NEW_COMMITMENTS_PER_TX !== 0) {
       throw new Error(`The number of new commitments must be a multiple of ${MAX_NEW_COMMITMENTS_PER_TX}.`);
     }
-
-    this.logger = createDebugLogger('aztec:l2_block:number_' + number);
 
     if (newEncryptedLogs) {
       this.attachLogs(newEncryptedLogs, LogType.ENCRYPTED);
@@ -499,13 +498,13 @@ export class L2Block {
       if (this[logFieldName] === logs) {
         // Comparing objects only by references is enough in this case since this should occur only when exactly
         // the same object is passed in and not a copy.
-        this.logger(`${logFieldName} logs already attached`);
+        L2Block.logger(`${logFieldName} logs already attached`);
         return;
       }
       throw new Error(`Trying to attach different ${logFieldName} logs to block ${this.number}.`);
     }
 
-    this.logger(`Attaching ${logFieldName} logs`);
+    L2Block.logger(`Attaching ${logFieldName} logs`);
 
     const numTxs = this.newCommitments.length / MAX_NEW_COMMITMENTS_PER_TX;
 

--- a/yarn-project/types/src/l2_block.ts
+++ b/yarn-project/types/src/l2_block.ts
@@ -12,12 +12,12 @@ import { makeAppendOnlyTreeSnapshot, makeGlobalVariables } from '@aztec/circuits
 import { BufferReader, serializeToBuffer } from '@aztec/circuits.js/utils';
 import { sha256, sha256ToField } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
+import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 
 import times from 'lodash.times';
 
 import { ContractData, L2Tx, LogType, PublicDataWrite, TxL2Logs } from './index.js';
 import { L2BlockL2Logs } from './logs/l2_block_l2_logs.js';
-import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 
 /**
  * The data that makes up the rollup proof, with encoder decoder functions.


### PR DESCRIPTION
# Description

1. Fixes #1067,
2. suffixed loggers in  RPC server with random string to be able to distinguish different instances,
3. when attaching logs in L2Block error doesn't get thrown when a log is attached the second time but it's the same object (this started occurring because aztec node's blocks already had logs attached by synchroniser in RPC server 1 --> this should not occur when we have a real HTTP connection with aztec node and not just a simple interface),
4. added the needed functions to RPC server and renamed some for the naming to be consistent).

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
