### PR TITLE
chore: Run quick-start guide in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1024,6 +1024,16 @@ jobs:
           name: "Test"
           command: cond_run_script end-to-end ./scripts/run_tests_local sample-dapp ./scripts/docker-compose-e2e-sandbox.yml
 
+  guides-up-quick-start:
+    machine:
+      image: ubuntu-2004:202010-01
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Test"
+          command: cond_run_script end-to-end ./scripts/run_tests_local guides/up_quick_start.test.ts ./scripts/docker-compose-e2e-sandbox.yml
+
   e2e-canary-test:
     machine:
       image: ubuntu-2004:202010-01
@@ -1499,6 +1509,7 @@ workflows:
       - guides-writing-an-account-contract: *e2e_test
       - guides-dapp-testing: *e2e_test
       - guides-sample-dapp: *e2e_test
+      - guides-up-quick-start: *e2e_test
 
       - e2e-end:
           requires:
@@ -1535,6 +1546,7 @@ workflows:
             - guides-writing-an-account-contract
             - guides-dapp-testing
             - guides-sample-dapp
+            - guides-up-quick-start
           <<: *defaults
 
         # Deployment and Canary tests

--- a/yarn-project/end-to-end/src/guides/up_quick_start.test.ts
+++ b/yarn-project/end-to-end/src/guides/up_quick_start.test.ts
@@ -8,6 +8,9 @@ describe('guides/up_quick_start', () => {
     await waitForSandbox();
     // eslint-disable-next-line no-console
     console.log(`Sandbox ready`);
-    execSync(`PATH=$PATH:../node_modules/.bin ./src/guides/up_quick_start.sh`, { shell: '/bin/bash', stdio: 'pipe' });
+    execSync(`DEBUG="aztec:*" PATH=$PATH:../node_modules/.bin ./src/guides/up_quick_start.sh`, {
+      shell: '/bin/bash',
+      stdio: 'pipe',
+    });
   }, 90_000);
 });

--- a/yarn-project/end-to-end/src/guides/up_quick_start.test.ts
+++ b/yarn-project/end-to-end/src/guides/up_quick_start.test.ts
@@ -1,0 +1,8 @@
+import { execSync } from 'child_process';
+
+// Entrypoint for running the up-quick-start script on the CI
+describe('guides/up_quick_start', () => {
+  it('works', () => {
+    execSync(`PATH=$PATH:../node_modules/.bin ./src/guides/up_quick_start.sh`, { shell: '/bin/bash', stdio: 'pipe' });
+  }, 90_000);
+});

--- a/yarn-project/end-to-end/src/guides/up_quick_start.test.ts
+++ b/yarn-project/end-to-end/src/guides/up_quick_start.test.ts
@@ -6,11 +6,12 @@ import { execSync } from 'child_process';
 describe('guides/up_quick_start', () => {
   it('works', async () => {
     await waitForSandbox();
-    // eslint-disable-next-line no-console
-    console.log(`Sandbox ready`);
-    execSync(`DEBUG="aztec:*" PATH=$PATH:../node_modules/.bin ./src/guides/up_quick_start.sh`, {
-      shell: '/bin/bash',
-      stdio: 'pipe',
-    });
+    execSync(
+      `DEBUG="aztec:*" AZTEC_RPC_HOST=\${SANDBOX_URL:-http://localhost:8080} PATH=$PATH:../node_modules/.bin ./src/guides/up_quick_start.sh`,
+      {
+        shell: '/bin/bash',
+        stdio: 'pipe',
+      },
+    );
   }, 90_000);
 });

--- a/yarn-project/end-to-end/src/guides/up_quick_start.test.ts
+++ b/yarn-project/end-to-end/src/guides/up_quick_start.test.ts
@@ -1,8 +1,11 @@
+import { waitForSandbox } from '@aztec/aztec.js';
+
 import { execSync } from 'child_process';
 
 // Entrypoint for running the up-quick-start script on the CI
 describe('guides/up_quick_start', () => {
-  it('works', () => {
+  it('works', async () => {
+    await waitForSandbox();
     execSync(`PATH=$PATH:../node_modules/.bin ./src/guides/up_quick_start.sh`, { shell: '/bin/bash', stdio: 'pipe' });
   }, 90_000);
 });

--- a/yarn-project/end-to-end/src/guides/up_quick_start.test.ts
+++ b/yarn-project/end-to-end/src/guides/up_quick_start.test.ts
@@ -6,6 +6,8 @@ import { execSync } from 'child_process';
 describe('guides/up_quick_start', () => {
   it('works', async () => {
     await waitForSandbox();
+    // eslint-disable-next-line no-console
+    console.log(`Sandbox ready`);
     execSync(`PATH=$PATH:../node_modules/.bin ./src/guides/up_quick_start.sh`, { shell: '/bin/bash', stdio: 'pipe' });
   }, 90_000);
 });


### PR DESCRIPTION
So that it doesn't run out of sync [again](https://github.com/AztecProtocol/aztec-packages/pull/2412).