### PR TITLE
fix(docs): Fix docs build during releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -878,9 +878,13 @@ jobs:
           name: "Require released code"
           command: |
             LAST_TAG="aztec-packages-v$(jq -r '.["."]' .release-please-manifest.json)"
-            git ls-remote --tags origin | grep -q "$LAST_TAG" && echo "Using code released from $LAST_TAG" || { echo "Skipping as $LAST_TAG is not yet published" && exit 0; }
-            echo "INCLUDE_RELEASED_CODE=1" >> docs/.env
-            git fetch origin --refetch --no-filter refs/tags/$LAST_TAG:refs/tags/$LAST_TAG
+            if git ls-remote --tags origin | grep "$LAST_TAG" > /dev/null; then
+              echo "Using code released from $LAST_TAG"
+              echo "INCLUDE_RELEASED_CODE=1" >> docs/.env
+              git fetch origin --refetch --no-filter refs/tags/$LAST_TAG:refs/tags/$LAST_TAG
+            else
+              echo "Skipping as $LAST_TAG is not yet published"
+            fi
       - run:
           name: "Build docs"
           command: build docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -877,10 +877,9 @@ jobs:
       - run:
           name: "Require released code"
           command: |
-            echo Requiring released code snippets
-            echo "INCLUDE_RELEASED_CODE=1" >> docs/.env
             LAST_TAG="aztec-packages-v$(jq -r '.["."]' .release-please-manifest.json)"
-            echo Fetching latest released tag $LAST_TAG
+            git ls-remote --tags origin | grep -q "$LAST_TAG" && echo "Using code released from $LAST_TAG" || { echo "Skipping as $LAST_TAG is not yet published" && exit 0; }
+            echo "INCLUDE_RELEASED_CODE=1" >> docs/.env
             git fetch origin --refetch --no-filter refs/tags/$LAST_TAG:refs/tags/$LAST_TAG
       - run:
           name: "Build docs"


### PR DESCRIPTION
Fixes the issue introduced in #3762, which caused the docs build step to always attempt to fetch the last released version. Due to how release-plase works, the last released version during a release is the version being released, which is not available as a tag to be fetched. To avoid this issue, we first check if the tag to be checked out is available, and if not, just load the code snippets from master.