### PR TITLE
fix(docs) adding missing page

### DIFF
--- a/docs/docs/dev_docs/wallets/building_a_wallet.md
+++ b/docs/docs/dev_docs/wallets/building_a_wallet.md
@@ -1,0 +1,3 @@
+# Building a Wallet
+
+## Todo write docs for building a wallet


### PR DESCRIPTION
Temporary fix for #1871 that adds the missing page to allow the docs to compile.  It looks like this page still needs to be implemented: 
https://github.com/jtfirek/aztec-packages/blob/2804230ab6fbac077b4375cad1e6d0e0d9e01ee7/docs/docs/dev_docs/dapps/main.md?plain=1#L35

I would be happy to take a stab at implementing this page if you guys would like to see this.
