### PR TITLE
ci: disable clang tidy for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,16 +316,17 @@ jobs:
           name: "Build"
           command: cond_spot_run_build circuits-wasm-linux-clang-assert 64
 
-  circuits-x86_64-linux-clang-tidy:
-    docker:
-      - image: aztecprotocol/alpine-build-image
-    resource_class: small
-    steps:
-      - *checkout
-      - *setup_env
-      - run:
-          name: "Build"
-          command: cond_spot_run_build circuits-x86_64-linux-clang-tidy 64
+  # TODO Disabling until this is 3-10x faster see #1152
+  # circuits-x86_64-linux-clang-tidy:
+  #   docker:
+  #     - image: aztecprotocol/alpine-build-image
+  #   resource_class: small
+  #   steps:
+  #     - *checkout
+  #     - *setup_env
+  #     - run:
+  #         name: "Build"
+  #         command: cond_spot_run_build circuits-x86_64-linux-clang-tidy 64
 
   circuits-x86_64-linux-clang:
     docker:
@@ -1050,7 +1051,7 @@ workflows:
           <<: *defaults
       - circuits-wasm-linux-clang: *defaults
       - circuits-wasm-linux-clang-assert: *defaults
-      - circuits-x86_64-linux-clang-tidy: *defaults
+      # - circuits-x86_64-linux-clang-tidy: *defaults # TODO #1152
       - circuits-x86_64-linux-clang: *defaults
       - circuits-x86_64-linux-clang-assert: *defaults
       - circuits-wasm-tests:
@@ -1062,7 +1063,7 @@ workflows:
           requires:
             - circuits-wasm-linux-clang
             - circuits-wasm-linux-clang-assert
-            - circuits-x86_64-linux-clang-tidy
+            # - circuits-x86_64-linux-clang-tidy # TODO #1152
             - circuits-x86_64-linux-clang
             - circuits-x86_64-linux-clang-assert
             - circuits-wasm-tests


### PR DESCRIPTION
This was taking up a spot instance for rather long

See https://github.com/AztecProtocol/aztec-packages/issues/1152 which will reenable this
