### PR TITLE
fix: typescript lookup of aztec.js types

### DIFF
--- a/yarn-project/aztec.js/package.json
+++ b/yarn-project/aztec.js/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "exports": {
     "node": "./dest/index.js",
-    "default": "./dest/main.js"
+    "default": "./dest/main.js",
+    "import": "./dest/index.js"
   },
   "typedocOptions": {
     "entryPoints": [


### PR DESCRIPTION
This doesn't necessarily affect how e.g. vite bundles the code, but typescript needs to know how to import the code.
