### PR TITLE
chore: name noir repos

### DIFF
--- a/yarn-project/noir-contracts/src/contracts/child_contract/Nargo.toml
+++ b/yarn-project/noir-contracts/src/contracts/child_contract/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "child-contract"
 authors = [""]
 compiler_version = "0.1"
 

--- a/yarn-project/noir-contracts/src/contracts/easy_zk_token_contract/Nargo.toml
+++ b/yarn-project/noir-contracts/src/contracts/easy_zk_token_contract/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "easy-zk-token-contract"
 authors = [""]
 compiler_version = "0.1"
 

--- a/yarn-project/noir-contracts/src/contracts/ecdsa_account_contract/Nargo.toml
+++ b/yarn-project/noir-contracts/src/contracts/ecdsa_account_contract/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "ecdsa-account-contract"
 authors = [""]
 compiler_version = "0.1"
 

--- a/yarn-project/noir-contracts/src/contracts/lending_contract/Nargo.toml
+++ b/yarn-project/noir-contracts/src/contracts/lending_contract/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "lending-contract"
 authors = [""]
 compiler_version = "0.1"
 

--- a/yarn-project/noir-contracts/src/contracts/non_native_token_contract/Nargo.toml
+++ b/yarn-project/noir-contracts/src/contracts/non_native_token_contract/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "non-native-token-contract"
 authors = [""]
 compiler_version = "0.1"
 

--- a/yarn-project/noir-contracts/src/contracts/parent_contract/Nargo.toml
+++ b/yarn-project/noir-contracts/src/contracts/parent_contract/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "parent-contract"
 authors = [""]
 compiler_version = "0.1"
 

--- a/yarn-project/noir-contracts/src/contracts/pending_commitments_contract/Nargo.toml
+++ b/yarn-project/noir-contracts/src/contracts/pending_commitments_contract/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "pending-commitments-contract"
 authors = [""]
 compiler_version = "0.1"
 

--- a/yarn-project/noir-contracts/src/contracts/pokeable_token_contract/Nargo.toml
+++ b/yarn-project/noir-contracts/src/contracts/pokeable_token_contract/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "pokable-token-contract"
 authors = [""]
 compiler_version = "0.1"
 

--- a/yarn-project/noir-contracts/src/contracts/public_token_contract/Nargo.toml
+++ b/yarn-project/noir-contracts/src/contracts/public_token_contract/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "public-token-contract"
 authors = [""]
 compiler_version = "0.1"
 

--- a/yarn-project/noir-contracts/src/contracts/schnorr_multi_key_account_contract/Nargo.toml
+++ b/yarn-project/noir-contracts/src/contracts/schnorr_multi_key_account_contract/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "schnorr-multi-key-account-contract"
 authors = [""]
 compiler_version = "0.1"
 

--- a/yarn-project/noir-contracts/src/contracts/schnorr_single_key_account_contract/Nargo.toml
+++ b/yarn-project/noir-contracts/src/contracts/schnorr_single_key_account_contract/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "schnorr-single-key-account-contract"
 authors = [""]
 compiler_version = "0.1"
 

--- a/yarn-project/noir-contracts/src/contracts/test_contract/Nargo.toml
+++ b/yarn-project/noir-contracts/src/contracts/test_contract/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "test-contract"
 authors = [""]
 compiler_version = "0.1"
 

--- a/yarn-project/noir-contracts/src/contracts/uniswap_contract/Nargo.toml
+++ b/yarn-project/noir-contracts/src/contracts/uniswap_contract/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "uniswap-contract"
 authors = [""]
 compiler_version = "0.1"
 

--- a/yarn-project/noir-contracts/src/contracts/zk_token_contract/Nargo.toml
+++ b/yarn-project/noir-contracts/src/contracts/zk_token_contract/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "zk-token-contract"
 authors = [""]
 compiler_version = "0.1"
 

--- a/yarn-project/noir-libs/easy-private-state/Nargo.toml
+++ b/yarn-project/noir-libs/easy-private-state/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "easy-private-state"
 authors = ["aztec-labs"]
 compiler_version = "0.7.1"
 

--- a/yarn-project/noir-libs/noir-aztec/Nargo.toml
+++ b/yarn-project/noir-libs/noir-aztec/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "noir-aztec"
 authors = [""]
 compiler_version = "0.1"
 

--- a/yarn-project/noir-libs/value-note/Nargo.toml
+++ b/yarn-project/noir-libs/value-note/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "value-note"
 authors = ["aztec-labs"]
 compiler_version = "0.7.1"
 


### PR DESCRIPTION
# Description

In the latest nightly, noir libs will not compile without a name field in the package.json. This pr adds the name field to allow stuff to compile

Please provide a paragraph or two giving a summary of the change, including relevant motivation and context.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
