### PR TITLE
chore: Add yellow paper build check to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -897,6 +897,17 @@ jobs:
               echo "Skipping doc deploy (not on master)."
             fi
 
+  check-yellow-paper:
+    machine:
+      image: ubuntu-2204:2023.07.2
+    resource_class: large
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Build yellow paper"
+          command: build yellow-paper
+
   e2e-join:
     docker:
       - image: cimg/base:2023.09
@@ -1057,6 +1068,8 @@ workflows:
 
       - mainnet-fork: *defaults
 
+      - check-yellow-paper: *defaults
+
       # Yarn Project
       - yarn-project-base:
           requires:
@@ -1175,6 +1188,7 @@ workflows:
             - guides-dapp-testing
             - guides-sample-dapp
             - guides-up-quick-start
+            - check-yellow-paper
           <<: *defaults
 
       # Benchmark jobs.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -897,7 +897,7 @@ jobs:
               echo "Skipping doc deploy (not on master)."
             fi
 
-  check-yellow-paper:
+  yellow-paper:
     machine:
       image: ubuntu-2204:2023.07.2
     resource_class: large
@@ -1068,7 +1068,7 @@ workflows:
 
       - mainnet-fork: *defaults
 
-      - check-yellow-paper: *defaults
+      - yellow-paper: *defaults
 
       # Yarn Project
       - yarn-project-base:
@@ -1188,7 +1188,7 @@ workflows:
             - guides-dapp-testing
             - guides-sample-dapp
             - guides-up-quick-start
-            - check-yellow-paper
+            - yellow-paper
           <<: *defaults
 
       # Benchmark jobs.

--- a/build_manifest.yml
+++ b/build_manifest.yml
@@ -170,3 +170,8 @@ docs:
     - ^.*.nr$
   dependencies:
     - yarn-project
+
+yellow-paper:
+  buildDir: yellow-paper
+  rebuildPatterns:
+    - ^yellow-paper/

--- a/yellow-paper/Dockerfile
+++ b/yellow-paper/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:18-alpine
+WORKDIR /usr/src
+COPY . .
+RUN yarn && yarn build --no-minify


### PR DESCRIPTION
Adds a step to the CI to build the yellow paper, in order to catch any build issues in our PRs.