### PR TITLE
chore: removed obsolete nargo flag

### DIFF
--- a/yarn-project/noir-contracts/src/scripts/compile.sh
+++ b/yarn-project/noir-contracts/src/scripts/compile.sh
@@ -66,9 +66,9 @@ for CONTRACT_NAME in "$@"; do
   # If VERBOSE is not set, compile with 'nargo' and redirect standard error (stderr) to /dev/null and standard output (stdout) to /dev/null.
   # If the compilation fails, rerun the compilation with 'nargo' and show the compiler output.
   if [[ -z "${VERBOSE:-}" ]]; then
-    "$NARGO_COMMAND" compile main --experimental-ssa --contracts 2> /dev/null > /dev/null  || (echo "Error compiling contract. Re-running as verbose to show compiler output:"; "$NARGO_COMMAND" compile main --experimental-ssa --contracts);
+    "$NARGO_COMMAND" compile main --contracts 2> /dev/null > /dev/null  || (echo "Error compiling contract. Re-running as verbose to show compiler output:"; "$NARGO_COMMAND" compile main --contracts);
   else
-    "$NARGO_COMMAND" compile main --experimental-ssa --contracts
+    "$NARGO_COMMAND" compile main --contracts
   fi
 
   cd $ROOT


### PR DESCRIPTION
# Description

After updating to nargo 0.9.0 --experimental-ssa flag is no longer supported. This PR removes it.

Error message I got after updating:
<img width="673" alt="image" src="https://github.com/AztecProtocol/aztec-packages/assets/13470840/ad76b25b-a02a-4da4-9df2-376a878ab0a6">

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
