### PR TITLE
chore: Remove unecessary calls to `pedersen__init`

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind.cpp
@@ -3,8 +3,6 @@
 #include "barretenberg/common/serialize.hpp"
 #include "pedersen.hpp"
 
-WASM_EXPORT void pedersen__init() {}
-
 WASM_EXPORT void pedersen__commit(uint8_t const* inputs_buffer, uint8_t* output)
 {
     std::vector<grumpkin::fq> to_commit;

--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind.hpp
@@ -4,5 +4,4 @@
 #include "barretenberg/common/streams.hpp"
 #include "barretenberg/common/timer.hpp"
 
-WASM_EXPORT void pedersen__init();
 WASM_EXPORT void pedersen__commit(uint8_t const* inputs_buffer, uint8_t* output);

--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind_new.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind_new.cpp
@@ -7,8 +7,6 @@ extern "C" {
 
 using namespace barretenberg;
 
-WASM_EXPORT void pedersen___init() {}
-
 WASM_EXPORT void pedersen___commit(fr::vec_in_buf inputs_buffer, affine_element::out_buf output)
 {
     std::vector<grumpkin::fq> to_commit;

--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind_new.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind_new.hpp
@@ -8,7 +8,5 @@ extern "C" {
 using namespace barretenberg;
 using affine_element = grumpkin::g1::affine_element;
 
-WASM_EXPORT void pedersen___init();
-
 WASM_EXPORT void pedersen___commit(fr::vec_in_buf inputs_buffer, affine_element::out_buf output);
 }

--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/c_bind.cpp
@@ -5,8 +5,6 @@
 
 extern "C" {
 
-WASM_EXPORT void pedersen_hash__init() {}
-
 WASM_EXPORT void pedersen__hash_with_hash_index(uint8_t const* inputs_buffer, uint32_t hash_index, uint8_t* output)
 {
     std::vector<grumpkin::fq> to_hash;

--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/c_bind.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/c_bind.hpp
@@ -7,7 +7,6 @@ extern "C" {
 
 using namespace barretenberg;
 
-WASM_EXPORT void pedersen_hash_init();
 WASM_EXPORT void pedersen_hash_with_hash_index(fr::vec_in_buf inputs_buffer,
                                                uint32_t const* hash_index,
                                                fr::out_buf output);

--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/c_bind_new.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/c_bind_new.cpp
@@ -5,8 +5,6 @@
 
 extern "C" {
 
-WASM_EXPORT void pedersen_hash_init() {}
-
 WASM_EXPORT void pedersen_hash_with_hash_index(uint8_t const* inputs_buffer,
                                                uint32_t const* hash_index,
                                                uint8_t* output)

--- a/barretenberg/exports.json
+++ b/barretenberg/exports.json
@@ -1,11 +1,5 @@
 [
   {
-    "functionName": "pedersen___init",
-    "inArgs": [],
-    "outArgs": [],
-    "isAsync": false
-  },
-  {
     "functionName": "pedersen___commit",
     "inArgs": [
       {
@@ -19,12 +13,6 @@
         "type": "affine_element::out_buf"
       }
     ],
-    "isAsync": false
-  },
-  {
-    "functionName": "pedersen_hash_init",
-    "inArgs": [],
-    "outArgs": [],
     "isAsync": false
   },
   {

--- a/barretenberg/ts/src/barretenberg_api/index.ts
+++ b/barretenberg/ts/src/barretenberg_api/index.ts
@@ -17,19 +17,9 @@ export class BarretenbergApi {
     await this.binder.wasm.destroy();
   }
 
-  async pedersenInit(): Promise<void> {
-    const result = await this.binder.callWasmExport('pedersen___init', [], []);
-    return;
-  }
-
   async pedersenCommit(inputsBuffer: Fr[]): Promise<Point> {
     const result = await this.binder.callWasmExport('pedersen___commit', [inputsBuffer], [Point]);
     return result[0];
-  }
-
-  async pedersenHashInit(): Promise<void> {
-    const result = await this.binder.callWasmExport('pedersen_hash_init', [], []);
-    return;
   }
 
   async pedersenHashWithHashIndex(inputsBuffer: Fr[], hashIndex: number): Promise<Fr> {

--- a/barretenberg/ts/src/barretenberg_api/pedersen.test.ts
+++ b/barretenberg/ts/src/barretenberg_api/pedersen.test.ts
@@ -6,7 +6,6 @@ describe('pedersen', () => {
 
   beforeAll(async () => {
     api = await Barretenberg.new(1);
-    await api.pedersenHashInit();
   }, 30000);
 
   afterAll(async () => {

--- a/barretenberg/ts/src/barretenberg_api/schnorr.test.ts
+++ b/barretenberg/ts/src/barretenberg_api/schnorr.test.ts
@@ -9,7 +9,6 @@ describe('schnorr', () => {
 
   beforeAll(async () => {
     api = await Barretenberg.new(1);
-    await api.pedersenInit();
   }, 30000);
 
   afterAll(async () => {

--- a/yarn-project/circuits.js/src/abis/abis.ts
+++ b/yarn-project/circuits.js/src/abis/abis.ts
@@ -103,7 +103,6 @@ export function inputBuffersToOutputBuffer(
  * @returns The hash of the transaction request.
  */
 export function hashTxRequest(wasm: IWasmModule, txRequest: TxRequest): Buffer {
-  wasm.call('pedersen__init');
   return wasmSyncCall(wasm, 'abis__hash_tx_request', txRequest, 32);
 }
 
@@ -131,7 +130,6 @@ export function computeFunctionSelector(wasm: IWasmModule, funcSig: string): Buf
  * @returns The hash of the verification key.
  */
 export function hashVK(wasm: IWasmModule, vkBuf: Buffer) {
-  wasm.call('pedersen__init');
   return wasmSyncCall(wasm, 'abis__hash_vk', vkBuf, 32);
 }
 
@@ -142,7 +140,6 @@ export function hashVK(wasm: IWasmModule, vkBuf: Buffer) {
  * @returns The function leaf.
  */
 export function computeFunctionLeaf(wasm: IWasmModule, fnLeaf: FunctionLeafPreimage): Fr {
-  wasm.call('pedersen__init');
   return Fr.fromBuffer(wasmSyncCall(wasm, 'abis__compute_function_leaf', fnLeaf, 32));
 }
 
@@ -154,7 +151,6 @@ export function computeFunctionLeaf(wasm: IWasmModule, fnLeaf: FunctionLeafPreim
  */
 export function computeFunctionTreeRoot(wasm: IWasmModule, fnLeaves: Fr[]) {
   const inputVector = serializeBufferArrayToVector(fnLeaves.map(fr => fr.toBuffer()));
-  wasm.call('pedersen__init');
   const result = wasmSyncCall(wasm, 'abis__compute_function_tree_root', inputVector, 32);
   return Fr.fromBuffer(result);
 }
@@ -173,7 +169,6 @@ export function hashConstructor(
   argsHash: Fr,
   constructorVKHash: Buffer,
 ): Fr {
-  wasm.call('pedersen__init');
   const result = inputBuffersToOutputBuffer(
     wasm,
     'abis__hash_constructor',
@@ -199,7 +194,6 @@ export function computeCompleteAddress(
   fnTreeRoot: Fr,
   constructorHash: Fr,
 ): CompleteAddress {
-  wasm.call('pedersen__init');
   return abisComputeCompleteAddress(wasm, deployerPubKey, contractAddrSalt, fnTreeRoot, constructorHash);
 }
 
@@ -216,7 +210,6 @@ export function computeContractAddressFromPartial(
   pubKey: PublicKey,
   partialAddress: Fr,
 ): AztecAddress {
-  wasm.call('pedersen__init');
   const result = inputBuffersToOutputBuffer(
     wasm,
     'abis__compute_contract_address_from_partial',
@@ -234,7 +227,6 @@ export function computeContractAddressFromPartial(
  * @returns A commitment nonce.
  */
 export function computeCommitmentNonce(wasm: IWasmModule, nullifierZero: Fr, commitmentIndex: number): Fr {
-  wasm.call('pedersen__init');
   return abisComputeCommitmentNonce(wasm, nullifierZero, new Fr(commitmentIndex));
 }
 
@@ -247,7 +239,6 @@ export function computeCommitmentNonce(wasm: IWasmModule, nullifierZero: Fr, com
  * @returns A siloed commitment.
  */
 export function siloCommitment(wasm: IWasmModule, contract: AztecAddress, innerCommitment: Fr): Fr {
-  wasm.call('pedersen__init');
   return abisSiloCommitment(wasm, contract, innerCommitment);
 }
 
@@ -259,7 +250,6 @@ export function siloCommitment(wasm: IWasmModule, contract: AztecAddress, innerC
  * @returns A unique commitment.
  */
 export function computeUniqueCommitment(wasm: IWasmModule, nonce: Fr, siloedCommitment: Fr): Fr {
-  wasm.call('pedersen__init');
   return abisComputeUniqueCommitment(wasm, nonce, siloedCommitment);
 }
 
@@ -272,7 +262,6 @@ export function computeUniqueCommitment(wasm: IWasmModule, nonce: Fr, siloedComm
  * @returns A siloed nullifier.
  */
 export function siloNullifier(wasm: IWasmModule, contract: AztecAddress, innerNullifier: Fr): Fr {
-  wasm.call('pedersen__init');
   return abisSiloNullifier(wasm, contract, innerNullifier);
 }
 
@@ -296,7 +285,6 @@ export function computeBlockHashWithGlobals(
   l1ToL2DataTreeRoot: Fr,
   publicDataTreeRoot: Fr,
 ): Fr {
-  wasm.call('pedersen__init');
   return abisComputeBlockHashWithGlobals(
     wasm,
     globals,
@@ -328,7 +316,6 @@ export function computeBlockHash(
   l1ToL2DataTreeRoot: Fr,
   publicDataTreeRoot: Fr,
 ): Fr {
-  wasm.call('pedersen__init');
   return abisComputeBlockHash(
     wasm,
     globalsHash,
@@ -347,7 +334,6 @@ export function computeBlockHash(
  * @returns The globals hash.
  */
 export function computeGlobalsHash(wasm: IWasmModule, globals: GlobalVariables): Fr {
-  wasm.call('pedersen__init');
   return abisComputeGlobalsHash(wasm, globals);
 }
 
@@ -359,7 +345,6 @@ export function computeGlobalsHash(wasm: IWasmModule, globals: GlobalVariables):
 
  */
 export function computePublicDataTreeValue(wasm: IWasmModule, value: Fr): Fr {
-  wasm.call('pedersen__init');
   return abisComputePublicDataTreeValue(wasm, value);
 }
 
@@ -372,7 +357,6 @@ export function computePublicDataTreeValue(wasm: IWasmModule, value: Fr): Fr {
 
  */
 export function computePublicDataTreeIndex(wasm: IWasmModule, contractAddress: AztecAddress, storageSlot: Fr): Fr {
-  wasm.call('pedersen__init');
   return abisComputePublicDataTreeIndex(wasm, contractAddress, storageSlot);
 }
 
@@ -389,7 +373,6 @@ export function computeVarArgsHash(wasm: IWasmModule, args: Fr[]): Promise<Fr> {
   if (args.length === 0) return Promise.resolve(Fr.ZERO);
   if (args.length > ARGS_HASH_CHUNK_SIZE * ARGS_HASH_CHUNK_COUNT)
     throw new Error(`Cannot hash more than ${ARGS_HASH_CHUNK_SIZE * ARGS_HASH_CHUNK_COUNT} arguments`);
-  wasm.call('pedersen__init');
 
   const wasmComputeVarArgs = (args: Fr[]) =>
     Fr.fromBuffer(wasmSyncCall(wasm, 'abis__compute_var_args_hash', new Vector(args), 32));
@@ -415,7 +398,6 @@ export function computeVarArgsHash(wasm: IWasmModule, args: Fr[]): Promise<Fr> {
  * @returns The contract leaf.
  */
 export function computeContractLeaf(wasm: IWasmModule, cd: NewContractData): Fr {
-  wasm.call('pedersen__init');
   const value = wasmSyncCall(wasm, 'abis__compute_contract_leaf', cd, 32);
   return Fr.fromBuffer(value);
 }
@@ -427,7 +409,6 @@ export function computeContractLeaf(wasm: IWasmModule, cd: NewContractData): Fr 
  * @returns The transaction hash.
  */
 export function computeTxHash(wasm: IWasmModule, txRequest: TxRequest): Fr {
-  wasm.call('pedersen__init');
   const value = wasmSyncCall(wasm, 'abis__compute_transaction_hash', txRequest, 32);
   return Fr.fromBuffer(value);
 }
@@ -458,7 +439,6 @@ export function computeCallStackItemHash(
  * @returns The call stack item hash.
  */
 export function computePrivateCallStackItemHash(wasm: IWasmModule, callStackItem: PrivateCallStackItem): Fr {
-  wasm.call('pedersen__init');
   const value = wasmSyncCall(wasm, 'abis__compute_private_call_stack_item_hash', callStackItem, 32);
   return Fr.fromBuffer(value);
 }
@@ -470,7 +450,6 @@ export function computePrivateCallStackItemHash(wasm: IWasmModule, callStackItem
  * @returns The call stack item hash.
  */
 export function computePublicCallStackItemHash(wasm: IWasmModule, callStackItem: PublicCallStackItem): Fr {
-  wasm.call('pedersen__init');
   const value = wasmSyncCall(wasm, 'abis__compute_public_call_stack_item_hash', callStackItem, 32);
   return Fr.fromBuffer(value);
 }
@@ -481,7 +460,6 @@ export function computePublicCallStackItemHash(wasm: IWasmModule, callStackItem:
  * @returns
  */
 export function computeSecretMessageHash(wasm: IWasmModule, secretMessage: Fr) {
-  wasm.call('pedersen__init');
   const value = wasmSyncCall(wasm, 'abis__compute_message_secret_hash', secretMessage, 32);
   return Fr.fromBuffer(value);
 }

--- a/yarn-project/circuits.js/src/barretenberg/crypto/pedersen/pedersen.ts
+++ b/yarn-project/circuits.js/src/barretenberg/crypto/pedersen/pedersen.ts
@@ -39,9 +39,6 @@ export function pedersenHashInputs(wasm: IWasmModule, inputs: Buffer[]): Buffer 
  * purposes.
  */
 export function pedersenHashWithHashIndex(wasm: IWasmModule, inputs: Buffer[], hashIndex: number): Buffer {
-  // If not done already, precompute constants.
-  wasm.call('pedersen__init');
-
   const data = serializeBufferArrayToVector(inputs);
 
   // WASM gives us 1024 bytes of scratch space which we can use without

--- a/yarn-project/circuits.js/src/kernel/private_kernel.ts
+++ b/yarn-project/circuits.js/src/kernel/private_kernel.ts
@@ -15,9 +15,6 @@ export { privateKernelSimOrdering, privateKernelSimInit, privateKernelSimInner }
  * @returns All of a function tree's nodes.
  */
 export function computeFunctionTree(wasm: CircuitsWasm, leaves: Fr[]): Fr[] {
-  // Init pedersen if needed
-  wasm.call('pedersen__init');
-
   // Size of the tree is 2^height times size of each element,
   // plus 4 for the size used in the std::vector serialization
   const outputBufSize = 2 ** (FUNCTION_TREE_HEIGHT + 1) * Fr.SIZE_IN_BYTES + 4;


### PR DESCRIPTION
Related to #3029 and resolves #3077 .

The generator context is initializing and extending generator data which outlives the lifetime of the function (it stays alive for the lifetime of wasm instance). There may be an argument in the future to add a method that will arbitrarily extend the generators, so that they do not get extended in the middle of a pedersen call, if this is wanted we can open up a separate issue.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
