### PR TITLE
fix: do not publish empty contract data

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -1,4 +1,13 @@
-import { L1ToL2MessageSource, L2Block, L2BlockSource, MerkleTreeId, Tx, TxHash, mockTx } from '@aztec/circuit-types';
+import {
+  ExtendedContractData,
+  L1ToL2MessageSource,
+  L2Block,
+  L2BlockSource,
+  MerkleTreeId,
+  Tx,
+  TxHash,
+  mockTx,
+} from '@aztec/circuit-types';
 import {
   BlockHeader,
   Fr,
@@ -208,6 +217,45 @@ describe('sequencer', () => {
     await sequencer.work();
 
     expect(publisher.processL2Block).not.toHaveBeenCalled();
+  });
+
+  it('publishes contract data', async () => {
+    const txWithContract = mockTx(0x10000);
+    (txWithContract.newContracts as Array<ExtendedContractData>) = [ExtendedContractData.random()];
+    txWithContract.data.constants.txContext.chainId = chainId;
+
+    const txWithEmptyContract = mockTx(0x20000);
+    (txWithEmptyContract.newContracts as Array<ExtendedContractData>) = [ExtendedContractData.empty()];
+    txWithEmptyContract.data.constants.txContext.chainId = chainId;
+
+    const block = L2Block.random(lastBlockNumber + 1);
+    const proof = makeEmptyProof();
+
+    p2p.getTxs.mockResolvedValueOnce([txWithContract, txWithEmptyContract]);
+    blockBuilder.buildL2Block.mockResolvedValueOnce([block, proof]);
+    publisher.processL2Block.mockResolvedValueOnce(true);
+    publisher.processNewContractData.mockResolvedValueOnce(true);
+    globalVariableBuilder.buildGlobalVariables.mockResolvedValueOnce(
+      new GlobalVariables(chainId, version, new Fr(lastBlockNumber + 1), Fr.ZERO),
+    );
+
+    await sequencer.initialSync();
+    await sequencer.work();
+
+    // check that the block was built with both transactions
+    expect(blockBuilder.buildL2Block).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.arrayContaining([
+        expect.objectContaining({ hash: await txWithContract.getTxHash() }),
+        expect.objectContaining({ hash: await txWithEmptyContract.getTxHash() }),
+      ]),
+      expect.any(Array),
+    );
+
+    // check that the empty contract did not get published
+    expect(publisher.processNewContractData).toHaveBeenCalledWith(block.number, block.getCalldataHash(), [
+      txWithContract.newContracts[0],
+    ]);
   });
 });
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -237,16 +237,24 @@ export class Sequencer {
     this.state = SequencerState.PUBLISHING_CONTRACT_DATA;
     const newContracts = validTxs.flatMap(tx => tx.newContracts).filter(cd => !cd.isEmpty());
 
-    if (newContracts.length > 0) {
-      const blockHash = block.getCalldataHash();
-      this.log.info(`Publishing ${newContracts.length} contracts in block hash ${blockHash.toString('hex')}`);
+    if (newContracts.length === 0) {
+      this.log.debug(`No new contracts to publish in block ${block.number}`);
+      return;
+    }
 
-      const publishedContractData = await this.publisher.processNewContractData(block.number, blockHash, newContracts);
-      if (publishedContractData) {
-        this.log(`Successfully published new contract data for block ${block.number}`);
-      } else if (!publishedContractData && newContracts.length) {
-        this.log(`Failed to publish new contract data for block ${block.number}`);
-      }
+    const blockCalldataHash = block.getCalldataHash();
+    this.log.info(`Publishing ${newContracts.length} contracts in block ${block.number}`);
+
+    const publishedContractData = await this.publisher.processNewContractData(
+      block.number,
+      blockCalldataHash,
+      newContracts,
+    );
+
+    if (publishedContractData) {
+      this.log(`Successfully published new contract data for block ${block.number}`);
+    } else if (!publishedContractData && newContracts.length) {
+      this.log(`Failed to publish new contract data for block ${block.number}`);
     }
   }
 


### PR DESCRIPTION
This PR fixes the sequencer publishing contract for every transaction.

Fix #2970 
