### PR TITLE
chore: Remove UnivariateView

### DIFF
--- a/barretenberg/cpp/src/barretenberg/relations/ecc_op_queue_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_op_queue_relation.hpp
@@ -44,62 +44,68 @@ template <typename FF_> class EccOpQueueRelationImpl {
                                   const FF& scaling_factor)
     {
         using Accumulator = std::tuple_element_t<0, ContainerOverSubrelations>;
-        using View = typename Accumulator::View;
+        // using View = typename Accumulator::View;
 
-        auto w_1 = View(in.w_l);
-        auto w_2 = View(in.w_r);
-        auto w_3 = View(in.w_o);
-        auto w_4 = View(in.w_4);
-        auto op_wire_1 = View(in.ecc_op_wire_1);
-        auto op_wire_2 = View(in.ecc_op_wire_2);
-        auto op_wire_3 = View(in.ecc_op_wire_3);
-        auto op_wire_4 = View(in.ecc_op_wire_4);
-        auto lagrange_ecc_op = View(in.lagrange_ecc_op);
+        // auto w_1 = View(in.w_l);
+        // auto w_2 = View(in.w_r);
+        // auto w_3 = View(in.w_o);
+        // auto w_4 = View(in.w_4);
+        // auto op_wire_1 = View(in.ecc_op_wire_1);
+        // auto op_wire_2 = View(in.ecc_op_wire_2);
+        // auto op_wire_3 = View(in.ecc_op_wire_3);
+        // auto op_wire_4 = View(in.ecc_op_wire_4);
+        // auto lagrange_ecc_op = View(in.lagrange_ecc_op);
 
         // If lagrange_ecc_op is the indicator for ecc_op_gates, this is the indicator for the complement
-        auto complement_ecc_op = lagrange_ecc_op * FF(-1) + FF(1);
+        Accumulator complement_ecc_op(in.lagrange_ecc_op);
+        complement_ecc_op *= FF(-1);
+        complement_ecc_op += FF(1);
 
         // Contribution (1)
-        auto tmp = op_wire_1 - w_1;
-        tmp *= lagrange_ecc_op;
+        Accumulator tmp(in.ecc_op_wire_1);
+        tmp -= in.w_l;
+        tmp *= in.lagrange_ecc_op;
         tmp *= scaling_factor;
         std::get<0>(accumulators) += tmp;
 
         // Contribution (2)
-        tmp = op_wire_2 - w_2;
-        tmp *= lagrange_ecc_op;
+        tmp = Accumulator(in.ecc_op_wire_2);
+        tmp -= in.w_r;
+        tmp *= in.lagrange_ecc_op;
         tmp *= scaling_factor;
         std::get<1>(accumulators) += tmp;
 
         // Contribution (3)
-        tmp = op_wire_3 - w_3;
-        tmp *= lagrange_ecc_op;
+        tmp = Accumulator(in.ecc_op_wire_3);
+        tmp -= in.w_o;
+        tmp *= in.lagrange_ecc_op;
         tmp *= scaling_factor;
         std::get<2>(accumulators) += tmp;
 
         // Contribution (4)
-        tmp = op_wire_4 - w_4;
-        tmp *= lagrange_ecc_op;
+        tmp = Accumulator(in.ecc_op_wire_4);
+        tmp -= in.w_4;
+        tmp *= in.lagrange_ecc_op;
         tmp *= scaling_factor;
         std::get<3>(accumulators) += tmp;
 
         // Contribution (5)
-        tmp = op_wire_1 * complement_ecc_op;
+        tmp = Accumulator(in.ecc_op_wire_1) * complement_ecc_op;
         tmp *= scaling_factor;
         std::get<4>(accumulators) += tmp;
 
         // Contribution (6)
-        tmp = op_wire_2 * complement_ecc_op;
+        tmp = Accumulator(in.ecc_op_wire_2) * complement_ecc_op;
         tmp *= scaling_factor;
         std::get<5>(accumulators) += tmp;
 
         // Contribution (7)
-        tmp = op_wire_3 * complement_ecc_op;
+        tmp = Accumulator(in.ecc_op_wire_3) * complement_ecc_op;
         tmp *= scaling_factor;
         std::get<6>(accumulators) += tmp;
 
         // Contribution (8)
-        tmp = op_wire_4 * complement_ecc_op;
+        tmp = Accumulator(in.ecc_op_wire_4) * complement_ecc_op;
         tmp *= scaling_factor;
         std::get<7>(accumulators) += tmp;
     };

--- a/barretenberg/cpp/src/barretenberg/relations/elliptic_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/elliptic_relation.hpp
@@ -47,50 +47,50 @@ template <typename FF_> class EllipticRelationImpl {
         // remove endomorphism coefficient in ecc add gate(not used))
 
         using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-        using View = typename Accumulator::View;
-        auto x_1 = View(in.w_r);
-        auto y_1 = View(in.w_o);
+        // using View = typename Accumulator::View;
+        const Accumulator& x_1 = in.w_r;
+        const Accumulator& y_1 = in.w_o;
 
-        auto x_2 = View(in.w_l_shift);
-        auto y_2 = View(in.w_4_shift);
-        auto y_3 = View(in.w_o_shift);
-        auto x_3 = View(in.w_r_shift);
+        const Accumulator& x_2 = in.w_l_shift;
+        const Accumulator& y_2 = in.w_4_shift;
+        const Accumulator& y_3 = in.w_o_shift;
+        const Accumulator& x_3 = in.w_r_shift;
 
-        auto q_sign = View(in.q_l);
-        auto q_elliptic = View(in.q_elliptic);
-        auto q_is_double = View(in.q_m);
+        const Accumulator& q_sign = in.q_l;
+        const Accumulator& q_elliptic = in.q_elliptic;
+        const Accumulator& q_is_double = in.q_m;
 
         // Contribution (1) point addition, x-coordinate check
         // q_elliptic * (x3 + x2 + x1)(x2 - x1)(x2 - x1) - y2^2 - y1^2 + 2(y2y1)*q_sign = 0
-        auto x_diff = (x_2 - x_1);
-        auto y2_sqr = (y_2 * y_2);
-        auto y1_sqr = (y_1 * y_1);
-        auto y1y2 = y_1 * y_2 * q_sign;
-        auto x_add_identity = (x_3 + x_2 + x_1) * x_diff * x_diff - y2_sqr - y1_sqr + y1y2 + y1y2;
+        Accumulator x_diff = (x_2 - x_1);
+        Accumulator y2_sqr = (y_2 * y_2);
+        Accumulator y1_sqr = (y_1 * y_1);
+        Accumulator y1y2 = y_1 * y_2 * q_sign;
+        Accumulator x_add_identity = (x_3 + x_2 + x_1) * x_diff * x_diff - y2_sqr - y1_sqr + y1y2 + y1y2;
         std::get<0>(accumulators) += x_add_identity * scaling_factor * q_elliptic * (-q_is_double + 1);
 
         // Contribution (2) point addition, x-coordinate check
         // q_elliptic * (q_sign * y1 + y3)(x2 - x1) + (x3 - x1)(y2 - q_sign * y1) = 0
-        auto y1_plus_y3 = y_1 + y_3;
-        auto y_diff = y_2 * q_sign - y_1;
-        auto y_add_identity = y1_plus_y3 * x_diff + (x_3 - x_1) * y_diff;
+        Accumulator y1_plus_y3 = y_1 + y_3;
+        Accumulator y_diff = y_2 * q_sign - y_1;
+        Accumulator y_add_identity = y1_plus_y3 * x_diff + (x_3 - x_1) * y_diff;
         std::get<1>(accumulators) += y_add_identity * scaling_factor * q_elliptic * (-q_is_double + 1);
 
         // Contribution (3) point doubling, x-coordinate check
         // (x3 + x1 + x1) (4y1*y1) - 9 * x1 * x1 * x1 * x1 = 0
         // N.B. we're using the equivalence x1*x1*x1 === y1*y1 - curve_b to reduce degree by 1
         const auto curve_b = get_curve_b();
-        auto x_pow_4 = (y1_sqr - curve_b) * x_1;
-        auto y1_sqr_mul_4 = y1_sqr + y1_sqr;
+        Accumulator x_pow_4 = (y1_sqr - curve_b) * x_1;
+        Accumulator y1_sqr_mul_4 = y1_sqr + y1_sqr;
         y1_sqr_mul_4 += y1_sqr_mul_4;
-        auto x1_pow_4_mul_9 = x_pow_4 * 9;
-        auto x_double_identity = (x_3 + x_1 + x_1) * y1_sqr_mul_4 - x1_pow_4_mul_9;
+        Accumulator x1_pow_4_mul_9 = x_pow_4 * 9;
+        Accumulator x_double_identity = (x_3 + x_1 + x_1) * y1_sqr_mul_4 - x1_pow_4_mul_9;
         std::get<0>(accumulators) += x_double_identity * scaling_factor * q_elliptic * q_is_double;
 
         // Contribution (4) point doubling, y-coordinate check
         // (y1 + y1) (2y1) - (3 * x1 * x1)(x1 - x3) = 0
-        auto x1_sqr_mul_3 = (x_1 + x_1 + x_1) * x_1;
-        auto y_double_identity = x1_sqr_mul_3 * (x_1 - x_3) - (y_1 + y_1) * (y_1 + y_3);
+        Accumulator x1_sqr_mul_3 = (x_1 + x_1 + x_1) * x_1;
+        Accumulator y_double_identity = x1_sqr_mul_3 * (x_1 - x_3) - (y_1 + y_1) * (y_1 + y_3);
         std::get<1>(accumulators) += y_double_identity * scaling_factor * q_elliptic * q_is_double;
     };
 };

--- a/barretenberg/cpp/src/barretenberg/relations/gen_perm_sort_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/gen_perm_sort_relation.hpp
@@ -36,30 +36,34 @@ template <typename FF_> class GenPermSortRelationImpl {
                                   const FF& scaling_factor)
     {
         using Accumulator = std::tuple_element_t<0, ContainerOverSubrelations>;
-        using View = typename Accumulator::View;
-        auto w_1 = View(in.w_l);
-        auto w_2 = View(in.w_r);
-        auto w_3 = View(in.w_o);
-        auto w_4 = View(in.w_4);
-        auto w_1_shift = View(in.w_l_shift);
-        auto q_sort = View(in.q_sort);
+        // using View = typename Accumulator::View;
+        // auto w_1 = View(in.w_l);
+        // auto w_2 = View(in.w_r);
+        // auto w_3 = View(in.w_o);
+        // auto w_4 = View(in.w_4);
+        // auto w_1_shift = View(in.w_l_shift);
+        // auto q_sort = View(in.q_sort);
+        // const Accumulator& w_1 = in.w_l;
+        // const Accumulator& w_2 = in.w_r;
+        // const Accumulator& w_3 = in.w_o;
+        // const Accumulator& w_4 = in.w_4;
 
         static const FF minus_one = FF(-1);
         static const FF minus_two = FF(-2);
         static const FF minus_three = FF(-3);
 
         // Compute wire differences
-        auto delta_1 = w_2 - w_1;
-        auto delta_2 = w_3 - w_2;
-        auto delta_3 = w_4 - w_3;
-        auto delta_4 = w_1_shift - w_4;
+        Accumulator delta_1 = in.w_r - in.w_l;
+        Accumulator delta_2 = in.w_o - in.w_r;
+        Accumulator delta_3 = in.w_4 - in.w_o;
+        Accumulator delta_4 = in.w_l_shift - in.w_4;
 
         // Contribution (1)
-        auto tmp_1 = delta_1;
+        Accumulator tmp_1 = delta_1;
         tmp_1 *= (delta_1 + minus_one);
         tmp_1 *= (delta_1 + minus_two);
         tmp_1 *= (delta_1 + minus_three);
-        tmp_1 *= q_sort;
+        tmp_1 *= in.q_sort;
         tmp_1 *= scaling_factor;
         std::get<0>(accumulators) += tmp_1;
 
@@ -68,7 +72,7 @@ template <typename FF_> class GenPermSortRelationImpl {
         tmp_2 *= (delta_2 + minus_one);
         tmp_2 *= (delta_2 + minus_two);
         tmp_2 *= (delta_2 + minus_three);
-        tmp_2 *= q_sort;
+        tmp_2 *= in.q_sort;
         tmp_2 *= scaling_factor;
         std::get<1>(accumulators) += tmp_2;
 
@@ -77,7 +81,7 @@ template <typename FF_> class GenPermSortRelationImpl {
         tmp_3 *= (delta_3 + minus_one);
         tmp_3 *= (delta_3 + minus_two);
         tmp_3 *= (delta_3 + minus_three);
-        tmp_3 *= q_sort;
+        tmp_3 *= in.q_sort;
         tmp_3 *= scaling_factor;
         std::get<2>(accumulators) += tmp_3;
 
@@ -86,7 +90,7 @@ template <typename FF_> class GenPermSortRelationImpl {
         tmp_4 *= (delta_4 + minus_one);
         tmp_4 *= (delta_4 + minus_two);
         tmp_4 *= (delta_4 + minus_three);
-        tmp_4 *= q_sort;
+        tmp_4 *= in.q_sort;
         tmp_4 *= scaling_factor;
         std::get<3>(accumulators) += tmp_4;
     };

--- a/barretenberg/cpp/src/barretenberg/relations/lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/lookup_relation.hpp
@@ -73,29 +73,29 @@ template <typename FF_> class LookupRelationImpl {
         const auto one_plus_beta = beta + FF(1);
         const auto gamma_by_one_plus_beta = gamma * one_plus_beta;
 
-        auto w_1 = View(in.w_l);
-        auto w_2 = View(in.w_r);
-        auto w_3 = View(in.w_o);
+        const Accumulator& w_1 = in.w_l;
+        const Accumulator& w_2 = in.w_r;
+        const Accumulator& w_3 = in.w_o;
 
-        auto w_1_shift = View(in.w_l_shift);
-        auto w_2_shift = View(in.w_r_shift);
-        auto w_3_shift = View(in.w_o_shift);
+        const Accumulator& w_1_shift = in.w_l_shift;
+        const Accumulator& w_2_shift = in.w_r_shift;
+        const Accumulator& w_3_shift = in.w_o_shift;
 
-        auto table_1 = View(in.table_1);
-        auto table_2 = View(in.table_2);
-        auto table_3 = View(in.table_3);
-        auto table_4 = View(in.table_4);
+        const Accumulator& table_1 = in.table_1;
+        const Accumulator& table_2 = in.table_2;
+        const Accumulator& table_3 = in.table_3;
+        const Accumulator& table_4 = in.table_4;
 
-        auto table_1_shift = View(in.table_1_shift);
-        auto table_2_shift = View(in.table_2_shift);
-        auto table_3_shift = View(in.table_3_shift);
-        auto table_4_shift = View(in.table_4_shift);
+        const Accumulator& table_1_shift = in.table_1_shift;
+        const Accumulator& table_2_shift = in.table_2_shift;
+        const Accumulator& table_3_shift = in.table_3_shift;
+        const Accumulator& table_4_shift = in.table_4_shift;
 
-        auto table_index = View(in.q_o);
-        auto column_1_step_size = View(in.q_r);
-        auto column_2_step_size = View(in.q_m);
-        auto column_3_step_size = View(in.q_c);
-        auto q_lookup = View(in.q_lookup);
+        const Accumulator& table_index = in.q_o;
+        const Accumulator& column_1_step_size = in.q_r;
+        const Accumulator& column_2_step_size = in.q_m;
+        const Accumulator& column_3_step_size = in.q_c;
+        const Accumulator& q_lookup = in.q_lookup;
 
         // (w_1 + q_2*w_1_shift) + η(w_2 + q_m*w_2_shift) + η²(w_3 + q_c*w_3_shift) + η³q_index.
         // deg 2 or 4
@@ -141,8 +141,8 @@ template <typename FF_> class LookupRelationImpl {
         const auto gamma_by_one_plus_beta = gamma * one_plus_beta; // deg 0 or 2
 
         // Contribution (1)
-        auto s_accum = View(in.sorted_accum);
-        auto s_accum_shift = View(in.sorted_accum_shift);
+        const Accumulator& s_accum = in.sorted_accum;
+        const Accumulator& s_accum_shift = in.sorted_accum_shift;
 
         auto tmp = (s_accum + s_accum_shift * beta + gamma_by_one_plus_beta); // 1 or 2
         return tmp;
@@ -180,29 +180,32 @@ template <typename FF_> class LookupRelationImpl {
 
             const auto& grand_product_delta = ParameterView(params.lookup_grand_product_delta);
 
-            auto z_lookup = View(in.z_lookup);
-            auto z_lookup_shift = View(in.z_lookup_shift);
+            const Accumulator& z_lookup = in.z_lookup;
+            const Accumulator& z_lookup_shift = in.z_lookup_shift;
 
-            auto lagrange_first = View(in.lagrange_first);
-            auto lagrange_last = View(in.lagrange_last);
+            const Accumulator& lagrange_first = in.lagrange_first;
+            const Accumulator& lagrange_last = in.lagrange_last;
 
             const auto lhs = compute_grand_product_numerator<Accumulator>(in, params);   // deg 4 or 10
             const auto rhs = compute_grand_product_denominator<Accumulator>(in, params); // deg 1 or 2
 
             // (deg 5 or 11) - (deg 3 or 5)
-            const auto tmp =
+            const Accumulator tmp =
                 lhs * (z_lookup + lagrange_first) - rhs * (z_lookup_shift + lagrange_last * grand_product_delta);
             std::get<0>(accumulators) += tmp * scaling_factor;
         };
 
         {
             using Accumulator = std::tuple_element_t<1, ContainerOverSubrelations>;
-            using View = typename Accumulator::View;
-            auto z_lookup_shift = View(in.z_lookup_shift);
-            auto lagrange_last = View(in.lagrange_last);
+            // using View = typename Accumulator::View;
+            // auto z_lookup_shift = View(in.z_lookup_shift);
+            // auto lagrange_last = View(in.lagrange_last);
 
             // Contribution (2)
-            std::get<1>(accumulators) += (lagrange_last * z_lookup_shift) * scaling_factor;
+            Accumulator tmp(in.lagrange_last);
+            tmp *= in.z_lookup_shift;
+            tmp *= scaling_factor;
+            std::get<1>(accumulators) += tmp;
         };
     };
 };

--- a/barretenberg/cpp/src/barretenberg/relations/permutation_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/permutation_relation.hpp
@@ -26,14 +26,14 @@ template <typename FF_> class UltraPermutationRelationImpl {
         using View = typename Accumulator::View;
         using ParameterView = GetParameterView<Parameters, View>;
 
-        auto w_1 = View(in.w_l);
-        auto w_2 = View(in.w_r);
-        auto w_3 = View(in.w_o);
-        auto w_4 = View(in.w_4);
-        auto id_1 = View(in.id_1);
-        auto id_2 = View(in.id_2);
-        auto id_3 = View(in.id_3);
-        auto id_4 = View(in.id_4);
+        const Accumulator& w_1 = in.w_l;
+        const Accumulator& w_2 = in.w_r;
+        const Accumulator& w_3 = in.w_o;
+        const Accumulator& w_4 = in.w_4;
+        const Accumulator& id_1 = in.id_1;
+        const Accumulator& id_2 = in.id_2;
+        const Accumulator& id_3 = in.id_3;
+        const Accumulator& id_4 = in.id_4;
 
         const auto& beta = ParameterView(params.beta);
         const auto& gamma = ParameterView(params.gamma);
@@ -49,15 +49,15 @@ template <typename FF_> class UltraPermutationRelationImpl {
         using View = typename Accumulator::View;
         using ParameterView = GetParameterView<Parameters, View>;
 
-        auto w_1 = View(in.w_l);
-        auto w_2 = View(in.w_r);
-        auto w_3 = View(in.w_o);
-        auto w_4 = View(in.w_4);
+        const Accumulator& w_1 = in.w_l;
+        const Accumulator& w_2 = in.w_r;
+        const Accumulator& w_3 = in.w_o;
+        const Accumulator& w_4 = in.w_4;
 
-        auto sigma_1 = View(in.sigma_1);
-        auto sigma_2 = View(in.sigma_2);
-        auto sigma_3 = View(in.sigma_3);
-        auto sigma_4 = View(in.sigma_4);
+        const Accumulator& sigma_1 = in.sigma_1;
+        const Accumulator& sigma_2 = in.sigma_2;
+        const Accumulator& sigma_3 = in.sigma_3;
+        const Accumulator& sigma_4 = in.sigma_4;
 
         const auto& beta = ParameterView(params.beta);
         const auto& gamma = ParameterView(params.gamma);
@@ -90,10 +90,10 @@ template <typename FF_> class UltraPermutationRelationImpl {
             using View = typename Accumulator::View;
             using ParameterView = GetParameterView<Parameters, View>;
             const auto public_input_delta = ParameterView(params.public_input_delta);
-            const auto z_perm = View(in.z_perm);
-            const auto z_perm_shift = View(in.z_perm_shift);
-            const auto lagrange_first = View(in.lagrange_first);
-            const auto lagrange_last = View(in.lagrange_last);
+            const Accumulator& z_perm = in.z_perm;
+            const Accumulator& z_perm_shift = in.z_perm_shift;
+            const Accumulator& lagrange_first = in.lagrange_first;
+            const Accumulator& lagrange_last = in.lagrange_last;
 
             // witness degree: deg 5 - deg 5 = deg 5
             // total degree: deg 9 - deg 10 = deg 10
@@ -107,11 +107,13 @@ template <typename FF_> class UltraPermutationRelationImpl {
         // Contribution (2)
         [&]() {
             using Accumulator = std::tuple_element_t<1, ContainerOverSubrelations>;
-            using View = typename Accumulator::View;
-            auto z_perm_shift = View(in.z_perm_shift);
-            auto lagrange_last = View(in.lagrange_last);
-
-            std::get<1>(accumulators) += (lagrange_last * z_perm_shift) * scaling_factor;
+            // using View = typename Accumulator::View;
+            // auto z_perm_shift = View(in.z_perm_shift);
+            // auto lagrange_last = View(in.lagrange_last);
+            Accumulator tmp(in.z_perm_shift);
+            tmp *= in.lagrange_last;
+            tmp *= scaling_factor;
+            std::get<1>(accumulators) += tmp;
         }();
     };
 };

--- a/barretenberg/cpp/src/barretenberg/relations/ultra_arithmetic_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ultra_arithmetic_relation.hpp
@@ -71,42 +71,60 @@ template <typename FF_> class UltraArithmeticRelationImpl {
     {
         {
             using Accumulator = std::tuple_element_t<0, ContainerOverSubrelations>;
-            using View = typename Accumulator::View;
-            auto w_l = View(in.w_l);
-            auto w_r = View(in.w_r);
-            auto w_o = View(in.w_o);
-            auto w_4 = View(in.w_4);
-            auto w_4_shift = View(in.w_4_shift);
-            auto q_m = View(in.q_m);
-            auto q_l = View(in.q_l);
-            auto q_r = View(in.q_r);
-            auto q_o = View(in.q_o);
-            auto q_4 = View(in.q_4);
-            auto q_c = View(in.q_c);
-            auto q_arith = View(in.q_arith);
+            // using View = typename Accumulator::View;
+            // auto w_l = View(in.w_l);
+            // auto w_r = View(in.w_r);
+            // auto w_o = View(in.w_o);
+            // auto w_4 = View(in.w_4);
+            // auto w_4_shift = View(in.w_4_shift);
+            // auto q_m = View(in.q_m);
+            // auto q_l = View(in.q_l);
+            // auto q_r = View(in.q_r);
+            // auto q_o = View(in.q_o);
+            // auto q_4 = View(in.q_4);
+            // auto q_c = View(in.q_c);
+            // auto q_arith = View(in.q_arith);
 
             static const FF neg_half = FF(-2).invert();
 
-            auto tmp = (q_arith - 3) * (q_m * w_r * w_l) * neg_half;
-            tmp += (q_l * w_l) + (q_r * w_r) + (q_o * w_o) + (q_4 * w_4) + q_c;
-            tmp += (q_arith - 1) * w_4_shift;
-            tmp *= q_arith;
+            Accumulator tmp(in.q_arith);
+            tmp -= 3;
+            tmp *= in.q_m;
+            tmp *= in.w_r;
+            tmp *= in.w_l;
+            tmp *= neg_half;
+            tmp += Accumulator(in.q_l) * in.w_l;
+            tmp += Accumulator(in.q_r) * in.w_r;
+            tmp += Accumulator(in.q_o) * in.w_o;
+            tmp += Accumulator(in.q_4) * in.w_4;
+            tmp += in.q_c;
+            tmp += Accumulator(in.w_4_shift) * (in.q_arith - 1);
+            tmp *= in.q_arith;
             tmp *= scaling_factor;
+            // auto tmp = (q_arith - 3) * (q_m * w_r * w_l) * neg_half;
+            // tmp += (q_l * w_l) + (q_r * w_r) + (q_o * w_o) + (q_4 * w_4) + q_c;
+            // tmp += (q_arith - 1) * w_4_shift;
+            // tmp *= q_arith;
+            // tmp *= scaling_factor;
             std::get<0>(evals) += tmp;
         }
         {
             using Accumulator = std::tuple_element_t<1, ContainerOverSubrelations>;
-            using View = typename Accumulator::View;
-            auto w_l = View(in.w_l);
-            auto w_4 = View(in.w_4);
-            auto w_l_shift = View(in.w_l_shift);
-            auto q_m = View(in.q_m);
-            auto q_arith = View(in.q_arith);
+            // using View = typename Accumulator::View;
+            // auto w_l = View(in.w_l);
+            // auto w_4 = View(in.w_4);
+            // auto w_l_shift = View(in.w_l_shift);
+            // auto q_m = View(in.q_m);
+            // auto q_arith = View(in.q_arith);
 
-            auto tmp = w_l + w_4 - w_l_shift + q_m;
-            tmp *= (q_arith - 2);
-            tmp *= (q_arith - 1);
-            tmp *= q_arith;
+            Accumulator tmp(in.w_l);
+            tmp += in.w_4;
+            tmp -= in.w_l_shift;
+            tmp += in.q_m;
+            // auto tmp = w_l + w_4 - w_l_shift + q_m;
+            tmp *= (in.q_arith - 2);
+            tmp *= (in.q_arith - 1);
+            tmp *= in.q_arith;
             tmp *= scaling_factor;
             std::get<1>(evals) += tmp;
         };


### PR DESCRIPTION
NOT READY FOR REVIEW/MERGE . PR is to check benchmarks to see if this PR speeds up sumcheck.

### The problem statement

The `UnivariateView` class is a wrapper around a `Univariate` type, that provides a `std::span` member variable that points into another `Univariate` object's `evaluations` member variable.

The purpose of `UnivariateView` is to provide access to a `Univariate` object with a larger-than-required `degree_end` parameter.

For example, consider a relation of degree `5`, that is accessing an `AllEntities` object whose `Univariate` members are all degree `6` (i.e. `degree_end = 6`).

When performing degree-5 relation arithmetic, we only want to work over the first 5 elements of each `Univariate` object's `evaluations` member variable. `UnivariateView` enables this via a sort of primitive pseduo-type-conversion. Instead of performing operations over a degree-6 `Univariate`, we perform operations over a degree-5 `UnivariateView` whose `std::span` member points to a degree-6 `Univariate`.

While this is *functional*, it feels like an anti-pattern. In our relation code, we represent `UnivariateView` via a vaguely defined `View` typedef. It is very unclear that `View` wraps a `std::span`. This leads to scenarios where we have defined *references* to `View` objects constructed from `Univariate` objects.

e.g. `auto& foo = View(in.q_sort);`

This is *very* dangerous as we are creating a reference to an object whose lifetime is undefined. Honestly it's surprising this has not been creating segfaults and crashes up to this point!

### Attempt at a solution

The fundamental issue is that we want to be able to evaluate degree-`x` operations on degree-`y` `Univariate` objects, where `x < y`.

This PR proposed solution is to upgrade the `Univariate` constructor and operator methods to accept, as input parameters, higher-degree `Univariate` types.

This enables a degree-`x` `Univariate` object to be defined, that can directly perform operations with degree-`y` `Univariate` operands, where `x < y`, without a performance penalty.

This enables us to remove the need for `UnivariateView` entirely.

N.B. this PR does not remove `UnivariateView` from the codebase to prevent merge-hell with outstanding branches that use the `UnivariateView` abstraction. Goal is for the PR to remove the need for `UnivariateView`, then we can fully delete in a future PR.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
