### PR TITLE
chore(tests): Add counter and private voting tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1319,6 +1319,8 @@ workflows:
       - e2e-inclusion-proofs-contract: *e2e_test
       - e2e-pending-commitments-contract: *e2e_test
       - e2e-ordering: *e2e_test
+      - e2e-counter: *e2e_test
+      - e2e-private-voting: *e2e_test
       - uniswap-trade-on-l1-from-l2: *e2e_test
       - integration-l1-publisher: *e2e_test
       - integration-archiver-l1-to-l2: *e2e_test
@@ -1358,6 +1360,8 @@ workflows:
             - e2e-inclusion-proofs-contract
             - e2e-pending-commitments-contract
             - e2e-ordering
+            - e2e-counter
+            - e2e-private-voting
             - uniswap-trade-on-l1-from-l2
             - integration-l1-publisher
             - integration-archiver-l1-to-l2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -554,6 +554,28 @@ jobs:
           name: "Test"
           command: cond_spot_run_compose end-to-end 4 ./scripts/docker-compose.yml TEST=e2e_note_getter.test.ts
 
+  e2e-counter:
+    docker:
+      - image: aztecprotocol/alpine-build-image
+    resource_class: small
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Test"
+          command: cond_spot_run_compose end-to-end 4 ./scripts/docker-compose.yml TEST=e2e_counter_contract.test.ts
+
+  e2e-private-voting:
+    docker:
+      - image: aztecprotocol/alpine-build-image
+    resource_class: small
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Test"
+          command: cond_spot_run_compose end-to-end 4 ./scripts/docker-compose.yml TEST=e2e_private_voting_contract.test.ts
+
   e2e-multiple-accounts-1-enc-key:
     docker:
       - image: aztecprotocol/alpine-build-image

--- a/yarn-project/end-to-end/src/e2e_counter_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_counter_contract.test.ts
@@ -12,7 +12,7 @@ describe('e2e_counter_contract', () => {
   let counterContract: CounterContract;
   let owner: AztecAddress;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     // Setup environment
     ({
       teardown,
@@ -25,9 +25,9 @@ describe('e2e_counter_contract', () => {
     counterContract = await CounterContract.deploy(wallet, 0, owner).send().deployed();
 
     logger(`Counter contract deployed at ${counterContract.address}`);
-  }, 100_000);
+  }, 25_000);
 
-  afterEach(() => teardown(), 30_000);
+  afterAll(() => teardown());
 
   describe('increments', () => {
     it('counts', async () => {

--- a/yarn-project/end-to-end/src/e2e_counter_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_counter_contract.test.ts
@@ -29,9 +29,11 @@ describe('e2e_counter_contract', () => {
 
   afterEach(() => teardown(), 30_000);
 
-  describe('increments', async () => {
-    const receipt = await counterContract.methods.increment(owner).send().wait();
-    expect(receipt.status).toBe(TxStatus.MINED);
-    expect(await counterContract.methods.get_counter(owner).view()).toBe(1n);
+  describe('increments', () => {
+    it('counts', async () => {
+      const receipt = await counterContract.methods.increment(owner).send().wait();
+      expect(receipt.status).toBe(TxStatus.MINED);
+      expect(await counterContract.methods.get_counter(owner).view()).toBe(1n);
+    });
   });
 });

--- a/yarn-project/end-to-end/src/e2e_counter_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_counter_contract.test.ts
@@ -1,10 +1,9 @@
-import { AccountWallet, AztecAddress, CompleteAddress, DebugLogger, Fr, TxStatus } from '@aztec/aztec.js';
+import { AccountWallet, AztecAddress, CompleteAddress, DebugLogger, TxStatus } from '@aztec/aztec.js';
 import { CounterContract } from '@aztec/noir-contracts.js/Counter';
 
 import { setup } from './fixtures/utils.js';
 
 describe('e2e_counter_contract', () => {
-  // let pxe: PXE;
   let wallet: AccountWallet;
   let accounts: CompleteAddress[];
   let logger: DebugLogger;
@@ -17,7 +16,6 @@ describe('e2e_counter_contract', () => {
     // Setup environment
     ({
       teardown,
-      // pxe,
       accounts,
       wallets: [wallet],
       logger,

--- a/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
@@ -29,11 +29,13 @@ describe('e2e_voting_contract', () => {
 
   afterEach(() => teardown(), 30_000);
 
-  describe('it votes', async () => {
-    const candidate = new Fr(1);
-    const tx = votingContract.methods.cast_vote(candidate).send();
-    const receipt = await tx.wait();
-    expect(receipt.status).toBe(TxStatus.MINED);
-    expect(await votingContract.methods.get_vote(candidate).view()).toBe(1n);
+  describe('votes', () => {
+    it('votes', async () => {
+      const candidate = new Fr(1);
+      const tx = votingContract.methods.cast_vote(candidate).send();
+      const receipt = await tx.wait();
+      expect(receipt.status).toBe(TxStatus.MINED);
+      expect(await votingContract.methods.get_vote(candidate).view()).toBe(1n);
+    });
   });
 });

--- a/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
@@ -31,7 +31,7 @@ describe('e2e_voting_contract', () => {
 
   describe('it votes', async () => {
     const candidate = new Fr(1);
-    const tx = await votingContract.methods.cast_vote(candidate).send();
+    const tx = votingContract.methods.cast_vote(candidate).send();
     const receipt = await tx.wait();
     expect(receipt.status).toBe(TxStatus.MINED);
     expect(await votingContract.methods.get_vote(candidate).view()).toBe(1n);

--- a/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
@@ -12,7 +12,7 @@ describe('e2e_voting_contract', () => {
   let votingContract: EasyPrivateVotingContract;
   let owner: AztecAddress;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     // Setup environment
     ({
       teardown,
@@ -25,9 +25,9 @@ describe('e2e_voting_contract', () => {
     votingContract = await EasyPrivateVotingContract.deploy(wallet, owner).send().deployed();
 
     logger(`Counter contract deployed at ${votingContract.address}`);
-  }, 100_000);
+  }, 25_000);
 
-  afterEach(() => teardown(), 30_000);
+  afterAll(() => teardown());
 
   describe('votes', () => {
     it('votes', async () => {

--- a/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
@@ -4,7 +4,6 @@ import { EasyPrivateVotingContract } from '@aztec/noir-contracts.js/EasyPrivateV
 import { setup } from './fixtures/utils.js';
 
 describe('e2e_voting_contract', () => {
-  //   let pxe: PXE;
   let wallet: AccountWallet;
   let accounts: CompleteAddress[];
   let logger: DebugLogger;
@@ -17,7 +16,6 @@ describe('e2e_voting_contract', () => {
     // Setup environment
     ({
       teardown,
-      //   pxe,
       accounts,
       wallets: [wallet],
       logger,

--- a/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
@@ -1,0 +1,41 @@
+import { AccountWallet, AztecAddress, CompleteAddress, DebugLogger, Fr, TxStatus } from '@aztec/aztec.js';
+import { EasyPrivateVotingContract } from '@aztec/noir-contracts.js/EasyPrivateVoting';
+
+import { setup } from './fixtures/utils.js';
+
+describe('e2e_voting_contract', () => {
+  //   let pxe: PXE;
+  let wallet: AccountWallet;
+  let accounts: CompleteAddress[];
+  let logger: DebugLogger;
+  let teardown: () => Promise<void>;
+
+  let votingContract: EasyPrivateVotingContract;
+  let owner: AztecAddress;
+
+  beforeEach(async () => {
+    // Setup environment
+    ({
+      teardown,
+      //   pxe,
+      accounts,
+      wallets: [wallet],
+      logger,
+    } = await setup(1));
+    owner = accounts[0].address;
+
+    votingContract = await EasyPrivateVotingContract.deploy(wallet, owner).send().deployed();
+
+    logger(`Counter contract deployed at ${votingContract.address}`);
+  }, 100_000);
+
+  afterEach(() => teardown(), 30_000);
+
+  describe('it votes', async () => {
+    const candidate = new Fr(1);
+    const tx = await votingContract.methods.cast_vote(candidate).send();
+    const receipt = await tx.wait();
+    expect(receipt.status).toBe(TxStatus.MINED);
+    expect(await votingContract.methods.get_vote(candidate).view()).toBe(1n);
+  });
+});


### PR DESCRIPTION
The Counter contract and the EasyPrivateVoting contracts did not have e2e tests. Now they do.

closes #4585 