### PR TITLE
fix: Start witness of ACIR generated by Noir start at zero not one

### DIFF
--- a/noir/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/noir/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -138,7 +138,7 @@ impl AcirContext {
     /// Adds a Variable to the context, whose exact value is resolved at
     /// runtime.
     pub(crate) fn add_variable(&mut self) -> AcirVar {
-        let var_index = self.acir_ir.next_witness_index();
+        let var_index = self.acir_ir.get_current_witness_and_update();
 
         let var_data = AcirVarData::Witness(var_index);
 
@@ -1347,7 +1347,7 @@ impl AcirContext {
         let mut b_outputs = Vec::new();
         let outputs_var = vecmap(outputs, |output| match output {
             AcirType::NumericType(_) => {
-                let witness_index = self.acir_ir.next_witness_index();
+                let witness_index = self.acir_ir.get_current_witness_and_update();
                 b_outputs.push(BrilligOutputs::Simple(witness_index));
                 let var = self.add_data(AcirVarData::Witness(witness_index));
                 AcirValue::Var(var, output.clone())
@@ -1412,7 +1412,7 @@ impl AcirContext {
                         array_values.push_back(nested_acir_value);
                     }
                     AcirType::NumericType(_) => {
-                        let witness_index = self.acir_ir.next_witness_index();
+                        let witness_index = self.acir_ir.get_current_witness_and_update();
                         witnesses.push(witness_index);
                         let var = self.add_data(AcirVarData::Witness(witness_index));
                         array_values.push_back(AcirValue::Var(var, element_type.clone()));
@@ -1497,7 +1497,7 @@ impl AcirContext {
         // Convert the inputs into expressions
         let inputs_expr = try_vecmap(inputs, |input| self.var_to_expression(input))?;
         // Generate output witnesses
-        let outputs_witness = vecmap(0..len, |_| self.acir_ir.next_witness_index());
+        let outputs_witness = vecmap(0..len, |_| self.acir_ir.get_current_witness_and_update());
         let output_expr =
             vecmap(&outputs_witness, |witness_index| Expression::from(*witness_index));
         let outputs_var = vecmap(&outputs_witness, |witness_index| {

--- a/noir/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/noir/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -1290,6 +1290,7 @@ impl AcirContext {
         inputs: Vec<Witness>,
         warnings: Vec<SsaReport>,
     ) -> GeneratedAcir {
+        self.acir_ir.current_witness_index -= 1;
         self.acir_ir.input_witnesses = inputs;
         self.acir_ir.warnings = warnings;
         self.acir_ir

--- a/noir/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
+++ b/noir/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
@@ -78,9 +78,9 @@ impl GeneratedAcir {
     /// Returns the current witness index and updates it 
     /// so that we have a fresh witness the next time this method is called
     pub(crate) fn get_current_witness_and_update(&mut self) -> Witness {
-        let next_witness_index = Witness(self.current_witness_index);
+        let current_witness_index = Witness(self.current_witness_index);
         self.current_witness_index += 1;
-        next_witness_index
+        current_witness_index
     }
 
     /// Converts [`Expression`] `expr` into a [`Witness`].

--- a/noir/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/sort.rs
+++ b/noir/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/sort.rs
@@ -25,7 +25,7 @@ impl GeneratedAcir {
         // witness for the input switches
         let mut conf = iter_extended::vecmap(0..n1, |i| {
             if generate_witness {
-                self.next_witness_index()
+                self.get_current_witness_and_update()
             } else {
                 bits[i]
             }
@@ -63,7 +63,7 @@ impl GeneratedAcir {
         let (w2, b2) = self.permutation_layer(&in_sub2, bits2, generate_witness)?;
         // apply the output switches
         for i in 0..(n - 1) / 2 {
-            let c = if generate_witness { self.next_witness_index() } else { bits[n1 + i] };
+            let c = if generate_witness { self.get_current_witness_and_update() } else { bits[n1 + i] };
             conf.push(c);
             let intermediate = self.mul_with_witness(&Expression::from(c), &(&b2[i] - &b1[i]));
             out_expr.push(&intermediate + &b1[i]);

--- a/noir/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/noir/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -294,7 +294,7 @@ impl Context {
         dfg: &DataFlowGraph,
     ) -> Result<Vec<Witness>, RuntimeError> {
         // The first witness (if any) is the next one
-        let start_witness = self.acir_context.current_witness_index().0 + 1;
+        let start_witness = self.acir_context.current_witness_index().0;
         for param_id in params {
             let typ = dfg.type_of_value(*param_id);
             let value = self.convert_ssa_block_param(&typ)?;


### PR DESCRIPTION
[Inside of Noir](https://github.com/AztecProtocol/aztec-packages/blob/217de090b15feb38d5cccfb21867cfd94edf0061/noir/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs#L297) we have a hardcoded +1 that is a remaining leakage from how we used to convert ACIR to a barretenberg constraint system. 

This PR does the necessary changes to remove the `+1`. I also had to change how we update the index when generating ACIR. Rather than incrementing the index and returning the incremented index, `next_witness_index()` is now `get_current_witness_and_update()` which only updates the witness index after returning the current witness index.

# Checklist:
Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
- [X] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
- [X] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
- [X] Every change is related to the PR description.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
