### PR TITLE
refactor: standardise toml parsers

### DIFF
--- a/yarn-project/cli/package.json
+++ b/yarn-project/cli/package.json
@@ -44,7 +44,6 @@
     "@aztec/types": "workspace:^",
     "@iarna/toml": "^2.2.5",
     "@libp2p/peer-id-factory": "^3.0.4",
-    "@ltd/j-toml": "^1.38.0",
     "commander": "^9.0.0",
     "jszip": "^3.10.1",
     "lodash.startcase": "^4.4.0",

--- a/yarn-project/cli/src/cmds/unbox.ts
+++ b/yarn-project/cli/src/cmds/unbox.ts
@@ -1,10 +1,12 @@
 import { LogFn } from '@aztec/foundation/log';
 
-import { parse, stringify } from '@iarna/toml';
+import { parse } from '@iarna/toml';
 import { execSync } from 'child_process';
 import { appendFileSync, cpSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
+
+import { prettyPrintNargoToml } from '../utils.js';
 
 const resolutions: { [key: string]: string } = {
   '@aztec/accounts': 'portal:.aztec-packages/yarn-project/accounts',
@@ -127,7 +129,7 @@ function nargoTomlUpdateToGithubDeps(path: string, cliVersion: string) {
     }
   });
 
-  const updatedToml = stringify(content);
+  const updatedToml = prettyPrintNargoToml(content);
 
   writeFileSync(path, updatedToml, 'utf-8');
 }
@@ -148,7 +150,7 @@ function nargoTomlUpdateToDevPath(path: string) {
     }
   });
 
-  const updatedToml = stringify(content);
+  const updatedToml = prettyPrintNargoToml(content);
 
   writeFileSync(path, updatedToml, 'utf-8');
 }

--- a/yarn-project/cli/src/update/noir.ts
+++ b/yarn-project/cli/src/update/noir.ts
@@ -1,12 +1,11 @@
 import { LogFn } from '@aztec/foundation/log';
-import { NoirPackageConfig, parseNoirPackageConfig } from '@aztec/foundation/noir';
+import { parseNoirPackageConfig } from '@aztec/foundation/noir';
 
-import TOML from '@ltd/j-toml';
+import TOML from '@iarna/toml';
 import { readFile } from 'fs/promises';
-import { EOL } from 'os';
 import { join, relative, resolve } from 'path';
 
-import { atomicUpdateFile } from '../utils.js';
+import { atomicUpdateFile, prettyPrintNargoToml } from '../utils.js';
 import { DependencyChanges } from './common.js';
 
 /**
@@ -49,31 +48,9 @@ export async function updateAztecNr(contractPath: string, tag: string, log: LogF
   }
 
   if (changes.dependencies.length > 0) {
-    const contents = prettyPrintTOML(packageConfig);
+    const contents = prettyPrintNargoToml(packageConfig);
     await atomicUpdateFile(configFilepath, contents);
   }
 
   return changes;
-}
-
-/**
- * Pretty prints a NoirPackageConfig to a string
- * @param packageConfig - Nargo.toml contents
- * @returns The Nargo.toml contents as a string
- */
-function prettyPrintTOML(packageConfig: NoirPackageConfig): string {
-  // hint to TOML.stringify how we want the file to look like
-  return TOML.stringify(
-    {
-      package: TOML.Section(packageConfig.package),
-      dependencies: TOML.Section(
-        Object.fromEntries(Object.entries(packageConfig.dependencies).map(([name, dep]) => [name, TOML.inline(dep)])),
-      ),
-    },
-    {
-      indent: 2,
-      newline: EOL as any,
-      newlineAround: 'section',
-    },
-  );
 }

--- a/yarn-project/cli/src/utils.ts
+++ b/yarn-project/cli/src/utils.ts
@@ -3,7 +3,9 @@ import { AztecAddress } from '@aztec/aztec.js/aztec_address';
 import { type L1ContractArtifactsForDeployment } from '@aztec/aztec.js/ethereum';
 import { type PXE } from '@aztec/aztec.js/interfaces/pxe';
 import { DebugLogger, LogFn } from '@aztec/foundation/log';
+import { NoirPackageConfig } from '@aztec/foundation/noir';
 
+import TOML from '@iarna/toml';
 import { CommanderError, InvalidArgumentError } from 'commander';
 import { readFile, rename, writeFile } from 'fs/promises';
 
@@ -204,4 +206,21 @@ export async function atomicUpdateFile(filePath: string, contents: string) {
       throw e;
     }
   }
+}
+
+/**
+ * Pretty prints Nargo.toml contents to a string
+ * @param config - Nargo.toml contents
+ * @returns The Nargo.toml contents as a string
+ */
+export function prettyPrintNargoToml(config: NoirPackageConfig): string {
+  const withoutDependencies = Object.fromEntries(Object.entries(config).filter(([key]) => key !== 'dependencies'));
+
+  const partialToml = TOML.stringify(withoutDependencies);
+  const dependenciesToml = Object.entries(config.dependencies).map(([name, dep]) => {
+    const depToml = TOML.stringify.value(dep);
+    return `${name} = ${depToml}`;
+  });
+
+  return partialToml + '\n[dependencies]\n' + dependenciesToml.join('\n') + '\n';
 }

--- a/yarn-project/noir-compiler/package.json
+++ b/yarn-project/noir-compiler/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@aztec/circuits.js": "workspace:^",
     "@aztec/foundation": "workspace:^",
-    "@ltd/j-toml": "^1.38.0",
+    "@iarna/toml": "^2.2.5",
     "@noir-lang/noir_wasm": "portal:../../noir/packages/noir_wasm",
     "base64-js": "^1.5.1",
     "commander": "^9.0.0",

--- a/yarn-project/noir-compiler/src/compile/noir/package.ts
+++ b/yarn-project/noir-compiler/src/compile/noir/package.ts
@@ -1,6 +1,6 @@
 import { NoirDependencyConfig, NoirPackageConfig, parseNoirPackageConfig } from '@aztec/foundation/noir';
 
-import { parse } from '@ltd/j-toml';
+import { parse } from '@iarna/toml';
 import { join } from 'node:path';
 
 import { FileManager } from './file-manager/file-manager.js';

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -327,7 +327,6 @@ __metadata:
     "@iarna/toml": ^2.2.5
     "@jest/globals": ^29.5.0
     "@libp2p/peer-id-factory": ^3.0.4
-    "@ltd/j-toml": ^1.38.0
     "@types/jest": ^29.5.0
     "@types/lodash.startcase": ^4.4.7
     "@types/node": ^18.7.23
@@ -576,8 +575,8 @@ __metadata:
   dependencies:
     "@aztec/circuits.js": "workspace:^"
     "@aztec/foundation": "workspace:^"
+    "@iarna/toml": ^2.2.5
     "@jest/globals": ^29.5.0
-    "@ltd/j-toml": ^1.38.0
     "@noir-lang/noir_wasm": "portal:../../noir/packages/noir_wasm"
     "@types/fs-extra": ^11.0.1
     "@types/jest": ^29.5.0
@@ -2526,13 +2525,6 @@ __metadata:
   version: 2.9.1
   resolution: "@lmdb/lmdb-win32-x64@npm:2.9.1"
   conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@ltd/j-toml@npm:^1.38.0":
-  version: 1.38.0
-  resolution: "@ltd/j-toml@npm:1.38.0"
-  checksum: 34f5d0ec652e790a7a733f0d3a8d9957d63997bd0efc13a61beb9d772bae75519453884fbc3fd6a2d5fe15674834bdd57ca1824bb1de8f829e5ce195fc5fa3ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR consolidates uses of TOML parsers/stringifiers to `@iarna/toml`.
