### PR TITLE
fix: disable barretenberg-benchmark-aggregator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,18 +227,18 @@ jobs:
           command: cond_spot_run_tests barretenberg-x86_64-linux-clang-assert 3 join_split_example_proofs_join_split_tests --gtest_filter=-*full_proof*
       - *save_logs
 
-  barretenberg-benchmark-aggregator:
-    docker:
-      - image: aztecprotocol/alpine-build-image
-    resource_class: small
-    steps:
-      - attach_workspace:
-          at: /tmp/test-logs
-      - *checkout
-      - *setup_env
-      - run:
-          name: "Test"
-          command: ./scripts/ci/store_test_benchmark_logs $AZTEC_GITHUB_TOKEN
+  # barretenberg-benchmark-aggregator:
+  #   docker:
+  #     - image: aztecprotocol/alpine-build-image
+  #   resource_class: small
+  #   steps:
+  #     - attach_workspace:
+  #         at: /tmp/test-logs
+  #     - *checkout
+  #     - *setup_env
+  #     - run:
+  #         name: "Test"
+  #         command: ./scripts/ci/store_test_benchmark_logs $AZTEC_GITHUB_TOKEN
 
   barretenberg-acir-tests-bb:
     docker:
@@ -1292,18 +1292,18 @@ workflows:
       - barretenberg-stdlib-recursion-turbo-tests: *bb_test
       - barretenberg-stdlib-recursion-ultra-tests: *bb_test
       - barretenberg-join-split-tests: *bb_test
-      - barretenberg-benchmark-aggregator:
-          requires:
-            - barretenberg-tests
-            - barretenberg-stdlib-tests
-            - barretenberg-stdlib-recursion-turbo-tests
-            - barretenberg-stdlib-recursion-ultra-tests
-            - barretenberg-join-split-tests
-          filters:
-            branches:
-              only:
-                - master
-          <<: *defaults
+      # - barretenberg-benchmark-aggregator:
+      #     requires:
+      #       - barretenberg-tests
+      #       - barretenberg-stdlib-tests
+      #       - barretenberg-stdlib-recursion-turbo-tests
+      #       - barretenberg-stdlib-recursion-ultra-tests
+      #       - barretenberg-join-split-tests
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      #     <<: *defaults
       - bb-js:
           requires:
             - barretenberg-wasm-linux-clang


### PR DESCRIPTION
Workaround until we figure this out. it's got a few undesirable properties right now
- git clone is broken (by me)
- relies on build reruns but we content cache
- uses circleci assumptions

Will rework soon