### PR TITLE
fix(pxe): Initialise aztecjs on pxe startup

### DIFF
--- a/yarn-project/pxe/src/bin/index.ts
+++ b/yarn-project/pxe/src/bin/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S node --no-warnings
+import { init } from '@aztec/foundation/crypto';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { createAztecNodeClient } from '@aztec/types';
 
@@ -15,6 +16,8 @@ const logger = createDebugLogger('aztec:pxe_service');
  */
 async function main() {
   logger.info(`Setting up PXE...`);
+
+  await init();
 
   const pxeConfig = getPXEServiceConfig();
   const nodeRpcClient = createAztecNodeClient(AZTEC_NODE_URL);


### PR DESCRIPTION
Call `initAztecJs` on pxe startup. Fixes the following error:

```
$ PXE_PORT=8085 yarn start
  aztec:pxe_service INFO Setting up PXE... +0ms
  aztec:pxe_service ERROR Error: Initialise first via initSingleton(). +2ms
```