### PR TITLE
feat!: API inconsistency fix

### DIFF
--- a/yarn-project/acir-simulator/src/client/view_data_oracle.ts
+++ b/yarn-project/acir-simulator/src/client/view_data_oracle.ts
@@ -136,14 +136,14 @@ export class ViewDataOracle extends TypedOracle {
     }
 
     const values = [];
-    for (let i = 0; i < Number(numberOfElements); i++) {
-      const storageSlot = startStorageSlot.value + BigInt(i);
+    for (let i = 0n; i < numberOfElements; i++) {
+      const storageSlot = new Fr(startStorageSlot.value + i);
       const value = await this.aztecNode.getPublicStorageAt(this.contractAddress, storageSlot);
       if (value === undefined) {
-        throw new Error(`Oracle storage read undefined: slot=${storageSlot.toString(16)}`);
+        throw new Error(`Oracle storage read undefined: slot=${storageSlot.toString()}`);
       }
 
-      this.log(`Oracle storage read: slot=${storageSlot.toString(16)} value=${value}`);
+      this.log(`Oracle storage read: slot=${storageSlot.toString()} value=${value}`);
       values.push(value);
     }
     return values;

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -340,15 +340,18 @@ export class AztecNodeService implements AztecNode {
   }
 
   /**
-   * Gets the storage value at the given contract slot.
+   * Gets the storage value at the given contract storage slot.
+   *
+   * @remarks The storage slot here refers to the slot as it is defined in Noir not the index in the merkle tree.
+   * Aztec's version of `eth_getStorageAt`.
+   *
    * @param contract - Address of the contract to query.
    * @param slot - Slot to query.
    * @returns Storage value at the given contract slot (or undefined if not found).
-   * Note: Aztec's version of `eth_getStorageAt`.
    */
-  public async getPublicStorageAt(contract: AztecAddress, slot: bigint): Promise<Fr | undefined> {
+  public async getPublicStorageAt(contract: AztecAddress, slot: Fr): Promise<Fr | undefined> {
     const committedDb = await this.#getWorldState();
-    const leafIndex = computePublicDataTreeIndex(await CircuitsWasm.get(), contract, new Fr(slot));
+    const leafIndex = computePublicDataTreeIndex(await CircuitsWasm.get(), contract, slot);
     const value = await committedDb.getLeafValue(MerkleTreeId.PUBLIC_DATA_TREE, leafIndex.value);
     return value ? Fr.fromBuffer(value) : undefined;
   }

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -187,11 +187,11 @@ export class PXEService implements PXE {
     return (await this.db.getContracts()).map(c => c.completeAddress.address);
   }
 
-  public async getPublicStorageAt(contract: AztecAddress, storageSlot: Fr) {
+  public async getPublicStorageAt(contract: AztecAddress, slot: Fr) {
     if ((await this.getContractData(contract)) === undefined) {
       throw new Error(`Contract ${contract.toString()} is not deployed`);
     }
-    return await this.node.getPublicStorageAt(contract, storageSlot.value);
+    return await this.node.getPublicStorageAt(contract, slot);
   }
 
   public async getNotes(filter: NoteFilter): Promise<ExtendedNote[]> {

--- a/yarn-project/types/src/interfaces/aztec-node.ts
+++ b/yarn-project/types/src/interfaces/aztec-node.ts
@@ -127,12 +127,16 @@ export interface AztecNode extends StateInfoProvider {
   getPendingTxByHash(txHash: TxHash): Promise<Tx | undefined>;
 
   /**
-   * Gets the storage value at the given contract slot. Our version of eth_getStorageAt.
+   * Gets the storage value at the given contract storage slot.
+   *
+   * @remarks The storage slot here refers to the slot as it is defined in Noir not the index in the merkle tree.
+   * Aztec's version of `eth_getStorageAt`.
+   *
    * @param contract - Address of the contract to query.
    * @param slot - Slot to query.
    * @returns Storage value at the given contract slot (or undefined if not found).
    */
-  getPublicStorageAt(contract: AztecAddress, slot: bigint): Promise<Fr | undefined>;
+  getPublicStorageAt(contract: AztecAddress, slot: Fr): Promise<Fr | undefined>;
 
   /**
    * Returns the current committed roots for the data trees.

--- a/yarn-project/types/src/interfaces/pxe.ts
+++ b/yarn-project/types/src/interfaces/pxe.ts
@@ -151,14 +151,17 @@ export interface PXE {
   getTx(txHash: TxHash): Promise<L2Tx | undefined>;
 
   /**
-   * Retrieves the public storage data at a specified contract address and storage slot.
+   * Gets the storage value at the given contract storage slot.
    *
-   * @param contract - The AztecAddress of the target contract.
-   * @param storageSlot - The Fr representing the storage slot to be fetched.
-   * @returns A buffer containing the public storage data at the storage slot.
+   * @remarks The storage slot here refers to the slot as it is defined in Noir not the index in the merkle tree.
+   * Aztec's version of `eth_getStorageAt`.
+   *
+   * @param contract - Address of the contract to query.
+   * @param slot - Slot to query.
+   * @returns Storage value at the given contract slot (or undefined if not found).
    * @throws If the contract is not deployed.
    */
-  getPublicStorageAt(contract: AztecAddress, storageSlot: Fr): Promise<Fr | undefined>;
+  getPublicStorageAt(contract: AztecAddress, slot: Fr): Promise<Fr | undefined>;
 
   /**
    * Gets notes of accounts registered in this PXE based on the provided filter.


### PR DESCRIPTION
Fixes [inconsistency](https://github.com/AztecProtocol/aztec-packages/pull/3173#discussion_r1379142314) spotted by Sean yesterday.

@Maddiaa0 I decided to change the slot to `Fr` instead of `bigint` because in this case it actually refers to a slot as it is defined in Noir and not an actually index in a tree.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
