### PR TITLE
fix: aztec-nr mirror url

### DIFF
--- a/yarn-project/aztec-nr/.gitrepo
+++ b/yarn-project/aztec-nr/.gitrepo
@@ -4,7 +4,7 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = git@github.com:AztecProtocol/aztec-nr.git
+	remote = https://github.com/AztecProtocol/aztec-nr
 	branch = master
 	commit = d6bea82a92949b51e70ca5e9061252f9ccfe0c7e
 	method = merge


### PR DESCRIPTION
Looks like we can only mirror with the https version in current setup