### PR TITLE
chore!: [DO NOT MERGE] change merkle_hash in private kernel circuit

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen_lookup.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen_lookup.cpp
@@ -173,12 +173,13 @@ grumpkin::fq hash_multiple(const std::vector<grumpkin::fq>& inputs, const size_t
     const size_t num_inputs = inputs.size();
 
     grumpkin::fq result = (pedersen_iv_table[hash_index]).x;
-    for (size_t i = 0; i < num_inputs; i++) {
+    result = hash_pair(result, num_inputs);
+    for (size_t i = 0; i < num_inputs - 1; i++) {
         result = hash_pair(result, inputs[i]);
     }
 
     auto final_result =
-        grumpkin::g1::affine_element(hash_single(result, false) + hash_single(grumpkin::fq(num_inputs), true));
+        grumpkin::g1::affine_element(hash_single(result, false) + hash_single(inputs[num_inputs - 1], true));
     return final_result.x;
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen_plookup.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen_plookup.cpp
@@ -172,16 +172,19 @@ field_t<C> pedersen_plookup_hash<C>::hash_multiple(const std::vector<field_t>& i
         return point{ 0, 0 }.x;
     }
 
-    auto result = plookup_read<C>::get_lookup_accumulators(MultiTableId::PEDERSEN_IV, hash_index)[ColumnIdx::C2][0];
     auto num_inputs = inputs.size();
-    for (size_t i = 0; i < num_inputs; i++) {
+
+    auto result = plookup_read<C>::get_lookup_accumulators(MultiTableId::PEDERSEN_IV, hash_index)[ColumnIdx::C2][0];
+    result = add_points(pedersen_plookup_hash<C>::hash_single(result, false), hash_single(field_t(num_inputs), true)).x;
+
+    for (size_t i = 0; i < num_inputs - 1; i++) {
         auto p2 = pedersen_plookup_hash<C>::hash_single(result, false);
         auto p1 = pedersen_plookup_hash<C>::hash_single(inputs[i], true);
         result = add_points(p1, p2).x;
     }
 
     auto p2 = hash_single(result, false);
-    auto p1 = hash_single(field_t(num_inputs), true);
+    auto p1 = hash_single(inputs[num_inputs - 1], true);
     return add_points(p1, p2).x;
 }
 

--- a/circuits/cpp/src/aztec3/utils/types/circuit_types.hpp
+++ b/circuits/cpp/src/aztec3/utils/types/circuit_types.hpp
@@ -97,7 +97,7 @@ template <typename Builder> struct CircuitTypes {
     static fr merkle_hash(fr left, fr right)
     {
         // use 0-generator for internal merkle hashing
-        return plonk::stdlib::pedersen_hash<Builder>::hash_multiple({ left, right }, 0);
+        return plonk::stdlib::pedersen_commitment<Builder>::commit({ left, right }, 0).x;
     };
 
     static grumpkin_point commit(const std::vector<fr>& inputs, const size_t hash_index = 0)

--- a/circuits/cpp/src/aztec3/utils/types/native_types.hpp
+++ b/circuits/cpp/src/aztec3/utils/types/native_types.hpp
@@ -83,7 +83,7 @@ struct NativeTypes {
     {
         // use 0-generator for internal merkle hashing
         // use lookup namespace since we now use ultraplonk
-        return crypto::pedersen_hash::lookup::hash_multiple({ left, right }, 0);
+        return crypto::pedersen_commitment::commit_native({ left, right }, 0).x;
     }
 
     static grumpkin_point commit(const std::vector<fr>& inputs, const size_t hash_index = 0)


### PR DESCRIPTION
This pulls in the pedersen changes from https://github.com/AztecProtocol/aztec-packages/pull/2585

since as it was noted, that flavour of pedersen hasing is not available in Noir.

Opening this PR to investigate the implications of this change.

 # Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
