### PR TITLE
fix: yarn install in canary

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -37,7 +37,8 @@ fi
 circuits/cpp/bootstrap.sh
 
 # Build the canary
-cd canary 
+cd canary
+yarn install --immutable
 yarn build 
 cd ..
 


### PR DESCRIPTION
`bootstrap.sh` needs to install the canary's dependencies.
