### PR TITLE
fix: docs github mirror action

### DIFF
--- a/.github/workflows/mirror_docs_repo.yml
+++ b/.github/workflows/mirror_docs_repo.yml
@@ -20,4 +20,11 @@ jobs:
 
       - name: Push to branch
         run: |
-          ./scripts/git_subrepo.sh push docs --branch=main
+          # we push using git subrepo (https://github.com/ingydotnet/git-subrepo)
+          # with some logic to recover from squashed parent commits
+          SUBREPO_PATH=docs
+          # identify ourselves, needed to commit
+          git config --global user.email "tech@aztecprotocol.com"
+          git config --global user.name "AztecBot"
+          # push to subrepo, commit locally
+          ./scripts/git_subrepo.sh push $SUBREPO_PATH --branch=main

--- a/scripts/git_subrepo.sh
+++ b/scripts/git_subrepo.sh
@@ -2,5 +2,33 @@
 set -eu
 
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
-"$SCRIPT_DIR"/git-subrepo/lib/git-subrepo $@
+
+# Check for unstaged changes
+if ! git diff-index --quiet HEAD --; then
+    echo "Error: You have unstaged changes. Please commit or stash them before running git_subrepo.sh."
+    exit 1
+fi
+
+SUBREPO_PATH="${2:-}"
+if [ -d "$SUBREPO_PATH" ] ; then
+    # Read parent commit from .gitrepo file
+    parent_commit=$(awk -F'= ' '/parent =/{print $2}' $SUBREPO_PATH/.gitrepo)
+    # Check if the parent commit exists in this branch
+    if ! git branch --contains $parent_commit | grep -q '\*'; then
+        echo "Auto-fixing squashed parent in $SUBREPO_PATH/.gitrepo."
+
+        # Get the commit that last wrote to .gitrepo
+        last_commit=$(git log -1 --pretty=format:%H -- "$SUBREPO_PATH/.gitrepo")
+        # Get parent of the last commit
+        new_parent=$(git log --pretty=%P -n 1 $last_commit)
+
+        # Update parent in .gitrepo file using perl
+        perl -pi -e "s/${parent_commit}/${new_parent}/g" "$SUBREPO_PATH/.gitrepo"
+
+        # Commit this change
+        git add "$SUBREPO_PATH/.gitrepo"
+        git commit -m "git_subrepo.sh: Fix parent in .gitrepo file."
+    fi
+fi
+"$SCRIPT_DIR"/git-subrepo/lib/git-subrepo -x $@
 

--- a/scripts/git_subrepo.sh
+++ b/scripts/git_subrepo.sh
@@ -35,6 +35,7 @@ if [ -d "$SUBREPO_PATH" ] ; then
 
         # Commit this change
         git add "$SUBREPO_PATH/.gitrepo"
+        # This commit should only go into squashed PRs
         git commit -m "git_subrepo.sh: Fix parent in .gitrepo file."
     fi
 fi

--- a/scripts/git_subrepo.sh
+++ b/scripts/git_subrepo.sh
@@ -9,6 +9,14 @@ if ! git diff-index --quiet HEAD --; then
     exit 1
 fi
 
+# git subrepo is quite nice, but has one flaw in our workflow:
+# We frequently squash commits in PRs, and we might update the .gitrepo file
+# with a parent commit that later does not exist. 
+# A backup heuristic is used to later find the squashed commit's parent
+# using the .gitrepo file's git history. This might be brittle 
+# in the face of e.g. a .gitrepo whitespace change, but it's a fallback, 
+# we only have this issue in master, and the file should only be edited
+# generally by subrepo commands.
 SUBREPO_PATH="${2:-}"
 if [ -d "$SUBREPO_PATH" ] ; then
     # Read parent commit from .gitrepo file


### PR DESCRIPTION
# Description

Should fix master.

The action had failed in master asking for identity. As well, I noticed that if the subrepo is updated, and then a commit squashed, the parent might become not a real commit. I kludged a fix for a squash workflow by finding the parent commit of where the file was edited last.

# Checklist:

- [*] I have reviewed my diff in github, line by line.
- [*] Every change is related to the PR description.
- [*] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [*] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [*] The branch has been merged or rebased against the head of its merge target.
- [*] I'm happy for the PR to be merged at the reviewer's next convenience.
