### PR TITLE
chore: enable project-specific tagged releases

### DIFF
--- a/build-system/scripts/deploy_npm
+++ b/build-system/scripts/deploy_npm
@@ -13,10 +13,26 @@ cd project/src/$(query_manifest projectDir $REPOSITORY)
 
 echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
 
+# Check if it's a repo-specific tag
+if [[ "$COMMIT_TAG" == *"/"* ]]; then
+  REPO_NAME="${COMMIT_TAG%%/*}"
+  COMMIT_TAG_VERSION="${COMMIT_TAG#*/}"
+  echo "Tag was made for: $REPO_NAME"
+  echo "Version: $COMMIT_TAG_VERSION"
+
+    # Check if REPO_NAME is equal to REPOSITORY
+  if [ "$REPO_NAME" != "$REPOSITORY" ]; then
+    echo "REPO_NAME ($REPO_NAME) does not match REPOSITORY ($REPOSITORY). Exiting..."
+    exit 1
+  fi
+else
+  COMMIT_TAG_VERSION=$COMMIT_TAG
+fi
+
 # We are publishing a tagged commit. Check it's a valid semver.
-VERSION=$(npx semver $COMMIT_TAG)
+VERSION=$(npx semver $COMMIT_TAG_VERSION)
 if [ -z "$VERSION" ]; then
-  echo "$COMMIT_TAG is not a semantic version."
+  echo "$COMMIT_TAG_VERSION is not a semantic version."
   exit 1
 fi
 


### PR DESCRIPTION
This change should allow us to create tags for releasing a specific package from `yarn-project`
e.g. Tagging `master` with `aztec.js/v0.1.1` will create a v0.1.1 release **only** for aztec.js. Tagging with `v0.1.1` will release everything on that version (we still check if current version is below that to avoid mis-versioning)

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
