### PR TITLE
1242 - e2e test related to the filtering of get_notes

### DIFF
--- a/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit.test.cpp
@@ -23,6 +23,11 @@ using aztec3::utils::array_length;
 using aztec3::utils::CircuitErrorCode;
 
 
+// TODO(https://github.com/AztecProtocol/aztec-packages/issues/892): test expected kernel failures if transient reads
+// (or their hints) don't match
+// TODO(https://github.com/AztecProtocol/aztec-packages/issues/836): test expected kernel failures if nullifiers (or
+// their hints) don't match
+
 /**************************************************************
  * MULTI ITERATION UNIT TESTS FOR NATIVE PRIVATE KERNEL CIRCUIT
  **************************************************************/

--- a/yarn-project/noir-contracts/src/contracts/pending_commitments_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/pending_commitments_contract/src/main.nr
@@ -118,6 +118,20 @@ contract PendingCommitments {
         context.finish()
     }
 
+    // Dumy nested/inner function (to pass a function which does nothing)
+    fn dummy(
+        //*********************************/
+        // Should eventually be hidden:
+        inputs: PrivateContextInputs,
+        //*********************************/
+        amount: Field,
+        owner: Field,
+    ) -> distinct pub abi::PrivateCircuitPublicInputs {
+        let storage = Storage::init();
+        let mut context = Context::new(inputs, abi::hash_args([amount, owner]));
+        context.finish()
+    }
+
     // Nested/inner function to create and insert a note
     fn insert_note(
         //*********************************/


### PR DESCRIPTION
Solves #1242

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [x] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [x] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
