### PR TITLE
move cheatcodes to aztec.js

### DIFF
--- a/yarn-project/aztec.js/src/utils/cheat_codes.ts
+++ b/yarn-project/aztec.js/src/utils/cheat_codes.ts
@@ -86,7 +86,7 @@ export class L1CheatCodes {
   }
 
   /**
-   * Get the current chainId
+   * Advance the chain by a number of blocks
    * @param numberOfBlocks - The number of blocks to mine
    * @returns The current chainId
    */
@@ -155,7 +155,6 @@ export class L1CheatCodes {
 
   /**
    * Computes the slot value for a given map and key.
-   * Both the baseSlot and key will be padded to 32 bytes in the function.
    * @param baseSlot - The base slot of the map (specified in noir contract)
    * @param key - The key to lookup in the map
    * @returns The storage slot of the value in the map

--- a/yarn-project/aztec.js/src/utils/index.ts
+++ b/yarn-project/aztec.js/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './pub_key.js';
 export * from './l1_contracts.js';
 export * from './l2_contracts.js';
 export * from './abi_types.js';
+export * from './cheat_codes.js';

--- a/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
@@ -1,5 +1,5 @@
 import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecAddress, AztecRPCServer, EthAddress, Fr } from '@aztec/aztec-rpc';
+import { AztecAddress, AztecRPCServer, EthAddress } from '@aztec/aztec-rpc';
 import { CheatCodes, Wallet } from '@aztec/aztec.js';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { LendingContract } from '@aztec/noir-contracts/types';
@@ -156,7 +156,7 @@ describe('e2e_cheat_codes', () => {
       await txInit.isMined({ interval: 0.1 });
 
       // fetch last updated ts from L2 contract and expect it to me same as new timestamp
-      const lastUpdatedTs = Number(new Fr((await contract.methods.getTot(0).view())['last_updated_ts']));
+      const lastUpdatedTs = Number((await contract.methods.getTot(0).view())['last_updated_ts']);
       expect(lastUpdatedTs).toEqual(newTimestamp);
       // ensure anvil is correctly updated
       expect(await cc.l1.timestamp()).toEqual(newTimestamp);

--- a/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
@@ -1,13 +1,12 @@
 import { AztecNodeService } from '@aztec/aztec-node';
 import { AztecAddress, AztecRPCServer, EthAddress, Fr } from '@aztec/aztec-rpc';
-import { Wallet } from '@aztec/aztec.js';
+import { CheatCodes, Wallet } from '@aztec/aztec.js';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { LendingContract } from '@aztec/noir-contracts/types';
 import { AztecRPC } from '@aztec/types';
 
 import { Account, Chain, HttpTransport, PublicClient, WalletClient, getAddress, getContract, parseEther } from 'viem';
 
-import { CheatCodes } from './fixtures/cheat_codes.js';
 import { setup } from './fixtures/utils.js';
 
 describe('e2e_cheat_codes', () => {
@@ -157,7 +156,7 @@ describe('e2e_cheat_codes', () => {
       await txInit.isMined({ interval: 0.1 });
 
       // fetch last updated ts from L2 contract and expect it to me same as new timestamp
-      const lastUpdatedTs = Number(new Fr((await contract.methods.getTot(0).view())[0][1]).value);
+      const lastUpdatedTs = Number(new Fr((await contract.methods.getTot(0).view())['last_updated_ts']));
       expect(lastUpdatedTs).toEqual(newTimestamp);
       // ensure anvil is correctly updated
       expect(await cc.l1.timestamp()).toEqual(newTimestamp);

--- a/yarn-project/end-to-end/src/fixtures/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/fixtures/cross_chain_test_harness.ts
@@ -1,6 +1,6 @@
 import { AztecNodeService } from '@aztec/aztec-node';
 import { AztecRPCServer } from '@aztec/aztec-rpc';
-import { Wallet, computeMessageSecretHash } from '@aztec/aztec.js';
+import { CheatCodes, Wallet, computeMessageSecretHash } from '@aztec/aztec.js';
 import { AztecAddress, CompleteAddress, EthAddress, Fr, PublicKey } from '@aztec/circuits.js';
 import { DeployL1Contracts } from '@aztec/ethereum';
 import { toBufferBE } from '@aztec/foundation/bigint-buffer';
@@ -12,7 +12,6 @@ import { AztecRPC, TxStatus } from '@aztec/types';
 
 import { Chain, HttpTransport, PublicClient, getContract } from 'viem';
 
-import { CheatCodes } from './cheat_codes.js';
 import { deployAndInitializeNonNativeL2TokenContracts } from './utils.js';
 
 /**

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -3,11 +3,13 @@ import { RpcServerConfig, createAztecRPCServer, getConfigEnvVars as getRpcConfig
 import {
   Account as AztecAccount,
   AztecAddress,
+  CheatCodes,
   Contract,
   ContractDeployer,
   EntrypointCollection,
   EntrypointWallet,
   EthAddress,
+  L1CheatCodes,
   Wallet,
   createAztecRpcClient as createJsonRpcClient,
   getL1ContractAddresses,
@@ -41,7 +43,6 @@ import {
 } from 'viem';
 import { mnemonicToAccount } from 'viem/accounts';
 
-import { CheatCodes, L1CheatCodes } from './cheat_codes.js';
 import { MNEMONIC, localAnvil } from './fixtures.js';
 
 const { SANDBOX_URL = '' } = process.env;

--- a/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
+++ b/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
@@ -1,6 +1,6 @@
 import { AztecNodeService } from '@aztec/aztec-node';
 import { AztecRPCServer } from '@aztec/aztec-rpc';
-import { AztecAddress, Fr, Wallet } from '@aztec/aztec.js';
+import { AztecAddress, CheatCodes, Fr, Wallet } from '@aztec/aztec.js';
 import { DeployL1Contracts, deployL1Contract } from '@aztec/ethereum';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { DebugLogger } from '@aztec/foundation/log';
@@ -10,7 +10,6 @@ import { AztecRPC, CompleteAddress, TxStatus } from '@aztec/types';
 
 import { getContract, parseEther } from 'viem';
 
-import { CheatCodes } from './fixtures/cheat_codes.js';
 import { CrossChainTestHarness } from './fixtures/cross_chain_test_harness.js';
 import { delay, deployAndInitializeNonNativeL2TokenContracts, setup } from './fixtures/utils.js';
 


### PR DESCRIPTION
* move cheatcodes to aztec.js so users just need to import this one package. (also `end-to-end` package is not published so no one could use them if we leave it where they are)
* fix a comment

Why aztec.js?
Ethers is annoying because for everything you have to import a different package. Instead it would be nice if everything can be in one. Hence moved it to aztec.js
