### PR TITLE
chore: Do not format boxes with global format

### DIFF
--- a/yarn-project/.prettierignore
+++ b/yarn-project/.prettierignore
@@ -2,4 +2,5 @@
 node_modules/
 dest/
 noir-contracts/**/*.json
+boxes/
 *.md


### PR DESCRIPTION
`boxes` is using a custom prettier config since it includes frontend code, so when running `yarn format` at the root of the yarn-project, a different formatting is applied. This PR omits boxes from the global yarn format to avoid inconsistencies.