### PR TITLE
fix: remove -u from build_wasm script so that we can skip the build when SKIP_CPP_BUILD is unset

### DIFF
--- a/.github/workflows/publish-bb.yml
+++ b/.github/workflows/publish-bb.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Compile Typescript
         run: |
           cd barretenberg/ts
-          yarn install && yarn && SKIP_CPP_BUILD=1 yarn build
+          yarn install && yarn && SKIP_CPP_BUILD=0 yarn build
 
       - name: Tar and GZip barretenberg.wasm
         working-directory: barretenberg/cpp/build-wasm/bin

--- a/.github/workflows/publish-bb.yml
+++ b/.github/workflows/publish-bb.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Compile Typescript
         run: |
           cd barretenberg/ts
-          yarn install && yarn && yarn build
+          yarn install && yarn && SKIP_CPP_BUILD=1 yarn build
 
       - name: Tar and GZip barretenberg.wasm
         working-directory: barretenberg/cpp/build-wasm/bin

--- a/.github/workflows/publish-bb.yml
+++ b/.github/workflows/publish-bb.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Compile Typescript
         run: |
           cd barretenberg/ts
-          yarn install && yarn && SKIP_CPP_BUILD=1 yarn build
+          yarn install && yarn && yarn build
 
       - name: Tar and GZip barretenberg.wasm
         working-directory: barretenberg/cpp/build-wasm/bin

--- a/barretenberg/ts/scripts/build_wasm.sh
+++ b/barretenberg/ts/scripts/build_wasm.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eu
+set -e
 
 if [ -z "$SKIP_CPP_BUILD" ]; then
   # Build the wasms and strip debug symbols.


### PR DESCRIPTION
The build wasm script uses set -u so if SKIP_CPP_BUILD is not set, then the script will error

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
