### PR TITLE
fix: nightly subrepo mirror

### DIFF
--- a/.github/workflows/mirror_repos.yml
+++ b/.github/workflows/mirror_repos.yml
@@ -6,9 +6,6 @@
 # action failing due to upstream changes, a manual resolution
 # PR with ./scripts/git_subrepo.sh pull will be needed.
 name: Mirror Repositories
-
-concurrency:
-  group: mirror-repositories
 on:
   schedule:
     # Run the workflow every night at 2:00 AM UTC.
@@ -38,6 +35,8 @@ jobs:
 
   mirror-to-build-system-repo:
     runs-on: ubuntu-latest
+    # Force sequential.
+    needs: mirror-to-docs-repo
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -59,6 +58,8 @@ jobs:
 
   mirror-to-barretenberg-repo:
     runs-on: ubuntu-latest
+    # Force sequential.
+    needs: mirror-to-build-system-repo
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -80,6 +81,8 @@ jobs:
 
   mirror-to-aztec-nr-repo:
     runs-on: ubuntu-latest
+    # Force sequential.
+    needs: mirror-to-barretenberg-repo
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/barretenberg/.gitrepo
+++ b/barretenberg/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/AztecProtocol/barretenberg
-	branch = main
-	commit = 7edb1644d0ae472a70fc3554b7d2cfc6c5496168
-	parent = 9f1a3a5e4b72506489645f8be8c8aa5129a2e179
+	branch = master
+	commit = 16c9bec3e171dd4704ba641735a28f0bf340d564
+	parent = b62c4de76264a4fa214c4a61841ef7199f970fde
 	method = merge
 	cmdver = 0.4.6

--- a/barretenberg/.gitrepo
+++ b/barretenberg/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/AztecProtocol/barretenberg
 	branch = main
-	commit = ae9f99c3caf0213882d843577374b03871cc7092
-	parent = c8a5cfb375b498475503c12cc83fcdba39f2ec5f
+	commit = 7edb1644d0ae472a70fc3554b7d2cfc6c5496168
+	parent = 9f1a3a5e4b72506489645f8be8c8aa5129a2e179
 	method = merge
 	cmdver = 0.4.6

--- a/build-system/.gitrepo
+++ b/build-system/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/AztecProtocol/build-system
 	branch = master
-	commit = 138c4eab1574d71c26f386a866f453a540802a06
-	parent = 1368b55d0a9bc9ea61e29bb095ca62aa6902645f
+	commit = c57b25101e8f0f73533a62cf8f1b4e4b9739d1ea
+	parent = 5308c21d4dc225233af8ae584c471e7bed5d9381
 	method = merge
 	cmdver = 0.4.6

--- a/build-system/.gitrepo
+++ b/build-system/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/AztecProtocol/build-system
 	branch = master
-	commit = c57b25101e8f0f73533a62cf8f1b4e4b9739d1ea
-	parent = 5308c21d4dc225233af8ae584c471e7bed5d9381
+	commit = 28dbd553e75d68b74dec3c3749cefefe3f600028
+	parent = 5f158708d7a667769c3d318c652f37260b59ba0a
 	method = merge
 	cmdver = 0.4.6

--- a/build-system/scripts/setup_env
+++ b/build-system/scripts/setup_env
@@ -6,7 +6,7 @@
 # The script should be sourced from the root of the repository, e.g:
 #   source ./build-system/scripts/setup_env
 # This ensures the resultant variables are set in the calling shell.
-set -eu
+set -xeu
 
 COMMIT_HASH=$1
 COMMIT_TAG=${2##*aztec-packages-}

--- a/build-system/scripts/setup_env
+++ b/build-system/scripts/setup_env
@@ -6,7 +6,7 @@
 # The script should be sourced from the root of the repository, e.g:
 #   source ./build-system/scripts/setup_env
 # This ensures the resultant variables are set in the calling shell.
-set -xeu
+set -eu
 
 COMMIT_HASH=$1
 COMMIT_TAG=${2##*aztec-packages-}

--- a/docs/.gitrepo
+++ b/docs/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/AztecProtocol/docs
 	branch = main
-	commit = 7198cb9deea0635a4dc769b7eeb8cd29ed57e6d3
-	parent = 0c3a6271a1d90fa95a0163606e49f432573e66da
+	commit = 4e06fd2d8b43cca83eae9fb04947131e8e5ad091
+	parent = 6223a94d09b7aa1cce23ea13b589495e15830540
 	method = merge
 	cmdver = 0.4.6

--- a/docs/.gitrepo
+++ b/docs/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/AztecProtocol/docs
 	branch = main
-	commit = 20fe6bd3ec37c32516ddd799918f5f268279b506
-	parent = bf2651e714e148cdd0a625a435fe1ee64d762ffb
+	commit = 7198cb9deea0635a4dc769b7eeb8cd29ed57e6d3
+	parent = 0c3a6271a1d90fa95a0163606e49f432573e66da
 	method = merge
 	cmdver = 0.4.6


### PR DESCRIPTION
- Proper concurrency control on sequential gitrepo pushes to prevent further breakage
- Manually aligning each 'parent' in the .gitrepo files to be the parent of the last commit that was published, and each 'commit' to be the latest commit in each repo that we reference