### PR TITLE
fix: update noir-contracts path to types

### DIFF
--- a/yarn-project/noir-contracts/package.json
+++ b/yarn-project/noir-contracts/package.json
@@ -58,7 +58,7 @@
     "src",
     "!*.test.*"
   ],
-  "types": "./dest/index.d.ts",
+  "types": "./dest/types/index.d.ts",
   "engines": {
     "node": ">=18"
   }


### PR DESCRIPTION
fixes imports when package is installed

<img width="618" alt="image" src="https://github.com/AztecProtocol/aztec-packages/assets/142251406/180205db-c690-4a41-9912-5dfcfa52dab0">
