### PR TITLE
chore(ci): Update acir tests to reflect compilation based off of package name

### DIFF
--- a/circuits/cpp/barretenberg/acir_tests/run_acir_tests.sh
+++ b/circuits/cpp/barretenberg/acir_tests/run_acir_tests.sh
@@ -7,7 +7,7 @@ set -e
 
 BB=$PWD/${BB:-../cpp/build/bin/bb}
 CRS_PATH=~/.bb-crs
-BRANCH=master
+BRANCH=mv/refresh-artifacts
 
 # Pull down the test vectors from the noir repo, if we don't have the folder already.
 if [ ! -d acir_tests ]; then
@@ -56,7 +56,7 @@ function test() {
     return
   fi
 
-  if [[ ! -f ./$1/target/main.json || ! -f ./$1/target/witness.tr ]]; then
+  if [[ ! -f ./$1/target/$dir_name.json || ! -f ./$1/target/witness.tr ]]; then
     echo -e "\033[33mSKIPPED\033[0m (uncompiled)"
     return
   fi
@@ -65,9 +65,9 @@ function test() {
 
   set +e
   if [ -n "$VERBOSE" ]; then
-    $BB prove_and_verify -v -c $CRS_PATH
+    $BB prove_and_verify -v -c $CRS_PATH -j ./target/$dir_name.json
   else
-    $BB prove_and_verify -c $CRS_PATH > /dev/null 2>&1
+    $BB prove_and_verify -c $CRS_PATH -j ./target/$dir_name.json > /dev/null 2>&1
   fi
   result=$?
   set -e

--- a/circuits/cpp/barretenberg/acir_tests/run_acir_tests.sh
+++ b/circuits/cpp/barretenberg/acir_tests/run_acir_tests.sh
@@ -7,7 +7,7 @@ set -e
 
 BB=$PWD/${BB:-../cpp/build/bin/bb}
 CRS_PATH=~/.bb-crs
-BRANCH=mv/refresh-artifacts
+BRANCH=master
 
 # Pull down the test vectors from the noir repo, if we don't have the folder already.
 if [ ! -d acir_tests ]; then


### PR DESCRIPTION
ACIR tests are failing and needed a refresh on the Noir side. However, there has been a change where compilation is specified off of the package name in the `Nargo.toml` rather than a specified file name such as `main.json`

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [X] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [X] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
