### PR TITLE
fix: block encoding

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -296,7 +296,7 @@ function makeL1ToL2MessageCancelledEvents(l1BlockNum: bigint, entryKeys: string[
  */
 function makeRollupTx(l2Block: L2Block) {
   const proof = `0x`;
-  const block = toHex(l2Block.encode());
+  const block = toHex(l2Block.toBufferWithLogs());
   const input = encodeFunctionData({ abi: RollupAbi, functionName: 'process', args: [proof, block] });
   return { input } as Transaction<bigint, number>;
 }

--- a/yarn-project/archiver/src/archiver/eth_log_handlers.ts
+++ b/yarn-project/archiver/src/archiver/eth_log_handlers.ts
@@ -104,7 +104,7 @@ async function getBlockFromCallData(
   });
   if (functionName !== 'process') throw new Error(`Unexpected method called ${functionName}`);
   const [, l2BlockHex] = args! as [Hex, Hex];
-  const block = L2Block.decode(Buffer.from(hexToBytes(l2BlockHex)));
+  const block = L2Block.fromBufferWithLogs(Buffer.from(hexToBytes(l2BlockHex)));
   if (BigInt(block.number) !== l2BlockNum) {
     throw new Error(`Block number mismatch: expected ${l2BlockNum} but got ${block.number}`);
   }

--- a/yarn-project/aztec-sandbox/docker-compose.yml
+++ b/yarn-project/aztec-sandbox/docker-compose.yml
@@ -29,9 +29,9 @@ services:
     image: otterscan/otterscan:develop
     # platform: linux/amd64
     ports:
-      - "5100:80"
+      - '5100:80'
     container_name: otterscan
     environment:
-    # otterscan env var is hardcoded to support erigon client
-    # but it also works for anvil
+      # otterscan env var is hardcoded to support erigon client
+      # but it also works for anvil
       - ERIGON_URL=http://127.0.0.1:${SANDBOX_ANVIL_PORT:-8545}

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -133,7 +133,7 @@ export const setupL1Contracts = async (
 /**
  * Sets up Private eXecution Environment (PXE).
  * @param numberOfAccounts - The number of new accounts to be created once the PXE is initiated.
- * @param aztecNode - The instance of an aztec node, if one is required
+ * @param aztecNode - An instance of Aztec Node.
  * @param firstPrivKey - The private key of the first account to be created.
  * @param logger - The logger to be used.
  * @param useLogSuffix - Whether to add a randomly generated suffix to the PXE debug logs.

--- a/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
@@ -315,11 +315,11 @@ describe('L1Publisher integration', () => {
       const expectedData = encodeFunctionData({
         abi: RollupAbi,
         functionName: 'process',
-        args: [`0x${l2Proof.toString('hex')}`, `0x${block.encode().toString('hex')}`],
+        args: [`0x${l2Proof.toString('hex')}`, `0x${block.toBufferWithLogs().toString('hex')}`],
       });
       expect(ethTx.input).toEqual(expectedData);
 
-      const decoderArgs = [`0x${block.encode().toString('hex')}`] as const;
+      const decoderArgs = [`0x${block.toBufferWithLogs().toString('hex')}`] as const;
       const decodedHashes = await decoderHelper.read.computeDiffRootAndMessagesHash(decoderArgs);
       const decodedRes = await decoderHelper.read.decode(decoderArgs);
       const stateInRollup = await rollup.read.rollupStateHash();
@@ -387,11 +387,11 @@ describe('L1Publisher integration', () => {
       const expectedData = encodeFunctionData({
         abi: RollupAbi,
         functionName: 'process',
-        args: [`0x${l2Proof.toString('hex')}`, `0x${block.encode().toString('hex')}`],
+        args: [`0x${l2Proof.toString('hex')}`, `0x${block.toBufferWithLogs().toString('hex')}`],
       });
       expect(ethTx.input).toEqual(expectedData);
 
-      const decoderArgs = [`0x${block.encode().toString('hex')}`] as const;
+      const decoderArgs = [`0x${block.toBufferWithLogs().toString('hex')}`] as const;
       const decodedHashes = await decoderHelper.read.computeDiffRootAndMessagesHash(decoderArgs);
       const decodedRes = await decoderHelper.read.decode(decoderArgs);
       const stateInRollup = await rollup.read.rollupStateHash();

--- a/yarn-project/foundation/src/json-rpc/client/json_rpc_client.ts
+++ b/yarn-project/foundation/src/json-rpc/client/json_rpc_client.ts
@@ -57,9 +57,9 @@ export async function defaultFetch(
   }
   if (!resp.ok) {
     if (noRetry) {
-      throw new NoRetryError(responseJson.error.message);
+      throw new NoRetryError('(JSON-RPC PROPAGATED) ' + responseJson.error.message);
     } else {
-      throw new Error(responseJson.error.message);
+      throw new Error('(JSON-RPC PROPAGATED) ' + responseJson.error.message);
     }
   }
 

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.test.ts
@@ -16,7 +16,7 @@ describe('L1Publisher', () => {
 
   beforeEach(() => {
     l2Block = L2Block.random(42);
-    l2Inputs = l2Block.encode();
+    l2Inputs = l2Block.toBufferWithLogs();
     l2Proof = Buffer.alloc(0);
 
     txSender = mock<L1PublisherTxSender>();

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -124,7 +124,7 @@ export class L1Publisher implements L2BlockReceiver {
    */
   public async processL2Block(l2BlockData: L2Block): Promise<boolean> {
     const proof = Buffer.alloc(0);
-    const txData = { proof, inputs: l2BlockData.encode() };
+    const txData = { proof, inputs: l2BlockData.toBufferWithLogs() };
 
     while (!this.interrupted) {
       if (!(await this.checkFeeDistributorBalance())) {

--- a/yarn-project/types/src/l2_block.test.ts
+++ b/yarn-project/types/src/l2_block.test.ts
@@ -22,14 +22,6 @@ describe('L2Block', () => {
     expect(recovered).toEqual(block);
   });
 
-  it('can serialise an L2 block to JSON and back', () => {
-    const block = L2Block.random(42);
-    const serialised = block.toJSON();
-    const recovered = L2Block.fromJSON(serialised);
-
-    expect(recovered).toEqual(block);
-  });
-
   // TS equivalent of `testComputeKernelLogsIterationWithoutLogs` in `Decoder.t.sol`
   it('correctly computes kernel logs hash when there are no logs', () => {
     // The following 2 values are copied from `testComputeKernelLogsIterationWithoutLogs` in `Decoder.t.sol`

--- a/yarn-project/types/src/l2_block.test.ts
+++ b/yarn-project/types/src/l2_block.test.ts
@@ -2,17 +2,20 @@ import { TxL2Logs } from './index.js';
 import { L2Block } from './l2_block.js';
 
 describe('L2Block', () => {
-  it('can encode a L2 block data object to buffer and back', () => {
+  it('can serialize an L2 block with logs to a buffer and back', () => {
     const block = L2Block.random(42);
 
-    const buffer = block.encode();
-    const recovered = L2Block.decode(buffer);
+    const buffer = block.toBufferWithLogs();
+    const recovered = L2Block.fromBufferWithLogs(buffer);
 
     expect(recovered).toEqual(block);
   });
 
-  it('can encode a L2 block to string and back', () => {
+  it('can serialize an L2 block without logs to a buffer and back', () => {
     const block = L2Block.random(42);
+    block.newEncryptedLogs = undefined;
+    block.newUnencryptedLogs = undefined;
+
     const serialised = block.toString();
     const recovered = L2Block.fromString(serialised);
 

--- a/yarn-project/types/src/l2_block.ts
+++ b/yarn-project/types/src/l2_block.ts
@@ -346,7 +346,9 @@ export class L2Block {
    */
   encode(): Buffer {
     if (this.newEncryptedLogs === undefined || this.newUnencryptedLogs === undefined) {
-      throw new Error('newEncryptedLogs and newUnencryptedLogs must be defined when encoding L2BlockData');
+      throw new Error(
+        `newEncryptedLogs and newUnencryptedLogs must be defined when encoding L2BlockData (block ${this.number})`,
+      );
     }
 
     return serializeToBuffer(

--- a/yarn-project/types/src/l2_block.ts
+++ b/yarn-project/types/src/l2_block.ts
@@ -403,37 +403,6 @@ export class L2Block {
   }
 
   /**
-   * Encodes the block as a JSON object.
-   * @returns The L2 block encoded as a JSON object.
-   */
-  toJSON() {
-    return {
-      globalVariables: this.globalVariables.toJSON(),
-      startPrivateDataTreeSnapshot: this.startPrivateDataTreeSnapshot.toString(),
-      startNullifierTreeSnapshot: this.startNullifierTreeSnapshot.toString(),
-      startContractTreeSnapshot: this.startContractTreeSnapshot.toString(),
-      startPublicDataTreeRoot: this.startPublicDataTreeRoot.toString(),
-      startL1ToL2MessagesTreeSnapshot: this.startL1ToL2MessagesTreeSnapshot.toString(),
-      startHistoricBlocksTreeSnapshot: this.startHistoricBlocksTreeSnapshot.toString(),
-      endPrivateDataTreeSnapshot: this.endPrivateDataTreeSnapshot.toString(),
-      endNullifierTreeSnapshot: this.endNullifierTreeSnapshot.toString(),
-      endContractTreeSnapshot: this.endContractTreeSnapshot.toString(),
-      endPublicDataTreeRoot: this.endPublicDataTreeRoot.toString(),
-      endL1ToL2MessagesTreeSnapshot: this.endL1ToL2MessagesTreeSnapshot.toString(),
-      endHistoricBlocksTreeSnapshot: this.endHistoricBlocksTreeSnapshot.toString(),
-      newCommitments: this.newCommitments.map(c => c.toString()),
-      newNullifiers: this.newNullifiers.map(n => n.toString()),
-      newPublicDataWrites: this.newPublicDataWrites.map(p => p.toString()),
-      newL2ToL1Msgs: this.newL2ToL1Msgs.map(m => m.toString()),
-      newContracts: this.newContracts.map(c => c.toString()),
-      newContractData: this.newContractData.map(c => c.toString()),
-      newL1ToL2Messages: this.newL1ToL2Messages.map(m => m.toString()),
-      newEncryptedLogs: this.newEncryptedLogs?.toJSON() ?? null,
-      newUnencryptedLogs: this.newUnencryptedLogs?.toJSON() ?? null,
-    };
-  }
-
-  /**
    * Deserializes L2 block without logs from a buffer.
    * @param buf - A serialized L2 block.
    * @returns Deserialized L2 block.
@@ -512,58 +481,6 @@ export class L2Block {
    */
   static fromString(str: string): L2Block {
     return L2Block.fromBuffer(Buffer.from(str, STRING_ENCODING));
-  }
-
-  static fromJSON(_obj: any): L2Block {
-    const globalVariables = GlobalVariables.fromJSON(_obj.globalVariables);
-    const number = Number(globalVariables.blockNumber.value);
-    const startPrivateDataTreeSnapshot = AppendOnlyTreeSnapshot.fromString(_obj.startPrivateDataTreeSnapshot);
-    const startNullifierTreeSnapshot = AppendOnlyTreeSnapshot.fromString(_obj.startNullifierTreeSnapshot);
-    const startContractTreeSnapshot = AppendOnlyTreeSnapshot.fromString(_obj.startContractTreeSnapshot);
-    const startPublicDataTreeRoot = Fr.fromString(_obj.startPublicDataTreeRoot);
-    const startL1ToL2MessagesTreeSnapshot = AppendOnlyTreeSnapshot.fromString(_obj.startL1ToL2MessagesTreeSnapshot);
-    const startHistoricBlocksTreeSnapshot = AppendOnlyTreeSnapshot.fromString(_obj.startHistoricBlocksTreeSnapshot);
-    const endPrivateDataTreeSnapshot = AppendOnlyTreeSnapshot.fromString(_obj.endPrivateDataTreeSnapshot);
-    const endNullifierTreeSnapshot = AppendOnlyTreeSnapshot.fromString(_obj.endNullifierTreeSnapshot);
-    const endContractTreeSnapshot = AppendOnlyTreeSnapshot.fromString(_obj.endContractTreeSnapshot);
-    const endPublicDataTreeRoot = Fr.fromString(_obj.endPublicDataTreeRoot);
-    const endL1ToL2MessagesTreeSnapshot = AppendOnlyTreeSnapshot.fromString(_obj.endL1ToL2MessagesTreeSnapshot);
-    const endHistoricBlocksTreeSnapshot = AppendOnlyTreeSnapshot.fromString(_obj.endHistoricBlocksTreeSnapshot);
-    const newCommitments = _obj.newCommitments.map((c: string) => Fr.fromString(c));
-    const newNullifiers = _obj.newNullifiers.map((n: string) => Fr.fromString(n));
-    const newPublicDataWrites = _obj.newPublicDataWrites.map((p: any) => PublicDataWrite.fromString(p));
-    const newL2ToL1Msgs = _obj.newL2ToL1Msgs.map((m: string) => Fr.fromString(m));
-    const newContracts = _obj.newContracts.map((c: string) => Fr.fromString(c));
-    const newContractData = _obj.newContractData.map((c: any) => ContractData.fromString(c));
-    const newL1ToL2Messages = _obj.newL1ToL2Messages.map((m: string) => Fr.fromString(m));
-    const newEncryptedLogs = _obj.newEncryptedLogs ? L2BlockL2Logs.fromJSON(_obj.newEncryptedLogs) : undefined;
-    const newUnencryptedLogs = _obj.newUnencryptedLogs ? L2BlockL2Logs.fromJSON(_obj.newUnencryptedLogs) : undefined;
-
-    return L2Block.fromFields({
-      number,
-      globalVariables,
-      startPrivateDataTreeSnapshot,
-      startNullifierTreeSnapshot,
-      startContractTreeSnapshot,
-      startPublicDataTreeRoot,
-      startL1ToL2MessagesTreeSnapshot,
-      startHistoricBlocksTreeSnapshot,
-      endPrivateDataTreeSnapshot,
-      endNullifierTreeSnapshot,
-      endContractTreeSnapshot,
-      endPublicDataTreeRoot,
-      endL1ToL2MessagesTreeSnapshot,
-      endHistoricBlocksTreeSnapshot,
-      newCommitments,
-      newNullifiers,
-      newPublicDataWrites,
-      newL2ToL1Msgs,
-      newContracts,
-      newContractData,
-      newL1ToL2Messages,
-      newEncryptedLogs,
-      newUnencryptedLogs,
-    });
   }
 
   /**


### PR DESCRIPTION
When `AztecNode.getBlocks` was called over JSON-RPC an error was thrown in cases when the logs were not yet attached to a block. This PR fixes it.

In this PR I also remove unused `toJSON` and `fromJSON` functionality from `L2Block`.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
