### PR TITLE
feat(token portal standard): create token portal standard and corresponding cross chain test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -737,6 +737,17 @@ jobs:
           name: "Test"
           command: cond_run_script end-to-end ./scripts/run_tests_local e2e_token_contract.test.ts
 
+  e2e-token-bridge-contract:
+    machine:
+      image: ubuntu-2004:202010-01
+    resource_class: large
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Test"
+          command: cond_run_script end-to-end ./scripts/run_tests_local e2e_token_bridge_contract.test.ts
+
   e2e-private-token-contract:
     machine:
       image: ubuntu-2004:202010-01
@@ -1459,6 +1470,7 @@ workflows:
       - e2e-deploy-contract: *e2e_test
       - e2e-lending-contract: *e2e_test
       - e2e-token-contract: *e2e_test
+      - e2e-token-bridge-contract: *e2e_test
       - e2e-private-token-contract: *e2e_test
       - e2e-sandbox-example: *e2e_test
       - e2e-multi-transfer-contract: *e2e_test
@@ -1494,6 +1506,7 @@ workflows:
             - e2e-deploy-contract
             - e2e-lending-contract
             - e2e-token-contract
+            - e2e-token-bridge-contract
             - e2e-private-token-contract
             - e2e-sandbox-example
             - e2e-multi-transfer-contract

--- a/l1-contracts/test/portals/UniswapPortal.sol
+++ b/l1-contracts/test/portals/UniswapPortal.sol
@@ -47,8 +47,8 @@ contract UniswapPortal {
    * @param _amountOutMinimum - The minimum amount of output assets to receive from the swap (slippage protection)
    * @param _aztecRecipient - The aztec address to receive the output assets
    * @param _secretHash - The hash of the secret consumable message
-   * @param _deadlineForL1ToL2Message - deadline for when the L1 to L2 message (to mint outpiut assets in L2) must be consumed by
-   * @param _canceller - The ethereum address that can cancel the deposit
+   * @param _deadlineForL1ToL2Message - deadline for when the L1 to L2 message (to mint output assets in L2) must be consumed by
+   * @param _canceller - The ethereum address that can cancel the L1 to L2 deposit
    * @param _withCaller - When true, using `msg.sender` as the caller, otherwise address(0)
    * @return The entryKey of the deposit transaction in the Inbox
    */

--- a/yarn-project/end-to-end/src/cli_docs_sandbox.test.ts
+++ b/yarn-project/end-to-end/src/cli_docs_sandbox.test.ts
@@ -77,7 +77,7 @@ describe('CLI docs sandbox', () => {
     logs.splice(0);
   };
 
-  it('prints example contracts', async () => {
+  it.only('prints example contracts', async () => {
     const docs = `
 // docs:start:example-contracts
 % aztec-cli example-contracts
@@ -104,6 +104,7 @@ SchnorrAuthWitnessAccountContractAbi
 SchnorrHardcodedAccountContractAbi
 SchnorrSingleKeyAccountContractAbi
 TestContractAbi
+TokenBridgeContractAbi
 TokenContractAbi
 UniswapContractAbi
 // docs:end:example-contracts

--- a/yarn-project/end-to-end/src/e2e_token_bridge.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_bridge.test.ts
@@ -139,9 +139,7 @@ describe('e2e_token_bridge_contract', () => {
 
     // 3. Consume message on aztec and mint publicly
     logger('Consuming messages on L2');
-    const tx = bridge.methods
-      .mint_public({ address: ownerAddress }, bridgeAmount, messageKey, secret, { address: ethAccount.toField() })
-      .send();
+    const tx = bridge.methods.mint_public(bridgeAmount, messageKey, secret, { address: ethAccount.toField() }).send();
     const receipt = await tx.wait();
     expect(receipt.status).toBe(TxStatus.MINED);
     const afterBalance = await token.methods.balance_of_public({ address: ownerAddress }).view();
@@ -174,13 +172,7 @@ describe('e2e_token_bridge_contract', () => {
 
     // 5. Withdraw from L2 bridge
     const withdrawTx = bridge.methods
-      .withdraw_public(
-        { address: ownerAddress },
-        { address: ethAccount.toField() },
-        withdrawAmount,
-        { address: EthAddress.ZERO.toField() },
-        nonce,
-      )
+      .withdraw_public({ address: ethAccount.toField() }, withdrawAmount, { address: EthAddress.ZERO.toField() }, nonce)
       .send();
     const withdrawReceipt = await withdrawTx.wait();
     expect(withdrawReceipt.status).toBe(TxStatus.MINED);
@@ -213,9 +205,7 @@ describe('e2e_token_bridge_contract', () => {
 
     // 3. Consume message on aztec and mint publicly
     logger('Consuming messages on L2');
-    const tx = bridge.methods
-      .mint({ address: ownerAddress }, bridgeAmount, messageKey, secret, { address: ethAccount.toField() })
-      .send();
+    const tx = bridge.methods.mint(bridgeAmount, messageKey, secret, { address: ethAccount.toField() }).send();
     const receipt = await tx.wait();
     expect(receipt.status).toBe(TxStatus.MINED);
     const txClaim = token.methods.redeem_shield({ address: ownerAddress }, bridgeAmount, secret).send();
@@ -248,7 +238,6 @@ describe('e2e_token_bridge_contract', () => {
     const withdrawTx = bridge.methods
       .withdraw(
         { address: token.address },
-        { address: ownerAddress },
         { address: ethAccount.toField() },
         withdrawAmount,
         { address: EthAddress.ZERO.toField() },

--- a/yarn-project/end-to-end/src/e2e_token_bridge.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_bridge.test.ts
@@ -1,0 +1,266 @@
+import { AztecNodeService } from '@aztec/aztec-node';
+import { AztecRPCServer } from '@aztec/aztec-rpc';
+import { AuthWitnessEntrypointWallet, computeMessageSecretHash } from '@aztec/aztec.js';
+import {
+  AztecAddress,
+  CircuitsWasm,
+  CompleteAddress,
+  EthAddress,
+  Fr,
+  FunctionSelector,
+  GeneratorIndex,
+} from '@aztec/circuits.js';
+import { pedersenPlookupCompressWithHashIndex } from '@aztec/circuits.js/barretenberg';
+import { DeployL1Contracts } from '@aztec/ethereum';
+import { DebugLogger } from '@aztec/foundation/log';
+import { SchnorrAuthWitnessAccountContract, TokenBridgeContract, TokenContract } from '@aztec/noir-contracts/types';
+import { AztecRPC, TxStatus } from '@aztec/types';
+
+import {
+  createAuthWitnessAccounts,
+  delay,
+  deployAndInitializeStandardizedTokenAndBridgeContracts,
+  setup,
+} from './fixtures/utils.js';
+
+const hashPayload = async (payload: Fr[]) => {
+  return pedersenPlookupCompressWithHashIndex(
+    await CircuitsWasm.get(),
+    payload.map(fr => fr.toBuffer()),
+    GeneratorIndex.SIGNATURE_PAYLOAD,
+  );
+};
+
+describe('e2e_token_bridge_contract', () => {
+  let aztecNode: AztecNodeService | undefined;
+  let aztecRpcServer: AztecRPC;
+  let wallets: AuthWitnessEntrypointWallet[];
+  let accounts: CompleteAddress[];
+  let logger: DebugLogger;
+
+  let ethAccount: EthAddress;
+  let ownerAddress: AztecAddress;
+  let token: TokenContract;
+  let bridge: TokenBridgeContract;
+  let tokenPortalAddress: EthAddress;
+  let tokenPortal: any;
+  let underlyingERC20: any;
+
+  beforeAll(async () => {
+    let deployL1ContractsValues: DeployL1Contracts;
+
+    ({ aztecNode, aztecRpcServer, deployL1ContractsValues, logger } = await setup(0));
+    ({ accounts, wallets } = await createAuthWitnessAccounts(aztecRpcServer, 3));
+
+    const walletClient = deployL1ContractsValues.walletClient;
+    const publicClient = deployL1ContractsValues.publicClient;
+    ethAccount = EthAddress.fromString((await walletClient.getAddresses())[0]);
+    ownerAddress = accounts[0].address;
+
+    logger(`Deploying and initializing token, portal and its bridge...`);
+    const contracts = await deployAndInitializeStandardizedTokenAndBridgeContracts(
+      wallets[0],
+      walletClient,
+      publicClient,
+      deployL1ContractsValues!.registryAddress,
+      ownerAddress,
+    );
+    token = contracts.l2Token;
+    bridge = contracts.bridge;
+    tokenPortalAddress = contracts.tokenPortalAddress;
+    tokenPortal = contracts.tokenPortal;
+    underlyingERC20 = contracts.underlyingERC20;
+    logger(`Deployed and initialized token, portal and its bridge.`);
+  }, 60_000);
+
+  afterEach(async () => {
+    await aztecNode?.stop();
+    if (aztecRpcServer instanceof AztecRPCServer) {
+      await aztecRpcServer?.stop();
+    }
+  });
+
+  // TODO(#2291) - replace with new cross chain harness impl
+  const mintTokensOnL1 = async (amount: bigint) => {
+    logger('Minting tokens on L1');
+    await underlyingERC20.write.mint([ethAccount.toString(), amount], {} as any);
+    expect(await underlyingERC20.read.balanceOf([ethAccount.toString()])).toBe(amount);
+  };
+
+  // TODO(#2291) - replace with new cross chain harness impl
+  const depositTokensToPortal = async (bridgeAmount: bigint, secretHash: Fr) => {
+    await underlyingERC20.write.approve([tokenPortalAddress.toString(), bridgeAmount], {} as any);
+
+    // Deposit tokens to the TokenPortal
+    const deadline = 2 ** 32 - 1; // max uint32 - 1
+    logger('Sending messages to L1 portal to be consumed');
+    const args = [
+      ownerAddress.toString(),
+      bridgeAmount,
+      deadline,
+      secretHash.toString(true),
+      ethAccount.toString(),
+    ] as const;
+    const { result: messageKeyHex } = await tokenPortal.simulate.depositToAztec(args, {
+      account: ethAccount.toString(),
+    } as any);
+    await tokenPortal.write.depositToAztec(args, {} as any);
+
+    return Fr.fromString(messageKeyHex);
+  };
+
+  const mintPublicOnL2 = async (amount: bigint) => {
+    const tx = token.methods.mint_public({ address: ownerAddress }, amount).send();
+    const receipt = await tx.wait();
+    expect(receipt.status).toBe(TxStatus.MINED);
+  };
+
+  it('Deposit funds (publicly) from L1 -> L2 and withdraw (publicly) back to L1', async () => {
+    const l1TokenBalance = 1000000n;
+    const bridgeAmount = 100n;
+    const secret = Fr.random();
+    const secretHash = await computeMessageSecretHash(secret);
+
+    // 1. Mint tokens on L1
+    await mintTokensOnL1(l1TokenBalance);
+
+    // 2. Deposit tokens to the TokenPortal
+    const messageKey = await depositTokensToPortal(bridgeAmount, secretHash);
+    expect(await underlyingERC20.read.balanceOf([ethAccount.toString()])).toBe(l1TokenBalance - bridgeAmount);
+
+    // Wait for the archiver to process the message
+    await delay(5000); /// waiting 5 seconds.
+
+    // Perform an unrelated transaction on L2 to progress the rollup - here we mint tokens to owner
+    const amount = 99n;
+    await mintPublicOnL2(amount);
+    const balanceBefore = await token.methods.balance_of_public({ address: ownerAddress }).view();
+    expect(balanceBefore).toBe(amount);
+
+    // 3. Consume message on aztec and mint publicly
+    logger('Consuming messages on L2');
+    const tx = bridge.methods
+      .mint_public({ address: ownerAddress }, bridgeAmount, messageKey, secret, { address: ethAccount.toField() })
+      .send();
+    const receipt = await tx.wait();
+    expect(receipt.status).toBe(TxStatus.MINED);
+    const afterBalance = await token.methods.balance_of_public({ address: ownerAddress }).view();
+    expect(afterBalance).toBe(balanceBefore + bridgeAmount);
+
+    // time to withdraw the funds again!
+    logger('Withdrawing funds from L2');
+
+    // 4. Give approval to bridge to burn owner's funds:
+    const withdrawAmount = 9n;
+    const nonce = Fr.random();
+
+    const burnMessageHash = async (caller: AztecAddress, from: AztecAddress, amount: bigint, nonce: Fr) => {
+      return await hashPayload([
+        caller.toField(),
+        token.address.toField(),
+        FunctionSelector.fromSignature('burn_public((Field),Field,Field)').toField(),
+        from.toField(),
+        new Fr(amount),
+        nonce,
+      ]);
+    };
+
+    const messageHash = await burnMessageHash(bridge.address, ownerAddress, withdrawAmount, nonce);
+    // Add it to the wallet as approved
+    const owner = await SchnorrAuthWitnessAccountContract.at(ownerAddress, wallets[0]);
+    const setValidTx = owner.methods.set_is_valid_storage(messageHash, 1).send();
+    const validTxReceipt = await setValidTx.wait();
+    expect(validTxReceipt.status).toBe(TxStatus.MINED);
+
+    // 5. Withdraw from L2 bridge
+    const withdrawTx = bridge.methods
+      .withdraw_public(
+        { address: ownerAddress },
+        { address: ethAccount.toField() },
+        withdrawAmount,
+        { address: EthAddress.ZERO.toField() },
+        nonce,
+      )
+      .send();
+    const withdrawReceipt = await withdrawTx.wait();
+    expect(withdrawReceipt.status).toBe(TxStatus.MINED);
+    expect(await token.methods.balance_of_public({ address: ownerAddress }).view()).toBe(afterBalance - withdrawAmount);
+
+    // TODO (#2291): Consume message on L1 -> update crosschain test harness to do this cleanly.
+  }, 120_000);
+
+  it('Deposit funds (privately) from L1 -> L2 and withdraw (privately) back to L1', async () => {
+    const l1TokenBalance = 1000000n;
+    const bridgeAmount = 100n;
+    const secret = Fr.random();
+    const secretHash = await computeMessageSecretHash(secret);
+
+    // 1. Mint tokens on L1
+    await mintTokensOnL1(l1TokenBalance);
+
+    // 2. Deposit tokens to the TokenPortal
+    const messageKey = await depositTokensToPortal(bridgeAmount, secretHash);
+    expect(await underlyingERC20.read.balanceOf([ethAccount.toString()])).toBe(l1TokenBalance - bridgeAmount);
+
+    // Wait for the archiver to process the message
+    await delay(5000); /// waiting 5 seconds.
+
+    // Perform an unrelated transaction on L2 to progress the rollup - here we mint tokens to owner
+    const amount = 99n;
+    await mintPublicOnL2(amount);
+    const balanceBefore = await token.methods.balance_of_public({ address: ownerAddress }).view();
+    expect(balanceBefore).toBe(amount);
+
+    // 3. Consume message on aztec and mint publicly
+    logger('Consuming messages on L2');
+    const tx = bridge.methods
+      .mint({ address: ownerAddress }, bridgeAmount, messageKey, secret, { address: ethAccount.toField() })
+      .send();
+    const receipt = await tx.wait();
+    expect(receipt.status).toBe(TxStatus.MINED);
+    const txClaim = token.methods.redeem_shield({ address: ownerAddress }, bridgeAmount, secret).send();
+    const receiptClaim = await txClaim.wait();
+    expect(receiptClaim.status).toBe(TxStatus.MINED);
+
+    const afterPrivateBalance = await token.methods.balance_of_private({ address: ownerAddress }).view();
+    expect(afterPrivateBalance).toBe(bridgeAmount);
+
+    // time to withdraw the funds again!
+    logger('Withdrawing funds from L2');
+
+    // 4. Give approval to bridge to burn owner's funds:
+    const withdrawAmount = 9n;
+    const nonce = Fr.random();
+    const burnMessageHash = async (caller: AztecAddress, from: AztecAddress, amount: bigint, nonce: Fr) => {
+      return await hashPayload([
+        caller.toField(),
+        token.address.toField(),
+        FunctionSelector.fromSignature('burn((Field),Field,Field)').toField(),
+        from.toField(),
+        new Fr(amount),
+        nonce,
+      ]);
+    };
+    const messageHash = await burnMessageHash(bridge.address, ownerAddress, withdrawAmount, nonce);
+    await wallets[0].signAndGetAuthWitness(messageHash); // wallet[0] -> ownerAddress
+
+    // 5. Withdraw from L2 bridge
+    const withdrawTx = bridge.methods
+      .withdraw(
+        { address: token.address },
+        { address: ownerAddress },
+        { address: ethAccount.toField() },
+        withdrawAmount,
+        { address: EthAddress.ZERO.toField() },
+        nonce,
+      )
+      .send();
+    const withdrawReceipt = await withdrawTx.wait();
+    expect(withdrawReceipt.status).toBe(TxStatus.MINED);
+    expect(await token.methods.balance_of_private({ address: ownerAddress }).view()).toBe(
+      afterPrivateBalance - withdrawAmount,
+    );
+
+    // TODO (#2291): Consume message on L1 -> update crosschain test harness to do this cleanly.
+  }, 120_000);
+});

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -394,7 +394,7 @@ export async function deployAndInitializeStandardizedTokenAndBridgeContracts(
     throw new Error(`Bridge token is not ${l2Token.address}`);
 
   // make the bridge a minter on the token:
-  const makeMinterTx = l2Token.methods.set_minter({ address: bridge.address }, 1).send();
+  const makeMinterTx = l2Token.methods.set_minter({ address: bridge.address }, true).send();
   const makeMinterReceipt = await makeMinterTx.wait();
   if (makeMinterReceipt.status !== TxStatus.MINED)
     throw new Error(`Make bridge a minter tx status is ${makeMinterReceipt.status}`);

--- a/yarn-project/noir-contracts/Nargo.toml
+++ b/yarn-project/noir-contracts/Nargo.toml
@@ -24,5 +24,6 @@ members = [
     "src/contracts/schnorr_single_key_account_contract",
     "src/contracts/test_contract",
     "src/contracts/token_contract",
+    "src/contracts/token_bridge_contract",
     "src/contracts/uniswap_contract",
 ]

--- a/yarn-project/noir-contracts/src/contracts/token_bridge_contract/Nargo.toml
+++ b/yarn-project/noir-contracts/src/contracts/token_bridge_contract/Nargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "token_bridge_contract"
+authors = [""]
+compiler_version = "0.1"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../aztec-nr/aztec" }
+value_note = { path = "../../../../aztec-nr/value-note"}
+safe_math = { path = "../../../../aztec-nr/safe-math" }

--- a/yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/main.nr
@@ -47,7 +47,6 @@ contract TokenBridge {
     // Consumes a L1->L2 message and calls the token contract to mint the appropriate amount publicly
     #[aztec(public)]
     fn mint_public(
-        recipient: AztecAddress,
         amount: Field,
         msg_key: Field, // L1 to L2 message key as derived from the inbox contract
         secret: Field,
@@ -55,13 +54,13 @@ contract TokenBridge {
     ) -> Field {
         let storage = Storage::init(Context::public(&mut context));
 
-        let content_hash = get_mint_content_hash(amount, recipient.address, canceller.address);
+        let content_hash = get_mint_content_hash(amount, context.msg_sender(), canceller.address);
 
         // Consume message and emit nullifier
         context.consume_l1_to_l2_message(msg_key, content_hash, secret);
 
         // Mint token on L2
-        Token::at(storage.token.read()).mint_public(context, recipient.address, amount)
+        Token::at(storage.token.read()).mint_public(context, context.msg_sender(), amount)
     }
 
     // Consumes a L1->L2 message and calls the token contract to mint the appropriate amount in private assets
@@ -69,7 +68,6 @@ contract TokenBridge {
     // This method is public because it accesses public storage. For similar reasons, the corresponding call on the token is also public
     #[aztec(public)]
     fn mint(
-        recipient: AztecAddress,
         amount: Field,
         msg_key: Field, // L1 to L2 message key as derived from the inbox contract
         secret: Field,
@@ -77,7 +75,7 @@ contract TokenBridge {
     ) -> Field {
         let storage = Storage::init(Context::public(&mut context));
 
-        let content_hash = get_mint_content_hash(amount, recipient.address, canceller.address);
+        let content_hash = get_mint_content_hash(amount, context.msg_sender(), canceller.address);
 
         // Consume message and emit nullifier
         context.consume_l1_to_l2_message(msg_key, content_hash, secret);
@@ -91,7 +89,6 @@ contract TokenBridge {
     // Requires `from` to give approval to the bridge to burn tokens on their behalf using witness signatures 
     #[aztec(public)]
     fn withdraw_public(
-        from: AztecAddress, // aztec address to withdraw from
         recipient: EthereumAddress, // ethereum address to withdraw to
         amount: Field,
         callerOnL1: EthereumAddress, // ethereum address that can call this function on the L1 portal (0x0 if anyone can call)
@@ -100,7 +97,7 @@ contract TokenBridge {
         let storage = Storage::init(Context::public(&mut context));
 
         // Burn tokens on L2
-        let return_value = Token::at(storage.token.read()).burn_public(context, from.address, amount, nonce);
+        let return_value = Token::at(storage.token.read()).burn_public(context, context.msg_sender(), amount, nonce);
 
         let content = get_withdraw_content_hash(amount, recipient.address, callerOnL1.address);
 
@@ -115,7 +112,6 @@ contract TokenBridge {
     #[aztec(private)]
     fn withdraw(
         token:AztecAddress, // can't read public storage in private, so pass the token and call an internal public fn to check if provided token is as expected.
-        from: AztecAddress, // aztec address to withdraw from
         recipient: EthereumAddress, // ethereum address to withdraw to
         amount: Field,
         callerOnL1: EthereumAddress, // ethereum address that can call this function on the L1 portal (0x0 if anyone can call)
@@ -123,7 +119,7 @@ contract TokenBridge {
     ) -> Field {
         // can't read public storage (`storage.token`) in private so let the user pass it in
         // later assert that this token address is as expected
-        let return_value = Token::at(token.address).burn(&mut context, from.address, amount, nonce);
+        let return_value = Token::at(token.address).burn(&mut context, context.msg_sender(), amount, nonce);
 
         let content = get_withdraw_content_hash(amount, recipient.address, callerOnL1.address);
         // Emit the l2 to l1 message

--- a/yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/main.nr
@@ -46,7 +46,7 @@ contract TokenBridge {
 
     // Consumes a L1->L2 message and calls the token contract to mint the appropriate amount publicly
     #[aztec(public)]
-    fn mint_public(
+    fn deposit_public(
         amount: Field,
         msg_key: Field, // L1 to L2 message key as derived from the inbox contract
         secret: Field,
@@ -60,14 +60,17 @@ contract TokenBridge {
         context.consume_l1_to_l2_message(msg_key, content_hash, secret);
 
         // Mint token on L2
-        Token::at(storage.token.read()).mint_public(context, context.msg_sender(), amount)
+        // If I call using the interface, for some reason, the kernel queues mint_public twice and mints double the tokens.
+        // So, for now, call the token contract directly
+        // Token::at(storage.token.read()).mint_public(context, context.msg_sender(), amount)
+        context.call_public_function(storage.token.read(), compute_selector("mint_public((Field),Field)"), [context.msg_sender(), amount])[0]
     }
 
     // Consumes a L1->L2 message and calls the token contract to mint the appropriate amount in private assets
     // User needs to call token.redeem_shield() to get the private assets
     // This method is public because it accesses public storage. For similar reasons, the corresponding call on the token is also public
     #[aztec(public)]
-    fn mint(
+    fn deposit(
         amount: Field,
         msg_key: Field, // L1 to L2 message key as derived from the inbox contract
         secret: Field,
@@ -111,7 +114,7 @@ contract TokenBridge {
     // Requires `from` to give approval to the bridge to burn tokens on their behalf using witness signatures 
     #[aztec(private)]
     fn withdraw(
-        token:AztecAddress, // can't read public storage in private, so pass the token and call an internal public fn to check if provided token is as expected.
+        token: AztecAddress, // can't read public storage in private, so pass the token and call an internal public fn to check if provided token is as expected.
         recipient: EthereumAddress, // ethereum address to withdraw to
         amount: Field,
         callerOnL1: EthereumAddress, // ethereum address that can call this function on the L1 portal (0x0 if anyone can call)
@@ -119,8 +122,12 @@ contract TokenBridge {
     ) -> Field {
         // can't read public storage (`storage.token`) in private so let the user pass it in
         // later assert that this token address is as expected
-        let return_value = Token::at(token.address).burn(&mut context, context.msg_sender(), amount, nonce);
-
+        // let return_value = Token::at(token.address).burn(&mut context, context.msg_sender(), amount, nonce);
+        let return_value = context.call_private_function(
+			token.address, 
+			compute_selector("burn((Field),Field,Field)"), 
+			[context.msg_sender(), amount, nonce]
+		);
         let content = get_withdraw_content_hash(amount, recipient.address, callerOnL1.address);
         // Emit the l2 to l1 message
         context.message_portal(content);
@@ -128,7 +135,8 @@ contract TokenBridge {
         // Assert that user provided token address is same as seen in storage. 
         context.call_public_function(token.address, compute_selector("_assert_token_is_same(Field)"), [token.address]);
 
-        return_value
+        return_value[0]
+
     }
 
     // /// Unconstrained /// 

--- a/yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/main.nr
@@ -1,0 +1,162 @@
+mod types;
+mod util;
+mod token_interface;
+
+// Minimal implementation of the token bridge that can move funds between L1 <> L2.
+// The bridge has a corresponding Portal contract on L1 that it is attached to 
+// And corresponds to a Token on L2 that uses the `AuthWit` accounts pattern.
+// Bridge has to be set as a minter on the token before it can be sued
+contract TokenBridge {
+    // Libs
+    use dep::aztec::{
+        context::{Context},
+        state_vars::{public_state::PublicState},
+        types::type_serialisation::field_serialisation::{
+            FieldSerialisationMethods, FIELD_SERIALISED_LEN,
+        },
+        oracle::compute_selector::compute_selector,
+    };
+
+    use crate::types::{AztecAddress, EthereumAddress};
+    use crate::token_interface::Token;
+    use crate::util::{get_mint_content_hash, get_withdraw_content_hash, compute_secret_hash};
+
+    struct Storage {
+        token: PublicState<Field, FIELD_SERIALISED_LEN>,
+    }
+
+    impl Storage {
+        fn init(context: Context) -> pub Self {
+            Storage {
+                token: PublicState::new(
+                    context,
+                    1,
+                    FieldSerialisationMethods,
+                )
+            }
+        }
+    }
+
+    #[aztec(private)]
+    fn constructor() {
+        // Currently not possible to execute public calls from constructor as code not yet available to sequencer.
+        // let selector = compute_selector("_initialize((Field))");
+        // let _callStackItem = context.call_public_function(context.this_address(), selector, [token]);
+    }
+
+    // Consumes a L1->L2 message and calls the token contract to mint the appropriate amount publicly
+    #[aztec(public)]
+    fn mint_public(
+        recipient: AztecAddress,
+        amount: Field,
+        msg_key: Field, // L1 to L2 message key as derived from the inbox contract
+        secret: Field,
+        canceller: EthereumAddress,
+    ) -> Field {
+        let storage = Storage::init(Context::public(&mut context));
+
+        let content_hash = get_mint_content_hash(amount, recipient.address, canceller.address);
+
+        // Consume message and emit nullifier
+        context.consume_l1_to_l2_message(msg_key, content_hash, secret);
+
+        // Mint token on L2
+        Token::at(storage.token.read()).mint_public(context, recipient.address, amount)
+    }
+
+    // Consumes a L1->L2 message and calls the token contract to mint the appropriate amount in private assets
+    // User needs to call token.redeem_shield() to get the private assets
+    // This method is public because it accesses public storage. For similar reasons, the corresponding call on the token is also public
+    #[aztec(public)]
+    fn mint(
+        recipient: AztecAddress,
+        amount: Field,
+        msg_key: Field, // L1 to L2 message key as derived from the inbox contract
+        secret: Field,
+        canceller: EthereumAddress,
+    ) -> Field {
+        let storage = Storage::init(Context::public(&mut context));
+
+        let content_hash = get_mint_content_hash(amount, recipient.address, canceller.address);
+
+        // Consume message and emit nullifier
+        context.consume_l1_to_l2_message(msg_key, content_hash, secret);
+
+        // Mint token on L2
+        let secret_hash = compute_secret_hash(secret);
+        Token::at(storage.token.read()).mint_private(context, amount, secret_hash)
+    }
+
+    // Burns the appropriate amount of tokens and creates a L2 to L1 withdraw message publicly
+    // Requires `from` to give approval to the bridge to burn tokens on their behalf using witness signatures 
+    #[aztec(public)]
+    fn withdraw_public(
+        from: AztecAddress, // aztec address to withdraw from
+        recipient: EthereumAddress, // ethereum address to withdraw to
+        amount: Field,
+        callerOnL1: EthereumAddress, // ethereum address that can call this function on the L1 portal (0x0 if anyone can call)
+        nonce: Field, // used in creating the approval message (to prevent replay attacks)
+    ) -> Field {
+        let storage = Storage::init(Context::public(&mut context));
+
+        // Burn tokens on L2
+        let return_value = Token::at(storage.token.read()).burn_public(context, from.address, amount, nonce);
+
+        let content = get_withdraw_content_hash(amount, recipient.address, callerOnL1.address);
+
+        // Emit the l2 to l1 message
+        context.message_portal(content);
+
+        return_value
+    }
+
+    // Burns the appropriate amount of tokens and creates a L2 to L1 withdraw message privately
+    // Requires `from` to give approval to the bridge to burn tokens on their behalf using witness signatures 
+    #[aztec(private)]
+    fn withdraw(
+        token:AztecAddress, // can't read public storage in private, so pass the token and call an internal public fn to check if provided token is as expected.
+        from: AztecAddress, // aztec address to withdraw from
+        recipient: EthereumAddress, // ethereum address to withdraw to
+        amount: Field,
+        callerOnL1: EthereumAddress, // ethereum address that can call this function on the L1 portal (0x0 if anyone can call)
+        nonce: Field, // used in creating the approval message (to prevent replay attacks)
+    ) -> Field {
+        // can't read public storage (`storage.token`) in private so let the user pass it in
+        // later assert that this token address is as expected
+        let return_value = Token::at(token.address).burn(&mut context, from.address, amount, nonce);
+
+        let content = get_withdraw_content_hash(amount, recipient.address, callerOnL1.address);
+        // Emit the l2 to l1 message
+        context.message_portal(content);
+
+        // Assert that user provided token address is same as seen in storage. 
+        context.call_public_function(token.address, compute_selector("_assert_token_is_same(Field)"), [token.address]);
+
+        return_value
+    }
+
+    // /// Unconstrained /// 
+
+    unconstrained fn token() -> Field {
+        let storage = Storage::init(Context::none());
+        storage.token.read()
+    }
+
+    /// SHOULD BE Internal ///
+
+    // We cannot do this from the constructor currently 
+    // Since this should be internal, for now, we ignore the safety checks of it, as they are 
+    // enforced by it being internal and only called from the constructor.
+    #[aztec(public)]
+    fn _initialize(token: AztecAddress) {
+        let storage = Storage::init(Context::public(&mut context));
+        storage.token.write(token.address);
+    }
+
+    #[aztec(public)]
+    internal fn _assert_token_is_same(token: Field) {
+        let storage = Storage::init(Context::public(&mut context));
+        assert(storage.token.read() == token, "Token address is not the same as seen in storage");
+    }
+
+}

--- a/yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/token_interface.nr
+++ b/yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/token_interface.nr
@@ -1,0 +1,74 @@
+use dep::aztec::{
+	context::{ PrivateContext, PublicContext, Context },
+	oracle::compute_selector::compute_selector
+};
+
+struct Token {
+  address: Field,
+}
+
+impl Token {
+  	fn at(address: Field) -> Self {
+      	Self {
+			address,
+      	}
+  	}
+
+	fn mint_public(
+			self,
+			context: PublicContext,
+			to: Field,
+			amount: Field,
+	) -> Field {
+		let return_value = context.call_public_function(
+			self.address, 
+			compute_selector("mint_public((Field),Field)"), 
+			[to, amount]
+		);
+		return_value[0]
+	}
+
+	fn mint_private(
+		self,
+		context: PublicContext,
+		amount: Field,
+		secret_hash: Field,
+    ) -> Field {
+		let return_value = context.call_public_function(
+			self.address, 
+			compute_selector("mint_private(Field,Field)"), 
+			[amount, secret_hash]
+		);
+		return_value[0]
+	}
+
+	fn burn(
+		self,
+		context: &mut PrivateContext,
+		from: Field,
+		amount: Field,
+		nonce: Field,
+		) -> Field {
+		let return_value = context.call_private_function(
+			self.address, 
+			compute_selector("burn((Field),Field,Field)"), 
+			[from, amount, nonce]
+		);
+		return_value[0]
+	}
+
+	fn burn_public(
+		self,
+		context: PublicContext,
+		from: Field,
+		amount: Field,
+		nonce: Field,
+		) -> Field {
+		let return_value = context.call_public_function(
+			self.address, 
+			compute_selector("burn_public((Field),Field,Field)"), 
+			[from, amount, nonce]
+		);
+		return_value[0]
+	}
+}

--- a/yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/types.nr
+++ b/yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/types.nr
@@ -1,0 +1,43 @@
+struct AztecAddress {
+  address: Field
+}
+
+impl AztecAddress {
+  fn new(address: Field) -> Self {
+    Self {
+      address
+    }
+  }
+
+  fn serialize(self: Self) -> [Field; 1] {
+    [self.address]
+  }
+
+  fn deserialize(fields: [Field; 1]) -> Self {
+    Self {
+      address: fields[0]
+    }
+  }
+}
+
+struct EthereumAddress {
+  address: Field
+}
+
+impl EthereumAddress {
+  fn new(address: Field) -> Self {
+    Self {
+      address
+    }
+  }
+
+  fn serialize(self: Self) -> [Field; 1] {
+    [self.address]
+  }
+
+  fn deserialize(fields: [Field; 1]) -> Self {
+    Self {
+      address: fields[0]
+    }
+  }
+}

--- a/yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/util.nr
+++ b/yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/util.nr
@@ -1,0 +1,87 @@
+use dep::std::hash::{pedersen_with_separator, sha256};
+use dep::aztec::constants_gen::{
+    GENERATOR_INDEX__SIGNATURE_PAYLOAD,
+    GENERATOR_INDEX__L1_TO_L2_MESSAGE_SECRET,
+};
+
+fn compute_secret_hash(secret: Field) -> Field {
+    // TODO(#1205) This is probably not the right index to use
+    pedersen_with_separator([secret], GENERATOR_INDEX__L1_TO_L2_MESSAGE_SECRET)[0]
+}
+
+// Computes a content hash of a deposit/mint message.
+fn get_mint_content_hash(amount: Field, owner_address: Field, canceller: Field) -> Field {
+    let mut hash_bytes: [u8; 100] = [0; 100];
+    let amount_bytes = amount.to_be_bytes(32);
+    let recipient_bytes = owner_address.to_be_bytes(32);
+    let canceller_bytes = canceller.to_be_bytes(32);
+
+    for i in 0..32 {
+        hash_bytes[i + 4] = amount_bytes[i];
+        hash_bytes[i + 36] = recipient_bytes[i];
+        hash_bytes[i + 68] = canceller_bytes[i];
+    }
+    
+    // Function selector: 0xeeb73071 keccak256('mint(uint256,bytes32,address)')
+    hash_bytes[0] = 0xee;
+    hash_bytes[1] = 0xb7;
+    hash_bytes[2] = 0x30;
+    hash_bytes[3] = 0x71;
+    
+    let content_sha256 = sha256(hash_bytes);
+
+    // // Convert the content_sha256 to a field element
+    let mut v = 1;
+    let mut high = 0 as Field;
+    let mut low = 0 as Field;
+
+    for i in 0..16 {
+        high = high + (content_sha256[15 - i] as Field) * v;
+        low = low + (content_sha256[16 + 15 - i] as Field) * v;
+        v = v * 256;
+    }
+
+    // Abuse that a % p + b % p = (a + b) % p and that low < p
+    let content_hash = low + high * v;
+    content_hash
+}
+
+// Computes a content hash of a withdraw message.
+fn get_withdraw_content_hash(amount: Field, recipient: Field, callerOnL1: Field) -> Field {
+    // Compute the content hash
+    // Compute sha256(selector || amount || recipient)
+    // then convert to a single field element
+    // add that to the l2 to l1 messages
+    let mut hash_bytes: [u8; 100] = [0; 100];
+    let amount_bytes = amount.to_be_bytes(32);
+    let recipient_bytes = recipient.to_be_bytes(32);
+    let callerOnL1_bytes = callerOnL1.to_be_bytes(32);
+    
+    //  0xb460af94, selector for "withdraw(uint256,address,address)"
+    hash_bytes[0] = 0xb4;
+    hash_bytes[1] = 0x60;
+    hash_bytes[2] = 0xaf;
+    hash_bytes[3] = 0x94;
+
+    for i in 0..32 {
+        hash_bytes[i + 4] = amount_bytes[i];
+        hash_bytes[i + 36] = recipient_bytes[i];
+        hash_bytes[i + 68] = callerOnL1_bytes[i];
+    }
+    let content_sha256 = sha256(hash_bytes);
+
+    // Convert the content_sha256 to a field element
+    let mut v = 1;
+    let mut high = 0 as Field;
+    let mut low = 0 as Field;
+    
+    for i in 0..16 {
+        high = high + (content_sha256[15 - i] as Field) * v;
+        low = low + (content_sha256[16 + 15 - i] as Field) * v;
+        v = v * 256;
+    }
+
+    // Abuse that a % p + b % p = (a + b) % p and that low < p
+    let content = low + high * v;
+    content
+}


### PR DESCRIPTION
Part of #2167. In Future PRs, I aim to 
* replace NonNativeToken and also replace `crosschainharness.ts`, delete existing cross chain e2e (#2291), 
* update uniswap portal
* update the AC style aggregation that Lasse had a draft PR for