### PR TITLE
feat!: Remove opcode supported from the backend

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -395,9 +395,7 @@ void acvm_info(const std::string& output_path)
     "language": {
         "name" : "PLONK-CSAT",
         "width" : 3
-    },
-    "opcodes_supported" : ["arithmetic", "directive", "brillig", "memory_init", "memory_op"],
-    "black_box_functions_supported" : ["and", "xor", "range", "sha256", "blake2s", "keccak256", "keccak_f1600", "schnorr_verify", "pedersen", "pedersen_hash", "ecdsa_secp256k1", "ecdsa_secp256r1", "fixed_base_scalar_mul", "recursive_aggregation"]
+    }
     })";
 
     size_t length = strlen(jsonData);

--- a/noir/tooling/backend_interface/src/cli/info.rs
+++ b/noir/tooling/backend_interface/src/cli/info.rs
@@ -13,12 +13,6 @@ pub(crate) struct InfoCommand {
 #[derive(Deserialize)]
 struct InfoResponse {
     language: LanguageResponse,
-    #[allow(dead_code)]
-    #[deprecated(note = "This field is deprecated and will be removed in the future")]
-    opcodes_supported: Vec<String>,
-    #[allow(dead_code)]
-    #[deprecated(note = "This field is deprecated and will be removed in the future")]
-    black_box_functions_supported: Vec<String>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Removes the opcodes supported from the info command because it is not used by Noir anymore,