### PR TITLE
fix(docs): Make git repo available when building docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -856,8 +856,11 @@ jobs:
           name: "Configure build for master"
           command: |
             if [ "$CIRCLE_BRANCH" == "master" ]; then
-              echo "Configuring build for master"
+              echo Configuring build for master
               echo "INCLUDE_RELEASED_CODE=1" >> docs/.env
+              LAST_TAG="aztec-packages-v$(jq -r '.["."]' .release-please-manifest.json)"
+              echo Fetching latest released tag $LAST_TAG
+              git fetch origin --refetch --no-filter refs/tags/$LAST_TAG:refs/tags/$LAST_TAG
             fi
       - run:
           name: "Build docs"

--- a/docs/Dockerfile.dockerignore
+++ b/docs/Dockerfile.dockerignore
@@ -10,3 +10,6 @@ docs/node_modules
 !circuits/cpp/src
 !.release-please-manifest.json
 !boxes
+
+# Docs build fetches code snippets from the last release using git show.
+!.git


### PR DESCRIPTION
This is a quick and dirty fix to get docs to load released code snippets again. We should not need to pass the entire git repo to the build context to make it work, but it should buy us some time until we ship a proper solution (see #3754).

