### PR TITLE
chore: Add node10 entrypoint to Foundation

### DIFF
--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "packageManager": "yarn@3.4.1",
   "type": "module",
+  "main": "./dest/index.js",
+  "types": "./dest/index.d.ts",
   "exports": {
     "./eslint": "./.eslintrc.cjs",
     "./prettier": "./.prettierrc.json",

--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -106,7 +106,6 @@
     "src",
     "!*.test.*"
   ],
-  "types": "./dest/index.d.ts",
   "engines": {
     "node": ">=18"
   }

--- a/yarn-project/foundation/src/index.ts
+++ b/yarn-project/foundation/src/index.ts
@@ -1,0 +1,27 @@
+// Reexport all folders at the root for packages targeting CommonJS
+export * as abi from './abi/index.js';
+export * as asyncMap from './async-map/index.js';
+export * as aztecAddress from './aztec-address/index.js';
+export * as bigintBuffer from './bigint-buffer/index.js';
+export * as collection from './collection/index.js';
+export * as committable from './committable/index.js';
+export * as crypto from './crypto/index.js';
+export * as errors from './errors/index.js';
+export * as ethAddress from './eth-address/index.js';
+export * as fields from './fields/index.js';
+export * as fifo from './fifo/index.js';
+export * as jsonRpc from './json-rpc/index.js';
+export * as jsonRpcClient from './json-rpc/client/index.js';
+export * as jsonRpcServer from './json-rpc/server/index.js';
+export * as log from './log/index.js';
+export * as mutex from './mutex/index.js';
+export * as retry from './retry/index.js';
+export * as runningPromise from './running-promise/index.js';
+export * as serialize from './serialize/index.js';
+export * as sleep from './sleep/index.js';
+export * as timer from './timer/index.js';
+export * as transport from './transport/index.js';
+export * as types from './types/index.js';
+export * as url from './url/index.js';
+export * as wasm from './wasm/index.js';
+export * as worker from './worker/index.js';

--- a/yarn-project/package.common.json
+++ b/yarn-project/package.common.json
@@ -11,6 +11,7 @@
     "node": ">=18"
   },
   "files": ["dest", "src", "!*.test.*"],
+  "types": "./dest/index.d.ts",
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@types/jest": "^29.5.0",

--- a/yarn-project/package.common.json
+++ b/yarn-project/package.common.json
@@ -10,11 +10,7 @@
   "engines": {
     "node": ">=18"
   },
-  "files": [
-    "dest",
-    "src",
-    "!*.test.*"
-  ],
+  "files": ["dest", "src", "!*.test.*"],
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@types/jest": "^29.5.0",

--- a/yarn-project/package.common.json
+++ b/yarn-project/package.common.json
@@ -10,8 +10,11 @@
   "engines": {
     "node": ">=18"
   },
-  "files": ["dest", "src", "!*.test.*"],
-  "types": "./dest/index.d.ts",
+  "files": [
+    "dest",
+    "src",
+    "!*.test.*"
+  ],
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@types/jest": "^29.5.0",


### PR DESCRIPTION
Using node10 module resolution fails when importing Foundation, since the `exports` entry with multiple entrypoints is ignored. This PR adds a `main` fallback with an index that re-exports every submodule as a named object. 

So a user with node10 module resolution and targetting a commonjs module can do:
```ts
import { sleep } from '@aztec/foundation';

async function main() {
  await sleep.sleep(1);
}
```

While a user targetting node16 and up can do:
```ts
import { sleep } from '@aztec/foundation/sleep';

async function main() {
  await sleep(1);
}
```

Note that importing `@aztec/foundation` under node16 fails, since there is no `.` entrypoint under exports.