### PR TITLE
refactor(aztec_noir): remove inputs from consume l1 to l2 message 

### DIFF
--- a/yarn-project/aztec-nr/aztec/src/context.nr
+++ b/yarn-project/aztec-nr/aztec/src/context.nr
@@ -174,14 +174,13 @@ impl PrivateContext {
     // docs:start:context_consume_l1_to_l2_message
     fn consume_l1_to_l2_message(
         &mut self,
-        inputs: abi::PrivateContextInputs,
         msg_key: Field,
         content: Field,
         secret: Field
     ) 
     // docs:end:context_consume_l1_to_l2_message
     {
-        let nullifier = process_l1_to_l2_message(inputs.block_data.l1_to_l2_messages_tree_root, inputs.call_context.storage_contract_address, msg_key, content, secret);
+        let nullifier = process_l1_to_l2_message(self.block_data.l1_to_l2_messages_tree_root, self.this_address(), msg_key, content, secret);
 
         // Push nullifier (and the "commitment" corresponding to this can be "empty")
         self.push_new_nullifier(nullifier, EMPTY_NULLIFIED_COMMITMENT)

--- a/yarn-project/noir-contracts/src/contracts/non_native_token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/non_native_token_contract/src/main.nr
@@ -96,7 +96,6 @@ contract NonNativeToken {
     fn mint(
         amount: Field,
         owner: Field,
-        // This field should be hidden
         msg_key: Field,
         secret: Field,
         canceller: Field,
@@ -106,7 +105,7 @@ contract NonNativeToken {
         let content_hash = get_mint_content_hash(amount, owner, canceller);
 
         // Get the l1 message from an oracle call
-        context.consume_l1_to_l2_message(inputs, msg_key, content_hash, secret);
+        context.consume_l1_to_l2_message(msg_key, content_hash, secret);
 
         let balance = storage.balances.at(owner);
         increment(balance, amount, owner);
@@ -141,7 +140,6 @@ contract NonNativeToken {
     fn mintPublic(
         amount: Field,
         owner_address: Field,
-        // This field should be hidden
         msg_key: Field,
         secret: Field,
         canceller: Field,


### PR DESCRIPTION
Was doing a little project using portals and noticed this. The api varies between public and private.

