### PR TITLE
chore(docs): Suggest CLI install per project

### DIFF
--- a/docs/docs/dev_docs/cli/cli-commands.md
+++ b/docs/docs/dev_docs/cli/cli-commands.md
@@ -8,7 +8,7 @@ Here you will find a reference to the commands available in the Aztec CLI.
 
 ### NPM
 
-This command will install the Aztec CLI as a developer dependency in your npm project.
+This command will install the Aztec CLI as a dev dependency in your npm project.
 
 ```bash
 npm install --save-dev @aztec/cli

--- a/docs/docs/dev_docs/cli/cli-commands.md
+++ b/docs/docs/dev_docs/cli/cli-commands.md
@@ -8,11 +8,17 @@ Here you will find a reference to the commands available in the Aztec CLI.
 
 ### NPM
 
-This command will install the Aztec CLI.
+This command will install the Aztec CLI as a developer dependency in your npm project.
 
 ```bash
-npm install -g @aztec/cli
+npm install --save-dev @aztec/cli
 ```
+
+:::info
+
+You can install the CLI globally, but it is recommended that you install the CLI as a local dependency in your project. This will make it easier to keep the CLI version in sync with the sandbox version.
+
+:::
 
 ### Docker
 

--- a/docs/docs/dev_docs/getting_started/quickstart.md
+++ b/docs/docs/dev_docs/getting_started/quickstart.md
@@ -32,10 +32,6 @@ This command will also install the CLI if a node package version of the CLI isn'
 
 Alternatively, you can [run the sandbox as an npm package](../cli/sandbox-reference.md#with-npm).
 
-## Install the CLI
-
-You can interact with the sandbox via the [Aztec CLI](../cli/main.md).
-
 ## Deploy a contract using the CLI
 
 The sandbox is preloaded with multiple accounts. Let's assign them to shell variables. Run the following in your terminal, so we can refer to the accounts as $ALICE and $BOB from now on:

--- a/docs/docs/dev_docs/getting_started/quickstart.md
+++ b/docs/docs/dev_docs/getting_started/quickstart.md
@@ -28,15 +28,13 @@ To install the latest Sandbox version, run:
 
 This will attempt to run the Sandbox on ` localhost:8080`, so you will have to make sure nothing else is running on that port or change the port defined in `./.aztec/docker-compose.yml`. Running the command again will overwrite any changes made to the `docker-compose.yml`.
 
+This command will also install the CLI if a node package version of the CLI isn't found locally.
+
 Alternatively, you can [run the sandbox as an npm package](../cli/sandbox-reference.md#with-npm).
 
 ## Install the CLI
 
-To interact with the Sandbox now that it's running locally, install the [Aztec CLI](https://www.npmjs.com/package/@aztec/cli):
-
-```bash
-npm install -g @aztec/cli
-```
+You can interact with the sandbox via the [Aztec CLI](../cli/main.md).
 
 ## Deploy a contract using the CLI
 

--- a/docs/docs/dev_docs/updating.md
+++ b/docs/docs/dev_docs/updating.md
@@ -3,23 +3,38 @@ title: Updating
 ---
 
 ## TL;DR
-1. **Updating the sandbox:** 
+
+1. **Updating the sandbox:**
+
 - If you installed sandbox via docker, run:
+
 ```shell
 /bin/bash -c "$(curl -fsSL 'https://sandbox.aztec.network')"
 ```
+
 - If you have installed via an npm package then step 3 handles the update.
 
 2. **Updating Aztec-CLI:**
+
 - The above command also downloads the aztec-cli if a node package version of the CLI isn't found locally.
 - If you have globally installed the CLI previously, then run:
+
 ```shell
-npm install -g @aztec/aztec-cli
+npm install -g @aztec/cli
 ```
+
 (replace with `yarn` or your node package version manager tool).
+
 - If you have aztec-cli listed as a local dependency in your project's `package.json`, then step 3 handles the update.
 
-3. **Updating aztec-nr and individual @aztec dependencies:**
+:::info
+
+You can install the CLI globally, but it is recommended that you install the CLI as a local dependency in your project. This will make it easier to keep the CLI version in sync with the sandbox version.
+
+:::
+
+1. **Updating aztec-nr and individual @aztec dependencies:**
+
 Inside your project run:
 
 ```shell
@@ -53,22 +68,28 @@ This will also update the CLI if a node package version of the CLI isn't found l
 
 ### npm
 
+:::info
+
+You can install the CLI globally, but it is recommended that you install the CLI as a local dependency in your project. This will make it easier to keep the CLI version in sync with the sandbox version.
+
+:::
+
 If the latest version was used when updating the sandbox then we can simply run the following command to update the CLI:
 
 ```shell
-npm install -g @aztec/cli
+npm install --save-dev @aztec/cli
 ```
 
 If a specific version was set for the sandbox then we need to install the CLI with the same version:
 
 ```shell
-npm install -g @aztec/cli@$SANDBOX_VERSION
+npm install --save-dev @aztec/cli@$SANDBOX_VERSION
 ```
 
 E.g.:
 
 ```shell
-npm install -g @aztec/cli@#include_aztec_short_version
+npm install --save-dev @aztec/cli@#include_aztec_short_version
 ```
 
 ### Docker


### PR DESCRIPTION
Update the docs to suggest that devs install the CLI as a dependency in their npm project instead of globally.
