### PR TITLE
deprecate `isMined()`

### DIFF
--- a/yarn-project/aztec.js/src/contract/sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract/sent_tx.ts
@@ -69,6 +69,9 @@ export class SentTx {
    * Resolves to true if the transaction status is 'MINED', false otherwise.
    * Throws an error if the transaction receipt cannot be fetched after the given timeout.
    *
+   * @deprecated Use wait() instead as it throws if the tx is not mined,
+   * while this would silently fail if the return value isn't checked explicitly.
+   *
    * @param opts - Options for configuring the waiting for the tx to be mined.
    * @returns A Promise that resolves to a boolean indicating if the transaction is mined or not.
    */


### PR DESCRIPTION
* `isMined()` doesn't throw an error if a tx was dropped or error-ed. So if a user were to use it on an `open` noir function that is failing an assertion, they would just get a silent failure when digging through the logs. `wait()` is a much better/cleaner solution!
* By deprecating, we ensure external devs won't use (or be confused about what to use - `isMined()` or `wait()`
* I didn't delete these yet because we have 100+ places where we use it and I don't want to spend my time rn on refactoring this.
