### PR TITLE
refactor: consistent naming of serialization method

### DIFF
--- a/yarn-project/acir-simulator/src/acvm/oracle/oracle.ts
+++ b/yarn-project/acir-simulator/src/acvm/oracle/oracle.ts
@@ -89,7 +89,7 @@ export class Oracle {
         `Low nullifier witness not found for nullifier ${parsedNullifier} at block ${parsedBlockNumber}.`,
       );
     }
-    return witness.toFieldArray().map(toACVMField);
+    return witness.toFields().map(toACVMField);
   }
 
   async getLowNullifierMembershipWitness(
@@ -105,7 +105,7 @@ export class Oracle {
         `Low nullifier witness not found for nullifier ${parsedNullifier} at block ${parsedBlockNumber}.`,
       );
     }
-    return witness.toFieldArray().map(toACVMField);
+    return witness.toFields().map(toACVMField);
   }
 
   async getPublicDataTreeWitness([blockNumber]: ACVMField[], [leafSlot]: ACVMField[]): Promise<ACVMField[]> {
@@ -116,7 +116,7 @@ export class Oracle {
     if (!witness) {
       throw new Error(`Public data witness not found for slot ${parsedLeafSlot} at block ${parsedBlockNumber}.`);
     }
-    return witness.toFieldArray().map(toACVMField);
+    return witness.toFields().map(toACVMField);
   }
 
   async getHeader([blockNumber]: ACVMField[]): Promise<ACVMField[]> {

--- a/yarn-project/acir-simulator/src/acvm/oracle/typed_oracle.ts
+++ b/yarn-project/acir-simulator/src/acvm/oracle/typed_oracle.ts
@@ -67,7 +67,7 @@ export class MessageLoadOracleInputs<N extends number> {
   ) {}
 
   toFields(): Fr[] {
-    return [...this.message.toFieldArray(), new Fr(this.index), ...this.siblingPath.toFieldArray()];
+    return [...this.message.toFields(), new Fr(this.index), ...this.siblingPath.toFields()];
   }
 }
 

--- a/yarn-project/circuit-types/src/interfaces/nullifier_tree.ts
+++ b/yarn-project/circuit-types/src/interfaces/nullifier_tree.ts
@@ -28,7 +28,7 @@ export class NullifierMembershipWitness {
    * Returns a field array representation of a nullifier witness.
    * @returns A field array representation of a nullifier witness.
    */
-  public toFieldArray(): Fr[] {
-    return [new Fr(this.index), ...this.leafPreimage.toFieldArray(), ...this.siblingPath.toFieldArray()];
+  public toFields(): Fr[] {
+    return [new Fr(this.index), ...this.leafPreimage.toFields(), ...this.siblingPath.toFields()];
   }
 }

--- a/yarn-project/circuit-types/src/interfaces/public_data_tree.ts
+++ b/yarn-project/circuit-types/src/interfaces/public_data_tree.ts
@@ -29,14 +29,14 @@ export class PublicDataWitness {
    * Returns a field array representation of a public data witness.
    * @returns A field array representation of a public data witness.
    */
-  public toFieldArray(): Fr[] {
+  public toFields(): Fr[] {
     return [
       new Fr(this.index),
       new Fr(this.leafPreimage.slot),
       new Fr(this.leafPreimage.value),
       new Fr(this.leafPreimage.nextIndex),
       new Fr(this.leafPreimage.nextSlot),
-      ...this.siblingPath.toFieldArray(),
+      ...this.siblingPath.toFields(),
     ];
   }
 }

--- a/yarn-project/circuit-types/src/l1_to_l2_message.ts
+++ b/yarn-project/circuit-types/src/l1_to_l2_message.ts
@@ -102,10 +102,10 @@ export class L1ToL2Message {
    * Returns each element within its own field so that it can be consumed by an acvm oracle call.
    * @returns The message as an array of fields (in order).
    */
-  toFieldArray(): Fr[] {
+  toFields(): Fr[] {
     return [
-      ...this.sender.toFieldArray(),
-      ...this.recipient.toFieldArray(),
+      ...this.sender.toFields(),
+      ...this.recipient.toFields(),
       this.content,
       this.secretHash,
       new Fr(BigInt(this.deadline)),
@@ -118,7 +118,7 @@ export class L1ToL2Message {
   }
 
   hash(): Fr {
-    return Fr.fromBufferReduce(sha256(serializeToBuffer(...this.toFieldArray())));
+    return Fr.fromBufferReduce(sha256(serializeToBuffer(...this.toFields())));
   }
 
   static fromBuffer(buffer: Buffer | BufferReader): L1ToL2Message {
@@ -177,7 +177,7 @@ export class L1Actor {
     return new L1Actor(EthAddress.ZERO, 0);
   }
 
-  toFieldArray(): Fr[] {
+  toFields(): Fr[] {
     return [this.sender.toField(), new Fr(BigInt(this.chainId))];
   }
 
@@ -216,7 +216,7 @@ export class L2Actor {
     return new L2Actor(AztecAddress.ZERO, 0);
   }
 
-  toFieldArray(): Fr[] {
+  toFields(): Fr[] {
     return [this.recipient.toField(), new Fr(BigInt(this.version))];
   }
 

--- a/yarn-project/circuit-types/src/sibling_path/sibling-path.ts
+++ b/yarn-project/circuit-types/src/sibling_path/sibling-path.ts
@@ -76,7 +76,7 @@ export class SiblingPath<N extends number> {
    * Convert the Sibling Path object into an array of field elements.
    * @returns The field array representation of this object.
    */
-  public toFieldArray(): Fr[] {
+  public toFields(): Fr[] {
     return this.data.map(buf => Fr.fromBuffer(buf));
   }
 
@@ -85,7 +85,7 @@ export class SiblingPath<N extends number> {
    * @returns A tuple representation of the sibling path.
    */
   public toTuple<N extends number>(): Tuple<Fr, N> {
-    const array = this.toFieldArray();
+    const array = this.toFields();
     return makeTuple(array.length as N, i => array[i], 0);
   }
 

--- a/yarn-project/circuits.js/src/structs/call_context.ts
+++ b/yarn-project/circuits.js/src/structs/call_context.ts
@@ -1,6 +1,6 @@
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { EthAddress } from '@aztec/foundation/eth-address';
-import { BufferReader, FieldReader, serializeToBuffer, serializeToFieldArray } from '@aztec/foundation/serialize';
+import { BufferReader, FieldReader, serializeToBuffer, serializeToFields } from '@aztec/foundation/serialize';
 import { FieldsOf } from '@aztec/foundation/types';
 
 import { Fr, FunctionSelector } from './index.js';
@@ -108,7 +108,7 @@ export class CallContext {
   }
 
   toFields(): Fr[] {
-    return serializeToFieldArray(...CallContext.getFields(this));
+    return serializeToFields(...CallContext.getFields(this));
   }
 
   /**

--- a/yarn-project/circuits.js/src/structs/global_variables.ts
+++ b/yarn-project/circuits.js/src/structs/global_variables.ts
@@ -1,5 +1,5 @@
 import { Fr } from '@aztec/foundation/fields';
-import { BufferReader, FieldReader, serializeToBuffer, serializeToFieldArray } from '@aztec/foundation/serialize';
+import { BufferReader, FieldReader, serializeToBuffer, serializeToFields } from '@aztec/foundation/serialize';
 import { FieldsOf } from '@aztec/foundation/types';
 
 /**
@@ -68,7 +68,7 @@ export class GlobalVariables {
   }
 
   toFields() {
-    return serializeToFieldArray(...GlobalVariables.getFields(this));
+    return serializeToFields(...GlobalVariables.getFields(this));
   }
 
   toJSON() {

--- a/yarn-project/circuits.js/src/structs/membership_witness.ts
+++ b/yarn-project/circuits.js/src/structs/membership_witness.ts
@@ -94,6 +94,6 @@ export class MembershipWitness<N extends number> {
 
   // import { SiblingPath } from '@aztec/merkle-tree';
   //   static fromSiblingPath<N extends number>(leafIndex: bigint, siblingPath: SiblingPath<N>): MembershipWitness<N> {
-  //     return new MembershipWitness<N>(siblingPath.pathSize, leafIndex, siblingPath.toFieldArray() as Tuple<Fr, N>);
+  //     return new MembershipWitness<N>(siblingPath.pathSize, leafIndex, siblingPath.toFields() as Tuple<Fr, N>);
   //   }
 }

--- a/yarn-project/circuits.js/src/structs/private_circuit_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/private_circuit_public_inputs.ts
@@ -2,13 +2,7 @@ import { makeTuple } from '@aztec/foundation/array';
 import { isArrayEmpty } from '@aztec/foundation/collection';
 import { pedersenHash } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
-import {
-  BufferReader,
-  FieldReader,
-  Tuple,
-  serializeToBuffer,
-  serializeToFieldArray,
-} from '@aztec/foundation/serialize';
+import { BufferReader, FieldReader, Tuple, serializeToBuffer, serializeToFields } from '@aztec/foundation/serialize';
 import { FieldsOf } from '@aztec/foundation/types';
 
 import {
@@ -282,7 +276,7 @@ export class PrivateCircuitPublicInputs {
    * Serialize this as a field array.
    */
   toFields(): Fr[] {
-    return serializeToFieldArray(...PrivateCircuitPublicInputs.getFields(this));
+    return serializeToFields(...PrivateCircuitPublicInputs.getFields(this));
   }
 
   hash(): Fr {

--- a/yarn-project/circuits.js/src/structs/public_circuit_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/public_circuit_public_inputs.ts
@@ -3,7 +3,7 @@ import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { isArrayEmpty } from '@aztec/foundation/collection';
 import { pedersenHash } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
-import { FieldReader, Tuple, serializeToBuffer, serializeToFieldArray } from '@aztec/foundation/serialize';
+import { FieldReader, Tuple, serializeToBuffer, serializeToFields } from '@aztec/foundation/serialize';
 import { FieldsOf } from '@aztec/foundation/types';
 
 import {
@@ -175,7 +175,7 @@ export class PublicCircuitPublicInputs {
   }
 
   toFields(): Fr[] {
-    return serializeToFieldArray(...PublicCircuitPublicInputs.getFields(this));
+    return serializeToFields(...PublicCircuitPublicInputs.getFields(this));
   }
 
   static fromFields(fields: Fr[] | FieldReader): PublicCircuitPublicInputs {

--- a/yarn-project/circuits.js/src/structs/rollup/nullifier_leaf/index.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/nullifier_leaf/index.ts
@@ -50,7 +50,7 @@ export class NullifierLeafPreimage implements IndexedTreeLeafPreimage {
     ];
   }
 
-  toFieldArray(): Fr[] {
+  toFields(): Fr[] {
     return this.toHashInputs().map(buf => Fr.fromBuffer(buf));
   }
 

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract.test.ts
@@ -47,7 +47,7 @@ describe('e2e_blacklist_token_contract', () => {
       index,
       value: Fr.fromBuffer(slowUpdateTreeSimulator.getLeafValue(index, includeUncommitted)!),
       // eslint-disable-next-line camelcase
-      sibling_path: (await slowUpdateTreeSimulator.getSiblingPath(index, includeUncommitted)).toFieldArray(),
+      sibling_path: (await slowUpdateTreeSimulator.getSiblingPath(index, includeUncommitted)).toFields(),
     };
   };
 

--- a/yarn-project/end-to-end/src/e2e_slow_tree.test.ts
+++ b/yarn-project/end-to-end/src/e2e_slow_tree.test.ts
@@ -35,7 +35,7 @@ describe('e2e_slow_tree', () => {
         index,
         value: Fr.fromBuffer(slowUpdateTreeSimulator.getLeafValue(index, includeUncommitted)!),
         // eslint-disable-next-line camelcase
-        sibling_path: (await slowUpdateTreeSimulator.getSiblingPath(index, includeUncommitted)).toFieldArray(),
+        sibling_path: (await slowUpdateTreeSimulator.getSiblingPath(index, includeUncommitted)).toFields(),
       };
     };
 

--- a/yarn-project/foundation/src/serialize/serialize.ts
+++ b/yarn-project/foundation/src/serialize/serialize.ts
@@ -190,11 +190,11 @@ export function serializeToBufferArray(...objs: Bufferable[]): Buffer[] {
  * @param objs - Objects to serialize.
  * @returns An array of fields with the concatenation of all fields.
  */
-export function serializeToFieldArray(...objs: Fieldeable[]): Fr[] {
+export function serializeToFields(...objs: Fieldeable[]): Fr[] {
   let ret: Fr[] = [];
   for (const obj of objs) {
     if (Array.isArray(obj)) {
-      ret = [...ret, ...serializeToFieldArray(...obj)];
+      ret = [...ret, ...serializeToFields(...obj)];
     } else if (obj instanceof Fr) {
       ret.push(obj);
     } else if (typeof obj === 'boolean' || typeof obj === 'number' || typeof obj === 'bigint') {

--- a/yarn-project/noir-protocol-circuits/src/noir_test_gen.test.ts
+++ b/yarn-project/noir-protocol-circuits/src/noir_test_gen.test.ts
@@ -107,7 +107,7 @@ describe('Data generation for noir tests', () => {
 
     const root = noteHashTree.getRoot(true);
     const siblingPaths = await Promise.all(
-      indexes.map(async index => (await noteHashTree.getSiblingPath(index, true)).toFieldArray()),
+      indexes.map(async index => (await noteHashTree.getSiblingPath(index, true)).toFields()),
     );
 
     expect({

--- a/yarn-project/pxe/src/kernel_oracle/index.ts
+++ b/yarn-project/pxe/src/kernel_oracle/index.ts
@@ -46,7 +46,7 @@ export class KernelOracle implements ProvingDataOracle {
     return new MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT>(
       path.pathSize,
       leafIndex,
-      path.toFieldArray() as Tuple<Fr, typeof NOTE_HASH_TREE_HEIGHT>,
+      path.toFields() as Tuple<Fr, typeof NOTE_HASH_TREE_HEIGHT>,
     );
   }
 

--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -155,15 +155,15 @@ export class SimulatorOracle implements DBOracle {
     // @todo Doing a nasty workaround here because of https://github.com/AztecProtocol/aztec-packages/issues/3414
     switch (treeId) {
       case MerkleTreeId.CONTRACT_TREE:
-        return (await this.stateInfoProvider.getContractSiblingPath(blockNumber, leafIndex)).toFieldArray();
+        return (await this.stateInfoProvider.getContractSiblingPath(blockNumber, leafIndex)).toFields();
       case MerkleTreeId.NULLIFIER_TREE:
-        return (await this.stateInfoProvider.getNullifierSiblingPath(blockNumber, leafIndex)).toFieldArray();
+        return (await this.stateInfoProvider.getNullifierSiblingPath(blockNumber, leafIndex)).toFields();
       case MerkleTreeId.NOTE_HASH_TREE:
-        return (await this.stateInfoProvider.getNoteHashSiblingPath(blockNumber, leafIndex)).toFieldArray();
+        return (await this.stateInfoProvider.getNoteHashSiblingPath(blockNumber, leafIndex)).toFields();
       case MerkleTreeId.PUBLIC_DATA_TREE:
-        return (await this.stateInfoProvider.getPublicDataSiblingPath(blockNumber, leafIndex)).toFieldArray();
+        return (await this.stateInfoProvider.getPublicDataSiblingPath(blockNumber, leafIndex)).toFields();
       case MerkleTreeId.ARCHIVE:
-        return (await this.stateInfoProvider.getArchiveSiblingPath(blockNumber, leafIndex)).toFieldArray();
+        return (await this.stateInfoProvider.getArchiveSiblingPath(blockNumber, leafIndex)).toFields();
       default:
         throw new Error('Not implemented');
     }

--- a/yarn-project/sequencer-client/src/block_builder/solo_block_builder.ts
+++ b/yarn-project/sequencer-client/src/block_builder/solo_block_builder.ts
@@ -362,7 +362,7 @@ export class SoloBlockBuilder implements BlockBuilder {
       const { size } = await this.db.getTreeInfo(treeId);
       // TODO: Check for off-by-one errors
       const path = await this.db.getSiblingPath(treeId, size);
-      return path.toFieldArray();
+      return path.toFields();
     };
 
     const newL1ToL2MessageTreeRootSiblingPathArray = await this.getSubtreeSiblingPath(
@@ -450,7 +450,7 @@ export class SoloBlockBuilder implements BlockBuilder {
       throw new Error(`Leaf with value ${value} not found in tree ${MerkleTreeId[treeId]}`);
     }
     const path = await this.db.getSiblingPath(treeId, index);
-    return new MembershipWitness(height, index, assertLength(path.toFieldArray(), height));
+    return new MembershipWitness(height, index, assertLength(path.toFields(), height));
   }
 
   protected async getConstantRollupData(globalVariables: GlobalVariables): Promise<ConstantRollupData> {
@@ -489,7 +489,7 @@ export class SoloBlockBuilder implements BlockBuilder {
       witness: new MembershipWitness(
         NULLIFIER_TREE_HEIGHT,
         BigInt(prevValueIndex.index),
-        assertLength(prevValueSiblingPath.toFieldArray(), NULLIFIER_TREE_HEIGHT),
+        assertLength(prevValueSiblingPath.toFields(), NULLIFIER_TREE_HEIGHT),
       ),
     };
   }
@@ -499,7 +499,7 @@ export class SoloBlockBuilder implements BlockBuilder {
     const fullSiblingPath = await this.db.getSiblingPath(treeId, nextAvailableLeafIndex);
 
     // Drop the first subtreeHeight items since we only care about the path to the subtree root
-    return fullSiblingPath.getSubtreeSiblingPath(subtreeHeight).toFieldArray();
+    return fullSiblingPath.getSubtreeSiblingPath(subtreeHeight).toFields();
   }
 
   protected async processPublicDataUpdateRequests(tx: ProcessedTx) {
@@ -525,7 +525,7 @@ export class SoloBlockBuilder implements BlockBuilder {
       return sortedNewLeavesIndexes[i];
     });
 
-    const subtreeSiblingPathAsFields = newSubtreeSiblingPath.toFieldArray();
+    const subtreeSiblingPathAsFields = newSubtreeSiblingPath.toFields();
     const newPublicDataSubtreeSiblingPath = makeTuple(PUBLIC_DATA_SUBTREE_SIBLING_PATH_LENGTH, i => {
       return subtreeSiblingPathAsFields[i];
     });
@@ -655,7 +655,7 @@ export class SoloBlockBuilder implements BlockBuilder {
         MembershipWitness.fromBufferArray(l.index, assertLength(l.siblingPath.toBufferArray(), NULLIFIER_TREE_HEIGHT)),
       );
 
-    const nullifierSubtreeSiblingPathArray = newNullifiersSubtreeSiblingPath.toFieldArray();
+    const nullifierSubtreeSiblingPathArray = newNullifiersSubtreeSiblingPath.toFields();
 
     const nullifierSubtreeSiblingPath = makeTuple(NULLIFIER_SUBTREE_SIBLING_PATH_LENGTH, i =>
       i < nullifierSubtreeSiblingPathArray.length ? nullifierSubtreeSiblingPathArray[i] : Fr.ZERO,


### PR DESCRIPTION
Naming of to fields methods was incosistent. This PR fixes it.
