### PR TITLE
refactor: consistent block number method naming

### DIFF
--- a/docs/docs/dev_docs/getting_started/cli.md
+++ b/docs/docs/dev_docs/getting_started/cli.md
@@ -28,7 +28,7 @@ Lets first establish that we are able to communicate with the Sandbox. Most comm
 
 To test communication with the Sandbox, let's run the command:
 
-`% aztec-cli block-height
+`% aztec-cli block-number
 1`
 
 You should see the current block number (1) printed to the screen!

--- a/docs/docs/dev_docs/getting_started/cli.md
+++ b/docs/docs/dev_docs/getting_started/cli.md
@@ -28,10 +28,10 @@ Lets first establish that we are able to communicate with the Sandbox. Most comm
 
 To test communication with the Sandbox, let's run the command:
 
-`% aztec-cli block-number
-0`
+`% aztec-cli block-height
+1`
 
-You should see the current block number (0) printed to the screen!
+You should see the current block number (1) printed to the screen!
 
 ## Contracts
 

--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -42,7 +42,7 @@ describe('Archiver', () => {
       1000,
     );
 
-    let latestBlockNum = await archiver.getBlockHeight();
+    let latestBlockNum = await archiver.getBlockNumber();
     expect(latestBlockNum).toEqual(0);
 
     const blocks = blockNums.map(x => L2Block.random(x, 4, x, x + 1, x * 2, x * 3));
@@ -95,11 +95,11 @@ describe('Archiver', () => {
     await archiver.start(false);
 
     // Wait until block 3 is processed. If this won't happen the test will fail with timeout.
-    while ((await archiver.getBlockHeight()) !== 3) {
+    while ((await archiver.getBlockNumber()) !== 3) {
       await sleep(100);
     }
 
-    latestBlockNum = await archiver.getBlockHeight();
+    latestBlockNum = await archiver.getBlockNumber();
     expect(latestBlockNum).toEqual(3);
 
     // Check that only 2 messages (l1ToL2MessageAddedEvents[3][2] and l1ToL2MessageAddedEvents[3][3]) are pending.

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -353,8 +353,8 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
    * Gets the number of the latest L2 block processed by the block source implementation.
    * @returns The number of the latest L2 block processed by the block source implementation.
    */
-  public getBlockHeight(): Promise<number> {
-    return this.store.getBlockHeight();
+  public getBlockNumber(): Promise<number> {
+    return this.store.getBlockNumber();
   }
 
   /**

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -127,7 +127,7 @@ export interface ArchiverDataStore {
    * Gets the number of the latest L2 block processed.
    * @returns The number of the latest L2 block processed.
    */
-  getBlockHeight(): Promise<number>;
+  getBlockNumber(): Promise<number>;
 
   /**
    * Gets the length of L2 blocks in store.
@@ -382,7 +382,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
    * Gets the number of the latest L2 block processed.
    * @returns The number of the latest L2 block processed.
    */
-  public getBlockHeight(): Promise<number> {
+  public getBlockNumber(): Promise<number> {
     if (this.l2Blocks.length === 0) return Promise.resolve(INITIAL_L2_BLOCK_NUM - 1);
     return Promise.resolve(this.l2Blocks[this.l2Blocks.length - 1].number);
   }

--- a/yarn-project/aztec-cli/README.md
+++ b/yarn-project/aztec-cli/README.md
@@ -409,21 +409,21 @@ Example usage:
 aztec-cli get-logs 1000 10
 ```
 
-### block-height
+### block-number
 
-Gets the current Aztec L2 block number/block height.
+Gets the current Aztec L2 block number.
 
 Syntax:
 
 ```shell
-aztec-cli block-height
+aztec-cli block-number
 ```
 
 Options:
 
 - `-u, --rpc-url <string>`: URL of the Aztec RPC. Default: `http://localhost:8080`.
 
-This command retrieves and displays the current Aztec L2 block number/block height.
+This command retrieves and displays the current Aztec L2 block number.
 
 ### example-contracts
 

--- a/yarn-project/aztec-cli/README.md
+++ b/yarn-project/aztec-cli/README.md
@@ -409,21 +409,21 @@ Example usage:
 aztec-cli get-logs 1000 10
 ```
 
-### block-num
+### block-height
 
-Gets the current Aztec L2 block number.
+Gets the current Aztec L2 block number/block height.
 
 Syntax:
 
 ```shell
-aztec-cli block-number
+aztec-cli block-height
 ```
 
 Options:
 
 - `-u, --rpc-url <string>`: URL of the Aztec RPC. Default: `http://localhost:8080`.
 
-This command retrieves and displays the current Aztec L2 block number.
+This command retrieves and displays the current Aztec L2 block number/block height.
 
 ### example-contracts
 

--- a/yarn-project/aztec-cli/src/index.ts
+++ b/yarn-project/aztec-cli/src/index.ts
@@ -459,12 +459,12 @@ export function getProgram(log: LogFn, debugLogger: DebugLogger): Command {
     });
 
   program
-    .command('block-height')
-    .description('Gets the current Aztec L2 block height.')
+    .command('block-number')
+    .description('Gets the current Aztec L2 block number.')
     .option('-u, --rpcUrl <string>', 'URL of the Aztec RPC', AZTEC_RPC_HOST || 'http://localhost:8080')
     .action(async (options: any) => {
       const client = createClient(options.rpcUrl);
-      const num = await client.getBlockHeight();
+      const num = await client.getBlockNumber();
       log(`${num}\n`);
     });
 

--- a/yarn-project/aztec-cli/src/index.ts
+++ b/yarn-project/aztec-cli/src/index.ts
@@ -459,12 +459,12 @@ export function getProgram(log: LogFn, debugLogger: DebugLogger): Command {
     });
 
   program
-    .command('block-number')
-    .description('Gets the current Aztec L2 block number.')
+    .command('block-height')
+    .description('Gets the current Aztec L2 block height.')
     .option('-u, --rpcUrl <string>', 'URL of the Aztec RPC', AZTEC_RPC_HOST || 'http://localhost:8080')
     .action(async (options: any) => {
       const client = createClient(options.rpcUrl);
-      const num = await client.getBlockNum();
+      const num = await client.getBlockHeight();
       log(`${num}\n`);
     });
 

--- a/yarn-project/aztec-node/src/aztec-node/http-node.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/http-node.test.ts
@@ -109,14 +109,14 @@ describe('HttpNode', () => {
     });
   });
 
-  describe('getBlockHeight', () => {
-    it('should fetch and return the block height', async () => {
-      const response = { blockHeight: 100 };
+  describe('getBlockNumber', () => {
+    it('should fetch and return current block number', async () => {
+      const response = { blockNumber: 100 };
       setFetchMock(response);
 
-      const result = await httpNode.getBlockHeight();
+      const result = await httpNode.getBlockNumber();
 
-      expect(fetch).toHaveBeenCalledWith(`${TEST_URL}get-block-height`);
+      expect(fetch).toHaveBeenCalledWith(`${TEST_URL}get-block-number`);
       expect(result).toBe(100);
     });
   });

--- a/yarn-project/aztec-node/src/aztec-node/http-node.ts
+++ b/yarn-project/aztec-node/src/aztec-node/http-node.ts
@@ -79,14 +79,14 @@ export class HttpNode implements AztecNode {
   }
 
   /**
-   * Method to fetch the current block height.
-   * @returns The block height as a number.
+   * Method to fetch the current block number.
+   * @returns The current block number.
    */
-  async getBlockHeight(): Promise<number> {
-    const url = new URL(`${this.baseUrl}/get-block-height`);
+  async getBlockNumber(): Promise<number> {
+    const url = new URL(`${this.baseUrl}/get-block-number`);
     const response = await fetch(url.toString());
     const respJson = await response.json();
-    return respJson.blockHeight;
+    return respJson.blockNumber;
   }
 
   /**

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -138,11 +138,11 @@ export class AztecNodeService implements AztecNode {
   }
 
   /**
-   * Method to fetch the current block height.
-   * @returns The block height as a number.
+   * Method to fetch the current block number.
+   * @returns The block number.
    */
-  public async getBlockHeight(): Promise<number> {
-    return await this.blockSource.getBlockHeight();
+  public async getBlockNumber(): Promise<number> {
+    return await this.blockSource.getBlockNumber();
   }
 
   /**
@@ -382,7 +382,7 @@ export class AztecNodeService implements AztecNode {
    * @returns A promise that fulfils once the world state is synced
    */
   private async syncWorldState() {
-    const blockSourceHeight = await this.blockSource.getBlockHeight();
+    const blockSourceHeight = await this.blockSource.getBlockNumber();
     await this.worldStateSynchroniser.syncImmediate(blockSourceHeight);
   }
 }

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -155,9 +155,9 @@ export class AztecRPCServer implements AztecRPC {
   }
 
   public async getBlock(blockNumber: number): Promise<L2Block | undefined> {
-    // If a negative block number is provided the current block height is fetched.
+    // If a negative block number is provided the current block number is fetched.
     if (blockNumber < 0) {
-      blockNumber = await this.node.getBlockHeight();
+      blockNumber = await this.node.getBlockNumber();
     }
     return await this.node.getBlock(blockNumber);
   }
@@ -241,8 +241,8 @@ export class AztecRPCServer implements AztecRPC {
     return partialReceipt;
   }
 
-  async getBlockHeight(): Promise<number> {
-    return await this.node.getBlockHeight();
+  async getBlockNumber(): Promise<number> {
+    return await this.node.getBlockNumber();
   }
 
   public async getContractDataAndBytecode(contractAddress: AztecAddress): Promise<ContractDataAndBytecode | undefined> {

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -241,7 +241,7 @@ export class AztecRPCServer implements AztecRPC {
     return partialReceipt;
   }
 
-  async getBlockNum(): Promise<number> {
+  async getBlockHeight(): Promise<number> {
     return await this.node.getBlockHeight();
   }
 

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/test/aztec_rpc_server.test.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/test/aztec_rpc_server.test.ts
@@ -18,7 +18,7 @@ async function createAztecRpcServer(): Promise<AztecRPC> {
   };
 
   // Setup the relevant mocks
-  node.getBlockHeight.mockResolvedValue(2);
+  node.getBlockNumber.mockResolvedValue(2);
   node.getVersion.mockResolvedValue(1);
   node.getChainId.mockResolvedValue(1);
   node.getRollupAddress.mockResolvedValue(EthAddress.random());

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/test/aztec_rpc_test_suite.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/test/aztec_rpc_test_suite.ts
@@ -120,7 +120,7 @@ export const aztecRpcTestSuite = (testName: string, aztecRpcSetup: () => Promise
     //       functions only call AztecNode and these methods are frequently used by the e2e tests.
 
     it('successfully gets a block number', async () => {
-      const blockNum = await rpc.getBlockNum();
+      const blockNum = await rpc.getBlockHeight();
       expect(blockNum).toBeGreaterThanOrEqual(INITIAL_L2_BLOCK_NUM);
     });
 

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/test/aztec_rpc_test_suite.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/test/aztec_rpc_test_suite.ts
@@ -120,7 +120,7 @@ export const aztecRpcTestSuite = (testName: string, aztecRpcSetup: () => Promise
     //       functions only call AztecNode and these methods are frequently used by the e2e tests.
 
     it('successfully gets a block number', async () => {
-      const blockNum = await rpc.getBlockHeight();
+      const blockNum = await rpc.getBlockNumber();
       expect(blockNum).toBeGreaterThanOrEqual(INITIAL_L2_BLOCK_NUM);
     });
 

--- a/yarn-project/aztec-rpc/src/note_processor/note_processor.ts
+++ b/yarn-project/aztec-rpc/src/note_processor/note_processor.ts
@@ -49,15 +49,15 @@ export class NoteProcessor {
   ) {}
 
   /**
-   * Check if the NoteProcessor is synchronised with the remote block height.
-   * The function queries the remote block height from the AztecNode and compares it with the syncedToBlock value in the NoteProcessor.
+   * Check if the NoteProcessor is synchronised with the remote block number.
+   * The function queries the remote block number from the AztecNode and compares it with the syncedToBlock value in the NoteProcessor.
    * If the values are equal, then the NoteProcessor is considered to be synchronised, otherwise not.
    *
-   * @returns A boolean indicating whether the NoteProcessor is synchronised with the remote block height or not.
+   * @returns A boolean indicating whether the NoteProcessor is synchronised with the remote block number or not.
    */
   public async isSynchronised() {
-    const remoteBlockHeight = await this.node.getBlockHeight();
-    return this.syncedToBlock === remoteBlockHeight;
+    const remoteBlockNumber = await this.node.getBlockNumber();
+    return this.syncedToBlock === remoteBlockNumber;
   }
 
   /**

--- a/yarn-project/aztec-rpc/src/synchroniser/synchroniser.test.ts
+++ b/yarn-project/aztec-rpc/src/synchroniser/synchroniser.test.ts
@@ -33,7 +33,7 @@ describe('Synchroniser', () => {
   });
 
   it('sets tree roots from aztec node on initial sync', async () => {
-    aztecNode.getBlockHeight.mockResolvedValue(3);
+    aztecNode.getBlockNumber.mockResolvedValue(3);
     aztecNode.getHistoricBlockData.mockResolvedValue(blockData);
 
     await synchroniser.initialSync();
@@ -52,9 +52,9 @@ describe('Synchroniser', () => {
     expect(roots[MerkleTreeId.CONTRACT_TREE]).toEqual(block.endContractTreeSnapshot.root);
   });
 
-  it('overrides tree roots from initial sync once block height is larger', async () => {
+  it('overrides tree roots from initial sync once current block number is larger', async () => {
     // Initial sync is done on block with height 3
-    aztecNode.getBlockHeight.mockResolvedValue(3);
+    aztecNode.getBlockNumber.mockResolvedValue(3);
     aztecNode.getHistoricBlockData.mockResolvedValue(blockData);
 
     await synchroniser.initialSync();
@@ -99,7 +99,7 @@ describe('Synchroniser', () => {
     await synchroniser.work();
 
     // Used in synchroniser.isAccountStateSynchronised
-    aztecNode.getBlockHeight.mockResolvedValueOnce(1);
+    aztecNode.getBlockNumber.mockResolvedValueOnce(1);
 
     // Manually adding account to database so that we can call synchroniser.isAccountStateSynchronised
     const keyStore = new TestKeyStore(await Grumpkin.new());

--- a/yarn-project/aztec-rpc/src/synchroniser/synchroniser.ts
+++ b/yarn-project/aztec-rpc/src/synchroniser/synchroniser.ts
@@ -19,7 +19,7 @@ export class Synchroniser {
   private noteProcessors: NoteProcessor[] = [];
   private interruptableSleep = new InterruptableSleep();
   private running = false;
-  private initialSyncBlockHeight = 0;
+  private initialSyncBlockNumber = 0;
   private synchedToBlock = 0;
   private log: DebugLogger;
   private noteProcessorsToCatchUp: NoteProcessor[] = [];
@@ -68,11 +68,11 @@ export class Synchroniser {
 
   protected async initialSync() {
     const [blockNumber, historicBlockData] = await Promise.all([
-      this.node.getBlockHeight(),
+      this.node.getBlockNumber(),
       this.node.getHistoricBlockData(),
     ]);
-    this.initialSyncBlockHeight = blockNumber;
-    this.synchedToBlock = this.initialSyncBlockHeight;
+    this.initialSyncBlockNumber = blockNumber;
+    this.synchedToBlock = this.initialSyncBlockNumber;
     await this.db.setHistoricBlockData(historicBlockData);
   }
 
@@ -193,7 +193,7 @@ export class Synchroniser {
 
   private async setBlockDataFromBlock(latestBlock: L2BlockContext) {
     const { block } = latestBlock;
-    if (block.number < this.initialSyncBlockHeight) return;
+    if (block.number < this.initialSyncBlockNumber) return;
 
     const wasm = await CircuitsWasm.get();
     const globalsHash = computeGlobalsHash(wasm, latestBlock.block.globalVariables);
@@ -266,10 +266,10 @@ export class Synchroniser {
    * Checks whether all the blocks were processed (tree roots updated, txs updated with block info, etc.).
    * @returns True if there are no outstanding blocks to be synched.
    * @remarks This indicates that blocks and transactions are synched even if notes are not.
-   * @remarks Compares local block height with the block height from aztec node.
+   * @remarks Compares local block number with the block number from aztec node.
    */
   public async isGlobalStateSynchronised() {
-    const latest = await this.node.getBlockHeight();
+    const latest = await this.node.getBlockNumber();
     return latest <= this.synchedToBlock;
   }
 

--- a/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
+++ b/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
@@ -79,8 +79,8 @@ export abstract class BaseWallet implements Wallet {
   getUnencryptedLogs(from: number, limit: number): Promise<L2BlockL2Logs[]> {
     return this.rpc.getUnencryptedLogs(from, limit);
   }
-  getBlockHeight(): Promise<number> {
-    return this.rpc.getBlockHeight();
+  getBlockNumber(): Promise<number> {
+    return this.rpc.getBlockNumber();
   }
   getNodeInfo(): Promise<NodeInfo> {
     return this.rpc.getNodeInfo();

--- a/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
+++ b/yarn-project/aztec.js/src/aztec_rpc_client/wallet.ts
@@ -79,8 +79,8 @@ export abstract class BaseWallet implements Wallet {
   getUnencryptedLogs(from: number, limit: number): Promise<L2BlockL2Logs[]> {
     return this.rpc.getUnencryptedLogs(from, limit);
   }
-  getBlockNum(): Promise<number> {
-    return this.rpc.getBlockNum();
+  getBlockHeight(): Promise<number> {
+    return this.rpc.getBlockHeight();
   }
   getNodeInfo(): Promise<NodeInfo> {
     return this.rpc.getNodeInfo();

--- a/yarn-project/aztec.js/src/utils/cheat_codes.ts
+++ b/yarn-project/aztec.js/src/utils/cheat_codes.ts
@@ -252,7 +252,7 @@ export class AztecCheatCodes {
    * @returns The current block number
    */
   public async blockNumber(): Promise<number> {
-    return await this.aztecRpc.getBlockHeight();
+    return await this.aztecRpc.getBlockNumber();
   }
 
   /**

--- a/yarn-project/aztec.js/src/utils/cheat_codes.ts
+++ b/yarn-project/aztec.js/src/utils/cheat_codes.ts
@@ -252,7 +252,7 @@ export class AztecCheatCodes {
    * @returns The current block number
    */
   public async blockNumber(): Promise<number> {
-    return await this.aztecRpc.getBlockNum();
+    return await this.aztecRpc.getBlockHeight();
   }
 
   /**

--- a/yarn-project/end-to-end/src/e2e_ordering.test.ts
+++ b/yarn-project/end-to-end/src/e2e_ordering.test.ts
@@ -17,7 +17,7 @@ describe('e2e_ordering', () => {
   let wallet: Wallet;
 
   const expectLogsFromLastBlockToBe = async (logMessages: bigint[]) => {
-    const l2BlockNum = await aztecRpcServer.getBlockNum();
+    const l2BlockNum = await aztecRpcServer.getBlockHeight();
     const unencryptedLogs = await aztecRpcServer.getUnencryptedLogs(l2BlockNum, 1);
     const unrolledLogs = L2BlockL2Logs.unrollLogs(unencryptedLogs);
     const bigintLogs = unrolledLogs.map((log: Buffer) => toBigIntBE(log));

--- a/yarn-project/end-to-end/src/e2e_ordering.test.ts
+++ b/yarn-project/end-to-end/src/e2e_ordering.test.ts
@@ -17,7 +17,7 @@ describe('e2e_ordering', () => {
   let wallet: Wallet;
 
   const expectLogsFromLastBlockToBe = async (logMessages: bigint[]) => {
-    const l2BlockNum = await aztecRpcServer.getBlockHeight();
+    const l2BlockNum = await aztecRpcServer.getBlockNumber();
     const unencryptedLogs = await aztecRpcServer.getUnencryptedLogs(l2BlockNum, 1);
     const unrolledLogs = L2BlockL2Logs.unrollLogs(unencryptedLogs);
     const bigintLogs = unrolledLogs.map((log: Buffer) => toBigIntBE(log));

--- a/yarn-project/end-to-end/src/e2e_pending_commitments_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_pending_commitments_contract.test.ts
@@ -30,7 +30,7 @@ describe('e2e_pending_commitments_contract', () => {
   });
 
   const expectCommitmentsSquashedExcept = async (exceptFirstFew: number) => {
-    const blockNum = await aztecNode!.getBlockHeight();
+    const blockNum = await aztecNode!.getBlockNumber();
     const block = (await aztecNode!.getBlocks(blockNum, 1))[0];
 
     // all new commitments should be zero (should be squashed)
@@ -44,7 +44,7 @@ describe('e2e_pending_commitments_contract', () => {
   };
 
   const expectNullifiersSquashedExcept = async (exceptFirstFew: number) => {
-    const blockNum = await aztecNode!.getBlockHeight();
+    const blockNum = await aztecNode!.getBlockNumber();
     const block = (await aztecNode!.getBlocks(blockNum, 1))[0];
 
     // 0th nullifier should be nonzero (txHash), all others should be zero (should be squashed)

--- a/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
@@ -27,7 +27,7 @@ describe('e2e_public_token_contract', () => {
   };
 
   const expectLogsFromLastBlockToBe = async (logMessages: string[]) => {
-    const l2BlockNum = await aztecRpcServer.getBlockNum();
+    const l2BlockNum = await aztecRpcServer.getBlockHeight();
     const unencryptedLogs = await aztecRpcServer.getUnencryptedLogs(l2BlockNum, 1);
     const unrolledLogs = L2BlockL2Logs.unrollLogs(unencryptedLogs);
     const asciiLogs = unrolledLogs.map(log => log.toString('ascii'));

--- a/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
@@ -27,7 +27,7 @@ describe('e2e_public_token_contract', () => {
   };
 
   const expectLogsFromLastBlockToBe = async (logMessages: string[]) => {
-    const l2BlockNum = await aztecRpcServer.getBlockHeight();
+    const l2BlockNum = await aztecRpcServer.getBlockNumber();
     const unencryptedLogs = await aztecRpcServer.getUnencryptedLogs(l2BlockNum, 1);
     const unrolledLogs = L2BlockL2Logs.unrollLogs(unencryptedLogs);
     const asciiLogs = unrolledLogs.map(log => log.toString('ascii'));

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -418,7 +418,7 @@ export const expectsNumOfEncryptedLogsInTheLastBlockToBe = async (
     // This means we can't perform this check if there is no node
     return;
   }
-  const l2BlockNum = await aztecNode.getBlockHeight();
+  const l2BlockNum = await aztecNode.getBlockNumber();
   const encryptedLogs = await aztecNode.getLogs(l2BlockNum, 1, LogType.ENCRYPTED);
   const unrolledLogs = L2BlockL2Logs.unrollLogs(encryptedLogs);
   expect(unrolledLogs.length).toBe(numEncryptedLogs);
@@ -439,7 +439,7 @@ export const expectUnencryptedLogsFromLastBlockToBe = async (
     // This means we can't perform this check if there is no node
     return;
   }
-  const l2BlockNum = await aztecNode.getBlockHeight();
+  const l2BlockNum = await aztecNode.getBlockNumber();
   const unencryptedLogs = await aztecNode.getLogs(l2BlockNum, 1, LogType.UNENCRYPTED);
   const unrolledLogs = L2BlockL2Logs.unrollLogs(unencryptedLogs);
   const asciiLogs = unrolledLogs.map(log => log.toString('ascii'));

--- a/yarn-project/p2p/src/client/mocks.ts
+++ b/yarn-project/p2p/src/client/mocks.ts
@@ -26,7 +26,7 @@ export class MockBlockSource implements L2BlockSource {
    * Gets the number of the latest L2 block processed by the block source implementation.
    * @returns In this mock instance, returns the number of L2 blocks that we've mocked.
    */
-  public getBlockHeight() {
+  public getBlockNumber() {
     return Promise.resolve(this.l2Blocks.length - 1);
   }
 

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -142,7 +142,7 @@ export class P2PClient implements P2P {
     }
 
     // get the current latest block number
-    this.latestBlockNumberAtStart = await this.l2BlockSource.getBlockHeight();
+    this.latestBlockNumberAtStart = await this.l2BlockSource.getBlockNumber();
 
     const blockToDownloadFrom = this.currentL2BlockNum + 1;
 

--- a/yarn-project/rollup-provider/src/app.ts
+++ b/yarn-project/rollup-provider/src/app.ts
@@ -69,10 +69,10 @@ export function appFactory(node: AztecNode, prefix: string) {
     ctx.status = 200;
   });
 
-  router.get('/get-block-height', async (ctx: Koa.Context) => {
+  router.get('/get-block-number', async (ctx: Koa.Context) => {
     ctx.set('content-type', 'application/json');
     ctx.body = {
-      blockHeight: await node.getBlockHeight(),
+      blockNumber: await node.getBlockNumber(),
     };
     ctx.status = 200;
   });

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -65,7 +65,7 @@ describe('sequencer', () => {
     });
 
     l2BlockSource = mock<L2BlockSource>({
-      getBlockHeight: () => Promise.resolve(lastBlockNumber),
+      getBlockNumber: () => Promise.resolve(lastBlockNumber),
     });
 
     l1ToL2MessageSource = mock<L1ToL2MessageSource>({

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -140,7 +140,7 @@ export class Sequencer {
       this.log(`Processing ${validTxs.length} txs...`);
       this.state = SequencerState.CREATING_BLOCK;
 
-      const blockNumber = (await this.l2BlockSource.getBlockHeight()) + 1;
+      const blockNumber = (await this.l2BlockSource.getBlockNumber()) + 1;
       const newGlobalVariables = await this.globalsBuilder.buildGlobalVariables(new Fr(blockNumber));
       const prevGlobalVariables = (await this.l2BlockSource.getL2Block(-1))?.globalVariables ?? GlobalVariables.empty();
 

--- a/yarn-project/types/src/interfaces/aztec-node.ts
+++ b/yarn-project/types/src/interfaces/aztec-node.ts
@@ -43,8 +43,8 @@ export interface AztecNode extends DataCommitmentProvider, L1ToL2MessageProvider
   getBlocks(from: number, limit: number): Promise<L2Block[]>;
 
   /**
-   * Method to fetch the current block height.
-   * @returns The block height as a number.
+   * Fetches the current block height (number of L2 blocks ever produced).
+   * @returns The block height.
    */
   getBlockHeight(): Promise<number>;
 

--- a/yarn-project/types/src/interfaces/aztec-node.ts
+++ b/yarn-project/types/src/interfaces/aztec-node.ts
@@ -43,10 +43,10 @@ export interface AztecNode extends DataCommitmentProvider, L1ToL2MessageProvider
   getBlocks(from: number, limit: number): Promise<L2Block[]>;
 
   /**
-   * Fetches the current block height (number of L2 blocks ever produced).
-   * @returns The block height.
+   * Fetches the current block number.
+   * @returns The block number.
    */
-  getBlockHeight(): Promise<number>;
+  getBlockNumber(): Promise<number>;
 
   /**
    * Method to fetch the version of the rollup the node is connected to.

--- a/yarn-project/types/src/interfaces/aztec_rpc.ts
+++ b/yarn-project/types/src/interfaces/aztec_rpc.ts
@@ -203,10 +203,10 @@ export interface AztecRPC {
   getUnencryptedLogs(from: number, limit: number): Promise<L2BlockL2Logs[]>;
 
   /**
-   * Fetches the current block height (number of L2 blocks ever produced).
-   * @returns The block height.
+   * Fetches the current block number.
+   * @returns The block number.
    */
-  getBlockHeight(): Promise<number>;
+  getBlockNumber(): Promise<number>;
 
   /**
    * Returns the information about the server's node
@@ -218,7 +218,7 @@ export interface AztecRPC {
    * Checks whether all the blocks were processed (tree roots updated, txs updated with block info, etc.).
    * @returns True if there are no outstanding blocks to be synched.
    * @remarks This indicates that blocks and transactions are synched even if notes are not.
-   * @remarks Compares local block height with the block height from aztec node.
+   * @remarks Compares local block number with the block number from aztec node.
    */
   isGlobalStateSynchronised(): Promise<boolean>;
 

--- a/yarn-project/types/src/interfaces/aztec_rpc.ts
+++ b/yarn-project/types/src/interfaces/aztec_rpc.ts
@@ -203,10 +203,10 @@ export interface AztecRPC {
   getUnencryptedLogs(from: number, limit: number): Promise<L2BlockL2Logs[]>;
 
   /**
-   * Get latest L2 block number.
-   * @returns The latest block number.
+   * Fetches the current block height (number of L2 blocks ever produced).
+   * @returns The block height.
    */
-  getBlockNum(): Promise<number>;
+  getBlockHeight(): Promise<number>;
 
   /**
    * Returns the information about the server's node

--- a/yarn-project/types/src/l2_block_source.ts
+++ b/yarn-project/types/src/l2_block_source.ts
@@ -16,7 +16,7 @@ export interface L2BlockSource {
    * Gets the number of the latest L2 block processed by the block source implementation.
    * @returns The number of the latest L2 block processed by the block source implementation.
    */
-  getBlockHeight(): Promise<number>;
+  getBlockNumber(): Promise<number>;
 
   /**
    * Gets an l2 block. If a negative number is passed, the block returned is the most recent.

--- a/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.test.ts
+++ b/yarn-project/world-state/src/synchroniser/server_world_state_synchroniser.test.ts
@@ -107,8 +107,8 @@ const createSynchroniser = (merkleTreeDb: any, rollupSource: any, blockCheckInte
 const log = createDebugLogger('aztec:server_world_state_synchroniser_test');
 
 describe('server_world_state_synchroniser', () => {
-  const rollupSource: Mockify<Pick<L2BlockSource, 'getBlockHeight' | 'getL2Blocks'>> = {
-    getBlockHeight: jest.fn().mockImplementation(getLatestBlockNumber),
+  const rollupSource: Mockify<Pick<L2BlockSource, 'getBlockNumber' | 'getL2Blocks'>> = {
+    getBlockNumber: jest.fn().mockImplementation(getLatestBlockNumber),
     getL2Blocks: jest.fn().mockImplementation(consumeNextBlocks),
   };
 
@@ -265,7 +265,7 @@ describe('server_world_state_synchroniser', () => {
 
   it('immediately syncs if no new blocks', async () => {
     const server = createSynchroniser(merkleTreeDb, rollupSource);
-    rollupSource.getBlockHeight.mockImplementationOnce(() => {
+    rollupSource.getBlockNumber.mockImplementationOnce(() => {
       return Promise.resolve(0);
     });
 
@@ -283,7 +283,7 @@ describe('server_world_state_synchroniser', () => {
 
   it("can't be started if already stopped", async () => {
     const server = createSynchroniser(merkleTreeDb, rollupSource);
-    rollupSource.getBlockHeight.mockImplementationOnce(() => {
+    rollupSource.getBlockNumber.mockImplementationOnce(() => {
       return Promise.resolve(0);
     });
 
@@ -395,7 +395,7 @@ describe('server_world_state_synchroniser', () => {
       .fill(0)
       .map((_, index: number) => getMockBlock(index + 1 + LATEST_BLOCK_NUMBER));
     await expect(server.syncImmediate(LATEST_BLOCK_NUMBER + 5)).rejects.toThrow(
-      `Unable to sync to block height ${LATEST_BLOCK_NUMBER + 5}, currently synced to block ${LATEST_BLOCK_NUMBER + 2}`,
+      `Unable to sync to block number ${LATEST_BLOCK_NUMBER + 5}, currently synced to block ${LATEST_BLOCK_NUMBER + 2}`,
     );
 
     let status = await server.status();

--- a/yarn-project/world-state/src/synchroniser/world_state_synchroniser.ts
+++ b/yarn-project/world-state/src/synchroniser/world_state_synchroniser.ts
@@ -46,11 +46,11 @@ export interface WorldStateSynchroniser {
   stop(): Promise<void>;
 
   /**
-   * Forces an immediate sync to an optionally provided minimum block height
-   * @param blockHeight - The minimum block height that we must sync to
+   * Forces an immediate sync to an optionally provided minimum block number
+   * @param minBlockNumber - The minimum block number that we must sync to
    * @returns A promise that resolves once the sync has completed.
    */
-  syncImmediate(blockHeight?: number): Promise<void>;
+  syncImmediate(minBlockNumber?: number): Promise<void>;
 
   /**
    * Returns an instance of MerkleTreeOperations that will include uncommitted data.


### PR DESCRIPTION
Renamed `AztecRPC.getBlockNum` to `getBlockNumber` and`AztecNode.getBlockHeight` to `getBlockNumber`. I decided to use the name block number because in the Ethereum JSON RPC spec there is `eth_blockNumber` call and I think it's a good idea to use the same naming.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
