### PR TITLE
refactor(bb): namespace proof_system=>bb

### DIFF
--- a/barretenberg/cpp/src/barretenberg/benchmark/goblin_bench/eccvm.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/goblin_bench/eccvm.bench.cpp
@@ -5,7 +5,7 @@
 #include "barretenberg/proof_system/circuit_builder/eccvm/eccvm_circuit_builder.hpp"
 
 using namespace benchmark;
-using namespace proof_system;
+using namespace bb;
 
 using Flavor = honk::flavor::ECCVM;
 using Builder = ECCVMCircuitBuilder<Flavor>;

--- a/barretenberg/cpp/src/barretenberg/benchmark/goblin_bench/goblin.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/goblin_bench/goblin.bench.cpp
@@ -9,7 +9,7 @@
 
 using namespace benchmark;
 using namespace bb;
-using namespace proof_system;
+using namespace bb;
 
 namespace {
 void goblin_full(State& state) noexcept

--- a/barretenberg/cpp/src/barretenberg/benchmark/ipa_bench/ipa.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ipa_bench/ipa.bench.cpp
@@ -3,8 +3,8 @@
 
 using namespace benchmark;
 using namespace bb;
-using namespace proof_system;
-using namespace proof_system::honk::pcs::ipa;
+using namespace bb;
+using namespace bb::honk::pcs::ipa;
 namespace {
 using Curve = curve::Grumpkin;
 using Fr = Curve::ScalarField;

--- a/barretenberg/cpp/src/barretenberg/benchmark/plonk_bench/plonk.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/plonk_bench/plonk.bench.cpp
@@ -12,8 +12,8 @@ constexpr size_t START = (MAX_GATES) >> (NUM_CIRCUITS - 1);
 // constexpr size_t MAX_HASH_ROUNDS = 8192;
 // constexpr size_t START_HASH_ROUNDS = 64;
 
-using Builder = proof_system::StandardCircuitBuilder;
-using Composer = proof_system::plonk::StandardComposer;
+using Builder = bb::StandardCircuitBuilder;
+using Composer = bb::plonk::StandardComposer;
 
 void generate_test_plonk_circuit(Builder& builder, size_t num_gates)
 {

--- a/barretenberg/cpp/src/barretenberg/benchmark/plonk_bench/standard_plonk.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/plonk_bench/standard_plonk.bench.cpp
@@ -4,8 +4,8 @@
 
 using namespace benchmark;
 
-using StandardBuilder = proof_system::StandardCircuitBuilder;
-using StandardPlonk = proof_system::plonk::StandardComposer;
+using StandardBuilder = bb::StandardCircuitBuilder;
+using StandardPlonk = bb::plonk::StandardComposer;
 
 /**
  * @brief Benchmark: Construction of a Standard proof for a circuit determined by the provided circuit function
@@ -13,8 +13,8 @@ using StandardPlonk = proof_system::plonk::StandardComposer;
 static void construct_proof_standard_power_of_2(State& state) noexcept
 {
     auto log2_of_gates = static_cast<size_t>(state.range(0));
-    bench_utils::construct_proof_with_specified_num_iterations<proof_system::plonk::StandardComposer>(
-        state, &bench_utils::generate_basic_arithmetic_circuit<proof_system::StandardCircuitBuilder>, log2_of_gates);
+    bench_utils::construct_proof_with_specified_num_iterations<bb::plonk::StandardComposer>(
+        state, &bench_utils::generate_basic_arithmetic_circuit<bb::StandardCircuitBuilder>, log2_of_gates);
 }
 
 BENCHMARK(construct_proof_standard_power_of_2)

--- a/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_bench/protogalaxy.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_bench/protogalaxy.bench.cpp
@@ -6,7 +6,7 @@
 
 using namespace benchmark;
 
-namespace proof_system::honk {
+namespace bb::honk {
 using Flavor = flavor::Ultra;
 using Instance = ProverInstance_<Flavor>;
 using Instances = ProverInstances_<Flavor, 2>;
@@ -38,4 +38,4 @@ void fold_one(State& state) noexcept
 }
 
 BENCHMARK(fold_one)->/* vary the circuit size */ DenseRange(14, 20)->Unit(kMillisecond);
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/benchmark/relations_bench/barycentric.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/relations_bench/barycentric.bench.cpp
@@ -12,7 +12,7 @@ using FF = bb::fr;
 using bb::BarycentricData;
 using bb::Univariate;
 
-namespace proof_system::benchmark {
+namespace bb::benchmark {
 
 void extend_2_to_6(State& state) noexcept
 {
@@ -23,4 +23,4 @@ void extend_2_to_6(State& state) noexcept
 }
 BENCHMARK(extend_2_to_6);
 
-} // namespace proof_system::benchmark
+} // namespace bb::benchmark

--- a/barretenberg/cpp/src/barretenberg/benchmark/relations_bench/relations.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/relations_bench/relations.bench.cpp
@@ -8,9 +8,9 @@ namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
 
-using namespace proof_system::honk::sumcheck;
+using namespace bb::honk::sumcheck;
 
-namespace proof_system::benchmark::relations {
+namespace bb::benchmark::relations {
 
 using Fr = bb::fr;
 using Fq = grumpkin::fr;
@@ -21,7 +21,7 @@ template <typename Flavor, typename Relation> void execute_relation(::benchmark:
     using AllValues = typename Flavor::AllValues;
     using SumcheckArrayOfValuesOverSubrelations = typename Relation::SumcheckArrayOfValuesOverSubrelations;
 
-    auto params = proof_system::RelationParameters<FF>::get_random();
+    auto params = bb::RelationParameters<FF>::get_random();
 
     // Extract an array containing all the polynomial evaluations at a given row i
     AllValues new_value{};
@@ -56,4 +56,4 @@ BENCHMARK(execute_relation<honk::flavor::ECCVM, ECCVMSetRelation<Fq>>);
 BENCHMARK(execute_relation<honk::flavor::ECCVM, ECCVMTranscriptRelation<Fq>>);
 BENCHMARK(execute_relation<honk::flavor::ECCVM, ECCVMWnafRelation<Fq>>);
 
-} // namespace proof_system::benchmark::relations
+} // namespace bb::benchmark::relations

--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/benchmark_utilities.hpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/benchmark_utilities.hpp
@@ -32,9 +32,9 @@ namespace bench_utils {
  */
 template <typename Builder> void generate_basic_arithmetic_circuit(Builder& builder, size_t log2_num_gates)
 {
-    proof_system::plonk::stdlib::field_t a(proof_system::plonk::stdlib::witness_t(&builder, bb::fr::random_element()));
-    proof_system::plonk::stdlib::field_t b(proof_system::plonk::stdlib::witness_t(&builder, bb::fr::random_element()));
-    proof_system::plonk::stdlib::field_t c(&builder);
+    bb::plonk::stdlib::field_t a(bb::plonk::stdlib::witness_t(&builder, bb::fr::random_element()));
+    bb::plonk::stdlib::field_t b(bb::plonk::stdlib::witness_t(&builder, bb::fr::random_element()));
+    bb::plonk::stdlib::field_t c(&builder);
     size_t passes = (1UL << log2_num_gates) / 4 - 4;
     if (static_cast<int>(passes) <= 0) {
         throw std::runtime_error("too few gates");
@@ -58,9 +58,9 @@ template <typename Builder> void generate_sha256_test_circuit(Builder& builder, 
 {
     std::string in;
     in.resize(32);
-    proof_system::plonk::stdlib::packed_byte_array<Builder> input(&builder, in);
+    bb::plonk::stdlib::packed_byte_array<Builder> input(&builder, in);
     for (size_t i = 0; i < num_iterations; i++) {
-        input = proof_system::plonk::stdlib::sha256<Builder>(input);
+        input = bb::plonk::stdlib::sha256<Builder>(input);
     }
 }
 
@@ -74,9 +74,9 @@ template <typename Builder> void generate_keccak_test_circuit(Builder& builder, 
 {
     std::string in = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01";
 
-    proof_system::plonk::stdlib::byte_array<Builder> input(&builder, in);
+    bb::plonk::stdlib::byte_array<Builder> input(&builder, in);
     for (size_t i = 0; i < num_iterations; i++) {
-        input = proof_system::plonk::stdlib::keccak<Builder>::hash(input);
+        input = bb::plonk::stdlib::keccak<Builder>::hash(input);
     }
 }
 
@@ -88,7 +88,7 @@ template <typename Builder> void generate_keccak_test_circuit(Builder& builder, 
  */
 template <typename Builder> void generate_ecdsa_verification_test_circuit(Builder& builder, size_t num_iterations)
 {
-    using curve = proof_system::plonk::stdlib::secp256k1<Builder>;
+    using curve = bb::plonk::stdlib::secp256k1<Builder>;
     using fr = typename curve::fr;
     using fq = typename curve::fq;
     using g1 = typename curve::g1;
@@ -114,19 +114,18 @@ template <typename Builder> void generate_ecdsa_verification_test_circuit(Builde
 
         typename curve::g1_bigfr_ct public_key = curve::g1_bigfr_ct::from_witness(&builder, account.public_key);
 
-        proof_system::plonk::stdlib::ecdsa::signature<Builder> sig{ typename curve::byte_array_ct(&builder, rr),
-                                                                    typename curve::byte_array_ct(&builder, ss),
-                                                                    proof_system::plonk::stdlib::uint8<Builder>(
-                                                                        &builder, vv) };
+        bb::plonk::stdlib::ecdsa::signature<Builder> sig{ typename curve::byte_array_ct(&builder, rr),
+                                                          typename curve::byte_array_ct(&builder, ss),
+                                                          bb::plonk::stdlib::uint8<Builder>(&builder, vv) };
 
         typename curve::byte_array_ct message(&builder, message_string);
 
         // Verify ecdsa signature
-        proof_system::plonk::stdlib::ecdsa::verify_signature<Builder,
-                                                             curve,
-                                                             typename curve::fq_ct,
-                                                             typename curve::bigfr_ct,
-                                                             typename curve::g1_bigfr_ct>(message, public_key, sig);
+        bb::plonk::stdlib::ecdsa::verify_signature<Builder,
+                                                   curve,
+                                                   typename curve::fq_ct,
+                                                   typename curve::bigfr_ct,
+                                                   typename curve::g1_bigfr_ct>(message, public_key, sig);
     }
 }
 
@@ -138,7 +137,7 @@ template <typename Builder> void generate_ecdsa_verification_test_circuit(Builde
  */
 template <typename Builder> void generate_merkle_membership_test_circuit(Builder& builder, size_t num_iterations)
 {
-    using namespace proof_system::plonk::stdlib;
+    using namespace bb::plonk::stdlib;
     using field_ct = field_t<Builder>;
     using witness_ct = witness_t<Builder>;
     using witness_ct = witness_t<Builder>;
@@ -165,35 +164,33 @@ template <typename Builder> void generate_merkle_membership_test_circuit(Builder
 }
 
 // ultrahonk
-inline proof_system::honk::UltraProver get_prover(
-    proof_system::honk::UltraComposer& composer,
-    void (*test_circuit_function)(proof_system::honk::UltraComposer::CircuitBuilder&, size_t),
-    size_t num_iterations)
+inline bb::honk::UltraProver get_prover(bb::honk::UltraComposer& composer,
+                                        void (*test_circuit_function)(bb::honk::UltraComposer::CircuitBuilder&, size_t),
+                                        size_t num_iterations)
 {
-    proof_system::honk::UltraComposer::CircuitBuilder builder;
+    bb::honk::UltraComposer::CircuitBuilder builder;
     test_circuit_function(builder, num_iterations);
-    std::shared_ptr<proof_system::honk::UltraComposer::Instance> instance = composer.create_instance(builder);
+    std::shared_ptr<bb::honk::UltraComposer::Instance> instance = composer.create_instance(builder);
     return composer.create_prover(instance);
 }
 
 // standard plonk
-inline proof_system::plonk::Prover get_prover(proof_system::plonk::StandardComposer& composer,
-                                              void (*test_circuit_function)(proof_system::StandardCircuitBuilder&,
-                                                                            size_t),
-                                              size_t num_iterations)
+inline bb::plonk::Prover get_prover(bb::plonk::StandardComposer& composer,
+                                    void (*test_circuit_function)(bb::StandardCircuitBuilder&, size_t),
+                                    size_t num_iterations)
 {
-    proof_system::StandardCircuitBuilder builder;
+    bb::StandardCircuitBuilder builder;
     test_circuit_function(builder, num_iterations);
     return composer.create_prover(builder);
 }
 
 // ultraplonk
-inline proof_system::plonk::UltraProver get_prover(
-    proof_system::plonk::UltraComposer& composer,
-    void (*test_circuit_function)(proof_system::honk::UltraComposer::CircuitBuilder&, size_t),
-    size_t num_iterations)
+inline bb::plonk::UltraProver get_prover(bb::plonk::UltraComposer& composer,
+                                         void (*test_circuit_function)(bb::honk::UltraComposer::CircuitBuilder&,
+                                                                       size_t),
+                                         size_t num_iterations)
 {
-    proof_system::plonk::UltraComposer::CircuitBuilder builder;
+    bb::plonk::UltraComposer::CircuitBuilder builder;
     test_circuit_function(builder, num_iterations);
     return composer.create_prover(builder);
 }

--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk.bench.cpp
@@ -5,7 +5,7 @@
 #include "barretenberg/ultra_honk/ultra_composer.hpp"
 
 using namespace benchmark;
-using namespace proof_system;
+using namespace bb;
 
 /**
  * @brief Benchmark: Construction of a Ultra Honk proof for a circuit determined by the provided circuit function

--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk_rounds.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk_rounds.bench.cpp
@@ -6,7 +6,7 @@
 #include "barretenberg/ultra_honk/ultra_prover.hpp"
 
 using namespace benchmark;
-using namespace proof_system;
+using namespace bb;
 
 // The rounds to measure
 enum {

--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_plonk.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_plonk.bench.cpp
@@ -3,7 +3,7 @@
 #include "barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp"
 
 using namespace benchmark;
-using namespace proof_system;
+using namespace bb;
 
 /**
  * @brief Benchmark: Construction of a Ultra Plonk proof for a circuit determined by the provided circuit function

--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_plonk_rounds.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_plonk_rounds.bench.cpp
@@ -4,7 +4,7 @@
 #include "barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp"
 
 using namespace benchmark;
-using namespace proof_system;
+using namespace bb;
 
 // The rounds to measure
 enum {

--- a/barretenberg/cpp/src/barretenberg/benchmark/widgets_bench/widget.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/widgets_bench/widget.bench.cpp
@@ -22,7 +22,7 @@ namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 #ifdef GET_PER_ROW_TIME
 constexpr size_t LARGE_DOMAIN_SIZE = 4;
@@ -113,4 +113,4 @@ BENCHMARK(accumulate_contribution<ProverGenPermSortWidget<ultra_settings>>);
 BENCHMARK(accumulate_contribution<ProverEllipticWidget<ultra_settings>>);
 BENCHMARK(accumulate_contribution<ProverPlookupAuxiliaryWidget<ultra_settings>>);
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/claim.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/claim.hpp
@@ -3,7 +3,7 @@
 #include "barretenberg/commitment_schemes/commitment_key.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
 
-namespace proof_system::honk::pcs {
+namespace bb::honk::pcs {
 /**
  * @brief Opening pair (r,v) for some witness polynomial p(X) such that p(r) = v
  *
@@ -72,4 +72,4 @@ template <typename Curve> class OpeningClaim {
 
     bool operator==(const OpeningClaim& other) const = default;
 };
-} // namespace proof_system::honk::pcs
+} // namespace bb::honk::pcs

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
@@ -19,7 +19,7 @@
 #include <memory>
 #include <string_view>
 
-namespace proof_system::honk::pcs {
+namespace bb::honk::pcs {
 
 /**
  * @brief CommitmentKey object over a pairing group 𝔾₁.
@@ -74,4 +74,4 @@ template <class Curve> class CommitmentKey {
     std::shared_ptr<bb::srs::factories::ProverCrs<Curve>> srs;
 };
 
-} // namespace proof_system::honk::pcs
+} // namespace bb::honk::pcs

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.test.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.test.hpp
@@ -13,7 +13,7 @@
 
 #include <gtest/gtest.h>
 
-namespace proof_system::honk::pcs {
+namespace bb::honk::pcs {
 
 template <class CK> inline std::shared_ptr<CK> CreateCommitmentKey();
 
@@ -206,4 +206,4 @@ using IpaCommitmentSchemeParams = ::testing::Types<curve::Grumpkin>;
 // using CommitmentSchemeParams =
 //     ::testing::Types<fake::Params<bb::g1>, fake::Params<grumpkin::g1>, kzg::Params>;
 
-} // namespace proof_system::honk::pcs
+} // namespace bb::honk::pcs

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini.cpp
@@ -42,7 +42,7 @@
  * The verifier is able to computed the simulated commitments to A₀₊(X) and A₀₋(X)
  * since they are linear-combinations of the commitments [fⱼ] and [gⱼ].
  */
-namespace proof_system::honk::pcs::gemini {
+namespace bb::honk::pcs::gemini {
 
 /**
  * @brief Computes d-1 fold polynomials Fold_i, i = 1, ..., d-1
@@ -188,4 +188,4 @@ ProverOutput<Curve> GeminiProver_<Curve>::compute_fold_polynomial_evaluations(
 
 template class GeminiProver_<curve::BN254>;
 template class GeminiProver_<curve::Grumpkin>;
-}; // namespace proof_system::honk::pcs::gemini
+}; // namespace bb::honk::pcs::gemini

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini.hpp
@@ -42,7 +42,7 @@
  * The verifier is able to computed the simulated commitments to A₀₊(X) and A₀₋(X)
  * since they are linear-combinations of the commitments [fⱼ] and [gⱼ].
  */
-namespace proof_system::honk::pcs::gemini {
+namespace bb::honk::pcs::gemini {
 
 /**
  * @brief Prover output (evalutation pair, witness) that can be passed on to Shplonk batch opening.
@@ -109,7 +109,7 @@ template <typename Curve> class GeminiProver_ {
     static ProverOutput<Curve> compute_fold_polynomial_evaluations(std::span<const Fr> mle_opening_point,
                                                                    std::vector<Polynomial>&& gemini_polynomials,
                                                                    const Fr& r_challenge);
-}; // namespace proof_system::honk::pcs::gemini
+}; // namespace bb::honk::pcs::gemini
 
 template <typename Curve> class GeminiVerifier_ {
     using Fr = typename Curve::ScalarField;
@@ -262,6 +262,6 @@ template <typename Curve> class GeminiVerifier_ {
         return { C0_r_pos, C0_r_neg };
     }
 
-}; // namespace proof_system::honk::pcs::gemini
+}; // namespace bb::honk::pcs::gemini
 
-} // namespace proof_system::honk::pcs::gemini
+} // namespace bb::honk::pcs::gemini

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini.test.cpp
@@ -7,7 +7,7 @@
 #include <gtest/gtest.h>
 #include <span>
 
-namespace proof_system::honk::pcs::gemini {
+namespace bb::honk::pcs::gemini {
 
 template <class Curve> class GeminiTest : public CommitmentTest<Curve> {
     using GeminiProver = GeminiProver_<Curve>;
@@ -238,4 +238,4 @@ TYPED_TEST(GeminiTest, DoubleWithShift)
                                            multilinear_commitments_to_be_shifted);
 }
 
-} // namespace proof_system::honk::pcs::gemini
+} // namespace bb::honk::pcs::gemini

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
@@ -14,7 +14,7 @@
  * https://hackmd.io/q-A8y6aITWyWJrvsGGMWNA?view.
  *
  */
-namespace proof_system::honk::pcs::ipa {
+namespace bb::honk::pcs::ipa {
 template <typename Curve> class IPA {
     using Fr = typename Curve::ScalarField;
     using GroupElement = typename Curve::Element;
@@ -280,4 +280,4 @@ template <typename Curve> class IPA {
     }
 };
 
-} // namespace proof_system::honk::pcs::ipa
+} // namespace bb::honk::pcs::ipa

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.test.cpp
@@ -9,7 +9,7 @@
 #include "barretenberg/polynomials/polynomial_arithmetic.hpp"
 #include <gtest/gtest.h>
 using namespace bb;
-namespace proof_system::honk::pcs::ipa::test {
+namespace bb::honk::pcs::ipa::test {
 
 using Curve = curve::Grumpkin;
 
@@ -176,4 +176,4 @@ TEST_F(IPATest, GeminiShplonkIPAWithShift)
 
     EXPECT_EQ(verified, true);
 }
-} // namespace proof_system::honk::pcs::ipa::test
+} // namespace bb::honk::pcs::ipa::test

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
@@ -9,7 +9,7 @@
 #include <memory>
 #include <utility>
 
-namespace proof_system::honk::pcs::kzg {
+namespace bb::honk::pcs::kzg {
 
 template <typename Curve> class KZG {
     using CK = CommitmentKey<Curve>;
@@ -101,4 +101,4 @@ template <typename Curve> class KZG {
         return { P_0, P_1 };
     };
 };
-} // namespace proof_system::honk::pcs::kzg
+} // namespace bb::honk::pcs::kzg

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.test.cpp
@@ -12,7 +12,7 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-namespace proof_system::honk::pcs::kzg {
+namespace bb::honk::pcs::kzg {
 
 template <class Curve> class KZGTest : public CommitmentTest<Curve> {
   public:
@@ -177,4 +177,4 @@ TYPED_TEST(KZGTest, GeminiShplonkKzgWithShift)
     EXPECT_EQ(verified, true);
 }
 
-} // namespace proof_system::honk::pcs::kzg
+} // namespace bb::honk::pcs::kzg

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplonk.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplonk.hpp
@@ -18,7 +18,7 @@
  * The challenges are ρ (batching) and r (random evaluation).
  *
  */
-namespace proof_system::honk::pcs::shplonk {
+namespace bb::honk::pcs::shplonk {
 
 /**
  * @brief Polynomial G(X) = Q(X) - ∑ₖ ẑₖ(r)⋅( Bₖ(X) − Tₖ(z) ), where Q(X) = ∑ₖ ( Bₖ(X) − Tₖ(X) ) / zₖ(X)
@@ -271,4 +271,4 @@ template <typename Curve> class ShplonkVerifier_ {
         return { { z_challenge, Fr(0) }, G_commitment };
     };
 };
-} // namespace proof_system::honk::pcs::shplonk
+} // namespace bb::honk::pcs::shplonk

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplonk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplonk.test.cpp
@@ -10,7 +10,7 @@
 #include "../commitment_key.test.hpp"
 #include "barretenberg/commitment_schemes/claim.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
-namespace proof_system::honk::pcs::shplonk {
+namespace bb::honk::pcs::shplonk {
 template <class Params> class ShplonkTest : public CommitmentTest<Params> {};
 
 using CurveTypes = ::testing::Types<curve::BN254, curve::Grumpkin>;
@@ -71,4 +71,4 @@ TYPED_TEST(ShplonkTest, ShplonkSimple)
 
     this->verify_opening_claim(verifier_claim, shplonk_prover_witness);
 }
-} // namespace proof_system::honk::pcs::shplonk
+} // namespace bb::honk::pcs::shplonk

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/verification_key.hpp
@@ -20,7 +20,7 @@
 #include <memory>
 #include <string_view>
 
-namespace proof_system::honk::pcs {
+namespace bb::honk::pcs {
 
 template <class Curve> class VerifierCommitmentKey;
 
@@ -98,4 +98,4 @@ template <> class VerifierCommitmentKey<curve::Grumpkin> {
     std::shared_ptr<bb::srs::factories::VerifierCrs<Curve>> srs;
 };
 
-} // namespace proof_system::honk::pcs
+} // namespace bb::honk::pcs

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/wrapper.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/wrapper.hpp
@@ -3,7 +3,7 @@
 #include "barretenberg/ecc/curves/bn254/g1.hpp"
 #include "gemini/gemini.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 struct OpeningProof {
     std::vector<bb::g1::affine_element> gemini;
@@ -11,4 +11,4 @@ struct OpeningProof {
     bb::g1::affine_element kzg;
 };
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/zeromorph/zeromorph.hpp
@@ -5,7 +5,7 @@
 #include "barretenberg/polynomials/polynomial.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::honk::pcs::zeromorph {
+namespace bb::honk::pcs::zeromorph {
 
 /**
  * @brief Compute powers of a given challenge
@@ -728,4 +728,4 @@ template <typename Curve> class ZeroMorphVerifier_ {
     }
 };
 
-} // namespace proof_system::honk::pcs::zeromorph
+} // namespace bb::honk::pcs::zeromorph

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/zeromorph/zeromorph.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/zeromorph/zeromorph.test.cpp
@@ -4,7 +4,7 @@
 
 #include <gtest/gtest.h>
 
-namespace proof_system::honk::pcs::zeromorph {
+namespace bb::honk::pcs::zeromorph {
 
 template <class Curve> class ZeroMorphTest : public CommitmentTest<Curve> {
   public:
@@ -532,4 +532,4 @@ TYPED_TEST(ZeroMorphWithConcatenationTest, ProveAndVerify)
     auto verified = this->execute_zeromorph_protocol(num_unshifted, num_shifted, num_concatenated);
     EXPECT_TRUE(verified);
 }
-} // namespace proof_system::honk::pcs::zeromorph
+} // namespace bb::honk::pcs::zeromorph

--- a/barretenberg/cpp/src/barretenberg/common/fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/fuzzer.hpp
@@ -690,7 +690,7 @@ template <template <typename> class Fuzzer, uint64_t Composers>
 constexpr void RunWithBuilders(const uint8_t* Data, const size_t Size, FastRandom& VarianceRNG)
 {
     if (Composers & 1) {
-        RunWithBuilder<Fuzzer, proof_system::StandardCircuitBuilder>(Data, Size, VarianceRNG);
+        RunWithBuilder<Fuzzer, bb::StandardCircuitBuilder>(Data, Size, VarianceRNG);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.cpp
@@ -5,8 +5,8 @@ namespace acir_format {
 
 template <typename Builder> void create_blake2s_constraints(Builder& builder, const Blake2sConstraint& constraint)
 {
-    using byte_array_ct = proof_system::plonk::stdlib::byte_array<Builder>;
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
+    using byte_array_ct = bb::plonk::stdlib::byte_array<Builder>;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
 
     // Create byte array struct
     byte_array_ct arr(&builder);
@@ -26,7 +26,7 @@ template <typename Builder> void create_blake2s_constraints(Builder& builder, co
         arr.write(element_bytes);
     }
 
-    byte_array_ct output_bytes = proof_system::plonk::stdlib::blake2s<Builder>(arr);
+    byte_array_ct output_bytes = bb::plonk::stdlib::blake2s<Builder>(arr);
 
     // Convert byte array to vector of field_t
     auto bytes = output_bytes.bytes();

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.cpp
@@ -5,8 +5,8 @@ namespace acir_format {
 
 template <typename Builder> void create_blake3_constraints(Builder& builder, const Blake3Constraint& constraint)
 {
-    using byte_array_ct = proof_system::plonk::stdlib::byte_array<Builder>;
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
+    using byte_array_ct = bb::plonk::stdlib::byte_array<Builder>;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
 
     // Create byte array struct
     byte_array_ct arr(&builder);
@@ -26,7 +26,7 @@ template <typename Builder> void create_blake3_constraints(Builder& builder, con
         arr.write(element_bytes);
     }
 
-    byte_array_ct output_bytes = proof_system::plonk::stdlib::blake3s<Builder>(arr);
+    byte_array_ct output_bytes = bb::plonk::stdlib::blake3s<Builder>(arr);
 
     // Convert byte array to vector of field_t
     auto bytes = output_bytes.bytes();

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
@@ -2,14 +2,14 @@
 #include "barretenberg/stdlib/primitives/memory/ram_table.hpp"
 #include "barretenberg/stdlib/primitives/memory/rom_table.hpp"
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 namespace acir_format {
 
 template <typename Builder>
-proof_system::plonk::stdlib::field_t<Builder> poly_to_field_ct(const poly_triple poly, Builder& builder)
+bb::plonk::stdlib::field_t<Builder> poly_to_field_ct(const poly_triple poly, Builder& builder)
 {
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
 
     ASSERT(poly.q_m == 0);
     ASSERT(poly.q_r == 0);
@@ -26,9 +26,9 @@ proof_system::plonk::stdlib::field_t<Builder> poly_to_field_ct(const poly_triple
 template <typename Builder>
 void create_block_constraints(Builder& builder, const BlockConstraint constraint, bool has_valid_witness_assignments)
 {
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
-    using rom_table_ct = proof_system::plonk::stdlib::rom_table<Builder>;
-    using ram_table_ct = proof_system::plonk::stdlib::ram_table<Builder>;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
+    using rom_table_ct = bb::plonk::stdlib::rom_table<Builder>;
+    using ram_table_ct = bb::plonk::stdlib::ram_table<Builder>;
 
     std::vector<field_ct> init;
     for (auto i : constraint.init) {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.cpp
@@ -3,7 +3,7 @@
 
 namespace acir_format {
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 template <typename Builder>
 crypto::ecdsa::signature ecdsa_convert_signature(Builder& builder, std::vector<uint32_t> signature)
@@ -64,11 +64,11 @@ secp256k1_ct::g1_ct ecdsa_convert_inputs(Builder* ctx, const secp256k1::g1::affi
 // with just a byte.
 // notice that this function truncates each field_element to a byte
 template <typename Builder>
-proof_system::plonk::stdlib::byte_array<Builder> ecdsa_vector_of_bytes_to_byte_array(
-    Builder& builder, std::vector<uint32_t> vector_of_bytes)
+bb::plonk::stdlib::byte_array<Builder> ecdsa_vector_of_bytes_to_byte_array(Builder& builder,
+                                                                           std::vector<uint32_t> vector_of_bytes)
 {
-    using byte_array_ct = proof_system::plonk::stdlib::byte_array<Builder>;
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
+    using byte_array_ct = bb::plonk::stdlib::byte_array<Builder>;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
 
     byte_array_ct arr(&builder);
 
@@ -95,10 +95,10 @@ void create_ecdsa_k1_verify_constraints(Builder& builder,
                                         const EcdsaSecp256k1Constraint& input,
                                         bool has_valid_witness_assignments)
 {
-    using secp256k1_ct = proof_system::plonk::stdlib::secp256k1<Builder>;
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
-    using bool_ct = proof_system::plonk::stdlib::bool_t<Builder>;
-    using byte_array_ct = proof_system::plonk::stdlib::byte_array<Builder>;
+    using secp256k1_ct = bb::plonk::stdlib::secp256k1<Builder>;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
+    using bool_ct = bb::plonk::stdlib::bool_t<Builder>;
+    using byte_array_ct = bb::plonk::stdlib::byte_array<Builder>;
 
     if (has_valid_witness_assignments == false) {
         dummy_ecdsa_constraint(builder, input);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.hpp
@@ -41,7 +41,7 @@ template <typename Builder>
 crypto::ecdsa::signature ecdsa_convert_signature(Builder& builder, std::vector<uint32_t> signature);
 witness_ct ecdsa_index_to_witness(Builder& builder, uint32_t index);
 template <typename Builder>
-proof_system::plonk::stdlib::byte_array<Builder> ecdsa_vector_of_bytes_to_byte_array(
-    Builder& builder, std::vector<uint32_t> vector_of_bytes);
+bb::plonk::stdlib::byte_array<Builder> ecdsa_vector_of_bytes_to_byte_array(Builder& builder,
+                                                                           std::vector<uint32_t> vector_of_bytes);
 
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.test.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 namespace acir_format::tests {
-using curve_ct = proof_system::plonk::stdlib::secp256k1<Builder>;
+using curve_ct = bb::plonk::stdlib::secp256k1<Builder>;
 
 class ECDSASecp256k1 : public ::testing::Test {
   protected:

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256r1.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256r1.cpp
@@ -5,7 +5,7 @@
 
 namespace acir_format {
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 secp256r1_ct::g1_ct ecdsa_convert_inputs(Builder* ctx, const secp256r1::g1::affine_element& input)
 {
@@ -28,9 +28,9 @@ void create_ecdsa_r1_verify_constraints(Builder& builder,
                                         const EcdsaSecp256r1Constraint& input,
                                         bool has_valid_witness_assignments)
 {
-    using secp256r1_ct = proof_system::plonk::stdlib::secp256r1<Builder>;
-    using bool_ct = proof_system::plonk::stdlib::bool_t<Builder>;
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
+    using secp256r1_ct = bb::plonk::stdlib::secp256r1<Builder>;
+    using bool_ct = bb::plonk::stdlib::bool_t<Builder>;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
 
     if (has_valid_witness_assignments == false) {
         dummy_ecdsa_constraint(builder, input);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256r1.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256r1.test.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 namespace acir_format::tests {
-using curve_ct = proof_system::plonk::stdlib::secp256r1<Builder>;
+using curve_ct = bb::plonk::stdlib::secp256r1<Builder>;
 
 // Generate r1 constraints given pre generated pubkey, sig and message values
 size_t generate_r1_constraints(EcdsaSecp256r1Constraint& ecdsa_r1_constraint,

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/fixed_base_scalar_mul.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/fixed_base_scalar_mul.cpp
@@ -8,9 +8,9 @@ namespace acir_format {
 
 template <typename Builder> void create_fixed_base_constraint(Builder& builder, const FixedBaseScalarMul& input)
 {
-    using cycle_group_ct = proof_system::plonk::stdlib::cycle_group<Builder>;
-    using cycle_scalar_ct = typename proof_system::plonk::stdlib::cycle_group<Builder>::cycle_scalar;
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
+    using cycle_group_ct = bb::plonk::stdlib::cycle_group<Builder>;
+    using cycle_scalar_ct = typename bb::plonk::stdlib::cycle_group<Builder>::cycle_scalar;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
 
     // Computes low * G + high * 2^128 * G
     //

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/keccak_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/keccak_constraint.cpp
@@ -7,8 +7,8 @@ namespace acir_format {
 
 template <typename Builder> void create_keccak_constraints(Builder& builder, const KeccakConstraint& constraint)
 {
-    using byte_array_ct = proof_system::plonk::stdlib::byte_array<Builder>;
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
+    using byte_array_ct = bb::plonk::stdlib::byte_array<Builder>;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
 
     // Create byte array struct
     byte_array_ct arr(&builder);
@@ -28,7 +28,7 @@ template <typename Builder> void create_keccak_constraints(Builder& builder, con
         arr.write(element_bytes);
     }
 
-    byte_array_ct output_bytes = proof_system::plonk::stdlib::keccak<Builder>::hash(arr);
+    byte_array_ct output_bytes = bb::plonk::stdlib::keccak<Builder>::hash(arr);
 
     // Convert byte array to vector of field_t
     auto bytes = output_bytes.bytes();
@@ -40,9 +40,9 @@ template <typename Builder> void create_keccak_constraints(Builder& builder, con
 
 template <typename Builder> void create_keccak_var_constraints(Builder& builder, const KeccakVarConstraint& constraint)
 {
-    using byte_array_ct = proof_system::plonk::stdlib::byte_array<Builder>;
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
-    using uint32_ct = proof_system::plonk::stdlib::uint32<Builder>;
+    using byte_array_ct = bb::plonk::stdlib::byte_array<Builder>;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
+    using uint32_ct = bb::plonk::stdlib::uint32<Builder>;
 
     // Create byte array struct
     byte_array_ct arr(&builder);
@@ -64,7 +64,7 @@ template <typename Builder> void create_keccak_var_constraints(Builder& builder,
 
     uint32_ct length = field_ct::from_witness_index(&builder, constraint.var_message_size);
 
-    byte_array_ct output_bytes = proof_system::plonk::stdlib::keccak<Builder>::hash(arr, length);
+    byte_array_ct output_bytes = bb::plonk::stdlib::keccak<Builder>::hash(arr, length);
 
     // Convert byte array to vector of field_t
     auto bytes = output_bytes.bytes();
@@ -76,10 +76,10 @@ template <typename Builder> void create_keccak_var_constraints(Builder& builder,
 
 template <typename Builder> void create_keccak_permutations(Builder& builder, const Keccakf1600& constraint)
 {
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
 
     // Create the array containing the permuted state
-    std::array<field_ct, proof_system::plonk::stdlib::keccak<Builder>::NUM_KECCAK_LANES> state;
+    std::array<field_ct, bb::plonk::stdlib::keccak<Builder>::NUM_KECCAK_LANES> state;
 
     // Get the witness assignment for each witness index
     // Write the witness assignment to the byte_array
@@ -88,8 +88,7 @@ template <typename Builder> void create_keccak_permutations(Builder& builder, co
         state[i] = field_ct::from_witness_index(&builder, constraint.state[i]);
     }
 
-    std::array<field_ct, 25> output_state =
-        proof_system::plonk::stdlib::keccak<Builder>::permutation_opcode(state, &builder);
+    std::array<field_ct, 25> output_state = bb::plonk::stdlib::keccak<Builder>::permutation_opcode(state, &builder);
 
     for (size_t i = 0; i < output_state.size(); ++i) {
         builder.assert_equal(output_state[i].normalize().witness_index, constraint.result[i]);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.cpp
@@ -3,7 +3,7 @@
 
 namespace acir_format {
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 template <typename Builder>
 void create_logic_gate(Builder& builder,
@@ -13,7 +13,7 @@ void create_logic_gate(Builder& builder,
                        const size_t num_bits,
                        const bool is_xor_gate)
 {
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
 
     field_ct left = field_ct::from_witness_index(&builder, a);
     field_ct right = field_ct::from_witness_index(&builder, b);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/pedersen.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/pedersen.cpp
@@ -2,11 +2,11 @@
 
 namespace acir_format {
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 template <typename Builder> void create_pedersen_constraint(Builder& builder, const PedersenConstraint& input)
 {
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
 
     std::vector<field_ct> scalars;
 
@@ -24,7 +24,7 @@ template <typename Builder> void create_pedersen_constraint(Builder& builder, co
 
 template <typename Builder> void create_pedersen_hash_constraint(Builder& builder, const PedersenHashConstraint& input)
 {
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
 
     std::vector<field_ct> scalars;
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.cpp
@@ -7,7 +7,7 @@
 
 namespace acir_format {
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 // `NUM_LIMB_BITS_IN_FIELD_SIMULATION` is the limb size when simulating a non-native field using the bigfield class
 // A aggregation object is two acir_format::g1_ct types where each coordinate in a point is a non-native field.
@@ -136,7 +136,7 @@ std::array<uint32_t, RecursionConstraint::AGGREGATION_OBJECT_SIZE> create_recurs
     vkey->program_width = noir_recursive_settings::program_width;
 
     Transcript_ct transcript(&builder, manifest, proof_fields, input.public_inputs.size());
-    aggregation_state_ct result = proof_system::plonk::stdlib::recursion::verify_proof_<bn254, noir_recursive_settings>(
+    aggregation_state_ct result = bb::plonk::stdlib::recursion::verify_proof_<bn254, noir_recursive_settings>(
         &builder, vkey, transcript, previous_aggregation);
 
     // Assign correct witness value to the verification key hash

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.hpp
@@ -5,7 +5,7 @@
 
 namespace acir_format {
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 /**
  * @brief RecursionConstraint struct contains information required to recursively verify a proof!

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/recursion_constraint.test.cpp
@@ -6,7 +6,7 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 class AcirRecursionConstraint : public ::testing::Test {
   protected:

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/schnorr_verify.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/schnorr_verify.cpp
@@ -4,7 +4,7 @@
 
 namespace acir_format {
 
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 
 template <typename Builder>
 crypto::schnorr::signature convert_signature(Builder& builder, std::vector<uint32_t> signature)
@@ -45,11 +45,11 @@ crypto::schnorr::signature convert_signature(Builder& builder, std::vector<uint3
 // with just a byte.
 // notice that this function truncates each field_element to a byte
 template <typename Builder>
-proof_system::plonk::stdlib::byte_array<Builder> vector_of_bytes_to_byte_array(Builder& builder,
-                                                                               std::vector<uint32_t> vector_of_bytes)
+bb::plonk::stdlib::byte_array<Builder> vector_of_bytes_to_byte_array(Builder& builder,
+                                                                     std::vector<uint32_t> vector_of_bytes)
 {
-    using byte_array_ct = proof_system::plonk::stdlib::byte_array<Builder>;
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
+    using byte_array_ct = bb::plonk::stdlib::byte_array<Builder>;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
 
     byte_array_ct arr(&builder);
 
@@ -66,8 +66,7 @@ proof_system::plonk::stdlib::byte_array<Builder> vector_of_bytes_to_byte_array(B
     return arr;
 }
 
-template <typename Builder>
-proof_system::plonk::stdlib::witness_t<Builder> index_to_witness(Builder& builder, uint32_t index)
+template <typename Builder> bb::plonk::stdlib::witness_t<Builder> index_to_witness(Builder& builder, uint32_t index)
 {
     fr value = builder.get_variable(index);
     return { &builder, value };
@@ -75,10 +74,10 @@ proof_system::plonk::stdlib::witness_t<Builder> index_to_witness(Builder& builde
 
 template <typename Builder> void create_schnorr_verify_constraints(Builder& builder, const SchnorrConstraint& input)
 {
-    using witness_ct = proof_system::plonk::stdlib::witness_t<Builder>;
-    using cycle_group_ct = proof_system::plonk::stdlib::cycle_group<Builder>;
-    using schnorr_signature_bits_ct = proof_system::plonk::stdlib::schnorr::signature_bits<Builder>;
-    using bool_ct = proof_system::plonk::stdlib::bool_t<Builder>;
+    using witness_ct = bb::plonk::stdlib::witness_t<Builder>;
+    using cycle_group_ct = bb::plonk::stdlib::cycle_group<Builder>;
+    using schnorr_signature_bits_ct = bb::plonk::stdlib::schnorr::signature_bits<Builder>;
+    using bool_ct = bb::plonk::stdlib::bool_t<Builder>;
 
     auto new_sig = convert_signature(builder, input.signature);
     // From ignorance, you will see me convert a bunch of witnesses from ByteArray -> BitArray

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/sha256_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/sha256_constraint.cpp
@@ -9,8 +9,8 @@ namespace acir_format {
 // pair<witness_index, bits>
 template <typename Builder> void create_sha256_constraints(Builder& builder, const Sha256Constraint& constraint)
 {
-    using byte_array_ct = proof_system::plonk::stdlib::byte_array<Builder>;
-    using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
+    using byte_array_ct = bb::plonk::stdlib::byte_array<Builder>;
+    using field_ct = bb::plonk::stdlib::field_t<Builder>;
 
     // Create byte array struct
     byte_array_ct arr(&builder);
@@ -31,7 +31,7 @@ template <typename Builder> void create_sha256_constraints(Builder& builder, con
     }
 
     // Compute sha256
-    byte_array_ct output_bytes = proof_system::plonk::stdlib::sha256<Builder>(arr);
+    byte_array_ct output_bytes = bb::plonk::stdlib::sha256<Builder>(arr);
 
     // Convert byte array to vector of field_t
     auto bytes = output_bytes.bytes();

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/acir_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/acir_composer.cpp
@@ -32,7 +32,7 @@ void AcirComposer::create_circuit(acir_format::acir_format& constraint_system, W
     vinfo("gates: ", builder_.get_total_circuit_size());
 }
 
-std::shared_ptr<proof_system::plonk::proving_key> AcirComposer::init_proving_key()
+std::shared_ptr<bb::plonk::proving_key> AcirComposer::init_proving_key()
 {
     acir_format::Composer composer;
     vinfo("computing proving key...");
@@ -82,7 +82,7 @@ std::vector<uint8_t> AcirComposer::create_goblin_proof()
     return goblin.construct_proof(goblin_builder_);
 }
 
-std::shared_ptr<proof_system::plonk::verification_key> AcirComposer::init_verification_key()
+std::shared_ptr<bb::plonk::verification_key> AcirComposer::init_verification_key()
 {
     if (!proving_key_) {
         throw_or_abort("Compute proving key first.");
@@ -94,10 +94,10 @@ std::shared_ptr<proof_system::plonk::verification_key> AcirComposer::init_verifi
     return verification_key_;
 }
 
-void AcirComposer::load_verification_key(proof_system::plonk::verification_key_data&& data)
+void AcirComposer::load_verification_key(bb::plonk::verification_key_data&& data)
 {
-    verification_key_ = std::make_shared<proof_system::plonk::verification_key>(
-        std::move(data), srs::get_crs_factory()->get_verifier_crs());
+    verification_key_ =
+        std::make_shared<bb::plonk::verification_key>(std::move(data), srs::get_crs_factory()->get_verifier_crs());
 }
 
 bool AcirComposer::verify_proof(std::vector<uint8_t> const& proof, bool is_recursive)

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/acir_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/acir_composer.hpp
@@ -20,13 +20,13 @@ class AcirComposer {
     template <typename Builder = UltraCircuitBuilder>
     void create_circuit(acir_format::acir_format& constraint_system, WitnessVector const& witness = {});
 
-    std::shared_ptr<proof_system::plonk::proving_key> init_proving_key();
+    std::shared_ptr<bb::plonk::proving_key> init_proving_key();
 
     std::vector<uint8_t> create_proof(bool is_recursive);
 
-    void load_verification_key(proof_system::plonk::verification_key_data&& data);
+    void load_verification_key(bb::plonk::verification_key_data&& data);
 
-    std::shared_ptr<proof_system::plonk::verification_key> init_verification_key();
+    std::shared_ptr<bb::plonk::verification_key> init_verification_key();
 
     bool verify_proof(std::vector<uint8_t> const& proof, bool is_recursive);
 
@@ -48,8 +48,8 @@ class AcirComposer {
     acir_format::GoblinBuilder goblin_builder_;
     Goblin goblin;
     size_t size_hint_;
-    std::shared_ptr<proof_system::plonk::proving_key> proving_key_;
-    std::shared_ptr<proof_system::plonk::verification_key> verification_key_;
+    std::shared_ptr<bb::plonk::proving_key> proving_key_;
+    std::shared_ptr<bb::plonk::verification_key> verification_key_;
     bool verbose_ = true;
 
     template <typename... Args> inline void vinfo(Args... args)

--- a/barretenberg/cpp/src/barretenberg/dsl/types.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/types.hpp
@@ -25,7 +25,7 @@
 
 namespace acir_format {
 
-using Builder = proof_system::UltraCircuitBuilder;
+using Builder = bb::UltraCircuitBuilder;
 using GoblinBuilder = bb::Goblin::Builder;
 using Composer = plonk::UltraComposer;
 
@@ -37,38 +37,38 @@ using Verifier =
 
 using RecursiveProver = plonk::UltraProver;
 
-using witness_ct = proof_system::plonk::stdlib::witness_t<Builder>;
-using public_witness_ct = proof_system::plonk::stdlib::public_witness_t<Builder>;
-using bool_ct = proof_system::plonk::stdlib::bool_t<Builder>;
-using byte_array_ct = proof_system::plonk::stdlib::byte_array<Builder>;
-using packed_byte_array_ct = proof_system::plonk::stdlib::packed_byte_array<Builder>;
-using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
-using suint_ct = proof_system::plonk::stdlib::safe_uint_t<Builder>;
-using uint8_ct = proof_system::plonk::stdlib::uint8<Builder>;
-using uint16_ct = proof_system::plonk::stdlib::uint16<Builder>;
-using uint32_ct = proof_system::plonk::stdlib::uint32<Builder>;
-using uint64_ct = proof_system::plonk::stdlib::uint64<Builder>;
-using bit_array_ct = proof_system::plonk::stdlib::bit_array<Builder>;
-using fq_ct = proof_system::plonk::stdlib::bigfield<Builder, bb::Bn254FqParams>;
-using biggroup_ct = proof_system::plonk::stdlib::element<Builder, fq_ct, field_ct, bb::g1>;
-using cycle_group_ct = proof_system::plonk::stdlib::cycle_group<Builder>;
-using cycle_scalar_ct = proof_system::plonk::stdlib::cycle_group<Builder>::cycle_scalar;
-using pedersen_commitment = proof_system::plonk::stdlib::pedersen_commitment<Builder>;
-using bn254 = proof_system::plonk::stdlib::bn254<Builder>;
-using secp256k1_ct = proof_system::plonk::stdlib::secp256k1<Builder>;
-using secp256r1_ct = proof_system::plonk::stdlib::secp256r1<Builder>;
+using witness_ct = bb::plonk::stdlib::witness_t<Builder>;
+using public_witness_ct = bb::plonk::stdlib::public_witness_t<Builder>;
+using bool_ct = bb::plonk::stdlib::bool_t<Builder>;
+using byte_array_ct = bb::plonk::stdlib::byte_array<Builder>;
+using packed_byte_array_ct = bb::plonk::stdlib::packed_byte_array<Builder>;
+using field_ct = bb::plonk::stdlib::field_t<Builder>;
+using suint_ct = bb::plonk::stdlib::safe_uint_t<Builder>;
+using uint8_ct = bb::plonk::stdlib::uint8<Builder>;
+using uint16_ct = bb::plonk::stdlib::uint16<Builder>;
+using uint32_ct = bb::plonk::stdlib::uint32<Builder>;
+using uint64_ct = bb::plonk::stdlib::uint64<Builder>;
+using bit_array_ct = bb::plonk::stdlib::bit_array<Builder>;
+using fq_ct = bb::plonk::stdlib::bigfield<Builder, bb::Bn254FqParams>;
+using biggroup_ct = bb::plonk::stdlib::element<Builder, fq_ct, field_ct, bb::g1>;
+using cycle_group_ct = bb::plonk::stdlib::cycle_group<Builder>;
+using cycle_scalar_ct = bb::plonk::stdlib::cycle_group<Builder>::cycle_scalar;
+using pedersen_commitment = bb::plonk::stdlib::pedersen_commitment<Builder>;
+using bn254 = bb::plonk::stdlib::bn254<Builder>;
+using secp256k1_ct = bb::plonk::stdlib::secp256k1<Builder>;
+using secp256r1_ct = bb::plonk::stdlib::secp256r1<Builder>;
 
-using hash_path_ct = proof_system::plonk::stdlib::merkle_tree::hash_path<Builder>;
+using hash_path_ct = bb::plonk::stdlib::merkle_tree::hash_path<Builder>;
 
-using schnorr_signature_bits_ct = proof_system::plonk::stdlib::schnorr::signature_bits<Builder>;
+using schnorr_signature_bits_ct = bb::plonk::stdlib::schnorr::signature_bits<Builder>;
 
 // Ultra-composer specific typesv
-using rom_table_ct = proof_system::plonk::stdlib::rom_table<Builder>;
-using ram_table_ct = proof_system::plonk::stdlib::ram_table<Builder>;
+using rom_table_ct = bb::plonk::stdlib::rom_table<Builder>;
+using ram_table_ct = bb::plonk::stdlib::ram_table<Builder>;
 
-using verification_key_ct = proof_system::plonk::stdlib::recursion::verification_key<bn254>;
-using aggregation_state_ct = proof_system::plonk::stdlib::recursion::aggregation_state<bn254>;
-using noir_recursive_settings = proof_system::plonk::stdlib::recursion::recursive_ultra_verifier_settings<bn254>;
-using Transcript_ct = proof_system::plonk::stdlib::recursion::Transcript<Builder>;
+using verification_key_ct = bb::plonk::stdlib::recursion::verification_key<bn254>;
+using aggregation_state_ct = bb::plonk::stdlib::recursion::aggregation_state<bn254>;
+using noir_recursive_settings = bb::plonk::stdlib::recursion::recursive_ultra_verifier_settings<bn254>;
+using Transcript_ct = bb::plonk::stdlib::recursion::Transcript<Builder>;
 
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/types.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/types.hpp
@@ -1,5 +1,5 @@
 #pragma once
 
-namespace proof_system {
+namespace bb {
 enum CurveType { BN254, SECP256K1, SECP256R1, GRUMPKIN };
 }

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.cpp
@@ -2,7 +2,7 @@
 #include "barretenberg/proof_system/composer/composer_lib.hpp"
 #include "barretenberg/proof_system/composer/permutation_lib.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 /**
  * @brief Compute witness polynomials
@@ -119,4 +119,4 @@ std::shared_ptr<typename Flavor::VerificationKey> ECCVMComposer_<Flavor>::comput
 }
 template class ECCVMComposer_<honk::flavor::ECCVM>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.hpp
@@ -7,7 +7,7 @@
 #include "barretenberg/srs/factories/file_crs_factory.hpp"
 #include "barretenberg/srs/global_crs.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 template <ECCVMFlavor Flavor> class ECCVMComposer_ {
   public:
     using FF = typename Flavor::FF;
@@ -77,4 +77,4 @@ template <ECCVMFlavor Flavor> class ECCVMComposer_ {
 // TODO(#532): this pattern is weird; is this not instantiating the templates?
 using ECCVMComposer = ECCVMComposer_<honk::flavor::ECCVM>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.test.cpp
@@ -12,7 +12,7 @@
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/sumcheck/sumcheck_round.hpp"
 
-using namespace proof_system::honk;
+using namespace bb::honk;
 
 namespace test_eccvm_composer {
 
@@ -35,10 +35,9 @@ TYPED_TEST_SUITE(ECCVMComposerTests, FlavorTypes);
 namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
-template <typename Flavor>
-proof_system::ECCVMCircuitBuilder<Flavor> generate_trace(numeric::random::Engine* engine = nullptr)
+template <typename Flavor> bb::ECCVMCircuitBuilder<Flavor> generate_trace(numeric::random::Engine* engine = nullptr)
 {
-    proof_system::ECCVMCircuitBuilder<Flavor> result;
+    bb::ECCVMCircuitBuilder<Flavor> result;
     using G1 = typename Flavor::CycleGroup;
     using Fr = typename G1::Fr;
 

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
@@ -10,7 +10,7 @@
 #include "barretenberg/relations/permutation_relation.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 /**
  * Create ECCVMProver_ from proving key, witness and manifest.
@@ -309,4 +309,4 @@ template <ECCVMFlavor Flavor> plonk::proof& ECCVMProver_<Flavor>::construct_proo
 
 template class ECCVMProver_<honk::flavor::ECCVM>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.hpp
@@ -8,7 +8,7 @@
 #include "barretenberg/sumcheck/sumcheck_output.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 // We won't compile this class with honk::flavor::Standard, but we will like want to compile it (at least for testing)
 // with a flavor that uses the curve Grumpkin, or a flavor that does/does not have zk, etc.
@@ -51,7 +51,7 @@ template <ECCVMFlavor Flavor> class ECCVMProver_ {
 
     std::vector<FF> public_inputs;
 
-    proof_system::RelationParameters<FF> relation_parameters;
+    bb::RelationParameters<FF> relation_parameters;
 
     std::shared_ptr<ProvingKey> key;
 
@@ -83,4 +83,4 @@ template <ECCVMFlavor Flavor> class ECCVMProver_ {
     plonk::proof proof;
 };
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_transcript.test.cpp
@@ -6,7 +6,7 @@
 #include "barretenberg/transcript/transcript.hpp"
 #include <gtest/gtest.h>
 
-using namespace proof_system::honk;
+using namespace bb::honk;
 
 template <typename Flavor> class ECCVMTranscriptTests : public ::testing::Test {
   public:
@@ -183,9 +183,9 @@ template <typename Flavor> class ECCVMTranscriptTests : public ::testing::Test {
 
         return manifest_expected;
     }
-    proof_system::ECCVMCircuitBuilder<Flavor> generate_trace(numeric::random::Engine* engine = nullptr)
+    bb::ECCVMCircuitBuilder<Flavor> generate_trace(numeric::random::Engine* engine = nullptr)
     {
-        proof_system::ECCVMCircuitBuilder<Flavor> result;
+        bb::ECCVMCircuitBuilder<Flavor> result;
         using G1 = typename Flavor::CycleGroup;
         using Fr = typename G1::Fr;
 

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
@@ -5,9 +5,9 @@
 #include "barretenberg/transcript/transcript.hpp"
 
 using namespace bb;
-using namespace proof_system::honk::sumcheck;
+using namespace bb::honk::sumcheck;
 
-namespace proof_system::honk {
+namespace bb::honk {
 template <typename Flavor>
 ECCVMVerifier_<Flavor>::ECCVMVerifier_(const std::shared_ptr<typename Flavor::VerificationKey>& verifier_key)
     : key(verifier_key)
@@ -283,4 +283,4 @@ template <typename Flavor> bool ECCVMVerifier_<Flavor>::verify_proof(const plonk
 
 template class ECCVMVerifier_<honk::flavor::ECCVM>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.hpp
@@ -3,7 +3,7 @@
 #include "barretenberg/plonk/proof_system/types/proof.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 template <typename Flavor> class ECCVMVerifier_ {
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
@@ -41,4 +41,4 @@ template <typename Flavor> class ECCVMVerifier_ {
 
 using ECCVMVerifierGrumpkin = ECCVMVerifier_<honk::flavor::ECCVM>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/examples/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/examples/c_bind.cpp
@@ -2,7 +2,7 @@
 #include "barretenberg/srs/global_crs.hpp"
 #include "simple/simple.hpp"
 
-using namespace proof_system::plonk::stdlib::types;
+using namespace bb::plonk::stdlib::types;
 
 WASM_EXPORT void examples_simple_create_and_verify_proof(bool* valid)
 {

--- a/barretenberg/cpp/src/barretenberg/examples/simple/simple.cpp
+++ b/barretenberg/cpp/src/barretenberg/examples/simple/simple.cpp
@@ -6,7 +6,7 @@
 
 namespace examples::simple {
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 using namespace stdlib::types;
 
 const size_t CIRCUIT_SIZE = 1 << 19;
@@ -51,7 +51,7 @@ proof create_proof(BuilderComposerPtrs pair)
     return proof;
 }
 
-bool verify_proof(BuilderComposerPtrs pair, proof_system::plonk::proof const& proof)
+bool verify_proof(BuilderComposerPtrs pair, bb::plonk::proof const& proof)
 {
     info("computing verification key...");
     pair.composer->compute_verification_key(*pair.builder);

--- a/barretenberg/cpp/src/barretenberg/examples/simple/simple.hpp
+++ b/barretenberg/cpp/src/barretenberg/examples/simple/simple.hpp
@@ -4,7 +4,7 @@
 
 namespace examples::simple {
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 using namespace stdlib::types;
 
 struct BuilderComposerPtrs {
@@ -16,7 +16,7 @@ BuilderComposerPtrs create_builder_and_composer();
 
 proof create_proof(BuilderComposerPtrs pair);
 
-bool verify_proof(BuilderComposerPtrs pair, proof_system::plonk::proof const& proof);
+bool verify_proof(BuilderComposerPtrs pair, bb::plonk::proof const& proof);
 
 void delete_builder_and_composer(BuilderComposerPtrs pair);
 

--- a/barretenberg/cpp/src/barretenberg/flavor/ecc_vm.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ecc_vm.hpp
@@ -26,7 +26,7 @@
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
 
-namespace proof_system::honk {
+namespace bb::honk {
 namespace flavor {
 
 template <typename CycleGroup_T, typename Curve_T, typename PCS_T> class ECCVMBase {
@@ -930,4 +930,4 @@ class ECCVM : public ECCVMBase<bb::g1, curve::Grumpkin, pcs::ipa::IPA<curve::Gru
 // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 
 } // namespace flavor
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -76,7 +76,7 @@
 #include <concepts>
 #include <vector>
 
-namespace proof_system::honk::flavor {
+namespace bb::honk::flavor {
 
 /**
  * @brief Base class template containing circuit-specifying data.
@@ -255,25 +255,25 @@ template <typename Tuple, std::size_t Index = 0> static constexpr auto create_tu
     }
 }
 
-} // namespace proof_system::honk::flavor
+} // namespace bb::honk::flavor
 
 // Forward declare honk flavors
-namespace proof_system::honk::flavor {
+namespace bb::honk::flavor {
 class Ultra;
 class ECCVM;
 class GoblinUltra;
 template <typename BuilderType> class UltraRecursive_;
 template <typename BuilderType> class GoblinUltraRecursive_;
-} // namespace proof_system::honk::flavor
+} // namespace bb::honk::flavor
 
 // Forward declare plonk flavors
-namespace proof_system::plonk::flavor {
+namespace bb::plonk::flavor {
 class Standard;
 class Ultra;
-} // namespace proof_system::plonk::flavor
+} // namespace bb::plonk::flavor
 
 // Establish concepts for testing flavor attributes
-namespace proof_system {
+namespace bb {
 /**
  * @brief Test whether a type T lies in a list of types ...U.
  *
@@ -326,4 +326,4 @@ inline std::string flavor_get_label(Container&& container, const Element& elemen
 }
 
 // clang-format on
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.test.cpp
@@ -4,10 +4,10 @@
 #include <cstddef>
 #include <gtest/gtest.h>
 
-namespace proof_system::test_flavor {
+namespace bb::test_flavor {
 TEST(Flavor, Getters)
 {
-    using Flavor = proof_system::honk::flavor::Ultra;
+    using Flavor = bb::honk::flavor::Ultra;
     using FF = Flavor::FF;
     using ProvingKey = typename Flavor::ProvingKey;
 
@@ -42,7 +42,7 @@ TEST(Flavor, Getters)
 
 TEST(Flavor, AllEntitiesSpecialMemberFunctions)
 {
-    using Flavor = proof_system::honk::flavor::Ultra;
+    using Flavor = bb::honk::flavor::Ultra;
     using FF = Flavor::FF;
     using PartiallyEvaluatedMultivariates = Flavor::PartiallyEvaluatedMultivariates;
     using Polynomial = bb::Polynomial<FF>;
@@ -68,7 +68,7 @@ TEST(Flavor, AllEntitiesSpecialMemberFunctions)
 
 TEST(Flavor, GetRow)
 {
-    using Flavor = proof_system::honk::flavor::Ultra;
+    using Flavor = bb::honk::flavor::Ultra;
     using FF = typename Flavor::FF;
     std::array<std::vector<FF>, Flavor::NUM_ALL_ENTITIES> data;
     std::generate(data.begin(), data.end(), []() {
@@ -83,4 +83,4 @@ TEST(Flavor, GetRow)
     EXPECT_EQ(row0.q_elliptic, prover_polynomials.q_elliptic[0]);
     EXPECT_EQ(row1.w_4_shift, prover_polynomials.w_4_shift[1]);
 }
-} // namespace proof_system::test_flavor
+} // namespace bb::test_flavor

--- a/barretenberg/cpp/src/barretenberg/flavor/generated/AvmMini_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/generated/AvmMini_flavor.hpp
@@ -17,7 +17,7 @@
 #include "barretenberg/relations/generated/AvmMini/mem_trace.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::honk::flavor {
+namespace bb::honk::flavor {
 
 class AvmMiniFlavor {
   public:
@@ -636,4 +636,4 @@ class AvmMiniFlavor {
     };
 };
 
-} // namespace proof_system::honk::flavor
+} // namespace bb::honk::flavor

--- a/barretenberg/cpp/src/barretenberg/flavor/generated/Toy_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/generated/Toy_flavor.hpp
@@ -17,7 +17,7 @@
 #include "barretenberg/relations/generated/Toy/two_column_perm.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 namespace flavor {
 
 class ToyFlavor {
@@ -369,4 +369,4 @@ class ToyFlavor {
 };
 
 } // namespace flavor
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/flavor/goblin_translator.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/goblin_translator.hpp
@@ -16,7 +16,7 @@
 #include "barretenberg/relations/translator_vm/translator_permutation_relation.hpp"
 #include "relation_definitions.hpp"
 
-namespace proof_system::honk::flavor {
+namespace bb::honk::flavor {
 
 class GoblinTranslator {
 
@@ -1138,4 +1138,4 @@ class GoblinTranslator {
 
     using Transcript = BaseTranscript;
 };
-} // namespace proof_system::honk::flavor
+} // namespace bb::honk::flavor

--- a/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra.hpp
@@ -19,7 +19,7 @@
 #include "barretenberg/transcript/transcript.hpp"
 #include "relation_definitions.hpp"
 
-namespace proof_system::honk::flavor {
+namespace bb::honk::flavor {
 
 class GoblinUltra {
   public:
@@ -46,25 +46,24 @@ class GoblinUltra {
     // The total number of witness entities not including shifts.
     static constexpr size_t NUM_WITNESS_ENTITIES = 14;
 
-    using GrandProductRelations =
-        std::tuple<proof_system::UltraPermutationRelation<FF>, proof_system::LookupRelation<FF>>;
+    using GrandProductRelations = std::tuple<bb::UltraPermutationRelation<FF>, bb::LookupRelation<FF>>;
 
     // define the tuple of Relations that comprise the Sumcheck relation
     // Note: made generic for use in GoblinUltraRecursive.
     template <typename FF>
-    using Relations_ = std::tuple<proof_system::UltraArithmeticRelation<FF>,
-                                  proof_system::UltraPermutationRelation<FF>,
-                                  proof_system::LookupRelation<FF>,
-                                  proof_system::GenPermSortRelation<FF>,
-                                  proof_system::EllipticRelation<FF>,
-                                  proof_system::AuxiliaryRelation<FF>,
-                                  proof_system::EccOpQueueRelation<FF>,
-                                  proof_system::DatabusLookupRelation<FF>,
-                                  proof_system::Poseidon2ExternalRelation<FF>,
-                                  proof_system::Poseidon2InternalRelation<FF>>;
+    using Relations_ = std::tuple<bb::UltraArithmeticRelation<FF>,
+                                  bb::UltraPermutationRelation<FF>,
+                                  bb::LookupRelation<FF>,
+                                  bb::GenPermSortRelation<FF>,
+                                  bb::EllipticRelation<FF>,
+                                  bb::AuxiliaryRelation<FF>,
+                                  bb::EccOpQueueRelation<FF>,
+                                  bb::DatabusLookupRelation<FF>,
+                                  bb::Poseidon2ExternalRelation<FF>,
+                                  bb::Poseidon2InternalRelation<FF>>;
     using Relations = Relations_<FF>;
 
-    using LogDerivLookupRelation = proof_system::DatabusLookupRelation<FF>;
+    using LogDerivLookupRelation = bb::DatabusLookupRelation<FF>;
 
     static constexpr size_t MAX_PARTIAL_RELATION_LENGTH = compute_max_partial_relation_length<Relations>();
     static constexpr size_t MAX_TOTAL_RELATION_LENGTH = compute_max_total_relation_length<Relations>();
@@ -623,4 +622,4 @@ class GoblinUltra {
     using Transcript = Transcript_<Commitment>;
 };
 
-} // namespace proof_system::honk::flavor
+} // namespace bb::honk::flavor

--- a/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra_recursive.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra_recursive.hpp
@@ -22,7 +22,7 @@
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include "barretenberg/stdlib/recursion/honk/transcript/transcript.hpp"
 
-namespace proof_system::honk::flavor {
+namespace bb::honk::flavor {
 
 /**
  * @brief The recursive counterpart to the "native" Goblin Ultra flavor.
@@ -152,7 +152,7 @@ template <typename BuilderType> class GoblinUltraRecursive_ {
     // Reuse the VerifierCommitments from GoblinUltra
     using VerifierCommitments = GoblinUltra::VerifierCommitments_<Commitment, VerificationKey>;
     // Reuse the transcript from GoblinUltra
-    using Transcript = proof_system::plonk::stdlib::recursion::honk::Transcript<CircuitBuilder>;
+    using Transcript = bb::plonk::stdlib::recursion::honk::Transcript<CircuitBuilder>;
 };
 
-} // namespace proof_system::honk::flavor
+} // namespace bb::honk::flavor

--- a/barretenberg/cpp/src/barretenberg/flavor/plonk_flavors.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/plonk_flavors.hpp
@@ -5,10 +5,10 @@
 #include "barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp"
 #include "barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp"
 
-namespace proof_system::plonk::flavor {
+namespace bb::plonk::flavor {
 class Standard {
   public:
-    using CircuitBuilder = proof_system::StandardCircuitBuilder;
+    using CircuitBuilder = bb::StandardCircuitBuilder;
     using ProvingKey = plonk::proving_key;
     using Curve = curve::BN254;
     using FF = Curve::ScalarField;
@@ -20,7 +20,7 @@ class Standard {
 
 class Ultra {
   public:
-    using CircuitBuilder = proof_system::UltraCircuitBuilder;
+    using CircuitBuilder = bb::UltraCircuitBuilder;
     using ProvingKey = plonk::proving_key;
     using Curve = curve::BN254;
     using FF = Curve::ScalarField;
@@ -151,4 +151,4 @@ class Ultra {
         return output;
     }
 };
-} // namespace proof_system::plonk::flavor
+} // namespace bb::plonk::flavor

--- a/barretenberg/cpp/src/barretenberg/flavor/relation_definitions.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/relation_definitions.hpp
@@ -11,19 +11,17 @@
 #define ACCUMULATE(...) _ACCUMULATE(__VA_ARGS__)
 #define _ACCUMULATE(RelationImpl, Flavor, AccumulatorType, EdgeType)                                                   \
     template void                                                                                                      \
-    RelationImpl<Flavor::FF>::accumulate<proof_system::Relation<RelationImpl<Flavor::FF>>::AccumulatorType,            \
-                                         EdgeType(Flavor)>(                                                            \
-        proof_system::Relation<RelationImpl<Flavor::FF>>::AccumulatorType&,                                            \
+    RelationImpl<Flavor::FF>::accumulate<bb::Relation<RelationImpl<Flavor::FF>>::AccumulatorType, EdgeType(Flavor)>(   \
+        bb::Relation<RelationImpl<Flavor::FF>>::AccumulatorType&,                                                      \
         EdgeType(Flavor) const&,                                                                                       \
         RelationParameters<Flavor::FF> const&,                                                                         \
         Flavor::FF const&);
 
 #define PERMUTATION_METHOD(...) _PERMUTATION_METHOD(__VA_ARGS__)
 #define _PERMUTATION_METHOD(MethodName, RelationImpl, Flavor, AccumulatorType, EdgeType)                               \
-    template typename proof_system::Relation<RelationImpl<Flavor::FF>>::AccumulatorType                                \
-    RelationImpl<Flavor::FF>::MethodName<proof_system::Relation<RelationImpl<Flavor::FF>>::AccumulatorType,            \
-                                         EdgeType(Flavor)>(EdgeType(Flavor) const&,                                    \
-                                                           RelationParameters<Flavor::FF> const&);
+    template typename bb::Relation<RelationImpl<Flavor::FF>>::AccumulatorType                                          \
+    RelationImpl<Flavor::FF>::MethodName<bb::Relation<RelationImpl<Flavor::FF>>::AccumulatorType, EdgeType(Flavor)>(   \
+        EdgeType(Flavor) const&, RelationParameters<Flavor::FF> const&);
 
 #define SUMCHECK_RELATION_CLASS(...) _SUMCHECK_RELATION_CLASS(__VA_ARGS__)
 #define DEFINE_SUMCHECK_RELATION_CLASS(RelationImpl, Flavor)                                                           \

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra.hpp
@@ -16,7 +16,7 @@
 #include "barretenberg/relations/ultra_arithmetic_relation.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::honk::flavor {
+namespace bb::honk::flavor {
 
 class Ultra {
   public:
@@ -43,15 +43,14 @@ class Ultra {
     // The total number of witness entities not including shifts.
     static constexpr size_t NUM_WITNESS_ENTITIES = 7;
 
-    using GrandProductRelations =
-        std::tuple<proof_system::UltraPermutationRelation<FF>, proof_system::LookupRelation<FF>>;
+    using GrandProductRelations = std::tuple<bb::UltraPermutationRelation<FF>, bb::LookupRelation<FF>>;
     // define the tuple of Relations that comprise the Sumcheck relation
-    using Relations = std::tuple<proof_system::UltraArithmeticRelation<FF>,
-                                 proof_system::UltraPermutationRelation<FF>,
-                                 proof_system::LookupRelation<FF>,
-                                 proof_system::GenPermSortRelation<FF>,
-                                 proof_system::EllipticRelation<FF>,
-                                 proof_system::AuxiliaryRelation<FF>>;
+    using Relations = std::tuple<bb::UltraArithmeticRelation<FF>,
+                                 bb::UltraPermutationRelation<FF>,
+                                 bb::LookupRelation<FF>,
+                                 bb::GenPermSortRelation<FF>,
+                                 bb::EllipticRelation<FF>,
+                                 bb::AuxiliaryRelation<FF>>;
 
     static constexpr size_t MAX_PARTIAL_RELATION_LENGTH = compute_max_partial_relation_length<Relations>();
     static_assert(MAX_PARTIAL_RELATION_LENGTH == 6);
@@ -603,4 +602,4 @@ class Ultra {
     };
 };
 
-} // namespace proof_system::honk::flavor
+} // namespace bb::honk::flavor

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_recursive.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_recursive.hpp
@@ -30,7 +30,7 @@
 #include "barretenberg/stdlib/primitives/curves/bn254.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 
-namespace proof_system::honk::flavor {
+namespace bb::honk::flavor {
 
 /**
  * @brief The recursive counterpart to the "native" Ultra flavor.
@@ -71,12 +71,12 @@ template <typename BuilderType> class UltraRecursive_ {
     static constexpr size_t NUM_WITNESS_ENTITIES = 7;
 
     // define the tuple of Relations that comprise the Sumcheck relation
-    using Relations = std::tuple<proof_system::UltraArithmeticRelation<FF>,
-                                 proof_system::UltraPermutationRelation<FF>,
-                                 proof_system::LookupRelation<FF>,
-                                 proof_system::GenPermSortRelation<FF>,
-                                 proof_system::EllipticRelation<FF>,
-                                 proof_system::AuxiliaryRelation<FF>>;
+    using Relations = std::tuple<bb::UltraArithmeticRelation<FF>,
+                                 bb::UltraPermutationRelation<FF>,
+                                 bb::LookupRelation<FF>,
+                                 bb::GenPermSortRelation<FF>,
+                                 bb::EllipticRelation<FF>,
+                                 bb::AuxiliaryRelation<FF>>;
 
     static constexpr size_t MAX_PARTIAL_RELATION_LENGTH = compute_max_partial_relation_length<Relations>();
 
@@ -378,7 +378,7 @@ template <typename BuilderType> class UltraRecursive_ {
         }
     };
 
-    using Transcript = proof_system::plonk::stdlib::recursion::honk::Transcript<CircuitBuilder>;
+    using Transcript = bb::plonk::stdlib::recursion::honk::Transcript<CircuitBuilder>;
 };
 
-} // namespace proof_system::honk::flavor
+} // namespace bb::honk::flavor

--- a/barretenberg/cpp/src/barretenberg/goblin/full_goblin_recursion.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/full_goblin_recursion.test.cpp
@@ -11,7 +11,7 @@
 
 #include <gtest/gtest.h>
 
-using namespace proof_system::honk;
+using namespace bb::honk;
 namespace goblin_recursion_tests {
 
 class GoblinRecursionTests : public ::testing::Test {
@@ -24,7 +24,7 @@ class GoblinRecursionTests : public ::testing::Test {
 
     using Curve = curve::BN254;
     using FF = Curve::ScalarField;
-    using GoblinUltraBuilder = proof_system::GoblinUltraCircuitBuilder;
+    using GoblinUltraBuilder = bb::GoblinUltraCircuitBuilder;
     using KernelInput = Goblin::AccumulationOutput;
 };
 

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
@@ -12,10 +12,10 @@
 namespace bb {
 
 class Goblin {
-    using HonkProof = proof_system::plonk::proof;
+    using HonkProof = bb::plonk::proof;
 
-    using GUHFlavor = proof_system::honk::flavor::GoblinUltra;
-    using GoblinUltraCircuitBuilder = proof_system::GoblinUltraCircuitBuilder;
+    using GUHFlavor = bb::honk::flavor::GoblinUltra;
+    using GoblinUltraCircuitBuilder = bb::GoblinUltraCircuitBuilder;
 
     using GUHVerificationKey = GUHFlavor::VerificationKey;
     using Commitment = GUHFlavor::Commitment;
@@ -55,19 +55,19 @@ class Goblin {
         }
     };
 
-    using GoblinUltraComposer = proof_system::honk::UltraComposer_<GUHFlavor>;
-    using GoblinUltraVerifier = proof_system::honk::UltraVerifier_<GUHFlavor>;
+    using GoblinUltraComposer = bb::honk::UltraComposer_<GUHFlavor>;
+    using GoblinUltraVerifier = bb::honk::UltraVerifier_<GUHFlavor>;
     using Builder = GoblinUltraCircuitBuilder;
-    using OpQueue = proof_system::ECCOpQueue;
-    using ECCVMFlavor = proof_system::honk::flavor::ECCVM;
-    using ECCVMBuilder = proof_system::ECCVMCircuitBuilder<ECCVMFlavor>;
-    using ECCVMComposer = proof_system::honk::ECCVMComposer;
-    using ECCVMProver = proof_system::honk::ECCVMProver_<ECCVMFlavor>;
-    using TranslatorBuilder = proof_system::GoblinTranslatorCircuitBuilder;
-    using TranslatorComposer = proof_system::honk::GoblinTranslatorComposer;
+    using OpQueue = bb::ECCOpQueue;
+    using ECCVMFlavor = bb::honk::flavor::ECCVM;
+    using ECCVMBuilder = bb::ECCVMCircuitBuilder<ECCVMFlavor>;
+    using ECCVMComposer = bb::honk::ECCVMComposer;
+    using ECCVMProver = bb::honk::ECCVMProver_<ECCVMFlavor>;
+    using TranslatorBuilder = bb::GoblinTranslatorCircuitBuilder;
+    using TranslatorComposer = bb::honk::GoblinTranslatorComposer;
     using RecursiveMergeVerifier =
-        proof_system::plonk::stdlib::recursion::goblin::MergeRecursiveVerifier_<GoblinUltraCircuitBuilder>;
-    using MergeVerifier = proof_system::honk::MergeVerifier_<GUHFlavor>;
+        bb::plonk::stdlib::recursion::goblin::MergeRecursiveVerifier_<GoblinUltraCircuitBuilder>;
+    using MergeVerifier = bb::honk::MergeVerifier_<GUHFlavor>;
 
     std::shared_ptr<OpQueue> op_queue = std::make_shared<OpQueue>();
 
@@ -256,7 +256,7 @@ class Goblin {
     }
 
     // ACIRHACK
-    bool verify_proof([[maybe_unused]] const proof_system::plonk::proof& proof) const
+    bool verify_proof([[maybe_unused]] const bb::plonk::proof& proof) const
     {
         // ACIRHACK: to do this properly, extract the proof correctly or maybe share transcripts.
         const auto extract_final_kernel_proof = [&]([[maybe_unused]] auto& input_proof) { return accumulator.proof; };

--- a/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
@@ -14,12 +14,12 @@ class GoblinMockCircuits {
     using FF = Curve::ScalarField;
     using Fbase = Curve::BaseField;
     using Point = Curve::AffineElement;
-    using CommitmentKey = proof_system::honk::pcs::CommitmentKey<Curve>;
-    using OpQueue = proof_system::ECCOpQueue;
-    using GoblinUltraBuilder = proof_system::GoblinUltraCircuitBuilder;
-    using Flavor = proof_system::honk::flavor::GoblinUltra;
-    using RecursiveFlavor = proof_system::honk::flavor::GoblinUltraRecursive_<GoblinUltraBuilder>;
-    using RecursiveVerifier = proof_system::plonk::stdlib::recursion::honk::UltraRecursiveVerifier_<RecursiveFlavor>;
+    using CommitmentKey = bb::honk::pcs::CommitmentKey<Curve>;
+    using OpQueue = bb::ECCOpQueue;
+    using GoblinUltraBuilder = bb::GoblinUltraCircuitBuilder;
+    using Flavor = bb::honk::flavor::GoblinUltra;
+    using RecursiveFlavor = bb::honk::flavor::GoblinUltraRecursive_<GoblinUltraBuilder>;
+    using RecursiveVerifier = bb::plonk::stdlib::recursion::honk::UltraRecursiveVerifier_<RecursiveFlavor>;
     using KernelInput = Goblin::AccumulationOutput;
     static constexpr size_t NUM_OP_QUEUE_COLUMNS = Flavor::NUM_WIRES;
 
@@ -61,10 +61,9 @@ class GoblinMockCircuits {
      *
      * @param op_queue
      */
-    static void perform_op_queue_interactions_for_mock_first_circuit(
-        std::shared_ptr<proof_system::ECCOpQueue>& op_queue)
+    static void perform_op_queue_interactions_for_mock_first_circuit(std::shared_ptr<bb::ECCOpQueue>& op_queue)
     {
-        proof_system::GoblinUltraCircuitBuilder builder{ op_queue };
+        bb::GoblinUltraCircuitBuilder builder{ op_queue };
 
         // Add some goblinized ecc ops
         construct_goblin_ecc_op_circuit(builder);

--- a/barretenberg/cpp/src/barretenberg/honk/proof_system/logderivative_library.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/proof_system/logderivative_library.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <typeinfo>
 
-namespace proof_system::honk::logderivative_library {
+namespace bb::honk::logderivative_library {
 
 /**
  * @brief Compute the inverse polynomial I(X) required for logderivative lookups
@@ -246,4 +246,4 @@ void accumulate_logderivative_permutation_subrelation_contributions(ContainerOve
     std::get<1>(accumulator) -=
         permutation_relation.template compute_write_term_predicate<Accumulator, 0>(in) * denominator_accumulator[1];
 }
-} // namespace proof_system::honk::logderivative_library
+} // namespace bb::honk::logderivative_library

--- a/barretenberg/cpp/src/barretenberg/honk/proof_system/permutation_library.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/proof_system/permutation_library.hpp
@@ -4,7 +4,7 @@
 #include "barretenberg/polynomials/polynomial.hpp"
 #include <typeinfo>
 
-namespace proof_system::honk::permutation_library {
+namespace bb::honk::permutation_library {
 
 /**
  * @brief Compute a permutation grand product polynomial Z_perm(X)
@@ -45,7 +45,7 @@ namespace proof_system::honk::permutation_library {
 template <typename Flavor, typename GrandProdRelation>
 void compute_permutation_grand_product(const size_t circuit_size,
                                        auto& full_polynomials,
-                                       proof_system::RelationParameters<typename Flavor::FF>& relation_parameters)
+                                       bb::RelationParameters<typename Flavor::FF>& relation_parameters)
 {
     using FF = typename Flavor::FF;
     using Polynomial = typename Flavor::Polynomial;
@@ -142,7 +142,7 @@ void compute_permutation_grand_product(const size_t circuit_size,
 template <typename Flavor>
 void compute_permutation_grand_products(std::shared_ptr<typename Flavor::ProvingKey>& key,
                                         typename Flavor::ProverPolynomials& full_polynomials,
-                                        proof_system::RelationParameters<typename Flavor::FF>& relation_parameters)
+                                        bb::RelationParameters<typename Flavor::FF>& relation_parameters)
 {
     using GrandProductRelations = typename Flavor::GrandProductRelations;
     using FF = typename Flavor::FF;
@@ -427,4 +427,4 @@ template <typename Flavor> inline void compute_lagrange_polynomials_for_goblin_t
     proving_key->lagrange_second = lagrange_polynomial_second.share();
 }
 
-} // namespace proof_system::honk::permutation_library
+} // namespace bb::honk::permutation_library

--- a/barretenberg/cpp/src/barretenberg/honk/utils/testing.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/utils/testing.hpp
@@ -2,7 +2,7 @@
 #include "barretenberg/common/zip_view.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 /**
  * @brief Get a ProverPolynomials instance initialized to sequential values starting at 0.
  * @details Values are assigned according to the order specified in the underlying array of the flavor class. The
@@ -43,4 +43,4 @@ template <typename Flavor> typename Flavor::ProverPolynomials get_zero_prover_po
     return prover_polynomials;
 }
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/compute_circuit_data.cpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/compute_circuit_data.cpp
@@ -10,9 +10,9 @@ namespace proofs {
 namespace join_split {
 
 using namespace join_split_example::proofs::join_split;
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 using namespace join_split_example::proofs::notes::native;
-using namespace proof_system::plonk::stdlib::merkle_tree;
+using namespace bb::plonk::stdlib::merkle_tree;
 
 join_split_tx noop_tx()
 {

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.cpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.cpp
@@ -8,8 +8,8 @@ namespace join_split_example {
 namespace proofs {
 namespace join_split {
 
-using namespace proof_system::plonk;
-using namespace proof_system::plonk::stdlib::merkle_tree;
+using namespace bb::plonk;
+using namespace bb::plonk::stdlib::merkle_tree;
 
 static std::shared_ptr<plonk::proving_key> proving_key;
 static std::shared_ptr<plonk::verification_key> verification_key;
@@ -49,7 +49,7 @@ void init_verification_key()
     }
 
     verification_key =
-        proof_system::plonk::compute_verification_key_common(proving_key, srs::get_crs_factory()->get_verifier_crs());
+        bb::plonk::compute_verification_key_common(proving_key, srs::get_crs_factory()->get_verifier_crs());
 }
 
 Prover new_join_split_prover(join_split_tx const& tx, bool mock)

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.test.cpp
@@ -13,7 +13,7 @@
 
 namespace join_split_example::proofs::join_split {
 
-using namespace proof_system::plonk::stdlib::merkle_tree;
+using namespace bb::plonk::stdlib::merkle_tree;
 
 /* Old join-split tests below. The value of having all of these logic tests is unclear, but we'll
    leave them around, at least for a while. */
@@ -26,8 +26,8 @@ constexpr bool CIRCUIT_CHANGE_EXPECTED = false;
 #endif
 
 using namespace bb;
-using namespace proof_system::plonk::stdlib;
-using namespace proof_system::plonk::stdlib::merkle_tree;
+using namespace bb::plonk::stdlib;
+using namespace bb::plonk::stdlib::merkle_tree;
 using namespace join_split_example::proofs::notes::native;
 using key_pair = join_split_example::fixtures::grumpkin_key_pair;
 

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split_circuit.cpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split_circuit.cpp
@@ -12,9 +12,9 @@ namespace join_split_example {
 namespace proofs {
 namespace join_split {
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 using namespace notes::circuit;
-using namespace proof_system::plonk::stdlib::merkle_tree;
+using namespace bb::plonk::stdlib::merkle_tree;
 using namespace crypto::schnorr;
 
 /**
@@ -33,7 +33,7 @@ field_ct process_input_note(field_ct const& account_private_key,
     const bool_ct valid_value = note.value == 0 || is_note_in_use;
     valid_value.assert_equal(true, "padding note non zero");
 
-    const bool_ct exists = proof_system::plonk::stdlib::merkle_tree::check_membership(
+    const bool_ct exists = bb::plonk::stdlib::merkle_tree::check_membership(
         merkle_root, hash_path, note.commitment, index.value.decompose_into_bits(DATA_TREE_DEPTH));
     const bool_ct valid = exists || is_propagated || !is_note_in_use;
     valid.assert_equal(true, "input note not a member");

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split_js_parity.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split_js_parity.test.cpp
@@ -13,8 +13,8 @@ namespace proofs {
 namespace join_split {
 
 using namespace bb;
-// using namespace proof_system::plonk::stdlib::types;
-using namespace proof_system::plonk::stdlib::merkle_tree;
+// using namespace bb::plonk::stdlib::types;
+using namespace bb::plonk::stdlib::merkle_tree;
 using namespace join_split_example::proofs::notes::native;
 using key_pair = join_split_example::fixtures::grumpkin_key_pair;
 

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split_tx.hpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split_tx.hpp
@@ -17,7 +17,7 @@ struct join_split_tx {
     uint32_t num_input_notes;
     std::array<uint32_t, 2> input_index;
     bb::fr old_data_root;
-    std::array<proof_system::plonk::stdlib::merkle_tree::fr_hash_path, 2> input_path;
+    std::array<bb::plonk::stdlib::merkle_tree::fr_hash_path, 2> input_path;
     std::array<notes::native::value::value_note, 2> input_note;
     std::array<notes::native::value::value_note, 2> output_note;
 
@@ -27,7 +27,7 @@ struct join_split_tx {
     bb::fr alias_hash;
     bool account_required;
     uint32_t account_note_index;
-    proof_system::plonk::stdlib::merkle_tree::fr_hash_path account_note_path;
+    bb::plonk::stdlib::merkle_tree::fr_hash_path account_note_path;
     grumpkin::g1::affine_element signing_pub_key;
 
     bb::fr backward_link; // 0: no link, otherwise: any commitment.

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/mock/mock_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/mock/mock_circuit.hpp
@@ -6,7 +6,7 @@ namespace join_split_example {
 namespace proofs {
 namespace mock {
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 template <typename Builder> void mock_circuit(Builder& builder, std::vector<bb::fr> const& public_inputs_)
 {

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/mock/mock_circuit.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/mock/mock_circuit.test.cpp
@@ -3,7 +3,7 @@
 #include "barretenberg/common/test.hpp"
 #include "barretenberg/join_split_example/types.hpp"
 
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 
 namespace rollup {
 namespace proofs {

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/asset_id.cpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/asset_id.cpp
@@ -3,7 +3,7 @@
 
 namespace join_split_example::proofs::notes::circuit {
 
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 
 std::pair<bool_ct, suint_ct> deflag_asset_id(suint_ct const& asset_id)
 {

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/asset_id.hpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/asset_id.hpp
@@ -3,7 +3,7 @@
 
 namespace join_split_example::proofs::notes::circuit {
 
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 
 std::pair<bool_ct, suint_ct> deflag_asset_id(suint_ct const& asset_id);
 

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/bridge_call_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/bridge_call_data.hpp
@@ -9,7 +9,7 @@ namespace proofs {
 namespace notes {
 namespace circuit {
 
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 
 constexpr uint32_t input_asset_id_a_shift = DEFI_BRIDGE_ADDRESS_ID_LEN;
 constexpr uint32_t input_asset_id_b_shift = input_asset_id_a_shift + DEFI_BRIDGE_INPUT_A_ASSET_ID_LEN;

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/claim/claim_note.hpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/claim/claim_note.hpp
@@ -13,7 +13,7 @@ namespace notes {
 namespace circuit {
 namespace claim {
 
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 
 struct partial_claim_note {
     suint_ct deposit_value;

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/claim/complete_partial_commitment.hpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/claim/complete_partial_commitment.hpp
@@ -9,7 +9,7 @@ namespace notes {
 namespace circuit {
 namespace claim {
 
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 
 inline auto complete_partial_commitment(field_ct const& partial_commitment,
                                         field_ct const& interaction_nonce,

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/claim/witness_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/claim/witness_data.hpp
@@ -8,7 +8,7 @@
 
 namespace join_split_example::proofs::notes::circuit::claim {
 
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 
 /**
  * Convert native claim note data into circuit witness data.

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/compute_nullifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/compute_nullifier.cpp
@@ -5,7 +5,7 @@
 namespace join_split_example::proofs::notes::circuit {
 
 using namespace bb;
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 
 field_ct compute_nullifier(field_ct const& note_commitment,
                            field_ct const& account_private_key,
@@ -40,7 +40,7 @@ field_ct compute_nullifier(field_ct const& note_commitment,
      * eth address.
      */
     auto blake_input = byte_array_ct(hashed_inputs);
-    auto blake_result = proof_system::plonk::stdlib::blake2s(blake_input);
+    auto blake_result = bb::plonk::stdlib::blake2s(blake_input);
     return field_ct(blake_result);
 }
 

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/value_note.hpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/value_note.hpp
@@ -5,7 +5,7 @@
 
 namespace join_split_example::proofs::notes::circuit::value {
 
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 
 struct value_note {
     group_ct owner;

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/value_note.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/value_note.test.cpp
@@ -7,7 +7,7 @@
 
 namespace join_split_example {
 using namespace bb;
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 using namespace join_split_example::proofs::notes;
 using namespace join_split_example::proofs::notes::circuit::value;
 

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/witness_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/notes/circuit/value/witness_data.hpp
@@ -4,7 +4,7 @@
 
 namespace join_split_example::proofs::notes::circuit::value {
 
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 
 struct witness_data {
     group_ct owner;

--- a/barretenberg/cpp/src/barretenberg/join_split_example/types.hpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/types.hpp
@@ -17,7 +17,7 @@
 
 namespace join_split_example {
 
-using Builder = proof_system::UltraCircuitBuilder;
+using Builder = bb::UltraCircuitBuilder;
 using Composer = plonk::UltraComposer;
 
 using Prover = std::conditional_t<std::same_as<Composer, plonk::UltraComposer>, plonk::UltraProver, plonk::Prover>;
@@ -25,22 +25,22 @@ using Prover = std::conditional_t<std::same_as<Composer, plonk::UltraComposer>, 
 using Verifier =
     std::conditional_t<std::same_as<Composer, plonk::UltraComposer>, plonk::UltraVerifier, plonk::Verifier>;
 
-using witness_ct = proof_system::plonk::stdlib::witness_t<Builder>;
-using public_witness_ct = proof_system::plonk::stdlib::public_witness_t<Builder>;
-using bool_ct = proof_system::plonk::stdlib::bool_t<Builder>;
-using byte_array_ct = proof_system::plonk::stdlib::byte_array<Builder>;
-using field_ct = proof_system::plonk::stdlib::field_t<Builder>;
-using suint_ct = proof_system::plonk::stdlib::safe_uint_t<Builder>;
-using uint32_ct = proof_system::plonk::stdlib::uint32<Builder>;
-using group_ct = proof_system::plonk::stdlib::cycle_group<Builder>;
-using pedersen_commitment = proof_system::plonk::stdlib::pedersen_commitment<Builder>;
-using pedersen_hash = proof_system::plonk::stdlib::pedersen_hash<Builder>;
-using bn254 = proof_system::plonk::stdlib::bn254<Builder>;
+using witness_ct = bb::plonk::stdlib::witness_t<Builder>;
+using public_witness_ct = bb::plonk::stdlib::public_witness_t<Builder>;
+using bool_ct = bb::plonk::stdlib::bool_t<Builder>;
+using byte_array_ct = bb::plonk::stdlib::byte_array<Builder>;
+using field_ct = bb::plonk::stdlib::field_t<Builder>;
+using suint_ct = bb::plonk::stdlib::safe_uint_t<Builder>;
+using uint32_ct = bb::plonk::stdlib::uint32<Builder>;
+using group_ct = bb::plonk::stdlib::cycle_group<Builder>;
+using pedersen_commitment = bb::plonk::stdlib::pedersen_commitment<Builder>;
+using pedersen_hash = bb::plonk::stdlib::pedersen_hash<Builder>;
+using bn254 = bb::plonk::stdlib::bn254<Builder>;
 
-using hash_path_ct = proof_system::plonk::stdlib::merkle_tree::hash_path<Builder>;
+using hash_path_ct = bb::plonk::stdlib::merkle_tree::hash_path<Builder>;
 
 namespace schnorr {
-using signature_bits = proof_system::plonk::stdlib::schnorr::signature_bits<Builder>;
+using signature_bits = bb::plonk::stdlib::schnorr::signature_bits<Builder>;
 } // namespace schnorr
 
 } // namespace join_split_example

--- a/barretenberg/cpp/src/barretenberg/plonk/composer/composer_lib.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/composer/composer_lib.cpp
@@ -6,7 +6,7 @@
 #include "barretenberg/commitment_schemes/commitment_key.hpp"
 #include "barretenberg/srs/factories/crs_factory.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 /**
  * @brief Retrieve lagrange forms of selector polynomials and compute monomial and coset-monomial forms and put into
@@ -71,9 +71,9 @@ std::shared_ptr<plonk::verification_key> compute_verification_key_common(
     }
 
     // Set the polynomial manifest in verification key.
-    circuit_verification_key->polynomial_manifest = proof_system::plonk::PolynomialManifest(proving_key->circuit_type);
+    circuit_verification_key->polynomial_manifest = bb::plonk::PolynomialManifest(proving_key->circuit_type);
 
     return circuit_verification_key;
 }
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/composer/composer_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/composer/composer_lib.hpp
@@ -3,7 +3,7 @@
 #include "barretenberg/plonk/proof_system/proving_key/proving_key.hpp"
 #include "barretenberg/plonk/proof_system/verification_key/verification_key.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 struct SelectorProperties {
     std::string name;
     // TODO: does the prover need the raw lagrange-base selector values?
@@ -81,4 +81,4 @@ std::shared_ptr<plonk::verification_key> compute_verification_key_common(
     // silencing for now but need to figure out where to extract type of VerifierCrs from :-/
     std::shared_ptr<bb::srs::factories::VerifierCrs<curve::BN254>> const& vrs);
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.cpp
@@ -12,7 +12,7 @@
 #include <cstdint>
 #include <string>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 /**
  * Compute witness polynomials (w_1, w_2, w_3, w_4).
@@ -169,4 +169,4 @@ plonk::Prover StandardComposer::create_prover(const CircuitBuilder& circuit_cons
     return output_state;
 }
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.hpp
@@ -10,7 +10,7 @@
 #include "barretenberg/srs/factories/file_crs_factory.hpp"
 #include <utility>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 class StandardComposer {
   public:
     using Flavor = plonk::flavor::Standard;
@@ -153,4 +153,4 @@ class StandardComposer {
     }
 };
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.test.cpp
@@ -6,8 +6,8 @@
 #include <gtest/gtest.h>
 
 using namespace bb;
-using namespace proof_system;
-using namespace proof_system::plonk;
+using namespace bb;
+using namespace bb::plonk;
 
 namespace {
 auto& engine = numeric::random::get_debug_engine();

--- a/barretenberg/cpp/src/barretenberg/plonk/composer/ultra_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/composer/ultra_composer.cpp
@@ -11,7 +11,7 @@
 #include <cstdint>
 #include <string>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 /**
  * @brief Computes `this.witness`, which is basiclly a set of polynomials mapped-to by strings.
@@ -516,4 +516,4 @@ void UltraComposer::add_table_column_selector_poly_to_proving_key(polynomial& se
     circuit_proving_key->polynomial_store.put(tag + "_fft", std::move(selector_poly_coset_form));
 }
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/composer/ultra_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/composer/ultra_composer.hpp
@@ -12,7 +12,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 class UltraComposer {
   public:
     using Flavor = flavor::Ultra;
@@ -97,4 +97,4 @@ class UltraComposer {
     }
 };
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/composer/ultra_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/composer/ultra_composer.test.cpp
@@ -10,10 +10,10 @@
 #include "barretenberg/stdlib/primitives/plookup/plookup.hpp"
 
 using namespace bb;
-using namespace proof_system;
-using namespace proof_system::plonk;
+using namespace bb;
+using namespace bb::plonk;
 
-namespace proof_system::plonk::test_ultra_plonk_composer {
+namespace bb::plonk::test_ultra_plonk_composer {
 
 namespace {
 auto& engine = numeric::random::get_debug_engine();
@@ -66,7 +66,7 @@ TYPED_TEST_SUITE(ultra_plonk_composer, BooleanTypes);
 
 TYPED_TEST(ultra_plonk_composer, create_gates_from_plookup_accumulators)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
     auto composer = UltraComposer();
 
     bb::fr input_value = fr::random_element();
@@ -647,7 +647,7 @@ TYPED_TEST(ultra_plonk_composer, non_native_field_multiplication)
     const auto q_indices = get_limb_witness_indices(split_into_limbs(uint256_t(q)));
     const auto r_indices = get_limb_witness_indices(split_into_limbs(uint256_t(r)));
 
-    proof_system::non_native_field_witnesses<fr> inputs{
+    bb::non_native_field_witnesses<fr> inputs{
         a_indices, b_indices, q_indices, r_indices, modulus_limbs, fr(uint256_t(modulus)),
     };
     const auto [lo_1_idx, hi_1_idx] = builder.evaluate_non_native_field_multiplication(inputs);
@@ -824,4 +824,4 @@ TEST(ultra_plonk_composer, range_constraint_small_variable)
     EXPECT_EQ(result, true);
 }
 
-} // namespace proof_system::plonk::test_ultra_plonk_composer
+} // namespace bb::plonk::test_ultra_plonk_composer

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/commitment_scheme.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/commitment_scheme.hpp
@@ -5,7 +5,7 @@
 #include "../types/program_settings.hpp"
 #include "barretenberg/plonk/work_queue/work_queue.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 class CommitmentScheme {
   public:
@@ -45,4 +45,4 @@ class CommitmentScheme {
                                                        bool in_lagrange_form = false) = 0;
 };
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/commitment_scheme.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/commitment_scheme.test.cpp
@@ -15,7 +15,7 @@
 #include "barretenberg/ecc/curves/bn254/pairing.hpp"
 
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 TEST(commitment_scheme, kate_open)
 {

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/kate_commitment_scheme.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/kate_commitment_scheme.cpp
@@ -2,7 +2,7 @@
 #include "../../../polynomials/polynomial_arithmetic.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 // Constructors for KateCommitmentScheme
 template <typename settings>
@@ -391,4 +391,4 @@ template class KateCommitmentScheme<standard_settings>;
 template class KateCommitmentScheme<ultra_settings>;
 template class KateCommitmentScheme<ultra_to_standard_settings>;
 template class KateCommitmentScheme<ultra_with_keccak_settings>;
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/kate_commitment_scheme.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/commitment_scheme/kate_commitment_scheme.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "commitment_scheme.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 template <typename settings> class KateCommitmentScheme : public CommitmentScheme {
   public:
@@ -39,4 +39,4 @@ template <typename settings> class KateCommitmentScheme : public CommitmentSchem
     plonk::commitment_open_proof kate_open_proof;
 };
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/constants.hpp
@@ -1,10 +1,10 @@
 #pragma once
 #include <cstdint>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 // limb size when simulating a non-native field using bigfield class
 // (needs to be a universal constant to be used by native verifier)
 static constexpr uint64_t NUM_LIMB_BITS_IN_FIELD_SIMULATION = 68;
 static constexpr uint32_t NUM_QUOTIENT_PARTS = 4;
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/prover/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/prover/prover.cpp
@@ -9,7 +9,7 @@
 
 using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 /**
  * Create ProverBase from proving key, witness and manifest.
@@ -397,7 +397,7 @@ template <typename settings> void ProverBase<settings>::execute_fourth_round()
     add_blinding_to_quotient_polynomial_parts();
 
     compute_quotient_commitments();
-} // namespace proof_system::plonk
+} // namespace bb::plonk
 
 template <typename settings> void ProverBase<settings>::execute_fifth_round()
 {
@@ -577,4 +577,4 @@ template class ProverBase<ultra_settings>;
 template class ProverBase<ultra_to_standard_settings>;
 template class ProverBase<ultra_with_keccak_settings>;
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/prover/prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/prover/prover.hpp
@@ -7,7 +7,7 @@
 #include "barretenberg/plonk/proof_system/proving_key/proving_key.hpp"
 #include "barretenberg/plonk/work_queue/work_queue.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 template <typename settings> class ProverBase {
 
@@ -106,4 +106,4 @@ typedef ProverBase<ultra_settings> UltraProver; // TODO(Mike): maybe just return
 typedef ProverBase<ultra_to_standard_settings> UltraToStandardProver;
 typedef ProverBase<ultra_with_keccak_settings> UltraWithKeccakProver;
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/prover/prover.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/prover/prover.test.cpp
@@ -66,7 +66,7 @@ sigma_3 = [39, 23, 4, 40, 41, 25, 33, 36, 37, 42, 43, 44, 45, 46, 47, 48]
 ```
 */
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 namespace prover_helpers {
 

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/proving_key/proving_key.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/proving_key/proving_key.cpp
@@ -3,7 +3,7 @@
 #include "barretenberg/numeric/bitop/get_msb.hpp"
 #include "barretenberg/polynomials/polynomial_arithmetic.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 // In all the constructors below, the pippenger_runtime_state takes (n + 1) as the input
 // as the degree of t_{high}(X) is (n + 1) for standard plonk. Refer to
@@ -88,4 +88,4 @@ void proving_key::init()
     memset((void*)&quotient_polynomial_parts[3][0], 0x00, sizeof(bb::fr) * circuit_size);
 }
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/proving_key/proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/proving_key/proving_key.hpp
@@ -17,7 +17,7 @@
 #include "barretenberg/proof_system/polynomial_store/polynomial_store.hpp"
 #endif
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 struct proving_key_data {
     uint32_t circuit_type;
@@ -84,4 +84,4 @@ struct proving_key {
     static constexpr size_t min_thread_block = 4UL;
 };
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/proving_key/proving_key.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/proving_key/proving_key.test.cpp
@@ -12,8 +12,8 @@
 #endif
 
 using namespace bb;
-using namespace proof_system;
-using namespace proof_system::plonk;
+using namespace bb;
+using namespace bb::plonk;
 
 // Test proving key serialization/deserialization to/from buffer
 TEST(proving_key, proving_key_from_serialized_key)

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/proving_key/serialize.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/proving_key/serialize.hpp
@@ -8,7 +8,7 @@
 #include <ios>
 #include <sys/stat.h>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 // Read the pre-computed polynomials
 template <typename B> inline void read(B& any, proving_key_data& key)
@@ -138,4 +138,4 @@ template <typename B> inline void write_to_file(B& os, std::string const& path, 
     write(os, key.memory_write_records);
 }
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/public_inputs/public_inputs.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/public_inputs/public_inputs.hpp
@@ -2,7 +2,7 @@
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include <vector>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 template <typename Field>
 Field compute_public_input_delta(const std::vector<Field>& inputs,
                                  const Field& beta,

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/public_inputs/public_inputs.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/public_inputs/public_inputs.test.cpp
@@ -61,7 +61,7 @@ sigma_3 = [39, 23, 4, 40, 41, 25, 33, 36, 37, 42, 43, 44, 45, 46, 47, 48]
 ```
 */
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 namespace {
 
@@ -138,7 +138,7 @@ TEST(test_public_inputs, compute_delta)
     for (size_t i = 0; i < num_public_inputs; ++i) {
         public_inputs.push_back(left[i]);
     }
-    fr target_delta = proof_system::plonk::compute_public_input_delta<fr>(public_inputs, beta, gamma, domain.root);
+    fr target_delta = bb::plonk::compute_public_input_delta<fr>(public_inputs, beta, gamma, domain.root);
 
     EXPECT_EQ((modified_result == target_delta), true);
 }

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/public_inputs/public_inputs_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/public_inputs/public_inputs_impl.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 /**
  * Public inputs!
@@ -137,4 +137,4 @@ Field compute_public_input_delta(const std::vector<Field>& public_inputs,
     T0 = numerator / denominator;
     return T0;
 }
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/types/commitment_open_proof.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/types/commitment_open_proof.hpp
@@ -3,10 +3,10 @@
 #include <cstdint>
 #include <vector>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 struct commitment_open_proof {
     std::vector<uint8_t> proof_data;
 };
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/types/polynomial_manifest.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/types/polynomial_manifest.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 enum PolynomialSource { WITNESS, SELECTOR, PERMUTATION, OTHER };
 
@@ -224,4 +224,4 @@ class PrecomputedPolyList {
     std::string operator[](size_t index) const { return precomputed_poly_ids[index]; }
 };
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/types/program_settings.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/types/program_settings.hpp
@@ -13,7 +13,7 @@
 #include "./prover_settings.hpp"
 #include "barretenberg/plonk/transcript/transcript.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 class standard_verifier_settings : public standard_settings {
   public:
@@ -137,4 +137,4 @@ class ultra_with_keccak_verifier_settings : public ultra_verifier_settings {
     static constexpr size_t num_challenge_bytes = 32;
     static constexpr transcript::HashType hash_type = transcript::HashType::Keccak256;
 };
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/types/proof.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/types/proof.hpp
@@ -6,7 +6,7 @@
 #include <ostream>
 #include <vector>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 struct proof {
     std::vector<uint8_t> proof_data;
@@ -45,4 +45,4 @@ inline std::ostream& operator<<(std::ostream& os, proof const& data)
     return os;
 }
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/types/prover_settings.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/types/prover_settings.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "barretenberg/proof_system/arithmetization/arithmetization.hpp"
 #include "barretenberg/transcript/transcript.hpp"
-namespace proof_system::plonk {
+namespace bb::plonk {
 class settings_base {
   public:
     static constexpr bool requires_shifted_wire(const uint64_t wire_shift_settings, const uint64_t wire_index)
@@ -52,4 +52,4 @@ class ultra_with_keccak_settings : public ultra_settings {
     static constexpr transcript::HashType hash_type = transcript::HashType::Keccak256;
 };
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/utils/generalized_permutation.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/utils/generalized_permutation.hpp
@@ -3,7 +3,7 @@
 #include "barretenberg/polynomials/iterate_over_domain.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 template <typename program_settings>
 inline void compute_gen_permutation_lagrange_base_single(bb::polynomial& output,
                                                          const std::vector<uint32_t>& permutation,
@@ -63,4 +63,4 @@ inline void compute_gen_permutation_lagrange_base_single(bb::polynomial& output,
     }
     ITERATE_OVER_DOMAIN_END;
 }
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/utils/kate_verification.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/utils/kate_verification.hpp
@@ -3,7 +3,7 @@
 #include "barretenberg/plonk/proof_system/verification_key/verification_key.hpp"
 #include <map>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 template <typename Field, typename Transcript, typename program_settings>
 Field compute_kate_batch_evaluation(typename Transcript::Key* key, const Transcript& transcript)
@@ -106,4 +106,4 @@ void populate_kate_element_map(verification_key* key,
     }
 }
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/utils/permutation.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/utils/permutation.hpp
@@ -5,7 +5,7 @@
 #include "barretenberg/polynomials/iterate_over_domain.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 struct permutation_subgroup_element {
     uint32_t subgroup_index = 0;
@@ -108,4 +108,4 @@ inline void compute_permutation_lagrange_base_single(bb::polynomial& output,
     }
     ITERATE_OVER_DOMAIN_END;
 }
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/sol_gen.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/sol_gen.hpp
@@ -1,4 +1,4 @@
-namespace proof_system {
+namespace bb {
 
 /**
  * Write a solidity file containing the vk params to the given stream.
@@ -154,9 +154,9 @@ inline void output_vk_sol(std::ostream& os, std::shared_ptr<plonk::verification_
         break;
     }
     default: {
-        std::cerr << "proof_system::output_vk_sol unsupported composer type. Defaulting to standard composer" << std::endl;
+        std::cerr << "bb::output_vk_sol unsupported composer type. Defaulting to standard composer" << std::endl;
         return output_vk_sol_standard(os, key, class_name);
     }
     }
 }
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/verification_key.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/verification_key.cpp
@@ -4,7 +4,7 @@
 #include "barretenberg/plonk/proof_system/constants.hpp"
 #include "barretenberg/polynomials/evaluation_domain.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 /**
  * @brief Hashes the evaluation domain to match the 'circuit' approach taken in
@@ -44,7 +44,7 @@ bb::fr verification_key_data::hash_native(const size_t hash_index) const
 
     std::vector<uint8_t> preimage_data;
 
-    preimage_data.push_back(static_cast<uint8_t>(proof_system::CircuitType(circuit_type)));
+    preimage_data.push_back(static_cast<uint8_t>(bb::CircuitType(circuit_type)));
 
     const uint256_t domain = eval_domain.domain;
     const uint256_t generator = eval_domain.generator;
@@ -152,4 +152,4 @@ sha256::hash verification_key::sha256_hash()
     return sha256::sha256(to_buffer(vk_data));
 }
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/verification_key.hpp
@@ -9,7 +9,7 @@
 #include "barretenberg/srs/global_crs.hpp"
 #include <map>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 struct verification_key_data {
     uint32_t circuit_type;
@@ -113,7 +113,7 @@ struct verification_key {
         *this = verification_key{ std::move(data), bb::srs::get_crs_factory()->get_verifier_crs() };
     }
     // Alias verification_key as verification_key_data in the schema
-    void msgpack_schema(auto& packer) const { packer.pack_schema(proof_system::plonk::verification_key_data{}); }
+    void msgpack_schema(auto& packer) const { packer.pack_schema(bb::plonk::verification_key_data{}); }
 };
 
 template <typename B> inline void read(B& buf, verification_key& key)
@@ -143,4 +143,4 @@ inline std::ostream& operator<<(std::ostream& os, verification_key const& key)
     return os << key.as_data();
 };
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/verification_key.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/verification_key.test.cpp
@@ -8,9 +8,9 @@ auto& engine = numeric::random::get_debug_engine();
 } // namespace
 
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
-namespace proof_system::plonk::test_verification_key {
+namespace bb::plonk::test_verification_key {
 
 /**
  * @brief generate a random vk data for use in tests
@@ -154,4 +154,4 @@ TEST(VerificationKey, HashEqualityDifferentRecursiveProofPublicInputIndices)
     vk1_data.recursive_proof_public_input_indices.push_back(42);
     expect_hashes_eq(vk0_data, vk1_data);
 }
-} // namespace proof_system::plonk::test_verification_key
+} // namespace bb::plonk::test_verification_key

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/verifier/verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/verifier/verifier.cpp
@@ -10,7 +10,7 @@
 
 using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 template <typename program_settings>
 VerifierBase<program_settings>::VerifierBase(std::shared_ptr<verification_key> verifier_key,
                                              const transcript::Manifest& input_manifest)
@@ -242,4 +242,4 @@ template class VerifierBase<ultra_verifier_settings>;
 template class VerifierBase<ultra_to_standard_verifier_settings>;
 template class VerifierBase<ultra_with_keccak_verifier_settings>;
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/verifier/verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/verifier/verifier.hpp
@@ -5,7 +5,7 @@
 #include "barretenberg/plonk/proof_system/commitment_scheme/commitment_scheme.hpp"
 #include "barretenberg/plonk/transcript/manifest.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 template <typename program_settings> class VerifierBase {
 
   public:
@@ -32,4 +32,4 @@ typedef VerifierBase<standard_verifier_settings> Verifier;
 typedef VerifierBase<ultra_verifier_settings> UltraVerifier;
 typedef VerifierBase<ultra_to_standard_verifier_settings> UltraToStandardVerifier;
 typedef VerifierBase<ultra_with_keccak_verifier_settings> UltraWithKeccakVerifier;
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/verifier/verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/verifier/verifier.test.cpp
@@ -14,7 +14,7 @@
 namespace verifier_helpers {
 
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 plonk::Verifier generate_verifier(std::shared_ptr<proving_key> circuit_proving_key)
 {

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/permutation_widget.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/permutation_widget.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "random_widget.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 template <typename Field,
           typename Group,
           typename Transcript,
@@ -38,6 +38,6 @@ class ProverPermutationWidget : public ProverRandomWidget {
                                          const transcript::StandardTranscript& transcript) override;
 };
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk
 
 #include "./permutation_widget_impl.hpp"

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/permutation_widget_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/permutation_widget_impl.hpp
@@ -8,7 +8,7 @@
 #include "barretenberg/polynomials/polynomial_arithmetic.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 template <size_t program_width, bool idpolys, const size_t num_roots_cut_out_of_vanishing_polynomial>
 ProverPermutationWidget<program_width, idpolys, num_roots_cut_out_of_vanishing_polynomial>::ProverPermutationWidget(
@@ -786,4 +786,4 @@ Field VerifierPermutationWidget<Field, Group, Transcript, num_roots_cut_out_of_v
 
 template class VerifierPermutationWidget<bb::fr, bb::g1::affine_element, transcript::StandardTranscript>;
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/plookup_widget.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/plookup_widget.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "random_widget.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 template <typename Field,
           typename Group,
           typename Transcript,
@@ -42,6 +42,6 @@ class ProverPlookupWidget : public ProverRandomWidget {
                                                 const transcript::StandardTranscript& transcript) override;
 };
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk
 
 #include "./plookup_widget_impl.hpp"

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/plookup_widget_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/plookup_widget_impl.hpp
@@ -8,7 +8,7 @@
 #include "barretenberg/transcript/transcript.hpp"
 #include <cstddef>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 template <const size_t num_roots_cut_out_of_vanishing_polynomial>
 ProverPlookupWidget<num_roots_cut_out_of_vanishing_polynomial>::ProverPlookupWidget(proving_key* input_key)
@@ -733,7 +733,7 @@ Field VerifierPlookupWidget<Field, Group, Transcript, num_roots_cut_out_of_vanis
     T0 = numerator - denominator;
     quotient_numerator_eval += T0 * alpha_base;
     return alpha_base * alpha.sqr() * alpha;
-} // namespace proof_system::plonk
+} // namespace bb::plonk
 
 template <typename Field, typename Group, typename Transcript, const size_t num_roots_cut_out_of_vanishing_polynomial>
 Field VerifierPlookupWidget<Field, Group, Transcript, num_roots_cut_out_of_vanishing_polynomial>::
@@ -748,4 +748,4 @@ Field VerifierPlookupWidget<Field, Group, Transcript, num_roots_cut_out_of_vanis
 
 template class VerifierPlookupWidget<bb::fr, bb::g1::affine_element, transcript::StandardTranscript>;
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/random_widget.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/random_widgets/random_widget.hpp
@@ -7,7 +7,7 @@
 namespace transcript {
 class Transcript;
 }
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 struct proving_key;
 
@@ -51,4 +51,4 @@ class ProverRandomWidget {
     proving_key* key;
 };
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/transition_widgets/arithmetic_widget.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/transition_widgets/arithmetic_widget.hpp
@@ -2,7 +2,7 @@
 
 #include "./transition_widget.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace widget {
 
 /**
@@ -105,4 +105,4 @@ using ProverArithmeticWidget = widget::TransitionWidget<bb::fr, Settings, widget
 template <typename Field, typename Group, typename Transcript, typename Settings>
 using VerifierArithmeticWidget = widget::GenericVerifierWidget<Field, Transcript, Settings, widget::ArithmeticKernel>;
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/transition_widgets/elliptic_widget.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/transition_widgets/elliptic_widget.hpp
@@ -2,7 +2,7 @@
 
 #include "./transition_widget.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace widget {
 
 /**
@@ -154,4 +154,4 @@ using ProverEllipticWidget = widget::TransitionWidget<bb::fr, Settings, widget::
 template <typename Field, typename Group, typename Transcript, typename Settings>
 using VerifierEllipticWidget = widget::GenericVerifierWidget<Field, Transcript, Settings, widget::EllipticKernel>;
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/transition_widgets/genperm_sort_widget.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/transition_widgets/genperm_sort_widget.hpp
@@ -2,7 +2,7 @@
 
 #include "./transition_widget.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace widget {
 
 template <class Field, class Getters, typename PolyContainer> class GenPermSortKernel {
@@ -107,4 +107,4 @@ using ProverGenPermSortWidget = widget::TransitionWidget<bb::fr, Settings, widge
 template <typename Field, typename Group, typename Transcript, typename Settings>
 using VerifierGenPermSortWidget = widget::GenericVerifierWidget<Field, Transcript, Settings, widget::GenPermSortKernel>;
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/transition_widgets/plookup_arithmetic_widget.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/transition_widgets/plookup_arithmetic_widget.hpp
@@ -2,7 +2,7 @@
 
 #include "./transition_widget.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace widget {
 
 /**
@@ -179,4 +179,4 @@ template <typename Field, typename Group, typename Transcript, typename Settings
 using VerifierPlookupArithmeticWidget =
     widget::GenericVerifierWidget<Field, Transcript, Settings, widget::PlookupArithmeticKernel>;
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/transition_widgets/plookup_auxiliary_widget.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/transition_widgets/plookup_auxiliary_widget.hpp
@@ -2,7 +2,7 @@
 
 #include "./transition_widget.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace widget {
 
 /**
@@ -330,4 +330,4 @@ template <typename Field, typename Group, typename Transcript, typename Settings
 using VerifierPlookupAuxiliaryWidget =
     widget::GenericVerifierWidget<Field, Transcript, Settings, widget::PlookupAuxiliaryKernel>;
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/transition_widgets/transition_widget.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/widgets/transition_widgets/transition_widget.hpp
@@ -11,8 +11,8 @@
 #include "barretenberg/plonk/work_queue/work_queue.hpp"
 #include "barretenberg/polynomials/iterate_over_domain.hpp"
 
-using namespace proof_system;
-namespace proof_system::plonk {
+using namespace bb;
+namespace bb::plonk {
 
 namespace widget {
 enum ChallengeIndex {
@@ -378,4 +378,4 @@ class GenericVerifierWidget {
     }
 };
 } // namespace widget
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/transcript/transcript.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/transcript/transcript.hpp
@@ -38,7 +38,7 @@ class Transcript {
     };
 
   public:
-    typedef proof_system::plonk::verification_key Key;
+    typedef bb::plonk::verification_key Key;
 
     /**
      * Create a new transcript for Prover based on the manifest.

--- a/barretenberg/cpp/src/barretenberg/plonk/work_queue/work_queue.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/work_queue/work_queue.cpp
@@ -3,7 +3,7 @@
 #include "barretenberg/polynomials/polynomial.hpp"
 #include "barretenberg/polynomials/polynomial_arithmetic.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 using namespace bb;
 
@@ -286,4 +286,4 @@ std::vector<work_queue::work_item> work_queue::get_queue() const
     return work_item_queue;
 }
 
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/plonk/work_queue/work_queue.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/work_queue/work_queue.hpp
@@ -3,7 +3,7 @@
 #include "barretenberg/plonk/proof_system/proving_key/proving_key.hpp"
 #include "barretenberg/plonk/transcript/transcript_wrappers.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 
 using namespace bb;
 
@@ -68,4 +68,4 @@ class work_queue {
     transcript::StandardTranscript* transcript;
     std::vector<work_item> work_item_queue;
 };
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/polynomials/evaluation_domain.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/evaluation_domain.cpp
@@ -66,7 +66,7 @@ EvaluationDomain<Fr>::EvaluationDomain(const size_t domain_size, const size_t ta
     , roots(nullptr)
 {
     // Grumpkin does not have many roots of unity and, given these are not used for Honk, we set it to one.
-    if (proof_system::IsAnyOf<Fr, grumpkin::fr>) {
+    if (bb::IsAnyOf<Fr, grumpkin::fr>) {
         root = Fr::one();
     } else {
         root = Fr::get_root_of_unity(log2_size);

--- a/barretenberg/cpp/src/barretenberg/proof_system/arithmetization/gate_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/arithmetization/gate_data.hpp
@@ -6,7 +6,7 @@
 // TODO(#557): The field-specific aliases for gates should be removed and the type could be explicit when this
 // structures are used to avoid having foo_gate and foo_gate_grumpkin (i.e. use foo_gate<field> instead). Moreover, we
 // need to ensure the read/write functions handle grumpkin gates as well.
-namespace proof_system {
+namespace bb {
 template <typename FF> struct add_triple_ {
     uint32_t a;
     uint32_t b;
@@ -163,4 +163,4 @@ template <typename FF> struct poseidon2_end_gate_ {
     uint32_t c;
     uint32_t d;
 };
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/circuit_builder_base.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/circuit_builder_base.cpp
@@ -2,7 +2,7 @@
 #include "barretenberg/ecc/curves/bn254/bn254.hpp"
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 
-namespace proof_system {
+namespace bb {
 
 /**
  * Join variable class b to variable class a.
@@ -45,4 +45,4 @@ void CircuitBuilderBase<FF>::assert_equal(const uint32_t a_variable_idx,
 // Standard honk/ plonk instantiation
 template class CircuitBuilderBase<bb::fr>;
 template class CircuitBuilderBase<grumpkin::fr>;
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/circuit_builder_base.hpp
@@ -8,7 +8,7 @@
 
 #include <unordered_map>
 
-namespace proof_system {
+namespace bb {
 static constexpr uint32_t DUMMY_TAG = 0;
 
 template <typename FF_> class CircuitBuilderBase {
@@ -382,7 +382,7 @@ template <typename FF_> class CircuitBuilderBase {
     }
 };
 
-} // namespace proof_system
+} // namespace bb
 
 // TODO(#217)(Cody): This will need updating based on the approach we take to ensure no multivariate is zero.
 /**

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/eccvm_builder_types.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/eccvm_builder_types.hpp
@@ -2,7 +2,7 @@
 
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 
-namespace proof_system_eccvm {
+namespace bb_eccvm {
 
 static constexpr size_t NUM_SCALAR_BITS = 128;
 static constexpr size_t WNAF_SLICE_BITS = 4;
@@ -44,4 +44,4 @@ template <typename CycleGroup> struct ScalarMul {
 
 template <typename CycleGroup> using MSM = std::vector<ScalarMul<CycleGroup>>;
 
-} // namespace proof_system_eccvm
+} // namespace bb_eccvm

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/eccvm_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/eccvm_circuit_builder.hpp
@@ -12,7 +12,7 @@
 #include "barretenberg/proof_system/op_queue/ecc_op_queue.hpp"
 #include "barretenberg/relations/relation_parameters.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename Flavor> class ECCVMCircuitBuilder {
   public:
@@ -24,21 +24,21 @@ template <typename Flavor> class ECCVMCircuitBuilder {
     using Element = typename CycleGroup::element;
     using AffineElement = typename CycleGroup::affine_element;
 
-    static constexpr size_t NUM_SCALAR_BITS = proof_system_eccvm::NUM_SCALAR_BITS;
-    static constexpr size_t WNAF_SLICE_BITS = proof_system_eccvm::WNAF_SLICE_BITS;
-    static constexpr size_t NUM_WNAF_SLICES = proof_system_eccvm::NUM_WNAF_SLICES;
-    static constexpr uint64_t WNAF_MASK = proof_system_eccvm::WNAF_MASK;
-    static constexpr size_t POINT_TABLE_SIZE = proof_system_eccvm::POINT_TABLE_SIZE;
-    static constexpr size_t WNAF_SLICES_PER_ROW = proof_system_eccvm::WNAF_SLICES_PER_ROW;
-    static constexpr size_t ADDITIONS_PER_ROW = proof_system_eccvm::ADDITIONS_PER_ROW;
+    static constexpr size_t NUM_SCALAR_BITS = bb_eccvm::NUM_SCALAR_BITS;
+    static constexpr size_t WNAF_SLICE_BITS = bb_eccvm::WNAF_SLICE_BITS;
+    static constexpr size_t NUM_WNAF_SLICES = bb_eccvm::NUM_WNAF_SLICES;
+    static constexpr uint64_t WNAF_MASK = bb_eccvm::WNAF_MASK;
+    static constexpr size_t POINT_TABLE_SIZE = bb_eccvm::POINT_TABLE_SIZE;
+    static constexpr size_t WNAF_SLICES_PER_ROW = bb_eccvm::WNAF_SLICES_PER_ROW;
+    static constexpr size_t ADDITIONS_PER_ROW = bb_eccvm::ADDITIONS_PER_ROW;
 
     static constexpr size_t NUM_POLYNOMIALS = Flavor::NUM_ALL_ENTITIES;
     static constexpr size_t NUM_WIRES = Flavor::NUM_WIRES;
 
-    using MSM = proof_system_eccvm::MSM<CycleGroup>;
-    using VMOperation = proof_system_eccvm::VMOperation<CycleGroup>;
+    using MSM = bb_eccvm::MSM<CycleGroup>;
+    using VMOperation = bb_eccvm::VMOperation<CycleGroup>;
     std::shared_ptr<ECCOpQueue> op_queue;
-    using ScalarMul = proof_system_eccvm::ScalarMul<CycleGroup>;
+    using ScalarMul = bb_eccvm::ScalarMul<CycleGroup>;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
 
     ECCVMCircuitBuilder()
@@ -492,7 +492,7 @@ template <typename Flavor> class ECCVMCircuitBuilder {
         auto eccvm_set_permutation_delta =
             gamma * (gamma + beta_sqr) * (gamma + beta_sqr + beta_sqr) * (gamma + beta_sqr + beta_sqr + beta_sqr);
         eccvm_set_permutation_delta = eccvm_set_permutation_delta.invert();
-        proof_system::RelationParameters<typename Flavor::FF> params{
+        bb::RelationParameters<typename Flavor::FF> params{
             .eta = 0,
             .beta = beta,
             .gamma = gamma,
@@ -505,9 +505,8 @@ template <typename Flavor> class ECCVMCircuitBuilder {
 
         auto polynomials = compute_polynomials();
         const size_t num_rows = polynomials.get_polynomial_size();
-        proof_system::honk::logderivative_library::
-            compute_logderivative_inverse<Flavor, honk::sumcheck::ECCVMLookupRelation<FF>>(
-                polynomials, params, num_rows);
+        bb::honk::logderivative_library::compute_logderivative_inverse<Flavor, honk::sumcheck::ECCVMLookupRelation<FF>>(
+            polynomials, params, num_rows);
 
         honk::permutation_library::compute_permutation_grand_product<Flavor, honk::sumcheck::ECCVMSetRelation<FF>>(
             num_rows, polynomials, params);
@@ -599,4 +598,4 @@ template <typename Flavor> class ECCVMCircuitBuilder {
         return num_rows_pow2;
     }
 };
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/eccvm_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/eccvm_circuit_builder.test.cpp
@@ -13,7 +13,7 @@ namespace eccvm_circuit_builder_tests {
 
 template <typename Flavor> class ECCVMCircuitBuilderTests : public ::testing::Test {};
 
-using FlavorTypes = ::testing::Types<proof_system::honk::flavor::ECCVM>;
+using FlavorTypes = ::testing::Types<bb::honk::flavor::ECCVM>;
 TYPED_TEST_SUITE(ECCVMCircuitBuilderTests, FlavorTypes);
 
 TYPED_TEST(ECCVMCircuitBuilderTests, BaseCase)
@@ -21,7 +21,7 @@ TYPED_TEST(ECCVMCircuitBuilderTests, BaseCase)
     using Flavor = TypeParam;
     using G1 = typename Flavor::CycleGroup;
     using Fr = typename G1::Fr;
-    proof_system::ECCVMCircuitBuilder<Flavor> circuit;
+    bb::ECCVMCircuitBuilder<Flavor> circuit;
     auto generators = G1::derive_generators("test generators", 3);
     typename G1::element a = generators[0];
     typename G1::element b = generators[1];
@@ -55,7 +55,7 @@ TYPED_TEST(ECCVMCircuitBuilderTests, Add)
 {
     using Flavor = TypeParam;
     using G1 = typename Flavor::CycleGroup;
-    proof_system::ECCVMCircuitBuilder<Flavor> circuit;
+    bb::ECCVMCircuitBuilder<Flavor> circuit;
 
     auto generators = G1::derive_generators("test generators", 3);
     typename G1::element a = generators[0];
@@ -71,7 +71,7 @@ TYPED_TEST(ECCVMCircuitBuilderTests, Mul)
     using Flavor = TypeParam;
     using G1 = typename Flavor::CycleGroup;
     using Fr = typename G1::Fr;
-    proof_system::ECCVMCircuitBuilder<Flavor> circuit;
+    bb::ECCVMCircuitBuilder<Flavor> circuit;
     auto generators = G1::derive_generators("test generators", 3);
     typename G1::element a = generators[0];
     Fr x = Fr::random_element(&engine);
@@ -87,7 +87,7 @@ TYPED_TEST(ECCVMCircuitBuilderTests, ShortMul)
     using Flavor = TypeParam;
     using G1 = typename Flavor::CycleGroup;
     using Fr = typename G1::Fr;
-    proof_system::ECCVMCircuitBuilder<Flavor> circuit;
+    bb::ECCVMCircuitBuilder<Flavor> circuit;
     auto generators = G1::derive_generators("test generators", 3);
 
     typename G1::element a = generators[0];
@@ -109,7 +109,7 @@ TYPED_TEST(ECCVMCircuitBuilderTests, EqFails)
     using Flavor = TypeParam;
     using G1 = typename Flavor::CycleGroup;
     using Fr = typename G1::Fr;
-    proof_system::ECCVMCircuitBuilder<Flavor> circuit;
+    bb::ECCVMCircuitBuilder<Flavor> circuit;
 
     auto generators = G1::derive_generators("test generators", 3);
     typename G1::element a = generators[0];
@@ -124,7 +124,7 @@ TYPED_TEST(ECCVMCircuitBuilderTests, EqFails)
 TYPED_TEST(ECCVMCircuitBuilderTests, EmptyRow)
 {
     using Flavor = TypeParam;
-    proof_system::ECCVMCircuitBuilder<Flavor> circuit;
+    bb::ECCVMCircuitBuilder<Flavor> circuit;
 
     circuit.empty_row();
 
@@ -137,7 +137,7 @@ TYPED_TEST(ECCVMCircuitBuilderTests, EmptyRowBetweenOps)
     using Flavor = TypeParam;
     using G1 = typename Flavor::CycleGroup;
     using Fr = typename G1::Fr;
-    proof_system::ECCVMCircuitBuilder<Flavor> circuit;
+    bb::ECCVMCircuitBuilder<Flavor> circuit;
 
     auto generators = G1::derive_generators("test generators", 3);
     typename G1::element a = generators[0];
@@ -158,7 +158,7 @@ TYPED_TEST(ECCVMCircuitBuilderTests, EndWithEq)
     using Flavor = TypeParam;
     using G1 = typename Flavor::CycleGroup;
     using Fr = typename G1::Fr;
-    proof_system::ECCVMCircuitBuilder<Flavor> circuit;
+    bb::ECCVMCircuitBuilder<Flavor> circuit;
 
     auto generators = G1::derive_generators("test generators", 3);
     typename G1::element a = generators[0];
@@ -178,7 +178,7 @@ TYPED_TEST(ECCVMCircuitBuilderTests, EndWithAdd)
     using Flavor = TypeParam;
     using G1 = typename Flavor::CycleGroup;
     using Fr = typename G1::Fr;
-    proof_system::ECCVMCircuitBuilder<Flavor> circuit;
+    bb::ECCVMCircuitBuilder<Flavor> circuit;
 
     auto generators = G1::derive_generators("test generators", 3);
     typename G1::element a = generators[0];
@@ -199,7 +199,7 @@ TYPED_TEST(ECCVMCircuitBuilderTests, EndWithMul)
     using Flavor = TypeParam;
     using G1 = typename Flavor::CycleGroup;
     using Fr = typename G1::Fr;
-    proof_system::ECCVMCircuitBuilder<Flavor> circuit;
+    bb::ECCVMCircuitBuilder<Flavor> circuit;
 
     auto generators = G1::derive_generators("test generators", 3);
     typename G1::element a = generators[0];
@@ -218,7 +218,7 @@ TYPED_TEST(ECCVMCircuitBuilderTests, EndWithNoop)
     using Flavor = TypeParam;
     using G1 = typename Flavor::CycleGroup;
     using Fr = typename G1::Fr;
-    proof_system::ECCVMCircuitBuilder<Flavor> circuit;
+    bb::ECCVMCircuitBuilder<Flavor> circuit;
 
     auto generators = G1::derive_generators("test generators", 3);
     typename G1::element a = generators[0];
@@ -257,13 +257,13 @@ TYPED_TEST(ECCVMCircuitBuilderTests, MSM)
     // single msms
     for (size_t j = 1; j < max_num_msms; ++j) {
         using Flavor = TypeParam;
-        proof_system::ECCVMCircuitBuilder<Flavor> circuit;
+        bb::ECCVMCircuitBuilder<Flavor> circuit;
         try_msms(j, circuit);
         bool result = circuit.check_circuit();
         EXPECT_EQ(result, true);
     }
     // chain msms
-    proof_system::ECCVMCircuitBuilder<Flavor> circuit;
+    bb::ECCVMCircuitBuilder<Flavor> circuit;
     for (size_t j = 1; j < 9; ++j) {
         try_msms(j, circuit);
     }

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/msm_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/msm_builder.hpp
@@ -4,7 +4,7 @@
 
 #include "./eccvm_builder_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename Flavor> class ECCVMMSMMBuilder {
   public:
@@ -13,9 +13,9 @@ template <typename Flavor> class ECCVMMSMMBuilder {
     using Element = typename CycleGroup::element;
     using AffineElement = typename CycleGroup::affine_element;
 
-    static constexpr size_t ADDITIONS_PER_ROW = proof_system_eccvm::ADDITIONS_PER_ROW;
-    static constexpr size_t NUM_SCALAR_BITS = proof_system_eccvm::NUM_SCALAR_BITS;
-    static constexpr size_t WNAF_SLICE_BITS = proof_system_eccvm::WNAF_SLICE_BITS;
+    static constexpr size_t ADDITIONS_PER_ROW = bb_eccvm::ADDITIONS_PER_ROW;
+    static constexpr size_t NUM_SCALAR_BITS = bb_eccvm::NUM_SCALAR_BITS;
+    static constexpr size_t WNAF_SLICE_BITS = bb_eccvm::WNAF_SLICE_BITS;
 
     struct MSMState {
         uint32_t pc = 0;
@@ -53,7 +53,7 @@ template <typename Flavor> class ECCVMMSMMBuilder {
      * @param total_number_of_muls
      * @return std::vector<MSMState>
      */
-    static std::vector<MSMState> compute_msm_state(const std::vector<proof_system_eccvm::MSM<CycleGroup>>& msms,
+    static std::vector<MSMState> compute_msm_state(const std::vector<bb_eccvm::MSM<CycleGroup>>& msms,
                                                    std::array<std::vector<size_t>, 2>& point_table_read_counts,
                                                    const uint32_t total_number_of_muls)
     {
@@ -279,4 +279,4 @@ template <typename Flavor> class ECCVMMSMMBuilder {
         return msm_state;
     }
 };
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/precomputed_tables_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/precomputed_tables_builder.hpp
@@ -2,7 +2,7 @@
 
 #include "./eccvm_builder_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename Flavor> class ECCVMPrecomputedTablesBuilder {
   public:
@@ -11,9 +11,9 @@ template <typename Flavor> class ECCVMPrecomputedTablesBuilder {
     using Element = typename CycleGroup::element;
     using AffineElement = typename CycleGroup::affine_element;
 
-    static constexpr size_t NUM_WNAF_SLICES = proof_system_eccvm::NUM_WNAF_SLICES;
-    static constexpr size_t WNAF_SLICES_PER_ROW = proof_system_eccvm::WNAF_SLICES_PER_ROW;
-    static constexpr size_t WNAF_SLICE_BITS = proof_system_eccvm::WNAF_SLICE_BITS;
+    static constexpr size_t NUM_WNAF_SLICES = bb_eccvm::NUM_WNAF_SLICES;
+    static constexpr size_t WNAF_SLICES_PER_ROW = bb_eccvm::WNAF_SLICES_PER_ROW;
+    static constexpr size_t WNAF_SLICE_BITS = bb_eccvm::WNAF_SLICE_BITS;
 
     struct PrecomputeState {
         int s1 = 0;
@@ -34,7 +34,7 @@ template <typename Flavor> class ECCVMPrecomputedTablesBuilder {
     };
 
     static std::vector<PrecomputeState> compute_precompute_state(
-        const std::vector<proof_system_eccvm::ScalarMul<CycleGroup>>& ecc_muls)
+        const std::vector<bb_eccvm::ScalarMul<CycleGroup>>& ecc_muls)
     {
         std::vector<PrecomputeState> precompute_state;
 
@@ -101,11 +101,11 @@ template <typename Flavor> class ECCVMPrecomputedTablesBuilder {
 
                 row.precompute_double = d2;
                 // fill accumulator in reverse order i.e. first row = 15[P], then 13[P], ..., 1[P]
-                row.precompute_accumulator = entry.precomputed_table[proof_system_eccvm::POINT_TABLE_SIZE - 1 - i];
+                row.precompute_accumulator = entry.precomputed_table[bb_eccvm::POINT_TABLE_SIZE - 1 - i];
                 precompute_state.emplace_back(row);
             }
         }
         return precompute_state;
     }
 };
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/transcript_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/eccvm/transcript_builder.hpp
@@ -2,7 +2,7 @@
 
 #include "./eccvm_builder_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename Flavor> class ECCVMTranscriptBuilder {
   public:
@@ -58,8 +58,7 @@ template <typename Flavor> class ECCVMTranscriptBuilder {
         }
     };
     static std::vector<TranscriptState> compute_transcript_state(
-        const std::vector<proof_system_eccvm::VMOperation<CycleGroup>>& vm_operations,
-        const uint32_t total_number_of_muls)
+        const std::vector<bb_eccvm::VMOperation<CycleGroup>>& vm_operations, const uint32_t total_number_of_muls)
     {
         std::vector<TranscriptState> transcript_state;
         VMState state{
@@ -75,7 +74,7 @@ template <typename Flavor> class ECCVMTranscriptBuilder {
         transcript_state.emplace_back(TranscriptState{});
         for (size_t i = 0; i < vm_operations.size(); ++i) {
             TranscriptState row;
-            const proof_system_eccvm::VMOperation<CycleGroup>& entry = vm_operations[i];
+            const bb_eccvm::VMOperation<CycleGroup>& entry = vm_operations[i];
 
             const bool is_mul = entry.mul;
             const bool z1_zero = (entry.mul) ? entry.z1 == 0 : true;
@@ -184,4 +183,4 @@ template <typename Flavor> class ECCVMTranscriptBuilder {
         return transcript_state;
     }
 };
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/generated/AvmMini_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/generated/AvmMini_circuit_builder.hpp
@@ -17,7 +17,7 @@
 
 using namespace bb;
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF> struct AvmMiniFullRow {
     FF avmMini_clk{};
@@ -70,7 +70,7 @@ template <typename FF> struct AvmMiniFullRow {
 
 class AvmMiniCircuitBuilder {
   public:
-    using Flavor = proof_system::honk::flavor::AvmMiniFlavor;
+    using Flavor = bb::honk::flavor::AvmMiniFlavor;
     using FF = Flavor::FF;
     using Row = AvmMiniFullRow<FF>;
 
@@ -202,4 +202,4 @@ class AvmMiniCircuitBuilder {
         return num_rows_pow2;
     }
 };
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/generated/Toy_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/generated/Toy_circuit_builder.hpp
@@ -18,7 +18,7 @@
 
 using namespace bb;
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF> struct ToyFullRow {
     FF toy_first{};
@@ -42,7 +42,7 @@ template <typename FF> struct ToyFullRow {
 
 class ToyCircuitBuilder {
   public:
-    using Flavor = proof_system::honk::flavor::ToyFlavor;
+    using Flavor = bb::honk::flavor::ToyFlavor;
     using FF = Flavor::FF;
     using Row = ToyFullRow<FF>;
 
@@ -94,7 +94,7 @@ class ToyCircuitBuilder {
 
         const FF gamma = FF::random_element();
         const FF beta = FF::random_element();
-        proof_system::RelationParameters<typename Flavor::FF> params{
+        bb::RelationParameters<typename Flavor::FF> params{
             .eta = 0,
             .beta = beta,
             .gamma = gamma,
@@ -137,7 +137,7 @@ class ToyCircuitBuilder {
 
         const auto evaluate_logderivative = [&]<typename LogDerivativeSettings>(const std::string& lookup_name) {
             // Check the logderivative relation
-            proof_system::honk::logderivative_library::compute_logderivative_inverse<Flavor, LogDerivativeSettings>(
+            bb::honk::logderivative_library::compute_logderivative_inverse<Flavor, LogDerivativeSettings>(
                 polys, params, num_rows);
 
             typename LogDerivativeSettings::SumcheckArrayOfValuesOverSubrelations lookup_result;
@@ -183,4 +183,4 @@ class ToyCircuitBuilder {
         return num_rows_pow2;
     }
 };
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_translator_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_translator_circuit_builder.cpp
@@ -13,7 +13,7 @@
 #include "barretenberg/plonk/proof_system/constants.hpp"
 #include "barretenberg/proof_system/op_queue/ecc_op_queue.hpp"
 #include <cstddef>
-namespace proof_system {
+namespace bb {
 using ECCVMOperation = ECCOpQueue::ECCVMOperation;
 
 /**
@@ -1067,4 +1067,4 @@ bool GoblinTranslatorCircuitBuilder::check_circuit()
 };
 template GoblinTranslatorCircuitBuilder::AccumulationInput generate_witness_values(
     bb::fr, bb::fr, bb::fr, bb::fr, bb::fr, bb::fr, bb::fr, bb::fq, bb::fq, bb::fq);
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_translator_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_translator_circuit_builder.hpp
@@ -19,7 +19,7 @@
 #include <cstdlib>
 #include <iterator>
 #include <tuple>
-namespace proof_system {
+namespace bb {
 /**
  * @brief GoblinTranslatorCircuitBuilder creates a circuit that evaluates the correctness of the evaluation of
  * EccOpQueue in Fq while operating in the Fr scalar field (r is the modulus of Fr and p is the modulus of Fp)
@@ -472,4 +472,4 @@ GoblinTranslatorCircuitBuilder::AccumulationInput generate_witness_values(Fr op_
                                                                           Fq previous_accumulator,
                                                                           Fq batching_challenge_v,
                                                                           Fq evaluation_input_x);
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_translator_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_translator_circuit_builder.test.cpp
@@ -9,7 +9,7 @@ using namespace bb;
 namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
-namespace proof_system {
+namespace bb {
 
 /**
  * @brief Check that a single accumulation gate is created correctly
@@ -129,4 +129,4 @@ TEST(GoblinTranslatorCircuitBuilder, SeveralOperationCorrectness)
     // Check the computation result is in line with what we've computed
     EXPECT_EQ(result, circuit_builder.get_computation_result());
 }
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_translator_mini.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_translator_mini.fuzzer.cpp
@@ -5,7 +5,7 @@ using Fq = ::curve::BN254::BaseField;
 
 extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size)
 {
-    constexpr size_t NUM_LIMB_BITS = proof_system::GoblinTranslatorCircuitBuilder::NUM_LIMB_BITS;
+    constexpr size_t NUM_LIMB_BITS = bb::GoblinTranslatorCircuitBuilder::NUM_LIMB_BITS;
     constexpr size_t WIDE_LIMB_BYTES = 2 * NUM_LIMB_BITS / 8;
     constexpr size_t TOTAL_SIZE = 1 + 5 * sizeof(numeric::uint256_t) + 2 * WIDE_LIMB_BYTES;
     char buffer[32] = { 0 };
@@ -32,10 +32,10 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size)
     memcpy(buffer, data + 1 + 5 * sizeof(uint256_t) + WIDE_LIMB_BYTES, WIDE_LIMB_BYTES);
     Fr z_2 = Fr(*(uint256_t*)(buffer));
 
-    proof_system::GoblinTranslatorCircuitBuilder::AccumulationInput single_accumulation_step =
-        proof_system::generate_witness_values(op, p_x_lo, p_x_hi, p_y_lo, p_y_hi, z_1, z_2, previous_accumulator, v, x);
+    bb::GoblinTranslatorCircuitBuilder::AccumulationInput single_accumulation_step =
+        bb::generate_witness_values(op, p_x_lo, p_x_hi, p_y_lo, p_y_hi, z_1, z_2, previous_accumulator, v, x);
 
-    auto circuit_builder = proof_system::GoblinTranslatorCircuitBuilder(v, x);
+    auto circuit_builder = bb::GoblinTranslatorCircuitBuilder(v, x);
     circuit_builder.create_accumulation_gate(single_accumulation_step);
     if (!circuit_builder.check_circuit()) {
         return 1;

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_ultra_circuit_builder.cpp
@@ -8,7 +8,7 @@
 using namespace bb;
 using namespace crypto;
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF> void GoblinUltraCircuitBuilder_<FF>::finalize_circuit()
 {
@@ -540,4 +540,4 @@ template <typename FF> bool GoblinUltraCircuitBuilder_<FF>::check_circuit()
 }
 
 template class GoblinUltraCircuitBuilder_<bb::fr>;
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_ultra_circuit_builder.hpp
@@ -3,7 +3,7 @@
 #include "barretenberg/proof_system/op_queue/ecc_op_queue.hpp"
 #include "ultra_circuit_builder.hpp"
 
-namespace proof_system {
+namespace bb {
 
 using namespace bb;
 
@@ -195,4 +195,4 @@ template <typename FF> class GoblinUltraCircuitBuilder_ : public UltraCircuitBui
     bool check_circuit();
 };
 using GoblinUltraCircuitBuilder = GoblinUltraCircuitBuilder_<bb::fr>;
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_ultra_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/goblin_ultra_circuit_builder.test.cpp
@@ -6,7 +6,7 @@ using namespace bb;
 namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
-namespace proof_system {
+namespace bb {
 
 TEST(GoblinUltraCircuitBuilder, CopyConstructor)
 {
@@ -157,4 +157,4 @@ TEST(GoblinUltraCircuitBuilder, GoblinEccOpQueueUltraOps)
     }
 }
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.cpp
@@ -9,7 +9,7 @@
 
 using namespace bb;
 
-namespace proof_system {
+namespace bb {
 
 /**
  * Create an addition gate.
@@ -561,4 +561,4 @@ template <typename FF> msgpack::sbuffer StandardCircuitBuilder_<FF>::export_circ
 template class StandardCircuitBuilder_<bb::fr>;
 template class StandardCircuitBuilder_<grumpkin::fr>;
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.hpp
@@ -7,7 +7,7 @@
 #include "circuit_builder_base.hpp"
 #include <array>
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF> class StandardCircuitBuilder_ : public CircuitBuilderBase<FF> {
   public:
@@ -148,4 +148,4 @@ template <typename FF> class StandardCircuitBuilder_ : public CircuitBuilderBase
 
 using StandardCircuitBuilder = StandardCircuitBuilder_<bb::fr>;
 using StandardGrumpkinCircuitBuilder = StandardCircuitBuilder_<grumpkin::fr>;
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/standard_circuit_builder.test.cpp
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 
 using namespace bb;
-using namespace proof_system;
+using namespace bb;
 
 namespace {
 auto& engine = numeric::random::get_debug_engine();

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/toy_avm/toy_avm_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/toy_avm/toy_avm_circuit_builder.test.cpp
@@ -20,8 +20,8 @@ namespace toy_avm_circuit_builder_tests {
 TEST(ToyAVMCircuitBuilder, BaseCase)
 {
 
-    using FF = proof_system::honk::flavor::ToyFlavor::FF;
-    using Builder = proof_system::ToyCircuitBuilder;
+    using FF = bb::honk::flavor::ToyFlavor::FF;
+    using Builder = bb::ToyCircuitBuilder;
     using Row = Builder::Row;
     Builder circuit_builder;
 

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.cpp
@@ -12,7 +12,7 @@
 
 using namespace bb;
 
-namespace proof_system {
+namespace bb {
 
 template <typename Arithmetization> void UltraCircuitBuilder_<Arithmetization>::finalize_circuit()
 {
@@ -1514,7 +1514,7 @@ std::array<uint32_t, 2> UltraCircuitBuilder_<Arithmetization>::decompose_non_nat
  * @details The data queued represents a non-native field multiplication identity a * b = q * p + r,
  * where a, b, q, r are all emulated non-native field elements that are each split across 4 distinct witness variables.
  *
- * Without this queue some functions, such as proof_system::plonk::stdlib::element::multiple_montgomery_ladder, would
+ * Without this queue some functions, such as bb::plonk::stdlib::element::multiple_montgomery_ladder, would
  * duplicate non-native field operations, which can be quite expensive. We queue up these operations, and remove
  * duplicates in the circuit finishing stage of the proving key computation.
  *
@@ -3489,4 +3489,4 @@ template class UltraCircuitBuilder_<arithmetization::UltraHonk<bb::fr>>;
 // To enable this we need to template plookup
 // template class UltraCircuitBuilder_<grumpkin::fr>;
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
@@ -12,7 +12,7 @@
 #include "circuit_builder_base.hpp"
 #include <optional>
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF> struct non_native_field_witnesses {
     // first 4 array elements = limbs
@@ -1167,4 +1167,4 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization:
     bool check_circuit();
 };
 using UltraCircuitBuilder = UltraCircuitBuilder_<arithmetization::Ultra<bb::fr>>;
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.test.cpp
@@ -7,7 +7,7 @@ using namespace bb;
 namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
-namespace proof_system {
+namespace bb {
 using plookup::ColumnIdx;
 using plookup::MultiTableId;
 
@@ -648,7 +648,7 @@ TEST(ultra_circuit_constructor, non_native_field_multiplication)
     const auto q_indices = get_limb_witness_indices(split_into_limbs(uint256_t(q)));
     const auto r_indices = get_limb_witness_indices(split_into_limbs(uint256_t(r)));
 
-    proof_system::non_native_field_witnesses<fr> inputs{
+    bb::non_native_field_witnesses<fr> inputs{
         a_indices, b_indices, q_indices, r_indices, modulus_limbs, fr(uint256_t(modulus)),
     };
     const auto [lo_1_idx, hi_1_idx] = circuit_constructor.evaluate_non_native_field_multiplication(inputs);
@@ -849,4 +849,4 @@ TEST(ultra_circuit_constructor, check_circuit_showcase)
     EXPECT_EQ(circuit_constructor.check_circuit(), true);
 }
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/composer/composer_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/composer/composer_lib.hpp
@@ -4,7 +4,7 @@
 
 #include <memory>
 
-namespace proof_system {
+namespace bb {
 
 /**
  * @brief Construct selector polynomials from circuit selector information and put into polynomial cache
@@ -145,4 +145,4 @@ std::vector<typename Flavor::Polynomial> construct_wire_polynomials_base(
     }
     return wire_polynomials;
 }
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/composer/composer_lib.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/composer/composer_lib.test.cpp
@@ -6,7 +6,7 @@
 #include <array>
 #include <gtest/gtest.h>
 
-namespace proof_system::test_composer_lib {
+namespace bb::test_composer_lib {
 
 class ComposerLibTests : public ::testing::Test {
   protected:
@@ -60,4 +60,4 @@ TEST_F(ComposerLibTests, ConstructSelectors)
     EXPECT_EQ(proving_key.q_c[3 + offset], 20);
 }
 
-} // namespace proof_system::test_composer_lib
+} // namespace bb::test_composer_lib

--- a/barretenberg/cpp/src/barretenberg/proof_system/composer/permutation_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/composer/permutation_lib.hpp
@@ -24,7 +24,7 @@
 
 // TODO(Cody): very little code is shared; should split this up into plonk/honk files.
 
-namespace proof_system {
+namespace bb {
 
 /**
  * @brief cycle_node represents the index of a value of the circuit.
@@ -527,4 +527,4 @@ void compute_honk_generalized_sigma_permutations(const typename Flavor::CircuitB
         proving_key->get_id_polynomials(), mapping.ids, proving_key);
 }
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/composer/permutation_lib.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/composer/permutation_lib.test.cpp
@@ -6,7 +6,7 @@
 #include <array>
 #include <gtest/gtest.h>
 
-namespace proof_system::test_composer_lib {
+namespace bb::test_composer_lib {
 
 class PermutationHelperTests : public ::testing::Test {
   protected:
@@ -90,4 +90,4 @@ TEST_F(PermutationHelperTests, ComputeStandardAuxPolynomials)
     compute_first_and_last_lagrange_polynomials<Flavor>(proving_key);
 }
 
-} // namespace proof_system::test_composer_lib
+} // namespace bb::test_composer_lib

--- a/barretenberg/cpp/src/barretenberg/proof_system/library/grand_product_delta.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/library/grand_product_delta.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <span>
-namespace proof_system::honk {
+namespace bb::honk {
 
 /**
  * @brief Compute the correction term for the permutation argument.
@@ -83,4 +83,4 @@ Field compute_lookup_grand_product_delta(const Field& beta, const Field& gamma, 
     return gamma_by_one_plus_beta.pow(domain_size);           // (γ(1 + β))^n
 }
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/proof_system/library/grand_product_library.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/library/grand_product_library.hpp
@@ -7,7 +7,7 @@
 #include "barretenberg/relations/relation_parameters.hpp"
 #include <typeinfo>
 
-namespace proof_system::honk::grand_product_library {
+namespace bb::honk::grand_product_library {
 
 // TODO(luke): This contains utilities for grand product computation and is not specific to the permutation grand
 // product. Update comments accordingly.
@@ -50,7 +50,7 @@ namespace proof_system::honk::grand_product_library {
 template <typename Flavor, typename GrandProdRelation>
 void compute_grand_product(const size_t circuit_size,
                            typename Flavor::ProverPolynomials& full_polynomials,
-                           proof_system::RelationParameters<typename Flavor::FF>& relation_parameters)
+                           bb::RelationParameters<typename Flavor::FF>& relation_parameters)
 {
     using FF = typename Flavor::FF;
     using Polynomial = typename Flavor::Polynomial;
@@ -144,7 +144,7 @@ void compute_grand_product(const size_t circuit_size,
 template <typename Flavor>
 void compute_grand_products(std::shared_ptr<typename Flavor::ProvingKey>& key,
                             typename Flavor::ProverPolynomials& full_polynomials,
-                            proof_system::RelationParameters<typename Flavor::FF>& relation_parameters)
+                            bb::RelationParameters<typename Flavor::FF>& relation_parameters)
 {
     using GrandProductRelations = typename Flavor::GrandProductRelations;
     using FF = typename Flavor::FF;
@@ -167,4 +167,4 @@ void compute_grand_products(std::shared_ptr<typename Flavor::ProvingKey>& key,
     });
 }
 
-} // namespace proof_system::honk::grand_product_library
+} // namespace bb::honk::grand_product_library

--- a/barretenberg/cpp/src/barretenberg/proof_system/library/grand_product_library.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/library/grand_product_library.test.cpp
@@ -7,7 +7,7 @@
 #include "barretenberg/srs/factories/file_crs_factory.hpp"
 #include <gtest/gtest.h>
 
-using namespace proof_system::honk;
+using namespace bb::honk;
 namespace grand_product_library_tests {
 
 template <class FF> class GrandProductTests : public testing::Test {
@@ -81,7 +81,7 @@ template <class FF> class GrandProductTests : public testing::Test {
         auto beta = FF::random_element();
         auto gamma = FF::random_element();
 
-        proof_system::RelationParameters<FF> params{
+        bb::RelationParameters<FF> params{
             .eta = 0,
             .beta = beta,
             .gamma = gamma,
@@ -91,8 +91,8 @@ template <class FF> class GrandProductTests : public testing::Test {
 
         typename Flavor::ProverPolynomials prover_polynomials;
         for (auto [prover_poly, key_poly] : zip_view(prover_polynomials.get_unshifted(), proving_key->get_all())) {
-            ASSERT(proof_system::flavor_get_label(prover_polynomials, prover_poly) ==
-                   proof_system::flavor_get_label(*proving_key, key_poly));
+            ASSERT(bb::flavor_get_label(prover_polynomials, prover_poly) ==
+                   bb::flavor_get_label(*proving_key, key_poly));
             prover_poly = key_poly.share();
         }
 
@@ -101,7 +101,7 @@ template <class FF> class GrandProductTests : public testing::Test {
         using LHS =
             typename std::tuple_element<PERMUTATION_RELATION_INDEX, typename Flavor::GrandProductRelations>::type;
         ASSERT(Flavor::NUM_WIRES == 4);
-        using RHS = typename proof_system::UltraPermutationRelation<FF>;
+        using RHS = typename bb::UltraPermutationRelation<FF>;
         static_assert(std::same_as<LHS, RHS>);
         grand_product_library::compute_grand_product<Flavor, RHS>(
             proving_key->circuit_size, prover_polynomials, params);
@@ -232,7 +232,7 @@ template <class FF> class GrandProductTests : public testing::Test {
         auto gamma = FF::random_element();
         auto eta = FF::random_element();
 
-        proof_system::RelationParameters<FF> params{
+        bb::RelationParameters<FF> params{
             .eta = eta,
             .beta = beta,
             .gamma = gamma,
@@ -242,14 +242,14 @@ template <class FF> class GrandProductTests : public testing::Test {
 
         typename Flavor::ProverPolynomials prover_polynomials;
         for (auto [prover_poly, key_poly] : zip_view(prover_polynomials.get_unshifted(), proving_key->get_all())) {
-            ASSERT(proof_system::flavor_get_label(prover_polynomials, prover_poly) ==
-                   proof_system::flavor_get_label(*proving_key, key_poly));
+            ASSERT(bb::flavor_get_label(prover_polynomials, prover_poly) ==
+                   bb::flavor_get_label(*proving_key, key_poly));
             prover_poly = key_poly.share();
         }
         for (auto [prover_poly, key_poly] :
              zip_view(prover_polynomials.get_shifted(), proving_key->get_to_be_shifted())) {
-            ASSERT(proof_system::flavor_get_label(prover_polynomials, prover_poly) ==
-                   proof_system::flavor_get_label(*proving_key, key_poly) + "_shift");
+            ASSERT(bb::flavor_get_label(prover_polynomials, prover_poly) ==
+                   bb::flavor_get_label(*proving_key, key_poly) + "_shift");
             prover_poly = key_poly.shifted();
         }
         // Test a few assignments
@@ -260,7 +260,7 @@ template <class FF> class GrandProductTests : public testing::Test {
         // Method 1: Compute z_lookup using the prover library method
         constexpr size_t LOOKUP_RELATION_INDEX = 1;
         using LHS = typename std::tuple_element<LOOKUP_RELATION_INDEX, typename Flavor::GrandProductRelations>::type;
-        using RHS = proof_system::LookupRelation<FF>;
+        using RHS = bb::LookupRelation<FF>;
         static_assert(std::same_as<LHS, RHS>);
         grand_product_library::compute_grand_product<Flavor, RHS>(
             proving_key->circuit_size, prover_polynomials, params);

--- a/barretenberg/cpp/src/barretenberg/proof_system/op_queue/ecc_op_queue.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/op_queue/ecc_op_queue.hpp
@@ -3,7 +3,7 @@
 #include "barretenberg/ecc/curves/bn254/bn254.hpp"
 #include "barretenberg/proof_system/circuit_builder/eccvm/eccvm_builder_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 enum EccOpCode { NULL_OP, ADD_ACCUM, MUL_ACCUM, EQUALITY };
 
@@ -26,7 +26,7 @@ class ECCOpQueue {
     Point accumulator = point_at_infinity;
 
   public:
-    using ECCVMOperation = proof_system_eccvm::VMOperation<Curve::Group>;
+    using ECCVMOperation = bb_eccvm::VMOperation<Curve::Group>;
     std::vector<ECCVMOperation> raw_ops;
     std::array<std::vector<Fr>, 4> ultra_ops; // ops encoded in the width-4 Ultra format
 
@@ -209,4 +209,4 @@ class ECCOpQueue {
     }
 };
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/op_queue/ecc_op_queue.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/op_queue/ecc_op_queue.test.cpp
@@ -1,7 +1,7 @@
 #include "barretenberg/proof_system/op_queue/ecc_op_queue.hpp"
 #include <gtest/gtest.h>
 
-namespace proof_system::test_flavor {
+namespace bb::test_flavor {
 TEST(ECCOpQueueTest, Basic)
 {
     ECCOpQueue op_queue;
@@ -37,4 +37,4 @@ TEST(ECCOpQueueTest, InternalAccumulatorCorrectness)
     EXPECT_TRUE(op_queue.get_accumulator().is_point_at_infinity());
 }
 
-} // namespace proof_system::test_flavor
+} // namespace bb::test_flavor

--- a/barretenberg/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store.cpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace proof_system {
+namespace bb {
 
 template <typename Fr> void PolynomialStore<Fr>::put(std::string const& key, Polynomial&& value)
 {
@@ -73,4 +73,4 @@ template <typename Fr> void PolynomialStore<Fr>::print()
 
 template class PolynomialStore<bb::fr>;
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace proof_system {
+namespace bb {
 
 template <typename Fr> class PolynomialStore {
   private:
@@ -44,4 +44,4 @@ template <typename Fr> class PolynomialStore {
     typename std::unordered_map<std::string, Polynomial>::const_iterator end() const { return polynomial_map.end(); }
 };
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store.test.cpp
@@ -4,25 +4,21 @@
 #include "barretenberg/polynomials/polynomial.hpp"
 #include "polynomial_store.hpp"
 
-namespace proof_system {
-
 using namespace bb;
-using Fr = bb::fr;
-using Polynomial = bb::Polynomial<Fr>;
 
 // Test basic put and get functionality
 TEST(PolynomialStore, PutThenGet)
 {
-    PolynomialStore<Fr> polynomial_store;
+    PolynomialStore<fr> polynomial_store;
 
     // Instantiate a polynomial with random coefficients
-    Polynomial poly(1024);
+    Polynomial<fr> poly(1024);
     for (auto& coeff : poly) {
-        coeff = Fr::random_element();
+        coeff = fr::random_element();
     }
 
     // Make a copy for comparison after original is moved into container
-    Polynomial poly_copy(poly);
+    Polynomial<fr> poly_copy(poly);
 
     // Move the poly into the container
     polynomial_store.put("id", std::move(poly));
@@ -34,9 +30,9 @@ TEST(PolynomialStore, PutThenGet)
 // Ensure that attempt to access non-existent key throws out_of_range exception
 TEST(PolynomialStore, NonexistentKey)
 {
-    PolynomialStore<Fr> polynomial_store;
+    PolynomialStore<fr> polynomial_store;
 
-    polynomial_store.put("id_1", Polynomial(100));
+    polynomial_store.put("id_1", Polynomial<fr>(100));
 
     polynomial_store.get("id_1"); // no problem!
 
@@ -46,14 +42,14 @@ TEST(PolynomialStore, NonexistentKey)
 // Ensure correct calculation of volume in bytes
 TEST(PolynomialStore, Volume)
 {
-    PolynomialStore<Fr> polynomial_store;
+    PolynomialStore<fr> polynomial_store;
     size_t size1 = 100;
     size_t size2 = 10;
     size_t size3 = 5000;
 
-    Polynomial poly1(size1);
-    Polynomial poly2(size2);
-    Polynomial poly3(size3);
+    Polynomial<fr> poly1(size1);
+    Polynomial<fr> poly2(size2);
+    Polynomial<fr> poly3(size3);
 
     polynomial_store.put("id_1", std::move(poly1));
     polynomial_store.put("id_2", std::move(poly2));
@@ -61,7 +57,7 @@ TEST(PolynomialStore, Volume)
 
     // polynomial_store.print();
 
-    size_t bytes_expected = sizeof(Fr) * (size1 + size2 + size3);
+    size_t bytes_expected = sizeof(fr) * (size1 + size2 + size3);
 
     EXPECT_EQ(polynomial_store.get_size_in_bytes(), bytes_expected);
 }
@@ -69,25 +65,23 @@ TEST(PolynomialStore, Volume)
 // Ensure that the remove method erases entry and reduces memory
 TEST(PolynomialStore, Remove)
 {
-    PolynomialStore<Fr> polynomial_store;
+    PolynomialStore<fr> polynomial_store;
     size_t size1 = 100;
     size_t size2 = 500;
-    Polynomial poly1(size1);
-    Polynomial poly2(size2);
+    Polynomial<fr> poly1(size1);
+    Polynomial<fr> poly2(size2);
 
     polynomial_store.put("id_1", std::move(poly1));
     polynomial_store.put("id_2", std::move(poly2));
 
-    size_t bytes_expected = sizeof(Fr) * (size1 + size2);
+    size_t bytes_expected = sizeof(fr) * (size1 + size2);
 
     EXPECT_EQ(polynomial_store.get_size_in_bytes(), bytes_expected);
 
     polynomial_store.remove("id_1");
 
-    bytes_expected -= sizeof(Fr) * size1;
+    bytes_expected -= sizeof(fr) * size1;
 
     EXPECT_THROW(polynomial_store.get("id_1"), std::out_of_range);
     EXPECT_EQ(polynomial_store.get_size_in_bytes(), bytes_expected);
 }
-
-} // namespace proof_system

--- a/barretenberg/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store_cache.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store_cache.cpp
@@ -1,6 +1,6 @@
 #include "./polynomial_store_cache.hpp"
 
-namespace proof_system {
+namespace bb {
 
 PolynomialStoreCache::PolynomialStoreCache()
     : max_cache_size_(40)
@@ -52,4 +52,4 @@ void PolynomialStoreCache::purge_until_free()
     }
 }
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store_cache.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store_cache.hpp
@@ -4,7 +4,7 @@
 #include <map>
 #include <string>
 
-namespace proof_system {
+namespace bb {
 
 /**
  * A cache that wraps an underlying external store. It favours holding the largest polynomials in it's cache up
@@ -35,4 +35,4 @@ class PolynomialStoreCache {
     void purge_until_free();
 };
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store_wasm.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store_wasm.cpp
@@ -2,7 +2,7 @@
 #include "barretenberg/env/data_store.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename Fr> void PolynomialStoreWasm<Fr>::put(std::string const& key, Polynomial&& value)
 {
@@ -21,4 +21,4 @@ template <typename Fr> bb::Polynomial<Fr> PolynomialStoreWasm<Fr>::get(std::stri
 
 template class PolynomialStoreWasm<bb::fr>;
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store_wasm.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/polynomial_store/polynomial_store_wasm.hpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace proof_system {
+namespace bb {
 
 template <typename Fr> class PolynomialStoreWasm {
   private:
@@ -16,4 +16,4 @@ template <typename Fr> class PolynomialStoreWasm {
     Polynomial get(std::string const& key);
 };
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/types/circuit_type.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/types/circuit_type.hpp
@@ -2,10 +2,10 @@
 #include <concepts>
 #include <cstdint>
 
-namespace proof_system {
+namespace bb {
 // TODO(#731): Changing the explicit value of these enum elements breaks brittle and outdated tests in circuits/cpp.
 enum class CircuitType : uint32_t { STANDARD = 0, ULTRA = 2, UNDEFINED = 3 };
 
 template <typename T, typename... U>
 concept IsAnyOf = (std::same_as<T, U> || ...);
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/proof_system/types/merkle_hash_type.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/types/merkle_hash_type.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace proof_system::merkle {
+namespace bb::merkle {
 // TODO(Cody) Get rid of this?
 enum HashType { FIXED_BASE_PEDERSEN, LOOKUP_PEDERSEN };
-} // namespace proof_system::merkle
+} // namespace bb::merkle

--- a/barretenberg/cpp/src/barretenberg/proof_system/types/pedersen_commitment_type.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/types/pedersen_commitment_type.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace proof_system::pedersen {
+namespace bb::pedersen {
 // TODO(Cody) Get rid of this?
 enum CommitmentType { FIXED_BASE_PEDERSEN, LOOKUP_PEDERSEN };
-} // namespace proof_system::pedersen
+} // namespace bb::pedersen

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/combiner.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/combiner.test.cpp
@@ -6,12 +6,12 @@
 #include "barretenberg/sumcheck/instance/instances.hpp"
 #include <gtest/gtest.h>
 
-using namespace proof_system::honk;
+using namespace bb::honk;
 namespace bb::test_protogalaxy_prover {
-using Flavor = proof_system::honk::flavor::Ultra;
+using Flavor = bb::honk::flavor::Ultra;
 using Polynomial = typename Flavor::Polynomial;
 using FF = typename Flavor::FF;
-using RelationParameters = proof_system::RelationParameters<FF>;
+using RelationParameters = bb::RelationParameters<FF>;
 using PowPolynomial = bb::PowPolynomial<FF>;
 
 // TODO(https://github.com/AztecProtocol/barretenberg/issues/780): Improve combiner tests to check more than the
@@ -43,7 +43,7 @@ TEST(Protogalaxy, CombinerOn2Instances)
 
             for (size_t idx = 0; idx < NUM_INSTANCES; idx++) {
                 auto instance = std::make_shared<ProverInstance>();
-                auto prover_polynomials = proof_system::honk::get_sequential_prover_polynomials<Flavor>(
+                auto prover_polynomials = bb::honk::get_sequential_prover_polynomials<Flavor>(
                     /*log_circuit_size=*/1, idx * 128);
                 restrict_to_standard_arithmetic_relation(prover_polynomials);
                 instance->prover_polynomials = std::move(prover_polynomials);
@@ -75,7 +75,7 @@ TEST(Protogalaxy, CombinerOn2Instances)
 
             for (size_t idx = 0; idx < NUM_INSTANCES; idx++) {
                 auto instance = std::make_shared<ProverInstance>();
-                auto prover_polynomials = proof_system::honk::get_zero_prover_polynomials<Flavor>(
+                auto prover_polynomials = bb::honk::get_zero_prover_polynomials<Flavor>(
                     /*log_circuit_size=*/1);
                 restrict_to_standard_arithmetic_relation(prover_polynomials);
                 instance->prover_polynomials = std::move(prover_polynomials);
@@ -166,7 +166,7 @@ TEST(Protogalaxy, CombinerOn4Instances)
 
         for (size_t idx = 0; idx < NUM_INSTANCES; idx++) {
             auto instance = std::make_shared<ProverInstance>();
-            auto prover_polynomials = proof_system::honk::get_zero_prover_polynomials<Flavor>(
+            auto prover_polynomials = bb::honk::get_zero_prover_polynomials<Flavor>(
                 /*log_circuit_size=*/1);
             instance->prover_polynomials = std::move(prover_polynomials);
             instance->instance_size = 2;

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/decider_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/decider_prover.cpp
@@ -1,7 +1,7 @@
 #include "decider_prover.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 /**
  * Create DeciderProver_ from an accumulator.
@@ -118,4 +118,4 @@ template <UltraFlavor Flavor> plonk::proof& DeciderProver_<Flavor>::construct_pr
 template class DeciderProver_<honk::flavor::Ultra>;
 template class DeciderProver_<honk::flavor::GoblinUltra>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/decider_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/decider_prover.hpp
@@ -8,7 +8,7 @@
 #include "barretenberg/sumcheck/sumcheck_output.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 template <UltraFlavor Flavor> class DeciderProver_ {
     using FF = typename Flavor::FF;
@@ -39,7 +39,7 @@ template <UltraFlavor Flavor> class DeciderProver_ {
 
     std::shared_ptr<Transcript> transcript;
 
-    proof_system::RelationParameters<FF> relation_parameters;
+    bb::RelationParameters<FF> relation_parameters;
 
     CommitmentLabels commitment_labels;
 
@@ -57,4 +57,4 @@ template <UltraFlavor Flavor> class DeciderProver_ {
 
 using DeciderProver = DeciderProver_<honk::flavor::Ultra>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/decider_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/decider_verifier.cpp
@@ -5,9 +5,9 @@
 #include "barretenberg/transcript/transcript.hpp"
 
 using namespace bb;
-using namespace proof_system::honk::sumcheck;
+using namespace bb::honk::sumcheck;
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 template <typename Flavor>
 DeciderVerifier_<Flavor>::DeciderVerifier_(const std::shared_ptr<Transcript>& transcript,
@@ -110,4 +110,4 @@ template <typename Flavor> bool DeciderVerifier_<Flavor>::verify_proof(const plo
 template class DeciderVerifier_<honk::flavor::Ultra>;
 template class DeciderVerifier_<honk::flavor::GoblinUltra>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/decider_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/decider_verifier.hpp
@@ -5,7 +5,7 @@
 #include "barretenberg/srs/global_crs.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 template <typename Flavor> class DeciderVerifier_ {
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
@@ -28,4 +28,4 @@ template <typename Flavor> class DeciderVerifier_ {
 
 using DeciderVerifier = DeciderVerifier_<honk::flavor::Ultra>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/folding_result.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/folding_result.hpp
@@ -2,7 +2,7 @@
 #include "barretenberg/flavor/flavor.hpp"
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/sumcheck/instance/prover_instance.hpp"
-namespace proof_system::honk {
+namespace bb::honk {
 /**
  * @brief The result of running the Protogalaxy prover containing a new accumulator (relaxed instance) as well as the
  * proof data to instantiate the verifier transcript.
@@ -15,4 +15,4 @@ template <class Flavor> struct FoldingResult {
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/656): turn folding data into a struct
     std::vector<uint8_t> folding_data;
 };
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.cpp
@@ -1,6 +1,6 @@
 #include "protogalaxy_prover.hpp"
 #include "barretenberg/flavor/flavor.hpp"
-namespace proof_system::honk {
+namespace bb::honk {
 template <class ProverInstances>
 void ProtoGalaxyProver_<ProverInstances>::finalise_and_send_instance(std::shared_ptr<Instance> instance,
                                                                      const std::string& domain_separator)
@@ -233,7 +233,7 @@ std::shared_ptr<typename ProverInstances::Instance> ProtoGalaxyProver_<ProverIns
     // Evaluate each relation parameter univariate at challenge to obtain the folded relation parameters and send to
     // the verifier
     auto& combined_relation_parameters = instances.relation_parameters;
-    auto folded_relation_parameters = proof_system::RelationParameters<FF>{
+    auto folded_relation_parameters = bb::RelationParameters<FF>{
         combined_relation_parameters.eta.evaluate(challenge),
         combined_relation_parameters.beta.evaluate(challenge),
         combined_relation_parameters.gamma.evaluate(challenge),
@@ -313,4 +313,4 @@ FoldingResult<typename ProverInstances::Flavor> ProtoGalaxyProver_<ProverInstanc
 
 template class ProtoGalaxyProver_<ProverInstances_<honk::flavor::Ultra, 2>>;
 template class ProtoGalaxyProver_<ProverInstances_<honk::flavor::GoblinUltra, 2>>;
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
@@ -11,7 +11,7 @@
 #include "barretenberg/relations/utils.hpp"
 #include "barretenberg/sumcheck/instance/instances.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 template <class ProverInstances_> class ProtoGalaxyProver_ {
   public:
     using ProverInstances = ProverInstances_;
@@ -434,4 +434,4 @@ template <class ProverInstances_> class ProtoGalaxyProver_ {
         const FF& compressed_perturbator);
 };
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -1,6 +1,6 @@
 #include "protogalaxy_verifier.hpp"
 #include "barretenberg/proof_system/library/grand_product_delta.hpp"
-namespace proof_system::honk {
+namespace bb::honk {
 
 template <class VerifierInstances>
 void ProtoGalaxyVerifier_<VerifierInstances>::receive_accumulator(const std::shared_ptr<Instance>& inst,
@@ -227,7 +227,7 @@ bool ProtoGalaxyVerifier_<VerifierInstances>::verify_folding_proof(std::vector<u
         auto next_alpha = transcript->template receive_from_prover<FF>("next_alpha_" + std::to_string(alpha_idx));
         verified = verified & (alpha == next_alpha);
     }
-    auto expected_parameters = proof_system::RelationParameters<FF>{};
+    auto expected_parameters = bb::RelationParameters<FF>{};
     for (size_t inst_idx = 0; inst_idx < VerifierInstances::NUM; inst_idx++) {
         auto instance = instances[inst_idx];
         expected_parameters.eta += instance->relation_parameters.eta * lagranges[inst_idx];
@@ -275,4 +275,4 @@ bool ProtoGalaxyVerifier_<VerifierInstances>::verify_folding_proof(std::vector<u
 
 template class ProtoGalaxyVerifier_<VerifierInstances_<honk::flavor::Ultra, 2>>;
 template class ProtoGalaxyVerifier_<VerifierInstances_<honk::flavor::GoblinUltra, 2>>;
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.hpp
@@ -6,7 +6,7 @@
 #include "barretenberg/sumcheck/instance/instances.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 template <class VerifierInstances> class ProtoGalaxyVerifier_ {
   public:
     using Flavor = typename VerifierInstances::Flavor;
@@ -86,4 +86,4 @@ template <class VerifierInstances> class ProtoGalaxyVerifier_ {
     bool verify_folding_proof(std::vector<uint8_t>);
 };
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/relations/auxiliary_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/auxiliary_relation.hpp
@@ -2,7 +2,7 @@
 #include "barretenberg/numeric/uint256/uint256.hpp"
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF_> class AuxiliaryRelationImpl {
   public:
@@ -337,4 +337,4 @@ template <typename FF_> class AuxiliaryRelationImpl {
 };
 
 template <typename FF> using AuxiliaryRelation = Relation<AuxiliaryRelationImpl<FF>>;
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation.hpp
@@ -8,7 +8,7 @@
 #include "barretenberg/polynomials/univariate.hpp"
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF_> class DatabusLookupRelationImpl {
   public:
@@ -183,4 +183,4 @@ template <typename FF_> class DatabusLookupRelationImpl {
 
 template <typename FF> using DatabusLookupRelation = Relation<DatabusLookupRelationImpl<FF>>;
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_op_queue_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_op_queue_relation.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF_> class EccOpQueueRelationImpl {
   public:
@@ -107,4 +107,4 @@ template <typename FF_> class EccOpQueueRelationImpl {
 
 template <typename FF> using EccOpQueueRelation = Relation<EccOpQueueRelationImpl<FF>>;
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_lookup_relation.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_lookup_relation.cpp
@@ -3,7 +3,7 @@
 #include "barretenberg/honk/proof_system/logderivative_library.hpp"
 #include "ecc_msm_relation.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 /**
  * @brief Expression for ECCVM lookup tables.
@@ -32,4 +32,4 @@ void ECCVMLookupRelationImpl<FF>::accumulate(ContainerOverSubrelations& accumula
 template class ECCVMLookupRelationImpl<grumpkin::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(ECCVMLookupRelationImpl, flavor::ECCVM);
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_lookup_relation.hpp
@@ -7,7 +7,7 @@
 #include "barretenberg/polynomials/univariate.hpp"
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 template <typename FF_> class ECCVMLookupRelationImpl {
   public:
@@ -247,4 +247,4 @@ template <typename FF_> class ECCVMLookupRelationImpl {
 
 template <typename FF> using ECCVMLookupRelation = Relation<ECCVMLookupRelationImpl<FF>>;
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_msm_relation.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_msm_relation.cpp
@@ -2,7 +2,7 @@
 #include "barretenberg/flavor/ecc_vm.hpp"
 #include "barretenberg/flavor/relation_definitions.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 /**
  * @brief MSM relations that evaluate the Strauss multiscalar multiplication algorithm.
@@ -394,4 +394,4 @@ void ECCVMMSMRelationImpl<FF>::accumulate(ContainerOverSubrelations& accumulator
 template class ECCVMMSMRelationImpl<grumpkin::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(ECCVMMSMRelationImpl, flavor::ECCVM);
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_msm_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_msm_relation.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 /**
  * @brief MSM relations that evaluate the Strauss multiscalar multiplication algorithm.
@@ -51,4 +51,4 @@ template <typename FF_> class ECCVMMSMRelationImpl {
 
 template <typename FF> using ECCVMMSMRelation = Relation<ECCVMMSMRelationImpl<FF>>;
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_point_table_relation.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_point_table_relation.cpp
@@ -2,7 +2,7 @@
 #include "barretenberg/flavor/ecc_vm.hpp"
 #include "barretenberg/flavor/relation_definitions.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 /**
  * @brief ECCVMPointTableRelationImpl
@@ -175,4 +175,4 @@ void ECCVMPointTableRelationImpl<FF>::accumulate(ContainerOverSubrelations& accu
 template class ECCVMPointTableRelationImpl<grumpkin::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(ECCVMPointTableRelationImpl, flavor::ECCVM);
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_point_table_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_point_table_relation.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 /**
  * @brief ECCVMPointTableRelationImpl
@@ -30,4 +30,4 @@ template <typename FF_> class ECCVMPointTableRelationImpl {
 
 template <typename FF> using ECCVMPointTableRelation = Relation<ECCVMPointTableRelationImpl<FF>>;
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_set_relation.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_set_relation.cpp
@@ -2,7 +2,7 @@
 #include "barretenberg/flavor/relation_definitions.hpp"
 #include "ecc_msm_relation.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 /**
  * @brief Performs list-equivalence checks for the ECCVM
@@ -397,4 +397,4 @@ template class ECCVMSetRelationImpl<grumpkin::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(ECCVMSetRelationImpl, flavor::ECCVM);
 DEFINE_SUMCHECK_PERMUTATION_CLASS(ECCVMSetRelationImpl, flavor::ECCVM);
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_set_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_set_relation.hpp
@@ -7,7 +7,7 @@
 #include "barretenberg/polynomials/univariate.hpp"
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 template <typename FF_> class ECCVMSetRelationImpl {
   public:
@@ -46,4 +46,4 @@ template <typename FF_> class ECCVMSetRelationImpl {
 
 template <typename FF> using ECCVMSetRelation = Relation<ECCVMSetRelationImpl<FF>>;
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation.cpp
@@ -5,7 +5,7 @@
 #include "barretenberg/flavor/ecc_vm.hpp"
 #include "barretenberg/flavor/relation_definitions.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 /**
  * @brief ECCVMTranscriptRelationImpl evaluates the correctness of the ECCVM transcript columns
@@ -258,4 +258,4 @@ void ECCVMTranscriptRelationImpl<FF>::accumulate(ContainerOverSubrelations& accu
 template class ECCVMTranscriptRelationImpl<grumpkin::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(ECCVMTranscriptRelationImpl, flavor::ECCVM);
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation.hpp
@@ -4,7 +4,7 @@
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 /**
  * @brief ECCVMTranscriptRelationImpl evaluates the correctness of the ECCVM transcript columns
@@ -55,4 +55,4 @@ template <typename FF_> class ECCVMTranscriptRelationImpl {
 
 template <typename FF> using ECCVMTranscriptRelation = Relation<ECCVMTranscriptRelationImpl<FF>>;
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_wnaf_relation.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_wnaf_relation.cpp
@@ -2,7 +2,7 @@
 #include "barretenberg/flavor/ecc_vm.hpp"
 #include "barretenberg/flavor/relation_definitions.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 /**
  * @brief ECCVMWnafRelationImpl evaluates relations that convert scalar multipliers into 4-bit WNAF slices
@@ -219,4 +219,4 @@ void ECCVMWnafRelationImpl<FF>::accumulate(ContainerOverSubrelations& accumulato
 template class ECCVMWnafRelationImpl<grumpkin::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(ECCVMWnafRelationImpl, flavor::ECCVM);
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_wnaf_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_wnaf_relation.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 /**
  * @brief ECCVMWnafRelationImpl evaluates relations that convert scalar multipliers into 4-bit WNAF slices
  * @details Each WNAF slice is a 4-bit slice representing one of 16 integers { -15, -13, ..., 15 }
@@ -48,4 +48,4 @@ template <typename FF_> class ECCVMWnafRelationImpl {
 
 template <typename FF> using ECCVMWnafRelation = Relation<ECCVMWnafRelationImpl<FF>>;
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/elliptic_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/elliptic_relation.hpp
@@ -3,7 +3,7 @@
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF_> class EllipticRelationImpl {
   public:
@@ -96,4 +96,4 @@ template <typename FF_> class EllipticRelationImpl {
 };
 
 template <typename FF> using EllipticRelation = Relation<EllipticRelationImpl<FF>>;
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/gen_perm_sort_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/gen_perm_sort_relation.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF_> class GenPermSortRelationImpl {
   public:
@@ -94,4 +94,4 @@ template <typename FF_> class GenPermSortRelationImpl {
 
 template <typename FF> using GenPermSortRelation = Relation<GenPermSortRelationImpl<FF>>;
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/generated/AvmMini/avm_mini.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/AvmMini/avm_mini.hpp
@@ -4,7 +4,7 @@
 #include "../../relation_types.hpp"
 #include "./declare_views.hpp"
 
-namespace proof_system::AvmMini_vm {
+namespace bb::AvmMini_vm {
 
 template <typename FF> struct Avm_miniRow {
     FF avmMini_rwa{};
@@ -423,4 +423,4 @@ template <typename FF_> class avm_miniImpl {
 
 template <typename FF> using avm_mini = Relation<avm_miniImpl<FF>>;
 
-} // namespace proof_system::AvmMini_vm
+} // namespace bb::AvmMini_vm

--- a/barretenberg/cpp/src/barretenberg/relations/generated/AvmMini/mem_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/AvmMini/mem_trace.hpp
@@ -4,7 +4,7 @@
 #include "../../relation_types.hpp"
 #include "./declare_views.hpp"
 
-namespace proof_system::AvmMini_vm {
+namespace bb::AvmMini_vm {
 
 template <typename FF> struct Mem_traceRow {
     FF memTrace_m_val{};
@@ -149,4 +149,4 @@ template <typename FF_> class mem_traceImpl {
 
 template <typename FF> using mem_trace = Relation<mem_traceImpl<FF>>;
 
-} // namespace proof_system::AvmMini_vm
+} // namespace bb::AvmMini_vm

--- a/barretenberg/cpp/src/barretenberg/relations/generated/Toy/lookup_xor.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/Toy/lookup_xor.hpp
@@ -7,7 +7,7 @@
 #include <cstddef>
 #include <tuple>
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 /**
  * @brief This class contains an example of how to set LookupSettings classes used by the
@@ -171,4 +171,4 @@ class lookup_xor_lookup_settings {
 template <typename FF_> using lookup_xor_relation = GenericLookupRelation<lookup_xor_lookup_settings, FF_>;
 template <typename FF_> using lookup_xor = GenericLookup<lookup_xor_lookup_settings, FF_>;
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/generated/Toy/toy_avm.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/Toy/toy_avm.hpp
@@ -4,7 +4,7 @@
 #include "../../relation_types.hpp"
 #include "./declare_views.hpp"
 
-namespace proof_system::Toy_vm {
+namespace bb::Toy_vm {
 
 template <typename FF> struct Toy_avmRow {
     FF toy_q_xor_table{};
@@ -64,4 +64,4 @@ template <typename FF_> class toy_avmImpl {
 
 template <typename FF> using toy_avm = Relation<toy_avmImpl<FF>>;
 
-} // namespace proof_system::Toy_vm
+} // namespace bb::Toy_vm

--- a/barretenberg/cpp/src/barretenberg/relations/generated/Toy/two_column_perm.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/Toy/two_column_perm.hpp
@@ -7,7 +7,7 @@
 #include <cstddef>
 #include <tuple>
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 class two_column_perm_permutation_settings {
   public:
@@ -91,4 +91,4 @@ template <typename FF_>
 using two_column_perm_relation = GenericPermutationRelation<two_column_perm_permutation_settings, FF_>;
 template <typename FF_> using two_column_perm = GenericPermutation<two_column_perm_permutation_settings, FF_>;
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/generic_lookup/generic_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generic_lookup/generic_lookup_relation.hpp
@@ -24,7 +24,7 @@
 #include "barretenberg/polynomials/univariate.hpp"
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 /**
  * @brief Specifies positions of elements in the tuple of entities received from methods in the Settings class
  *
@@ -479,4 +479,4 @@ using GenericLookupRelation = Relation<GenericLookupRelationImpl<Settings, FF>>;
 
 template <typename Settings, typename FF> using GenericLookup = GenericLookupRelationImpl<Settings, FF>;
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/generic_permutation/generic_permutation_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generic_permutation/generic_permutation_relation.hpp
@@ -15,7 +15,7 @@
 #include "barretenberg/polynomials/univariate.hpp"
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 /**
  * @brief Specifies positions of elements in the tuple of entities received from methods in the Settings class
  *
@@ -213,4 +213,4 @@ using GenericPermutationRelation = Relation<GenericPermutationRelationImpl<Setti
 
 template <typename Settings, typename FF> using GenericPermutation = GenericPermutationRelationImpl<Settings, FF>;
 
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/relations/lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/lookup_relation.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 /**
  * @brief LookupRelationImpl defines the algebra for the lookup polynomial:
@@ -209,4 +209,4 @@ template <typename FF_> class LookupRelationImpl {
 
 template <typename FF> using LookupRelation = Relation<LookupRelationImpl<FF>>;
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/nested_containers.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/nested_containers.hpp
@@ -2,7 +2,7 @@
 #include "barretenberg/polynomials/univariate.hpp"
 #include <tuple>
 
-namespace proof_system {
+namespace bb {
 
 /**
  * @brief Generic templates for constructing a container of containers of varying length, where the various lengths are
@@ -40,4 +40,4 @@ using TupleOfValues = typename TupleOfContainersOverArray<ExtractValueType, FF, 
 
 template <typename FF, auto LENGTHS> using ArrayOfValues = HomogeneousTupleToArray<TupleOfValues<FF, LENGTHS>>;
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/nested_containers.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/nested_containers.test.cpp
@@ -3,9 +3,9 @@
 #include "barretenberg/polynomials/univariate.hpp"
 #include <gtest/gtest.h>
 
-using namespace proof_system;
+using namespace bb;
 
-namespace proof_system::nested_contianers_tests {
+namespace bb::nested_contianers_tests {
 
 using FF = bb::fr;
 
@@ -23,4 +23,4 @@ TEST_F(NestedContainers, Univariate)
     EXPECT_EQ(std::get<2>(tuple), result2);
 }
 
-} // namespace proof_system::nested_contianers_tests
+} // namespace bb::nested_contianers_tests

--- a/barretenberg/cpp/src/barretenberg/relations/permutation_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/permutation_relation.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF_> class UltraPermutationRelationImpl {
   public:
@@ -118,4 +118,4 @@ template <typename FF_> class UltraPermutationRelationImpl {
 
 template <typename FF> using UltraPermutationRelation = Relation<UltraPermutationRelationImpl<FF>>;
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/poseidon2_external_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/poseidon2_external_relation.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "barretenberg/relations/relation_types.hpp"
-namespace proof_system {
+namespace bb {
 
 template <typename FF_> class Poseidon2ExternalRelationImpl {
   public:
@@ -114,4 +114,4 @@ template <typename FF_> class Poseidon2ExternalRelationImpl {
 };
 
 template <typename FF> using Poseidon2ExternalRelation = Relation<Poseidon2ExternalRelationImpl<FF>>;
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/poseidon2_internal_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/poseidon2_internal_relation.hpp
@@ -2,7 +2,7 @@
 #include "barretenberg/crypto/poseidon2/poseidon2_params.hpp"
 #include "relation_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF_> class Poseidon2InternalRelationImpl {
   public:
@@ -91,7 +91,7 @@ template <typename FF_> class Poseidon2InternalRelationImpl {
         tmp *= scaling_factor;
         std::get<3>(evals) += tmp;
     };
-}; // namespace proof_system
+}; // namespace bb
 
 template <typename FF> using Poseidon2InternalRelation = Relation<Poseidon2InternalRelationImpl<FF>>;
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/relation_manual.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/relation_manual.test.cpp
@@ -4,7 +4,7 @@
 #include "barretenberg/relations/relation_parameters.hpp"
 #include <gtest/gtest.h>
 
-namespace proof_system::relation_manual_tests {
+namespace bb::relation_manual_tests {
 
 using FF = bb::fr;
 
@@ -165,4 +165,4 @@ TEST_F(RelationManual, Poseidon2InternalRelationRandom)
     EXPECT_EQ(acc[2], 0);
     EXPECT_EQ(acc[3], 0);
 }
-}; // namespace proof_system::relation_manual_tests
+}; // namespace bb::relation_manual_tests

--- a/barretenberg/cpp/src/barretenberg/relations/relation_parameters.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/relation_parameters.hpp
@@ -3,7 +3,7 @@
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include <array>
 
-namespace proof_system {
+namespace bb {
 
 /**
  * @brief Container for parameters used by the grand product (permutation, lookup) Honk relations
@@ -75,4 +75,4 @@ template <typename T> struct RelationParameters {
         return result;
     }
 };
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/relation_types.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/relation_types.hpp
@@ -6,7 +6,7 @@
 template <typename T>
 concept IsField = std::same_as<T, bb::fr> /* || std::same_as<T, grumpkin::fr> */;
 
-namespace proof_system {
+namespace bb {
 
 /**
  * @brief A type to optionally extract a view of a relation parameter in a relation.
@@ -143,4 +143,4 @@ template <typename RelationImpl> class Relation : public RelationImpl {
     using UnivariateAccumulator0 = std::tuple_element_t<0, SumcheckTupleOfUnivariatesOverSubrelations>;
     using ValueAccumulator0 = std::tuple_element_t<0, SumcheckArrayOfValuesOverSubrelations>;
 };
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/goblin_translator_relation_consistency.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/goblin_translator_relation_consistency.test.cpp
@@ -14,9 +14,9 @@
 #include "barretenberg/flavor/goblin_translator.hpp"
 #include <gtest/gtest.h>
 
-using namespace proof_system;
+using namespace bb;
 
-namespace proof_system::ultra_relation_consistency_tests {
+namespace bb::ultra_relation_consistency_tests {
 
 using Flavor = honk::flavor::GoblinTranslator;
 using FF = typename Flavor::FF;
@@ -948,4 +948,4 @@ TEST_F(GoblinTranslatorRelationConsistency, NonNativeFieldRelation)
     run_test(/*random_inputs=*/true);
 };
 
-} // namespace proof_system::ultra_relation_consistency_tests
+} // namespace bb::ultra_relation_consistency_tests

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_decomposition_relation.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_decomposition_relation.cpp
@@ -1,7 +1,7 @@
 #include "barretenberg/relations/translator_vm/translator_decomposition_relation.hpp"
 #include "barretenberg/flavor/goblin_translator.hpp"
 
-namespace proof_system {
+namespace bb {
 
 /**
  * @brief Expression for decomposition of various values into smaller limbs or microlimbs.
@@ -619,4 +619,4 @@ void GoblinTranslatorDecompositionRelationImpl<FF>::accumulate(ContainerOverSubr
 template class GoblinTranslatorDecompositionRelationImpl<bb::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(GoblinTranslatorDecompositionRelationImpl, honk::flavor::GoblinTranslator);
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_decomposition_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_decomposition_relation.hpp
@@ -2,7 +2,7 @@
 #include "barretenberg/numeric/uint256/uint256.hpp"
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF_> class GoblinTranslatorDecompositionRelationImpl {
   public:
@@ -90,4 +90,4 @@ template <typename FF_> class GoblinTranslatorDecompositionRelationImpl {
 template <typename FF>
 using GoblinTranslatorDecompositionRelation = Relation<GoblinTranslatorDecompositionRelationImpl<FF>>;
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.cpp
@@ -1,7 +1,7 @@
 #include "barretenberg/relations/translator_vm/translator_extra_relations.hpp"
 #include "barretenberg/flavor/goblin_translator.hpp"
 
-namespace proof_system {
+namespace bb {
 
 /**
  * @brief Expression for enforcing the value of the Opcode to be {0,1,2,3,4,8}
@@ -152,4 +152,4 @@ template class GoblinTranslatorAccumulatorTransferRelationImpl<bb::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(GoblinTranslatorOpcodeConstraintRelationImpl, honk::flavor::GoblinTranslator);
 DEFINE_SUMCHECK_RELATION_CLASS(GoblinTranslatorAccumulatorTransferRelationImpl, honk::flavor::GoblinTranslator);
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF_> class GoblinTranslatorOpcodeConstraintRelationImpl {
   public:
@@ -79,4 +79,4 @@ using GoblinTranslatorOpcodeConstraintRelation = Relation<GoblinTranslatorOpcode
 template <typename FF>
 using GoblinTranslatorAccumulatorTransferRelation = Relation<GoblinTranslatorAccumulatorTransferRelationImpl<FF>>;
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_gen_perm_sort_relation.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_gen_perm_sort_relation.cpp
@@ -1,7 +1,7 @@
 #include "barretenberg/relations/translator_vm/translator_gen_perm_sort_relation.hpp"
 #include "barretenberg/flavor/goblin_translator.hpp"
 
-namespace proof_system {
+namespace bb {
 
 /**
  * @brief Expression for the generalized permutation sort relation
@@ -129,4 +129,4 @@ void GoblinTranslatorGenPermSortRelationImpl<FF>::accumulate(ContainerOverSubrel
 template class GoblinTranslatorGenPermSortRelationImpl<bb::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(GoblinTranslatorGenPermSortRelationImpl, honk::flavor::GoblinTranslator);
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_gen_perm_sort_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_gen_perm_sort_relation.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF_> class GoblinTranslatorGenPermSortRelationImpl {
   public:
@@ -46,4 +46,4 @@ template <typename FF_> class GoblinTranslatorGenPermSortRelationImpl {
 template <typename FF>
 using GoblinTranslatorGenPermSortRelation = Relation<GoblinTranslatorGenPermSortRelationImpl<FF>>;
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_non_native_field_relation.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_non_native_field_relation.cpp
@@ -1,7 +1,7 @@
 #include "barretenberg/relations/translator_vm/translator_non_native_field_relation.hpp"
 #include "barretenberg/flavor/goblin_translator.hpp"
 
-namespace proof_system {
+namespace bb {
 /**
  * @brief Expression for the computation of Goblin Translator accumulator in integers through 68-bit limbs and
  * native field (prime) limb
@@ -280,4 +280,4 @@ void GoblinTranslatorNonNativeFieldRelationImpl<FF>::accumulate(ContainerOverSub
 template class GoblinTranslatorNonNativeFieldRelationImpl<bb::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(GoblinTranslatorNonNativeFieldRelationImpl, honk::flavor::GoblinTranslator);
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_non_native_field_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_non_native_field_relation.hpp
@@ -2,7 +2,7 @@
 #include "barretenberg/ecc/curves/bn254/bn254.hpp"
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF_> class GoblinTranslatorNonNativeFieldRelationImpl {
   public:
@@ -87,4 +87,4 @@ template <typename FF_> class GoblinTranslatorNonNativeFieldRelationImpl {
 template <typename FF>
 using GoblinTranslatorNonNativeFieldRelation = Relation<GoblinTranslatorNonNativeFieldRelationImpl<FF>>;
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_permutation_relation.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_permutation_relation.cpp
@@ -1,7 +1,7 @@
 #include "barretenberg/relations/translator_vm/translator_permutation_relation.hpp"
 #include "barretenberg/flavor/goblin_translator.hpp"
 
-namespace proof_system {
+namespace bb {
 
 /**
  * @brief Compute contribution of the goblin translator permutation relation for a given edge (internal function)
@@ -62,4 +62,4 @@ void GoblinTranslatorPermutationRelationImpl<FF>::accumulate(ContainerOverSubrel
 template class GoblinTranslatorPermutationRelationImpl<bb::fr>;
 DEFINE_SUMCHECK_RELATION_CLASS(GoblinTranslatorPermutationRelationImpl, honk::flavor::GoblinTranslator);
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_permutation_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_permutation_relation.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF_> class GoblinTranslatorPermutationRelationImpl {
   public:
@@ -83,4 +83,4 @@ template <typename FF_> class GoblinTranslatorPermutationRelationImpl {
 template <typename FF>
 using GoblinTranslatorPermutationRelation = Relation<GoblinTranslatorPermutationRelationImpl<FF>>;
 
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/ultra_arithmetic_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ultra_arithmetic_relation.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "barretenberg/relations/relation_types.hpp"
 
-namespace proof_system {
+namespace bb {
 
 template <typename FF_> class UltraArithmeticRelationImpl {
   public:
@@ -114,4 +114,4 @@ template <typename FF_> class UltraArithmeticRelationImpl {
 };
 
 template <typename FF> using UltraArithmeticRelation = Relation<UltraArithmeticRelationImpl<FF>>;
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/ultra_relation_consistency.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ultra_relation_consistency.test.cpp
@@ -24,9 +24,9 @@
 #include "barretenberg/relations/ultra_arithmetic_relation.hpp"
 #include <gtest/gtest.h>
 
-using namespace proof_system;
+using namespace bb;
 
-namespace proof_system::ultra_relation_consistency_tests {
+namespace bb::ultra_relation_consistency_tests {
 
 using FF = bb::fr;
 struct InputElements {
@@ -681,4 +681,4 @@ TEST_F(UltraRelationConsistency, Poseidon2InternalRelation)
     run_test(/*random_inputs=*/true);
 };
 
-} // namespace proof_system::ultra_relation_consistency_tests
+} // namespace bb::ultra_relation_consistency_tests

--- a/barretenberg/cpp/src/barretenberg/relations/utils.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/utils.hpp
@@ -72,7 +72,7 @@ template <typename Flavor> class RelationUtils {
      * @param current_scalar power of the challenge
      */
     static void scale_univariates(auto& tuple, const RelationSeparator& challenges, FF& current_scalar)
-        requires proof_system::IsFoldingFlavor<Flavor>
+        requires bb::IsFoldingFlavor<Flavor>
     {
         size_t idx = 0;
         std::array<FF, NUM_SUBRELATIONS> tmp{ current_scalar };
@@ -92,7 +92,7 @@ template <typename Flavor> class RelationUtils {
      * @param current_scalar power of the challenge
      */
     static void scale_univariates(auto& tuple, const RelationSeparator& challenge, FF& current_scalar)
-        requires(!proof_system::IsFoldingFlavor<Flavor>)
+        requires(!bb::IsFoldingFlavor<Flavor>)
     {
         auto scale_by_consecutive_powers_of_challenge = [&]<size_t, size_t>(auto& element) {
             element *= current_scalar;
@@ -193,7 +193,7 @@ template <typename Flavor> class RelationUtils {
                                          const RelationSeparator& challenges,
                                          FF current_scalar,
                                          FF& result)
-        requires proof_system::IsFoldingFlavor<Flavor>
+        requires bb::IsFoldingFlavor<Flavor>
     {
         size_t idx = 0;
         std::array<FF, NUM_SUBRELATIONS> tmp{ current_scalar };
@@ -212,7 +212,7 @@ template <typename Flavor> class RelationUtils {
      * @param result Batched result
      */
     static void scale_and_batch_elements(auto& tuple, const RelationSeparator& challenge, FF current_scalar, FF& result)
-        requires(!proof_system::IsFoldingFlavor<Flavor>)
+        requires(!bb::IsFoldingFlavor<Flavor>)
     {
         auto scale_by_challenge_and_accumulate = [&](auto& element) {
             for (auto& entry : element) {

--- a/barretenberg/cpp/src/barretenberg/smt_verification/smt_bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/smt_bigfield.test.cpp
@@ -28,11 +28,11 @@
 
 using namespace smt_circuit;
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
-using field_ct = proof_system::plonk::stdlib::field_t<StandardCircuitBuilder>;
-using witness_t = proof_system::plonk::stdlib::witness_t<StandardCircuitBuilder>;
-using pub_witness_t = proof_system::plonk::stdlib::public_witness_t<StandardCircuitBuilder>;
+using field_ct = bb::plonk::stdlib::field_t<StandardCircuitBuilder>;
+using witness_t = bb::plonk::stdlib::witness_t<StandardCircuitBuilder>;
+using pub_witness_t = bb::plonk::stdlib::public_witness_t<StandardCircuitBuilder>;
 
 using bn254 = stdlib::bn254<StandardCircuitBuilder>;
 

--- a/barretenberg/cpp/src/barretenberg/smt_verification/smt_examples.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/smt_examples.test.cpp
@@ -9,15 +9,15 @@
 #include "barretenberg/smt_verification/circuit/circuit.hpp"
 
 using namespace bb;
-using namespace proof_system;
+using namespace bb;
 
 namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
 
-using field_t = proof_system::plonk::stdlib::field_t<StandardCircuitBuilder>;
-using witness_t = proof_system::plonk::stdlib::witness_t<StandardCircuitBuilder>;
-using pub_witness_t = proof_system::plonk::stdlib::public_witness_t<StandardCircuitBuilder>;
+using field_t = bb::plonk::stdlib::field_t<StandardCircuitBuilder>;
+using witness_t = bb::plonk::stdlib::witness_t<StandardCircuitBuilder>;
+using pub_witness_t = bb::plonk::stdlib::public_witness_t<StandardCircuitBuilder>;
 
 TEST(circuit_verification, multiplication_true)
 {

--- a/barretenberg/cpp/src/barretenberg/smt_verification/smt_polynomials.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/smt_polynomials.test.cpp
@@ -14,12 +14,12 @@
 #include "barretenberg/smt_verification/circuit/circuit.hpp"
 
 using namespace bb;
-using namespace proof_system;
+using namespace bb;
 using namespace smt_circuit;
 
-using field_ct = proof_system::plonk::stdlib::field_t<StandardCircuitBuilder>;
-using witness_t = proof_system::plonk::stdlib::witness_t<StandardCircuitBuilder>;
-using pub_witness_t = proof_system::plonk::stdlib::public_witness_t<StandardCircuitBuilder>;
+using field_ct = bb::plonk::stdlib::field_t<StandardCircuitBuilder>;
+using witness_t = bb::plonk::stdlib::witness_t<StandardCircuitBuilder>;
+using pub_witness_t = bb::plonk::stdlib::public_witness_t<StandardCircuitBuilder>;
 
 // TODO(alex): z1 = z2, s1=s2, but coefficients are not public
 namespace {

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/add_2_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/add_2_circuit.hpp
@@ -4,8 +4,8 @@
 
 template <typename Builder> class Add2Circuit {
   public:
-    typedef proof_system::plonk::stdlib::public_witness_t<Builder> public_witness_ct;
-    typedef proof_system::plonk::stdlib::field_t<Builder> field_ct;
+    typedef bb::plonk::stdlib::public_witness_t<Builder> public_witness_ct;
+    typedef bb::plonk::stdlib::field_t<Builder> field_ct;
 
     // Three public inputs
     static Builder generate(uint256_t inputs[])

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/blake_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/blake_circuit.hpp
@@ -3,8 +3,8 @@
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include "barretenberg/stdlib/primitives/witness/witness.hpp"
 
-using namespace proof_system::plonk;
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk;
+using namespace bb::plonk::stdlib;
 
 using numeric::uint256_t;
 

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/ecdsa_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/ecdsa_circuit.hpp
@@ -12,7 +12,7 @@
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include "barretenberg/stdlib/primitives/witness/witness.hpp"
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 using namespace stdlib;
 using numeric::uint256_t;
 

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/recursive_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/recursive_circuit.hpp
@@ -9,7 +9,7 @@
 #include "barretenberg/stdlib/recursion/verifier/verifier.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 using namespace stdlib;
 using numeric::uint256_t;
 
@@ -33,7 +33,7 @@ template <typename OuterBuilder> class RecursiveCircuit {
     using inner_scalar_field = typename inner_curve::ScalarFieldNative;
     using outer_scalar_field = typename outer_curve::BaseFieldNative;
     using pairing_target_field = bb::fq12;
-    static constexpr bool is_ultra_to_ultra = std::is_same_v<OuterBuilder, proof_system::UltraCircuitBuilder>;
+    static constexpr bool is_ultra_to_ultra = std::is_same_v<OuterBuilder, bb::UltraCircuitBuilder>;
     using ProverOfInnerCircuit =
         std::conditional_t<is_ultra_to_ultra, plonk::UltraProver, plonk::UltraToStandardProver>;
     using VerifierOfInnerProof =

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/key_gen.cpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/key_gen.cpp
@@ -32,7 +32,7 @@ void generate_keys(std::string output_path, std::string flavour_prefix, std::str
     {
         auto vk_filename = output_path + "/keys/" + vk_class_name + ".sol";
         std::ofstream os(vk_filename);
-        proof_system::output_vk_sol(os, vkey, vk_class_name);
+        bb::output_vk_sol(os, vkey, vk_class_name);
         info("VK contract written to: ", vk_filename);
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.cpp
@@ -4,7 +4,7 @@
 
 #include "../../primitives/packed_byte_array/packed_byte_array.hpp"
 
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 template <typename C>
 cycle_group<C> pedersen_commitment<C>::commit(const std::vector<field_t>& inputs, const GeneratorContext context)
@@ -40,8 +40,8 @@ cycle_group<C> pedersen_commitment<C>::commit(const std::vector<std::pair<field_
     return cycle_group::batch_mul(scalars, points);
 }
 
-template class pedersen_commitment<proof_system::StandardCircuitBuilder>;
-template class pedersen_commitment<proof_system::UltraCircuitBuilder>;
-template class pedersen_commitment<proof_system::GoblinUltraCircuitBuilder>;
+template class pedersen_commitment<bb::StandardCircuitBuilder>;
+template class pedersen_commitment<bb::UltraCircuitBuilder>;
+template class pedersen_commitment<bb::GoblinUltraCircuitBuilder>;
 
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.hpp
@@ -4,7 +4,7 @@
 #include "barretenberg/crypto/pedersen_commitment/pedersen.hpp"
 #include "barretenberg/stdlib/primitives/group/cycle_group.hpp"
 
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 template <typename CircuitBuilder> class pedersen_commitment {
   private:
@@ -20,4 +20,4 @@ template <typename CircuitBuilder> class pedersen_commitment {
     static cycle_group commit(const std::vector<std::pair<field_t, GeneratorContext>>& input_pairs);
 };
 
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/commitment/pedersen/pedersen.test.cpp
@@ -8,7 +8,7 @@
 
 namespace test_StdlibPedersen {
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
@@ -82,7 +82,7 @@ template <typename Builder> class StdlibPedersen : public testing::Test {
     }
 };
 
-using CircuitTypes = testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder>;
+using CircuitTypes = testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder>;
 
 TYPED_TEST_SUITE(StdlibPedersen, CircuitTypes);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/aes128/aes128.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/aes128/aes128.cpp
@@ -10,7 +10,7 @@
 using namespace crypto::aes128;
 using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace aes128 {
 template <typename Builder> using byte_pair = std::pair<field_t<Builder>, field_t<Builder>>;
@@ -302,8 +302,8 @@ std::vector<field_t<Builder>> encrypt_buffer_cbc(const std::vector<field_t<Build
     template std::vector<field_t<Builder>> encrypt_buffer_cbc<Builder>(                                                \
         const std::vector<field_t<Builder>>&, const field_t<Builder>&, const field_t<Builder>&)
 
-INSTANTIATE_ENCRYPT_BUFFER_CBC(proof_system::UltraCircuitBuilder);
-INSTANTIATE_ENCRYPT_BUFFER_CBC(proof_system::GoblinUltraCircuitBuilder);
+INSTANTIATE_ENCRYPT_BUFFER_CBC(bb::UltraCircuitBuilder);
+INSTANTIATE_ENCRYPT_BUFFER_CBC(bb::GoblinUltraCircuitBuilder);
 } // namespace aes128
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/aes128/aes128.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/aes128/aes128.hpp
@@ -7,7 +7,7 @@
 #include "../../primitives/witness/witness.hpp"
 #include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 namespace aes128 {
@@ -19,4 +19,4 @@ std::vector<stdlib::field_t<Builder>> encrypt_buffer_cbc(const std::vector<stdli
 
 } // namespace aes128
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/aes128/aes128.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/aes128/aes128.test.cpp
@@ -5,12 +5,12 @@
 #include <gtest/gtest.h>
 
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 TEST(stdlib_aes128, encrypt_64_bytes)
 {
-    typedef stdlib::field_t<proof_system::UltraCircuitBuilder> field_pt;
-    typedef stdlib::witness_t<proof_system::UltraCircuitBuilder> witness_pt;
+    typedef stdlib::field_t<bb::UltraCircuitBuilder> field_pt;
+    typedef stdlib::witness_t<bb::UltraCircuitBuilder> witness_pt;
 
     uint8_t key[16]{ 0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c };
     uint8_t out[64]{ 0x76, 0x49, 0xab, 0xac, 0x81, 0x19, 0xb2, 0x46, 0xce, 0xe9, 0x8e, 0x9b, 0x12, 0xe9, 0x19, 0x7d,
@@ -32,7 +32,7 @@ TEST(stdlib_aes128, encrypt_64_bytes)
         return converted;
     };
 
-    auto builder = proof_system::UltraCircuitBuilder();
+    auto builder = bb::UltraCircuitBuilder();
 
     std::vector<field_pt> in_field{
         witness_pt(&builder, fr(convert_bytes(in))),

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
@@ -4,7 +4,7 @@
 #include "../../primitives/circuit_builders/circuit_builders_fwd.hpp"
 #include "../../primitives/uint/uint.hpp"
 #include "barretenberg/crypto/ecdsa/ecdsa.hpp"
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace ecdsa {
 
@@ -44,6 +44,6 @@ template <typename Builder> static signature<Builder> from_witness(Builder* ctx,
 
 } // namespace ecdsa
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk
 
 #include "./ecdsa_impl.hpp"

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
@@ -7,10 +7,10 @@
 #include "ecdsa.hpp"
 
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 namespace test_stdlib_ecdsa {
-using Builder = proof_system::UltraCircuitBuilder;
+using Builder = bb::UltraCircuitBuilder;
 using curve = stdlib::secp256k1<Builder>;
 using curveR1 = stdlib::secp256r1<Builder>;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -4,7 +4,7 @@
 #include "barretenberg/stdlib/hash/sha256/sha256.hpp"
 #include "barretenberg/stdlib/primitives//bit_array/bit_array.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace ecdsa {
 
@@ -88,7 +88,7 @@ bool_t<Builder> verify_signature(const stdlib::byte_array<Builder>& message,
     // TODO(Cody): Having Plookup should not determine which curve is used.
     // Use special plookup secp256k1 ECDSA mul if available (this relies on k1 endomorphism, and cannot be used for
     // other curves)
-    if constexpr (HasPlookup<Builder> && Curve::type == proof_system::CurveType::SECP256K1) {
+    if constexpr (HasPlookup<Builder> && Curve::type == bb::CurveType::SECP256K1) {
         result = G1::secp256k1_ecdsa_mul(public_key, u1, u2);
     } else {
         result = G1::batch_mul({ G1::one(ctx), public_key }, { u1, u2 });
@@ -163,7 +163,7 @@ bool_t<Builder> verify_signature_prehashed_message_noassert(const stdlib::byte_a
     G1 result;
     // Use special plookup secp256k1 ECDSA mul if available (this relies on k1 endomorphism, and cannot be used for
     // other curves)
-    if constexpr (HasPlookup<Builder> && Curve::type == proof_system::CurveType::SECP256K1) {
+    if constexpr (HasPlookup<Builder> && Curve::type == bb::CurveType::SECP256K1) {
         result = G1::secp256k1_ecdsa_mul(public_key, u1, u2);
     } else {
         result = G1::batch_mul({ G1::one(ctx), public_key }, { u1, u2 });
@@ -224,4 +224,4 @@ bool_t<Builder> verify_signature_noassert(const stdlib::byte_array<Builder>& mes
 
 } // namespace ecdsa
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/schnorr/schnorr.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/schnorr/schnorr.cpp
@@ -7,7 +7,7 @@
 #include "barretenberg/stdlib/primitives/group/cycle_group.hpp"
 #include <array>
 
-namespace proof_system::plonk::stdlib::schnorr {
+namespace bb::plonk::stdlib::schnorr {
 
 /**
  * @brief Instantiate a witness containing the signature (s, e) as a quadruple of
@@ -91,25 +91,25 @@ bool_t<C> signature_verification_result(const byte_array<C>& message,
 #define VERIFY_SIGNATURE_INTERNAL(circuit_type)                                                                        \
     template std::array<field_t<circuit_type>, 2> verify_signature_internal<circuit_type>(                             \
         const byte_array<circuit_type>&, const cycle_group<circuit_type>&, const signature_bits<circuit_type>&)
-VERIFY_SIGNATURE_INTERNAL(proof_system::StandardCircuitBuilder);
-VERIFY_SIGNATURE_INTERNAL(proof_system::UltraCircuitBuilder);
-VERIFY_SIGNATURE_INTERNAL(proof_system::GoblinUltraCircuitBuilder);
+VERIFY_SIGNATURE_INTERNAL(bb::StandardCircuitBuilder);
+VERIFY_SIGNATURE_INTERNAL(bb::UltraCircuitBuilder);
+VERIFY_SIGNATURE_INTERNAL(bb::GoblinUltraCircuitBuilder);
 #define VERIFY_SIGNATURE(circuit_type)                                                                                 \
     template void verify_signature<circuit_type>(                                                                      \
         const byte_array<circuit_type>&, const cycle_group<circuit_type>&, const signature_bits<circuit_type>&)
-VERIFY_SIGNATURE(proof_system::StandardCircuitBuilder);
-VERIFY_SIGNATURE(proof_system::UltraCircuitBuilder);
-VERIFY_SIGNATURE(proof_system::GoblinUltraCircuitBuilder);
+VERIFY_SIGNATURE(bb::StandardCircuitBuilder);
+VERIFY_SIGNATURE(bb::UltraCircuitBuilder);
+VERIFY_SIGNATURE(bb::GoblinUltraCircuitBuilder);
 #define SIGNATURE_VERIFICATION_RESULT(circuit_type)                                                                    \
     template bool_t<circuit_type> signature_verification_result<circuit_type>(                                         \
         const byte_array<circuit_type>&, const cycle_group<circuit_type>&, const signature_bits<circuit_type>&)
-SIGNATURE_VERIFICATION_RESULT(proof_system::StandardCircuitBuilder);
-SIGNATURE_VERIFICATION_RESULT(proof_system::UltraCircuitBuilder);
-SIGNATURE_VERIFICATION_RESULT(proof_system::GoblinUltraCircuitBuilder);
+SIGNATURE_VERIFICATION_RESULT(bb::StandardCircuitBuilder);
+SIGNATURE_VERIFICATION_RESULT(bb::UltraCircuitBuilder);
+SIGNATURE_VERIFICATION_RESULT(bb::GoblinUltraCircuitBuilder);
 #define CONVERT_SIGNATURE(circuit_type)                                                                                \
     template signature_bits<circuit_type> convert_signature<circuit_type>(circuit_type*,                               \
                                                                           const crypto::schnorr::signature&)
-CONVERT_SIGNATURE(proof_system::StandardCircuitBuilder);
-CONVERT_SIGNATURE(proof_system::UltraCircuitBuilder);
-CONVERT_SIGNATURE(proof_system::GoblinUltraCircuitBuilder);
-} // namespace proof_system::plonk::stdlib::schnorr
+CONVERT_SIGNATURE(bb::StandardCircuitBuilder);
+CONVERT_SIGNATURE(bb::UltraCircuitBuilder);
+CONVERT_SIGNATURE(bb::GoblinUltraCircuitBuilder);
+} // namespace bb::plonk::stdlib::schnorr

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/schnorr/schnorr.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/schnorr/schnorr.hpp
@@ -6,7 +6,7 @@
 #include "../../primitives/witness/witness.hpp"
 #include "barretenberg/crypto/schnorr/schnorr.hpp"
 
-namespace proof_system::plonk::stdlib::schnorr {
+namespace bb::plonk::stdlib::schnorr {
 
 template <typename C> struct signature_bits {
     typename cycle_group<C>::cycle_scalar s;
@@ -28,4 +28,4 @@ bool_t<C> signature_verification_result(const byte_array<C>& message,
                                         const cycle_group<C>& pub_key,
                                         const signature_bits<C>& sig);
 
-} // namespace proof_system::plonk::stdlib::schnorr
+} // namespace bb::plonk::stdlib::schnorr

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/schnorr/schnorr.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/schnorr/schnorr.test.cpp
@@ -5,13 +5,13 @@
 #include "barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp"
 #include "schnorr.hpp"
 
-namespace proof_system::test_stdlib_schnorr {
+namespace bb::test_stdlib_schnorr {
 
 using namespace bb;
-using namespace proof_system::plonk::stdlib;
-using namespace proof_system::plonk::stdlib::schnorr;
+using namespace bb::plonk::stdlib;
+using namespace bb::plonk::stdlib::schnorr;
 
-using Builder = proof_system::UltraCircuitBuilder;
+using Builder = bb::UltraCircuitBuilder;
 using bool_ct = bool_t<Builder>;
 using byte_array_ct = byte_array<Builder>;
 using field_ct = field_t<Builder>;
@@ -179,4 +179,4 @@ TEST(stdlib_schnorr, signature_verification_result_failure)
     EXPECT_EQ(verification_result, true);
 }
 
-} // namespace proof_system::test_stdlib_schnorr
+} // namespace bb::test_stdlib_schnorr

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/benchmarks/celer/sha256.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/benchmarks/celer/sha256.bench.cpp
@@ -13,10 +13,10 @@
 
 using namespace benchmark;
 
-using Builder = proof_system::UltraCircuitBuilder;
-using Composer = proof_system::plonk::UltraComposer;
-using Prover = proof_system::plonk::UltraProver;
-using Verifier = proof_system::plonk::UltraVerifier;
+using Builder = bb::UltraCircuitBuilder;
+using Composer = bb::plonk::UltraComposer;
+using Prover = bb::plonk::UltraProver;
+using Verifier = bb::plonk::UltraVerifier;
 
 constexpr size_t NUM_HASHES = 20;
 constexpr size_t CHUNK_SIZE = 64;
@@ -33,9 +33,9 @@ void generate_test_plonk_circuit(Builder& builder, size_t num_bytes)
 {
     std::string in;
     in.resize(num_bytes);
-    proof_system::plonk::stdlib::packed_byte_array<Builder> input(&builder, in);
+    bb::plonk::stdlib::packed_byte_array<Builder> input(&builder, in);
 
-    proof_system::plonk::stdlib::sha256<Builder>(input);
+    bb::plonk::stdlib::sha256<Builder>(input);
 }
 
 // Because of the way we do internal allocations in some of our more complex structures, we can't just globally allocate

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/benchmarks/external/external.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/benchmarks/external/external.bench.cpp
@@ -12,11 +12,11 @@
 
 using namespace benchmark;
 
-using Builder = proof_system::UltraCircuitBuilder;
-using Composer = proof_system::plonk::UltraComposer;
+using Builder = bb::UltraCircuitBuilder;
+using Composer = bb::plonk::UltraComposer;
 
-using Prover = proof_system::plonk::UltraProver;
-using Verifier = proof_system::plonk::UltraVerifier;
+using Prover = bb::plonk::UltraProver;
+using Verifier = bb::plonk::UltraVerifier;
 
 constexpr size_t PROOF_COUNT_LOG = 10;
 constexpr size_t NUM_PROOFS = 3;
@@ -36,9 +36,9 @@ void generate_test_sha256_plonk_circuit(Builder& builder, size_t num_iterations)
         in[i] = 0;
     }
 
-    proof_system::plonk::stdlib::packed_byte_array<Builder> input(&builder, in);
+    bb::plonk::stdlib::packed_byte_array<Builder> input(&builder, in);
     for (size_t i = 0; i < num_iterations; i++) {
-        input = proof_system::plonk::stdlib::sha256<Builder>(input);
+        input = bb::plonk::stdlib::sha256<Builder>(input);
     }
 }
 
@@ -117,9 +117,9 @@ void generate_test_blake3s_plonk_circuit(Builder& builder, size_t num_iterations
     for (size_t i = 0; i < 32; ++i) {
         in[i] = 0;
     }
-    proof_system::plonk::stdlib::packed_byte_array<Builder> input(&builder, in);
+    bb::plonk::stdlib::packed_byte_array<Builder> input(&builder, in);
     for (size_t i = 0; i < num_iterations; i++) {
-        input = proof_system::plonk::stdlib::blake3s<Builder>(input);
+        input = bb::plonk::stdlib::blake3s<Builder>(input);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/benchmarks/sha256/sha256.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/benchmarks/sha256/sha256.bench.cpp
@@ -4,10 +4,10 @@
 
 using namespace benchmark;
 
-using Builder = proof_system::UltraCircuitBuilder;
-using Composer = proof_system::plonk::UltraComposer;
-using Prover = proof_system::plonk::UltraProver;
-using Verifier = proof_system::plonk::UltraVerifier;
+using Builder = bb::UltraCircuitBuilder;
+using Composer = bb::plonk::UltraComposer;
+using Prover = bb::plonk::UltraProver;
+using Verifier = bb::plonk::UltraVerifier;
 
 constexpr size_t NUM_HASHES = 8;
 constexpr size_t BYTES_PER_CHUNK = 512;
@@ -26,8 +26,8 @@ void generate_test_plonk_circuit(Builder& builder, size_t num_bytes)
     for (size_t i = 0; i < num_bytes; ++i) {
         in[i] = get_random_char();
     }
-    proof_system::plonk::stdlib::packed_byte_array<Builder> input(&builder, in);
-    proof_system::plonk::stdlib::sha256<Builder>(input);
+    bb::plonk::stdlib::packed_byte_array<Builder> input(&builder, in);
+    bb::plonk::stdlib::sha256<Builder>(input);
 }
 
 void* builders[NUM_HASHES];

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.cpp
@@ -3,7 +3,7 @@
 #include "blake2s_plookup.hpp"
 #include "blake_util.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 namespace {
@@ -136,12 +136,9 @@ template <typename Builder> byte_array<Builder> blake2s(const byte_array<Builder
     return result;
 }
 
-template byte_array<proof_system::StandardCircuitBuilder> blake2s(
-    const byte_array<proof_system::StandardCircuitBuilder>& input);
-template byte_array<proof_system::UltraCircuitBuilder> blake2s(
-    const byte_array<proof_system::UltraCircuitBuilder>& input);
-template byte_array<proof_system::GoblinUltraCircuitBuilder> blake2s(
-    const byte_array<proof_system::GoblinUltraCircuitBuilder>& input);
+template byte_array<bb::StandardCircuitBuilder> blake2s(const byte_array<bb::StandardCircuitBuilder>& input);
+template byte_array<bb::UltraCircuitBuilder> blake2s(const byte_array<bb::UltraCircuitBuilder>& input);
+template byte_array<bb::GoblinUltraCircuitBuilder> blake2s(const byte_array<bb::GoblinUltraCircuitBuilder>& input);
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.hpp
@@ -2,10 +2,10 @@
 #include "barretenberg/stdlib/primitives/byte_array/byte_array.hpp"
 #include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder> byte_array<Builder> blake2s(const byte_array<Builder>& input);
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
@@ -5,9 +5,9 @@
 #include <gtest/gtest.h>
 
 using namespace bb;
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 
-using Builder = proof_system::UltraCircuitBuilder;
+using Builder = bb::UltraCircuitBuilder;
 
 using field_ct = field_t<Builder>;
 using witness_ct = witness_t<Builder>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s_plookup.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s_plookup.cpp
@@ -15,7 +15,7 @@
  * 2. replace use of uint32 with basic field_t type
  *
  **/
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 namespace blake2s_plookup {
@@ -166,12 +166,10 @@ template <typename Builder> byte_array<Builder> blake2s(const byte_array<Builder
     return result;
 }
 
-template byte_array<proof_system::UltraCircuitBuilder> blake2s(
-    const byte_array<proof_system::UltraCircuitBuilder>& input);
-template byte_array<proof_system::GoblinUltraCircuitBuilder> blake2s(
-    const byte_array<proof_system::GoblinUltraCircuitBuilder>& input);
+template byte_array<bb::UltraCircuitBuilder> blake2s(const byte_array<bb::UltraCircuitBuilder>& input);
+template byte_array<bb::GoblinUltraCircuitBuilder> blake2s(const byte_array<bb::GoblinUltraCircuitBuilder>& input);
 
 } // namespace blake2s_plookup
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s_plookup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s_plookup.hpp
@@ -9,7 +9,7 @@
 #include "../../primitives/field/field.hpp"
 #include "../../primitives/packed_byte_array/packed_byte_array.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 namespace blake2s_plookup {
@@ -19,4 +19,4 @@ template <typename Builder> byte_array<Builder> blake2s(const byte_array<Builder
 } // namespace blake2s_plookup
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake_util.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake_util.hpp
@@ -4,7 +4,7 @@
 #include "barretenberg/stdlib/primitives/plookup/plookup.hpp"
 #include "barretenberg/stdlib/primitives/uint/uint.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 namespace blake_util {
@@ -255,4 +255,4 @@ void round_fn_lookup(field_t<Builder> state[BLAKE3_STATE_SIZE],
 } // namespace blake_util
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.cpp
@@ -3,7 +3,7 @@
 #include "barretenberg/stdlib/primitives/uint/uint.hpp"
 #include "blake3s_plookup.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 namespace blake3_internal {
@@ -254,11 +254,8 @@ template <typename Builder> byte_array<Builder> blake3s(const byte_array<Builder
     return result;
 }
 
-template byte_array<proof_system::StandardCircuitBuilder> blake3s(
-    const byte_array<proof_system::StandardCircuitBuilder>& input);
-template byte_array<proof_system::UltraCircuitBuilder> blake3s(
-    const byte_array<proof_system::UltraCircuitBuilder>& input);
-template byte_array<proof_system::GoblinUltraCircuitBuilder> blake3s(
-    const byte_array<proof_system::GoblinUltraCircuitBuilder>& input);
+template byte_array<bb::StandardCircuitBuilder> blake3s(const byte_array<bb::StandardCircuitBuilder>& input);
+template byte_array<bb::UltraCircuitBuilder> blake3s(const byte_array<bb::UltraCircuitBuilder>& input);
+template byte_array<bb::GoblinUltraCircuitBuilder> blake3s(const byte_array<bb::GoblinUltraCircuitBuilder>& input);
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.hpp
@@ -2,10 +2,10 @@
 #include "barretenberg/stdlib/primitives/byte_array/byte_array.hpp"
 #include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder> byte_array<Builder> blake3s(const byte_array<Builder>& input);
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
@@ -5,14 +5,14 @@
 #include <gtest/gtest.h>
 
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
-using byte_array = stdlib::byte_array<proof_system::StandardCircuitBuilder>;
-using public_witness_t = stdlib::public_witness_t<proof_system::StandardCircuitBuilder>;
-using byte_array_plookup = stdlib::byte_array<proof_system::UltraCircuitBuilder>;
-using public_witness_t_plookup = stdlib::public_witness_t<proof_system::UltraCircuitBuilder>;
-using StandardBuilder = proof_system::StandardCircuitBuilder;
-using UltraBuilder = proof_system::UltraCircuitBuilder;
+using byte_array = stdlib::byte_array<bb::StandardCircuitBuilder>;
+using public_witness_t = stdlib::public_witness_t<bb::StandardCircuitBuilder>;
+using byte_array_plookup = stdlib::byte_array<bb::UltraCircuitBuilder>;
+using public_witness_t_plookup = stdlib::public_witness_t<bb::UltraCircuitBuilder>;
+using StandardBuilder = bb::StandardCircuitBuilder;
+using UltraBuilder = bb::UltraCircuitBuilder;
 
 TEST(stdlib_blake3s, test_single_block)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s_plookup.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s_plookup.cpp
@@ -7,7 +7,7 @@
 #include "barretenberg/stdlib/primitives/plookup/plookup.hpp"
 #include "barretenberg/stdlib/primitives/uint/uint.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 namespace blake3s_plookup {
@@ -260,11 +260,9 @@ template <typename Builder> byte_array<Builder> blake3s(const byte_array<Builder
     return result;
 }
 
-template byte_array<proof_system::UltraCircuitBuilder> blake3s(
-    const byte_array<proof_system::UltraCircuitBuilder>& input);
-template byte_array<proof_system::GoblinUltraCircuitBuilder> blake3s(
-    const byte_array<proof_system::GoblinUltraCircuitBuilder>& input);
+template byte_array<bb::UltraCircuitBuilder> blake3s(const byte_array<bb::UltraCircuitBuilder>& input);
+template byte_array<bb::GoblinUltraCircuitBuilder> blake3s(const byte_array<bb::GoblinUltraCircuitBuilder>& input);
 } // namespace blake3s_plookup
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s_plookup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s_plookup.hpp
@@ -9,7 +9,7 @@
 #include "../../primitives/field/field.hpp"
 #include "../../primitives/packed_byte_array/packed_byte_array.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 namespace blake3s_plookup {
@@ -19,4 +19,4 @@ template <typename Builder> byte_array<Builder> blake3s(const byte_array<Builder
 } // namespace blake3s_plookup
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
@@ -3,7 +3,7 @@
 #include "barretenberg/numeric/bitop/sparse_form.hpp"
 #include "barretenberg/stdlib/primitives/logic/logic.hpp"
 #include "barretenberg/stdlib/primitives/uint/uint.hpp"
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 using namespace plookup;
@@ -889,8 +889,8 @@ stdlib::byte_array<Builder> keccak<Builder>::sponge_squeeze_for_permutation_opco
     }
     return result;
 }
-template class keccak<proof_system::UltraCircuitBuilder>;
-template class keccak<proof_system::GoblinUltraCircuitBuilder>;
+template class keccak<bb::UltraCircuitBuilder>;
+template class keccak<bb::GoblinUltraCircuitBuilder>;
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.hpp
@@ -4,7 +4,7 @@
 #include "barretenberg/stdlib/primitives/uint/uint.hpp"
 #include <array>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 template <typename Builder> class bit_array;
 
@@ -203,4 +203,4 @@ template <typename Builder> class keccak {
 };
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
@@ -5,9 +5,9 @@
 #include <gtest/gtest.h>
 
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
-typedef proof_system::UltraCircuitBuilder Builder;
+typedef bb::UltraCircuitBuilder Builder;
 typedef stdlib::byte_array<Builder> byte_array;
 typedef stdlib::public_witness_t<Builder> public_witness_t;
 typedef stdlib::field_t<Builder> field_ct;

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen.bench.cpp
@@ -10,10 +10,10 @@
 #define BARRETENBERG_SRS_PATH "../srs_db/ignition"
 
 using namespace benchmark;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
-using Builder = proof_system::UltraCircuitBuilder;
-using Composer = proof_system::plonk::UltraComposer;
+using Builder = bb::UltraCircuitBuilder;
+using Composer = bb::plonk::UltraComposer;
 
 constexpr size_t NUM_CIRCUITS = 10;
 
@@ -45,7 +45,7 @@ void generate_test_pedersen_hash_circuit(Builder& builder, size_t num_repetition
     plonk::stdlib::field_t<Builder> out(plonk::stdlib::witness_t(&builder, bb::fr::random_element()));
 
     for (size_t i = 0; i < num_repetitions; ++i) {
-        out = proof_system::plonk::stdlib::pedersen_hash<Builder>::hash({ left, out });
+        out = bb::plonk::stdlib::pedersen_hash<Builder>::hash({ left, out });
     }
 }
 
@@ -56,7 +56,7 @@ void generate_test_pedersen_hash_buffer_circuit(Builder& builder, size_t num_rep
         stdlib::byte_array<Builder> tmp(plonk::stdlib::witness_t(&builder, bb::fr::random_element()));
         input.write(tmp);
     }
-    auto out = proof_system::plonk::stdlib::pedersen_hash<Builder>::hash_buffer(input);
+    auto out = bb::plonk::stdlib::pedersen_hash<Builder>::hash_buffer(input);
     (void)out;
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen.cpp
@@ -1,9 +1,9 @@
 #include "pedersen.hpp"
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 using namespace bb;
-using namespace proof_system;
+using namespace bb;
 
 template <typename C>
 field_t<C> pedersen_hash<C>::hash(const std::vector<field_ct>& inputs, const GeneratorContext context)
@@ -86,8 +86,8 @@ field_t<C> pedersen_hash<C>::hash_buffer(const stdlib::byte_array<C>& input, Gen
     }
     return hashed;
 }
-template class pedersen_hash<proof_system::StandardCircuitBuilder>;
-template class pedersen_hash<proof_system::UltraCircuitBuilder>;
-template class pedersen_hash<proof_system::GoblinUltraCircuitBuilder>;
+template class pedersen_hash<bb::StandardCircuitBuilder>;
+template class pedersen_hash<bb::UltraCircuitBuilder>;
+template class pedersen_hash<bb::GoblinUltraCircuitBuilder>;
 
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen.hpp
@@ -6,7 +6,7 @@
 
 #include "../../primitives/circuit_builders/circuit_builders.hpp"
 
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 using namespace bb;
 /**
@@ -31,4 +31,4 @@ template <typename Builder> class pedersen_hash {
     static field_ct hash_buffer(const stdlib::byte_array<Builder>& input, GeneratorContext context = {});
 };
 
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/pedersen/pedersen.test.cpp
@@ -7,7 +7,7 @@
 
 namespace test_StdlibPedersen {
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
@@ -245,7 +245,7 @@ template <typename Builder> class StdlibPedersen : public testing::Test {
     }
 };
 
-using CircuitTypes = testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder>;
+using CircuitTypes = testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder>;
 
 TYPED_TEST_SUITE(StdlibPedersen, CircuitTypes);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.cpp
@@ -1,9 +1,9 @@
 #include "barretenberg/stdlib/hash/poseidon2/poseidon2.hpp"
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 using namespace bb;
-using namespace proof_system;
+using namespace bb;
 
 /**
  * @brief Hash a vector of field_ct.
@@ -41,6 +41,6 @@ template <typename C> field_t<C> poseidon2<C>::hash_buffer(C& builder, const std
     }
     return hash(builder, elements);
 }
-template class poseidon2<proof_system::GoblinUltraCircuitBuilder>;
+template class poseidon2<bb::GoblinUltraCircuitBuilder>;
 
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.hpp
@@ -6,7 +6,7 @@
 
 #include "../../primitives/circuit_builders/circuit_builders.hpp"
 
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 using namespace bb;
 /**
@@ -30,6 +30,6 @@ template <typename Builder> class poseidon2 {
     static field_ct hash_buffer(Builder& builder, const stdlib::byte_array<Builder>& input);
 };
 
-extern template class poseidon2<proof_system::GoblinUltraCircuitBuilder>;
+extern template class poseidon2<bb::GoblinUltraCircuitBuilder>;
 
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.test.cpp
@@ -6,7 +6,7 @@
 
 namespace test_StdlibPoseidon2 {
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
@@ -148,7 +148,7 @@ template <typename Builder> class StdlibPoseidon2 : public testing::Test {
     }
 };
 
-using CircuitTypes = testing::Types<proof_system::GoblinUltraCircuitBuilder>;
+using CircuitTypes = testing::Types<bb::GoblinUltraCircuitBuilder>;
 
 TYPED_TEST_SUITE(StdlibPoseidon2, CircuitTypes);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2_permutation.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2_permutation.cpp
@@ -3,7 +3,7 @@
 #include "barretenberg/proof_system/arithmetization/gate_data.hpp"
 #include "barretenberg/proof_system/circuit_builder/goblin_ultra_circuit_builder.hpp"
 
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 /**
  * @brief Circuit form of Poseidon2 permutation from https://eprint.iacr.org/2023/323.
@@ -205,4 +205,4 @@ void Poseidon2Permutation<Params, Builder>::initial_external_matrix_multiplicati
 
 template class Poseidon2Permutation<crypto::Poseidon2Bn254ScalarFieldParams, GoblinUltraCircuitBuilder>;
 
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2_permutation.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2_permutation.hpp
@@ -6,9 +6,9 @@
 #include "barretenberg/crypto/poseidon2/poseidon2_permutation.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
-using namespace proof_system;
+using namespace bb;
 template <typename Params, typename Builder> class Poseidon2Permutation {
   public:
     using NativePermutation = crypto::Poseidon2Permutation<Params>;
@@ -64,4 +64,4 @@ template <typename Params, typename Builder> class Poseidon2Permutation {
 
 extern template class Poseidon2Permutation<crypto::Poseidon2Bn254ScalarFieldParams, GoblinUltraCircuitBuilder>;
 
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/sponge/sponge.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/sponge/sponge.hpp
@@ -9,7 +9,7 @@
 #include "barretenberg/stdlib/hash/poseidon2/poseidon2_permutation.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 /**
  * @brief Implements the circuit form of a cryptographic sponge over prime fields.
@@ -179,4 +179,4 @@ template <size_t rate, size_t capacity, size_t t, typename Permutation, typename
         return hash_variable_length<1>(builder, input)[0];
     }
 };
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.cpp
@@ -3,7 +3,7 @@
 #include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp"
 #include "sha256_plookup.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace internal {
 constexpr uint32_t init_constants[8]{ 0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
@@ -179,17 +179,13 @@ template <typename Builder> packed_byte_array<Builder> sha256(const packed_byte_
     return packed_byte_array<Builder>(output, 4);
 }
 
-template byte_array<proof_system::StandardCircuitBuilder> sha256_block(
-    const byte_array<proof_system::StandardCircuitBuilder>& input);
-template byte_array<proof_system::UltraCircuitBuilder> sha256_block(
-    const byte_array<proof_system::UltraCircuitBuilder>& input);
-template byte_array<proof_system::GoblinUltraCircuitBuilder> sha256_block(
-    const byte_array<proof_system::GoblinUltraCircuitBuilder>& input);
-template packed_byte_array<proof_system::StandardCircuitBuilder> sha256(
-    const packed_byte_array<proof_system::StandardCircuitBuilder>& input);
-template packed_byte_array<proof_system::UltraCircuitBuilder> sha256(
-    const packed_byte_array<proof_system::UltraCircuitBuilder>& input);
-template packed_byte_array<proof_system::GoblinUltraCircuitBuilder> sha256(
-    const packed_byte_array<proof_system::GoblinUltraCircuitBuilder>& input);
+template byte_array<bb::StandardCircuitBuilder> sha256_block(const byte_array<bb::StandardCircuitBuilder>& input);
+template byte_array<bb::UltraCircuitBuilder> sha256_block(const byte_array<bb::UltraCircuitBuilder>& input);
+template byte_array<bb::GoblinUltraCircuitBuilder> sha256_block(const byte_array<bb::GoblinUltraCircuitBuilder>& input);
+template packed_byte_array<bb::StandardCircuitBuilder> sha256(
+    const packed_byte_array<bb::StandardCircuitBuilder>& input);
+template packed_byte_array<bb::UltraCircuitBuilder> sha256(const packed_byte_array<bb::UltraCircuitBuilder>& input);
+template packed_byte_array<bb::GoblinUltraCircuitBuilder> sha256(
+    const packed_byte_array<bb::GoblinUltraCircuitBuilder>& input);
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.hpp
@@ -5,9 +5,9 @@
 #include "barretenberg/stdlib/primitives/uint/uint.hpp"
 #include "sha256_plookup.hpp"
 #include <array>
-// namespace proof_system::plonk
+// namespace bb::plonk
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 template <typename Builder> class bit_array;
 
@@ -25,4 +25,4 @@ template <typename Builder> field_t<Builder> sha256_to_field(const packed_byte_a
 }
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.test.cpp
@@ -13,12 +13,12 @@ namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
 
-namespace proof_system::test_stdlib_sha256 {
+namespace bb::test_stdlib_sha256 {
 
 using namespace bb;
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 
-using Builder = proof_system::UltraCircuitBuilder;
+using Builder = bb::UltraCircuitBuilder;
 
 using byte_array_ct = byte_array<Builder>;
 using packed_byte_array_ct = packed_byte_array<Builder>;
@@ -120,18 +120,18 @@ std::array<uint64_t, 8> inner_block(std::array<uint64_t, 64>& w)
 //     auto builder = UltraPlonkBuilder();
 
 //     std::array<uint64_t, 64> w_inputs;
-//     std::array<proof_system::plonk::stdlib::field_t<proof_system::UltraCircuitBuilder>, 64> w_elements;
+//     std::array<bb::plonk::stdlib::field_t<bb::UltraCircuitBuilder>, 64> w_elements;
 
 //     for (size_t i = 0; i < 64; ++i) {
 //         w_inputs[i] = engine.get_random_uint32();
-//         w_elements[i] = proof_system::plonk::stdlib::witness_t<proof_system::UltraCircuitBuilder>(&builder,
+//         w_elements[i] = bb::plonk::stdlib::witness_t<bb::UltraCircuitBuilder>(&builder,
 //         bb::fr(w_inputs[i]));
 //     }
 
 //     const auto expected = inner_block(w_inputs);
 
-//     const std::array<proof_system::plonk::stdlib::field_t<proof_system::UltraCircuitBuilder>, 8> result =
-//         proof_system::plonk::stdlib::sha256_inner_block(w_elements);
+//     const std::array<bb::plonk::stdlib::field_t<bb::UltraCircuitBuilder>, 8> result =
+//         bb::plonk::stdlib::sha256_inner_block(w_elements);
 //     for (size_t i = 0; i < 8; ++i) {
 //         EXPECT_EQ(uint256_t(result[i].get_value()).data[0] & 0xffffffffUL,
 //                   uint256_t(expected[i]).data[0] & 0xffffffffUL);
@@ -141,22 +141,22 @@ std::array<uint64_t, 8> inner_block(std::array<uint64_t, 64>& w)
 //     auto prover = composer.create_prover();
 
 //     auto verifier = composer.create_verifier();
-//     proof_system::plonk::proof proof = prover.construct_proof();
+//     bb::plonk::proof proof = prover.construct_proof();
 //     bool proof_result = builder.check_circuit();
 //     EXPECT_EQ(proof_result, true);
 // }
 
 TEST(stdlib_sha256, test_plookup_55_bytes)
 {
-    typedef proof_system::plonk::stdlib::field_t<proof_system::UltraCircuitBuilder> field_pt;
-    typedef proof_system::plonk::stdlib::packed_byte_array<proof_system::UltraCircuitBuilder> packed_byte_array_pt;
+    typedef bb::plonk::stdlib::field_t<bb::UltraCircuitBuilder> field_pt;
+    typedef bb::plonk::stdlib::packed_byte_array<bb::UltraCircuitBuilder> packed_byte_array_pt;
 
     // 55 bytes is the largest number of bytes that can be hashed in a single block,
     // accounting for the single padding bit, and the 64 size bits required by the SHA-256 standard.
-    auto builder = proof_system::UltraCircuitBuilder();
+    auto builder = bb::UltraCircuitBuilder();
     packed_byte_array_pt input(&builder, "An 8 character password? Snow White and the 7 Dwarves..");
 
-    packed_byte_array_pt output_bits = proof_system::plonk::stdlib::sha256(input);
+    packed_byte_array_pt output_bits = bb::plonk::stdlib::sha256(input);
 
     std::vector<field_pt> output = output_bits.to_unverified_byte_slices(4);
 
@@ -181,7 +181,7 @@ TEST(stdlib_sha256, test_55_bytes)
     auto builder = Builder();
     packed_byte_array_ct input(&builder, "An 8 character password? Snow White and the 7 Dwarves..");
 
-    packed_byte_array_ct output_bits = proof_system::plonk::stdlib::sha256(input);
+    packed_byte_array_ct output_bits = bb::plonk::stdlib::sha256(input);
 
     std::vector<field_ct> output = output_bits.to_unverified_byte_slices(4);
 
@@ -201,13 +201,13 @@ TEST(stdlib_sha256, test_55_bytes)
 
 TEST(stdlib_sha256, test_NIST_vector_one_packed_byte_array)
 {
-    typedef proof_system::plonk::stdlib::field_t<proof_system::UltraCircuitBuilder> field_pt;
-    typedef proof_system::plonk::stdlib::packed_byte_array<proof_system::UltraCircuitBuilder> packed_byte_array_pt;
+    typedef bb::plonk::stdlib::field_t<bb::UltraCircuitBuilder> field_pt;
+    typedef bb::plonk::stdlib::packed_byte_array<bb::UltraCircuitBuilder> packed_byte_array_pt;
 
-    auto builder = proof_system::UltraCircuitBuilder();
+    auto builder = bb::UltraCircuitBuilder();
 
     packed_byte_array_pt input(&builder, "abc");
-    packed_byte_array_pt output_bytes = proof_system::plonk::stdlib::sha256(input);
+    packed_byte_array_pt output_bytes = bb::plonk::stdlib::sha256(input);
     std::vector<field_pt> output = output_bytes.to_unverified_byte_slices(4);
     EXPECT_EQ(uint256_t(output[0].get_value()).data[0], (uint64_t)0xBA7816BFU);
     EXPECT_EQ(uint256_t(output[1].get_value()).data[0], (uint64_t)0x8F01CFEAU);
@@ -225,14 +225,14 @@ TEST(stdlib_sha256, test_NIST_vector_one_packed_byte_array)
 
 TEST(stdlib_sha256, test_NIST_vector_one)
 {
-    typedef proof_system::plonk::stdlib::field_t<proof_system::UltraCircuitBuilder> field_pt;
-    typedef proof_system::plonk::stdlib::packed_byte_array<proof_system::UltraCircuitBuilder> packed_byte_array_pt;
+    typedef bb::plonk::stdlib::field_t<bb::UltraCircuitBuilder> field_pt;
+    typedef bb::plonk::stdlib::packed_byte_array<bb::UltraCircuitBuilder> packed_byte_array_pt;
 
-    auto builder = proof_system::UltraCircuitBuilder();
+    auto builder = bb::UltraCircuitBuilder();
 
     packed_byte_array_pt input(&builder, "abc");
 
-    packed_byte_array_pt output_bits = proof_system::plonk::stdlib::sha256(input);
+    packed_byte_array_pt output_bits = bb::plonk::stdlib::sha256(input);
 
     std::vector<field_pt> output = output_bits.to_unverified_byte_slices(4);
 
@@ -256,7 +256,7 @@ TEST(stdlib_sha256, test_NIST_vector_two)
 
     byte_array_ct input(&builder, "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
 
-    byte_array_ct output_bits = proof_system::plonk::stdlib::sha256<Builder>(input);
+    byte_array_ct output_bits = bb::plonk::stdlib::sha256<Builder>(input);
 
     std::vector<field_ct> output = packed_byte_array_ct(output_bits).to_unverified_byte_slices(4);
 
@@ -281,7 +281,7 @@ TEST(stdlib_sha256, test_NIST_vector_three)
     // one byte, 0xbd
     byte_array_ct input(&builder, std::vector<uint8_t>{ 0xbd });
 
-    byte_array_ct output_bits = proof_system::plonk::stdlib::sha256<Builder>(input);
+    byte_array_ct output_bits = bb::plonk::stdlib::sha256<Builder>(input);
 
     std::vector<field_ct> output = packed_byte_array_ct(output_bits).to_unverified_byte_slices(4);
 
@@ -306,7 +306,7 @@ TEST(stdlib_sha256, test_NIST_vector_four)
     // 4 bytes, 0xc98c8e55
     byte_array_ct input(&builder, std::vector<uint8_t>{ 0xc9, 0x8c, 0x8e, 0x55 });
 
-    byte_array_ct output_bits = proof_system::plonk::stdlib::sha256<Builder>(input);
+    byte_array_ct output_bits = bb::plonk::stdlib::sha256<Builder>(input);
 
     std::vector<field_ct> output = packed_byte_array_ct(output_bits).to_unverified_byte_slices(4);
 
@@ -327,10 +327,10 @@ TEST(stdlib_sha256, test_NIST_vector_four)
 
 HEAVY_TEST(stdlib_sha256, test_NIST_vector_five)
 {
-    typedef proof_system::plonk::stdlib::field_t<proof_system::UltraCircuitBuilder> field_pt;
-    typedef proof_system::plonk::stdlib::packed_byte_array<proof_system::UltraCircuitBuilder> packed_byte_array_pt;
+    typedef bb::plonk::stdlib::field_t<bb::UltraCircuitBuilder> field_pt;
+    typedef bb::plonk::stdlib::packed_byte_array<bb::UltraCircuitBuilder> packed_byte_array_pt;
 
-    auto builder = proof_system::UltraCircuitBuilder();
+    auto builder = bb::UltraCircuitBuilder();
 
     packed_byte_array_pt input(
         &builder,
@@ -345,7 +345,7 @@ HEAVY_TEST(stdlib_sha256, test_NIST_vector_five)
         "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
         "AAAAAAAAAA");
 
-    packed_byte_array_pt output_bits = proof_system::plonk::stdlib::sha256<proof_system::UltraCircuitBuilder>(input);
+    packed_byte_array_pt output_bits = bb::plonk::stdlib::sha256<bb::UltraCircuitBuilder>(input);
 
     std::vector<field_pt> output = output_bits.to_unverified_byte_slices(4);
 
@@ -374,7 +374,7 @@ TEST(stdlib_sha256, test_input_len_multiple)
         auto input_buf = std::vector<uint8_t>(inp, 1);
 
         byte_array_ct input(&builder, input_buf);
-        byte_array_ct output_bits = proof_system::plonk::stdlib::sha256<Builder>(input);
+        byte_array_ct output_bits = bb::plonk::stdlib::sha256<Builder>(input);
 
         auto circuit_output = output_bits.get_value();
 
@@ -418,7 +418,7 @@ TEST(stdlib_sha256, test_input_str_len_multiple)
         auto input_buf = std::vector<uint8_t>(input_str.begin(), input_str.end());
 
         byte_array_ct input(&builder, input_buf);
-        byte_array_ct output_bits = proof_system::plonk::stdlib::sha256<Builder>(input);
+        byte_array_ct output_bits = bb::plonk::stdlib::sha256<Builder>(input);
 
         auto circuit_output = output_bits.get_value();
 
@@ -428,4 +428,4 @@ TEST(stdlib_sha256, test_input_str_len_multiple)
     }
 }
 
-} // namespace proof_system::test_stdlib_sha256
+} // namespace bb::test_stdlib_sha256

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.cpp
@@ -9,7 +9,7 @@
 
 using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace sha256_plookup {
 
@@ -363,10 +363,9 @@ template <typename Builder> packed_byte_array<Builder> sha256(const packed_byte_
     return packed_byte_array<Builder>(output, 4);
 }
 
-template packed_byte_array<proof_system::UltraCircuitBuilder> sha256(
-    const packed_byte_array<proof_system::UltraCircuitBuilder>& input);
-template packed_byte_array<proof_system::GoblinUltraCircuitBuilder> sha256(
-    const packed_byte_array<proof_system::GoblinUltraCircuitBuilder>& input);
+template packed_byte_array<bb::UltraCircuitBuilder> sha256(const packed_byte_array<bb::UltraCircuitBuilder>& input);
+template packed_byte_array<bb::GoblinUltraCircuitBuilder> sha256(
+    const packed_byte_array<bb::GoblinUltraCircuitBuilder>& input);
 } // namespace sha256_plookup
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.hpp
@@ -9,7 +9,7 @@
 #include "../../primitives/field/field.hpp"
 #include "../../primitives/packed_byte_array/packed_byte_array.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace sha256_plookup {
 
@@ -87,4 +87,4 @@ std::array<field_t<Builder>, 8> sha256_block(const std::array<field_t<Builder>, 
 template <typename Builder> packed_byte_array<Builder> sha256(const packed_byte_array<Builder>& input);
 } // namespace sha256_plookup
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/hash.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/hash.hpp
@@ -8,7 +8,7 @@
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include <vector>
 
-namespace proof_system::plonk::stdlib::merkle_tree {
+namespace bb::plonk::stdlib::merkle_tree {
 
 inline bb::fr hash_pair_native(bb::fr const& lhs, bb::fr const& rhs)
 {
@@ -63,4 +63,4 @@ inline std::vector<bb::fr> compute_tree_native(std::vector<bb::fr> const& input)
     return tree;
 }
 
-} // namespace proof_system::plonk::stdlib::merkle_tree
+} // namespace bb::plonk::stdlib::merkle_tree

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/hash.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/hash.test.cpp
@@ -5,12 +5,12 @@
 #include "barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp"
 #include "barretenberg/stdlib/merkle_tree/membership.hpp"
 
-namespace proof_system::stdlib_merkle_tree_hash_test {
+namespace bb::stdlib_merkle_tree_hash_test {
 
 using namespace bb;
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 
-using Builder = proof_system::UltraCircuitBuilder;
+using Builder = bb::UltraCircuitBuilder;
 
 using field_ct = field_t<Builder>;
 using witness_ct = witness_t<Builder>;
@@ -64,4 +64,4 @@ TEST(stdlib_merkle_tree_hash, compute_tree_native)
     }
     EXPECT_EQ(tree_vector.back(), mem_tree.root());
 }
-} // namespace proof_system::stdlib_merkle_tree_hash_test
+} // namespace bb::stdlib_merkle_tree_hash_test

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/hash_path.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/hash_path.hpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <vector>
 
-namespace proof_system::plonk::stdlib::merkle_tree {
+namespace bb::plonk::stdlib::merkle_tree {
 
 using namespace bb;
 
@@ -61,13 +61,13 @@ inline fr zero_hash_at_height(size_t height)
     return current;
 }
 
-} // namespace proof_system::plonk::stdlib::merkle_tree
+} // namespace bb::plonk::stdlib::merkle_tree
 
 // We add to std namespace as fr_hash_path is actually a std::vector, and this is the only way
 // to achieve effective ADL.
 namespace std {
 template <typename Ctx>
-inline std::ostream& operator<<(std::ostream& os, proof_system::plonk::stdlib::merkle_tree::hash_path<Ctx> const& path)
+inline std::ostream& operator<<(std::ostream& os, bb::plonk::stdlib::merkle_tree::hash_path<Ctx> const& path)
 {
     os << "[\n";
     for (size_t i = 0; i < path.size(); ++i) {
@@ -77,7 +77,7 @@ inline std::ostream& operator<<(std::ostream& os, proof_system::plonk::stdlib::m
     return os;
 }
 
-inline std::ostream& operator<<(std::ostream& os, proof_system::plonk::stdlib::merkle_tree::fr_hash_path const& path)
+inline std::ostream& operator<<(std::ostream& os, bb::plonk::stdlib::merkle_tree::fr_hash_path const& path)
 {
     os << "[\n";
     for (size_t i = 0; i < path.size(); ++i) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/membership.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/membership.hpp
@@ -4,9 +4,7 @@
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include "hash_path.hpp"
 
-namespace proof_system::plonk {
-namespace stdlib {
-namespace merkle_tree {
+namespace bb::plonk::stdlib::merkle_tree {
 
 template <typename Builder> using bit_vector = std::vector<bool_t<Builder>>;
 /**
@@ -316,6 +314,4 @@ void batch_update_membership(field_t<Builder> const& new_root,
         new_root, rollup_root, old_root, old_path, zero_subtree_root, start_index.decompose_into_bits(), height, msg);
 }
 
-} // namespace merkle_tree
-} // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk::stdlib::merkle_tree

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/membership.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/membership.test.cpp
@@ -11,13 +11,13 @@ namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
 
-namespace proof_system::stdlib_merkle_test {
+namespace bb::stdlib_merkle_test {
 
 using namespace bb;
-using namespace proof_system::plonk::stdlib::merkle_tree;
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib::merkle_tree;
+using namespace bb::plonk::stdlib;
 
-using Builder = proof_system::UltraCircuitBuilder;
+using Builder = bb::UltraCircuitBuilder;
 
 using bool_ct = bool_t<Builder>;
 using field_ct = field_t<Builder>;
@@ -247,4 +247,4 @@ TEST(stdlib_merkle_tree, test_update_memberships)
     bool result = builder.check_circuit();
     EXPECT_EQ(result, true);
 }
-} // namespace proof_system::stdlib_merkle_test
+} // namespace bb::stdlib_merkle_test

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/memory_store.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/memory_store.hpp
@@ -4,7 +4,7 @@
 #include <map>
 #include <set>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace merkle_tree {
 
@@ -88,4 +88,4 @@ class MemoryStore {
 
 } // namespace merkle_tree
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/memory_tree.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/memory_tree.cpp
@@ -1,9 +1,7 @@
 #include "memory_tree.hpp"
 #include "hash.hpp"
 
-namespace proof_system::plonk {
-namespace stdlib {
-namespace merkle_tree {
+namespace bb::plonk::stdlib::merkle_tree {
 
 MemoryTree::MemoryTree(size_t depth)
     : depth_(depth)
@@ -76,6 +74,4 @@ fr MemoryTree::update_element(size_t index, fr const& value)
     return root_;
 }
 
-} // namespace merkle_tree
-} // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk::stdlib::merkle_tree

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/memory_tree.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/memory_tree.hpp
@@ -1,9 +1,7 @@
 #pragma once
 #include "hash_path.hpp"
 
-namespace proof_system::plonk {
-namespace stdlib {
-namespace merkle_tree {
+namespace bb::plonk::stdlib::merkle_tree {
 
 using namespace bb;
 
@@ -43,6 +41,4 @@ class MemoryTree {
     std::vector<bb::fr> hashes_;
 };
 
-} // namespace merkle_tree
-} // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk::stdlib::merkle_tree

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/memory_tree.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/memory_tree.test.cpp
@@ -2,7 +2,7 @@
 #include <gtest/gtest.h>
 
 using namespace bb;
-using namespace proof_system::plonk::stdlib::merkle_tree;
+using namespace bb::plonk::stdlib::merkle_tree;
 
 static std::vector<fr> VALUES = []() {
     std::vector<fr> values(4);

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/merkle_tree.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/merkle_tree.bench.cpp
@@ -5,7 +5,7 @@
 #include <benchmark/benchmark.h>
 
 using namespace benchmark;
-using namespace proof_system::plonk::stdlib::merkle_tree;
+using namespace bb::plonk::stdlib::merkle_tree;
 
 namespace {
 auto& engine = numeric::random::get_debug_engine();

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/merkle_tree.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/merkle_tree.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 #include <sstream>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace merkle_tree {
 
@@ -355,4 +355,4 @@ template class MerkleTree<MemoryStore>;
 
 } // namespace merkle_tree
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/merkle_tree.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/merkle_tree.hpp
@@ -2,7 +2,7 @@
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include "hash_path.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace merkle_tree {
 
@@ -99,4 +99,4 @@ template <typename Store> class MerkleTree {
 
 } // namespace merkle_tree
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/merkle_tree.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/merkle_tree.test.cpp
@@ -5,12 +5,12 @@
 #include "memory_store.hpp"
 #include "memory_tree.hpp"
 
-namespace proof_system::test_stdlib_merkle_tree {
+namespace bb::test_stdlib_merkle_tree {
 
-using namespace proof_system::plonk::stdlib;
-using namespace proof_system::plonk::stdlib::merkle_tree;
+using namespace bb::plonk::stdlib;
+using namespace bb::plonk::stdlib::merkle_tree;
 
-using Builder = proof_system::UltraCircuitBuilder;
+using Builder = bb::UltraCircuitBuilder;
 
 using field_ct = field_t<Builder>;
 using witness_ct = witness_t<Builder>;
@@ -184,4 +184,4 @@ TEST(stdlib_merkle_tree, test_get_sibling_path_layers)
         EXPECT_NE(before[2], after[2]);
     }
 }
-} // namespace proof_system::test_stdlib_merkle_tree
+} // namespace bb::test_stdlib_merkle_tree

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_leaf.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_leaf.hpp
@@ -2,7 +2,7 @@
 #include "barretenberg/crypto/pedersen_commitment/pedersen.hpp"
 #include "barretenberg/serialize/msgpack.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace merkle_tree {
 
@@ -115,4 +115,4 @@ inline std::pair<size_t, bool> find_closest_leaf(std::vector<WrappedNullifierLea
 
 } // namespace merkle_tree
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.cpp
@@ -1,7 +1,7 @@
 #include "nullifier_memory_tree.hpp"
 #include "../hash.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace merkle_tree {
 
@@ -74,4 +74,4 @@ fr NullifierMemoryTree::update_element(fr const& value)
 
 } // namespace merkle_tree
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp
@@ -3,7 +3,7 @@
 #include "../memory_tree.hpp"
 #include "nullifier_leaf.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace merkle_tree {
 
@@ -95,4 +95,4 @@ class NullifierMemoryTree : public MemoryTree {
 
 } // namespace merkle_tree
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_memory_tree.test.cpp
@@ -2,7 +2,7 @@
 #include <gtest/gtest.h>
 
 using namespace bb;
-using namespace proof_system::plonk::stdlib::merkle_tree;
+using namespace bb::plonk::stdlib::merkle_tree;
 
 void print_tree(const size_t depth, std::vector<fr> hashes, std::string const& msg)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 #include <sstream>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace merkle_tree {
 
@@ -87,4 +87,4 @@ template class NullifierTree<MemoryStore>;
 
 } // namespace merkle_tree
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.hpp
@@ -3,7 +3,7 @@
 #include "../merkle_tree.hpp"
 #include "nullifier_leaf.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace merkle_tree {
 
@@ -40,4 +40,4 @@ template <typename Store> class NullifierTree : public MerkleTree<Store> {
 
 } // namespace merkle_tree
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merkle_tree/nullifier_tree/nullifier_tree.test.cpp
@@ -6,7 +6,7 @@
 #include "nullifier_memory_tree.hpp"
 
 using namespace bb;
-using namespace proof_system::plonk::stdlib::merkle_tree;
+using namespace bb::plonk::stdlib::merkle_tree;
 
 namespace {
 auto& engine = numeric::random::get_debug_engine();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/address/address.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/address/address.hpp
@@ -6,7 +6,7 @@
 #include "barretenberg/stdlib/primitives/group/cycle_group.hpp"
 #include "barretenberg/stdlib/primitives/witness/witness.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 using bb::fr;
@@ -144,4 +144,4 @@ template <typename Builder> class address_t {
 };
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.fuzzer.hpp
@@ -121,11 +121,11 @@ FastRandom VarianceRNG(0);
  */
 template <typename Builder> class BigFieldBase {
   private:
-    typedef proof_system::plonk::stdlib::bool_t<Builder> bool_t;
-    typedef proof_system::plonk::stdlib::field_t<Builder> field_t;
-    typedef proof_system::plonk::stdlib::witness_t<Builder> witness_t;
-    typedef proof_system::plonk::stdlib::public_witness_t<Builder> public_witness_t;
-    typedef proof_system::plonk::stdlib::bigfield<Builder, bb::Bn254FqParams> bigfield_t;
+    typedef bb::plonk::stdlib::bool_t<Builder> bool_t;
+    typedef bb::plonk::stdlib::field_t<Builder> field_t;
+    typedef bb::plonk::stdlib::witness_t<Builder> witness_t;
+    typedef bb::plonk::stdlib::public_witness_t<Builder> public_witness_t;
+    typedef bb::plonk::stdlib::bigfield<Builder, bb::Bn254FqParams> bigfield_t;
 
   public:
     /**
@@ -1930,7 +1930,7 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
  */
 extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* Data, size_t Size, size_t MaxSize, unsigned int Seed)
 {
-    using FuzzerClass = BigFieldBase<proof_system::StandardCircuitBuilder>;
+    using FuzzerClass = BigFieldBase<bb::StandardCircuitBuilder>;
     auto fast_random = FastRandom(Seed);
     auto size_occupied = ArithmeticFuzzHelper<FuzzerClass>::MutateInstructionBuffer(Data, Size, MaxSize, fast_random);
     if ((fast_random.next() % 200) < fuzzer_havoc_settings.GEN_LLVM_POST_MUTATION_PROB) {
@@ -1951,7 +1951,7 @@ extern "C" size_t LLVMFuzzerCustomCrossOver(const uint8_t* Data1,
                                             size_t MaxOutSize,
                                             unsigned int Seed)
 {
-    using FuzzerClass = BigFieldBase<proof_system::StandardCircuitBuilder>;
+    using FuzzerClass = BigFieldBase<bb::StandardCircuitBuilder>;
     auto fast_random = FastRandom(Seed);
     auto vecA = ArithmeticFuzzHelper<FuzzerClass>::parseDataIntoInstructions(Data1, Size1);
     auto vecB = ArithmeticFuzzHelper<FuzzerClass>::parseDataIntoInstructions(Data2, Size2);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -11,7 +11,7 @@
 
 #include "../circuit_builders/circuit_builders_fwd.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder, typename T> class bigfield {
@@ -498,6 +498,6 @@ template <typename C, typename T> inline std::ostream& operator<<(std::ostream& 
 }
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk
 
 #include "bigfield_impl.hpp"

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -20,7 +20,7 @@
 
 namespace test_stdlib_bigfield {
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 /* A note regarding Plookup:
    stdlib_bigfield_plookup tests were present when this file was standardized
@@ -847,7 +847,7 @@ template <typename Builder> class stdlib_bigfield : public testing::Test {
 };
 
 // Define types for which the above tests will be constructed.
-typedef testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder> CircuitTypes;
+typedef testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder> CircuitTypes;
 // Define the suite of tests.
 TYPED_TEST_SUITE(stdlib_bigfield, CircuitTypes);
 TYPED_TEST(stdlib_bigfield, badmul)
@@ -979,7 +979,7 @@ TYPED_TEST(stdlib_bigfield, division_context)
 // // PLOOKUP TESTS
 // TEST(stdlib_bigfield_plookup, test_mul)
 // {
-//     plonk::UltraPlonkBuilder builder = proof_system::plonk::UltraPlonkBuilder();
+//     plonk::UltraPlonkBuilder builder = bb::plonk::UltraPlonkBuilder();
 //     size_t num_repetitions = 1;
 //     for (size_t i = 0; i < num_repetitions; ++i) {
 //         fq inputs[3]{ fq::random_element(), fq::random_element(), fq::random_element() };
@@ -1026,7 +1026,7 @@ TYPED_TEST(stdlib_bigfield, division_context)
 
 // TEST(stdlib_bigfield_plookup, test_sqr)
 // {
-//     plonk::UltraPlonkBuilder builder = proof_system::plonk::UltraPlonkBuilder();
+//     plonk::UltraPlonkBuilder builder = bb::plonk::UltraPlonkBuilder();
 //     size_t num_repetitions = 10;
 //     for (size_t i = 0; i < num_repetitions; ++i) {
 //         fq inputs[3]{ fq::random_element(), fq::random_element(), fq::random_element() };

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -11,7 +11,7 @@
 
 using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder, typename T>
@@ -2023,7 +2023,7 @@ void bigfield<Builder, T>::unsafe_evaluate_multiply_add(const bigfield& input_le
         };
         field_t<Builder> remainder_prime_limb = field_t<Builder>::accumulate(prime_limb_accumulator);
 
-        proof_system::non_native_field_witnesses<bb::fr> witnesses{
+        bb::non_native_field_witnesses<bb::fr> witnesses{
             {
                 left.binary_basis_limbs[0].element.normalize().witness_index,
                 left.binary_basis_limbs[1].element.normalize().witness_index,
@@ -2363,7 +2363,7 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
             }
 
             if (i > 0) {
-                proof_system::non_native_field_witnesses<bb::fr> mul_witnesses = {
+                bb::non_native_field_witnesses<bb::fr> mul_witnesses = {
                     {
                         left[i].binary_basis_limbs[0].element.normalize().witness_index,
                         left[i].binary_basis_limbs[1].element.normalize().witness_index,
@@ -2459,7 +2459,7 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
         };
         field_t<Builder> remainder_prime_limb = field_t<Builder>::accumulate(prime_limb_accumulator);
 
-        proof_system::non_native_field_witnesses<bb::fr> witnesses{
+        bb::non_native_field_witnesses<bb::fr> witnesses{
             {
                 left[0].binary_basis_limbs[0].element.normalize().witness_index,
                 left[0].binary_basis_limbs[1].element.normalize().witness_index,
@@ -2938,4 +2938,4 @@ std::pair<bool, size_t> bigfield<Builder, T>::get_quotient_reduction_info(const 
 }
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -16,7 +16,7 @@
 template <typename Builder, typename NativeGroup>
 concept IsNotGoblinInefficiencyTrap = !(IsGoblinBuilder<Builder> && std::same_as<NativeGroup, bb::g1>);
 
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 // ( ͡° ͜ʖ ͡°)
 template <class Builder, class Fq, class Fr, class NativeGroup> class element {
@@ -905,7 +905,7 @@ inline std::ostream& operator<<(std::ostream& os, element<C, Fq, Fr, G> const& v
 {
     return os << "{ " << v.x << " , " << v.y << " }";
 }
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib
 
 #include "biggroup_batch_mul.hpp"
 #include "biggroup_bn254.hpp"

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -14,7 +14,7 @@ namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 // One can only define a TYPED_TEST with a single template paramter.
 // Our workaround is to pass parameters of the following type.
@@ -819,9 +819,9 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
 };
 
 enum UseBigfield { No, Yes };
-using TestTypes = testing::Types<TestType<stdlib::bn254<proof_system::StandardCircuitBuilder>, UseBigfield::No>,
-                                 TestType<stdlib::bn254<proof_system::UltraCircuitBuilder>, UseBigfield::Yes>,
-                                 TestType<stdlib::bn254<proof_system::GoblinUltraCircuitBuilder>, UseBigfield::No>>;
+using TestTypes = testing::Types<TestType<stdlib::bn254<bb::StandardCircuitBuilder>, UseBigfield::No>,
+                                 TestType<stdlib::bn254<bb::UltraCircuitBuilder>, UseBigfield::Yes>,
+                                 TestType<stdlib::bn254<bb::GoblinUltraCircuitBuilder>, UseBigfield::No>>;
 
 TYPED_TEST_SUITE(stdlib_biggroup, TestTypes);
 
@@ -907,7 +907,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, multiple_montgomery_ladder)
 HEAVY_TYPED_TEST(stdlib_biggroup, compute_naf)
 {
     // ULTRATODO: make this work for secp curves
-    if constexpr (TypeParam::Curve::type == proof_system::CurveType::BN254) {
+    if constexpr (TypeParam::Curve::type == bb::CurveType::BN254) {
         size_t num_repetitions = 1;
         for (size_t i = 0; i < num_repetitions; i++) {
             TestFixture::test_compute_naf();
@@ -980,7 +980,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_batch_4)
 /* The following tests are specific to BN254 and don't work when Fr is a bigfield */
 HEAVY_TYPED_TEST(stdlib_biggroup, bn254_endo_batch_mul)
 {
-    if constexpr (TypeParam::Curve::type == proof_system::CurveType::BN254 && !TypeParam::use_bigfield) {
+    if constexpr (TypeParam::Curve::type == bb::CurveType::BN254 && !TypeParam::use_bigfield) {
         if constexpr (HasGoblinBuilder<TypeParam>) {
             GTEST_SKIP() << "https://github.com/AztecProtocol/barretenberg/issues/707";
         } else {
@@ -992,7 +992,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, bn254_endo_batch_mul)
 }
 HEAVY_TYPED_TEST(stdlib_biggroup, mixed_mul_bn254_endo)
 {
-    if constexpr (TypeParam::Curve::type == proof_system::CurveType::BN254 && !TypeParam::use_bigfield) {
+    if constexpr (TypeParam::Curve::type == bb::CurveType::BN254 && !TypeParam::use_bigfield) {
         if constexpr (HasGoblinBuilder<TypeParam>) {
             GTEST_SKIP() << "https://github.com/AztecProtocol/barretenberg/issues/707";
         } else {
@@ -1006,7 +1006,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, mixed_mul_bn254_endo)
 /* The following tests are specific to SECP256k1 */
 HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_secp256k1)
 {
-    if constexpr (TypeParam::Curve::type == proof_system::CurveType::SECP256K1) {
+    if constexpr (TypeParam::Curve::type == bb::CurveType::SECP256K1) {
         TestFixture::test_wnaf_secp256k1();
     } else {
         GTEST_SKIP();
@@ -1014,7 +1014,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_secp256k1)
 }
 HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_8bit_secp256k1)
 {
-    if constexpr (TypeParam::Curve::type == proof_system::CurveType::SECP256K1) {
+    if constexpr (TypeParam::Curve::type == bb::CurveType::SECP256K1) {
         TestFixture::test_wnaf_8bit_secp256k1();
     } else {
         GTEST_SKIP();
@@ -1022,7 +1022,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_8bit_secp256k1)
 }
 HEAVY_TYPED_TEST(stdlib_biggroup, ecdsa_mul_secp256k1)
 {
-    if constexpr (TypeParam::Curve::type == proof_system::CurveType::SECP256K1) {
+    if constexpr (TypeParam::Curve::type == bb::CurveType::SECP256K1) {
         TestFixture::test_ecdsa_mul_secp256k1();
     } else {
         GTEST_SKIP();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_batch_mul.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_batch_mul.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 /**
@@ -58,4 +58,4 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::wnaf_batch_mul(const std::vector<el
     return accumulator;
 }
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_bn254.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_bn254.hpp
@@ -7,7 +7,7 @@
  * We use a special case algorithm to split bn254 scalar multipliers into endomorphism scalars
  *
  **/
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 /**
@@ -424,4 +424,4 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::bn254_endo_batch_mul(const std::vec
     return accumulator;
 }
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 /**
@@ -93,4 +93,4 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::goblin_batch_mul(const std::vector<
 }
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.test.cpp
@@ -14,7 +14,7 @@ namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 template <typename Curve> class stdlib_biggroup_goblin : public testing::Test {
     using element_ct = typename Curve::Element;
@@ -77,7 +77,7 @@ template <typename Curve> class stdlib_biggroup_goblin : public testing::Test {
     }
 };
 
-using TestTypes = testing::Types<stdlib::bn254<proof_system::GoblinUltraCircuitBuilder>>;
+using TestTypes = testing::Types<stdlib::bn254<bb::GoblinUltraCircuitBuilder>>;
 
 TYPED_TEST_SUITE(stdlib_biggroup_goblin, TestTypes);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
@@ -5,7 +5,7 @@
 
 using namespace bb;
 
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 template <typename C, class Fq, class Fr, class G>
 element<C, Fq, Fr, G>::element()
@@ -730,4 +730,4 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::operator*(const Fr& scalar) const
         return element(out_x, out_y) - element(offset_generators.second);
     }
 }
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "barretenberg/ecc/curves/secp256k1/secp256k1.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 /**
@@ -568,4 +568,4 @@ std::vector<bool_t<C>> element<C, Fq, Fr, G>::compute_naf(const Fr& scalar, cons
     return naf_entries;
 }
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.hpp
@@ -5,7 +5,7 @@
  * TODO: we should try to genericize this, but this method is super fiddly and we need it to be efficient!
  *
  **/
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename C, class Fq, class Fr, class G>
@@ -141,4 +141,4 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::secp256k1_ecdsa_mul(const element& 
     return accumulator;
 }
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_tables.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_tables.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "barretenberg/proof_system/plookup_tables/types.hpp"
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 using plookup::MultiTableId;
@@ -644,4 +644,4 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::lookup_table_base<length>::get(
     return element::one(bits[0].get_context());
 }
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bit_array/bit_array.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bit_array/bit_array.cpp
@@ -3,7 +3,7 @@
 
 #include <bitset>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder>
@@ -157,9 +157,9 @@ template <typename Builder> std::string bit_array<Builder>::get_witness_as_strin
     return output;
 }
 
-template class bit_array<proof_system::StandardCircuitBuilder>;
-template class bit_array<proof_system::UltraCircuitBuilder>;
-template class bit_array<proof_system::GoblinUltraCircuitBuilder>;
+template class bit_array<bb::StandardCircuitBuilder>;
+template class bit_array<bb::UltraCircuitBuilder>;
+template class bit_array<bb::GoblinUltraCircuitBuilder>;
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bit_array/bit_array.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bit_array/bit_array.fuzzer.hpp
@@ -30,10 +30,10 @@ FastRandom VarianceRNG(0);
  */
 template <typename Builder> class BitArrayFuzzBase {
   private:
-    typedef proof_system::plonk::stdlib::bit_array<Builder> bit_array_t;
-    typedef proof_system::plonk::stdlib::byte_array<Builder> byte_array_t;
+    typedef bb::plonk::stdlib::bit_array<Builder> bit_array_t;
+    typedef bb::plonk::stdlib::byte_array<Builder> byte_array_t;
     template <size_t NumBytes, size_t NumWords>
-    static std::vector<uint8_t> to_vector(std::array<proof_system::plonk::stdlib::uint32<Builder>, NumWords>& a32)
+    static std::vector<uint8_t> to_vector(std::array<bb::plonk::stdlib::uint32<Builder>, NumWords>& a32)
     {
         /* Convert array of uint32_t to vector of uint8_t */
         std::vector<uint8_t> v(NumBytes);
@@ -60,7 +60,7 @@ template <typename Builder> class BitArrayFuzzBase {
              */
             return static_cast<byte_array_t>(bit_array).get_value();
         } else if (bit_array.size() - offset == NumBits) {
-            std::array<proof_system::plonk::stdlib::uint32<Builder>, NumWords> a32;
+            std::array<bb::plonk::stdlib::uint32<Builder>, NumWords> a32;
             bit_array.template populate_uint32_array<NumWords>(offset, a32);
             return to_vector<NumBytes, NumWords>(a32);
         } else {
@@ -92,7 +92,7 @@ template <typename Builder> class BitArrayFuzzBase {
              */
             return static_cast<byte_array_t>(bit_array).get_value();
         } else if (bit_array.size() == NumBits) {
-            std::array<proof_system::plonk::stdlib::uint32<Builder>, NumWords> a32;
+            std::array<bb::plonk::stdlib::uint32<Builder>, NumWords> a32;
 
             /* Switch between two different methods to retrieve the uint32 array */
             if (cast_or_populate) {
@@ -445,8 +445,7 @@ template <typename Builder> class BitArrayFuzzBase {
                 if (bit_array.size() == MAX_ARRAY_SIZE / 32) {
                     std::array<uint32_t, MAX_ARRAY_SIZE> a32;
                     const auto a32_ =
-                        static_cast<std::array<proof_system::plonk::stdlib::uint32<Builder>, MAX_ARRAY_SIZE>>(
-                            bit_array);
+                        static_cast<std::array<bb::plonk::stdlib::uint32<Builder>, MAX_ARRAY_SIZE>>(bit_array);
                     for (size_t i = 0; i < a32_.size(); i++) {
                         a32[i] = static_cast<uint32_t>(a32_[i].get_value());
                     }
@@ -883,7 +882,7 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
  */
 extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* Data, size_t Size, size_t MaxSize, unsigned int Seed)
 {
-    using FuzzerClass = BitArrayFuzzBase<proof_system::StandardCircuitBuilder>;
+    using FuzzerClass = BitArrayFuzzBase<bb::StandardCircuitBuilder>;
     auto fast_random = FastRandom(Seed);
     auto size_occupied = ArithmeticFuzzHelper<FuzzerClass>::MutateInstructionBuffer(Data, Size, MaxSize, fast_random);
     if ((fast_random.next() % 200) < fuzzer_havoc_settings.GEN_LLVM_POST_MUTATION_PROB) {
@@ -904,7 +903,7 @@ extern "C" size_t LLVMFuzzerCustomCrossOver(const uint8_t* Data1,
                                             size_t MaxOutSize,
                                             unsigned int Seed)
 {
-    using FuzzerClass = BitArrayFuzzBase<proof_system::StandardCircuitBuilder>;
+    using FuzzerClass = BitArrayFuzzBase<bb::StandardCircuitBuilder>;
     auto fast_random = FastRandom(Seed);
     auto vecA = ArithmeticFuzzHelper<FuzzerClass>::parseDataIntoInstructions(Data1, Size1);
     auto vecB = ArithmeticFuzzHelper<FuzzerClass>::parseDataIntoInstructions(Data2, Size2);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bit_array/bit_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bit_array/bit_array.hpp
@@ -3,7 +3,7 @@
 #include "../uint/uint.hpp"
 #include <algorithm>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder> class bit_array {
@@ -180,4 +180,4 @@ template <typename Builder> class bit_array {
 };
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bit_array/bit_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bit_array/bit_array.test.cpp
@@ -20,7 +20,7 @@
 namespace test_stdlib_bit_array {
 
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 namespace {
 auto& engine = numeric::random::get_debug_engine();
@@ -28,7 +28,7 @@ auto& engine = numeric::random::get_debug_engine();
 
 template <class Builder> class BitArrayTest : public ::testing::Test {};
 
-using CircuitTypes = ::testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder>;
+using CircuitTypes = ::testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder>;
 TYPED_TEST_SUITE(BitArrayTest, CircuitTypes);
 
 TYPED_TEST(BitArrayTest, test_uint32_input_output_consistency)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.cpp
@@ -2,9 +2,9 @@
 #include "../circuit_builders/circuit_builders.hpp"
 
 using namespace bb;
-using namespace proof_system;
+using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder>
@@ -548,9 +548,9 @@ template <typename Builder> bool_t<Builder> bool_t<Builder>::normalize() const
     return *this;
 }
 
-template class bool_t<proof_system::StandardCircuitBuilder>;
-template class bool_t<proof_system::UltraCircuitBuilder>;
-template class bool_t<proof_system::GoblinUltraCircuitBuilder>;
+template class bool_t<bb::StandardCircuitBuilder>;
+template class bool_t<bb::UltraCircuitBuilder>;
+template class bool_t<bb::GoblinUltraCircuitBuilder>;
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.fuzzer.hpp
@@ -27,8 +27,8 @@ FastRandom VarianceRNG(0);
  */
 template <typename Builder> class BoolFuzzBase {
   private:
-    typedef proof_system::plonk::stdlib::bool_t<Builder> bool_t;
-    typedef proof_system::plonk::stdlib::witness_t<Builder> witness_t;
+    typedef bb::plonk::stdlib::bool_t<Builder> bool_t;
+    typedef bb::plonk::stdlib::witness_t<Builder> witness_t;
 
   public:
     /**
@@ -801,7 +801,7 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
  */
 extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* Data, size_t Size, size_t MaxSize, unsigned int Seed)
 {
-    using FuzzerClass = BoolFuzzBase<proof_system::StandardCircuitBuilder>;
+    using FuzzerClass = BoolFuzzBase<bb::StandardCircuitBuilder>;
     auto fast_random = FastRandom(Seed);
     auto size_occupied = ArithmeticFuzzHelper<FuzzerClass>::MutateInstructionBuffer(Data, Size, MaxSize, fast_random);
     if ((fast_random.next() % 200) < fuzzer_havoc_settings.GEN_LLVM_POST_MUTATION_PROB) {
@@ -822,7 +822,7 @@ extern "C" size_t LLVMFuzzerCustomCrossOver(const uint8_t* Data1,
                                             size_t MaxOutSize,
                                             unsigned int Seed)
 {
-    using FuzzerClass = BoolFuzzBase<proof_system::StandardCircuitBuilder>;
+    using FuzzerClass = BoolFuzzBase<bb::StandardCircuitBuilder>;
     auto fast_random = FastRandom(Seed);
     auto vecA = ArithmeticFuzzHelper<FuzzerClass>::parseDataIntoInstructions(Data1, Size1);
     auto vecB = ArithmeticFuzzHelper<FuzzerClass>::parseDataIntoInstructions(Data2, Size2);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.hpp
@@ -2,7 +2,7 @@
 #include "../circuit_builders/circuit_builders_fwd.hpp"
 #include "../witness/witness.hpp"
 
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 template <typename Builder> class bool_t {
   public:
@@ -75,4 +75,4 @@ template <typename T> inline std::ostream& operator<<(std::ostream& os, bool_t<T
     return os << v.get_value();
 }
 
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.test.cpp
@@ -10,7 +10,7 @@
 
 namespace test_stdlib_bool {
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 namespace {
 auto& engine = numeric::random::get_debug_engine();
@@ -18,7 +18,7 @@ auto& engine = numeric::random::get_debug_engine();
 
 template <class Builder> class BoolTest : public ::testing::Test {};
 
-using CircuitTypes = ::testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder>;
+using CircuitTypes = ::testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder>;
 
 TYPED_TEST_SUITE(BoolTest, CircuitTypes);
 TYPED_TEST(BoolTest, TestBasicOperations)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.cpp
@@ -6,7 +6,7 @@
 
 using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 // ULTRA: Further merging with
@@ -380,9 +380,9 @@ typename byte_array<Builder>::byte_slice byte_array<Builder>::split_byte(const s
     return { low, scaled_high, bit };
 }
 
-template class byte_array<proof_system::StandardCircuitBuilder>;
-template class byte_array<proof_system::UltraCircuitBuilder>;
-template class byte_array<proof_system::GoblinUltraCircuitBuilder>;
+template class byte_array<bb::StandardCircuitBuilder>;
+template class byte_array<bb::UltraCircuitBuilder>;
+template class byte_array<bb::GoblinUltraCircuitBuilder>;
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.fuzzer.hpp
@@ -31,9 +31,9 @@ FastRandom VarianceRNG(0);
  */
 template <typename Builder> class ByteArrayFuzzBase {
   private:
-    typedef proof_system::plonk::stdlib::byte_array<Builder> byte_array_t;
-    typedef proof_system::plonk::stdlib::field_t<Builder> field_t;
-    typedef proof_system::plonk::stdlib::safe_uint_t<Builder> suint_t;
+    typedef bb::plonk::stdlib::byte_array<Builder> byte_array_t;
+    typedef bb::plonk::stdlib::field_t<Builder> field_t;
+    typedef bb::plonk::stdlib::safe_uint_t<Builder> suint_t;
 
     template <class From, class To> static To from_to(const From& in, const std::optional<size_t> size = std::nullopt)
     {
@@ -930,7 +930,7 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
  */
 extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* Data, size_t Size, size_t MaxSize, unsigned int Seed)
 {
-    using FuzzerClass = ByteArrayFuzzBase<proof_system::StandardCircuitBuilder>;
+    using FuzzerClass = ByteArrayFuzzBase<bb::StandardCircuitBuilder>;
     auto fast_random = FastRandom(Seed);
     auto size_occupied = ArithmeticFuzzHelper<FuzzerClass>::MutateInstructionBuffer(Data, Size, MaxSize, fast_random);
     if ((fast_random.next() % 200) < fuzzer_havoc_settings.GEN_LLVM_POST_MUTATION_PROB) {
@@ -951,7 +951,7 @@ extern "C" size_t LLVMFuzzerCustomCrossOver(const uint8_t* Data1,
                                             size_t MaxOutSize,
                                             unsigned int Seed)
 {
-    using FuzzerClass = ByteArrayFuzzBase<proof_system::StandardCircuitBuilder>;
+    using FuzzerClass = ByteArrayFuzzBase<bb::StandardCircuitBuilder>;
     auto fast_random = FastRandom(Seed);
     auto vecA = ArithmeticFuzzHelper<FuzzerClass>::parseDataIntoInstructions(Data1, Size1);
     auto vecB = ArithmeticFuzzHelper<FuzzerClass>::parseDataIntoInstructions(Data2, Size2);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.hpp
@@ -3,7 +3,7 @@
 #include "../circuit_builders/circuit_builders_fwd.hpp"
 #include "../field/field.hpp"
 #include "../safe_uint/safe_uint.hpp"
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder> class byte_array {
@@ -100,4 +100,4 @@ template <typename Builder> inline std::ostream& operator<<(std::ostream& os, by
     return os;
 }
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.test.cpp
@@ -9,7 +9,7 @@
 
 namespace test_stdlib_byte_array {
 using namespace bb;
-using namespace proof_system::plonk::stdlib;
+using namespace bb::plonk::stdlib;
 
 #define STDLIB_TYPE_ALIASES                                                                                            \
     using Builder = TypeParam;                                                                                         \
@@ -22,7 +22,7 @@ template <class Builder> class ByteArrayTest : public ::testing::Test {};
 
 template <class Builder> using byte_array_ct = byte_array<Builder>;
 
-using CircuitTypes = ::testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder>;
+using CircuitTypes = ::testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder>;
 TYPED_TEST_SUITE(ByteArrayTest, CircuitTypes);
 
 TYPED_TEST(ByteArrayTest, test_reverse)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp
@@ -8,11 +8,10 @@
 #include "barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp"
 
 template <typename T>
-concept HasPlookup =
-    proof_system::IsAnyOf<T, proof_system::UltraCircuitBuilder, proof_system::GoblinUltraCircuitBuilder>;
+concept HasPlookup = bb::IsAnyOf<T, bb::UltraCircuitBuilder, bb::GoblinUltraCircuitBuilder>;
 
 template <typename T>
-concept IsGoblinBuilder = proof_system::IsAnyOf<T, proof_system::GoblinUltraCircuitBuilder>;
+concept IsGoblinBuilder = bb::IsAnyOf<T, bb::GoblinUltraCircuitBuilder>;
 template <typename T>
 concept IsNotGoblinBuilder = !
 IsGoblinBuilder<T>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp
@@ -9,12 +9,12 @@ construction in stdlib and contains macros for explicit instantiation.
 #pragma once
 #include <concepts>
 
-namespace proof_system::honk {
+namespace bb::honk {
 namespace flavor {
 class Standard;
 class Ultra;
 } // namespace flavor
-} // namespace proof_system::honk
+} // namespace bb::honk
 
 namespace bb {
 class Bn254FrParams;
@@ -24,7 +24,7 @@ template <class Params> struct alignas(32) field;
 namespace arithmetization {
 template <typename FF_> class Ultra;
 } // namespace arithmetization
-namespace proof_system {
+namespace bb {
 template <class FF> class StandardCircuitBuilder_;
 using StandardCircuitBuilder = StandardCircuitBuilder_<bb::field<bb::Bn254FrParams>>;
 using StandardGrumpkinCircuitBuilder = StandardCircuitBuilder_<bb::field<bb::Bn254FqParams>>;
@@ -32,4 +32,4 @@ template <class Arithmetization> class UltraCircuitBuilder_;
 using UltraCircuitBuilder = UltraCircuitBuilder_<arithmetization::Ultra<bb::field<bb::Bn254FrParams>>>;
 template <class FF> class GoblinUltraCircuitBuilder_;
 using GoblinUltraCircuitBuilder = GoblinUltraCircuitBuilder_<bb::field<bb::Bn254FrParams>>;
-} // namespace proof_system
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/curves/bn254.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/curves/bn254.hpp
@@ -4,11 +4,11 @@
 #include "../field/field.hpp"
 #include "barretenberg/ecc/curves/types.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename CircuitBuilder> struct bn254 {
-    static constexpr proof_system::CurveType type = proof_system::CurveType::BN254;
+    static constexpr bb::CurveType type = bb::CurveType::BN254;
     // TODO(#673): This flag is temporary. It is needed in the verifier classes (GeminiVerifier, etc.) while these
     // classes are instantiated with "native" curve types. Eventually, the verifier classes will be instantiated only
     // with stdlib types, and "native" verification will be acheived via a simulated builder.
@@ -41,4 +41,4 @@ template <typename CircuitBuilder> struct bn254 {
 
 }; // namespace bn254
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/curves/secp256k1.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/curves/secp256k1.hpp
@@ -6,11 +6,11 @@
 
 #include "barretenberg/ecc/curves/secp256k1/secp256k1.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename CircuitType> struct secp256k1 {
-    static constexpr proof_system::CurveType type = proof_system::CurveType::SECP256K1;
+    static constexpr bb::CurveType type = bb::CurveType::SECP256K1;
 
     typedef ::secp256k1::fq fq;
     typedef ::secp256k1::fr fr;
@@ -30,4 +30,4 @@ template <typename CircuitType> struct secp256k1 {
     typedef element<Builder, fq_ct, bigfr_ct, g1> g1_bigfr_ct;
 };
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/curves/secp256r1.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/curves/secp256r1.hpp
@@ -6,11 +6,11 @@
 
 #include "barretenberg/ecc/curves/secp256r1/secp256r1.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename CircuitType> struct secp256r1 {
-    static constexpr proof_system::CurveType type = proof_system::CurveType::SECP256R1;
+    static constexpr bb::CurveType type = bb::CurveType::SECP256R1;
 
     typedef ::secp256r1::fq fq;
     typedef ::secp256r1::fr fr;
@@ -30,4 +30,4 @@ template <typename CircuitType> struct secp256r1 {
     typedef element<Builder, fq_ct, bigfr_ct, g1> g1_bigfr_ct;
 };
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/array.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/array.hpp
@@ -3,7 +3,7 @@
 #include "../safe_uint/safe_uint.hpp"
 #include "field.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 /**
@@ -176,4 +176,4 @@ void push_array_to_array(std::array<field_t<Builder>, size_1> const& source,
 }
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/array.test.cpp
@@ -15,7 +15,7 @@ auto& engine = numeric::random::get_debug_engine();
 template <class T> void ignore_unused(T&) {} // use to ignore unused variables in lambdas
 
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 template <typename Builder> class stdlib_array : public testing::Test {
     typedef stdlib::bool_t<Builder> bool_ct;
@@ -595,7 +595,7 @@ template <typename Builder> class stdlib_array : public testing::Test {
     }
 };
 
-typedef testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder> CircuitTypes;
+typedef testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder> CircuitTypes;
 
 TYPED_TEST_SUITE(stdlib_array, CircuitTypes);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
@@ -4,9 +4,9 @@
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 #include <functional>
 
-using namespace proof_system;
+using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder>
@@ -724,7 +724,7 @@ void field_t<Builder>::create_range_constraint(const size_t num_bits, std::strin
             if constexpr (HasPlookup<Builder>) {
                 context->decompose_into_default_range(normalize().get_witness_index(),
                                                       num_bits,
-                                                      proof_system::UltraCircuitBuilder::DEFAULT_PLOOKUP_RANGE_BITNUM,
+                                                      bb::UltraCircuitBuilder::DEFAULT_PLOOKUP_RANGE_BITNUM,
                                                       msg);
             } else {
                 context->decompose_into_base4_accumulators(normalize().get_witness_index(), num_bits, msg);
@@ -1140,9 +1140,9 @@ std::vector<bool_t<Builder>> field_t<Builder>::decompose_into_bits(
     return result;
 }
 
-template class field_t<proof_system::StandardCircuitBuilder>;
-template class field_t<proof_system::UltraCircuitBuilder>;
-template class field_t<proof_system::GoblinUltraCircuitBuilder>;
+template class field_t<bb::StandardCircuitBuilder>;
+template class field_t<bb::UltraCircuitBuilder>;
+template class field_t<bb::GoblinUltraCircuitBuilder>;
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.fuzzer.hpp
@@ -120,10 +120,10 @@ FastRandom VarianceRNG(0);
  */
 template <typename Builder> class FieldBase {
   private:
-    typedef proof_system::plonk::stdlib::bool_t<Builder> bool_t;
-    typedef proof_system::plonk::stdlib::field_t<Builder> field_t;
-    typedef proof_system::plonk::stdlib::witness_t<Builder> witness_t;
-    typedef proof_system::plonk::stdlib::public_witness_t<Builder> public_witness_t;
+    typedef bb::plonk::stdlib::bool_t<Builder> bool_t;
+    typedef bb::plonk::stdlib::field_t<Builder> field_t;
+    typedef bb::plonk::stdlib::witness_t<Builder> witness_t;
+    typedef bb::plonk::stdlib::public_witness_t<Builder> public_witness_t;
 
   public:
     /**
@@ -1017,8 +1017,8 @@ template <typename Builder> class FieldBase {
                  *
                  * TEST(stdlib_field, test_construct_via_bool_t)
                  * {
-                 *     proof_system::StandardCircuitBuilder builder =
-                 * proof_system::proof_system::StandardCircuitBuilder(); field_t a(witness_t(&builder,
+                 *     bb::StandardCircuitBuilder builder =
+                 * bb::bb::StandardCircuitBuilder(); field_t a(witness_t(&builder,
                  * fr(uint256_t{0xf396b678452ebf15, 0x82ae10893982638b, 0xdf185a29c65fbf80, 0x1d18b2de99e48308})));
                  * field_t b = a - a; field_t c(static_cast<bool_t>(b)); std::cout << c.get_value() << std::endl;
                  * }
@@ -1969,7 +1969,7 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
  */
 extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* Data, size_t Size, size_t MaxSize, unsigned int Seed)
 {
-    using FuzzerClass = FieldBase<proof_system::StandardCircuitBuilder>;
+    using FuzzerClass = FieldBase<bb::StandardCircuitBuilder>;
     auto fast_random = FastRandom(Seed);
     auto size_occupied = ArithmeticFuzzHelper<FuzzerClass>::MutateInstructionBuffer(Data, Size, MaxSize, fast_random);
     if ((fast_random.next() % 200) < fuzzer_havoc_settings.GEN_LLVM_POST_MUTATION_PROB) {
@@ -1990,7 +1990,7 @@ extern "C" size_t LLVMFuzzerCustomCrossOver(const uint8_t* Data1,
                                             size_t MaxOutSize,
                                             unsigned int Seed)
 {
-    using FuzzerClass = FieldBase<proof_system::StandardCircuitBuilder>;
+    using FuzzerClass = FieldBase<bb::StandardCircuitBuilder>;
     auto fast_random = FastRandom(Seed);
     auto vecA = ArithmeticFuzzHelper<FuzzerClass>::parseDataIntoInstructions(Data1, Size1);
     auto vecB = ArithmeticFuzzHelper<FuzzerClass>::parseDataIntoInstructions(Data2, Size2);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.hpp
@@ -4,7 +4,7 @@
 #include "barretenberg/common/assert.hpp"
 #include <functional>
 
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 template <typename Builder> class bool_t;
 template <typename Builder> class field_t {
@@ -424,4 +424,4 @@ template <typename Builder> inline std::ostream& operator<<(std::ostream& os, fi
 {
     return os << v.get_value();
 }
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
@@ -8,7 +8,7 @@
 #include <gtest/gtest.h>
 #include <utility>
 
-using namespace proof_system;
+using namespace bb;
 
 namespace test_stdlib_field {
 
@@ -19,7 +19,7 @@ auto& engine = numeric::random::get_debug_engine();
 template <class T> void ignore_unused(T&) {} // use to ignore unused variables in lambdas
 
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 template <typename Builder> class stdlib_field : public testing::Test {
     typedef stdlib::bool_t<Builder> bool_ct;
@@ -908,7 +908,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
     }
 };
 
-typedef testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder> CircuitTypes;
+typedef testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder> CircuitTypes;
 
 TYPED_TEST_SUITE(stdlib_field, CircuitTypes);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
@@ -5,7 +5,7 @@
 #include "./cycle_group.hpp"
 #include "barretenberg/proof_system/plookup_tables/types.hpp"
 #include "barretenberg/stdlib/primitives/plookup/plookup.hpp"
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 template <typename Composer>
 cycle_group<Composer>::cycle_group(Composer* _context)
@@ -211,7 +211,7 @@ cycle_group<Composer> cycle_group<Composer>::dbl() const
         return cycle_group(x3, y3, is_point_at_infinity().get_value());
     }
     cycle_group result(witness_t(context, x3), witness_t(context, y3), is_point_at_infinity());
-    context->create_ecc_dbl_gate(proof_system::ecc_dbl_gate_<FF>{
+    context->create_ecc_dbl_gate(bb::ecc_dbl_gate_<FF>{
         .x1 = x.get_witness_index(),
         .y1 = modified_y.normalize().get_witness_index(),
         .x3 = result.x.get_witness_index(),
@@ -282,7 +282,7 @@ cycle_group<Composer> cycle_group<Composer>::unconditional_add(const cycle_group
     field_t r_y(witness_t(context, p3.y));
     cycle_group result(r_x, r_y, false);
 
-    proof_system::ecc_add_gate_<FF> add_gate{
+    bb::ecc_add_gate_<FF> add_gate{
         .x1 = x.get_witness_index(),
         .y1 = y.get_witness_index(),
         .x2 = other.x.get_witness_index(),
@@ -334,7 +334,7 @@ cycle_group<Composer> cycle_group<Composer>::unconditional_subtract(const cycle_
         field_t r_y(witness_t(context, p3.y));
         cycle_group result(r_x, r_y, false);
 
-        proof_system::ecc_add_gate_<FF> add_gate{
+        bb::ecc_add_gate_<FF> add_gate{
             .x1 = x.get_witness_index(),
             .y1 = y.get_witness_index(),
             .x2 = other.x.get_witness_index(),
@@ -1358,8 +1358,8 @@ template <typename Composer> cycle_group<Composer> cycle_group<Composer>::operat
     throw_or_abort("Implementation under construction...");
 }
 
-template class cycle_group<proof_system::StandardCircuitBuilder>;
-template class cycle_group<proof_system::UltraCircuitBuilder>;
-template class cycle_group<proof_system::GoblinUltraCircuitBuilder>;
+template class cycle_group<bb::StandardCircuitBuilder>;
+template class cycle_group<bb::UltraCircuitBuilder>;
+template class cycle_group<bb::GoblinUltraCircuitBuilder>;
 
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
@@ -8,7 +8,7 @@
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include <optional>
 
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 template <typename Composer>
 concept IsUltraArithmetic = (Composer::CIRCUIT_TYPE == CircuitType::ULTRA);
@@ -233,4 +233,4 @@ inline std::ostream& operator<<(std::ostream& os, cycle_group<ComposerContext> c
 {
     return os << v.get_value();
 }
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
@@ -19,7 +19,7 @@
 
 namespace stdlib_cycle_group_tests {
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 namespace {
 auto& engine = numeric::random::get_debug_engine();
@@ -47,7 +47,7 @@ template <class Builder> class CycleGroupTest : public ::testing::Test {
     };
 };
 
-using CircuitTypes = ::testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder>;
+using CircuitTypes = ::testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder>;
 TYPED_TEST_SUITE(CycleGroupTest, CircuitTypes);
 
 TYPED_TEST(CycleGroupTest, TestDbl)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/logic/logic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/logic/logic.cpp
@@ -6,7 +6,7 @@
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include <cstddef>
 
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 /**
  * @brief A logical AND or XOR over a variable number of bits.
@@ -113,7 +113,7 @@ field_t<Builder> logic<Builder>::create_logic_constraint(
         return field_t<Builder>::from_witness_index(ctx, out_idx);
     }
 }
-template class logic<proof_system::StandardCircuitBuilder>;
-template class logic<proof_system::UltraCircuitBuilder>;
-template class logic<proof_system::GoblinUltraCircuitBuilder>;
-} // namespace proof_system::plonk::stdlib
+template class logic<bb::StandardCircuitBuilder>;
+template class logic<bb::UltraCircuitBuilder>;
+template class logic<bb::GoblinUltraCircuitBuilder>;
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/logic/logic.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/logic/logic.hpp
@@ -7,7 +7,7 @@
 #include <functional>
 #include <utility>
 
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 template <typename Builder> class logic {
   public:
@@ -27,4 +27,4 @@ template <typename Builder> class logic {
                 return std::make_pair(left_chunk, right_chunk);
             });
 };
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/logic/logic.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/logic/logic.test.cpp
@@ -25,11 +25,11 @@ auto& engine = numeric::random::get_debug_engine();
 template <class T> void ignore_unused(T&) {} // use to ignore unused variables in lambdas
 
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 template <class Builder> class LogicTest : public testing::Test {};
 
-using CircuitTypes = ::testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder>;
+using CircuitTypes = ::testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder>;
 
 TYPED_TEST_SUITE(LogicTest, CircuitTypes);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.cpp
@@ -3,7 +3,7 @@
 #include "../bool/bool.hpp"
 #include "../circuit_builders/circuit_builders.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 /**
@@ -273,7 +273,7 @@ template <typename Builder> void DynamicArray<Builder>::conditional_pop(const bo
     _length -= predicate;
 }
 
-template class DynamicArray<proof_system::UltraCircuitBuilder>;
-template class DynamicArray<proof_system::GoblinUltraCircuitBuilder>;
+template class DynamicArray<bb::UltraCircuitBuilder>;
+template class DynamicArray<bb::GoblinUltraCircuitBuilder>;
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "../circuit_builders/circuit_builders_fwd.hpp"
 #include "ram_table.hpp"
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 /**
@@ -48,4 +48,4 @@ template <typename Builder> class DynamicArray {
     mutable ram_table<Builder> _inner_table;
 };
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.test.cpp
@@ -9,14 +9,14 @@
 
 namespace test_stdlib_dynamic_array {
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 namespace {
 auto& engine = numeric::random::get_debug_engine();
 }
 
 // Defining ultra-specific types for local testing.
-using Builder = proof_system::UltraCircuitBuilder;
+using Builder = bb::UltraCircuitBuilder;
 using bool_ct = stdlib::bool_t<Builder>;
 using field_ct = stdlib::field_t<Builder>;
 using witness_ct = stdlib::witness_t<Builder>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.cpp
@@ -2,7 +2,7 @@
 
 #include "../circuit_builders/circuit_builders.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 /**
@@ -252,7 +252,7 @@ template <typename Builder> void ram_table<Builder>::write(const field_pt& index
     }
 }
 
-template class ram_table<proof_system::UltraCircuitBuilder>;
-template class ram_table<proof_system::GoblinUltraCircuitBuilder>;
+template class ram_table<bb::UltraCircuitBuilder>;
+template class ram_table<bb::GoblinUltraCircuitBuilder>;
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.hpp
@@ -2,7 +2,7 @@
 #include "../circuit_builders/circuit_builders_fwd.hpp"
 #include "../field/field.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 // A runtime-defined read-only memory table. Table entries must be initialized in the constructor.
@@ -57,4 +57,4 @@ template <typename Builder> class ram_table {
     mutable Builder* _context = nullptr;
 };
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.test.cpp
@@ -6,9 +6,9 @@
 
 namespace test_stdlib_ram_table {
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 // Defining ultra-specific types for local testing.
-using Builder = proof_system::UltraCircuitBuilder;
+using Builder = bb::UltraCircuitBuilder;
 using field_ct = stdlib::field_t<Builder>;
 using witness_ct = stdlib::witness_t<Builder>;
 using ram_table_ct = stdlib::ram_table<Builder>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
@@ -4,7 +4,7 @@
 
 using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder> rom_table<Builder>::rom_table(const std::vector<field_pt>& table_entries)
@@ -122,7 +122,7 @@ template <typename Builder> field_t<Builder> rom_table<Builder>::operator[](cons
     return field_pt::from_witness_index(context, output_idx);
 }
 
-template class rom_table<proof_system::UltraCircuitBuilder>;
-template class rom_table<proof_system::GoblinUltraCircuitBuilder>;
+template class rom_table<bb::UltraCircuitBuilder>;
+template class rom_table<bb::GoblinUltraCircuitBuilder>;
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.hpp
@@ -2,7 +2,7 @@
 #include "../circuit_builders/circuit_builders_fwd.hpp"
 #include "../field/field.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 // A runtime-defined read-only memory table. Table entries must be initialized in the constructor.
@@ -41,4 +41,4 @@ template <typename Builder> class rom_table {
     mutable Builder* context = nullptr;
 };
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.test.cpp
@@ -7,10 +7,10 @@
 
 namespace test_stdlib_rom_array {
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 // Defining ultra-specific types for local testing.
-using Builder = proof_system::UltraCircuitBuilder;
+using Builder = bb::UltraCircuitBuilder;
 using field_ct = stdlib::field_t<Builder>;
 using witness_ct = stdlib::witness_t<Builder>;
 using rom_table_ct = stdlib::rom_table<Builder>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
@@ -4,7 +4,7 @@
 
 using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder>
@@ -139,7 +139,7 @@ std::array<field_t<Builder>, 2> twin_rom_table<Builder>::operator[](const field_
     };
 }
 
-template class twin_rom_table<proof_system::UltraCircuitBuilder>;
-template class twin_rom_table<proof_system::GoblinUltraCircuitBuilder>;
+template class twin_rom_table<bb::UltraCircuitBuilder>;
+template class twin_rom_table<bb::GoblinUltraCircuitBuilder>;
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.hpp
@@ -2,7 +2,7 @@
 #include "../circuit_builders/circuit_builders_fwd.hpp"
 #include "../field/field.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 // A runtime-defined read-only memory table. Table entries must be initialized in the constructor.
@@ -43,4 +43,4 @@ template <typename Builder> class twin_rom_table {
     mutable Builder* context = nullptr;
 };
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/packed_byte_array/packed_byte_array.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/packed_byte_array/packed_byte_array.cpp
@@ -4,7 +4,7 @@
 
 using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 namespace {
@@ -266,9 +266,9 @@ template <typename Builder> std::string packed_byte_array<Builder>::get_value() 
     return bytes;
 }
 
-template class packed_byte_array<proof_system::StandardCircuitBuilder>;
-template class packed_byte_array<proof_system::UltraCircuitBuilder>;
-template class packed_byte_array<proof_system::GoblinUltraCircuitBuilder>;
+template class packed_byte_array<bb::StandardCircuitBuilder>;
+template class packed_byte_array<bb::UltraCircuitBuilder>;
+template class packed_byte_array<bb::GoblinUltraCircuitBuilder>;
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/packed_byte_array/packed_byte_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/packed_byte_array/packed_byte_array.hpp
@@ -4,7 +4,7 @@
 #include "../circuit_builders/circuit_builders_fwd.hpp"
 #include "../field/field.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder> class packed_byte_array {
@@ -64,4 +64,4 @@ template <typename Builder> inline std::ostream& operator<<(std::ostream& os, pa
     return os;
 }
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/packed_byte_array/packed_byte_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/packed_byte_array/packed_byte_array.test.cpp
@@ -9,7 +9,7 @@
 
 namespace test_stdlib_packed_byte_array {
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 namespace {
 auto& engine = numeric::random::get_debug_engine();
@@ -21,7 +21,7 @@ auto& engine = numeric::random::get_debug_engine();
 
 template <class Builder> class PackedByteArrayTest : public ::testing::Test {};
 
-using CircuitTypes = ::testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder>;
+using CircuitTypes = ::testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder>;
 TYPED_TEST_SUITE(PackedByteArrayTest, CircuitTypes);
 
 TYPED_TEST(PackedByteArrayTest, string_constructor_and_get_value_consistency)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/plookup/plookup.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/plookup/plookup.cpp
@@ -3,11 +3,11 @@
 #include "barretenberg/proof_system/plookup_tables/types.hpp"
 #include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 class UltraPlonkBuilder;
-} // namespace proof_system::plonk
+} // namespace bb::plonk
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 using plookup::ColumnIdx;
@@ -91,7 +91,7 @@ field_t<Builder> plookup_read<Builder>::read_from_1_to_2_table(const MultiTableI
     return lookup[ColumnIdx::C2][0];
 }
 
-template class plookup_read<proof_system::UltraCircuitBuilder>;
-template class plookup_read<proof_system::GoblinUltraCircuitBuilder>;
+template class plookup_read<bb::UltraCircuitBuilder>;
+template class plookup_read<bb::GoblinUltraCircuitBuilder>;
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/plookup/plookup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/plookup/plookup.hpp
@@ -6,7 +6,7 @@
 #include <array>
 #include <vector>
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder> class plookup_read {
@@ -26,4 +26,4 @@ template <typename Builder> class plookup_read {
                                                                const bool is_2_to_1_lookup = false);
 };
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/plookup/plookup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/plookup/plookup.test.cpp
@@ -11,14 +11,14 @@
 
 namespace test_stdlib_plookups {
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 using namespace plookup;
 
 // Defining ultra-specific types for local testing.
-using Builder = proof_system::UltraCircuitBuilder;
+using Builder = bb::UltraCircuitBuilder;
 using field_ct = stdlib::field_t<Builder>;
 using witness_ct = stdlib::witness_t<Builder>;
-using plookup_read = proof_system::plonk::stdlib::plookup_read<Builder>;
+using plookup_read = bb::plonk::stdlib::plookup_read<Builder>;
 namespace {
 auto& engine = numeric::random::get_debug_engine();
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.cpp
@@ -3,7 +3,7 @@
 #include "../circuit_builders/circuit_builders.hpp"
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder>
@@ -239,9 +239,9 @@ std::array<safe_uint_t<Builder>, 3> safe_uint_t<Builder>::slice(const uint8_t ms
     return result;
 }
 
-template class safe_uint_t<proof_system::StandardCircuitBuilder>;
-template class safe_uint_t<proof_system::UltraCircuitBuilder>;
-template class safe_uint_t<proof_system::GoblinUltraCircuitBuilder>;
+template class safe_uint_t<bb::StandardCircuitBuilder>;
+template class safe_uint_t<bb::UltraCircuitBuilder>;
+template class safe_uint_t<bb::GoblinUltraCircuitBuilder>;
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.fuzzer.hpp
@@ -110,11 +110,11 @@ FastRandom VarianceRNG(0);
  */
 template <typename Builder> class SafeUintFuzzBase {
   private:
-    typedef proof_system::plonk::stdlib::bool_t<Builder> bool_t;
-    typedef proof_system::plonk::stdlib::field_t<Builder> field_t;
-    typedef proof_system::plonk::stdlib::safe_uint_t<Builder> suint_t;
-    typedef proof_system::plonk::stdlib::witness_t<Builder> witness_t;
-    typedef proof_system::plonk::stdlib::public_witness_t<Builder> public_witness_t;
+    typedef bb::plonk::stdlib::bool_t<Builder> bool_t;
+    typedef bb::plonk::stdlib::field_t<Builder> field_t;
+    typedef bb::plonk::stdlib::safe_uint_t<Builder> suint_t;
+    typedef bb::plonk::stdlib::witness_t<Builder> witness_t;
+    typedef bb::plonk::stdlib::public_witness_t<Builder> public_witness_t;
 
   public:
     /**
@@ -1420,7 +1420,7 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
  */
 extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* Data, size_t Size, size_t MaxSize, unsigned int Seed)
 {
-    using FuzzerClass = SafeUintFuzzBase<proof_system::StandardCircuitBuilder>;
+    using FuzzerClass = SafeUintFuzzBase<bb::StandardCircuitBuilder>;
     auto fast_random = FastRandom(Seed);
     auto size_occupied = ArithmeticFuzzHelper<FuzzerClass>::MutateInstructionBuffer(Data, Size, MaxSize, fast_random);
     if ((fast_random.next() % 200) < fuzzer_havoc_settings.GEN_LLVM_POST_MUTATION_PROB) {
@@ -1441,7 +1441,7 @@ extern "C" size_t LLVMFuzzerCustomCrossOver(const uint8_t* Data1,
                                             size_t MaxOutSize,
                                             unsigned int Seed)
 {
-    using FuzzerClass = SafeUintFuzzBase<proof_system::StandardCircuitBuilder>;
+    using FuzzerClass = SafeUintFuzzBase<bb::StandardCircuitBuilder>;
     auto fast_random = FastRandom(Seed);
     auto vecA = ArithmeticFuzzHelper<FuzzerClass>::parseDataIntoInstructions(Data1, Size1);
     auto vecB = ArithmeticFuzzHelper<FuzzerClass>::parseDataIntoInstructions(Data2, Size2);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.hpp
@@ -11,7 +11,7 @@
 // Despite the name, it is *not* a "safe" version of the uint class - as operations are positive integer
 // operations, and not modulo 2^t for some t, as they are in the uint class.
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder> class safe_uint_t {
@@ -210,4 +210,4 @@ template <typename Builder> inline std::ostream& operator<<(std::ostream& os, sa
     return os << v.value;
 }
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.test.cpp
@@ -24,13 +24,13 @@ auto& engine = numeric::random::get_debug_engine();
 
 namespace test_stdlib_safe_uint {
 using namespace bb;
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 template <class T> void ignore_unused(T&) {} // use to ignore unused variables in lambdas
 
 template <class Builder> class SafeUintTest : public ::testing::Test {};
 
-using CircuitTypes = ::testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder>;
+using CircuitTypes = ::testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder>;
 TYPED_TEST_SUITE(SafeUintTest, CircuitTypes);
 
 // CONSTRUCTOR

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
@@ -2,9 +2,9 @@
 #include "uint.hpp"
 
 using namespace bb;
-using namespace proof_system;
+using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 /**
@@ -391,10 +391,10 @@ std::pair<uint<Builder, Native>, uint<Builder, Native>> uint<Builder, Native>::d
     return std::make_pair(quotient, remainder);
 }
 
-template class uint<proof_system::StandardCircuitBuilder, uint8_t>;
-template class uint<proof_system::StandardCircuitBuilder, uint16_t>;
-template class uint<proof_system::StandardCircuitBuilder, uint32_t>;
-template class uint<proof_system::StandardCircuitBuilder, uint64_t>;
+template class uint<bb::StandardCircuitBuilder, uint8_t>;
+template class uint<bb::StandardCircuitBuilder, uint16_t>;
+template class uint<bb::StandardCircuitBuilder, uint32_t>;
+template class uint<bb::StandardCircuitBuilder, uint64_t>;
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/comparison.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/comparison.cpp
@@ -3,7 +3,7 @@
 
 using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder, typename Native>
@@ -97,9 +97,9 @@ template <typename Builder, typename Native> bool_t<Builder> uint<Builder, Nativ
     return (field_t<Builder>(*this).is_zero()).normalize();
 }
 
-template class uint<proof_system::StandardCircuitBuilder, uint8_t>;
-template class uint<proof_system::StandardCircuitBuilder, uint16_t>;
-template class uint<proof_system::StandardCircuitBuilder, uint32_t>;
-template class uint<proof_system::StandardCircuitBuilder, uint64_t>;
+template class uint<bb::StandardCircuitBuilder, uint8_t>;
+template class uint<bb::StandardCircuitBuilder, uint16_t>;
+template class uint<bb::StandardCircuitBuilder, uint32_t>;
+template class uint<bb::StandardCircuitBuilder, uint64_t>;
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/logic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/logic.cpp
@@ -2,9 +2,9 @@
 #include "uint.hpp"
 
 using namespace bb;
-using namespace proof_system;
+using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder, typename Native>
@@ -523,10 +523,10 @@ uint<Builder, Native> uint<Builder, Native>::logic_operator(const uint& other, c
     return result;
 }
 
-template class uint<proof_system::StandardCircuitBuilder, uint8_t>;
-template class uint<proof_system::StandardCircuitBuilder, uint16_t>;
-template class uint<proof_system::StandardCircuitBuilder, uint32_t>;
-template class uint<proof_system::StandardCircuitBuilder, uint64_t>;
+template class uint<bb::StandardCircuitBuilder, uint8_t>;
+template class uint<bb::StandardCircuitBuilder, uint16_t>;
+template class uint<bb::StandardCircuitBuilder, uint32_t>;
+template class uint<bb::StandardCircuitBuilder, uint64_t>;
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/arithmetic.cpp
@@ -2,9 +2,9 @@
 #include "uint.hpp"
 
 using namespace bb;
-using namespace proof_system;
+using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder, typename Native>
@@ -256,14 +256,14 @@ std::pair<uint_plookup<Builder, Native>, uint_plookup<Builder, Native>> uint_plo
 
     return std::make_pair(quotient, remainder);
 }
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint8_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint8_t>;
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint16_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint16_t>;
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint32_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint32_t>;
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint64_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint64_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint8_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint8_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint16_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint16_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint32_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint32_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint64_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint64_t>;
 ;
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/comparison.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/comparison.cpp
@@ -3,7 +3,7 @@
 
 using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder, typename Native>
@@ -74,13 +74,13 @@ template <typename Builder, typename Native> bool_t<Builder> uint_plookup<Builde
     return (field_t<Builder>(*this).is_zero()).normalize();
 }
 
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint8_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint8_t>;
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint16_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint16_t>;
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint32_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint32_t>;
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint64_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint64_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint8_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint8_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint16_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint16_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint32_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint32_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint64_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint64_t>;
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/logic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/logic.cpp
@@ -3,7 +3,7 @@
 
 using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 using namespace plookup;
@@ -326,14 +326,14 @@ uint_plookup<Builder, Native> uint_plookup<Builder, Native>::logic_operator(cons
     return result;
 }
 
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint8_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint8_t>;
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint16_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint16_t>;
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint32_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint32_t>;
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint64_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint64_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint8_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint8_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint16_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint16_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint32_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint32_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint64_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint64_t>;
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/uint.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/uint.cpp
@@ -3,7 +3,7 @@
 
 using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder, typename Native>
@@ -240,14 +240,14 @@ bool_t<Builder> uint_plookup<Builder, Native>::at(const size_t bit_index) const
     return result;
 }
 
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint8_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint8_t>;
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint16_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint16_t>;
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint32_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint32_t>;
-template class uint_plookup<proof_system::UltraCircuitBuilder, uint64_t>;
-template class uint_plookup<proof_system::GoblinUltraCircuitBuilder, uint64_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint8_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint8_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint16_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint16_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint32_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint32_t>;
+template class uint_plookup<bb::UltraCircuitBuilder, uint64_t>;
+template class uint_plookup<bb::GoblinUltraCircuitBuilder, uint64_t>;
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/uint.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/plookup/uint.hpp
@@ -5,7 +5,7 @@
 #include "../../field/field.hpp"
 #include "../../plookup/plookup.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 template <typename Builder, typename Native> class uint_plookup {
@@ -173,4 +173,4 @@ template <typename T, typename w> inline std::ostream& operator<<(std::ostream& 
     return os << v.get_value();
 }
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
@@ -2,9 +2,9 @@
 #include "../circuit_builders/circuit_builders.hpp"
 
 using namespace bb;
-using namespace proof_system;
+using namespace bb;
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 /**
@@ -390,10 +390,10 @@ template <typename Builder, typename Native> bool_t<Builder> uint<Builder, Nativ
     return result;
 }
 
-template class uint<proof_system::StandardCircuitBuilder, uint8_t>;
-template class uint<proof_system::StandardCircuitBuilder, uint16_t>;
-template class uint<proof_system::StandardCircuitBuilder, uint32_t>;
-template class uint<proof_system::StandardCircuitBuilder, uint64_t>;
+template class uint<bb::StandardCircuitBuilder, uint8_t>;
+template class uint<bb::StandardCircuitBuilder, uint16_t>;
+template class uint<bb::StandardCircuitBuilder, uint32_t>;
+template class uint<bb::StandardCircuitBuilder, uint64_t>;
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.fuzzer.hpp
@@ -32,13 +32,13 @@ FastRandom VarianceRNG(0);
  */
 template <typename Builder> class UintFuzzBase {
   private:
-    typedef proof_system::plonk::stdlib::bool_t<Builder> bool_t;
-    typedef proof_system::plonk::stdlib::uint<Builder, uint8_t> uint_8_t;
-    typedef proof_system::plonk::stdlib::uint<Builder, uint16_t> uint_16_t;
-    typedef proof_system::plonk::stdlib::uint<Builder, uint32_t> uint_32_t;
-    typedef proof_system::plonk::stdlib::uint<Builder, uint64_t> uint_64_t;
-    typedef proof_system::plonk::stdlib::field_t<Builder> field_t;
-    typedef proof_system::plonk::stdlib::byte_array<Builder> byte_array_t;
+    typedef bb::plonk::stdlib::bool_t<Builder> bool_t;
+    typedef bb::plonk::stdlib::uint<Builder, uint8_t> uint_8_t;
+    typedef bb::plonk::stdlib::uint<Builder, uint16_t> uint_16_t;
+    typedef bb::plonk::stdlib::uint<Builder, uint32_t> uint_32_t;
+    typedef bb::plonk::stdlib::uint<Builder, uint64_t> uint_64_t;
+    typedef bb::plonk::stdlib::field_t<Builder> field_t;
+    typedef bb::plonk::stdlib::byte_array<Builder> byte_array_t;
 
     template <class From, class To> static To from_to(const From& in, const std::optional<size_t> size = std::nullopt)
     {
@@ -1547,7 +1547,7 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
  */
 extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* Data, size_t Size, size_t MaxSize, unsigned int Seed)
 {
-    using FuzzerClass = UintFuzzBase<proof_system::StandardCircuitBuilder>;
+    using FuzzerClass = UintFuzzBase<bb::StandardCircuitBuilder>;
     auto fast_random = FastRandom(Seed);
     auto size_occupied = ArithmeticFuzzHelper<FuzzerClass>::MutateInstructionBuffer(Data, Size, MaxSize, fast_random);
     if ((fast_random.next() % 200) < fuzzer_havoc_settings.GEN_LLVM_POST_MUTATION_PROB) {
@@ -1568,7 +1568,7 @@ extern "C" size_t LLVMFuzzerCustomCrossOver(const uint8_t* Data1,
                                             size_t MaxOutSize,
                                             unsigned int Seed)
 {
-    using FuzzerClass = UintFuzzBase<proof_system::StandardCircuitBuilder>;
+    using FuzzerClass = UintFuzzBase<bb::StandardCircuitBuilder>;
     auto fast_random = FastRandom(Seed);
     auto vecA = ArithmeticFuzzHelper<FuzzerClass>::parseDataIntoInstructions(Data1, Size1);
     auto vecB = ArithmeticFuzzHelper<FuzzerClass>::parseDataIntoInstructions(Data2, Size2);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.hpp
@@ -7,7 +7,7 @@
 
 #include "./plookup/uint.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 /**
@@ -202,4 +202,4 @@ using uint64 =
     typename std::conditional<HasPlookup<Builder>, uint_plookup<Builder, uint64_t>, uint<Builder, uint64_t>>::type;
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.test.cpp
@@ -4,8 +4,8 @@
 #include <gtest/gtest.h>
 
 using namespace bb;
-using namespace proof_system::plonk;
-using namespace proof_system;
+using namespace bb::plonk;
+using namespace bb;
 
 namespace {
 auto& engine = numeric::random::get_debug_engine();
@@ -1739,7 +1739,7 @@ template <typename Builder> class stdlib_uint : public testing::Test {
     }
 };
 
-typedef testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder> CircuitTypes;
+typedef testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder> CircuitTypes;
 
 TYPED_TEST_SUITE(stdlib_uint, CircuitTypes);
 
@@ -1916,10 +1916,10 @@ TYPED_TEST(stdlib_uint, test_at)
 // There was one plookup-specific test in the ./plookup/uint_plookup.test.cpp
 TEST(stdlib_uint32, test_accumulators_plookup_uint32)
 {
-    using uint32_ct = proof_system::plonk::stdlib::uint32<proof_system::UltraCircuitBuilder>;
-    using witness_ct = proof_system::plonk::stdlib::witness_t<proof_system::UltraCircuitBuilder>;
+    using uint32_ct = bb::plonk::stdlib::uint32<bb::UltraCircuitBuilder>;
+    using witness_ct = bb::plonk::stdlib::witness_t<bb::UltraCircuitBuilder>;
 
-    proof_system::UltraCircuitBuilder builder;
+    bb::UltraCircuitBuilder builder;
 
     uint32_t a_val = engine.get_random_uint32();
     uint32_t b_val = engine.get_random_uint32();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/witness/witness.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/witness/witness.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 
 // indicates whether a witness index actually contains a constant
@@ -82,4 +82,4 @@ template <typename Builder> class public_witness_t : public witness_t<Builder> {
 };
 
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/aggregation_state/aggregation_state.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/aggregation_state/aggregation_state.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "../../primitives/field/field.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace recursion {
 
@@ -109,4 +109,4 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, aggregation_s
 
 } // namespace recursion
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/aggregation_state/native_aggregation_state.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/aggregation_state/native_aggregation_state.hpp
@@ -3,7 +3,7 @@
 #include "barretenberg/ecc/curves/bn254/g1.hpp"
 #include "barretenberg/ecc/groups/affine_element.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace recursion {
 
@@ -41,4 +41,4 @@ inline std::ostream& operator<<(std::ostream& os, native_aggregation_state const
 
 } // namespace recursion
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/transcript/transcript.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/transcript/transcript.hpp
@@ -13,12 +13,12 @@
 #include "barretenberg/stdlib/utility/utility.hpp"
 
 // Note: this namespace will be sensible once stdlib is moved out of the plonk namespace
-namespace proof_system::plonk::stdlib::recursion::honk {
+namespace bb::plonk::stdlib::recursion::honk {
 template <typename Builder> class Transcript {
   public:
     using field_ct = field_t<Builder>;
     using FF = bb::fr;
-    using BaseTranscript = proof_system::honk::BaseTranscript;
+    using BaseTranscript = bb::honk::BaseTranscript;
     using StdlibTypes = utility::StdlibTypesUtility<Builder>;
 
     static constexpr size_t HASH_OUTPUT_SIZE = BaseTranscript::HASH_OUTPUT_SIZE;
@@ -101,4 +101,4 @@ template <typename Builder> class Transcript {
         return StdlibTypes::from_witness(builder, element);
     }
 };
-} // namespace proof_system::plonk::stdlib::recursion::honk
+} // namespace bb::plonk::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/transcript/transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/transcript/transcript.test.cpp
@@ -8,13 +8,13 @@
 #include "barretenberg/stdlib/recursion/honk/transcript/transcript.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::plonk::stdlib::recursion::honk {
+namespace bb::plonk::stdlib::recursion::honk {
 
 using Builder = UltraCircuitBuilder;
-using UltraFlavor = ::proof_system::honk::flavor::Ultra;
-using UltraRecursiveFlavor = ::proof_system::honk::flavor::UltraRecursive_<Builder>;
+using UltraFlavor = ::bb::honk::flavor::Ultra;
+using UltraRecursiveFlavor = ::bb::honk::flavor::UltraRecursive_<Builder>;
 using FF = bb::fr;
-using BaseTranscript = ::proof_system::honk::BaseTranscript;
+using BaseTranscript = ::bb::honk::BaseTranscript;
 
 /**
  * @brief Create some mock data; add it to the provided prover transcript in various mock rounds
@@ -176,4 +176,4 @@ TEST(RecursiveHonkTranscript, ReturnValuesMatch)
     EXPECT_EQ(static_cast<FF>(native_alpha), stdlib_alpha.get_value());
     EXPECT_EQ(static_cast<FF>(native_beta), stdlib_beta.get_value());
 }
-} // namespace proof_system::plonk::stdlib::recursion::honk
+} // namespace bb::plonk::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/goblin_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/goblin_verifier.test.cpp
@@ -7,7 +7,7 @@
 #include "barretenberg/ultra_honk/ultra_composer.hpp"
 #include "barretenberg/ultra_honk/ultra_verifier.hpp"
 
-namespace proof_system::plonk::stdlib::recursion::honk {
+namespace bb::plonk::stdlib::recursion::honk {
 
 /**
  * @brief Test suite for recursive verification of Goblin Ultra Honk proofs
@@ -19,10 +19,10 @@ namespace proof_system::plonk::stdlib::recursion::honk {
 template <typename BuilderType> class GoblinRecursiveVerifierTest : public testing::Test {
 
     // Define types relevant for testing
-    using UltraFlavor = ::proof_system::honk::flavor::Ultra;
-    using GoblinUltraFlavor = ::proof_system::honk::flavor::GoblinUltra;
-    using UltraComposer = ::proof_system::honk::UltraComposer_<UltraFlavor>;
-    using GoblinUltraComposer = ::proof_system::honk::UltraComposer_<GoblinUltraFlavor>;
+    using UltraFlavor = ::bb::honk::flavor::Ultra;
+    using GoblinUltraFlavor = ::bb::honk::flavor::GoblinUltra;
+    using UltraComposer = ::bb::honk::UltraComposer_<UltraFlavor>;
+    using GoblinUltraComposer = ::bb::honk::UltraComposer_<GoblinUltraFlavor>;
 
     // Define types for the inner circuit, i.e. the circuit whose proof will be recursively verified
     using InnerFlavor = GoblinUltraFlavor;
@@ -34,7 +34,7 @@ template <typename BuilderType> class GoblinRecursiveVerifierTest : public testi
 
     // Types for recursive verifier circuit
     using OuterBuilder = BuilderType;
-    using RecursiveFlavor = ::proof_system::honk::flavor::GoblinUltraRecursive_<OuterBuilder>;
+    using RecursiveFlavor = ::bb::honk::flavor::GoblinUltraRecursive_<OuterBuilder>;
     using RecursiveVerifier = UltraRecursiveVerifier_<RecursiveFlavor>;
     using VerificationKey = typename RecursiveVerifier::VerificationKey;
 
@@ -279,4 +279,4 @@ HEAVY_TYPED_TEST(GoblinRecursiveVerifierTest, SingleRecursiveVerificationFailure
     TestFixture::test_recursive_verification_fails();
 };
 
-} // namespace proof_system::plonk::stdlib::recursion::honk
+} // namespace bb::plonk::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/merge_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/merge_recursive_verifier.cpp
@@ -1,6 +1,6 @@
 #include "barretenberg/stdlib/recursion/honk/verifier/merge_recursive_verifier.hpp"
 
-namespace proof_system::plonk::stdlib::recursion::goblin {
+namespace bb::plonk::stdlib::recursion::goblin {
 
 template <typename CircuitBuilder>
 MergeRecursiveVerifier_<CircuitBuilder>::MergeRecursiveVerifier_(CircuitBuilder* builder)
@@ -85,4 +85,4 @@ std::array<typename bn254<CircuitBuilder>::Element, 2> MergeRecursiveVerifier_<C
 template class MergeRecursiveVerifier_<GoblinUltraCircuitBuilder>;
 template class MergeRecursiveVerifier_<UltraCircuitBuilder>;
 
-} // namespace proof_system::plonk::stdlib::recursion::goblin
+} // namespace bb::plonk::stdlib::recursion::goblin

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/merge_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/merge_recursive_verifier.hpp
@@ -4,15 +4,15 @@
 #include "barretenberg/stdlib/primitives/curves/bn254.hpp"
 #include "barretenberg/stdlib/recursion/honk/transcript/transcript.hpp"
 
-namespace proof_system::plonk::stdlib::recursion::goblin {
+namespace bb::plonk::stdlib::recursion::goblin {
 template <typename CircuitBuilder> class MergeRecursiveVerifier_ {
   public:
     using Curve = bn254<CircuitBuilder>;
     using FF = typename Curve::ScalarField;
     using Commitment = typename Curve::Element;
     using GroupElement = typename Curve::Element;
-    using KZG = ::proof_system::honk::pcs::kzg::KZG<Curve>;
-    using OpeningClaim = ::proof_system::honk::pcs::OpeningClaim<Curve>;
+    using KZG = ::bb::honk::pcs::kzg::KZG<Curve>;
+    using OpeningClaim = ::bb::honk::pcs::OpeningClaim<Curve>;
     using PairingPoints = std::array<GroupElement, 2>;
     using Transcript = honk::Transcript<CircuitBuilder>;
 
@@ -26,4 +26,4 @@ template <typename CircuitBuilder> class MergeRecursiveVerifier_ {
     PairingPoints verify_proof(const plonk::proof& proof);
 };
 
-} // namespace proof_system::plonk::stdlib::recursion::goblin
+} // namespace bb::plonk::stdlib::recursion::goblin

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/merge_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/merge_verifier.test.cpp
@@ -4,7 +4,7 @@
 #include "barretenberg/stdlib/recursion/honk/verifier/merge_recursive_verifier.hpp"
 #include "barretenberg/ultra_honk/ultra_composer.hpp"
 
-namespace proof_system::plonk::stdlib::recursion::goblin {
+namespace bb::plonk::stdlib::recursion::goblin {
 
 /**
  * @brief Test suite for recursive verification of Goblin Merge proofs
@@ -20,8 +20,8 @@ class RecursiveMergeVerifierTest : public testing::Test {
     using RecursiveMergeVerifier = MergeRecursiveVerifier_<RecursiveBuilder>;
 
     // Define types relevant for inner circuit
-    using GoblinUltraFlavor = ::proof_system::honk::flavor::GoblinUltra;
-    using GoblinUltraComposer = ::proof_system::honk::UltraComposer_<GoblinUltraFlavor>;
+    using GoblinUltraFlavor = ::bb::honk::flavor::GoblinUltra;
+    using GoblinUltraComposer = ::bb::honk::UltraComposer_<GoblinUltraFlavor>;
     using InnerFlavor = GoblinUltraFlavor;
     using InnerComposer = GoblinUltraComposer;
     using InnerBuilder = typename InnerComposer::CircuitBuilder;
@@ -29,7 +29,7 @@ class RecursiveMergeVerifierTest : public testing::Test {
     // Define additional types for testing purposes
     using Commitment = InnerFlavor::Commitment;
     using FF = InnerFlavor::FF;
-    using VerifierCommitmentKey = ::proof_system::honk::pcs::VerifierCommitmentKey<curve::BN254>;
+    using VerifierCommitmentKey = ::bb::honk::pcs::VerifierCommitmentKey<curve::BN254>;
 
   public:
     static void SetUpTestSuite() { bb::srs::init_crs_factory("../srs_db/ignition"); }
@@ -97,4 +97,4 @@ TEST_F(RecursiveMergeVerifierTest, SingleRecursiveVerification)
     RecursiveMergeVerifierTest::test_recursive_merge_verification();
 };
 
-} // namespace proof_system::plonk::stdlib::recursion::goblin
+} // namespace bb::plonk::stdlib::recursion::goblin

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/ultra_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/ultra_recursive_verifier.cpp
@@ -4,7 +4,7 @@
 #include "barretenberg/proof_system/library/grand_product_delta.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::plonk::stdlib::recursion::honk {
+namespace bb::plonk::stdlib::recursion::honk {
 
 template <typename Flavor>
 UltraRecursiveVerifier_<Flavor>::UltraRecursiveVerifier_(
@@ -20,12 +20,12 @@ UltraRecursiveVerifier_<Flavor>::UltraRecursiveVerifier_(
 template <typename Flavor>
 std::array<typename Flavor::GroupElement, 2> UltraRecursiveVerifier_<Flavor>::verify_proof(const plonk::proof& proof)
 {
-    using Sumcheck = ::proof_system::honk::sumcheck::SumcheckVerifier<Flavor>;
+    using Sumcheck = ::bb::honk::sumcheck::SumcheckVerifier<Flavor>;
     using Curve = typename Flavor::Curve;
-    using ZeroMorph = ::proof_system::honk::pcs::zeromorph::ZeroMorphVerifier_<Curve>;
+    using ZeroMorph = ::bb::honk::pcs::zeromorph::ZeroMorphVerifier_<Curve>;
     using VerifierCommitments = typename Flavor::VerifierCommitments;
     using CommitmentLabels = typename Flavor::CommitmentLabels;
-    using RelationParams = ::proof_system::RelationParameters<FF>;
+    using RelationParams = ::bb::RelationParameters<FF>;
     using Transcript = typename Flavor::Transcript;
 
     RelationParams relation_parameters;
@@ -86,10 +86,9 @@ std::array<typename Flavor::GroupElement, 2> UltraRecursiveVerifier_<Flavor>::ve
             transcript->template receive_from_prover<Commitment>(commitment_labels.lookup_inverses);
     }
 
-    const FF public_input_delta = proof_system::honk::compute_public_input_delta<Flavor>(
+    const FF public_input_delta = bb::honk::compute_public_input_delta<Flavor>(
         public_inputs, beta, gamma, circuit_size, static_cast<uint32_t>(pub_inputs_offset.get_value()));
-    const FF lookup_grand_product_delta =
-        proof_system::honk::compute_lookup_grand_product_delta<FF>(beta, gamma, circuit_size);
+    const FF lookup_grand_product_delta = bb::honk::compute_lookup_grand_product_delta<FF>(beta, gamma, circuit_size);
 
     relation_parameters.beta = beta;
     relation_parameters.gamma = gamma;
@@ -125,8 +124,8 @@ std::array<typename Flavor::GroupElement, 2> UltraRecursiveVerifier_<Flavor>::ve
     return pairing_points;
 }
 
-template class UltraRecursiveVerifier_<proof_system::honk::flavor::UltraRecursive_<UltraCircuitBuilder>>;
-template class UltraRecursiveVerifier_<proof_system::honk::flavor::UltraRecursive_<GoblinUltraCircuitBuilder>>;
-template class UltraRecursiveVerifier_<proof_system::honk::flavor::GoblinUltraRecursive_<UltraCircuitBuilder>>;
-template class UltraRecursiveVerifier_<proof_system::honk::flavor::GoblinUltraRecursive_<GoblinUltraCircuitBuilder>>;
-} // namespace proof_system::plonk::stdlib::recursion::honk
+template class UltraRecursiveVerifier_<bb::honk::flavor::UltraRecursive_<UltraCircuitBuilder>>;
+template class UltraRecursiveVerifier_<bb::honk::flavor::UltraRecursive_<GoblinUltraCircuitBuilder>>;
+template class UltraRecursiveVerifier_<bb::honk::flavor::GoblinUltraRecursive_<UltraCircuitBuilder>>;
+template class UltraRecursiveVerifier_<bb::honk::flavor::GoblinUltraRecursive_<GoblinUltraCircuitBuilder>>;
+} // namespace bb::plonk::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/ultra_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/ultra_recursive_verifier.hpp
@@ -5,7 +5,7 @@
 #include "barretenberg/stdlib/recursion/honk/transcript/transcript.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
 
-namespace proof_system::plonk::stdlib::recursion::honk {
+namespace bb::plonk::stdlib::recursion::honk {
 template <typename Flavor> class UltraRecursiveVerifier_ {
   public:
     using FF = typename Flavor::FF;
@@ -40,4 +40,4 @@ template <typename Flavor> class UltraRecursiveVerifier_ {
 // Instance declarations for Ultra and Goblin-Ultra verifier circuits with both conventional Ultra and Goblin-Ultra
 // arithmetization.
 using UltraRecursiveVerifier = UltraRecursiveVerifier_<UltraCircuitBuilder>;
-} // namespace proof_system::plonk::stdlib::recursion::honk
+} // namespace bb::plonk::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/verifier.test.cpp
@@ -7,7 +7,7 @@
 #include "barretenberg/ultra_honk/ultra_composer.hpp"
 #include "barretenberg/ultra_honk/ultra_verifier.hpp"
 
-namespace proof_system::plonk::stdlib::recursion::honk {
+namespace bb::plonk::stdlib::recursion::honk {
 
 /**
  * @brief Test suite for recursive verification of conventional Ultra Honk proofs
@@ -19,10 +19,10 @@ namespace proof_system::plonk::stdlib::recursion::honk {
 template <typename BuilderType> class RecursiveVerifierTest : public testing::Test {
 
     // Define types relevant for testing
-    using UltraFlavor = ::proof_system::honk::flavor::Ultra;
-    using GoblinUltraFlavor = ::proof_system::honk::flavor::GoblinUltra;
-    using UltraComposer = ::proof_system::honk::UltraComposer_<UltraFlavor>;
-    using GoblinUltraComposer = ::proof_system::honk::UltraComposer_<GoblinUltraFlavor>;
+    using UltraFlavor = ::bb::honk::flavor::Ultra;
+    using GoblinUltraFlavor = ::bb::honk::flavor::GoblinUltra;
+    using UltraComposer = ::bb::honk::UltraComposer_<UltraFlavor>;
+    using GoblinUltraComposer = ::bb::honk::UltraComposer_<GoblinUltraFlavor>;
 
     using InnerFlavor = UltraFlavor;
     using InnerComposer = UltraComposer;
@@ -32,7 +32,7 @@ template <typename BuilderType> class RecursiveVerifierTest : public testing::Te
     using FF = InnerFlavor::FF;
 
     // Types for recursive verifier circuit
-    using RecursiveFlavor = ::proof_system::honk::flavor::UltraRecursive_<BuilderType>;
+    using RecursiveFlavor = ::bb::honk::flavor::UltraRecursive_<BuilderType>;
     using RecursiveVerifier = UltraRecursiveVerifier_<RecursiveFlavor>;
     using OuterBuilder = BuilderType;
     using VerificationKey = typename RecursiveVerifier::VerificationKey;
@@ -263,4 +263,4 @@ HEAVY_TYPED_TEST(RecursiveVerifierTest, SingleRecursiveVerificationFailure)
     TestFixture::test_recursive_verification_fails();
 };
 
-} // namespace proof_system::plonk::stdlib::recursion::honk
+} // namespace bb::plonk::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/transcript/transcript.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/transcript/transcript.hpp
@@ -14,7 +14,7 @@
 #include "barretenberg/ecc/curves/bn254/g1.hpp"
 #include "barretenberg/plonk/transcript/transcript.hpp"
 
-namespace proof_system::plonk::stdlib::recursion {
+namespace bb::plonk::stdlib::recursion {
 template <typename Builder> class Transcript {
   public:
     using field_pt = field_t<Builder>;
@@ -405,4 +405,4 @@ template <typename Builder> class Transcript {
 
     size_t current_round = 0;
 };
-} // namespace proof_system::plonk::stdlib::recursion
+} // namespace bb::plonk::stdlib::recursion

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/transcript/transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/transcript/transcript.test.cpp
@@ -5,7 +5,7 @@
 #include "barretenberg/transcript/transcript.hpp"
 #include "transcript.hpp"
 
-namespace proof_system::plonk::stdlib::recursion {
+namespace bb::plonk::stdlib::recursion {
 
 // TODO(Cody): Testing only one circuit type.
 using Builder = StandardCircuitBuilder;
@@ -273,4 +273,4 @@ TEST(stdlib_transcript, validate_transcript)
     auto result = builder.check_circuit();
     EXPECT_EQ(result, true);
 }
-} // namespace proof_system::plonk::stdlib::recursion
+} // namespace bb::plonk::stdlib::recursion

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.hpp
@@ -15,7 +15,7 @@
 #include "barretenberg/stdlib/hash/pedersen/pedersen.hpp"
 #include <map>
 
-namespace proof_system::plonk::stdlib::recursion {
+namespace bb::plonk::stdlib::recursion {
 
 /**
  * @brief Constructs a packed buffer of field elements to be fed into a Pedersen hash function
@@ -449,4 +449,4 @@ template <typename Curve> struct verification_key {
     Builder* context;
 };
 
-} // namespace proof_system::plonk::stdlib::recursion
+} // namespace bb::plonk::stdlib::recursion

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/verification_key/verification_key.test.cpp
@@ -10,7 +10,7 @@ namespace {
 auto& engine = numeric::random::get_debug_engine();
 } // namespace
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
 /**
  * @brief A test fixture that will let us generate VK data and run tests
@@ -20,8 +20,8 @@ using namespace proof_system::plonk;
  */
 template <typename Builder> class VerificationKeyFixture : public testing::Test {
   public:
-    using Curve = proof_system::plonk::stdlib::bn254<Builder>;
-    using RecursVk = proof_system::plonk::stdlib::recursion::verification_key<Curve>;
+    using Curve = bb::plonk::stdlib::bn254<Builder>;
+    using RecursVk = bb::plonk::stdlib::recursion::verification_key<Curve>;
 
     static void SetUpTestSuite() { bb::srs::init_crs_factory("../srs_db/ignition"); }
 
@@ -44,7 +44,7 @@ template <typename Builder> class VerificationKeyFixture : public testing::Test 
     }
 };
 
-using CircuitTypes = testing::Types<proof_system::StandardCircuitBuilder, proof_system::UltraCircuitBuilder>;
+using CircuitTypes = testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder>;
 TYPED_TEST_SUITE(VerificationKeyFixture, CircuitTypes);
 
 TYPED_TEST(VerificationKeyFixture, VkDataVsRecursionHashNative)

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/program_settings.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/program_settings.hpp
@@ -3,7 +3,7 @@
 #include "barretenberg/plonk/proof_system/types/program_settings.hpp"
 #include "barretenberg/stdlib/recursion/transcript/transcript.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace recursion {
 
@@ -12,18 +12,16 @@ template <typename Curve> class recursive_ultra_verifier_settings : public plonk
     typedef typename Curve::ScalarField fr_ct;
     typedef typename Curve::GroupNative::affine_element g1;
     typedef typename Curve::Builder Builder;
-    typedef proof_system::plonk::stdlib::recursion::Transcript<Builder> Transcript_pt;
-    typedef proof_system::plonk::VerifierPermutationWidget<fr_ct, g1, Transcript_pt> PermutationWidget;
-    typedef proof_system::plonk::VerifierPlookupWidget<fr_ct, g1, Transcript_pt> PlookupWidget;
+    typedef bb::plonk::stdlib::recursion::Transcript<Builder> Transcript_pt;
+    typedef bb::plonk::VerifierPermutationWidget<fr_ct, g1, Transcript_pt> PermutationWidget;
+    typedef bb::plonk::VerifierPlookupWidget<fr_ct, g1, Transcript_pt> PlookupWidget;
 
-    typedef proof_system::plonk::ultra_settings base_settings;
+    typedef bb::plonk::ultra_settings base_settings;
 
-    typedef proof_system::plonk::VerifierPlookupArithmeticWidget<fr_ct, g1, Transcript_pt, base_settings>
-        PlookupArithmeticWidget;
-    typedef proof_system::plonk::VerifierGenPermSortWidget<fr_ct, g1, Transcript_pt, base_settings> GenPermSortWidget;
-    typedef proof_system::plonk::VerifierEllipticWidget<fr_ct, g1, Transcript_pt, base_settings> EllipticWidget;
-    typedef proof_system::plonk::VerifierPlookupAuxiliaryWidget<fr_ct, g1, Transcript_pt, base_settings>
-        PlookupAuxiliaryWidget;
+    typedef bb::plonk::VerifierPlookupArithmeticWidget<fr_ct, g1, Transcript_pt, base_settings> PlookupArithmeticWidget;
+    typedef bb::plonk::VerifierGenPermSortWidget<fr_ct, g1, Transcript_pt, base_settings> GenPermSortWidget;
+    typedef bb::plonk::VerifierEllipticWidget<fr_ct, g1, Transcript_pt, base_settings> EllipticWidget;
+    typedef bb::plonk::VerifierPlookupAuxiliaryWidget<fr_ct, g1, Transcript_pt, base_settings> PlookupAuxiliaryWidget;
 
     static constexpr size_t num_challenge_bytes = 16;
     static constexpr transcript::HashType hash_type = transcript::HashType::PedersenBlake3s;
@@ -89,22 +87,20 @@ class recursive_ultra_to_standard_verifier_settings : public recursive_ultra_ver
     typedef typename Curve::ScalarField fr_ct;
     typedef typename Curve::GroupNative::affine_element g1;
     typedef typename Curve::Builder Builder;
-    typedef proof_system::plonk::stdlib::recursion::Transcript<Builder> Transcript_pt;
-    typedef proof_system::plonk::VerifierPermutationWidget<fr_ct, g1, Transcript_pt> PermutationWidget;
-    typedef proof_system::plonk::VerifierPlookupWidget<fr_ct, g1, Transcript_pt> PlookupWidget;
+    typedef bb::plonk::stdlib::recursion::Transcript<Builder> Transcript_pt;
+    typedef bb::plonk::VerifierPermutationWidget<fr_ct, g1, Transcript_pt> PermutationWidget;
+    typedef bb::plonk::VerifierPlookupWidget<fr_ct, g1, Transcript_pt> PlookupWidget;
 
-    typedef proof_system::plonk::ultra_to_standard_settings base_settings;
+    typedef bb::plonk::ultra_to_standard_settings base_settings;
 
-    typedef proof_system::plonk::VerifierPlookupArithmeticWidget<fr_ct, g1, Transcript_pt, base_settings>
-        PlookupArithmeticWidget;
-    typedef proof_system::plonk::VerifierGenPermSortWidget<fr_ct, g1, Transcript_pt, base_settings> GenPermSortWidget;
-    typedef proof_system::plonk::VerifierEllipticWidget<fr_ct, g1, Transcript_pt, base_settings> EllipticWidget;
-    typedef proof_system::plonk::VerifierPlookupAuxiliaryWidget<fr_ct, g1, Transcript_pt, base_settings>
-        PlookupAuxiliaryWidget;
+    typedef bb::plonk::VerifierPlookupArithmeticWidget<fr_ct, g1, Transcript_pt, base_settings> PlookupArithmeticWidget;
+    typedef bb::plonk::VerifierGenPermSortWidget<fr_ct, g1, Transcript_pt, base_settings> GenPermSortWidget;
+    typedef bb::plonk::VerifierEllipticWidget<fr_ct, g1, Transcript_pt, base_settings> EllipticWidget;
+    typedef bb::plonk::VerifierPlookupAuxiliaryWidget<fr_ct, g1, Transcript_pt, base_settings> PlookupAuxiliaryWidget;
 
     static constexpr transcript::HashType hash_type = transcript::HashType::PedersenBlake3s;
 };
 
 } // namespace recursion
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/verifier.hpp
@@ -14,7 +14,7 @@
 #include "barretenberg/stdlib/recursion/transcript/transcript.hpp"
 #include "barretenberg/stdlib/recursion/verifier/program_settings.hpp"
 
-namespace proof_system::plonk {
+namespace bb::plonk {
 namespace stdlib {
 namespace recursion {
 
@@ -99,7 +99,7 @@ void populate_kate_element_map(typename Curve::Builder* ctx,
     fr_ct u = transcript.get_challenge_field_element("separator", 0);
 
     fr_ct batch_evaluation =
-        proof_system::plonk::compute_kate_batch_evaluation<fr_ct, Transcript, program_settings>(key, transcript);
+        bb::plonk::compute_kate_batch_evaluation<fr_ct, Transcript, program_settings>(key, transcript);
     batch_opening_scalar = -batch_evaluation;
 
     kate_g1_elements.insert({ "PI_Z_OMEGA", PI_Z_OMEGA });
@@ -431,4 +431,4 @@ aggregation_state<bn254<typename Flavor::CircuitBuilder>> verify_proof(
 
 } // namespace recursion
 } // namespace stdlib
-} // namespace proof_system::plonk
+} // namespace bb::plonk

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/verifier.test.cpp
@@ -12,11 +12,11 @@
 #include "barretenberg/stdlib/primitives/curves/bn254.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::plonk::stdlib {
+namespace bb::plonk::stdlib {
 
 template <typename OuterComposer> class stdlib_verifier : public testing::Test {
 
-    using InnerComposer = proof_system::plonk::UltraComposer;
+    using InnerComposer = bb::plonk::UltraComposer;
     using InnerBuilder = typename InnerComposer::CircuitBuilder;
 
     using OuterBuilder = typename OuterComposer::CircuitBuilder;
@@ -46,7 +46,7 @@ template <typename OuterComposer> class stdlib_verifier : public testing::Test {
     // select the relevant prover and verifier types (whose settings use the same hash for fiat-shamir),
     // depending on the Inner-Outer combo. It's a bit clunky, but the alternative is to have a template argument
     // for the hashtype, and that would pervade the entire UltraPlonkComposer, which would be horrendous.
-    static constexpr bool is_ultra_to_ultra = std::is_same_v<OuterComposer, proof_system::plonk::UltraComposer>;
+    static constexpr bool is_ultra_to_ultra = std::is_same_v<OuterComposer, bb::plonk::UltraComposer>;
     using ProverOfInnerCircuit =
         std::conditional_t<is_ultra_to_ultra, plonk::UltraProver, plonk::UltraToStandardProver>;
     using VerifierOfInnerProof =
@@ -212,7 +212,7 @@ template <typename OuterComposer> class stdlib_verifier : public testing::Test {
 
         plonk::proof proof_to_recursively_verify_b = prover.construct_proof();
 
-        auto output = proof_system::plonk::stdlib::recursion::verify_proof<outer_curve, RecursiveSettings>(
+        auto output = bb::plonk::stdlib::recursion::verify_proof<outer_curve, RecursiveSettings>(
             &outer_circuit, verification_key_b, recursive_manifest, proof_to_recursively_verify_b, previous_output);
 
         verification_key_b->hash();
@@ -265,8 +265,8 @@ template <typename OuterComposer> class stdlib_verifier : public testing::Test {
 
         transcript::Manifest recursive_manifest = InnerComposer::create_manifest(prover_a.key->num_public_inputs);
 
-        proof_system::plonk::stdlib::recursion::aggregation_state<outer_curve> output =
-            proof_system::plonk::stdlib::recursion::verify_proof<outer_curve, RecursiveSettings>(
+        bb::plonk::stdlib::recursion::aggregation_state<outer_curve> output =
+            bb::plonk::stdlib::recursion::verify_proof<outer_curve, RecursiveSettings>(
                 &outer_circuit, verification_key, recursive_manifest, recursive_proof);
 
         return { output, verification_key };
@@ -617,4 +617,4 @@ HEAVY_TYPED_TEST(stdlib_verifier, recursive_proof_composition_const_verif_key)
     TestFixture::test_recursive_proof_composition_with_constant_verification_key();
 }
 
-} // namespace proof_system::plonk::stdlib
+} // namespace bb::plonk::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/types/ultra.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/types/ultra.hpp
@@ -19,11 +19,11 @@
 #include "barretenberg/stdlib/primitives/witness/witness.hpp"
 #include "barretenberg/stdlib/recursion/verifier/program_settings.hpp"
 
-namespace proof_system::plonk::stdlib::types {
+namespace bb::plonk::stdlib::types {
 
-using namespace proof_system::plonk;
+using namespace bb::plonk;
 
-using Builder = proof_system::UltraCircuitBuilder;
+using Builder = bb::UltraCircuitBuilder;
 using Composer = plonk::UltraComposer;
 
 // TODO(Cody): These might be wrong depending on desired F-S hash.
@@ -66,4 +66,4 @@ using rom_table_ct = stdlib::rom_table<plonk::UltraComposer>;
 
 using recursive_inner_verifier_settings = recursion::recursive_ultra_verifier_settings<bn254>;
 
-} // namespace proof_system::plonk::stdlib::types
+} // namespace bb::plonk::stdlib::types

--- a/barretenberg/cpp/src/barretenberg/stdlib/utility/utility.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/utility/utility.hpp
@@ -11,7 +11,7 @@
 #include "barretenberg/stdlib/primitives/biggroup/biggroup.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 
-namespace proof_system::plonk::stdlib::recursion::utility {
+namespace bb::plonk::stdlib::recursion::utility {
 
 /**
  * @brief Utility class for converting native types to corresponding stdlib types
@@ -131,4 +131,4 @@ template <typename Builder> class StdlibTypesUtility {
         using type = Univariate<LENGTH>;
     };
 };
-} // namespace proof_system::plonk::stdlib::recursion::utility
+} // namespace bb::plonk::stdlib::recursion::utility

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/instances.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/instances.hpp
@@ -2,7 +2,7 @@
 #include "barretenberg/sumcheck/instance/prover_instance.hpp"
 #include "barretenberg/sumcheck/instance/verifier_instance.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 template <typename Flavor_, size_t NUM_> struct ProverInstances_ {
   public:
@@ -17,7 +17,7 @@ template <typename Flavor_, size_t NUM_> struct ProverInstances_ {
     // The extended length here is the length of a composition of polynomials.
     static constexpr size_t EXTENDED_LENGTH = (Flavor::MAX_TOTAL_RELATION_LENGTH - 1) * (NUM - 1) + 1;
     static constexpr size_t BATCHED_EXTENDED_LENGTH = (Flavor::MAX_TOTAL_RELATION_LENGTH - 1 + NUM - 1) * (NUM - 1) + 1;
-    using RelationParameters = proof_system::RelationParameters<Univariate<FF, EXTENDED_LENGTH>>;
+    using RelationParameters = bb::RelationParameters<Univariate<FF, EXTENDED_LENGTH>>;
     using RelationSeparator = std::array<Univariate<FF, BATCHED_EXTENDED_LENGTH>, NUM_SUBRELATIONS - 1>;
     ArrayType _data;
     RelationParameters relation_parameters;
@@ -105,4 +105,4 @@ template <typename Flavor_, size_t NUM_> struct VerifierInstances_ {
         std::generate(_data.begin(), _data.end(), []() { return std::make_unique<Instance>(); });
     };
 };
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.cpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.cpp
@@ -5,7 +5,7 @@
 #include "barretenberg/proof_system/library/grand_product_delta.hpp"
 #include "barretenberg/proof_system/library/grand_product_library.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 /**
  * @brief Helper method to compute quantities like total number of gates and dyadic circuit size
  *
@@ -428,4 +428,4 @@ template <class Flavor> void ProverInstance_<Flavor>::compute_grand_product_poly
 template class ProverInstance_<honk::flavor::Ultra>;
 template class ProverInstance_<honk::flavor::GoblinUltra>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
@@ -5,7 +5,7 @@
 #include "barretenberg/proof_system/composer/composer_lib.hpp"
 #include "barretenberg/relations/relation_parameters.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 /**
  * @brief  An Instance is normally constructed from a finalized circuit and it's role is to compute all the polynomials
  * involved in creating a proof and, if requested, the verification key.
@@ -46,7 +46,7 @@ template <class Flavor> class ProverInstance_ {
     // instances
     size_t pub_inputs_offset = 0;
     RelationSeparator alphas;
-    proof_system::RelationParameters<FF> relation_parameters;
+    bb::RelationParameters<FF> relation_parameters;
     std::vector<uint32_t> recursive_proof_public_input_indices;
 
     bool is_accumulator = false;
@@ -107,4 +107,4 @@ template <class Flavor> class ProverInstance_ {
     void add_plookup_memory_records_to_wire_4(FF);
 };
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.test.cpp
@@ -6,7 +6,7 @@
 #include "barretenberg/srs/factories/file_crs_factory.hpp"
 #include <gtest/gtest.h>
 
-using namespace proof_system::honk;
+using namespace bb::honk;
 namespace instance_tests {
 
 template <class Flavor> class InstanceTests : public testing::Test {

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/verifier_instance.hpp
@@ -2,7 +2,7 @@
 #include "barretenberg/flavor/flavor.hpp"
 #include "barretenberg/relations/relation_parameters.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 template <class Flavor> class VerifierInstance_ {
   public:
     using FF = typename Flavor::FF;
@@ -28,4 +28,4 @@ template <class Flavor> class VerifierInstance_ {
     WitnessCommitments witness_commitments;
     CommitmentLabels commitment_labels;
 };
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/sumcheck/partial_evaluation.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/partial_evaluation.test.cpp
@@ -3,12 +3,12 @@
 
 #include <gtest/gtest.h>
 
-using namespace proof_system::honk::sumcheck;
+using namespace bb::honk::sumcheck;
 namespace test_sumcheck_polynomials {
 
 template <typename Flavor> class PartialEvaluationTests : public testing::Test {};
 
-using Flavors = testing::Types<proof_system::honk::flavor::Ultra>;
+using Flavors = testing::Types<bb::honk::flavor::Ultra>;
 
 TYPED_TEST_SUITE(PartialEvaluationTests, Flavors);
 

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -5,7 +5,7 @@
 #include "barretenberg/transcript/transcript.hpp"
 #include "sumcheck_round.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 template <typename Flavor> class SumcheckProver {
 
@@ -83,7 +83,7 @@ template <typename Flavor> class SumcheckProver {
      * @details
      */
     SumcheckOutput<Flavor> prove(ProverPolynomials& full_polynomials,
-                                 const proof_system::RelationParameters<FF>& relation_parameters,
+                                 const bb::RelationParameters<FF>& relation_parameters,
                                  const RelationSeparator alpha,
                                  const std::vector<FF>& gate_challenges)
     {
@@ -202,7 +202,7 @@ template <typename Flavor> class SumcheckVerifier {
      * @param relation_parameters
      * @param transcript
      */
-    SumcheckOutput<Flavor> verify(const proof_system::RelationParameters<FF>& relation_parameters,
+    SumcheckOutput<Flavor> verify(const bb::RelationParameters<FF>& relation_parameters,
                                   RelationSeparator alpha,
                                   const std::vector<FF>& gate_challenges)
     {
@@ -257,4 +257,4 @@ template <typename Flavor> class SumcheckVerifier {
         return SumcheckOutput<Flavor>{ multivariate_challenge, purported_evaluations, verified };
     };
 };
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.test.cpp
@@ -12,9 +12,9 @@
 
 #include <gtest/gtest.h>
 
-using namespace proof_system::honk;
-using namespace proof_system::honk::sumcheck;
-using Flavor = proof_system::honk::flavor::Ultra;
+using namespace bb::honk;
+using namespace bb::honk::sumcheck;
+using Flavor = bb::honk::flavor::Ultra;
 using FF = typename Flavor::FF;
 using ProverPolynomials = typename Flavor::ProverPolynomials;
 using RelationSeparator = Flavor::RelationSeparator;
@@ -213,7 +213,7 @@ TEST_F(SumcheckTests, ProverAndVerifierSimple)
         full_polynomials.q_arith = q_arith;
 
         // Set aribitrary random relation parameters
-        proof_system::RelationParameters<FF> relation_parameters{
+        bb::RelationParameters<FF> relation_parameters{
             .beta = FF::random_element(),
             .gamma = FF::random_element(),
             .public_input_delta = FF::one(),

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_output.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_output.hpp
@@ -4,7 +4,7 @@
 #include <optional>
 #include <vector>
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 /**
  * @brief Contains the multi-linear evaluations of the polynomials at the challenge point 'u'.
@@ -20,4 +20,4 @@ template <typename Flavor> struct SumcheckOutput {
     // Whether or not the claimed multilinear evaluations and final sumcheck evaluation have been confirmed
     std::optional<bool> verified = false; // optional b/c this struct is shared by the Prover/Verifier
 };
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
@@ -7,7 +7,7 @@
 #include "barretenberg/relations/relation_types.hpp"
 #include "barretenberg/relations/utils.hpp"
 
-namespace proof_system::honk::sumcheck {
+namespace bb::honk::sumcheck {
 
 /*
  Notation: The polynomial P(X0, X1) that is the low-degree extension of its values vij = P(i,j)
@@ -103,7 +103,7 @@ template <typename Flavor> class SumcheckProverRound {
     template <typename ProverPolynomialsOrPartiallyEvaluatedMultivariates>
     bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH> compute_univariate(
         ProverPolynomialsOrPartiallyEvaluatedMultivariates& polynomials,
-        const proof_system::RelationParameters<FF>& relation_parameters,
+        const bb::RelationParameters<FF>& relation_parameters,
         const bb::PowPolynomial<FF>& pow_polynomial,
         const RelationSeparator alpha)
     {
@@ -204,7 +204,7 @@ template <typename Flavor> class SumcheckProverRound {
 
             using Relation = typename std::tuple_element_t<relation_idx, Relations>;
             const bool is_subrelation_linearly_independent =
-                proof_system::subrelation_is_linearly_independent<Relation, subrelation_idx>();
+                bb::subrelation_is_linearly_independent<Relation, subrelation_idx>();
             // Except from the log derivative subrelation, each other subrelation in part is required to be 0 hence we
             // multiply by the power polynomial. As the sumcheck prover is required to send a univariate to the
             // verifier, we additionally need a univariate contribution from the pow polynomial.
@@ -236,7 +236,7 @@ template <typename Flavor> class SumcheckProverRound {
     template <size_t relation_idx = 0>
     void accumulate_relation_univariates(SumcheckTupleOfTuplesOfUnivariates& univariate_accumulators,
                                          const auto& extended_edges,
-                                         const proof_system::RelationParameters<FF>& relation_parameters,
+                                         const bb::RelationParameters<FF>& relation_parameters,
                                          const FF& scaling_factor)
     {
         using Relation = std::tuple_element_t<relation_idx, Relations>;
@@ -322,7 +322,7 @@ template <typename Flavor> class SumcheckVerifierRound {
     // so instead of having claimed evaluations of each relation in part  you have the actual evaluations
     // kill the pow_univariat
     FF compute_full_honk_relation_purported_value(ClaimedEvaluations purported_evaluations,
-                                                  const proof_system::RelationParameters<FF>& relation_parameters,
+                                                  const bb::RelationParameters<FF>& relation_parameters,
                                                   const bb::PowPolynomial<FF>& pow_polynomial,
                                                   const RelationSeparator alpha)
     {
@@ -335,4 +335,4 @@ template <typename Flavor> class SumcheckVerifierRound {
         return output;
     }
 };
-} // namespace proof_system::honk::sumcheck
+} // namespace bb::honk::sumcheck

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.test.cpp
@@ -4,8 +4,8 @@
 
 #include <gtest/gtest.h>
 
-using namespace proof_system::honk;
-using namespace proof_system::honk::sumcheck;
+using namespace bb::honk;
+using namespace bb::honk::sumcheck;
 
 using bb::BarycentricData;
 using bb::Univariate;
@@ -22,7 +22,7 @@ namespace test_sumcheck_round {
  */
 TEST(SumcheckRound, SumcheckTupleOfTuplesOfUnivariates)
 {
-    using Flavor = proof_system::honk::flavor::Ultra;
+    using Flavor = bb::honk::flavor::Ultra;
     using FF = typename Flavor::FF;
     using RelationSeparator = typename Flavor::RelationSeparator;
 
@@ -73,7 +73,7 @@ TEST(SumcheckRound, SumcheckTupleOfTuplesOfUnivariates)
  */
 TEST(SumcheckRound, TuplesOfEvaluationArrays)
 {
-    using Flavor = proof_system::honk::flavor::Ultra;
+    using Flavor = bb::honk::flavor::Ultra;
     using Utils = bb::RelationUtils<Flavor>;
     using FF = typename Flavor::FF;
     using RelationSeparator = typename Flavor::RelationSeparator;
@@ -113,7 +113,7 @@ TEST(SumcheckRound, TuplesOfEvaluationArrays)
  */
 TEST(SumcheckRound, AddTuplesOfTuplesOfUnivariates)
 {
-    using Flavor = proof_system::honk::flavor::Ultra;
+    using Flavor = bb::honk::flavor::Ultra;
     using FF = typename Flavor::FF;
 
     // Define some arbitrary univariates

--- a/barretenberg/cpp/src/barretenberg/transcript/transcript.hpp
+++ b/barretenberg/cpp/src/barretenberg/transcript/transcript.hpp
@@ -7,7 +7,7 @@
 // #define LOG_CHALLENGES
 // #define LOG_INTERACTIONS
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 template <typename T, typename... U>
 concept Loggable = (std::same_as<T, bb::fr> || std::same_as<T, grumpkin::fr> ||
@@ -363,4 +363,4 @@ template <typename FF, typename T, size_t N> std::array<FF, N> challenges_to_fie
     std::move(arr.begin(), arr.end(), result.begin());
     return result;
 }
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/transcript/transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/transcript/transcript.test.cpp
@@ -6,7 +6,7 @@ namespace bb::honk_transcript_tests {
 using FF = bb::fr;
 using Fr = bb::fr;
 using Fq = bb::fq;
-using Transcript = proof_system::honk::BaseTranscript;
+using Transcript = bb::honk::BaseTranscript;
 
 /**
  * @brief Test sending, receiving, and exporting proofs

--- a/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.cpp
@@ -11,7 +11,7 @@
 #include "barretenberg/proof_system/composer/composer_lib.hpp"
 #include "barretenberg/proof_system/composer/permutation_lib.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 using Flavor = honk::flavor::GoblinTranslator;
 using Curve = typename Flavor::Curve;
 using FF = typename Flavor::FF;
@@ -184,11 +184,11 @@ void GoblinTranslatorComposer::compute_witness(CircuitBuilder& circuit_builder)
 
     // We construct concatenated versions of range constraint polynomials, where several polynomials are concatenated
     // into one. These polynomials are not commited to.
-    proof_system::honk::permutation_library::compute_concatenated_polynomials<Flavor>(proving_key.get());
+    bb::honk::permutation_library::compute_concatenated_polynomials<Flavor>(proving_key.get());
 
     // We also contruct ordered polynomials, which have the same values as concatenated ones + enough values to bridge
     // the range from 0 to maximum range defined by the range constraint.
-    proof_system::honk::permutation_library::compute_goblin_translator_range_constraint_ordered_polynomials<Flavor>(
+    bb::honk::permutation_library::compute_goblin_translator_range_constraint_ordered_polynomials<Flavor>(
         proving_key.get());
 
     computed_witness = true;
@@ -273,12 +273,11 @@ std::shared_ptr<typename Flavor::ProvingKey> GoblinTranslatorComposer::compute_p
 
     // Compute polynomials with odd and even indices set to 1 up to the minicircuit margin + lagrange polynomials at
     // second and second to last indices in the minicircuit
-    proof_system::honk::permutation_library::compute_lagrange_polynomials_for_goblin_translator<Flavor>(
-        proving_key.get());
+    bb::honk::permutation_library::compute_lagrange_polynomials_for_goblin_translator<Flavor>(proving_key.get());
 
     // Compute the numerator for the permutation argument with several repetitions of steps bridging 0 and maximum range
     // constraint
-    proof_system::honk::permutation_library::compute_extra_range_constraint_numerator<Flavor>(proving_key.get());
+    bb::honk::permutation_library::compute_extra_range_constraint_numerator<Flavor>(proving_key.get());
 
     return proving_key;
 }
@@ -314,4 +313,4 @@ std::shared_ptr<VerificationKey> GoblinTranslatorComposer::compute_verification_
 
     return verification_key;
 }
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.hpp
@@ -7,7 +7,7 @@
 #include "barretenberg/translator_vm/goblin_translator_prover.hpp"
 #include "barretenberg/translator_vm/goblin_translator_verifier.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 class GoblinTranslatorComposer {
   public:
     using Flavor = honk::flavor::GoblinTranslator;
@@ -70,4 +70,4 @@ class GoblinTranslatorComposer {
         return commitment_key;
     };
 };
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.test.cpp
@@ -8,10 +8,10 @@
 
 #include <gtest/gtest.h>
 
-using namespace proof_system::honk;
+using namespace bb::honk;
 using CircuitBuilder = flavor::GoblinTranslator::CircuitBuilder;
 using Transcript = flavor::GoblinTranslator::Transcript;
-using OpQueue = proof_system::ECCOpQueue;
+using OpQueue = bb::ECCOpQueue;
 
 namespace test_goblin_translator_composer {
 
@@ -57,7 +57,7 @@ TEST_F(GoblinTranslatorComposerTests, Basic)
     auto z = Fr::random_element();
 
     // Add the same operations to the ECC op queue; the native computation is performed under the hood.
-    auto op_queue = std::make_shared<proof_system::ECCOpQueue>();
+    auto op_queue = std::make_shared<bb::ECCOpQueue>();
     for (size_t i = 0; i < 500; i++) {
         op_queue->add_accumulate(P1);
         op_queue->mul_accumulate(P2, z);

--- a/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_prover.cpp
@@ -5,7 +5,7 @@
 #include "barretenberg/proof_system/library/grand_product_library.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 /**
  * Create GoblinTranslatorProver from proving key, witness and manifest.
@@ -197,4 +197,4 @@ plonk::proof& GoblinTranslatorProver::construct_proof()
     return export_proof();
 }
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_prover.hpp
@@ -4,7 +4,7 @@
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/sumcheck/sumcheck_output.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 // We won't compile this class with honk::flavor::Standard, but we will like want to compile it (at least for testing)
 // with a flavor that uses the curve Grumpkin, or a flavor that does/does not have zk, etc.
@@ -40,7 +40,7 @@ class GoblinTranslatorProver {
 
     std::shared_ptr<Transcript> transcript = std::make_shared<Transcript>();
 
-    proof_system::RelationParameters<FF> relation_parameters;
+    bb::RelationParameters<FF> relation_parameters;
 
     std::shared_ptr<ProvingKey> key;
 
@@ -57,4 +57,4 @@ class GoblinTranslatorProver {
     plonk::proof proof;
 };
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_verifier.cpp
@@ -4,9 +4,9 @@
 #include "barretenberg/transcript/transcript.hpp"
 
 using namespace bb;
-using namespace proof_system::honk::sumcheck;
+using namespace bb::honk::sumcheck;
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 GoblinTranslatorVerifier::GoblinTranslatorVerifier(
     const std::shared_ptr<typename Flavor::VerificationKey>& verifier_key,
@@ -312,4 +312,4 @@ bool GoblinTranslatorVerifier::verify_translation(const TranslationEvaluations& 
     return is_value_reconstructed;
 }
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_verifier.hpp
@@ -3,7 +3,7 @@
 #include "barretenberg/goblin/translation_evaluations.hpp"
 #include "barretenberg/plonk/proof_system/types/proof.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 class GoblinTranslatorVerifier {
   public:
     using Flavor = honk::flavor::GoblinTranslator;
@@ -38,4 +38,4 @@ class GoblinTranslatorVerifier {
     bool verify_proof(const plonk::proof& proof);
     bool verify_translation(const TranslationEvaluations& translation_evaluations);
 };
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/databus_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/databus_composer.test.cpp
@@ -10,7 +10,7 @@
 #include "barretenberg/ultra_honk/ultra_composer.hpp"
 #include "barretenberg/ultra_honk/ultra_prover.hpp"
 
-using namespace proof_system::honk;
+using namespace bb::honk;
 
 namespace test_ultra_honk_composer {
 
@@ -49,12 +49,12 @@ class DataBusComposerTests : public ::testing::Test {
  */
 TEST_F(DataBusComposerTests, CallDataRead)
 {
-    auto op_queue = std::make_shared<proof_system::ECCOpQueue>();
+    auto op_queue = std::make_shared<bb::ECCOpQueue>();
 
     // Add mock data to op queue to simulate interaction with a previous circuit
     op_queue->populate_with_mock_initital_data();
 
-    auto builder = proof_system::GoblinUltraCircuitBuilder{ op_queue };
+    auto builder = bb::GoblinUltraCircuitBuilder{ op_queue };
 
     // Create a general test circuit
     generate_test_circuit(builder);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/goblin_ultra_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/goblin_ultra_composer.test.cpp
@@ -8,7 +8,7 @@
 #include "barretenberg/ultra_honk/ultra_composer.hpp"
 #include "barretenberg/ultra_honk/ultra_prover.hpp"
 
-using namespace proof_system::honk;
+using namespace bb::honk;
 
 namespace test_ultra_honk_composer {
 
@@ -94,12 +94,12 @@ class GoblinUltraHonkComposerTests : public ::testing::Test {
  */
 TEST_F(GoblinUltraHonkComposerTests, SingleCircuit)
 {
-    auto op_queue = std::make_shared<proof_system::ECCOpQueue>();
+    auto op_queue = std::make_shared<bb::ECCOpQueue>();
 
     // Add mock data to op queue to simulate interaction with a previous circuit
     op_queue->populate_with_mock_initital_data();
 
-    auto builder = proof_system::GoblinUltraCircuitBuilder{ op_queue };
+    auto builder = bb::GoblinUltraCircuitBuilder{ op_queue };
 
     generate_test_circuit(builder);
 
@@ -122,7 +122,7 @@ TEST_F(GoblinUltraHonkComposerTests, SingleCircuit)
 TEST_F(GoblinUltraHonkComposerTests, MultipleCircuitsMergeOnly)
 {
     // Instantiate EccOpQueue. This will be shared across all circuits in the series
-    auto op_queue = std::make_shared<proof_system::ECCOpQueue>();
+    auto op_queue = std::make_shared<bb::ECCOpQueue>();
 
     // Add mock data to op queue to simulate interaction with a previous circuit
     op_queue->populate_with_mock_initital_data();
@@ -130,7 +130,7 @@ TEST_F(GoblinUltraHonkComposerTests, MultipleCircuitsMergeOnly)
     // Construct multiple test circuits that share an ECC op queue. Generate and verify a proof for each.
     size_t NUM_CIRCUITS = 3;
     for (size_t i = 0; i < NUM_CIRCUITS; ++i) {
-        auto builder = proof_system::GoblinUltraCircuitBuilder{ op_queue };
+        auto builder = bb::GoblinUltraCircuitBuilder{ op_queue };
 
         generate_test_circuit(builder);
 
@@ -150,7 +150,7 @@ TEST_F(GoblinUltraHonkComposerTests, MultipleCircuitsMergeOnly)
 TEST_F(GoblinUltraHonkComposerTests, MultipleCircuitsHonkOnly)
 {
     // Instantiate EccOpQueue. This will be shared across all circuits in the series
-    auto op_queue = std::make_shared<proof_system::ECCOpQueue>();
+    auto op_queue = std::make_shared<bb::ECCOpQueue>();
 
     // Add mock data to op queue to simulate interaction with a previous circuit
     op_queue->populate_with_mock_initital_data();
@@ -158,7 +158,7 @@ TEST_F(GoblinUltraHonkComposerTests, MultipleCircuitsHonkOnly)
     // Construct multiple test circuits that share an ECC op queue. Generate and verify a proof for each.
     size_t NUM_CIRCUITS = 3;
     for (size_t i = 0; i < NUM_CIRCUITS; ++i) {
-        auto builder = proof_system::GoblinUltraCircuitBuilder{ op_queue };
+        auto builder = bb::GoblinUltraCircuitBuilder{ op_queue };
 
         generate_test_circuit(builder);
 
@@ -178,7 +178,7 @@ TEST_F(GoblinUltraHonkComposerTests, MultipleCircuitsHonkOnly)
 TEST_F(GoblinUltraHonkComposerTests, MultipleCircuitsHonkAndMerge)
 {
     // Instantiate EccOpQueue. This will be shared across all circuits in the series
-    auto op_queue = std::make_shared<proof_system::ECCOpQueue>();
+    auto op_queue = std::make_shared<bb::ECCOpQueue>();
 
     // Add mock data to op queue to simulate interaction with a previous circuit
     op_queue->populate_with_mock_initital_data();
@@ -186,7 +186,7 @@ TEST_F(GoblinUltraHonkComposerTests, MultipleCircuitsHonkAndMerge)
     // Construct multiple test circuits that share an ECC op queue. Generate and verify a proof for each.
     size_t NUM_CIRCUITS = 3;
     for (size_t i = 0; i < NUM_CIRCUITS; ++i) {
-        auto builder = proof_system::GoblinUltraCircuitBuilder{ op_queue };
+        auto builder = bb::GoblinUltraCircuitBuilder{ op_queue };
 
         generate_test_circuit(builder);
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/goblin_ultra_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/goblin_ultra_transcript.test.cpp
@@ -6,13 +6,13 @@
 #include "barretenberg/ultra_honk/ultra_composer.hpp"
 #include <gtest/gtest.h>
 
-using namespace proof_system::honk;
+using namespace bb::honk;
 
 class GoblinUltraTranscriptTests : public ::testing::Test {
   public:
     static void SetUpTestSuite() { bb::srs::init_crs_factory("../srs_db/ignition"); }
 
-    using Flavor = proof_system::honk::flavor::GoblinUltra;
+    using Flavor = bb::honk::flavor::GoblinUltra;
     using FF = Flavor::FF;
 
     /**

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
@@ -1,6 +1,6 @@
 #include "merge_prover.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 /**
  * Create MergeProver_
@@ -119,4 +119,4 @@ template <typename Flavor> plonk::proof& MergeProver_<Flavor>::construct_proof()
 template class MergeProver_<honk::flavor::Ultra>;
 template class MergeProver_<honk::flavor::GoblinUltra>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
@@ -7,7 +7,7 @@
 #include "barretenberg/proof_system/op_queue/ecc_op_queue.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 /**
  * @brief Prover class for the Goblin ECC op queue transcript merge protocol
@@ -39,4 +39,4 @@ template <typename Flavor> class MergeProver_ {
     plonk::proof proof;
 };
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
@@ -1,6 +1,6 @@
 #include "merge_verifier.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 template <typename Flavor>
 MergeVerifier_<Flavor>::MergeVerifier_()
@@ -82,4 +82,4 @@ template <typename Flavor> bool MergeVerifier_<Flavor>::verify_proof(const plonk
 template class MergeVerifier_<honk::flavor::Ultra>;
 template class MergeVerifier_<honk::flavor::GoblinUltra>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
@@ -8,7 +8,7 @@
 #include "barretenberg/srs/global_crs.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 /**
  * @brief Verifier class for the Goblin ECC op queue transcript merge protocol
@@ -36,4 +36,4 @@ template <typename Flavor> class MergeVerifier_ {
     bool verify_proof(const plonk::proof& proof);
 };
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/protogalaxy.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/protogalaxy.test.cpp
@@ -3,7 +3,7 @@
 #include "barretenberg/ultra_honk/ultra_composer.hpp"
 #include <gtest/gtest.h>
 
-using namespace proof_system::honk;
+using namespace bb::honk;
 
 using Flavor = flavor::Ultra;
 using VerificationKey = Flavor::VerificationKey;
@@ -16,7 +16,7 @@ using Projective = Flavor::GroupElement;
 using Builder = Flavor::CircuitBuilder;
 using Polynomial = typename Flavor::Polynomial;
 using ProverPolynomials = Flavor::ProverPolynomials;
-using RelationParameters = proof_system::RelationParameters<FF>;
+using RelationParameters = bb::RelationParameters<FF>;
 using WitnessCommitments = typename Flavor::WitnessCommitments;
 using CommitmentKey = Flavor::CommitmentKey;
 using PowPolynomial = bb::PowPolynomial<FF>;
@@ -149,7 +149,7 @@ TEST_F(ProtoGalaxyTests, PerturbatorPolynomial)
         poly = get_random_polynomial(instance_size);
     }
     auto full_polynomials = construct_ultra_full_polynomials(random_polynomials);
-    auto relation_parameters = proof_system::RelationParameters<FF>::get_random();
+    auto relation_parameters = bb::RelationParameters<FF>::get_random();
     RelationSeparator alphas;
     for (auto& alpha : alphas) {
         alpha = FF::random_element();

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/relation_correctness.test.cpp
@@ -12,7 +12,7 @@
 #include "barretenberg/ultra_honk/ultra_composer.hpp"
 #include <gtest/gtest.h>
 
-using namespace proof_system::honk;
+using namespace bb::honk;
 
 namespace test_honk_relations {
 
@@ -226,7 +226,7 @@ template <typename Flavor> void create_some_ecc_op_queue_gates(auto& circuit_bui
 {
     using G1 = typename Flavor::Curve::Group;
     using FF = typename Flavor::FF;
-    static_assert(proof_system::IsGoblinFlavor<Flavor>);
+    static_assert(bb::IsGoblinFlavor<Flavor>);
     const size_t num_ecc_operations = 10; // arbitrary
     for (size_t i = 0; i < num_ecc_operations; ++i) {
         auto point = G1::affine_one * FF::random_element();
@@ -258,7 +258,7 @@ TEST_F(RelationCorrectnessTests, UltraRelationCorrectness)
 
     // Create a composer and then add an assortment of gates designed to ensure that the constraint(s) represented
     // by each relation are non-trivially exercised.
-    auto builder = proof_system::UltraCircuitBuilder();
+    auto builder = bb::UltraCircuitBuilder();
 
     // Create an assortment of representative gates
     create_some_add_gates<Flavor>(builder);
@@ -310,7 +310,7 @@ TEST_F(RelationCorrectnessTests, GoblinUltraRelationCorrectness)
 
     // Create a composer and then add an assortment of gates designed to ensure that the constraint(s) represented
     // by each relation are non-trivially exercised.
-    auto builder = proof_system::GoblinUltraCircuitBuilder();
+    auto builder = bb::GoblinUltraCircuitBuilder();
 
     // Create an assortment of representative gates
     create_some_add_gates<Flavor>(builder);
@@ -377,7 +377,7 @@ TEST_F(RelationCorrectnessTests, GoblinTranslatorPermutationRelationCorrectness)
     using FF = typename Flavor::FF;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     using Polynomial = bb::Polynomial<FF>;
-    using namespace proof_system::honk::permutation_library;
+    using namespace bb::honk::permutation_library;
     auto& engine = numeric::random::get_debug_engine();
     auto circuit_size = Flavor::MINI_CIRCUIT_SIZE * Flavor::CONCATENATION_INDEX;
 
@@ -385,7 +385,7 @@ TEST_F(RelationCorrectnessTests, GoblinTranslatorPermutationRelationCorrectness)
     FF gamma = FF::random_element();
 
     // Fill relation parameters
-    proof_system::RelationParameters<FF> params;
+    bb::RelationParameters<FF> params;
     params.gamma = gamma;
 
     // Create storage for polynomials
@@ -479,7 +479,7 @@ TEST_F(RelationCorrectnessTests, GoblinTranslatorPermutationRelationCorrectness)
     compute_concatenated_polynomials<Flavor>(&prover_polynomials);
 
     // Compute the grand product polynomial
-    grand_product_library::compute_grand_product<Flavor, proof_system::GoblinTranslatorPermutationRelation<FF>>(
+    grand_product_library::compute_grand_product<Flavor, bb::GoblinTranslatorPermutationRelation<FF>>(
         circuit_size, prover_polynomials, params);
     prover_polynomials.z_perm_shift = prover_polynomials.z_perm.shifted();
 
@@ -502,7 +502,7 @@ TEST_F(RelationCorrectnessTests, GoblinTranslatorGenPermSortRelationCorrectness)
     const auto max_value = (1 << Flavor::MICRO_LIMB_BITS) - 1;
 
     // No relation parameters are used in this relation
-    proof_system::RelationParameters<FF> params;
+    bb::RelationParameters<FF> params;
 
     ProverPolynomials prover_polynomials;
     // Allocate polynomials
@@ -583,7 +583,7 @@ TEST_F(RelationCorrectnessTests, GoblinTranslatorExtraRelationsCorrectness)
     auto mini_circuit_size = Flavor::MINI_CIRCUIT_SIZE;
 
     // We only use accumulated_result from relation parameters in this relation
-    proof_system::RelationParameters<FF> params;
+    bb::RelationParameters<FF> params;
     params.accumulated_result = {
         FF::random_element(), FF::random_element(), FF::random_element(), FF::random_element()
     };
@@ -684,7 +684,7 @@ TEST_F(RelationCorrectnessTests, GoblinTranslatorDecompositionRelationCorrectnes
     auto circuit_size = Flavor::FULL_CIRCUIT_SIZE;
 
     // Decomposition relation doesn't use any relation parameters
-    proof_system::RelationParameters<FF> params;
+    bb::RelationParameters<FF> params;
 
     // Create storage for polynomials
     ProverPolynomials prover_polynomials;
@@ -1060,7 +1060,7 @@ TEST_F(RelationCorrectnessTests, GoblinTranslatorNonNativeRelationCorrectness)
 
     auto& engine = numeric::random::get_debug_engine();
 
-    auto op_queue = std::make_shared<proof_system::ECCOpQueue>();
+    auto op_queue = std::make_shared<bb::ECCOpQueue>();
 
     // Generate random EccOpQueue actions
     for (size_t i = 0; i < ((Flavor::MINI_CIRCUIT_SIZE >> 1) - 1); i++) {
@@ -1083,11 +1083,10 @@ TEST_F(RelationCorrectnessTests, GoblinTranslatorNonNativeRelationCorrectness)
     const auto evaluation_input_x = BF::random_element(&engine);
 
     // Generating all the values is pretty tedious, so just use CircuitBuilder
-    auto circuit_builder =
-        proof_system::GoblinTranslatorCircuitBuilder(batching_challenge_v, evaluation_input_x, op_queue);
+    auto circuit_builder = bb::GoblinTranslatorCircuitBuilder(batching_challenge_v, evaluation_input_x, op_queue);
 
     // The non-native field relation uses limbs of evaluation_input_x and powers of batching_challenge_v as inputs
-    proof_system::RelationParameters<FF> params;
+    bb::RelationParameters<FF> params;
     auto v_power = BF::one();
     for (size_t i = 0; i < 4 /*Number of powers of v that we need {1,2,3,4}*/; i++) {
         v_power *= batching_challenge_v;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/sumcheck.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/sumcheck.test.cpp
@@ -14,10 +14,10 @@
 
 #include <gtest/gtest.h>
 
-using namespace proof_system::honk;
-using namespace proof_system::honk::sumcheck;
+using namespace bb::honk;
+using namespace bb::honk::sumcheck;
 
-using Flavor = proof_system::honk::flavor::Ultra;
+using Flavor = bb::honk::flavor::Ultra;
 using FF = typename Flavor::FF;
 
 namespace test_sumcheck_round {
@@ -39,7 +39,7 @@ TEST_F(SumcheckTestsRealCircuit, Ultra)
     using RelationSeparator = typename Flavor::RelationSeparator;
 
     // Create a composer and a dummy circuit with a few gates
-    auto builder = proof_system::UltraCircuitBuilder();
+    auto builder = bb::UltraCircuitBuilder();
     FF a = FF::one();
 
     // Add some basic add gates, with a public input for good measure

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.cpp
@@ -4,7 +4,7 @@
 #include "barretenberg/proof_system/composer/permutation_lib.hpp"
 #include "barretenberg/proof_system/library/grand_product_library.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 /**
  * Compute verification key consisting of selector precommitments.
@@ -132,4 +132,4 @@ DeciderVerifier_<Flavor> UltraComposer_<Flavor>::create_decider_verifier(const s
 
 template class UltraComposer_<honk::flavor::Ultra>;
 template class UltraComposer_<honk::flavor::GoblinUltra>;
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.hpp
@@ -12,7 +12,7 @@
 #include "barretenberg/ultra_honk/ultra_prover.hpp"
 #include "barretenberg/ultra_honk/ultra_verifier.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 template <UltraFlavor Flavor> class UltraComposer_ {
   public:
     using CircuitBuilder = typename Flavor::CircuitBuilder;
@@ -137,4 +137,4 @@ template <UltraFlavor Flavor> class UltraComposer_ {
 // TODO(#532): this pattern is weird; is this not instantiating the templates?
 using UltraComposer = UltraComposer_<honk::flavor::Ultra>;
 using GoblinUltraComposer = UltraComposer_<honk::flavor::GoblinUltra>;
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.test.cpp
@@ -16,7 +16,7 @@
 #include <string>
 #include <vector>
 
-using namespace proof_system::honk;
+using namespace bb::honk;
 
 namespace test_ultra_honk_composer {
 
@@ -69,7 +69,7 @@ class UltraHonkComposerTests : public ::testing::Test {
  */
 TEST_F(UltraHonkComposerTests, ANonZeroPolynomialIsAGoodPolynomial)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
 
     auto composer = UltraComposer();
     auto instance = composer.create_instance(circuit_builder);
@@ -96,7 +96,7 @@ TEST_F(UltraHonkComposerTests, ANonZeroPolynomialIsAGoodPolynomial)
  */
 TEST_F(UltraHonkComposerTests, PublicInputs)
 {
-    auto builder = proof_system::UltraCircuitBuilder();
+    auto builder = bb::UltraCircuitBuilder();
     size_t num_gates = 10;
 
     // Add some arbitrary arithmetic gates that utilize public inputs
@@ -120,7 +120,7 @@ TEST_F(UltraHonkComposerTests, PublicInputs)
 
 TEST_F(UltraHonkComposerTests, XorConstraint)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
 
     uint32_t left_value = engine.get_random_uint32();
     uint32_t right_value = engine.get_random_uint32();
@@ -148,7 +148,7 @@ TEST_F(UltraHonkComposerTests, XorConstraint)
 
 TEST_F(UltraHonkComposerTests, create_gates_from_plookup_accumulators)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
 
     bb::fr input_value = fr::random_element();
     const fr input_lo = static_cast<uint256_t>(input_value).slice(0, plookup::fixed_base::table::BITS_PER_LO_SCALAR);
@@ -215,7 +215,7 @@ TEST_F(UltraHonkComposerTests, create_gates_from_plookup_accumulators)
 
 TEST_F(UltraHonkComposerTests, test_no_lookup_proof)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
 
     for (size_t i = 0; i < 16; ++i) {
         for (size_t j = 0; j < 16; ++j) {
@@ -240,7 +240,7 @@ TEST_F(UltraHonkComposerTests, test_elliptic_gate)
 {
     typedef grumpkin::g1::affine_element affine_element;
     typedef grumpkin::g1::element element;
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
 
     affine_element p1 = affine_element::random_element();
     affine_element p2 = affine_element::random_element();
@@ -272,7 +272,7 @@ TEST_F(UltraHonkComposerTests, test_elliptic_gate)
 
 TEST_F(UltraHonkComposerTests, non_trivial_tag_permutation)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
     fr a = fr::random_element();
     fr b = -a;
 
@@ -300,7 +300,7 @@ TEST_F(UltraHonkComposerTests, non_trivial_tag_permutation)
 
 TEST_F(UltraHonkComposerTests, non_trivial_tag_permutation_and_cycles)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
     fr a = fr::random_element();
     fr c = -a;
 
@@ -339,7 +339,7 @@ TEST_F(UltraHonkComposerTests, non_trivial_tag_permutation_and_cycles)
 TEST_F(UltraHonkComposerTests, bad_tag_permutation)
 {
     {
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         fr a = fr::random_element();
         fr b = -a;
 
@@ -364,7 +364,7 @@ TEST_F(UltraHonkComposerTests, bad_tag_permutation)
     }
     // Same as above but without tag creation to check reason of failure is really tag mismatch
     {
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         fr a = fr::random_element();
         fr b = -a;
 
@@ -384,7 +384,7 @@ TEST_F(UltraHonkComposerTests, bad_tag_permutation)
 
 TEST_F(UltraHonkComposerTests, sort_widget)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
     fr a = fr::one();
     fr b = fr(2);
     fr c = fr(3);
@@ -412,7 +412,7 @@ TEST_F(UltraHonkComposerTests, sort_with_edges_gate)
     fr h = fr(8);
 
     {
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         auto a_idx = circuit_builder.add_variable(a);
         auto b_idx = circuit_builder.add_variable(b);
         auto c_idx = circuit_builder.add_variable(c);
@@ -429,7 +429,7 @@ TEST_F(UltraHonkComposerTests, sort_with_edges_gate)
     }
 
     {
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         auto a_idx = circuit_builder.add_variable(a);
         auto b_idx = circuit_builder.add_variable(b);
         auto c_idx = circuit_builder.add_variable(c);
@@ -445,7 +445,7 @@ TEST_F(UltraHonkComposerTests, sort_with_edges_gate)
         prove_and_verify(circuit_builder, composer, /*expected_result=*/false);
     }
     {
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         auto a_idx = circuit_builder.add_variable(a);
         auto b_idx = circuit_builder.add_variable(b);
         auto c_idx = circuit_builder.add_variable(c);
@@ -461,7 +461,7 @@ TEST_F(UltraHonkComposerTests, sort_with_edges_gate)
         prove_and_verify(circuit_builder, composer, /*expected_result=*/false);
     }
     {
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         auto a_idx = circuit_builder.add_variable(a);
         auto c_idx = circuit_builder.add_variable(c);
         auto d_idx = circuit_builder.add_variable(d);
@@ -477,7 +477,7 @@ TEST_F(UltraHonkComposerTests, sort_with_edges_gate)
         prove_and_verify(circuit_builder, composer, /*expected_result=*/false);
     }
     {
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         auto idx = add_variables(circuit_builder, { 1,  2,  5,  6,  7,  10, 11, 13, 16, 17, 20, 22, 22, 25,
                                                     26, 29, 29, 32, 32, 33, 35, 38, 39, 39, 42, 42, 43, 45 });
         circuit_builder.create_sort_constraint_with_edges(idx, 1, 45);
@@ -486,7 +486,7 @@ TEST_F(UltraHonkComposerTests, sort_with_edges_gate)
         prove_and_verify(circuit_builder, composer, /*expected_result=*/true);
     }
     {
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         auto idx = add_variables(circuit_builder, { 1,  2,  5,  6,  7,  10, 11, 13, 16, 17, 20, 22, 22, 25,
                                                     26, 29, 29, 32, 32, 33, 35, 38, 39, 39, 42, 42, 43, 45 });
         circuit_builder.create_sort_constraint_with_edges(idx, 1, 29);
@@ -499,7 +499,7 @@ TEST_F(UltraHonkComposerTests, sort_with_edges_gate)
 TEST_F(UltraHonkComposerTests, range_constraint)
 {
     {
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         auto indices = add_variables(circuit_builder, { 1, 2, 3, 4, 5, 6, 7, 8 });
         for (size_t i = 0; i < indices.size(); i++) {
             circuit_builder.create_new_range_constraint(indices[i], 8);
@@ -511,7 +511,7 @@ TEST_F(UltraHonkComposerTests, range_constraint)
         prove_and_verify(circuit_builder, composer, /*expected_result=*/true);
     }
     {
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         auto indices = add_variables(circuit_builder, { 3 });
         for (size_t i = 0; i < indices.size(); i++) {
             circuit_builder.create_new_range_constraint(indices[i], 3);
@@ -523,7 +523,7 @@ TEST_F(UltraHonkComposerTests, range_constraint)
         prove_and_verify(circuit_builder, composer, /*expected_result=*/true);
     }
     {
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         auto indices = add_variables(circuit_builder, { 1, 2, 3, 4, 5, 6, 8, 25 });
         for (size_t i = 0; i < indices.size(); i++) {
             circuit_builder.create_new_range_constraint(indices[i], 8);
@@ -534,7 +534,7 @@ TEST_F(UltraHonkComposerTests, range_constraint)
         prove_and_verify(circuit_builder, composer, /*expected_result=*/false);
     }
     {
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         auto indices =
             add_variables(circuit_builder, { 1, 2, 3, 4, 5, 6, 10, 8, 15, 11, 32, 21, 42, 79, 16, 10, 3, 26, 19, 51 });
         for (size_t i = 0; i < indices.size(); i++) {
@@ -546,7 +546,7 @@ TEST_F(UltraHonkComposerTests, range_constraint)
         prove_and_verify(circuit_builder, composer, /*expected_result=*/true);
     }
     {
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         auto indices =
             add_variables(circuit_builder, { 1, 2, 3, 80, 5, 6, 29, 8, 15, 11, 32, 21, 42, 79, 16, 10, 3, 26, 13, 14 });
         for (size_t i = 0; i < indices.size(); i++) {
@@ -558,7 +558,7 @@ TEST_F(UltraHonkComposerTests, range_constraint)
         prove_and_verify(circuit_builder, composer, /*expected_result=*/false);
     }
     {
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         auto indices =
             add_variables(circuit_builder, { 1, 0, 3, 80, 5, 6, 29, 8, 15, 11, 32, 21, 42, 79, 16, 10, 3, 26, 13, 14 });
         for (size_t i = 0; i < indices.size(); i++) {
@@ -573,7 +573,7 @@ TEST_F(UltraHonkComposerTests, range_constraint)
 
 TEST_F(UltraHonkComposerTests, range_with_gates)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
     auto idx = add_variables(circuit_builder, { 1, 2, 3, 4, 5, 6, 7, 8 });
     for (size_t i = 0; i < idx.size(); i++) {
         circuit_builder.create_new_range_constraint(idx[i], 8);
@@ -592,7 +592,7 @@ TEST_F(UltraHonkComposerTests, range_with_gates)
 
 TEST_F(UltraHonkComposerTests, range_with_gates_where_range_is_not_a_power_of_two)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
     auto idx = add_variables(circuit_builder, { 1, 2, 3, 4, 5, 6, 7, 8 });
     for (size_t i = 0; i < idx.size(); i++) {
         circuit_builder.create_new_range_constraint(idx[i], 12);
@@ -613,7 +613,7 @@ TEST_F(UltraHonkComposerTests, sort_widget_complex)
 {
     {
 
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         std::vector<fr> a = { 1, 3, 4, 7, 7, 8, 11, 14, 15, 15, 18, 19, 21, 21, 24, 25, 26, 27, 30, 32 };
         std::vector<uint32_t> ind;
         for (size_t i = 0; i < a.size(); i++)
@@ -625,7 +625,7 @@ TEST_F(UltraHonkComposerTests, sort_widget_complex)
     }
     {
 
-        auto circuit_builder = proof_system::UltraCircuitBuilder();
+        auto circuit_builder = bb::UltraCircuitBuilder();
         std::vector<fr> a = { 1, 3, 4, 7, 7, 8, 16, 14, 15, 15, 18, 19, 21, 21, 24, 25, 26, 27, 30, 32 };
         std::vector<uint32_t> ind;
         for (size_t i = 0; i < a.size(); i++)
@@ -639,7 +639,7 @@ TEST_F(UltraHonkComposerTests, sort_widget_complex)
 
 TEST_F(UltraHonkComposerTests, sort_widget_neg)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
     fr a = fr::one();
     fr b = fr(2);
     fr c = fr(3);
@@ -657,7 +657,7 @@ TEST_F(UltraHonkComposerTests, sort_widget_neg)
 
 TEST_F(UltraHonkComposerTests, composed_range_constraint)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
     auto c = fr::random_element();
     auto d = uint256_t(c).slice(0, 133);
     auto e = fr(d);
@@ -672,7 +672,7 @@ TEST_F(UltraHonkComposerTests, composed_range_constraint)
 TEST_F(UltraHonkComposerTests, non_native_field_multiplication)
 {
     using fq = bb::fq;
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
 
     fq a = fq::random_element();
     fq b = fq::random_element();
@@ -716,7 +716,7 @@ TEST_F(UltraHonkComposerTests, non_native_field_multiplication)
     const auto q_indices = get_limb_witness_indices(split_into_limbs(uint256_t(q)));
     const auto r_indices = get_limb_witness_indices(split_into_limbs(uint256_t(r)));
 
-    proof_system::non_native_field_witnesses<fr> inputs{
+    bb::non_native_field_witnesses<fr> inputs{
         a_indices, b_indices, q_indices, r_indices, modulus_limbs, fr(uint256_t(modulus)),
     };
     const auto [lo_1_idx, hi_1_idx] = circuit_builder.evaluate_non_native_field_multiplication(inputs);
@@ -728,7 +728,7 @@ TEST_F(UltraHonkComposerTests, non_native_field_multiplication)
 
 TEST_F(UltraHonkComposerTests, rom)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
 
     uint32_t rom_values[8]{
         circuit_builder.add_variable(fr::random_element()), circuit_builder.add_variable(fr::random_element()),
@@ -770,7 +770,7 @@ TEST_F(UltraHonkComposerTests, rom)
 
 TEST_F(UltraHonkComposerTests, ram)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
 
     uint32_t ram_values[8]{
         circuit_builder.add_variable(fr::random_element()), circuit_builder.add_variable(fr::random_element()),
@@ -834,7 +834,7 @@ TEST_F(UltraHonkComposerTests, ram)
 
 TEST_F(UltraHonkComposerTests, range_checks_on_duplicates)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
 
     uint32_t a = circuit_builder.add_variable(100);
     uint32_t b = circuit_builder.add_variable(100);
@@ -874,7 +874,7 @@ TEST_F(UltraHonkComposerTests, range_checks_on_duplicates)
 // before range constraints are applied to it.
 TEST_F(UltraHonkComposerTests, range_constraint_small_variable)
 {
-    auto circuit_builder = proof_system::UltraCircuitBuilder();
+    auto circuit_builder = bb::UltraCircuitBuilder();
 
     uint16_t mask = (1 << 8) - 1;
     int a = engine.get_random_uint16() & mask;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
@@ -1,7 +1,7 @@
 #include "ultra_prover.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 /**
  * Create UltraProver_ from an instance.
@@ -215,4 +215,4 @@ template <UltraFlavor Flavor> plonk::proof& UltraProver_<Flavor>::construct_proo
 template class UltraProver_<honk::flavor::Ultra>;
 template class UltraProver_<honk::flavor::GoblinUltra>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.hpp
@@ -8,7 +8,7 @@
 #include "barretenberg/sumcheck/sumcheck_output.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 template <UltraFlavor Flavor> class UltraProver_ {
     using FF = typename Flavor::FF;
@@ -42,7 +42,7 @@ template <UltraFlavor Flavor> class UltraProver_ {
 
     std::shared_ptr<Transcript> transcript;
 
-    proof_system::RelationParameters<FF> relation_parameters;
+    bb::RelationParameters<FF> relation_parameters;
 
     CommitmentLabels commitment_labels;
 
@@ -61,4 +61,4 @@ template <UltraFlavor Flavor> class UltraProver_ {
 using UltraProver = UltraProver_<honk::flavor::Ultra>;
 using GoblinUltraProver = UltraProver_<honk::flavor::GoblinUltra>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_transcript.test.cpp
@@ -6,13 +6,13 @@
 #include "barretenberg/ultra_honk/ultra_composer.hpp"
 #include <gtest/gtest.h>
 
-using namespace proof_system::honk;
+using namespace bb::honk;
 
 class UltraTranscriptTests : public ::testing::Test {
   public:
     static void SetUpTestSuite() { bb::srs::init_crs_factory("../srs_db/ignition"); }
 
-    using Flavor = proof_system::honk::flavor::Ultra;
+    using Flavor = bb::honk::flavor::Ultra;
     using FF = Flavor::FF;
 
     /**

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
@@ -4,9 +4,9 @@
 #include "barretenberg/transcript/transcript.hpp"
 
 using namespace bb;
-using namespace proof_system::honk::sumcheck;
+using namespace bb::honk::sumcheck;
 
-namespace proof_system::honk {
+namespace bb::honk {
 template <typename Flavor>
 UltraVerifier_<Flavor>::UltraVerifier_(const std::shared_ptr<Transcript>& transcript,
                                        const std::shared_ptr<VerificationKey>& verifier_key)
@@ -54,7 +54,7 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const plonk
     using VerifierCommitments = typename Flavor::VerifierCommitments;
     using CommitmentLabels = typename Flavor::CommitmentLabels;
 
-    proof_system::RelationParameters<FF> relation_parameters;
+    bb::RelationParameters<FF> relation_parameters;
 
     transcript = std::make_shared<Transcript>(proof.proof_data);
 
@@ -166,4 +166,4 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const plonk
 template class UltraVerifier_<honk::flavor::Ultra>;
 template class UltraVerifier_<honk::flavor::GoblinUltra>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.hpp
@@ -5,7 +5,7 @@
 #include "barretenberg/srs/global_crs.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 template <typename Flavor> class UltraVerifier_ {
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
@@ -35,4 +35,4 @@ template <typename Flavor> class UltraVerifier_ {
 using UltraVerifier = UltraVerifier_<honk::flavor::Ultra>;
 using GoblinUltraVerifier = UltraVerifier_<honk::flavor::GoblinUltra>;
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/AvmMini_common.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/AvmMini_common.hpp
@@ -3,9 +3,9 @@
 #include "barretenberg/proof_system/circuit_builder/circuit_builder_base.hpp"
 #include "barretenberg/proof_system/circuit_builder/generated/AvmMini_circuit_builder.hpp"
 
-using Flavor = proof_system::honk::flavor::AvmMiniFlavor;
+using Flavor = bb::honk::flavor::AvmMiniFlavor;
 using FF = Flavor::FF;
-using Row = proof_system::AvmMiniFullRow<bb::fr>;
+using Row = bb::AvmMiniFullRow<bb::fr>;
 
 namespace avm_trace {
 

--- a/barretenberg/cpp/src/barretenberg/vm/generated/AvmMini_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/AvmMini_composer.cpp
@@ -6,7 +6,7 @@
 #include "barretenberg/proof_system/composer/permutation_lib.hpp"
 #include "barretenberg/vm/generated/AvmMini_verifier.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 using Flavor = honk::flavor::AvmMiniFlavor;
 void AvmMiniComposer::compute_witness(CircuitConstructor& circuit)
@@ -83,4 +83,4 @@ std::shared_ptr<Flavor::VerificationKey> AvmMiniComposer::compute_verification_k
     return verification_key;
 }
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/vm/generated/AvmMini_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/AvmMini_composer.hpp
@@ -8,7 +8,7 @@
 #include "barretenberg/vm/generated/AvmMini_prover.hpp"
 #include "barretenberg/vm/generated/AvmMini_verifier.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 class AvmMiniComposer {
   public:
     using Flavor = honk::flavor::AvmMiniFlavor;
@@ -66,4 +66,4 @@ class AvmMiniComposer {
     };
 };
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/vm/generated/AvmMini_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/AvmMini_prover.cpp
@@ -11,7 +11,7 @@
 #include "barretenberg/relations/permutation_relation.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 using Flavor = honk::flavor::AvmMiniFlavor;
 
@@ -29,13 +29,12 @@ AvmMiniProver::AvmMiniProver(std::shared_ptr<Flavor::ProvingKey> input_key,
     , commitment_key(commitment_key)
 {
     for (auto [prover_poly, key_poly] : zip_view(prover_polynomials.get_unshifted(), key->get_all())) {
-        ASSERT(proof_system::flavor_get_label(prover_polynomials, prover_poly) ==
-               proof_system::flavor_get_label(*key, key_poly));
+        ASSERT(bb::flavor_get_label(prover_polynomials, prover_poly) == bb::flavor_get_label(*key, key_poly));
         prover_poly = key_poly.share();
     }
     for (auto [prover_poly, key_poly] : zip_view(prover_polynomials.get_shifted(), key->get_to_be_shifted())) {
-        ASSERT(proof_system::flavor_get_label(prover_polynomials, prover_poly) ==
-               proof_system::flavor_get_label(*key, key_poly) + "_shift");
+        ASSERT(bb::flavor_get_label(prover_polynomials, prover_poly) ==
+               bb::flavor_get_label(*key, key_poly) + "_shift");
         prover_poly = key_poly.shifted();
     }
 }
@@ -130,4 +129,4 @@ plonk::proof& AvmMiniProver::construct_proof()
     return export_proof();
 }
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/vm/generated/AvmMini_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/AvmMini_prover.hpp
@@ -8,7 +8,7 @@
 #include "barretenberg/sumcheck/sumcheck_output.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 class AvmMiniProver {
 
@@ -38,7 +38,7 @@ class AvmMiniProver {
 
     std::vector<FF> public_inputs;
 
-    proof_system::RelationParameters<FF> relation_parameters;
+    bb::RelationParameters<FF> relation_parameters;
 
     std::shared_ptr<ProvingKey> key;
 
@@ -59,4 +59,4 @@ class AvmMiniProver {
     plonk::proof proof;
 };
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/vm/generated/AvmMini_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/AvmMini_verifier.cpp
@@ -6,9 +6,9 @@
 #include "barretenberg/transcript/transcript.hpp"
 
 using namespace bb;
-using namespace proof_system::honk::sumcheck;
+using namespace bb::honk::sumcheck;
 
-namespace proof_system::honk {
+namespace bb::honk {
 AvmMiniVerifier::AvmMiniVerifier(std::shared_ptr<Flavor::VerificationKey> verifier_key)
     : key(verifier_key)
 {}
@@ -147,4 +147,4 @@ bool AvmMiniVerifier::verify_proof(const plonk::proof& proof)
     return sumcheck_verified.value();
 }
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/vm/generated/AvmMini_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/AvmMini_verifier.hpp
@@ -5,7 +5,7 @@
 #include "barretenberg/plonk/proof_system/types/proof.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 class AvmMiniVerifier {
     using Flavor = honk::flavor::AvmMiniFlavor;
     using FF = Flavor::FF;
@@ -30,4 +30,4 @@ class AvmMiniVerifier {
     std::shared_ptr<Transcript> transcript;
 };
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/vm/generated/Toy_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/Toy_composer.cpp
@@ -6,7 +6,7 @@
 #include "barretenberg/proof_system/composer/permutation_lib.hpp"
 #include "barretenberg/vm/generated/Toy_verifier.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 using Flavor = honk::flavor::ToyFlavor;
 void ToyComposer::compute_witness(CircuitConstructor& circuit)
@@ -82,4 +82,4 @@ std::shared_ptr<Flavor::VerificationKey> ToyComposer::compute_verification_key(C
     return verification_key;
 }
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/vm/generated/Toy_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/Toy_composer.hpp
@@ -8,7 +8,7 @@
 #include "barretenberg/vm/generated/Toy_prover.hpp"
 #include "barretenberg/vm/generated/Toy_verifier.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 class ToyComposer {
   public:
     using Flavor = honk::flavor::ToyFlavor;
@@ -66,4 +66,4 @@ class ToyComposer {
     };
 };
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/vm/generated/Toy_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/Toy_prover.cpp
@@ -11,7 +11,7 @@
 #include "barretenberg/relations/permutation_relation.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 using Flavor = honk::flavor::ToyFlavor;
 
@@ -28,13 +28,12 @@ ToyProver::ToyProver(std::shared_ptr<Flavor::ProvingKey> input_key, std::shared_
     , commitment_key(commitment_key)
 {
     for (auto [prover_poly, key_poly] : zip_view(prover_polynomials.get_unshifted(), key->get_all())) {
-        ASSERT(proof_system::flavor_get_label(prover_polynomials, prover_poly) ==
-               proof_system::flavor_get_label(*key, key_poly));
+        ASSERT(bb::flavor_get_label(prover_polynomials, prover_poly) == bb::flavor_get_label(*key, key_poly));
         prover_poly = key_poly.share();
     }
     for (auto [prover_poly, key_poly] : zip_view(prover_polynomials.get_shifted(), key->get_to_be_shifted())) {
-        ASSERT(proof_system::flavor_get_label(prover_polynomials, prover_poly) ==
-               proof_system::flavor_get_label(*key, key_poly) + "_shift");
+        ASSERT(bb::flavor_get_label(prover_polynomials, prover_poly) ==
+               bb::flavor_get_label(*key, key_poly) + "_shift");
         prover_poly = key_poly.shifted();
     }
 }
@@ -128,4 +127,4 @@ plonk::proof& ToyProver::construct_proof()
     return export_proof();
 }
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/vm/generated/Toy_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/Toy_prover.hpp
@@ -8,7 +8,7 @@
 #include "barretenberg/sumcheck/sumcheck_output.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 
 class ToyProver {
 
@@ -38,7 +38,7 @@ class ToyProver {
 
     std::vector<FF> public_inputs;
 
-    proof_system::RelationParameters<FF> relation_parameters;
+    bb::RelationParameters<FF> relation_parameters;
 
     std::shared_ptr<ProvingKey> key;
 
@@ -59,4 +59,4 @@ class ToyProver {
     plonk::proof proof;
 };
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/vm/generated/Toy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/Toy_verifier.cpp
@@ -6,9 +6,9 @@
 #include "barretenberg/transcript/transcript.hpp"
 
 using namespace bb;
-using namespace proof_system::honk::sumcheck;
+using namespace bb::honk::sumcheck;
 
-namespace proof_system::honk {
+namespace bb::honk {
 ToyVerifier::ToyVerifier(std::shared_ptr<Flavor::VerificationKey> verifier_key)
     : key(verifier_key)
 {}
@@ -113,4 +113,4 @@ bool ToyVerifier::verify_proof(const plonk::proof& proof)
     return sumcheck_verified.value();
 }
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/vm/generated/Toy_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/Toy_verifier.hpp
@@ -5,7 +5,7 @@
 #include "barretenberg/plonk/proof_system/types/proof.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
 
-namespace proof_system::honk {
+namespace bb::honk {
 class ToyVerifier {
     using Flavor = honk::flavor::ToyFlavor;
     using FF = Flavor::FF;
@@ -30,4 +30,4 @@ class ToyVerifier {
     std::shared_ptr<Transcript> transcript;
 };
 
-} // namespace proof_system::honk
+} // namespace bb::honk

--- a/barretenberg/cpp/src/barretenberg/vm/tests/helpers.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/tests/helpers.test.cpp
@@ -15,12 +15,12 @@ using namespace avm_trace;
  */
 void validate_trace_proof(std::vector<Row>&& trace)
 {
-    auto circuit_builder = proof_system::AvmMiniCircuitBuilder();
+    auto circuit_builder = bb::AvmMiniCircuitBuilder();
     circuit_builder.set_trace(std::move(trace));
 
     EXPECT_TRUE(circuit_builder.check_circuit());
 
-    auto composer = proof_system::honk::AvmMiniComposer();
+    auto composer = bb::honk::AvmMiniComposer();
     auto prover = composer.create_prover(circuit_builder);
     auto proof = prover.construct_proof();
 


### PR DESCRIPTION
This is just a rename. Followups include getting rid of 'using namespace bb;' statements where now redundant 