### PR TITLE
chore: Increase guides-dapp-testing test timeout

### DIFF
--- a/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
+++ b/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
@@ -46,7 +46,7 @@ describe('guides/dapp/testing', () => {
         await token.methods.mint_private(20n, secretHash).send().wait();
         await token.methods.redeem_shield({ address: recipient.getAddress() }, 20n, secret).send().wait();
         expect(await token.methods.balance_of_private({ address: recipient.getAddress() }).view()).toEqual(20n);
-      });
+      }, 30_000);
     });
   });
 
@@ -78,7 +78,7 @@ describe('guides/dapp/testing', () => {
         await token.methods.mint_private(20n, secretHash).send().wait();
         await token.methods.redeem_shield({ address: recipient.getAddress() }, 20n, secret).send().wait();
         expect(await token.methods.balance_of_private({ address: recipient.getAddress() }).view()).toEqual(20n);
-      });
+      }, 30_000);
     });
     // docs:end:sandbox-example
 
@@ -104,7 +104,7 @@ describe('guides/dapp/testing', () => {
         await token.methods.mint_private(20n, secretHash).send().wait();
         await token.methods.redeem_shield({ address: recipient.getAddress() }, 20n, secret).send().wait();
         expect(await token.methods.balance_of_private({ address: recipient.getAddress() }).view()).toEqual(20n);
-      });
+      }, 30_000);
     });
 
     describe('cheats', () => {


### PR DESCRIPTION
Attempt at solving CI timeout on guides-dapp-testing (see example failing run [here](https://app.circleci.com/pipelines/github/AztecProtocol/aztec-packages/10931/workflows/3a7171eb-da58-4ae8-9188-b7fd59b67eef/jobs/412220)).