### PR TITLE
refactor: consistent deploy method across `Contract` and generated TS classes

### DIFF
--- a/yarn-project/aztec.js/src/contract/contract.ts
+++ b/yarn-project/aztec.js/src/contract/contract.ts
@@ -1,6 +1,6 @@
 import { ContractArtifact } from '@aztec/foundation/abi';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
-import { PublicKey } from '@aztec/types';
+import { PXE, PublicKey } from '@aztec/types';
 
 import { DeployMethod, Point } from '../index.js';
 import { Wallet } from '../wallet/index.js';
@@ -37,22 +37,22 @@ export class Contract extends ContractBase {
 
   /**
    * Creates a tx to deploy a new instance of a contract.
-   * @param wallet - The wallet for executing the deployment.
+   * @param pxe - The pxe for executing the deployment.
    * @param artifact - Build artifact of the contract to deploy
    * @param args - Arguments for the constructor.
    */
-  public static deploy(wallet: Wallet, artifact: ContractArtifact, args: any[]) {
-    return new DeployMethod(Point.ZERO, wallet, artifact, args);
+  public static deploy(pxe: PXE, artifact: ContractArtifact, args: any[]) {
+    return new DeployMethod(Point.ZERO, pxe, artifact, args);
   }
 
   /**
    * Creates a tx to deploy a new instance of a contract using the specified public key to derive the address.
    * @param publicKey - Public key for deriving the address.
-   * @param wallet - The wallet for executing the deployment.
+   * @param pxe - The pxe for executing the deployment.
    * @param artifact - Build artifact of the contract.
    * @param args - Arguments for the constructor.
    */
-  public static deployWithPublicKey(publicKey: PublicKey, wallet: Wallet, artifact: ContractArtifact, args: any[]) {
-    return new DeployMethod(publicKey, wallet, artifact, args);
+  public static deployWithPublicKey(publicKey: PublicKey, pxe: PXE, artifact: ContractArtifact, args: any[]) {
+    return new DeployMethod(publicKey, pxe, artifact, args);
   }
 }


### PR DESCRIPTION
`deploy` method is different between `Contract` and the generated types. This is confusing for devs.
![image](https://github.com/AztecProtocol/aztec-packages/assets/13470840/0d92e1c7-ba0c-4414-b053-b6fe7904ad0b)

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
