### PR TITLE
fix: dont spam logs with yarn install

### DIFF
--- a/barretenberg/ts/.yarnrc.yml
+++ b/barretenberg/ts/.yarnrc.yml
@@ -1,2 +1,5 @@
 nodeLinker: node-modules
 yarnPath: '.yarn/releases/yarn-berry.cjs'
+logFilters:
+  - code: YN0013
+    level: discard

--- a/boxes/.yarnrc.yml
+++ b/boxes/.yarnrc.yml
@@ -1,3 +1,6 @@
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-berry.cjs
+logFilters:
+  - code: YN0013
+    level: discard

--- a/noir/.yarnrc.yml
+++ b/noir/.yarnrc.yml
@@ -7,3 +7,6 @@ plugins:
     spec: "@yarnpkg/plugin-workspace-tools"
 
 yarnPath: .yarn/releases/yarn-3.6.3.cjs
+logFilters:
+  - code: YN0013
+    level: discard

--- a/noir/docs/.yarnrc.yml
+++ b/noir/docs/.yarnrc.yml
@@ -1,1 +1,4 @@
 nodeLinker: node-modules
+logFilters:
+  - code: YN0013
+    level: discard


### PR DESCRIPTION
This output was getting cut off in the noir-packages ci job. This standardizes what was already in yarn-project