### PR TITLE
chore: re-enabling pubkey check

### DIFF
--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -92,10 +92,10 @@ export class AztecRPCServer implements AztecRPC {
 
   public async registerAccount(privKey: PrivateKey, account: CompleteAddress) {
     const pubKey = this.keyStore.addAccount(privKey);
-    // TODO: Re-enable this check once https://github.com/AztecProtocol/aztec-packages/issues/1556 is solved
-    // if (!pubKey.equals(account.publicKey)) {
-    //   throw new Error(`Public key mismatch: ${pubKey.toString()} != ${account.publicKey.toString()}`);
-    // }
+    if (!pubKey.equals(account.publicKey)) {
+      // The derived public key must match the one provided in the complete address
+      throw new Error(`Public key mismatch: ${pubKey.toString()} != ${account.publicKey.toString()}`);
+    }
     await this.db.addCompleteAddress(account);
     this.synchroniser.addAccount(pubKey, this.keyStore);
   }


### PR DESCRIPTION
I tried reproducing #1556 issue but it doesn't seem to occur anymore. For this reason the pubkey check can be re-enabled.

Fixes #1556 

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
