### PR TITLE
refactor!: Use NoteSerialize and NoteDeserialize traits for note specific serialization 

### DIFF
--- a/boxes/token/src/contracts/src/main.nr
+++ b/boxes/token/src/contracts/src/main.nr
@@ -328,9 +328,9 @@ contract Token {
     ) -> pub [Field; 4] {
         let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
         if (storage_slot == storage.pending_shields.get_storage_slot()) {
-            note_utils::compute_note_hash_and_nullifier(TransparentNote::deserialize, note_header, serialized_note)
+            note_utils::compute_note_hash_and_nullifier(TransparentNote::deserialize_content, note_header, serialized_note)
         } else {
-            note_utils::compute_note_hash_and_nullifier(TokenNote::deserialize, note_header, serialized_note)
+            note_utils::compute_note_hash_and_nullifier(TokenNote::deserialize_content, note_header, serialized_note)
         }
     }
     // docs:end:compute_note_hash_and_nullifier

--- a/boxes/token/src/contracts/src/types/balances_map.nr
+++ b/boxes/token/src/contracts/src/types/balances_map.nr
@@ -6,7 +6,6 @@ use dep::aztec::{
     protocol_types::{
         address::AztecAddress,
         constants::MAX_READ_REQUESTS_PER_CALL,
-        traits::{Serialize, Deserialize}
     },
     state_vars::{
         set::Set,
@@ -37,11 +36,11 @@ impl<T> BalancesMap<T> {
         }
     }
 
-    unconstrained pub fn balance_of<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress) -> SafeU120 where T: Deserialize<T_SERIALIZED_LEN> + Serialize<T_SERIALIZED_LEN> + NoteInterface + OwnedNote {
+    unconstrained pub fn balance_of<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress) -> SafeU120 where T: NoteInterface<T_SERIALIZED_LEN> + OwnedNote {
         self.balance_of_with_offset(owner, 0)
     }
 
-  unconstrained pub fn balance_of_with_offset<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, offset: u32) -> SafeU120 where T: Deserialize<T_SERIALIZED_LEN> + Serialize<T_SERIALIZED_LEN> + NoteInterface + OwnedNote {
+  unconstrained pub fn balance_of_with_offset<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, offset: u32) -> SafeU120 where T: NoteInterface<T_SERIALIZED_LEN> + OwnedNote {
       // Same as SafeU120::new(0), but fewer constraints because no check. 
       let mut balance = SafeU120::min();
       // docs:start:view_notes
@@ -61,7 +60,7 @@ impl<T> BalancesMap<T> {
       balance
   }
 
-    pub fn add<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, addend: SafeU120) where T: Deserialize<T_SERIALIZED_LEN> + Serialize<T_SERIALIZED_LEN> + NoteInterface + OwnedNote {
+    pub fn add<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, addend: SafeU120) where T: NoteInterface<T_SERIALIZED_LEN> + OwnedNote {
         let mut addend_note = T::new(addend, owner);
 
         // docs:start:insert
@@ -69,7 +68,7 @@ impl<T> BalancesMap<T> {
         // docs:end:insert
     }
 
-    pub fn sub<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, subtrahend: SafeU120) where T: Deserialize<T_SERIALIZED_LEN> + Serialize<T_SERIALIZED_LEN> + NoteInterface + OwnedNote{
+    pub fn sub<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, subtrahend: SafeU120) where T: NoteInterface<T_SERIALIZED_LEN> + OwnedNote{
         // docs:start:get_notes
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, subtrahend);
         let maybe_notes = self.map.at(owner).get_notes(options);
@@ -105,7 +104,7 @@ impl<T> BalancesMap<T> {
 pub fn filter_notes_min_sum<T, T_SERIALIZED_LEN>(
     notes: [Option<T>; MAX_READ_REQUESTS_PER_CALL],
     min_sum: SafeU120
-) -> [Option<T>; MAX_READ_REQUESTS_PER_CALL] where T: Deserialize<T_SERIALIZED_LEN> + Serialize<T_SERIALIZED_LEN> + NoteInterface + OwnedNote {
+) -> [Option<T>; MAX_READ_REQUESTS_PER_CALL] where T: NoteInterface<T_SERIALIZED_LEN> + OwnedNote {
     let mut selected = [Option::none(); MAX_READ_REQUESTS_PER_CALL];
     let mut sum = SafeU120::min();
     for i in 0..notes.len() {

--- a/boxes/token/src/contracts/src/types/token_note.nr
+++ b/boxes/token/src/contracts/src/types/token_note.nr
@@ -1,10 +1,8 @@
-use dep::aztec::protocol_types::{
-    address::AztecAddress,
-    constants::{
-        MAX_READ_REQUESTS_PER_CALL
-    },
-};
 use dep::aztec::{
+    protocol_types::{
+        address::AztecAddress,
+        constants::MAX_READ_REQUESTS_PER_CALL
+    },
     note::{
         note_header::NoteHeader,
         note_interface::NoteInterface,
@@ -14,10 +12,6 @@ use dep::aztec::{
     state_vars::set::Set,
     log::emit_encrypted_log,
     hash::pedersen_hash,
-    protocol_types::traits::{
-        Serialize,
-        Deserialize
-    },
 };
 use dep::aztec::oracle::{
     rand::rand,
@@ -49,14 +43,12 @@ struct TokenNote {
     header: NoteHeader,
 }
 
-impl Serialize<TOKEN_NOTE_LEN> for TokenNote {
-    fn serialize(self) -> [Field; TOKEN_NOTE_LEN] {
+impl NoteInterface<TOKEN_NOTE_LEN> for TokenNote {
+    fn serialize_content(self) -> [Field; TOKEN_NOTE_LEN] {
         [self.amount.value as Field, self.owner.to_field(), self.randomness]
     }
-}
 
-impl Deserialize<TOKEN_NOTE_LEN> for TokenNote {
-    fn deserialize(serialized_note: [Field; TOKEN_NOTE_LEN]) -> Self {
+    fn deserialize_content(serialized_note: [Field; TOKEN_NOTE_LEN]) -> Self {
         Self {
             amount: SafeU120::new(serialized_note[0]),
             owner: AztecAddress::from_field(serialized_note[1]),
@@ -64,12 +56,10 @@ impl Deserialize<TOKEN_NOTE_LEN> for TokenNote {
             header: NoteHeader::empty(),
         }
     }
-}
 
-impl NoteInterface for TokenNote {
     fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash(self.serialize(), 0)
+        pedersen_hash(self.serialize_content(), 0)
     }
 
     // docs:start:nullifier
@@ -100,8 +90,8 @@ impl NoteInterface for TokenNote {
         self.header = header;
     }
 
-    fn get_header(note: TokenNote) -> NoteHeader {
-        note.header
+    fn get_header(self) -> NoteHeader {
+        self.header
     }
 
     // Broadcasts the note as an encrypted log on L1.
@@ -114,7 +104,7 @@ impl NoteInterface for TokenNote {
               (*context).this_address(),
               slot,
               encryption_pub_key,
-              self.serialize(),
+              self.serialize_content(),
           );
       }
   }

--- a/boxes/token/src/contracts/src/types/transparent_note.nr
+++ b/boxes/token/src/contracts/src/types/transparent_note.nr
@@ -7,7 +7,6 @@ use dep::aztec::{
     },
     hash::{compute_secret_hash, pedersen_hash},
     context::PrivateContext,
-    protocol_types::traits::{Serialize, Deserialize, Empty}
 };
 
 global TRANSPARENT_NOTE_LEN: Field = 2;
@@ -23,14 +22,12 @@ struct TransparentNote {
     header: NoteHeader,
 }
 
-impl Serialize<TRANSPARENT_NOTE_LEN> for TransparentNote {
-    fn serialize(self) -> [Field; TRANSPARENT_NOTE_LEN] {
+impl NoteInterface<TRANSPARENT_NOTE_LEN> for TransparentNote {
+    fn serialize_content(self) -> [Field; TRANSPARENT_NOTE_LEN] {
         [self.amount, self.secret_hash]
     }
-}
 
-impl Deserialize<TRANSPARENT_NOTE_LEN> for TransparentNote {
-    fn deserialize(serialized_note: [Field; TRANSPARENT_NOTE_LEN]) -> Self {
+    fn deserialize_content(serialized_note: [Field; TRANSPARENT_NOTE_LEN]) -> Self {
         TransparentNote {
             amount: serialized_note[0],
             secret_hash: serialized_note[1],
@@ -38,19 +35,10 @@ impl Deserialize<TRANSPARENT_NOTE_LEN> for TransparentNote {
             header: NoteHeader::empty(),
         }
     }
-}
-
-impl Empty for TransparentNote {
-    fn empty() -> Self {
-        TransparentNote::new(0, 0)
-    }
-}
-
-impl NoteInterface for TransparentNote {
 
     fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash(self.serialize(), 0)
+        pedersen_hash(self.serialize_content(), 0)
     }
 
     fn compute_nullifier(self, _context: &mut PrivateContext) -> Field {
@@ -63,13 +51,12 @@ impl NoteInterface for TransparentNote {
         pedersen_hash([self.secret, siloed_note_hash],0)
     }
 
-
     fn set_header(&mut self, header: NoteHeader) {
         self.header = header;
     }
 
-    fn get_header(note: TransparentNote) -> NoteHeader {
-        note.header
+    fn get_header(self) -> NoteHeader {
+        self.header
     }
 
     fn broadcast(self, context: &mut PrivateContext, slot: Field) {
@@ -89,6 +76,7 @@ impl TransparentNote {
             header: NoteHeader::empty(),
         }
     }
+
     // new oracle call primitive
     // get me the secret corresponding to this hash
     pub fn new_from_secret(amount: Field, secret: Field) -> Self {

--- a/yarn-project/aztec-nr/address-note/src/address_note.nr
+++ b/yarn-project/aztec-nr/address-note/src/address_note.nr
@@ -4,7 +4,7 @@ use dep::aztec::log::emit_encrypted_log;
 use dep::aztec::{
     protocol_types::{
         address::AztecAddress,
-        traits::{Serialize, Deserialize, Empty}
+        traits::Empty
     },
     note::{
         note_header::NoteHeader,
@@ -31,14 +31,12 @@ struct AddressNote {
     header: NoteHeader,
 }
 
-impl Serialize<ADDRESS_NOTE_LEN> for AddressNote {
-    fn serialize(self) -> [Field; ADDRESS_NOTE_LEN]{
+impl NoteInterface<ADDRESS_NOTE_LEN>  for AddressNote {
+    fn serialize_content(self) -> [Field; ADDRESS_NOTE_LEN]{
         [self.address.to_field(), self.owner.to_field(), self.randomness]
     }
-}
 
-impl Deserialize<ADDRESS_NOTE_LEN> for AddressNote {
-    fn deserialize(serialized_note: [Field; ADDRESS_NOTE_LEN]) -> Self {
+    fn deserialize_content(serialized_note: [Field; ADDRESS_NOTE_LEN]) -> Self {
         AddressNote {
             address: AztecAddress::from_field(serialized_note[0]),
             owner: AztecAddress::from_field(serialized_note[1]),
@@ -46,12 +44,10 @@ impl Deserialize<ADDRESS_NOTE_LEN> for AddressNote {
             header: NoteHeader::empty(),
         }
     }
-}
 
-impl NoteInterface for AddressNote {
     fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash(self.serialize(), 0)
+        pedersen_hash(self.serialize_content(), 0)
     }
 
     fn compute_nullifier(self, context: &mut PrivateContext) -> Field {
@@ -93,7 +89,7 @@ impl NoteInterface for AddressNote {
             (*context).this_address(),
             slot,
             encryption_pub_key,
-            self.serialize(),
+            self.serialize_content(),
         );
         // docs:end:encrypted
     }

--- a/yarn-project/aztec-nr/aztec/src/history/note_inclusion.nr
+++ b/yarn-project/aztec-nr/aztec/src/history/note_inclusion.nr
@@ -33,7 +33,7 @@ pub fn prove_note_inclusion<Note, N>(
     note_with_header: Note,
     block_number: u32, // The block at which we'll prove that the note exists
     context: PrivateContext
-) where Note: NoteInterface {
+) where Note: NoteInterface<N> {
     let note_commitment = compute_note_hash_for_consumption(note_with_header);
 
     prove_note_commitment_inclusion(note_commitment, block_number, context);

--- a/yarn-project/aztec-nr/aztec/src/history/note_validity.nr
+++ b/yarn-project/aztec-nr/aztec/src/history/note_validity.nr
@@ -12,7 +12,7 @@ pub fn prove_note_validity<Note, N>(
     note_with_header: Note,
     block_number: u32, // The block at which we'll prove that the note exists
     context: &mut PrivateContext
-) where Note: NoteInterface {
+) where Note: NoteInterface<N> {
     prove_note_inclusion(note_with_header, block_number, *context);
     prove_note_not_nullified(note_with_header, block_number, context);
 }

--- a/yarn-project/aztec-nr/aztec/src/history/nullifier_non_inclusion.nr
+++ b/yarn-project/aztec-nr/aztec/src/history/nullifier_non_inclusion.nr
@@ -53,7 +53,7 @@ pub fn prove_note_not_nullified<Note, N>(
     note_with_header: Note,
     block_number: u32, // The block at which we'll prove that the note was not nullified
     context: &mut PrivateContext
-) where Note: NoteInterface {
+) where Note: NoteInterface<N> {
     let nullifier = compute_siloed_nullifier(note_with_header, context);
 
     prove_nullifier_non_inclusion(nullifier, block_number, *context);

--- a/yarn-project/aztec-nr/aztec/src/note/lifecycle.nr
+++ b/yarn-project/aztec-nr/aztec/src/note/lifecycle.nr
@@ -9,14 +9,13 @@ use crate::note::{
     utils::{compute_note_hash_for_insertion, compute_note_hash_for_consumption},
 };
 use crate::oracle::notes::{notify_created_note, notify_nullified_note};
-use dep::protocol_types::traits::{Serialize, Deserialize};
 
 pub fn create_note<Note, N>(
     context: &mut PrivateContext,
     storage_slot: Field,
     note: &mut Note,
     broadcast: bool
-) where Note: NoteInterface + Serialize<N> + Deserialize<N> {
+) where Note: NoteInterface<N> {
     let contract_address = (*context).this_address();
 
     let header = NoteHeader { contract_address, storage_slot, nonce: 0, is_transient: true };
@@ -26,7 +25,7 @@ pub fn create_note<Note, N>(
     let inner_note_hash = compute_note_hash_for_insertion(*note);
 
     // TODO: Strong typing required because of https://github.com/noir-lang/noir/issues/4088
-    let serialized_note: [Field; N] = Note::serialize(*note);
+    let serialized_note: [Field; N] = Note::serialize_content(*note);
     assert(notify_created_note(storage_slot, serialized_note, inner_note_hash) == 0);
 
     context.push_new_note_hash(inner_note_hash);
@@ -36,7 +35,11 @@ pub fn create_note<Note, N>(
     }
 }
 
-pub fn create_note_hash_from_public<Note>(context: &mut PublicContext, storage_slot: Field, note: &mut Note) where Note: NoteInterface {
+pub fn create_note_hash_from_public<Note, N>(
+    context: &mut PublicContext,
+    storage_slot: Field,
+    note: &mut Note
+) where Note: NoteInterface<N> {
     let contract_address = (*context).this_address();
 
     let header = NoteHeader { contract_address, storage_slot, nonce: 0, is_transient: true };
@@ -47,7 +50,7 @@ pub fn create_note_hash_from_public<Note>(context: &mut PublicContext, storage_s
     context.push_new_note_hash(inner_note_hash);
 }
 
-pub fn destroy_note<Note>(context: &mut PrivateContext, note: Note) where Note: NoteInterface {
+pub fn destroy_note<Note, N>(context: &mut PrivateContext, note: Note) where Note: NoteInterface<N> {
     let mut nullifier = 0;
     let mut consumed_note_hash: Field = 0;
     nullifier = note.compute_nullifier(context);

--- a/yarn-project/aztec-nr/aztec/src/note/note_getter.nr
+++ b/yarn-project/aztec-nr/aztec/src/note/note_getter.nr
@@ -7,7 +7,6 @@ use dep::protocol_types::{
         MAX_NOTES_PER_PAGE,
         VIEW_NOTE_ORACLE_RETURN_LENGTH,
     },
-    traits::{Deserialize, Serialize}
 };
 use crate::context::PrivateContext;
 use crate::note::{
@@ -22,7 +21,7 @@ fn check_note_header<Note, N>(
     context: PrivateContext,
     storage_slot: Field,
     note: Note
-) where Note: NoteInterface {
+) where Note: NoteInterface<N> {
     let header = note.get_header();
     let contract_address = context.this_address();
     assert(header.contract_address.eq(contract_address));
@@ -73,7 +72,7 @@ fn check_notes_order<N>(
 pub fn get_note<Note, N>(
     context: &mut PrivateContext,
     storage_slot: Field
-) -> Note where Note: NoteInterface + Deserialize<N> {
+) -> Note where Note: NoteInterface<N> {
     let note = get_note_internal(storage_slot);
 
     check_note_header(*context, storage_slot, note);
@@ -88,7 +87,7 @@ pub fn get_notes<Note, N, FILTER_ARGS>(
     context: &mut PrivateContext,
     storage_slot: Field,
     options: NoteGetterOptions<Note, N, FILTER_ARGS>
-) -> [Option<Note>; MAX_READ_REQUESTS_PER_CALL] where Note: NoteInterface + Deserialize<N> + Serialize<N> {
+) -> [Option<Note>; MAX_READ_REQUESTS_PER_CALL] where Note: NoteInterface<N> {
     let opt_notes = get_notes_internal(storage_slot, options);
     let mut num_notes = 0;
     let mut prev_fields = [0; N];
@@ -96,7 +95,7 @@ pub fn get_notes<Note, N, FILTER_ARGS>(
         let opt_note = opt_notes[i];
         if opt_note.is_some() {
             let note = opt_note.unwrap_unchecked();
-            let fields = note.serialize();
+            let fields = note.serialize_content();
             check_note_header(*context, storage_slot, note);
             check_note_fields(fields, options.selects);
             if i != 0 {
@@ -118,7 +117,7 @@ pub fn get_notes<Note, N, FILTER_ARGS>(
     opt_notes
 }
 
-unconstrained fn get_note_internal<Note, N>(storage_slot: Field) -> Note where Note: NoteInterface + Deserialize<N> {
+unconstrained fn get_note_internal<Note, N>(storage_slot: Field) -> Note where Note: NoteInterface<N> {
     let placeholder_note = [Option::none()];
     let placeholder_fields = [0; GET_NOTE_ORACLE_RETURN_LENGTH];
     let placeholder_note_length = [0; N];
@@ -142,7 +141,7 @@ unconstrained fn get_note_internal<Note, N>(storage_slot: Field) -> Note where N
 unconstrained fn get_notes_internal<Note, N, FILTER_ARGS>(
     storage_slot: Field,
     options: NoteGetterOptions<Note, N, FILTER_ARGS>
-) -> [Option<Note>; MAX_READ_REQUESTS_PER_CALL] where Note: NoteInterface + Deserialize<N> {
+) -> [Option<Note>; MAX_READ_REQUESTS_PER_CALL] where Note: NoteInterface<N> {
     let (num_selects, select_by, select_values, select_comparators, sort_by, sort_order) = flatten_options(options.selects, options.sorts);
     let placeholder_opt_notes = [Option::none(); MAX_READ_REQUESTS_PER_CALL];
     let placeholder_fields = [0; GET_NOTES_ORACLE_RETURN_LENGTH];
@@ -171,7 +170,7 @@ unconstrained fn get_notes_internal<Note, N, FILTER_ARGS>(
 unconstrained pub fn view_notes<Note, N>(
     storage_slot: Field,
     options: NoteViewerOptions<Note, N>
-) -> [Option<Note>; MAX_NOTES_PER_PAGE] where Note: NoteInterface + Deserialize<N> {
+) -> [Option<Note>; MAX_NOTES_PER_PAGE] where Note: NoteInterface<N> {
     let (num_selects, select_by, select_values, select_comparators, sort_by, sort_order) = flatten_options(options.selects, options.sorts);
     let placeholder_opt_notes = [Option::none(); MAX_NOTES_PER_PAGE];
     let placeholder_fields = [0; VIEW_NOTE_ORACLE_RETURN_LENGTH];

--- a/yarn-project/aztec-nr/aztec/src/note/note_getter_options.nr
+++ b/yarn-project/aztec-nr/aztec/src/note/note_getter_options.nr
@@ -1,7 +1,6 @@
 use dep::std::option::Option;
 use dep::protocol_types::{
     constants::MAX_READ_REQUESTS_PER_CALL,
-    traits::Deserialize,
 };
 use crate::note::note_interface::NoteInterface;
 
@@ -92,7 +91,7 @@ struct NoteGetterOptions<Note, N, FILTER_ARGS> {
 // And finally, a custom filter to refine the outcome further.
 impl<Note, N, FILTER_ARGS> NoteGetterOptions<Note, N, FILTER_ARGS> {
     // This function initializes a NoteGetterOptions that simply returns the maximum number of notes allowed in a call.
-    pub fn new() -> NoteGetterOptions<Note, N, Field> where Note: NoteInterface + Deserialize<N> {
+    pub fn new() -> NoteGetterOptions<Note, N, Field> where Note: NoteInterface<N> {
         NoteGetterOptions {
             selects: BoundedVec::new(Option::none()),
             sorts: BoundedVec::new(Option::none()),
@@ -109,7 +108,7 @@ impl<Note, N, FILTER_ARGS> NoteGetterOptions<Note, N, FILTER_ARGS> {
     pub fn with_filter(
         filter: fn ([Option<Note>; MAX_READ_REQUESTS_PER_CALL], FILTER_ARGS) -> [Option<Note>; MAX_READ_REQUESTS_PER_CALL],
         filter_args: FILTER_ARGS,
-    ) -> Self where Note: NoteInterface + Deserialize<N> {
+    ) -> Self where Note: NoteInterface<N> {
          NoteGetterOptions {
             selects: BoundedVec::new(Option::none()),
             sorts: BoundedVec::new(Option::none()),

--- a/yarn-project/aztec-nr/aztec/src/note/note_interface.nr
+++ b/yarn-project/aztec-nr/aztec/src/note/note_interface.nr
@@ -2,7 +2,11 @@ use crate::context::PrivateContext;
 use crate::note::note_header::NoteHeader;
 
 // docs:start:note_interface
-trait NoteInterface {
+trait NoteInterface<N> {
+    fn serialize_content(self) -> [Field; N];
+
+    fn deserialize_content(fields: [Field; N]) -> Self;
+
     fn compute_note_content_hash(self) -> Field;
 
     fn get_header(self) -> NoteHeader;

--- a/yarn-project/aztec-nr/aztec/src/note/note_viewer_options.nr
+++ b/yarn-project/aztec-nr/aztec/src/note/note_viewer_options.nr
@@ -2,7 +2,6 @@ use dep::std::option::Option;
 use crate::note::note_getter_options::{Select, Sort, Comparator, NoteStatus};
 use dep::protocol_types::{
     constants::MAX_NOTES_PER_PAGE,
-    traits::Deserialize,
 };
 use crate::note::note_interface::NoteInterface;
 
@@ -17,7 +16,7 @@ struct NoteViewerOptions<Note, N> {
 // docs:end:NoteViewerOptions
 
 impl<Note, N> NoteViewerOptions<Note, N> {
-    pub fn new() -> NoteViewerOptions<Note, N> where Note: NoteInterface + Deserialize<N> {
+    pub fn new() -> NoteViewerOptions<Note, N> where Note: NoteInterface<N> {
         NoteViewerOptions {
             selects: BoundedVec::new(Option::none()),
             sorts: BoundedVec::new(Option::none()),

--- a/yarn-project/aztec-nr/aztec/src/note/utils.nr
+++ b/yarn-project/aztec-nr/aztec/src/note/utils.nr
@@ -15,7 +15,6 @@ use dep::protocol_types::{
         GENERATOR_INDEX__SILOED_COMMITMENT,
     },
     hash::pedersen_hash,
-    traits::{Deserialize, Serialize},
 };
 
 fn compute_siloed_hash(contract_address: AztecAddress, inner_note_hash: Field) -> Field {
@@ -28,7 +27,7 @@ fn compute_unique_hash(nonce: Field, siloed_note_hash: Field) -> Field {
     pedersen_hash(inputs, GENERATOR_INDEX__UNIQUE_COMMITMENT)
 }
 
-fn compute_inner_note_hash<Note, N>(note: Note) -> Field where Note: NoteInterface {
+fn compute_inner_note_hash<Note, N>(note: Note) -> Field where Note: NoteInterface<N> {
     let header = note.get_header();
     let note_hash = note.compute_note_content_hash();
 
@@ -36,7 +35,7 @@ fn compute_inner_note_hash<Note, N>(note: Note) -> Field where Note: NoteInterfa
     pedersen_hash([header.storage_slot, note_hash], 0)
 }
 
-fn compute_siloed_note_hash<Note>(note_with_header: Note) -> Field where Note: NoteInterface {
+fn compute_siloed_note_hash<Note, N>(note_with_header: Note) -> Field where Note: NoteInterface<N> {
     let header = note_with_header.get_header();
 
     let inner_note_hash = compute_inner_note_hash(note_with_header);
@@ -44,7 +43,7 @@ fn compute_siloed_note_hash<Note>(note_with_header: Note) -> Field where Note: N
     compute_siloed_hash(header.contract_address, inner_note_hash)
 }
 
-fn compute_unique_siloed_note_hash<Note, N>(note_with_header: Note) -> Field where Note: NoteInterface {
+fn compute_unique_siloed_note_hash<Note, N>(note_with_header: Note) -> Field where Note: NoteInterface<N> {
     let header = note_with_header.get_header();
 
     let siloed_note_hash = compute_siloed_note_hash(note_with_header);
@@ -52,10 +51,10 @@ fn compute_unique_siloed_note_hash<Note, N>(note_with_header: Note) -> Field whe
     compute_unique_hash(header.nonce, siloed_note_hash)
 }
 
-pub fn compute_siloed_nullifier<Note>(
+pub fn compute_siloed_nullifier<Note, N>(
     note_with_header: Note,
     context: &mut PrivateContext
-) -> Field where Note: NoteInterface {
+) -> Field where Note: NoteInterface<N> {
     let header = note_with_header.get_header();
     let inner_nullifier = note_with_header.compute_nullifier(context);
 
@@ -63,11 +62,11 @@ pub fn compute_siloed_nullifier<Note>(
     pedersen_hash(input, GENERATOR_INDEX__OUTER_NULLIFIER)
 }
 
-pub fn compute_note_hash_for_insertion<Note>(note: Note) -> Field where Note: NoteInterface {
+pub fn compute_note_hash_for_insertion<Note, N>(note: Note) -> Field where Note: NoteInterface<N> {
     compute_inner_note_hash(note)
 }
 
-pub fn compute_note_hash_for_consumption<Note>(note: Note) -> Field where Note: NoteInterface {
+pub fn compute_note_hash_for_consumption<Note, N>(note: Note) -> Field where Note: NoteInterface<N> {
     let header = note.get_header();
     // There are 3 cases for reading a note intended for consumption:
     // 1. The note was inserted in this transaction, and is transient.
@@ -90,11 +89,11 @@ pub fn compute_note_hash_for_consumption<Note>(note: Note) -> Field where Note: 
 }
 
 pub fn compute_note_hash_and_nullifier<T, N, S>(
-    deserialize: fn([Field; N]) -> T,
+    deserialize_content: fn([Field; N]) -> T,
     note_header: NoteHeader,
     serialized_note: [Field; S]
-) -> [Field; 4] where T: NoteInterface {
-    let mut note = deserialize(arr_copy_slice(serialized_note, [0; N], 0));
+) -> [Field; 4] where T: NoteInterface<N> {
+    let mut note = deserialize_content(arr_copy_slice(serialized_note, [0; N], 0));
     // TODO: change this to note.setHeader(header) once https://github.com/noir-lang/noir/issues/4095 is fixed
     T::set_header((&mut note), note_header);
 

--- a/yarn-project/aztec-nr/aztec/src/oracle/notes.nr
+++ b/yarn-project/aztec-nr/aztec/src/oracle/notes.nr
@@ -7,7 +7,6 @@ use crate::utils::arr_copy_slice;
 
 use dep::protocol_types::{
     address::AztecAddress,
-    traits::Deserialize
 };
 
 #[oracle(notifyCreatedNote)]
@@ -84,7 +83,7 @@ unconstrained pub fn get_notes<Note, N, M, S, NS>(
     mut placeholder_opt_notes: [Option<Note>; S], // TODO: Remove it and use `limit` to initialize the note array.
     placeholder_fields: [Field; NS], // TODO: Remove it and use `limit` to initialize the note array.
     _placeholder_note_length: [Field; N] // Turbofish hack? Compiler breaks calculating read_offset unless we add this parameter
-) -> [Option<Note>; S] where Note: NoteInterface + Deserialize<N> {
+) -> [Option<Note>; S] where Note: NoteInterface<N> {
     let fields = get_notes_oracle_wrapper(
         storage_slot,
         num_selects,
@@ -110,7 +109,7 @@ unconstrained pub fn get_notes<Note, N, M, S, NS>(
             let is_transient = fields[read_offset + 1] as bool;
             let header = NoteHeader { contract_address, nonce, storage_slot, is_transient };
             let serialized_note = arr_copy_slice(fields, [0; N], read_offset + 2);
-            let mut note = Note::deserialize(serialized_note);
+            let mut note = Note::deserialize_content(serialized_note);
             // TODO: change this to note.setHeader(header) once https://github.com/noir-lang/noir/issues/4095 is fixed
             Note::set_header(&mut note, header);
             placeholder_opt_notes[i] = Option::some(note);

--- a/yarn-project/aztec-nr/aztec/src/state_vars/immutable_singleton.nr
+++ b/yarn-project/aztec-nr/aztec/src/state_vars/immutable_singleton.nr
@@ -1,8 +1,7 @@
 use dep::std::option::Option;
 use dep::protocol_types::{
     address::AztecAddress,
-    traits::{Serialize, Deserialize},
-        constants::{
+    constants::{
         GENERATOR_INDEX__INITIALIZATION_NULLIFIER,
     },
     hash::pedersen_hash,
@@ -63,7 +62,7 @@ impl<Note> ImmutableSingleton<Note> {
         self,
         note: &mut Note, 
         broadcast: bool,
-    ) where Note: NoteInterface + Serialize<N> + Deserialize<N> {
+    ) where Note: NoteInterface<N> {
         let context = self.context.unwrap();
 
         // Nullify the storage slot.
@@ -80,7 +79,7 @@ impl<Note> ImmutableSingleton<Note> {
     // docs:end:initialize
 
     // docs:start:get_note
-    pub fn get_note<N>(self) -> Note where Note: NoteInterface + Deserialize<N> {
+    pub fn get_note<N>(self) -> Note where Note: NoteInterface<N> {
         let context = self.context.unwrap();
         let storage_slot = self.storage_slot;
         get_note(context, storage_slot)
@@ -88,7 +87,7 @@ impl<Note> ImmutableSingleton<Note> {
     // docs:end:get_note
 
     // docs:start:view_note
-    unconstrained pub fn view_note<N>(self) -> Note  where Note: NoteInterface + Deserialize<N> {
+    unconstrained pub fn view_note<N>(self) -> Note  where Note: NoteInterface<N> {
         let options = NoteViewerOptions::new().set_limit(1);
         view_notes(self.storage_slot, options)[0].unwrap()
     }

--- a/yarn-project/aztec-nr/aztec/src/state_vars/set.nr
+++ b/yarn-project/aztec-nr/aztec/src/state_vars/set.nr
@@ -3,7 +3,6 @@ use crate::abi::PublicContextInputs;
 use dep::protocol_types::{
     constants::{MAX_NOTES_PER_PAGE, MAX_READ_REQUESTS_PER_CALL},
     abis::side_effect::{SideEffect, SideEffectLinkedToNoteHash},
-    traits::{Deserialize, Serialize},
 };
 use crate::context::{PrivateContext, PublicContext, Context};
 use crate::note::{
@@ -43,7 +42,7 @@ impl<Note> Set<Note> {
     pub fn insert<N>(self,
         note: &mut Note,
         broadcast: bool,
-    ) where Note: NoteInterface + Deserialize<N> + Serialize<N> {
+    ) where Note: NoteInterface<N> {
         create_note(
             self.context.private.unwrap(),
             self.storage_slot,
@@ -54,7 +53,7 @@ impl<Note> Set<Note> {
     // docs:end:insert
 
     // docs:start:insert_from_public
-    pub fn insert_from_public(self, note: &mut Note) where Note: NoteInterface {
+    pub fn insert_from_public<N>(self, note: &mut Note) where Note: NoteInterface<N> {
         create_note_hash_from_public(
             self.context.public.unwrap(),
             self.storage_slot,
@@ -74,7 +73,7 @@ impl<Note> Set<Note> {
     }
 
     // docs:start:remove
-    pub fn remove(self, note: Note) where Note: NoteInterface {
+    pub fn remove<N>(self, note: Note) where Note: NoteInterface<N> {
         let context = self.context.private.unwrap();
         let note_hash = compute_note_hash_for_consumption(note);
         let has_been_read = context.read_requests.any(|r: SideEffect| r.value == note_hash);
@@ -91,7 +90,7 @@ impl<Note> Set<Note> {
     pub fn get_notes<N, FILTER_ARGS>(
         self,
         options: NoteGetterOptions<Note, N, FILTER_ARGS>,
-    ) -> [Option<Note>; MAX_READ_REQUESTS_PER_CALL] where Note: NoteInterface + Serialize<N> + Deserialize<N> {
+    ) -> [Option<Note>; MAX_READ_REQUESTS_PER_CALL] where Note: NoteInterface<N> {
         let storage_slot = self.storage_slot;
         let opt_notes = get_notes(
             self.context.private.unwrap(),
@@ -106,7 +105,7 @@ impl<Note> Set<Note> {
     unconstrained pub fn view_notes<N>(
         self,
         options: NoteViewerOptions<Note, N>,
-    ) -> [Option<Note>; MAX_NOTES_PER_PAGE] where Note: NoteInterface + Deserialize<N> {
+    ) -> [Option<Note>; MAX_NOTES_PER_PAGE] where Note: NoteInterface<N> {
         view_notes(self.storage_slot, options)
     }
     // docs:end:view_notes

--- a/yarn-project/aztec-nr/aztec/src/state_vars/singleton.nr
+++ b/yarn-project/aztec-nr/aztec/src/state_vars/singleton.nr
@@ -6,7 +6,6 @@ use dep::protocol_types::{
         GENERATOR_INDEX__INITIALIZATION_NULLIFIER,
     },
     hash::pedersen_hash,
-    traits::{Serialize, Deserialize},
 };
 
 use crate::context::{PrivateContext, PublicContext, Context};
@@ -69,7 +68,7 @@ impl<Note> Singleton<Note> {
         self,
         note: &mut Note,
         broadcast: bool,
-    ) where Note: NoteInterface + Serialize<N> + Deserialize<N> {
+    ) where Note: NoteInterface<N> {
         let context = self.context.unwrap();
 
         // Nullify the storage slot.
@@ -85,7 +84,7 @@ impl<Note> Singleton<Note> {
         self,
         new_note: &mut Note,
         broadcast: bool,
-    ) where Note: NoteInterface + Serialize<N> + Deserialize<N> {
+    ) where Note: NoteInterface<N> {
         let context = self.context.unwrap();
         let prev_note = get_note(context, self.storage_slot);
 
@@ -98,7 +97,7 @@ impl<Note> Singleton<Note> {
     // docs:end:replace
 
     // docs:start:get_note
-    pub fn get_note<N>(self, broadcast: bool) -> Note where Note: NoteInterface + Serialize<N> + Deserialize<N> {
+    pub fn get_note<N>(self, broadcast: bool) -> Note where Note: NoteInterface<N> {
         let context = self.context.unwrap();
         let mut note = get_note(context, self.storage_slot);
 
@@ -114,7 +113,7 @@ impl<Note> Singleton<Note> {
     // docs:end:get_note
 
     // docs:start:view_note
-    unconstrained pub fn view_note<N>(self) -> Note where Note: NoteInterface + Deserialize<N> {
+    unconstrained pub fn view_note<N>(self) -> Note where Note: NoteInterface<N> {
         let options = NoteViewerOptions::new().set_limit(1);
         view_notes(self.storage_slot, options)[0].unwrap()
     }

--- a/yarn-project/aztec-nr/field-note/src/field_note.nr
+++ b/yarn-project/aztec-nr/field-note/src/field_note.nr
@@ -5,7 +5,6 @@ use dep::aztec::{
     },
     hash::pedersen_hash,
     context::PrivateContext,
-    protocol_types::traits::{Serialize, Deserialize},
 };
 
 global FIELD_NOTE_LEN: Field = 1;
@@ -18,25 +17,21 @@ struct FieldNote {
     header: NoteHeader,
 }
 
-impl Serialize<FIELD_NOTE_LEN> for FieldNote {
-    fn serialize(self) -> [Field; FIELD_NOTE_LEN]{
+impl NoteInterface<FIELD_NOTE_LEN> for FieldNote {
+    fn serialize_content(self) -> [Field; FIELD_NOTE_LEN]{
         [self.value]
     }
-}
 
-impl Deserialize<FIELD_NOTE_LEN> for FieldNote {
-    fn deserialize(serialized_note: [Field; FIELD_NOTE_LEN]) -> Self {
+    fn deserialize_content(serialized_note: [Field; FIELD_NOTE_LEN]) -> Self {
         FieldNote {
             value: serialized_note[0],
             header: NoteHeader::empty(),
         }
     }
-}
 
-impl NoteInterface for FieldNote {
     fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash(self.serialize(), 0)
+        pedersen_hash(self.serialize_content(), 0)
     }
 
     fn compute_nullifier(self, _context: &mut PrivateContext) -> Field {

--- a/yarn-project/aztec-nr/value-note/src/value_note.nr
+++ b/yarn-project/aztec-nr/value-note/src/value_note.nr
@@ -29,14 +29,12 @@ struct ValueNote {
 }
 // docs:end:value-note-def
 
-impl Serialize<VALUE_NOTE_LEN> for ValueNote {
-    fn serialize(self) -> [Field; VALUE_NOTE_LEN] {
+impl NoteInterface<VALUE_NOTE_LEN> for ValueNote {
+    fn serialize_content(self) -> [Field; VALUE_NOTE_LEN] {
         [self.value, self.owner.to_field(), self.randomness]
     }
-}
 
-impl Deserialize<VALUE_NOTE_LEN> for ValueNote {
-    fn deserialize(serialized_note: [Field; VALUE_NOTE_LEN]) -> Self {
+    fn deserialize_content(serialized_note: [Field; VALUE_NOTE_LEN]) -> Self {
         ValueNote {
             value: serialized_note[0],
             owner: AztecAddress::from_field(serialized_note[1]),
@@ -44,13 +42,10 @@ impl Deserialize<VALUE_NOTE_LEN> for ValueNote {
             header: NoteHeader::empty(),
         }
     }
-}
-
-impl NoteInterface for ValueNote {
 
     fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash(self.serialize(),0)
+        pedersen_hash(self.serialize_content(),0)
     }
 
     // docs:start:nullifier
@@ -95,7 +90,7 @@ impl NoteInterface for ValueNote {
             (*context).this_address(),
             slot,
             encryption_pub_key,
-            self.serialize(),
+            self.serialize_content(),
         );
     }
 }

--- a/yarn-project/noir-contracts/contracts/benchmarking_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/benchmarking_contract/src/main.nr
@@ -75,6 +75,6 @@ contract Benchmarking {
         serialized_note: [Field; VALUE_NOTE_LEN]
     ) -> pub [Field; 4] {
         let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
-        note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize, note_header, serialized_note)
+        note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize_content, note_header, serialized_note)
     }
 }

--- a/yarn-project/noir-contracts/contracts/card_game_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/card_game_contract/src/main.nr
@@ -198,6 +198,6 @@ contract CardGame {
         serialized_note: [Field; VALUE_NOTE_LEN]
     ) -> pub [Field; 4] {
         let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
-        note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize, note_header, serialized_note)
+        note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize_content, note_header, serialized_note)
     }
 }

--- a/yarn-project/noir-contracts/contracts/counter_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/counter_contract/src/main.nr
@@ -58,7 +58,7 @@ contract Counter {
         serialized_note: [Field; VALUE_NOTE_LEN]
     ) -> pub [Field; 4] {
         let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
-        note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize, note_header, serialized_note)
+        note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize_content, note_header, serialized_note)
     }
     // docs:end:nullifier
 }

--- a/yarn-project/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -240,7 +240,7 @@ contract DocsExample {
         serialized_note: [Field; CARD_NOTE_LEN]
     ) -> pub [Field; 4] {
         let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
-        note_utils::compute_note_hash_and_nullifier(CardNote::deserialize, note_header, serialized_note)
+        note_utils::compute_note_hash_and_nullifier(CardNote::deserialize_content, note_header, serialized_note)
     }
 
     /// Macro equivalence section

--- a/yarn-project/noir-contracts/contracts/docs_example_contract/src/types/card_note.nr
+++ b/yarn-project/noir-contracts/contracts/docs_example_contract/src/types/card_note.nr
@@ -13,7 +13,7 @@ use dep::aztec::{
     context::PrivateContext,
     protocol_types::{
         address::AztecAddress,
-        traits::{Serialize, Deserialize, Empty}
+        traits::Empty
     }
 };
 
@@ -41,14 +41,12 @@ impl CardNote {
     }
 }
 
-impl Serialize<CARD_NOTE_LEN> for CardNote {
-    fn serialize(self) -> [Field; CARD_NOTE_LEN] {
+impl NoteInterface<CARD_NOTE_LEN> for CardNote {
+    fn serialize_content(self) -> [Field; CARD_NOTE_LEN] {
         [self.points as Field, self.randomness, self.owner.to_field()]
     }
-}
 
-impl Deserialize<CARD_NOTE_LEN> for CardNote {
-    fn deserialize(serialized_note: [Field; CARD_NOTE_LEN]) -> Self {
+    fn deserialize_content(serialized_note: [Field; CARD_NOTE_LEN]) -> Self {
         CardNote {
             points: serialized_note[0] as u8,
             randomness: serialized_note[1],
@@ -56,11 +54,9 @@ impl Deserialize<CARD_NOTE_LEN> for CardNote {
             header: NoteHeader::empty(),
         }
     }
-}
 
-impl NoteInterface for CardNote {
     fn compute_note_content_hash(self) -> Field {
-        pedersen_hash(self.serialize(), 0)
+        pedersen_hash(self.serialize_content(), 0)
     }
 
     fn compute_nullifier(self, context: &mut PrivateContext) -> Field {
@@ -99,7 +95,7 @@ impl NoteInterface for CardNote {
             (*context).this_address(),
             slot,
             encryption_pub_key,
-            self.serialize(),
+            self.serialize_content(),
         );
     }
 }

--- a/yarn-project/noir-contracts/contracts/easy_private_token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/easy_private_token_contract/src/main.nr
@@ -68,7 +68,7 @@ contract EasyPrivateToken {
         serialized_note: [Field; VALUE_NOTE_LEN]
     ) -> pub [Field; 4] {
         let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
-        note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize, note_header, serialized_note)
+        note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize_content, note_header, serialized_note)
     }
 }
 // docs:end:easy_private_token_contract

--- a/yarn-project/noir-contracts/contracts/ecdsa_account_contract/src/ecdsa_public_key_note.nr
+++ b/yarn-project/noir-contracts/contracts/ecdsa_account_contract/src/ecdsa_public_key_note.nr
@@ -12,7 +12,6 @@ use dep::aztec::{
     log::emit_encrypted_log,
     hash::pedersen_hash,
     context::PrivateContext,
-    protocol_types::traits::{Serialize, Deserialize},
 };
 
 global ECDSA_PUBLIC_KEY_NOTE_LEN: Field = 5;
@@ -26,14 +25,14 @@ struct EcdsaPublicKeyNote {
     header: NoteHeader,
 }
 
-impl Serialize<ECDSA_PUBLIC_KEY_NOTE_LEN> for EcdsaPublicKeyNote {
-   // serialize the note as 5 fields where:
+impl NoteInterface<ECDSA_PUBLIC_KEY_NOTE_LEN> for EcdsaPublicKeyNote {
+    // serialize the note as 5 fields where:
     // [0] = x[0..31] (upper bound excluded)
     // [1] = x[31]
     // [2] = y[0..31]
     // [3] = y[31]
     // [4] = owner
-    fn serialize(self) -> [Field; ECDSA_PUBLIC_KEY_NOTE_LEN] {
+    fn serialize_content(self) -> [Field; ECDSA_PUBLIC_KEY_NOTE_LEN] {
         let mut x: Field = 0;
         let mut y: Field = 0;
         let mut mul: Field = 1;
@@ -51,10 +50,8 @@ impl Serialize<ECDSA_PUBLIC_KEY_NOTE_LEN> for EcdsaPublicKeyNote {
         
         [x, last_x, y, last_y, self.owner.to_field()]
     }
-}
 
-impl Deserialize<ECDSA_PUBLIC_KEY_NOTE_LEN> for EcdsaPublicKeyNote {
-    fn deserialize(serialized_note: [Field; ECDSA_PUBLIC_KEY_NOTE_LEN]) -> EcdsaPublicKeyNote {
+    fn deserialize_content(serialized_note: [Field; ECDSA_PUBLIC_KEY_NOTE_LEN]) -> EcdsaPublicKeyNote {
         let mut x: [u8; 32] = [0; 32];
         let mut y: [u8; 32] = [0; 32];
 
@@ -72,12 +69,10 @@ impl Deserialize<ECDSA_PUBLIC_KEY_NOTE_LEN> for EcdsaPublicKeyNote {
 
         EcdsaPublicKeyNote { x, y, owner: AztecAddress::from_field(serialized_note[4]), header: NoteHeader::empty() }
     }
-}
 
-impl NoteInterface for EcdsaPublicKeyNote {
     fn compute_note_content_hash(note: EcdsaPublicKeyNote) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash(note.serialize(), 0)
+        pedersen_hash(note.serialize_content(), 0)
     }
 
    fn compute_nullifier(self, context: &mut PrivateContext) -> Field {
@@ -118,7 +113,7 @@ impl NoteInterface for EcdsaPublicKeyNote {
             (*context).this_address(),
             slot,
             encryption_pub_key,
-            self.serialize(),
+            self.serialize_content(),
         );
     }
 }

--- a/yarn-project/noir-contracts/contracts/ecdsa_account_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/ecdsa_account_contract/src/main.nr
@@ -98,6 +98,10 @@ contract EcdsaAccount {
     ) -> pub [Field; 4] {
         assert(storage_slot == storage.public_key.get_storage_slot());
         let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
-        note_utils::compute_note_hash_and_nullifier(EcdsaPublicKeyNote::deserialize, note_header, serialized_note)
+        note_utils::compute_note_hash_and_nullifier(
+            EcdsaPublicKeyNote::deserialize_content,
+            note_header,
+            serialized_note
+        )
     }
 }

--- a/yarn-project/noir-contracts/contracts/escrow_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/escrow_contract/src/main.nr
@@ -68,6 +68,6 @@ contract Escrow {
     ) -> pub [Field; 4] {
         let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
         assert(storage_slot == storage.owners.get_storage_slot());
-        note_utils::compute_note_hash_and_nullifier(AddressNote::deserialize, note_header, serialized_note)
+        note_utils::compute_note_hash_and_nullifier(AddressNote::deserialize_content, note_header, serialized_note)
     }
 }

--- a/yarn-project/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
@@ -239,6 +239,6 @@ contract InclusionProofs {
         serialized_note: [Field; VALUE_NOTE_LEN]
     ) -> pub [Field; 4] {
         let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
-        note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize, note_header, serialized_note)
+        note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize_content, note_header, serialized_note)
     }
 }

--- a/yarn-project/noir-contracts/contracts/pending_commitments_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/pending_commitments_contract/src/main.nr
@@ -282,6 +282,6 @@ contract PendingCommitments {
         serialized_note: [Field; VALUE_NOTE_LEN]
     ) -> pub [Field; 4] {
         let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
-        note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize, note_header, serialized_note)
+        note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize_content, note_header, serialized_note)
     }
 }

--- a/yarn-project/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -103,6 +103,10 @@ contract SchnorrAccount {
     ) -> pub [Field; 4] {
         assert(storage_slot == storage.signing_public_key.get_storage_slot());
         let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
-        note_utils::compute_note_hash_and_nullifier(PublicKeyNote::deserialize, note_header, serialized_note)
+        note_utils::compute_note_hash_and_nullifier(
+            PublicKeyNote::deserialize_content,
+            note_header,
+            serialized_note
+        )
     }
 }

--- a/yarn-project/noir-contracts/contracts/schnorr_account_contract/src/public_key_note.nr
+++ b/yarn-project/noir-contracts/contracts/schnorr_account_contract/src/public_key_note.nr
@@ -13,7 +13,6 @@ use dep::aztec::{
     context::PrivateContext,
     protocol_types::{
         address::AztecAddress,
-        traits::{Serialize, Deserialize},
     }
 };
 
@@ -28,14 +27,12 @@ struct PublicKeyNote {
     header: NoteHeader,
 }
 
-impl Serialize<PUBLIC_KEY_NOTE_LEN> for PublicKeyNote {
-    fn serialize(self) -> [Field; PUBLIC_KEY_NOTE_LEN] {
+impl NoteInterface<PUBLIC_KEY_NOTE_LEN> for PublicKeyNote {
+    fn serialize_content(self) -> [Field; PUBLIC_KEY_NOTE_LEN] {
         [self.x, self.y, self.owner.to_field()]
     }
-}
 
-impl Deserialize<PUBLIC_KEY_NOTE_LEN> for PublicKeyNote {
-    fn deserialize(serialized_note: [Field; PUBLIC_KEY_NOTE_LEN]) -> PublicKeyNote {
+    fn deserialize_content(serialized_note: [Field; PUBLIC_KEY_NOTE_LEN]) -> PublicKeyNote {
         PublicKeyNote {
             x: serialized_note[0],
             y: serialized_note[1],
@@ -43,9 +40,6 @@ impl Deserialize<PUBLIC_KEY_NOTE_LEN> for PublicKeyNote {
             header: NoteHeader::empty()
         }
     }
-}
-
-impl NoteInterface for PublicKeyNote {
 
     fn compute_nullifier(self, context: &mut PrivateContext) -> Field {
         let unique_siloed_note_hash = compute_note_hash_for_consumption(self);
@@ -71,7 +65,7 @@ impl NoteInterface for PublicKeyNote {
 
     fn compute_note_content_hash(note: PublicKeyNote) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash(note.serialize(), 0)
+        pedersen_hash(note.serialize_content(), 0)
     }
 
     fn set_header(&mut self, header: NoteHeader) {
@@ -90,7 +84,7 @@ impl NoteInterface for PublicKeyNote {
             (*context).this_address(),
             slot,
             encryption_pub_key,
-            self.serialize(),
+            self.serialize_content(),
         );
     }
 }

--- a/yarn-project/noir-contracts/contracts/stateful_test_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/stateful_test_contract/src/main.nr
@@ -63,6 +63,6 @@ contract StatefulTest {
         serialized_note: [Field; VALUE_NOTE_LEN]
     ) -> pub [Field; 4] {
         let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
-        note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize, note_header, serialized_note)
+        note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize_content, note_header, serialized_note)
     }
 }

--- a/yarn-project/noir-contracts/contracts/test_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/test_contract/src/main.nr
@@ -332,11 +332,11 @@ contract Test {
     ) -> pub [Field; 4] {
         if (storage_slot == storage.example_constant.get_storage_slot()) {
             let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
-            note_utils::compute_note_hash_and_nullifier(FieldNote::deserialize, note_header, serialized_note)
+            note_utils::compute_note_hash_and_nullifier(FieldNote::deserialize_content, note_header, serialized_note)
         } else {
             // For ValueNotes created via write_value_to_storage
             let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
-            note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize, note_header, serialized_note)
+            note_utils::compute_note_hash_and_nullifier(ValueNote::deserialize_content, note_header, serialized_note)
         }
     }
 }

--- a/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/main.nr
@@ -348,11 +348,11 @@ contract TokenBlacklist {
     ) -> pub [Field; 4] {
         let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
         if (storage_slot == storage.pending_shields.get_storage_slot()) {
-            note_utils::compute_note_hash_and_nullifier(TransparentNote::deserialize, note_header, preimage)
+            note_utils::compute_note_hash_and_nullifier(TransparentNote::deserialize_content, note_header, preimage)
         } else if (storage_slot == storage.slow_update.get_storage_slot()) {
-            note_utils::compute_note_hash_and_nullifier(FieldNote::deserialize, note_header, preimage)
+            note_utils::compute_note_hash_and_nullifier(FieldNote::deserialize_content, note_header, preimage)
         } else {
-            note_utils::compute_note_hash_and_nullifier(TokenNote::deserialize, note_header, preimage)
+            note_utils::compute_note_hash_and_nullifier(TokenNote::deserialize_content, note_header, preimage)
         }
     }
 }

--- a/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/balances_map.nr
+++ b/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/balances_map.nr
@@ -6,7 +6,6 @@ use dep::aztec::{
     protocol_types::{
         address::AztecAddress,
         constants::MAX_READ_REQUESTS_PER_CALL,
-        traits::{Serialize, Deserialize}
     },
     state_vars::{
         set::Set,
@@ -23,7 +22,6 @@ use dep::aztec::{
 use crate::types::token_note::{TokenNote, OwnedNote};
 
 struct BalancesMap<T> {
-    context: Context,
     map: Map<AztecAddress, Set<T>>
 }
 
@@ -34,16 +32,15 @@ impl<T> BalancesMap<T> {
     ) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         Self {
-            context,
             map: Map::new(context, storage_slot, |context, slot| Set::new(context, slot))
         }
     }
 
-    unconstrained pub fn balance_of<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress) -> SafeU120 where T: Deserialize<T_SERIALIZED_LEN> + Serialize<T_SERIALIZED_LEN> + NoteInterface + OwnedNote {
+    unconstrained pub fn balance_of<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress) -> SafeU120 where T: NoteInterface<T_SERIALIZED_LEN> + OwnedNote {
         self.balance_of_with_offset(owner, 0)
     }
 
-  unconstrained pub fn balance_of_with_offset<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, offset: u32) -> SafeU120 where T: Deserialize<T_SERIALIZED_LEN> + Serialize<T_SERIALIZED_LEN> + NoteInterface + OwnedNote {
+  unconstrained pub fn balance_of_with_offset<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, offset: u32) -> SafeU120 where T: NoteInterface<T_SERIALIZED_LEN> + OwnedNote {
       // Same as SafeU120::new(0), but fewer constraints because no check. 
       let mut balance = SafeU120::min();
       // docs:start:view_notes
@@ -63,7 +60,7 @@ impl<T> BalancesMap<T> {
       balance
   }
 
-    pub fn add<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, addend: SafeU120) where T: Deserialize<T_SERIALIZED_LEN> + Serialize<T_SERIALIZED_LEN> + NoteInterface + OwnedNote {
+    pub fn add<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, addend: SafeU120) where T: NoteInterface<T_SERIALIZED_LEN> + OwnedNote {
         let mut addend_note = T::new(addend, owner);
 
         // docs:start:insert
@@ -71,7 +68,7 @@ impl<T> BalancesMap<T> {
         // docs:end:insert
     }
 
-    pub fn sub<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, subtrahend: SafeU120) where T: Deserialize<T_SERIALIZED_LEN> + Serialize<T_SERIALIZED_LEN> + NoteInterface + OwnedNote{
+    pub fn sub<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, subtrahend: SafeU120) where T: NoteInterface<T_SERIALIZED_LEN> + OwnedNote{
         // docs:start:get_notes
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, subtrahend);
         let maybe_notes = self.map.at(owner).get_notes(options);
@@ -107,7 +104,7 @@ impl<T> BalancesMap<T> {
 pub fn filter_notes_min_sum<T, T_SERIALIZED_LEN>(
     notes: [Option<T>; MAX_READ_REQUESTS_PER_CALL],
     min_sum: SafeU120
-) -> [Option<T>; MAX_READ_REQUESTS_PER_CALL] where T: Deserialize<T_SERIALIZED_LEN> + Serialize<T_SERIALIZED_LEN> + NoteInterface + OwnedNote {
+) -> [Option<T>; MAX_READ_REQUESTS_PER_CALL] where T: NoteInterface<T_SERIALIZED_LEN> + OwnedNote {
     let mut selected = [Option::none(); MAX_READ_REQUESTS_PER_CALL];
     let mut sum = SafeU120::min();
     for i in 0..notes.len() {

--- a/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/token_note.nr
+++ b/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/token_note.nr
@@ -1,10 +1,10 @@
-use dep::aztec::protocol_types::{
-    address::AztecAddress,
-    constants::{
-        MAX_READ_REQUESTS_PER_CALL
-    },
-};
 use dep::aztec::{
+    protocol_types::{
+        address::AztecAddress,
+        constants::{
+            MAX_READ_REQUESTS_PER_CALL
+        },
+    },
     note::{
         note_header::NoteHeader,
         note_interface::NoteInterface,
@@ -14,10 +14,6 @@ use dep::aztec::{
     state_vars::set::Set,
     log::emit_encrypted_log,
     hash::pedersen_hash,
-    protocol_types::traits::{
-        Serialize,
-        Deserialize
-    },
 };
 use dep::aztec::oracle::{
     rand::rand,
@@ -49,14 +45,12 @@ struct TokenNote {
     header: NoteHeader,
 }
 
-impl Serialize<TOKEN_NOTE_LEN> for TokenNote {
-    fn serialize(self) -> [Field; TOKEN_NOTE_LEN] {
+impl NoteInterface<TOKEN_NOTE_LEN> for TokenNote {
+    fn serialize_content(self) -> [Field; TOKEN_NOTE_LEN] {
         [self.amount.value as Field, self.owner.to_field(), self.randomness]
     }
-}
 
-impl Deserialize<TOKEN_NOTE_LEN> for TokenNote {
-    fn deserialize(serialized_note: [Field; TOKEN_NOTE_LEN]) -> Self {
+    fn deserialize_content(serialized_note: [Field; TOKEN_NOTE_LEN]) -> Self {
         Self {
             amount: SafeU120::new(serialized_note[0]),
             owner: AztecAddress::from_field(serialized_note[1]),
@@ -64,12 +58,10 @@ impl Deserialize<TOKEN_NOTE_LEN> for TokenNote {
             header: NoteHeader::empty(),
         }
     }
-}
-
-impl NoteInterface for TokenNote {
+    
       fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash(self.serialize(), 0)
+        pedersen_hash(self.serialize_content(), 0)
     }
 
     // docs:start:nullifier
@@ -114,7 +106,7 @@ impl NoteInterface for TokenNote {
               (*context).this_address(),
               slot,
               encryption_pub_key,
-              self.serialize(),
+              self.serialize_content(),
           );
       }
   }

--- a/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/transparent_note.nr
+++ b/yarn-project/noir-contracts/contracts/token_blacklist_contract/src/types/transparent_note.nr
@@ -7,7 +7,6 @@ use dep::aztec::{
     },
     hash::{compute_secret_hash, pedersen_hash},
     context::PrivateContext,
-    protocol_types::traits::{Serialize, Deserialize}
 };
 
 global TRANSPARENT_NOTE_LEN: Field = 2;
@@ -23,28 +22,23 @@ struct TransparentNote {
     header: NoteHeader,
 }
 
-impl Serialize<TRANSPARENT_NOTE_LEN> for TransparentNote {
-    fn serialize(self) -> [Field; TRANSPARENT_NOTE_LEN] {
+impl NoteInterface<TRANSPARENT_NOTE_LEN> for TransparentNote {
+    fn serialize_content(self) -> [Field; TRANSPARENT_NOTE_LEN] {
         [self.amount, self.secret_hash]
     }
-}
 
-impl Deserialize<TRANSPARENT_NOTE_LEN> for TransparentNote {
-    fn deserialize(preimage: [Field; TRANSPARENT_NOTE_LEN]) -> Self {
+    fn deserialize_content(serialized_note: [Field; TRANSPARENT_NOTE_LEN]) -> Self {
         TransparentNote {
-            amount: preimage[0],
-            secret_hash: preimage[1],
+            amount: serialized_note[0],
+            secret_hash: serialized_note[1],
             secret: 0,
             header: NoteHeader::empty(),
         }
     }
-}
-
-impl NoteInterface for TransparentNote {
 
     fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash(self.serialize(), 0)
+        pedersen_hash(self.serialize_content(), 0)
     }
 
     fn compute_nullifier(self, _context: &mut PrivateContext) -> Field {

--- a/yarn-project/noir-contracts/contracts/token_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/token_contract/src/main.nr
@@ -396,9 +396,13 @@ contract Token {
     ) -> pub [Field; 4] {
         let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
         if (storage_slot == storage.pending_shields.get_storage_slot()) {
-            note_utils::compute_note_hash_and_nullifier(TransparentNote::deserialize, note_header, serialized_note)
+            note_utils::compute_note_hash_and_nullifier(
+                TransparentNote::deserialize_content,
+                note_header,
+                serialized_note
+            )
         } else {
-            note_utils::compute_note_hash_and_nullifier(TokenNote::deserialize, note_header, serialized_note)
+            note_utils::compute_note_hash_and_nullifier(TokenNote::deserialize_content, note_header, serialized_note)
         }
     }
     // docs:end:compute_note_hash_and_nullifier

--- a/yarn-project/noir-contracts/contracts/token_contract/src/types/balances_map.nr
+++ b/yarn-project/noir-contracts/contracts/token_contract/src/types/balances_map.nr
@@ -6,7 +6,6 @@ use dep::aztec::{
     protocol_types::{
         address::AztecAddress,
         constants::MAX_READ_REQUESTS_PER_CALL,
-        traits::{Serialize, Deserialize}
     },
     state_vars::{
         set::Set,
@@ -37,11 +36,11 @@ impl<T> BalancesMap<T> {
         }
     }
 
-    unconstrained pub fn balance_of<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress) -> SafeU120 where T: Deserialize<T_SERIALIZED_LEN> + Serialize<T_SERIALIZED_LEN> + NoteInterface + OwnedNote {
+    unconstrained pub fn balance_of<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress) -> SafeU120 where T: NoteInterface<T_SERIALIZED_LEN> + OwnedNote {
         self.balance_of_with_offset(owner, 0)
     }
 
-  unconstrained pub fn balance_of_with_offset<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, offset: u32) -> SafeU120 where T: Deserialize<T_SERIALIZED_LEN> + Serialize<T_SERIALIZED_LEN> + NoteInterface + OwnedNote {
+  unconstrained pub fn balance_of_with_offset<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, offset: u32) -> SafeU120 where T: NoteInterface<T_SERIALIZED_LEN> + OwnedNote {
       // Same as SafeU120::new(0), but fewer constraints because no check. 
       let mut balance = SafeU120::min();
       // docs:start:view_notes
@@ -61,7 +60,7 @@ impl<T> BalancesMap<T> {
       balance
   }
 
-    pub fn add<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, addend: SafeU120) where T: Deserialize<T_SERIALIZED_LEN> + Serialize<T_SERIALIZED_LEN> + NoteInterface + OwnedNote {
+    pub fn add<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, addend: SafeU120) where T: NoteInterface<T_SERIALIZED_LEN> + OwnedNote {
         let mut addend_note = T::new(addend, owner);
 
         // docs:start:insert
@@ -69,7 +68,7 @@ impl<T> BalancesMap<T> {
         // docs:end:insert
     }
 
-    pub fn sub<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, subtrahend: SafeU120) where T: Deserialize<T_SERIALIZED_LEN> + Serialize<T_SERIALIZED_LEN> + NoteInterface + OwnedNote{
+    pub fn sub<T_SERIALIZED_LEN>(self: Self, owner: AztecAddress, subtrahend: SafeU120) where T: NoteInterface<T_SERIALIZED_LEN> + OwnedNote{
         // docs:start:get_notes
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, subtrahend);
         let maybe_notes = self.map.at(owner).get_notes(options);
@@ -105,7 +104,7 @@ impl<T> BalancesMap<T> {
 pub fn filter_notes_min_sum<T, T_SERIALIZED_LEN>(
     notes: [Option<T>; MAX_READ_REQUESTS_PER_CALL],
     min_sum: SafeU120
-) -> [Option<T>; MAX_READ_REQUESTS_PER_CALL] where T: Deserialize<T_SERIALIZED_LEN> + Serialize<T_SERIALIZED_LEN> + NoteInterface + OwnedNote {
+) -> [Option<T>; MAX_READ_REQUESTS_PER_CALL] where T: NoteInterface<T_SERIALIZED_LEN> + OwnedNote {
     let mut selected = [Option::none(); MAX_READ_REQUESTS_PER_CALL];
     let mut sum = SafeU120::min();
     for i in 0..notes.len() {

--- a/yarn-project/noir-contracts/contracts/token_contract/src/types/token_note.nr
+++ b/yarn-project/noir-contracts/contracts/token_contract/src/types/token_note.nr
@@ -1,10 +1,8 @@
-use dep::aztec::protocol_types::{
-    address::AztecAddress,
-    constants::{
-        MAX_READ_REQUESTS_PER_CALL
-    },
-};
 use dep::aztec::{
+    protocol_types::{
+        address::AztecAddress,
+        constants::MAX_READ_REQUESTS_PER_CALL
+    },
     note::{
         note_header::NoteHeader,
         note_interface::NoteInterface,
@@ -14,10 +12,6 @@ use dep::aztec::{
     state_vars::set::Set,
     log::emit_encrypted_log,
     hash::pedersen_hash,
-    protocol_types::traits::{
-        Serialize,
-        Deserialize
-    },
 };
 use dep::aztec::oracle::{
     rand::rand,
@@ -49,14 +43,12 @@ struct TokenNote {
     header: NoteHeader,
 }
 
-impl Serialize<TOKEN_NOTE_LEN> for TokenNote {
-    fn serialize(self) -> [Field; TOKEN_NOTE_LEN] {
+impl NoteInterface<TOKEN_NOTE_LEN> for TokenNote {
+    fn serialize_content(self) -> [Field; TOKEN_NOTE_LEN] {
         [self.amount.value as Field, self.owner.to_field(), self.randomness]
     }
-}
 
-impl Deserialize<TOKEN_NOTE_LEN> for TokenNote {
-    fn deserialize(serialized_note: [Field; TOKEN_NOTE_LEN]) -> Self {
+    fn deserialize_content(serialized_note: [Field; TOKEN_NOTE_LEN]) -> Self {
         Self {
             amount: SafeU120::new(serialized_note[0]),
             owner: AztecAddress::from_field(serialized_note[1]),
@@ -64,12 +56,10 @@ impl Deserialize<TOKEN_NOTE_LEN> for TokenNote {
             header: NoteHeader::empty(),
         }
     }
-}
 
-impl NoteInterface for TokenNote {
     fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash(self.serialize(), 0)
+        pedersen_hash(self.serialize_content(), 0)
     }
 
     // docs:start:nullifier
@@ -100,8 +90,8 @@ impl NoteInterface for TokenNote {
         self.header = header;
     }
 
-    fn get_header(note: TokenNote) -> NoteHeader {
-        note.header
+    fn get_header(self) -> NoteHeader {
+        self.header
     }
 
     // Broadcasts the note as an encrypted log on L1.
@@ -114,7 +104,7 @@ impl NoteInterface for TokenNote {
               (*context).this_address(),
               slot,
               encryption_pub_key,
-              self.serialize(),
+              self.serialize_content(),
           );
       }
   }

--- a/yarn-project/noir-contracts/contracts/token_contract/src/types/transparent_note.nr
+++ b/yarn-project/noir-contracts/contracts/token_contract/src/types/transparent_note.nr
@@ -7,7 +7,6 @@ use dep::aztec::{
     },
     hash::{compute_secret_hash, pedersen_hash},
     context::PrivateContext,
-    protocol_types::traits::{Serialize, Deserialize, Empty}
 };
 
 global TRANSPARENT_NOTE_LEN: Field = 2;
@@ -23,14 +22,12 @@ struct TransparentNote {
     header: NoteHeader,
 }
 
-impl Serialize<TRANSPARENT_NOTE_LEN> for TransparentNote {
-    fn serialize(self) -> [Field; TRANSPARENT_NOTE_LEN] {
+impl NoteInterface<TRANSPARENT_NOTE_LEN> for TransparentNote {
+    fn serialize_content(self) -> [Field; TRANSPARENT_NOTE_LEN] {
         [self.amount, self.secret_hash]
     }
-}
 
-impl Deserialize<TRANSPARENT_NOTE_LEN> for TransparentNote {
-    fn deserialize(serialized_note: [Field; TRANSPARENT_NOTE_LEN]) -> Self {
+    fn deserialize_content(serialized_note: [Field; TRANSPARENT_NOTE_LEN]) -> Self {
         TransparentNote {
             amount: serialized_note[0],
             secret_hash: serialized_note[1],
@@ -38,19 +35,10 @@ impl Deserialize<TRANSPARENT_NOTE_LEN> for TransparentNote {
             header: NoteHeader::empty(),
         }
     }
-}
-
-impl Empty for TransparentNote {
-    fn empty() -> Self {
-        TransparentNote::new(0, 0)
-    }
-}
-
-impl NoteInterface for TransparentNote {
 
     fn compute_note_content_hash(self) -> Field {
         // TODO(#1205) Should use a non-zero generator index.
-        pedersen_hash(self.serialize(), 0)
+        pedersen_hash(self.serialize_content(), 0)
     }
 
     fn compute_nullifier(self, _context: &mut PrivateContext) -> Field {
@@ -63,13 +51,12 @@ impl NoteInterface for TransparentNote {
         pedersen_hash([self.secret, siloed_note_hash],0)
     }
 
-
     fn set_header(&mut self, header: NoteHeader) {
         self.header = header;
     }
 
-    fn get_header(note: TransparentNote) -> NoteHeader {
-        note.header
+    fn get_header(self) -> NoteHeader {
+        self.header
     }
 
     fn broadcast(self, context: &mut PrivateContext, slot: Field) {
@@ -89,6 +76,7 @@ impl TransparentNote {
             header: NoteHeader::empty(),
         }
     }
+
     // new oracle call primitive
     // get me the secret corresponding to this hash
     pub fn new_from_secret(amount: Field, secret: Field) -> Self {


### PR DESCRIPTION
This PR introduces updates the `NoteInterface` to include serialization and deserialization specific to notes. 

The change is made to distinguish between `Serialization` of the full struct, and serialization for note content which is used when computing the `note_hash`, `nullifier` and emitting an encrypted log. 

The trait is extended as follows.
```rust
    fn serialize_content(self) -> [Field; N];
    fn deserialize_content(fields: [Field; N]) -> Self;
``` 

With the change, trying to pass a `Note` as an argument to a contract function will fail if the `serialize` function is not implemented on the `Note`. The `serialize` is expected to be the full struct, so should make it easier to figure out what is wrong for users that run into this case. 