### PR TITLE
fix: msgpack blowup with bigger objects

### DIFF
--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/serialize/msgpack_impl/schema_impl.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/serialize/msgpack_impl/schema_impl.hpp
@@ -212,7 +212,7 @@ inline void msgpack_schema_pack(MsgpackSchemaPacker& packer, std::array<T, N> co
  * @param obj The object to print schema of.
  * @return std::string The schema as a string.
  */
-inline std::string msgpack_schema_to_string(auto obj)
+inline std::string msgpack_schema_to_string(const auto& obj)
 {
     msgpack::sbuffer output;
     MsgpackSchemaPacker printer{ output };


### PR DESCRIPTION
These objects are quite big, but the reason it breaks wasm is not super clear.