### PR TITLE
fix: Option to fail silently when retrying

### DIFF
--- a/yarn-project/foundation/src/json-rpc/client/json_rpc_client.ts
+++ b/yarn-project/foundation/src/json-rpc/client/json_rpc_client.ts
@@ -79,6 +79,7 @@ export function makeFetch(retries: number[], noRetry: boolean, log?: DebugLogger
       'JsonRpcClient request',
       makeBackoff(retries),
       log,
+      true,
     );
   };
 }

--- a/yarn-project/foundation/src/retry/index.ts
+++ b/yarn-project/foundation/src/retry/index.ts
@@ -40,6 +40,7 @@ export function* makeBackoff(retries: number[]) {
  * @param name - The optional name of the operation, used for logging purposes.
  * @param backoff - The optional backoff generator providing the intervals in seconds between retries. Defaults to a predefined series.
  * @param log - Logger to use for logging.
+ * @param failSilently - Do not log errors while retrying.
  * @returns A Promise that resolves with the successful result of the provided function, or rejects if backoff generator ends.
  * @throws If `NoRetryError` is thrown by the `fn`, it is rethrown.
  */
@@ -48,6 +49,7 @@ export async function retry<Result>(
   name = 'Operation',
   backoff = backoffGenerator(),
   log = createDebugLogger('aztec:foundation:retry'),
+  failSilently = false,
 ) {
   while (true) {
     try {
@@ -62,7 +64,7 @@ export async function retry<Result>(
         throw err;
       }
       log(`${name} failed. Will retry in ${s}s...`);
-      log.error(err);
+      !failSilently && log.error(err);
       await sleep(s * 1000);
       continue;
     }


### PR DESCRIPTION
Fixes #1783 
Add `failSilently` option to `retry` function. 
This means that nothing will be printed until we run out of retries, at which point the error will be thrown.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
