### PR TITLE
fix: build-system spot request cancellation

### DIFF
--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/aggregation_state/aggregation_state.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/aggregation_state/aggregation_state.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "../../primitives/field/field.hpp"
 
+
 namespace proof_system::plonk {
 namespace stdlib {
 namespace recursion {


### PR DESCRIPTION
This was showing a red herring error when other errors occurred. Historically this sort of thing has confused people.