### PR TITLE
fix: flaky e2e-p2p test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
@@ -22,6 +22,8 @@ import { mnemonicToAccount } from 'viem/accounts';
 import { MNEMONIC } from './fixtures/fixtures.js';
 import { setup } from './fixtures/utils.js';
 
+// Don't set this to a higher value than 9 because each node will use a different L1 publisher account and anvil seeds
+// only 10 accounts with ETH (9 and not 10 because first account is used by sandbox).
 const NUM_NODES = 4;
 const NUM_TXS_PER_BLOCK = 4;
 const NUM_TXS_PER_NODE = 2;


### PR DESCRIPTION
Fixes #3654

**Note**: Lasse had a good hunch that it's most likely caused by different nodes using the same l1 publisher private key. This PR changes this and uses different accounts for different nodes. I am quite confident that that is the culprit so I will close the issue.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
