### PR TITLE
fix(docs): Force docs build using latest released code always

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -853,15 +853,13 @@ jobs:
           name: "Copy docs dockerignore"
           command: cp docs/.dockerignore .
       - run:
-          name: "Configure build for master"
+          name: "Require released code"
           command: |
-            if [ "$CIRCLE_BRANCH" == "master" ]; then
-              echo Configuring build for master
-              echo "INCLUDE_RELEASED_CODE=1" >> docs/.env
-              LAST_TAG="aztec-packages-v$(jq -r '.["."]' .release-please-manifest.json)"
-              echo Fetching latest released tag $LAST_TAG
-              git fetch origin --refetch --no-filter refs/tags/$LAST_TAG:refs/tags/$LAST_TAG
-            fi
+            echo Requiring released code snippets
+            echo "INCLUDE_RELEASED_CODE=1" >> docs/.env
+            LAST_TAG="aztec-packages-v$(jq -r '.["."]' .release-please-manifest.json)"
+            echo Fetching latest released tag $LAST_TAG
+            git fetch origin --refetch --no-filter refs/tags/$LAST_TAG:refs/tags/$LAST_TAG
       - run:
           name: "Build docs"
           command: build docs


### PR DESCRIPTION
Having two different docs builds, one with released code and one without, doesn't fly with build-system, since it checks the content hash of the content to determine whether to rebuild based on committed data only. This means that the hack introduced [here](https://github.com/AztecProtocol/aztec-packages/pull/3716) does not work.

So we'll just build as if we were in master on every run, for now.