### PR TITLE
feat!: adding all the (note, nonce) pairs in `PXE.addNote` and hiding `PXE.getNoteNonces`

### DIFF
--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -80,9 +80,6 @@ export abstract class BaseWallet implements Wallet {
   addNote(note: ExtendedNote): Promise<void> {
     return this.pxe.addNote(note);
   }
-  getNoteNonces(note: ExtendedNote): Promise<Fr[]> {
-    return this.pxe.getNoteNonces(note);
-  }
   getBlock(number: number): Promise<L2Block | undefined> {
     return this.pxe.getBlock(number);
   }

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -221,42 +221,44 @@ export class PXEService implements PXE {
       throw new Error('Unknown account.');
     }
 
-    const [nonce] = await this.getNoteNonces(note);
-    if (!nonce) {
+    const nonces = await this.getNoteNonces(note);
+    if (nonces.length === 0) {
       throw new Error(`Cannot find the note in tx: ${note.txHash}.`);
     }
 
-    const { innerNoteHash, siloedNoteHash, uniqueSiloedNoteHash, innerNullifier } =
-      await this.simulator.computeNoteHashAndNullifier(note.contractAddress, nonce, note.storageSlot, note.note);
+    for (const nonce of nonces) {
+      const { innerNoteHash, siloedNoteHash, uniqueSiloedNoteHash, innerNullifier } =
+        await this.simulator.computeNoteHashAndNullifier(note.contractAddress, nonce, note.storageSlot, note.note);
 
-    // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1386)
-    // This can always be `uniqueSiloedNoteHash` once notes added from public also include nonces.
-    const noteHashToLookUp = nonce.isZero() ? siloedNoteHash : uniqueSiloedNoteHash;
-    const index = await this.node.findLeafIndex(MerkleTreeId.NOTE_HASH_TREE, noteHashToLookUp);
-    if (index === undefined) {
-      throw new Error('Note does not exist.');
+      // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1386)
+      // This can always be `uniqueSiloedNoteHash` once notes added from public also include nonces.
+      const noteHashToLookUp = nonce.isZero() ? siloedNoteHash : uniqueSiloedNoteHash;
+      const index = await this.node.findLeafIndex(MerkleTreeId.NOTE_HASH_TREE, noteHashToLookUp);
+      if (index === undefined) {
+        throw new Error('Note does not exist.');
+      }
+
+      const wasm = await CircuitsWasm.get();
+      const siloedNullifier = siloNullifier(wasm, note.contractAddress, innerNullifier!);
+      const nullifierIndex = await this.node.findLeafIndex(MerkleTreeId.NULLIFIER_TREE, siloedNullifier);
+      if (nullifierIndex !== undefined) {
+        throw new Error('The note has been destroyed.');
+      }
+
+      await this.db.addNote(
+        new NoteDao(
+          note.note,
+          note.contractAddress,
+          note.storageSlot,
+          note.txHash,
+          nonce,
+          innerNoteHash,
+          siloedNullifier,
+          index,
+          publicKey,
+        ),
+      );
     }
-
-    const wasm = await CircuitsWasm.get();
-    const siloedNullifier = siloNullifier(wasm, note.contractAddress, innerNullifier!);
-    const nullifierIndex = await this.node.findLeafIndex(MerkleTreeId.NULLIFIER_TREE, siloedNullifier);
-    if (nullifierIndex !== undefined) {
-      throw new Error('The note has been destroyed.');
-    }
-
-    await this.db.addNote(
-      new NoteDao(
-        note.note,
-        note.contractAddress,
-        note.storageSlot,
-        note.txHash,
-        nonce,
-        innerNoteHash,
-        siloedNullifier,
-        index,
-        publicKey,
-      ),
-    );
   }
 
   public async getNoteNonces(note: ExtendedNote): Promise<Fr[]> {

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -261,7 +261,13 @@ export class PXEService implements PXE {
     }
   }
 
-  public async getNoteNonces(note: ExtendedNote): Promise<Fr[]> {
+  /**
+   * Finds the nonce(s) for a given note.
+   * @param note - The note to find the nonces for.
+   * @returns The nonces of the note.
+   * @remarks More than a single nonce may be returned since there might be more than one nonce for a given note.
+   */
+  private async getNoteNonces(note: ExtendedNote): Promise<Fr[]> {
     const tx = await this.node.getTx(note.txHash);
     if (!tx) {
       throw new Error(`Unknown tx: ${note.txHash}`);

--- a/yarn-project/types/src/interfaces/pxe.ts
+++ b/yarn-project/types/src/interfaces/pxe.ts
@@ -178,14 +178,6 @@ export interface PXE {
   addNote(note: ExtendedNote): Promise<void>;
 
   /**
-   * Finds the nonce(s) for a given note.
-   * @param note - The note to find the nonces for.
-   * @returns The nonces of the note.
-   * @remarks More than a single nonce may be returned since there might be more than one nonce for a given note.
-   */
-  getNoteNonces(note: ExtendedNote): Promise<Fr[]>;
-
-  /**
    * Get the given block.
    * @param number - The block number being requested.
    * @returns The blocks requested.


### PR DESCRIPTION
Changes:

1. Until now we have added only 1 `NoteDao` to a db in the `PXE.addNote` endpoint even when multiple nonces were found.
2. `PXE.getNoteNonces` no longer needs to be exposed so I hide it here.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
