### PR TITLE
chore: Refactor e2e test teardown

### DIFF
--- a/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_rpc_servers.test.ts
@@ -26,6 +26,7 @@ describe('e2e_2_rpc_servers', () => {
   let userA: CompleteAddress;
   let userB: CompleteAddress;
   let logger: DebugLogger;
+  let teardownA: () => Promise<void>;
 
   beforeEach(async () => {
     // this test can't be run against the sandbox as it requires 2 RPC servers
@@ -39,6 +40,7 @@ describe('e2e_2_rpc_servers', () => {
       accounts,
       wallets: [walletA],
       logger,
+      teardown: teardownA,
     } = await setup(1));
     [userA] = accounts;
 
@@ -51,13 +53,8 @@ describe('e2e_2_rpc_servers', () => {
   }, 100_000);
 
   afterEach(async () => {
-    await aztecNode?.stop();
-    if (aztecRpcServerA instanceof AztecRPCServer) {
-      await aztecRpcServerA?.stop();
-    }
-    if (aztecRpcServerB instanceof AztecRPCServer) {
-      await aztecRpcServerB?.stop();
-    }
+    await teardownA();
+    if (aztecRpcServerB instanceof AztecRPCServer) await aztecRpcServerB.stop();
   });
 
   const awaitUserSynchronized = async (wallet: Wallet, owner: AztecAddress) => {

--- a/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
+++ b/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
@@ -1,4 +1,3 @@
-import { AztecRPCServer } from '@aztec/aztec-rpc';
 import {
   AccountContract,
   AccountManager,
@@ -45,12 +44,7 @@ function itShouldBehaveLikeAnAccountContract(
       child = await ChildContract.deploy(wallet).send().deployed();
     }, 60_000);
 
-    afterEach(async () => {
-      await context.aztecNode?.stop();
-      if (context.aztecRpcServer instanceof AztecRPCServer) {
-        await context.aztecRpcServer.stop();
-      }
-    });
+    afterEach(() => context.teardown());
 
     it('calls a private function', async () => {
       const { logger } = context;

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -1,5 +1,3 @@
-import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecRPCServer } from '@aztec/aztec-rpc';
 import { BatchCall, ContractDeployer, Fr, Wallet, isContractDeployed } from '@aztec/aztec.js';
 import { CircuitsWasm } from '@aztec/circuits.js';
 import { pedersenPlookupCommitInputs } from '@aztec/circuits.js/barretenberg';
@@ -13,24 +11,19 @@ import times from 'lodash.times';
 import { setup } from './fixtures/utils.js';
 
 describe('e2e_block_building', () => {
-  let aztecNode: AztecNodeService | undefined;
   let aztecRpcServer: AztecRPC;
   let logger: DebugLogger;
   let wallet: Wallet;
+  let teardown: () => Promise<void>;
 
   describe('multi-txs block', () => {
     const abi = TestContractAbi;
 
     beforeAll(async () => {
-      ({ aztecNode, aztecRpcServer, logger, wallet } = await setup(1));
+      ({ teardown, aztecRpcServer, logger, wallet } = await setup(1));
     }, 100_000);
 
-    afterAll(async () => {
-      await aztecNode?.stop();
-      if (aztecRpcServer instanceof AztecRPCServer) {
-        await aztecRpcServer?.stop();
-      }
-    });
+    afterAll(() => teardown());
 
     it('assembles a block with multiple txs', async () => {
       // Assemble N contract deployment txs
@@ -63,18 +56,14 @@ describe('e2e_block_building', () => {
   // Regressions for https://github.com/AztecProtocol/aztec-packages/issues/2502
   describe('double-spends on the same block', () => {
     let contract: TestContract;
+    let teardown: () => Promise<void>;
 
     beforeAll(async () => {
-      ({ aztecNode, aztecRpcServer, logger, wallet } = await setup(1));
+      ({ teardown, aztecRpcServer, logger, wallet } = await setup(1));
       contract = await TestContract.deploy(wallet).send().deployed();
     }, 100_000);
 
-    afterAll(async () => {
-      await aztecNode?.stop();
-      if (aztecRpcServer instanceof AztecRPCServer) {
-        await aztecRpcServer?.stop();
-      }
-    });
+    afterAll(() => teardown());
 
     it('drops tx with private nullifier already emitted on the same block', async () => {
       const nullifier = Fr.random();

--- a/yarn-project/end-to-end/src/e2e_card_game.test.ts
+++ b/yarn-project/end-to-end/src/e2e_card_game.test.ts
@@ -1,5 +1,3 @@
-import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecRPCServer } from '@aztec/aztec-rpc';
 import { AccountWallet, AztecAddress, Wallet, deployInitialSandboxAccounts } from '@aztec/aztec.js';
 import { DebugLogger } from '@aztec/foundation/log';
 import { CardGameContract } from '@aztec/noir-contracts/types';
@@ -46,9 +44,9 @@ function unwrapOptions<T>(options: NoirOption<T>[]): T[] {
 const GAME_ID = 42;
 
 describe('e2e_card_game', () => {
-  let aztecNode: AztecNodeService | undefined;
   let aztecRpcServer: AztecRPC;
   let logger: DebugLogger;
+  let teardown: () => Promise<void>;
 
   let wallets: AccountWallet[];
   let firstPlayerWallet: Wallet;
@@ -66,19 +64,14 @@ describe('e2e_card_game', () => {
   beforeEach(async () => {
     // Card stats are derived from the users' private keys, so to get consistent values, we set up the
     // initial sandbox accounts that always use the same private keys, instead of random ones.
-    ({ aztecNode, aztecRpcServer, logger } = await setup(0));
+    ({ aztecRpcServer, logger, teardown } = await setup(0));
     wallets = await Promise.all((await deployInitialSandboxAccounts(aztecRpcServer)).map(a => a.account.getWallet()));
     [firstPlayerWallet, secondPlayerWallet, thirdPlayerWallet] = wallets;
     [firstPlayer, secondPlayer, thirdPlayer] = wallets.map(a => a.getAddress());
     await deployContract();
   }, 100_000);
 
-  afterEach(async () => {
-    await aztecNode?.stop();
-    if (aztecRpcServer instanceof AztecRPCServer) {
-      await aztecRpcServer?.stop();
-    }
-  });
+  afterEach(() => teardown());
 
   const deployContract = async () => {
     logger(`Deploying L2 contract...`);

--- a/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
@@ -1,5 +1,4 @@
-import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecRPCServer, EthAddress } from '@aztec/aztec-rpc';
+import { EthAddress } from '@aztec/aztec-rpc';
 import { CheatCodes, Wallet } from '@aztec/aztec.js';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { TestContract } from '@aztec/noir-contracts/types';
@@ -10,10 +9,10 @@ import { Account, Chain, HttpTransport, PublicClient, WalletClient, getAddress, 
 import { setup } from './fixtures/utils.js';
 
 describe('e2e_cheat_codes', () => {
-  let aztecNode: AztecNodeService | undefined;
   let aztecRpcServer: AztecRPC;
   let wallet: Wallet;
   let cc: CheatCodes;
+  let teardown: () => Promise<void>;
 
   let walletClient: WalletClient<HttpTransport, Chain, Account>;
   let publicClient: PublicClient<HttpTransport, Chain>;
@@ -21,19 +20,14 @@ describe('e2e_cheat_codes', () => {
 
   beforeAll(async () => {
     let deployL1ContractsValues;
-    ({ aztecNode, aztecRpcServer, wallet, cheatCodes: cc, deployL1ContractsValues } = await setup());
+    ({ teardown, aztecRpcServer, wallet, cheatCodes: cc, deployL1ContractsValues } = await setup());
 
     walletClient = deployL1ContractsValues.walletClient;
     publicClient = deployL1ContractsValues.publicClient;
     rollupAddress = deployL1ContractsValues.rollupAddress;
   }, 100_000);
 
-  afterAll(async () => {
-    await aztecNode?.stop();
-    if (aztecRpcServer instanceof AztecRPCServer) {
-      await aztecRpcServer?.stop();
-    }
-  });
+  afterAll(() => teardown());
 
   describe('L1 only', () => {
     describe('mine', () => {

--- a/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
@@ -1,5 +1,3 @@
-import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecRPCServer } from '@aztec/aztec-rpc';
 import { AztecAddress, Contract, ContractDeployer, Fr, Wallet, isContractDeployed } from '@aztec/aztec.js';
 import { CompleteAddress, getContractDeploymentInfo } from '@aztec/circuits.js';
 import { DebugLogger } from '@aztec/foundation/log';
@@ -9,22 +7,17 @@ import { AztecRPC, TxStatus } from '@aztec/types';
 import { setup } from './fixtures/utils.js';
 
 describe('e2e_deploy_contract', () => {
-  let aztecNode: AztecNodeService | undefined;
   let aztecRpcServer: AztecRPC;
   let accounts: CompleteAddress[];
   let logger: DebugLogger;
   let wallet: Wallet;
+  let teardown: () => Promise<void>;
 
   beforeEach(async () => {
-    ({ aztecNode, aztecRpcServer, accounts, logger, wallet } = await setup());
+    ({ aztecRpcServer, accounts, logger, wallet } = await setup());
   }, 100_000);
 
-  afterEach(async () => {
-    await aztecNode?.stop();
-    if (aztecRpcServer instanceof AztecRPCServer) {
-      await aztecRpcServer?.stop();
-    }
-  });
+  afterEach(() => teardown());
 
   /**
    * Milestone 1.1.

--- a/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
@@ -14,7 +14,7 @@ describe('e2e_deploy_contract', () => {
   let teardown: () => Promise<void>;
 
   beforeEach(async () => {
-    ({ aztecRpcServer, accounts, logger, wallet } = await setup());
+    ({ teardown, aztecRpcServer, accounts, logger, wallet } = await setup());
   }, 100_000);
 
   afterEach(() => teardown());

--- a/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
@@ -1,5 +1,4 @@
 import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecRPCServer } from '@aztec/aztec-rpc';
 import { AztecAddress, Wallet, computeMessageSecretHash, generatePublicKey, getSchnorrAccount } from '@aztec/aztec.js';
 import { Fr, GrumpkinScalar } from '@aztec/circuits.js';
 import { DebugLogger } from '@aztec/foundation/log';
@@ -14,6 +13,7 @@ describe('e2e_multiple_accounts_1_enc_key', () => {
   const wallets: Wallet[] = [];
   const accounts: AztecAddress[] = [];
   let logger: DebugLogger;
+  let teardown: () => Promise<void>;
 
   let tokenAddress: AztecAddress;
 
@@ -21,7 +21,7 @@ describe('e2e_multiple_accounts_1_enc_key', () => {
   const numAccounts = 3;
 
   beforeEach(async () => {
-    ({ aztecNode, aztecRpcServer, logger } = await setup(0));
+    ({ teardown, aztecNode, aztecRpcServer, logger } = await setup(0));
 
     const encryptionPrivateKey = GrumpkinScalar.random();
 
@@ -58,12 +58,7 @@ describe('e2e_multiple_accounts_1_enc_key', () => {
     );
   }, 100_000);
 
-  afterEach(async () => {
-    await aztecNode?.stop();
-    if (aztecRpcServer instanceof AztecRPCServer) {
-      await aztecRpcServer?.stop();
-    }
-  });
+  afterEach(() => teardown());
 
   const expectBalance = async (userIndex: number, expectedBalance: bigint) => {
     const wallet = wallets[userIndex];

--- a/yarn-project/end-to-end/src/e2e_nested_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_nested_contract.test.ts
@@ -1,5 +1,3 @@
-import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecRPCServer } from '@aztec/aztec-rpc';
 import { AztecAddress, BatchCall, Fr, Wallet } from '@aztec/aztec.js';
 import { toBigIntBE } from '@aztec/foundation/bigint-buffer';
 import { DebugLogger } from '@aztec/foundation/log';
@@ -10,21 +8,16 @@ import { AztecRPC, L2BlockL2Logs } from '@aztec/types';
 import { setup } from './fixtures/utils.js';
 
 describe('e2e_nested_contract', () => {
-  let aztecNode: AztecNodeService | undefined;
   let aztecRpcServer: AztecRPC;
   let wallet: Wallet;
   let logger: DebugLogger;
+  let teardown: () => Promise<void>;
 
   beforeEach(async () => {
-    ({ aztecNode, aztecRpcServer, wallet, logger } = await setup());
+    ({ teardown, aztecRpcServer, wallet, logger } = await setup());
   }, 100_000);
 
-  afterEach(async () => {
-    await aztecNode?.stop();
-    if (aztecRpcServer instanceof AztecRPCServer) {
-      await aztecRpcServer?.stop();
-    }
-  });
+  afterEach(() => teardown());
 
   describe('parent manually calls child', () => {
     let parentContract: ParentContract;

--- a/yarn-project/end-to-end/src/e2e_ordering.test.ts
+++ b/yarn-project/end-to-end/src/e2e_ordering.test.ts
@@ -1,6 +1,4 @@
 // Test suite for testing proper ordering of side effects
-import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecRPCServer } from '@aztec/aztec-rpc';
 import { Wallet } from '@aztec/aztec.js';
 import { Fr, FunctionSelector } from '@aztec/circuits.js';
 import { toBigIntBE } from '@aztec/foundation/bigint-buffer';
@@ -12,9 +10,9 @@ import { setup } from './fixtures/utils.js';
 
 // See https://github.com/AztecProtocol/aztec-packages/issues/1601
 describe('e2e_ordering', () => {
-  let aztecNode: AztecNodeService | undefined;
   let aztecRpcServer: AztecRPC;
   let wallet: Wallet;
+  let teardown: () => Promise<void>;
 
   const expectLogsFromLastBlockToBe = async (logMessages: bigint[]) => {
     const l2BlockNum = await aztecRpcServer.getBlockNumber();
@@ -26,15 +24,10 @@ describe('e2e_ordering', () => {
   };
 
   beforeEach(async () => {
-    ({ aztecNode, aztecRpcServer, wallet } = await setup());
+    ({ teardown, aztecRpcServer, wallet } = await setup());
   }, 100_000);
 
-  afterEach(async () => {
-    await aztecNode?.stop();
-    if (aztecRpcServer instanceof AztecRPCServer) {
-      await aztecRpcServer?.stop();
-    }
-  });
+  afterEach(() => teardown());
 
   describe('with parent and child contract', () => {
     let parent: ParentContract;

--- a/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
@@ -11,7 +11,7 @@ import { Grumpkin } from '@aztec/circuits.js/barretenberg';
 import { DebugLogger } from '@aztec/foundation/log';
 import { TestContractAbi } from '@aztec/noir-contracts/artifacts';
 import { BootstrapNode, P2PConfig, createLibP2PPeerId, exportLibP2PPeerIdToString } from '@aztec/p2p';
-import { AztecRPC, TxStatus } from '@aztec/types';
+import { TxStatus } from '@aztec/types';
 
 import { setup } from './fixtures/utils.js';
 
@@ -28,21 +28,14 @@ interface NodeContext {
 }
 
 describe('e2e_p2p_network', () => {
-  let aztecNode: AztecNodeService | undefined;
-  let aztecRpcServer: AztecRPC;
   let config: AztecNodeConfig;
   let logger: DebugLogger;
-
+  let teardown: () => Promise<void>;
   beforeEach(async () => {
-    ({ aztecNode, aztecRpcServer, config, logger } = await setup(0));
+    ({ teardown, config, logger } = await setup(0));
   }, 100_000);
 
-  afterEach(async () => {
-    await aztecNode?.stop();
-    if (aztecRpcServer instanceof AztecRPCServer) {
-      await aztecRpcServer?.stop();
-    }
-  });
+  afterEach(() => teardown());
 
   it('should rollup txs from all peers', async () => {
     // create the bootstrap node for the network

--- a/yarn-project/end-to-end/src/e2e_pending_commitments_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_pending_commitments_contract.test.ts
@@ -1,33 +1,26 @@
 import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecRPCServer } from '@aztec/aztec-rpc';
 import { AztecAddress, Fr, Wallet } from '@aztec/aztec.js';
 import { DebugLogger } from '@aztec/foundation/log';
 import { PendingCommitmentsContract } from '@aztec/noir-contracts/types';
-import { AztecRPC, CompleteAddress, TxStatus } from '@aztec/types';
+import { CompleteAddress, TxStatus } from '@aztec/types';
 
 import { setup } from './fixtures/utils.js';
 
 describe('e2e_pending_commitments_contract', () => {
   let aztecNode: AztecNodeService | undefined;
-  let aztecRpcServer: AztecRPC;
   let wallet: Wallet;
   let logger: DebugLogger;
   let owner: AztecAddress;
-
+  let teardown: () => Promise<void>;
   let contract: PendingCommitmentsContract;
 
   beforeEach(async () => {
     let accounts: CompleteAddress[];
-    ({ aztecNode, aztecRpcServer, accounts, wallet, logger } = await setup(2));
+    ({ teardown, aztecNode, accounts, wallet, logger } = await setup(2));
     owner = accounts[0].address;
   }, 100_000);
 
-  afterEach(async () => {
-    await aztecNode?.stop();
-    if (aztecRpcServer instanceof AztecRPCServer) {
-      await aztecRpcServer?.stop();
-    }
-  });
+  afterEach(() => teardown());
 
   const expectCommitmentsSquashedExcept = async (exceptFirstFew: number) => {
     const blockNum = await aztecNode!.getBlockNumber();

--- a/yarn-project/end-to-end/src/e2e_private_airdrop.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_airdrop.test.ts
@@ -1,6 +1,4 @@
-import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecRPCServer } from '@aztec/aztec-rpc';
-import { AztecRPC, CompleteAddress, TxHash, Wallet } from '@aztec/aztec.js';
+import { CompleteAddress, TxHash, Wallet } from '@aztec/aztec.js';
 import { Fr, MAX_NEW_COMMITMENTS_PER_CALL } from '@aztec/circuits.js';
 import { DebugLogger } from '@aztec/foundation/log';
 import { PrivateTokenAirdropContract } from '@aztec/noir-contracts/types';
@@ -23,16 +21,15 @@ describe('private airdrop', () => {
   const initialSupply = 1000n;
   const claimsStorageSlot = new Fr(2n);
 
-  let aztecNode: AztecNodeService | undefined;
-  let aztecRpcServer: AztecRPC;
   let wallets: Wallet[];
   let contracts: PrivateTokenAirdropContract[];
   let accounts: CompleteAddress[];
   let claims: Claim[];
   let logger: DebugLogger;
+  let teardown: () => Promise<void>;
 
   beforeEach(async () => {
-    ({ aztecNode, aztecRpcServer, accounts, wallets, logger } = await setup(numberOfAccounts));
+    ({ teardown, accounts, wallets, logger } = await setup(numberOfAccounts));
 
     logger(`Deploying zk token contract...`);
     const owner = accounts[0].address;
@@ -45,12 +42,7 @@ describe('private airdrop', () => {
     }
   }, 100_000);
 
-  afterEach(async () => {
-    await aztecNode?.stop();
-    if (aztecRpcServer instanceof AztecRPCServer) {
-      await aztecRpcServer?.stop();
-    }
-  }, 30_000);
+  afterEach(() => teardown());
 
   const expectBalance = async (accountIndex: number, expectedBalance: bigint) => {
     const account = accounts[accountIndex].address;

--- a/yarn-project/end-to-end/src/e2e_private_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_token_contract.test.ts
@@ -1,35 +1,28 @@
 import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecRPCServer } from '@aztec/aztec-rpc';
 import { AztecAddress, Wallet } from '@aztec/aztec.js';
 import { DebugLogger } from '@aztec/foundation/log';
 import { PrivateTokenContract } from '@aztec/noir-contracts/types';
-import { AztecRPC, CompleteAddress, TxStatus } from '@aztec/types';
+import { CompleteAddress, TxStatus } from '@aztec/types';
 
 import { expectsNumOfEncryptedLogsInTheLastBlockToBe, setup } from './fixtures/utils.js';
 
 describe('e2e_private_token_contract', () => {
   let aztecNode: AztecNodeService | undefined;
-  let aztecRpcServer: AztecRPC;
   let wallet: Wallet;
   let logger: DebugLogger;
   let owner: AztecAddress;
   let receiver: AztecAddress;
-
+  let teardown: () => Promise<void>;
   let contract: PrivateTokenContract;
 
   beforeEach(async () => {
     let accounts: CompleteAddress[];
-    ({ aztecNode, aztecRpcServer, accounts, wallet, logger } = await setup(2));
+    ({ teardown, aztecNode, accounts, wallet, logger } = await setup(2));
     owner = accounts[0].address;
     receiver = accounts[1].address;
   }, 100_000);
 
-  afterEach(async () => {
-    await aztecNode?.stop();
-    if (aztecRpcServer instanceof AztecRPCServer) {
-      await aztecRpcServer?.stop();
-    }
-  });
+  afterEach(() => teardown());
 
   const expectBalance = async (owner: AztecAddress, expectedBalance: bigint) => {
     const balance = await contract.methods.getBalance(owner).view({ from: owner });

--- a/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
@@ -1,19 +1,16 @@
-import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecRPCServer } from '@aztec/aztec-rpc';
 import { AccountWallet, AztecAddress } from '@aztec/aztec.js';
 import { Fr, FunctionSelector } from '@aztec/circuits.js';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { DebugLogger } from '@aztec/foundation/log';
 import { TokenBridgeContract, TokenContract } from '@aztec/noir-contracts/types';
-import { AztecRPC, TxStatus } from '@aztec/types';
+import { TxStatus } from '@aztec/types';
 
 import { CrossChainTestHarness } from './fixtures/cross_chain_test_harness.js';
 import { delay, hashPayload, setup } from './fixtures/utils.js';
 
 describe('e2e_public_cross_chain_messaging', () => {
-  let aztecNode: AztecNodeService | undefined;
-  let aztecRpcServer: AztecRPC;
   let logger: DebugLogger;
+  let teardown: () => Promise<void>;
 
   let ownerWallet: AccountWallet;
   let user2Wallet: AccountWallet;
@@ -33,6 +30,7 @@ describe('e2e_public_cross_chain_messaging', () => {
       accounts,
       wallets,
       logger: logger_,
+      teardown: teardown_,
       cheatCodes,
     } = await setup(2);
     crossChainTestHarness = await CrossChainTestHarness.new(
@@ -49,8 +47,7 @@ describe('e2e_public_cross_chain_messaging', () => {
     ownerEthAddress = crossChainTestHarness.ethAccount;
     ownerAddress = crossChainTestHarness.ownerAddress;
     outbox = crossChainTestHarness.outbox;
-    aztecRpcServer = crossChainTestHarness.aztecRpcServer;
-    aztecNode = aztecNode_;
+    teardown = teardown_;
     ownerWallet = wallets[0];
     user2Wallet = wallets[1];
 
@@ -59,10 +56,7 @@ describe('e2e_public_cross_chain_messaging', () => {
   }, 100_000);
 
   afterEach(async () => {
-    await aztecNode?.stop();
-    if (aztecRpcServer instanceof AztecRPCServer) {
-      await aztecRpcServer?.stop();
-    }
+    await teardown();
     await crossChainTestHarness?.stop();
   });
 

--- a/yarn-project/end-to-end/src/e2e_public_to_private_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_to_private_messaging.test.ts
@@ -1,6 +1,4 @@
-import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecRPCServer } from '@aztec/aztec-rpc';
-import { AztecAddress, AztecRPC } from '@aztec/aztec.js';
+import { AztecAddress } from '@aztec/aztec.js';
 import { EthAddress } from '@aztec/circuits.js';
 import { DebugLogger } from '@aztec/foundation/log';
 
@@ -8,9 +6,8 @@ import { CrossChainTestHarness } from './fixtures/cross_chain_test_harness.js';
 import { delay, setup } from './fixtures/utils.js';
 
 describe('e2e_public_to_private_messaging', () => {
-  let aztecNode: AztecNodeService | undefined;
-  let aztecRpcServer: AztecRPC;
   let logger: DebugLogger;
+  let teardown: () => Promise<void>;
 
   let ethAccount: EthAddress;
 
@@ -29,6 +26,7 @@ describe('e2e_public_to_private_messaging', () => {
       wallet,
       logger: logger_,
       cheatCodes,
+      teardown: teardown_,
     } = await setup(2);
     crossChainTestHarness = await CrossChainTestHarness.new(
       aztecNode_,
@@ -43,18 +41,14 @@ describe('e2e_public_to_private_messaging', () => {
     ethAccount = crossChainTestHarness.ethAccount;
     ownerAddress = crossChainTestHarness.ownerAddress;
     underlyingERC20 = crossChainTestHarness.underlyingERC20;
-    aztecRpcServer = crossChainTestHarness.aztecRpcServer;
-    aztecNode = aztecNode_;
 
+    teardown = teardown_;
     logger = logger_;
     logger('Successfully deployed contracts and initialized portal');
   }, 100_000);
 
   afterEach(async () => {
-    await aztecNode?.stop();
-    if (aztecRpcServer instanceof AztecRPCServer) {
-      await aztecRpcServer?.stop();
-    }
+    await teardown();
     await crossChainTestHarness?.stop();
   });
 

--- a/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_token_contract.test.ts
@@ -1,5 +1,3 @@
-import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecRPCServer } from '@aztec/aztec-rpc';
 import { AztecAddress, Wallet } from '@aztec/aztec.js';
 import { DebugLogger } from '@aztec/foundation/log';
 import { PublicTokenContract } from '@aztec/noir-contracts/types';
@@ -10,11 +8,11 @@ import times from 'lodash.times';
 import { expectUnencryptedLogsFromLastBlockToBe, setup } from './fixtures/utils.js';
 
 describe('e2e_public_token_contract', () => {
-  let aztecNode: AztecNodeService | undefined;
   let aztecRpcServer: AztecRPC;
   let wallet: Wallet;
   let logger: DebugLogger;
   let recipient: AztecAddress;
+  let teardown: () => Promise<void>;
 
   let contract: PublicTokenContract;
 
@@ -28,16 +26,11 @@ describe('e2e_public_token_contract', () => {
 
   beforeEach(async () => {
     let accounts: CompleteAddress[];
-    ({ aztecNode, aztecRpcServer, accounts, wallet, logger } = await setup());
+    ({ teardown, aztecRpcServer, accounts, wallet, logger } = await setup());
     recipient = accounts[0].address;
   }, 100_000);
 
-  afterEach(async () => {
-    await aztecNode?.stop();
-    if (aztecRpcServer instanceof AztecRPCServer) {
-      await aztecRpcServer?.stop();
-    }
-  });
+  afterEach(() => teardown());
 
   it('should deploy a public token contract', async () => {
     const { txReceipt } = await deployContract();

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -1,5 +1,10 @@
 import { AztecNodeConfig, AztecNodeService, getConfigEnvVars } from '@aztec/aztec-node';
-import { RpcServerConfig, createAztecRPCServer, getConfigEnvVars as getRpcConfigEnvVars } from '@aztec/aztec-rpc';
+import {
+  AztecRPCServer,
+  RpcServerConfig,
+  createAztecRPCServer,
+  getConfigEnvVars as getRpcConfigEnvVars,
+} from '@aztec/aztec-rpc';
 import {
   AccountWallet,
   AztecAddress,
@@ -211,6 +216,10 @@ export async function setup(
    * The cheat codes.
    */
   cheatCodes: CheatCodes;
+  /**
+   * Function to stop the started services.
+   */
+  teardown: () => Promise<void>;
 }> {
   const config = getConfigEnvVars();
 
@@ -238,6 +247,11 @@ export async function setup(
 
   const cheatCodes = await CheatCodes.create(config.rpcUrl, aztecRpcServer!);
 
+  const teardown = async () => {
+    await aztecNode?.stop();
+    if (aztecRpcServer instanceof AztecRPCServer) await aztecRpcServer?.stop();
+  };
+
   return {
     aztecNode,
     aztecRpcServer,
@@ -248,6 +262,7 @@ export async function setup(
     wallets,
     logger,
     cheatCodes,
+    teardown,
   };
 }
 

--- a/yarn-project/end-to-end/src/guides/writing_an_account_contract.test.ts
+++ b/yarn-project/end-to-end/src/guides/writing_an_account_contract.test.ts
@@ -1,4 +1,3 @@
-import { AztecRPCServer } from '@aztec/aztec-rpc';
 import {
   AccountManager,
   AuthWitnessProvider,
@@ -48,12 +47,7 @@ describe('guides/writing_an_account_contract', () => {
     context = await setup(0);
   }, 60_000);
 
-  afterEach(async () => {
-    await context.aztecNode?.stop();
-    if (context.aztecRpcServer instanceof AztecRPCServer) {
-      await context.aztecRpcServer.stop();
-    }
-  });
+  afterEach(() => context.teardown());
 
   it('works', async () => {
     const { aztecRpcServer: rpc, logger } = context;

--- a/yarn-project/end-to-end/src/integration_archiver_l1_to_l2.test.ts
+++ b/yarn-project/end-to-end/src/integration_archiver_l1_to_l2.test.ts
@@ -1,7 +1,6 @@
 import { Archiver } from '@aztec/archiver';
-import { AztecNodeConfig, AztecNodeService } from '@aztec/aztec-node';
-import { AztecRPCServer } from '@aztec/aztec-rpc';
-import { AztecAddress, AztecRPC, CompleteAddress, Wallet, computeMessageSecretHash } from '@aztec/aztec.js';
+import { AztecNodeConfig } from '@aztec/aztec-node';
+import { AztecAddress, CompleteAddress, Wallet, computeMessageSecretHash } from '@aztec/aztec.js';
 import { DeployL1Contracts } from '@aztec/ethereum';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
@@ -14,12 +13,11 @@ import { delay, deployAndInitializeNonNativeL2TokenContracts, setNextBlockTimest
 
 // TODO (#2291) - Replace with token bridge standard
 describe('archiver integration with l1 to l2 messages', () => {
-  let aztecNode: AztecNodeService | undefined;
-  let aztecRpcServer: AztecRPC;
   let wallet: Wallet;
   let archiver: Archiver;
   let logger: DebugLogger;
   let config: AztecNodeConfig;
+  let teardown: () => Promise<void>;
 
   let l2Contract: NonNativeTokenContract;
   let ethAccount: EthAddress;
@@ -36,7 +34,7 @@ describe('archiver integration with l1 to l2 messages', () => {
   beforeEach(async () => {
     let deployL1ContractsValues: DeployL1Contracts | undefined;
     let accounts: CompleteAddress[];
-    ({ aztecNode, aztecRpcServer, wallet, deployL1ContractsValues, accounts, config, logger } = await setup(2));
+    ({ teardown, wallet, deployL1ContractsValues, accounts, config, logger } = await setup(2));
     archiver = await Archiver.createAndSync(config);
 
     const walletClient = deployL1ContractsValues.walletClient;
@@ -66,10 +64,7 @@ describe('archiver integration with l1 to l2 messages', () => {
 
   afterEach(async () => {
     await archiver.stop();
-    await aztecNode?.stop();
-    if (aztecRpcServer instanceof AztecRPCServer) {
-      await aztecRpcServer?.stop();
-    }
+    await teardown();
   }, 30_000);
 
   const expectBalance = async (owner: AztecAddress, expectedBalance: bigint) => {

--- a/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
+++ b/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
@@ -1,5 +1,4 @@
 import { AztecNodeService } from '@aztec/aztec-node';
-import { AztecRPCServer } from '@aztec/aztec-rpc';
 import { AztecAddress, CheatCodes, Fr, Wallet } from '@aztec/aztec.js';
 import { DeployL1Contracts, deployL1Contract } from '@aztec/ethereum';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -38,6 +37,7 @@ describe.skip('uniswap_trade_on_l1_from_l2', () => {
   let accounts: CompleteAddress[];
   let logger: DebugLogger;
   let cheatCodes: CheatCodes;
+  let teardown: () => Promise<void>;
 
   let ethAccount: EthAddress;
   let owner: AztecAddress;
@@ -53,10 +53,8 @@ describe.skip('uniswap_trade_on_l1_from_l2', () => {
 
   beforeEach(async () => {
     let deployL1ContractsValues: DeployL1Contracts;
-    ({ aztecNode, aztecRpcServer, deployL1ContractsValues, accounts, logger, wallet, cheatCodes } = await setup(
-      2,
-      dumpedState,
-    ));
+    ({ teardown, aztecNode, aztecRpcServer, deployL1ContractsValues, accounts, logger, wallet, cheatCodes } =
+      await setup(2, dumpedState));
 
     const walletClient = deployL1ContractsValues.walletClient;
     const publicClient = deployL1ContractsValues.publicClient;
@@ -121,10 +119,7 @@ describe.skip('uniswap_trade_on_l1_from_l2', () => {
   }, 100_000);
 
   afterEach(async () => {
-    await aztecNode?.stop();
-    if (aztecRpcServer instanceof AztecRPCServer) {
-      await aztecRpcServer?.stop();
-    }
+    await teardown();
     await wethCrossChainHarness.stop();
     await daiCrossChainHarness.stop();
   });


### PR DESCRIPTION
Removes the repeated teardown snippet that stopped the aztec node and rpc server in favor of a callback returned by the `setup` method itself.