### PR TITLE
fix(acir): when retrying failed ACIR tests it should not use the default CLI argument

### DIFF
--- a/circuits/cpp/barretenberg/acir_tests/run_acir_tests.sh
+++ b/circuits/cpp/barretenberg/acir_tests/run_acir_tests.sh
@@ -61,7 +61,7 @@ function test() {
   else
     echo -e "\033[31mFAILED\033[0m"
     # Run again verbose.
-    $BB prove_and_verify -v -c $CRS_PATH
+    $BB prove_and_verify -v -c $CRS_PATH -b ./target/$dir_name.bytecode
     exit 1
   fi
 


### PR DESCRIPTION
If a test is ran and it fails, the script will try to re-run the test using verbose mode so that you can debug the failure.

Since we were not passing the flag for the bytecode, it will use the default path of `./target/main.bytecode` which would inevitably fail because all of the compiled tests are named after their directories, like `./target/1_mul.bytecode` .

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
