### PR TITLE
fix(rpc): Fixes getNodeInfo serialisation

### DIFF
--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/test/aztec_rpc_test_suite.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/test/aztec_rpc_test_suite.ts
@@ -132,9 +132,9 @@ export const aztecRpcTestSuite = (testName: string, aztecRpcSetup: () => Promise
 
     it('successfully gets node info', async () => {
       const nodeInfo = await rpc.getNodeInfo();
-      expect(nodeInfo.version).toBeDefined();
-      expect(nodeInfo.chainId).toBeDefined();
-      expect(nodeInfo.rollupAddress).toBeDefined();
+      expect(typeof nodeInfo.version).toEqual('number');
+      expect(typeof nodeInfo.chainId).toEqual('number');
+      expect(nodeInfo.rollupAddress.toString()).toMatch(/0x[a-fA-F0-9]+/);
     });
 
     // Note: Not testing `isGlobalStateSynchronised`, `isAccountStateSynchronised` and `getSyncStatus` as these methods


### PR DESCRIPTION
When calling the RPC server across HTTP, the automagical json-rpc-server serialisation was failing to deserialise the `NodeInfo`. The constructor of the NodeInfo object was not exactly `Object`, so the converter did not go recursively into each field. 

This PR makes the check for "is something an object" wider, and changes the RPC server test so it reproduces the issue without the fix. Before this change, `getNodeInfo().rollupAddress` was equal to `{ type: 'EthAddress', data: '0x...' }`, so calling `toString()` on it resulted in the string `[object Object]`.