### PR TITLE
feat(bb): avoid initializing CRS for `bb info` command

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -332,6 +332,13 @@ int main(int argc, char* argv[])
         std::string vk_path = getOption(args, "-k", "./target/vk");
         CRS_PATH = getOption(args, "-c", "./crs");
         bool recursive = flagPresent(args, "-r") || flagPresent(args, "--recursive");
+
+        // Skip CRS initialization for any command which doesn't require the CRS.
+        if (command == "info") {
+            std::string output_path = getOption(args, "-o", "info.json");
+            acvmInfo(output_path);
+        }
+
         init();
 
         if (command == "prove_and_verify") {
@@ -355,9 +362,6 @@ int main(int argc, char* argv[])
         } else if (command == "vk_as_fields") {
             std::string output_path = getOption(args, "-o", vk_path + "_fields.json");
             vkAsFields(vk_path, output_path);
-        } else if (command == "info") {
-            std::string output_path = getOption(args, "-o", "info.json");
-            acvmInfo(output_path);
         } else {
             std::cerr << "Unknown command: " << command << "\n";
             return 1;

--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -337,6 +337,7 @@ int main(int argc, char* argv[])
         if (command == "info") {
             std::string output_path = getOption(args, "-o", "info.json");
             acvmInfo(output_path);
+            return 0;
         }
 
         init();


### PR DESCRIPTION
This PR executes the `bb info` command before we initialize the CRS as it doesn't require it. This avoids having to read a large amount of data from file / download from AWS when it is unnecessary.
