### PR TITLE
refactor: Renaming storage getters

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/http-node.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/http-node.test.ts
@@ -372,7 +372,7 @@ describe('HttpNode', () => {
     });
   });
 
-  describe('getStorageAt', () => {
+  describe('getPublicStorageAt', () => {
     it('should fetch and return the storage value at the given contract slot', async () => {
       const contractAddress = AztecAddress.random();
       const slot = BigInt(789);
@@ -380,9 +380,9 @@ describe('HttpNode', () => {
       const response = { value: storageValue.toString('hex') };
       setFetchMock(response);
 
-      const result = await httpNode.getStorageAt(contractAddress, slot);
+      const result = await httpNode.getPublicStorageAt(contractAddress, slot);
 
-      const url = `${TEST_URL}storage-at?address=${contractAddress}&slot=${slot.toString()}`;
+      const url = `${TEST_URL}public-storage-at?address=${contractAddress}&slot=${slot.toString()}`;
       expect(fetch).toHaveBeenCalledWith(url);
       expect(result).toEqual(storageValue);
     });
@@ -393,9 +393,9 @@ describe('HttpNode', () => {
       const response = {};
       setFetchMock(response);
 
-      const result = await httpNode.getStorageAt(contractAddress, slot);
+      const result = await httpNode.getPublicStorageAt(contractAddress, slot);
 
-      const url = `${TEST_URL}storage-at?address=${contractAddress}&slot=${slot.toString()}`;
+      const url = `${TEST_URL}public-storage-at?address=${contractAddress}&slot=${slot.toString()}`;
       expect(fetch).toHaveBeenCalledWith(url);
       expect(result).toBeUndefined();
     });

--- a/yarn-project/aztec-node/src/aztec-node/http-node.ts
+++ b/yarn-project/aztec-node/src/aztec-node/http-node.ts
@@ -284,8 +284,8 @@ export class HttpNode implements AztecNode {
    * @returns Storage value at the given contract slot (or undefined if not found).
    * Note: Aztec's version of `eth_getStorageAt`.
    */
-  async getStorageAt(contract: AztecAddress, slot: bigint): Promise<Buffer | undefined> {
-    const url = new URL(`${this.baseUrl}/storage-at`);
+  async getPublicStorageAt(contract: AztecAddress, slot: bigint): Promise<Buffer | undefined> {
+    const url = new URL(`${this.baseUrl}/public-storage-at`);
     url.searchParams.append('address', contract.toString());
     url.searchParams.append('slot', slot.toString());
     const response = await (await fetch(url.toString())).json();

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -292,7 +292,7 @@ export class AztecNodeService implements AztecNode {
    * @returns Storage value at the given contract slot (or undefined if not found).
    * Note: Aztec's version of `eth_getStorageAt`.
    */
-  public async getStorageAt(contract: AztecAddress, slot: bigint): Promise<Buffer | undefined> {
+  public async getPublicStorageAt(contract: AztecAddress, slot: bigint): Promise<Buffer | undefined> {
     const leafIndex = computePublicDataTreeLeafIndex(contract, new Fr(slot), await CircuitsWasm.get());
     return this.merkleTreeDB.getLeafValue(MerkleTreeId.PUBLIC_DATA_TREE, leafIndex, false);
   }

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -185,31 +185,31 @@ export class AztecRPCServer implements AztecRPC {
   }
 
   /**
-   * Retrieves the storage data at a specified contract address and storage slot.
+   * Retrieves the preimage data at a specified contract address and storage slot.
    * The returned data is an array of note preimage items, with each item containing its value.
    *
    * @param contract - The AztecAddress of the target contract.
    * @param storageSlot - The Fr representing the storage slot to be fetched.
    * @returns A promise that resolves to an array of note preimage items, each containing its value.
    */
-  public async getStorageAt(contract: AztecAddress, storageSlot: Fr) {
+  public async getPreimagesAt(contract: AztecAddress, storageSlot: Fr) {
     const noteSpendingInfo = await this.db.getNoteSpendingInfo(contract, storageSlot);
     return noteSpendingInfo.map(d => d.notePreimage.items.map(item => item.value));
   }
 
   /**
    * Retrieves the public storage data at a specified contract address and storage slot.
-   * The returned data is an array of note preimage items, with each item containing its value.
+   * The returned data is data at the storage slot or throws an error if the contract is not deployed.
    *
    * @param contract - The AztecAddress of the target contract.
    * @param storageSlot - The Fr representing the storage slot to be fetched.
-   * @returns A promise that resolves to an array of note preimage items, each containing its value.
+   * @returns A buffer containing the public storage data at the storage slot.
    */
   public async getPublicStorageAt(contract: AztecAddress, storageSlot: Fr) {
     if (!(await this.isContractDeployed(contract))) {
       throw new Error(`Contract ${contract.toString()} is not deployed`);
     }
-    return await this.node.getStorageAt(contract, storageSlot.value);
+    return await this.node.getPublicStorageAt(contract, storageSlot.value);
   }
 
   /**

--- a/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
+++ b/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
@@ -61,8 +61,8 @@ export abstract class BaseWallet implements Wallet {
   getTxReceipt(txHash: TxHash): Promise<TxReceipt> {
     return this.rpc.getTxReceipt(txHash);
   }
-  getStorageAt(contract: AztecAddress, storageSlot: Fr): Promise<any> {
-    return this.rpc.getStorageAt(contract, storageSlot);
+  getPreimagesAt(contract: AztecAddress, storageSlot: Fr): Promise<any> {
+    return this.rpc.getPreimagesAt(contract, storageSlot);
   }
   getPublicStorageAt(contract: AztecAddress, storageSlot: Fr): Promise<any> {
     return this.rpc.getPublicStorageAt(contract, storageSlot);

--- a/yarn-project/rollup-provider/src/app.ts
+++ b/yarn-project/rollup-provider/src/app.ts
@@ -205,11 +205,11 @@ export function appFactory(node: AztecNode, prefix: string) {
     ctx.status = 200;
   });
 
-  router.get('/storage-at', async (ctx: Koa.Context) => {
-    logger('storage-at');
+  router.get('/public-storage-at', async (ctx: Koa.Context) => {
+    logger('public-storage-at');
     const address = ctx.query.address!;
     const slot = ctx.query.slot!;
-    const value = await node.getStorageAt(AztecAddress.fromString(address as string), BigInt(slot as string));
+    const value = await node.getPublicStorageAt(AztecAddress.fromString(address as string), BigInt(slot as string));
     ctx.set('content-type', 'application/json');
     ctx.body = {
       value: value?.toString('hex'),

--- a/yarn-project/types/src/interfaces/aztec-node.ts
+++ b/yarn-project/types/src/interfaces/aztec-node.ts
@@ -102,7 +102,7 @@ export interface AztecNode extends DataCommitmentProvider, L1ToL2MessageProvider
    * @param slot - Slot to query.
    * @returns Storage value at the given contract slot (or undefined if not found).
    */
-  getStorageAt(contract: AztecAddress, slot: bigint): Promise<Buffer | undefined>;
+  getPublicStorageAt(contract: AztecAddress, slot: bigint): Promise<Buffer | undefined>;
 
   /**
    * Returns the current committed roots for the data trees.

--- a/yarn-project/types/src/interfaces/aztec_rpc.ts
+++ b/yarn-project/types/src/interfaces/aztec_rpc.ts
@@ -67,8 +67,8 @@ export interface AztecRPC {
   simulateTx(txRequest: TxExecutionRequest): Promise<Tx>;
   sendTx(tx: Tx): Promise<TxHash>;
   getTxReceipt(txHash: TxHash): Promise<TxReceipt>;
-  getPreimagesAt(contract: AztecAddress, storageSlot: Fr): Promise<any>;
-  getPublicStorageAt(contract: AztecAddress, storageSlot: Fr): Promise<any>;
+  getPreimagesAt(contract: AztecAddress, storageSlot: Fr): Promise<bigint[][]>;
+  getPublicStorageAt(contract: AztecAddress, storageSlot: Fr): Promise<Buffer | undefined>;
   viewTx(functionName: string, args: any[], to: AztecAddress, from?: AztecAddress): Promise<any>;
   getContractData(contractAddress: AztecAddress): Promise<ContractPublicData | undefined>;
   getContractInfo(contractAddress: AztecAddress): Promise<ContractData | undefined>;

--- a/yarn-project/types/src/interfaces/aztec_rpc.ts
+++ b/yarn-project/types/src/interfaces/aztec_rpc.ts
@@ -67,7 +67,7 @@ export interface AztecRPC {
   simulateTx(txRequest: TxExecutionRequest): Promise<Tx>;
   sendTx(tx: Tx): Promise<TxHash>;
   getTxReceipt(txHash: TxHash): Promise<TxReceipt>;
-  getStorageAt(contract: AztecAddress, storageSlot: Fr): Promise<any>;
+  getPreimagesAt(contract: AztecAddress, storageSlot: Fr): Promise<any>;
   getPublicStorageAt(contract: AztecAddress, storageSlot: Fr): Promise<any>;
   viewTx(functionName: string, args: any[], to: AztecAddress, from?: AztecAddress): Promise<any>;
   getContractData(contractAddress: AztecAddress): Promise<ContractPublicData | undefined>;


### PR DESCRIPTION
# Description

This pr renames the storage getters to improve clarity.

The `getStorageAt` was inconsistently used for both private and public storage depending on implementation at RPC or Node.

- For public storage we now use `getPublicStorageAt(who, slot)` which returns a single value
- For private preimages we now use `getPreimagesAt(who, slot)` which returns an array of preimages

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
