### PR TITLE
chore: fix bb wasm build when using remote cache

### DIFF
--- a/barretenberg/bootstrap_cache.sh
+++ b/barretenberg/bootstrap_cache.sh
@@ -10,4 +10,4 @@ extract_repo bb.js \
   /usr/src/barretenberg/cpp/build-wasm-threads/bin ./cpp/build-wasm-threads
 
 echo -e "\033[1mBuilding ESM bb.ts...\033[0m"
-(cd ts && ./bootstrap.sh esm)
+(cd ts && SKIP_CPP_BUILD=1 ./scripts/build_wasm.sh && ./bootstrap.sh esm)


### PR DESCRIPTION
Build was succeeding but tests failed with:

```
ENOENT: no such file or directory, open '<dir>/aztec-packages/barretenberg/ts/dest/node/barretenberg_wasm/fetch_code/node/../../barretenberg-threads.wasm'
```

With this change everything now works as expected. Thanks @spalladino for the fix!