### PR TITLE
chore: update noir readme alter noir bootstrap to always install tagged version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ To build the C++ code, follow the [instructions in the circuits subdirectory](./
 
 To build Typescript code, make sure to have [`nvm`](https://github.com/nvm-sh/nvm) (node version manager) installed.
 
+To build noir code, make sure that you are using the `aztec` tagged version of nargo. This is the latest pin version the team works on to ensure local and ci environments are in sync. This should be installed through `noir-contracts/bootstrap.sh` and the regular `bootstrap.sh` script. However if you find yourself wanting to update to the latest `aztec` tag outside of these channels, you can run `noirup -v aztec` to manually download the latest binaries.
+
 ## Continuous Integration
 
 This repository uses CircleCI for continuous integration. Build steps are managed using [`build-system`](https://github.com/AztecProtocol/build-system). Small packages are built and tested as part of a docker build operation, while larger ones and end-to-end tests spin up a large AWS spot instance. Each successful build step creates a new docker image that gets tagged with the package name and commit.

--- a/yarn-project/noir-contracts/Dockerfile.build
+++ b/yarn-project/noir-contracts/Dockerfile.build
@@ -14,7 +14,9 @@ COPY . .
 WORKDIR /usr/src/yarn-project/noir-contracts 
 
 # Download and extract nargo
-RUN ./scripts/install_noir.sh
+ENV NARGO_HOME="/usr/src/yarn-project/noir-contracts/.nargo"
+RUN ./scripts/install_noirup.sh $(pwd)
 ENV PATH="/usr/src/yarn-project/noir-contracts/.nargo/bin:${PATH}"
 
+RUN ./scripts/install_noir.sh
 RUN ./scripts/compile_ci.sh

--- a/yarn-project/noir-contracts/README.md
+++ b/yarn-project/noir-contracts/README.md
@@ -10,6 +10,28 @@ Please note that any example contract set out herein is provided solely for info
 
 ### Installing Noir
 
+An essential tool for managing noir versions is noirup.
+
+- Install [noirup](https://github.com/noir-lang/noirup)
+  ```
+  curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
+  ```
+
+### Happy Path
+Currently we all work from a single `aztec` tagged noir release. This release updates independently from noir's regular cadence to allow us to rapidly prototype new features. 
+It has prebuilt binaries and is super easy to install using `noirup`
+
+- Install [noirup](https://github.com/noir-lang/noirup)
+  ```
+  curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
+  ```
+- Install `aztec` tagged nargo
+  ```
+  noirup -v aztec
+  ```
+
+### Building from source (If working with custom features)
+
 - Install [noirup](https://github.com/noir-lang/noirup)
   ```
   curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
@@ -42,11 +64,11 @@ Please note that any example contract set out herein is provided solely for info
   git clone https://github.com/noir-lang/noir.git
   ```
 
-- Checkout aztec3 branch
+- Checkout your target noir branch
 
   ```
   cd noir
-  git checkout aztec3
+  git checkout <branch>
   ```
 
 - Enable direnv

--- a/yarn-project/noir-contracts/bootstrap.sh
+++ b/yarn-project/noir-contracts/bootstrap.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
 # Install noir if it is not installed already
-if ! command -v nargo &> /dev/null
+if ! command -v noirup &> /dev/null
 then
     echo "Installing noir"
-    ./scripts/install_noir.sh
+    source ./scripts/install_noirup.sh
 fi
 
+# Update noir
+./scripts/install_noir.sh
 
 # Use yarn script to compile and create types
 yarn 

--- a/yarn-project/noir-contracts/scripts/install_noir.sh
+++ b/yarn-project/noir-contracts/scripts/install_noir.sh
@@ -1,25 +1,8 @@
 #!/bin/bash
-# Script to install noirup and the latest nargo
+# Script to install noirup and the latest aztec nargo
 set -eu
 
 VERSION="aztec"
-
-export NARGO_HOME="$(pwd)/.nargo"
-NARGO_BIN_DIR="$NARGO_HOME/bin"
-BIN_URL="https://raw.githubusercontent.com/noir-lang/noirup/master/noirup"
-BIN_PATH="$NARGO_BIN_DIR/noirup"
-NARGO_MAN_DIR="$NARGO_HOME/share/man/man1"
-
-# Clean
-rm -rf $NARGO_HOME
-
-# Install noirup.
-mkdir -p $NARGO_BIN_DIR
-mkdir -p $NARGO_MAN_DIR
-
-curl -# -L $BIN_URL -o $BIN_PATH
-chmod +x $BIN_PATH
-export PATH=$NARGO_BIN_DIR:$PATH
 
 # Install nargo
 noirup -v $VERSION

--- a/yarn-project/noir-contracts/scripts/install_noirup.sh
+++ b/yarn-project/noir-contracts/scripts/install_noirup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Script to install noirup and the latest nargo
+set -eu
+
+SPECIFIED_HOME=${1:-$HOME}
+VERSION="aztec"
+
+export NARGO_HOME="$SPECIFIED_HOME/.nargo"
+NARGO_BIN_DIR="$NARGO_HOME/bin"
+BIN_URL="https://raw.githubusercontent.com/noir-lang/noirup/master/noirup"
+BIN_PATH="$NARGO_BIN_DIR/noirup"
+NARGO_MAN_DIR="$NARGO_HOME/share/man/man1"
+
+# Clean
+rm -rf $NARGO_HOME
+
+# Install noirup.
+mkdir -p $NARGO_BIN_DIR
+mkdir -p $NARGO_MAN_DIR
+
+curl -# -Ls $BIN_URL -o $BIN_PATH
+chmod +x $BIN_PATH
+export PATH=$NARGO_BIN_DIR:$PATH


### PR DESCRIPTION
Update noir installation instructions, 

Update the noir installation scripts to always install the tagged release on bootstrap