### PR TITLE
feat: Initial cheatcode `loadPublic`

### DIFF
--- a/yarn-project/end-to-end/src/CheatCodes.ts
+++ b/yarn-project/end-to-end/src/CheatCodes.ts
@@ -1,0 +1,55 @@
+import { AztecAddress, CircuitsWasm, Fr } from '@aztec/circuits.js';
+import { pedersenPlookupCommitInputs } from '@aztec/circuits.js/barretenberg';
+import { AztecRPC } from '@aztec/types';
+
+/**
+ * A class that provides utility functions for interacting with the chain.
+ */
+export class CheatCodes {
+  constructor(
+    /**
+     * The RPC client to use for interacting with the chain
+     */
+    public aztecRpc: AztecRPC,
+    /**
+     * The circuits wasm module used for pedersen hashing
+     */
+    public wasm: CircuitsWasm,
+  ) {}
+
+  static async create(aztecRpc: AztecRPC): Promise<CheatCodes> {
+    return new CheatCodes(aztecRpc, await CircuitsWasm.get());
+  }
+
+  /**
+   * Computes the slot value for a given map and key.
+   * @param baseSlot - The base slot of the map (specified in noir contract)
+   * @param key - The key to lookup in the map
+   * @returns The storage slot of the value in the map
+   */
+  public computeSlotInMap(baseSlot: Fr | bigint, key: Fr | bigint): Fr {
+    const mappingStorageSlot = typeof baseSlot === 'bigint' ? new Fr(baseSlot) : baseSlot;
+    const frKey = typeof key === 'bigint' ? new Fr(key) : key;
+
+    // Based on `at` function in
+    // aztec3-packages/yarn-project/noir-contracts/src/contracts/noir-aztec/src/state_vars/map.nr
+    return Fr.fromBuffer(
+      pedersenPlookupCommitInputs(
+        this.wasm,
+        [mappingStorageSlot, frKey].map(f => f.toBuffer()),
+      ),
+    );
+  }
+
+  /**
+   * Loads the value stored at the given slot in the public storage of the given contract.
+   * @param who - The address of the contract
+   * @param slot - The storage slot to lookup
+   * @returns The value stored at the given slot
+   */
+  public async loadPublic(who: AztecAddress, slot: Fr | bigint): Promise<Fr> {
+    const frSlot = typeof slot === 'bigint' ? new Fr(slot) : slot;
+    const publicStorage = await this.aztecRpc.getPublicStorageAt(who, frSlot);
+    return publicStorage ? Fr.fromBuffer(publicStorage) : Fr.ZERO;
+  }
+}

--- a/yarn-project/end-to-end/src/cheat_codes.ts
+++ b/yarn-project/end-to-end/src/cheat_codes.ts
@@ -24,7 +24,7 @@ export class CheatCodes {
 
   static async create(rpcUrl: string, aztecRpc: AztecRPC): Promise<CheatCodes> {
     const l1CheatCodes = new L1CheatCodes(rpcUrl);
-    const l2CheatCodes = new L2CheatCodes(aztecRpc, await CircuitsWasm.get());
+    const l2CheatCodes = new L2CheatCodes(aztecRpc, await CircuitsWasm.get(), l1CheatCodes);
     return new CheatCodes(l1CheatCodes, l2CheatCodes);
   }
 }
@@ -87,9 +87,7 @@ class L1CheatCodes {
    */
   public async mine(numberOfBlocks = 1): Promise<void> {
     const res = await this.rpcCall('anvil_mine', `[${numberOfBlocks}]`);
-    if (res.error) {
-      throw new Error(`Error mining: ${res.error.message}`);
-    }
+    if (res.error) throw new Error(`Error mining: ${res.error.message}`);
     this.logger(`Mined ${numberOfBlocks} blocks`);
   }
 
@@ -99,9 +97,7 @@ class L1CheatCodes {
    */
   public async setNextBlockTimestamp(timestamp: number): Promise<void> {
     const res = await this.rpcCall('anvil_setNextBlockTimestamp', `[${timestamp}]`);
-    if (res.error) {
-      throw new Error(`Error setting next block timestamp: ${res.error.message}`);
-    }
+    if (res.error) throw new Error(`Error setting next block timestamp: ${res.error.message}`);
     this.logger(`Set next block timestamp to ${timestamp}`);
   }
 
@@ -122,6 +118,10 @@ class L2CheatCodes {
      * The circuits wasm module used for pedersen hashing
      */
     public wasm: CircuitsWasm,
+    /**
+     * The L1 cheat codes.
+     */
+    public l1: L1CheatCodes,
     /**
      * The logger to use for the l2 cheatcodes
      */

--- a/yarn-project/end-to-end/src/cheat_codes.ts
+++ b/yarn-project/end-to-end/src/cheat_codes.ts
@@ -3,8 +3,8 @@ import { pedersenPlookupCommitInputs } from '@aztec/circuits.js/barretenberg';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { AztecRPC } from '@aztec/types';
 
-const toFr = (what: Fr | bigint): Fr => {
-  return typeof what === 'bigint' ? new Fr(what) : what;
+const toFr = (value: Fr | bigint): Fr => {
+  return typeof value === 'bigint' ? new Fr(value) : value;
 };
 
 /**
@@ -44,9 +44,10 @@ class L1CheatCodes {
     public logger = createDebugLogger('aztec:cheat_codes:l1'),
   ) {}
 
-  async rpcCall(method: string, params: string) {
+  async rpcCall(method: string, params: any[]) {
+    const paramsString = JSON.stringify(params);
     const content = {
-      body: `{"jsonrpc":"2.0", "method": "${method}", "params": ${params}, "id": 1}`,
+      body: `{"jsonrpc":"2.0", "method": "${method}", "params": ${paramsString}, "id": 1}`,
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
     };
@@ -58,7 +59,7 @@ class L1CheatCodes {
    * @returns The current block number
    */
   public async blockNumber(): Promise<number> {
-    const res = await this.rpcCall('eth_blockNumber', `[]`);
+    const res = await this.rpcCall('eth_blockNumber', []);
     return parseInt(res.result, 16);
   }
 
@@ -67,7 +68,7 @@ class L1CheatCodes {
    * @returns The current chainId
    */
   public async chainId(): Promise<number> {
-    const res = await this.rpcCall('eth_chainId', `[]`);
+    const res = await this.rpcCall('eth_chainId', []);
     return parseInt(res.result, 16);
   }
 
@@ -76,7 +77,7 @@ class L1CheatCodes {
    * @returns The current timestamp
    */
   public async timestamp(): Promise<number> {
-    const res = await this.rpcCall('eth_getBlockByNumber', `["latest", true]`);
+    const res = await this.rpcCall('eth_getBlockByNumber', ['latest', true]);
     return parseInt(res.result.timestamp, 16);
   }
 
@@ -86,7 +87,7 @@ class L1CheatCodes {
    * @returns The current chainId
    */
   public async mine(numberOfBlocks = 1): Promise<void> {
-    const res = await this.rpcCall('anvil_mine', `[${numberOfBlocks}]`);
+    const res = await this.rpcCall('anvil_mine', [numberOfBlocks]);
     if (res.error) throw new Error(`Error mining: ${res.error.message}`);
     this.logger(`Mined ${numberOfBlocks} blocks`);
   }
@@ -96,7 +97,7 @@ class L1CheatCodes {
    * @param timestamp - The timestamp to set the next block to
    */
   public async setNextBlockTimestamp(timestamp: number): Promise<void> {
-    const res = await this.rpcCall('anvil_setNextBlockTimestamp', `[${timestamp}]`);
+    const res = await this.rpcCall('anvil_setNextBlockTimestamp', [timestamp]);
     if (res.error) throw new Error(`Error setting next block timestamp: ${res.error.message}`);
     this.logger(`Set next block timestamp to ${timestamp}`);
   }

--- a/yarn-project/end-to-end/src/cheat_codes.ts
+++ b/yarn-project/end-to-end/src/cheat_codes.ts
@@ -49,7 +49,11 @@ export class CheatCodes {
    */
   public async loadPublic(who: AztecAddress, slot: Fr | bigint): Promise<Fr> {
     const frSlot = typeof slot === 'bigint' ? new Fr(slot) : slot;
-    const publicStorage = await this.aztecRpc.getPublicStorageAt(who, frSlot);
-    return publicStorage ? Fr.fromBuffer(publicStorage) : Fr.ZERO;
+    const storageValue = await this.aztecRpc.getPublicStorageAt(who, frSlot);
+    if (storageValue === undefined) {
+      throw new Error(`Storage slot ${frSlot} not found`);
+    }
+
+    return Fr.fromBuffer(storageValue);
   }
 }

--- a/yarn-project/end-to-end/src/cross_chain/test_harness.ts
+++ b/yarn-project/end-to-end/src/cross_chain/test_harness.ts
@@ -28,13 +28,13 @@ export class CrossChainTestHarness {
     accounts: AztecAddress[],
     wallet: Wallet,
     logger: DebugLogger,
+    cheatCodes: CheatCodes,
   ): Promise<CrossChainTestHarness> {
     const walletClient = deployL1ContractsValues.walletClient;
     const publicClient = deployL1ContractsValues.publicClient;
     const ethAccount = EthAddress.fromString((await walletClient.getAddresses())[0]);
     const [ownerAddress, receiver] = accounts;
     const ownerPub = await aztecRpcServer.getPublicKey(ownerAddress);
-    const cc = await CheatCodes.create(aztecRpcServer);
 
     const outbox = getContract({
       address: deployL1ContractsValues.outboxAddress.toString(),
@@ -62,7 +62,7 @@ export class CrossChainTestHarness {
     return new CrossChainTestHarness(
       aztecNode,
       aztecRpcServer,
-      cc,
+      cheatCodes,
       accounts,
       logger,
       l2Contract,

--- a/yarn-project/end-to-end/src/cross_chain/test_harness.ts
+++ b/yarn-project/end-to-end/src/cross_chain/test_harness.ts
@@ -204,9 +204,9 @@ export class CrossChainTestHarness {
   }
 
   async expectPublicBalanceOnL2(owner: AztecAddress, expectedBalance: bigint, publicBalanceSlot: bigint) {
-    const balance = await this.cc.loadPublic(
+    const balance = await this.cc.l2.loadPublic(
       this.l2Contract.address,
-      this.cc.computeSlotInMap(publicBalanceSlot, owner.toField()),
+      this.cc.l2.computeSlotInMap(publicBalanceSlot, owner.toField()),
     );
     expect(balance.value).toBe(expectedBalance);
   }

--- a/yarn-project/end-to-end/src/cross_chain/test_harness.ts
+++ b/yarn-project/end-to-end/src/cross_chain/test_harness.ts
@@ -12,7 +12,8 @@ import { AztecRPC, TxStatus } from '@aztec/types';
 
 import { Chain, HttpTransport, PublicClient, getContract } from 'viem';
 
-import { deployAndInitializeNonNativeL2TokenContracts, expectAztecStorageSlot } from '../utils.js';
+import { CheatCodes } from '../cheat_codes.js';
+import { deployAndInitializeNonNativeL2TokenContracts } from '../utils.js';
 
 /**
  * A Class for testing cross chain interactions, contains common interactions
@@ -33,6 +34,7 @@ export class CrossChainTestHarness {
     const ethAccount = EthAddress.fromString((await walletClient.getAddresses())[0]);
     const [ownerAddress, receiver] = accounts;
     const ownerPub = await aztecRpcServer.getPublicKey(ownerAddress);
+    const cc = await CheatCodes.create(aztecRpcServer);
 
     const outbox = getContract({
       address: deployL1ContractsValues.outboxAddress.toString(),
@@ -60,6 +62,7 @@ export class CrossChainTestHarness {
     return new CrossChainTestHarness(
       aztecNode,
       aztecRpcServer,
+      cc,
       accounts,
       logger,
       l2Contract,
@@ -80,6 +83,8 @@ export class CrossChainTestHarness {
     public aztecNode: AztecNodeService | undefined,
     /** AztecRpcServer. */
     public aztecRpcServer: AztecRPC,
+    /** CheatCodes. */
+    public cc: CheatCodes,
     /** Accounts. */
     public accounts: AztecAddress[],
     /** Logger. */
@@ -199,14 +204,11 @@ export class CrossChainTestHarness {
   }
 
   async expectPublicBalanceOnL2(owner: AztecAddress, expectedBalance: bigint, publicBalanceSlot: bigint) {
-    await expectAztecStorageSlot(
-      this.logger,
-      this.aztecRpcServer,
-      this.l2Contract,
-      publicBalanceSlot,
-      owner.toField(),
-      expectedBalance,
+    const balance = await this.cc.loadPublic(
+      this.l2Contract.address,
+      this.cc.computeSlotInMap(publicBalanceSlot, owner.toField()),
     );
+    expect(balance.value).toBe(expectedBalance);
   }
 
   async checkEntryIsNotInOutbox(withdrawAmount: bigint, callerOnL1: EthAddress = EthAddress.ZERO): Promise<Fr> {

--- a/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
@@ -1,0 +1,53 @@
+import { AztecNodeService } from '@aztec/aztec-node';
+import { AztecRPCServer } from '@aztec/aztec-rpc';
+import { AztecRPC } from '@aztec/types';
+
+import { CheatCodes } from './cheat_codes.js';
+import { setup } from './utils.js';
+
+describe('e2e_cheat_codes', () => {
+  let aztecNode: AztecNodeService | undefined;
+  let aztecRpcServer: AztecRPC;
+
+  let cc: CheatCodes;
+
+  beforeAll(async () => {
+    ({ aztecNode, aztecRpcServer, cheatCodes: cc } = await setup());
+  }, 100_000);
+
+  afterAll(async () => {
+    await aztecNode?.stop();
+    if (aztecRpcServer instanceof AztecRPCServer) {
+      await aztecRpcServer?.stop();
+    }
+  });
+
+  describe('L1 only', () => {
+    describe('mine', () => {
+      it(`mine block`, async () => {
+        const blockNumber = await cc.l1.blockNumber();
+        await cc.l1.mine();
+        expect(await cc.l1.blockNumber()).toBe(blockNumber + 1);
+      });
+
+      it.each([10, 42, 99])(`mine blocks`, async increment => {
+        const blockNumber = await cc.l1.blockNumber();
+        await cc.l1.mine(increment);
+        expect(await cc.l1.blockNumber()).toBe(blockNumber + increment);
+      });
+    });
+
+    it.each([100, 42, 99])('setNextBlockTimestamp', async increment => {
+      const blockNumber = await cc.l1.blockNumber();
+      const timestamp = await cc.l1.timestamp();
+      await cc.l1.setNextBlockTimestamp(timestamp + increment);
+
+      expect(await cc.l1.timestamp()).toBe(timestamp);
+
+      await cc.l1.mine();
+
+      expect(await cc.l1.blockNumber()).toBe(blockNumber + 1);
+      expect(await cc.l1.timestamp()).toBe(timestamp + increment);
+    });
+  });
+});

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
@@ -33,6 +33,7 @@ describe('e2e_cross_chain_messaging', () => {
       accounts,
       wallet,
       logger: logger_,
+      cheatCodes,
     } = await setup(2);
     crossChainTestHarness = await CrossChainTestHarness.new(
       initialBalance,
@@ -42,6 +43,7 @@ describe('e2e_cross_chain_messaging', () => {
       accounts,
       wallet,
       logger_,
+      cheatCodes,
     );
 
     l2Contract = crossChainTestHarness.l2Contract;

--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -47,6 +47,10 @@ describe('e2e_lending_contract', () => {
 
   // Fetch a storage snapshot from the contract that we can use to compare between transitions.
   const getStorageSnapshot = async (contract: Contract, aztecNode: AztecRPC, account: Account) => {
+    const loadPublicStorageInMap = async (slot: Fr | bigint, key: Fr | bigint) => {
+      return await cc.l2.loadPublic(contract.address, cc.l2.computeSlotInMap(slot, key));
+    };
+
     const storageValues: { [key: string]: any } = {};
     {
       const baseSlot = cc.l2.computeSlotInMap(1n, 0n);
@@ -56,19 +60,10 @@ describe('e2e_lending_contract', () => {
 
     const accountKey = await account.key();
 
-    storageValues['private_collateral'] = await cc.l2.loadPublic(
-      contract.address,
-      cc.l2.computeSlotInMap(2n, accountKey),
-    );
-    storageValues['public_collateral'] = await cc.l2.loadPublic(
-      contract.address,
-      cc.l2.computeSlotInMap(2n, account.address.toField()),
-    );
-    storageValues['private_debt'] = await cc.l2.loadPublic(contract.address, cc.l2.computeSlotInMap(3n, accountKey));
-    storageValues['public_debt'] = await cc.l2.loadPublic(
-      contract.address,
-      cc.l2.computeSlotInMap(3n, account.address.toField()),
-    );
+    storageValues['private_collateral'] = await loadPublicStorageInMap(2n, accountKey);
+    storageValues['public_collateral'] = await loadPublicStorageInMap(2n, account.address.toField());
+    storageValues['private_debt'] = await loadPublicStorageInMap(3n, accountKey);
+    storageValues['public_debt'] = await loadPublicStorageInMap(3n, account.address.toField());
 
     return storageValues;
   };

--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -4,7 +4,6 @@ import { AztecAddress, Contract, Fr, Wallet } from '@aztec/aztec.js';
 import { CircuitsWasm } from '@aztec/circuits.js';
 import { pedersenPlookupCommitInputs } from '@aztec/circuits.js/barretenberg';
 import { DebugLogger } from '@aztec/foundation/log';
-import { sleep } from '@aztec/foundation/sleep';
 import { LendingContract } from '@aztec/noir-contracts/types';
 import { AztecRPC, TxStatus } from '@aztec/types';
 

--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -50,22 +50,25 @@ describe('e2e_lending_contract', () => {
   const getStorageSnapshot = async (contract: Contract, aztecNode: AztecRPC, account: Account) => {
     const storageValues: { [key: string]: any } = {};
     {
-      const baseSlot = cc.computeSlotInMap(1n, 0n);
-      storageValues['interestAccumulator'] = await cc.loadPublic(contract.address, baseSlot);
-      storageValues['last_updated_ts'] = await cc.loadPublic(contract.address, baseSlot.value + 1n);
+      const baseSlot = cc.l2.computeSlotInMap(1n, 0n);
+      storageValues['interestAccumulator'] = await cc.l2.loadPublic(contract.address, baseSlot);
+      storageValues['last_updated_ts'] = await cc.l2.loadPublic(contract.address, baseSlot.value + 1n);
     }
 
     const accountKey = await account.key();
 
-    storageValues['private_collateral'] = await cc.loadPublic(contract.address, cc.computeSlotInMap(2n, accountKey));
-    storageValues['public_collateral'] = await cc.loadPublic(
+    storageValues['private_collateral'] = await cc.l2.loadPublic(
       contract.address,
-      cc.computeSlotInMap(2n, account.address.toField()),
+      cc.l2.computeSlotInMap(2n, accountKey),
     );
-    storageValues['private_debt'] = await cc.loadPublic(contract.address, cc.computeSlotInMap(3n, accountKey));
-    storageValues['public_debt'] = await cc.loadPublic(
+    storageValues['public_collateral'] = await cc.l2.loadPublic(
       contract.address,
-      cc.computeSlotInMap(3n, account.address.toField()),
+      cc.l2.computeSlotInMap(2n, account.address.toField()),
+    );
+    storageValues['private_debt'] = await cc.l2.loadPublic(contract.address, cc.l2.computeSlotInMap(3n, accountKey));
+    storageValues['public_debt'] = await cc.l2.loadPublic(
+      contract.address,
+      cc.l2.computeSlotInMap(3n, account.address.toField()),
     );
 
     return storageValues;

--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -4,6 +4,7 @@ import { AztecAddress, Contract, Fr, Wallet } from '@aztec/aztec.js';
 import { CircuitsWasm } from '@aztec/circuits.js';
 import { pedersenPlookupCommitInputs } from '@aztec/circuits.js/barretenberg';
 import { DebugLogger } from '@aztec/foundation/log';
+import { sleep } from '@aztec/foundation/sleep';
 import { LendingContract } from '@aztec/noir-contracts/types';
 import { AztecRPC, TxStatus } from '@aztec/types';
 
@@ -35,8 +36,7 @@ describe('e2e_lending_contract', () => {
   };
 
   beforeEach(async () => {
-    ({ aztecNode, aztecRpcServer, wallet, accounts, logger } = await setup());
-    cc = await CheatCodes.create(aztecRpcServer);
+    ({ aztecNode, aztecRpcServer, wallet, accounts, logger, cheatCodes: cc } = await setup());
   }, 100_000);
 
   afterEach(async () => {

--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -7,7 +7,7 @@ import { DebugLogger } from '@aztec/foundation/log';
 import { LendingContract } from '@aztec/noir-contracts/types';
 import { AztecRPC, TxStatus } from '@aztec/types';
 
-import { CheatCodes } from './CheatCodes.js';
+import { CheatCodes } from './cheat_codes.js';
 import { setup } from './utils.js';
 
 describe('e2e_lending_contract', () => {

--- a/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
@@ -33,6 +33,7 @@ describe('e2e_public_cross_chain_messaging', () => {
       accounts,
       wallet,
       logger: logger_,
+      cheatCodes,
     } = await setup(2);
     crossChainTestHarness = await CrossChainTestHarness.new(
       initialBalance,
@@ -42,6 +43,7 @@ describe('e2e_public_cross_chain_messaging', () => {
       accounts,
       wallet,
       logger_,
+      cheatCodes,
     );
 
     l2Contract = crossChainTestHarness.l2Contract;

--- a/yarn-project/end-to-end/src/e2e_public_to_private_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_to_private_messaging.test.ts
@@ -29,6 +29,7 @@ describe('e2e_public_to_private_messaging', () => {
       accounts,
       wallet,
       logger: logger_,
+      cheatCodes,
     } = await setup(2);
     crossChainTestHarness = await CrossChainTestHarness.new(
       initialBalance,
@@ -38,6 +39,7 @@ describe('e2e_public_to_private_messaging', () => {
       accounts,
       wallet,
       logger_,
+      cheatCodes,
     );
 
     ethAccount = crossChainTestHarness.ethAccount;

--- a/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
@@ -40,8 +40,7 @@ describe('e2e_public_token_contract', () => {
   };
 
   beforeEach(async () => {
-    ({ aztecNode, aztecRpcServer, accounts, wallet, logger } = await setup());
-    cc = await CheatCodes.create(aztecRpcServer);
+    ({ aztecNode, aztecRpcServer, accounts, wallet, logger, cheatCodes: cc } = await setup());
   }, 100_000);
 
   afterEach(async () => {

--- a/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
@@ -71,9 +71,9 @@ describe('e2e_public_token_contract', () => {
 
     expect(receipt.status).toBe(TxStatus.MINED);
 
-    const balance = await cc.loadPublic(
+    const balance = await cc.l2.loadPublic(
       deployedContract.address,
-      cc.computeSlotInMap(balanceSlot, recipient.toField()),
+      cc.l2.computeSlotInMap(balanceSlot, recipient.toField()),
     );
     expect(balance.value).toBe(mintAmount);
 
@@ -99,9 +99,9 @@ describe('e2e_public_token_contract', () => {
     expect(receipts.map(r => r.status)).toEqual(times(3, () => TxStatus.MINED));
     expect(receipts.map(r => r.blockNumber)).toEqual(times(3, () => receipts[0].blockNumber));
 
-    const balance = await cc.loadPublic(
+    const balance = await cc.l2.loadPublic(
       deployedContract.address,
-      cc.computeSlotInMap(balanceSlot, recipient.toField()),
+      cc.l2.computeSlotInMap(balanceSlot, recipient.toField()),
     );
     expect(balance.value).toBe(mintAmount * 3n);
 

--- a/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
@@ -70,10 +70,7 @@ describe('e2e_public_token_contract', () => {
 
     expect(receipt.status).toBe(TxStatus.MINED);
 
-    const balance = await cc.l2.loadPublic(
-      deployedContract.address,
-      cc.l2.computeSlotInMap(balanceSlot, recipient.toField()),
-    );
+    const balance = await cc.l2.loadPublic(contract.address, cc.l2.computeSlotInMap(balanceSlot, recipient.toField()));
     expect(balance.value).toBe(mintAmount);
 
     await expectLogsFromLastBlockToBe(['Coins minted']);
@@ -98,10 +95,7 @@ describe('e2e_public_token_contract', () => {
     expect(receipts.map(r => r.status)).toEqual(times(3, () => TxStatus.MINED));
     expect(receipts.map(r => r.blockNumber)).toEqual(times(3, () => receipts[0].blockNumber));
 
-    const balance = await cc.l2.loadPublic(
-      deployedContract.address,
-      cc.l2.computeSlotInMap(balanceSlot, recipient.toField()),
-    );
+    const balance = await cc.l2.loadPublic(contract.address, cc.l2.computeSlotInMap(balanceSlot, recipient.toField()));
     expect(balance.value).toBe(mintAmount * 3n);
 
     await expectLogsFromLastBlockToBe(['Coins minted', 'Coins minted', 'Coins minted']);

--- a/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
@@ -7,7 +7,8 @@ import { AztecRPC, L2BlockL2Logs, TxStatus } from '@aztec/types';
 
 import times from 'lodash.times';
 
-import { expectAztecStorageSlot, setup } from './utils.js';
+import { CheatCodes } from './cheat_codes.js';
+import { setup } from './utils.js';
 
 describe('e2e_public_token_contract', () => {
   let aztecNode: AztecNodeService | undefined;
@@ -18,6 +19,8 @@ describe('e2e_public_token_contract', () => {
 
   let contract: PublicTokenContract;
   const balanceSlot = 1n;
+
+  let cc: CheatCodes;
 
   const deployContract = async () => {
     logger(`Deploying L2 public contract...`);
@@ -38,6 +41,7 @@ describe('e2e_public_token_contract', () => {
 
   beforeEach(async () => {
     ({ aztecNode, aztecRpcServer, accounts, wallet, logger } = await setup());
+    cc = await CheatCodes.create(aztecRpcServer);
   }, 100_000);
 
   afterEach(async () => {
@@ -66,7 +70,13 @@ describe('e2e_public_token_contract', () => {
     const receipt = await tx.getReceipt();
 
     expect(receipt.status).toBe(TxStatus.MINED);
-    await expectAztecStorageSlot(logger, aztecRpcServer, contract, balanceSlot, recipient.toField(), mintAmount);
+
+    const balance = await cc.loadPublic(
+      deployedContract.address,
+      cc.computeSlotInMap(balanceSlot, recipient.toField()),
+    );
+    expect(balance.value).toBe(mintAmount);
+
     await expectLogsFromLastBlockToBe(['Coins minted']);
   }, 45_000);
 
@@ -89,7 +99,12 @@ describe('e2e_public_token_contract', () => {
     expect(receipts.map(r => r.status)).toEqual(times(3, () => TxStatus.MINED));
     expect(receipts.map(r => r.blockNumber)).toEqual(times(3, () => receipts[0].blockNumber));
 
-    await expectAztecStorageSlot(logger, aztecRpcServer, contract, balanceSlot, recipient.toField(), mintAmount * 3n);
+    const balance = await cc.loadPublic(
+      deployedContract.address,
+      cc.computeSlotInMap(balanceSlot, recipient.toField()),
+    );
+    expect(balance.value).toBe(mintAmount * 3n);
+
     await expectLogsFromLastBlockToBe(['Coins minted', 'Coins minted', 'Coins minted']);
   }, 60_000);
 });

--- a/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
+++ b/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
@@ -32,6 +32,7 @@ describe('uniswap_trade_on_l1_from_l2', () => {
   let wallet: Wallet;
   let accounts: AztecAddress[];
   let logger: DebugLogger;
+  let cheatCodes: CheatCodes;
 
   let ethAccount: EthAddress;
   let ownerAddress: AztecAddress;
@@ -48,7 +49,7 @@ describe('uniswap_trade_on_l1_from_l2', () => {
 
   beforeEach(async () => {
     let deployL1ContractsValues: DeployL1Contracts;
-    ({ aztecNode, aztecRpcServer, deployL1ContractsValues, accounts, logger, wallet } = await setup(2));
+    ({ aztecNode, aztecRpcServer, deployL1ContractsValues, accounts, logger, wallet, cheatCodes } = await setup(2));
 
     const walletClient = deployL1ContractsValues.walletClient;
     const publicClient = deployL1ContractsValues.publicClient;
@@ -74,7 +75,7 @@ describe('uniswap_trade_on_l1_from_l2', () => {
     daiCrossChainHarness = new CrossChainTestHarness(
       aztecNode,
       aztecRpcServer,
-      await CheatCodes.create(aztecRpcServer),
+      cheatCodes,
       accounts,
       logger,
       daiContracts.l2Contract,
@@ -103,7 +104,7 @@ describe('uniswap_trade_on_l1_from_l2', () => {
     wethCrossChainHarness = new CrossChainTestHarness(
       aztecNode,
       aztecRpcServer,
-      await CheatCodes.create(aztecRpcServer),
+      cheatCodes,
       accounts,
       logger,
       wethContracts.l2Contract,

--- a/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
+++ b/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
@@ -10,6 +10,7 @@ import { AztecRPC, TxStatus } from '@aztec/types';
 
 import { getContract, parseEther } from 'viem';
 
+import { CheatCodes } from './cheat_codes.js';
 import { CrossChainTestHarness } from './cross_chain/test_harness.js';
 import { delay, deployAndInitializeNonNativeL2TokenContracts, setup } from './utils.js';
 
@@ -73,6 +74,7 @@ describe('uniswap_trade_on_l1_from_l2', () => {
     daiCrossChainHarness = new CrossChainTestHarness(
       aztecNode,
       aztecRpcServer,
+      await CheatCodes.create(aztecRpcServer),
       accounts,
       logger,
       daiContracts.l2Contract,
@@ -101,6 +103,7 @@ describe('uniswap_trade_on_l1_from_l2', () => {
     wethCrossChainHarness = new CrossChainTestHarness(
       aztecNode,
       aztecRpcServer,
+      await CheatCodes.create(aztecRpcServer),
       accounts,
       logger,
       wethContracts.l2Contract,

--- a/yarn-project/end-to-end/src/utils.ts
+++ b/yarn-project/end-to-end/src/utils.ts
@@ -52,6 +52,7 @@ import {
 } from 'viem';
 import { mnemonicToAccount } from 'viem/accounts';
 
+import { CheatCodes } from './cheat_codes.js';
 import { MNEMONIC, localAnvil } from './fixtures.js';
 
 const { SANDBOX_URL = '' } = process.env;
@@ -304,6 +305,10 @@ export async function setup(numberOfAccounts = 1): Promise<{
    * Logger instance named as the current test.
    */
   logger: DebugLogger;
+  /**
+   * The cheat codes.
+   */
+  cheatCodes: CheatCodes;
 }> {
   const config = getConfigEnvVars();
   const logger = getLogger();
@@ -322,6 +327,8 @@ export async function setup(numberOfAccounts = 1): Promise<{
 
   const { aztecRpcServer, accounts, wallet } = await setupAztecRPCServer(numberOfAccounts, aztecNode, privKey, logger);
 
+  const cheatCodes = await CheatCodes.create(config.rpcUrl, aztecRpcServer!);
+
   return {
     aztecNode,
     aztecRpcServer,
@@ -330,6 +337,7 @@ export async function setup(numberOfAccounts = 1): Promise<{
     config,
     wallet,
     logger,
+    cheatCodes,
   };
 }
 

--- a/yarn-project/end-to-end/src/utils.ts
+++ b/yarn-project/end-to-end/src/utils.ts
@@ -539,35 +539,6 @@ export async function calculateAztecStorageSlot(slot: bigint, key: Fr): Promise<
 }
 
 /**
- * Check the value of a public mapping's storage slot.
- * @param logger - A logger instance.
- * @param aztecNode - An instance of the aztec node service.
- * @param contract - The contract to check the storage slot of.
- * @param slot - The mapping's storage slot.
- * @param key - The mapping's key.
- * @param expectedValue - The expected value of the mapping.
- */
-export async function expectAztecStorageSlot(
-  logger: DebugLogger,
-  aztecRpc: AztecRPC,
-  contract: Contract,
-  slot: bigint,
-  key: Fr,
-  expectedValue: bigint,
-) {
-  const storageSlot = await calculateAztecStorageSlot(slot, key);
-  const storageValue = await aztecRpc.getPublicStorageAt(contract.address!, storageSlot);
-  if (storageValue === undefined) {
-    throw new Error(`Storage slot ${storageSlot} not found`);
-  }
-
-  const balance = toBigIntBE(storageValue);
-
-  logger(`Account ${key.toShortString()} balance: ${balance}`);
-  expect(balance).toBe(expectedValue);
-}
-
-/**
  * Checks the number of encrypted logs in the last block is as expected.
  * @param aztecNode - The instance of aztec node for retrieving the logs.
  * @param numEncryptedLogs - The number of expected logs.

--- a/yarn-project/end-to-end/src/utils.ts
+++ b/yarn-project/end-to-end/src/utils.ts
@@ -17,14 +17,13 @@ import {
   getL1ContractAddresses,
 } from '@aztec/aztec.js';
 import {
-  CircuitsWasm,
   DeploymentInfo,
   PartialContractAddress,
   PrivateKey,
   PublicKey,
   getContractDeploymentInfo,
 } from '@aztec/circuits.js';
-import { Schnorr, pedersenPlookupCommitInputs } from '@aztec/circuits.js/barretenberg';
+import { Schnorr } from '@aztec/circuits.js/barretenberg';
 import { DeployL1Contracts, deployL1Contract, deployL1Contracts } from '@aztec/ethereum';
 import { ContractAbi } from '@aztec/foundation/abi';
 import { Fr } from '@aztec/foundation/fields';
@@ -521,28 +520,6 @@ export async function deployAndInitializeNonNativeL2TokenContracts(
  */
 export function delay(ms: number): Promise<void> {
   return new Promise<void>(resolve => setTimeout(resolve, ms));
-}
-
-/**
- * Calculates the slot value of a mapping within noir.
- * @param slot - The storage slot of the mapping.
- * @param key - The key within the mapping.
- * @returns The mapping's key.
- */
-export async function calculateAztecStorageSlot(slot: bigint, key: Fr): Promise<Fr> {
-  const wasm = await CircuitsWasm.get();
-  const mappingStorageSlot = new Fr(slot); // this value is manually set in the Noir contract
-
-  // Based on `at` function in
-  // aztec3-packages/yarn-project/noir-contracts/src/contracts/noir-aztec/src/state_vars/map.nr
-  const storageSlot = Fr.fromBuffer(
-    pedersenPlookupCommitInputs(
-      wasm,
-      [mappingStorageSlot, key].map(f => f.toBuffer()),
-    ),
-  );
-
-  return storageSlot; //.value;
 }
 
 /**

--- a/yarn-project/end-to-end/src/utils.ts
+++ b/yarn-project/end-to-end/src/utils.ts
@@ -27,7 +27,6 @@ import {
 import { Schnorr, pedersenPlookupCommitInputs } from '@aztec/circuits.js/barretenberg';
 import { DeployL1Contracts, deployL1Contract, deployL1Contracts } from '@aztec/ethereum';
 import { ContractAbi } from '@aztec/foundation/abi';
-import { toBigIntBE } from '@aztec/foundation/bigint-buffer';
 import { Fr } from '@aztec/foundation/fields';
 import { mustSucceedFetch } from '@aztec/foundation/json-rpc/client';
 import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';


### PR DESCRIPTION
# Description

Fixes #1281.

Introduces an initial `CheatCodes` class that will contain the non-intrusive cheatcodes, and can later be altered as a fork of the node.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
