### PR TITLE
chore: automatic c_binds for commit should return a point instead of an Fr element

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind.cpp
@@ -9,7 +9,7 @@ WASM_EXPORT void pedersen__commit(uint8_t const* inputs_buffer, uint8_t* output)
 {
     std::vector<grumpkin::fq> to_compress;
     read(inputs_buffer, to_compress);
-    grumpkin::g1::affine_element pedersen_hash = crypto::pedersen_commitment::commit_native(to_compress);
+    grumpkin::g1::affine_element pedersen_commitment = crypto::pedersen_commitment::commit_native(to_compress);
 
-    serialize::write(output, pedersen_hash);
+    serialize::write(output, pedersen_commitment);
 }

--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind_new.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind_new.cpp
@@ -1,6 +1,6 @@
+#include "c_bind_new.hpp"
 #include "../pedersen_hash/pedersen.hpp"
 #include "barretenberg/common/serialize.hpp"
-#include "c_bind.hpp"
 #include "pedersen.hpp"
 
 extern "C" {
@@ -9,12 +9,12 @@ using namespace barretenberg;
 
 WASM_EXPORT void pedersen___init() {}
 
-WASM_EXPORT void pedersen___commit(fr::vec_in_buf inputs_buffer, fr::out_buf output)
+WASM_EXPORT void pedersen___commit(fr::vec_in_buf inputs_buffer, affine_element::out_buf output)
 {
     std::vector<grumpkin::fq> to_compress;
     read(inputs_buffer, to_compress);
-    grumpkin::g1::affine_element pedersen_hash = crypto::pedersen_commitment::commit_native(to_compress);
+    grumpkin::g1::affine_element pedersen_commitment = crypto::pedersen_commitment::commit_native(to_compress);
 
-    serialize::write(output, pedersen_hash);
+    serialize::write(output, pedersen_commitment);
 }
 }

--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind_new.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind_new.hpp
@@ -1,12 +1,14 @@
 #pragma once
 #include "barretenberg/common/wasm_export.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 
 extern "C" {
 
 using namespace barretenberg;
+using affine_element = grumpkin::g1::affine_element;
 
 WASM_EXPORT void pedersen___init();
 
-WASM_EXPORT void pedersen___commit(fr::vec_in_buf inputs_buffer, fr::out_buf output);
+WASM_EXPORT void pedersen___commit(fr::vec_in_buf inputs_buffer, affine_element::out_buf output);
 }

--- a/barretenberg/exports.json
+++ b/barretenberg/exports.json
@@ -16,7 +16,7 @@
     "outArgs": [
       {
         "name": "output",
-        "type": "fr::out_buf"
+        "type": "affine_element::out_buf"
       }
     ],
     "isAsync": false

--- a/barretenberg/ts/src/barretenberg_api/index.ts
+++ b/barretenberg/ts/src/barretenberg_api/index.ts
@@ -22,8 +22,8 @@ export class BarretenbergApi {
     return;
   }
 
-  async pedersenCommit(inputsBuffer: Fr[]): Promise<Fr> {
-    const result = await this.binder.callWasmExport('pedersen___commit', [inputsBuffer], [Fr]);
+  async pedersenCommit(inputsBuffer: Fr[]): Promise<Point> {
+    const result = await this.binder.callWasmExport('pedersen___commit', [inputsBuffer], [Point]);
     return result[0];
   }
 

--- a/barretenberg/ts/src/barretenberg_api/pedersen.test.ts
+++ b/barretenberg/ts/src/barretenberg_api/pedersen.test.ts
@@ -1,5 +1,5 @@
 import { Barretenberg } from '../barretenberg/index.js';
-import { Fr } from '../types/index.js';
+import { Fr, Point } from '../types/index.js';
 
 describe('pedersen', () => {
   let api: Barretenberg;
@@ -20,6 +20,11 @@ describe('pedersen', () => {
 
   it('pedersenCommit', async () => {
     const result = await api.pedersenCommit([new Fr(4n), new Fr(8n), new Fr(12n)]);
-    expect(result).toEqual(new Fr(18374309251862457296563484909553154519357910650678202211610516068880120638872n));
+    expect(result).toEqual(
+      new Point(
+        new Fr(18374309251862457296563484909553154519357910650678202211610516068880120638872n),
+        new Fr(2572141322478528249692953821523229170092797347760799983831061874108357705739n),
+      ),
+    );
   });
 });


### PR DESCRIPTION
Commit history was a bit messed up in #3071 

Related to #3029 
# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
