### PR TITLE
fix: Do not fail if npm package has not yet been deployed

### DIFF
--- a/yarn-project/deploy_npm.sh
+++ b/yarn-project/deploy_npm.sh
@@ -21,7 +21,7 @@ function deploy_package() {
         TAG_ARG="--tag $TAG"
     fi
 
-    PUBLISHED_VERSION=$(npm show . version ${TAG_ARG:-} 2> /dev/null)
+    PUBLISHED_VERSION=$(npm show . version ${TAG_ARG:-} 2> /dev/null) || true
     HIGHER_VERSION=$(npx semver ${VERSION} ${PUBLISHED_VERSION} | tail -1)
 
     # If there is already a published package equal to given version, assume this is a re-run of a deploy, and early out.


### PR DESCRIPTION
The check for the current version was failing if the package didn't exist, so the first deployment a package would always fail. We're now hitting this with the pxe.