### PR TITLE
fix(noir-mirror): don't update .gitrepo on push 

### DIFF
--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
 
-      - name: Clone noir:
+      - name: Clone noir
         run: |
           # clone noir repo for manipulations, we use aztec bot token for writeability
           git clone https://x-access-token:${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}@github.com/noir-lang/noir.git noir-repo

--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -45,7 +45,7 @@ jobs:
             BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
             if [[ "$COMMIT_HEURISTIC" = "" ]] ; then
               # If that doesn't work, look for the last 'method = pull' commit
-              COMMIT_HEURISTIC=$(git log -p -S"method = pull" --reverse --source -- noir/.gitrepo | grep -m 1 '^commit' | awk '{print $2}' || true)
+              COMMIT_HEURISTIC=$(git log -p -S"method = pull" --source -- noir/.gitrepo | grep -m 1 '^commit' | awk '{print $2}' || true)
             fi
             if [[ "$COMMIT_HEURISTIC" = "" ]] ; then
               # It it fails, just use our gitrepo parent commit (last time we pushed or pulled)

--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -41,9 +41,13 @@ jobs:
             # Get the last sync PR's last commit state
             LAST_MERGED_PR_HASH=`gh pr list --repo=noir-lang/noir --state merged --head aztec-packages --json headRefOid --jq=.[0].headRefOid`
             # Use a commit heuristic where we look at when .gitrepo first started to look at that commit state (through a push)
-            COMMIT_HEURISTIC=$(git log -p -S"$LAST_MERGED_PR_HASH" --reverse --source --  noir/.gitrepo | grep -m 1 '^commit'  | awk '{print $2}' || true)
+            COMMIT_HEURISTIC=$(git log -p -S"$LAST_MERGED_PR_HASH" --reverse --source -- noir/.gitrepo | grep -m 1 '^commit' | awk '{print $2}' || true)
             BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
-            if [[ "$COMMIT_HEURISTIC" = "" ]] ; then
+            if [[ " $COMMIT_HEURISTIC" = "" ]] ; then
+              # If that doesn't work, look for the last 'method = pull' commit
+              COMMIT_HEURISTIC=$(git log -p -S"method = pull" --reverse --source -- noir/.gitrepo | grep -m 1 '^commit' | awk '{print $2}' || true)
+            fi
+            if [[ " $COMMIT_HEURISTIC" = "" ]] ; then
               # It it fails, just use our gitrepo parent commit (last time we pushed or pulled)
               COMMIT_HEURISTIC=$BASE_AZTEC_COMMIT
             fi

--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -27,6 +27,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
 
+      - name: Clone noir:
+        run: |
+          # clone noir repo for manipulations, we use aztec bot token for writeability
+          git clone https://x-access-token:${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}@github.com/noir-lang/noir.git noir-repo
+
       - name: Setup env
         run: |
           set -xue # print commands
@@ -43,7 +48,7 @@ jobs:
             # Use a commit heuristic where we look at when .gitrepo first started to look at that commit state (through a push)
             for i in {0..10}; do
               # Search backwards for 10 commits in case some commits got in the last PR without syncing to aztec
-              HASH=`git rev-parse $LAST_MERGED_PR_HASH~$i`
+              HASH=`cd noir && git rev-parse $LAST_MERGED_PR_HASH~$i`
               COMMIT_HEURISTIC=$(git log -p -S"$HASH" --reverse --source -- noir/.gitrepo | grep -m 1 '^commit' | awk '{print $2}' || true)
               BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
               if [[ "$COMMIT_HEURISTIC" != "" ]] ; then
@@ -61,83 +66,80 @@ jobs:
           }
           echo "$(compute_commit_message)" >> .COMMIT_MESSAGE
 
-      # # We push using git subrepo (https://github.com/ingydotnet/git-subrepo)
-      # # and push all Aztec commits as a single commit with metadata.
-      # - name: Push to branch
-      #   run: |
-      #     set -xue # print commands
-      #     # Enable gh executable. We spread out the API requests between the github actions bot token, and aztecbot
-      #     export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
-      #     SUBREPO_PATH=noir
-      #     BRANCH=aztec-sync-test
-      #     if [[ "$PR_URL" == "" ]]; then
-      #       # if no staging branch, we can overwrite
-      #       STAGING_BRANCH=$BRANCH
-      #     else 
-      #       # otherwise we first reset our staging branch
-      #       STAGING_BRANCH=$BRANCH-staging
-      #     fi
-      #     # identify ourselves, needed to commit
-      #     git config --global user.name AztecBot
-      #     git config --global user.email tech@aztecprotocol.com
-      #     BASE_NOIR_COMMIT=`git config --file=noir/.gitrepo subrepo.commit`
-      #     BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
+      # We push using git subrepo (https://github.com/ingydotnet/git-subrepo)
+      # and push all Aztec commits as a single commit with metadata.
+      - name: Push to branch
+        run: |
+          set -xue # print commands
+          # Enable gh executable. We spread out the API requests between the github actions bot token, and aztecbot
+          export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          SUBREPO_PATH=noir
+          BRANCH=aztec-sync-test
+          if [[ "$PR_URL" == "" ]]; then
+            # if no staging branch, we can overwrite
+            STAGING_BRANCH=$BRANCH
+          else 
+            # otherwise we first reset our staging branch
+            STAGING_BRANCH=$BRANCH-staging
+          fi
+          # identify ourselves, needed to commit
+          git config --global user.name AztecBot
+          git config --global user.email tech@aztecprotocol.com
+          BASE_NOIR_COMMIT=`git config --file=noir/.gitrepo subrepo.commit`
+          BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
 
-      #     # clone noir repo for manipulations, we use aztec bot token for writeability
-      #     git clone https://x-access-token:${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}@github.com/noir-lang/noir.git noir-repo
+          # reset_pr: Reset aztec-sync-test staging. If no PR, this is the PR branch.
+          function reset_noir_staging_branch() {
+            cd noir-repo
+            git checkout $STAGING_BRANCH || git checkout -b $STAGING_BRANCH
+            git reset --hard "$BASE_NOIR_COMMIT"
+            # Reset our branch to our expected target
+            git push origin $STAGING_BRANCH --force
+            cd ..
+          }
+          # force_sync_staging: Push to our aztec-sync-test staging branch.
+          function force_sync_staging() {
+            MESSAGE=$(cat .COMMIT_MESSAGE)
+            git commit --allow-empty -m"chore: Sync to noir-lang/noir" -m"$MESSAGE"
+            COMMIT=$(git rev-parse HEAD)
+            # Now push to it with subrepo with computed commit messages
+            if ./scripts/git-subrepo/lib/git-subrepo push $SUBREPO_PATH --squash --branch=$STAGING_BRANCH; then
+              git reset $COMMIT
+              git commit --allow-empty --amend -am "$(git log -1 --pretty=%B) [skip ci]"
+              git push
+            else
+              echo "Problems syncing noir. We may need to pull the subrepo."
+              exit 1
+            fi
+          }
+          # merge_staging_branch: Merge our staging branch into aztec-sync-test.
+          function merge_staging_branch() {
+            # Fix PR branch
+            cd noir-repo
+            git fetch # see recent change
+            git checkout $BRANCH || git checkout -b $BRANCH
+            git merge -Xtheirs $STAGING_BRANCH
+            git push origin $BRANCH
+            cd ..
+          }
+          reset_noir_staging_branch
+          force_sync_staging
+          if [[ "$PR_URL" != "" ]]; then
+            merge_staging_branch
+          fi
 
-      #     # reset_pr: Reset aztec-sync-test staging. If no PR, this is the PR branch.
-      #     function reset_noir_staging_branch() {
-      #       cd noir-repo
-      #       git checkout $STAGING_BRANCH || git checkout -b $STAGING_BRANCH
-      #       git reset --hard "$BASE_NOIR_COMMIT"
-      #       # Reset our branch to our expected target
-      #       git push origin $STAGING_BRANCH --force
-      #       cd ..
-      #     }
-      #     # force_sync_staging: Push to our aztec-sync-test staging branch.
-      #     function force_sync_staging() {
-      #       MESSAGE=$(cat .COMMIT_MESSAGE)
-      #       git commit --allow-empty -m"chore: Sync to noir-lang/noir" -m"$MESSAGE"
-      #       COMMIT=$(git rev-parse HEAD)
-      #       # Now push to it with subrepo with computed commit messages
-      #       if ./scripts/git-subrepo/lib/git-subrepo push $SUBREPO_PATH --squash --branch=$STAGING_BRANCH; then
-      #         git reset $COMMIT
-      #         git commit --allow-empty --amend -am "$(git log -1 --pretty=%B) [skip ci]"
-      #         git push
-      #       else
-      #         echo "Problems syncing noir. We may need to pull the subrepo."
-      #         exit 1
-      #       fi
-      #     }
-      #     # merge_staging_branch: Merge our staging branch into aztec-sync-test.
-      #     function merge_staging_branch() {
-      #       # Fix PR branch
-      #       cd noir-repo
-      #       git fetch # see recent change
-      #       git checkout $BRANCH || git checkout -b $BRANCH
-      #       git merge -Xtheirs $STAGING_BRANCH
-      #       git push origin $BRANCH
-      #       cd ..
-      #     }
-      #     reset_noir_staging_branch
-      #     force_sync_staging
-      #     if [[ "$PR_URL" != "" ]]; then
-      #       merge_staging_branch
-      #     fi
-
-      # - name: Update PR
-      #   run: |
-      #     set -xue # print commands
-      #     MESSAGE=$(cat .COMMIT_MESSAGE)
-      #     # Formatted for updating the PR, overrides for release-please commit message parsing 
-      #     PR_BODY="""BEGIN_COMMIT_OVERRIDE
-      #     $MESSAGE
-      #     END_COMMIT_OVERRIDE"""
-      #     # for cross-opening PR in noir repo, we use aztecbot's token
-      #     export GH_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-      #     if [[ "$PR_URL" == "" ]]; then
-      #       gh pr create --repo noir-lang/noir --title "feat: Sync from aztec-sync-test" --body "$PR_BODY" --base master --head aztec-sync-test
-      #     else
-      #       gh pr edit "$PR_URL" --body "$PR_BODY"
-      #     fi
+      - name: Update PR
+        run: |
+          set -xue # print commands
+          MESSAGE=$(cat .COMMIT_MESSAGE)
+          # Formatted for updating the PR, overrides for release-please commit message parsing 
+          PR_BODY="""BEGIN_COMMIT_OVERRIDE
+          $MESSAGE
+          END_COMMIT_OVERRIDE"""
+          # for cross-opening PR in noir repo, we use aztecbot's token
+          export GH_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+          if [[ "$PR_URL" == "" ]]; then
+            gh pr create --repo noir-lang/noir --title "feat: Sync from aztec-sync-test" --body "$PR_BODY" --base master --head aztec-sync-test
+          else
+            gh pr edit "$PR_URL" --body "$PR_BODY"
+          fi

--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -41,12 +41,15 @@ jobs:
             # Get the last sync PR's last commit state
             LAST_MERGED_PR_HASH=`gh pr list --repo=noir-lang/noir --state merged --head aztec-sync-test --json headRefOid --jq=.[0].headRefOid`
             # Use a commit heuristic where we look at when .gitrepo first started to look at that commit state (through a push)
-            COMMIT_HEURISTIC=$(git log -p -S"$LAST_MERGED_PR_HASH" --reverse --source -- noir/.gitrepo | grep -m 1 '^commit' | awk '{print $2}' || true)
-            BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
-            if [[ "$COMMIT_HEURISTIC" = "" ]] ; then
-              # If that doesn't work, look for the last 'method = pull' commit
-              COMMIT_HEURISTIC=$(git log -p -S"method = pull" --source -- noir/.gitrepo | grep -m 1 '^commit' | awk '{print $2}' || true)
-            fi
+            for i in {0..10}; do
+              # Search backwards for 10 commits in case some commits got in the last PR without syncing to aztec
+              HASH=`git rev-parse $LAST_MERGED_PR_HASH~$i`
+              COMMIT_HEURISTIC=$(git log -p -S"$HASH" --reverse --source -- noir/.gitrepo | grep -m 1 '^commit' | awk '{print $2}' || true)
+              BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
+              if [[ "$COMMIT_HEURISTIC" != "" ]] ; then
+                break
+              fi
+            done
             if [[ "$COMMIT_HEURISTIC" = "" ]] ; then
               # It it fails, just use our gitrepo parent commit (last time we pushed or pulled)
               COMMIT_HEURISTIC=$BASE_AZTEC_COMMIT

--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -27,18 +27,13 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
 
-      - name: Clone noir
-        run: |
-          # clone noir repo for manipulations, we use aztec bot token for writeability
-          git clone https://x-access-token:${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}@github.com/noir-lang/noir.git noir-repo
-
       - name: Setup env
         run: |
           set -xue # print commands
           # Enable gh executable. We spread out the API requests between the github actions bot token, and aztecbot
           export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
           # Do we have a PR active?
-          PR_URL=$(gh pr list --repo noir-lang/noir --head aztec-sync-test --json url --jq ".[0].url")
+          PR_URL=$(gh pr list --repo noir-lang/noir --head aztec-packages --json url --jq ".[0].url")
           echo "PR_URL=$PR_URL" >> $GITHUB_ENV
 
           # compute_commit_message: Create a filtered git log for release-please changelog / metadata
@@ -46,15 +41,8 @@ jobs:
             # Get the last sync PR's last commit state
             LAST_MERGED_PR_HASH=`gh pr list --repo=noir-lang/noir --state merged --head aztec-packages --json headRefOid --jq=.[0].headRefOid`
             # Use a commit heuristic where we look at when .gitrepo first started to look at that commit state (through a push)
-            for i in {0..10}; do
-              # Search backwards for 10 commits in case some commits got in the last PR without syncing to aztec
-              HASH=`cd noir && git rev-parse $LAST_MERGED_PR_HASH~$i`
-              COMMIT_HEURISTIC=$(git log -p -S"$HASH" --reverse --source -- noir/.gitrepo | grep -m 1 '^commit' | awk '{print $2}' || true)
-              BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
-              if [[ "$COMMIT_HEURISTIC" != "" ]] ; then
-                break
-              fi
-            done
+            COMMIT_HEURISTIC=$(git log -p -S"$LAST_MERGED_PR_HASH" --reverse --source --  noir/.gitrepo | grep -m 1 '^commit'  | awk '{print $2}' || true)
+            BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
             if [[ "$COMMIT_HEURISTIC" = "" ]] ; then
               # It it fails, just use our gitrepo parent commit (last time we pushed or pulled)
               COMMIT_HEURISTIC=$BASE_AZTEC_COMMIT
@@ -62,7 +50,7 @@ jobs:
             # Create a filtered git log for release-please changelog / metadata
             RAW_MESSAGE=$(git log --pretty=format:"%s" $COMMIT_HEURISTIC..HEAD -- noir/  ':!noir/.gitrepo' | grep -v 'git subrepo' || true)
             # Fix Aztec PR links and output message
-            echo "$RAW_MESSAGE" | sed -E 's/\(#([0-9]+)\)/(https:\/\/github.com\/AztecProtocol\/aztec-sync-test\/pull\/\1)/g'
+            echo "$RAW_MESSAGE" | sed -E 's/\(#([0-9]+)\)/(https:\/\/github.com\/AztecProtocol\/aztec-packages\/pull\/\1)/g'
           }
           echo "$(compute_commit_message)" >> .COMMIT_MESSAGE
 
@@ -74,7 +62,7 @@ jobs:
           # Enable gh executable. We spread out the API requests between the github actions bot token, and aztecbot
           export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
           SUBREPO_PATH=noir
-          BRANCH=aztec-sync-test
+          BRANCH=aztec-packages
           if [[ "$PR_URL" == "" ]]; then
             # if no staging branch, we can overwrite
             STAGING_BRANCH=$BRANCH
@@ -88,7 +76,10 @@ jobs:
           BASE_NOIR_COMMIT=`git config --file=noir/.gitrepo subrepo.commit`
           BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
 
-          # reset_pr: Reset aztec-sync-test staging. If no PR, this is the PR branch.
+          # clone noir repo for manipulations, we use aztec bot token for writeability
+          git clone https://x-access-token:${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}@github.com/noir-lang/noir.git noir-repo
+
+          # reset_pr: Reset aztec-packages staging. If no PR, this is the PR branch.
           function reset_noir_staging_branch() {
             cd noir-repo
             git checkout $STAGING_BRANCH || git checkout -b $STAGING_BRANCH
@@ -97,22 +88,21 @@ jobs:
             git push origin $STAGING_BRANCH --force
             cd ..
           }
-          # force_sync_staging: Push to our aztec-sync-test staging branch.
+          # force_sync_staging: Push to our aztec-packages staging branch.
           function force_sync_staging() {
             MESSAGE=$(cat .COMMIT_MESSAGE)
             git commit --allow-empty -m"chore: Sync to noir-lang/noir" -m"$MESSAGE"
             COMMIT=$(git rev-parse HEAD)
             # Now push to it with subrepo with computed commit messages
             if ./scripts/git-subrepo/lib/git-subrepo push $SUBREPO_PATH --squash --branch=$STAGING_BRANCH; then
+              # We don't push a commit to aztec anymore so that we can maintain the 'commit' as our last pull branch
               git reset $COMMIT
-              git commit --allow-empty --amend -am "$(git log -1 --pretty=%B) [skip ci]"
-              git push
             else
               echo "Problems syncing noir. We may need to pull the subrepo."
               exit 1
             fi
           }
-          # merge_staging_branch: Merge our staging branch into aztec-sync-test.
+          # merge_staging_branch: Merge our staging branch into aztec-packages.
           function merge_staging_branch() {
             # Fix PR branch
             cd noir-repo
@@ -139,7 +129,7 @@ jobs:
           # for cross-opening PR in noir repo, we use aztecbot's token
           export GH_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           if [[ "$PR_URL" == "" ]]; then
-            gh pr create --repo noir-lang/noir --title "feat: Sync from aztec-sync-test" --body "$PR_BODY" --base master --head aztec-sync-test
+            gh pr create --repo noir-lang/noir --title "feat: Sync from aztec-packages" --body "$PR_BODY" --base master --head aztec-packages
           else
             gh pr edit "$PR_URL" --body "$PR_BODY"
           fi

--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -39,7 +39,7 @@ jobs:
           # compute_commit_message: Create a filtered git log for release-please changelog / metadata
           function compute_commit_message() {
             # Get the last sync PR's last commit state
-            LAST_MERGED_PR_HASH=`gh pr list --repo=noir-lang/noir --state merged --head aztec-sync-test --json headRefOid --jq=.[0].headRefOid`
+            LAST_MERGED_PR_HASH=`gh pr list --repo=noir-lang/noir --state merged --head aztec-packages --json headRefOid --jq=.[0].headRefOid`
             # Use a commit heuristic where we look at when .gitrepo first started to look at that commit state (through a push)
             for i in {0..10}; do
               # Search backwards for 10 commits in case some commits got in the last PR without syncing to aztec

--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -108,7 +108,7 @@ jobs:
             cd noir-repo
             git fetch # see recent change
             git checkout $BRANCH || git checkout -b $BRANCH
-            git merge -Xtheirs $STAGING_BRANCH
+            git merge -Xtheirs origin/$STAGING_BRANCH
             git push origin $BRANCH
             cd ..
           }

--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -33,13 +33,13 @@ jobs:
           # Enable gh executable. We spread out the API requests between the github actions bot token, and aztecbot
           export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
           # Do we have a PR active?
-          PR_URL=$(gh pr list --repo noir-lang/noir --head aztec-packages --json url --jq ".[0].url")
+          PR_URL=$(gh pr list --repo noir-lang/noir --head aztec-sync-test --json url --jq ".[0].url")
           echo "PR_URL=$PR_URL" >> $GITHUB_ENV
 
           # compute_commit_message: Create a filtered git log for release-please changelog / metadata
           function compute_commit_message() {
             # Get the last sync PR's last commit state
-            LAST_MERGED_PR_HASH=`gh pr list --repo=noir-lang/noir --state merged --head aztec-packages --json headRefOid --jq=.[0].headRefOid`
+            LAST_MERGED_PR_HASH=`gh pr list --repo=noir-lang/noir --state merged --head aztec-sync-test --json headRefOid --jq=.[0].headRefOid`
             # Use a commit heuristic where we look at when .gitrepo first started to look at that commit state (through a push)
             COMMIT_HEURISTIC=$(git log -p -S"$LAST_MERGED_PR_HASH" --reverse --source -- noir/.gitrepo | grep -m 1 '^commit' | awk '{print $2}' || true)
             BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
@@ -54,87 +54,87 @@ jobs:
             # Create a filtered git log for release-please changelog / metadata
             RAW_MESSAGE=$(git log --pretty=format:"%s" $COMMIT_HEURISTIC..HEAD -- noir/  ':!noir/.gitrepo' | grep -v 'git subrepo' || true)
             # Fix Aztec PR links and output message
-            echo "$RAW_MESSAGE" | sed -E 's/\(#([0-9]+)\)/(https:\/\/github.com\/AztecProtocol\/aztec-packages\/pull\/\1)/g'
+            echo "$RAW_MESSAGE" | sed -E 's/\(#([0-9]+)\)/(https:\/\/github.com\/AztecProtocol\/aztec-sync-test\/pull\/\1)/g'
           }
           echo "$(compute_commit_message)" >> .COMMIT_MESSAGE
 
-      # We push using git subrepo (https://github.com/ingydotnet/git-subrepo)
-      # and push all Aztec commits as a single commit with metadata.
-      - name: Push to branch
-        run: |
-          set -xue # print commands
-          # Enable gh executable. We spread out the API requests between the github actions bot token, and aztecbot
-          export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
-          SUBREPO_PATH=noir
-          BRANCH=aztec-packages
-          if [[ "$PR_URL" == "" ]]; then
-            # if no staging branch, we can overwrite
-            STAGING_BRANCH=$BRANCH
-          else 
-            # otherwise we first reset our staging branch
-            STAGING_BRANCH=$BRANCH-staging
-          fi
-          # identify ourselves, needed to commit
-          git config --global user.name AztecBot
-          git config --global user.email tech@aztecprotocol.com
-          BASE_NOIR_COMMIT=`git config --file=noir/.gitrepo subrepo.commit`
-          BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
+      # # We push using git subrepo (https://github.com/ingydotnet/git-subrepo)
+      # # and push all Aztec commits as a single commit with metadata.
+      # - name: Push to branch
+      #   run: |
+      #     set -xue # print commands
+      #     # Enable gh executable. We spread out the API requests between the github actions bot token, and aztecbot
+      #     export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+      #     SUBREPO_PATH=noir
+      #     BRANCH=aztec-sync-test
+      #     if [[ "$PR_URL" == "" ]]; then
+      #       # if no staging branch, we can overwrite
+      #       STAGING_BRANCH=$BRANCH
+      #     else 
+      #       # otherwise we first reset our staging branch
+      #       STAGING_BRANCH=$BRANCH-staging
+      #     fi
+      #     # identify ourselves, needed to commit
+      #     git config --global user.name AztecBot
+      #     git config --global user.email tech@aztecprotocol.com
+      #     BASE_NOIR_COMMIT=`git config --file=noir/.gitrepo subrepo.commit`
+      #     BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
 
-          # clone noir repo for manipulations, we use aztec bot token for writeability
-          git clone https://x-access-token:${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}@github.com/noir-lang/noir.git noir-repo
+      #     # clone noir repo for manipulations, we use aztec bot token for writeability
+      #     git clone https://x-access-token:${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}@github.com/noir-lang/noir.git noir-repo
 
-          # reset_pr: Reset aztec-packages staging. If no PR, this is the PR branch.
-          function reset_noir_staging_branch() {
-            cd noir-repo
-            git checkout $STAGING_BRANCH || git checkout -b $STAGING_BRANCH
-            git reset --hard "$BASE_NOIR_COMMIT"
-            # Reset our branch to our expected target
-            git push origin $STAGING_BRANCH --force
-            cd ..
-          }
-          # force_sync_staging: Push to our aztec-packages staging branch.
-          function force_sync_staging() {
-            MESSAGE=$(cat .COMMIT_MESSAGE)
-            git commit --allow-empty -m"chore: Sync to noir-lang/noir" -m"$MESSAGE"
-            COMMIT=$(git rev-parse HEAD)
-            # Now push to it with subrepo with computed commit messages
-            if ./scripts/git-subrepo/lib/git-subrepo push $SUBREPO_PATH --squash --branch=$STAGING_BRANCH; then
-              git reset $COMMIT
-              git commit --allow-empty --amend -am "$(git log -1 --pretty=%B) [skip ci]"
-              git push
-            else
-              echo "Problems syncing noir. We may need to pull the subrepo."
-              exit 1
-            fi
-          }
-          # merge_staging_branch: Merge our staging branch into aztec-packages.
-          function merge_staging_branch() {
-            # Fix PR branch
-            cd noir-repo
-            git fetch # see recent change
-            git checkout $BRANCH || git checkout -b $BRANCH
-            git merge -Xtheirs $STAGING_BRANCH
-            git push origin $BRANCH
-            cd ..
-          }
-          reset_noir_staging_branch
-          force_sync_staging
-          if [[ "$PR_URL" != "" ]]; then
-            merge_staging_branch
-          fi
+      #     # reset_pr: Reset aztec-sync-test staging. If no PR, this is the PR branch.
+      #     function reset_noir_staging_branch() {
+      #       cd noir-repo
+      #       git checkout $STAGING_BRANCH || git checkout -b $STAGING_BRANCH
+      #       git reset --hard "$BASE_NOIR_COMMIT"
+      #       # Reset our branch to our expected target
+      #       git push origin $STAGING_BRANCH --force
+      #       cd ..
+      #     }
+      #     # force_sync_staging: Push to our aztec-sync-test staging branch.
+      #     function force_sync_staging() {
+      #       MESSAGE=$(cat .COMMIT_MESSAGE)
+      #       git commit --allow-empty -m"chore: Sync to noir-lang/noir" -m"$MESSAGE"
+      #       COMMIT=$(git rev-parse HEAD)
+      #       # Now push to it with subrepo with computed commit messages
+      #       if ./scripts/git-subrepo/lib/git-subrepo push $SUBREPO_PATH --squash --branch=$STAGING_BRANCH; then
+      #         git reset $COMMIT
+      #         git commit --allow-empty --amend -am "$(git log -1 --pretty=%B) [skip ci]"
+      #         git push
+      #       else
+      #         echo "Problems syncing noir. We may need to pull the subrepo."
+      #         exit 1
+      #       fi
+      #     }
+      #     # merge_staging_branch: Merge our staging branch into aztec-sync-test.
+      #     function merge_staging_branch() {
+      #       # Fix PR branch
+      #       cd noir-repo
+      #       git fetch # see recent change
+      #       git checkout $BRANCH || git checkout -b $BRANCH
+      #       git merge -Xtheirs $STAGING_BRANCH
+      #       git push origin $BRANCH
+      #       cd ..
+      #     }
+      #     reset_noir_staging_branch
+      #     force_sync_staging
+      #     if [[ "$PR_URL" != "" ]]; then
+      #       merge_staging_branch
+      #     fi
 
-      - name: Update PR
-        run: |
-          set -xue # print commands
-          MESSAGE=$(cat .COMMIT_MESSAGE)
-          # Formatted for updating the PR, overrides for release-please commit message parsing 
-          PR_BODY="""BEGIN_COMMIT_OVERRIDE
-          $MESSAGE
-          END_COMMIT_OVERRIDE"""
-          # for cross-opening PR in noir repo, we use aztecbot's token
-          export GH_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          if [[ "$PR_URL" == "" ]]; then
-            gh pr create --repo noir-lang/noir --title "feat: Sync from aztec-packages" --body "$PR_BODY" --base master --head aztec-packages
-          else
-            gh pr edit "$PR_URL" --body "$PR_BODY"
-          fi
+      # - name: Update PR
+      #   run: |
+      #     set -xue # print commands
+      #     MESSAGE=$(cat .COMMIT_MESSAGE)
+      #     # Formatted for updating the PR, overrides for release-please commit message parsing 
+      #     PR_BODY="""BEGIN_COMMIT_OVERRIDE
+      #     $MESSAGE
+      #     END_COMMIT_OVERRIDE"""
+      #     # for cross-opening PR in noir repo, we use aztecbot's token
+      #     export GH_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+      #     if [[ "$PR_URL" == "" ]]; then
+      #       gh pr create --repo noir-lang/noir --title "feat: Sync from aztec-sync-test" --body "$PR_BODY" --base master --head aztec-sync-test
+      #     else
+      #       gh pr edit "$PR_URL" --body "$PR_BODY"
+      #     fi

--- a/.github/workflows/mirror_noir_subrepo.yml
+++ b/.github/workflows/mirror_noir_subrepo.yml
@@ -43,11 +43,11 @@ jobs:
             # Use a commit heuristic where we look at when .gitrepo first started to look at that commit state (through a push)
             COMMIT_HEURISTIC=$(git log -p -S"$LAST_MERGED_PR_HASH" --reverse --source -- noir/.gitrepo | grep -m 1 '^commit' | awk '{print $2}' || true)
             BASE_AZTEC_COMMIT=`git config --file=noir/.gitrepo subrepo.parent`
-            if [[ " $COMMIT_HEURISTIC" = "" ]] ; then
+            if [[ "$COMMIT_HEURISTIC" = "" ]] ; then
               # If that doesn't work, look for the last 'method = pull' commit
               COMMIT_HEURISTIC=$(git log -p -S"method = pull" --reverse --source -- noir/.gitrepo | grep -m 1 '^commit' | awk '{print $2}' || true)
             fi
-            if [[ " $COMMIT_HEURISTIC" = "" ]] ; then
+            if [[ "$COMMIT_HEURISTIC" = "" ]] ; then
               # It it fails, just use our gitrepo parent commit (last time we pushed or pulled)
               COMMIT_HEURISTIC=$BASE_AZTEC_COMMIT
             fi

--- a/noir/.gitrepo
+++ b/noir/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/noir-lang/noir
 	branch = aztec-packages
-	commit = 5f5843e35052b9d3599b8ab4f7633db0a225e82f
+	commit = 6ff518af281afe601edb8574d425b07d9d2f9c5d
 	parent = e5ca533ea4513cf3c6b7e3eb057083838b861a6b
 	method = merge
 	cmdver = 0.4.6

--- a/noir/.gitrepo
+++ b/noir/.gitrepo
@@ -7,6 +7,6 @@
 	remote = https://github.com/noir-lang/noir
 	branch = aztec-packages
 	commit = 6ff518af281afe601edb8574d425b07d9d2f9c5d
-	parent = e5ca533ea4513cf3c6b7e3eb057083838b861a6b
+	parent = 2082fedfb03d4882a269881f51c5337263bc539b
 	method = merge
 	cmdver = 0.4.6


### PR DESCRIPTION
We no longer need a commit on aztec side, and if we forgo this we're a bit more robust actually because then the base URL is always the last pull
There is a heuristic for finding the last commit that should be considered 'synced' for commit message computation purposes. The heuristic failed because
1. there were extra commits in aztec packages after our pull
2. then when we fell back to our gitrepo commit, it was changed on sync

To fix this, we can exploit not needing to actually know our last pushed commit as we know squash. This way, our 'commit' variable in our .gitrepo is always our last *pull* and not pull or push