### PR TITLE
fix: canary tests to use a fork

### DIFF
--- a/yarn-project/canary/scripts/docker-compose.yml
+++ b/yarn-project/canary/scripts/docker-compose.yml
@@ -34,4 +34,5 @@ services:
       ETHEREUM_HOST: http://fork:8545
       CHAIN_ID: 31337
       PXE_URL: http://sandbox:8080
+      SEARCH_START_BLOCK: ${FORK_BLOCK_NUMBER:-0}
     command: ${TEST:-./src/uniswap_trade_on_l1_from_l2.test.ts}

--- a/yarn-project/canary/scripts/run_tests
+++ b/yarn-project/canary/scripts/run_tests
@@ -7,8 +7,9 @@ set -eu
 export TEST=$1
 export IMAGE=${2:-canary}
 export COMPOSE_FILE=${3:-./scripts/docker-compose.yml}
-
-if [ "$TEST" = "uniswap_trade_on_l1_from_l2.test.ts" ]; then
+:
+# if test name ends with uniswap_trade_on_l1_from_l2.test.ts, use the forked mainnet
+if [[ "$TEST" == *"uniswap_trade_on_l1_from_l2.test.ts" ]]; then
   export FORK_URL=https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c
   export FORK_BLOCK_NUMBER=17514288
 fi


### PR DESCRIPTION
Fix #2698 
Fork was always working for `e2e-canary-test` but not for `run-deployment-canary-uniswap` even though they use the same script and similar docker-compose file. 

BUT the `run_test.sh` script only created the fork variables if  `TEST_NAME = uniswap_trade_on_l1_from_l2.test.ts` - this is true for the canary test but not the the deployment script where `TEST_NAME = ./src/uniswap_trade_on_l1_from_l2.test.ts`

No point in over-engineering to use the dumped state since `run-deployment-canary-uniswap` only runs during releases