### PR TITLE
fix(ci): don't leave DRY_DEPLOY unset

### DIFF
--- a/build-system/scripts/setup_env
+++ b/build-system/scripts/setup_env
@@ -31,6 +31,8 @@ echo "PULL_REQUEST=$PULL_REQUEST"
 if [[ "$COMMIT_MESSAGE" == *"[ci dry-deploy]"* ]]; then
   COMMIT_TAG=v999.999.999
   DRY_DEPLOY=1
+else
+  DRY_DEPLOY=0
 fi
 
 if [ -n "${COMMIT_TAG:-}" ]; then


### PR DESCRIPTION
Seems last release failed at deploy-dockerhub stage [here](https://app.circleci.com/pipelines/github/AztecProtocol/aztec-packages/17177/workflows/440a5e67-ae97-470c-b66b-c002c0628572/jobs/753907)

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
