### PR TITLE
fix: noir-compiler breadth-first resolver

### DIFF
--- a/yarn-project/noir-compiler/src/cli/contract.ts
+++ b/yarn-project/noir-compiler/src/cli/contract.ts
@@ -69,13 +69,11 @@ export function compileContract(program: Command, name = 'contract', log: LogFn 
             const tsPath = resolve(projectPath, typescript, `${contract.name}.ts`);
             log(`Writing ${contract.name} typescript interface to ${path.relative(currentDir, tsPath)}`);
             let relativeArtifactPath = path.relative(path.dirname(tsPath), artifactPath);
-            log(`Relative path: ${relativeArtifactPath}`);
             if (relativeArtifactPath === `${contract.name}.json`) {
               // relative path edge case, prepending ./ for local import - the above logic just does
               // `${contract.name}.json`, which is not a valid import for a file in the same directory
               relativeArtifactPath = `./${contract.name}.json`;
             }
-            log(`Relative path after correction: ${relativeArtifactPath}`);
             const tsWrapper = generateTypescriptContractInterface(contract, relativeArtifactPath);
             mkdirpSync(path.dirname(tsPath));
             writeFileSync(tsPath, tsWrapper);

--- a/yarn-project/noir-compiler/src/compile/noir/dependencies/dependency-manager.test.ts
+++ b/yarn-project/noir-compiler/src/compile/noir/dependencies/dependency-manager.test.ts
@@ -18,6 +18,9 @@ describe('DependencyManager', () => {
           lib2: {
             path: '/lib2',
           },
+          lib3: {
+            path: '/lib3',
+          },
         },
         package: {
           name: 'test_contract',
@@ -38,7 +41,7 @@ describe('DependencyManager', () => {
 
   it('resolves root dependencies', async () => {
     await manager.resolveDependencies();
-    expect(manager.getEntrypointDependencies()).toEqual(['lib1', 'lib2']);
+    expect(manager.getEntrypointDependencies()).toEqual(['lib1', 'lib2', 'lib3']);
   });
 
   it('resolves library dependencies', async () => {
@@ -75,7 +78,7 @@ class TestDependencyResolver implements NoirDependencyResolver {
           package: new NoirPackage('/lib2', '/lib2/src', {
             dependencies: {
               lib3: {
-                path: '/lib3',
+                path: '../lib3',
               },
             },
             package: {


### PR DESCRIPTION
This PR fixes an issue hit by @spypsy and @catmcgee last week while working on a sample contract. They were not able to compile their contract because the compiler failed to find all of the needed dependencies.

I've identified the issue with `NoirDependencyManager` resolving dependencies in a depth-first manner. This caused issues with libraries that had dependencies of their own linked to by relative paths. This was a problem because the new pipeline using wasm only unpacks the required folder from a github archive (while Nargo gets the whole thing). In the contract's case, it had dependencies on easy_private_state and value_note (in this order) but easy_private_state needed value_note to exist before the manager resolved it.

This PR replaces the algorithm with a breadth-first resolver which fixes this. It also adds updates the existing unit test for the manager to check this edge case.
