### PR TITLE
feat: historic access data tree

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1200,6 +1200,7 @@ workflows:
 
       - e2e-2-pxes: *e2e_test
       - e2e-deploy-contract: *e2e_test
+      - e2e-stateful-test-contract: e2e_test
       - e2e-lending-contract: *e2e_test
       - e2e-token-contract: *e2e_test
       - e2e-private-airdrop: *e2e_test
@@ -1237,6 +1238,7 @@ workflows:
           requires:
             - e2e-2-pxes
             - e2e-deploy-contract
+            - e2e-stateful-test-contract
             - e2e-lending-contract
             - e2e-token-contract
             - e2e-private-airdrop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1200,7 +1200,7 @@ workflows:
 
       - e2e-2-pxes: *e2e_test
       - e2e-deploy-contract: *e2e_test
-      - e2e-stateful-test-contract: e2e_test
+      - e2e-stateful-test-contract: *e2e_test
       - e2e-lending-contract: *e2e_test
       - e2e-token-contract: *e2e_test
       - e2e-private-airdrop: *e2e_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -553,6 +553,18 @@ jobs:
           name: "Test"
           command: cond_run_script end-to-end ./scripts/run_tests_local e2e_deploy_contract.test.ts
 
+  e2e-stateful-test-contract:
+    machine:
+      image: ubuntu-2204:2023.07.2
+    resource_class: large
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Test"
+          command: cond_run_script end-to-end ./scripts/run_tests_local e2e_stateful_test_contract.test.ts
+
+
   e2e-lending-contract:
     machine:
       image: ubuntu-2204:2023.07.2

--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen_lookup.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen_lookup.cpp
@@ -173,12 +173,13 @@ grumpkin::fq hash_multiple(const std::vector<grumpkin::fq>& inputs, const size_t
     const size_t num_inputs = inputs.size();
 
     grumpkin::fq result = (pedersen_iv_table[hash_index]).x;
-    for (size_t i = 0; i < num_inputs; i++) {
+    result = hash_pair(result, num_inputs);
+    for (size_t i = 0; i < num_inputs - 1; i++) {
         result = hash_pair(result, inputs[i]);
     }
 
     auto final_result =
-        grumpkin::g1::affine_element(hash_single(result, false) + hash_single(grumpkin::fq(num_inputs), true));
+        grumpkin::g1::affine_element(hash_single(result, false) + hash_single(inputs[num_inputs - 1], true));
     return final_result.x;
 }
 

--- a/yarn-project/acir-simulator/src/acvm/oracle/oracle.ts
+++ b/yarn-project/acir-simulator/src/acvm/oracle/oracle.ts
@@ -4,6 +4,7 @@ import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr, Point } from '@aztec/foundation/fields';
 import { createDebugLogger } from '@aztec/foundation/log';
+import { MerkleTreeId } from '@aztec/types';
 
 import { ACVMField } from '../acvm.js';
 import { convertACVMFieldToBuffer, fromACVMField } from '../deserialize.js';
@@ -130,8 +131,9 @@ export class Oracle {
     return toAcvmL1ToL2MessageLoadOracleInputs(message, root);
   }
 
-  async getMembershipWitness([leafValue]: ACVMField[]): Promise<ACVMField[]> {
-    return (await this.typedOracle.getMembershipWitness(fromACVMField(leafValue))).map(toACVMField);
+  async getMembershipWitness([treeId]: ACVMField[], [leafValue]: ACVMField[]): Promise<ACVMField[]> {
+    const merkleTreeId: MerkleTreeId = Number(fromACVMField(treeId).toBigInt());
+    return (await this.typedOracle.getMembershipWitness(merkleTreeId, fromACVMField(leafValue))).map(toACVMField);
   }
 
   async getPortalContractAddress([aztecAddress]: ACVMField[]): Promise<ACVMField> {

--- a/yarn-project/acir-simulator/src/acvm/oracle/oracle.ts
+++ b/yarn-project/acir-simulator/src/acvm/oracle/oracle.ts
@@ -130,8 +130,8 @@ export class Oracle {
     return toAcvmL1ToL2MessageLoadOracleInputs(message, root);
   }
 
-  async getDataTreePath([commitment]: ACVMField[]): Promise<ACVMField[]> {
-    return (await this.typedOracle.getDataTreePath(fromACVMField(commitment))).map(toACVMField);
+  async getMembershipWitness([leafValue]: ACVMField[]): Promise<ACVMField[]> {
+    return (await this.typedOracle.getMembershipWitness(fromACVMField(leafValue))).map(toACVMField);
   }
 
   async getPortalContractAddress([aztecAddress]: ACVMField[]): Promise<ACVMField> {

--- a/yarn-project/acir-simulator/src/acvm/oracle/oracle.ts
+++ b/yarn-project/acir-simulator/src/acvm/oracle/oracle.ts
@@ -130,6 +130,10 @@ export class Oracle {
     return toAcvmL1ToL2MessageLoadOracleInputs(message, root);
   }
 
+  async getDataTreePath([commitment]: ACVMField[]): Promise<ACVMField[]> {
+    return (await this.typedOracle.getDataTreePath(fromACVMField(commitment))).map(toACVMField);
+  }
+
   async getPortalContractAddress([aztecAddress]: ACVMField[]): Promise<ACVMField> {
     const contractAddress = AztecAddress.fromString(aztecAddress);
     const portalContactAddress = await this.typedOracle.getPortalContractAddress(contractAddress);

--- a/yarn-project/acir-simulator/src/acvm/oracle/typed_oracle.ts
+++ b/yarn-project/acir-simulator/src/acvm/oracle/typed_oracle.ts
@@ -113,6 +113,10 @@ export abstract class TypedOracle {
     throw new Error('Not available.');
   }
 
+  getDataTreePath(_commitment: Fr): Promise<Fr[]> {
+    throw new Error('Not available.');
+  }
+
   getPortalContractAddress(_contractAddress: AztecAddress): Promise<EthAddress> {
     throw new Error('Not available.');
   }

--- a/yarn-project/acir-simulator/src/acvm/oracle/typed_oracle.ts
+++ b/yarn-project/acir-simulator/src/acvm/oracle/typed_oracle.ts
@@ -3,7 +3,7 @@ import { FunctionSelector } from '@aztec/foundation/abi';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr, GrumpkinScalar } from '@aztec/foundation/fields';
-import { CompleteAddress, PublicKey } from '@aztec/types';
+import { CompleteAddress, MerkleTreeId, PublicKey } from '@aztec/types';
 
 /**
  * Information about a note needed during execution.
@@ -113,7 +113,7 @@ export abstract class TypedOracle {
     throw new Error('Not available.');
   }
 
-  getMembershipWitness(_leafValue: Fr): Promise<Fr[]> {
+  getMembershipWitness(_treeId: MerkleTreeId, _leafValue: Fr): Promise<Fr[]> {
     throw new Error('Not available.');
   }
 

--- a/yarn-project/acir-simulator/src/acvm/oracle/typed_oracle.ts
+++ b/yarn-project/acir-simulator/src/acvm/oracle/typed_oracle.ts
@@ -113,7 +113,7 @@ export abstract class TypedOracle {
     throw new Error('Not available.');
   }
 
-  getDataTreePath(_commitment: Fr): Promise<Fr[]> {
+  getMembershipWitness(_commitment: Fr): Promise<Fr[]> {
     throw new Error('Not available.');
   }
 

--- a/yarn-project/acir-simulator/src/acvm/oracle/typed_oracle.ts
+++ b/yarn-project/acir-simulator/src/acvm/oracle/typed_oracle.ts
@@ -113,7 +113,7 @@ export abstract class TypedOracle {
     throw new Error('Not available.');
   }
 
-  getMembershipWitness(_commitment: Fr): Promise<Fr[]> {
+  getMembershipWitness(_leafValue: Fr): Promise<Fr[]> {
     throw new Error('Not available.');
   }
 

--- a/yarn-project/acir-simulator/src/client/client_execution_context.ts
+++ b/yarn-project/acir-simulator/src/client/client_execution_context.ts
@@ -349,7 +349,7 @@ export class ClientExecutionContext extends ViewDataOracle {
    */
   async callPrivateFunction(targetContractAddress: AztecAddress, functionSelector: FunctionSelector, argsHash: Fr) {
     this.log(
-      `Calling private function ${this.contractAddress}:${functionSelector} from ${this.callContext.storageContractAddress}`,
+      `Calling private function ${targetContractAddress}:${functionSelector} from ${this.callContext.storageContractAddress}`,
     );
 
     const targetAbi = await this.db.getFunctionABI(targetContractAddress, functionSelector);

--- a/yarn-project/acir-simulator/src/client/client_execution_context.ts
+++ b/yarn-project/acir-simulator/src/client/client_execution_context.ts
@@ -275,7 +275,7 @@ export class ClientExecutionContext extends ViewDataOracle {
       noteHashToLookUp = computeUniqueCommitment(wasm, nonce, noteHashToLookUp);
     }
 
-    const index = await this.db.getCommitmentIndex(noteHashToLookUp);
+    const index = await this.db.findCommitmentIndex(noteHashToLookUp.toBuffer());
     const exists = index !== undefined;
     if (exists) {
       this.gotNotes.set(noteHashToLookUp.value, index);

--- a/yarn-project/acir-simulator/src/client/db_oracle.ts
+++ b/yarn-project/acir-simulator/src/client/db_oracle.ts
@@ -3,6 +3,7 @@ import { FunctionAbi, FunctionDebugMetadata, FunctionSelector } from '@aztec/fou
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
+import { MerkleTreeId } from '@aztec/types';
 
 import { NoteData } from '../acvm/index.js';
 import { CommitmentsDB } from '../public/index.js';
@@ -84,4 +85,19 @@ export interface DBOracle extends CommitmentsDB {
    * @returns A Promise that resolves to a HistoricBlockData object.
    */
   getHistoricBlockData(): Promise<HistoricBlockData>;
+
+  /**
+   * Fetch the index of the leaf in the respective tree
+   * @param treeId - The id of the tree to search.
+   * @param leafValue - The leaf value buffer.
+   * @returns - The index of the leaf. Undefined if it does not exist in the tree.
+   */
+  findLeafIndex(treeId: MerkleTreeId, leafValue: Buffer): Promise<bigint | undefined>;
+
+  /**
+   * Fetch the sibling path of the leaf in the respective tree
+   * @param treeId - The id of the tree to search.
+   * @param leafIndex - The index of the leaf.
+   */
+  getSiblingPath(treeId: MerkleTreeId, leafIndex: bigint): Promise<Fr[]>;
 }

--- a/yarn-project/acir-simulator/src/client/private_execution.test.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.test.ts
@@ -382,7 +382,7 @@ describe('Private Execution test suite', () => {
       const nonce = new Fr(1n);
       const customNoteHash = hash([toBufferBE(amount, 32), secret.toBuffer()]);
       const innerNoteHash = Fr.fromBuffer(hash([storageSlot.toBuffer(), customNoteHash]));
-      oracle.getCommitmentIndex.mockResolvedValue(2n);
+      oracle.findCommitmentIndex.mockResolvedValue(2n);
 
       const result = await runSimulator({
         abi,
@@ -734,7 +734,7 @@ describe('Private Execution test suite', () => {
       const storageSlot = new Fr(2);
       const innerNoteHash = hash([storageSlot.toBuffer(), noteHash.toBuffer()]);
       const siloedNoteHash = siloCommitment(wasm, contractAddress, Fr.fromBuffer(innerNoteHash));
-      oracle.getCommitmentIndex.mockResolvedValue(0n);
+      oracle.findCommitmentIndex.mockResolvedValue(0n);
 
       const result = await runSimulator({
         abi,

--- a/yarn-project/acir-simulator/src/client/view_data_oracle.ts
+++ b/yarn-project/acir-simulator/src/client/view_data_oracle.ts
@@ -114,7 +114,7 @@ export class ViewDataOracle extends TypedOracle {
       noteHashToLookUp = computeUniqueCommitment(wasm, nonce, noteHashToLookUp);
     }
 
-    const index = await this.db.getCommitmentIndex(noteHashToLookUp);
+    const index = await this.db.findCommitmentIndex(noteHashToLookUp.toBuffer());
     return index !== undefined;
   }
 
@@ -126,6 +126,20 @@ export class ViewDataOracle extends TypedOracle {
   public async getL1ToL2Message(msgKey: Fr) {
     const message = await this.db.getL1ToL2Message(msgKey);
     return { ...message, root: this.historicBlockData.l1ToL2MessagesTreeRoot };
+  }
+
+  /**
+   * Fetches the index and data tree path for a commitment
+   * @param commitment - The commitment
+   * @returns The index and data tree path
+   */
+  public async getDataTreePath(commitment: Fr): Promise<Fr[]> {
+    const index = await this.db.findCommitmentIndex(commitment.toBuffer());
+    if (!index) {
+      throw new Error(`Commitment ${commitment} not found in private data tree`);
+    }
+    const path = await this.db.getDataTreePath(index);
+    return [new Fr(index), ...path.toFieldArray()];
   }
 
   /**

--- a/yarn-project/acir-simulator/src/client/view_data_oracle.ts
+++ b/yarn-project/acir-simulator/src/client/view_data_oracle.ts
@@ -130,13 +130,14 @@ export class ViewDataOracle extends TypedOracle {
 
   /**
    * Fetches the index and data tree path for a commitment
-   * @param commitment - The commitment
+   * @param leafValue - The commitment
    * @returns The index and data tree path
    */
-  public async getDataTreePath(commitment: Fr): Promise<Fr[]> {
-    const index = await this.db.findCommitmentIndex(commitment.toBuffer());
+  public async getMembershipWitness(leafValue: Fr): Promise<Fr[]> {
+    // @todo @lherskind #2572
+    const index = await this.db.findCommitmentIndex(leafValue.toBuffer());
     if (!index) {
-      throw new Error(`Commitment ${commitment} not found in private data tree`);
+      throw new Error(`Leaf value: ${leafValue} not found in private data tree`);
     }
     const path = await this.db.getDataTreePath(index);
     return [new Fr(index), ...path.toFieldArray()];

--- a/yarn-project/acir-simulator/src/public/db.ts
+++ b/yarn-project/acir-simulator/src/public/db.ts
@@ -1,7 +1,6 @@
 import { EthAddress, FunctionSelector } from '@aztec/circuits.js';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
-import { DataCommitmentProvider } from '@aztec/types';
 
 import { MessageLoadOracleInputs } from '../acvm/index.js';
 

--- a/yarn-project/acir-simulator/src/public/db.ts
+++ b/yarn-project/acir-simulator/src/public/db.ts
@@ -56,7 +56,7 @@ export interface PublicContractsDB {
 }
 
 /** Database interface for providing access to commitment tree and l1 to l2 messages tree (append only data trees). */
-export interface CommitmentsDB extends DataCommitmentProvider {
+export interface CommitmentsDB {
   /**
    * Gets a confirmed L1 to L2 message for the given message key.
    * TODO(Maddiaa): Can be combined with aztec-node method that does the same thing.
@@ -64,4 +64,11 @@ export interface CommitmentsDB extends DataCommitmentProvider {
    * @returns - The l1 to l2 message object
    */
   getL1ToL2Message(msgKey: Fr): Promise<MessageLoadOracleInputs>;
+
+  /**
+   * Find the index of the given commitment.
+   * @param leafValue - The value to search for.
+   * @returns The index of the given leaf of undefined if not found.
+   */
+  findCommitmentIndex(leafValue: Buffer): Promise<bigint | undefined>;
 }

--- a/yarn-project/acir-simulator/src/public/db.ts
+++ b/yarn-project/acir-simulator/src/public/db.ts
@@ -1,6 +1,7 @@
 import { EthAddress, FunctionSelector } from '@aztec/circuits.js';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
+import { DataCommitmentProvider } from '@aztec/types';
 
 import { MessageLoadOracleInputs } from '../acvm/index.js';
 
@@ -55,7 +56,7 @@ export interface PublicContractsDB {
 }
 
 /** Database interface for providing access to commitment tree and l1 to l2 messages tree (append only data trees). */
-export interface CommitmentsDB {
+export interface CommitmentsDB extends DataCommitmentProvider {
   /**
    * Gets a confirmed L1 to L2 message for the given message key.
    * TODO(Maddiaa): Can be combined with aztec-node method that does the same thing.
@@ -63,11 +64,4 @@ export interface CommitmentsDB {
    * @returns - The l1 to l2 message object
    */
   getL1ToL2Message(msgKey: Fr): Promise<MessageLoadOracleInputs>;
-
-  /**
-   * Gets the index of a commitment in the private data tree.
-   * @param commitment - The commitment.
-   * @returns - The index of the commitment. Undefined if it does not exist in the tree.
-   */
-  getCommitmentIndex(commitment: Fr): Promise<bigint | undefined>;
 }

--- a/yarn-project/acir-simulator/src/public/public_execution_context.ts
+++ b/yarn-project/acir-simulator/src/public/public_execution_context.ts
@@ -130,7 +130,7 @@ export class PublicExecutionContext extends TypedOracle {
     // Once public kernel or base rollup circuit injects nonces, this can be updated to use uniqueSiloedCommitment.
     const wasm = await CircuitsWasm.get();
     const siloedNoteHash = siloCommitment(wasm, this.execution.contractAddress, innerNoteHash);
-    const index = await this.commitmentsDb.getCommitmentIndex(siloedNoteHash);
+    const index = await this.commitmentsDb.findCommitmentIndex(siloedNoteHash.toBuffer());
     return index !== undefined;
   }
 

--- a/yarn-project/aztec-nr/aztec/src/messaging.nr
+++ b/yarn-project/aztec-nr/aztec/src/messaging.nr
@@ -5,7 +5,7 @@ use l1_to_l2_message_getter_data::make_l1_to_l2_message_getter_data;
 
 use crate::abi::PublicContextInputs;
 use crate::oracle::get_l1_to_l2_message::get_l1_to_l2_message_call;
-
+use dep::std::merkle::compute_merkle_root;
 
 // Returns the nullifier for the message
 fn process_l1_to_l2_message(l1_to_l2_root: Field, storage_contract_address: Field, msg_key: Field, content: Field, secret: Field) -> Field{
@@ -13,8 +13,13 @@ fn process_l1_to_l2_message(l1_to_l2_root: Field, storage_contract_address: Fiel
     let returned_message = get_l1_to_l2_message_call(msg_key);
     let l1_to_l2_message_data = make_l1_to_l2_message_getter_data(returned_message, 0, secret);
 
-    // Check tree roots against the inputs 
-    assert(l1_to_l2_message_data.root == l1_to_l2_root);
+    // Commitment should equal the msg_key if the message exsits and oracle is honest.
+    let commitment = l1_to_l2_message_data.message.message_hash();
+    assert(commitment == msg_key, "Data don't match the message key");
+    
+    // Validate that the commitment is indeed in the l1 to l2 message tree.
+    let root = compute_merkle_root(commitment, l1_to_l2_message_data.leaf_index, l1_to_l2_message_data.sibling_path);
+    assert(root == l1_to_l2_root, "Invalid root");
 
     // Validate this is the target contract
     assert(l1_to_l2_message_data.message.recipient == storage_contract_address);

--- a/yarn-project/aztec-nr/aztec/src/messaging.nr
+++ b/yarn-project/aztec-nr/aztec/src/messaging.nr
@@ -13,12 +13,12 @@ fn process_l1_to_l2_message(l1_to_l2_root: Field, storage_contract_address: Fiel
     let returned_message = get_l1_to_l2_message_call(msg_key);
     let l1_to_l2_message_data = make_l1_to_l2_message_getter_data(returned_message, 0, secret);
 
-    // Commitment should equal the msg_key if the message exsits and oracle is honest.
-    let commitment = l1_to_l2_message_data.message.message_hash();
-    assert(commitment == msg_key, "Data don't match the message key");
+    // leaf should equal the msg_key if the message exsits and oracle is honest.
+    let leaf = l1_to_l2_message_data.message.message_hash();
+    assert(leaf == msg_key, "Data don't match the message key");
     
     // Validate that the commitment is indeed in the l1 to l2 message tree.
-    let root = compute_merkle_root(commitment, l1_to_l2_message_data.leaf_index, l1_to_l2_message_data.sibling_path);
+    let root = compute_merkle_root(leaf, l1_to_l2_message_data.leaf_index, l1_to_l2_message_data.sibling_path);
     assert(root == l1_to_l2_root, "Invalid root");
 
     // Validate this is the target contract

--- a/yarn-project/end-to-end/src/e2e_stateful_test_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_stateful_test_contract.test.ts
@@ -93,9 +93,9 @@ describe('e2e_deploy_contract', () => {
     expect(isIncludedReceipt.status).toEqual(TxStatus.MINED);
 
     const badValueNote = { ...valueNote, owner: 100n };
-    const badCommitment = new Fr(await statefulContract.methods.get_commitment(badValueNote).view());
+    const badLeafValue = new Fr(await statefulContract.methods.get_commitment(badValueNote).view());
     await expect(statefulContract.methods.is_included_in_history(badValueNote).simulate()).rejects.toThrowError(
-      `Commitment ${badCommitment} not found in private data tree`,
+      `Leaf value: ${badLeafValue} not found in private data tree`,
     );
   }, 30_000);
 });

--- a/yarn-project/end-to-end/src/e2e_stateful_test_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_stateful_test_contract.test.ts
@@ -1,0 +1,101 @@
+/* eslint-disable camelcase */
+import { AztecNodeConfig, AztecNodeService, getConfigEnvVars } from '@aztec/aztec-node';
+import { CheatCodes, Fr, Wallet } from '@aztec/aztec.js';
+import { CircuitsWasm, CompleteAddress } from '@aztec/circuits.js';
+import { pedersenHashInputs, pedersenPlookupCommitInputs } from '@aztec/circuits.js/barretenberg';
+import { DebugLogger } from '@aztec/foundation/log';
+import { StatefulTestContract } from '@aztec/noir-contracts/types';
+import { PXE } from '@aztec/types';
+
+import { setup } from './fixtures/utils.js';
+
+describe('e2e_deploy_contract', () => {
+  let aztecNode: AztecNodeService | undefined;
+  let pxe: PXE;
+  let accounts: CompleteAddress[];
+  let logger: DebugLogger;
+  let wallet: Wallet;
+  let teardown: () => Promise<void>;
+  let cheatCodes: CheatCodes;
+
+  let statefulContract: StatefulTestContract;
+
+  beforeEach(async () => {
+    ({ teardown, aztecNode, pxe, accounts, logger, wallet, cheatCodes } = await setup());
+    statefulContract = await StatefulTestContract.deploy(wallet, accounts[0].address, 1).send().deployed();
+  }, 100_000);
+
+  afterEach(() => teardown());
+
+  it('Try to get a witness', async () => {
+    if (!aztecNode) {
+      throw new Error('No aztec node');
+    }
+    const owner = accounts[0].address;
+
+    console.log(`Historic: ${(await aztecNode.getHistoricBlockData()).privateDataTreeRoot.toBigInt()}`);
+
+    const tx = statefulContract.methods.create_note(owner, 99n).send();
+    const receipt = await tx.wait();
+
+    const storageSlot = cheatCodes.aztec.computeSlotInMap(1n, owner);
+    const notes = await pxe.getPrivateStorageAt(owner, statefulContract.address, storageSlot);
+    const note = notes[1];
+
+    const nonces = await pxe.getNoteNonces(statefulContract.address, storageSlot, note, receipt.txHash);
+
+    const valueNote = {
+      value: note.items[0],
+      owner: note.items[1],
+      randomness: note.items[2],
+      header: {
+        contract_address: statefulContract.address,
+        nonce: nonces[0],
+        storage_slot: storageSlot,
+      },
+    };
+
+    const commitment = new Fr(await statefulContract.methods.get_commitment(valueNote).view());
+    console.log(`Commitment: ${commitment}`);
+
+    const index = await aztecNode.findCommitmentIndex(commitment.toBuffer());
+    console.log(`Index: ${index}`);
+
+    const circuitsWasm = await CircuitsWasm.get();
+    // pedersenPlookupCommitInputs
+    // const h = (a: Fr, b: Fr) => Fr.fromBuffer(pedersenPlookupCommitInputs(circuitsWasm, [a.toBuffer(), b.toBuffer()]));
+    const h = (a: Fr, b: Fr) => Fr.fromBuffer(pedersenHashInputs(circuitsWasm, [a.toBuffer(), b.toBuffer()]));
+
+    const path = await statefulContract.methods.get_path(valueNote).view();
+    console.log(`Path: `, path);
+
+    const historic = await aztecNode.getHistoricBlockData();
+    const root = await statefulContract.methods.get_root(valueNote).view();
+    console.log(`Historic: ${historic.privateDataTreeRoot.toBigInt()}, our computed: ${root}`);
+
+    // Computing the root from path, using the `pedersenHashInputs`
+    // crypto::pedersen_hash::lookup::hash_multiple function.
+    // Noir is using:
+    // crypto::pedersen_commitment::lookup::compress_native
+    const rootFromPath = (leaf: Fr, index: bigint, path: any[]) => {
+      const temps: bigint[] = [];
+      let node = leaf;
+      let i = index;
+      for (const sibling of path) {
+        if (i % 2n === 0n) {
+          node = h(node, new Fr(sibling));
+        } else {
+          node = h(new Fr(sibling), node);
+        }
+
+        temps.push(node.toBigInt());
+        i /= 2n;
+      }
+      console.log(temps);
+      return node;
+    };
+
+    const myRoot = rootFromPath(commitment, index ?? 0n, path.slice());
+    console.log(`Historic: ${historic.privateDataTreeRoot.toBigInt()}, myroot: ${myRoot.toBigInt()}`);
+  });
+});

--- a/yarn-project/end-to-end/src/e2e_stateful_test_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_stateful_test_contract.test.ts
@@ -4,7 +4,7 @@ import { CheatCodes, Fr, TxStatus, Wallet } from '@aztec/aztec.js';
 import { CircuitsWasm, CompleteAddress, FunctionSelector } from '@aztec/circuits.js';
 import { pedersenHashInputs, pedersenPlookupCommitInputs } from '@aztec/circuits.js/barretenberg';
 import { StatefulTestContract } from '@aztec/noir-contracts/types';
-import { PXE } from '@aztec/types';
+import { MerkleTreeId, PXE } from '@aztec/types';
 
 import { setup } from './fixtures/utils.js';
 
@@ -25,7 +25,7 @@ describe('e2e_deploy_contract', () => {
 
   afterEach(() => teardown());
 
-  it('Try to get a witness', async () => {
+  it('Check commitment inclusion in historic data', async () => {
     if (!aztecNode) {
       throw new Error('No aztec node');
     }
@@ -95,7 +95,7 @@ describe('e2e_deploy_contract', () => {
     const badValueNote = { ...valueNote, owner: 100n };
     const badLeafValue = new Fr(await statefulContract.methods.get_commitment(badValueNote).view());
     await expect(statefulContract.methods.is_included_in_history(badValueNote).simulate()).rejects.toThrowError(
-      `Leaf value: ${badLeafValue} not found in private data tree`,
+      `Leaf value: ${badLeafValue} not found in tree ${MerkleTreeId.PRIVATE_DATA_TREE}`,
     );
   }, 30_000);
 });

--- a/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/almost_value_note.nr
+++ b/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/almost_value_note.nr
@@ -1,0 +1,38 @@
+
+use dep::value_note::value_note::ValueNote;
+use dep::aztec::note::note_header::NoteHeader;
+
+struct AlmostValueNote {
+    value: Field,
+    owner: Field,
+    randomness: Field,
+    header: NoteHeader,
+}
+
+impl AlmostValueNote {
+    fn serialize(self) -> [Field; 6] {
+        [self.value, self.owner, self.randomness, self.header.contract_address, self.header.nonce, self.header.storage_slot]
+    }
+
+    fn deserialize(serialized: [Field; 6]) -> Self {
+        AlmostValueNote {
+            value: serialized[0],
+            owner: serialized[1],
+            randomness: serialized[2],
+            header: NoteHeader {
+                contract_address: serialized[3],
+                nonce: serialized[4],
+                storage_slot: serialized[5],
+            },
+        }
+    }
+
+    fn to_value_note(self) -> ValueNote {
+        ValueNote {
+            value: self.value,
+            owner: self.owner,
+            randomness: self.randomness,
+            header: self.header,
+        }
+    }
+}

--- a/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/historic_commitment_oracle.nr
+++ b/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/historic_commitment_oracle.nr
@@ -8,12 +8,12 @@ struct PrivateDataMembershipWitness {
     path: [Field; PRIVATE_DATA_TREE_HEIGHT],
 }
 
-#[oracle(getDataTreePath)]
-fn get_private_data_sibling_witness_oracle(_commitment: Field) -> [Field; PRIVATE_DATA_MEMBERSHIP_WITNESS_LEN] {}
+#[oracle(getMembershipWitness)]
+fn get_private_data_membership_witness_oracle(_commitment: Field) -> [Field; PRIVATE_DATA_MEMBERSHIP_WITNESS_LEN] {}
 
-unconstrained fn get_private_data_sibling_witness(commitment: Field) -> PrivateDataMembershipWitness {
+unconstrained fn get_private_data_membership_witness(commitment: Field) -> PrivateDataMembershipWitness {
     assert(PRIVATE_DATA_MEMBERSHIP_WITNESS_LEN == PRIVATE_DATA_TREE_HEIGHT + 1);
-    let fields = get_private_data_sibling_witness_oracle(commitment);
+    let fields = get_private_data_membership_witness_oracle(commitment);
     PrivateDataMembershipWitness {
         index: fields[0],
         path: arr_copy_slice(fields, [0; PRIVATE_DATA_TREE_HEIGHT], 1)

--- a/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/historic_commitment_oracle.nr
+++ b/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/historic_commitment_oracle.nr
@@ -1,0 +1,22 @@
+use dep::aztec::constants_gen::PRIVATE_DATA_TREE_HEIGHT;
+use dep::aztec::utils::arr_copy_slice;
+
+global PRIVATE_DATA_MEMBERSHIP_WITNESS_LEN: Field = 33;
+
+struct PrivateDataMembershipWitness {
+    index: Field,
+    path: [Field; PRIVATE_DATA_TREE_HEIGHT],
+}
+
+#[oracle(getDataTreePath)]
+fn get_private_data_sibling_witness_oracle(_commitment: Field) -> [Field; PRIVATE_DATA_MEMBERSHIP_WITNESS_LEN] {}
+
+unconstrained fn get_private_data_sibling_witness(commitment: Field) -> PrivateDataMembershipWitness {
+    assert(PRIVATE_DATA_MEMBERSHIP_WITNESS_LEN == PRIVATE_DATA_TREE_HEIGHT + 1);
+    let fields = get_private_data_sibling_witness_oracle(commitment);
+    PrivateDataMembershipWitness {
+        index: fields[0],
+        path: arr_copy_slice(fields, [0; PRIVATE_DATA_TREE_HEIGHT], 1)
+    }
+
+}

--- a/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/historic_membership_oracle.nr
+++ b/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/historic_membership_oracle.nr
@@ -9,11 +9,11 @@ struct PrivateDataMembershipWitness {
 }
 
 #[oracle(getMembershipWitness)]
-fn get_private_data_membership_witness_oracle(_commitment: Field) -> [Field; PRIVATE_DATA_MEMBERSHIP_WITNESS_LEN] {}
+fn get_private_data_membership_witness_oracle(_treeId: Field, _commitment: Field) -> [Field; PRIVATE_DATA_MEMBERSHIP_WITNESS_LEN] {}
 
 unconstrained fn get_private_data_membership_witness(commitment: Field) -> PrivateDataMembershipWitness {
     assert(PRIVATE_DATA_MEMBERSHIP_WITNESS_LEN == PRIVATE_DATA_TREE_HEIGHT + 1);
-    let fields = get_private_data_membership_witness_oracle(commitment);
+    let fields = get_private_data_membership_witness_oracle(2, commitment);
     PrivateDataMembershipWitness {
         index: fields[0],
         path: arr_copy_slice(fields, [0; PRIVATE_DATA_TREE_HEIGHT], 1)

--- a/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/main.nr
@@ -22,7 +22,7 @@ contract StatefulTest {
         },
     };
     use dep::aztec::constants_gen::PRIVATE_DATA_TREE_HEIGHT;
-    use crate::historic_commitment_oracle::{get_private_data_sibling_witness, PrivateDataMembershipWitness};
+    use crate::historic_commitment_oracle::{get_private_data_membership_witness, PrivateDataMembershipWitness};
     use dep::aztec::note::utils::compute_note_hash_for_read_or_nullify;
     use crate::almost_value_note::AlmostValueNote;
 
@@ -97,7 +97,7 @@ contract StatefulTest {
     ) {
         let note = note.to_value_note();
         let commitment = compute_note_hash_for_read_or_nullify(ValueNoteMethods, note);
-        let witness = get_private_data_sibling_witness(commitment);
+        let witness = get_private_data_membership_witness(commitment);
         let root = compute_merkle_root(commitment, witness.index, witness.path);
         assert(context.block_data.private_data_tree_root == root, "Note is not included in history");
     }
@@ -107,7 +107,7 @@ contract StatefulTest {
     ) -> [Field; PRIVATE_DATA_TREE_HEIGHT] {
         // compute the commitment 
         let commitment = compute_note_hash_for_read_or_nullify(ValueNoteMethods, note);
-        let witness = get_private_data_sibling_witness(commitment);
+        let witness = get_private_data_membership_witness(commitment);
         witness.path
     }
 
@@ -120,7 +120,7 @@ contract StatefulTest {
     unconstrained fn get_root(note: ValueNote) -> Field {
         // compute the commitment 
         let commitment = compute_note_hash_for_read_or_nullify(ValueNoteMethods, note);
-        let witness = get_private_data_sibling_witness(commitment);
+        let witness = get_private_data_membership_witness(commitment);
         compute_merkle_root(commitment, witness.index, witness.path)
     }
 

--- a/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/main.nr
@@ -1,6 +1,9 @@
+mod historic_commitment_oracle;
+
 // A contract used for testing a random hodgepodge of small features from simulator and end-to-end tests.
 contract StatefulTest {
     use dep::std::option::Option;
+    use dep::std::merkle::compute_merkle_root;
     use dep::value_note::{
         balance_utils,
         utils::{increment, decrement},
@@ -17,6 +20,9 @@ contract StatefulTest {
             FieldSerializationMethods, FIELD_SERIALIZED_LEN,
         },
     };
+    use dep::aztec::constants_gen::PRIVATE_DATA_TREE_HEIGHT;
+    use crate::historic_commitment_oracle::{get_private_data_sibling_witness, PrivateDataMembershipWitness};
+    use dep::aztec::note::utils::compute_note_hash_for_read_or_nullify;
 
     struct Storage {
         notes: Map<Set<ValueNote, VALUE_NOTE_LEN>>,
@@ -80,6 +86,28 @@ contract StatefulTest {
 
         let recipient_notes = storage.notes.at(recipient);
         increment(recipient_notes, amount, recipient);
+    }
+
+    unconstrained fn get_path(
+        note: ValueNote
+    ) -> [Field; PRIVATE_DATA_TREE_HEIGHT] {
+        // compute the commitment 
+        let commitment = compute_note_hash_for_read_or_nullify(ValueNoteMethods, note);
+        let witness = get_private_data_sibling_witness(commitment);
+        witness.path
+    }
+
+    unconstrained fn get_commitment(
+        note: ValueNote
+    ) -> Field {
+        compute_note_hash_for_read_or_nullify(ValueNoteMethods, note)
+    }
+
+    unconstrained fn get_root(note: ValueNote) -> Field {
+        // compute the commitment 
+        let commitment = compute_note_hash_for_read_or_nullify(ValueNoteMethods, note);
+        let witness = get_private_data_sibling_witness(commitment);
+        compute_merkle_root(commitment, witness.index, witness.path)
     }
 
     unconstrained fn summed_values(

--- a/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/main.nr
@@ -1,4 +1,5 @@
 mod historic_commitment_oracle;
+mod almost_value_note;
 
 // A contract used for testing a random hodgepodge of small features from simulator and end-to-end tests.
 contract StatefulTest {
@@ -23,6 +24,7 @@ contract StatefulTest {
     use dep::aztec::constants_gen::PRIVATE_DATA_TREE_HEIGHT;
     use crate::historic_commitment_oracle::{get_private_data_sibling_witness, PrivateDataMembershipWitness};
     use dep::aztec::note::utils::compute_note_hash_for_read_or_nullify;
+    use crate::almost_value_note::AlmostValueNote;
 
     struct Storage {
         notes: Map<Set<ValueNote, VALUE_NOTE_LEN>>,
@@ -86,6 +88,18 @@ contract StatefulTest {
 
         let recipient_notes = storage.notes.at(recipient);
         increment(recipient_notes, amount, recipient);
+    }
+
+    // We cannot use valueNote directly because of its serialize here. Unconstrained are different.
+    #[aztec(private)]
+    fn is_included_in_history(
+        note: AlmostValueNote
+    ) {
+        let note = note.to_value_note();
+        let commitment = compute_note_hash_for_read_or_nullify(ValueNoteMethods, note);
+        let witness = get_private_data_sibling_witness(commitment);
+        let root = compute_merkle_root(commitment, witness.index, witness.path);
+        assert(context.block_data.private_data_tree_root == root, "Note is not included in history");
     }
 
     unconstrained fn get_path(

--- a/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/stateful_test_contract/src/main.nr
@@ -1,4 +1,4 @@
-mod historic_commitment_oracle;
+mod historic_membership_oracle;
 mod almost_value_note;
 
 // A contract used for testing a random hodgepodge of small features from simulator and end-to-end tests.
@@ -22,7 +22,7 @@ contract StatefulTest {
         },
     };
     use dep::aztec::constants_gen::PRIVATE_DATA_TREE_HEIGHT;
-    use crate::historic_commitment_oracle::{get_private_data_membership_witness, PrivateDataMembershipWitness};
+    use crate::historic_membership_oracle::{get_private_data_membership_witness, PrivateDataMembershipWitness};
     use dep::aztec::note::utils::compute_note_hash_for_read_or_nullify;
     use crate::almost_value_note::AlmostValueNote;
 

--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -103,11 +103,7 @@ export class SimulatorOracle implements DBOracle {
    * @returns - The index of the commitment. Undefined if it does not exist in the tree.
    */
   async findCommitmentIndex(leafValue: Buffer) {
-    return await this.dataTreeProvider.findCommitmentIndex(leafValue);
-  }
-
-  async getDataTreePath(leafIndex: bigint) {
-    return await this.dataTreeProvider.getDataTreePath(leafIndex);
+    return await this.findLeafIndex(MerkleTreeId.PRIVATE_DATA_TREE, leafValue);
   }
 
   public async findLeafIndex(treeId: MerkleTreeId, leafValue: Buffer): Promise<bigint | undefined> {

--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -9,7 +9,7 @@ import {
   HistoricBlockData,
   PublicKey,
 } from '@aztec/circuits.js';
-import { DataCommitmentProvider, KeyStore, L1ToL2MessageProvider } from '@aztec/types';
+import { DataCommitmentProvider, KeyStore, L1ToL2MessageProvider, MerkleTreeId } from '@aztec/types';
 
 import { ContractDataOracle } from '../contract_data_oracle/index.js';
 import { Database } from '../database/index.js';
@@ -108,6 +108,25 @@ export class SimulatorOracle implements DBOracle {
 
   async getDataTreePath(leafIndex: bigint) {
     return await this.dataTreeProvider.getDataTreePath(leafIndex);
+  }
+
+  public async findLeafIndex(treeId: MerkleTreeId, leafValue: Buffer): Promise<bigint | undefined> {
+    switch (treeId) {
+      case MerkleTreeId.PRIVATE_DATA_TREE:
+        return await this.dataTreeProvider.findCommitmentIndex(leafValue);
+      default:
+        throw new Error('Not implemented');
+    }
+  }
+
+  public async getSiblingPath(treeId: MerkleTreeId, leafIndex: bigint): Promise<Fr[]> {
+    // @todo This is doing a nasty workaround as http_rpc_client was not happy about a generic `getSiblingPath` function being exposed.
+    switch (treeId) {
+      case MerkleTreeId.PRIVATE_DATA_TREE:
+        return (await this.dataTreeProvider.getDataTreePath(leafIndex)).toFieldArray();
+      default:
+        throw new Error('Not implemented');
+    }
   }
 
   /**

--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -99,11 +99,15 @@ export class SimulatorOracle implements DBOracle {
 
   /**
    * Gets the index of a commitment in the private data tree.
-   * @param commitment - The commitment.
+   * @param leafValue - The commitment buffer.
    * @returns - The index of the commitment. Undefined if it does not exist in the tree.
    */
-  async getCommitmentIndex(commitment: Fr) {
-    return await this.dataTreeProvider.findCommitmentIndex(commitment.toBuffer());
+  async findCommitmentIndex(leafValue: Buffer) {
+    return await this.dataTreeProvider.findCommitmentIndex(leafValue);
+  }
+
+  async getDataTreePath(leafIndex: bigint) {
+    return await this.dataTreeProvider.getDataTreePath(leafIndex);
   }
 
   /**

--- a/yarn-project/sequencer-client/src/simulator/public_executor.ts
+++ b/yarn-project/sequencer-client/src/simulator/public_executor.ts
@@ -6,7 +6,7 @@ import {
   PublicStateDB,
 } from '@aztec/acir-simulator';
 import { AztecAddress, CircuitsWasm, EthAddress, Fr, FunctionSelector, HistoricBlockData } from '@aztec/circuits.js';
-import { ContractDataSource, L1ToL2MessageSource, MerkleTreeId } from '@aztec/types';
+import { ContractDataSource, L1ToL2MessageSource, MerkleTreeId, SiblingPath } from '@aztec/types';
 import { MerkleTreeOperations, computePublicDataTreeLeafIndex } from '@aztec/world-state';
 
 /**
@@ -98,7 +98,11 @@ export class WorldStateDB implements CommitmentsDB {
     };
   }
 
-  public async getCommitmentIndex(commitment: Fr): Promise<bigint | undefined> {
-    return await this.db.findLeafIndex(MerkleTreeId.PRIVATE_DATA_TREE, commitment.toBuffer());
+  public async findCommitmentIndex(commitment: Buffer): Promise<bigint | undefined> {
+    return await this.db.findLeafIndex(MerkleTreeId.PRIVATE_DATA_TREE, commitment);
+  }
+
+  public async getDataTreePath(leafIndex: bigint): Promise<SiblingPath<32>> {
+    return await this.db.getSiblingPath(MerkleTreeId.PRIVATE_DATA_TREE, leafIndex);
   }
 }


### PR DESCRIPTION
Fixes #2584 as part of #2572

- Updates the pedersen `hash_multiple` to follow the version used in noir (`plookup_commit`).
  - This is essentially a work around just to allow testing the feature. 
- Unifies the naming of `getCommitmentIndex` and `findCommitmentIndex` to `findCommitmentIndex`
- Adds `getMembershipWitness` oracle which currently provides both index and path. It only works for the data tree atm, but as part of #2572 should be made to work with the other trees. 

Uses an `AlmostValueNote` as input since the macro is using the `serialize` function, which for `ValueNote` don't include the header so it is invalid.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
