### PR TITLE
feat(ci): pin noir version to aztec tag

### DIFF
--- a/yarn-project/noir-contracts/scripts/install_noir.sh
+++ b/yarn-project/noir-contracts/scripts/install_noir.sh
@@ -2,7 +2,7 @@
 # Script to install noirup and the latest nargo
 set -eu
 
-VERSION="nightly"
+VERSION="aztec"
 
 export NARGO_HOME="$(pwd)/.nargo"
 NARGO_BIN_DIR="$NARGO_HOME/bin"


### PR DESCRIPTION
TLDR:
This pins the noir release to the aztec tag on the noir repo. 
This is out of sync with nightly and can be manually bumped by us.

**Overview**
Myself and kev had a little sync and have a nice minimal solution that should unblock us for the meantime.
We have created a dedicated tag aztec within noir that points to a fixed commit.
This is good as we do not need to bring noir compilation into our CI, we can leverage noir's existing build pipelines to rebuild commits for us.
If we need to retag the release, we can run
```bash
git tag -f -a aztec <commit>
git push -f origin refs/tags/aztec
```
Then trigger a build in the build-nargo pipeline to create the release for us.
Our ci will then automatically target that commit.
Longer term solutions:
1. The noir compiler package discussed above.
1. Increasing retention for nightly builds, tagging them with a unique tag, changing that tag within aztec's git repo.
1. Creating CI that will auto generate new artifacts on aztec tag releases.