### PR TITLE
fix: Pad L1 to L2 messages upon retrieval from L1

### DIFF
--- a/yarn-project/archiver/package.json
+++ b/yarn-project/archiver/package.json
@@ -57,6 +57,7 @@
     "concurrently": "^8.0.1",
     "jest": "^29.5.0",
     "jest-mock-extended": "^3.0.4",
+    "lodash.times": "^4.3.2",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"

--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -10,6 +10,8 @@ import { Chain, HttpTransport, Log, PublicClient, Transaction, encodeFunctionDat
 
 import { Archiver } from './archiver.js';
 import { ArchiverDataStore, MemoryArchiverStore } from './archiver_store.js';
+import times from 'lodash.times';
+import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/circuits.js';
 
 describe('Archiver', () => {
   const rollupAddress = EthAddress.ZERO.toString();
@@ -201,6 +203,53 @@ describe('Archiver', () => {
     const expectedPendingMessageKeys = additionalL1ToL2MessagesBlock102;
     const actualPendingMessageKeys = (await archiver.getPendingL1ToL2Messages(100)).map(key => key.toString(true));
     expect(actualPendingMessageKeys).toEqual(expectedPendingMessageKeys);
+
+    await archiver.stop();
+  }, 10_000);
+
+  it('pads L1 to L2 messages', async () => {
+    const NUM_RECEIVED_L1_MESSAGES = 2;
+
+    const archiver = new Archiver(
+      publicClient,
+      EthAddress.fromString(rollupAddress),
+      EthAddress.fromString(inboxAddress),
+      EthAddress.fromString(registryAddress),
+      EthAddress.fromString(contractDeploymentEmitterAddress),
+      0,
+      archiverStore,
+      1000,
+    );
+
+    let latestBlockNum = await archiver.getBlockNumber();
+    expect(latestBlockNum).toEqual(0);
+
+    const block = L2Block.random(1, 4, 1, 2, 4, 6);
+    block.newL1ToL2Messages = times(2, Fr.random);
+    const rollupTx = makeRollupTx(block);
+
+    publicClient.getBlockNumber.mockResolvedValueOnce(2500n);
+    // logs should be created in order of how archiver syncs.
+    publicClient.getLogs
+    .mockResolvedValueOnce(makeL1ToL2MessageAddedEvents(100n, block.newL1ToL2Messages.map(x => x.toString(true))))
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([makeL2BlockProcessedEvent(101n, 1n)])
+    .mockResolvedValue([]);
+    publicClient.getTransaction.mockResolvedValueOnce(rollupTx);
+
+    await archiver.start(false);
+
+    // Wait until block 1 is processed. If this won't happen the test will fail with timeout.
+    while ((await archiver.getBlockNumber()) !== 1) {
+      await sleep(100);
+    }
+
+    latestBlockNum = await archiver.getBlockNumber();
+    expect(latestBlockNum).toEqual(1);
+
+    const expectedL1Messages = block.newL1ToL2Messages.concat(times(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP - NUM_RECEIVED_L1_MESSAGES, () => Fr.ZERO)).map(x => x.value);
+    const receivedBlock = await archiver.getBlock(1);
+    expect(receivedBlock?.newL1ToL2Messages.map(x => x.value)).toEqual(expectedL1Messages);
 
     await archiver.stop();
   }, 10_000);

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -1,4 +1,4 @@
-import { FunctionSelector } from '@aztec/circuits.js';
+import { FunctionSelector, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/circuits.js';
 import { createEthereumChain } from '@aztec/ethereum';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -35,6 +35,7 @@ import {
   retrieveNewContractData,
   retrieveNewPendingL1ToL2Messages,
 } from './data_retrieval.js';
+import { padArrayEnd } from '@aztec/foundation/collection';
 
 /**
  * Pulls L2 blocks in a non-blocking manner and provides interface for their retrieval.
@@ -281,8 +282,10 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
     // store retrieved L2 blocks after removing new logs information.
     // remove logs to serve "lightweight" block information. Logs can be fetched separately if needed.
     await this.store.addBlocks(
-      retrievedBlocks.retrievedData.map(block =>
-        L2Block.fromFields(omit(block, ['newEncryptedLogs', 'newUnencryptedLogs']), block.getBlockHash()),
+      retrievedBlocks.retrievedData.map(block => {
+        block.newL1ToL2Messages = padArrayEnd(block.newL1ToL2Messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
+        return L2Block.fromFields(omit(block, ['newEncryptedLogs', 'newUnencryptedLogs']), block.getBlockHash());
+      }
       ),
     );
 

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -283,6 +283,7 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
     // remove logs to serve "lightweight" block information. Logs can be fetched separately if needed.
     await this.store.addBlocks(
       retrievedBlocks.retrievedData.map(block => {
+        // Ensure we pad the L1 to L2 message array to the full size before storing.
         block.newL1ToL2Messages = padArrayEnd(block.newL1ToL2Messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
         return L2Block.fromFields(omit(block, ['newEncryptedLogs', 'newUnencryptedLogs']), block.getBlockHash());
       }

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -1,6 +1,7 @@
 import { FunctionSelector, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/circuits.js';
 import { createEthereumChain } from '@aztec/ethereum';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
+import { padArrayEnd } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { DebugLogger, createDebugLogger } from '@aztec/foundation/log';
@@ -35,7 +36,6 @@ import {
   retrieveNewContractData,
   retrieveNewPendingL1ToL2Messages,
 } from './data_retrieval.js';
-import { padArrayEnd } from '@aztec/foundation/collection';
 
 /**
  * Pulls L2 blocks in a non-blocking manner and provides interface for their retrieval.
@@ -286,8 +286,7 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
         // Ensure we pad the L1 to L2 message array to the full size before storing.
         block.newL1ToL2Messages = padArrayEnd(block.newL1ToL2Messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
         return L2Block.fromFields(omit(block, ['newEncryptedLogs', 'newUnencryptedLogs']), block.getBlockHash());
-      }
-      ),
+      }),
     );
 
     // set the L1 block for the next search

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -107,6 +107,7 @@ __metadata:
     jest: ^29.5.0
     jest-mock-extended: ^3.0.4
     lodash.omit: ^4.5.0
+    lodash.times: ^4.3.2
     ts-jest: ^29.1.0
     ts-node: ^10.9.1
     tsc-watch: ^6.0.0


### PR DESCRIPTION
This PR fixes a bug where L1 to L2 message padding is lost upon retrieval from L1.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
