### PR TITLE
chore(tests): use new account class in e2e tests

### DIFF
--- a/yarn-project/aztec.js/src/account/account.ts
+++ b/yarn-project/aztec.js/src/account/account.ts
@@ -130,7 +130,7 @@ export class Account {
    * @param opts - Options to wait for the tx to be mined.
    * @returns A Wallet instance.
    */
-  public async waitDeploy(opts: WaitOpts): Promise<Wallet> {
+  public async waitDeploy(opts: WaitOpts = {}): Promise<Wallet> {
     return (await this.deploy()).getWallet(opts);
   }
 }

--- a/yarn-project/aztec.js/src/account/account.ts
+++ b/yarn-project/aztec.js/src/account/account.ts
@@ -1,10 +1,10 @@
 import { Fr, PublicKey, getContractDeploymentInfo } from '@aztec/circuits.js';
 import { AztecRPC, PrivateKey } from '@aztec/types';
 
-import { AccountWallet, ContractDeployer, WaitOpts, Wallet, generatePublicKey } from '../index.js';
+import { AccountWallet, ContractDeployer, DeployMethod, WaitOpts, Wallet, generatePublicKey } from '../index.js';
 import { CompleteAddress, isCompleteAddress } from './complete_address.js';
 import { DeployAccountSentTx } from './deploy_account_sent_tx.js';
-import { AccountContract, Salt } from './index.js';
+import { AccountContract, Entrypoint, Salt } from './index.js';
 
 /**
  * Manages a user account. Provides methods for calculating the account's address, deploying the account contract,
@@ -16,6 +16,7 @@ export class Account {
 
   private completeAddress?: CompleteAddress;
   private encryptionPublicKey?: PublicKey;
+  private deployMethod?: DeployMethod;
 
   constructor(
     private rpc: AztecRPC,
@@ -35,6 +36,16 @@ export class Account {
       this.encryptionPublicKey = await generatePublicKey(this.encryptionPrivateKey);
     }
     return this.encryptionPublicKey;
+  }
+
+  /**
+   * Returns the entrypoint for this account as defined by its account contract.
+   * @returns An entrypoint.
+   */
+  public async getEntrypoint(): Promise<Entrypoint> {
+    const nodeInfo = await this.rpc.getNodeInfo();
+    const completeAddress = await this.getCompleteAddress();
+    return this.accountContract.getEntrypoint(completeAddress, nodeInfo);
   }
 
   /**
@@ -61,10 +72,8 @@ export class Account {
    * @returns A Wallet instance.
    */
   public async getWallet(): Promise<Wallet> {
-    const nodeInfo = await this.rpc.getNodeInfo();
-    const completeAddress = await this.getCompleteAddress();
-    const account = await this.accountContract.getEntrypoint(completeAddress, nodeInfo);
-    return new AccountWallet(this.rpc, account);
+    const entrypoint = await this.getEntrypoint();
+    return new AccountWallet(this.rpc, entrypoint);
   }
 
   /**
@@ -80,6 +89,24 @@ export class Account {
   }
 
   /**
+   * Returns the pre-populated deployment method to deploy the account contract that backs this account.
+   * Typically you will not need this method and can call `deploy` directly. Use this for having finer
+   * grained control on when to create, simulate, and send the deployment tx.
+   * @returns A DeployMethod instance that deploys this account contract.
+   */
+  public async getDeployMethod() {
+    if (!this.deployMethod) {
+      if (!this.salt) throw new Error(`Cannot deploy account contract without known salt.`);
+      await this.register();
+      const encryptionPublicKey = await this.getEncryptionPublicKey();
+      const deployer = new ContractDeployer(this.accountContract.getContractAbi(), this.rpc, encryptionPublicKey);
+      const args = await this.accountContract.getDeploymentArgs();
+      this.deployMethod = deployer.deploy(...args);
+    }
+    return this.deployMethod;
+  }
+
+  /**
    * Deploys the account contract that backs this account.
    * Uses the salt provided in the constructor or a randomly generated one.
    * Note that if the Account is constructed with an explicit complete address
@@ -88,12 +115,9 @@ export class Account {
    * @returns A SentTx object that can be waited to get the associated Wallet.
    */
   public async deploy(): Promise<DeployAccountSentTx> {
-    if (!this.salt) throw new Error(`Cannot deploy account contract without known salt.`);
-    const wallet = await this.register();
-    const encryptionPublicKey = await this.getEncryptionPublicKey();
-    const deployer = new ContractDeployer(this.accountContract.getContractAbi(), this.rpc, encryptionPublicKey);
-    const args = await this.accountContract.getDeploymentArgs();
-    const sentTx = deployer.deploy(...args).send({ contractAddressSalt: this.salt });
+    const deployMethod = await this.getDeployMethod();
+    const wallet = await this.getWallet();
+    const sentTx = deployMethod.send({ contractAddressSalt: this.salt });
     return new DeployAccountSentTx(wallet, sentTx.getTxHash());
   }
 

--- a/yarn-project/aztec.js/src/account/entrypoint/entrypoint_collection.ts
+++ b/yarn-project/aztec.js/src/account/entrypoint/entrypoint_collection.ts
@@ -1,6 +1,7 @@
 import { AztecAddress } from '@aztec/circuits.js';
 import { FunctionCall, TxExecutionRequest } from '@aztec/types';
 
+import { Account } from '../account.js';
 import { CreateTxRequestOpts, Entrypoint } from './index.js';
 
 /**
@@ -9,6 +10,25 @@ import { CreateTxRequestOpts, Entrypoint } from './index.js';
  */
 export class EntrypointCollection implements Entrypoint {
   private entrypoints: Map<string, Entrypoint> = new Map();
+
+  constructor(entrypoints: [AztecAddress, Entrypoint][] = []) {
+    for (const [key, value] of entrypoints) {
+      this.registerAccount(key, value);
+    }
+  }
+
+  /**
+   * Creates a new instance out of a set of Accounts.
+   * @param accounts - Accounts to register in this entrypoint.
+   * @returns A new instance.
+   */
+  static async fromAccounts(accounts: Account[]) {
+    const collection = new EntrypointCollection();
+    for (const account of accounts) {
+      collection.registerAccount((await account.getCompleteAddress()).address, await account.getEntrypoint());
+    }
+    return collection;
+  }
 
   /**
    * Registers an entrypoint against an aztec address

--- a/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
@@ -40,15 +40,15 @@ describe('e2e_escrow_contract', () => {
 
     // Generate private key for escrow contract, register key in rpc server, and deploy
     // Note that we need to register it first if we want to emit an encrypted note for it in the constructor
-    // TODO: We need a nicer interface for deploying contracts!
     escrowPrivateKey = PrivateKey.random();
     escrowPublicKey = await generatePublicKey(escrowPrivateKey);
     const salt = Fr.random();
     const deployInfo = await getContractDeploymentInfo(EscrowContractAbi, [owner], salt, escrowPublicKey);
     await aztecRpcServer.addAccount(escrowPrivateKey, deployInfo.address, deployInfo.partialAddress);
-    const escrowDeployTx = EscrowContract.deployWithPublicKey(wallet, escrowPublicKey, owner);
-    await escrowDeployTx.send({ contractAddressSalt: salt }).wait();
-    escrowContract = await EscrowContract.create(escrowDeployTx.completeContractAddress!, wallet);
+
+    escrowContract = await EscrowContract.deployWithPublicKey(wallet, escrowPublicKey, owner)
+      .send({ contractAddressSalt: salt })
+      .deployed();
     logger(`Escrow contract deployed at ${escrowContract.address}`);
 
     // Deploy ZK token contract and mint funds for the escrow contract

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -2,28 +2,20 @@ import { AztecNodeConfig, AztecNodeService, getConfigEnvVars } from '@aztec/azte
 import { RpcServerConfig, createAztecRPCServer, getConfigEnvVars as getRpcConfigEnvVars } from '@aztec/aztec-rpc';
 import {
   AccountWallet,
+  Account as AztecAccount,
   AztecAddress,
   Contract,
   ContractDeployer,
-  DeployMethod,
   Entrypoint,
   EntrypointCollection,
   EthAddress,
-  SentTx,
-  SingleKeyAccountEntrypoint,
   Wallet,
   createAztecRpcClient as createJsonRpcClient,
   generatePublicKey,
   getL1ContractAddresses,
+  getUnsafeSchnorrAccount,
 } from '@aztec/aztec.js';
-import {
-  DeploymentInfo,
-  PartialContractAddress,
-  PrivateKey,
-  PublicKey,
-  getContractDeploymentInfo,
-} from '@aztec/circuits.js';
-import { Schnorr } from '@aztec/circuits.js/barretenberg';
+import { PartialContractAddress, PrivateKey, PublicKey, getContractDeploymentInfo } from '@aztec/circuits.js';
 import { DeployL1Contracts, deployL1Contract, deployL1Contracts } from '@aztec/ethereum';
 import { ContractAbi } from '@aztec/foundation/abi';
 import { Fr } from '@aztec/foundation/fields';
@@ -31,7 +23,6 @@ import { mustSucceedFetch } from '@aztec/foundation/json-rpc/client';
 import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
 import { PortalERC20Abi, PortalERC20Bytecode, TokenPortalAbi, TokenPortalBytecode } from '@aztec/l1-artifacts';
-import { SchnorrSingleKeyAccountContractAbi } from '@aztec/noir-contracts/artifacts';
 import { NonNativeTokenContract } from '@aztec/noir-contracts/types';
 import { AztecRPC, L2BlockL2Logs, LogType, TxStatus } from '@aztec/types';
 
@@ -128,34 +119,6 @@ const setupL1Contracts = async (l1RpcUrl: string, account: HDAccount, logger: De
 };
 
 /**
- * Container to hold information about txs
- */
-type TxContext = {
-  /**
-   * The fully built and sent transaction.
-   */
-  tx: SentTx | undefined;
-  /**
-   * The deploy method.
-   */
-  deployMethod: DeployMethod;
-
-  /**
-   * Contract address salt.
-   */
-  salt: Fr;
-
-  /**
-   * The user's private key.
-   */
-  privateKey: PrivateKey;
-  /**
-   * The fully derived deployment data.
-   */
-  deploymentData: DeploymentInfo;
-};
-
-/**
  * Sets up Aztec RPC Server.
  * @param numberOfAccounts - The number of new accounts to be created once the RPC server is initiated.
  * @param aztecNode - The instance of an aztec node, if one is required
@@ -189,83 +152,29 @@ export async function setupAztecRPCServer(
   logger: DebugLogger;
 }> {
   const rpcConfig = getRpcConfigEnvVars();
-
   const aztecRpcServer = await createRpcServer(rpcConfig, aztecNode, logger, useLogSuffix);
 
-  const accountCollection = new EntrypointCollection();
-  const txContexts: TxContext[] = [];
-
   logger('RPC server created, deploying accounts...');
+  const accounts: AztecAccount[] = [];
 
+  // Prepare deployments
   for (let i = 0; i < numberOfAccounts; ++i) {
-    // We use the well-known private key and the validating account contract for the first account,
-    // and generate random key pairs for the rest.
-    // TODO(#662): Let the aztec rpc server generate the key pair rather than hardcoding the private key
     const privateKey = i === 0 && firstPrivKey !== null ? firstPrivKey! : PrivateKey.random();
-    const publicKey = await generatePublicKey(privateKey);
-    const salt = Fr.random();
-    const deploymentData = await getContractDeploymentInfo(SchnorrSingleKeyAccountContractAbi, [], salt, publicKey);
-
-    const contractDeployer = new ContractDeployer(SchnorrSingleKeyAccountContractAbi, aztecRpcServer!, publicKey);
-    const deployMethod = contractDeployer.deploy();
-    await deployMethod.simulate({ contractAddressSalt: salt });
-    txContexts.push({
-      tx: undefined,
-      deployMethod,
-      salt,
-      privateKey,
-      deploymentData,
-    });
+    const account = getUnsafeSchnorrAccount(aztecRpcServer, privateKey);
+    await account.getDeployMethod().then(d => d.simulate({ contractAddressSalt: account.salt }));
+    accounts.push(account);
   }
 
-  // We do this in a separate loop to try and get all transactions into the same rollup.
-  // Doing this here will submit the transactions with minimal delay between them.
-  for (const context of txContexts) {
-    logger(`Deploying account contract for ${context.deploymentData.address.toString()}`);
-    context.tx = context.deployMethod.send();
-  }
+  // Send them and await them to be mined
+  const txs = await Promise.all(accounts.map(account => account.deploy()));
+  await Promise.all(txs.map(tx => tx.wait({ interval: 0.1 })));
 
-  // Await for all txs to be mined (see #1392)
-  for (const context of txContexts) {
-    await context.tx!.isMined({ interval: 0.1 });
-  }
-
-  // Register the corresponding accounts
-  for (const context of txContexts) {
-    const publicKey = await generatePublicKey(context.privateKey);
-    const receipt = await context.tx!.getReceipt();
-    if (receipt.status !== TxStatus.MINED) {
-      throw new Error(`Deployment tx not mined (status is ${receipt.status})`);
-    }
-    const receiptAddress = receipt.contractAddress!;
-    if (!receiptAddress.equals(context.deploymentData.address)) {
-      throw new Error(
-        `Deployment address does not match for account contract (expected ${context.deploymentData.address} got ${receiptAddress})`,
-      );
-    }
-    await aztecRpcServer!.addAccount(
-      context.privateKey,
-      context.deploymentData.address,
-      context.deploymentData.partialAddress,
-    );
-    accountCollection.registerAccount(
-      context.deploymentData.address,
-      new SingleKeyAccountEntrypoint(
-        context.deploymentData.address,
-        context.deploymentData.partialAddress,
-        context.privateKey,
-        await Schnorr.new(),
-      ),
-    );
-    logger(`Created account ${context.deploymentData.address.toString()} with public key ${publicKey.toString()}`);
-  }
-
-  const accounts = await aztecRpcServer!.getAccounts();
-  const wallet = new AccountWallet(aztecRpcServer!, accountCollection);
+  // Assemble them into a single wallet
+  const wallet = new AccountWallet(aztecRpcServer, await EntrypointCollection.fromAccounts(accounts));
 
   return {
     aztecRpcServer: aztecRpcServer!,
-    accounts,
+    accounts: await aztecRpcServer!.getAccounts(),
     wallet,
     logger,
   };


### PR DESCRIPTION
Uses the `Account` class introduced in #1429 for e2e test setup. This required adding new methods to the `Account` class for being able to simulate the deployment without sending and assembling an `EntrypointCollection` out of multiple `Account`s.