### PR TITLE
fix: Make lsp work in docker, plus some other install tweaks.

### DIFF
--- a/aztec-up/bin/.aztec-run
+++ b/aztec-up/bin/.aztec-run
@@ -13,7 +13,7 @@ VERSION=${VERSION:-"latest"}
 DOCKER_HOST_BINDS=""
 
 # Volumes to pass to the container.
-DOCKER_VOLUME="-v $HOME:/root"
+DOCKER_VOLUME="-v $HOME:$HOME"
 
 # Colors.
 y="\033[33m"
@@ -35,7 +35,7 @@ fi
 
 # Set up host.docker.internal alias on Linux, just like it is on mac.
 UNAME=$(uname -s)
-if [ "$UNAME" == "Linux" ]; then
+if [[ -z "${SKIP_NET:-}" && "$UNAME" == "Linux" ]]; then
   if docker info 2>/dev/null | grep -q rootless; then
     # We're in rootless docker. Probe for the host ip and use that.
     ip=$(hostname -I | head | tr -d ' ')
@@ -58,7 +58,7 @@ done
 # If so, warn and exit.
 for i in "${!args[@]}"; do
     arg=${args[$i]}
-    if [[ -f "$arg" || -d "$arg" && $(realpath $arg) != ${HOME}* ]]; then
+    if [[ -f "$arg" || -d "$arg" ]] && [[ $(realpath $arg) != ${HOME}* ]]; then
       warn "Due to how we containerize our applications, paths outside of $HOME cannot be referenced."
       exit 1
     fi
@@ -77,7 +77,7 @@ DOCKER_VOLUME="$DOCKER_VOLUME -v cache:/cache"
 docker run \
   -ti \
   --rm \
-  --workdir "${PWD/$HOME/\/root}" \
+  --workdir "$PWD" \
   $DOCKER_HOST_BINDS \
   $DOCKER_ENV \
   $DOCKER_VOLUME \

--- a/aztec-up/bin/aztec-install
+++ b/aztec-up/bin/aztec-install
@@ -33,7 +33,7 @@ function title() {
   if [ "$(uname -s)" == "Darwin" ]; then
     echo -e "${y}WARNING: For best performance we recommend adjusting your default docker settings:"
     echo -e     "         - Under general, enable VirtioFS."
-    echo -e     "         - Under resources, set CPUs to ~80-100% your maximum."
+    echo -e     "         - Under resources, set CPUs to ~80% your maximum."
     echo -e     "         - Under resources, set Memory to ~80% your maximum."
     echo -e     "You may receive a warning about your home directory being mounted into a container."
     echo -e     "This is requested so we can read and write project files, that is all."
@@ -100,6 +100,8 @@ function pull_container {
   fi
 }
 
+export DOCKER_CLI_HINTS=false
+
 if [ -z "${SKIP_PULL:-}" ]; then
   info "Pulling aztec version $VERSION..."
   pull_container aztec-sandbox
@@ -149,7 +151,7 @@ function update_path_env_var {
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]; then
       # Add the target directory to the user's PATH in their profile.
-      echo "export PATH=\$PATH:$TARGET_DIR" >> "$SHELL_PROFILE"
+      echo "export PATH=\"\$PATH:$TARGET_DIR\"" >> "$SHELL_PROFILE"
       info "Done! Starting fresh shell..."
       $SHELL
     else

--- a/noir/Cargo.lock
+++ b/noir/Cargo.lock
@@ -1979,7 +1979,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -2227,9 +2227,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libm"
@@ -2371,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "wasi",
@@ -2867,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -3961,6 +3961,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4257,27 +4267,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
 dependencies = [
- "autocfg",
  "backtrace",
  "bytes",
  "libc",
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.5",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/noir/Dockerfile
+++ b/noir/Dockerfile
@@ -5,6 +5,7 @@ RUN ./scripts/bootstrap_native.sh
 
 # When running the container, mount the users home directory to /root
 FROM ubuntu:lunar
+# Install Tini as nargo doesn't handle signals properly.
+RUN apt-get update && apt-get install -y tini && rm -rf /var/lib/apt/lists/* && apt-get clean
 COPY --from=0 /usr/src/noir/target/release/nargo /usr/src/noir/target/release/nargo
-WORKDIR /root
-ENTRYPOINT ["/usr/src/noir/target/release/nargo"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/src/noir/target/release/nargo"]

--- a/noir/scripts/bootstrap_native.sh
+++ b/noir/scripts/bootstrap_native.sh
@@ -13,4 +13,8 @@ else
 fi
 
 # Build native.
-cargo build --features="noirc_driver/aztec" --release
+if [ -n "${DEBUG:-}" ]; then
+  cargo build --features="noirc_driver/aztec"
+else
+  cargo build --features="noirc_driver/aztec" --release
+fi

--- a/noir/tooling/nargo_cli/src/cli/lsp_cmd.rs
+++ b/noir/tooling/nargo_cli/src/cli/lsp_cmd.rs
@@ -39,9 +39,11 @@ pub(crate) fn run(
                 .layer(LifecycleLayer::default())
                 .layer(CatchUnwindLayer::default())
                 .layer(ConcurrencyLayer::default())
-                .layer(ClientProcessMonitorLayer::new(client))
+                // .layer(ClientProcessMonitorLayer::new(client))
                 .service(router)
         });
+
+        eprintln!("LSP starting...");
 
         // Prefer truly asynchronous piped stdin/stdout without blocking tasks.
         #[cfg(unix)]

--- a/noir/tooling/nargo_cli/src/cli/lsp_cmd.rs
+++ b/noir/tooling/nargo_cli/src/cli/lsp_cmd.rs
@@ -1,5 +1,5 @@
 use async_lsp::{
-    client_monitor::ClientProcessMonitorLayer, concurrency::ConcurrencyLayer,
+    concurrency::ConcurrencyLayer,
     panic::CatchUnwindLayer, server::LifecycleLayer, tracing::TracingLayer,
 };
 use clap::Args;
@@ -39,7 +39,6 @@ pub(crate) fn run(
                 .layer(LifecycleLayer::default())
                 .layer(CatchUnwindLayer::default())
                 .layer(ConcurrencyLayer::default())
-                // .layer(ClientProcessMonitorLayer::new(client))
                 .service(router)
         });
 


### PR DESCRIPTION
* LSP couldn't work in docker due to `ClientProcessMonitor` thing which needs to be able to see the pid of vscode, in order to exit when vscode is not there. Not quite sure why it's needed as vscode launches the process, so the process terminates on vscode exit anyway.
* Mount HOME at HOME rather than /root.
* Fix conditional.
* Disable annoying CLI hints on windows docker.
* Wrap nargo launcher in `tini` as it doesn't handle signals as expected.
* Allow for debug builds of noir via script using env var.