### PR TITLE
standard honk on grumpkin

### DIFF
--- a/circuits/cpp/barretenberg/cpp/bootstrap.sh
+++ b/circuits/cpp/barretenberg/cpp/bootstrap.sh
@@ -49,9 +49,10 @@ cmake --preset $PRESET -DCMAKE_BUILD_TYPE=RelWithAssert
 cmake --build --preset $PRESET ${@/#/--target }
 
 cd ./build
-# The Grumpkin SRS is generated manually at the moment only up to a large enough size for tests
+# The Grumpkin SRS is generated manually at the moment, only up to a large enough size for tests
+# If tests require more points, the parameter can be increased here.
 cmake --build . --parallel --target grumpkin_srs_gen
-./bin/grumpkin_srs_gen 4096
+./bin/grumpkin_srs_gen 8192
 echo "Generated Grumpkin SRS successfully"
 
 # Install wasi-sdk.

--- a/circuits/cpp/barretenberg/cpp/bootstrap.sh
+++ b/circuits/cpp/barretenberg/cpp/bootstrap.sh
@@ -48,6 +48,12 @@ echo "#################################"
 cmake --preset $PRESET -DCMAKE_BUILD_TYPE=RelWithAssert
 cmake --build --preset $PRESET ${@/#/--target }
 
+cd ./build
+# The Grumpkin SRS is generated manually at the moment only up to a large enough size for tests
+cmake --build . --parallel --target grumpkin_srs_gen
+./bin/grumpkin_srs_gen 4096
+echo "Generated Grumpkin SRS successfully"
+
 # Install wasi-sdk.
 ./scripts/install-wasi-sdk.sh
 

--- a/circuits/cpp/barretenberg/cpp/scripts/run_tests
+++ b/circuits/cpp/barretenberg/cpp/scripts/run_tests
@@ -25,5 +25,5 @@ docker run --rm -t $IMAGE_URI /bin/sh -c "\
   cd /usr/src/barretenberg/cpp/srs_db; \
   ./download_ignition.sh $NUM_TRANSCRIPTS; \
   cd /usr/src/barretenberg/cpp/build; \
-./bin/grumpkin_srs_gen 1048576; \
+  ./bin/grumpkin_srs_gen 1048576; \
   for BIN in $TESTS; do ./bin/\$BIN $@; done"

--- a/circuits/cpp/barretenberg/cpp/scripts/run_tests
+++ b/circuits/cpp/barretenberg/cpp/scripts/run_tests
@@ -25,4 +25,5 @@ docker run --rm -t $IMAGE_URI /bin/sh -c "\
   cd /usr/src/barretenberg/cpp/srs_db; \
   ./download_ignition.sh $NUM_TRANSCRIPTS; \
   cd /usr/src/barretenberg/cpp/build; \
+./bin/grumpkin_srs_gen 1048576; \
   for BIN in $TESTS; do ./bin/\$BIN $@; done"

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.hpp
@@ -40,7 +40,9 @@ struct acir_format {
     // A standard plonk arithmetic constraint, as defined in the poly_triple struct, consists of selector values
     // for q_M,q_L,q_R,q_O,q_C and indices of three variables taking the role of left, right and output wire
     // This could be a large vector so use slab allocator, we don't expect the blackbox implementations to be so large.
-    std::vector<poly_triple, ContainerSlabAllocator<poly_triple>> constraints;
+    std::vector<poly_triple_<curve::BN254::ScalarField>,
+                ContainerSlabAllocator<poly_triple_<curve::BN254::ScalarField>>>
+        constraints;
     std::vector<BlockConstraint> block_constraints;
 
     // For serialization, update with any new fields

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/acir_composer.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/acir_composer.cpp
@@ -31,8 +31,9 @@ void AcirComposer::create_circuit(acir_format::acir_format& constraint_system)
     size_hint_ = circuit_subgroup_size_;
 }
 
-void AcirComposer::init_proving_key(std::shared_ptr<barretenberg::srs::factories::CrsFactory> const& crs_factory,
-                                    acir_format::acir_format& constraint_system)
+void AcirComposer::init_proving_key(
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> const& crs_factory,
+    acir_format::acir_format& constraint_system)
 {
     vinfo("building circuit... ", size_hint_);
     builder_ = acir_format::Builder(size_hint_);
@@ -52,7 +53,7 @@ void AcirComposer::init_proving_key(std::shared_ptr<barretenberg::srs::factories
 }
 
 std::vector<uint8_t> AcirComposer::create_proof(
-    std::shared_ptr<barretenberg::srs::factories::CrsFactory> const& crs_factory,
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> const& crs_factory,
     acir_format::acir_format& constraint_system,
     acir_format::WitnessVector& witness,
     bool is_recursive)
@@ -107,8 +108,9 @@ std::shared_ptr<proof_system::plonk::verification_key> AcirComposer::init_verifi
     return verification_key_;
 }
 
-void AcirComposer::load_verification_key(std::shared_ptr<barretenberg::srs::factories::CrsFactory> const& crs_factory,
-                                         proof_system::plonk::verification_key_data&& data)
+void AcirComposer::load_verification_key(
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> const& crs_factory,
+    proof_system::plonk::verification_key_data&& data)
 {
     verification_key_ =
         std::make_shared<proof_system::plonk::verification_key>(std::move(data), crs_factory->get_verifier_crs());

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/acir_composer.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/acir_composer.hpp
@@ -13,16 +13,18 @@ class AcirComposer {
 
     void create_circuit(acir_format::acir_format& constraint_system);
 
-    void init_proving_key(std::shared_ptr<barretenberg::srs::factories::CrsFactory> const& crs_factory,
+    void init_proving_key(std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> const& crs_factory,
                           acir_format::acir_format& constraint_system);
 
-    std::vector<uint8_t> create_proof(std::shared_ptr<barretenberg::srs::factories::CrsFactory> const& crs_factory,
-                                      acir_format::acir_format& constraint_system,
-                                      acir_format::WitnessVector& witness,
-                                      bool is_recursive);
+    std::vector<uint8_t> create_proof(
+        std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> const& crs_factory,
+        acir_format::acir_format& constraint_system,
+        acir_format::WitnessVector& witness,
+        bool is_recursive);
 
-    void load_verification_key(std::shared_ptr<barretenberg::srs::factories::CrsFactory> const& crs_factory,
-                               proof_system::plonk::verification_key_data&& data);
+    void load_verification_key(
+        std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> const& crs_factory,
+        proof_system::plonk::verification_key_data&& data);
 
     std::shared_ptr<proof_system::plonk::verification_key> init_verification_key();
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/curves/grumpkin/grumpkin.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/curves/grumpkin/grumpkin.hpp
@@ -22,7 +22,7 @@ struct GrumpkinG1Params {
     };
     static constexpr barretenberg::fr a{ 0UL, 0UL, 0UL, 0UL };
 
-    // generator point = (x, y) = (1, sqrt(-15))
+    // generator point = (x, y) = (1, sqrt(-16)), sqrt(-16) = 4i
     static constexpr barretenberg::fr one_x = barretenberg::fr::one();
     static constexpr barretenberg::fr one_y{
         0x11b2dff1448c41d8UL, 0x23d3446f21c77dc3UL, 0xaa7b8cf435dfafbbUL, 0x14b34cf69dc25d68UL

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/examples/simple/simple.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/examples/simple/simple.cpp
@@ -20,7 +20,7 @@ void build_circuit(Builder& builder)
 }
 
 BuilderComposerPtrs create_builder_and_composer(
-    std::shared_ptr<barretenberg::srs::factories::CrsFactory> const& crs_factory)
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> const& crs_factory)
 {
     // WARNING: Size hint is essential to perform 512k circuits!
     auto builder = std::make_unique<Builder>(CIRCUIT_SIZE);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/examples/simple/simple.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/examples/simple/simple.hpp
@@ -13,7 +13,7 @@ struct BuilderComposerPtrs {
 };
 
 BuilderComposerPtrs create_builder_and_composer(
-    std::shared_ptr<barretenberg::srs::factories::CrsFactory> const& crs_factory);
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> const& crs_factory);
 
 proof create_proof(BuilderComposerPtrs pair);
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/examples/simple/simple.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/examples/simple/simple.test.cpp
@@ -8,7 +8,7 @@ namespace examples::simple {
 TEST(examples_simple, create_proof)
 {
     auto srs_path = std::filesystem::absolute("../srs_db/ignition");
-    auto crs_factory = std::make_shared<barretenberg::srs::factories::FileCrsFactory>(srs_path);
+    auto crs_factory = std::make_shared<barretenberg::srs::factories::FileCrsFactory<curve::BN254>>(srs_path);
     auto ptrs = create_builder_and_composer(crs_factory);
     auto proof = create_proof(ptrs);
     bool valid = verify_proof(ptrs, proof);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/grumpkin_srs_gen/grumpkin_srs_gen.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/grumpkin_srs_gen/grumpkin_srs_gen.cpp
@@ -11,7 +11,9 @@ const std::string protocol_name = "BARRETENBERG_GRUMPKIN_IPA_CRS";
 /**
  * @brief Generates a monomial basis Grumpkin SRS.
  *
- * @details We only provide functionality create a single transcript file.
+ * @details We only provide functionality to create a single transcript file.
+ * ! Note that, unlike the bn254 SRS, the first element of the Grumpkin SRS will not be equal to point one defined in
+ * grumpkin.hpp as this function finds Grumpkin points in an arbitrary order.
  *
  */
 int main(int argc, char** argv)

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/composer/standard_composer.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/composer/standard_composer.hpp
@@ -26,7 +26,7 @@ template <StandardFlavor Flavor> class StandardComposer_ {
     std::shared_ptr<VerificationKey> verification_key;
 
     // The crs_factory holds the path to the srs and exposes methods to extract the srs elements
-    std::shared_ptr<srs::factories::CrsFactory> crs_factory_;
+    std::shared_ptr<srs::factories::CrsFactory<typename Flavor::Curve>> crs_factory_;
 
     // The commitment key is passed to the prover but also used herein to compute the verfication key commitments
     std::shared_ptr<PCSCommitmentKey> commitment_key;
@@ -37,15 +37,22 @@ template <StandardFlavor Flavor> class StandardComposer_ {
 
     bool computed_witness = false;
     // TODO(Luke): use make_shared
+    // TODO(#637): design the crs factory better
     StandardComposer_()
-        : StandardComposer_(
-              std::shared_ptr<srs::factories::CrsFactory>(new srs::factories::FileCrsFactory("../srs_db/ignition")))
-    {}
-    StandardComposer_(std::shared_ptr<srs::factories::CrsFactory> crs_factory)
+    {
+        if constexpr (IsGrumpkinFlavor<Flavor>) {
+            crs_factory_ = barretenberg::srs::get_grumpkin_crs_factory();
+
+        } else {
+            crs_factory_ = barretenberg::srs::get_crs_factory();
+        }
+    }
+
+    StandardComposer_(std::shared_ptr<srs::factories::CrsFactory<typename Flavor::Curve>> crs_factory)
         : crs_factory_(std::move(crs_factory))
     {}
 
-    StandardComposer_(std::unique_ptr<srs::factories::CrsFactory>&& crs_factory)
+    StandardComposer_(std::unique_ptr<srs::factories::CrsFactory<typename Flavor::Curve>>&& crs_factory)
         : crs_factory_(std::move(crs_factory))
     {}
     StandardComposer_(std::shared_ptr<ProvingKey> p_key, std::shared_ptr<VerificationKey> v_key)

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/composer/ultra_composer.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/composer/ultra_composer.hpp
@@ -31,7 +31,7 @@ template <UltraFlavor Flavor> class UltraComposer_ {
     std::shared_ptr<VerificationKey> verification_key;
 
     // The crs_factory holds the path to the srs and exposes methods to extract the srs elements
-    std::shared_ptr<srs::factories::CrsFactory> crs_factory_;
+    std::shared_ptr<srs::factories::CrsFactory<typename Flavor::Curve>> crs_factory_;
 
     // The commitment key is passed to the prover but also used herein to compute the verfication key commitments
     std::shared_ptr<PCSCommitmentKey> commitment_key;
@@ -46,10 +46,9 @@ template <UltraFlavor Flavor> class UltraComposer_ {
     size_t num_public_inputs = 0;
     size_t num_ecc_op_gates = 0;
 
-    UltraComposer_()
-        : crs_factory_(barretenberg::srs::get_crs_factory()){};
+    UltraComposer_() { crs_factory_ = barretenberg::srs::get_crs_factory(); }
 
-    explicit UltraComposer_(std::shared_ptr<srs::factories::CrsFactory> crs_factory)
+    explicit UltraComposer_(std::shared_ptr<srs::factories::CrsFactory<typename Flavor::Curve>> crs_factory)
         : crs_factory_(std::move(crs_factory))
     {}
 
@@ -84,6 +83,8 @@ template <UltraFlavor Flavor> class UltraComposer_ {
     };
 };
 extern template class UltraComposer_<honk::flavor::Ultra>;
+// TODO: the UltraGrumpkin flavor still works on BN254 because plookup needs to be templated to be able to construct
+// Grumpkin circuits.
 extern template class UltraComposer_<honk::flavor::UltraGrumpkin>;
 extern template class UltraComposer_<honk::flavor::GoblinUltra>;
 // TODO(#532): this pattern is weird; is this not instantiating the templates?

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/composer/ultra_composer.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/composer/ultra_composer.test.cpp
@@ -274,8 +274,7 @@ TEST_F(UltraHonkComposerTests, test_elliptic_gate)
     uint32_t x3 = circuit_constructor.add_variable(p3.x);
     uint32_t y3 = circuit_constructor.add_variable(p3.y);
 
-    ecc_add_gate gate{ x1, y1, x2, y2, x3, y3, 1, 1 };
-    circuit_constructor.create_ecc_add_gate(gate);
+    circuit_constructor.create_ecc_add_gate({ x1, y1, x2, y2, x3, y3, 1, 1 });
 
     grumpkin::fq beta = grumpkin::fq::cube_root_of_unity();
     affine_element p2_endo = p2;
@@ -283,15 +282,13 @@ TEST_F(UltraHonkComposerTests, test_elliptic_gate)
     p3 = affine_element(element(p1) + element(p2_endo));
     x3 = circuit_constructor.add_variable(p3.x);
     y3 = circuit_constructor.add_variable(p3.y);
-    gate = ecc_add_gate{ x1, y1, x2, y2, x3, y3, beta, 1 };
-    circuit_constructor.create_ecc_add_gate(gate);
+    circuit_constructor.create_ecc_add_gate({ x1, y1, x2, y2, x3, y3, beta, 1 });
 
     p2_endo.x *= beta;
     p3 = affine_element(element(p1) - element(p2_endo));
     x3 = circuit_constructor.add_variable(p3.x);
     y3 = circuit_constructor.add_variable(p3.y);
-    gate = ecc_add_gate{ x1, y1, x2, y2, x3, y3, beta.sqr(), -1 };
-    circuit_constructor.create_ecc_add_gate(gate);
+    circuit_constructor.create_ecc_add_gate({ x1, y1, x2, y2, x3, y3, beta.sqr(), -1 });
 
     auto composer = UltraComposer();
     prove_and_verify(circuit_constructor, composer, /*expected_result=*/true);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/flavor/goblin_ultra.hpp
@@ -29,15 +29,15 @@ namespace proof_system::honk::flavor {
 class GoblinUltra {
   public:
     using CircuitBuilder = UltraCircuitBuilder;
-    using FF = barretenberg::fr;
-    using Polynomial = barretenberg::Polynomial<FF>;
-    using PolynomialHandle = std::span<FF>;
-    using G1 = barretenberg::g1;
-    using GroupElement = G1::element;
-    using Commitment = G1::affine_element;
-    using CommitmentHandle = G1::affine_element;
     using PCSParams = pcs::kzg::Params;
     using PCS = pcs::kzg::KZG<PCSParams>;
+    using Curve = PCSParams::Curve;
+    using GroupElement = Curve::Element;
+    using Commitment = Curve::AffineElement;
+    using CommitmentHandle = Curve::AffineElement;
+    using FF = Curve::ScalarField;
+    using Polynomial = barretenberg::Polynomial<FF>;
+    using PolynomialHandle = std::span<FF>;
 
     static constexpr size_t NUM_WIRES = CircuitBuilder::NUM_WIRES;
     // The number of multivariate polynomials on which a sumcheck prover sumcheck operates (including shifts). We often

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/flavor/standard.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/flavor/standard.hpp
@@ -32,15 +32,15 @@ namespace proof_system::honk::flavor {
 class Standard {
   public:
     using CircuitBuilder = StandardCircuitBuilder;
-    using FF = barretenberg::fr;
-    using Polynomial = barretenberg::Polynomial<FF>;
-    using PolynomialHandle = std::span<FF>;
-    using G1 = barretenberg::g1;
-    using GroupElement = G1::element;
-    using Commitment = G1::affine_element;
-    using CommitmentHandle = G1::affine_element;
     using PCSParams = pcs::kzg::Params;
     using PCS = pcs::kzg::KZG<PCSParams>;
+    using Curve = PCSParams::Curve;
+    using GroupElement = Curve::Element;
+    using Commitment = Curve::AffineElement;
+    using CommitmentHandle = Curve::AffineElement;
+    using FF = Curve::ScalarField;
+    using Polynomial = barretenberg::Polynomial<FF>;
+    using PolynomialHandle = std::span<FF>;
 
     static constexpr size_t NUM_WIRES = CircuitBuilder::NUM_WIRES;
     // The number of multivariate polynomials on which a sumcheck prover sumcheck operates (including shifts). We often

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/flavor/standard_grumpkin.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/flavor/standard_grumpkin.hpp
@@ -23,16 +23,16 @@ class StandardGrumpkin {
     // TODO(Mara): At the moment this class is a duplicate of the Standard flavor with a different PCS for testing
     // purposes. This will be changed to Grumpkin once generating Honk proofs over Grumpkin has been enabled.
   public:
-    using CircuitBuilder = StandardCircuitBuilder;
-    using FF = barretenberg::fr;
-    using Polynomial = barretenberg::Polynomial<FF>;
-    using PolynomialHandle = std::span<FF>;
-    using G1 = barretenberg::g1;
-    using GroupElement = G1::element;
-    using Commitment = G1::affine_element;
-    using CommitmentHandle = G1::affine_element;
+    using CircuitBuilder = StandardGrumpkinCircuitBuilder;
     using PCSParams = pcs::ipa::Params;
     using PCS = pcs::ipa::IPA<PCSParams>;
+    using Curve = PCSParams::Curve;
+    using GroupElement = Curve::Element;
+    using Commitment = Curve::AffineElement;
+    using CommitmentHandle = Curve::AffineElement;
+    using FF = Curve::ScalarField;
+    using Polynomial = barretenberg::Polynomial<FF>;
+    using PolynomialHandle = std::span<FF>;
     static constexpr size_t NUM_WIRES = CircuitBuilder::NUM_WIRES;
     // The number of multivariate polynomials on which a sumcheck prover sumcheck operates (including shifts). We often
     // need containers of this size to hold related data, so we choose a name more agnostic than `NUM_POLYNOMIALS`

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/flavor/ultra.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/flavor/ultra.hpp
@@ -28,18 +28,15 @@ namespace proof_system::honk::flavor {
 class Ultra {
   public:
     using CircuitBuilder = UltraCircuitBuilder;
-    using FF = barretenberg::fr;
-    using Polynomial = barretenberg::Polynomial<FF>;
-    using PolynomialHandle = std::span<FF>;
-    using G1 = barretenberg::g1;
-    using GroupElement = G1::element;
-    using Commitment = G1::affine_element;
-    using CommitmentHandle = G1::affine_element;
-    // UltraHonk will be run with KZG by default but temporarily we set the commitment to IPA to
-    // be able to do e2e tests with this pcs as well
-    // TODO: instantiate this with both IPA and KZG when the templating work is finished
     using PCSParams = pcs::kzg::Params;
     using PCS = pcs::kzg::KZG<PCSParams>;
+    using Curve = PCSParams::Curve;
+    using GroupElement = Curve::Element;
+    using Commitment = Curve::AffineElement;
+    using CommitmentHandle = Curve::AffineElement;
+    using FF = Curve::ScalarField;
+    using Polynomial = barretenberg::Polynomial<FF>;
+    using PolynomialHandle = std::span<FF>;
 
     static constexpr size_t NUM_WIRES = CircuitBuilder::NUM_WIRES;
     // The number of multivariate polynomials on which a sumcheck prover sumcheck operates (including shifts). We often

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/flavor/ultra_grumpkin.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/flavor/ultra_grumpkin.hpp
@@ -2,6 +2,7 @@
 #include "barretenberg/ecc/curves/bn254/g1.hpp"
 #include "barretenberg/honk/pcs/commitment_key.hpp"
 #include "barretenberg/honk/pcs/ipa/ipa.hpp"
+#include "barretenberg/honk/pcs/kzg/kzg.hpp"
 #include "barretenberg/honk/sumcheck/polynomials/barycentric_data.hpp"
 #include "barretenberg/honk/sumcheck/polynomials/univariate.hpp"
 #include "barretenberg/honk/sumcheck/relations/auxiliary_relation.hpp"
@@ -25,19 +26,19 @@
 namespace proof_system::honk::flavor {
 
 class UltraGrumpkin {
-    // TODO(Mara): At the moment this class is a duplicate of the Standard flavor with a different PCS for testing
-    // purposes. This will be changed to Grumpkin once generating Honk proofs over Grumpkin has been enabled.
+    // TODO(#636): At the moment this class is a duplicate of the Ultra flavor with a different PCS for testing
+    // purposes. This can be changed to Grumpkin and IPA once UltraCircuitBuilder also works on Grumpkin.
   public:
     using CircuitBuilder = UltraCircuitBuilder;
-    using FF = barretenberg::fr;
+    using PCSParams = pcs::kzg::Params;
+    using PCS = pcs::kzg::KZG<PCSParams>;
+    using Curve = PCSParams::Curve;
+    using GroupElement = Curve::Element;
+    using Commitment = Curve::AffineElement;
+    using CommitmentHandle = Curve::AffineElement;
+    using FF = Curve::ScalarField;
     using Polynomial = barretenberg::Polynomial<FF>;
     using PolynomialHandle = std::span<FF>;
-    using G1 = barretenberg::g1;
-    using GroupElement = G1::element;
-    using Commitment = G1::affine_element;
-    using CommitmentHandle = G1::affine_element;
-    using PCSParams = pcs::ipa::Params;
-    using PCS = pcs::ipa::IPA<PCSParams>;
 
     static constexpr size_t NUM_WIRES = CircuitBuilder::NUM_WIRES;
     // The number of multivariate polynomials on which a sumcheck prover sumcheck operates (including shifts). We often

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/commitment_key.test.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/commitment_key.test.hpp
@@ -23,17 +23,17 @@ template <class CK> inline std::shared_ptr<CK> CreateCommitmentKey();
 
 template <> inline std::shared_ptr<kzg::Params::CommitmentKey> CreateCommitmentKey<kzg::Params::CommitmentKey>()
 {
-    constexpr size_t n = 128;
-    std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory(
-        new barretenberg::srs::factories::FileCrsFactory("../srs_db/ignition"));
+    constexpr size_t n = 4096;
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory<kzg::Params::Curve>> crs_factory(
+        new barretenberg::srs::factories::FileCrsFactory<kzg::Params::Curve>("../srs_db/ignition", 4096));
     return std::make_shared<kzg::Params::CommitmentKey>(n, crs_factory);
 }
 // For IPA
 template <> inline std::shared_ptr<ipa::Params::CommitmentKey> CreateCommitmentKey<ipa::Params::CommitmentKey>()
 {
-    constexpr size_t n = 128;
-    std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory(
-        new barretenberg::srs::factories::FileCrsFactory("../srs_db/ignition"));
+    constexpr size_t n = 4096;
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory<ipa::Params::Curve>> crs_factory(
+        new barretenberg::srs::factories::FileCrsFactory<ipa::Params::Curve>("../srs_db/grumpkin", 4096));
     return std::make_shared<ipa::Params::CommitmentKey>(n, crs_factory);
 }
 
@@ -47,17 +47,17 @@ template <class VK> inline std::shared_ptr<VK> CreateVerificationKey();
 
 template <> inline std::shared_ptr<kzg::Params::VerificationKey> CreateVerificationKey<kzg::Params::VerificationKey>()
 {
-    constexpr size_t n = 128;
-    std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory(
-        new barretenberg::srs::factories::FileCrsFactory("../srs_db/ignition"));
+    constexpr size_t n = 4096;
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory<kzg::Params::Curve>> crs_factory(
+        new barretenberg::srs::factories::FileCrsFactory<kzg::Params::Curve>("../srs_db/ignition", 4096));
     return std::make_shared<kzg::Params::VerificationKey>(n, crs_factory);
 }
 // For IPA
 template <> inline std::shared_ptr<ipa::Params::VerificationKey> CreateVerificationKey<ipa::Params::VerificationKey>()
 {
-    constexpr size_t n = 128;
-    std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory(
-        new barretenberg::srs::factories::FileCrsFactory("../srs_db/ignition"));
+    constexpr size_t n = 4096;
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory<ipa::Params::Curve>> crs_factory(
+        new barretenberg::srs::factories::FileCrsFactory<ipa::Params::Curve>("../srs_db/grumpkin", 4096));
     return std::make_shared<ipa::Params::VerificationKey>(n, crs_factory);
 }
 template <typename VK> inline std::shared_ptr<VK> CreateVerificationKey()
@@ -72,7 +72,6 @@ template <typename Params> class CommitmentTest : public ::testing::Test {
     using Fr = typename Params::Fr;
     using Commitment = typename Params::Commitment;
     using Polynomial = typename Params::Polynomial;
-    using Transcript = transcript::StandardTranscript;
 
   public:
     CommitmentTest()
@@ -127,6 +126,7 @@ template <typename Params> class CommitmentTest : public ::testing::Test {
         Fr y_expected = witness.evaluate(x);
         EXPECT_EQ(y, y_expected) << "OpeningClaim: evaluations mismatch";
         Commitment commitment_expected = commit(witness);
+        // found it
         EXPECT_EQ(commitment, commitment_expected) << "OpeningClaim: commitment mismatch";
     }
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/gemini/gemini.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/gemini/gemini.test.cpp
@@ -100,7 +100,8 @@ template <class Params> class GeminiTest : public CommitmentTest<Params> {
     }
 };
 
-TYPED_TEST_SUITE(GeminiTest, CommitmentSchemeParams);
+using ParamsTypes = ::testing::Types<kzg::Params, ipa::Params>;
+TYPED_TEST_SUITE(GeminiTest, ParamsTypes);
 
 TYPED_TEST(GeminiTest, Single)
 {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
@@ -15,8 +15,8 @@
  *
  */
 namespace proof_system::honk::pcs::ipa {
-
 template <typename Params> class IPA {
+    using Curve = typename Params::Curve;
     using Fr = typename Params::Fr;
     using GroupElement = typename Params::GroupElement;
     using Commitment = typename Params::Commitment;
@@ -86,15 +86,14 @@ template <typename Params> class IPA {
             // L_i = < a_vec_lo, G_vec_hi > + inner_prod_L * aux_generator
             L_elements[i] =
                 // TODO(#473)
-                barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points<curve::BN254>(
+                barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points<Curve>(
                     &a_vec[0], &G_vec_local[round_size], round_size, ck->pippenger_runtime_state);
             L_elements[i] += aux_generator * inner_prod_L;
 
             // R_i = < a_vec_hi, G_vec_lo > + inner_prod_R * aux_generator
             // TODO(#473)
-            R_elements[i] =
-                barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points<curve::BN254>(
-                    &a_vec[round_size], &G_vec_local[0], round_size, ck->pippenger_runtime_state);
+            R_elements[i] = barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points<Curve>(
+                &a_vec[round_size], &G_vec_local[0], round_size, ck->pippenger_runtime_state);
             R_elements[i] += aux_generator * inner_prod_R;
 
             std::string index = std::to_string(i);
@@ -168,9 +167,8 @@ template <typename Params> class IPA {
             msm_scalars[2 * i + 1] = round_challenges_inv[i].sqr();
         }
         // TODO(#473)
-        GroupElement LR_sums =
-            barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points<curve::BN254>(
-                &msm_scalars[0], &msm_elements[0], pippenger_size, vk->pippenger_runtime_state);
+        GroupElement LR_sums = barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points<Curve>(
+            &msm_scalars[0], &msm_elements[0], pippenger_size, vk->pippenger_runtime_state);
         GroupElement C_zero = C_prime + LR_sums;
 
         /**
@@ -213,7 +211,7 @@ template <typename Params> class IPA {
             G_vec_local[i >> 1] = srs_elements[i];
         }
         // TODO(#473)
-        auto G_zero = barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points<curve::BN254>(
+        auto G_zero = barretenberg::scalar_multiplication::pippenger_without_endomorphism_basis_points<Curve>(
             &s_vec[0], &G_vec_local[0], poly_degree, vk->pippenger_runtime_state);
 
         auto a_zero = transcript.template receive_from_prover<Fr>("IPA:a_0");

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/ipa/ipa.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/ipa/ipa.test.cpp
@@ -1,3 +1,5 @@
+#include "../gemini/gemini.hpp"
+#include "../shplonk/shplonk_single.hpp"
 #include "barretenberg/common/mem.hpp"
 #include "barretenberg/ecc/curves/bn254/fq12.hpp"
 #include "barretenberg/ecc/curves/types.hpp"
@@ -77,5 +79,96 @@ TEST_F(IPATest, Open)
     EXPECT_TRUE(result);
 
     EXPECT_EQ(prover_transcript.get_manifest(), verifier_transcript.get_manifest());
+}
+
+TEST_F(IPATest, GeminiShplonkIPAWithShift)
+{
+    using IPA = IPA<Params>;
+    using Shplonk = shplonk::SingleBatchOpeningScheme<Params>;
+    using Gemini = gemini::MultilinearReductionScheme<Params>;
+
+    const size_t n = 8;
+    const size_t log_n = 3;
+
+    Fr rho = Fr::random_element();
+
+    // Generate multilinear polynomials, their commitments (genuine and mocked) and evaluations (genuine) at a random
+    // point.
+    const auto mle_opening_point = this->random_evaluation_point(log_n); // sometimes denoted 'u'
+    auto poly1 = this->random_polynomial(n);
+    auto poly2 = this->random_polynomial(n);
+    poly2[0] = Fr::zero(); // this property is required of polynomials whose shift is used
+
+    GroupElement commitment1 = this->commit(poly1);
+    GroupElement commitment2 = this->commit(poly2);
+
+    auto eval1 = poly1.evaluate_mle(mle_opening_point);
+    auto eval2 = poly2.evaluate_mle(mle_opening_point);
+    auto eval2_shift = poly2.evaluate_mle(mle_opening_point, true);
+
+    std::vector<Fr> multilinear_evaluations = { eval1, eval2, eval2_shift };
+
+    std::vector<Fr> rhos = Gemini::powers_of_rho(rho, multilinear_evaluations.size());
+
+    Fr batched_evaluation = Fr::zero();
+    for (size_t i = 0; i < rhos.size(); ++i) {
+        batched_evaluation += multilinear_evaluations[i] * rhos[i];
+    }
+
+    Polynomial batched_unshifted(n);
+    Polynomial batched_to_be_shifted(n);
+    batched_unshifted.add_scaled(poly1, rhos[0]);
+    batched_unshifted.add_scaled(poly2, rhos[1]);
+    batched_to_be_shifted.add_scaled(poly2, rhos[2]);
+
+    GroupElement batched_commitment_unshifted = GroupElement::zero();
+    GroupElement batched_commitment_to_be_shifted = GroupElement::zero();
+    batched_commitment_unshifted = commitment1 * rhos[0] + commitment2 * rhos[1];
+    batched_commitment_to_be_shifted = commitment2 * rhos[2];
+
+    auto prover_transcript = ProverTranscript<Fr>::init_empty();
+
+    auto fold_polynomials = Gemini::compute_fold_polynomials(
+        mle_opening_point, std::move(batched_unshifted), std::move(batched_to_be_shifted));
+
+    for (size_t l = 0; l < log_n - 1; ++l) {
+        std::string label = "FOLD_" + std::to_string(l + 1);
+        auto commitment = this->ck()->commit(fold_polynomials[l + 2]);
+        prover_transcript.send_to_verifier(label, commitment);
+    }
+
+    const Fr r_challenge = prover_transcript.get_challenge("Gemini:r");
+
+    const auto [gemini_opening_pairs, gemini_witnesses] =
+        Gemini::compute_fold_polynomial_evaluations(mle_opening_point, std::move(fold_polynomials), r_challenge);
+
+    for (size_t l = 0; l < log_n; ++l) {
+        std::string label = "Gemini:a_" + std::to_string(l);
+        const auto& evaluation = gemini_opening_pairs[l + 1].evaluation;
+        prover_transcript.send_to_verifier(label, evaluation);
+    }
+
+    const Fr nu_challenge = prover_transcript.get_challenge("Shplonk:nu");
+    auto batched_quotient_Q = Shplonk::compute_batched_quotient(gemini_opening_pairs, gemini_witnesses, nu_challenge);
+    prover_transcript.send_to_verifier("Shplonk:Q", this->ck()->commit(batched_quotient_Q));
+
+    const Fr z_challenge = prover_transcript.get_challenge("Shplonk:z");
+    const auto [shplonk_opening_pair, shplonk_witness] = Shplonk::compute_partially_evaluated_batched_quotient(
+        gemini_opening_pairs, gemini_witnesses, std::move(batched_quotient_Q), nu_challenge, z_challenge);
+
+    IPA::compute_opening_proof(this->ck(), shplonk_opening_pair, shplonk_witness, prover_transcript);
+
+    auto verifier_transcript = VerifierTranscript<Fr>::init_empty(prover_transcript);
+
+    auto gemini_verifier_claim = Gemini::reduce_verify(mle_opening_point,
+                                                       batched_evaluation,
+                                                       batched_commitment_unshifted,
+                                                       batched_commitment_to_be_shifted,
+                                                       verifier_transcript);
+
+    const auto shplonk_verifier_claim = Shplonk::reduce_verify(this->vk(), gemini_verifier_claim, verifier_transcript);
+    bool verified = IPA::verify(this->vk(), shplonk_verifier_claim, verifier_transcript);
+
+    EXPECT_EQ(verified, true);
 }
 } // namespace proof_system::honk::pcs::ipa

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/kzg/kzg.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/kzg/kzg.test.cpp
@@ -163,7 +163,7 @@ TYPED_TEST(KZGTest, GeminiShplonkKzgWithShift)
                                                        verifier_transcript);
 
     // Shplonk verifier claim: commitment [Q] - [Q_z], opening point (z_challenge, 0)
-    const auto shplonk_verifier_claim = Shplonk::reduce_verify(gemini_verifier_claim, verifier_transcript);
+    const auto shplonk_verifier_claim = Shplonk::reduce_verify(this->vk(), gemini_verifier_claim, verifier_transcript);
 
     // KZG verifier:
     // aggregates inputs [Q] - [Q_z] and [W] into an 'accumulator' (can perform pairing check on result)

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/shplonk/shplonk.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/shplonk/shplonk.test.cpp
@@ -13,7 +13,8 @@
 namespace proof_system::honk::pcs::shplonk {
 template <class Params> class ShplonkTest : public CommitmentTest<Params> {};
 
-TYPED_TEST_SUITE(ShplonkTest, CommitmentSchemeParams);
+using ParamsTypes = ::testing::Types<kzg::Params, ipa::Params>;
+TYPED_TEST_SUITE(ShplonkTest, ParamsTypes);
 
 // Test of Shplonk prover/verifier for two polynomials of different size, each opened at a single (different) point
 TYPED_TEST(ShplonkTest, ShplonkSimple)
@@ -64,7 +65,7 @@ TYPED_TEST(ShplonkTest, ShplonkSimple)
     auto verifier_transcript = VerifierTranscript<Fr>::init_empty(prover_transcript);
 
     // Execute the shplonk verifier functionality
-    const auto verifier_claim = Shplonk::reduce_verify(opening_claims, verifier_transcript);
+    const auto verifier_claim = Shplonk::reduce_verify(this->vk(), opening_claims, verifier_transcript);
 
     this->verify_opening_claim(verifier_claim, shplonk_prover_witness);
 }

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/shplonk/shplonk_single.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/shplonk/shplonk_single.hpp
@@ -20,6 +20,7 @@ template <typename Params> class SingleBatchOpeningScheme {
     using GroupElement = typename Params::GroupElement;
     using Commitment = typename Params::Commitment;
     using Polynomial = barretenberg::Polynomial<Fr>;
+    using VK = typename Params::VerificationKey;
 
   public:
     /**
@@ -123,7 +124,8 @@ template <typename Params> class SingleBatchOpeningScheme {
      * @param transcript
      * @return OpeningClaim
      */
-    static OpeningClaim<Params> reduce_verify(std::span<const OpeningClaim<Params>> claims,
+    static OpeningClaim<Params> reduce_verify(std::shared_ptr<VK> vk,
+                                              std::span<const OpeningClaim<Params>> claims,
                                               VerifierTranscript<Fr>& transcript)
     {
         const size_t num_claims = claims.size();
@@ -169,7 +171,9 @@ template <typename Params> class SingleBatchOpeningScheme {
             current_nu *= nu;
         }
         // [G] += G₀⋅[1] = [G] + (∑ⱼ ρʲ ⋅ vⱼ / ( r − xⱼ ))⋅[1]
-        G_commitment += GroupElement::one() * G_commitment_constant;
+
+        //  GroupElement sort_of_one{ x, y };
+        G_commitment += vk->srs->get_first_g1() * G_commitment_constant;
 
         // Return opening pair (z, 0) and commitment [G]
         return { { z_challenge, Fr::zero() }, G_commitment };

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/proof_system/composer_lib.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/proof_system/composer_lib.hpp
@@ -19,7 +19,7 @@ namespace proof_system::honk {
 template <typename Flavor>
 std::shared_ptr<typename Flavor::VerificationKey> compute_verification_key_common(
     std::shared_ptr<typename Flavor::ProvingKey> const& proving_key,
-    std::shared_ptr<barretenberg::srs::factories::VerifierCrs> const& vrs)
+    std::shared_ptr<barretenberg::srs::factories::VerifierCrs<typename Flavor::Curve>> const& vrs)
 {
     auto verification_key = std::make_shared<typename Flavor::VerificationKey>(
         proving_key->circuit_size, proving_key->num_public_inputs, vrs);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/proof_system/ultra_verifier.cpp
@@ -165,7 +165,7 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const plonk
                                               transcript);
 
     // Produce a Shplonk claim: commitment [Q] - [Q_z], evaluation zero (at random challenge z)
-    auto shplonk_claim = Shplonk::reduce_verify(gemini_claim, transcript);
+    auto shplonk_claim = Shplonk::reduce_verify(pcs_verification_key, gemini_claim, transcript);
 
     // // Verify the Shplonk claim with KZG or IPA
     return PCS::verify(pcs_verification_key, shplonk_claim, transcript);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/proof_system/verifier.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/proof_system/verifier.cpp
@@ -160,7 +160,7 @@ template <typename Flavor> bool StandardVerifier_<Flavor>::verify_proof(const pl
                                               transcript);
 
     // Produce a Shplonk claim: commitment [Q] - [Q_z], evaluation zero (at random challenge z)
-    auto shplonk_claim = Shplonk::reduce_verify(gemini_claim, transcript);
+    auto shplonk_claim = Shplonk::reduce_verify(pcs_verification_key, gemini_claim, transcript);
 
     // Verify the Shplonk claim with KZG or IPA
     return PCS::verify(pcs_verification_key, shplonk_claim, transcript);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/sumcheck/relations/relation_correctness.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/sumcheck/relations/relation_correctness.test.cpp
@@ -185,8 +185,7 @@ template <typename Flavor> void create_some_elliptic_curve_addition_gates(auto& 
     uint32_t x3 = circuit_builder.add_variable(p3.x);
     uint32_t y3 = circuit_builder.add_variable(p3.y);
 
-    ecc_add_gate gate{ x1, y1, x2, y2, x3, y3, beta_scalar, -1 };
-    circuit_builder.create_ecc_add_gate(gate);
+    circuit_builder.create_ecc_add_gate({ x1, y1, x2, y2, x3, y3, beta_scalar, -1 });
 }
 
 template <typename Flavor> void create_some_ecc_op_queue_gates(auto& circuit_builder)

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/sumcheck/sumcheck.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/sumcheck/sumcheck.test.cpp
@@ -570,8 +570,7 @@ TEST_F(SumcheckTests, RealCircuitUltra)
     uint32_t x3 = circuit_constructor.add_variable(p3.x);
     uint32_t y3 = circuit_constructor.add_variable(p3.y);
 
-    ecc_add_gate gate{ x1, y1, x2, y2, x3, y3, beta_scalar, -1 };
-    circuit_constructor.create_ecc_add_gate(gate);
+    circuit_constructor.create_ecc_add_gate({ x1, y1, x2, y2, x3, y3, beta_scalar, -1 });
 
     // Add some RAM gates
     uint32_t ram_values[8]{

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/transcript/transcript.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/transcript/transcript.test.cpp
@@ -124,8 +124,8 @@ TYPED_TEST(TranscriptTests, ProverManifestConsistency)
 {
     using Flavor = TypeParam;
     // Construct a simple circuit of size n = 8 (i.e. the minimum circuit size)
-    fr a = 1;
-    auto circuit_constructor = proof_system::StandardCircuitBuilder();
+    typename Flavor::FF a = 1;
+    auto circuit_constructor = typename Flavor::CircuitBuilder();
     circuit_constructor.add_variable(a);
     circuit_constructor.add_public_variable(a);
 
@@ -152,8 +152,8 @@ TYPED_TEST(TranscriptTests, VerifierManifestConsistency)
 {
     using Flavor = TypeParam;
     // Construct a simple circuit of size n = 8 (i.e. the minimum circuit size)
-    auto circuit_constructor = proof_system::StandardCircuitBuilder();
-    fr a = 1;
+    typename Flavor::FF a = 1;
+    auto circuit_constructor = typename Flavor::CircuitBuilder();
     circuit_constructor.add_variable(a);
     circuit_constructor.add_public_variable(a);
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/compute_circuit_data.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/compute_circuit_data.hpp
@@ -21,7 +21,7 @@ struct circuit_data {
         : num_gates(0)
     {}
 
-    std::shared_ptr<barretenberg::srs::factories::CrsFactory> srs;
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> srs;
     std::shared_ptr<plonk::proving_key> proving_key;
     std::shared_ptr<plonk::verification_key> verification_key;
     size_t num_gates;
@@ -40,7 +40,7 @@ inline bool exists(std::string const& path)
 template <typename Composer, typename F>
 circuit_data get_circuit_data(std::string const& name,
                               std::string const& path_name,
-                              std::shared_ptr<barretenberg::srs::factories::CrsFactory> const& srs,
+                              std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> const& srs,
                               std::string const& key_path,
                               bool compute,
                               bool save,

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/compute_circuit_data.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/compute_circuit_data.cpp
@@ -59,7 +59,8 @@ join_split_tx noop_tx()
     return tx;
 }
 
-circuit_data get_circuit_data(std::shared_ptr<barretenberg::srs::factories::CrsFactory> const& srs, bool mock)
+circuit_data get_circuit_data(std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> const& srs,
+                              bool mock)
 {
     std::cerr << "Getting join-split circuit data..." << std::endl;
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/compute_circuit_data.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/compute_circuit_data.hpp
@@ -10,7 +10,8 @@ join_split_tx noop_tx();
 
 using circuit_data = proofs::circuit_data;
 
-circuit_data get_circuit_data(std::shared_ptr<barretenberg::srs::factories::CrsFactory> const& srs, bool mock = false);
+circuit_data get_circuit_data(std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> const& srs,
+                              bool mock = false);
 
 } // namespace join_split
 } // namespace proofs

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.cpp
@@ -14,7 +14,8 @@ using namespace proof_system::plonk::stdlib::merkle_tree;
 static std::shared_ptr<plonk::proving_key> proving_key;
 static std::shared_ptr<plonk::verification_key> verification_key;
 
-void init_proving_key(std::shared_ptr<barretenberg::srs::factories::CrsFactory> const& crs_factory, bool mock)
+void init_proving_key(std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> const& crs_factory,
+                      bool mock)
 {
     if (proving_key) {
         return;
@@ -42,7 +43,7 @@ void release_proving_key()
     proving_key.reset();
 }
 
-void init_verification_key(std::shared_ptr<barretenberg::srs::factories::CrsFactory> const& crs_factory)
+void init_verification_key(std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> const& crs_factory)
 {
     if (!proving_key) {
         std::abort();

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.hpp
@@ -7,11 +7,12 @@ namespace join_split_example {
 namespace proofs {
 namespace join_split {
 
-void init_proving_key(std::shared_ptr<barretenberg::srs::factories::CrsFactory> const& crs_factory, bool mock);
+void init_proving_key(std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> const& crs_factory,
+                      bool mock);
 
 void release_proving_key();
 
-void init_verification_key(std::shared_ptr<barretenberg::srs::factories::CrsFactory> const& crs_factory);
+void init_verification_key(std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> const& crs_factory);
 
 Prover new_join_split_prover(join_split_tx const& tx, bool mock);
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.test.cpp
@@ -43,9 +43,10 @@ class join_split_tests : public ::testing::Test {
     static constexpr size_t ACCOUNT_INDEX = 14;
     static void SetUpTestCase()
     {
-        auto null_crs_factory = std::make_shared<barretenberg::srs::factories::CrsFactory>();
+        auto null_crs_factory = std::make_shared<barretenberg::srs::factories::CrsFactory<curve::BN254>>();
         init_proving_key(null_crs_factory, false);
-        auto crs_factory = std::make_unique<barretenberg::srs::factories::FileCrsFactory>("../srs_db/ignition");
+        auto crs_factory =
+            std::make_unique<barretenberg::srs::factories::FileCrsFactory<curve::BN254>>("../srs_db/ignition");
         init_verification_key(std::move(crs_factory));
         info("vk hash: ", get_verification_key()->sha256_hash());
     }

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split_js_parity.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split_js_parity.test.cpp
@@ -25,9 +25,10 @@ class join_split_js_parity_tests : public ::testing::Test {
   protected:
     static void SetUpTestCase()
     {
-        auto null_crs_factory = std::make_shared<barretenberg::srs::factories::CrsFactory>();
+        auto null_crs_factory = std::make_shared<barretenberg::srs::factories::CrsFactory<curve::BN254>>();
         init_proving_key(null_crs_factory, false);
-        auto crs_factory = std::make_unique<barretenberg::srs::factories::FileCrsFactory>("../srs_db/ignition");
+        auto crs_factory =
+            std::make_unique<barretenberg::srs::factories::FileCrsFactory<curve::BN254>>("../srs_db/ignition");
         init_verification_key(std::move(crs_factory));
         info("vk hash: ", get_verification_key()->sha256_hash());
     }

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/composer_lib.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/composer_lib.cpp
@@ -44,7 +44,8 @@ void compute_monomial_and_coset_selector_forms(plonk::proving_key* circuit_provi
  */
 std::shared_ptr<plonk::verification_key> compute_verification_key_common(
     std::shared_ptr<plonk::proving_key> const& proving_key,
-    std::shared_ptr<barretenberg::srs::factories::VerifierCrs> const& vrs)
+    // Here too
+    std::shared_ptr<barretenberg::srs::factories::VerifierCrs<curve::BN254>> const& vrs)
 {
     auto circuit_verification_key = std::make_shared<plonk::verification_key>(
         proving_key->circuit_size, proving_key->num_public_inputs, vrs, proving_key->circuit_type);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/composer_lib.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/composer_lib.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "barretenberg/ecc/curves/bn254/bn254.hpp"
 #include "barretenberg/plonk/proof_system/proving_key/proving_key.hpp"
 #include "barretenberg/plonk/proof_system/verification_key/verification_key.hpp"
 
@@ -20,11 +21,12 @@ struct SelectorProperties {
  * in that case.
  * @return std::shared_ptr<typename Flavor::ProvingKey>
  */
-std::shared_ptr<plonk::proving_key> initialize_proving_key(const auto& circuit_constructor,
-                                                           barretenberg::srs::factories::CrsFactory* crs_factory,
-                                                           const size_t minimum_circuit_size,
-                                                           const size_t num_randomized_gates,
-                                                           CircuitType circuit_type)
+std::shared_ptr<plonk::proving_key> initialize_proving_key(
+    const auto& circuit_constructor,
+    barretenberg::srs::factories::CrsFactory<curve::BN254>* crs_factory,
+    const size_t minimum_circuit_size,
+    const size_t num_randomized_gates,
+    CircuitType circuit_type)
 {
     const size_t num_gates = circuit_constructor.num_gates;
 
@@ -77,6 +79,7 @@ void compute_monomial_and_coset_selector_forms(plonk::proving_key* key,
  */
 std::shared_ptr<plonk::verification_key> compute_verification_key_common(
     std::shared_ptr<plonk::proving_key> const& proving_key,
-    std::shared_ptr<barretenberg::srs::factories::VerifierCrs> const& vrs);
+    // silencing for now but need to figure out where to extract type of VerifierCrs from :-/
+    std::shared_ptr<barretenberg::srs::factories::VerifierCrs<curve::BN254>> const& vrs);
 
 } // namespace proof_system::plonk

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.cpp
@@ -37,7 +37,8 @@ void StandardComposer::compute_witness(const CircuitBuilder& circuit_constructor
 
     const size_t subgroup_size = circuit_constructor.get_circuit_subgroup_size(num_constraints + NUM_RESERVED_GATES);
 
-    auto wire_polynomial_evaluations = construct_wire_polynomials_base<Flavor>(circuit_constructor, subgroup_size);
+    auto wire_polynomial_evaluations =
+        construct_wire_polynomials_base<StandardComposer::Flavor>(circuit_constructor, subgroup_size);
 
     for (size_t j = 0; j < program_width; ++j) {
         std::string index = std::to_string(j + 1);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.hpp
@@ -15,6 +15,7 @@ namespace proof_system::plonk {
 class StandardComposer {
   public:
     using Flavor = plonk::flavor::Standard;
+
     using CircuitBuilder = StandardCircuitBuilder;
 
     static constexpr std::string_view NAME_STRING = "StandardPlonk";
@@ -24,19 +25,19 @@ class StandardComposer {
     std::shared_ptr<plonk::verification_key> circuit_verification_key;
 
     // The crs_factory holds the path to the srs and exposes methods to extract the srs elements
-    std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory_;
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> crs_factory_;
 
     bool computed_witness = false;
 
     StandardComposer()
-        : StandardComposer(std::shared_ptr<barretenberg::srs::factories::CrsFactory>(
-              new barretenberg::srs::factories::FileCrsFactory("../srs_db/ignition")))
+        : StandardComposer(std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>>(
+              new barretenberg::srs::factories::FileCrsFactory<curve::BN254>("../srs_db/ignition")))
     {}
-    StandardComposer(std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory)
+    StandardComposer(std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> crs_factory)
         : crs_factory_(std::move(crs_factory))
     {}
 
-    StandardComposer(std::unique_ptr<barretenberg::srs::factories::CrsFactory>&& crs_factory)
+    StandardComposer(std::unique_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>>&& crs_factory)
         : crs_factory_(std::move(crs_factory))
     {}
     StandardComposer(std::shared_ptr<plonk::proving_key> p_key, std::shared_ptr<plonk::verification_key> v_key)

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.test.cpp
@@ -40,7 +40,7 @@ TEST(standard_plonk_composer, composer_from_serialized_keys)
     auto pk_data = from_buffer<plonk::proving_key_data>(pk_buf);
     auto vk_data = from_buffer<plonk::verification_key_data>(vk_buf);
 
-    auto crs = std::make_unique<barretenberg::srs::factories::FileCrsFactory>("../srs_db/ignition");
+    auto crs = std::make_unique<barretenberg::srs::factories::FileCrsFactory<curve::BN254>>("../srs_db/ignition");
     auto proving_key =
         std::make_shared<plonk::proving_key>(std::move(pk_data), crs->get_prover_crs(pk_data.circuit_size + 1));
     auto verification_key = std::make_shared<plonk::verification_key>(std::move(vk_data), crs->get_verifier_crs());
@@ -282,8 +282,7 @@ TEST(standard_plonk_composer, and_constraint)
         // include non-nice numbers of bits, that will bleed over gate boundaries
         size_t extra_bits = 2 * (i % 4);
 
-        accumulator_triple accumulators =
-            builder.create_and_constraint(left_witness_index, right_witness_index, 32 + extra_bits);
+        auto accumulators = builder.create_and_constraint(left_witness_index, right_witness_index, 32 + extra_bits);
         // builder.create_and_constraint(left_witness_index, right_witness_index, 32 + extra_bits);
 
         for (uint32_t j = 0; j < 16; ++j) {
@@ -354,8 +353,7 @@ TEST(standard_plonk_composer, xor_constraint)
         // include non-nice numbers of bits, that will bleed over gate boundaries
         size_t extra_bits = 2 * (i % 4);
 
-        accumulator_triple accumulators =
-            builder.create_xor_constraint(left_witness_index, right_witness_index, 32 + extra_bits);
+        auto accumulators = builder.create_xor_constraint(left_witness_index, right_witness_index, 32 + extra_bits);
 
         for (uint32_t j = 0; j < 16; ++j) {
             uint32_t left_expected = (left_value >> (30U - (2 * j)));
@@ -422,17 +420,15 @@ TEST(standard_plonk_composer, big_add_gate_with_bit_extract)
         uint32_t input = engine.get_random_uint32();
         uint32_t output = input + (quad_value > 1 ? 1 : 0);
 
-        add_quad gate{ builder.add_variable(uint256_t(input)),
-                       builder.add_variable(uint256_t(output)),
-                       right_idx,
-                       left_idx,
-                       fr(6),
-                       -fr(6),
-                       fr::zero(),
-                       fr::zero(),
-                       fr::zero() };
-
-        builder.create_big_add_gate_with_bit_extraction(gate);
+        builder.create_big_add_gate_with_bit_extraction({ builder.add_variable(uint256_t(input)),
+                                                          builder.add_variable(uint256_t(output)),
+                                                          right_idx,
+                                                          left_idx,
+                                                          fr(6),
+                                                          -fr(6),
+                                                          fr::zero(),
+                                                          fr::zero(),
+                                                          fr::zero() });
     };
 
     generate_constraints(0);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/turbo_composer.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/turbo_composer.hpp
@@ -22,18 +22,18 @@ class TurboComposer {
     std::shared_ptr<plonk::verification_key> circuit_verification_key;
 
     // The crs_factory holds the path to the srs and exposes methods to extract the srs elements
-    std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory_;
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> crs_factory_;
 
     bool computed_witness = false;
     TurboComposer()
-        : TurboComposer(std::shared_ptr<barretenberg::srs::factories::CrsFactory>(
-              new barretenberg::srs::factories::FileCrsFactory("../srs_db/ignition")))
+        : TurboComposer(std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>>(
+              new barretenberg::srs::factories::FileCrsFactory<curve::BN254>("../srs_db/ignition")))
     {}
 
-    TurboComposer(std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory)
+    TurboComposer(std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> crs_factory)
         : crs_factory_(std::move(crs_factory))
     {}
-    TurboComposer(std::unique_ptr<barretenberg::srs::factories::CrsFactory>&& crs_factory)
+    TurboComposer(std::unique_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>>&& crs_factory)
         : crs_factory_(std::move(crs_factory))
     {}
     TurboComposer(std::shared_ptr<plonk::proving_key> p_key, std::shared_ptr<plonk::verification_key> v_key)

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/ultra_composer.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/ultra_composer.hpp
@@ -17,6 +17,7 @@ class UltraComposer {
   public:
     using Flavor = flavor::Ultra;
     using CircuitBuilder = UltraCircuitBuilder;
+    using Curve = Flavor::Curve;
 
     static constexpr std::string_view NAME_STRING = "UltraPlonk";
     static constexpr CircuitType type = CircuitType::ULTRA;
@@ -26,7 +27,7 @@ class UltraComposer {
     std::shared_ptr<plonk::verification_key> circuit_verification_key;
 
     // The crs_factory holds the path to the srs and exposes methods to extract the srs elements
-    std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory_;
+    std::shared_ptr<barretenberg::srs::factories::CrsFactory<Curve>> crs_factory_;
 
     bool computed_witness = false;
 
@@ -40,9 +41,9 @@ class UltraComposer {
         : UltraComposer("../srs_db/ignition"){};
 
     UltraComposer(std::string const& crs_path)
-        : UltraComposer(std::make_unique<barretenberg::srs::factories::FileCrsFactory>(crs_path)){};
+        : UltraComposer(std::make_unique<barretenberg::srs::factories::FileCrsFactory<Curve>>(crs_path)){};
 
-    explicit UltraComposer(std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory)
+    explicit UltraComposer(std::shared_ptr<barretenberg::srs::factories::CrsFactory<Curve>> crs_factory)
         : crs_factory_(std::move(crs_factory))
     {}
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/ultra_composer.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/ultra_composer.test.cpp
@@ -186,8 +186,7 @@ TYPED_TEST(ultra_plonk_composer, test_elliptic_gate)
     uint32_t x3 = builder.add_variable(p3.x);
     uint32_t y3 = builder.add_variable(p3.y);
 
-    ecc_add_gate gate{ x1, y1, x2, y2, x3, y3, 1, 1 };
-    builder.create_ecc_add_gate(gate);
+    builder.create_ecc_add_gate({ x1, y1, x2, y2, x3, y3, 1, 1 });
 
     grumpkin::fq beta = grumpkin::fq::cube_root_of_unity();
     affine_element p2_endo = p2;
@@ -195,15 +194,13 @@ TYPED_TEST(ultra_plonk_composer, test_elliptic_gate)
     p3 = affine_element(element(p1) + element(p2_endo));
     x3 = builder.add_variable(p3.x);
     y3 = builder.add_variable(p3.y);
-    gate = ecc_add_gate{ x1, y1, x2, y2, x3, y3, beta, 1 };
-    builder.create_ecc_add_gate(gate);
+    builder.create_ecc_add_gate({ x1, y1, x2, y2, x3, y3, beta, 1 });
 
     p2_endo.x *= beta;
     p3 = affine_element(element(p1) - element(p2_endo));
     x3 = builder.add_variable(p3.x);
     y3 = builder.add_variable(p3.y);
-    gate = ecc_add_gate{ x1, y1, x2, y2, x3, y3, beta.sqr(), -1 };
-    builder.create_ecc_add_gate(gate);
+    builder.create_ecc_add_gate({ x1, y1, x2, y2, x3, y3, beta.sqr(), -1 });
 
     TestFixture::prove_and_verify(builder, composer, /*expected_result=*/true);
 }

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/flavor/flavor.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/flavor/flavor.hpp
@@ -10,6 +10,9 @@ class Standard {
   public:
     using CircuitBuilder = proof_system::StandardCircuitBuilder;
     using ProvingKey = plonk::proving_key;
+    using Curve = curve::BN254;
+    using FF = Curve::ScalarField;
+    using Polynomial = barretenberg::Polynomial<FF>;
     static constexpr size_t NUM_WIRES = CircuitBuilder::NUM_WIRES;
     // Whether or not the first row of the execution trace is reserved for 0s to enable shifts
     static constexpr bool has_zero_row = false;
@@ -19,6 +22,9 @@ class Turbo {
   public:
     using CircuitBuilder = proof_system::TurboCircuitBuilder;
     using ProvingKey = plonk::proving_key;
+    using Curve = curve::BN254;
+    using FF = Curve::ScalarField;
+    using Polynomial = barretenberg::Polynomial<FF>;
     static constexpr size_t NUM_WIRES = CircuitBuilder::NUM_WIRES;
     // Whether or not the first row of the execution trace is reserved for 0s to enable shifts
     static constexpr bool has_zero_row = false;
@@ -28,6 +34,9 @@ class Ultra {
   public:
     using CircuitBuilder = proof_system::UltraCircuitBuilder;
     using ProvingKey = plonk::proving_key;
+    using Curve = curve::BN254;
+    using FF = Curve::ScalarField;
+    using Polynomial = barretenberg::Polynomial<FF>;
     static constexpr size_t NUM_WIRES = CircuitBuilder::NUM_WIRES;
     // Whether or not the first row of the execution trace is reserved for 0s to enable shifts
     static constexpr bool has_zero_row = false;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/commitment_scheme.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/commitment_scheme.test.cpp
@@ -35,9 +35,9 @@ TEST(commitment_scheme, kate_open)
     transcript::StandardTranscript inp_tx = transcript::StandardTranscript(transcript::Manifest());
     plonk::KateCommitmentScheme<turbo_settings> newKate;
 
-    // std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory = (new
+    // std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> crs_factory = (new
     // FileReferenceStringFactory("../srs_db/ignition"));
-    auto file_crs = std::make_shared<barretenberg::srs::factories::FileCrsFactory>("../srs_db/ignition");
+    auto file_crs = std::make_shared<barretenberg::srs::factories::FileCrsFactory<curve::BN254>>("../srs_db/ignition");
     auto crs = file_crs->get_prover_crs(n);
     auto circuit_proving_key = std::make_shared<proving_key>(n, 0, crs, CircuitType::STANDARD);
     work_queue queue(circuit_proving_key.get(), &inp_tx);
@@ -94,7 +94,7 @@ TEST(commitment_scheme, kate_batch_open)
     transcript::StandardTranscript inp_tx = transcript::StandardTranscript(transcript::Manifest());
     plonk::KateCommitmentScheme<turbo_settings> newKate;
 
-    auto file_crs = std::make_shared<barretenberg::srs::factories::FileCrsFactory>("../srs_db/ignition");
+    auto file_crs = std::make_shared<barretenberg::srs::factories::FileCrsFactory<curve::BN254>>("../srs_db/ignition");
     auto crs = file_crs->get_prover_crs(n);
     auto circuit_proving_key = std::make_shared<proving_key>(n, 0, crs, CircuitType::STANDARD);
     work_queue queue(circuit_proving_key.get(), &inp_tx);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/proving_key/proving_key.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/proving_key/proving_key.test.cpp
@@ -26,7 +26,7 @@ TEST(proving_key, proving_key_from_serialized_key)
     plonk::proving_key& p_key = *composer.compute_proving_key(builder);
     auto pk_buf = to_buffer(p_key);
     auto pk_data = from_buffer<plonk::proving_key_data>(pk_buf);
-    auto crs = std::make_unique<barretenberg::srs::factories::FileCrsFactory>("../srs_db/ignition");
+    auto crs = std::make_unique<barretenberg::srs::factories::FileCrsFactory<curve::BN254>>("../srs_db/ignition");
     auto proving_key =
         std::make_shared<plonk::proving_key>(std::move(pk_data), crs->get_prover_crs(pk_data.circuit_size + 1));
 
@@ -63,7 +63,7 @@ TEST(proving_key, proving_key_from_serialized_key_ultra)
     plonk::proving_key& p_key = *composer.compute_proving_key(builder);
     auto pk_buf = to_buffer(p_key);
     auto pk_data = from_buffer<plonk::proving_key_data>(pk_buf);
-    auto crs = std::make_unique<barretenberg::srs::factories::FileCrsFactory>("../srs_db/ignition");
+    auto crs = std::make_unique<barretenberg::srs::factories::FileCrsFactory<curve::BN254>>("../srs_db/ignition");
     auto proving_key =
         std::make_shared<plonk::proving_key>(std::move(pk_data), crs->get_prover_crs(pk_data.circuit_size + 1));
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/verification_key.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/verification_key.cpp
@@ -87,7 +87,7 @@ barretenberg::fr verification_key_data::compress_native(const size_t hash_index)
 
 verification_key::verification_key(const size_t num_gates,
                                    const size_t num_inputs,
-                                   std::shared_ptr<barretenberg::srs::factories::VerifierCrs> const& crs,
+                                   std::shared_ptr<barretenberg::srs::factories::VerifierCrs<curve::BN254>> const& crs,
                                    CircuitType circuit_type_)
     : circuit_type(circuit_type_)
     , circuit_size(num_gates)
@@ -99,7 +99,7 @@ verification_key::verification_key(const size_t num_gates,
 {}
 
 verification_key::verification_key(verification_key_data&& data,
-                                   std::shared_ptr<barretenberg::srs::factories::VerifierCrs> const& crs)
+                                   std::shared_ptr<barretenberg::srs::factories::VerifierCrs<curve::BN254>> const& crs)
     : circuit_type(static_cast<CircuitType>(data.circuit_type))
     , circuit_size(data.circuit_size)
     , log_circuit_size(numeric::get_msb(data.circuit_size))

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/verification_key.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/verification_key.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "barretenberg/common/streams.hpp"
 #include "barretenberg/crypto/sha256/sha256.hpp"
+#include "barretenberg/ecc/curves/bn254/bn254.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barretenberg/plonk/proof_system/types/polynomial_manifest.hpp"
 #include "barretenberg/polynomials/evaluation_domain.hpp"
@@ -70,10 +71,10 @@ struct verification_key {
     // default constructor needed for msgpack unpack
     verification_key() = default;
     verification_key(verification_key_data&& data,
-                     std::shared_ptr<barretenberg::srs::factories::VerifierCrs> const& crs);
+                     std::shared_ptr<barretenberg::srs::factories::VerifierCrs<curve::BN254>> const& crs);
     verification_key(const size_t num_gates,
                      const size_t num_inputs,
-                     std::shared_ptr<barretenberg::srs::factories::VerifierCrs> const& crs,
+                     std::shared_ptr<barretenberg::srs::factories::VerifierCrs<curve::BN254>> const& crs,
                      CircuitType circuit_type);
 
     verification_key(const verification_key& other);
@@ -103,7 +104,7 @@ struct verification_key {
 
     barretenberg::evaluation_domain domain;
 
-    std::shared_ptr<barretenberg::srs::factories::VerifierCrs> reference_string;
+    std::shared_ptr<barretenberg::srs::factories::VerifierCrs<curve::BN254>> reference_string;
 
     std::map<std::string, barretenberg::g1::affine_element> commitments;
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/verifier/verifier.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/verifier/verifier.test.cpp
@@ -41,7 +41,7 @@ plonk::Verifier generate_verifier(std::shared_ptr<proving_key> circuit_proving_k
                                                            state));
     }
 
-    auto crs = std::make_shared<barretenberg::srs::factories::FileVerifierCrs>("../srs_db/ignition");
+    auto crs = std::make_shared<barretenberg::srs::factories::FileVerifierCrs<curve::BN254>>("../srs_db/ignition");
     std::shared_ptr<verification_key> circuit_verification_key =
         std::make_shared<verification_key>(circuit_proving_key->circuit_size,
                                            circuit_proving_key->num_public_inputs,

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/evaluation_domain.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/evaluation_domain.hpp
@@ -5,7 +5,7 @@
 
 namespace barretenberg {
 
-template <typename Fr> class EvaluationDomain {
+template <typename FF> class EvaluationDomain {
   public:
     EvaluationDomain()
         : size(0)
@@ -15,13 +15,13 @@ template <typename Fr> class EvaluationDomain {
         , log2_thread_size(0)
         , log2_num_threads(0)
         , generator_size(0)
-        , root(fr::zero())
-        , root_inverse(fr::zero())
-        , domain(fr::zero())
-        , domain_inverse(fr::zero())
-        , generator(fr::zero())
-        , generator_inverse(fr::zero())
-        , four_inverse(fr::zero())
+        , root(FF::zero())
+        , root_inverse(FF::zero())
+        , domain(FF::zero())
+        , domain_inverse(FF::zero())
+        , generator(FF::zero())
+        , generator_inverse(FF::zero())
+        , four_inverse(FF::zero())
         , roots(nullptr){};
 
     EvaluationDomain(const size_t domain_size, const size_t target_generator_size = 0);
@@ -36,8 +36,8 @@ template <typename Fr> class EvaluationDomain {
     void compute_lookup_table();
     void compute_generator_table(const size_t target_generator_size);
 
-    const std::vector<Fr*>& get_round_roots() const { return round_roots; };
-    const std::vector<Fr*>& get_inverse_round_roots() const { return inverse_round_roots; }
+    const std::vector<FF*>& get_round_roots() const { return round_roots; };
+    const std::vector<FF*>& get_inverse_round_roots() const { return inverse_round_roots; }
 
     size_t size;        // n, always a power of 2
     size_t num_threads; // num_threads * thread_size = size
@@ -47,28 +47,28 @@ template <typename Fr> class EvaluationDomain {
     size_t log2_num_threads;
     size_t generator_size;
 
-    Fr root;           // omega; the nth root of unity
-    Fr root_inverse;   // omega^{-1}
-    Fr domain;         // n; same as size
-    Fr domain_inverse; // n^{-1}
-    Fr generator;
-    Fr generator_inverse;
-    Fr four_inverse;
+    FF root;           // omega; the nth root of unity
+    FF root_inverse;   // omega^{-1}
+    FF domain;         // n; same as size
+    FF domain_inverse; // n^{-1}
+    FF generator;
+    FF generator_inverse;
+    FF four_inverse;
 
   private:
-    std::vector<Fr*> round_roots; // An entry for each of the log(n) rounds: each entry is a pointer to
+    std::vector<FF*> round_roots; // An entry for each of the log(n) rounds: each entry is a pointer to
                                   // the subset of the roots of unity required for that fft round.
                                   // E.g. round_roots[0] = [1, ω^(n/2 - 1)],
                                   //      round_roots[1] = [1, ω^(n/4 - 1), ω^(n/2 - 1), ω^(3n/4 - 1)]
                                   //      ...
-    std::vector<Fr*> inverse_round_roots;
+    std::vector<FF*> inverse_round_roots;
 
-    std::shared_ptr<Fr[]> roots;
+    std::shared_ptr<FF[]> roots;
 };
 
 // tell the compiler we will take care of instantiating these in the .cpp file
 extern template class EvaluationDomain<barretenberg::fr>;
-extern template class EvaluationDomain<grumpkin::fr>;
+// extern template class EvaluationDomain<grumpkin::fr>;
 // add alias for compatibility
 using evaluation_domain = EvaluationDomain<barretenberg::fr>;
 } // namespace barretenberg

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.test.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 
 using namespace barretenberg;
+// TODO(#635): This tests should be typed to run on both barretenberg::fr and grumpkin::fr.
 
 TEST(polynomials, evaluation_domain)
 {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/arithmetization/gate_data.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/arithmetization/gate_data.hpp
@@ -16,7 +16,6 @@ template <typename FF> struct add_triple_ {
     FF c_scaling;
     FF const_scaling;
 };
-using add_triple = add_triple_<barretenberg::fr>;
 
 template <typename FF> struct add_quad_ {
     uint32_t a;
@@ -29,8 +28,6 @@ template <typename FF> struct add_quad_ {
     FF d_scaling;
     FF const_scaling;
 };
-using add_quad = add_quad_<barretenberg::fr>;
-
 template <typename FF> struct mul_quad_ {
     uint32_t a;
     uint32_t b;
@@ -43,8 +40,6 @@ template <typename FF> struct mul_quad_ {
     FF d_scaling;
     FF const_scaling;
 };
-using mul_quad = mul_quad_<barretenberg::fr>;
-
 template <typename FF> struct mul_triple_ {
     uint32_t a;
     uint32_t b;
@@ -53,8 +48,6 @@ template <typename FF> struct mul_triple_ {
     FF c_scaling;
     FF const_scaling;
 };
-using mul_triple = mul_triple_<barretenberg::fr>;
-
 template <typename FF> struct poly_triple_ {
     uint32_t a;
     uint32_t b;
@@ -67,9 +60,7 @@ template <typename FF> struct poly_triple_ {
 
     friend bool operator==(poly_triple_<FF> const& lhs, poly_triple_<FF> const& rhs) = default;
 };
-
 using poly_triple = poly_triple_<barretenberg::fr>;
-
 struct ecc_op_tuple {
     uint32_t op;
     uint32_t x_lo;
@@ -80,7 +71,7 @@ struct ecc_op_tuple {
     uint32_t z_hi;
 };
 
-template <typename B> inline void read(B& buf, poly_triple& constraint)
+template <typename B, typename FF> inline void read(B& buf, poly_triple_<FF>& constraint)
 {
     using serialize::read;
     read(buf, constraint.a);
@@ -92,7 +83,7 @@ template <typename B> inline void read(B& buf, poly_triple& constraint)
     read(buf, constraint.q_o);
     read(buf, constraint.q_c);
 }
-template <typename B> inline void write(B& buf, poly_triple const& constraint)
+template <typename B, typename FF> inline void write(B& buf, poly_triple_<FF> const& constraint)
 {
     using serialize::write;
     write(buf, constraint.a);
@@ -115,23 +106,17 @@ template <typename FF> struct fixed_group_add_quad_ {
     FF q_y_1;
     FF q_y_2;
 };
-using fixed_group_add_quad = fixed_group_add_quad_<barretenberg::fr>;
-
 template <typename FF> struct fixed_group_init_quad_ {
     FF q_x_1;
     FF q_x_2;
     FF q_y_1;
     FF q_y_2;
 };
-using fixed_group_init_quad = fixed_group_init_quad_<barretenberg::fr>;
-
 template <typename FF> struct accumulator_triple_ {
     std::vector<uint32_t> left;
     std::vector<uint32_t> right;
     std::vector<uint32_t> out;
 };
-using accumulator_triple = accumulator_triple_<barretenberg::fr>;
-
 template <typename FF> struct ecc_add_gate_ {
     uint32_t x1;
     uint32_t y1;
@@ -142,5 +127,4 @@ template <typename FF> struct ecc_add_gate_ {
     FF endomorphism_coefficient;
     FF sign_coefficient;
 };
-using ecc_add_gate = ecc_add_gate_<barretenberg::fr>;
 } // namespace proof_system

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_translator_circuit_builder.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_translator_circuit_builder.hpp
@@ -24,10 +24,10 @@ class GoblinTranslatorCircuitBuilder : CircuitBuilderBase<arithmetization::Gobli
      * We won't need these standard gates that are defined as virtual in circuit builder base
      *
      */
-    void create_add_gate(const add_triple&) override{};
-    void create_mul_gate(const mul_triple&) override{};
+    void create_add_gate(const add_triple_<Fr>&) override{};
+    void create_mul_gate(const mul_triple_<Fr>&) override{};
     void create_bool_gate(const uint32_t) override{};
-    void create_poly_gate(const poly_triple&) override{};
+    void create_poly_gate(const poly_triple_<Fr>&) override{};
     [[nodiscard]] size_t get_num_constant_gates() const override { return 0; };
 
     /**

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.cpp
@@ -301,14 +301,14 @@ std::vector<uint32_t> StandardCircuitBuilder_<FF>::decompose_into_base4_accumula
 }
 
 template <typename FF>
-accumulator_triple StandardCircuitBuilder_<FF>::create_logic_constraint(const uint32_t a,
-                                                                        const uint32_t b,
-                                                                        const size_t num_bits,
-                                                                        const bool is_xor_gate)
+accumulator_triple_<FF> StandardCircuitBuilder_<FF>::create_logic_constraint(const uint32_t a,
+                                                                             const uint32_t b,
+                                                                             const size_t num_bits,
+                                                                             const bool is_xor_gate)
 {
     this->assert_valid_variables({ a, b });
 
-    accumulator_triple accumulators;
+    accumulator_triple_<FF> accumulators;
 
     const uint256_t left_witness_value(this->get_variable(a));
     const uint256_t right_witness_value(this->get_variable(b));
@@ -457,17 +457,17 @@ template <typename FF> uint32_t StandardCircuitBuilder_<FF>::put_constant_variab
 }
 
 template <typename FF>
-accumulator_triple StandardCircuitBuilder_<FF>::create_and_constraint(const uint32_t a,
-                                                                      const uint32_t b,
-                                                                      const size_t num_bits)
+accumulator_triple_<FF> StandardCircuitBuilder_<FF>::create_and_constraint(const uint32_t a,
+                                                                           const uint32_t b,
+                                                                           const size_t num_bits)
 {
     return create_logic_constraint(a, b, num_bits, false);
 }
 
 template <typename FF>
-accumulator_triple StandardCircuitBuilder_<FF>::create_xor_constraint(const uint32_t a,
-                                                                      const uint32_t b,
-                                                                      const size_t num_bits)
+accumulator_triple_<FF> StandardCircuitBuilder_<FF>::create_xor_constraint(const uint32_t a,
+                                                                           const uint32_t b,
+                                                                           const size_t num_bits)
 {
     return create_logic_constraint(a, b, num_bits, true);
 }
@@ -494,13 +494,16 @@ template <typename FF> bool StandardCircuitBuilder_<FF>::check_circuit()
     FF gate_sum;
     FF left, right, output;
     for (size_t i = 0; i < this->num_gates; i++) {
+
         gate_sum = FF::zero();
         left = this->get_variable(w_l[i]);
         right = this->get_variable(w_r[i]);
         output = this->get_variable(w_o[i]);
         gate_sum = q_m[i] * left * right + q_1[i] * left + q_2[i] * right + q_3[i] * output + q_c[i];
-        if (!gate_sum.is_zero())
+        if (!gate_sum.is_zero()) {
+            info("gate number", i);
             return false;
+        }
     }
     return true;
 }

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp
@@ -84,7 +84,7 @@ template <typename FF> class StandardCircuitBuilder_ : public CircuitBuilderBase
                                                const fixed_group_init_quad_<FF>& init);
     void create_fixed_group_add_gate_final(const add_quad_<FF>& in);
 
-    fixed_group_add_quad previous_add_quad;
+    fixed_group_add_quad_<FF> previous_add_quad;
 
     // TODO(#216)(Adrian): This should be a virtual overridable method in the base class.
     void fix_witness(const uint32_t witness_index, const FF& witness_value);
@@ -100,12 +100,12 @@ template <typename FF> class StandardCircuitBuilder_ : public CircuitBuilderBase
         decompose_into_base4_accumulators(variable_index, num_bits, msg);
     }
 
-    accumulator_triple create_logic_constraint(const uint32_t a,
-                                               const uint32_t b,
-                                               const size_t num_bits,
-                                               bool is_xor_gate);
-    accumulator_triple create_and_constraint(const uint32_t a, const uint32_t b, const size_t num_bits);
-    accumulator_triple create_xor_constraint(const uint32_t a, const uint32_t b, const size_t num_bits);
+    accumulator_triple_<FF> create_logic_constraint(const uint32_t a,
+                                                    const uint32_t b,
+                                                    const size_t num_bits,
+                                                    bool is_xor_gate);
+    accumulator_triple_<FF> create_and_constraint(const uint32_t a, const uint32_t b, const size_t num_bits);
+    accumulator_triple_<FF> create_xor_constraint(const uint32_t a, const uint32_t b, const size_t num_bits);
 
     // TODO(#216)(Adrian): The 2 following methods should be virtual in the base class
     uint32_t put_constant_variable(const FF& variable);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/turbo_circuit_builder.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/turbo_circuit_builder.cpp
@@ -33,7 +33,7 @@ TurboCircuitBuilder_<FF>::TurboCircuitBuilder_(const size_t size_hint)
  * @param in Specifies addition gate parameters:
  * w_l, w_r, w_o, q_1, q_2, q_3, q_c.
  * */
-template <typename FF> void TurboCircuitBuilder_<FF>::create_add_gate(const add_triple& in)
+template <typename FF> void TurboCircuitBuilder_<FF>::create_add_gate(const add_triple_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c });
 
@@ -64,7 +64,7 @@ template <typename FF> void TurboCircuitBuilder_<FF>::create_add_gate(const add_
  * @param in Specifies addition gate parameters:
  * w_l, w_r, w_o, w_4, q_1, q_2, q_3, q_4, q_c.
  * */
-template <typename FF> void TurboCircuitBuilder_<FF>::create_big_add_gate(const add_quad& in)
+template <typename FF> void TurboCircuitBuilder_<FF>::create_big_add_gate(const add_quad_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c, in.d });
 
@@ -102,7 +102,7 @@ template <typename FF> void TurboCircuitBuilder_<FF>::create_big_add_gate(const 
  * ensure this assumption is backed by a constraint (e.g., c and d could be accumulators produced using the TurboPLONK
  * function `decompose_into_base4_accumulators`).
  * */
-template <typename FF> void TurboCircuitBuilder_<FF>::create_big_add_gate_with_bit_extraction(const add_quad& in)
+template <typename FF> void TurboCircuitBuilder_<FF>::create_big_add_gate_with_bit_extraction(const add_quad_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c, in.d });
 
@@ -124,7 +124,7 @@ template <typename FF> void TurboCircuitBuilder_<FF>::create_big_add_gate_with_b
     ++this->num_gates;
 }
 
-template <typename FF> void TurboCircuitBuilder_<FF>::create_big_mul_gate(const mul_quad& in)
+template <typename FF> void TurboCircuitBuilder_<FF>::create_big_mul_gate(const mul_quad_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c, in.d });
 
@@ -163,7 +163,7 @@ template <typename FF> void TurboCircuitBuilder_<FF>::create_big_mul_gate(const 
  * @warning Even with the constraint on w_3, it is typically necessary to range constrain the wire value that will be
  * returned.
  */
-template <typename FF> void TurboCircuitBuilder_<FF>::create_balanced_add_gate(const add_quad& in)
+template <typename FF> void TurboCircuitBuilder_<FF>::create_balanced_add_gate(const add_quad_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c, in.d });
 
@@ -194,7 +194,7 @@ template <typename FF> void TurboCircuitBuilder_<FF>::create_balanced_add_gate(c
  * @param in Contains the values for w_l, w_r, w_o,
  * q_m, q_3, q_c.
  * */
-template <typename FF> void TurboCircuitBuilder_<FF>::create_mul_gate(const mul_triple& in)
+template <typename FF> void TurboCircuitBuilder_<FF>::create_mul_gate(const mul_triple_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c });
 
@@ -255,7 +255,7 @@ template <typename FF> void TurboCircuitBuilder_<FF>::create_bool_gate(const uin
  * @param in Contains the values for
  * w_l, w_r, w_o, q_m, q_1, q_2, q_3, q_c.
  * */
-template <typename FF> void TurboCircuitBuilder_<FF>::create_poly_gate(const poly_triple& in)
+template <typename FF> void TurboCircuitBuilder_<FF>::create_poly_gate(const poly_triple_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c });
 
@@ -283,7 +283,7 @@ template <typename FF> void TurboCircuitBuilder_<FF>::create_poly_gate(const pol
  *
  * @param in Witnesses and values of two points.
  * */
-template <typename FF> void TurboCircuitBuilder_<FF>::create_fixed_group_add_gate(const fixed_group_add_quad& in)
+template <typename FF> void TurboCircuitBuilder_<FF>::create_fixed_group_add_gate(const fixed_group_add_quad_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c, in.d });
 
@@ -314,8 +314,8 @@ template <typename FF> void TurboCircuitBuilder_<FF>::create_fixed_group_add_gat
  * @param init Initialization parameters (points).
  * */
 template <typename FF>
-void TurboCircuitBuilder_<FF>::create_fixed_group_add_gate_with_init(const fixed_group_add_quad& in,
-                                                                     const fixed_group_init_quad& init)
+void TurboCircuitBuilder_<FF>::create_fixed_group_add_gate_with_init(const fixed_group_add_quad_<FF>& in,
+                                                                     const fixed_group_init_quad_<FF>& init)
 {
     this->assert_valid_variables({ in.a, in.b, in.c, in.d });
 
@@ -339,7 +339,7 @@ void TurboCircuitBuilder_<FF>::create_fixed_group_add_gate_with_init(const fixed
     ++this->num_gates;
 }
 
-template <typename FF> void TurboCircuitBuilder_<FF>::create_fixed_group_add_gate_final(const add_quad& in)
+template <typename FF> void TurboCircuitBuilder_<FF>::create_fixed_group_add_gate_final(const add_quad_<FF>& in)
 {
     create_big_add_gate(in);
 }
@@ -563,10 +563,10 @@ std::vector<uint32_t> TurboCircuitBuilder_<FF>::decompose_into_base4_accumulator
  * The same holds, mutatis mutandis, for T.right.
  */
 template <typename FF>
-accumulator_triple TurboCircuitBuilder_<FF>::create_logic_constraint(const uint32_t a,
-                                                                     const uint32_t b,
-                                                                     const size_t num_bits,
-                                                                     const bool is_xor_gate)
+accumulator_triple_<FF> TurboCircuitBuilder_<FF>::create_logic_constraint(const uint32_t a,
+                                                                          const uint32_t b,
+                                                                          const size_t num_bits,
+                                                                          const bool is_xor_gate)
 {
     this->assert_valid_variables({ a, b });
 
@@ -647,7 +647,7 @@ accumulator_triple TurboCircuitBuilder_<FF>::create_logic_constraint(const uint3
     const uint256_t left_witness_value(this->get_variable(a));
     const uint256_t right_witness_value(this->get_variable(b));
 
-    accumulator_triple accumulators;
+    accumulator_triple_<FF> accumulators;
     FF left_accumulator = FF::zero();
     FF right_accumulator = FF::zero();
     FF out_accumulator = FF::zero();
@@ -751,17 +751,17 @@ accumulator_triple TurboCircuitBuilder_<FF>::create_logic_constraint(const uint3
 }
 
 template <typename FF>
-accumulator_triple TurboCircuitBuilder_<FF>::create_and_constraint(const uint32_t a,
-                                                                   const uint32_t b,
-                                                                   const size_t num_bits)
+accumulator_triple_<FF> TurboCircuitBuilder_<FF>::create_and_constraint(const uint32_t a,
+                                                                        const uint32_t b,
+                                                                        const size_t num_bits)
 {
     return create_logic_constraint(a, b, num_bits, false);
 }
 
 template <typename FF>
-accumulator_triple TurboCircuitBuilder_<FF>::create_xor_constraint(const uint32_t a,
-                                                                   const uint32_t b,
-                                                                   const size_t num_bits)
+accumulator_triple_<FF> TurboCircuitBuilder_<FF>::create_xor_constraint(const uint32_t a,
+                                                                        const uint32_t b,
+                                                                        const size_t num_bits)
 {
     return create_logic_constraint(a, b, num_bits, true);
 }

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/turbo_circuit_builder.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/turbo_circuit_builder.hpp
@@ -54,19 +54,20 @@ template <typename FF> class TurboCircuitBuilder_ : public CircuitBuilderBase<ar
     };
     ~TurboCircuitBuilder_() {}
 
-    void create_add_gate(const add_triple& in);
+    void create_add_gate(const add_triple_<FF>& in);
 
-    void create_big_add_gate(const add_quad& in);
-    void create_big_add_gate_with_bit_extraction(const add_quad& in);
-    void create_big_mul_gate(const mul_quad& in);
-    void create_balanced_add_gate(const add_quad& in);
+    void create_big_add_gate(const add_quad_<FF>& in);
+    void create_big_add_gate_with_bit_extraction(const add_quad_<FF>& in);
+    void create_big_mul_gate(const mul_quad_<FF>& in);
+    void create_balanced_add_gate(const add_quad_<FF>& in);
 
-    void create_mul_gate(const mul_triple& in);
+    void create_mul_gate(const mul_triple_<FF>& in);
     void create_bool_gate(const uint32_t a);
-    void create_poly_gate(const poly_triple& in);
-    void create_fixed_group_add_gate(const fixed_group_add_quad& in);
-    void create_fixed_group_add_gate_with_init(const fixed_group_add_quad& in, const fixed_group_init_quad& init);
-    void create_fixed_group_add_gate_final(const add_quad& in);
+    void create_poly_gate(const poly_triple_<FF>& in);
+    void create_fixed_group_add_gate(const fixed_group_add_quad_<FF>& in);
+    void create_fixed_group_add_gate_with_init(const fixed_group_add_quad_<FF>& in,
+                                               const fixed_group_init_quad_<FF>& init);
+    void create_fixed_group_add_gate_final(const add_quad_<FF>& in);
     void fix_witness(const uint32_t witness_index, const FF& witness_value);
 
     FF arithmetic_gate_evaluation(const size_t index, const FF alpha_base);
@@ -90,12 +91,12 @@ template <typename FF> class TurboCircuitBuilder_ : public CircuitBuilderBase<ar
         decompose_into_base4_accumulators(variable_index, num_bits, msg);
     }
 
-    accumulator_triple create_logic_constraint(const uint32_t a,
-                                               const uint32_t b,
-                                               const size_t num_bits,
-                                               bool is_xor_gate);
-    accumulator_triple create_and_constraint(const uint32_t a, const uint32_t b, const size_t num_bits);
-    accumulator_triple create_xor_constraint(const uint32_t a, const uint32_t b, const size_t num_bits);
+    accumulator_triple_<FF> create_logic_constraint(const uint32_t a,
+                                                    const uint32_t b,
+                                                    const size_t num_bits,
+                                                    bool is_xor_gate);
+    accumulator_triple_<FF> create_and_constraint(const uint32_t a, const uint32_t b, const size_t num_bits);
+    accumulator_triple_<FF> create_xor_constraint(const uint32_t a, const uint32_t b, const size_t num_bits);
 
     uint32_t put_constant_variable(const FF& variable);
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.cpp
@@ -118,7 +118,7 @@ template <typename FF> void UltraCircuitBuilder_<FF>::add_gates_to_ensure_all_po
  *
  * @param in A structure with variable indexes and selector values for the gate.
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_add_gate(const add_triple& in)
+template <typename FF> void UltraCircuitBuilder_<FF>::create_add_gate(const add_triple_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c });
 
@@ -149,7 +149,7 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_add_gate(const add_
  * @param include_next_gate_w_4 Switches on/off the addition of w_4 at the next index
  */
 template <typename FF>
-void UltraCircuitBuilder_<FF>::create_big_add_gate(const add_quad& in, const bool include_next_gate_w_4)
+void UltraCircuitBuilder_<FF>::create_big_add_gate(const add_quad_<FF>& in, const bool include_next_gate_w_4)
 {
     this->assert_valid_variables({ in.a, in.b, in.c, in.d });
     w_l.emplace_back(in.a);
@@ -176,7 +176,7 @@ void UltraCircuitBuilder_<FF>::create_big_add_gate(const add_quad& in, const boo
  *
  * @param in Structure with variables and witness selector values
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_big_add_gate_with_bit_extraction(const add_quad& in)
+template <typename FF> void UltraCircuitBuilder_<FF>::create_big_add_gate_with_bit_extraction(const add_quad_<FF>& in)
 {
     // This method is an artifact of a turbo plonk feature that implicitly extracts
     // a high or low bit from a base-4 quad and adds it into the arithmetic gate relationship.
@@ -239,7 +239,7 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_big_add_gate_with_b
  *
  * @param in Structure containing variables and witness selectors
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_big_mul_gate(const mul_quad& in)
+template <typename FF> void UltraCircuitBuilder_<FF>::create_big_mul_gate(const mul_quad_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c, in.d });
 
@@ -263,7 +263,7 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_big_mul_gate(const 
 
 // Creates a width-4 addition gate, where the fourth witness must be a boolean.
 // Can be used to normalize a 32-bit addition
-template <typename FF> void UltraCircuitBuilder_<FF>::create_balanced_add_gate(const add_quad& in)
+template <typename FF> void UltraCircuitBuilder_<FF>::create_balanced_add_gate(const add_quad_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c, in.d });
 
@@ -303,7 +303,7 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_balanced_add_gate(c
  *
  * @param in Structure containing variables and witness selectors
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_mul_gate(const mul_triple& in)
+template <typename FF> void UltraCircuitBuilder_<FF>::create_mul_gate(const mul_triple_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c });
 
@@ -358,7 +358,7 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_bool_gate(const uin
  *
  * @param in Structure containing variables and witness selectors
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_poly_gate(const poly_triple& in)
+template <typename FF> void UltraCircuitBuilder_<FF>::create_poly_gate(const poly_triple_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c });
 
@@ -391,7 +391,7 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_poly_gate(const pol
  * added, the resulting point coordinates and the selector values that describe whether the endomorphism is used on the
  * second point and whether it is negated.
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_ecc_add_gate(const ecc_add_gate& in)
+template <typename FF> void UltraCircuitBuilder_<FF>::create_ecc_add_gate(const ecc_add_gate_<FF>& in)
 {
     /**
      * | 1  | 2  | 3  | 4  |
@@ -3535,4 +3535,7 @@ template <typename FF> bool UltraCircuitBuilder_<FF>::check_circuit()
     return result;
 }
 template class UltraCircuitBuilder_<barretenberg::fr>;
+// To enable this we need to template plookup
+// template class UltraCircuitBuilder_<grumpkin::fr>;
+
 } // namespace proof_system

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
@@ -644,17 +644,17 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<ar
 
     void add_gates_to_ensure_all_polys_are_non_zero();
 
-    void create_add_gate(const add_triple& in) override;
+    void create_add_gate(const add_triple_<FF>& in) override;
 
-    void create_big_add_gate(const add_quad& in, const bool use_next_gate_w_4 = false);
-    void create_big_add_gate_with_bit_extraction(const add_quad& in);
-    void create_big_mul_gate(const mul_quad& in);
-    void create_balanced_add_gate(const add_quad& in);
+    void create_big_add_gate(const add_quad_<FF>& in, const bool use_next_gate_w_4 = false);
+    void create_big_add_gate_with_bit_extraction(const add_quad_<FF>& in);
+    void create_big_mul_gate(const mul_quad_<FF>& in);
+    void create_balanced_add_gate(const add_quad_<FF>& in);
 
-    void create_mul_gate(const mul_triple& in) override;
+    void create_mul_gate(const mul_triple_<FF>& in) override;
     void create_bool_gate(const uint32_t a) override;
-    void create_poly_gate(const poly_triple& in) override;
-    void create_ecc_add_gate(const ecc_add_gate& in);
+    void create_poly_gate(const poly_triple_<FF>& in) override;
+    void create_ecc_add_gate(const ecc_add_gate_<FF>& in);
 
     void fix_witness(const uint32_t witness_index, const FF& witness_value);
 
@@ -678,7 +678,7 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<ar
              *    num_bits <= DEFAULT_PLOOKUP_RANGE_BITNUM is correctly enforced in the circuit.
              *    Longer term, as Zac says, we would need to refactor the composer to fix this.
              **/
-            create_poly_gate(poly_triple{
+            create_poly_gate(poly_triple_<FF>{
                 .a = variable_index,
                 .b = variable_index,
                 .c = variable_index,
@@ -694,12 +694,12 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<ar
         }
     }
 
-    accumulator_triple create_logic_constraint(const uint32_t a,
-                                               const uint32_t b,
-                                               const size_t num_bits,
-                                               bool is_xor_gate);
-    accumulator_triple create_and_constraint(const uint32_t a, const uint32_t b, const size_t num_bits);
-    accumulator_triple create_xor_constraint(const uint32_t a, const uint32_t b, const size_t num_bits);
+    accumulator_triple_<FF> create_logic_constraint(const uint32_t a,
+                                                    const uint32_t b,
+                                                    const size_t num_bits,
+                                                    bool is_xor_gate);
+    accumulator_triple_<FF> create_and_constraint(const uint32_t a, const uint32_t b, const size_t num_bits);
+    accumulator_triple_<FF> create_xor_constraint(const uint32_t a, const uint32_t b, const size_t num_bits);
 
     uint32_t put_constant_variable(const FF& variable);
 
@@ -1201,5 +1201,8 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<ar
     bool check_circuit();
 };
 extern template class UltraCircuitBuilder_<barretenberg::fr>;
+// TODO: template plookup to be able to be able to have UltraCircuitBuilder on Grumpkin
+// extern template class UltraCircuitBuilder_<grumpkin::fr>;
 using UltraCircuitBuilder = UltraCircuitBuilder_<barretenberg::fr>;
+// using UltraGrumpkinCircuitBuilder = UltraCircuitBuilder_<grumpkin::fr>;
 } // namespace proof_system

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.test.cpp
@@ -147,8 +147,7 @@ TEST(ultra_circuit_constructor, test_elliptic_gate)
     uint32_t x3 = circuit_constructor.add_variable(p3.x);
     uint32_t y3 = circuit_constructor.add_variable(p3.y);
 
-    ecc_add_gate gate{ x1, y1, x2, y2, x3, y3, 1, 1 };
-    circuit_constructor.create_ecc_add_gate(gate);
+    circuit_constructor.create_ecc_add_gate({ x1, y1, x2, y2, x3, y3, 1, 1 });
 
     grumpkin::fq beta = grumpkin::fq::cube_root_of_unity();
     affine_element p2_endo = p2;
@@ -156,15 +155,13 @@ TEST(ultra_circuit_constructor, test_elliptic_gate)
     p3 = affine_element(element(p1) + element(p2_endo));
     x3 = circuit_constructor.add_variable(p3.x);
     y3 = circuit_constructor.add_variable(p3.y);
-    gate = ecc_add_gate{ x1, y1, x2, y2, x3, y3, beta, 1 };
-    circuit_constructor.create_ecc_add_gate(gate);
+    circuit_constructor.create_ecc_add_gate({ x1, y1, x2, y2, x3, y3, beta, 1 });
 
     p2_endo.x *= beta;
     p3 = affine_element(element(p1) - element(p2_endo));
     x3 = circuit_constructor.add_variable(p3.x);
     y3 = circuit_constructor.add_variable(p3.y);
-    gate = ecc_add_gate{ x1, y1, x2, y2, x3, y3, beta.sqr(), -1 };
-    circuit_constructor.create_ecc_add_gate(gate);
+    circuit_constructor.create_ecc_add_gate({ x1, y1, x2, y2, x3, y3, beta.sqr(), -1 });
 
     auto saved_state = UltraCircuitBuilder::CircuitDataBackup::store_full_state(circuit_constructor);
     bool result = circuit_constructor.check_circuit();
@@ -172,8 +169,7 @@ TEST(ultra_circuit_constructor, test_elliptic_gate)
     EXPECT_EQ(result, true);
     EXPECT_TRUE(saved_state.is_same_state(circuit_constructor));
 
-    gate = ecc_add_gate{ x1 + 1, y1, x2, y2, x3, y3, beta.sqr(), -1 };
-    circuit_constructor.create_ecc_add_gate(gate);
+    circuit_constructor.create_ecc_add_gate({ x1 + 1, y1, x2, y2, x3, y3, beta.sqr(), -1 });
 
     EXPECT_EQ(circuit_constructor.check_circuit(), false);
 }

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/composer/composer_lib.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/composer/composer_lib.hpp
@@ -45,7 +45,7 @@ void construct_selector_polynomials(const typename Flavor::CircuitBuilder& circu
 
         // Copy the selector values for all gates, keeping the rows at which we store public inputs as 0.
         // Initializing the polynomials in this way automatically applies 0-padding to the selectors.
-        barretenberg::polynomial selector_poly_lagrange(proving_key->circuit_size);
+        typename Flavor::Polynomial selector_poly_lagrange(proving_key->circuit_size);
         for (size_t i = 0; i < selector_values.size(); ++i) {
             selector_poly_lagrange[i + gate_offset] = selector_values[i];
         }
@@ -75,10 +75,10 @@ void construct_selector_polynomials(const typename Flavor::CircuitBuilder& circu
  * @param circuit_constructor
  * @param dyadic_circuit_size Power of 2 circuit size
  *
- * @return std::vector<barretenberg::polynomial>
+ * @return std::vector<typename Flavor::Polynomial>
  * */
 template <typename Flavor>
-std::vector<barretenberg::polynomial> construct_wire_polynomials_base(
+std::vector<typename Flavor::Polynomial> construct_wire_polynomials_base(
     const typename Flavor::CircuitBuilder& circuit_constructor, const size_t dyadic_circuit_size)
 {
     // Determine size of each block of data in the wire polynomials
@@ -96,13 +96,13 @@ std::vector<barretenberg::polynomial> construct_wire_polynomials_base(
     size_t pub_input_offset = num_zero_rows + num_ecc_op_gates;
     size_t gate_offset = num_zero_rows + num_ecc_op_gates + num_public_inputs;
 
-    std::vector<barretenberg::polynomial> wire_polynomials;
+    std::vector<typename Flavor::Polynomial> wire_polynomials;
 
     // Populate the wire polynomials with values from ecc op gates, public inputs and conventional wires
     for (size_t wire_idx = 0; wire_idx < Flavor::NUM_WIRES; ++wire_idx) {
 
         // Expect all values to be set to 0 initially
-        barretenberg::polynomial w_lagrange(dyadic_circuit_size);
+        typename Flavor::Polynomial w_lagrange(dyadic_circuit_size);
 
         // Insert leading zero row into wire poly (for clarity; not stricly necessary due to zero-initialization)
         for (size_t i = 0; i < num_zero_rows; ++i) {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/composer/composer_lib.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/composer/composer_lib.test.cpp
@@ -14,7 +14,7 @@ class ComposerLibTests : public ::testing::Test {
     using FF = typename Flavor::FF;
     Flavor::CircuitBuilder circuit_constructor;
     Flavor::ProvingKey proving_key = []() {
-        auto crs_factory = barretenberg::srs::factories::CrsFactory();
+        auto crs_factory = barretenberg::srs::factories::CrsFactory<curve::BN254>();
         auto crs = crs_factory.get_prover_crs(4);
         return Flavor::ProvingKey(/*circuit_size=*/4, /*num_public_inputs=*/0);
     }();

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/composer/permutation_lib.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/composer/permutation_lib.hpp
@@ -62,7 +62,9 @@ namespace {
 
 /**
  * @brief Compute all CyclicPermutations of the circuit. Each CyclicPermutation represents the indices of the values in
- * the witness wires that must have the same value.
+ * the witness wires that must have the same value.    using Curve = curve::BN254;
+    using FF = Curve::ScalarField;
+    using Polynomial = barretenberg::Polynomial<FF>;
  *
  * @tparam program_width Program width
  *
@@ -284,6 +286,7 @@ void compute_honk_style_permutation_lagrange_polynomials_from_mapping(
     std::array<std::vector<permutation_subgroup_element>, Flavor::NUM_WIRES>& permutation_mappings,
     typename Flavor::ProvingKey* proving_key)
 {
+    using FF = typename Flavor::FF;
     const size_t num_gates = proving_key->circuit_size;
 
     size_t wire_index = 0;
@@ -299,16 +302,14 @@ void compute_honk_style_permutation_lagrange_polynomials_from_mapping(
             //  -(i+1) -> (n+i)
             // These indices are chosen so they can easily be computed by the verifier. They can expect the running
             // product to be equal to the "public input delta" that is computed in <honk/utils/grand_product_delta.hpp>
-            current_permutation_poly[i] =
-                -barretenberg::fr(current_mapping.row_index + 1 + num_gates * current_mapping.column_index);
+            current_permutation_poly[i] = -FF(current_mapping.row_index + 1 + num_gates * current_mapping.column_index);
         } else if (current_mapping.is_tag) {
             // Set evaluations to (arbitrary) values disjoint from non-tag values
             current_permutation_poly[i] = num_gates * Flavor::NUM_WIRES + current_mapping.row_index;
         } else {
             // For the regular permutation we simply point to the next location by setting the evaluation to its
             // index
-            current_permutation_poly[i] =
-                barretenberg::fr(current_mapping.row_index + num_gates * current_mapping.column_index);
+            current_permutation_poly[i] = FF(current_mapping.row_index + num_gates * current_mapping.column_index);
         }
         ITERATE_OVER_DOMAIN_END;
         wire_index++;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/composer/permutation_lib.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/composer/permutation_lib.test.cpp
@@ -14,7 +14,8 @@ class PermutationHelperTests : public ::testing::Test {
     using FF = typename Flavor::FF;
     using ProvingKey = Flavor::ProvingKey;
     Flavor::CircuitBuilder circuit_constructor;
-    barretenberg::srs::factories::CrsFactory crs_factory = barretenberg::srs::factories::CrsFactory();
+    barretenberg::srs::factories::CrsFactory<curve::BN254> crs_factory =
+        barretenberg::srs::factories::CrsFactory<curve::BN254>();
     std::shared_ptr<Flavor::ProvingKey> proving_key;
 
     virtual void SetUp()

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/factories/crs_factory.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/factories/crs_factory.hpp
@@ -21,7 +21,7 @@ template <typename Curve> class ProverCrs {
     ;
 
     /**
-     * Returns the monomial points in a form to be consumed by scalar_multiplication pippenger algorithm.
+     *  @brief Returns the monomial points in a form to be consumed by scalar_multiplication pippenger algorithm.
      */
     virtual typename Curve::AffineElement* get_monomial_points() = 0;
     virtual size_t get_monomial_size() const = 0;
@@ -36,7 +36,15 @@ template <> class VerifierCrs<curve::BN254> {
 
   public:
     virtual Curve::G2AffineElement get_g2x() const = 0;
+    /**
+     * @brief As the G_2 element of the CRS is fixed, we can precompute the operations performed on it during the
+     * pairing algorithm to optimise pairing computations.
+     */
     virtual barretenberg::pairing::miller_lines const* get_precomputed_g2_lines() const = 0;
+    /**
+     *  @brief Returns the first G_1 element from the CRS, used by the Shplonk verifier to compute the final
+     * commtiment.
+     */
     virtual Curve::AffineElement get_first_g1() const = 0;
 };
 
@@ -44,8 +52,16 @@ template <> class VerifierCrs<curve::Grumpkin> {
     using Curve = curve::Grumpkin;
 
   public:
+    /**
+     * @brief Returns the G_1 elements in the CRS after the pippenger point table has been applied on them
+     *
+     */
     virtual Curve::AffineElement* get_monomial_points() const = 0;
     virtual size_t get_monomial_size() const = 0;
+    /**
+     * @brief Returns the first G_1 element from the CRS, used by the Shplonk verifier to compute the final
+     * commtiment.
+     */
     virtual Curve::AffineElement get_first_g1() const = 0;
 };
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/factories/crs_factory.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/factories/crs_factory.hpp
@@ -3,6 +3,7 @@
 #include "barretenberg/ecc/curves/bn254/bn254.hpp"
 #include "barretenberg/ecc/curves/bn254/g1.hpp"
 #include "barretenberg/ecc/curves/bn254/g2.hpp"
+#include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 #include <cstddef>
 
 namespace barretenberg::pairing {
@@ -26,30 +27,43 @@ template <typename Curve> class ProverCrs {
     virtual size_t get_monomial_size() const = 0;
 };
 
-class VerifierCrs {
+template <typename Curve> class VerifierCrs {
   public:
     virtual ~VerifierCrs() = default;
-    ;
+};
+template <> class VerifierCrs<curve::BN254> {
+    using Curve = curve::BN254;
 
-    virtual barretenberg::g2::affine_element get_g2x() const = 0;
-
+  public:
+    virtual Curve::G2AffineElement get_g2x() const = 0;
     virtual barretenberg::pairing::miller_lines const* get_precomputed_g2_lines() const = 0;
+    virtual Curve::AffineElement get_first_g1() const = 0;
+};
+
+template <> class VerifierCrs<curve::Grumpkin> {
+    using Curve = curve::Grumpkin;
+
+  public:
+    virtual Curve::AffineElement* get_monomial_points() const = 0;
+    virtual size_t get_monomial_size() const = 0;
+    virtual Curve::AffineElement get_first_g1() const = 0;
 };
 
 /**
  * A factory class to return the prover crs and verifier crs on request.
  * You can construct an empty placeholder factory, because composers need to be given a factory at construction time.
  */
-class CrsFactory {
+template <typename Curve> class CrsFactory {
   public:
     CrsFactory() = default;
     CrsFactory(CrsFactory&& other) = default;
     virtual ~CrsFactory() = default;
-    virtual std::shared_ptr<barretenberg::srs::factories::ProverCrs<curve::BN254>> get_prover_crs(size_t)
+    virtual std::shared_ptr<barretenberg::srs::factories::ProverCrs<Curve>> get_prover_crs(size_t) { return nullptr; }
+    virtual std::shared_ptr<barretenberg::srs::factories::VerifierCrs<Curve>> get_verifier_crs(
+        [[maybe_unused]] size_t degree = 0)
     {
         return nullptr;
     }
-    virtual std::shared_ptr<barretenberg::srs::factories::VerifierCrs> get_verifier_crs() { return nullptr; }
 };
 
 } // namespace barretenberg::srs::factories

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/factories/file_crs_factory.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/factories/file_crs_factory.cpp
@@ -3,67 +3,79 @@
 #include "barretenberg/ecc/curves/bn254/bn254.hpp"
 #include "barretenberg/ecc/curves/bn254/g1.hpp"
 #include "barretenberg/ecc/curves/bn254/pairing.hpp"
+#include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 #include "barretenberg/ecc/scalar_multiplication/point_table.hpp"
 #include "barretenberg/ecc/scalar_multiplication/scalar_multiplication.hpp"
 
 namespace barretenberg::srs::factories {
 
-template <typename Curve>
-FileProverCrs<Curve>::FileProverCrs(const size_t num_points, std::string const& path)
-    : num_points(num_points)
-{
-    monomials_ = scalar_multiplication::point_table_alloc<typename Curve::AffineElement>(num_points);
-
-    srs::IO<Curve>::read_transcript_g1(monomials_.get(), num_points, path);
-    scalar_multiplication::generate_pippenger_point_table<Curve>(monomials_.get(), monomials_.get(), num_points);
-}
-
-FileVerifierCrs::FileVerifierCrs(std::string const& path)
+FileVerifierCrs<curve::BN254>::FileVerifierCrs(std::string const& path, const size_t)
     : precomputed_g2_lines(
           (barretenberg::pairing::miller_lines*)(aligned_alloc(64, sizeof(barretenberg::pairing::miller_lines) * 2)))
 {
-
+    using Curve = curve::BN254;
+    auto point_buf = scalar_multiplication::point_table_alloc<Curve::AffineElement>(1);
+    srs::IO<Curve>::read_transcript_g1(point_buf.get(), 1, path);
     srs::IO<curve::BN254>::read_transcript_g2(g2_x, path);
     barretenberg::pairing::precompute_miller_lines(barretenberg::g2::one, precomputed_g2_lines[0]);
     barretenberg::pairing::precompute_miller_lines(g2_x, precomputed_g2_lines[1]);
+    first_g1 = point_buf[0];
 }
 
-FileVerifierCrs::~FileVerifierCrs()
+FileVerifierCrs<curve::BN254>::~FileVerifierCrs()
 {
     aligned_free(precomputed_g2_lines);
 }
 
-g2::affine_element FileVerifierCrs::get_g2x() const
+FileVerifierCrs<curve::Grumpkin>::FileVerifierCrs(std::string const& path, const size_t num_points)
+    : num_points(num_points)
 {
-    return g2_x;
+    using Curve = curve::Grumpkin;
+    monomials_ = scalar_multiplication::point_table_alloc<Curve::AffineElement>(num_points);
+    srs::IO<Curve>::read_transcript_g1(monomials_.get(), num_points, path);
+    scalar_multiplication::generate_pippenger_point_table<Curve>(monomials_.get(), monomials_.get(), num_points);
+    first_g1 = monomials_[0];
+};
+
+curve::Grumpkin::AffineElement* FileVerifierCrs<curve::Grumpkin>::get_monomial_points() const
+{
+    return monomials_.get();
 }
 
-pairing::miller_lines const* FileVerifierCrs::get_precomputed_g2_lines() const
+size_t FileVerifierCrs<curve::Grumpkin>::get_monomial_size() const
 {
-    return precomputed_g2_lines;
+    return num_points;
 }
 
-FileCrsFactory::FileCrsFactory(std::string path, size_t initial_degree)
+template <typename Curve>
+FileCrsFactory<Curve>::FileCrsFactory(std::string path, size_t initial_degree)
     : path_(std::move(path))
     , degree_(initial_degree)
-    , verifier_crs_(std::make_shared<FileVerifierCrs>(path_))
 {}
 
-std::shared_ptr<barretenberg::srs::factories::ProverCrs<curve::BN254>> FileCrsFactory::get_prover_crs(size_t degree)
+template <typename Curve>
+std::shared_ptr<barretenberg::srs::factories::ProverCrs<Curve>> FileCrsFactory<Curve>::get_prover_crs(size_t degree)
 {
     if (degree != degree_ || !prover_crs_) {
-        prover_crs_ = std::make_shared<FileProverCrs<curve::BN254>>(degree, path_);
+        prover_crs_ = std::make_shared<FileProverCrs<Curve>>(degree, path_);
         degree_ = degree;
     }
     return prover_crs_;
 }
 
-std::shared_ptr<barretenberg::srs::factories::VerifierCrs> FileCrsFactory::get_verifier_crs()
+template <typename Curve>
+std::shared_ptr<barretenberg::srs::factories::VerifierCrs<Curve>> FileCrsFactory<Curve>::get_verifier_crs(size_t degree)
 {
+    if (degree != degree_ || !verifier_crs_) {
+        verifier_crs_ = std::make_shared<FileVerifierCrs<Curve>>(path_, degree);
+        degree_ = degree;
+    }
     return verifier_crs_;
 }
 
 template class FileProverCrs<curve::BN254>;
 template class FileProverCrs<curve::Grumpkin>;
+template class FileCrsFactory<curve::BN254>;
+template class FileCrsFactory<curve::Grumpkin>;
 
 } // namespace barretenberg::srs::factories

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/factories/mem_crs_factory.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/factories/mem_crs_factory.cpp
@@ -30,24 +30,27 @@ class MemProverCrs : public ProverCrs<curve::BN254> {
     std::shared_ptr<g1::affine_element[]> monomials_;
 };
 
-class MemVerifierCrs : public VerifierCrs {
+class MemVerifierCrs : public VerifierCrs<curve::BN254> {
   public:
     MemVerifierCrs(g2::affine_element const& g2_point)
         : g2_x(g2_point)
+        , precomputed_g2_lines(
+              static_cast<pairing::miller_lines*>(aligned_alloc(64, sizeof(barretenberg::pairing::miller_lines) * 2)))
     {
-        precomputed_g2_lines =
-            (pairing::miller_lines*)(aligned_alloc(64, sizeof(barretenberg::pairing::miller_lines) * 2));
+
         barretenberg::pairing::precompute_miller_lines(barretenberg::g2::one, precomputed_g2_lines[0]);
         barretenberg::pairing::precompute_miller_lines(g2_x, precomputed_g2_lines[1]);
     }
 
-    ~MemVerifierCrs() { aligned_free(precomputed_g2_lines); }
+    virtual ~MemVerifierCrs() { aligned_free(precomputed_g2_lines); }
 
-    g2::affine_element get_g2x() const override { return g2_x; }
+    g2::affine_element get_g2x() const { return g2_x; }
 
-    pairing::miller_lines const* get_precomputed_g2_lines() const override { return precomputed_g2_lines; }
+    pairing::miller_lines const* get_precomputed_g2_lines() const { return precomputed_g2_lines; }
+    g1::affine_element get_first_g1() const { return first_g1x; };
 
   private:
+    g1::affine_element first_g1x;
     g2::affine_element g2_x;
     pairing::miller_lines* precomputed_g2_lines;
 };
@@ -66,7 +69,7 @@ std::shared_ptr<barretenberg::srs::factories::ProverCrs<curve::BN254>> MemCrsFac
     return prover_crs_;
 }
 
-std::shared_ptr<barretenberg::srs::factories::VerifierCrs> MemCrsFactory::get_verifier_crs()
+std::shared_ptr<barretenberg::srs::factories::VerifierCrs<curve::BN254>> MemCrsFactory::get_verifier_crs(size_t)
 {
     return verifier_crs_;
 }

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/factories/mem_crs_factory.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/factories/mem_crs_factory.hpp
@@ -10,19 +10,22 @@ namespace barretenberg::srs::factories {
 
 /**
  * Create reference strings given pointers to in memory buffers.
+ *
+ * This class is currently only used with wasm and works exclusively with the BN254 CRS.
  */
-class MemCrsFactory : public CrsFactory {
+class MemCrsFactory : public CrsFactory<curve::BN254> {
   public:
     MemCrsFactory(std::vector<g1::affine_element> const& points, g2::affine_element const g2_point);
     MemCrsFactory(MemCrsFactory&& other) = default;
 
     std::shared_ptr<barretenberg::srs::factories::ProverCrs<curve::BN254>> get_prover_crs(size_t degree) override;
 
-    std::shared_ptr<barretenberg::srs::factories::VerifierCrs> get_verifier_crs() override;
+    std::shared_ptr<barretenberg::srs::factories::VerifierCrs<curve::BN254>> get_verifier_crs(
+        size_t degree = 0) override;
 
   private:
     std::shared_ptr<barretenberg::srs::factories::ProverCrs<curve::BN254>> prover_crs_;
-    std::shared_ptr<barretenberg::srs::factories::VerifierCrs> verifier_crs_;
+    std::shared_ptr<barretenberg::srs::factories::VerifierCrs<curve::BN254>> verifier_crs_;
 };
 
 } // namespace barretenberg::srs::factories

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/factories/mem_crs_factory.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/factories/mem_crs_factory.test.cpp
@@ -12,7 +12,7 @@ using namespace barretenberg::srs::factories;
 TEST(reference_string, mem_file_consistency)
 {
     // Load 1024 from file.
-    auto file_crs = FileCrsFactory("../srs_db/ignition", 1024);
+    auto file_crs = FileCrsFactory<curve::BN254>("../srs_db/ignition", 1024);
 
     // Use low level io lib to read 1024 from file.
     std::vector<g1::affine_element> points(1024);
@@ -42,4 +42,9 @@ TEST(reference_string, mem_file_consistency)
                      file_verifier_crs->get_precomputed_g2_lines(),
                      sizeof(barretenberg::pairing::miller_lines) * 2),
               0);
+}
+
+TEST(reference_string, grumpkin)
+{
+    auto file_crs = FileCrsFactory<curve::Grumpkin>("../srs_db/grumpkin");
 }

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/global_crs.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/global_crs.cpp
@@ -31,7 +31,7 @@ void init_grumpkin_crs_factory(std::string crs_path)
 std::shared_ptr<factories::CrsFactory<curve::BN254>> get_crs_factory()
 {
     if (!crs_factory) {
-        throw_or_abort("You need vto initalize the global CRS with a call to init_crs_factory(...)!");
+        throw_or_abort("You need to initalize the global CRS with a call to init_crs_factory(...)!");
     }
     return crs_factory;
 }
@@ -39,7 +39,7 @@ std::shared_ptr<factories::CrsFactory<curve::BN254>> get_crs_factory()
 std::shared_ptr<factories::CrsFactory<curve::Grumpkin>> get_grumpkin_crs_factory()
 {
     if (!grumpkin_crs_factory) {
-        throw_or_abort("You need vto initalize the global CRS with a call to init_grumpkin_crs_factory(...)!");
+        throw_or_abort("You need to initalize the global CRS with a call to init_grumpkin_crs_factory(...)!");
     }
     return grumpkin_crs_factory;
 }

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/global_crs.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/global_crs.cpp
@@ -4,26 +4,43 @@
 #include "barretenberg/common/throw_or_abort.hpp"
 
 namespace {
-std::shared_ptr<barretenberg::srs::factories::CrsFactory> crs_factory;
-}
+// TODO(#637): As a PoC we have two global variables for the two CRS but this could be improved to avoid duplication.
+std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> crs_factory;
+std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::Grumpkin>> grumpkin_crs_factory;
+} // namespace
 
 namespace barretenberg::srs {
 
+// Initialises the crs using the memory buffers
 void init_crs_factory(std::vector<g1::affine_element> const& points, g2::affine_element const g2_point)
 {
     crs_factory = std::make_shared<factories::MemCrsFactory>(points, g2_point);
 }
 
+// Initialises crs from a file path this we use in the entire codebase
 void init_crs_factory(std::string crs_path)
 {
-    crs_factory = std::make_shared<factories::FileCrsFactory>(crs_path);
+    crs_factory = std::make_shared<factories::FileCrsFactory<curve::BN254>>(crs_path);
 }
 
-std::shared_ptr<factories::CrsFactory> get_crs_factory()
+void init_grumpkin_crs_factory(std::string crs_path)
+{
+    grumpkin_crs_factory = std::make_shared<factories::FileCrsFactory<curve::Grumpkin>>(crs_path);
+}
+
+std::shared_ptr<factories::CrsFactory<curve::BN254>> get_crs_factory()
 {
     if (!crs_factory) {
-        throw_or_abort("You need to initalize the global CRS with a call to init_crs_factory(...)!");
+        throw_or_abort("You need vto initalize the global CRS with a call to init_crs_factory(...)!");
     }
     return crs_factory;
+}
+
+std::shared_ptr<factories::CrsFactory<curve::Grumpkin>> get_grumpkin_crs_factory()
+{
+    if (!grumpkin_crs_factory) {
+        throw_or_abort("You need vto initalize the global CRS with a call to init_grumpkin_crs_factory(...)!");
+    }
+    return grumpkin_crs_factory;
 }
 } // namespace barretenberg::srs

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/global_crs.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/global_crs.hpp
@@ -1,11 +1,15 @@
 #include "./factories/crs_factory.hpp"
+#include "barretenberg/ecc/curves/bn254/bn254.hpp"
+#include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 
 namespace barretenberg::srs {
-
 void init_crs_factory(std::vector<barretenberg::g1::affine_element> const& points,
                       barretenberg::g2::affine_element const g2_point);
 
 void init_crs_factory(std::string crs_path);
+void init_grumpkin_crs_factory(std::string crs_path);
 
-std::shared_ptr<barretenberg::srs::factories::CrsFactory> get_crs_factory();
+std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::BN254>> get_crs_factory();
+std::shared_ptr<barretenberg::srs::factories::CrsFactory<curve::Grumpkin>> get_grumpkin_crs_factory();
+
 } // namespace barretenberg::srs

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen.cpp
@@ -143,10 +143,10 @@ point<C> pedersen_hash<C>::hash_single_internal(const field_t& in,
 
     grumpkin::g1::element::batch_normalize(&multiplication_transcript[0], num_quads + 1);
 
-    fixed_group_init_quad init_quad{ origin_points[0].x,
-                                     (origin_points[0].x - origin_points[1].x),
-                                     origin_points[0].y,
-                                     (origin_points[0].y - origin_points[1].y) };
+    fixed_group_init_quad_<fr> init_quad{ origin_points[0].x,
+                                          (origin_points[0].x - origin_points[1].x),
+                                          origin_points[0].y,
+                                          (origin_points[0].y - origin_points[1].y) };
 
     /**
      * Fill the gates as following:
@@ -180,7 +180,7 @@ point<C> pedersen_hash<C>::hash_single_internal(const field_t& in,
     fr x_alpha = accumulator_offset;
     std::vector<uint32_t> accumulator_witnesses;
     for (size_t i = 0; i < num_quads; ++i) {
-        fixed_group_add_quad round_quad;
+        fixed_group_add_quad_<fr> round_quad;
         round_quad.d = ctx->add_variable(accumulator_transcript[i]);
         round_quad.a = ctx->add_variable(multiplication_transcript[i].x);
         round_quad.b = ctx->add_variable(multiplication_transcript[i].y);
@@ -225,17 +225,16 @@ point<C> pedersen_hash<C>::hash_single_internal(const field_t& in,
                  *        - init_quad.q_x_2 * round_quad.d
                  *        + init_quad.q_x_2
                  * */
-                mul_quad x_init_quad{ .a = round_quad.a,
-                                      .b = round_quad.c,
-                                      .c = 0,
-                                      .d = round_quad.d,
-                                      .mul_scaling = -1,
-                                      .a_scaling = 0,
-                                      .b_scaling = init_quad.q_x_1,
-                                      .c_scaling = 0,
-                                      .d_scaling = -init_quad.q_x_2,
-                                      .const_scaling = init_quad.q_x_2 };
-                ctx->create_big_mul_gate(x_init_quad);
+                ctx->create_big_mul_gate({ .a = round_quad.a,
+                                           .b = round_quad.c,
+                                           .c = 0,
+                                           .d = round_quad.d,
+                                           .mul_scaling = -1,
+                                           .a_scaling = 0,
+                                           .b_scaling = init_quad.q_x_1,
+                                           .c_scaling = 0,
+                                           .d_scaling = -init_quad.q_x_2,
+                                           .const_scaling = init_quad.q_x_2 });
             }
             gates.create_fixed_group_add_gate_with_init(round_quad, init_quad);
         };
@@ -245,15 +244,15 @@ point<C> pedersen_hash<C>::hash_single_internal(const field_t& in,
 
     // In Turbo PLONK, this effectively just adds the last row of the table as witnesses.
     // In Standard PLONK, this also creates the constraint involving the final two rows.
-    add_quad add_quad{ ctx->add_variable(multiplication_transcript[num_quads].x),
-                       ctx->add_variable(multiplication_transcript[num_quads].y),
-                       ctx->add_variable(x_alpha),
-                       ctx->add_variable(accumulator_transcript[num_quads]),
-                       fr::zero(),
-                       fr::zero(),
-                       fr::zero(),
-                       fr::zero(),
-                       fr::zero() };
+    add_quad_<fr> add_quad{ ctx->add_variable(multiplication_transcript[num_quads].x),
+                            ctx->add_variable(multiplication_transcript[num_quads].y),
+                            ctx->add_variable(x_alpha),
+                            ctx->add_variable(accumulator_transcript[num_quads]),
+                            fr::zero(),
+                            fr::zero(),
+                            fr::zero(),
+                            fr::zero(),
+                            fr::zero() };
     gates.create_fixed_group_add_gate_final(add_quad);
     accumulator_witnesses.push_back(add_quad.d);
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen_gates.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen_gates.hpp
@@ -22,9 +22,10 @@ namespace stdlib {
  */
 template <typename Composer> class pedersen_gates {
   public:
-    using fixed_group_add_quad = proof_system::fixed_group_add_quad;
-    using fixed_group_init_quad = proof_system::fixed_group_init_quad;
-    using add_quad = proof_system::add_quad;
+    using FF = typename Composer::FF;
+    using fixed_group_add_quad = proof_system::fixed_group_add_quad_<FF>;
+    using fixed_group_init_quad = proof_system::fixed_group_init_quad_<FF>;
+    using add_quad = proof_system::add_quad_<FF>;
 
     Composer* context;
     fixed_group_add_quad previous_add_quad;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen_plookup.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen_plookup.cpp
@@ -67,10 +67,14 @@ point<C> pedersen_plookup_hash<C>::add_points(const point& p1, const point& p2, 
 
     point p3{ witness_t(ctx, x_3_raw), witness_t(ctx, y_3_raw) };
 
-    ecc_add_gate add_gate =
-        ecc_add_gate{ p1.x.witness_index, p1.y.witness_index, p2.x.witness_index,       p2.y.witness_index,
-                      p3.x.witness_index, p3.y.witness_index, endomorphism_coefficient, sign_coefficient };
-    ctx->create_ecc_add_gate(add_gate);
+    ctx->create_ecc_add_gate({ p1.x.witness_index,
+                               p1.y.witness_index,
+                               p2.x.witness_index,
+                               p2.y.witness_index,
+                               p3.x.witness_index,
+                               p3.y.witness_index,
+                               endomorphism_coefficient,
+                               sign_coefficient });
 
     return p3;
 }

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.cpp
@@ -150,11 +150,16 @@ bool_t<ComposerContext> bool_t<ComposerContext>::operator&(const bool_t& other) 
         fr q2(i_a * (1 - 2 * i_b));
         fr q3(-1);
         fr qc(i_a * i_b);
-
-        const poly_triple gate_coefficients{
-            witness_index, other.witness_index, result.witness_index, qm, q1, q2, q3, qc,
-        };
-        context->create_poly_gate(gate_coefficients);
+        context->create_poly_gate({
+            witness_index,
+            other.witness_index,
+            result.witness_index,
+            qm,
+            q1,
+            q2,
+            q3,
+            qc,
+        });
     } else if (witness_index != IS_CONSTANT && other.witness_index == IS_CONSTANT) {
         if (other.witness_bool ^ other.witness_inverted) {
             result = bool_t<ComposerContext>(*this);
@@ -229,11 +234,14 @@ bool_t<ComposerContext> bool_t<ComposerContext>::operator|(const bool_t& other) 
             right_coefficient = barretenberg::fr::one();
             constant_coefficient = barretenberg::fr::zero();
         }
-        const poly_triple gate_coefficients{
-            witness_index,    other.witness_index, result.witness_index,        multiplicative_coefficient,
-            left_coefficient, right_coefficient,   barretenberg::fr::neg_one(), constant_coefficient
-        };
-        context->create_poly_gate(gate_coefficients);
+        context->create_poly_gate({ witness_index,
+                                    other.witness_index,
+                                    result.witness_index,
+                                    multiplicative_coefficient,
+                                    left_coefficient,
+                                    right_coefficient,
+                                    barretenberg::fr::neg_one(),
+                                    constant_coefficient });
     } else if (witness_index != IS_CONSTANT && other.witness_index == IS_CONSTANT) {
         if (other.witness_bool ^ other.witness_inverted) {
             result.witness_index = IS_CONSTANT;
@@ -289,11 +297,14 @@ bool_t<ComposerContext> bool_t<ComposerContext>::operator^(const bool_t& other) 
             right_coefficient = barretenberg::fr::neg_one();
             constant_coefficient = barretenberg::fr::one();
         }
-        const poly_triple gate_coefficients{
-            witness_index,    other.witness_index, result.witness_index,        multiplicative_coefficient,
-            left_coefficient, right_coefficient,   barretenberg::fr::neg_one(), constant_coefficient
-        };
-        context->create_poly_gate(gate_coefficients);
+        context->create_poly_gate({ witness_index,
+                                    other.witness_index,
+                                    result.witness_index,
+                                    multiplicative_coefficient,
+                                    left_coefficient,
+                                    right_coefficient,
+                                    barretenberg::fr::neg_one(),
+                                    constant_coefficient });
     } else if (witness_index != IS_CONSTANT && other.witness_index == IS_CONSTANT) {
         // witness ^ 1 = !witness
         if (other.witness_bool ^ other.witness_inverted) {
@@ -364,11 +375,14 @@ bool_t<ComposerContext> bool_t<ComposerContext>::operator==(const bool_t& other)
             right_coefficient = barretenberg::fr::one();
             constant_coefficient = barretenberg::fr::zero();
         }
-        const poly_triple gate_coefficients{
-            witness_index,    other.witness_index, result.witness_index,        multiplicative_coefficient,
-            left_coefficient, right_coefficient,   barretenberg::fr::neg_one(), constant_coefficient
-        };
-        context->create_poly_gate(gate_coefficients);
+        context->create_poly_gate({ witness_index,
+                                    other.witness_index,
+                                    result.witness_index,
+                                    multiplicative_coefficient,
+                                    left_coefficient,
+                                    right_coefficient,
+                                    barretenberg::fr::neg_one(),
+                                    constant_coefficient });
         return result;
     }
 }
@@ -538,10 +552,7 @@ template <typename ComposerContext> bool_t<ComposerContext> bool_t<ComposerConte
     barretenberg::fr q_o = barretenberg::fr::neg_one();
     barretenberg::fr q_m = barretenberg::fr::zero();
     barretenberg::fr q_r = barretenberg::fr::zero();
-
-    const poly_triple gate_coefficients{ witness_index, witness_index, new_witness, q_m, q_l, q_r, q_o, q_c };
-
-    context->create_poly_gate(gate_coefficients);
+    context->create_poly_gate({ witness_index, witness_index, new_witness, q_m, q_l, q_r, q_o, q_c });
 
     witness_index = new_witness;
     witness_bool = new_value;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp
@@ -18,11 +18,13 @@ class Ultra;
 
 namespace barretenberg {
 class Bn254FrParams;
+class Bn254FqParams;
 template <class Params> struct alignas(32) field;
 } // namespace barretenberg
 namespace proof_system {
 template <class FF> class StandardCircuitBuilder_;
 using StandardCircuitBuilder = StandardCircuitBuilder_<barretenberg::field<barretenberg::Bn254FrParams>>;
+using StandardGrumpkinCircuitBuilder = StandardCircuitBuilder_<barretenberg::field<barretenberg::Bn254FqParams>>;
 template <class FF> class TurboCircuitBuilder_;
 using TurboCircuitBuilder = TurboCircuitBuilder_<barretenberg::field<barretenberg::Bn254FrParams>>;
 template <class FF> class UltraCircuitBuilder_;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
@@ -121,14 +121,13 @@ field_t<ComposerContext> field_t<ComposerContext>::operator+(const field_t& othe
         out += other.additive_constant;
         result.witness_index = ctx->add_variable(out);
 
-        const add_triple gate_coefficients{ witness_index,
-                                            other.witness_index,
-                                            result.witness_index,
-                                            multiplicative_constant,
-                                            other.multiplicative_constant,
-                                            barretenberg::fr::neg_one(),
-                                            (additive_constant + other.additive_constant) };
-        ctx->create_add_gate(gate_coefficients);
+        ctx->create_add_gate({ witness_index,
+                               other.witness_index,
+                               result.witness_index,
+                               multiplicative_constant,
+                               other.multiplicative_constant,
+                               barretenberg::fr::neg_one(),
+                               (additive_constant + other.additive_constant) });
     }
     return result;
 }
@@ -233,15 +232,14 @@ field_t<ComposerContext> field_t<ComposerContext>::operator*(const field_t& othe
         out += T0;
         out += q_c;
         result.witness_index = ctx->add_variable(out);
-        const poly_triple gate_coefficients{ .a = witness_index,
-                                             .b = other.witness_index,
-                                             .c = result.witness_index,
-                                             .q_m = q_m,
-                                             .q_l = q_l,
-                                             .q_r = q_r,
-                                             .q_o = barretenberg::fr::neg_one(),
-                                             .q_c = q_c };
-        ctx->create_poly_gate(gate_coefficients);
+        ctx->create_poly_gate({ .a = witness_index,
+                                .b = other.witness_index,
+                                .c = result.witness_index,
+                                .q_m = q_m,
+                                .q_l = q_l,
+                                .q_r = q_r,
+                                .q_o = barretenberg::fr::neg_one(),
+                                .q_c = q_c });
     }
     return result;
 }
@@ -289,15 +287,14 @@ field_t<ComposerContext> field_t<ComposerContext>::divide_no_zero_check(const fi
             barretenberg::fr q_c = -get_value();
             barretenberg::fr out_value = get_value() / other.get_value();
             result.witness_index = ctx->add_variable(out_value);
-            const poly_triple gate_coefficients{ .a = result.witness_index,
-                                                 .b = other.witness_index,
-                                                 .c = result.witness_index,
-                                                 .q_m = q_m,
-                                                 .q_l = q_l,
-                                                 .q_r = 0,
-                                                 .q_o = 0,
-                                                 .q_c = q_c };
-            ctx->create_poly_gate(gate_coefficients);
+            ctx->create_poly_gate({ .a = result.witness_index,
+                                    .b = other.witness_index,
+                                    .c = result.witness_index,
+                                    .q_m = q_m,
+                                    .q_l = q_l,
+                                    .q_r = 0,
+                                    .q_o = 0,
+                                    .q_c = q_c });
         }
     } else {
         // TODO SHOULD WE CARE ABOUT IF THE DIVISOR IS ZERO?
@@ -335,15 +332,14 @@ field_t<ComposerContext> field_t<ComposerContext>::divide_no_zero_check(const fi
         barretenberg::fr q_o = -multiplicative_constant;
         barretenberg::fr q_c = -additive_constant;
 
-        const poly_triple gate_coefficients{ .a = result.witness_index,
-                                             .b = other.witness_index,
-                                             .c = witness_index,
-                                             .q_m = q_m,
-                                             .q_l = q_l,
-                                             .q_r = q_r,
-                                             .q_o = q_o,
-                                             .q_c = q_c };
-        ctx->create_poly_gate(gate_coefficients);
+        ctx->create_poly_gate({ .a = result.witness_index,
+                                .b = other.witness_index,
+                                .c = witness_index,
+                                .q_m = q_m,
+                                .q_l = q_l,
+                                .q_r = q_r,
+                                .q_o = q_o,
+                                .q_c = q_c });
     }
     return result;
 }
@@ -439,8 +435,7 @@ field_t<ComposerContext> field_t<ComposerContext>::madd(const field_t& to_mul, c
 
     field_t<ComposerContext> result(ctx);
     result.witness_index = ctx->add_variable(out);
-
-    const mul_quad gate_coefficients{
+    ctx->create_big_mul_gate({
         .a = witness_index == IS_CONSTANT ? ctx->zero_idx : witness_index,
         .b = to_mul.witness_index == IS_CONSTANT ? ctx->zero_idx : to_mul.witness_index,
         .c = to_add.witness_index == IS_CONSTANT ? ctx->zero_idx : to_add.witness_index,
@@ -451,8 +446,7 @@ field_t<ComposerContext> field_t<ComposerContext>::madd(const field_t& to_mul, c
         .c_scaling = q_3,
         .d_scaling = -barretenberg::fr(1),
         .const_scaling = q_c,
-    };
-    ctx->create_big_mul_gate(gate_coefficients);
+    });
     return result;
 }
 
@@ -481,7 +475,7 @@ field_t<ComposerContext> field_t<ComposerContext>::add_two(const field_t& add_a,
     field_t<ComposerContext> result(ctx);
     result.witness_index = ctx->add_variable(out);
 
-    const mul_quad gate_coefficients{
+    ctx->create_big_mul_gate({
         .a = witness_index == IS_CONSTANT ? ctx->zero_idx : witness_index,
         .b = add_a.witness_index == IS_CONSTANT ? ctx->zero_idx : add_a.witness_index,
         .c = add_b.witness_index == IS_CONSTANT ? ctx->zero_idx : add_b.witness_index,
@@ -492,8 +486,7 @@ field_t<ComposerContext> field_t<ComposerContext>::add_two(const field_t& add_a,
         .c_scaling = q_3,
         .d_scaling = -barretenberg::fr(1),
         .const_scaling = q_c,
-    };
-    ctx->create_big_mul_gate(gate_coefficients);
+    });
     return result;
 }
 
@@ -523,15 +516,13 @@ template <typename ComposerContext> field_t<ComposerContext> field_t<ComposerCon
     // <=> this.v * this.v * [ 0 ] + this.v * [this.mul] + this.v * [ 0 ] + result.v * [ -1] + [this.add] == 0
     // <=> this.v * this.v * [q_m] + this.v * [   q_l  ] + this.v * [q_r] + result.v * [q_o] + [   q_c  ] == 0
 
-    const add_triple gate_coefficients{ .a = witness_index,
-                                        .b = witness_index,
-                                        .c = result.witness_index,
-                                        .a_scaling = multiplicative_constant,
-                                        .b_scaling = 0,
-                                        .c_scaling = barretenberg::fr::neg_one(),
-                                        .const_scaling = additive_constant };
-
-    context->create_add_gate(gate_coefficients);
+    context->create_add_gate({ .a = witness_index,
+                               .b = witness_index,
+                               .c = result.witness_index,
+                               .a_scaling = multiplicative_constant,
+                               .b_scaling = 0,
+                               .c_scaling = barretenberg::fr::neg_one(),
+                               .const_scaling = additive_constant });
     return result;
 }
 
@@ -552,7 +543,8 @@ template <typename ComposerContext> void field_t<ComposerContext>::assert_is_zer
     // this.v * 0 * [q_m] + this.v * [   q_l  ] + 0 * [q_r] + 0 * [q_o] + [   q_c  ] == 0
 
     ComposerContext* ctx = context;
-    const poly_triple gate_coefficients{
+
+    context->create_poly_gate({
         .a = witness_index,
         .b = ctx->zero_idx,
         .c = ctx->zero_idx,
@@ -561,8 +553,7 @@ template <typename ComposerContext> void field_t<ComposerContext>::assert_is_zer
         .q_r = barretenberg::fr(0),
         .q_o = barretenberg::fr(0),
         .q_c = additive_constant,
-    };
-    context->create_poly_gate(gate_coefficients);
+    });
 }
 
 template <typename ComposerContext> void field_t<ComposerContext>::assert_is_not_zero(std::string const& msg) const
@@ -593,7 +584,7 @@ template <typename ComposerContext> void field_t<ComposerContext>::assert_is_not
     // <=> this.v * inverse.v * [   q_m  ] + this.v * [q_l] + inverse.v * [   q_r  ] + 0 * [q_o] + [q_c] == 0
 
     // (a * mul_const + add_const) * b - 1 = 0
-    const poly_triple gate_coefficients{
+    context->create_poly_gate({
         .a = witness_index,             // input value
         .b = inverse.witness_index,     // inverse
         .c = ctx->zero_idx,             // no output
@@ -602,8 +593,7 @@ template <typename ComposerContext> void field_t<ComposerContext>::assert_is_not
         .q_r = additive_constant,       // b * mul_const
         .q_o = barretenberg::fr(0),     // c * 0
         .q_c = barretenberg::fr(-1),    // -1
-    };
-    context->create_poly_gate(gate_coefficients);
+    });
 }
 
 template <typename ComposerContext> bool_t<ComposerContext> field_t<ComposerContext>::is_zero() const
@@ -641,28 +631,28 @@ template <typename ComposerContext> bool_t<ComposerContext> field_t<ComposerCont
     barretenberg::fr q_r = barretenberg::fr::zero();
     barretenberg::fr q_o = barretenberg::fr::one();
     barretenberg::fr q_c = barretenberg::fr::neg_one();
-    const poly_triple gate_coefficients_a{ .a = k.witness_index,
-                                           .b = k_inverse.witness_index,
-                                           .c = is_zero.witness_index,
-                                           .q_m = q_m,
-                                           .q_l = q_l,
-                                           .q_r = q_r,
-                                           .q_o = q_o,
-                                           .q_c = q_c };
-    context->create_poly_gate(gate_coefficients_a);
+
+    context->create_poly_gate({ .a = k.witness_index,
+                                .b = k_inverse.witness_index,
+                                .c = is_zero.witness_index,
+                                .q_m = q_m,
+                                .q_l = q_l,
+                                .q_r = q_r,
+                                .q_o = q_o,
+                                .q_c = q_c });
 
     // is_zero * k_inverse - is_zero = 0
     q_o = barretenberg::fr::neg_one();
     q_c = barretenberg::fr::zero();
-    const poly_triple gate_coefficients_b{ .a = is_zero.witness_index,
-                                           .b = k_inverse.witness_index,
-                                           .c = is_zero.witness_index,
-                                           .q_m = q_m,
-                                           .q_l = q_l,
-                                           .q_r = q_r,
-                                           .q_o = q_o,
-                                           .q_c = q_c };
-    context->create_poly_gate(gate_coefficients_b);
+
+    context->create_poly_gate({ .a = is_zero.witness_index,
+                                .b = k_inverse.witness_index,
+                                .c = is_zero.witness_index,
+                                .q_m = q_m,
+                                .q_l = q_l,
+                                .q_r = q_r,
+                                .q_o = q_o,
+                                .q_c = q_c });
     return is_zero;
 }
 
@@ -897,7 +887,7 @@ void field_t<ComposerContext>::evaluate_linear_identity(const field_t& a,
     barretenberg::fr q_4 = d.multiplicative_constant;
     barretenberg::fr q_c = a.additive_constant + b.additive_constant + c.additive_constant + d.additive_constant;
 
-    const add_quad gate_coefficients{
+    ctx->create_big_add_gate({
         a.witness_index == IS_CONSTANT ? ctx->zero_idx : a.witness_index,
         b.witness_index == IS_CONSTANT ? ctx->zero_idx : b.witness_index,
         c.witness_index == IS_CONSTANT ? ctx->zero_idx : c.witness_index,
@@ -907,8 +897,7 @@ void field_t<ComposerContext>::evaluate_linear_identity(const field_t& a,
         q_3,
         q_4,
         q_c,
-    };
-    ctx->create_big_add_gate(gate_coefficients);
+    });
 }
 
 template <typename ComposerContext>
@@ -934,7 +923,7 @@ void field_t<ComposerContext>::evaluate_polynomial_identity(const field_t& a,
     barretenberg::fr q_4 = d.multiplicative_constant;
     barretenberg::fr q_c = a.additive_constant * b.additive_constant + c.additive_constant + d.additive_constant;
 
-    const mul_quad gate_coefficients{
+    ctx->create_big_mul_gate({
         a.witness_index == IS_CONSTANT ? ctx->zero_idx : a.witness_index,
         b.witness_index == IS_CONSTANT ? ctx->zero_idx : b.witness_index,
         c.witness_index == IS_CONSTANT ? ctx->zero_idx : c.witness_index,
@@ -945,8 +934,7 @@ void field_t<ComposerContext>::evaluate_polynomial_identity(const field_t& a,
         q_3,
         q_4,
         q_c,
-    };
-    ctx->create_big_mul_gate(gate_coefficients);
+    });
 }
 
 /**

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
@@ -138,27 +138,25 @@ template <typename Composer> class stdlib_field : public testing::Test {
                  */
                 if (true_when_y_val_zero) {
                     // constraint: 0*x + 1*y + 0*0 + 0 == 0
-                    add_triple t{ .a = x.witness_index,
-                                  .b = y.witness_index,
-                                  .c = composer.zero_idx,
-                                  .a_scaling = 0,
-                                  .b_scaling = 1,
-                                  .c_scaling = 0,
-                                  .const_scaling = 0 };
 
-                    composer.create_add_gate(t);
+                    composer.create_add_gate({ .a = x.witness_index,
+                                               .b = y.witness_index,
+                                               .c = composer.zero_idx,
+                                               .a_scaling = 0,
+                                               .b_scaling = 1,
+                                               .c_scaling = 0,
+                                               .const_scaling = 0 });
                     expected_result = false;
                 } else {
                     // constraint: 0*x + 1*y + 0*0 - 1 == 0
-                    add_triple t{ .a = x.witness_index,
-                                  .b = y.witness_index,
-                                  .c = composer.zero_idx,
-                                  .a_scaling = 0,
-                                  .b_scaling = 1,
-                                  .c_scaling = 0,
-                                  .const_scaling = -1 };
 
-                    composer.create_add_gate(t);
+                    composer.create_add_gate({ .a = x.witness_index,
+                                               .b = y.witness_index,
+                                               .c = composer.zero_idx,
+                                               .a_scaling = 0,
+                                               .b_scaling = 1,
+                                               .c_scaling = 0,
+                                               .const_scaling = -1 });
                     expected_result = true;
                 }
             }

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/group.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/group.hpp
@@ -153,16 +153,16 @@ auto group<ComposerContext>::fixed_base_scalar_mul_internal(const field_t<Compos
 
     grumpkin::g1::element::batch_normalize(&multiplication_transcript[0], num_quads + 1);
 
-    fixed_group_init_quad init_quad{ origin_points[0].x,
-                                     (origin_points[0].x - origin_points[1].x),
-                                     origin_points[0].y,
-                                     (origin_points[0].y - origin_points[1].y) };
+    fixed_group_init_quad_<typename ComposerContext::FF> init_quad{ origin_points[0].x,
+                                                                    (origin_points[0].x - origin_points[1].x),
+                                                                    origin_points[0].y,
+                                                                    (origin_points[0].y - origin_points[1].y) };
 
     fr x_alpha = accumulator_offset;
     std::vector<uint32_t> accumulator_witnesses;
     pedersen_gates<ComposerContext> pedersen_gates(ctx);
     for (size_t i = 0; i < num_quads; ++i) {
-        fixed_group_add_quad round_quad;
+        fixed_group_add_quad_<typename ComposerContext::FF> round_quad;
         round_quad.d = ctx->add_variable(accumulator_transcript[i]);
         round_quad.a = ctx->add_variable(multiplication_transcript[i].x);
         round_quad.b = ctx->add_variable(multiplication_transcript[i].y);
@@ -193,15 +193,15 @@ auto group<ComposerContext>::fixed_base_scalar_mul_internal(const field_t<Compos
         accumulator_witnesses.push_back(round_quad.d);
     }
 
-    add_quad add_quad{ ctx->add_variable(multiplication_transcript[num_quads].x),
-                       ctx->add_variable(multiplication_transcript[num_quads].y),
-                       ctx->add_variable(x_alpha),
-                       ctx->add_variable(accumulator_transcript[num_quads]),
-                       fr::zero(),
-                       fr::zero(),
-                       fr::zero(),
-                       fr::zero(),
-                       fr::zero() };
+    add_quad_<typename ComposerContext::FF> add_quad{ ctx->add_variable(multiplication_transcript[num_quads].x),
+                                                      ctx->add_variable(multiplication_transcript[num_quads].y),
+                                                      ctx->add_variable(x_alpha),
+                                                      ctx->add_variable(accumulator_transcript[num_quads]),
+                                                      fr::zero(),
+                                                      fr::zero(),
+                                                      fr::zero(),
+                                                      fr::zero(),
+                                                      fr::zero() };
     ctx->create_big_add_gate(add_quad);
     accumulator_witnesses.push_back(add_quad.d);
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
@@ -80,7 +80,7 @@ uint<Composer, Native> uint<Composer, Native>::operator+(const uint& other) cons
      * is {0, 1, 2}.
      **/
 
-    const add_quad gate{
+    const add_quad_<typename Composer::FF> gate{
         .a = witness_index,
         .b = other.witness_index,
         .c = ctx->add_variable(remainder),
@@ -161,7 +161,7 @@ uint<Composer, Native> uint<Composer, Native>::operator-(const uint& other) cons
     //   witness - other_witness - remainder - 2**width . overflow + (2**width + constant_term) == 0
     // and
     //   overflow in {0, 1, 2}
-    const add_quad gate{
+    const add_quad_<typename Composer::FF> gate{
         .a = lhs_idx,
         .b = rhs_idx,
         .c = ctx->add_variable(remainder),
@@ -232,7 +232,7 @@ uint<Composer, Native> uint<Composer, Native>::operator*(const uint& other) cons
      *      ab + a const_b + b const_a - r - (2**width) overflow + (const_a const_b % 2**width) == 0
      */
 
-    const mul_quad gate{
+    const mul_quad_<typename Composer::FF> gate{
         .a = witness_index, // a
         .b = rhs_idx,       // b
         .c = ctx->add_variable(remainder),
@@ -344,30 +344,29 @@ std::pair<uint<Composer, Native>, uint<Composer, Native>> uint<Composer, Native>
 
     // constraint: qb + const_b q + 0 b - a + r - const_a == 0
     // i.e., a + const_a = q(b + const_b) + r
-    const mul_quad division_gate{ .a = quotient_idx,  // q
-                                  .b = divisor_idx,   // b
-                                  .c = dividend_idx,  // a
-                                  .d = remainder_idx, // r
-                                  .mul_scaling = fr::one(),
-                                  .a_scaling = other.additive_constant,
-                                  .b_scaling = fr::zero(),
-                                  .c_scaling = fr::neg_one(),
-                                  .d_scaling = fr::one(),
-                                  .const_scaling = -fr(additive_constant) };
-    ctx->create_big_mul_gate(division_gate);
+    ctx->create_big_mul_gate({ .a = quotient_idx,  // q
+                               .b = divisor_idx,   // b
+                               .c = dividend_idx,  // a
+                               .d = remainder_idx, // r
+                               .mul_scaling = fr::one(),
+                               .a_scaling = other.additive_constant,
+                               .b_scaling = fr::zero(),
+                               .c_scaling = fr::neg_one(),
+                               .d_scaling = fr::one(),
+                               .const_scaling = -fr(additive_constant) });
 
     // set delta = (b + const_b - r - 1)
     const uint256_t delta = divisor - r - 1;
     const uint32_t delta_idx = ctx->add_variable(delta);
 
     // constraint: b - r - delta + const_b - 1 == 0
-    const add_triple delta_gate{ .a = divisor_idx,
-                                 .b = remainder_idx,
-                                 .c = delta_idx,
-                                 .a_scaling = fr::one(),
-                                 .b_scaling = fr::neg_one(),
-                                 .c_scaling = fr::neg_one(),
-                                 .const_scaling = other.additive_constant + fr::neg_one() };
+    const add_triple_<typename Composer::FF> delta_gate{ .a = divisor_idx,
+                                                         .b = remainder_idx,
+                                                         .c = delta_idx,
+                                                         .a_scaling = fr::one(),
+                                                         .b_scaling = fr::neg_one(),
+                                                         .c_scaling = fr::neg_one(),
+                                                         .const_scaling = other.additive_constant + fr::neg_one() };
 
     ctx->create_add_gate(delta_gate);
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/logic.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/logic.cpp
@@ -134,7 +134,7 @@ uint<Composer, Native> uint<Composer, Native>::operator>>(const size_t shift) co
     const uint32_t left_index = shift == width - 1 ? context->zero_idx : accumulators[static_cast<size_t>(idx - 1)];
 
     // Constraint: -6.(self >> shift) + 12.a[idx-1] + 6.high bit of (a[idx] - 4.a[idx-1]) = 0.
-    const add_quad gate{
+    const add_quad_<typename Composer::FF> gate{
         .a = context->zero_idx,
         .b = context->add_variable(output),
         .c = right_index,
@@ -199,13 +199,13 @@ uint<Composer, Native> uint<Composer, Native>::operator<<(const size_t shift) co
         const uint256_t output = (get_value() << shift) & MASK; // (value * 2**shift) % 2**32
 
         // constraint: A.2**shift - A_{x-1}.2**width + (value * 2**shift) % 2**32 == 0
-        const add_triple gate{ .a = base_idx,
-                               .b = right_idx,
-                               .c = context->add_variable(output),
-                               .a_scaling = base_shift_factor,
-                               .b_scaling = -fr(right_shift_factor),
-                               .c_scaling = fr::neg_one(),
-                               .const_scaling = fr::zero() };
+        const add_triple_<typename Composer::FF> gate{ .a = base_idx,
+                                                       .b = right_idx,
+                                                       .c = context->add_variable(output),
+                                                       .a_scaling = base_shift_factor,
+                                                       .b_scaling = -fr(right_shift_factor),
+                                                       .c_scaling = fr::neg_one(),
+                                                       .const_scaling = fr::zero() };
 
         context->create_add_gate(gate);
 
@@ -272,15 +272,15 @@ uint<Composer, Native> uint<Composer, Native>::operator<<(const size_t shift) co
      *                       + 6 * high bit of A_x - 4 A_{x-1}                                   ,
      * where A = witness and shift = s = 2x + 1 and A_{-1} = 0.
      */
-    const add_quad gate{ .a = context->add_variable(output),
-                         .b = base_index,
-                         .c = left_index,
-                         .d = right_index,
-                         .a_scaling = -q_1,
-                         .b_scaling = q_2,
-                         .c_scaling = fr::zero(),
-                         .d_scaling = -q_3,
-                         .const_scaling = fr::zero() };
+    const add_quad_<typename Composer::FF> gate{ .a = context->add_variable(output),
+                                                 .b = base_index,
+                                                 .c = left_index,
+                                                 .d = right_index,
+                                                 .a_scaling = -q_1,
+                                                 .b_scaling = q_2,
+                                                 .c_scaling = fr::zero(),
+                                                 .d_scaling = -q_3,
+                                                 .const_scaling = fr::zero() };
 
     context->create_big_add_gate_with_bit_extraction(gate);
 
@@ -344,13 +344,13 @@ uint<Composer, Native> uint<Composer, Native>::ror(const size_t target_rotation)
         const fr base_shift_factor = t1;
 
         // constraint: 4^{w-x} A + (1 - 4^w) A_pivot - out == 0
-        const add_triple gate{ .a = base_idx,
-                               .b = left_idx,
-                               .c = context->add_variable(output),
-                               .a_scaling = base_shift_factor,
-                               .b_scaling = left_shift_factor,
-                               .c_scaling = fr::neg_one(),
-                               .const_scaling = fr::zero() };
+        const add_triple_<typename Composer::FF> gate{ .a = base_idx,
+                                                       .b = left_idx,
+                                                       .c = context->add_variable(output),
+                                                       .a_scaling = base_shift_factor,
+                                                       .b_scaling = left_shift_factor,
+                                                       .c_scaling = fr::neg_one(),
+                                                       .const_scaling = fr::zero() };
 
         context->create_add_gate(gate);
 
@@ -413,15 +413,15 @@ uint<Composer, Native> uint<Composer, Native>::ror(const size_t target_rotation)
      *   -out + (2 * 4^{w-x}) A + (2 - 2 * 4^{w}) A_{w-x-1} + (1 - 4^w) a_{x-1, 1} == 0.
      *
      */
-    const add_quad gate{ .a = context->add_variable(output),
-                         .b = base_idx,
-                         .c = next_pivot_idx,
-                         .d = pivot_idx,
-                         .a_scaling = q_1,
-                         .b_scaling = q_2,
-                         .c_scaling = fr::zero(),
-                         .d_scaling = q_3,
-                         .const_scaling = fr::zero() };
+    const add_quad_<typename Composer::FF> gate{ .a = context->add_variable(output),
+                                                 .b = base_idx,
+                                                 .c = next_pivot_idx,
+                                                 .d = pivot_idx,
+                                                 .a_scaling = q_1,
+                                                 .b_scaling = q_2,
+                                                 .c_scaling = fr::zero(),
+                                                 .d_scaling = q_3,
+                                                 .const_scaling = fr::zero() };
 
     context->create_big_add_gate_with_bit_extraction(gate);
 
@@ -483,7 +483,7 @@ uint<Composer, Native> uint<Composer, Native>::logic_operator(const uint& other,
     const uint32_t lhs_idx = is_constant() ? ctx->add_variable(lhs) : witness_index;
     const uint32_t rhs_idx = other.is_constant() ? ctx->add_variable(rhs) : other.witness_index;
 
-    accumulator_triple logic_accumulators;
+    accumulator_triple_<typename Composer::FF> logic_accumulators;
 
     switch (op_type) {
     case AND: {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/arithmetic.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/arithmetic.cpp
@@ -26,7 +26,7 @@ uint_plookup<Composer, Native> uint_plookup<Composer, Native>::operator+(const u
     const uint256_t overflow = sum >> width;
     const uint256_t remainder = sum & MASK;
 
-    const add_quad gate{
+    const add_quad_<typename Composer::FF> gate{
         is_constant() ? ctx->zero_idx : witness_index,
         other.is_constant() ? ctx->zero_idx : other.witness_index,
         ctx->add_variable(remainder),
@@ -71,7 +71,7 @@ uint_plookup<Composer, Native> uint_plookup<Composer, Native>::operator-(const u
     const uint256_t overflow = difference >> width;
     const uint256_t remainder = difference & MASK;
 
-    const add_quad gate{
+    const add_quad_<typename Composer::FF> gate{
         lhs_idx,
         rhs_idx,
         ctx->add_variable(remainder),
@@ -113,7 +113,7 @@ uint_plookup<Composer, Native> uint_plookup<Composer, Native>::operator*(const u
     const uint256_t overflow = product >> width;
     const uint256_t remainder = product & MASK;
 
-    const mul_quad gate{
+    const mul_quad_<fr> gate{
         witness_index,
         rhs_idx,
         ctx->add_variable(remainder),
@@ -210,7 +210,7 @@ std::pair<uint_plookup<Composer, Native>, uint_plookup<Composer, Native>> uint_p
     const uint32_t quotient_idx = ctx->add_variable(q);
     const uint32_t remainder_idx = ctx->add_variable(r);
 
-    const mul_quad division_gate{
+    const mul_quad_<fr> division_gate{
         quotient_idx,            // q
         divisor_idx,             // b
         dividend_idx,            // a
@@ -228,7 +228,7 @@ std::pair<uint_plookup<Composer, Native>, uint_plookup<Composer, Native>> uint_p
     const uint256_t delta = divisor - r;
 
     const uint32_t delta_idx = ctx->add_variable(delta);
-    const add_triple delta_gate{
+    const add_triple_<fr> delta_gate{
         divisor_idx,             // b
         remainder_idx,           // r
         delta_idx,               // d

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/arithmetic.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/arithmetic.cpp
@@ -10,6 +10,7 @@ namespace stdlib {
 template <typename Composer, typename Native>
 uint_plookup<Composer, Native> uint_plookup<Composer, Native>::operator+(const uint_plookup& other) const
 {
+
     ASSERT(context == other.context || (context != nullptr && other.context == nullptr) ||
            (context == nullptr && other.context != nullptr));
     Composer* ctx = (context == nullptr) ? other.context : context;
@@ -26,15 +27,15 @@ uint_plookup<Composer, Native> uint_plookup<Composer, Native>::operator+(const u
     const uint256_t overflow = sum >> width;
     const uint256_t remainder = sum & MASK;
 
-    const add_quad_<typename Composer::FF> gate{
+    const add_quad_<FF> gate{
         is_constant() ? ctx->zero_idx : witness_index,
         other.is_constant() ? ctx->zero_idx : other.witness_index,
         ctx->add_variable(remainder),
         ctx->add_variable(overflow),
-        fr::one(),
-        fr::one(),
-        fr::neg_one(),
-        -fr(CIRCUIT_UINT_MAX_PLUS_ONE),
+        FF::one(),
+        FF::one(),
+        FF::neg_one(),
+        -FF(CIRCUIT_UINT_MAX_PLUS_ONE),
         constants,
     };
 
@@ -50,6 +51,7 @@ uint_plookup<Composer, Native> uint_plookup<Composer, Native>::operator+(const u
 template <typename Composer, typename Native>
 uint_plookup<Composer, Native> uint_plookup<Composer, Native>::operator-(const uint_plookup& other) const
 {
+
     ASSERT(context == other.context || (context != nullptr && other.context == nullptr) ||
            (context == nullptr && other.context != nullptr));
 
@@ -71,15 +73,15 @@ uint_plookup<Composer, Native> uint_plookup<Composer, Native>::operator-(const u
     const uint256_t overflow = difference >> width;
     const uint256_t remainder = difference & MASK;
 
-    const add_quad_<typename Composer::FF> gate{
+    const add_quad_<FF> gate{
         lhs_idx,
         rhs_idx,
         ctx->add_variable(remainder),
         ctx->add_variable(overflow),
-        fr::one(),
-        fr::neg_one(),
-        fr::neg_one(),
-        -fr(CIRCUIT_UINT_MAX_PLUS_ONE),
+        FF::one(),
+        FF::neg_one(),
+        FF::neg_one(),
+        -FF(CIRCUIT_UINT_MAX_PLUS_ONE),
         CIRCUIT_UINT_MAX_PLUS_ONE + constant_term,
     };
 
@@ -95,6 +97,7 @@ uint_plookup<Composer, Native> uint_plookup<Composer, Native>::operator-(const u
 template <typename Composer, typename Native>
 uint_plookup<Composer, Native> uint_plookup<Composer, Native>::operator*(const uint_plookup& other) const
 {
+
     Composer* ctx = (context == nullptr) ? other.context : context;
 
     if (is_constant() && other.is_constant()) {
@@ -113,16 +116,16 @@ uint_plookup<Composer, Native> uint_plookup<Composer, Native>::operator*(const u
     const uint256_t overflow = product >> width;
     const uint256_t remainder = product & MASK;
 
-    const mul_quad_<fr> gate{
+    const mul_quad_<FF> gate{
         witness_index,
         rhs_idx,
         ctx->add_variable(remainder),
         ctx->add_variable(overflow),
-        fr::one(),
+        FF::one(),
         other.additive_constant,
         additive_constant,
-        fr::neg_one(),
-        -fr(CIRCUIT_UINT_MAX_PLUS_ONE),
+        FF::neg_one(),
+        -FF(CIRCUIT_UINT_MAX_PLUS_ONE),
         0,
     };
 
@@ -180,12 +183,12 @@ std::pair<uint_plookup<Composer, Native>, uint_plookup<Composer, Native>> uint_p
     // We want to force the divisor to be non-zero, as this is an error state
     if (other.is_constant() && other.get_value() == 0) {
         // TODO: should have an actual error handler!
-        const uint32_t one = ctx->add_variable(fr::one());
-        ctx->assert_equal_constant(one, fr::zero());
+        const uint32_t one = ctx->add_variable(FF::one());
+        ctx->assert_equal_constant(one, FF::zero());
         ctx->failure("plookup_arithmetic: divide by zero!");
     } else if (!other.is_constant()) {
         const bool_t<Composer> is_divisor_zero = field_t<Composer>(other).is_zero();
-        ctx->assert_equal_constant(is_divisor_zero.witness_index, fr::zero(), "plookup_arithmetic: divide by zero!");
+        ctx->assert_equal_constant(is_divisor_zero.witness_index, FF::zero(), "plookup_arithmetic: divide by zero!");
     }
 
     if (is_constant() && other.is_constant()) {
@@ -210,17 +213,17 @@ std::pair<uint_plookup<Composer, Native>, uint_plookup<Composer, Native>> uint_p
     const uint32_t quotient_idx = ctx->add_variable(q);
     const uint32_t remainder_idx = ctx->add_variable(r);
 
-    const mul_quad_<fr> division_gate{
+    const mul_quad_<FF> division_gate{
         quotient_idx,            // q
         divisor_idx,             // b
         dividend_idx,            // a
         remainder_idx,           // r
-        fr::one(),               // q_m.w_1.w_2 = q.b
+        FF::one(),               // q_m.w_1.w_2 = q.b
         other.additive_constant, // q_l.w_1 = q.b if b const
-        fr::zero(),              // q_2.w_2 = 0
-        fr::neg_one(),           // q_3.w_3 = -a
-        fr::one(),               // q_4.w_4 = r
-        -fr(additive_constant)   // q_c = -a if a const
+        FF::zero(),              // q_2.w_2 = 0
+        FF::neg_one(),           // q_3.w_3 = -a
+        FF::one(),               // q_4.w_4 = r
+        -FF(additive_constant)   // q_c = -a if a const
     };
     ctx->create_big_mul_gate(division_gate);
 
@@ -228,13 +231,13 @@ std::pair<uint_plookup<Composer, Native>, uint_plookup<Composer, Native>> uint_p
     const uint256_t delta = divisor - r;
 
     const uint32_t delta_idx = ctx->add_variable(delta);
-    const add_triple_<fr> delta_gate{
+    const add_triple_<FF> delta_gate{
         divisor_idx,             // b
         remainder_idx,           // r
         delta_idx,               // d
-        fr::one(),               // q_l = 1
-        fr::neg_one(),           // q_r = -1
-        fr::neg_one(),           // q_o = -1
+        FF::one(),               // q_l = 1
+        FF::neg_one(),           // q_r = -1
+        FF::neg_one(),           // q_o = -1
         other.additive_constant, // q_c = d if const
     };
     ctx->create_add_gate(delta_gate);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/uint.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/uint.hpp
@@ -10,6 +10,7 @@ namespace stdlib {
 
 template <typename Composer, typename Native> class uint_plookup {
   public:
+    using FF = typename Composer::FF;
     static constexpr size_t width = sizeof(Native) * 8;
 
     uint_plookup(const witness_t<Composer>& other);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
@@ -215,15 +215,15 @@ template <typename Composer, typename Native> uint<Composer, Native> uint<Compos
         const uint256_t value = get_unbounded_value();
         const uint256_t overflow = value >> width;
         const uint256_t remainder = value & MASK;
-        const add_quad gate{ .a = witness_index,
-                             .b = context->zero_idx,
-                             .c = context->add_variable(remainder),
-                             .d = context->add_variable(overflow),
-                             .a_scaling = fr::one(),
-                             .b_scaling = fr::zero(),
-                             .c_scaling = fr::neg_one(),
-                             .d_scaling = -fr(CIRCUIT_UINT_MAX_PLUS_ONE),
-                             .const_scaling = (additive_constant & MASK) };
+        const add_quad_<typename Composer::FF> gate{ .a = witness_index,
+                                                     .b = context->zero_idx,
+                                                     .c = context->add_variable(remainder),
+                                                     .d = context->add_variable(overflow),
+                                                     .a_scaling = fr::one(),
+                                                     .b_scaling = fr::zero(),
+                                                     .c_scaling = fr::neg_one(),
+                                                     .d_scaling = -fr(CIRCUIT_UINT_MAX_PLUS_ONE),
+                                                     .const_scaling = (additive_constant & MASK) };
 
         context->create_balanced_add_gate(gate);
 
@@ -323,7 +323,7 @@ template <typename Composer, typename Native> bool_t<Composer> uint<Composer, Na
         // difference in quads = 0, 1, 2, 3 = delta
         // (delta - lo_bit) / 2 \in [0, 1]
         // lo_bit \in [0, 1]
-        add_quad gate{
+        add_quad_<typename Composer::FF> gate{
             context->add_variable(lo_bit), context->add_variable(hi_bit), right_idx, left_idx, 1, 2, -1, 4, 0,
         };
         context->create_new_range_constraint(gate.a, 1);
@@ -352,15 +352,15 @@ template <typename Composer, typename Native> bool_t<Composer> uint<Composer, Na
     if ((bit_index & 1UL) == 0UL) {
         // we want a low bit
         uint256_t lo_bit = quad & 1;
-        add_quad gate{ .a = context->add_variable(lo_bit),
-                       .b = context->zero_idx,
-                       .c = right_idx,
-                       .d = left_idx,
-                       .a_scaling = fr(3),
-                       .b_scaling = fr::zero(),
-                       .c_scaling = -fr(3),
-                       .d_scaling = fr(12),
-                       .const_scaling = fr::zero() };
+        add_quad_<typename Composer::FF> gate{ .a = context->add_variable(lo_bit),
+                                               .b = context->zero_idx,
+                                               .c = right_idx,
+                                               .d = left_idx,
+                                               .a_scaling = fr(3),
+                                               .b_scaling = fr::zero(),
+                                               .c_scaling = -fr(3),
+                                               .d_scaling = fr(12),
+                                               .const_scaling = fr::zero() };
         /** constraint:
          *    3 lo_bit + 0 * 0 - 3 a_pivot + 12 a_{pivot - 1} + 0 + 6 high bit of (A_pivot - 4 A_{pivot - 1}) == 0
          *  i.e.,
@@ -376,15 +376,15 @@ template <typename Composer, typename Native> bool_t<Composer> uint<Composer, Na
     // if 'index' is odd, we want a high bit
     uint256_t hi_bit = quad >> 1;
 
-    add_quad gate{ .a = context->zero_idx,
-                   .b = context->add_variable(hi_bit),
-                   .c = right_idx,
-                   .d = left_idx,
-                   .a_scaling = fr::zero(),
-                   .b_scaling = -fr(6),
-                   .c_scaling = fr::zero(),
-                   .d_scaling = fr::zero(),
-                   .const_scaling = fr::zero() };
+    add_quad_<typename Composer::FF> gate{ .a = context->zero_idx,
+                                           .b = context->add_variable(hi_bit),
+                                           .c = right_idx,
+                                           .d = left_idx,
+                                           .a_scaling = fr::zero(),
+                                           .b_scaling = -fr(6),
+                                           .c_scaling = fr::zero(),
+                                           .d_scaling = fr::zero(),
+                                           .const_scaling = fr::zero() };
 
     /**
      * constraint:

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.test.cpp
@@ -1129,17 +1129,16 @@ template <typename Composer> class stdlib_uint : public testing::Test {
 
         // constraint: qb + const_b q + 0 b - a + r - const_a == 0
         // i.e., a + const_a = q(b + const_b) + r
-        const mul_quad division_gate{ .a = quotient_idx,  // q
-                                      .b = divisor_idx,   // b
-                                      .c = dividend_idx,  // a
-                                      .d = remainder_idx, // r
-                                      .mul_scaling = fr::one(),
-                                      .a_scaling = b.get_additive_constant(),
-                                      .b_scaling = fr::zero(),
-                                      .c_scaling = fr::neg_one(),
-                                      .d_scaling = fr::one(),
-                                      .const_scaling = -a.get_additive_constant() };
-        composer.create_big_mul_gate(division_gate);
+        composer.create_big_mul_gate({ .a = quotient_idx,  // q
+                                       .b = divisor_idx,   // b
+                                       .c = dividend_idx,  // a
+                                       .d = remainder_idx, // r
+                                       .mul_scaling = fr::one(),
+                                       .a_scaling = b.get_additive_constant(),
+                                       .b_scaling = fr::zero(),
+                                       .c_scaling = fr::neg_one(),
+                                       .d_scaling = fr::one(),
+                                       .const_scaling = -a.get_additive_constant() });
 
         // set delta = (b + const_b - r)
 
@@ -1147,7 +1146,7 @@ template <typename Composer> class stdlib_uint : public testing::Test {
         const uint256_t delta = divisor - r - 1;
         const uint32_t delta_idx = composer.add_variable(delta);
 
-        const add_triple delta_gate{
+        composer.create_add_gate({
             .a = divisor_idx,   // b
             .b = remainder_idx, // r
             .c = delta_idx,     // d
@@ -1155,9 +1154,7 @@ template <typename Composer> class stdlib_uint : public testing::Test {
             .b_scaling = fr::neg_one(),
             .c_scaling = fr::neg_one(),
             .const_scaling = b.get_additive_constant(),
-        };
-
-        composer.create_add_gate(delta_gate);
+        });
 
         // validate delta is in the correct range
         stdlib::field_t<Composer>::from_witness_index(&composer, delta_idx)

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
@@ -444,7 +444,7 @@ template <typename Curve> struct verification_key {
 
     // Native data:
 
-    std::shared_ptr<barretenberg::srs::factories::VerifierCrs> reference_string;
+    std::shared_ptr<barretenberg::srs::factories::VerifierCrs<curve::BN254>> reference_string;
 
     PolynomialManifest polynomial_manifest;
     // Used to check in the circuit if a proof contains any aggregated state.

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.test.cpp
@@ -57,7 +57,7 @@ TYPED_TEST(VerificationKeyFixture, vk_data_vs_recursion_compress_native)
     verification_key_data vk_data = TestFixture::rand_vk_data();
     verification_key_data vk_data_copy = vk_data;
 
-    auto file_crs = std::make_unique<barretenberg::srs::factories::FileCrsFactory>("../srs_db/ignition");
+    auto file_crs = std::make_unique<barretenberg::srs::factories::FileCrsFactory<curve::BN254>>("../srs_db/ignition");
     auto file_verifier = file_crs->get_verifier_crs();
 
     auto native_vk = std::make_shared<verification_key>(std::move(vk_data_copy), file_verifier);
@@ -77,7 +77,7 @@ TYPED_TEST(VerificationKeyFixture, compress_vs_compress_native)
 
     verification_key_data vk_data = TestFixture::rand_vk_data();
 
-    auto file_crs = std::make_unique<barretenberg::srs::factories::FileCrsFactory>("../srs_db/ignition");
+    auto file_crs = std::make_unique<barretenberg::srs::factories::FileCrsFactory<curve::BN254>>("../srs_db/ignition");
     auto file_verifier = file_crs->get_verifier_crs();
 
     auto native_vk = std::make_shared<verification_key>(std::move(vk_data), file_verifier);


### PR DESCRIPTION
# Description

This PR provides an initial solution for having a complete grumpkin flavor in standard honk and contains the following modifications:
* the `FileCrsFactory` now has functionality to produce CRSes for both curves (with their key differences) and I addressed any dependent changes in the codebase
* the PCSes are now curve agnostic, having the curve set by their parameters and missing tests were added (shlponk\gemini on both grumpkin and bn254 which surfaced a bug in shplonk; unit testing gemini+shplonk+ipa as only the kzg-variant was tested) 
* continued work on enabling field-agnostic gates from (https://github.com/AztecProtocol/barretenberg/issues/557, i have to link issues manually)
* to avoid divison by zero caused by inverting the root of unity in `EvaluationDomain<grumpkin::fr>` we hardcode the roots of unity to 1 given Grumpkin does not have many roots of unity.

Opens https://github.com/AztecProtocol/barretenberg/issues/635 
https://github.com/AztecProtocol/barretenberg/issues/637
https://github.com/AztecProtocol/barretenberg/issues/636, 
https://github.com/AztecProtocol/barretenberg/issues/640
for subsequent work.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
