### PR TITLE
feat: tree ids in noir

### DIFF
--- a/yarn-project/aztec-nr/aztec/src/oracle/get_membership_witness.nr
+++ b/yarn-project/aztec-nr/aztec/src/oracle/get_membership_witness.nr
@@ -5,6 +5,10 @@ use dep::protocol_types::constants::{
 };
 use crate::utils::arr_copy_slice;
 
+global CONTRACT_TREE_ID = 0;
+global NOTE_HASH_TREE_ID = 2;
+global ARCHIVE_TREE_ID = 5;
+
 // Note: We have M here because we need to somehow set it when calling get_membership_witness function and one way to
 // do it is to set M here and then set type of the return param, e.g.:
 //
@@ -26,21 +30,18 @@ unconstrained pub fn get_membership_witness<N, M>(block_number: u32, tree_id: Fi
 }
 
 unconstrained pub fn get_contract_membership_witness(block_number: u32, leaf_value: Field) -> MembershipWitness<CONTRACT_TREE_HEIGHT, CONTRACT_TREE_HEIGHT + 1> {
-    let contract_tree_id = 0; // TODO(#3443)
-    get_membership_witness(block_number, contract_tree_id, leaf_value)
+    get_membership_witness(block_number, CONTRACT_TREE_ID, leaf_value)
 }
 
 // Note: get_nullifier_membership_witness function is implemented in get_nullifier_membership_witness.nr
 
 unconstrained pub fn get_note_hash_membership_witness<N, M>(block_number: u32, leaf_value: Field) -> MembershipWitness<NOTE_HASH_TREE_HEIGHT, NOTE_HASH_TREE_HEIGHT + 1> {
-    let note_hash_tree_id = 2; // TODO(#3443)
-    get_membership_witness(block_number, note_hash_tree_id, leaf_value)
+    get_membership_witness(block_number, NOTE_HASH_TREE_ID, leaf_value)
 }
 
 // There is no `get_public_data_membership_witness` function because it doesn't make sense to be getting a membership
 // witness for a value in the public data tree.
 
 unconstrained pub fn get_archive_membership_witness(block_number: u32, leaf_value: Field) -> MembershipWitness<ARCHIVE_HEIGHT, ARCHIVE_HEIGHT + 1> {
-    let archive_tree_id = 5; // TODO(#3443)
-    get_membership_witness(block_number, archive_tree_id, leaf_value)
+    get_membership_witness(block_number, ARCHIVE_TREE_ID, leaf_value)
 }

--- a/yarn-project/types/src/merkle_tree_id.ts
+++ b/yarn-project/types/src/merkle_tree_id.ts
@@ -1,5 +1,6 @@
 /**
  * Defines the possible Merkle tree IDs.
+ * NOTE: If you change this, update get_membership_witness.nr as well.
  */
 export enum MerkleTreeId {
   CONTRACT_TREE = 0,


### PR DESCRIPTION
Fixes [#3443](https://github.com/AztecProtocol/aztec-packages/issues/3443)

Given that the tree ids are used only in 1 noir file I decided to tackle the issue just by adding a comment to merkle_tree_id.ts and grouping the constants next to each other.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
