### PR TITLE
fix: Fix fuzzing build

### DIFF
--- a/circuits/cpp/barretenberg/cpp/CMakePresets.json
+++ b/circuits/cpp/barretenberg/cpp/CMakePresets.json
@@ -82,7 +82,7 @@
       "name": "fuzzing",
       "displayName": "Build with fuzzing",
       "description": "Build default preset but with fuzzing enabled",
-      "inherits": "default",
+      "inherits": "clang16-dbg",
       "binaryDir": "build-fuzzing",
       "cacheVariables": {
         "FUZZING": "ON"
@@ -197,7 +197,7 @@
     },
     {
       "name": "fuzzing",
-      "inherits": "default",
+      "inherits": "clang16-dbg",
       "configurePreset": "fuzzing"
     },
     { 
@@ -270,7 +270,7 @@
     },
     {
       "name": "fuzzing",
-      "inherits": "default",
+      "inherits": "clang16-dbg",
       "configurePreset": "fuzzing"
     },
     {


### PR DESCRIPTION
Our build fails without clang16. This makes the fuzzing build use clang16

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [x] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
