### PR TITLE
refactor: simplified AztecRpc.registerAccount function

### DIFF
--- a/yarn-project/acir-simulator/src/client/private_execution.test.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.test.ts
@@ -196,8 +196,8 @@ describe('Private Execution test suite', () => {
     };
 
     beforeEach(async () => {
-      const ownerCompleteAddress = await CompleteAddress.fromPrivateKey(ownerPk);
-      const recipientCompleteAddress = await CompleteAddress.fromPrivateKey(recipientPk);
+      const ownerCompleteAddress = await CompleteAddress.fromPrivateKeyAndPartialAddress(ownerPk, Fr.random());
+      const recipientCompleteAddress = await CompleteAddress.fromPrivateKeyAndPartialAddress(recipientPk, Fr.random());
 
       owner = ownerCompleteAddress.address;
       recipient = recipientCompleteAddress.address;
@@ -426,8 +426,8 @@ describe('Private Execution test suite', () => {
     };
 
     beforeEach(async () => {
-      const ownerCompleteAddress = await CompleteAddress.fromPrivateKey(ownerPk);
-      const recipientCompleteAddress = await CompleteAddress.fromPrivateKey(recipientPk);
+      const ownerCompleteAddress = await CompleteAddress.fromPrivateKeyAndPartialAddress(ownerPk, Fr.random());
+      const recipientCompleteAddress = await CompleteAddress.fromPrivateKeyAndPartialAddress(recipientPk, Fr.random());
 
       owner = ownerCompleteAddress.address;
       recipient = recipientCompleteAddress.address;
@@ -676,7 +676,7 @@ describe('Private Execution test suite', () => {
     let recipient: AztecAddress;
 
     beforeEach(async () => {
-      const recipientCompleteAddress = await CompleteAddress.fromPrivateKey(recipientPk);
+      const recipientCompleteAddress = await CompleteAddress.fromPrivateKeyAndPartialAddress(recipientPk, Fr.random());
       recipient = recipientCompleteAddress.address;
       oracle.getCompleteAddress.mockImplementation((address: AztecAddress) => {
         if (address.equals(recipient)) return Promise.resolve(recipientCompleteAddress);
@@ -816,7 +816,7 @@ describe('Private Execution test suite', () => {
     let owner: AztecAddress;
 
     beforeEach(async () => {
-      const ownerCompleteAddress = await CompleteAddress.fromPrivateKey(ownerPk);
+      const ownerCompleteAddress = await CompleteAddress.fromPrivateKeyAndPartialAddress(ownerPk, Fr.random());
 
       owner = ownerCompleteAddress.address;
 

--- a/yarn-project/acir-simulator/src/client/unconstrained_execution.test.ts
+++ b/yarn-project/acir-simulator/src/client/unconstrained_execution.test.ts
@@ -30,7 +30,7 @@ describe('Unconstrained Execution test suite', () => {
     };
 
     beforeEach(async () => {
-      const ownerCompleteAddress = await CompleteAddress.fromPrivateKey(ownerPk);
+      const ownerCompleteAddress = await CompleteAddress.fromPrivateKeyAndPartialAddress(ownerPk, Fr.random());
       owner = ownerCompleteAddress.address;
 
       oracle.getCompleteAddress.mockImplementation((address: AztecAddress) => {

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -10,6 +10,7 @@ import {
   FunctionData,
   KernelCircuitPublicInputs,
   MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX,
+  PartialAddress,
   PrivateKey,
   PublicCallRequest,
 } from '@aztec/circuits.js';
@@ -90,13 +91,10 @@ export class AztecRPCServer implements AztecRPC {
     this.log.info('Stopped');
   }
 
-  public async registerAccount(privKey: PrivateKey, account: CompleteAddress) {
+  public async registerAccount(privKey: PrivateKey, partialAddress: PartialAddress) {
     const pubKey = this.keyStore.addAccount(privKey);
-    if (!pubKey.equals(account.publicKey)) {
-      // The derived public key must match the one provided in the complete address
-      throw new Error(`Public key mismatch: ${pubKey.toString()} != ${account.publicKey.toString()}`);
-    }
-    await this.db.addCompleteAddress(account);
+    const completeAddress = await CompleteAddress.fromPrivateKeyAndPartialAddress(privKey, partialAddress);
+    await this.db.addCompleteAddress(completeAddress);
     this.synchroniser.addAccount(pubKey, this.keyStore);
   }
 

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/test/aztec_rpc_test_suite.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/test/aztec_rpc_test_suite.ts
@@ -19,7 +19,10 @@ export const aztecRpcTestSuite = (testName: string, aztecRpcSetup: () => Promise
 
     it('registers an account and returns it as an account only and not as a recipient', async () => {
       const keyPair = ConstantKeyPair.random(await Grumpkin.new());
-      const completeAddress = await CompleteAddress.fromPrivateKey(await keyPair.getPrivateKey());
+      const completeAddress = await CompleteAddress.fromPrivateKeyAndPartialAddress(
+        await keyPair.getPrivateKey(),
+        Fr.random(),
+      );
 
       await rpc.registerAccount(await keyPair.getPrivateKey(), completeAddress);
 
@@ -56,7 +59,10 @@ export const aztecRpcTestSuite = (testName: string, aztecRpcSetup: () => Promise
 
     it('cannot register the same account twice', async () => {
       const keyPair = ConstantKeyPair.random(await Grumpkin.new());
-      const completeAddress = await CompleteAddress.fromPrivateKey(await keyPair.getPrivateKey());
+      const completeAddress = await CompleteAddress.fromPrivateKeyAndPartialAddress(
+        await keyPair.getPrivateKey(),
+        Fr.random(),
+      );
 
       await rpc.registerAccount(await keyPair.getPrivateKey(), completeAddress);
       await expect(async () => rpc.registerAccount(await keyPair.getPrivateKey(), completeAddress)).rejects.toThrow(

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/test/aztec_rpc_test_suite.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/test/aztec_rpc_test_suite.ts
@@ -24,7 +24,7 @@ export const aztecRpcTestSuite = (testName: string, aztecRpcSetup: () => Promise
         Fr.random(),
       );
 
-      await rpc.registerAccount(await keyPair.getPrivateKey(), completeAddress);
+      await rpc.registerAccount(await keyPair.getPrivateKey(), completeAddress.partialAddress);
 
       // Check that the account is correctly registered using the getAccounts and getRecipients methods
       const accounts = await rpc.getAccounts();
@@ -64,10 +64,10 @@ export const aztecRpcTestSuite = (testName: string, aztecRpcSetup: () => Promise
         Fr.random(),
       );
 
-      await rpc.registerAccount(await keyPair.getPrivateKey(), completeAddress);
-      await expect(async () => rpc.registerAccount(await keyPair.getPrivateKey(), completeAddress)).rejects.toThrow(
-        `Complete address corresponding to ${completeAddress.address} already exists`,
-      );
+      await rpc.registerAccount(await keyPair.getPrivateKey(), completeAddress.partialAddress);
+      await expect(async () =>
+        rpc.registerAccount(await keyPair.getPrivateKey(), completeAddress.partialAddress),
+      ).rejects.toThrow(`Complete address corresponding to ${completeAddress.address} already exists`);
     });
 
     it('cannot register the same recipient twice', async () => {

--- a/yarn-project/aztec-rpc/src/synchroniser/synchroniser.test.ts
+++ b/yarn-project/aztec-rpc/src/synchroniser/synchroniser.test.ts
@@ -105,7 +105,7 @@ describe('Synchroniser', () => {
     const keyStore = new TestKeyStore(await Grumpkin.new());
     const privateKey = PrivateKey.random();
     keyStore.addAccount(privateKey);
-    const completeAddress = await CompleteAddress.fromPrivateKey(privateKey);
+    const completeAddress = await CompleteAddress.fromPrivateKeyAndPartialAddress(privateKey, Fr.random());
     await database.addCompleteAddress(completeAddress);
 
     // Add the account which will add the note processor to the synchroniser

--- a/yarn-project/aztec.js/src/account/account.ts
+++ b/yarn-project/aztec.js/src/account/account.ts
@@ -84,7 +84,7 @@ export class Account {
    */
   public async register(): Promise<AccountWallet> {
     const completeAddress = await this.getCompleteAddress();
-    await this.rpc.registerAccount(this.encryptionPrivateKey, completeAddress);
+    await this.rpc.registerAccount(this.encryptionPrivateKey, completeAddress.partialAddress);
     return this.getWallet();
   }
 

--- a/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
+++ b/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
@@ -1,4 +1,4 @@
-import { AztecAddress, CircuitsWasm, Fr, PrivateKey, TxContext } from '@aztec/circuits.js';
+import { AztecAddress, CircuitsWasm, Fr, PartialAddress, PrivateKey, TxContext } from '@aztec/circuits.js';
 import {
   AztecRPC,
   ContractData,
@@ -31,8 +31,8 @@ export abstract class BaseWallet implements Wallet {
 
   abstract createTxExecutionRequest(execs: FunctionCall[], opts?: CreateTxRequestOpts): Promise<TxExecutionRequest>;
 
-  registerAccount(privKey: PrivateKey, completeAddress: CompleteAddress): Promise<void> {
-    return this.rpc.registerAccount(privKey, completeAddress);
+  registerAccount(privKey: PrivateKey, partialAddress: PartialAddress): Promise<void> {
+    return this.rpc.registerAccount(privKey, partialAddress);
   }
   registerRecipient(account: CompleteAddress): Promise<void> {
     return this.rpc.registerRecipient(account);

--- a/yarn-project/aztec.js/src/utils/account.ts
+++ b/yarn-project/aztec.js/src/utils/account.ts
@@ -27,7 +27,7 @@ export async function createAccounts(
     const privKey = i == 0 && privateKey ? privateKey : PrivateKey.random();
     const publicKey = await generatePublicKey(privKey);
     const deploymentInfo = await getContractDeploymentInfo(accountContractAbi, [], salt, publicKey);
-    await aztecRpcClient.registerAccount(privKey, deploymentInfo.completeAddress);
+    await aztecRpcClient.registerAccount(privKey, deploymentInfo.completeAddress.partialAddress);
     const contractDeployer = new ContractDeployer(accountContractAbi, aztecRpcClient, publicKey);
     const tx = contractDeployer.deploy().send({ contractAddressSalt: salt });
     await tx.isMined({ interval: 0.5 });

--- a/yarn-project/circuits.js/src/types/complete_address.ts
+++ b/yarn-project/circuits.js/src/types/complete_address.ts
@@ -51,11 +51,10 @@ export class CompleteAddress {
     return new CompleteAddress(address, pubKey, partialAddress);
   }
 
-  static async fromPrivateKey(privateKey: PrivateKey): Promise<CompleteAddress> {
+  static async fromPrivateKeyAndPartialAddress(privateKey: PrivateKey, partialAddress: Fr): Promise<CompleteAddress> {
     const wasm = await CircuitsWasm.get();
     const grumpkin = new Grumpkin(wasm);
     const pubKey = grumpkin.mul(Grumpkin.generator, privateKey);
-    const partialAddress = Fr.random();
     const address = computeContractAddressFromPartial(wasm, pubKey, partialAddress);
     return new CompleteAddress(address, pubKey, partialAddress);
   }

--- a/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
@@ -45,7 +45,7 @@ describe('e2e_escrow_contract', () => {
     escrowPublicKey = await generatePublicKey(escrowPrivateKey);
     const salt = Fr.random();
     const deployInfo = await getContractDeploymentInfo(EscrowContractAbi, [owner], salt, escrowPublicKey);
-    await aztecRpcServer.registerAccount(escrowPrivateKey, deployInfo.completeAddress);
+    await aztecRpcServer.registerAccount(escrowPrivateKey, deployInfo.completeAddress.partialAddress);
 
     escrowContract = await EscrowContract.deployWithPublicKey(wallet, escrowPublicKey, owner)
       .send({ contractAddressSalt: salt })

--- a/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
@@ -161,7 +161,7 @@ describe('e2e_p2p_network', () => {
     const aztecRpcServer = await createAztecRPCServer(node, rpcConfig, {}, true);
 
     const keyPair = ConstantKeyPair.random(await Grumpkin.new());
-    const completeAddress = await CompleteAddress.fromPrivateKey(await keyPair.getPrivateKey());
+    const completeAddress = await CompleteAddress.fromPrivateKeyAndPartialAddress(await keyPair.getPrivateKey());
     await aztecRpcServer.registerAccount(await keyPair.getPrivateKey(), completeAddress);
 
     const txs = await submitTxsTo(aztecRpcServer, completeAddress.address, numTxs, completeAddress.publicKey);

--- a/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
@@ -161,8 +161,11 @@ describe('e2e_p2p_network', () => {
     const aztecRpcServer = await createAztecRPCServer(node, rpcConfig, {}, true);
 
     const keyPair = ConstantKeyPair.random(await Grumpkin.new());
-    const completeAddress = await CompleteAddress.fromPrivateKeyAndPartialAddress(await keyPair.getPrivateKey());
-    await aztecRpcServer.registerAccount(await keyPair.getPrivateKey(), completeAddress);
+    const completeAddress = await CompleteAddress.fromPrivateKeyAndPartialAddress(
+      await keyPair.getPrivateKey(),
+      Fr.random(),
+    );
+    await aztecRpcServer.registerAccount(await keyPair.getPrivateKey(), completeAddress.partialAddress);
 
     const txs = await submitTxsTo(aztecRpcServer, completeAddress.address, numTxs, completeAddress.publicKey);
     return {

--- a/yarn-project/types/src/interfaces/aztec_rpc.ts
+++ b/yarn-project/types/src/interfaces/aztec_rpc.ts
@@ -1,4 +1,4 @@
-import { AztecAddress, EthAddress, Fr, PrivateKey } from '@aztec/circuits.js';
+import { AztecAddress, EthAddress, Fr, PartialAddress, PrivateKey } from '@aztec/circuits.js';
 import { ContractAbi } from '@aztec/foundation/abi';
 import {
   CompleteAddress,
@@ -67,11 +67,11 @@ export interface AztecRPC {
    * Registers an account in the Aztec RPC server.
    *
    * @param privKey - Private key of the corresponding user master public key.
-   * @param account - A complete address of the account.
+   * @param partialAddress - A partial address of the account contract corresponding to the account being registered.
    * @returns Empty promise.
    * @throws If the account is already registered.
    */
-  registerAccount(privKey: PrivateKey, account: CompleteAddress): Promise<void>;
+  registerAccount(privKey: PrivateKey, partialAddress: PartialAddress): Promise<void>;
 
   /**
    * Registers recipient in the Aztec RPC server.


### PR DESCRIPTION
Refactored `AztecRpc.registerAddress` to take in `PartialAddress` instead of a "full" `CompleteAddress`.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
