### PR TITLE
chore(noir-contracts): 1655 - rename functions to make hack clearer for publicly created notes

### DIFF
--- a/yarn-project/noir-contracts/src/contracts/docs_example_contract/src/actions.nr
+++ b/yarn-project/noir-contracts/src/contracts/docs_example_contract/src/actions.nr
@@ -150,7 +150,7 @@ fn assert_contains_card<RERUEN_LEN, FILTER_PARAMS>(
     state_var: Set<CardNote, CARD_NOTE_LEN>,
     card: CardNote,
 ) {
-    state_var.assert_contains_and_remove(card);
+    state_var.assert_contains_note_and_remove(card);
 }
 // docs:end:state_vars-SetContains
 

--- a/yarn-project/noir-contracts/src/contracts/docs_example_contract/src/actions.nr
+++ b/yarn-project/noir-contracts/src/contracts/docs_example_contract/src/actions.nr
@@ -150,7 +150,7 @@ fn assert_contains_card<RERUEN_LEN, FILTER_PARAMS>(
     state_var: Set<CardNote, CARD_NOTE_LEN>,
     card: CardNote,
 ) {
-    state_var.assert_contains_note_and_remove(card);
+    state_var.assert_contains_and_remove(card);
 }
 // docs:end:state_vars-SetContains
 

--- a/yarn-project/noir-contracts/src/contracts/native_token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/native_token_contract/src/main.nr
@@ -351,7 +351,7 @@ contract NativeToken {
         let public_note = TransparentNote::new_from_secret(amount, secret);
 
         // Ensure that the note exists in the tree and remove it.
-        pending_shields.assert_contains_and_remove(public_note);
+        pending_shields.assert_contains_and_remove_publicly_created(public_note);
 
         // Mint the tokens
         let balance = storage.balances.at(owner);

--- a/yarn-project/noir-contracts/src/contracts/non_native_token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/non_native_token_contract/src/main.nr
@@ -247,7 +247,7 @@ contract NonNativeToken {
         let public_note = TransparentNote::new_from_secret(amount, secret);
 
         // Ensure that the note exists in the tree and remove it.
-        pending_shields.assert_contains_and_remove(public_note);
+        pending_shields.assert_contains_and_remove_publicly_created(public_note);
 
         // Mint the tokens
         let balance = storage.balances.at(owner);

--- a/yarn-project/noir-contracts/src/contracts/private_token_airdrop_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/private_token_airdrop_contract/src/main.nr
@@ -166,7 +166,7 @@ contract PrivateTokenAirdrop {
 
         // Remove the claim note if it exists in the set.
         let note = ClaimNote::new(amount, secret);
-        storage.claims.assert_contains_and_remove(note);
+        storage.claims.assert_contains_note_and_remove(note);
 
         // Send the value note.
         let balance = storage.balances.at(owner);

--- a/yarn-project/noir-contracts/src/contracts/private_token_airdrop_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/private_token_airdrop_contract/src/main.nr
@@ -166,7 +166,7 @@ contract PrivateTokenAirdrop {
 
         // Remove the claim note if it exists in the set.
         let note = ClaimNote::new(amount, secret);
-        storage.claims.assert_contains_note_and_remove(note);
+        storage.claims.assert_contains_and_remove(note);
 
         // Send the value note.
         let balance = storage.balances.at(owner);

--- a/yarn-project/noir-libs/aztec-noir/src/state_vars/set.nr
+++ b/yarn-project/noir-libs/aztec-noir/src/state_vars/set.nr
@@ -49,9 +49,7 @@ impl<Note, N> Set<Note, N> {
         );
     }
 
-    // TODO(1386): rename `assert_contains_and_remove`
-    // once `get_commitment` works for privately created note hashes
-    fn assert_contains_note_and_remove(self, note: Note) {
+    fn assert_contains_and_remove(self, note: Note) {
         let mut note_with_header = note;
         // TODO(1386): replace with `ensure_note_hash_exists`
         // once `get_commitment` works for privately created note hashes
@@ -69,10 +67,9 @@ impl<Note, N> Set<Note, N> {
         );
     }
 
-    // TODO(1386): remove this function and replace with `assert_contains_and_remove`
-    // once public kernel injects nonces to note hashes.
     // NOTE: this function should ONLY be used for PUBLICLY-CREATED note hashes!
-    // WARNING: function will be deprecated/removed eventually
+    // WARNING: function will be deprecated/removed eventually once `assert_contains_and_remove`
+    // works for publicly-created note hashes as well.
     fn assert_contains_and_remove_publicly_created(self, note: Note) {
         let mut note_with_header = note;
         // Modifies note with the header which is necessary for the next step (remove).

--- a/yarn-project/noir-libs/aztec-noir/src/state_vars/set.nr
+++ b/yarn-project/noir-libs/aztec-noir/src/state_vars/set.nr
@@ -49,11 +49,10 @@ impl<Note, N> Set<Note, N> {
         );
     }
 
-    // TODO(#1386)
-    // Should be replaced by `assert_contains_and_remove`.
-    fn assert_contains_note_and_remove(self, note: Note) {
+    fn assert_contains_and_remove(self, note: Note) {
         let mut note_with_header = note;
-        ensure_note_exists(
+        // Modifies note with the header which is necessary for the next step (remove).
+        ensure_note_hash_exists(
             self.context.private.unwrap(),
             self.storage_slot,
             self.note_interface,
@@ -67,10 +66,11 @@ impl<Note, N> Set<Note, N> {
         );
     }
 
-    // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1386):
-    // replace function above ^ once public kernel injects
-    // nonces to note hashes.
-    fn assert_contains_and_remove(self, note: Note) {
+    // TODO(1386): remove this function and use `assert_contains_and_remove`
+    // once public kernel injects nonces to note hashes.
+    // NOTE: this function should ONLY be used for PUBLICLY-CREATED note hashes!
+    // WARNING: function will be deprecated/removed eventually
+    fn assert_contains_and_remove_publicly_created(self, note: Note) {
         let mut note_with_header = note;
         // Modifies note with the header which is necessary for the next step (remove).
         ensure_note_hash_exists(

--- a/yarn-project/noir-libs/aztec-noir/src/state_vars/set.nr
+++ b/yarn-project/noir-libs/aztec-noir/src/state_vars/set.nr
@@ -49,10 +49,13 @@ impl<Note, N> Set<Note, N> {
         );
     }
 
-    fn assert_contains_and_remove(self, note: Note) {
+    // TODO(1386): rename `assert_contains_and_remove`
+    // once `get_commitment` works for privately created note hashes
+    fn assert_contains_note_and_remove(self, note: Note) {
         let mut note_with_header = note;
-        // Modifies note with the header which is necessary for the next step (remove).
-        ensure_note_hash_exists(
+        // TODO(1386): replace with `ensure_note_hash_exists`
+        // once `get_commitment` works for privately created note hashes
+        ensure_note_exists(
             self.context.private.unwrap(),
             self.storage_slot,
             self.note_interface,
@@ -66,7 +69,7 @@ impl<Note, N> Set<Note, N> {
         );
     }
 
-    // TODO(1386): remove this function and use `assert_contains_and_remove`
+    // TODO(1386): remove this function and replace with `assert_contains_and_remove`
     // once public kernel injects nonces to note hashes.
     // NOTE: this function should ONLY be used for PUBLICLY-CREATED note hashes!
     // WARNING: function will be deprecated/removed eventually


### PR DESCRIPTION
Resolves #1655

`assert_contains_and_remove` has a hack that makes it only work for publicly created note hashes. This PR renames the function to make it clear that it only works for publicly created note hashes. It also renames `assert_contains_note_and_remove` to `assert_contains_and_remove` with a TODO to tweak it to only `ensure_note_hash_exists` instead of `ensure_note_exists` once `get_commitment` supports privately created commitments.