### PR TITLE
feat(892): add hints for matching transient read requests with correspondi…

### DIFF
--- a/circuits/cpp/src/aztec3/circuits/abis/private_kernel/private_kernel_inputs_ordering.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/private_kernel/private_kernel_inputs_ordering.hpp
@@ -8,8 +8,6 @@
 
 #include <barretenberg/barretenberg.hpp>
 
-#include <cstdint>
-
 namespace aztec3::circuits::abis::private_kernel {
 
 using aztec3::utils::types::CircuitTypes;

--- a/circuits/cpp/src/aztec3/circuits/abis/private_kernel/private_kernel_inputs_ordering.hpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/private_kernel/private_kernel_inputs_ordering.hpp
@@ -8,6 +8,8 @@
 
 #include <barretenberg/barretenberg.hpp>
 
+#include <cstdint>
+
 namespace aztec3::circuits::abis::private_kernel {
 
 using aztec3::utils::types::CircuitTypes;

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/common.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/common.cpp
@@ -22,7 +22,6 @@ using aztec3::circuits::abis::KernelCircuitPublicInputs;
 using aztec3::circuits::abis::NewContractData;
 using aztec3::circuits::abis::ReadRequestMembershipWitness;
 
-using aztec3::utils::array_length;
 using aztec3::utils::array_push;
 using aztec3::utils::is_array_empty;
 using aztec3::utils::push_array_to_array;

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit.test.cpp
@@ -60,7 +60,7 @@ TEST_F(native_private_kernel_tests, native_accumulate_transient_read_requests)
     private_inputs_init.private_call.read_request_membership_witnesses[0].is_transient = true;
 
     std::array<fr, MAX_READ_REQUESTS_PER_TX> hint_to_commitments{};
-    hint_to_commitments[0] = private_inputs_init.private_call.read_request_membership_witnesses[0].hint_to_commitment;
+    hint_to_commitments[0] = fr(1);
 
     DummyBuilder builder = DummyBuilder("native_private_kernel_tests__native_accumulate_transient_read_requests");
     auto public_inputs = native_private_kernel_circuit_initial(builder, private_inputs_init);
@@ -76,7 +76,7 @@ TEST_F(native_private_kernel_tests, native_accumulate_transient_read_requests)
     private_inputs_inner.private_call.call_stack_item.public_inputs.read_requests[0] = fr(12);
     private_inputs_inner.private_call.read_request_membership_witnesses[0].is_transient = true;
 
-    hint_to_commitments[1] = private_inputs_inner.private_call.read_request_membership_witnesses[0].hint_to_commitment;
+    hint_to_commitments[1] = fr(0);
 
     // We need to update the previous_kernel's private_call_stack because the current_call_stack_item has changed
     // i.e. we changed the new_commitments and read_requests of the current_call_stack_item's public_inputs
@@ -117,7 +117,7 @@ TEST_F(native_private_kernel_tests, native_transient_read_requests_no_match)
     private_inputs_init.private_call.read_request_membership_witnesses[0].is_transient = true;
 
     std::array<fr, MAX_READ_REQUESTS_PER_TX> hint_to_commitments{};
-    hint_to_commitments[0] = private_inputs_init.private_call.read_request_membership_witnesses[0].hint_to_commitment;
+    hint_to_commitments[0] = fr(1);
 
     DummyBuilder builder = DummyBuilder("native_private_kernel_tests__native_transient_read_requests_no_match");
     auto public_inputs = native_private_kernel_circuit_initial(builder, private_inputs_init);
@@ -133,7 +133,7 @@ TEST_F(native_private_kernel_tests, native_transient_read_requests_no_match)
     private_inputs_inner.private_call.call_stack_item.public_inputs.read_requests[0] = fr(12);
     private_inputs_inner.private_call.read_request_membership_witnesses[0].is_transient = true;
 
-    hint_to_commitments[1] = private_inputs_inner.private_call.read_request_membership_witnesses[0].hint_to_commitment;
+    hint_to_commitments[1] = fr(0);  // There is not correct possible value.
 
     // We need to update the previous_kernel's private_call_stack because the current_call_stack_item has changed
     // i.e. we changed the new_commitments and read_requests of the current_call_stack_item's public_inputs

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit_ordering.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit_ordering.cpp
@@ -12,9 +12,6 @@
 
 #include <barretenberg/numeric/uint256/uint256.hpp>
 
-#include <cstddef>
-#include <cstdint>
-
 namespace {
 using NT = aztec3::utils::types::NativeTypes;
 

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit_ordering.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit_ordering.cpp
@@ -10,7 +10,10 @@
 #include "aztec3/utils/circuit_errors.hpp"
 #include "aztec3/utils/dummy_circuit_builder.hpp"
 
+#include <barretenberg/numeric/uint256/uint256.hpp>
+
 #include <cstddef>
+#include <cstdint>
 
 namespace {
 using NT = aztec3::utils::types::NativeTypes;
@@ -34,9 +37,6 @@ void initialise_end_values(PreviousKernelData<NT> const& previous_kernel,
 
 namespace aztec3::circuits::kernel::private_kernel {
 
-// TODO(https://github.com/AztecProtocol/aztec-packages/issues/892): optimized based on hints
-// regarding matching a read request to a commitment
-// i.e., we get pairs i,j such that read_requests[i] == new_commitments[j]
 void match_reads_to_commitments(DummyCircuitBuilder& builder,
                                 std::array<NT::fr, MAX_READ_REQUESTS_PER_TX> const& read_requests,
                                 std::array<NT::fr, MAX_READ_REQUESTS_PER_TX> const& hint_to_commitments,
@@ -46,16 +46,14 @@ void match_reads_to_commitments(DummyCircuitBuilder& builder,
     for (size_t rr_idx = 0; rr_idx < MAX_READ_REQUESTS_PER_TX; rr_idx++) {
         const auto& read_request = read_requests[rr_idx];
         const auto& hint_to_commitment = hint_to_commitments[rr_idx];
+        const auto hint_pos = static_cast<size_t>(uint64_t(hint_to_commitment));
 
         if (read_request != 0) {
             size_t match_pos = MAX_NEW_COMMITMENTS_PER_TX;
-            // TODO(https://github.com/AztecProtocol/aztec-packages/issues/892): inefficient
-            // O(n^2) inner loop will be optimized via matching hints
-            for (size_t c_idx = 0; c_idx < MAX_NEW_COMMITMENTS_PER_TX; c_idx++) {
-                match_pos = (read_request == new_commitments[c_idx]) ? c_idx : match_pos;
+            if (hint_pos < MAX_NEW_COMMITMENTS_PER_TX) {
+                match_pos = read_request == new_commitments[hint_pos] ? hint_pos : match_pos;
             }
 
-            // Transient reads MUST match a pending commitment
             builder.do_assert(
                 match_pos != MAX_NEW_COMMITMENTS_PER_TX,
                 format("read_request at position [",

--- a/yarn-project/aztec-rpc/src/kernel_prover/kernel_prover.ts
+++ b/yarn-project/aztec-rpc/src/kernel_prover/kernel_prover.ts
@@ -3,6 +3,7 @@ import {
   AztecAddress,
   CONTRACT_TREE_HEIGHT,
   Fr,
+  MAX_NEW_COMMITMENTS_PER_TX,
   MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL,
   MAX_READ_REQUESTS_PER_CALL,
   MAX_READ_REQUESTS_PER_TX,
@@ -19,7 +20,7 @@ import {
   makeEmptyProof,
   makeTuple,
 } from '@aztec/circuits.js';
-import { assertLength } from '@aztec/foundation/serialize';
+import { Tuple, assertLength } from '@aztec/foundation/serialize';
 
 import { KernelProofCreator, ProofCreator, ProofOutput, ProofOutputFinal } from './proof_creator.js';
 import { ProvingDataOracle } from './proving_data_oracle.js';
@@ -84,9 +85,6 @@ export class KernelProver {
       publicInputs: PrivateKernelPublicInputs.empty(),
       proof: makeEmptyProof(),
     };
-
-    //TODO(#892): Dealing with this ticket we will fill the following hint array with the correct hints.
-    const hintToCommitments = makeTuple(MAX_READ_REQUESTS_PER_TX, Fr.zero);
 
     while (executionStack.length) {
       const currentExecution = executionStack.pop()!;
@@ -169,6 +167,10 @@ export class KernelProver {
       assertLength<Fr, typeof VK_TREE_HEIGHT>(previousVkMembershipWitness.siblingPath, VK_TREE_HEIGHT),
     );
 
+    const hintToCommitments = this.getReadRequestHints(
+      output.publicInputs.end.readRequests,
+      output.publicInputs.end.newCommitments,
+    );
     const privateInputs = new PrivateKernelInputsOrdering(previousKernelData, hintToCommitments);
     const outputFinal = await this.proofCreator.createProofOrdering(privateInputs);
 
@@ -238,5 +240,24 @@ export class KernelProver {
       data,
       commitment: newCommitments[i],
     }));
+  }
+
+  private getReadRequestHints(
+    readRequests: Tuple<Fr, typeof MAX_READ_REQUESTS_PER_TX>,
+    commitments: Tuple<Fr, typeof MAX_NEW_COMMITMENTS_PER_TX>,
+  ): Tuple<Fr, typeof MAX_READ_REQUESTS_PER_TX> {
+    const hints = makeTuple(MAX_READ_REQUESTS_PER_TX, Fr.zero);
+    for (let i = 0; i < MAX_READ_REQUESTS_PER_TX && !readRequests[i].isZero(); i++) {
+      const equalToRR = (cmt: Fr) => cmt.equals(readRequests[i]);
+      const result = commitments.findIndex(equalToRR);
+      if (result == -1) {
+        throw new Error(
+          `The read request at index ${i} with value ${readRequests[i].toString()} does not match to any commitment.`,
+        );
+      } else {
+        hints[i] = new Fr(result);
+      }
+    }
+    return hints;
   }
 }


### PR DESCRIPTION
Add hints for matching transient read requests with corresponding commitments.
Resolves #892 

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [x] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [x] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
