### PR TITLE
fix: swap branch exclusion for release-please on report gates diff workflow

### DIFF
--- a/.github/workflows/protocol-circuits-gate-diff.yml
+++ b/.github/workflows/protocol-circuits-gate-diff.yml
@@ -5,11 +5,10 @@ on:
     branches:
       - master
   pull_request:
-    branches-ignore:
-      - "release-please--*"
 
 jobs:
   compare_protocol_circuits_gates:
+    if: "!startsWith(github.head_ref, 'release-please--')"
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code

--- a/.github/workflows/protocol-circuits-gate-diff.yml
+++ b/.github/workflows/protocol-circuits-gate-diff.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   compare_protocol_circuits_gates:
-    if: "!startsWith(github.head_ref, 'fix-ignore-release-please-from-gate-diff')"
+    if: "!startsWith(github.head_ref, 'release-please--')"
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code

--- a/.github/workflows/protocol-circuits-gate-diff.yml
+++ b/.github/workflows/protocol-circuits-gate-diff.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   compare_protocol_circuits_gates:
-    if: "!startsWith(github.head_ref, 'release-please--')"
+    if: "!startsWith(github.head_ref, 'fix-ignore-release-please-from-gate-diff')"
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code


### PR DESCRIPTION
it was based on the target branch, should be based on source branch.

