### PR TITLE
fix: Hack an ordering index for enqueued public calls

### DIFF
--- a/yarn-project/acir-simulator/src/client/execution_result.ts
+++ b/yarn-project/acir-simulator/src/client/execution_result.ts
@@ -100,9 +100,9 @@ export function collectUnencryptedLogs(execResult: ExecutionResult): FunctionL2L
  * @returns All enqueued public function calls.
  */
 export function collectEnqueuedPublicFunctionCalls(execResult: ExecutionResult): PublicCallRequest[] {
-  // without the .reverse(), the logs will be in a queue like fashion which is wrong as the kernel processes it like a stack.
+  // without the reverse sort, the logs will be in a queue like fashion which is wrong as the kernel processes it like a stack.
   return [
     ...execResult.enqueuedPublicFunctionCalls,
-    ...[...execResult.nestedExecutions].reverse().flatMap(collectEnqueuedPublicFunctionCalls),
-  ];
+    ...[...execResult.nestedExecutions].flatMap(collectEnqueuedPublicFunctionCalls),
+  ].sort((a, b) => b.order! - a.order!);
 }

--- a/yarn-project/acir-simulator/src/client/private_execution.test.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.test.ts
@@ -763,7 +763,7 @@ describe('Private Execution test suite', () => {
   });
 
   describe('enqueued calls', () => {
-    it.each([false, true])('parent should enqueue call to child', async isInternal => {
+    it.each([false, true])('parent should enqueue call to child (internal %p)', async isInternal => {
       const parentAbi = ParentContractAbi.functions.find(f => f.name === 'enqueueCallToChild')!;
       const childContractAbi = ParentContractAbi.functions[0];
       const childAddress = AztecAddress.random();
@@ -798,6 +798,7 @@ describe('Private Execution test suite', () => {
           isDelegateCall: false,
           isStaticCall: false,
         }),
+        order: 0,
       });
 
       const publicCallRequestHash = computeCallStackItemHash(

--- a/yarn-project/acir-simulator/src/client/private_execution.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.ts
@@ -28,6 +28,9 @@ import { AcirSimulator, ExecutionResult, NewNoteData, NewNullifierData } from '.
 import { ClientTxExecutionContext } from './client_execution_context.js';
 import { acvmFieldMessageToString, oracleDebugCallToFormattedStr } from './debug.js';
 
+/** Orderings of side effects */
+type Orderings = { /** Public call stack execution requests */ publicCall: number };
+
 /**
  * The private function execution class.
  */
@@ -40,7 +43,7 @@ export class PrivateFunctionExecution {
     private argsHash: Fr,
     private callContext: CallContext,
     private curve: Grumpkin,
-
+    private orderings: Orderings = { publicCall: 0 },
     private log = createDebugLogger('aztec:simulator:secret_execution'),
   ) {}
 
@@ -139,9 +142,12 @@ export class PrivateFunctionExecution {
           frToSelector(fromACVMField(acvmFunctionSelector)),
           this.context.packedArgsCache.unpack(fromACVMField(acvmArgsHash)),
           this.callContext,
+          this.orderings,
         );
 
-        this.log(`Enqueued call to public function ${acvmContractAddress}:${acvmFunctionSelector}`);
+        this.log(
+          `Enqueued call to public function #${enqueuedRequest.order} ${acvmContractAddress}:${acvmFunctionSelector}`,
+        );
         enqueuedPublicFunctionCalls.push(enqueuedRequest);
         return toAcvmEnqueuePublicFunctionResult(enqueuedRequest);
       },
@@ -279,6 +285,8 @@ export class PrivateFunctionExecution {
       targetArgsHash,
       derivedCallContext,
       curve,
+      this.orderings,
+      this.log,
     );
 
     return nestedExecution.run();
@@ -292,6 +300,7 @@ export class PrivateFunctionExecution {
    * @param targetFunctionSelector - The function selector of the function to call.
    * @param targetArgs - The arguments to pass to the function.
    * @param callerContext - The call context of the caller.
+   * @param orderings - Orderings.
    * @returns The public call stack item with the request information.
    */
   private async enqueuePublicFunctionCall(
@@ -299,15 +308,18 @@ export class PrivateFunctionExecution {
     targetFunctionSelector: Buffer,
     targetArgs: Fr[],
     callerContext: CallContext,
+    orderings: Orderings,
   ): Promise<PublicCallRequest> {
     const targetAbi = await this.context.db.getFunctionABI(targetContractAddress, targetFunctionSelector);
     const derivedCallContext = await this.deriveCallContext(callerContext, targetContractAddress, false, false);
+    const order = orderings.publicCall++;
 
     return PublicCallRequest.from({
       args: targetArgs,
       callContext: derivedCallContext,
       functionData: FunctionData.fromAbi(targetAbi),
       contractAddress: targetContractAddress,
+      order,
     });
   }
 

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -4,8 +4,17 @@ import {
   collectEnqueuedPublicFunctionCalls,
   collectUnencryptedLogs,
 } from '@aztec/acir-simulator';
-import { AztecAddress, CompleteAddress, FunctionData, PrivateKey } from '@aztec/circuits.js';
+import {
+  AztecAddress,
+  CompleteAddress,
+  FunctionData,
+  KernelCircuitPublicInputs,
+  MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX,
+  PrivateKey,
+  PublicCallRequest,
+} from '@aztec/circuits.js';
 import { encodeArguments } from '@aztec/foundation/abi';
+import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/fields';
 import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import {
@@ -404,13 +413,14 @@ export class AztecRPCServer implements AztecRPC {
     const kernelProver = new KernelProver(kernelOracle);
     this.log(`Executing kernel prover...`);
     const { proof, publicInputs } = await kernelProver.prove(txExecutionRequest.toTxRequest(), executionResult);
-    this.log('Proof completed!');
 
     const newContractPublicFunctions = newContract ? getNewContractPublicFunctions(newContract) : [];
 
     const encryptedLogs = new TxL2Logs(collectEncryptedLogs(executionResult));
     const unencryptedLogs = new TxL2Logs(collectUnencryptedLogs(executionResult));
     const enqueuedPublicFunctions = collectEnqueuedPublicFunctionCalls(executionResult);
+
+    await this.patchPublicCallStackOrdering(publicInputs, enqueuedPublicFunctions);
 
     return new Tx(
       publicInputs,
@@ -419,6 +429,42 @@ export class AztecRPCServer implements AztecRPC {
       unencryptedLogs,
       newContractPublicFunctions,
       enqueuedPublicFunctions,
+    );
+  }
+
+  // This is a hack to fix ordering of public calls enqueued in the call stack. Since the private kernel cannot
+  // keep track of side effects that happen after or before a nested call, we override the public call stack
+  // it emits with whatever we got from the simulator collected enqueued calls. As a sanity check, we at least verify
+  // that the elements are the same, so we are only tweaking their ordering.
+  // See yarn-project/end-to-end/src/e2e_ordering.test.ts
+  // See https://github.com/AztecProtocol/aztec-packages/issues/1615
+  private async patchPublicCallStackOrdering(
+    publicInputs: KernelCircuitPublicInputs,
+    enqueuedPublicCalls: PublicCallRequest[],
+  ) {
+    const callToHash = (call: PublicCallRequest) => call.toPublicCallStackItem().then(item => item.hash());
+    const enqueuedPublicCallsHashes = await Promise.all(enqueuedPublicCalls.map(callToHash));
+    const { publicCallStack } = publicInputs.end;
+
+    // Validate all items in enqueued public calls are in the kernel emitted stack
+    const areEqual = enqueuedPublicCallsHashes.reduce(
+      (accum, enqueued) => accum && !!publicCallStack.find(item => item.equals(enqueued)),
+      true,
+    );
+
+    if (!areEqual) {
+      throw new Error(
+        `Enqueued public function calls and public call stack do not match.\nEnqueued calls: ${enqueuedPublicCallsHashes
+          .map(h => h.toString())
+          .join(', ')}\nPublic call stack: ${publicCallStack.map(i => i.toString()).join(', ')}`,
+      );
+    }
+
+    // Override kernel output
+    publicInputs.end.publicCallStack = padArrayEnd(
+      enqueuedPublicCallsHashes,
+      Fr.ZERO,
+      MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX,
     );
   }
 

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -420,6 +420,7 @@ export class AztecRPCServer implements AztecRPC {
     const unencryptedLogs = new TxL2Logs(collectUnencryptedLogs(executionResult));
     const enqueuedPublicFunctions = collectEnqueuedPublicFunctionCalls(executionResult);
 
+    // HACK(#1639): Manually patches the ordering of the public call stack
     await this.patchPublicCallStackOrdering(publicInputs, enqueuedPublicFunctions);
 
     return new Tx(

--- a/yarn-project/aztec-rpc/src/kernel_prover/kernel_prover.ts
+++ b/yarn-project/aztec-rpc/src/kernel_prover/kernel_prover.ts
@@ -188,8 +188,7 @@ export class KernelProver {
       functionData.functionSelectorBuffer,
     );
 
-    // TODO
-    // FIXME: https://github.com/AztecProtocol/aztec3-packages/issues/262
+    // TODO(#262): Use real acir hash
     // const acirHash = keccak(Buffer.from(bytecode, 'hex'));
     const acirHash = Fr.fromBuffer(Buffer.alloc(32, 0));
 

--- a/yarn-project/circuits.js/src/structs/call_stack_item.ts
+++ b/yarn-project/circuits.js/src/structs/call_stack_item.ts
@@ -1,5 +1,7 @@
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 
+import { computePublicCallStackItemHash } from '../abis/abis.js';
+import { CircuitsWasm } from '../index.js';
 import { serializeToBuffer } from '../utils/serialize.js';
 import { FunctionData } from './function_data.js';
 import { PrivateCircuitPublicInputs } from './private_circuit_public_inputs.js';
@@ -90,5 +92,13 @@ export class PublicCallStackItem {
 
   isEmpty() {
     return this.contractAddress.isZero() && this.functionData.isEmpty() && this.publicInputs.isEmpty();
+  }
+
+  /**
+   * Computes this call stack item hash.
+   * @returns Hash.
+   */
+  public async hash() {
+    return computePublicCallStackItemHash(await CircuitsWasm.get(), this);
   }
 }

--- a/yarn-project/circuits.js/src/structs/public_call_request.ts
+++ b/yarn-project/circuits.js/src/structs/public_call_request.ts
@@ -35,6 +35,10 @@ export class PublicCallRequest {
      * Function arguments.
      */
     public args: Fr[],
+    /**
+     * Optional ordering within a tx execution.
+     */
+    public order?: number,
   ) {}
 
   /**
@@ -75,7 +79,7 @@ export class PublicCallRequest {
    * @returns The array.
    */
   static getFields(fields: FieldsOf<PublicCallRequest>) {
-    return [fields.contractAddress, fields.functionData, fields.callContext, fields.args] as const;
+    return [fields.contractAddress, fields.functionData, fields.callContext, fields.args, fields.order] as const;
   }
 
   /**

--- a/yarn-project/end-to-end/src/e2e_ordering.test.ts
+++ b/yarn-project/end-to-end/src/e2e_ordering.test.ts
@@ -2,7 +2,7 @@
 import { AztecNodeService } from '@aztec/aztec-node';
 import { AztecRPCServer } from '@aztec/aztec-rpc';
 import { BatchCall, Wallet } from '@aztec/aztec.js';
-import { Fr } from '@aztec/circuits.js';
+import { Fr, PublicCallRequest } from '@aztec/circuits.js';
 import { toBigInt } from '@aztec/foundation/serialize';
 import { ChildContract, ParentContract } from '@aztec/noir-contracts/types';
 import { AztecRPC, FunctionCall, L2BlockL2Logs } from '@aztec/types';
@@ -35,32 +35,50 @@ describe('e2e_ordering', () => {
       child = await ChildContract.deploy(wallet).send().deployed();
     });
 
-    const getChildStoredValue = () =>
-      aztecRpcServer.getPublicStorageAt(child.address, new Fr(1)).then(x => toBigInt(x!));
+    describe('enqueued public calls ordering', () => {
+      const sendBatch = async (actions: FunctionCall[]) => {
+        const batch = new BatchCall(wallet, actions);
+        const tx = await batch.simulate();
+        await batch.send().wait();
+        const logs = await aztecRpcServer.getUnencryptedLogs(1, 10).then(L2BlockL2Logs.unrollLogs);
+        const value = await aztecRpcServer.getPublicStorageAt(child.address, new Fr(1)).then(x => toBigInt(x!));
+        return { tx, logs, value };
+      };
 
-    // Fails since current value at the end of execution is 10, not 20
-    it.skip('orders public function execution requests when nested call is last', async () => {
-      const actions: FunctionCall[] = [
-        child.methods.pubSetValue(10).request(),
-        parent.methods.enqueueCallToChild(child.address, child.methods.pubSetValue.selector, 20).request(),
-      ];
+      const callsToHashes = (enqueuedPublicCalls: PublicCallRequest[]) =>
+        Promise.all(enqueuedPublicCalls.map(call => call.toPublicCallStackItem().then(item => item.hash())));
 
-      await new BatchCall(wallet, actions).send().wait();
-      expect(await getChildStoredValue()).toEqual(20n);
-      const logs = await aztecRpcServer.getUnencryptedLogs(1, 10).then(L2BlockL2Logs.unrollLogs);
-      expect(logs).toEqual([[10], [20]].map(Buffer.from));
-    });
+      it('orders public function execution requests when nested call is last', async () => {
+        const actions: FunctionCall[] = [
+          child.methods.pubSetValue(10).request(),
+          parent.methods.enqueueCallToChild(child.address, child.methods.pubSetValue.selector, 20).request(),
+        ];
 
-    it('orders public function execution requests when nested call is first', async () => {
-      const actions: FunctionCall[] = [
-        parent.methods.enqueueCallToChild(child.address, child.methods.pubSetValue.selector, 10).request(),
-        child.methods.pubSetValue(20).request(),
-      ];
+        const { tx, logs, value } = await sendBatch(actions);
+        const { enqueuedPublicFunctionCalls: enqueuedPublicCalls } = tx;
 
-      await new BatchCall(wallet, actions).send().wait();
-      expect(await getChildStoredValue()).toEqual(20n);
-      const logs = await aztecRpcServer.getUnencryptedLogs(1, 10).then(L2BlockL2Logs.unrollLogs);
-      expect(logs).toEqual([[10], [20]].map(Buffer.from));
+        expect(enqueuedPublicCalls.length).toEqual(2);
+        expect(tx.data.end.publicCallStack.slice(0, 2)).toEqual(await callsToHashes(enqueuedPublicCalls));
+        expect(enqueuedPublicCalls.map(c => c.args[0].toBigInt())).toEqual([20n, 10n]);
+        expect(logs).toEqual([[10], [20]].map(Buffer.from));
+        expect(value).toEqual(20n);
+      });
+
+      it('orders public function execution requests when nested call is first', async () => {
+        const actions: FunctionCall[] = [
+          parent.methods.enqueueCallToChild(child.address, child.methods.pubSetValue.selector, 10).request(),
+          child.methods.pubSetValue(20).request(),
+        ];
+
+        const { tx, logs, value } = await sendBatch(actions);
+        const { enqueuedPublicFunctionCalls: enqueuedPublicCalls } = tx;
+
+        expect(enqueuedPublicCalls.length).toEqual(2);
+        expect(tx.data.end.publicCallStack.slice(0, 2)).toEqual(await callsToHashes(enqueuedPublicCalls));
+        expect(enqueuedPublicCalls.map(c => c.args[0].toBigInt())).toEqual([20n, 10n]);
+        expect(logs).toEqual([[10], [20]].map(Buffer.from));
+        expect(value).toEqual(20n);
+      });
     });
   });
 });

--- a/yarn-project/end-to-end/src/e2e_ordering.test.ts
+++ b/yarn-project/end-to-end/src/e2e_ordering.test.ts
@@ -1,11 +1,11 @@
 // Test suite for testing proper ordering of side effects
 import { AztecNodeService } from '@aztec/aztec-node';
 import { AztecRPCServer } from '@aztec/aztec-rpc';
-import { BatchCall, Wallet } from '@aztec/aztec.js';
-import { Fr, PublicCallRequest } from '@aztec/circuits.js';
+import { Wallet } from '@aztec/aztec.js';
+import { Fr } from '@aztec/circuits.js';
 import { toBigInt } from '@aztec/foundation/serialize';
 import { ChildContract, ParentContract } from '@aztec/noir-contracts/types';
-import { AztecRPC, FunctionCall, L2BlockL2Logs } from '@aztec/types';
+import { AztecRPC, L2BlockL2Logs } from '@aztec/types';
 
 import { setup } from './fixtures/utils.js';
 
@@ -29,56 +29,52 @@ describe('e2e_ordering', () => {
   describe('with parent and child contract', () => {
     let parent: ParentContract;
     let child: ChildContract;
+    let pubSetValueSelector: Buffer;
 
     beforeEach(async () => {
       parent = await ParentContract.deploy(wallet).send().deployed();
       child = await ChildContract.deploy(wallet).send().deployed();
+      pubSetValueSelector = child.methods.pubSetValue.selector;
     });
 
     describe('enqueued public calls ordering', () => {
-      const sendBatch = async (actions: FunctionCall[]) => {
-        const batch = new BatchCall(wallet, actions);
-        const tx = await batch.simulate();
-        await batch.send().wait();
-        const logs = await aztecRpcServer.getUnencryptedLogs(1, 10).then(L2BlockL2Logs.unrollLogs);
-        const value = await aztecRpcServer.getPublicStorageAt(child.address, new Fr(1)).then(x => toBigInt(x!));
-        return { tx, logs, value };
-      };
+      const nestedValue = 10n;
+      const directValue = 20n;
 
-      const callsToHashes = (enqueuedPublicCalls: PublicCallRequest[]) =>
-        Promise.all(enqueuedPublicCalls.map(call => call.toPublicCallStackItem().then(item => item.hash())));
+      const expectedOrders = {
+        enqueueCallsToChildWithNestedFirst: [nestedValue, directValue],
+        enqueueCallsToChildWithNestedLast: [directValue, nestedValue],
+      } as const;
 
-      it('orders public function execution requests when nested call is last', async () => {
-        const actions: FunctionCall[] = [
-          child.methods.pubSetValue(10).request(),
-          parent.methods.enqueueCallToChild(child.address, child.methods.pubSetValue.selector, 20).request(),
-        ];
+      it.each(['enqueueCallsToChildWithNestedFirst', 'enqueueCallsToChildWithNestedLast'] as const)(
+        'orders public function execution in %s',
+        async method => {
+          const expectedOrder = expectedOrders[method];
+          const action = parent.methods[method](child.address, pubSetValueSelector);
+          const tx = await action.simulate();
+          await action.send().wait();
 
-        const { tx, logs, value } = await sendBatch(actions);
-        const { enqueuedPublicFunctionCalls: enqueuedPublicCalls } = tx;
+          // There are two enqueued calls
+          const enqueuedPublicCalls = tx.enqueuedPublicFunctionCalls;
+          expect(enqueuedPublicCalls.length).toEqual(2);
 
-        expect(enqueuedPublicCalls.length).toEqual(2);
-        expect(tx.data.end.publicCallStack.slice(0, 2)).toEqual(await callsToHashes(enqueuedPublicCalls));
-        expect(enqueuedPublicCalls.map(c => c.args[0].toBigInt())).toEqual([20n, 10n]);
-        expect(logs).toEqual([[10], [20]].map(Buffer.from));
-        expect(value).toEqual(20n);
-      });
+          // The call stack hashes in the output of the kernel proof match the tx enqueuedPublicFunctionCalls
+          const hashes = await Promise.all(enqueuedPublicCalls.map(c => c.toPublicCallStackItem().then(i => i.hash())));
+          expect(tx.data.end.publicCallStack.slice(0, 2)).toEqual(hashes);
 
-      it('orders public function execution requests when nested call is first', async () => {
-        const actions: FunctionCall[] = [
-          parent.methods.enqueueCallToChild(child.address, child.methods.pubSetValue.selector, 10).request(),
-          child.methods.pubSetValue(20).request(),
-        ];
+          // The enqueued public calls are in the expected order based on the argument they set (stack is reversed!)
+          expect(enqueuedPublicCalls.map(c => c.args[0].toBigInt())).toEqual([...expectedOrder].reverse());
 
-        const { tx, logs, value } = await sendBatch(actions);
-        const { enqueuedPublicFunctionCalls: enqueuedPublicCalls } = tx;
+          // Logs are emitted in the expected order
+          const logs = await aztecRpcServer.getUnencryptedLogs(1, 10).then(L2BlockL2Logs.unrollLogs);
+          const expectedLogs = expectedOrder.map(x => Buffer.from([Number(x)]));
+          expect(logs).toEqual(expectedLogs);
 
-        expect(enqueuedPublicCalls.length).toEqual(2);
-        expect(tx.data.end.publicCallStack.slice(0, 2)).toEqual(await callsToHashes(enqueuedPublicCalls));
-        expect(enqueuedPublicCalls.map(c => c.args[0].toBigInt())).toEqual([20n, 10n]);
-        expect(logs).toEqual([[10], [20]].map(Buffer.from));
-        expect(value).toEqual(20n);
-      });
+          // The final value of the child is the last one set
+          const value = await aztecRpcServer.getPublicStorageAt(child.address, new Fr(1)).then(x => toBigInt(x!));
+          expect(value).toEqual(expectedOrder[1]);
+        },
+      );
     });
   });
 });

--- a/yarn-project/noir-contracts/src/contracts/parent_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/parent_contract/src/main.nr
@@ -86,6 +86,40 @@ contract Parent {
         context.finish()
     }
 
+    // Private function that enqueues two calls to a child contract: 
+    // - one through a nested call to enqueueCallToChild with value 10,
+    // - followed by one issued directly from this function with value 20.
+    fn enqueueCallsToChildWithNestedFirst(
+        inputs: PrivateContextInputs,
+        targetContract: Field,
+        targetSelector: Field,
+    ) -> distinct pub abi::PrivateCircuitPublicInputs {
+        let mut context = PrivateContext::new(inputs, abi::hash_args([targetContract, targetSelector]));
+
+        let enqueueCallToChildSelector = 0x94015a34;
+        let _ret = context.call_private_function(context.this_address(), enqueueCallToChildSelector, [targetContract, targetSelector, 10]);
+        context.call_public_function(targetContract, targetSelector, [20]);
+
+        context.finish()
+    }
+
+    // Private function that enqueues two calls to a child contract: 
+    // - one issued directly from this function with value 20,
+    // - followed by one through a nested call to enqueueCallToChild with value 10.
+    fn enqueueCallsToChildWithNestedLast(
+        inputs: PrivateContextInputs,
+        targetContract: Field,
+        targetSelector: Field,
+    ) -> distinct pub abi::PrivateCircuitPublicInputs {
+        let mut context = PrivateContext::new(inputs, abi::hash_args([targetContract, targetSelector]));
+
+        context.call_public_function(targetContract, targetSelector, [20]);
+        let enqueueCallToChildSelector = 0x94015a34;
+        let _ret = context.call_private_function(context.this_address(), enqueueCallToChildSelector, [targetContract, targetSelector, 10]);
+
+        context.finish()
+    }
+
     // Private function to enqueue a call to the targetContract address using the selector and argument provided
     fn enqueueCallToChildTwice(
         inputs: PrivateContextInputs,


### PR DESCRIPTION
Introduces an `order` field in `PublicCallRequest` (that is not sent to cpp) which gets populated by the simulator, and used at the end to reorder the enqueued public function calls and the public call stack. The global order is kept by the simulator across nested calls, and increased when each oracle call to enqueue a public function is hit. This ordering can be reused for other side effects as well, and should mimic the transition counters solution proposed [here](https://discourse.aztec.network/t/identifying-the-ordering-of-state-access-across-contract-calls/382/12#transition-counters-for-private-calls-2).

Fixes #1624