### PR TITLE
fix: bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -36,7 +36,6 @@ fi
 
 circuits/cpp/bootstrap.sh
 l1-contracts/bootstrap.sh
-(cd yarn-project/noir-contracts && ./bootstrap.sh)
 
 if [ "$(uname)" = "Darwin" ]; then
   # works around https://github.com/AztecProtocol/aztec3-packages/issues/158
@@ -46,9 +45,22 @@ else
 fi
 nvm install
 
-# Until we push .yarn/cache, we still need to install.
 cd yarn-project
 yarn install --immutable
+
+# Build the necessary dependencies for noir contracts typegen.
+for DIR in foundation noir-compiler; do
+  echo "Building $DIR..."
+  cd $DIR
+  yarn build
+  cd ..
+done
+
+cd noir-contracts && ./bootstrap.sh
+
+# Until we push .yarn/cache, we still need to install.
+cd ../
+yarn
 # We do not need to build individual packages, yarn build will build the root tsconfig.json
 yarn build
 yarn --cwd circuits.js remake-bindings


### PR DESCRIPTION
# Description

When running bootstrap.sh from a freshly cloned repository the bootstrap fails because generating the noir contract types fails. This happens because for the typegen to succeed we need to build foundation and noir-compiler packages first. This PR fixes it.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
