### PR TITLE
fix: push cli docker image to docker hub

### DIFF
--- a/yarn-project/cli/aztec-cli
+++ b/yarn-project/cli/aztec-cli
@@ -34,7 +34,7 @@ fi
 
 # fallback on docker
 
-CLI_IMAGE=${CLI_IMAGE:-"aztecprotocol/aztec-cli"}
+CLI_IMAGE=${CLI_IMAGE:-"aztecprotocol/cli"}
 CLI_VERSION=${CLI_VERSION:-"latest"}
 
 DOCKER_PATH=""

--- a/yarn-project/deploy_dockerhub.sh
+++ b/yarn-project/deploy_dockerhub.sh
@@ -5,7 +5,7 @@ DIST_TAG=${1:-"latest"}
 extract_repo yarn-project /usr/src project
 PROJECT_ROOT=$(pwd)/project/src/
 
-for REPOSITORY in "pxe" "aztec-sandbox"; do
+for REPOSITORY in "pxe" "aztec-sandbox" "cli"; do
   echo "Deploying $REPOSITORY $DIST_TAG"
   RELATIVE_PROJECT_DIR=$(query_manifest relativeProjectDir $REPOSITORY)
   cd "$PROJECT_ROOT/$RELATIVE_PROJECT_DIR"


### PR DESCRIPTION
In #3031 I forgot to push the CLI docker image to dockerhub. This fixes that and also updates the name of the expected docker image in the bash wrapper script to match.

Related #2875 

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [x] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
