### PR TITLE
feat: throw compile time error if contract has too many fns

### DIFF
--- a/yarn-project/noir-compiler/package.json
+++ b/yarn-project/noir-compiler/package.json
@@ -45,6 +45,7 @@
     }
   },
   "dependencies": {
+    "@aztec/circuits.js": "workspace:^",
     "@aztec/foundation": "workspace:^",
     "@ltd/j-toml": "^1.38.0",
     "@noir-lang/noir_wasm": "portal:../../noir/packages/noir_wasm",

--- a/yarn-project/noir-compiler/src/contract-interface-gen/abi.ts
+++ b/yarn-project/noir-compiler/src/contract-interface-gen/abi.ts
@@ -1,3 +1,4 @@
+import { FUNCTION_TREE_HEIGHT } from '@aztec/circuits.js';
 import { ContractArtifact, DebugMetadata, FunctionArtifact, FunctionType } from '@aztec/foundation/abi';
 
 import { deflate } from 'pako';
@@ -88,6 +89,9 @@ export function generateContractArtifact(
   { contract, debug }: NoirContractCompilationArtifacts,
   aztecNrVersion?: string,
 ): ContractArtifact {
+  if (contract.functions.length > 2 ** FUNCTION_TREE_HEIGHT) {
+    throw new Error(`Contract can only have a maximum of ${2 ** FUNCTION_TREE_HEIGHT} functions`);
+  }
   const originalFunctions = contract.functions;
   // TODO why sort? we should have idempotent compilation so this should not be needed.
   const sortedFunctions = [...contract.functions].sort((fnA, fnB) => fnA.name.localeCompare(fnB.name));

--- a/yarn-project/noir-compiler/tsconfig.json
+++ b/yarn-project/noir-compiler/tsconfig.json
@@ -7,6 +7,9 @@
   },
   "references": [
     {
+      "path": "../circuits.js"
+    },
+    {
       "path": "../foundation"
     }
   ],

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -572,6 +572,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/noir-compiler@workspace:noir-compiler"
   dependencies:
+    "@aztec/circuits.js": "workspace:^"
     "@aztec/foundation": "workspace:^"
     "@jest/globals": ^29.5.0
     "@ltd/j-toml": ^1.38.0


### PR DESCRIPTION
fix #3500 

Contracts can be compiled using nargo and nargo-wasm. So either we place compile time checks in aztec-nr or in `noir-compiler`. I have done it in later - specifically when we generate contract artifacts since that is the earliest function used by both noir-wasm + nargo.

Let me know if there is a better place to add the check 🤷 