### PR TITLE
chore: do not run CCI on release-please branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1061,10 +1061,12 @@ defaults: &defaults
       # do nothing if tagged other than:
       only: /^aztec-packages-v.*/
     branches:
+      # do nothing on release please branches
+      # unless they are tagged
       ignore:
-        # do nothing on release please branches
-        # unless they are tagged
         - /^release-please--.*/
+      only:
+        - /.*/
   context:
     - build
     - slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ jobs:
       # NOTE: we usually use alpine build image when making spot images, but
       # we are not able to upload to S3 with it
       image: ubuntu-2204:2023.07.2
-    resource_class: medium 
+    resource_class: medium
     steps:
       - *checkout
       - *setup_env
@@ -1058,7 +1058,13 @@ jobs:
 defaults: &defaults
   filters:
     tags:
+      # do nothing if tagged other than:
       only: /^aztec-packages-v.*/
+    branches:
+      ignore:
+        # do nothing on release please branches
+        # unless they are tagged
+        - /^release-please--.*/
   context:
     - build
     - slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1058,11 +1058,8 @@ jobs:
 defaults: &defaults
   filters:
     tags:
-      # do nothing if tagged other than:
       only: /^aztec-packages-v.*/
     branches:
-      # do nothing on release please branches
-      # unless they are tagged
       ignore:
         - /^release-please--.*/
       only:


### PR DESCRIPTION
Without this PR, the [release-please branch re-runs CCI whenever someone merges a PR](https://app.circleci.com/pipelines/github/AztecProtocol/aztec-packages?branch=release-please--branches--master).

This PR makes it so that we never perform work in CCI on release-please branches.