### PR TITLE
fix: correct type errors in `noir-contracts` output

### DIFF
--- a/yarn-project/noir-compiler/src/contract-interface-gen/contractTypescript.ts
+++ b/yarn-project/noir-compiler/src/contract-interface-gen/contractTypescript.ts
@@ -156,7 +156,7 @@ function generateArtifactGetter(name: string) {
 function generateAbiStatement(name: string, artifactImportPath: string) {
   const stmts = [
     `import ${name}ContractArtifactJson from '${artifactImportPath}' assert { type: 'json' };`,
-    `export const ${name}ContractArtifact = ${name}ContractArtifactJson as ContractArtifact;`,
+    `export const ${name}ContractArtifact = ${name}ContractArtifactJson as unknown as ContractArtifact;`,
   ];
   return stmts.join('\n');
 }


### PR DESCRIPTION
It's currently not possible to bootstrap the repository due to type errors in `noir-contract` due to how loading from json interacts with TS type system. This PR silences these warnings so that we can bootstrap again.
