### PR TITLE
feat: barretenberg PR migrate tool

### DIFF
--- a/scripts/migrate_barretenberg_branch.sh
+++ b/scripts/migrate_barretenberg_branch.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -eu
+
+# Usage: ./this.sh <branch> <commit_message>
+# Script for migrating PRs from barretenberg repo to aztec-packages.
+# Meant to be used from master with a branch name that exists on barretenberg repo but not aztec-packages.
+# You can change the commit message after with git commit --amend if needed.
+
+# Display usage if not enough arguments
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <branch> <commit_message>"
+    exit 1
+fi
+
+# Check for unstaged changes
+if ! git diff-index --quiet HEAD --; then
+    echo "Error: You have unstaged changes. Please commit or stash them before running git_subrepo.sh."
+    exit 1
+fi
+
+BRANCH="$1"
+COMMIT_MESSAGE="$2"
+SUBREPO_PATH=circuits/cpp/barretenberg # can be changed to another subrepo if useful
+
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+cd "$SCRIPT_DIR"/..
+
+echo "(branch migrate) Switching to a new branch named '$BRANCH' (this branch can't already exist)"
+
+# Check if branch already exists
+if git rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
+    echo "Error: Aztec branch '$BRANCH' already exists. Please delete it with 'git branch -D $BRANCH' if you are sure you don't need it."
+    exit 1
+fi
+
+git checkout -b "$BRANCH"
+
+echo "(branch migrate) Pulling from upstream barretenberg repo. If this doesn't work, your barretenberg branch may need to merge barretenberg master."
+# note: we use force with the assumption that people don't care about their subrepo stash branch
+if ! scripts/git_subrepo.sh pull "$SUBREPO_PATH" --branch=$BRANCH --force; then
+    echo "Error: Failed to pull from upstream barretenberg repo. Check your branch name or network connection."
+    exit 1
+fi
+
+echo "(branch migrate) Automatic git data fix"
+# Tosses away the .gitrepo changes, as those we only want if pulling from barretenberg master, not PRs (which will go in as aztec commits).
+# because git-subrepo uses 'git rm -r', we fix up .gitmodules after as well. This is an edge-case gotcha using 
+# git submodules along with git-subrepo.
+
+git checkout HEAD^ -- "$SUBREPO_PATH"/.gitrepo .gitmodules
+
+if ! git commit --amend -m "$COMMIT_MESSAGE"; then
+    echo "Error: Failed to commit changes. Check your commit message."
+    exit 1
+fi
+echo "(branch migrate) All done. You can now 'git push origin HEAD' and click to create a PR on aztec. Changes will then automatically go into barretenberg when merged."


### PR DESCRIPTION
# Description

Originally this was going to be a short video, then I hit edge cases. I went for a script. Hopefully I can do a video in a bit explaining what is needed to know to understand this, but after this it should be a one liner:

`./scripts/migrate_barretenberg_branch.sh <barretenberg-branch> "<commit-message>"`

There is a fair bit of error handling and recovery advice as this is a cross-repo stitching and thus edge-case prone.
I hit one big gotcha here that is worked around with any such operation briefly doing a `git rm <folder>`, and git rm updating .gitmodules surprisingly. This gets rid of this diff, which is 'expected' when git submodules interact with git subrepo. 
Also it tosses away the .gitrepo changes, as those we only want if pulling from barretenberg master, not PRs (which will go in as aztec commits).

# Checklist:

- [*] I have reviewed my diff in github, line by line.
- [*] Every change is related to the PR description.
- [*] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [*] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [*] The branch has been merged or rebased against the head of its merge target.
- [*] I'm happy for the PR to be merged at the reviewer's next convenience.
