### PR TITLE
fix: Update docs search config

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -10,7 +10,7 @@ const katex = require("rehype-katex");
 const config = {
   title: "Aztec Docs",
   tagline: "Ethereum, encrypted",
-  url: "https://docs.aztec.network",
+  url: "https://aztec-docs-dev.netlify.app/",
   baseUrl: "/",
   trailingSlash: false,
   onBrokenLinks: "throw",
@@ -50,6 +50,7 @@ const config = {
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
+        // removed until approved by legal (GDPR)
         //         gtag: {
         //           trackingID: "G-WSBTSFJCSF",
         //           anonymizeIP: true,
@@ -89,9 +90,9 @@ const config = {
         },
       ],
       algolia: {
-        appId: "CL4NK79B0W",
-        apiKey: "21d89dadaa37a4d1b6bf4b17978dcf7f",
-        indexName: "aztec",
+        appId: "I5BXQIOJ1H",
+        apiKey: "aeeba49f90558700f8035c54e150080c",
+        indexName: "dev_docs",
       },
       colorMode: {
         defaultMode: "light",


### PR DESCRIPTION
This PR updates the algolia search config so it should work with the dev docs site. This is on the basic free plan which should be sufficient for our needs for now and should be updated before making this the official docs hosted at docs.aztec.network.

closes #1909 

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [x] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
