### PR TITLE
fix(git): Use https in submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "build-system"]
 	path = build-system
-	url = git@github.com:AztecProtocol/build-system.git
+	url = https://github.com/AztecProtocol/build-system
 [submodule "barretenberg"]
 	path = circuits/cpp/barretenberg
-	url = git@github.com:AztecProtocol/barretenberg.git
+	url = https://github.com/AztecProtocol/barretenberg
 [submodule "legacy-nested-build-system"]
 	path = circuits/build-system
-	url = git@github.com:AztecProtocol/build-system.git
+	url = https://github.com/AztecProtocol/build-system
 [submodule "l1-contracts/lib/openzeppelin-contracts"]
 	path = l1-contracts/lib/openzeppelin-contracts
 	url = https://github.com/openzeppelin/openzeppelin-contracts


### PR DESCRIPTION
This works around the need to authenticate that apparently exists with public git:// repos.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
