### PR TITLE
fix: setup aztec-cli cache

### DIFF
--- a/yarn-project/cli/Dockerfile
+++ b/yarn-project/cli/Dockerfile
@@ -4,7 +4,3 @@ ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/cli/dest/bin/index.j
 # The version has been updated in yarn-project-prod.
 # Adding COMMIT_TAG here to rebuild versioned image.
 ARG COMMIT_TAG=""
-
-ENV XDG_CACHE_HOME /cache
-RUN mkdir /cache && chmod 777 /cache
-VOLUME /cache

--- a/yarn-project/cli/Dockerfile
+++ b/yarn-project/cli/Dockerfile
@@ -4,3 +4,7 @@ ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/cli/dest/bin/index.j
 # The version has been updated in yarn-project-prod.
 # Adding COMMIT_TAG here to rebuild versioned image.
 ARG COMMIT_TAG=""
+
+ENV XDG_CACHE_HOME /cache
+RUN mkdir /cache && chmod 777 /cache
+VOLUME /cache

--- a/yarn-project/cli/aztec-cli
+++ b/yarn-project/cli/aztec-cli
@@ -148,7 +148,10 @@ if [[ ! -z "${DEBUG:-}" ]]; then
   DOCKER_ENV="$DOCKER_ENV -e DEBUG=$DEBUG"
 fi
 
-DOCKER_VOLUME="$DOCKER_VOLUME -v cache:/cache"
+COMPILER_CACHE="$HOME/.aztec/cache"
+mkdir -p "$COMPILER_CACHE"
+DOCKER_VOLUME="$DOCKER_VOLUME -v $COMPILER_CACHE:/cache"
+DOCKER_ENV="$DOCKER_ENV -e XDG_CACHE_HOME=/cache"
 
 $DOCKER_PATH run \
   --rm \


### PR DESCRIPTION
Mount a writeable cache volume for the compiler to use to store libraries it downloads during compilation of contracts.