### PR TITLE
chore: remove debug output from `run_acir_tests` script

### DIFF
--- a/circuits/cpp/barretenberg/acir_tests/run_acir_tests.sh
+++ b/circuits/cpp/barretenberg/acir_tests/run_acir_tests.sh
@@ -54,7 +54,7 @@ function test() {
     $BB prove_and_verify -c $CRS_PATH -b ./target/$dir_name.bytecode > /dev/null 2>&1
   fi
   result=$?
-  set -xeu
+  set -eu
 
   if [ $result -eq 0 ]; then
     echo -e "\033[32mPASSED\033[0m"


### PR DESCRIPTION
This snuck in in the https://github.com/AztecProtocol/aztec-packages/commit/0036e0742a67dfa8aa1fcdb498b89caca6441508 PR.

`-x` allows one to print the command before executing it, so its good for debugging, but when running tests it becomes verbose for the CI

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
