### PR TITLE
chore: fix clippy warnings in `avm-transpiler`

### DIFF
--- a/avm-transpiler/src/instructions.rs
+++ b/avm-transpiler/src/instructions.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::fmt::{self, Display};
 use std::fmt::{Debug, Formatter};
 
 use crate::opcodes::AvmOpcode;
@@ -28,26 +28,29 @@ pub struct AvmInstruction {
     /// Different instructions have different numbers of operands
     pub operands: Vec<AvmOperand>,
 }
-impl AvmInstruction {
-    /// String representation for printing AVM programs
-    pub fn to_string(&self) -> String {
-        let mut out_str = format!("opcode {}", self.opcode.name());
+
+impl Display for AvmInstruction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "opcode {}", self.opcode.name())?;
         if let Some(indirect) = self.indirect {
-            out_str += format!(", indirect: {}", indirect).as_str();
+            write!(f, ", indirect: {}", indirect)?;
         }
         // TODO(4271): add in_tag alongside its support in TS
         if let Some(dst_tag) = self.dst_tag {
-            out_str += format!(", dst_tag: {}", dst_tag as u8).as_str();
+            write!(f, ", dst_tag: {}", dst_tag as u8)?;
         }
         if !self.operands.is_empty() {
-            out_str += ", operands: [";
+            write!(f, ", operands: [")?;
             for operand in &self.operands {
-                out_str += format!("{}, ", operand.to_string()).as_str();
+                write!(f, "{operand}, ")?;
             }
-            out_str += "]";
-        }
-        out_str
+            write!(f, "]")?;
+        };
+        Ok(())
     }
+}
+
+impl AvmInstruction {
     /// Bytes representation for generating AVM bytecode
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
@@ -69,7 +72,7 @@ impl AvmInstruction {
 
 impl Debug for AvmInstruction {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_string())
+        write!(f, "{self}")
     }
 }
 
@@ -106,14 +109,18 @@ pub enum AvmOperand {
     // TODO(4267): Support operands of size other than 32 bits (for SET)
     U128 { value: u128 },
 }
-impl AvmOperand {
-    pub fn to_string(&self) -> String {
+
+impl Display for AvmOperand {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            AvmOperand::U32 { value } => format!(" U32:{}", value),
+            AvmOperand::U32 { value } => write!(f, " U32:{}", value),
             // TODO(4267): Support operands of size other than 32 bits (for SET)
-            AvmOperand::U128 { value } => format!(" U128:{}", value),
+            AvmOperand::U128 { value } => write!(f, " U128:{}", value),
         }
     }
+}
+
+impl AvmOperand {
     pub fn to_be_bytes(&self) -> Vec<u8> {
         match self {
             AvmOperand::U32 { value } => value.to_be_bytes().to_vec(),

--- a/avm-transpiler/src/transpile_contract.rs
+++ b/avm-transpiler/src/transpile_contract.rs
@@ -1,3 +1,4 @@
+use base64::Engine;
 use log::info;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -101,7 +102,7 @@ impl From<CompiledAcirContract> for TranspiledContract {
                     function_type: function.function_type,
                     is_internal: function.is_internal,
                     abi: function.abi,
-                    bytecode: base64::encode(avm_bytecode),
+                    bytecode: base64::prelude::BASE64_STANDARD.encode(avm_bytecode),
                     debug_symbols: function.debug_symbols,
                 }));
             } else {


### PR DESCRIPTION
This PR replaces `to_string` methods with `Display` trait impls. I've also removed the usage of a deprecated function.