### PR TITLE
fix: aztec binary fixes

### DIFF
--- a/yarn-project/aztec/src/cli/cli.ts
+++ b/yarn-project/aztec/src/cli/cli.ts
@@ -51,10 +51,10 @@ export function getProgram(userLog: LogFn, debugLogger: DebugLogger): Command {
         services = await startPXE(options, signalHandlers, userLog);
       } else if (options.archiver) {
         const { startArchiver } = await import('./cmds/start_archiver.js');
-        await startArchiver(options, signalHandlers);
+        services = await startArchiver(options, signalHandlers);
       } else if (options.p2pBootstrap) {
         const { startP2PBootstrap } = await import('./cmds/start_p2p_bootstrap.js');
-        await startP2PBootstrap(options, signalHandlers, debugLogger);
+        await startP2PBootstrap(options, signalHandlers, userLog, debugLogger);
       }
       if (services.length) {
         const rpcServer = createNamespacedJsonRpcServer(services, debugLogger);

--- a/yarn-project/aztec/src/cli/cmds/start_p2p_bootstrap.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_p2p_bootstrap.ts
@@ -1,11 +1,13 @@
 import { DebugLogger } from '@aztec/aztec.js';
 import { BootstrapNode, P2PConfig, getP2PConfigEnvVars } from '@aztec/p2p';
 
+import { LogFn } from '../../../../foundation/src/log/log_fn.js';
 import { mergeEnvVarsAndCliOptions, parseModuleOptions } from '../util.js';
 
 export const startP2PBootstrap = async (
   options: any,
   signalHandlers: (() => Promise<void>)[],
+  userLog: LogFn,
   debugLogger: DebugLogger,
 ) => {
   // Start a P2P bootstrap node.
@@ -14,5 +16,6 @@ export const startP2PBootstrap = async (
   const bootstrapNode = new BootstrapNode(debugLogger);
   const config = mergeEnvVarsAndCliOptions<P2PConfig>(envVars, cliOptions);
   await bootstrapNode.start(config);
+  userLog(`P2P bootstrap node started on ${config.tcpListenIp}:${config.tcpListenPort}`);
   signalHandlers.push(bootstrapNode.stop);
 };

--- a/yarn-project/p2p-bootstrap/terraform/main.tf
+++ b/yarn-project/p2p-bootstrap/terraform/main.tf
@@ -124,10 +124,6 @@ resource "aws_ecs_task_definition" "p2p-bootstrap" {
         "value": "production"
       },
       {
-        "name": "MODE",
-        "value": "p2p-bootstrap"
-      },
-      {
         "name": "P2P_TCP_LISTEN_PORT",
         "value": "${var.BOOTNODE_LISTEN_PORT + count.index}"
       },


### PR DESCRIPTION
Small fixes following introduction of `aztec` binary.

- Archiver http server wasn't starting
- Ensure p2p bootstrap server logs to user
- Remove unused env variable in terraform