### PR TITLE
fix: remove aztec.nr version check from noir-compiler

### DIFF
--- a/yarn-project/noir-compiler/src/index.ts
+++ b/yarn-project/noir-compiler/src/index.ts
@@ -7,7 +7,6 @@ import { CompileOpts, NargoContractCompiler } from './compile/nargo.js';
 import { FileManager } from './compile/noir/file-manager/file-manager.js';
 import { NoirWasmCompileOptions, NoirWasmContractCompiler } from './compile/noir/noir-wasm-compiler.js';
 import { generateContractArtifact } from './contract-interface-gen/abi.js';
-import { AztecNrVersion } from './versions.js';
 
 export * from './versions.js';
 
@@ -44,10 +43,6 @@ export async function compileUsingNoirWasm(
   const compiler = NoirWasmContractCompiler.new(fileManager, resolve(projectPath), opts);
   const artifacts = await compiler.compile();
   const resolvedAztecNrVersion = compiler.getResolvedAztecNrVersion();
-
-  if (resolvedAztecNrVersion && AztecNrVersion !== resolvedAztecNrVersion) {
-    opts.log(`WARNING: Aztec.nr version mismatch: expected "${AztecNrVersion}", got "${resolvedAztecNrVersion}"`);
-  }
 
   return artifacts.map(artifact => generateContractArtifact(artifact, resolvedAztecNrVersion));
 }

--- a/yarn-project/noir-compiler/src/versions.ts
+++ b/yarn-project/noir-compiler/src/versions.ts
@@ -5,7 +5,6 @@ import NoirVersion from './noir-version.json' assert { type: 'json' };
 // read package.json at runtime instead of compile time so that we keep rootDir as-is in tsconfig
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
 
-export const AztecNrVersion = `aztec-packages-v${pkg.version}`;
 export const NoirWasmVersion = pkg.dependencies['@noir-lang/noir_wasm'];
 export const NoirTag = NoirVersion.tag;
 export const NoirCommit = NoirVersion.commit;


### PR DESCRIPTION
Removes bad check: noir-compiler's package.json never gets the latest version in so it would always fail this check. Ideal case would be to properly version aztec.nr and check against that version.
