### PR TITLE
fix: Make target architecture configurable, target westmere in GA.

### DIFF
--- a/.github/workflows/publish-bb.yml
+++ b/.github/workflows/publish-bb.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           cd barretenberg/cpp
 
-          cmake --preset default -DCMAKE_BUILD_TYPE=RelWithAssert
+          cmake --preset default -DCMAKE_BUILD_TYPE=RelWithAssert -DTARGET_ARCH=westmere
           cmake --build --preset default --target bb
 
       - name: Tar and GZip bb Binary (Ubuntu)

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -16,6 +16,9 @@
         "CC": "clang",
         "CXX": "clang++",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      },
+      "cacheVariables": {
+        "TARGET_ARCH": "skylake"
       }
     },
     {
@@ -51,20 +54,20 @@
         "DISABLE_ASM": "ON"
       }
     },
-    {"name":"asan",
-    "displayName": "Debugging build with address sanitizer on Clang-16",
-  "description": "Build with address sanitizer on clang16 with debugging information",
-  "inherits":"clang16-dbg",
+    {
+      "name": "asan",
+      "displayName": "Debugging build with address sanitizer on Clang-16",
+      "description": "Build with address sanitizer on clang16 with debugging information",
+      "inherits": "clang16-dbg",
       "binaryDir": "build-asan",
-"environment": {
+      "environment": {
         "CMAKE_BUILD_TYPE": "Debug"
       },
       "cacheVariables": {
         "ENABLE_ASAN": "ON",
-        "DISABLE_ASM": "ON" 
+        "DISABLE_ASM": "ON"
       }
-
-},
+    },
     {
       "name": "gcc",
       "displayName": "Build with GCC",
@@ -193,7 +196,8 @@
       "name": "clang16-dbg",
       "inherits": "default",
       "configurePreset": "clang16-dbg"
-    },{
+    },
+    {
       "name": "asan",
       "inherits": "default",
       "configurePreset": "asan"
@@ -218,7 +222,7 @@
       "inherits": "clang16",
       "configurePreset": "fuzzing"
     },
-    { 
+    {
       "name": "smt-verification",
       "inherits": "clang16",
       "configurePreset": "smt-verification"
@@ -278,7 +282,7 @@
       "inherits": "default",
       "configurePreset": "clang16-dbg"
     },
-  {
+    {
       "name": "asan",
       "inherits": "default",
       "configurePreset": "asan"

--- a/barretenberg/cpp/cmake/arch.cmake
+++ b/barretenberg/cpp/cmake/arch.cmake
@@ -6,5 +6,6 @@ if(WASM)
 endif()
 
 if(NOT WASM AND NOT APPLE AND NOT ARM)
-    add_compile_options(-march=skylake)
+    message(STATUS "Target architecture: ${TARGET_ARCH}")
+    add_compile_options(-march=${TARGET_ARCH})
 endif()


### PR DESCRIPTION
As title.
I'm assuming(!) that westmere is old enough to not cause issues, but havent actually fired up some old intel machine to test this works where the old one didn't.

While it's good we can now do this, I'm not totally sure why we should *need* a backend to be present.
Maybe nargo can have a no backend mode where it makes some assumptions about what's available (printing a warning that its assuming), but still allows one to produce acir.

Because in theory, none of our sandbox users should really *need* a backend to be present.