### PR TITLE
refactor: Remove unnecessary computation

### DIFF
--- a/l1-contracts/src/core/libraries/decoders/Decoder.sol
+++ b/l1-contracts/src/core/libraries/decoders/Decoder.sol
@@ -385,6 +385,7 @@ library Decoder {
       for (uint256 j = 0; j < treeSize; j += 2) {
         _leafs[j / 2] = sha256(bytes.concat(_leafs[j], _leafs[j + 1]));
       }
+      treeSize /= 2;
     }
 
     return _leafs[0];

--- a/l1-contracts/src/core/libraries/decoders/TxsDecoder.sol
+++ b/l1-contracts/src/core/libraries/decoders/TxsDecoder.sol
@@ -268,6 +268,7 @@ library TxsDecoder {
       for (uint256 j = 0; j < treeSize; j += 2) {
         _leafs[j / 2] = sha256(bytes.concat(_leafs[j], _leafs[j + 1]));
       }
+      treeSize /= 2;
     }
 
     return _leafs[0];


### PR DESCRIPTION
The merkle tree computations were done a bit hastily so seems like it was forgotten to reduce how much was computed. Not producing unexpected results, just computing unused hashes, so this pr is removing those unneeded computations. 