### PR TITLE
chore: Fixes in deploy scripts

### DIFF
--- a/build-system/scripts/deploy_dockerhub
+++ b/build-system/scripts/deploy_dockerhub
@@ -37,8 +37,9 @@ echo "Deploying to dockerhub: $IMAGE_DEPLOY_URI"
 # Login.
 retry ensure_repo $REPOSITORY $ECR_DEPLOY_REGION
 
-# Login to dockerhub.
+# Login to dockerhub and ecr
 dockerhub_login
+ecr_login
 
 echo "Pulling $IMAGE_COMMIT_URI"
 # Pull image.

--- a/yarn-project/deploy_npm.sh
+++ b/yarn-project/deploy_npm.sh
@@ -37,7 +37,7 @@ function deploy_package() {
     TMP=$(mktemp)
     jq --arg v $VERSION '.version = $v' package.json > $TMP && mv $TMP package.json
 
-    if [ -z "$STANDALONE" ]; then
+    if [ -z "${STANDALONE:-}" ]; then
     # Update each dependent @aztec package version in package.json.
     for PKG in $(jq --raw-output ".dependencies | keys[] | select(contains(\"@aztec/\"))" package.json); do
         jq --arg v $VERSION ".dependencies[\"$PKG\"] = \$v" package.json > $TMP && mv $TMP package.json
@@ -49,7 +49,7 @@ function deploy_package() {
     package.json > $TMP && mv $TMP package.json
 
     # Publish
-    if [ -n "$COMMIT_TAG" ] ; then 
+    if [ -n "${COMMIT_TAG:-}" ] ; then 
         npm publish $TAG_ARG --access public
     else
         npm publish --dry-run $TAG_ARG --access public


### PR DESCRIPTION
Attempts to fix two recent bugs in the CI on deployments:

[deploy-npm](https://app.circleci.com/pipelines/github/AztecProtocol/aztec-packages/12989/workflows/8a666562-fbd1-4984-8dd3-73ded253fa12/jobs/528434?invite=true#step-103-1151_65):
```
yarn-project/deploy_npm.sh: line 40: STANDALONE: unbound variable
```

[deploy-sandbox](https://app.circleci.com/pipelines/github/AztecProtocol/aztec-packages/12989/workflows/8a666562-fbd1-4984-8dd3-73ded253fa12/jobs/528435?invite=true#step-103-552_177)
```
Error response from daemon: Head "https://278380418400.dkr.ecr.us-east-2.amazonaws.com/v2/aztec-sandbox/manifests/cache-9bb9af92b2b92bd13529f3125bcc1c6b6be44bfd-x86_64": no basic auth credentials
```