### PR TITLE
fix: retry with git checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ checkout: &checkout
 
       # Only download metadata when fetching.
       retry git fetch --depth 1 --filter=blob:none origin $CIRCLE_SHA1
-      git checkout FETCH_HEAD
+      retry git checkout FETCH_HEAD
 
 # Called setup_env to setup a bunch of global variables used throughout the rest of the build process.
 # It takes the required CCI environment variables as inputs, and gives them normalised names for the rest of


### PR DESCRIPTION
Works around rate limiting on git. We may want to up this count but it is not a bad idea to still have retries. Turns out this hits the network. Not that surprising in retrospect (git checkout can sync to find branches on the remote), but I usually think of it in the fully local DB case so didn't think of adding this before
