### PR TITLE
Fixed amount of retrieved logs and blocks

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver_store.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.test.ts
@@ -1,0 +1,70 @@
+import { INITIAL_L2_BLOCK_NUM, L2Block, L2BlockL2Logs, LogType } from '@aztec/types';
+
+import { ArchiverDataStore, MemoryArchiverStore } from './archiver_store.js';
+
+describe('Archiver Memory Store', () => {
+  let archiverStore: ArchiverDataStore;
+
+  beforeEach(() => {
+    archiverStore = new MemoryArchiverStore();
+  });
+
+  it('can store and retrieve blocks', async () => {
+    const blocks = Array(10)
+      .fill(0)
+      .map((_, index) => L2Block.random(index));
+    await archiverStore.addL2Blocks(blocks);
+    // Offset indices by INTIAL_L2_BLOCK_NUM to ensure we are correctly aligned
+    for (const [from, limit] of [
+      [0 + INITIAL_L2_BLOCK_NUM, 10],
+      [3 + INITIAL_L2_BLOCK_NUM, 3],
+      [1 + INITIAL_L2_BLOCK_NUM, 7],
+      [5 + INITIAL_L2_BLOCK_NUM, 8],
+    ]) {
+      const expected = blocks.slice(from - INITIAL_L2_BLOCK_NUM, from - INITIAL_L2_BLOCK_NUM + limit);
+      const actual = await archiverStore.getL2Blocks(from, limit);
+      expect(expected).toEqual(actual);
+    }
+  });
+
+  test.each([LogType.ENCRYPTED, LogType.UNENCRYPTED])('can store and retrieve logs', async (logType: LogType) => {
+    const logs = Array(10)
+      .fill(0)
+      .map(_ => L2BlockL2Logs.random(6, 3, 2));
+    await archiverStore.addLogs(logs, logType);
+    // Offset indices by INTIAL_L2_BLOCK_NUM to ensure we are correctly aligned
+    for (const [from, limit] of [
+      [0 + INITIAL_L2_BLOCK_NUM, 10],
+      [3 + INITIAL_L2_BLOCK_NUM, 3],
+      [1 + INITIAL_L2_BLOCK_NUM, 7],
+      [5 + INITIAL_L2_BLOCK_NUM, 8],
+    ]) {
+      const expected = logs.slice(from - INITIAL_L2_BLOCK_NUM, from - INITIAL_L2_BLOCK_NUM + limit);
+      const actual = await archiverStore.getLogs(from, limit, logType);
+      expect(expected).toEqual(actual);
+    }
+  });
+
+  it('throws if we try and request less than 1 block', async () => {
+    const blocks = Array(10)
+      .fill(0)
+      .map((_, index) => L2Block.random(index));
+    await archiverStore.addL2Blocks(blocks);
+    await expect(async () => await archiverStore.getL2Blocks(1, 0)).rejects.toThrow(
+      `Invalid block range from: 1, limit: 0`,
+    );
+  });
+
+  test.each([LogType.ENCRYPTED, LogType.UNENCRYPTED])(
+    'throws if we try and request less than 1 log',
+    async (logType: LogType) => {
+      const logs = Array(10)
+        .fill(0)
+        .map(_ => L2BlockL2Logs.random(6, 3, 2));
+      await archiverStore.addLogs(logs, logType);
+      await expect(async () => await archiverStore.getLogs(1, 0, logType)).rejects.toThrow(
+        `Invalid block range from: 1, limit: 0`,
+      );
+    },
+  );
+});

--- a/yarn-project/archiver/src/archiver/archiver_store.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.test.ts
@@ -20,6 +20,8 @@ describe('Archiver Memory Store', () => {
       [3 + INITIAL_L2_BLOCK_NUM, 3],
       [1 + INITIAL_L2_BLOCK_NUM, 7],
       [5 + INITIAL_L2_BLOCK_NUM, 8],
+      [10 + INITIAL_L2_BLOCK_NUM, 1],
+      [11 + INITIAL_L2_BLOCK_NUM, 1],
     ]) {
       const expected = blocks.slice(from - INITIAL_L2_BLOCK_NUM, from - INITIAL_L2_BLOCK_NUM + limit);
       const actual = await archiverStore.getL2Blocks(from, limit);
@@ -38,6 +40,8 @@ describe('Archiver Memory Store', () => {
       [3 + INITIAL_L2_BLOCK_NUM, 3],
       [1 + INITIAL_L2_BLOCK_NUM, 7],
       [5 + INITIAL_L2_BLOCK_NUM, 8],
+      [10 + INITIAL_L2_BLOCK_NUM, 1],
+      [11 + INITIAL_L2_BLOCK_NUM, 1],
     ]) {
       const expected = logs.slice(from - INITIAL_L2_BLOCK_NUM, from - INITIAL_L2_BLOCK_NUM + limit);
       const actual = await archiverStore.getLogs(from, limit, logType);

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -256,8 +256,8 @@ export class MemoryArchiverStore implements ArchiverDataStore {
    * @returns The requested L2 blocks.
    */
   public getL2Blocks(from: number, limit: number): Promise<L2Block[]> {
-    if (from < INITIAL_L2_BLOCK_NUM) {
-      throw new Error(`Invalid block range ${from}`);
+    if (from < INITIAL_L2_BLOCK_NUM || limit < 1) {
+      throw new Error(`Invalid block range from: ${from}, limit: ${limit}`);
     }
     if (from > this.l2Blocks.length) {
       return Promise.resolve([]);
@@ -297,8 +297,8 @@ export class MemoryArchiverStore implements ArchiverDataStore {
    * @returns The requested logs.
    */
   getLogs(from: number, limit: number, logType: LogType): Promise<L2BlockL2Logs[]> {
-    if (from < INITIAL_L2_BLOCK_NUM) {
-      throw new Error(`Invalid block range ${from}`);
+    if (from < INITIAL_L2_BLOCK_NUM || limit < 1) {
+      throw new Error(`Invalid block range from: ${from}, limit: ${limit}`);
     }
     const logs = logType === LogType.ENCRYPTED ? this.encryptedLogs : this.unencryptedLogs;
     if (from > logs.length) {

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -263,7 +263,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
       return Promise.resolve([]);
     }
     const startIndex = from - INITIAL_L2_BLOCK_NUM;
-    const endIndex = from + limit;
+    const endIndex = startIndex + limit;
     return Promise.resolve(this.l2Blocks.slice(startIndex, endIndex));
   }
 
@@ -305,7 +305,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
       return Promise.resolve([]);
     }
     const startIndex = from - INITIAL_L2_BLOCK_NUM;
-    const endIndex = from + limit;
+    const endIndex = startIndex + limit;
     return Promise.resolve(logs.slice(startIndex, endIndex));
   }
 


### PR DESCRIPTION
This PR fixes a bug where an incorrect number of logs and/or blocks are retrieved from the Archiver.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
