### PR TITLE
fix: selector name regression

### DIFF
--- a/circuits/cpp/src/aztec3/circuits/abis/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/.test.cpp
@@ -51,8 +51,8 @@ TEST(abi_tests, native_read_write_call_context)
 TEST(abi_tests, native_read_write_function_data)
 {
     FunctionData<NT> const function_data = {
-        .function_selector =
-            FunctionSelector<NT>{
+        .selector =
+            {
                 .value = 11,
             },
         .is_private = false,
@@ -70,8 +70,8 @@ TEST(abi_tests, native_read_write_function_data)
 TEST(abi_tests, native_to_circuit_function_data)
 {
     FunctionData<NT> const native_function_data = {
-        .function_selector =
-            FunctionSelector<NT>{
+        .selector =
+            {
                 .value = 11,
             },
         .is_private = false,

--- a/circuits/cpp/src/aztec3/circuits/abis/c_bind.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/c_bind.test.cpp
@@ -125,7 +125,7 @@ TEST(abi_tests, hash_tx_request)
     EXPECT_EQ(got_hash, tx_request.hash());
 }
 
-TEST(abi_tests, compute_function_selector_transfer)
+TEST(abi_tests, compute_selector_transfer)
 {
     const char* function_signature = "transfer(address,uint256)";
 
@@ -191,8 +191,8 @@ TEST(abi_tests, compute_function_leaf)
 {
     // Construct FunctionLeafPreimage with some randomized fields
     auto const preimage = FunctionLeafPreimage<NT>{
-        .function_selector =
-            FunctionSelector<NT>{
+        .selector =
+            {
                 .value = engine.get_random_uint32(),
             },
         .is_private = static_cast<bool>(engine.get_random_uint8() & 1),
@@ -282,8 +282,8 @@ TEST(abi_tests, compute_function_tree)
 TEST(abi_tests, hash_constructor)
 {
     // Randomize required values
-    auto const func_data = FunctionData<NT>{ .function_selector =
-                                                 FunctionSelector<NT>{
+    auto const func_data = FunctionData<NT>{ .selector =
+                                                 {
                                                      .value = 10,
                                                  },
                                              .is_private = true,

--- a/circuits/cpp/src/aztec3/circuits/abis/function_data.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/function_data.hpp
@@ -18,17 +18,17 @@ template <typename NCT> struct FunctionData {
     using boolean = typename NCT::boolean;
     using fr = typename NCT::fr;
 
-    FunctionSelector<NCT> function_selector;
+    FunctionSelector<NCT> selector;
     boolean is_internal = false;
     boolean is_private = false;
     boolean is_constructor = false;
 
-    MSGPACK_FIELDS(function_selector, is_internal, is_private, is_constructor);
+    MSGPACK_FIELDS(selector, is_internal, is_private, is_constructor);
 
     boolean operator==(FunctionData<NCT> const& other) const
     {
-        return function_selector == other.function_selector && is_internal == other.is_internal &&
-               is_private == other.is_private && is_constructor == other.is_constructor;
+        return selector == other.selector && is_internal == other.is_internal && is_private == other.is_private &&
+               is_constructor == other.is_constructor;
     };
 
     template <typename Builder> FunctionData<CircuitTypes<Builder>> to_circuit_type(Builder& builder) const
@@ -39,7 +39,7 @@ template <typename NCT> struct FunctionData {
         auto to_ct = [&](auto& e) { return aztec3::utils::types::to_ct(builder, e); };
 
         FunctionData<CircuitTypes<Builder>> function_data = {
-            function_selector.to_circuit_type(builder),
+            selector.to_circuit_type(builder),
             to_ct(is_internal),
             to_ct(is_private),
             to_ct(is_constructor),
@@ -55,7 +55,7 @@ template <typename NCT> struct FunctionData {
         auto to_nt = [&](auto& e) { return aztec3::utils::types::to_nt<Builder>(e); };
 
         FunctionData<NativeTypes> function_data = {
-            to_native_type(function_selector),
+            to_native_type(selector),
             to_nt(is_internal),
             to_nt(is_private),
             to_nt(is_constructor),
@@ -68,7 +68,7 @@ template <typename NCT> struct FunctionData {
     {
         static_assert(!(std::is_same<NativeTypes, NCT>::value));
 
-        function_selector.set_public();
+        selector.set_public();
         fr(is_internal).set_public();
         fr(is_private).set_public();
         fr(is_constructor).set_public();
@@ -78,7 +78,7 @@ template <typename NCT> struct FunctionData {
     fr hash() const
     {
         std::vector<fr> const inputs = {
-            fr(function_selector.value),
+            fr(selector.value),
             fr(is_internal),
             fr(is_private),
             fr(is_constructor),

--- a/circuits/cpp/src/aztec3/circuits/abis/function_leaf_preimage.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/function_leaf_preimage.hpp
@@ -17,7 +17,7 @@ using std::is_same;
  * Templated on NativeTypes/CircuitTypes.
  *
  * @details A FunctionLeafPreimage contains:
- * - `function_selector` keccak hash of function signature truncated to NUM_FUNCTION_SELECTOR_BYTES
+ * - `selector` keccak hash of function signature truncated to NUM_FUNCTION_SELECTOR_BYTES
  * - `is_private` boolean flag
  * - `vk_hash` pedersen hash of the function verification key
  * - `acir_hash` hash of the function's acir bytecode
@@ -32,19 +32,19 @@ template <typename NCT> struct FunctionLeafPreimage {
     using fr = typename NCT::fr;
     using uint32 = typename NCT::uint32;
 
-    FunctionSelector<NCT> function_selector = {};
+    FunctionSelector<NCT> selector = {};
     boolean is_internal = false;
     boolean is_private = false;
     fr vk_hash = 0;
     fr acir_hash = 0;
 
     // For serialization, update with new fields
-    MSGPACK_FIELDS(function_selector, is_internal, is_private, vk_hash, acir_hash);
+    MSGPACK_FIELDS(selector, is_internal, is_private, vk_hash, acir_hash);
 
     boolean operator==(FunctionLeafPreimage<NCT> const& other) const
     {
-        return function_selector == other.function_selector && is_internal == other.is_internal &&
-               is_private == other.is_private && vk_hash == other.vk_hash && acir_hash == other.acir_hash;
+        return selector == other.selector && is_internal == other.is_internal && is_private == other.is_private &&
+               vk_hash == other.vk_hash && acir_hash == other.acir_hash;
     };
 
     template <typename Builder> FunctionLeafPreimage<CircuitTypes<Builder>> to_circuit_type(Builder& builder) const
@@ -55,11 +55,7 @@ template <typename NCT> struct FunctionLeafPreimage {
         auto to_ct = [&](auto& e) { return aztec3::utils::types::to_ct(builder, e); };
 
         FunctionLeafPreimage<CircuitTypes<Builder>> preimage = {
-            function_selector.to_circuit_type(builder),
-            to_ct(is_internal),
-            to_ct(is_private),
-            to_ct(vk_hash),
-            to_ct(acir_hash),
+            selector.to_circuit_type(builder), to_ct(is_internal), to_ct(is_private), to_ct(vk_hash), to_ct(acir_hash),
         };
 
         return preimage;
@@ -72,7 +68,7 @@ template <typename NCT> struct FunctionLeafPreimage {
         auto to_nt = [&](auto& e) { return aztec3::utils::types::to_nt<Builder>(e); };
 
         FunctionLeafPreimage<NativeTypes> preimage = {
-            to_native_type(function_selector), to_nt(is_internal), to_nt(is_private), to_nt(vk_hash), to_nt(acir_hash),
+            to_native_type(selector), to_nt(is_internal), to_nt(is_private), to_nt(vk_hash), to_nt(acir_hash),
         };
 
         return preimage;
@@ -82,7 +78,7 @@ template <typename NCT> struct FunctionLeafPreimage {
     {
         static_assert(!(std::is_same<NativeTypes, NCT>::value));
 
-        function_selector.set_public();
+        selector.set_public();
         fr(is_internal).set_public();
         fr(is_private).set_public();
         vk_hash.set_public();
@@ -92,7 +88,7 @@ template <typename NCT> struct FunctionLeafPreimage {
     fr hash() const
     {
         std::vector<fr> const inputs = {
-            function_selector.value, fr(is_internal), fr(is_private), vk_hash, acir_hash,
+            selector.value, fr(is_internal), fr(is_private), vk_hash, acir_hash,
         };
         return NCT::compress(inputs, GeneratorIndex::FUNCTION_LEAF);
     }

--- a/circuits/cpp/src/aztec3/circuits/abis/function_selector.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/function_selector.hpp
@@ -29,11 +29,11 @@ template <typename NCT> struct FunctionSelector {
         // Capture the circuit builder:
         auto to_ct = [&](auto& e) { return aztec3::utils::types::to_ct(builder, e); };
 
-        FunctionSelector<CircuitTypes<Builder>> function_selector = {
+        FunctionSelector<CircuitTypes<Builder>> selector = {
             to_ct(value),
         };
 
-        return function_selector;
+        return selector;
     };
 
     template <typename Builder> FunctionSelector<NativeTypes> to_native_type() const
@@ -41,11 +41,11 @@ template <typename NCT> struct FunctionSelector {
         static_assert(std::is_same<CircuitTypes<Builder>, NCT>::value);
         auto to_nt = [&](auto& e) { return aztec3::utils::types::to_nt<Builder>(e); };
 
-        FunctionSelector<NativeTypes> function_selector = {
+        FunctionSelector<NativeTypes> selector = {
             to_nt(value),
         };
 
-        return function_selector;
+        return selector;
     };
 
     void set_public()

--- a/circuits/cpp/src/aztec3/circuits/apps/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/.test.cpp
@@ -75,8 +75,8 @@ class state_var_tests : public ::testing::Test {
             uint256_t(0x01071e9a23e0f7edULL, 0x5d77b35d1830fa3eULL, 0xc6ba3660bb1f0c0bULL, 0x2ef9f7f09867fd6eULL));
 
         FunctionData<NT> const function_data{
-            .function_selector =
-                FunctionSelector<NT>{
+            .selector =
+                {
                     .value = 1,  // TODO: deduce this from the contract, somehow.
                 },
             .is_private = true,

--- a/circuits/cpp/src/aztec3/circuits/apps/contract.tpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/contract.tpp
@@ -23,8 +23,8 @@ template <typename NCT> void Contract<NCT>::set_functions(std::vector<FunctionDe
             throw_or_abort("Name already exists");
         }
         function_datas[function.name] = FunctionData<NCT>{
-            .function_selector =
-                FunctionSelector<NT>{
+            .selector =
+                {
                     .value = static_cast<uint32>(i),
                 },
             .is_private = function.is_private,

--- a/circuits/cpp/src/aztec3/circuits/apps/function_execution_context.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/function_execution_context.hpp
@@ -178,8 +178,8 @@ template <typename Builder> class FunctionExecutionContext {
 
         const FunctionData<CT> f_function_data_ct{
             // Note: we MUST
-            .function_selector =
-                FunctionSelector<CT>{
+            .selector =
+                {
                     .value = f_encoding_ct,
                 },
             .is_private = true,

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/escrow/.test.cpp
@@ -16,8 +16,8 @@ class escrow_tests : public ::testing::Test {
             uint256_t(0x01071e9a23e0f7edULL, 0x5d77b35d1830fa3eULL, 0xc6ba3660bb1f0c0bULL, 0x2ef9f7f09867fd6eULL));
 
         FunctionData<NT> const function_data{
-            .function_selector =
-                FunctionSelector<NT>{
+            .selector =
+                {
                     .value = 1,  // TODO: deduce this from the contract, somehow.
                 },
             .is_private = true,

--- a/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/.test.cpp
@@ -22,8 +22,8 @@ TEST(private_to_private_function_call_tests, circuit_private_to_private_function
         uint256_t(0x01071e9a23e0f7edULL, 0x5d77b35d1830fa3eULL, 0xc6ba3660bb1f0c0bULL, 0x2ef9f7f09867fd6eULL);
 
     const FunctionData<NT> function_data{
-        .function_selector =
-            FunctionSelector<NT>{
+        .selector =
+            {
                 .value = 1,  // TODO: deduce this from the contract, somehow.
             },
         .is_private = true,

--- a/circuits/cpp/src/aztec3/circuits/hash.hpp
+++ b/circuits/cpp/src/aztec3/circuits/hash.hpp
@@ -295,7 +295,7 @@ void check_membership(Builder& builder,
  * @brief Calculate the function tree root from the sibling path and leaf preimage.
  *
  * @tparam NCT (native or circuit)
- * @param function_selector in leaf preimage
+ * @param selector in leaf preimage
  * @param is_internal in leaf preimage
  * @param is_private in leaf preimage
  * @param vk_hash in leaf preimage
@@ -305,7 +305,7 @@ void check_membership(Builder& builder,
  * @return NCT::fr
  */
 template <typename NCT> typename NCT::fr function_tree_root_from_siblings(
-    FunctionSelector<NCT> const& function_selector,
+    FunctionSelector<NCT> const& selector,
     typename NCT::boolean const& is_internal,
     typename NCT::boolean const& is_private,
     typename NCT::fr const& vk_hash,
@@ -314,7 +314,7 @@ template <typename NCT> typename NCT::fr function_tree_root_from_siblings(
     std::array<typename NCT::fr, FUNCTION_TREE_HEIGHT> const& function_leaf_sibling_path)
 {
     const auto function_leaf_preimage = FunctionLeafPreimage<NCT>{
-        .function_selector = function_selector,
+        .selector = selector,
         .is_internal = is_internal,
         .is_private = is_private,
         .vk_hash = vk_hash,

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/common.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/common.cpp
@@ -398,7 +398,7 @@ void common_contract_logic(DummyBuilder& builder,
 
         // The logic below ensures that the contract exists in the contracts tree
         auto const& computed_function_tree_root =
-            function_tree_root_from_siblings<NT>(private_call.call_stack_item.function_data.function_selector,
+            function_tree_root_from_siblings<NT>(private_call.call_stack_item.function_data.selector,
                                                  private_call.call_stack_item.function_data.is_internal,
                                                  true,  // is_private
                                                  private_call_vk_hash,

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit_init.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit_init.test.cpp
@@ -193,7 +193,7 @@ TEST_F(native_private_kernel_init_tests, contract_deployment_function_data_misma
     auto private_inputs = do_private_call_get_kernel_inputs_init(true, constructor, standard_test_args());
 
     // Modify the function selector in function data.
-    private_inputs.tx_request.function_data.function_selector = FunctionSelector<NT>{
+    private_inputs.tx_request.function_data.selector = {
         .value = numeric::random::get_engine().get_random_uint32(),
     };
 

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/testing_harness.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/testing_harness.cpp
@@ -156,8 +156,8 @@ std::pair<PrivateCallData<NT>, ContractDeploymentData<NT>> create_private_call_d
     const Point<NT> msg_sender_pub_key = { .x = 123456789, .y = 123456789 };
 
     FunctionData<NT> const function_data{
-        .function_selector =
-            FunctionSelector<NT>{
+        .selector =
+            {
                 .value = 1,  // TODO: deduce this from the contract, somehow.
             },
         .is_private = true,
@@ -203,7 +203,7 @@ std::pair<PrivateCallData<NT>, ContractDeploymentData<NT>> create_private_call_d
         // push to array/vector
         // use variation of `compute_root_partial_left_tree` to compute the root from leaves
         // const auto& function_leaf_preimage = FunctionLeafPreimage<NT>{
-        //    .function_selector = function_data.function_selector,
+        //    .selector = function_data.selector,
         //    .is_private = function_data.is_private,
         //    .vk_hash = private_circuit_vk_hash,
         //    .acir_hash = acir_hash,
@@ -230,7 +230,7 @@ std::pair<PrivateCallData<NT>, ContractDeploymentData<NT>> create_private_call_d
         // update the contract address in the call context now that it is known
         call_context.storage_contract_address = contract_address;
     } else {
-        const NT::fr& function_tree_root = function_tree_root_from_siblings<NT>(function_data.function_selector,
+        const NT::fr& function_tree_root = function_tree_root_from_siblings<NT>(function_data.selector,
                                                                                 function_data.is_internal,
                                                                                 function_data.is_private,
                                                                                 private_circuit_vk_hash,

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/.test.cpp
@@ -107,8 +107,8 @@ PublicCallStackItem generate_call_stack_item(NT::fr contract_address,
 {
     NT::uint32 count = seed + 1;
     FunctionData<NT> const function_data{
-        .function_selector =
-            FunctionSelector<NT>{
+        .selector =
+            {
                 .value = count,
             },
         .is_private = false,
@@ -267,8 +267,8 @@ PublicKernelInputs<NT> get_kernel_inputs_with_previous_kernel(NT::boolean privat
     const NT::address msg_sender = NT::fr(1);
 
     FunctionData<NT> const function_data{
-        .function_selector =
-            FunctionSelector<NT>{
+        .selector =
+            {
                 .value = 1,
             },
         .is_private = false,
@@ -646,7 +646,7 @@ TEST(public_kernel_tests, function_selector_must_be_valid)
     DummyBuilder dummyBuilder = DummyBuilder("public_kernel_tests__function_selector_must_be_valid");
     PublicKernelInputs<NT> inputs = get_kernel_inputs_with_previous_kernel(true);
 
-    inputs.public_call.call_stack_item.function_data.function_selector = FunctionSelector<NT>{
+    inputs.public_call.call_stack_item.function_data.selector = {
         .value = 0,
     };
     auto public_inputs = native_public_kernel_circuit_private_previous_kernel(dummyBuilder, inputs);

--- a/circuits/cpp/src/aztec3/circuits/kernel/public/common.hpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/public/common.hpp
@@ -180,7 +180,7 @@ void common_validate_inputs(DummyBuilder& builder, KernelInput const& public_ker
     builder.do_assert(this_call_stack_item.contract_address != 0,
                       "Contract address must be non-zero",
                       CircuitErrorCode::PUBLIC_KERNEL__CONTRACT_ADDRESS_INVALID);
-    builder.do_assert(this_call_stack_item.function_data.function_selector.value != 0,
+    builder.do_assert(this_call_stack_item.function_data.selector.value != 0,
                       "Function signature must be non-zero",
                       CircuitErrorCode::PUBLIC_KERNEL__FUNCTION_SIGNATURE_INVALID);
     builder.do_assert(this_call_stack_item.function_data.is_constructor == false,

--- a/yarn-project/circuits.js/src/cbind/circuits.gen.ts
+++ b/yarn-project/circuits.js/src/cbind/circuits.gen.ts
@@ -288,15 +288,15 @@ export function fromFunctionSelector(o: FunctionSelector): MsgpackFunctionSelect
 }
 
 interface MsgpackFunctionData {
-  function_selector: MsgpackFunctionSelector;
+  selector: MsgpackFunctionSelector;
   is_internal: boolean;
   is_private: boolean;
   is_constructor: boolean;
 }
 
 export function toFunctionData(o: MsgpackFunctionData): FunctionData {
-  if (o.function_selector === undefined) {
-    throw new Error('Expected function_selector in FunctionData deserialization');
+  if (o.selector === undefined) {
+    throw new Error('Expected selector in FunctionData deserialization');
   }
   if (o.is_internal === undefined) {
     throw new Error('Expected is_internal in FunctionData deserialization');
@@ -307,12 +307,12 @@ export function toFunctionData(o: MsgpackFunctionData): FunctionData {
   if (o.is_constructor === undefined) {
     throw new Error('Expected is_constructor in FunctionData deserialization');
   }
-  return new FunctionData(toFunctionSelector(o.function_selector), o.is_internal, o.is_private, o.is_constructor);
+  return new FunctionData(toFunctionSelector(o.selector), o.is_internal, o.is_private, o.is_constructor);
 }
 
 export function fromFunctionData(o: FunctionData): MsgpackFunctionData {
   if (o.selector === undefined) {
-    throw new Error('Expected functionSelector in FunctionData serialization');
+    throw new Error('Expected selector in FunctionData serialization');
   }
   if (o.isInternal === undefined) {
     throw new Error('Expected isInternal in FunctionData serialization');
@@ -324,7 +324,7 @@ export function fromFunctionData(o: FunctionData): MsgpackFunctionData {
     throw new Error('Expected isConstructor in FunctionData serialization');
   }
   return {
-    function_selector: fromFunctionSelector(o.selector),
+    selector: fromFunctionSelector(o.selector),
     is_internal: o.isInternal,
     is_private: o.isPrivate,
     is_constructor: o.isConstructor,

--- a/yarn-project/circuits.js/src/structs/__snapshots__/function_data.test.ts.snap
+++ b/yarn-project/circuits.js/src/structs/__snapshots__/function_data.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`basic FunctionData serialization serializes a trivial FunctionData and prints it 1`] = `
-"function_selector:
+"selector:
 value: 123
 
 is_internal: 0

--- a/yarn-project/circuits.js/src/structs/__snapshots__/function_leaf_preimage.test.ts.snap
+++ b/yarn-project/circuits.js/src/structs/__snapshots__/function_leaf_preimage.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`basic FunctionLeafPreimage serialization serializes a trivial Function Leaf Preimage and prints it 1`] = `
-"function_selector:
+"selector:
 value: 8972
 
 is_internal: 0

--- a/yarn-project/circuits.js/src/structs/kernel/__snapshots__/index.test.ts.snap
+++ b/yarn-project/circuits.js/src/structs/kernel/__snapshots__/index.test.ts.snap
@@ -94,7 +94,7 @@ portal_contract_address: 0x202020202020202020202020202020202020202
 function_tree_root: 0xb03
  ]
 optionally_revealed_data: [ call_stack_item_hash: 0xc01
-function_data: function_selector:
+function_data: selector:
 value: c02
 
 is_internal: 0
@@ -108,7 +108,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xc02
-function_data: function_selector:
+function_data: selector:
 value: c03
 
 is_internal: 0
@@ -122,7 +122,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xc03
-function_data: function_selector:
+function_data: selector:
 value: c04
 
 is_internal: 0
@@ -136,7 +136,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xc04
-function_data: function_selector:
+function_data: selector:
 value: c05
 
 is_internal: 0
@@ -333,7 +333,7 @@ portal_contract_address: 0x202020202020202020202020202020202020202
 function_tree_root: 0xb03
  ]
 optionally_revealed_data: [ call_stack_item_hash: 0xc01
-function_data: function_selector:
+function_data: selector:
 value: c02
 
 is_internal: 0
@@ -347,7 +347,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xc02
-function_data: function_selector:
+function_data: selector:
 value: c03
 
 is_internal: 0
@@ -361,7 +361,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xc03
-function_data: function_selector:
+function_data: selector:
 value: c04
 
 is_internal: 0
@@ -375,7 +375,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xc04
-function_data: function_selector:
+function_data: selector:
 value: c05
 
 is_internal: 0
@@ -520,7 +520,7 @@ vk_path: [ 0x1000 0x1001 0x1002 ]
 exports[`structs/kernel serializes and prints private_kernel_inputs_init 1`] = `
 "tx_request:
 origin: 0x1
-function_data: function_selector:
+function_data: selector:
 value: 257
 
 is_internal: 0
@@ -548,7 +548,7 @@ version: 0x0
 private_call:
 call_stack_item:
 contract_address: 0x1001
-function_data: function_selector:
+function_data: selector:
 value: 4098
 
 is_internal: 0
@@ -600,7 +600,7 @@ version: 0x2511
 is_execution_request: 0
 
 private_call_stack_preimages: [ contract_address: 0x1011
-function_data: function_selector:
+function_data: selector:
 value: 1012
 
 is_internal: 0
@@ -651,7 +651,7 @@ version: 0x2521
 
 is_execution_request: 0
  contract_address: 0x1012
-function_data: function_selector:
+function_data: selector:
 value: 1013
 
 is_internal: 0
@@ -702,7 +702,7 @@ version: 0x2522
 
 is_execution_request: 0
  contract_address: 0x1013
-function_data: function_selector:
+function_data: selector:
 value: 1014
 
 is_internal: 0
@@ -753,7 +753,7 @@ version: 0x2523
 
 is_execution_request: 0
  contract_address: 0x1014
-function_data: function_selector:
+function_data: selector:
 value: 1015
 
 is_internal: 0
@@ -940,7 +940,7 @@ portal_contract_address: 0x202020202020202020202020202020202020202
 function_tree_root: 0xb03
  ]
 optionally_revealed_data: [ call_stack_item_hash: 0xc01
-function_data: function_selector:
+function_data: selector:
 value: c02
 
 is_internal: 0
@@ -954,7 +954,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xc02
-function_data: function_selector:
+function_data: selector:
 value: c03
 
 is_internal: 0
@@ -968,7 +968,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xc03
-function_data: function_selector:
+function_data: selector:
 value: c04
 
 is_internal: 0
@@ -982,7 +982,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xc04
-function_data: function_selector:
+function_data: selector:
 value: c05
 
 is_internal: 0
@@ -1125,7 +1125,7 @@ vk_path: [ 0x1000 0x1001 0x1002 ]
 private_call:
 call_stack_item:
 contract_address: 0x1001
-function_data: function_selector:
+function_data: selector:
 value: 4098
 
 is_internal: 0
@@ -1177,7 +1177,7 @@ version: 0x2511
 is_execution_request: 0
 
 private_call_stack_preimages: [ contract_address: 0x1011
-function_data: function_selector:
+function_data: selector:
 value: 1012
 
 is_internal: 0
@@ -1228,7 +1228,7 @@ version: 0x2521
 
 is_execution_request: 0
  contract_address: 0x1012
-function_data: function_selector:
+function_data: selector:
 value: 1013
 
 is_internal: 0
@@ -1279,7 +1279,7 @@ version: 0x2522
 
 is_execution_request: 0
  contract_address: 0x1013
-function_data: function_selector:
+function_data: selector:
 value: 1014
 
 is_internal: 0
@@ -1330,7 +1330,7 @@ version: 0x2523
 
 is_execution_request: 0
  contract_address: 0x1014
-function_data: function_selector:
+function_data: selector:
 value: 1015
 
 is_internal: 0
@@ -1515,7 +1515,7 @@ portal_contract_address: 0x202020202020202020202020202020202020202
 function_tree_root: 0xb03
  ]
 optionally_revealed_data: [ call_stack_item_hash: 0xc01
-function_data: function_selector:
+function_data: selector:
 value: c02
 
 is_internal: 0
@@ -1529,7 +1529,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xc02
-function_data: function_selector:
+function_data: selector:
 value: c03
 
 is_internal: 0
@@ -1543,7 +1543,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xc03
-function_data: function_selector:
+function_data: selector:
 value: c04
 
 is_internal: 0
@@ -1557,7 +1557,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xc04
-function_data: function_selector:
+function_data: selector:
 value: c05
 
 is_internal: 0
@@ -1783,7 +1783,7 @@ portal_contract_address: 0x202020202020202020202020202020202020202
 function_tree_root: 0xb03
  ]
 optionally_revealed_data: [ call_stack_item_hash: 0xc01
-function_data: function_selector:
+function_data: selector:
 value: c02
 
 is_internal: 0
@@ -1797,7 +1797,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xc02
-function_data: function_selector:
+function_data: selector:
 value: c03
 
 is_internal: 0
@@ -1811,7 +1811,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xc03
-function_data: function_selector:
+function_data: selector:
 value: c04
 
 is_internal: 0
@@ -1825,7 +1825,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xc04
-function_data: function_selector:
+function_data: selector:
 value: c05
 
 is_internal: 0
@@ -1968,7 +1968,7 @@ vk_path: [ 0x1000 0x1001 0x1002 ]
 public_call:
 call_stack_item:
 contract_address: 0x1001
-function_data: function_selector:
+function_data: selector:
 value: 4098
 
 is_internal: 0
@@ -2087,7 +2087,7 @@ prover_address: 0x1b12
 is_execution_request: 0
 
 public_call_stack_preimages: [ contract_address: 0x1301
-function_data: function_selector:
+function_data: selector:
 value: 1302
 
 is_internal: 0
@@ -2205,7 +2205,7 @@ prover_address: 0x1e12
 
 is_execution_request: 0
  contract_address: 0x1302
-function_data: function_selector:
+function_data: selector:
 value: 1303
 
 is_internal: 0
@@ -2323,7 +2323,7 @@ prover_address: 0x1e13
 
 is_execution_request: 0
  contract_address: 0x1303
-function_data: function_selector:
+function_data: selector:
 value: 1304
 
 is_internal: 0
@@ -2441,7 +2441,7 @@ prover_address: 0x1e14
 
 is_execution_request: 0
  contract_address: 0x1304
-function_data: function_selector:
+function_data: selector:
 value: 1305
 
 is_internal: 0

--- a/yarn-project/circuits.js/src/structs/rollup/__snapshots__/base_rollup.test.ts.snap
+++ b/yarn-project/circuits.js/src/structs/rollup/__snapshots__/base_rollup.test.ts.snap
@@ -96,7 +96,7 @@ portal_contract_address: 0x101010101010101010101010101010101010101
 function_tree_root: 0xc02
  ]
 optionally_revealed_data: [ call_stack_item_hash: 0xd00
-function_data: function_selector:
+function_data: selector:
 value: d01
 
 is_internal: 0
@@ -110,7 +110,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xd01
-function_data: function_selector:
+function_data: selector:
 value: d02
 
 is_internal: 0
@@ -124,7 +124,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xd02
-function_data: function_selector:
+function_data: selector:
 value: d03
 
 is_internal: 0
@@ -138,7 +138,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xd03
-function_data: function_selector:
+function_data: selector:
 value: d04
 
 is_internal: 0
@@ -372,7 +372,7 @@ portal_contract_address: 0x101010101010101010101010101010101010101
 function_tree_root: 0xd02
  ]
 optionally_revealed_data: [ call_stack_item_hash: 0xe00
-function_data: function_selector:
+function_data: selector:
 value: e01
 
 is_internal: 0
@@ -386,7 +386,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xe01
-function_data: function_selector:
+function_data: selector:
 value: e02
 
 is_internal: 0
@@ -400,7 +400,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xe02
-function_data: function_selector:
+function_data: selector:
 value: e03
 
 is_internal: 0
@@ -414,7 +414,7 @@ pay_fee_from_public_l2: 0
 called_from_l1: 1
 called_from_public_l2: 0
  call_stack_item_hash: 0xe03
-function_data: function_selector:
+function_data: selector:
 value: e04
 
 is_internal: 0


### PR DESCRIPTION
I introduced a regression in my function [selector type PR](https://github.com/AztecProtocol/aztec-packages/pull/1518) which caused the selector name to be incorrect in circuits.gen.ts. The issue was with having different names for selector in FunctionData struct in TS and C++.

This PR fixes it.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
