### PR TITLE
chore: publish kv store to npm

### DIFF
--- a/yarn-project/deploy_npm.sh
+++ b/yarn-project/deploy_npm.sh
@@ -99,3 +99,4 @@ deploy_package p2p
 deploy_package world-state
 deploy_package sequencer-client
 deploy_package aztec-node
+deploy_package kv-store


### PR DESCRIPTION
to help with using `@aztec/merkle-tree` for people using slow updates tree.

Later we can revisit internalising this package (as detailed in #4413)