### PR TITLE
fix(docs): Fix imports in token contract tutorial

### DIFF
--- a/docs/docs/dev_docs/getting_started/token_contract_tutorial.md
+++ b/docs/docs/dev_docs/getting_started/token_contract_tutorial.md
@@ -257,10 +257,10 @@ contract Token {
         },
         oracle::compute_selector::compute_selector,
         auth::{assert_valid_message_for, assert_valid_public_message_for}
+        types::address::AztecAddress,
     };
 
-    use crate::types::{AztecAddress, TransparentNote, TransparentNoteMethods, TRANSPARENT_NOTE_LEN};
-    use crate::account_interface::AccountContract;
+    use crate::types::{TransparentNote, TransparentNoteMethods, TRANSPARENT_NOTE_LEN};
     use crate::util::{compute_message_hash};
 ```
 


### PR DESCRIPTION
Quick fix. We should use `include_code` everywhere instead.