### PR TITLE
feat: Produce graph of internal Barretenberg dependencies

### DIFF
--- a/barretenberg/cpp/.gitignore
+++ b/barretenberg/cpp/.gitignore
@@ -9,3 +9,5 @@ CMakeUserPresets.json
 acir_tests
 # we may download go in scripts/collect_heap_information.sh
 go*.tar.gz
+barretenberg_modules.dot
+barretenberg_modules.png

--- a/barretenberg/cpp/scripts/barretenberg_module_digraph.sh
+++ b/barretenberg/cpp/scripts/barretenberg_module_digraph.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -eu
+
+TMP=tmp.dot;
+RESULT_DOT=barretenberg_modules.dot;
+RESULT_PNG=barretenberg_modules.png;
+
+# initialize a directed graph for graphviz
+echo digraph BarretenbergModules { > $TMP;
+# populate the directed graph
+for file in $(find ./src/barretenberg/ -iname CMakeLists.txt); do
+  opening_chars=$(head -c 19 "$file");
+    if [ "$opening_chars" == barretenberg_module ]; then
+      awk -f ./scripts/barretenberg_module_digraph_edges.awk $file >> $TMP
+    fi;
+done;
+echo } >> $TMP;
+
+# apply transitive reduction to remove dependcies that are implied by satisfied by other dependencies
+cat $TMP | tred > $RESULT_DOT;
+rm $TMP;
+
+# produce a PNG of the graph
+dot -Tpng $RESULT_DOT -o $RESULT_PNG

--- a/barretenberg/cpp/scripts/barretenberg_module_digraph.sh
+++ b/barretenberg/cpp/scripts/barretenberg_module_digraph.sh
@@ -16,7 +16,7 @@ for file in $(find ./src/barretenberg/ -iname CMakeLists.txt); do
 done;
 echo } >> $TMP;
 
-# apply transitive reduction to remove dependcies that are implied by satisfied by other dependencies
+# apply transitive reduction to remove dependcies that are implied by other dependencies
 cat $TMP | tred > $RESULT_DOT;
 rm $TMP;
 

--- a/barretenberg/cpp/scripts/barretenberg_module_digraph.sh
+++ b/barretenberg/cpp/scripts/barretenberg_module_digraph.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
 set -eu
 
-TMP=tmp.dot;
-RESULT_DOT=barretenberg_modules.dot;
-RESULT_PNG=barretenberg_modules.png;
+TMP=tmp.dot
+RESULT_DOT=barretenberg_modules.dot
+RESULT_PNG=barretenberg_modules.png
 
 # initialize a directed graph for graphviz
-echo digraph BarretenbergModules { > $TMP;
+echo digraph BarretenbergModules { > $TMP
 # populate the directed graph
 for file in $(find ./src/barretenberg/ -iname CMakeLists.txt); do
-  opening_chars=$(head -c 19 "$file");
+  opening_chars=$(head -c 19 "$file")
     if [ "$opening_chars" == barretenberg_module ]; then
       awk -f ./scripts/barretenberg_module_digraph_edges.awk $file >> $TMP
-    fi;
-done;
-echo } >> $TMP;
+    fi
+done
+echo } >> $TMP
 
 # apply transitive reduction to remove dependcies that are implied by other dependencies
-cat $TMP | tred > $RESULT_DOT;
-rm $TMP;
+cat $TMP | tred > $RESULT_DOT
+rm $TMP
 
 # produce a PNG of the graph
 dot -Tpng $RESULT_DOT -o $RESULT_PNG

--- a/barretenberg/cpp/scripts/barretenberg_module_digraph_edges.awk
+++ b/barretenberg/cpp/scripts/barretenberg_module_digraph_edges.awk
@@ -7,9 +7,14 @@ function extract_edges(line) {
     gsub(/[ ]+/, " ", line); # Sub multiple spaces for a single space
     split(line, modules, " ");
 
-    # Print each element in the array
-    for (i = 2; i <= length(modules); i++) {
-        print modules[1]" -> "modules[i];
+    # If node has no dependencies, just add the node
+    if (length(modules)==1) {
+        print modules[1];
+    }
+    else { # add edges
+        for (i = 2; i <= length(modules); i++) {
+            print modules[1]" -> "modules[i];
+        }
     }
 }
 

--- a/barretenberg/cpp/scripts/barretenberg_module_digraph_edges.awk
+++ b/barretenberg/cpp/scripts/barretenberg_module_digraph_edges.awk
@@ -5,7 +5,7 @@ function extract_edges(line) {
     gsub(/^[ ]+/, "", line); # Remove leading spaces and tabs
     gsub(/[ ]+$/, "", line); # Remove trailing spaces and tabs
     gsub(/[ ]+/, " ", line); # Sub multiple spaces for a single space
-    split(line, modules, " ");
+    split(line, modules, " "); # Split into an array of words
 
     # If node has no dependencies, just add the node
     if (length(modules)==1) {
@@ -20,7 +20,7 @@ function extract_edges(line) {
 
 # Main AWK script
 {
-    # Concatenate lines if the opening parentheses is not closed
+    # Concatenate lines if the opening parenthesis is not closed
     while (!/\)/) {
         current_line = $0;
         getline;

--- a/barretenberg/cpp/scripts/barretenberg_module_digraph_edges.awk
+++ b/barretenberg/cpp/scripts/barretenberg_module_digraph_edges.awk
@@ -1,0 +1,30 @@
+# Function to extract words between parentheses
+function extract_edges(line) {
+    match(line, /\(.*\)/);  # Find the portion within parentheses
+    line = substr(line, RSTART + 1, RLENGTH - 2);  # Extract the words
+    gsub(/^[ ]+/, "", line); # Remove leading spaces and tabs
+    gsub(/[ ]+$/, "", line); # Remove trailing spaces and tabs
+    gsub(/[ ]+/, " ", line); # Sub multiple spaces for a single space
+    split(line, modules, " ");
+
+    # Print each element in the array
+    for (i = 2; i <= length(modules); i++) {
+        print modules[1]" -> "modules[i];
+    }
+}
+
+# Main AWK script
+{
+    # Concatenate lines if the opening parentheses is not closed
+    while (!/\)/) {
+        current_line = $0;
+        getline;
+        $0 = current_line $0;
+    }
+
+    # Check if the line begins with "barretenberg_module". If so, extact the digraph edges
+     function_name = "barretenberg_module";
+    if ($0 ~ "^" function_name "\\(") {
+        extract_edges($0);
+    }
+}


### PR DESCRIPTION
The graph is directed, with $A\to B$ meaning that $A$ depends on $B$. Result:
![barretenberg_modules](https://github.com/AztecProtocol/aztec-packages/assets/26756572/5bc0745a-1b14-431f-9059-16e4b6b4a217)
A follow on could rewrite the CMakeLists.txt files to actually make use of this minimal representation of dependencies, but that feels unnecessary at the moment.
