### PR TITLE
fix: mirror_noir_subrepo.yml

### DIFF
--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -33,13 +33,13 @@ jobs:
           # Enable gh executable. We spread out the API requests between the github actions bot token, and aztecbot
           export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
           # Do we have a PR active?
-          PR_URL=$(gh pr list --repo noir-lang/noir --head aztec-test-sync --json url --jq ".[0].url")
+          PR_URL=$(gh pr list --repo noir-lang/noir --head aztec-packages --json url --jq ".[0].url")
           echo "PR_URL=$PR_URL" >> $GITHUB_ENV
 
           # compute_commit_message: Create a filtered git log for release-please changelog / metadata
           function compute_commit_message() {
             # Get the last sync PR's last commit state
-            LAST_MERGED_PR_HASH=`gh pr list --repo=noir-lang/noir --state merged --head aztec-test-sync --json headRefOid --jq=.[0].headRefOid`
+            LAST_MERGED_PR_HASH=`gh pr list --repo=noir-lang/noir --state merged --head aztec-packages --json headRefOid --jq=.[0].headRefOid`
             # Use a commit heuristic where we look at when .gitrepo first started to look at that commit state (through a push)
             COMMIT_HEURISTIC=$(git log -p -S"$LAST_MERGED_PR_HASH" --reverse --source --  noir/.gitrepo | grep -m 1 '^commit'  | awk '{print $2}' || true)
             BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
@@ -50,7 +50,7 @@ jobs:
             # Create a filtered git log for release-please changelog / metadata
             RAW_MESSAGE=$(git log --pretty=format:"%s" $COMMIT_HEURISTIC..HEAD -- noir/  ':!noir/.gitrepo' | grep -v 'git subrepo' || true)
             # Fix Aztec PR links and output message
-            echo "$RAW_MESSAGE" | sed -E 's/\(#([0-9]+)\)/(https:\/\/github.com\/AztecProtocol\/aztec-test-sync\/pull\/\1)/g'
+            echo "$RAW_MESSAGE" | sed -E 's/\(#([0-9]+)\)/(https:\/\/github.com\/AztecProtocol\/aztec-packages\/pull\/\1)/g'
           }
           echo "$(compute_commit_message)" >> .COMMIT_MESSAGE
 
@@ -62,7 +62,7 @@ jobs:
           # Enable gh executable. We spread out the API requests between the github actions bot token, and aztecbot
           export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
           SUBREPO_PATH=noir
-          BRANCH=aztec-test-sync
+          BRANCH=aztec-packages
           if [[ "$PR_URL" == "" ]]; then
             # if no staging branch, we can overwrite
             STAGING_BRANCH=$BRANCH
@@ -79,7 +79,7 @@ jobs:
           # clone noir repo for manipulations, we use aztec bot token for writeability
           git clone https://x-access-token:${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}@github.com/noir-lang/noir.git noir-repo
 
-          # reset_pr: Reset aztec-test-sync staging. If no PR, this is the PR branch.
+          # reset_pr: Reset aztec-packages staging. If no PR, this is the PR branch.
           function reset_noir_staging_branch() {
             cd noir-repo
             git checkout $STAGING_BRANCH || git checkout -b $STAGING_BRANCH
@@ -88,7 +88,7 @@ jobs:
             git push origin $STAGING_BRANCH --force
             cd ..
           }
-          # force_sync_staging: Push to our aztec-test-sync staging branch.
+          # force_sync_staging: Push to our aztec-packages staging branch.
           function force_sync_staging() {
             MESSAGE=$(cat .COMMIT_MESSAGE)
             git commit --allow-empty -m"chore: Sync to noir-lang/noir" -m"$MESSAGE"
@@ -103,7 +103,7 @@ jobs:
               exit 1
             fi
           }
-          # merge_staging_branch: Merge our staging branch into aztec-test-sync.
+          # merge_staging_branch: Merge our staging branch into aztec-packages.
           function merge_staging_branch() {
             # Fix PR branch
             cd noir-repo
@@ -130,7 +130,7 @@ jobs:
           # for cross-opening PR in noir repo, we use aztecbot's token
           export GH_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           if [[ "$PR_URL" == "" ]]; then
-            gh pr create --repo noir-lang/noir --title "feat: Sync from aztec-test-sync" --body "$PR_BODY" --base master --head aztec-test-sync
+            gh pr create --repo noir-lang/noir --title "feat: Sync from aztec-packages" --body "$PR_BODY" --base master --head aztec-packages
           else
             gh pr edit "$PR_URL" --body "$PR_BODY"
           fi

--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -33,13 +33,13 @@ jobs:
           # Enable gh executable. We spread out the API requests between the github actions bot token, and aztecbot
           export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
           # Do we have a PR active?
-          PR_URL=$(gh pr list --repo noir-lang/noir --head aztec-packages --json url --jq ".[0].url")
+          PR_URL=$(gh pr list --repo noir-lang/noir --head aztec-test-sync --json url --jq ".[0].url")
           echo "PR_URL=$PR_URL" >> $GITHUB_ENV
 
           # compute_commit_message: Create a filtered git log for release-please changelog / metadata
           function compute_commit_message() {
             # Get the last sync PR's last commit state
-            LAST_MERGED_PR_HASH=`gh pr list --repo=noir-lang/noir --state merged --head aztec-packages --json headRefOid --jq=.[0].headRefOid`
+            LAST_MERGED_PR_HASH=`gh pr list --repo=noir-lang/noir --state merged --head aztec-test-sync --json headRefOid --jq=.[0].headRefOid`
             # Use a commit heuristic where we look at when .gitrepo first started to look at that commit state (through a push)
             COMMIT_HEURISTIC=$(git log -p -S"$LAST_MERGED_PR_HASH" --reverse --source --  noir/.gitrepo | grep -m 1 '^commit'  | awk '{print $2}' || true)
             if [[ "$COMMIT_HEURISTIC" = "" ]] ; then
@@ -49,7 +49,7 @@ jobs:
             # Create a filtered git log for release-please changelog / metadata
             RAW_MESSAGE=$(git log --pretty=format:"%s" $COMMIT_HEURISTIC..HEAD -- noir/  ':!noir/.gitrepo' | grep -v 'git subrepo' || true)
             # Fix Aztec PR links and output message
-            echo "$RAW_MESSAGE" | sed -E 's/\(#([0-9]+)\)/(https:\/\/github.com\/AztecProtocol\/aztec-packages\/pull\/\1)/g'
+            echo "$RAW_MESSAGE" | sed -E 's/\(#([0-9]+)\)/(https:\/\/github.com\/AztecProtocol\/aztec-test-sync\/pull\/\1)/g'
           }
           echo "$(compute_commit_message)" >> .COMMIT_MESSAGE
 
@@ -61,7 +61,7 @@ jobs:
           # Enable gh executable. We spread out the API requests between the github actions bot token, and aztecbot
           export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
           SUBREPO_PATH=noir
-          BRANCH=aztec-packages
+          BRANCH=aztec-test-sync
           if [[ "$PR_URL" == "" ]]; then
             # if no staging branch, we can overwrite
             STAGING_BRANCH=$BRANCH
@@ -78,7 +78,7 @@ jobs:
           # clone noir repo for manipulations, we use aztec bot token for writeability
           git clone https://x-access-token:${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}@github.com/noir-lang/noir.git noir-repo
 
-          # reset_pr: Reset aztec-packages staging. If no PR, this is the PR branch.
+          # reset_pr: Reset aztec-test-sync staging. If no PR, this is the PR branch.
           function reset_noir_staging_branch() {
             cd noir-repo
             git checkout $STAGING_BRANCH || git checkout -b $STAGING_BRANCH
@@ -87,7 +87,7 @@ jobs:
             git push origin $STAGING_BRANCH --force
             cd ..
           }
-          # force_sync_staging: Push to our aztec-packages staging branch.
+          # force_sync_staging: Push to our aztec-test-sync staging branch.
           function force_sync_staging() {
             MESSAGE=$(cat .COMMIT_MESSAGE)
             git commit --allow-empty -m"chore: Sync to noir-lang/noir" -m"$MESSAGE"
@@ -102,7 +102,7 @@ jobs:
               exit 1
             fi
           }
-          # merge_staging_branch: Merge our staging branch into aztec-packages.
+          # merge_staging_branch: Merge our staging branch into aztec-test-sync.
           function merge_staging_branch() {
             # Fix PR branch
             cd noir-repo
@@ -129,7 +129,7 @@ jobs:
           # for cross-opening PR in noir repo, we use aztecbot's token
           export GH_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           if [[ "$PR_URL" == "" ]]; then
-            gh pr create --repo noir-lang/noir --title "feat: Sync from aztec-packages" --body "$PR_BODY" --base master --head aztec-packages
+            gh pr create --repo noir-lang/noir --title "feat: Sync from aztec-test-sync" --body "$PR_BODY" --base master --head aztec-test-sync
           else
             gh pr edit "$PR_URL" --body "$PR_BODY"
           fi

--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -21,24 +21,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get noir master's last sync commit
-        id: last_merge_hash
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // NOTE: more robust heuristic needed if aztecbot opens different kinds of PRs
-            const response = await github.rest.search.commits({
-              q: 'author:AztecBot committer:web-flow repo:noir-lang/noir sort:committer-date'
-            });
-            console.log(response.data.items);
-            return response.data.items[0].sha;
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-
 
       - name: Setup env
         run: |
@@ -55,7 +42,7 @@ jobs:
             LAST_MERGED_PR_HASH=`gh pr list --repo=noir-lang/noir --state merged --head aztec-packages --json headRefOid --jq=.[0].headRefOid`
             # Use a commit heuristic where we look at when .gitrepo first started to look at that commit state (through a push)
             COMMIT_HEURISTIC=$(git log -p -S"$LAST_MERGED_PR_HASH" --reverse --source --  noir/.gitrepo | grep -m 1 '^commit'  | awk '{print $2}' || true)
-            if [[ " $COMMIT_HEURISTIC" = "" ]] ; then
+            if [[ "$COMMIT_HEURISTIC" = "" ]] ; then
               # It it fails, just use our gitrepo parent commit (last time we pushed or pulled)
               COMMIT_HEURISTIC=$BASE_AZTEC_COMMIT
             fi

--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -42,6 +42,7 @@ jobs:
             LAST_MERGED_PR_HASH=`gh pr list --repo=noir-lang/noir --state merged --head aztec-test-sync --json headRefOid --jq=.[0].headRefOid`
             # Use a commit heuristic where we look at when .gitrepo first started to look at that commit state (through a push)
             COMMIT_HEURISTIC=$(git log -p -S"$LAST_MERGED_PR_HASH" --reverse --source --  noir/.gitrepo | grep -m 1 '^commit'  | awk '{print $2}' || true)
+            BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
             if [[ "$COMMIT_HEURISTIC" = "" ]] ; then
               # It it fails, just use our gitrepo parent commit (last time we pushed or pulled)
               COMMIT_HEURISTIC=$BASE_AZTEC_COMMIT

--- a/noir/.gitrepo
+++ b/noir/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/noir-lang/noir
-	branch = aztec-test-sync
-	commit = be6ae018e484621f7a0743df5951f8ef0a45af98
-	parent = ac87124e8fbb756cc34180a174011e33bfe19217
+	branch = aztec-packages
+	commit = 6ff518af281afe601edb8574d425b07d9d2f9c5d
+	parent = 2082fedfb03d4882a269881f51c5337263bc539b
 	method = merge
 	cmdver = 0.4.6

--- a/noir/.gitrepo
+++ b/noir/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/noir-lang/noir
-	branch = aztec-packages
-	commit = 6ff518af281afe601edb8574d425b07d9d2f9c5d
-	parent = 2082fedfb03d4882a269881f51c5337263bc539b
+	branch = aztec-test-sync
+	commit = be6ae018e484621f7a0743df5951f8ef0a45af98
+	parent = ac87124e8fbb756cc34180a174011e33bfe19217
 	method = merge
 	cmdver = 0.4.6


### PR DESCRIPTION
- accidentally unused step removed
- fixes blank space typo preventing this check from kicking in
