### PR TITLE
chore: resume CCI runs on release-please branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1059,9 +1059,15 @@ defaults: &defaults
   filters:
     tags:
       only: /^aztec-packages-v.*/
-    branches:
-      ignore:
-        - /^release-please--.*/
+    # We would like to ignore release-please branches,
+    # but doing so breaks github status checks:
+    # the PR spins as it waits for the status check to complete,
+    # which never happens because the branch is ignored.
+    # Long term solution would require the status checks
+    # when the *source branch* on the PR release-please.
+    # branches:
+    #   ignore:
+    #     - /^release-please--.*/
   context:
     - build
     - slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1063,7 +1063,7 @@ defaults: &defaults
     # but doing so breaks github status checks:
     # the PR spins as it waits for the status check to complete,
     # which never happens because the branch is ignored.
-    # Long term solution would require the status checks
+    # Long term solution would require disabling the status checks on `master`
     # when the *source branch* on the PR release-please.
     # branches:
     #   ignore:


### PR DESCRIPTION
Allow running CCI on release-please branch again.

This is not ideal, since it is wasted work, but presently there are required statuses from CCI on our github PRs, so when CCI doesn't run on release-please branch, it requires an admin for force merge.