### PR TITLE
refactor: another pedantic change to public state naming

### DIFF
--- a/docs/docs/aztec/developer/wallet-providers/keys.md
+++ b/docs/docs/aztec/developer/wallet-providers/keys.md
@@ -107,7 +107,7 @@ An application in Noir can request a nullifier from the current user for computi
 
 ```noir
 fn compute_nullifier(self) -> Field {
-    let siloed_note_hash = compute_siloed_note_hash(ValueNoteInterface, self);
+    let siloed_note_hash = compute_siloed_note_hash(ValueNoteMethods, self);
     let secret = get_secret_key(self.owner);
     dep::std::hash::pedersen([siloed_note_hash, secret])[0]
 }

--- a/yarn-project/noir-contracts/src/contracts/child_contract/src/storage.nr
+++ b/yarn-project/noir-contracts/src/contracts/child_contract/src/storage.nr
@@ -1,6 +1,6 @@
 use dep::aztec::state_vars::public_state::PublicState;
-use dep::aztec::state_vars::type_serialisation_interface::field_serialisation_interface::FieldSerialisationInterface;
-use dep::aztec::state_vars::type_serialisation_interface::field_serialisation_interface::FIELD_SERIALISED_LEN;
+use dep::aztec::state_vars::type_serialisation::field_serialisation::FieldSerialisationMethods;
+use dep::aztec::state_vars::type_serialisation::field_serialisation::FIELD_SERIALISED_LEN;
 
 struct Storage {
     current_value: PublicState<Field, FIELD_SERIALISED_LEN>,
@@ -9,7 +9,7 @@ struct Storage {
 impl Storage {
     fn init() -> Self {
         Storage {
-            current_value: PublicState::new(1, FieldSerialisationInterface),
+            current_value: PublicState::new(1, FieldSerialisationMethods),
         }
     }
 }

--- a/yarn-project/noir-contracts/src/contracts/easy_zk_token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/easy_zk_token_contract/src/main.nr
@@ -5,7 +5,7 @@ contract EasyZkToken {
     use dep::value_note::{
             balance_utils,
             value_note::{
-                ValueNoteInterface,
+                ValueNoteMethods,
                 VALUE_NOTE_LEN,
             },
     };
@@ -105,6 +105,6 @@ contract EasyZkToken {
     // Note 2: Having it in all the contracts gives us the ability to compute the note hash and nullifier differently for different kind of notes.
     unconstrained fn compute_note_hash_and_nullifier(contract_address: Field, nonce: Field, storage_slot: Field, preimage: [Field; VALUE_NOTE_LEN]) -> [Field; 4] {
         let note_header = NoteHeader { contract_address, nonce, storage_slot };
-        note_utils::compute_note_hash_and_nullifier(ValueNoteInterface, note_header, preimage)
+        note_utils::compute_note_hash_and_nullifier(ValueNoteMethods, note_header, preimage)
     }
 }

--- a/yarn-project/noir-contracts/src/contracts/escrow_contract/src/address_note.nr
+++ b/yarn-project/noir-contracts/src/contracts/escrow_contract/src/address_note.nr
@@ -28,7 +28,7 @@ impl AddressNote {
     }
 
     fn compute_nullifier(self) -> Field {
-        let siloed_note_hash = compute_siloed_note_hash(AddressNoteInterface, self);
+        let siloed_note_hash = compute_siloed_note_hash(AddressNoteMethods, self);
         let owner_nullifying_public_key = get_public_key(self.owner);
         let secret = get_secret_key(owner_nullifying_public_key);
         dep::std::hash::pedersen([
@@ -82,7 +82,7 @@ fn set_header(note: &mut AddressNote, header: NoteHeader) {
     note.set_header(header);
 }
 
-global AddressNoteInterface = NoteInterface {
+global AddressNoteMethods = NoteInterface {
     deserialise,
     serialise,
     compute_note_hash,

--- a/yarn-project/noir-contracts/src/contracts/escrow_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/escrow_contract/src/main.nr
@@ -19,7 +19,7 @@ contract Escrow {
 
     use crate::address_note::{
         AddressNote,
-        AddressNoteInterface,
+        AddressNoteMethods,
         ADDRESS_NOTE_LEN
     };
 
@@ -74,6 +74,6 @@ contract Escrow {
     unconstrained fn compute_note_hash_and_nullifier(contract_address: Field, nonce: Field, storage_slot: Field, preimage: [Field; ADDRESS_NOTE_LEN]) -> [Field; 4] {
         let note_header = NoteHeader { contract_address, nonce, storage_slot };
         assert(storage_slot == 1);
-        note_utils::compute_note_hash_and_nullifier(AddressNoteInterface, note_header, preimage)
+        note_utils::compute_note_hash_and_nullifier(AddressNoteMethods, note_header, preimage)
     }
 }

--- a/yarn-project/noir-contracts/src/contracts/escrow_contract/src/storage.nr
+++ b/yarn-project/noir-contracts/src/contracts/escrow_contract/src/storage.nr
@@ -4,7 +4,7 @@ use dep::aztec::state_vars::{
 
 use crate::address_note::{
     AddressNote,
-    AddressNoteInterface,
+    AddressNoteMethods,
     ADDRESS_NOTE_LEN,
 };
 
@@ -15,7 +15,7 @@ struct Storage {
 impl Storage {
     fn init() -> Self {
         Storage {
-            owners: Set::new(1, AddressNoteInterface),
+            owners: Set::new(1, AddressNoteMethods),
         }
     }
 }

--- a/yarn-project/noir-contracts/src/contracts/lending_contract/src/storage.nr
+++ b/yarn-project/noir-contracts/src/contracts/lending_contract/src/storage.nr
@@ -1,8 +1,8 @@
 use dep::aztec::state_vars::map::Map;
 use dep::aztec::state_vars::public_state::PublicState;
-use dep::aztec::state_vars::type_serialisation_interface::TypeSerialisationInterface;
-use dep::aztec::state_vars::type_serialisation_interface::field_serialisation_interface::FieldSerialisationInterface;
-use dep::aztec::state_vars::type_serialisation_interface::field_serialisation_interface::FIELD_SERIALISED_LEN;
+use dep::aztec::state_vars::type_serialisation::TypeSerialisationInterface;
+use dep::aztec::state_vars::type_serialisation::field_serialisation::FieldSerialisationMethods;
+use dep::aztec::state_vars::type_serialisation::field_serialisation::FIELD_SERIALISED_LEN;
 use dep::std::hash::pedersen;
 
 // Utility struct used to easily get a "id" for a private user that sits in the same
@@ -30,7 +30,6 @@ impl Account {
 }
 
 
-global TOT_SERIALISED_LEN: Field = 2;
 
 // Struct to be used to represent "totals". Generally, there should be one per asset.
 // It stores the global values that are shared among all users, such as an accumulator
@@ -41,6 +40,8 @@ struct Tot {
     interest_accumulator: u120,
     last_updated_ts: u120,
 }
+
+global TOT_SERIALISED_LEN: Field = 2;
 
 fn deserialiseTot(fields: [Field; TOT_SERIALISED_LEN]) -> Tot {
     Tot {
@@ -53,35 +54,35 @@ fn serialiseTot(tot: Tot) -> [Field; TOT_SERIALISED_LEN] {
     [tot.interest_accumulator as Field, tot.last_updated_ts as Field]
 }
 
-global TotSerialisationInterface = TypeSerialisationInterface {
+global TotSerialisationMethods = TypeSerialisationInterface {
     deserialise: deserialiseTot,
     serialise: serialiseTot,
 };
 
 
-// Struct to be used to represent positions when we have more reads.
-global POS_SERIALISED_LEN: Field = 2;
+// // Struct to be used to represent positions when we have more reads.
+// global POS_SERIALISED_LEN: Field = 2;
 
-struct Pos {
-    owner: Field,
-    value: Field,
-}
+// struct Pos {
+//     owner: Field,
+//     value: Field,
+// }
 
-fn deserialisePos(fields: [Field; POS_SERIALISED_LEN]) -> Pos {
-    Pos {
-        owner: fields[0],
-        value: fields[1],
-    }
-}
+// fn deserialisePos(fields: [Field; POS_SERIALISED_LEN]) -> Pos {
+//     Pos {
+//         owner: fields[0],
+//         value: fields[1],
+//     }
+// }
 
-fn serialisePos(pos: Pos) -> [Field; POS_SERIALISED_LEN] {
-    [pos.owner, pos.value]
-}
+// fn serialisePos(pos: Pos) -> [Field; POS_SERIALISED_LEN] {
+//     [pos.owner, pos.value]
+// }
 
-global PosSerialisationInterface = TypeSerialisationInterface {
-    deserialise: deserialisePos,
-    serialise: serialisePos,
-};
+// global PosSerialisationMethods = TypeSerialisationInterface {
+//     deserialise: deserialisePos,
+//     serialise: serialisePos,
+// };
 
 
 // Storage structure, containing all storage, and specifying what slots they use.
@@ -94,9 +95,9 @@ struct Storage {
 impl Storage {
     fn init() -> Self {
         Storage {
-            assets: Map::new(1, |slot| PublicState::new(slot, TotSerialisationInterface)), // uses 2 storage slots.
-            collateral: Map::new(2, |slot| PublicState::new(slot, FieldSerialisationInterface)), // uses 1 storage slots.
-            static_debt: Map::new(3, |slot| PublicState::new(slot, FieldSerialisationInterface)), // uses 1 storage slots. 
+            assets: Map::new(1, |slot| PublicState::new(slot, TotSerialisationMethods)),
+            collateral: Map::new(2, |slot| PublicState::new(slot, FieldSerialisationMethods)),
+            static_debt: Map::new(3, |slot| PublicState::new(slot, FieldSerialisationMethods)),
         }
     }
 }

--- a/yarn-project/noir-contracts/src/contracts/non_native_token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/non_native_token_contract/src/main.nr
@@ -21,7 +21,7 @@ contract NonNativeToken {
     use dep::value_note::{
         balance_utils,
         utils::{send_note, spend_notes},
-        value_note::{VALUE_NOTE_LEN, ValueNoteInterface},
+        value_note::{VALUE_NOTE_LEN, ValueNoteMethods},
     };
 
     use crate::transparent_note::TransparentNote;
@@ -327,6 +327,6 @@ contract NonNativeToken {
     // Note 2: Having it in all the contracts gives us the ability to compute the note hash and nullifier differently for different kind of notes.
     unconstrained fn compute_note_hash_and_nullifier(contract_address: Field, nonce: Field, storage_slot: Field, preimage: [Field; VALUE_NOTE_LEN]) -> [Field; 4] {
         let note_header = NoteHeader { contract_address, nonce, storage_slot };
-        note_utils::compute_note_hash_and_nullifier(ValueNoteInterface, note_header, preimage)
+        note_utils::compute_note_hash_and_nullifier(ValueNoteMethods, note_header, preimage)
     }
 }

--- a/yarn-project/noir-contracts/src/contracts/non_native_token_contract/src/storage.nr
+++ b/yarn-project/noir-contracts/src/contracts/non_native_token_contract/src/storage.nr
@@ -2,15 +2,15 @@ use dep::aztec::state_vars::{
     map::Map,
     set::Set,
     public_state::PublicState,
-    type_serialisation_interface::field_serialisation_interface::{
+    type_serialisation::field_serialisation::{
         FIELD_SERIALISED_LEN,
-        FieldSerialisationInterface,
+        FieldSerialisationMethods,
     },
 };
 
 use dep::value_note::value_note::{
     ValueNote,
-    ValueNoteInterface,
+    ValueNoteMethods,
     VALUE_NOTE_LEN,
 };
 
@@ -23,8 +23,8 @@ struct Storage {
 impl Storage {
     fn init() -> Self {
         Storage {
-            balances: Map::new(1, |slot| Set::new(slot, ValueNoteInterface)),
-            public_balances: Map::new(2, |slot| PublicState::new(slot, FieldSerialisationInterface)),
+            balances: Map::new(1, |slot| Set::new(slot, ValueNoteMethods)),
+            public_balances: Map::new(2, |slot| PublicState::new(slot, FieldSerialisationMethods)),
         }
     }
 }

--- a/yarn-project/noir-contracts/src/contracts/pending_commitments_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/pending_commitments_contract/src/main.nr
@@ -9,7 +9,7 @@ contract PendingCommitments {
     use dep::value_note::{
         balance_utils,
         filter::get_2_notes,
-        value_note::{VALUE_NOTE_LEN, ValueNote, ValueNoteInterface},
+        value_note::{VALUE_NOTE_LEN, ValueNote, ValueNoteMethods},
     };
 
     use crate::storage::Storage;
@@ -231,6 +231,6 @@ contract PendingCommitments {
     // Note 2: Having it in all the contracts gives us the ability to compute the note hash and nullifier differently for different kind of notes.
     unconstrained fn compute_note_hash_and_nullifier(contract_address: Field, nonce: Field, storage_slot: Field, preimage: [Field; VALUE_NOTE_LEN]) -> [Field; 4] {
         let note_header = NoteHeader { contract_address, nonce, storage_slot };
-        note_utils::compute_note_hash_and_nullifier(ValueNoteInterface, note_header, preimage)
+        note_utils::compute_note_hash_and_nullifier(ValueNoteMethods, note_header, preimage)
     }
 }

--- a/yarn-project/noir-contracts/src/contracts/pending_commitments_contract/src/storage.nr
+++ b/yarn-project/noir-contracts/src/contracts/pending_commitments_contract/src/storage.nr
@@ -4,7 +4,7 @@ use dep::aztec::state_vars::{
 };
 use dep::value_note::value_note::{
     ValueNote,
-    ValueNoteInterface,
+    ValueNoteMethods,
     VALUE_NOTE_LEN,
 };
 
@@ -15,7 +15,7 @@ struct Storage {
 impl Storage {
     fn init() -> Self {
         Storage {
-            balances: Map::new(1, |s| Set::new(s, ValueNoteInterface)),
+            balances: Map::new(1, |s| Set::new(s, ValueNoteMethods)),
         }
     }
 }

--- a/yarn-project/noir-contracts/src/contracts/pokeable_token_contract/src/address_note.nr
+++ b/yarn-project/noir-contracts/src/contracts/pokeable_token_contract/src/address_note.nr
@@ -27,7 +27,7 @@ impl AddressNote {
     }
 
     fn compute_nullifier(self) -> Field {
-        let siloed_note_hash = compute_siloed_note_hash(AddressNoteInterface, self);
+        let siloed_note_hash = compute_siloed_note_hash(AddressNoteMethods, self);
         let owner_nullifying_public_key = get_public_key(self.address);
         let secret = get_secret_key(owner_nullifying_public_key);
         dep::std::hash::pedersen([
@@ -79,7 +79,7 @@ fn set_header(note: &mut AddressNote, header: NoteHeader) {
     note.set_header(header);
 }
 
-global AddressNoteInterface = NoteInterface {
+global AddressNoteMethods = NoteInterface {
     deserialise,
     serialise,
     compute_note_hash,

--- a/yarn-project/noir-contracts/src/contracts/pokeable_token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/pokeable_token_contract/src/main.nr
@@ -22,7 +22,7 @@ contract PokeableToken {
     use dep::aztec::log::emit_encrypted_log;
 
     use crate::storage::Storage;
-    use crate::address_note::{AddressNote, AddressNoteInterface};
+    use crate::address_note::{AddressNote, AddressNoteMethods};
 
     // Constructs the contract and sets `initial_supply` which is fully owned by `sender`.
     fn constructor(
@@ -135,7 +135,7 @@ contract PokeableToken {
     unconstrained fn compute_note_hash_and_nullifier(contract_address: Field, nonce: Field, storage_slot: Field, preimage: [Field; VALUE_NOTE_LEN]) -> [Field; 4] {
         let note_header = NoteHeader { contract_address, nonce, storage_slot };
         if (storage_slot == 1) | (storage_slot == 2) {
-            note_utils::compute_note_hash_and_nullifier(AddressNoteInterface, note_header, preimage)
+            note_utils::compute_note_hash_and_nullifier(AddressNoteMethods, note_header, preimage)
         } else {
             note_utils::compute_note_hash_and_nullifier(ValueNoteMethods, note_header, preimage)
         }

--- a/yarn-project/noir-contracts/src/contracts/pokeable_token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/pokeable_token_contract/src/main.nr
@@ -6,7 +6,7 @@ contract PokeableToken {
     use dep::value_note::{
         balance_utils,
         utils::{send_note, spend_notes},
-        value_note::{VALUE_NOTE_LEN, ValueNoteInterface, ValueNote},
+        value_note::{VALUE_NOTE_LEN, ValueNoteMethods, ValueNote},
         filter::get_2_notes,
     };
     use dep::aztec::abi;
@@ -137,7 +137,7 @@ contract PokeableToken {
         if (storage_slot == 1) | (storage_slot == 2) {
             note_utils::compute_note_hash_and_nullifier(AddressNoteInterface, note_header, preimage)
         } else {
-            note_utils::compute_note_hash_and_nullifier(ValueNoteInterface, note_header, preimage)
+            note_utils::compute_note_hash_and_nullifier(ValueNoteMethods, note_header, preimage)
         }
     }
 }

--- a/yarn-project/noir-contracts/src/contracts/pokeable_token_contract/src/storage.nr
+++ b/yarn-project/noir-contracts/src/contracts/pokeable_token_contract/src/storage.nr
@@ -10,7 +10,7 @@ use crate::address_note::{
 };
 use dep::value_note::value_note::{
     ValueNote,
-    ValueNoteInterface,
+    ValueNoteMethods,
     VALUE_NOTE_LEN,
 };
 
@@ -25,7 +25,7 @@ impl Storage {
         Storage {
             sender: ImmutableSingleton::new(1, AddressNoteInterface),
             recipient: ImmutableSingleton::new(2, AddressNoteInterface),
-            balances: Map::new(3, |s| Set::new(s, ValueNoteInterface)),
+            balances: Map::new(3, |slot| Set::new(slot, ValueNoteMethods)),
         }
     }
 }

--- a/yarn-project/noir-contracts/src/contracts/pokeable_token_contract/src/storage.nr
+++ b/yarn-project/noir-contracts/src/contracts/pokeable_token_contract/src/storage.nr
@@ -5,7 +5,7 @@ use dep::aztec::state_vars::{
 };
 use crate::address_note::{
     AddressNote,
-    AddressNoteInterface,
+    AddressNoteMethods,
     ADDRESS_NOTE_LEN,
 };
 use dep::value_note::value_note::{
@@ -23,8 +23,8 @@ struct Storage {
 impl Storage {
     fn init() -> Self {
         Storage {
-            sender: ImmutableSingleton::new(1, AddressNoteInterface),
-            recipient: ImmutableSingleton::new(2, AddressNoteInterface),
+            sender: ImmutableSingleton::new(1, AddressNoteMethods),
+            recipient: ImmutableSingleton::new(2, AddressNoteMethods),
             balances: Map::new(3, |slot| Set::new(slot, ValueNoteMethods)),
         }
     }

--- a/yarn-project/noir-contracts/src/contracts/public_token_contract/src/storage.nr
+++ b/yarn-project/noir-contracts/src/contracts/public_token_contract/src/storage.nr
@@ -1,7 +1,7 @@
 use dep::aztec::state_vars::map::Map;
 use dep::aztec::state_vars::public_state::PublicState;
-use dep::aztec::state_vars::type_serialisation_interface::field_serialisation_interface::FieldSerialisationInterface;
-use dep::aztec::state_vars::type_serialisation_interface::field_serialisation_interface::FIELD_SERIALISED_LEN;
+use dep::aztec::state_vars::type_serialisation::field_serialisation::FieldSerialisationMethods;
+use dep::aztec::state_vars::type_serialisation::field_serialisation::FIELD_SERIALISED_LEN;
 
 struct Storage {
     balances: Map<PublicState<Field, FIELD_SERIALISED_LEN>>,
@@ -11,7 +11,7 @@ struct Storage {
 impl Storage {
     fn init() -> Self {
         Storage {
-            balances: Map::new(1, |slot| PublicState::new(slot, FieldSerialisationInterface)),
+            balances: Map::new(1, |slot| PublicState::new(slot, FieldSerialisationMethods)),
         }
     }
 }

--- a/yarn-project/noir-contracts/src/contracts/schnorr_multi_key_account_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/schnorr_multi_key_account_contract/src/main.nr
@@ -24,7 +24,7 @@ contract SchnorrMultiKeyAccount {
 
     use crate::storage::Storage;
     use crate::public_key_note::PublicKeyNote;
-    use crate::public_key_note::PublicKeyNoteInterface;
+    use crate::public_key_note::PublicKeyNoteMethods;
     use crate::public_key_note::PUBLIC_KEY_NOTE_LEN;
 
     fn entrypoint(
@@ -90,6 +90,6 @@ contract SchnorrMultiKeyAccount {
     unconstrained fn compute_note_hash_and_nullifier(contract_address: Field, nonce: Field, storage_slot: Field, preimage: [Field; PUBLIC_KEY_NOTE_LEN]) -> [Field; 4] {
         assert(storage_slot == 1);
         let note_header = NoteHeader { contract_address, nonce, storage_slot };
-        note_utils::compute_note_hash_and_nullifier(PublicKeyNoteInterface, note_header, preimage)
+        note_utils::compute_note_hash_and_nullifier(PublicKeyNoteMethods, note_header, preimage)
     }
 }

--- a/yarn-project/noir-contracts/src/contracts/schnorr_multi_key_account_contract/src/public_key_note.nr
+++ b/yarn-project/noir-contracts/src/contracts/schnorr_multi_key_account_contract/src/public_key_note.nr
@@ -32,7 +32,7 @@ impl PublicKeyNote {
     }
 
     fn compute_nullifier(self) -> Field {
-        let siloed_note_hash = compute_siloed_note_hash(PublicKeyNoteInterface, self);
+        let siloed_note_hash = compute_siloed_note_hash(PublicKeyNoteMethods, self);
         let owner_nullifying_public_key = get_public_key(self.owner);
         let secret = get_secret_key(owner_nullifying_public_key);
         dep::std::hash::pedersen([
@@ -88,7 +88,7 @@ fn set_header(note: &mut PublicKeyNote, header: NoteHeader) {
     note.set_header(header);
 }
 
-global PublicKeyNoteInterface = NoteInterface {
+global PublicKeyNoteMethods = NoteInterface {
     deserialise,
     serialise,
     compute_note_hash,

--- a/yarn-project/noir-contracts/src/contracts/schnorr_multi_key_account_contract/src/storage.nr
+++ b/yarn-project/noir-contracts/src/contracts/schnorr_multi_key_account_contract/src/storage.nr
@@ -4,7 +4,7 @@ use dep::aztec::state_vars::{
 
 use crate::public_key_note::{
     PublicKeyNote,
-    PublicKeyNoteInterface,
+    PublicKeyNoteMethods,
     PUBLIC_KEY_NOTE_LEN,
 };
 
@@ -15,7 +15,7 @@ struct Storage {
 impl Storage {
     fn init() -> Self {
         Storage {
-            signing_public_key: ImmutableSingleton::new(1, PublicKeyNoteInterface)
+            signing_public_key: ImmutableSingleton::new(1, PublicKeyNoteMethods)
         }
     }
 }

--- a/yarn-project/noir-contracts/src/contracts/zk_token_contract/src/claim_note.nr
+++ b/yarn-project/noir-contracts/src/contracts/zk_token_contract/src/claim_note.nr
@@ -42,7 +42,7 @@ impl ClaimNote {
     }
 
     fn compute_nullifier(self) -> Field {
-        let siloed_note_hash = compute_siloed_note_hash(ClaimNoteInterface, self);
+        let siloed_note_hash = compute_siloed_note_hash(ClaimNoteMethods, self);
         dep::std::hash::pedersen([
             siloed_note_hash,
             self.secret_hash, // Include the secret_hash again so that the public won't know the note has been claimed.
@@ -90,7 +90,7 @@ fn set_header(note: &mut ClaimNote, header: NoteHeader) {
     note.set_header(header)
 }
 
-global ClaimNoteInterface = NoteInterface {
+global ClaimNoteMethods = NoteInterface {
     deserialise,
     serialise,
     compute_note_hash,

--- a/yarn-project/noir-contracts/src/contracts/zk_token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/zk_token_contract/src/main.nr
@@ -6,7 +6,7 @@ contract ZkToken {
     use dep::value_note::{
         balance_utils,
         utils::{send_note, spend_notes},
-        value_note::{VALUE_NOTE_LEN, ValueNoteInterface},
+        value_note::{VALUE_NOTE_LEN, ValueNoteMethods},
     };
 
     use dep::aztec::abi;
@@ -169,7 +169,7 @@ contract ZkToken {
         if (storage_slot == 2) {
             note_utils::compute_note_hash_and_nullifier(ClaimNoteInterface, note_header, preimage)
         } else {
-            note_utils::compute_note_hash_and_nullifier(ValueNoteInterface, note_header, preimage)
+            note_utils::compute_note_hash_and_nullifier(ValueNoteMethods, note_header, preimage)
         }
     }
 }

--- a/yarn-project/noir-contracts/src/contracts/zk_token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/zk_token_contract/src/main.nr
@@ -19,7 +19,7 @@ contract ZkToken {
     use dep::aztec::log::emit_unencrypted_log;
 
     use crate::storage::Storage;
-    use crate::claim_note::{ClaimNote, ClaimNoteInterface};
+    use crate::claim_note::{ClaimNote, ClaimNoteMethods};
 
 
     // Constructs the contract and sets `initial_supply` which is fully owned by `owner`.
@@ -167,7 +167,7 @@ contract ZkToken {
     unconstrained fn compute_note_hash_and_nullifier(contract_address: Field, nonce: Field, storage_slot: Field, preimage: [Field; VALUE_NOTE_LEN]) -> [Field; 4] {
         let note_header = NoteHeader { contract_address, nonce, storage_slot };
         if (storage_slot == 2) {
-            note_utils::compute_note_hash_and_nullifier(ClaimNoteInterface, note_header, preimage)
+            note_utils::compute_note_hash_and_nullifier(ClaimNoteMethods, note_header, preimage)
         } else {
             note_utils::compute_note_hash_and_nullifier(ValueNoteMethods, note_header, preimage)
         }

--- a/yarn-project/noir-contracts/src/contracts/zk_token_contract/src/storage.nr
+++ b/yarn-project/noir-contracts/src/contracts/zk_token_contract/src/storage.nr
@@ -4,7 +4,7 @@ use dep::aztec::state_vars::{
 };
 use dep::value_note::value_note::{
     ValueNote,
-    ValueNoteInterface,
+    ValueNoteMethods,
     VALUE_NOTE_LEN,
 };
 use crate::claim_note::{CLAIM_NOTE_LEN, ClaimNote, ClaimNoteInterface};
@@ -17,7 +17,7 @@ struct Storage {
 impl Storage {
     fn init() -> Self {
         Storage {
-            balances: Map::new(1, |s| Set::new(s, ValueNoteInterface)),
+            balances: Map::new(1, |s| Set::new(s, ValueNoteMethods)),
             claims: Set::new(2, ClaimNoteInterface),
         }
     }

--- a/yarn-project/noir-contracts/src/contracts/zk_token_contract/src/storage.nr
+++ b/yarn-project/noir-contracts/src/contracts/zk_token_contract/src/storage.nr
@@ -7,7 +7,7 @@ use dep::value_note::value_note::{
     ValueNoteMethods,
     VALUE_NOTE_LEN,
 };
-use crate::claim_note::{CLAIM_NOTE_LEN, ClaimNote, ClaimNoteInterface};
+use crate::claim_note::{CLAIM_NOTE_LEN, ClaimNote, ClaimNoteMethods};
 
 struct Storage {
     balances: Map<Set<ValueNote, VALUE_NOTE_LEN>>,
@@ -18,7 +18,7 @@ impl Storage {
     fn init() -> Self {
         Storage {
             balances: Map::new(1, |s| Set::new(s, ValueNoteMethods)),
-            claims: Set::new(2, ClaimNoteInterface),
+            claims: Set::new(2, ClaimNoteMethods),
         }
     }
 }

--- a/yarn-project/noir-libs/easy-private-state/src/easy_private_state.nr
+++ b/yarn-project/noir-libs/easy-private-state/src/easy_private_state.nr
@@ -2,7 +2,7 @@ use dep::value_note::{
     filter::get_2_notes,
     value_note::{
         ValueNote,
-        ValueNoteInterface,
+        ValueNoteMethods,
         VALUE_NOTE_LEN,
     },
 };
@@ -28,7 +28,7 @@ impl EasyPrivateUint {
     fn new(storage_slot: Field) -> Self {
         let set = Set {
             storage_slot,
-            note_interface: ValueNoteInterface,
+            note_interface: ValueNoteMethods,
         };
         EasyPrivateUint {
             set,

--- a/yarn-project/noir-libs/noir-aztec/src/state_vars.nr
+++ b/yarn-project/noir-libs/noir-aztec/src/state_vars.nr
@@ -1,6 +1,6 @@
 mod immutable_singleton;
 mod map;
 mod public_state;
-mod type_serialisation_interface;
+mod type_serialisation;
 mod set;
 mod singleton;

--- a/yarn-project/noir-libs/noir-aztec/src/state_vars/public_state.nr
+++ b/yarn-project/noir-libs/noir-aztec/src/state_vars/public_state.nr
@@ -1,23 +1,23 @@
 use crate::oracle::storage::storage_read;
 use crate::oracle::storage::storage_write;
-use crate::state_vars::type_serialisation_interface::TypeSerialisationInterface;
+use crate::state_vars::type_serialisation::TypeSerialisationInterface;
 
 struct PublicState<T, N> {
     storage_slot: Field,
-    serialisation_interface: TypeSerialisationInterface<T, N>,
+    serialisation_methods: TypeSerialisationInterface<T, N>,
 }
 
 impl<T, N> PublicState<T, N> {
-    fn new(storage_slot: Field, serialisation_interface: TypeSerialisationInterface<T, N>) -> Self {
-        PublicState { storage_slot, serialisation_interface }
+    fn new(storage_slot: Field, serialisation_methods: TypeSerialisationInterface<T, N>) -> Self {
+        PublicState { storage_slot, serialisation_methods }
     }
 
     fn read(self) -> T {
-        storage_read(self.storage_slot, self.serialisation_interface.deserialise)
+        storage_read(self.storage_slot, self.serialisation_methods.deserialise)
     }
 
     fn write(self, value: T) {
-        let serialise = self.serialisation_interface.serialise;
+        let serialise = self.serialisation_methods.serialise;
         let fields = serialise(value);
         storage_write(self.storage_slot, fields);
     }

--- a/yarn-project/noir-libs/noir-aztec/src/state_vars/type_serialisation.nr
+++ b/yarn-project/noir-libs/noir-aztec/src/state_vars/type_serialisation.nr
@@ -1,4 +1,4 @@
-mod field_serialisation_interface;
+mod field_serialisation;
 
 /**
  * Before Noir supports traits, a way of specifying the serialisation and deserialisation methods for a type.

--- a/yarn-project/noir-libs/noir-aztec/src/state_vars/type_serialisation/field_serialisation.nr
+++ b/yarn-project/noir-libs/noir-aztec/src/state_vars/type_serialisation/field_serialisation.nr
@@ -1,4 +1,4 @@
-use crate::state_vars::type_serialisation_interface::TypeSerialisationInterface;
+use crate::state_vars::type_serialisation::TypeSerialisationInterface;
 
 global FIELD_SERIALISED_LEN: Field = 1;
 
@@ -10,7 +10,7 @@ fn serialiseField(value: Field) -> [Field; FIELD_SERIALISED_LEN] {
     [value]
 }
 
-global FieldSerialisationInterface = TypeSerialisationInterface {
+global FieldSerialisationMethods = TypeSerialisationInterface {
     deserialise: deserialiseField,
     serialise: serialiseField,
 };

--- a/yarn-project/noir-libs/value-note/src/balance_utils.nr
+++ b/yarn-project/noir-libs/value-note/src/balance_utils.nr
@@ -1,5 +1,5 @@
 use dep::aztec::note::note_getter::view_notes;
-use crate::value_note::{VALUE_NOTE_LEN, ValueNoteInterface};
+use crate::value_note::{VALUE_NOTE_LEN, ValueNoteMethods};
 
 unconstrained fn get_balance(storage_slot: Field) -> Field {
     get_balance_internal(storage_slot, 10, 0)
@@ -11,9 +11,9 @@ unconstrained fn get_balance(storage_slot: Field) -> Field {
 unconstrained fn get_balance_internal(storage_slot: Field, limit: u32, offset: u32) -> Field {
     let mut balance = 0;
 
-    let opt_notes = view_notes(storage_slot, ValueNoteInterface, limit, offset);
+    let opt_notes = view_notes(storage_slot, ValueNoteMethods, limit, offset);
     let len = opt_notes.len();
-    let dummy = ValueNoteInterface.dummy;
+    let dummy = ValueNoteMethods.dummy;
     for i in 0..len {
         balance += opt_notes[i].unwrap_or(dummy()).value;
     }

--- a/yarn-project/noir-libs/value-note/src/value_note.nr
+++ b/yarn-project/noir-libs/value-note/src/value_note.nr
@@ -53,7 +53,7 @@ impl ValueNote {
     }
 
     fn compute_nullifier(self) -> Field {
-        let siloed_note_hash = compute_siloed_note_hash(ValueNoteInterface, self);
+        let siloed_note_hash = compute_siloed_note_hash(ValueNoteMethods, self);
         let owner_nullifying_public_key = get_public_key(self.owner);
         // TODO: get_secret_key should just accept an address
         // TODO!
@@ -106,7 +106,7 @@ fn set_header(note: &mut ValueNote, header: NoteHeader) {
     note.set_header(header)
 }
 
-global ValueNoteInterface = NoteInterface {
+global ValueNoteMethods = NoteInterface {
     deserialise,
     serialise,
     compute_note_hash,


### PR DESCRIPTION
# Description

I was writing docs, and something still felt a bit off when trying to explain and justify the process of `PublicState` initialisation. Renaming things helped describe what was happening.

I renamed structs from `MyTypeSerialisationInterface` to `MyTypeSerialisationMethods`. Only `TypeSerialisationInterface` is an interface. We then create global instances of methods which adhere to this interface.

Similarly, I've renamed `MyNoteInterface` structs to be `MyNoteMethods`, because they're collections of methods which adhere to the `NoteInterface`. E.g. `ValueNoteMethods` implement the `NoteInterface`.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] The branch has been merged or rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
