### PR TITLE
feat: replace single bit range constraints with basic bool gates

### DIFF
--- a/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp
@@ -779,7 +779,9 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization:
                                      std::string const msg = "create_new_range_constraint");
     void create_range_constraint(const uint32_t variable_index, const size_t num_bits, std::string const& msg)
     {
-        if (num_bits <= DEFAULT_PLOOKUP_RANGE_BITNUM) {
+        if (num_bits == 1) {
+            create_bool_gate(variable_index);
+        } else if (num_bits <= DEFAULT_PLOOKUP_RANGE_BITNUM) {
             /**
              * N.B. if `variable_index` is not used in any arithmetic constraints, this will create an unsatisfiable
              *      circuit!


### PR DESCRIPTION
This PR pulls the optimisation made in https://github.com/noir-lang/noir/pull/3234 across into the backend.

I've added this to the circuit builder to ensure this change gets made in the most instances of a range constraint being added, if this is undesirable then I can move it up to the `dsl` folder so we just deserialise a boolean range constraint into a normal constraint.