### PR TITLE
chore(subrepo): push aztec-nr, update default branches 

### DIFF
--- a/.github/workflows/mirror_repos.yml
+++ b/.github/workflows/mirror_repos.yml
@@ -50,7 +50,7 @@ jobs:
           git config --global user.name AztecBot
           git config --global user.email tech@aztecprotocol.com
 
-          if ./scripts/git_subrepo.sh push $SUBREPO_PATH --branch=main; then
+          if ./scripts/git_subrepo.sh push $SUBREPO_PATH --branch=master; then
             git fetch # in case a commit came after this
             git rebase origin/master
             git commit --amend -m "$(git log -1 --pretty=%B) [skip ci]"
@@ -71,7 +71,7 @@ jobs:
           git config --global user.name AztecBot
           git config --global user.email tech@aztecprotocol.com
 
-          if ./scripts/git_subrepo.sh push $SUBREPO_PATH --branch=main; then
+          if ./scripts/git_subrepo.sh push $SUBREPO_PATH --branch=master; then
             git fetch # in case a commit came after this
             git rebase origin/master
             git commit --amend -m "$(git log -1 --pretty=%B) [skip ci]"
@@ -92,7 +92,7 @@ jobs:
           git config --global user.name AztecBot
           git config --global user.email tech@aztecprotocol.com
 
-          if ./scripts/git_subrepo.sh push $SUBREPO_PATH --branch=main; then
+          if ./scripts/git_subrepo.sh push $SUBREPO_PATH --branch=master; then
             git fetch # in case a commit came after this
             git rebase origin/master
             git commit --amend -m "$(git log -1 --pretty=%B) [skip ci]"

--- a/yarn-project/aztec-nr/.gitrepo
+++ b/yarn-project/aztec-nr/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:AztecProtocol/aztec-nr.git
 	branch = master
-	commit = f662901567fa19e205062d84180763f06cddd641
+	commit = 05f63d4c14d73e6112d6aafdacb6e4ece209caad
 	method = merge
 	cmdver = 0.4.6
-	parent = a91db48d1943fdc2e39535a153216b7aaca40de4
+	parent = 748ddaa845fe6485648f7697df5d2e06108f2577

--- a/yarn-project/aztec-nr/.gitrepo
+++ b/yarn-project/aztec-nr/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:AztecProtocol/aztec-nr.git
 	branch = master
-	commit = 05f63d4c14d73e6112d6aafdacb6e4ece209caad
+	commit = d6bea82a92949b51e70ca5e9061252f9ccfe0c7e
 	method = merge
 	cmdver = 0.4.6
-	parent = 748ddaa845fe6485648f7697df5d2e06108f2577
+	parent = 62376ba4513fffdd96fd0b85c2b5884ec8bb224f

--- a/yarn-project/aztec-nr/.gitrepo
+++ b/yarn-project/aztec-nr/.gitrepo
@@ -9,4 +9,4 @@
 	commit = f662901567fa19e205062d84180763f06cddd641
 	method = merge
 	cmdver = 0.4.6
-	parent = 8df8fa7351ca79c022e2eb7dddfd7cf0145876df
+	parent = a91db48d1943fdc2e39535a153216b7aaca40de4

--- a/yarn-project/aztec-nr/README.md
+++ b/yarn-project/aztec-nr/README.md
@@ -4,7 +4,7 @@
   <h1>Aztec.nr</h1>
 
   <p>
-    <strong>Aztec Smart Contract Development Framework</strong>
+    <strong>Aztec Smart Contract Framework</strong>
   </p>
 
   <p>
@@ -18,7 +18,7 @@
 
 # Aztec.nr
 
-`Aztec-nr` is a [Noir](https://noir-lang.org) framework for contract development on [Aztec](aztec.network).
+`Aztec-nr` is a [Noir](https://noir-lang.org) framework for smart contracts on [Aztec](aztec.network).
 
 ### Directory Structure
 ```


### PR DESCRIPTION
Wrong target branch on some repos, pushed bb to main not master (i copied the flow for docs which did use main).

Manually pushed aztec-nr, it failed last night as the bot did not have write perms

