### PR TITLE
fix: padded printing for e2e-cli

### DIFF
--- a/yarn-project/cli/src/index.ts
+++ b/yarn-project/cli/src/index.ts
@@ -113,7 +113,7 @@ export function getProgram(log: LogFn, debugLogger: DebugLogger): Command {
         publicKey = await generatePublicKey(key);
       } else {
         const key = GrumpkinScalar.random();
-        privKey = key.toString();
+        privKey = key.toString(true);
         publicKey = await generatePublicKey(key);
       }
       log(`\nPrivate Key: ${privKey}\nPublic Key: ${publicKey.toString()}\n`);
@@ -144,7 +144,7 @@ export function getProgram(log: LogFn, debugLogger: DebugLogger): Command {
       log(`\nCreated new account:\n`);
       log(`Address:         ${address.toString()}`);
       log(`Public key:      ${publicKey.toString()}`);
-      if (!options.privateKey) log(`Private key:     ${privateKey.toString()}`);
+      if (!options.privateKey) log(`Private key:     ${privateKey.toString(true)}`);
       log(`Partial address: ${partialAddress.toString()}`);
     });
 

--- a/yarn-project/foundation/src/fields/grumpkin_scalar.ts
+++ b/yarn-project/foundation/src/fields/grumpkin_scalar.ts
@@ -108,10 +108,11 @@ export class GrumpkinScalar {
    * The resulting string is prefixed with '0x' and contains the exact number of hex characters required
    * to represent the numeric value of this instance.
    *
+   * @param padTo32 - Whether to pad the resulting string to 32 bytes.
    * @returns A hexadecimal string representing the GrumpkinScalar value.
    */
-  toString() {
-    return toHex(this.value);
+  toString(padTo32 = false) {
+    return toHex(this.value, padTo32);
   }
 
   /**


### PR DESCRIPTION
This fixes a 1 in 256 chance of failure when the last hex byte was 00.