### PR TITLE
chore: Use simple "flat" CRS.

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/get_bn254_crs.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/get_bn254_crs.cpp
@@ -1,34 +1,16 @@
 #include "get_bn254_crs.hpp"
 
-// Gets the transcript URL from the BARRETENBERG_TRANSCRIPT_URL environment variable, if set.
-// Otherwise returns the default URL.
-namespace {
-std::string get_bn254_transcript_url()
-{
-    const char* ENV_VAR_NAME = "BARRETENBERG_TRANSCRIPT_URL";
-    const std::string DEFAULT_URL = "https://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/monomial/transcript00.dat";
-
-    const char* env_url = std::getenv(ENV_VAR_NAME);
-
-    auto environment_variable_exists = ((env_url != nullptr) && *env_url);
-
-    return environment_variable_exists ? std::string(env_url) : DEFAULT_URL;
-}
-} // namespace
-
 std::vector<uint8_t> download_bn254_g1_data(size_t num_points)
 {
-    size_t g1_start = 28;
-    size_t g1_end = g1_start + num_points * 64 - 1;
+    size_t g1_end = num_points * 64 - 1;
 
-    std::string url = get_bn254_transcript_url();
+    std::string url = "https://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/flat/g1.dat";
 
-    std::string command =
-        "curl -s -H \"Range: bytes=" + std::to_string(g1_start) + "-" + std::to_string(g1_end) + "\" '" + url + "'";
+    std::string command = "curl -s -H \"Range: bytes=0-" + std::to_string(g1_end) + "\" '" + url + "'";
 
     auto data = exec_pipe(command);
     // Header + num_points * sizeof point.
-    if (data.size() < g1_end - g1_start) {
+    if (data.size() < g1_end) {
         throw std::runtime_error("Failed to download g1 data.");
     }
 
@@ -37,14 +19,8 @@ std::vector<uint8_t> download_bn254_g1_data(size_t num_points)
 
 std::vector<uint8_t> download_bn254_g2_data()
 {
-    size_t g2_start = 28 + 5040001 * 64;
-    size_t g2_end = g2_start + 128 - 1;
-
-    std::string url = get_bn254_transcript_url();
-
-    std::string command =
-        "curl -s -H \"Range: bytes=" + std::to_string(g2_start) + "-" + std::to_string(g2_end) + "\" '" + url + "'";
-
+    std::string url = "https://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/flat/g2.dat";
+    std::string command = "curl -s '" + url + "'";
     return exec_pipe(command);
 }
 
@@ -58,12 +34,13 @@ std::vector<barretenberg::g1::affine_element> get_bn254_g1_data(const std::files
         size_file.close();
     }
     if (size >= num_points) {
-        vinfo("using cached crs at: ", path);
-        auto data = read_file(path / "g1.dat", 28 + num_points * 64);
+        auto file = path / "g1.dat";
+        vinfo("using cached crs at: ", file);
+        auto data = read_file(file, num_points * 64);
         auto points = std::vector<barretenberg::g1::affine_element>(num_points);
-        auto size_of_points_in_bytes = num_points * 64;
-        barretenberg::srs::IO<curve::BN254>::read_affine_elements_from_buffer(
-            points.data(), (char*)data.data(), size_of_points_in_bytes);
+        for (size_t i = 0; i < num_points; ++i) {
+            points[i] = from_buffer<barretenberg::g1::affine_element>(data, i * 64);
+        }
         return points;
     }
 
@@ -79,8 +56,9 @@ std::vector<barretenberg::g1::affine_element> get_bn254_g1_data(const std::files
     new_size_file.close();
 
     auto points = std::vector<barretenberg::g1::affine_element>(num_points);
-    barretenberg::srs::IO<curve::BN254>::read_affine_elements_from_buffer(
-        points.data(), (char*)data.data(), data.size());
+    for (size_t i = 0; i < num_points; ++i) {
+        points[i] = from_buffer<barretenberg::g1::affine_element>(data, i * 64);
+    }
     return points;
 }
 
@@ -90,14 +68,10 @@ barretenberg::g2::affine_element get_bn254_g2_data(const std::filesystem::path& 
 
     try {
         auto data = read_file(path / "g2.dat");
-        barretenberg::g2::affine_element g2_point;
-        barretenberg::srs::IO<curve::BN254>::read_affine_elements_from_buffer(&g2_point, (char*)data.data(), 128);
-        return g2_point;
+        return from_buffer<barretenberg::g2::affine_element>(data.data());
     } catch (std::exception&) {
         auto data = download_bn254_g2_data();
         write_file(path / "g2.dat", data);
-        barretenberg::g2::affine_element g2_point;
-        barretenberg::srs::IO<curve::BN254>::read_affine_elements_from_buffer(&g2_point, (char*)data.data(), 128);
-        return g2_point;
+        return from_buffer<barretenberg::g2::affine_element>(data.data());
     }
 }

--- a/barretenberg/cpp/src/barretenberg/bb/get_grumpkin_crs.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/get_grumpkin_crs.cpp
@@ -45,8 +45,9 @@ std::vector<curve::Grumpkin::AffineElement> get_grumpkin_g1_data(const std::file
         size_file.close();
     }
     if (size >= num_points) {
-        vinfo("using cached crs at: ", path);
-        auto data = read_file(path / "grumpkin_g1.dat", 28 + num_points * 64);
+        auto file = path / "grumpkin_g1.dat";
+        vinfo("using cached crs at: ", file);
+        auto data = read_file(file, 28 + num_points * 64);
         auto points = std::vector<curve::Grumpkin::AffineElement>(num_points);
         auto size_of_points_in_bytes = num_points * 64;
         barretenberg::srs::IO<curve::Grumpkin>::read_affine_elements_from_buffer(

--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -19,7 +19,14 @@
 #include <vector>
 
 using namespace barretenberg;
-std::string CRS_PATH = "./crs";
+
+std::string getHomeDir()
+{
+    char* home = std::getenv("HOME");
+    return home != nullptr ? std::string(home) : "./";
+}
+
+std::string CRS_PATH = getHomeDir() + "/.bb-crs";
 bool verbose = false;
 
 const std::filesystem::path current_path = std::filesystem::current_path();
@@ -441,7 +448,7 @@ int main(int argc, char* argv[])
         std::string proof_path = get_option(args, "-p", "./proofs/proof");
         std::string vk_path = get_option(args, "-k", "./target/vk");
         std::string pk_path = get_option(args, "-r", "./target/pk");
-        CRS_PATH = get_option(args, "-c", "./crs");
+        CRS_PATH = get_option(args, "-c", CRS_PATH);
         bool recursive = flag_present(args, "-r") || flag_present(args, "--recursive");
 
         // Skip CRS initialization for any command which doesn't require the CRS.

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field2_declarations.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field2_declarations.hpp
@@ -138,4 +138,16 @@ template <class base_field, class Params> struct alignas(32) field2 {
     }
 };
 
+template <typename B, typename base_field, typename Params> void read(B& it, field2<base_field, Params>& value)
+{
+    using serialize::read;
+    read(it, value.c0);
+    read(it, value.c1);
+}
+template <typename B, typename base_field, typename Params> void write(B& buf, field2<base_field, Params> const& value)
+{
+    using serialize::write;
+    write(buf, value.c0);
+    write(buf, value.c1);
+}
 } // namespace barretenberg

--- a/barretenberg/cpp/src/barretenberg/srs/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/srs/c_bind.cpp
@@ -9,18 +9,18 @@
 using namespace barretenberg;
 
 /**
- * WARNING: The SRS is not encoded the same way as all the read/write methods encode.
- * Have to use the old school io functions to parse the buffers.
+ * We are not passed a vector (length prefixed), but the buffer and num points independently.
+ * Saves on having the generate the vector awkwardly calling side after downloading crs.
  */
-WASM_EXPORT void srs_init_srs(uint8_t const* points_buf, uint32_t const* num_points, uint8_t const* g2_point_buf)
+WASM_EXPORT void srs_init_srs(uint8_t const* points_buf, uint32_t const* num_points_buf, uint8_t const* g2_point_buf)
 {
-    auto points = std::vector<g1::affine_element>(ntohl(*num_points));
-    srs::IO<curve::BN254>::read_affine_elements_from_buffer(points.data(), (char*)points_buf, points.size() * 64);
-
-    g2::affine_element g2_point;
-    srs::IO<curve::BN254>::read_affine_elements_from_buffer(&g2_point, (char*)g2_point_buf, 128);
-
-    barretenberg::srs::init_crs_factory(points, g2_point);
+    auto num_points = ntohl(*num_points_buf);
+    auto g1_points = std::vector<g1::affine_element>(num_points);
+    for (size_t i = 0; i < num_points; ++i) {
+        g1_points[i] = from_buffer<barretenberg::g1::affine_element>(points_buf, i * 64);
+    }
+    auto g2_point = from_buffer<g2::affine_element>(g2_point_buf);
+    barretenberg::srs::init_crs_factory(g1_points, g2_point);
 }
 
 /**

--- a/barretenberg/ts/src/crs/net_crs.ts
+++ b/barretenberg/ts/src/crs/net_crs.ts
@@ -21,12 +21,11 @@ export class NetCrs {
   }
 
   async downloadG1Data() {
-    const g1Start = 28;
-    const g1End = g1Start + this.numPoints * 64 - 1;
+    const g1End = this.numPoints * 64 - 1;
 
-    const response = await fetch('https://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/monomial/transcript00.dat', {
+    const response = await fetch('https://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/flat/g1.dat', {
       headers: {
-        Range: `bytes=${g1Start}-${g1End}`,
+        Range: `bytes=0-${g1End}`,
       },
       cache: 'force-cache',
     });
@@ -38,13 +37,7 @@ export class NetCrs {
    * Download the G2 points data.
    */
   async downloadG2Data() {
-    const g2Start = 28 + 5040001 * 64;
-    const g2End = g2Start + 128 - 1;
-
-    const response2 = await fetch('https://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/monomial/transcript00.dat', {
-      headers: {
-        Range: `bytes=${g2Start}-${g2End}`,
-      },
+    const response2 = await fetch('https://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/flat/g2.dat', {
       cache: 'force-cache',
     });
 


### PR DESCRIPTION
There's no need for us to have such a convoluted set of transcripts for our CRS in a complicated format. This:
* Uses a single 6GB "flat" CRS with no header data in the ignition s3 bucket, in normalised big-endian form.
* Allows us to use our normal deserialization functions for the fields, as opposed to specific custom SRS reading code.
* Means we can now download, without complexity, any size CRS we need.
* Changes names to eg `bn254_g1.dat` so doesn't conflict with old cache.
* Get's rid of `size` file and just directly analyses file sizes.

It doesn't address:
* The new grumpkin CRS that arrived yesterday. Someone else can tackle that one. We also need to figure out how to generate a real one. Another trusted setup??....
