### PR TITLE
docs: streamlined pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,1 @@
-Please provide a paragraph or two giving a summary of the change, including relevant motivation and context.
-
-# Checklist:
-Remove the checklist to signal you've completed it. Enable auto-merge if the PR is ready to merge.
-- [ ] If the pull request requires a cryptography review (e.g. cryptographic algorithm implementations) I have added the 'crypto' tag.
-- [ ] I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
-- [ ] Every change is related to the PR description.
-- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
+Please read [CONTRIBUTING.md](https://github.com/AztecProtocol/aztec-packages/blob/master/CONTRIBUTING.md) for guidelines. Provide a paragraph or two giving a summary of the change, including relevant motivation and context.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,1 @@
-Please read [CONTRIBUTING.md](https://github.com/AztecProtocol/aztec-packages/blob/master/CONTRIBUTING.md) for guidelines. Provide a paragraph or two giving a summary of the change, including relevant motivation and context.
+Please read [CONTRIBUTING.md](https://github.com/AztecProtocol/aztec-packages/blob/master/CONTRIBUTING.md) for guidelines and remove this line.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ When opening the pull request you will be presented with a template and a series
 If you're looking for a good place to start, look for issues labeled ["good first issue"](https://github.com/AztecProtocol/aztec-packages/labels/good%20first%20issue)!
 
 ## Pull request checklist:
+- I've provided a paragraph or two giving a summary of the change in the description, including relevant motivation and context.
 - I've enabled auto-merge if the PR is ready to merge.
 - I have updated the yellow paper when making changes to associated functionality (e.g. outward-facing spec changes).
 - I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,10 @@ Any non-trivial code contribution must be first discussed with the maintainers i
 When opening the pull request you will be presented with a template and a series of instructions. Read through it carefully and follow all the steps. Expect a review and feedback from the maintainers afterward.
 
 If you're looking for a good place to start, look for issues labeled ["good first issue"](https://github.com/AztecProtocol/aztec-packages/labels/good%20first%20issue)!
+
+## Pull request checklist:
+- I've enabled auto-merge if the PR is ready to merge.
+- I have updated the yellow paper when making changes to associated functionality (e.g. outward-facing spec changes).
+- I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
+- Every change is related to the PR description.s
+- I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).


### PR DESCRIPTION
The checklist was getting into many commits. This is a practical fix to just tell people to look at CONTRIBUTING.md, and shuffle stuff there.