### PR TITLE
fix: reinstate v stripping in build

### DIFF
--- a/build-system/scripts/build
+++ b/build-system/scripts/build
@@ -135,13 +135,9 @@ if [[ -n "$COMMIT_TAG" ]]; then
     COMMIT_TAG_VERSION=$COMMIT_TAG
   fi
 
-  ## We are building a tagged commit. Check it's a valid semver.
-  #VERSION=$(npx semver $COMMIT_TAG_VERSION)
-  #if [ -z "$VERSION" ]; then
-  #  COMMIT_TAG_VERSION=""
-  #else
-  #  COMMIT_TAG_VERSION=$VERSION
-  #fi
+  # We are building a tagged commit. 
+  # We prefer to strip the leading 'v' (if it exists) from versions when passing to docker.
+  COMMIT_TAG_VERSION=${COMMIT_TAG_VERSION#v}
 else
   COMMIT_TAG_VERSION=""
 fi


### PR DESCRIPTION
We pass the tagged version number into docker builds. In some cases this number is written into the 'version' field of package json. We write this number in without the 'v' at the start so it needs removing at some point in the build process.

This version number is then made available to consumers of the application.
