### PR TITLE
chore(ci): Clean up stale image tags

### DIFF
--- a/build-system/scripts/clean_image_tags
+++ b/build-system/scripts/clean_image_tags
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+REPOSITORY=$1
+EXISTING_TAG=$2
+REGION=${3:-$ECR_REGION}
+
+IMAGE_TAGS=$(aws ecr describe-images --repository-name $REPOSITORY --image-ids "imageTag=$EXISTING_TAG" | jq -r '.imageDetails[0].imageTags[]')
+TAGS_COUNT=$(echo "$IMAGE_TAGS" | wc -l)
+
+echo "Found $TAGS_COUNT for $REPOSITORY:$EXISTING_TAG"
+
+if [ $TAGS_COUNT -le 500 ]; then
+  echo "Less than 500 tags found, nothing to do here."
+  exit 0
+else
+  echo "Pruning stale images"
+fi
+
+# Collect all the commits ids in the repository and remove the remote for faster lookups
+# See warning in https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
+git config fetch.recurseSubmodules false 
+git fetch --filter=tree:0 origin
+ORIGIN_URL=$(git remote get-url origin)
+git remote remove origin
+
+# Loop over all tags and, if they are no longer in the repo, kill them
+# This happens for all commits tagged for PRs that then get squashed and merged
+IFS=$'\n'
+for TAG in $IMAGE_TAGS; do
+    if [[ $TAG =~ ^cache-[0-9a-fA-F]+-builder$ ]]; then      
+      TAG_COMMIT=$(echo "$TAG" | cut -d '-' -f 2)
+      if git cat-file -e $TAG_COMMIT; then
+        echo "Commit for $TAG found"
+      else
+        echo "Removing $TAG since commit was not found."
+        untag_remote_image $REPOSITORY $TAG
+      fi
+    fi
+done
+
+# Reinstate the remote
+git remote add origin $ORIGIN_URL || git remote set-url origin $ORIGIN_URL

--- a/build-system/scripts/tag_remote_image
+++ b/build-system/scripts/tag_remote_image
@@ -27,9 +27,22 @@ NEW_TAG_MANIFEST=$(aws ecr batch-get-image \
 
 if [ "$EXISTING_TAG_MANIFEST" != "$NEW_TAG_MANIFEST" ]; then
   echo "Tagging $1:$EXISTING_TAG as $1:$NEW_TAG..."
-  aws ecr put-image \
+  TAG_RESULT=$(aws ecr put-image \
     --region $REGION \
     --repository-name $REPOSITORY \
     --image-tag $NEW_TAG \
-    --image-manifest "$EXISTING_TAG_MANIFEST" > /dev/null 2>&1
+    --image-manifest "$EXISTING_TAG_MANIFEST" 2>&1)
+  TAG_EXIT_CODE=$?
+  
+  # If we failed to tag due to too many tags on this image, then clean some of them up and try again
+  if [ $TAG_EXIT_CODE -ne 0 ] && $(echo $TAG_RESULT | grep -q LimitExceededException); then
+    echo "Failed to tag due to limit exceeded. Starting tag cleanup."
+    clean_image_tags $REPOSITORY $EXISTING_TAG $REGION
+
+    aws ecr put-image \
+      --region $REGION \
+      --repository-name $REPOSITORY \
+      --image-tag $NEW_TAG \
+      --image-manifest "$EXISTING_TAG_MANIFEST"
+  fi
 fi


### PR DESCRIPTION
Attempt at cleaning up image tags when a tag operation fails due to limit exceeded. The `clean_image_tags` loops over all image tags that look like a commit, and check if the commit is anywhere in git. If it isn't, it's because it belongs to a branch that got deleted (most likely, a PR that was merged) and we can safely kill it.

We can still theoretically hit the 1000 limit in this scenario, but I think it's a lot less likely. A local test run of the script showed that most image tags correspond to non-existing commits.