### PR TITLE
refactor!: replace Note::compute_note_hash with Note::compute_note_content_hash

### DIFF
--- a/boxes/token/src/contracts/src/types/token_note.nr
+++ b/boxes/token/src/contracts/src/types/token_note.nr
@@ -58,13 +58,9 @@ impl Deserialize<TOKEN_NOTE_LEN> for TokenNote {
 }
 
 impl NoteInterface for TokenNote {
-      fn compute_note_hash(self) -> Field {
+      fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash([
-            self.amount.value as Field, 
-            self.owner.to_field(),
-            self.randomness,
-        ],0)
+        pedersen_hash(self.serialize(), 0)
     }
 
     // docs:start:nullifier

--- a/boxes/token/src/contracts/src/types/transparent_note.nr
+++ b/boxes/token/src/contracts/src/types/transparent_note.nr
@@ -42,12 +42,9 @@ impl Deserialize<TRANSPARENT_NOTE_LEN> for TransparentNote {
 
 impl NoteInterface for TransparentNote {
 
-    fn compute_note_hash(self) -> Field {
+    fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash([
-            self.amount,
-            self.secret_hash,
-        ],0)
+        pedersen_hash(self.serialize(), 0)
     }
 
     fn compute_nullifier(self, _context: &mut PrivateContext) -> Field {

--- a/docs/docs/developers/contracts/syntax/storage/storage_slots.md
+++ b/docs/docs/developers/contracts/syntax/storage/storage_slots.md
@@ -31,7 +31,7 @@ sequenceDiagram
     Set->>LifeCycle: create_note(derived_slot, note)
     LifeCycle->>LifeCycle: note.header = NoteHeader { contract_address, <br> storage_slot: derived_slot, nonce: 0, is_transient: true }
     LifeCycle->>Utils: compute_inner_note_hash(note)
-    Utils->>TokenNote: compute_note_hash(note)
+    Utils->>TokenNote: note.compute_note_content_hash()
     TokenNote->>Utils: note_hash = H(amount, to, randomness)
     Utils->>NoteHash: compute_inner_hash(derived_slot, note_hash)
     NoteHash->>LifeCycle: inner_note_hash = H(derived_slot, note_hash)

--- a/docs/docs/misc/migration_notes.md
+++ b/docs/docs/misc/migration_notes.md
@@ -6,6 +6,31 @@ keywords: [sandbox, cli, aztec, notes, migration, updating, upgrading]
 
 Aztec is in full-speed development. Literally every version breaks compatibility with the previous ones. This page attempts to target errors and difficulties you might encounter when upgrading, and how to resolve them.
 
+## TBD
+
+### `Note::compute_note_hash` renamed to `Note::compute_note_content_hash`
+The `compute_note_hash` function in of the `Note` trait has been renamed to `compute_note_content_hash` to avoid being confused with the actual note hash.
+
+Before:
+```rust
+impl NoteInterface for CardNote {
+    fn compute_note_hash(self) -> Field {
+        pedersen_hash([
+            self.owner.to_field(),
+        ],0)
+    }
+```
+
+Now:
+```rust
+impl NoteInterface for CardNote {
+    fn compute_note_content_hash(self) -> Field {
+        pedersen_hash([
+            self.owner.to_field(),
+        ],0)
+    }
+``````
+
 ## 0.22.0
 
 ### [Aztec.nr] `Serialize`, `Deserialize`, `NoteInterface` as Traits, removal of SerializationMethods and SERIALIZED_LEN

--- a/docs/docs/misc/migration_notes.md
+++ b/docs/docs/misc/migration_notes.md
@@ -17,7 +17,7 @@ impl NoteInterface for CardNote {
     fn compute_note_hash(self) -> Field {
         pedersen_hash([
             self.owner.to_field(),
-        ],0)
+        ], 0)
     }
 ```
 
@@ -27,7 +27,7 @@ impl NoteInterface for CardNote {
     fn compute_note_content_hash(self) -> Field {
         pedersen_hash([
             self.owner.to_field(),
-        ],0)
+        ], 0)
     }
 ``````
 

--- a/yarn-project/aztec-nr/address-note/src/address_note.nr
+++ b/yarn-project/aztec-nr/address-note/src/address_note.nr
@@ -49,7 +49,7 @@ impl Deserialize<ADDRESS_NOTE_LEN> for AddressNote {
 }
 
 impl NoteInterface for AddressNote {
-    fn compute_note_hash(self) -> Field {
+    fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash(self.serialize(), 0)
     }

--- a/yarn-project/aztec-nr/aztec/src/note/note_interface.nr
+++ b/yarn-project/aztec-nr/aztec/src/note/note_interface.nr
@@ -3,7 +3,7 @@ use crate::note::note_header::NoteHeader;
 
 // docs:start:note_interface
 trait NoteInterface {
-    fn compute_note_hash(self) -> Field;
+    fn compute_note_content_hash(self) -> Field;
 
     fn get_header(self) -> NoteHeader;
 

--- a/yarn-project/aztec-nr/aztec/src/note/utils.nr
+++ b/yarn-project/aztec-nr/aztec/src/note/utils.nr
@@ -18,11 +18,6 @@ use dep::protocol_types::{
     traits::{Deserialize, Serialize},
 };
 
-fn compute_inner_hash(storage_slot: Field, note_hash: Field) -> Field {
-    // TODO(#1205) Do we need a generator index here?
-    pedersen_hash([storage_slot, note_hash], 0)
-}
-
 fn compute_siloed_hash(contract_address: AztecAddress, inner_note_hash: Field) -> Field {
     let inputs = [contract_address.to_field(), inner_note_hash];
     pedersen_hash(inputs, GENERATOR_INDEX__SILOED_COMMITMENT)
@@ -35,9 +30,10 @@ fn compute_unique_hash(nonce: Field, siloed_note_hash: Field) -> Field {
 
 fn compute_inner_note_hash<Note, N>(note: Note) -> Field where Note: NoteInterface {
     let header = note.get_header();
-    let note_hash = note.compute_note_hash();
+    let note_hash = note.compute_note_content_hash();
 
-    compute_inner_hash(header.storage_slot, note_hash)
+    // TODO(#1205) Do we need a generator index here?
+    pedersen_hash([header.storage_slot, note_hash], 0)
 }
 
 fn compute_siloed_note_hash<Note>(note_with_header: Note) -> Field where Note: NoteInterface {
@@ -95,8 +91,7 @@ pub fn compute_note_hash_and_nullifier<T, N, S>(
     // TODO: change this to note.setHeader(header) once https://github.com/noir-lang/noir/issues/4095 is fixed
     T::set_header((&mut note), note_header);
 
-    let note_hash = note.compute_note_hash();
-    let inner_note_hash = compute_inner_hash(note_header.storage_slot, note_hash);
+    let inner_note_hash = compute_inner_note_hash(note);
 
     let siloed_note_hash = compute_siloed_hash(note_header.contract_address, inner_note_hash);
 

--- a/yarn-project/aztec-nr/field-note/src/field_note.nr
+++ b/yarn-project/aztec-nr/field-note/src/field_note.nr
@@ -34,7 +34,7 @@ impl Deserialize<FIELD_NOTE_LEN> for FieldNote {
 }
 
 impl NoteInterface for FieldNote {
-    fn compute_note_hash(self) -> Field {
+    fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash(self.serialize(), 0)
     }

--- a/yarn-project/aztec-nr/value-note/src/value_note.nr
+++ b/yarn-project/aztec-nr/value-note/src/value_note.nr
@@ -48,7 +48,7 @@ impl Deserialize<VALUE_NOTE_LEN> for ValueNote {
 
 impl NoteInterface for ValueNote {
 
-    fn compute_note_hash(self) -> Field {
+    fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash(self.serialize(),0)
     }

--- a/yarn-project/noir-contracts/contracts/docs_example_contract/src/types/card_note.nr
+++ b/yarn-project/noir-contracts/contracts/docs_example_contract/src/types/card_note.nr
@@ -59,12 +59,8 @@ impl Deserialize<CARD_NOTE_LEN> for CardNote {
 }
 
 impl NoteInterface for CardNote {
-    fn compute_note_hash(self) -> Field {
-        pedersen_hash([
-            self.points as Field, 
-            self.randomness,
-            self.owner.to_field(),
-        ],0)
+    fn compute_note_content_hash(self) -> Field {
+        pedersen_hash(self.serialize(), 0)
     }
 
     fn compute_nullifier(self, context: &mut PrivateContext) -> Field {

--- a/yarn-project/noir-contracts/contracts/ecdsa_account_contract/src/ecdsa_public_key_note.nr
+++ b/yarn-project/noir-contracts/contracts/ecdsa_account_contract/src/ecdsa_public_key_note.nr
@@ -75,7 +75,7 @@ impl Deserialize<ECDSA_PUBLIC_KEY_NOTE_LEN> for EcdsaPublicKeyNote {
 }
 
 impl NoteInterface for EcdsaPublicKeyNote {
-    fn compute_note_hash(note: EcdsaPublicKeyNote) -> Field {
+    fn compute_note_content_hash(note: EcdsaPublicKeyNote) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash(note.serialize(), 0)
     }

--- a/yarn-project/noir-contracts/contracts/schnorr_account_contract/src/public_key_note.nr
+++ b/yarn-project/noir-contracts/contracts/schnorr_account_contract/src/public_key_note.nr
@@ -69,7 +69,7 @@ impl NoteInterface for PublicKeyNote {
         ],0)
     }
 
-    fn compute_note_hash(note: PublicKeyNote) -> Field {
+    fn compute_note_content_hash(note: PublicKeyNote) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash(note.serialize(), 0)
     }

--- a/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/token_note.nr
+++ b/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/token_note.nr
@@ -54,13 +54,9 @@ impl Deserialize<TOKEN_NOTE_LEN> for TokenNote {
 }
 
 impl NoteInterface for TokenNote {
-      fn compute_note_hash(self) -> Field {
+      fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash([
-            self.amount.value as Field, 
-            self.owner.to_field(),
-            self.randomness,
-        ],0)
+        pedersen_hash(self.serialize(), 0)
     }
 
     // docs:start:nullifier

--- a/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/transparent_note.nr
+++ b/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/transparent_note.nr
@@ -42,12 +42,9 @@ impl Deserialize<TRANSPARENT_NOTE_LEN> for TransparentNote {
 
 impl NoteInterface for TransparentNote {
 
-    fn compute_note_hash(self) -> Field {
+    fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash([
-            self.amount,
-            self.secret_hash,
-        ],0)
+        pedersen_hash(self.serialize(), 0)
     }
 
     fn compute_nullifier(self, _context: &mut PrivateContext) -> Field {

--- a/yarn-project/noir-contracts/contracts/token_contract/src/types/token_note.nr
+++ b/yarn-project/noir-contracts/contracts/token_contract/src/types/token_note.nr
@@ -61,13 +61,9 @@ impl Deserialize<TOKEN_NOTE_LEN> for TokenNote {
 }
 
 impl NoteInterface for TokenNote {
-    fn compute_note_hash(self) -> Field {
+    fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash([
-            self.amount.value as Field, 
-            self.owner.to_field(),
-            self.randomness,
-        ],0)
+        pedersen_hash(self.serialize(), 0)
     }
 
     // docs:start:nullifier

--- a/yarn-project/noir-contracts/contracts/token_contract/src/types/transparent_note.nr
+++ b/yarn-project/noir-contracts/contracts/token_contract/src/types/transparent_note.nr
@@ -44,17 +44,13 @@ impl Empty for TransparentNote {
     fn empty() -> Self {
         TransparentNote::new(0, 0)
     }
-
 }
 
 impl NoteInterface for TransparentNote {
 
-    fn compute_note_hash(self) -> Field {
+    fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash([
-            self.amount,
-            self.secret_hash,
-        ],0)
+        pedersen_hash(self.serialize(), 0)
     }
 
     fn compute_nullifier(self, _context: &mut PrivateContext) -> Field {
@@ -62,7 +58,6 @@ impl NoteInterface for TransparentNote {
     }
 
     fn compute_nullifier_without_context(self) -> Field {
-        // TODO(#1386): should use `compute_note_hash_for_read_or_nullify` once public functions inject nonce!
         let siloed_note_hash = compute_note_hash_for_read_or_nullify(self);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([self.secret, siloed_note_hash],0)


### PR DESCRIPTION
Part of #4199.

Discussions with @sirasistant and others lead to updating the `compute_note_hash` function name to `compute_note_content_hash` to avoid confusion with the actual note hash.