### PR TITLE
fix(noir-ci): reinstate artifact builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,7 +472,7 @@ jobs:
           name: "Build and test"
           command: build key-store
 
-  noir-contracts:
+  noir-contracts-build:
     docker:
       - image: aztecprotocol/alpine-build-image
     resource_class: small
@@ -481,7 +481,18 @@ jobs:
       - *setup_env
       - run:
           name: "Build and test"
-          command: cond_spot_run_build noir-contracts 32
+          command: cond_spot_run_build noir-contracts-build 32
+
+  noir-contracts:
+    machine:
+      image: ubuntu-2004:202010-01
+    resource_class: large
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Build and test"
+          command: build noir-contracts
 
   noir-compiler:
     machine:
@@ -1094,13 +1105,13 @@ workflows:
           <<: *defaults
 
       - l1-contracts: *defaults
-      - noir-contracts: *defaults
+      - noir-contracts-build: *defaults
 
       - yarn-project-base:
           requires:
             - circuits-wasm-linux-clang
             - l1-contracts
-            - noir-contracts
+            - noir-contracts-build
           <<: *defaults
 
       - aztec-js: *yarn_project
@@ -1119,6 +1130,7 @@ workflows:
       - p2p-bootstrap: *yarn_project
       - l1-artifacts: *yarn_project
       - noir-compiler: *yarn_project
+      - noir-contracts: *yarn_project
       - sequencer-client: *yarn_project
       - types: *yarn_project
       - circuits-js: *yarn_project
@@ -1143,6 +1155,7 @@ workflows:
             - p2p-bootstrap
             - l1-artifacts
             - noir-compiler
+            - noir-contracts
             - sequencer-client
             - types
             - circuits-js

--- a/build_manifest.json
+++ b/build_manifest.json
@@ -2,54 +2,77 @@
   "barretenberg-x86_64-linux-clang": {
     "buildDir": "circuits/cpp/barretenberg/cpp",
     "dockerfile": "dockerfiles/Dockerfile.x86_64-linux-clang",
-    "rebuildPatterns": ["^circuits/cpp/barretenberg/cpp/"],
+    "rebuildPatterns": [
+      "^circuits/cpp/barretenberg/cpp/"
+    ],
     "dependencies": []
   },
   "barretenberg-x86_64-linux-clang-assert": {
     "buildDir": "circuits/cpp/barretenberg/cpp",
     "dockerfile": "dockerfiles/Dockerfile.x86_64-linux-clang-assert",
-    "rebuildPatterns": ["^circuits/cpp/barretenberg/cpp/"],
+    "rebuildPatterns": [
+      "^circuits/cpp/barretenberg/cpp/"
+    ],
     "dependencies": []
   },
   "barretenberg-x86_64-linux-clang-fuzzing": {
     "buildDir": "circuits/cpp/barretenberg/cpp",
     "dockerfile": "dockerfiles/Dockerfile.x86_64-linux-clang-fuzzing",
-    "rebuildPatterns": ["^circuits/cpp/barretenberg/cpp/"],
+    "rebuildPatterns": [
+      "^circuits/cpp/barretenberg/cpp/"
+    ],
     "dependencies": []
   },
   "barretenberg-x86_64-linux-gcc": {
     "buildDir": "circuits/cpp/barretenberg/cpp",
     "dockerfile": "dockerfiles/Dockerfile.x86_64-linux-gcc",
-    "rebuildPatterns": ["^circuits/cpp/barretenberg/cpp/"],
+    "rebuildPatterns": [
+      "^circuits/cpp/barretenberg/cpp/"
+    ],
     "dependencies": []
   },
   "barretenberg-wasm-linux-clang": {
     "buildDir": "circuits/cpp/barretenberg/cpp",
     "dockerfile": "dockerfiles/Dockerfile.wasm-linux-clang",
-    "rebuildPatterns": ["^circuits/cpp/barretenberg/cpp/"],
+    "rebuildPatterns": [
+      "^circuits/cpp/barretenberg/cpp/"
+    ],
     "dependencies": []
   },
   "barretenberg-circuits-x86_64-linux-clang-builder-runner": {
     "buildDir": "circuits/cpp/barretenberg/cpp",
     "dockerfile": "dockerfiles/Dockerfile.circuits-x86_64-linux-clang-builder-runner",
-    "rebuildPatterns": ["^circuits/cpp/barretenberg/cpp/"],
+    "rebuildPatterns": [
+      "^circuits/cpp/barretenberg/cpp/"
+    ],
     "dependencies": []
   },
   "barretenberg-circuits-wasm-linux-clang-builder-runner": {
     "buildDir": "circuits/cpp/barretenberg/cpp",
     "dockerfile": "dockerfiles/Dockerfile.circuits-wasm-linux-clang-builder-runner",
-    "rebuildPatterns": ["^circuits/cpp/barretenberg/cpp/"],
+    "rebuildPatterns": [
+      "^circuits/cpp/barretenberg/cpp/"
+    ],
     "dependencies": []
   },
   "bb.js": {
     "buildDir": "circuits/cpp/barretenberg/ts",
-    "rebuildPatterns": ["^circuits/cpp/barretenberg/ts/"],
-    "dependencies": ["barretenberg-wasm-linux-clang"]
+    "rebuildPatterns": [
+      "^circuits/cpp/barretenberg/ts/"
+    ],
+    "dependencies": [
+      "barretenberg-wasm-linux-clang"
+    ]
   },
   "barretenberg-acir-tests": {
     "buildDir": "circuits/cpp/barretenberg/acir_tests",
-    "rebuildPatterns": ["^circuits/cpp/barretenberg/acir_tests/"],
-    "dependencies": ["bb.js", "barretenberg-x86_64-linux-clang-assert"]
+    "rebuildPatterns": [
+      "^circuits/cpp/barretenberg/acir_tests/"
+    ],
+    "dependencies": [
+      "bb.js",
+      "barretenberg-x86_64-linux-clang-assert"
+    ]
   },
   "circuits-wasm-linux-clang": {
     "buildDir": "circuits/cpp",
@@ -330,8 +353,7 @@
     "dependencies": [
       "aztec.js",
       "foundation",
-      "noir-compiler",
-      "noir-contracts-build"
+      "noir-compiler"
     ]
   },
   "noir-compiler": {

--- a/build_manifest.json
+++ b/build_manifest.json
@@ -307,6 +307,19 @@
       "types"
     ]
   },
+  "noir-contracts-build": {
+    "buildDir": "yarn-project",
+    "projectDir": "yarn-project/noir-contracts",
+    "dockerfile": "noir-contracts/Dockerfile.build",
+    "rebuildPatterns": [
+      "^yarn-project/noir-contracts/"
+    ],
+    "dependencies": [
+      "aztec.js",
+      "foundation",
+      "noir-compiler"
+    ]
+  },
   "noir-contracts": {
     "buildDir": "yarn-project",
     "projectDir": "yarn-project/noir-contracts",
@@ -317,7 +330,8 @@
     "dependencies": [
       "aztec.js",
       "foundation",
-      "noir-compiler"
+      "noir-compiler",
+      "noir-contracts-build"
     ]
   },
   "noir-compiler": {

--- a/yarn-project/noir-contracts/Dockerfile
+++ b/yarn-project/noir-contracts/Dockerfile
@@ -3,7 +3,7 @@ FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 COPY . .
 
 WORKDIR /usr/src/yarn-project/noir-contracts
-RUN yarn build && yarn formatting && yarn test
+RUN yarn build && yarn test
 
 # Prune dev dependencies. See comment in base image.
 RUN yarn cache clean

--- a/yarn-project/noir-contracts/Dockerfile
+++ b/yarn-project/noir-contracts/Dockerfile
@@ -1,20 +1,15 @@
-# Running on ubuntu until noir supports an alpine build
+FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 
-# Builder stage to build the noir artifacts
-FROM ubuntu:kinetic
-
-RUN apt-get update && apt-get install -y \
-    curl \
-    git \
-    sed
-
-WORKDIR /usr/src/yarn-project
 COPY . .
 
-WORKDIR /usr/src/yarn-project/noir-contracts 
+WORKDIR /usr/src/yarn-project/noir-contracts
+RUN yarn build && yarn formatting && yarn test
 
-# Download and extract nargo
-RUN ./scripts/install_noir.sh
-ENV PATH="/usr/src/yarn-project/noir-contracts/.nargo/bin:${PATH}"
+# Prune dev dependencies. See comment in base image.
+RUN yarn cache clean
+RUN yarn workspaces focus --production > /dev/null
 
-RUN ./scripts/compile_ci.sh
+FROM node:18-alpine
+COPY --from=builder /usr/src/yarn-project/noir-contracts /usr/src/yarn-project/noir-contracts
+WORKDIR /usr/src/yarn-project/noir-contracts
+ENTRYPOINT ["yarn"]

--- a/yarn-project/noir-contracts/Dockerfile.build
+++ b/yarn-project/noir-contracts/Dockerfile.build
@@ -1,0 +1,20 @@
+# Running on ubuntu until noir supports an alpine build
+
+# Builder stage to build the noir artifacts
+FROM ubuntu:kinetic
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    sed
+
+WORKDIR /usr/src/yarn-project
+COPY . .
+
+WORKDIR /usr/src/yarn-project/noir-contracts 
+
+# Download and extract nargo
+RUN ./scripts/install_noir.sh
+ENV PATH="/usr/src/yarn-project/noir-contracts/.nargo/bin:${PATH}"
+
+RUN ./scripts/compile_ci.sh

--- a/yarn-project/yarn-project-base/Dockerfile
+++ b/yarn-project/yarn-project-base/Dockerfile
@@ -1,6 +1,6 @@
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/circuits-wasm-linux-clang as circuits
 FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/l1-contracts as contracts
-FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/noir-contracts as noir
+FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/noir-contracts-build as noir
 
 FROM node:18-alpine AS builder_
 RUN apk update && apk add --no-cache build-base git python3 curl bash jq sed

--- a/yarn-project/yarn-project-base/Dockerfile
+++ b/yarn-project/yarn-project-base/Dockerfile
@@ -119,6 +119,7 @@ WORKDIR /usr/src/yarn-project/noir-contracts
 # Run yarn build to have the json ABIs available for the types generator
 RUN yarn build
 RUN ./scripts/types_ci.sh
+RUN yarn formatting:fix
 # Run yarn build again to build the types
 RUN yarn build
 

--- a/yarn-project/yarn-project-base/Dockerfile
+++ b/yarn-project/yarn-project-base/Dockerfile
@@ -119,7 +119,6 @@ WORKDIR /usr/src/yarn-project/noir-contracts
 # Run yarn build to have the json ABIs available for the types generator
 RUN yarn build
 RUN ./scripts/types_ci.sh
-RUN yarn formatting:fix
 # Run yarn build again to build the types
 RUN yarn build
 


### PR DESCRIPTION
This pr reintroduces the old build step such that the @aztec/noir-contracts package can be published correctly. 

- It changes the name of the old noir-contracts build step to noir-contracts-build to prevent the npm publish publishing the build step container rather than the artifacts container


Question:
- Ive just copied the dockerfile from every other repo, i assume its fine if i just remove formatting for the noir contracts stuff

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
