### PR TITLE
chore: remove temporary logging

### DIFF
--- a/yarn-project/aztec.js/src/contract/sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract/sent_tx.ts
@@ -1,4 +1,4 @@
-import { FieldsOf, MAX_NEW_NULLIFIERS_PER_TX } from '@aztec/circuits.js';
+import { FieldsOf } from '@aztec/circuits.js';
 import { retryUntil } from '@aztec/foundation/retry';
 import { ExtendedNote, GetUnencryptedLogsResponse, PXE, TxHash, TxReceipt, TxStatus } from '@aztec/types';
 
@@ -66,34 +66,7 @@ export class SentTx {
     }
     const receipt = await this.waitForReceipt(opts);
     if (receipt.status !== TxStatus.MINED) {
-      // ############## Temporary code start ##############
-      // A few logs placed here temporarily to help me (@benesjan) debug an issue with intermittent failure of
-      // 2 pixies test.
-      // https://github.com/AztecProtocol/aztec-packages/issues/3357
-      // For whatever reason (according to logs) the tx which appears here as dropped seems to be correctly included
-      // in a block and the block built and submitted on-chain. I will try to fetch the latest block here and see
-      // which txs it contains to check if the block source used here has the relevant block. If it doesn't then
-      // the test is probably misconfigured and an incorrect block source is used (pxe pointing to a different aztec
-      // node or smt like that) or there is some bigger issue with block sync somewhere.
-      const blockNum = await this.pxe.getBlockNumber();
-      const block = await this.pxe.getBlock(blockNum);
-      if (block) {
-        const txHashes = [];
-        for (let txIndex = 0; txIndex < block!.numberOfTxs; txIndex++) {
-          const txHash = block!.newNullifiers[MAX_NEW_NULLIFIERS_PER_TX * txIndex];
-          txHashes.push(txHash.toString());
-        }
-        throw new Error(
-          `Transaction ${await this.getTxHash()} was ${
-            receipt.status
-          }.\nTx hashes of txs included in the last synced block ${block?.number} are: ${txHashes}`,
-        );
-      } else {
-        throw new Error(`Transaction ${await this.getTxHash()} was ${receipt.status}. Block ${blockNum} not found.`);
-      }
-      // ############## Temporary code end ##############
-
-      // throw new Error(`Transaction ${await this.getTxHash()} was ${receipt.status}`);
+      throw new Error(`Transaction ${await this.getTxHash()} was ${receipt.status}`);
     }
     if (opts?.debug) {
       const txHash = await this.getTxHash();


### PR DESCRIPTION
The 2 pixies test have not failed since I fixed [this race condition](https://github.com/AztecProtocol/aztec-packages/commit/9557a66dce6104e794a7ab20172738954d4315ba) last week so I think we can be pretty confident that it was really the case of the failures. For this reason I am removing the temporary logging here.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
