### PR TITLE
fix: There is no main.js

### DIFF
--- a/yarn-project/aztec.js/package.json
+++ b/yarn-project/aztec.js/package.json
@@ -4,11 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "exports": {
-    ".": {
-      "node": "./dest/index.js",
-      "import": "./dest/index.js",
-      "default": "./dest/main.js"
-    },
+    ".": "./dest/index.js",
     "./interfaces/pxe": "./dest/api/interfaces/pxe.js",
     "./abi": "./dest/api/abi.js",
     "./aztec_address": "./dest/api/aztec_address.js",


### PR DESCRIPTION
For some reason there was a default export to main.js for aztec.js.
This caused an issue for someone externally, I'm not sure why it only triggered since last release, where the root exports were explicitly moved into a "." block.
Regardless, it seems the appropriate thing is just always export `./dest/index.js`.