### PR TITLE
fix: Add missing properties to deployed packages

### DIFF
--- a/build-system/scripts/deploy_npm
+++ b/build-system/scripts/deploy_npm
@@ -50,7 +50,7 @@ if [ -z "$STANDALONE" ]; then
 fi
 
 # Filter on whitelist of properties.
-jq '{name, version, exports, main, homepage, author, type, license, dependencies, description, bin} | with_entries( select( .value != null ) )' \
+jq '{name, version, exports, main, homepage, author, type, license, dependencies, description, bin, engine, types} | with_entries( select( .value != null ) )' \
 package.json > $TMP && mv $TMP package.json
 
 # Publish if we have a commit tag

--- a/build-system/scripts/deploy_npm
+++ b/build-system/scripts/deploy_npm
@@ -49,10 +49,6 @@ if [ -z "$STANDALONE" ]; then
   done
 fi
 
-# Filter on whitelist of properties.
-jq '{name, version, exports, main, homepage, author, type, license, dependencies, description, bin, engine, types} | with_entries( select( .value != null ) )' \
-package.json > $TMP && mv $TMP package.json
-
 # Publish if we have a commit tag
 if [ -n "$COMMIT_TAG" ] ; then 
   npm publish $TAG_ARG --access public


### PR DESCRIPTION
We were failing to publish `types` and `engine` in our packages. This PR removes the `package.json` properties whitelist altogether, [as agreed with @charlielye](https://aztecprotocol.slack.com/archives/C04BTJAA694/p1696425549075069?thread_ts=1696425187.843659&cid=C04BTJAA694).

![image](https://github.com/AztecProtocol/aztec-packages/assets/429604/ce39d213-e607-485b-9b96-6132d0168cc1)
