### PR TITLE
test: no private key account state

### DIFF
--- a/yarn-project/aztec-rpc/src/synchronizer/synchronizer.ts
+++ b/yarn-project/aztec-rpc/src/synchronizer/synchronizer.ts
@@ -247,15 +247,18 @@ export class Synchronizer {
    * @returns True if the account is fully synched, false otherwise.
    * @remarks Checks whether all the notes from all the blocks have been processed. If it is not the case, the
    *          retrieved information from contracts might be old/stale (e.g. old token balance).
+   * @throws If checking a sync status of account which is not registered.
    */
   public async isAccountStateSynchronized(account: AztecAddress) {
     const completeAddress = await this.db.getCompleteAddress(account);
     if (!completeAddress) {
-      return false;
+      throw new Error(`Checking if account is synched is not possible for ${account} because it is not registered.`);
     }
     const processor = this.noteProcessors.find(x => x.publicKey.equals(completeAddress.publicKey));
     if (!processor) {
-      return false;
+      throw new Error(
+        `Checking if account is synched is not possible for ${account} because it is only registered as a recipient.`,
+      );
     }
     return await processor.isSynchronized();
   }

--- a/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
@@ -72,9 +72,12 @@ describe('e2e_2_rpc_servers', () => {
     tokenAddress: AztecAddress,
     owner: AztecAddress,
     expectedBalance: bigint,
+    checkIfSynchronized = true,
   ) => {
-    // First wait until the corresponding RPC server has synchronized the account
-    await awaitUserSynchronized(wallet, owner);
+    if (checkIfSynchronized) {
+      // First wait until the corresponding RPC server has synchronized the account
+      await awaitUserSynchronized(wallet, owner);
+    }
 
     // Then check the balance
     const contractWithWallet = await TokenContract.at(tokenAddress, wallet);
@@ -203,7 +206,7 @@ describe('e2e_2_rpc_servers', () => {
     expect(storedValue).toBe(newValueToSet);
   });
 
-  it.only('private state is "zero" when Aztec RPC Server does not have the account private key', async () => {
+  it('private state is "zero" when Aztec RPC Server does not have the account private key', async () => {
     const userABalance = 100n;
     const userBBalance = 150n;
 
@@ -227,19 +230,17 @@ describe('e2e_2_rpc_servers', () => {
     // Mint tokens to user B
     await mintTokens(contractWithWalletA, userB.address, userBBalance);
 
-    // Ensure that both servers are synchronized
-    await awaitServerSynchronized(aztecRpcServerA);
-    await awaitServerSynchronized(aztecRpcServerB);
-
     // Check that user A balance is 100 on server A
     await expectTokenBalance(walletA, completeTokenAddress.address, userA.address, userABalance);
     // Check that user B balance is 150 on server B
     await expectTokenBalance(walletB, completeTokenAddress.address, userB.address, userBBalance);
 
     // CHECK THAT PRIVATE BALANCES ARE 0 WHEN ACCOUNT'S PRIVATE KEYS ARE NOT REGISTERED
+    // Note: Not checking if the account is synchronized because it is not registered as an account (it would throw).
+    const checkIfSynchronized = false;
     // Check that user A balance is 0 on server B
-    await expectTokenBalance(walletB, completeTokenAddress.address, userA.address, 0n);
+    await expectTokenBalance(walletB, completeTokenAddress.address, userA.address, 0n, checkIfSynchronized);
     // Check that user B balance is 0 on server A
-    await expectTokenBalance(walletA, completeTokenAddress.address, userB.address, 0n);
+    await expectTokenBalance(walletA, completeTokenAddress.address, userB.address, 0n, checkIfSynchronized);
   });
 });

--- a/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
@@ -123,7 +123,7 @@ describe('e2e_2_rpc_servers', () => {
     // Add account A to wallet B
     await aztecRpcServerB.registerRecipient(userA);
 
-    // Add token to RPC server B
+    // Add token to RPC server B (RPC server A already has it because it was deployed through it)
     await aztecRpcServerB.addContracts([
       {
         abi: TokenContract.abi,
@@ -218,7 +218,7 @@ describe('e2e_2_rpc_servers', () => {
     // Add account A to wallet B
     await aztecRpcServerB.registerRecipient(userA);
 
-    // Add token to RPC server B
+    // Add token to RPC server B (RPC server A already has it because it was deployed through it)
     await aztecRpcServerB.addContracts([
       {
         abi: TokenContract.abi,

--- a/yarn-project/types/src/interfaces/aztec_rpc.ts
+++ b/yarn-project/types/src/interfaces/aztec_rpc.ts
@@ -241,6 +241,7 @@ export interface AztecRPC {
    * @deprecated Use `getSyncStatus` instead.
    * @remarks Checks whether all the notes from all the blocks have been processed. If it is not the case, the
    * retrieved information from contracts might be old/stale (e.g. old token balance).
+   * @throws If checking a sync status of account which is not registered.
    */
   isAccountStateSynchronized(account: AztecAddress): Promise<boolean>;
 


### PR DESCRIPTION
Fixes #2458 

> Note: Now the Synchronizer throws if we request a sync status for account which is not registered. I think this is the correct behavior because when a dev requests this info for unregistered account it would probably be a mistake even though returning false there is correct (unregistered account is technically not synchronized).

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
