### PR TITLE
feat(oracle): add oracle to get portal contract address

### DIFF
--- a/yarn-project/acir-simulator/src/acvm/acvm.ts
+++ b/yarn-project/acir-simulator/src/acvm/acvm.ts
@@ -38,7 +38,7 @@ type ORACLE_NAMES =
   | 'createNullifier'
   | 'getCommitment'
   | 'getL1ToL2Message'
-  | 'getPortalAddress'
+  | 'getPortalContractAddress'
   | 'emitEncryptedLog'
   | 'emitUnencryptedLog'
   | 'getPublicKey'

--- a/yarn-project/acir-simulator/src/acvm/acvm.ts
+++ b/yarn-project/acir-simulator/src/acvm/acvm.ts
@@ -38,6 +38,7 @@ type ORACLE_NAMES =
   | 'createNullifier'
   | 'getCommitment'
   | 'getL1ToL2Message'
+  | 'getPortalAddress'
   | 'emitEncryptedLog'
   | 'emitUnencryptedLog'
   | 'getPublicKey'

--- a/yarn-project/acir-simulator/src/client/private_execution.test.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.test.ts
@@ -85,11 +85,13 @@ describe('Private Execution test suite', () => {
     args = [],
     origin = AztecAddress.random(),
     contractAddress = defaultContractAddress,
+    portalContractAddress = EthAddress.ZERO,
     txContext = {},
   }: {
     abi: FunctionAbi;
     origin?: AztecAddress;
     contractAddress?: AztecAddress;
+    portalContractAddress?: EthAddress;
     args?: any[];
     txContext?: Partial<FieldsOf<TxContext>>;
   }) => {
@@ -107,7 +109,7 @@ describe('Private Execution test suite', () => {
       txRequest,
       abi,
       functionData.isConstructor ? AztecAddress.ZERO : contractAddress,
-      EthAddress.ZERO,
+      portalContractAddress,
       blockData,
     );
   };
@@ -978,6 +980,20 @@ describe('Private Execution test suite', () => {
       oracle.getPublicKey.mockResolvedValue([pubKey, partialAddress]);
       const result = await runSimulator({ origin: AztecAddress.random(), abi, args });
       expect(result.returnValues).toEqual([pubKey.x.value, pubKey.y.value]);
+    });
+  });
+
+  describe('Context oracles', () => {
+    it("Should be able to get and return the contract's portal contract address", async () => {
+      const portalContractAddress = EthAddress.random();
+
+      // Tweak the contract ABI so we can extract return values
+      const abi = TestContractAbi.functions.find(f => f.name === 'getPortalAddress')!;
+      abi.returnTypes = [{ kind: 'field' }];
+
+      // Generate a partial address, pubkey, and resulting address
+      const result = await runSimulator({ origin: AztecAddress.random(), abi, args: [], portalContractAddress });
+      expect(result.returnValues).toEqual([portalContractAddress.toField().value]);
     });
   });
 });

--- a/yarn-project/acir-simulator/src/client/private_execution.test.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.test.ts
@@ -986,13 +986,17 @@ describe('Private Execution test suite', () => {
   describe('Context oracles', () => {
     it("Should be able to get and return the contract's portal contract address", async () => {
       const portalContractAddress = EthAddress.random();
+      const aztecAddressToQuery = AztecAddress.random();
 
       // Tweak the contract ABI so we can extract return values
-      const abi = TestContractAbi.functions.find(f => f.name === 'getPortalAddress')!;
+      const abi = TestContractAbi.functions.find(f => f.name === 'getPortalContractAddress')!;
       abi.returnTypes = [{ kind: 'field' }];
 
-      // Generate a partial address, pubkey, and resulting address
-      const result = await runSimulator({ origin: AztecAddress.random(), abi, args: [], portalContractAddress });
+      const args = [aztecAddressToQuery.toField()];
+
+      // Overwrite the oracle return value
+      oracle.getPortalContractAddress.mockResolvedValue(portalContractAddress);
+      const result = await runSimulator({ origin: AztecAddress.random(), abi, args });
       expect(result.returnValues).toEqual([portalContractAddress.toField().value]);
     });
   });

--- a/yarn-project/acir-simulator/src/client/private_execution.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.ts
@@ -175,9 +175,10 @@ export class PrivateFunctionExecution {
 
         return Promise.resolve(ZERO_ACVM_FIELD);
       },
-      getPortalAddress: () => {
-        // TODO: should this look into the oracle itself?
-        return Promise.resolve(toACVMField(this.callContext.portalContractAddress));
+      getPortalContractAddress: async ([aztecAddress]) => {
+        const contractAddress = AztecAddress.fromString(aztecAddress);
+        const portalContactAddress = await this.context.db.getPortalContractAddress(contractAddress);
+        return Promise.resolve(toACVMField(portalContactAddress));
       },
     });
 

--- a/yarn-project/acir-simulator/src/client/private_execution.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.ts
@@ -175,6 +175,10 @@ export class PrivateFunctionExecution {
 
         return Promise.resolve(ZERO_ACVM_FIELD);
       },
+      getPortalAddress: () => {
+        // TODO: should this look into the oracle itself?
+        return Promise.resolve(toACVMField(this.callContext.portalContractAddress));
+      },
     });
 
     const publicInputs = extractPublicInputs(partialWitness, acir);

--- a/yarn-project/acir-simulator/src/client/simulator.ts
+++ b/yarn-project/acir-simulator/src/client/simulator.ts
@@ -41,7 +41,6 @@ export class AcirSimulator {
     request: TxExecutionRequest,
     entryPointABI: FunctionAbi,
     contractAddress: AztecAddress,
-    // TODO: should this be fetched first - where is it calculated
     portalContractAddress: EthAddress,
     constantHistoricBlockData: ConstantHistoricBlockData,
   ): Promise<ExecutionResult> {

--- a/yarn-project/acir-simulator/src/client/simulator.ts
+++ b/yarn-project/acir-simulator/src/client/simulator.ts
@@ -41,6 +41,7 @@ export class AcirSimulator {
     request: TxExecutionRequest,
     entryPointABI: FunctionAbi,
     contractAddress: AztecAddress,
+    // TODO: should this be fetched first - where is it calculated
     portalContractAddress: EthAddress,
     constantHistoricBlockData: ConstantHistoricBlockData,
   ): Promise<ExecutionResult> {

--- a/yarn-project/acir-simulator/src/client/unconstrained_execution.ts
+++ b/yarn-project/acir-simulator/src/client/unconstrained_execution.ts
@@ -83,6 +83,11 @@ export class UnconstrainedFunctionExecution {
         }
         return values.map(v => toACVMField(v));
       },
+      getPortalContractAddress: async ([aztecAddress]) => {
+        const contractAddress = AztecAddress.fromString(aztecAddress);
+        const portalContactAddress = await this.context.db.getPortalContractAddress(contractAddress);
+        return Promise.resolve(toACVMField(portalContactAddress));
+      },
     });
 
     const returnValues: ACVMField[] = extractReturnWitness(acir, partialWitness);

--- a/yarn-project/acir-simulator/src/public/executor.ts
+++ b/yarn-project/acir-simulator/src/public/executor.ts
@@ -154,8 +154,8 @@ export class PublicExecutor {
       },
       getPortalContractAddress: async ([aztecAddress]) => {
         const contractAddress = AztecAddress.fromString(aztecAddress);
-        let portalContactAddress = await this.contractsDb.getPortalContractAddress(contractAddress);
-        if (!portalContactAddress) portalContactAddress = EthAddress.ZERO;
+        const portalContactAddress =
+          (await this.contractsDb.getPortalContractAddress(contractAddress)) ?? EthAddress.ZERO;
         return Promise.resolve(toACVMField(portalContactAddress));
       },
     });

--- a/yarn-project/acir-simulator/src/public/executor.ts
+++ b/yarn-project/acir-simulator/src/public/executor.ts
@@ -152,6 +152,12 @@ export class PublicExecutor {
         this.log(`Emitted unencrypted log: "${log.toString('ascii')}"`);
         return Promise.resolve(ZERO_ACVM_FIELD);
       },
+      getPortalContractAddress: async ([aztecAddress]) => {
+        const contractAddress = AztecAddress.fromString(aztecAddress);
+        let portalContactAddress = await this.contractsDb.getPortalContractAddress(contractAddress);
+        if (!portalContactAddress) portalContactAddress = EthAddress.ZERO;
+        return Promise.resolve(toACVMField(portalContactAddress));
+      },
     });
 
     const returnValues = extractReturnWitness(acir, partialWitness).map(fromACVMField);

--- a/yarn-project/aztec-sandbox/src/examples/uniswap_trade_on_l1_from_l2.ts
+++ b/yarn-project/aztec-sandbox/src/examples/uniswap_trade_on_l1_from_l2.ts
@@ -246,18 +246,15 @@ async function main() {
     .swap(
       selector,
       wethL2Contract.address.toField(),
-      wethTokenPortalAddress.toField(),
       wethAmountToBridge,
       new Fr(3000),
       daiL2Contract.address.toField(),
-      daiTokenPortalAddress.toField(),
       new Fr(minimumOutputAmount),
       owner,
       owner,
       secretHash,
       new Fr(2 ** 32 - 1),
       ethAccount.toField(),
-      uniswapPortalAddress,
       ethAccount.toField(),
     )
     .send({ origin: owner });

--- a/yarn-project/aztec-sandbox/src/examples/uniswap_trade_on_l1_from_l2.ts
+++ b/yarn-project/aztec-sandbox/src/examples/uniswap_trade_on_l1_from_l2.ts
@@ -129,7 +129,6 @@ async function deployAllContracts(owner: AztecAddress) {
     wethTokenPortalAddress,
     uniswapL2Contract,
     uniswapPortal,
-    uniswapPortalAddress,
   };
 }
 
@@ -185,7 +184,6 @@ async function main() {
     wethTokenPortalAddress,
     uniswapL2Contract,
     uniswapPortal,
-    uniswapPortalAddress,
   } = result;
 
   // Give me some WETH so I can deposit to L2 and do the swap...

--- a/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
+++ b/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
@@ -23,8 +23,7 @@ import { delay, deployAndInitializeNonNativeL2TokenContracts, setup } from './fi
 
 const dumpedState = 'src/fixtures/dumps/uniswap_state';
 // When taking a dump use the block number of the fork to improve speed.
-// const EXPECTED_FORKED_BLOCK = 0; //17514288;
-const EXPECTED_FORKED_BLOCK = 17514288;
+const EXPECTED_FORKED_BLOCK = 0; //17514288;
 // We tell the archiver to only sync from this block.
 process.env.SEARCH_START_BLOCK = EXPECTED_FORKED_BLOCK.toString();
 

--- a/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
+++ b/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
@@ -206,7 +206,6 @@ describe('uniswap_trade_on_l1_from_l2', () => {
         secretHash,
         new Fr(2 ** 32 - 1),
         ethAccount.toField(),
-        uniswapPortalAddress,
         ethAccount.toField(),
       )
       .send({ origin: ownerAddress });

--- a/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
+++ b/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
@@ -23,7 +23,8 @@ import { delay, deployAndInitializeNonNativeL2TokenContracts, setup } from './fi
 
 const dumpedState = 'src/fixtures/dumps/uniswap_state';
 // When taking a dump use the block number of the fork to improve speed.
-const EXPECTED_FORKED_BLOCK = 0; //17514288;
+// const EXPECTED_FORKED_BLOCK = 0; //17514288;
+const EXPECTED_FORKED_BLOCK = 17514288;
 // We tell the archiver to only sync from this block.
 process.env.SEARCH_START_BLOCK = EXPECTED_FORKED_BLOCK.toString();
 
@@ -196,11 +197,9 @@ describe('uniswap_trade_on_l1_from_l2', () => {
       .swap(
         selector,
         wethCrossChainHarness.l2Contract.address.toField(),
-        wethCrossChainHarness.tokenPortalAddress.toField(),
         wethAmountToBridge,
         new Fr(3000),
         daiCrossChainHarness.l2Contract.address.toField(),
-        daiCrossChainHarness.tokenPortalAddress.toField(),
         new Fr(minimumOutputAmount),
         ownerAddress,
         ownerAddress,

--- a/yarn-project/noir-contracts/src/contracts/test_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/test_contract/src/main.nr
@@ -12,7 +12,8 @@ contract Test {
     use dep::aztec::oracle::{
         create_l2_to_l1_message::create_l2_to_l1_message,
         create_nullifier::create_nullifier,
-        get_public_key::get_public_key
+        get_public_key::get_public_key,
+        context::get_portal_address
     };
 
     fn constructor(
@@ -29,6 +30,16 @@ contract Test {
         let mut context = Context::new(inputs, abi::hash_args([address]));
         let pub_key = get_public_key(address);
         context.return_values.push_array([pub_key.x, pub_key.y]);
+        context.finish()
+    }
+
+    // Get the portal contract address through an oracle call
+    fn getPortalAddress(
+        inputs: PrivateContextInputs,
+    ) -> distinct pub abi::PrivateCircuitPublicInputs {
+        let mut context = Context::new(inputs, abi::hash_args([]));
+        let portal_address = get_portal_address();
+        context.return_values.push_array([portal_address]);
         context.finish()
     }
 

--- a/yarn-project/noir-contracts/src/contracts/test_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/test_contract/src/main.nr
@@ -12,7 +12,8 @@ contract Test {
     use dep::aztec::oracle::{
         create_l2_to_l1_message::create_l2_to_l1_message,
         create_nullifier::create_nullifier,
-        get_public_key::get_public_key
+        get_public_key::get_public_key,
+        context::get_portal_address
     };
 
     fn constructor(
@@ -33,11 +34,12 @@ contract Test {
     }
 
     // Get the portal contract address through an oracle call
-    fn getPortalAddress(
+    fn getPortalContractAddress(
         inputs: PrivateContextInputs,
+        aztec_address: Field
     ) -> distinct pub abi::PrivateCircuitPublicInputs {
         let mut context = Context::new(inputs, abi::hash_args([]));
-        let portal_address = context.this_portal_address();
+        let portal_address = get_portal_address(aztec_address);
         context.return_values.push_array([portal_address]);
         context.finish()
     }

--- a/yarn-project/noir-contracts/src/contracts/test_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/test_contract/src/main.nr
@@ -12,8 +12,7 @@ contract Test {
     use dep::aztec::oracle::{
         create_l2_to_l1_message::create_l2_to_l1_message,
         create_nullifier::create_nullifier,
-        get_public_key::get_public_key,
-        context::get_portal_address
+        get_public_key::get_public_key
     };
 
     fn constructor(
@@ -38,7 +37,7 @@ contract Test {
         inputs: PrivateContextInputs,
     ) -> distinct pub abi::PrivateCircuitPublicInputs {
         let mut context = Context::new(inputs, abi::hash_args([]));
-        let portal_address = get_portal_address();
+        let portal_address = context.this_portal_address();
         context.return_values.push_array([portal_address]);
         context.finish()
     }

--- a/yarn-project/noir-contracts/src/contracts/uniswap_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/uniswap_contract/src/main.nr
@@ -4,7 +4,10 @@ contract Uniswap {
     use dep::aztec::abi::PrivateContextInputs;
     use dep::aztec::abi::PublicContextInputs;
     use dep::aztec::context::Context;
-    use dep::aztec::oracle::public_call;
+    use dep::aztec::oracle::{
+        public_call,
+        context::get_portal_address
+    };
     use dep::aztec::private_call_stack_item::PrivateCallStackItem;
     use dep::aztec::public_call_stack_item::PublicCallStackItem;
     use dep::aztec::types::point::Point;
@@ -28,11 +31,9 @@ contract Uniswap {
         inputs: PrivateContextInputs,
         withdrawFnSelector: Field, // withdraw method on inputAsset (l2 contract) that would withdraw to L1
         inputAsset: Field, 
-        inputAssetPortalAddress: Field, // l1 portal of input asset
         inputAmount: Field,
         uniswapFeeTier: Field, // which uniswap tier to use (eg 3000 for 0.3% fee)
         outputAsset: Field,
-        outputAssetPortalAddress: Field, // l1 portal of output asset
         minimumOutputAmount: Field, // minimum output amount to receive (slippage protection for the swap)
         sender: Field, 
         recipient: Field, // receiver address of output asset after the swap
@@ -45,11 +46,9 @@ contract Uniswap {
         let mut context = Context::new(inputs, abi::hash_args([
             withdrawFnSelector,
             inputAsset,
-            inputAssetPortalAddress,
             inputAmount,
             uniswapFeeTier,
             outputAsset,
-            outputAssetPortalAddress,
             minimumOutputAmount,
             sender,
             recipient,
@@ -72,6 +71,10 @@ contract Uniswap {
         
         let result = return_values[0];
         context.return_values.push(result);
+
+        // Get portal addresses
+        let inputAssetPortalAddress = get_portal_address(inputAsset);
+        let outputAssetPortalAddress = get_portal_address(outputAsset);
 
         // Send the swap message to L1 portal
         let content_hash = _compute_swap_content_hash(

--- a/yarn-project/noir-contracts/src/contracts/uniswap_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/uniswap_contract/src/main.nr
@@ -40,7 +40,6 @@ contract Uniswap {
         secretHash: Field, // for when l1 uniswap portal inserts the message to consume output assets on L2
         deadlineForL1ToL2Message: Field, // for when l1 uniswap portal inserts the message to consume output assets on L2
         cancellerForL1ToL2Message: Field, // L1 address of who can cancel the message to consume assets on L2.
-        l1UniswapPortal: Field, // L1 address of uniswap portal contract
         callerOnL1: Field, // ethereum address that can call this function on the L1 portal (0x0 if anyone can call)
     ) -> distinct pub abi::PrivateCircuitPublicInputs {
         let mut context = Context::new(inputs, abi::hash_args([
@@ -55,9 +54,13 @@ contract Uniswap {
             secretHash,
             deadlineForL1ToL2Message,
             cancellerForL1ToL2Message,
-            l1UniswapPortal,
             callerOnL1,
         ]));
+
+        // Get portal addresses
+        let l1UniswapPortal = context.this_portal_address();
+        let inputAssetPortalAddress = get_portal_address(inputAsset);
+        let outputAssetPortalAddress = get_portal_address(outputAsset);
 
         // inputAsset.withdraw(inputAmount, sender, recipient=l1UniswapPortal, callerOnL1=l1UniswapPortal) 
         // only uniswap portal can call this (done to safeguard ordering of message consumption)
@@ -71,10 +74,6 @@ contract Uniswap {
         
         let result = return_values[0];
         context.return_values.push(result);
-
-        // Get portal addresses
-        let inputAssetPortalAddress = get_portal_address(inputAsset);
-        let outputAssetPortalAddress = get_portal_address(outputAsset);
 
         // Send the swap message to L1 portal
         let content_hash = _compute_swap_content_hash(

--- a/yarn-project/noir-libs/noir-aztec/src/context.nr
+++ b/yarn-project/noir-libs/noir-aztec/src/context.nr
@@ -105,9 +105,8 @@ impl Context {
         self.inputs.call_context.storage_contract_address
     }
 
-    fn this_portal_address(_self: Self) -> Field {
-        // Get the portal contract address from an oracle call
-        get_portal_address()
+    fn this_portal_address(self) -> Field {
+        self.inputs.call_context.portal_contract_address
     }
 
     fn chain_id(self) -> Field {

--- a/yarn-project/noir-libs/noir-aztec/src/context.nr
+++ b/yarn-project/noir-libs/noir-aztec/src/context.nr
@@ -47,6 +47,7 @@ use crate::oracle::{
     call_private_function::call_private_function_internal,
     public_call::call_public_function_internal,
     enqueue_public_function_call::enqueue_public_function_call_internal,
+    context::get_portal_address,
 };
 
 
@@ -104,8 +105,9 @@ impl Context {
         self.inputs.call_context.storage_contract_address
     }
 
-    fn this_portal_address(self) -> Field {
-        self.inputs.call_context.portal_contract_address
+    fn this_portal_address(_self: Self) -> Field {
+        // Get the portal contract address from an oracle call
+        get_portal_address()
     }
 
     fn chain_id(self) -> Field {

--- a/yarn-project/noir-libs/noir-aztec/src/oracle.nr
+++ b/yarn-project/noir-libs/noir-aztec/src/oracle.nr
@@ -1,5 +1,6 @@
 mod arguments;
 mod call_private_function;
+mod context;
 mod create_commitment;
 mod create_l2_to_l1_message;
 mod create_nullifier;

--- a/yarn-project/noir-libs/noir-aztec/src/oracle/context.nr
+++ b/yarn-project/noir-libs/noir-aztec/src/oracle/context.nr
@@ -1,0 +1,8 @@
+#[oracle(getPortalAddress)]
+fn _get_portal_address() -> Field {}
+
+
+unconstrained fn get_portal_address() -> Field {
+    let portal_address = _get_portal_address();
+    portal_address
+}

--- a/yarn-project/noir-libs/noir-aztec/src/oracle/context.nr
+++ b/yarn-project/noir-libs/noir-aztec/src/oracle/context.nr
@@ -1,8 +1,7 @@
-#[oracle(getPortalAddress)]
-fn _get_portal_address() -> Field {}
+#[oracle(getPortalContractAddress)]
+fn _get_portal_address(_contract_address: Field) -> Field {}
 
-
-unconstrained fn get_portal_address() -> Field {
-    let portal_address = _get_portal_address();
+unconstrained fn get_portal_address(contract_address: Field) -> Field {
+    let portal_address = _get_portal_address(contract_address);
     portal_address
 }


### PR DESCRIPTION
**Overview**
closes: #1464 

Adds an oracle that returns the portal address for a given contract address. 
A unit test is added, and the uniswap portal test is altered to use this oracle rather than injecting the portals as function inputs

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
