### PR TITLE
chore(docs): aztec-up doesnt need `latest`, remove warnings around sandbox/cli npm pkgs

### DIFF
--- a/docs/docs/dev_docs/cli/cli-commands.md
+++ b/docs/docs/dev_docs/cli/cli-commands.md
@@ -13,28 +13,6 @@ Here you will find a reference to the commands available in the Aztec CLI.
 
 The CLI will be installed automatically via Docker by running the command to install and start the sandbox, [instructions here](./sandbox-reference.md#with-docker).
 
-:::info
-
-The `@aztec/aztec-sandbox` and `@aztec/cli` packages published to npm **should not be used**, in favor of Docker. If you've installed the sandbox or the CLI via NPM, **uninstall** them and remove them from your project dependencies and [install via Docker](./sandbox-reference.md#with-docker).
-
-<Tabs>
-  <TabItem value="yarn" label="yarn" default>
-    
-<code>
-yarn global remove @aztec/aztec-sandbox @aztec/cli
-</code>
-
-  </TabItem>
-  <TabItem value="npm" label="npm">
-
-<code>
-npm -g uninstall @aztec/aztec-sandbox @aztec/cli
-</code>
-
-   </TabItem>
-</Tabs>
-:::
-
 ## Update
 
 The CLI comes with an update command.

--- a/docs/docs/dev_docs/updating.md
+++ b/docs/docs/dev_docs/updating.md
@@ -2,34 +2,12 @@
 title: Updating
 ---
 
-:::info
-The `@aztec/aztec-sandbox` and `@aztec/cli` packages published to npm **should not be used**, in favor of Docker. If you've installed the sandbox or the CLI via NPM, **uninstall** them and remove them from your project dependencies and [install via Docker](./cli/sandbox-reference.md#with-docker).
-
-<Tabs>
-  <TabItem value="yarn" label="yarn" default>
-    
-<code>
-yarn global remove @aztec/aztec-sandbox @aztec/cli
-</code>
-
-  </TabItem>
-  <TabItem value="npm" label="npm">
-
-<code>
-npm -g uninstall @aztec/aztec-sandbox @aztec/cli
-</code>
-
-   </TabItem>
-</Tabs>
-
-:::
-
 ## TL;DR
 
 1. Updating the sandbox and CLI:
 
 ```shell
-aztec-up latest
+aztec-up
 ```
 
 2. Updating aztec-nr and individual @aztec dependencies:
@@ -47,13 +25,15 @@ The sandbox must be running for the update command to work. Make sure it is [ins
 
 ---
 
-There are three components whose versions need to be kept compatible:
+There are four components whose versions need to be kept compatible:
 
 1. Aztec Sandbox
 2. Aztec CLI
-3. `Aztec.nr`, the Noir framework for writing Aztec contracts
+3. aztec-nargo
+4. `Aztec.nr`, the Noir framework for writing Aztec contracts
 
-All three are using the same versioning scheme and their versions must match. Docker ensures that the sandbox and CLI are always compatible, but you need to update Aztec.nr manually or using `aztec-cli update`.
+First three are packaged together in docker and are kept compatible by running `aztec-up`.
+But you need to update your Aztec.nr version manually or using `aztec-cli update`.
 
 ## Updating Aztec.nr packages
 
@@ -91,5 +71,5 @@ If the dependencies fail to resolve ensure that the tag matches a tag in the [az
 `aztec-nargo` is updated by running:
 
 ```bash
-aztec-up latest
+aztec-up
 ```

--- a/yarn-project/cli/README.md
+++ b/yarn-project/cli/README.md
@@ -3,20 +3,12 @@
 The Aztec CLI `aztec-cli` is a command-line interface (CLI) tool for interacting with Aztec. It provides various commands for deploying contracts, creating accounts, interacting with contracts, and retrieving blockchain data.
 
 ## Installation
+1. In your terminal, download the sandbox by running
+```
+bash -i <(curl -s install.aztec.network)
+```
 
-To use `aztec-cli`, you need to have Node.js installed on your system. Follow these steps to install and set up the CLI tool:
-
-1. Install Node.js: Visit the official Node.js website (https://nodejs.org) and download the installer for your operating system. Follow the installation instructions to install Node.js.
-
-2. Install `aztec-cli` package: Open a terminal or command prompt and run the following command to install `aztec-cli` globally on your system:
-
-   ```shell
-   npm install -g @aztec/cli
-   ```
-
-   This will install the `aztec-cli` globally, making it accessible from any location in your terminal.
-
-3. Verify the installation: After the installation is complete, run the following command to verify that `aztec-cli` is installed correctly:
+2. Verify the installation: After the installation is complete, run the following command to verify that `aztec-cli` is installed correctly:
 
    ```shell
    aztec-cli --version


### PR DESCRIPTION
its been long enough that we don't nede to tell people to not use aztec-cli or sandbox npm pkgs