### PR TITLE
fix(nargo_check.sh): UNIX standard grep

### DIFF
--- a/yarn-project/noir-contracts/scripts/nargo_check.sh
+++ b/yarn-project/noir-contracts/scripts/nargo_check.sh
@@ -4,7 +4,7 @@
 nargo_check() {
     echo "Using $(nargo --version)"
     EXPECTED_VERSION=$(jq -r '.commit' ../noir-compiler/src/noir-version.json)
-    FOUND_VERSION=$(nargo --version | grep -oP 'git version hash: \K[0-9a-f]+')
+    FOUND_VERSION=$(nargo --version | grep -o 'git version hash: [0-9a-f]*' | cut -d' ' -f4)
     if [ "$EXPECTED_VERSION" != "$FOUND_VERSION" ]; then
       echo "Expected nargo version $EXPECTED_VERSION but found version $FOUND_VERSION. Aborting."
       exit 1


### PR DESCRIPTION
Mac does not support the -P flag.