### PR TITLE
fix: update bootstrap compilation order

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -35,7 +35,6 @@ if [ ! -f ~/.nvm/nvm.sh ]; then
 fi
 
 circuits/cpp/bootstrap.sh
-l1-contracts/bootstrap.sh
 
 if [ "$(uname)" = "Darwin" ]; then
   # works around https://github.com/AztecProtocol/aztec3-packages/issues/158
@@ -49,22 +48,24 @@ cd yarn-project
 yarn install --immutable
 
 # Build the necessary dependencies for noir contracts typegen.
-for DIR in foundation noir-compiler; do
+for DIR in foundation noir-compiler circuits.js; do
   echo "Building $DIR..."
   cd $DIR
   yarn build
   cd ..
 done
 
-cd noir-contracts && ./bootstrap.sh
+# Run remake bindings before building noir contracts or l1 contracts as they depend on files created by it.
+yarn --cwd circuits.js remake-bindings
+yarn --cwd circuits.js remake-constants
+
+(cd noir-contracts && ./bootstrap.sh)
+(cd .. && l1-contracts/bootstrap.sh)
 
 # Until we push .yarn/cache, we still need to install.
-cd ../
 yarn
 # We do not need to build individual packages, yarn build will build the root tsconfig.json
 yarn build
-yarn --cwd circuits.js remake-bindings
-yarn --cwd circuits.js remake-constants
 cd ..
 
 echo


### PR DESCRIPTION
Eth and Aztec contracts are currently built before the update constants script runs, potentially leading to stale artifacts being compiled. This is currently not an issue as artifacts are commited, however i could forsee it becoming one. 

