### PR TITLE
fix: retry git submodule fetch

### DIFF
--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/aggregation_state/aggregation_state.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/aggregation_state/aggregation_state.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include "../../primitives/field/field.hpp"
 
-
 namespace proof_system::plonk {
 namespace stdlib {
 namespace recursion {


### PR DESCRIPTION
Attempting to stabilize problems seen with github intermittently rate limiting(?) our build runners.

See https://github.com/AztecProtocol/build-system/pull/18