### PR TITLE
feat!: Unencrypted logs are not strings

### DIFF
--- a/yarn-project/acir-simulator/src/acvm/oracle/oracle.ts
+++ b/yarn-project/acir-simulator/src/acvm/oracle/oracle.ts
@@ -258,7 +258,7 @@ export class Oracle {
   }
 
   emitUnencryptedLog([contractAddress]: ACVMField[], [eventSelector]: ACVMField[], message: ACVMField[]): ACVMField {
-    const logPayload = Buffer.concat(message.map(charBuffer => Fr.fromString(charBuffer).toBuffer().subarray(-1)));
+    const logPayload = Buffer.concat(message.map(fromACVMField).map(f => f.toBuffer()));
     const log = new UnencryptedL2Log(
       AztecAddress.fromString(contractAddress),
       EventSelector.fromField(fromACVMField(eventSelector)),

--- a/yarn-project/noir-contracts/contracts/test_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/test_contract/src/main.nr
@@ -233,6 +233,11 @@ contract Test {
         emit_unencrypted_log_from_private(&mut context, context.msg_sender());
     }
 
+    #[aztec(private)]
+    fn emit_array_as_unencrypted_log(fields: [Field; 5]) {
+        emit_unencrypted_log_from_private(&mut context, fields);
+    }
+
     // docs:start:is-time-equal
     #[aztec(public)]
     fn is_time_equal(time: Field) -> Field {


### PR DESCRIPTION
The private execution oracle was assuming unencrypted log payloads were strings, where each character was encoded as a field. This means that emitting a field array did not work, since all bytes but the least significant one for each field were thrown out.

Given we are not emitting strings from anywhere across our sample contracts, this commit changes the oracle so it does not throw away the fields contents, and instead pushes everything into the log payload.
