### PR TITLE
fix: Format barretenberg

### DIFF
--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/benchmark/relations_bench/barycentric.bench.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/benchmark/relations_bench/barycentric.bench.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barretenberg/polynomials/barycentric.hpp"
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include <benchmark/benchmark.h>
 
 using namespace benchmark;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/common/fuzzer.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/common/fuzzer.hpp
@@ -88,82 +88,79 @@ class FastRandom {
  *
  * @tparam T
  */
-template <typename T> concept SimpleRng = requires(T a)
-{
-    {
-        a.next()
-    }
-    ->std::convertible_to<uint32_t>;
-};
+template <typename T>
+concept SimpleRng = requires(T a) {
+                        {
+                            a.next()
+                            } -> std::convertible_to<uint32_t>;
+                    };
 /**
  * @brief Concept for forcing ArgumentSizes to be size_t
  *
  * @tparam T
  */
-template <typename T> concept InstructionArgumentSizes = requires
-{
-    {
-        std::make_tuple(T::CONSTANT,
-                        T::WITNESS,
-                        T::CONSTANT_WITNESS,
-                        T::ADD,
-                        T::SUBTRACT,
-                        T::MULTIPLY,
-                        T::DIVIDE,
-                        T::ADD_TWO,
-                        T::MADD,
-                        T::MULT_MADD,
-                        T::MSUB_DIV,
-                        T::SQR,
-                        T::SQR_ADD,
-                        T::SUBTRACT_WITH_CONSTRAINT,
-                        T::DIVIDE_WITH_CONSTRAINTS,
-                        T::SLICE,
-                        T::ASSERT_ZERO,
-                        T::ASSERT_NOT_ZERO)
-    }
-    ->std::same_as<std::tuple<size_t>>;
-};
+template <typename T>
+concept InstructionArgumentSizes = requires {
+                                       {
+                                           std::make_tuple(T::CONSTANT,
+                                                           T::WITNESS,
+                                                           T::CONSTANT_WITNESS,
+                                                           T::ADD,
+                                                           T::SUBTRACT,
+                                                           T::MULTIPLY,
+                                                           T::DIVIDE,
+                                                           T::ADD_TWO,
+                                                           T::MADD,
+                                                           T::MULT_MADD,
+                                                           T::MSUB_DIV,
+                                                           T::SQR,
+                                                           T::SQR_ADD,
+                                                           T::SUBTRACT_WITH_CONSTRAINT,
+                                                           T::DIVIDE_WITH_CONSTRAINTS,
+                                                           T::SLICE,
+                                                           T::ASSERT_ZERO,
+                                                           T::ASSERT_NOT_ZERO)
+                                           } -> std::same_as<std::tuple<size_t>>;
+                                   };
 
 /**
  * @brief Concept for Havoc Configurations
  *
  * @tparam T
  */
-template <typename T> concept HavocConfigConstraint = requires
-{
-    {
-        std::make_tuple(T::GEN_MUTATION_COUNT_LOG, T::GEN_STRUCTURAL_MUTATION_PROBABILITY)
-    }
-    ->std::same_as<std::tuple<size_t>>;
-    T::GEN_MUTATION_COUNT_LOG <= 7;
-};
+template <typename T>
+concept HavocConfigConstraint =
+    requires {
+        {
+            std::make_tuple(T::GEN_MUTATION_COUNT_LOG, T::GEN_STRUCTURAL_MUTATION_PROBABILITY)
+            } -> std::same_as<std::tuple<size_t>>;
+        T::GEN_MUTATION_COUNT_LOG <= 7;
+    };
 /**
  * @brief Concept specifying the class used by the fuzzer
  *
  * @tparam T
  */
-template <typename T> concept ArithmeticFuzzHelperConstraint = requires
-{
-    typename T::ArgSizes;
-    typename T::Instruction;
-    typename T::ExecutionState;
-    typename T::ExecutionHandler;
-    InstructionArgumentSizes<typename T::ArgSizes>;
-};
+template <typename T>
+concept ArithmeticFuzzHelperConstraint = requires {
+                                             typename T::ArgSizes;
+                                             typename T::Instruction;
+                                             typename T::ExecutionState;
+                                             typename T::ExecutionHandler;
+                                             InstructionArgumentSizes<typename T::ArgSizes>;
+                                         };
 
 /**
  * @brief Fuzzer uses only composers with check_circuit function
  *
  * @tparam T
  */
-template <typename T> concept CheckableComposer = requires(T a)
-{
-    {
-        a.check_circuit()
-    }
-    ->std::same_as<bool>;
-};
+template <typename T>
+concept CheckableComposer = requires(T a) {
+                                {
+                                    a.check_circuit()
+                                    } -> std::same_as<bool>;
+                            };
 
 /**
  * @brief The fuzzer can use a postprocessing function that is specific to the type being fuzzed
@@ -173,13 +170,11 @@ template <typename T> concept CheckableComposer = requires(T a)
  * @tparam Context The class containing the full context
  */
 template <typename T, typename Composer, typename Context>
-concept PostProcessingEnabled = requires(Composer composer, Context context)
-{
-    {
-        T::postProcess(&composer, context)
-    }
-    ->std::same_as<bool>;
-};
+concept PostProcessingEnabled = requires(Composer composer, Context context) {
+                                    {
+                                        T::postProcess(&composer, context)
+                                        } -> std::same_as<bool>;
+                                };
 
 /**
  * @brief This concept is used when we want to limit the number of executions of certain instructions (for example,
@@ -187,11 +182,11 @@ concept PostProcessingEnabled = requires(Composer composer, Context context)
  *
  * @tparam T
  */
-template <typename T> concept InstructionWeightsEnabled = requires
-{
-    typename T::InstructionWeights;
-    T::InstructionWeights::_LIMIT;
-};
+template <typename T>
+concept InstructionWeightsEnabled = requires {
+                                        typename T::InstructionWeights;
+                                        T::InstructionWeights::_LIMIT;
+                                    };
 
 /**
  * @brief Mutate the value of a field element
@@ -202,7 +197,9 @@ template <typename T> concept InstructionWeightsEnabled = requires
  * @param havoc_config Mutation configuration
  * @return Mutated element
  */
-template <typename T, typename FF> inline static FF mutateFieldElement(FF e, T& rng) requires SimpleRng<T>
+template <typename T, typename FF>
+inline static FF mutateFieldElement(FF e, T& rng)
+    requires SimpleRng<T>
 {
     // With a certain probability, we apply changes to the Montgomery form, rather than the plain form. This
     // has merit, since the computation is performed in montgomery form and comparisons are often performed
@@ -292,7 +289,9 @@ template <typename T, typename FF> inline static FF mutateFieldElement(FF e, T& 
  *
  * @tparam T
  */
-template <typename T> requires ArithmeticFuzzHelperConstraint<T> class ArithmeticFuzzHelper {
+template <typename T>
+    requires ArithmeticFuzzHelperConstraint<T>
+class ArithmeticFuzzHelper {
   private:
     /**
      * @brief Mutator swapping two instructions together
@@ -599,8 +598,8 @@ template <typename T> requires ArithmeticFuzzHelperConstraint<T> class Arithmeti
     template <typename Composer>
     // TODO(@Rumata888)(from Zac: maybe try to fix? not comfortable refactoring this myself. Issue #1807)
     // NOLINTNEXTLINE(readability-function-size, google-readability-function-size)
-    inline static void executeInstructions(
-        std::vector<typename T::Instruction>& instructions) requires CheckableComposer<Composer>
+    inline static void executeInstructions(std::vector<typename T::Instruction>& instructions)
+        requires CheckableComposer<Composer>
     {
         typename T::ExecutionState state;
         Composer composer = Composer();

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/common/serialize.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/common/serialize.hpp
@@ -51,7 +51,8 @@ __extension__ using uint128_t = unsigned __int128;
 // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast, cert-dcl58-cpp)
 // clang-format on
 
-template <typename T> concept IntegralOrEnum = std::integral<T> || std::is_enum_v<T>;
+template <typename T>
+concept IntegralOrEnum = std::integral<T> || std::is_enum_v<T>;
 
 namespace serialize {
 // Forward declare derived msgpack methods

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/common/streams.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/common/streams.hpp
@@ -110,7 +110,8 @@ template <std::integral T, typename A> inline std::ostream& operator<<(std::ostr
 }
 
 template <typename T, typename A>
-requires(!std::integral<T>) inline std::ostream& operator<<(std::ostream& os, std::vector<T, A> const& arr)
+    requires(!std::integral<T>)
+inline std::ostream& operator<<(std::ostream& os, std::vector<T, A> const& arr)
 {
     os << "[\n";
     for (auto element : arr) {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/crypto/blake3s/blake3s.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/crypto/blake3s/blake3s.test.cpp
@@ -1,5 +1,5 @@
-#include "../blake2s/blake2s.hpp"
 #include "blake3s.hpp"
+#include "../blake2s/blake2s.hpp"
 
 #include <gtest/gtest.h>
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/crypto/ecdsa/ecdsa.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/crypto/ecdsa/ecdsa.test.cpp
@@ -1,8 +1,8 @@
+#include "ecdsa.hpp"
 #include "barretenberg/common/serialize.hpp"
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 #include "barretenberg/ecc/curves/secp256r1/secp256r1.hpp"
 #include "barretenberg/serialize/test_helper.hpp"
-#include "ecdsa.hpp"
 #include <gtest/gtest.h>
 
 using namespace barretenberg;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/crypto/generators/generator_data.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/crypto/generators/generator_data.test.cpp
@@ -1,5 +1,5 @@
-#include "./fixed_base_scalar_mul.hpp"
 #include "./generator_data.hpp"
+#include "./fixed_base_scalar_mul.hpp"
 #include "barretenberg/common/streams.hpp"
 #include <gtest/gtest.h>
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/crypto/hmac/hmac.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/crypto/hmac/hmac.hpp
@@ -93,8 +93,8 @@ std::array<uint8_t, Hash::OUTPUT_SIZE> hmac(const MessageContainer& message, con
  * @return Fr output field element as uint512_t( H(10...0 || HMAC(k,m)) || H(00...0 || HMAC(k,m)) ) % r
  */
 template <typename Hash, typename Fr, typename MessageContainer, typename KeyContainer>
-Fr get_unbiased_field_from_hmac(const MessageContainer& message,
-                                const KeyContainer& key) requires(Hash::OUTPUT_SIZE == 32)
+Fr get_unbiased_field_from_hmac(const MessageContainer& message, const KeyContainer& key)
+    requires(Hash::OUTPUT_SIZE == 32)
 {
     // Strong assumption that works for now with our suite of Hashers
     static_assert(Hash::BLOCK_SIZE > Hash::OUTPUT_SIZE);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/crypto/schnorr/proof_of_possession.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/crypto/schnorr/proof_of_possession.test.cpp
@@ -1,6 +1,6 @@
 
-#include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 #include "proof_of_possession.hpp"
+#include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 #include <gtest/gtest.h>
 
 using namespace barretenberg;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/crypto/schnorr/schnorr.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/crypto/schnorr/schnorr.test.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 #include "schnorr.hpp"
+#include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 #include <gtest/gtest.h>
 
 using namespace barretenberg;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
@@ -1,7 +1,7 @@
+#include "block_constraint.hpp"
 #include "acir_format.hpp"
 #include "barretenberg/plonk/proof_system/types/proof.hpp"
 #include "barretenberg/plonk/proof_system/verification_key/verification_key.hpp"
-#include "block_constraint.hpp"
 
 #include <gtest/gtest.h>
 #include <vector>

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.test.cpp
@@ -1,8 +1,8 @@
+#include "ecdsa_secp256k1.hpp"
 #include "acir_format.hpp"
 #include "barretenberg/crypto/ecdsa/ecdsa.hpp"
 #include "barretenberg/plonk/proof_system/types/proof.hpp"
 #include "barretenberg/plonk/proof_system/verification_key/verification_key.hpp"
-#include "ecdsa_secp256k1.hpp"
 
 #include <gtest/gtest.h>
 #include <vector>

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256r1.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256r1.test.cpp
@@ -1,8 +1,8 @@
+#include "ecdsa_secp256r1.hpp"
 #include "acir_format.hpp"
 #include "barretenberg/crypto/ecdsa/ecdsa.hpp"
 #include "barretenberg/plonk/proof_system/types/proof.hpp"
 #include "barretenberg/plonk/proof_system/verification_key/verification_key.hpp"
-#include "ecdsa_secp256r1.hpp"
 
 #include <gtest/gtest.h>
 #include <vector>

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.test.cpp
@@ -1,7 +1,7 @@
+#include "recursion_constraint.hpp"
 #include "acir_format.hpp"
 #include "barretenberg/plonk/proof_system/types/proof.hpp"
 #include "barretenberg/plonk/proof_system/verification_key/verification_key.hpp"
-#include "recursion_constraint.hpp"
 
 #include <gtest/gtest.h>
 #include <vector>

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq.test.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/serialize/test_helper.hpp"
 #include "fq.hpp"
+#include "barretenberg/serialize/test_helper.hpp"
 #include <gtest/gtest.h>
 
 using namespace barretenberg;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fr.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fr.test.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/serialize/test_helper.hpp"
 #include "fr.hpp"
+#include "barretenberg/serialize/test_helper.hpp"
 #include <gtest/gtest.h>
 
 using namespace barretenberg;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/curves/secp256k1/secp256k1.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/curves/secp256k1/secp256k1.test.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/numeric/random/engine.hpp"
 #include "secp256k1.hpp"
+#include "barretenberg/numeric/random/engine.hpp"
 #include <gtest/gtest.h>
 
 namespace test_secp256k1 {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/curves/secp256r1/secp256r1.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/curves/secp256r1/secp256r1.test.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/numeric/random/engine.hpp"
 #include "secp256r1.hpp"
+#include "barretenberg/numeric/random/engine.hpp"
 #include <gtest/gtest.h>
 
 namespace test_secp256r1 {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl_x64.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl_x64.hpp
@@ -30,12 +30,12 @@ template <class T> field<T> field<T>::asm_mul_with_coarse_reduction(const field&
             : "%r"(&a),
               "%r"(&b),
               "r"(&r),
-              [ modulus_0 ] "m"(modulus_0),
-              [ modulus_1 ] "m"(modulus_1),
-              [ modulus_2 ] "m"(modulus_2),
-              [ modulus_3 ] "m"(modulus_3),
-              [ r_inv ] "m"(r_inv),
-              [ zero_reference ] "m"(zero_ref)
+              [modulus_0] "m"(modulus_0),
+              [modulus_1] "m"(modulus_1),
+              [modulus_2] "m"(modulus_2),
+              [modulus_3] "m"(modulus_3),
+              [r_inv] "m"(r_inv),
+              [zero_reference] "m"(zero_ref)
             : "%rdx", "%rdi", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
     return r;
 }
@@ -62,12 +62,12 @@ template <class T> void field<T>::asm_self_mul_with_coarse_reduction(const field
             :
             : "r"(&a),
               "r"(&b),
-              [ modulus_0 ] "m"(modulus_0),
-              [ modulus_1 ] "m"(modulus_1),
-              [ modulus_2 ] "m"(modulus_2),
-              [ modulus_3 ] "m"(modulus_3),
-              [ r_inv ] "m"(r_inv),
-              [ zero_reference ] "m"(zero_ref)
+              [modulus_0] "m"(modulus_0),
+              [modulus_1] "m"(modulus_1),
+              [modulus_2] "m"(modulus_2),
+              [modulus_3] "m"(modulus_3),
+              [r_inv] "m"(r_inv),
+              [zero_reference] "m"(zero_ref)
             : "%rdx", "%rdi", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 }
 
@@ -100,12 +100,12 @@ template <class T> field<T> field<T>::asm_sqr_with_coarse_reduction(const field&
             : "%r"(&a),
               "%r"(&a),
               "r"(&r),
-              [ modulus_0 ] "m"(modulus_0),
-              [ modulus_1 ] "m"(modulus_1),
-              [ modulus_2 ] "m"(modulus_2),
-              [ modulus_3 ] "m"(modulus_3),
-              [ r_inv ] "m"(r_inv),
-              [ zero_reference ] "m"(zero_ref)
+              [modulus_0] "m"(modulus_0),
+              [modulus_1] "m"(modulus_1),
+              [modulus_2] "m"(modulus_2),
+              [modulus_3] "m"(modulus_3),
+              [r_inv] "m"(r_inv),
+              [zero_reference] "m"(zero_ref)
             : "%rdx", "%rdi", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 
 #else
@@ -124,12 +124,12 @@ template <class T> field<T> field<T>::asm_sqr_with_coarse_reduction(const field&
             :
             : "r"(&a),
               "r"(&r),
-              [ zero_reference ] "m"(zero_ref),
-              [ modulus_0 ] "m"(modulus_0),
-              [ modulus_1 ] "m"(modulus_1),
-              [ modulus_2 ] "m"(modulus_2),
-              [ modulus_3 ] "m"(modulus_3),
-              [ r_inv ] "m"(r_inv)
+              [zero_reference] "m"(zero_ref),
+              [modulus_0] "m"(modulus_0),
+              [modulus_1] "m"(modulus_1),
+              [modulus_2] "m"(modulus_2),
+              [modulus_3] "m"(modulus_3),
+              [r_inv] "m"(r_inv)
             : "%rcx", "%rdx", "%rdi", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 #endif
     return r;
@@ -162,12 +162,12 @@ template <class T> void field<T>::asm_self_sqr_with_coarse_reduction(const field
             :
             : "r"(&a),
               "r"(&a),
-              [ modulus_0 ] "m"(modulus_0),
-              [ modulus_1 ] "m"(modulus_1),
-              [ modulus_2 ] "m"(modulus_2),
-              [ modulus_3 ] "m"(modulus_3),
-              [ r_inv ] "m"(r_inv),
-              [ zero_reference ] "m"(zero_ref)
+              [modulus_0] "m"(modulus_0),
+              [modulus_1] "m"(modulus_1),
+              [modulus_2] "m"(modulus_2),
+              [modulus_3] "m"(modulus_3),
+              [r_inv] "m"(r_inv),
+              [zero_reference] "m"(zero_ref)
             : "%rdx", "%rdi", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 
 #else
@@ -184,12 +184,12 @@ template <class T> void field<T>::asm_self_sqr_with_coarse_reduction(const field
             STORE_FIELD_ELEMENT("%0", "%%r12", "%%r13", "%%r14", "%%r15")
             :
             : "r"(&a),
-              [ zero_reference ] "m"(zero_ref),
-              [ modulus_0 ] "m"(modulus_0),
-              [ modulus_1 ] "m"(modulus_1),
-              [ modulus_2 ] "m"(modulus_2),
-              [ modulus_3 ] "m"(modulus_3),
-              [ r_inv ] "m"(r_inv)
+              [zero_reference] "m"(zero_ref),
+              [modulus_0] "m"(modulus_0),
+              [modulus_1] "m"(modulus_1),
+              [modulus_2] "m"(modulus_2),
+              [modulus_3] "m"(modulus_3),
+              [r_inv] "m"(r_inv)
             : "%rcx", "%rdx", "%rdi", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 #endif
 }
@@ -213,10 +213,10 @@ template <class T> field<T> field<T>::asm_add_with_coarse_reduction(const field&
             : "%r"(&a),
               "%r"(&b),
               "r"(&r),
-              [ twice_not_modulus_0 ] "m"(twice_not_modulus_0),
-              [ twice_not_modulus_1 ] "m"(twice_not_modulus_1),
-              [ twice_not_modulus_2 ] "m"(twice_not_modulus_2),
-              [ twice_not_modulus_3 ] "m"(twice_not_modulus_3)
+              [twice_not_modulus_0] "m"(twice_not_modulus_0),
+              [twice_not_modulus_1] "m"(twice_not_modulus_1),
+              [twice_not_modulus_2] "m"(twice_not_modulus_2),
+              [twice_not_modulus_3] "m"(twice_not_modulus_3)
             : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
     return r;
 }
@@ -237,10 +237,10 @@ template <class T> void field<T>::asm_self_add_with_coarse_reduction(const field
             :
             : "r"(&a),
               "r"(&b),
-              [ twice_not_modulus_0 ] "m"(twice_not_modulus_0),
-              [ twice_not_modulus_1 ] "m"(twice_not_modulus_1),
-              [ twice_not_modulus_2 ] "m"(twice_not_modulus_2),
-              [ twice_not_modulus_3 ] "m"(twice_not_modulus_3)
+              [twice_not_modulus_0] "m"(twice_not_modulus_0),
+              [twice_not_modulus_1] "m"(twice_not_modulus_1),
+              [twice_not_modulus_2] "m"(twice_not_modulus_2),
+              [twice_not_modulus_3] "m"(twice_not_modulus_3)
             : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 }
 
@@ -261,10 +261,10 @@ template <class T> field<T> field<T>::asm_sub_with_coarse_reduction(const field&
         : "r"(&a),
           "r"(&b),
           "r"(&r),
-          [ twice_modulus_0 ] "m"(twice_modulus_0),
-          [ twice_modulus_1 ] "m"(twice_modulus_1),
-          [ twice_modulus_2 ] "m"(twice_modulus_2),
-          [ twice_modulus_3 ] "m"(twice_modulus_3)
+          [twice_modulus_0] "m"(twice_modulus_0),
+          [twice_modulus_1] "m"(twice_modulus_1),
+          [twice_modulus_2] "m"(twice_modulus_2),
+          [twice_modulus_3] "m"(twice_modulus_3)
         : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
     return r;
 }
@@ -283,10 +283,10 @@ template <class T> void field<T>::asm_self_sub_with_coarse_reduction(const field
         :
         : "r"(&a),
           "r"(&b),
-          [ twice_modulus_0 ] "m"(twice_modulus_0),
-          [ twice_modulus_1 ] "m"(twice_modulus_1),
-          [ twice_modulus_2 ] "m"(twice_modulus_2),
-          [ twice_modulus_3 ] "m"(twice_modulus_3)
+          [twice_modulus_0] "m"(twice_modulus_0),
+          [twice_modulus_1] "m"(twice_modulus_1),
+          [twice_modulus_2] "m"(twice_modulus_2),
+          [twice_modulus_3] "m"(twice_modulus_3)
         : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 }
 
@@ -315,10 +315,10 @@ template <class T> void field<T>::asm_conditional_negate(field& r, const uint64_
             :
             : "r"(predicate),
               "r"(&r),
-              [ twice_modulus_0 ] "i"(twice_modulus_0),
-              [ twice_modulus_1 ] "i"(twice_modulus_1),
-              [ twice_modulus_2 ] "i"(twice_modulus_2),
-              [ twice_modulus_3 ] "i"(twice_modulus_3)
+              [twice_modulus_0] "i"(twice_modulus_0),
+              [twice_modulus_1] "i"(twice_modulus_1),
+              [twice_modulus_2] "i"(twice_modulus_2),
+              [twice_modulus_3] "i"(twice_modulus_3)
             : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 }
 
@@ -337,10 +337,10 @@ template <class T> field<T> field<T>::asm_reduce_once(const field& a) noexcept
             :
             : "r"(&a),
               "r"(&r),
-              [ not_modulus_0 ] "m"(not_modulus_0),
-              [ not_modulus_1 ] "m"(not_modulus_1),
-              [ not_modulus_2 ] "m"(not_modulus_2),
-              [ not_modulus_3 ] "m"(not_modulus_3)
+              [not_modulus_0] "m"(not_modulus_0),
+              [not_modulus_1] "m"(not_modulus_1),
+              [not_modulus_2] "m"(not_modulus_2),
+              [not_modulus_3] "m"(not_modulus_3)
             : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
     return r;
 }
@@ -357,10 +357,10 @@ template <class T> void field<T>::asm_self_reduce_once(const field& a) noexcept
                     STORE_FIELD_ELEMENT("%0", "%%r12", "%%r13", "%%r14", "%%r15")
             :
             : "r"(&a),
-              [ not_modulus_0 ] "m"(not_modulus_0),
-              [ not_modulus_1 ] "m"(not_modulus_1),
-              [ not_modulus_2 ] "m"(not_modulus_2),
-              [ not_modulus_3 ] "m"(not_modulus_3)
+              [not_modulus_0] "m"(not_modulus_0),
+              [not_modulus_1] "m"(not_modulus_1),
+              [not_modulus_2] "m"(not_modulus_2),
+              [not_modulus_3] "m"(not_modulus_3)
             : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "cc", "memory");
 }
 } // namespace barretenberg

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/groups/group_impl_asm.tcc
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/groups/group_impl_asm.tcc
@@ -101,10 +101,10 @@ inline void group<coordinate_field, subgroup_field, GroupParams>::conditional_ne
                              : "r"(src),
                                "r"(dest),
                                "r"(predicate),
-                               [ modulus_0 ] "i"(twice_modulus_0),
-                               [ modulus_1 ] "i"(twice_modulus_1),
-                               [ modulus_2 ] "i"(twice_modulus_2),
-                               [ modulus_3 ] "i"(twice_modulus_3)
+                               [modulus_0] "i"(twice_modulus_0),
+                               [modulus_1] "i"(twice_modulus_1),
+                               [modulus_2] "i"(twice_modulus_2),
+                               [modulus_3] "i"(twice_modulus_3)
                              : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "%ymm0", "memory", "cc");
 #else
         __asm__ __volatile__("xorq %%r8, %%r8                              \n\t"
@@ -141,10 +141,10 @@ inline void group<coordinate_field, subgroup_field, GroupParams>::conditional_ne
                              : "r"(src),
                                "r"(dest),
                                "r"(predicate),
-                               [ modulus_0 ] "i"(twice_modulus_0),
-                               [ modulus_1 ] "i"(twice_modulus_1),
-                               [ modulus_2 ] "i"(twice_modulus_2),
-                               [ modulus_3 ] "i"(twice_modulus_3)
+                               [modulus_0] "i"(twice_modulus_0),
+                               [modulus_1] "i"(twice_modulus_1),
+                               [modulus_2] "i"(twice_modulus_2),
+                               [modulus_3] "i"(twice_modulus_3)
                              : "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "memory", "cc");
 #endif
     } else {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/groups/wnaf.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/ecc/groups/wnaf.test.cpp
@@ -1,6 +1,6 @@
+#include "wnaf.hpp"
 #include "../curves/bn254/fr.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
-#include "wnaf.hpp"
 #include <gtest/gtest.h>
 
 using namespace barretenberg;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/ipa/ipa.hpp
@@ -2,6 +2,7 @@
 #include "barretenberg/common/assert.hpp"
 #include "barretenberg/ecc/scalar_multiplication/scalar_multiplication.hpp"
 #include "barretenberg/honk/pcs/claim.hpp"
+#include "barretenberg/honk/pcs/verification_key.hpp"
 #include "barretenberg/honk/transcript/transcript.hpp"
 #include <cstddef>
 #include <numeric>

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/ipa/ipa.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/ipa/ipa.test.cpp
@@ -1,3 +1,4 @@
+#include "ipa.hpp"
 #include "../gemini/gemini.hpp"
 #include "../shplonk/shplonk.hpp"
 #include "barretenberg/common/mem.hpp"
@@ -6,7 +7,6 @@
 #include "barretenberg/honk/pcs/commitment_key.test.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
 #include "barretenberg/polynomials/polynomial_arithmetic.hpp"
-#include "ipa.hpp"
 #include <gtest/gtest.h>
 using namespace barretenberg;
 namespace proof_system::honk::pcs::ipa::test {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/kzg/kzg.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/kzg/kzg.test.cpp
@@ -1,7 +1,7 @@
 
+#include "kzg.hpp"
 #include "../gemini/gemini.hpp"
 #include "../shplonk/shplonk.hpp"
-#include "kzg.hpp"
 
 #include "../commitment_key.test.hpp"
 #include "barretenberg/honk/pcs/claim.hpp"

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/shplonk/shplonk.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/pcs/shplonk/shplonk.test.cpp
@@ -1,5 +1,5 @@
-#include "../gemini/gemini.hpp"
 #include "shplonk.hpp"
+#include "../gemini/gemini.hpp"
 
 #include <algorithm>
 #include <gtest/internal/gtest-internal.h>

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/proof_system/prover_library.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/proof_system/prover_library.test.cpp
@@ -1,11 +1,11 @@
 
+#include "prover_library.hpp"
 #include "barretenberg/ecc/curves/bn254/bn254.hpp"
 #include "barretenberg/honk/flavor/standard.hpp"
 #include "barretenberg/honk/flavor/ultra.hpp"
 #include "barretenberg/honk/proof_system/grand_product_library.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
 #include "prover.hpp"
-#include "prover_library.hpp"
 
 #include "barretenberg/srs/factories/file_crs_factory.hpp"
 #include <array>

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/sumcheck/sumcheck.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/sumcheck/sumcheck.test.cpp
@@ -1,3 +1,4 @@
+#include "sumcheck.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barretenberg/honk/composer/standard_composer.hpp"
 #include "barretenberg/honk/composer/ultra_composer.hpp"
@@ -10,7 +11,6 @@
 #include "barretenberg/proof_system/relations/lookup_relation.hpp"
 #include "barretenberg/proof_system/relations/permutation_relation.hpp"
 #include "barretenberg/proof_system/relations/ultra_arithmetic_relation.hpp"
-#include "sumcheck.hpp"
 #include <gtest/gtest.h>
 
 using namespace proof_system::honk;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/sumcheck/sumcheck_round.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/sumcheck/sumcheck_round.hpp
@@ -3,6 +3,7 @@
 #include "barretenberg/common/thread.hpp"
 #include "barretenberg/polynomials/barycentric.hpp"
 #include "barretenberg/polynomials/pow.hpp"
+#include "barretenberg/proof_system/flavor/flavor.hpp"
 #include "barretenberg/proof_system/relations/relation_parameters.hpp"
 
 namespace proof_system::honk::sumcheck {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/sumcheck/sumcheck_round.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/sumcheck/sumcheck_round.test.cpp
@@ -1,8 +1,8 @@
+#include "sumcheck_round.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barretenberg/honk/flavor/standard.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 #include "barretenberg/polynomials/univariate.hpp"
-#include "sumcheck_round.hpp"
 
 #include <tuple>
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/transcript/transcript.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/transcript/transcript.test.cpp
@@ -1,3 +1,4 @@
+#include "transcript.hpp"
 #include "barretenberg/ecc/curves/bn254/g1.hpp"
 #include "barretenberg/honk/composer/standard_composer.hpp"
 #include "barretenberg/honk/composer/ultra_composer.hpp"
@@ -5,7 +6,6 @@
 #include "barretenberg/numeric/bitop/get_msb.hpp"
 #include "barretenberg/polynomials/univariate.hpp"
 #include "barretenberg/proof_system/flavor/flavor.hpp"
-#include "transcript.hpp"
 #include <gtest/gtest.h>
 
 using namespace proof_system::honk;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/utils/power_polynomial.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/honk/utils/power_polynomial.test.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/numeric/random/engine.hpp"
 #include "power_polynomial.hpp"
+#include "barretenberg/numeric/random/engine.hpp"
 #include <gtest/gtest.h>
 
 TEST(power_polynomial, test_full_polynomial_correctness)

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/mock/mock_circuit.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/mock/mock_circuit.test.cpp
@@ -1,7 +1,7 @@
+#include "mock_circuit.hpp"
 #include "../join_split/join_split_tx.hpp"
 #include "barretenberg/common/test.hpp"
 #include "barretenberg/join_split_example/types.hpp"
-#include "mock_circuit.hpp"
 
 using namespace proof_system::plonk::stdlib;
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/compute_nullifier.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/compute_nullifier.test.cpp
@@ -1,5 +1,5 @@
-#include "../../../../fixtures/user_context.hpp"
 #include "../../native/value/compute_nullifier.hpp"
+#include "../../../../fixtures/user_context.hpp"
 #include "../../native/value/value_note.hpp"
 #include "./compute_nullifier.hpp"
 #include "./value_note.hpp"

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/value_note.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/value_note.test.cpp
@@ -1,6 +1,6 @@
+#include "../../native/value/value_note.hpp"
 #include "../../../../fixtures/user_context.hpp"
 #include "../../constants.hpp"
-#include "../../native/value/value_note.hpp"
 #include "barretenberg/join_split_example/types.hpp"
 #include "value_note.hpp"
 #include <gtest/gtest.h>

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/numeric/random/engine.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/numeric/random/engine.test.cpp
@@ -1,6 +1,6 @@
+#include "engine.hpp"
 #include "barretenberg/common/log.hpp"
 #include "barretenberg/common/streams.hpp"
-#include "engine.hpp"
 #include <gtest/gtest.h>
 
 TEST(engine, GetRandomUint64)

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/numeric/uint128/uint128.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/numeric/uint128/uint128.test.cpp
@@ -1,5 +1,5 @@
-#include "../random/engine.hpp"
 #include "uint128.hpp"
+#include "../random/engine.hpp"
 #include <gtest/gtest.h>
 #ifdef __i386__
 namespace {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256.test.cpp
@@ -1,5 +1,5 @@
-#include "../random/engine.hpp"
 #include "uint256.hpp"
+#include "../random/engine.hpp"
 #include <gtest/gtest.h>
 
 namespace {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx.test.cpp
@@ -1,5 +1,5 @@
-#include "../random/engine.hpp"
 #include "./uintx.hpp"
+#include "../random/engine.hpp"
 #include <gtest/gtest.h>
 
 namespace {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.test.cpp
@@ -1,6 +1,6 @@
+#include "barretenberg/plonk/composer/standard_composer.hpp"
 #include "barretenberg/crypto/generators/generator_data.hpp"
 #include "barretenberg/crypto/pedersen_commitment/pedersen.hpp"
-#include "barretenberg/plonk/composer/standard_composer.hpp"
 #include "barretenberg/plonk/proof_system/proving_key/serialize.hpp"
 #include "barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp"
 #include <gtest/gtest.h>

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/proving_key/proving_key.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/proving_key/proving_key.test.cpp
@@ -1,10 +1,10 @@
+#include "proving_key.hpp"
 #include "barretenberg/common/streams.hpp"
 #include "barretenberg/common/test.hpp"
 #include "barretenberg/plonk/composer/standard_composer.hpp"
 #include "barretenberg/plonk/composer/ultra_composer.hpp"
 #include "barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp"
 #include "barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp"
-#include "proving_key.hpp"
 #include "serialize.hpp"
 
 #ifndef __wasm__

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/public_inputs/public_inputs.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/public_inputs/public_inputs.test.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/polynomials/evaluation_domain.hpp"
 #include "public_inputs.hpp"
+#include "barretenberg/polynomials/evaluation_domain.hpp"
 #include <gtest/gtest.h>
 
 using namespace barretenberg;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/verification_key.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/verification_key.test.cpp
@@ -1,7 +1,7 @@
+#include "verification_key.hpp"
 #include "barretenberg/common/streams.hpp"
 #include "barretenberg/common/test.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
-#include "verification_key.hpp"
 
 namespace {
 auto& engine = numeric::random::get_debug_engine();

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/barycentric.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/barycentric.test.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barycentric.hpp"
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include <gtest/gtest.h>
 
 namespace barretenberg::test_barycentric {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -150,7 +150,8 @@ template <typename Fr> void Polynomial<Fr>::zero_memory_beyond(const size_t star
  **/
 
 template <typename Fr>
-void Polynomial<Fr>::fft(const EvaluationDomain<Fr>& domain) requires polynomial_arithmetic::SupportsFFT<Fr>
+void Polynomial<Fr>::fft(const EvaluationDomain<Fr>& domain)
+    requires polynomial_arithmetic::SupportsFFT<Fr>
 {
     ASSERT(in_place_operation_viable(domain.size));
     zero_memory_beyond(domain.size);
@@ -159,9 +160,8 @@ void Polynomial<Fr>::fft(const EvaluationDomain<Fr>& domain) requires polynomial
 }
 
 template <typename Fr>
-void Polynomial<Fr>::partial_fft(const EvaluationDomain<Fr>& domain,
-                                 Fr constant,
-                                 bool is_coset) requires polynomial_arithmetic::SupportsFFT<Fr>
+void Polynomial<Fr>::partial_fft(const EvaluationDomain<Fr>& domain, Fr constant, bool is_coset)
+    requires polynomial_arithmetic::SupportsFFT<Fr>
 {
     ASSERT(in_place_operation_viable(domain.size));
     zero_memory_beyond(domain.size);
@@ -170,7 +170,8 @@ void Polynomial<Fr>::partial_fft(const EvaluationDomain<Fr>& domain,
 }
 
 template <typename Fr>
-void Polynomial<Fr>::coset_fft(const EvaluationDomain<Fr>& domain) requires polynomial_arithmetic::SupportsFFT<Fr>
+void Polynomial<Fr>::coset_fft(const EvaluationDomain<Fr>& domain)
+    requires polynomial_arithmetic::SupportsFFT<Fr>
 {
     ASSERT(in_place_operation_viable(domain.size));
     zero_memory_beyond(domain.size);
@@ -181,7 +182,8 @@ void Polynomial<Fr>::coset_fft(const EvaluationDomain<Fr>& domain) requires poly
 template <typename Fr>
 void Polynomial<Fr>::coset_fft(const EvaluationDomain<Fr>& domain,
                                const EvaluationDomain<Fr>& large_domain,
-                               const size_t domain_extension) requires polynomial_arithmetic::SupportsFFT<Fr>
+                               const size_t domain_extension)
+    requires polynomial_arithmetic::SupportsFFT<Fr>
 {
     size_t extended_size = domain.size * domain_extension;
 
@@ -192,8 +194,8 @@ void Polynomial<Fr>::coset_fft(const EvaluationDomain<Fr>& domain,
 }
 
 template <typename Fr>
-void Polynomial<Fr>::coset_fft_with_constant(const EvaluationDomain<Fr>& domain,
-                                             const Fr& constant) requires polynomial_arithmetic::SupportsFFT<Fr>
+void Polynomial<Fr>::coset_fft_with_constant(const EvaluationDomain<Fr>& domain, const Fr& constant)
+    requires polynomial_arithmetic::SupportsFFT<Fr>
 {
     ASSERT(in_place_operation_viable(domain.size));
     zero_memory_beyond(domain.size);
@@ -202,8 +204,8 @@ void Polynomial<Fr>::coset_fft_with_constant(const EvaluationDomain<Fr>& domain,
 }
 
 template <typename Fr>
-void Polynomial<Fr>::coset_fft_with_generator_shift(const EvaluationDomain<Fr>& domain,
-                                                    const Fr& constant) requires polynomial_arithmetic::SupportsFFT<Fr>
+void Polynomial<Fr>::coset_fft_with_generator_shift(const EvaluationDomain<Fr>& domain, const Fr& constant)
+    requires polynomial_arithmetic::SupportsFFT<Fr>
 {
     ASSERT(in_place_operation_viable(domain.size));
     zero_memory_beyond(domain.size);
@@ -212,7 +214,8 @@ void Polynomial<Fr>::coset_fft_with_generator_shift(const EvaluationDomain<Fr>& 
 }
 
 template <typename Fr>
-void Polynomial<Fr>::ifft(const EvaluationDomain<Fr>& domain) requires polynomial_arithmetic::SupportsFFT<Fr>
+void Polynomial<Fr>::ifft(const EvaluationDomain<Fr>& domain)
+    requires polynomial_arithmetic::SupportsFFT<Fr>
 {
     ASSERT(in_place_operation_viable(domain.size));
     zero_memory_beyond(domain.size);
@@ -221,8 +224,8 @@ void Polynomial<Fr>::ifft(const EvaluationDomain<Fr>& domain) requires polynomia
 }
 
 template <typename Fr>
-void Polynomial<Fr>::ifft_with_constant(const EvaluationDomain<Fr>& domain,
-                                        const Fr& constant) requires polynomial_arithmetic::SupportsFFT<Fr>
+void Polynomial<Fr>::ifft_with_constant(const EvaluationDomain<Fr>& domain, const Fr& constant)
+    requires polynomial_arithmetic::SupportsFFT<Fr>
 {
     ASSERT(in_place_operation_viable(domain.size));
     zero_memory_beyond(domain.size);
@@ -231,7 +234,8 @@ void Polynomial<Fr>::ifft_with_constant(const EvaluationDomain<Fr>& domain,
 }
 
 template <typename Fr>
-void Polynomial<Fr>::coset_ifft(const EvaluationDomain<Fr>& domain) requires polynomial_arithmetic::SupportsFFT<Fr>
+void Polynomial<Fr>::coset_ifft(const EvaluationDomain<Fr>& domain)
+    requires polynomial_arithmetic::SupportsFFT<Fr>
 {
     ASSERT(in_place_operation_viable(domain.size));
     zero_memory_beyond(domain.size);
@@ -240,23 +244,24 @@ void Polynomial<Fr>::coset_ifft(const EvaluationDomain<Fr>& domain) requires pol
 }
 
 template <typename Fr>
-Fr Polynomial<Fr>::compute_kate_opening_coefficients(const Fr& z) requires polynomial_arithmetic::SupportsFFT<Fr>
+Fr Polynomial<Fr>::compute_kate_opening_coefficients(const Fr& z)
+    requires polynomial_arithmetic::SupportsFFT<Fr>
 {
     return polynomial_arithmetic::compute_kate_opening_coefficients(coefficients_.get(), coefficients_.get(), z, size_);
 }
 
 template <typename Fr>
-Fr Polynomial<Fr>::compute_barycentric_evaluation(
-    const Fr& z, const EvaluationDomain<Fr>& domain) requires polynomial_arithmetic::SupportsFFT<Fr>
+Fr Polynomial<Fr>::compute_barycentric_evaluation(const Fr& z, const EvaluationDomain<Fr>& domain)
+    requires polynomial_arithmetic::SupportsFFT<Fr>
 {
     return polynomial_arithmetic::compute_barycentric_evaluation(coefficients_.get(), domain.size, z, domain);
 }
 
 template <typename Fr>
-Fr Polynomial<Fr>::evaluate_from_fft(
-    const EvaluationDomain<Fr>& large_domain,
-    const Fr& z,
-    const EvaluationDomain<Fr>& small_domain) requires polynomial_arithmetic::SupportsFFT<Fr>
+Fr Polynomial<Fr>::evaluate_from_fft(const EvaluationDomain<Fr>& large_domain,
+                                     const Fr& z,
+                                     const EvaluationDomain<Fr>& small_domain)
+    requires polynomial_arithmetic::SupportsFFT<Fr>
 
 {
     return polynomial_arithmetic::evaluate_from_fft(coefficients_.get(), large_domain, z, small_domain);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -104,28 +104,34 @@ template <typename Fr> class Polynomial {
     Fr evaluate(const Fr& z, const size_t target_size) const;
     Fr evaluate(const Fr& z) const;
 
-    Fr compute_barycentric_evaluation(
-        const Fr& z, const EvaluationDomain<Fr>& domain) requires polynomial_arithmetic::SupportsFFT<Fr>;
+    Fr compute_barycentric_evaluation(const Fr& z, const EvaluationDomain<Fr>& domain)
+        requires polynomial_arithmetic::SupportsFFT<Fr>;
     Fr evaluate_from_fft(const EvaluationDomain<Fr>& large_domain,
                          const Fr& z,
-                         const EvaluationDomain<Fr>& small_domain) requires polynomial_arithmetic::SupportsFFT<Fr>;
-    void fft(const EvaluationDomain<Fr>& domain) requires polynomial_arithmetic::SupportsFFT<Fr>;
-    void partial_fft(const EvaluationDomain<Fr>& domain,
-                     Fr constant = 1,
-                     bool is_coset = false) requires polynomial_arithmetic::SupportsFFT<Fr>;
-    void coset_fft(const EvaluationDomain<Fr>& domain) requires polynomial_arithmetic::SupportsFFT<Fr>;
+                         const EvaluationDomain<Fr>& small_domain)
+        requires polynomial_arithmetic::SupportsFFT<Fr>;
+    void fft(const EvaluationDomain<Fr>& domain)
+        requires polynomial_arithmetic::SupportsFFT<Fr>;
+    void partial_fft(const EvaluationDomain<Fr>& domain, Fr constant = 1, bool is_coset = false)
+        requires polynomial_arithmetic::SupportsFFT<Fr>;
+    void coset_fft(const EvaluationDomain<Fr>& domain)
+        requires polynomial_arithmetic::SupportsFFT<Fr>;
     void coset_fft(const EvaluationDomain<Fr>& domain,
                    const EvaluationDomain<Fr>& large_domain,
-                   const size_t domain_extension) requires polynomial_arithmetic::SupportsFFT<Fr>;
-    void coset_fft_with_constant(const EvaluationDomain<Fr>& domain,
-                                 const Fr& costant) requires polynomial_arithmetic::SupportsFFT<Fr>;
-    void coset_fft_with_generator_shift(const EvaluationDomain<Fr>& domain,
-                                        const Fr& constant) requires polynomial_arithmetic::SupportsFFT<Fr>;
-    void ifft(const EvaluationDomain<Fr>& domain) requires polynomial_arithmetic::SupportsFFT<Fr>;
-    void ifft_with_constant(const EvaluationDomain<Fr>& domain,
-                            const Fr& constant) requires polynomial_arithmetic::SupportsFFT<Fr>;
-    void coset_ifft(const EvaluationDomain<Fr>& domain) requires polynomial_arithmetic::SupportsFFT<Fr>;
-    Fr compute_kate_opening_coefficients(const Fr& z) requires polynomial_arithmetic::SupportsFFT<Fr>;
+                   const size_t domain_extension)
+        requires polynomial_arithmetic::SupportsFFT<Fr>;
+    void coset_fft_with_constant(const EvaluationDomain<Fr>& domain, const Fr& costant)
+        requires polynomial_arithmetic::SupportsFFT<Fr>;
+    void coset_fft_with_generator_shift(const EvaluationDomain<Fr>& domain, const Fr& constant)
+        requires polynomial_arithmetic::SupportsFFT<Fr>;
+    void ifft(const EvaluationDomain<Fr>& domain)
+        requires polynomial_arithmetic::SupportsFFT<Fr>;
+    void ifft_with_constant(const EvaluationDomain<Fr>& domain, const Fr& constant)
+        requires polynomial_arithmetic::SupportsFFT<Fr>;
+    void coset_ifft(const EvaluationDomain<Fr>& domain)
+        requires polynomial_arithmetic::SupportsFFT<Fr>;
+    Fr compute_kate_opening_coefficients(const Fr& z)
+        requires polynomial_arithmetic::SupportsFFT<Fr>;
 
     bool is_empty() const { return (coefficients_ == nullptr) || (size_ == 0); }
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
@@ -59,9 +59,8 @@ void copy_polynomial(const Fr* src, Fr* dest, size_t num_src_coefficients, size_
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void fft_inner_serial(std::vector<Fr*> coeffs,
-                                               const size_t domain_size,
-                                               const std::vector<Fr*>& root_table)
+    requires SupportsFFT<Fr>
+void fft_inner_serial(std::vector<Fr*> coeffs, const size_t domain_size, const std::vector<Fr*>& root_table)
 {
     // Assert that the number of polynomials is a power of two.
     const size_t num_polys = coeffs.size();
@@ -147,9 +146,10 @@ void scale_by_generator(Fr* coeffs,
  * @param subgroup_roots Pointer to the array for saving subgroup members.
  * */
 template <typename Fr>
-requires SupportsFFT<Fr> void compute_multiplicative_subgroup(const size_t log2_subgroup_size,
-                                                              const EvaluationDomain<Fr>& src_domain,
-                                                              Fr* subgroup_roots)
+    requires SupportsFFT<Fr>
+void compute_multiplicative_subgroup(const size_t log2_subgroup_size,
+                                     const EvaluationDomain<Fr>& src_domain,
+                                     Fr* subgroup_roots)
 {
     size_t subgroup_size = 1UL << log2_subgroup_size;
     // Step 1: get primitive 4th root of unity
@@ -169,10 +169,11 @@ requires SupportsFFT<Fr> void compute_multiplicative_subgroup(const size_t log2_
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void fft_inner_parallel(std::vector<Fr*> coeffs,
-                                                 const EvaluationDomain<Fr>& domain,
-                                                 const Fr&,
-                                                 const std::vector<Fr*>& root_table)
+    requires SupportsFFT<Fr>
+void fft_inner_parallel(std::vector<Fr*> coeffs,
+                        const EvaluationDomain<Fr>& domain,
+                        const Fr&,
+                        const std::vector<Fr*>& root_table)
 {
     auto scratch_space_ptr = get_scratch_space<Fr>(domain.size);
     auto scratch_space = scratch_space_ptr.get();
@@ -296,7 +297,8 @@ requires SupportsFFT<Fr> void fft_inner_parallel(std::vector<Fr*> coeffs,
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void fft_inner_parallel(
+    requires SupportsFFT<Fr>
+void fft_inner_parallel(
     Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain, const Fr&, const std::vector<Fr*>& root_table)
 {
     parallel_for(domain.num_threads, [&](size_t j) {
@@ -390,10 +392,11 @@ requires SupportsFFT<Fr> void fft_inner_parallel(
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void partial_fft_serial_inner(Fr* coeffs,
-                                                       Fr* target,
-                                                       const EvaluationDomain<Fr>& domain,
-                                                       const std::vector<Fr*>& root_table)
+    requires SupportsFFT<Fr>
+void partial_fft_serial_inner(Fr* coeffs,
+                              Fr* target,
+                              const EvaluationDomain<Fr>& domain,
+                              const std::vector<Fr*>& root_table)
 {
     // We wish to compute a partial modified FFT of 2 rounds from given coefficients.
     // We need a 2-round modified FFT for commiting to the 4n-sized quotient polynomial for
@@ -432,7 +435,8 @@ requires SupportsFFT<Fr> void partial_fft_serial_inner(Fr* coeffs,
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void partial_fft_parellel_inner(
+    requires SupportsFFT<Fr>
+void partial_fft_parellel_inner(
     Fr* coeffs, const EvaluationDomain<Fr>& domain, const std::vector<Fr*>& root_table, Fr constant, bool is_coset)
 {
     // We wish to compute a partial modified FFT of 2 rounds from given coefficients.
@@ -503,33 +507,43 @@ requires SupportsFFT<Fr> void partial_fft_parellel_inner(
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void partial_fft_serial(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain)
+    requires SupportsFFT<Fr>
+void partial_fft_serial(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain)
 {
     partial_fft_serial_inner(coeffs, target, domain, domain.get_round_roots());
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void partial_fft(Fr* coeffs, const EvaluationDomain<Fr>& domain, Fr constant, bool is_coset)
+    requires SupportsFFT<Fr>
+void partial_fft(Fr* coeffs, const EvaluationDomain<Fr>& domain, Fr constant, bool is_coset)
 {
     partial_fft_parellel_inner(coeffs, domain, domain.get_round_roots(), constant, is_coset);
 }
 
-template <typename Fr> requires SupportsFFT<Fr> void fft(Fr* coeffs, const EvaluationDomain<Fr>& domain)
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void fft(Fr* coeffs, const EvaluationDomain<Fr>& domain)
 {
     fft_inner_parallel({ coeffs }, domain, domain.root, domain.get_round_roots());
 }
 
-template <typename Fr> requires SupportsFFT<Fr> void fft(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain)
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void fft(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain)
 {
     fft_inner_parallel(coeffs, target, domain, domain.root, domain.get_round_roots());
 }
 
-template <typename Fr> requires SupportsFFT<Fr> void fft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain)
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void fft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain)
 {
     fft_inner_parallel<Fr>(coeffs, domain.size, domain.root, domain.get_round_roots());
 }
 
-template <typename Fr> requires SupportsFFT<Fr> void ifft(Fr* coeffs, const EvaluationDomain<Fr>& domain)
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void ifft(Fr* coeffs, const EvaluationDomain<Fr>& domain)
 {
     fft_inner_parallel({ coeffs }, domain, domain.root_inverse, domain.get_inverse_round_roots());
     ITERATE_OVER_DOMAIN_START(domain);
@@ -537,7 +551,9 @@ template <typename Fr> requires SupportsFFT<Fr> void ifft(Fr* coeffs, const Eval
     ITERATE_OVER_DOMAIN_END;
 }
 
-template <typename Fr> requires SupportsFFT<Fr> void ifft(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain)
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void ifft(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain)
 {
     fft_inner_parallel(coeffs, target, domain, domain.root_inverse, domain.get_inverse_round_roots());
     ITERATE_OVER_DOMAIN_START(domain);
@@ -545,7 +561,9 @@ template <typename Fr> requires SupportsFFT<Fr> void ifft(Fr* coeffs, Fr* target
     ITERATE_OVER_DOMAIN_END;
 }
 
-template <typename Fr> requires SupportsFFT<Fr> void ifft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain)
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void ifft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain)
 {
     fft_inner_parallel(coeffs, domain, domain.root_inverse, domain.get_inverse_round_roots());
 
@@ -562,7 +580,8 @@ template <typename Fr> requires SupportsFFT<Fr> void ifft(std::vector<Fr*> coeff
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void fft_with_constant(Fr* coeffs, const EvaluationDomain<Fr>& domain, const Fr& value)
+    requires SupportsFFT<Fr>
+void fft_with_constant(Fr* coeffs, const EvaluationDomain<Fr>& domain, const Fr& value)
 {
     fft_inner_parallel({ coeffs }, domain, domain.root, domain.get_round_roots());
     ITERATE_OVER_DOMAIN_START(domain);
@@ -570,21 +589,25 @@ requires SupportsFFT<Fr> void fft_with_constant(Fr* coeffs, const EvaluationDoma
     ITERATE_OVER_DOMAIN_END;
 }
 
-template <typename Fr> requires SupportsFFT<Fr> void coset_fft(Fr* coeffs, const EvaluationDomain<Fr>& domain)
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void coset_fft(Fr* coeffs, const EvaluationDomain<Fr>& domain)
 {
     scale_by_generator(coeffs, coeffs, domain, Fr::one(), domain.generator, domain.generator_size);
     fft(coeffs, domain);
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void coset_fft(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain)
+    requires SupportsFFT<Fr>
+void coset_fft(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain)
 {
     scale_by_generator(coeffs, target, domain, Fr::one(), domain.generator, domain.generator_size);
     fft(coeffs, target, domain);
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void coset_fft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain)
+    requires SupportsFFT<Fr>
+void coset_fft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain)
 {
     const size_t num_polys = coeffs.size();
     ASSERT(is_power_of_two(num_polys));
@@ -600,10 +623,11 @@ requires SupportsFFT<Fr> void coset_fft(std::vector<Fr*> coeffs, const Evaluatio
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void coset_fft(Fr* coeffs,
-                                        const EvaluationDomain<Fr>& domain,
-                                        const EvaluationDomain<Fr>&,
-                                        const size_t domain_extension)
+    requires SupportsFFT<Fr>
+void coset_fft(Fr* coeffs,
+               const EvaluationDomain<Fr>& domain,
+               const EvaluationDomain<Fr>&,
+               const size_t domain_extension)
 {
     const size_t log2_domain_extension = static_cast<size_t>(numeric::get_msb(domain_extension));
     Fr primitive_root = Fr::get_root_of_unity(domain.log2_size + log2_domain_extension);
@@ -660,9 +684,8 @@ requires SupportsFFT<Fr> void coset_fft(Fr* coeffs,
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void coset_fft_with_constant(Fr* coeffs,
-                                                      const EvaluationDomain<Fr>& domain,
-                                                      const Fr& constant)
+    requires SupportsFFT<Fr>
+void coset_fft_with_constant(Fr* coeffs, const EvaluationDomain<Fr>& domain, const Fr& constant)
 {
     Fr start = constant;
     scale_by_generator(coeffs, coeffs, domain, start, domain.generator, domain.generator_size);
@@ -670,16 +693,16 @@ requires SupportsFFT<Fr> void coset_fft_with_constant(Fr* coeffs,
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void coset_fft_with_generator_shift(Fr* coeffs,
-                                                             const EvaluationDomain<Fr>& domain,
-                                                             const Fr& constant)
+    requires SupportsFFT<Fr>
+void coset_fft_with_generator_shift(Fr* coeffs, const EvaluationDomain<Fr>& domain, const Fr& constant)
 {
     scale_by_generator(coeffs, coeffs, domain, Fr::one(), domain.generator * constant, domain.generator_size);
     fft(coeffs, domain);
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void ifft_with_constant(Fr* coeffs, const EvaluationDomain<Fr>& domain, const Fr& value)
+    requires SupportsFFT<Fr>
+void ifft_with_constant(Fr* coeffs, const EvaluationDomain<Fr>& domain, const Fr& value)
 {
     fft_inner_parallel({ coeffs }, domain, domain.root_inverse, domain.get_inverse_round_roots());
     Fr T0 = domain.domain_inverse * value;
@@ -688,14 +711,17 @@ requires SupportsFFT<Fr> void ifft_with_constant(Fr* coeffs, const EvaluationDom
     ITERATE_OVER_DOMAIN_END;
 }
 
-template <typename Fr> requires SupportsFFT<Fr> void coset_ifft(Fr* coeffs, const EvaluationDomain<Fr>& domain)
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void coset_ifft(Fr* coeffs, const EvaluationDomain<Fr>& domain)
 {
     ifft(coeffs, domain);
     scale_by_generator(coeffs, coeffs, domain, Fr::one(), domain.generator_inverse, domain.size);
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void coset_ifft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain)
+    requires SupportsFFT<Fr>
+void coset_ifft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain)
 {
     ifft(coeffs, domain);
 
@@ -826,9 +852,10 @@ template <typename Fr> Fr evaluate(const std::vector<Fr*> coeffs, const Fr& z, c
  * L_i(X), we perform a (k*i)-left-shift of this vector.
  */
 template <typename Fr>
-requires SupportsFFT<Fr> void compute_lagrange_polynomial_fft(Fr* l_1_coefficients,
-                                                              const EvaluationDomain<Fr>& src_domain,
-                                                              const EvaluationDomain<Fr>& target_domain)
+    requires SupportsFFT<Fr>
+void compute_lagrange_polynomial_fft(Fr* l_1_coefficients,
+                                     const EvaluationDomain<Fr>& src_domain,
+                                     const EvaluationDomain<Fr>& target_domain)
 {
     // Step 1: Compute the 1/denominator for each evaluation: 1 / (X_i - 1)
     Fr multiplicand = target_domain.root; // kn'th root of unity w'
@@ -872,11 +899,11 @@ requires SupportsFFT<Fr> void compute_lagrange_polynomial_fft(Fr* l_1_coefficien
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void divide_by_pseudo_vanishing_polynomial(
-    std::vector<Fr*> coeffs,
-    const EvaluationDomain<Fr>& src_domain,
-    const EvaluationDomain<Fr>& target_domain,
-    const size_t num_roots_cut_out_of_vanishing_polynomial)
+    requires SupportsFFT<Fr>
+void divide_by_pseudo_vanishing_polynomial(std::vector<Fr*> coeffs,
+                                           const EvaluationDomain<Fr>& src_domain,
+                                           const EvaluationDomain<Fr>& target_domain,
+                                           const size_t num_roots_cut_out_of_vanishing_polynomial)
 {
     // Older version:
     // the PLONK divisor polynomial is equal to the vanishing polynomial divided by the vanishing polynomial for the
@@ -982,7 +1009,8 @@ requires SupportsFFT<Fr> void divide_by_pseudo_vanishing_polynomial(
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> Fr compute_kate_opening_coefficients(const Fr* src, Fr* dest, const Fr& z, const size_t n)
+    requires SupportsFFT<Fr>
+Fr compute_kate_opening_coefficients(const Fr* src, Fr* dest, const Fr& z, const size_t n)
 {
     // if `coeffs` represents F(X), we want to compute W(X)
     // where W(X) = F(X) - F(z) / (X - z)
@@ -1011,7 +1039,8 @@ requires SupportsFFT<Fr> Fr compute_kate_opening_coefficients(const Fr* src, Fr*
  * @param zeta - the name given (in our code) to the evaluation challenge ʓ from the Plonk paper.
  */
 template <typename Fr>
-requires SupportsFFT<Fr> barretenberg::polynomial_arithmetic::LagrangeEvaluations<Fr> get_lagrange_evaluations(
+    requires SupportsFFT<Fr>
+barretenberg::polynomial_arithmetic::LagrangeEvaluations<Fr> get_lagrange_evaluations(
     const Fr& zeta, const EvaluationDomain<Fr>& domain, const size_t num_roots_cut_out_of_vanishing_polynomial)
 {
     // Compute Z_H*(ʓ), l_start(ʓ), l_{end}(ʓ)
@@ -1092,10 +1121,11 @@ requires SupportsFFT<Fr> barretenberg::polynomial_arithmetic::LagrangeEvaluation
 //                           n.(ʓ.ω^{1-i)} - 1)
 //
 template <typename Fr>
-requires SupportsFFT<Fr> Fr compute_barycentric_evaluation(const Fr* coeffs,
-                                                           const size_t num_coeffs,
-                                                           const Fr& z,
-                                                           const EvaluationDomain<Fr>& domain)
+    requires SupportsFFT<Fr>
+Fr compute_barycentric_evaluation(const Fr* coeffs,
+                                  const size_t num_coeffs,
+                                  const Fr& z,
+                                  const EvaluationDomain<Fr>& domain)
 {
     Fr* denominators = static_cast<Fr*>(aligned_alloc(64, sizeof(Fr) * num_coeffs));
 
@@ -1137,7 +1167,8 @@ requires SupportsFFT<Fr> Fr compute_barycentric_evaluation(const Fr* coeffs,
 
 // Convert an fft with `current_size` point evaluations, to one with `current_size >> compress_factor` point evaluations
 template <typename Fr>
-requires SupportsFFT<Fr> void compress_fft(const Fr* src, Fr* dest, const size_t cur_size, const size_t compress_factor)
+    requires SupportsFFT<Fr>
+void compress_fft(const Fr* src, Fr* dest, const size_t cur_size, const size_t compress_factor)
 {
     // iterate from top to bottom, allows `dest` to overlap with `src`
     size_t log2_compress_factor = (size_t)numeric::get_msb(compress_factor);
@@ -1149,10 +1180,11 @@ requires SupportsFFT<Fr> void compress_fft(const Fr* src, Fr* dest, const size_t
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> Fr evaluate_from_fft(const Fr* poly_coset_fft,
-                                              const EvaluationDomain<Fr>& large_domain,
-                                              const Fr& z,
-                                              const EvaluationDomain<Fr>& small_domain)
+    requires SupportsFFT<Fr>
+Fr evaluate_from_fft(const Fr* poly_coset_fft,
+                     const EvaluationDomain<Fr>& large_domain,
+                     const Fr& z,
+                     const EvaluationDomain<Fr>& small_domain)
 {
     size_t n = small_domain.size;
     Fr* small_poly_coset_fft = static_cast<Fr*>(aligned_alloc(64, sizeof(Fr) * n));
@@ -1210,7 +1242,8 @@ template <typename Fr> Fr compute_linear_polynomial_product_evaluation(const Fr*
 }
 
 template <typename Fr>
-requires SupportsFFT<Fr> void fft_linear_polynomial_product(
+    requires SupportsFFT<Fr>
+void fft_linear_polynomial_product(
     const Fr* roots, Fr* dest, const size_t n, const EvaluationDomain<Fr>& domain, const bool is_coset)
 {
     size_t m = domain.size >> 1;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.hpp
@@ -4,7 +4,8 @@
 namespace barretenberg {
 namespace polynomial_arithmetic {
 
-template <typename T> concept SupportsFFT = T::Params::has_high_2adicity;
+template <typename T>
+concept SupportsFFT = T::Params::has_high_2adicity;
 
 template <typename Fr> struct LagrangeEvaluations {
     Fr vanishing_poly;
@@ -29,71 +30,92 @@ void copy_polynomial(const Fr* src, Fr* dest, size_t num_src_coefficients, size_
 
 //  2. Compute a lookup table of the roots of unity, and suffer through cache misses from nonlinear access patterns
 template <typename Fr>
-requires SupportsFFT<Fr> void fft_inner_serial(std::vector<Fr*> coeffs,
-                                               const size_t domain_size,
-                                               const std::vector<Fr*>& root_table);
+    requires SupportsFFT<Fr>
+void fft_inner_serial(std::vector<Fr*> coeffs, const size_t domain_size, const std::vector<Fr*>& root_table);
 template <typename Fr>
-requires SupportsFFT<Fr> void fft_inner_parallel(std::vector<Fr*> coeffs,
-                                                 const EvaluationDomain<Fr>& domain,
-                                                 const Fr&,
-                                                 const std::vector<Fr*>& root_table);
-
-template <typename Fr> requires SupportsFFT<Fr> void fft(Fr* coeffs, const EvaluationDomain<Fr>& domain);
-template <typename Fr> requires SupportsFFT<Fr> void fft(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain);
-template <typename Fr> requires SupportsFFT<Fr> void fft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain);
-template <typename Fr>
-requires SupportsFFT<Fr> void fft_with_constant(Fr* coeffs, const EvaluationDomain<Fr>& domain, const Fr& value);
-
-template <typename Fr> requires SupportsFFT<Fr> void coset_fft(Fr* coeffs, const EvaluationDomain<Fr>& domain);
-template <typename Fr>
-requires SupportsFFT<Fr> void coset_fft(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain);
-template <typename Fr>
-requires SupportsFFT<Fr> void coset_fft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain);
-template <typename Fr>
-requires SupportsFFT<Fr> void coset_fft(Fr* coeffs,
-                                        const EvaluationDomain<Fr>& small_domain,
-                                        const EvaluationDomain<Fr>& large_domain,
-                                        const size_t domain_extension);
+    requires SupportsFFT<Fr>
+void fft_inner_parallel(std::vector<Fr*> coeffs,
+                        const EvaluationDomain<Fr>& domain,
+                        const Fr&,
+                        const std::vector<Fr*>& root_table);
 
 template <typename Fr>
-requires SupportsFFT<Fr> void coset_fft_with_constant(Fr* coeffs,
-                                                      const EvaluationDomain<Fr>& domain,
-                                                      const Fr& constant);
+    requires SupportsFFT<Fr>
+void fft(Fr* coeffs, const EvaluationDomain<Fr>& domain);
 template <typename Fr>
-requires SupportsFFT<Fr> void coset_fft_with_generator_shift(Fr* coeffs,
-                                                             const EvaluationDomain<Fr>& domain,
-                                                             const Fr& constant);
-
-template <typename Fr> requires SupportsFFT<Fr> void ifft(Fr* coeffs, const EvaluationDomain<Fr>& domain);
-template <typename Fr> requires SupportsFFT<Fr> void ifft(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain);
-template <typename Fr> requires SupportsFFT<Fr> void ifft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain);
-
+    requires SupportsFFT<Fr>
+void fft(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain);
 template <typename Fr>
-requires SupportsFFT<Fr> void ifft_with_constant(Fr* coeffs, const EvaluationDomain<Fr>& domain, const Fr& value);
-
-template <typename Fr> requires SupportsFFT<Fr> void coset_ifft(Fr* coeffs, const EvaluationDomain<Fr>& domain);
+    requires SupportsFFT<Fr>
+void fft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain);
 template <typename Fr>
-requires SupportsFFT<Fr> void coset_ifft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain);
+    requires SupportsFFT<Fr>
+void fft_with_constant(Fr* coeffs, const EvaluationDomain<Fr>& domain, const Fr& value);
 
 template <typename Fr>
-requires SupportsFFT<Fr> void partial_fft_serial_inner(Fr* coeffs,
-                                                       Fr* target,
-                                                       const EvaluationDomain<Fr>& domain,
-                                                       const std::vector<Fr*>& root_table);
+    requires SupportsFFT<Fr>
+void coset_fft(Fr* coeffs, const EvaluationDomain<Fr>& domain);
 template <typename Fr>
-requires SupportsFFT<Fr> void partial_fft_parellel_inner(Fr* coeffs,
-                                                         const EvaluationDomain<Fr>& domain,
-                                                         const std::vector<Fr*>& root_table,
-                                                         Fr constant = 1,
-                                                         bool is_coset = false);
+    requires SupportsFFT<Fr>
+void coset_fft(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain);
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void coset_fft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain);
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void coset_fft(Fr* coeffs,
+               const EvaluationDomain<Fr>& small_domain,
+               const EvaluationDomain<Fr>& large_domain,
+               const size_t domain_extension);
 
 template <typename Fr>
-requires SupportsFFT<Fr> void partial_fft_serial(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain);
+    requires SupportsFFT<Fr>
+void coset_fft_with_constant(Fr* coeffs, const EvaluationDomain<Fr>& domain, const Fr& constant);
 template <typename Fr>
-requires SupportsFFT<Fr> void partial_fft(Fr* coeffs,
-                                          const EvaluationDomain<Fr>& domain,
-                                          Fr constant = 1,
-                                          bool is_coset = false);
+    requires SupportsFFT<Fr>
+void coset_fft_with_generator_shift(Fr* coeffs, const EvaluationDomain<Fr>& domain, const Fr& constant);
+
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void ifft(Fr* coeffs, const EvaluationDomain<Fr>& domain);
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void ifft(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain);
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void ifft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain);
+
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void ifft_with_constant(Fr* coeffs, const EvaluationDomain<Fr>& domain, const Fr& value);
+
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void coset_ifft(Fr* coeffs, const EvaluationDomain<Fr>& domain);
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void coset_ifft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain);
+
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void partial_fft_serial_inner(Fr* coeffs,
+                              Fr* target,
+                              const EvaluationDomain<Fr>& domain,
+                              const std::vector<Fr*>& root_table);
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void partial_fft_parellel_inner(Fr* coeffs,
+                                const EvaluationDomain<Fr>& domain,
+                                const std::vector<Fr*>& root_table,
+                                Fr constant = 1,
+                                bool is_coset = false);
+
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void partial_fft_serial(Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain);
+template <typename Fr>
+    requires SupportsFFT<Fr>
+void partial_fft(Fr* coeffs, const EvaluationDomain<Fr>& domain, Fr constant = 1, bool is_coset = false);
 
 template <typename Fr>
 void add(const Fr* a_coeffs, const Fr* b_coeffs, Fr* r_coeffs, const EvaluationDomain<Fr>& domain);
@@ -110,27 +132,31 @@ void mul(const Fr* a_coeffs, const Fr* b_coeffs, Fr* r_coeffs, const EvaluationD
 // for all X = k*n'th roots of unity.
 // To compute the vector for the k*n-fft transform of L_i(X), we perform a (k*i)-left-shift of this vector
 template <typename Fr>
-requires SupportsFFT<Fr> void compute_lagrange_polynomial_fft(Fr* l_1_coefficients,
-                                                              const EvaluationDomain<Fr>& src_domain,
-                                                              const EvaluationDomain<Fr>& target_domain);
+    requires SupportsFFT<Fr>
+void compute_lagrange_polynomial_fft(Fr* l_1_coefficients,
+                                     const EvaluationDomain<Fr>& src_domain,
+                                     const EvaluationDomain<Fr>& target_domain);
 
 template <typename Fr>
-requires SupportsFFT<Fr> void divide_by_pseudo_vanishing_polynomial(
-    std::vector<Fr*> coeffs,
-    const EvaluationDomain<Fr>& src_domain,
-    const EvaluationDomain<Fr>& target_domain,
-    const size_t num_roots_cut_out_of_vanishing_polynomial = 4);
+    requires SupportsFFT<Fr>
+void divide_by_pseudo_vanishing_polynomial(std::vector<Fr*> coeffs,
+                                           const EvaluationDomain<Fr>& src_domain,
+                                           const EvaluationDomain<Fr>& target_domain,
+                                           const size_t num_roots_cut_out_of_vanishing_polynomial = 4);
 
 // void populate_with_vanishing_polynomial(Fr* coeffs, const size_t num_non_zero_entries, const EvaluationDomain<Fr>&
 // src_domain, const EvaluationDomain<Fr>& target_domain);
 
 template <typename Fr>
-requires SupportsFFT<Fr> Fr compute_kate_opening_coefficients(const Fr* src, Fr* dest, const Fr& z, const size_t n);
+    requires SupportsFFT<Fr>
+Fr compute_kate_opening_coefficients(const Fr* src, Fr* dest, const Fr& z, const size_t n);
 
 // compute Z_H*(z), l_start(z), l_{end}(z) (= l_{n-4}(z))
 template <typename Fr>
-requires SupportsFFT<Fr> LagrangeEvaluations<Fr> get_lagrange_evaluations(
-    const Fr& z, const EvaluationDomain<Fr>& domain, const size_t num_roots_cut_out_of_vanishing_polynomial = 4);
+    requires SupportsFFT<Fr>
+LagrangeEvaluations<Fr> get_lagrange_evaluations(const Fr& z,
+                                                 const EvaluationDomain<Fr>& domain,
+                                                 const size_t num_roots_cut_out_of_vanishing_polynomial = 4);
 template <typename Fr>
 Fr compute_barycentric_evaluation(const Fr* coeffs,
                                   const size_t num_coeffs,
@@ -138,16 +164,15 @@ Fr compute_barycentric_evaluation(const Fr* coeffs,
                                   const EvaluationDomain<Fr>& domain);
 // Convert an fft with `current_size` point evaluations, to one with `current_size >> compress_factor` point evaluations
 template <typename Fr>
-requires SupportsFFT<Fr> void compress_fft(const Fr* src,
-                                           Fr* dest,
-                                           const size_t current_size,
-                                           const size_t compress_factor);
+    requires SupportsFFT<Fr>
+void compress_fft(const Fr* src, Fr* dest, const size_t current_size, const size_t compress_factor);
 
 template <typename Fr>
-requires SupportsFFT<Fr> Fr evaluate_from_fft(const Fr* poly_coset_fft,
-                                              const EvaluationDomain<Fr>& large_domain,
-                                              const Fr& z,
-                                              const EvaluationDomain<Fr>& small_domain);
+    requires SupportsFFT<Fr>
+Fr evaluate_from_fft(const Fr* poly_coset_fft,
+                     const EvaluationDomain<Fr>& large_domain,
+                     const Fr& z,
+                     const EvaluationDomain<Fr>& small_domain);
 
 // This function computes sum of all scalars in a given array.
 template <typename Fr> Fr compute_sum(const Fr* src, const size_t n);
@@ -162,7 +187,8 @@ template <typename Fr> Fr compute_linear_polynomial_product_evaluation(const Fr*
 // This function computes the lagrange (or coset-lagrange) form of the polynomial (x - a)(x - b)(x - c)...
 // given n distinct roots (a, b, c, ...).
 template <typename Fr>
-requires SupportsFFT<Fr> void fft_linear_polynomial_product(
+    requires SupportsFFT<Fr>
+void fft_linear_polynomial_product(
     const Fr* roots, Fr* dest, const size_t n, const EvaluationDomain<Fr>& domain, const bool is_coset = false);
 
 // This function interpolates from points {(z_1, f(z_1)), (z_2, f(z_2)), ...}.

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.test.cpp
@@ -1,9 +1,9 @@
+#include "polynomial_arithmetic.hpp"
 #include "barretenberg/common/mem.hpp"
 #include "barretenberg/numeric/bitop/get_msb.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 #include "barretenberg/polynomials/evaluation_domain.hpp"
 #include "polynomial.hpp"
-#include "polynomial_arithmetic.hpp"
 #include <algorithm>
 #include <cstddef>
 #include <gtest/gtest.h>

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/pow.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/polynomials/pow.test.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "pow.hpp"
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include <gtest/gtest.h>
 
 namespace barretenberg::test_pow {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_translator_circuit_builder.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_translator_circuit_builder.test.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/ecc/curves/bn254/bn254.hpp"
 #include "goblin_translator_circuit_builder.hpp"
+#include "barretenberg/ecc/curves/bn254/bn254.hpp"
 #include <array>
 #include <cstddef>
 #include <gtest/gtest.h>

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.test.cpp
@@ -1,6 +1,6 @@
+#include "standard_circuit_builder.hpp"
 #include "barretenberg/crypto/generators/generator_data.hpp"
 #include "barretenberg/crypto/pedersen_commitment/pedersen.hpp"
-#include "standard_circuit_builder.hpp"
 #include <gtest/gtest.h>
 
 using namespace barretenberg;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/turbo_circuit_builder.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/turbo_circuit_builder.test.cpp
@@ -1,6 +1,6 @@
+#include "turbo_circuit_builder.hpp"
 #include "barretenberg/crypto/generators/fixed_base_scalar_mul.hpp"
 #include "barretenberg/crypto/generators/generator_data.hpp"
-#include "turbo_circuit_builder.hpp"
 #include <gtest/gtest.h>
 
 using namespace barretenberg;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.test.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/crypto/generators/generator_data.hpp"
 #include "ultra_circuit_builder.hpp"
+#include "barretenberg/crypto/generators/generator_data.hpp"
 #include <gtest/gtest.h>
 
 using namespace barretenberg;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/composer/composer_lib.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/composer/composer_lib.test.cpp
@@ -1,6 +1,6 @@
+#include "barretenberg/proof_system/composer/composer_lib.hpp"
 #include "barretenberg/common/slab_allocator.hpp"
 #include "barretenberg/honk/flavor/standard.hpp" // TODO: needed?
-#include "barretenberg/proof_system/composer/composer_lib.hpp"
 #include "barretenberg/proof_system/types/circuit_type.hpp"
 #include "barretenberg/srs/factories/crs_factory.hpp"
 #include <array>

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/composer/permutation_lib.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/composer/permutation_lib.test.cpp
@@ -1,6 +1,6 @@
+#include "barretenberg/proof_system/composer/permutation_lib.hpp"
 #include "barretenberg/honk/flavor/standard.hpp" // TODO: needed?
 #include "barretenberg/proof_system/composer/composer_lib.hpp"
-#include "barretenberg/proof_system/composer/permutation_lib.hpp"
 #include "barretenberg/proof_system/types/circuit_type.hpp"
 #include "barretenberg/srs/factories/crs_factory.hpp"
 #include <array>

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/relations/relation_types.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/relations/relation_types.hpp
@@ -3,10 +3,8 @@
 #include "relation_parameters.hpp"
 
 namespace proof_system {
-template <typename T> concept HasSubrelationLinearlyIndependentMember = requires(T)
-{
-    T::Relation::SUBRELATION_LINEARLY_INDEPENDENT;
-};
+template <typename T>
+concept HasSubrelationLinearlyIndependentMember = requires(T) { T::Relation::SUBRELATION_LINEARLY_INDEPENDENT; };
 /**
  * @brief The templates defined herein facilitate sharing the relation arithmetic between the prover and the verifier.
  *
@@ -31,9 +29,9 @@ template <typename T> concept HasSubrelationLinearlyIndependentMember = requires
  * @return requires
  */
 template <typename FF, typename AccumulatorTypes, typename T>
-requires std::is_same<std::span<FF>, T>::value inline
-    typename std::tuple_element<0, typename AccumulatorTypes::AccumulatorViews>::type
-    get_view(const T& input, const size_t index)
+    requires std::is_same<std::span<FF>, T>::value
+inline typename std::tuple_element<0, typename AccumulatorTypes::AccumulatorViews>::type get_view(const T& input,
+                                                                                                  const size_t index)
 {
     return input[index];
 }
@@ -107,8 +105,8 @@ template <typename RelationImpl> class Relation : public RelationImpl {
      * @tparam size_t
      */
     template <size_t>
-    static constexpr bool is_subrelation_linearly_independent() requires(
-        !HasSubrelationLinearlyIndependentMember<Relation>)
+    static constexpr bool is_subrelation_linearly_independent()
+        requires(!HasSubrelationLinearlyIndependentMember<Relation>)
     {
         return true;
     }
@@ -119,8 +117,8 @@ template <typename RelationImpl> class Relation : public RelationImpl {
      * @tparam size_t
      */
     template <size_t subrelation_index>
-    static constexpr bool is_subrelation_linearly_independent() requires(
-        HasSubrelationLinearlyIndependentMember<Relation>)
+    static constexpr bool is_subrelation_linearly_independent()
+        requires(HasSubrelationLinearlyIndependentMember<Relation>)
     {
         return std::get<subrelation_index>(Relation::SUBRELATION_LINEARLY_INDEPENDENT);
     }

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/types/circuit_type.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/proof_system/types/circuit_type.hpp
@@ -5,5 +5,6 @@
 namespace proof_system {
 enum class CircuitType : uint32_t { STANDARD, TURBO, ULTRA, UNDEFINED };
 
-template <typename T, typename... U> concept IsAnyOf = (std::same_as<T, U> || ...);
+template <typename T, typename... U>
+concept IsAnyOf = (std::same_as<T, U> || ...);
 } // namespace proof_system

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/serialize/msgpack.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/serialize/msgpack.hpp
@@ -99,4 +99,7 @@ e.g. unpacking
 // Define a macro that takes any amount of parameters and expands to a msgpack method definition
 // __VA__ARGS__ expands to the parmeters, comma separated.
 #define MSGPACK_FIELDS(...)                                                                                            \
-    void msgpack(auto pack_fn) { pack_fn(NVP(__VA_ARGS__)); }
+    void msgpack(auto pack_fn)                                                                                         \
+    {                                                                                                                  \
+        pack_fn(NVP(__VA_ARGS__));                                                                                     \
+    }

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/serialize/msgpack_impl/concepts.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/serialize/msgpack_impl/concepts.hpp
@@ -4,23 +4,15 @@ struct DoNothing {
     void operator()(auto...) {}
 };
 namespace msgpack_concepts {
-template <typename T> concept HasMsgPack = requires(T t, DoNothing nop)
-{
-    t.msgpack(nop);
-};
+template <typename T>
+concept HasMsgPack = requires(T t, DoNothing nop) { t.msgpack(nop); };
 
-template <typename T> concept HasMsgPackSchema = requires(const T t, DoNothing nop)
-{
-    t.msgpack_schema(nop);
-};
+template <typename T>
+concept HasMsgPackSchema = requires(const T t, DoNothing nop) { t.msgpack_schema(nop); };
 
-template <typename T> concept HasMsgPackPack = requires(T t, DoNothing nop)
-{
-    t.msgpack_pack(nop);
-};
-template <typename T, typename... Args> concept MsgpackConstructible = requires(T object, Args... args)
-{
-    T{ args... };
-};
+template <typename T>
+concept HasMsgPackPack = requires(T t, DoNothing nop) { t.msgpack_pack(nop); };
+template <typename T, typename... Args>
+concept MsgpackConstructible = requires(T object, Args... args) { T{ args... }; };
 
 } // namespace msgpack_concepts

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/serialize/msgpack_impl/func_traits.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/serialize/msgpack_impl/func_traits.hpp
@@ -32,10 +32,9 @@ template <typename R, typename T, typename... Vs> struct func_traits<R (T::*)(Vs
 
 // Define a concept that checks if the type is a lambda (or functor) type
 // This is done by checking if T::operator() exists
-template <typename T> concept LambdaType = requires()
-{
-    typename std::enable_if_t<std::is_member_function_pointer_v<decltype(&T::operator())>, void>;
-};
+template <typename T>
+concept LambdaType =
+    requires() { typename std::enable_if_t<std::is_member_function_pointer_v<decltype(&T::operator())>, void>; };
 
 // Overload for lambda (or functor) types
 template <LambdaType T> constexpr auto get_func_traits()

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/serialize/msgpack_impl/schema_impl.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/serialize/msgpack_impl/schema_impl.hpp
@@ -102,10 +102,8 @@ inline void _schema_pack_map_content(MsgpackSchemaPacker&)
 }
 
 namespace msgpack_concepts {
-template <typename T> concept SchemaPackable = requires(T value, MsgpackSchemaPacker packer)
-{
-    msgpack_schema_pack(packer, value);
-};
+template <typename T>
+concept SchemaPackable = requires(T value, MsgpackSchemaPacker packer) { msgpack_schema_pack(packer, value); };
 } // namespace msgpack_concepts
 
 // Helper for packing (key, value, key, value, ...) arguments
@@ -121,8 +119,8 @@ inline void _schema_pack_map_content(MsgpackSchemaPacker& packer, std::string ke
 }
 
 template <typename T>
-requires(!msgpack_concepts::HasMsgPackSchema<T> &&
-         !msgpack_concepts::HasMsgPack<T>) inline void msgpack_schema_pack(MsgpackSchemaPacker& packer, T const& obj)
+    requires(!msgpack_concepts::HasMsgPackSchema<T> && !msgpack_concepts::HasMsgPack<T>)
+inline void msgpack_schema_pack(MsgpackSchemaPacker& packer, T const& obj)
 {
     packer.pack(msgpack_schema_name(obj));
 }
@@ -146,8 +144,8 @@ inline void msgpack_schema_pack(MsgpackSchemaPacker& packer, T const& obj)
  * @param object The object in question.
  */
 template <msgpack_concepts::HasMsgPack T>
-requires(!msgpack_concepts::HasMsgPackSchema<T>) inline void msgpack_schema_pack(MsgpackSchemaPacker& packer,
-                                                                                 T const& object)
+    requires(!msgpack_concepts::HasMsgPackSchema<T>)
+inline void msgpack_schema_pack(MsgpackSchemaPacker& packer, T const& object)
 {
     std::string type = msgpack_schema_name(object);
     packer.pack_with_name(type, object);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/factories/mem_crs_factory.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/factories/mem_crs_factory.test.cpp
@@ -1,8 +1,8 @@
+#include "mem_crs_factory.hpp"
 #include "../io.hpp"
 #include "barretenberg/ecc/curves/bn254/bn254.hpp"
 #include "barretenberg/ecc/curves/bn254/pairing.hpp"
 #include "file_crs_factory.hpp"
-#include "mem_crs_factory.hpp"
 #include <fstream>
 #include <gtest/gtest.h>
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/io.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/io.hpp
@@ -46,10 +46,8 @@ struct Manifest {
 };
 
 // Detect whether a curve has a G2AffineElement defined
-template <typename Curve> concept HasG2 = requires
-{
-    typename Curve::G2AffineElement;
-};
+template <typename Curve>
+concept HasG2 = requires { typename Curve::G2AffineElement; };
 
 // If Curve has a G2AffineElement type, check whether T is this type.
 template <typename Curve, typename T>
@@ -323,7 +321,8 @@ template <typename Curve> class IO {
         }
     }
 
-    static void read_transcript_g2(auto& g2_x, std::string const& dir) requires HasG2<Curve>
+    static void read_transcript_g2(auto& g2_x, std::string const& dir)
+        requires HasG2<Curve>
     {
         const size_t g2_size = sizeof(typename Curve::G2BaseField) * 2;
         std::string path = format(dir, "/g2.dat");
@@ -356,10 +355,8 @@ template <typename Curve> class IO {
         byteswap(&g2_x, size);
     }
 
-    static void read_transcript(AffineElement* monomials,
-                                auto& g2_x,
-                                size_t degree,
-                                std::string const& path) requires HasG2<Curve>
+    static void read_transcript(AffineElement* monomials, auto& g2_x, size_t degree, std::string const& path)
+        requires HasG2<Curve>
     {
         read_transcript_g1(monomials, degree, path);
         read_transcript_g2(g2_x, path);
@@ -374,7 +371,8 @@ template <typename Curve> class IO {
     static void write_transcript(AffineElement const* g1_x,
                                  auto const* g2_x,
                                  Manifest const& manifest,
-                                 std::string const& dir) requires HasG2<Curve>
+                                 std::string const& dir)
+        requires HasG2<Curve>
     {
         const size_t num_g1_x = manifest.num_g1_points;
         const size_t num_g2_x = manifest.num_g2_points;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/io.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/io.test.cpp
@@ -1,7 +1,7 @@
+#include "io.hpp"
 #include "barretenberg/common/mem.hpp"
 #include "barretenberg/ecc/curves/bn254/fq12.hpp"
 #include "barretenberg/ecc/curves/bn254/pairing.hpp"
-#include "io.hpp"
 #include <gtest/gtest.h>
 
 using namespace barretenberg;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/scalar_multiplication.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/srs/scalar_multiplication.test.cpp
@@ -9,10 +9,10 @@
  * reason for for ecc to depend on srs.
  */
 
+#include "barretenberg/ecc/scalar_multiplication/scalar_multiplication.hpp"
 #include "barretenberg/common/mem.hpp"
 #include "barretenberg/common/test.hpp"
 #include "barretenberg/ecc/scalar_multiplication/point_table.hpp"
-#include "barretenberg/ecc/scalar_multiplication/scalar_multiplication.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 #include "barretenberg/srs/factories/file_crs_factory.hpp"
 #include "barretenberg/srs/io.hpp"
@@ -36,7 +36,8 @@ template <typename Curve> class ScalarMultiplicationTests : public ::testing::Te
         }
     }();
 
-    static void read_transcript_g2(std::string const& srs_path) requires srs::HasG2<Curve>
+    static void read_transcript_g2(std::string const& srs_path)
+        requires srs::HasG2<Curve>
     {
         typename Curve::G2AffineElement g2_x;
         srs::IO<Curve>::read_transcript_g2(g2_x, srs_path);

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.test.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/common/test.hpp"
 #include "barretenberg/crypto/pedersen_commitment/pedersen.hpp"
+#include "barretenberg/common/test.hpp"
 #include "barretenberg/crypto/pedersen_commitment/pedersen_lookup.hpp"
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 #include "barretenberg/numeric/random/engine.hpp"

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen_plookup.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen_plookup.test.cpp
@@ -1,3 +1,4 @@
+#include "pedersen_plookup.hpp"
 #include "barretenberg/common/test.hpp"
 #include "barretenberg/crypto/pedersen_commitment/pedersen.hpp"
 #include "barretenberg/crypto/pedersen_commitment/pedersen_lookup.hpp"
@@ -5,7 +6,6 @@
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 #include "barretenberg/stdlib/primitives/curves/bn254.hpp"
 #include "pedersen.hpp"
-#include "pedersen_plookup.hpp"
 
 namespace test_stdlib_pedersen {
 using namespace barretenberg;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
@@ -1,9 +1,9 @@
+#include "barretenberg/crypto/ecdsa/ecdsa.hpp"
 #include "../../primitives/bigfield/bigfield.hpp"
 #include "../../primitives/biggroup/biggroup.hpp"
 #include "../../primitives/curves/secp256k1.hpp"
 #include "../../primitives/curves/secp256r1.hpp"
 #include "barretenberg/common/test.hpp"
-#include "barretenberg/crypto/ecdsa/ecdsa.hpp"
 #include "ecdsa.hpp"
 
 using namespace barretenberg;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/benchmarks/celer/sha256.bench.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/benchmarks/celer/sha256.bench.cpp
@@ -6,8 +6,8 @@
  * @date 2023-08-02
  *
  */
-#include "barretenberg/plonk/composer/ultra_composer.hpp"
 #include "barretenberg/stdlib/hash/sha256/sha256.hpp"
+#include "barretenberg/plonk/composer/ultra_composer.hpp"
 #include <benchmark/benchmark.h>
 #include <bit>
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/benchmarks/sha256/sha256.bench.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/benchmarks/sha256/sha256.bench.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/plonk/composer/ultra_composer.hpp"
 #include "barretenberg/stdlib/hash/sha256/sha256.hpp"
+#include "barretenberg/plonk/composer/ultra_composer.hpp"
 #include <benchmark/benchmark.h>
 
 using namespace benchmark;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/common/streams.hpp"
 #include "barretenberg/crypto/blake3s/blake3s.hpp"
+#include "barretenberg/common/streams.hpp"
 #include "blake3s.hpp"
 #include "blake3s_plookup.hpp"
 #include <gtest/gtest.h>

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
@@ -1,5 +1,5 @@
-#include "../../primitives/plookup/plookup.hpp"
 #include "barretenberg/crypto/keccak/keccak.hpp"
+#include "../../primitives/plookup/plookup.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 #include "keccak.hpp"
 #include <gtest/gtest.h>

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.test.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/common/test.hpp"
 #include "barretenberg/crypto/sha256/sha256.hpp"
+#include "barretenberg/common/test.hpp"
 #include "barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp"
 #include "barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp"
 #include "barretenberg/proof_system/plookup_tables/plookup_tables.hpp"

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/merkle_tree.bench.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/merkle_tree.bench.cpp
@@ -1,7 +1,7 @@
+#include "merkle_tree.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 #include "hash.hpp"
 #include "memory_store.hpp"
-#include "merkle_tree.hpp"
 #include <benchmark/benchmark.h>
 
 using namespace benchmark;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/merkle_tree.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/merkle_tree.test.cpp
@@ -1,9 +1,9 @@
+#include "merkle_tree.hpp"
 #include "barretenberg/common/streams.hpp"
 #include "barretenberg/common/test.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 #include "memory_store.hpp"
 #include "memory_tree.hpp"
-#include "merkle_tree.hpp"
 
 namespace proof_system::test_stdlib_merkle_tree {
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.test.cpp
@@ -1,9 +1,9 @@
+#include "nullifier_tree.hpp"
 #include "../memory_store.hpp"
 #include "barretenberg/common/streams.hpp"
 #include "barretenberg/common/test.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 #include "nullifier_memory_tree.hpp"
-#include "nullifier_tree.hpp"
 
 using namespace barretenberg;
 using namespace proof_system::plonk::stdlib::merkle_tree;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.fuzzer.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.fuzzer.hpp
@@ -236,7 +236,9 @@ template <typename Composer> class BigFieldBase {
          * @param rng PRNG used
          * @return A random instruction
          */
-        template <typename T> inline static Instruction generateRandom(T& rng) requires SimpleRng<T>
+        template <typename T>
+        inline static Instruction generateRandom(T& rng)
+            requires SimpleRng<T>
         {
             // Choose which instruction we are going to generate
             OPCODE instruction_opcode = static_cast<OPCODE>(rng.next() % (OPCODE::_LAST));
@@ -362,7 +364,8 @@ template <typename Composer> class BigFieldBase {
          * @return Mutated element
          */
         template <typename T>
-        inline static fq mutateFieldElement(fq e, T& rng, HavocSettings& havoc_config) requires SimpleRng<T>
+        inline static fq mutateFieldElement(fq e, T& rng, HavocSettings& havoc_config)
+            requires SimpleRng<T>
         {
             // With a certain probability, we apply changes to the Montgomery form, rather than the plain form. This
             // has merit, since the computation is performed in montgomery form and comparisons are often performed
@@ -458,9 +461,8 @@ template <typename Composer> class BigFieldBase {
          * @return Mutated instruction
          */
         template <typename T>
-        inline static Instruction mutateInstruction(Instruction instruction,
-                                                    T& rng,
-                                                    HavocSettings& havoc_config) requires SimpleRng<T>
+        inline static Instruction mutateInstruction(Instruction instruction, T& rng, HavocSettings& havoc_config)
+            requires SimpleRng<T>
         {
 #define PUT_RANDOM_BYTE_IF_LUCKY(variable)                                                                             \
     if (rng.next() & 1) {                                                                                              \

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/bit_array/bit_array.fuzzer.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/bit_array/bit_array.fuzzer.hpp
@@ -170,7 +170,9 @@ template <typename Composer> class BitArrayFuzzBase {
          * @param rng PRNG used
          * @return A random instruction
          */
-        template <typename T> inline static Instruction generateRandom(T& rng) requires SimpleRng<T>
+        template <typename T>
+        inline static Instruction generateRandom(T& rng)
+            requires SimpleRng<T>
         {
             // Choose which instruction we are going to generate
             OPCODE instruction_opcode = static_cast<OPCODE>(rng.next() % (OPCODE::_LAST));
@@ -229,9 +231,8 @@ template <typename Composer> class BitArrayFuzzBase {
          * @return Mutated instruction
          */
         template <typename T>
-        inline static Instruction mutateInstruction(Instruction instruction,
-                                                    T& rng,
-                                                    HavocSettings& havoc_config) requires SimpleRng<T>
+        inline static Instruction mutateInstruction(Instruction instruction, T& rng, HavocSettings& havoc_config)
+            requires SimpleRng<T>
         {
             (void)rng;
             (void)havoc_config;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/bit_array/bit_array.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/bit_array/bit_array.test.cpp
@@ -1,9 +1,9 @@
+#include "bit_array.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 #include "barretenberg/stdlib/primitives/byte_array/byte_array.hpp"
 #include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include "barretenberg/stdlib/primitives/witness/witness.hpp"
-#include "bit_array.hpp"
 #include <gtest/gtest.h>
 
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.fuzzer.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.fuzzer.hpp
@@ -72,7 +72,9 @@ template <typename Composer> class BoolFuzzBase {
          * @param rng PRNG used
          * @return A random instruction
          */
-        template <typename T> inline static Instruction generateRandom(T& rng) requires SimpleRng<T>
+        template <typename T>
+        inline static Instruction generateRandom(T& rng)
+            requires SimpleRng<T>
         {
             // Choose which instruction we are going to generate
             OPCODE instruction_opcode = static_cast<OPCODE>(rng.next() % (OPCODE::_LAST));
@@ -129,9 +131,8 @@ template <typename Composer> class BoolFuzzBase {
          * @return Mutated instruction
          */
         template <typename T>
-        inline static Instruction mutateInstruction(Instruction instruction,
-                                                    T& rng,
-                                                    HavocSettings& havoc_config) requires SimpleRng<T>
+        inline static Instruction mutateInstruction(Instruction instruction, T& rng, HavocSettings& havoc_config)
+            requires SimpleRng<T>
         {
             (void)rng;
             (void)havoc_config;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.test.cpp
@@ -1,6 +1,6 @@
+#include "bool.hpp"
 #include "barretenberg/stdlib/primitives/byte_array/byte_array.cpp"
 #include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp"
-#include "bool.hpp"
 #include <gtest/gtest.h>
 
 #define STDLIB_TYPE_ALIASES                                                                                            \

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.fuzzer.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.fuzzer.hpp
@@ -106,7 +106,9 @@ template <typename Composer> class ByteArrayFuzzBase {
          * @param rng PRNG used
          * @return A random instruction
          */
-        template <typename T> inline static Instruction generateRandom(T& rng) requires SimpleRng<T>
+        template <typename T>
+        inline static Instruction generateRandom(T& rng)
+            requires SimpleRng<T>
         {
             // Choose which instruction we are going to generate
             OPCODE instruction_opcode = static_cast<OPCODE>(rng.next() % (OPCODE::_LAST));
@@ -176,9 +178,8 @@ template <typename Composer> class ByteArrayFuzzBase {
          * @return Mutated instruction
          */
         template <typename T>
-        inline static Instruction mutateInstruction(Instruction instruction,
-                                                    T& rng,
-                                                    HavocSettings& havoc_config) requires SimpleRng<T>
+        inline static Instruction mutateInstruction(Instruction instruction, T& rng, HavocSettings& havoc_config)
+            requires SimpleRng<T>
         {
             (void)rng;
             (void)havoc_config;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp
@@ -7,7 +7,8 @@
 #include "barretenberg/proof_system/circuit_builder/turbo_circuit_builder.hpp"
 #include "barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp"
 
-template <typename T> concept HasPlookup = proof_system::IsAnyOf<T, proof_system::UltraCircuitBuilder>;
+template <typename T>
+concept HasPlookup = proof_system::IsAnyOf<T, proof_system::UltraCircuitBuilder>;
 
 #define INSTANTIATE_STDLIB_METHOD(stdlib_method)                                                                       \
     template stdlib_method(proof_system::StandardCircuitBuilder);                                                      \

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/array.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/array.test.cpp
@@ -1,5 +1,5 @@
-#include "../bool/bool.hpp"
 #include "array.hpp"
+#include "../bool/bool.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 #include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp"
 #include "field.hpp"

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.fuzzer.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.fuzzer.hpp
@@ -227,7 +227,9 @@ template <typename Composer> class FieldBase {
          * @param rng PRNG used
          * @return A random instruction
          */
-        template <typename T> inline static Instruction generateRandom(T& rng) requires SimpleRng<T>
+        template <typename T>
+        inline static Instruction generateRandom(T& rng)
+            requires SimpleRng<T>
         {
             // Choose which instruction we are going to generate
             OPCODE instruction_opcode = static_cast<OPCODE>(rng.next() % (OPCODE::_LAST));
@@ -325,9 +327,8 @@ template <typename Composer> class FieldBase {
          * @return Mutated element
          */
         template <typename T>
-        inline static barretenberg::fr mutateFieldElement(barretenberg::fr e,
-                                                          T& rng,
-                                                          HavocSettings& havoc_config) requires SimpleRng<T>
+        inline static barretenberg::fr mutateFieldElement(barretenberg::fr e, T& rng, HavocSettings& havoc_config)
+            requires SimpleRng<T>
         {
             // With a certain probability, we apply changes to the Montgomery form, rather than the plain form. This
             // has merit, since the computation is performed in montgomery form and comparisons are often performed
@@ -423,9 +424,8 @@ template <typename Composer> class FieldBase {
          * @return Mutated instruction
          */
         template <typename T>
-        inline static Instruction mutateInstruction(Instruction instruction,
-                                                    T& rng,
-                                                    HavocSettings& havoc_config) requires SimpleRng<T>
+        inline static Instruction mutateInstruction(Instruction instruction, T& rng, HavocSettings& havoc_config)
+            requires SimpleRng<T>
         {
 #define PUT_RANDOM_BYTE_IF_LUCKY(variable)                                                                             \
     if (rng.next() & 1) {                                                                                              \

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
@@ -1,10 +1,10 @@
+#include "field.hpp"
 #include "../bool/bool.hpp"
 #include "array.hpp"
 #include "barretenberg/common/streams.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 #include "barretenberg/plonk/proof_system/constants.hpp"
 #include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp"
-#include "field.hpp"
 #include <gtest/gtest.h>
 #include <utility>
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/group.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/group.test.cpp
@@ -1,6 +1,6 @@
+#include "barretenberg/stdlib/primitives/group/group.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
-#include "barretenberg/stdlib/primitives/group/group.hpp"
 #include "barretenberg/stdlib/primitives/witness/witness.hpp"
 #include <gtest/gtest.h>
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/plookup/plookup.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/plookup/plookup.test.cpp
@@ -1,3 +1,4 @@
+#include "plookup.hpp"
 #include "../byte_array/byte_array.hpp"
 #include "barretenberg/crypto/pedersen_commitment/pedersen_lookup.hpp"
 #include "barretenberg/numeric/bitop/rotate.hpp"
@@ -7,7 +8,6 @@
 #include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp"
 #include "barretenberg/stdlib/primitives/curves/secp256k1.hpp"
 #include "barretenberg/stdlib/primitives/uint/uint.hpp"
-#include "plookup.hpp"
 #include <gtest/gtest.h>
 
 namespace test_stdlib_plookups {

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.fuzzer.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.fuzzer.hpp
@@ -189,7 +189,9 @@ template <typename Composer> class SafeUintFuzzBase {
          * @param rng PRNG used
          * @return A random instruction
          */
-        template <typename T> inline static Instruction generateRandom(T& rng) requires SimpleRng<T>
+        template <typename T>
+        inline static Instruction generateRandom(T& rng)
+            requires SimpleRng<T>
         {
             // Choose which instruction we are going to generate
             OPCODE instruction_opcode = static_cast<OPCODE>(rng.next() % (OPCODE::_LAST));
@@ -284,7 +286,8 @@ template <typename Composer> class SafeUintFuzzBase {
          * @return Mutated element
          */
         template <typename T>
-        inline static fr mutateFieldElement(fr e, T& rng, HavocSettings& havoc_config) requires SimpleRng<T>
+        inline static fr mutateFieldElement(fr e, T& rng, HavocSettings& havoc_config)
+            requires SimpleRng<T>
         {
             // With a certain probability, we apply changes to the Montgomery form, rather than the plain form. This has
             // merit, since the computation is performed in montgomery form and comparisons are often performed in it,
@@ -377,9 +380,8 @@ template <typename Composer> class SafeUintFuzzBase {
          * @return Mutated instruction
          */
         template <typename T>
-        inline static Instruction mutateInstruction(Instruction instruction,
-                                                    T& rng,
-                                                    HavocSettings& havoc_config) requires SimpleRng<T>
+        inline static Instruction mutateInstruction(Instruction instruction, T& rng, HavocSettings& havoc_config)
+            requires SimpleRng<T>
         {
 #define PUT_RANDOM_BYTE_IF_LUCKY(variable)                                                                             \
     if (rng.next() & 1) {                                                                                              \

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.test.cpp
@@ -1,9 +1,9 @@
 
+#include "safe_uint.hpp"
 #include "../byte_array/byte_array.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 #include "barretenberg/stdlib/primitives/bool/bool.hpp"
 #include "barretenberg/stdlib/primitives/witness/witness.hpp"
-#include "safe_uint.hpp"
 #include <cstddef>
 #include <gtest/gtest.h>
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.fuzzer.hpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.fuzzer.hpp
@@ -105,7 +105,9 @@ template <typename Composer> class UintFuzzBase {
          * @param rng PRNG used
          * @return A random instruction
          */
-        template <typename T> inline static Instruction generateRandom(T& rng) requires SimpleRng<T>
+        template <typename T>
+        inline static Instruction generateRandom(T& rng)
+            requires SimpleRng<T>
         {
             // Choose which instruction we are going to generate
             OPCODE instruction_opcode = static_cast<OPCODE>(rng.next() % (OPCODE::_LAST));
@@ -165,9 +167,8 @@ template <typename Composer> class UintFuzzBase {
          * @return Mutated instruction
          */
         template <typename T>
-        inline static Instruction mutateInstruction(Instruction instruction,
-                                                    T& rng,
-                                                    HavocSettings& havoc_config) requires SimpleRng<T>
+        inline static Instruction mutateInstruction(Instruction instruction, T& rng, HavocSettings& havoc_config)
+            requires SimpleRng<T>
         {
             (void)rng;
             (void)havoc_config;

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.test.cpp
@@ -1,5 +1,5 @@
-#include "barretenberg/numeric/random/engine.hpp"
 #include "uint.hpp"
+#include "barretenberg/numeric/random/engine.hpp"
 #include <functional>
 #include <gtest/gtest.h>
 

--- a/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/verifier.test.cpp
+++ b/circuits/cpp/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/verifier.test.cpp
@@ -1,5 +1,5 @@
-#include "program_settings.hpp"
 #include "verifier.hpp"
+#include "program_settings.hpp"
 
 #include "barretenberg/common/test.hpp"
 #include "barretenberg/ecc/curves/bn254/fq12.hpp"

--- a/circuits/cpp/format.sh
+++ b/circuits/cpp/format.sh
@@ -14,7 +14,7 @@ elif [ -n "${1:-}" ]; then
     sed -i.bak 's/\r$//' $FILE && rm ${FILE}.bak
   done
 else
-  for FILE in $(find ./src -iname *.hpp -o -iname *.cpp -o -iname *.tcc | grep -v src/boost); do
+  for FILE in $(find ./{src,barretenberg} -iname *.hpp -o -iname *.cpp -o -iname *.tcc | grep -v src/boost); do
     clang-format -i $FILE
     sed -i.bak 's/\r$//' $FILE && rm ${FILE}.bak
   done

--- a/circuits/cpp/src/aztec3/circuits/abis/c_bind.test.cpp
+++ b/circuits/cpp/src/aztec3/circuits/abis/c_bind.test.cpp
@@ -1,4 +1,5 @@
 #include "c_bind.h"
+
 #include "function_leaf_preimage.hpp"
 #include "tx_request.hpp"
 

--- a/circuits/cpp/src/aztec3/circuits/kernel/private/common.cpp
+++ b/circuits/cpp/src/aztec3/circuits/kernel/private/common.cpp
@@ -193,11 +193,10 @@ void common_update_end_values(DummyBuilder& builder,
         std::array<NT::fr, MAX_NEW_NULLIFIERS_PER_CALL> siloed_nullified_commitments{};
         for (size_t i = 0; i < MAX_NEW_NULLIFIERS_PER_CALL; ++i) {
             siloed_nullified_commitments[i] =
-                nullified_commitments[i] == fr(0)
-                    ? fr(0)  // don't silo when empty
-                    : nullified_commitments[i] == fr(EMPTY_NULLIFIED_COMMITMENT)
-                          ? fr(EMPTY_NULLIFIED_COMMITMENT)  // don't silo when empty
-                          : silo_commitment<NT>(storage_contract_address, nullified_commitments[i]);
+                nullified_commitments[i] == fr(0) ? fr(0)  // don't silo when empty
+                : nullified_commitments[i] == fr(EMPTY_NULLIFIED_COMMITMENT)
+                    ? fr(EMPTY_NULLIFIED_COMMITMENT)  // don't silo when empty
+                    : silo_commitment<NT>(storage_contract_address, nullified_commitments[i]);
         }
 
         push_array_to_array(


### PR DESCRIPTION
The format script from circuits was not catching the barretenberg folder, so it was not being formatted when `format.sh` was being run. This fixes the script and runs a format on all of bb, and adds the missing imports that surfaced this issue.