### PR TITLE
fix: wait for accounts to catch up with notes when deployed

### DIFF
--- a/yarn-project/aztec.js/src/account/manager/index.ts
+++ b/yarn-project/aztec.js/src/account/manager/index.ts
@@ -8,6 +8,7 @@ import {
   DeployMethod,
   WaitOpts,
   generatePublicKey,
+  retryUntil,
 } from '../../index.js';
 import { AccountContract, Salt } from '../index.js';
 import { AccountInterface } from '../interface.js';
@@ -88,11 +89,13 @@ export class AccountManager {
    * Registers this account in the PXE Service and returns the associated wallet. Registering
    * the account on the PXE Service is required for managing private state associated with it.
    * Use the returned wallet to create Contract instances to be interacted with from this account.
+   * @param opts - Options to wait for the account to be registered.
    * @returns A Wallet instance.
    */
-  public async register(): Promise<AccountWalletWithPrivateKey> {
+  public async register(opts: WaitOpts = {}): Promise<AccountWalletWithPrivateKey> {
     const completeAddress = await this.getCompleteAddress();
     await this.pxe.registerAccount(this.encryptionPrivateKey, completeAddress.partialAddress);
+    await this.waitSynch(opts);
     return this.getWallet();
   }
 
@@ -140,6 +143,31 @@ export class AccountManager {
    */
   public async waitDeploy(opts: WaitOpts = {}): Promise<AccountWalletWithPrivateKey> {
     await this.deploy().then(tx => tx.wait(opts));
+    return this.getWallet();
+  }
+
+  /**
+   * Waits for the account to finish synchronizing with the PXE Service.
+   * @param opts - Options to wait for account to finish synchronizing
+   * @returns A wallet instance
+   */
+  public async waitSynch({ interval, timeout }: WaitOpts): Promise<AccountWalletWithPrivateKey> {
+    const address = (await this.getCompleteAddress()).address;
+    await retryUntil(
+      async () => {
+        const status = await this.pxe.getSyncStatus();
+        const accountSynchedToBlock = status.notes[address.toString()];
+        if (!accountSynchedToBlock) {
+          return false;
+        } else {
+          return accountSynchedToBlock >= status.blocks;
+        }
+      },
+      'waitSynch',
+      interval,
+      timeout,
+    );
+
     return this.getWallet();
   }
 }

--- a/yarn-project/aztec.js/src/account/manager/util.ts
+++ b/yarn-project/aztec.js/src/account/manager/util.ts
@@ -1,0 +1,29 @@
+import { CompleteAddress, PXE, WaitOpts, retryUntil } from '../../index.js';
+
+/**
+ * Waits for the account to finish synchronizing with the PXE Service.
+ * @param pxe - PXE instance
+ * @param address - Address to wait for synch
+ * @param opts - Wait options
+ */
+export async function waitForAccountSynch(
+  pxe: PXE,
+  address: CompleteAddress,
+  { interval, timeout }: WaitOpts,
+): Promise<void> {
+  const publicKey = address.publicKey.toString();
+  await retryUntil(
+    async () => {
+      const status = await pxe.getSyncStatus();
+      const accountSynchedToBlock = status.notes[publicKey];
+      if (typeof accountSynchedToBlock === 'undefined') {
+        return false;
+      } else {
+        return accountSynchedToBlock >= status.blocks;
+      }
+    },
+    'waitForAccountSynch',
+    timeout,
+    interval,
+  );
+}

--- a/yarn-project/aztec.js/src/contract/index.ts
+++ b/yarn-project/aztec.js/src/contract/index.ts
@@ -37,6 +37,6 @@
  */
 export * from './contract.js';
 export * from './contract_function_interaction.js';
-export * from './sent_tx.js';
+export { SentTx, WaitOpts } from './sent_tx.js';
 export * from './contract_base.js';
 export * from './batch_call.js';

--- a/yarn-project/aztec.js/src/contract/sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract/sent_tx.ts
@@ -19,7 +19,7 @@ export type WaitOpts = {
   debug?: boolean;
 };
 
-const DefaultWaitOpts: WaitOpts = {
+export const DefaultWaitOpts: WaitOpts = {
   timeout: 60,
   interval: 1,
   waitForNotesSync: true,

--- a/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
@@ -6,11 +6,13 @@ import {
   EthAddress,
   ExtendedNote,
   Fr,
+  GrumpkinScalar,
   Note,
   PXE,
   TxStatus,
   Wallet,
   computeMessageSecretHash,
+  getUnsafeSchnorrAccount,
   retryUntil,
 } from '@aztec/aztec.js';
 import { ChildContract, TokenContract } from '@aztec/noir-contracts/types';
@@ -247,5 +249,23 @@ describe('e2e_2_pxes', () => {
     await expectTokenBalance(walletB, completeTokenAddress.address, userA.address, 0n, checkIfSynchronized);
     // Check that user B balance is 0 on server A
     await expectTokenBalance(walletA, completeTokenAddress.address, userB.address, 0n, checkIfSynchronized);
+  });
+
+  it('permits migrating an account from one PXE to another', async () => {
+    const privateKey = GrumpkinScalar.random();
+    const account = getUnsafeSchnorrAccount(pxeA, privateKey, Fr.random());
+    const completeAddress = await account.getCompleteAddress();
+    const wallet = await account.waitDeploy();
+
+    await expect(wallet.isAccountStateSynchronized(completeAddress.address)).resolves.toBe(true);
+    const accountOnB = getUnsafeSchnorrAccount(pxeB, privateKey, completeAddress);
+    const walletOnB = await accountOnB.getWallet();
+
+    // need to register first otherwise the new PXE won't know about the account
+    await expect(walletOnB.isAccountStateSynchronized(completeAddress.address)).rejects.toThrow();
+
+    await accountOnB.register();
+    // registering should wait for the account to be synchronized
+    await expect(walletOnB.isAccountStateSynchronized(completeAddress.address)).resolves.toBe(true);
   });
 });

--- a/yarn-project/pxe/src/synchronizer/synchronizer.test.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.test.ts
@@ -1,7 +1,7 @@
 import { CompleteAddress, Fr, GrumpkinScalar, HistoricBlockData } from '@aztec/circuits.js';
 import { Grumpkin } from '@aztec/circuits.js/barretenberg';
 import { TestKeyStore } from '@aztec/key-store';
-import { AztecNode, L2Block, MerkleTreeId } from '@aztec/types';
+import { AztecNode, INITIAL_L2_BLOCK_NUM, L2Block, MerkleTreeId } from '@aztec/types';
 
 import { MockProxy, mock } from 'jest-mock-extended';
 import omit from 'lodash.omit';
@@ -99,7 +99,7 @@ describe('Synchronizer', () => {
     await synchronizer.work();
 
     // Used in synchronizer.isAccountStateSynchronized
-    aztecNode.getBlockNumber.mockResolvedValue(1);
+    aztecNode.getBlockNumber.mockResolvedValueOnce(1);
 
     // Manually adding account to database so that we can call synchronizer.isAccountStateSynchronized
     const keyStore = new TestKeyStore(await Grumpkin.new());
@@ -109,25 +109,11 @@ describe('Synchronizer', () => {
     await database.addCompleteAddress(completeAddress);
 
     // Add the account which will add the note processor to the synchronizer
-    synchronizer.addAccount(completeAddress.publicKey, keyStore, 1);
-
-    expect(await synchronizer.isAccountStateSynchronized(completeAddress.address)).toBe(false);
-    expect(synchronizer.getSyncStatus()).toEqual({
-      blocks: 1,
-      notes: {
-        [completeAddress.publicKey.toString()]: 0,
-      },
-    });
+    synchronizer.addAccount(completeAddress.publicKey, keyStore, INITIAL_L2_BLOCK_NUM);
 
     await synchronizer.workNoteProcessorCatchUp();
 
     expect(await synchronizer.isAccountStateSynchronized(completeAddress.address)).toBe(true);
-    expect(synchronizer.getSyncStatus()).toEqual({
-      blocks: 1,
-      notes: {
-        [completeAddress.publicKey.toString()]: 1,
-      },
-    });
   });
 });
 

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -288,7 +288,12 @@ export class Synchronizer {
   public getSyncStatus() {
     return {
       blocks: this.synchedToBlock,
-      notes: Object.fromEntries(this.noteProcessors.map(n => [n.publicKey.toString(), n.status.syncedToBlock])),
+      notes: Object.fromEntries(
+        [...this.noteProcessors, ...this.noteProcessorsToCatchUp].map(n => [
+          n.publicKey.toString(),
+          n.status.syncedToBlock,
+        ]),
+      ),
     };
   }
 }

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -259,7 +259,8 @@ export class Synchronizer {
     if (!completeAddress) {
       throw new Error(`Checking if account is synched is not possible for ${account} because it is not registered.`);
     }
-    const processor = this.noteProcessors.find(x => x.publicKey.equals(completeAddress.publicKey));
+    const findByPublicKey = (x: NoteProcessor) => x.publicKey.equals(completeAddress.publicKey);
+    const processor = this.noteProcessors.find(findByPublicKey) ?? this.noteProcessorsToCatchUp.find(findByPublicKey);
     if (!processor) {
       throw new Error(
         `Checking if account is synched is not possible for ${account} because it is only registered as a recipient.`,

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -240,7 +240,8 @@ export class Synchronizer {
    * @returns A promise that resolves once the account is added to the Synchronizer.
    */
   public addAccount(publicKey: PublicKey, keyStore: KeyStore, startingBlock: number) {
-    const processor = this.noteProcessors.find(x => x.publicKey.equals(publicKey));
+    const predicate = (x: NoteProcessor) => x.publicKey.equals(publicKey);
+    const processor = this.noteProcessors.find(predicate) ?? this.noteProcessorsToCatchUp.find(predicate);
     if (processor) return;
 
     this.noteProcessorsToCatchUp.push(new NoteProcessor(publicKey, keyStore, this.db, this.node, startingBlock));

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -288,12 +288,7 @@ export class Synchronizer {
   public getSyncStatus() {
     return {
       blocks: this.synchedToBlock,
-      notes: Object.fromEntries(
-        [...this.noteProcessors, ...this.noteProcessorsToCatchUp].map(n => [
-          n.publicKey.toString(),
-          n.status.syncedToBlock,
-        ]),
-      ),
+      notes: Object.fromEntries(this.noteProcessors.map(n => [n.publicKey.toString(), n.status.syncedToBlock])),
     };
   }
 }


### PR DESCRIPTION
Fix #466. This PR ensures that the PXE (and its Synchronizer service) are fully synced up with the node before accepting transactions.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
