### PR TITLE
fix: foundry

### DIFF
--- a/l1-contracts/scripts/install_foundry.sh
+++ b/l1-contracts/scripts/install_foundry.sh
@@ -18,4 +18,4 @@ chmod +x $BIN_PATH
 export PATH=$FOUNDRY_BIN_DIR:$PATH
 
 # Use version.
-foundryup --version nightly-bdea91c79055e8adcf33e714984edba9a3e33d2a
+foundryup


### PR DESCRIPTION
Foundry dropped the specific version of binary we use and it resulted in this error:
`gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
foundryup: command failed: tar -xzC /mnt/user-data/jan/tmp/aztec-packages/l1-contracts/.foundry/bin
foundryup: downloading manpages`

I unpinned the version and it fixes it.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
