### PR TITLE
feat: Benchmark commit function

### DIFF
--- a/barretenberg/cpp/src/barretenberg/benchmark/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/benchmark/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(commit_bench)
 add_subdirectory(decrypt_bench)
 add_subdirectory(ipa_bench)
 add_subdirectory(pippenger_bench)

--- a/barretenberg/cpp/src/barretenberg/benchmark/commit_bench/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/benchmark/commit_bench/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Each source represents a separate benchmark suite 
+set(BENCHMARK_SOURCES
+  commit.bench.cpp
+)
+
+# Required libraries for benchmark suites
+set(LINKED_LIBRARIES
+  commitment_schemes
+  benchmark::benchmark
+)
+
+# Add executable and custom target for each suite, e.g. ultra_honk_bench
+foreach(BENCHMARK_SOURCE ${BENCHMARK_SOURCES})
+  get_filename_component(BENCHMARK_NAME ${BENCHMARK_SOURCE} NAME_WE) # extract name without extension
+  add_executable(${BENCHMARK_NAME}_bench main.bench.cpp ${BENCHMARK_SOURCE})
+  target_link_libraries(${BENCHMARK_NAME}_bench ${LINKED_LIBRARIES})
+  add_custom_target(run_${BENCHMARK_NAME} COMMAND ${BENCHMARK_NAME} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+endforeach()

--- a/barretenberg/cpp/src/barretenberg/benchmark/commit_bench/commit.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/commit_bench/commit.bench.cpp
@@ -1,0 +1,38 @@
+
+#include "barretenberg/commitment_schemes/commitment_key.hpp"
+#include <benchmark/benchmark.h>
+
+namespace bb {
+
+template <typename Curve>
+std::shared_ptr<honk::pcs::CommitmentKey<Curve>> create_commitment_key(const size_t num_points)
+{
+    std::string srs_path;
+    if constexpr (std::same_as<Curve, curve::BN254>) {
+        srs_path = "../srs_db/ignition";
+    } else {
+        static_assert(std::same_as<Curve, curve::Grumpkin>);
+        srs_path = "../srs_db/grumpkin";
+    }
+    std::shared_ptr<bb::srs::factories::CrsFactory<Curve>> crs_factory(
+        new bb::srs::factories::FileCrsFactory<Curve>(srs_path, num_points));
+    return std::make_shared<honk::pcs::CommitmentKey<Curve>>(num_points, crs_factory);
+}
+
+constexpr size_t MAX_LOG_NUM_POINTS = 24;
+constexpr size_t MAX_NUM_POINTS = 1 << 24;
+
+auto key = create_commitment_key<curve::BN254>(MAX_NUM_POINTS);
+
+template <typename Curve> void bench_commit(::benchmark::State& state)
+{
+    const size_t num_points = 1 << state.range(0);
+    const auto polynomial = Polynomial<typename Curve::ScalarField>(num_points);
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(key->commit(polynomial));
+    }
+}
+
+BENCHMARK(bench_commit<curve::BN254>)->DenseRange(10, MAX_LOG_NUM_POINTS)->Unit(benchmark::kMillisecond);
+
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/benchmark/commit_bench/commit.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/commit_bench/commit.bench.cpp
@@ -20,7 +20,7 @@ std::shared_ptr<honk::pcs::CommitmentKey<Curve>> create_commitment_key(const siz
 }
 
 constexpr size_t MAX_LOG_NUM_POINTS = 24;
-constexpr size_t MAX_NUM_POINTS = 1 << 24;
+constexpr size_t MAX_NUM_POINTS = 1 << MAX_LOG_NUM_POINTS;
 
 auto key = create_commitment_key<curve::BN254>(MAX_NUM_POINTS);
 

--- a/barretenberg/cpp/src/barretenberg/benchmark/commit_bench/main.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/commit_bench/main.bench.cpp
@@ -1,0 +1,3 @@
+#include <benchmark/benchmark.h>
+
+BENCHMARK_MAIN();

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -234,7 +234,7 @@ template <typename Fr> class Polynomial {
     static Polynomial random(const size_t num_coeffs)
     {
         Polynomial p(num_coeffs);
-        std::generate_n(p.begin(), num_coeffs, [&]() { return Fr::random_element(); });
+        std::generate_n(p.begin(), num_coeffs, []() { return Fr::random_element(); });
         return p;
     }
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -231,6 +231,15 @@ template <typename Fr> class Polynomial {
     std::size_t size() const { return size_; }
     std::size_t capacity() const { return size_ + MAXIMUM_COEFFICIENT_SHIFT; }
 
+    static Polynomial random(const size_t num_coeffs)
+    {
+        Polynomial p(num_coeffs);
+        for (size_t i = 0; i < num_coeffs; ++i) {
+            p[i] = Fr::random_element();
+        }
+        return p;
+    }
+
   private:
     // allocate a fresh memory pointer for backing memory
     // DOES NOT initialize memory

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -234,9 +234,7 @@ template <typename Fr> class Polynomial {
     static Polynomial random(const size_t num_coeffs)
     {
         Polynomial p(num_coeffs);
-        for (size_t i = 0; i < num_coeffs; ++i) {
-            p[i] = Fr::random_element();
-        }
+        std::generate_n(p.begin(), num_coeffs, [&]() { return Fr::random_element(); });
         return p;
     }
 


### PR DESCRIPTION
Straightforwardly added a benchmark of our fundamental `commit` function over BN254. Results:

```
% taskset -c 0-15 ./bin/commit_bench                                              1m 4s ~/barretenberg-cpp/build master + mainframe
2024-01-22T16:21:55+00:00
Running ./bin/commit_bench
Run on (128 X 2649.99 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x64)
  L1 Instruction 32 KiB (x64)
  L2 Unified 512 KiB (x64)
  L3 Unified 32768 KiB (x8)
Load Average: 6.56, 8.97, 11.08
------------------------------------------------------------------------
Benchmark                              Time             CPU   Iterations
------------------------------------------------------------------------
bench_commit<curve::BN254>/10      0.443 ms        0.351 ms         2010
bench_commit<curve::BN254>/11      0.853 ms        0.828 ms          833
bench_commit<curve::BN254>/12      0.900 ms        0.874 ms          860
bench_commit<curve::BN254>/13      0.845 ms        0.819 ms          788
bench_commit<curve::BN254>/14       1.06 ms        0.857 ms          822
bench_commit<curve::BN254>/15       1.32 ms        0.918 ms          744
bench_commit<curve::BN254>/16       2.08 ms         1.15 ms          606
bench_commit<curve::BN254>/17       3.42 ms         1.65 ms          421
bench_commit<curve::BN254>/18       5.21 ms         2.37 ms          300
bench_commit<curve::BN254>/19       10.2 ms         2.69 ms          200
bench_commit<curve::BN254>/20       21.4 ms         1.60 ms          331
bench_commit<curve::BN254>/21       53.9 ms         1.88 ms          100
bench_commit<curve::BN254>/22        103 ms         3.38 ms          100
bench_commit<curve::BN254>/23        225 ms         9.47 ms           55
bench_commit<curve::BN254>/24        505 ms         30.1 ms           10
```
