### PR TITLE
chore: Add the ability to create deterministic proofs

### DIFF
--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/prover/prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/prover/prover.hpp
@@ -82,6 +82,18 @@ template <typename settings> class ProverBase {
         queue.put_ifft_data(result, work_item_number);
     }
 
+    fr random_fr_element()
+    {
+        // By default we will use zero knowledge, however
+        // when debugging, it is useful to be able to
+        // generate a deterministic proof.
+        if (use_zero_knowledge) {
+            return fr::random_element();
+        }
+        // Returns a random field element
+        return fr::zero();
+    }
+
     void reset();
 
     size_t circuit_size;
@@ -97,6 +109,7 @@ template <typename settings> class ProverBase {
 
   private:
     plonk::proof proof;
+    bool use_zero_knowledge;
 };
 extern template class ProverBase<standard_settings>;
 extern template class ProverBase<ultra_settings>;

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/permutation_widget.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/permutation_widget.hpp
@@ -36,7 +36,8 @@ class ProverPermutationWidget : public ProverRandomWidget {
 
     void compute_round_commitments(transcript::StandardTranscript& transcript,
                                    const size_t round_number,
-                                   work_queue& queue) override;
+                                   work_queue& queue,
+                                   std::function<barretenberg::fr()> randomness) override;
 
     barretenberg::fr compute_quotient_contribution(const barretenberg::fr& alpha_base,
                                                    const transcript::StandardTranscript& transcript) override;

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/permutation_widget_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/permutation_widget_impl.hpp
@@ -56,7 +56,10 @@ ProverPermutationWidget<program_width, idpolys, num_roots_cut_out_of_vanishing_p
  */
 template <size_t program_width, bool idpolys, const size_t num_roots_cut_out_of_vanishing_polynomial>
 void ProverPermutationWidget<program_width, idpolys, num_roots_cut_out_of_vanishing_polynomial>::
-    compute_round_commitments(transcript::StandardTranscript& transcript, const size_t round_number, work_queue& queue)
+    compute_round_commitments(transcript::StandardTranscript& transcript,
+                              const size_t round_number,
+                              work_queue& queue,
+                              std::function<fr()> randomness)
 {
     if (round_number != 3) {
         return;
@@ -310,7 +313,7 @@ void ProverPermutationWidget<program_width, idpolys, num_roots_cut_out_of_vanish
     const size_t z_randomness = 3;
     ASSERT(z_randomness < num_roots_cut_out_of_vanishing_polynomial);
     for (size_t k = 0; k < z_randomness; ++k) {
-        z_perm[(key->circuit_size - num_roots_cut_out_of_vanishing_polynomial) + 1 + k] = fr::random_element();
+        z_perm[(key->circuit_size - num_roots_cut_out_of_vanishing_polynomial) + 1 + k] = randomness();
     }
 
     z_perm.ifft(key->small_domain);

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/plookup_widget.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/plookup_widget.hpp
@@ -40,7 +40,8 @@ class ProverPlookupWidget : public ProverRandomWidget {
 
     inline void compute_round_commitments(transcript::StandardTranscript& transcript,
                                           const size_t round_number,
-                                          work_queue& queue) override;
+                                          work_queue& queue,
+                                          std::function<barretenberg::fr()> randomness) override;
 
     inline barretenberg::fr compute_quotient_contribution(const barretenberg::fr& alpha_base,
                                                           const transcript::StandardTranscript& transcript) override;

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/plookup_widget_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/plookup_widget_impl.hpp
@@ -342,7 +342,7 @@ void ProverPlookupWidget<num_roots_cut_out_of_vanishing_polynomial>::compute_gra
  */
 template <const size_t num_roots_cut_out_of_vanishing_polynomial>
 void ProverPlookupWidget<num_roots_cut_out_of_vanishing_polynomial>::compute_round_commitments(
-    transcript::StandardTranscript& transcript, const size_t round_number, work_queue& queue)
+    transcript::StandardTranscript& transcript, const size_t round_number, work_queue& queue, std::function<fr()>)
 {
     if (round_number == 2) {
         compute_sorted_list_polynomial(transcript);

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/random_widget.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/random_widget.hpp
@@ -5,7 +5,6 @@
 
 #include <functional>
 #include <map>
-#include <vector>
 namespace transcript {
 class Transcript;
 }

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/random_widget.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/random_widget.hpp
@@ -3,7 +3,9 @@
 #include "barretenberg/plonk/transcript/transcript.hpp"
 #include "barretenberg/plonk/work_queue/work_queue.hpp"
 
+#include <functional>
 #include <map>
+#include <vector>
 namespace transcript {
 class Transcript;
 }
@@ -43,7 +45,10 @@ class ProverRandomWidget {
 
     virtual ~ProverRandomWidget() {}
 
-    virtual void compute_round_commitments(transcript::StandardTranscript&, const size_t, work_queue&){};
+    virtual void compute_round_commitments(transcript::StandardTranscript&,
+                                           const size_t,
+                                           work_queue&,
+                                           std::function<barretenberg::fr()>){};
 
     virtual barretenberg::fr compute_quotient_contribution(const barretenberg::fr& alpha_base,
                                                            const transcript::StandardTranscript& transcript) = 0;


### PR DESCRIPTION
## Problem

Since the prove function is not deterministic, debugging proofs over multiple runs is not possible. The non-determinism arises due to the fact that we want to add zero knowledge to the proofs being created.

## Solution

This PR (in spirit) adds the ability to make the function which generates the randomness deterministic 

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
