### PR TITLE
chore(Aztec.nr): Remove the open keyword from public functions

### DIFF
--- a/yarn-project/noir-contracts/src/contracts/child_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/child_contract/src/main.nr
@@ -28,7 +28,7 @@ contract Child {
 
     // Returns base_value + 42.
     #[aztec(public)]
-    open fn pubGetValue(base_value: Field) {
+    fn pubGetValue(base_value: Field) {
         let returnValue = base_value + context.chain_id() + context.version() + context.block_number() + context.timestamp();
 
         context.return_values.push(returnValue);
@@ -36,7 +36,7 @@ contract Child {
 
     // Sets `current_value` to `new_value`
     #[aztec(public)]
-    open fn pubSetValue(new_value: Field) {
+    fn pubSetValue(new_value: Field) {
         let storage = Storage::init();
         storage.current_value.write(new_value);
         let _hash = emit_unencrypted_log(new_value);
@@ -45,7 +45,7 @@ contract Child {
 
     // Increments `current_value` by `new_value`
     #[aztec(public)]
-    open fn pubIncValue(new_value: Field) {
+    fn pubIncValue(new_value: Field) {
         let storage = Storage::init();
         let old_value = storage.current_value.read();
         storage.current_value.write(old_value + new_value);
@@ -55,7 +55,7 @@ contract Child {
 
     // Increments `current_value` by `new_value`. Can only be called from this contract.
     #[aztec(public)]
-    open fn pubIncValueInternal(new_value: Field) {
+    fn pubIncValueInternal(new_value: Field) {
         let storage = Storage::init();
         assert(inputs.call_context.msg_sender == inputs.call_context.storage_contract_address);
         let old_value = storage.current_value.read();
@@ -65,7 +65,7 @@ contract Child {
     }
 
     #[aztec(public)]
-    open fn setValueTwiceWithNestedFirst() {
+    fn setValueTwiceWithNestedFirst() {
         let pubSetValueSelector = 0x5b0f91b0;
         let _ret = context.call_public_function(context.this_address(), pubSetValueSelector, [10]);
 
@@ -75,7 +75,7 @@ contract Child {
     }
 
     #[aztec(public)]
-    open fn setValueTwiceWithNestedLast() {
+    fn setValueTwiceWithNestedLast() {
         let storage = Storage::init();
         storage.current_value.write(20);
         let _hash = emit_unencrypted_log(20);

--- a/yarn-project/noir-contracts/src/contracts/example_public_state_increment_BROKE/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/example_public_state_increment_BROKE/src/main.nr
@@ -35,7 +35,7 @@ contract ExamplePublicStateIncrement {
 
     // a += b;
     #[aztec(public)]
-    open fn increment_a(
+    fn increment_a(
         b: Field,
     ) {
         let storage = Storage::init();

--- a/yarn-project/noir-contracts/src/contracts/import_test_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/import_test_contract/src/main.nr
@@ -75,7 +75,7 @@ contract ImportTest {
     // Used for testing calling an open function from another open function
     // See yarn-project/end-to-end/src/e2e_nested_contract.test.ts
     #[aztec(public)]
-    open fn pubCallOpenFn(
+    fn pubCallOpenFn(
         target: Field,
     ) {
         let test_contract_instance = TestPublicContextInterface::at(target);

--- a/yarn-project/noir-contracts/src/contracts/lending_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/lending_contract/src/main.nr
@@ -30,7 +30,7 @@ contract Lending {
     ) {}
 
     #[aztec(public)]
-    open fn init(
+    fn init(
         oracle_address: Field,
         loan_to_value: Field,
         collateral_asset: Field,
@@ -60,7 +60,7 @@ contract Lending {
     // Create a position.
     // keccak256("update_accumulator()") >> 224 -> 0x1873b536
     #[aztec(public)]
-    open fn update_accumulator() {
+    fn update_accumulator() {
         let storage = Storage::init();
 
         let asset_loc = storage.assets.at(0);
@@ -101,7 +101,7 @@ contract Lending {
     }
 
     #[aztec(public)]
-    open fn deposit_public(
+    fn deposit_public(
         owner: Field,
         amount: Field,
         collateral_asset: Field,
@@ -142,7 +142,7 @@ contract Lending {
     }
 
     #[aztec(public)]
-    open fn withdraw_public(
+    fn withdraw_public(
         to: Field,
         amount: Field,
     ) {
@@ -197,7 +197,7 @@ contract Lending {
     }
 
     #[aztec(public)]
-    open fn borrow_public(
+    fn borrow_public(
         to: Field,
         amount: Field
     ) {
@@ -250,7 +250,7 @@ contract Lending {
     }
 
     #[aztec(public)]
-    open fn repay_public(
+    fn repay_public(
         owner: Field,
         amount: Field,
         stable_coin: Field,

--- a/yarn-project/noir-contracts/src/contracts/native_token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/native_token_contract/src/main.nr
@@ -46,7 +46,7 @@ contract NativeToken {
 
     // uint256(keccak256("owner_mint_pub(field,field)")) >> 224 -> 1071038680
     #[aztec(public)]
-    open fn owner_mint_pub(
+    fn owner_mint_pub(
         to: Field,
         amount: Field,
     ) {
@@ -59,7 +59,7 @@ contract NativeToken {
 
     // uint256(keccak256("owner_mint_priv(field,field)")) >> 224 -> 3157518188
     #[aztec(public)]
-    open fn owner_mint_priv(
+    fn owner_mint_priv(
         amount: Field,
         secret_hash: Field,
     ) {
@@ -123,7 +123,7 @@ contract NativeToken {
     // upon consuming valid messages from a token portal contract
     // uint256(keccak256("mintPublic(field,field,field,field,field)")) >> 224 -> 1598652179
     #[aztec(public)]
-    open fn mintPublic(
+    fn mintPublic(
         amount: Field,
         owner_address: Field,
         // This field should be hidden
@@ -151,7 +151,7 @@ contract NativeToken {
     // Withdraws using user's public balance.
     // uint256(keccak256("withdrawPublic(field,field,field)")) >> 224 -> 2996031894
     #[aztec(public)]
-    open fn withdrawPublic(
+    fn withdrawPublic(
         amount: Field,
         recipient: Field,
         callerOnL1: Field, // ethereum address that can call this function on the L1 portal (0x0 if anyone can call)
@@ -177,7 +177,7 @@ contract NativeToken {
     }
 
     #[aztec(public)]
-    open fn approve(
+    fn approve(
         spender: Field,
         allowance: Field,
     ) {
@@ -187,7 +187,7 @@ contract NativeToken {
 
     // uint256(keccak256("transfer_pub(field,field)")) >> 224 -> 1012824788
     #[aztec(public)]
-    open fn transfer_pub(
+    fn transfer_pub(
         to: Field,
         amount: Field,
     ) {
@@ -209,7 +209,7 @@ contract NativeToken {
 
     // uint256(keccak256("transfer_from_pub(field,field,field)")) >> 224 -> 1602017294
     #[aztec(public)]
-    open fn transfer_from_pub(
+    fn transfer_from_pub(
         from: Field,
         to: Field,
         amount: Field,
@@ -257,7 +257,7 @@ contract NativeToken {
     // Shield creates a way for a user to move tokens from the public context into the private context.
     // uint256(keccak256("shield(field,field)")) >> 224 -> 845411215
     #[aztec(public)]
-    open fn shield(
+    fn shield(
         amount: Field,
         secretHash: Field,
     ) {

--- a/yarn-project/noir-contracts/src/contracts/non_native_token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/non_native_token_contract/src/main.nr
@@ -100,7 +100,7 @@ contract NonNativeToken {
     // This mint function differs to the typical token mint function as it only allows minting
     // upon consuming valid messages from a token portal contract
     #[aztec(public)]
-    open fn mintPublic(
+    fn mintPublic(
         amount: Field,
         owner_address: Field,
         // This field should be hidden
@@ -128,7 +128,7 @@ contract NonNativeToken {
 
     // Withdraws using user's public balance.
     #[aztec(public)]
-    open fn withdrawPublic(
+    fn withdrawPublic(
         amount: Field,
         recipient: Field,
         callerOnL1: Field, // ethereum address that can call this function on the L1 portal (0x0 if anyone can call)
@@ -174,7 +174,7 @@ contract NonNativeToken {
 
     // Shield creates a way for a user to move tokens from the public context into the private context.
     #[aztec(public)]
-    open fn shield(
+    fn shield(
         amount: Field,
         secretHash: Field,
     ) {
@@ -242,7 +242,7 @@ contract NonNativeToken {
     }
 
     #[aztec(public)]
-    open fn addUnshieldedBalance(
+    fn addUnshieldedBalance(
         amount: Field,
         recipient: Field,
     ) {

--- a/yarn-project/noir-contracts/src/contracts/parent_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/parent_contract/src/main.nr
@@ -20,7 +20,7 @@ contract Parent {
 
     // Public function to directly call another public function to the targetContract using the selector and value provided
     #[aztec(public)]
-    open fn pubEntryPoint(
+    fn pubEntryPoint(
         targetContract: Field,
         targetSelector: Field,
         initValue: Field
@@ -32,7 +32,7 @@ contract Parent {
 
     // Same as pubEntryPoint, but calls the target contract twice, using the return value from the first invocation as the argument for the second.
     #[aztec(public)]
-    open fn pubEntryPointTwice(
+    fn pubEntryPointTwice(
         targetContract: Field,
         targetSelector: Field,
         initValue: Field

--- a/yarn-project/noir-contracts/src/contracts/price_feed_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/price_feed_contract/src/main.nr
@@ -7,7 +7,7 @@ contract PriceFeed {
     fn constructor(){}
 
     #[aztec(public)]
-    open fn set_price(
+    fn set_price(
         asset_id: Field,
         price: u120,
     ) {
@@ -19,7 +19,7 @@ contract PriceFeed {
     }
 
     #[aztec(public)]
-    open fn get_price(
+    fn get_price(
         asset_id: Field,
     ) {
         let storage = Storage::init();

--- a/yarn-project/noir-contracts/src/contracts/public_token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/public_token_contract/src/main.nr
@@ -14,7 +14,7 @@ contract PublicToken {
 
     // Mints `amount` of tokens to a `recipient`.
     #[aztec(public)]
-    open fn mint(
+    fn mint(
         amount: Field,
         recipient: Field,
     ) {
@@ -33,7 +33,7 @@ contract PublicToken {
 
     // Transfers `amount` of tokens from `msg_sender` to `recipient`.
     #[aztec(public)]
-    open fn transfer(
+    fn transfer(
         amount: Field,
         recipient: Field,
     ) {

--- a/yarn-project/noir-contracts/src/contracts/test_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/test_contract/src/main.nr
@@ -82,7 +82,7 @@ contract Test {
 
     // Purely exists for testing
     #[aztec(public)]
-    open fn createL2ToL1MessagePublic(
+    fn createL2ToL1MessagePublic(
         amount: Field,
         secretHash: Field,
     ) {
@@ -96,7 +96,7 @@ contract Test {
 
     // Purely exists for testing
     #[aztec(public)]
-    open fn createNullifierPublic(
+    fn createNullifierPublic(
         amount: Field,
         secretHash: Field,
     ) {
@@ -108,7 +108,7 @@ contract Test {
     }
 
     #[aztec(public)]
-    open fn isTimeEqual(
+    fn isTimeEqual(
         time: Field,
     ) {
         assert(context.timestamp() == time);


### PR DESCRIPTION
## Overview

The open keyword can now be implied if a function is marked `#[aztec(public)]`. This pr removes the open keyword.

Depends on:
- https://github.com/noir-lang/noir/pull/2508
    - depends on this workflow run:
        - https://github.com/noir-lang/noir/actions/runs/6039831975 


