### PR TITLE
feat(l1-contracts): remove remappings of @aztec

### DIFF
--- a/l1-contracts/foundry.toml
+++ b/l1-contracts/foundry.toml
@@ -5,11 +5,7 @@ libs = ['lib']
 solc = "0.8.21"
 
 remappings = [
-  "@oz/=lib/openzeppelin-contracts/contracts/",
-  "@aztec/core/=src/core/",
-  "@aztec/periphery/=src/periphery/",
-  "@aztec/mock/=src/mock/",
-  "@aztec/verifier/=lib/aztec-verifier-contracts/src/"
+  "@oz/=lib/openzeppelin-contracts/contracts/"
 ]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -3,17 +3,17 @@
 pragma solidity >=0.8.18;
 
 // Interfaces
-import {IRollup} from "@aztec/core/interfaces/IRollup.sol";
-import {IInbox} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
-import {IOutbox} from "@aztec/core/interfaces/messagebridge/IOutbox.sol";
-import {IRegistry} from "@aztec/core/interfaces/messagebridge/IRegistry.sol";
+import {IRollup} from "./interfaces/IRollup.sol";
+import {IInbox} from "./interfaces/messagebridge/IInbox.sol";
+import {IOutbox} from "./interfaces/messagebridge/IOutbox.sol";
+import {IRegistry} from "./interfaces/messagebridge/IRegistry.sol";
 
 // Libraries
-import {Decoder} from "@aztec/core/libraries/Decoder.sol";
-import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {Decoder} from "./libraries/Decoder.sol";
+import {Errors} from "./libraries/Errors.sol";
 
 // Contracts
-import {MockVerifier} from "@aztec/mock/MockVerifier.sol";
+import {MockVerifier} from "../mock/MockVerifier.sol";
 
 /**
  * @title Rollup

--- a/l1-contracts/src/core/interfaces/messagebridge/IInbox.sol
+++ b/l1-contracts/src/core/interfaces/messagebridge/IInbox.sol
@@ -2,7 +2,7 @@
 // Copyright 2023 Aztec Labs.
 pragma solidity >=0.8.18;
 
-import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
+import {DataStructures} from "../../libraries/DataStructures.sol";
 
 /**
  * @title Inbox

--- a/l1-contracts/src/core/libraries/Decoder.sol
+++ b/l1-contracts/src/core/libraries/Decoder.sol
@@ -3,8 +3,8 @@
 pragma solidity >=0.8.18;
 
 // Libraries
-import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
-import {Hash} from "@aztec/core/libraries/Hash.sol";
+import {Constants} from "./ConstantsGen.sol";
+import {Hash} from "./Hash.sol";
 
 /**
  * @title Decoder Library

--- a/l1-contracts/src/core/messagebridge/Inbox.sol
+++ b/l1-contracts/src/core/messagebridge/Inbox.sol
@@ -3,15 +3,15 @@
 pragma solidity >=0.8.18;
 
 // Interfaces
-import {IInbox} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
-import {IRegistry} from "@aztec/core/interfaces/messagebridge/IRegistry.sol";
+import {IInbox} from "../interfaces/messagebridge/IInbox.sol";
+import {IRegistry} from "../interfaces/messagebridge/IRegistry.sol";
 
 // Libraries
-import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
-import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
-import {Errors} from "@aztec/core/libraries/Errors.sol";
-import {Hash} from "@aztec/core/libraries/Hash.sol";
-import {MessageBox} from "@aztec/core/libraries/MessageBox.sol";
+import {Constants} from "../libraries/ConstantsGen.sol";
+import {DataStructures} from "../libraries/DataStructures.sol";
+import {Errors} from "../libraries/Errors.sol";
+import {Hash} from "../libraries/Hash.sol";
+import {MessageBox} from "../libraries/MessageBox.sol";
 
 /**
  * @title Inbox

--- a/l1-contracts/src/core/messagebridge/Outbox.sol
+++ b/l1-contracts/src/core/messagebridge/Outbox.sol
@@ -3,14 +3,14 @@
 pragma solidity >=0.8.18;
 
 // Interfaces
-import {IOutbox} from "@aztec/core/interfaces/messagebridge/IOutbox.sol";
-import {IRegistry} from "@aztec/core/interfaces/messagebridge/IRegistry.sol";
+import {IOutbox} from "../interfaces/messagebridge/IOutbox.sol";
+import {IRegistry} from "../interfaces/messagebridge/IRegistry.sol";
 
 // Libraries
-import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
-import {Errors} from "@aztec/core/libraries/Errors.sol";
-import {Hash} from "@aztec/core/libraries/Hash.sol";
-import {MessageBox} from "@aztec/core/libraries/MessageBox.sol";
+import {DataStructures} from "../libraries/DataStructures.sol";
+import {Errors} from "../libraries/Errors.sol";
+import {Hash} from "../libraries/Hash.sol";
+import {MessageBox} from "../libraries/MessageBox.sol";
 
 /**
  * @title Outbox

--- a/l1-contracts/src/core/messagebridge/Registry.sol
+++ b/l1-contracts/src/core/messagebridge/Registry.sol
@@ -3,14 +3,14 @@
 pragma solidity >=0.8.18;
 
 // Interfaces
-import {IRegistry} from "@aztec/core/interfaces/messagebridge/IRegistry.sol";
-import {IRollup} from "@aztec/core/interfaces/IRollup.sol";
-import {IInbox} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
-import {IOutbox} from "@aztec/core/interfaces/messagebridge/IOutbox.sol";
+import {IRegistry} from "../interfaces/messagebridge/IRegistry.sol";
+import {IRollup} from "../interfaces/IRollup.sol";
+import {IInbox} from "../interfaces/messagebridge/IInbox.sol";
+import {IOutbox} from "../interfaces/messagebridge/IOutbox.sol";
 
 // Libraries
-import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
-import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {DataStructures} from "../libraries/DataStructures.sol";
+import {Errors} from "../libraries/Errors.sol";
 
 /**
  * @title Registry

--- a/l1-contracts/test/Decoder.t.sol
+++ b/l1-contracts/test/Decoder.t.sol
@@ -4,13 +4,13 @@ pragma solidity >=0.8.18;
 
 import {Test} from "forge-std/Test.sol";
 
-import {Hash} from "@aztec/core/libraries/Hash.sol";
-import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
+import {Hash} from "../src/core/libraries/Hash.sol";
+import {DataStructures} from "../src/core/libraries/DataStructures.sol";
 import {DecoderHelper} from "./DecoderHelper.sol";
-import {Registry} from "@aztec/core/messagebridge/Registry.sol";
-import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
-import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";
-import {Rollup} from "@aztec/core/Rollup.sol";
+import {Registry} from "../src/core/messagebridge/Registry.sol";
+import {Inbox} from "../src/core/messagebridge/Inbox.sol";
+import {Outbox} from "../src/core/messagebridge/Outbox.sol";
+import {Rollup} from "../src/core/Rollup.sol";
 
 /**
  * Blocks are generated using the `integration_l1_publisher.test.ts` tests.

--- a/l1-contracts/test/DecoderHelper.sol
+++ b/l1-contracts/test/DecoderHelper.sol
@@ -2,8 +2,8 @@
 // Copyright 2023 Aztec Labs.
 pragma solidity >=0.8.18;
 
-import {Decoder} from "@aztec/core/libraries/Decoder.sol";
-import {Rollup} from "@aztec/core/Rollup.sol";
+import {Decoder} from "../src/core/libraries/Decoder.sol";
+import {Rollup} from "../src/core/Rollup.sol";
 
 contract DecoderHelper {
   function decode(bytes calldata _l2Block)

--- a/l1-contracts/test/Inbox.t.sol
+++ b/l1-contracts/test/Inbox.t.sol
@@ -3,14 +3,14 @@
 pragma solidity >=0.8.18;
 
 import {Test} from "forge-std/Test.sol";
-import {IInbox} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
-import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
-import {Registry} from "@aztec/core/messagebridge/Registry.sol";
-import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
-import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {IInbox} from "../src/core/interfaces/messagebridge/IInbox.sol";
+import {Inbox} from "../src/core/messagebridge/Inbox.sol";
+import {Registry} from "../src/core/messagebridge/Registry.sol";
+import {Constants} from "../src/core/libraries/ConstantsGen.sol";
+import {Errors} from "../src/core/libraries/Errors.sol";
 
-import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
-import {MessageBox} from "@aztec/core/libraries/MessageBox.sol";
+import {DataStructures} from "../src/core/libraries/DataStructures.sol";
+import {MessageBox} from "../src/core/libraries/MessageBox.sol";
 
 contract InboxTest is Test {
   event MessageAdded(

--- a/l1-contracts/test/Outbox.t.sol
+++ b/l1-contracts/test/Outbox.t.sol
@@ -3,12 +3,12 @@
 pragma solidity >=0.8.18;
 
 import {Test} from "forge-std/Test.sol";
-import {IOutbox} from "@aztec/core/interfaces/messagebridge/IOutbox.sol";
-import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";
-import {Registry} from "@aztec/core/messagebridge/Registry.sol";
-import {Errors} from "@aztec/core/libraries/Errors.sol";
-import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
-import {MessageBox} from "@aztec/core/libraries/MessageBox.sol";
+import {IOutbox} from "../src/core/interfaces/messagebridge/IOutbox.sol";
+import {Outbox} from "../src/core/messagebridge/Outbox.sol";
+import {Registry} from "../src/core/messagebridge/Registry.sol";
+import {Errors} from "../src/core/libraries/Errors.sol";
+import {DataStructures} from "../src/core/libraries/DataStructures.sol";
+import {MessageBox} from "../src/core/libraries/MessageBox.sol";
 
 contract OutboxTest is Test {
   Registry internal registry;

--- a/l1-contracts/test/Registry.t.sol
+++ b/l1-contracts/test/Registry.t.sol
@@ -3,13 +3,13 @@
 pragma solidity >=0.8.18;
 
 import {Test} from "forge-std/Test.sol";
-import {IInbox} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
-import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
-import {Registry} from "@aztec/core/messagebridge/Registry.sol";
-import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {IInbox} from "../src/core/interfaces/messagebridge/IInbox.sol";
+import {Inbox} from "../src/core/messagebridge/Inbox.sol";
+import {Registry} from "../src/core/messagebridge/Registry.sol";
+import {Errors} from "../src/core/libraries/Errors.sol";
 
-import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
-import {MessageBox} from "@aztec/core/libraries/MessageBox.sol";
+import {DataStructures} from "../src/core/libraries/DataStructures.sol";
+import {MessageBox} from "../src/core/libraries/MessageBox.sol";
 
 contract RegistryTest is Test {
   address internal constant DEAD = address(0xdead);

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -6,13 +6,13 @@ import {Test} from "forge-std/Test.sol";
 
 import {DecoderTest} from "./Decoder.t.sol";
 
-import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
+import {DataStructures} from "../src/core/libraries/DataStructures.sol";
 
-import {Registry} from "@aztec/core/messagebridge/Registry.sol";
-import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
-import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";
-import {Errors} from "@aztec/core/libraries/Errors.sol";
-import {Rollup} from "@aztec/core/Rollup.sol";
+import {Registry} from "../src/core/messagebridge/Registry.sol";
+import {Inbox} from "../src/core/messagebridge/Inbox.sol";
+import {Outbox} from "../src/core/messagebridge/Outbox.sol";
+import {Errors} from "../src/core/libraries/Errors.sol";
+import {Rollup} from "../src/core/Rollup.sol";
 
 /**
  * Blocks are generated using the `integration_l1_publisher.test.ts` tests.

--- a/l1-contracts/test/portals/TokenPortal.sol
+++ b/l1-contracts/test/portals/TokenPortal.sol
@@ -4,11 +4,11 @@ import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
 
 // Messaging
-import {IRegistry} from "@aztec/core/interfaces/messagebridge/IRegistry.sol";
-import {IInbox} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
-import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
+import {IRegistry} from "../../src/core/interfaces/messagebridge/IRegistry.sol";
+import {IInbox} from "../../src/core/interfaces/messagebridge/IInbox.sol";
+import {DataStructures} from "../../src/core/libraries/DataStructures.sol";
 // docs:start:content_hash_sol_import
-import {Hash} from "@aztec/core/libraries/Hash.sol";
+import {Hash} from "../../src/core/libraries/Hash.sol";
 // docs:end:content_hash_sol_import
 
 contract TokenPortal {

--- a/l1-contracts/test/portals/TokenPortal.t.sol
+++ b/l1-contracts/test/portals/TokenPortal.t.sol
@@ -3,17 +3,17 @@ pragma solidity >=0.8.18;
 import "forge-std/Test.sol";
 
 // Rollup Proccessor
-import {Rollup} from "@aztec/core/Rollup.sol";
-import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
-import {Registry} from "@aztec/core/messagebridge/Registry.sol";
-import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";
-import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
-import {Hash} from "@aztec/core/libraries/Hash.sol";
-import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {Rollup} from "../../src/core/Rollup.sol";
+import {Inbox} from "../../src/core/messagebridge/Inbox.sol";
+import {Registry} from "../../src/core/messagebridge/Registry.sol";
+import {Outbox} from "../../src/core/messagebridge/Outbox.sol";
+import {DataStructures} from "../../src/core/libraries/DataStructures.sol";
+import {Hash} from "../../src/core/libraries/Hash.sol";
+import {Errors} from "../../src/core/libraries/Errors.sol";
 
 // Interfaces
-import {IRegistry} from "@aztec/core/interfaces/messagebridge/IRegistry.sol";
-import {IInbox} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
+import {IRegistry} from "../../src/core/interfaces/messagebridge/IRegistry.sol";
+import {IInbox} from "../../src/core/interfaces/messagebridge/IInbox.sol";
 
 // Portal tokens
 import {TokenPortal} from "./TokenPortal.sol";

--- a/l1-contracts/test/portals/UniswapPortal.sol
+++ b/l1-contracts/test/portals/UniswapPortal.sol
@@ -1,12 +1,12 @@
 pragma solidity >=0.8.18;
 
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
-import {IRegistry} from "@aztec/core/interfaces/messagebridge/IRegistry.sol";
+import {IRegistry} from "../../src/core/interfaces/messagebridge/IRegistry.sol";
 
 import {TokenPortal} from "./TokenPortal.sol";
 import {ISwapRouter} from "../external/ISwapRouter.sol";
-import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
-import {Hash} from "@aztec/core/libraries/Hash.sol";
+import {DataStructures} from "../../src/core/libraries/DataStructures.sol";
+import {Hash} from "../../src/core/libraries/Hash.sol";
 
 /**
  * @title UniswapPortal

--- a/l1-contracts/test/portals/UniswapPortal.t.sol
+++ b/l1-contracts/test/portals/UniswapPortal.t.sol
@@ -3,13 +3,13 @@ pragma solidity >=0.8.18;
 import "forge-std/Test.sol";
 
 // Rollup Proccessor
-import {Rollup} from "@aztec/core/Rollup.sol";
-import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
-import {Registry} from "@aztec/core/messagebridge/Registry.sol";
-import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";
-import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
-import {Hash} from "@aztec/core/libraries/Hash.sol";
-import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {Rollup} from "../../src/core/Rollup.sol";
+import {Inbox} from "../../src/core/messagebridge/Inbox.sol";
+import {Registry} from "../../src/core/messagebridge/Registry.sol";
+import {Outbox} from "../../src/core/messagebridge/Outbox.sol";
+import {DataStructures} from "../../src/core/libraries/DataStructures.sol";
+import {Hash} from "../../src/core/libraries/Hash.sol";
+import {Errors} from "../../src/core/libraries/Errors.sol";
 
 // Interfaces
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";


### PR DESCRIPTION
Currently you can't use the npm package `@aztec/l1-contracts` due to these remappings. `npx hardhat compile` would fail with `unable to find module @aztec/core/package.json. Install it with npm`

I have left `@oz` remappings since that is only used in the tests. Happy to remove it too though