### PR TITLE
fix: Don't repeatedly scan for missing messages

### DIFF
--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -136,6 +136,9 @@ export async function retrieveNewPendingL1ToL2Messages(
       searchStartBlock,
       searchEndBlock,
     );
+    if (newL1ToL2MessageLogs.length === 0) {
+      break;
+    }
     const newL1ToL2Messages = processPendingL1ToL2MessageAddedLogs(newL1ToL2MessageLogs);
     retrievedNewL1ToL2Messages.push(...newL1ToL2Messages);
     // handles the case when there are no new messages:
@@ -171,6 +174,9 @@ export async function retrieveNewCancelledL1ToL2Messages(
       searchStartBlock,
       searchEndBlock,
     );
+    if (newL1ToL2MessageCancelledLogs.length === 0) {
+      break;
+    }
     const newCancelledL1ToL2Messages = processCancelledL1ToL2MessagesLogs(newL1ToL2MessageCancelledLogs);
     retrievedNewCancelledL1ToL2Messages.push(...newCancelledL1ToL2Messages);
     // handles the case when there are no new messages:

--- a/yarn-project/end-to-end/src/integration_archiver_l1_to_l2.test.ts
+++ b/yarn-project/end-to-end/src/integration_archiver_l1_to_l2.test.ts
@@ -34,6 +34,7 @@ describe('archiver integration with l1 to l2 messages', () => {
     let deployL1ContractsValues: DeployL1Contracts | undefined;
     let accounts: CompleteAddress[];
     ({ teardown, wallet, deployL1ContractsValues, accounts, config, logger } = await setup(2));
+    config.archiverPollingIntervalMS = 100;
     archiver = await Archiver.createAndSync(config);
 
     const walletClient = deployL1ContractsValues.walletClient;


### PR DESCRIPTION
This PR fixes an issues in the archiver where we repeatedly scan for L1 to L2 messages unnecessarily causing very long startup times.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
