### PR TITLE
fix: loosen permissions on the target directory for unbox when using docker

### DIFF
--- a/yarn-project/cli/aztec-cli
+++ b/yarn-project/cli/aztec-cli
@@ -109,6 +109,8 @@ if [[ "$AZTEC_CLI_COMMAND" == "unbox" ]]; then
     mkdir -p "$DIR"
   fi
 
+  # avoid "Error: EACCES: permission denied, mkdir..." inside the unbox command, which creates subdirectories
+  chmod 777 "$DIR"
   add_mount "$DIR"
 fi
 


### PR DESCRIPTION
attempting to fix this issue identified by josh:
![image](https://github.com/AztecProtocol/aztec-packages/assets/142251406/f67bf83c-6449-43b3-8cba-238c164982c6)

i don't get the perm issue via docker on os-x, so this may be windows specified (can't reproduce error locally...)

