### PR TITLE
feat: use tree snapshots in aztec-node/pxe/oracles

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -27,6 +27,7 @@ import {
   ContractDataSource,
   ExtendedContractData,
   GetUnencryptedLogsResponse,
+  INITIAL_L2_BLOCK_NUM,
   L1ToL2MessageAndIndex,
   L1ToL2MessageSource,
   L2Block,
@@ -301,42 +302,59 @@ export class AztecNodeService implements AztecNode {
 
   /**
    * Find the index of the given leaf in the given tree.
+   * @param blockNumber - The block number at which to get the data
    * @param treeId - The tree to search in.
    * @param leafValue - The value to search for
    * @returns The index of the given leaf in the given tree or undefined if not found.
    */
-  public async findLeafIndex(treeId: MerkleTreeId, leafValue: Fr): Promise<bigint | undefined> {
+  public async findLeafIndex(
+    blockNumber: number | 'latest',
+    treeId: MerkleTreeId,
+    leafValue: Fr,
+  ): Promise<bigint | undefined> {
     const committedDb = await this.#getWorldState();
     return committedDb.findLeafIndex(treeId, leafValue.toBuffer());
   }
 
   /**
    * Returns a sibling path for the given index in the contract tree.
+   * @param blockNumber - The block number at which to get the data.
    * @param leafIndex - The index of the leaf for which the sibling path is required.
    * @returns The sibling path for the leaf index.
    */
-  public async getContractSiblingPath(leafIndex: bigint): Promise<SiblingPath<typeof CONTRACT_TREE_HEIGHT>> {
-    const committedDb = await this.#getWorldState();
+  public async getContractSiblingPath(
+    blockNumber: number | 'latest',
+    leafIndex: bigint,
+  ): Promise<SiblingPath<typeof CONTRACT_TREE_HEIGHT>> {
+    const committedDb = await this.#getWorldState(blockNumber);
     return committedDb.getSiblingPath(MerkleTreeId.CONTRACT_TREE, leafIndex);
   }
 
   /**
    * Returns a sibling path for the given index in the nullifier tree.
+   * @param blockNumber - The block number at which to get the data.
    * @param leafIndex - The index of the leaf for which the sibling path is required.
    * @returns The sibling path for the leaf index.
    */
-  public async getNullifierTreeSiblingPath(leafIndex: bigint): Promise<SiblingPath<typeof NULLIFIER_TREE_HEIGHT>> {
-    const committedDb = await this.#getWorldState();
+  public async getNullifierTreeSiblingPath(
+    blockNumber: number | 'latest',
+    leafIndex: bigint,
+  ): Promise<SiblingPath<typeof NULLIFIER_TREE_HEIGHT>> {
+    const committedDb = await this.#getWorldState(blockNumber);
     return committedDb.getSiblingPath(MerkleTreeId.NULLIFIER_TREE, leafIndex);
   }
 
   /**
    * Returns a sibling path for the given index in the data tree.
+   * @param blockNumber - The block number at which to get the data.
    * @param leafIndex - The index of the leaf for which the sibling path is required.
    * @returns The sibling path for the leaf index.
    */
-  public async getNoteHashSiblingPath(leafIndex: bigint): Promise<SiblingPath<typeof NOTE_HASH_TREE_HEIGHT>> {
-    const committedDb = await this.#getWorldState();
+  public async getNoteHashSiblingPath(
+    blockNumber: number | 'latest',
+    leafIndex: bigint,
+  ): Promise<SiblingPath<typeof NOTE_HASH_TREE_HEIGHT>> {
+    const committedDb = await this.#getWorldState(blockNumber);
     return committedDb.getSiblingPath(MerkleTreeId.NOTE_HASH_TREE, leafIndex);
   }
 
@@ -348,38 +366,50 @@ export class AztecNodeService implements AztecNode {
    */
   public async getL1ToL2MessageAndIndex(messageKey: Fr): Promise<L1ToL2MessageAndIndex> {
     // todo: #697 - make this one lookup.
-    const index = (await this.findLeafIndex(MerkleTreeId.L1_TO_L2_MESSAGES_TREE, messageKey))!;
+    const index = (await this.findLeafIndex('latest', MerkleTreeId.L1_TO_L2_MESSAGES_TREE, messageKey))!;
     const message = await this.l1ToL2MessageSource.getConfirmedL1ToL2Message(messageKey);
     return Promise.resolve(new L1ToL2MessageAndIndex(index, message));
   }
 
   /**
    * Returns a sibling path for a leaf in the committed l1 to l2 data tree.
+   * @param blockNumber - The block number at which to get the data.
    * @param leafIndex - Index of the leaf in the tree.
    * @returns The sibling path.
    */
-  public async getL1ToL2MessageSiblingPath(leafIndex: bigint): Promise<SiblingPath<typeof L1_TO_L2_MSG_TREE_HEIGHT>> {
-    const committedDb = await this.#getWorldState();
+  public async getL1ToL2MessageSiblingPath(
+    blockNumber: number | 'latest',
+    leafIndex: bigint,
+  ): Promise<SiblingPath<typeof L1_TO_L2_MSG_TREE_HEIGHT>> {
+    const committedDb = await this.#getWorldState(blockNumber);
     return committedDb.getSiblingPath(MerkleTreeId.L1_TO_L2_MESSAGES_TREE, leafIndex);
   }
 
   /**
    * Returns a sibling path for a leaf in the committed blocks tree.
+   * @param blockNumber - The block number at which to get the data.
    * @param leafIndex - Index of the leaf in the tree.
    * @returns The sibling path.
    */
-  public async getBlocksTreeSiblingPath(leafIndex: bigint): Promise<SiblingPath<typeof BLOCKS_TREE_HEIGHT>> {
-    const committedDb = await this.#getWorldState();
+  public async getBlocksTreeSiblingPath(
+    blockNumber: number | 'latest',
+    leafIndex: bigint,
+  ): Promise<SiblingPath<typeof BLOCKS_TREE_HEIGHT>> {
+    const committedDb = await this.#getWorldState(blockNumber);
     return committedDb.getSiblingPath(MerkleTreeId.BLOCKS_TREE, leafIndex);
   }
 
   /**
    * Returns a sibling path for a leaf in the committed public data tree.
+   * @param blockNumber - The block number at which to get the data.
    * @param leafIndex - Index of the leaf in the tree.
    * @returns The sibling path.
    */
-  public async getPublicDataTreeSiblingPath(leafIndex: bigint): Promise<SiblingPath<typeof PUBLIC_DATA_TREE_HEIGHT>> {
-    const committedDb = await this.#getWorldState();
+  public async getPublicDataTreeSiblingPath(
+    blockNumber: number | 'latest',
+    leafIndex: bigint,
+  ): Promise<SiblingPath<typeof PUBLIC_DATA_TREE_HEIGHT>> {
+    const committedDb = await this.#getWorldState(blockNumber);
     return committedDb.getSiblingPath(MerkleTreeId.PUBLIC_DATA_TREE, leafIndex);
   }
 
@@ -390,17 +420,17 @@ export class AztecNodeService implements AztecNode {
    * @returns The nullifier membership witness (if found).
    */
   public async getNullifierMembershipWitness(
-    blockNumber: number,
+    blockNumber: number | 'latest',
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined> {
-    const committedDb = await this.#getWorldState();
-    const index = await committedDb.findLeafIndex(MerkleTreeId.NULLIFIER_TREE, nullifier.toBuffer());
+    const db = await this.#getWorldState(blockNumber);
+    const index = await db.findLeafIndex(MerkleTreeId.NULLIFIER_TREE, nullifier.toBuffer());
     if (!index) {
       return undefined;
     }
 
-    const leafDataPromise = committedDb.getLeafData(MerkleTreeId.NULLIFIER_TREE, Number(index));
-    const siblingPathPromise = committedDb.getSiblingPath<typeof NULLIFIER_TREE_HEIGHT>(
+    const leafDataPromise = db.getLeafData(MerkleTreeId.NULLIFIER_TREE, Number(index));
+    const siblingPathPromise = db.getSiblingPath<typeof NULLIFIER_TREE_HEIGHT>(
       MerkleTreeId.NULLIFIER_TREE,
       BigInt(index),
     );
@@ -429,10 +459,10 @@ export class AztecNodeService implements AztecNode {
    * TODO: This is a confusing behavior and we should eventually address that.
    */
   public async getLowNullifierMembershipWitness(
-    blockNumber: number,
+    blockNumber: number | 'latest',
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined> {
-    const committedDb = await this.#getWorldState();
+    const committedDb = await this.#getWorldState(blockNumber);
     const { index, alreadyPresent } = await committedDb.getPreviousValueIndex(
       MerkleTreeId.NULLIFIER_TREE,
       nullifier.toBigInt(),
@@ -555,24 +585,38 @@ export class AztecNodeService implements AztecNode {
 
   /**
    * Returns an instance of MerkleTreeOperations having first ensured the world state is fully synched
+   * @param blockNumber - The block number at which to get the data.
    * @returns An instance of a committed MerkleTreeOperations
    */
-  async #getWorldState() {
+  async #getWorldState(blockNumber: number | 'latest' = 'latest') {
+    if (typeof blockNumber === 'number' && blockNumber < INITIAL_L2_BLOCK_NUM) {
+      throw new Error('Invalid block number to get world state for: ' + blockNumber);
+    }
+
+    let blockSyncedTo: number = 0;
     try {
       // Attempt to sync the world state if necessary
-      await this.#syncWorldState();
+      blockSyncedTo = await this.#syncWorldState();
     } catch (err) {
       this.log.error(`Error getting world state: ${err}`);
     }
-    return this.worldStateSynchronizer.getCommitted();
+
+    // using a snapshot could be less efficient than using the committed db
+    if (blockNumber === 'latest' || blockNumber === blockSyncedTo) {
+      return this.worldStateSynchronizer.getCommitted();
+    } else if (blockNumber < blockSyncedTo) {
+      return this.worldStateSynchronizer.getSnapshot(blockNumber);
+    } else {
+      throw new Error(`Block ${blockNumber} not yet synced`);
+    }
   }
 
   /**
    * Ensure we fully sync the world state
    * @returns A promise that fulfils once the world state is synced
    */
-  async #syncWorldState() {
+  async #syncWorldState(): Promise<number> {
     const blockSourceHeight = await this.blockSource.getBlockNumber();
-    await this.worldStateSynchronizer.syncImmediate(blockSourceHeight);
+    return this.worldStateSynchronizer.syncImmediate(blockSourceHeight);
   }
 }

--- a/yarn-project/pxe/src/contract_tree/index.ts
+++ b/yarn-project/pxe/src/contract_tree/index.ts
@@ -146,12 +146,14 @@ export class ContractTree {
    * If the witness hasn't been previously computed, this function will request the contract node
    * to find the contract's index and path in order to create the membership witness.
    *
+   * @param blockNumber - The block number at which to get the data.
+   *
    * @returns A Promise that resolves to the MembershipWitness object for the given contract tree.
    */
-  public async getContractMembershipWitness() {
+  public async getContractMembershipWitness(blockNumber: number | 'latest' = 'latest') {
     const index = await this.getContractIndex();
 
-    const siblingPath = await this.stateInfoProvider.getContractSiblingPath(index);
+    const siblingPath = await this.stateInfoProvider.getContractSiblingPath(blockNumber, index);
     return new MembershipWitness<typeof CONTRACT_TREE_HEIGHT>(
       CONTRACT_TREE_HEIGHT,
       index,
@@ -226,7 +228,7 @@ export class ContractTree {
       const root = await this.getFunctionTreeRoot();
       const newContractData = new NewContractData(completeAddress.address, portalContract, root);
       const commitment = computeContractLeaf(newContractData);
-      this.contractIndex = await this.stateInfoProvider.findLeafIndex(MerkleTreeId.CONTRACT_TREE, commitment);
+      this.contractIndex = await this.stateInfoProvider.findLeafIndex('latest', MerkleTreeId.CONTRACT_TREE, commitment);
       if (this.contractIndex === undefined) {
         throw new Error(
           `Failed to find contract at ${completeAddress.address} with portal ${portalContract} resulting in commitment ${commitment}.`,

--- a/yarn-project/pxe/src/kernel_oracle/index.ts
+++ b/yarn-project/pxe/src/kernel_oracle/index.ts
@@ -24,7 +24,7 @@ export class KernelOracle implements ProvingDataOracle {
   }
 
   async getNoteMembershipWitness(leafIndex: bigint): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT>> {
-    const path = await this.node.getNoteHashSiblingPath(leafIndex);
+    const path = await this.node.getNoteHashSiblingPath('latest', leafIndex);
     return new MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT>(
       path.pathSize,
       leafIndex,

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -237,13 +237,13 @@ export class PXEService implements PXE {
       // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1386)
       // This can always be `uniqueSiloedNoteHash` once notes added from public also include nonces.
       const noteHashToLookUp = nonce.isZero() ? siloedNoteHash : uniqueSiloedNoteHash;
-      const index = await this.node.findLeafIndex(MerkleTreeId.NOTE_HASH_TREE, noteHashToLookUp);
+      const index = await this.node.findLeafIndex('latest', MerkleTreeId.NOTE_HASH_TREE, noteHashToLookUp);
       if (index === undefined) {
         throw new Error('Note does not exist.');
       }
 
       const siloedNullifier = siloNullifier(note.contractAddress, innerNullifier!);
-      const nullifierIndex = await this.node.findLeafIndex(MerkleTreeId.NULLIFIER_TREE, siloedNullifier);
+      const nullifierIndex = await this.node.findLeafIndex('latest', MerkleTreeId.NULLIFIER_TREE, siloedNullifier);
       if (nullifierIndex !== undefined) {
         throw new Error('The note has been destroyed.');
       }

--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -115,7 +115,7 @@ export class SimulatorOracle implements DBOracle {
     const messageAndIndex = await this.stateInfoProvider.getL1ToL2MessageAndIndex(msgKey);
     const message = messageAndIndex.message.toFieldArray();
     const index = messageAndIndex.index;
-    const siblingPath = await this.stateInfoProvider.getL1ToL2MessageSiblingPath(index);
+    const siblingPath = await this.stateInfoProvider.getL1ToL2MessageSiblingPath('latest', index);
     return {
       message,
       siblingPath: siblingPath.toFieldArray(),
@@ -129,16 +129,15 @@ export class SimulatorOracle implements DBOracle {
    * @returns - The index of the commitment. Undefined if it does not exist in the tree.
    */
   async getCommitmentIndex(commitment: Fr) {
-    return await this.stateInfoProvider.findLeafIndex(MerkleTreeId.NOTE_HASH_TREE, commitment);
+    return await this.stateInfoProvider.findLeafIndex('latest', MerkleTreeId.NOTE_HASH_TREE, commitment);
   }
 
   async getNullifierIndex(nullifier: Fr) {
-    return await this.stateInfoProvider.findLeafIndex(MerkleTreeId.NULLIFIER_TREE, nullifier);
+    return await this.stateInfoProvider.findLeafIndex('latest', MerkleTreeId.NULLIFIER_TREE, nullifier);
   }
 
   public async findLeafIndex(blockNumber: number, treeId: MerkleTreeId, leafValue: Fr): Promise<bigint | undefined> {
-    this.log.warn('Block number ignored in SimulatorOracle.findLeafIndex because archival node is not yet implemented');
-    return await this.stateInfoProvider.findLeafIndex(treeId, leafValue);
+    return await this.stateInfoProvider.findLeafIndex(blockNumber, treeId, leafValue);
   }
 
   public async getSiblingPath(blockNumber: number, treeId: MerkleTreeId, leafIndex: bigint): Promise<Fr[]> {
@@ -148,13 +147,13 @@ export class SimulatorOracle implements DBOracle {
     // @todo Doing a nasty workaround here because of https://github.com/AztecProtocol/aztec-packages/issues/3414
     switch (treeId) {
       case MerkleTreeId.NULLIFIER_TREE:
-        return (await this.stateInfoProvider.getNullifierTreeSiblingPath(leafIndex)).toFieldArray();
+        return (await this.stateInfoProvider.getNullifierTreeSiblingPath(blockNumber, leafIndex)).toFieldArray();
       case MerkleTreeId.NOTE_HASH_TREE:
-        return (await this.stateInfoProvider.getNoteHashSiblingPath(leafIndex)).toFieldArray();
+        return (await this.stateInfoProvider.getNoteHashSiblingPath(blockNumber, leafIndex)).toFieldArray();
       case MerkleTreeId.BLOCKS_TREE:
-        return (await this.stateInfoProvider.getBlocksTreeSiblingPath(leafIndex)).toFieldArray();
+        return (await this.stateInfoProvider.getBlocksTreeSiblingPath(blockNumber, leafIndex)).toFieldArray();
       case MerkleTreeId.PUBLIC_DATA_TREE:
-        return (await this.stateInfoProvider.getPublicDataTreeSiblingPath(leafIndex)).toFieldArray();
+        return (await this.stateInfoProvider.getPublicDataTreeSiblingPath(blockNumber, leafIndex)).toFieldArray();
       default:
         throw new Error('Not implemented');
     }

--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -141,9 +141,6 @@ export class SimulatorOracle implements DBOracle {
   }
 
   public async getSiblingPath(blockNumber: number, treeId: MerkleTreeId, leafIndex: bigint): Promise<Fr[]> {
-    this.log.warn(
-      'Block number ignored in SimulatorOracle.getSiblingPath because archival node is not yet implemented',
-    );
     // @todo Doing a nasty workaround here because of https://github.com/AztecProtocol/aztec-packages/issues/3414
     switch (treeId) {
       case MerkleTreeId.NULLIFIER_TREE:

--- a/yarn-project/types/src/interfaces/state_provider.ts
+++ b/yarn-project/types/src/interfaces/state_provider.ts
@@ -14,41 +14,57 @@ import { MerkleTreeId } from '../merkle_tree_id.js';
 import { SiblingPath } from '../sibling_path.js';
 import { NullifierMembershipWitness } from './nullifier_witness.js';
 
+/** Helper type for a specific L2 block number or the latest block number */
+type BlockNumber = number | 'latest';
+
 /**
  * Interface providing methods for retrieving information about content of the state trees.
  */
 export interface StateInfoProvider {
   /**
    * Find the index of the given leaf in the given tree.
+   * @param blockNumber - The block number at which to get the data or 'latest' for latest data
    * @param treeId - The tree to search in.
    * @param leafValue - The value to search for
    * @returns The index of the given leaf in the given tree or undefined if not found.
    */
-  findLeafIndex(treeId: MerkleTreeId, leafValue: Fr): Promise<bigint | undefined>;
+  findLeafIndex(blockNumber: BlockNumber, treeId: MerkleTreeId, leafValue: Fr): Promise<bigint | undefined>;
 
   /**
    * Returns a sibling path for the given index in the contract tree.
+   * @param blockNumber - The block number at which to get the data.
    * @param leafIndex - The index of the leaf for which the sibling path is required.
    * @returns The sibling path for the leaf index.
    * TODO: https://github.com/AztecProtocol/aztec-packages/issues/3414
    */
-  getContractSiblingPath(leafIndex: bigint): Promise<SiblingPath<typeof CONTRACT_TREE_HEIGHT>>;
+  getContractSiblingPath(
+    blockNumber: BlockNumber,
+    leafIndex: bigint,
+  ): Promise<SiblingPath<typeof CONTRACT_TREE_HEIGHT>>;
 
   /**
    * Returns a sibling path for the given index in the nullifier tree.
+   * @param blockNumber - The block number at which to get the data.
    * @param leafIndex - The index of the leaf for which the sibling path is required.
    * @returns The sibling path for the leaf index.
    * TODO: https://github.com/AztecProtocol/aztec-packages/issues/3414
    */
-  getNullifierTreeSiblingPath(leafIndex: bigint): Promise<SiblingPath<typeof NULLIFIER_TREE_HEIGHT>>;
+  getNullifierTreeSiblingPath(
+    blockNumber: BlockNumber,
+    leafIndex: bigint,
+  ): Promise<SiblingPath<typeof NULLIFIER_TREE_HEIGHT>>;
 
   /**
    * Returns a sibling path for the given index in the note hash tree.
+   * @param blockNumber - The block number at which to get the data.
    * @param leafIndex - The index of the leaf for which the sibling path is required.
    * @returns The sibling path for the leaf index.
    * TODO: https://github.com/AztecProtocol/aztec-packages/issues/3414
    */
-  getNoteHashSiblingPath(leafIndex: bigint): Promise<SiblingPath<typeof NOTE_HASH_TREE_HEIGHT>>;
+  getNoteHashSiblingPath(
+    blockNumber: BlockNumber,
+    leafIndex: bigint,
+  ): Promise<SiblingPath<typeof NOTE_HASH_TREE_HEIGHT>>;
 
   /**
    * Gets a confirmed/consumed L1 to L2 message for the given message key (throws if not found).
@@ -60,46 +76,64 @@ export interface StateInfoProvider {
 
   /**
    * Returns a sibling path for a leaf in the committed l1 to l2 data tree.
+   * @param blockNumber - The block number at which to get the data.
    * @param leafIndex - Index of the leaf in the tree.
    * @returns The sibling path.
    * TODO: https://github.com/AztecProtocol/aztec-packages/issues/3414
    */
-  getL1ToL2MessageSiblingPath(leafIndex: bigint): Promise<SiblingPath<typeof L1_TO_L2_MSG_TREE_HEIGHT>>;
+  getL1ToL2MessageSiblingPath(
+    blockNumber: BlockNumber,
+    leafIndex: bigint,
+  ): Promise<SiblingPath<typeof L1_TO_L2_MSG_TREE_HEIGHT>>;
 
   /**
    * Returns a sibling path for a leaf in the committed historic blocks tree.
+   * @param blockNumber - The block number at which to get the data.
    * @param leafIndex - Index of the leaf in the tree.
    * @returns The sibling path.
    * TODO: https://github.com/AztecProtocol/aztec-packages/issues/3414
    */
-  getBlocksTreeSiblingPath(leafIndex: bigint): Promise<SiblingPath<typeof BLOCKS_TREE_HEIGHT>>;
+  getBlocksTreeSiblingPath(
+    blockNumber: BlockNumber,
+    leafIndex: bigint,
+  ): Promise<SiblingPath<typeof BLOCKS_TREE_HEIGHT>>;
 
   /**
    * Returns a sibling path for a leaf in the committed public data tree.
+   * @param blockNumber - The block number at which to get the data.
    * @param leafIndex - Index of the leaf in the tree.
    * @returns The sibling path.
    * TODO: https://github.com/AztecProtocol/aztec-packages/issues/3414
    */
-  getPublicDataTreeSiblingPath(leafIndex: bigint): Promise<SiblingPath<typeof PUBLIC_DATA_TREE_HEIGHT>>;
+  getPublicDataTreeSiblingPath(
+    blockNumber: BlockNumber,
+    leafIndex: bigint,
+  ): Promise<SiblingPath<typeof PUBLIC_DATA_TREE_HEIGHT>>;
 
   /**
    * Returns a nullifier membership witness for a given nullifier at a given block.
-   * @param blockNumber - The block number at which to get the index.
+   * @param blockNumber - The block number at which to get the data.
    * @param nullifier - Nullifier we try to find witness for.
    * @returns The nullifier membership witness (if found).
    */
-  getNullifierMembershipWitness(blockNumber: number, nullifier: Fr): Promise<NullifierMembershipWitness | undefined>;
+  getNullifierMembershipWitness(
+    blockNumber: BlockNumber,
+    nullifier: Fr,
+  ): Promise<NullifierMembershipWitness | undefined>;
 
   /**
    * Returns a low nullifier membership witness for a given nullifier at a given block.
-   * @param blockNumber - The block number at which to get the index.
+   * @param blockNumber - The block number at which to get the data.
    * @param nullifier - Nullifier we try to find the low nullifier witness for.
    * @returns The low nullifier membership witness (if found).
    * @remarks Low nullifier witness can be used to perform a nullifier non-inclusion proof by leveraging the "linked
    * list structure" of leaves and proving that a lower nullifier is pointing to a bigger next value than the nullifier
    * we are trying to prove non-inclusion for.
    */
-  getLowNullifierMembershipWitness(blockNumber: number, nullifier: Fr): Promise<NullifierMembershipWitness | undefined>;
+  getLowNullifierMembershipWitness(
+    blockNumber: BlockNumber,
+    nullifier: Fr,
+  ): Promise<NullifierMembershipWitness | undefined>;
 
   /**
    * Get a block specified by its number.

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -135,16 +135,16 @@ export class ServerWorldStateSynchronizer implements WorldStateSynchronizer {
   /**
    * Forces an immediate sync
    * @param minBlockNumber - The minimum block number that we must sync to
-   * @returns A promise that resolves once the sync has completed.
+   * @returns A promise that resolves to the blockNumber the world state has synced to
    */
-  public async syncImmediate(minBlockNumber?: number): Promise<void> {
+  public async syncImmediate(minBlockNumber?: number): Promise<number> {
     if (this.currentState !== WorldStateRunningState.RUNNING) {
       throw new Error(`World State is not running, unable to perform sync`);
     }
     // If we have been given a block number to sync to and we have reached that number
     // then return.
     if (minBlockNumber !== undefined && minBlockNumber <= this.currentL2BlockNum) {
-      return;
+      return this.currentL2BlockNum;
     }
     const blockToSyncTo = minBlockNumber === undefined ? 'latest' : `${minBlockNumber}`;
     this.log(`World State at block ${this.currentL2BlockNum}, told to sync to block ${blockToSyncTo}...`);
@@ -153,7 +153,7 @@ export class ServerWorldStateSynchronizer implements WorldStateSynchronizer {
     while (true) {
       // Check the block number again
       if (minBlockNumber !== undefined && minBlockNumber <= this.currentL2BlockNum) {
-        return;
+        return this.currentL2BlockNum;
       }
       // Poll for more blocks
       const numBlocks = await this.l2BlockDownloader.pollImmediate();
@@ -169,7 +169,7 @@ export class ServerWorldStateSynchronizer implements WorldStateSynchronizer {
           `Unable to sync to block number ${minBlockNumber}, currently synced to block ${this.currentL2BlockNum}`,
         );
       }
-      return;
+      return this.currentL2BlockNum;
     }
   }
 

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -135,7 +135,7 @@ export class ServerWorldStateSynchronizer implements WorldStateSynchronizer {
   /**
    * Forces an immediate sync
    * @param minBlockNumber - The minimum block number that we must sync to
-   * @returns A promise that resolves to the blockNumber the world state has synced to
+   * @returns A promise that resolves with the block number the world state was synced to
    */
   public async syncImmediate(minBlockNumber?: number): Promise<number> {
     if (this.currentState !== WorldStateRunningState.RUNNING) {

--- a/yarn-project/world-state/src/synchronizer/world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/world_state_synchronizer.ts
@@ -48,7 +48,7 @@ export interface WorldStateSynchronizer {
   /**
    * Forces an immediate sync to an optionally provided minimum block number
    * @param minBlockNumber - The minimum block number that we must sync to
-   * @returns A promise that resolves once the sync has completed.
+   * @returns A promise that resolves with the block number the world state was synced to
    */
   syncImmediate(minBlockNumber?: number): Promise<number>;
 

--- a/yarn-project/world-state/src/synchronizer/world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/world_state_synchronizer.ts
@@ -50,7 +50,7 @@ export interface WorldStateSynchronizer {
    * @param minBlockNumber - The minimum block number that we must sync to
    * @returns A promise that resolves once the sync has completed.
    */
-  syncImmediate(minBlockNumber?: number): Promise<void>;
+  syncImmediate(minBlockNumber?: number): Promise<number>;
 
   /**
    * Returns an instance of MerkleTreeOperations that will include uncommitted data.


### PR DESCRIPTION
This PR starts using the world state snapshots created in #3468.