### PR TITLE
fix: create canary dockerhub manifest

### DIFF
--- a/build-system/scripts/create_dockerhub_manifest
+++ b/build-system/scripts/create_dockerhub_manifest
@@ -15,6 +15,7 @@ fi
 
 REPOSITORY=$1
 ARCH_LIST=$2
+DIST_TAG=${3:-"latest"}
 
 echo "Repo: $REPOSITORY"
 echo "Arch list: $ARCH_LIST"
@@ -26,7 +27,7 @@ USERNAME="aztecprotocolci"
 IMAGE_TAG=$(extract_tag_version $REPOSITORY true)
 
 MANIFEST_DEPLOY_URI=$ACCOUNT/$REPOSITORY:$IMAGE_TAG
-MANIFEST_LATEST_URI=$ACCOUNT/$REPOSITORY:latest
+MANIFEST_LATEST_URI=$ACCOUNT/$REPOSITORY:$DIST_TAG
 
 # Login to dockerhub.
 dockerhub_login
@@ -42,11 +43,11 @@ do
   IMAGE_DEPLOY_URI=$ACCOUNT/$REPOSITORY:$IMAGE_TAG-$A
   echo "Adding image $IMAGE_DEPLOY_URI to manifest list $MANIFEST_DEPLOY_URI"
   docker_or_dryrun manifest create $MANIFEST_DEPLOY_URI \
-  --amend $IMAGE_DEPLOY_URI
-  
+    --amend $IMAGE_DEPLOY_URI
+
   echo "Adding image $IMAGE_DEPLOY_URI to manifest list $MANIFEST_LATEST_URI"
   docker_or_dryrun manifest create $MANIFEST_LATEST_URI \
-  --amend $IMAGE_DEPLOY_URI
+    --amend $IMAGE_DEPLOY_URI
 done
 
 IFS=$OLD_IFS

--- a/build-system/scripts/create_dockerhub_manifest
+++ b/build-system/scripts/create_dockerhub_manifest
@@ -27,7 +27,7 @@ USERNAME="aztecprotocolci"
 IMAGE_TAG=$(extract_tag_version $REPOSITORY true)
 
 MANIFEST_DEPLOY_URI=$ACCOUNT/$REPOSITORY:$IMAGE_TAG
-MANIFEST_LATEST_URI=$ACCOUNT/$REPOSITORY:$DIST_TAG
+MANIFEST_DIST_URI=$ACCOUNT/$REPOSITORY:$DIST_TAG
 
 # Login to dockerhub.
 dockerhub_login
@@ -45,8 +45,8 @@ do
   docker_or_dryrun manifest create $MANIFEST_DEPLOY_URI \
     --amend $IMAGE_DEPLOY_URI
 
-  echo "Adding image $IMAGE_DEPLOY_URI to manifest list $MANIFEST_LATEST_URI"
-  docker_or_dryrun manifest create $MANIFEST_LATEST_URI \
+  echo "Adding image $IMAGE_DEPLOY_URI to manifest list $MANIFEST_DIST_URI"
+  docker_or_dryrun manifest create $MANIFEST_DIST_URI \
     --amend $IMAGE_DEPLOY_URI
 done
 
@@ -57,6 +57,6 @@ echo "Pushing manifest list $MANIFEST_DEPLOY_URI..."
 # Push the version tagged list
 docker_or_dryrun manifest push --purge $MANIFEST_DEPLOY_URI
 
-echo "Pushing manifest list $MANIFEST_LATEST_URI..."
+echo "Pushing manifest list $MANIFEST_DIST_URI..."
 # Push the latest tagged list
-docker_or_dryrun manifest push --purge $MANIFEST_LATEST_URI
+docker_or_dryrun manifest push --purge $MANIFEST_DIST_URI

--- a/yarn-project/deploy_dockerhub.sh
+++ b/yarn-project/deploy_dockerhub.sh
@@ -6,7 +6,7 @@ extract_repo yarn-project /usr/src project
 PROJECT_ROOT=$(pwd)/project/src/
 
 for REPOSITORY in "pxe" "aztec-sandbox"; do
-  echo "Deploying $REPOSITORY $TAG"
+  echo "Deploying $REPOSITORY $DIST_TAG"
   RELATIVE_PROJECT_DIR=$(query_manifest relativeProjectDir $REPOSITORY)
   cd "$PROJECT_ROOT/$RELATIVE_PROJECT_DIR"
 


### PR DESCRIPTION
The create-manifest job was not using the `DIST_TAG` and still only deploying as `latest`

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
