### PR TITLE
fix(cli): Unbox should set up the accounts package

### DIFF
--- a/yarn-project/cli/src/cmds/unbox.ts
+++ b/yarn-project/cli/src/cmds/unbox.ts
@@ -63,6 +63,7 @@ function copyDependenciesToBox(dirName: string, destPath: string) {
     'barretenberg/ts',
     'yarn-project/aztec-nr',
     'yarn-project/noir-protocol-circuits',
+    'yarn-project/accounts',
     'yarn-project/aztec.js',
     'yarn-project/circuits.js',
     'yarn-project/foundation',


### PR DESCRIPTION
Should fix the following reported by @jzaki:

```
...
YN0001: │ Error: @aztec/accounts@portal:.aztec-packages/yarn-project/accounts::locator=%40aztec%2Fbox-blank%40workspace%3A.: Manifest not found
...
```