### PR TITLE
feat: Launch the monorepo in a codespace.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,17 @@
 {
-	"image": "node:lts-bookworm-slim",
-	"features": { "ghcr.io/devcontainers/features/docker-in-docker:2": {}},
-	"postCreateCommand": "curl -s install.aztec.network | VERSION=master NON_INTERACTIVE=1 BIN_PATH=/usr/local/bin bash -s",
-	"customizations": {
-		"vscode": {
-			"settings": {},
-			"extensions": ["noir-lang.vscode-noir"]
-		}
-	},
-	"workspaceMount": "source=${localWorkspaceFolder},target=/root/workspace,type=bind",
-    "workspaceFolder": "/root/workspace"
+  "image": "node:lts-bookworm-slim",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+  "postCreateCommand": "curl -s install.aztec.network | VERSION=master NON_INTERACTIVE=1 BIN_PATH=/usr/local/bin bash -s",
+  "customizations": {
+    "vscode": {
+      "settings": {},
+      "extensions": [
+        "noir-lang.vscode-noir"
+      ]
+    }
+  },
+  "workspaceMount": "source=${localWorkspaceFolder},target=/root/workspace,type=bind",
+  "workspaceFolder": "/root/workspace"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+	"image": "node:lts-bookworm-slim",
+	"features": { "ghcr.io/devcontainers/features/docker-in-docker:2": {}},
+	"postCreateCommand": "cat /root/workspace/aztec-up/bin/aztec-install | VERSION=master NON_INTERACTIVE=1 BIN_PATH=/usr/local/bin bash -s",
+	"customizations": {
+		"vscode": {
+			"settings": {},
+			"extensions": ["noir-lang.vscode-noir"]
+		}
+	},
+	"workspaceMount": "source=${localWorkspaceFolder},target=/root/workspace,type=bind",
+    "workspaceFolder": "/root/workspace"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"image": "node:lts-bookworm-slim",
 	"features": { "ghcr.io/devcontainers/features/docker-in-docker:2": {}},
-	"postCreateCommand": "cat /root/workspace/aztec-up/bin/aztec-install | VERSION=master NON_INTERACTIVE=1 BIN_PATH=/usr/local/bin bash -s",
+	"postCreateCommand": "curl -s install.aztec.network | VERSION=master NON_INTERACTIVE=1 BIN_PATH=/usr/local/bin bash -s",
 	"customizations": {
 		"vscode": {
 			"settings": {},


### PR DESCRIPTION
This adds a `.devcontainer/devcontainer.json` file to the monorepo.
This allows one to launch a codespace terminal from github in browser.

The *expected* outcome of this would a codespace ready to go, for actually developing our monorepo. A little bit like what our mainframe offers. And I think it could well be worth configuring an image with all the right tools to support this. But that wasn't really the goal of this PR.

This actually just installs the latest master containers into a minimal codespace, that allows a developer to unbox a project and run it against a sandbox etc. It just makes it a bit easier to test this flow directly in the monorepo.

Hey. I ❤️  monorepo.