### PR TITLE
Fix noir ecdsa verification in acc contract.

### DIFF
--- a/yarn-project/circuits.js/src/barretenberg/crypto/ecdsa/index.ts
+++ b/yarn-project/circuits.js/src/barretenberg/crypto/ecdsa/index.ts
@@ -1,8 +1,4 @@
-import { toBufferBE } from '@aztec/foundation/bigint-buffer';
-import { numToUInt32BE } from '@aztec/foundation/serialize';
 import { IWasmModule } from '@aztec/foundation/wasm';
-
-import { secp256k1 } from '@noble/curves/secp256k1';
 
 import { CircuitsWasm, PrivateKey } from '../../../index.js';
 import { Signer } from '../index.js';
@@ -47,18 +43,10 @@ export class Ecdsa implements Signer {
     this.wasm.writeMemory(mem, msg);
     this.wasm.call('ecdsa__construct_signature', mem, msg.length, 0, 32, 64, 96);
 
-    // TODO(#913): Understand why this doesn't work
-    // const sig = new EcdsaSignature(
-    //   Buffer.from(this.wasm.getMemorySlice(32, 64)),
-    //   Buffer.from(this.wasm.getMemorySlice(64, 96)),
-    //   Buffer.from(this.wasm.getMemorySlice(96, 97)),
-    // );
-
-    const signature = secp256k1.sign(msg, privateKey.value);
     return new EcdsaSignature(
-      toBufferBE(signature.r, 32),
-      toBufferBE(signature.s, 32),
-      numToUInt32BE(signature.recovery!).subarray(3, 4),
+      Buffer.from(this.wasm.getMemorySlice(32, 64)),
+      Buffer.from(this.wasm.getMemorySlice(64, 96)),
+      Buffer.from(this.wasm.getMemorySlice(96, 97)),
     );
   }
 

--- a/yarn-project/noir-contracts/src/contracts/ecdsa_account_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/ecdsa_account_contract/src/main.nr
@@ -12,7 +12,6 @@ contract EcdsaAccount {
     use dep::aztec::abi::CallContext;
     use dep::aztec::context::Context;
     use dep::aztec::log::emit_encrypted_log;
-    use dep::aztec::oracle::debug_log;
     use dep::aztec::oracle::get_public_key::get_public_key;
     use dep::aztec::private_call_stack_item::PrivateCallStackItem;
     use dep::aztec::public_call_stack_item::PublicCallStackItem;
@@ -49,16 +48,12 @@ contract EcdsaAccount {
         let public_key = storage.public_key.get_note(&mut context);
 
         // Verify payload signature using Ethereum's signing scheme
+        // Note that noir expects the hash of the message/challenge as input to the ECDSA verification.
         let payload_bytes: [u8; entrypoint::ENTRYPOINT_PAYLOAD_SIZE_IN_BYTES] = payload.to_be_bytes();
         let challenge: [u8; 32] = std::hash::sha256(payload_bytes);
-        let verification = std::ecdsa_secp256k1::verify_signature(public_key.x, public_key.y, signature, challenge);
+        let hashed_challenge: [u8; 32] = std::hash::sha256(challenge);
+        let verification = std::ecdsa_secp256k1::verify_signature(public_key.x, public_key.y, signature, hashed_challenge);
         assert(verification == true);
-
-        // debug_log::debug_log_format("Verification result is {0}", [verification as Field]);
-        // debug_log::debug_log_array_with_prefix("public_key.x", public_key.x);
-        // debug_log::debug_log_array_with_prefix("public_key.y", public_key.y);
-        // debug_log::debug_log_array_with_prefix("challenge", challenge);
-        // debug_log::debug_log_array_with_prefix("signature", signature);
 
         payload.execute_calls(&mut context);
 


### PR DESCRIPTION
# Description

resolves #913 

Detailed hackmd: https://hackmd.io/9QRzytElQE2sMLf4S7qR1A?view

TLDR: ECDSA signing in bberg and verification in noir has a minor "difference". Signature construction and verification should operate consistently on the message.

<img width="445" alt="image" src="https://github.com/AztecProtocol/aztec-packages/assets/19621621/b845ab1c-44ca-49ea-932d-ed05ed51b204">

<img width="567" alt="image" src="https://github.com/AztecProtocol/aztec-packages/assets/19621621/5ae6fd8d-4a64-4196-973c-ffc45bfd10cf">

The noir ecdsa verification takes in the hashed message $z$ as an argument. So we need to hash the message before calling `std::ecdsa_secp256k1::verify_signature`.

The reason this worked with the noble curves package was: in the noble package, the message is never hashed. It is used as is for signing a message. Therefore the noir-ecdsa-verify works as we don't need to hash the message in verification.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] The branch has been merged or rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
