### PR TITLE
fix: compilation on homebrew clang 16.06

### DIFF
--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/numeric/bitop/count_leading_zeros.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/numeric/bitop/count_leading_zeros.test.cpp
@@ -19,17 +19,6 @@ TEST(bitop, ClzUint640)
     EXPECT_EQ(numeric::count_leading_zeros(a), 0U);
 }
 
-TEST(bitop, ClzSizeT)
-{
-    size_t a = 0x80;
-    auto r = numeric::count_leading_zeros(a);
-    if (sizeof(a) == 4) {
-        EXPECT_EQ(r, 24U);
-    } else {
-        EXPECT_EQ(r, 56U);
-    }
-}
-
 TEST(bitop, ClzUint256255)
 {
     uint256_t a = 0x1;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/ultra_recursive_verifier.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/ultra_recursive_verifier.cpp
@@ -63,11 +63,11 @@ std::array<typename Flavor::GroupElement, 2> UltraRecursiveVerifier_<Flavor>::ve
     const auto pub_inputs_offset = transcript.template receive_from_prover<uint32_t>("pub_inputs_offset");
 
     // For debugging purposes only
-    ASSERT(static_cast<size_t>(circuit_size.get_value()) == key->circuit_size);
-    ASSERT(static_cast<size_t>(public_input_size.get_value()) == key->num_public_inputs);
+    ASSERT(static_cast<uint32_t>(circuit_size.get_value()) == key->circuit_size);
+    ASSERT(static_cast<uint32_t>(public_input_size.get_value()) == key->num_public_inputs);
 
     std::vector<FF> public_inputs;
-    for (size_t i = 0; i < static_cast<size_t>(public_input_size.get_value()); ++i) {
+    for (size_t i = 0; i < static_cast<uint32_t>(public_input_size.get_value()); ++i) {
         auto public_input_i = transcript.template receive_from_prover<FF>("public_input_" + std::to_string(i));
         public_inputs.emplace_back(public_input_i);
     }
@@ -101,7 +101,7 @@ std::array<typename Flavor::GroupElement, 2> UltraRecursiveVerifier_<Flavor>::ve
     auto [beta, gamma] = transcript.get_challenges("beta", "gamma");
 
     const FF public_input_delta = proof_system::honk::compute_public_input_delta<Flavor>(
-        public_inputs, beta, gamma, circuit_size, static_cast<size_t>(pub_inputs_offset.get_value()));
+        public_inputs, beta, gamma, circuit_size, static_cast<uint32_t>(pub_inputs_offset.get_value()));
     const FF lookup_grand_product_delta =
         proof_system::honk::compute_lookup_grand_product_delta<FF>(beta, gamma, circuit_size);
 
@@ -115,7 +115,7 @@ std::array<typename Flavor::GroupElement, 2> UltraRecursiveVerifier_<Flavor>::ve
     commitments.z_lookup = transcript.template receive_from_prover<Commitment>(commitment_labels.z_lookup);
 
     // Execute Sumcheck Verifier
-    auto sumcheck = Sumcheck(static_cast<size_t>(circuit_size.get_value()));
+    auto sumcheck = Sumcheck(static_cast<uint32_t>(circuit_size.get_value()));
 
     std::optional sumcheck_output = sumcheck.verify(relation_parameters, transcript);
 


### PR DESCRIPTION
Unfortunately size_t seems to be weird on newer clang - it is defined as unsigned long and incompatible with both our `uint32_t` and `uint64_t` types suddenly! There's a few ways to resolve this, but overall I don't think `size_t` is needed. It's weird for us to rely too much on the native word size. I think we should use `uint32_t` if makes sense (sizes that will be under 4 billion etc and we want to use the fastest type in WASM) and uint64_t if it makes sense (if we need the size, want an efficient math type for bigint multiplies etc). 

There's a chance something weirder is going on, but I would think that (e.g. malfunctioning int types) would trigger a lot of errors.