### PR TITLE
chore(ci): fix output name in release please workflow

### DIFF
--- a/circuits/cpp/barretenberg/.github/workflows/release-please.yml
+++ b/circuits/cpp/barretenberg/.github/workflows/release-please.yml
@@ -28,7 +28,7 @@ jobs:
           repo: AztecProtocol/barretenberg
           ref: master
           token: ${{ secrets.GITHUB_TOKEN }}
-          inputs: '{ "tag": "${{ steps.release.outputs.tag-name }}", "publish": true }'
+          inputs: '{ "tag": "${{ steps.release.outputs.tag_name }}", "publish": true }'
 
 
   

--- a/circuits/cpp/barretenberg/.github/workflows/release-please.yml
+++ b/circuits/cpp/barretenberg/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Dispatch to publish workflow
         uses: benc-uk/workflow-dispatch@v1
-        if: ${{ steps.release.outputs.tag-name }}
+        if: ${{ steps.release.outputs.tag_name }}
         with:
           workflow: publish.yml
           repo: AztecProtocol/barretenberg


### PR DESCRIPTION
See equivalent line in Noir CI:
https://github.com/noir-lang/noir/blob/b467a2d72659d28195ea2015a6fba2738eae1f16/.github/workflows/release.yml#L13