### PR TITLE
chore(ci): Trigger barretenberg CI re-run

### DIFF
--- a/build-system/scripts/build
+++ b/build-system/scripts/build
@@ -131,7 +131,7 @@ for STAGE in $STAGES; do
   CACHE_FROM="--cache-from $STAGE_IMAGE_COMMIT_URI $CACHE_FROM"
 
   echo "Pushing stage: $STAGE"
-  docker push $STAGE_IMAGE_COMMIT_URI > /dev/null 2>&1
+  docker push $STAGE_IMAGE_COMMIT_URI > /dev/null
   echo
 done
 
@@ -151,5 +151,5 @@ echo "Building image: $IMAGE_COMMIT_URI"
 docker build -t $IMAGE_COMMIT_URI -f $DOCKERFILE $CACHE_FROM --build-arg COMMIT_TAG=$COMMIT_TAG --build-arg ARG_COMMIT_HASH=$COMMIT_HASH . \
   | while read line ; do echo "$(date "+%H:%M:%S")| $line"; done
 echo "Pushing image: $IMAGE_COMMIT_URI"
-docker push $IMAGE_COMMIT_URI > /dev/null 2>&1
+docker push $IMAGE_COMMIT_URI > /dev/null
 untag_remote_image $REPOSITORY tainted

--- a/build-system/scripts/tag_remote_image
+++ b/build-system/scripts/tag_remote_image
@@ -31,5 +31,5 @@ if [ "$EXISTING_TAG_MANIFEST" != "$NEW_TAG_MANIFEST" ]; then
     --region $REGION \
     --repository-name $REPOSITORY \
     --image-tag $NEW_TAG \
-    --image-manifest "$EXISTING_TAG_MANIFEST" > /dev/null 2>&1
+    --image-manifest "$EXISTING_TAG_MANIFEST" > /dev/null
 fi

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -62,6 +62,7 @@ bool proveAndVerify(const std::string& bytecodePath, const std::string& witnessP
     std::cout << verified << std::endl;
     return verified;
 }
+
 /**
  * @brief Creates a proof for an ACIR circuit
  *


### PR DESCRIPTION
Job `barretenberg-x86_64-linux-clang-fuzzing` is failing on master because:
```
An error occurred (LimitExceededException) when calling the PutImage operation (reached max retries: 2): Adding tag 'cache-f6329bac2a788b0fe690244c0c7db4fdc9441240' to an image in the repository with name 'barretenberg-x86_64-linux-clang-fuzzing' in registry with id '278380418400' exceeds the maximum allowed number of tags per image which is '1000'
```

This adds a newline within the bb rebuild-patterns so the bb image gets rebuilt, and we stop throwing tags on top of the same image.