### PR TITLE
feat: ZeroMorph

### DIFF
--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -182,12 +182,13 @@ template <typename Curve> class ZeroMorphProver {
     {
         (void)N_max;
 
-        auto q_zeta = zeta_x.factor_roots(x_challenge);
-        auto q_Z = Z_x.factor_roots(x_challenge);
+        // Compute q_{\zeta} and q_Z in place
+        zeta_x.factor_roots(x_challenge);
+        Z_x.factor_roots(x_challenge);
 
-        // Partially evaluated zeromorph identity polynomial Z_x
-        auto result = q_zeta;
-        result.add_scaled(q_Z, z_challenge);
+        // Compute batched quotient q_{\zeta} + z*q_Z
+        auto result = zeta_x;
+        result.add_scaled(Z_x, z_challenge);
 
         // WORKTODO: it wouldn't make sense to store the massive poly that results from shifting by N_{max}-(N-1). Can
         // we just compute the shifted commitment without ever storing the shifted poly explicitly?

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -12,7 +12,7 @@ namespace proof_system::honk::pcs::zeromorph {
  *
  * @tparam Curve
  */
-template <typename Curve> class ZeroMorphProver {
+template <typename Curve> class ZeroMorphProver_ {
     using Fr = typename Curve::ScalarField;
     using Commitment = typename Curve::AffineElement;
     using Polynomial = barretenberg::Polynomial<Fr>;
@@ -252,7 +252,7 @@ template <typename Curve> class ZeroMorphProver {
  *
  * @tparam Curve
  */
-template <typename Curve> class ZeroMorphVerifier {
+template <typename Curve> class ZeroMorphVerifier_ {
     using Fr = typename Curve::ScalarField;
     using Commitment = typename Curve::AffineElement;
 

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -12,8 +12,8 @@ template <typename Curve> class ZeroMorphProver {
     using Commitment = typename Curve::AffineElement;
     using Polynomial = barretenberg::Polynomial<Fr>;
 
-    // WORKTODO: whats the real number? 25?
-    // Number of G1 elements in the srs. (It is not possible to commit to polynomials of degree > N_max-1).
+    // TODO(#742): Set this N_max to be the number of G1 elements in the mocked zeromorph SRS once it's in place. (Then,
+    // eventually, set it based on the real SRS).
     static const size_t N_max = 1 << 10;
 
   public:
@@ -217,7 +217,7 @@ template <typename Curve> class ZeroMorphProver {
         auto batched_quotient = zeta_x;
         batched_quotient.add_scaled(Z_x, z_challenge);
 
-        // TODO(ISSUE#): To complete the degree check, we need to commit to (q_{\zeta} + z*q_Z)*X^{N_max - N - 1}.
+        // TODO(#742): To complete the degree check, we need to commit to (q_{\zeta} + z*q_Z)*X^{N_max - N - 1}.
         // Verification then requires a pairing check similar to the standard KZG check but with [1]_2 replaced by
         // [X^{N_max - N -1}]_2. Two issues: A) we do not have an SRS with these G2 elements (so need to generate a fake
         // setup until we can do the real thing), and B) its not clear to me how to update our pairing algorithms to do

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -30,20 +30,23 @@ template <typename Curve> class ZeroMorphProver {
     static std::vector<Polynomial> compute_multivariate_quotients(std::span<Fr> input_polynomial,
                                                                   std::span<Fr> u_challenge)
     {
-        size_t log_n = numeric::get_msb(input_polynomial.size());
+        size_t n = input_polynomial.size();
+        size_t log_n = numeric::get_msb(n);
 
         // Define the vector of quotients q_k, k = 0, ..., log_n-1
-        std::vector<Polynomial> multilinear_quotients;
-        multilinear_quotients.reserve(log_n);
+        std::vector<Polynomial> quotients;
+        quotients.reserve(log_n);
 
         // WORKTODO: Actually compute the q_k here!
-        size_t k = 0;
-        for (auto& quotient : multilinear_quotients) {
+        for (size_t k = 0; k < log_n; ++k) {
             (void)u_challenge;
-            quotient = Polynomial(1 << k); // deg(q_k) = 2^k - 1
+            // Note: in reality we want polys of size 2^k but for convenience use size n for now
+            // quotient = Polynomial(1 << k); // deg(q_k) = 2^k - 1
+            quotients.emplace_back(Polynomial(n)); // deg(q_k) = 2^k - 1
+            quotients[k][0] = k;                   // add an arbitrary non-zero coefficient
         }
 
-        return multilinear_quotients;
+        return quotients;
     }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -178,18 +178,19 @@ template <typename Curve> class ZeroMorphProver {
      * @return Polynomial
      */
     static Polynomial compute_batched_evaluation_and_degree_check_quotient(
-        Polynomial& Z_x, Polynomial& zeta_x, Fr x_challenge, Fr z_challenge, size_t N_max)
+        Polynomial& zeta_x, Polynomial& Z_x, Fr x_challenge, Fr z_challenge, size_t N_max)
     {
-        (void)Z_x;
-        (void)zeta_x;
-        (void)x_challenge;
-        (void)z_challenge;
         (void)N_max;
 
-        size_t N = Z_x.size();
+        auto q_zeta = zeta_x.factor_roots(x_challenge);
+        auto q_Z = Z_x.factor_roots(x_challenge);
 
         // Partially evaluated zeromorph identity polynomial Z_x
-        auto result = Polynomial(N);
+        auto result = q_zeta;
+        result.add_scaled(q_Z, z_challenge);
+
+        // WORKTODO: it wouldn't make sense to store the massive poly that results from shifting by N_{max}-(N-1). Can
+        // we just compute the shifted commitment without ever storing the shifted poly explicitly?
 
         return result;
     }

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -91,7 +91,7 @@ template <typename Curve> class ZeroMorphProver {
         auto scalar = Fr(1); // y^k
         for (auto& quotient : quotients) {
             // Accumulate y^k*q_k into q, at the index offset N - d_k - 1
-            size_t deg_k = (1ULL << k) - 1;
+            auto deg_k = static_cast<size_t>((1 << k) - 1);
             size_t offset = N - deg_k - 1;
             for (size_t idx = 0; idx < deg_k + 1; ++idx) {
                 result[offset + idx] += scalar * quotient[idx];
@@ -129,9 +129,8 @@ template <typename Curve> class ZeroMorphProver {
         auto y_power = Fr(1); // y^k
         for (auto& quotient : quotients) {
             // Accumulate y^k * x^{N - d_k - 1} * q_k into \hat{q}
-            size_t deg_k = (1 << k) - 1;
-            auto x_power = x_challenge.pow(N - deg_k - 1);
-            // size_t offset = N - deg_k - 1;
+            auto deg_k = static_cast<size_t>((1 << k) - 1);
+            auto x_power = x_challenge.pow(N - deg_k - 1); // x^{N - d_k - 1}
             for (size_t idx = 0; idx < deg_k + 1; ++idx) {
                 result[idx] -= y_power * x_power * quotient[idx];
             }

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -1,0 +1,172 @@
+#pragma once
+// #include "barretenberg/honk/pcs/claim.hpp"
+// #include "barretenberg/honk/pcs/commitment_key.hpp"
+// #include "barretenberg/honk/pcs/verification_key.hpp"
+// #include "barretenberg/honk/transcript/transcript.hpp"
+#include "barretenberg/polynomials/polynomial.hpp"
+
+/**
+ * @brief
+ *
+ */
+namespace proof_system::honk::pcs::zeromorph {
+
+template <typename Curve> class ZeroMorphProver {
+    using Fr = typename Curve::ScalarField;
+    using Commitment = typename Curve::AffineElement;
+    using Polynomial = barretenberg::Polynomial<Fr>;
+
+  public:
+    /**
+     * @brief Compute multivariate quotients q_k(X_0, ..., X_{k-1}) for f(X_0, ..., X_{d-1})
+     * @details Given multilinear polynomial f = f(X_0, ..., X_{d-1}) for which f(u) = v, compute q_k such that:
+     *
+     *  f(X_0, ..., X_{d-1}) - v = \sum_{k=0}^{d-1} (X_k - u_k)q_k(X_0, ..., X_{k-1})
+     *
+     * @param input_polynomial Multilinear polynomial f(X_0, ..., X_{d-1})
+     * @param u_challenge Multivariate challenge u = (u_0, ..., u_{d-1})
+     * @return std::vector<Polynomial>
+     */
+    static std::vector<Polynomial> compute_multivariate_quotients(std::span<Fr> input_polynomial,
+                                                                  std::span<Fr> u_challenge)
+    {
+        size_t log_n = numeric::get_msb(input_polynomial.size());
+
+        // Define the vector of quotients q_k, k = 0, ..., log_n-1
+        std::vector<Polynomial> multilinear_quotients;
+        multilinear_quotients.reserve(log_n);
+
+        // WORKTODO: Actually compute the q_k here!
+        size_t k = 0;
+        for (auto& quotient : multilinear_quotients) {
+            (void)u_challenge;
+            quotient = Polynomial(1 << k); // deg(q_k) = 2^k - 1
+        }
+
+        return multilinear_quotients;
+    }
+
+    /**
+     * @brief Construct batched, lifted-degree univariate quotient
+     *
+     * @param quotients Polynomials q_k, interpreted as univariates; deg(q_k) = 2^k - 1
+     * @param N
+     * @return Polynomial
+     */
+    static Polynomial compute_batched_lifted_degree_quotient(std::vector<Polynomial>& quotients,
+                                                             Fr y_challenge,
+                                                             size_t N)
+    {
+        (void)y_challenge;
+
+        // Batched lifted degree quotient polynomial
+        auto result = Polynomial(N);
+
+        // WORKTODO: Compute q = \sum_k y^k * X^{N - d_k - 1} * q_k
+        for (auto& quotient : quotients) {
+            // Simply accumulate y^k*q_k into q, at the index offset N - d_k - 1
+            (void)quotient;
+        }
+
+        return result;
+    }
+
+    /**
+     * @brief Compute partially evaluated degree check polynomial \zeta_x = q - \sum_k y^k * x^{N - d_k - 1} * q_k
+     * @details Compute \zeta_x, where
+     *
+     *                          \zeta_x = q - \sum_k y^k * x^{N - d_k - 1} * q_k
+     *
+     * @param batched_quotient
+     * @param quotients
+     * @param y_challenge
+     * @param x_challenge
+     * @param N
+     * @return Polynomial Degree check polynomial \zeta_x such that \zeta_x(x) = 0
+     */
+    static Polynomial compute_partially_evaluated_degree_check_polynomial(
+        Polynomial& batched_quotient, std::vector<Polynomial>& quotients, Fr y_challenge, Fr x_challenge, size_t N)
+    {
+        (void)batched_quotient;
+        (void)y_challenge;
+        (void)x_challenge;
+
+        // Partially evaluated degree check polynomial \zeta_x
+        auto result = Polynomial(N);
+
+        // WORKTODO: Compute partially evaluated degree check polynomial q - \sum_k y^k * x^{N - d_k - 1} * q_k
+        for (auto& quotient : quotients) {
+            // Simply add y^k*x^{N - d_k - 1}q_k into q
+            (void)quotient;
+        }
+
+        return result;
+    }
+
+    /**
+     * @brief Compute partially evaluated zeromorph identity polynomial Z_x
+     * @details Compute Z_x, where
+     *
+     *     Z_x = f - v - \sum_k (x^{2^k}\Phi_{n-k-1}(x^{2^{k-1}}) - u_k\Phi_{n-k}(x^{2^k})) * q_k
+     *
+     * @param input_polynomial
+     * @param quotients
+     * @param v_evaluation
+     * @param x_challenge
+     * @return Polynomial
+     */
+    static Polynomial compute_partially_evaluated_zeromorph_identity_polynomial(Polynomial& input_polynomial,
+                                                                                std::vector<Polynomial>& quotients,
+                                                                                Fr v_evaluation,
+                                                                                Fr x_challenge)
+    {
+        (void)input_polynomial;
+        (void)v_evaluation;
+        (void)x_challenge;
+        size_t N = input_polynomial.size();
+
+        // Partially evaluated zeromorph identity polynomial Z_x
+        auto result = Polynomial(N);
+
+        // WORKTODO: Compute partially evaluated degree check polynomial q - \sum_k y^k * x^{N - d_k - 1} * q_k
+        for (auto& quotient : quotients) {
+            (void)quotient;
+        }
+
+        return result;
+    }
+
+    /**
+     * @brief Compute combined evaluation and degree-check quotient polynomial pi
+     * @details Compute univariate quotient pi, where
+     *
+     *  pi = (q_\zeta + z*q_Z) X^{N_{max}-(N-1)}, with q_\zeta = \zeta_x/(X-x), q_Z = Z_x/(X-x)
+     *
+     * @param Z_x
+     * @param zeta_x
+     * @param x_challenge
+     * @param z_challenge
+     * @param N_max
+     * @return Polynomial
+     */
+    static Polynomial compute_batched_evaluation_and_degree_check_quotient(
+        Polynomial& Z_x, Polynomial& zeta_x, Fr x_challenge, Fr z_challenge, size_t N_max)
+    {
+        (void)Z_x;
+        (void)zeta_x;
+        (void)x_challenge;
+        (void)z_challenge;
+        (void)N_max;
+
+        size_t N = Z_x.size();
+
+        // Partially evaluated zeromorph identity polynomial Z_x
+        auto result = Polynomial(N);
+
+        return result;
+    }
+};
+
+template <typename Curve> class ZeroMorphVerifier {};
+
+} // namespace proof_system::honk::pcs::zeromorph

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -159,12 +159,12 @@ template <typename Curve> class ZeroMorphProver_ {
      * @param x_challenge
      * @return Polynomial
      */
-    static Polynomial compute_partially_evaluated_zeromorph_identity_polynomial_new(Polynomial& f_batched,
-                                                                                    Polynomial& g_batched,
-                                                                                    std::vector<Polynomial>& quotients,
-                                                                                    Fr v_evaluation,
-                                                                                    std::span<Fr> u_challenge,
-                                                                                    Fr x_challenge)
+    static Polynomial compute_partially_evaluated_zeromorph_identity_polynomial(Polynomial& f_batched,
+                                                                                Polynomial& g_batched,
+                                                                                std::vector<Polynomial>& quotients,
+                                                                                Fr v_evaluation,
+                                                                                std::span<Fr> u_challenge,
+                                                                                Fr x_challenge)
     {
         size_t N = f_batched.size();
         size_t log_N = quotients.size();

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -28,8 +28,8 @@ template <typename Curve> class ZeroMorphProver_ {
      *
      *  f(X_0, ..., X_{d-1}) - v = \sum_{k=0}^{d-1} (X_k - u_k)q_k(X_0, ..., X_{k-1})
      *
-     * The polynomials q_k can be computed explicitly as the difference of the partial evaluation of f in the last k
-     * variables at, respectively, u'' = (u_k + 1, u_{k+1}, ..., u_{n-1}) and u' = (u_k, ..., u_{n-1}). I.e.
+     * The polynomials q_k can be computed explicitly as the difference of the partial evaluation of f in the last
+     * (n - k) variables at, respectively, u'' = (u_k + 1, u_{k+1}, ..., u_{n-1}) and u' = (u_k, ..., u_{n-1}). I.e.
      *
      *  q_k(X_0, ..., X_{k-1}) = f(X_0,...,X_{k-1}, u'') - f(X_0,...,X_{k-1}, u')
      *
@@ -57,8 +57,8 @@ template <typename Curve> class ZeroMorphProver_ {
         // Compute the q_k in reverse order, i.e. q_{n-1}, ..., q_0
         for (size_t k = 0; k < log_poly_size; ++k) {
             // Define partial evaluation point u' = (u_k, ..., u_{n-1})
-            auto partial_size = static_cast<std::ptrdiff_t>(k + 1);
-            std::vector<Fr> u_partial(u_challenge.end() - partial_size, u_challenge.end());
+            auto evaluation_point_size = static_cast<std::ptrdiff_t>(k + 1);
+            std::vector<Fr> u_partial(u_challenge.end() - evaluation_point_size, u_challenge.end());
 
             // Compute f' = f(X_0,...,X_{k-1}, u')
             auto f_1 = polynomial.partial_evaluate_mle(u_partial);

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
@@ -139,10 +139,11 @@ TYPED_TEST(ZeroMorphTest, PartiallyEvaluatedQuotientZeta)
 
     auto x_challenge = Fr::random_element();
 
+    // Contruct zeta_x using the prover method
     auto zeta_x = ZeroMorphProver::compute_partially_evaluated_degree_check_polynomial(
         batched_quotient, quotients, y_challenge, x_challenge);
 
-    // Now explicitly compute the expected result
+    // Now construct zeta_x explicitly
     auto zeta_x_expected = Polynomial(N);
     zeta_x_expected += batched_quotient;
     // q_batched - \sum_k q_k * y^k * x^{N - deg(q_k) - 1}
@@ -155,8 +156,8 @@ TYPED_TEST(ZeroMorphTest, PartiallyEvaluatedQuotientZeta)
 
 /**
  * @brief Demonstrate formulas for efficiently computing \Phi_k(x) = \sum_{i=0}^{k-1}x^i
- * @details \Phi_k(x) = \sum_{i=0}^{k-1}x^i
- *                    = (x^{2^k} - 1) / (x - 1)
+ * @details \Phi_k(x) = \sum_{i=0}^{k-1}x^i = (x^{2^k} - 1) / (x - 1)
+ *
  */
 TYPED_TEST(ZeroMorphTest, PhiEvaluation)
 {
@@ -220,12 +221,13 @@ TYPED_TEST(ZeroMorphTest, PartiallyEvaluatedQuotientZ)
 
     auto x_challenge = Fr::random_element();
 
+    // Construct Z_x using the prover method
     auto Z_x = ZeroMorphProver::compute_partially_evaluated_zeromorph_identity_polynomial(
         multilinear_f, quotients, v_evaluation, u_challenge, x_challenge);
 
     // Compute Z_x directly
     auto Z_x_expected = multilinear_f;
-    Z_x_expected[0] -= v_evaluation;
+    Z_x_expected[0] -= v_evaluation * this->Phi(x_challenge, log_N);
     for (size_t k = 0; k < log_N; ++k) {
         auto x_pow_2k = x_challenge.pow(1 << k);         // x^{2^k}
         auto x_pow_2kp1 = x_challenge.pow(1 << (k + 1)); // x^{2^{k+1}}
@@ -246,67 +248,338 @@ TYPED_TEST(ZeroMorphTest, Single)
     using Fr = typename TypeParam::ScalarField;
     using Commitment = typename TypeParam::AffineElement;
     using ZeroMorphProver = ZeroMorphProver<TypeParam>;
-    size_t N_max = 32; // mock
     size_t n = 16;
     size_t log_n = numeric::get_msb(n);
+
+    // Construct a random multilinear polynomial f, and (u,v) such that f(u) = v.
+    auto f_polynomial = this->random_polynomial(n);
+    auto u_challenge = this->random_evaluation_point(log_n);
+    auto v_evaluation = f_polynomial.evaluate_mle(u_challenge);
+    auto f_commitment = this->commit(f_polynomial);
 
     // Initialize an empty ProverTranscript
     auto prover_transcript = ProverTranscript<Fr>::init_empty();
 
-    // Construct a random multilinear polynomial f, and (u,v) such that f(u) = v.
-    auto multilinear_f = this->random_polynomial(n);
-    auto u_challenge = this->random_evaluation_point(log_n);
-    auto v_evaluation = multilinear_f.evaluate_mle(u_challenge);
+    // Execute Prover protocol
+    {
+        // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
+        auto quotients = ZeroMorphProver::compute_multilinear_quotients(f_polynomial, u_challenge);
 
-    // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
-    auto quotients = ZeroMorphProver::compute_multilinear_quotients(multilinear_f, u_challenge);
+        // Compute and send commitments C_{q_k} = [q_k], k = 0,...,d-1
+        std::vector<Commitment> q_k_commitments;
+        q_k_commitments.reserve(log_n);
+        for (size_t idx = 0; idx < log_n; ++idx) {
+            q_k_commitments[idx] = this->commit(quotients[idx]);
+            std::string label = "ZM:C_q_" + std::to_string(idx);
+            prover_transcript.send_to_verifier(label, q_k_commitments[idx]);
+        }
 
-    // Compute and send commitment C = [f]
-    Commitment f_commitment = this->commit(multilinear_f);
-    prover_transcript.send_to_verifier("ZM:C", f_commitment);
+        // Get challenge y
+        auto y_challenge = prover_transcript.get_challenge("ZM:y");
 
-    // Compute and send commitments C_k = [q_k], k = 0,...,d-1
-    std::vector<Commitment> q_k_commitments;
-    q_k_commitments.reserve(log_n);
-    for (size_t idx = 0; idx < log_n; ++idx) {
-        q_k_commitments[idx] = this->commit(quotients[idx]);
-        std::string label = "ZM:C_" + std::to_string(idx);
-        prover_transcript.send_to_verifier(label, q_k_commitments[idx]);
+        // Compute the batched, lifted-degree quotient \hat{q}
+        auto batched_quotient = ZeroMorphProver::compute_batched_lifted_degree_quotient(quotients, y_challenge, n);
+
+        // Compute and send the commitment C_q = [\hat{q}]
+        auto q_commitment = this->commit(batched_quotient);
+        prover_transcript.send_to_verifier("ZM:C_q", q_commitment);
+
+        // Get challenges x and z
+        auto [x_challenge, z_challenge] = prover_transcript.get_challenges("ZM:x", "ZM:z");
+
+        // Compute degree check polynomial \zeta partially evaluated at x
+        auto zeta_x = ZeroMorphProver::compute_partially_evaluated_degree_check_polynomial(
+            batched_quotient, quotients, y_challenge, x_challenge);
+
+        // Compute ZeroMorph identity polynomial Z partially evaluated at x
+        auto Z_x = ZeroMorphProver::compute_partially_evaluated_zeromorph_identity_polynomial(
+            f_polynomial, quotients, v_evaluation, u_challenge, x_challenge);
+
+        // Compute batched degree and ZM-identity quotient polynomial pi
+        auto pi_polynomial = ZeroMorphProver::compute_batched_evaluation_and_degree_check_quotient(
+            zeta_x, Z_x, x_challenge, z_challenge);
+
+        // Compute and send proof commitment pi
+        auto pi_commitment = this->commit(pi_polynomial);
+        prover_transcript.send_to_verifier("ZM:PI", pi_commitment);
     }
 
-    // Get challenge y
-    auto y_challenge = prover_transcript.get_challenge("ZM:y");
-    (void)y_challenge;
+    auto verifier_transcript = VerifierTranscript<Fr>::init_empty(prover_transcript);
 
-    // Compute the batched, lifted-degree quotient \hat{q}
-    auto batched_quotient = ZeroMorphProver::compute_batched_lifted_degree_quotient(quotients, y_challenge, n);
+    // Execute Verifier protocol
+    {
+        // Receive commitments [q_k]
+        std::vector<Commitment> C_q_k;
+        C_q_k.reserve(log_n);
+        for (size_t i = 0; i < log_n; ++i) {
+            C_q_k.emplace_back(
+                verifier_transcript.template receive_from_prover<Commitment>("ZM:C_q_" + std::to_string(i)));
+        }
 
-    // Compute and send the commitment C_q = [\hat{q}]
-    auto q_commitment = this->commit(batched_quotient);
-    prover_transcript.send_to_verifier("ZM:C_q", q_commitment);
+        // Challenge y
+        auto y_challenge = verifier_transcript.get_challenge("ZM:y");
 
-    // Get challenges x and z
-    auto [x_challenge, z_challenge] = prover_transcript.get_challenges("ZM:x", "ZM:z");
+        // Receive commitment C_{q}
+        auto C_q = verifier_transcript.template receive_from_prover<Commitment>("ZM:C_q");
 
-    // Compute degree check polynomial \zeta partially evaluated at x
-    auto zeta_x = ZeroMorphProver::compute_partially_evaluated_degree_check_polynomial(
-        batched_quotient, quotients, y_challenge, x_challenge);
+        // Challenges x, z
+        auto [x_challenge, z_challenge] = verifier_transcript.get_challenges("ZM:x", "ZM:z");
 
-    // Compute ZeroMorph identity polynomial Z partially evaluated at x
-    auto Z_x = ZeroMorphProver::compute_partially_evaluated_zeromorph_identity_polynomial(
-        multilinear_f, quotients, v_evaluation, u_challenge, x_challenge);
+        // Compute commitment C_{v,x}
+        auto C_v_x = Commitment::one() * v_evaluation * this->Phi(x_challenge, log_n);
 
-    // Compute batched degree and ZM-identity quotient polynomial
-    auto pi_polynomial = ZeroMorphProver::compute_batched_evaluation_and_degree_check_quotient(
-        zeta_x, Z_x, x_challenge, z_challenge, N_max);
+        // Compute commitment C_{\zeta_x}
+        auto C_zeta_x = C_q;
+        for (size_t k = 0; k < log_n; ++k) {
+            size_t deg_k = (1ULL << k) - 1;
+            // Compute scalar y^k * x^{N - deg_k - 1}
+            auto scalar = y_challenge.pow(k);
+            scalar *= x_challenge.pow(n - deg_k - 1);
+            scalar *= Fr(-1);
 
-    // Compute and send proof commitment pi
-    auto pi_commitment = this->commit(pi_polynomial);
-    prover_transcript.send_to_verifier("ZM:PI", pi_commitment);
+            C_zeta_x = C_zeta_x + C_q_k[k] * scalar;
+        }
 
-    bool verified = true;
+        // Compute commitment C_{Z_x}
+        auto C_Z_x = f_commitment + C_v_x * Fr(-1); // C_f - C_{v,x}
+        for (size_t k = 0; k < log_n; ++k) {
+            // Compute scalar x^{2^k} * \Phi_{n-k-1}(x^{2^{k+1}}) - u_k *  \Phi_{n-k}(x^{2^k})
+            auto x_pow_2k = x_challenge.pow(1 << k);         // x^{2^k}
+            auto x_pow_2kp1 = x_challenge.pow(1 << (k + 1)); // x^{2^{k+1}}
+            auto scalar = x_pow_2k * this->Phi(x_pow_2kp1, log_n - k - 1);
+            scalar -= u_challenge[k] * this->Phi(x_pow_2k, log_n - k);
+            scalar *= Fr(-1);
 
-    EXPECT_EQ(verified, true);
+            C_Z_x = C_Z_x + C_q_k[k] * scalar;
+        }
+
+        // Compute commitment C_{\zeta,Z}
+        auto C_zeta_Z = C_zeta_x + C_Z_x * z_challenge;
+
+        // Receive proof commitment \pi
+        auto C_pi = verifier_transcript.template receive_from_prover<Commitment>("ZM:PI");
+
+        // The prover and verifier manifests should agree
+        EXPECT_EQ(prover_transcript.get_manifest(), verifier_transcript.get_manifest());
+
+        // Construct inputs and perform pairing check to verify claimed evaluation
+        auto P0 = C_zeta_Z + C_pi * x_challenge;
+        auto P1 = -C_pi;
+        auto verified = this->vk()->pairing_check(P0, P1);
+        EXPECT_TRUE(verified);
+    }
 }
+
+/**
+ * @brief Full Prover/Verifier protocol for proving multilinear evaluation f(u) = v
+ *
+ */
+// TYPED_TEST(ZeroMorphTest, SingleZxOnly)
+// {
+//     using Fr = typename TypeParam::ScalarField;
+//     using Commitment = typename TypeParam::AffineElement;
+//     using ZeroMorphProver = ZeroMorphProver<TypeParam>;
+//     size_t n = 16;
+//     size_t log_n = numeric::get_msb(n);
+
+//     // Construct a random multilinear polynomial f, and (u,v) such that f(u) = v.
+//     auto multilinear_f = this->random_polynomial(n);
+//     auto u_challenge = this->random_evaluation_point(log_n);
+//     auto v_evaluation = multilinear_f.evaluate_mle(u_challenge);
+
+//     // Initialize an empty ProverTranscript
+//     auto prover_transcript = ProverTranscript<Fr>::init_empty();
+
+//     // Execute Prover protocol
+
+//     // WORKTODO: this is a little funny. [f] will have been sent previously. It must be in hash used to generate u.
+//     // Compute and send commitment C = [f] and evaluation v = f(u)
+//     Commitment f_commitment = this->commit(multilinear_f);
+//     prover_transcript.send_to_verifier("ZM:C", f_commitment);
+//     prover_transcript.send_to_verifier("ZM:v", v_evaluation);
+
+//     // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
+//     auto quotients = ZeroMorphProver::compute_multilinear_quotients(multilinear_f, u_challenge);
+
+//     // Compute and send commitments C_{q_k} = [q_k], k = 0,...,d-1
+//     std::vector<Commitment> q_k_commitments;
+//     q_k_commitments.reserve(log_n);
+//     for (size_t idx = 0; idx < log_n; ++idx) {
+//         q_k_commitments[idx] = this->commit(quotients[idx]);
+//         std::string label = "ZM:C_q_" + std::to_string(idx);
+//         prover_transcript.send_to_verifier(label, q_k_commitments[idx]);
+//     }
+
+//     // Get challenge x
+//     auto x_challenge = prover_transcript.get_challenge("ZM:x");
+
+//     // Compute ZeroMorph identity polynomial Z partially evaluated at x
+//     auto Z_x = ZeroMorphProver::compute_partially_evaluated_zeromorph_identity_polynomial(
+//         multilinear_f, quotients, v_evaluation, u_challenge, x_challenge);
+
+//     // Compute and send proof commitment pi
+//     Z_x.factor_roots(x_challenge);
+//     auto pi_commitment = this->commit(Z_x);
+//     prover_transcript.send_to_verifier("ZM:PI", pi_commitment);
+
+//     auto verifier_transcript = VerifierTranscript<Fr>::init_empty(prover_transcript);
+
+//     // Execute Verifier protocol
+
+//     // Receive commitments to f and q_k, and evaluation v = f(u)
+//     auto C_f = verifier_transcript.template receive_from_prover<Commitment>("ZM:C");
+//     auto v_eval = verifier_transcript.template receive_from_prover<Fr>("ZM:v");
+
+//     std::vector<Commitment> C_q_k;
+//     C_q_k.reserve(log_n);
+//     for (size_t i = 0; i < log_n; ++i) {
+//         C_q_k.emplace_back(verifier_transcript.template receive_from_prover<Commitment>("ZM:C_q_" +
+//         std::to_string(i)));
+//     }
+
+//     // Challenge y
+//     auto x_chal = verifier_transcript.get_challenge("ZM:x");
+
+//     // Compute commitment C_{v,x}
+//     auto C_v_x = Commitment::one() * v_eval * this->Phi(x_chal, log_n);
+
+//     // Compute commitment C_{Z_x}
+//     auto C_Z_x = C_f + C_v_x * Fr(-1); // C_f - C_{v,x}
+//     for (size_t k = 0; k < log_n; ++k) {
+//         auto x_pow_2k = x_chal.pow(1 << k);         // x^{2^k}
+//         auto x_pow_2kp1 = x_chal.pow(1 << (k + 1)); // x^{2^{k+1}}
+//         // Compute scalar x^{2^k} * \Phi_{n-k-1}(x^{2^{k+1}}) - u_k *  \Phi_{n-k}(x^{2^k})
+//         auto scalar = x_pow_2k * this->Phi(x_pow_2kp1, log_n - k - 1);
+//         scalar -= u_challenge[k] * this->Phi(x_pow_2k, log_n - k);
+//         C_Z_x = C_Z_x + C_q_k[k] * scalar * Fr(-1);
+//     }
+
+//     // Receive proof commitment \pi
+//     auto C_pi = verifier_transcript.template receive_from_prover<Commitment>("ZM:PI");
+
+//     // Construct pairing check inputs
+//     auto P0 = C_Z_x + C_pi * x_chal;
+//     auto P1 = C_pi * Fr(-1);
+
+//     // Do pairing check
+//     auto verified = this->vk()->pairing_check(P0, P1);
+//     EXPECT_TRUE(verified);
+
+//     // prover_transcript.print();
+//     // verifier_transcript.print();
+//     EXPECT_EQ(prover_transcript.get_manifest(), verifier_transcript.get_manifest());
+// }
+
+// /**
+//  * @brief Full Prover/Verifier protocol for proving multilinear evaluation f(u) = v
+//  *
+//  */
+// TYPED_TEST(ZeroMorphTest, SingleZetaxOnly)
+// {
+//     using Fr = typename TypeParam::ScalarField;
+//     using Commitment = typename TypeParam::AffineElement;
+//     using ZeroMorphProver = ZeroMorphProver<TypeParam>;
+//     size_t n = 16;
+//     size_t log_n = numeric::get_msb(n);
+
+//     // Construct a random multilinear polynomial f, and (u,v) such that f(u) = v.
+//     auto multilinear_f = this->random_polynomial(n);
+//     auto u_challenge = this->random_evaluation_point(log_n);
+//     // auto v_evaluation = multilinear_f.evaluate_mle(u_challenge);
+
+//     // Initialize an empty ProverTranscript
+//     auto prover_transcript = ProverTranscript<Fr>::init_empty();
+
+//     // Execute Prover protocol
+
+//     // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
+//     auto quotients = ZeroMorphProver::compute_multilinear_quotients(multilinear_f, u_challenge);
+
+//     // Compute and send commitments C_{q_k} = [q_k], k = 0,...,d-1
+//     std::vector<Commitment> q_k_commitments;
+//     q_k_commitments.reserve(log_n);
+//     for (size_t idx = 0; idx < log_n; ++idx) {
+//         q_k_commitments[idx] = this->commit(quotients[idx]);
+//         std::string label = "ZM:C_q_" + std::to_string(idx);
+//         prover_transcript.send_to_verifier(label, q_k_commitments[idx]);
+//     }
+
+//     // Get challenge y
+//     auto y_challenge = prover_transcript.get_challenge("ZM:y");
+
+//     // Compute the batched, lifted-degree quotient \hat{q}
+//     auto batched_quotient = ZeroMorphProver::compute_batched_lifted_degree_quotient(quotients, y_challenge, n);
+
+//     // Compute and send the commitment C_q = [\hat{q}]
+//     auto q_commitment = this->commit(batched_quotient);
+//     prover_transcript.send_to_verifier("ZM:C_q", q_commitment);
+
+//     // Get challenges x and z
+//     auto x_challenge = prover_transcript.get_challenge("ZM:x");
+
+//     // Compute degree check polynomial \zeta partially evaluated at x
+//     auto zeta_x = ZeroMorphProver::compute_partially_evaluated_degree_check_polynomial(
+//         batched_quotient, quotients, y_challenge, x_challenge);
+
+//     auto commitment_zeta_x = this->commit(zeta_x);
+
+//     // Compute and send proof commitment pi
+//     zeta_x.factor_roots(x_challenge);
+//     auto pi_commitment = this->commit(zeta_x);
+//     prover_transcript.send_to_verifier("ZM:PI", pi_commitment);
+
+//     auto verifier_transcript = VerifierTranscript<Fr>::init_empty(prover_transcript);
+
+//     // Execute Verifier protocol
+//     // Receive commitments to f and q_k, and evaluation v = f(u)
+//     std::vector<Commitment> C_q_k;
+//     C_q_k.reserve(log_n);
+//     for (size_t i = 0; i < log_n; ++i) {
+//         C_q_k.emplace_back(verifier_transcript.template receive_from_prover<Commitment>("ZM:C_q_" +
+//         std::to_string(i)));
+//     }
+
+//     // Challenge y
+//     auto y_chal = verifier_transcript.get_challenge("ZM:y");
+//     (void)y_chal;
+
+//     // Receive commitment C_{q}
+//     auto C_q = verifier_transcript.template receive_from_prover<Commitment>("ZM:C_q");
+//     (void)C_q;
+
+//     // Challenges x, z
+//     auto x_chal = verifier_transcript.get_challenge("ZM:x");
+
+//     // Compute commitment C_{\zeta_x}
+//     auto C_zeta_x = C_q;
+//     for (size_t k = 0; k < log_n; ++k) {
+//         size_t deg_k = (1ULL << k) - 1;
+//         // y^k * x^{N - deg_k - 1}
+//         auto scalar = y_chal.pow(k);
+//         scalar *= x_chal.pow(n - deg_k - 1);
+//         scalar *= Fr(-1);
+//         C_zeta_x = C_zeta_x + C_q_k[k] * scalar;
+//     }
+
+//     EXPECT_EQ(commitment_zeta_x, C_zeta_x);
+
+//     // Receive proof commitment \pi
+//     auto C_pi = verifier_transcript.template receive_from_prover<Commitment>("ZM:PI");
+//     (void)C_pi;
+
+//     // Construct pairing check inputs
+//     auto P0 = C_zeta_x + C_pi * x_chal;
+//     auto P1 = -C_pi;
+
+//     auto verified = this->vk()->pairing_check(P0, P1);
+//     (void)verified;
+
+//     // Do pairing check
+//     EXPECT_TRUE(verified);
+
+//     // prover_transcript.print();
+//     // verifier_transcript.print();
+//     EXPECT_EQ(prover_transcript.get_manifest(), verifier_transcript.get_manifest());
+// }
 
 } // namespace proof_system::honk::pcs::zeromorph

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
@@ -93,20 +93,29 @@ TYPED_TEST(ZeroMorphTest, BatchedLiftedDegreeQuotient)
     const size_t N = 8;
 
     // Define some mock q_k with deg(q_k) = 2^k - 1
-    Polynomial q_0 = { 1, 0, 0, 0, 0, 0, 0, 0 };
-    Polynomial q_1 = { 2, 3, 0, 0, 0, 0, 0, 0 };
-    Polynomial q_2 = { 4, 5, 6, 7, 0, 0, 0, 0 };
-
+    std::array<Fr, N> data_0 = { 1, 0, 0, 0, 0, 0, 0, 0 };
+    std::array<Fr, N> data_1 = { 2, 3, 0, 0, 0, 0, 0, 0 };
+    std::array<Fr, N> data_2 = { 4, 5, 6, 7, 0, 0, 0, 0 };
+    Polynomial q_0(data_0);
+    Polynomial q_1(data_1);
+    Polynomial q_2(data_2);
     std::vector<Polynomial> quotients = { q_0, q_1, q_2 };
+
     auto y_challenge = Fr::random_element();
 
+    // Compute batched quotient \hat{q} using the prover method
     auto batched_quotient = ZeroMorphProver::compute_batched_lifted_degree_quotient(quotients, y_challenge, N);
 
     // Now explicitly define q_k_lifted = X^{N-2^k} * q_k and compute the expected batched result
+    std::array<Fr, N> data_0_lifted = { 0, 0, 0, 0, 0, 0, 0, 1 };
+    std::array<Fr, N> data_1_lifted = { 0, 0, 0, 0, 0, 0, 2, 3 };
+    std::array<Fr, N> data_2_lifted = { 0, 0, 0, 0, 4, 5, 6, 7 };
+    Polynomial q_0_lifted(data_0_lifted);
+    Polynomial q_1_lifted(data_1_lifted);
+    Polynomial q_2_lifted(data_2_lifted);
+
+    // Explicitly compute \hat{q}
     auto batched_quotient_expected = Polynomial(N);
-    Polynomial q_0_lifted = { 0, 0, 0, 0, 0, 0, 0, 1 };
-    Polynomial q_1_lifted = { 0, 0, 0, 0, 0, 0, 2, 3 };
-    Polynomial q_2_lifted = { 0, 0, 0, 0, 4, 5, 6, 7 };
     batched_quotient_expected += q_0_lifted;
     batched_quotient_expected.add_scaled(q_1_lifted, y_challenge);
     batched_quotient_expected.add_scaled(q_2_lifted, y_challenge * y_challenge);
@@ -128,11 +137,14 @@ TYPED_TEST(ZeroMorphTest, PartiallyEvaluatedQuotientZeta)
     const size_t N = 8;
 
     // Define some mock q_k with deg(q_k) = 2^k - 1
-    Polynomial q_0 = { 1, 0, 0, 0, 0, 0, 0, 0 };
-    Polynomial q_1 = { 2, 3, 0, 0, 0, 0, 0, 0 };
-    Polynomial q_2 = { 4, 5, 6, 7, 0, 0, 0, 0 };
-
+    std::array<Fr, N> data_0 = { 1, 0, 0, 0, 0, 0, 0, 0 };
+    std::array<Fr, N> data_1 = { 2, 3, 0, 0, 0, 0, 0, 0 };
+    std::array<Fr, N> data_2 = { 4, 5, 6, 7, 0, 0, 0, 0 };
+    Polynomial q_0(data_0);
+    Polynomial q_1(data_1);
+    Polynomial q_2(data_2);
     std::vector<Polynomial> quotients = { q_0, q_1, q_2 };
+
     auto y_challenge = Fr::random_element();
 
     auto batched_quotient = ZeroMorphProver::compute_batched_lifted_degree_quotient(quotients, y_challenge, N);
@@ -213,10 +225,12 @@ TYPED_TEST(ZeroMorphTest, PartiallyEvaluatedQuotientZ)
     Fr v_evaluation = multilinear_f.evaluate_mle(u_challenge);
 
     // Define some mock q_k with deg(q_k) = 2^k - 1
-    Polynomial q_0 = { 1, 0, 0, 0, 0, 0, 0, 0 };
-    Polynomial q_1 = { 2, 3, 0, 0, 0, 0, 0, 0 };
-    Polynomial q_2 = { 4, 5, 6, 7, 0, 0, 0, 0 };
-
+    std::array<Fr, N> data_0 = { 1, 0, 0, 0, 0, 0, 0, 0 };
+    std::array<Fr, N> data_1 = { 2, 3, 0, 0, 0, 0, 0, 0 };
+    std::array<Fr, N> data_2 = { 4, 5, 6, 7, 0, 0, 0, 0 };
+    Polynomial q_0(data_0);
+    Polynomial q_1(data_1);
+    Polynomial q_2(data_2);
     std::vector<Polynomial> quotients = { q_0, q_1, q_2 };
 
     auto x_challenge = Fr::random_element();
@@ -243,7 +257,7 @@ TYPED_TEST(ZeroMorphTest, PartiallyEvaluatedQuotientZ)
  * @brief Full Prover/Verifier protocol for proving multilinear evaluation f(u) = v
  *
  */
-TYPED_TEST(ZeroMorphTest, Single)
+TYPED_TEST(ZeroMorphTest, ProveAndVerifySingle)
 {
     using Fr = typename TypeParam::ScalarField;
     using Commitment = typename TypeParam::AffineElement;

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
@@ -12,6 +12,17 @@ template <class Curve> class ZeroMorphTest : public CommitmentTest<Curve> {
     using Commitment = typename Curve::AffineElement;
     using GroupElement = typename Curve::Element;
     using Polynomial = barretenberg::Polynomial<Fr>;
+
+    // Evaluate Phi_k(x) = \sum_{i=0}^k x^i using the direct inefficent formula
+    Fr Phi(Fr challenge, size_t subscript)
+    {
+        size_t length = 1 << subscript;
+        auto result = Fr(0);
+        for (size_t idx = 0; idx < length; ++idx) {
+            result += challenge.pow(idx);
+        }
+        return result;
+    }
 };
 
 using CurveTypes = ::testing::Types<curve::BN254>;
@@ -73,13 +84,9 @@ TYPED_TEST(ZeroMorphTest, BatchedLiftedDegreeQuotient)
     const size_t N = 8;
 
     // Define some mock q_k with deg(q_k) = 2^k - 1
-    std::array<Fr, N> poly_0 = { 1, 0, 0, 0, 0, 0, 0, 0 };
-    std::array<Fr, N> poly_1 = { 2, 3, 0, 0, 0, 0, 0, 0 };
-    std::array<Fr, N> poly_2 = { 4, 5, 6, 7, 0, 0, 0, 0 };
-
-    auto q_0 = Polynomial{ poly_0 };
-    auto q_1 = Polynomial{ poly_1 };
-    auto q_2 = Polynomial{ poly_2 };
+    Polynomial q_0 = { 1, 0, 0, 0, 0, 0, 0, 0 };
+    Polynomial q_1 = { 2, 3, 0, 0, 0, 0, 0, 0 };
+    Polynomial q_2 = { 4, 5, 6, 7, 0, 0, 0, 0 };
 
     std::vector<Polynomial> quotients = { q_0, q_1, q_2 };
     auto y_challenge = Fr::random_element();
@@ -88,9 +95,9 @@ TYPED_TEST(ZeroMorphTest, BatchedLiftedDegreeQuotient)
 
     // Now explicitly define q_k_lifted = X^{N-2^k} * q_k and compute the expected batched result
     auto batched_quotient_expected = Polynomial(N);
-    std::array<Fr, N> q_0_lifted = { 0, 0, 0, 0, 0, 0, 0, 1 };
-    std::array<Fr, N> q_1_lifted = { 0, 0, 0, 0, 0, 0, 2, 3 };
-    std::array<Fr, N> q_2_lifted = { 0, 0, 0, 0, 4, 5, 6, 7 };
+    Polynomial q_0_lifted = { 0, 0, 0, 0, 0, 0, 0, 1 };
+    Polynomial q_1_lifted = { 0, 0, 0, 0, 0, 0, 2, 3 };
+    Polynomial q_2_lifted = { 0, 0, 0, 0, 4, 5, 6, 7 };
     batched_quotient_expected += q_0_lifted;
     batched_quotient_expected.add_scaled(q_1_lifted, y_challenge);
     batched_quotient_expected.add_scaled(q_2_lifted, y_challenge * y_challenge);
@@ -112,20 +119,16 @@ TYPED_TEST(ZeroMorphTest, PartiallyEvaluatedQuotientZeta)
     const size_t N = 8;
 
     // Define some mock q_k with deg(q_k) = 2^k - 1
-    std::array<Fr, N> poly_0 = { 1, 0, 0, 0, 0, 0, 0, 0 };
-    std::array<Fr, N> poly_1 = { 2, 3, 0, 0, 0, 0, 0, 0 };
-    std::array<Fr, N> poly_2 = { 4, 5, 6, 7, 0, 0, 0, 0 };
-
-    auto q_0 = Polynomial{ poly_0 };
-    auto q_1 = Polynomial{ poly_1 };
-    auto q_2 = Polynomial{ poly_2 };
+    Polynomial q_0 = { 1, 0, 0, 0, 0, 0, 0, 0 };
+    Polynomial q_1 = { 2, 3, 0, 0, 0, 0, 0, 0 };
+    Polynomial q_2 = { 4, 5, 6, 7, 0, 0, 0, 0 };
 
     std::vector<Polynomial> quotients = { q_0, q_1, q_2 };
-    auto y_challenge = Fr::one();
+    auto y_challenge = Fr::random_element();
 
     auto batched_quotient = ZeroMorphProver::compute_batched_lifted_degree_quotient(quotients, y_challenge, N);
 
-    auto x_challenge = Fr::one();
+    auto x_challenge = Fr::random_element();
 
     auto zeta_x = ZeroMorphProver::compute_partially_evaluated_degree_check_polynomial(
         batched_quotient, quotients, y_challenge, x_challenge);
@@ -133,11 +136,51 @@ TYPED_TEST(ZeroMorphTest, PartiallyEvaluatedQuotientZeta)
     // Now explicitly compute the expected result
     auto zeta_x_expected = Polynomial(N);
     zeta_x_expected += batched_quotient;
-    zeta_x_expected.add_scaled(q_0, x_challenge.pow(N - 1));
-    zeta_x_expected.add_scaled(q_1, y_challenge * x_challenge.pow(N - 2 - 1));
-    zeta_x_expected.add_scaled(q_2, y_challenge * y_challenge * x_challenge.pow(N - 4 - 1));
+    // q_batched - \sum_k q_k * y^k * x^{N - deg(q_k) - 1}
+    zeta_x_expected.add_scaled(q_0, -x_challenge.pow(N - 0 - 1));
+    zeta_x_expected.add_scaled(q_1, -y_challenge * x_challenge.pow(N - 1 - 1));
+    zeta_x_expected.add_scaled(q_2, -y_challenge * y_challenge * x_challenge.pow(N - 3 - 1));
 
     EXPECT_EQ(zeta_x, zeta_x_expected);
+}
+
+/**
+ * @brief Demonstrate formulas for efficiently computing \Phi_k(x) = \sum_{i=0}^{k-1}x^i
+ * @details \Phi_k(x) = \sum_{i=0}^{k-1}x^i = (x^{2^n} - 1) / (x - 1)
+ *
+ */
+TYPED_TEST(ZeroMorphTest, PhiEvaluation)
+{
+    using Fr = typename TypeParam::ScalarField;
+    const size_t N = 8;
+    size_t n = numeric::get_msb(N);
+
+    // \Phi_n(x)
+    {
+        auto x_challenge = Fr::random_element();
+
+        auto efficient = (x_challenge.pow(1 << n) - 1) / (x_challenge - 1);
+
+        auto expected = this->Phi(x_challenge, n);
+
+        EXPECT_EQ(efficient, expected);
+    }
+
+    // \Phi_{n-k-1}(x^{2^{k + 1}})
+    {
+        auto x_challenge = Fr::random_element();
+
+        size_t k = 2;
+
+        // x^{2^{k+1}}
+        auto x_pow = x_challenge.pow(1 << (k + 1));
+
+        auto efficient = x_challenge.pow(1 << n) - 1; // x^N - 1
+        efficient = efficient / (x_pow - 1);          // (x^N - 1) / (x^{2^{k + 1}} - 1)
+
+        auto expected = this->Phi(x_pow, n - k - 1);
+        EXPECT_EQ(efficient, expected);
+    }
 }
 
 /**
@@ -147,6 +190,42 @@ TYPED_TEST(ZeroMorphTest, PartiallyEvaluatedQuotientZeta)
 TYPED_TEST(ZeroMorphTest, PartiallyEvaluatedQuotientZ)
 {
     // Define some useful type aliases
+    using ZeroMorphProver = ZeroMorphProver<TypeParam>;
+    using Fr = typename TypeParam::ScalarField;
+    using Polynomial = barretenberg::Polynomial<Fr>;
+
+    const size_t N = 8;
+    size_t log_N = numeric::get_msb(N);
+
+    // Construct a random multilinear polynomial f, and (u,v) such that f(u) = v.
+    Polynomial multilinear_f = this->random_polynomial(N);
+    std::vector<Fr> u_challenge = this->random_evaluation_point(log_N);
+    Fr v_evaluation = multilinear_f.evaluate_mle(u_challenge);
+
+    // Define some mock q_k with deg(q_k) = 2^k - 1
+    Polynomial q_0 = { 1, 0, 0, 0, 0, 0, 0, 0 };
+    Polynomial q_1 = { 2, 3, 0, 0, 0, 0, 0, 0 };
+    Polynomial q_2 = { 4, 5, 6, 7, 0, 0, 0, 0 };
+
+    std::vector<Polynomial> quotients = { q_0, q_1, q_2 };
+
+    auto x_challenge = Fr::random_element();
+
+    auto Z_x = ZeroMorphProver::compute_partially_evaluated_zeromorph_identity_polynomial(
+        multilinear_f, quotients, v_evaluation, u_challenge, x_challenge);
+
+    // Compute Z_x directly
+    auto Z_x_expected = multilinear_f;
+    Z_x_expected[0] -= v_evaluation;
+    for (size_t k = 0; k < log_N; ++k) {
+        auto x_pow_2k = x_challenge.pow(1 << k);         // x^{2^k}
+        auto x_pow_2kp1 = x_challenge.pow(1 << (k + 1)); // x^{2^{k+1}}
+        // x^{2^k} * \Phi_{n-k-1}(x^{2^{k+1}}) - u_k *  \Phi_{n-k}(x^{2^k})
+        auto scalar = x_pow_2k * this->Phi(x_pow_2kp1, log_N - k - 1) - u_challenge[k] * this->Phi(x_pow_2k, log_N - k);
+        Z_x_expected.add_scaled(quotients[k], -scalar);
+    }
+
+    EXPECT_EQ(Z_x, Z_x_expected);
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
@@ -146,8 +146,8 @@ TYPED_TEST(ZeroMorphTest, PartiallyEvaluatedQuotientZeta)
 
 /**
  * @brief Demonstrate formulas for efficiently computing \Phi_k(x) = \sum_{i=0}^{k-1}x^i
- * @details \Phi_k(x) = \sum_{i=0}^{k-1}x^i = (x^{2^n} - 1) / (x - 1)
- *
+ * @details \Phi_k(x) = \sum_{i=0}^{k-1}x^i
+ *                    = (x^{2^k} - 1) / (x - 1)
  */
 TYPED_TEST(ZeroMorphTest, PhiEvaluation)
 {
@@ -166,7 +166,7 @@ TYPED_TEST(ZeroMorphTest, PhiEvaluation)
         EXPECT_EQ(efficient, expected);
     }
 
-    // \Phi_{n-k-1}(x^{2^{k + 1}})
+    // \Phi_{n-k-1}(x^{2^{k + 1}}) = (x^{2^n} - 1) / (x^{2^{k + 1}} - 1)
     {
         auto x_challenge = Fr::random_element();
 

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
@@ -1,0 +1,117 @@
+#include "zeromorph.hpp"
+#include "../commitment_key.test.hpp"
+#include "barretenberg/honk/transcript/transcript.hpp"
+
+#include <gtest/gtest.h>
+
+namespace proof_system::honk::pcs::zeromorph {
+
+template <class Curve> class ZeroMorphTest : public CommitmentTest<Curve> {
+  public:
+    using Fr = typename Curve::ScalarField;
+    using Commitment = typename Curve::AffineElement;
+    using GroupElement = typename Curve::Element;
+    using Polynomial = barretenberg::Polynomial<Fr>;
+};
+
+using CurveTypes = ::testing::Types<curve::BN254>;
+TYPED_TEST_SUITE(ZeroMorphTest, CurveTypes);
+
+/**
+ * @brief Test method for computing q_k given multilinear f
+ * @details Given f = f(X_0, ..., X_{d-1}), and (u,v) such that f(u) = v, compute q_k = q_k(X_0, ..., X_{k-1}) such that
+ * the following identity holds:
+ *
+ *  f(X_0, ..., X_{d-1}) - v = \sum_{k=0}^{d-1} (X_k - u_k)q_k(X_0, ..., X_{k-1})
+ *
+ */
+TYPED_TEST(ZeroMorphTest, QuotientConstruction)
+{
+    using ZeroMorphProver = ZeroMorphProver<TypeParam>;
+    size_t n = 16;
+    size_t log_n = numeric::get_msb(n);
+
+    // Construct a random multilinear polynomial f, and (u,v) such that f(u) = v.
+    auto multilinear_f = this->random_polynomial(n);
+    auto u_challenge = this->random_evaluation_point(log_n);
+    auto v_evaluation = multilinear_f.evaluate_mle(u_challenge);
+    (void)v_evaluation;
+
+    // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
+    auto quotients = ZeroMorphProver::compute_multivariate_quotients(multilinear_f, u_challenge);
+
+    // WORKTODO: show that the q_k were properly constructed by showing that, for a random multilinear challenge z, the
+    // following holds: f(z) - v = \sum_{k=0}^{d-1} (z_k - u_k)q_k(z)
+    auto z_challenge = this->random_evaluation_point(log_n);
+
+    EXPECT_TRUE(true);
+}
+
+TYPED_TEST(ZeroMorphTest, Single)
+{
+    using Fr = typename TypeParam::ScalarField;
+    using Commitment = typename TypeParam::AffineElement;
+    using ZeroMorphProver = ZeroMorphProver<TypeParam>;
+    size_t N_max = 25; // ???
+    size_t n = 16;
+    size_t log_n = numeric::get_msb(n);
+
+    // Initialize an empty ProverTranscript
+    auto prover_transcript = ProverTranscript<Fr>::init_empty();
+
+    // Construct a random multilinear polynomial f, and (u,v) such that f(u) = v.
+    auto multilinear_f = this->random_polynomial(n);
+    auto u_challenge = this->random_evaluation_point(log_n);
+    auto v_evaluation = multilinear_f.evaluate_mle(u_challenge);
+
+    // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
+    auto quotients = ZeroMorphProver::compute_multivariate_quotients(multilinear_f, u_challenge);
+
+    // Compute and send commitment C = [f]
+    Commitment f_commitment = this->commit(multilinear_f);
+    prover_transcript.send_to_verifier("ZM:C", f_commitment);
+
+    // Compute and send commitments C_k = [q_k], k = 0,...,d-1
+    std::vector<Commitment> q_k_commitments;
+    q_k_commitments.reserve(log_n);
+    for (size_t idx = 0; idx < log_n; ++idx) {
+        q_k_commitments[idx] = this->commit(quotients[idx]);
+        std::string label = "ZM:C_" + std::to_string(idx);
+        prover_transcript.send_to_verifier(label, q_k_commitments[idx]);
+    }
+
+    // Get challenge y
+    auto y_challenge = prover_transcript.get_challenge("ZM:y");
+
+    // Compute the batched, lifted-degree quotient \hat{q}
+    auto batched_quotient = ZeroMorphProver::compute_batched_lifted_degree_quotient(quotients, y_challenge, n);
+
+    // Compute and send the commitment C_q = [\hat{q}]
+    auto q_commitment = this->commit(batched_quotient);
+    prover_transcript.send_to_verifier("ZM:C_q", q_commitment);
+
+    // Get challenges x and z
+    auto [x_challenge, z_challenge] = prover_transcript.get_challenges("ZM:x", "ZM:z");
+
+    // Compute degree check polynomial \zeta partially evaluated at x
+    auto zeta_x = ZeroMorphProver::compute_partially_evaluated_degree_check_polynomial(
+        batched_quotient, quotients, y_challenge, x_challenge, n);
+
+    // Compute ZeroMorph identity polynomial Z partially evaluated at x
+    auto Z_x = ZeroMorphProver::compute_partially_evaluated_zeromorph_identity_polynomial(
+        multilinear_f, quotients, v_evaluation, x_challenge);
+
+    // Compute batched degree and ZM-identity quotient polynomial
+    auto pi_polynomial = ZeroMorphProver::compute_batched_evaluation_and_degree_check_quotient(
+        zeta_x, Z_x, x_challenge, z_challenge, N_max);
+
+    // Compute and send proof commitment pi
+    auto pi_commitment = this->commit(pi_polynomial);
+    prover_transcript.send_to_verifier("ZM:PI", pi_commitment);
+
+    bool verified = true;
+
+    EXPECT_EQ(verified, true);
+}
+
+} // namespace proof_system::honk::pcs::zeromorph

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
@@ -12,8 +12,8 @@ template <class Curve> class ZeroMorphTest : public CommitmentTest<Curve> {
     using Polynomial = barretenberg::Polynomial<Fr>;
     using Commitment = typename Curve::AffineElement;
     using GroupElement = typename Curve::Element;
-    using ZeroMorphProver = ZeroMorphProver<Curve>;
-    using ZeroMorphVerifier = ZeroMorphVerifier<Curve>;
+    using ZeroMorphProver = ZeroMorphProver_<Curve>;
+    using ZeroMorphVerifier = ZeroMorphVerifier_<Curve>;
 
     // Evaluate Phi_k(x) = \sum_{i=0}^k x^i using the direct inefficent formula
     Fr Phi(Fr challenge, size_t subscript)
@@ -233,7 +233,7 @@ TYPED_TEST_SUITE(ZeroMorphTest, CurveTypes);
 TYPED_TEST(ZeroMorphTest, QuotientConstruction)
 {
     // Define some useful type aliases
-    using ZeroMorphProver = ZeroMorphProver<TypeParam>;
+    using ZeroMorphProver = ZeroMorphProver_<TypeParam>;
     using Fr = typename TypeParam::ScalarField;
     using Polynomial = barretenberg::Polynomial<Fr>;
 
@@ -280,7 +280,7 @@ TYPED_TEST(ZeroMorphTest, QuotientConstruction)
 TYPED_TEST(ZeroMorphTest, BatchedLiftedDegreeQuotient)
 {
     // Define some useful type aliases
-    using ZeroMorphProver = ZeroMorphProver<TypeParam>;
+    using ZeroMorphProver = ZeroMorphProver_<TypeParam>;
     using Fr = typename TypeParam::ScalarField;
     using Polynomial = barretenberg::Polynomial<Fr>;
 
@@ -324,7 +324,7 @@ TYPED_TEST(ZeroMorphTest, BatchedLiftedDegreeQuotient)
 TYPED_TEST(ZeroMorphTest, PartiallyEvaluatedQuotientZeta)
 {
     // Define some useful type aliases
-    using ZeroMorphProver = ZeroMorphProver<TypeParam>;
+    using ZeroMorphProver = ZeroMorphProver_<TypeParam>;
     using Fr = typename TypeParam::ScalarField;
     using Polynomial = barretenberg::Polynomial<Fr>;
 
@@ -406,7 +406,7 @@ TYPED_TEST(ZeroMorphTest, PhiEvaluation)
 TYPED_TEST(ZeroMorphTest, PartiallyEvaluatedQuotientZ)
 {
     // Define some useful type aliases
-    using ZeroMorphProver = ZeroMorphProver<TypeParam>;
+    using ZeroMorphProver = ZeroMorphProver_<TypeParam>;
     using Fr = typename TypeParam::ScalarField;
     using Polynomial = barretenberg::Polynomial<Fr>;
 

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
@@ -262,12 +262,12 @@ TYPED_TEST(ZeroMorphTest, ProveAndVerifySingle)
     using Fr = typename TypeParam::ScalarField;
     using Commitment = typename TypeParam::AffineElement;
     using ZeroMorphProver = ZeroMorphProver<TypeParam>;
-    size_t n = 16;
-    size_t log_n = numeric::get_msb(n);
+    size_t N = 16;
+    size_t log_N = numeric::get_msb(N);
 
     // Construct a random multilinear polynomial f, and (u,v) such that f(u) = v.
-    auto f_polynomial = this->random_polynomial(n);
-    auto u_challenge = this->random_evaluation_point(log_n);
+    auto f_polynomial = this->random_polynomial(N);
+    auto u_challenge = this->random_evaluation_point(log_N);
     auto v_evaluation = f_polynomial.evaluate_mle(u_challenge);
     auto f_commitment = this->commit(f_polynomial);
 
@@ -281,8 +281,8 @@ TYPED_TEST(ZeroMorphTest, ProveAndVerifySingle)
 
         // Compute and send commitments C_{q_k} = [q_k], k = 0,...,d-1
         std::vector<Commitment> q_k_commitments;
-        q_k_commitments.reserve(log_n);
-        for (size_t idx = 0; idx < log_n; ++idx) {
+        q_k_commitments.reserve(log_N);
+        for (size_t idx = 0; idx < log_N; ++idx) {
             q_k_commitments[idx] = this->commit(quotients[idx]);
             std::string label = "ZM:C_q_" + std::to_string(idx);
             prover_transcript.send_to_verifier(label, q_k_commitments[idx]);
@@ -292,7 +292,7 @@ TYPED_TEST(ZeroMorphTest, ProveAndVerifySingle)
         auto y_challenge = prover_transcript.get_challenge("ZM:y");
 
         // Compute the batched, lifted-degree quotient \hat{q}
-        auto batched_quotient = ZeroMorphProver::compute_batched_lifted_degree_quotient(quotients, y_challenge, n);
+        auto batched_quotient = ZeroMorphProver::compute_batched_lifted_degree_quotient(quotients, y_challenge, N);
 
         // Compute and send the commitment C_q = [\hat{q}]
         auto q_commitment = this->commit(batched_quotient);
@@ -324,8 +324,8 @@ TYPED_TEST(ZeroMorphTest, ProveAndVerifySingle)
     {
         // Receive commitments [q_k]
         std::vector<Commitment> C_q_k;
-        C_q_k.reserve(log_n);
-        for (size_t i = 0; i < log_n; ++i) {
+        C_q_k.reserve(log_N);
+        for (size_t i = 0; i < log_N; ++i) {
             C_q_k.emplace_back(
                 verifier_transcript.template receive_from_prover<Commitment>("ZM:C_q_" + std::to_string(i)));
         }
@@ -340,15 +340,15 @@ TYPED_TEST(ZeroMorphTest, ProveAndVerifySingle)
         auto [x_challenge, z_challenge] = verifier_transcript.get_challenges("ZM:x", "ZM:z");
 
         // Compute commitment C_{v,x}
-        auto C_v_x = Commitment::one() * v_evaluation * this->Phi(x_challenge, log_n);
+        auto C_v_x = Commitment::one() * v_evaluation * this->Phi(x_challenge, log_N);
 
         // Compute commitment C_{\zeta_x}
         auto C_zeta_x = C_q;
-        for (size_t k = 0; k < log_n; ++k) {
-            size_t deg_k = (1ULL << k) - 1;
+        for (size_t k = 0; k < log_N; ++k) {
+            auto deg_k = static_cast<size_t>((1 << k) - 1);
             // Compute scalar y^k * x^{N - deg_k - 1}
             auto scalar = y_challenge.pow(k);
-            scalar *= x_challenge.pow(n - deg_k - 1);
+            scalar *= x_challenge.pow(N - deg_k - 1);
             scalar *= Fr(-1);
 
             C_zeta_x = C_zeta_x + C_q_k[k] * scalar;
@@ -356,12 +356,12 @@ TYPED_TEST(ZeroMorphTest, ProveAndVerifySingle)
 
         // Compute commitment C_{Z_x}
         auto C_Z_x = f_commitment + C_v_x * Fr(-1); // C_f - C_{v,x}
-        for (size_t k = 0; k < log_n; ++k) {
+        for (size_t k = 0; k < log_N; ++k) {
             // Compute scalar x^{2^k} * \Phi_{n-k-1}(x^{2^{k+1}}) - u_k *  \Phi_{n-k}(x^{2^k})
             auto x_pow_2k = x_challenge.pow(1 << k);         // x^{2^k}
             auto x_pow_2kp1 = x_challenge.pow(1 << (k + 1)); // x^{2^{k+1}}
-            auto scalar = x_pow_2k * this->Phi(x_pow_2kp1, log_n - k - 1);
-            scalar -= u_challenge[k] * this->Phi(x_pow_2k, log_n - k);
+            auto scalar = x_pow_2k * this->Phi(x_pow_2kp1, log_N - k - 1);
+            scalar -= u_challenge[k] * this->Phi(x_pow_2k, log_N - k);
             scalar *= Fr(-1);
 
             C_Z_x = C_Z_x + C_q_k[k] * scalar;
@@ -383,217 +383,5 @@ TYPED_TEST(ZeroMorphTest, ProveAndVerifySingle)
         EXPECT_TRUE(verified);
     }
 }
-
-/**
- * @brief Full Prover/Verifier protocol for proving multilinear evaluation f(u) = v
- *
- */
-// TYPED_TEST(ZeroMorphTest, SingleZxOnly)
-// {
-//     using Fr = typename TypeParam::ScalarField;
-//     using Commitment = typename TypeParam::AffineElement;
-//     using ZeroMorphProver = ZeroMorphProver<TypeParam>;
-//     size_t n = 16;
-//     size_t log_n = numeric::get_msb(n);
-
-//     // Construct a random multilinear polynomial f, and (u,v) such that f(u) = v.
-//     auto multilinear_f = this->random_polynomial(n);
-//     auto u_challenge = this->random_evaluation_point(log_n);
-//     auto v_evaluation = multilinear_f.evaluate_mle(u_challenge);
-
-//     // Initialize an empty ProverTranscript
-//     auto prover_transcript = ProverTranscript<Fr>::init_empty();
-
-//     // Execute Prover protocol
-
-//     // WORKTODO: this is a little funny. [f] will have been sent previously. It must be in hash used to generate u.
-//     // Compute and send commitment C = [f] and evaluation v = f(u)
-//     Commitment f_commitment = this->commit(multilinear_f);
-//     prover_transcript.send_to_verifier("ZM:C", f_commitment);
-//     prover_transcript.send_to_verifier("ZM:v", v_evaluation);
-
-//     // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
-//     auto quotients = ZeroMorphProver::compute_multilinear_quotients(multilinear_f, u_challenge);
-
-//     // Compute and send commitments C_{q_k} = [q_k], k = 0,...,d-1
-//     std::vector<Commitment> q_k_commitments;
-//     q_k_commitments.reserve(log_n);
-//     for (size_t idx = 0; idx < log_n; ++idx) {
-//         q_k_commitments[idx] = this->commit(quotients[idx]);
-//         std::string label = "ZM:C_q_" + std::to_string(idx);
-//         prover_transcript.send_to_verifier(label, q_k_commitments[idx]);
-//     }
-
-//     // Get challenge x
-//     auto x_challenge = prover_transcript.get_challenge("ZM:x");
-
-//     // Compute ZeroMorph identity polynomial Z partially evaluated at x
-//     auto Z_x = ZeroMorphProver::compute_partially_evaluated_zeromorph_identity_polynomial(
-//         multilinear_f, quotients, v_evaluation, u_challenge, x_challenge);
-
-//     // Compute and send proof commitment pi
-//     Z_x.factor_roots(x_challenge);
-//     auto pi_commitment = this->commit(Z_x);
-//     prover_transcript.send_to_verifier("ZM:PI", pi_commitment);
-
-//     auto verifier_transcript = VerifierTranscript<Fr>::init_empty(prover_transcript);
-
-//     // Execute Verifier protocol
-
-//     // Receive commitments to f and q_k, and evaluation v = f(u)
-//     auto C_f = verifier_transcript.template receive_from_prover<Commitment>("ZM:C");
-//     auto v_eval = verifier_transcript.template receive_from_prover<Fr>("ZM:v");
-
-//     std::vector<Commitment> C_q_k;
-//     C_q_k.reserve(log_n);
-//     for (size_t i = 0; i < log_n; ++i) {
-//         C_q_k.emplace_back(verifier_transcript.template receive_from_prover<Commitment>("ZM:C_q_" +
-//         std::to_string(i)));
-//     }
-
-//     // Challenge y
-//     auto x_chal = verifier_transcript.get_challenge("ZM:x");
-
-//     // Compute commitment C_{v,x}
-//     auto C_v_x = Commitment::one() * v_eval * this->Phi(x_chal, log_n);
-
-//     // Compute commitment C_{Z_x}
-//     auto C_Z_x = C_f + C_v_x * Fr(-1); // C_f - C_{v,x}
-//     for (size_t k = 0; k < log_n; ++k) {
-//         auto x_pow_2k = x_chal.pow(1 << k);         // x^{2^k}
-//         auto x_pow_2kp1 = x_chal.pow(1 << (k + 1)); // x^{2^{k+1}}
-//         // Compute scalar x^{2^k} * \Phi_{n-k-1}(x^{2^{k+1}}) - u_k *  \Phi_{n-k}(x^{2^k})
-//         auto scalar = x_pow_2k * this->Phi(x_pow_2kp1, log_n - k - 1);
-//         scalar -= u_challenge[k] * this->Phi(x_pow_2k, log_n - k);
-//         C_Z_x = C_Z_x + C_q_k[k] * scalar * Fr(-1);
-//     }
-
-//     // Receive proof commitment \pi
-//     auto C_pi = verifier_transcript.template receive_from_prover<Commitment>("ZM:PI");
-
-//     // Construct pairing check inputs
-//     auto P0 = C_Z_x + C_pi * x_chal;
-//     auto P1 = C_pi * Fr(-1);
-
-//     // Do pairing check
-//     auto verified = this->vk()->pairing_check(P0, P1);
-//     EXPECT_TRUE(verified);
-
-//     // prover_transcript.print();
-//     // verifier_transcript.print();
-//     EXPECT_EQ(prover_transcript.get_manifest(), verifier_transcript.get_manifest());
-// }
-
-// /**
-//  * @brief Full Prover/Verifier protocol for proving multilinear evaluation f(u) = v
-//  *
-//  */
-// TYPED_TEST(ZeroMorphTest, SingleZetaxOnly)
-// {
-//     using Fr = typename TypeParam::ScalarField;
-//     using Commitment = typename TypeParam::AffineElement;
-//     using ZeroMorphProver = ZeroMorphProver<TypeParam>;
-//     size_t n = 16;
-//     size_t log_n = numeric::get_msb(n);
-
-//     // Construct a random multilinear polynomial f, and (u,v) such that f(u) = v.
-//     auto multilinear_f = this->random_polynomial(n);
-//     auto u_challenge = this->random_evaluation_point(log_n);
-//     // auto v_evaluation = multilinear_f.evaluate_mle(u_challenge);
-
-//     // Initialize an empty ProverTranscript
-//     auto prover_transcript = ProverTranscript<Fr>::init_empty();
-
-//     // Execute Prover protocol
-
-//     // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
-//     auto quotients = ZeroMorphProver::compute_multilinear_quotients(multilinear_f, u_challenge);
-
-//     // Compute and send commitments C_{q_k} = [q_k], k = 0,...,d-1
-//     std::vector<Commitment> q_k_commitments;
-//     q_k_commitments.reserve(log_n);
-//     for (size_t idx = 0; idx < log_n; ++idx) {
-//         q_k_commitments[idx] = this->commit(quotients[idx]);
-//         std::string label = "ZM:C_q_" + std::to_string(idx);
-//         prover_transcript.send_to_verifier(label, q_k_commitments[idx]);
-//     }
-
-//     // Get challenge y
-//     auto y_challenge = prover_transcript.get_challenge("ZM:y");
-
-//     // Compute the batched, lifted-degree quotient \hat{q}
-//     auto batched_quotient = ZeroMorphProver::compute_batched_lifted_degree_quotient(quotients, y_challenge, n);
-
-//     // Compute and send the commitment C_q = [\hat{q}]
-//     auto q_commitment = this->commit(batched_quotient);
-//     prover_transcript.send_to_verifier("ZM:C_q", q_commitment);
-
-//     // Get challenges x and z
-//     auto x_challenge = prover_transcript.get_challenge("ZM:x");
-
-//     // Compute degree check polynomial \zeta partially evaluated at x
-//     auto zeta_x = ZeroMorphProver::compute_partially_evaluated_degree_check_polynomial(
-//         batched_quotient, quotients, y_challenge, x_challenge);
-
-//     auto commitment_zeta_x = this->commit(zeta_x);
-
-//     // Compute and send proof commitment pi
-//     zeta_x.factor_roots(x_challenge);
-//     auto pi_commitment = this->commit(zeta_x);
-//     prover_transcript.send_to_verifier("ZM:PI", pi_commitment);
-
-//     auto verifier_transcript = VerifierTranscript<Fr>::init_empty(prover_transcript);
-
-//     // Execute Verifier protocol
-//     // Receive commitments to f and q_k, and evaluation v = f(u)
-//     std::vector<Commitment> C_q_k;
-//     C_q_k.reserve(log_n);
-//     for (size_t i = 0; i < log_n; ++i) {
-//         C_q_k.emplace_back(verifier_transcript.template receive_from_prover<Commitment>("ZM:C_q_" +
-//         std::to_string(i)));
-//     }
-
-//     // Challenge y
-//     auto y_chal = verifier_transcript.get_challenge("ZM:y");
-//     (void)y_chal;
-
-//     // Receive commitment C_{q}
-//     auto C_q = verifier_transcript.template receive_from_prover<Commitment>("ZM:C_q");
-//     (void)C_q;
-
-//     // Challenges x, z
-//     auto x_chal = verifier_transcript.get_challenge("ZM:x");
-
-//     // Compute commitment C_{\zeta_x}
-//     auto C_zeta_x = C_q;
-//     for (size_t k = 0; k < log_n; ++k) {
-//         size_t deg_k = (1ULL << k) - 1;
-//         // y^k * x^{N - deg_k - 1}
-//         auto scalar = y_chal.pow(k);
-//         scalar *= x_chal.pow(n - deg_k - 1);
-//         scalar *= Fr(-1);
-//         C_zeta_x = C_zeta_x + C_q_k[k] * scalar;
-//     }
-
-//     EXPECT_EQ(commitment_zeta_x, C_zeta_x);
-
-//     // Receive proof commitment \pi
-//     auto C_pi = verifier_transcript.template receive_from_prover<Commitment>("ZM:PI");
-//     (void)C_pi;
-
-//     // Construct pairing check inputs
-//     auto P0 = C_zeta_x + C_pi * x_chal;
-//     auto P1 = -C_pi;
-
-//     auto verified = this->vk()->pairing_check(P0, P1);
-//     (void)verified;
-
-//     // Do pairing check
-//     EXPECT_TRUE(verified);
-
-//     // prover_transcript.print();
-//     // verifier_transcript.print();
-//     EXPECT_EQ(prover_transcript.get_manifest(), verifier_transcript.get_manifest());
-// }
 
 } // namespace proof_system::honk::pcs::zeromorph

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
@@ -377,6 +377,10 @@ TYPED_TEST(ZeroMorphTest, ProveAndVerifySingle)
         EXPECT_EQ(prover_transcript.get_manifest(), verifier_transcript.get_manifest());
 
         // Construct inputs and perform pairing check to verify claimed evaluation
+        // Note: The pairing check (without the degree check component X^{N_max-N-1}) can be expressed naturally as
+        // e(C_{\zeta,Z}, [1]_2) = e(pi, [X - x]_2). This can be rearranged (e.g. see the plonk paper) as
+        // e(C_{\zeta,Z} - x*pi, [1]_2) * e(-pi, [X]_2) = 1, or
+        // e(P_0, [1]_2) * e(P_1, [X]_2) = 1
         auto P0 = C_zeta_Z + C_pi * x_challenge;
         auto P1 = -C_pi;
         auto verified = this->vk()->pairing_check(P0, P1);

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
@@ -138,7 +138,7 @@ template <class Curve> class ZeroMorphTest : public CommitmentTest<Curve> {
                 batched_quotient, quotients, y_challenge, x_challenge);
 
             // Compute ZeroMorph identity polynomial Z partially evaluated at x
-            auto Z_x = ZeroMorphProver::compute_partially_evaluated_zeromorph_identity_polynomial_new(
+            auto Z_x = ZeroMorphProver::compute_partially_evaluated_zeromorph_identity_polynomial(
                 f_batched, g_batched, quotients, v_evaluation, u_challenge, x_challenge);
 
             // Compute batched degree and ZM-identity quotient polynomial pi
@@ -438,7 +438,7 @@ TYPED_TEST(ZeroMorphTest, PartiallyEvaluatedQuotientZ)
     auto x_challenge = Fr::random_element();
 
     // Construct Z_x using the prover method
-    auto Z_x = ZeroMorphProver::compute_partially_evaluated_zeromorph_identity_polynomial_new(
+    auto Z_x = ZeroMorphProver::compute_partially_evaluated_zeromorph_identity_polynomial(
         f_batched, g_batched, quotients, v_batched, u_challenge, x_challenge);
 
     // Compute Z_x directly

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
@@ -105,9 +105,6 @@ template <class Curve> class ZeroMorphTest : public CommitmentTest<Curve> {
             auto f_polynomial = f_batched;
             f_polynomial += g_batched.shifted();
 
-            // The batched evaluation should match the evaluation of the batched polynomial
-            // ASSERT_EQ(v_evaluation, f_polynomial.evaluate_mle(u_challenge));
-
             // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
             auto quotients = ZeroMorphProver::compute_multilinear_quotients(f_polynomial, u_challenge);
 

--- a/barretenberg/cpp/src/barretenberg/honk/sumcheck/sumcheck.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/sumcheck/sumcheck.test.cpp
@@ -143,6 +143,16 @@ TEST_F(SumcheckTests, PolynomialNormalization)
                               l_6 * full_polynomials[i][6] + l_7 * full_polynomials[i][7];
         EXPECT_EQ(hand_computed_value, sumcheck.partially_evaluated_polynomials[i][0]);
     }
+
+    // We can also check the correctness of the multilinear evaluations produced by Sumcheck by directly evaluating the
+    // full polynomials at challenge u via the evaluate_mle() function
+    std::vector<FF> u_challenge = { u_0, u_1, u_2 };
+    for (size_t i = 0; i < NUM_POLYNOMIALS; i++) {
+        barretenberg::Polynomial<FF> poly(full_polynomials[i]);
+        auto v_expected = poly.evaluate_mle(u_challenge);
+        auto v_result = output.claimed_evaluations[i];
+        EXPECT_EQ(v_expected, v_result);
+    }
 }
 
 TEST_F(SumcheckTests, Prover)

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -69,17 +69,6 @@ Polynomial<Fr>::Polynomial(std::span<const Fr> coefficients)
 }
 
 template <typename Fr>
-Polynomial<Fr>::Polynomial(std::initializer_list<Fr> coefficients)
-    : size_(coefficients.size())
-{
-    coefficients_ = allocate_aligned_memory(sizeof(Fr) * capacity());
-    memcpy(static_cast<void*>(coefficients_.get()),
-           static_cast<void const*>(coefficients.begin()),
-           sizeof(Fr) * coefficients.size());
-    zero_memory_beyond(size_);
-}
-
-template <typename Fr>
 Polynomial<Fr>::Polynomial(std::span<const Fr> interpolation_points, std::span<const Fr> evaluations)
     : Polynomial(interpolation_points.size())
 {

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -426,13 +426,11 @@ template <typename Fr> Polynomial<Fr> Polynomial<Fr>::partial_evaluate_mle(std::
     ASSERT(size_ >= static_cast<size_t>(1 << m));
     size_t n = numeric::get_msb(size_);
 
-    // we do m rounds l = 0,...,m-1.
-    // in round l, n_l is the size of the buffer containing the polynomial partially evaluated
-    // at u_0,..., u_l in variables X_{n-l-1}, ..., X_{n-1}.
-    // in round 0, this is half the size of the original polynomial
+    // Partial evaluation is done in m rounds l = 0,...,m-1. At the end of round l, the polynomial has been partially
+    // evaluated at u_{m-l-1}, ..., u_{m-1} in variables X_{n-l-1}, ..., X_{n-1}. The size of this polynomial is n_l.
     size_t n_l = 1 << (n - 1);
 
-    // temporary buffer of half the size of the polynomial
+    // Temporary buffer of half the size of the polynomial
     pointer tmp_ptr = allocate_aligned_memory(sizeof(Fr) * n_l);
     auto tmp = tmp_ptr.get();
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -69,6 +69,17 @@ Polynomial<Fr>::Polynomial(std::span<const Fr> coefficients)
 }
 
 template <typename Fr>
+Polynomial<Fr>::Polynomial(std::initializer_list<Fr> coefficients)
+    : size_(coefficients.size())
+{
+    coefficients_ = allocate_aligned_memory(sizeof(Fr) * capacity());
+    memcpy(static_cast<void*>(coefficients_.get()),
+           static_cast<void const*>(coefficients.begin()),
+           sizeof(Fr) * coefficients.size());
+    zero_memory_beyond(size_);
+}
+
+template <typename Fr>
 Polynomial<Fr>::Polynomial(std::span<const Fr> interpolation_points, std::span<const Fr> evaluations)
     : Polynomial(interpolation_points.size())
 {

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -3,6 +3,7 @@
 #include "barretenberg/common/slab_allocator.hpp"
 #include "barretenberg/common/thread.hpp"
 #include "barretenberg/common/thread_utils.hpp"
+#include "barretenberg/numeric/bitop/pow.hpp"
 #include "polynomial_arithmetic.hpp"
 #include <cstddef>
 #include <fcntl.h>
@@ -422,7 +423,8 @@ template <typename Fr> Polynomial<Fr> Polynomial<Fr>::partial_evaluate_mle(std::
     // Get size of partial evaluation point u = (u_0,...,u_{m-1})
     const size_t m = evaluation_points.size();
 
-    // WORKTODO: Assert that the size of the polynomial being evaluated is a power of 2 and > (1 << m)
+    // Assert that the size of the polynomial being evaluated is a power of 2 greater than (1 << m)
+    ASSERT(numeric::is_power_of_two(size_));
     ASSERT(size_ >= static_cast<size_t>(1 << m));
     size_t n = numeric::get_msb(size_);
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -211,7 +211,7 @@ template <typename Fr> class Polynomial {
      *
      * @note Intuitively, partially evaluating in one variable collapses the hypercube in one dimension, halving the
      * number of coefficients needed to represent the result. To partially evaluate starting with the first variable (as
-     * is done in evaluate_mle), the vector of coefficents is halved by combining consecutive rows in a pairwise
+     * is done in evaluate_mle), the vector of coefficents is halved by combining adjacent rows in a pairwise
      * fashion (similar to what is done in Sumcheck via "edges"). To evaluate starting from the last variable, we
      * instead bisect the whole vector and combine the two halves. I.e. rather than coefficents being combined with
      * their immediate neighbor, they are combined with the coefficient that lives n/2 indices away.

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -206,6 +206,18 @@ template <typename Fr> class Polynomial {
     Fr evaluate_mle(std::span<const Fr> evaluation_points, bool shift = false) const;
 
     /**
+     * @brief Partially evaluates in the last k variables a polynomial interpreted as a multilinear extension.
+     *
+     * @details Partially evaluates p(X) = (a_0, ..., a_{2^n-1}) considered as multilinear extension p(X_0,…,X_{n-1}) =
+     * \sum_i a_i*L_i(X_0,…,X_{n-1}) at u = (u_0,…,u_{m-1}), m < n, in the last m variables X_n-m,…,X_{n-1}. The result
+     * is a multilinear polynomial in n-m variables g(X_0,…,X_{n-m-1})) = p(X_0,…,X_{n-m-1},u_0,...u_{m-1}).
+     *
+     * @param evaluation_points an MLE partial evaluation point u = (u_0,…,u_{m-1})
+     * @return Polynomial<Fr> g(X_0,…,X_{n-m-1})) = p(X_0,…,X_{n-m-1},u_0,...u_{m-1})
+     */
+    Polynomial<Fr> partial_evaluate_mle(std::span<const Fr> evaluation_points) const;
+
+    /**
      * @brief Divides p(X) by (X-r₁)⋯(X−rₘ) in-place.
      * Assumes that p(rⱼ)=0 for all j
      *

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -30,9 +30,6 @@ template <typename Fr> class Polynomial {
     // Create a polynomial from the given fields.
     Polynomial(std::span<const Fr> coefficients);
 
-    // Construct from initializer list, e.g. Polynomial poly = {1, 2, 3}
-    Polynomial(std::initializer_list<Fr> coefficients);
-
     // Allow polynomials to be entirely reset/dormant
     Polynomial() = default;
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -209,6 +209,13 @@ template <typename Fr> class Polynomial {
      * \sum_i a_i*L_i(X_0,…,X_{n-1}) at u = (u_0,…,u_{m-1}), m < n, in the last m variables X_n-m,…,X_{n-1}. The result
      * is a multilinear polynomial in n-m variables g(X_0,…,X_{n-m-1})) = p(X_0,…,X_{n-m-1},u_0,...u_{m-1}).
      *
+     * @note Intuitively, partially evaluating in one variable collapses the hypercube in one dimension, halving the
+     * number of coefficients needed to represent the result. To partially evaluate starting with the first variable (as
+     * is done in evaluate_mle), the vector of coefficents is halved by combining consecutive rows in a pairwise
+     * fashion (similar to what is done in Sumcheck via "edges"). To evaluate starting from the last variable, we
+     * instead bisect the whole vector and combine the two halves. I.e. rather than coefficents being combined with
+     * their immediate neighbor, they are combined with the coefficient that lives n/2 indices away.
+     *
      * @param evaluation_points an MLE partial evaluation point u = (u_0,…,u_{m-1})
      * @return Polynomial<Fr> g(X_0,…,X_{n-m-1})) = p(X_0,…,X_{n-m-1},u_0,...u_{m-1})
      */

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -30,6 +30,9 @@ template <typename Fr> class Polynomial {
     // Create a polynomial from the given fields.
     Polynomial(std::span<const Fr> coefficients);
 
+    // Construct from initializer list, e.g. Polynomial poly = {1, 2, 3}
+    Polynomial(std::initializer_list<Fr> coefficients);
+
     // Allow polynomials to be entirely reset/dormant
     Polynomial() = default;
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.test.cpp
@@ -1095,6 +1095,43 @@ TYPED_TEST(PolynomialTests, evaluate_mle)
     test_case(2);
 }
 
+/**
+ * @brief Test the function for partially evaluating MLE polynomials
+ *
+ */
+TYPED_TEST(PolynomialTests, partial_evaluate_mle)
+{
+    // Initialize a random polynomial
+    using FF = TypeParam;
+    size_t N = 32;
+    Polynomial<FF> poly(N);
+    for (auto& coeff : poly) {
+        coeff = FF::random_element();
+    }
+
+    // Define a random multivariate evaluation point u = (u_0, u_1, u_2, u_3, u_4)
+    auto u_0 = FF::random_element();
+    auto u_1 = FF::random_element();
+    auto u_2 = FF::random_element();
+    auto u_3 = FF::random_element();
+    auto u_4 = FF::random_element();
+    std::vector<FF> u_challenge = { u_0, u_1, u_2, u_3, u_4 };
+
+    // Show that directly computing v = p(u_0,...,u_4) yields the same result as first computing the partial evaluation
+    // in the last 3 variables g(X_0,X_1) = p(X_0,X_1,u_2,u_3,u_4), then v = g(u_0,u_1)
+
+    // Compute v = p(u_0,...,u_4)
+    auto v_expected = poly.evaluate_mle(u_challenge);
+
+    // Compute g(X_0,X_1) = p(X_0,X_1,u_2,u_3,u_4), then v = g(u_0,u_1)
+    std::vector<FF> u_part_1 = { u_0, u_1 };
+    std::vector<FF> u_part_2 = { u_2, u_3, u_4 };
+    auto partial_evaluated_poly = poly.partial_evaluate_mle(u_part_2);
+    auto v_result = partial_evaluated_poly.evaluate_mle(u_part_1);
+
+    EXPECT_EQ(v_result, v_expected);
+}
+
 TYPED_TEST(PolynomialTests, factor_roots)
 {
     using FF = TypeParam;


### PR DESCRIPTION
Adds ZeroMorph functionality (without zk) required to prove and verify batched multilinear evaluation claims, including efficient handling of shifts. For now, the protocol is fully laid out in a test. Incorporation into honk will be done in a separate PR.

The best resource for understanding this PR is this companion [doc](https://hackmd.io/dlf9xEwhTQyE3hiGbq4FsA?view). The full batched protocol description therein matches the implementation.

Note: The goal of this first pass was to make the implementations as clear as possible. There are many simple optimizations that could be introduced to make things more efficient. 


# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
