### PR TITLE
fix: build cli image before releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,6 +454,32 @@ jobs:
             echo "export DOCKER_BUILDKIT=" > $BASH_ENV
             build aztec-sandbox false arm64
 
+  cli-x86_64:
+    machine:
+      image: ubuntu-2204:2023.07.2
+    resource_class: large
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Build and test"
+          command: build cli false x86_64
+
+  cli-arm64:
+    machine:
+      image: ubuntu-2204:2023.07.2
+    resource_class: arm.large
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Build and test"
+          # We need to force not to use docker buildkit because for some reason on arm only, it ends up making a call
+          # out to eu-west2 despite the image being locally tagged, resulting in unauthorized 401. Weird docker bug?
+          command: |
+            echo "export DOCKER_BUILDKIT=" > $BASH_ENV
+            build cli false arm64
+
   aztec-p2p-bootstrap:
     machine:
       image: ubuntu-2204:2023.07.2
@@ -547,6 +573,7 @@ jobs:
           command: |
             create_ecr_manifest aztec-sandbox x86_64,arm64
             create_ecr_manifest pxe x86_64,arm64
+            create_ecr_manifest cli x86_64,arm64
 
   boxes-blank-react:
     machine:
@@ -1260,6 +1287,15 @@ workflows:
             - yarn-project
           <<: *defaults
 
+      - cli-x86_64:
+          requires:
+            - yarn-project
+          <<: *defaults
+      - cli-arm64:
+          requires:
+            - yarn-project
+          <<: *defaults
+
       - aztec-p2p-bootstrap:
           requires:
             - yarn-project
@@ -1290,6 +1326,8 @@ workflows:
             - aztec-sandbox-arm64
             - pxe-x86_64
             - pxe-arm64
+            - cli-x86_64
+            - cli-arm64
           <<: *defaults
 
       - boxes-blank-react:

--- a/build_manifest.yml
+++ b/build_manifest.yml
@@ -124,7 +124,7 @@ aztec-faucet:
   dependencies:
     - yarn-project
 
-aztec-cli:
+cli:
   buildDir: yarn-project
   projectDir: yarn-project/cli
   dependencies:

--- a/yarn-project/cli/aztec-cli
+++ b/yarn-project/cli/aztec-cli
@@ -34,7 +34,7 @@ fi
 
 # fallback on docker
 
-CLI_IMAGE=${CLI_IMAGE:-"aztecprotocol/aztec-cli"}
+CLI_IMAGE=${CLI_IMAGE:-"aztecprotocol/cli"}
 CLI_VERSION=${CLI_VERSION:-"latest"}
 
 DOCKER_PATH=""

--- a/yarn-project/deploy_dockerhub.sh
+++ b/yarn-project/deploy_dockerhub.sh
@@ -5,7 +5,7 @@ DIST_TAG=${1:-"latest"}
 extract_repo yarn-project /usr/src project
 PROJECT_ROOT=$(pwd)/project/src/
 
-for REPOSITORY in "pxe" "aztec-sandbox"; do
+for REPOSITORY in "pxe" "aztec-sandbox" "cli"; do
   echo "Deploying $REPOSITORY $DIST_TAG"
   RELATIVE_PROJECT_DIR=$(query_manifest relativeProjectDir $REPOSITORY)
   cd "$PROJECT_ROOT/$RELATIVE_PROJECT_DIR"


### PR DESCRIPTION
This PR adds the CircleCI jobs to build the CLI image for x86 and arm. In #3120 we push the images, but they weren't getting built :face_exhaling: 

#3120 got reverted to unblock release of 0.13.1. This PR restores the changes from #3120 and also builds the image to be published

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [x] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
