### PR TITLE
fix: bootstrap bbjs.

### DIFF
--- a/barretenberg/bootstrap.sh
+++ b/barretenberg/bootstrap.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
+set -eu
+
+# Navigate to script folder
+cd "$(dirname "$0")"
+
 (cd cpp && ./bootstrap.sh)
-cd ts
-yarn build
-npm link
+(cd ts && yarn install --immutable && yarn build && npm link)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -70,7 +70,7 @@ if [[ -f .bootstrapped && $(cat .bootstrapped) -eq "$VERSION" ]]; then
   (cd circuits/cpp && cmake --build --preset wasm -j --target aztec3-circuits.wasm)
 else
   # Heavy bootstrap.
-  barretenberg/cpp/bootstrap.sh
+  barretenberg/bootstrap.sh
   circuits/cpp/bootstrap.sh
   yarn-project/bootstrap.sh
 

--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -27,7 +27,6 @@ yarn workspace @aztec/circuits.js remake-bindings
 yarn workspace @aztec/circuits.js remake-constants
 
 (cd noir-contracts && ./bootstrap.sh)
-(cd boxes && ./bootstrap.sh)
 (cd .. && l1-contracts/bootstrap.sh)
 
 # We do not need to build individual packages, yarn build will build the root tsconfig.json


### PR DESCRIPTION
As title.
Removing bootstrapping boxes as:
* It doesn't work (think it needs to be done after the yarn build), and it doesn't fail due to missing `set -e` flags.
* It isn't needed? We only need to bootstrap what's needed to get a working dev env for running tests.