### PR TITLE
chore: Check tree roots in world state sync

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -266,6 +266,8 @@ export class Sequencer {
     const syncedBlocks = await Promise.all([
       this.worldState.status().then((s: WorldStateStatus) => s.syncedToL2Block),
       this.p2pClient.getStatus().then(s => s.syncedToL2Block),
+      this.l2BlockSource.getBlockNumber(),
+      this.l1ToL2MessageSource.getBlockNumber(),
     ]);
     const min = Math.min(...syncedBlocks);
     return min >= this.lastPublishedBlock;

--- a/yarn-project/types/src/contract_data.ts
+++ b/yarn-project/types/src/contract_data.ts
@@ -55,6 +55,12 @@ export interface ContractDataSource {
    * @returns The function's data.
    */
   getPublicFunction(address: AztecAddress, selector: FunctionSelector): Promise<EncodedContractFunction | undefined>;
+
+  /**
+   * Gets the number of the latest L2 block processed by the implementation.
+   * @returns The number of the latest L2 block processed by the implementation.
+   */
+  getBlockNumber(): Promise<number>;
 }
 
 /**

--- a/yarn-project/types/src/l1_to_l2_message.ts
+++ b/yarn-project/types/src/l1_to_l2_message.ts
@@ -21,6 +21,12 @@ export interface L1ToL2MessageSource {
    * @returns The confirmed L1 to L2 message (throws if not found)
    */
   getConfirmedL1ToL2Message(messageKey: Fr): Promise<L1ToL2Message>;
+
+  /**
+   * Gets the number of the latest L2 block processed by the implementation.
+   * @returns The number of the latest L2 block processed by the implementation.
+   */
+  getBlockNumber(): Promise<number>;
 }
 
 /**

--- a/yarn-project/types/src/logs/l2_logs_source.ts
+++ b/yarn-project/types/src/logs/l2_logs_source.ts
@@ -26,4 +26,10 @@ export interface L2LogsSource {
    * @returns A promise signalling completion of the stop process.
    */
   stop(): Promise<void>;
+
+  /**
+   * Gets the number of the latest L2 block processed by the implementation.
+   * @returns The number of the latest L2 block processed by the implementation.
+   */
+  getBlockNumber(): Promise<number>;
 }


### PR DESCRIPTION
Checks that the resulting roots on the world state sync match the ones on the retrieved L2 block after applying all tree changes. This is not fixing any issues I could reproduce, but is meant to be an extra sanity check to fail loudly if we hit it.

As a somewhat related change, this PR also forces the sequencer to wait on the L2 block and L1toL2 message sources to be synced before proceeding.

