### PR TITLE
fix: Fix off by one in circuits.js when fetching points from transcript

### DIFF
--- a/yarn-project/circuits.js/src/crs/index.ts
+++ b/yarn-project/circuits.js/src/crs/index.ts
@@ -95,7 +95,7 @@ export class FileCrs {
     const g1Start = 28;
     const g1Length = this.numPoints * 64;
 
-    const g2Start = 28 + 5040000 * 64;
+    const g2Start = 28 + 5040001 * 64;
     const g2Length = 128;
     // Lazily seek our data
     const fileHandle = await open(this.path, 'r');


### PR DESCRIPTION
This now accounts for the generator point being added to the beginning of the transcript.

Since no proofs were being made, this does not fail any tests as there is no need to download the crs.


