### PR TITLE
fix(noir-compiler): compile time error if ctor is missing

### DIFF
--- a/yarn-project/noir-compiler/src/contract-interface-gen/abi.ts
+++ b/yarn-project/noir-compiler/src/contract-interface-gen/abi.ts
@@ -89,6 +89,10 @@ export function generateContractArtifact(
   { contract, debug }: NoirContractCompilationArtifacts,
   aztecNrVersion?: string,
 ): ContractArtifact {
+  const constructorArtifact = contract.functions.find(({ name }) => name === 'constructor');
+  if (constructorArtifact === undefined) {
+    throw new Error('Contract must have a constructor function');
+  }
   if (contract.functions.length > 2 ** FUNCTION_TREE_HEIGHT) {
     throw new Error(`Contract can only have a maximum of ${2 ** FUNCTION_TREE_HEIGHT} functions`);
   }


### PR DESCRIPTION
Fix a part of the problem highlighted by #3630 

Also created 
* https://github.com/noir-lang/noir/issues/3768
* [Discussion to see why we prioritise Aztec-nr issues over noir syntax issues. E.g. if we have storage and a syntax error in a method, instead of showinf the syntax error, we say "no compute_note_hash_and_nullifier() found"](https://aztecprotocol.slack.com/archives/C03P17YHVK8/p1702312023384759)
