### PR TITLE
feat(bb): op counting mode

### DIFF
--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -172,7 +172,7 @@
       "description": "Build with op counting",
       "inherits": "clang16",
       "binaryDir": "build-op-counting",
-      "cacheVariables": {
+      "environment": {
         "CXXFLAGS": "-DBB_USE_OP_COUNT"
       }
     },

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -167,6 +167,16 @@
       }
     },
     {
+      "name": "op-counting",
+      "displayName": "Release build with operation counts for benchmarks",
+      "description": "Build with op counting",
+      "inherits": "clang16",
+      "binaryDir": "build-op-counting",
+      "cacheVariables": {
+        "CXXFLAGS": "-DBB_USE_OP_COUNT"
+      }
+    },
+    {
       "name": "coverage",
       "displayName": "Build with coverage",
       "description": "Build default preset but with coverage enabled",
@@ -299,6 +309,11 @@
       "name": "clang16",
       "inherits": "default",
       "configurePreset": "clang16"
+    },
+    {
+      "name": "op-counting",
+      "inherits": "default",
+      "configurePreset": "op-counting"
     },
     {
       "name": "clang16-dbg",

--- a/barretenberg/cpp/src/barretenberg/benchmark/basics_bench/basics.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/basics_bench/basics.bench.cpp
@@ -20,6 +20,7 @@
  *      sequential_copy:                        3.3
  *
  */
+#include "barretenberg/common/op_count.hpp"
 #include "barretenberg/common/thread.hpp"
 #include "barretenberg/ecc/curves/bn254/bn254.hpp"
 #include <benchmark/benchmark.h>
@@ -272,6 +273,9 @@ void projective_point_accidental_doubling(State& state)
     }
 }
 
+template <bb::detail::OperationLabel Op> struct GlobalOpCount {
+    void print() { std::cout << Op.value << std::endl; }
+};
 /**
  * @brief Evaluate how much projective point doubling costs (in cache)
  *
@@ -280,7 +284,6 @@ void projective_point_accidental_doubling(State& state)
  */
 void projective_point_doubling(State& state)
 {
-    BB_INCREMENT_OP_COUNT();
     numeric::RNG& engine = numeric::get_debug_randomness();
     std::vector<Curve::Element> copy_vector(2);
     for (size_t j = 0; j < 2; j++) {

--- a/barretenberg/cpp/src/barretenberg/benchmark/basics_bench/basics.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/basics_bench/basics.bench.cpp
@@ -273,9 +273,6 @@ void projective_point_accidental_doubling(State& state)
     }
 }
 
-template <bb::detail::OperationLabel Op> struct GlobalOpCount {
-    void print() { std::cout << Op.value << std::endl; }
-};
 /**
  * @brief Evaluate how much projective point doubling costs (in cache)
  *

--- a/barretenberg/cpp/src/barretenberg/benchmark/basics_bench/basics.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/basics_bench/basics.bench.cpp
@@ -280,6 +280,7 @@ void projective_point_accidental_doubling(State& state)
  */
 void projective_point_doubling(State& state)
 {
+    BB_INCREMENT_OP_COUNT();
     numeric::RNG& engine = numeric::get_debug_randomness();
     std::vector<Curve::Element> copy_vector(2);
     for (size_t j = 0; j < 2; j++) {

--- a/barretenberg/cpp/src/barretenberg/benchmark/goblin_bench/goblin.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/goblin_bench/goblin.bench.cpp
@@ -2,6 +2,7 @@
 #include <benchmark/benchmark.h>
 
 #include "barretenberg/benchmark/ultra_bench/mock_proofs.hpp"
+#include "barretenberg/common/op_count_google_bench.hpp"
 #include "barretenberg/goblin/goblin.hpp"
 #include "barretenberg/goblin/mock_circuits.hpp"
 #include "barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp"
@@ -67,6 +68,7 @@ BENCHMARK_DEFINE_F(GoblinBench, GoblinFull)(benchmark::State& state)
     GoblinMockCircuits::perform_op_queue_interactions_for_mock_first_circuit(goblin.op_queue);
 
     for (auto _ : state) {
+        BB_REPORT_OP_COUNT_IN_BENCH(state);
         // Perform a specified number of iterations of function/kernel accumulation
         perform_goblin_accumulation_rounds(state, goblin);
 

--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk_rounds.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk_rounds.bench.cpp
@@ -1,6 +1,7 @@
 #include <benchmark/benchmark.h>
 
 #include "barretenberg/benchmark/ultra_bench/mock_proofs.hpp"
+#include "barretenberg/common/op_count_google_bench.hpp"
 #include "barretenberg/proof_system/circuit_builder/ultra_circuit_builder.hpp"
 #include "barretenberg/ultra_honk/ultra_composer.hpp"
 #include "barretenberg/ultra_honk/ultra_prover.hpp"
@@ -30,12 +31,17 @@ enum {
 BB_PROFILE static void test_round_inner(State& state, UltraProver& prover, size_t index) noexcept
 {
     auto time_if_index = [&](size_t target_index, auto&& func) -> void {
+        BB_REPORT_OP_COUNT_IN_BENCH(state);
         if (index == target_index) {
             state.ResumeTiming();
         }
+
         func();
         if (index == target_index) {
             state.PauseTiming();
+        } else {
+            // We don't actually want to write to user-defined counters
+            BB_REPORT_OP_COUNT_BENCH_CANCEL();
         }
     };
 

--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk_rounds.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk_rounds.bench.cpp
@@ -27,7 +27,7 @@ enum {
  * @param prover - The ultrahonk prover.
  * @param index - The pass to measure.
  **/
-BBERG_PROFILE static void test_round_inner(State& state, UltraProver& prover, size_t index) noexcept
+BB_PROFILE static void test_round_inner(State& state, UltraProver& prover, size_t index) noexcept
 {
     auto time_if_index = [&](size_t target_index, auto&& func) -> void {
         if (index == target_index) {
@@ -47,7 +47,7 @@ BBERG_PROFILE static void test_round_inner(State& state, UltraProver& prover, si
     time_if_index(RELATION_CHECK, [&] { prover.execute_relation_check_rounds(); });
     time_if_index(ZEROMORPH, [&] { prover.execute_zeromorph_rounds(); });
 }
-BBERG_PROFILE static void test_round(State& state, size_t index) noexcept
+BB_PROFILE static void test_round(State& state, size_t index) noexcept
 {
     bb::srs::init_crs_factory("../srs_db/ignition");
 

--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_plonk_rounds.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_plonk_rounds.bench.cpp
@@ -17,7 +17,7 @@ enum {
     SIXTH_BATCH_OPEN
 };
 
-BBERG_PROFILE static void plonk_round(
+BB_PROFILE static void plonk_round(
     State& state, plonk::UltraProver& prover, size_t target_index, size_t index, auto&& func) noexcept
 {
     if (index == target_index) {
@@ -37,7 +37,7 @@ BBERG_PROFILE static void plonk_round(
  * @param prover - The ultraplonk prover.
  * @param index - The pass to measure.
  **/
-BBERG_PROFILE static void test_round_inner(State& state, plonk::UltraProver& prover, size_t index) noexcept
+BB_PROFILE static void test_round_inner(State& state, plonk::UltraProver& prover, size_t index) noexcept
 {
     plonk_round(state, prover, PREAMBLE, index, [&] { prover.execute_preamble_round(); });
     plonk_round(state, prover, FIRST_WIRE_COMMITMENTS, index, [&] { prover.execute_first_round(); });
@@ -47,7 +47,7 @@ BBERG_PROFILE static void test_round_inner(State& state, plonk::UltraProver& pro
     plonk_round(state, prover, FIFTH_COMPUTE_QUOTIENT_EVALUTION, index, [&] { prover.execute_fifth_round(); });
     plonk_round(state, prover, SIXTH_BATCH_OPEN, index, [&] { prover.execute_sixth_round(); });
 }
-BBERG_PROFILE static void test_round(State& state, size_t index) noexcept
+BB_PROFILE static void test_round(State& state, size_t index) noexcept
 {
     bb::srs::init_crs_factory("../srs_db/ignition");
     for (auto _ : state) {

--- a/barretenberg/cpp/src/barretenberg/common/compiler_hints.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/compiler_hints.hpp
@@ -1,16 +1,26 @@
 #pragma once
 
 #ifdef _WIN32
-#define BBERG_INLINE __forceinline inline
+#define BB_INLINE __forceinline inline
 #else
-#define BBERG_INLINE __attribute__((always_inline)) inline
+#define BB_INLINE __attribute__((always_inline)) inline
 #endif
 
 // TODO(AD): Other instrumentation?
 #ifdef XRAY
-#define BBERG_PROFILE [[clang::xray_always_instrument]] [[clang::noinline]]
-#define BBERG_NO_PROFILE [[clang::xray_never_instrument]]
+#define BB_PROFILE [[clang::xray_always_instrument]] [[clang::noinline]]
+#define BB_NO_PROFILE [[clang::xray_never_instrument]]
 #else
-#define BBERG_PROFILE
-#define BBERG_NO_PROFILE
+#define BB_PROFILE
+#define BB_NO_PROFILE
+#endif
+
+// Optimization hints for clang - which outcome of an expression is expected for better
+// branch-prediction optimization
+#ifdef __clang__
+#define BB_LIKELY(x) __builtin_expect(!!(x), 1)
+#define BB_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+#define BB_LIKELY(x) x
+#define BB_UNLIKELY(x) x
 #endif

--- a/barretenberg/cpp/src/barretenberg/common/op_count.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.cpp
@@ -1,0 +1,39 @@
+
+#pragma once
+#ifndef NO_OP_COUNTS
+#include "op_count.hpp"
+#include <iostream>
+#include <sstream>
+#include <thread>
+
+namespace {
+void print_op_counts()
+{
+    __GLOBAL_OP_COUNTS.print();
+}
+} // namespace
+
+GlobalOpCountContainer::GlobalOpCountContainer()
+{
+    (void)std::atexit(print_op_counts);
+}
+
+void GlobalOpCountContainer::add_entry(const char* key, const std::size_t* count)
+{
+    std::unique_lock<std::mutex> lock(mutex);
+    std::stringstream ss;
+    ss << std::this_thread::get_id();
+    counts.push_back({ key, ss.str(), count });
+}
+
+void GlobalOpCountContainer::print() const
+{
+    for (const Entry& entry : counts) {
+        std::cout << entry.key << ": " << entry.count << "@" << entry.thread_id << std::endl;
+    }
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+GlobalOpCountContainer __GLOBAL_OP_COUNTS;
+
+#endif

--- a/barretenberg/cpp/src/barretenberg/common/op_count.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.cpp
@@ -33,6 +33,12 @@ void GlobalOpCountContainer::print() const
     }
 }
 
+void GlobalOpCountContainer::clear()
+{
+    std::unique_lock<std::mutex> lock(mutex);
+    counts.clear();
+}
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 GlobalOpCountContainer GLOBAL_OP_COUNTS;
 } // namespace bb::detail

--- a/barretenberg/cpp/src/barretenberg/common/op_count.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.cpp
@@ -8,7 +8,9 @@
 namespace {
 void print_op_counts()
 {
+    std::cout << "print_op_counts() START" << std::endl;
     bb::detail::GLOBAL_OP_COUNTS.print();
+    std::cout << "print_op_counts() END" << std::endl;
 }
 } // namespace
 
@@ -29,7 +31,7 @@ void GlobalOpCountContainer::add_entry(const char* key, const std::size_t* count
 void GlobalOpCountContainer::print() const
 {
     for (const Entry& entry : counts) {
-        std::cout << entry.key << ": " << entry.count << "@" << entry.thread_id << std::endl;
+        std::cout << entry.key << ": " << *entry.count << "@" << entry.thread_id << std::endl;
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/common/op_count.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.cpp
@@ -1,5 +1,4 @@
 
-#pragma once
 #ifndef NO_OP_COUNTS
 #include "op_count.hpp"
 #include <iostream>
@@ -9,10 +8,11 @@
 namespace {
 void print_op_counts()
 {
-    __GLOBAL_OP_COUNTS.print();
+    bb::detail::GLOBAL_OP_COUNTS.print();
 }
 } // namespace
 
+namespace bb::detail {
 GlobalOpCountContainer::GlobalOpCountContainer()
 {
     (void)std::atexit(print_op_counts);
@@ -34,6 +34,6 @@ void GlobalOpCountContainer::print() const
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-GlobalOpCountContainer __GLOBAL_OP_COUNTS;
-
+GlobalOpCountContainer GLOBAL_OP_COUNTS;
+} // namespace bb::detail
 #endif

--- a/barretenberg/cpp/src/barretenberg/common/op_count.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.cpp
@@ -1,6 +1,6 @@
 
 #include <cstddef>
-#ifndef NO_OP_COUNTS
+#ifdef BB_USE_OP_COUNT
 #include "op_count.hpp"
 #include <iostream>
 #include <sstream>

--- a/barretenberg/cpp/src/barretenberg/common/op_count.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.cpp
@@ -6,7 +6,8 @@
 #include <sstream>
 #include <thread>
 
-void GlobalOpCountContainer::add_entry(const char* key, const std::size_t* count)
+namespace bb::detail {
+void GlobalOpCountContainer::add_entry(const char* key, std::size_t* count)
 {
     std::unique_lock<std::mutex> lock(mutex);
     std::stringstream ss;
@@ -18,7 +19,9 @@ void GlobalOpCountContainer::print() const
 {
     std::cout << "print_op_counts() START" << std::endl;
     for (const Entry& entry : counts) {
-        std::cout << entry.key << "\t" << *entry.count << "\t[thread=" << entry.thread_id << "]" << std::endl;
+        if (*entry.count > 0) {
+            std::cout << entry.key << "\t" << *entry.count << "\t[thread=" << entry.thread_id << "]" << std::endl;
+        }
     }
     std::cout << "print_op_counts() END" << std::endl;
 }
@@ -27,7 +30,9 @@ std::map<std::string, std::size_t> GlobalOpCountContainer::get_aggregate_counts(
 {
     std::map<std::string, std::size_t> aggregate_counts;
     for (const Entry& entry : counts) {
-        aggregate_counts[entry.key] += *entry.count;
+        if (*entry.count > 0) {
+            aggregate_counts[entry.key] += *entry.count;
+        }
     }
     return aggregate_counts;
 }
@@ -35,7 +40,9 @@ std::map<std::string, std::size_t> GlobalOpCountContainer::get_aggregate_counts(
 void GlobalOpCountContainer::clear()
 {
     std::unique_lock<std::mutex> lock(mutex);
-    counts.clear();
+    for (Entry& entry : counts) {
+        *entry.count = 0;
+    }
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/barretenberg/cpp/src/barretenberg/common/op_count.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.cpp
@@ -1,23 +1,22 @@
 
+#include <cstddef>
 #ifndef NO_OP_COUNTS
 #include "op_count.hpp"
 #include <iostream>
 #include <sstream>
 #include <thread>
 
-namespace {
-void print_op_counts()
-{
-    std::cout << "print_op_counts() START" << std::endl;
-    bb::detail::GLOBAL_OP_COUNTS.print();
-    std::cout << "print_op_counts() END" << std::endl;
-}
-} // namespace
+// namespace {
+// void print_op_counts()
+// {
+//     bb::detail::GLOBAL_OP_COUNTS.print();
+// }
+// } // namespace
 
 namespace bb::detail {
 GlobalOpCountContainer::~GlobalOpCountContainer()
 {
-    print_op_counts();
+    // print_op_counts();
 }
 
 void GlobalOpCountContainer::add_entry(const char* key, const std::size_t* count)
@@ -30,9 +29,20 @@ void GlobalOpCountContainer::add_entry(const char* key, const std::size_t* count
 
 void GlobalOpCountContainer::print() const
 {
+    std::cout << "print_op_counts() START" << std::endl;
     for (const Entry& entry : counts) {
         std::cout << entry.key << "\t" << *entry.count << "\t[thread=" << entry.thread_id << "]" << std::endl;
     }
+    std::cout << "print_op_counts() END" << std::endl;
+}
+
+std::map<std::string, std::size_t> GlobalOpCountContainer::get_aggregate_counts() const
+{
+    std::map<std::string, std::size_t> aggregate_counts;
+    for (const Entry& entry : counts) {
+        aggregate_counts[entry.key] += *entry.count;
+    }
+    return aggregate_counts;
 }
 
 void GlobalOpCountContainer::clear()

--- a/barretenberg/cpp/src/barretenberg/common/op_count.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.cpp
@@ -15,9 +15,9 @@ void print_op_counts()
 } // namespace
 
 namespace bb::detail {
-GlobalOpCountContainer::GlobalOpCountContainer()
+GlobalOpCountContainer::~GlobalOpCountContainer()
 {
-    (void)std::atexit(print_op_counts);
+    print_op_counts();
 }
 
 void GlobalOpCountContainer::add_entry(const char* key, const std::size_t* count)
@@ -31,7 +31,7 @@ void GlobalOpCountContainer::add_entry(const char* key, const std::size_t* count
 void GlobalOpCountContainer::print() const
 {
     for (const Entry& entry : counts) {
-        std::cout << entry.key << ": " << *entry.count << "@" << entry.thread_id << std::endl;
+        std::cout << entry.key << "\t" << *entry.count << "\t[thread=" << entry.thread_id << "]" << std::endl;
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/common/op_count.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.cpp
@@ -6,19 +6,6 @@
 #include <sstream>
 #include <thread>
 
-// namespace {
-// void print_op_counts()
-// {
-//     bb::detail::GLOBAL_OP_COUNTS.print();
-// }
-// } // namespace
-
-namespace bb::detail {
-GlobalOpCountContainer::~GlobalOpCountContainer()
-{
-    // print_op_counts();
-}
-
 void GlobalOpCountContainer::add_entry(const char* key, const std::size_t* count)
 {
     std::unique_lock<std::mutex> lock(mutex);

--- a/barretenberg/cpp/src/barretenberg/common/op_count.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.hpp
@@ -1,0 +1,69 @@
+
+#pragma once
+#include <cstdlib>
+#include <string>
+
+#ifdef NO_OP_COUNTS
+// require a semicolon to appease formatters
+#define INCREMENT_OP_COUNT() (void)0
+#else
+/**
+ * Provides an abstraction that counts operations based on function names.
+ * For efficiency, we spread out counts across threads.
+ */
+
+#include "barretenberg/common/compiler_hints.hpp"
+#include <algorithm>
+#include <atomic>
+#include <mutex>
+#include <vector>
+template <std::size_t N> struct OperationLabel {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+    constexpr OperationLabel(const char (&str)[N]) { std::copy_n(str, str + N, value); }
+
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+    char value[N];
+};
+
+// Contains all statically known op counts
+struct GlobalOpCountContainer {
+  public:
+    struct Entry {
+        const char* key;
+        std::string thread_id;
+        const std::size_t* count;
+    };
+    GlobalOpCountContainer();
+    std::mutex mutex;
+    std::vector<Entry> counts;
+    void print() const;
+    void add_entry(const char* key, const std::size_t* count);
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+extern GlobalOpCountContainer __GLOBAL_OP_COUNTS;
+
+template <OperationLabel Op> struct GlobalOpCount {
+  public:
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    static std::atomic_size_t global_count;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    // static std::mutex thread_counts_mutex;
+    // // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    // static std::vector<ThreadOpCount<Op>*> thread_counts;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    static thread_local std::size_t* thread_local_count;
+
+    static void increment_op_count()
+    {
+        if (BB_UNLIKELY(thread_local_count == nullptr)) {
+            thread_local_count = new std::size_t();
+            __GLOBAL_OP_COUNTS.add_entry(Op.value, thread_local_count);
+        }
+        (*thread_local_count)++;
+    }
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define INCREMENT_OP_COUNT() GlobalOpCount<__func__>::increment_op_count()
+#endif

--- a/barretenberg/cpp/src/barretenberg/common/op_count.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.hpp
@@ -24,6 +24,8 @@
 #include <string>
 #include <vector>
 namespace bb::detail {
+// Compile-time string
+// See e.g. https://www.reddit.com/r/cpp_questions/comments/pumi9r/does_c20_not_support_string_literals_as_template/
 template <std::size_t N> struct OperationLabel {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
     constexpr OperationLabel(const char (&str)[N])
@@ -38,7 +40,6 @@ template <std::size_t N> struct OperationLabel {
 };
 
 // Contains all statically known op counts
-// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
 struct GlobalOpCountContainer {
   public:
     struct Entry {
@@ -46,8 +47,6 @@ struct GlobalOpCountContainer {
         std::string thread_id;
         const std::size_t* count;
     };
-    // print on destructor
-    ~GlobalOpCountContainer();
     std::mutex mutex;
     std::vector<Entry> counts;
     void print() const;

--- a/barretenberg/cpp/src/barretenberg/common/op_count.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.hpp
@@ -5,7 +5,9 @@
 
 #ifdef NO_OP_COUNTS
 // require a semicolon to appease formatters
-#define INCREMENT_OP_COUNT() (void)0
+#define BB_INCREMENT_OP_COUNT() (void)0
+#define BB_PRINT_OP_COUNTS() (void)0
+#define BB_CLEAR_OP_COUNTS() (void)0
 #else
 /**
  * Provides an abstraction that counts operations based on function names.
@@ -43,6 +45,7 @@ struct GlobalOpCountContainer {
     std::mutex mutex;
     std::vector<Entry> counts;
     void print() const;
+    void clear();
     void add_entry(const char* key, const std::size_t* count);
 };
 
@@ -73,5 +76,7 @@ template <OperationLabel Op> thread_local std::size_t* GlobalOpCount<Op>::thread
 } // namespace bb::detail
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define INCREMENT_OP_COUNT() bb::detail::GlobalOpCount<__func__>::increment_op_count()
+#define BB_INCREMENT_OP_COUNT() bb::detail::GlobalOpCount<__func__>::increment_op_count()
+#define BB_PRINT_OP_COUNTS() bb::detail::GLOBAL_OP_COUNTS.print()
+#define BB_CLEAR_OP_COUNTS() bb::detail::GLOBAL_OP_COUNTS.clear()
 #endif

--- a/barretenberg/cpp/src/barretenberg/common/op_count.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.hpp
@@ -1,12 +1,12 @@
 
 #pragma once
 
-#ifdef NO_OP_COUNTS
+#ifndef BB_USE_OP_COUNT
 // require a semicolon to appease formatters
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define BB_OP_COUNT_TRACK() (void)0
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define BB_OP_COUNT_TRACK_NAME() (void)0
+#define BB_OP_COUNT_TRACK_NAME(name) (void)0
 #else
 /**
  * Provides an abstraction that counts operations based on function names.

--- a/barretenberg/cpp/src/barretenberg/common/op_count.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.hpp
@@ -79,6 +79,10 @@ template <OperationLabel Op> thread_local std::size_t* GlobalOpCount<Op>::thread
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define BB_INCREMENT_OP_COUNT() bb::detail::GlobalOpCount<__func__>::increment_op_count()
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define BB_INCREMENT_OP_COUNT() bb::detail::GlobalOpCount<__func__>::increment_op_count()
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define BB_PRINT_OP_COUNTS() bb::detail::GLOBAL_OP_COUNTS.print()
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define BB_CLEAR_OP_COUNTS() bb::detail::GLOBAL_OP_COUNTS.clear()
 #endif

--- a/barretenberg/cpp/src/barretenberg/common/op_count.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.hpp
@@ -1,12 +1,13 @@
 
 #pragma once
-#include <cstdlib>
-#include <string>
 
 #ifdef NO_OP_COUNTS
 // require a semicolon to appease formatters
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define BB_INCREMENT_OP_COUNT() (void)0
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define BB_PRINT_OP_COUNTS() (void)0
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define BB_CLEAR_OP_COUNTS() (void)0
 #else
 /**
@@ -17,7 +18,10 @@
 #include "barretenberg/common/compiler_hints.hpp"
 #include <algorithm>
 #include <atomic>
+#include <cstdlib>
+#include <map>
 #include <mutex>
+#include <string>
 #include <vector>
 namespace bb::detail {
 template <std::size_t N> struct OperationLabel {
@@ -49,6 +53,7 @@ struct GlobalOpCountContainer {
     void print() const;
     void clear();
     void add_entry(const char* key, const std::size_t* count);
+    std::map<std::string, std::size_t> get_aggregate_counts() const;
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/barretenberg/cpp/src/barretenberg/common/op_count.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.hpp
@@ -4,11 +4,9 @@
 #ifdef NO_OP_COUNTS
 // require a semicolon to appease formatters
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define BB_INCREMENT_OP_COUNT() (void)0
+#define BB_OP_COUNT_TRACK() (void)0
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define BB_PRINT_OP_COUNTS() (void)0
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define BB_CLEAR_OP_COUNTS() (void)0
+#define BB_OP_COUNT_TRACK_NAME() (void)0
 #else
 /**
  * Provides an abstraction that counts operations based on function names.
@@ -83,11 +81,7 @@ template <OperationLabel Op> thread_local std::size_t* GlobalOpCount<Op>::thread
 } // namespace bb::detail
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define BB_INCREMENT_OP_COUNT() bb::detail::GlobalOpCount<__func__>::increment_op_count()
+#define BB_OP_COUNT_TRACK() bb::detail::GlobalOpCount<__func__>::increment_op_count()
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define BB_INCREMENT_OP_COUNT() bb::detail::GlobalOpCount<__func__>::increment_op_count()
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define BB_PRINT_OP_COUNTS() bb::detail::GLOBAL_OP_COUNTS.print()
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define BB_CLEAR_OP_COUNTS() bb::detail::GLOBAL_OP_COUNTS.clear()
+#define BB_OP_COUNT_TRACK_NAME(name) bb::detail::GlobalOpCount<name>::increment_op_count()
 #endif

--- a/barretenberg/cpp/src/barretenberg/common/op_count.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.hpp
@@ -45,13 +45,14 @@ struct GlobalOpCountContainer {
     struct Entry {
         std::string key;
         std::string thread_id;
-        const std::size_t* count;
+        std::size_t* count;
     };
     std::mutex mutex;
     std::vector<Entry> counts;
     void print() const;
+    // NOTE: Should be called when other threads aren't active
     void clear();
-    void add_entry(const char* key, const std::size_t* count);
+    void add_entry(const char* key, std::size_t* count);
     std::map<std::string, std::size_t> get_aggregate_counts() const;
 };
 

--- a/barretenberg/cpp/src/barretenberg/common/op_count.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count.hpp
@@ -20,18 +20,18 @@
 #include <mutex>
 #include <vector>
 namespace bb::detail {
-template <std::size_t N> struct OperationLabel {
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-    constexpr OperationLabel(const char (&str)[N])
-    {
-        for (std::size_t i = 0; i != N; ++i) {
-            value[i] = str[i];
-        }
-    }
+// template <std::size_t N> struct OperationLabel {
+//     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+//     constexpr OperationLabel(const char (&str)[N])
+//     {
+//         for (std::size_t i = 0; i != N; ++i) {
+//             value[i] = str[i];
+//         }
+//     }
 
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-    char value[N];
-};
+//     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+//     char value[N];
+// };
 
 // Contains all statically known op counts
 struct GlobalOpCountContainer {
@@ -52,7 +52,7 @@ struct GlobalOpCountContainer {
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern GlobalOpCountContainer GLOBAL_OP_COUNTS;
 
-template <OperationLabel Op> struct GlobalOpCount {
+template <const char* Op> struct GlobalOpCount {
   public:
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     static thread_local std::size_t* thread_local_count;
@@ -65,13 +65,13 @@ template <OperationLabel Op> struct GlobalOpCount {
         }
         if (BB_UNLIKELY(thread_local_count == nullptr)) {
             thread_local_count = new std::size_t();
-            GLOBAL_OP_COUNTS.add_entry(Op.value, thread_local_count);
+            GLOBAL_OP_COUNTS.add_entry(Op, thread_local_count);
         }
         (*thread_local_count)++;
     }
 };
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-template <OperationLabel Op> thread_local std::size_t* GlobalOpCount<Op>::thread_local_count;
+template <const char* Op> thread_local std::size_t* GlobalOpCount<Op>::thread_local_count;
 
 } // namespace bb::detail
 

--- a/barretenberg/cpp/src/barretenberg/common/op_count_google_bench.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count_google_bench.hpp
@@ -1,0 +1,51 @@
+
+#pragma once
+#include <benchmark/benchmark.h>
+
+#ifdef NO_OP_COUNTS
+namespace bb {
+struct GoogleBenchOpCountReporter {
+    GoogleBenchOpCountReporter(::benchmark::State& state)
+        : state(state)
+    {
+        // unused, we don't have op counts on
+        (void)state;
+    }
+};
+}; // namespace bb
+// require a semicolon to appease formatters
+#define BB_REPORT_OP_COUNT_IN_BENCH(state) (void)0
+#define BB_REPORT_OP_COUNT_BENCH_CANCEL() (void)0
+#else
+#include "op_count.hpp"
+namespace bb {
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+struct GoogleBenchOpCountReporter {
+    // We allow having a ref member as this only lives inside a function frame
+    ::benchmark::State& state;
+    bool cancelled = false;
+    GoogleBenchOpCountReporter(::benchmark::State& state)
+        : state(state)
+    {
+        // Intent: Clear when we enter the state loop
+        bb::detail::GLOBAL_OP_COUNTS.clear();
+    }
+    ~GoogleBenchOpCountReporter()
+    {
+        // Allow for conditional reporting
+        if (cancelled) {
+            return;
+        }
+        // Intent: Collect results when we exit the state loop
+        for (auto& entry : bb::detail::GLOBAL_OP_COUNTS.get_aggregate_counts()) {
+            state.counters[entry.first] = static_cast<double>(entry.second);
+        }
+    }
+};
+// Allow for integration with google benchmark user-defined counters
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define BB_REPORT_OP_COUNT_IN_BENCH(state) GoogleBenchOpCountReporter __bb_report_op_count_in_bench{ state };
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define BB_REPORT_OP_COUNT_BENCH_CANCEL() __bb_report_op_count_in_bench.cancelled = true;
+}; // namespace bb
+#endif

--- a/barretenberg/cpp/src/barretenberg/common/op_count_google_bench.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/op_count_google_bench.hpp
@@ -2,11 +2,10 @@
 #pragma once
 #include <benchmark/benchmark.h>
 
-#ifdef NO_OP_COUNTS
+#ifndef BB_USE_OP_COUNT
 namespace bb {
 struct GoogleBenchOpCountReporter {
     GoogleBenchOpCountReporter(::benchmark::State& state)
-        : state(state)
     {
         // unused, we don't have op counts on
         (void)state;

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -52,7 +52,7 @@ class ThreadPool {
     std::condition_variable complete_condition_;
     bool stop = false;
 
-    BBERG_NO_PROFILE void worker_loop(size_t thread_index);
+    BB_NO_PROFILE void worker_loop(size_t thread_index);
 
     void do_iterations()
     {

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
@@ -214,39 +214,39 @@ template <class Params_> struct alignas(32) field {
         return result;
     }
 
-    BBERG_INLINE constexpr field operator*(const field& other) const noexcept;
-    BBERG_INLINE constexpr field operator+(const field& other) const noexcept;
-    BBERG_INLINE constexpr field operator-(const field& other) const noexcept;
-    BBERG_INLINE constexpr field operator-() const noexcept;
+    BB_INLINE constexpr field operator*(const field& other) const noexcept;
+    BB_INLINE constexpr field operator+(const field& other) const noexcept;
+    BB_INLINE constexpr field operator-(const field& other) const noexcept;
+    BB_INLINE constexpr field operator-() const noexcept;
     constexpr field operator/(const field& other) const noexcept;
 
     // prefix increment (++x)
-    BBERG_INLINE constexpr field operator++() noexcept;
+    BB_INLINE constexpr field operator++() noexcept;
     // postfix increment (x++)
     // NOLINTNEXTLINE
-    BBERG_INLINE constexpr field operator++(int) noexcept;
+    BB_INLINE constexpr field operator++(int) noexcept;
 
-    BBERG_INLINE constexpr field& operator*=(const field& other) noexcept;
-    BBERG_INLINE constexpr field& operator+=(const field& other) noexcept;
-    BBERG_INLINE constexpr field& operator-=(const field& other) noexcept;
+    BB_INLINE constexpr field& operator*=(const field& other) noexcept;
+    BB_INLINE constexpr field& operator+=(const field& other) noexcept;
+    BB_INLINE constexpr field& operator-=(const field& other) noexcept;
     constexpr field& operator/=(const field& other) noexcept;
 
     // NOTE: comparison operators exist so that `field` is comparible with stl methods that require them.
     //       (e.g. std::sort)
     //       Finite fields do not have an explicit ordering, these should *NEVER* be used in algebraic algorithms.
-    BBERG_INLINE constexpr bool operator>(const field& other) const noexcept;
-    BBERG_INLINE constexpr bool operator<(const field& other) const noexcept;
-    BBERG_INLINE constexpr bool operator==(const field& other) const noexcept;
-    BBERG_INLINE constexpr bool operator!=(const field& other) const noexcept;
+    BB_INLINE constexpr bool operator>(const field& other) const noexcept;
+    BB_INLINE constexpr bool operator<(const field& other) const noexcept;
+    BB_INLINE constexpr bool operator==(const field& other) const noexcept;
+    BB_INLINE constexpr bool operator!=(const field& other) const noexcept;
 
-    BBERG_INLINE constexpr field to_montgomery_form() const noexcept;
-    BBERG_INLINE constexpr field from_montgomery_form() const noexcept;
+    BB_INLINE constexpr field to_montgomery_form() const noexcept;
+    BB_INLINE constexpr field from_montgomery_form() const noexcept;
 
-    BBERG_INLINE constexpr field sqr() const noexcept;
-    BBERG_INLINE constexpr void self_sqr() noexcept;
+    BB_INLINE constexpr field sqr() const noexcept;
+    BB_INLINE constexpr void self_sqr() noexcept;
 
-    BBERG_INLINE constexpr field pow(const uint256_t& exponent) const noexcept;
-    BBERG_INLINE constexpr field pow(uint64_t exponent) const noexcept;
+    BB_INLINE constexpr field pow(const uint256_t& exponent) const noexcept;
+    BB_INLINE constexpr field pow(uint64_t exponent) const noexcept;
     static constexpr uint256_t modulus_minus_two =
         uint256_t(Params::modulus_0 - 2ULL, Params::modulus_1, Params::modulus_2, Params::modulus_3);
     constexpr field invert() const noexcept;
@@ -259,21 +259,21 @@ template <class Params_> struct alignas(32) field {
      */
     constexpr std::pair<bool, field> sqrt() const noexcept;
 
-    BBERG_INLINE constexpr void self_neg() noexcept;
+    BB_INLINE constexpr void self_neg() noexcept;
 
-    BBERG_INLINE constexpr void self_to_montgomery_form() noexcept;
-    BBERG_INLINE constexpr void self_from_montgomery_form() noexcept;
+    BB_INLINE constexpr void self_to_montgomery_form() noexcept;
+    BB_INLINE constexpr void self_from_montgomery_form() noexcept;
 
-    BBERG_INLINE constexpr void self_conditional_negate(uint64_t predicate) noexcept;
+    BB_INLINE constexpr void self_conditional_negate(uint64_t predicate) noexcept;
 
-    BBERG_INLINE constexpr field reduce_once() const noexcept;
-    BBERG_INLINE constexpr void self_reduce_once() noexcept;
+    BB_INLINE constexpr field reduce_once() const noexcept;
+    BB_INLINE constexpr void self_reduce_once() noexcept;
 
-    BBERG_INLINE constexpr void self_set_msb() noexcept;
-    [[nodiscard]] BBERG_INLINE constexpr bool is_msb_set() const noexcept;
-    [[nodiscard]] BBERG_INLINE constexpr uint64_t is_msb_set_word() const noexcept;
+    BB_INLINE constexpr void self_set_msb() noexcept;
+    [[nodiscard]] BB_INLINE constexpr bool is_msb_set() const noexcept;
+    [[nodiscard]] BB_INLINE constexpr uint64_t is_msb_set_word() const noexcept;
 
-    [[nodiscard]] BBERG_INLINE constexpr bool is_zero() const noexcept;
+    [[nodiscard]] BB_INLINE constexpr bool is_zero() const noexcept;
 
     static constexpr field get_root_of_unity(size_t subgroup_size) noexcept;
 
@@ -281,15 +281,15 @@ template <class Params_> struct alignas(32) field {
 
     static field serialize_from_buffer(const uint8_t* buffer) { return from_buffer<field>(buffer); }
 
-    [[nodiscard]] BBERG_INLINE std::vector<uint8_t> to_buffer() const { return ::to_buffer(*this); }
+    [[nodiscard]] BB_INLINE std::vector<uint8_t> to_buffer() const { return ::to_buffer(*this); }
 
     struct wide_array {
         uint64_t data[8]; // NOLINT
     };
-    BBERG_INLINE constexpr wide_array mul_512(const field& other) const noexcept;
-    BBERG_INLINE constexpr wide_array sqr_512() const noexcept;
+    BB_INLINE constexpr wide_array mul_512(const field& other) const noexcept;
+    BB_INLINE constexpr wide_array sqr_512() const noexcept;
 
-    BBERG_INLINE constexpr field conditionally_subtract_from_double_modulus(const uint64_t predicate) const noexcept
+    BB_INLINE constexpr field conditionally_subtract_from_double_modulus(const uint64_t predicate) const noexcept
     {
         if (predicate != 0) {
             constexpr field p{
@@ -436,8 +436,8 @@ template <class Params_> struct alignas(32) field {
         return os;
     }
 
-    BBERG_INLINE static void __copy(const field& a, field& r) noexcept { r = a; } // NOLINT
-    BBERG_INLINE static void __swap(field& src, field& dest) noexcept             // NOLINT
+    BB_INLINE static void __copy(const field& a, field& r) noexcept { r = a; } // NOLINT
+    BB_INLINE static void __swap(field& src, field& dest) noexcept             // NOLINT
     {
         field T = dest;
         dest = src;
@@ -499,68 +499,62 @@ template <class Params_> struct alignas(32) field {
         {}
     };
 
-    BBERG_INLINE static constexpr std::pair<uint64_t, uint64_t> mul_wide(uint64_t a, uint64_t b) noexcept;
+    BB_INLINE static constexpr std::pair<uint64_t, uint64_t> mul_wide(uint64_t a, uint64_t b) noexcept;
 
-    BBERG_INLINE static constexpr uint64_t mac(
+    BB_INLINE static constexpr uint64_t mac(
         uint64_t a, uint64_t b, uint64_t c, uint64_t carry_in, uint64_t& carry_out) noexcept;
 
-    BBERG_INLINE static constexpr void mac(
+    BB_INLINE static constexpr void mac(
         uint64_t a, uint64_t b, uint64_t c, uint64_t carry_in, uint64_t& out, uint64_t& carry_out) noexcept;
 
-    BBERG_INLINE static constexpr uint64_t mac_mini(uint64_t a, uint64_t b, uint64_t c, uint64_t& out) noexcept;
+    BB_INLINE static constexpr uint64_t mac_mini(uint64_t a, uint64_t b, uint64_t c, uint64_t& out) noexcept;
 
-    BBERG_INLINE static constexpr void mac_mini(
+    BB_INLINE static constexpr void mac_mini(
         uint64_t a, uint64_t b, uint64_t c, uint64_t& out, uint64_t& carry_out) noexcept;
 
-    BBERG_INLINE static constexpr uint64_t mac_discard_lo(uint64_t a, uint64_t b, uint64_t c) noexcept;
+    BB_INLINE static constexpr uint64_t mac_discard_lo(uint64_t a, uint64_t b, uint64_t c) noexcept;
 
-    BBERG_INLINE static constexpr uint64_t addc(uint64_t a,
-                                                uint64_t b,
-                                                uint64_t carry_in,
-                                                uint64_t& carry_out) noexcept;
+    BB_INLINE static constexpr uint64_t addc(uint64_t a, uint64_t b, uint64_t carry_in, uint64_t& carry_out) noexcept;
 
-    BBERG_INLINE static constexpr uint64_t sbb(uint64_t a,
-                                               uint64_t b,
-                                               uint64_t borrow_in,
-                                               uint64_t& borrow_out) noexcept;
+    BB_INLINE static constexpr uint64_t sbb(uint64_t a, uint64_t b, uint64_t borrow_in, uint64_t& borrow_out) noexcept;
 
-    BBERG_INLINE static constexpr uint64_t square_accumulate(uint64_t a,
-                                                             uint64_t b,
-                                                             uint64_t c,
-                                                             uint64_t carry_in_lo,
-                                                             uint64_t carry_in_hi,
-                                                             uint64_t& carry_lo,
-                                                             uint64_t& carry_hi) noexcept;
-    BBERG_INLINE constexpr field reduce() const noexcept;
-    BBERG_INLINE constexpr field add(const field& other) const noexcept;
-    BBERG_INLINE constexpr field subtract(const field& other) const noexcept;
-    BBERG_INLINE constexpr field subtract_coarse(const field& other) const noexcept;
-    BBERG_INLINE constexpr field montgomery_mul(const field& other) const noexcept;
-    BBERG_INLINE constexpr field montgomery_mul_big(const field& other) const noexcept;
-    BBERG_INLINE constexpr field montgomery_square() const noexcept;
+    BB_INLINE static constexpr uint64_t square_accumulate(uint64_t a,
+                                                          uint64_t b,
+                                                          uint64_t c,
+                                                          uint64_t carry_in_lo,
+                                                          uint64_t carry_in_hi,
+                                                          uint64_t& carry_lo,
+                                                          uint64_t& carry_hi) noexcept;
+    BB_INLINE constexpr field reduce() const noexcept;
+    BB_INLINE constexpr field add(const field& other) const noexcept;
+    BB_INLINE constexpr field subtract(const field& other) const noexcept;
+    BB_INLINE constexpr field subtract_coarse(const field& other) const noexcept;
+    BB_INLINE constexpr field montgomery_mul(const field& other) const noexcept;
+    BB_INLINE constexpr field montgomery_mul_big(const field& other) const noexcept;
+    BB_INLINE constexpr field montgomery_square() const noexcept;
 
 #if (BBERG_NO_ASM == 0)
-    BBERG_INLINE static field asm_mul(const field& a, const field& b) noexcept;
-    BBERG_INLINE static field asm_sqr(const field& a) noexcept;
-    BBERG_INLINE static field asm_add(const field& a, const field& b) noexcept;
-    BBERG_INLINE static field asm_sub(const field& a, const field& b) noexcept;
-    BBERG_INLINE static field asm_mul_with_coarse_reduction(const field& a, const field& b) noexcept;
-    BBERG_INLINE static field asm_sqr_with_coarse_reduction(const field& a) noexcept;
-    BBERG_INLINE static field asm_add_with_coarse_reduction(const field& a, const field& b) noexcept;
-    BBERG_INLINE static field asm_sub_with_coarse_reduction(const field& a, const field& b) noexcept;
-    BBERG_INLINE static field asm_add_without_reduction(const field& a, const field& b) noexcept;
-    BBERG_INLINE static void asm_self_sqr(const field& a) noexcept;
-    BBERG_INLINE static void asm_self_add(const field& a, const field& b) noexcept;
-    BBERG_INLINE static void asm_self_sub(const field& a, const field& b) noexcept;
-    BBERG_INLINE static void asm_self_mul_with_coarse_reduction(const field& a, const field& b) noexcept;
-    BBERG_INLINE static void asm_self_sqr_with_coarse_reduction(const field& a) noexcept;
-    BBERG_INLINE static void asm_self_add_with_coarse_reduction(const field& a, const field& b) noexcept;
-    BBERG_INLINE static void asm_self_sub_with_coarse_reduction(const field& a, const field& b) noexcept;
-    BBERG_INLINE static void asm_self_add_without_reduction(const field& a, const field& b) noexcept;
+    BB_INLINE static field asm_mul(const field& a, const field& b) noexcept;
+    BB_INLINE static field asm_sqr(const field& a) noexcept;
+    BB_INLINE static field asm_add(const field& a, const field& b) noexcept;
+    BB_INLINE static field asm_sub(const field& a, const field& b) noexcept;
+    BB_INLINE static field asm_mul_with_coarse_reduction(const field& a, const field& b) noexcept;
+    BB_INLINE static field asm_sqr_with_coarse_reduction(const field& a) noexcept;
+    BB_INLINE static field asm_add_with_coarse_reduction(const field& a, const field& b) noexcept;
+    BB_INLINE static field asm_sub_with_coarse_reduction(const field& a, const field& b) noexcept;
+    BB_INLINE static field asm_add_without_reduction(const field& a, const field& b) noexcept;
+    BB_INLINE static void asm_self_sqr(const field& a) noexcept;
+    BB_INLINE static void asm_self_add(const field& a, const field& b) noexcept;
+    BB_INLINE static void asm_self_sub(const field& a, const field& b) noexcept;
+    BB_INLINE static void asm_self_mul_with_coarse_reduction(const field& a, const field& b) noexcept;
+    BB_INLINE static void asm_self_sqr_with_coarse_reduction(const field& a) noexcept;
+    BB_INLINE static void asm_self_add_with_coarse_reduction(const field& a, const field& b) noexcept;
+    BB_INLINE static void asm_self_sub_with_coarse_reduction(const field& a, const field& b) noexcept;
+    BB_INLINE static void asm_self_add_without_reduction(const field& a, const field& b) noexcept;
 
-    BBERG_INLINE static void asm_conditional_negate(field& r, uint64_t predicate) noexcept;
-    BBERG_INLINE static field asm_reduce_once(const field& a) noexcept;
-    BBERG_INLINE static void asm_self_reduce_once(const field& a) noexcept;
+    BB_INLINE static void asm_conditional_negate(field& r, uint64_t predicate) noexcept;
+    BB_INLINE static field asm_reduce_once(const field& a) noexcept;
+    BB_INLINE static void asm_self_reduce_once(const field& a) noexcept;
     static constexpr uint64_t zero_reference = 0x00ULL;
 #endif
     static constexpr size_t COSET_GENERATOR_SIZE = 15;

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "barretenberg/common/op_count.hpp"
 #include "barretenberg/common/slab_allocator.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
 #include "barretenberg/numeric/bitop/get_msb.hpp"
@@ -25,6 +26,7 @@ namespace bb {
  **/
 template <class T> constexpr field<T> field<T>::operator*(const field& other) const noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f*");
     if constexpr (BBERG_NO_ASM || (T::modulus_3 >= 0x4000000000000000ULL) ||
                   (T::modulus_1 == 0 && T::modulus_2 == 0 && T::modulus_3 == 0)) {
         // >= 255-bits or <= 64-bits.
@@ -39,6 +41,7 @@ template <class T> constexpr field<T> field<T>::operator*(const field& other) co
 
 template <class T> constexpr field<T>& field<T>::operator*=(const field& other) noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f*=");
     if constexpr (BBERG_NO_ASM || (T::modulus_3 >= 0x4000000000000000ULL) ||
                   (T::modulus_1 == 0 && T::modulus_2 == 0 && T::modulus_3 == 0)) {
         // >= 255-bits or <= 64-bits.
@@ -60,6 +63,7 @@ template <class T> constexpr field<T>& field<T>::operator*=(const field& other) 
  **/
 template <class T> constexpr field<T> field<T>::sqr() const noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::sqr");
     if constexpr (BBERG_NO_ASM || (T::modulus_3 >= 0x4000000000000000ULL) ||
                   (T::modulus_1 == 0 && T::modulus_2 == 0 && T::modulus_3 == 0)) {
         return montgomery_square();
@@ -73,6 +77,7 @@ template <class T> constexpr field<T> field<T>::sqr() const noexcept
 
 template <class T> constexpr void field<T>::self_sqr() noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::self_sqr");
     if constexpr (BBERG_NO_ASM || (T::modulus_3 >= 0x4000000000000000ULL) ||
                   (T::modulus_1 == 0 && T::modulus_2 == 0 && T::modulus_3 == 0)) {
         *this = montgomery_square();
@@ -92,6 +97,7 @@ template <class T> constexpr void field<T>::self_sqr() noexcept
  **/
 template <class T> constexpr field<T> field<T>::operator+(const field& other) const noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f+");
     if constexpr (BBERG_NO_ASM || (T::modulus_3 >= 0x4000000000000000ULL) ||
                   (T::modulus_1 == 0 && T::modulus_2 == 0 && T::modulus_3 == 0)) {
         return add(other);
@@ -105,6 +111,7 @@ template <class T> constexpr field<T> field<T>::operator+(const field& other) co
 
 template <class T> constexpr field<T>& field<T>::operator+=(const field& other) noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f+=");
     if constexpr (BBERG_NO_ASM || (T::modulus_3 >= 0x4000000000000000ULL) ||
                   (T::modulus_1 == 0 && T::modulus_2 == 0 && T::modulus_3 == 0)) {
         (*this) = operator+(other);
@@ -120,12 +127,14 @@ template <class T> constexpr field<T>& field<T>::operator+=(const field& other) 
 
 template <class T> constexpr field<T> field<T>::operator++() noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("++f");
     return *this += 1;
 }
 
 // NOLINTNEXTLINE(cert-dcl21-cpp) circular linting errors. If const is added, linter suggests removing
 template <class T> constexpr field<T> field<T>::operator++(int) noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f++");
     field<T> value_before_incrementing = *this;
     *this += 1;
     return value_before_incrementing;
@@ -138,6 +147,7 @@ template <class T> constexpr field<T> field<T>::operator++(int) noexcept
  **/
 template <class T> constexpr field<T> field<T>::operator-(const field& other) const noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f-");
     if constexpr (BBERG_NO_ASM || (T::modulus_3 >= 0x4000000000000000ULL) ||
                   (T::modulus_1 == 0 && T::modulus_2 == 0 && T::modulus_3 == 0)) {
         return subtract_coarse(other); // modulus - *this;
@@ -151,6 +161,7 @@ template <class T> constexpr field<T> field<T>::operator-(const field& other) co
 
 template <class T> constexpr field<T> field<T>::operator-() const noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("-f");
     if constexpr ((T::modulus_3 >= 0x4000000000000000ULL) ||
                   (T::modulus_1 == 0 && T::modulus_2 == 0 && T::modulus_3 == 0)) {
         constexpr field p{ modulus.data[0], modulus.data[1], modulus.data[2], modulus.data[3] };
@@ -179,6 +190,7 @@ template <class T> constexpr field<T> field<T>::operator-() const noexcept
 
 template <class T> constexpr field<T>& field<T>::operator-=(const field& other) noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f-=");
     if constexpr (BBERG_NO_ASM || (T::modulus_3 >= 0x4000000000000000ULL) ||
                   (T::modulus_1 == 0 && T::modulus_2 == 0 && T::modulus_3 == 0)) {
         *this = subtract_coarse(other); // subtract(other);
@@ -194,6 +206,7 @@ template <class T> constexpr field<T>& field<T>::operator-=(const field& other) 
 
 template <class T> constexpr void field<T>::self_neg() noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::self_neg");
     if constexpr ((T::modulus_3 >= 0x4000000000000000ULL) ||
                   (T::modulus_1 == 0 && T::modulus_2 == 0 && T::modulus_3 == 0)) {
         constexpr field p{ modulus.data[0], modulus.data[1], modulus.data[2], modulus.data[3] };
@@ -206,6 +219,7 @@ template <class T> constexpr void field<T>::self_neg() noexcept
 
 template <class T> constexpr void field<T>::self_conditional_negate(const uint64_t predicate) noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::self_conditional_negate");
     if constexpr (BBERG_NO_ASM || (T::modulus_3 >= 0x4000000000000000ULL) ||
                   (T::modulus_1 == 0 && T::modulus_2 == 0 && T::modulus_3 == 0)) {
         *this = predicate ? -(*this) : *this; // NOLINT
@@ -231,6 +245,7 @@ template <class T> constexpr void field<T>::self_conditional_negate(const uint64
  */
 template <class T> constexpr bool field<T>::operator>(const field& other) const noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f>");
     const field left = reduce_once();
     const field right = other.reduce_once();
     const bool t0 = left.data[3] > right.data[3];
@@ -260,6 +275,7 @@ template <class T> constexpr bool field<T>::operator<(const field& other) const 
 
 template <class T> constexpr bool field<T>::operator==(const field& other) const noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f==");
     const field left = reduce_once();
     const field right = other.reduce_once();
     return (left.data[0] == right.data[0]) && (left.data[1] == right.data[1]) && (left.data[2] == right.data[2]) &&
@@ -273,6 +289,7 @@ template <class T> constexpr bool field<T>::operator!=(const field& other) const
 
 template <class T> constexpr field<T> field<T>::to_montgomery_form() const noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::to_montgomery_form");
     constexpr field r_squared{ T::r_squared_0, T::r_squared_1, T::r_squared_2, T::r_squared_3 };
 
     field result = *this;
@@ -290,12 +307,14 @@ template <class T> constexpr field<T> field<T>::to_montgomery_form() const noexc
 
 template <class T> constexpr field<T> field<T>::from_montgomery_form() const noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::from_montgomery_form");
     constexpr field one_raw{ 1, 0, 0, 0 };
     return operator*(one_raw).reduce_once();
 }
 
 template <class T> constexpr void field<T>::self_to_montgomery_form() noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::self_to_montgomery_form");
     constexpr field r_squared{ T::r_squared_0, T::r_squared_1, T::r_squared_2, T::r_squared_3 };
     self_reduce_once();
     self_reduce_once();
@@ -306,6 +325,7 @@ template <class T> constexpr void field<T>::self_to_montgomery_form() noexcept
 
 template <class T> constexpr void field<T>::self_from_montgomery_form() noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::self_from_montgomery_form");
     constexpr field one_raw{ 1, 0, 0, 0 };
     *this *= one_raw;
     self_reduce_once();
@@ -313,6 +333,7 @@ template <class T> constexpr void field<T>::self_from_montgomery_form() noexcept
 
 template <class T> constexpr field<T> field<T>::reduce_once() const noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::reduce_once");
     if constexpr (BBERG_NO_ASM || (T::modulus_3 >= 0x4000000000000000ULL) ||
                   (T::modulus_1 == 0 && T::modulus_2 == 0 && T::modulus_3 == 0)) {
         return reduce();
@@ -326,6 +347,7 @@ template <class T> constexpr field<T> field<T>::reduce_once() const noexcept
 
 template <class T> constexpr void field<T>::self_reduce_once() noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::self_reduce_once");
     if constexpr (BBERG_NO_ASM || (T::modulus_3 >= 0x4000000000000000ULL) ||
                   (T::modulus_1 == 0 && T::modulus_2 == 0 && T::modulus_3 == 0)) {
         *this = reduce();
@@ -340,7 +362,7 @@ template <class T> constexpr void field<T>::self_reduce_once() noexcept
 
 template <class T> constexpr field<T> field<T>::pow(const uint256_t& exponent) const noexcept
 {
-
+    BB_OP_COUNT_TRACK_NAME("f::pow");
     field accumulator{ data[0], data[1], data[2], data[3] };
     field to_mul{ data[0], data[1], data[2], data[3] };
     const uint64_t maximum_set_bit = exponent.get_msb();
@@ -366,6 +388,7 @@ template <class T> constexpr field<T> field<T>::pow(const uint64_t exponent) con
 
 template <class T> constexpr field<T> field<T>::invert() const noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::invert");
     if (*this == zero()) {
         throw_or_abort("Trying to invert zero in the field");
     }
@@ -379,6 +402,7 @@ template <class T> void field<T>::batch_invert(field* coeffs, const size_t n) no
 
 template <class T> void field<T>::batch_invert(std::span<field> coeffs) noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::batch_invert");
     const size_t n = coeffs.size();
 
     auto temporaries_ptr = std::static_pointer_cast<field[]>(get_mem_slab(n * sizeof(field)));
@@ -427,6 +451,7 @@ template <class T> void field<T>::batch_invert(std::span<field> coeffs) noexcept
 
 template <class T> constexpr field<T> field<T>::tonelli_shanks_sqrt() const noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::tonelli_shanks_sqrt");
     // Tonelli-shanks algorithm begins by finding a field element Q and integer S,
     // such that (p - 1) = Q.2^{s}
 
@@ -506,6 +531,7 @@ template <class T> constexpr field<T> field<T>::tonelli_shanks_sqrt() const noex
 
 template <class T> constexpr std::pair<bool, field<T>> field<T>::sqrt() const noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::sqrt");
     field root;
     if constexpr ((T::modulus_0 & 0x3UL) == 0x3UL) {
         constexpr uint256_t sqrt_exponent = (modulus + uint256_t(1)) >> 2;
@@ -522,11 +548,13 @@ template <class T> constexpr std::pair<bool, field<T>> field<T>::sqrt() const no
 
 template <class T> constexpr field<T> field<T>::operator/(const field& other) const noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f/");
     return operator*(other.invert());
 }
 
 template <class T> constexpr field<T>& field<T>::operator/=(const field& other) noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f/=");
     *this = operator/(other);
     return *this;
 }
@@ -563,6 +591,7 @@ template <class T> constexpr field<T> field<T>::get_root_of_unity(size_t subgrou
 
 template <class T> field<T> field<T>::random_element(numeric::RNG* engine) noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::random_element");
     if (engine == nullptr) {
         engine = &numeric::get_randomness();
     }
@@ -575,6 +604,7 @@ template <class T> field<T> field<T>::random_element(numeric::RNG* engine) noexc
 
 template <class T> constexpr size_t field<T>::primitive_root_log_size() noexcept
 {
+    BB_OP_COUNT_TRACK_NAME("f::primitive_root_log_size");
     uint256_t target = modulus - 1;
     size_t result = 0;
     while (!target.get_bit(result)) {

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl_generic.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl_generic.hpp
@@ -105,7 +105,7 @@ constexpr uint64_t field<T>::addc(const uint64_t a,
                                   const uint64_t carry_in,
                                   uint64_t& carry_out) noexcept
 {
-    BB_INCREMENT_OP_COUNT();
+    BB_OP_COUNT_TRACK();
 #if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     uint128_t res = static_cast<uint128_t>(a) + static_cast<uint128_t>(b) + static_cast<uint128_t>(carry_in);
     carry_out = static_cast<uint64_t>(res >> 64);

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl_generic.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl_generic.hpp
@@ -4,6 +4,8 @@
 #include <cstdint>
 
 #include "./field_impl.hpp"
+#include "barretenberg/common/op_count.hpp"
+
 namespace bb {
 
 // NOLINTBEGIN(readability-implicit-bool-conversion)
@@ -103,6 +105,7 @@ constexpr uint64_t field<T>::addc(const uint64_t a,
                                   const uint64_t carry_in,
                                   uint64_t& carry_out) noexcept
 {
+    INCREMENT_OP_COUNT();
 #if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     uint128_t res = static_cast<uint128_t>(a) + static_cast<uint128_t>(b) + static_cast<uint128_t>(carry_in);
     carry_out = static_cast<uint64_t>(res >> 64);

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl_generic.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl_generic.hpp
@@ -105,7 +105,7 @@ constexpr uint64_t field<T>::addc(const uint64_t a,
                                   const uint64_t carry_in,
                                   uint64_t& carry_out) noexcept
 {
-    INCREMENT_OP_COUNT();
+    BB_INCREMENT_OP_COUNT();
 #if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     uint128_t res = static_cast<uint128_t>(a) + static_cast<uint128_t>(b) + static_cast<uint128_t>(carry_in);
     carry_out = static_cast<uint64_t>(res >> 64);

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element.hpp
@@ -84,11 +84,11 @@ template <class Fq, class Fr, class Params> class alignas(32) element {
 
     constexpr element normalize() const noexcept;
     static element infinity();
-    BBERG_INLINE constexpr element set_infinity() const noexcept;
-    BBERG_INLINE constexpr void self_set_infinity() noexcept;
-    [[nodiscard]] BBERG_INLINE constexpr bool is_point_at_infinity() const noexcept;
-    [[nodiscard]] BBERG_INLINE constexpr bool on_curve() const noexcept;
-    BBERG_INLINE constexpr bool operator==(const element& other) const noexcept;
+    BB_INLINE constexpr element set_infinity() const noexcept;
+    BB_INLINE constexpr void self_set_infinity() noexcept;
+    [[nodiscard]] BB_INLINE constexpr bool is_point_at_infinity() const noexcept;
+    [[nodiscard]] BB_INLINE constexpr bool on_curve() const noexcept;
+    BB_INLINE constexpr bool operator==(const element& other) const noexcept;
 
     static void batch_normalize(element* elements, size_t num_elements) noexcept;
     static void batch_affine_add(const std::span<affine_element<Fq, Fr, Params>>& first_group,

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -445,7 +445,7 @@ constexpr element<Fq, Fr, T> element<Fq, Fr, T>::operator+=(const element& other
 template <class Fq, class Fr, class T>
 constexpr element<Fq, Fr, T> element<Fq, Fr, T>::operator+(const element& other) const noexcept
 {
-    BB_INCREMENT_OP_COUNT();
+    BB_OP_COUNT_TRACK();
     element result(*this);
     return (result += other);
 }
@@ -460,7 +460,7 @@ constexpr element<Fq, Fr, T> element<Fq, Fr, T>::operator-=(const element& other
 template <class Fq, class Fr, class T>
 constexpr element<Fq, Fr, T> element<Fq, Fr, T>::operator-(const element& other) const noexcept
 {
-    BB_INCREMENT_OP_COUNT();
+    BB_OP_COUNT_TRACK();
     element result(*this);
     return (result -= other);
 }

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "barretenberg/common/op_count.hpp"
 #include "barretenberg/common/thread.hpp"
 #include "barretenberg/ecc/groups/element.hpp"
 #include "element.hpp"
@@ -444,6 +445,7 @@ constexpr element<Fq, Fr, T> element<Fq, Fr, T>::operator+=(const element& other
 template <class Fq, class Fr, class T>
 constexpr element<Fq, Fr, T> element<Fq, Fr, T>::operator+(const element& other) const noexcept
 {
+    BB_INCREMENT_OP_COUNT();
     element result(*this);
     return (result += other);
 }
@@ -458,6 +460,7 @@ constexpr element<Fq, Fr, T> element<Fq, Fr, T>::operator-=(const element& other
 template <class Fq, class Fr, class T>
 constexpr element<Fq, Fr, T> element<Fq, Fr, T>::operator-(const element& other) const noexcept
 {
+    BB_INCREMENT_OP_COUNT();
     element result(*this);
     return (result -= other);
 }

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/group.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/group.hpp
@@ -115,9 +115,9 @@ template <typename _coordinate_field, typename _subgroup_field, typename GroupPa
         return derive_generators(domain_bytes, num_generators, starting_index);
     }
 
-    BBERG_INLINE static void conditional_negate_affine(const affine_element* src,
-                                                       affine_element* dest,
-                                                       uint64_t predicate);
+    BB_INLINE static void conditional_negate_affine(const affine_element* src,
+                                                    affine_element* dest,
+                                                    uint64_t predicate);
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
@@ -9,6 +9,7 @@
 #include "./scalar_multiplication.hpp"
 
 #include "barretenberg/common/mem.hpp"
+#include "barretenberg/common/op_count.hpp"
 #include "barretenberg/common/thread.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
 #include "barretenberg/ecc/groups/wnaf.hpp"
@@ -876,6 +877,7 @@ typename Curve::Element pippenger(typename Curve::ScalarField* scalars,
                                   pippenger_runtime_state<Curve>& state,
                                   bool handle_edge_cases)
 {
+    BB_OP_COUNT_TRACK();
     using Group = typename Curve::Group;
     using Element = typename Curve::Element;
 

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.hpp
@@ -30,17 +30,17 @@ template <IsECCVMFlavor Flavor> class ECCVMProver_ {
                           const std::shared_ptr<PCSCommitmentKey>& commitment_key,
                           const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());
 
-    BBERG_PROFILE void execute_preamble_round();
-    BBERG_PROFILE void execute_wire_commitments_round();
-    BBERG_PROFILE void execute_log_derivative_commitments_round();
-    BBERG_PROFILE void execute_grand_product_computation_round();
-    BBERG_PROFILE void execute_relation_check_rounds();
-    BBERG_PROFILE void execute_univariatization_round();
-    BBERG_PROFILE void execute_pcs_evaluation_round();
-    BBERG_PROFILE void execute_shplonk_batched_quotient_round();
-    BBERG_PROFILE void execute_shplonk_partial_evaluation_round();
-    BBERG_PROFILE void execute_final_pcs_round();
-    BBERG_PROFILE void execute_transcript_consistency_univariate_opening_round();
+    BB_PROFILE void execute_preamble_round();
+    BB_PROFILE void execute_wire_commitments_round();
+    BB_PROFILE void execute_log_derivative_commitments_round();
+    BB_PROFILE void execute_grand_product_computation_round();
+    BB_PROFILE void execute_relation_check_rounds();
+    BB_PROFILE void execute_univariatization_round();
+    BB_PROFILE void execute_pcs_evaluation_round();
+    BB_PROFILE void execute_shplonk_batched_quotient_round();
+    BB_PROFILE void execute_shplonk_partial_evaluation_round();
+    BB_PROFILE void execute_final_pcs_round();
+    BB_PROFILE void execute_transcript_consistency_univariate_opening_round();
 
     HonkProof& export_proof();
     HonkProof& construct_proof();

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/prover/prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/prover/prover.hpp
@@ -19,13 +19,13 @@ template <typename settings> class ProverBase {
     ProverBase& operator=(const ProverBase& other) = delete;
     ProverBase& operator=(ProverBase&& other);
 
-    BBERG_PROFILE void execute_preamble_round();
-    BBERG_PROFILE void execute_first_round();
-    BBERG_PROFILE void execute_second_round();
-    BBERG_PROFILE void execute_third_round();
-    BBERG_PROFILE void execute_fourth_round();
-    BBERG_PROFILE void execute_fifth_round();
-    BBERG_PROFILE void execute_sixth_round();
+    BB_PROFILE void execute_preamble_round();
+    BB_PROFILE void execute_first_round();
+    BB_PROFILE void execute_second_round();
+    BB_PROFILE void execute_third_round();
+    BB_PROFILE void execute_fourth_round();
+    BB_PROFILE void execute_fifth_round();
+    BB_PROFILE void execute_sixth_round();
 
     void add_polynomial_evaluations_to_transcript();
     void compute_batch_opening_polynomials();

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/decider_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/decider_prover.hpp
@@ -28,9 +28,9 @@ template <IsUltraFlavor Flavor> class DeciderProver_ {
                             const std::shared_ptr<CommitmentKey>&,
                             const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());
 
-    BBERG_PROFILE void execute_preamble_round();
-    BBERG_PROFILE void execute_relation_check_rounds();
-    BBERG_PROFILE void execute_zeromorph_rounds();
+    BB_PROFILE void execute_preamble_round();
+    BB_PROFILE void execute_relation_check_rounds();
+    BB_PROFILE void execute_zeromorph_rounds();
 
     HonkProof& export_proof();
     HonkProof& construct_proof();

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
@@ -91,7 +91,7 @@ template <class ProverInstances_> class ProtoGalaxyProver_ {
      *
      * TODO(https://github.com/AztecProtocol/barretenberg/issues/753): fold goblin polynomials
      */
-    BBERG_PROFILE FoldingResult<Flavor> fold_instances();
+    BB_PROFILE FoldingResult<Flavor> fold_instances();
 
     /**
      * @brief For a new round challenge δ at each iteration of the ProtoGalaxy protocol, compute the vector

--- a/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_prover.hpp
@@ -27,11 +27,11 @@ class GoblinTranslatorProver {
                                     const std::shared_ptr<CommitmentKey>& commitment_key,
                                     const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());
 
-    BBERG_PROFILE void execute_preamble_round();
-    BBERG_PROFILE void execute_wire_and_sorted_constraints_commitments_round();
-    BBERG_PROFILE void execute_grand_product_computation_round();
-    BBERG_PROFILE void execute_relation_check_rounds();
-    BBERG_PROFILE void execute_zeromorph_rounds();
+    BB_PROFILE void execute_preamble_round();
+    BB_PROFILE void execute_wire_and_sorted_constraints_commitments_round();
+    BB_PROFILE void execute_grand_product_computation_round();
+    BB_PROFILE void execute_relation_check_rounds();
+    BB_PROFILE void execute_zeromorph_rounds();
     HonkProof& export_proof();
     HonkProof& construct_proof();
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
@@ -28,7 +28,7 @@ class MergeProver {
 
     explicit MergeProver(const std::shared_ptr<ECCOpQueue>&);
 
-    BBERG_PROFILE HonkProof construct_proof();
+    BB_PROFILE HonkProof construct_proof();
 
   private:
     std::shared_ptr<ECCOpQueue> op_queue;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.hpp
@@ -27,13 +27,13 @@ template <IsUltraFlavor Flavor> class UltraProver_ {
                           const std::shared_ptr<CommitmentKey>&,
                           const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());
 
-    BBERG_PROFILE void execute_preamble_round();
-    BBERG_PROFILE void execute_wire_commitments_round();
-    BBERG_PROFILE void execute_sorted_list_accumulator_round();
-    BBERG_PROFILE void execute_log_derivative_inverse_round();
-    BBERG_PROFILE void execute_grand_product_computation_round();
-    BBERG_PROFILE void execute_relation_check_rounds();
-    BBERG_PROFILE void execute_zeromorph_rounds();
+    BB_PROFILE void execute_preamble_round();
+    BB_PROFILE void execute_wire_commitments_round();
+    BB_PROFILE void execute_sorted_list_accumulator_round();
+    BB_PROFILE void execute_log_derivative_inverse_round();
+    BB_PROFILE void execute_grand_product_computation_round();
+    BB_PROFILE void execute_relation_check_rounds();
+    BB_PROFILE void execute_zeromorph_rounds();
 
     HonkProof& export_proof();
     HonkProof& construct_proof();


### PR DESCRIPTION
- Introduces preset 'op-counting' that builds with support for operation counts
- Introduces mechanism to connect this to google benchmark
- Support for ultra_honk_rounds_bench and goblin_bench right now
![image](https://github.com/AztecProtocol/aztec-packages/assets/163993/9785e99b-ef1f-4ea6-bfab-cd63d33499e1)

For best results run with e.g. `./bin/goblin_bench --benchmark_min_time=0s --benchmark_counters_tabular=true`

other: - Make macros consistently have BB_, rename some BBERG_ macros