### PR TITLE
feat: add oracle for slow updates

### DIFF
--- a/yarn-project/acir-simulator/src/acvm/oracle/oracle.ts
+++ b/yarn-project/acir-simulator/src/acvm/oracle/oracle.ts
@@ -53,6 +53,12 @@ export class Oracle {
     return witness.map(toACVMField);
   }
 
+  async popMint(): Promise<ACVMField[]> {
+    const mint = await this.typedOracle.popMint();
+    if (!mint) throw new Error(`No mints available`);
+    return mint.map(toACVMField);
+  }
+
   async getNotes(
     [storageSlot]: ACVMField[],
     [numSelects]: ACVMField[],

--- a/yarn-project/acir-simulator/src/acvm/oracle/typed_oracle.ts
+++ b/yarn-project/acir-simulator/src/acvm/oracle/typed_oracle.ts
@@ -80,6 +80,10 @@ export abstract class TypedOracle {
     throw new Error('Not available.');
   }
 
+  popMint(): Promise<Fr[]> {
+    throw new Error('Not available.');
+  }
+
   getNotes(
     _storageSlot: Fr,
     _numSelects: number,

--- a/yarn-project/acir-simulator/src/client/db_oracle.ts
+++ b/yarn-project/acir-simulator/src/client/db_oracle.ts
@@ -36,6 +36,12 @@ export interface DBOracle extends CommitmentsDB {
   getAuthWitness(messageHash: Fr): Promise<Fr[]>;
 
   /**
+   * Retrieve a mint from the pez dispenser.
+   * @returns A promise that resolves to an array of field elements representing the mint.
+   */
+  popMint(): Promise<Fr[]>;
+
+  /**
    * Retrieve the secret key associated with a specific public key.
    * The function only allows access to the secret keys of the transaction creator,
    * and throws an error if the address does not match the public key address of the key pair.

--- a/yarn-project/acir-simulator/src/client/view_data_oracle.ts
+++ b/yarn-project/acir-simulator/src/client/view_data_oracle.ts
@@ -57,6 +57,14 @@ export class ViewDataOracle extends TypedOracle {
   }
 
   /**
+   * Pops a mint from the PEZ dispenser
+   * @returns The mint values
+   */
+  public popMint(): Promise<Fr[]> {
+    return this.db.popMint();
+  }
+
+  /**
    * Gets some notes for a contract address and storage slot.
    * Returns a flattened array containing real-note-count and note preimages.
    *

--- a/yarn-project/aztec-nr/slow-updates-tree/src/slow_map.nr
+++ b/yarn-project/aztec-nr/slow-updates-tree/src/slow_map.nr
@@ -2,10 +2,8 @@ use dep::aztec::context::{PrivateContext, PublicContext, Context};
 use dep::aztec::state_vars::public_state::PublicState;
 use dep::aztec::types::type_serialization::TypeSerializationInterface;
 use dep::aztec::oracle::storage::{storage_read, storage_write};
-use dep::aztec::oracle::debug_log::debug_log_format;
 
 use dep::std::hash::pedersen_hash;
-
 use dep::std::option::Option;
 
 // The epoch length is just a random number for now.
@@ -250,7 +248,6 @@ impl<N,M> SlowMap<N,M> {
     let fields = root.serialize();
     storage_write(self.storage_slot, fields);
   }
-
 }
 
 pub fn compute_merkle_root<N>(leaf: Field, index: Field, hash_path: [Field; N]) -> Field {

--- a/yarn-project/aztec-nr/slow-updates-tree/src/slow_map.nr
+++ b/yarn-project/aztec-nr/slow-updates-tree/src/slow_map.nr
@@ -57,6 +57,10 @@ struct SlowUpdateProof<N, M> {
   after: SlowUpdateInner<N>,
 }
 
+pub fn deserialize_slow_update_proof<N, M>(serialized: [Field; M]) -> SlowUpdateProof<N, M> {
+  SlowUpdateProof::deserialize(serialized)
+}
+
 impl<N, M> SlowUpdateProof<N, M> {
   pub fn serialize(self: Self) -> pub [Field; M] {
     let mut serialized = [0; M];

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -33,6 +33,10 @@ export abstract class BaseWallet implements Wallet {
 
   abstract createAuthWitness(message: Fr): Promise<AuthWitness>;
 
+  addMint(mint: Fr[]): Promise<void> {
+    return this.pxe.addMint(mint);
+  }
+
   registerAccount(privKey: GrumpkinPrivateKey, partialAddress: PartialAddress): Promise<CompleteAddress> {
     return this.pxe.registerAccount(privKey, partialAddress);
   }

--- a/yarn-project/end-to-end/src/e2e_slow_tree.test.ts
+++ b/yarn-project/end-to-end/src/e2e_slow_tree.test.ts
@@ -1,4 +1,4 @@
-import { CheatCodes, Fr, Wallet, sleep } from '@aztec/aztec.js';
+import { CheatCodes, Fr, Wallet } from '@aztec/aztec.js';
 import { CircuitsWasm } from '@aztec/circuits.js';
 import { DebugLogger } from '@aztec/foundation/log';
 import { Pedersen, SparseTree, newTree } from '@aztec/merkle-tree';

--- a/yarn-project/end-to-end/src/e2e_slow_tree.test.ts
+++ b/yarn-project/end-to-end/src/e2e_slow_tree.test.ts
@@ -91,7 +91,7 @@ describe('e2e_slow_tree', () => {
     logger('Initial state');
     await status(key);
     await wallet.addMint(getMembershipMint(await getMembershipProof(key, true)));
-    await contract.methods.read_at().send().wait();
+    await contract.methods.read_at(key).send().wait();
 
     logger(`Updating tree[${key}] to 1 from public`);
     await contract.methods
@@ -104,7 +104,7 @@ describe('e2e_slow_tree', () => {
     const zeroProof = await getMembershipProof(key, false);
     logger(`"Reads" tree[${zeroProof.index}] from the tree, equal to ${zeroProof.value}`);
     await wallet.addMint(getMembershipMint({ ...zeroProof, value: new Fr(0) }));
-    await contract.methods.read_at().send().wait();
+    await contract.methods.read_at(key).send().wait();
 
     // Progress time to beyond the update and thereby commit it to the tree.
     await cheatCodes.aztec.warp((await cheatCodes.eth.timestamp()) + 1000);
@@ -116,17 +116,17 @@ describe('e2e_slow_tree', () => {
       `Tries to "read" tree[${zeroProof.index}] from the tree, but is rejected as value is not ${zeroProof.value}`,
     );
     await wallet.addMint(getMembershipMint({ ...zeroProof, value: new Fr(0) }));
-    await expect(contract.methods.read_at().simulate()).rejects.toThrowError(
+    await expect(contract.methods.read_at(key).simulate()).rejects.toThrowError(
       'Assertion failed: Root does not match expected',
     );
 
     logger(`"Reads" tree[${key}], expect to be 1`);
     await wallet.addMint(getMembershipMint({ ...zeroProof, value: new Fr(1) }));
-    await contract.methods.read_at().send().wait();
+    await contract.methods.read_at(key).send().wait();
 
     logger(`Updating tree[${key}] to 4 from private`);
     await wallet.addMint(getUpdateMint(await getUpdateProof(4n, key)));
-    await contract.methods.update_at_private().send().wait();
+    await contract.methods.update_at_private(key, 4n).send().wait();
     await tree.updateLeaf(new Fr(4).toBuffer(), key);
 
     await status(key);

--- a/yarn-project/end-to-end/src/e2e_slow_tree.test.ts
+++ b/yarn-project/end-to-end/src/e2e_slow_tree.test.ts
@@ -42,6 +42,10 @@ describe('e2e_slow_tree', () => {
       };
     };
 
+    const getMembershipMint = (proof: { index: bigint; value: Fr; sibling_path: Fr[] }) => {
+      return [new Fr(proof.index), proof.value, ...proof.sibling_path];
+    };
+
     const getUpdateProof = async (newValue: bigint, index: bigint) => {
       const beforeProof = await getMembershipProof(index, false);
       const afterProof = await getMembershipProof(index, true);
@@ -57,6 +61,22 @@ describe('e2e_slow_tree', () => {
       };
     };
 
+    const getUpdateMint = (proof: {
+      index: bigint;
+      new_value: bigint;
+      before: { value: Fr; sibling_path: Fr[] };
+      after: { value: Fr; sibling_path: Fr[] };
+    }) => {
+      return [
+        new Fr(proof.index),
+        new Fr(proof.new_value),
+        proof.before.value,
+        ...proof.before.sibling_path,
+        proof.after.value,
+        ...proof.after.sibling_path,
+      ];
+    };
+
     const status = async (key: bigint) => {
       logger(`\tTime: ${await cheatCodes.eth.timestamp()}`);
       logger('\tRoot', await contract.methods.un_read_root(owner).view());
@@ -70,11 +90,8 @@ describe('e2e_slow_tree', () => {
 
     logger('Initial state');
     await status(key);
-
-    await contract.methods
-      .read_at({ ...(await getMembershipProof(key, true)), value: 0n })
-      .send()
-      .wait();
+    await wallet.addMint(getMembershipMint(await getMembershipProof(key, true)));
+    await contract.methods.read_at().send().wait();
 
     logger(`Updating tree[${key}] to 1 from public`);
     await contract.methods
@@ -86,7 +103,8 @@ describe('e2e_slow_tree', () => {
 
     const zeroProof = await getMembershipProof(key, false);
     logger(`"Reads" tree[${zeroProof.index}] from the tree, equal to ${zeroProof.value}`);
-    await contract.methods.read_at(zeroProof).send().wait();
+    await wallet.addMint(getMembershipMint({ ...zeroProof, value: new Fr(0) }));
+    await contract.methods.read_at().send().wait();
 
     // Progress time to beyond the update and thereby commit it to the tree.
     await cheatCodes.aztec.warp((await cheatCodes.eth.timestamp()) + 1000);
@@ -97,20 +115,18 @@ describe('e2e_slow_tree', () => {
     logger(
       `Tries to "read" tree[${zeroProof.index}] from the tree, but is rejected as value is not ${zeroProof.value}`,
     );
-    await expect(contract.methods.read_at(zeroProof).simulate()).rejects.toThrowError(
+    await wallet.addMint(getMembershipMint({ ...zeroProof, value: new Fr(0) }));
+    await expect(contract.methods.read_at().simulate()).rejects.toThrowError(
       'Assertion failed: Root does not match expected',
     );
+
     logger(`"Reads" tree[${key}], expect to be 1`);
-    await contract.methods
-      .read_at({ ...(await getMembershipProof(key, false)), value: 1n })
-      .send()
-      .wait();
+    await wallet.addMint(getMembershipMint({ ...zeroProof, value: new Fr(1) }));
+    await contract.methods.read_at().send().wait();
 
     logger(`Updating tree[${key}] to 4 from private`);
-    await contract.methods
-      .update_at_private(await getUpdateProof(4n, key))
-      .send()
-      .wait();
+    await wallet.addMint(getUpdateMint(await getUpdateProof(4n, key)));
+    await contract.methods.update_at_private().send().wait();
     await tree.updateLeaf(new Fr(4).toBuffer(), key);
 
     await status(key);

--- a/yarn-project/noir-contracts/src/contracts/slow_tree_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/slow_tree_contract/src/main.nr
@@ -75,9 +75,10 @@ contract SlowTree {
     }
 
     #[aztec(private)]
-    fn read_at() -> Field {
+    fn read_at(index: Field) -> Field {
         let fields = pop_mint();
         let p: MembershipProof<TREE_HEIGHT, MEMBERSHIP_SIZE> = deserialize_membership_proof(fields);
+        assert(index == p.index, "Index does not match expected");
 
         let expected_root = compute_merkle_root(p.value, p.index, p.sibling_path);
         let selector = compute_selector("_assert_current_root(Field,Field)");
@@ -102,9 +103,11 @@ contract SlowTree {
     }
 
     #[aztec(private)]
-    fn update_at_private() {
+    fn update_at_private(index: Field, new_value: Field) {
         let fields = pop_mint();
         let p: SlowUpdateProof<TREE_HEIGHT, UPDATE_SIZE> = deserialize_slow_update_proof(fields);
+        assert(index == p.index, "Index does not match expected");
+        assert(new_value == p.new_value, "New value does not match expected");
 
         // We compute the root before.
         let before_root = compute_merkle_root(p.before.value, p.index, p.before.sibling_path);

--- a/yarn-project/noir-contracts/src/contracts/slow_tree_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/slow_tree_contract/src/main.nr
@@ -1,3 +1,6 @@
+mod pez;
+mod types;
+
 // This contract allow us to "read" public storage in private through a delayed tree.
 // More documentation need to be outlined for this properly, but there is some in 
 // https://github.com/AztecProtocol/aztec-packages/pull/2732/files
@@ -22,8 +25,11 @@ contract SlowTree {
         },
     };
     use dep::slow_updates_tree::slow_map::{
-        SlowMap, Leaf, SlowUpdateProof, compute_merkle_root
+        SlowMap, Leaf, SlowUpdateProof, compute_merkle_root, deserialize_slow_update_proof
     };
+
+    use crate::pez::pop_mint;
+    use crate::types::{MembershipProof, deserialize_membership_proof};
 
     global TREE_HEIGHT: Field = 254;
     global MEMBERSHIP_SIZE: Field = 256; // TREE_HEIGHT + 2
@@ -31,39 +37,6 @@ contract SlowTree {
 
     struct Storage {
         trees: Map<SlowMap<TREE_HEIGHT, UPDATE_SIZE>>,
-    }
-
-    // A single inclusion proof.
-    // M = N + 2
-    struct MembershipProof<N, M> {
-        index: Field,
-        value: Field,
-        sibling_path: [Field; N],
-
-    }
-
-    impl<N, M> MembershipProof<N, M> {
-        pub fn serialize(self: Self) -> pub [Field; M] {
-        let mut serialized = [0; M];
-        serialized[0] = self.index;
-        serialized[1] = self.value;
-        for i in 0..N {
-            serialized[2 + i] = self.sibling_path[i];
-        }
-        serialized
-        }
-
-        pub fn deserialize(serialized: [Field; M]) -> pub Self {
-        let mut sibling_path = [0; N];
-        for i in 0..N {
-            sibling_path[i] = serialized[2 + i];
-        }
-        MembershipProof {
-            index: serialized[0],
-            value: serialized[1],
-            sibling_path,
-        }
-        }
     }
 
     impl Storage {
@@ -102,7 +75,10 @@ contract SlowTree {
     }
 
     #[aztec(private)]
-    fn read_at(p: MembershipProof<TREE_HEIGHT, MEMBERSHIP_SIZE>) -> Field {
+    fn read_at() -> Field {
+        let fields = pop_mint();
+        let p: MembershipProof<TREE_HEIGHT, MEMBERSHIP_SIZE> = deserialize_membership_proof(fields);
+
         let expected_root = compute_merkle_root(p.value, p.index, p.sibling_path);
         let selector = compute_selector("_assert_current_root(Field,Field)");
         context.call_public_function(
@@ -126,7 +102,10 @@ contract SlowTree {
     }
 
     #[aztec(private)]
-    fn update_at_private(p: SlowUpdateProof<TREE_HEIGHT, UPDATE_SIZE>) {
+    fn update_at_private() {
+        let fields = pop_mint();
+        let p: SlowUpdateProof<TREE_HEIGHT, UPDATE_SIZE> = deserialize_slow_update_proof(fields);
+
         // We compute the root before.
         let before_root = compute_merkle_root(p.before.value, p.index, p.before.sibling_path);
         let after_root = compute_merkle_root(p.after.value, p.index, p.after.sibling_path);

--- a/yarn-project/noir-contracts/src/contracts/slow_tree_contract/src/pez.nr
+++ b/yarn-project/noir-contracts/src/contracts/slow_tree_contract/src/pez.nr
@@ -1,0 +1,6 @@
+#[oracle(popMint)]
+fn pop_mint_oracle<N>() -> [Field; N] {}
+
+unconstrained pub fn pop_mint<N>() -> [Field; N] {
+    pop_mint_oracle()
+}

--- a/yarn-project/noir-contracts/src/contracts/slow_tree_contract/src/types.nr
+++ b/yarn-project/noir-contracts/src/contracts/slow_tree_contract/src/types.nr
@@ -1,7 +1,3 @@
-
-
-
-
 // A single inclusion proof.
 // M = N + 2
 struct MembershipProof<N, M> {

--- a/yarn-project/noir-contracts/src/contracts/slow_tree_contract/src/types.nr
+++ b/yarn-project/noir-contracts/src/contracts/slow_tree_contract/src/types.nr
@@ -1,0 +1,40 @@
+
+
+
+
+// A single inclusion proof.
+// M = N + 2
+struct MembershipProof<N, M> {
+    index: Field,
+    value: Field,
+    sibling_path: [Field; N],
+}
+
+pub fn deserialize_membership_proof<N, M>(serialized: [Field; M]) -> pub MembershipProof<N, M> {
+  let mut sibling_path = [0; N];
+  for i in 0..N {
+      sibling_path[i] = serialized[2 + i];
+  }
+  MembershipProof {
+      index: serialized[0],
+      value: serialized[1],
+      sibling_path,
+  }
+}
+
+
+impl<N, M> MembershipProof<N, M> {
+    pub fn serialize(self: Self) -> pub [Field; M] {
+      let mut serialized = [0; M];
+      serialized[0] = self.index;
+      serialized[1] = self.value;
+      for i in 0..N {
+          serialized[2 + i] = self.sibling_path[i];
+      }
+      serialized
+    }
+
+    pub fn deserialize(serialized: [Field; M]) -> Self {
+      deserialize_membership_proof(serialized)
+    }
+}

--- a/yarn-project/pxe/src/database/database.ts
+++ b/yarn-project/pxe/src/database/database.ts
@@ -25,6 +25,18 @@ export interface Database extends ContractDatabase {
   getAuthWitness(messageHash: Fr): Promise<Fr[]>;
 
   /**
+   * Adding a mint to the pez dispenser.
+   * @param mint - An array of field elements representing the mint.
+   */
+  addMint(mint: Fr[]): Promise<void>;
+
+  /**
+   * Get the next mint from the pez dispenser.
+   * @returns A promise that resolves to an array of field elements representing the mint.
+   */
+  popMint(): Promise<Fr[] | undefined>;
+
+  /**
    * Get auxiliary transaction data based on contract address and storage slot.
    * It searches for matching NoteSpendingInfoDao objects in the MemoryDB's noteSpendingInfoTable
    * where both the contractAddress and storageSlot properties match the given inputs.

--- a/yarn-project/pxe/src/database/memory_db.ts
+++ b/yarn-project/pxe/src/database/memory_db.ts
@@ -20,6 +20,7 @@ export class MemoryDB extends MemoryContractDatabase implements Database {
   private globalVariablesHash: Fr | undefined;
   private addresses: CompleteAddress[] = [];
   private authWitnesses: Record<string, Fr[]> = {};
+  private pezDispenser: Fr[][] = [];
 
   constructor(logSuffix?: string) {
     super(createDebugLogger(logSuffix ? 'aztec:memory_db_' + logSuffix : 'aztec:memory_db'));
@@ -42,6 +43,15 @@ export class MemoryDB extends MemoryContractDatabase implements Database {
    */
   public getAuthWitness(messageHash: Fr): Promise<Fr[]> {
     return Promise.resolve(this.authWitnesses[messageHash.toString()]);
+  }
+
+  public addMint(mint: Fr[]): Promise<void> {
+    this.pezDispenser.push(mint);
+    return Promise.resolve();
+  }
+
+  public popMint(): Promise<Fr[] | undefined> {
+    return Promise.resolve(this.pezDispenser.pop());
   }
 
   public addNoteSpendingInfo(noteSpendingInfoDao: NoteSpendingInfoDao) {

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -118,6 +118,10 @@ export class PXEService implements PXE {
     return this.db.addAuthWitness(witness.requestHash, witness.witness);
   }
 
+  public addMint(mint: Fr[]) {
+    return this.db.addMint(mint);
+  }
+
   public async registerAccount(privKey: GrumpkinPrivateKey, partialAddress: PartialAddress): Promise<CompleteAddress> {
     const completeAddress = await CompleteAddress.fromPrivateKeyAndPartialAddress(privKey, partialAddress);
     const wasAdded = await this.db.addCompleteAddress(completeAddress);

--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -44,6 +44,12 @@ export class SimulatorOracle implements DBOracle {
     return witness;
   }
 
+  async popMint(): Promise<Fr[]> {
+    const mint = await this.db.popMint();
+    if (!mint) throw new Error(`No mints available`);
+    return mint;
+  }
+
   async getNotes(contractAddress: AztecAddress, storageSlot: Fr) {
     const noteDaos = await this.db.getNoteSpendingInfo(contractAddress, storageSlot);
     return noteDaos.map(

--- a/yarn-project/types/src/interfaces/pxe.ts
+++ b/yarn-project/types/src/interfaces/pxe.ts
@@ -41,6 +41,12 @@ export interface PXE {
   addAuthWitness(authWitness: AuthWitness): Promise<void>;
 
   /**
+   * Adding a mint to the pez dispenser.
+   * @param mint - An array of field elements representing the mint.
+   */
+  addMint(mint: Fr[]): Promise<void>;
+
+  /**
    * Registers a user account in PXE given its master encryption private key.
    * Once a new account is registered, the PXE Service will trial-decrypt all published notes on
    * the chain and store those that correspond to the registered account. Will do nothing if the


### PR DESCRIPTION
Experimental, very much in progress.

Fixes #2852, building on top of #2732. 

For the experimentation here needed a name for my "data-stack" as it could practically hold whatever you want to throw at it. Was listening to https://www.youtube.com/watch?v=DTrNwbemNK0 while building so its the pez dispenser. The PEZ dispenser is essentially a stack managed by the PXE that hold `mint`s (PEZ Dispenser = "PfeffErminZ"/peppermint dispenser). A `mint` is `Fr[]` which can hold whatever data really, here just used to feed membership proofs and update proofs into the slow updates map.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
