### PR TITLE
feat(aztec-js): Return contract instance when awaiting deploy tx

### DIFF
--- a/circuits/README.md
+++ b/circuits/README.md
@@ -8,7 +8,7 @@ See [CODING_STANDARD.md](./CODING_STANDARD.md)\*\* before contributing!
 
 ## Repository Overview
 
-The [`aztec3-circpuits`](https://github.com/AztecProtocol/aztec3-packages) circuits folder contains circuits and related C++ code (`cpp/`) for Aztec3 along with Typescript wrappers (`ts/`).
+The [`aztec3-circuits`](https://github.com/AztecProtocol/aztec3-packages) circuits folder contains circuits and related C++ code (`cpp/`) for Aztec3 along with Typescript wrappers (`ts/`).
 
 ### Dependencies
 

--- a/yarn-project/aztec-sandbox/src/examples/uniswap_trade_on_l1_from_l2.ts
+++ b/yarn-project/aztec-sandbox/src/examples/uniswap_trade_on_l1_from_l2.ts
@@ -109,7 +109,7 @@ async function deployAllContracts(owner: AztecAddress) {
 
   // deploy l2 uniswap contract and attach to portal
   const tx = UniswapContract.deploy(aztecRpcClient).send({ portalContract: uniswapPortalAddress });
-  await tx.isMined(0, 0.5);
+  await tx.isMined({ interval: 0.5 });
   const receipt = await tx.getReceipt();
   const uniswapL2Contract = await UniswapContract.create(receipt.contractAddress!, wallet);
   await uniswapL2Contract.attach(uniswapPortalAddress);
@@ -158,7 +158,7 @@ const transferWethOnL2 = async (
   const transferTx = wethL2Contract.methods
     .transfer(transferAmount, ownerAddress, receiver)
     .send({ origin: ownerAddress });
-  await transferTx.isMined(0, 0.5);
+  await transferTx.isMined({ interval: 0.5 });
   const transferReceipt = await transferTx.getReceipt();
   // expect(transferReceipt.status).toBe(TxStatus.MINED);
   logger(`WETH to L2 Transfer Receipt status: ${transferReceipt.status} should be ${TxStatus.MINED}`);
@@ -226,7 +226,7 @@ async function main() {
   const consumptionTx = wethL2Contract.methods
     .mint(wethAmountToBridge, owner, messageKey, secret, ethAccount.toField())
     .send({ origin: owner });
-  await consumptionTx.isMined(0, 0.5);
+  await consumptionTx.isMined({ interval: 0.5 });
   const consumptionReceipt = await consumptionTx.getReceipt();
   // expect(consumptionReceipt.status).toBe(TxStatus.MINED);
   logger(`Consumption Receipt status: ${consumptionReceipt.status} should be ${TxStatus.MINED}`);
@@ -261,7 +261,7 @@ async function main() {
       ethAccount.toField(),
     )
     .send({ origin: owner });
-  await withdrawTx.isMined(0, 0.5);
+  await withdrawTx.isMined({ interval: 0.5 });
   const withdrawReceipt = await withdrawTx.getReceipt();
   // expect(withdrawReceipt.status).toBe(TxStatus.MINED);
   logger(`Withdraw receipt status: ${withdrawReceipt.status} should be ${TxStatus.MINED}`);
@@ -312,7 +312,7 @@ async function main() {
   const daiMintTx = daiL2Contract.methods
     .mint(daiAmountToBridge, owner, depositDaiMessageKey, secret, ethAccount.toField())
     .send({ origin: owner });
-  await daiMintTx.isMined(0, 0.5);
+  await daiMintTx.isMined({ interval: 0.5 });
   const daiMintTxReceipt = await daiMintTx.getReceipt();
   // expect(daiMintTxReceipt.status).toBe(TxStatus.MINED);
   logger(`DAI mint TX status: ${daiMintTxReceipt.status} should be ${TxStatus.MINED}`);

--- a/yarn-project/aztec-sandbox/src/examples/util.ts
+++ b/yarn-project/aztec-sandbox/src/examples/util.ts
@@ -49,7 +49,7 @@ export async function deployAndInitializeNonNativeL2TokenContracts(
   const tx = NonNativeTokenContract.deploy(wallet, initialBalance, owner).send({
     portalContract: tokenPortalAddress,
   });
-  await tx.isMined(0, 0.1);
+  await tx.isMined({ interval: 0.1 });
   const receipt = await tx.getReceipt();
   const l2Contract = await NonNativeTokenContract.create(receipt.contractAddress!, wallet);
   await l2Contract.attach(tokenPortalAddress);

--- a/yarn-project/aztec-sandbox/src/examples/zk_token_contract.ts
+++ b/yarn-project/aztec-sandbox/src/examples/zk_token_contract.ts
@@ -61,7 +61,7 @@ async function main() {
   // Mint more tokens
   logger(`Minting ${SECONDARY_AMOUNT} more coins`);
   const mintTx = zkContract.methods.mint(SECONDARY_AMOUNT, ownerAddress).send({ origin: ownerAddress });
-  await mintTx.isMined(0, 0.5);
+  await mintTx.isMined({ interval: 0.5 });
   const balanceAfterMint = await getBalance(zkContract, ownerAddress);
   logger(`Owner's balance is now: ${balanceAfterMint}`);
 
@@ -70,7 +70,7 @@ async function main() {
   const transferTx = zkContract.methods
     .transfer(SECONDARY_AMOUNT, ownerAddress, address2)
     .send({ origin: ownerAddress });
-  await transferTx.isMined(0, 0.5);
+  await transferTx.isMined({ interval: 0.5 });
   const balanceAfterTransfer = await getBalance(zkContract, ownerAddress);
   const receiverBalance = await getBalance(zkContract, address2);
   logger(`Owner's balance is now ${balanceAfterTransfer}`);

--- a/yarn-project/aztec.js/src/contract_deployer/deploy_sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract_deployer/deploy_sent_tx.ts
@@ -1,0 +1,55 @@
+import { FieldsOf } from '@aztec/circuits.js';
+import { ContractAbi } from '@aztec/foundation/abi';
+import { TxHash, TxReceipt } from '@aztec/types';
+
+import { AztecAddress, AztecRPC, Contract, ContractBase, SentTx, WaitOpts, Wallet } from '../index.js';
+
+/** Options related to waiting for a deployment tx. */
+export type DeployedWaitOpts = WaitOpts & {
+  /** Wallet to use for creating a contract instance. Uses the one set in the deployer constructor if not set. */
+  wallet?: Wallet;
+};
+
+/** Extends a transaction receipt with a contract instance that represents the newly deployed contract. */
+export type DeployTxReceipt<TContract extends ContractBase = Contract> = FieldsOf<TxReceipt> & {
+  /** Instance of the newly deployed contract. */
+  contract: TContract;
+};
+
+/**
+ * A contract deployment transaction sent to the network, extending SentTx with methods to create a contract instance.
+ */
+export class DeploySentTx<TContract extends ContractBase = Contract> extends SentTx {
+  constructor(private abi: ContractAbi, wallet: AztecRPC | Wallet, txHashPromise: Promise<TxHash>) {
+    super(wallet, txHashPromise);
+  }
+
+  /**
+   * Awaits for the tx to be mined and returns the contract instance. Throws if tx is not mined.
+   * @param opts - Options for configuring the waiting for the tx to be mined.
+   * @returns The deployed contract instance.
+   */
+  public async deployed(opts?: DeployedWaitOpts): Promise<TContract> {
+    const receipt = await this.wait(opts);
+    return receipt.contract;
+  }
+
+  /**
+   * Awaits for the tx to be mined and returns the receipt along with a contract instance. Throws if tx is not mined.
+   * @param opts - Options for configuring the waiting for the tx to be mined.
+   * @returns The transaction receipt with the deployed contract instance.
+   */
+  public async wait(opts?: DeployedWaitOpts): Promise<DeployTxReceipt<TContract>> {
+    const receipt = await super.wait(opts);
+    const contract = await this.getContractInstance(opts?.wallet, receipt.contractAddress);
+    return { ...receipt, contract };
+  }
+
+  protected getContractInstance(wallet?: Wallet, address?: AztecAddress): Promise<TContract> {
+    const isWallet = (rpc: AztecRPC | Wallet): rpc is Wallet => !!(rpc as Wallet).createAuthenticatedTxRequest;
+    const contractWallet = wallet ?? (isWallet(this.arc) && this.arc);
+    if (!contractWallet) throw new Error(`A wallet is required for creating a contract instance`);
+    if (!address) throw new Error(`Contract address is missing from transaction receipt`);
+    return Contract.create(address, this.abi, contractWallet) as Promise<TContract>;
+  }
+}

--- a/yarn-project/aztec.js/src/utils/account.ts
+++ b/yarn-project/aztec.js/src/utils/account.ts
@@ -29,7 +29,7 @@ export async function createAccounts(
     await aztecRpcClient.addAccount(privKey, deploymentInfo.address, deploymentInfo.partialAddress);
     const contractDeployer = new ContractDeployer(accountContractAbi, aztecRpcClient, publicKey);
     const tx = contractDeployer.deploy().send({ contractAddressSalt: salt });
-    await tx.isMined(0, 0.5);
+    await tx.isMined({ interval: 0.5 });
     const receipt = await tx.getReceipt();
     if (receipt.status !== TxStatus.MINED) {
       throw new Error(`Deployment tx not mined (status is ${receipt.status})`);

--- a/yarn-project/end-to-end/src/cross_chain/test_harness.ts
+++ b/yarn-project/end-to-end/src/cross_chain/test_harness.ts
@@ -157,7 +157,7 @@ export class CrossChainTestHarness {
       .transfer(transferAmount, this.ownerAddress, this.receiver)
       .send({ origin: this.accounts[0] });
 
-    await transferTx.isMined(0, 0.1);
+    await transferTx.isMined({ interval: 0.1 });
     const transferReceipt = await transferTx.getReceipt();
 
     expect(transferReceipt.status).toBe(TxStatus.MINED);
@@ -170,7 +170,7 @@ export class CrossChainTestHarness {
       .mint(bridgeAmount, this.ownerAddress, messageKey, secret, this.ethAccount.toField())
       .send({ origin: this.ownerAddress });
 
-    await consumptionTx.isMined(0, 0.1);
+    await consumptionTx.isMined({ interval: 0.1 });
     const consumptionReceipt = await consumptionTx.getReceipt();
     expect(consumptionReceipt.status).toBe(TxStatus.MINED);
   }
@@ -182,7 +182,7 @@ export class CrossChainTestHarness {
       .mintPublic(bridgeAmount, this.ownerAddress, messageKey, secret, this.ethAccount.toField())
       .send({ origin: this.ownerAddress });
 
-    await consumptionTx.isMined(0, 0.1);
+    await consumptionTx.isMined({ interval: 0.1 });
     const consumptionReceipt = await consumptionTx.getReceipt();
     expect(consumptionReceipt.status).toBe(TxStatus.MINED);
   }
@@ -254,7 +254,7 @@ export class CrossChainTestHarness {
   async shieldFundsOnL2(shieldAmount: bigint, secretHash: Fr) {
     this.logger('Shielding funds on L2');
     const shieldTx = this.l2Contract.methods.shield(shieldAmount, secretHash).send({ origin: this.ownerAddress });
-    await shieldTx.isMined(0, 0.1);
+    await shieldTx.isMined({ interval: 0.1 });
     const shieldReceipt = await shieldTx.getReceipt();
     expect(shieldReceipt.status).toBe(TxStatus.MINED);
   }

--- a/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
@@ -80,7 +80,7 @@ describe('e2e_2_rpc_servers', () => {
     logger(`Deploying ZkToken contract...`);
     const tx = ZkTokenContract.deploy(aztecRpcServerA, initialBalance, owner).send();
     const receipt = await tx.getReceipt();
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const minedReceipt = await tx.getReceipt();
     expect(minedReceipt.status).toEqual(TxStatus.MINED);
     logger('L2 contract deployed');
@@ -121,7 +121,7 @@ describe('e2e_2_rpc_servers', () => {
     const contractWithWalletA = await ZkTokenContract.create(tokenAddress, walletA);
     const txAToB = contractWithWalletA.methods.transfer(transferAmount1, userA, userB).send({ origin: userA });
 
-    await txAToB.isMined(0, 0.1);
+    await txAToB.isMined({ interval: 0.1 });
     const receiptAToB = await txAToB.getReceipt();
 
     expect(receiptAToB.status).toBe(TxStatus.MINED);
@@ -136,7 +136,7 @@ describe('e2e_2_rpc_servers', () => {
     const contractWithWalletB = await ZkTokenContract.create(tokenAddress, walletB);
     const txBToA = contractWithWalletB.methods.transfer(transferAmount2, userB, userA).send({ origin: userB });
 
-    await txBToA.isMined(0, 0.1);
+    await txBToA.isMined({ interval: 0.1 });
     const receiptBToA = await txBToA.getReceipt();
 
     expect(receiptBToA.status).toBe(TxStatus.MINED);
@@ -152,7 +152,7 @@ describe('e2e_2_rpc_servers', () => {
     logger(`Deploying Child contract...`);
     const tx = ChildContract.deploy(aztecRpcServerA).send();
     const receipt = await tx.getReceipt();
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const minedReceipt = await tx.getReceipt();
     expect(minedReceipt.status).toEqual(TxStatus.MINED);
     logger('Child contract deployed');
@@ -188,7 +188,7 @@ describe('e2e_2_rpc_servers', () => {
 
     const childContractWithWalletB = await ChildContract.create(childAddress, walletB);
     const tx = childContractWithWalletB.methods.pubStoreValue(newValueToSet).send({ origin: userB });
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
 
     const receipt = await tx.getReceipt();
     expect(receipt.status).toBe(TxStatus.MINED);

--- a/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
+++ b/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
@@ -54,14 +54,14 @@ function itShouldBehaveLikeAnAccountContract(
       const { logger } = context;
       logger('Calling private function...');
       const tx = child.methods.value(42).send();
-      expect(await tx.isMined(0, 0.1)).toBeTruthy();
+      expect(await tx.isMined({ interval: 0.1 })).toBeTruthy();
     }, 60_000);
 
     it('calls a public function', async () => {
       const { logger, aztecRpcServer } = context;
       logger('Calling public function...');
       const tx = child.methods.pubStoreValue(42).send();
-      expect(await tx.isMined(0, 0.1)).toBeTruthy();
+      expect(await tx.isMined({ interval: 0.1 })).toBeTruthy();
       expect(toBigInt((await aztecRpcServer.getPublicStorageAt(child.address, new Fr(1)))!)).toEqual(42n);
     }, 60_000);
 

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
@@ -75,7 +75,7 @@ describe('e2e_cross_chain_messaging', () => {
       .withdraw(withdrawAmount, ownerAddress, ethAccount, EthAddress.ZERO.toField())
       .send({ origin: ownerAddress });
 
-    await withdrawTx.isMined(0, 0.1);
+    await withdrawTx.isMined({ interval: 0.1 });
     const withdrawReceipt = await withdrawTx.getReceipt();
 
     expect(withdrawReceipt.status).toBe(TxStatus.MINED);

--- a/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
@@ -46,7 +46,7 @@ describe('e2e_deploy_contract', () => {
       }),
     );
     logger(`Receipt received and expecting contract deployment at ${receipt.contractAddress}`);
-    const isMined = await tx.isMined(0, 0.1);
+    const isMined = await tx.isMined({ interval: 0.1 });
     const receiptAfterMined = await tx.getReceipt();
 
     expect(isMined).toBe(true);
@@ -65,7 +65,7 @@ describe('e2e_deploy_contract', () => {
     for (let index = 0; index < 2; index++) {
       logger(`Deploying contract ${index + 1}...`);
       const tx = deployer.deploy().send({ contractAddressSalt: Fr.random() });
-      const isMined = await tx.isMined(0, 0.1);
+      const isMined = await tx.isMined({ interval: 0.1 });
       expect(isMined).toBe(true);
       const receipt = await tx.getReceipt();
       expect(receipt.status).toBe(TxStatus.MINED);
@@ -82,7 +82,7 @@ describe('e2e_deploy_contract', () => {
 
     {
       const tx = deployer.deploy().send({ contractAddressSalt });
-      const isMined = await tx.isMined(0, 0.1);
+      const isMined = await tx.isMined({ interval: 0.1 });
 
       expect(isMined).toBe(true);
       const receipt = await tx.getReceipt();
@@ -93,7 +93,7 @@ describe('e2e_deploy_contract', () => {
 
     {
       const tx = deployer.deploy().send({ contractAddressSalt });
-      const isMined = await tx.isMined(0, 0.1);
+      const isMined = await tx.isMined({ interval: 0.1 });
       expect(isMined).toBe(false);
       const receipt = await tx.getReceipt();
 

--- a/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
@@ -47,16 +47,13 @@ describe('e2e_escrow_contract', () => {
     const salt = Fr.random();
     const deployInfo = await getContractDeploymentInfo(EscrowContractAbi, [owner], salt, escrowPublicKey);
     await aztecRpcServer.addAccount(escrowPrivateKey, deployInfo.address, deployInfo.partialAddress);
-    const escrowDeployTx = EscrowContract.deployWithPublicKey(aztecRpcServer, escrowPublicKey, owner);
+    const escrowDeployTx = EscrowContract.deployWithPublicKey(wallet, escrowPublicKey, owner);
     await escrowDeployTx.send({ contractAddressSalt: salt }).wait();
     escrowContract = await EscrowContract.create(escrowDeployTx.completeContractAddress!, wallet);
     logger(`Escrow contract deployed at ${escrowContract.address}`);
 
     // Deploy ZK token contract and mint funds for the escrow contract
-    zkTokenContract = await ZkTokenContract.deploy(aztecRpcServer, 100n, escrowContract.address)
-      .send()
-      .wait()
-      .then(async r => await ZkTokenContract.create(r.contractAddress!, wallet));
+    zkTokenContract = await ZkTokenContract.deploy(wallet, 100n, escrowContract.address).send().deployed();
     logger(`Token contract deployed at ${zkTokenContract.address}`);
   }, 100_000);
 

--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -24,7 +24,7 @@ describe('e2e_lending_contract', () => {
 
     logger(`Tx sent with hash ${await tx.getTxHash()}`);
     const receipt = await tx.getReceipt();
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const txReceipt = await tx.getReceipt();
     logger(`L2 contract deployed at ${receipt.contractAddress}`);
     contract = await LendingContract.create(receipt.contractAddress!, wallet);
@@ -102,7 +102,7 @@ describe('e2e_lending_contract', () => {
       // Initialize the contract values, setting the interest accumulator to 1e9 and the last updated timestamp to now.
       logger('Initializing contract');
       const tx = deployedContract.methods.init().send({ origin: recipient });
-      await tx.isMined(0, 0.1);
+      await tx.isMined({ interval: 0.1 });
       const receipt = await tx.getReceipt();
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['initial'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
@@ -119,7 +119,7 @@ describe('e2e_lending_contract', () => {
       // - increase the private collateral.
       logger('Depositing 🥸 : 💰 -> 🏦');
       const tx = deployedContract.methods.deposit_private(account.secret, 0n, 420n).send({ origin: recipient });
-      await tx.isMined(0, 0.1);
+      await tx.isMined({ interval: 0.1 });
       const receipt = await tx.getReceipt();
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['private_deposit'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
@@ -142,7 +142,7 @@ describe('e2e_lending_contract', () => {
       // - increase the public collateral.
       logger('Depositing 🥸 on behalf of recipient: 💰 -> 🏦');
       const tx = deployedContract.methods.deposit_private(0n, recipient.toField(), 420n).send({ origin: recipient });
-      await tx.isMined(0, 0.1);
+      await tx.isMined({ interval: 0.1 });
       const receipt = await tx.getReceipt();
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['private_deposit_on_behalf'] = await getStorageSnapshot(
@@ -172,7 +172,7 @@ describe('e2e_lending_contract', () => {
 
       logger('Depositing: 💰 -> 🏦');
       const tx = deployedContract.methods.deposit_public(account.address, 211n).send({ origin: recipient });
-      await tx.isMined(0, 0.1);
+      await tx.isMined({ interval: 0.1 });
       const receipt = await tx.getReceipt();
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['public_deposit'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
@@ -200,7 +200,7 @@ describe('e2e_lending_contract', () => {
 
       logger('Borrow 🥸 : 🏦 -> 🍌');
       const tx = deployedContract.methods.borrow_private(account.secret, 69n).send({ origin: recipient });
-      await tx.isMined(0, 0.1);
+      await tx.isMined({ interval: 0.1 });
       const receipt = await tx.getReceipt();
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['private_borrow'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
@@ -229,7 +229,7 @@ describe('e2e_lending_contract', () => {
 
       logger('Borrow: 🏦 -> 🍌');
       const tx = deployedContract.methods.borrow_public(69n).send({ origin: recipient });
-      await tx.isMined(0, 0.1);
+      await tx.isMined({ interval: 0.1 });
       const receipt = await tx.getReceipt();
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['public_borrow'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
@@ -261,7 +261,7 @@ describe('e2e_lending_contract', () => {
 
       logger('Repay 🥸 : 🍌 -> 🏦');
       const tx = deployedContract.methods.repay_private(account.secret, 0n, 20n).send({ origin: recipient });
-      await tx.isMined(0, 0.1);
+      await tx.isMined({ interval: 0.1 });
       const receipt = await tx.getReceipt();
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['private_repay'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
@@ -295,7 +295,7 @@ describe('e2e_lending_contract', () => {
 
       logger('Repay 🥸  on behalf of public: 🍌 -> 🏦');
       const tx = deployedContract.methods.repay_private(0n, recipient.toField(), 20n).send({ origin: recipient });
-      await tx.isMined(0, 0.1);
+      await tx.isMined({ interval: 0.1 });
       const receipt = await tx.getReceipt();
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['private_repay_on_behalf'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
@@ -329,7 +329,7 @@ describe('e2e_lending_contract', () => {
 
       logger('Repay: 🍌 -> 🏦');
       const tx = deployedContract.methods.repay_public(recipient.toField(), 20n).send({ origin: recipient });
-      await tx.isMined(0, 0.1);
+      await tx.isMined({ interval: 0.1 });
       const receipt = await tx.getReceipt();
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['public_repay'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
@@ -363,7 +363,7 @@ describe('e2e_lending_contract', () => {
 
       logger('Withdraw: 🏦 -> 💰');
       const tx = deployedContract.methods.withdraw_public(42n).send({ origin: recipient });
-      await tx.isMined(0, 0.1);
+      await tx.isMined({ interval: 0.1 });
       const receipt = await tx.getReceipt();
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['public_withdraw'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
@@ -397,7 +397,7 @@ describe('e2e_lending_contract', () => {
 
       logger('Withdraw 🥸 : 🏦 -> 💰');
       const tx = deployedContract.methods.withdraw_private(account.secret, 42n).send({ origin: recipient });
-      await tx.isMined(0, 0.1);
+      await tx.isMined({ interval: 0.1 });
       const receipt = await tx.getReceipt();
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['private_withdraw'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
@@ -429,7 +429,7 @@ describe('e2e_lending_contract', () => {
       // - fail
 
       const tx = deployedContract.methods._deposit(recipient.toField(), 42n).send({ origin: recipient });
-      await tx.isMined(0, 0.1);
+      await tx.isMined({ interval: 0.1 });
       const receipt = await tx.getReceipt();
       expect(receipt.status).toBe(TxStatus.DROPPED);
       logger('Rejected call directly to internal function 🧚 ');

--- a/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
@@ -69,7 +69,7 @@ describe('e2e_multiple_accounts_1_enc_key', () => {
     const tx = ZkTokenContract.deploy(aztecRpcServer, initialBalance, accounts[0]).send();
     const receipt = await tx.getReceipt();
     zkTokenAddress = receipt.contractAddress!;
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const minedReceipt = await tx.getReceipt();
     expect(minedReceipt.status).toEqual(TxStatus.MINED);
     logger('ZK Token deployed');
@@ -107,7 +107,7 @@ describe('e2e_multiple_accounts_1_enc_key', () => {
     const contractWithWallet = await ZkTokenContract.create(zkTokenAddress, wallets[senderIndex]);
 
     const tx = contractWithWallet.methods.transfer(transferAmount, sender, receiver).send({ origin: sender });
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const receipt = await tx.getReceipt();
 
     expect(receipt.status).toBe(TxStatus.MINED);

--- a/yarn-project/end-to-end/src/e2e_nested_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_nested_contract.test.ts
@@ -39,7 +39,7 @@ describe('e2e_nested_contract', () => {
     const deployer = new ContractDeployer(abi, aztecRpcServer);
     const tx = deployer.deploy().send();
 
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
 
     const receipt = await tx.getReceipt();
     const contract = await Contract.create(receipt.contractAddress!, abi, wallet);
@@ -60,7 +60,7 @@ describe('e2e_nested_contract', () => {
       .entryPoint(childContract.address, Fr.fromBuffer(childContract.methods.value.selector))
       .send({ origin: accounts[0] });
 
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const receipt = await tx.getReceipt();
 
     expect(receipt.status).toBe(TxStatus.MINED);
@@ -71,7 +71,7 @@ describe('e2e_nested_contract', () => {
       .pubEntryPoint(childContract.address, Fr.fromBuffer(childContract.methods.pubValue.selector), 42n)
       .send({ origin: accounts[0] });
 
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const receipt = await tx.getReceipt();
 
     expect(receipt.status).toBe(TxStatus.MINED);
@@ -82,7 +82,7 @@ describe('e2e_nested_contract', () => {
       .enqueueCallToChild(childContract.address, Fr.fromBuffer(childContract.methods.pubStoreValue.selector), 42n)
       .send({ origin: accounts[0] });
 
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const receipt = await tx.getReceipt();
     expect(receipt.status).toBe(TxStatus.MINED);
 
@@ -100,7 +100,7 @@ describe('e2e_nested_contract', () => {
       )
       .send({ origin: accounts[0] });
 
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const receipt = await tx.getReceipt();
     expect(receipt.status).toBe(TxStatus.MINED);
 
@@ -116,7 +116,7 @@ describe('e2e_nested_contract', () => {
       )
       .send({ origin: accounts[0] });
 
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const receipt = await tx.getReceipt();
     expect(receipt.status).toBe(TxStatus.MINED);
 
@@ -134,7 +134,7 @@ describe('e2e_nested_contract', () => {
       )
       .send({ origin: accounts[0] });
 
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const receipt = await tx.getReceipt();
     expect(receipt.status).toBe(TxStatus.MINED);
 
@@ -153,7 +153,7 @@ describe('e2e_nested_contract', () => {
       )
       .send({ origin: accounts[0] });
 
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const receipt = await tx.getReceipt();
 
     expect(receipt.status).toBe(TxStatus.MINED);

--- a/yarn-project/end-to-end/src/e2e_non_contract_account.test.ts
+++ b/yarn-project/end-to-end/src/e2e_non_contract_account.test.ts
@@ -63,7 +63,7 @@ describe('e2e_non_contract_account', () => {
     logger(`Deploying L2 contract...`);
     const tx = PokeableTokenContract.deploy(aztecRpcServer, initialBalance, sender, recipient, poker).send();
     const receipt = await tx.getReceipt();
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const minedReceipt = await tx.getReceipt();
     expect(minedReceipt.status).toEqual(TxStatus.MINED);
     logger('L2 contract deployed');
@@ -98,7 +98,7 @@ describe('e2e_non_contract_account', () => {
     // Send transaction as poker (arbitrary non-contract account)
     const tx = contractWithNoContractWallet.methods.poke().send({ origin: poker });
 
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const receipt = await tx.getReceipt();
     expect(receipt.status).toBe(TxStatus.MINED);
 

--- a/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
@@ -65,7 +65,7 @@ describe('e2e_p2p_network', () => {
     // now ensure that all txs were successfully mined
     for (const context of contexts) {
       for (const tx of context.txs) {
-        const isMined = await tx.isMined(0, 0.1);
+        const isMined = await tx.isMined({ interval: 0.1 });
         const receiptAfterMined = await tx.getReceipt();
 
         expect(isMined).toBe(true);

--- a/yarn-project/end-to-end/src/e2e_pending_commitments_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_pending_commitments_contract.test.ts
@@ -31,7 +31,7 @@ describe('e2e_pending_commitments_contract', () => {
     logger(`Deploying L2 contract...`);
     const tx = PendingCommitmentsContract.deploy(aztecRpcServer).send();
     const receipt = await tx.getReceipt();
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     await tx.getReceipt();
     logger('L2 contract deployed');
     contract = await PendingCommitmentsContract.create(receipt.contractAddress!, wallet);
@@ -48,7 +48,7 @@ describe('e2e_pending_commitments_contract', () => {
       .test_insert_then_get_then_nullify_flat(mintAmount, owner)
       .send({ origin: owner });
 
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const receipt = await tx.getReceipt();
     expect(receipt.status).toBe(TxStatus.MINED);
   }, 60_000);
@@ -69,7 +69,7 @@ describe('e2e_pending_commitments_contract', () => {
       )
       .send({ origin: owner });
 
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const receipt = await tx.getReceipt();
     expect(receipt.status).toBe(TxStatus.MINED);
   }, 60_000);

--- a/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
@@ -70,7 +70,7 @@ describe('e2e_public_cross_chain_messaging', () => {
       .withdrawPublic(withdrawAmount, ethAccount.toField(), EthAddress.ZERO.toField())
       .send({ origin: ownerAddress });
 
-    await withdrawTx.isMined(0, 0.1);
+    await withdrawTx.isMined({ interval: 0.1 });
     const withdrawReceipt = await withdrawTx.getReceipt();
 
     expect(withdrawReceipt.status).toBe(TxStatus.MINED);

--- a/yarn-project/end-to-end/src/e2e_zk_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_zk_token_contract.test.ts
@@ -35,14 +35,8 @@ describe('e2e_zk_token_contract', () => {
 
   const deployContract = async (initialBalance: bigint, owner: AztecAddress) => {
     logger(`Deploying L2 contract...`);
-    const tx = ZkTokenContract.deploy(wallet, initialBalance, owner).send();
-    const receipt = await tx.getReceipt();
-    await tx.isMined(0, 0.1);
-    const minedReceipt = await tx.getReceipt();
-    expect(minedReceipt.status).toEqual(TxStatus.MINED);
-    logger('L2 contract deployed');
-    contract = await ZkTokenContract.create(receipt.contractAddress!, wallet);
-    return contract;
+    contract = await ZkTokenContract.deploy(wallet, initialBalance, owner).send().deployed();
+    logger(`L2 contract deployed at ${contract.address}`);
   };
 
   /**
@@ -67,14 +61,14 @@ describe('e2e_zk_token_contract', () => {
 
     const [owner] = accounts;
 
-    const deployedContract = await deployContract(0n, owner);
+    await deployContract(0n, owner);
     await expectBalance(owner, 0n);
 
     await expectsNumOfEncryptedLogsInTheLastBlockToBe(aztecNode, 0);
 
-    const tx = deployedContract.methods.mint(mintAmount, owner).send({ origin: owner });
+    const tx = contract.methods.mint(mintAmount, owner).send({ origin: owner });
 
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const receipt = await tx.getReceipt();
 
     expect(receipt.status).toBe(TxStatus.MINED);
@@ -102,7 +96,7 @@ describe('e2e_zk_token_contract', () => {
 
     const tx = contract.methods.transfer(transferAmount, owner, receiver).send({ origin: accounts[0] });
 
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const receipt = await tx.getReceipt();
 
     expect(receipt.status).toBe(TxStatus.MINED);

--- a/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
+++ b/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
@@ -126,7 +126,7 @@ describe('uniswap_trade_on_l1_from_l2', () => {
     });
     // deploy l2 uniswap contract and attach to portal
     const tx = UniswapContract.deploy(aztecRpcServer).send({ portalContract: uniswapPortalAddress });
-    await tx.isMined(0, 0.1);
+    await tx.isMined({ interval: 0.1 });
     const receipt = await tx.getReceipt();
     expect(receipt.status).toEqual(TxStatus.MINED);
     uniswapL2Contract = await UniswapContract.create(receipt.contractAddress!, wallet);
@@ -199,7 +199,7 @@ describe('uniswap_trade_on_l1_from_l2', () => {
         ethAccount.toField(),
       )
       .send({ origin: ownerAddress });
-    await withdrawTx.isMined(0, 0.1);
+    await withdrawTx.isMined({ interval: 0.1 });
     const withdrawReceipt = await withdrawTx.getReceipt();
     expect(withdrawReceipt.status).toBe(TxStatus.MINED);
 

--- a/yarn-project/end-to-end/src/utils.ts
+++ b/yarn-project/end-to-end/src/utils.ts
@@ -228,7 +228,7 @@ export async function setupAztecRPCServer(
 
   for (const context of txContexts) {
     const publicKey = await generatePublicKey(context.privateKey);
-    await context.tx!.isMined(0, 0.1);
+    await context.tx!.isMined({ interval: 0.1 });
     const receipt = await context.tx!.getReceipt();
     if (receipt.status !== TxStatus.MINED) {
       throw new Error(`Deployment tx not mined (status is ${receipt.status})`);
@@ -349,7 +349,7 @@ export async function deployContract(
   const deployMethod = deployer.deploy(...args);
   await deployMethod.create({ contractAddressSalt });
   const tx = deployMethod.send();
-  expect(await tx.isMined(0, 0.1)).toBeTruthy();
+  expect(await tx.isMined({ interval: 0.1 })).toBeTruthy();
   const receipt = await tx.getReceipt();
   return { address: receipt.contractAddress!, partialContractAddress: deployMethod.partialContractAddress! };
 }
@@ -423,7 +423,7 @@ export async function deployL2Contracts(wallet: Wallet, abis: ContractAbi[]) {
   const calls = await Promise.all(abis.map(abi => new ContractDeployer(abi, wallet).deploy()));
   for (const call of calls) await call.create();
   const txs = await Promise.all(calls.map(c => c.send()));
-  expect(every(await Promise.all(txs.map(tx => tx.isMined(0, 0.1))))).toBeTruthy();
+  expect(every(await Promise.all(txs.map(tx => tx.isMined({ interval: 0.1 }))))).toBeTruthy();
   const receipts = await Promise.all(txs.map(tx => tx.getReceipt()));
   const contracts = zipWith(
     abis,
@@ -488,7 +488,7 @@ export async function deployAndInitializeNonNativeL2TokenContracts(
     portalContract: tokenPortalAddress,
     contractAddressSalt: Fr.random(),
   });
-  await tx.isMined(0, 0.1);
+  await tx.isMined({ interval: 0.1 });
   const receipt = await tx.getReceipt();
   if (receipt.status !== TxStatus.MINED) throw new Error(`Tx status is ${receipt.status}`);
   const l2Contract = await NonNativeTokenContract.create(receipt.contractAddress!, wallet);

--- a/yarn-project/noir-compiler/src/typegen/index.ts
+++ b/yarn-project/noir-compiler/src/typegen/index.ts
@@ -108,14 +108,14 @@ function generateDeploy(input: ContractAbi) {
    * Creates a tx to deploy a new instance of this contract.
    */
   public static deploy(rpc: AztecRPC, ${args}) {
-    return new DeployMethod(Point.ZERO, rpc, ${abiName}, Array.from(arguments).slice(1));
+    return new DeployMethod<${input.name}Contract>(Point.ZERO, rpc, ${abiName}, Array.from(arguments).slice(1));
   }
 
   /**
    * Creates a tx to deploy a new instance of this contract using the specified public key to derive the address.
    */
   public static deployWithPublicKey(rpc: AztecRPC, publicKey: PublicKey, ${args}) {
-    return new DeployMethod(publicKey, rpc, ${abiName}, Array.from(arguments).slice(2));
+    return new DeployMethod<${input.name}Contract>(publicKey, rpc, ${abiName}, Array.from(arguments).slice(2));
   }
   `;
 }


### PR DESCRIPTION
Overrides the `send` method of `DeployMethod` so it returns a `DeploySentTx`. This tx can be `wait`ed to return a receipt with the contract instance, and also provides a `deployed` method that returns just the contract. The wallet used for the instance can be set when creating the `DeployMethod` or passed as an argument to `wait`/`deployed`. Typed contracts return a typed version of DeployMethod that returns a typed contract instance.

Example usage:

```ts
const contract = await ZkTokenContract.deploy(wallet, initialBalance, owner).send().deployed();
```

Does not modify existing APIs except for converting `timeout` and `interval` in `wait` from positional to option-like arguments.

Fixes #1341 