### PR TITLE
chore: update path to acir artifacts

### DIFF
--- a/barretenberg/acir_tests/clone_test_vectors.sh
+++ b/barretenberg/acir_tests/clone_test_vectors.sh
@@ -10,10 +10,10 @@ if [ ! -d acir_tests ]; then
     git clone -b $BRANCH --filter=blob:none --no-checkout https://github.com/noir-lang/noir.git
     cd noir
     git sparse-checkout init --cone
-    git sparse-checkout set tooling/nargo_cli/tests/acir_artifacts
+    git sparse-checkout set test_programs/acir_artifacts
     git checkout
     cd ..
-    mv noir/tooling/nargo_cli/tests/acir_artifacts acir_tests
+    mv noir/test_programs/acir_artifacts acir_tests
     rm -rf noir
   fi
 fi

--- a/barretenberg/acir_tests/gen_inner_proof_inputs.sh
+++ b/barretenberg/acir_tests/gen_inner_proof_inputs.sh
@@ -5,7 +5,7 @@ set -eu
 
 BIN=${BIN:-../cpp/build/bin/bb}
 CRS_PATH=~/.bb-crs
-BRANCH=master
+BRANCH=tf/restructure-integration-tests
 VERBOSE=${VERBOSE:-}
 RECURSIVE=true
 PROOF_NAME="proof_a"

--- a/barretenberg/acir_tests/run_acir_tests.sh
+++ b/barretenberg/acir_tests/run_acir_tests.sh
@@ -13,7 +13,7 @@ trap handle_sigchild SIGCHLD
 BIN=${BIN:-../cpp/build/bin/bb}
 FLOW=${FLOW:-prove_and_verify}
 CRS_PATH=~/.bb-crs
-BRANCH=master
+BRANCH=tf/restructure-integration-tests
 VERBOSE=${VERBOSE:-}
 TEST_NAMES=("$@")
 # We get little performance benefit over 16 cores (in fact it can be worse).


### PR DESCRIPTION
This PR updates the path to the acir artifacts to match https://github.com/noir-lang/noir/pull/3485