### PR TITLE
feat: move `is_empty` method onto `Empty` trait

### DIFF
--- a/yarn-project/aztec-nr/aztec/src/note/note_header.nr
+++ b/yarn-project/aztec-nr/aztec/src/note/note_header.nr
@@ -14,6 +14,13 @@ impl Empty for NoteHeader {
     fn empty() -> Self {
         NoteHeader { contract_address: AztecAddress::zero(), nonce: 0, storage_slot: 0, is_transient: false }
     }
+
+    fn is_empty(self) -> bool {
+        (self.contract_address == AztecAddress::zero()) &
+        (self.nonce == 0) &
+        (self.storage_slot == 0) &
+        (self.is_transient == false) 
+    }
 }
 
 impl NoteHeader {

--- a/yarn-project/noir-protocol-circuits/src/crates/private-kernel-lib/src/common.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/private-kernel-lib/src/common.nr
@@ -46,7 +46,6 @@ use dep::types::{
             validate_array,
         },
     },
-    traits::{is_empty, is_empty_array},
 };
 
 pub fn validate_arrays(app_public_inputs: PrivateCircuitPublicInputs) {
@@ -135,12 +134,8 @@ fn perform_static_call_checks(private_call: PrivateCallData) {
     let is_static_call = public_inputs.call_context.is_static_call;
     if is_static_call {
         // No state changes are allowed for static calls:
-        assert(
-            is_empty_array(public_inputs.new_commitments), "new_commitments must be empty for static calls"
-        );
-        assert(
-            is_empty_array(public_inputs.new_nullifiers), "new_nullifiers must be empty for static calls"
-        );
+        assert(public_inputs.new_commitments.is_empty(), "new_commitments must be empty for static calls");
+        assert(public_inputs.new_nullifiers.is_empty(), "new_nullifiers must be empty for static calls");
     }
 }
 
@@ -203,7 +198,7 @@ pub fn update_end_values(private_call: PrivateCallData, public_inputs: &mut Kern
     // Nullifier key validation requests.
     for i in 0..MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_CALL {
         let request = nullifier_key_validation_requests[i];
-        if !is_empty(request) {
+        if !request.is_empty() {
             public_inputs.end.nullifier_key_validation_requests.push(request.to_context(storage_contract_address));
         }
     }

--- a/yarn-project/noir-protocol-circuits/src/crates/private-kernel-lib/src/private_kernel_init.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/private-kernel-lib/src/private_kernel_init.nr
@@ -10,7 +10,6 @@ use dep::types::{
     address::{AztecAddress, PublicKeysHash, compute_initialization_hash},
     mocked::{Proof, verify_previous_kernel_state},
     transaction::request::TxRequest,
-    traits::is_empty_array,
 };
 
 // Initialization struct for private inputs to the private kernel

--- a/yarn-project/noir-protocol-circuits/src/crates/private-kernel-lib/src/private_kernel_ordering.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/private-kernel-lib/src/private_kernel_ordering.nr
@@ -31,7 +31,7 @@ use dep::types::{
     utils::{
         arrays::{array_length, array_eq},
     },
-    traits::{Empty, is_empty}
+    traits::Empty
 };
 
 struct PrivateKernelInputsOrdering {
@@ -55,7 +55,7 @@ impl PrivateKernelInputsOrdering {
         let requests = self.previous_kernel.public_inputs.end.nullifier_key_validation_requests;
         for i in 0..MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_TX {
             let request = requests[i];
-            if !is_empty(request) {
+            if !request.is_empty() {
                 let master_secret_key = self.master_nullifier_secret_keys[i];
                 let computed_public_key = master_secret_key.derive_public_key();
                 assert(computed_public_key.eq(request.public_key), "Cannot derive nullifier public key from the master key.");
@@ -99,7 +99,7 @@ impl PrivateKernelInputsOrdering {
                 sorted[indexes[i]]
             };
             assert(item.eq(original[i]), "Sorted item is not equal");
-            let is_empty = is_empty(item);
+            let is_empty = item.is_empty();
 
             if prev_was_empty {
                 assert(is_empty, "Empty items must be at the end");
@@ -239,7 +239,7 @@ mod tests {
         utils::{
             arrays::{array_eq, array_length},
         },
-        traits::{Empty, is_empty, is_empty_array}
+        traits::Empty
     };
 
     struct PrivateKernelOrderingInputsBuilder {
@@ -303,9 +303,9 @@ mod tests {
             let sorted_indexes = indexes.sort_via(|a_index: u32, b_index: u32| {
                 let a = original[a_index];
                 let b = original[b_index];
-                if is_empty(b) {
+                if b.is_empty() {
                     true
-                } else if is_empty(a) {
+                } else if a.is_empty() {
                     false
                 } else {
                     a.counter() < b.counter()
@@ -399,7 +399,7 @@ mod tests {
         builder.nullify_transient_commitment(1, 0);
         let new_nullifiers = builder.get_new_nullifiers();
         let public_inputs = builder.execute();
-        assert(is_empty_array(public_inputs.end.new_commitments));
+        assert(public_inputs.end.new_commitments.is_empty());
 
         // The nullifier at index 1 is chopped.
         let expected_new_nullifiers = [new_nullifiers[0], new_nullifiers[2]];
@@ -440,7 +440,7 @@ mod tests {
         builder.nullify_transient_commitment(2, 0);
         let new_nullifiers = builder.get_new_nullifiers();
         let public_inputs = builder.execute();
-        assert(is_empty_array(public_inputs.end.new_commitments));
+        assert(public_inputs.end.new_commitments.is_empty());
         assert(array_eq(public_inputs.end.new_nullifiers, [new_nullifiers[0]]));
     }
 

--- a/yarn-project/noir-protocol-circuits/src/crates/public-kernel-lib/src/common.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/public-kernel-lib/src/common.nr
@@ -29,7 +29,6 @@ use dep::types::{
     utils::{
         arrays::{array_length, array_to_bounded_vec},
     },
-    traits::is_empty_array
 };
 use crate::hash::{compute_public_data_tree_index, compute_public_data_tree_value};
 

--- a/yarn-project/noir-protocol-circuits/src/crates/rollup-lib/src/abis/public_data_tree_leaf.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/rollup-lib/src/abis/public_data_tree_leaf.nr
@@ -17,6 +17,10 @@ impl Empty for PublicDataTreeLeafPreimage {
             next_index: 0,
         }
     }
+
+    fn is_empty(self) -> bool {
+        (self.slot == 0) & (self.value == 0) & (self.next_slot == 0) & (self.next_index == 0)
+    }
 }
 
 impl Hash for PublicDataTreeLeafPreimage {
@@ -26,12 +30,6 @@ impl Hash for PublicDataTreeLeafPreimage {
         } else {
             dep::std::hash::pedersen_hash([self.slot, self.value, (self.next_index as Field), self.next_slot])
         }
-    }
-}
-
-impl PublicDataTreeLeafPreimage {
-    pub fn is_empty(self) -> bool {
-        (self.slot == 0) & (self.value == 0) & (self.next_slot == 0) & (self.next_index == 0)
     }
 }
 
@@ -53,10 +51,8 @@ impl Empty for PublicDataTreeLeaf  {
             value: 0,
         }
     }
-}
 
-impl PublicDataTreeLeaf {
-    pub fn is_empty(self) -> bool {
-        (self.slot == 0) & (self.value == 0)
+    fn is_empty(self) -> bool {
+        self == PublicDataTreeLeaf::empty()
     }
 }

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/call_request.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/call_request.nr
@@ -21,11 +21,9 @@ impl Empty for CallerContext {
             storage_contract_address: AztecAddress::zero(),
         }
     }
-}
 
-impl CallerContext {
-    pub fn is_empty(self) -> bool {
-        self.msg_sender.is_zero() & self.storage_contract_address.is_zero()
+    fn is_empty(self) -> bool {
+        self == CallerContext::empty()
     }
 }
 
@@ -57,10 +55,8 @@ impl Empty for CallRequest {
             end_side_effect_counter: 0,
         }
     }
-}
 
-impl CallRequest {
-    pub fn is_empty(self) -> bool {
+    fn is_empty(self) -> bool {
         self.hash == 0
     }
 }

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/global_variables.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/global_variables.nr
@@ -73,6 +73,10 @@ impl Empty for GlobalVariables {
             fee_recipient: AztecAddress::empty(),
         }
     }
+
+    fn is_empty(self) -> bool {
+        self == GlobalVariables::empty()
+    }
 }
 
 #[test]

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/new_contract_data.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/new_contract_data.nr
@@ -26,6 +26,10 @@ impl Empty for NewContractData {
             contract_class_id: ContractClassId::from_field(0),
         }
     }
+
+    fn is_empty(self) -> bool {
+        self == NewContractData::empty()
+    }
 }
 
 impl Hash for NewContractData {
@@ -40,13 +44,4 @@ impl Hash for NewContractData {
             ], GENERATOR_INDEX__CONTRACT_LEAF)
         }
     }
-}
-
-impl NewContractData {
-    pub fn is_empty(self) -> bool {
-        (self.contract_address.to_field() == 0) & 
-        (self.portal_contract_address.to_field() == 0) & 
-        (self.contract_class_id.to_field() == 0)
-    }
-
 }

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/nullifier_key_validation_request.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/nullifier_key_validation_request.nr
@@ -28,6 +28,10 @@ impl Empty for NullifierKeyValidationRequest {
             secret_key: GrumpkinPrivateKey::zero(),
         }
     }
+
+    fn is_empty(self) -> bool {
+        self == NullifierKeyValidationRequest::empty()
+    }
 }
 
 impl Serialize<NULLIFIER_KEY_VALIDATION_REQUEST_SERIALIZED_LEN> for NullifierKeyValidationRequest {
@@ -81,6 +85,10 @@ impl Empty for NullifierKeyValidationRequestContext {
             secret_key: GrumpkinPrivateKey::zero(),
             contract_address: AztecAddress::zero(),
         }
+    }
+    
+    fn is_empty(self) -> bool {
+        self == NullifierKeyValidationRequestContext::empty()
     }
 }
 

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/nullifier_leaf_preimage.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/nullifier_leaf_preimage.nr
@@ -16,6 +16,10 @@ impl Empty for NullifierLeafPreimage {
             next_index : 0,
         }
     }
+
+    fn is_empty(self) -> bool {
+        (self.nullifier == 0) & (self.next_nullifier == 0) & (self.next_index == 0)
+    }
 }
 
 impl Hash for NullifierLeafPreimage {
@@ -29,10 +33,6 @@ impl Hash for NullifierLeafPreimage {
 }
 
 impl NullifierLeafPreimage {
-    pub fn is_empty(self) -> bool {
-        (self.nullifier == 0) & (self.next_nullifier == 0) & (self.next_index == 0)
-    }
-
     pub fn serialize(self) -> [Field; NULLIFIER_LEAF_PREIMAGE_LENGTH] {
         [self.nullifier, self.next_nullifier, self.next_index as Field]
     }

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/public_data_read.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/public_data_read.nr
@@ -20,6 +20,10 @@ impl Empty for PublicDataRead {
             value : 0,
         }
     }
+
+    fn is_empty(self) -> bool {
+        self == PublicDataRead::empty()
+    }
 }
 
 impl Hash for PublicDataRead {
@@ -28,11 +32,5 @@ impl Hash for PublicDataRead {
             self.leaf_slot,
             self.value,
         ], GENERATOR_INDEX__PUBLIC_DATA_READ)
-    }
-}
-
-impl PublicDataRead {
-    pub fn is_empty(self) -> bool {
-        (self.leaf_slot == 0) & (self.value == 0)
     }
 }

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/public_data_update_request.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/public_data_update_request.nr
@@ -23,6 +23,10 @@ impl Empty for PublicDataUpdateRequest {
             new_value : 0
         }
     }
+
+    fn is_empty(self) -> bool {
+        self == PublicDataUpdateRequest::empty()
+    }
 }
 
 impl Hash for PublicDataUpdateRequest {
@@ -32,11 +36,5 @@ impl Hash for PublicDataUpdateRequest {
             self.old_value,
             self.new_value
         ], GENERATOR_INDEX__PUBLIC_DATA_UPDATE_REQUEST)
-    }
-}
-
-impl PublicDataUpdateRequest {
-    pub fn is_empty(self) -> bool {
-        (self.leaf_slot == 0) & (self.old_value == 0) & (self.new_value == 0)
     }
 }

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/side_effect.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/abis/side_effect.nr
@@ -31,6 +31,10 @@ impl Empty for SideEffect {
             counter: 0,
         }
     }
+
+    fn is_empty(self) -> bool {
+        self == SideEffect::empty()
+    }
 }
 
 impl Hash for SideEffect {
@@ -82,6 +86,10 @@ impl Empty for SideEffectLinkedToNoteHash {
             note_hash: 0,
             counter: 0,
         }
+    }
+
+    fn is_empty(self) -> bool {
+        self == SideEffectLinkedToNoteHash::empty()
     }
 }
 

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/address.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/address.nr
@@ -30,6 +30,10 @@ impl Empty for AztecAddress {
             inner : 0
         }
     }
+
+    fn is_empty(self) -> bool {
+        self == AztecAddress::empty()
+    }
 }
 
 impl ToField for AztecAddress {
@@ -107,6 +111,10 @@ impl Empty for EthAddress {
         Self {
             inner : 0
         }
+    }
+
+    fn is_empty(self) -> bool {
+        self == EthAddress::empty()
     }
 }
 

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/contrakt/storage_read.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/contrakt/storage_read.nr
@@ -30,6 +30,10 @@ impl Empty for StorageRead {
             current_value: 0,
         }
     }
+
+    fn is_empty(self) -> bool {
+        self.storage_slot == 0
+    }
 }
 
 impl Hash for StorageRead {
@@ -50,11 +54,5 @@ impl Deserialize<CONTRACT_STORAGE_READ_LENGTH> for StorageRead {
             storage_slot: serialized[0],
             current_value: serialized[1],
         }
-    }
-}
-
-impl StorageRead {
-    pub fn is_empty(self) -> bool {
-        self.storage_slot == 0
     }
 }

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/contrakt/storage_update_request.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/contrakt/storage_update_request.nr
@@ -36,6 +36,10 @@ impl Empty for StorageUpdateRequest {
             new_value: 0,
         }
     }
+
+    fn is_empty(self) -> bool {
+        self.storage_slot == 0
+    }
 }
 
 impl Hash for StorageUpdateRequest {
@@ -57,11 +61,5 @@ impl Deserialize<CONTRACT_STORAGE_UPDATE_REQUEST_LENGTH> for StorageUpdateReques
             old_value: serialized[1],
             new_value: serialized[2],
         }
-    }
-}
-
-impl StorageUpdateRequest {
-    pub fn is_empty(self) -> bool {
-        self.storage_slot == 0
     }
 }

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/header.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/header.nr
@@ -92,6 +92,13 @@ impl Empty for Header {
             global_variables: GlobalVariables::empty(),
         }
     }
+
+    fn is_empty(self) -> bool {
+        (self.last_archive == AppendOnlyTreeSnapshot::zero()) &
+        (self.body_hash == [0; NUM_FIELDS_PER_SHA256]) &
+        (self.state == StateReference::empty()) &
+        (self.global_variables == GlobalVariables::empty())
+    }
 }
 
 impl Hash for Header {

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/partial_state_reference.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/partial_state_reference.nr
@@ -73,6 +73,10 @@ impl Empty for PartialStateReference {
             public_data_tree: AppendOnlyTreeSnapshot::zero(),
         }
     }
+
+    fn is_empty(self) -> bool {
+        self == PartialStateReference::empty()
+    }
 }
 
 #[test]

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/state_reference.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/state_reference.nr
@@ -65,6 +65,10 @@ impl Empty for StateReference {
             partial: PartialStateReference::empty(),
         }
     }
+
+    fn is_empty(self) -> bool {
+        self == StateReference::empty()
+    }
 }
 
 #[test]

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/traits.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/traits.nr
@@ -13,21 +13,23 @@ use dep::std::cmp::Eq;
 // Preferred over Default trait to convey intent, as default doesn't necessarily mean empty.
 trait Empty {
     fn empty() -> Self;
+
+    fn is_empty(self) -> bool;
 }
 
-impl Empty for Field { fn empty() -> Self {0} }
+impl Empty for Field { fn empty() -> Self {0} fn is_empty(self) -> bool { self == Self::empty() }}
 
-impl Empty for u1 { fn empty() -> Self {0} }
-impl Empty for u8 { fn empty() -> Self {0} }
-impl Empty for u16 { fn empty() -> Self {0} }
-impl Empty for u32 { fn empty() -> Self {0} }
-impl Empty for u64 { fn empty() -> Self {0} }
+impl Empty for u1 { fn empty() -> Self {0} fn is_empty(self) -> bool { self == Self::empty() } }
+impl Empty for u8 { fn empty() -> Self {0} fn is_empty(self) -> bool { self == Self::empty() } }
+impl Empty for u16 { fn empty() -> Self {0} fn is_empty(self) -> bool { self == Self::empty() } }
+impl Empty for u32 { fn empty() -> Self {0} fn is_empty(self) -> bool { self == Self::empty() } }
+impl Empty for u64 { fn empty() -> Self {0} fn is_empty(self) -> bool { self == Self::empty() } }
 
-pub fn is_empty<T>(item: T) -> bool where T: Empty + Eq {
-    item.eq(T::empty())
+pub fn is_empty<T>(item: T) -> bool where T: Empty {
+    item.is_empty()
 }
 
-pub fn is_empty_array<T, N>(array: [T; N]) -> bool where T: Empty + Eq {
+pub fn is_empty_array<T, N>(array: [T; N]) -> bool where T: Empty {
     array.all(|elem| is_empty(elem))
 }
 

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/traits.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/traits.nr
@@ -25,12 +25,14 @@ impl Empty for u16 { fn empty() -> Self {0} fn is_empty(self) -> bool { self == 
 impl Empty for u32 { fn empty() -> Self {0} fn is_empty(self) -> bool { self == Self::empty() } }
 impl Empty for u64 { fn empty() -> Self {0} fn is_empty(self) -> bool { self == Self::empty() } }
 
-pub fn is_empty<T>(item: T) -> bool where T: Empty {
-    item.is_empty()
-}
-
-pub fn is_empty_array<T, N>(array: [T; N]) -> bool where T: Empty {
-    array.all(|elem| is_empty(elem))
+impl<T, N> Empty for [T;N] where T: Empty {
+    fn empty() -> Self { 
+        [T::empty(); N]
+    }
+    
+    fn is_empty(self) -> bool {
+        self.all(|elem: T| elem.is_empty())
+    }
 }
 
 trait Hash {

--- a/yarn-project/noir-protocol-circuits/src/crates/types/src/utils/arrays.nr
+++ b/yarn-project/noir-protocol-circuits/src/crates/types/src/utils/arrays.nr
@@ -1,11 +1,11 @@
 use dep::std::array;
 use dep::std::cmp::Eq;
-use crate::traits::{Empty, is_empty};
+use crate::traits::Empty;
 
-pub fn array_to_bounded_vec<T, N>(array: [T; N]) -> BoundedVec<T, N> where T: Empty + Eq {
+pub fn array_to_bounded_vec<T, N>(array: [T; N]) -> BoundedVec<T, N> where T: Empty {
     let mut len = 0;
     for elem in array {
-        if !is_empty(elem) {
+        if !elem.is_empty() {
             len += 1;
         }
     }
@@ -23,7 +23,7 @@ pub fn validate_array<T, N>(array: [T; N]) where T: Empty + Eq {
     let mut last_non_zero_pos = 0;
 
     for i in 0..array_length {
-        let is_empty = is_empty(array[i]);
+        let is_empty = array[i].is_empty();
         if !is_empty {
             last_non_zero_pos = i;
         } else if is_empty & (first_zero_pos == array_length) {
@@ -35,11 +35,11 @@ pub fn validate_array<T, N>(array: [T; N]) where T: Empty + Eq {
 
 // Helper method to determine the number of non-zero/empty elements in a validated array (ie, validate_array(array) 
 // should be true).
-pub fn array_length<T, N>(array: [T; N]) -> Field where T: Empty + Eq {
+pub fn array_length<T, N>(array: [T; N]) -> Field where T: Empty {
     let mut length = 0;
     let mut end = false;
     for elem in array {
-        end |= is_empty(elem);
+        end |= elem.is_empty();
         if !end {
             length += 1;
         }


### PR DESCRIPTION
This PR moves the `is_empty` method onto the `Empty` trait.

This aims to avoid any inconsistency between calling `T.is_empty` and `is_empty(T)` as these didn't always line up. 