### PR TITLE
fix: turn otterscan optional, default off

### DIFF
--- a/docs/docs/dev_docs/getting_started/quickstart.md
+++ b/docs/docs/dev_docs/getting_started/quickstart.md
@@ -34,7 +34,7 @@ This quickstart walks you through installing the Sandbox, deploying your first N
 
 ## Sandbox Contents
 
-The sandbox contains a local ethereum instance running [Anvil](https://book.getfoundry.sh/anvil/), a local instance of the Aztec rollup, an aztec private execution client for handling user transactions and state, and, if using Docker, an [Otterscan](https://github.com/otterscan/otterscan) block explorer for the local ethereum network.
+The sandbox contains a local ethereum instance running [Anvil](https://book.getfoundry.sh/anvil/), a local instance of the Aztec rollup, an aztec private execution client for handling user transactions and state, and, if using Docker, an optional [Otterscan](https://github.com/otterscan/otterscan) block explorer for the local ethereum network.
 
 These provide a self contained environment which deploys Aztec on a local (empty) ethereum network, creates 3 smart contract wallet accounts on the rollup, and allows transactions to be processed on the local Aztec sequencer.
 
@@ -67,7 +67,7 @@ SANDBOX_VERSION=<version> /bin/bash -c "$(curl -fsSL 'https://sandbox.aztec.netw
 
 NOTE: If `SANDBOX_VERSION` is not defined, the script will pull the latest release of the sandbox. The sandbox version should be the same as your `@aztec/cli` package to ensure compatibility.
 
-Once docker is up, you can see ethereum layer 1 activity through the local [otterscan](http://localhost:5100). This is especially useful for dapps that use L1-L2 messaging through [portal contracts](../contracts/portals/main.md).
+Once docker is up, if you have the environment variable `SANDBOX_OTTERSCAN=true`, you can see ethereum layer 1 activity through the local [otterscan](http://localhost:5100). This is especially useful for dapps that use L1-L2 messaging through [portal contracts](../contracts/portals/main.md).
 
 ### With npm
 

--- a/yarn-project/aztec-sandbox/docker-compose.yml
+++ b/yarn-project/aztec-sandbox/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     ports:
       - '5100:80'
     container_name: otterscan
+    command: /bin/sh -c "if [ \"$$SANDBOX_OTTERSCAN\" = \"true\" ]; then ./run-nginx.sh; else sleep infinity; fi"
     environment:
       # otterscan env var is hardcoded to support erigon client
       # but it also works for anvil


### PR DESCRIPTION
due to annoying graceful shutdown time of the container

