### PR TITLE
chore: Do not fail jq dependencies check for package with no deps

### DIFF
--- a/build-system/scripts/deploy_npm
+++ b/build-system/scripts/deploy_npm
@@ -49,7 +49,7 @@ jq --arg v $VERSION '.version = $v' package.json >$TMP && mv $TMP package.json
 
 if [ -z "$STANDALONE" ]; then
   # Update each dependent @aztec package version in package.json.
-  for PKG in $(jq --raw-output ".dependencies | keys[] | select(contains(\"@aztec/\"))" package.json); do
+  for PKG in $(jq --raw-output ".dependencies | try keys[] | select(contains(\"@aztec/\"))" package.json); do
     jq --arg v $VERSION ".dependencies[\"$PKG\"] = \$v" package.json >$TMP && mv $TMP package.json
   done
 fi
@@ -62,9 +62,11 @@ else
   # Check if version exists
   if npm view "$PACKAGE_NAME@$VERSION" version >/dev/null 2>&1; then
     # Tag the existing version
+    echo "Tagging existing version $VERSION with $TAG"
     npm dist-tag add $PACKAGE_NAME@$VERSION $TAG
   else
     # Publish new version
+    echo "Publishing new version $VERSION with $TAG"
     npm publish $TAG_ARG --access public
   fi
 fi


### PR DESCRIPTION
The `deploy_npm` script would show a jq error when trying to fetch dependencies for a package with no dependencies (eg [here](https://app.circleci.com/pipelines/github/AztecProtocol/aztec-packages/20218/workflows/7bd2eb23-a437-4ee6-8218-d943ce6dc04c/jobs/912425?invite=true#step-107-756_55)). This prevents jq from failing that check and just returns an empty list.