### PR TITLE
fix: segment tree insertion stats by depth

### DIFF
--- a/yarn-project/circuit-types/src/stats/metrics.ts
+++ b/yarn-project/circuit-types/src/stats/metrics.ts
@@ -146,13 +146,25 @@ export const Metrics = [
     events: ['tx-sequencer-processing'],
   },
   {
-    name: 'batch_insert_into_append_only_tree_ms',
+    name: 'batch_insert_into_append_only_tree_16_depth_ms',
     groupBy: 'leaf-count',
     description: 'Time to insert a batch of leaves into an append-only tree',
     events: ['tree-insertion'],
   },
   {
-    name: 'batch_insert_into_indexed_tree_ms',
+    name: 'batch_insert_into_append_only_tree_32_depth_ms',
+    groupBy: 'leaf-count',
+    description: 'Time to insert a batch of leaves into an append-only tree',
+    events: ['tree-insertion'],
+  },
+  {
+    name: 'batch_insert_into_indexed_tree_20_depth_ms',
+    groupBy: 'leaf-count',
+    description: 'Time to insert a batch of leaves into an indexed tree',
+    events: ['tree-insertion'],
+  },
+  {
+    name: 'batch_insert_into_indexed_tree_40_depth_ms',
     groupBy: 'leaf-count',
     description: 'Time to insert a batch of leaves into an indexed tree',
     events: ['tree-insertion'],

--- a/yarn-project/scripts/src/benchmarks/aggregate.ts
+++ b/yarn-project/scripts/src/benchmarks/aggregate.ts
@@ -167,10 +167,19 @@ function processTxSequencerProcessingStats(entry: TxSequencerProcessingStats, re
 /** Process a tree insertion event and updates results */
 function processTreeInsertion(entry: TreeInsertionStats, results: BenchmarkCollectedResults) {
   const bucket = entry.batchSize;
+  const depth = entry.treeDepth;
   if (entry.treeType === 'append-only') {
-    append(results, 'batch_insert_into_append_only_tree_ms', bucket, entry.duration);
+    if (depth === 16) {
+      append(results, 'batch_insert_into_append_only_tree_16_depth_ms', bucket, entry.duration);
+    } else if (depth === 32) {
+      append(results, 'batch_insert_into_append_only_tree_32_depth_ms', bucket, entry.duration);
+    }
   } else if (entry.treeType === 'indexed') {
-    append(results, 'batch_insert_into_indexed_tree_ms', bucket, entry.duration);
+    if (depth === 20) {
+      append(results, 'batch_insert_into_indexed_tree_20_depth_ms', bucket, entry.duration);
+    } else if (depth === 40) {
+      append(results, 'batch_insert_into_indexed_tree_40_depth_ms', bucket, entry.duration);
+    }
   }
 }
 


### PR DESCRIPTION
Extract more accurate data for tree insertion duration by segmenting metrics by their tree depth