### PR TITLE
chore: add a link back to `aztec-packages` in noir sync PR

### DIFF
--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -57,7 +57,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           github_token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          pr_title: 'feat: aztec-packages'
-          pr_body: 'Development from Aztec.'
+          pr_title: 'feat: Sync commits from `aztec-packages`'
+          pr_body: 'Development from [aztec-packages](https://github.com/AztecProtocol/aztec-packages).'
           destination_branch: 'master'
           source_branch: 'aztec-packages'


### PR DESCRIPTION
This PR adds a link from the Noir repo PR back to aztec-packages. I'm adding this for laziness reasons so I can avoid some typing.