### PR TITLE
fix: Docs: Sandbox version numbers

### DIFF
--- a/docs/docs/dev_docs/getting_started/sandbox.md
+++ b/docs/docs/dev_docs/getting_started/sandbox.md
@@ -128,8 +128,8 @@ yarn add @aztec/aztec.js @aztec/noir-contracts typescript @types/node
     "start": "yarn build && DEBUG='token' node ./dest/index.js"
   },
   "dependencies": {
-    "@aztec/aztec.js": "^#include_aztec_version",
-    "@aztec/noir-contracts": "^#include_aztec_version",
+    "@aztec/aztec.js": "^0.8.7",
+    "@aztec/noir-contracts": "^0.8.7",
     "@types/node": "^20.6.3",
     "typescript": "^5.2.2"
   }


### PR DESCRIPTION
The `#include_aztec_version` doesn't work as a package reference in package.json. This PR fixes the update in https://github.com/AztecProtocol/aztec-packages/pull/2703 until we come up with a better solution.


# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [x] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
