### PR TITLE
fix: unify base64 interface between mac and linux (cherry-picked)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1239,6 +1239,7 @@ circuits-x86_64-test: &circuits-x86_64-test
   requires:
     - circuits-x86_64-linux-clang-assert
   <<: *defaults
+
 workflows:
   system:
     when:

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/bb/get_bytecode.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/bb/get_bytecode.hpp
@@ -6,12 +6,6 @@
  */
 inline std::vector<uint8_t> get_bytecode(const std::string& bytecodePath)
 {
-// base64 on mac is different from linux
-#ifdef __APPLE__
-    std::string command = "base64 -D -i " + bytecodePath + " | gunzip";
-#else
-    std::string command = "base64 -d " + bytecodePath + " | gunzip";
-#endif
-
+    std::string command = "cat " + bytecodePath + " | base64 -d | gunzip";
     return exec_pipe(command);
 }


### PR DESCRIPTION
Similar to the solution noted https://github.com/AztecProtocol/aztec-packages/issues/1850#issuecomment-1696569591

This has moved up in priority because Mac has decided to change the base64 interface again for newer Mac's.

We can remove base64 in a followup PR, it was originally blocked by double_verify_proof but we've noted that is an orthogonal problem.

This has been cherry-picked from https://github.com/AztecProtocol/aztec-packages/pull/1855

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
