### PR TITLE
chore: make stdlib bn254 naming match native version

### DIFF
--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.cpp
@@ -84,10 +84,10 @@ void create_recursion_constraints(Builder& builder,
     }
 
     if (!inner_aggregation_indices_all_zero) {
-        std::array<bn254::fq_ct, 4> aggregation_elements;
+        std::array<bn254::BaseField, 4> aggregation_elements;
         for (size_t i = 0; i < 4; ++i) {
             aggregation_elements[i] =
-                bn254::fq_ct(field_ct::from_witness_index(&builder, aggregation_input[4 * i]),
+                bn254::BaseField(field_ct::from_witness_index(&builder, aggregation_input[4 * i]),
                              field_ct::from_witness_index(&builder, aggregation_input[4 * i + 1]),
                              field_ct::from_witness_index(&builder, aggregation_input[4 * i + 2]),
                              field_ct::from_witness_index(&builder, aggregation_input[4 * i + 3]));
@@ -95,8 +95,8 @@ void create_recursion_constraints(Builder& builder,
         }
         // If we have a previous aggregation object, assign it to `previous_aggregation` so that it is included
         // in stdlib::recursion::verify_proof
-        previous_aggregation.P0 = bn254::g1_ct(aggregation_elements[0], aggregation_elements[1]);
-        previous_aggregation.P1 = bn254::g1_ct(aggregation_elements[2], aggregation_elements[3]);
+        previous_aggregation.P0 = bn254::Group(aggregation_elements[0], aggregation_elements[1]);
+        previous_aggregation.P1 = bn254::Group(aggregation_elements[2], aggregation_elements[3]);
         previous_aggregation.has_data = true;
     } else {
         previous_aggregation.has_data = false;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/recursive_circuit.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/recursive_circuit.hpp
@@ -22,7 +22,7 @@ template <typename OuterComposer> class RecursiveCircuit {
     typedef stdlib::recursion::recursive_ultra_verifier_settings<outer_curve> recursive_settings;
     typedef stdlib::recursion::recursive_ultra_to_standard_verifier_settings<outer_curve>
         ultra_to_standard_recursive_settings;
-    typedef inner_curve::fr_ct fr_ct;
+    typedef inner_curve::ScalarField fr_ct;
     typedef inner_curve::public_witness_ct public_witness_ct;
     typedef inner_curve::witness_ct witness_ct;
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.test.cpp
@@ -18,7 +18,7 @@ template <typename Composer> class stdlib_pedersen : public testing::Test {
     typedef stdlib::bn254<Composer> curve;
 
     typedef typename curve::byte_array_ct byte_array_ct;
-    typedef typename curve::fr_ct fr_ct;
+    typedef typename curve::ScalarField fr_ct;
     typedef typename curve::witness_ct witness_ct;
     typedef typename curve::public_witness_ct public_witness_ct;
     typedef typename stdlib::pedersen_commitment<Composer> pedersen_commitment;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -26,7 +26,7 @@ using namespace proof_system::plonk;
    stdlib_bigfield_plookup tests were present when this file was standardized
    to be more proving system-agnostic. Those tests are commented out  below, but modified
    in the following ways:
-     - pbigfield_t was replaced by bn254::fq_ct;
+     - pbigfield_t was replaced by bn254::BaseField;
      - pwitness_t  was replaced by bn254::witness_ct.
 */
 
@@ -38,8 +38,8 @@ template <typename Composer> class stdlib_bigfield : public testing::Test {
 
     typedef stdlib::bn254<Composer> bn254;
 
-    typedef typename bn254::fr_ct fr_ct;
-    typedef typename bn254::fq_ct fq_ct;
+    typedef typename bn254::ScalarField fr_ct;
+    typedef typename bn254::BaseField fq_ct;
     typedef typename bn254::public_witness_ct public_witness_ct;
     typedef typename bn254::witness_ct witness_ct;
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -28,9 +28,9 @@ template <typename _Curve, bool _use_bigfield = false> struct TestType {
     using Curve = _Curve;
     static const bool use_bigfield = _use_bigfield;
     using element_ct =
-        typename std::conditional<_use_bigfield, typename Curve::g1_bigfr_ct, typename Curve::g1_ct>::type;
+        typename std::conditional<_use_bigfield, typename Curve::g1_bigfr_ct, typename Curve::Group>::type;
     // the field of scalars acting on element_ct
-    using scalar_ct = typename std::conditional<_use_bigfield, typename Curve::bigfr_ct, typename Curve::fr_ct>::type;
+    using scalar_ct = typename std::conditional<_use_bigfield, typename Curve::bigfr_ct, typename Curve::ScalarField>::type;
 };
 
 template <typename TestType> class stdlib_biggroup : public testing::Test {
@@ -38,9 +38,9 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
     using element_ct = typename TestType::element_ct;
     using scalar_ct = typename TestType::scalar_ct;
 
-    using fq = typename Curve::fq;
-    using fr = typename Curve::fr;
-    using g1 = typename Curve::g1;
+    using fq = typename Curve::BaseFieldNative;
+    using fr = typename Curve::ScalarFieldNative;
+    using g1 = typename Curve::GroupNative;
     using affine_element = typename g1::affine_element;
     using element = typename g1::element;
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/curves/bn254.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/curves/bn254.hpp
@@ -10,27 +10,31 @@ namespace stdlib {
 template <typename CircuitBuilder> struct bn254 {
     static constexpr proof_system::CurveType type = proof_system::CurveType::BN254;
 
-    // NOTE: Naming in flux here; maybe name should reflect "native" somehow?
-    using BaseField = curve::BN254::BaseField;
-    using fq = BaseField;
-    using ScalarField = curve::BN254::ScalarField;
-    using fr = ScalarField;
-    using Group = curve::BN254::Group;
-    using g1 = Group;
+    // Corresponding native types (used exclusively for testing)
+    using ScalarFieldNative = curve::BN254::ScalarField;
+    using BaseFieldNative = curve::BN254::BaseField;
+    using GroupNative = curve::BN254::Group;
 
+    // Stdlib types corresponding to those defined in the native description of the curve.
+    // Note: its useful to have these type names match the native analog exactly so that components that digest a Curve
+    // (e.g. Gemini) can be agnostic as to whether they're operating on native or stdlib types.
+    using ScalarField = field_t<CircuitBuilder>;
+    using BaseField = bigfield<CircuitBuilder, barretenberg::Bn254FqParams>;
+    using Group = element<CircuitBuilder, BaseField, ScalarField, GroupNative>;
+    using Element = Group;
+    using AffineElement = Group;
+
+    // Additional types with no analog in the native description of the curve
     using Builder = CircuitBuilder;
     using Composer = CircuitBuilder;
-    typedef witness_t<CircuitBuilder> witness_ct;
-    typedef public_witness_t<CircuitBuilder> public_witness_ct;
-    typedef field_t<CircuitBuilder> fr_ct;
-    typedef byte_array<CircuitBuilder> byte_array_ct;
-    typedef bool_t<CircuitBuilder> bool_ct;
-    typedef stdlib::uint32<CircuitBuilder> uint32_ct;
+    using witness_ct = witness_t<CircuitBuilder>;
+    using public_witness_ct = public_witness_t<CircuitBuilder>;
+    using byte_array_ct = byte_array<CircuitBuilder>;
+    using bool_ct = bool_t<CircuitBuilder>;
+    using uint32_ct = stdlib::uint32<CircuitBuilder>;
 
-    typedef bigfield<CircuitBuilder, barretenberg::Bn254FqParams> fq_ct;
-    typedef bigfield<CircuitBuilder, barretenberg::Bn254FrParams> bigfr_ct;
-    typedef element<CircuitBuilder, fq_ct, fr_ct, Group> g1_ct;
-    typedef element<CircuitBuilder, fq_ct, bigfr_ct, Group> g1_bigfr_ct;
+    using bigfr_ct = bigfield<CircuitBuilder, barretenberg::Bn254FrParams>;
+    using g1_bigfr_ct = element<CircuitBuilder, BaseField, bigfr_ct, GroupNative>;
 
 }; // namespace bn254
 } // namespace stdlib

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/aggregation_state/aggregation_state.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/aggregation_state/aggregation_state.hpp
@@ -13,11 +13,11 @@ namespace recursion {
  *   has_data: indicates if this aggregation state contain past (P0, P1)
  */
 template <typename Curve> struct aggregation_state {
-    typename Curve::g1_ct P0;
-    typename Curve::g1_ct P1;
+    typename Curve::Group P0;
+    typename Curve::Group P1;
 
     // The public inputs of the inner ciruit are now private inputs of the outer circuit!
-    std::vector<typename Curve::fr_ct> public_inputs;
+    std::vector<typename Curve::ScalarField> public_inputs;
     std::vector<uint32_t> proof_witness_indices;
     bool has_data = false;
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/program_settings.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/program_settings.hpp
@@ -10,8 +10,8 @@ namespace recursion {
 
 template <typename Curve> class recursive_ultra_verifier_settings : public plonk::ultra_verifier_settings {
   public:
-    typedef typename Curve::fr_ct fr_ct;
-    typedef typename Curve::g1::affine_element g1;
+    typedef typename Curve::ScalarField fr_ct;
+    typedef typename Curve::GroupNative::affine_element g1;
     typedef typename Curve::Composer Composer;
     typedef proof_system::plonk::stdlib::recursion::Transcript<Composer> Transcript_pt;
     typedef proof_system::plonk::VerifierPermutationWidget<fr_ct, g1, Transcript_pt> PermutationWidget;
@@ -88,8 +88,8 @@ template <typename Curve> class recursive_ultra_verifier_settings : public plonk
 template <typename Curve>
 class recursive_ultra_to_standard_verifier_settings : public recursive_ultra_verifier_settings<Curve> {
   public:
-    typedef typename Curve::fr_ct fr_ct;
-    typedef typename Curve::g1::affine_element g1;
+    typedef typename Curve::ScalarField fr_ct;
+    typedef typename Curve::GroupNative::affine_element g1;
     typedef typename Curve::Composer Composer;
     typedef proof_system::plonk::stdlib::recursion::Transcript<Composer> Transcript_pt;
     typedef proof_system::plonk::VerifierPermutationWidget<fr_ct, g1, Transcript_pt> PermutationWidget;
@@ -110,8 +110,8 @@ class recursive_ultra_to_standard_verifier_settings : public recursive_ultra_ver
 
 template <typename Curve> class recursive_turbo_verifier_settings : public plonk::turbo_settings {
   public:
-    typedef typename Curve::fr_ct fr_ct;
-    typedef typename Curve::g1::affine_element g1;
+    typedef typename Curve::ScalarField fr_ct;
+    typedef typename Curve::GroupNative::affine_element g1;
     typedef typename Curve::Composer Composer;
     typedef Transcript<Composer> Transcript_pt;
     typedef proof_system::plonk::VerifierPermutationWidget<fr_ct, g1, Transcript_pt> PermutationWidget;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/verifier.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/verifier.hpp
@@ -28,13 +28,13 @@ template <typename Curve, typename Transcript, typename program_settings>
 void populate_kate_element_map(typename Curve::Builder* ctx,
                                typename Transcript::Key* key,
                                const Transcript& transcript,
-                               std::map<std::string, typename Curve::g1_ct>& kate_g1_elements,
-                               std::map<std::string, typename Curve::fr_ct>& kate_fr_elements_at_zeta,
-                               std::map<std::string, typename Curve::fr_ct>& kate_fr_elements_at_zeta_large,
-                               std::map<std::string, typename Curve::fr_ct>& kate_fr_elements_at_zeta_omega,
-                               typename Curve::fr_ct& batch_opening_scalar)
+                               std::map<std::string, typename Curve::Group>& kate_g1_elements,
+                               std::map<std::string, typename Curve::ScalarField>& kate_fr_elements_at_zeta,
+                               std::map<std::string, typename Curve::ScalarField>& kate_fr_elements_at_zeta_large,
+                               std::map<std::string, typename Curve::ScalarField>& kate_fr_elements_at_zeta_omega,
+                               typename Curve::ScalarField& batch_opening_scalar)
 {
-    using fr_ct = typename Curve::fr_ct;
+    using fr_ct = typename Curve::ScalarField;
     const auto& polynomial_manifest = key->polynomial_manifest;
     for (size_t i = 0; i < key->polynomial_manifest.size(); ++i) {
         const auto& item = polynomial_manifest[i];
@@ -111,7 +111,7 @@ void populate_kate_element_map(typename Curve::Builder* ctx,
 
 template <typename Curve>
 lagrange_evaluations<typename Curve::Builder> get_lagrange_evaluations(
-    const typename Curve::fr_ct& z,
+    const typename Curve::ScalarField& z,
     const evaluation_domain<typename Curve::Builder>& domain,
     const size_t num_roots_cut_out_of_vanishing_polynomial = 4)
 {
@@ -124,7 +124,7 @@ lagrange_evaluations<typename Curve::Builder> get_lagrange_evaluations(
     // NOTE: If in future, there arises a need to cut off more zeros, this method will not require any changes.
     //
 
-    typedef typename Curve::fr_ct fr_ct;
+    typedef typename Curve::ScalarField fr_ct;
     typedef typename Curve::Builder Builder;
 
     fr_ct z_pow = z.pow(field_t<Builder>(domain.size));
@@ -199,9 +199,9 @@ aggregation_state<Curve> verify_proof_(typename Curve::Builder* context,
                                        Transcript<typename Curve::Builder>& transcript,
                                        const aggregation_state<Curve> previous_output = aggregation_state<Curve>())
 {
-    using fr_ct = typename Curve::fr_ct;
-    using fq_ct = typename Curve::fq_ct;
-    using g1_ct = typename Curve::g1_ct;
+    using fr_ct = typename Curve::ScalarField;
+    using fq_ct = typename Curve::BaseField;
+    using g1_ct = typename Curve::Group;
     using Builder = typename Curve::Builder;
 
     key->program_width = program_settings::program_width;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/verifier.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/verifier.test.cpp
@@ -29,14 +29,14 @@ template <typename OuterComposer> class stdlib_verifier : public testing::Test {
     using recursive_settings = recursion::recursive_ultra_verifier_settings<outer_curve>;
     using ultra_to_standard_recursive_settings = recursion::recursive_ultra_to_standard_verifier_settings<outer_curve>;
 
-    using inner_scalar_field_ct = inner_curve::fr_ct;
-    using inner_ground_field_ct = inner_curve::fq_ct;
+    using inner_scalar_field_ct = inner_curve::ScalarField;
+    using inner_ground_field_ct = inner_curve::BaseField;
     using public_witness_ct = inner_curve::public_witness_ct;
     using witness_ct = inner_curve::witness_ct;
     using byte_array_ct = inner_curve::byte_array_ct;
 
-    using inner_scalar_field = typename inner_curve::ScalarField;
-    using outer_scalar_field = typename outer_curve::BaseField;
+    using inner_scalar_field = typename inner_curve::ScalarFieldNative;
+    using outer_scalar_field = typename outer_curve::BaseFieldNative;
     using pairing_target_field = barretenberg::fq12;
 
     // These constexpr definitions are to allow for the following: An Ultra Pedersen hash evaluates to a

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/verifier_turbo.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/verifier_turbo.test.cpp
@@ -27,14 +27,14 @@ template <typename OuterComposer> class stdlib_verifier_turbo : public testing::
     using verification_key_pt = recursion::verification_key<outer_curve>;
     using recursive_settings = recursion::recursive_turbo_verifier_settings<outer_curve>;
 
-    using inner_scalar_field_ct = inner_curve::fr_ct;
-    using inner_ground_field_ct = inner_curve::fq_ct;
+    using inner_scalar_field_ct = inner_curve::ScalarField;
+    using inner_ground_field_ct = inner_curve::BaseField;
     using public_witness_ct = inner_curve::public_witness_ct;
     using witness_ct = inner_curve::witness_ct;
     using byte_array_ct = inner_curve::byte_array_ct;
 
-    using inner_scalar_field = typename inner_curve::ScalarField;
-    using outer_scalar_field = typename outer_curve::BaseField;
+    using inner_scalar_field = typename inner_curve::ScalarFieldNative;
+    using outer_scalar_field = typename outer_curve::BaseFieldNative;
     using pairing_target_field = barretenberg::fq12;
 
     using ProverOfInnerCircuit = plonk::TurboProver;


### PR DESCRIPTION
We have a native and stdlib version of the struct `bn254`, which describes the key curve parameters, e.g. `ScalarField`, `Group`, etc. (Eventually Grumpkin will have the same). There are other objects (e.g. Gemini, Shplonk) templated on `Curve` which should be agnostic to whether the types they're operating on are native or stdlib types. To facilitate this, I've updated the naming in `stdlib::bn254` to match the corresponding native description in `curve::BN254`. Contexts for which the explicit "composer type" suffix `ct` is desired can employ appropriate aliases.