### PR TITLE
fix: maintan docs .gitrepo

### DIFF
--- a/.github/workflows/mirror_docs_repo.yml
+++ b/.github/workflows/mirror_docs_repo.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'docs/**'
+      - '!docs/.gitrepo'
 
 jobs:
   build:
@@ -24,11 +25,11 @@ jobs:
           # with some logic to recover from squashed parent commits
           SUBREPO_PATH=docs
           # identify ourselves, needed to commit
-          git config --global user.email "tech@aztecprotocol.com"
-          git config --global user.name "AztecBot"
-          # push to subrepo, commit locally. The commit is lost
-          # when the github action ends, however it is not needed
-          # to continue to replay. If we do hit issues such as this 
+          git config --global user.name AztecBot
+          git config --global user.email tech@aztecprotocol.com
+          # push to subrepo, commit to master. The commit is needed
+          # to continue to replay. If we still hit issues such as this
           # action failing due to upstream changes, a manual resolution
           # PR with ./scripts/git_subrepo.sh pull will be needed.
           ./scripts/git_subrepo.sh push $SUBREPO_PATH --branch=main
+          git push # update .gitrepo on master


### PR DESCRIPTION
# Description

I thought it would smart replay, but seems its simply a hard problem not to have the extra commit info.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
