### PR TITLE
chore: Sandbox logging tweaks

### DIFF
--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -97,9 +97,10 @@ export class AztecRPCServer implements AztecRPC {
     if (wasAdded) {
       const pubKey = this.keyStore.addAccount(privKey);
       this.synchroniser.addAccount(pubKey, this.keyStore);
-      this.log.info(`Added account: ${completeAddress.toReadableString()}`);
+      this.log.info(`Registered account ${completeAddress.address.toString()}`);
+      this.log.debug(`Registered ${completeAddress.toReadableString()}`);
     } else {
-      this.log.info(`Account "${completeAddress.toReadableString()}" already registered.`);
+      this.log.info(`Account "${completeAddress.address.toString()}" already registered.`);
     }
   }
 

--- a/yarn-project/aztec-sandbox/docker-compose-fork.yml
+++ b/yarn-project/aztec-sandbox/docker-compose-fork.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - '8080:8080'
     environment:
-      DEBUG: 'aztec:*,wasm'
+      DEBUG: 'aztec:*'
       ETHEREUM_HOST: http://fork:8545
       CHAIN_ID: 31337
       ARCHIVER_POLLING_INTERVAL_MS: 50

--- a/yarn-project/aztec-sandbox/docker-compose.yml
+++ b/yarn-project/aztec-sandbox/docker-compose.yml
@@ -1,18 +1,18 @@
 version: '3'
 services:
-  fork:
-    image: ghcr.io/foundry-rs/foundry:nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43
-    entrypoint: 'anvil -p 8545 --host 0.0.0.0 --chain-id 31337'
+  ethereum:
+    image: ghcr.io/foundry-rs/foundry:v1.0.0
+    command: '"anvil --silent -p 8545 --host 0.0.0.0 --chain-id 31337"'
     ports:
       - '8545:8545'
 
-  rpc-server:
+  aztec:
     image: aztecprotocol/aztec-sandbox:latest
     ports:
       - '8080:8080'
     environment:
-      DEBUG: 'aztec:*,wasm'
-      ETHEREUM_HOST: http://fork:8545
+      DEBUG: # DEBUG is loaded from the user shell running compose
+      ETHEREUM_HOST: http://ethereum:8545
       CHAIN_ID: 31337
       ARCHIVER_POLLING_INTERVAL_MS: 50
       P2P_BLOCK_CHECK_INTERVAL_MS: 50

--- a/yarn-project/aztec-sandbox/package.json
+++ b/yarn-project/aztec-sandbox/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "prepare": "node ../yarn-project-base/scripts/update_build_manifest.mjs package.json",
     "build": "yarn clean && tsc -b",
-    "start": "node ./dest",
+    "start": "node --no-warnings ./dest",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T prettier -w ./src",

--- a/yarn-project/aztec-sandbox/src/index.ts
+++ b/yarn-project/aztec-sandbox/src/index.ts
@@ -62,6 +62,8 @@ async function main() {
   const hdAccount = mnemonicToAccount(MNEMONIC);
   const privKey = hdAccount.getHdKey().privateKey;
 
+  logger.info('Setting up Aztec Sandbox, please stand by...');
+  logger.info('Deploying rollup contracts to L1...');
   const deployedL1Contracts = await waitThenDeploy(aztecNodeConfig.rpcUrl, hdAccount);
   aztecNodeConfig.publisherPrivateKey = new PrivateKey(Buffer.from(privKey!));
   aztecNodeConfig.rollupContract = deployedL1Contracts.rollupAddress;
@@ -71,11 +73,11 @@ async function main() {
   const aztecNode = await AztecNodeService.createAndSync(aztecNodeConfig);
   const aztecRpcServer = await createAztecRPCServer(aztecNode, rpcConfig);
 
-  logger('Deploying initial accounts...');
+  logger.info('Setting up test accounts...');
   const accounts = await deployInitialSandboxAccounts(aztecRpcServer);
 
   const shutdown = async () => {
-    logger('Shutting down...');
+    logger.info('Shutting down...');
     await aztecRpcServer.stop();
     await aztecNode.stop();
     process.exit(0);

--- a/yarn-project/canary/package.json
+++ b/yarn-project/canary/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T prettier -w ./src",
-    "test": "DEBUG='aztec:*,wasm' NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --runInBand --passWithNoTests --testTimeout=15000"
+    "test": "DEBUG='aztec:*' NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --runInBand --passWithNoTests --testTimeout=15000"
   },
   "jest": {
     "preset": "ts-jest/presets/default-esm",

--- a/yarn-project/canary/scripts/docker-compose-e2e-sandbox.yml
+++ b/yarn-project/canary/scripts/docker-compose-e2e-sandbox.yml
@@ -15,7 +15,7 @@ services:
   sandbox:
     image: $ECR_URL/aztec-sandbox:cache-$COMMIT_HASH
     environment:
-      DEBUG: 'aztec:*,wasm'
+      DEBUG: 'aztec:*'
       ETHEREUM_HOST: http://fork:8545
       CHAIN_ID: 31337
       ARCHIVER_POLLING_INTERVAL_MS: 50

--- a/yarn-project/canary/scripts/docker-compose.yml
+++ b/yarn-project/canary/scripts/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   sandbox:
     image: aztecprotocol/aztec-sandbox:latest
     environment:
-      DEBUG: 'aztec:*,wasm'
+      DEBUG: 'aztec:*'
       ETHEREUM_HOST: http://fork:8545
       CHAIN_ID: 31337
       ARCHIVER_POLLING_INTERVAL_MS: 50

--- a/yarn-project/circuits.js/src/wasm/circuits_wasm.ts
+++ b/yarn-project/circuits.js/src/wasm/circuits_wasm.ts
@@ -62,7 +62,7 @@ export class CircuitsWasm implements IWasmModule {
    * @param loggerName - The logger name.
    * @returns The wrapper.
    */
-  private static async new(initial = 30, maximum = 8192, loggerName = 'wasm'): Promise<CircuitsWasm> {
+  private static async new(initial = 30, maximum = 8192, loggerName = 'aztec:wasm'): Promise<CircuitsWasm> {
     const wasm = new WasmModule(
       await fetchBinary(CODE_PATH),
       module => ({

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -11,7 +11,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src \"!src/web/main.js\" && run -T eslint ./src",
     "formatting:fix": "run -T prettier -w ./src",
-    "test": "DEBUG='aztec:*,wasm' NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --runInBand --passWithNoTests --testTimeout=15000",
+    "test": "DEBUG='aztec:*' NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --runInBand --passWithNoTests --testTimeout=15000",
     "test:integration": "concurrently -k -s first -c reset,dim -n test,anvil \"yarn test:integration:run\" \"anvil\"",
     "test:integration:run": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --no-cache --runInBand --config jest.integration.config.json"
   },

--- a/yarn-project/end-to-end/scripts/docker-compose-e2e-sandbox.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose-e2e-sandbox.yml
@@ -15,7 +15,7 @@ services:
   sandbox:
     image: aztecprotocol/aztec-sandbox:latest
     environment:
-      DEBUG: 'aztec:*,wasm'
+      DEBUG: 'aztec:*'
       ETHEREUM_HOST: http://fork:8545
       CHAIN_ID: 31337
       ARCHIVER_POLLING_INTERVAL_MS: 50

--- a/yarn-project/foundation/src/wasm/wasm_module.ts
+++ b/yarn-project/foundation/src/wasm/wasm_module.ts
@@ -59,7 +59,7 @@ export class WasmModule implements IWasmModule {
   constructor(
     private module: WebAssembly.Module | Buffer,
     private importFn: (module: WasmModule) => any,
-    loggerName = 'wasm',
+    loggerName = 'aztec:wasm',
   ) {
     this.debug = createDebugOnlyLogger(loggerName);
     this.mutexQ.put(true);


### PR DESCRIPTION
Packages a bunch of tweaks to Sandbox debugging and logging, such as:
- Wasm debug logs are now prefixed as `aztec:wasm`, not `wasm`, so they are visible when debugging via `aztec:*`
- Defaults sandbox logging to INFO instead of DEBUG
- Allows users to configure sandbox debug by exporting `DEBUG='aztec:*'` in their shell (related to #1605)
- Silences all anvil logs since they didn't provide any useful info (fixes #1580)
- Renames container names in the sandbox docker-compose (anvil was not running a fork, and the sandbox is not just an rpc-server)