### PR TITLE
docs: remove mentions of noir-compiler

### DIFF
--- a/docs/docs/dev_docs/contracts/compiling.md
+++ b/docs/docs/dev_docs/contracts/compiling.md
@@ -235,19 +235,6 @@ Read more about how to use the Aztec.nr interfaces [here](./syntax/functions.md#
 At the moment, the compiler generates these interfaces from already compiled ABIs, and not from source code. This means that you should not import a generated interface from within the same project as its source contract, or you risk circular references.
 :::
 
-## Compile using nodejs
-
-You can also programmatically access the compiler via the `@aztec/noir-compiler` package. To do this, install the package into your nodejs project:
-
-`npm install @aztec/noir-compiler`
-
-The compiler exposes the following functions:
-
-- `compileUsingNoirWasm`: Compiles an Aztec.nr project in the target folder using a WASM build of the compiler and returns the generated ABIs.
-- `compileUsingNargo`: Does the same as `compileUsingNargo` but instead of WASM it uses the `nargo` binary available on the shell `PATH`
-- `generateTypescriptContractInterface`: Generates a typescript class for the given contract artifact.
-- `generateNoirContractInterface`: Generates a Aztec.nr interface struct for the given contract artifact.
-
 ## Next steps
 
 Once you have compiled your contracts, you can use the generated artifacts via the `Contract` class in the `aztec.js` package to deploy and interact with them, or rely on the type-safe typescript classes directly. Alternatively, use the CLI [to deploy](../../dev_docs/cli/main.md#deploying-a-token-contract) and [interact](../../dev_docs/cli/main.md#sending-a-transaction) with them.

--- a/docs/docs/dev_docs/contracts/deploying.md
+++ b/docs/docs/dev_docs/contracts/deploying.md
@@ -25,25 +25,10 @@ aztec-cli deploy /path/to/contract/artifact.json
 </TabItem>
 <TabItem value="js" label="Aztec.js">
 
-Pre-requisite - Generate type-safe typescript classes for your contract when compiling using the `@aztec/noir-compiler` package. You can install the package by running `npm install @aztec/noir-compiler`.
+Pre-requisite - Compile the contract and generate a type-safe typescript class for it.
 
-```ts
-import { readFileSync, writeFileSync } from "fs";
-import { createConsoleLogger } from "@aztec/foundation/log";
-import {
-  compileUsingNoirWasm,
-  generateTypescriptContractInterface,
-} from "@aztec/noir-compiler";
-
-const compiled: ContractArtifact[] = await compileUsingNoirWasm(
-  projectPathToContractFolder,
-  { log: createConsoleLogger() }
-);
-const abiImportPath = "../target/Example.json";
-writeFileSync(
-  tsInterfaceDestFilePath,
-  generateTypescriptContractInterface(compiled[0], abiImportPath)
-);
+```bash
+aztec-cli compile /path/to/contract -o target/ -ts target/
 ```
 
 This would create a typescript file like `Example.ts` in the path specified. More details in the [compiling page](./compiling.md)
@@ -51,7 +36,7 @@ This would create a typescript file like `Example.ts` in the path specified. Mor
 Now you can import it to easily deploy and interact with the contract.
 
 ```ts
-import { ExampleContract } from "./Example.js";
+import { ExampleContract } from "./target/Example.js";
 
 const tx = ExampleContract.deploy(pxe).send();
 await tx.wait({ interval: 0.5 });


### PR DESCRIPTION
This PR removes references to `@aztec/noir-compiler` from the docs since it can't be installed through npm anymore (its got a `portal:` dependency on `noir_wasm`).
