### PR TITLE
fix: Set side effect counter on contract reads

### DIFF
--- a/yarn-project/circuits.js/src/structs/public_circuit_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/public_circuit_public_inputs.ts
@@ -49,8 +49,12 @@ export class ContractStorageRead {
      * Value read from the storage slot.
      */
     currentValue: Fr;
+    /**
+     * Optional side effect counter tracking position of this event in tx execution.
+     */
+    sideEffectCounter?: number;
   }) {
-    return new ContractStorageRead(args.storageSlot, args.currentValue);
+    return new ContractStorageRead(args.storageSlot, args.currentValue, args.sideEffectCounter);
   }
 
   toBuffer() {


### PR DESCRIPTION
The side effect counter was not being collected in `ContractStorageRead`s due to an error in the `from` static method. This PR fixes it and reenables a test on public execution.

Fixes #1588 