### PR TITLE
fix: Fix rebuild pattern slashes.

### DIFF
--- a/barretenberg/cpp/.rebuild_patterns
+++ b/barretenberg/cpp/.rebuild_patterns
@@ -1,4 +1,4 @@
-^barretenberg/cpp/.*\\.(cpp|cc|cxx|c\\+\\+|h|hpp|hxx|h\\+\\+|c|h|inl|inc|ipp|tpp|cmake)$
-^barretenberg/cpp/.*CMakeLists\\.txt$
+^barretenberg/cpp/.*\.(cpp|cc|cxx|c\+\+|h|hpp|hxx|h\+\+|c|h|inl|inc|ipp|tpp|cmake)$
+^barretenberg/cpp/.*CMakeLists\.txt$
 ^barretenberg/cpp/.*Dockerfile.*$
 ^barretenberg/cpp/scripts/

--- a/build-system/scripts/calculate_content_hash
+++ b/build-system/scripts/calculate_content_hash
@@ -6,10 +6,9 @@ set -eu
 REPOSITORY=$1
 COMMIT_HASH=${2:-${COMMIT_HASH:-$(git rev-parse HEAD)}}
 
-# Compute REBUILD_PATTERNS from the build manifest
-REBUILD_PATTERNS=$(query_manifest rebuildPatterns $REPOSITORY)
+# Get list of rebuild patterns, concat them with regex 'or' (|), and double escape \ for awk -v.
+AWK_PATTERN=$(query_manifest rebuildPatterns $REPOSITORY | tr '\n' '|' | sed 's/\\/\\\\/g')
 
-AWK_PATTERN=$(echo $REBUILD_PATTERNS | sed 's/ /|/g')
 cd "$(git rev-parse --show-toplevel)"
 
 # an example line is

--- a/build_manifest.yml
+++ b/build_manifest.yml
@@ -101,7 +101,7 @@ yarn-project-base:
 yarn-project:
   buildDir: yarn-project
   rebuildPatterns:
-    - ^yarn-project/.*\\.(ts|js|cjs|mjs|json|html|md)$
+    - ^yarn-project/.*\.(ts|js|cjs|mjs|json|html|md)$
     - ^yarn-project/Dockerfile
   dependencies:
     - yarn-project-base

--- a/circuits/cpp/.rebuild_patterns
+++ b/circuits/cpp/.rebuild_patterns
@@ -1,3 +1,3 @@
-^circuits/.*\\.(cpp|cc|cxx|c\\+\\+|h|hpp|hxx|h\\+\\+|c|h|inl|inc|ipp|tpp|cmake)$
-^circuits/.*CMakeLists\\.txt$
+^circuits/.*\.(cpp|cc|cxx|c\+\+|h|hpp|hxx|h\+\+|c|h|inl|inc|ipp|tpp|cmake)$
+^circuits/.*CMakeLists\.txt$
 ^circuits/.*Dockerfile.*$


### PR DESCRIPTION
A broken approach had been taken to our rebuild patterns.
They were not actually regular expressions, as they had had double backslashes inserted in order to handle the fact that awk in "awk -v" mode requires c-string style patterns, which means the slashes needed to be escaped.
This meant the patterns didn't work right in any other regex context such as when using "grep -E".
This fix normalises the patterns into standard regex format, and in content hash generation, we now perform the escaping of slashes there for awk.