### PR TITLE
docs(yellowpaper): update `cast` instruction description with truncation operation

### DIFF
--- a/yellow-paper/docs/public-vm/gen/_InstructionSet.mdx
+++ b/yellow-paper/docs/public-vm/gen/_InstructionSet.mdx
@@ -710,7 +710,7 @@ Type cast
 	- **aOffset**: memory offset of word to cast
 	- **dstOffset**: memory offset specifying where to store operation's result
 - **Expression**: `M[dstOffset] = cast<dst-tag>(M[aOffset])`
-- **Details**: Cast a word in memory based on the `dst-tag` specified in the bytecode. Truncates when casting to a smaller type, left-zero-pads when casting to a larger type. See [here](./state-model#cast-and-tag-conversions) for more details.
+- **Details**: Cast a word in memory based on the `dst-tag` specified in the bytecode. Truncates (`M[dstOffset] = M[aOffset] mod 2^dstsize`) when casting to a smaller type, left-zero-pads when casting to a larger type. See [here](./state-model#cast-and-tag-conversions) for more details.
 - **Tag updates**: `T[dstOffset] = dst-tag`
 - **Bit-size**: 96
 

--- a/yellow-paper/src/preprocess/InstructionSet/InstructionSet.js
+++ b/yellow-paper/src/preprocess/InstructionSet/InstructionSet.js
@@ -279,7 +279,7 @@ const INSTRUCTION_SET_RAW = [
         ],
         "Expression": "`M[dstOffset] = cast<dst-tag>(M[aOffset])`",
         "Summary": "Type cast",
-        "Details": "Cast a word in memory based on the `dst-tag` specified in the bytecode. Truncates when casting to a smaller type, left-zero-pads when casting to a larger type. See [here](./state-model#cast-and-tag-conversions) for more details.",
+        "Details": "Cast a word in memory based on the `dst-tag` specified in the bytecode. Truncates (`M[dstOffset] = M[aOffset] mod 2^dstsize`) when casting to a smaller type, left-zero-pads when casting to a larger type. See [here](./state-model#cast-and-tag-conversions) for more details.",
         "Tag checks": "",
         "Tag updates": "`T[dstOffset] = dst-tag`",
     },


### PR DESCRIPTION
Simple docs update