### PR TITLE
feat: Zeromorph changes for full Goblin

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/zeromorph/zeromorph.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "barretenberg/polynomials/polynomial.hpp"
-
 namespace proof_system::honk::pcs::zeromorph {
 
 /**
@@ -188,7 +187,7 @@ template <typename Curve> class ZeroMorphProver_ {
      *
      * where f_batched = \sum_{i=0}^{m-1}\rho^i*f_i, g_batched = \sum_{i=0}^{l-1}\rho^{m+i}*g_i
      *
-     * and concatenation_term = \sum_{i=0}^{concatenation_index}(x^{i * min_N + 1}concatenation_groups_batched_{i})
+     * and concatenation_term = \sum_{i=0}^{num_chunks_per_group}(x^{i * min_N + 1}concatenation_groups_batched_{i})
      *
      * @note The concatenation term arises from an implementation detail in the Goblin Translator and is not part of the
      * conventional ZM protocol
@@ -240,7 +239,7 @@ template <typename Curve> class ZeroMorphProver_ {
         }
 
         // If necessary, add to Z_x the contribution related to concatenated polynomials:
-        // \sum_{i=0}^{concatenation_index}(x^{i * min_n + 1}concatenation_groups_batched_{i}).
+        // \sum_{i=0}^{num_chunks_per_group}(x^{i * min_n + 1}concatenation_groups_batched_{i}).
         // We are effectively reconstructing concatenated polynomials from their chunks now that we know x
         // Note: this is an implementation detail related to Goblin Translator and is not part of the standard protocol.
         if (!concatenation_groups_batched.empty()) {
@@ -314,18 +313,22 @@ template <typename Curve> class ZeroMorphProver_ {
      */
     static void prove(const auto& f_polynomials,
                       const auto& g_polynomials,
-                      auto& evaluations,
+                      auto&& f_evaluations,
+                      auto&& g_shift_evaluations,
                       auto& multilinear_challenge,
                       auto& commitment_key,
-                      auto& transcript)
+                      auto& transcript,
+                      const auto& concatenated_polynomials = {},
+                      const auto& concatenated_evaluations = {},
+                      const auto& concatenation_groups = {})
     {
         // Generate batching challenge \rho and powers 1,...,\rho^{m-1}
         FF rho = transcript.get_challenge("rho");
-        std::vector<FF> rhos = powers_of_challenge(rho, evaluations.size());
+        std::vector<FF> rhos = powers_of_challenge(rho, 200); // WORKTODO
 
         // Extract multilinear challenge u and claimed multilinear evaluations from Sumcheck output
         std::span<FF> u_challenge = multilinear_challenge;
-        auto claimed_evaluations = evaluations.pointer_view();
+        // std::span<FF> claimed_evaluations = evaluations;
         size_t log_N = u_challenge.size();
         size_t N = 1 << log_N;
 
@@ -340,21 +343,48 @@ template <typename Curve> class ZeroMorphProver_ {
         size_t poly_idx = 0;     // TODO(#391) zip
         for (auto& f_poly : f_polynomials) {
             f_batched.add_scaled(f_poly, rhos[poly_idx]);
-            batched_evaluation += rhos[poly_idx] * (*claimed_evaluations[poly_idx]);
+            batched_evaluation += rhos[poly_idx] * f_evaluations[poly_idx];
             ++poly_idx;
         }
 
+        size_t offset = poly_idx;
+        poly_idx = 0;
         Polynomial g_batched(N); // batched to-be-shifted polynomials
         for (auto& g_poly : g_polynomials) {
-            g_batched.add_scaled(g_poly, rhos[poly_idx]);
-            batched_evaluation += rhos[poly_idx] * (*claimed_evaluations[poly_idx]);
+            g_batched.add_scaled(g_poly, rhos[offset + poly_idx]);
+            batched_evaluation += rhos[offset + poly_idx] * g_shift_evaluations[poly_idx];
             ++poly_idx;
         };
+
+        size_t num_groups = concatenation_groups.size();
+        size_t num_chunks_per_group = concatenation_groups.empty() ? 0 : concatenation_groups[0].size();
+        // Concatenated polynomials
+        // std::vector<Polynomial> concatenated_polynomials;
+        Polynomial concatenated_batched(N);
+
+        // construct concatention_groups_batched
+        std::vector<Polynomial> concatenation_groups_batched;
+        for (size_t i = 0; i < num_chunks_per_group; ++i) {
+            concatenation_groups_batched.push_back(Polynomial(N));
+        }
+        // for each group
+        offset += poly_idx;
+        poly_idx = 0;
+        for (size_t i = 0; i < num_groups; ++i) {
+            concatenated_batched.add_scaled(concatenated_polynomials[i], rhos[offset + poly_idx]);
+            // for each element in a group
+            for (size_t j = 0; j < num_chunks_per_group; ++j) {
+                concatenation_groups_batched[j].add_scaled(concatenation_groups[i][j], rhos[offset + poly_idx]);
+            }
+            batched_evaluation += rhos[offset + poly_idx] * concatenated_evaluations[poly_idx];
+            ++poly_idx;
+        }
 
         // Compute the full batched polynomial f = f_batched + g_batched.shifted() = f_batched + h_batched. This is the
         // polynomial for which we compute the quotients q_k and prove f(u) = v_batched.
         auto f_polynomial = f_batched;
         f_polynomial += g_batched.shifted();
+        f_polynomial += concatenated_batched;
 
         // Compute the multilinear quotients q_k = q_k(X_0, ..., X_{k-1})
         auto quotients = compute_multilinear_quotients(f_polynomial, u_challenge);
@@ -386,8 +416,13 @@ template <typename Curve> class ZeroMorphProver_ {
             compute_partially_evaluated_degree_check_polynomial(batched_quotient, quotients, y_challenge, x_challenge);
 
         // Compute ZeroMorph identity polynomial Z partially evaluated at x
-        auto Z_x = compute_partially_evaluated_zeromorph_identity_polynomial(
-            f_batched, g_batched, quotients, batched_evaluation, u_challenge, x_challenge);
+        auto Z_x = compute_partially_evaluated_zeromorph_identity_polynomial(f_batched,
+                                                                             g_batched,
+                                                                             quotients,
+                                                                             batched_evaluation,
+                                                                             u_challenge,
+                                                                             x_challenge,
+                                                                             concatenation_groups_batched);
 
         // Compute batched degree-check and ZM-identity quotient polynomial pi
         auto pi_polynomial =
@@ -396,6 +431,27 @@ template <typename Curve> class ZeroMorphProver_ {
         // Compute and send proof commitment pi
         auto pi_commitment = commitment_key->commit(pi_polynomial);
         transcript.send_to_verifier("ZM:PI", pi_commitment);
+    }
+
+    static void prove(const auto& f_polynomials,
+                      const auto& g_polynomials,
+                      auto& evaluations,
+                      auto& multilinear_challenge,
+                      auto& commitment_key,
+                      auto& transcript,
+                      const std::vector<std::span<FF>>& concatenated_polynomials = {},
+                      const std::vector<std::vector<std::span<FF>>>& concatenation_groups = {})
+    {
+        return prove(f_polynomials,
+                     g_polynomials,
+                     evaluations.get_unshifted(),
+                     evaluations.get_shifted(),
+                     multilinear_challenge,
+                     commitment_key,
+                     transcript,
+                     concatenated_polynomials,
+                     evaluations.get_concatenated_constraints(),
+                     concatenation_groups);
     }
 };
 
@@ -468,7 +524,7 @@ template <typename Curve> class ZeroMorphVerifier_ {
      *              + concatentation_term
      * where
      *
-     *  concatenation_term = \sum{i=0}^{o-1}\sum_{j=0}^{concatenation_index}(rho^{m+l+i} * x^{j * min_N + 1}
+     *  concatenation_term = \sum{i=0}^{o-1}\sum_{j=0}^{num_chunks_per_group}(rho^{m+l+i} * x^{j * min_N + 1}
      *                       * concatenation_groups_commitments_{i}_{j})
      *
      * @note The concatenation term arises from an implementation detail in the Goblin Translator and is not part of the
@@ -490,7 +546,7 @@ template <typename Curve> class ZeroMorphVerifier_ {
                                     FF batched_evaluation,
                                     FF x_challenge,
                                     std::vector<FF> u_challenge,
-                                    std::vector<std::vector<Commitment>> concatenation_groups_commitments = {})
+                                    const std::vector<std::vector<Commitment>>& concatenation_groups_commitments = {})
     {
         size_t log_N = C_q_k.size();
         size_t N = 1 << log_N;
@@ -600,21 +656,33 @@ template <typename Curve> class ZeroMorphVerifier_ {
      * @param transcript
      * @return std::array<Commitment, 2> Inputs to the final pairing check
      */
-    static std::array<Commitment, 2> verify(auto& commitments,
-                                            auto& claimed_evaluations,
-                                            auto& multivariate_challenge,
-                                            auto& transcript)
+    static std::array<Commitment, 2> verify_internal(auto& commitments,
+                                                     auto&& unshifted_evaluations,
+                                                     [[maybe_unused]] auto&& shifted_evaluations,
+                                                     [[maybe_unused]] auto&& concatenated_evaluations,
+                                                     auto& multivariate_challenge,
+                                                     auto& transcript)
     {
         size_t log_N = multivariate_challenge.size();
         FF rho = transcript.get_challenge("rho");
 
         // Compute powers of batching challenge rho
-        std::vector<FF> rhos = pcs::zeromorph::powers_of_challenge(rho, claimed_evaluations.size());
+        std::vector<FF> rhos = pcs::zeromorph::powers_of_challenge(rho, 200); // WORKTODO
 
         // Construct batched evaluation v = sum_{i=0}^{m-1}\rho^i*f_i(u) + sum_{i=0}^{l-1}\rho^{m+i}*h_i(u)
         FF batched_evaluation = FF(0);
         size_t evaluation_idx = 0;
-        for (auto& value : claimed_evaluations.get_unshifted_then_shifted()) {
+        for (auto& value : unshifted_evaluations) {
+            batched_evaluation += value * rhos[evaluation_idx];
+            ++evaluation_idx;
+        }
+
+        for (auto& value : shifted_evaluations) {
+            batched_evaluation += value * rhos[evaluation_idx];
+            ++evaluation_idx;
+        }
+
+        for (auto& value : concatenated_evaluations) {
             batched_evaluation += value * rhos[evaluation_idx];
             ++evaluation_idx;
         }
@@ -645,7 +713,8 @@ template <typename Curve> class ZeroMorphVerifier_ {
                                          rho,
                                          batched_evaluation,
                                          x_challenge,
-                                         multivariate_challenge);
+                                         multivariate_challenge,
+                                         commitments.get_concatenation_groups());
 
         // Compute commitment C_{\zeta,Z}
         auto C_zeta_Z = C_zeta_x + C_Z_x * z_challenge;
@@ -662,6 +731,19 @@ template <typename Curve> class ZeroMorphVerifier_ {
         auto P1 = -C_pi;
 
         return { P0, P1 };
+    }
+
+    static std::array<Commitment, 2> verify(auto& commitments,
+                                            auto& claimed_evaluations,
+                                            auto& multivariate_challenge,
+                                            auto& transcript)
+    {
+        return verify_internal(commitments,
+                               claimed_evaluations.get_unshifted(),
+                               claimed_evaluations.get_shifted(),
+                               claimed_evaluations.get_concatenated_constraints(),
+                               multivariate_challenge,
+                               transcript);
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/zeromorph/zeromorph.hpp
@@ -328,7 +328,6 @@ template <typename Curve> class ZeroMorphProver_ {
 
         // Extract multilinear challenge u and claimed multilinear evaluations from Sumcheck output
         std::span<FF> u_challenge = multilinear_challenge;
-        // std::span<FF> claimed_evaluations = evaluations;
         size_t log_N = u_challenge.size();
         size_t N = 1 << log_N;
 

--- a/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra.hpp
@@ -324,6 +324,10 @@ class GoblinUltra {
         {
             return { ecc_op_wire_1, ecc_op_wire_2, ecc_op_wire_3, ecc_op_wire_4 };
         };
+
+        std::vector<HandleType> get_unshifted_then_shifted_then_special() { return {}; }
+        std::vector<HandleType> get_concatenated_constraints() { return {}; }
+
         // Gemini-specific getters.
         std::vector<HandleType> get_unshifted() override
         {
@@ -523,6 +527,8 @@ class GoblinUltra {
 
     class VerifierCommitments : public AllEntities<Commitment, CommitmentHandle> {
       public:
+        std::vector<std::vector<CommitmentHandle>> get_concatenation_groups() { return {}; }; // WORKTODO
+
         VerifierCommitments(std::shared_ptr<VerificationKey> verification_key,
                             [[maybe_unused]] const BaseTranscript<FF>& transcript)
         {

--- a/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra_recursive.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra_recursive.hpp
@@ -314,6 +314,9 @@ template <typename BuilderType> class GoblinUltraRecursive_ {
             return { ecc_op_wire_1, ecc_op_wire_2, ecc_op_wire_3, ecc_op_wire_4 };
         };
         // Gemini-specific getters.
+        std::vector<HandleType> get_unshifted_then_shifted_then_special() { return {}; }
+        std::vector<HandleType> get_concatenated_constraints() { return {}; }
+
         std::vector<HandleType> get_unshifted() override
         {
             return { q_c,
@@ -487,6 +490,8 @@ template <typename BuilderType> class GoblinUltraRecursive_ {
 
     class VerifierCommitments : public AllEntities<Commitment, CommitmentHandle> {
       public:
+        std::vector<std::vector<CommitmentHandle>> get_concatenation_groups() { return {}; };
+
         VerifierCommitments(std::shared_ptr<VerificationKey> verification_key)
         {
             this->q_m = verification_key->q_m;

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra.hpp
@@ -304,6 +304,9 @@ class Ultra {
             return { table_1_shift, table_2_shift, table_3_shift,      table_4_shift, w_l_shift,     w_r_shift,
                      w_o_shift,     w_4_shift,     sorted_accum_shift, z_perm_shift,  z_lookup_shift };
         };
+
+        std::vector<HandleType> get_concatenated_constraints() { return {}; }
+        std::vector<HandleType> get_unshifted_then_shifted_then_special() { return {}; }
     };
 
   public:
@@ -440,6 +443,8 @@ class Ultra {
 
     class VerifierCommitments : public AllEntities<Commitment, CommitmentHandle> {
       public:
+        std::vector<std::vector<CommitmentHandle>> get_concatenation_groups() { return {}; };
+
         VerifierCommitments(std::shared_ptr<VerificationKey> verification_key,
                             [[maybe_unused]] const BaseTranscript<FF>& transcript)
         {

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_recursive.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_recursive.hpp
@@ -272,6 +272,9 @@ template <typename BuilderType> class UltraRecursive_ {
 
         std::vector<HandleType> get_wires() override { return { w_l, w_r, w_o, w_4 }; };
         // Gemini-specific getters.
+        std::vector<HandleType> get_unshifted_then_shifted_then_special() { return {}; }
+        std::vector<HandleType> get_concatenated_constraints() { return {}; }
+
         std::vector<HandleType> get_unshifted() override
         {
             return { q_c,           q_l,   q_r,      q_o,     q_4,     q_m,          q_arith, q_sort,
@@ -401,6 +404,8 @@ template <typename BuilderType> class UltraRecursive_ {
 
     class VerifierCommitments : public AllEntities<Commitment, CommitmentHandle> {
       public:
+        std::vector<std::vector<CommitmentHandle>> get_concatenation_groups() { return {}; };
+
         VerifierCommitments(std::shared_ptr<VerificationKey> verification_key)
         {
             this->q_m = verification_key->q_m;


### PR DESCRIPTION
This PR adds polynomial "concatenation" functionality into ZeroMorph.

The idea behind concatenation is the following: given several polynomials (for example, $X_1$, $X_2$, $X_3$, $X_4$, $Y_1$, $Y_2$, $Y_3$, $Y_4$)  of length n, we want to show that the set of values in $X$ polynomials is identical to the values in $Y$.The way we can do it is with a grand product argument, however sumcheck complexity of the grand product argument is quadratic in the number of polynomials that are used in the GP (we have to extend the univariate to the degree d and then we need to multiply those (d+1) elements d times). However, if we were to perform the same grand product instead on polynomials $X= (X_1|X_2|X_3|X_4)$ and $Y=(Y_1|Y_2|Y_3|Y_4)$, the length of the sumcheck would increase 4 times, but the degree d would decrease proportionately. 

So let's say we have an original circuit of length n, where all non-permutation relations are satisfied (including on $X_i$ and $Y_i$ polynomials). However, for the grand product argument we extend the polynomials to length $k\cdot n$ , where $k$ is a power of 2. Then we use the property of Zeromorph that it uses univariate commitments for commiting to multilinear polynomials. Because of this property, the final univariate opening of $X$ at challenge $x$ is equivalent to opening $X_1+x^n\cdot X_2+x^{2n}\cdot X_3+x^{3n}\cdot X_4$. So what we do in Zeromorph is substitute the opening of a concatenated polynomial by opening of a polynomial derived from a combination of $X_i$ polynomials multiplied by powers of $x$. This allows us to have fewer commitments and avoid shifts to prove the composition of concatenated polynomials

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
