### PR TITLE
chore: add FunctionData.fromAbi for QoL 

### DIFF
--- a/yarn-project/acir-simulator/src/client/private_execution.test.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.test.ts
@@ -527,7 +527,7 @@ describe('Private Execution test suite', () => {
         abi: parentAbi,
         args,
       });
-      
+
       // Alter function data (abi) to match the manipulated oracle
       const functionData = FunctionData.fromAbi(childContractAbi);
       functionData.isInternal = isInternal;

--- a/yarn-project/acir-simulator/src/client/private_execution.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.ts
@@ -266,7 +266,7 @@ export class PrivateFunctionExecution {
     curve: Grumpkin,
   ) {
     const targetAbi = await this.context.db.getFunctionABI(targetContractAddress, targetFunctionSelector);
-    const targetFunctionData = new FunctionData(targetFunctionSelector, targetAbi.isInternal, true, false);
+    const targetFunctionData = FunctionData.fromAbi(targetAbi);
     const derivedCallContext = await this.deriveCallContext(callerContext, targetContractAddress, false, false);
     const context = this.context.extend();
 
@@ -304,7 +304,7 @@ export class PrivateFunctionExecution {
     return PublicCallRequest.from({
       args: targetArgs,
       callContext: derivedCallContext,
-      functionData: new FunctionData(targetFunctionSelector, targetAbi.isInternal, false, false),
+      functionData: FunctionData.fromAbi(targetAbi),
       contractAddress: targetContractAddress,
     });
   }

--- a/yarn-project/acir-simulator/src/client/private_execution.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.ts
@@ -267,7 +267,6 @@ export class PrivateFunctionExecution {
   ) {
     const targetAbi = await this.context.db.getFunctionABI(targetContractAddress, targetFunctionSelector);
     const targetFunctionData = FunctionData.fromAbi(targetAbi);
-    console.log(`callPrivateFunction `, targetFunctionData);
     const derivedCallContext = await this.deriveCallContext(callerContext, targetContractAddress, false, false);
     const context = this.context.extend();
 
@@ -303,7 +302,6 @@ export class PrivateFunctionExecution {
     const targetAbi = await this.context.db.getFunctionABI(targetContractAddress, targetFunctionSelector);
     const derivedCallContext = await this.deriveCallContext(callerContext, targetContractAddress, false, false);
 
-    console.log(`enqueuePublicFunctionCall() `, FunctionData.fromAbi(targetAbi));
     return PublicCallRequest.from({
       args: targetArgs,
       callContext: derivedCallContext,

--- a/yarn-project/acir-simulator/src/client/private_execution.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.ts
@@ -267,6 +267,7 @@ export class PrivateFunctionExecution {
   ) {
     const targetAbi = await this.context.db.getFunctionABI(targetContractAddress, targetFunctionSelector);
     const targetFunctionData = FunctionData.fromAbi(targetAbi);
+    console.log(`callPrivateFunction `, targetFunctionData);
     const derivedCallContext = await this.deriveCallContext(callerContext, targetContractAddress, false, false);
     const context = this.context.extend();
 
@@ -301,6 +302,8 @@ export class PrivateFunctionExecution {
   ): Promise<PublicCallRequest> {
     const targetAbi = await this.context.db.getFunctionABI(targetContractAddress, targetFunctionSelector);
     const derivedCallContext = await this.deriveCallContext(callerContext, targetContractAddress, false, false);
+
+    console.log(`enqueuePublicFunctionCall() `, FunctionData.fromAbi(targetAbi));
     return PublicCallRequest.from({
       args: targetArgs,
       callContext: derivedCallContext,

--- a/yarn-project/acir-simulator/src/public/index.test.ts
+++ b/yarn-project/acir-simulator/src/public/index.test.ts
@@ -7,9 +7,8 @@ import {
   PrivateHistoricTreeRoots,
 } from '@aztec/circuits.js';
 import { pedersenPlookupCommitInputs } from '@aztec/circuits.js/barretenberg';
-import { FunctionAbi, encodeArguments } from '@aztec/foundation/abi';
+import { FunctionAbi, encodeArguments, generateFunctionSelector } from '@aztec/foundation/abi';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
-import { keccak } from '@aztec/foundation/crypto';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { toBigInt } from '@aztec/foundation/serialize';
@@ -63,7 +62,7 @@ describe('ACIR public execution simulator', () => {
       it('should run the mint function', async () => {
         const contractAddress = AztecAddress.random();
         const mintAbi = PublicTokenContractAbi.functions.find(f => f.name === 'mint')!;
-        const functionData = new FunctionData(Buffer.alloc(4), false, false, false);
+        const functionData = FunctionData.fromAbi(mintAbi);
         const args = encodeArguments(mintAbi, [140, recipient]);
 
         const callContext = CallContext.from({
@@ -192,11 +191,14 @@ describe('ACIR public execution simulator', () => {
       async isInternal => {
         const parentContractAddress = AztecAddress.random();
         const parentEntryPointFn = ParentContractAbi.functions.find(f => f.name === 'pubEntryPoint')!;
-        const parentEntryPointFnSelector = keccak(Buffer.from(parentEntryPointFn.name)).subarray(0, 4);
+        const parentEntryPointFnSelector = generateFunctionSelector(
+          parentEntryPointFn.name,
+          parentEntryPointFn.parameters,
+        );
 
         const childContractAddress = AztecAddress.random();
         const childValueFn = ChildContractAbi.functions.find(f => f.name === 'pubValue')!;
-        const childValueFnSelector = keccak(Buffer.from(childValueFn.name)).subarray(0, 4);
+        const childValueFnSelector = generateFunctionSelector(childValueFn.name, childValueFn.parameters);
 
         const initialValue = 3n;
 

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -11,7 +11,7 @@ import {
   PrivateKey,
   PublicKey,
 } from '@aztec/circuits.js';
-import { FunctionType, encodeArguments } from '@aztec/foundation/abi';
+import { encodeArguments } from '@aztec/foundation/abi';
 import { Fr } from '@aztec/foundation/fields';
 import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import {

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -385,19 +385,10 @@ export class AztecRPCServer implements AztecRPC {
       throw new Error(`Unknown function ${functionName} in contract ${contract.name}.`);
     }
 
-    const flatArgs = encodeArguments(functionDao, args);
-
-    const functionData = new FunctionData(
-      functionDao.selector,
-      functionDao.isInternal,
-      functionDao.functionType === FunctionType.SECRET,
-      false,
-    );
-
     return {
-      args: flatArgs,
+      args: encodeArguments(functionDao, args),
       from,
-      functionData,
+      functionData: FunctionData.fromAbi(functionDao),
       to,
     };
   }

--- a/yarn-project/aztec-rpc/src/contract_tree/index.ts
+++ b/yarn-project/aztec-rpc/src/contract_tree/index.ts
@@ -89,8 +89,7 @@ export class ContractTree {
     }));
     const leaves = generateFunctionLeaves(functions, wasm);
     const root = computeFunctionTreeRoot(wasm, leaves);
-    const constructorSelector = generateFunctionSelector(constructorAbi.name, constructorAbi.parameters);
-    const functionData = new FunctionData(constructorSelector, false, true, true);
+    const functionData = FunctionData.fromAbi(constructorAbi);
     const vkHash = hashVKStr(constructorAbi.verificationKey, wasm);
     const argsHash = await computeVarArgsHash(wasm, args);
     const constructorHash = hashConstructor(wasm, functionData, argsHash, vkHash);

--- a/yarn-project/aztec.js/src/account_impl/single_key_account_contract.ts
+++ b/yarn-project/aztec.js/src/account_impl/single_key_account_contract.ts
@@ -50,12 +50,11 @@ export class SingleKeyAccountContract implements AccountImplementation {
     const publicKey = await generatePublicKey(this.privateKey);
     const args = [payload, publicKey.toBuffer(), signature, this.partialContractAddress];
     const abi = this.getEntrypointAbi();
-    const selector = generateFunctionSelector(abi.name, abi.parameters);
     const packedArgs = await PackedArguments.fromArgs(encodeArguments(abi, args), wasm);
     const txRequest = TxExecutionRequest.from({
       argsHash: packedArgs.hash,
       origin: this.address,
-      functionData: new FunctionData(selector, abi.isInternal, true, false),
+      functionData: FunctionData.fromAbi(abi),
       txContext,
       packedArguments: [...callsPackedArguments, packedArgs],
     });

--- a/yarn-project/aztec.js/src/account_impl/single_key_account_contract.ts
+++ b/yarn-project/aztec.js/src/account_impl/single_key_account_contract.ts
@@ -7,7 +7,7 @@ import {
   TxContext,
 } from '@aztec/circuits.js';
 import { Signer } from '@aztec/circuits.js/barretenberg';
-import { ContractAbi, encodeArguments, generateFunctionSelector } from '@aztec/foundation/abi';
+import { ContractAbi, encodeArguments } from '@aztec/foundation/abi';
 import { ExecutionRequest, PackedArguments, TxExecutionRequest } from '@aztec/types';
 
 import partition from 'lodash.partition';

--- a/yarn-project/aztec.js/src/account_impl/stored_key_account_contract.ts
+++ b/yarn-project/aztec.js/src/account_impl/stored_key_account_contract.ts
@@ -1,6 +1,6 @@
 import { AztecAddress, CircuitsWasm, FunctionData, PrivateKey, TxContext } from '@aztec/circuits.js';
 import { Signer } from '@aztec/circuits.js/barretenberg';
-import { ContractAbi, encodeArguments, generateFunctionSelector } from '@aztec/foundation/abi';
+import { ContractAbi, encodeArguments } from '@aztec/foundation/abi';
 import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import { ExecutionRequest, PackedArguments, TxExecutionRequest } from '@aztec/types';
 

--- a/yarn-project/aztec.js/src/account_impl/stored_key_account_contract.ts
+++ b/yarn-project/aztec.js/src/account_impl/stored_key_account_contract.ts
@@ -41,12 +41,11 @@ export class StoredKeyAccountContract implements AccountImplementation {
 
     const args = [payload, signature];
     const abi = this.getEntrypointAbi();
-    const selector = generateFunctionSelector(abi.name, abi.parameters);
     const packedArgs = await PackedArguments.fromArgs(encodeArguments(abi, args), wasm);
     const txRequest = TxExecutionRequest.from({
       argsHash: packedArgs.hash,
       origin: this.address,
-      functionData: new FunctionData(selector, abi.isInternal, true, false),
+      functionData: FunctionData.fromAbi(abi),
       txContext,
       packedArguments: [...callsPackedArguments, packedArgs],
     });

--- a/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
@@ -98,16 +98,9 @@ export class ContractFunctionInteraction {
     const flatArgs = encodeArguments(this.functionDao, this.args);
     from = from ?? this.wallet.getAddress();
 
-    const functionData = new FunctionData(
-      generateFunctionSelector(this.functionDao.name, this.functionDao.parameters),
-      this.functionDao.isInternal,
-      this.functionDao.functionType === FunctionType.SECRET,
-      this.functionDao.name === 'constructor',
-    );
-
     return {
       args: flatArgs,
-      functionData,
+      functionData: FunctionData.fromAbi(this.functionDao),
       to,
       from,
     };

--- a/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
@@ -1,5 +1,5 @@
 import { AztecAddress, Fr, FunctionData, TxContext } from '@aztec/circuits.js';
-import { FunctionAbi, FunctionType, encodeArguments, generateFunctionSelector } from '@aztec/foundation/abi';
+import { FunctionAbi, FunctionType, encodeArguments } from '@aztec/foundation/abi';
 import { ExecutionRequest, Tx, TxExecutionRequest } from '@aztec/types';
 
 import { Wallet } from '../aztec_rpc_client/wallet.js';

--- a/yarn-project/circuits.js/src/contract/contract_deployment_info.ts
+++ b/yarn-project/circuits.js/src/contract/contract_deployment_info.ts
@@ -41,8 +41,7 @@ export async function getContractDeploymentInfo(
   }));
   const leaves = generateFunctionLeaves(functions, wasm);
   const functionTreeRoot = computeFunctionTreeRoot(wasm, leaves);
-  const constructorSelector = generateFunctionSelector(constructorAbi.name, constructorAbi.parameters);
-  const functionData = new FunctionData(constructorSelector, false, true, true);
+  const functionData = FunctionData.fromAbi(constructorAbi);
   const flatArgs = encodeArguments(constructorAbi, args);
   const argsHash = await computeVarArgsHash(wasm, flatArgs);
   const constructorHash = hashConstructor(wasm, functionData, argsHash, constructorVkHash.toBuffer());

--- a/yarn-project/circuits.js/src/structs/function_data.ts
+++ b/yarn-project/circuits.js/src/structs/function_data.ts
@@ -1,5 +1,7 @@
+import { FunctionAbi, FunctionType, generateFunctionSelector } from '@aztec/foundation/abi';
 import { BufferReader, deserializeUInt32, numToUInt32BE } from '@aztec/foundation/serialize';
 
+import { ContractFunctionDao } from '../index.js';
 import { serializeToBuffer } from '../utils/serialize.js';
 
 const FUNCTION_SELECTOR_LENGTH = 4;
@@ -40,6 +42,16 @@ export class FunctionData {
       this.functionSelectorBuffer = numToUInt32BE(functionSelector);
     }
   }
+
+  static fromAbi(abi: FunctionAbi | ContractFunctionDao): FunctionData {
+    return new FunctionData(
+      generateFunctionSelector(abi.name, abi.parameters),
+      abi.isInternal,
+      abi.functionType === FunctionType.SECRET,
+      abi.name === 'constructor',
+    );
+  }
+
   // For serialization, must match function_selector name in C++ and return as number
   // TODO(AD) somehow remove this cruft, probably by using a buffer selector in C++
   get functionSelector(): number {


### PR DESCRIPTION
# Description

Fixes #1223 where possible by introducing a `fromAbi` function on the `FunctionData`, note that we can also use a `ContractFunctionDao` since it consist of data from that abi.

For the public executor, we don't have the abi so we still need to populate it little differently there.  


# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
