### PR TITLE
fix(build): Update ubuntu version used in Docker builds

### DIFF
--- a/circuits/cpp/barretenberg/cpp/dockerfiles/Dockerfile.wasm-linux-clang
+++ b/circuits/cpp/barretenberg/cpp/dockerfiles/Dockerfile.wasm-linux-clang
@@ -1,4 +1,4 @@
-FROM ubuntu:kinetic AS builder
+FROM ubuntu:lunar AS builder
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential wget git libssl-dev cmake ninja-build curl
 RUN curl https://wasmtime.dev/install.sh -sSf | bash /dev/stdin --version v3.0.1
 WORKDIR /usr/src/barretenberg/cpp

--- a/circuits/cpp/dockerfiles/Dockerfile.wasm-linux-clang
+++ b/circuits/cpp/dockerfiles/Dockerfile.wasm-linux-clang
@@ -1,4 +1,4 @@
-FROM ubuntu:kinetic AS builder
+FROM ubuntu:lunar AS builder
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential wget git libssl-dev cmake ninja-build curl binaryen
 
 WORKDIR /usr/src/circuits/cpp/barretenberg/cpp

--- a/circuits/cpp/dockerfiles/Dockerfile.wasm-linux-clang-assert
+++ b/circuits/cpp/dockerfiles/Dockerfile.wasm-linux-clang-assert
@@ -1,4 +1,4 @@
-FROM ubuntu:kinetic AS builder
+FROM ubuntu:lunar AS builder
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git libssl-dev cmake ninja-build curl binaryen
 
 WORKDIR /usr/src/circuits/cpp/barretenberg/cpp
@@ -9,7 +9,7 @@ COPY . .
 
 RUN cmake --preset wasm && cmake --build --preset wasm
 
-FROM ubuntu:kinetic
+FROM ubuntu:lunar
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y xz-utils curl
 RUN curl https://wasmtime.dev/install.sh -sSf | bash /dev/stdin --version v3.0.1
 COPY --from=builder /usr/src/circuits/cpp/barretenberg/cpp/srs_db /usr/src/circuits/cpp/barretenberg/cpp/srs_db

--- a/yarn-project/noir-contracts/Dockerfile.build
+++ b/yarn-project/noir-contracts/Dockerfile.build
@@ -1,7 +1,7 @@
 # Running on ubuntu until noir supports an alpine build
 
 # Builder stage to build the noir artifacts
-FROM ubuntu:kinetic
+FROM ubuntu:lunar
 
 RUN apt-get update && apt-get install -y \
     curl \


### PR DESCRIPTION
This PR fixes the builds of a number of packages by updating the version of ubuntu used in the base docker image.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
