### PR TITLE
feat: pass note as argument

### DIFF
--- a/yarn-project/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -33,6 +33,7 @@ contract DocsExample {
         card_note::{CardNote, CARD_NOTE_LEN},
         leader::Leader,
     };
+    use dep::aztec::oracle::debug_log::{debug_log_format, debug_log_array_with_prefix};
 
     struct Storage {
         // Shows how to create a custom struct in PublicState
@@ -206,6 +207,23 @@ contract DocsExample {
 
     unconstrained fn get_leader() -> pub Leader {
         storage.leader.read()
+    }
+
+    #[aztec(private)]
+    fn match_card(new_card: CardNote) {
+        let card = storage.legendary_card.get_note(false);
+        let fields = card.serialize();
+
+        debug_log_array_with_prefix("Card: ", fields);
+
+        assert(card.points == new_card.points, "Invalid points");
+        assert(card.randomness == new_card.randomness, "Invalid randomness");
+        assert(card.owner == new_card.owner, "Invalid owner");
+        assert(card.header.contract_address == new_card.header.contract_address, "Invalid contract address");
+        debug_log_format("CARD MATCHING: {0} != {1}", [card.header.nonce, new_card.header.nonce]);
+        assert(card.header.nonce == new_card.header.nonce, "Invalid nonce");
+        assert(card.header.storage_slot == new_card.header.storage_slot, "Invalid storage slot");
+        assert(card.header.is_transient == new_card.header.is_transient, "Invalid transient");
     }
 
     unconstrained fn get_legendary_card() -> pub CardNote {

--- a/yarn-project/noir-contracts/contracts/docs_example_contract/src/types/card_note.nr
+++ b/yarn-project/noir-contracts/contracts/docs_example_contract/src/types/card_note.nr
@@ -13,12 +13,13 @@ use dep::aztec::{
     context::PrivateContext,
     protocol_types::{
         address::AztecAddress,
-        traits::Empty
+        traits::{Empty, Serialize}
     }
 };
 
 // Shows how to create a custom note
 
+global FULL_CARD_NOTE_LEN: Field = 7;
 global CARD_NOTE_LEN: Field = 3;
 
 // docs:start:state_vars-CardNote
@@ -38,6 +39,22 @@ impl CardNote {
             owner,
             header: NoteHeader::empty(),
         }
+    }
+}
+
+impl Serialize<FULL_CARD_NOTE_LEN> for CardNote {
+    fn serialize(self) -> [Field; FULL_CARD_NOTE_LEN] {
+        let fields = [
+            self.points as Field, 
+            self.randomness,
+            self.owner.to_field(),
+            self.header.contract_address.to_field(),
+            self.header.nonce,
+            self.header.storage_slot,
+            self.header.is_transient as Field,
+        ];
+
+        fields
     }
 }
 


### PR DESCRIPTION
This pr is targeting to implement an example of passing a note in as an argument.

It is currently experience some issues. It can pass the note, but the header seems to invalidly populated. Part of it (the `contract_address` and `storage_slot`) are populated as expected, but the `nonce` and `is_transient` values does not make sense.

It does not fail the `args_hash` check, so it is unclear where exactly the issue is, but the values are not as expected. The initial witness and packed values both looked fine. 


**EDIT**:
Figured the issue. The `singleton::get_note` is NOT returning the note in state, but instead the note that it is inserting to replace it. This means that the nonce have not yet been set and that the note is transient when checking, making it fail. If the test is done with 