### PR TITLE
feat: Efficient ZM quotient computation

### DIFF
--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -37,7 +37,20 @@ template <typename Curve> class ZeroMorphProver_ {
 
   public:
     /**
-     * @brief Compute multivariate quotients q_k(X_0, ..., X_{k-1}) for f(X_0, ..., X_{d-1})
+     * @brief Compute multivariate quotients q_k(X_0, ..., X_{k-1}) for f(X_0, ..., X_{n-1})
+     * @details Starting from the coefficients of f, compute q_k inductively from k = n - 1, to k = 0.
+     *          f needs to be updated at each step. 
+     *          
+     *          First, compute q_{n-1} of size N/2 by
+     *          q_{n-1}[l] = f[N/2 + l ] - f[l].
+     *
+     *          Update f by f[l] <- f[l] + u_{n-1} * q_{n-1}[l]; f now has size N/2.
+     *          Compute q_{n-2} of size N/(2^2) by
+     *          q_{n-2}[l] = f[N/2^2 + l] - f[l].
+     *
+     *          Update f by f[l] <- f[l] + u_{n-2} * q_{n-2}[l]; f now has size N/(2^2).
+     *          Compute q_{n-3} of size N/(2^3) by
+     *          q_{n-3}[l] = f[N/2^3 + l] - f[l]. Repeat similarly until you reach q_0.
      *
      * @param polynomial Multilinear polynomial f(X_0, ..., X_{d-1})
      * @param u_challenge Multivariate challenge u = (u_0, ..., u_{d-1})

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -57,7 +57,7 @@ template <typename Curve> class ZeroMorphProver_ {
             quotients.emplace_back(Polynomial(size)); // degree 2^k - 1
         }
 
-        // Compute the first 2^{n-1} coefficients of q_{n-1}
+        // Compute the coefficients of q_{n-1}
         size_t size_q = 1 << (log_N - 1);
         Polynomial q = Polynomial(size_q);
         for (size_t l = 0; l < size_q; ++l) {
@@ -71,10 +71,7 @@ template <typename Curve> class ZeroMorphProver_ {
 
         std::vector<FF> g(polynomial.data().get(), polynomial.data().get() + size_q);
 
-        // Compute the first 2^k coefficients of q_k in reverse order from k= n-2, i.e. q_{n-2}, ..., q_0
-        // Define the intermediate polynomial f_k
-        // Polynomial f_k = Polynomial(size_q);
-        // Polynomial g = polynomial;
+        // Compute q_k in reverse order from k= n-2, i.e. q_{n-2}, ..., q_0
         for (size_t k = 1; k < log_N; ++k) {
             // Compute f_k
             for (size_t l = 0; l < size_q; ++l) {
@@ -90,7 +87,6 @@ template <typename Curve> class ZeroMorphProver_ {
 
             quotients[log_N - k - 1] = q;
             g = f_k;
-            // f = Polynomial(size_q);
         }
 
         return quotients;

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -58,8 +58,7 @@ template <typename Curve> class ZeroMorphProver_ {
 
         // Compute the first 2^{n-1} coefficients of q_{n-1}
         size_t size_q = 1 << (log_N-1);
-        Polynomial q;
-
+        Polynomial q = Polynomial(size_q);
         for (size_t l = 0; l < size_q; ++l) {
             q[l] = polynomial[size_q + l] - polynomial[l];
         }
@@ -68,24 +67,24 @@ template <typename Curve> class ZeroMorphProver_ {
 
         // Compute the first 2^k coefficients of q_k in reverse order from k= n-2, i.e. q_{n-2}, ..., q_0
         //Define the intermediate polynomial f
-        Polynomial f;
-
+        Polynomial f = Polynomial(size_q);
+        Polynomial g = polynomial;
         for (size_t k = 0; k < log_N -1; ++k) {
-            // Compute f = f_{n-1-k}
+            // Compute f = f_{k+1}
             for (size_t l = 0; l < size_q; ++l) {
-                f[l] = polynomial[l] + u_challenge[log_N-1-k]*q[l];
+                f[l] = g[l] + u_challenge[log_N-1-k] * q[l];
             }
 
             size_q = size_q/2;
-            q = 0;
+            q = Polynomial(size_q);
 
             for (size_t l = 0; l < size_q; ++l) {
                 q[l] = f[size_q + l] - f[l];
             }
 
-            quotients[log_N - k - 1] = q;
-            polynomial = f;
-            f=0;
+            quotients[log_N - k - 2] = q;
+            g = f;
+            f = Polynomial(size_q);
         }
 
         return quotients;

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -39,8 +39,8 @@ template <typename Curve> class ZeroMorphProver_ {
     /**
      * @brief Compute multivariate quotients q_k(X_0, ..., X_{k-1}) for f(X_0, ..., X_{n-1})
      * @details Starting from the coefficients of f, compute q_k inductively from k = n - 1, to k = 0.
-     *          f needs to be updated at each step. 
-     *          
+     *          f needs to be updated at each step.
+     *
      *          First, compute q_{n-1} of size N/2 by
      *          q_{n-1}[l] = f[N/2 + l ] - f[l].
      *

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -37,13 +37,14 @@ template <typename Curve> class ZeroMorphProver_ {
 
   public:
     /**
-     * @brief 
-     * 
-     * @param polynomial 
-     * @param u_challenge 
-     * @return std::vector<Polynomial> 
+     * @brief
+     *
+     * @param polynomial
+     * @param u_challenge
+     * @return std::vector<Polynomial>
      */
-    static std::vector<Polynomial> compute_multilinear_quotients_efficient(Polynomial polynomial, std::span<FF> u_challenge)
+    static std::vector<Polynomial> compute_multilinear_quotients_efficient(Polynomial polynomial,
+                                                                           std::span<FF> u_challenge)
     {
         size_t log_N = numeric::get_msb(polynomial.size());
         // The size of the multilinear challenge must equal the log of the polynomial size
@@ -57,7 +58,7 @@ template <typename Curve> class ZeroMorphProver_ {
         }
 
         // Compute the first 2^{n-1} coefficients of q_{n-1}
-        size_t size_q = 1 << (log_N-1);
+        size_t size_q = 1 << (log_N - 1);
         Polynomial q = Polynomial(size_q);
         for (size_t l = 0; l < size_q; ++l) {
             q[l] = polynomial[size_q + l] - polynomial[l];
@@ -68,19 +69,19 @@ template <typename Curve> class ZeroMorphProver_ {
         std::vector<FF> f_k;
         f_k.resize(size_q);
 
-        std::vector<FF> g(polynomial.data(), polynomial.data()+size_q);
+        std::vector<FF> g(polynomial.data().get(), polynomial.data().get() + size_q);
 
         // Compute the first 2^k coefficients of q_k in reverse order from k= n-2, i.e. q_{n-2}, ..., q_0
-        //Define the intermediate polynomial f_k
+        // Define the intermediate polynomial f_k
         // Polynomial f_k = Polynomial(size_q);
         // Polynomial g = polynomial;
-        for (size_t k = 1; k < log_N ; ++k) {
-            // Compute f_k 
+        for (size_t k = 1; k < log_N; ++k) {
+            // Compute f_k
             for (size_t l = 0; l < size_q; ++l) {
-                f_k[l] = g[l] + u_challenge[log_N-k] * q[l];
+                f_k[l] = g[l] + u_challenge[log_N - k] * q[l];
             }
 
-            size_q = size_q/2;
+            size_q = size_q / 2;
             q = Polynomial(size_q);
 
             for (size_t l = 0; l < size_q; ++l) {
@@ -404,7 +405,7 @@ template <typename Curve> class ZeroMorphProver_ {
         f_polynomial += g_batched.shifted();
 
         // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
-        auto quotients = compute_multilinear_quotients(f_polynomial, u_challenge);
+        auto quotients = compute_multilinear_quotients_efficient(f_polynomial, u_challenge);
 
         // Compute and send commitments C_{q_k} = [q_k], k = 0,...,d-1
         std::vector<Commitment> q_k_commitments;

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -43,7 +43,7 @@ template <typename Curve> class ZeroMorphProver_ {
      * @param u_challenge Multivariate challenge u = (u_0, ..., u_{d-1})
      * @return std::vector<Polynomial> degree < 2^k truncation of q_k
      */
-    static std::vector<Polynomial> compute_multilinear_quotients_efficient(Polynomial polynomial,
+    static std::vector<Polynomial> compute_multilinear_quotients(Polynomial polynomial,
                                                                            std::span<FF> u_challenge)
     {
         size_t log_N = numeric::get_msb(polynomial.size());
@@ -349,7 +349,7 @@ template <typename Curve> class ZeroMorphProver_ {
         f_polynomial += g_batched.shifted();
 
         // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
-        auto quotients = compute_multilinear_quotients_efficient(f_polynomial, u_challenge);
+        auto quotients = compute_multilinear_quotients(f_polynomial, u_challenge);
 
         // Compute and send commitments C_{q_k} = [q_k], k = 0,...,d-1
         std::vector<Commitment> q_k_commitments;

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -37,6 +37,50 @@ template <typename Curve> class ZeroMorphProver_ {
 
   public:
     /**
+     * @brief 
+     * 
+     * @param polynomial 
+     * @param u_challenge 
+     * @return std::vector<Polynomial> 
+     */
+    static std::vector<Polynomial> compute_multilinear_quotients_efficient(Polynomial polynomial, std::span<FF> u_challenge)
+    {
+        size_t log_N = numeric::get_msb(polynomial.size());
+        // The size of the multilinear challenge must equal the log of the polynomial size
+        ASSERT(log_N == u_challenge.size());
+
+        // Define the vector of quotients q_k, k = 0, ..., log_N-1
+        std::vector<Polynomial> quotients;
+        for (size_t k = 0; k < log_N; ++k) {
+            size_t size = 1 << k;
+            quotients.emplace_back(Polynomial(size)); // degree 2^k - 1
+        }
+
+        // Compute the q_k in reverse order, i.e. q_{n-1}, ..., q_0
+        for (size_t k = 0; k < log_N; ++k) {
+            // Define partial evaluation point u' = (u_k, ..., u_{n-1})
+            auto evaluation_point_size = static_cast<std::ptrdiff_t>(k + 1);
+            std::vector<FF> u_partial(u_challenge.end() - evaluation_point_size, u_challenge.end());
+
+            // Compute f' = f(X_0,...,X_{k-1}, u')
+            auto f_1 = polynomial.partial_evaluate_mle(u_partial);
+
+            // Increment first element to get altered partial evaluation point u'' = (u_k + 1, u_{k+1}, ..., u_{n-1})
+            u_partial[0] += 1;
+
+            // Compute f'' = f(X_0,...,X_{k-1}, u'')
+            auto f_2 = polynomial.partial_evaluate_mle(u_partial);
+
+            // Compute q_k = f''(X_0,...,X_{k-1}) - f'(X_0,...,X_{k-1})
+            auto q_k = f_2;
+            q_k -= f_1;
+
+            quotients[log_N - k - 1] = q_k;
+        }
+
+        return quotients;
+    }
+    /**
      * @brief Compute multivariate quotients q_k(X_0, ..., X_{k-1}) for f(X_0, ..., X_{d-1})
      * @details Given multilinear polynomial f = f(X_0, ..., X_{d-1}) for which f(u) = v, compute q_k such that:
      *

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -37,11 +37,11 @@ template <typename Curve> class ZeroMorphProver_ {
 
   public:
     /**
-     * @brief Compute the degree < 2^k truncation of multivariate quotients q_k(X_0, ..., X_{k-1}) for f(X_0, ..., X_{d-1})
+     * @brief Compute multivariate quotients q_k(X_0, ..., X_{k-1}) for f(X_0, ..., X_{d-1})
      *
      * @param polynomial Multilinear polynomial f(X_0, ..., X_{d-1})
      * @param u_challenge Multivariate challenge u = (u_0, ..., u_{d-1})
-     * @return std::vector<Polynomial> degree < 2^k truncation of q_k
+     * @return std::vector<Polynomial> The quotients q_k
      */
     static std::vector<Polynomial> compute_multilinear_quotients(Polynomial polynomial,
                                                                            std::span<FF> u_challenge)

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -43,8 +43,7 @@ template <typename Curve> class ZeroMorphProver_ {
      * @param u_challenge Multivariate challenge u = (u_0, ..., u_{d-1})
      * @return std::vector<Polynomial> The quotients q_k
      */
-    static std::vector<Polynomial> compute_multilinear_quotients(Polynomial polynomial,
-                                                                           std::span<FF> u_challenge)
+    static std::vector<Polynomial> compute_multilinear_quotients(Polynomial polynomial, std::span<FF> u_challenge)
     {
         size_t log_N = numeric::get_msb(polynomial.size());
         // The size of the multilinear challenge must equal the log of the polynomial size

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.hpp
@@ -65,26 +65,31 @@ template <typename Curve> class ZeroMorphProver_ {
 
         quotients[log_N - 1] = q;
 
+        std::vector<FF> f_k;
+        f_k.resize(size_q);
+
+        std::vector<FF> g(polynomial.data(), polynomial.data()+size_q);
+
         // Compute the first 2^k coefficients of q_k in reverse order from k= n-2, i.e. q_{n-2}, ..., q_0
-        //Define the intermediate polynomial f
-        Polynomial f = Polynomial(size_q);
-        Polynomial g = polynomial;
-        for (size_t k = 0; k < log_N -1; ++k) {
-            // Compute f = f_{k+1}
+        //Define the intermediate polynomial f_k
+        // Polynomial f_k = Polynomial(size_q);
+        // Polynomial g = polynomial;
+        for (size_t k = 1; k < log_N ; ++k) {
+            // Compute f_k 
             for (size_t l = 0; l < size_q; ++l) {
-                f[l] = g[l] + u_challenge[log_N-1-k] * q[l];
+                f_k[l] = g[l] + u_challenge[log_N-k] * q[l];
             }
 
             size_q = size_q/2;
             q = Polynomial(size_q);
 
             for (size_t l = 0; l < size_q; ++l) {
-                q[l] = f[size_q + l] - f[l];
+                q[l] = f_k[size_q + l] - f_k[l];
             }
 
-            quotients[log_N - k - 2] = q;
-            g = f;
-            f = Polynomial(size_q);
+            quotients[log_N - k - 1] = q;
+            g = f_k;
+            // f = Polynomial(size_q);
         }
 
         return quotients;

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
@@ -513,7 +513,8 @@ TYPED_TEST(ZeroMorphTest, QuotientConstructionEfficient)
     Fr v_evaluation = multilinear_f.evaluate_mle(u_challenge);
 
     // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
-    std::vector<Polynomial> quotients = ZeroMorphProver::compute_multilinear_quotients_efficient(multilinear_f, u_challenge);
+    std::vector<Polynomial> quotients =
+        ZeroMorphProver::compute_multilinear_quotients_efficient(multilinear_f, u_challenge);
 
     // Show that the q_k were properly constructed by showing that the identity holds at a random multilinear challenge
     // z, i.e. f(z) - v - \sum_{k=0}^{d-1} (z_k - u_k)q_k(z) = 0

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
@@ -496,6 +496,49 @@ using CurveTypes = ::testing::Types<curve::BN254>;
 TYPED_TEST_SUITE(ZeroMorphTest, CurveTypes);
 TYPED_TEST_SUITE(ZeroMorphWithConcatenationTest, CurveTypes);
 
+TYPED_TEST(ZeroMorphTest, QuotientConstructionEfficient)
+{
+    // Define some useful type aliases
+    using ZeroMorphProver = ZeroMorphProver_<TypeParam>;
+    using Fr = typename TypeParam::ScalarField;
+    using Polynomial = barretenberg::Polynomial<Fr>;
+
+    // Define size parameters
+    size_t N = 16;
+    size_t log_N = numeric::get_msb(N);
+
+    // Construct a random multilinear polynomial f, and (u,v) such that f(u) = v.
+    Polynomial multilinear_f = this->random_polynomial(N);
+    std::vector<Fr> u_challenge = this->random_evaluation_point(log_N);
+    Fr v_evaluation = multilinear_f.evaluate_mle(u_challenge);
+
+    // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
+    std::vector<Polynomial> quotients = ZeroMorphProver::compute_multilinear_quotients_efficient(multilinear_f, u_challenge);
+
+    // Show that the q_k were properly constructed by showing that the identity holds at a random multilinear challenge
+    // z, i.e. f(z) - v - \sum_{k=0}^{d-1} (z_k - u_k)q_k(z) = 0
+    std::vector<Fr> z_challenge = this->random_evaluation_point(log_N);
+
+    Fr result = multilinear_f.evaluate_mle(z_challenge);
+    result -= v_evaluation;
+    for (size_t k = 0; k < log_N; ++k) {
+        auto q_k_eval = Fr(0);
+        if (k == 0) {
+            // q_0 = a_0 is a constant polynomial so it's evaluation is simply its constant coefficient
+            q_k_eval = quotients[k][0];
+        } else {
+            // Construct (u_0, ..., u_{k-1})
+            auto subrange_size = static_cast<std::ptrdiff_t>(k);
+            std::vector<Fr> z_partial(z_challenge.begin(), z_challenge.begin() + subrange_size);
+            q_k_eval = quotients[k].evaluate_mle(z_partial);
+        }
+        // result = result - (z_k - u_k) * q_k(u_0, ..., u_{k-1})
+        result -= (z_challenge[k] - u_challenge[k]) * q_k_eval;
+    }
+
+    EXPECT_EQ(result, 0);
+}
+
 /**
  * @brief Test method for computing q_k given multilinear f
  * @details Given f = f(X_0, ..., X_{d-1}), and (u,v) such that f(u) = v, compute q_k = q_k(X_0, ..., X_{k-1}) such that

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
@@ -504,7 +504,7 @@ TYPED_TEST_SUITE(ZeroMorphWithConcatenationTest, CurveTypes);
  *  f(X_0, ..., X_{d-1}) - v = \sum_{k=0}^{d-1} (X_k - u_k)q_k(X_0, ..., X_{k-1})
  *
  */
-TYPED_TEST(ZeroMorphTest, QuotientConstructionEfficient)
+TYPED_TEST(ZeroMorphTest, QuotientConstruction)
 {
     // Define some useful type aliases
     using ZeroMorphProver = ZeroMorphProver_<TypeParam>;
@@ -522,7 +522,7 @@ TYPED_TEST(ZeroMorphTest, QuotientConstructionEfficient)
 
     // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
     std::vector<Polynomial> quotients =
-        ZeroMorphProver::compute_multilinear_quotients_efficient(multilinear_f, u_challenge);
+        ZeroMorphProver::compute_multilinear_quotients(multilinear_f, u_challenge);
 
     // Show that the q_k were properly constructed by showing that the identity holds at a random multilinear challenge
     // z, i.e. f(z) - v - \sum_{k=0}^{d-1} (z_k - u_k)q_k(z) = 0

--- a/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/pcs/zeromorph/zeromorph.test.cpp
@@ -521,8 +521,7 @@ TYPED_TEST(ZeroMorphTest, QuotientConstruction)
     Fr v_evaluation = multilinear_f.evaluate_mle(u_challenge);
 
     // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
-    std::vector<Polynomial> quotients =
-        ZeroMorphProver::compute_multilinear_quotients(multilinear_f, u_challenge);
+    std::vector<Polynomial> quotients = ZeroMorphProver::compute_multilinear_quotients(multilinear_f, u_challenge);
 
     // Show that the q_k were properly constructed by showing that the identity holds at a random multilinear challenge
     // z, i.e. f(z) - v - \sum_{k=0}^{d-1} (z_k - u_k)q_k(z) = 0


### PR DESCRIPTION
Implements the efficient algorithm detailed in the ZM paper for computing the multilinear quotients $q_k$ that are fundamental to the ZM protocol. This replaces the original naive (and inefficient) implementation. This work does not address parallelism in all possible locations.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
