### PR TITLE
fix: Benchmark script fixes for master branch

### DIFF
--- a/scripts/ci/assemble_e2e_benchmark.sh
+++ b/scripts/ci/assemble_e2e_benchmark.sh
@@ -13,7 +13,7 @@ BENCHMARK_FILE_JSON="benchmark.json"
 
 # Adapted from yarn-project/end-to-end/scripts/upload_logs_to_s3.sh
 if [ "${CIRCLE_BRANCH:-}" = "master" ]; then
-  LOG_SOURCE_FOLDER="logs-v1/master/$COMMIT_HASH/"
+  LOG_SOURCE_FOLDER="logs-v1/master/$COMMIT_HASH"
   BENCHMARK_TARGET_FILE="benchmarks-v1/master/$COMMIT_HASH.json"
   BENCHMARK_LATEST_FILE="benchmarks-v1/latest.json"
 elif [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
@@ -36,8 +36,8 @@ aws s3 cp "s3://${BUCKET_NAME}/${LOG_SOURCE_FOLDER}/" $LOG_FOLDER --exclude '*' 
 # to find the latest log files for the unchanged benchmarks.
 EXPECTED_BENCHMARK_COUNT=$(find yarn-project/end-to-end/src -type f -name "bench*.test.ts" | wc -l)
 DOWNLOADED_BENCHMARK_COUNT=$(find $LOG_FOLDER -type f -name "*.jsonl" | wc -l)
-if [ "$DOWNLOADED_BENCHMARK_COUNT" -lt "$EXPECTED_BENCHMARK_COUNT"]; then
-  echo Found $DOWNLOADED_BENCHMARK_COUNT out of $EXPECTED_BENCHMARK_COUNT benchmark log files. Exiting.
+if [ "$DOWNLOADED_BENCHMARK_COUNT" -lt "$EXPECTED_BENCHMARK_COUNT" ]; then
+  echo Found $DOWNLOADED_BENCHMARK_COUNT out of $EXPECTED_BENCHMARK_COUNT benchmark log files in s3://${BUCKET_NAME}/${LOG_SOURCE_FOLDER}/. Exiting.
   exit 0
 fi
 

--- a/scripts/ci/assemble_e2e_benchmark.sh
+++ b/scripts/ci/assemble_e2e_benchmark.sh
@@ -19,9 +19,12 @@ if [ "${CIRCLE_BRANCH:-}" = "master" ]; then
 elif [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
   LOG_SOURCE_FOLDER="logs-v1/pulls/${CIRCLE_PULL_REQUEST##*/}"
   BENCHMARK_TARGET_FILE="benchmarks-v1/pulls/${CIRCLE_PULL_REQUEST##*/}.json"
+elif [ -n "${CIRCLE_TAG:-}" ]; then
+  echo "Skipping benchmark run for ${CIRCLE_TAG} tagged release."
+  exit 0
 else
-  echo "Can only run benchmark aggregation on master or on a PR. Ensure CIRCLE_BRANCH or CIRCLE_PULL_REQUEST are set."
-  exit 1
+  echo "Skipping benchmark run on branch ${CIRCLE_BRANCH:-unknown}."
+  exit 0
 fi
 
 # Download benchmark log files from S3 LOG_SOURCE_FOLDER into local LOG_FOLDER


### PR DESCRIPTION
Fixes issues in benchmark script for `master` branch:
- Source logs folder path was incorrect (had an extra slash)
- Downloaded logs check was incorrect (missing space in comparison)
- Does not exit with error when on a tagged release