### PR TITLE
chore(circuits): delete old code that set a different generator index per vector entry in pedersen commitment

### DIFF
--- a/circuits/cpp/src/aztec3/circuits/apps/notes/default_private_note/note.tpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/notes/default_private_note/note.tpp
@@ -18,10 +18,6 @@ using aztec3::circuits::apps::state_vars::StateVar;
 
 namespace aztec3::circuits::apps::notes {
 
-using aztec3::GeneratorIndex;
-
-using crypto::generators::generator_index_t;
-
 using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
 using plonk::stdlib::witness_t;
@@ -62,27 +58,6 @@ typename CircuitTypes<Builder>::fr DefaultPrivateNote<Builder, V>::compute_commi
 
     grumpkin_point const storage_slot_point = state_var->storage_slot_point;
 
-    std::vector<fr> const inputs;
-    std::vector<generator_index_t> const generators;
-
-    auto gen_pair_address = [&](std::optional<address> const& input, size_t const hash_sub_index) {
-        if (!input) {
-            throw_or_abort(
-                "Cannot commit to a partial preimage. Call compute_partial_commitment instead, or complete "
-                "the preimage.");
-        }
-        return std::make_pair((*input).to_field(), generator_index_t({ GeneratorIndex::COMMITMENT, hash_sub_index }));
-    };
-
-    auto gen_pair_fr = [&](std::optional<fr> const& input, size_t const hash_sub_index) {
-        if (!input) {
-            throw_or_abort(
-                "Cannot commit to a partial preimage. Call compute_partial_commitment instead, or complete "
-                "the preimage.");
-        }
-        return std::make_pair(*input, generator_index_t({ GeneratorIndex::COMMITMENT, hash_sub_index }));
-    };
-
     if (!note_preimage.salt) {
         note_preimage.salt = get_oracle().generate_random_element();
     }
@@ -90,18 +65,17 @@ typename CircuitTypes<Builder>::fr DefaultPrivateNote<Builder, V>::compute_commi
     const auto& [value, owner, creator_address, memo, salt, nonce, is_dummy] = note_preimage;
 
     const grumpkin_point commitment_point =
-        storage_slot_point +
-        CT::commit(
-            { gen_pair_fr(value, PrivateStateNoteGeneratorIndex::VALUE),
-              gen_pair_address(owner, PrivateStateNoteGeneratorIndex::OWNER),
-              gen_pair_address(creator_address, PrivateStateNoteGeneratorIndex::CREATOR),
-              gen_pair_fr(memo, PrivateStateNoteGeneratorIndex::MEMO),
-              gen_pair_fr(salt, PrivateStateNoteGeneratorIndex::SALT),
-              gen_pair_fr(nonce, PrivateStateNoteGeneratorIndex::NONCE),
-              std::make_pair(
-                  is_dummy, generator_index_t({ GeneratorIndex::COMMITMENT, PrivateStateNoteGeneratorIndex::IS_DUMMY }))
-
-            });
+        storage_slot_point + CT::commit(
+                                 {
+                                     *value,                        /*PrivateStateNoteGeneratorIndex::VALUE*/
+                                     (*owner).to_field(),           /*PrivateStateNoteGeneratorIndex::OWNER*/
+                                     (*creator_address).to_field(), /*PrivateStateNoteGeneratorIndex::CREATOR*/
+                                     *memo,                         /*PrivateStateNoteGeneratorIndex::MEMO*/
+                                     *salt,                         /*PrivateStateNoteGeneratorIndex::SALT*/
+                                     *nonce,                        /*PrivateStateNoteGeneratorIndex::NONCE*/
+                                     is_dummy,                      /*PrivateStateNoteGeneratorIndex::IS_DUMMY*/
+                                 },
+                                 GeneratorIndex::COMMITMENT);
 
     commitment = commitment_point.x;
 

--- a/circuits/cpp/src/aztec3/circuits/apps/notes/default_private_note/note_preimage.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/notes/default_private_note/note_preimage.hpp
@@ -10,7 +10,6 @@ namespace aztec3::circuits::apps::notes {
 
 using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
-using crypto::generators::generator_index_t;
 
 template <typename NCT, typename V> struct DefaultPrivateNotePreimage {
     using fr = typename NCT::fr;

--- a/circuits/cpp/src/aztec3/circuits/apps/notes/default_singleton_private_note/note.tpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/notes/default_singleton_private_note/note.tpp
@@ -5,6 +5,7 @@
 #include "../../state_vars/state_var_base.hpp"
 #include "../note_interface.hpp"
 
+#include "aztec3/constants.hpp"
 #include "aztec3/utils/types/circuit_types.hpp"
 #include "aztec3/utils/types/convert.hpp"
 #include "aztec3/utils/types/native_types.hpp"
@@ -19,8 +20,6 @@ using aztec3::circuits::apps::state_vars::StateVar;
 namespace aztec3::circuits::apps::notes {
 
 using aztec3::GeneratorIndex;
-
-using crypto::generators::generator_index_t;
 
 using aztec3::utils::types::CircuitTypes;
 using aztec3::utils::types::NativeTypes;
@@ -62,23 +61,6 @@ typename CircuitTypes<Builder>::fr DefaultSingletonPrivateNote<Builder, V>::comp
 
     grumpkin_point const storage_slot_point = state_var->storage_slot_point;
 
-    std::vector<fr> const inputs;
-    std::vector<generator_index_t> const generators;
-
-    auto gen_pair_address = [&](std::optional<address> const& input, size_t const hash_sub_index) {
-        if (!input) {
-            throw_or_abort("Cannot commit to a partial preimage.");
-        }
-        return std::make_pair((*input).to_field(), generator_index_t({ GeneratorIndex::COMMITMENT, hash_sub_index }));
-    };
-
-    auto gen_pair_fr = [&](std::optional<fr> const& input, size_t const hash_sub_index) {
-        if (!input) {
-            throw_or_abort("Cannot commit to a partial preimage.");
-        }
-        return std::make_pair(*input, generator_index_t({ GeneratorIndex::COMMITMENT, hash_sub_index }));
-    };
-
     if (!note_preimage.salt) {
         note_preimage.salt = get_oracle().generate_random_element();
     }
@@ -86,12 +68,14 @@ typename CircuitTypes<Builder>::fr DefaultSingletonPrivateNote<Builder, V>::comp
     const auto& [value, owner, salt, nonce] = note_preimage;
 
     const grumpkin_point commitment_point =
-        storage_slot_point + CT::commit({
-                                 gen_pair_fr(value, PrivateStateNoteGeneratorIndex::VALUE),
-                                 gen_pair_address(owner, PrivateStateNoteGeneratorIndex::OWNER),
-                                 gen_pair_fr(salt, PrivateStateNoteGeneratorIndex::SALT),
-                                 gen_pair_fr(nonce, PrivateStateNoteGeneratorIndex::NONCE),
-                             });
+        storage_slot_point + CT::commit(
+                                 {
+                                     *value,              /*PrivateStateNoteGeneratorIndex::VALUE*/
+                                     (*owner).to_field(), /*PrivateStateNoteGeneratorIndex::OWNER*/
+                                     *salt,               /*PrivateStateNoteGeneratorIndex::SALT*/
+                                     *nonce,              /*PrivateStateNoteGeneratorIndex::NONCE*/
+                                 },
+                                 GeneratorIndex::COMMITMENT);
 
     commitment = commitment_point.x;
 

--- a/circuits/cpp/src/aztec3/circuits/apps/state_vars/mapping_state_var.hpp
+++ b/circuits/cpp/src/aztec3/circuits/apps/state_vars/mapping_state_var.hpp
@@ -64,7 +64,6 @@ template <typename Builder, typename V> class MappingStateVar : public StateVar<
     V& at(std::optional<fr> const& key);
 
     static std::tuple<NT::grumpkin_point, bool> compute_slot_point_at_mapping_key(NT::fr const& start_slot,
-                                                                                  size_t level_of_container_nesting,
                                                                                   std::optional<NT::fr> const& key);
 
     std::tuple<grumpkin_point, bool> compute_slot_point_at_mapping_key(std::optional<fr> const& key);


### PR DESCRIPTION
Followup ticket: https://github.com/AztecProtocol/aztec-packages/issues/2701