### PR TITLE
fix: debug build

### DIFF
--- a/barretenberg/cpp/src/barretenberg/proof_system/plookup_tables/fixed_base/fixed_base.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/plookup_tables/fixed_base/fixed_base.cpp
@@ -272,4 +272,19 @@ template MultiTable table::get_fixed_base_table<1, table::BITS_PER_HI_SCALAR>(Mu
 template MultiTable table::get_fixed_base_table<2, table::BITS_PER_LO_SCALAR>(MultiTableId);
 template MultiTable table::get_fixed_base_table<3, table::BITS_PER_HI_SCALAR>(MultiTableId);
 
+const table::all_multi_tables table::fixed_base_tables = {
+    table::generate_tables<BITS_PER_LO_SCALAR>(lhs_base_point_lo),
+    table::generate_tables<BITS_PER_HI_SCALAR>(lhs_base_point_hi),
+    table::generate_tables<BITS_PER_LO_SCALAR>(rhs_base_point_lo),
+    table::generate_tables<BITS_PER_HI_SCALAR>(rhs_base_point_hi),
+};
+
+const std::array<table::affine_element, table::NUM_FIXED_BASE_MULTI_TABLES>
+    table::fixed_base_table_offset_generators = {
+        table::generate_generator_offset<BITS_PER_LO_SCALAR>(lhs_base_point_lo),
+        table::generate_generator_offset<BITS_PER_HI_SCALAR>(lhs_base_point_hi),
+        table::generate_generator_offset<BITS_PER_LO_SCALAR>(rhs_base_point_lo),
+        table::generate_generator_offset<BITS_PER_HI_SCALAR>(rhs_base_point_hi),
+    };
+
 } // namespace plookup::fixed_base

--- a/barretenberg/cpp/src/barretenberg/proof_system/plookup_tables/fixed_base/fixed_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/plookup_tables/fixed_base/fixed_base.hpp
@@ -46,12 +46,7 @@ class table : public FixedBaseParams {
     // fixed_base_tables = lookup tables of precomputed base points required for our lookup arguments.
     // N.B. these "tables" are not plookup tables, just regular ol' software lookup tables.
     // Used to build the proper plookup table and in the `BasicTable::get_values_from_key` method
-    inline static const all_multi_tables fixed_base_tables = {
-        table::generate_tables<BITS_PER_LO_SCALAR>(lhs_base_point_lo),
-        table::generate_tables<BITS_PER_HI_SCALAR>(lhs_base_point_hi),
-        table::generate_tables<BITS_PER_LO_SCALAR>(rhs_base_point_lo),
-        table::generate_tables<BITS_PER_HI_SCALAR>(rhs_base_point_hi),
-    };
+    static const all_multi_tables fixed_base_tables;
 
     /**
      * @brief offset generators!
@@ -68,13 +63,7 @@ class table : public FixedBaseParams {
      * The final scalar multiplication output will have a precisely-known contribution from the offset generators,
      * which can then be subtracted off with a single point subtraction.
      **/
-    inline static const std::array<affine_element, table::NUM_FIXED_BASE_MULTI_TABLES>
-        fixed_base_table_offset_generators = {
-            table::generate_generator_offset<BITS_PER_LO_SCALAR>(lhs_base_point_lo),
-            table::generate_generator_offset<BITS_PER_HI_SCALAR>(lhs_base_point_hi),
-            table::generate_generator_offset<BITS_PER_LO_SCALAR>(rhs_base_point_lo),
-            table::generate_generator_offset<BITS_PER_HI_SCALAR>(rhs_base_point_hi),
-        };
+    static const std::array<affine_element, table::NUM_FIXED_BASE_MULTI_TABLES> fixed_base_table_offset_generators;
 
     static bool lookup_table_exists_for_point(const affine_element& input);
     static std::optional<std::array<MultiTableId, 2>> get_lookup_table_ids_for_point(const affine_element& input);


### PR DESCRIPTION
This was failing with e.g. 
```
ecc_lookup_relation.cpp:(.text.startup[_ZN7plookup10fixed_base5table34fixed_base_table_offset_generatorsE]+0x39): undefined reference to `barretenberg::group_elements::affine_element<barretenberg::field<barretenberg::Bn254FrParams>, barretenberg::field<barretenberg::Bn254FqParams>, grumpkin::GrumpkinG1Params> plookup::fixed_base::table::generate_generator_offset<128ul>(barretenberg::group_elements::affine_element<barretenberg::field<barretenberg::Bn254FrParams>, barretenberg::field<barretenberg::Bn254FqParams>, grumpkin::GrumpkinG1Params> const&)'
```
I'm not entirely sure why - but static arrays should be initialized in compilation units anyway.