### PR TITLE
feat: Public view functions (unconstrained can read public storage)

### DIFF
--- a/yarn-project/acir-simulator/src/client/simulator.ts
+++ b/yarn-project/acir-simulator/src/client/simulator.ts
@@ -6,7 +6,7 @@ import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';
-import { FunctionCall, TxExecutionRequest } from '@aztec/types';
+import { AztecNode, FunctionCall, TxExecutionRequest } from '@aztec/types';
 
 import { PackedArgsCache } from '../packed_args_cache.js';
 import { ClientTxExecutionContext } from './client_execution_context.js';
@@ -92,6 +92,7 @@ export class AcirSimulator {
    * @param contractAddress - The address of the contract.
    * @param portalContractAddress - The address of the portal contract.
    * @param historicRoots - The historic roots.
+   * @param aztecNode - The AztecNode instance.
    * @returns The return values of the function.
    */
   public async runUnconstrained(
@@ -101,6 +102,7 @@ export class AcirSimulator {
     contractAddress: AztecAddress,
     portalContractAddress: EthAddress,
     historicRoots: PrivateHistoricTreeRoots,
+    aztecNode: AztecNode | undefined = undefined,
   ) {
     if (entryPointABI.functionType !== FunctionType.UNCONSTRAINED) {
       throw new Error(`Cannot run ${entryPointABI.functionType} function as constrained`);
@@ -129,7 +131,7 @@ export class AcirSimulator {
       callContext,
     );
 
-    return execution.run();
+    return execution.run(aztecNode);
   }
 
   /**

--- a/yarn-project/acir-simulator/src/client/simulator.ts
+++ b/yarn-project/acir-simulator/src/client/simulator.ts
@@ -102,7 +102,7 @@ export class AcirSimulator {
     contractAddress: AztecAddress,
     portalContractAddress: EthAddress,
     historicRoots: PrivateHistoricTreeRoots,
-    aztecNode: AztecNode | undefined = undefined,
+    aztecNode?: AztecNode,
   ) {
     if (entryPointABI.functionType !== FunctionType.UNCONSTRAINED) {
       throw new Error(`Cannot run ${entryPointABI.functionType} function as constrained`);

--- a/yarn-project/acir-simulator/src/client/unconstrained_execution.ts
+++ b/yarn-project/acir-simulator/src/client/unconstrained_execution.ts
@@ -58,7 +58,8 @@ export class UnconstrainedFunctionExecution {
       getCommitment: ([commitment]) => this.context.getCommitment(this.contractAddress, commitment),
       storageRead: async ([slot], [numberOfElements]) => {
         if (aztecNode === undefined) {
-          throw new Error('AztecNode is undefined');
+          this.log(`Aztec node is undefined, cannot read public storage`);
+          throw new Error(`Aztec node is undefined, cannot read public storage`);
         }
         const startStorageSlot = fromACVMField(slot);
         const values = [];
@@ -66,6 +67,7 @@ export class UnconstrainedFunctionExecution {
           const storageSlot = startStorageSlot.value + BigInt(i);
           const value = await aztecNode.getPublicStorageAt(this.contractAddress, storageSlot);
           if (value === undefined) {
+            this.log(`Oracle storage read: slot=${storageSlot.toString()} value=undefined`);
             throw new Error(`Oracle storage read: slot=${storageSlot.toString()} value=undefined`);
           }
           const frValue = Fr.fromBuffer(value);

--- a/yarn-project/acir-simulator/src/client/unconstrained_execution.ts
+++ b/yarn-project/acir-simulator/src/client/unconstrained_execution.ts
@@ -58,20 +58,27 @@ export class UnconstrainedFunctionExecution {
       getCommitment: ([commitment]) => this.context.getCommitment(this.contractAddress, commitment),
       storageRead: async ([slot], [numberOfElements]) => {
         if (!aztecNode) {
-          this.log(`Aztec node is undefined, cannot read public storage`);
-          throw new Error(`Aztec node is undefined, cannot read public storage`);
+          const errMsg = `Aztec node is undefined, cannot read storage`;
+          this.log(errMsg);
+          throw new Error(errMsg);
         }
+
+        const makeLogMsg = (slot: bigint, value: string) =>
+          `Oracle storage read: slot=${slot.toString()} value=${value}`;
+
         const startStorageSlot = fromACVMField(slot);
         const values = [];
         for (let i = 0; i < Number(numberOfElements); i++) {
           const storageSlot = startStorageSlot.value + BigInt(i);
           const value = await aztecNode.getPublicStorageAt(this.contractAddress, storageSlot);
           if (value === undefined) {
-            this.log(`Oracle storage read: slot=${storageSlot.toString()} value=undefined`);
-            throw new Error(`Oracle storage read: slot=${storageSlot.toString()} value=undefined`);
+            const logMsg = makeLogMsg(storageSlot, 'undefined');
+            this.log(logMsg);
+            throw new Error(logMsg);
           }
           const frValue = Fr.fromBuffer(value);
-          this.log(`Oracle storage read: slot=${storageSlot.toString()} value=${frValue.toString()}`);
+          const logMsg = makeLogMsg(storageSlot, frValue.toString());
+          this.log(logMsg);
           values.push(frValue);
         }
         return values.map(v => toACVMField(v));

--- a/yarn-project/acir-simulator/src/client/unconstrained_execution.ts
+++ b/yarn-project/acir-simulator/src/client/unconstrained_execution.ts
@@ -30,7 +30,7 @@ export class UnconstrainedFunctionExecution {
    * @param aztecNode - The aztec node.
    * @returns The return values of the executed function.
    */
-  public async run(aztecNode: AztecNode | undefined = undefined): Promise<any[]> {
+  public async run(aztecNode?: AztecNode): Promise<any[]> {
     this.log(
       `Executing unconstrained function ${this.contractAddress.toShortString()}:${this.functionData.functionSelectorBuffer.toString(
         'hex',
@@ -57,7 +57,7 @@ export class UnconstrainedFunctionExecution {
       getL1ToL2Message: ([msgKey]) => this.context.getL1ToL2Message(fromACVMField(msgKey)),
       getCommitment: ([commitment]) => this.context.getCommitment(this.contractAddress, commitment),
       storageRead: async ([slot], [numberOfElements]) => {
-        if (aztecNode === undefined) {
+        if (!aztecNode) {
           this.log(`Aztec node is undefined, cannot read public storage`);
           throw new Error(`Aztec node is undefined, cannot read public storage`);
         }

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -76,6 +76,7 @@ export class AztecNodeService implements AztecNode {
     // create the tx pool and the p2p client, which will need the l2 block source
     const p2pClient = await createP2PClient(config, new InMemoryTxPool(), archiver);
 
+    // @todo @lherskind
     // now create the merkle trees and the world state syncher
     const merkleTreeDB = await MerkleTrees.new(levelup(createMemDown()), await CircuitsWasm.get());
     const worldStateSynchroniser = new ServerWorldStateSynchroniser(merkleTreeDB, archiver);

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -76,7 +76,6 @@ export class AztecNodeService implements AztecNode {
     // create the tx pool and the p2p client, which will need the l2 block source
     const p2pClient = await createP2PClient(config, new InMemoryTxPool(), archiver);
 
-    // @todo @lherskind
     // now create the merkle trees and the world state syncher
     const merkleTreeDB = await MerkleTrees.new(levelup(createMemDown()), await CircuitsWasm.get());
     const worldStateSynchroniser = new ServerWorldStateSynchroniser(merkleTreeDB, archiver);

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -383,6 +383,7 @@ export class AztecRPCServer implements AztecRPC {
       contractAddress,
       portalContract,
       historicRoots,
+      this.node,
     );
     this.log('Unconstrained simulation completed!');
 

--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -46,7 +46,7 @@ describe('e2e_lending_contract', () => {
   const getStorageSnapshot = async (contract: LendingContract, aztecNode: AztecRPC, account: Account) => {
     const storageValues: { [key: string]: Fr } = {};
     const accountKey = await account.key();
-    const toFields = (res: any) => res[0].map((v: number | bigint | Fr) => new Fr(v));
+    const toFields = (res: any[]) => res[0].map((v: number | bigint | Fr) => new Fr(v));
 
     [storageValues['interestAccumulator'], storageValues['last_updated_ts']] = toFields(
       await contract.methods.getTot(0).view(),

--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -1,13 +1,12 @@
 import { AztecNodeService } from '@aztec/aztec-node';
 import { AztecRPCServer } from '@aztec/aztec-rpc';
-import { AztecAddress, Contract, Fr, Wallet } from '@aztec/aztec.js';
+import { AztecAddress, Fr, Wallet } from '@aztec/aztec.js';
 import { CircuitsWasm } from '@aztec/circuits.js';
 import { pedersenPlookupCommitInputs } from '@aztec/circuits.js/barretenberg';
 import { DebugLogger } from '@aztec/foundation/log';
 import { LendingContract } from '@aztec/noir-contracts/types';
 import { AztecRPC, TxStatus } from '@aztec/types';
 
-import { CheatCodes } from './cheat_codes.js';
 import { setup } from './fixtures/utils.js';
 
 describe('e2e_lending_contract', () => {
@@ -17,9 +16,7 @@ describe('e2e_lending_contract', () => {
   let accounts: AztecAddress[];
   let logger: DebugLogger;
 
-  let contract: Contract;
-
-  let cc: CheatCodes;
+  let contract: LendingContract;
 
   const deployContract = async () => {
     logger(`Deploying L2 public contract...`);
@@ -35,7 +32,7 @@ describe('e2e_lending_contract', () => {
   };
 
   beforeEach(async () => {
-    ({ aztecNode, aztecRpcServer, wallet, accounts, logger, cheatCodes: cc } = await setup());
+    ({ aztecNode, aztecRpcServer, wallet, accounts, logger } = await setup());
   }, 100_000);
 
   afterEach(async () => {
@@ -46,24 +43,22 @@ describe('e2e_lending_contract', () => {
   });
 
   // Fetch a storage snapshot from the contract that we can use to compare between transitions.
-  const getStorageSnapshot = async (contract: Contract, aztecNode: AztecRPC, account: Account) => {
-    const loadPublicStorageInMap = async (slot: Fr | bigint, key: Fr | bigint) => {
-      return await cc.l2.loadPublic(contract.address, cc.l2.computeSlotInMap(slot, key));
-    };
-
-    const storageValues: { [key: string]: any } = {};
-    {
-      const baseSlot = cc.l2.computeSlotInMap(1n, 0n);
-      storageValues['interestAccumulator'] = await cc.l2.loadPublic(contract.address, baseSlot);
-      storageValues['last_updated_ts'] = await cc.l2.loadPublic(contract.address, baseSlot.value + 1n);
-    }
-
+  const getStorageSnapshot = async (contract: LendingContract, aztecNode: AztecRPC, account: Account) => {
+    const storageValues: { [key: string]: Fr } = {};
     const accountKey = await account.key();
+    const toFields = (res: any) => res[0].map((v: number | bigint | Fr) => new Fr(v));
 
-    storageValues['private_collateral'] = await loadPublicStorageInMap(2n, accountKey);
-    storageValues['public_collateral'] = await loadPublicStorageInMap(2n, account.address.toField());
-    storageValues['private_debt'] = await loadPublicStorageInMap(3n, accountKey);
-    storageValues['public_debt'] = await loadPublicStorageInMap(3n, account.address.toField());
+    [storageValues['interestAccumulator'], storageValues['last_updated_ts']] = toFields(
+      await contract.methods.getTot(0).view({ from: account.address }),
+    );
+
+    [storageValues['private_collateral'], storageValues['private_debt']] = toFields(
+      await contract.methods.getPosition(accountKey).view({ from: account.address }),
+    );
+
+    [storageValues['public_collateral'], storageValues['public_debt']] = toFields(
+      await contract.methods.getPosition(account.address.toField()).view({ from: account.address }),
+    );
 
     return storageValues;
   };

--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -49,15 +49,15 @@ describe('e2e_lending_contract', () => {
     const toFields = (res: any) => res[0].map((v: number | bigint | Fr) => new Fr(v));
 
     [storageValues['interestAccumulator'], storageValues['last_updated_ts']] = toFields(
-      await contract.methods.getTot(0).view({ from: account.address }),
+      await contract.methods.getTot(0).view(),
     );
 
     [storageValues['private_collateral'], storageValues['private_debt']] = toFields(
-      await contract.methods.getPosition(accountKey).view({ from: account.address }),
+      await contract.methods.getPosition(accountKey).view(),
     );
 
     [storageValues['public_collateral'], storageValues['public_debt']] = toFields(
-      await contract.methods.getPosition(account.address.toField()).view({ from: account.address }),
+      await contract.methods.getPosition(account.address.toField()).view(),
     );
 
     return storageValues;

--- a/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
@@ -82,7 +82,6 @@ describe('e2e_public_cross_chain_messaging', () => {
     // Generate a claim secret using pedersen
     const l1TokenBalance = 1000000n;
     const bridgeAmount = 100n;
-    const publicBalanceSlot = 3n; // check contract's storage.nr for slot assignment
 
     const [secret, secretHash] = await crossChainTestHarness.generateClaimSecret();
 
@@ -98,14 +97,14 @@ describe('e2e_public_cross_chain_messaging', () => {
     await crossChainTestHarness.performL2Transfer(transferAmount);
 
     await crossChainTestHarness.consumeMessageOnAztecAndMintPublicly(bridgeAmount, messageKey, secret);
-    await crossChainTestHarness.expectPublicBalanceOnL2(ownerAddress, bridgeAmount, publicBalanceSlot);
+    await crossChainTestHarness.expectPublicBalanceOnL2(ownerAddress, bridgeAmount);
 
     // time to withdraw the funds again!
     logger('Withdrawing funds from L2');
     const withdrawAmount = 9n;
     const entryKey = await crossChainTestHarness.checkEntryIsNotInOutbox(withdrawAmount);
     await withdrawFundsFromAztec(withdrawAmount);
-    await crossChainTestHarness.expectPublicBalanceOnL2(ownerAddress, bridgeAmount - withdrawAmount, publicBalanceSlot);
+    await crossChainTestHarness.expectPublicBalanceOnL2(ownerAddress, bridgeAmount - withdrawAmount);
 
     // Check balance before and after exit.
     expect(await underlyingERC20.read.balanceOf([ethAccount.toString()])).toBe(l1TokenBalance - bridgeAmount);

--- a/yarn-project/end-to-end/src/e2e_public_to_private_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_to_private_messaging.test.ts
@@ -65,7 +65,6 @@ describe('e2e_public_to_private_messaging', () => {
     const l1TokenBalance = 1000000n;
     const bridgeAmount = 100n;
     const shieldAmount = 50n;
-    const publicBalanceSlot = 3n; // check contract's storage.nr for slot assignment
 
     const [secret, secretHash] = await crossChainTestHarness.generateClaimSecret();
 
@@ -83,19 +82,19 @@ describe('e2e_public_to_private_messaging', () => {
     await crossChainTestHarness.expectBalanceOnL2(ownerAddress, initialBalance - transferAmount);
 
     await crossChainTestHarness.consumeMessageOnAztecAndMintPublicly(bridgeAmount, messageKey, secret);
-    await crossChainTestHarness.expectPublicBalanceOnL2(ownerAddress, bridgeAmount, publicBalanceSlot);
+    await crossChainTestHarness.expectPublicBalanceOnL2(ownerAddress, bridgeAmount);
 
     // Create the commitment to be spent in the private domain
     await crossChainTestHarness.shieldFundsOnL2(shieldAmount, secretHash);
 
     // Create the transaction spending the commitment
     await crossChainTestHarness.redeemShieldPrivatelyOnL2(shieldAmount, secret);
-    await crossChainTestHarness.expectPublicBalanceOnL2(ownerAddress, bridgeAmount - shieldAmount, publicBalanceSlot);
+    await crossChainTestHarness.expectPublicBalanceOnL2(ownerAddress, bridgeAmount - shieldAmount);
     await crossChainTestHarness.expectBalanceOnL2(ownerAddress, initialBalance + shieldAmount - transferAmount);
 
     // Unshield the tokens again, sending them to the same account, however this can be any account.
     await crossChainTestHarness.unshieldTokensOnL2(shieldAmount);
-    await crossChainTestHarness.expectPublicBalanceOnL2(ownerAddress, bridgeAmount, publicBalanceSlot);
+    await crossChainTestHarness.expectPublicBalanceOnL2(ownerAddress, bridgeAmount);
     await crossChainTestHarness.expectBalanceOnL2(ownerAddress, initialBalance - transferAmount);
   }, 200_000);
 });

--- a/yarn-project/end-to-end/src/fixtures/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/fixtures/cross_chain_test_harness.ts
@@ -203,12 +203,10 @@ export class CrossChainTestHarness {
     expect(balance).toBe(expectedBalance);
   }
 
-  async expectPublicBalanceOnL2(owner: AztecAddress, expectedBalance: bigint, publicBalanceSlot: bigint) {
-    const balance = await this.cc.l2.loadPublic(
-      this.l2Contract.address,
-      this.cc.l2.computeSlotInMap(publicBalanceSlot, owner.toField()),
-    );
-    expect(balance.value).toBe(expectedBalance);
+  async expectPublicBalanceOnL2(owner: AztecAddress, expectedBalance: bigint) {
+    this.logger(`test_harness::expectPublicBalanceOnL2`);
+    const balance = (await this.l2Contract.methods.publicBalanceOf(owner.toField()).view({ from: owner }))[0];
+    expect(balance).toBe(expectedBalance);
   }
 
   async checkEntryIsNotInOutbox(withdrawAmount: bigint, callerOnL1: EthAddress = EthAddress.ZERO): Promise<Fr> {

--- a/yarn-project/end-to-end/src/fixtures/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/fixtures/cross_chain_test_harness.ts
@@ -204,7 +204,6 @@ export class CrossChainTestHarness {
   }
 
   async expectPublicBalanceOnL2(owner: AztecAddress, expectedBalance: bigint) {
-    this.logger(`test_harness::expectPublicBalanceOnL2`);
     const balance = (await this.l2Contract.methods.publicBalanceOf(owner.toField()).view({ from: owner }))[0];
     expect(balance).toBe(expectedBalance);
   }

--- a/yarn-project/noir-contracts/src/contracts/lending_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/lending_contract/src/main.nr
@@ -306,4 +306,22 @@ contract Lending {
         debt_loc.write(static_debt - amount);
         1
     }
+
+    unconstrained fn getTot(
+        assetId: Field,
+    ) -> [Field; 2]{
+        let storage = Storage::init();
+        let asset = storage.assets.at(assetId);
+        let tot = asset.read();
+        [tot.interest_accumulator as Field, tot.last_updated_ts as Field]
+    }
+
+    unconstrained fn getPosition(
+        owner: Field,
+    ) -> [Field; 2] {
+        let storage = Storage::init();
+        let collateral = storage.collateral.at(owner).read();
+        let debt = storage.static_debt.at(owner).read();
+        [collateral, debt] 
+    }
 }

--- a/yarn-project/noir-contracts/src/contracts/non_native_token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/non_native_token_contract/src/main.nr
@@ -346,4 +346,11 @@ contract NonNativeToken {
             note_utils::compute_note_hash_and_nullifier(ValueNoteMethods, note_header, preimage)
         }
     }
+
+    unconstrained fn publicBalanceOf(
+        owner: Field,
+    ) -> Field {
+        let storage = Storage::init();
+        storage.public_balances.at(owner).read()
+    }
 }

--- a/yarn-project/noir-contracts/src/contracts/public_token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/public_token_contract/src/main.nr
@@ -61,4 +61,10 @@ contract PublicToken {
         }
     }
 
+    unconstrained fn publicBalanceOf(
+        owner: Field,
+    ) -> Field {
+        let storage = Storage::init();
+        storage.balances.at(owner).read()
+    }
 }


### PR DESCRIPTION
Addresses #1375 by giving the unconstrained execution access to public storage through the node.

Good things: 
- Makes it simpler to read values

Bad things:
- Because the simulator is much slower than reading the value, makes testing slower 😭.

The return value from view functions are an array of `bigint` but should be altered to be following the abi specification instead for easy access.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
