### PR TITLE
fix: fix paths in `barretenberg` bootstrap.sh script

### DIFF
--- a/circuits/cpp/barretenberg/cpp/bootstrap.sh
+++ b/circuits/cpp/barretenberg/cpp/bootstrap.sh
@@ -54,6 +54,7 @@ cd ./build
 cmake --build . --parallel --target grumpkin_srs_gen
 ./bin/grumpkin_srs_gen 8192
 echo "Generated Grumpkin SRS successfully"
+cd ../
 
 # Install wasi-sdk.
 ./scripts/install-wasi-sdk.sh


### PR DESCRIPTION
In https://github.com/AztecProtocol/aztec-packages/pull/1258, we added a `cd` into the build directory but didn't `cd` back out again. This means that all the paths for the rest of the script are incorrect.


# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [x] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
