### PR TITLE
chore: Build boxes as part of workspace

### DIFF
--- a/yarn-project/tsconfig.json
+++ b/yarn-project/tsconfig.json
@@ -39,7 +39,10 @@
     { "path": "prover-client/tsconfig.json" },
     { "path": "sequencer-client/tsconfig.json" },
     { "path": "types/tsconfig.json" },
-    { "path": "world-state/tsconfig.json" }
+    { "path": "world-state/tsconfig.json" },
+    { "path": "boxes/private-token/tsconfig.json" },
+    { "path": "boxes/blank/tsconfig.json" },
+    { "path": "boxes/blank-react/tsconfig.json" }
   ],
   "files": ["./@types/jest/index.d.ts"]
 }


### PR DESCRIPTION
Running yarn build or build:dev at the workspace root does not run tsc on the boxes, which means we don't get compiler warnings if we change a dependency and accidentally break them. This includes the boxes in the root tsconfig so they are covered by tsc.