### PR TITLE
chore: Add bootstrap_cache for avm-transpiler

### DIFF
--- a/avm-transpiler/bootstrap_cache.sh
+++ b/avm-transpiler/bootstrap_cache.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eu
+
+cd "$(dirname "$0")"
+source ../build-system/scripts/setup_env '' '' mainframe_$USER > /dev/null
+
+echo -e "\033[1mRetrieving avm-transpiler from remote cache...\033[0m"
+extract_repo avm-transpiler \
+  /usr/src/avm-transpiler/target/release/avm-transpiler ./target/release/


### PR DESCRIPTION
Allows the avm-transpiler binary to be downloaded from the CI cache instead of built locally if BOOTSTRAP_USE_REMOTE_CACHE is set.
