### PR TITLE
fix: return DecodedReturn instead of any[]

### DIFF
--- a/yarn-project/acir-simulator/src/client/execution_result.ts
+++ b/yarn-project/acir-simulator/src/client/execution_result.ts
@@ -1,9 +1,9 @@
 import { PrivateCallStackItem, PublicCallRequest, ReadRequestMembershipWitness } from '@aztec/circuits.js';
+import { DecodedReturn } from '@aztec/foundation/abi';
 import { Fr } from '@aztec/foundation/fields';
 import { FunctionL2Logs } from '@aztec/types';
 
 import { ACVMField } from '../acvm/index.js';
-import { DecodedReturn } from '@aztec/foundation/abi';
 
 /**
  * The contents of a new note.

--- a/yarn-project/acir-simulator/src/client/execution_result.ts
+++ b/yarn-project/acir-simulator/src/client/execution_result.ts
@@ -3,6 +3,7 @@ import { Fr } from '@aztec/foundation/fields';
 import { FunctionL2Logs } from '@aztec/types';
 
 import { ACVMField } from '../acvm/index.js';
+import { DecodedReturn } from '@aztec/foundation/abi';
 
 /**
  * The contents of a new note.
@@ -56,7 +57,7 @@ export interface ExecutionResult {
   /** The preimages of the executed function. */
   preimages: ExecutionPreimages;
   /** The decoded return values of the executed function. */
-  returnValues: any[];
+  returnValues: DecodedReturn;
   /** The nested executions. */
   nestedExecutions: this[];
   /** Enqueued public function execution requests to be picked up by the sequencer. */

--- a/yarn-project/acir-simulator/src/client/private_execution.test.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.test.ts
@@ -1014,7 +1014,7 @@ describe('Private Execution test suite', () => {
     it('gets the public key for an address', async () => {
       // Tweak the contract ABI so we can extract return values
       const abi = TestContractAbi.functions.find(f => f.name === 'getPublicKey')!;
-      abi.returnTypes = [{ kind: 'field' }, { kind: 'field' }];
+      abi.returnTypes = [{ kind: 'array', length: 2, type: { kind: 'field' } }];
 
       // Generate a partial address, pubkey, and resulting address
       const partialAddress = Fr.random();
@@ -1043,7 +1043,7 @@ describe('Private Execution test suite', () => {
       // Overwrite the oracle return value
       oracle.getPortalContractAddress.mockResolvedValue(portalContractAddress);
       const result = await runSimulator({ origin: AztecAddress.random(), abi, args });
-      expect(result.returnValues).toEqual([portalContractAddress.toField().value]);
+      expect(result.returnValues).toEqual(portalContractAddress.toField().value);
     });
 
     it('this_address should return the current context address', async () => {
@@ -1055,7 +1055,7 @@ describe('Private Execution test suite', () => {
 
       // Overwrite the oracle return value
       const result = await runSimulator({ origin: AztecAddress.random(), abi, args: [], contractAddress });
-      expect(result.returnValues).toEqual([contractAddress.toField().value]);
+      expect(result.returnValues).toEqual(contractAddress.toField().value);
     });
 
     it("this_portal_address should return the current context's portal address", async () => {
@@ -1067,7 +1067,7 @@ describe('Private Execution test suite', () => {
 
       // Overwrite the oracle return value
       const result = await runSimulator({ origin: AztecAddress.random(), abi, args: [], portalContractAddress });
-      expect(result.returnValues).toEqual([portalContractAddress.toField().value]);
+      expect(result.returnValues).toEqual(portalContractAddress.toField().value);
     });
   });
 });

--- a/yarn-project/acir-simulator/src/client/simulator.ts
+++ b/yarn-project/acir-simulator/src/client/simulator.ts
@@ -160,13 +160,13 @@ export class AcirSimulator {
         args: encodeArguments(abi, [contractAddress, nonce, storageSlot, extendedPreimage]),
       };
 
-      const [[innerNoteHash, siloedNoteHash, uniqueSiloedNoteHash, innerNullifier]] = await this.runUnconstrained(
+      const [innerNoteHash, siloedNoteHash, uniqueSiloedNoteHash, innerNullifier] = (await this.runUnconstrained(
         execRequest,
         AztecAddress.ZERO,
         abi,
         AztecAddress.ZERO,
         EthAddress.ZERO,
-      );
+      )) as bigint[];
 
       return {
         innerNoteHash: new Fr(innerNoteHash),

--- a/yarn-project/acir-simulator/src/client/unconstrained_execution.test.ts
+++ b/yarn-project/acir-simulator/src/client/unconstrained_execution.test.ts
@@ -87,7 +87,7 @@ describe('Unconstrained Execution test suite', () => {
         EthAddress.ZERO,
       );
 
-      expect(result).toEqual([9n]);
+      expect(result).toEqual(9n);
     }, 30_000);
   });
 });

--- a/yarn-project/acir-simulator/src/client/unconstrained_execution.ts
+++ b/yarn-project/acir-simulator/src/client/unconstrained_execution.ts
@@ -1,5 +1,5 @@
 import { CallContext, FunctionData } from '@aztec/circuits.js';
-import { FunctionAbi, decodeReturnValues } from '@aztec/foundation/abi';
+import { DecodedReturn, FunctionAbi, decodeReturnValues } from '@aztec/foundation/abi';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
 import { createDebugLogger } from '@aztec/foundation/log';
@@ -30,7 +30,7 @@ export class UnconstrainedFunctionExecution {
    * @param aztecNode - The aztec node.
    * @returns The return values of the executed function.
    */
-  public async run(aztecNode?: AztecNode): Promise<any[]> {
+  public async run(aztecNode?: AztecNode): Promise<DecodedReturn> {
     this.log(
       `Executing unconstrained function ${this.contractAddress.toShortString()}:${this.functionData.functionSelectorBuffer.toString(
         'hex',

--- a/yarn-project/aztec-sandbox/src/examples/private_token_contract.ts
+++ b/yarn-project/aztec-sandbox/src/examples/private_token_contract.ts
@@ -37,8 +37,7 @@ async function deployZKContract(owner: AztecAddress) {
  * @returns The owner's current balance of the token.
  */
 async function getBalance(contract: Contract, ownerAddress: AztecAddress) {
-  const [balance] = await contract.methods.getBalance(ownerAddress).view({ from: ownerAddress });
-  return balance;
+  return await contract.methods.getBalance(ownerAddress).view({ from: ownerAddress });
 }
 
 /**

--- a/yarn-project/aztec-sandbox/src/examples/uniswap_trade_on_l1_from_l2.ts
+++ b/yarn-project/aztec-sandbox/src/examples/uniswap_trade_on_l1_from_l2.ts
@@ -133,8 +133,7 @@ async function deployAllContracts(owner: AztecAddress) {
 }
 
 const getL2BalanceOf = async (aztecRpcClient: AztecRPC, owner: AztecAddress, l2Contract: NonNativeTokenContract) => {
-  const [balance] = await l2Contract.methods.getBalance(owner).view({ from: owner });
-  return balance;
+  return await l2Contract.methods.getBalance(owner).view({ from: owner });
 };
 
 const logExpectedBalanceOnL2 = async (

--- a/yarn-project/aztec.js/README.md
+++ b/yarn-project/aztec.js/README.md
@@ -37,7 +37,7 @@ console.log(`Transferred ${amount} to ${recipientAddress}!`);
 import { Contract } from '@aztec/aztec.js';
 
 const contract = await Contract.create(contractAddress, contractAbi, aztecRpcServer);
-const [balance] = contract.methods
+const balance = contract.methods
     .getBalance(accountPublicKey))
     .view({ from: accountAddress });
 console.log(`Account balance: ${balance}.`);

--- a/yarn-project/canary/src/uniswap_trade_on_l1_from_l2.test.ts
+++ b/yarn-project/canary/src/uniswap_trade_on_l1_from_l2.test.ts
@@ -136,9 +136,11 @@ async function deployAllContracts(
   };
 }
 
-const getL2BalanceOf = async (owner: AztecAddress, l2Contract: NonNativeTokenContract) => {
-  const [balance] = await l2Contract.methods.getBalance(owner).view({ from: owner });
-  return balance;
+const getL2BalanceOf = async (
+  owner: AztecAddress,
+  l2Contract: NonNativeTokenContract
+) => {
+  return await l2Contract.methods.getBalance(owner).view({ from: owner });
 };
 
 const expectBalanceOnL2 = async (owner: AztecAddress, expectedBalance: bigint, l2Contract: NonNativeTokenContract) => {

--- a/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
@@ -71,7 +71,7 @@ describe('e2e_2_rpc_servers', () => {
 
     // Then check the balance
     const contractWithWallet = await PrivateTokenContract.create(tokenAddress, wallet);
-    const [balance] = await contractWithWallet.methods.getBalance(owner).view({ from: owner });
+    const balance = await contractWithWallet.methods.getBalance(owner).view({ from: owner });
     logger(`Account ${owner} balance: ${balance}`);
     expect(balance).toBe(expectedBalance);
   };

--- a/yarn-project/end-to-end/src/e2e_aztec_js_browser.test.ts
+++ b/yarn-project/end-to-end/src/e2e_aztec_js_browser.test.ts
@@ -147,7 +147,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
           PrivateTokenContractAbi,
           wallet,
         );
-        const [balance] = await contract.methods.getBalance(owner).view({ from: owner });
+        const balance = await contract.methods.getBalance(owner).view({ from: owner });
         return balance;
       },
       SANDBOX_URL,
@@ -187,8 +187,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
         );
         await contract.methods.transfer(transferAmount, owner, receiver).send({ origin: owner }).wait();
         console.log(`Transfered ${transferAmount} tokens to new Account`);
-        const [balance] = await contract.methods.getBalance(receiver).view({ from: receiver });
-        return balance;
+        return await contract.methods.getBalance(receiver).view({ from: receiver });
       },
       SANDBOX_URL,
       privKey.toString(),

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
@@ -66,7 +66,7 @@ describe('e2e_cross_chain_messaging', () => {
   });
 
   const expectBalance = async (owner: AztecAddress, expectedBalance: bigint) => {
-    const [balance] = await l2Contract.methods.getBalance(owner).view({ from: owner });
+    const balance = await l2Contract.methods.getBalance(owner).view({ from: owner });
     logger(`Account ${owner} balance: ${balance}`);
     expect(balance).toBe(expectedBalance);
   };

--- a/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
@@ -62,7 +62,7 @@ describe('e2e_escrow_contract', () => {
   }, 30_000);
 
   const expectBalance = async (who: AztecAddress, expectedBalance: bigint) => {
-    const [balance] = await privateTokenContract.methods.getBalance(who).view({ from: who });
+    const balance = await privateTokenContract.methods.getBalance(who).view({ from: who });
     logger(`Account ${who} balance: ${balance}`);
     expect(balance).toBe(expectedBalance);
   };

--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -46,19 +46,17 @@ describe('e2e_lending_contract', () => {
   const getStorageSnapshot = async (contract: LendingContract, aztecNode: AztecRPC, account: Account) => {
     const storageValues: { [key: string]: Fr } = {};
     const accountKey = await account.key();
-    const toFields = (res: any[]) => res[0].map((v: number | bigint | Fr) => new Fr(v));
 
-    [storageValues['interestAccumulator'], storageValues['last_updated_ts']] = toFields(
-      await contract.methods.getTot(0).view(),
-    );
+    const tot = await contract.methods.getTot(0).view();
+    const privatePos = await contract.methods.getPosition(accountKey).view();
+    const publicPos = await contract.methods.getPosition(account.address.toField()).view();
 
-    [storageValues['private_collateral'], storageValues['private_debt']] = toFields(
-      await contract.methods.getPosition(accountKey).view(),
-    );
-
-    [storageValues['public_collateral'], storageValues['public_debt']] = toFields(
-      await contract.methods.getPosition(account.address.toField()).view(),
-    );
+    storageValues['interest_accumulator'] = new Fr(tot['interest_accumulator']);
+    storageValues['last_updated_ts'] = new Fr(tot['last_updated_ts']);
+    storageValues['private_collateral'] = new Fr(privatePos["collateral"]);
+    storageValues['private_debt'] = new Fr(privatePos["static_debt"]);
+    storageValues['public_collateral'] = new Fr(publicPos["collateral"]);
+    storageValues['public_debt'] = new Fr(publicPos["static_debt"]);
 
     return storageValues;
   };
@@ -103,7 +101,7 @@ describe('e2e_lending_contract', () => {
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['initial'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
 
-      expect(storageSnapshots['initial']['interestAccumulator']).toEqual(new Fr(1000000000n));
+      expect(storageSnapshots['initial']['interest_accumulator']).toEqual(new Fr(1000000000n));
       expect(storageSnapshots['initial']['last_updated_ts'].value).toBeGreaterThan(0n);
     }
 
@@ -121,8 +119,8 @@ describe('e2e_lending_contract', () => {
       storageSnapshots['private_deposit'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
 
       // @todo The accumulator should not increase when there are no debt. But we don't have reads/writes enough right now to handle that.
-      expect(storageSnapshots['private_deposit']['interestAccumulator'].value).toBeGreaterThan(
-        storageSnapshots['initial']['interestAccumulator'].value,
+      expect(storageSnapshots['private_deposit']['interest_accumulator'].value).toBeGreaterThan(
+        storageSnapshots['initial']['interest_accumulator'].value,
       );
       expect(storageSnapshots['private_deposit']['last_updated_ts'].value).toBeGreaterThan(
         storageSnapshots['initial']['last_updated_ts'].value,
@@ -147,8 +145,8 @@ describe('e2e_lending_contract', () => {
         account,
       );
 
-      expect(storageSnapshots['private_deposit_on_behalf']['interestAccumulator'].value).toBeGreaterThan(
-        storageSnapshots['private_deposit']['interestAccumulator'].value,
+      expect(storageSnapshots['private_deposit_on_behalf']['interest_accumulator'].value).toBeGreaterThan(
+        storageSnapshots['private_deposit']['interest_accumulator'].value,
       );
       expect(storageSnapshots['private_deposit_on_behalf']['last_updated_ts'].value).toBeGreaterThan(
         storageSnapshots['private_deposit']['last_updated_ts'].value,
@@ -173,8 +171,8 @@ describe('e2e_lending_contract', () => {
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['public_deposit'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
 
-      expect(storageSnapshots['public_deposit']['interestAccumulator'].value).toBeGreaterThan(
-        storageSnapshots['private_deposit_on_behalf']['interestAccumulator'].value,
+      expect(storageSnapshots['public_deposit']['interest_accumulator'].value).toBeGreaterThan(
+        storageSnapshots['private_deposit_on_behalf']['interest_accumulator'].value,
       );
       expect(storageSnapshots['public_deposit']['last_updated_ts'].value).toBeGreaterThan(
         storageSnapshots['private_deposit_on_behalf']['last_updated_ts'].value,
@@ -201,8 +199,8 @@ describe('e2e_lending_contract', () => {
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['private_borrow'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
 
-      expect(storageSnapshots['private_borrow']['interestAccumulator'].value).toBeGreaterThan(
-        storageSnapshots['public_deposit']['interestAccumulator'].value,
+      expect(storageSnapshots['private_borrow']['interest_accumulator'].value).toBeGreaterThan(
+        storageSnapshots['public_deposit']['interest_accumulator'].value,
       );
       expect(storageSnapshots['private_borrow']['last_updated_ts'].value).toBeGreaterThan(
         storageSnapshots['public_deposit']['last_updated_ts'].value,
@@ -230,8 +228,8 @@ describe('e2e_lending_contract', () => {
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['public_borrow'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
 
-      expect(storageSnapshots['public_borrow']['interestAccumulator'].value).toBeGreaterThan(
-        storageSnapshots['private_borrow']['interestAccumulator'].value,
+      expect(storageSnapshots['public_borrow']['interest_accumulator'].value).toBeGreaterThan(
+        storageSnapshots['private_borrow']['interest_accumulator'].value,
       );
       expect(storageSnapshots['public_borrow']['last_updated_ts'].value).toBeGreaterThan(
         storageSnapshots['private_borrow']['last_updated_ts'].value,
@@ -262,8 +260,8 @@ describe('e2e_lending_contract', () => {
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['private_repay'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
 
-      expect(storageSnapshots['private_repay']['interestAccumulator'].value).toBeGreaterThan(
-        storageSnapshots['public_borrow']['interestAccumulator'].value,
+      expect(storageSnapshots['private_repay']['interest_accumulator'].value).toBeGreaterThan(
+        storageSnapshots['public_borrow']['interest_accumulator'].value,
       );
       expect(storageSnapshots['private_repay']['last_updated_ts'].value).toBeGreaterThan(
         storageSnapshots['public_borrow']['last_updated_ts'].value,
@@ -296,8 +294,8 @@ describe('e2e_lending_contract', () => {
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['private_repay_on_behalf'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
 
-      expect(storageSnapshots['private_repay_on_behalf']['interestAccumulator'].value).toBeGreaterThan(
-        storageSnapshots['private_repay']['interestAccumulator'].value,
+      expect(storageSnapshots['private_repay_on_behalf']['interest_accumulator'].value).toBeGreaterThan(
+        storageSnapshots['private_repay']['interest_accumulator'].value,
       );
       expect(storageSnapshots['private_repay_on_behalf']['last_updated_ts'].value).toBeGreaterThan(
         storageSnapshots['private_repay']['last_updated_ts'].value,
@@ -330,8 +328,8 @@ describe('e2e_lending_contract', () => {
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['public_repay'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
 
-      expect(storageSnapshots['public_repay']['interestAccumulator'].value).toBeGreaterThan(
-        storageSnapshots['private_repay_on_behalf']['interestAccumulator'].value,
+      expect(storageSnapshots['public_repay']['interest_accumulator'].value).toBeGreaterThan(
+        storageSnapshots['private_repay_on_behalf']['interest_accumulator'].value,
       );
       expect(storageSnapshots['public_repay']['last_updated_ts'].value).toBeGreaterThan(
         storageSnapshots['private_repay_on_behalf']['last_updated_ts'].value,
@@ -364,8 +362,8 @@ describe('e2e_lending_contract', () => {
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['public_withdraw'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
 
-      expect(storageSnapshots['public_withdraw']['interestAccumulator'].value).toBeGreaterThan(
-        storageSnapshots['public_repay']['interestAccumulator'].value,
+      expect(storageSnapshots['public_withdraw']['interest_accumulator'].value).toBeGreaterThan(
+        storageSnapshots['public_repay']['interest_accumulator'].value,
       );
       expect(storageSnapshots['public_withdraw']['last_updated_ts'].value).toBeGreaterThan(
         storageSnapshots['public_repay']['last_updated_ts'].value,
@@ -398,8 +396,8 @@ describe('e2e_lending_contract', () => {
       expect(receipt.status).toBe(TxStatus.MINED);
       storageSnapshots['private_withdraw'] = await getStorageSnapshot(deployedContract, aztecRpcServer, account);
 
-      expect(storageSnapshots['private_withdraw']['interestAccumulator'].value).toBeGreaterThan(
-        storageSnapshots['public_withdraw']['interestAccumulator'].value,
+      expect(storageSnapshots['private_withdraw']['interest_accumulator'].value).toBeGreaterThan(
+        storageSnapshots['public_withdraw']['interest_accumulator'].value,
       );
       expect(storageSnapshots['private_withdraw']['last_updated_ts'].value).toBeGreaterThan(
         storageSnapshots['public_withdraw']['last_updated_ts'].value,

--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -53,10 +53,10 @@ describe('e2e_lending_contract', () => {
 
     storageValues['interest_accumulator'] = new Fr(tot['interest_accumulator']);
     storageValues['last_updated_ts'] = new Fr(tot['last_updated_ts']);
-    storageValues['private_collateral'] = new Fr(privatePos["collateral"]);
-    storageValues['private_debt'] = new Fr(privatePos["static_debt"]);
-    storageValues['public_collateral'] = new Fr(publicPos["collateral"]);
-    storageValues['public_debt'] = new Fr(publicPos["static_debt"]);
+    storageValues['private_collateral'] = new Fr(privatePos['collateral']);
+    storageValues['private_debt'] = new Fr(privatePos['static_debt']);
+    storageValues['public_collateral'] = new Fr(publicPos['collateral']);
+    storageValues['public_debt'] = new Fr(publicPos['static_debt']);
 
     return storageValues;
   };

--- a/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
@@ -68,7 +68,7 @@ describe('e2e_multiple_accounts_1_enc_key', () => {
 
     // Then check the balance
     const contractWithWallet = await PrivateTokenContract.create(privateTokenAddress, wallet);
-    const [balance] = await contractWithWallet.methods.getBalance(owner).view({ from: owner });
+    const balance = await contractWithWallet.methods.getBalance(owner).view({ from: owner });
     logger(`Account ${owner} balance: ${balance}`);
     expect(balance).toBe(expectedBalance);
   };

--- a/yarn-project/end-to-end/src/e2e_non_contract_account.test.ts
+++ b/yarn-project/end-to-end/src/e2e_non_contract_account.test.ts
@@ -46,7 +46,7 @@ describe('e2e_non_contract_account', () => {
   });
 
   const expectBalance = async (owner: AztecAddress, expectedBalance: bigint) => {
-    const [balance] = await contract.methods.getBalance(owner).view({ from: owner });
+    const balance = await contract.methods.getBalance(owner).view({ from: owner });
     logger(`Account ${owner} balance: ${balance}`);
     expect(balance).toBe(expectedBalance);
   };

--- a/yarn-project/end-to-end/src/e2e_private_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_token_contract.test.ts
@@ -32,7 +32,7 @@ describe('e2e_private_token_contract', () => {
   });
 
   const expectBalance = async (owner: AztecAddress, expectedBalance: bigint) => {
-    const [balance] = await contract.methods.getBalance(owner).view({ from: owner });
+    const balance = await contract.methods.getBalance(owner).view({ from: owner });
     logger(`Account ${owner} balance: ${balance}`);
     expect(balance).toBe(expectedBalance);
   };

--- a/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
@@ -66,7 +66,7 @@ describe('e2e_public_token_contract', () => {
 
     expect(receipt.status).toBe(TxStatus.MINED);
 
-    const balance = (await contract.methods.publicBalanceOf(recipient.toField()).view({ from: recipient }))[0];
+    const balance = await contract.methods.publicBalanceOf(recipient.toField()).view({ from: recipient });
     expect(balance).toBe(mintAmount);
 
     await expectLogsFromLastBlockToBe(['Coins minted']);
@@ -91,7 +91,7 @@ describe('e2e_public_token_contract', () => {
     expect(receipts.map(r => r.status)).toEqual(times(3, () => TxStatus.MINED));
     expect(receipts.map(r => r.blockNumber)).toEqual(times(3, () => receipts[0].blockNumber));
 
-    const balance = (await contract.methods.publicBalanceOf(recipient.toField()).view({ from: recipient }))[0];
+    const balance = await contract.methods.publicBalanceOf(recipient.toField()).view({ from: recipient });
     expect(balance).toBe(mintAmount * 3n);
 
     await expectLogsFromLastBlockToBe(['Coins minted', 'Coins minted', 'Coins minted']);

--- a/yarn-project/end-to-end/src/fixtures/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/fixtures/cross_chain_test_harness.ts
@@ -193,8 +193,7 @@ export class CrossChainTestHarness {
   }
 
   async getL2BalanceOf(owner: AztecAddress) {
-    const [balance] = await this.l2Contract.methods.getBalance(owner).view({ from: owner });
-    return balance;
+    return await this.l2Contract.methods.getBalance(owner).view({ from: owner });
   }
 
   async expectBalanceOnL2(owner: AztecAddress, expectedBalance: bigint) {

--- a/yarn-project/end-to-end/src/fixtures/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/fixtures/cross_chain_test_harness.ts
@@ -203,7 +203,7 @@ export class CrossChainTestHarness {
   }
 
   async expectPublicBalanceOnL2(owner: AztecAddress, expectedBalance: bigint) {
-    const balance = (await this.l2Contract.methods.publicBalanceOf(owner.toField()).view({ from: owner }))[0];
+    const balance = await this.l2Contract.methods.publicBalanceOf(owner.toField()).view({ from: owner });
     expect(balance).toBe(expectedBalance);
   }
 

--- a/yarn-project/end-to-end/src/integration_archiver_l1_to_l2.test.ts
+++ b/yarn-project/end-to-end/src/integration_archiver_l1_to_l2.test.ts
@@ -71,7 +71,7 @@ describe('archiver integration with l1 to l2 messages', () => {
   }, 30_000);
 
   const expectBalance = async (owner: AztecAddress, expectedBalance: bigint) => {
-    const [balance] = await l2Contract.methods.getBalance(owner).view({ from: owner });
+    const balance = await l2Contract.methods.getBalance(owner).view({ from: owner });
     logger(`Account ${owner} balance: ${balance}`);
     expect(balance).toBe(expectedBalance);
   };

--- a/yarn-project/foundation/src/abi/decoder.ts
+++ b/yarn-project/foundation/src/abi/decoder.ts
@@ -4,7 +4,7 @@ import { Fr } from '@aztec/foundation/fields';
 /**
  * The type of our decoded ABI.
  */
-type DecodedReturn = bigint | boolean | DecodedReturn[] | { [key: string]: DecodedReturn };
+export type DecodedReturn = bigint | boolean | DecodedReturn[] | { [key: string]: DecodedReturn };
 
 /**
  * Decodes return values from a function call.
@@ -21,6 +21,11 @@ class ReturnValuesDecoder {
   private decodeReturn(abiType: ABIType): DecodedReturn {
     switch (abiType.kind) {
       case 'field':
+        return this.getNextField().value;
+      case 'integer':
+        if (abiType.sign === 'signed') {
+          throw new Error('Unsupported type: signed integer');
+        }
         return this.getNextField().value;
       case 'boolean':
         return !this.getNextField().isZero();
@@ -57,14 +62,18 @@ class ReturnValuesDecoder {
 
   /**
    * Decodes all the return values for the given function ABI.
+   * Noir support only single return value (value can be struct).
    * @returns The decoded return values.
    */
-  public decode() {
-    const returnValues = [];
-    for (let i = 0; i < this.abi.returnTypes.length; i += 1) {
-      returnValues.push(this.decodeReturn(this.abi.returnTypes[i]));
+  public decode(): DecodedReturn {
+    if (this.abi.returnTypes.length > 1) {
+      console.log(this.abi.returnTypes);
+      throw new Error('Multiple return values not supported');
     }
-    return returnValues;
+    if (this.abi.returnTypes.length === 0) {
+      return [];
+    }
+    return this.decodeReturn(this.abi.returnTypes[0]);
   }
 }
 

--- a/yarn-project/foundation/src/abi/decoder.ts
+++ b/yarn-project/foundation/src/abi/decoder.ts
@@ -62,7 +62,8 @@ class ReturnValuesDecoder {
 
   /**
    * Decodes all the return values for the given function ABI.
-   * Noir support only single return value (value can be struct).
+   * Noir support only single return value
+   * The return value can however be simple types, structs or arrays
    * @returns The decoded return values.
    */
   public decode(): DecodedReturn {

--- a/yarn-project/foundation/src/abi/decoder.ts
+++ b/yarn-project/foundation/src/abi/decoder.ts
@@ -67,7 +67,6 @@ class ReturnValuesDecoder {
    */
   public decode(): DecodedReturn {
     if (this.abi.returnTypes.length > 1) {
-      console.log(this.abi.returnTypes);
       throw new Error('Multiple return values not supported');
     }
     if (this.abi.returnTypes.length === 0) {

--- a/yarn-project/noir-contracts/src/contracts/lending_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/lending_contract/src/main.nr
@@ -1,5 +1,6 @@
 mod storage;
 
+// Single asset lending contract. Just for show.
 contract Lending {
     use dep::aztec::{
         abi,
@@ -17,6 +18,11 @@ contract Lending {
         call_public_function_no_args,
     };
     use crate::storage::{Storage, Tot, Account};
+
+    struct Pos {
+        collateral: Field,
+        static_debt: Field,
+    }
 
     // Constructs the contract.
     fn constructor(
@@ -309,19 +315,17 @@ contract Lending {
 
     unconstrained fn getTot(
         assetId: Field,
-    ) -> [Field; 2]{
+    ) -> Tot {
         let storage = Storage::init();
-        let asset = storage.assets.at(assetId);
-        let tot = asset.read();
-        [tot.interest_accumulator as Field, tot.last_updated_ts as Field]
+        storage.assets.at(assetId).read()
     }
 
     unconstrained fn getPosition(
         owner: Field,
-    ) -> [Field; 2] {
+    ) -> Pos {
         let storage = Storage::init();
         let collateral = storage.collateral.at(owner).read();
-        let debt = storage.static_debt.at(owner).read();
-        [collateral, debt] 
+        let static_debt = storage.static_debt.at(owner).read();
+        Pos {collateral, static_debt}
     }
 }


### PR DESCRIPTION
Return a single `DecodedReturn` instead of the `any[]` that we are currently returning when as the return values in execution results. As noir let you have one return value (that return value can be an array or struct etc) we should just return that directly instead of wrapping it inside an array for the return values. This makes it more straight-forward to use view functions as well as you can get structs directly that way (example from lending contract)



Fixes a naming from `interestAccumulator` -> `interest_accumulator` as well.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
