### PR TITLE
chore: Add md to rebuild patterns

### DIFF
--- a/build_manifest.yml
+++ b/build_manifest.yml
@@ -101,7 +101,7 @@ yarn-project-base:
 yarn-project:
   buildDir: yarn-project
   rebuildPatterns:
-    - ^yarn-project/.*\\.(ts|js|cjs|mjs|json|html)$
+    - ^yarn-project/.*\\.(ts|js|cjs|mjs|json|html|md)$
     - ^yarn-project/Dockerfile
   dependencies:
     - yarn-project-base


### PR DESCRIPTION
The yarn formatting step currently checks md files as well. This means that an incorrectly formatted md file in yarn project will cause the yarn-project-formatting job to fail, but pushing a new commit with the fix won't trigger yarn-project to rebuild, so yarn-project-formatting will keep seeing the malformed md, and will keep failing.

See [this workflow run](https://app.circleci.com/pipelines/github/AztecProtocol/aztec-packages/13854/workflows/4981ebef-0028-48a3-aa72-b456cba54a9e) for an example.
