### PR TITLE
fix: reprocess notes in pxe when a new contract is added

### DIFF
--- a/yarn-project/acir-simulator/src/client/db_oracle.ts
+++ b/yarn-project/acir-simulator/src/client/db_oracle.ts
@@ -6,7 +6,16 @@ import { Fr } from '@aztec/foundation/fields';
 import { L2Block, MerkleTreeId, NullifierMembershipWitness, PublicDataWitness } from '@aztec/types';
 
 import { NoteData } from '../acvm/index.js';
-import { CommitmentsDB } from '../public/index.js';
+import { CommitmentsDB } from '../public/db.js';
+
+/**
+ * Error thrown when a contract is not found in the database.
+ */
+export class ContractNotFoundError extends Error {
+  constructor(contractAddress: string) {
+    super(`DB has no contract with address ${contractAddress}`);
+  }
+}
 
 /**
  * A function artifact with optional debug metadata

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -59,7 +59,6 @@ export class Archiver implements L2BlockSource, L2LogsSource, ContractDataSource
    * @param inboxAddress - Ethereum address of the inbox contract.
    * @param registryAddress - Ethereum address of the registry contract.
    * @param contractDeploymentEmitterAddress - Ethereum address of the contractDeploymentEmitter contract.
-   * @param searchStartBlock - The L1 block from which to start searching for new blocks.
    * @param pollingIntervalMs - The interval for polling for L1 logs (in milliseconds).
    * @param store - An archiver data store for storage & retrieval of blocks, encrypted logs & contract data.
    * @param log - A logger.

--- a/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
@@ -292,7 +292,7 @@ describe('e2e_2_pxes', () => {
 
     await expectsNumOfEncryptedLogsInTheLastBlockToBe(aztecNode, 1);
 
-    // // Transfer funds from A to B via PXE A
+    // Transfer funds from A to B via PXE A
     const contractWithWalletA = await TokenContract.at(tokenAddress, walletA);
     const receiptAToB = await contractWithWalletA.methods
       .transfer(userA.address, userB.address, transferAmount1, 0)
@@ -310,5 +310,74 @@ describe('e2e_2_pxes', () => {
     ]);
     await expectTokenBalance(walletA, tokenAddress, userA.address, initialBalance - transferAmount1);
     await expectTokenBalance(walletB, tokenAddress, userB.address, transferAmount1);
+  });
+
+  it('permits sending funds to a user, and spending them, before they have registered the contract', async () => {
+    const initialBalance = 987n;
+    const transferAmount1 = 654n;
+    const transferAmount2 = 323n;
+
+    // setup an account that is shared across PXEs
+    const sharedPrivateKey = GrumpkinScalar.random();
+    const sharedAccountOnA = getUnsafeSchnorrAccount(pxeA, sharedPrivateKey, Fr.random());
+    const sharedAccountAddress = sharedAccountOnA.getCompleteAddress();
+    const sharedWalletOnA = await sharedAccountOnA.waitDeploy();
+    await expect(sharedWalletOnA.isAccountStateSynchronized(sharedAccountAddress.address)).resolves.toBe(true);
+
+    const sharedAccountOnB = getUnsafeSchnorrAccount(pxeB, sharedPrivateKey, sharedAccountAddress);
+    await sharedAccountOnB.register();
+    const sharedWalletOnB = await sharedAccountOnB.getWallet();
+
+    await pxeA.registerRecipient(userB);
+
+    // deploy the contract on PXE A
+    const completeTokenAddress = await deployTokenContract(initialBalance, userA.address, pxeA);
+    const tokenAddress = completeTokenAddress.address;
+
+    // Transfer funds from A to Shared Wallet via PXE A
+    const contractWithWalletA = await TokenContract.at(tokenAddress, walletA);
+    const receiptAToShared = await contractWithWalletA.methods
+      .transfer(userA.address, sharedAccountAddress.address, transferAmount1, 0)
+      .send()
+      .wait();
+    expect(receiptAToShared.status).toBe(TxStatus.MINED);
+
+    // Now send funds from Shared Wallet to B via PXE A
+    const contractWithSharedWalletA = await TokenContract.at(tokenAddress, sharedWalletOnA);
+    const receiptSharedToB = await contractWithSharedWalletA.methods
+      .transfer(sharedAccountAddress.address, userB.address, transferAmount2, 0)
+      .send()
+      .wait();
+    expect(receiptSharedToB.status).toBe(TxStatus.MINED);
+
+    // check balances from PXE-A's perspective
+    await expectTokenBalance(walletA, tokenAddress, userA.address, initialBalance - transferAmount1);
+    await expectTokenBalance(
+      sharedWalletOnA,
+      tokenAddress,
+      sharedAccountAddress.address,
+      transferAmount1 - transferAmount2,
+    );
+
+    // now add the contract and check balances from PXE-B's perspective.
+    // The process should be:
+    // PXE-B had previously deferred the notes from A -> Shared, and Shared -> B
+    // PXE-B adds the contract
+    // PXE-B reprocesses the deferred notes, and sees the nullifier for A -> Shared
+    await pxeB.addContracts([
+      {
+        artifact: TokenContract.artifact,
+        completeAddress: completeTokenAddress,
+        portalContract: EthAddress.ZERO,
+      },
+    ]);
+    await expectTokenBalance(walletB, tokenAddress, userB.address, transferAmount2);
+    await expect(sharedWalletOnB.isAccountStateSynchronized(sharedAccountAddress.address)).resolves.toBe(true);
+    await expectTokenBalance(
+      sharedWalletOnB,
+      tokenAddress,
+      sharedAccountAddress.address,
+      transferAmount1 - transferAmount2,
+    );
   });
 });

--- a/yarn-project/pxe/src/contract_data_oracle/index.ts
+++ b/yarn-project/pxe/src/contract_data_oracle/index.ts
@@ -52,7 +52,7 @@ export class ContractDataOracle {
    *
    * @param contractAddress - The AztecAddress representing the contract containing the function.
    * @param functionName - The name of the function.
-   * @returns The corresponding function's artifact as an object, or undefined if the function is not found.
+   * @returns The corresponding function's artifact as an object
    */
   public async getFunctionArtifactByName(
     contractAddress: AztecAddress,
@@ -94,6 +94,7 @@ export class ContractDataOracle {
    * @param contractAddress - The contract's address.
    * @param selector - The function selector.
    * @returns A Promise that resolves to a Buffer containing the bytecode of the specified function.
+   * @throws Error if the contract address is unknown or not found.
    */
   public async getBytecode(contractAddress: AztecAddress, selector: FunctionSelector) {
     const tree = await this.getTree(contractAddress);

--- a/yarn-project/pxe/src/contract_data_oracle/index.ts
+++ b/yarn-project/pxe/src/contract_data_oracle/index.ts
@@ -1,5 +1,6 @@
-import { AztecAddress, MembershipWitness, VK_TREE_HEIGHT } from '@aztec/circuits.js';
-import { FunctionDebugMetadata, FunctionSelector, getFunctionDebugMetadata } from '@aztec/foundation/abi';
+import { ContractNotFoundError } from '@aztec/acir-simulator';
+import { AztecAddress, ContractFunctionDao, MembershipWitness, VK_TREE_HEIGHT } from '@aztec/circuits.js';
+import { FunctionDebugMetadata, FunctionSelector } from '@aztec/foundation/abi';
 import { ContractDatabase, StateInfoProvider } from '@aztec/types';
 
 import { ContractTree } from '../contract_tree/index.js';
@@ -47,20 +48,25 @@ export class ContractDataOracle {
   /**
    * Retrieves the artifact of a specified function within a given contract.
    * The function is identified by its name, which is unique within a contract.
+   * Throws if the contract has not been added to the database.
    *
    * @param contractAddress - The AztecAddress representing the contract containing the function.
    * @param functionName - The name of the function.
-   * @returns The corresponding function's artifact as an object.
+   * @returns The corresponding function's artifact as an object, or undefined if the function is not found.
    */
-  public async getFunctionArtifactByName(contractAddress: AztecAddress, functionName: string) {
-    const contract = await this.db.getContract(contractAddress);
-    return contract?.functions.find(f => f.name === functionName);
+  public async getFunctionArtifactByName(
+    contractAddress: AztecAddress,
+    functionName: string,
+  ): Promise<ContractFunctionDao | undefined> {
+    const tree = await this.getTree(contractAddress);
+    return tree.contract.getFunctionArtifactByName(functionName);
   }
 
   /**
    * Retrieves the debug metadata of a specified function within a given contract.
    * The function is identified by its selector, which is a unique code generated from the function's signature.
    * Returns undefined if the debug metadata for the given function is not found.
+   * Throws if the contract has not been added to the database.
    *
    * @param contractAddress - The AztecAddress representing the contract containing the function.
    * @param selector - The function selector.
@@ -70,14 +76,14 @@ export class ContractDataOracle {
     contractAddress: AztecAddress,
     selector: FunctionSelector,
   ): Promise<FunctionDebugMetadata | undefined> {
-    const contract = await this.db.getContract(contractAddress);
-    const functionArtifact = contract?.functions.find(f => f.selector.equals(selector));
+    const tree = await this.getTree(contractAddress);
+    const functionArtifact = tree.contract.getFunctionArtifact(selector);
 
-    if (!contract || !functionArtifact) {
+    if (!functionArtifact) {
       return undefined;
     }
 
-    return getFunctionDebugMetadata(contract, functionArtifact.name);
+    return tree.contract.getFunctionDebugMetadataByName(functionArtifact.name);
   }
 
   /**
@@ -147,12 +153,12 @@ export class ContractDataOracle {
    * @returns A ContractTree instance associated with the specified contract address.
    * @throws An Error if the contract is not found in the ContractDatabase.
    */
-  private async getTree(contractAddress: AztecAddress) {
+  private async getTree(contractAddress: AztecAddress): Promise<ContractTree> {
     let tree = this.trees.find(t => t.contract.completeAddress.address.equals(contractAddress));
     if (!tree) {
       const contract = await this.db.getContract(contractAddress);
       if (!contract) {
-        throw new Error(`Unknown contract: ${contractAddress}`);
+        throw new ContractNotFoundError(contractAddress.toString());
       }
 
       tree = new ContractTree(contract, this.stateProvider);

--- a/yarn-project/pxe/src/database/deferred_note_dao.test.ts
+++ b/yarn-project/pxe/src/database/deferred_note_dao.test.ts
@@ -1,0 +1,32 @@
+import { AztecAddress, Fr } from '@aztec/circuits.js';
+import { Note, randomTxHash } from '@aztec/types';
+
+import { DeferredNoteDao } from './deferred_note_dao.js';
+
+export const randomDeferredNoteDao = ({
+  note = Note.random(),
+  contractAddress = AztecAddress.random(),
+  txHash = randomTxHash(),
+  storageSlot = Fr.random(),
+  txNullifier = Fr.random(),
+  newCommitments = [Fr.random(), Fr.random()],
+  dataStartIndexForTx = Math.floor(Math.random() * 100),
+}: Partial<DeferredNoteDao> = {}) => {
+  return new DeferredNoteDao(
+    note,
+    contractAddress,
+    storageSlot,
+    txHash,
+    txNullifier,
+    newCommitments,
+    dataStartIndexForTx,
+  );
+};
+
+describe('Deferred Note DAO', () => {
+  it('convert to and from buffer', () => {
+    const deferredNote = randomDeferredNoteDao();
+    const buf = deferredNote.toBuffer();
+    expect(DeferredNoteDao.fromBuffer(buf)).toEqual(deferredNote);
+  });
+});

--- a/yarn-project/pxe/src/database/deferred_note_dao.test.ts
+++ b/yarn-project/pxe/src/database/deferred_note_dao.test.ts
@@ -1,9 +1,10 @@
-import { AztecAddress, Fr } from '@aztec/circuits.js';
+import { AztecAddress, Fr, Point } from '@aztec/circuits.js';
 import { Note, randomTxHash } from '@aztec/types';
 
 import { DeferredNoteDao } from './deferred_note_dao.js';
 
 export const randomDeferredNoteDao = ({
+  publicKey = Point.random(),
   note = Note.random(),
   contractAddress = AztecAddress.random(),
   txHash = randomTxHash(),
@@ -13,6 +14,7 @@ export const randomDeferredNoteDao = ({
   dataStartIndexForTx = Math.floor(Math.random() * 100),
 }: Partial<DeferredNoteDao> = {}) => {
   return new DeferredNoteDao(
+    publicKey,
     note,
     contractAddress,
     storageSlot,

--- a/yarn-project/pxe/src/database/deferred_note_dao.ts
+++ b/yarn-project/pxe/src/database/deferred_note_dao.ts
@@ -1,0 +1,51 @@
+import { AztecAddress, Fr, Vector } from '@aztec/circuits.js';
+import { serializeToBuffer } from '@aztec/circuits.js/utils';
+import { BufferReader, Note, TxHash } from '@aztec/types';
+
+/**
+ * A note that is intended for us, but we cannot decode it yet because the contract is not yet in our database.
+ *
+ * So keep the state that we need to decode it later.
+ */
+export class DeferredNoteDao {
+  constructor(
+    /** The note as emitted from the Noir contract. */
+    public note: Note,
+    /** The contract address this note is created in. */
+    public contractAddress: AztecAddress,
+    /** The specific storage location of the note on the contract. */
+    public storageSlot: Fr,
+    /** The hash of the tx the note was created in. */
+    public txHash: TxHash,
+    /** The first nullifier emitted by the transaction */
+    public txNullifier: Fr,
+    /** New commitments in this transaction, one of which belongs to this note */
+    public newCommitments: Fr[],
+    /** The next available leaf index for the note hash tree for this transaction */
+    public dataStartIndexForTx: number,
+  ) {}
+
+  toBuffer(): Buffer {
+    return serializeToBuffer(
+      this.note.toBuffer(),
+      this.contractAddress.toBuffer(),
+      this.storageSlot.toBuffer(),
+      this.txHash.toBuffer(),
+      this.txNullifier.toBuffer(),
+      new Vector(this.newCommitments),
+      this.dataStartIndexForTx,
+    );
+  }
+  static fromBuffer(buffer: Buffer | BufferReader) {
+    const reader = BufferReader.asReader(buffer);
+    return new DeferredNoteDao(
+      reader.readObject(Note),
+      reader.readObject(AztecAddress),
+      reader.readObject(Fr),
+      reader.readObject(TxHash),
+      reader.readObject(Fr),
+      reader.readVector(Fr),
+      reader.readNumber(),
+    );
+  }
+}

--- a/yarn-project/pxe/src/database/deferred_note_dao.ts
+++ b/yarn-project/pxe/src/database/deferred_note_dao.ts
@@ -1,4 +1,4 @@
-import { AztecAddress, Fr, Vector } from '@aztec/circuits.js';
+import { AztecAddress, Fr, Point, PublicKey, Vector } from '@aztec/circuits.js';
 import { serializeToBuffer } from '@aztec/circuits.js/utils';
 import { BufferReader, Note, TxHash } from '@aztec/types';
 
@@ -9,6 +9,8 @@ import { BufferReader, Note, TxHash } from '@aztec/types';
  */
 export class DeferredNoteDao {
   constructor(
+    /** The public key associated with this note */
+    public publicKey: PublicKey,
     /** The note as emitted from the Noir contract. */
     public note: Note,
     /** The contract address this note is created in. */
@@ -27,6 +29,7 @@ export class DeferredNoteDao {
 
   toBuffer(): Buffer {
     return serializeToBuffer(
+      this.publicKey.toBuffer(),
       this.note.toBuffer(),
       this.contractAddress.toBuffer(),
       this.storageSlot.toBuffer(),
@@ -39,6 +42,7 @@ export class DeferredNoteDao {
   static fromBuffer(buffer: Buffer | BufferReader) {
     const reader = BufferReader.asReader(buffer);
     return new DeferredNoteDao(
+      reader.readObject(Point),
       reader.readObject(Note),
       reader.readObject(AztecAddress),
       reader.readObject(Fr),

--- a/yarn-project/pxe/src/database/kv_pxe_database.ts
+++ b/yarn-project/pxe/src/database/kv_pxe_database.ts
@@ -109,7 +109,7 @@ export class KVPxeDatabase implements PxeDatabase {
     }
   }
 
-  getDeferredNotesByContract(contractAddress: AztecAddress): DeferredNoteDao[] {
+  getDeferredNotesByContract(contractAddress: AztecAddress): Promise<DeferredNoteDao[]> {
     const noteIds = this.#deferredNotesByContract.getValues(contractAddress.toString());
     const notes: DeferredNoteDao[] = [];
     for (const noteId of noteIds) {
@@ -122,7 +122,7 @@ export class KVPxeDatabase implements PxeDatabase {
       notes.push(note);
     }
 
-    return notes;
+    return Promise.resolve(notes);
   }
 
   *#getAllNonNullifiedNotes(): IterableIterator<NoteDao> {

--- a/yarn-project/pxe/src/database/memory_db.ts
+++ b/yarn-project/pxe/src/database/memory_db.ts
@@ -5,6 +5,7 @@ import { createDebugLogger } from '@aztec/foundation/log';
 import { MerkleTreeId, NoteFilter } from '@aztec/types';
 
 import { MemoryContractDatabase } from '../contract_database/index.js';
+import { DeferredNoteDao } from './deferred_note_dao.js';
 import { NoteDao } from './note_dao.js';
 import { PxeDatabase } from './pxe_database.js';
 
@@ -52,6 +53,11 @@ export class MemoryDB extends MemoryContractDatabase implements PxeDatabase {
   public addNote(note: NoteDao): Promise<void> {
     this.notesTable.push(note);
     return Promise.resolve();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public addDeferredNotes(notes: DeferredNoteDao[]): Promise<void> {
+    throw new Error('Method not implemented.');
   }
 
   public addCapsule(capsule: Fr[]): Promise<void> {

--- a/yarn-project/pxe/src/database/memory_db.ts
+++ b/yarn-project/pxe/src/database/memory_db.ts
@@ -17,7 +17,7 @@ import { PxeDatabase } from './pxe_database.js';
  */
 export class MemoryDB extends MemoryContractDatabase implements PxeDatabase {
   private notesTable: NoteDao[] = [];
-
+  private deferredNotesTable: DeferredNoteDao[] = [];
   private treeRoots: Record<MerkleTreeId, Fr> | undefined;
   private globalVariablesHash: Fr | undefined;
   private blockNumber: number | undefined;
@@ -56,19 +56,25 @@ export class MemoryDB extends MemoryContractDatabase implements PxeDatabase {
     return Promise.resolve();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public addDeferredNotes(notes: DeferredNoteDao[]): Promise<void> {
-    throw new Error('Method not implemented.');
+    this.deferredNotesTable.push(...notes);
+    return Promise.resolve();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public getDeferredNotesByContract(contractAddress: AztecAddress): Promise<DeferredNoteDao[]> {
-    throw new Error('Method not implemented.');
+    return Promise.resolve(this.deferredNotesTable.filter(note => note.contractAddress.equals(contractAddress)));
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public removeDeferredNotesByContract(contractAddress: AztecAddress): Promise<DeferredNoteDao[]> {
-    throw new Error('Method not implemented.');
+    const removed: DeferredNoteDao[] = [];
+    this.deferredNotesTable = this.deferredNotesTable.filter(note => {
+      if (note.contractAddress.equals(contractAddress)) {
+        removed.push(note);
+        return false;
+      }
+      return true;
+    });
+    return Promise.resolve(removed);
   }
 
   public addCapsule(capsule: Fr[]): Promise<void> {

--- a/yarn-project/pxe/src/database/memory_db.ts
+++ b/yarn-project/pxe/src/database/memory_db.ts
@@ -17,6 +17,7 @@ import { PxeDatabase } from './pxe_database.js';
  */
 export class MemoryDB extends MemoryContractDatabase implements PxeDatabase {
   private notesTable: NoteDao[] = [];
+
   private treeRoots: Record<MerkleTreeId, Fr> | undefined;
   private globalVariablesHash: Fr | undefined;
   private blockNumber: number | undefined;
@@ -62,6 +63,11 @@ export class MemoryDB extends MemoryContractDatabase implements PxeDatabase {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public getDeferredNotesByContract(contractAddress: AztecAddress): Promise<DeferredNoteDao[]> {
+    throw new Error('Method not implemented.');
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public removeDeferredNotesByContract(contractAddress: AztecAddress): Promise<DeferredNoteDao[]> {
     throw new Error('Method not implemented.');
   }
 

--- a/yarn-project/pxe/src/database/memory_db.ts
+++ b/yarn-project/pxe/src/database/memory_db.ts
@@ -60,6 +60,11 @@ export class MemoryDB extends MemoryContractDatabase implements PxeDatabase {
     throw new Error('Method not implemented.');
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public getDeferredNotesByContract(contractAddress: AztecAddress): Promise<DeferredNoteDao[]> {
+    throw new Error('Method not implemented.');
+  }
+
   public addCapsule(capsule: Fr[]): Promise<void> {
     this.capsuleStack.push(capsule);
     return Promise.resolve();

--- a/yarn-project/pxe/src/database/note_dao.ts
+++ b/yarn-project/pxe/src/database/note_dao.ts
@@ -1,3 +1,4 @@
+import { NoteData } from '@aztec/acir-simulator';
 import { AztecAddress, Fr, Point, PublicKey } from '@aztec/circuits.js';
 import { toBigIntBE, toBufferBE } from '@aztec/foundation/bigint-buffer';
 import { BufferReader, Note, TxHash } from '@aztec/types';
@@ -5,7 +6,7 @@ import { BufferReader, Note, TxHash } from '@aztec/types';
 /**
  * A note with contextual data.
  */
-export class NoteDao {
+export class NoteDao implements NoteData {
   constructor(
     /** The note as emitted from the Noir contract. */
     public note: Note,

--- a/yarn-project/pxe/src/database/pxe_database.ts
+++ b/yarn-project/pxe/src/database/pxe_database.ts
@@ -74,6 +74,12 @@ export interface PxeDatabase extends ContractDatabase {
   getDeferredNotesByContract(contractAddress: AztecAddress): Promise<DeferredNoteDao[]>;
 
   /**
+   * Remove deferred notes for a given contract address.
+   * @param contractAddress - The contract address to remove the deferred notes for.
+   */
+  removeDeferredNotesByContract(contractAddress: AztecAddress): Promise<DeferredNoteDao[]>;
+
+  /**
    * Remove nullified notes associated with the given account and nullifiers.
    *
    * @param nullifiers - An array of Fr instances representing nullifiers to be matched.

--- a/yarn-project/pxe/src/database/pxe_database.ts
+++ b/yarn-project/pxe/src/database/pxe_database.ts
@@ -76,6 +76,7 @@ export interface PxeDatabase extends ContractDatabase {
   /**
    * Remove deferred notes for a given contract address.
    * @param contractAddress - The contract address to remove the deferred notes for.
+   * @returns an array of the removed deferred notes
    */
   removeDeferredNotesByContract(contractAddress: AztecAddress): Promise<DeferredNoteDao[]>;
 

--- a/yarn-project/pxe/src/database/pxe_database.ts
+++ b/yarn-project/pxe/src/database/pxe_database.ts
@@ -3,6 +3,7 @@ import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
 import { ContractDatabase, MerkleTreeId, NoteFilter } from '@aztec/types';
 
+import { DeferredNoteDao } from './deferred_note_dao.js';
 import { NoteDao } from './note_dao.js';
 
 /**
@@ -59,6 +60,12 @@ export interface PxeDatabase extends ContractDatabase {
    * @param notes - An array of notes.
    */
   addNotes(notes: NoteDao[]): Promise<void>;
+
+  /**
+   * Add notes to the database that are intended for us, but we don't yet have the contract.
+   * @param deferredNotes - An array of deferred notes.
+   */
+  addDeferredNotes(deferredNotes: DeferredNoteDao[]): Promise<void>;
 
   /**
    * Remove nullified notes associated with the given account and nullifiers.

--- a/yarn-project/pxe/src/database/pxe_database.ts
+++ b/yarn-project/pxe/src/database/pxe_database.ts
@@ -68,6 +68,12 @@ export interface PxeDatabase extends ContractDatabase {
   addDeferredNotes(deferredNotes: DeferredNoteDao[]): Promise<void>;
 
   /**
+   * Get deferred notes for a given contract address.
+   * @param contractAddress - The contract address to get the deferred notes for.
+   */
+  getDeferredNotesByContract(contractAddress: AztecAddress): Promise<DeferredNoteDao[]>;
+
+  /**
    * Remove nullified notes associated with the given account and nullifiers.
    *
    * @param nullifiers - An array of Fr instances representing nullifiers to be matched.

--- a/yarn-project/pxe/src/note_processor/produce_note_dao.ts
+++ b/yarn-project/pxe/src/note_processor/produce_note_dao.ts
@@ -1,0 +1,131 @@
+import { AcirSimulator } from '@aztec/acir-simulator';
+import { Fr, PublicKey } from '@aztec/circuits.js';
+import { computeCommitmentNonce, siloNullifier } from '@aztec/circuits.js/abis';
+import { L1NotePayload, TxHash } from '@aztec/types';
+
+import { NoteDao } from '../database/note_dao.js';
+
+/**
+ * Decodes a note from a transaction that we know was intended for us.
+ * Throws if we do not yet have the contract corresponding to the note in our database.
+ * Accepts a set of excluded indices, which are indices that have been assigned a note in the same tx.
+ * Inserts the index of the note into the excludedIndices set if the note is successfully decoded.
+ *
+ * @param publicKey - The public counterpart to the private key to be used in note decryption.
+ * @param payload - An instance of l1NotePayload.
+ * @param txHash - The hash of the transaction that created the note.
+ * @param txNullifier - The first nullifier emitted by the transaction.
+ * @param newCommitments - New commitments in this transaction, one of which belongs to this note.
+ * @param dataStartIndexForTx - The next available leaf index for the note hash tree for this transaction.
+ * @param excludedIndices - Indices that have been assigned a note in the same tx. Notes in a tx can have the same l1NotePayload, we need to find a different index for each replicate.
+ * @param simulator - An instance of AcirSimulator.
+ * @returns an instance of NoteDao, or throws. inserts the index of the note into the excludedIndices set.
+ */
+export async function produceNoteDao(
+  simulator: AcirSimulator,
+  publicKey: PublicKey,
+  payload: L1NotePayload,
+  txHash: TxHash,
+  txNullifier: Fr,
+  newCommitments: Fr[],
+  dataStartIndexForTx: number,
+  excludedIndices: Set<number>,
+): Promise<NoteDao> {
+  const { commitmentIndex, nonce, innerNoteHash, siloedNullifier } = await findNoteIndexAndNullifier(
+    simulator,
+    newCommitments,
+    txNullifier,
+    payload,
+    excludedIndices,
+  );
+  const index = BigInt(dataStartIndexForTx + commitmentIndex);
+  excludedIndices?.add(commitmentIndex);
+  return new NoteDao(
+    payload.note,
+    payload.contractAddress,
+    payload.storageSlot,
+    txHash,
+    nonce,
+    innerNoteHash,
+    siloedNullifier,
+    index,
+    publicKey,
+  );
+}
+
+/**
+ * Find the index of the note in the note hash tree by computing the note hash with different nonce and see which
+ * commitment for the current tx matches this value.
+ * Compute a nullifier for a given l1NotePayload.
+ * The nullifier is calculated using the private key of the account,
+ * contract address, and the note associated with the l1NotePayload.
+ * This method assists in identifying spent commitments in the private state.
+ * @param commitments - Commitments in the tx. One of them should be the note's commitment.
+ * @param firstNullifier - First nullifier in the tx.
+ * @param l1NotePayload - An instance of l1NotePayload.
+ * @param excludedIndices - Indices that have been assigned a note in the same tx. Notes in a tx can have the same
+ * l1NotePayload. We need to find a different index for each replicate.
+ * @returns Information for a decrypted note, including the index of its commitment, nonce, inner note
+ * hash, and the siloed nullifier. Throw if cannot find the nonce for the note.
+ */
+async function findNoteIndexAndNullifier(
+  simulator: AcirSimulator,
+  commitments: Fr[],
+  firstNullifier: Fr,
+  { contractAddress, storageSlot, note }: L1NotePayload,
+  excludedIndices: Set<number>,
+) {
+  let commitmentIndex = 0;
+  let nonce: Fr | undefined;
+  let innerNoteHash: Fr | undefined;
+  let siloedNoteHash: Fr | undefined;
+  let uniqueSiloedNoteHash: Fr | undefined;
+  let innerNullifier: Fr | undefined;
+  for (; commitmentIndex < commitments.length; ++commitmentIndex) {
+    if (excludedIndices.has(commitmentIndex)) {
+      continue;
+    }
+
+    const commitment = commitments[commitmentIndex];
+    if (commitment.equals(Fr.ZERO)) {
+      break;
+    }
+
+    const expectedNonce = computeCommitmentNonce(firstNullifier, commitmentIndex);
+    ({ innerNoteHash, siloedNoteHash, uniqueSiloedNoteHash, innerNullifier } =
+      await simulator.computeNoteHashAndNullifier(contractAddress, expectedNonce, storageSlot, note));
+    if (commitment.equals(uniqueSiloedNoteHash)) {
+      nonce = expectedNonce;
+      break;
+    }
+  }
+
+  if (!nonce) {
+    let errorString;
+    if (siloedNoteHash == undefined) {
+      errorString = 'Cannot find a matching commitment for the note.';
+    } else {
+      errorString = `We decrypted a log, but couldn't find a corresponding note in the tree.
+This might be because the note was nullified in the same tx which created it.
+In that case, everything is fine. To check whether this is the case, look back through
+the logs for a notification
+'important: chopped commitment for siloed inner hash note
+${siloedNoteHash.toString()}'.
+If you can see that notification. Everything's fine.
+If that's not the case, and you can't find such a notification, something has gone wrong.
+There could be a problem with the way you've defined a custom note, or with the way you're
+serializing / deserializing / hashing / encrypting / decrypting that note.
+Please see the following github issue to track an improvement that we're working on:
+https://github.com/AztecProtocol/aztec-packages/issues/1641`;
+    }
+
+    throw new Error(errorString);
+  }
+
+  return {
+    commitmentIndex,
+    nonce,
+    innerNoteHash: innerNoteHash!,
+    siloedNullifier: siloNullifier(contractAddress, innerNullifier!),
+  };
+}

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -99,11 +99,9 @@ export class PXEService implements PXE {
    */
   public async start() {
     const { l2BlockPollingIntervalMS } = this.config;
-    this.synchronizer.start(1, l2BlockPollingIntervalMS);
     this.jobQueue.start();
     this.log.info('Started Job Queue');
-    await this.jobQueue.syncPoint();
-    this.log.info('Synced Job Queue');
+    await this.synchronizer.start(1, l2BlockPollingIntervalMS);
     await this.restoreNoteProcessors();
     const info = await this.getNodeInfo();
     this.log.info(`Started PXE connected to chain ${info.chainId} version ${info.protocolVersion}`);

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -88,8 +88,9 @@ export class PXEService implements PXE {
     this.synchronizer = new Synchronizer(node, db, this.jobQueue, logSuffix);
     this.contractDataOracle = new ContractDataOracle(db, node);
     this.simulator = getAcirSimulator(db, node, keyStore, this.contractDataOracle);
-
     this.nodeVersion = getPackageInfo().version;
+
+    this.jobQueue.start();
   }
 
   /**
@@ -99,8 +100,6 @@ export class PXEService implements PXE {
    */
   public async start() {
     const { l2BlockPollingIntervalMS } = this.config;
-    this.jobQueue.start();
-    this.log.info('Started Job Queue');
     await this.synchronizer.start(1, l2BlockPollingIntervalMS);
     await this.restoreNoteProcessors();
     const info = await this.getNodeInfo();

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -57,7 +57,6 @@ import { TxPXEProcessingStats } from '@aztec/types/stats';
 
 import { PXEServiceConfig, getPackageInfo } from '../config/index.js';
 import { ContractDataOracle } from '../contract_data_oracle/index.js';
-import { DeferredNoteDao } from '../database/deferred_note_dao.js';
 import { PxeDatabase } from '../database/index.js';
 import { NoteDao } from '../database/note_dao.js';
 import { KernelOracle } from '../kernel_oracle/index.js';
@@ -210,7 +209,7 @@ export class PXEService implements PXE {
       const portalInfo =
         contract.portalContract && !contract.portalContract.isZero() ? ` with portal ${contract.portalContract}` : '';
       this.log.info(`Added contract ${contract.name} at ${contractAztecAddress}${portalInfo}`);
-      await this.synchronizer.retryDeferredNotesForContract(contractAztecAddress);
+      await this.synchronizer.reprocessDeferredNotesForContract(contractAztecAddress);
     }
   }
 
@@ -489,10 +488,6 @@ export class PXEService implements PXE {
       l1ContractAddresses: contractAddresses,
     };
     return nodeInfo;
-  }
-
-  #retryDeferredNote(deferredNote: DeferredNoteDao) {
-    this.synchronizer;
   }
 
   /**

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -339,7 +339,11 @@ export class Synchronizer {
    * Retry decoding any deferred notes for the specified contract address.
    * @param contractAddress - the contract address that has just been added
    */
-  public async reprocessDeferredNotesForContract(contractAddress: AztecAddress) {
+  public reprocessDeferredNotesForContract(contractAddress: AztecAddress): Promise<void> {
+    return this.jobQueue.put(() => this.#reprocessDeferredNotesForContract(contractAddress));
+  }
+
+  async #reprocessDeferredNotesForContract(contractAddress: AztecAddress): Promise<void> {
     const deferredNotes = await this.db.getDeferredNotesByContract(contractAddress);
 
     // group deferred notes by txHash to properly deal with possible duplicates

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -106,8 +106,7 @@ export class Synchronizer {
   protected async work(limit = 1): Promise<boolean> {
     const from = this.getSynchedBlockNumber() + 1;
     try {
-      // TODO: is getting logs redundant? see getBlocks within lmdb_archiver_store.ts
-      // It seems that getBlocks already returns the logs.
+      // Possibly improve after https://github.com/AztecProtocol/aztec-packages/issues/3870
       let encryptedLogs = await this.node.getLogs(from, limit, LogType.ENCRYPTED);
       if (!encryptedLogs.length) {
         return false;

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -95,6 +95,8 @@ export class Synchronizer {
   protected async work(limit = 1): Promise<boolean> {
     const from = this.getSynchedBlockNumber() + 1;
     try {
+      // TODO: is getting logs redundant? see getBlocks within lmdb_archiver_store.ts
+      // It seems that getBlocks already returns the logs.
       let encryptedLogs = await this.node.getLogs(from, limit, LogType.ENCRYPTED);
       if (!encryptedLogs.length) {
         return false;

--- a/yarn-project/types/src/contract_dao.ts
+++ b/yarn-project/types/src/contract_dao.ts
@@ -1,5 +1,13 @@
 import { CompleteAddress, ContractFunctionDao } from '@aztec/circuits.js';
-import { ContractArtifact, DebugMetadata, EventAbi, FunctionSelector, FunctionType } from '@aztec/foundation/abi';
+import {
+  ContractArtifact,
+  DebugMetadata,
+  EventAbi,
+  FunctionDebugMetadata,
+  FunctionSelector,
+  FunctionType,
+  getFunctionDebugMetadata,
+} from '@aztec/foundation/abi';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { prefixBufferWithLength } from '@aztec/foundation/serialize';
 
@@ -40,6 +48,18 @@ export class ContractDao implements ContractArtifact {
 
   get debug(): DebugMetadata | undefined {
     return this.contractArtifact.debug;
+  }
+
+  getFunctionArtifact(selector: FunctionSelector): ContractFunctionDao | undefined {
+    return this.functions.find(f => f.selector.equals(selector));
+  }
+
+  getFunctionArtifactByName(functionName: string): ContractFunctionDao | undefined {
+    return this.functions.find(f => f.name === functionName);
+  }
+
+  getFunctionDebugMetadataByName(functionName: string): FunctionDebugMetadata | undefined {
+    return getFunctionDebugMetadata(this, functionName);
   }
 
   toBuffer(): Buffer {

--- a/yarn-project/types/src/stats/stats.ts
+++ b/yarn-project/types/src/stats/stats.ts
@@ -108,6 +108,8 @@ export type NoteProcessorCaughtUpStats = {
 export type NoteProcessorStats = {
   /** How many notes have been seen and trial-decrypted. */
   seen: number;
+  /** How many notes had decryption deferred due to a missing contract */
+  deferred: number;
   /** How many notes were successfully decrypted. */
   decrypted: number;
   /** How many notes failed processing. */

--- a/yarn-project/types/src/tx/tx_hash.ts
+++ b/yarn-project/types/src/tx/tx_hash.ts
@@ -1,4 +1,4 @@
-import { deserializeBigInt, serializeBigInt } from '@aztec/foundation/serialize';
+import { BufferReader, deserializeBigInt, serializeBigInt } from '@aztec/foundation/serialize';
 
 /**
  * A class representing hash of Aztec transaction.
@@ -23,6 +23,24 @@ export class TxHash {
     if (buffer.length !== TxHash.SIZE) {
       throw new Error(`Expected buffer to have length ${TxHash.SIZE} but was ${buffer.length}`);
     }
+  }
+
+  /**
+   * Returns the raw buffer of the hash.
+   * @returns The buffer containing the hash.
+   */
+  public toBuffer() {
+    return this.buffer;
+  }
+
+  /**
+   * Creates a TxHash from a buffer.
+   * @param buffer - The buffer to create from.
+   * @returns A new TxHash object.
+   */
+  public static fromBuffer(buffer: Buffer | BufferReader) {
+    const reader = BufferReader.asReader(buffer);
+    return new TxHash(reader.readBytes(TxHash.SIZE));
   }
 
   /**


### PR DESCRIPTION
Add notion of a Deferred Note: a note that we can *decrypt*, but not decode because we don't have the contract artifact in our PXE database. 

We hang on to these deferred notes in a new store in our PXE database, and reprocess them when their contract is made available. 

When we reprocess and successfully decode, we also need to search if we have already nullified the newly decoded note.
