### PR TITLE
chore(docs): remove non native token in docs + update portal docs

### DIFF
--- a/docs/docs/dev_docs/contracts/portals/main.md
+++ b/docs/docs/dev_docs/contracts/portals/main.md
@@ -38,7 +38,7 @@ An example usage of this flow is a token bridge. You can deposit to Aztec i.e. m
 
 #include_code token_portal_deposit l1-contracts/test/portals/TokenPortal.sol solidity
 
-To consume the message on Aztec, we can use the `consume_l1_to_l2_message` function within the `context` struct. 
+To consume the message on Aztec, we can use the `consume_l1_to_l2_message` function from the `context`. 
 The `msg_key` is the hash of the message produced from the `sendL2Message` call, the `content` is the content of the message, and the `secret` is the pre-image hashed to compute the `secretHash`.
 
 #include_code context_consume_l1_to_l2_message /yarn-project/aztec-nr/aztec/src/context.nr rust
@@ -49,7 +49,7 @@ On Aztec, to consume the message and mint the notes, in the Aztec contract a `cl
 
 #include_code token_bridge_claim_private yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/main.nr rust
 
-Note that, if you deposited to Aztec publicly (using the `TokenPortal.depositToAztecPublic()` method that was shown earlier), you have to call the `claim_public` method on the aztec contract which works similar to `claim_private` but operates in the public domain and calculates the appropriate content hash:
+Note that, if you deposited to Aztec publicly (using the `TokenPortal.depositToAztecPublic()` method that was shown earlier), you have to call the `claim_public` method on the Aztec contract which works similar to `claim_private` but operates in the public domain and calculates the appropriate content hash:
 
 #include_code token_bridge_claim_public yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/main.nr rust
 
@@ -75,11 +75,11 @@ When sending a message from L2 to L1 we don't need to pass recipient, deadline, 
 Access control on the L1 portal contract is essential to prevent consumption of messages sent from the wrong L2 contract.
 :::
 
-As earlier, we can use a token bridge as an example. In this case, we are burning tokens on L2 and sending a message to the portal to free them on L1.
+As earlier, we can use a token bridge as an example. In this case, we are burning tokens on L2 and sending a message to the portal to free them on L1. The burn happens privately, so it doesn't leak the burn amount on Aztec.
 
 #include_code token_bridge_exit_private yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/main.nr rust
 
-Here, you are burning your funds privately, and not leaking the burn amount on Aztec. However, you can also exit publicly:
+You can also exit publicly:
 
 #include_code token_bridge_exit_public yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/main.nr rust
 

--- a/docs/docs/dev_docs/contracts/syntax/messaging.md
+++ b/docs/docs/dev_docs/contracts/syntax/messaging.md
@@ -5,10 +5,12 @@ description: Documentation of Aztec's Messaging system
 
 # Messaging
 
-## L1 --> L2
+## L1 -> L2
 The context available within functions includes the ability to send messages to l1. For more information on how cross chain communication works in Aztec, see the [documentation on communication.](../../../concepts/foundation/communication/cross_chain_calls.md)
 
-#include_code non_native_token_withdraw  /yarn-project/noir-contracts/src/contracts/non_native_token_contract/src/main.nr rust
+#include_code token_bridge_exit_private  /yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/main.nr rust
+
+#include_code token_bridge_exit_public  /yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/main.nr rust
 
 ### What happens behind the scenes?
 When a user sends a message from a [portal contract](../../../concepts/foundation/communication/cross_chain_calls.md#portal) to the rollup's inbox it gets processed and added to the `l1 to l2 messages tree`.
@@ -31,4 +33,4 @@ When calling the `consume_l1_to_l2_message` function on a contract; a number of 
 
 As the same nullifier cannot be created twice. We cannot consume the message again.
 
-## L2 ->> L1
+## L2 -> L1

--- a/l1-contracts/test/portals/TokenPortal.sol
+++ b/l1-contracts/test/portals/TokenPortal.sol
@@ -22,6 +22,7 @@ contract TokenPortal {
     l2TokenAddress = _l2TokenAddress;
   }
 
+  // docs:start:token_portal_deposit
   /**
    * @notice Deposit funds into the portal and adds an L2 message which can only be consumed publicly on Aztec
    * @param _to - The aztec address of the recipient
@@ -92,6 +93,7 @@ contract TokenPortal {
       actor, _deadline, contentHash, _secretHashForL2MessageConsumption
     );
   }
+  // docs:end:token_portal_deposit
 
   // docs:start:token_portal_cancel
   /**

--- a/yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/token_bridge_contract/src/main.nr
@@ -45,6 +45,7 @@ contract TokenBridge {
         // let _callStackItem = context.call_public_function(context.this_address(), selector, [context.msg_sender()]);
     }
 
+    // docs:start:token_bridge_claim_public
     // Consumes a L1->L2 message and calls the token contract to mint the appropriate amount publicly
     #[aztec(public)]
     fn claim_public(
@@ -65,7 +66,9 @@ contract TokenBridge {
 
         1
     }
+    // docs:end:token_bridge_claim_public
 
+    // docs:start:token_bridge_exit_public
     // Burns the appropriate amount of tokens and creates a L2 to L1 withdraw message publicly
     // Requires `msg.sender` to give approval to the bridge to burn tokens on their behalf using witness signatures 
     #[aztec(public)]
@@ -86,7 +89,9 @@ contract TokenBridge {
    
         1
     }
+    // docs:end:token_bridge_exit_public
 
+    // docs:start:token_bridge_claim_private
     // Consumes a L1->L2 message and calls the token contract to mint the appropriate amount in private assets
     // User needs to call token.redeem_shield() to get the private assets
     #[aztec(private)]
@@ -113,7 +118,9 @@ contract TokenBridge {
 
         1
     }
+    // docs:end:token_bridge_claim_private
 
+    // docs:start:token_bridge_exit_private
     // Burns the appropriate amount of tokens and creates a L2 to L1 withdraw message privately
     // Requires `msg.sender` (caller of the method) to give approval to the bridge to burn tokens on their behalf using witness signatures 
     #[aztec(private)]
@@ -136,6 +143,7 @@ contract TokenBridge {
 
         1
     }
+    // docs:end:token_bridge_exit_private
     
     // /// Unconstrained /// 
 


### PR DESCRIPTION
Poprtal had updates with new deposit and cancel flows so wanted to update the docs

Similarly removed references to non_native_token in docs now that we have the token bridge!