### PR TITLE
refactor: remove duplicated global variables

### DIFF
--- a/yarn-project/acir-simulator/src/public/executor.ts
+++ b/yarn-project/acir-simulator/src/public/executor.ts
@@ -1,4 +1,4 @@
-import { GlobalVariables, Header, PublicCircuitPublicInputs } from '@aztec/circuits.js';
+import { Header, PublicCircuitPublicInputs } from '@aztec/circuits.js';
 import { createDebugLogger } from '@aztec/foundation/log';
 
 import { Oracle, acvm, extractCallStack, extractReturnWitness } from '../acvm/index.js';
@@ -91,7 +91,7 @@ export class PublicExecutor {
    * @param globalVariables - The global variables to use.
    * @returns The result of the run plus all nested runs.
    */
-  public async simulate(execution: PublicExecution, globalVariables: GlobalVariables): Promise<PublicExecutionResult> {
+  public async simulate(execution: PublicExecution): Promise<PublicExecutionResult> {
     const selector = execution.functionData.selector;
     const acir = await this.contractsDb.getBytecode(execution.contractAddress, selector);
     if (!acir) {
@@ -107,7 +107,6 @@ export class PublicExecutor {
     const context = new PublicExecutionContext(
       execution,
       this.header,
-      globalVariables,
       packedArgs,
       sideEffectCounter,
       this.stateDb,

--- a/yarn-project/acir-simulator/src/public/public_execution_context.ts
+++ b/yarn-project/acir-simulator/src/public/public_execution_context.ts
@@ -1,5 +1,5 @@
 import { FunctionL2Logs, UnencryptedL2Log } from '@aztec/circuit-types';
-import { CallContext, FunctionData, FunctionSelector, GlobalVariables, Header } from '@aztec/circuits.js';
+import { CallContext, FunctionData, FunctionSelector, Header } from '@aztec/circuits.js';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
@@ -26,7 +26,6 @@ export class PublicExecutionContext extends TypedOracle {
      */
     public readonly execution: PublicExecution,
     private readonly header: Header,
-    private readonly globalVariables: GlobalVariables,
     private readonly packedArgsCache: PackedArgsCache,
     private readonly sideEffectCounter: SideEffectCounter,
     private readonly stateDb: PublicStateDB,
@@ -43,13 +42,17 @@ export class PublicExecutionContext extends TypedOracle {
    * @param args - The arguments to the function.
    * @param callContext - The call context of the function.
    * @param header - Contains data required to reconstruct a block hash (historical roots etc.).
-   * @param globalVariables - The global variables.
    * @param witnessStartIndex - The index where to start inserting the parameters.
    * @returns The initial witness.
    */
   public getInitialWitness(witnessStartIndex = 0) {
     const { callContext, args } = this.execution;
-    const fields = [...callContext.toFields(), ...this.header.toFields(), ...this.globalVariables.toFields(), ...args];
+    const fields = [
+      ...callContext.toFields(),
+      ...this.header.toFields(),
+      ...this.header.globalVariables.toFields(),
+      ...args,
+    ];
 
     return toACVMWitness(witnessStartIndex, fields);
   }
@@ -198,7 +201,6 @@ export class PublicExecutionContext extends TypedOracle {
     const context = new PublicExecutionContext(
       nestedExecution,
       this.header,
-      this.globalVariables,
       this.packedArgsCache,
       this.sideEffectCounter,
       this.stateDb,


### PR DESCRIPTION
Global variables appeared inside the header, aswell as an input to the executor
