### PR TITLE
fix(ci): terraform listener resources

### DIFF
--- a/yarn-project/aztec-node/terraform/main.tf
+++ b/yarn-project/aztec-node/terraform/main.tf
@@ -377,6 +377,6 @@ resource "aws_lb_listener" "aztec-node-tcp-listener" {
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.aztec-bootstrap-target-group[count.index].arn
+    target_group_arn = aws_lb_target_group.aztec-node-target-group[count.index].arn
   }
 }

--- a/yarn-project/aztec-node/terraform/main.tf
+++ b/yarn-project/aztec-node/terraform/main.tf
@@ -365,27 +365,18 @@ resource "aws_security_group_rule" "allow-node-tcp" {
   security_group_id = data.terraform_remote_state.aztec-network_iac.outputs.p2p_security_group_id
 }
 
-## Commented out here and setup manually as terraform (or the aws provider version we are using) has a bug
-## NLB listeners can't have a 'weight' property defined. You will see there isn't one here but that doesn't
-## stop it trying to automatically specify one and giving an error
+resource "aws_lb_listener" "aztec-node-tcp-listener" {
+  count             = local.node_count
+  load_balancer_arn = data.terraform_remote_state.aztec-network_iac.outputs.nlb_arn
+  port              = var.NODE_TCP_PORT + count.index
+  protocol          = "TCP"
 
-# resource "aws_lb_listener" "aztec-node-tcp-listener" {
-#   count             = local.node_count
-#   load_balancer_arn = data.terraform_remote_state.aztec-network_iac.outputs.nlb_arn
-#   port              = var.NODE_TCP_PORT + count.index
-#   protocol          = "TCP"
+  tags = {
+    name = "aztec-node-${count.index}-tcp-listener"
+  }
 
-#   tags = {
-#     name = "aztec-node-${count.index}-tcp-listener"
-#   }
-
-#   default_action {
-#     type = "forward"
-
-#     forward {
-#       target_group {
-#         arn = aws_lb_target_group.aztec-bootstrap-target-group[count.index].arn
-#       }
-#     }
-#   }
-# }
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.aztec-bootstrap-target-group[count.index].arn
+  }
+}

--- a/yarn-project/aztec-node/terraform/main.tf
+++ b/yarn-project/aztec-node/terraform/main.tf
@@ -1,9 +1,3 @@
-# Terraform to setup a prototype network of Aztec Nodes in AWS
-# It sets up 2 full nodes with different ports/keys etc.
-# Some duplication across the 2 defined services, could possibly
-# be refactored to use modules as and when we build out infrastructure for real
-
-
 terraform {
   backend "s3" {
     bucket = "aztec-terraform"

--- a/yarn-project/p2p-bootstrap/terraform/main.tf
+++ b/yarn-project/p2p-bootstrap/terraform/main.tf
@@ -224,27 +224,18 @@ resource "aws_security_group_rule" "allow-bootstrap-tcp" {
   security_group_id = data.terraform_remote_state.aztec-network_iac.outputs.p2p_security_group_id
 }
 
-## Commented out here and setup manually as terraform (or the aws provider version we are using) has a bug
-## NLB listeners can't have a 'weight' property defined. You will see there isn't one here but that doesn't
-## stop it trying to automatically specify one and giving an error
+resource "aws_lb_listener" "aztec-bootstrap-tcp-listener" {
+  count             = local.bootnode_count
+  load_balancer_arn = data.terraform_remote_state.aztec-network_iac.outputs.nlb_arn
+  port              = var.BOOTNODE_LISTEN_PORT + count.index
+  protocol          = "TCP"
 
-# resource "aws_lb_listener" "aztec-bootstrap-tcp-listener" {
-#   count             = local.bootnode_count
-#   load_balancer_arn = data.terraform_remote_state.aztec-network_iac.outputs.nlb_arn
-#   port              = var.BOOTNODE_LISTEN_PORT + count.index
-#   protocol          = "TCP"
+  tags = {
+    name = "aztec-bootstrap-${count.index}-target-group"
+  }
 
-#   tags = {
-#     name = "aztec-bootstrap-${count.index}-target-group"
-#   }
-
-#   default_action {
-#     type = "forward"
-
-#     forward {
-#       target_group {
-#         arn = aws_lb_target_group.aztec-bootstrap-target-group[count.index].arn
-#       }
-#     }
-#   }
-# }
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.aztec-bootstrap-target-group[count.index].arn
+  }
+}


### PR DESCRIPTION
Apparently `aws_lb_listener` should not be using `forward` section under `default_action` and directly set `target_group_arn`

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
