### PR TITLE
fix!: Gates command should always return 8 bytes

### DIFF
--- a/barretenberg/ts/src/main.ts
+++ b/barretenberg/ts/src/main.ts
@@ -126,7 +126,15 @@ export async function prove(
 export async function gateCount(bytecodePath: string) {
   const api = await Barretenberg.new(1);
   try {
-    process.stdout.write(`${await getGates(bytecodePath, api)}`);
+    const numberOfGates = await getGates(bytecodePath, api);
+
+    // Create an 8-byte buffer and write the number into it.
+    // Writing number directly to stdout will result in a variable sized
+    // input depending on the size.
+    const buffer = Buffer.alloc(8);
+    buffer.writeBigInt64LE(BigInt(numberOfGates));
+
+    process.stdout.write(buffer);
   } finally {
     await api.destroy();
   }


### PR DESCRIPTION
## Problem

Writing number directly to stdout will result in a variable number of bytes depending on the number. The spec requires us to have 8 bytes in little endian format.

## Solution

Write number into buffer with 8 bytes and then write the buffer to stdout

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
