### PR TITLE
fix: Benchmark preset uses clang16

### DIFF
--- a/circuits/cpp/barretenberg/cpp/CMakePresets.json
+++ b/circuits/cpp/barretenberg/cpp/CMakePresets.json
@@ -29,20 +29,20 @@
       }
     },
     {
-      "name": "clang15",
-      "displayName": "Build with Clang-15",
-      "description": "Build with globally installed Clang-15",
+      "name": "clang16",
+      "displayName": "Build with Clang-16",
+      "description": "Build with globally installed Clang-16",
       "inherits": "default",
       "environment": {
-        "CC": "clang-15",
-        "CXX": "clang++-15"
+        "CC": "clang-16",
+        "CXX": "clang++-16"
       }
     },
     {
-      "name": "clang15-dbg",
-      "displayName": "Debugging build with Clang-15",
-      "description": "Build with globally installed Clang-15 in debug mode",
-      "inherits": "clang15",
+      "name": "clang16-dbg",
+      "displayName": "Debugging build with Clang-16",
+      "description": "Build with globally installed Clang-16 in debug mode",
+      "inherits": "clang16",
       "environment": {
         "CMAKE_BUILD_TYPE": "Debug"
       },
@@ -75,7 +75,7 @@
       "name": "bench",
       "displayName": "Build benchmarks",
       "description": "Build default preset but with a special benchmark directory",
-      "inherits": "clang15",
+      "inherits": "clang16",
       "binaryDir": "build-bench"
     },
     {
@@ -161,14 +161,14 @@
       "configurePreset": "homebrew"
     },
     {
-      "name": "clang15",
+      "name": "clang16",
       "inherits": "default",
-      "configurePreset": "clang15"
+      "configurePreset": "clang16"
     },
     {
-      "name": "clang15-dbg",
+      "name": "clang16-dbg",
       "inherits": "default",
-      "configurePreset": "clang15-dbg"
+      "configurePreset": "clang16-dbg"
     },
     {
       "name": "gcc",
@@ -182,7 +182,7 @@
     },
     {
       "name": "bench",
-      "inherits": "clang15",
+      "inherits": "clang16",
       "configurePreset": "bench"
     },
     {
@@ -229,14 +229,14 @@
       "configurePreset": "homebrew"
     },
     {
-      "name": "clang15",
+      "name": "clang16",
       "inherits": "default",
-      "configurePreset": "clang15"
+      "configurePreset": "clang16"
     },
     {
-      "name": "clang15-dbg",
+      "name": "clang16-dbg",
       "inherits": "default",
-      "configurePreset": "clang15-dbg"
+      "configurePreset": "clang16-dbg"
     },
     {
       "name": "gcc",
@@ -250,7 +250,7 @@
     },
     {
       "name": "bench",
-      "inherits": "clang15",
+      "inherits": "clang16",
       "configurePreset": "bench"
     },
     {

--- a/circuits/cpp/barretenberg/cpp/CMakePresets.json
+++ b/circuits/cpp/barretenberg/cpp/CMakePresets.json
@@ -75,7 +75,7 @@
       "name": "bench",
       "displayName": "Build benchmarks",
       "description": "Build default preset but with a special benchmark directory",
-      "inherits": "default",
+      "inherits": "clang15",
       "binaryDir": "build-bench"
     },
     {
@@ -182,7 +182,7 @@
     },
     {
       "name": "bench",
-      "inherits": "default",
+      "inherits": "clang15",
       "configurePreset": "bench"
     },
     {
@@ -250,7 +250,7 @@
     },
     {
       "name": "bench",
-      "inherits": "default",
+      "inherits": "clang15",
       "configurePreset": "bench"
     },
     {


### PR DESCRIPTION
Without this, the benchmark preset fails to buid for older version of clang.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [x] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [x] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
