### PR TITLE
chore: surpress chained macro warning

### DIFF
--- a/noir/aztec_macros/src/lib.rs
+++ b/noir/aztec_macros/src/lib.rs
@@ -203,7 +203,7 @@ macro_rules! chained_path {
         {
             ident_path($base)
         }
-    }; 
+    };
     ( $base:expr $(, $tail:expr)* ) => {
         {
             let mut base_path = ident_path($base);

--- a/noir/aztec_macros/src/lib.rs
+++ b/noir/aztec_macros/src/lib.rs
@@ -199,6 +199,11 @@ fn lambda(parameters: Vec<(Pattern, UnresolvedType)>, body: Expression) -> Expre
 }
 
 macro_rules! chained_path {
+    ( $base:expr ) => {
+        {
+            ident_path($base)
+        }
+    }; 
     ( $base:expr $(, $tail:expr)* ) => {
         {
             let mut base_path = ident_path($base);


### PR DESCRIPTION
Fixes (annoying) compilation warning experienced when compiling aztec macros