### PR TITLE
fix: pxe notes crashing spuriously

### DIFF
--- a/yarn-project/pxe/src/database/kv_pxe_database.ts
+++ b/yarn-project/pxe/src/database/kv_pxe_database.ts
@@ -1,5 +1,6 @@
 import { ContractDao, MerkleTreeId, NoteFilter, PublicKey } from '@aztec/circuit-types';
 import { AztecAddress, BlockHeader, CompleteAddress } from '@aztec/circuits.js';
+import { toBufferBE } from '@aztec/foundation/bigint-buffer';
 import { Fr, Point } from '@aztec/foundation/fields';
 import { AztecArray, AztecKVStore, AztecMap, AztecMultiMap, AztecSingleton } from '@aztec/kv-store';
 
@@ -27,18 +28,21 @@ export class KVPxeDatabase implements PxeDatabase {
   #authWitnesses: AztecMap<string, Buffer[]>;
   #capsules: AztecArray<Buffer[]>;
   #contracts: AztecMap<string, Buffer>;
-  #notes: AztecArray<Buffer>;
-  #nullifiedNotes: AztecMap<number, boolean>;
-  #notesByContract: AztecMultiMap<string, number>;
-  #notesByStorageSlot: AztecMultiMap<string, number>;
-  #notesByTxHash: AztecMultiMap<string, number>;
-  #notesByOwner: AztecMultiMap<string, number>;
+
+  #notes: AztecMap<string, Buffer>;
+  #notesByNullifier: AztecMap<string, string>;
+  #notesByContract: AztecMultiMap<string, string>;
+  #notesByStorageSlot: AztecMultiMap<string, string>;
+  #notesByTxHash: AztecMultiMap<string, string>;
+  #notesByOwner: AztecMultiMap<string, string>;
+
   #deferredNotes: AztecArray<Buffer>;
   #deferredNotesByContract: AztecMultiMap<string, number>;
   #syncedBlockPerPublicKey: AztecMap<string, number>;
+
   #db: AztecKVStore;
 
-  constructor(db: AztecKVStore) {
+  constructor(private db: AztecKVStore) {
     this.#db = db;
 
     this.#addresses = db.createArray('addresses');
@@ -51,9 +55,8 @@ export class KVPxeDatabase implements PxeDatabase {
     this.#synchronizedBlock = db.createSingleton('block_header');
     this.#syncedBlockPerPublicKey = db.createMap('synced_block_per_public_key');
 
-    this.#notes = db.createArray('notes');
-    this.#nullifiedNotes = db.createMap('nullified_notes');
-
+    this.#notes = db.createMap('notes');
+    this.#notesByNullifier = db.createMap('notes');
     this.#notesByContract = db.createMultiMap('notes_by_contract');
     this.#notesByStorageSlot = db.createMultiMap('notes_by_storage_slot');
     this.#notesByTxHash = db.createMultiMap('notes_by_tx_hash');
@@ -88,17 +91,22 @@ export class KVPxeDatabase implements PxeDatabase {
     await this.addNotes([note]);
   }
 
-  async addNotes(notes: NoteDao[]): Promise<void> {
-    const newLength = await this.#notes.push(...notes.map(note => note.toBuffer()));
-    for (const [index, note] of notes.entries()) {
-      const noteId = newLength - notes.length + index;
-      await Promise.all([
-        this.#notesByContract.set(note.contractAddress.toString(), noteId),
-        this.#notesByStorageSlot.set(note.storageSlot.toString(), noteId),
-        this.#notesByTxHash.set(note.txHash.toString(), noteId),
-        this.#notesByOwner.set(note.publicKey.toString(), noteId),
-      ]);
-    }
+  addNotes(notes: NoteDao[]): Promise<void> {
+    return this.db.transaction(() => {
+      for (const dao of notes) {
+        // store notes by their index in the notes hash tree
+        // this provides the uniqueness we need to store individual notes
+        // and should also return notes in the order that they were created.
+        // Had we stored them by their nullifier, they would be returned in random order
+        const noteIndex = toBufferBE(dao.index, 32).toString();
+        void this.#notes.set(noteIndex, dao.toBuffer());
+        void this.#notesByNullifier.set(dao.siloedNullifier.toString(), noteIndex);
+        void this.#notesByContract.set(dao.contractAddress.toString(), noteIndex);
+        void this.#notesByStorageSlot.set(dao.storageSlot.toString(), noteIndex);
+        void this.#notesByTxHash.set(dao.txHash.toString(), noteIndex);
+        void this.#notesByOwner.set(dao.publicKey.toString(), noteIndex);
+      }
+    });
   }
 
   async addDeferredNotes(deferredNotes: DeferredNoteDao[]): Promise<void> {
@@ -155,19 +163,9 @@ export class KVPxeDatabase implements PxeDatabase {
     });
   }
 
-  *#getAllNonNullifiedNotes(): IterableIterator<NoteDao> {
-    for (const [index, serialized] of this.#notes.entries()) {
-      if (this.#nullifiedNotes.has(index)) {
-        continue;
-      }
-
-      yield NoteDao.fromBuffer(serialized);
-    }
-  }
-
-  async getNotes(filter: NoteFilter): Promise<NoteDao[]> {
+  #getNotes(filter: NoteFilter = {}): NoteDao[] {
     const publicKey: PublicKey | undefined = filter.owner
-      ? (await this.getCompleteAddress(filter.owner))?.publicKey
+      ? this.#getCompleteAddress(filter.owner)?.publicKey
       : undefined;
 
     const initialNoteIds = publicKey
@@ -178,15 +176,11 @@ export class KVPxeDatabase implements PxeDatabase {
       ? this.#notesByContract.getValues(filter.contractAddress.toString())
       : filter.storageSlot
       ? this.#notesByStorageSlot.getValues(filter.storageSlot.toString())
-      : undefined;
-
-    if (!initialNoteIds) {
-      return Array.from(this.#getAllNonNullifiedNotes());
-    }
+      : this.#notes.keys();
 
     const result: NoteDao[] = [];
     for (const noteId of initialNoteIds) {
-      const serializedNote = this.#notes.at(noteId);
+      const serializedNote = this.#notes.get(noteId);
       if (!serializedNote) {
         continue;
       }
@@ -214,26 +208,43 @@ export class KVPxeDatabase implements PxeDatabase {
     return result;
   }
 
+  getNotes(filter: NoteFilter): Promise<NoteDao[]> {
+    return Promise.resolve(this.#getNotes(filter));
+  }
+
   removeNullifiedNotes(nullifiers: Fr[], account: PublicKey): Promise<NoteDao[]> {
     if (nullifiers.length === 0) {
       return Promise.resolve([]);
     }
-    const nullifierSet = new Set(nullifiers.map(n => n.toString()));
+
     return this.#db.transaction(() => {
-      const notesIds = this.#notesByOwner.getValues(account.toString());
       const nullifiedNotes: NoteDao[] = [];
 
-      for (const noteId of notesIds) {
-        const note = NoteDao.fromBuffer(this.#notes.at(noteId)!);
-        if (nullifierSet.has(note.siloedNullifier.toString())) {
-          nullifiedNotes.push(note);
-
-          void this.#nullifiedNotes.set(noteId, true);
-          void this.#notesByOwner.deleteValue(account.toString(), noteId);
-          void this.#notesByTxHash.deleteValue(note.txHash.toString(), noteId);
-          void this.#notesByContract.deleteValue(note.contractAddress.toString(), noteId);
-          void this.#notesByStorageSlot.deleteValue(note.storageSlot.toString(), noteId);
+      for (const nullifier of nullifiers) {
+        const noteIndex = this.#notesByNullifier.get(nullifier.toString());
+        if (!noteIndex) {
+          continue;
         }
+
+        const noteBuffer = noteIndex ? this.#notes.get(noteIndex) : undefined;
+
+        if (!noteBuffer) {
+          // note doesn't exist. Maybe it got nullified already
+          continue;
+        }
+
+        const note = NoteDao.fromBuffer(noteBuffer);
+        if (!note.publicKey.equals(account)) {
+          // tried to nullify someone else's note
+          continue;
+        }
+
+        nullifiedNotes.push(note);
+
+        void this.#notesByOwner.deleteValue(account.toString(), noteIndex);
+        void this.#notesByTxHash.deleteValue(note.txHash.toString(), noteIndex);
+        void this.#notesByContract.deleteValue(note.contractAddress.toString(), noteIndex);
+        void this.#notesByStorageSlot.deleteValue(note.storageSlot.toString(), noteIndex);
       }
 
       return nullifiedNotes;
@@ -320,14 +331,18 @@ export class KVPxeDatabase implements PxeDatabase {
     });
   }
 
-  getCompleteAddress(address: AztecAddress): Promise<CompleteAddress | undefined> {
+  #getCompleteAddress(address: AztecAddress): CompleteAddress | undefined {
     const index = this.#addressIndex.get(address.toString());
     if (typeof index === 'undefined') {
-      return Promise.resolve(undefined);
+      return undefined;
     }
 
     const value = this.#addresses.at(index);
-    return Promise.resolve(value ? CompleteAddress.fromBuffer(value) : undefined);
+    return value ? CompleteAddress.fromBuffer(value) : undefined;
+  }
+
+  getCompleteAddress(address: AztecAddress): Promise<CompleteAddress | undefined> {
+    return Promise.resolve(this.#getCompleteAddress(address));
   }
 
   getCompleteAddresses(): Promise<CompleteAddress[]> {
@@ -343,7 +358,7 @@ export class KVPxeDatabase implements PxeDatabase {
   }
 
   estimateSize(): number {
-    const notesSize = Array.from(this.#getAllNonNullifiedNotes()).reduce((sum, note) => sum + note.getSize(), 0);
+    const notesSize = Array.from(this.#getNotes({})).reduce((sum, note) => sum + note.getSize(), 0);
     const authWitsSize = Array.from(this.#authWitnesses.values()).reduce(
       (sum, value) => sum + value.length * Fr.SIZE_IN_BYTES,
       0,


### PR DESCRIPTION
This PR refactors how the PXE stores notes. They're now stored by their index in the note hash tree which should provide both uniqueness and a sorted order for notes.

This gets rid of the "nullifiedNotes" set so reading and removing notes should be cleaner and more efficient.