### PR TITLE
chore(ci): Deploy sandbox dependencies to npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -951,6 +951,7 @@ jobs:
     steps:
       - *checkout
       - *setup_env
+      # Aztec.js and dependencies
       - run:
           name: "foundation"
           working_directory: foundation
@@ -964,18 +965,6 @@ jobs:
             deploy_ecr circuits.js
             deploy_npm circuits.js
       - run:
-          name: "l1-artifacts"
-          working_directory: l1-artifacts
-          command: |
-            deploy_ecr l1-artifacts
-            deploy_npm l1-artifacts
-      - run:
-          name: "aztec-ethereum"
-          working_directory: ethereum
-          command: |
-            deploy_ecr ethereum
-            deploy_npm ethereum
-      - run:
           name: "types"
           working_directory: types
           command: |
@@ -987,6 +976,19 @@ jobs:
           command: |
             deploy_ecr aztec.js
             deploy_npm aztec.js
+      # Aztec CLI and dependencies
+      - run:
+          name: "l1-artifacts"
+          working_directory: l1-artifacts
+          command: |
+            deploy_ecr l1-artifacts
+            deploy_npm l1-artifacts
+      - run:
+          name: "aztec-ethereum"
+          working_directory: ethereum
+          command: |
+            deploy_ecr ethereum
+            deploy_npm ethereum
       - run:
           name: "noir-compiler"
           working_directory: noir-compiler
@@ -1005,6 +1007,55 @@ jobs:
           command: |
             deploy_ecr aztec-cli
             deploy_npm aztec-cli
+      # Aztec Sandbox and dependencies
+      - run:
+          name: "aztec-rpc"
+          working_directory: aztec-rpc
+          command: |
+            deploy_ecr aztec-rpc
+            deploy_npm aztec-rpc
+      - run:
+          name: "acir-simulator"
+          working_directory: acir-simulator
+          command: |
+            deploy_ecr acir-simulator
+            deploy_npm acir-simulator
+      - run:
+          name: "archiver"
+          working_directory: archiver
+          command: |
+            deploy_ecr archiver
+            deploy_npm archiver
+      - run:
+          name: "merkle-tree"
+          working_directory: merkle-tree
+          command: |
+            deploy_ecr merkle-tree
+            deploy_npm merkle-tree
+      - run:
+          name: "p2p"
+          working_directory: p2p
+          command: |
+            deploy_ecr p2p
+            deploy_npm p2p
+      - run:
+          name: "sequencer-client"
+          working_directory: sequencer-client
+          command: |
+            deploy_ecr sequencer-client
+            deploy_npm sequencer-client
+      - run:
+          name: "world-state"
+          working_directory: world-state
+          command: |
+            deploy_ecr world-state
+            deploy_npm world-state
+      - run:
+          name: "aztec-node"
+          working_directory: aztec-node
+          command: |
+            deploy_ecr aztec-node
+            deploy_npm aztec-node
       - run:
           name: "aztec-sandbox"
           working_directory: aztec-sandbox


### PR DESCRIPTION
We were publishing `aztec-sandbox` to npm, but were missing many of its dependencies. This adds them manually to the CI script. Eventually, it'd be nice to migrate to a tool that handles this automatically (@ludamad another feature request for a monorepo tool, if we go with one).

Also, bear in mind this still is untested, since I need to tag to test, and I don't want to tag a commit not on master.

Fixes #1536 