### PR TITLE
fix: Grammar and Punctuation Corrections in Aztec Documentation

### DIFF
--- a/docs/docs/about_aztec/history/differences_to_aztec_connect.md
+++ b/docs/docs/about_aztec/history/differences_to_aztec_connect.md
@@ -8,7 +8,7 @@ In Aztec our architecture must process arbitrary circuits written by potentially
 
 **Privacy set must be shared across all contracts**
 
-In Connect observers knew when different note types were being created (value note, account note etc). This cannot be the case in Aztec, as we want to provide strong privacy gaurantees to all private contracts even if they have few transactions interacting with their contract.
+In Connect observers knew when different note types were being created (value note, account note etc). This cannot be the case in Aztec, as we want to provide strong privacy guarantees to all private contracts even if they have few transactions interacting with their contract.
 
 **Support for call semantics**
 

--- a/docs/docs/about_aztec/history/history.mdx
+++ b/docs/docs/about_aztec/history/history.mdx
@@ -35,8 +35,8 @@ The original blockchain.
 
 - Originally: None.
 - Now:
-  - some specific apps on L1
-  - some specific apps, deployed via L2, like zk.money and Aztec Connect.
+  - Some specific apps on L1
+  - Some specific apps, deployed via L2, like zk.money and Aztec Connect.
 
 ---
 

--- a/docs/docs/about_aztec/roadmap/cryptography_roadmap.md
+++ b/docs/docs/about_aztec/roadmap/cryptography_roadmap.md
@@ -10,15 +10,15 @@ Publish the Honk paper, describing practical considerations for constructing our
 
 ## Honk
 
-Honk is a sumcheck-based zk-SNARK protocol with blazing-fast zk proof construction. We need Honk to allow users to prove correct execution of complicated, multi-step computations using recursion in a resource constraint environment like a cell phone. This is necessary for our mission, because we need to make sure our users' sensitive information never leaves their devices!
+Honk is a sumcheck-based zk-SNARK protocol with blazing-fast zk proof construction. We need Honk to allow users to prove correct execution of complicated, multi-step computations using recursion in a resource constrained environment like a cell phone. This is necessary for our mission, because we need to make sure our users' sensitive information never leaves their devices!
 
 List of Honk projects:
 
 - Completed: basic Honk prover and verifier with respectable construction and verification speeds, but no optimization.
 - Upcoming:
   - Bringing "Ultra" functionality to Honk: lookup tables, efficient range constraints, RAM, ROM, and more will result in orders-of-magnitude improvements to Honk's prover times.
-  - Recursion using cycles of curves will allow for efficient recursive verification of Honk proofs. Using this technique will lower the barrier to entry of our rollup providers, resulting in a more robust set of providers and greater security for the Aztec network.
+  - Recursion using cycles of curves will allow for efficient recursive verification of Honk proofs. Using this technique will lower the barrier to entry for our rollup providers, resulting in a more robust set of providers and greater security for the Aztec network.
 
 ## Goblin projects
 
-Goblin is a deferred verification framework thats allow for an order-of-magnitude increase in the complexity of computations that Aztec users can execute with full privacy. This corresponds to a 10x increase in the expressivity of Noir programs that can be run in practice without melting anybody's favorite phone or laptop. Read more [here](https://hackmd.io/@aztec-network/B19AA8812).
+Goblin is a deferred verification framework that allows for an order-of-magnitude increase in the complexity of computations that Aztec users can execute with full privacy. This corresponds to a 10x increase in the expressivity of Noir programs that can be run in practice without melting anybody's favorite phone or laptop. Read more [here](https://hackmd.io/@aztec-network/B19AA8812).

--- a/docs/docs/about_aztec/roadmap/engineering_roadmap.md
+++ b/docs/docs/about_aztec/roadmap/engineering_roadmap.md
@@ -44,10 +44,12 @@ The engineering roadmap is long. There are no timings assigned here. In a loose 
 ## Enforcing correct ordering Public & Private State Transitions
 
 ## Enforcing correct ordering of other 'side effects'
+
 - Log ordering
 - Enqueued public function calls
 
 ## What data actually needs to be submitted on-chain?
+
 - For Public Functions:
     - Just emit the initially-enqueued public function request data? (The 'inputs' of the tx);
         - I.e. contract address, function selector, args, call_context.
@@ -58,7 +60,7 @@ The engineering roadmap is long. There are no timings assigned here. In a loose 
 
 - Write detailed specs, given recent protocol changes.
 - Review the code to ensure it matches what we _think_ the protocol is.
-- Open issues to ensure the code matches the spec.
+- Open issues to ensure the code matches the specs.
 - (Note: bringing cryptographers into the fold (to review specs) is a separate section, later in this doc).
 
 ## Iterate on the Sandbox
@@ -102,7 +104,7 @@ CI takes up a significant amount of time. It gets its own section here, so we re
 - Note Discovery RFP
 - Decide on the protocol
 - Spec
-- Build it.
+- Build it
 
 ## Privacy-preserving queries to public nodes
 
@@ -114,7 +116,7 @@ CI takes up a significant amount of time. It gets its own section here, so we re
 
 - Write up keys spec
 - Get internal comments
-- Do a RFC from the external community
+- Do an RFC from the external community
 - Implement
 
 ## Slow Updates tree?
@@ -148,7 +150,7 @@ We _need_ a way to read mutable public data from a private function.
 
 ## Testing UX team
 
-A team focussed on testing and debugging UX.
+A team focused on testing and debugging UX.
 This team should have free rein to design and add any features they see fit.
 
 Some example features:
@@ -165,13 +167,14 @@ Some example features:
 ## Proper Circuits
 
 ### Redesign
+
 - The Bus
     - The bus will have an impact on the way we design the circuit logic.
     - We can hopefully avoid hashing in circuit 1 and unpacking that hash in circuit 2.
     - Understand the 'bus' and how we can use it to pass variable amounts of data between recursive circuit iterations.
     - Redesign all circuit logic to allow for the variable-sized arrays that the 'bus' enables.
 - Enable 'dynamic/variable-sized **loops**'
-    - allow each `for` loop (eg read requests, insertions, commitment squashing, call stack processing, bip32 key derivation, etc.) to vary in size, by deferring each loop to its own final circuit. This would require complex folding stuff.
+    - allow each `for` loop (e.g., read requests, insertions, commitment squashing, call stack processing, bip32 key derivation, etc.) to vary in size, by deferring each loop to its own final circuit. This would require complex folding stuff.
     - This would give much more flexibility over the sizes of various arrays that a circuit can output. Without it, if one array of an app circuit needs to be size 2000, but other arrays aren't used, we'd use a kernel where every array is size 2048, meaning a huge amount of unnecessary loops of computation for those empty arrays.
 - Improvements
     - We can definitely change how call stacks are processed within a kernel, to reduce hashing.
@@ -213,10 +216,12 @@ Also, we do a lot of sha256-compressing in our kernel and rollup circuits for da
 ### Ultra -> Standard Squisher Circuit
 
 ## Authentication: access to private data
+
 - Private data must not be returned to an app, unless the user authorizes it.
 
 ## Validation: preventing execution of malicious bytecode
-- A node should check that the bytecode provided by an application for a given app matches the leaf in the contract tree to ensure that user doesn't execute unplanned code which might access their notes.
+
+- A node should check that the bytecode provided by an application for a given app matches the leaf in the contract tree to ensure that the user doesn't execute unplanned code which might access their notes.
 
 ## Fuzz Testing
 
@@ -230,15 +235,17 @@ An investigation into how formal verification techniques might improve the secur
 
 ## Hashes
 
-- An improved, standardised Pedersen hash in barretenberg.
+- An improved, standardized Pedersen hash in barretenberg.
 - Poseidon hashing in barretenberg.
 
 ## Tree epochs
+
 - Nullifier tree epochs
 - Maybe other tree epochs.
 
 ## Chaining txs
-- We have the ability to spend pending notes (which haven't-yet been added to the tree) _within the context of a single tx_.
+
+- We have the ability to spend pending notes (which haven't yet been added to the tree) _within the context of a single tx_.
 - We need the ability to spend pending notes (which haven't yet been added to the tree) across different txs, within the context of a single rollup.
     - This happens if Alice generates two txs X & Y, where tx Y spends notes from tx X. If we want Alice to be able to generate these txs in parallel (without interacting with the network at all), we need a way for tx Y to spend notes before they've been added to the tree. The 'chaining tx' concepts from Aztec Connect can enable this.
 - This added _a lot_ of complexity to Aztec Connect. Especially around fees, iirc. Caution needed.

--- a/docs/docs/about_aztec/roadmap/features_initial_ldt.md
+++ b/docs/docs/about_aztec/roadmap/features_initial_ldt.md
@@ -4,7 +4,7 @@ title: Sandbox Features
 
 The Aztec Sandbox is intended to provide developers with a lightweight and fast local node.
 
-Developers should be able to quickly spin up local, emulated instances of an Ethereum blockchain and an Aztec encrypted rollup, and start deploying private contracts and submitting private txs.
+Developers should be able to quickly spin up local, emulated instances of an Ethereum blockchain and an Aztec encrypted rollup, and start deploying private contracts and submitting private transactions.
 
 The sandbox allows developers to:
 


### PR DESCRIPTION
This Pull Request addresses several grammatical and punctuation errors identified in the Aztec documentation. Specific updates include corrections to certain words and phrases for better adherence to standard writing and grammar rules.

Please provide a paragraph or two giving a summary of the change, including relevant motivation and context.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
