### PR TITLE
chore: Enforce bracing around blocks. Generally considered easier to read and less error prone.

### DIFF
--- a/yarn-project/acir-simulator/package.json
+++ b/yarn-project/acir-simulator/package.json
@@ -15,7 +15,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"
   },
   "inherits": [

--- a/yarn-project/acir-simulator/src/acvm/deserialize.ts
+++ b/yarn-project/acir-simulator/src/acvm/deserialize.ts
@@ -105,7 +105,9 @@ export class PublicInputsReader {
    */
   public readField(): Fr {
     const acvmField = this.publicInputs.shift();
-    if (!acvmField) throw new Error('Not enough public inputs');
+    if (!acvmField) {
+      throw new Error('Not enough public inputs');
+    }
     return fromACVMField(acvmField);
   }
 

--- a/yarn-project/acir-simulator/src/acvm/oracle/oracle.ts
+++ b/yarn-project/acir-simulator/src/acvm/oracle/oracle.ts
@@ -49,7 +49,9 @@ export class Oracle {
   async getAuthWitness([messageHash]: ACVMField[]): Promise<ACVMField[]> {
     const messageHashField = fromACVMField(messageHash);
     const witness = await this.typedOracle.getAuthWitness(messageHashField);
-    if (!witness) throw new Error(`Authorization not found for message hash ${messageHashField}`);
+    if (!witness) {
+      throw new Error(`Authorization not found for message hash ${messageHashField}`);
+    }
     return witness.map(toACVMField);
   }
 

--- a/yarn-project/acir-simulator/src/client/pick_notes.ts
+++ b/yarn-project/acir-simulator/src/client/pick_notes.ts
@@ -78,10 +78,14 @@ const selectNotes = <T extends ContainsNote>(noteDatas: T[], selects: Select[]):
   noteDatas.filter(noteData => selects.every(({ index, value }) => noteData.note.items[index]?.equals(value)));
 
 const sortNotes = (a: Fr[], b: Fr[], sorts: Sort[], level = 0): number => {
-  if (sorts[level] === undefined) return 0;
+  if (sorts[level] === undefined) {
+    return 0;
+  }
 
   const { index, order } = sorts[level];
-  if (order === 0) return 0;
+  if (order === 0) {
+    return 0;
+  }
 
   const dir = order === 1 ? [-1, 1] : [1, -1];
   return a[index].value === b[index].value

--- a/yarn-project/acir-simulator/src/client/private_execution.test.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.test.ts
@@ -156,8 +156,12 @@ describe('Private Execution test suite', () => {
   beforeEach(() => {
     oracle = mock<DBOracle>();
     oracle.getSecretKey.mockImplementation((contractAddress: AztecAddress, pubKey: PublicKey) => {
-      if (pubKey.equals(ownerCompleteAddress.publicKey)) return Promise.resolve(ownerPk);
-      if (pubKey.equals(recipientCompleteAddress.publicKey)) return Promise.resolve(recipientPk);
+      if (pubKey.equals(ownerCompleteAddress.publicKey)) {
+        return Promise.resolve(ownerPk);
+      }
+      if (pubKey.equals(recipientCompleteAddress.publicKey)) {
+        return Promise.resolve(recipientPk);
+      }
       throw new Error(`Unknown address ${pubKey}`);
     });
     oracle.getHistoricBlockData.mockResolvedValue(blockData);
@@ -209,8 +213,12 @@ describe('Private Execution test suite', () => {
 
     beforeEach(() => {
       oracle.getCompleteAddress.mockImplementation((address: AztecAddress) => {
-        if (address.equals(owner)) return Promise.resolve(ownerCompleteAddress);
-        if (address.equals(recipient)) return Promise.resolve(recipientCompleteAddress);
+        if (address.equals(owner)) {
+          return Promise.resolve(ownerCompleteAddress);
+        }
+        if (address.equals(recipient)) {
+          return Promise.resolve(recipientCompleteAddress);
+        }
         throw new Error(`Unknown address ${address}`);
       });
 
@@ -420,7 +428,9 @@ describe('Private Execution test suite', () => {
 
     beforeEach(() => {
       oracle.getCompleteAddress.mockImplementation((address: AztecAddress) => {
-        if (address.equals(recipient)) return Promise.resolve(recipientCompleteAddress);
+        if (address.equals(recipient)) {
+          return Promise.resolve(recipientCompleteAddress);
+        }
         throw new Error(`Unknown address ${address}`);
       });
     });
@@ -558,7 +568,9 @@ describe('Private Execution test suite', () => {
   describe('pending commitments contract', () => {
     beforeEach(() => {
       oracle.getCompleteAddress.mockImplementation((address: AztecAddress) => {
-        if (address.equals(owner)) return Promise.resolve(ownerCompleteAddress);
+        if (address.equals(owner)) {
+          return Promise.resolve(ownerCompleteAddress);
+        }
         throw new Error(`Unknown address ${address}`);
       });
     });

--- a/yarn-project/acir-simulator/src/client/simulator.ts
+++ b/yarn-project/acir-simulator/src/client/simulator.ts
@@ -45,7 +45,9 @@ export class AcirSimulator {
    * @returns ACVM WasmBlackBoxFunctionSolver
    */
   public static getSolver(): Promise<WasmBlackBoxFunctionSolver> {
-    if (!this.solver) this.solver = createBlackBoxSolver();
+    if (!this.solver) {
+      this.solver = createBlackBoxSolver();
+    }
     return this.solver;
   }
 

--- a/yarn-project/acir-simulator/src/client/unconstrained_execution.test.ts
+++ b/yarn-project/acir-simulator/src/client/unconstrained_execution.test.ts
@@ -33,7 +33,9 @@ describe('Unconstrained Execution test suite', () => {
       owner = ownerCompleteAddress.address;
 
       oracle.getCompleteAddress.mockImplementation((address: AztecAddress) => {
-        if (address.equals(owner)) return Promise.resolve(ownerCompleteAddress);
+        if (address.equals(owner)) {
+          return Promise.resolve(ownerCompleteAddress);
+        }
         throw new Error(`Unknown address ${address}`);
       });
     });

--- a/yarn-project/acir-simulator/src/public/executor.ts
+++ b/yarn-project/acir-simulator/src/public/executor.ts
@@ -93,7 +93,9 @@ export class PublicExecutor {
   public async simulate(execution: PublicExecution, globalVariables: GlobalVariables): Promise<PublicExecutionResult> {
     const selector = execution.functionData.selector;
     const acir = await this.contractsDb.getBytecode(execution.contractAddress, selector);
-    if (!acir) throw new Error(`Bytecode not found for ${execution.contractAddress}:${selector}`);
+    if (!acir) {
+      throw new Error(`Bytecode not found for ${execution.contractAddress}:${selector}`);
+    }
 
     // Functions can request to pack arguments before calling other functions.
     // We use this cache to hold the packed arguments.

--- a/yarn-project/acir-simulator/src/public/public_execution_context.ts
+++ b/yarn-project/acir-simulator/src/public/public_execution_context.ts
@@ -185,7 +185,9 @@ export class PublicExecutionContext extends TypedOracle {
     }
 
     const acir = await this.contractsDb.getBytecode(targetContractAddress, functionSelector);
-    if (!acir) throw new Error(`Bytecode not found for ${targetContractAddress}:${functionSelector}`);
+    if (!acir) {
+      throw new Error(`Bytecode not found for ${targetContractAddress}:${functionSelector}`);
+    }
 
     const functionData = new FunctionData(functionSelector, isInternal, false, false);
 

--- a/yarn-project/acir-simulator/src/public/state_actions.ts
+++ b/yarn-project/acir-simulator/src/public/state_actions.ts
@@ -39,9 +39,13 @@ export class ContractStorageActionsCollector {
   public async read(storageSlot: Fr, sideEffectCounter: number): Promise<Fr> {
     const slot = storageSlot.value;
     const updateRequest = this.contractStorageUpdateRequests.get(slot);
-    if (updateRequest) return updateRequest.newValue;
+    if (updateRequest) {
+      return updateRequest.newValue;
+    }
     const read = this.contractStorageReads.get(slot);
-    if (read) return read.currentValue;
+    if (read) {
+      return read.currentValue;
+    }
     const value = await this.db.storageRead(this.address, storageSlot);
     this.contractStorageReads.set(slot, { currentValue: value, sideEffectCounter });
     return value;

--- a/yarn-project/archiver/package.json
+++ b/yarn-project/archiver/package.json
@@ -15,7 +15,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests",
     "start": "node ./dest",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'",

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -507,7 +507,9 @@ export class MemoryArchiverStore implements ArchiverDataStore {
    * @returns The number of the latest L2 block processed.
    */
   public getBlockNumber(): Promise<number> {
-    if (this.l2BlockContexts.length === 0) return Promise.resolve(INITIAL_L2_BLOCK_NUM - 1);
+    if (this.l2BlockContexts.length === 0) {
+      return Promise.resolve(INITIAL_L2_BLOCK_NUM - 1);
+    }
     return Promise.resolve(this.l2BlockContexts[this.l2BlockContexts.length - 1].block.number);
   }
 }

--- a/yarn-project/archiver/src/archiver/eth_log_handlers.ts
+++ b/yarn-project/archiver/src/archiver/eth_log_handlers.ts
@@ -102,7 +102,9 @@ async function getBlockFromCallData(
     abi: RollupAbi.filter(item => item.type.toString() !== 'constructor'),
     data,
   });
-  if (functionName !== 'process') throw new Error(`Unexpected method called ${functionName}`);
+  if (functionName !== 'process') {
+    throw new Error(`Unexpected method called ${functionName}`);
+  }
   const [, l2BlockHex] = args! as [Hex, Hex];
   const block = L2Block.fromBufferWithLogs(Buffer.from(hexToBytes(l2BlockHex)));
   if (BigInt(block.number) !== l2BlockNum) {

--- a/yarn-project/archiver/src/archiver/l1_to_l2_message_store.ts
+++ b/yarn-project/archiver/src/archiver/l1_to_l2_message_store.ts
@@ -59,7 +59,9 @@ export class PendingL1ToL2MessageStore extends L1ToL2MessageStore {
 
   removeMessage(messageKey: Fr) {
     // ignore 0 - messageKey is a hash, so a 0 can probabilistically never occur. It is best to skip it.
-    if (messageKey.equals(Fr.ZERO)) return;
+    if (messageKey.equals(Fr.ZERO)) {
+      return;
+    }
     const messageKeyBigInt = messageKey.value;
     const msgAndCount = this.store.get(messageKeyBigInt);
     if (!msgAndCount) {

--- a/yarn-project/aztec-faucet/package.json
+++ b/yarn-project/aztec-faucet/package.json
@@ -17,7 +17,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"
   },
   "inherits": [

--- a/yarn-project/aztec-node/package.json
+++ b/yarn-project/aztec-node/package.json
@@ -18,7 +18,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"
   },
   "inherits": [

--- a/yarn-project/aztec-sandbox/package.json
+++ b/yarn-project/aztec-sandbox/package.json
@@ -18,7 +18,7 @@
     "start": "node --no-warnings ./dest/bin",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "build:dev": "tsc -b --watch",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests",
     "run:example:token": "DEBUG='aztec:*' node ./dest/examples/token.js"

--- a/yarn-project/aztec.js/package.json
+++ b/yarn-project/aztec.js/package.json
@@ -22,7 +22,7 @@
     "build:ts": "tsc -b",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"
   },
   "inherits": [

--- a/yarn-project/aztec.js/src/account/manager/index.ts
+++ b/yarn-project/aztec.js/src/account/manager/index.ts
@@ -107,7 +107,9 @@ export class AccountManager {
    */
   public async getDeployMethod() {
     if (!this.deployMethod) {
-      if (!this.salt) throw new Error(`Cannot deploy account contract without known salt.`);
+      if (!this.salt) {
+        throw new Error(`Cannot deploy account contract without known salt.`);
+      }
       await this.#register();
       const encryptionPublicKey = this.getEncryptionPublicKey();
       const deployer = new ContractDeployer(this.accountContract.getContractArtifact(), this.pxe, encryptionPublicKey);

--- a/yarn-project/aztec.js/src/contract/sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract/sent_tx.ts
@@ -65,8 +65,9 @@ export class SentTx {
       throw new Error('Cannot set getNotes to true if waitForNotesSync is false');
     }
     const receipt = await this.waitForReceipt(opts);
-    if (receipt.status !== TxStatus.MINED)
+    if (receipt.status !== TxStatus.MINED) {
       throw new Error(`Transaction ${await this.getTxHash()} was ${receipt.status}`);
+    }
     if (opts?.debug) {
       const txHash = await this.getTxHash();
       const tx = (await this.pxe.getTx(txHash))!;
@@ -110,12 +111,18 @@ export class SentTx {
       async () => {
         const txReceipt = await this.pxe.getTxReceipt(txHash);
         // If receipt is not yet available, try again
-        if (txReceipt.status === TxStatus.PENDING) return undefined;
+        if (txReceipt.status === TxStatus.PENDING) {
+          return undefined;
+        }
         // If the tx was dropped, return it
-        if (txReceipt.status === TxStatus.DROPPED) return txReceipt;
+        if (txReceipt.status === TxStatus.DROPPED) {
+          return txReceipt;
+        }
         // If we don't care about waiting for notes to be synced, return the receipt
         const waitForNotesSync = opts?.waitForNotesSync ?? DefaultWaitOpts.waitForNotesSync;
-        if (!waitForNotesSync) return txReceipt;
+        if (!waitForNotesSync) {
+          return txReceipt;
+        }
         // Check if all sync blocks on the PXE Service are greater or equal than the block in which the tx was mined
         const { blocks, notes } = await this.pxe.getSyncStatus();
         const targetBlock = txReceipt.blockNumber!;

--- a/yarn-project/aztec.js/src/contract_deployer/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract_deployer/deploy_method.ts
@@ -48,7 +48,9 @@ export class DeployMethod<TContract extends ContractBase = Contract> extends Bas
   ) {
     super(pxe);
     const constructorArtifact = artifact.functions.find(f => f.name === 'constructor');
-    if (!constructorArtifact) throw new Error('Cannot find constructor in the artifact.');
+    if (!constructorArtifact) {
+      throw new Error('Cannot find constructor in the artifact.');
+    }
     this.constructorArtifact = constructorArtifact;
   }
 

--- a/yarn-project/aztec.js/src/contract_deployer/deploy_sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract_deployer/deploy_sent_tx.ts
@@ -60,8 +60,12 @@ export class DeploySentTx<TContract extends Contract = Contract> extends SentTx 
   protected getContractInstance(wallet?: Wallet, address?: AztecAddress): Promise<TContract> {
     const isWallet = (pxe: PXE | Wallet): pxe is Wallet => !!(pxe as Wallet).createTxExecutionRequest;
     const contractWallet = wallet ?? (isWallet(this.pxe) && this.pxe);
-    if (!contractWallet) throw new Error(`A wallet is required for creating a contract instance`);
-    if (!address) throw new Error(`Contract address is missing from transaction receipt`);
+    if (!contractWallet) {
+      throw new Error(`A wallet is required for creating a contract instance`);
+    }
+    if (!address) {
+      throw new Error(`Contract address is missing from transaction receipt`);
+    }
     return Contract.at(address, this.artifact, contractWallet) as Promise<TContract>;
   }
 }

--- a/yarn-project/aztec.js/src/utils/cheat_codes.ts
+++ b/yarn-project/aztec.js/src/utils/cheat_codes.ts
@@ -87,7 +87,9 @@ export class EthCheatCodes {
    */
   public async mine(numberOfBlocks = 1): Promise<void> {
     const res = await this.rpcCall('hardhat_mine', [numberOfBlocks]);
-    if (res.error) throw new Error(`Error mining: ${res.error.message}`);
+    if (res.error) {
+      throw new Error(`Error mining: ${res.error.message}`);
+    }
     this.logger(`Mined ${numberOfBlocks} blocks`);
   }
 
@@ -97,7 +99,9 @@ export class EthCheatCodes {
    */
   public async setNextBlockTimestamp(timestamp: number): Promise<void> {
     const res = await this.rpcCall('evm_setNextBlockTimestamp', [timestamp]);
-    if (res.error) throw new Error(`Error setting next block timestamp: ${res.error.message}`);
+    if (res.error) {
+      throw new Error(`Error setting next block timestamp: ${res.error.message}`);
+    }
     this.logger(`Set next block timestamp to ${timestamp}`);
   }
 
@@ -107,7 +111,9 @@ export class EthCheatCodes {
    */
   public async dumpChainState(fileName: string): Promise<void> {
     const res = await this.rpcCall('hardhat_dumpState', []);
-    if (res.error) throw new Error(`Error dumping state: ${res.error.message}`);
+    if (res.error) {
+      throw new Error(`Error dumping state: ${res.error.message}`);
+    }
     const jsonContent = JSON.stringify(res.result);
     fs.writeFileSync(`${fileName}.json`, jsonContent, 'utf8');
     this.logger(`Dumped state to ${fileName}`);
@@ -120,7 +126,9 @@ export class EthCheatCodes {
   public async loadChainState(fileName: string): Promise<void> {
     const data = JSON.parse(fs.readFileSync(`${fileName}.json`, 'utf8'));
     const res = await this.rpcCall('hardhat_loadState', [data]);
-    if (res.error) throw new Error(`Error loading state: ${res.error.message}`);
+    if (res.error) {
+      throw new Error(`Error loading state: ${res.error.message}`);
+    }
     this.logger(`Loaded state from ${fileName}`);
   }
 
@@ -144,7 +152,9 @@ export class EthCheatCodes {
   public async store(contract: EthAddress, slot: bigint, value: bigint): Promise<void> {
     // for the rpc call, we need to change value to be a 32 byte hex string.
     const res = await this.rpcCall('hardhat_setStorageAt', [contract.toString(), toHex(slot), toHex(value, true)]);
-    if (res.error) throw new Error(`Error setting storage for contract ${contract} at ${slot}: ${res.error.message}`);
+    if (res.error) {
+      throw new Error(`Error setting storage for contract ${contract} at ${slot}: ${res.error.message}`);
+    }
     this.logger(`Set storage for contract ${contract} at ${slot} to ${value}`);
   }
 
@@ -166,7 +176,9 @@ export class EthCheatCodes {
    */
   public async startImpersonating(who: EthAddress): Promise<void> {
     const res = await this.rpcCall('hardhat_impersonateAccount', [who.toString()]);
-    if (res.error) throw new Error(`Error impersonating ${who}: ${res.error.message}`);
+    if (res.error) {
+      throw new Error(`Error impersonating ${who}: ${res.error.message}`);
+    }
     this.logger(`Impersonating ${who}`);
   }
 
@@ -176,7 +188,9 @@ export class EthCheatCodes {
    */
   public async stopImpersonating(who: EthAddress): Promise<void> {
     const res = await this.rpcCall('hardhat_stopImpersonatingAccount', [who.toString()]);
-    if (res.error) throw new Error(`Error when stopping the impersonation of ${who}: ${res.error.message}`);
+    if (res.error) {
+      throw new Error(`Error when stopping the impersonation of ${who}: ${res.error.message}`);
+    }
     this.logger(`Stopped impersonating ${who}`);
   }
 
@@ -187,7 +201,9 @@ export class EthCheatCodes {
    */
   public async etch(contract: EthAddress, bytecode: `0x${string}`): Promise<void> {
     const res = await this.rpcCall('hardhat_setCode', [contract.toString(), bytecode]);
-    if (res.error) throw new Error(`Error setting bytecode for ${contract}: ${res.error.message}`);
+    if (res.error) {
+      throw new Error(`Error setting bytecode for ${contract}: ${res.error.message}`);
+    }
     this.logger(`Set bytecode for ${contract} to ${bytecode}`);
   }
 

--- a/yarn-project/circuits.js/package.json
+++ b/yarn-project/circuits.js/package.json
@@ -22,7 +22,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "remake-bindings": "DEBUG=wasm ts-node-esm src/cbind/circuits.in.ts && prettier -w src/cbind/circuits.gen.ts",
     "remake-constants": "ts-node-esm src/cbind/constants.in.ts && prettier -w src/cbind/constants.gen.ts",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"

--- a/yarn-project/circuits.js/src/abis/abis.ts
+++ b/yarn-project/circuits.js/src/abis/abis.ts
@@ -368,9 +368,12 @@ const ARGS_HASH_CHUNK_COUNT = 16;
  * @returns Pedersen hash of the arguments.
  */
 export function computeVarArgsHash(args: Fr[]) {
-  if (args.length === 0) return Fr.ZERO;
-  if (args.length > ARGS_HASH_CHUNK_SIZE * ARGS_HASH_CHUNK_COUNT)
+  if (args.length === 0) {
+    return Fr.ZERO;
+  }
+  if (args.length > ARGS_HASH_CHUNK_SIZE * ARGS_HASH_CHUNK_COUNT) {
     throw new Error(`Cannot hash more than ${ARGS_HASH_CHUNK_SIZE * ARGS_HASH_CHUNK_COUNT} arguments`);
+  }
 
   let chunksHashes = chunk(args, ARGS_HASH_CHUNK_SIZE).map(c => {
     if (c.length < ARGS_HASH_CHUNK_SIZE) {

--- a/yarn-project/circuits.js/src/cbind/compiler.ts
+++ b/yarn-project/circuits.js/src/cbind/compiler.ts
@@ -351,7 +351,9 @@ export class CbindCompiler {
     // Raw object, used as return value of fromType() generated functions.
     let result = `interface Msgpack${name} {\n`;
     for (const [key, value] of Object.entries(type)) {
-      if (key === '__typename') continue;
+      if (key === '__typename') {
+        continue;
+      }
       result += `  ${key}: ${this.getMsgpackTypename(value)};\n`;
     }
     result += '}';
@@ -370,7 +372,9 @@ export class CbindCompiler {
     const checkerSyntax = () => {
       const statements: string[] = [];
       for (const [key] of Object.entries(type)) {
-        if (key === '__typename') continue;
+        if (key === '__typename') {
+          continue;
+        }
         statements.push(
           `  if (o.${key} === undefined) { throw new Error("Expected ${key} in ${typename} deserialization"); }`,
         );
@@ -382,7 +386,9 @@ export class CbindCompiler {
     const constructorBodySyntax = () => {
       const statements: string[] = [];
       for (const [key, value] of Object.entries(type)) {
-        if (key === '__typename') continue;
+        if (key === '__typename') {
+          continue;
+        }
         statements.push(`  ${msgpackConverterExpr(this.getTypeInfo(value), `o.${key}`)},`);
       }
       return statements.join('\n');
@@ -411,7 +417,9 @@ return ${callSyntax.call(this)};
     const checkerSyntax = () => {
       const statements: string[] = [];
       for (const [key] of Object.entries(type)) {
-        if (key === '__typename') continue;
+        if (key === '__typename') {
+          continue;
+        }
         statements.push(
           `  if (o.${camelCase(key)} === undefined) { throw new Error("Expected ${camelCase(
             key,
@@ -423,7 +431,9 @@ return ${callSyntax.call(this)};
     const bodySyntax = () => {
       const statements: string[] = [];
       for (const [key, value] of Object.entries(type)) {
-        if (key === '__typename') continue;
+        if (key === '__typename') {
+          continue;
+        }
         statements.push(`  ${key}: ${classConverterExpr(this.getTypeInfo(value), `o.${camelCase(key)}`)},`);
       }
       return statements.join('\n');

--- a/yarn-project/circuits.js/src/tests/factories.ts
+++ b/yarn-project/circuits.js/src/tests/factories.ts
@@ -588,7 +588,9 @@ export function makePublicKernelInputsWithTweak(
     makePreviousKernelData(seed, kernelCircuitPublicInputs),
     makePublicCallData(seed + 0x1000),
   );
-  if (tweak) tweak(publicKernelInputs);
+  if (tweak) {
+    tweak(publicKernelInputs);
+  }
   // Set the call stack item for this circuit iteration at the top of the call stack
   publicKernelInputs.previousKernel.publicInputs.end.publicCallStack[MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX - 1] =
     computeCallStackItemHash(publicKernelInputs.publicCall.callStackItem);

--- a/yarn-project/circuits.js/src/wasm/circuits_wasm.ts
+++ b/yarn-project/circuits.js/src/wasm/circuits_wasm.ts
@@ -48,7 +48,9 @@ export class CircuitsWasm implements IWasmModule {
    * @returns The singleton.
    */
   public static get(): Promise<CircuitsWasm> {
-    if (!this.instance) this.instance = CircuitsWasm.new();
+    if (!this.instance) {
+      this.instance = CircuitsWasm.new();
+    }
     return this.instance;
   }
 

--- a/yarn-project/cli/package.json
+++ b/yarn-project/cli/package.json
@@ -18,7 +18,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests",
     "start": "node --no-warnings ./dest/bin/index.js"
   },

--- a/yarn-project/cli/src/encoding.ts
+++ b/yarn-project/cli/src/encoding.ts
@@ -42,9 +42,14 @@ function encodeArg(arg: string, abiType: ABIType, name: string): any {
     }
     return res;
   } else if (kind === 'boolean') {
-    if (arg === 'true') return true;
-    if (arg === 'false') return false;
-    else throw Error(`Invalid boolean value passed for ${name}: ${arg}.`);
+    if (arg === 'true') {
+      return true;
+    }
+    if (arg === 'false') {
+      return false;
+    } else {
+      throw Error(`Invalid boolean value passed for ${name}: ${arg}.`);
+    }
   } else if (kind === 'array') {
     let arr;
     const res = [];
@@ -53,9 +58,12 @@ function encodeArg(arg: string, abiType: ABIType, name: string): any {
     } catch {
       throw new Error(`Unable to parse arg ${arg} as array for ${name} parameter`);
     }
-    if (!Array.isArray(arr)) throw Error(`Invalid argument ${arg} passed for array parameter ${name}.`);
-    if (arr.length !== abiType.length)
+    if (!Array.isArray(arr)) {
+      throw Error(`Invalid argument ${arg} passed for array parameter ${name}.`);
+    }
+    if (arr.length !== abiType.length) {
       throw Error(`Invalid array length passed for ${name}. Expected ${abiType.length}, received ${arr.length}.`);
+    }
     for (let i = 0; i < abiType.length; i += 1) {
       res.push(encodeArg(arr[i], abiType.type, name));
     }
@@ -71,12 +79,16 @@ function encodeArg(arg: string, abiType: ABIType, name: string): any {
     } catch {
       throw new Error(`Unable to parse arg ${arg} as struct`);
     }
-    if (Array.isArray(obj)) throw Error(`Array passed for arg ${name}. Expected a struct.`);
+    if (Array.isArray(obj)) {
+      throw Error(`Array passed for arg ${name}. Expected a struct.`);
+    }
     const res: any = {};
     for (const field of abiType.fields) {
       // Remove field name from list as it's present
       const arg = obj[field.name];
-      if (!arg) throw Error(`Expected field ${field.name} not found in struct ${name}.`);
+      if (!arg) {
+        throw Error(`Expected field ${field.name} not found in struct ${name}.`);
+      }
       res[field.name] = encodeArg(obj[field.name], field.type, field.name);
     }
     return res;

--- a/yarn-project/cli/src/index.ts
+++ b/yarn-project/cli/src/index.ts
@@ -188,7 +188,9 @@ export function getProgram(log: LogFn, debugLogger: DebugLogger): Command {
       log(`\nNew account:\n`);
       log(`Address:         ${address.toString()}`);
       log(`Public key:      ${publicKey.toString()}`);
-      if (!privateKey) log(`Private key:     ${actualPrivateKey.toString(true)}`);
+      if (!privateKey) {
+        log(`Private key:     ${actualPrivateKey.toString(true)}`);
+      }
       log(`Partial address: ${partialAddress.toString()}`);
     });
 
@@ -259,7 +261,9 @@ export function getProgram(log: LogFn, debugLogger: DebugLogger): Command {
       const deployer = new ContractDeployer(contractArtifact, client, publicKey);
 
       const constructor = getFunctionArtifact(contractArtifact, 'constructor');
-      if (!constructor) throw new Error(`Constructor not found in contract ABI`);
+      if (!constructor) {
+        throw new Error(`Constructor not found in contract ABI`);
+      }
 
       debugLogger(`Input arguments: ${rawArgs.map((x: any) => `"${x}"`).join(', ')}`);
       const args = encodeArgs(rawArgs, constructorArtifact!.parameters);
@@ -295,8 +299,11 @@ export function getProgram(log: LogFn, debugLogger: DebugLogger): Command {
       const client = await createCompatibleClient(options.rpcUrl, debugLogger);
       const address = options.contractAddress;
       const isDeployed = await isContractDeployed(client, address);
-      if (isDeployed) log(`\nContract found at ${address.toString()}\n`);
-      else log(`\nNo contract found at ${address.toString()}\n`);
+      if (isDeployed) {
+        log(`\nContract found at ${address.toString()}\n`);
+      } else {
+        log(`\nNo contract found at ${address.toString()}\n`);
+      }
     });
 
   program
@@ -392,8 +399,12 @@ export function getProgram(log: LogFn, debugLogger: DebugLogger): Command {
       const pxe = await createCompatibleClient(rpcUrl, debugLogger);
 
       if (follow) {
-        if (txHash) throw Error('Cannot use --follow with --tx-hash');
-        if (toBlock) throw Error('Cannot use --follow with --to-block');
+        if (txHash) {
+          throw Error('Cannot use --follow with --tx-hash');
+        }
+        if (toBlock) {
+          throw Error('Cannot use --follow with --to-block');
+        }
       }
 
       const filter: LogFilter = { txHash, fromBlock, toBlock, afterLog, contractAddress, selector };
@@ -407,9 +418,13 @@ export function getProgram(log: LogFn, debugLogger: DebugLogger): Command {
             .filter(([, value]) => value !== undefined)
             .map(([key, value]) => `${key}: ${value}`)
             .join(', ');
-          if (!follow) log(`No logs found for filter: {${filterOptions}}`);
+          if (!follow) {
+            log(`No logs found for filter: {${filterOptions}}`);
+          }
         } else {
-          if (!follow && !filter.afterLog) log('Logs found: \n');
+          if (!follow && !filter.afterLog) {
+            log('Logs found: \n');
+          }
           logs.forEach(unencryptedLog => log(unencryptedLog.toHumanReadable()));
           // Set the continuation parameter for the following requests
           filter.afterLog = logs[logs.length - 1].id;
@@ -421,7 +436,9 @@ export function getProgram(log: LogFn, debugLogger: DebugLogger): Command {
         log('Fetching logs...');
         while (true) {
           const maxLogsHit = await fetchLogs();
-          if (!maxLogsHit) await sleep(1000);
+          if (!maxLogsHit) {
+            await sleep(1000);
+          }
         }
       } else {
         while (await fetchLogs()) {

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -8,7 +8,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src \"!src/web/main.js\" && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "DEBUG='aztec:*' NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --runInBand --passWithNoTests --testTimeout=15000 --forceExit",
     "test:integration": "concurrently -k -s first -c reset,dim -n test,anvil \"yarn test:integration:run\" \"anvil\"",
     "test:integration:run": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --no-cache --runInBand --config jest.integration.config.json"

--- a/yarn-project/end-to-end/src/cli_docs_sandbox.test.ts
+++ b/yarn-project/end-to-end/src/cli_docs_sandbox.test.ts
@@ -72,7 +72,9 @@ Rollup Address: 0x0dcd1bf9a1b36ce34237eeafef220932846bcd82
   const findInLogs = (regex: RegExp) => {
     for (const log of logs) {
       const match = regex.exec(log);
-      if (match) return match;
+      if (match) {
+        return match;
+      }
     }
   };
 
@@ -80,7 +82,9 @@ Rollup Address: 0x0dcd1bf9a1b36ce34237eeafef220932846bcd82
     const matches = [];
     for (const log of logs) {
       const match = regex.exec(log);
-      if (match) matches.push(match);
+      if (match) {
+        matches.push(match);
+      }
     }
     return matches;
   };

--- a/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
@@ -58,7 +58,9 @@ describe('e2e_2_pxes', () => {
 
   afterEach(async () => {
     await teardownA();
-    if ((pxeB as any).stop) await (pxeB as any).stop();
+    if ((pxeB as any).stop) {
+      await (pxeB as any).stop();
+    }
   });
 
   const awaitUserSynchronized = async (wallet: Wallet, owner: AztecAddress) => {

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -53,7 +53,9 @@ describe('e2e_block_building', () => {
       // Send them simultaneously to be picked up by the sequencer
       const txs = await Promise.all(methods.map(method => method.send()));
       logger(`Txs sent with hashes: `);
-      for (const tx of txs) logger(` ${await tx.getTxHash()}`);
+      for (const tx of txs) {
+        logger(` ${await tx.getTxHash()}`);
+      }
 
       // Await txs to be mined and assert they are all mined on the same block
       const receipts = await Promise.all(txs.map(tx => tx.wait()));
@@ -111,7 +113,9 @@ describe('e2e_block_building', () => {
     it('drops tx with private nullifier already emitted on the same block', async () => {
       const nullifier = Fr.random();
       const calls = times(2, () => contract.methods.emit_nullifier(nullifier));
-      for (const call of calls) await call.simulate();
+      for (const call of calls) {
+        await call.simulate();
+      }
       const [tx1, tx2] = calls.map(call => call.send());
       await tx1.wait();
       await expect(tx2.wait()).rejects.toThrowError(/dropped/);
@@ -120,7 +124,9 @@ describe('e2e_block_building', () => {
     it('drops tx with public nullifier already emitted on the same block', async () => {
       const secret = Fr.random();
       const calls = times(2, () => contract.methods.create_nullifier_public(140n, secret));
-      for (const call of calls) await call.simulate();
+      for (const call of calls) {
+        await call.simulate();
+      }
       const [tx1, tx2] = calls.map(call => call.send());
       await tx1.wait();
       await expect(tx2.wait()).rejects.toThrowError(/dropped/);
@@ -142,7 +148,9 @@ describe('e2e_block_building', () => {
         contract.methods.emit_nullifier(emittedPublicNullifier),
       ];
 
-      for (const call of calls) await call.simulate();
+      for (const call of calls) {
+        await call.simulate();
+      }
       const [tx1, tx2] = calls.map(call => call.send());
       await tx1.wait();
       await expect(tx2.wait()).rejects.toThrowError(/dropped/);

--- a/yarn-project/end-to-end/src/fixtures/logging.ts
+++ b/yarn-project/end-to-end/src/fixtures/logging.ts
@@ -18,7 +18,9 @@ export function isMetricsLoggingRequested() {
  * Idempotent and automatically called by `setup` if CI or BENCHMARK env vars are set.
  */
 export function setupMetricsLogger(filename: string) {
-  if (metricsLoggerSet) return;
+  if (metricsLoggerSet) {
+    return;
+  }
   mkdirpSync(dirname(filename));
   const logger = winston.createLogger({
     level: 'debug',

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -58,7 +58,9 @@ export { deployAndInitializeTokenAndBridgeContracts } from '../shared/cross_chai
 const { PXE_URL = '', AZTEC_NODE_URL = '' } = process.env;
 
 const getAztecNodeUrl = () => {
-  if (AZTEC_NODE_URL) return AZTEC_NODE_URL;
+  if (AZTEC_NODE_URL) {
+    return AZTEC_NODE_URL;
+  }
 
   // If AZTEC_NODE_URL is not set, we assume that the PXE is running on the same host as the Aztec Node and use the default port
   const url = new URL(PXE_URL);
@@ -290,8 +292,12 @@ export async function setup(numberOfAccounts = 1, opts: SetupOptions = {}): Prom
   const cheatCodes = CheatCodes.create(config.rpcUrl, pxe!);
 
   const teardown = async () => {
-    if (aztecNode instanceof AztecNodeService) await aztecNode?.stop();
-    if (pxe instanceof PXEService) await pxe?.stop();
+    if (aztecNode instanceof AztecNodeService) {
+      await aztecNode?.stop();
+    }
+    if (pxe instanceof PXEService) {
+      await pxe?.stop();
+    }
   };
 
   return {

--- a/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
@@ -284,7 +284,9 @@ describe('L1Publisher integration', () => {
 
       // check that values are in the inbox
       for (let j = 0; j < l1ToL2Messages.length; j++) {
-        if (l1ToL2Messages[j].isZero()) continue;
+        if (l1ToL2Messages[j].isZero()) {
+          continue;
+        }
         expect(await inbox.read.contains([l1ToL2Messages[j].toString(true)])).toBeTruthy();
       }
 
@@ -341,7 +343,9 @@ describe('L1Publisher integration', () => {
 
       // check that values have been consumed from the inbox
       for (let j = 0; j < l1ToL2Messages.length; j++) {
-        if (l1ToL2Messages[j].isZero()) continue;
+        if (l1ToL2Messages[j].isZero()) {
+          continue;
+        }
         expect(await inbox.read.contains([l1ToL2Messages[j].toString(true)])).toBeFalsy();
       }
       // check that values are inserted into the outbox
@@ -418,7 +422,11 @@ describe('L1Publisher integration', () => {
  * Converts a hex string into a buffer. String may be 0x-prefixed or not.
  */
 function hexStringToBuffer(hex: string): Buffer {
-  if (!/^(0x)?[a-fA-F0-9]+$/.test(hex)) throw new Error(`Invalid format for hex string: "${hex}"`);
-  if (hex.length % 2 === 1) throw new Error(`Invalid length for hex string: "${hex}"`);
+  if (!/^(0x)?[a-fA-F0-9]+$/.test(hex)) {
+    throw new Error(`Invalid format for hex string: "${hex}"`);
+  }
+  if (hex.length % 2 === 1) {
+    throw new Error(`Invalid length for hex string: "${hex}"`);
+  }
   return Buffer.from(hex.replace(/^0x/, ''), 'hex');
 }

--- a/yarn-project/end-to-end/src/shared/cli.ts
+++ b/yarn-project/end-to-end/src/shared/cli.ts
@@ -60,7 +60,9 @@ export const cliTestSuite = (
     const findInLogs = (regex: RegExp) => {
       for (const log of logs) {
         const match = regex.exec(log);
-        if (match) return match;
+        if (match) {
+          return match;
+        }
       }
     };
 
@@ -68,7 +70,9 @@ export const cliTestSuite = (
       const matches = [];
       for (const log of logs) {
         const match = regex.exec(log);
-        if (match) matches.push(match);
+        if (match) {
+          matches.push(match);
+        }
       }
       return matches;
     };

--- a/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
@@ -89,7 +89,9 @@ export async function deployAndInitializeTokenAndBridgeContracts(
 
   // now wait for the deploy txs to be mined. This way we send all tx in the same rollup.
   const deployReceipt = await deployTx.wait();
-  if (deployReceipt.status !== TxStatus.MINED) throw new Error(`Deploy token tx status is ${deployReceipt.status}`);
+  if (deployReceipt.status !== TxStatus.MINED) {
+    throw new Error(`Deploy token tx status is ${deployReceipt.status}`);
+  }
   const token = await TokenContract.at(deployReceipt.contractAddress!, wallet);
 
   // deploy l2 token bridge and attach to the portal
@@ -97,17 +99,23 @@ export async function deployAndInitializeTokenAndBridgeContracts(
     .send({ portalContract: tokenPortalAddress })
     .deployed();
 
-  if ((await token.methods.admin().view()) !== owner.toBigInt()) throw new Error(`Token admin is not ${owner}`);
+  if ((await token.methods.admin().view()) !== owner.toBigInt()) {
+    throw new Error(`Token admin is not ${owner}`);
+  }
 
-  if ((await bridge.methods.token().view()) !== token.address.toBigInt())
+  if ((await bridge.methods.token().view()) !== token.address.toBigInt()) {
     throw new Error(`Bridge token is not ${token.address}`);
+  }
 
   // make the bridge a minter on the token:
   const makeMinterTx = token.methods.set_minter(bridge.address, true).send();
   const makeMinterReceipt = await makeMinterTx.wait();
-  if (makeMinterReceipt.status !== TxStatus.MINED)
+  if (makeMinterReceipt.status !== TxStatus.MINED) {
     throw new Error(`Make bridge a minter tx status is ${makeMinterReceipt.status}`);
-  if ((await token.methods.is_minter(bridge.address).view()) === 1n) throw new Error(`Bridge is not a minter`);
+  }
+  if ((await token.methods.is_minter(bridge.address).view()) === 1n) {
+    throw new Error(`Bridge is not a minter`);
+  }
 
   // initialize portal
   await tokenPortal.write.initialize(

--- a/yarn-project/ethereum/package.json
+++ b/yarn-project/ethereum/package.json
@@ -15,7 +15,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'",
     "start": "node ./dest/index.js",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"

--- a/yarn-project/foundation/.eslintrc.cjs
+++ b/yarn-project/foundation/.eslintrc.cjs
@@ -82,6 +82,7 @@ module.exports = {
     'require-await': 2,
     'no-console': 'error',
     'no-constant-condition': 'off',
+    curly: ['error', 'all'],
     camelcase: 2,
     'no-restricted-imports': [
       'error',

--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -41,7 +41,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test:light": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"
   },

--- a/yarn-project/foundation/src/bigint-buffer/index.ts
+++ b/yarn-project/foundation/src/bigint-buffer/index.ts
@@ -33,7 +33,9 @@ export function toBigIntBE(buf: Buffer): bigint {
  * @returns A little-endian buffer representation of num.
  */
 export function toBufferLE(num: bigint, width: number): Buffer {
-  if (num < BigInt(0)) throw new Error(`Cannot convert negative bigint ${num.toString()} to buffer with toBufferLE.`);
+  if (num < BigInt(0)) {
+    throw new Error(`Cannot convert negative bigint ${num.toString()} to buffer with toBufferLE.`);
+  }
   const hex = num.toString(16);
   const buffer = Buffer.from(hex.padStart(width * 2, '0').slice(0, width * 2), 'hex');
   buffer.reverse();
@@ -47,10 +49,14 @@ export function toBufferLE(num: bigint, width: number): Buffer {
  * @returns A big-endian buffer representation of num.
  */
 export function toBufferBE(num: bigint, width: number): Buffer {
-  if (num < BigInt(0)) throw new Error(`Cannot convert negative bigint ${num.toString()} to buffer with toBufferBE.`);
+  if (num < BigInt(0)) {
+    throw new Error(`Cannot convert negative bigint ${num.toString()} to buffer with toBufferBE.`);
+  }
   const hex = num.toString(16);
   const buffer = Buffer.from(hex.padStart(width * 2, '0').slice(0, width * 2), 'hex');
-  if (buffer.length > width) throw new Error(`Number ${num.toString(16)} does not fit in ${width}`);
+  if (buffer.length > width) {
+    throw new Error(`Number ${num.toString(16)} does not fit in ${width}`);
+  }
   return buffer;
 }
 

--- a/yarn-project/foundation/src/collection/array.ts
+++ b/yarn-project/foundation/src/collection/array.ts
@@ -8,7 +8,9 @@ import { Tuple } from '../serialize/types.js';
  * @returns A new padded array.
  */
 export function padArrayEnd<T, N extends number>(arr: T[], elem: T, length: N): Tuple<T, N> {
-  if (arr.length > length) throw new Error(`Array size exceeds target length`);
+  if (arr.length > length) {
+    throw new Error(`Array size exceeds target length`);
+  }
   // Since typescript cannot always deduce that something is a tuple, we cast
   return [...arr, ...Array(length - arr.length).fill(elem)] as Tuple<T, N>;
 }
@@ -21,7 +23,9 @@ export function padArrayEnd<T, N extends number>(arr: T[], elem: T, length: N): 
  * @returns A new padded array.
  */
 export function padArrayStart<T, N extends number>(arr: T[], elem: T, length: N): Tuple<T, N> {
-  if (arr.length > length) throw new Error(`Array size exceeds target length`);
+  if (arr.length > length) {
+    throw new Error(`Array size exceeds target length`);
+  }
   // Since typescript cannot always deduce that something is a tuple, we cast
   return [...Array(length - arr.length).fill(elem), ...arr] as Tuple<T, N>;
 }
@@ -33,7 +37,9 @@ export function padArrayStart<T, N extends number>(arr: T[], elem: T, length: N)
  */
 export function isArrayEmpty<T>(arr: T[], isEmpty: (item: T) => boolean): boolean {
   for (const item of arr) {
-    if (!isEmpty(item)) return false;
+    if (!isEmpty(item)) {
+      return false;
+    }
   }
   return true;
 }

--- a/yarn-project/foundation/src/crypto/random/index.ts
+++ b/yarn-project/foundation/src/crypto/random/index.ts
@@ -6,8 +6,12 @@ import isNode from 'detect-node';
 const MAX_BYTES = 65536;
 
 const getWebCrypto = () => {
-  if (typeof window !== 'undefined' && window.crypto) return window.crypto;
-  if (typeof self !== 'undefined' && self.crypto) return self.crypto;
+  if (typeof window !== 'undefined' && window.crypto) {
+    return window.crypto;
+  }
+  if (typeof self !== 'undefined' && self.crypto) {
+    return self.crypto;
+  }
   return undefined;
 };
 

--- a/yarn-project/foundation/src/fields/point.ts
+++ b/yarn-project/foundation/src/fields/point.ts
@@ -128,7 +128,9 @@ export class Point {
  * @returns Whether it looks like a point.
  */
 export function isPoint(obj: object): obj is Point {
-  if (!obj) return false;
+  if (!obj) {
+    return false;
+  }
   const point = obj as Point;
   return point.kind === 'point' && point.x !== undefined && point.y !== undefined;
 }

--- a/yarn-project/foundation/src/json-rpc/class_converter.ts
+++ b/yarn-project/foundation/src/json-rpc/class_converter.ts
@@ -197,9 +197,13 @@ export class ClassConverter {
    */
   private lookupObject(classObj: any) {
     const nameResult = this.toName.get(classObj.constructor);
-    if (nameResult) return { type: nameResult[0], encoding: nameResult[1] };
+    if (nameResult) {
+      return { type: nameResult[0], encoding: nameResult[1] };
+    }
     const classResult = this.toClass.get(classObj.constructor.name);
-    if (classResult) return { type: classObj.constructor.name, encoding: classResult[1] };
+    if (classResult) {
+      return { type: classObj.constructor.name, encoding: classResult[1] };
+    }
     throw new Error(`Could not find class ${classObj.constructor.name} in lookup.`);
   }
 }

--- a/yarn-project/foundation/src/json-rpc/client/json_rpc_client.ts
+++ b/yarn-project/foundation/src/json-rpc/client/json_rpc_client.ts
@@ -123,7 +123,9 @@ export function createJsonRpcClient<T extends object>(
     {},
     {
       get: (target, rpcMethod: string) => {
-        if (['then', 'catch'].includes(rpcMethod)) return Reflect.get(target, rpcMethod);
+        if (['then', 'catch'].includes(rpcMethod)) {
+          return Reflect.get(target, rpcMethod);
+        }
         return (...params: any[]) => {
           debug(format(`JsonRpcClient.constructor`, 'proxy', rpcMethod, '<-', params));
           return request(rpcMethod, params);

--- a/yarn-project/foundation/src/log/logger.ts
+++ b/yarn-project/foundation/src/log/logger.ts
@@ -39,7 +39,9 @@ export type DebugLogger = LogFn & Logger;
  */
 export function createDebugLogger(name: string): DebugLogger {
   const debugLogger = debug(name);
-  if (currentLevel === 'debug') debugLogger.enabled = true;
+  if (currentLevel === 'debug') {
+    debugLogger.enabled = true;
+  }
 
   const logger = {
     silent: () => {},
@@ -78,7 +80,9 @@ function logWithDebug(debug: debug.Debugger, level: LogLevel, msg: string, data?
 
   msg = data ? `${msg} ${fmtLogData(data)}` : msg;
   if (debug.enabled) {
-    if (level !== 'debug') msg = `${level.toUpperCase()} ${msg}`;
+    if (level !== 'debug') {
+      msg = `${level.toUpperCase()} ${msg}`;
+    }
     debug(msg);
   } else if (LogLevels.indexOf(level) <= LogLevels.indexOf(currentLevel)) {
     printLog(`${getPrefix(debug, level)} ${msg}`);
@@ -94,7 +98,9 @@ function logWithDebug(debug: debug.Debugger, level: LogLevel, msg: string, data?
 function getPrefix(debugLogger: debug.Debugger, level: LogLevel) {
   const levelLabel = currentLevel !== level ? ` ${level.toUpperCase()}` : '';
   const prefix = `${debugLogger.namespace.replace(/^aztec:/, '')}${levelLabel}`;
-  if (!isNode || !isatty(process.stderr.fd)) return prefix;
+  if (!isNode || !isatty(process.stderr.fd)) {
+    return prefix;
+  }
   const colorIndex = debug.selectColor(debugLogger.namespace) as number;
   const colorCode = '\u001B[3' + (colorIndex < 8 ? colorIndex : '8;5;' + colorIndex);
   return `  ${colorCode};1m${prefix}\u001B[0m`;

--- a/yarn-project/foundation/src/transport/interface/transferable.ts
+++ b/yarn-project/foundation/src/transport/interface/transferable.ts
@@ -36,7 +36,9 @@ export interface TransferDescriptor<T = any> {
  * @returns A boolean indicating whether the object is transferable.
  */
 function isTransferable(thing: any): thing is Transferable {
-  if (!thing || typeof thing !== 'object') return false;
+  if (!thing || typeof thing !== 'object') {
+    return false;
+  }
   // Don't check too thoroughly, since the list of transferable things in JS might grow over time
   return true;
 }
@@ -109,7 +111,9 @@ export function Transfer<T>(payload: T, transferables: Transferable[]): Transfer
  */
 export function Transfer<T>(payload: T, transferables?: Transferable[]): TransferDescriptor<T> {
   if (!transferables) {
-    if (!isTransferable(payload)) throw Error();
+    if (!isTransferable(payload)) {
+      throw Error();
+    }
     transferables = [payload];
   }
 

--- a/yarn-project/foundation/src/wasm/wasm_module.ts
+++ b/yarn-project/foundation/src/wasm/wasm_module.ts
@@ -232,7 +232,9 @@ export class WasmModule implements IWasmModule {
     addr = addr >>> 0;
     const m = this.getMemory();
     let i = addr;
-    for (; m[i] !== 0; ++i);
+    while (m[i] !== 0) {
+      ++i;
+    }
     return Buffer.from(m.slice(addr, i)).toString('ascii');
   }
 

--- a/yarn-project/key-store/package.json
+++ b/yarn-project/key-store/package.json
@@ -15,7 +15,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"
   },
   "inherits": [

--- a/yarn-project/merkle-tree/package.json
+++ b/yarn-project/merkle-tree/package.json
@@ -15,7 +15,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"
   },
   "inherits": [

--- a/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
@@ -110,7 +110,9 @@ export class StandardIndexedTree extends TreeBase implements IndexedTree {
    */
   public getLeafValue(index: bigint, includeUncommitted: boolean): Promise<Buffer | undefined> {
     const leaf = this.getLatestLeafDataCopy(Number(index), includeUncommitted);
-    if (!leaf) return Promise.resolve(undefined);
+    if (!leaf) {
+      return Promise.resolve(undefined);
+    }
     return Promise.resolve(toBufferBE(leaf.value, 32));
   }
 
@@ -453,7 +455,9 @@ export class StandardIndexedTree extends TreeBase implements IndexedTree {
         // check the pending low nullifiers for a low nullifier that works
         // This is the case where the next value is less than the pending
         for (let j = 0; j < pendingInsertionSubtree.length; j++) {
-          if (pendingInsertionSubtree[j].value === 0n) continue;
+          if (pendingInsertionSubtree[j].value === 0n) {
+            continue;
+          }
 
           if (
             pendingInsertionSubtree[j].value < newValue &&

--- a/yarn-project/noir-compiler/package.json
+++ b/yarn-project/noir-compiler/package.json
@@ -22,7 +22,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"
   },
   "inherits": [

--- a/yarn-project/noir-compiler/src/cli/contract.ts
+++ b/yarn-project/noir-compiler/src/cli/contract.ts
@@ -41,8 +41,12 @@ export function compileContract(program: Command, name = 'contract', log: LogFn 
         /* eslint-enable jsdoc/require-jsdoc */
       ) => {
         const { outdir, typescript, interface: noirInterface, compiler } = options;
-        if (typeof projectPath !== 'string') throw new Error(`Missing project path argument`);
-        if (compiler !== 'nargo' && compiler !== 'wasm') throw new Error(`Invalid compiler: ${compiler}`);
+        if (typeof projectPath !== 'string') {
+          throw new Error(`Missing project path argument`);
+        }
+        if (compiler !== 'nargo' && compiler !== 'wasm') {
+          throw new Error(`Invalid compiler: ${compiler}`);
+        }
         const currentDir = process.cwd();
 
         const compile = compiler === 'wasm' ? compileUsingNoirWasm : compileUsingNargo;

--- a/yarn-project/noir-compiler/src/cli/noir-interface.ts
+++ b/yarn-project/noir-compiler/src/cli/noir-interface.ts
@@ -37,7 +37,9 @@ export function generateNoirInterface(program: Command, name = 'interface', log:
         /* eslint-enable jsdoc/require-jsdoc */
       ) => {
         const { outdir, artifacts } = options;
-        if (typeof projectPath !== 'string') throw new Error(`Missing project path argument`);
+        if (typeof projectPath !== 'string') {
+          throw new Error(`Missing project path argument`);
+        }
         const currentDir = process.cwd();
 
         const artifactsDir = resolve(projectPath, artifacts);
@@ -45,7 +47,9 @@ export function generateNoirInterface(program: Command, name = 'interface', log:
           const artifactPath = resolve(artifactsDir, artifactsDirItem);
           if (statSync(artifactPath).isFile() && artifactPath.endsWith('.json')) {
             const contract = JSON.parse(readFileSync(artifactPath).toString());
-            if (!isContractArtifact(contract)) continue;
+            if (!isContractArtifact(contract)) {
+              continue;
+            }
             const interfacePath = resolve(projectPath, outdir, `${contract.name}_interface.nr`);
             log(`Writing ${contract.name} Noir external interface to ${path.relative(currentDir, interfacePath)}`);
             try {

--- a/yarn-project/noir-compiler/src/cli/typescript.ts
+++ b/yarn-project/noir-compiler/src/cli/typescript.ts
@@ -37,7 +37,9 @@ export function generateTypescriptInterface(program: Command, name = 'typescript
         /* eslint-enable jsdoc/require-jsdoc */
       ) => {
         const { outdir, artifacts } = options;
-        if (typeof projectPath !== 'string') throw new Error(`Missing project path argument`);
+        if (typeof projectPath !== 'string') {
+          throw new Error(`Missing project path argument`);
+        }
         const currentDir = process.cwd();
 
         const artifactsDir = resolve(projectPath, artifacts);
@@ -45,7 +47,9 @@ export function generateTypescriptInterface(program: Command, name = 'typescript
           const artifactPath = resolve(artifactsDir, artifactsDirItem);
           if (statSync(artifactPath).isFile() && artifactPath.endsWith('.json')) {
             const contract = JSON.parse(readFileSync(artifactPath).toString());
-            if (!isContractArtifact(contract)) continue;
+            if (!isContractArtifact(contract)) {
+              continue;
+            }
             const tsPath = resolve(projectPath, outdir, `${contract.name}.ts`);
             log(`Writing ${contract.name} typescript interface to ${path.relative(currentDir, tsPath)}`);
             let relativeArtifactPath = path.relative(path.dirname(tsPath), artifactPath);

--- a/yarn-project/noir-compiler/src/contract-interface-gen/abi.ts
+++ b/yarn-project/noir-compiler/src/contract-interface-gen/abi.ts
@@ -16,7 +16,9 @@ function generateFunctionArtifact(fn: NoirFunctionEntry): FunctionArtifact {
 
   // If the function is not unconstrained, the first item is inputs or CallContext which we should omit
   let parameters = fn.abi.parameters;
-  if (functionType !== FunctionType.UNCONSTRAINED) parameters = parameters.slice(1);
+  if (functionType !== FunctionType.UNCONSTRAINED) {
+    parameters = parameters.slice(1);
+  }
 
   // If the function is secret, the return is the public inputs, which should be omitted
   const returnTypes = functionType === FunctionType.SECRET ? [] : [fn.abi.return_type];

--- a/yarn-project/noir-compiler/src/contract-interface-gen/typescript.ts
+++ b/yarn-project/noir-compiler/src/contract-interface-gen/typescript.ts
@@ -26,8 +26,12 @@ function abiTypeToTypescript(type: ABIParameter['type']): string {
     case 'array':
       return `${abiTypeToTypescript(type.type)}[]`;
     case 'struct':
-      if (isEthereumAddressStruct(type)) return 'EthAddressLike';
-      if (isAztecAddressStruct(type)) return 'AztecAddressLike';
+      if (isEthereumAddressStruct(type)) {
+        return 'EthAddressLike';
+      }
+      if (isAztecAddressStruct(type)) {
+        return 'AztecAddressLike';
+      }
       return `{ ${type.fields.map(f => `${f.name}: ${abiTypeToTypescript(f.type)}`).join(', ')} }`;
     default:
       throw new Error(`Unknown type ${type}`);

--- a/yarn-project/noir-compiler/src/utils.ts
+++ b/yarn-project/noir-compiler/src/utils.ts
@@ -8,14 +8,26 @@ import { ContractArtifact } from '@aztec/foundation/abi';
  * @returns True if it looks like a ContractArtifact.
  */
 export function isContractArtifact(input: any): input is ContractArtifact {
-  if (typeof input !== 'object') return false;
+  if (typeof input !== 'object') {
+    return false;
+  }
   const maybeContractArtifact = input as ContractArtifact;
-  if (typeof maybeContractArtifact.name !== 'string') return false;
-  if (!Array.isArray(maybeContractArtifact.functions)) return false;
+  if (typeof maybeContractArtifact.name !== 'string') {
+    return false;
+  }
+  if (!Array.isArray(maybeContractArtifact.functions)) {
+    return false;
+  }
   for (const fn of maybeContractArtifact.functions) {
-    if (typeof fn.name !== 'string') return false;
-    if (typeof fn.functionType !== 'string') return false;
-    if (typeof fn.isInternal !== 'boolean') return false;
+    if (typeof fn.name !== 'string') {
+      return false;
+    }
+    if (typeof fn.functionType !== 'string') {
+      return false;
+    }
+    if (typeof fn.isInternal !== 'boolean') {
+      return false;
+    }
   }
   return true;
 }

--- a/yarn-project/noir-contracts/package.json
+++ b/yarn-project/noir-contracts/package.json
@@ -11,7 +11,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests",
     "noir:clean": "rm -rf ./src/artifacts ./src/types && mkdir -p ../aztec.js/src/artifacts/ && find ../aztec.js/src/artifacts/ -mindepth 1 -delete && rm -rf target/",
     "noir:build": "./src/scripts/compile.sh",

--- a/yarn-project/noir-contracts/src/scripts/copy_output.ts
+++ b/yarn-project/noir-contracts/src/scripts/copy_output.ts
@@ -56,7 +56,9 @@ function processNoirCompilerArtifact(projectName: string, contractName: string) 
 
 const main = () => {
   const name = process.argv[2];
-  if (!name) throw new Error(`Missing argument contract name`);
+  if (!name) {
+    throw new Error(`Missing argument contract name`);
+  }
 
   const projectName = `${snakeCase(name)}_contract`;
   const contractName = upperFirst(camelCase(name));

--- a/yarn-project/noir-contracts/src/scripts/copy_source.ts
+++ b/yarn-project/noir-contracts/src/scripts/copy_source.ts
@@ -69,7 +69,9 @@ function copyNrFilesExceptInterface(contractName: string): void {
 
 const main = () => {
   const contractName = process.argv[2];
-  if (!contractName) throw new Error(`Missing argument contract name`);
+  if (!contractName) {
+    throw new Error(`Missing argument contract name`);
+  }
 
   copyNrFilesExceptInterface(contractName);
 };

--- a/yarn-project/noir-protocol-circuits/package.json
+++ b/yarn-project/noir-protocol-circuits/package.json
@@ -11,7 +11,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "noir:build": "cd src && nargo compile --no-backend && rm -rf ./target/debug_*",
     "noir:types": "yarn ts-node --esm src/scripts/generate_ts_from_abi.ts && yarn formatting:fix",
     "noir:test": "cd src && nargo test",

--- a/yarn-project/noir-protocol-circuits/src/scripts/generate_ts_from_abi.ts
+++ b/yarn-project/noir-protocol-circuits/src/scripts/generate_ts_from_abi.ts
@@ -114,7 +114,9 @@ function generateStructInterfaces(type: ABIType, output: Set<string>): string {
   if (type.kind === 'array' && type.type.kind === 'struct' && !output.has(getLastComponentOfPath(type.type.path))) {
     result += generateStructInterfaces(type.type, output);
   }
-  if (type.kind !== 'struct') return result;
+  if (type.kind !== 'struct') {
+    return result;
+  }
 
   // List of structs encountered while viewing this type that we need to generate
   // bindings for.

--- a/yarn-project/p2p-bootstrap/package.json
+++ b/yarn-project/p2p-bootstrap/package.json
@@ -15,7 +15,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'",
     "start": "node ./dest/index.js",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"

--- a/yarn-project/p2p/package.json
+++ b/yarn-project/p2p/package.json
@@ -15,7 +15,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests",
     "start": "node ./dest",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'"

--- a/yarn-project/p2p/src/service/libp2p_service.ts
+++ b/yarn-project/p2p/src/service/libp2p_service.ts
@@ -83,8 +83,12 @@ export class LibP2PService implements P2PService {
     }
     const { enableNat, tcpListenIp, tcpListenPort, announceHostname, announcePort } = this.config;
     this.logger(`Starting P2P node on ${tcpListenIp}:${tcpListenPort}`);
-    if (announceHostname) this.logger(`Announcing at ${announceHostname}/tcp/${announcePort ?? tcpListenPort}`);
-    if (enableNat) this.logger(`Enabling NAT in libp2p module`);
+    if (announceHostname) {
+      this.logger(`Announcing at ${announceHostname}/tcp/${announcePort ?? tcpListenPort}`);
+    }
+    if (enableNat) {
+      this.logger(`Enabling NAT in libp2p module`);
+    }
 
     this.node.addEventListener('peer:discovery', evt => {
       const peerId = evt.detail.id;

--- a/yarn-project/package.common.json
+++ b/yarn-project/package.common.json
@@ -4,7 +4,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"
   },
   "engines": {

--- a/yarn-project/prover-client/package.json
+++ b/yarn-project/prover-client/package.json
@@ -15,7 +15,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"
   },
   "inherits": [

--- a/yarn-project/pxe/package.json
+++ b/yarn-project/pxe/package.json
@@ -16,7 +16,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests",
     "start": "DEBUG='aztec:*' && node ./dest/bin/index.js"
   },

--- a/yarn-project/pxe/src/database/memory_db.ts
+++ b/yarn-project/pxe/src/database/memory_db.ts
@@ -95,7 +95,9 @@ export class MemoryDB extends MemoryContractDatabase implements Database {
 
   public getTreeRoots(): Record<MerkleTreeId, Fr> {
     const roots = this.treeRoots;
-    if (!roots) throw new Error(`Tree roots not set in memory database`);
+    if (!roots) {
+      throw new Error(`Tree roots not set in memory database`);
+    }
     return roots;
   }
 
@@ -106,7 +108,9 @@ export class MemoryDB extends MemoryContractDatabase implements Database {
 
   public getHistoricBlockData(): HistoricBlockData {
     const roots = this.getTreeRoots();
-    if (!this.globalVariablesHash) throw new Error(`Global variables hash not set in memory database`);
+    if (!this.globalVariablesHash) {
+      throw new Error(`Global variables hash not set in memory database`);
+    }
     return new HistoricBlockData(
       roots[MerkleTreeId.NOTE_HASH_TREE],
       roots[MerkleTreeId.NULLIFIER_TREE],

--- a/yarn-project/pxe/src/note_processor/note_processor.ts
+++ b/yarn-project/pxe/src/note_processor/note_processor.ts
@@ -203,10 +203,14 @@ export class NoteProcessor {
     let uniqueSiloedNoteHash: Fr | undefined;
     let innerNullifier: Fr | undefined;
     for (; commitmentIndex < commitments.length; ++commitmentIndex) {
-      if (excludedIndices.has(commitmentIndex)) continue;
+      if (excludedIndices.has(commitmentIndex)) {
+        continue;
+      }
 
       const commitment = commitments[commitmentIndex];
-      if (commitment.equals(Fr.ZERO)) break;
+      if (commitment.equals(Fr.ZERO)) {
+        break;
+      }
 
       const expectedNonce = computeCommitmentNonce(firstNullifier, commitmentIndex);
       ({ innerNoteHash, siloedNoteHash, uniqueSiloedNoteHash, innerNullifier } =

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -276,7 +276,9 @@ export class PXEService implements PXE {
     const commitments = tx.newCommitments;
     for (let i = 0; i < commitments.length; ++i) {
       const commitment = commitments[i];
-      if (commitment.equals(Fr.ZERO)) break;
+      if (commitment.equals(Fr.ZERO)) {
+        break;
+      }
 
       const nonce = computeCommitmentNonce(firstNullifier, i);
       const { siloedNoteHash, uniqueSiloedNoteHash } = await this.simulator.computeNoteHashAndNullifier(
@@ -321,7 +323,9 @@ export class PXEService implements PXE {
     const newContract = deployedContractAddress ? await this.db.getContract(deployedContractAddress) : undefined;
 
     const tx = await this.#simulateAndProve(txRequest, newContract);
-    if (simulatePublic) await this.#simulatePublicCalls(tx);
+    if (simulatePublic) {
+      await this.#simulatePublicCalls(tx);
+    }
     this.log.info(`Executed local simulation for ${await tx.getTxHash()}`);
 
     return tx;

--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -31,16 +31,19 @@ export class SimulatorOracle implements DBOracle {
 
   async getCompleteAddress(address: AztecAddress): Promise<CompleteAddress> {
     const completeAddress = await this.db.getCompleteAddress(address);
-    if (!completeAddress)
+    if (!completeAddress) {
       throw new Error(
         `No public key registered for address ${address.toString()}. Register it by calling pxe.registerRecipient(...) or pxe.registerAccount(...).\nSee docs for context: https://docs.aztec.network/dev_docs/contracts/common_errors#no-public-key-registered-error`,
       );
+    }
     return completeAddress;
   }
 
   async getAuthWitness(messageHash: Fr): Promise<Fr[]> {
     const witness = await this.db.getAuthWitness(messageHash);
-    if (!witness) throw new Error(`Unknown auth witness for message hash ${messageHash.toString(true)}`);
+    if (!witness) {
+      throw new Error(`Unknown auth witness for message hash ${messageHash.toString(true)}`);
+    }
     return witness;
   }
 

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -39,7 +39,9 @@ export class Synchronizer {
    * @param retryInterval - The time interval (in ms) to wait before retrying if no data is available.
    */
   public async start(from = INITIAL_L2_BLOCK_NUM, limit = 1, retryInterval = 1000) {
-    if (this.running) return;
+    if (this.running) {
+      return;
+    }
     this.running = true;
 
     if (from < this.synchedToBlock + 1) {
@@ -197,7 +199,9 @@ export class Synchronizer {
 
   private async setBlockDataFromBlock(latestBlock: L2BlockContext) {
     const { block } = latestBlock;
-    if (block.number < this.initialSyncBlockNumber) return;
+    if (block.number < this.initialSyncBlockNumber) {
+      return;
+    }
 
     const globalsHash = computeGlobalsHash(latestBlock.block.globalVariables);
     const blockData = new HistoricBlockData(
@@ -241,7 +245,9 @@ export class Synchronizer {
   public addAccount(publicKey: PublicKey, keyStore: KeyStore, startingBlock: number) {
     const predicate = (x: NoteProcessor) => x.publicKey.equals(publicKey);
     const processor = this.noteProcessors.find(predicate) ?? this.noteProcessorsToCatchUp.find(predicate);
-    if (processor) return;
+    if (processor) {
+      return;
+    }
 
     this.noteProcessorsToCatchUp.push(new NoteProcessor(publicKey, keyStore, this.db, this.node, startingBlock));
   }

--- a/yarn-project/scripts/package.json
+++ b/yarn-project/scripts/package.json
@@ -14,7 +14,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'",
     "start": "node ./dest/index.js",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"

--- a/yarn-project/scripts/src/benchmarks/aggregate.ts
+++ b/yarn-project/scripts/src/benchmarks/aggregate.ts
@@ -52,15 +52,21 @@ function append(
     log(`Value ${value} for ${metric} in ${bucket} is not a number`);
     return;
   }
-  if (!results[metric]) results[metric] = {};
-  if (!results[metric]![bucket]) results[metric]![bucket] = [];
+  if (!results[metric]) {
+    results[metric] = {};
+  }
+  if (!results[metric]![bucket]) {
+    results[metric]![bucket] = [];
+  }
   results[metric]![bucket].push(numeric);
 }
 
 /** Processes an entry with event name 'rollup-published-to-l1' and updates results */
 function processRollupPublished(entry: L1PublishStats, results: BenchmarkCollectedResults) {
   const bucket = entry.txCount;
-  if (!BENCHMARK_BLOCK_SIZES.includes(bucket)) return;
+  if (!BENCHMARK_BLOCK_SIZES.includes(bucket)) {
+    return;
+  }
   append(results, 'l1_rollup_calldata_gas', bucket, entry.calldataGas);
   append(results, 'l1_rollup_calldata_size_in_bytes', bucket, entry.calldataSize);
   append(results, 'l1_rollup_execution_gas', bucket, entry.gasUsed);
@@ -72,8 +78,12 @@ function processRollupPublished(entry: L1PublishStats, results: BenchmarkCollect
  */
 function processRollupBlockSynced(entry: L2BlockHandledStats, results: BenchmarkCollectedResults) {
   const bucket = entry.txCount;
-  if (!BENCHMARK_BLOCK_SIZES.includes(bucket)) return;
-  if (entry.isBlockOurs) return;
+  if (!BENCHMARK_BLOCK_SIZES.includes(bucket)) {
+    return;
+  }
+  if (entry.isBlockOurs) {
+    return;
+  }
   append(results, 'l2_block_processing_time_in_ms', bucket, entry.duration);
 }
 
@@ -83,7 +93,9 @@ function processRollupBlockSynced(entry: L2BlockHandledStats, results: Benchmark
  */
 function processCircuitSimulation(entry: CircuitSimulationStats, results: BenchmarkCollectedResults) {
   const bucket = entry.circuitName;
-  if (!bucket) return;
+  if (!bucket) {
+    return;
+  }
   append(results, 'circuit_simulation_time_in_ms', bucket, entry.duration);
   append(results, 'circuit_input_size_in_bytes', bucket, entry.inputSize);
   append(results, 'circuit_output_size_in_bytes', bucket, entry.outputSize);
@@ -105,14 +117,17 @@ function processNoteProcessorCaughtUp(entry: NoteProcessorCaughtUpStats, results
     append(results, 'note_history_successful_decrypting_time_in_ms', blocks, duration);
     append(results, 'pxe_database_size_in_bytes', blocks, dbSize);
   }
-  if (BENCHMARK_HISTORY_CHAIN_LENGTHS.includes(blocks) && decrypted === 0)
+  if (BENCHMARK_HISTORY_CHAIN_LENGTHS.includes(blocks) && decrypted === 0) {
     append(results, 'note_history_trial_decrypting_time_in_ms', blocks, duration);
+  }
 }
 
 /** Processes an entry with event name 'l2-block-built' and updates results where buckets are rollup sizes */
 function processL2BlockBuilt(entry: L2BlockBuiltStats, results: BenchmarkCollectedResults) {
   const bucket = entry.txCount;
-  if (!BENCHMARK_BLOCK_SIZES.includes(bucket)) return;
+  if (!BENCHMARK_BLOCK_SIZES.includes(bucket)) {
+    return;
+  }
   append(results, 'l2_block_building_time_in_ms', bucket, entry.duration);
   append(results, 'l2_block_rollup_simulation_time_in_ms', bucket, entry.rollupCircuitsDuration);
   append(results, 'l2_block_public_tx_process_time_in_ms', bucket, entry.publicProcessDuration);
@@ -121,8 +136,12 @@ function processL2BlockBuilt(entry: L2BlockBuiltStats, results: BenchmarkCollect
 /** Processes entries with event name node-synced-chain-history emitted by benchmark tests where buckets are chain lengths */
 function processNodeSyncedChain(entry: NodeSyncedChainHistoryStats, results: BenchmarkCollectedResults) {
   const bucket = entry.blockCount;
-  if (!BENCHMARK_HISTORY_CHAIN_LENGTHS.includes(bucket)) return;
-  if (entry.txsPerBlock !== BENCHMARK_HISTORY_BLOCK_SIZE) return;
+  if (!BENCHMARK_HISTORY_CHAIN_LENGTHS.includes(bucket)) {
+    return;
+  }
+  if (entry.txsPerBlock !== BENCHMARK_HISTORY_BLOCK_SIZE) {
+    return;
+  }
   append(results, 'node_history_sync_time_in_ms', bucket, entry.duration);
   append(results, 'node_database_size_in_bytes', bucket, entry.dbSize);
 }
@@ -188,7 +207,9 @@ export async function main() {
     results[metricName as MetricName] = resultMetric;
     for (const [bucketName, bucket] of Object.entries(metric)) {
       let avg = bucket.reduce((acc, val) => acc + val, 0) / bucket.length;
-      if (avg > 100) avg = Math.floor(avg);
+      if (avg > 100) {
+        avg = Math.floor(avg);
+      }
       resultMetric[bucketName] = avg;
     }
   }

--- a/yarn-project/scripts/src/benchmarks/comment.ts
+++ b/yarn-project/scripts/src/benchmarks/comment.ts
@@ -16,7 +16,9 @@ const log = createConsoleLogger();
 
 /** Returns the number of the current PR */
 function getPrNumber() {
-  if (!process.env.CIRCLE_PULL_REQUEST) throw new Error(`Not in Circle PR`);
+  if (!process.env.CIRCLE_PULL_REQUEST) {
+    throw new Error(`Not in Circle PR`);
+  }
   const fragments = process.env.CIRCLE_PULL_REQUEST.split('/');
   return fragments[fragments.length - 1];
 }
@@ -60,8 +62,11 @@ function sendGitHubRequest(url: string, method = 'GET', data?: object): Promise<
     'User-Agent': OWNER,
     'Content-Type': undefined as string | undefined,
   };
-  if (data) headers['Content-Type'] = 'application/json';
-  else delete headers['Content-Type'];
+  if (data) {
+    headers['Content-Type'] = 'application/json';
+  } else {
+    delete headers['Content-Type'];
+  }
 
   const requestOptions = { method, headers };
 
@@ -91,7 +96,9 @@ function sendGitHubRequest(url: string, method = 'GET', data?: object): Promise<
       reject(error);
     });
 
-    if (data) req.write(JSON.stringify(data));
+    if (data) {
+      req.write(JSON.stringify(data));
+    }
     req.end();
   });
 }

--- a/yarn-project/scripts/src/benchmarks/markdown.ts
+++ b/yarn-project/scripts/src/benchmarks/markdown.ts
@@ -26,7 +26,9 @@ const log = createConsoleLogger();
 
 /** Returns whether the value should be a warning, based on the % difference and absolute value. */
 function isWarning(row: string, col: string, value: number, base: number | undefined) {
-  if (base === undefined) return false;
+  if (base === undefined) {
+    return false;
+  }
   const absPercentDiff = Math.abs(Math.round(((value - base) / base) * 100));
   if ((row.endsWith('_ms') || col.endsWith('_ms')) && value < SMALL_MS_THRESHOLD) {
     return absPercentDiff >= WARNING_DIFF_THRESHOLD_SMALL_MS;
@@ -62,10 +64,14 @@ function getWarnings(
   data: Record<string, Record<string, number>>,
   base: Record<string, Record<string, number>> | undefined,
 ) {
-  if (!base) return [];
+  if (!base) {
+    return [];
+  }
   const warnings: string[] = [];
   for (const row in data) {
-    if (row === 'timestamp') continue;
+    if (row === 'timestamp') {
+      continue;
+    }
     for (const col in data[row]) {
       const value = data[row][col];
       const baseValue = (base[row] ?? {})[col];
@@ -101,13 +107,17 @@ function getCell(
 /** Wraps the metric name in a span with a title with the description, if found. */
 function withDesc(name: string) {
   const description = Metrics.find(m => m.name === name)?.description;
-  if (!description) return name;
+  if (!description) {
+    return name;
+  }
   return `<span title="${description}">${name}</span>`;
 }
 
 /** Formats a numeric value for display. */
 function formatValue(value: number) {
-  if (value < 100) return value.toPrecision(3);
+  if (value < 100) {
+    return value.toPrecision(3);
+  }
   return value.toLocaleString();
 }
 
@@ -117,7 +127,9 @@ function transpose(obj: any) {
   for (const outerKey in obj) {
     const innerObj = obj[outerKey];
     for (const innerKey in innerObj) {
-      if (!transposed[innerKey]) transposed[innerKey] = {};
+      if (!transposed[innerKey]) {
+        transposed[innerKey] = {};
+      }
       transposed[innerKey][outerKey] = innerObj[innerKey];
     }
   }

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -15,7 +15,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests",
     "test:integration": "concurrently -k -s first -c reset,dim -n test,anvil \"yarn test:integration:run\" \"anvil\"",
     "test:integration:run": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --no-cache --config jest.integration.config.json"

--- a/yarn-project/sequencer-client/src/block_builder/solo_block_builder.ts
+++ b/yarn-project/sequencer-client/src/block_builder/solo_block_builder.ts
@@ -527,7 +527,9 @@ export class SoloBlockBuilder implements BlockBuilder {
     height: N,
   ): Promise<MembershipWitness<N>> {
     // If this is an empty tx, then just return zeroes
-    if (value.isZero()) return this.makeEmptyMembershipWitness(height);
+    if (value.isZero()) {
+      return this.makeEmptyMembershipWitness(height);
+    }
 
     const index = await this.db.findLeafIndex(treeId, value.toBuffer());
     if (index === undefined) {
@@ -576,7 +578,9 @@ export class SoloBlockBuilder implements BlockBuilder {
     const tree = MerkleTreeId.NULLIFIER_TREE;
     const prevValueIndex = await this.db.getPreviousValueIndex(tree, frToBigInt(nullifier));
     const prevValueInfo = await this.db.getLeafData(tree, prevValueIndex.index);
-    if (!prevValueInfo) throw new Error(`Nullifier tree should have one initial leaf`);
+    if (!prevValueInfo) {
+      throw new Error(`Nullifier tree should have one initial leaf`);
+    }
     const prevValueSiblingPath = await this.db.getSiblingPath(tree, BigInt(prevValueIndex.index));
 
     return {

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -134,10 +134,14 @@ export class L1Publisher implements L2BlockReceiver {
       }
 
       const txHash = await this.sendProcessTx(txData);
-      if (!txHash) break;
+      if (!txHash) {
+        break;
+      }
 
       const receipt = await this.getTransactionReceipt(txHash);
-      if (!receipt) break;
+      if (!receipt) {
+        break;
+      }
 
       // Tx was mined successfully
       if (receipt.status) {
@@ -184,17 +188,23 @@ export class L1Publisher implements L2BlockReceiver {
 
       const arr = _contractData.length ? _contractData : contractData;
       const txHashes = await this.sendEmitNewContractDataTx(l2BlockNum, l2BlockHash, arr);
-      if (!txHashes) break;
+      if (!txHashes) {
+        break;
+      }
       // filter successful txs
       _contractData = arr.filter((_, i) => !!txHashes[i]);
 
       const receipts = await Promise.all(
         txHashes.filter(isNotUndefined).map(txHash => this.getTransactionReceipt(txHash)),
       );
-      if (!receipts?.length) break;
+      if (!receipts?.length) {
+        break;
+      }
 
       // ALL Txs were mined successfully
-      if (receipts.length === contractData.length && receipts.every(r => r?.status)) return true;
+      if (receipts.length === contractData.length && receipts.every(r => r?.status)) {
+        return true;
+      }
 
       this.log(
         `Transaction status failed: ${receipts

--- a/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
+++ b/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
@@ -77,7 +77,9 @@ export class ViemTxSender implements L1PublisherTxSender {
 
   async getTransactionStats(txHash: string): Promise<TransactionStats | undefined> {
     const tx = await this.publicClient.getTransaction({ hash: txHash as Hex });
-    if (!tx) return undefined;
+    if (!tx) {
+      return undefined;
+    }
     const calldata = hexToBytes(tx.input);
     return {
       transactionHash: tx.hash,

--- a/yarn-project/sequencer-client/src/sequencer/public_processor.ts
+++ b/yarn-project/sequencer-client/src/sequencer/public_processor.ts
@@ -159,7 +159,9 @@ export class PublicProcessor {
 
   protected async processEnqueuedPublicCalls(tx: Tx): Promise<[PublicKernelPublicInputs, Proof, FunctionL2Logs[]]> {
     this.log(`Executing enqueued public calls for tx ${await tx.getTxHash()}`);
-    if (!tx.enqueuedPublicFunctionCalls) throw new Error(`Missing preimages for enqueued public calls`);
+    if (!tx.enqueuedPublicFunctionCalls) {
+      throw new Error(`Missing preimages for enqueued public calls`);
+    }
 
     let kernelOutput = new KernelCircuitPublicInputs(
       CombinedAccumulatedData.fromFinalAccumulatedData(tx.data.end),
@@ -196,7 +198,9 @@ export class PublicProcessor {
 
         [kernelOutput, kernelProof] = await this.runKernelCircuit(callData, kernelOutput, kernelProof);
 
-        if (!enqueuedExecutionResult) enqueuedExecutionResult = result;
+        if (!enqueuedExecutionResult) {
+          enqueuedExecutionResult = result;
+        }
       }
       // HACK(#1622): Manually patches the ordering of public state actions
       // TODO(#757): Enforce proper ordering of public state actions

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -56,9 +56,15 @@ export class Sequencer {
    * @param config - New parameters.
    */
   public updateConfig(config: SequencerConfig) {
-    if (config.transactionPollingIntervalMS) this.pollingIntervalMs = config.transactionPollingIntervalMS;
-    if (config.maxTxsPerBlock) this.maxTxsPerBlock = config.maxTxsPerBlock;
-    if (config.minTxsPerBlock) this.minTxsPerBLock = config.minTxsPerBlock;
+    if (config.transactionPollingIntervalMS) {
+      this.pollingIntervalMs = config.transactionPollingIntervalMS;
+    }
+    if (config.maxTxsPerBlock) {
+      this.maxTxsPerBlock = config.maxTxsPerBlock;
+    }
+    if (config.minTxsPerBlock) {
+      this.minTxsPerBLock = config.minTxsPerBlock;
+    }
   }
 
   /**
@@ -119,14 +125,18 @@ export class Sequencer {
       }
 
       // Do not go forward with new block if the previous one has not been mined and processed
-      if (!prevBlockSynced) return;
+      if (!prevBlockSynced) {
+        return;
+      }
 
       const workTimer = new Timer();
       this.state = SequencerState.WAITING_FOR_TXS;
 
       // Get txs to build the new block
       const pendingTxs = await this.p2pClient.getTxs();
-      if (pendingTxs.length < this.minTxsPerBLock) return;
+      if (pendingTxs.length < this.minTxsPerBLock) {
+        return;
+      }
       this.log.info(`Retrieved ${pendingTxs.length} txs from P2P pool`);
 
       const blockNumber = (await this.l2BlockSource.getBlockNumber()) + 1;
@@ -146,7 +156,9 @@ export class Sequencer {
       // Filter out invalid txs
       // TODO: It should be responsibility of the P2P layer to validate txs before passing them on here
       const validTxs = await this.takeValidTxs(pendingTxs, newGlobalVariables);
-      if (validTxs.length < this.minTxsPerBLock) return;
+      if (validTxs.length < this.minTxsPerBLock) {
+        return;
+      }
 
       this.log.info(`Building block ${blockNumber} with ${validTxs.length} transactions`);
       this.state = SequencerState.CREATING_BLOCK;
@@ -284,7 +296,9 @@ export class Sequencer {
 
       tx.data.end.newNullifiers.forEach(n => thisBlockNullifiers.add(n.toBigInt()));
       validTxs.push(tx);
-      if (validTxs.length >= this.maxTxsPerBlock) break;
+      if (validTxs.length >= this.maxTxsPerBlock) {
+        break;
+      }
     }
 
     // Make sure we remove these from the tx pool so we do not consider it again
@@ -373,13 +387,17 @@ export class Sequencer {
 
     // Ditch this tx if it has a repeated nullifiers
     const uniqNullifiers = new Set(newNullifiers.map(n => n.toBigInt()));
-    if (uniqNullifiers.size !== newNullifiers.length) return true;
+    if (uniqNullifiers.size !== newNullifiers.length) {
+      return true;
+    }
 
     for (const nullifier of newNullifiers) {
       // TODO(AD): this is an exhaustive search currently
       const db = this.worldState.getLatest();
       const indexInDb = await db.findLeafIndex(MerkleTreeId.NULLIFIER_TREE, nullifier.toBuffer());
-      if (indexInDb !== undefined) return true;
+      if (indexInDb !== undefined) {
+        return true;
+      }
     }
     return false;
   }

--- a/yarn-project/sequencer-client/src/simulator/public_executor.ts
+++ b/yarn-project/sequencer-client/src/simulator/public_executor.ts
@@ -109,7 +109,9 @@ class WorldStatePublicDB implements PublicStateDB {
   public async storageRead(contract: AztecAddress, slot: Fr): Promise<Fr> {
     const index = computePublicDataTreeIndex(contract, slot).value;
     const cached = this.writeCache.get(index);
-    if (cached !== undefined) return cached;
+    if (cached !== undefined) {
+      return cached;
+    }
     const value = await this.db.getLeafValue(MerkleTreeId.PUBLIC_DATA_TREE, index);
     return value ? Fr.fromBuffer(value) : Fr.ZERO;
   }

--- a/yarn-project/sequencer-client/src/simulator/public_kernel.ts
+++ b/yarn-project/sequencer-client/src/simulator/public_kernel.ts
@@ -18,7 +18,9 @@ export class WasmPublicKernelCircuitSimulator implements PublicKernelCircuitSimu
    * @returns The public inputs as outputs of the simulation.
    */
   public async publicKernelCircuitPrivateInput(input: PublicKernelInputs): Promise<PublicKernelPublicInputs> {
-    if (!input.previousKernel.publicInputs.isPrivate) throw new Error(`Expected private kernel previous inputs`);
+    if (!input.previousKernel.publicInputs.isPrivate) {
+      throw new Error(`Expected private kernel previous inputs`);
+    }
     const [duration, result] = await elapsed(() => executePublicKernelPrivatePrevious(input));
     this.log(`Simulated public kernel circuit with private input`, {
       eventName: 'circuit-simulation',
@@ -36,7 +38,9 @@ export class WasmPublicKernelCircuitSimulator implements PublicKernelCircuitSimu
    * @returns The public inputs as outputs of the simulation.
    */
   public async publicKernelCircuitNonFirstIteration(input: PublicKernelInputs): Promise<PublicKernelPublicInputs> {
-    if (input.previousKernel.publicInputs.isPrivate) throw new Error(`Expected public kernel previous inputs`);
+    if (input.previousKernel.publicInputs.isPrivate) {
+      throw new Error(`Expected public kernel previous inputs`);
+    }
     const [duration, result] = await elapsed(() => executePublicKernelPublicPrevious(input));
     this.log(`Simulated public kernel circuit non-first iteration`, {
       eventName: 'circuit-simulation',

--- a/yarn-project/types/package.json
+++ b/yarn-project/types/package.json
@@ -18,7 +18,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"
   },
   "inherits": [

--- a/yarn-project/types/src/tx/tx.ts
+++ b/yarn-project/types/src/tx/tx.ts
@@ -155,7 +155,9 @@ export class Tx {
   getTxHash(): Promise<TxHash> {
     // Private kernel functions are executed client side and for this reason tx hash is already set as first nullifier
     const firstNullifier = this.data?.end.newNullifiers[0];
-    if (!firstNullifier) throw new Error(`Cannot get tx hash since first nullifier is missing`);
+    if (!firstNullifier) {
+      throw new Error(`Cannot get tx hash since first nullifier is missing`);
+    }
     return Promise.resolve(new TxHash(firstNullifier.toBuffer()));
   }
 

--- a/yarn-project/world-state/package.json
+++ b/yarn-project/world-state/package.json
@@ -15,7 +15,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
-    "formatting:fix": "run -T prettier -w ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"
   },
   "inherits": [

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -564,7 +564,9 @@ export class MerkleTrees implements MerkleTreeDb {
 
       // Sync the public data tree
       for (const dataWrite of l2Block.newPublicDataWrites) {
-        if (dataWrite.isEmpty()) continue;
+        if (dataWrite.isEmpty()) {
+          continue;
+        }
         const { newValue, leafIndex } = dataWrite;
         await this._updateLeaf(MerkleTreeId.PUBLIC_DATA_TREE, newValue.toBuffer(), leafIndex.value);
       }


### PR DESCRIPTION
As title.

`yarn formatting:fix` now runs eslint with fix enabled first, allowing auto fixing of these kinds of issues.

Calling out to ChatGPT as my curly supporting hype-man:

1. Readability: Curly braces make the structure of the code clearer, especially in complex codebases. It's easier to identify the start and end of control blocks.
2. Maintainability: When modifying code, clear block delimiters reduce the chance of introducing errors. For example, if you need to add a new statement to an if block that was initially written without braces, the absence of braces might lead to logical errors.
3. Error Reduction: One of the famous bugs related to the absence of curly braces is Apple's "goto fail;" bug. Such bugs occur when the intended block scope is not properly defined, leading to unexpected behavior.
4. Consistency: Enforcing a consistent style, like always using braces, can make the code more uniform and easier to understand for all team members.

![](https://github.com/AztecProtocol/aztec-packages/assets/5764343/d24b4133-2e57-4790-97df-fe0e88880011)

