### PR TITLE
chore: fix rust tests

### DIFF
--- a/noir/acvm-repo/acir/src/circuit/black_box_functions.rs
+++ b/noir/acvm-repo/acir/src/circuit/black_box_functions.rs
@@ -48,7 +48,7 @@ pub enum BlackBoxFunc {
     /// Addition over the embedded curve on which [`FieldElement`][acir_field::FieldElement] is defined.
     EmbeddedCurveAdd,
     /// Point doubling over the embedded curve on which [`FieldElement`][acir_field::FieldElement] is defined.
-    EmbeddedCurveDouble
+    EmbeddedCurveDouble,
 }
 
 impl std::fmt::Display for BlackBoxFunc {

--- a/noir/acvm-repo/acvm/src/compiler/transformers/mod.rs
+++ b/noir/acvm-repo/acvm/src/compiler/transformers/mod.rs
@@ -124,8 +124,7 @@ pub(super) fn transform_internal(
                         ..
                     }
                     | acir::circuit::opcodes::BlackBoxFuncCall::EmbeddedCurveAdd {
-                        outputs,
-                        ..
+                        outputs, ..
                     }
                     | acir::circuit::opcodes::BlackBoxFuncCall::EmbeddedCurveDouble {
                         outputs,

--- a/noir/acvm-repo/acvm/tests/solver.rs
+++ b/noir/acvm-repo/acvm/tests/solver.rs
@@ -50,6 +50,24 @@ impl BlackBoxFunctionSolver for StubbedBackend {
     ) -> Result<(FieldElement, FieldElement), BlackBoxResolutionError> {
         panic!("Path not trodden by this test")
     }
+
+    fn ec_add(
+        &self,
+        _input1_x: &FieldElement,
+        _input1_y: &FieldElement,
+        _input2_x: &FieldElement,
+        _input2_y: &FieldElement,
+    ) -> Result<(FieldElement, FieldElement), BlackBoxResolutionError> {
+        panic!("Path not trodden by this test")
+    }
+
+    fn ec_double(
+        &self,
+        _input_x: &FieldElement,
+        _input_y: &FieldElement,
+    ) -> Result<(FieldElement, FieldElement), BlackBoxResolutionError> {
+        panic!("Path not trodden by this test")
+    }
 }
 
 // Reenable these test cases once we move the brillig implementation of inversion down into the acvm stdlib.

--- a/noir/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/noir/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -1086,6 +1086,24 @@ pub(crate) mod tests {
         ) -> Result<(FieldElement, FieldElement), BlackBoxResolutionError> {
             Ok((4_u128.into(), 5_u128.into()))
         }
+
+        fn ec_add(
+            &self,
+            _input1_x: &FieldElement,
+            _input1_y: &FieldElement,
+            _input2_x: &FieldElement,
+            _input2_y: &FieldElement,
+        ) -> Result<(FieldElement, FieldElement), BlackBoxResolutionError> {
+            panic!("Path not trodden by this test")
+        }
+
+        fn ec_double(
+            &self,
+            _input_x: &FieldElement,
+            _input_y: &FieldElement,
+        ) -> Result<(FieldElement, FieldElement), BlackBoxResolutionError> {
+            panic!("Path not trodden by this test")
+        }
     }
 
     pub(crate) fn create_context() -> BrilligContext {

--- a/noir/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
+++ b/noir/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
@@ -591,7 +591,7 @@ fn black_box_func_expected_input_size(name: BlackBoxFunc) -> Option<usize> {
         BlackBoxFunc::FixedBaseScalarMul => Some(2),
         // Recursive aggregation has a variable number of inputs
         BlackBoxFunc::RecursiveAggregation => None,
-        // Addition over the embedded curve: input are coordinates (x1,y1) and (x2,y2) of the Grumpkin points 
+        // Addition over the embedded curve: input are coordinates (x1,y1) and (x2,y2) of the Grumpkin points
         BlackBoxFunc::EmbeddedCurveAdd => Some(4),
         // Doubling over the embedded curve: input is (x,y) coordinate of the point.
         BlackBoxFunc::EmbeddedCurveDouble => Some(2),
@@ -624,7 +624,7 @@ fn black_box_expected_output_size(name: BlackBoxFunc) -> Option<usize> {
         | BlackBoxFunc::EcdsaSecp256r1 => Some(1),
         // Output of operations over the embedded curve
         // will be 2 field elements representing the point.
-        BlackBoxFunc::FixedBaseScalarMul 
+        BlackBoxFunc::FixedBaseScalarMul
         | BlackBoxFunc::EmbeddedCurveAdd
         | BlackBoxFunc::EmbeddedCurveDouble => Some(2),
         // Recursive aggregation has a variable number of outputs

--- a/noir/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
+++ b/noir/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
@@ -424,7 +424,7 @@ fn simplify_black_box_func(
         BlackBoxFunc::FixedBaseScalarMul
         | BlackBoxFunc::SchnorrVerify
         | BlackBoxFunc::PedersenCommitment
-        | BlackBoxFunc::PedersenHash 
+        | BlackBoxFunc::PedersenHash
         | BlackBoxFunc::EmbeddedCurveAdd
         | BlackBoxFunc::EmbeddedCurveDouble => {
             // Currently unsolvable here as we rely on an implementation in the backend.

--- a/noir/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/noir/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -187,7 +187,7 @@ mod test {
             instruction::{Binary, BinaryOp, Instruction, TerminatorInstruction},
             map::Id,
             types::Type,
-            value::Value,
+            value::{Value, ValueId},
         },
     };
 

--- a/noir/tooling/debugger/src/context.rs
+++ b/noir/tooling/debugger/src/context.rs
@@ -483,6 +483,24 @@ mod tests {
         ) -> Result<(FieldElement, FieldElement), acvm::BlackBoxResolutionError> {
             unimplemented!();
         }
+
+        fn ec_add(
+            &self,
+            _input1_x: &FieldElement,
+            _input1_y: &FieldElement,
+            _input2_x: &FieldElement,
+            _input2_y: &FieldElement,
+        ) -> Result<(FieldElement, FieldElement), acvm::BlackBoxResolutionError> {
+            unimplemented!();
+        }
+
+        fn ec_double(
+            &self,
+            _input_x: &FieldElement,
+            _input_y: &FieldElement,
+        ) -> Result<(FieldElement, FieldElement), acvm::BlackBoxResolutionError> {
+            unimplemented!();
+        }
     }
 
     #[test]

--- a/noir/tooling/lsp/src/requests/goto_definition.rs
+++ b/noir/tooling/lsp/src/requests/goto_definition.rs
@@ -137,25 +137,3 @@ mod goto_definition_tests {
         assert!(&response.is_some());
     }
 }
-
-#[cfg(test)]
-mod character_to_line_offset_tests {
-    use super::*;
-
-    #[test]
-    fn test_character_to_line_offset() {
-        let line = "Hello, dark!";
-        let character = 8;
-
-        let result = character_to_line_offset(line, character).unwrap();
-        assert_eq!(result, 8);
-
-        // In the case of a multi-byte character, the offset should be the byte index of the character
-        // byte offset for 8 character (黑) is expected to be 10
-        let line = "Hello, 黑!";
-        let character = 8;
-
-        let result = character_to_line_offset(line, character).unwrap();
-        assert_eq!(result, 10);
-    }
-}

--- a/noir/tooling/lsp/src/solver.rs
+++ b/noir/tooling/lsp/src/solver.rs
@@ -99,4 +99,22 @@ impl BlackBoxFunctionSolver for MockBackend {
     ) -> Result<acvm::FieldElement, acvm::BlackBoxResolutionError> {
         unimplemented!()
     }
+
+    fn ec_add(
+        &self,
+        _input1_x: &acvm::FieldElement,
+        _input1_y: &acvm::FieldElement,
+        _input2_x: &acvm::FieldElement,
+        _input2_y: &acvm::FieldElement,
+    ) -> Result<(acvm::FieldElement, acvm::FieldElement), acvm::BlackBoxResolutionError> {
+        unimplemented!();
+    }
+
+    fn ec_double(
+        &self,
+        _input_x: &acvm::FieldElement,
+        _input_y: &acvm::FieldElement,
+    ) -> Result<(acvm::FieldElement, acvm::FieldElement), acvm::BlackBoxResolutionError> {
+        unimplemented!();
+    }
 }

--- a/noir/yarn.lock
+++ b/noir/yarn.lock
@@ -11520,18 +11520,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-<<<<<<< HEAD
-"fast-fifo@npm:^1.1.0, fast-fifo@npm:^1.2.0":
-  version: 1.3.2
-  resolution: "fast-fifo@npm:1.3.2"
-  checksum: 6bfcba3e4df5af7be3332703b69a7898a8ed7020837ec4395bb341bd96cc3a6d86c3f6071dd98da289618cf2234c70d84b2a6f09a33dd6f988b1ff60d8e54275
-  languageName: node
-  linkType: hard
-
-"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.0":
-||||||| a3366d645
-"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.0":
-=======
 "fast-equals@npm:^5.0.1":
   version: 5.0.1
   resolution: "fast-equals@npm:5.0.1"
@@ -11547,7 +11535,6 @@ __metadata:
   linkType: hard
 
 "fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.0, fast-glob@npm:^3.3.2":
->>>>>>> refs/subrepo/noir/fetch
   version: 3.3.2
   resolution: "fast-glob@npm:3.3.2"
   dependencies:
@@ -12146,18 +12133,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-<<<<<<< HEAD
-"fwd-stream@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "fwd-stream@npm:1.0.4"
-  dependencies:
-    readable-stream: ~1.0.26-4
-  checksum: db4dcf68f214b3fabd6cd9658630dfd1d7ed8d43f7f45408027a90220cd75276e782d1e958821775d7a3a4a83034778e75a097bdc7002c758e8896f76213c65d
-  languageName: node
-  linkType: hard
-
-||||||| a3366d645
-=======
 "fwd-stream@npm:^1.0.4":
   version: 1.0.4
   resolution: "fwd-stream@npm:1.0.4"
@@ -12174,7 +12149,6 @@ __metadata:
   languageName: node
   linkType: hard
 
->>>>>>> refs/subrepo/noir/fetch
 "gensync@npm:^1.0.0-beta.1, gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -13391,21 +13365,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-<<<<<<< HEAD
-"import-local@npm:^3.0.2":
-  version: 3.1.0
-  resolution: "import-local@npm:3.1.0"
-  dependencies:
-    pkg-dir: ^4.2.0
-    resolve-cwd: ^3.0.0
-  bin:
-    import-local-fixture: fixtures/cli.js
-  checksum: bfcdb63b5e3c0e245e347f3107564035b128a414c4da1172a20dc67db2504e05ede4ac2eee1252359f78b0bfd7b19ef180aec427c2fce6493ae782d73a04cddd
-  languageName: node
-  linkType: hard
-
-||||||| a3366d645
-=======
 "import-local@npm:^3.0.2":
   version: 3.1.0
   resolution: "import-local@npm:3.1.0"
@@ -13425,7 +13384,6 @@ __metadata:
   languageName: node
   linkType: hard
 
->>>>>>> refs/subrepo/noir/fetch
 "imurmurhash@npm:^0.1.4":
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"


### PR DESCRIPTION
A bunch of the tests in rust are broken as the trait implementations for the EC operations were removed