### PR TITLE
fix: reinstate Ultra arith rec verifier test

### DIFF
--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -263,7 +263,7 @@ class Ultra;
 class ECCVM;
 class GoblinUltra;
 template <typename BuilderType> class UltraRecursive_;
-class GoblinUltraRecursive;
+template <typename BuilderType> class GoblinUltraRecursive_;
 } // namespace proof_system::honk::flavor
 
 // Forward declare plonk flavors
@@ -293,18 +293,23 @@ concept IsUltraFlavor = IsAnyOf<T, honk::flavor::Ultra, honk::flavor::GoblinUltr
 
 template <typename T> 
 concept IsGoblinFlavor = IsAnyOf<T, honk::flavor::GoblinUltra,
-                                    honk::flavor::GoblinUltraRecursive>;
+                                    honk::flavor::GoblinUltraRecursive_<UltraCircuitBuilder>,
+                                    honk::flavor::GoblinUltraRecursive_<GoblinUltraCircuitBuilder>>;
 
 template <typename T> 
 concept IsRecursiveFlavor = IsAnyOf<T, honk::flavor::UltraRecursive_<UltraCircuitBuilder>, 
                                        honk::flavor::UltraRecursive_<GoblinUltraCircuitBuilder>, 
-                                       honk::flavor::GoblinUltraRecursive>;
+                                       honk::flavor::GoblinUltraRecursive_<UltraCircuitBuilder>,
+                                       honk::flavor::GoblinUltraRecursive_<GoblinUltraCircuitBuilder>>;
 
 template <typename T> concept IsGrumpkinFlavor = IsAnyOf<T, honk::flavor::ECCVM>;
 
-template <typename T> concept IsFoldingFlavor = IsAnyOf<T, honk::flavor::Ultra, honk::flavor::GoblinUltra,honk::flavor::UltraRecursive_<UltraCircuitBuilder>, 
-                                       honk::flavor::UltraRecursive_<GoblinUltraCircuitBuilder>, 
-                                       honk::flavor::GoblinUltraRecursive>;
+template <typename T> concept IsFoldingFlavor = IsAnyOf<T, honk::flavor::Ultra, 
+                                                           honk::flavor::GoblinUltra, 
+                                                           honk::flavor::UltraRecursive_<UltraCircuitBuilder>, 
+                                                           honk::flavor::UltraRecursive_<GoblinUltraCircuitBuilder>, 
+                                                           honk::flavor::GoblinUltraRecursive_<UltraCircuitBuilder>, 
+                                                           honk::flavor::GoblinUltraRecursive_<GoblinUltraCircuitBuilder>>;
 
 template <typename T> concept UltraFlavor = IsAnyOf<T, honk::flavor::Ultra, honk::flavor::GoblinUltra>;
 

--- a/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra_recursive.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra_recursive.hpp
@@ -38,9 +38,9 @@ namespace proof_system::honk::flavor {
  *
  * @tparam BuilderType Determines the arithmetization of the verifier circuit defined based on this flavor.
  */
-class GoblinUltraRecursive {
+template <typename BuilderType> class GoblinUltraRecursive_ {
   public:
-    using CircuitBuilder = GoblinUltraCircuitBuilder;
+    using CircuitBuilder = BuilderType; // Determines arithmetization of circuit instantiated with this flavor
     using Curve = plonk::stdlib::bn254<CircuitBuilder>;
     using GroupElement = Curve::Element;
     using FF = Curve::ScalarField;

--- a/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra_recursive.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra_recursive.hpp
@@ -42,10 +42,10 @@ template <typename BuilderType> class GoblinUltraRecursive_ {
   public:
     using CircuitBuilder = BuilderType; // Determines arithmetization of circuit instantiated with this flavor
     using Curve = plonk::stdlib::bn254<CircuitBuilder>;
-    using GroupElement = Curve::Element;
-    using FF = Curve::ScalarField;
-    using Commitment = Curve::Element;
-    using CommitmentHandle = Curve::Element;
+    using GroupElement = typename Curve::Element;
+    using FF = typename Curve::ScalarField;
+    using Commitment = typename Curve::Element;
+    using CommitmentHandle = typename Curve::Element;
     using NativeVerificationKey = flavor::GoblinUltra::VerificationKey;
 
     // Note(luke): Eventually this may not be needed at all

--- a/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
@@ -18,8 +18,8 @@ class GoblinMockCircuits {
     using OpQueue = proof_system::ECCOpQueue;
     using GoblinUltraBuilder = proof_system::GoblinUltraCircuitBuilder;
     using Flavor = proof_system::honk::flavor::GoblinUltra;
-    using RecursiveFlavor = proof_system::honk::flavor::GoblinUltraRecursive;
-    using RecursiveVerifier = proof_system::plonk::stdlib::recursion::honk::GoblinRecursiveVerifier;
+    using RecursiveFlavor = proof_system::honk::flavor::GoblinUltraRecursive_<GoblinUltraBuilder>;
+    using RecursiveVerifier = proof_system::plonk::stdlib::recursion::honk::UltraRecursiveVerifier_<RecursiveFlavor>;
     using KernelInput = Goblin::AccumulationOutput;
     static constexpr size_t NUM_OP_QUEUE_COLUMNS = Flavor::NUM_WIRES;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/goblin_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/goblin_verifier.test.cpp
@@ -33,9 +33,9 @@ template <typename BuilderType> class GoblinRecursiveVerifierTest : public testi
     using InnerFF = InnerFlavor::FF;
 
     // Types for recursive verifier circuit
-    using RecursiveFlavor = ::proof_system::honk::flavor::GoblinUltraRecursive;
-    using RecursiveVerifier = UltraRecursiveVerifier_<RecursiveFlavor>;
     using OuterBuilder = BuilderType;
+    using RecursiveFlavor = ::proof_system::honk::flavor::GoblinUltraRecursive_<OuterBuilder>;
+    using RecursiveVerifier = UltraRecursiveVerifier_<RecursiveFlavor>;
     using VerificationKey = typename RecursiveVerifier::VerificationKey;
 
     // Helper for getting composer for prover/verifier of recursive (outer) circuit
@@ -255,7 +255,7 @@ template <typename BuilderType> class GoblinRecursiveVerifierTest : public testi
 };
 
 // Run the recursive verifier tests with conventional Ultra builder and Goblin builder
-using BuilderTypes = testing::Types<GoblinUltraCircuitBuilder>;
+using BuilderTypes = testing::Types<UltraCircuitBuilder, GoblinUltraCircuitBuilder>;
 
 TYPED_TEST_SUITE(GoblinRecursiveVerifierTest, BuilderTypes);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/ultra_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/ultra_recursive_verifier.cpp
@@ -127,5 +127,6 @@ std::array<typename Flavor::GroupElement, 2> UltraRecursiveVerifier_<Flavor>::ve
 
 template class UltraRecursiveVerifier_<proof_system::honk::flavor::UltraRecursive_<UltraCircuitBuilder>>;
 template class UltraRecursiveVerifier_<proof_system::honk::flavor::UltraRecursive_<GoblinUltraCircuitBuilder>>;
-template class UltraRecursiveVerifier_<proof_system::honk::flavor::GoblinUltraRecursive>;
+template class UltraRecursiveVerifier_<proof_system::honk::flavor::GoblinUltraRecursive_<UltraCircuitBuilder>>;
+template class UltraRecursiveVerifier_<proof_system::honk::flavor::GoblinUltraRecursive_<GoblinUltraCircuitBuilder>>;
 } // namespace proof_system::plonk::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/ultra_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/ultra_recursive_verifier.hpp
@@ -40,5 +40,4 @@ template <typename Flavor> class UltraRecursiveVerifier_ {
 // Instance declarations for Ultra and Goblin-Ultra verifier circuits with both conventional Ultra and Goblin-Ultra
 // arithmetization.
 using UltraRecursiveVerifier = UltraRecursiveVerifier_<UltraCircuitBuilder>;
-using GoblinRecursiveVerifier = UltraRecursiveVerifier_<proof_system::honk::flavor::GoblinUltraRecursive>;
 } // namespace proof_system::plonk::stdlib::recursion::honk


### PR DESCRIPTION
Reinstate the Builder template param on the GoblinUltraRecursive flavor. This allows for the aithmetization of a GUH recursive verifier circuit to be GU or U - both of which will be needed in the aztec architecture.

