### PR TITLE
feat: Aztec CI files in Noir

### DIFF
--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -50,10 +50,11 @@ jobs:
           repository: noir-lang/noir
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
       - name: Create PR for Aztec Branch
+        continue-on-error: true
         uses: repo-sync/pull-request@v2
         with:
           github_token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           pr_title: 'feat: aztec-packages'
-          pr_body: 'Change this to a description of the body of changes.'
+          pr_body: 'Development from Aztec.'
           destination_branch: 'master'
           source_branch: 'aztec'

--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -1,0 +1,59 @@
+# Mirror a special 'aztec' branch on noir any changes that have accumulated in aztec.
+# Might fail if we have pushed changes to noir that we don't expect - in which case we need an explicit pull PR.
+# See the last example of such a PR for instructions.
+name: Mirror to noir repo
+
+# Don't allow multiple of these running at once:
+concurrency:
+  group: ${{ github.workflow }}
+on:
+  push:
+    branches:
+      - ad/sync-noir
+    paths:
+      - 'noir/**'
+      - '!noir/.gitrepo'
+
+jobs:
+  mirror_repo:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+
+      # We push using git subrepo (https://github.com/ingydotnet/git-subrepo)
+      # with some logic to recover from squashed parent commits
+      # We push to subrepo, commit to master. The commit is needed
+      # to continue to replay. If we still hit issues such as this
+      # action failing due to upstream changes, a manual resolution
+      # PR with ./scripts/git_subrepo.sh pull will be needed.
+      - name: Push to branch
+        run: |
+          SUBREPO_PATH=noir
+          BRANCH=aztec
+          # identify ourselves, needed to commit
+          git config --global user.name AztecBot
+          git config --global user.email tech@aztecprotocol.com
+          if ./scripts/git_subrepo.sh push $SUBREPO_PATH --branch=$BRANCH; then
+            git commit --amend -m "$(git log -1 --pretty=%B) [skip ci]"
+            git push
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          repository: noir-lang/noir
+          token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+      - name: Create PR for Aztec Branch
+        uses: repo-sync/pull-request@v2
+        with:
+          github_token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+          pr_title: 'feat: aztec-packages'
+          pr_body: 'Change this to a description of the body of changes.'
+          destination_branch: 'master'
+          source_branch: 'aztec'

--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -9,7 +9,7 @@ concurrency:
 on:
   push:
     branches:
-      - ad/sync-noir
+      - master
     paths:
       - 'noir/**'
       - '!noir/.gitrepo'

--- a/noir/.gitrepo
+++ b/noir/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = git@github.com:noir-lang/noir
+	remote = https://github.com/noir-lang/noir
 	branch = master
 	commit = 90a63042d5b5eb2edf03378dff46ce75c9cb33ba
-	parent = 8f1cb832cd0adeff0da69da293bb45a3748583e7
-	method = merge
+	parent = bef260888e9f3799543d5a76f5ba40d9b9e4db89
+	method = pull
 	cmdver = 0.4.6

--- a/noir/deny.toml
+++ b/noir/deny.toml
@@ -8,6 +8,7 @@ unsound = "warn"
 yanked = "warn"
 notice = "warn"
 
+
 # This section is considered when running `cargo deny check bans`.
 # More documentation about the 'bans' section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html

--- a/noir/deny.toml
+++ b/noir/deny.toml
@@ -8,7 +8,6 @@ unsound = "warn"
 yanked = "warn"
 notice = "warn"
 
-
 # This section is considered when running `cargo deny check bans`.
 # More documentation about the 'bans' section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html

--- a/scripts/fix_subrepo_edge_case.sh
+++ b/scripts/fix_subrepo_edge_case.sh
@@ -22,4 +22,4 @@ git config --file="$SUBREPO_PATH/.gitrepo" subrepo.parent $new_parent
 # Commit this change
 git add "$SUBREPO_PATH/.gitrepo"
 # This commit should only go into squashed PRs
-git commit -m "git_subrepo.sh: Fix parent in .gitrepo file."
+git commit -m "git_subrepo.sh: Fix parent in .gitrepo file. [skip ci]"


### PR DESCRIPTION
This is a dual-list commit in both Noir and aztec repo. In this PR, Aztec gets the code to make a mirror, and the mirror action pushes to our `aztec` branch in Noir. The `aztec` branch features this as the first commit, to then be pushed one by one from master as Noir changes come in.