### PR TITLE
chore: Use released code for publishing docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -853,24 +853,25 @@ jobs:
           name: "Copy docs dockerignore"
           command: cp docs/.dockerignore .
       - run:
-          name: "Configure build for master"
-          command: |
-            if [ "$CIRCLE_BRANCH" == "master" ]; then
-              echo "Configuring build for master"
-              echo "INCLUDE_RELEASED_CODE=1" >> docs/.env
-            fi
-      - run:
-          name: "Build docs"
+          name: "Build docs using latest code"
           command: build docs
+
+  deploy-docs:
+    machine:
+      image: ubuntu-2204:2023.07.2
+    resource_class: large
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Copy docs dockerignore"
+          command: cp docs/.dockerignore .
+      - run:
+          name: "Build master docs using released code published in dockerhub"
+          command: build docs Dockerfile.prod
       - run:
           name: "Deploy docs"
-          command: |
-            if [ "$CIRCLE_BRANCH" == "master" ]; then
-              echo "Deploying docs (on master)."
-              docs/deploy_netlify.sh
-            else
-              echo "Skipping doc deploy (not on master)."
-            fi
+          command: docs/deploy_netlify.sh
 
   yellow-paper:
     machine:
@@ -928,6 +929,7 @@ jobs:
             deploy_dockerhub cli
             deploy_dockerhub aztec-faucet
             deploy_dockerhub mainnet-fork
+            deploy_dockerhub l1-contracts
       - run:
           name: "Release canary to NPM: yarn-project"
           command: |
@@ -1215,3 +1217,10 @@ workflows:
 
       # Production releases.
       - deploy-and-release: *defaults_deploy
+      - deploy-docs:
+          requires:
+            - deploy-and-release
+          filters:
+            branches:
+              only: master
+          <<: *defaults

--- a/build_manifest.yml
+++ b/build_manifest.yml
@@ -212,6 +212,20 @@ docs:
   dependencies:
     - yarn-project
 
+docs-prod:
+  buildDir: .
+  dockerfile: docs/Dockerfile.prod
+  rebuildPatterns:
+  - ^docs/
+  - ^.*.cpp$
+  - ^.*.hpp$
+  - ^.*.ts$
+  - ^.release-please-manifest.json$
+  - ^.*/noir-version.json$
+  - ^.*.nr$
+  dependencies:
+    - yarn-project
+
 yellow-paper:
   buildDir: yellow-paper
   rebuildPatterns:

--- a/docs/Dockerfile.prod
+++ b/docs/Dockerfile.prod
@@ -1,0 +1,6 @@
+FROM aztecprotocol/l1-contracts AS l1-contracts
+FROM aztecprotocol/aztec-sandbox
+COPY --from=l1-contracts /usr/src/l1-contracts /usr/src/l1-contracts
+WORKDIR /usr/src/docs
+COPY ./docs .
+RUN yarn && yarn build


### PR DESCRIPTION
Removes the need to set INCLUDE_RELEASED_CODE when building docs, and just builds off the published images of sandbox and l1-contracts on dockerhub. This ensures that the API reference we are generating is actually from the latest release and not from whatever's on master (which is a bug we have today).

Note that we keep the INCLUDE_RELEASED_CODE logic in our docs build script just to try it out locally.