### PR TITLE
feat: restore latest block number

### DIFF
--- a/yarn-project/archiver/src/archiver/config.ts
+++ b/yarn-project/archiver/src/archiver/config.ts
@@ -41,6 +41,11 @@ export interface ArchiverConfig {
    * The deployed L1 contract addresses
    */
   l1Contracts: L1ContractAddresses;
+
+  /**
+   * Optional dir to store data. If omitted will store in memory.
+   */
+  dataDirectory?: string;
 }
 
 /**
@@ -59,6 +64,7 @@ export function getConfigEnvVars(): ArchiverConfig {
     API_KEY,
     INBOX_CONTRACT_ADDRESS,
     REGISTRY_CONTRACT_ADDRESS,
+    DATA_DIRECTORY,
   } = process.env;
   // Populate the relevant addresses for use by the archiver.
   const addresses: L1ContractAddresses = {
@@ -78,5 +84,6 @@ export function getConfigEnvVars(): ArchiverConfig {
     searchStartBlock: SEARCH_START_BLOCK ? +SEARCH_START_BLOCK : 0,
     apiKey: API_KEY,
     l1Contracts: addresses,
+    dataDirectory: DATA_DIRECTORY,
   };
 }

--- a/yarn-project/aztec-node/package.json
+++ b/yarn-project/aztec-node/package.json
@@ -53,6 +53,7 @@
     "@jest/globals": "^29.5.0",
     "@rushstack/eslint-patch": "^1.1.4",
     "@types/jest": "^29.5.0",
+    "@types/leveldown": "^4.0.4",
     "@types/levelup": "^5.1.2",
     "@types/memdown": "^3.0.0",
     "@types/node": "^18.7.23",

--- a/yarn-project/aztec-node/src/aztec-node/db.ts
+++ b/yarn-project/aztec-node/src/aztec-node/db.ts
@@ -1,0 +1,60 @@
+import { LevelDown, default as leveldown } from 'leveldown';
+import { LevelUp, default as levelup } from 'levelup';
+import { MemDown, default as memdown } from 'memdown';
+import { join } from 'node:path';
+
+import { AztecNodeConfig } from './config.js';
+
+export const createMemDown = () => (memdown as any)() as MemDown<any, any>;
+export const createLevelDown = (path: string) => (leveldown as any)(path) as LevelDown;
+
+const DB_SUBDIR = 'aztec-node';
+const NODE_METADATA_KEY = '@@aztec_node_metadata';
+
+/**
+ * The metadata for an aztec node.
+ */
+type NodeMetadata = {
+  /**
+   * The address of the rollup contract on L1
+   */
+  rollupContractAddress: string;
+};
+
+/**
+ * Opens the database for the aztec node.
+ * @param config - The configuration to be used by the aztec node.
+ * @returns The database for the aztec node.
+ */
+export async function openDb(config: AztecNodeConfig): Promise<LevelUp> {
+  const nodeMetadata: NodeMetadata = {
+    rollupContractAddress: config.l1Contracts.rollupAddress.toString(),
+  };
+
+  const db = levelup(config.dataDirectory ? createLevelDown(join(config.dataDirectory, DB_SUBDIR)) : createMemDown());
+  const prevNodeMetadata = await getNodeMetadata(db);
+
+  // if the rollup addresses are different, wipe the local database and start over
+  if (nodeMetadata.rollupContractAddress !== prevNodeMetadata.rollupContractAddress) {
+    await db.clear();
+  }
+
+  await db.put(NODE_METADATA_KEY, JSON.stringify(nodeMetadata));
+  return db;
+}
+
+/**
+ * Gets the metadata for the aztec node.
+ * @param db - The database for the aztec node.
+ * @returns Node metadata.
+ */
+async function getNodeMetadata(db: LevelUp): Promise<NodeMetadata> {
+  try {
+    const value: Buffer = await db.get(NODE_METADATA_KEY);
+    return JSON.parse(value.toString('utf-8'));
+  } catch {
+    return {
+      rollupContractAddress: '',
+    };
+  }
+}

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -57,6 +57,7 @@
     "lodash.times": "^4.3.2",
     "lodash.zip": "^4.2.0",
     "lodash.zipwith": "^4.2.0",
+    "memdown": "^6.1.1",
     "puppeteer": "^21.3.4",
     "string-argv": "^0.3.2",
     "ts-jest": "^29.1.0",
@@ -68,6 +69,7 @@
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.1.4",
     "@types/lodash.compact": "^3.0.7",
+    "@types/memdown": "^3.0.2",
     "concurrently": "^7.6.0"
   },
   "files": [

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -47,6 +47,7 @@
     "@types/lodash.times": "^4.3.7",
     "@types/lodash.zip": "^4.2.7",
     "@types/lodash.zipwith": "^4.2.7",
+    "@types/memdown": "^3.0.3",
     "@types/node": "^18.7.23",
     "jest": "^29.5.0",
     "koa": "^2.14.2",
@@ -69,7 +70,6 @@
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.1.4",
     "@types/lodash.compact": "^3.0.7",
-    "@types/memdown": "^3.0.2",
     "concurrently": "^7.6.0"
   },
   "files": [

--- a/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
@@ -1,4 +1,4 @@
-import { createMemDown, getConfigEnvVars } from '@aztec/aztec-node';
+import { getConfigEnvVars } from '@aztec/aztec-node';
 import {
   AztecAddress,
   GlobalVariables,
@@ -33,6 +33,7 @@ import { MerkleTreeOperations, MerkleTrees } from '@aztec/world-state';
 
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import { default as levelup } from 'levelup';
+import { default as memdown } from 'memdown';
 import {
   Address,
   Chain,
@@ -123,7 +124,7 @@ describe('L1Publisher integration', () => {
       publicClient,
     });
 
-    builderDb = await MerkleTrees.new(levelup(createMemDown())).then(t => t.asLatest());
+    builderDb = await MerkleTrees.new(levelup((memdown as any)())).then(t => t.asLatest());
     const vks = getVerificationKeys();
     const simulator = await WasmRollupCircuitSimulator.new();
     const prover = new EmptyRollupProver();

--- a/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
@@ -33,7 +33,7 @@ import { MerkleTreeOperations, MerkleTrees } from '@aztec/world-state';
 
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import { default as levelup } from 'levelup';
-import { default as memdown } from 'memdown';
+import memdown from 'memdown';
 import {
   Address,
   Chain,

--- a/yarn-project/world-state/package.json
+++ b/yarn-project/world-state/package.json
@@ -48,6 +48,7 @@
     "@types/memdown": "^3.0.0",
     "@types/node": "^18.7.23",
     "jest": "^29.5.0",
+    "memdown": "^6.1.1",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -133,6 +133,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@rushstack/eslint-patch": ^1.1.4
     "@types/jest": ^29.5.0
+    "@types/leveldown": ^4.0.4
     "@types/levelup": ^5.1.2
     "@types/memdown": ^3.0.0
     "@types/node": ^18.7.23
@@ -386,6 +387,7 @@ __metadata:
     "@types/lodash.times": ^4.3.7
     "@types/lodash.zip": ^4.2.7
     "@types/lodash.zipwith": ^4.2.7
+    "@types/memdown": ^3.0.2
     "@types/node": ^18.7.23
     concurrently: ^7.6.0
     jest: ^29.5.0
@@ -397,6 +399,7 @@ __metadata:
     lodash.times: ^4.3.2
     lodash.zip: ^4.2.0
     lodash.zipwith: ^4.2.0
+    memdown: ^6.1.1
     puppeteer: ^21.3.4
     string-argv: ^0.3.2
     ts-jest: ^29.1.0
@@ -4486,6 +4489,16 @@ __metadata:
     "@types/abstract-leveldown": "*"
     "@types/node": "*"
   checksum: 0a476bd8d3c71266fdb323875d3312bf7828d6ab9f1bf9882a0ff93d04044660e45cd211ca8ec34c5665eaa773f98fe9fee14235792835bd06cb68192fe44669
+  languageName: node
+  linkType: hard
+
+"@types/leveldown@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@types/leveldown@npm:4.0.4"
+  dependencies:
+    "@types/abstract-leveldown": "*"
+    "@types/node": "*"
+  checksum: 630b2d2d1c48f83d14ab0f6c03ad2af1c427675c3692873c4fd3d673bde4140eabc028ce5736ad3d76aeea20769cf53df6f83468a4f0cf28f6d04dbb435edf48
   languageName: node
   linkType: hard
 

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -387,7 +387,7 @@ __metadata:
     "@types/lodash.times": ^4.3.7
     "@types/lodash.zip": ^4.2.7
     "@types/lodash.zipwith": ^4.2.7
-    "@types/memdown": ^3.0.2
+    "@types/memdown": ^3.0.3
     "@types/node": ^18.7.23
     concurrently: ^7.6.0
     jest: ^29.5.0
@@ -4708,6 +4708,15 @@ __metadata:
   dependencies:
     "@types/abstract-leveldown": "*"
   checksum: bfc36240e32ed6f82b2b858be88aa8814e8c1e0a8922aae8bf44ce07a2c9e0e7bf867e01cab8aad10e1cab2d0bcb0b800b4f63b89d9c791328892acc00683469
+  languageName: node
+  linkType: hard
+
+"@types/memdown@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "@types/memdown@npm:3.0.3"
+  dependencies:
+    "@types/abstract-leveldown": "*"
+  checksum: 9aa311838574b51e4334878102c80c6abc0e1ec14fe00f98c6ee812f3e6b24db53de632e0f763692730e0147e5c41add0ac4257c3deb3dc7abce176708ed73a4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the `WorldStateSynchroniser` to save and restore the last L2 block it has seen.

Fix #2357 

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [x] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
