### PR TITLE
feat: add bbjs testing workflow

### DIFF
--- a/circuits/cpp/barretenberg/.github/workflows/bbjs-testing.yml
+++ b/circuits/cpp/barretenberg/.github/workflows/bbjs-testing.yml
@@ -1,0 +1,66 @@
+name: Test bb.js
+
+on:
+  push:
+    branches:
+      - jb/bbjs-testing
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install bleeding edge cmake
+        run: |
+          sudo apt -y remove --purge cmake
+          sudo snap install cmake --classic
+
+      - name: Create Build Environment
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install ninja-build yarn
+
+      - name: Install Clang16
+        run: |
+          wget https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.0/clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+          tar -xvf clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+          sudo cp clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04/bin/* /usr/local/bin/
+          sudo cp -r clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04/include/* /usr/local/include/
+          sudo cp -r clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04/lib/* /usr/local/lib/
+          sudo cp -r clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04/share/* /usr/local/share/
+
+      - name: Install yarn
+        run: |
+          curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+          echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+          sudo apt -y update && sudo apt -y install yarn
+      - name: Compile Barretenberg
+        run: |
+          cd cpp
+
+          cmake --preset default -DCMAKE_BUILD_TYPE=RelWithAssert
+          cmake --build --preset default --target bb
+
+      - name: Install WASI-SDK
+        run: |
+          cd cpp
+          ./scripts/install-wasi-sdk.sh
+
+      - name: Compile Typescript
+        run: |
+          cd ts
+          yarn install && yarn && yarn build
+
+      - name: Output result
+        run: |
+          cd ts/dest
+          ls -R

--- a/circuits/cpp/barretenberg/.github/workflows/bbjs-testing.yml
+++ b/circuits/cpp/barretenberg/.github/workflows/bbjs-testing.yml
@@ -56,7 +56,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: noir-lang/nextjs-bbjs-demo
-          ref: bbjs-tests
           path: nextjs-bbjs-demo
 
       - name: Update package.json to point to local tarball dependency

--- a/circuits/cpp/barretenberg/.github/workflows/bbjs-testing.yml
+++ b/circuits/cpp/barretenberg/.github/workflows/bbjs-testing.yml
@@ -3,10 +3,11 @@ name: Test bb.js
 on:
   push:
     branches:
-      - jb/bbjs-testing
+      - "**"
 
 jobs:
   build:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
 
     steps:
@@ -29,26 +30,11 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install ninja-build yarn
 
-      - name: Install Clang16
-        run: |
-          wget https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.0/clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-          tar -xvf clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-          sudo cp clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04/bin/* /usr/local/bin/
-          sudo cp -r clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04/include/* /usr/local/include/
-          sudo cp -r clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04/lib/* /usr/local/lib/
-          sudo cp -r clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04/share/* /usr/local/share/
-
       - name: Install yarn
         run: |
           curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
           echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
           sudo apt -y update && sudo apt -y install yarn
-      - name: Compile Barretenberg
-        run: |
-          cd cpp
-
-          cmake --preset default -DCMAKE_BUILD_TYPE=RelWithAssert
-          cmake --build --preset default --target bb
 
       - name: Install WASI-SDK
         run: |
@@ -60,7 +46,37 @@ jobs:
           cd ts
           yarn install && yarn && yarn build
 
-      - name: Output result
+      - name: Pack the library for npm
         run: |
-          cd ts/dest
-          ls -R
+          cd ts
+          npm pack
+          echo "TARBALL_NAME=$(ls *.tgz)" >> $GITHUB_ENV
+
+      - name: Checkout nextjs-bbjs-demo repository
+        uses: actions/checkout@v3
+        with:
+          repository: noir-lang/nextjs-bbjs-demo
+          ref: bbjs-tests
+          path: nextjs-bbjs-demo
+
+      - name: Update package.json to point to local tarball dependency
+        run: |
+          jq ".dependencies[\"@aztec/bb.js\"] = \"file:../ts/${TARBALL_NAME}\"" nextjs-bbjs-demo/package.json > nextjs-bbjs-demo/package.temp.json
+          mv nextjs-bbjs-demo/package.temp.json nextjs-bbjs-demo/package.json
+          cat nextjs-bbjs-demo/package.json
+
+      - name: Install dependencies in nextjs-bbjs-demo
+        run: |
+          cd nextjs-bbjs-demo
+          npm install
+
+      - name: Output bb.js package contents
+        run: |
+          cd nextjs-bbjs-demo/node_modules/@aztec/bb.js
+
+      - name: Run dev and test scripts concurrently
+        run: |
+          cd nextjs-bbjs-demo
+          npm run dev
+          sleep 30
+          npm run test


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow named `Test bb.js`. The purpose of this workflow is to automate the testing and building process for our `bb.js` library in the browser.

**Key Features of the Workflow:**
- Compiles the TypeScript code and packs the library for npm.
- Integrates with the `nextjs-bbjs-demo` repository for testing.
- Runs development and test scripts for thorough validation.

Links to: https://github.com/noir-lang/noir/issues/2252

This workflow is tested here: https://github.com/AztecProtocol/barretenberg/pull/702

Needs this to be merged: https://github.com/noir-lang/nextjs-bbjs-demo/pull/1