### PR TITLE
fix(ci): Publish missing sandbox dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1051,6 +1051,12 @@ jobs:
             deploy_ecr world-state
             deploy_npm world-state
       - run:
+          name: "key-store"
+          working_directory: key-store
+          command: |
+            deploy_ecr key-store
+            deploy_npm key-store
+      - run:
           name: "aztec-node"
           working_directory: aztec-node
           command: |


### PR DESCRIPTION
To be fair, I did mention in https://github.com/AztecProtocol/aztec-packages/pull/1593 that this should be automated and not manual, and it was not yet tested.