### PR TITLE
fix: Reset keccak var inputs to 0

### DIFF
--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
@@ -310,4 +310,79 @@ TEST(acir_format, test_schnorr_verify_small_range)
     auto verifier = composer.create_ultra_with_keccak_verifier(builder);
     EXPECT_EQ(verifier.verify_proof(proof), true);
 }
+
+TEST(acir_format, test_var_keccak)
+{
+    HashInput input1;
+    input1.witness = 1;
+    input1.num_bits = 8;
+    HashInput input2;
+    input2.witness = 2;
+    input2.num_bits = 8;
+    HashInput input3;
+    input3.witness = 3;
+    input3.num_bits = 8;
+    KeccakVarConstraint keccak;
+    keccak.inputs = { input1, input2, input3 };
+    keccak.var_message_size = 4;
+    keccak.result = { 5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                      21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36 };
+
+    RangeConstraint range_a{
+        .witness = 1,
+        .num_bits = 8,
+    };
+    RangeConstraint range_b{
+        .witness = 2,
+        .num_bits = 8,
+    };
+    RangeConstraint range_c{
+        .witness = 3,
+        .num_bits = 8,
+    };
+    RangeConstraint range_d{
+        .witness = 4,
+        .num_bits = 8,
+    };
+
+    auto dummy = poly_triple{
+        .a = 1,
+        .b = 0,
+        .c = 0,
+        .q_m = 0,
+        .q_l = 1,
+        .q_r = 0,
+        .q_o = 0,
+        .q_c = fr::neg_one() * fr(4),
+    };
+
+    acir_format constraint_system{
+        .varnum = 37,
+        .public_inputs = {},
+        .logic_constraints = {},
+        .range_constraints = { range_a, range_b, range_c, range_d },
+        .sha256_constraints = {},
+        .schnorr_constraints = {},
+        .ecdsa_k1_constraints = {},
+        .ecdsa_r1_constraints = {},
+        .blake2s_constraints = {},
+        .keccak_constraints = {},
+        .keccak_var_constraints = { keccak },
+        .pedersen_constraints = {},
+        .hash_to_field_constraints = {},
+        .fixed_base_scalar_mul_constraints = {},
+        .recursion_constraints = {},
+        .constraints = { dummy },
+        .block_constraints = {},
+    };
+
+    auto builder = create_circuit_with_witness(constraint_system, { 4, 2, 6, 2 });
+
+    auto composer = Composer();
+    auto prover = composer.create_ultra_with_keccak_prover(builder);
+    auto proof = prover.construct_proof();
+    auto verifier = composer.create_ultra_with_keccak_verifier(builder);
+    EXPECT_EQ(verifier.verify_proof(proof), true);
+}
+
 } // namespace acir_format::tests

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
@@ -567,8 +567,16 @@ template <typename Composer> byte_array<Composer> keccak<Composer>::sponge_squee
  * @return std::vector<field_t<Composer>>
  */
 template <typename Composer>
-std::vector<field_t<Composer>> keccak<Composer>::format_input_lanes(byte_array_ct& input, const uint32_ct& num_bytes)
+std::vector<field_t<Composer>> keccak<Composer>::format_input_lanes(byte_array_ct& _input, const uint32_ct& num_bytes)
 {
+    byte_array_ct input(_input);
+
+    // make sure that every byte past `num_bytes` is zero!
+    for (size_t i = 0; i < input.size(); ++i) {
+        bool_ct valid_byte = uint32_ct(static_cast<uint32_t>(i)) < num_bytes;
+        input.set_byte(i, (input[i] * valid_byte));
+    }
+
     auto* ctx = input.get_context();
 
     // We require that `num_bytes` does not exceed the size of our input byte array.

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
@@ -242,3 +242,30 @@ TEST(stdlib_keccak, test_double_block_variable_length)
     bool proof_result = composer.check_circuit();
     EXPECT_EQ(proof_result, true);
 }
+
+TEST(stdlib_keccak, test_variable_length_nonzero_input_greater_than_byte_array_size)
+
+{
+    Composer composer = Composer();
+    std::string input = "";
+    size_t target_length = 2;
+    size_t byte_array_length = 200;
+    for (size_t i = 0; i < target_length; ++i) {
+        input += "a";
+    }
+    std::vector<uint8_t> input_expected(input.begin(), input.end());
+    std::vector<uint8_t> expected = stdlib::keccak<Composer>::hash_native(input_expected);
+    for (size_t i = target_length; i < byte_array_length; ++i) {
+        input += "a";
+    }
+    std::vector<uint8_t> input_v(input.begin(), input.end());
+
+    byte_array input_arr(&composer, input_v);
+
+    uint32_ct length(witness_ct(&composer, 2));
+    byte_array output = stdlib::keccak<Composer>::hash(input_arr, length);
+
+    EXPECT_EQ(output.get_value(), expected);
+    bool proof_result = composer.check_circuit();
+    EXPECT_EQ(proof_result, true);
+}


### PR DESCRIPTION
This PR fixes noir issue 1934 (https://github.com/noir-lang/noir/issues/1934):

 When using variable size keccak, the inputs that are after the provided length where not set to 0.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [X] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [X] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [X] Every change is related to the PR description.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
