### PR TITLE
chore: Remove "as unknown" casts for ABIs where possible

### DIFF
--- a/yarn-project/aztec.js/src/account/contract/ecdsa_account_contract.ts
+++ b/yarn-project/aztec.js/src/account/contract/ecdsa_account_contract.ts
@@ -13,7 +13,7 @@ import { BaseAccountContract } from './base_account_contract.js';
  */
 export class EcdsaAccountContract extends BaseAccountContract {
   constructor(private signingPrivateKey: Buffer) {
-    super(EcdsaAccountContractAbi as unknown as ContractAbi);
+    super(EcdsaAccountContractAbi as ContractAbi);
   }
 
   async getDeploymentArgs() {

--- a/yarn-project/aztec.js/src/account/contract/schnorr_account_contract.ts
+++ b/yarn-project/aztec.js/src/account/contract/schnorr_account_contract.ts
@@ -13,7 +13,7 @@ import { BaseAccountContract } from './base_account_contract.js';
  */
 export class SchnorrAccountContract extends BaseAccountContract {
   constructor(private signingPrivateKey: GrumpkinPrivateKey) {
-    super(SchnorrAccountContractAbi as unknown as ContractAbi);
+    super(SchnorrAccountContractAbi as ContractAbi);
   }
 
   async getDeploymentArgs() {

--- a/yarn-project/aztec.js/src/account/contract/single_key_account_contract.ts
+++ b/yarn-project/aztec.js/src/account/contract/single_key_account_contract.ts
@@ -14,7 +14,7 @@ import { BaseAccountContract } from './base_account_contract.js';
  */
 export class SingleKeyAccountContract extends BaseAccountContract {
   constructor(private encryptionPrivateKey: GrumpkinPrivateKey) {
-    super(SchnorrSingleKeyAccountContractAbi as unknown as ContractAbi);
+    super(SchnorrSingleKeyAccountContractAbi as ContractAbi);
   }
 
   getDeploymentArgs(): Promise<any[]> {

--- a/yarn-project/aztec.js/src/account/defaults/default_entrypoint.ts
+++ b/yarn-project/aztec.js/src/account/defaults/default_entrypoint.ts
@@ -90,6 +90,6 @@ export class DefaultAccountEntrypoint implements EntrypointInterface {
         },
       ],
       returnTypes: [],
-    } as unknown as FunctionAbiHeader;
+    } as FunctionAbiHeader;
   }
 }

--- a/yarn-project/aztec.js/src/contract/checker.test.ts
+++ b/yarn-project/aztec.js/src/contract/checker.test.ts
@@ -156,6 +156,7 @@ describe('abiChecker', () => {
             {
               type: {
                 kind: 'struct',
+                path: 'mystruct',
                 fields: [
                   {
                     name: 'name',

--- a/yarn-project/aztec.js/src/contract/checker.ts
+++ b/yarn-project/aztec.js/src/contract/checker.ts
@@ -66,7 +66,7 @@ function abiParameterTypeChecker(type: ABIType): boolean {
     case 'array':
       return checkAttributes(type, { length: 'number', type: 'object' }) && abiParameterTypeChecker(type.type);
     case 'struct':
-      return checkAttributes(type, { fields: 'object' }) && checkStruct(type);
+      return checkAttributes(type, { fields: 'object', path: 'string' }) && checkStruct(type);
     default:
       throw new Error('ABI function parameter has an unrecognised type');
   }

--- a/yarn-project/boxes/private-token/src/artifacts/PrivateToken.ts
+++ b/yarn-project/boxes/private-token/src/artifacts/PrivateToken.ts
@@ -17,7 +17,7 @@ import { AztecRPC, PublicKey } from '@aztec/types';
 
 import PrivateTokenContractAbiJson from './private_token_contract.json' assert { type: 'json' };
 
-export const PrivateTokenContractAbi = PrivateTokenContractAbiJson as unknown as ContractAbi;
+export const PrivateTokenContractAbi = PrivateTokenContractAbiJson as ContractAbi;
 
 /**
  * Type-safe interface for contract PrivateToken;

--- a/yarn-project/cli/src/test/mocks.ts
+++ b/yarn-project/cli/src/test/mocks.ts
@@ -48,6 +48,7 @@ export const mockContractAbi: ContractAbi = {
           name: 'structParam',
           type: {
             kind: 'struct',
+            path: 'mystruct',
             fields: [
               { name: 'subField1', type: { kind: 'field' } },
               { name: 'subField2', type: { kind: 'boolean' } },

--- a/yarn-project/foundation/src/abi/abi.ts
+++ b/yarn-project/foundation/src/abi/abi.ts
@@ -93,6 +93,10 @@ export interface StructType extends BasicType<'struct'> {
    * The fields of the struct.
    */
   fields: ABIVariable[];
+  /**
+   * Fully qualified name of the struct.
+   */
+  path: string;
 }
 
 /**

--- a/yarn-project/foundation/src/abi/decoder.test.ts
+++ b/yarn-project/foundation/src/abi/decoder.test.ts
@@ -1,4 +1,4 @@
-import { FunctionAbi } from './abi.js';
+import { ABIParameterVisibility, FunctionAbi } from './abi.js';
 import { decodeFunctionSignature, decodeFunctionSignatureWithParameterNames } from './decoder.js';
 
 describe('abi/decoder', () => {
@@ -20,7 +20,7 @@ describe('abi/decoder', () => {
             { name: 'secretHash', type: { kind: 'field' } },
           ],
         },
-        visibility: 'private',
+        visibility: 'private' as ABIParameterVisibility,
       },
       {
         name: 'aDeepStruct',
@@ -58,10 +58,10 @@ describe('abi/decoder', () => {
             },
           ],
         },
-        visibility: 'private',
+        visibility: 'private' as ABIParameterVisibility,
       },
     ],
-  } as unknown as Pick<FunctionAbi, 'name' | 'parameters'>;
+  } as Pick<FunctionAbi, 'name' | 'parameters'>;
 
   it('decodes function signature', () => {
     expect(decodeFunctionSignature(abi.name, abi.parameters)).toMatchInlineSnapshot(

--- a/yarn-project/noir-compiler/src/contract-interface-gen/typescript.ts
+++ b/yarn-project/noir-compiler/src/contract-interface-gen/typescript.ts
@@ -146,7 +146,7 @@ function generateAbiGetter(name: string) {
 function generateAbiStatement(name: string, abiImportPath: string) {
   const stmts = [
     `import ${name}ContractAbiJson from '${abiImportPath}' assert { type: 'json' };`,
-    `export const ${name}ContractAbi = ${name}ContractAbiJson as unknown as ContractAbi;`,
+    `export const ${name}ContractAbi = ${name}ContractAbiJson as ContractAbi;`,
   ];
   return stmts.join('\n');
 }

--- a/yarn-project/noir-contracts/scripts/types.sh
+++ b/yarn-project/noir-contracts/scripts/types.sh
@@ -47,7 +47,7 @@ write_export() {
 
 
     # artifacts
-    echo "export const ${NAME}ContractAbi = ${NAME}Json as unknown as ContractAbi;"  >> "$artifacts_dir/index.ts";
+    echo "export const ${NAME}ContractAbi = ${NAME}Json as ContractAbi;"  >> "$artifacts_dir/index.ts";
     echo "Written typescript for $NAME"
 
     # types


### PR DESCRIPTION
Adds missing path property to struct types and removes "as unknown" casts for going from json files to ABI types. 

Note that the cast is still needed since ts loads JSON files with values understood as strings, so without the cast the type checker complains about `visibility` being a string rather than an `ABIVisibility`. And changing the visibility type from an enum to a union type doesn't cut it, see [this ts issue](https://github.com/microsoft/TypeScript/issues/26552) for more info.