### PR TITLE
chore(bb): remove -Wfatal-errors

### DIFF
--- a/barretenberg/cpp/src/CMakeLists.txt
+++ b/barretenberg/cpp/src/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 # Specifying `-Wno-${ERROR_NAME}` will silence the error completely.
 # To preserve the warning, but prevent them from causing the build to fail,
 # use the flag `-Wno-error=${ERROR_NAME}`
-add_compile_options(-Werror -Wall -Wextra -Wconversion -Wsign-conversion -Wfatal-errors)
+add_compile_options(-Werror -Wall -Wextra -Wconversion -Wsign-conversion)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-fcolor-diagnostics -fconstexpr-steps=100000000)


### PR DESCRIPTION
Seeking feedback on this one, but it doesn't always feel the most productive to see only one error at a time during refactoring. There's already an error limit of 20, and while the CLI might be a bit more spammed the IDE can comfortably show many errors. Even in CLI cases, it can be productive to work through multiple errors without recompiling.