### PR TITLE
chore: Fix autocomplete in packages that depend on noir-compiler

### DIFF
--- a/yarn-project/noir-compiler/src/noir-version.ts
+++ b/yarn-project/noir-compiler/src/noir-version.ts
@@ -1,3 +1,0 @@
-import * as version from './noir-version.json' assert { type: 'json' };
-
-export default version.default;


### PR DESCRIPTION
Autocomplete was not working in a few packages. A lot of binary search pointed to an unused `noir-version.ts` file in `noir-compiler` which broke tsserver autocomplete for `noir-compiler` and all dependent packages. Deleting it did the trick.

Why on earth that file was breaking tsserver is left as an exercise for the reader, because I have no idea.

[Screencast from 2023-10-09 23-03-36.webm](https://github.com/AztecProtocol/aztec-packages/assets/429604/06777af6-312f-49fc-9806-7dcfb0e383ff)
