### PR TITLE
fix: bb sync take 2

### DIFF
--- a/circuits/cpp/barretenberg/.gitrepo
+++ b/circuits/cpp/barretenberg/.gitrepo
@@ -7,6 +7,6 @@
 	remote = https://github.com/AztecProtocol/barretenberg
 	branch = master
 	commit = 3afc2438053f530e49fbebbdbadd8db8a630bb8c
-	parent = 347a38a54e0ea7f6da1b45a8640b8506c3712bb1
+	parent = 5f08fff8355671e883bef0380bf06313429d3e1d
 	method = merge
 	cmdver = 0.4.6

--- a/circuits/cpp/barretenberg/README.md
+++ b/circuits/cpp/barretenberg/README.md
@@ -2,6 +2,7 @@
 
 Barretenberg aims to be a stand-alone and well-specified library, but please see https://github.com/AztecProtocol/aztec-packages/edit/master/circuits/cpp/barretenberg for the authoritative source of this code. 
 The separate repository https://github.com/AztecProtocol/barretenberg is available if working on barretenberg independently of Aztec, however it is encouraged to develop in the context of Aztec to see if it will cause issues for Aztec end-to-end tests. 
+**Currently, merging only occurs in aztec-packages. This is a mirror-only repository until it matures. Legacy release merges need an admin**
 As the spec solidifies, this should be less of an issue. Aztec and Barretenberg are currently under heavy development.
 
 **This code is highly experimental, use at your own risk!**


### PR DESCRIPTION
A persistent bad commit got in there. For reference, the `parent` was wrong, and didn't get caught by the fixup script.