### PR TITLE
fix: clang version in README and subrepo edge case

### DIFF
--- a/circuits/cpp/barretenberg/.gitrepo
+++ b/circuits/cpp/barretenberg/.gitrepo
@@ -7,6 +7,6 @@
 	remote = https://github.com/AztecProtocol/barretenberg
 	branch = master
 	commit = 9b6fc607d7c7de57033d10fd8a3e1c424e400a5b
-	parent = 3b4bb999a720a67517f9b3318db33f4d6488f492
+	parent = 0039c4fdf7c713d9f375d6abda15353325e38d56
 	method = merge
 	cmdver = 0.4.6

--- a/circuits/cpp/barretenberg/.gitrepo
+++ b/circuits/cpp/barretenberg/.gitrepo
@@ -7,6 +7,6 @@
 	remote = https://github.com/AztecProtocol/barretenberg
 	branch = master
 	commit = 9b6fc607d7c7de57033d10fd8a3e1c424e400a5b
-	parent = 0039c4fdf7c713d9f375d6abda15353325e38d56
+	parent = 3b4bb999a720a67517f9b3318db33f4d6488f492
 	method = merge
 	cmdver = 0.4.6

--- a/circuits/cpp/barretenberg/README.md
+++ b/circuits/cpp/barretenberg/README.md
@@ -11,7 +11,7 @@ As the spec solidifies, this should be less of an issue. Aztec and Barretenberg 
 
 - cmake >= 3.24
 - Ninja (used by the presets as the default generator)
-- clang >= 10 or gcc >= 10
+- clang >= 16 or gcc >= 10
 - clang-format
 - libomp (if multithreading is required. Multithreading can be disabled using the compiler flag `-DMULTITHREADING 0`)
 

--- a/scripts/fix_subrepo_edge_case.sh
+++ b/scripts/fix_subrepo_edge_case.sh
@@ -1,0 +1,25 @@
+# git subrepo is quite nice, but has one flaw in our workflow:
+# We frequently squash commits in PRs, and we might update the .gitrepo file
+# with a parent commit that later does not exist. 
+# A backup heuristic is used to later find the squashed commit's parent
+# using the .gitrepo file's git history. This might be brittle 
+# in the face of e.g. a .gitrepo whitespace change, but it's a fallback, 
+# we only have this issue in master, and the file should only be edited
+# generally by subrepo commands.
+set -eu
+
+SUBREPO_PATH="${1:-}"
+echo "Auto-fixing squashed parent in $SUBREPO_PATH/.gitrepo."
+
+# Get the commit that last wrote to .gitrepo
+last_commit=$(git log -1 --pretty=format:%H -- "$SUBREPO_PATH/.gitrepo")
+# Get parent of the last commit
+new_parent=$(git log --pretty=%P -n 1 $last_commit)
+
+# Update parent in .gitrepo file
+git config --file="$SUBREPO_PATH/.gitrepo" subrepo.parent $new_parent
+
+# Commit this change
+git add "$SUBREPO_PATH/.gitrepo"
+# This commit should only go into squashed PRs
+git commit -m "git_subrepo.sh: Fix parent in .gitrepo file."

--- a/scripts/git_subrepo.sh
+++ b/scripts/git_subrepo.sh
@@ -31,6 +31,7 @@ fi
 # Capture both stdout and stderr to a variable
 output=$("$SCRIPT_DIR/git-subrepo/lib/git-subrepo" "$@" 2>&1)
 
+echo $output
 # Check for the specific error message
 if echo "$output" | grep -q "doesn't contain upstream HEAD"; then
     "$SCRIPT_DIR/fix_subrepo_edge_case.sh" "$SUBREPO_PATH"

--- a/scripts/git_subrepo.sh
+++ b/scripts/git_subrepo.sh
@@ -33,13 +33,12 @@ run_subrepo() {
     local exit_code="${PIPESTATUS[0]}"  # Capture the exit status of git-subrepo command
 
     if [ $exit_code -ne 0 ]; then
-        # Check for the specific error message
+        # Check for the specific error message and maybe recover
         if grep -q "doesn't contain upstream HEAD" /tmp/subrepo_output.log; then
             "$SCRIPT_DIR/fix_subrepo_edge_case.sh" "$SUBREPO_PATH"
             echo "Rerunning..."
             "$SCRIPT_DIR/git-subrepo/lib/git-subrepo" "$@"
         else
-            echo "An unknown error occurred."
             exit $exit_code
         fi
     fi

--- a/scripts/git_subrepo.sh
+++ b/scripts/git_subrepo.sh
@@ -34,7 +34,7 @@ output=$("$SCRIPT_DIR/git-subrepo/lib/git-subrepo" "$@" 2>&1)
 # Check for the specific error message
 if echo "$output" | grep -q "doesn't contain upstream HEAD"; then
     "$SCRIPT_DIR/fix_subrepo_edge_case.sh" "$SUBREPO_PATH"
-    echo "Rerunning 
+    echo "Rerunning"
     #"$SCRIPT_DIR"/git-subrepo/lib/git-subrepo $@
 else
     # Forward the output (both stdout and stderr)

--- a/scripts/git_subrepo.sh
+++ b/scripts/git_subrepo.sh
@@ -29,7 +29,7 @@ fi
 
 # Try our first pass
 # Capture both stdout and stderr to a variable
-output=$("$SCRIPT_DIR/git-subrepo/lib/git-subrepo" "$@" 2>&1)
+output=$("$SCRIPT_DIR/git-subrepo/lib/git-subrepo" "$@" 2>&1 || true)
 
 echo $output
 # Check for the specific error message


### PR DESCRIPTION
- document clang 16 needed
- It seems bad parents can still get stuck even though we try to detect them. Let's catch the error message.