### PR TITLE
chore: Add stdlib tests for pedersen commitment

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.test.cpp
@@ -1,291 +1,99 @@
-// #include "barretenberg/crypto/pedersen_commitment/pedersen.hpp"
-// #include "barretenberg/common/test.hpp"
-// #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
-// #include "barretenberg/numeric/random/engine.hpp"
-// #include "barretenberg/stdlib/primitives/curves/bn254.hpp"
-// #include "pedersen.hpp"
+#include "barretenberg/crypto/pedersen_commitment/pedersen.hpp"
+#include "barretenberg/common/test.hpp"
+#include "barretenberg/crypto/pedersen_commitment/c_bind_new.hpp"
+#include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
+#include "barretenberg/numeric/random/engine.hpp"
+#include "barretenberg/stdlib/primitives/curves/bn254.hpp"
+#include "pedersen.hpp"
 
-// namespace test_StdlibPedersen {
-// using namespace barretenberg;
-// using namespace proof_system::plonk;
-// namespace {
-// auto& engine = numeric::random::get_debug_engine();
-// }
+namespace test_StdlibPedersen {
+using namespace barretenberg;
+using namespace proof_system::plonk;
+namespace {
+auto& engine = numeric::random::get_debug_engine();
+}
 
-// template <typename Builder> class StdlibPedersen : public testing::Test {
-//     using _curve = stdlib::bn254<Builder>;
+template <typename Builder> class StdlibPedersen : public testing::Test {
+    using _curve = stdlib::bn254<Builder>;
 
-//     using byte_array_ct = typename _curve::byte_array_ct;
-//     using fr_ct = typename _curve::ScalarField;
-//     using witness_ct = typename _curve::witness_ct;
-//     using public_witness_ct = typename _curve::public_witness_ct;
-//     using pedersen_commitment = typename stdlib::pedersen_commitment<Builder>;
+    using byte_array_ct = typename _curve::byte_array_ct;
+    using fr_ct = typename _curve::ScalarField;
+    using witness_ct = typename _curve::witness_ct;
+    using public_witness_ct = typename _curve::public_witness_ct;
+    using pedersen_commitment = typename stdlib::pedersen_commitment<Builder>;
 
-//   public:
-//     static void test_pedersen()
-//     {
+  public:
+    static void test_pedersen()
+    {
 
-//         Builder builder;
+        Builder builder;
 
-//         fr left_in = fr::random_element();
-//         fr right_in = fr::random_element();
+        fr left_in = fr::random_element();
+        fr right_in = fr::random_element();
 
-//         // ensure left has skew 1, right has skew 0
-//         if ((left_in.from_montgomery_form().data[0] & 1) == 1) {
-//             left_in += fr::one();
-//         }
-//         if ((right_in.from_montgomery_form().data[0] & 1) == 0) {
-//             right_in += fr::one();
-//         }
+        // ensure left has skew 1, right has skew 0
+        if ((left_in.from_montgomery_form().data[0] & 1) == 1) {
+            left_in += fr::one();
+        }
+        if ((right_in.from_montgomery_form().data[0] & 1) == 0) {
+            right_in += fr::one();
+        }
 
-//         fr_ct left = public_witness_ct(&builder, left_in);
-//         fr_ct right = witness_ct(&builder, right_in);
+        fr_ct left = public_witness_ct(&builder, left_in);
+        fr_ct right = witness_ct(&builder, right_in);
 
-//         builder.fix_witness(left.witness_index, left.get_value());
-//         builder.fix_witness(right.witness_index, right.get_value());
+        builder.fix_witness(left.witness_index, left.get_value());
+        builder.fix_witness(right.witness_index, right.get_value());
 
-//         fr_ct out = pedersen_hash::hash({left, right});
+        auto out = pedersen_commitment::commit({ left, right });
 
-//         info("num gates = ", builder.get_num_gates());
+        info("num gates = ", builder.get_num_gates());
 
-//         bool result = builder.check_circuit();
-//         EXPECT_EQ(result, true);
+        bool result = builder.check_circuit();
+        EXPECT_EQ(result, true);
 
-//         fr hash_native = crypto::pedersen_hash::hash({ left.get_value(), right.get_value() });
-//         EXPECT_EQ(out.get_value(), hash_native);
-//     }
+        auto commit_native = crypto::pedersen_commitment::commit_native({ left.get_value(), right.get_value() });
 
-//     static void test_pedersen_edge_cases()
-//     {
-//         Builder builder;
+        EXPECT_EQ(out.x.get_value(), commit_native.x);
+        EXPECT_EQ(out.y.get_value(), commit_native.y);
+    }
 
-//         fr zero_fr = fr::zero();
-//         fr one_fr = fr::one();
-//         fr r_minus_one_fr = fr::modulus - 1;
-//         fr r_minus_two_fr = fr::modulus - 2;
-//         fr r_fr = fr::modulus;
+    static void test_hash_constants()
+    {
+        Builder builder;
 
-//         fr_ct zero = witness_ct(&builder, zero_fr);
-//         fr_ct one = witness_ct(&builder, one_fr);
-//         fr_ct r_minus_one = witness_ct(&builder, r_minus_one_fr);
-//         fr_ct r_minus_two = witness_ct(&builder, r_minus_two_fr);
-//         fr_ct r = witness_ct(&builder, r_fr);
+        std::vector<barretenberg::fr> inputs;
+        std::vector<stdlib::field_t<Builder>> witness_inputs;
 
-//         fr_ct out_1_with_zero = pedersen_hash::hash({zero, one});
-//         fr_ct out_1_with_r = pedersen_hash::hash({r, one});
-//         fr_ct out_2 = pedersen_hash::hash({r_minus_one, r_minus_two});
-//         fr_ct out_with_zero = pedersen_hash::hash({out_1_with_zero, out_2});
-//         fr_ct out_with_r = pedersen_hash::hash({out_1_with_r, out_2});
+        for (size_t i = 0; i < 8; ++i) {
+            inputs.push_back(barretenberg::fr::random_element());
+            if (i % 2 == 1) {
+                witness_inputs.push_back(witness_ct(&builder, inputs[i]));
+            } else {
+                witness_inputs.push_back(fr_ct(&builder, inputs[i]));
+            }
+        }
 
-//         info("num gates = ", builder.get_num_gates());
+        auto expected = crypto::pedersen_commitment::commit_native(inputs);
+        auto result = pedersen_commitment::commit(witness_inputs);
 
-//         bool result = builder.check_circuit();
-//         EXPECT_EQ(result, true);
+        EXPECT_EQ(result.x.get_value(), expected.x);
+        EXPECT_EQ(result.y.get_value(), expected.y);
+    }
+};
 
-//         EXPECT_EQ(bool(out_1_with_zero.get_value() == out_1_with_r.get_value()), true);
+using CircuitTypes = testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder>;
 
-//         fr hash_native_1_with_zero =
-//             crypto::pedersen_hash::hash({ zero.get_value(), one.get_value() });
-//         fr hash_native_1_with_r = crypto::pedersen_hash::hash({ r.get_value(), one.get_value() });
-//         fr hash_native_2 =
-//             crypto::pedersen_hash::hash({ r_minus_one.get_value(), r_minus_two.get_value() });
-//         fr hash_native_with_zero =
-//             crypto::pedersen_hash::hash({ out_1_with_zero.get_value(), out_2.get_value() });
-//         fr hash_native_with_r =
-//             crypto::pedersen_hash::hash({ out_1_with_r.get_value(), out_2.get_value() });
+TYPED_TEST_SUITE(StdlibPedersen, CircuitTypes);
 
-//         EXPECT_EQ(out_1_with_zero.get_value(), hash_native_1_with_zero);
-//         EXPECT_EQ(out_1_with_r.get_value(), hash_native_1_with_r);
-//         EXPECT_EQ(out_2.get_value(), hash_native_2);
-//         EXPECT_EQ(out_with_zero.get_value(), hash_native_with_zero);
-//         EXPECT_EQ(out_with_r.get_value(), hash_native_with_r);
-//         EXPECT_EQ(hash_native_with_zero, hash_native_with_r);
-//     }
+TYPED_TEST(StdlibPedersen, Small)
+{
+    TestFixture::test_pedersen();
+};
 
-//     static void test_pedersen_large()
-//     {
-//         Builder builder;
+TYPED_TEST(StdlibPedersen, HashConstants)
+{
+    TestFixture::test_hash_constants();
+};
 
-//         fr left_in = fr::random_element();
-//         fr right_in = fr::random_element();
-//         // ensure left has skew 1, right has skew 0
-//         if ((left_in.from_montgomery_form().data[0] & 1) == 1) {
-//             left_in += fr::one();
-//         }
-//         if ((right_in.from_montgomery_form().data[0] & 1) == 0) {
-//             right_in += fr::one();
-//         }
-//         fr_ct left = witness_ct(&builder, left_in);
-//         fr_ct right = witness_ct(&builder, right_in);
-
-//         for (size_t i = 0; i < 256; ++i) {
-//             left = pedersen_hash::hash(left, right);
-//         }
-
-//         builder.set_public_input(left.witness_index);
-
-//         info("num gates = ", builder.get_num_gates());
-
-//         bool result = builder.check_circuit();
-//         EXPECT_EQ(result, true);
-//     }
-
-//     static void test_compress_byte_array()
-//     {
-//         const size_t num_input_bytes = 351;
-
-//         Builder builder;
-
-//         std::vector<uint8_t> input;
-//         input.reserve(num_input_bytes);
-//         for (size_t i = 0; i < num_input_bytes; ++i) {
-//             input.push_back(engine.get_random_uint8());
-//         }
-
-//         fr expected = crypto::pedersen_hash::hash_buffer(input);
-
-//         byte_array_ct circuit_input(&builder, input);
-//         auto result = pedersen_hash::hash(circuit_input);
-
-//         EXPECT_EQ(result.get_value(), expected);
-
-//         info("num gates = ", builder.get_num_gates());
-
-//         bool proof_result = builder.check_circuit();
-//         EXPECT_EQ(proof_result, true);
-//     }
-
-//     static void test_multi_compress()
-//     {
-//         Builder builder;
-
-//         for (size_t i = 0; i < 7; ++i) {
-//             std::vector<barretenberg::fr> inputs;
-//             inputs.push_back(barretenberg::fr::random_element());
-//             inputs.push_back(barretenberg::fr::random_element());
-//             inputs.push_back(barretenberg::fr::random_element());
-//             inputs.push_back(barretenberg::fr::random_element());
-
-//             if (i == 1) {
-//                 inputs[0] = barretenberg::fr(0);
-//             }
-//             if (i == 2) {
-//                 inputs[1] = barretenberg::fr(0);
-//                 inputs[2] = barretenberg::fr(0);
-//             }
-//             if (i == 3) {
-//                 inputs[3] = barretenberg::fr(0);
-//             }
-//             if (i == 4) {
-//                 inputs[0] = barretenberg::fr(0);
-//                 inputs[3] = barretenberg::fr(0);
-//             }
-//             if (i == 5) {
-//                 inputs[0] = barretenberg::fr(0);
-//                 inputs[1] = barretenberg::fr(0);
-//                 inputs[2] = barretenberg::fr(0);
-//                 inputs[3] = barretenberg::fr(0);
-//             }
-//             if (i == 6) {
-//                 inputs[1] = barretenberg::fr(1);
-//             }
-//             std::vector<fr_ct> witnesses;
-//             for (auto input : inputs) {
-//                 witnesses.push_back(witness_ct(&builder, input));
-//             }
-
-//             barretenberg::fr expected = crypto::pedersen_hash::hash(inputs);
-
-//             fr_ct result = pedersen_hash::hash(witnesses);
-//             EXPECT_EQ(result.get_value(), expected);
-//         }
-
-//         info("num gates = ", builder.get_num_gates());
-
-//         bool proof_result = builder.check_circuit();
-//         EXPECT_EQ(proof_result, true);
-//     }
-
-//     static void test_compress_eight()
-//     {
-//         Builder builder;
-
-//         std::vector<grumpkin::fq> inputs;
-//         inputs.reserve(8);
-//         std::vector<stdlib::field_t<Builder>> witness_inputs;
-
-//         for (size_t i = 0; i < 8; ++i) {
-//             inputs.emplace_back(barretenberg::fr::random_element());
-//             witness_inputs.emplace_back(witness_ct(&builder, inputs[i]));
-//         }
-
-//         constexpr size_t hash_idx = 10;
-//         grumpkin::fq expected = crypto::pedersen_hash::hash(inputs, hash_idx);
-//         auto result = pedersen_hash::hash(witness_inputs, hash_idx);
-
-//         EXPECT_EQ(result.get_value(), expected);
-//     }
-
-//     static void test_compress_constants()
-//     {
-//         Builder builder;
-
-//         std::vector<barretenberg::fr> inputs;
-//         std::vector<stdlib::field_t<Builder>> witness_inputs;
-
-//         for (size_t i = 0; i < 8; ++i) {
-//             inputs.push_back(barretenberg::fr::random_element());
-//             if (i % 2 == 1) {
-//                 witness_inputs.push_back(witness_ct(&builder, inputs[i]));
-//             } else {
-//                 witness_inputs.push_back(fr_ct(&builder, inputs[i]));
-//             }
-//         }
-
-//         barretenberg::fr expected = crypto::pedersen_hash::hash(inputs);
-//         auto result = pedersen_hash::hash(witness_inputs);
-
-//         EXPECT_EQ(result.get_value(), expected);
-//     }
-// };
-
-// using CircuitTypes = testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder>;
-
-// TYPED_TEST_SUITE(StdlibPedersen, CircuitTypes);
-
-// TYPED_TEST(StdlibPedersen, Small)
-// {
-//     TestFixture::test_pedersen();
-// };
-
-// TYPED_TEST(StdlibPedersen, EdgeCases)
-// {
-//     TestFixture::test_pedersen_edge_cases();
-// };
-
-// HEAVY_TYPED_TEST(StdlibPedersen, Large)
-// {
-//     TestFixture::test_pedersen_large();
-// };
-
-// TYPED_TEST(StdlibPedersen, CompressByteArray)
-// {
-//     TestFixture::test_compress_byte_array();
-// };
-
-// TYPED_TEST(StdlibPedersen, MultiCompress)
-// {
-//     TestFixture::test_multi_compress();
-// };
-
-// TYPED_TEST(StdlibPedersen, CompressEight)
-// {
-//     TestFixture::test_compress_eight();
-// };
-
-// TYPED_TEST(StdlibPedersen, CompressConstants)
-// {
-//     TestFixture::test_compress_constants();
-// };
-
-// } // namespace test_StdlibPedersen
+} // namespace test_StdlibPedersen


### PR DESCRIPTION
When we merged the mega PR, we commented out the stdlib pedersen commitment code. This was okay for the most part because we had tests for pedersen hashing tests. This adds back smoke pedersen commitment tests.

Also happy to just remove the file, if folks want.

Related to #3029 

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
