### PR TITLE
feat: Private calls and initialization of undeployed contracts

### DIFF
--- a/yarn-project/acir-simulator/src/client/private_execution.test.ts
+++ b/yarn-project/acir-simulator/src/client/private_execution.test.ts
@@ -277,11 +277,18 @@ describe('Private Execution test suite', () => {
       oracle.getFunctionArtifactByName.mockImplementation((_, functionName: string) =>
         Promise.resolve(getFunctionArtifact(StatefulTestContractArtifact, functionName)),
       );
+
+      oracle.getFunctionArtifact.mockImplementation((_, selector: FunctionSelector) =>
+        Promise.resolve(getFunctionArtifact(StatefulTestContractArtifact, selector)),
+      );
+
+      oracle.getPortalContractAddress.mockResolvedValue(EthAddress.ZERO);
     });
 
     it('should have a constructor with arguments that inserts notes', async () => {
       const artifact = getFunctionArtifact(StatefulTestContractArtifact, 'constructor');
-      const result = await runSimulator({ args: [owner, 140], artifact });
+      const topLevelResult = await runSimulator({ args: [owner, 140], artifact });
+      const result = topLevelResult.nestedExecutions[0];
 
       expect(result.newNotes).toHaveLength(1);
       const newNote = result.newNotes[0];

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -4,7 +4,6 @@ import {
   ContractDeploymentData,
   FunctionData,
   TxContext,
-  computeContractAddressFromInstance,
   computePartialAddress,
   getContractInstanceFromDeployParams,
 } from '@aztec/circuits.js';
@@ -77,7 +76,7 @@ export class DeployMethod<TContract extends ContractBase = Contract> extends Bas
 
     const deployParams = [this.artifact, this.args, contractAddressSalt, this.publicKey, portalContract] as const;
     const instance = getContractInstanceFromDeployParams(...deployParams);
-    const address = computeContractAddressFromInstance(instance);
+    const address = instance.address;
 
     const contractDeploymentData = new ContractDeploymentData(
       this.publicKey,

--- a/yarn-project/circuits.js/src/contract/contract_instance.ts
+++ b/yarn-project/circuits.js/src/contract/contract_instance.ts
@@ -1,7 +1,7 @@
 import { ContractArtifact } from '@aztec/foundation/abi';
 import { ContractInstance, ContractInstanceWithAddress } from '@aztec/types/contracts';
 
-import { EthAddress, Fr, PublicKey, computeContractClassId, getContractClassFromArtifact } from '../index.js';
+import { EthAddress, Fr, Point, PublicKey, computeContractClassId, getContractClassFromArtifact } from '../index.js';
 import {
   computeContractAddressFromInstance,
   computeInitializationHash,
@@ -20,10 +20,10 @@ import { isConstructor } from './contract_tree/contract_tree.js';
  */
 export function getContractInstanceFromDeployParams(
   artifact: ContractArtifact,
-  args: any[],
-  contractAddressSalt: Fr,
-  publicKey: PublicKey,
-  portalContractAddress: EthAddress,
+  args: any[] = [],
+  contractAddressSalt: Fr = Fr.random(),
+  publicKey: PublicKey = Point.ZERO,
+  portalContractAddress: EthAddress = EthAddress.ZERO,
 ): ContractInstanceWithAddress {
   const constructorArtifact = artifact.functions.find(isConstructor);
   if (!constructorArtifact) {

--- a/yarn-project/circuits.js/src/structs/complete_address.ts
+++ b/yarn-project/circuits.js/src/structs/complete_address.ts
@@ -1,5 +1,5 @@
 import { AztecAddress } from '@aztec/foundation/aztec-address';
-import { Fr, Point } from '@aztec/foundation/fields';
+import { Fr, GrumpkinScalar, Point } from '@aztec/foundation/fields';
 import { BufferReader } from '@aztec/foundation/serialize';
 
 import { Grumpkin } from '../barretenberg/index.js';
@@ -46,6 +46,12 @@ export class CompleteAddress {
     const publicKey = Point.random();
     const address = computeContractAddressFromPartial({ publicKey, partialAddress });
     return new CompleteAddress(address, publicKey, partialAddress);
+  }
+
+  static fromRandomPrivateKey() {
+    const privateKey = GrumpkinScalar.random();
+    const partialAddress = Fr.random();
+    return { privateKey, completeAddress: CompleteAddress.fromPrivateKeyAndPartialAddress(privateKey, partialAddress) };
   }
 
   static fromPrivateKeyAndPartialAddress(privateKey: GrumpkinPrivateKey, partialAddress: Fr): CompleteAddress {

--- a/yarn-project/noir-compiler/src/contract-interface-gen/typescript.ts
+++ b/yarn-project/noir-compiler/src/contract-interface-gen/typescript.ts
@@ -169,7 +169,7 @@ function generateAbiStatement(name: string, artifactImportPath: string) {
  * @returns The corresponding ts code.
  */
 export function generateTypescriptContractInterface(input: ContractArtifact, artifactImportPath?: string) {
-  const methods = input.functions.filter(f => f.name !== 'constructor' && !f.isInternal).map(generateMethod);
+  const methods = input.functions.filter(f => !f.isInternal).map(generateMethod);
   const deploy = artifactImportPath && generateDeploy(input);
   const ctor = artifactImportPath && generateConstructor(input.name);
   const at = artifactImportPath && generateAt(input.name);

--- a/yarn-project/noir-contracts/contracts/stateful_test_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/stateful_test_contract/src/main.nr
@@ -51,11 +51,7 @@ contract StatefulTest {
     #[aztec(private)]
     fn constructor(owner: AztecAddress, value: Field) {
         let selector = FunctionSelector::from_signature("create_note((Field),Field)");
-        let _res = context.call_private_function(
-            context.this_address(),
-            selector,
-            [owner.to_field(), value]
-        );
+        let _res = context.call_private_function(context.this_address(), selector, [owner.to_field(), value]);
     }
 
     #[aztec(private)]

--- a/yarn-project/noir-contracts/contracts/stateful_test_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/stateful_test_contract/src/main.nr
@@ -1,6 +1,9 @@
 // A contract used for testing a random hodgepodge of small features from simulator and end-to-end tests.
 contract StatefulTest {
-    use dep::aztec::protocol_types::address::AztecAddress;
+    use dep::aztec::protocol_types::{
+        address::AztecAddress,
+        abis::function_selector::FunctionSelector,
+    };
     use dep::std::option::Option;
     use dep::value_note::{
         balance_utils,
@@ -47,8 +50,12 @@ contract StatefulTest {
 
     #[aztec(private)]
     fn constructor(owner: AztecAddress, value: Field) {
-        let loc = storage.notes.at(owner);
-        increment(loc, value, owner);
+        let selector = FunctionSelector::from_signature("create_note((Field),Field)");
+        let _res = context.call_private_function(
+            context.this_address(),
+            selector,
+            [owner.to_field(), value]
+        );
     }
 
     #[aztec(private)]

--- a/yarn-project/noir-protocol-circuits/src/crates/private-kernel-lib/src/private_kernel_inner.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/private-kernel-lib/src/private_kernel_inner.nr
@@ -32,7 +32,6 @@ impl PrivateKernelInputsInner {
         let this_call_stack_item = self.private_call.call_stack_item;
         let function_data = this_call_stack_item.function_data;
         assert(function_data.is_private, "Private kernel circuit can only execute a private function");
-        assert(function_data.is_constructor == false, "A constructor must be executed as the first tx in the recursion");
         assert(self.previous_kernel.public_inputs.is_private, "Can only verify a private kernel snark in the private kernel circuit");
     }
 
@@ -539,15 +538,6 @@ mod tests {
         let mut builder = PrivateKernelInnerInputsBuilder::new();
 
         builder.private_call.function_data.is_private = false;
-
-        builder.failed();
-    }
-
-    #[test(should_fail_with="A constructor must be executed as the first tx in the recursion")]
-    fn private_function_is_constructor_fails() {
-        let mut builder = PrivateKernelInnerInputsBuilder::new();
-
-        builder.private_call.function_data.is_constructor = true;
 
         builder.failed();
     }

--- a/yarn-project/pxe/src/contract_data_oracle/private_functions_tree.ts
+++ b/yarn-project/pxe/src/contract_data_oracle/private_functions_tree.ts
@@ -43,7 +43,7 @@ export class PrivateFunctionsTree {
     if (!artifact) {
       throw new Error(
         `Unknown function. Selector ${selector.toString()} not found in the artifact of contract ${this.contract.instance.address.toString()}. Expected one of: ${this.contract.functions
-          .map(f => f.selector.toString())
+          .map(f => `${f.name} (${f.selector.toString()})`)
           .join(', ')}`,
       );
     }


### PR DESCRIPTION
Adds final tweaks to kernel circuit and e2e tests to check that a contract private function can be called without needing to initialize or deploy the contract, and to check that a contract can be privately initialized without deploying it.

Fixes #4057
Fixes #4058
Fixes #4059