### PR TITLE
fix: exposing `PXE.getBlock`, exporting `createAztecNodeClient` from `aztec.js`

### DIFF
--- a/yarn-project/aztec.js/src/index.ts
+++ b/yarn-project/aztec.js/src/index.ts
@@ -32,6 +32,7 @@ export {
   TxStatus,
   UnencryptedL2Log,
   emptyFunctionCall,
+  createAztecNodeClient,
 } from '@aztec/types';
 export { ContractArtifact } from '@aztec/foundation/abi';
 export { createDebugLogger, DebugLogger } from '@aztec/foundation/log';

--- a/yarn-project/aztec.js/src/pxe_client.ts
+++ b/yarn-project/aztec.js/src/pxe_client.ts
@@ -14,6 +14,7 @@ import {
   ExtendedContractData,
   ExtendedNote,
   ExtendedUnencryptedL2Log,
+  L2Block,
   L2BlockL2Logs,
   L2Tx,
   LogId,
@@ -27,6 +28,12 @@ import {
 
 export { makeFetch } from '@aztec/foundation/json-rpc/client';
 
+/**
+ * Creates a JSON-RPC client to remotely talk to PXE.
+ * @param url - The URL of the PXE.
+ * @param fetch - The fetch implementation to use.
+ * @returns A JSON-RPC client of PXE.
+ */
 export const createPXEClient = (url: string, fetch = makeFetch([1, 2, 3], true)): PXE =>
   createJsonRpcClient<PXE>(
     url,
@@ -48,6 +55,7 @@ export const createPXEClient = (url: string, fetch = makeFetch([1, 2, 3], true))
       AuthWitness,
       L2Tx,
       LogId,
+      L2Block,
     },
     { Tx, TxReceipt, L2BlockL2Logs },
     false,

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -7,6 +7,7 @@ import {
   ExtendedNote,
   FunctionCall,
   GetUnencryptedLogsResponse,
+  L2Block,
   L2Tx,
   LogFilter,
   NodeInfo,
@@ -81,6 +82,9 @@ export abstract class BaseWallet implements Wallet {
   }
   getNoteNonces(note: ExtendedNote): Promise<Fr[]> {
     return this.pxe.getNoteNonces(note);
+  }
+  getBlock(number: number): Promise<L2Block | undefined> {
+    return this.pxe.getBlock(number);
   }
   viewTx(functionName: string, args: any[], to: AztecAddress, from?: AztecAddress | undefined): Promise<any> {
     return this.pxe.viewTx(functionName, args, to, from);

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -29,7 +29,7 @@ import {
 } from '@aztec/l1-artifacts';
 import { PXEService, createPXEService, getPXEServiceConfig } from '@aztec/pxe';
 import { SequencerClient } from '@aztec/sequencer-client';
-import { AztecNode, L2BlockL2Logs, LogType, PXE, createAztecNodeRpcClient } from '@aztec/types';
+import { AztecNode, L2BlockL2Logs, LogType, PXE, createAztecNodeClient } from '@aztec/types';
 
 import * as path from 'path';
 import {
@@ -166,7 +166,7 @@ async function setupWithSandbox(account: Account, config: AztecNodeConfig, logge
   // we are setting up against the sandbox, l1 contracts are already deployed
   const aztecNodeUrl = getAztecNodeUrl();
   logger(`Creating Aztec Node client to remote host ${aztecNodeUrl}`);
-  const aztecNode = createAztecNodeRpcClient(aztecNodeUrl);
+  const aztecNode = createAztecNodeClient(aztecNodeUrl);
   logger(`Creating PXE client to remote host ${PXE_URL}`);
   const pxeClient = createPXEClient(PXE_URL);
   await waitForPXE(pxeClient, logger);

--- a/yarn-project/pxe/src/bin/index.ts
+++ b/yarn-project/pxe/src/bin/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S node --no-warnings
 import { createDebugLogger } from '@aztec/foundation/log';
-import { createAztecNodeRpcClient } from '@aztec/types';
+import { createAztecNodeClient } from '@aztec/types';
 
 import { getPXEServiceConfig } from '../config/index.js';
 import { startPXEHttpServer } from '../pxe_http/index.js';
@@ -17,7 +17,7 @@ async function main() {
   logger.info(`Setting up PXE...`);
 
   const pxeConfig = getPXEServiceConfig();
-  const nodeRpcClient = createAztecNodeRpcClient(AZTEC_NODE_URL);
+  const nodeRpcClient = createAztecNodeClient(AZTEC_NODE_URL);
   const pxeService = await createPXEService(nodeRpcClient, pxeConfig);
 
   const shutdown = async () => {

--- a/yarn-project/types/src/aztec_node/rpc/aztec_node_client.ts
+++ b/yarn-project/types/src/aztec_node/rpc/aztec_node_client.ts
@@ -19,13 +19,13 @@ import {
 } from '@aztec/types';
 
 /**
- * Creates a JSON-RPC client to remotely talk to an AztecNode.
- * @param url - The URL of the AztecNode
- * @param fetch - The fetch implementation to use
- * @returns A JSON-RPC client
+ * Creates a JSON-RPC client to remotely talk to an Aztec Node.
+ * @param url - The URL of the Aztec Node.
+ * @param fetch - The fetch implementation to use.
+ * @returns A JSON-RPC client of Aztec Node.
  */
-export function createAztecNodeRpcClient(url: string, fetch = defaultFetch): AztecNode {
-  const rpcClient = createJsonRpcClient<AztecNode>(
+export function createAztecNodeClient(url: string, fetch = defaultFetch): AztecNode {
+  return createJsonRpcClient<AztecNode>(
     url,
     {
       AztecAddress,
@@ -47,5 +47,4 @@ export function createAztecNodeRpcClient(url: string, fetch = defaultFetch): Azt
     false,
     fetch,
   );
-  return rpcClient;
 }

--- a/yarn-project/types/src/aztec_node/rpc/index.ts
+++ b/yarn-project/types/src/aztec_node/rpc/index.ts
@@ -1,1 +1,1 @@
-export * from './http_rpc_client.js';
+export * from './aztec_node_client.js';

--- a/yarn-project/types/src/interfaces/pxe.ts
+++ b/yarn-project/types/src/interfaces/pxe.ts
@@ -161,7 +161,7 @@ export interface PXE {
   getPublicStorageAt(contract: AztecAddress, storageSlot: Fr): Promise<Buffer | undefined>;
 
   /**
-   * Gets notes OF ACCOUNTS REGISTERED IN THIS PXE based on the provided filter.
+   * Gets notes based on the provided filter.
    * @param filter - The filter to apply to the notes.
    * @returns The requested notes.
    */

--- a/yarn-project/types/src/interfaces/pxe.ts
+++ b/yarn-project/types/src/interfaces/pxe.ts
@@ -6,6 +6,7 @@ import {
   ExtendedContractData,
   ExtendedNote,
   GetUnencryptedLogsResponse,
+  L2Block,
   L2Tx,
   LogFilter,
   Tx,
@@ -160,7 +161,7 @@ export interface PXE {
   getPublicStorageAt(contract: AztecAddress, storageSlot: Fr): Promise<Buffer | undefined>;
 
   /**
-   * Gets notes based on the provided filter.
+   * Gets notes OF ACCOUNTS REGISTERED IN THIS PXE based on the provided filter.
    * @param filter - The filter to apply to the notes.
    * @returns The requested notes.
    */
@@ -180,6 +181,13 @@ export interface PXE {
    * @remarks More than a single nonce may be returned since there might be more than one nonce for a given note.
    */
   getNoteNonces(note: ExtendedNote): Promise<Fr[]>;
+
+  /**
+   * Get the a given block.
+   * @param number - The block number being requested.
+   * @returns The blocks requested.
+   */
+  getBlock(number: number): Promise<L2Block | undefined>;
 
   /**
    * Simulate the execution of a view (read-only) function on a deployed contract without actually modifying state.


### PR DESCRIPTION
A few fixes of issues which were stumbled upon by a grantee @harshnambiar.

Issues:
1. `getBlock` method was not exposed on `PXE` even though it's implemented in `PXEService`,
2. `createAztecNodeRpcClient` naming is not consistent with `createPXEClient` (`createAztecNodeRpcClient` --> `createAztecNodeClient`),
3. `createAztecNodeClient` method is not exposed in `aztec.js`.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
