### PR TITLE
fix: wasm-compiler `bin` package type

### DIFF
--- a/yarn-project/foundation/src/noir/noir_package_config.ts
+++ b/yarn-project/foundation/src/noir/noir_package_config.ts
@@ -13,7 +13,7 @@ const noirLocalDependencySchema = z.object({
 const noirPackageConfigSchema = z.object({
   package: z.object({
     name: z.string().default(''),
-    type: z.enum(['lib', 'contract', 'binary']).default('binary'),
+    type: z.enum(['lib', 'contract', 'bin']).default('bin'),
     entry: z.string().optional(),
     description: z.string().optional(),
     authors: z.array(z.string()).optional(),

--- a/yarn-project/noir-compiler/src/compile/noir/noir-wasm-compiler.ts
+++ b/yarn-project/noir-compiler/src/compile/noir/noir-wasm-compiler.ts
@@ -105,6 +105,7 @@ export class NoirWasmContractCompiler {
     } catch (err) {
       if (err instanceof Error && err.name === 'CompileError') {
         this.#processCompileError(err as CompileError);
+        throw new Error('Compilation failed');
       }
 
       throw err;
@@ -121,7 +122,6 @@ export class NoirWasmContractCompiler {
   };
 
   #processCompileError(err: CompileError): void {
-    this.#log('Error compiling contract');
     for (const diag of err.diagnostics) {
       this.#log(`  ${diag.message}`);
       const contents = this.#resolveFile(diag.file);

--- a/yarn-project/noir-compiler/src/compile/noir/noir-wasm-compiler.ts
+++ b/yarn-project/noir-compiler/src/compile/noir/noir-wasm-compiler.ts
@@ -83,6 +83,12 @@ export class NoirWasmContractCompiler {
    * Compiles the project.
    */
   public async compile(): Promise<NoirCompilationArtifacts[]> {
+    const isContract = this.#package.getType() === 'contract';
+    // limit to contracts-only because the rest of the pipeline only supports processing contracts
+    if (!isContract) {
+      throw new Error('Noir project is not a contract');
+    }
+
     this.#debugLog(`Compiling contract at ${this.#package.getEntryPointPath()}`);
     await this.#dependencyManager.resolveDependencies();
     this.#debugLog(`Dependencies: ${this.#dependencyManager.getPackageNames().join(', ')}`);
@@ -90,7 +96,7 @@ export class NoirWasmContractCompiler {
     initializeResolver(this.#resolveFile);
 
     try {
-      const result = compile(this.#package.getEntryPointPath(), true, {
+      const result = compile(this.#package.getEntryPointPath(), isContract, {
         /* eslint-disable camelcase */
         root_dependencies: this.#dependencyManager.getEntrypointDependencies(),
         library_dependencies: this.#dependencyManager.getLibraryDependencies(),

--- a/yarn-project/noir-compiler/src/compile/noir/package.ts
+++ b/yarn-project/noir-compiler/src/compile/noir/package.ts
@@ -47,7 +47,7 @@ export class NoirPackage {
         entrypoint = 'lib.nr';
         break;
       case 'contract':
-      case 'binary':
+      case 'bin':
         entrypoint = 'main.nr';
         break;
       default:


### PR DESCRIPTION
This PR updates the wasm-compiler to recognize, but not accept the `bin` package type in a Nargo.toml file. Previously it would knew about `binary` but the correct value is `bin`.

A couple of commits taken from #3250

