### PR TITLE
fix: strip leading 'v' from dockerhub tags

### DIFF
--- a/build-system/scripts/deploy_dockerhub
+++ b/build-system/scripts/deploy_dockerhub
@@ -30,8 +30,8 @@ if [[ "$COMMIT_TAG" == *"/"* ]]; then
   COMMIT_TAG_VERSION="${COMMIT_TAG#*/}"
   echo "Tag was made for: $REPO_NAME"
   echo "Version: $COMMIT_TAG_VERSION"
-
-    # Check if REPO_NAME is equal to REPOSITORY
+  
+  # Check if REPO_NAME is equal to REPOSITORY
   if [ "$REPO_NAME" != "$REPOSITORY" ]; then
     echo "REPO_NAME ($REPO_NAME) does not match REPOSITORY ($REPOSITORY). Exiting..."
     exit 1
@@ -48,6 +48,8 @@ VERSION=$(npx semver $COMMIT_TAG_VERSION)
 if [ -z "$VERSION" ]; then
   echo "$COMMIT_TAG_VERSION is not a semantic version."
   exit 1
+else
+  COMMIT_TAG_VERSION=$VERSION
 fi
 
 echo "Deploying to dockerhub: $IMAGE_DEPLOY_URI"


### PR DESCRIPTION
Publish dockerhub tags as `0.7.5` rather than `v0.7.5` for consistency with NPM
# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
