### PR TITLE
fix: dont assume safety of nvm

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -10,7 +10,7 @@ if [ "$(uname)" = "Darwin" ]; then
 else
   \. ~/.nvm/nvm.sh
 fi
-set +eu
+set +eu # nvm runs in our context - don't assume it's compatible with these flags
 nvm install
 set -eu
 

--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -10,7 +10,9 @@ if [ "$(uname)" = "Darwin" ]; then
 else
   \. ~/.nvm/nvm.sh
 fi
+set +eu
 nvm install
+set -eu
 
 yarn install --immutable
 


### PR DESCRIPTION
This runs in the context of our bash setup and generally for various reasons has errored on me. Since we don't control this script, toggle off safety