### PR TITLE
fix: Exit with error log when COMMIT_TAG is not set properly on canary

### DIFF
--- a/yarn-project/canary/Dockerfile
+++ b/yarn-project/canary/Dockerfile
@@ -1,9 +1,9 @@
-FROM 278380418400.dkr.ecr.us-east-2.amazonaws.com/yarn-project-base AS builder
+FROM 278380418400.dkr.ecr.eu-west-2.amazonaws.com/yarn-project-base AS builder
 
 RUN apk update && apk add --no-cache udev ttf-freefont chromium curl jq bash
 ENV CHROME_BIN="/usr/bin/chromium-browser" PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
 
-ARG COMMIT_TAG="0.7.5"
+ARG COMMIT_TAG="."
 
 COPY . .
 

--- a/yarn-project/end-to-end/scripts/setup_canary.sh
+++ b/yarn-project/end-to-end/scripts/setup_canary.sh
@@ -7,7 +7,7 @@ TARGET_PKGS_FILE=$2
 # Check if file exists and read it into an array
 if [ -f "$TARGET_PKGS_FILE" ]; then
   mapfile -t TARGET_PKGS < <(cat "$TARGET_PKGS_FILE")
-  echo "Loaded array:"
+  echo "Loaded package array:"
   for i in "${TARGET_PKGS[@]}"; do
     echo "$i"
   done
@@ -20,7 +20,16 @@ if [ -z "$COMMIT_TAG" ]; then
   exit 0
 fi
 
+set +e  # Temporarily disable exit on error
 VERSION=$(npx semver $COMMIT_TAG)
+RESULT=$?  # Capture the exit status of the last command
+set -e  # Re-enable exit on error
+
+if [ $RESULT -ne 0 ]; then
+  echo "Error when running 'npx semver' with commit tag: $COMMIT_TAG"
+  exit 1
+fi
+
 if [ -z "$VERSION" ]; then
   echo "$COMMIT_TAG is not a semantic version."
   exit 1


### PR DESCRIPTION
Revert default `COMMIT_TAG` on canary Dockerfile, so it logs an error when called out a `COMMIT_TAG` or a malformed one

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
