### PR TITLE
fix: COMMIT_TAG arg value in canary Dockerfile

### DIFF
--- a/yarn-project/canary/Dockerfile
+++ b/yarn-project/canary/Dockerfile
@@ -2,7 +2,7 @@ FROM node:18-alpine
 RUN apk update && apk add --no-cache udev ttf-freefont chromium curl jq bash
 ENV CHROME_BIN="/usr/bin/chromium-browser" PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
 
-ARG COMMIT_TAG="v0.1.0-alpha62"
+ARG COMMIT_TAG=""
 
 #Build canary
 WORKDIR /usr/src/


### PR DESCRIPTION
This change went in mistakenly, the value should stay empty

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
