### PR TITLE
chore: Use retries by default on rpc client fetch

### DIFF
--- a/yarn-project/aztec.js/src/aztec_rpc_client.ts
+++ b/yarn-project/aztec.js/src/aztec_rpc_client.ts
@@ -1,5 +1,5 @@
 import { AztecAddress, CompleteAddress, EthAddress, Fr, GrumpkinScalar, Point } from '@aztec/circuits.js';
-import { createJsonRpcClient, defaultFetch } from '@aztec/foundation/json-rpc/client';
+import { createJsonRpcClient, makeFetch } from '@aztec/foundation/json-rpc/client';
 import {
   AuthWitness,
   AztecRPC,
@@ -15,7 +15,7 @@ import {
 
 export { makeFetch } from '@aztec/foundation/json-rpc/client';
 
-export const createAztecRpcClient = (url: string, fetch = defaultFetch): AztecRPC =>
+export const createAztecRpcClient = (url: string, fetch = makeFetch([1, 2, 3], true)): AztecRPC =>
   createJsonRpcClient<AztecRPC>(
     url,
     {

--- a/yarn-project/boxes/private-token/src/tests/privatetoken.frontend.test.ts
+++ b/yarn-project/boxes/private-token/src/tests/privatetoken.frontend.test.ts
@@ -7,7 +7,6 @@ import {
   Fr,
   Wallet,
   createAztecRpcClient,
-  makeFetch,
   waitForSandbox,
 } from '@aztec/aztec.js';
 import { FunctionAbi } from '@aztec/foundation/abi';
@@ -27,7 +26,7 @@ const MINT_AMOUNT = 11n;
 // as well as anvil.  anvil can be started with yarn test:integration
 const setupSandbox = async () => {
   const { SANDBOX_URL = 'http://localhost:8080' } = process.env;
-  const aztecRpc = createAztecRpcClient(SANDBOX_URL, makeFetch([1, 2, 3], true));
+  const aztecRpc = createAztecRpcClient(SANDBOX_URL);
   await waitForSandbox(aztecRpc);
   return aztecRpc;
 };

--- a/yarn-project/canary/src/aztec_js_browser.test.ts
+++ b/yarn-project/canary/src/aztec_js_browser.test.ts
@@ -54,7 +54,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
   let page: Page;
 
   beforeAll(async () => {
-    testClient = AztecJs.createAztecRpcClient(SANDBOX_URL!, AztecJs.makeFetch([1, 2, 3], true));
+    testClient = AztecJs.createAztecRpcClient(SANDBOX_URL!);
     await AztecJs.waitForSandbox(testClient);
     const pathRes = path.resolve(__dirname, './web');
     app = new Koa();
@@ -108,7 +108,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
     const result = await page.evaluate(
       async (rpcUrl, privateKeyString) => {
         const { GrumpkinScalar, createAztecRpcClient, makeFetch, getUnsafeSchnorrAccount } = window.AztecJs;
-        const client = createAztecRpcClient(rpcUrl!, makeFetch([1, 2, 3], true));
+        const client = createAztecRpcClient(rpcUrl!);
         const privateKey = GrumpkinScalar.fromString(privateKeyString);
         const account = getUnsafeSchnorrAccount(client, privateKey);
         await account.waitDeploy();
@@ -133,7 +133,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
     const result = await page.evaluate(
       async (rpcUrl, contractAddress, PrivateTokenContractAbi) => {
         const { Contract, AztecAddress, createAztecRpcClient, makeFetch } = window.AztecJs;
-        const client = createAztecRpcClient(rpcUrl!, makeFetch([1, 2, 3], true));
+        const client = createAztecRpcClient(rpcUrl!);
         const owner = (await client.getRegisteredAccounts())[0].address;
         const [wallet] = await AztecJs.getSandboxAccountsWallets(client);
         const contract = await Contract.at(AztecAddress.fromString(contractAddress), PrivateTokenContractAbi, wallet);
@@ -154,7 +154,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
       async (rpcUrl, contractAddress, transferAmount, PrivateTokenContractAbi) => {
         console.log(`Starting transfer tx`);
         const { AztecAddress, Contract, createAztecRpcClient, makeFetch } = window.AztecJs;
-        const client = createAztecRpcClient(rpcUrl!, makeFetch([1, 2, 3], true));
+        const client = createAztecRpcClient(rpcUrl!);
         const accounts = await client.getRegisteredAccounts();
         const owner = accounts[0].address;
         const receiver = accounts[1].address;
@@ -181,7 +181,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
       async (rpcUrl, privateKeyString, initialBalance, PrivateTokenContractAbi) => {
         const { GrumpkinScalar, DeployMethod, createAztecRpcClient, makeFetch, getUnsafeSchnorrAccount } =
           window.AztecJs;
-        const client = createAztecRpcClient(rpcUrl!, makeFetch([1, 2, 3], true));
+        const client = createAztecRpcClient(rpcUrl!);
         let accounts = await client.getRegisteredAccounts();
         if (accounts.length === 0) {
           // This test needs an account for deployment. We create one in case there is none available in the RPC server.

--- a/yarn-project/canary/src/uniswap_trade_on_l1_from_l2.test.ts
+++ b/yarn-project/canary/src/uniswap_trade_on_l1_from_l2.test.ts
@@ -9,7 +9,6 @@ import {
   createDebugLogger,
   getL1ContractAddresses,
   getSandboxAccountsWallets,
-  makeFetch,
   sleep,
   waitForSandbox,
 } from '@aztec/aztec.js';
@@ -51,7 +50,7 @@ const ethRpcUrl = ETHEREUM_HOST;
 
 const hdAccount = mnemonicToAccount(MNEMONIC);
 
-const aztecRpcClient = createAztecRpcClient(aztecRpcUrl, makeFetch([1, 2, 3], true));
+const aztecRpcClient = createAztecRpcClient(aztecRpcUrl);
 let wallet: Wallet;
 
 /**

--- a/yarn-project/cli/src/client.ts
+++ b/yarn-project/cli/src/client.ts
@@ -1,5 +1,4 @@
 import { AztecRPC, createAztecRpcClient } from '@aztec/aztec.js';
-import { makeFetch } from '@aztec/foundation/json-rpc/client';
 import { DebugLogger } from '@aztec/foundation/log';
 import { fileURLToPath } from '@aztec/foundation/url';
 
@@ -7,16 +6,13 @@ import { readFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { gtr, ltr, satisfies, valid } from 'semver';
 
-const retries = [1, 1, 2];
-
 /**
  * Creates an Aztec RPC client with a given set of retries on non-server errors.
  * @param rpcUrl - URL of the RPC server.
  * @returns An RPC client.
  */
 export function createClient(rpcUrl: string) {
-  const fetch = makeFetch(retries, true);
-  return createAztecRpcClient(rpcUrl, fetch);
+  return createAztecRpcClient(rpcUrl);
 }
 
 /**

--- a/yarn-project/end-to-end/src/aztec_rpc_sandbox.test.ts
+++ b/yarn-project/end-to-end/src/aztec_rpc_sandbox.test.ts
@@ -1,10 +1,10 @@
 import { aztecRpcTestSuite } from '@aztec/aztec-rpc';
-import { createAztecRpcClient, makeFetch, waitForSandbox } from '@aztec/aztec.js';
+import { createAztecRpcClient, waitForSandbox } from '@aztec/aztec.js';
 
 const { SANDBOX_URL = 'http://localhost:8080' } = process.env;
 
 const setup = async () => {
-  const aztecRpc = createAztecRpcClient(SANDBOX_URL, makeFetch([1, 2, 3], true));
+  const aztecRpc = createAztecRpcClient(SANDBOX_URL);
   await waitForSandbox(aztecRpc);
   return aztecRpc;
 };

--- a/yarn-project/end-to-end/src/e2e_aztec_js_browser.test.ts
+++ b/yarn-project/end-to-end/src/e2e_aztec_js_browser.test.ts
@@ -57,7 +57,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
   let page: Page;
 
   beforeAll(async () => {
-    testClient = AztecJs.createAztecRpcClient(SANDBOX_URL!, AztecJs.makeFetch([1, 2, 3], true));
+    testClient = AztecJs.createAztecRpcClient(SANDBOX_URL!);
     await AztecJs.waitForSandbox(testClient);
 
     app = new Koa();
@@ -111,7 +111,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
     const result = await page.evaluate(
       async (rpcUrl, privateKeyString) => {
         const { GrumpkinScalar, createAztecRpcClient, makeFetch, getUnsafeSchnorrAccount } = window.AztecJs;
-        const client = createAztecRpcClient(rpcUrl!, makeFetch([1, 2, 3], true));
+        const client = createAztecRpcClient(rpcUrl!);
         const privateKey = GrumpkinScalar.fromString(privateKeyString);
         const account = getUnsafeSchnorrAccount(client, privateKey);
         await account.waitDeploy();
@@ -136,7 +136,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
     const result = await page.evaluate(
       async (rpcUrl, contractAddress, PrivateTokenContractAbi) => {
         const { Contract, AztecAddress, createAztecRpcClient, makeFetch } = window.AztecJs;
-        const client = createAztecRpcClient(rpcUrl!, makeFetch([1, 2, 3], true));
+        const client = createAztecRpcClient(rpcUrl!);
         const owner = (await client.getRegisteredAccounts())[0].address;
         const [wallet] = await AztecJs.getSandboxAccountsWallets(client);
         const contract = await Contract.at(AztecAddress.fromString(contractAddress), PrivateTokenContractAbi, wallet);
@@ -156,7 +156,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
       async (rpcUrl, contractAddress, transferAmount, PrivateTokenContractAbi) => {
         console.log(`Starting transfer tx`);
         const { AztecAddress, Contract, createAztecRpcClient, makeFetch } = window.AztecJs;
-        const client = createAztecRpcClient(rpcUrl!, makeFetch([1, 2, 3], true));
+        const client = createAztecRpcClient(rpcUrl!);
         const accounts = await client.getRegisteredAccounts();
         const receiver = accounts[1].address;
         const [wallet] = await AztecJs.getSandboxAccountsWallets(client);
@@ -178,7 +178,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
       async (rpcUrl, privateKeyString, initialBalance, PrivateTokenContractAbi) => {
         const { GrumpkinScalar, DeployMethod, createAztecRpcClient, makeFetch, getUnsafeSchnorrAccount } =
           window.AztecJs;
-        const client = createAztecRpcClient(rpcUrl!, makeFetch([1, 2, 3], true));
+        const client = createAztecRpcClient(rpcUrl!);
         let accounts = await client.getRegisteredAccounts();
         if (accounts.length === 0) {
           // This test needs an account for deployment. We create one in case there is none available in the RPC server.

--- a/yarn-project/end-to-end/src/e2e_aztec_js_browser.test.ts
+++ b/yarn-project/end-to-end/src/e2e_aztec_js_browser.test.ts
@@ -110,7 +110,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
   it('Creates an account', async () => {
     const result = await page.evaluate(
       async (rpcUrl, privateKeyString) => {
-        const { GrumpkinScalar, createAztecRpcClient, makeFetch, getUnsafeSchnorrAccount } = window.AztecJs;
+        const { GrumpkinScalar, createAztecRpcClient, getUnsafeSchnorrAccount } = window.AztecJs;
         const client = createAztecRpcClient(rpcUrl!);
         const privateKey = GrumpkinScalar.fromString(privateKeyString);
         const account = getUnsafeSchnorrAccount(client, privateKey);
@@ -135,7 +135,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
   it("Gets the owner's balance", async () => {
     const result = await page.evaluate(
       async (rpcUrl, contractAddress, PrivateTokenContractAbi) => {
-        const { Contract, AztecAddress, createAztecRpcClient, makeFetch } = window.AztecJs;
+        const { Contract, AztecAddress, createAztecRpcClient } = window.AztecJs;
         const client = createAztecRpcClient(rpcUrl!);
         const owner = (await client.getRegisteredAccounts())[0].address;
         const [wallet] = await AztecJs.getSandboxAccountsWallets(client);
@@ -155,7 +155,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
     const result = await page.evaluate(
       async (rpcUrl, contractAddress, transferAmount, PrivateTokenContractAbi) => {
         console.log(`Starting transfer tx`);
-        const { AztecAddress, Contract, createAztecRpcClient, makeFetch } = window.AztecJs;
+        const { AztecAddress, Contract, createAztecRpcClient } = window.AztecJs;
         const client = createAztecRpcClient(rpcUrl!);
         const accounts = await client.getRegisteredAccounts();
         const receiver = accounts[1].address;
@@ -176,8 +176,7 @@ conditionalDescribe()('e2e_aztec.js_browser', () => {
   const deployPrivateTokenContract = async () => {
     const txHash = await page.evaluate(
       async (rpcUrl, privateKeyString, initialBalance, PrivateTokenContractAbi) => {
-        const { GrumpkinScalar, DeployMethod, createAztecRpcClient, makeFetch, getUnsafeSchnorrAccount } =
-          window.AztecJs;
+        const { GrumpkinScalar, DeployMethod, createAztecRpcClient, getUnsafeSchnorrAccount } = window.AztecJs;
         const client = createAztecRpcClient(rpcUrl!);
         let accounts = await client.getRegisteredAccounts();
         if (accounts.length === 0) {

--- a/yarn-project/end-to-end/src/e2e_sandbox_example.test.ts
+++ b/yarn-project/end-to-end/src/e2e_sandbox_example.test.ts
@@ -2,14 +2,7 @@
 
 /* eslint-disable import/no-duplicates */
 // docs:start:imports
-import {
-  AztecRPC,
-  createAztecRpcClient,
-  createDebugLogger,
-  getSchnorrAccount,
-  makeFetch,
-  waitForSandbox,
-} from '@aztec/aztec.js';
+import { AztecRPC, createAztecRpcClient, createDebugLogger, getSchnorrAccount, waitForSandbox } from '@aztec/aztec.js';
 // docs:end:imports
 
 /* eslint-enable @typescript-eslint/no-unused-vars */
@@ -33,9 +26,8 @@ describe('e2e_sandbox_example', () => {
     const logger = createDebugLogger('private-token');
     const sandboxUrl = 'http://localhost:8080';
 
-    // We create AztecRPC client connected to the sandbox URL and we use fetch with
-    // 3 automatic retries and a 1s, 2s and 3s intervals between failures.
-    const aztecRpc = createAztecRpcClient(sandboxUrl, makeFetch([1, 2, 3], false));
+    // We create AztecRPC client connected to the sandbox URL
+    const aztecRpc = createAztecRpcClient(sandboxUrl);
     // Wait for sandbox to be ready
     await waitForSandbox(aztecRpc);
 

--- a/yarn-project/end-to-end/src/e2e_sandbox_example.test.ts
+++ b/yarn-project/end-to-end/src/e2e_sandbox_example.test.ts
@@ -9,15 +9,14 @@ import { AztecRPC, createAztecRpcClient, createDebugLogger, getSchnorrAccount, w
 // Note: this is a hack to make the docs use http://localhost:8080 and CI to use the SANDBOX_URL
 import { createAztecRpcClient as createAztecRpcClient2 } from '@aztec/aztec.js';
 import { GrumpkinScalar } from '@aztec/circuits.js';
-import { defaultFetch } from '@aztec/foundation/json-rpc/client';
 import { PrivateTokenContract } from '@aztec/noir-contracts/types';
 
 const { SANDBOX_URL = 'http://localhost:8080' } = process.env;
 
 describe('e2e_sandbox_example', () => {
   // Note: this is a hack to make the docs use http://localhost:8080 and CI to use the SANDBOX_URL
-  const createAztecRpcClient = (url: string, fetch = defaultFetch) => {
-    return createAztecRpcClient2(SANDBOX_URL!, fetch);
+  const createAztecRpcClient = (_url: string) => {
+    return createAztecRpcClient2(SANDBOX_URL!);
   };
 
   it('sandbox example works', async () => {

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -11,7 +11,6 @@ import {
   createAztecRpcClient as createJsonRpcClient,
   getL1ContractAddresses,
   getSandboxAccountsWallets,
-  makeFetch,
 } from '@aztec/aztec.js';
 import { CompleteAddress } from '@aztec/circuits.js';
 import { DeployL1Contracts, deployL1Contract, deployL1Contracts } from '@aztec/ethereum';
@@ -73,7 +72,7 @@ const createRpcServer = async (
 ): Promise<AztecRPC> => {
   if (SANDBOX_URL) {
     logger(`Creating JSON RPC client to remote host ${SANDBOX_URL}`);
-    const jsonClient = createJsonRpcClient(SANDBOX_URL, makeFetch([1, 2, 3], true));
+    const jsonClient = createJsonRpcClient(SANDBOX_URL);
     await waitForRPCServer(jsonClient, logger);
     logger('JSON RPC client connected to RPC Server');
     return jsonClient;


### PR DESCRIPTION
Tests that used the default `fetch` implementation with retries (like [`guides-sample-dapp`](https://app.circleci.com/pipelines/github/AztecProtocol/aztec-packages/10931/workflows/3a7171eb-da58-4ae8-9188-b7fd59b67eef/jobs/412217)) were failing due to connection issues. This PR changes the default fetch to always retry 3 times, which was what were manually configuring in most scenarios.