### PR TITLE
fix: remove noirup from noir-contract's bootstrap

### DIFF
--- a/yarn-project/noir-contracts/bootstrap.sh
+++ b/yarn-project/noir-contracts/bootstrap.sh
@@ -1,15 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Install noir if it is not installed already
-if ! command -v noirup &> /dev/null
-then
-    echo "Installing noir"
-    source ./scripts/install_noirup.sh
-fi
-
-# Update noir
-./scripts/install_noir.sh
-
-# Use yarn script to compile and create types
-yarn 
 yarn noir:build:all

--- a/yarn-project/noir-contracts/scripts/compile.sh
+++ b/yarn-project/noir-contracts/scripts/compile.sh
@@ -13,7 +13,7 @@ build() {
   echo "Compiling $CONTRACT_NAME..."
   rm -rf ${CONTRACT_FOLDER}/target
 
-  node "$COMPILER" contract "$CONTRACT_FOLDER"
+  node --no-warnings "$COMPILER" contract "$CONTRACT_FOLDER"
 }
 
 export -f build


### PR DESCRIPTION
Removes the noirup commands from noir-compiler's bootstrap script as it's not needed since the switch to noir_wasm.