### PR TITLE
chore: format l1-contracts after generating constants

### DIFF
--- a/l1-contracts/package.json
+++ b/l1-contracts/package.json
@@ -7,6 +7,7 @@
     "solhint": "https://github.com/LHerskind/solhint#master"
   },
   "scripts": {
+    "format": "./.foundry/bin/forge fmt",
     "lint": "solhint --config ./.solhint.json --fix \"src/**/*.sol\"",
     "slither": "forge clean && forge build --build-info --skip '*/test/**' --force && slither . --checklist --ignore-compile --show-ignored-findings --config-file ./slither.config.json | tee slither_output.md",
     "slither-has-diff": "./slither_has_diff.sh"

--- a/yarn-project/circuits.js/package.json
+++ b/yarn-project/circuits.js/package.json
@@ -26,7 +26,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "remake-constants": "node --loader ts-node/esm src/scripts/constants.in.ts && prettier -w src/constants.gen.ts",
+    "remake-constants": "node --loader ts-node/esm src/scripts/constants.in.ts && prettier -w src/constants.gen.ts && cd ../../l1-contracts && ./.foundry/bin/forge fmt",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"
   },
   "inherits": [


### PR DESCRIPTION
This makes it so that we don't need to run `forge fmt` manually after bootstrapping `yarn-project`