### PR TITLE
feat: Validate nargo version against expected one

### DIFF
--- a/yarn-project/noir-compiler/src/cli/contract.ts
+++ b/yarn-project/noir-compiler/src/cli/contract.ts
@@ -39,7 +39,7 @@ export function compileContract(program: Command, name = 'contract', log: LogFn 
 
         const compile = compileUsingNargo;
         log(`Compiling contracts...`);
-        const result = await compile(projectPath);
+        const result = await compile(projectPath, { log });
 
         for (const contract of result) {
           const artifactPath = resolve(projectPath, outdir, `${contract.name}.json`);

--- a/yarn-project/noir-compiler/src/index.ts
+++ b/yarn-project/noir-compiler/src/index.ts
@@ -2,6 +2,10 @@ import { ContractAbi } from '@aztec/foundation/abi';
 
 import { CompileOpts, NargoContractCompiler } from './compile/nargo.js';
 import { generateAztecAbi } from './contract-interface-gen/abi.js';
+import NoirVersion from './noir-version.json' assert { type: 'json' };
+
+const { commit: NoirCommit, tag: NoirTag } = NoirVersion;
+export { NoirCommit, NoirTag };
 
 export { generateNoirContractInterface } from './contract-interface-gen/noir.js';
 export { generateTypescriptContractInterface } from './contract-interface-gen/typescript.js';

--- a/yarn-project/noir-compiler/src/noir-version.json
+++ b/yarn-project/noir-compiler/src/noir-version.json
@@ -1,0 +1,4 @@
+{
+  "tag": "aztec",
+  "commit": "39e1433a9c4184b72f3c5ab0368cfaa5d4ce537b"
+}

--- a/yarn-project/noir-compiler/tsconfig.json
+++ b/yarn-project/noir-compiler/tsconfig.json
@@ -10,5 +10,5 @@
       "path": "../foundation"
     }
   ],
-  "include": ["src"]
+  "include": ["src", "src/*.json"]
 }

--- a/yarn-project/noir-contracts/Dockerfile.build
+++ b/yarn-project/noir-contracts/Dockerfile.build
@@ -4,6 +4,7 @@
 FROM ubuntu:jammy
 
 RUN apt-get update && apt-get install -y \
+    jq \
     curl \
     git \
     sed

--- a/yarn-project/noir-contracts/scripts/compile.sh
+++ b/yarn-project/noir-contracts/scripts/compile.sh
@@ -41,7 +41,15 @@ build() {
   nargo compile --output-debug;
 }
 
+# Check nargo version matches the expected one
 echo "Using $(nargo --version)"
+EXPECTED_VERSION=$(jq -r '.commit' ../noir-compiler/src/noir-version.json)
+FOUND_VERSION=$(nargo --version | grep -oP 'git version hash: \K[0-9a-f]+')
+if [ "$EXPECTED_VERSION" != "$FOUND_VERSION" ]; then
+  echo "Expected nargo version $EXPECTED_VERSION but found version $FOUND_VERSION. Aborting."
+  exit 1
+fi
+
 
 # Build contracts
 for CONTRACT_NAME in "$@"; do

--- a/yarn-project/noir-contracts/scripts/install_noir.sh
+++ b/yarn-project/noir-contracts/scripts/install_noir.sh
@@ -2,7 +2,7 @@
 # Script to install noirup and the latest aztec nargo
 set -eu
 
-VERSION="aztec"
+VERSION="${VERSION:-$(jq -r '.tag' ../noir-compiler/src/noir-version.json)}"
 
 # Install nargo
 noirup -v $VERSION


### PR DESCRIPTION
Adds a `noir-version.json` file in the `noir-compiler` project, which pins what is the expected nargo tag and commit hash to be used for Aztec.

- When installing nargo in the CI, the `tag` is used as the argument for `noirup`.
- When using the noir compiler from the CLI or programmatically, a warning is emitted if the current nargo version does not match the expected one in the json file.
- When building contracts using `yarn noir:build`, an error is thrown if the version does not match.

The `noir-version.json` file is reached by the `noir-complier` rebuild patterns, which is a build-system dependency of `noir-contracts`, which means that all contracts in the repo should get recompiled when we bump to a new version of Noir. Fixes #2185.

---

This also allows us to **start versioning the aztec noir releases** rather than having a moving tag that potentially breaks master (and any open branches) when we update to a breaking release. To make the most of out this, I believe we should publish each aztec release as both `aztec` (so it's easy for end users to just install that version when they are starting) and a specific tag like `aztec-0.7.0` that we refer to in the `noir-version`.

Alternatively, we can drop the `aztec` tag altogether, and either 1) automatically update our docs to reflect the tag listed in `noir-verison.json` in the install instructions (requires a smarter `include_code` macro) or 2) have the aztec-cli run `noirup` on its own to install the version required.