### PR TITLE
use .eth and .aztec instead of .l1 and .l2

### DIFF
--- a/docs/docs/dev_docs/testing/cheat_codes.md
+++ b/docs/docs/dev_docs/testing/cheat_codes.md
@@ -6,16 +6,16 @@ title: Cheat Codes
 
 To help with testing, the sandbox is shipped with a set of cheatcodes.
 
-Cheatcodes allow you to change the time of the L2 block, load certain state or more easily manipulate L1 instead of having to write dedicated RPC calls to anvil. 
+Cheatcodes allow you to change the time of the Aztec block, load certain state or more easily manipulate Ethereum instead of having to write dedicated RPC calls to anvil. 
 
 :::info Prerequisites
-If you aren't familiar with [Anvil](https://book.getfoundry.sh/anvil/), we recommend reading up on that since Aztec Sandbox uses Anvil as the local L1 instance.
+If you aren't familiar with [Anvil](https://book.getfoundry.sh/anvil/), we recommend reading up on that since Aztec Sandbox uses Anvil as the local Ethereum instance.
 :::
 
 ### Aims
 
 The guide will cover how to manipulate the state of the:
-- L1 blockchain;
+- Ethereum blockchain;
 - Aztec network.
 
 ### Dependencies
@@ -31,53 +31,53 @@ const aztecRpcClient = createAztecRpcClient(aztecRpcUrl);
 const cc = await CheatCodes.create(aztecRpcUrl, aztecRpcClient);
 ```
 
-There are two properties of the CheatCodes class - `l1` and `l2` for cheatcodes relating to the L1 and L2 (Aztec) respectively.
+There are two properties of the CheatCodes class - `eth` and `aztec` for cheatcodes relating to the Ethereum blockchain (L1) and the Aztec network (L2) respectively.
 
-## L1 related cheatcodes
+## Ethereum related cheatcodes
 These are cheatcodes exposed from anvil conveniently wrapped for ease of use in the Sandbox.
 
 ### Interface
 ```
-// Fetch current block number of L1
+// Fetch current block number of Ethereum
 public async blockNumber(): Promise<number> 
 
-// Fetch chain ID of L1
+// Fetch chain ID of the local Ethereum instance
 public async chainId(): Promise<number> 
 
-// Fetch current timestamp on L1
+// Fetch current timestamp on Ethereum
 public async timestamp(): Promise<number> 
 
-// Mine a given number of blocks on L1. Mines 1 block by default
+// Mine a given number of blocks on Ethereum. Mines 1 block by default
 public async mine(numberOfBlocks = 1): Promise<void> 
 
-// Set the timestamp for the next block on L1. 
+// Set the timestamp for the next block on Ethereum. 
 public async setNextBlockTimestamp(timestamp: number): Promise<void> 
 
-// Dumps the current L1 chain state to a given file. 
+// Dumps the current Ethereum chain state to a given file. 
 public async dumpChainState(fileName: string): Promise<void> 
 
-// Loads the L1 chain state from a file. You may use `dumpChainState()` to save the state of the L1 chain to a file and later load it. 
+// Loads the Ethereum chain state from a file. You may use `dumpChainState()` to save the state of the Ethereum chain to a file and later load it. 
 public async loadChainState(fileName: string): Promise<void> 
 
-// Load the value at a storage slot of a contract address on L1
+// Load the value at a storage slot of a contract address on Ethereum
 public async load(contract: EthAddress, slot: bigint): Promise<bigint> 
 
-// Set the value at a storage slot of a contract address on L1 (e.g. modify a storage variable on your portal contract or even the rollup contract). 
+// Set the value at a storage slot of a contract address on Ethereum (e.g. modify a storage variable on your portal contract or even the rollup contract). 
 public async store(contract: EthAddress, slot: bigint, value: bigint): Promise<void> 
 
-// Computes the slot value for a given map and key on L1. A convenient wrapper to find the appropriate storage slot to load or overwrite the state.
+// Computes the slot value for a given map and key on Ethereum. A convenient wrapper to find the appropriate storage slot to load or overwrite the state.
 public keccak256(baseSlot: bigint, key: bigint): bigint
 
-// Let you send transactions on L1 impersonating an externally owned or contract, without knowing the private key.
+// Let you send transactions on Ethereum impersonating an externally owned or contract, without knowing the private key.
 public async startImpersonating(who: EthAddress): Promise<void> 
 
-// Stop impersonating an account on L1 that you are currently impersonating.
+// Stop impersonating an account on Ethereum that you are currently impersonating.
 public async stopImpersonating(who: EthAddress): Promise<void> 
 
-// Set the bytecode for a L1 contract
+// Set the bytecode for a Ethereum contract
 public async etch(contract: EthAddress, bytecode: `0x${string}`): Promise<void> 
 
-// Get the bytecode for a L1 contract
+// Get the bytecode for a Ethereum contract
 public async getBytecode(contract: EthAddress): Promise<`0x${string}`> 
 ```
 
@@ -89,11 +89,11 @@ public async blockNumber(): Promise<number>
 ```
 
 #### Description
-Fetches the current L1 block number.
+Fetches the current Ethereum block number.
 
 #### Example
 ```js
-const blockNumber = await cc.l1.blockNumber()
+const blockNumber = await cc.eth.blockNumber()
 ```
 
 ### chainId
@@ -104,11 +104,11 @@ public async chainId(): Promise<number>
 ```
 
 #### Description
-Fetches the L1 chain ID
+Fetches the Ethereum chain ID
 
 #### Example 
 ```js
-const chainId = await cc.l1.chainId()
+const chainId = await cc.eth.chainId()
 ```
 
 ### timestamp
@@ -119,11 +119,11 @@ public async timestamp(): Promise<number>
 ```
 
 #### Description 
-Fetches the current L1 timestamp.
+Fetches the current Ethereum timestamp.
 
 #### Example
 ```js 
-const timestamp = await cc.l1.timestamp()
+const timestamp = await cc.eth.timestamp()
 ```
 
 ### mine
@@ -134,13 +134,13 @@ public async mine(numberOfBlocks = 1): Promise<void>
 ```
 
 #### Description
-Mines the specified number of blocks on L1 (default 1).
+Mines the specified number of blocks on Ethereum (default 1).
 
 #### Example
 ```js
-const blockNum = await cc.l1.blockNumber();
-await cc.l1.mine(10) // mines 10 blocks
-const newBlockNum = await cc.l1.blockNumber(); // = blockNum + 10.
+const blockNum = await cc.eth.blockNumber();
+await cc.eth.mine(10) // mines 10 blocks
+const newBlockNum = await cc.eth.blockNumber(); // = blockNum + 10.
 ```
 
 ### setNextBlockTimestamp
@@ -151,13 +151,13 @@ public async setNextBlockTimestamp(timestamp: number): Promise<void>
 ```
 
 #### Description
-Sets the timestamp (unix format in seconds) for the next mined block on L1.
+Sets the timestamp (unix format in seconds) for the next mined block on Ethereum.
 Remember that timestamp can only be set in the future and not in the past.
 
 #### Example
 ```js
 // // Set next block timestamp to 16 Aug 2023 10:54:30 GMT
-await cc.l1.setNextBlockTimestamp(1692183270) 
+await cc.eth.setNextBlockTimestamp(1692183270) 
 // next transaction you will do will have the timestamp as 1692183270
 ```
 
@@ -169,13 +169,13 @@ public async dumpChainState(fileName: string): Promise<void>
 ```
 
 #### Description
-Dumps the current L1 chain state to a file.
+Dumps the current Ethereum chain state to a file.
 Stores a hex string representing the complete state of the chain in a file with the provided path. Can be re-imported into a fresh/restarted instance of Anvil to reattain the same state.
 When combined with `loadChainState()` cheatcode, it can be let you easily import the current state of mainnet into the Anvil instance of the sandbox, to use Uniswap for example.
 
 #### Example
 ```js
-await cc.l1.dumpChainState('chain-state.json') 
+await cc.eth.dumpChainState('chain-state.json') 
 ```
 
 ### loadChainState
@@ -186,12 +186,12 @@ public async loadChainState(fileName: string): Promise<void>
 ```
 
 #### Description
-Loads the L1 chain state from a file which contains a hex string representing an L1 state. 
-When given a file previously written to by `cc.l1.dumpChainState()`, it merges the contents into the current chain state. Will overwrite any colliding accounts/storage slots.
+Loads the Ethereum chain state from a file which contains a hex string representing an Ethereum state. 
+When given a file previously written to by `cc.eth.dumpChainState()`, it merges the contents into the current chain state. Will overwrite any colliding accounts/storage slots.
 
 #### Example  
 ```js
-await cc.l1.loadChainState('chain-state.json')
+await cc.eth.loadChainState('chain-state.json')
 ```
 
 ### load  
@@ -202,7 +202,7 @@ public async load(contract: EthAddress, slot: bigint): Promise<bigint>
 ```
 
 #### Description  
-Loads the value at a storage slot of a L1 contract.
+Loads the value at a storage slot of a Ethereum contract.
 
 #### Example
 ```
@@ -211,7 +211,7 @@ Loads the value at a storage slot of a L1 contract.
 /// }
 
 const leetContractAddress = EthAddress.fromString('0x1234...');
-const value = await cc.l1.load(leetContractAddress, BigInt(0));
+const value = await cc.eth.load(leetContractAddress, BigInt(0));
 console.log(value); // 1337
 ```
 
@@ -223,7 +223,7 @@ public async store(contract: EthAddress, slot: bigint, value: bigint): Promise<v
 ```
 
 #### Description
-Stores the value in storage slot on a L1 contract.
+Stores the value in storage slot on a Ethereum contract.
 
 #### Example
 ```
@@ -232,8 +232,8 @@ Stores the value in storage slot on a L1 contract.
 /// }
 
 const leetContractAddress = EthAddress.fromString('0x1234...');
-await cc.l1.store(leetContractAddress, BigInt(0), BigInt(1000));
-const value = await cc.l1.load(leetContractAddress, BigInt(0));
+await cc.eth.store(leetContractAddress, BigInt(0), BigInt(1000));
+const value = await cc.eth.load(leetContractAddress, BigInt(0));
 console.log(value); // 1000
 ```
 
@@ -256,9 +256,9 @@ Computes the storage slot for a map key.
 
 // find the storage slot for key `0xdead` in the balance map.
 const address = BigInt('0x000000000000000000000000000000000000dead');
-const slot = cc.l1.keccak256(1n, address);
+const slot = cc.eth.keccak256(1n, address);
 // store balance of 0xdead as 100
-await cc.l1.store(contractAddress, slot, 100n);
+await cc.eth.store(contractAddress, slot, 100n);
 ```
 
 ### startImpersonating
@@ -269,12 +269,12 @@ public async startImpersonating(who: EthAddress): Promise<void>
 ```
 
 #### Description  
-Start impersonating an L1 account.
+Start impersonating an Ethereum account.
 This allows you to use this address as a sender.
 
 #### Example
 ```js
-await cc.l1.startImpersonating(EthAddress.fromString(address));
+await cc.eth.startImpersonating(EthAddress.fromString(address));
 ```
 
 ### stopImpersonating
@@ -285,12 +285,12 @@ public async stopImpersonating(who: EthAddress): Promise<void>
 ```
 
 #### Description
-Stop impersonating an L1 account.
+Stop impersonating an Ethereum account.
 Stops an active impersonation started by startImpersonating.
 
 #### Example
 ```js  
-await cc.l1.stopImpersonating(EthAddress.fromString(address)) 
+await cc.eth.stopImpersonating(EthAddress.fromString(address)) 
 ```
 
 ### getBytecode
@@ -301,11 +301,11 @@ public async getBytecode(contract: EthAddress): Promise<`0x${string}`>
 ```
 
 #### Description  
-Get the bytecode for an L1 contract.
+Get the bytecode for an Ethereum contract.
 
 #### Example
 ```js
-const bytecode = await cc.l1.getBytecode(contract) // 0x6080604052348015610010...
+const bytecode = await cc.eth.getBytecode(contract) // 0x6080604052348015610010...
 ```
 
 ### etch
@@ -316,24 +316,24 @@ public async etch(contract: EthAddress, bytecode: `0x${string}`): Promise<void>
 ```
 
 #### Description
-Set the bytecode for an L1 contract.
+Set the bytecode for an Ethereum contract.
 
 #### Example  
 ```js
 const bytecode = `0x6080604052348015610010...`
-await cc.l1.etch(contract, bytecode)
-console.log(await cc.l1.getBytecode(contract)) // 0x6080604052348015610010...
+await cc.eth.etch(contract, bytecode)
+console.log(await cc.eth.getBytecode(contract)) // 0x6080604052348015610010...
 ```
 
-## L2 related cheatcodes
+## Aztec related cheatcodes
 These are cheatcodes specific to manipulating the state of Aztec rollup.
 
 ### Interface
 ```
-// Get the current L2 block number
+// Get the current aztec block number
 public async blockNumber(): Promise<number>
 
-// Set time of the next execution on L2. It also modifies time on L1 for next execution and stores this time as the last rollup block on the rollup contract.
+// Set time of the next execution on aztec. It also modifies time on Ethereum for next execution and stores this time as the last rollup block on the rollup contract.
 public async warp(to: number): Promise<void>
 
 // Loads the value stored at the given slot in the public storage of the given contract.
@@ -351,11 +351,11 @@ public async blockNumber(): Promise<number>
 ```
 
 #### Description  
-Get the current L2 block number.
+Get the current aztec block number.
 
 #### Example
 ```js
-const blockNumber = await cc.l2.blockNumber()
+const blockNumber = await cc.aztec.blockNumber()
 ```
 
 ### warp 
@@ -366,14 +366,14 @@ public async warp(to: number): Promise<void>
 ```
 
 #### Description
-Sets the time of L1 and the time of the next L2 block.
-Like with the corresponding L1 cheatcode, time can only be set in the future, not the past.
+Sets the time on Ethereum and the time of the next block on Aztec.
+Like with the corresponding Ethereum cheatcode, time can only be set in the future, not the past.
 
 #### Example
 ```js
-const timestamp = await cc.l1.timestamp();
+const timestamp = await cc.eth.timestamp();
 const newTimestamp = timestamp + 100_000_000;
-await cc.l2.warp(newTimestamp);
+await cc.aztec.warp(newTimestamp);
 
 // any noir contract calls that make use of current timestamp and is executed in the next rollup block will now read `newTimestamp`
 ```
@@ -409,7 +409,7 @@ The baseSlot is specified in the noir contract.
 ///     ...
 /// }
 
-const slot = cc.l2.computeSlotInMap(1n, key)
+const slot = cc.aztec.computeSlotInMap(1n, key)
 ```
 
 ### loadPublic
@@ -445,8 +445,8 @@ Note: One Field element occupies a storage slot. So structs with multiple field 
 /// }
 
 const address = AztecAddress.fromString("0x123...")
-const slot = cc.l2.computeSlotInMap(1n, key)
-const value = await cc.l2.loadPublic(address, slot);
+const slot = cc.aztec.computeSlotInMap(1n, key)
+const value = await cc.aztec.loadPublic(address, slot);
 ```
 ## Participate
 

--- a/yarn-project/aztec.js/src/utils/cheat_codes.ts
+++ b/yarn-project/aztec.js/src/utils/cheat_codes.ts
@@ -17,35 +17,35 @@ const toFr = (value: Fr | bigint): Fr => {
 export class CheatCodes {
   constructor(
     /**
-     * The L1 cheat codes.
+     * The cheat codes for ethereum (L1).
      */
-    public l1: L1CheatCodes,
+    public eth: EthCheatCodes,
     /**
-     * The L2 cheat codes.
+     * The cheat codes for aztec.
      */
-    public l2: L2CheatCodes,
+    public aztec: AztecCheatCodes,
   ) {}
 
   static async create(rpcUrl: string, aztecRpc: AztecRPC): Promise<CheatCodes> {
-    const l1CheatCodes = new L1CheatCodes(rpcUrl);
-    const l2CheatCodes = new L2CheatCodes(aztecRpc, await CircuitsWasm.get(), l1CheatCodes);
-    return new CheatCodes(l1CheatCodes, l2CheatCodes);
+    const ethCheatCodes = new EthCheatCodes(rpcUrl);
+    const aztecCheatCodes = new AztecCheatCodes(aztecRpc, await CircuitsWasm.get(), ethCheatCodes);
+    return new CheatCodes(ethCheatCodes, aztecCheatCodes);
   }
 }
 
 /**
- * A class that provides utility functions for interacting with the L1 chain.
+ * A class that provides utility functions for interacting with ethereum (L1).
  */
-export class L1CheatCodes {
+export class EthCheatCodes {
   constructor(
     /**
      * The RPC client to use for interacting with the chain
      */
     public rpcUrl: string,
     /**
-     * The logger to use for the l1 cheatcodes
+     * The logger to use for the eth cheatcodes
      */
-    public logger = createDebugLogger('aztec:cheat_codes:l1'),
+    public logger = createDebugLogger('aztec:cheat_codes:eth'),
   ) {}
 
   async rpcCall(method: string, params: any[]) {
@@ -130,7 +130,7 @@ export class L1CheatCodes {
   }
 
   /**
-   * Load the value at a storage slot of a contract address on L1
+   * Load the value at a storage slot of a contract address on eth
    * @param contract - The contract address
    * @param slot - The storage slot
    * @returns - The value at the storage slot
@@ -141,7 +141,7 @@ export class L1CheatCodes {
   }
 
   /**
-   * Set the value at a storage slot of a contract address on L1
+   * Set the value at a storage slot of a contract address on eth
    * @param contract - The contract address
    * @param slot - The storage slot
    * @param value - The value to set the storage slot to
@@ -208,9 +208,9 @@ export class L1CheatCodes {
 }
 
 /**
- * A class that provides utility functions for interacting with the L2 chain.
+ * A class that provides utility functions for interacting with the aztec chain.
  */
-export class L2CheatCodes {
+export class AztecCheatCodes {
   constructor(
     /**
      * The RPC client to use for interacting with the chain
@@ -221,13 +221,13 @@ export class L2CheatCodes {
      */
     public wasm: CircuitsWasm,
     /**
-     * The L1 cheat codes.
+     * The eth cheat codes.
      */
-    public l1: L1CheatCodes,
+    public eth: EthCheatCodes,
     /**
-     * The logger to use for the l2 cheatcodes
+     * The logger to use for the aztec cheatcodes
      */
-    public logger = createDebugLogger('aztec:cheat_codes:l2'),
+    public logger = createDebugLogger('aztec:cheat_codes:aztec'),
   ) {}
 
   /**
@@ -256,16 +256,16 @@ export class L2CheatCodes {
   }
 
   /**
-   * Set time of the next execution on L2.
-   * It also modifies time on L1 for next execution and stores this time as the last rollup block on the rollup contract.
+   * Set time of the next execution on aztec.
+   * It also modifies time on eth for next execution and stores this time as the last rollup block on the rollup contract.
    * @param to - The timestamp to set the next block to (must be greater than current time)
    */
   public async warp(to: number): Promise<void> {
     const rollupContract = (await this.aztecRpc.getNodeInfo()).rollupAddress;
-    await this.l1.setNextBlockTimestamp(to);
+    await this.eth.setNextBlockTimestamp(to);
     // also store this time on the rollup contract (slot 1 tracks `lastBlockTs`).
     // This is because when the sequencer executes public functions, it uses the timestamp stored in the rollup contract.
-    await this.l1.store(rollupContract, 1n, BigInt(to));
+    await this.eth.store(rollupContract, 1n, BigInt(to));
   }
 
   /**

--- a/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
@@ -41,42 +41,42 @@ describe('e2e_cheat_codes', () => {
   describe('L1 only', () => {
     describe('mine', () => {
       it(`mine block`, async () => {
-        const blockNumber = await cc.l1.blockNumber();
-        await cc.l1.mine();
-        expect(await cc.l1.blockNumber()).toBe(blockNumber + 1);
+        const blockNumber = await cc.eth.blockNumber();
+        await cc.eth.mine();
+        expect(await cc.eth.blockNumber()).toBe(blockNumber + 1);
       });
 
       it.each([10, 42, 99])(`mine blocks`, async increment => {
-        const blockNumber = await cc.l1.blockNumber();
-        await cc.l1.mine(increment);
-        expect(await cc.l1.blockNumber()).toBe(blockNumber + increment);
+        const blockNumber = await cc.eth.blockNumber();
+        await cc.eth.mine(increment);
+        expect(await cc.eth.blockNumber()).toBe(blockNumber + increment);
       });
     });
 
     it.each([100, 42, 99])('setNextBlockTimestamp', async increment => {
-      const blockNumber = await cc.l1.blockNumber();
-      const timestamp = await cc.l1.timestamp();
-      await cc.l1.setNextBlockTimestamp(timestamp + increment);
+      const blockNumber = await cc.eth.blockNumber();
+      const timestamp = await cc.eth.timestamp();
+      await cc.eth.setNextBlockTimestamp(timestamp + increment);
 
-      expect(await cc.l1.timestamp()).toBe(timestamp);
+      expect(await cc.eth.timestamp()).toBe(timestamp);
 
-      await cc.l1.mine();
+      await cc.eth.mine();
 
-      expect(await cc.l1.blockNumber()).toBe(blockNumber + 1);
-      expect(await cc.l1.timestamp()).toBe(timestamp + increment);
+      expect(await cc.eth.blockNumber()).toBe(blockNumber + 1);
+      expect(await cc.eth.timestamp()).toBe(timestamp + increment);
     });
 
     it('setNextBlockTimestamp to a past timestamp throws', async () => {
-      const timestamp = await cc.l1.timestamp();
+      const timestamp = await cc.eth.timestamp();
       const pastTimestamp = timestamp - 1000;
-      await expect(async () => await cc.l1.setNextBlockTimestamp(pastTimestamp)).rejects.toThrow(
+      await expect(async () => await cc.eth.setNextBlockTimestamp(pastTimestamp)).rejects.toThrow(
         `Error setting next block timestamp: Timestamp error: ${pastTimestamp} is lower than or equal to previous block's timestamp`,
       );
     });
 
     it('load a value at a particular storage slot', async () => {
       // check that storage slot 0 is empty as expected
-      const res = await cc.l1.load(EthAddress.ZERO, 0n);
+      const res = await cc.eth.load(EthAddress.ZERO, 0n);
       expect(res).toBe(0n);
     });
 
@@ -86,18 +86,18 @@ describe('e2e_cheat_codes', () => {
         const storageSlot = BigInt('0x' + storageSlotInHex);
         const valueToSet = 5n;
         const contractAddress = EthAddress.fromString('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266');
-        await cc.l1.store(contractAddress, storageSlot, valueToSet);
-        expect(await cc.l1.load(contractAddress, storageSlot)).toBe(valueToSet);
+        await cc.eth.store(contractAddress, storageSlot, valueToSet);
+        expect(await cc.eth.load(contractAddress, storageSlot)).toBe(valueToSet);
         // also test with the keccak value of the slot - can be used to compute storage slots of maps
-        await cc.l1.store(contractAddress, cc.l1.keccak256(0n, storageSlot), valueToSet);
-        expect(await cc.l1.load(contractAddress, cc.l1.keccak256(0n, storageSlot))).toBe(valueToSet);
+        await cc.eth.store(contractAddress, cc.eth.keccak256(0n, storageSlot), valueToSet);
+        expect(await cc.eth.load(contractAddress, cc.eth.keccak256(0n, storageSlot))).toBe(valueToSet);
       },
     );
 
     it('set bytecode correctly', async () => {
       const contractAddress = EthAddress.fromString('0x70997970C51812dc3A010C7d01b50e0d17dc79C8');
-      await cc.l1.etch(contractAddress, '0x1234');
-      expect(await cc.l1.getBytecode(contractAddress)).toBe('0x1234');
+      await cc.eth.etch(contractAddress, '0x1234');
+      expect(await cc.eth.getBytecode(contractAddress)).toBe('0x1234');
     });
 
     it('impersonate', async () => {
@@ -113,7 +113,7 @@ describe('e2e_cheat_codes', () => {
       const beforeBalance = await publicClient.getBalance({ address: randomAddress });
 
       // impersonate random address
-      await cc.l1.startImpersonating(EthAddress.fromString(randomAddress));
+      await cc.eth.startImpersonating(EthAddress.fromString(randomAddress));
       // send funds from random address
       const amountToSend = parseEther('0.1');
       const txHash = await walletClient.sendTransaction({
@@ -126,7 +126,7 @@ describe('e2e_cheat_codes', () => {
       expect(await publicClient.getBalance({ address: randomAddress })).toBe(beforeBalance - amountToSend - feePaid);
 
       // stop impersonating
-      await cc.l1.stopImpersonating(EthAddress.fromString(randomAddress));
+      await cc.eth.stopImpersonating(EthAddress.fromString(randomAddress));
 
       // making calls from random address should not be successful
       try {
@@ -150,9 +150,9 @@ describe('e2e_cheat_codes', () => {
       const contract = await LendingContract.at(receipt.contractAddress!, wallet);
 
       // now update time:
-      const timestamp = await cc.l1.timestamp();
+      const timestamp = await cc.eth.timestamp();
       const newTimestamp = timestamp + 100_000_000;
-      await cc.l2.warp(newTimestamp);
+      await cc.aztec.warp(newTimestamp);
 
       // ensure rollup contract is correctly updated
       const rollup = getContract({ address: getAddress(rollupAddress.toString()), abi: RollupAbi, publicClient });
@@ -167,16 +167,16 @@ describe('e2e_cheat_codes', () => {
       const lastUpdatedTs = Number((await contract.methods.getTot(0).view())['last_updated_ts']);
       expect(lastUpdatedTs).toEqual(newTimestamp);
       // ensure anvil is correctly updated
-      expect(await cc.l1.timestamp()).toEqual(newTimestamp);
+      expect(await cc.eth.timestamp()).toEqual(newTimestamp);
       // ensure rollup contract is correctly updated
       expect(Number(await rollup.read.lastBlockTs())).toEqual(newTimestamp);
       expect;
     }, 50_000);
 
     it('should throw if setting L2 block time to a past timestamp', async () => {
-      const timestamp = await cc.l1.timestamp();
+      const timestamp = await cc.eth.timestamp();
       const pastTimestamp = timestamp - 1000;
-      await expect(async () => await cc.l2.warp(pastTimestamp)).rejects.toThrow(
+      await expect(async () => await cc.aztec.warp(pastTimestamp)).rejects.toThrow(
         `Error setting next block timestamp: Timestamp error: ${pastTimestamp} is lower than or equal to previous block's timestamp`,
       );
     });

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -232,8 +232,8 @@ export async function setup(
   const config = getConfigEnvVars();
 
   if (stateLoad) {
-    const l1CheatCodes = new EthCheatCodes(config.rpcUrl);
-    await l1CheatCodes.loadChainState(stateLoad);
+    const ethCheatCodes = new EthCheatCodes(config.rpcUrl);
+    await ethCheatCodes.loadChainState(stateLoad);
   }
 
   const logger = getLogger();

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -9,7 +9,7 @@ import {
   EntrypointCollection,
   EntrypointWallet,
   EthAddress,
-  L1CheatCodes,
+  EthCheatCodes,
   Wallet,
   createAztecRpcClient as createJsonRpcClient,
   getL1ContractAddresses,
@@ -232,7 +232,7 @@ export async function setup(
   const config = getConfigEnvVars();
 
   if (stateLoad) {
-    const l1CheatCodes = new L1CheatCodes(config.rpcUrl);
+    const l1CheatCodes = new EthCheatCodes(config.rpcUrl);
     await l1CheatCodes.loadChainState(stateLoad);
   }
 


### PR DESCRIPTION
In case we like the `.eth` and `.aztec` variation over `.l1` and `.l2` in cheatcodes!

This would get merged into my docs pr #1585 