### PR TITLE
feat: compile base rollup as a circuit

### DIFF
--- a/yarn-project/noir-protocol-circuits/src/Nargo.toml
+++ b/yarn-project/noir-protocol-circuits/src/Nargo.toml
@@ -16,5 +16,6 @@ members = [
     "crates/rollup-lib",
     "crates/rollup-merge",
     "crates/rollup-base",
+    "crates/rollup-base-simulated",
     "crates/rollup-root",
 ]

--- a/yarn-project/noir-protocol-circuits/src/crates/rollup-base-simulated/Nargo.toml
+++ b/yarn-project/noir-protocol-circuits/src/crates/rollup-base-simulated/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rollup_base_simulated"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.18.0"
+
+[dependencies]
+rollup_lib = { path = "../rollup-lib" }
+types = { path = "../types" }

--- a/yarn-project/noir-protocol-circuits/src/crates/rollup-base-simulated/src/main.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/rollup-base-simulated/src/main.nr
@@ -1,5 +1,5 @@
 use dep::rollup_lib::base::{BaseRollupInputs,BaseOrMergeRollupPublicInputs};
 
-fn main(inputs: BaseRollupInputs) -> pub BaseOrMergeRollupPublicInputs {
+unconstrained fn main(inputs: BaseRollupInputs) -> pub BaseOrMergeRollupPublicInputs {
     inputs.base_rollup_circuit()
 }

--- a/yarn-project/noir-protocol-circuits/src/index.ts
+++ b/yarn-project/noir-protocol-circuits/src/index.ts
@@ -26,7 +26,7 @@ import PublicKernelPrivatePreviousJson from './target/public_kernel_private_prev
 import PublicKernelPrivatePreviousSimulatedJson from './target/public_kernel_private_previous_simulated.json' assert { type: 'json' };
 import PublicKernelPublicPreviousJson from './target/public_kernel_public_previous.json' assert { type: 'json' };
 import PublicKernelPublicPreviousSimulatedJson from './target/public_kernel_public_previous_simulated.json' assert { type: 'json' };
-import BaseRollupJson from './target/rollup_base.json' assert { type: 'json' };
+import BaseRollupSimulatedJson from './target/rollup_base_simulated.json' assert { type: 'json' };
 import MergeRollupJson from './target/rollup_merge.json' assert { type: 'json' };
 import RootRollupJson from './target/rollup_root.json' assert { type: 'json' };
 import {
@@ -416,12 +416,12 @@ async function executeMergeRollupWithACVM(input: MergeRollupInputType): Promise<
  * Executes the base rollup with the given inputs using the acvm.
  */
 async function executeBaseRollupWithACVM(input: BaseRollupInputType): Promise<BaseRollupReturnType> {
-  const initialWitnessMap = abiEncode(BaseRollupJson.abi as Abi, input as any);
+  const initialWitnessMap = abiEncode(BaseRollupSimulatedJson.abi as Abi, input as any);
 
   // Execute the circuit on those initial witness values
   //
   // Decode the bytecode from base64 since the acvm does not know about base64 encoding
-  const decodedBytecode = Buffer.from(BaseRollupJson.bytecode, 'base64');
+  const decodedBytecode = Buffer.from(BaseRollupSimulatedJson.bytecode, 'base64');
   //
   // Execute the circuit
   const _witnessMap = await executeCircuitWithBlackBoxSolver(
@@ -434,7 +434,7 @@ async function executeBaseRollupWithACVM(input: BaseRollupInputType): Promise<Ba
   );
 
   // Decode the witness map into two fields, the return values and the inputs
-  const decodedInputs: DecodedInputs = abiDecode(BaseRollupJson.abi as Abi, _witnessMap);
+  const decodedInputs: DecodedInputs = abiDecode(BaseRollupSimulatedJson.abi as Abi, _witnessMap);
 
   // Cast the inputs as the return type
   return decodedInputs.return_value as BaseRollupReturnType;


### PR DESCRIPTION
This PR adds a variant of the base rollup that is a circuit. This makes sure that PRs don't break compilation as a circuit of the base rollup and tracks its constraint count.
After the last noir pull, thanks to @TomAFrench compilation is now much faster, allowing to compile the base rollup as a circuit in a reasonable time (prev. it took 5 minutes, now some seconds)