### PR TITLE
fix: Update "Edit this page" url to link to the correct repo

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -41,7 +41,12 @@ const config = {
         docs: {
           path: "processed-docs",
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/AztecProtocol/docs/edit/main/",
+          editUrl: (params) => {
+            return (
+              `https://github.com/AztecProtocol/aztec-packages/edit/master/docs/docs/` +
+              params.docPath
+            );
+          },
           routeBasePath: "/",
           remarkPlugins: [math],
           rehypePlugins: [katex],


### PR DESCRIPTION
The current "edit this page" link url on the bottom of each page links to the other docs repo (https://github.com/AztecProtocol/docs). This PR updates it to point to the docs in this repo. 

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [x] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
