### PR TITLE
fix: noir contract artifacts generation in CI

### DIFF
--- a/yarn-project/yarn-project-base/Dockerfile
+++ b/yarn-project/yarn-project-base/Dockerfile
@@ -116,8 +116,11 @@ COPY . .
 COPY --from=noir /usr/src/yarn-project/noir-contracts/src/contracts /usr/src/yarn-project/noir-contracts/src/contracts
 WORKDIR /usr/src/yarn-project/noir-contracts
 
+# Run yarn build to have the json ABIs available for the types generator
 RUN yarn build
 RUN ./scripts/types_ci.sh
+# Run yarn build again to build the types
+RUN yarn build
 
 # Take noir contract artifacts into the final build image
 FROM builder_ as final


### PR DESCRIPTION
# Description

In CI we used stale build of contract types because we failed to build them after generating them. This was causing issues when there was a change which required re-generating these types. This PR fixes this.

See [this PR](https://github.com/AztecProtocol/aztec-packages/pull/1365) for proof that that was the issue.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] The branch has been merged or rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
