### PR TITLE
chore: update directory from which to pull noir test cases

### DIFF
--- a/circuits/cpp/barretenberg/acir_tests/run_acir_tests.sh
+++ b/circuits/cpp/barretenberg/acir_tests/run_acir_tests.sh
@@ -18,10 +18,10 @@ if [ ! -d acir_tests ]; then
     git clone -b $BRANCH --filter=blob:none --no-checkout https://github.com/noir-lang/noir.git
     cd noir
     git sparse-checkout init --cone
-    git sparse-checkout set crates/nargo_cli/tests/test_data_ssa_refactor
+    git sparse-checkout set crates/nargo_cli/tests/test_data
     git checkout
     cd ..
-    mv noir/crates/nargo_cli/tests/test_data_ssa_refactor acir_tests
+    mv noir/crates/nargo_cli/tests/test_data acir_tests
     rm -rf noir
   fi
 fi


### PR DESCRIPTION
# Description

https://github.com/noir-lang/noir/pull/2074 performs a cleanup of the location of the Noir test data directory and so bberg needs to update to match

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] The branch has been merged or rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
