### PR TITLE
fix: better update steps for dockerized sandbox

### DIFF
--- a/yarn-project/cli/src/update/update.ts
+++ b/yarn-project/cli/src/update/update.ts
@@ -34,9 +34,10 @@ export async function update(
 
     if (currentSandboxVersion && lt(currentSandboxVersion, targetSandboxVersion)) {
       log(`
-Sandbox is older than version ${targetSandboxVersion}. If running in docker update it with the following command then restart the container:
-docker pull aztecprotocol/aztec-sandbox:latest
-Once the container is restarted, run the \`aztec-cli update\` command again`);
+Sandbox is older than version ${targetSandboxVersion}. If running via docker-compose, follow update instructions:
+https://docs.aztec.network/dev_docs/cli/updating
+
+Once the sandbox is updated, run the \`aztec-cli update\` command again`);
       return;
     }
   }


### PR DESCRIPTION
Improves error message shown to user when running the `update` command in the CLI if dockerized Sandbox is out of date.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [x] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
