### PR TITLE
chore(log): Show log level in debug logs

### DIFF
--- a/yarn-project/foundation/src/log/logger.ts
+++ b/yarn-project/foundation/src/log/logger.ts
@@ -76,11 +76,12 @@ function logWithDebug(debug: debug.Debugger, level: LogLevel, msg: string, data?
     handler(level, debug.namespace, msg, data);
   }
 
-  const msgWithData = data ? `${msg} ${fmtLogData(data)}` : msg;
+  msg = data ? `${msg} ${fmtLogData(data)}` : msg;
   if (debug.enabled) {
-    debug(msgWithData);
+    if (level !== 'debug') msg = `${level.toUpperCase()} ${msg}`;
+    debug(msg);
   } else if (LogLevels.indexOf(level) <= LogLevels.indexOf(currentLevel)) {
-    printLog(`${getPrefix(debug, level)} ${msgWithData}`);
+    printLog(`${getPrefix(debug, level)} ${msg}`);
   }
 }
 


### PR DESCRIPTION
When emitting an INFO/WARN/ERROR log via the `debug` interface, the message will now include the severity level, so it's easier to spot errors. DEBUG is not shown so it's not annoying.