### PR TITLE
fix(avm): fix usage of Fr with tagged memory

### DIFF
--- a/yarn-project/acir-simulator/src/avm/opcodes/external_calls.test.ts
+++ b/yarn-project/acir-simulator/src/avm/opcodes/external_calls.test.ts
@@ -40,7 +40,7 @@ describe('External Calls', () => {
       const addr = new Fr(123456n);
 
       const argsOffset = 2;
-      const args = [new Fr(1n), new Fr(2n), new Fr(3n)];
+      const args = [new Field(1n), new Field(2n), new Field(3n)];
       const argsSize = args.length;
 
       const retOffset = 8;
@@ -48,8 +48,8 @@ describe('External Calls', () => {
 
       const successOffset = 7;
 
-      machineState.memory.set(0, gas);
-      machineState.memory.set(1, addr);
+      machineState.memory.set(0, new Field(gas));
+      machineState.memory.set(1, new Field(addr));
       machineState.memory.setSlice(2, args);
 
       const otherContextInstructions: [Opcode, any[]][] = [
@@ -72,10 +72,10 @@ describe('External Calls', () => {
       await instruction.execute(machineState, journal);
 
       const successValue = machineState.memory.get(successOffset);
-      expect(successValue).toEqual(new Fr(1n));
+      expect(successValue).toEqual(new Field(1n));
 
       const retValue = machineState.memory.getSlice(retOffset, retSize);
-      expect(retValue).toEqual([new Fr(1n), new Fr(2n)]);
+      expect(retValue).toEqual([new Field(1n), new Field(2n)]);
 
       // Check that the storage call has been merged into the parent journal
       const { storageWrites } = journal.flush();
@@ -126,7 +126,7 @@ describe('External Calls', () => {
 
       // No revert has occurred, but the nested execution has failed
       const successValue = machineState.memory.get(successOffset);
-      expect(successValue).toEqual(new Fr(0n));
+      expect(successValue).toEqual(new Field(0n));
     });
   });
 });

--- a/yarn-project/acir-simulator/src/avm/opcodes/external_calls.ts
+++ b/yarn-project/acir-simulator/src/avm/opcodes/external_calls.ts
@@ -39,10 +39,11 @@ export class Call extends Instruction {
 
     // We only take as much data as was specified in the return size -> TODO: should we be reverting here
     const returnData = returnObject.output.slice(0, this.retSize);
+    const convertedReturnData = returnData.map(f => new Field(f));
 
     // Write our return data into memory
-    machineState.memory.set(this.successOffset, new Fr(success));
-    machineState.memory.setSlice(this.retOffset, returnData);
+    machineState.memory.set(this.successOffset, new Field(success ? 1 : 0));
+    machineState.memory.setSlice(this.retOffset, convertedReturnData);
 
     if (success) {
       avmContext.mergeJournal();
@@ -84,10 +85,11 @@ export class StaticCall extends Instruction {
 
     // We only take as much data as was specified in the return size -> TODO: should we be reverting here
     const returnData = returnObject.output.slice(0, this.retSize);
+    const convertedReturnData = returnData.map(f => new Field(f));
 
     // Write our return data into memory
-    machineState.memory.set(this.successOffset, new Fr(success));
-    machineState.memory.setSlice(this.retOffset, returnData);
+    machineState.memory.set(this.successOffset, new Field(success ? 1 : 0));
+    machineState.memory.setSlice(this.retOffset, convertedReturnData);
 
     if (success) {
       avmContext.mergeJournal();

--- a/yarn-project/acir-simulator/src/avm/opcodes/storage.test.ts
+++ b/yarn-project/acir-simulator/src/avm/opcodes/storage.test.ts
@@ -63,6 +63,6 @@ describe('Storage Instructions', () => {
     expect(journal.readStorage).toBeCalledWith(address, new Fr(a.toBigInt()));
 
     const actual = machineState.memory.get(1);
-    expect(actual).toEqual(expectedResult);
+    expect(actual).toEqual(new Field(expectedResult));
   });
 });

--- a/yarn-project/acir-simulator/src/avm/opcodes/storage.ts
+++ b/yarn-project/acir-simulator/src/avm/opcodes/storage.ts
@@ -1,6 +1,7 @@
 import { Fr } from '@aztec/foundation/fields';
 
 import { AvmMachineState } from '../avm_machine_state.js';
+import { Field } from '../avm_memory_types.js';
 import { AvmInterpreterError } from '../interpreter/interpreter.js';
 import { AvmJournal } from '../journal/journal.js';
 import { Instruction } from './instruction.js';
@@ -44,9 +45,12 @@ export class SLoad extends Instruction {
   async execute(machineState: AvmMachineState, journal: AvmJournal): Promise<void> {
     const slot = machineState.memory.get(this.slotOffset);
 
-    const data = journal.readStorage(machineState.executionEnvironment.storageAddress, new Fr(slot.toBigInt()));
+    const data: Fr = await journal.readStorage(
+      machineState.executionEnvironment.storageAddress,
+      new Fr(slot.toBigInt()),
+    );
 
-    machineState.memory.set(this.destOffset, await data);
+    machineState.memory.set(this.destOffset, new Field(data));
 
     this.incrementPc(machineState);
   }


### PR DESCRIPTION
Some calls to TaggedMemory were using `Fr` since it respected the defined interface. This was too lax, we really only want specific types in memory. We may allow conversion, but we cannot allow just any type that satisfies the interface. Therefore I'm changing this to specific classes.

Ref #4213.