### PR TITLE
chore: Clean up and refactor arithmetization

### DIFF
--- a/barretenberg/cpp/src/barretenberg/plonk/composer/composer_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/composer/composer_lib.hpp
@@ -55,9 +55,9 @@ void enforce_nonzero_selector_polynomials(const auto& circuit_constructor, auto*
 {
     for (size_t idx = 0; idx < circuit_constructor.num_selectors; ++idx) {
         auto current_selector =
-            proving_key->polynomial_store.get(circuit_constructor.selector_names_[idx] + "_lagrange");
+            proving_key->polynomial_store.get(circuit_constructor.selector_names[idx] + "_lagrange");
         current_selector[current_selector.size() - 1] = idx + 1;
-        proving_key->polynomial_store.put(circuit_constructor.selector_names_[idx] + "_lagrange",
+        proving_key->polynomial_store.put(circuit_constructor.selector_names[idx] + "_lagrange",
                                           std::move(current_selector));
     }
 }

--- a/barretenberg/cpp/src/barretenberg/proof_system/arithmetization/arithmetization.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/arithmetization/arithmetization.hpp
@@ -29,80 +29,74 @@ namespace arithmetization {
  *
  * We should only do this if it becomes necessary or convenient.
  */
-template <typename FF> class Arithmetization {
-  protected:
-    using SelectorType = std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>;
-    using DataType = std::vector<SelectorType>;
-
-    DataType selectors;
-
-  public:
-    Arithmetization(size_t n)
-        : selectors(n)
-    {}
-    size_t size() const { return selectors.size(); };
-    typename DataType::const_iterator begin() const { return selectors.begin(); };
-    typename DataType::iterator begin() { return selectors.begin(); };
-    typename DataType::const_iterator end() const { return selectors.end(); };
-    typename DataType::iterator end() { return selectors.end(); };
-
-    void reserve(size_t size_hint)
-    {
-        for (auto& p : this->selectors) {
-            p.reserve(size_hint);
-        }
-    }
-};
 
 // These are not magic numbers and they should not be written with global constants. These parameters are not accessible
 // through clearly named static class members.
-template <typename _FF> class Standard : public Arithmetization<_FF> {
+template <typename _FF> class Standard {
   public:
     static constexpr size_t NUM_WIRES = 3;
     static constexpr size_t num_selectors = 5;
     using FF = _FF;
-    using SelectorType = typename Arithmetization<FF>::SelectorType;
+    using SelectorType = std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>;
 
-    SelectorType& q_m() { return this->selectors[0]; };
-    SelectorType& q_1() { return this->selectors[1]; };
-    SelectorType& q_2() { return this->selectors[2]; };
-    SelectorType& q_3() { return this->selectors[3]; };
-    SelectorType& q_c() { return this->selectors[4]; };
+    std::vector<SelectorType> selectors;
+
+    SelectorType& q_m() { return selectors[0]; };
+    SelectorType& q_1() { return selectors[1]; };
+    SelectorType& q_2() { return selectors[2]; };
+    SelectorType& q_3() { return selectors[3]; };
+    SelectorType& q_c() { return selectors[4]; };
 
     Standard()
-        : Arithmetization<FF>(num_selectors)
+        : selectors(num_selectors)
     {}
 
-    const auto& get() const { return this->selectors; };
+    const auto& get() const { return selectors; };
+
+    void reserve(size_t size_hint)
+    {
+        for (auto& p : selectors) {
+            p.reserve(size_hint);
+        }
+    }
 
     // Note: These are needed for Plonk only (for poly storage in a std::map). Must be in same order as above struct.
     inline static const std::vector<std::string> selector_names = { "q_m", "q_1", "q_2", "q_3", "q_c" };
 };
 
-template <typename _FF> class Ultra : public Arithmetization<_FF> {
+template <typename _FF> class Ultra {
   public:
     static constexpr size_t NUM_WIRES = 4;
     static constexpr size_t num_selectors = 11;
     using FF = _FF;
-    using SelectorType = typename Arithmetization<FF>::SelectorType;
+    using SelectorType = std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>;
 
-    SelectorType& q_m() { return this->selectors[0]; };
-    SelectorType& q_c() { return this->selectors[1]; };
-    SelectorType& q_1() { return this->selectors[2]; };
-    SelectorType& q_2() { return this->selectors[3]; };
-    SelectorType& q_3() { return this->selectors[4]; };
-    SelectorType& q_4() { return this->selectors[5]; };
-    SelectorType& q_arith() { return this->selectors[6]; };
-    SelectorType& q_sort() { return this->selectors[7]; };
-    SelectorType& q_elliptic() { return this->selectors[8]; };
-    SelectorType& q_aux() { return this->selectors[9]; };
-    SelectorType& q_lookup_type() { return this->selectors[10]; };
+    std::vector<SelectorType> selectors;
+
+    SelectorType& q_m() { return selectors[0]; };
+    SelectorType& q_c() { return selectors[1]; };
+    SelectorType& q_1() { return selectors[2]; };
+    SelectorType& q_2() { return selectors[3]; };
+    SelectorType& q_3() { return selectors[4]; };
+    SelectorType& q_4() { return selectors[5]; };
+    SelectorType& q_arith() { return selectors[6]; };
+    SelectorType& q_sort() { return selectors[7]; };
+    SelectorType& q_elliptic() { return selectors[8]; };
+    SelectorType& q_aux() { return selectors[9]; };
+    SelectorType& q_lookup_type() { return selectors[10]; };
 
     Ultra()
-        : Arithmetization<FF>(num_selectors)
+        : selectors(num_selectors)
     {}
 
-    const auto& get() const { return this->selectors; };
+    const auto& get() const { return selectors; };
+
+    void reserve(size_t size_hint)
+    {
+        for (auto& p : selectors) {
+            p.reserve(size_hint);
+        }
+    }
 
     // Note: These are needed for Plonk only (for poly storage in a std::map). Must be in same order as above struct.
     inline static const std::vector<std::string> selector_names = { "q_m",        "q_c",   "q_1",       "q_2",

--- a/barretenberg/cpp/src/barretenberg/proof_system/arithmetization/arithmetization.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/arithmetization/arithmetization.hpp
@@ -17,173 +17,102 @@ namespace arithmetization {
  * @remark It may make sense to say this is only partial arithmetization data, with the full data being
  * contained in the circuit constructor. We could change the name of this class if it conflicts with common usage.
  *
- * @tparam _NUM_WIRES
- * @tparam _num_selectors
+ * @note For even greater modularity, in each instantiation we could specify a list of components here, where a
+ * component is a meaningful collection of functions for creating gates, as in:
+ *
+ * struct Component {
+ *     using Arithmetic = component::Arithmetic3Wires;
+ *     using RangeConstraints = component::Base4Accumulators or component::GenPerm or...
+ *     using LookupTables = component::Plookup4Wire or component::CQ8Wire or...
+ *     ...
+ * };
+ *
+ * We should only do this if it becomes necessary or convenient.
  */
-template <size_t _NUM_WIRES, size_t _num_selectors> struct Arithmetization {
-    static constexpr size_t NUM_WIRES = _NUM_WIRES;
-    static constexpr size_t num_selectors = _num_selectors;
+template <typename FF> class Arithmetization {
+  protected:
+    using SelectorType = std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>;
+    using DataType = std::vector<SelectorType>;
 
-    // Note: For even greater modularity, in each instantiation we could specify a list of components here, where a
-    // component is a meaningful collection of functions for creating gates, as in:
-    //
-    // struct Component {
-    //     using Arithmetic = component::Arithmetic3Wires;
-    //     using RangeConstraints = component::Base4Accumulators or component::GenPerm or...
-    //     using LookupTables = component::Plookup4Wire or component::CQ8Wire or...
-    //     ...
-    // };
-    //
-    // We should only do this if it becomes necessary or convenient.
-};
+    DataType selectors;
 
-template <typename FF, size_t num_selectors> struct SelectorsBase {
-    using DataType = std::array<std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>, num_selectors>;
-    DataType _data;
-    size_t size() { return _data.size(); };
-    typename DataType::const_iterator begin() const { return _data.begin(); };
-    typename DataType::iterator begin() { return _data.begin(); };
-    typename DataType::const_iterator end() const { return _data.end(); };
-    typename DataType::iterator end() { return _data.end(); };
+  public:
+    Arithmetization(size_t n)
+        : selectors(n)
+    {}
+    size_t size() const { return selectors.size(); };
+    typename DataType::const_iterator begin() const { return selectors.begin(); };
+    typename DataType::iterator begin() { return selectors.begin(); };
+    typename DataType::const_iterator end() const { return selectors.end(); };
+    typename DataType::iterator end() { return selectors.end(); };
+
+    void reserve(size_t size_hint)
+    {
+        for (auto& p : this->selectors) {
+            p.reserve(size_hint);
+        }
+    }
 };
 
 // These are not magic numbers and they should not be written with global constants. These parameters are not accessible
 // through clearly named static class members.
-template <typename _FF> class Standard : public Arithmetization</*NUM_WIRES =*/3, /*num_selectors =*/5> {
+template <typename _FF> class Standard : public Arithmetization<_FF> {
   public:
+    static constexpr size_t NUM_WIRES = 3;
+    static constexpr size_t num_selectors = 5;
     using FF = _FF;
-    struct Selectors : SelectorsBase<FF, num_selectors> {
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_m = std::get<0>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_1 = std::get<1>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_2 = std::get<2>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_3 = std::get<3>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_c = std::get<4>(this->_data);
-        Selectors()
-            : SelectorsBase<FF, num_selectors>(){};
-        Selectors(const Selectors& other)
-            : SelectorsBase<FF, num_selectors>(other)
-        {}
-        Selectors(Selectors&& other)
-        {
-            this->_data = std::move(other._data);
-            this->q_m = std::get<0>(this->_data);
-            this->q_1 = std::get<1>(this->_data);
-            this->q_2 = std::get<2>(this->_data);
-            this->q_3 = std::get<3>(this->_data);
-            this->q_c = std::get<4>(this->_data);
-        };
-        Selectors& operator=(Selectors&& other)
-        {
-            SelectorsBase<FF, num_selectors>::operator=(other);
-            return *this;
-        }
-        ~Selectors() = default;
-    };
+    using SelectorType = typename Arithmetization<FF>::SelectorType;
+
+    SelectorType& q_m() { return this->selectors[0]; };
+    SelectorType& q_1() { return this->selectors[1]; };
+    SelectorType& q_2() { return this->selectors[2]; };
+    SelectorType& q_3() { return this->selectors[3]; };
+    SelectorType& q_c() { return this->selectors[4]; };
+
+    Standard()
+        : Arithmetization<FF>(num_selectors)
+    {}
+
+    const auto& get() const { return this->selectors; };
+
     // Note: These are needed for Plonk only (for poly storage in a std::map). Must be in same order as above struct.
     inline static const std::vector<std::string> selector_names = { "q_m", "q_1", "q_2", "q_3", "q_c" };
 };
 
-template <typename _FF> class Turbo : public Arithmetization</*NUM_WIRES =*/4, /*num_selectors =*/11> {
+template <typename _FF> class Ultra : public Arithmetization<_FF> {
   public:
+    static constexpr size_t NUM_WIRES = 4;
+    static constexpr size_t num_selectors = 11;
     using FF = _FF;
-    struct Selectors : SelectorsBase<FF, num_selectors> {
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_m = std::get<0>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_c = std::get<1>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_1 = std::get<2>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_2 = std::get<3>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_3 = std::get<4>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_4 = std::get<5>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_5 = std::get<6>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_arith = std::get<7>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_fixed_base = std::get<8>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_range = std::get<9>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_logic = std::get<10>(this->_data);
-        Selectors()
-            : SelectorsBase<FF, num_selectors>(){};
-        Selectors(const Selectors& other)
-            : SelectorsBase<FF, num_selectors>(other)
-        {}
-        Selectors(Selectors&& other)
-        {
-            this->_data = std::move(other._data);
-            this->q_m = std::get<0>(this->_data);
-            this->q_c = std::get<1>(this->_data);
-            this->q_1 = std::get<2>(this->_data);
-            this->q_2 = std::get<3>(this->_data);
-            this->q_3 = std::get<4>(this->_data);
-            this->q_4 = std::get<5>(this->_data);
-            this->q_5 = std::get<6>(this->_data);
-            this->q_arith = std::get<7>(this->_data);
-            this->q_fixed_base = std::get<8>(this->_data);
-            this->q_range = std::get<9>(this->_data);
-            this->q_logic = std::get<10>(this->_data);
-        };
-        Selectors& operator=(Selectors&& other)
-        {
-            SelectorsBase<FF, num_selectors>::operator=(other);
-            return *this;
-        }
-        ~Selectors() = default;
-    };
-};
+    using SelectorType = typename Arithmetization<FF>::SelectorType;
 
-template <typename _FF> class Ultra : public Arithmetization</*NUM_WIRES =*/4, /*num_selectors =*/11> {
-  public:
-    using FF = _FF;
-    struct Selectors : SelectorsBase<FF, num_selectors> {
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_m = std::get<0>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_c = std::get<1>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_1 = std::get<2>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_2 = std::get<3>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_3 = std::get<4>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_4 = std::get<5>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_arith = std::get<6>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_sort = std::get<7>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_elliptic = std::get<8>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_aux = std::get<9>(this->_data);
-        std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>& q_lookup_type = std::get<10>(this->_data);
-        Selectors()
-            : SelectorsBase<FF, num_selectors>(){};
-        Selectors(const Selectors& other)
-            : SelectorsBase<FF, num_selectors>(other)
-        {}
-        Selectors(Selectors&& other)
-        {
-            this->_data = std::move(other._data);
-            this->q_m = std::get<0>(this->_data);
-            this->q_c = std::get<1>(this->_data);
-            this->q_1 = std::get<2>(this->_data);
-            this->q_2 = std::get<3>(this->_data);
-            this->q_3 = std::get<4>(this->_data);
-            this->q_4 = std::get<5>(this->_data);
-            this->q_arith = std::get<6>(this->_data);
-            this->q_sort = std::get<7>(this->_data);
-            this->q_elliptic = std::get<8>(this->_data);
-            this->q_aux = std::get<9>(this->_data);
-            this->q_lookup_type = std::get<10>(this->_data);
-        };
-        Selectors& operator=(Selectors&& other)
-        {
-            SelectorsBase<FF, num_selectors>::operator=(other);
-            return *this;
-        }
-        ~Selectors() = default;
-        // Selectors() = default;
-        // Selectors(const Selectors& other) = default;
-        // Selectors(Selectors&& other) = default;
-        // Selectors& operator=(Selectors const& other) = default;
-        // Selectors& operator=(Selectors&& other) = default;
-        // ~Selectors() = default;
-    };
+    SelectorType& q_m() { return this->selectors[0]; };
+    SelectorType& q_c() { return this->selectors[1]; };
+    SelectorType& q_1() { return this->selectors[2]; };
+    SelectorType& q_2() { return this->selectors[3]; };
+    SelectorType& q_3() { return this->selectors[4]; };
+    SelectorType& q_4() { return this->selectors[5]; };
+    SelectorType& q_arith() { return this->selectors[6]; };
+    SelectorType& q_sort() { return this->selectors[7]; };
+    SelectorType& q_elliptic() { return this->selectors[8]; };
+    SelectorType& q_aux() { return this->selectors[9]; };
+    SelectorType& q_lookup_type() { return this->selectors[10]; };
+
+    Ultra()
+        : Arithmetization<FF>(num_selectors)
+    {}
+
+    const auto& get() const { return this->selectors; };
+
     // Note: These are needed for Plonk only (for poly storage in a std::map). Must be in same order as above struct.
     inline static const std::vector<std::string> selector_names = { "q_m",        "q_c",   "q_1",       "q_2",
                                                                     "q_3",        "q_4",   "q_arith",   "q_sort",
                                                                     "q_elliptic", "q_aux", "table_type" };
 };
-class GoblinTranslator : public Arithmetization</*NUM_WIRES =*/81, /*num_selectors =*/0> {
+
+class GoblinTranslator {
   public:
-    // Dirty hack
-    using Selectors = bool;
-    using FF = curve::BN254::ScalarField;
+    static constexpr size_t NUM_WIRES = 81;
+    static constexpr size_t num_selectors = 0;
 };
 } // namespace arithmetization

--- a/barretenberg/cpp/src/barretenberg/proof_system/arithmetization/arithmetization.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/arithmetization/arithmetization.hpp
@@ -79,6 +79,8 @@ template <typename _FF> class Standard : public Arithmetization</*NUM_WIRES =*/3
         }
         ~Selectors() = default;
     };
+    // Note: These are needed for Plonk only (for poly storage in a std::map). Must be in same order as above struct.
+    inline static const std::vector<std::string> selector_names = { "q_m", "q_1", "q_2", "q_3", "q_c" };
 };
 
 template <typename _FF> class Turbo : public Arithmetization</*NUM_WIRES =*/4, /*num_selectors =*/11> {
@@ -173,6 +175,10 @@ template <typename _FF> class Ultra : public Arithmetization</*NUM_WIRES =*/4, /
         // Selectors& operator=(Selectors&& other) = default;
         // ~Selectors() = default;
     };
+    // Note: These are needed for Plonk only (for poly storage in a std::map). Must be in same order as above struct.
+    inline static const std::vector<std::string> selector_names = { "q_m",        "q_c",   "q_1",       "q_2",
+                                                                    "q_3",        "q_4",   "q_arith",   "q_sort",
+                                                                    "q_elliptic", "q_aux", "table_type" };
 };
 class GoblinTranslator : public Arithmetization</*NUM_WIRES =*/81, /*num_selectors =*/0> {
   public:

--- a/barretenberg/cpp/src/barretenberg/proof_system/arithmetization/arithmetization.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/arithmetization/arithmetization.hpp
@@ -32,11 +32,11 @@ namespace arithmetization {
 
 // These are not magic numbers and they should not be written with global constants. These parameters are not accessible
 // through clearly named static class members.
-template <typename _FF> class Standard {
+template <typename FF_> class Standard {
   public:
     static constexpr size_t NUM_WIRES = 3;
     static constexpr size_t num_selectors = 5;
-    using FF = _FF;
+    using FF = FF_;
     using SelectorType = std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>;
 
     std::vector<SelectorType> selectors;
@@ -64,11 +64,11 @@ template <typename _FF> class Standard {
     inline static const std::vector<std::string> selector_names = { "q_m", "q_1", "q_2", "q_3", "q_c" };
 };
 
-template <typename _FF> class Ultra {
+template <typename FF_> class Ultra {
   public:
     static constexpr size_t NUM_WIRES = 4;
     static constexpr size_t num_selectors = 11;
-    using FF = _FF;
+    using FF = FF_;
     using SelectorType = std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>;
 
     std::vector<SelectorType> selectors;

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/circuit_builder_base.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/circuit_builder_base.cpp
@@ -11,10 +11,10 @@ namespace proof_system {
  * @param b_variable_idx Index of a variable in class b.
  * @param msg Class tag.
  * */
-template <typename Arithmetization>
-void CircuitBuilderBase<Arithmetization>::assert_equal(const uint32_t a_variable_idx,
-                                                       const uint32_t b_variable_idx,
-                                                       std::string const& msg)
+template <typename FF>
+void CircuitBuilderBase<FF>::assert_equal(const uint32_t a_variable_idx,
+                                          const uint32_t b_variable_idx,
+                                          std::string const& msg)
 {
     assert_valid_variables({ a_variable_idx, b_variable_idx });
     bool values_equal = (get_variable(a_variable_idx) == get_variable(b_variable_idx));
@@ -43,8 +43,6 @@ void CircuitBuilderBase<Arithmetization>::assert_equal(const uint32_t a_variable
         real_variable_tags[a_real_idx] = real_variable_tags[b_real_idx];
 }
 // Standard honk/ plonk instantiation
-template class CircuitBuilderBase<arithmetization::Standard<barretenberg::fr>>;
-template class CircuitBuilderBase<arithmetization::Standard<grumpkin::fr>>;
-template class CircuitBuilderBase<arithmetization::Ultra<barretenberg::fr>>;
-template class CircuitBuilderBase<arithmetization::GoblinTranslator>;
+template class CircuitBuilderBase<barretenberg::fr>;
+template class CircuitBuilderBase<grumpkin::fr>;
 } // namespace proof_system

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/circuit_builder_base.hpp
@@ -17,6 +17,9 @@ template <typename FF_> class CircuitBuilderBase {
     using EmbeddedCurve =
         std::conditional_t<std::same_as<FF, barretenberg::g1::coordinate_field>, curve::BN254, curve::Grumpkin>;
 
+    // WORKTODO: hackily defining this here in the base for now. Get acir-bberg test failure otherwise
+    std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, /* max num wires = */ 4> wires;
+
     size_t num_gates = 0;
 
     std::vector<uint32_t> public_inputs;

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/circuit_builder_base.hpp
@@ -18,7 +18,7 @@ template <typename FF_> class CircuitBuilderBase {
         std::conditional_t<std::same_as<FF, barretenberg::g1::coordinate_field>, curve::BN254, curve::Grumpkin>;
 
     // WORKTODO: hackily defining this here in the base for now. Get acir-bberg test failure otherwise
-    std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, /* max num wires = */ 4> wires;
+    // std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, /* max num wires = */ 4> wires;
 
     size_t num_gates = 0;
 

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/circuit_builder_base.hpp
@@ -17,9 +17,6 @@ template <typename FF_> class CircuitBuilderBase {
     using EmbeddedCurve =
         std::conditional_t<std::same_as<FF, barretenberg::g1::coordinate_field>, curve::BN254, curve::Grumpkin>;
 
-    // WORKTODO: hackily defining this here in the base for now. Get acir-bberg test failure otherwise
-    // std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, /* max num wires = */ 4> wires;
-
     size_t num_gates = 0;
 
     std::vector<uint32_t> public_inputs;

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_translator_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_translator_circuit_builder.hpp
@@ -73,12 +73,15 @@ namespace proof_system {
  * microlimb.
  *
  */
-class GoblinTranslatorCircuitBuilder : public CircuitBuilderBase<arithmetization::GoblinTranslator> {
+class GoblinTranslatorCircuitBuilder : public CircuitBuilderBase<barretenberg::fr> {
     // We don't need templating for Goblin
     using Fr = barretenberg::fr;
     using Fq = barretenberg::fq;
+    using Arithmetization = arithmetization::GoblinTranslator;
 
   public:
+    static constexpr size_t NUM_WIRES = Arithmetization::NUM_WIRES;
+
     /**
      * We won't need these standard gates that are defined as virtual in circuit builder base
      *
@@ -324,6 +327,8 @@ class GoblinTranslatorCircuitBuilder : public CircuitBuilderBase<arithmetization
     // The input we evaluate polynomials on
     Fq evaluation_input_x;
 
+    std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, NUM_WIRES> wires;
+
     /**
      * @brief Construct a new Goblin Translator Circuit Builder object
      *
@@ -334,11 +339,11 @@ class GoblinTranslatorCircuitBuilder : public CircuitBuilderBase<arithmetization
      * @param evaluation_input_x_
      */
     GoblinTranslatorCircuitBuilder(Fq batching_challenge_v_, Fq evaluation_input_x_)
-        : CircuitBuilderBase({}, DEFAULT_TRANSLATOR_VM_LENGTH)
+        : CircuitBuilderBase(DEFAULT_TRANSLATOR_VM_LENGTH)
         , batching_challenge_v(batching_challenge_v_)
         , evaluation_input_x(evaluation_input_x_)
     {
-        add_variable(FF::zero());
+        add_variable(Fr::zero());
         for (auto& wire : wires) {
             wire.emplace_back(0);
         }

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_ultra_circuit_builder.cpp
@@ -9,7 +9,7 @@ namespace proof_system {
 
 template <typename FF> void GoblinUltraCircuitBuilder_<FF>::finalize_circuit()
 {
-    UltraCircuitBuilder_<FF>::finalize_circuit();
+    UltraCircuitBuilder_<arithmetization::Ultra<FF>>::finalize_circuit();
 }
 
 /**
@@ -22,7 +22,7 @@ template <typename FF> void GoblinUltraCircuitBuilder_<FF>::finalize_circuit()
 // polynomials is zero, which is required for them to be shiftable.
 template <typename FF> void GoblinUltraCircuitBuilder_<FF>::add_gates_to_ensure_all_polys_are_non_zero()
 {
-    UltraCircuitBuilder_<FF>::add_gates_to_ensure_all_polys_are_non_zero();
+    UltraCircuitBuilder_<arithmetization::Ultra<FF>>::add_gates_to_ensure_all_polys_are_non_zero();
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_ultra_circuit_builder.hpp
@@ -16,12 +16,12 @@ namespace proof_system {
 
 using namespace barretenberg;
 
-template <typename FF> class GoblinUltraCircuitBuilder_ : public UltraCircuitBuilder_<FF> {
+template <typename FF> class GoblinUltraCircuitBuilder_ : public UltraCircuitBuilder_<arithmetization::Ultra<FF>> {
   public:
     static constexpr std::string_view NAME_STRING = "GoblinUltraArithmetization";
     static constexpr CircuitType CIRCUIT_TYPE = CircuitType::ULTRA;
     static constexpr size_t DEFAULT_NON_NATIVE_FIELD_LIMB_BITS =
-        UltraCircuitBuilder_<FF>::DEFAULT_NON_NATIVE_FIELD_LIMB_BITS;
+        UltraCircuitBuilder_<arithmetization::Ultra<FF>>::DEFAULT_NON_NATIVE_FIELD_LIMB_BITS;
 
     size_t num_ecc_op_gates = 0; // number of ecc op "gates" (rows); these are placed at the start of the circuit
 
@@ -56,7 +56,7 @@ template <typename FF> class GoblinUltraCircuitBuilder_ : public UltraCircuitBui
   public:
     GoblinUltraCircuitBuilder_(const size_t size_hint = 0,
                                std::shared_ptr<ECCOpQueue> op_queue_in = std::make_shared<ECCOpQueue>())
-        : UltraCircuitBuilder_<FF>(size_hint)
+        : UltraCircuitBuilder_<arithmetization::Ultra<FF>>(size_hint)
         , op_queue(op_queue_in)
     {
         // Set indices to constants corresponding to Goblin ECC op codes
@@ -86,7 +86,7 @@ template <typename FF> class GoblinUltraCircuitBuilder_ : public UltraCircuitBui
      */
     size_t get_num_gates() const override
     {
-        auto num_ultra_gates = UltraCircuitBuilder_<FF>::get_num_gates();
+        auto num_ultra_gates = UltraCircuitBuilder_<arithmetization::Ultra<FF>>::get_num_gates();
         return num_ultra_gates + num_ecc_op_gates;
     }
 
@@ -101,7 +101,8 @@ template <typename FF> class GoblinUltraCircuitBuilder_ : public UltraCircuitBui
         size_t romcount = 0;
         size_t ramcount = 0;
         size_t nnfcount = 0;
-        UltraCircuitBuilder_<FF>::get_num_gates_split_into_components(count, rangecount, romcount, ramcount, nnfcount);
+        UltraCircuitBuilder_<arithmetization::Ultra<FF>>::get_num_gates_split_into_components(
+            count, rangecount, romcount, ramcount, nnfcount);
 
         size_t total = count + romcount + ramcount + rangecount + num_ecc_op_gates;
         std::cout << "gates = " << total << " (arith " << count << ", rom " << romcount << ", ram " << ramcount

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.cpp
@@ -518,7 +518,7 @@ template <typename FF> bool StandardCircuitBuilder_<FF>::check_circuit()
  */
 template <typename FF> msgpack::sbuffer StandardCircuitBuilder_<FF>::export_circuit()
 {
-    using base = CircuitBuilderBase<arithmetization::Standard<FF>>;
+    using base = CircuitBuilderBase<FF>;
     CircuitSchema cir;
 
     uint64_t modulus[4] = {

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp
@@ -23,15 +23,15 @@ template <typename FF> class StandardCircuitBuilder_ : public CircuitBuilderBase
     static constexpr merkle::HashType merkle_hash_type = merkle::HashType::FIXED_BASE_PEDERSEN;
     static constexpr pedersen::CommitmentType commitment_type = pedersen::CommitmentType::FIXED_BASE_PEDERSEN;
 
-    // std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, NUM_WIRES> wires;
+    std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, NUM_WIRES> wires;
     Arithmetization selectors;
 
     using WireVector = std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>;
     using SelectorVector = std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>;
 
-    WireVector& w_l = std::get<0>(this->wires);
-    WireVector& w_r = std::get<1>(this->wires);
-    WireVector& w_o = std::get<2>(this->wires);
+    WireVector& w_l = std::get<0>(wires);
+    WireVector& w_r = std::get<1>(wires);
+    WireVector& w_o = std::get<2>(wires);
 
     SelectorVector& q_m = this->selectors.q_m();
     SelectorVector& q_1 = this->selectors.q_1();

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp
@@ -71,6 +71,8 @@ template <typename FF> class StandardCircuitBuilder_ : public CircuitBuilderBase
     {
         CircuitBuilderBase<FF>::operator=(std::move(other));
         constant_variable_indices = other.constant_variable_indices;
+        wires = other.wires;
+        selectors = other.selectors;
         return *this;
     };
     ~StandardCircuitBuilder_() override = default;

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp
@@ -24,7 +24,7 @@ template <typename FF> class StandardCircuitBuilder_ : public CircuitBuilderBase
     static constexpr pedersen::CommitmentType commitment_type = pedersen::CommitmentType::FIXED_BASE_PEDERSEN;
 
     std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, NUM_WIRES> wires;
-    typename Arithmetization::Selectors selectors;
+    Arithmetization selectors;
 
     using WireVector = std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>;
     using SelectorVector = std::vector<FF, barretenberg::ContainerSlabAllocator<FF>>;
@@ -33,11 +33,11 @@ template <typename FF> class StandardCircuitBuilder_ : public CircuitBuilderBase
     WireVector& w_r = std::get<1>(this->wires);
     WireVector& w_o = std::get<2>(this->wires);
 
-    SelectorVector& q_m = this->selectors.q_m;
-    SelectorVector& q_1 = this->selectors.q_1;
-    SelectorVector& q_2 = this->selectors.q_2;
-    SelectorVector& q_3 = this->selectors.q_3;
-    SelectorVector& q_c = this->selectors.q_c;
+    SelectorVector& q_m = this->selectors.q_m();
+    SelectorVector& q_1 = this->selectors.q_1();
+    SelectorVector& q_2 = this->selectors.q_2();
+    SelectorVector& q_3 = this->selectors.q_3();
+    SelectorVector& q_c = this->selectors.q_c();
 
     static constexpr size_t UINT_LOG2_BASE = 2;
 
@@ -49,9 +49,7 @@ template <typename FF> class StandardCircuitBuilder_ : public CircuitBuilderBase
     StandardCircuitBuilder_(const size_t size_hint = 0)
         : CircuitBuilderBase<FF>(size_hint)
     {
-        for (auto& p : selectors) {
-            p.reserve(size_hint);
-        }
+        selectors.reserve(size_hint);
         w_l.reserve(size_hint);
         w_r.reserve(size_hint);
         w_o.reserve(size_hint);

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp
@@ -23,7 +23,7 @@ template <typename FF> class StandardCircuitBuilder_ : public CircuitBuilderBase
     static constexpr merkle::HashType merkle_hash_type = merkle::HashType::FIXED_BASE_PEDERSEN;
     static constexpr pedersen::CommitmentType commitment_type = pedersen::CommitmentType::FIXED_BASE_PEDERSEN;
 
-    std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, NUM_WIRES> wires;
+    // std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, NUM_WIRES> wires;
     Arithmetization selectors;
 
     using WireVector = std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>;

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.cpp
@@ -2678,21 +2678,22 @@ template <typename Arithmetization> void UltraCircuitBuilder_<Arithmetization>::
  * @return fr
  */
 template <typename Arithmetization>
-inline Arithmetization::FF UltraCircuitBuilder_<Arithmetization>::compute_arithmetic_identity(FF q_arith_value,
-                                                                                              FF q_1_value,
-                                                                                              FF q_2_value,
-                                                                                              FF q_3_value,
-                                                                                              FF q_4_value,
-                                                                                              FF q_m_value,
-                                                                                              FF q_c_value,
-                                                                                              FF w_1_value,
-                                                                                              FF w_2_value,
-                                                                                              FF w_3_value,
-                                                                                              FF w_4_value,
-                                                                                              FF w_1_shifted_value,
-                                                                                              FF w_4_shifted_value,
-                                                                                              FF alpha_base,
-                                                                                              FF alpha) const
+inline typename Arithmetization::FF UltraCircuitBuilder_<Arithmetization>::compute_arithmetic_identity(
+    FF q_arith_value,
+    FF q_1_value,
+    FF q_2_value,
+    FF q_3_value,
+    FF q_4_value,
+    FF q_m_value,
+    FF q_c_value,
+    FF w_1_value,
+    FF w_2_value,
+    FF w_3_value,
+    FF w_4_value,
+    FF w_1_shifted_value,
+    FF w_4_shifted_value,
+    FF alpha_base,
+    FF alpha) const
 {
     constexpr FF neg_half = FF(-2).invert();
     // The main arithmetic identity that gets activated for q_arith_value == 1
@@ -2743,14 +2744,15 @@ inline Arithmetization::FF UltraCircuitBuilder_<Arithmetization>::compute_arithm
  * @return fr
  */
 template <typename Arithmetization>
-inline Arithmetization::FF UltraCircuitBuilder_<Arithmetization>::compute_genperm_sort_identity(FF q_sort_value,
-                                                                                                FF w_1_value,
-                                                                                                FF w_2_value,
-                                                                                                FF w_3_value,
-                                                                                                FF w_4_value,
-                                                                                                FF w_1_shifted_value,
-                                                                                                FF alpha_base,
-                                                                                                FF alpha) const
+inline typename Arithmetization::FF UltraCircuitBuilder_<Arithmetization>::compute_genperm_sort_identity(
+    FF q_sort_value,
+    FF w_1_value,
+    FF w_2_value,
+    FF w_3_value,
+    FF w_4_value,
+    FF w_1_shifted_value,
+    FF alpha_base,
+    FF alpha) const
 {
     // Power of alpha to separate individual delta relations
     // TODO(kesha): This is a repeated computation which can be efficiently optimized
@@ -2802,17 +2804,18 @@ inline Arithmetization::FF UltraCircuitBuilder_<Arithmetization>::compute_genper
  * @return fr
  */
 template <typename Arithmetization>
-inline Arithmetization::FF UltraCircuitBuilder_<Arithmetization>::compute_elliptic_identity(FF q_elliptic_value,
-                                                                                            FF q_1_value,
-                                                                                            FF q_m_value,
-                                                                                            FF w_2_value,
-                                                                                            FF w_3_value,
-                                                                                            FF w_1_shifted_value,
-                                                                                            FF w_2_shifted_value,
-                                                                                            FF w_3_shifted_value,
-                                                                                            FF w_4_shifted_value,
-                                                                                            FF alpha_base,
-                                                                                            FF alpha) const
+inline typename Arithmetization::FF UltraCircuitBuilder_<Arithmetization>::compute_elliptic_identity(
+    FF q_elliptic_value,
+    FF q_1_value,
+    FF q_m_value,
+    FF w_2_value,
+    FF w_3_value,
+    FF w_1_shifted_value,
+    FF w_2_shifted_value,
+    FF w_3_shifted_value,
+    FF w_4_shifted_value,
+    FF alpha_base,
+    FF alpha) const
 {
     const FF x_1 = w_2_value;
     const FF y_1 = w_3_value;
@@ -2885,25 +2888,26 @@ inline Arithmetization::FF UltraCircuitBuilder_<Arithmetization>::compute_ellipt
  */
 
 template <typename Arithmetization>
-inline Arithmetization::FF UltraCircuitBuilder_<Arithmetization>::compute_auxilary_identity(FF q_aux_value,
-                                                                                            FF q_arith_value,
-                                                                                            FF q_1_value,
-                                                                                            FF q_2_value,
-                                                                                            FF q_3_value,
-                                                                                            FF q_4_value,
-                                                                                            FF q_m_value,
-                                                                                            FF q_c_value,
-                                                                                            FF w_1_value,
-                                                                                            FF w_2_value,
-                                                                                            FF w_3_value,
-                                                                                            FF w_4_value,
-                                                                                            FF w_1_shifted_value,
-                                                                                            FF w_2_shifted_value,
-                                                                                            FF w_3_shifted_value,
-                                                                                            FF w_4_shifted_value,
-                                                                                            FF alpha_base,
-                                                                                            FF alpha,
-                                                                                            FF eta) const
+inline typename Arithmetization::FF UltraCircuitBuilder_<Arithmetization>::compute_auxilary_identity(
+    FF q_aux_value,
+    FF q_arith_value,
+    FF q_1_value,
+    FF q_2_value,
+    FF q_3_value,
+    FF q_4_value,
+    FF q_m_value,
+    FF q_c_value,
+    FF w_1_value,
+    FF w_2_value,
+    FF w_3_value,
+    FF w_4_value,
+    FF w_1_shifted_value,
+    FF w_2_shifted_value,
+    FF w_3_shifted_value,
+    FF w_4_shifted_value,
+    FF alpha_base,
+    FF alpha,
+    FF eta) const
 {
     constexpr FF LIMB_SIZE(uint256_t(1) << DEFAULT_NON_NATIVE_FIELD_LIMB_BITS);
     // TODO(kesha): Replace with a constant defined in header

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.cpp
@@ -14,7 +14,7 @@ using namespace barretenberg;
 
 namespace proof_system {
 
-template <typename FF> void UltraCircuitBuilder_<FF>::finalize_circuit()
+template <typename Arithmetization> void UltraCircuitBuilder_<Arithmetization>::finalize_circuit()
 {
     /**
      * First of all, add the gates related to ROM arrays and range lists.
@@ -58,7 +58,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::finalize_circuit()
 // TODO(#423): This function adds valid (but arbitrary) gates to ensure that the circuit which includes
 // them will not result in any zero-polynomials. It also ensures that the first coefficient of the wire
 // polynomials is zero, which is required for them to be shiftable.
-template <typename FF> void UltraCircuitBuilder_<FF>::add_gates_to_ensure_all_polys_are_non_zero()
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::add_gates_to_ensure_all_polys_are_non_zero()
 {
     // First add a gate to simultaneously ensure first entries of all wires is zero and to add a non
     // zero value to all selectors aside from q_c and q_lookup
@@ -117,7 +118,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::add_gates_to_ensure_all_po
  *
  * @param in A structure with variable indexes and selector values for the gate.
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_add_gate(const add_triple_<FF>& in)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_add_gate(const add_triple_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c });
 
@@ -147,8 +149,9 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_add_gate(const add_
  * @param in Structure with variable indexes and wire selector values
  * @param include_next_gate_w_4 Switches on/off the addition of w_4 at the next index
  */
-template <typename FF>
-void UltraCircuitBuilder_<FF>::create_big_add_gate(const add_quad_<FF>& in, const bool include_next_gate_w_4)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_big_add_gate(const add_quad_<FF>& in,
+                                                                const bool include_next_gate_w_4)
 {
     this->assert_valid_variables({ in.a, in.b, in.c, in.d });
     w_l.emplace_back(in.a);
@@ -175,7 +178,8 @@ void UltraCircuitBuilder_<FF>::create_big_add_gate(const add_quad_<FF>& in, cons
  *
  * @param in Structure with variables and witness selector values
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_big_add_gate_with_bit_extraction(const add_quad_<FF>& in)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_big_add_gate_with_bit_extraction(const add_quad_<FF>& in)
 {
     // This method is an artifact of a turbo plonk feature that implicitly extracts
     // a high or low bit from a base-4 quad and adds it into the arithmetic gate relationship.
@@ -238,7 +242,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_big_add_gate_with_b
  *
  * @param in Structure containing variables and witness selectors
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_big_mul_gate(const mul_quad_<FF>& in)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_big_mul_gate(const mul_quad_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c, in.d });
 
@@ -262,7 +267,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_big_mul_gate(const 
 
 // Creates a width-4 addition gate, where the fourth witness must be a boolean.
 // Can be used to normalize a 32-bit addition
-template <typename FF> void UltraCircuitBuilder_<FF>::create_balanced_add_gate(const add_quad_<FF>& in)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_balanced_add_gate(const add_quad_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c, in.d });
 
@@ -302,7 +308,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_balanced_add_gate(c
  *
  * @param in Structure containing variables and witness selectors
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_mul_gate(const mul_triple_<FF>& in)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_mul_gate(const mul_triple_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c });
 
@@ -328,7 +335,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_mul_gate(const mul_
  *
  * @param variable_index the variable which needs to be constrained
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_bool_gate(const uint32_t variable_index)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_bool_gate(const uint32_t variable_index)
 {
     this->assert_valid_variables({ variable_index });
 
@@ -357,7 +365,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_bool_gate(const uin
  *
  * @param in Structure containing variables and witness selectors
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_poly_gate(const poly_triple_<FF>& in)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_poly_gate(const poly_triple_<FF>& in)
 {
     this->assert_valid_variables({ in.a, in.b, in.c });
 
@@ -388,7 +397,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_poly_gate(const pol
  * @param in Elliptic curve point addition gate parameters, including the the affine coordinates of the two points being
  * added, the resulting point coordinates and the selector values that describe whether the second point is negated.
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_ecc_add_gate(const ecc_add_gate_<FF>& in)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_ecc_add_gate(const ecc_add_gate_<FF>& in)
 {
     /**
      * gate structure:
@@ -454,7 +464,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_ecc_add_gate(const 
  *
  * @param in Elliptic curve point doubling gate parameters
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_ecc_dbl_gate(const ecc_dbl_gate_<FF>& in)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_ecc_dbl_gate(const ecc_dbl_gate_<FF>& in)
 {
     /**
      * gate structure:
@@ -517,7 +528,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_ecc_dbl_gate(const 
  * @param witness_index The index of the witness we are fixing
  * @param witness_value The value we are fixing it to
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::fix_witness(const uint32_t witness_index, const FF& witness_value)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::fix_witness(const uint32_t witness_index, const FF& witness_value)
 {
     this->assert_valid_variables({ witness_index });
 
@@ -539,7 +551,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::fix_witness(const uint32_t
     ++this->num_gates;
 }
 
-template <typename FF> uint32_t UltraCircuitBuilder_<FF>::put_constant_variable(const FF& variable)
+template <typename Arithmetization>
+uint32_t UltraCircuitBuilder_<Arithmetization>::put_constant_variable(const FF& variable)
 {
     if (constant_variable_indices.contains(variable)) {
         return constant_variable_indices.at(variable);
@@ -551,7 +564,8 @@ template <typename FF> uint32_t UltraCircuitBuilder_<FF>::put_constant_variable(
     }
 }
 
-template <typename FF> plookup::BasicTable& UltraCircuitBuilder_<FF>::get_table(const plookup::BasicTableId id)
+template <typename Arithmetization>
+plookup::BasicTable& UltraCircuitBuilder_<Arithmetization>::get_table(const plookup::BasicTableId id)
 {
     for (plookup::BasicTable& table : lookup_tables) {
         if (table.id == id) {
@@ -567,8 +581,8 @@ template <typename FF> plookup::BasicTable& UltraCircuitBuilder_<FF>::get_table(
  * @brief Perform a series of lookups, one for each 'row' in read_values.
  */
 
-template <typename FF>
-plookup::ReadData<uint32_t> UltraCircuitBuilder_<FF>::create_gates_from_plookup_accumulators(
+template <typename Arithmetization>
+plookup::ReadData<uint32_t> UltraCircuitBuilder_<Arithmetization>::create_gates_from_plookup_accumulators(
     const plookup::MultiTableId& id,
     const plookup::ReadData<FF>& read_values,
     const uint32_t key_a_index,
@@ -616,8 +630,9 @@ plookup::ReadData<uint32_t> UltraCircuitBuilder_<FF>::create_gates_from_plookup_
 /**
  * Generalized Permutation Methods
  **/
-template <typename FF>
-typename UltraCircuitBuilder_<FF>::RangeList UltraCircuitBuilder_<FF>::create_range_list(const uint64_t target_range)
+template <typename Arithmetization>
+typename UltraCircuitBuilder_<Arithmetization>::RangeList UltraCircuitBuilder_<Arithmetization>::create_range_list(
+    const uint64_t target_range)
 {
     RangeList result;
     const auto range_tag = get_new_tag(); // current_tag + 1;
@@ -649,11 +664,9 @@ typename UltraCircuitBuilder_<FF>::RangeList UltraCircuitBuilder_<FF>::create_ra
 
 // range constraint a value by decomposing it into limbs whose size should be the default range constraint size
 
-template <typename FF>
-std::vector<uint32_t> UltraCircuitBuilder_<FF>::decompose_into_default_range(const uint32_t variable_index,
-                                                                             const uint64_t num_bits,
-                                                                             const uint64_t target_range_bitnum,
-                                                                             std::string const& msg)
+template <typename Arithmetization>
+std::vector<uint32_t> UltraCircuitBuilder_<Arithmetization>::decompose_into_default_range(
+    const uint32_t variable_index, const uint64_t num_bits, const uint64_t target_range_bitnum, std::string const& msg)
 {
     this->assert_valid_variables({ variable_index });
 
@@ -764,10 +777,10 @@ std::vector<uint32_t> UltraCircuitBuilder_<FF>::decompose_into_default_range(con
  * @param variable_index
  * @param target_range
  */
-template <typename FF>
-void UltraCircuitBuilder_<FF>::create_new_range_constraint(const uint32_t variable_index,
-                                                           const uint64_t target_range,
-                                                           std::string const msg)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_new_range_constraint(const uint32_t variable_index,
+                                                                        const uint64_t target_range,
+                                                                        std::string const msg)
 {
     if (uint256_t(this->get_variable(variable_index)).data[0] > target_range) {
         if (!this->failed()) {
@@ -818,7 +831,7 @@ void UltraCircuitBuilder_<FF>::create_new_range_constraint(const uint32_t variab
     }
 }
 
-template <typename FF> void UltraCircuitBuilder_<FF>::process_range_list(RangeList& list)
+template <typename Arithmetization> void UltraCircuitBuilder_<Arithmetization>::process_range_list(RangeList& list)
 {
     this->assert_valid_variables(list.variable_indices);
 
@@ -872,7 +885,7 @@ template <typename FF> void UltraCircuitBuilder_<FF>::process_range_list(RangeLi
     create_sort_constraint_with_edges(indices, 0, list.target_range);
 }
 
-template <typename FF> void UltraCircuitBuilder_<FF>::process_range_lists()
+template <typename Arithmetization> void UltraCircuitBuilder_<Arithmetization>::process_range_lists()
 {
     for (auto& i : range_lists) {
         process_range_list(i.second);
@@ -892,8 +905,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::process_range_lists()
   * std::map<uint64_t, RangeList> range_lists;
 */
 // Check for a sequence of variables that neighboring differences are at most 3 (used for batched range checkj)
-template <typename FF>
-void UltraCircuitBuilder_<FF>::create_sort_constraint(const std::vector<uint32_t>& variable_index)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_sort_constraint(const std::vector<uint32_t>& variable_index)
 {
     constexpr size_t gate_width = plonk::ultra_settings::program_width;
     ASSERT(variable_index.size() % gate_width == 0);
@@ -939,8 +952,8 @@ void UltraCircuitBuilder_<FF>::create_sort_constraint(const std::vector<uint32_t
 
 // useful to put variables in the witness that aren't already used - e.g. the dummy variables of the range constraint in
 // multiples of three
-template <typename FF>
-void UltraCircuitBuilder_<FF>::create_dummy_constraints(const std::vector<uint32_t>& variable_index)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_dummy_constraints(const std::vector<uint32_t>& variable_index)
 {
     std::vector<uint32_t> padded_list = variable_index;
     constexpr size_t gate_width = plonk::ultra_settings::program_width;
@@ -972,10 +985,9 @@ void UltraCircuitBuilder_<FF>::create_dummy_constraints(const std::vector<uint32
 }
 
 // Check for a sequence of variables that neighboring differences are at most 3 (used for batched range checks)
-template <typename FF>
-void UltraCircuitBuilder_<FF>::create_sort_constraint_with_edges(const std::vector<uint32_t>& variable_index,
-                                                                 const FF& start,
-                                                                 const FF& end)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_sort_constraint_with_edges(
+    const std::vector<uint32_t>& variable_index, const FF& start, const FF& end)
 {
     // Convenient to assume size is at least 8 (gate_width = 4) for separate gates for start and end conditions
     constexpr size_t gate_width = plonk::ultra_settings::program_width;
@@ -1061,8 +1073,8 @@ void UltraCircuitBuilder_<FF>::create_sort_constraint_with_edges(const std::vect
 
 // range constraint a value by decomposing it into limbs whose size should be the default range constraint size
 
-template <typename FF>
-std::vector<uint32_t> UltraCircuitBuilder_<FF>::decompose_into_default_range_better_for_oddlimbnum(
+template <typename Arithmetization>
+std::vector<uint32_t> UltraCircuitBuilder_<Arithmetization>::decompose_into_default_range_better_for_oddlimbnum(
     const uint32_t variable_index, const size_t num_bits, std::string const& msg)
 {
     std::vector<uint32_t> sums;
@@ -1156,7 +1168,8 @@ std::vector<uint32_t> UltraCircuitBuilder_<FF>::decompose_into_default_range_bet
  *
  * @param type
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::apply_aux_selectors(const AUX_SELECTORS type)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::apply_aux_selectors(const AUX_SELECTORS type)
 {
     q_aux.emplace_back(type == AUX_SELECTORS::NONE ? 0 : 1);
     q_sort.emplace_back(0);
@@ -1316,11 +1329,11 @@ template <typename FF> void UltraCircuitBuilder_<FF>::apply_aux_selectors(const 
  * Applies range constraints to two 70-bit limbs, splititng each into 5 14-bit sublimbs.
  * We can efficiently chain together two 70-bit limb checks in 3 gates, using auxiliary gates
  **/
-template <typename FF>
-void UltraCircuitBuilder_<FF>::range_constrain_two_limbs(const uint32_t lo_idx,
-                                                         const uint32_t hi_idx,
-                                                         const size_t lo_limb_bits,
-                                                         const size_t hi_limb_bits)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::range_constrain_two_limbs(const uint32_t lo_idx,
+                                                                      const uint32_t hi_idx,
+                                                                      const size_t lo_limb_bits,
+                                                                      const size_t hi_limb_bits)
 {
     // Validate limbs are <= 70 bits. If limbs are larger we require more witnesses and cannot use our limb accumulation
     // custom gate
@@ -1407,8 +1420,8 @@ void UltraCircuitBuilder_<FF>::range_constrain_two_limbs(const uint32_t lo_idx,
  * @return std::array<uint32_t, 2> The indices of new limbs.
  */
 
-template <typename FF>
-std::array<uint32_t, 2> UltraCircuitBuilder_<FF>::decompose_non_native_field_double_width_limb(
+template <typename Arithmetization>
+std::array<uint32_t, 2> UltraCircuitBuilder_<Arithmetization>::decompose_non_native_field_double_width_limb(
     const uint32_t limb_idx, const size_t num_limb_bits)
 {
     ASSERT(uint256_t(this->get_variable_reference(limb_idx)) < (uint256_t(1) << num_limb_bits));
@@ -1446,8 +1459,8 @@ std::array<uint32_t, 2> UltraCircuitBuilder_<FF>::decompose_non_native_field_dou
  * N.B.: This method does NOT evaluate the prime field component of non-native field multiplications.
  **/
 
-template <typename FF>
-std::array<uint32_t, 2> UltraCircuitBuilder_<FF>::evaluate_non_native_field_multiplication(
+template <typename Arithmetization>
+std::array<uint32_t, 2> UltraCircuitBuilder_<Arithmetization>::evaluate_non_native_field_multiplication(
     const non_native_field_witnesses& input, const bool range_constrain_quotient_and_remainder)
 {
 
@@ -1609,7 +1622,8 @@ std::array<uint32_t, 2> UltraCircuitBuilder_<FF>::evaluate_non_native_field_mult
  * Iterates over the cached_non_native_field_multiplication objects,
  * removes duplicates, and instantiates the remainder as constraints`
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::process_non_native_field_multiplications()
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::process_non_native_field_multiplications()
 {
     for (size_t i = 0; i < cached_partial_non_native_field_multiplications.size(); ++i) {
         auto& c = cached_partial_non_native_field_multiplications[i];
@@ -1666,8 +1680,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::process_non_native_field_m
  *
  **/
 
-template <typename FF>
-std::array<uint32_t, 2> UltraCircuitBuilder_<FF>::queue_partial_non_native_field_multiplication(
+template <typename Arithmetization>
+std::array<uint32_t, 2> UltraCircuitBuilder_<Arithmetization>::queue_partial_non_native_field_multiplication(
     const non_native_field_witnesses& input)
 {
 
@@ -1713,8 +1727,8 @@ std::array<uint32_t, 2> UltraCircuitBuilder_<FF>::queue_partial_non_native_field
  * field elements in 4 gates (would normally take 5)
  **/
 
-template <typename FF>
-std::array<uint32_t, 5> UltraCircuitBuilder_<FF>::evaluate_non_native_field_addition(
+template <typename Arithmetization>
+std::array<uint32_t, 5> UltraCircuitBuilder_<Arithmetization>::evaluate_non_native_field_addition(
     add_simple limb0, add_simple limb1, add_simple limb2, add_simple limb3, std::tuple<uint32_t, uint32_t, FF> limbp)
 {
     const auto& x_0 = std::get<0>(limb0).first;
@@ -1836,8 +1850,8 @@ std::array<uint32_t, 5> UltraCircuitBuilder_<FF>::evaluate_non_native_field_addi
     };
 }
 
-template <typename FF>
-std::array<uint32_t, 5> UltraCircuitBuilder_<FF>::evaluate_non_native_field_subtraction(
+template <typename Arithmetization>
+std::array<uint32_t, 5> UltraCircuitBuilder_<Arithmetization>::evaluate_non_native_field_subtraction(
     add_simple limb0, add_simple limb1, add_simple limb2, add_simple limb3, std::tuple<uint32_t, uint32_t, FF> limbp)
 {
     const auto& x_0 = std::get<0>(limb0).first;
@@ -1964,7 +1978,7 @@ std::array<uint32_t, 5> UltraCircuitBuilder_<FF>::evaluate_non_native_field_subt
  *
  * @param record Stores details of this read operation. Mutated by this fn!
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_ROM_gate(RomRecord& record)
+template <typename Arithmetization> void UltraCircuitBuilder_<Arithmetization>::create_ROM_gate(RomRecord& record)
 {
     // Record wire value can't yet be computed
     record.record_witness = this->add_variable(0);
@@ -1984,7 +1998,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_ROM_gate(RomRecord&
  *
  * @param record Stores details of this read operation. Mutated by this fn!
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_sorted_ROM_gate(RomRecord& record)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_sorted_ROM_gate(RomRecord& record)
 {
     record.record_witness = this->add_variable(0);
     apply_aux_selectors(AUX_SELECTORS::ROM_CONSISTENCY_CHECK);
@@ -2007,7 +2022,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_sorted_ROM_gate(Rom
  * @return size_t The index of the element
  */
 
-template <typename FF> size_t UltraCircuitBuilder_<FF>::create_ROM_array(const size_t array_size)
+template <typename Arithmetization>
+size_t UltraCircuitBuilder_<Arithmetization>::create_ROM_array(const size_t array_size)
 {
     RomTranscript new_transcript;
     for (size_t i = 0; i < array_size; ++i) {
@@ -2024,7 +2040,7 @@ template <typename FF> size_t UltraCircuitBuilder_<FF>::create_ROM_array(const s
  *
  * @param record Stores details of this read operation. Mutated by this fn!
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_RAM_gate(RamRecord& record)
+template <typename Arithmetization> void UltraCircuitBuilder_<Arithmetization>::create_RAM_gate(RamRecord& record)
 {
     // Record wire value can't yet be computed (uses randomnes generated during proof construction).
     // However it needs a distinct witness index,
@@ -2049,7 +2065,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_RAM_gate(RamRecord&
  *
  * @param record Stores details of this read operation. Mutated by this fn!
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::create_sorted_RAM_gate(RamRecord& record)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_sorted_RAM_gate(RamRecord& record)
 {
     record.record_witness = this->add_variable(0);
     apply_aux_selectors(AUX_SELECTORS::RAM_CONSISTENCY_CHECK);
@@ -2067,8 +2084,8 @@ template <typename FF> void UltraCircuitBuilder_<FF>::create_sorted_RAM_gate(Ram
  *
  * @param record Stores details of this read operation. Mutated by this fn!
  */
-template <typename FF>
-void UltraCircuitBuilder_<FF>::create_final_sorted_RAM_gate(RamRecord& record, const size_t ram_array_size)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::create_final_sorted_RAM_gate(RamRecord& record, const size_t ram_array_size)
 {
     record.record_witness = this->add_variable(0);
     record.gate_index = this->num_gates;
@@ -2096,7 +2113,8 @@ void UltraCircuitBuilder_<FF>::create_final_sorted_RAM_gate(RamRecord& record, c
  * @param array_size The size of region in elements
  * @return size_t The index of the element
  */
-template <typename FF> size_t UltraCircuitBuilder_<FF>::create_RAM_array(const size_t array_size)
+template <typename Arithmetization>
+size_t UltraCircuitBuilder_<Arithmetization>::create_RAM_array(const size_t array_size)
 {
     RamTranscript new_transcript;
     for (size_t i = 0; i < array_size; ++i) {
@@ -2113,10 +2131,10 @@ template <typename FF> size_t UltraCircuitBuilder_<FF>::create_RAM_array(const s
  * @param index_value The index of the cell within the array (an actual index, not a witness index)
  * @param value_witness The index of the witness with the value that should be in the
  */
-template <typename FF>
-void UltraCircuitBuilder_<FF>::init_RAM_element(const size_t ram_id,
-                                                const size_t index_value,
-                                                const uint32_t value_witness)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::init_RAM_element(const size_t ram_id,
+                                                             const size_t index_value,
+                                                             const uint32_t value_witness)
 {
     ASSERT(ram_arrays.size() > ram_id);
     RamTranscript& ram_array = ram_arrays[ram_id];
@@ -2137,8 +2155,8 @@ void UltraCircuitBuilder_<FF>::init_RAM_element(const size_t ram_id,
     ram_array.records.emplace_back(new_record);
 }
 
-template <typename FF>
-uint32_t UltraCircuitBuilder_<FF>::read_RAM_array(const size_t ram_id, const uint32_t index_witness)
+template <typename Arithmetization>
+uint32_t UltraCircuitBuilder_<Arithmetization>::read_RAM_array(const size_t ram_id, const uint32_t index_witness)
 {
     ASSERT(ram_arrays.size() > ram_id);
     RamTranscript& ram_array = ram_arrays[ram_id];
@@ -2166,10 +2184,10 @@ uint32_t UltraCircuitBuilder_<FF>::read_RAM_array(const size_t ram_id, const uin
     return value_witness;
 }
 
-template <typename FF>
-void UltraCircuitBuilder_<FF>::write_RAM_array(const size_t ram_id,
-                                               const uint32_t index_witness,
-                                               const uint32_t value_witness)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::write_RAM_array(const size_t ram_id,
+                                                            const uint32_t index_witness,
+                                                            const uint32_t value_witness)
 {
     ASSERT(ram_arrays.size() > ram_id);
     RamTranscript& ram_array = ram_arrays[ram_id];
@@ -2209,10 +2227,10 @@ void UltraCircuitBuilder_<FF>::write_RAM_array(const size_t ram_id,
  * @param index_value The index of the cell within the array (an actual index, not a witness index)
  * @param value_witness The index of the witness with the value that should be in the
  */
-template <typename FF>
-void UltraCircuitBuilder_<FF>::set_ROM_element(const size_t rom_id,
-                                               const size_t index_value,
-                                               const uint32_t value_witness)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::set_ROM_element(const size_t rom_id,
+                                                            const size_t index_value,
+                                                            const uint32_t value_witness)
 {
     ASSERT(rom_arrays.size() > rom_id);
     RomTranscript& rom_array = rom_arrays[rom_id];
@@ -2252,10 +2270,10 @@ void UltraCircuitBuilder_<FF>::set_ROM_element(const size_t rom_id,
  * @param index_value Index in the array
  * @param value_witnesses The witnesses to put in the slot
  */
-template <typename FF>
-void UltraCircuitBuilder_<FF>::set_ROM_element_pair(const size_t rom_id,
-                                                    const size_t index_value,
-                                                    const std::array<uint32_t, 2>& value_witnesses)
+template <typename Arithmetization>
+void UltraCircuitBuilder_<Arithmetization>::set_ROM_element_pair(const size_t rom_id,
+                                                                 const size_t index_value,
+                                                                 const std::array<uint32_t, 2>& value_witnesses)
 {
     ASSERT(rom_arrays.size() > rom_id);
     RomTranscript& rom_array = rom_arrays[rom_id];
@@ -2283,8 +2301,8 @@ void UltraCircuitBuilder_<FF>::set_ROM_element_pair(const size_t rom_id,
  * @param index_witness The witness with the index inside the array
  * @return uint32_t Cell value witness index
  */
-template <typename FF>
-uint32_t UltraCircuitBuilder_<FF>::read_ROM_array(const size_t rom_id, const uint32_t index_witness)
+template <typename Arithmetization>
+uint32_t UltraCircuitBuilder_<Arithmetization>::read_ROM_array(const size_t rom_id, const uint32_t index_witness)
 {
     ASSERT(rom_arrays.size() > rom_id);
     RomTranscript& rom_array = rom_arrays[rom_id];
@@ -2316,8 +2334,9 @@ uint32_t UltraCircuitBuilder_<FF>::read_ROM_array(const size_t rom_id, const uin
  * @return std::array<uint32_t, 2> A pair of indexes of witness variables of cell values
  */
 
-template <typename FF>
-std::array<uint32_t, 2> UltraCircuitBuilder_<FF>::read_ROM_array_pair(const size_t rom_id, const uint32_t index_witness)
+template <typename Arithmetization>
+std::array<uint32_t, 2> UltraCircuitBuilder_<Arithmetization>::read_ROM_array_pair(const size_t rom_id,
+                                                                                   const uint32_t index_witness)
 {
     std::array<uint32_t, 2> value_witnesses;
 
@@ -2352,7 +2371,7 @@ std::array<uint32_t, 2> UltraCircuitBuilder_<FF>::read_ROM_array_pair(const size
  * @param rom_id The id of the ROM table
  * @param gate_offset_from_public_inputs Required to track the gate position of where we're adding extra gates
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::process_ROM_array(const size_t rom_id)
+template <typename Arithmetization> void UltraCircuitBuilder_<Arithmetization>::process_ROM_array(const size_t rom_id)
 {
 
     auto& rom_array = rom_arrays[rom_id];
@@ -2438,7 +2457,7 @@ template <typename FF> void UltraCircuitBuilder_<FF>::process_ROM_array(const si
  * @param ram_id The id of the RAM table
  * @param gate_offset_from_public_inputs Required to track the gate position of where we're adding extra gates
  */
-template <typename FF> void UltraCircuitBuilder_<FF>::process_RAM_array(const size_t ram_id)
+template <typename Arithmetization> void UltraCircuitBuilder_<Arithmetization>::process_RAM_array(const size_t ram_id)
 {
     RamTranscript& ram_array = ram_arrays[ram_id];
     const auto access_tag = get_new_tag();      // current_tag + 1;
@@ -2578,13 +2597,13 @@ template <typename FF> void UltraCircuitBuilder_<FF>::process_RAM_array(const si
     }
 }
 
-template <typename FF> void UltraCircuitBuilder_<FF>::process_ROM_arrays()
+template <typename Arithmetization> void UltraCircuitBuilder_<Arithmetization>::process_ROM_arrays()
 {
     for (size_t i = 0; i < rom_arrays.size(); ++i) {
         process_ROM_array(i);
     }
 }
-template <typename FF> void UltraCircuitBuilder_<FF>::process_RAM_arrays()
+template <typename Arithmetization> void UltraCircuitBuilder_<Arithmetization>::process_RAM_arrays()
 {
     for (size_t i = 0; i < ram_arrays.size(); ++i) {
         process_RAM_array(i);
@@ -2658,22 +2677,22 @@ template <typename FF> void UltraCircuitBuilder_<FF>::process_RAM_arrays()
  * @param alpha
  * @return fr
  */
-template <typename FF>
-inline FF UltraCircuitBuilder_<FF>::compute_arithmetic_identity(FF q_arith_value,
-                                                                FF q_1_value,
-                                                                FF q_2_value,
-                                                                FF q_3_value,
-                                                                FF q_4_value,
-                                                                FF q_m_value,
-                                                                FF q_c_value,
-                                                                FF w_1_value,
-                                                                FF w_2_value,
-                                                                FF w_3_value,
-                                                                FF w_4_value,
-                                                                FF w_1_shifted_value,
-                                                                FF w_4_shifted_value,
-                                                                FF alpha_base,
-                                                                FF alpha) const
+template <typename Arithmetization>
+inline Arithmetization::FF UltraCircuitBuilder_<Arithmetization>::compute_arithmetic_identity(FF q_arith_value,
+                                                                                              FF q_1_value,
+                                                                                              FF q_2_value,
+                                                                                              FF q_3_value,
+                                                                                              FF q_4_value,
+                                                                                              FF q_m_value,
+                                                                                              FF q_c_value,
+                                                                                              FF w_1_value,
+                                                                                              FF w_2_value,
+                                                                                              FF w_3_value,
+                                                                                              FF w_4_value,
+                                                                                              FF w_1_shifted_value,
+                                                                                              FF w_4_shifted_value,
+                                                                                              FF alpha_base,
+                                                                                              FF alpha) const
 {
     constexpr FF neg_half = FF(-2).invert();
     // The main arithmetic identity that gets activated for q_arith_value == 1
@@ -2723,15 +2742,15 @@ inline FF UltraCircuitBuilder_<FF>::compute_arithmetic_identity(FF q_arith_value
  * @param alpha
  * @return fr
  */
-template <typename FF>
-inline FF UltraCircuitBuilder_<FF>::compute_genperm_sort_identity(FF q_sort_value,
-                                                                  FF w_1_value,
-                                                                  FF w_2_value,
-                                                                  FF w_3_value,
-                                                                  FF w_4_value,
-                                                                  FF w_1_shifted_value,
-                                                                  FF alpha_base,
-                                                                  FF alpha) const
+template <typename Arithmetization>
+inline Arithmetization::FF UltraCircuitBuilder_<Arithmetization>::compute_genperm_sort_identity(FF q_sort_value,
+                                                                                                FF w_1_value,
+                                                                                                FF w_2_value,
+                                                                                                FF w_3_value,
+                                                                                                FF w_4_value,
+                                                                                                FF w_1_shifted_value,
+                                                                                                FF alpha_base,
+                                                                                                FF alpha) const
 {
     // Power of alpha to separate individual delta relations
     // TODO(kesha): This is a repeated computation which can be efficiently optimized
@@ -2782,18 +2801,18 @@ inline FF UltraCircuitBuilder_<FF>::compute_genperm_sort_identity(FF q_sort_valu
  * @param w_4_shifted_value y₃
  * @return fr
  */
-template <typename FF>
-inline FF UltraCircuitBuilder_<FF>::compute_elliptic_identity(FF q_elliptic_value,
-                                                              FF q_1_value,
-                                                              FF q_m_value,
-                                                              FF w_2_value,
-                                                              FF w_3_value,
-                                                              FF w_1_shifted_value,
-                                                              FF w_2_shifted_value,
-                                                              FF w_3_shifted_value,
-                                                              FF w_4_shifted_value,
-                                                              FF alpha_base,
-                                                              FF alpha) const
+template <typename Arithmetization>
+inline Arithmetization::FF UltraCircuitBuilder_<Arithmetization>::compute_elliptic_identity(FF q_elliptic_value,
+                                                                                            FF q_1_value,
+                                                                                            FF q_m_value,
+                                                                                            FF w_2_value,
+                                                                                            FF w_3_value,
+                                                                                            FF w_1_shifted_value,
+                                                                                            FF w_2_shifted_value,
+                                                                                            FF w_3_shifted_value,
+                                                                                            FF w_4_shifted_value,
+                                                                                            FF alpha_base,
+                                                                                            FF alpha) const
 {
     const FF x_1 = w_2_value;
     const FF y_1 = w_3_value;
@@ -2865,26 +2884,26 @@ inline FF UltraCircuitBuilder_<FF>::compute_elliptic_identity(FF q_elliptic_valu
  *
  */
 
-template <typename FF>
-inline FF UltraCircuitBuilder_<FF>::compute_auxilary_identity(FF q_aux_value,
-                                                              FF q_arith_value,
-                                                              FF q_1_value,
-                                                              FF q_2_value,
-                                                              FF q_3_value,
-                                                              FF q_4_value,
-                                                              FF q_m_value,
-                                                              FF q_c_value,
-                                                              FF w_1_value,
-                                                              FF w_2_value,
-                                                              FF w_3_value,
-                                                              FF w_4_value,
-                                                              FF w_1_shifted_value,
-                                                              FF w_2_shifted_value,
-                                                              FF w_3_shifted_value,
-                                                              FF w_4_shifted_value,
-                                                              FF alpha_base,
-                                                              FF alpha,
-                                                              FF eta) const
+template <typename Arithmetization>
+inline Arithmetization::FF UltraCircuitBuilder_<Arithmetization>::compute_auxilary_identity(FF q_aux_value,
+                                                                                            FF q_arith_value,
+                                                                                            FF q_1_value,
+                                                                                            FF q_2_value,
+                                                                                            FF q_3_value,
+                                                                                            FF q_4_value,
+                                                                                            FF q_m_value,
+                                                                                            FF q_c_value,
+                                                                                            FF w_1_value,
+                                                                                            FF w_2_value,
+                                                                                            FF w_3_value,
+                                                                                            FF w_4_value,
+                                                                                            FF w_1_shifted_value,
+                                                                                            FF w_2_shifted_value,
+                                                                                            FF w_3_shifted_value,
+                                                                                            FF w_4_shifted_value,
+                                                                                            FF alpha_base,
+                                                                                            FF alpha,
+                                                                                            FF eta) const
 {
     constexpr FF LIMB_SIZE(uint256_t(1) << DEFAULT_NON_NATIVE_FIELD_LIMB_BITS);
     // TODO(kesha): Replace with a constant defined in header
@@ -3139,7 +3158,7 @@ inline FF UltraCircuitBuilder_<FF>::compute_auxilary_identity(FF q_aux_value,
  * @return true
  * @return false
  */
-template <typename FF> bool UltraCircuitBuilder_<FF>::check_circuit()
+template <typename Arithmetization> bool UltraCircuitBuilder_<Arithmetization>::check_circuit()
 {
     bool result = true;
     CircuitDataBackup circuit_backup = CircuitDataBackup::store_prefinilized_state(this);
@@ -3399,7 +3418,7 @@ template <typename FF> bool UltraCircuitBuilder_<FF>::check_circuit()
     circuit_backup.restore_prefinilized_state(this);
     return result;
 }
-template class UltraCircuitBuilder_<barretenberg::fr>;
+template class UltraCircuitBuilder_<arithmetization::Ultra<barretenberg::fr>>;
 // To enable this we need to template plookup
 // template class UltraCircuitBuilder_<grumpkin::fr>;
 

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
@@ -15,9 +15,11 @@ namespace proof_system {
 
 using namespace barretenberg;
 
-template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<FF> {
+template <typename Arithmetization>
+class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization::FF> {
   public:
-    using Arithmetization = arithmetization::Ultra<FF>;
+    // using Arithmetization = arithmetization::Ultra<FF>;
+    using FF = Arithmetization::FF;
     static constexpr size_t NUM_WIRES = Arithmetization::NUM_WIRES;
     // Keeping NUM_WIRES, at least temporarily, for backward compatibility
     static constexpr size_t program_width = Arithmetization::NUM_WIRES;
@@ -1046,6 +1048,6 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<FF
 
     bool check_circuit();
 };
-extern template class UltraCircuitBuilder_<barretenberg::fr>;
-using UltraCircuitBuilder = UltraCircuitBuilder_<barretenberg::fr>;
+extern template class UltraCircuitBuilder_<arithmetization::Ultra<barretenberg::fr>>;
+using UltraCircuitBuilder = UltraCircuitBuilder_<arithmetization::Ultra<barretenberg::fr>>;
 } // namespace proof_system

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
@@ -18,8 +18,7 @@ using namespace barretenberg;
 template <typename Arithmetization>
 class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization::FF> {
   public:
-    // using Arithmetization = arithmetization::Ultra<FF>;
-    using FF = Arithmetization::FF;
+    using FF = typename Arithmetization::FF;
     static constexpr size_t NUM_WIRES = Arithmetization::NUM_WIRES;
     // Keeping NUM_WIRES, at least temporarily, for backward compatibility
     static constexpr size_t program_width = Arithmetization::NUM_WIRES;

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
@@ -600,6 +600,8 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<FF
     UltraCircuitBuilder_(UltraCircuitBuilder_&& other)
         : CircuitBuilderBase<FF>(std::move(other))
     {
+        wires = other.wires;
+        selectors = other.selectors;
         constant_variable_indices = other.constant_variable_indices;
 
         lookup_tables = other.lookup_tables;
@@ -616,6 +618,8 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<FF
     UltraCircuitBuilder_& operator=(UltraCircuitBuilder_&& other)
     {
         CircuitBuilderBase<FF>::operator=(std::move(other));
+        wires = other.wires;
+        selectors = other.selectors;
         constant_variable_indices = other.constant_variable_indices;
 
         lookup_tables = other.lookup_tables;

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
@@ -3,7 +3,6 @@
 #include "barretenberg/plonk/proof_system/types/polynomial_manifest.hpp"
 #include "barretenberg/plonk/proof_system/types/prover_settings.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
-#include "barretenberg/proof_system/arithmetization/arithmetization.hpp"
 #include "barretenberg/proof_system/op_queue/ecc_op_queue.hpp"
 #include "barretenberg/proof_system/plookup_tables/plookup_tables.hpp"
 #include "barretenberg/proof_system/plookup_tables/types.hpp"
@@ -16,8 +15,15 @@ namespace proof_system {
 
 using namespace barretenberg;
 
-template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<arithmetization::Ultra<FF>> {
+template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<FF> {
   public:
+    using Arithmetization = arithmetization::Ultra<FF>;
+    static constexpr size_t NUM_WIRES = Arithmetization::NUM_WIRES;
+    // Keeping NUM_WIRES, at least temporarily, for backward compatibility
+    static constexpr size_t program_width = Arithmetization::NUM_WIRES;
+    static constexpr size_t num_selectors = Arithmetization::num_selectors;
+    std::vector<std::string> selector_names = Arithmetization::selector_names;
+
     static constexpr std::string_view NAME_STRING = "UltraArithmetization";
     static constexpr CircuitType CIRCUIT_TYPE = CircuitType::ULTRA;
     static constexpr merkle::HashType merkle_hash_type = merkle::HashType::LOOKUP_PEDERSEN;
@@ -212,12 +218,6 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<ar
         }
     };
 
-    inline std::vector<std::string> ultra_selector_names()
-    {
-        std::vector<std::string> result{ "q_m",     "q_c",    "q_1",        "q_2",   "q_3",       "q_4",
-                                         "q_arith", "q_sort", "q_elliptic", "q_aux", "table_type" };
-        return result;
-    }
     struct non_native_field_multiplication_cross_terms {
         uint32_t lo_0_idx;
         uint32_t lo_1_idx;
@@ -526,25 +526,28 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<ar
         }
     };
 
+    std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, NUM_WIRES> wires;
+    typename Arithmetization::Selectors selectors;
+
     using WireVector = std::vector<uint32_t, ContainerSlabAllocator<uint32_t>>;
     using SelectorVector = std::vector<FF, ContainerSlabAllocator<FF>>;
 
-    WireVector& w_l = std::get<0>(this->wires);
-    WireVector& w_r = std::get<1>(this->wires);
-    WireVector& w_o = std::get<2>(this->wires);
-    WireVector& w_4 = std::get<3>(this->wires);
+    WireVector& w_l = std::get<0>(wires);
+    WireVector& w_r = std::get<1>(wires);
+    WireVector& w_o = std::get<2>(wires);
+    WireVector& w_4 = std::get<3>(wires);
 
-    SelectorVector& q_m = this->selectors.q_m;
-    SelectorVector& q_c = this->selectors.q_c;
-    SelectorVector& q_1 = this->selectors.q_1;
-    SelectorVector& q_2 = this->selectors.q_2;
-    SelectorVector& q_3 = this->selectors.q_3;
-    SelectorVector& q_4 = this->selectors.q_4;
-    SelectorVector& q_arith = this->selectors.q_arith;
-    SelectorVector& q_sort = this->selectors.q_sort;
-    SelectorVector& q_elliptic = this->selectors.q_elliptic;
-    SelectorVector& q_aux = this->selectors.q_aux;
-    SelectorVector& q_lookup_type = this->selectors.q_lookup_type;
+    SelectorVector& q_m = selectors.q_m;
+    SelectorVector& q_c = selectors.q_c;
+    SelectorVector& q_1 = selectors.q_1;
+    SelectorVector& q_2 = selectors.q_2;
+    SelectorVector& q_3 = selectors.q_3;
+    SelectorVector& q_4 = selectors.q_4;
+    SelectorVector& q_arith = selectors.q_arith;
+    SelectorVector& q_sort = selectors.q_sort;
+    SelectorVector& q_elliptic = selectors.q_elliptic;
+    SelectorVector& q_aux = selectors.q_aux;
+    SelectorVector& q_lookup_type = selectors.q_lookup_type;
 
     // These are variables that we have used a gate on, to enforce that they are
     // equal to a defined value.
@@ -583,8 +586,11 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<ar
 
     void process_non_native_field_multiplications();
     UltraCircuitBuilder_(const size_t size_hint = 0)
-        : CircuitBuilderBase<arithmetization::Ultra<FF>>(ultra_selector_names(), size_hint)
+        : CircuitBuilderBase<FF>(size_hint)
     {
+        for (auto& p : selectors) {
+            p.reserve(size_hint);
+        }
         w_l.reserve(size_hint);
         w_r.reserve(size_hint);
         w_o.reserve(size_hint);
@@ -594,7 +600,7 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<ar
     };
     UltraCircuitBuilder_(const UltraCircuitBuilder_& other) = delete;
     UltraCircuitBuilder_(UltraCircuitBuilder_&& other)
-        : CircuitBuilderBase<arithmetization::Ultra<FF>>(std::move(other))
+        : CircuitBuilderBase<FF>(std::move(other))
     {
         constant_variable_indices = other.constant_variable_indices;
 
@@ -611,7 +617,7 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<ar
     UltraCircuitBuilder_& operator=(const UltraCircuitBuilder_& other) = delete;
     UltraCircuitBuilder_& operator=(UltraCircuitBuilder_&& other)
     {
-        CircuitBuilderBase<arithmetization::Ultra<FF>>::operator=(std::move(other));
+        CircuitBuilderBase<FF>::operator=(std::move(other));
         constant_variable_indices = other.constant_variable_indices;
 
         lookup_tables = other.lookup_tables;
@@ -723,7 +729,6 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<ar
             romcount += 1; // we add an addition gate after procesing a rom array
         }
 
-        constexpr size_t gate_width = CircuitBuilderBase<arithmetization::Ultra<FF>>::program_width;
         // each RAM gate adds +2 extra gates due to the ram reads being copied to a sorted list set,
         // as well as an extra gate to validate timestamps
         std::vector<size_t> ram_timestamps;
@@ -744,12 +749,12 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<ar
             // if a range check of length `max_timestamp` already exists, we are double counting.
             // We record `ram_timestamps` to detect and correct for this error when we process range lists.
             ram_timestamps.push_back(max_timestamp);
-            size_t padding = (gate_width - (max_timestamp % gate_width)) % gate_width;
-            if (max_timestamp == gate_width)
-                padding += gate_width;
+            size_t padding = (NUM_WIRES - (max_timestamp % NUM_WIRES)) % NUM_WIRES;
+            if (max_timestamp == NUM_WIRES)
+                padding += NUM_WIRES;
             const size_t ram_range_check_list_size = max_timestamp + padding;
 
-            size_t ram_range_check_gate_count = (ram_range_check_list_size / gate_width);
+            size_t ram_range_check_gate_count = (ram_range_check_list_size / NUM_WIRES);
             ram_range_check_gate_count += 1; // we need to add 1 extra addition gates for every distinct range list
 
             ram_range_sizes.push_back(ram_range_check_gate_count);
@@ -757,9 +762,9 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<ar
         }
         for (const auto& list : range_lists) {
             auto list_size = list.second.variable_indices.size();
-            size_t padding = (gate_width - (list.second.variable_indices.size() % gate_width)) % gate_width;
-            if (list.second.variable_indices.size() == gate_width)
-                padding += gate_width;
+            size_t padding = (NUM_WIRES - (list.second.variable_indices.size() % NUM_WIRES)) % NUM_WIRES;
+            if (list.second.variable_indices.size() == NUM_WIRES)
+                padding += NUM_WIRES;
             list_size += padding;
 
             for (size_t i = 0; i < ram_timestamps.size(); ++i) {
@@ -767,7 +772,7 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<ar
                     ram_range_exists[i] = true;
                 }
             }
-            rangecount += (list_size / gate_width);
+            rangecount += (list_size / NUM_WIRES);
             rangecount += 1; // we need to add 1 extra addition gates for every distinct range list
         }
         // update rangecount to include the ram range checks the composer will eventually be creating

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
@@ -526,16 +526,16 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<FF
         }
     };
 
-    std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, NUM_WIRES> wires;
+    // std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, NUM_WIRES> wires;
     Arithmetization selectors;
 
     using WireVector = std::vector<uint32_t, ContainerSlabAllocator<uint32_t>>;
     using SelectorVector = std::vector<FF, ContainerSlabAllocator<FF>>;
 
-    WireVector& w_l = std::get<0>(wires);
-    WireVector& w_r = std::get<1>(wires);
-    WireVector& w_o = std::get<2>(wires);
-    WireVector& w_4 = std::get<3>(wires);
+    WireVector& w_l = std::get<0>(this->wires);
+    WireVector& w_r = std::get<1>(this->wires);
+    WireVector& w_o = std::get<2>(this->wires);
+    WireVector& w_4 = std::get<3>(this->wires);
 
     SelectorVector& q_m = selectors.q_m();
     SelectorVector& q_c = selectors.q_c();

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
@@ -527,7 +527,7 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<FF
     };
 
     std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, NUM_WIRES> wires;
-    typename Arithmetization::Selectors selectors;
+    Arithmetization selectors;
 
     using WireVector = std::vector<uint32_t, ContainerSlabAllocator<uint32_t>>;
     using SelectorVector = std::vector<FF, ContainerSlabAllocator<FF>>;
@@ -537,17 +537,17 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<FF
     WireVector& w_o = std::get<2>(wires);
     WireVector& w_4 = std::get<3>(wires);
 
-    SelectorVector& q_m = selectors.q_m;
-    SelectorVector& q_c = selectors.q_c;
-    SelectorVector& q_1 = selectors.q_1;
-    SelectorVector& q_2 = selectors.q_2;
-    SelectorVector& q_3 = selectors.q_3;
-    SelectorVector& q_4 = selectors.q_4;
-    SelectorVector& q_arith = selectors.q_arith;
-    SelectorVector& q_sort = selectors.q_sort;
-    SelectorVector& q_elliptic = selectors.q_elliptic;
-    SelectorVector& q_aux = selectors.q_aux;
-    SelectorVector& q_lookup_type = selectors.q_lookup_type;
+    SelectorVector& q_m = selectors.q_m();
+    SelectorVector& q_c = selectors.q_c();
+    SelectorVector& q_1 = selectors.q_1();
+    SelectorVector& q_2 = selectors.q_2();
+    SelectorVector& q_3 = selectors.q_3();
+    SelectorVector& q_4 = selectors.q_4();
+    SelectorVector& q_arith = selectors.q_arith();
+    SelectorVector& q_sort = selectors.q_sort();
+    SelectorVector& q_elliptic = selectors.q_elliptic();
+    SelectorVector& q_aux = selectors.q_aux();
+    SelectorVector& q_lookup_type = selectors.q_lookup_type();
 
     // These are variables that we have used a gate on, to enforce that they are
     // equal to a defined value.
@@ -588,9 +588,7 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<FF
     UltraCircuitBuilder_(const size_t size_hint = 0)
         : CircuitBuilderBase<FF>(size_hint)
     {
-        for (auto& p : selectors) {
-            p.reserve(size_hint);
-        }
+        selectors.reserve(size_hint);
         w_l.reserve(size_hint);
         w_r.reserve(size_hint);
         w_o.reserve(size_hint);

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
@@ -526,16 +526,16 @@ template <typename FF> class UltraCircuitBuilder_ : public CircuitBuilderBase<FF
         }
     };
 
-    // std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, NUM_WIRES> wires;
+    std::array<std::vector<uint32_t, barretenberg::ContainerSlabAllocator<uint32_t>>, NUM_WIRES> wires;
     Arithmetization selectors;
 
     using WireVector = std::vector<uint32_t, ContainerSlabAllocator<uint32_t>>;
     using SelectorVector = std::vector<FF, ContainerSlabAllocator<FF>>;
 
-    WireVector& w_l = std::get<0>(this->wires);
-    WireVector& w_r = std::get<1>(this->wires);
-    WireVector& w_o = std::get<2>(this->wires);
-    WireVector& w_4 = std::get<3>(this->wires);
+    WireVector& w_l = std::get<0>(wires);
+    WireVector& w_r = std::get<1>(wires);
+    WireVector& w_o = std::get<2>(wires);
+    WireVector& w_4 = std::get<3>(wires);
 
     SelectorVector& q_m = selectors.q_m();
     SelectorVector& q_c = selectors.q_c();

--- a/barretenberg/cpp/src/barretenberg/proof_system/composer/composer_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/composer/composer_lib.hpp
@@ -39,7 +39,7 @@ void construct_selector_polynomials(const typename Flavor::CircuitBuilder& circu
 
     // TODO(#398): Loose coupling here! Would rather build up pk from arithmetization
     size_t selector_idx = 0; // TODO(https://github.com/AztecProtocol/barretenberg/issues/391) zip
-    for (auto& selector_values : circuit_constructor.selectors) {
+    for (auto& selector_values : circuit_constructor.selectors.get()) {
         ASSERT(proving_key->circuit_size >= selector_values.size());
 
         // Copy the selector values for all gates, keeping the rows at which we store public inputs as 0.

--- a/barretenberg/cpp/src/barretenberg/proof_system/composer/composer_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/composer/composer_lib.hpp
@@ -53,7 +53,7 @@ void construct_selector_polynomials(const typename Flavor::CircuitBuilder& circu
             proving_key->_precomputed_polynomials[selector_idx] = selector_poly_lagrange;
         } else if constexpr (IsPlonkFlavor<Flavor>) {
             // TODO(Cody): Loose coupling here of selector_names and selector_properties.
-            proving_key->polynomial_store.put(circuit_constructor.selector_names_[selector_idx] + "_lagrange",
+            proving_key->polynomial_store.put(circuit_constructor.selector_names[selector_idx] + "_lagrange",
                                               std::move(selector_poly_lagrange));
         }
         ++selector_idx;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp
@@ -21,12 +21,16 @@ class Bn254FrParams;
 class Bn254FqParams;
 template <class Params> struct alignas(32) field;
 } // namespace barretenberg
+namespace arithmetization {
+template <typename FF_> class Ultra;
+} // namespace arithmetization
 namespace proof_system {
 template <class FF> class StandardCircuitBuilder_;
 using StandardCircuitBuilder = StandardCircuitBuilder_<barretenberg::field<barretenberg::Bn254FrParams>>;
 using StandardGrumpkinCircuitBuilder = StandardCircuitBuilder_<barretenberg::field<barretenberg::Bn254FqParams>>;
-template <class FF> class UltraCircuitBuilder_;
-using UltraCircuitBuilder = UltraCircuitBuilder_<barretenberg::field<barretenberg::Bn254FrParams>>;
+template <class Arithmetization> class UltraCircuitBuilder_;
+using UltraCircuitBuilder =
+    UltraCircuitBuilder_<arithmetization::Ultra<barretenberg::field<barretenberg::Bn254FrParams>>>;
 template <class FF> class GoblinUltraCircuitBuilder_;
 using GoblinUltraCircuitBuilder = GoblinUltraCircuitBuilder_<barretenberg::field<barretenberg::Bn254FrParams>>;
 } // namespace proof_system


### PR DESCRIPTION
Simplify and consolidate Arithmetization classes and move Arithmetization templating from `CircuitBuilderBase` to `UltraCircuitBuilder_`. This will facilitate reuse of Ultra builder functionality for new arithmetizations (e.g. Ultra + DataBus) via inheritance from `UltraCircuitBuilder_<NewArithmetization>`
