### PR TITLE
feat: deploy l1 contracts npm pkg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1359,8 +1359,8 @@ workflows:
           <<: *deploy_defaults
       - deploy-npm:
           requires:
-            - e2e-end
-          <<: *deploy_defaults
+            - yarn-project
+          <<: *defaults
 
       - deploy-end:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1359,8 +1359,8 @@ workflows:
           <<: *deploy_defaults
       - deploy-npm:
           requires:
-            - yarn-project
-          <<: *defaults
+            - e2e-end
+          <<: *deploy_defaults
 
       - deploy-end:
           requires:

--- a/yarn-project/README.md
+++ b/yarn-project/README.md
@@ -40,3 +40,25 @@ To add a new package, make sure to add it to the `build_manifest.json`, to the `
 - `tsconfig.json`
 
 You may also need to modify the [Dockerfile](yarn-project/yarn-project-base/Dockerfile) to copy your new `package.json` into the container to get CI to pass.
+
+## Deploying npm packages
+`deploy-npm` script handles the releases of npm packages within yarn-project. But the initial release is a manual process:
+
+1. Ensure relevant folders are copied in by docker in `yarn-project/yarn-project-base/Dockerfile` and `yarn-project/Dockerfile`
+2. SSH into the CI
+3. Run the following:
+```sh
+cd project
+./build-system/scripts/setup_env "$(git rev-parse HEAD)" "" "" ""
+source /tmp/.bash_env*
+BUILD_SYSTEM_DEBUG=1
+COMMIT_TAG=<RELEASE_TAG_NUMBER_YOU_WANT e.g. aztec-packages-v0.8.8>
+```
+4. Follow the [`deploy-npm` script](./deploy_npm.sh). 
+    - Best to run the `deploy_package()` method line by line by manually setting `REPOSITORY` var.
+    - Extract `VERSION` as the script shows (in the eg it should be 0.8.8)
+    - Skip the version existing checks like `if [ "$VERSION" == "$PUBLISHED_VERSION" ]` and `if [ "$VERSION" != "$HIGHER_VERSION" ]`. Since this is our first time deploying the package, `PUBLISHED_VERSION` and `HIGHER_VERSION` will be empty and hence these checks would fail. These checks are necessary in the CI for continual releases.
+    - Locally update the package version in package.json using `jq` as shown in the script
+    - Do a dry-run
+    - If dry run succeeds, publish the package!
+5. Create a PR by adding your package into the `deploy-npm` script so next release onwards, CI can cut releases for your package.

--- a/yarn-project/deploy_npm.sh
+++ b/yarn-project/deploy_npm.sh
@@ -77,3 +77,5 @@ deploy_package world-state
 deploy_package sequencer-client
 deploy_package aztec-node
 deploy_package aztec-sandbox
+# this should always be at the last because we do `cd ..` at the end of the deploy_package function
+deploy_package ../l1-contracts

--- a/yarn-project/deploy_npm.sh
+++ b/yarn-project/deploy_npm.sh
@@ -6,6 +6,8 @@ extract_repo yarn-project /usr/src project
 cd project/src/yarn-project
 
 echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+# also copy npcrc into the l1-contracts directory
+cp .npmrc ../l1-contracts
 
 function deploy_package() {
     REPOSITORY=$1
@@ -55,7 +57,11 @@ function deploy_package() {
     fi
 
     # Back to root
-    cd ..
+    if [ "$REPOSITORY" == "../l1-contracts" ]; then
+        cd ../yarn-project
+    else
+        cd ..
+    fi
 }
 
 deploy_package foundation
@@ -77,5 +83,4 @@ deploy_package world-state
 deploy_package sequencer-client
 deploy_package aztec-node
 deploy_package aztec-sandbox
-# this should always be at the last because we do `cd ..` at the end of the deploy_package function
 deploy_package ../l1-contracts

--- a/yarn-project/deploy_npm.sh
+++ b/yarn-project/deploy_npm.sh
@@ -11,7 +11,7 @@ function deploy_package() {
     REPOSITORY=$1
     cd $REPOSITORY
 
-    VERSION=$(extract_tag_version $REPOSITORY true)
+    VERSION=$(extract_tag_version $REPOSITORY false)
     echo "Deploying $REPOSITORY $VERSION"
 
     # If the commit tag itself has a dist-tag (e.g. v2.1.0-testnet.123), extract the dist-tag.

--- a/yarn-project/yarn-project-base/Dockerfile
+++ b/yarn-project/yarn-project-base/Dockerfile
@@ -73,6 +73,7 @@ COPY --from=circuits /usr/src/circuits/cpp/build-wasm/bin /usr/src/circuits/cpp/
 # Copy ignition download script.
 COPY --from=circuits /usr/src/barretenberg/cpp/srs_db/download_ignition.sh /usr/src/barretenberg/cpp/srs_db/download_ignition.sh
 
-# Generate L1 contract TypeScript artifacts.
+# Copy L1 contracts.
 COPY --from=contracts /usr/src/l1-contracts /usr/src/l1-contracts
+# Generate L1 contract TypeScript artifacts.
 RUN cd l1-artifacts && ./scripts/generate-artifacts.sh

--- a/yarn-project/yarn-project-base/Dockerfile
+++ b/yarn-project/yarn-project-base/Dockerfile
@@ -74,5 +74,5 @@ COPY --from=circuits /usr/src/circuits/cpp/build-wasm/bin /usr/src/circuits/cpp/
 COPY --from=circuits /usr/src/barretenberg/cpp/srs_db/download_ignition.sh /usr/src/barretenberg/cpp/srs_db/download_ignition.sh
 
 # Generate L1 contract TypeScript artifacts.
-COPY --from=contracts /usr/src/l1-contracts/out /usr/src/l1-contracts/out
+COPY --from=contracts /usr/src/l1-contracts /usr/src/l1-contracts
 RUN cd l1-artifacts && ./scripts/generate-artifacts.sh


### PR DESCRIPTION
Introducing https://www.npmjs.com/package/@aztec/l1-contracts
I have manually deployed v0.8.8 (since deploy-npm script works for continual releases). Next release onwards CI should release 0.8.9 automatically!

Also created a README so people don't struggle as much!

Thanks @ludamad @PhilWindle for the help! 
