### PR TITLE
docs: fix: update cheat codes to connect to ethRpcUrl

### DIFF
--- a/docs/docs/dev_docs/testing/cheat_codes.md
+++ b/docs/docs/dev_docs/testing/cheat_codes.md
@@ -25,13 +25,14 @@ For this guide, the following Aztec packages are used:
 
 - @aztec/aztec.js
 
-### Initialisation
+### Initialization
 
 ```ts
 import { createPXEClient, CheatCodes } from "@aztec/aztec.js";
 const pxeRpcUrl = "http://localhost:8080";
+const ethRpcUrl = "http://localhost:8545";
 const pxe = createPXEClient(pxeRpcUrl);
-const cc = await CheatCodes.create(pxeRpcUrl, pxe);
+const cc = await CheatCodes.create(ethRpcUrl, pxe);
 ```
 
 There are two properties of the CheatCodes class - `eth` and `aztec` for cheatcodes relating to the Ethereum blockchain (L1) and the Aztec network (L2) respectively.


### PR DESCRIPTION
When setting up cheat codes, you should connect to ethRpcUrl instead of the pxe url.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [x] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
