### PR TITLE
chore: deploy canary release of bb.js to npm via CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -970,6 +970,11 @@ jobs:
             deploy_dockerhub aztec-faucet
             deploy_dockerhub mainnet-fork
       - run:
+          name: "Release canary to NPM: bb.js"
+          command: |
+            should_release || exit 0
+            deploy_npm bb.js canary
+      - run:
           name: "Release canary to NPM: yarn-project"
           command: |
             should_release || exit 0

--- a/build-system/scripts/check_env
+++ b/build-system/scripts/check_env
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# check that the current system is able to run the build system.
+
+[ -n "${BUILD_SYSTEM_DEBUG:-}" ] && set -x # conditionally trace
+set -eu
+
+# check that our bash version is new enough.
+major_version=${BASH_VERSION%%.*}
+
+# Check if the major version is less than 4
+if [[ $major_version -lt 4 ]]; then
+    echo "Bash version 4 or greater is required."
+    exit 1
+fi

--- a/build-system/scripts/setup_env
+++ b/build-system/scripts/setup_env
@@ -23,6 +23,8 @@ PROJECT=$(cat $ROOT_PATH/PROJECT)
 COMMIT_MESSAGE=$(git log -n 1 --pretty=format:"%s" $COMMIT_HASH)
 PATH=$PATH:$BUILD_SYSTEM_PATH/scripts
 
+check_env
+
 export BRANCH
 
 echo "COMMIT_HASH=$COMMIT_HASH"


### PR DESCRIPTION
This PR releases bb.js npm via CCI under the `canary` tag, while maintaining the release via Github Actions under the `latest` tag. They should be identical. Once we are confident in the release via CCI, we can deploy both `canary` and `latest` from CCI in a followup PR.

Also add check_env script during setup_env to ensure the version of bash is high enough.
