### PR TITLE
chore(log): do not log to console in tests

### DIFF
--- a/yarn-project/foundation/src/log/logger.ts
+++ b/yarn-project/foundation/src/log/logger.ts
@@ -57,7 +57,7 @@ export function createDebugLogger(name: string): DebugLogger {
 function logWithDebug(debug: debug.Debugger, level: LogLevel, args: any[]) {
   if (debug.enabled) {
     debug(args[0], ...args.slice(1));
-  } else if (LogLevels.indexOf(level) <= LogLevels.indexOf(currentLevel)) {
+  } else if (LogLevels.indexOf(level) <= LogLevels.indexOf(currentLevel) && process.env.NODE_ENV !== 'test') {
     printLog([getPrefix(debug, level), ...args]);
   }
 }


### PR DESCRIPTION
Disable logging in tests. We were polluting test output with default INFO logs, eg:

```
 PASS  src/sequencer/sequencer.test.ts
  ● Console
    console.error
      sequencer Submitted rollup block 1 with 1 transactions

      87 |   console.log('NODEENV', process.env.NODE_ENV);
      88 |   // eslint-disable-next-line no-console
    > 89 |   console.error(...args);
         |           ^
      90 | }

      at printLog (../../foundation/src/log/logger.ts:89:11)
      at logWithDebug (../../foundation/src/log/logger.ts:63:5)
      at Function.info (../../foundation/src/log/logger.ts:47:31)
      at TestSubject.work (sequencer/sequencer.ts:175:16)
      at Object.<anonymous> (sequencer/sequencer.test.ts:104:5)
```