### PR TITLE
refactor!: introduce compute_note_hash_for_(consumption/insertion)

### DIFF
--- a/boxes/token/src/contracts/src/types/token_note.nr
+++ b/boxes/token/src/contracts/src/types/token_note.nr
@@ -8,7 +8,7 @@ use dep::aztec::{
     note::{
         note_header::NoteHeader,
         note_interface::NoteInterface,
-        utils::compute_note_hash_for_read_or_nullify,
+        utils::compute_note_hash_for_consumption,
     },
     context::PrivateContext,
     state_vars::set::Set,
@@ -65,7 +65,7 @@ impl NoteInterface for TokenNote {
 
     // docs:start:nullifier
     fn compute_nullifier(self, context: &mut PrivateContext) -> Field {
-        let note_hash_for_nullify = compute_note_hash_for_read_or_nullify(self);
+        let note_hash_for_nullify = compute_note_hash_for_consumption(self);
         let secret = context.request_nullifier_secret_key(self.owner);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([
@@ -77,7 +77,7 @@ impl NoteInterface for TokenNote {
     // docs:end:nullifier
 
     fn compute_nullifier_without_context(self) -> Field {
-        let note_hash_for_nullify = compute_note_hash_for_read_or_nullify(self);
+        let note_hash_for_nullify = compute_note_hash_for_consumption(self);
         let secret = get_nullifier_secret_key(self.owner);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([

--- a/boxes/token/src/contracts/src/types/transparent_note.nr
+++ b/boxes/token/src/contracts/src/types/transparent_note.nr
@@ -3,7 +3,7 @@ use dep::aztec::{
     note::{
         note_header::NoteHeader,
         note_interface::NoteInterface,
-        utils::compute_note_hash_for_read_or_nullify,
+        utils::compute_note_hash_for_consumption,
     },
     hash::{compute_secret_hash, pedersen_hash},
     context::PrivateContext,
@@ -52,7 +52,7 @@ impl NoteInterface for TransparentNote {
     }
 
     fn compute_nullifier_without_context(self) -> Field {
-        let siloed_note_hash = compute_note_hash_for_read_or_nullify(self);
+        let siloed_note_hash = compute_note_hash_for_consumption(self);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([self.secret, siloed_note_hash],0)
     }

--- a/docs/docs/misc/migration_notes.md
+++ b/docs/docs/misc/migration_notes.md
@@ -29,7 +29,15 @@ impl NoteInterface for CardNote {
             self.owner.to_field(),
         ], 0)
     }
-``````
+```
+
+### Introduce `compute_note_hash_for_consumption` and `compute_note_hash_for_insertion`
+
+Makes a split in logic for note hash computation for consumption and insertion. This is to avoid confusion between the two, and to make it clear that the note hash for consumption is different from the note hash for insertion (sometimes).
+
+`compute_note_hash_for_consumption` replaces `compute_note_hash_for_read_or_nullify`.
+`compute_note_hash_for_insertion` is new, and mainly used in `lifecycle.nr``
+
 
 ## 0.22.0
 

--- a/yarn-project/aztec-nr/address-note/src/address_note.nr
+++ b/yarn-project/aztec-nr/address-note/src/address_note.nr
@@ -9,7 +9,7 @@ use dep::aztec::{
     note::{
         note_header::NoteHeader,
         note_interface::NoteInterface,
-        utils::compute_note_hash_for_read_or_nullify,
+        utils::compute_note_hash_for_consumption,
     },
     oracle::{
         rand::rand,
@@ -55,7 +55,7 @@ impl NoteInterface for AddressNote {
     }
 
     fn compute_nullifier(self, context: &mut PrivateContext) -> Field {
-        let note_hash_for_nullify = compute_note_hash_for_read_or_nullify(self);
+        let note_hash_for_nullify = compute_note_hash_for_consumption(self);
         let secret = context.request_nullifier_secret_key(self.owner);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([
@@ -66,7 +66,7 @@ impl NoteInterface for AddressNote {
     }
 
     fn compute_nullifier_without_context(self) -> Field {
-        let note_hash_for_nullify = compute_note_hash_for_read_or_nullify(self);
+        let note_hash_for_nullify = compute_note_hash_for_consumption(self);
         let secret = get_nullifier_secret_key(self.owner);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([

--- a/yarn-project/aztec-nr/aztec/src/history/note_inclusion.nr
+++ b/yarn-project/aztec-nr/aztec/src/history/note_inclusion.nr
@@ -3,7 +3,7 @@ use dep::std::merkle::compute_merkle_root;
 use crate::{
     context::PrivateContext,
     note::{
-        utils::compute_note_hash_for_read_or_nullify,
+        utils::compute_note_hash_for_consumption,
         note_header::NoteHeader,
         note_interface::NoteInterface,
     },
@@ -34,7 +34,7 @@ pub fn prove_note_inclusion<Note, N>(
     block_number: u32, // The block at which we'll prove that the note exists
     context: PrivateContext
 ) where Note: NoteInterface {
-    let note_commitment = compute_note_hash_for_read_or_nullify(note_with_header);
+    let note_commitment = compute_note_hash_for_consumption(note_with_header);
 
     prove_note_commitment_inclusion(note_commitment, block_number, context);
 }

--- a/yarn-project/aztec-nr/aztec/src/note/lifecycle.nr
+++ b/yarn-project/aztec-nr/aztec/src/note/lifecycle.nr
@@ -6,7 +6,7 @@ use crate::context::{
 use crate::note::{
     note_header::NoteHeader,
     note_interface::NoteInterface,
-    utils::compute_note_hash_for_read_or_nullify,
+    utils::{compute_note_hash_for_insertion, compute_note_hash_for_consumption},
 };
 use crate::oracle::notes::{notify_created_note, notify_nullified_note};
 use dep::protocol_types::traits::{Serialize, Deserialize};
@@ -23,7 +23,7 @@ pub fn create_note<Note, N>(
     // TODO: change this to note.setHeader(header) once https://github.com/noir-lang/noir/issues/4095 is fixed
     Note::set_header(note, header);
     // As `is_transient` is true, this will compute the inner note hsah
-    let inner_note_hash = compute_note_hash_for_read_or_nullify(*note);
+    let inner_note_hash = compute_note_hash_for_insertion(*note);
 
     // TODO: Strong typing required because of https://github.com/noir-lang/noir/issues/4088
     let serialized_note: [Field; N] = Note::serialize(*note);
@@ -42,28 +42,28 @@ pub fn create_note_hash_from_public<Note>(context: &mut PublicContext, storage_s
     let header = NoteHeader { contract_address, storage_slot, nonce: 0, is_transient: true };
     // TODO: change this to note.setHeader(header) once https://github.com/noir-lang/noir/issues/4095 is fixed
     Note::set_header(note, header);
-    let inner_note_hash = compute_note_hash_for_read_or_nullify(*note);
+    let inner_note_hash = compute_note_hash_for_insertion(*note);
 
     context.push_new_note_hash(inner_note_hash);
 }
 
 pub fn destroy_note<Note>(context: &mut PrivateContext, note: Note) where Note: NoteInterface {
     let mut nullifier = 0;
-    let mut nullified_commitment: Field = 0;
+    let mut consumed_note_hash: Field = 0;
     nullifier = note.compute_nullifier(context);
 
-    // We also need the note commitment corresponding to the "nullifier"
+    // We also need the note hash corresponding to the "nullifier"
     let header = note.get_header();
-    // `nullified_commitment` is used to inform the kernel which pending commitment
+    // `consumed_note_hash` is used to inform the kernel which pending note hash
     // the nullifier corresponds to so they can be matched and both squashed/deleted.
     // nonzero nonce implies "persistable" nullifier (nullifies a persistent/in-tree
-    // commitment) in which case `nullified_commitment` is not used since the kernel
+    // note hash) in which case `consumed_note_hash` is not used since the kernel
     // just siloes and forwards the nullifier to its output.
     if (header.is_transient) {
-        // TODO(1718): Can we reuse the note commitment computed in `compute_nullifier`?
-        nullified_commitment = compute_note_hash_for_read_or_nullify(note);
+        // TODO(1718): Can we reuse the note hash computed in `compute_nullifier`?
+        consumed_note_hash = compute_note_hash_for_consumption(note);
     }
-    assert(notify_nullified_note(nullifier, nullified_commitment) == 0);
+    assert(notify_nullified_note(nullifier, consumed_note_hash) == 0);
 
-    context.push_new_nullifier(nullifier, nullified_commitment)
+    context.push_new_nullifier(nullifier, consumed_note_hash)
 }

--- a/yarn-project/aztec-nr/aztec/src/note/note_getter.nr
+++ b/yarn-project/aztec-nr/aztec/src/note/note_getter.nr
@@ -14,7 +14,7 @@ use crate::note::{
     note_getter_options::{NoteGetterOptions, Select, Sort, SortOrder, Comparator, NoteStatus},
     note_interface::NoteInterface,
     note_viewer_options::NoteViewerOptions,
-    utils::compute_note_hash_for_read_or_nullify,
+    utils::compute_note_hash_for_consumption,
 };
 use crate::oracle;
 
@@ -78,7 +78,7 @@ pub fn get_note<Note, N>(
 
     check_note_header(*context, storage_slot, note);
 
-    let note_hash_for_read_request = compute_note_hash_for_read_or_nullify(note);
+    let note_hash_for_read_request = compute_note_hash_for_consumption(note);
 
     context.push_read_request(note_hash_for_read_request);
     note
@@ -104,7 +104,7 @@ pub fn get_notes<Note, N, FILTER_ARGS>(
             }
             prev_fields = fields;
 
-            let note_hash_for_read_request = compute_note_hash_for_read_or_nullify(note);
+            let note_hash_for_read_request = compute_note_hash_for_consumption(note);
             // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1410): test to ensure
             // failure if malicious oracle injects 0 nonce here for a "pre-existing" note.
             context.push_read_request(note_hash_for_read_request);

--- a/yarn-project/aztec-nr/aztec/src/note/utils.nr
+++ b/yarn-project/aztec-nr/aztec/src/note/utils.nr
@@ -63,10 +63,17 @@ pub fn compute_siloed_nullifier<Note>(
     pedersen_hash(input, GENERATOR_INDEX__OUTER_NULLIFIER)
 }
 
-pub fn compute_note_hash_for_read_or_nullify<Note>(note: Note) -> Field where Note: NoteInterface {
-    let header = note.get_header();
+pub fn compute_note_hash_for_insertion<Note>(note: Note) -> Field where Note: NoteInterface {
+    compute_inner_note_hash(note)
+}
 
-    // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1386)
+pub fn compute_note_hash_for_consumption<Note>(note: Note) -> Field where Note: NoteInterface {
+    let header = note.get_header();
+    // There are 3 cases for reading a note intended for consumption:
+    // 1. The note was inserted in this transaction, and is transient.
+    // 2. The note was inserted in a previous transaction, and was inserted in public
+    // 3. The note was inserted in a previous transaction, and was inserted in private
+
     if (header.is_transient) {
         // If a note is transient, we just read the inner_note_hash (kernel will silo by contract address).
         compute_inner_note_hash(note)

--- a/yarn-project/aztec-nr/aztec/src/state_vars/set.nr
+++ b/yarn-project/aztec-nr/aztec/src/state_vars/set.nr
@@ -13,7 +13,7 @@ use crate::note::{
     note_header::NoteHeader,
     note_interface::NoteInterface,
     note_viewer_options::NoteViewerOptions,
-    utils::compute_note_hash_for_read_or_nullify,
+    utils::compute_note_hash_for_consumption,
 };
 
 // docs:start:struct
@@ -74,7 +74,7 @@ impl<Note> Set<Note> {
     // docs:start:remove
     pub fn remove(self, note: Note) where Note: NoteInterface {
         let context = self.context.private.unwrap();
-        let note_hash = compute_note_hash_for_read_or_nullify(note);
+        let note_hash = compute_note_hash_for_consumption(note);
         let has_been_read = context.read_requests.any(|r: SideEffect| r.value == note_hash);
         assert(has_been_read, "Can only remove a note that has been read from the set.");
 

--- a/yarn-project/aztec-nr/value-note/src/value_note.nr
+++ b/yarn-project/aztec-nr/value-note/src/value_note.nr
@@ -6,7 +6,7 @@ use dep::aztec::{
     note::{
         note_header::NoteHeader,
         note_interface::NoteInterface,
-        utils::compute_note_hash_for_read_or_nullify,
+        utils::compute_note_hash_for_consumption,
     },
     oracle::{
         rand::rand,
@@ -56,7 +56,7 @@ impl NoteInterface for ValueNote {
     // docs:start:nullifier
 
     fn compute_nullifier(self, context: &mut PrivateContext) -> Field {
-        let note_hash_for_nullify = compute_note_hash_for_read_or_nullify(self);
+        let note_hash_for_nullify = compute_note_hash_for_consumption(self);
         let secret = context.request_nullifier_secret_key(self.owner);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([
@@ -69,7 +69,7 @@ impl NoteInterface for ValueNote {
     // docs:end:nullifier
 
     fn compute_nullifier_without_context(self) -> Field {
-        let note_hash_for_nullify = compute_note_hash_for_read_or_nullify(self);
+        let note_hash_for_nullify = compute_note_hash_for_consumption(self);
         let secret = get_nullifier_secret_key(self.owner);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([

--- a/yarn-project/noir-contracts/contracts/docs_example_contract/src/types/card_note.nr
+++ b/yarn-project/noir-contracts/contracts/docs_example_contract/src/types/card_note.nr
@@ -2,7 +2,7 @@ use dep::aztec::{
     note::{
         note_header::NoteHeader,
         note_interface::NoteInterface,
-        utils::compute_note_hash_for_read_or_nullify,
+        utils::compute_note_hash_for_consumption,
     },
     oracle::{
         nullifier_key::get_nullifier_secret_key,
@@ -64,7 +64,7 @@ impl NoteInterface for CardNote {
     }
 
     fn compute_nullifier(self, context: &mut PrivateContext) -> Field {
-        let note_hash_for_nullify = compute_note_hash_for_read_or_nullify(self);
+        let note_hash_for_nullify = compute_note_hash_for_consumption(self);
         let secret = context.request_nullifier_secret_key(self.owner);
         pedersen_hash([
             note_hash_for_nullify,
@@ -74,7 +74,7 @@ impl NoteInterface for CardNote {
     }
 
     fn compute_nullifier_without_context(self) -> Field {
-        let note_hash_for_nullify = compute_note_hash_for_read_or_nullify(self);
+        let note_hash_for_nullify = compute_note_hash_for_consumption(self);
         let secret = get_nullifier_secret_key(self.owner);
         pedersen_hash([
             note_hash_for_nullify,

--- a/yarn-project/noir-contracts/contracts/ecdsa_account_contract/src/ecdsa_public_key_note.nr
+++ b/yarn-project/noir-contracts/contracts/ecdsa_account_contract/src/ecdsa_public_key_note.nr
@@ -3,7 +3,7 @@ use dep::aztec::{
     note::{
         note_header::NoteHeader,
         note_interface::NoteInterface,
-        utils::compute_note_hash_for_read_or_nullify,
+        utils::compute_note_hash_for_consumption,
     },
     oracle::{
         nullifier_key::get_nullifier_secret_key,
@@ -81,7 +81,7 @@ impl NoteInterface for EcdsaPublicKeyNote {
     }
 
    fn compute_nullifier(self, context: &mut PrivateContext) -> Field {
-        let unique_siloed_note_hash = compute_note_hash_for_read_or_nullify(self);
+        let unique_siloed_note_hash = compute_note_hash_for_consumption(self);
         let secret = context.request_nullifier_secret_key(self.owner);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([
@@ -92,7 +92,7 @@ impl NoteInterface for EcdsaPublicKeyNote {
     }
 
     fn compute_nullifier_without_context(self) -> Field {
-        let unique_siloed_note_hash = compute_note_hash_for_read_or_nullify(self);
+        let unique_siloed_note_hash = compute_note_hash_for_consumption(self);
         let secret = get_nullifier_secret_key(self.owner);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([

--- a/yarn-project/noir-contracts/contracts/schnorr_account_contract/src/public_key_note.nr
+++ b/yarn-project/noir-contracts/contracts/schnorr_account_contract/src/public_key_note.nr
@@ -2,7 +2,7 @@ use dep::aztec::{
     note::{
         note_header::NoteHeader,
         note_interface::NoteInterface,
-        utils::compute_note_hash_for_read_or_nullify,
+        utils::compute_note_hash_for_consumption,
     },
     hash::pedersen_hash,
     oracle::{
@@ -48,7 +48,7 @@ impl Deserialize<PUBLIC_KEY_NOTE_LEN> for PublicKeyNote {
 impl NoteInterface for PublicKeyNote {
 
     fn compute_nullifier(self, context: &mut PrivateContext) -> Field {
-        let unique_siloed_note_hash = compute_note_hash_for_read_or_nullify(self);
+        let unique_siloed_note_hash = compute_note_hash_for_consumption(self);
         let secret = context.request_nullifier_secret_key(self.owner);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([
@@ -59,7 +59,7 @@ impl NoteInterface for PublicKeyNote {
     }
 
     fn compute_nullifier_without_context(self) -> Field {
-        let unique_siloed_note_hash = compute_note_hash_for_read_or_nullify(self);
+        let unique_siloed_note_hash = compute_note_hash_for_consumption(self);
         let secret = get_nullifier_secret_key(self.owner);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([

--- a/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/balance_set.nr
+++ b/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/balance_set.nr
@@ -14,7 +14,6 @@ use dep::aztec::note::{
 use dep::aztec::note::{
     note_header::NoteHeader,
     note_interface::NoteInterface,
-    utils::compute_note_hash_for_read_or_nullify,
 };
 use crate::types::token_note::TokenNote;
 

--- a/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/token_note.nr
+++ b/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/token_note.nr
@@ -4,7 +4,7 @@ use dep::aztec::{
     note::{
         note_header::NoteHeader,
         note_interface::NoteInterface,
-        utils::compute_note_hash_for_read_or_nullify,
+        utils::compute_note_hash_for_consumption,
     },
     context::PrivateContext,
     state_vars::set::Set,
@@ -61,7 +61,7 @@ impl NoteInterface for TokenNote {
 
     // docs:start:nullifier
     fn compute_nullifier(self, context: &mut PrivateContext) -> Field {
-        let note_hash_for_nullify = compute_note_hash_for_read_or_nullify(self);
+        let note_hash_for_nullify = compute_note_hash_for_consumption(self);
         let secret = context.request_nullifier_secret_key(self.owner);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([
@@ -73,7 +73,7 @@ impl NoteInterface for TokenNote {
     // docs:end:nullifier
 
     fn compute_nullifier_without_context(self) -> Field {
-        let note_hash_for_nullify = compute_note_hash_for_read_or_nullify(self);
+        let note_hash_for_nullify = compute_note_hash_for_consumption(self);
         let secret = get_nullifier_secret_key(self.owner);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([

--- a/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/transparent_note.nr
+++ b/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/transparent_note.nr
@@ -3,7 +3,7 @@ use dep::aztec::{
     note::{
         note_header::NoteHeader,
         note_interface::NoteInterface,
-        utils::compute_note_hash_for_read_or_nullify,
+        utils::compute_note_hash_for_consumption,
     },
     hash::{compute_secret_hash, pedersen_hash},
     context::PrivateContext,
@@ -52,8 +52,7 @@ impl NoteInterface for TransparentNote {
     }
 
     fn compute_nullifier_without_context(self) -> Field {
-        // TODO(#1386): should use `compute_note_hash_for_read_or_nullify` once public functions inject nonce!
-        let siloed_note_hash = compute_note_hash_for_read_or_nullify(self);
+        let siloed_note_hash = compute_note_hash_for_consumption(self);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([self.secret, siloed_note_hash],0)
     }

--- a/yarn-project/noir-contracts/contracts/token_contract/src/types/balance_set.nr
+++ b/yarn-project/noir-contracts/contracts/token_contract/src/types/balance_set.nr
@@ -15,8 +15,7 @@ use dep::aztec::note::{
 };
 use dep::aztec::note::{
     note_header::NoteHeader,
-    note_interface::NoteInterface,
-    utils::compute_note_hash_for_read_or_nullify,
+    note_interface::NoteInterface
 };
 use crate::types::token_note::TokenNote;
 

--- a/yarn-project/noir-contracts/contracts/token_contract/src/types/token_note.nr
+++ b/yarn-project/noir-contracts/contracts/token_contract/src/types/token_note.nr
@@ -8,7 +8,7 @@ use dep::aztec::{
     note::{
         note_header::NoteHeader,
         note_interface::NoteInterface,
-        utils::compute_note_hash_for_read_or_nullify,
+        utils::compute_note_hash_for_consumption,
     },
     context::PrivateContext,
     state_vars::set::Set,
@@ -68,7 +68,7 @@ impl NoteInterface for TokenNote {
 
     // docs:start:nullifier
     fn compute_nullifier(self, context: &mut PrivateContext) -> Field {
-        let note_hash_for_nullify = compute_note_hash_for_read_or_nullify(self);
+        let note_hash_for_nullify = compute_note_hash_for_consumption(self);
         let secret = context.request_nullifier_secret_key(self.owner);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([
@@ -80,7 +80,7 @@ impl NoteInterface for TokenNote {
     // docs:end:nullifier
 
     fn compute_nullifier_without_context(self) -> Field {
-        let note_hash_for_nullify = compute_note_hash_for_read_or_nullify(self);
+        let note_hash_for_nullify = compute_note_hash_for_consumption(self);
         let secret = get_nullifier_secret_key(self.owner);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([

--- a/yarn-project/noir-contracts/contracts/token_contract/src/types/transparent_note.nr
+++ b/yarn-project/noir-contracts/contracts/token_contract/src/types/transparent_note.nr
@@ -3,7 +3,7 @@ use dep::aztec::{
     note::{
         note_header::NoteHeader,
         note_interface::NoteInterface,
-        utils::compute_note_hash_for_read_or_nullify,
+        utils::compute_note_hash_for_consumption,
     },
     hash::{compute_secret_hash, pedersen_hash},
     context::PrivateContext,
@@ -58,7 +58,7 @@ impl NoteInterface for TransparentNote {
     }
 
     fn compute_nullifier_without_context(self) -> Field {
-        let siloed_note_hash = compute_note_hash_for_read_or_nullify(self);
+        let siloed_note_hash = compute_note_hash_for_consumption(self);
         // TODO(#1205) Should use a non-zero generator index.
         pedersen_hash([self.secret, siloed_note_hash],0)
     }


### PR DESCRIPTION
Part of #4199 

Replaces the `compute_note_hash_for_read_or_nullify` with two functions:
- `compute_note_hash_for_insertion`
- `compute_note_hash_for_consumption`

The practical difference is small, but should make it a bit easier to follow the flow