### PR TITLE
fix: Use bool for set_minter

### DIFF
--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -87,9 +87,9 @@ describe('e2e_lending_contract', () => {
     }
 
     await waitForSuccess(collateralAsset.methods._initialize(accounts[0]).send());
-    await waitForSuccess(collateralAsset.methods.set_minter({ address: lendingContract.address }, 1).send());
+    await waitForSuccess(collateralAsset.methods.set_minter({ address: lendingContract.address }, true).send());
     await waitForSuccess(stableCoin.methods._initialize(accounts[0]).send());
-    await waitForSuccess(stableCoin.methods.set_minter({ address: lendingContract.address }, 1).send());
+    await waitForSuccess(stableCoin.methods.set_minter({ address: lendingContract.address }, true).send());
 
     return { priceFeedContract, lendingContract, collateralAsset, stableCoin };
   };

--- a/yarn-project/end-to-end/src/e2e_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract.test.ts
@@ -127,14 +127,14 @@ describe('e2e_token_contract', () => {
     });
 
     it('Add minter as admin', async () => {
-      const tx = asset.withWallet(wallets[1]).methods.set_minter({ address: accounts[1].address }, 1).send();
+      const tx = asset.withWallet(wallets[1]).methods.set_minter({ address: accounts[1].address }, true).send();
       const receipt = await tx.wait();
       expect(receipt.status).toBe(TxStatus.MINED);
       expect(await asset.methods.is_minter({ address: accounts[1].address }).view()).toBe(true);
     });
 
     it('Revoke minter as admin', async () => {
-      const tx = asset.withWallet(wallets[1]).methods.set_minter({ address: accounts[1].address }, 0).send();
+      const tx = asset.withWallet(wallets[1]).methods.set_minter({ address: accounts[1].address }, false).send();
       const receipt = await tx.wait();
       expect(receipt.status).toBe(TxStatus.MINED);
       expect(await asset.methods.is_minter({ address: accounts[1].address }).view()).toBe(false);
@@ -147,7 +147,7 @@ describe('e2e_token_contract', () => {
         );
       });
       it('Revoke minter not as admin', async () => {
-        await expect(asset.methods.set_minter({ address: accounts[0].address }, 0).simulate()).rejects.toThrowError(
+        await expect(asset.methods.set_minter({ address: accounts[0].address }, false).simulate()).rejects.toThrowError(
           'Assertion failed: caller is not admin',
         );
       });

--- a/yarn-project/noir-contracts/src/contracts/token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/token_contract/src/main.nr
@@ -113,9 +113,8 @@ contract Token {
     #[aztec(public)]
     fn set_minter(
         minter: AztecAddress,
-        approve: Field,
+        approve: bool,
     ) {
-        assert((approve == 1) | (approve == 0), "not providing boolean");
         let storage = Storage::init(Context::public(&mut context));
         assert(storage.admin.read() == context.msg_sender(), "caller is not admin");
         storage.minters.at(minter.address).write(approve as Field);


### PR DESCRIPTION
With the newest version of aztec.nr bools in function params are allowed, so this pr updates the `set_minter` function in the token to use this instead of a field that is constrained to be 0 or 1. 

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
