### PR TITLE
fix: Nargo destination path in bootstrap cache

### DIFF
--- a/noir/bootstrap_cache.sh
+++ b/noir/bootstrap_cache.sh
@@ -5,6 +5,6 @@ cd "$(dirname "$0")"
 source ../build-system/scripts/setup_env '' '' mainframe_$USER > /dev/null
 
 echo -e "\033[1mRetrieving noir packages from remote cache...\033[0m"
-extract_repo noir-packages /usr/src/noir/packages ./noir
+extract_repo noir-packages /usr/src/noir/packages ./
 echo -e "\033[1mRetrieving nargo from remote cache...\033[0m"
-extract_repo noir /usr/src/noir/target/release ./noir/target
+extract_repo noir /usr/src/noir/target/release ./target/


### PR DESCRIPTION
The destination path when copying nargo from the CI cache in bootstrap_cache was wrong, it was getting copied to `~/monorepo/noir/noir/target/release` (note the double `noir`).