### PR TITLE
chore: Switch to upstream docusaurus-plugin-typedoc

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -123,7 +123,7 @@ const config = {
       },
     ],
     [
-      "@spalladino/docusaurus-plugin-typedoc",
+      "docusaurus-plugin-typedoc",
       {
         id: "apis/pxe",
         entryPoints: ["../yarn-project/types/src/interfaces/aztec_rpc.ts"],
@@ -135,7 +135,7 @@ const config = {
       },
     ],
     [
-      "@spalladino/docusaurus-plugin-typedoc",
+      "docusaurus-plugin-typedoc",
       {
         id: "apis/aztec-js",
         entryPoints: [

--- a/docs/package.json
+++ b/docs/package.json
@@ -37,9 +37,9 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.4.1",
-    "@spalladino/docusaurus-plugin-typedoc": "^0.20.3",
     "@tsconfig/docusaurus": "^1.0.5",
     "concurrently": "^8.0.1",
+    "docusaurus-plugin-typedoc": "^0.20.2",
     "nodemon": "^3.0.1",
     "typedoc": "^0.25.1",
     "typedoc-plugin-markdown": "^3.16.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1875,11 +1875,6 @@
     p-map "^4.0.0"
     webpack-sources "^3.2.2"
 
-"@spalladino/docusaurus-plugin-typedoc@^0.20.3":
-  version "0.20.3"
-  resolved "https://registry.yarnpkg.com/@spalladino/docusaurus-plugin-typedoc/-/docusaurus-plugin-typedoc-0.20.3.tgz#04e0f8db61b8328ab0b8d6d4bd43a59fb0cdbbdd"
-  integrity sha512-LufWGbOUbyztOgJY42UDeQ0bnpTqZBtdIL1duTaIMpNj1MM2N9F3QqQhmQY3J9SnqCnkMjZu13RnK/ninWbLLg==
-
 "@svgr/babel-plugin-add-jsx-attribute@^6.5.1":
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.5.1.tgz#74a5d648bd0347bda99d82409d87b8ca80b9a1ba"
@@ -3960,6 +3955,11 @@ dns-packet@^5.2.2:
   integrity sha512-EgqGeaBB8hLiHLZtp/IbaDQTL8pZ0+IvwzSHA6d7VyMDM+B9hgddEMa9xjK5oYnw0ci0JQ6g2XCD7/f6cafU6g==
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
+
+docusaurus-plugin-typedoc@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-typedoc/-/docusaurus-plugin-typedoc-0.20.2.tgz#fc355cbe436a65b1b09f1ec8943fd9d0f06bf365"
+  integrity sha512-AOEogRFMtU2Ud5Qfatxji/I9csu70CgvtUAMFGDklGJWdFJRqY2gqVFzye8iMw8/Y6/fhb39aCG31rvjcA6QFw==
 
 dom-converter@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
We were using a fork of `docusaurus-plugin-typedoc` due to a bugfix. Now that [the fix was merged upstream](https://github.com/tgreyuk/typedoc-plugin-markdown/pull/472), we can go back to the main version of the package.