### PR TITLE
chore: update url for acir artifacts

### DIFF
--- a/circuits/cpp/barretenberg/acir_tests/run_acir_tests.sh
+++ b/circuits/cpp/barretenberg/acir_tests/run_acir_tests.sh
@@ -30,10 +30,10 @@ if [ ! -d acir_tests ]; then
     git clone -b $BRANCH --filter=blob:none --no-checkout https://github.com/noir-lang/noir.git
     cd noir
     git sparse-checkout init --cone
-    git sparse-checkout set crates/nargo_cli/tests/acir_artifacts
+    git sparse-checkout set tooling/nargo_cli/tests/acir_artifacts
     git checkout
     cd ..
-    mv noir/crates/nargo_cli/tests/acir_artifacts acir_tests
+    mv noir/tooling/nargo_cli/tests/acir_artifacts acir_tests
     rm -rf noir
   fi
 fi


### PR DESCRIPTION
The url for the acir artifacts has been moved in the noir repo. This PR updates it.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
