### PR TITLE
fix: 'gte'&'lte' need follow ASCII character set order when load leaves

### DIFF
--- a/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
@@ -242,7 +242,7 @@ export class StandardIndexedTree extends TreeBase implements IndexedTree {
       this.db
         .createReadStream({
           gte: indexToKeyLeaf(this.getName(), startingIndex),
-          lte: indexToKeyLeaf(this.getName(), 2n ** BigInt(this.getDepth())),
+          lte: indexToKeyLeaf(this.getName(), BigInt((2n ** BigInt(this.getDepth())).toString().replace(/\d/g, '9'))),
         })
         .on('data', function (data) {
           const index = Number(data.key);


### PR DESCRIPTION

As desc in: https://github.com/AztecProtocol/aztec-packages/issues/3423

`gte`, `lte` are compared by characters (numbers) in the ASCII character set. So here is a potential bug that it would miss some `Leaf` when loadTree.  
For example:  When we load from levelDB a  tree called `NULLIFIER_TREE` of height `16` (i.e,  `2n ** BigInt(this.getDepth()) = 65536`),   the runtime code is as below:
```
this.db
        .createReadStream({
           gte: 'NULLIFIER_TREE:LEAF:0'
           lte: 'NULLIFIER_TREE:LEAF:65536'
         });
```
then, you could find that many leaves whose key starts with `'NULLIFIER_TREE:LEAF:7'`/`'NULLIFIER_TREE:LEAF:8'`/`'NULLIFIER_TREE:LEAF:9'` will be missed.





Please provide a paragraph or two giving a summary of the change, including relevant motivation and context.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [x] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [x] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
