### PR TITLE
chore(docs): Update lsp install instructions

### DIFF
--- a/docs/docs/dev_docs/contracts/main.md
+++ b/docs/docs/dev_docs/contracts/main.md
@@ -20,15 +20,23 @@ An **Aztec smart contract** is a smart contract with **private** state variables
 
 ## Install aztec-nargo
 
-To write an Aztec.nr contract, you need to write Noir, `aztec-nargo` comes with a built-in compiler for Aztec contracts written in Noir. See install instructions [here](../cli/sandbox-reference.md).
+To write an Aztec.nr contract, you need to the compiler, `aztec-nargo` which is installed when you install the sandbox. See install instructions [here](../cli/sandbox-reference.md).
 
 :::info
 For those coming from vanilla Noir, the version used for aztec.nr is tracked separately to nargo for vanilla Noir. Be sure to use `aztec-nargo` to compile your contracts.
 :::
 
-## Install `nargo` (recommended)
+## Install Noir LSP (recommended)
 
-`aztec-nargo` comes with the Noir compiler, so installing `nargo` is not required, however it is recommended as it provides a better developer experience for writing contracts. You will need nargo installed to take advantage of the [Noir Language Server](https://noir-lang.org/docs/getting_started/tooling/language_server), which provides syntax highlighting and formatting for your Aztec contracts.
+Install the [Noir Language Support extension](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir) to get syntax highlighting, syntax error detection and go-to definitions for your Aztec contracts.
+
+Once the extension is installed, go to your VSCode settings, search for "noir" and update the `Noir: Nargo Path` field to point to your `aztec-nargo` executable.
+
+You can print the path of your `aztec-nargo` executable by running:
+
+```bash
+which aztec-nargo
+```
 
 ## Install Noir tooling
 

--- a/docs/docs/dev_docs/getting_started/aztecnr-getting-started.md
+++ b/docs/docs/dev_docs/getting_started/aztecnr-getting-started.md
@@ -205,11 +205,17 @@ You can also test the functions by applying what you learned in the [quickstart]
 
 Congratulations, you have now written, compiled, and deployed your first Aztec.nr smart contract!
 
-## Install `nargo` (recommended)
+## Install Noir LSP (recommended)
 
-The CLI comes with the Noir compiler, so installing `nargo` is not required, however it is recommended as it provides a better developer experience for writing contracts. You will need nargo installed to take advantage of the [Noir Language Server](https://noir-lang.org/docs/getting_started/tooling/language_server), which provides syntax highlighting and formatting for your Aztec contracts.
+Install the [Noir Language Support extension](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir) to get syntax highlighting, syntax error detection and go-to definitions for your Aztec contracts.
 
-You will also need `nargo` if you want to run unit tests in Noir.
+Once the extension is installed, go to your VSCode settings, search for "noir" and update the `Noir: Nargo Path` field to point to your `aztec-nargo` executable.
+
+You can print the path of your `aztec-nargo` executable by running:
+
+```bash
+which aztec-nargo
+```
 
 ## What's next?
 

--- a/docs/docs/dev_docs/tutorials/writing_dapp/contract_deployment.md
+++ b/docs/docs/dev_docs/tutorials/writing_dapp/contract_deployment.md
@@ -3,7 +3,7 @@
 To add contracts to your application, we'll start by creating a new `aztec-nargo` project. We'll then compile the contracts, and write a simple script to deploy them to our Sandbox.
 
 :::info
-Follow the instructions [here](../../contracts/setup.md) to install `nargo` if you haven't done so already.
+Follow the instructions [here](../../cli/sandbox-reference.md) to install `aztec-nargo` if you haven't done so already.
 :::
 
 ## Initialize Aztec project


### PR DESCRIPTION
Remove the recommendation to install `nargo` for syntax highlighting.

Add recommendation to install the LSP extensions and point it to aztec-nargo.

closes #4098 