### PR TITLE
chore: Start sandbox as a bin from npm package

### DIFF
--- a/yarn-project/aztec-sandbox/package.json
+++ b/yarn-project/aztec-sandbox/package.json
@@ -6,6 +6,7 @@
     ".": "./dest/index.js",
     "./http": "./dest/server.js"
   },
+  "bin": "./dest/index.js",
   "typedocOptions": {
     "entryPoints": [
       "./src/index.ts"

--- a/yarn-project/aztec-sandbox/src/index.ts
+++ b/yarn-project/aztec-sandbox/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env -S node --no-warnings
 import { AztecNodeConfig, AztecNodeService, getConfigEnvVars } from '@aztec/aztec-node';
 import { createAztecRPCServer, getConfigEnvVars as getRpcConfigEnvVars } from '@aztec/aztec-rpc';
 import { deployInitialSandboxAccounts } from '@aztec/aztec.js';
@@ -34,7 +35,7 @@ async function waitThenDeploy(rpcUrl: string, hdAccount: HDAccount) {
       try {
         chainId = await publicClient.getChainId();
       } catch (err) {
-        logger(`Failed to get Chain ID. Retrying...`);
+        logger.warn(`Failed to connect to Ethereum node at ${rpcUrl}. Retrying...`);
       }
       return chainId;
     },
@@ -44,7 +45,7 @@ async function waitThenDeploy(rpcUrl: string, hdAccount: HDAccount) {
   );
 
   if (!chainID) {
-    throw Error(`ETH RPC server unresponsive at ${rpcUrl}.`);
+    throw Error(`Ethereum node unresponsive at ${rpcUrl}.`);
   }
 
   // Deploy L1 contracts

--- a/yarn-project/foundation/src/log/logger.ts
+++ b/yarn-project/foundation/src/log/logger.ts
@@ -69,7 +69,7 @@ function logWithDebug(debug: debug.Debugger, level: LogLevel, args: any[]) {
  * @returns Log prefix.
  */
 function getPrefix(debugLogger: debug.Debugger, level: LogLevel) {
-  const levelLabel = currentLevel !== level ? ` ${level.toUpperCase}` : '';
+  const levelLabel = currentLevel !== level ? ` ${level.toUpperCase()}` : '';
   const prefix = `${debugLogger.namespace.replace(/^aztec:/, '')}${levelLabel}`;
   if (!isNode || !isatty(process.stderr.fd)) return prefix;
   const colorIndex = debug.selectColor(debugLogger.namespace) as number;

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -205,6 +205,8 @@ __metadata:
     ts-node: ^10.9.1
     typescript: ^5.0.4
     viem: ^1.2.5
+  bin:
+    aztec-sandbox: ./dest/index.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Allows starting the aztec sandbox from the npm package directly via `yarn aztec-sandbox`. 

Unrelated fixes:
- Failed to connect errors are outputted as warn
- Log level is properly shown in logs