### PR TITLE
chore: Rename getAccounts to getRegisteredAccounts

### DIFF
--- a/docs/docs/dev_docs/contracts/deploying.md
+++ b/docs/docs/dev_docs/contracts/deploying.md
@@ -116,7 +116,7 @@ await aztecRpc.registerRecipient(completeAddress);
 </TabItem>
 </Tabs>
 
-When you create a new account, it gets automatically registered. It can be verified by calling `aztec-cli get-accounts` OR in aztec.js by using `await aztecRpc.getAccounts()`
+When you create a new account, it gets automatically registered. It can be verified by calling `aztec-cli get-accounts` OR in aztec.js by using `await aztecRpc.getRegisteredAccounts()`
 
 > **NOTE 1**: If we didn't register owner as a recipient we could not encrypt a note for the owner and the contract deployment would fail because constructor execution would fail (we need owner's public key to encrypt a note).
 

--- a/docs/docs/dev_docs/getting_started/sandbox.md
+++ b/docs/docs/dev_docs/getting_started/sandbox.md
@@ -218,7 +218,7 @@ That might seem like a lot to digest but it can be broken down into the followin
 2. We wait for the deployment of the 2 account contracts to complete.
 3. We retrieve the expected account addresses from the `Account` objects and ensure that they are present in the set of account addresses registered on the Sandbox.
 
-Note, we use the `getAccounts` api to verify that the addresses computed as part of the
+Note, we use the `getRegisteredAccounts` api to verify that the addresses computed as part of the
 account contract deployment have been successfully added to the Sandbox.
 
 If you were looking at your terminal that is running the Sandbox you should hopefully have seen a lot of activity. This is because the Sandbox will have simulated the deployment of both contracts, executed the private kernel circuit for each before submitted 2 transactions to the pool. The sequencer will have picked them up and inserted them into a rollup and executed the recursive rollup circuits before publishing the rollup to Anvil. Once this has completed, the rollup is retrieved and pulled down to the internal RPC Server so that any new account state can be decrypted.

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/aztec_rpc_server.ts
@@ -117,7 +117,7 @@ export class AztecRPCServer implements AztecRPC {
     }
   }
 
-  public async getAccounts(): Promise<CompleteAddress[]> {
+  public async getRegisteredAccounts(): Promise<CompleteAddress[]> {
     // Get complete addresses of both the recipients and the accounts
     const addresses = await this.db.getCompleteAddresses();
     // Filter out the addresses not corresponding to accounts
@@ -126,8 +126,8 @@ export class AztecRPCServer implements AztecRPC {
     return accounts;
   }
 
-  public async getAccount(address: AztecAddress): Promise<CompleteAddress | undefined> {
-    const result = await this.getAccounts();
+  public async getRegisteredAccount(address: AztecAddress): Promise<CompleteAddress | undefined> {
+    const result = await this.getRegisteredAccounts();
     const account = result.find(r => r.address.equals(address));
     return Promise.resolve(account);
   }

--- a/yarn-project/aztec-rpc/src/aztec_rpc_server/test/aztec_rpc_test_suite.ts
+++ b/yarn-project/aztec-rpc/src/aztec_rpc_server/test/aztec_rpc_test_suite.ts
@@ -27,13 +27,13 @@ export const aztecRpcTestSuite = (testName: string, aztecRpcSetup: () => Promise
       await rpc.registerAccount(await keyPair.getPrivateKey(), completeAddress.partialAddress);
 
       // Check that the account is correctly registered using the getAccounts and getRecipients methods
-      const accounts = await rpc.getAccounts();
+      const accounts = await rpc.getRegisteredAccounts();
       const recipients = await rpc.getRecipients();
       expect(accounts).toContainEqual(completeAddress);
       expect(recipients).not.toContainEqual(completeAddress);
 
       // Check that the account is correctly registered using the getAccount and getRecipient methods
-      const account = await rpc.getAccount(completeAddress.address);
+      const account = await rpc.getRegisteredAccount(completeAddress.address);
       const recipient = await rpc.getRecipient(completeAddress.address);
       expect(account).toEqual(completeAddress);
       expect(recipient).toBeUndefined();
@@ -45,13 +45,13 @@ export const aztecRpcTestSuite = (testName: string, aztecRpcSetup: () => Promise
       await rpc.registerRecipient(completeAddress);
 
       // Check that the recipient is correctly registered using the getAccounts and getRecipients methods
-      const accounts = await rpc.getAccounts();
+      const accounts = await rpc.getRegisteredAccounts();
       const recipients = await rpc.getRecipients();
       expect(accounts).not.toContainEqual(completeAddress);
       expect(recipients).toContainEqual(completeAddress);
 
       // Check that the recipient is correctly registered using the getAccount and getRecipient methods
-      const account = await rpc.getAccount(completeAddress.address);
+      const account = await rpc.getRegisteredAccount(completeAddress.address);
       const recipient = await rpc.getRecipient(completeAddress.address);
       expect(account).toBeUndefined();
       expect(recipient).toEqual(completeAddress);

--- a/yarn-project/aztec-sandbox/src/bin/index.ts
+++ b/yarn-project/aztec-sandbox/src/bin/index.ts
@@ -44,7 +44,7 @@ async function main() {
   logger.info(`Debug logs will be written to ${logPath}`);
   const accountStrings = [`Initial Accounts:\n\n`];
 
-  const registeredAccounts = await rpcServer.getAccounts();
+  const registeredAccounts = await rpcServer.getRegisteredAccounts();
   for (const account of accounts) {
     const completeAddress = await account.account.getCompleteAddress();
     if (registeredAccounts.find(a => a.equals(completeAddress))) {

--- a/yarn-project/aztec.js/src/account/index.ts
+++ b/yarn-project/aztec.js/src/account/index.ts
@@ -92,7 +92,7 @@ export async function getWallet(
   address: AztecAddress,
   accountContract: AccountContract,
 ): Promise<AccountWallet> {
-  const completeAddress = await rpc.getAccount(address);
+  const completeAddress = await rpc.getRegisteredAccount(address);
   if (!completeAddress) {
     throw new Error(`Account ${address} not found`);
   }

--- a/yarn-project/aztec.js/src/contract/contract.test.ts
+++ b/yarn-project/aztec.js/src/contract/contract.test.ts
@@ -102,7 +102,7 @@ describe('Contract Class', () => {
     wallet.getTxReceipt.mockResolvedValue(mockTxReceipt);
     wallet.getNodeInfo.mockResolvedValue(mockNodeInfo);
     wallet.simulateTx.mockResolvedValue(mockTx);
-    wallet.getAccounts.mockResolvedValue([account]);
+    wallet.getRegisteredAccounts.mockResolvedValue([account]);
   });
 
   it('should create and send a contract method tx', async () => {

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -37,11 +37,11 @@ export abstract class BaseWallet implements Wallet {
   registerRecipient(account: CompleteAddress): Promise<void> {
     return this.rpc.registerRecipient(account);
   }
-  getAccounts(): Promise<CompleteAddress[]> {
-    return this.rpc.getAccounts();
+  getRegisteredAccounts(): Promise<CompleteAddress[]> {
+    return this.rpc.getRegisteredAccounts();
   }
-  getAccount(address: AztecAddress): Promise<CompleteAddress | undefined> {
-    return this.rpc.getAccount(address);
+  getRegisteredAccount(address: AztecAddress): Promise<CompleteAddress | undefined> {
+    return this.rpc.getRegisteredAccount(address);
   }
   getRecipients(): Promise<CompleteAddress[]> {
     return this.rpc.getRecipients();

--- a/yarn-project/boxes/private-token/src/app/components/wallet_dropdown.tsx
+++ b/yarn-project/boxes/private-token/src/app/components/wallet_dropdown.tsx
@@ -16,7 +16,7 @@ export function WalletDropdown({ selected, onSelectChange, onError }: Props) {
       return;
     }
     const loadOptions = async () => {
-      const fetchedOptions = await rpcClient.getAccounts();
+      const fetchedOptions = await rpcClient.getRegisteredAccounts();
       setOptions(fetchedOptions);
       onSelectChange(fetchedOptions[0]);
     };

--- a/yarn-project/boxes/private-token/src/tests/privatetoken.frontend.test.ts
+++ b/yarn-project/boxes/private-token/src/tests/privatetoken.frontend.test.ts
@@ -109,7 +109,7 @@ describe('ZK Contract Tests', () => {
 
   beforeAll(async () => {
     rpcClient = await setupSandbox();
-    const accounts = await rpcClient.getAccounts();
+    const accounts = await rpcClient.getRegisteredAccounts();
     [owner, account2, _account3] = accounts;
 
     wallet = await getWallet(owner, rpcClient);

--- a/yarn-project/canary/src/aztec_js_browser.test.ts
+++ b/yarn-project/canary/src/aztec_js_browser.test.ts
@@ -120,7 +120,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
       SANDBOX_URL,
       privKey.toString(),
     );
-    const accounts = await testClient.getAccounts();
+    const accounts = await testClient.getRegisteredAccounts();
     const stringAccounts = accounts.map(acc => acc.address.toString());
     expect(stringAccounts.includes(result)).toBeTruthy();
   }, 15_000);
@@ -134,7 +134,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
       async (rpcUrl, contractAddress, PrivateTokenContractAbi) => {
         const { Contract, AztecAddress, createAztecRpcClient, makeFetch } = window.AztecJs;
         const client = createAztecRpcClient(rpcUrl!, makeFetch([1, 2, 3], true));
-        const owner = (await client.getAccounts())[0].address;
+        const owner = (await client.getRegisteredAccounts())[0].address;
         const [wallet] = await AztecJs.getSandboxAccountsWallets(client);
         const contract = await Contract.at(AztecAddress.fromString(contractAddress), PrivateTokenContractAbi, wallet);
         const balance = await contract.methods.getBalance(owner).view({ from: owner });
@@ -155,7 +155,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
         console.log(`Starting transfer tx`);
         const { AztecAddress, Contract, createAztecRpcClient, makeFetch } = window.AztecJs;
         const client = createAztecRpcClient(rpcUrl!, makeFetch([1, 2, 3], true));
-        const accounts = await client.getAccounts();
+        const accounts = await client.getRegisteredAccounts();
         const owner = accounts[0].address;
         const receiver = accounts[1].address;
         const [wallet] = await AztecJs.getSandboxAccountsWallets(client);
@@ -182,12 +182,12 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
         const { GrumpkinScalar, DeployMethod, createAztecRpcClient, makeFetch, getUnsafeSchnorrAccount } =
           window.AztecJs;
         const client = createAztecRpcClient(rpcUrl!, makeFetch([1, 2, 3], true));
-        let accounts = await client.getAccounts();
+        let accounts = await client.getRegisteredAccounts();
         if (accounts.length === 0) {
           // This test needs an account for deployment. We create one in case there is none available in the RPC server.
           const privateKey = GrumpkinScalar.fromString(privateKeyString);
           await getUnsafeSchnorrAccount(client, privateKey).waitDeploy();
-          accounts = await client.getAccounts();
+          accounts = await client.getRegisteredAccounts();
         }
         const owner = accounts[0];
         const tx = new DeployMethod(owner.publicKey, client, PrivateTokenContractAbi, [

--- a/yarn-project/canary/src/cli.test.ts
+++ b/yarn-project/canary/src/cli.test.ts
@@ -84,14 +84,14 @@ describe('CLI canary', () => {
   };
 
   it('creates & retrieves an account', async () => {
-    existingAccounts = await aztecRpcClient.getAccounts();
+    existingAccounts = await aztecRpcClient.getRegisteredAccounts();
     debug('Create an account');
     await run(`create-account`);
     const foundAddress = findInLogs(/Address:\s+(?<address>0x[a-fA-F0-9]+)/)?.groups?.address;
     expect(foundAddress).toBeDefined();
     const newAddress = AztecAddress.fromString(foundAddress!);
 
-    const accountsAfter = await aztecRpcClient.getAccounts();
+    const accountsAfter = await aztecRpcClient.getRegisteredAccounts();
     const expectedAccounts = [...existingAccounts.map(a => a.address), newAddress];
     expect(accountsAfter.map(a => a.address)).toEqual(expectedAccounts);
     const newCompleteAddress = accountsAfter[accountsAfter.length - 1];
@@ -150,7 +150,7 @@ describe('CLI canary', () => {
     expect(balance!).toEqual(`${BigInt(INITIAL_BALANCE).toString()}n`);
 
     debug('Transfer some tokens');
-    const existingAccounts = await aztecRpcClient.getAccounts();
+    const existingAccounts = await aztecRpcClient.getRegisteredAccounts();
     // ensure we pick a different acc
     const receiver = existingAccounts.find(acc => acc.address.toString() !== ownerAddress.toString());
 

--- a/yarn-project/canary/src/uniswap_trade_on_l1_from_l2.test.ts
+++ b/yarn-project/canary/src/uniswap_trade_on_l1_from_l2.test.ts
@@ -185,7 +185,7 @@ describe('uniswap_trade_on_l1_from_l2', () => {
     logger('Running L1/L2 messaging test on HTTP interface.');
 
     [wallet] = await getSandboxAccountsWallets(aztecRpcClient);
-    const accounts = await wallet.getAccounts();
+    const accounts = await wallet.getRegisteredAccounts();
     const owner = accounts[0].address;
     const receiver = accounts[1].address;
 

--- a/yarn-project/cli/src/index.ts
+++ b/yarn-project/cli/src/index.ts
@@ -292,7 +292,7 @@ export function getProgram(log: LogFn, debugLogger: DebugLogger): Command {
     .option('-u, --rpc-url <string>', 'URL of the Aztec RPC', AZTEC_RPC_HOST || 'http://localhost:8080')
     .action(async (options: any) => {
       const client = await createCompatibleClient(options.rpcUrl, debugLogger);
-      const accounts = await client.getAccounts();
+      const accounts = await client.getRegisteredAccounts();
       if (!accounts.length) {
         log('No accounts found.');
       } else {
@@ -311,7 +311,7 @@ export function getProgram(log: LogFn, debugLogger: DebugLogger): Command {
     .action(async (_address, options) => {
       const client = await createCompatibleClient(options.rpcUrl, debugLogger);
       const address = AztecAddress.fromString(_address);
-      const account = await client.getAccount(address);
+      const account = await client.getRegisteredAccount(address);
 
       if (!account) {
         log(`Unknown account ${_address}`);

--- a/yarn-project/cli/src/test/utils.test.ts
+++ b/yarn-project/cli/src/test/utils.test.ts
@@ -28,14 +28,14 @@ describe('CLI Utils', () => {
     // returns a parsed Aztec Address
     const aztecAddress = AztecAddress.random();
     const result = await getTxSender(client, aztecAddress.toString());
-    expect(client.getAccounts).toHaveBeenCalledTimes(0);
+    expect(client.getRegisteredAccounts).toHaveBeenCalledTimes(0);
     expect(result).toEqual(aztecAddress);
 
     // returns an address found in the aztec client
     const completeAddress = await CompleteAddress.random();
-    client.getAccounts.mockResolvedValueOnce([completeAddress]);
+    client.getRegisteredAccounts.mockResolvedValueOnce([completeAddress]);
     const resultWithoutString = await getTxSender(client);
-    expect(client.getAccounts).toHaveBeenCalled();
+    expect(client.getRegisteredAccounts).toHaveBeenCalled();
     expect(resultWithoutString).toEqual(completeAddress.address);
 
     // throws when invalid parameter passed
@@ -47,7 +47,7 @@ describe('CLI Utils', () => {
     ).rejects.toThrow(`Invalid option 'from' passed: ${errorAddr}`);
 
     // Throws error when no string is passed & no accounts found in RPC
-    client.getAccounts.mockResolvedValueOnce([]);
+    client.getRegisteredAccounts.mockResolvedValueOnce([]);
     await expect(
       (async () => {
         await getTxSender(client);

--- a/yarn-project/cli/src/utils.ts
+++ b/yarn-project/cli/src/utils.ts
@@ -104,7 +104,7 @@ export async function getTxSender(client: AztecRPC, _from?: string) {
       throw new Error(`Invalid option 'from' passed: ${_from}`);
     }
   } else {
-    const accounts = await client.getAccounts();
+    const accounts = await client.getRegisteredAccounts();
     if (!accounts.length) {
       throw new Error('No accounts found in Aztec RPC instance.');
     }

--- a/yarn-project/end-to-end/src/e2e_aztec_js_browser.test.ts
+++ b/yarn-project/end-to-end/src/e2e_aztec_js_browser.test.ts
@@ -123,7 +123,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
       SANDBOX_URL,
       privKey.toString(),
     );
-    const accounts = await testClient.getAccounts();
+    const accounts = await testClient.getRegisteredAccounts();
     const stringAccounts = accounts.map(acc => acc.address.toString());
     expect(stringAccounts.includes(result)).toBeTruthy();
   }, 15_000);
@@ -137,7 +137,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
       async (rpcUrl, contractAddress, PrivateTokenContractAbi) => {
         const { Contract, AztecAddress, createAztecRpcClient, makeFetch } = window.AztecJs;
         const client = createAztecRpcClient(rpcUrl!, makeFetch([1, 2, 3], true));
-        const owner = (await client.getAccounts())[0].address;
+        const owner = (await client.getRegisteredAccounts())[0].address;
         const [wallet] = await AztecJs.getSandboxAccountsWallets(client);
         const contract = await Contract.at(AztecAddress.fromString(contractAddress), PrivateTokenContractAbi, wallet);
         const balance = await contract.methods.getBalance(owner).view({ from: owner });
@@ -157,7 +157,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
         console.log(`Starting transfer tx`);
         const { AztecAddress, Contract, createAztecRpcClient, makeFetch } = window.AztecJs;
         const client = createAztecRpcClient(rpcUrl!, makeFetch([1, 2, 3], true));
-        const accounts = await client.getAccounts();
+        const accounts = await client.getRegisteredAccounts();
         const receiver = accounts[1].address;
         const [wallet] = await AztecJs.getSandboxAccountsWallets(client);
         const contract = await Contract.at(AztecAddress.fromString(contractAddress), PrivateTokenContractAbi, wallet);
@@ -179,12 +179,12 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
         const { GrumpkinScalar, DeployMethod, createAztecRpcClient, makeFetch, getUnsafeSchnorrAccount } =
           window.AztecJs;
         const client = createAztecRpcClient(rpcUrl!, makeFetch([1, 2, 3], true));
-        let accounts = await client.getAccounts();
+        let accounts = await client.getRegisteredAccounts();
         if (accounts.length === 0) {
           // This test needs an account for deployment. We create one in case there is none available in the RPC server.
           const privateKey = GrumpkinScalar.fromString(privateKeyString);
           await getUnsafeSchnorrAccount(client, privateKey).waitDeploy();
-          accounts = await client.getAccounts();
+          accounts = await client.getRegisteredAccounts();
         }
         const owner = accounts[0];
         const tx = new DeployMethod(owner.publicKey, client, PrivateTokenContractAbi, [

--- a/yarn-project/end-to-end/src/e2e_cli.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cli.test.ts
@@ -100,14 +100,14 @@ describe('CLI e2e test', () => {
   };
 
   it('creates & retrieves an account', async () => {
-    existingAccounts = await aztecRpcClient.getAccounts();
+    existingAccounts = await aztecRpcClient.getRegisteredAccounts();
     debug('Create an account');
     await run(`create-account`);
     const foundAddress = findInLogs(/Address:\s+(?<address>0x[a-fA-F0-9]+)/)?.groups?.address;
     expect(foundAddress).toBeDefined();
     const newAddress = AztecAddress.fromString(foundAddress!);
 
-    const accountsAfter = await aztecRpcClient.getAccounts();
+    const accountsAfter = await aztecRpcClient.getRegisteredAccounts();
     const expectedAccounts = [...existingAccounts.map(a => a.address), newAddress];
     expect(accountsAfter.map(a => a.address)).toEqual(expectedAccounts);
     const newCompleteAddress = accountsAfter[accountsAfter.length - 1];
@@ -166,7 +166,7 @@ describe('CLI e2e test', () => {
     expect(balance!).toEqual(`${BigInt(INITIAL_BALANCE).toString()}n`);
 
     debug('Transfer some tokens');
-    const existingAccounts = await aztecRpcClient.getAccounts();
+    const existingAccounts = await aztecRpcClient.getRegisteredAccounts();
     // ensure we pick a different acc
     const receiver = existingAccounts.find(acc => acc.address.toString() !== ownerAddress.toString());
 

--- a/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
@@ -38,7 +38,7 @@ describe('e2e_multiple_accounts_1_enc_key', () => {
 
     // Verify that all accounts use the same encryption key
     const encryptionPublicKey = await generatePublicKey(encryptionPrivateKey);
-    for (const account of await aztecRpcServer.getAccounts()) {
+    for (const account of await aztecRpcServer.getRegisteredAccounts()) {
       expect(account.publicKey).toEqual(encryptionPublicKey);
     }
 

--- a/yarn-project/end-to-end/src/e2e_sandbox_example.test.ts
+++ b/yarn-project/end-to-end/src/e2e_sandbox_example.test.ts
@@ -79,7 +79,7 @@ describe('e2e_sandbox_example', () => {
     const [alice, bob] = (await Promise.all(accounts.map(x => x.getCompleteAddress()))).map(x => x.address);
 
     // Verify that the accounts were deployed
-    const registeredAccounts = (await aztecRpc.getAccounts()).map(x => x.address);
+    const registeredAccounts = (await aztecRpc.getRegisteredAccounts()).map(x => x.address);
     for (const [account, name] of [
       [alice, 'Alice'],
       [bob, 'Bob'],

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -160,7 +160,7 @@ export async function setupAztecRPCServer(
 
   return {
     aztecRpcServer: rpc!,
-    accounts: await rpc!.getAccounts(),
+    accounts: await rpc!.getRegisteredAccounts(),
     wallets,
     logger,
   };

--- a/yarn-project/end-to-end/src/sample-dapp/deploy.mjs
+++ b/yarn-project/end-to-end/src/sample-dapp/deploy.mjs
@@ -12,7 +12,7 @@ const { SANDBOX_URL = 'http://localhost:8080' } = process.env;
 
 async function main() {
   const client = createAztecRpcClient(SANDBOX_URL);
-  const [owner] = await client.getAccounts();
+  const [owner] = await client.getRegisteredAccounts();
 
   const privateTokenDeployer = new ContractDeployer(PrivateTokenArtifact, client);
   const { contractAddress: privateTokenAddress } = await privateTokenDeployer.deploy(100n, owner.address).send().wait();

--- a/yarn-project/end-to-end/src/sample-dapp/index.mjs
+++ b/yarn-project/end-to-end/src/sample-dapp/index.mjs
@@ -43,7 +43,7 @@ async function transferPrivateFunds(client) {
 
 async function showPublicBalances(client) {
   // docs:start:showPublicBalances
-  const accounts = await client.getAccounts();
+  const accounts = await client.getRegisteredAccounts();
   const publicToken = await getPublicToken(client);
 
   for (const account of accounts) {

--- a/yarn-project/end-to-end/src/sample-dapp/index.mjs
+++ b/yarn-project/end-to-end/src/sample-dapp/index.mjs
@@ -7,14 +7,14 @@ const { SANDBOX_URL = 'http://localhost:8080' } = process.env;
 
 async function showAccounts(client) {
   // docs:start:showAccounts
-  const accounts = await client.getAccounts();
+  const accounts = await client.getRegisteredAccounts();
   console.log(`User accounts:\n${accounts.map(a => a.address).join('\n')}`);
   // docs:end:showAccounts
 }
 
 async function showPrivateBalances(client) {
   // docs:start:showPrivateBalances
-  const accounts = await client.getAccounts();
+  const accounts = await client.getRegisteredAccounts();
   const privateToken = await getPrivateToken(client);
 
   for (const account of accounts) {

--- a/yarn-project/types/src/interfaces/aztec_rpc.ts
+++ b/yarn-project/types/src/interfaces/aztec_rpc.ts
@@ -103,14 +103,14 @@ export interface AztecRPC {
    *
    * @returns A promise that resolves to an array of the accounts registered on this RPC server.
    */
-  getAccounts(): Promise<CompleteAddress[]>;
+  getRegisteredAccounts(): Promise<CompleteAddress[]>;
 
   /**
    * Retrieves the complete address of the account corresponding to the provided aztec address.
    * @param address - The aztec address of the account contract.
    * @returns A promise that resolves to the complete address of the requested account.
    */
-  getAccount(address: AztecAddress): Promise<CompleteAddress | undefined>;
+  getRegisteredAccount(address: AztecAddress): Promise<CompleteAddress | undefined>;
 
   /**
    * Retrieves the list of recipients added to this rpc server.


### PR DESCRIPTION
It was brought up that `getAccounts` in the RPC Server interface was confusing, since that interface is shared with the `Wallet`, and it's not clear if the accounts being queried correspond to all those listed in the RPC server or just to the wallet. This rename should make it clearer.