### PR TITLE
fix: update docs search keys

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -90,9 +90,9 @@ const config = {
         },
       ],
       algolia: {
-        appId: "I5BXQIOJ1H",
-        apiKey: "aeeba49f90558700f8035c54e150080c",
-        indexName: "dev_docs",
+        appId: "YOMNCJ88NY",
+        apiKey: "ef5490899a6f9618f55c7997ba5b35b4",
+        indexName: "aztec--dev",
       },
       colorMode: {
         defaultMode: "light",


### PR DESCRIPTION
I applied for free search crawling via our search provider (Algolia) and was approved since we are an open source project. I am updating the search config to match our free license.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [x] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
