### PR TITLE
fix: Remove npx from extract_tag_version

### DIFF
--- a/build-system/scripts/extract_tag_version
+++ b/build-system/scripts/extract_tag_version
@@ -41,14 +41,14 @@ if [[ "$COMMIT_TAG" == *"/"* ]]; then
 fi
 
 # Check it's a valid semver.
-VERSION=$(npx semver "$COMMIT_TAG_VERSION")
-if [[ -z "$VERSION" ]]; then
+SEMVER_REGEX="^v?([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$"
+if ! [[ $COMMIT_TAG_VERSION =~ $SEMVER_REGEX ]]; then
   echo "$COMMIT_TAG_VERSION is not a semantic version." >&2
   if [[ "$ERROR_ON_FAIL" == "true" ]]; then
     exit 1
   else
-    VERSION=""
+    COMMIT_TAG_VERSION=""
   fi
 fi
 
-echo "$VERSION"
+echo "${COMMIT_TAG_VERSION#v}"


### PR DESCRIPTION
Removes npx from `extract_tag_version`, so it can be safely called from the base aztec alpine build image, so it doesn't fail when called from the `build` script.

Manually run tests:
```
$ COMMIT_TAG=v0.8.7 ./scripts/extract_tag_version foo
0.8.7
$ COMMIT_TAG=0.8.7 ./scripts/extract_tag_version foo
0.8.7
$ COMMIT_TAG=repo/v0.8.7 ./scripts/extract_tag_version foo
Tag was made for: repo
Version: v0.8.7
REPO_NAME (repo) does not match REPOSITORY (foo). Exiting...
$ COMMIT_TAG=foo/v0.8.7 ./scripts/extract_tag_version foo
Tag was made for: foo
Version: v0.8.7
0.8.7
$ COMMIT_TAG=foo/v0.8.7 ./scripts/extract_tag_version foo
Tag was made for: foo
Version: v0.8.7
0.8.7
$ COMMIT_TAG=foo/0.8.7 ./scripts/extract_tag_version foo
Tag was made for: foo
Version: 0.8.7
0.8.7
$ COMMIT_TAG=foo/notsemver ./scripts/extract_tag_version foo
Tag was made for: foo
Version: notsemver
notsemver is not a semantic version.

$ COMMIT_TAG=notsemver ./scripts/extract_tag_version foo
notsemver is not a semantic version.

$ COMMIT_TAG=0.8.7 ./scripts/extract_tag_version foo
0.8.7
$ COMMIT_TAG=v0.8.7 ./scripts/extract_tag_version foo
0.8.7
$ COMMIT_TAG=v0.8.7-alpha1 ./scripts/extract_tag_version foo
0.8.7-alpha1
```