### PR TITLE
revert: bring back ssh git clone

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,13 +41,20 @@ checkout: &checkout
         exit 1
       }
       cd $HOME
+      mkdir -p .ssh
+      chmod 0700 .ssh
+      retry_10 ssh-keyscan -t rsa github.com >> .ssh/known_hosts
 
+      # A read only key for cloning the repository.
+      echo $GIT_CHECKOUT_KEY | base64 -d > .ssh/id_rsa
+
+      chmod 0600 .ssh/id_rsa
       # IF YOU'RE CHANGING THIS, YOU ALSO WANT TO CHANGE: build-system/remote_build/remote_build
       # Shallow checkout this commit.
       mkdir -p project
       cd project
       git init
-      git remote add origin https://github.com/AztecProtocol/aztec-packages
+      git remote add origin $CIRCLE_REPOSITORY_URL
 
       # Only download metadata when fetching.
       retry_10 git fetch --depth 50 --filter=blob:none origin $CIRCLE_SHA1


### PR DESCRIPTION
It seems we're hitting 500 from github consistently. This is weird, there's no outage. Revert the last suspect thing done here.