### PR TITLE
fix: bootstrap.sh

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -16,17 +16,17 @@ set -eu
 
 yarn install --immutable
 
-# Run remake bindings before building Aztec.nr contracts or l1 contracts as they depend on files created by it.
-yarn --cwd circuits.js remake-bindings
-yarn --cwd circuits.js remake-constants
-
 # Build the necessary dependencies for Aztec.nr contracts typegen.
-for DIR in foundation noir-compiler circuits.js; do
+for DIR in foundation noir-compiler; do
   echo "Building $DIR..."
   cd $DIR
   yarn build
   cd ..
 done
+
+# Run remake bindings before building Aztec.nr contracts or l1 contracts as they depend on files created by it.
+yarn --cwd circuits.js remake-bindings
+yarn --cwd circuits.js remake-constants
 
 (cd noir-contracts && ./bootstrap.sh)
 (cd .. && l1-contracts/bootstrap.sh)


### PR DESCRIPTION
Running bootstrap.sh on a freshly cloned repo failed with:
<img width="940" alt="image" src="https://github.com/AztecProtocol/aztec-packages/assets/13470840/8df66cc1-6ce9-4183-a8a8-295af00d3e70">

The issue is that the `circuits.in.ts` is dependent on `foundation` package but we do not build it before remaking the bindings.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
