### PR TITLE
chore: move { Fr } imports to foundation/fields

### DIFF
--- a/yarn-project/aztec.js/src/account/contract/ecdsa_account_contract.ts
+++ b/yarn-project/aztec.js/src/account/contract/ecdsa_account_contract.ts
@@ -1,6 +1,6 @@
-import { Fr } from '@aztec/circuits.js';
 import { Ecdsa } from '@aztec/circuits.js/barretenberg';
 import { ContractAbi } from '@aztec/foundation/abi';
+import { Fr } from '@aztec/foundation/fields';
 import { AuthWitness, CompleteAddress } from '@aztec/types';
 
 import EcdsaAccountContractAbi from '../../abis/ecdsa_account_contract.json' assert { type: 'json' };

--- a/yarn-project/aztec.js/src/account/contract/schnorr_account_contract.ts
+++ b/yarn-project/aztec.js/src/account/contract/schnorr_account_contract.ts
@@ -1,6 +1,6 @@
-import { Fr } from '@aztec/circuits.js';
 import { Schnorr } from '@aztec/circuits.js/barretenberg';
 import { ContractAbi } from '@aztec/foundation/abi';
+import { Fr } from '@aztec/foundation/fields';
 import { AuthWitness, CompleteAddress, GrumpkinPrivateKey } from '@aztec/types';
 
 import SchnorrAccountContractAbi from '../../abis/schnorr_account_contract.json' assert { type: 'json' };

--- a/yarn-project/aztec.js/src/account/contract/single_key_account_contract.ts
+++ b/yarn-project/aztec.js/src/account/contract/single_key_account_contract.ts
@@ -1,6 +1,7 @@
-import { Fr, PartialAddress } from '@aztec/circuits.js';
+import { PartialAddress } from '@aztec/circuits.js';
 import { Schnorr } from '@aztec/circuits.js/barretenberg';
 import { ContractAbi } from '@aztec/foundation/abi';
+import { Fr } from '@aztec/foundation/fields';
 import { AuthWitness, CompleteAddress, GrumpkinPrivateKey } from '@aztec/types';
 
 import SchnorrSingleKeyAccountContractAbi from '../../abis/schnorr_single_key_account_contract.json' assert { type: 'json' };

--- a/yarn-project/aztec.js/src/account/interface.ts
+++ b/yarn-project/aztec.js/src/account/interface.ts
@@ -1,4 +1,4 @@
-import { Fr } from '@aztec/circuits.js';
+import { Fr } from '@aztec/foundation/fields';
 import { AuthWitness, CompleteAddress, FunctionCall, TxExecutionRequest } from '@aztec/types';
 
 // docs:start:account-interface

--- a/yarn-project/aztec.js/src/account/manager/index.ts
+++ b/yarn-project/aztec.js/src/account/manager/index.ts
@@ -1,4 +1,5 @@
-import { Fr, PublicKey, getContractDeploymentInfo } from '@aztec/circuits.js';
+import { PublicKey, getContractDeploymentInfo } from '@aztec/circuits.js';
+import { Fr } from '@aztec/foundation/fields';
 import { CompleteAddress, GrumpkinPrivateKey, PXE } from '@aztec/types';
 
 import { AccountWallet, ContractDeployer, DeployMethod, WaitOpts, generatePublicKey } from '../../index.js';

--- a/yarn-project/aztec.js/src/sandbox/index.ts
+++ b/yarn-project/aztec.js/src/sandbox/index.ts
@@ -1,4 +1,4 @@
-import { Fr, GrumpkinScalar } from '@aztec/circuits.js';
+import { Fr, GrumpkinScalar } from '@aztec/foundation/fields';
 import { sleep } from '@aztec/foundation/sleep';
 
 import zip from 'lodash.zip';

--- a/yarn-project/circuits.js/src/structs/kernel/previous_kernel_data.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/previous_kernel_data.ts
@@ -1,9 +1,9 @@
+import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, Tuple } from '@aztec/foundation/serialize';
 
 import { privateKernelDummyPreviousKernel } from '../../cbind/circuits.gen.js';
 import { CircuitsWasm, VK_TREE_HEIGHT, makeTuple } from '../../index.js';
 import { serializeToBuffer } from '../../utils/serialize.js';
-import { Fr } from '../index.js';
 import { Proof, makeEmptyProof } from '../proof.js';
 import { UInt32 } from '../shared.js';
 import { VerificationKey } from '../verification_key.js';

--- a/yarn-project/circuits.js/src/structs/kernel/private_kernel.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/private_kernel.ts
@@ -1,3 +1,4 @@
+import { Fr } from '@aztec/foundation/fields';
 import { Tuple } from '@aztec/foundation/serialize';
 
 import {
@@ -11,7 +12,6 @@ import {
 import { FieldsOf } from '../../utils/jsUtils.js';
 import { serializeToBuffer } from '../../utils/serialize.js';
 import { PrivateCallStackItem } from '../call_stack_item.js';
-import { Fr } from '../index.js';
 import { MembershipWitness } from '../membership_witness.js';
 import { Proof } from '../proof.js';
 import { ReadRequestMembershipWitness } from '../read_request_membership_witness.js';

--- a/yarn-project/circuits.js/src/types/partial_address.ts
+++ b/yarn-project/circuits.js/src/types/partial_address.ts
@@ -1,4 +1,4 @@
-import { Fr } from '../index.js';
+import { Fr } from '@aztec/foundation/fields';
 
 /**
  * A type which along with public key forms a preimage of a contract address. See the link bellow for more details

--- a/yarn-project/cli/src/encoding.ts
+++ b/yarn-project/cli/src/encoding.ts
@@ -1,5 +1,5 @@
-import { Fr } from '@aztec/aztec.js';
 import { ABIParameter, ABIType, StructType } from '@aztec/foundation/abi';
+import { Fr } from '@aztec/foundation/fields';
 
 /**
  * Parses a hex string into an ABI struct type.

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
@@ -1,6 +1,6 @@
 import { AccountWallet, AztecAddress, computeAuthWitMessageHash } from '@aztec/aztec.js';
-import { Fr } from '@aztec/circuits.js';
 import { EthAddress } from '@aztec/foundation/eth-address';
+import { Fr } from '@aztec/foundation/fields';
 import { DebugLogger } from '@aztec/foundation/log';
 import { TokenBridgeContract, TokenContract } from '@aztec/noir-contracts/types';
 import { TxStatus } from '@aztec/types';

--- a/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
@@ -6,7 +6,7 @@ import {
   generatePublicKey,
   getSchnorrAccount,
 } from '@aztec/aztec.js';
-import { Fr, GrumpkinScalar } from '@aztec/circuits.js';
+import { Fr, GrumpkinScalar } from '@aztec/foundation/fields';
 import { DebugLogger } from '@aztec/foundation/log';
 import { TokenContract } from '@aztec/noir-contracts/types';
 import { AztecNode, PXE, TxStatus } from '@aztec/types';

--- a/yarn-project/end-to-end/src/e2e_ordering.test.ts
+++ b/yarn-project/end-to-end/src/e2e_ordering.test.ts
@@ -1,7 +1,8 @@
 // Test suite for testing proper ordering of side effects
 import { Wallet } from '@aztec/aztec.js';
-import { Fr, FunctionSelector } from '@aztec/circuits.js';
+import { FunctionSelector } from '@aztec/circuits.js';
 import { toBigIntBE } from '@aztec/foundation/bigint-buffer';
+import { Fr } from '@aztec/foundation/fields';
 import { toBigInt } from '@aztec/foundation/serialize';
 import { ChildContract, ParentContract } from '@aztec/noir-contracts/types';
 import { L2BlockL2Logs, PXE, TxStatus, UnencryptedL2Log } from '@aztec/types';

--- a/yarn-project/end-to-end/src/e2e_private_airdrop.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_airdrop.test.ts
@@ -1,5 +1,6 @@
 import { CompleteAddress, NotePreimage, TxHash, Wallet } from '@aztec/aztec.js';
-import { Fr, MAX_NEW_COMMITMENTS_PER_CALL } from '@aztec/circuits.js';
+import { MAX_NEW_COMMITMENTS_PER_CALL } from '@aztec/circuits.js';
+import { Fr } from '@aztec/foundation/fields';
 import { DebugLogger } from '@aztec/foundation/log';
 import { PrivateTokenAirdropContract } from '@aztec/noir-contracts/types';
 

--- a/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
@@ -1,6 +1,6 @@
 import { AccountWallet, AztecAddress, computeAuthWitMessageHash } from '@aztec/aztec.js';
-import { Fr } from '@aztec/circuits.js';
 import { EthAddress } from '@aztec/foundation/eth-address';
+import { Fr } from '@aztec/foundation/fields';
 import { DebugLogger } from '@aztec/foundation/log';
 import { TokenBridgeContract, TokenContract } from '@aztec/noir-contracts/types';
 import { TxStatus } from '@aztec/types';

--- a/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
+++ b/yarn-project/end-to-end/src/uniswap_trade_on_l1_from_l2.test.ts
@@ -1,7 +1,7 @@
 import { AccountWallet, AztecAddress, computeAuthWitMessageHash } from '@aztec/aztec.js';
-import { Fr } from '@aztec/circuits.js';
 import { deployL1Contract } from '@aztec/ethereum';
 import { EthAddress } from '@aztec/foundation/eth-address';
+import { Fr } from '@aztec/foundation/fields';
 import { DebugLogger } from '@aztec/foundation/log';
 import { UniswapPortalAbi, UniswapPortalBytecode } from '@aztec/l1-artifacts';
 import { UniswapContract } from '@aztec/noir-contracts/types';

--- a/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
@@ -1,4 +1,5 @@
-import { Fr, GlobalVariables } from '@aztec/circuits.js';
+import { GlobalVariables } from '@aztec/circuits.js';
+import { Fr } from '@aztec/foundation/fields';
 import { createDebugLogger } from '@aztec/foundation/log';
 
 /**

--- a/yarn-project/types/src/auth_witness.ts
+++ b/yarn-project/types/src/auth_witness.ts
@@ -1,5 +1,6 @@
-import { Fr, Vector } from '@aztec/circuits.js';
+import { Vector } from '@aztec/circuits.js';
 import { BufferReader, serializeToBuffer } from '@aztec/circuits.js/utils';
+import { Fr } from '@aztec/foundation/fields';
 
 /**
  * An authentication witness. Used to authorize an action by a user.


### PR DESCRIPTION
help avoid any possible import errors (like circular import)

