### PR TITLE
refactor: from < genesis allowed in getBlocks

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -209,7 +209,7 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
     // ********** Events that are processed per block **********
 
     // Read all data from chain and then write to our stores at the end
-    const nextExpectedL2BlockNum = BigInt(this.store.getBlocksLength() + INITIAL_L2_BLOCK_NUM);
+    const nextExpectedL2BlockNum = BigInt((await this.store.getBlockNumber()) + 1);
     this.log(
       `Retrieving chain state from L1 block: ${this.nextL2BlockFromBlock}, next expected l2 block number: ${nextExpectedL2BlockNum}`,
     );
@@ -318,7 +318,7 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
   public async getBlock(number: number): Promise<L2Block | undefined> {
     // If the number provided is -ve, then return the latest block.
     if (number < 0) {
-      number = this.store.getBlocksLength();
+      number = await this.store.getBlockNumber();
     }
     const blocks = await this.store.getBlocks(number, 1);
     return blocks.length === 0 ? undefined : blocks[0];

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -270,7 +270,7 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
 
     // store retrieved L2 blocks after removing new logs information.
     // remove logs to serve "lightweight" block information. Logs can be fetched separately if needed.
-    await this.store.addL2Blocks(
+    await this.store.addBlocks(
       retrievedBlocks.retrievedData.map(block =>
         L2Block.fromFields(omit(block, ['newEncryptedLogs', 'newUnencryptedLogs']), block.getBlockHash()),
       ),
@@ -306,8 +306,8 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
    * @param limit - The number of blocks to return.
    * @returns The requested L2 blocks.
    */
-  public getL2Blocks(from: number, limit: number): Promise<L2Block[]> {
-    return this.store.getL2Blocks(from, limit);
+  public getBlocks(from: number, limit: number): Promise<L2Block[]> {
+    return this.store.getBlocks(from, limit);
   }
 
   /**
@@ -315,12 +315,12 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
    * @param number - The block number to return (inclusive).
    * @returns The requested L2 block.
    */
-  public async getL2Block(number: number): Promise<L2Block | undefined> {
+  public async getBlock(number: number): Promise<L2Block | undefined> {
     // If the number provided is -ve, then return the latest block.
     if (number < 0) {
       number = this.store.getBlocksLength();
     }
-    const blocks = await this.store.getL2Blocks(number, 1);
+    const blocks = await this.store.getBlocks(number, 1);
     return blocks.length === 0 ? undefined : blocks[0];
   }
 

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -11,7 +11,6 @@ import {
   EncodedContractFunction,
   ExtendedContractData,
   GetUnencryptedLogsResponse,
-  INITIAL_L2_BLOCK_NUM,
   L1ToL2Message,
   L1ToL2MessageSource,
   L2Block,

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -49,17 +49,17 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
   /**
    * Next L1 block number to fetch `L2BlockProcessed` logs from (i.e. `fromBlock` in eth_getLogs).
    */
-  private nextL2BlockFromBlock = 0n;
+  private nextL2BlockFromL1Block = 0n;
 
   /**
    * Last Processed Block Number
    */
-  private lastProcessedBlockNumber = 0n;
+  private lastProcessedL1BlockNumber = 0n;
 
   /**
    * Use this to track logged block in order to avoid repeating the same message.
    */
-  private lastLoggedBlockNumber = 0n;
+  private lastLoggedL1BlockNumber = 0n;
 
   /**
    * Creates a new instance of the Archiver.
@@ -84,8 +84,8 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
     private readonly pollingIntervalMs = 10_000,
     private readonly log: DebugLogger = createDebugLogger('aztec:archiver'),
   ) {
-    this.nextL2BlockFromBlock = BigInt(searchStartBlock);
-    this.lastProcessedBlockNumber = BigInt(searchStartBlock);
+    this.nextL2BlockFromL1Block = BigInt(searchStartBlock);
+    this.lastProcessedL1BlockNumber = BigInt(searchStartBlock);
   }
 
   /**
@@ -139,12 +139,12 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
    * @param blockUntilSynced - If true, blocks until the archiver has fully synced.
    */
   private async sync(blockUntilSynced: boolean) {
-    const currentBlockNumber = await this.publicClient.getBlockNumber();
-    if (currentBlockNumber <= this.lastProcessedBlockNumber) {
+    const currentL1BlockNumber = await this.publicClient.getBlockNumber();
+    if (currentL1BlockNumber <= this.lastProcessedL1BlockNumber) {
       // reducing logs, otherwise this gets triggered on every loop (1s)
-      if (currentBlockNumber !== this.lastLoggedBlockNumber) {
-        this.log(`No new blocks to process, current block number: ${currentBlockNumber}`);
-        this.lastLoggedBlockNumber = currentBlockNumber;
+      if (currentL1BlockNumber !== this.lastLoggedL1BlockNumber) {
+        this.log(`No new blocks to process, current block number: ${currentL1BlockNumber}`);
+        this.lastLoggedL1BlockNumber = currentL1BlockNumber;
       }
       return;
     }
@@ -183,15 +183,15 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
       this.publicClient,
       this.inboxAddress,
       blockUntilSynced,
-      this.lastProcessedBlockNumber + 1n, // + 1 to prevent re-including messages from the last processed block
-      currentBlockNumber,
+      this.lastProcessedL1BlockNumber + 1n, // + 1 to prevent re-including messages from the last processed block
+      currentL1BlockNumber,
     );
     const retrievedCancelledL1ToL2Messages = await retrieveNewCancelledL1ToL2Messages(
       this.publicClient,
       this.inboxAddress,
       blockUntilSynced,
-      this.lastProcessedBlockNumber + 1n,
-      currentBlockNumber,
+      this.lastProcessedL1BlockNumber + 1n,
+      currentL1BlockNumber,
     );
 
     // TODO (#717): optimise this - there could be messages in confirmed that are also in pending.
@@ -203,21 +203,21 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
     this.log('Removing pending l1 to l2 messages from store where messages were cancelled');
     await this.store.cancelPendingL1ToL2Messages(retrievedCancelledL1ToL2Messages.retrievedData);
 
-    this.lastProcessedBlockNumber = currentBlockNumber;
+    this.lastProcessedL1BlockNumber = currentL1BlockNumber;
 
     // ********** Events that are processed per block **********
 
     // Read all data from chain and then write to our stores at the end
     const nextExpectedL2BlockNum = BigInt((await this.store.getBlockNumber()) + 1);
     this.log(
-      `Retrieving chain state from L1 block: ${this.nextL2BlockFromBlock}, next expected l2 block number: ${nextExpectedL2BlockNum}`,
+      `Retrieving chain state from L1 block: ${this.nextL2BlockFromL1Block}, next expected l2 block number: ${nextExpectedL2BlockNum}`,
     );
     const retrievedBlocks = await retrieveBlocks(
       this.publicClient,
       this.rollupAddress,
       blockUntilSynced,
-      this.nextL2BlockFromBlock,
-      currentBlockNumber,
+      this.nextL2BlockFromL1Block,
+      currentL1BlockNumber,
       nextExpectedL2BlockNum,
     );
 
@@ -230,8 +230,8 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
       this.publicClient,
       this.contractDeploymentEmitterAddress,
       blockUntilSynced,
-      this.nextL2BlockFromBlock,
-      currentBlockNumber,
+      this.nextL2BlockFromL1Block,
+      currentL1BlockNumber,
       blockHashMapping,
     );
     if (retrievedBlocks.retrievedData.length === 0) {
@@ -276,7 +276,7 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
     );
 
     // set the L1 block for the next search
-    this.nextL2BlockFromBlock = retrievedBlocks.nextEthBlockNumber;
+    this.nextL2BlockFromL1Block = retrievedBlocks.nextEthBlockNumber;
   }
 
   /**

--- a/yarn-project/archiver/src/archiver/archiver_store.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.test.ts
@@ -65,9 +65,17 @@ describe('Archiver Memory Store', () => {
       .fill(0)
       .map((_, index) => L2Block.random(index));
     await archiverStore.addL2Blocks(blocks);
-    await expect(async () => await archiverStore.getL2Blocks(1, 0)).rejects.toThrow(
-      `Invalid block range from: 1, limit: 0`,
-    );
+    await expect(async () => await archiverStore.getL2Blocks(1, 0)).rejects.toThrow(`Invalid limit: 0`);
+  });
+
+  it('returns from the beginning when "from" < genesis block', async () => {
+    const blocks = Array(10)
+      .fill(0)
+      .map((_, index) => L2Block.random(index));
+    await archiverStore.addL2Blocks(blocks);
+    const retrievedBlocks = await archiverStore.getL2Blocks(-5, 1);
+    expect(retrievedBlocks.length).toEqual(1);
+    expect(retrievedBlocks[0]).toEqual(blocks[0]);
   });
 
   test.each([LogType.ENCRYPTED, LogType.UNENCRYPTED])(
@@ -77,9 +85,7 @@ describe('Archiver Memory Store', () => {
         .fill(0)
         .map(_ => L2BlockL2Logs.random(6, 3, 2));
       await archiverStore.addLogs(logs, logType);
-      await expect(async () => await archiverStore.getLogs(1, 0, logType)).rejects.toThrow(
-        `Invalid block range from: 1, limit: 0`,
-      );
+      await expect(async () => await archiverStore.getLogs(1, 0, logType)).rejects.toThrow(`Invalid limit: 0`);
     },
   );
 

--- a/yarn-project/archiver/src/archiver/archiver_store.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.test.ts
@@ -73,7 +73,9 @@ describe('Archiver Memory Store', () => {
       .fill(0)
       .map((_, index) => L2Block.random(index));
     await archiverStore.addBlocks(blocks);
-    const retrievedBlocks = await archiverStore.getBlocks(-5, 1);
+    const from = -5;
+    const limit = 1;
+    const retrievedBlocks = await archiverStore.getBlocks(from, limit);
     expect(retrievedBlocks.length).toEqual(1);
     expect(retrievedBlocks[0]).toEqual(blocks[0]);
   });

--- a/yarn-project/archiver/src/archiver/archiver_store.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.test.ts
@@ -24,7 +24,7 @@ describe('Archiver Memory Store', () => {
     const blocks = Array(10)
       .fill(0)
       .map((_, index) => L2Block.random(index));
-    await archiverStore.addL2Blocks(blocks);
+    await archiverStore.addBlocks(blocks);
     // Offset indices by INITIAL_L2_BLOCK_NUM to ensure we are correctly aligned
     for (const [from, limit] of [
       [0 + INITIAL_L2_BLOCK_NUM, 10],
@@ -35,7 +35,7 @@ describe('Archiver Memory Store', () => {
       [11 + INITIAL_L2_BLOCK_NUM, 1],
     ]) {
       const expected = blocks.slice(from - INITIAL_L2_BLOCK_NUM, from - INITIAL_L2_BLOCK_NUM + limit);
-      const actual = await archiverStore.getL2Blocks(from, limit);
+      const actual = await archiverStore.getBlocks(from, limit);
       expect(expected).toEqual(actual);
     }
   });
@@ -64,16 +64,16 @@ describe('Archiver Memory Store', () => {
     const blocks = Array(10)
       .fill(0)
       .map((_, index) => L2Block.random(index));
-    await archiverStore.addL2Blocks(blocks);
-    await expect(async () => await archiverStore.getL2Blocks(1, 0)).rejects.toThrow(`Invalid limit: 0`);
+    await archiverStore.addBlocks(blocks);
+    await expect(async () => await archiverStore.getBlocks(1, 0)).rejects.toThrow(`Invalid limit: 0`);
   });
 
   it('returns from the beginning when "from" < genesis block', async () => {
     const blocks = Array(10)
       .fill(0)
       .map((_, index) => L2Block.random(index));
-    await archiverStore.addL2Blocks(blocks);
-    const retrievedBlocks = await archiverStore.getL2Blocks(-5, 1);
+    await archiverStore.addBlocks(blocks);
+    const retrievedBlocks = await archiverStore.getBlocks(-5, 1);
     expect(retrievedBlocks.length).toEqual(1);
     expect(retrievedBlocks[0]).toEqual(blocks[0]);
   });
@@ -97,7 +97,7 @@ describe('Archiver Memory Store', () => {
         .fill(0)
         .map((_, index: number) => L2Block.random(index + 1, 4, 2, 3, 2, 2));
 
-      await archiverStore.addL2Blocks(blocks);
+      await archiverStore.addBlocks(blocks);
       await archiverStore.addLogs(
         blocks.map(block => block.newUnencryptedLogs!),
         LogType.UNENCRYPTED,
@@ -124,7 +124,7 @@ describe('Archiver Memory Store', () => {
           L2Block.random(index + 1, txsPerBlock, 2, numPublicFunctionCalls, 2, numUnencryptedLogs),
         );
 
-      await archiverStore.addL2Blocks(blocks);
+      await archiverStore.addBlocks(blocks);
       await archiverStore.addLogs(
         blocks.map(block => block.newUnencryptedLogs!),
         LogType.UNENCRYPTED,

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -30,7 +30,7 @@ export interface ArchiverDataStore {
    * @param blocks - The L2 blocks to be added to the store.
    * @returns True if the operation is successful.
    */
-  addL2Blocks(blocks: L2Block[]): Promise<boolean>;
+  addBlocks(blocks: L2Block[]): Promise<boolean>;
 
   /**
    * Gets up to `limit` amount of L2 blocks starting from `from`.
@@ -38,7 +38,7 @@ export interface ArchiverDataStore {
    * @param limit - The number of blocks to return.
    * @returns The requested L2 blocks.
    */
-  getL2Blocks(from: number, limit: number): Promise<L2Block[]>;
+  getBlocks(from: number, limit: number): Promise<L2Block[]>;
 
   /**
    * Gets an l2 tx.
@@ -215,7 +215,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
    * @param blocks - The L2 blocks to be added to the store.
    * @returns True if the operation is successful (always in this implementation).
    */
-  public addL2Blocks(blocks: L2Block[]): Promise<boolean> {
+  public addBlocks(blocks: L2Block[]): Promise<boolean> {
     this.l2BlockContexts.push(...blocks.map(block => new L2BlockContext(block)));
     this.l2Txs.push(...blocks.flatMap(b => b.getTxs()));
     return Promise.resolve(true);
@@ -301,7 +301,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
    * @returns The requested L2 blocks.
    * @remarks When "from" is smaller than genesis block number, blocks from the beginning are returned.
    */
-  public getL2Blocks(from: number, limit: number): Promise<L2Block[]> {
+  public getBlocks(from: number, limit: number): Promise<L2Block[]> {
     // Return an empty array if we are outside of range
     if (limit < 1) {
       throw new Error(`Invalid limit: ${limit}`);

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -299,16 +299,17 @@ export class MemoryArchiverStore implements ArchiverDataStore {
    * @param from - Number of the first block to return (inclusive).
    * @param limit - The number of blocks to return.
    * @returns The requested L2 blocks.
+   * @remarks When "from" is smaller than genesis block number, blocks from the beginning are returned.
    */
   public getL2Blocks(from: number, limit: number): Promise<L2Block[]> {
     // Return an empty array if we are outside of range
     if (limit < 1) {
-      throw new Error(`Invalid block range from: ${from}, limit: ${limit}`);
+      throw new Error(`Invalid limit: ${limit}`);
     }
-    if (from < INITIAL_L2_BLOCK_NUM || from > this.l2BlockContexts.length) {
+    if (from >= this.l2BlockContexts.length) {
       return Promise.resolve([]);
     }
-    const startIndex = from - INITIAL_L2_BLOCK_NUM;
+    const startIndex = Math.max(from - INITIAL_L2_BLOCK_NUM, 0);
     const endIndex = startIndex + limit;
     return Promise.resolve(this.l2BlockContexts.slice(startIndex, endIndex).map(blockContext => blockContext.block));
   }
@@ -354,7 +355,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
    */
   getLogs(from: number, limit: number, logType: LogType): Promise<L2BlockL2Logs[]> {
     if (from < INITIAL_L2_BLOCK_NUM || limit < 1) {
-      throw new Error(`Invalid block range from: ${from}, limit: ${limit}`);
+      throw new Error(`Invalid limit: ${limit}`);
     }
     const logs = logType === LogType.ENCRYPTED ? this.encryptedLogsPerBlock : this.unencryptedLogsPerBlock;
     if (from > logs.length) {

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -150,12 +150,6 @@ export interface ArchiverDataStore {
    * @returns The number of the latest L2 block processed.
    */
   getBlockNumber(): Promise<number>;
-
-  /**
-   * Gets the length of L2 blocks in store.
-   * @returns The length of L2 Blocks stored.
-   */
-  getBlocksLength(): number;
 }
 
 /**
@@ -306,12 +300,14 @@ export class MemoryArchiverStore implements ArchiverDataStore {
     if (limit < 1) {
       throw new Error(`Invalid limit: ${limit}`);
     }
-    if (from >= this.l2BlockContexts.length) {
+
+    const fromIndex = Math.max(from - INITIAL_L2_BLOCK_NUM, 0);
+    if (fromIndex >= this.l2BlockContexts.length) {
       return Promise.resolve([]);
     }
-    const startIndex = Math.max(from - INITIAL_L2_BLOCK_NUM, 0);
-    const endIndex = startIndex + limit;
-    return Promise.resolve(this.l2BlockContexts.slice(startIndex, endIndex).map(blockContext => blockContext.block));
+
+    const toIndex = fromIndex + limit;
+    return Promise.resolve(this.l2BlockContexts.slice(fromIndex, toIndex).map(blockContext => blockContext.block));
   }
 
   /**
@@ -513,13 +509,5 @@ export class MemoryArchiverStore implements ArchiverDataStore {
   public getBlockNumber(): Promise<number> {
     if (this.l2BlockContexts.length === 0) return Promise.resolve(INITIAL_L2_BLOCK_NUM - 1);
     return Promise.resolve(this.l2BlockContexts[this.l2BlockContexts.length - 1].block.number);
-  }
-
-  /**
-   * Gets the length of L2 blocks in store.
-   * @returns The length of L2 Blocks array.
-   */
-  public getBlocksLength(): number {
-    return this.l2BlockContexts.length;
   }
 }

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -159,7 +159,7 @@ export class AztecNodeService implements AztecNode {
    * @returns The blocks requested.
    */
   public async getBlock(number: number): Promise<L2Block | undefined> {
-    return await this.blockSource.getL2Block(number);
+    return await this.blockSource.getBlock(number);
   }
 
   /**
@@ -169,7 +169,7 @@ export class AztecNodeService implements AztecNode {
    * @returns The blocks requested.
    */
   public async getBlocks(from: number, limit: number): Promise<L2Block[]> {
-    return (await this.blockSource.getL2Blocks(from, limit)) ?? [];
+    return (await this.blockSource.getBlocks(from, limit)) ?? [];
   }
 
   /**
@@ -401,7 +401,7 @@ export class AztecNodeService implements AztecNode {
     this.log.info(`Simulating tx ${await tx.getTxHash()}`);
     const blockNumber = (await this.blockSource.getBlockNumber()) + 1;
     const newGlobalVariables = await this.globalVariableBuilder.buildGlobalVariables(new Fr(blockNumber));
-    const prevGlobalVariables = (await this.blockSource.getL2Block(-1))?.globalVariables ?? GlobalVariables.empty();
+    const prevGlobalVariables = (await this.blockSource.getBlock(-1))?.globalVariables ?? GlobalVariables.empty();
 
     // Instantiate merkle trees so uncommitted updates by this simulation are local to it.
     // TODO we should be able to remove this after https://github.com/AztecProtocol/aztec-packages/issues/1869

--- a/yarn-project/p2p/src/client/mocks.ts
+++ b/yarn-project/p2p/src/client/mocks.ts
@@ -45,7 +45,7 @@ export class MockBlockSource implements L2BlockSource {
    * @param number - The block number to return (inclusive).
    * @returns The requested L2 block.
    */
-  public getL2Block(number: number) {
+  public getBlock(number: number) {
     return Promise.resolve(this.l2Blocks[number]);
   }
 
@@ -55,7 +55,7 @@ export class MockBlockSource implements L2BlockSource {
    * @param limit - The maximum number of blocks to return.
    * @returns The requested mocked L2 blocks.
    */
-  public getL2Blocks(from: number, limit: number) {
+  public getBlocks(from: number, limit: number) {
     return Promise.resolve(this.l2Blocks.slice(from, from + limit));
   }
 

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -164,7 +164,7 @@ export class P2PClient implements P2P {
     // start looking for further blocks
     const blockProcess = async () => {
       while (!this.stopping) {
-        const blocks = await this.blockDownloader.getL2Blocks();
+        const blocks = await this.blockDownloader.getBlocks();
         await this.handleL2Blocks(blocks);
       }
     };

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -141,7 +141,7 @@ export class Sequencer {
       this.state = SequencerState.CREATING_BLOCK;
 
       const newGlobalVariables = await this.globalsBuilder.buildGlobalVariables(new Fr(blockNumber));
-      const prevGlobalVariables = (await this.l2BlockSource.getL2Block(-1))?.globalVariables ?? GlobalVariables.empty();
+      const prevGlobalVariables = (await this.l2BlockSource.getBlock(-1))?.globalVariables ?? GlobalVariables.empty();
 
       // Process txs and drop the ones that fail processing
       // We create a fresh processor each time to reset any cached state (eg storage writes)

--- a/yarn-project/types/src/l2_block_downloader/l2_block_downloader.ts
+++ b/yarn-project/types/src/l2_block_downloader/l2_block_downloader.ts
@@ -60,7 +60,7 @@ export class L2BlockDownloader {
   private async collectBlocks() {
     let totalBlocks = 0;
     while (true) {
-      const blocks = await this.l2BlockSource.getL2Blocks(this.from, 10);
+      const blocks = await this.l2BlockSource.getBlocks(this.from, 10);
       if (!blocks.length) {
         return totalBlocks;
       }
@@ -87,7 +87,7 @@ export class L2BlockDownloader {
    * @param timeout - optional timeout value to prevent permanent blocking
    * @returns The next batch of blocks from the queue.
    */
-  public async getL2Blocks(timeout?: number) {
+  public async getBlocks(timeout?: number): Promise<L2Block[]> {
     try {
       const blocks = await this.blockQueue.get(timeout);
       if (!blocks) {

--- a/yarn-project/types/src/l2_block_source.ts
+++ b/yarn-project/types/src/l2_block_source.ts
@@ -31,7 +31,7 @@ export interface L2BlockSource {
    * @param number - The block number to return (inclusive).
    * @returns The requested L2 block.
    */
-  getL2Block(number: number): Promise<L2Block | undefined>;
+  getBlock(number: number): Promise<L2Block | undefined>;
 
   /**
    * Gets up to `limit` amount of L2 blocks starting from `from`.
@@ -39,7 +39,7 @@ export interface L2BlockSource {
    * @param limit - The maximum number of blocks to return.
    * @returns The requested L2 blocks.
    */
-  getL2Blocks(from: number, limit: number): Promise<L2Block[]>;
+  getBlocks(from: number, limit: number): Promise<L2Block[]>;
 
   /**
    * Gets an l2 tx.

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
@@ -118,7 +118,7 @@ const log = createDebugLogger('aztec:server_world_state_synchronizer_test');
 describe('server_world_state_synchronizer', () => {
   const rollupSource = mock<L2BlockSource>({
     getBlockNumber: jest.fn(getLatestBlockNumber),
-    getL2Blocks: jest.fn(consumeNextBlocks),
+    getBlocks: jest.fn(consumeNextBlocks),
   });
 
   const merkleTreeDb = mock<MerkleTreeDb>({

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -173,7 +173,7 @@ export class ServerWorldStateSynchronizer implements WorldStateSynchronizer {
    */
   private async collectAndProcessBlocks() {
     // This request for blocks will timeout after 1 second if no blocks are received
-    const blocks = await this.l2BlockDownloader.getL2Blocks(1);
+    const blocks = await this.l2BlockDownloader.getBlocks(1);
     await this.handleL2Blocks(blocks);
     await this.commitCurrentL2BlockNumber();
   }


### PR DESCRIPTION
Fixes #411
+ renamed getL2Blocks in archiver as getBlocks to make it consistent with the naming in `AztecNode` interface.
+ removed the `getBlocksLength` function from archiver interface. It's redundant because `getBlockNumber` can be used instead.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
