### PR TITLE
fix: fix clang-16 check

### DIFF
--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -26,7 +26,7 @@ ARCH=$(uname -m)
 if [ "$OS" == "macos" ]; then
   PRESET=default
 else
-  if [ "$(which clang++-15)" != "" ]; then
+  if [ "$(which clang++-16)" != "" ]; then
     PRESET=clang16
   else
     PRESET=default


### PR DESCRIPTION
@spalladino noticed the bootstrap script checked for clang-15 to enable the `clang-16` profile. This PR updates to check to look for `clang-16`

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [x] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
