### PR TITLE
fix(cli): Unbox command should run as release

### DIFF
--- a/yarn-project/Dockerfile.prod
+++ b/yarn-project/Dockerfile.prod
@@ -8,6 +8,7 @@ RUN apt update && apt install -y jq && rm -rf /var/lib/apt/lists/* && apt-get cl
 COPY --from=yarn-project /usr/src /usr/src
 WORKDIR /usr/src/yarn-project
 # TODO: Use release-please to update package.json directly, and remove this!
+ARG COMMIT_TAG=""
 RUN ./scripts/version_packages.sh
 # Productionify. See comment in yarn-project-base/Dockerfile.
 RUN yarn workspaces focus @aztec/cli @aztec/aztec-sandbox @aztec/aztec-faucet @aztec/aztec.js --production && \

--- a/yarn-project/Dockerfile.prod
+++ b/yarn-project/Dockerfile.prod
@@ -7,7 +7,6 @@ FROM node:18.19.0 AS builder
 RUN apt update && apt install -y jq && rm -rf /var/lib/apt/lists/* && apt-get clean
 COPY --from=yarn-project /usr/src /usr/src
 WORKDIR /usr/src/yarn-project
-ARG COMMIT_TAG=""
 # TODO: Use release-please to update package.json directly, and remove this!
 RUN ./scripts/version_packages.sh
 # Productionify. See comment in yarn-project-base/Dockerfile.
@@ -28,6 +27,8 @@ RUN rm -rf /usr/src/noir/target
 # We could also use distroless, to get us about 20mb off, but meh. It's actually useful to shell into containers.
 #FROM gcr.io/distroless/nodejs18-debian12
 FROM ubuntu:lunar
+ARG COMMIT_TAG=""
+ENV COMMIT_TAG=$COMMIT_TAG
 # RUN apt update && apt install -y nodejs && rm -rf /var/lib/apt/lists/* && apt-get clean
 RUN apt update && apt install -y curl && rm -rf /var/lib/apt/lists/* && apt-get clean
 ENV NODE_VERSION=18.19.0

--- a/yarn-project/cli/Dockerfile
+++ b/yarn-project/cli/Dockerfile
@@ -4,7 +4,6 @@ ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/cli/dest/bin/index.j
 # The version has been updated in yarn-project-prod.
 # Adding COMMIT_TAG here to rebuild versioned image.
 ARG COMMIT_TAG=""
-ENV COMMIT_TAG=$COMMIT_TAG
 
 RUN mkdir /cache && chmod 777 /cache
 ENV XDG_CACHE_HOME /cache

--- a/yarn-project/cli/Dockerfile
+++ b/yarn-project/cli/Dockerfile
@@ -4,6 +4,7 @@ ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/cli/dest/bin/index.j
 # The version has been updated in yarn-project-prod.
 # Adding COMMIT_TAG here to rebuild versioned image.
 ARG COMMIT_TAG=""
+ENV COMMIT_TAG=$COMMIT_TAG
 
 RUN mkdir /cache && chmod 777 /cache
 ENV XDG_CACHE_HOME /cache


### PR DESCRIPTION
Running `aztec-cli unbox` with the 0.17.0 CLI will unbox creating an `.aztec-packages` folder and setting dependencies as portals:

```
~/Projects/tmp/unbox$ which aztec-cli
/home/santiago/.aztec/bin/aztec-cli
~/Projects/tmp/unbox$ aztec-cli --version
0.17.0
~/Projects/tmp/unbox$ ls blank/.aztec-packages/
barretenberg  yarn-project
~/Projects/tmp/unbox$ jq .dependencies blank/package.json 
{
  "@aztec/accounts": "portal:.aztec-packages/yarn-project/accounts",
  "@aztec/aztec.js": "portal:.aztec-packages/yarn-project/aztec.js",
  "serve": "^14.2.1"
}
```

This seems to point to aztec-cli not picking up the `COMMIT_TAG` env var here:

https://github.com/AztecProtocol/aztec-packages/blob/fc1d5399f24edafdc10cf9810f0cc6268008a3d8/yarn-project/cli/src/cmds/unbox.ts#L38-L55

This fix should make the env var available to the CLI. However, I haven't tested this (is it possible to build the cli image as if it were a release?), and it's unclear if this is the "right" fix. Should the CLI expect that env var at all? Should the default be "release mode" and only require an env var to run in "dev mode"?