### PR TITLE
docs: documenting issue with `context.block_header`

### DIFF
--- a/yarn-project/aztec-nr/aztec/src/oracle/get_block_header.nr
+++ b/yarn-project/aztec-nr/aztec/src/oracle/get_block_header.nr
@@ -29,7 +29,13 @@ pub fn get_block_header(block_number: Field, context: PrivateContext) -> BlockHe
 
     // 3) Get the membership wintess of the block in the blocks tree
     let blocks_tree_id = 5; // TODO(#3443)
-    let witness: MembershipWitness<BLOCKS_TREE_HEIGHT, BLOCKS_TREE_HEIGHT + 1> = get_membership_witness(block_number, blocks_tree_id, block_hash);
+    
+    // Using `block_number` here for path is incorrect and it will break if we pass in an incorrect block number on input.
+    // Instead here should be the block number corresponding to `context.block_header.blocks_tree_root`
+    // This is not currently available in private context. See issue #3564
+    let path_block_number = block_number;
+    
+    let witness: MembershipWitness<BLOCKS_TREE_HEIGHT, BLOCKS_TREE_HEIGHT + 1> = get_membership_witness(path_block_number, blocks_tree_id, block_hash);
 
     // 4) Check that the block is in the blocks tree (i.e. the witness is valid)
     assert(context.block_header.blocks_tree_root == compute_merkle_root(block_hash, witness.index, witness.path), "Proving membership of a block in blocks tree failed");

--- a/yarn-project/end-to-end/src/e2e_inclusion_proofs_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_inclusion_proofs_contract.test.ts
@@ -46,7 +46,8 @@ describe('e2e_inclusion_proofs_contract', () => {
 
     {
       // Prove note inclusion in a given block.
-      // We prove the note existence at current block number because we don't currently have historical data
+      // TODO: Use here note block number from the creation note tx to test archival node. This is currently not
+      // possible because of issue #3564
       const blockNumber = await pxe.getBlockNumber();
       const ignoredCommitment = 0; // Not ignored only when the note doesn't exist
       await contract.methods.proveNoteInclusion(owner, blockNumber, ignoredCommitment).send().wait();
@@ -54,7 +55,8 @@ describe('e2e_inclusion_proofs_contract', () => {
 
     {
       // Prove that the note has not been nullified
-      // We prove the note existence at current block number because we don't currently have historical data
+      // TODO: Use here note block number from the creation note tx to test archival node. This is currently not
+      // possible because of issue #3564
       const blockNumber = await pxe.getBlockNumber();
       const ignoredNullifier = 0; // Not ignored only when the note doesn't exist
       await contract.methods.proveNullifierNonInclusion(owner, blockNumber, ignoredNullifier).send().wait();

--- a/yarn-project/noir-contracts/src/contracts/inclusion_proofs_contract/src/main.nr
+++ b/yarn-project/noir-contracts/src/contracts/inclusion_proofs_contract/src/main.nr
@@ -103,6 +103,7 @@ contract InclusionProofs {
         // TODO: assert that block number is less than the block number of context.block_header
         // --> This will either require a new oracle method that returns block_header.global_variables_hash preimage
         //     or modifying the private context so that we somehow expose it.
+        // Blocked by #3564
 
         // 1) Get block header from oracle and ensure that the block hash is included in the current blocks tree
         //    root.
@@ -146,6 +147,7 @@ contract InclusionProofs {
         // TODO: assert that block number is less than the block number of context.block_header
         // --> This will either require a new oracle method that returns block_header.global_variables_hash preimage
         //     or modifying the private context so that we somehow expose it.
+        // Blocked by #3564
 
         // 1) Get block header from oracle and ensure that the block hash is included in the current blocks tree
         //    root.
@@ -217,6 +219,7 @@ contract InclusionProofs {
         // TODO: assert that block number is less than the block number of context.block_header
         // --> This will either require a new oracle method that returns block_header.global_variables_hash preimage
         //     or modifying the private context so that we somehow expose it.
+        // Blocked by #3564
 
         // 1) Get block header from oracle and ensure that the block hash is included in the current blocks tree
         //    root.
@@ -249,6 +252,7 @@ contract InclusionProofs {
         // TODO: assert that block number is less than the block number of context.block_header
         // --> This will either require a new oracle method that returns block_header.global_variables_hash preimage
         //     or modifying the private context so that we somehow expose it.
+        // Blocked by #3564
 
         // 1) Get block header from oracle and ensure that the block hash is included in the current blocks tree
         //    root.


### PR DESCRIPTION
I was incorrectly trying to fetch a sibling path from an older block when proving that a block header is legit. This caused the test to break when proving inclusion at an older block. I currently could not address it because of issue #3564 so I decided to only document it in this PR.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
