### PR TITLE
fix: bump foundry version

### DIFF
--- a/l1-contracts/scripts/install_foundry.sh
+++ b/l1-contracts/scripts/install_foundry.sh
@@ -18,4 +18,4 @@ chmod +x $BIN_PATH
 export PATH=$FOUNDRY_BIN_DIR:$PATH
 
 # Use version.
-foundryup --version nightly-ac4e264fdb60aedc202d3ebebb37ef7edf8dcd69
+foundryup --version nightly-bdea91c79055e8adcf33e714984edba9a3e33d2a


### PR DESCRIPTION
Bump version of foundry to a newer version. The previous nightly tag didn't have any release binaries up on Github (maybe they got deleted by their CI?) so it was failing to install.

They have fixed the libc issue (see foundry-rs/foundry#5903) as well so we could potentially move back to installing latest but it might break again if they do decide to build on a newer Ubuntu version.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
