### PR TITLE
feat(avm-transpiler): implement tags for SET and others

### DIFF
--- a/avm-transpiler/src/instructions.rs
+++ b/avm-transpiler/src/instructions.rs
@@ -4,6 +4,7 @@ use std::fmt::{Debug, Formatter};
 use crate::opcodes::AvmOpcode;
 
 /// Common values of the indirect instruction flag
+pub const ALL_DIRECT: u8 = 0b00000000;
 pub const ZEROTH_OPERAND_INDIRECT: u8 = 0b00000001;
 pub const FIRST_OPERAND_INDIRECT: u8 = 0b00000010;
 pub const ZEROTH_FIRST_OPERANDS_INDIRECT: u8 = 0b00000011;
@@ -20,10 +21,9 @@ pub struct AvmInstruction {
     /// The 0th bit corresponds to an instruction's 0th offset arg, 1st to 1st, etc...
     pub indirect: Option<u8>,
 
-    /// Some instructions have a destination or input tag
-    // TODO(4271): add in_tag alongside its support in TS
-    //pub in_tag: Option<AvmTypeTag>,
-    pub dst_tag: Option<AvmTypeTag>,
+    /// Some instructions have a destination xor input tag
+    /// Its usage will depend on the instruction.
+    pub tag: Option<AvmTypeTag>,
 
     /// Different instructions have different numbers of operands
     pub operands: Vec<AvmOperand>,
@@ -35,9 +35,9 @@ impl Display for AvmInstruction {
         if let Some(indirect) = self.indirect {
             write!(f, ", indirect: {}", indirect)?;
         }
-        // TODO(4271): add in_tag alongside its support in TS
-        if let Some(dst_tag) = self.dst_tag {
-            write!(f, ", dst_tag: {}", dst_tag as u8)?;
+        // This will be either inTag or dstTag depending on the operation
+        if let Some(dst_tag) = self.tag {
+            write!(f, ", tag: {}", dst_tag as u8)?;
         }
         if !self.operands.is_empty() {
             write!(f, ", operands: [")?;
@@ -58,10 +58,9 @@ impl AvmInstruction {
         if let Some(indirect) = self.indirect {
             bytes.push(indirect);
         }
-        // TODO(4271): add in_tag alongside its support in TS
-        if let Some(dst_tag) = self.dst_tag {
-            // TODO(4271): make 8 bits when TS supports deserialization of 8 bit flags
-            bytes.extend_from_slice(&(dst_tag as u8).to_be_bytes());
+        // This will be either inTag or dstTag depending on the operation
+        if let Some(tag) = self.tag {
+            bytes.extend_from_slice(&(tag as u8).to_be_bytes());
         }
         for operand in &self.operands {
             bytes.extend_from_slice(&operand.to_be_bytes());
@@ -82,14 +81,14 @@ impl Default for AvmInstruction {
             opcode: AvmOpcode::ADD,
             // TODO(4266): default to Some(0), since all instructions have indirect flag except jumps
             indirect: None,
-            dst_tag: None,
+            tag: None,
             operands: vec![],
         }
     }
 }
 
 /// AVM instructions may include a type tag
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum AvmTypeTag {
     UNINITIALIZED,
     UINT8,
@@ -105,16 +104,20 @@ pub enum AvmTypeTag {
 /// Constants (as used by the SET instruction) can have size
 /// different from 32 bits
 pub enum AvmOperand {
+    U8 { value: u8 },
+    U16 { value: u16 },
     U32 { value: u32 },
-    // TODO(4267): Support operands of size other than 32 bits (for SET)
+    U64 { value: u64 },
     U128 { value: u128 },
 }
 
 impl Display for AvmOperand {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
+            AvmOperand::U8 { value } => write!(f, " U8:{}", value),
+            AvmOperand::U16 { value } => write!(f, " U16:{}", value),
             AvmOperand::U32 { value } => write!(f, " U32:{}", value),
-            // TODO(4267): Support operands of size other than 32 bits (for SET)
+            AvmOperand::U64 { value } => write!(f, " U64:{}", value),
             AvmOperand::U128 { value } => write!(f, " U128:{}", value),
         }
     }
@@ -123,8 +126,10 @@ impl Display for AvmOperand {
 impl AvmOperand {
     pub fn to_be_bytes(&self) -> Vec<u8> {
         match self {
+            AvmOperand::U8 { value } => value.to_be_bytes().to_vec(),
+            AvmOperand::U16 { value } => value.to_be_bytes().to_vec(),
             AvmOperand::U32 { value } => value.to_be_bytes().to_vec(),
-            // TODO(4267): Support operands of size other than 32 bits (for SET)
+            AvmOperand::U64 { value } => value.to_be_bytes().to_vec(),
             AvmOperand::U128 { value } => value.to_be_bytes().to_vec(),
         }
     }

--- a/avm-transpiler/src/utils.rs
+++ b/avm-transpiler/src/utils.rs
@@ -11,7 +11,7 @@ use crate::instructions::AvmInstruction;
 /// assuming the 0th ACIR opcode is the wrapper.
 pub fn extract_brillig_from_acir(opcodes: &Vec<Opcode>) -> &Brillig {
     if opcodes.len() != 1 {
-        panic!("There should only be one brillig opcode");
+        panic!("An AVM program should be contained entirely in only a single ACIR opcode flagged as 'Brillig'");
     }
     let opcode = &opcodes[0];
     match opcode {

--- a/yarn-project/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/yarn-project/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -16,6 +16,41 @@ contract AvmTest {
         argA + argB
     }
 
+    #[aztec(public-vm)]
+    fn setOpcodeUint8() -> pub u8 {
+        8 as u8
+    }
+
+    // Bit size 16 in Noir is deprecated.
+    // #[aztec(public-vm)]
+    // fn setOpcodeUint16() -> pub u16 {
+    //     60000 as u16
+    // }
+
+    #[aztec(public-vm)]
+    fn setOpcodeUint32() -> pub u32 {
+        1 << 30 as u32
+    }
+
+    #[aztec(public-vm)]
+    fn setOpcodeUint64() -> pub u64 {
+        1 << 60 as u64
+    }
+
+    // Can't return this since it doesn't fit in a Noir field.
+    // #[aztec(public-vm)]
+    // fn setOpcodeUint128() -> pub u128 {
+    //     1 << 120 as u128
+    // }
+
+    // Field should fit in 128 bits
+    // ACIR only supports fields of up to 126 bits!
+    // Same with internal fields for unconstrained functions, apprently.
+    #[aztec(public-vm)]
+    fn setOpcodeSmallField() -> pub Field {
+        200 as Field
+    }
+
     /************************************************************************
      * AvmContext functions
      ************************************************************************/

--- a/yarn-project/simulator/src/avm/avm_memory_types.ts
+++ b/yarn-project/simulator/src/avm/avm_memory_types.ts
@@ -335,7 +335,7 @@ export class TaggedMemory {
 
   // Truncates the value to fit the type.
   public static integralFromTag(v: bigint | number, tag: TypeTag): IntegralValue {
-    v = v as bigint;
+    v = BigInt(v);
     switch (tag) {
       case TypeTag.UINT8:
         return new Uint8(v & ((1n << 8n) - 1n));


### PR DESCRIPTION
Generates tags for
* `BinaryFieldOp`
* `BinaryIntOp`
* `Const` (SET on the AVM)
* CAST on the AVM

Gotcha (1): Brillig seems to only support fields of <= 126 bits. We now support CONST of a field (Brillig) and transpile it to a `SET<u128>` + `CAST<field>`.

It's very difficult to test this e2e in the `avm_test` contract since Noir does a lot of optimizations. Moreover, Noir currently generates code that compares different bit sizes and uses unsupported bit sizes.

As an example
```
#[aztec(public-vm)]
fn setOpcodeUint64() -> pub u64 {
    1 << 60 as u64
}
```

produces (using `nargo compile --package avm_test_contract --show-ssa --print-acir`)

```
Compiled ACIR for AvmTest::avm_setOpcodeUint64 (unoptimized):
current witness index : 0
public parameters indices : []
return value indices : [0]
BRILLIG: inputs: []
outputs: [Simple(Witness(0))]
[Const { destination: MemoryAddress(0), bit_size: 32, value: Value { inner: 1025 } }, CalldataCopy { destination_address: MemoryAddress(1024), size: 0, offset: 0 }, Call { location: 5 }, Mov { destination: MemoryAddress(1024), source: MemoryAddress(2) }, Stop { return_data_offset: 1024, return_data_size: 1 }, Const { destination: MemoryAddress(2), bit_size: 64, value: Value { inner: 2⁶⁰ } }, Mov { destination: MemoryAddress(3), source: MemoryAddress(2) }, Mov { destination: MemoryAddress(2), source: MemoryAddress(3) }, Return]

Initial SSA:
brillig fn avm_setOpcodeUint64 f0 {
  b0():
    call f1()
    return u64 2⁶⁰
}

...
After Dead Instruction Elimination:
brillig fn avm_setOpcodeUint64 f0 {
  b0():
    return u64 2⁶⁰
}
```

Closes #4268.