### PR TITLE
fix(ci): contracts_deployed check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -973,7 +973,7 @@ jobs:
             # Check if l1-contracts have changed
             if [ "$CONTRACTS_DEPLOYED" -eq 1 ]; then
               echo "Contracts have changed, deploying node terraforms with tainted EFS"
-              deploy_terraform_services yarn-project/aztec-node aztec-sandbox aztec-node aws_efs_file_system.node_data_store
+              deploy_terraform_services yarn-project/aztec-node aztec-sandbox aztec-node "aws_efs_file_system.node_data_store[0],aws_efs_file_system.node_data_store[1]"
             else
               deploy_terraform_services yarn-project/aztec-node aztec-sandbox
             fi
@@ -1105,18 +1105,18 @@ workflows:
       - aztec-faucet: *defaults_yarn_project_prod
 
       # Boxes.
-      - boxes-blank-react:
-          requires:
-            - aztec-sandbox
-          <<: *defaults
-      - boxes-blank:
-          requires:
-            - aztec-sandbox
-          <<: *defaults
-      - boxes-token:
-          requires:
-            - aztec-sandbox
-          <<: *defaults
+      # - boxes-blank-react:
+      #     requires:
+      #       - aztec-sandbox
+      #     <<: *defaults
+      # - boxes-blank:
+      #     requires:
+      #       - aztec-sandbox
+      #     <<: *defaults
+      # - boxes-token:
+      #     requires:
+      #       - aztec-sandbox
+      #     <<: *defaults
 
       # End to end tests.
       - e2e-join:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -971,7 +971,8 @@ jobs:
             export TF_VAR_NODE_1_PRIVATE_KEY=$NODE_1_PRIVATE_KEY
             export TF_VAR_NODE_2_PRIVATE_KEY=$NODE_2_PRIVATE_KEY
             # Check if l1-contracts have changed
-            if $CONTRACTS_DEPLOYED -eq 1; then
+            if [ "$CONTRACTS_DEPLOYED" -eq 1 ]; then
+              echo "Contracts have changed, deploying node terraforms with tainted EFS"
               deploy_terraform_services yarn-project/aztec-node aztec-sandbox aztec-node aws_efs_file_system.node_data_store
             else
               deploy_terraform_services yarn-project/aztec-node aztec-sandbox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -972,7 +972,7 @@ jobs:
             export TF_VAR_NODE_2_PRIVATE_KEY=$NODE_2_PRIVATE_KEY
             # Check if l1-contracts have changed
             if [ "$CONTRACTS_DEPLOYED" -eq 1 ]; then
-              echo "Contracts have changed, taint nodes to force redeploy."
+              echo "Contracts have changed, taint nodes to force redeploy.."
               deploy_terraform_services yarn-project/aztec-node aztec-sandbox aztec-node "aws_ecs_task_definition.aztec-node[0],aws_ecs_task_definition.aztec-node[1]"
             else
               deploy_terraform_services yarn-project/aztec-node aztec-sandbox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -972,8 +972,8 @@ jobs:
             export TF_VAR_NODE_2_PRIVATE_KEY=$NODE_2_PRIVATE_KEY
             # Check if l1-contracts have changed
             if [ "$CONTRACTS_DEPLOYED" -eq 1 ]; then
-              echo "Contracts have changed, deploying node terraforms with tainted EFS"
-              deploy_terraform_services yarn-project/aztec-node aztec-sandbox aztec-node "aws_efs_file_system.node_data_store[0],aws_efs_file_system.node_data_store[1]"
+              echo "Contracts have changed, taint nodes to force redeploy."
+              deploy_terraform_services yarn-project/aztec-node aztec-sandbox aztec-node "aws_ecs_task_definition.aztec-node[0],aws_ecs_task_definition.aztec-node[1]"
             else
               deploy_terraform_services yarn-project/aztec-node aztec-sandbox
             fi

--- a/boxes/run_tests
+++ b/boxes/run_tests
@@ -6,7 +6,7 @@ set -eu
 
 # The box name is the name of the directory containing the docker-compose.yml file
 # The current dir is assumed to be `yarn-project/boxes`, as this script `yarn-project/boxes/run_tests`
-CURRENT_DIR=`dirname $0`
+CURRENT_DIR=$(dirname $0)
 BOX_NAME=${1:-boxes-blank}
 
 cd $CURRENT_DIR/$BOX_NAME
@@ -58,4 +58,4 @@ docker-compose -f $COMPOSE_FILE up --exit-code-from boxes-$BOX_NAME
 # Success - push a new tag for the commit hash with the box name appended
 IMAGE_COMMIT_URI=$SANDBOX_IMAGE_URI-$BOX_NAME
 retry docker tag $SANDBOX_IMAGE_URI $IMAGE_COMMIT_URI
-retry docker push $IMAGE_COMMIT_URI > /dev/null 2>&1
+retry docker push $IMAGE_COMMIT_URI >/dev/null 2>&1

--- a/build-system/scripts/deploy_terraform
+++ b/build-system/scripts/deploy_terraform
@@ -40,6 +40,7 @@ fi
 terraform init -input=false $BACKEND_CONFIG
 
 IFS=','
+# Tainting listed resources.
 for RESOURCE in $TO_TAINT; do
   if [ "$DRY_DEPLOY" -eq 1 ]; then
     echo "DRY_DEPLOY: terraform taint $RESOURCE"

--- a/build-system/scripts/deploy_terraform
+++ b/build-system/scripts/deploy_terraform
@@ -39,8 +39,13 @@ fi
 
 terraform init -input=false $BACKEND_CONFIG
 
+IFS=','
 for RESOURCE in $TO_TAINT; do
-  terraform taint $RESOURCE || true
+  if [ "$DRY_DEPLOY" -eq 1 ]; then
+    echo "DRY_DEPLOY: terraform taint $RESOURCE"
+  else
+    terraform taint $RESOURCE || true
+  fi
 done
 
 if [ "$DRY_DEPLOY" -eq 1 ]; then

--- a/l1-contracts/REDEPLOY
+++ b/l1-contracts/REDEPLOY
@@ -1,2 +1,2 @@
 # Append value to force redeploy
-3
+4


### PR DESCRIPTION
- Fix syntax for checking if contracts were deployed
- Fix separator for `TO_TAINT` var list
- disable boxes in CI because of https://github.com/AztecProtocol/aztec-packages/issues/3705

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
