### PR TITLE
chore(benchmark): Measure block sync time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -937,7 +937,7 @@ jobs:
       - run:
           name: "Benchmark"
           command: cond_run_script end-to-end ./scripts/run_tests_local benchmarks/bench_publish_rollup.test.ts
-          environment: { DEBUG: 'aztec:benchmarks:*,aztec:sequencer' }
+          environment: { DEBUG: 'aztec:benchmarks:*,aztec:sequencer,aztec:world_state,aztec:merkle_trees' }
 
   build-docs:
     machine:

--- a/scripts/ci/aggregate_e2e_benchmark.js
+++ b/scripts/ci/aggregate_e2e_benchmark.js
@@ -12,8 +12,8 @@ const {
   L1_ROLLUP_CALLDATA_GAS,
   L1_ROLLUP_EXECUTION_GAS,
   L2_BLOCK_PROCESSING_TIME,
-  ROLLUP_BLOCK_SYNCED,
-  ROLLUP_PUBLISHED_TO_L1,
+  L2_BLOCK_SYNCED,
+  L2_BLOCK_PUBLISHED_TO_L1,
   ROLLUP_SIZES,
   BENCHMARK_FILE_JSON,
 } = require("./benchmark_shared.js");
@@ -58,9 +58,9 @@ function processRollupBlockSynced(entry, results) {
 // Processes a parsed entry from a logfile and updates results
 function processEntry(entry, results) {
   switch (entry.eventName) {
-    case ROLLUP_PUBLISHED_TO_L1:
+    case L2_BLOCK_PUBLISHED_TO_L1:
       return processRollupPublished(entry, results);
-    case ROLLUP_BLOCK_SYNCED:
+    case L2_BLOCK_SYNCED:
       return processRollupBlockSynced(entry, results);
     default:
       return;

--- a/scripts/ci/aggregate_e2e_benchmark.js
+++ b/scripts/ci/aggregate_e2e_benchmark.js
@@ -11,6 +11,8 @@ const {
   L1_ROLLUP_CALLDATA_SIZE_IN_BYTES,
   L1_ROLLUP_CALLDATA_GAS,
   L1_ROLLUP_EXECUTION_GAS,
+  L2_BLOCK_PROCESSING_TIME,
+  ROLLUP_BLOCK_SYNCED,
   ROLLUP_PUBLISHED_TO_L1,
   ROLLUP_SIZES,
   BENCHMARK_FILE_JSON,
@@ -44,11 +46,22 @@ function processRollupPublished(entry, results) {
   append(results, L1_ROLLUP_EXECUTION_GAS, bucket, entry.gasUsed);
 }
 
+// Processes an entry with event name 'l2-block-handled' and updates results
+// Skips instances where the block was emitted by the same node where the processing is skipped
+function processRollupBlockSynced(entry, results) {
+  const bucket = entry.txCount;
+  if (!ROLLUP_SIZES.includes(bucket)) return;
+  if (entry.isBlockOurs) return;
+  append(results, L2_BLOCK_PROCESSING_TIME, bucket, entry.duration);
+}
+
 // Processes a parsed entry from a logfile and updates results
 function processEntry(entry, results) {
   switch (entry.eventName) {
     case ROLLUP_PUBLISHED_TO_L1:
       return processRollupPublished(entry, results);
+    case ROLLUP_BLOCK_SYNCED:
+      return processRollupBlockSynced(entry, results);
     default:
       return;
   }
@@ -73,6 +86,8 @@ async function main() {
     }
   }
 
+  console.log(`Collected entries:`, JSON.stringify(results, null, 2));
+
   // For each bucket of each metric compute the average all collected datapoints
   for (const metricName in results) {
     const metric = results[metricName];
@@ -88,6 +103,7 @@ async function main() {
   results.timestamp = new Date().toISOString();
 
   // Write results to disk
+  console.log(`Aggregated results:`, JSON.stringify(results, null, 2));
   fs.writeFileSync(BENCHMARK_FILE_JSON, JSON.stringify(results, null, 2));
 }
 

--- a/scripts/ci/benchmark_shared.js
+++ b/scripts/ci/benchmark_shared.js
@@ -5,8 +5,8 @@ const L1_ROLLUP_EXECUTION_GAS = "l1_rollup_execution_gas";
 const L2_BLOCK_PROCESSING_TIME = "l2_block_processing_time_in_ms";
 
 // Events to track
-const ROLLUP_PUBLISHED_TO_L1 = "rollup-published-to-l1";
-const ROLLUP_BLOCK_SYNCED = "l2-block-handled";
+const L2_BLOCK_PUBLISHED_TO_L1 = "rollup-published-to-l1";
+const L2_BLOCK_SYNCED = "l2-block-handled";
 
 // Rollup sizes to track (duplicated from yarn-project/end-to-end/src/benchmarks/bench_publish_rollup.test.ts)
 const ROLLUP_SIZES = process.env.ROLLUP_SIZES
@@ -21,8 +21,8 @@ module.exports = {
   L1_ROLLUP_CALLDATA_GAS,
   L1_ROLLUP_EXECUTION_GAS,
   L2_BLOCK_PROCESSING_TIME,
-  ROLLUP_PUBLISHED_TO_L1,
-  ROLLUP_BLOCK_SYNCED,
+  L2_BLOCK_PUBLISHED_TO_L1,
+  L2_BLOCK_SYNCED,
   ROLLUP_SIZES,
   BENCHMARK_FILE_JSON,
 };

--- a/scripts/ci/benchmark_shared.js
+++ b/scripts/ci/benchmark_shared.js
@@ -2,9 +2,11 @@
 const L1_ROLLUP_CALLDATA_SIZE_IN_BYTES = "l1_rollup_calldata_size_in_bytes";
 const L1_ROLLUP_CALLDATA_GAS = "l1_rollup_calldata_gas";
 const L1_ROLLUP_EXECUTION_GAS = "l1_rollup_execution_gas";
+const L2_BLOCK_PROCESSING_TIME = "l2_block_processing_time_in_ms";
 
 // Events to track
 const ROLLUP_PUBLISHED_TO_L1 = "rollup-published-to-l1";
+const ROLLUP_BLOCK_SYNCED = "l2-block-handled";
 
 // Rollup sizes to track (duplicated from yarn-project/end-to-end/src/benchmarks/bench_publish_rollup.test.ts)
 const ROLLUP_SIZES = process.env.ROLLUP_SIZES
@@ -18,7 +20,9 @@ module.exports = {
   L1_ROLLUP_CALLDATA_SIZE_IN_BYTES,
   L1_ROLLUP_CALLDATA_GAS,
   L1_ROLLUP_EXECUTION_GAS,
+  L2_BLOCK_PROCESSING_TIME,
   ROLLUP_PUBLISHED_TO_L1,
+  ROLLUP_BLOCK_SYNCED,
   ROLLUP_SIZES,
   BENCHMARK_FILE_JSON,
 };

--- a/yarn-project/aztec-node/src/aztec-node/config.ts
+++ b/yarn-project/aztec-node/src/aztec-node/config.ts
@@ -6,18 +6,25 @@ import { getConfigEnvVars as getWorldStateVars } from '@aztec/world-state';
 /**
  * The configuration the aztec node.
  */
-export type AztecNodeConfig = ArchiverConfig & SequencerClientConfig & P2PConfig;
+export type AztecNodeConfig = ArchiverConfig &
+  SequencerClientConfig &
+  P2PConfig & {
+    /** Whether the sequencer is disabled for this node. */
+    disableSequencer: boolean;
+  };
 
 /**
  * Returns the config of the aztec node from environment variables with reasonable defaults.
  * @returns A valid aztec node config.
  */
 export function getConfigEnvVars(): AztecNodeConfig {
+  const { SEQ_DISABLED } = process.env;
   const allEnvVars: AztecNodeConfig = {
     ...getSequencerVars(),
     ...getArchiverVars(),
     ...getP2PConfigEnvVars(),
     ...getWorldStateVars(),
+    disableSequencer: !!SEQ_DISABLED,
   };
 
   return allEnvVars;

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -63,7 +63,7 @@ export class AztecNodeService implements AztecNode {
     protected readonly contractDataSource: ContractDataSource,
     protected readonly l1ToL2MessageSource: L1ToL2MessageSource,
     protected readonly worldStateSynchronizer: WorldStateSynchronizer,
-    protected readonly sequencer: SequencerClient,
+    protected readonly sequencer: SequencerClient | undefined,
     protected readonly chainId: number,
     protected readonly version: number,
     protected readonly globalVariableBuilder: GlobalVariableBuilder,
@@ -97,14 +97,10 @@ export class AztecNodeService implements AztecNode {
     await Promise.all([p2pClient.start(), worldStateSynchronizer.start()]);
 
     // now create the sequencer
-    const sequencer = await SequencerClient.new(
-      config,
-      p2pClient,
-      worldStateSynchronizer,
-      archiver,
-      archiver,
-      archiver,
-    );
+    const sequencer = config.disableSequencer
+      ? undefined
+      : await SequencerClient.new(config, p2pClient, worldStateSynchronizer, archiver, archiver, archiver);
+
     return new AztecNodeService(
       config,
       p2pClient,
@@ -126,7 +122,7 @@ export class AztecNodeService implements AztecNode {
    * Returns the sequencer client instance.
    * @returns The sequencer client instance.
    */
-  public getSequencer(): SequencerClient {
+  public getSequencer(): SequencerClient | undefined {
     return this.sequencer;
   }
 
@@ -237,7 +233,8 @@ export class AztecNodeService implements AztecNode {
    * Method to stop the aztec node.
    */
   public async stop() {
-    await this.sequencer.stop();
+    this.log.info(`Stopping`);
+    await this.sequencer?.stop();
     await this.p2pClient.stop();
     await this.worldStateSynchronizer.stop();
     await this.blockSource.stop();

--- a/yarn-project/end-to-end/.gitignore
+++ b/yarn-project/end-to-end/.gitignore
@@ -1,1 +1,2 @@
 addresses.json
+/log

--- a/yarn-project/foundation/src/log/index.ts
+++ b/yarn-project/foundation/src/log/index.ts
@@ -1,5 +1,5 @@
 /** Structured log data to include with the message. */
-export type LogData = Record<string, string | number | bigint>;
+export type LogData = Record<string, string | number | bigint | boolean>;
 
 /** A callable logger instance. */
 export type LogFn = (msg: string, data?: LogData) => void;

--- a/yarn-project/foundation/src/timer/elapsed.ts
+++ b/yarn-project/foundation/src/timer/elapsed.ts
@@ -1,0 +1,12 @@
+import { Timer } from './timer.js';
+
+/**
+ * Measures the elapsed execution time of a function call or promise once it is awaited.
+ * @param fn - Function or promise.
+ * @returns A timer object.
+ */
+export async function elapsed<T>(fn: Promise<T> | (() => T | Promise<T>)): Promise<[Timer, T]> {
+  const timer = new Timer();
+  const result = await (typeof fn === 'function' ? fn() : fn);
+  return [timer, result];
+}

--- a/yarn-project/foundation/src/timer/index.ts
+++ b/yarn-project/foundation/src/timer/index.ts
@@ -1,2 +1,3 @@
 export { TimeoutTask } from './timeout.js';
 export { Timer } from './timer.js';
+export { elapsed } from './elapsed.js';

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -145,12 +145,7 @@ export class L1Publisher implements L2BlockReceiver {
         const stats: L1PublishStats = {
           ...pick(receipt, 'gasPrice', 'gasUsed', 'transactionHash'),
           ...pick(tx!, 'calldataGas', 'calldataSize'),
-          txCount: l2BlockData.numberOfTxs,
-          blockNumber: l2BlockData.number,
-          encryptedLogCount: l2BlockData.newEncryptedLogs?.getTotalLogCount() ?? 0,
-          unencryptedLogCount: l2BlockData.newUnencryptedLogs?.getTotalLogCount() ?? 0,
-          encryptedLogSize: l2BlockData.newEncryptedLogs?.getSerializedLength() ?? 0,
-          unencryptedLogSize: l2BlockData.newUnencryptedLogs?.getSerializedLength() ?? 0,
+          ...l2BlockData.getStats(),
           eventName: 'rollup-published-to-l1',
         };
         this.log.info(`Published L2 block to L1 rollup contract`, stats);

--- a/yarn-project/types/src/l2_block.ts
+++ b/yarn-project/types/src/l2_block.ts
@@ -810,6 +810,21 @@ export class L2Block {
   }
 
   /**
+   * Returns stats used for logging.
+   * @returns Stats on tx count, number, and log size and count.
+   */
+  getStats() {
+    return {
+      txCount: this.numberOfTxs,
+      blockNumber: this.number,
+      encryptedLogCount: this.newEncryptedLogs?.getTotalLogCount() ?? 0,
+      unencryptedLogCount: this.newUnencryptedLogs?.getTotalLogCount() ?? 0,
+      encryptedLogSize: this.newEncryptedLogs?.getSerializedLength() ?? 0,
+      unencryptedLogSize: this.newUnencryptedLogs?.getSerializedLength() ?? 0,
+    };
+  }
+
+  /**
    * Inspect for debugging purposes..
    * @param maxBufferSize - The number of bytes to be extracted from buffer.
    * @returns A human-friendly string representation of the l2Block.

--- a/yarn-project/world-state/package.json
+++ b/yarn-project/world-state/package.json
@@ -48,6 +48,7 @@
     "@types/memdown": "^3.0.0",
     "@types/node": "^18.7.23",
     "jest": "^29.5.0",
+    "jest-mock-extended": "^3.0.5",
     "memdown": "^6.1.1",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",

--- a/yarn-project/world-state/src/merkle-tree/merkle_tree_operations_facade.ts
+++ b/yarn-project/world-state/src/merkle-tree/merkle_tree_operations_facade.ts
@@ -2,7 +2,14 @@ import { Fr } from '@aztec/foundation/fields';
 import { LowLeafWitnessData } from '@aztec/merkle-tree';
 import { L2Block, MerkleTreeId, SiblingPath } from '@aztec/types';
 
-import { CurrentTreeRoots, LeafData, MerkleTreeDb, MerkleTreeOperations, TreeInfo } from '../index.js';
+import {
+  CurrentTreeRoots,
+  HandleL2BlockResult,
+  LeafData,
+  MerkleTreeDb,
+  MerkleTreeOperations,
+  TreeInfo,
+} from '../index.js';
 
 /**
  * Wraps a MerkleTreeDbOperations to call all functions with a preset includeUncommitted flag.
@@ -144,7 +151,7 @@ export class MerkleTreeOperationsFacade implements MerkleTreeOperations {
    * @param block - The L2 block to handle.
    * @returns Empty promise.
    */
-  public handleL2Block(block: L2Block): Promise<void> {
+  public handleL2Block(block: L2Block): Promise<HandleL2BlockResult> {
     return this.trees.handleL2Block(block);
   }
 

--- a/yarn-project/world-state/src/merkle-tree/merkle_tree_operations_facade.ts
+++ b/yarn-project/world-state/src/merkle-tree/merkle_tree_operations_facade.ts
@@ -149,7 +149,7 @@ export class MerkleTreeOperationsFacade implements MerkleTreeOperations {
   /**
    * Handles a single L2 block (i.e. Inserts the new commitments into the merkle tree).
    * @param block - The L2 block to handle.
-   * @returns Empty promise.
+   * @returns Whether the block handled was produced by this same node.
    */
   public handleL2Block(block: L2Block): Promise<HandleL2BlockResult> {
     return this.trees.handleL2Block(block);

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -180,6 +180,7 @@ export class ServerWorldStateSynchronizer implements WorldStateSynchronizer {
   /**
    * Handles a list of L2 blocks (i.e. Inserts the new commitments into the merkle tree).
    * @param l2Blocks - The L2 blocks to handle.
+   * @returns Whether the block handled was produced by this same node.
    */
   private async handleL2Blocks(l2Blocks: L2Block[]) {
     for (const l2Block of l2Blocks) {

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -1,10 +1,11 @@
 import { SerialQueue } from '@aztec/foundation/fifo';
 import { createDebugLogger } from '@aztec/foundation/log';
+import { elapsed } from '@aztec/foundation/timer';
 import { L2Block, L2BlockDownloader, L2BlockSource } from '@aztec/types';
 
 import { LevelUp } from 'levelup';
 
-import { MerkleTreeOperations, MerkleTrees } from '../index.js';
+import { HandleL2BlockResult, MerkleTreeOperations, MerkleTrees } from '../index.js';
 import { MerkleTreeOperationsFacade } from '../merkle-tree/merkle_tree_operations_facade.js';
 import { WorldStateConfig } from './config.js';
 import { WorldStateRunningState, WorldStateStatus, WorldStateSynchronizer } from './world_state_synchronizer.js';
@@ -182,7 +183,13 @@ export class ServerWorldStateSynchronizer implements WorldStateSynchronizer {
    */
   private async handleL2Blocks(l2Blocks: L2Block[]) {
     for (const l2Block of l2Blocks) {
-      await this.handleL2Block(l2Block);
+      const [time, result] = await elapsed(() => this.handleL2Block(l2Block));
+      this.log(`Handled new L2 block`, {
+        eventName: 'l2-block-handled',
+        duration: time.ms(),
+        isBlockOurs: result.isBlockOurs,
+        ...l2Block.getStats(),
+      });
     }
   }
 
@@ -190,8 +197,8 @@ export class ServerWorldStateSynchronizer implements WorldStateSynchronizer {
    * Handles a single L2 block (i.e. Inserts the new commitments into the merkle tree).
    * @param l2Block - The L2 block to handle.
    */
-  private async handleL2Block(l2Block: L2Block) {
-    await this.merkleTreeDb.handleL2Block(l2Block);
+  private async handleL2Block(l2Block: L2Block): Promise<HandleL2BlockResult> {
+    const result = await this.merkleTreeDb.handleL2Block(l2Block);
     this.currentL2BlockNum = l2Block.number;
     if (
       this.currentState === WorldStateRunningState.SYNCHING &&
@@ -202,6 +209,7 @@ export class ServerWorldStateSynchronizer implements WorldStateSynchronizer {
         this.syncResolve();
       }
     }
+    return result;
   }
 
   /**

--- a/yarn-project/world-state/src/world-state-db/index.ts
+++ b/yarn-project/world-state/src/world-state-db/index.ts
@@ -208,7 +208,7 @@ export interface MerkleTreeOperations {
    * Handles a single L2 block (i.e. Inserts the new commitments into the merkle tree).
    * @param block - The L2 block to handle.
    */
-  handleL2Block(block: L2Block): Promise<void>;
+  handleL2Block(block: L2Block): Promise<HandleL2BlockResult>;
 
   /**
    * Commits pending changes to the underlying store.
@@ -220,6 +220,11 @@ export interface MerkleTreeOperations {
    */
   rollback(): Promise<void>;
 }
+
+/** Return type for handleL2Block */
+export type HandleL2BlockResult = {
+  /** Whether the block processed was emitted by our sequencer */ isBlockOurs: boolean;
+};
 
 /**
  * Outputs a tree leaves using for debugging purposes.

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -36,6 +36,7 @@ import { MerkleTreeOperationsFacade } from '../merkle-tree/merkle_tree_operation
 import { computeGlobalVariablesHash } from '../utils.js';
 import {
   CurrentTreeRoots,
+  HandleL2BlockResult,
   INITIAL_NULLIFIER_TREE_SIZE,
   IndexedTreeId,
   MerkleTreeDb,
@@ -381,8 +382,8 @@ export class MerkleTrees implements MerkleTreeDb {
    * Handles a single L2 block (i.e. Inserts the new commitments into the merkle tree).
    * @param block - The L2 block to handle.
    */
-  public async handleL2Block(block: L2Block): Promise<void> {
-    await this.synchronize(() => this._handleL2Block(block));
+  public async handleL2Block(block: L2Block): Promise<HandleL2BlockResult> {
+    return await this.synchronize(() => this._handleL2Block(block));
   }
 
   /**
@@ -526,7 +527,7 @@ export class MerkleTrees implements MerkleTreeDb {
    * Handles a single L2 block (i.e. Inserts the new commitments into the merkle tree).
    * @param l2Block - The L2 block to handle.
    */
-  private async _handleL2Block(l2Block: L2Block) {
+  private async _handleL2Block(l2Block: L2Block): Promise<HandleL2BlockResult> {
     const treeRootWithIdPairs = [
       [l2Block.endContractTreeSnapshot.root, MerkleTreeId.CONTRACT_TREE],
       [l2Block.endNullifierTreeSnapshot.root, MerkleTreeId.NULLIFIER_TREE],
@@ -541,10 +542,10 @@ export class MerkleTrees implements MerkleTreeDb {
     };
     const ourBlock = treeRootWithIdPairs.every(([root, id]) => compareRoot(root, id));
     if (ourBlock) {
-      this.log(`Block ${l2Block.number} is ours, committing world state..`);
+      this.log(`Block ${l2Block.number} is ours, committing world state`);
       await this._commit();
     } else {
-      this.log(`Block ${l2Block.number} is not ours, rolling back world state and committing state from chain..`);
+      this.log(`Block ${l2Block.number} is not ours, rolling back world state and committing state from chain`);
       await this._rollback();
 
       // Sync the append only trees
@@ -575,7 +576,7 @@ export class MerkleTrees implements MerkleTreeDb {
       // Sync and add the block to the historic blocks tree
       const globalVariablesHash = await computeGlobalVariablesHash(l2Block.globalVariables);
       await this._updateLatestGlobalVariablesHash(globalVariablesHash);
-      this.log(`Synced global variables with hash ${this.latestGlobalVariablesHash.toString()}`);
+      this.log(`Synced global variables with hash ${globalVariablesHash}`);
 
       const blockHash = await this._getCurrentBlockHash(globalVariablesHash, true);
       await this._appendLeaves(MerkleTreeId.BLOCKS_TREE, [blockHash.toBuffer()]);
@@ -597,5 +598,7 @@ export class MerkleTrees implements MerkleTreeDb {
         this.log(`Tree ${treeName} synched with size ${info.size} root ${rootStr}`);
       }
     }
+
+    return { isBlockOurs: ourBlock };
   }
 }

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -381,6 +381,7 @@ export class MerkleTrees implements MerkleTreeDb {
   /**
    * Handles a single L2 block (i.e. Inserts the new commitments into the merkle tree).
    * @param block - The L2 block to handle.
+   * @returns Whether the block handled was produced by this same node.
    */
   public async handleL2Block(block: L2Block): Promise<HandleL2BlockResult> {
     return await this.synchronize(() => this._handleL2Block(block));

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -792,6 +792,7 @@ __metadata:
     "@types/memdown": ^3.0.0
     "@types/node": ^18.7.23
     jest: ^29.5.0
+    jest-mock-extended: ^3.0.5
     levelup: ^5.1.1
     lodash.times: ^4.3.2
     memdown: ^6.1.1


### PR DESCRIPTION
Extends the bench_publish_rollup test to spin up a 2nd node, without a sequencer, to measure how long it takes to process the published blocks.