### PR TITLE
fix: Do not warn on mismatched cli/sandbox version

### DIFF
--- a/yarn-project/aztec-cli/src/client.ts
+++ b/yarn-project/aztec-cli/src/client.ts
@@ -36,7 +36,7 @@ export async function createCompatibleClient(rpcUrl: string, logger: DebugLogger
     await checkServerVersion(client, expectedVersionRange, logger);
   } catch (err) {
     if (err instanceof VersionMismatchError) {
-      logger.warn(err.message);
+      logger.debug(err.message);
     } else {
       throw err;
     }


### PR DESCRIPTION
Due to #1892, the check implemented in #1849 always fails when run against the Sandbox docker image. This PR disables it temporarily.