### PR TITLE
Add severity levels to logger

### DIFF
--- a/yarn-project/archiver/src/index.ts
+++ b/yarn-project/archiver/src/index.ts
@@ -1,4 +1,4 @@
-import { createConsoleLogger } from '@aztec/foundation/log';
+import { createDebugLogger } from '@aztec/foundation/log';
 
 import { fileURLToPath } from 'url';
 import { createPublicClient, http } from 'viem';
@@ -9,7 +9,7 @@ import { Archiver, getConfigEnvVars } from './archiver/index.js';
 
 export * from './archiver/index.js';
 
-const log = createConsoleLogger('aztec:archiver_init');
+const log = createDebugLogger('aztec:archiver');
 
 /**
  * A function which instantiates and starts Archiver.
@@ -47,7 +47,7 @@ async function main() {
 if (process.argv[1] === fileURLToPath(import.meta.url).replace(/\/index\.js$/, '')) {
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   main().catch(err => {
-    log(err);
+    log.fatal(err);
     process.exit(1);
   });
 }

--- a/yarn-project/archiver/src/index.ts
+++ b/yarn-project/archiver/src/index.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '@aztec/foundation/log';
+import { createConsoleLogger } from '@aztec/foundation/log';
 
 import { fileURLToPath } from 'url';
 import { createPublicClient, http } from 'viem';
@@ -9,7 +9,7 @@ import { Archiver, getConfigEnvVars } from './archiver/index.js';
 
 export * from './archiver/index.js';
 
-const log = createLogger('aztec:archiver_init');
+const log = createConsoleLogger('aztec:archiver_init');
 
 /**
  * A function which instantiates and starts Archiver.

--- a/yarn-project/aztec-cli/src/index.ts
+++ b/yarn-project/aztec-cli/src/index.ts
@@ -12,7 +12,7 @@ import {
 import { StructType } from '@aztec/foundation/abi';
 import { randomBytes } from '@aztec/foundation/crypto';
 import { JsonStringify } from '@aztec/foundation/json-rpc';
-import { createLogger } from '@aztec/foundation/log';
+import { createConsoleLogger } from '@aztec/foundation/log';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { SchnorrSingleKeyAccountContractAbi } from '@aztec/noir-contracts/artifacts';
 import { ContractData, L2BlockL2Logs, TxHash } from '@aztec/types';
@@ -26,7 +26,7 @@ import { deployAztecContracts, getContractAbi, getTxSender, prepTx } from './uti
 const accountCreationSalt = Fr.ZERO;
 
 const debugLogger = createDebugLogger('aztec:cli');
-const log = createLogger();
+const log = createConsoleLogger();
 
 const program = new Command();
 

--- a/yarn-project/aztec-cli/src/utils.ts
+++ b/yarn-project/aztec-cli/src/utils.ts
@@ -1,7 +1,7 @@
 import { AztecAddress, AztecRPC } from '@aztec/aztec.js';
 import { createEthereumChain, deployL1Contracts } from '@aztec/ethereum';
 import { ContractAbi } from '@aztec/foundation/abi';
-import { DebugLogger, Logger } from '@aztec/foundation/log';
+import { DebugLogger, LogFn } from '@aztec/foundation/log';
 
 import fs from 'fs';
 import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
@@ -32,7 +32,7 @@ export async function deployAztecContracts(
  * @param fileDir - The directory of the compiled contract ABI.
  * @returns The parsed ContractABI.
  */
-export function getContractAbi(fileDir: string, log: Logger) {
+export function getContractAbi(fileDir: string, log: LogFn) {
   const contents = fs.readFileSync(fileDir, 'utf8');
   let contractAbi: ContractAbi;
   try {
@@ -83,7 +83,7 @@ export function prepTx(
   _contractAddress: string,
   functionName: string,
   _functionArgs: string[],
-  log: Logger,
+  log: LogFn,
 ) {
   let contractAddress;
   try {

--- a/yarn-project/aztec-node/src/aztec-node/http-node.ts
+++ b/yarn-project/aztec-node/src/aztec-node/http-node.ts
@@ -5,7 +5,7 @@ import {
   L1_TO_L2_MSG_TREE_HEIGHT,
   PRIVATE_DATA_TREE_HEIGHT,
 } from '@aztec/circuits.js';
-import { LogFn, createConsoleLogger } from '@aztec/foundation/log';
+import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import {
   AztecNode,
   ContractData,
@@ -26,9 +26,9 @@ import {
  */
 export class HttpNode implements AztecNode {
   private baseUrl: string;
-  private log: LogFn;
+  private log: DebugLogger;
 
-  constructor(baseUrl: string, log = createConsoleLogger('aztec:http-node')) {
+  constructor(baseUrl: string, log = createDebugLogger('aztec:http-node')) {
     this.baseUrl = baseUrl.toString().replace(/\/$/, '');
     this.log = log;
   }
@@ -183,7 +183,7 @@ export class HttpNode implements AztecNode {
     url.searchParams.append('hash', txHash.toString());
     const response = await fetch(url.toString());
     if (response.status === 404) {
-      this.log(`Tx ${txHash.toString()} not found`);
+      this.log.info(`Tx ${txHash.toString()} not found`);
       return undefined;
     }
     const txBuffer = Buffer.from(await (await fetch(url.toString())).arrayBuffer());

--- a/yarn-project/aztec-node/src/aztec-node/http-node.ts
+++ b/yarn-project/aztec-node/src/aztec-node/http-node.ts
@@ -5,7 +5,7 @@ import {
   L1_TO_L2_MSG_TREE_HEIGHT,
   PRIVATE_DATA_TREE_HEIGHT,
 } from '@aztec/circuits.js';
-import { Logger, createLogger } from '@aztec/foundation/log';
+import { Logger, createConsoleLogger } from '@aztec/foundation/log';
 import {
   AztecNode,
   ContractData,
@@ -28,7 +28,7 @@ export class HttpNode implements AztecNode {
   private baseUrl: string;
   private log: Logger;
 
-  constructor(baseUrl: string, log = createLogger('aztec:http-node')) {
+  constructor(baseUrl: string, log = createConsoleLogger('aztec:http-node')) {
     this.baseUrl = baseUrl.toString().replace(/\/$/, '');
     this.log = log;
   }

--- a/yarn-project/aztec-node/src/aztec-node/http-node.ts
+++ b/yarn-project/aztec-node/src/aztec-node/http-node.ts
@@ -5,7 +5,7 @@ import {
   L1_TO_L2_MSG_TREE_HEIGHT,
   PRIVATE_DATA_TREE_HEIGHT,
 } from '@aztec/circuits.js';
-import { Logger, createConsoleLogger } from '@aztec/foundation/log';
+import { LogFn, createConsoleLogger } from '@aztec/foundation/log';
 import {
   AztecNode,
   ContractData,
@@ -26,7 +26,7 @@ import {
  */
 export class HttpNode implements AztecNode {
   private baseUrl: string;
-  private log: Logger;
+  private log: LogFn;
 
   constructor(baseUrl: string, log = createConsoleLogger('aztec:http-node')) {
     this.baseUrl = baseUrl.toString().replace(/\/$/, '');

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -7,6 +7,7 @@ import {
   PRIVATE_DATA_TREE_HEIGHT,
 } from '@aztec/circuits.js';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
+import { createDebugLogger } from '@aztec/foundation/log';
 import { InMemoryTxPool, P2P, createP2PClient } from '@aztec/p2p';
 import { SequencerClient, getCombinedHistoricTreeRoots } from '@aztec/sequencer-client';
 import {
@@ -56,6 +57,7 @@ export class AztecNodeService implements AztecNode {
     protected sequencer: SequencerClient,
     protected chainId: number,
     protected version: number,
+    private log = createDebugLogger('aztec:node'),
   ) {}
 
   /**
@@ -188,7 +190,7 @@ export class AztecNodeService implements AztecNode {
     if (tx.data.constants.historicTreeRoots.privateHistoricTreeRoots.isEmpty()) {
       tx.data.constants.historicTreeRoots = await getCombinedHistoricTreeRoots(this.merkleTreeDB.asLatest());
     }
-
+    this.log.info(`Received tx ${await tx.getTxHash()}`);
     await this.p2pClient!.sendTx(tx);
   }
 
@@ -201,6 +203,7 @@ export class AztecNodeService implements AztecNode {
     await this.worldStateSynchroniser.stop();
     await this.merkleTreeDB.stop();
     await this.blockSource.stop();
+    this.log.info(`Stopped`);
   }
 
   /**

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/create_aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/create_aztec_rpc_server.ts
@@ -34,8 +34,15 @@ export async function createAztecRPCServer(
   aztecNode: AztecNode,
   config: RpcServerConfig,
   { keyStore, db }: CreateAztecRPCServerOptions = {},
+  useLogSuffix: string | boolean | undefined = undefined,
 ) {
-  const logSuffix = Math.random().toString(16).slice(2, 8);
+  const logSuffix =
+    typeof useLogSuffix === 'boolean'
+      ? useLogSuffix
+        ? Math.random().toString(16).slice(2, 8)
+        : undefined
+      : useLogSuffix;
+
   keyStore = keyStore || new TestKeyStore(await Grumpkin.new());
   db = db || new MemoryDB(logSuffix);
 

--- a/yarn-project/aztec-rpc/src/database/memory_db.ts
+++ b/yarn-project/aztec-rpc/src/database/memory_db.ts
@@ -21,8 +21,8 @@ export class MemoryDB extends MemoryContractDatabase implements Database {
   private treeRoots: Record<MerkleTreeId, Fr> | undefined;
   private publicKeys: Map<bigint, [PublicKey, PartialContractAddress]> = new Map();
 
-  constructor(logSuffix = '0') {
-    super(createDebugLogger('aztec:memory_db_' + logSuffix));
+  constructor(logSuffix?: string) {
+    super(createDebugLogger(logSuffix ? 'aztec:memory_db_' + logSuffix : 'aztec:memory_db'));
   }
 
   /**

--- a/yarn-project/aztec-rpc/src/synchroniser/synchroniser.ts
+++ b/yarn-project/aztec-rpc/src/synchroniser/synchroniser.ts
@@ -23,7 +23,9 @@ export class Synchroniser {
   private log: DebugLogger;
 
   constructor(private node: AztecNode, private db: Database, logSuffix = '') {
-    this.log = createDebugLogger('aztec:aztec_rpc_synchroniser_' + logSuffix);
+    this.log = createDebugLogger(
+      logSuffix ? `aztec:aztec_rpc_synchroniser_${logSuffix}` : 'aztec:aztec_rpc_synchroniser',
+    );
   }
 
   /**

--- a/yarn-project/aztec-sandbox/src/index.ts
+++ b/yarn-project/aztec-sandbox/src/index.ts
@@ -91,9 +91,9 @@ async function main() {
 }
 
 main()
-  .then(() => logger(`Aztec JSON RPC listening on port ${SERVER_PORT}`))
-  .then(() => logger(`${splash}\n${github}\n\n`))
+  .then(() => logger.info(`Aztec JSON RPC listening on port ${SERVER_PORT}`))
+  .then(() => logger.info(`${splash}\n${github}\n\n`))
   .catch(err => {
-    logger(err);
+    logger.fatal(err);
     process.exit(1);
   });

--- a/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
@@ -45,7 +45,7 @@ describe('e2e_2_rpc_servers', () => {
       aztecRpcServer: aztecRpcServerB,
       accounts: accounts,
       wallet: walletB,
-    } = await setupAztecRPCServer(1, aztecNode!));
+    } = await setupAztecRPCServer(1, aztecNode!, null, undefined, true));
     [userB] = accounts;
 
     logger(`Deploying L2 contract...`);

--- a/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
@@ -160,7 +160,7 @@ describe('e2e_p2p_network', () => {
     numTxs: number,
   ): Promise<NodeContext> => {
     const rpcConfig = getRpcConfig();
-    const aztecRpcServer = await createAztecRPCServer(node, rpcConfig);
+    const aztecRpcServer = await createAztecRPCServer(node, rpcConfig, {}, true);
     const keyPair = ConstantKeyPair.random(await Grumpkin.new());
     const partialAddress = Fr.random();
     const publicKey = keyPair.getPublicKey();

--- a/yarn-project/end-to-end/src/utils.ts
+++ b/yarn-project/end-to-end/src/utils.ts
@@ -76,6 +76,7 @@ const createRpcServer = async (
   rpcConfig: RpcServerConfig,
   aztecNode: AztecNodeService | undefined,
   logger: DebugLogger,
+  useLogSuffix?: boolean | string
 ): Promise<AztecRPC> => {
   if (SANDBOX_URL) {
     logger(`Creating JSON RPC client to remote host ${SANDBOX_URL}`);
@@ -86,7 +87,7 @@ const createRpcServer = async (
   } else if (!aztecNode) {
     throw new Error('Invalid aztec node when creating RPC server');
   }
-  return createAztecRPCServer(aztecNode, rpcConfig);
+  return createAztecRPCServer(aztecNode, rpcConfig, {}, useLogSuffix);
 };
 
 const setupL1Contracts = async (l1RpcUrl: string, account: HDAccount, logger: DebugLogger) => {
@@ -151,6 +152,7 @@ type TxContext = {
  * @param aztecNode - The instance of an aztec node, if one is required
  * @param firstPrivKey - The private key of the first account to be created.
  * @param logger - The logger to be used.
+ * @param useLogSuffix - Whether to add a randomly generated suffix to the RPC server debug logs.
  * @returns Aztec RPC server, accounts, wallets and logger.
  */
 export async function setupAztecRPCServer(
@@ -158,6 +160,7 @@ export async function setupAztecRPCServer(
   aztecNode: AztecNodeService | undefined,
   firstPrivKey: Uint8Array | null = null,
   logger = getLogger(),
+  useLogSuffix = false,
 ): Promise<{
   /**
    * The Aztec RPC instance.
@@ -178,7 +181,7 @@ export async function setupAztecRPCServer(
 }> {
   const rpcConfig = getRpcConfigEnvVars();
 
-  const aztecRpcServer = await createRpcServer(rpcConfig, aztecNode, logger);
+  const aztecRpcServer = await createRpcServer(rpcConfig, aztecNode, logger, useLogSuffix);
 
   const accountCollection = new AccountCollection();
   const txContexts: TxContext[] = [];

--- a/yarn-project/end-to-end/src/utils.ts
+++ b/yarn-project/end-to-end/src/utils.ts
@@ -63,7 +63,10 @@ const waitForRPCServer = async (rpcServer: AztecRPC, logger: DebugLogger) => {
   }, 'RPC Get Node Info');
 };
 
-const createAztecNode = async (nodeConfig: AztecNodeConfig, logger: DebugLogger): Promise<AztecNodeService | undefined> => {
+const createAztecNode = async (
+  nodeConfig: AztecNodeConfig,
+  logger: DebugLogger,
+): Promise<AztecNodeService | undefined> => {
   if (SANDBOX_URL) {
     logger(`Not creating Aztec Node as we are running against a sandbox at ${SANDBOX_URL}`);
     return undefined;
@@ -76,7 +79,7 @@ const createRpcServer = async (
   rpcConfig: RpcServerConfig,
   aztecNode: AztecNodeService | undefined,
   logger: DebugLogger,
-  useLogSuffix?: boolean | string
+  useLogSuffix?: boolean | string,
 ): Promise<AztecRPC> => {
   if (SANDBOX_URL) {
     logger(`Creating JSON RPC client to remote host ${SANDBOX_URL}`);

--- a/yarn-project/end-to-end/src/utils.ts
+++ b/yarn-project/end-to-end/src/utils.ts
@@ -23,7 +23,7 @@ import { toBigIntBE } from '@aztec/foundation/bigint-buffer';
 import { randomBytes } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
 import { mustSucceedFetch } from '@aztec/foundation/json-rpc';
-import { DebugLogger, Logger, createDebugLogger } from '@aztec/foundation/log';
+import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
 import { PortalERC20Abi, PortalERC20Bytecode, TokenPortalAbi, TokenPortalBytecode } from '@aztec/l1-artifacts';
 import { SchnorrSingleKeyAccountContractAbi } from '@aztec/noir-contracts/artifacts';
@@ -50,7 +50,7 @@ import { MNEMONIC, localAnvil } from './fixtures.js';
 
 const { SANDBOX_URL = '' } = process.env;
 
-const waitForRPCServer = async (rpcServer: AztecRPC, logger: Logger) => {
+const waitForRPCServer = async (rpcServer: AztecRPC, logger: DebugLogger) => {
   await retryUntil(async () => {
     try {
       logger('Attmpting to contact RPC Server...');
@@ -63,7 +63,7 @@ const waitForRPCServer = async (rpcServer: AztecRPC, logger: Logger) => {
   }, 'RPC Get Node Info');
 };
 
-const createAztecNode = async (nodeConfig: AztecNodeConfig, logger: Logger): Promise<AztecNodeService | undefined> => {
+const createAztecNode = async (nodeConfig: AztecNodeConfig, logger: DebugLogger): Promise<AztecNodeService | undefined> => {
   if (SANDBOX_URL) {
     logger(`Not creating Aztec Node as we are running against a sandbox at ${SANDBOX_URL}`);
     return undefined;
@@ -75,7 +75,7 @@ const createAztecNode = async (nodeConfig: AztecNodeConfig, logger: Logger): Pro
 const createRpcServer = async (
   rpcConfig: RpcServerConfig,
   aztecNode: AztecNodeService | undefined,
-  logger: Logger,
+  logger: DebugLogger,
 ): Promise<AztecRPC> => {
   if (SANDBOX_URL) {
     logger(`Creating JSON RPC client to remote host ${SANDBOX_URL}`);
@@ -89,7 +89,7 @@ const createRpcServer = async (
   return createAztecRPCServer(aztecNode, rpcConfig);
 };
 
-const setupL1Contracts = async (l1RpcUrl: string, account: HDAccount, logger: Logger) => {
+const setupL1Contracts = async (l1RpcUrl: string, account: HDAccount, logger: DebugLogger) => {
   if (SANDBOX_URL) {
     logger(`Retrieving contract addresses from ${SANDBOX_URL}`);
     const l1Contracts = await getL1ContractAddresses(SANDBOX_URL);
@@ -456,7 +456,7 @@ export async function calculateAztecStorageSlot(slot: bigint, key: Fr): Promise<
  * @param expectedValue - The expected value of the mapping.
  */
 export async function expectAztecStorageSlot(
-  logger: Logger,
+  logger: DebugLogger,
   aztecRpc: AztecRPC,
   contract: Contract,
   slot: bigint,

--- a/yarn-project/foundation/src/fifo/bounded_serial_queue.ts
+++ b/yarn-project/foundation/src/fifo/bounded_serial_queue.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '../log/console.js';
+import { createConsoleLogger } from '../log/console.js';
 import { Semaphore } from './semaphore.js';
 import { SerialQueue } from './serial_queue.js';
 
@@ -10,7 +10,7 @@ export class BoundedSerialQueue {
   private readonly queue = new SerialQueue();
   private semaphore: Semaphore;
 
-  constructor(maxQueueSize: number, private log = createLogger('aztec:foundation:bounded_serial_queue')) {
+  constructor(maxQueueSize: number, private log = createConsoleLogger('aztec:foundation:bounded_serial_queue')) {
     this.semaphore = new Semaphore(maxQueueSize);
   }
 

--- a/yarn-project/foundation/src/fifo/bounded_serial_queue.ts
+++ b/yarn-project/foundation/src/fifo/bounded_serial_queue.ts
@@ -1,4 +1,4 @@
-import { createConsoleLogger } from '../log/console.js';
+import { createDebugLogger } from '../log/index.js';
 import { Semaphore } from './semaphore.js';
 import { SerialQueue } from './serial_queue.js';
 
@@ -10,7 +10,7 @@ export class BoundedSerialQueue {
   private readonly queue = new SerialQueue();
   private semaphore: Semaphore;
 
-  constructor(maxQueueSize: number, private log = createConsoleLogger('aztec:foundation:bounded_serial_queue')) {
+  constructor(maxQueueSize: number, private log = createDebugLogger('aztec:foundation:bounded_serial_queue')) {
     this.semaphore = new Semaphore(maxQueueSize);
   }
 

--- a/yarn-project/foundation/src/fifo/memory_fifo.ts
+++ b/yarn-project/foundation/src/fifo/memory_fifo.ts
@@ -1,4 +1,4 @@
-import { createConsoleLogger } from '../log/console.js';
+import { createDebugLogger } from '../log/index.js';
 
 /**
  * A simple fifo queue. It can grow unbounded. It can have multiple producers and consumers.
@@ -10,7 +10,7 @@ export class MemoryFifo<T> {
   private items: T[] = [];
   private flushing = false;
 
-  constructor(private log = createConsoleLogger('aztec:foundation:memory_fifo')) {}
+  constructor(private log = createDebugLogger('aztec:foundation:memory_fifo')) {}
 
   /**
    * Returns the current number of items in the queue.

--- a/yarn-project/foundation/src/fifo/memory_fifo.ts
+++ b/yarn-project/foundation/src/fifo/memory_fifo.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '../log/console.js';
+import { createConsoleLogger } from '../log/console.js';
 
 /**
  * A simple fifo queue. It can grow unbounded. It can have multiple producers and consumers.
@@ -10,7 +10,7 @@ export class MemoryFifo<T> {
   private items: T[] = [];
   private flushing = false;
 
-  constructor(private log = createLogger('aztec:foundation:memory_fifo')) {}
+  constructor(private log = createConsoleLogger('aztec:foundation:memory_fifo')) {}
 
   /**
    * Returns the current number of items in the queue.

--- a/yarn-project/foundation/src/json-rpc/server/json_rpc_server.ts
+++ b/yarn-project/foundation/src/json-rpc/server/json_rpc_server.ts
@@ -5,7 +5,7 @@ import bodyParser from 'koa-bodyparser';
 import compress from 'koa-compress';
 import Router from 'koa-router';
 
-import { createLogger } from '../../log/index.js';
+import { createConsoleLogger } from '../../log/index.js';
 import { JsonClassConverterInput, StringClassConverterInput } from '../class_converter.js';
 import { convertBigintsInObj } from '../convert.js';
 import { JsonProxy } from './json_proxy.js';
@@ -22,7 +22,7 @@ export class JsonRpcServer {
     objectClassMap: JsonClassConverterInput,
     private createApi: boolean,
     private disallowedMethods: string[] = [],
-    private log = createLogger('aztec:foundation:json-rpc:server'),
+    private log = createConsoleLogger('aztec:foundation:json-rpc:server'),
   ) {
     this.proxy = new JsonProxy(handler, stringClassMap, objectClassMap);
   }

--- a/yarn-project/foundation/src/json-rpc/server/json_rpc_server.ts
+++ b/yarn-project/foundation/src/json-rpc/server/json_rpc_server.ts
@@ -5,7 +5,7 @@ import bodyParser from 'koa-bodyparser';
 import compress from 'koa-compress';
 import Router from 'koa-router';
 
-import { createConsoleLogger } from '../../log/index.js';
+import { createDebugLogger } from '../../log/index.js';
 import { JsonClassConverterInput, StringClassConverterInput } from '../class_converter.js';
 import { convertBigintsInObj } from '../convert.js';
 import { JsonProxy } from './json_proxy.js';
@@ -22,7 +22,7 @@ export class JsonRpcServer {
     objectClassMap: JsonClassConverterInput,
     private createApi: boolean,
     private disallowedMethods: string[] = [],
-    private log = createConsoleLogger('aztec:foundation:json-rpc:server'),
+    private log = createDebugLogger('aztec:foundation:json-rpc:server'),
   ) {
     this.proxy = new JsonProxy(handler, stringClassMap, objectClassMap);
   }

--- a/yarn-project/foundation/src/log/console.ts
+++ b/yarn-project/foundation/src/log/console.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 /**
- * Logger is a utility type that represents a logging function that accepts any number of arguments.
+ * Logger is a utility type that represents a console logging function that accepts any number of arguments.
  * It is used to provide customizable logging functionality, allowing developers to easily log messages
  * with optional prefixes and custom formatting or output destinations.
  */
@@ -36,7 +36,7 @@ class ConsoleLogger {
  * @param prefix - The optional string to prepend to each log message.
  * @returns A Logger function that accepts any number of arguments and logs them with the specified prefix.
  */
-export function createLogger(prefix?: string): Logger {
+export function createConsoleLogger(prefix?: string): Logger {
   if (prefix) {
     const logger = new ConsoleLogger(prefix, console.log);
     return (...args: any[]) => logger.log(...args);

--- a/yarn-project/foundation/src/log/console.ts
+++ b/yarn-project/foundation/src/log/console.ts
@@ -1,11 +1,5 @@
 /* eslint-disable no-console */
-
-/**
- * Logger is a utility type that represents a console logging function that accepts any number of arguments.
- * It is used to provide customizable logging functionality, allowing developers to easily log messages
- * with optional prefixes and custom formatting or output destinations.
- */
-export type Logger = (...args: any[]) => void;
+import { LogFn } from './index.js';
 
 /**
  * ConsoleLogger is a utility class that provides customizable console logging functionality.
@@ -36,7 +30,7 @@ class ConsoleLogger {
  * @param prefix - The optional string to prepend to each log message.
  * @returns A Logger function that accepts any number of arguments and logs them with the specified prefix.
  */
-export function createConsoleLogger(prefix?: string): Logger {
+export function createConsoleLogger(prefix?: string): LogFn {
   if (prefix) {
     const logger = new ConsoleLogger(prefix, console.log);
     return (...args: any[]) => logger.log(...args);

--- a/yarn-project/foundation/src/log/debug.ts
+++ b/yarn-project/foundation/src/log/debug.ts
@@ -1,5 +1,7 @@
 import debug from 'debug';
 
+import { LogFn } from './index.js';
+
 let preLogHook: ((...args: any[]) => void) | undefined;
 let postLogHook: ((...args: any[]) => void) | undefined;
 
@@ -24,16 +26,11 @@ function theFunctionThroughWhichAllLogsPass(logger: any, ...args: any[]) {
 }
 
 /**
- * A debug logger.
- */
-export type DebugLogger = (...args: any[]) => void;
-
-/**
  * Return a logger, meant to be silent by default and verbose during debugging.
  * @param name - The module name of the logger.
  * @returns A callable log function.
  */
-export function createDebugLogger(name: string): DebugLogger {
+export function createDebugOnlyLogger(name: string): LogFn {
   const logger = debug(name);
   return (...args: any[]) => theFunctionThroughWhichAllLogsPass(logger, ...args);
 }

--- a/yarn-project/foundation/src/log/index.ts
+++ b/yarn-project/foundation/src/log/index.ts
@@ -1,3 +1,9 @@
+/**
+ * A callable logger instance.
+ */
+export type LogFn = (...args: any[]) => void;
+
 export * from './console.js';
 export * from './debug.js';
+export * from './logger.js';
 export * from './log_history.js';

--- a/yarn-project/foundation/src/log/log_history.test.ts
+++ b/yarn-project/foundation/src/log/log_history.test.ts
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals';
 
-import { createDebugLogger, enableLogs } from './debug.js';
+import { createDebugOnlyLogger, enableLogs } from './debug.js';
 import { LogHistory } from './log_history.js';
 
 jest.useFakeTimers({ doNotFake: ['performance'] });
@@ -12,7 +12,7 @@ describe('log history', () => {
   const name = 'test:a';
 
   beforeEach(() => {
-    debug = createDebugLogger(name);
+    debug = createDebugOnlyLogger(name);
     enableLogs(name);
     logHistory = new LogHistory();
   });
@@ -53,7 +53,7 @@ describe('log history', () => {
   it('only keeps logs with enabled namespace', () => {
     logHistory.enable();
     const name2 = 'test:b';
-    const debug2 = createDebugLogger(name2);
+    const debug2 = createDebugOnlyLogger(name2);
     debug('0');
     debug2('zero');
     expect(logHistory.getLogs()).toEqual([[timestemp, name, '0']]);

--- a/yarn-project/foundation/src/log/logger.ts
+++ b/yarn-project/foundation/src/log/logger.ts
@@ -1,0 +1,71 @@
+import debug from 'debug';
+
+import { LogFn } from './index.js';
+
+const LogLevels = ['silent', 'fatal', 'error', 'warn', 'info', 'debug'] as const;
+const DefaultLogLevel = 'info' as const;
+
+/**
+ * A valid log severity level.
+ */
+type LogLevel = (typeof LogLevels)[number];
+
+const envLogLevel = process.env.LOG_LEVEL?.toLowerCase() as LogLevel;
+const currentLevel = LogLevels.includes(envLogLevel) ? envLogLevel : DefaultLogLevel;
+
+/**
+ * Logger that supports multiple severity levels.
+ */
+export type Logger = { [K in LogLevel]: LogFn };
+
+/**
+ * Logger that supports multiple severity levels and can be called directly to issue a debug statement.
+ * Intended as a drop-in replacement for the debug module.
+ */
+export type DebugLogger = LogFn & Logger;
+
+/**
+ * Creates a new DebugLogger for the current module, defaulting to the LOG_LEVEL env var.
+ * If DEBUG="[module]" env is set, will enable debug logging if the module matches.
+ * Uses npm debug for debug level and console.error for other levels.
+ * @param name - Name of the module.
+ * @returns A debug logger.
+ */
+export function createDebugLogger(name: string): DebugLogger {
+  const debugLogger = debug(name);
+  if (currentLevel === 'debug') debugLogger.enabled = true;
+
+  const logger = {
+    silent: () => {},
+    fatal: (...args: any[]) => logWithDebug(debugLogger, 'fatal', args),
+    error: (...args: any[]) => logWithDebug(debugLogger, 'error', args),
+    warn: (...args: any[]) => logWithDebug(debugLogger, 'warn', args),
+    info: (...args: any[]) => logWithDebug(debugLogger, 'info', args),
+    debug: (...args: any[]) => logWithDebug(debugLogger, 'debug', args),
+  };
+  return Object.assign(debugLogger, logger);
+}
+
+/**
+ * Logs args to npm debug if enabled or log level is debug, console.error otherwise.
+ * @param debug - Instance of npm debug.
+ * @param level - Intended log level.
+ * @param args - Args to log.
+ */
+function logWithDebug(debug: debug.Debugger, level: LogLevel, args: any[]) {
+  if (debug.enabled) {
+    debug(args);
+  } else if (LogLevels.indexOf(level) <= LogLevels.indexOf(currentLevel)) {
+    if (currentLevel !== level) args = [level.toUpperCase(), ...args];
+    printLog(args);
+  }
+}
+
+/**
+ * Outputs to console error.
+ * @param args - Args to log.
+ */
+function printLog(args: any[]) {
+  // eslint-disable-next-line no-console
+  console.error(...args);
+}

--- a/yarn-project/foundation/src/log/logger.ts
+++ b/yarn-project/foundation/src/log/logger.ts
@@ -1,5 +1,7 @@
 import debug from 'debug';
 
+
+
 import { LogFn } from './index.js';
 
 const LogLevels = ['silent', 'fatal', 'error', 'warn', 'info', 'debug'] as const;
@@ -54,10 +56,11 @@ export function createDebugLogger(name: string): DebugLogger {
  */
 function logWithDebug(debug: debug.Debugger, level: LogLevel, args: any[]) {
   if (debug.enabled) {
-    debug(args);
+    debug(args[0], ...args.slice(1));
   } else if (LogLevels.indexOf(level) <= LogLevels.indexOf(currentLevel)) {
     if (currentLevel !== level) args = [level.toUpperCase(), ...args];
-    printLog(args);
+    const prefix = `  ${debug.namespace.replace(/^aztec:/, '')}`;
+    printLog([prefix, ...args]);
   }
 }
 

--- a/yarn-project/foundation/src/retry/index.ts
+++ b/yarn-project/foundation/src/retry/index.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '../log/index.js';
+import { createConsoleLogger } from '../log/index.js';
 import { sleep } from '../sleep/index.js';
 import { Timer } from '../timer/index.js';
 
@@ -32,7 +32,7 @@ export async function retry<Result>(
   fn: () => Promise<Result>,
   name = 'Operation',
   backoff = backoffGenerator(),
-  log = createLogger('aztec:foundation:retry'),
+  log = createConsoleLogger('aztec:foundation:retry'),
 ) {
   while (true) {
     try {

--- a/yarn-project/foundation/src/retry/index.ts
+++ b/yarn-project/foundation/src/retry/index.ts
@@ -1,4 +1,4 @@
-import { createConsoleLogger } from '../log/index.js';
+import { createDebugLogger } from '../log/index.js';
 import { sleep } from '../sleep/index.js';
 import { Timer } from '../timer/index.js';
 
@@ -32,7 +32,7 @@ export async function retry<Result>(
   fn: () => Promise<Result>,
   name = 'Operation',
   backoff = backoffGenerator(),
-  log = createConsoleLogger('aztec:foundation:retry'),
+  log = createDebugLogger('aztec:foundation:retry'),
 ) {
   while (true) {
     try {

--- a/yarn-project/foundation/src/transport/dispatch/create_dispatch_fn.ts
+++ b/yarn-project/foundation/src/transport/dispatch/create_dispatch_fn.ts
@@ -1,4 +1,4 @@
-import { createDebugLogger } from '../../log/debug.js';
+import { createDebugLogger } from '../../log/index.js';
 
 /**
  * Represents a message object for dispatching function calls.

--- a/yarn-project/foundation/src/wasm/wasm/empty_wasi_sdk.ts
+++ b/yarn-project/foundation/src/wasm/wasm/empty_wasi_sdk.ts
@@ -1,4 +1,4 @@
-import { createDebugLogger } from '../../log/index.js';
+import { createDebugOnlyLogger } from '../../log/index.js';
 
 /**
  * Dummy implementation of a necessary part of the wasi api:
@@ -7,7 +7,7 @@ import { createDebugLogger } from '../../log/index.js';
  * TODO find a way to update off of wasi 12.
  */
 /* eslint-disable camelcase */
-export const getEmptyWasiSdk = (debug = createDebugLogger('wasm:empty_wasi_sdk')) => ({
+export const getEmptyWasiSdk = (debug = createDebugOnlyLogger('wasm:empty_wasi_sdk')) => ({
   /**
    * Retrieves the current time from the system clock.
    * This function is a dummy implementation of the WASI API's `clock_time_get` method,

--- a/yarn-project/foundation/src/wasm/wasm/wasm_module.ts
+++ b/yarn-project/foundation/src/wasm/wasm/wasm_module.ts
@@ -2,7 +2,7 @@ import { Buffer } from 'buffer';
 import { randomBytes } from 'crypto';
 
 import { MemoryFifo } from '../../fifo/index.js';
-import { DebugLogger, createDebugLogger } from '../../log/index.js';
+import { LogFn, createDebugOnlyLogger } from '../../log/index.js';
 import { getEmptyWasiSdk } from './empty_wasi_sdk.js';
 
 /**
@@ -48,7 +48,7 @@ export class WasmModule implements IWasmModule {
   private heap!: Uint8Array;
   private instance?: WebAssembly.Instance;
   private mutexQ = new MemoryFifo<boolean>();
-  private debug: DebugLogger;
+  private debug: LogFn;
 
   /**
    * Create a wasm module. Should be followed by await init();.
@@ -61,7 +61,7 @@ export class WasmModule implements IWasmModule {
     private importFn: (module: WasmModule) => any,
     loggerName = 'wasm',
   ) {
-    this.debug = createDebugLogger(loggerName);
+    this.debug = createDebugOnlyLogger(loggerName);
     this.mutexQ.put(true);
   }
 
@@ -147,7 +147,7 @@ export class WasmModule implements IWasmModule {
    * Add a logger.
    * @param logger - Function to call when logging.
    */
-  public addLogger(logger: DebugLogger) {
+  public addLogger(logger: LogFn) {
     const oldDebug = this.debug;
     this.debug = (...args: any[]) => {
       logger(...args);

--- a/yarn-project/merkle-tree/src/sparse_tree/sparse_tree.test.ts
+++ b/yarn-project/merkle-tree/src/sparse_tree/sparse_tree.test.ts
@@ -1,5 +1,5 @@
 import { CircuitsWasm } from '@aztec/circuits.js';
-import { createLogger } from '@aztec/foundation/log';
+import { createConsoleLogger } from '@aztec/foundation/log';
 import { IWasmModule } from '@aztec/foundation/wasm';
 import { Hasher, SiblingPath } from '@aztec/types';
 
@@ -15,7 +15,7 @@ import { treeTestSuite } from '../test/test_suite.js';
 import { createMemDown } from '../test/utils/create_mem_down.js';
 import { SparseTree } from './sparse_tree.js';
 
-const log = createLogger('aztec:sparse_tree_test');
+const log = createConsoleLogger('aztec:sparse_tree_test');
 
 const createDb = async (
   levelUp: levelup.LevelUp,

--- a/yarn-project/merkle-tree/src/sparse_tree/sparse_tree.test.ts
+++ b/yarn-project/merkle-tree/src/sparse_tree/sparse_tree.test.ts
@@ -1,5 +1,5 @@
 import { CircuitsWasm } from '@aztec/circuits.js';
-import { createConsoleLogger } from '@aztec/foundation/log';
+import { createDebugLogger } from '@aztec/foundation/log';
 import { IWasmModule } from '@aztec/foundation/wasm';
 import { Hasher, SiblingPath } from '@aztec/types';
 
@@ -15,7 +15,7 @@ import { treeTestSuite } from '../test/test_suite.js';
 import { createMemDown } from '../test/utils/create_mem_down.js';
 import { SparseTree } from './sparse_tree.js';
 
-const log = createConsoleLogger('aztec:sparse_tree_test');
+const log = createDebugLogger('aztec:sparse_tree_test');
 
 const createDb = async (
   levelUp: levelup.LevelUp,

--- a/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
@@ -1,11 +1,11 @@
 import { toBigIntBE, toBufferBE } from '@aztec/foundation/bigint-buffer';
-import { createLogger } from '@aztec/foundation/log';
+import { createConsoleLogger } from '@aztec/foundation/log';
 import { SiblingPath } from '@aztec/types';
 
 import { IndexedTree, LeafData } from '../interfaces/indexed_tree.js';
 import { TreeBase } from '../tree_base.js';
 
-const log = createLogger('aztec:standard-indexed-tree');
+const log = createConsoleLogger('aztec:standard-indexed-tree');
 
 const indexToKeyLeaf = (name: string, index: bigint) => {
   return `${name}:leaf:${index}`;

--- a/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
@@ -1,11 +1,11 @@
 import { toBigIntBE, toBufferBE } from '@aztec/foundation/bigint-buffer';
-import { createConsoleLogger } from '@aztec/foundation/log';
+import { createDebugLogger } from '@aztec/foundation/log';
 import { SiblingPath } from '@aztec/types';
 
 import { IndexedTree, LeafData } from '../interfaces/indexed_tree.js';
 import { TreeBase } from '../tree_base.js';
 
-const log = createConsoleLogger('aztec:standard-indexed-tree');
+const log = createDebugLogger('aztec:standard-indexed-tree');
 
 const indexToKeyLeaf = (name: string, index: bigint) => {
   return `${name}:leaf:${index}`;

--- a/yarn-project/noir-compiler/src/cli.ts
+++ b/yarn-project/noir-compiler/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { createLogger } from '@aztec/foundation/log';
+import { createConsoleLogger } from '@aztec/foundation/log';
 
 import { Command } from 'commander';
 import fsExtra from 'fs-extra';
@@ -10,7 +10,7 @@ import { ContractCompiler } from './compile.js';
 import { generateType } from './index.js';
 
 const program = new Command();
-const log = createLogger('noir-compiler-cli');
+const log = createConsoleLogger('noir-compiler-cli');
 
 const main = async () => {
   program

--- a/yarn-project/noir-contracts/src/scripts/copy_output.ts
+++ b/yarn-project/noir-contracts/src/scripts/copy_output.ts
@@ -1,5 +1,5 @@
 import { ABIParameter, ABIType, FunctionType } from '@aztec/foundation/abi';
-import { createLogger } from '@aztec/foundation/log';
+import { createConsoleLogger } from '@aztec/foundation/log';
 import { generateType } from '@aztec/noir-compiler';
 
 import { readFileSync, writeFileSync } from 'fs';
@@ -12,7 +12,7 @@ import { join as pathJoin } from 'path';
 import mockedKeys from './mockedKeys.json' assert { type: 'json' };
 
 const STATEMENT_TYPES = ['type', 'params', 'return'] as const;
-const log = createLogger('aztec:noir-contracts');
+const log = createConsoleLogger('aztec:noir-contracts');
 
 const PROJECT_CONTRACTS = [
   { name: 'SchnorrSingleKeyAccount', target: '../aztec.js/src/abis/', exclude: ['bytecode', 'verificationKey'] },

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -172,9 +172,10 @@ export class Sequencer {
       await this.publishContractPublicData(validTxs, block);
 
       await this.publishL2Block(block);
+      this.log.info(`Submitted rollup block ${block.number} with ${processedTxs.length} transactions`);
     } catch (err) {
-      this.log(err);
-      this.log(`Rolling back world state DB`);
+      this.log.error(err);
+      this.log.error(`Rolling back world state DB`);
       await this.worldState.getLatest().rollback();
     }
   }

--- a/yarn-project/types/src/l2_block_downloader/l2_block_downloader.ts
+++ b/yarn-project/types/src/l2_block_downloader/l2_block_downloader.ts
@@ -1,10 +1,10 @@
 import { MemoryFifo, Semaphore } from '@aztec/foundation/fifo';
-import { createConsoleLogger } from '@aztec/foundation/log';
+import { createDebugLogger } from '@aztec/foundation/log';
 import { InterruptableSleep } from '@aztec/foundation/sleep';
 
 import { INITIAL_L2_BLOCK_NUM, L2Block, L2BlockSource } from '../index.js';
 
-const log = createConsoleLogger('aztec:l2_block_downloader');
+const log = createDebugLogger('aztec:l2_block_downloader');
 
 /**
  * Downloads L2 blocks from a L2BlockSource.

--- a/yarn-project/types/src/l2_block_downloader/l2_block_downloader.ts
+++ b/yarn-project/types/src/l2_block_downloader/l2_block_downloader.ts
@@ -1,10 +1,10 @@
 import { MemoryFifo, Semaphore } from '@aztec/foundation/fifo';
-import { createLogger } from '@aztec/foundation/log';
+import { createConsoleLogger } from '@aztec/foundation/log';
 import { InterruptableSleep } from '@aztec/foundation/sleep';
 
 import { INITIAL_L2_BLOCK_NUM, L2Block, L2BlockSource } from '../index.js';
 
-const log = createLogger('aztec:l2_block_downloader');
+const log = createConsoleLogger('aztec:l2_block_downloader');
 
 /**
  * Downloads L2 blocks from a L2BlockSource.

--- a/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.test.ts
+++ b/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.test.ts
@@ -10,7 +10,7 @@ import {
   MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
   NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
 } from '@aztec/circuits.js';
-import { createLogger } from '@aztec/foundation/log';
+import { createConsoleLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { INITIAL_LEAF, Pedersen } from '@aztec/merkle-tree';
 import {
@@ -103,7 +103,7 @@ const getMockBlock = (blockNumber: number, newContractsCommitments?: Buffer[]) =
 const createSynchroniser = (merkleTreeDb: any, rollupSource: any) =>
   new ServerWorldStateSynchroniser(merkleTreeDb as MerkleTreeDb, rollupSource as L2BlockSource);
 
-const log = createLogger('aztec:server_world_state_synchroniser_test');
+const log = createConsoleLogger('aztec:server_world_state_synchroniser_test');
 
 describe('server_world_state_synchroniser', () => {
   const rollupSource: Mockify<Pick<L2BlockSource, 'getBlockHeight' | 'getL2Blocks'>> = {

--- a/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.test.ts
+++ b/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.test.ts
@@ -10,7 +10,7 @@ import {
   MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
   NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
 } from '@aztec/circuits.js';
-import { createConsoleLogger } from '@aztec/foundation/log';
+import { createDebugLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { INITIAL_LEAF, Pedersen } from '@aztec/merkle-tree';
 import {
@@ -103,7 +103,7 @@ const getMockBlock = (blockNumber: number, newContractsCommitments?: Buffer[]) =
 const createSynchroniser = (merkleTreeDb: any, rollupSource: any) =>
   new ServerWorldStateSynchroniser(merkleTreeDb as MerkleTreeDb, rollupSource as L2BlockSource);
 
-const log = createConsoleLogger('aztec:server_world_state_synchroniser_test');
+const log = createDebugLogger('aztec:server_world_state_synchroniser_test');
 
 describe('server_world_state_synchroniser', () => {
   const rollupSource: Mockify<Pick<L2BlockSource, 'getBlockHeight' | 'getL2Blocks'>> = {


### PR DESCRIPTION
Introduces a new logger class that behaves like the old `DebugLogger` (it's callable and forwards everything to [npm debug](https://www.npmjs.com/package/debug)), and also adds `info`, `warn`, `error`, and `fatal` methods. These are logged to `console.error` based on the `LOG_LEVEL`, using the same format as npm debug. Note that `DEBUG` is still supported, so it's possible to combine the two.

Adds a few `info` statements to log important events in the rpc server, node, and sequencer. As an example, the output of the sandbox looks like this when running the token example:

![Screenshot from 2023-07-20 14-41-24](https://github.com/AztecProtocol/aztec-packages/assets/429604/981b448d-2ac4-4f56-be68-f5c561d18b34)

Later down the road, we can inject winston, pino, or bunyan for more complex logging. But this fits the bill for sandbox.

Fixes #1116 
