### PR TITLE
chore: Remove bn254 instantiation of eccvm plus naming changes

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.cpp
@@ -115,6 +115,5 @@ std::shared_ptr<typename Flavor::VerificationKey> ECCVMComposer_<Flavor>::comput
     return verification_key;
 }
 template class ECCVMComposer_<honk::flavor::ECCVM>;
-template class ECCVMComposer_<honk::flavor::ECCVMGrumpkin>;
 
 } // namespace proof_system::honk

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.hpp
@@ -33,14 +33,9 @@ template <ECCVMFlavor Flavor> class ECCVMComposer_ {
     bool contains_recursive_proof = false;
     bool computed_witness = false;
     ECCVMComposer_()
-        requires(std::same_as<Flavor, honk::flavor::ECCVMGrumpkin>)
-    {
-        crs_factory_ = barretenberg::srs::get_grumpkin_crs_factory();
-    };
-    ECCVMComposer_()
         requires(std::same_as<Flavor, honk::flavor::ECCVM>)
     {
-        crs_factory_ = barretenberg::srs::get_crs_factory();
+        crs_factory_ = barretenberg::srs::get_grumpkin_crs_factory();
     };
 
     explicit ECCVMComposer_(
@@ -75,10 +70,8 @@ template <ECCVMFlavor Flavor> class ECCVMComposer_ {
     };
 };
 extern template class ECCVMComposer_<honk::flavor::ECCVM>;
-extern template class ECCVMComposer_<honk::flavor::ECCVMGrumpkin>;
 
 // TODO(#532): this pattern is weird; is this not instantiating the templates?
 using ECCVMComposer = ECCVMComposer_<honk::flavor::ECCVM>;
-using ECCVMGrumpkinComposer = ECCVMComposer_<honk::flavor::ECCVMGrumpkin>;
 
 } // namespace proof_system::honk

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.test.cpp
@@ -21,7 +21,7 @@ template <typename Flavor> class ECCVMComposerTests : public ::testing::Test {
     // TODO(640): The Standard Honk on Grumpkin test suite fails unless the SRS is initialized for every test.
     void SetUp() override
     {
-        if constexpr (std::is_same<Flavor, flavor::ECCVMGrumpkin>::value) {
+        if constexpr (std::is_same<Flavor, flavor::ECCVM>::value) {
             barretenberg::srs::init_grumpkin_crs_factory("../srs_db/grumpkin");
         } else {
             barretenberg::srs::init_crs_factory("../srs_db/ignition");
@@ -29,7 +29,7 @@ template <typename Flavor> class ECCVMComposerTests : public ::testing::Test {
     };
 };
 
-using FlavorTypes = ::testing::Types<flavor::ECCVM, flavor::ECCVMGrumpkin>;
+using FlavorTypes = ::testing::Types<flavor::ECCVM>;
 TYPED_TEST_SUITE(ECCVMComposerTests, FlavorTypes);
 
 namespace {
@@ -83,6 +83,7 @@ TYPED_TEST(ECCVMComposerTests, BaseCase)
     auto proof = prover.construct_proof();
     auto verifier = composer.create_verifier(circuit_constructor);
     bool verified = verifier.verify_proof(proof);
+
     ASSERT_TRUE(verified);
 }
 

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
@@ -9,14 +9,6 @@
 #include "barretenberg/relations/lookup_relation.hpp"
 #include "barretenberg/relations/permutation_relation.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
-#include <algorithm>
-#include <array>
-#include <cstddef>
-#include <memory>
-#include <span>
-#include <string>
-#include <utility>
-#include <vector>
 
 namespace proof_system::honk {
 
@@ -43,8 +35,8 @@ ECCVMProver_<Flavor>::ECCVMProver_(std::shared_ptr<typename Flavor::ProvingKey> 
     prover_polynomials.transcript_msm_transition = key->transcript_msm_transition;
     prover_polynomials.transcript_pc = key->transcript_pc;
     prover_polynomials.transcript_msm_count = key->transcript_msm_count;
-    prover_polynomials.transcript_x = key->transcript_x;
-    prover_polynomials.transcript_y = key->transcript_y;
+    prover_polynomials.transcript_Px = key->transcript_Px;
+    prover_polynomials.transcript_Py = key->transcript_Py;
     prover_polynomials.transcript_z1 = key->transcript_z1;
     prover_polynomials.transcript_z2 = key->transcript_z2;
     prover_polynomials.transcript_z1zero = key->transcript_z1zero;
@@ -319,47 +311,29 @@ template <ECCVMFlavor Flavor> plonk::proof& ECCVMProver_<Flavor>::export_proof()
 
 template <ECCVMFlavor Flavor> plonk::proof& ECCVMProver_<Flavor>::construct_proof()
 {
-    // Add circuit size public input size and public inputs to transcript.
     execute_preamble_round();
 
-    // Compute first three wire commitments
     execute_wire_commitments_round();
 
-    // Compute sorted list accumulator and commitment
     execute_log_derivative_commitments_round();
 
-    // Fiat-Shamir: beta & gamma
-    // Compute grand product(s) and commitments.
     execute_grand_product_computation_round();
 
-    // Fiat-Shamir: alpha
-    // Run sumcheck subprotocol.
     execute_relation_check_rounds();
 
-    // Fiat-Shamir: rho
-    // Compute Fold polynomials and their commitments.
     execute_univariatization_round();
 
-    // Fiat-Shamir: r
-    // Compute Fold evaluations
     execute_pcs_evaluation_round();
 
-    // Fiat-Shamir: nu
-    // Compute Shplonk batched quotient commitment Q
     execute_shplonk_batched_quotient_round();
 
-    // Fiat-Shamir: z
-    // Compute partial evaluation Q_z
     execute_shplonk_partial_evaluation_round();
 
-    // Fiat-Shamir: z
-    // Compute PCS opening proof (either KZG quotient commitment or IPA opening proof)
     execute_final_pcs_round();
 
     return export_proof();
 }
 
 template class ECCVMProver_<honk::flavor::ECCVM>;
-template class ECCVMProver_<honk::flavor::ECCVMGrumpkin>;
 
 } // namespace proof_system::honk

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.hpp
@@ -74,8 +74,5 @@ template <ECCVMFlavor Flavor> class ECCVMProver_ {
 };
 
 extern template class ECCVMProver_<honk::flavor::ECCVM>;
-extern template class ECCVMProver_<honk::flavor::ECCVMGrumpkin>;
-
-using ECCVMProver = ECCVMProver_<honk::flavor::ECCVM>;
 
 } // namespace proof_system::honk

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
@@ -70,8 +70,8 @@ template <typename Flavor> bool ECCVMVerifier_<Flavor>::verify_proof(const plonk
     commitments.transcript_pc = transcript.template receive_from_prover<Commitment>(commitment_labels.transcript_pc);
     commitments.transcript_msm_count =
         transcript.template receive_from_prover<Commitment>(commitment_labels.transcript_msm_count);
-    commitments.transcript_x = transcript.template receive_from_prover<Commitment>(commitment_labels.transcript_x);
-    commitments.transcript_y = transcript.template receive_from_prover<Commitment>(commitment_labels.transcript_y);
+    commitments.transcript_Px = transcript.template receive_from_prover<Commitment>(commitment_labels.transcript_Px);
+    commitments.transcript_Py = transcript.template receive_from_prover<Commitment>(commitment_labels.transcript_Py);
     commitments.transcript_z1 = transcript.template receive_from_prover<Commitment>(commitment_labels.transcript_z1);
     commitments.transcript_z2 = transcript.template receive_from_prover<Commitment>(commitment_labels.transcript_z2);
     commitments.transcript_z1zero =
@@ -261,6 +261,5 @@ template <typename Flavor> bool ECCVMVerifier_<Flavor>::verify_proof(const plonk
 }
 
 template class ECCVMVerifier_<honk::flavor::ECCVM>;
-template class ECCVMVerifier_<honk::flavor::ECCVMGrumpkin>;
 
 } // namespace proof_system::honk

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.hpp
@@ -40,9 +40,6 @@ template <typename Flavor> class ECCVMVerifier_ {
 };
 
 extern template class ECCVMVerifier_<honk::flavor::ECCVM>;
-extern template class ECCVMVerifier_<honk::flavor::ECCVMGrumpkin>;
-
-using ECCVMVerifier = ECCVMVerifier_<honk::flavor::ECCVM>;
-using ECCVMVerifierGrumpkin = ECCVMVerifier_<honk::flavor::ECCVMGrumpkin>;
+using ECCVMVerifierGrumpkin = ECCVMVerifier_<honk::flavor::ECCVM>;
 
 } // namespace proof_system::honk

--- a/barretenberg/cpp/src/barretenberg/flavor/ecc_vm.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ecc_vm.hpp
@@ -114,8 +114,8 @@ template <typename CycleGroup_T, typename Curve_T, typename PCS_T> class ECCVMBa
         DataType transcript_msm_transition;    // column 4
         DataType transcript_pc;                // column 5
         DataType transcript_msm_count;         // column 6
-        DataType transcript_x;                 // column 7
-        DataType transcript_y;                 // column 8
+        DataType transcript_Px;                // column 7
+        DataType transcript_Py;                // column 8
         DataType transcript_z1;                // column 9
         DataType transcript_z2;                // column 10
         DataType transcript_z1zero;            // column 11
@@ -192,8 +192,8 @@ template <typename CycleGroup_T, typename Curve_T, typename PCS_T> class ECCVMBa
                             &transcript_msm_transition,
                             &transcript_pc,
                             &transcript_msm_count,
-                            &transcript_x,
-                            &transcript_y,
+                            &transcript_Px,
+                            &transcript_Py,
                             &transcript_z1,
                             &transcript_z2,
                             &transcript_z1zero,
@@ -271,8 +271,8 @@ template <typename CycleGroup_T, typename Curve_T, typename PCS_T> class ECCVMBa
                 transcript_msm_transition,
                 transcript_pc,
                 transcript_msm_count,
-                transcript_x,
-                transcript_y,
+                transcript_Px,
+                transcript_Py,
                 transcript_z1,
                 transcript_z2,
                 transcript_z1zero,
@@ -366,8 +366,8 @@ template <typename CycleGroup_T, typename Curve_T, typename PCS_T> class ECCVMBa
         DataType transcript_msm_transition;          // column 7
         DataType transcript_pc;                      // column 8
         DataType transcript_msm_count;               // column 9
-        DataType transcript_x;                       // column 10
-        DataType transcript_y;                       // column 11
+        DataType transcript_Px;                      // column 10
+        DataType transcript_Py;                      // column 11
         DataType transcript_z1;                      // column 12
         DataType transcript_z2;                      // column 13
         DataType transcript_z1zero;                  // column 14
@@ -484,8 +484,8 @@ template <typename CycleGroup_T, typename Curve_T, typename PCS_T> class ECCVMBa
                             &transcript_msm_transition,
                             &transcript_pc,
                             &transcript_msm_count,
-                            &transcript_x,
-                            &transcript_y,
+                            &transcript_Px,
+                            &transcript_Py,
                             &transcript_z1,
                             &transcript_z2,
                             &transcript_z1zero,
@@ -589,8 +589,8 @@ template <typename CycleGroup_T, typename Curve_T, typename PCS_T> class ECCVMBa
                 transcript_msm_transition,
                 transcript_pc,
                 transcript_msm_count,
-                transcript_x,
-                transcript_y,
+                transcript_Px,
+                transcript_Py,
                 transcript_z1,
                 transcript_z2,
                 transcript_z1zero,
@@ -669,8 +669,8 @@ template <typename CycleGroup_T, typename Curve_T, typename PCS_T> class ECCVMBa
                 transcript_eq,
                 transcript_collision_check,
                 transcript_msm_transition,
-                transcript_x,
-                transcript_y,
+                transcript_Px,
+                transcript_Py,
                 transcript_z1,
                 transcript_z2,
                 transcript_z1zero,
@@ -923,8 +923,8 @@ template <typename CycleGroup_T, typename Curve_T, typename PCS_T> class ECCVMBa
             Base::transcript_msm_transition = "TRANSCRIPT_MSM_TRANSITION";
             Base::transcript_pc = "TRANSCRIPT_PC";
             Base::transcript_msm_count = "TRANSCRIPT_MSM_COUNT";
-            Base::transcript_x = "TRANSCRIPT_X";
-            Base::transcript_y = "TRANSCRIPT_Y";
+            Base::transcript_Px = "TRANSCRIPT_PX";
+            Base::transcript_Py = "TRANSCRIPT_PY";
             Base::transcript_z1 = "TRANSCRIPT_Z1";
             Base::transcript_z2 = "TRANSCRIPT_Z2";
             Base::transcript_z1zero = "TRANSCRIPT_Z1ZERO";
@@ -1028,8 +1028,8 @@ template <typename CycleGroup_T, typename Curve_T, typename PCS_T> class ECCVMBa
         Commitment transcript_msm_transition_comm;
         Commitment transcript_pc_comm;
         Commitment transcript_msm_count_comm;
-        Commitment transcript_x_comm;
-        Commitment transcript_y_comm;
+        Commitment transcript_Px_comm;
+        Commitment transcript_Py_comm;
         Commitment transcript_z1_comm;
         Commitment transcript_z2_comm;
         Commitment transcript_z1zero_comm;
@@ -1136,9 +1136,9 @@ template <typename CycleGroup_T, typename Curve_T, typename PCS_T> class ECCVMBa
                 BaseTranscript<FF>::proof_data, num_bytes_read);
             transcript_msm_count_comm = BaseTranscript<FF>::template deserialize_from_buffer<Commitment>(
                 BaseTranscript<FF>::proof_data, num_bytes_read);
-            transcript_x_comm = BaseTranscript<FF>::template deserialize_from_buffer<Commitment>(
+            transcript_Px_comm = BaseTranscript<FF>::template deserialize_from_buffer<Commitment>(
                 BaseTranscript<FF>::proof_data, num_bytes_read);
-            transcript_y_comm = BaseTranscript<FF>::template deserialize_from_buffer<Commitment>(
+            transcript_Py_comm = BaseTranscript<FF>::template deserialize_from_buffer<Commitment>(
                 BaseTranscript<FF>::proof_data, num_bytes_read);
             transcript_z1_comm = BaseTranscript<FF>::template deserialize_from_buffer<Commitment>(
                 BaseTranscript<FF>::proof_data, num_bytes_read);
@@ -1328,8 +1328,8 @@ template <typename CycleGroup_T, typename Curve_T, typename PCS_T> class ECCVMBa
                                                              BaseTranscript<FF>::proof_data);
             BaseTranscript<FF>::template serialize_to_buffer(transcript_pc_comm, BaseTranscript<FF>::proof_data);
             BaseTranscript<FF>::template serialize_to_buffer(transcript_msm_count_comm, BaseTranscript<FF>::proof_data);
-            BaseTranscript<FF>::template serialize_to_buffer(transcript_x_comm, BaseTranscript<FF>::proof_data);
-            BaseTranscript<FF>::template serialize_to_buffer(transcript_y_comm, BaseTranscript<FF>::proof_data);
+            BaseTranscript<FF>::template serialize_to_buffer(transcript_Px_comm, BaseTranscript<FF>::proof_data);
+            BaseTranscript<FF>::template serialize_to_buffer(transcript_Py_comm, BaseTranscript<FF>::proof_data);
             BaseTranscript<FF>::template serialize_to_buffer(transcript_z1_comm, BaseTranscript<FF>::proof_data);
             BaseTranscript<FF>::template serialize_to_buffer(transcript_z2_comm, BaseTranscript<FF>::proof_data);
             BaseTranscript<FF>::template serialize_to_buffer(transcript_z1zero_comm, BaseTranscript<FF>::proof_data);
@@ -1433,20 +1433,19 @@ template <typename CycleGroup_T, typename Curve_T, typename PCS_T> class ECCVMBa
     };
 };
 
-class ECCVM : public ECCVMBase<grumpkin::g1, curve::BN254, pcs::kzg::KZG<curve::BN254>> {};
-class ECCVMGrumpkin : public ECCVMBase<barretenberg::g1, curve::Grumpkin, pcs::ipa::IPA<curve::Grumpkin>> {};
+class ECCVM : public ECCVMBase<barretenberg::g1, curve::Grumpkin, pcs::ipa::IPA<curve::Grumpkin>> {};
 
 // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 
 } // namespace flavor
 namespace sumcheck {
 
-extern template class ECCVMTranscriptRelationImpl<barretenberg::fr>;
-extern template class ECCVMWnafRelationImpl<barretenberg::fr>;
-extern template class ECCVMPointTableRelationImpl<barretenberg::fr>;
-extern template class ECCVMMSMRelationImpl<barretenberg::fr>;
-extern template class ECCVMSetRelationImpl<barretenberg::fr>;
-extern template class ECCVMLookupRelationImpl<barretenberg::fr>;
+extern template class ECCVMTranscriptRelationImpl<grumpkin::fr>;
+extern template class ECCVMWnafRelationImpl<grumpkin::fr>;
+extern template class ECCVMPointTableRelationImpl<grumpkin::fr>;
+extern template class ECCVMMSMRelationImpl<grumpkin::fr>;
+extern template class ECCVMSetRelationImpl<grumpkin::fr>;
+extern template class ECCVMLookupRelationImpl<grumpkin::fr>;
 
 DECLARE_SUMCHECK_RELATION_CLASS(ECCVMTranscriptRelationImpl, flavor::ECCVM);
 DECLARE_SUMCHECK_RELATION_CLASS(ECCVMWnafRelationImpl, flavor::ECCVM);
@@ -1455,14 +1454,6 @@ DECLARE_SUMCHECK_RELATION_CLASS(ECCVMMSMRelationImpl, flavor::ECCVM);
 DECLARE_SUMCHECK_RELATION_CLASS(ECCVMSetRelationImpl, flavor::ECCVM);
 DECLARE_SUMCHECK_RELATION_CLASS(ECCVMLookupRelationImpl, flavor::ECCVM);
 
-DECLARE_SUMCHECK_RELATION_CLASS(ECCVMTranscriptRelationImpl, flavor::ECCVMGrumpkin);
-DECLARE_SUMCHECK_RELATION_CLASS(ECCVMWnafRelationImpl, flavor::ECCVMGrumpkin);
-DECLARE_SUMCHECK_RELATION_CLASS(ECCVMPointTableRelationImpl, flavor::ECCVMGrumpkin);
-DECLARE_SUMCHECK_RELATION_CLASS(ECCVMMSMRelationImpl, flavor::ECCVMGrumpkin);
-DECLARE_SUMCHECK_RELATION_CLASS(ECCVMSetRelationImpl, flavor::ECCVMGrumpkin);
-DECLARE_SUMCHECK_RELATION_CLASS(ECCVMLookupRelationImpl, flavor::ECCVMGrumpkin);
-
 DECLARE_SUMCHECK_PERMUTATION_CLASS(ECCVMSetRelationImpl, flavor::ECCVM);
-DECLARE_SUMCHECK_PERMUTATION_CLASS(ECCVMSetRelationImpl, flavor::ECCVMGrumpkin);
 } // namespace sumcheck
 } // namespace proof_system::honk

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -301,7 +301,6 @@ template <typename Tuple, std::size_t Index = 0> static constexpr auto create_tu
 namespace proof_system::honk::flavor {
 class Ultra;
 class ECCVM;
-class ECCVMGrumpkin;
 class GoblinUltra;
 template <typename BuilderType> class UltraRecursive_;
 template <typename BuilderType> class GoblinUltraRecursive_;
@@ -343,11 +342,11 @@ concept IsRecursiveFlavor = IsAnyOf<T, honk::flavor::UltraRecursive_<UltraCircui
                                        honk::flavor::GoblinUltraRecursive_<UltraCircuitBuilder>, 
                                        honk::flavor::GoblinUltraRecursive_<GoblinUltraCircuitBuilder>>;
 
-template <typename T> concept IsGrumpkinFlavor = IsAnyOf<T, honk::flavor::ECCVMGrumpkin>;
+template <typename T> concept IsGrumpkinFlavor = IsAnyOf<T, honk::flavor::ECCVM>;
 
 template <typename T> concept UltraFlavor = IsAnyOf<T, honk::flavor::Ultra, honk::flavor::GoblinUltra>;
 
-template <typename T> concept ECCVMFlavor = IsAnyOf<T, honk::flavor::ECCVM, honk::flavor::ECCVMGrumpkin>;
+template <typename T> concept ECCVMFlavor = IsAnyOf<T, honk::flavor::ECCVM>;
 
 // clang-format on
 } // namespace proof_system

--- a/barretenberg/cpp/src/barretenberg/goblin/full_goblin_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/full_goblin_composer.test.cpp
@@ -30,7 +30,7 @@ class FullGoblinComposerTests : public ::testing::Test {
     using CommitmentKey = proof_system::honk::pcs::CommitmentKey<Curve>;
     using GoblinUltraBuilder = proof_system::GoblinUltraCircuitBuilder;
     using GoblinUltraComposer = proof_system::honk::GoblinUltraComposer;
-    using ECCVMFlavor = proof_system::honk::flavor::ECCVMGrumpkin;
+    using ECCVMFlavor = proof_system::honk::flavor::ECCVM;
     using ECCVMBuilder = proof_system::ECCVMCircuitBuilder<ECCVMFlavor>;
     using ECCVMComposer = proof_system::honk::ECCVMComposer_<ECCVMFlavor>;
     using VMOp = proof_system_eccvm::VMOperation<ECCVMFlavor::CycleGroup>;

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/eccvm_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/eccvm_circuit_builder.hpp
@@ -253,8 +253,8 @@ template <typename Flavor> class ECCVMCircuitBuilder {
      multiplication?
      *          transcript_pc: point counter for transcript columns
      *          transcript_msm_count: counts number of muls processed in an ongoing multiscalar multiplication
-     *          transcript_x: input transcript point, x-coordinate
-     *          transcript_y: input transcriot point, y-coordinate
+     *          transcript_Px: input transcript point, x-coordinate
+     *          transcript_Py: input transcriot point, y-coordinate
      *          transcript_op: input transcript opcode value
      *          transcript_z1: input transcript scalar multiplier (low component, 128 bits max)
      *          transcript_z2: input transcript scalar multipplier (high component, 128 bits max)
@@ -365,8 +365,8 @@ template <typename Flavor> class ECCVMCircuitBuilder {
             polys.transcript_msm_transition[i] = transcript_state[i].msm_transition;
             polys.transcript_pc[i] = transcript_state[i].pc;
             polys.transcript_msm_count[i] = transcript_state[i].msm_count;
-            polys.transcript_x[i] = transcript_state[i].base_x;
-            polys.transcript_y[i] = transcript_state[i].base_y;
+            polys.transcript_Px[i] = transcript_state[i].base_x;
+            polys.transcript_Py[i] = transcript_state[i].base_y;
             polys.transcript_z1[i] = transcript_state[i].z1;
             polys.transcript_z2[i] = transcript_state[i].z2;
             polys.transcript_z1zero[i] = transcript_state[i].z1_zero;

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/eccvm_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/eccvm_circuit_builder.test.cpp
@@ -13,7 +13,7 @@ namespace eccvm_circuit_builder_tests {
 
 template <typename Flavor> class ECCVMCircuitBuilderTests : public ::testing::Test {};
 
-using FlavorTypes = ::testing::Types<proof_system::honk::flavor::ECCVM, proof_system::honk::flavor::ECCVMGrumpkin>;
+using FlavorTypes = ::testing::Types<proof_system::honk::flavor::ECCVM>;
 TYPED_TEST_SUITE(ECCVMCircuitBuilderTests, FlavorTypes);
 
 TYPED_TEST(ECCVMCircuitBuilderTests, BaseCase)

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_lookup_relation.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_lookup_relation.cpp
@@ -32,6 +32,5 @@ void ECCVMLookupRelationImpl<FF>::accumulate(ContainerOverSubrelations& accumula
 template class ECCVMLookupRelationImpl<barretenberg::fr>;
 template class ECCVMLookupRelationImpl<grumpkin::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(ECCVMLookupRelationImpl, flavor::ECCVM);
-DEFINE_SUMCHECK_RELATION_CLASS(ECCVMLookupRelationImpl, flavor::ECCVMGrumpkin);
 
 } // namespace proof_system::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_msm_relation.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_msm_relation.cpp
@@ -391,8 +391,7 @@ void ECCVMMSMRelationImpl<FF>::accumulate(ContainerOverSubrelations& accumulator
     // perform lookups on (pc / slice_i / x / y)
 }
 
-template class ECCVMMSMRelationImpl<barretenberg::fr>;
+template class ECCVMMSMRelationImpl<grumpkin::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(ECCVMMSMRelationImpl, flavor::ECCVM);
-DEFINE_SUMCHECK_RELATION_CLASS(ECCVMMSMRelationImpl, flavor::ECCVMGrumpkin);
 
 } // namespace proof_system::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_point_table_relation.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_point_table_relation.cpp
@@ -172,8 +172,7 @@ void ECCVMPointTableRelationImpl<FF>::accumulate(ContainerOverSubrelations& accu
         (-lagrange_first + 1) * (-precompute_point_transition + 1) * y_add_check * scaling_factor;
 }
 
-template class ECCVMPointTableRelationImpl<barretenberg::fr>;
+template class ECCVMPointTableRelationImpl<grumpkin::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(ECCVMPointTableRelationImpl, flavor::ECCVM);
-DEFINE_SUMCHECK_RELATION_CLASS(ECCVMPointTableRelationImpl, flavor::ECCVMGrumpkin);
 
 } // namespace proof_system::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_set_relation.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_set_relation.cpp
@@ -232,7 +232,7 @@ Accumulator ECCVMSetRelationImpl<FF>::compute_permutation_denominator(const AllE
     using View = typename Accumulator::View;
 
     // TODO(@zac-williamson). The degree of this contribution is 17! makes overall relation degree 19.
-    // Can optimize by refining the algebra, once we have a stable base to iterate off of.
+    // Can optimise by refining the algebra, once we have a stable base to iterate off of.
     const auto& gamma = params.gamma;
     const auto& beta = params.beta;
     const auto& beta_sqr = params.beta_sqr;
@@ -280,16 +280,16 @@ Accumulator ECCVMSetRelationImpl<FF>::compute_permutation_denominator(const AllE
     }
 
     /**
-     * @brief Second term: tuple of (transcript_pc, transcript_x, transcript_y, z1) OR (transcript_pc, \lambda *
-     * transcript_x, -transcript_y, z2) for each scalar multiplication in ECCVMTranscriptRelation columns. (the latter
+     * @brief Second term: tuple of (transcript_pc, transcript_Px, transcript_Py, z1) OR (transcript_pc, \lambda *
+     * transcript_Px, -transcript_Py, z2) for each scalar multiplication in ECCVMTranscriptRelation columns. (the latter
      * term uses the curve endomorphism: \lambda = cube root of unity). These values must be equivalent to the second
      * term values in `compute_permutation_numerator`
      */
     {
         const auto& transcript_pc = View(in.transcript_pc);
 
-        auto transcript_x = View(in.transcript_x);
-        auto transcript_y = View(in.transcript_y);
+        auto transcript_Px = View(in.transcript_Px);
+        auto transcript_Py = View(in.transcript_Py);
         auto z1 = View(in.transcript_z1);
         auto z2 = View(in.transcript_z2);
         auto z1_zero = View(in.transcript_z1zero);
@@ -300,9 +300,9 @@ Accumulator ECCVMSetRelationImpl<FF>::compute_permutation_denominator(const AllE
         auto lookup_second = (-z2_zero + 1);
         FF endomorphism_base_field_shift = FF::cube_root_of_unity();
 
-        auto transcript_input1 = transcript_pc + transcript_x * beta + transcript_y * beta_sqr + z1 * beta_cube;
-        auto transcript_input2 = (transcript_pc - 1) + transcript_x * endomorphism_base_field_shift * beta -
-                                 transcript_y * beta_sqr + z2 * beta_cube;
+        auto transcript_input1 = transcript_pc + transcript_Px * beta + transcript_Py * beta_sqr + z1 * beta_cube;
+        auto transcript_input2 = (transcript_pc - 1) + transcript_Px * endomorphism_base_field_shift * beta -
+                                 transcript_Py * beta_sqr + z2 * beta_cube;
 
         // | q_mul | z2_zero | z1_zero | lookup                 |
         // | ----- | ------- | ------- | ---------------------- |
@@ -393,10 +393,8 @@ void ECCVMSetRelationImpl<FF>::accumulate(ContainerOverSubrelations& accumulator
     std::get<1>(accumulator) += (lagrange_last * z_perm_shift) * scaling_factor;
 }
 
-template class ECCVMSetRelationImpl<barretenberg::fr>;
+template class ECCVMSetRelationImpl<grumpkin::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(ECCVMSetRelationImpl, flavor::ECCVM);
-DEFINE_SUMCHECK_RELATION_CLASS(ECCVMSetRelationImpl, flavor::ECCVMGrumpkin);
 DEFINE_SUMCHECK_PERMUTATION_CLASS(ECCVMSetRelationImpl, flavor::ECCVM);
-DEFINE_SUMCHECK_PERMUTATION_CLASS(ECCVMSetRelationImpl, flavor::ECCVMGrumpkin);
 
 } // namespace proof_system::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_wnaf_relation.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_wnaf_relation.cpp
@@ -216,8 +216,7 @@ void ECCVMWnafRelationImpl<FF>::accumulate(ContainerOverSubrelations& accumulato
     // the set equivalence relation
 }
 
-template class ECCVMWnafRelationImpl<barretenberg::fr>;
+template class ECCVMWnafRelationImpl<grumpkin::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(ECCVMWnafRelationImpl, flavor::ECCVM);
-DEFINE_SUMCHECK_RELATION_CLASS(ECCVMWnafRelationImpl, flavor::ECCVMGrumpkin);
 
 } // namespace proof_system::honk::sumcheck


### PR DESCRIPTION
Removing bn254 ECCVM instantiation plus some minor naming changes and cleanup. (Split out from larger PR by @codygunton)

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
