### PR TITLE
fix: avoid ambiguity on blank and blank-react (prefix issue)

### DIFF
--- a/yarn-project/cli/src/unbox.ts
+++ b/yarn-project/cli/src/unbox.ts
@@ -103,7 +103,7 @@ async function downloadContractAndBoxFromGithub(
   // small string conversion, in the ABI the contract name looks like PrivateToken
   // but in the repostory it looks like private_token
 
-  log(`Downloading @aztex/boxes/${contractName} to ${outputPath}...`);
+  log(`Downloading @aztex/boxes/${contractName}/ to ${outputPath}...`);
   // Step 1: Fetch the monorepo ZIP from GitHub, matching the CLI version
   const url = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/archive/refs/tags/${tag}.zip`;
   const response = await fetch(url);
@@ -116,7 +116,7 @@ async function downloadContractAndBoxFromGithub(
   // this is currently only implemented for `blank` and `private-token` under 'boxes/{box-name}/'
   const repoDirectoryPrefix = `${GITHUB_REPO}-${tag}`;
 
-  const boxPath = `${repoDirectoryPrefix}/${BOXES_PATH}/${contractName}`;
+  const boxPath = `${repoDirectoryPrefix}/${BOXES_PATH}/${contractName}/`;
   await copyFolderFromGithub(data, boxPath, outputPath, log);
 
   // the expected noir version is contained in


### PR DESCRIPTION
because `blank` is a prefix of `blank-react`, copying blank would also grab blank-react contents

tested locally on all 3 boxes like
<img width="1166" alt="image" src="https://github.com/AztecProtocol/aztec-packages/assets/142251406/7ee8d9b8-81fd-4193-8852-7fe4dedd3597">
