### PR TITLE
chore: fix some circular imports

### DIFF
--- a/yarn-project/archiver/src/rpc/archiver_client.ts
+++ b/yarn-project/archiver/src/rpc/archiver_client.ts
@@ -10,7 +10,7 @@ import {
 import { EthAddress, Fr } from '@aztec/circuits.js';
 import { createJsonRpcClient, makeFetch } from '@aztec/foundation/json-rpc/client';
 
-import { ArchiveSource } from '../index.js';
+import { ArchiveSource } from '../archiver/archiver.js';
 
 export const createArchiverClient = (url: string, fetch = makeFetch([1, 2, 3], true)): ArchiveSource =>
   createJsonRpcClient<ArchiveSource>(

--- a/yarn-project/archiver/src/rpc/archiver_server.ts
+++ b/yarn-project/archiver/src/rpc/archiver_server.ts
@@ -10,7 +10,7 @@ import {
 import { EthAddress, Fr } from '@aztec/circuits.js';
 import { JsonRpcServer } from '@aztec/foundation/json-rpc/server';
 
-import { Archiver } from '../index.js';
+import { Archiver } from '..//archiver/archiver.js';
 
 /**
  * Wrap an Archiver instance with a JSON RPC HTTP server.

--- a/yarn-project/archiver/src/rpc/archiver_server.ts
+++ b/yarn-project/archiver/src/rpc/archiver_server.ts
@@ -10,7 +10,7 @@ import {
 import { EthAddress, Fr } from '@aztec/circuits.js';
 import { JsonRpcServer } from '@aztec/foundation/json-rpc/server';
 
-import { Archiver } from '..//archiver/archiver.js';
+import { Archiver } from '../archiver/archiver.js';
 
 /**
  * Wrap an Archiver instance with a JSON RPC HTTP server.

--- a/yarn-project/circuit-types/src/aztec_node/rpc/aztec_node_client.ts
+++ b/yarn-project/circuit-types/src/aztec_node/rpc/aztec_node_client.ts
@@ -6,7 +6,7 @@ import { Fr } from '@aztec/foundation/fields';
 import { createJsonRpcClient, defaultFetch } from '@aztec/foundation/json-rpc/client';
 
 import { ContractData, ExtendedContractData } from '../../contract_data.js';
-import { AztecNode } from '../../interfaces/index.js';
+import { AztecNode } from '../../interfaces/aztec-node.js';
 import { L1ToL2MessageAndIndex } from '../../l1_to_l2_message.js';
 import { L2Block } from '../../l2_block.js';
 import { L2Tx } from '../../l2_tx.js';

--- a/yarn-project/circuit-types/src/notes/note_filter.ts
+++ b/yarn-project/circuit-types/src/notes/note_filter.ts
@@ -1,6 +1,6 @@
 import { AztecAddress, Fr } from '@aztec/circuits.js';
 
-import { TxHash } from '../index.js';
+import { TxHash } from '../tx/tx_hash.js';
 
 /**
  * The status of notes to retrieve.

--- a/yarn-project/circuits.js/src/abis/abis.ts
+++ b/yarn-project/circuits.js/src/abis/abis.ts
@@ -15,19 +15,19 @@ import {
   GeneratorIndex,
 } from '../constants.gen.js';
 import { MerkleTreeCalculator } from '../merkle/merkle_tree_calculator.js';
-import {
+import type {
   ContractDeploymentData,
   FunctionData,
   FunctionLeafPreimage,
   NewContractData,
   PublicCallStackItem,
-  PublicCircuitPublicInputs,
   SideEffect,
   SideEffectLinkedToNoteHash,
   TxContext,
   TxRequest,
-  VerificationKey,
 } from '../structs/index.js';
+import { PublicCircuitPublicInputs } from '../structs/public_circuit_public_inputs.js';
+import { VerificationKey } from '../structs/verification_key.js';
 
 /**
  * Computes a hash of a transaction request.

--- a/yarn-project/circuits.js/src/barretenberg/crypto/schnorr/index.ts
+++ b/yarn-project/circuits.js/src/barretenberg/crypto/schnorr/index.ts
@@ -2,7 +2,8 @@ import { BarretenbergSync } from '@aztec/bb.js';
 import { Point } from '@aztec/foundation/fields';
 import { numToUInt32BE } from '@aztec/foundation/serialize';
 
-import { GrumpkinPrivateKey, PublicKey } from '../../../types/index.js';
+import { GrumpkinPrivateKey } from '../../../types/grumpkin_private_key.js';
+import { PublicKey } from '../../../types/public_key.js';
 import { SchnorrSignature } from './signature.js';
 
 export * from './signature.js';

--- a/yarn-project/circuits.js/src/barretenberg/crypto/schnorr/signature.ts
+++ b/yarn-project/circuits.js/src/barretenberg/crypto/schnorr/signature.ts
@@ -2,7 +2,7 @@ import { randomBytes } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, mapTuple } from '@aztec/foundation/serialize';
 
-import { Signature } from '../index.js';
+import { Signature } from '../signature/index.js';
 
 /**
  * Schnorr signature used for transactions.

--- a/yarn-project/circuits.js/src/contract/contract_address.ts
+++ b/yarn-project/circuits.js/src/contract/contract_address.ts
@@ -1,10 +1,12 @@
 import { FunctionAbi, FunctionSelector, encodeArguments } from '@aztec/foundation/abi';
+import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { pedersenHash } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
 import { ContractInstance } from '@aztec/types/contracts';
 
 import { computeVarArgsHash } from '../abis/abis.js';
-import { AztecAddress, GeneratorIndex, PublicKey } from '../index.js';
+import { GeneratorIndex } from '../constants.gen.js';
+import { PublicKey } from '../types/public_key.js';
 
 // TODO(@spalladino): Review all generator indices in this file
 

--- a/yarn-project/circuits.js/src/contract/contract_instance.ts
+++ b/yarn-project/circuits.js/src/contract/contract_instance.ts
@@ -1,7 +1,11 @@
 import { ContractArtifact } from '@aztec/foundation/abi';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { Fr, Point } from '@aztec/foundation/fields';
 import { ContractInstance, ContractInstanceWithAddress } from '@aztec/types/contracts';
 
-import { EthAddress, Fr, Point, PublicKey, computeContractClassId, getContractClassFromArtifact } from '../index.js';
+import { getContractClassFromArtifact } from '../contract/contract_class.js';
+import { computeContractClassId } from '../contract/contract_class_id.js';
+import { PublicKey } from '../types/public_key.js';
 import {
   computeContractAddressFromInstance,
   computeInitializationHash,

--- a/yarn-project/circuits.js/src/structs/complete_address.ts
+++ b/yarn-project/circuits.js/src/structs/complete_address.ts
@@ -3,13 +3,10 @@ import { Fr, GrumpkinScalar, Point } from '@aztec/foundation/fields';
 import { BufferReader } from '@aztec/foundation/serialize';
 
 import { Grumpkin } from '../barretenberg/index.js';
-import {
-  GrumpkinPrivateKey,
-  PartialAddress,
-  PublicKey,
-  computeContractAddressFromPartial,
-  computePartialAddress,
-} from '../index.js';
+import { computeContractAddressFromPartial, computePartialAddress } from '../contract/contract_address.js';
+import { GrumpkinPrivateKey } from '../types/grumpkin_private_key.js';
+import { PartialAddress } from '../types/partial_address.js';
+import { PublicKey } from '../types/public_key.js';
 
 /**
  * A complete address is a combination of an Aztec address, a public key and a partial address.

--- a/yarn-project/circuits.js/src/structs/contract_deployment_data.ts
+++ b/yarn-project/circuits.js/src/structs/contract_deployment_data.ts
@@ -1,6 +1,8 @@
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { Fr, Point } from '@aztec/foundation/fields';
 import { BufferReader, FieldReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
-import { EthAddress, Fr, Point, PublicKey } from '../index.js';
+import { PublicKey } from '../types/public_key.js';
 
 /**
  * Contract deployment data in a TxContext

--- a/yarn-project/circuits.js/src/structs/kernel/previous_kernel_data.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/previous_kernel_data.ts
@@ -2,7 +2,7 @@ import { makeTuple } from '@aztec/foundation/array';
 import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, Tuple, serializeToBuffer } from '@aztec/foundation/serialize';
 
-import { VK_TREE_HEIGHT } from '../../index.js';
+import { VK_TREE_HEIGHT } from '../../constants.gen.js';
 import { Proof, makeEmptyProof } from '../proof.js';
 import { UInt32 } from '../shared.js';
 import { VerificationKey } from '../verification_key.js';

--- a/yarn-project/circuits.js/src/structs/private_circuit_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/private_circuit_public_inputs.ts
@@ -17,8 +17,10 @@ import {
   NUM_FIELDS_PER_SHA256,
   RETURN_VALUES_LENGTH,
 } from '../constants.gen.js';
+import { ContractDeploymentData } from '../structs/contract_deployment_data.js';
+import { Header } from '../structs/header.js';
+import { SideEffect, SideEffectLinkedToNoteHash } from '../structs/side_effects.js';
 import { CallContext } from './call_context.js';
-import { ContractDeploymentData, Header, SideEffect, SideEffectLinkedToNoteHash } from './index.js';
 import { NullifierKeyValidationRequest } from './nullifier_key_validation_request.js';
 
 /**

--- a/yarn-project/circuits.js/src/structs/public_call_request.ts
+++ b/yarn-project/circuits.js/src/structs/public_call_request.ts
@@ -1,18 +1,15 @@
+import { AztecAddress } from '@aztec/foundation/aztec-address';
+import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import { FieldsOf } from '@aztec/foundation/types';
 
 import { computeVarArgsHash } from '../abis/abis.js';
-import { CallerContext } from './call_request.js';
-import {
-  AztecAddress,
-  CallContext,
-  CallRequest,
-  Fr,
-  FunctionData,
-  PublicCallStackItem,
-  PublicCircuitPublicInputs,
-  Vector,
-} from './index.js';
+import { CallContext } from './call_context.js';
+import { CallRequest, CallerContext } from './call_request.js';
+import { FunctionData } from './function_data.js';
+import { PublicCallStackItem } from './public_call_stack_item.js';
+import { PublicCircuitPublicInputs } from './public_circuit_public_inputs.js';
+import { Vector } from './shared.js';
 
 /**
  * Represents a request to call a public function from a private function. Serialization is

--- a/yarn-project/circuits.js/src/structs/public_circuit_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/public_circuit_public_inputs.ts
@@ -18,13 +18,10 @@ import {
   RETURN_VALUES_LENGTH,
 } from '../constants.gen.js';
 import { CallContext } from './call_context.js';
-import {
-  ContractStorageRead,
-  ContractStorageUpdateRequest,
-  Header,
-  SideEffect,
-  SideEffectLinkedToNoteHash,
-} from './index.js';
+import { ContractStorageRead } from './contract_storage_read.js';
+import { ContractStorageUpdateRequest } from './contract_storage_update_request.js';
+import { Header } from './header.js';
+import { SideEffect, SideEffectLinkedToNoteHash } from './side_effects.js';
 
 /**
  * Public inputs to a public circuit.

--- a/yarn-project/circuits.js/src/structs/tx_context.ts
+++ b/yarn-project/circuits.js/src/structs/tx_context.ts
@@ -1,7 +1,8 @@
+import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import { FieldsOf } from '@aztec/foundation/types';
 
-import { ContractDeploymentData, Fr } from './index.js';
+import { ContractDeploymentData } from '../structs/contract_deployment_data.js';
 
 /**
  * Transaction context.

--- a/yarn-project/circuits.js/src/types/deployment_info.ts
+++ b/yarn-project/circuits.js/src/types/deployment_info.ts
@@ -1,4 +1,6 @@
-import { CompleteAddress, Fr } from '../index.js';
+import { Fr } from '@aztec/foundation/fields';
+
+import { CompleteAddress } from '../structs/complete_address.js';
 
 /**
  * Represents the data generated as part of contract deployment.

--- a/yarn-project/foundation/src/abi/selector.ts
+++ b/yarn-project/foundation/src/abi/selector.ts
@@ -1,10 +1,9 @@
-import { fromHex, toBigIntBE, toBufferBE } from '@aztec/foundation/bigint-buffer';
-import { BufferReader, FieldReader } from '@aztec/foundation/serialize';
-
 import { randomBytes } from 'crypto';
 
+import { fromHex, toBigIntBE, toBufferBE } from '../bigint-buffer/index.js';
 import { keccak } from '../crypto/keccak/index.js';
 import { Fr } from '../fields/index.js';
+import { BufferReader, FieldReader } from '../serialize/index.js';
 import { type ABIParameter } from './abi.js';
 import { decodeFunctionSignature } from './decoder.js';
 

--- a/yarn-project/foundation/src/array/array.ts
+++ b/yarn-project/foundation/src/array/array.ts
@@ -1,6 +1,6 @@
-import { Tuple } from '@aztec/foundation/serialize';
+import { Tuple } from '../serialize/index.js';
 
-export type { FieldsOf } from '@aztec/foundation/types';
+export type { FieldsOf } from '../types/index.js';
 
 /**
  * Create an array over an integer range.

--- a/yarn-project/foundation/src/serialize/free_funcs.ts
+++ b/yarn-project/foundation/src/serialize/free_funcs.ts
@@ -1,4 +1,4 @@
-import { Fr } from '@aztec/foundation/fields';
+import { Fr } from '../fields/fields.js';
 
 /**
  * Convert a boolean value to its corresponding byte representation in a Buffer of size 1.

--- a/yarn-project/foundation/src/serialize/serialize.ts
+++ b/yarn-project/foundation/src/serialize/serialize.ts
@@ -1,5 +1,4 @@
-import { toBigIntBE, toBufferBE } from '@aztec/foundation/bigint-buffer';
-
+import { toBigIntBE, toBufferBE } from '../bigint-buffer/index.js';
 import { Fr } from '../fields/fields.js';
 import { numToUInt32BE } from './free_funcs.js';
 


### PR DESCRIPTION
This PR fixes the circular imports in circuits.js, circuit-types, archiver and also rewrites imports in foundation to be consistent (there were a couple of instances of files in foundation that did `import { x } from '@aztec/foundation'`).
