### PR TITLE
fix: docker-compose up, rather than run.

### DIFF
--- a/build-system/scripts/cond_run_compose
+++ b/build-system/scripts/cond_run_compose
@@ -27,7 +27,7 @@ if ! check_rebuild $SUCCESS_TAG $REPOSITORY; then
   cd $(query_manifest projectDir $REPOSITORY)
 
   export $@
-  docker-compose -f $COMPOSE_FILE run $REPOSITORY
+  docker-compose -f $COMPOSE_FILE up --exit-code-from $REPOSITORY --force-recreate
 
   upload_logs_to_s3 log
 

--- a/yarn-project/end-to-end/scripts/docker-compose.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     environment:
       BENCHMARK: 'true'
       LOG_LEVL: 'debug'
-      DEBUG: ${DEBUG:-'aztec:*'}
+      DEBUG: ${DEBUG:-aztec:*}
       ETHEREUM_HOST: http://fork:8545
       CHAIN_ID: 31337
       PXE_URL: http://sandbox:8080


### PR DESCRIPTION
`docker run` seems to be exposing race conditions in how certain tests start. e.g. guides/*
Reverting to `docker up`, although worried it's masking issues.