### PR TITLE
fix(build-system): image expiring

### DIFF
--- a/build-system/scripts/ensure_repo
+++ b/build-system/scripts/ensure_repo
@@ -8,20 +8,17 @@ LIFECYCLE_POLICY='{
   "rules": [
     {
       "rulePriority": 1,
-      "description": "No more than 200 cache images.",
+      "description": "No more than 1000 images, regardless of tag status.",
       "selection": {
-        "tagStatus": "tagged",
-        "tagPrefixList": ["cache-"],
         "countType": "imageCountMoreThan",
-        "countNumber": 200
+        "countNumber": 1000
       },
       "action": {
         "type": "expire"
       }
     }
   ]
-}
-'
+}'
 
 REPOSITORY=$1
 REGION=$2

--- a/build-system/scripts/ensure_repo
+++ b/build-system/scripts/ensure_repo
@@ -10,6 +10,7 @@ LIFECYCLE_POLICY='{
       "rulePriority": 1,
       "description": "No more than 1000 images, regardless of tag status.",
       "selection": {
+        "tagStatus": "any",
         "countType": "imageCountMoreThan",
         "countNumber": 1000
       },


### PR DESCRIPTION
We used to tag a lot, but now actually we push a lot of unique images. We shouldn't stop at tagged images.