### PR TITLE
fix: use Github Bot token for dispatch workflow

### DIFF
--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -19,6 +19,7 @@ jobs:
         id: release
         uses: google-github-actions/release-please-action@v3
         with:
+          token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           command: manifest
 
       - name: Dispatch to publish workflow
@@ -26,7 +27,6 @@ jobs:
         if: ${{ steps.release.outputs.tag_name }}
         with:
           workflow: publish-bb.yml
-          repo: AztecProtocol/aztec-packages
           ref: master
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           inputs: '{ "tag": "${{ steps.release.outputs.tag_name }}", "publish": true }'


### PR DESCRIPTION
The github dispatch workflow is not working when we cut releases. This is a potential fix.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
