### PR TITLE
docs: Quick start guide for up page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -115,4 +115,6 @@ You can embed code snippets into a `.md`/`.mdx` file from code which lives elsew
     - `#include_code hello path/from/repo/root/to/file.ts typescript`
   - And somewhere else, you can write:
     - `#include_code goodbye path/from/repo/root/to/file.ts typescript`
+- You can add as a last optional parameter a comma-separated list of options to tweak the display of the code block, for example:
+  - `#include_code hello path/from/repo/root/to/file.ts typescript noTitle,noLineNumbers,noSourceLink`
 - Ironically, we can't show you a rendering of these examples, because this README.md file doesn't support the `#include_code` macro!

--- a/docs/docs/external/up-quick-start.md
+++ b/docs/docs/external/up-quick-start.md
@@ -23,3 +23,5 @@ We can check Alice's private token balance by querying the contract:
 And use Alice's private key to [send a transaction](../concepts/foundation/transactions.md) to transfer tokens to Bob, and check the result:
 
 #include_code transfer yarn-project/end-to-end/src/guides/up_quick_start.sh bash noTitle,noLineNumbers,noSourceLink
+
+To learn more, check out an extended version of this quick start [on our docs](../dev_docs/getting_started/cli.md).

--- a/docs/docs/external/up-quick-start.md
+++ b/docs/docs/external/up-quick-start.md
@@ -1,6 +1,8 @@
 # Quick start
 
-:::info This guide is meant to be included in the up.aztec.network site and not in the main documentation.
+:::info 
+This guide is meant to be included in the up.aztec.network site and not in the main documentation.
+:::
 
 To interact with the sandbox, install the aztec CLI:
 
@@ -8,16 +10,16 @@ To interact with the sandbox, install the aztec CLI:
 
 The sandbox is preloaded with two accounts, let's assign them as Alice and Bob:
 
-#include_code declare-accounts yarn-project/end-to-end/src/guides/up_quick_start.sh bash
+#include_code declare-accounts yarn-project/end-to-end/src/guides/up_quick_start.sh bash noTitle,noLineNumbers,noSourceLink
 
 Start by deploying a private token contract, minting an initial supply to Alice:
 
-#include_code deploy yarn-project/end-to-end/src/guides/up_quick_start.sh bash
+#include_code deploy yarn-project/end-to-end/src/guides/up_quick_start.sh bash noTitle,noLineNumbers,noSourceLink
 
 We can check Alice's balance by querying the contract:
 
-#include_code get-balance yarn-project/end-to-end/src/guides/up_quick_start.sh bash
+#include_code get-balance yarn-project/end-to-end/src/guides/up_quick_start.sh bash noTitle,noLineNumbers,noSourceLink
 
 And use Alice's private key to send a transaction to transfer tokens to Bob, and check the result:
 
-#include_code transfer yarn-project/end-to-end/src/guides/up_quick_start.sh bash
+#include_code transfer yarn-project/end-to-end/src/guides/up_quick_start.sh bash noTitle,noLineNumbers,noSourceLink

--- a/docs/docs/external/up-quick-start.md
+++ b/docs/docs/external/up-quick-start.md
@@ -1,0 +1,23 @@
+# Quick start
+
+:::info This guide is meant to be included in the up.aztec.network site and not in the main documentation.
+
+To interact with the sandbox, install the aztec CLI:
+
+`npm install -g @aztec/cli`
+
+The sandbox is preloaded with two accounts, let's assign them as Alice and Bob:
+
+#include_code declare-accounts yarn-project/end-to-end/src/guides/up_quick_start.sh bash
+
+Start by deploying a private token contract, minting an initial supply to Alice:
+
+#include_code deploy yarn-project/end-to-end/src/guides/up_quick_start.sh bash
+
+We can check Alice's balance by querying the contract:
+
+#include_code get-balance yarn-project/end-to-end/src/guides/up_quick_start.sh bash
+
+And use Alice's private key to send a transaction to transfer tokens to Bob, and check the result:
+
+#include_code transfer yarn-project/end-to-end/src/guides/up_quick_start.sh bash

--- a/docs/docs/external/up-quick-start.md
+++ b/docs/docs/external/up-quick-start.md
@@ -12,11 +12,11 @@ The sandbox is preloaded with two accounts, let's assign them as Alice and Bob:
 
 #include_code declare-accounts yarn-project/end-to-end/src/guides/up_quick_start.sh bash noTitle,noLineNumbers,noSourceLink
 
-Start by deploying a private token contract, minting an initial supply to Alice:
+Start by deploying a private token contract, minting an initial supply of private tokens to Alice:
 
 #include_code deploy yarn-project/end-to-end/src/guides/up_quick_start.sh bash noTitle,noLineNumbers,noSourceLink
 
-We can check Alice's balance by querying the contract:
+We can check Alice's private token balance by querying the contract:
 
 #include_code get-balance yarn-project/end-to-end/src/guides/up_quick_start.sh bash noTitle,noLineNumbers,noSourceLink
 

--- a/docs/docs/external/up-quick-start.md
+++ b/docs/docs/external/up-quick-start.md
@@ -4,15 +4,15 @@
 This guide is meant to be included in the up.aztec.network site and not in the main documentation.
 :::
 
-To interact with the sandbox, install the aztec CLI:
+To interact with the sandbox, install the [Aztec CLI](../dev_docs/cli/main.md):
 
 `npm install -g @aztec/cli`
 
-The sandbox is preloaded with two accounts, let's assign them as Alice and Bob:
+The sandbox is preloaded with two [accounts](../concepts/foundation/accounts/main.md), let's assign them as Alice and Bob:
 
 #include_code declare-accounts yarn-project/end-to-end/src/guides/up_quick_start.sh bash noTitle,noLineNumbers,noSourceLink
 
-Start by deploying a private token contract, minting an initial supply of private tokens to Alice:
+Start by deploying a private token [contract](../concepts/foundation/contracts.md), minting an initial supply of private tokens to Alice:
 
 #include_code deploy yarn-project/end-to-end/src/guides/up_quick_start.sh bash noTitle,noLineNumbers,noSourceLink
 
@@ -20,6 +20,6 @@ We can check Alice's private token balance by querying the contract:
 
 #include_code get-balance yarn-project/end-to-end/src/guides/up_quick_start.sh bash noTitle,noLineNumbers,noSourceLink
 
-And use Alice's private key to send a transaction to transfer tokens to Bob, and check the result:
+And use Alice's private key to [send a transaction](../concepts/foundation/transactions.md) to transfer tokens to Bob, and check the result:
 
 #include_code transfer yarn-project/end-to-end/src/guides/up_quick_start.sh bash noTitle,noLineNumbers,noSourceLink

--- a/docs/docs/external/up-quick-start.md
+++ b/docs/docs/external/up-quick-start.md
@@ -20,7 +20,7 @@ We can check Alice's private token balance by querying the contract:
 
 #include_code get-balance yarn-project/end-to-end/src/guides/up_quick_start.sh bash noTitle,noLineNumbers,noSourceLink
 
-And use Alice's private key to [send a transaction](../concepts/foundation/transactions.md) to transfer tokens to Bob, and check the result:
+We can have Alice privately transfer tokens to Bob. Only Alice and Bob will know what's happened. Here, we use Alice's private key to [send a transaction](../concepts/foundation/transactions.md) to transfer tokens to Bob, and check the result:
 
 #include_code transfer yarn-project/end-to-end/src/guides/up_quick_start.sh bash noTitle,noLineNumbers,noSourceLink
 

--- a/docs/src/preprocess/index.js
+++ b/docs/src/preprocess/index.js
@@ -209,6 +209,11 @@ async function processMarkdownFilesInDir(rootDir, docsDir, regex) {
         const identifier = match[1];
         const codeFilePath = match[2]; // Absolute path to the code file from the root of the Docusaurus project
         const language = match[3];
+        const opts = match[4] || "";
+
+        const noTitle = opts.includes("noTitle");
+        const noLineNumbers = opts.includes("noLineNumbers");
+        const noSourceLink = opts.includes("noSourceLink");
 
         try {
           const absoluteCodeFilePath = path.join(rootDir, codeFilePath);
@@ -224,7 +229,12 @@ async function processMarkdownFilesInDir(rootDir, docsDir, regex) {
             codeFilePath
           )}#L${startLine}-L${endLine}`;
 
-          const replacement = `\`\`\`${language} title="${identifier}" showLineNumbers \n${codeSnippet}\n\`\`\`\n> [<sup><sub>Source code: ${url}</sub></sup>](${url})\n`;
+          const title = noTitle ? "" : `title="${identifier}"`;
+          const lineNumbers = noLineNumbers ? "" : "showLineNumbers";
+          const source = noSourceLink
+            ? ""
+            : `\n> [<sup><sub>Source code: ${url}</sub></sup>](${url})`;
+          const replacement = `\`\`\`${language} ${title} ${lineNumbers} \n${codeSnippet}\n\`\`\`${source}\n`;
 
           // Replace the include tag with the code snippet
           updatedContent = updatedContent.replace(fullMatch, replacement);
@@ -365,7 +375,8 @@ async function run() {
    * `/gm`
    *   - match globally (g) across the entire input text and consider multiple lines (m) when matching. This is necessary to handle multiple include tags throughout the markdown content.
    */
-  const regex = /^(?!<!--.*)(?=.*#include_code\s+(\S+)\s+(\S+)\s+(\S+)).*$/gm;
+  const regex =
+    /^(?!<!--.*)(?=.*#include_code\s+(\S+)\s+(\S+)\s+(\S+)(?:[ ]+(\S+))?).*$/gm;
 
   const content = await processMarkdownFilesInDir(rootDir, docsDir, regex);
 

--- a/yarn-project/end-to-end/src/guides/up_quick_start.sh
+++ b/yarn-project/end-to-end/src/guides/up_quick_start.sh
@@ -1,0 +1,52 @@
+# Run locally from end-to-end folder while running anvil and sandbox with:
+# PATH=$PATH:../node_modules/.bin ./src/guides/up_quick_start.sh
+
+set -eux
+
+# docs:start:declare-accounts
+ALICE="0x2e13f0201905944184fc2c09d29fcf0cac07647be171656a275f63d99b819360"
+BOB="0x0d557417a3ce7d7b356a8f15d79a868fd8da2af9c5f4981feb9bcf0b614bd17e"
+# docs:end:declare-accounts
+
+# docs:start:deploy
+aztec-cli deploy \
+  --contract-abi PrivateTokenContractAbi \
+  --args 1000000 $ALICE \
+  --salt 0
+# docs:end:deploy
+
+aztec-cli check-deploy --contract-address 0x03b030d48607ba8a0562f0f1f82be26c3f091e45e10f74c2d8cebb80d526a69f
+
+# docs:start:get-balance
+aztec-cli call getBalance \
+  --args $ALICE \
+  --contract-abi PrivateTokenContractAbi \
+  --contract-address 0x03b030d48607ba8a0562f0f1f82be26c3f091e45e10f74c2d8cebb80d526a69f
+# docs:end:get-balance
+
+# docs:start:transfer
+aztec-cli send transfer \
+  --args 500 $ALICE $BOB \
+  --contract-abi PrivateTokenContractAbi \
+  --contract-address 0x03b030d48607ba8a0562f0f1f82be26c3f091e45e10f74c2d8cebb80d526a69f \
+  --private-key 0xb2803ec899f76f6b2ac011480d24028f1a29587f8a3a92f7ee9d48d8c085c284
+
+aztec-cli call getBalance \
+  --args $ALICE \
+  --contract-abi PrivateTokenContractAbi \
+  --contract-address 0x03b030d48607ba8a0562f0f1f82be26c3f091e45e10f74c2d8cebb80d526a69f
+
+aztec-cli call getBalance \
+  --args $BOB \
+  --contract-abi PrivateTokenContractAbi \
+  --contract-address 0x03b030d48607ba8a0562f0f1f82be26c3f091e45e10f74c2d8cebb80d526a69f
+# docs:end:transfer
+
+aztec-cli get-logs
+
+# Test end result
+BOB_BALANCE=$(aztec-cli call getBalance --args $BOB --contract-abi PrivateTokenContractAbi --contract-address 0x03b030d48607ba8a0562f0f1f82be26c3f091e45e10f74c2d8cebb80d526a69f)
+if ! echo $BOB_BALANCE | grep -q 500; then 
+  echo "Incorrect Bob balance after transaction (expected 500 but got $BOB_BALANCE)"
+  exit 1
+fi


### PR DESCRIPTION
Adds a quick start guide for the up page, to be embedded there instead of listed in docs.

Related to #1406 