### PR TITLE
bug: Push siloed nullifier to `pendingNullifiers`

### DIFF
--- a/yarn-project/acir-simulator/src/client/client_execution_context.ts
+++ b/yarn-project/acir-simulator/src/client/client_execution_context.ts
@@ -1,4 +1,5 @@
-import { PrivateHistoricTreeRoots, ReadRequestMembershipWitness, TxContext } from '@aztec/circuits.js';
+import { CircuitsWasm, PrivateHistoricTreeRoots, ReadRequestMembershipWitness, TxContext } from '@aztec/circuits.js';
+import { siloNullifier } from '@aztec/circuits.js/abis';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr, Point } from '@aztec/foundation/fields';
 import { createDebugLogger } from '@aztec/foundation/log';
@@ -236,12 +237,15 @@ export class ClientTxExecutionContext {
   }
 
   /**
-   * Adding a nullifier into the current set of all pending nullifiers created
+   * Adding a siloed nullifier into the current set of all pending nullifiers created
    * within the current transaction/execution.
    * @param innerNullifier - The pending nullifier to add in the list (not yet siloed by contract address).
+   * @param contractAddress - The contract address
    */
-  public pushNewNullifier(innerNullifier: Fr) {
-    this.pendingNullifiers.add(innerNullifier);
+  public async pushNewNullifier(innerNullifier: Fr, contractAddress: AztecAddress) {
+    const wasm = await CircuitsWasm.get();
+    const siloedNullifier = siloNullifier(wasm, contractAddress, innerNullifier);
+    this.pendingNullifiers.add(siloedNullifier);
   }
 
   /**

--- a/yarn-project/acir-simulator/src/client/private_execution.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.ts
@@ -92,13 +92,13 @@ export class PrivateFunctionExecution {
         });
         return Promise.resolve(ZERO_ACVM_FIELD);
       },
-      notifyNullifiedNote: ([slot], [nullifier], acvmPreimage, [innerNoteHash]) => {
+      notifyNullifiedNote: async ([slot], [nullifier], acvmPreimage, [innerNoteHash]) => {
         newNullifiers.push({
           preimage: acvmPreimage.map(f => fromACVMField(f)),
           storageSlot: fromACVMField(slot),
           nullifier: fromACVMField(nullifier),
         });
-        this.context.pushNewNullifier(fromACVMField(nullifier), this.contractAddress);
+        await this.context.pushNewNullifier(fromACVMField(nullifier), this.contractAddress);
         this.context.nullifyPendingNotes(fromACVMField(innerNoteHash), this.contractAddress, fromACVMField(slot));
         return Promise.resolve(ZERO_ACVM_FIELD);
       },

--- a/yarn-project/acir-simulator/src/client/private_execution.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.ts
@@ -98,7 +98,7 @@ export class PrivateFunctionExecution {
           storageSlot: fromACVMField(slot),
           nullifier: fromACVMField(nullifier),
         });
-        this.context.pushNewNullifier(fromACVMField(nullifier));
+        this.context.pushNewNullifier(fromACVMField(nullifier), this.contractAddress);
         this.context.nullifyPendingNotes(fromACVMField(innerNoteHash), this.contractAddress, fromACVMField(slot));
         return Promise.resolve(ZERO_ACVM_FIELD);
       },


### PR DESCRIPTION
The `pendingNullifiers` is used to filter out notes that are already spent. But currently while filtering, we compare a siloed nullifier with an inner nullifier:
https://github.com/AztecProtocol/aztec-packages/blob/91bb1a951c8adfc839f3b944edd410d5e04b55aa/yarn-project/acir-simulator/src/client/client_execution_context.ts#L133-L134
This PR fixes it by adding a siloed nullifier to `pendingNullifiers`.