### PR TITLE
fix: reenable goblin bbjs for a single test

### DIFF
--- a/barretenberg/acir_tests/Dockerfile.bb.js
+++ b/barretenberg/acir_tests/Dockerfile.bb.js
@@ -15,7 +15,7 @@ ENV VERBOSE=1
 # Run double_verify_proof through bb.js on node to check 512k support.
 RUN BIN=../ts/dest/node/main.js FLOW=prove_then_verify ./run_acir_tests.sh double_verify_proof
 # TODO(https://github.com/AztecProtocol/barretenberg/issues/811) make this able to run double_verify_proof
-RUN BIN=../ts/dest/node/main.js FLOW=prove_and_verify_goblin ./run_acir_tests.sh
+# RUN BIN=../ts/dest/node/main.js FLOW=prove_and_verify_goblin ./run_acir_tests.sh 
 # Run 1_mul through bb.js build, all_cmds flow, to test all cli args.
 RUN BIN=../ts/dest/node/main.js FLOW=all_cmds ./run_acir_tests.sh 1_mul
 # Run double_verify_proof through bb.js on chrome testing multi-threaded browser support.

--- a/barretenberg/acir_tests/Dockerfile.bb.js
+++ b/barretenberg/acir_tests/Dockerfile.bb.js
@@ -15,7 +15,7 @@ ENV VERBOSE=1
 # Run double_verify_proof through bb.js on node to check 512k support.
 RUN BIN=../ts/dest/node/main.js FLOW=prove_then_verify ./run_acir_tests.sh double_verify_proof
 # TODO(https://github.com/AztecProtocol/barretenberg/issues/811) make this able to run double_verify_proof
-# RUN BIN=../ts/dest/node/main.js FLOW=prove_and_verify_goblin ./run_acir_tests.sh 
+RUN BIN=../ts/dest/node/main.js FLOW=prove_and_verify_goblin ./run_acir_tests.sh assert_statement
 # Run 1_mul through bb.js build, all_cmds flow, to test all cli args.
 RUN BIN=../ts/dest/node/main.js FLOW=all_cmds ./run_acir_tests.sh 1_mul
 # Run double_verify_proof through bb.js on chrome testing multi-threaded browser support.


### PR DESCRIPTION
Apparently running all of the acir tests sometimes takes too long. Run only a single one as has been done historically.