### PR TITLE
fix: bump e2e non contract test timeout

### DIFF
--- a/yarn-project/end-to-end/src/e2e_non_contract_account.test.ts
+++ b/yarn-project/end-to-end/src/e2e_non_contract_account.test.ts
@@ -108,5 +108,5 @@ describe('e2e_non_contract_account', () => {
     await expectBalance(recipient, initialBalance);
 
     await expectsNumOfEncryptedLogsInTheLastBlockToBe(aztecNode, 1);
-  }, 60_000);
+  }, 120_000);
 });


### PR DESCRIPTION
Two step plan:

1. I introduce this hacky test timeout bump
2. We follow up in #1322

Likely bumps are needed for now for stability, and we should watch e2e times. A profiler view would be great.