### PR TITLE
fix: build script exiting on failed grep

### DIFF
--- a/build-system/scripts/build
+++ b/build-system/scripts/build
@@ -83,8 +83,10 @@ if [[ $FORCE_BUILD == 'false' ]] && check_rebuild cache-"$CONTENT_HASH" $REPOSIT
   exit 0
 fi
 
+echo "Initializing submodules..."
 init_submodules $REPOSITORY
 
+echo "Checking for terraform..."
 # Validate any terraform if it exists.
 if [ -d $ROOT_PATH/$PROJECT_DIR/terraform ]; then
   ensure_terraform
@@ -102,7 +104,7 @@ if [ -d $ROOT_PATH/$PROJECT_DIR/terraform ]; then
 fi
 
 # Pull latest parents that are not ours. We also do not want to pull images suffixed by _, this is how we scope intermediate build images.
-PARENTS=$(cat $DOCKERFILE | sed -n -e 's/^FROM \([^[:space:]]\+\).*/\1/p' | sed '/_$/d' | grep -v $ECR_DEPLOY_URL  | sort | uniq)
+PARENTS=$(cat $DOCKERFILE | sed -n -e 's/^FROM \([^[:space:]]\+\).*/\1/p' | sed '/_$/d' | { grep -v $ECR_DEPLOY_URL || true; } | sort | uniq)
 for PARENT in $PARENTS; do
   [ "$PARENT" == "scratch" ] && continue
   fetch_image $PARENT
@@ -127,6 +129,7 @@ for PARENT in $PARENTS; do
   retry docker tag $PARENT_IMAGE_URI $TAG
 done
 
+echo "Extracting commit tag version..."
 COMMIT_TAG_VERSION=$(extract_tag_version $REPOSITORY "false")
 
 # Pull, build and push each named stage to cache.

--- a/build-system/scripts/build
+++ b/build-system/scripts/build
@@ -127,7 +127,7 @@ for PARENT in $PARENTS; do
   retry docker tag $PARENT_IMAGE_URI $TAG
 done
 
-COMMIT_TAG_VERSION=$(extract_tag_version $REPOSITORY false)
+COMMIT_TAG_VERSION=$(extract_tag_version $REPOSITORY "false")
 
 # Pull, build and push each named stage to cache.
 STAGE_CACHE_FROM=""

--- a/yarn-project/canary/Dockerfile
+++ b/yarn-project/canary/Dockerfile
@@ -22,6 +22,10 @@ WORKDIR /usr/src/yarn-project/canary
 RUN ./scripts/update_packages.sh $COMMIT_TAG
 RUN yarn && yarn build
 
+FROM node:18-alpine
+COPY --from=builder /usr/src/ /usr/src/
+WORKDIR /usr/src/yarn-project/canary
+
 # Copy web artifacts for browser test
 RUN cp ./node_modules/@aztec/aztec.js/dest/main.js src/web/
 RUN cp ./node_modules/@aztec/circuits.js/resources/aztec3-circuits.wasm src/web/


### PR DESCRIPTION
`build` script was failing when trying to `grep` any images on dockerfiles that were not "ours".

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
