### PR TITLE
chore: add debugging to run_tests

### DIFF
--- a/circuits/cpp/barretenberg/cpp/scripts/run_tests
+++ b/circuits/cpp/barretenberg/cpp/scripts/run_tests
@@ -3,7 +3,7 @@
 # 1. The number of ignition transcripts to download.
 # 2. The set of gtest binary names to run.
 # 3-n. The arguments to pass to the gtest binaries.
-set -eu
+set -exu
 
 NUM_TRANSCRIPTS=$1
 TESTS=$2

--- a/circuits/cpp/barretenberg/ts/scripts/run_tests
+++ b/circuits/cpp/barretenberg/ts/scripts/run_tests
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -xe
 
 $(aws ecr get-login --region us-east-2 --no-include-email) 2> /dev/null
 

--- a/circuits/cpp/scripts/run_tests
+++ b/circuits/cpp/scripts/run_tests
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -exu
 
 # To be called from CI for testing with docker and AWS.
 # Can't be called locally unless AWS credentials are set up.

--- a/circuits/cpp/scripts/run_tests_local
+++ b/circuits/cpp/scripts/run_tests_local
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -exu
 
 DIR="$(dirname "$0")"
 

--- a/yarn-project/canary/scripts/run_tests
+++ b/yarn-project/canary/scripts/run_tests
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script is used to run an e2e test in CI (see config.yml and cond_spot_run_tests).
 # It sets a few environment variables used inside the docker-compose.yml, pulls images, and runs docker-compose.
-set -eu
+set -exu
 
 export TEST=$1
 export IMAGE=${2:-canary}

--- a/yarn-project/end-to-end/scripts/run_tests
+++ b/yarn-project/end-to-end/scripts/run_tests
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script is used to run an e2e test in CI (see config.yml and cond_spot_run_tests).
 # It sets a few environment variables used inside the docker-compose.yml, pulls images, and runs docker-compose.
-set -eu
+set -exu
 
 export TEST=$1
 export COMPOSE_FILE=${2:-docker-compose.yml}

--- a/yarn-project/end-to-end/scripts/run_tests_local
+++ b/yarn-project/end-to-end/scripts/run_tests_local
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script is used to run an e2e test in CI (see config.yml and cond_run_script).
 # It sets a few environment variables used inside the docker-compose.yml, pulls images, and runs docker-compose.
-set -eu
+set -exu
 
 export TEST=$1
 export COMPOSE_FILE=${2:-./scripts/docker-compose.yml}


### PR DESCRIPTION
A few intermittent errors came up and there was uncertainty what line they were coming from as they were generic http throttles. I don't think tracing every line in these files hurts.