### PR TITLE
fix(bb): .gitignore

### DIFF
--- a/barretenberg/cpp/.gitignore
+++ b/barretenberg/cpp/.gitignore
@@ -6,8 +6,6 @@ src/barretenberg/rollup/proofs/*/fixtures
 srs_db/*/*/transcript*
 CMakeUserPresets.json
 .vscode/settings.json
-# to be unignored when we agree on clang-tidy rules
-.clangd
 acir_tests
 # we may download go in scripts/collect_heap_information.sh
 go*.tar.gz


### PR DESCRIPTION
We have indeed decided on some clang-tidy rules.