### PR TITLE
docs: add compression circuit outline

### DIFF
--- a/yarn-project/circuits.js/src/structs/aggregation_object.ts
+++ b/yarn-project/circuits.js/src/structs/aggregation_object.ts
@@ -6,7 +6,7 @@ import { UInt32, Vector } from './shared.js';
 import { G1AffineElement } from './verification_key.js';
 
 /**
- * Contains the aggregated proof of all the previous kernel iterations.
+ * Contains the aggregated elements to be used as public inputs for delayed final verification.
  *
  * See barretenberg/cpp/src/barretenberg/stdlib/recursion/aggregation_state/native_aggregation_state.hpp
  * for more context.

--- a/yellow-paper/docs/l1-smart-contracts/index.md
+++ b/yellow-paper/docs/l1-smart-contracts/index.md
@@ -287,10 +287,7 @@ As mentioned earlier, this is done to ensure that the messages are not used to D
 Since we will be building the tree on L1, we need to use a gas-friendly hash-function such as SHA256. 
 However, as we need to allow users to prove inclusion in this tree, we cannot just insert the SHA256 tree into the rollup state, it requires too many constraints to be used by most small users. 
 Therefore, we need to "convert" the tree into a tree using a more snark-friendly hash.
-This part is done in a to-be-defined circuit.
-:::info TODO
-Write about the `MessageCompression` circuits
-:::
+This part is done in the [message compression circuits](./../rollup-circuits/message-compression.md).
 
 Furthermore, to build the tree on L1, we need to put some storage on L1 such that the insertions don't need to provide a lot of merkle-related data which could be cumbersome to do and prone to race-conditions. 
 For example two insertions based on inclusion paths that are created at the same time will invalidate each other. 

--- a/yellow-paper/docs/l1-smart-contracts/index.md
+++ b/yellow-paper/docs/l1-smart-contracts/index.md
@@ -33,7 +33,7 @@ def process(block: ProvenBlock, proof: Proof):
     assert self.outbox.insert(
         block_number, 
         header.content_commitment.out_hash, 
-        header.content_commitment.tx_tree_height
+        header.content_commitment.tx_tree_height + 1
     )
     self.archive = block.archive
 
@@ -112,17 +112,16 @@ class StateTransitioner:
         archive: Fr,
         proof: Proof
     ):
-        assert self.AVAILABILITY_ORACLE.is_available(txs_hash)
+        assert self.AVAILABILITY_ORACLE.is_available(header.content_commitment.txs_hash)
         assert self.validate_header(header)
-        assert self.archive == header.last_archive
-        assert VERIFIER.verify(header, block.archive, proof)
-        assert self.INBOX.consume() == header.in_hash
+        assert VERIFIER.verify(header, archive, proof)
+        assert self.INBOX.consume() == header.content_commitment.in_hash
         assert self.OUTBOX.insert(
             block_number, 
             header.content_commitment.out_hash, 
-            header.content_commitment.tx_tree_height
+            header.content_commitment.tx_tree_height + 1
         )
-        self.archive = block.archive
+        self.archive = archive
         emit BlockProcessed(block_number)
 
     def validate_header(
@@ -287,7 +286,7 @@ As mentioned earlier, this is done to ensure that the messages are not used to D
 Since we will be building the tree on L1, we need to use a gas-friendly hash-function such as SHA256. 
 However, as we need to allow users to prove inclusion in this tree, we cannot just insert the SHA256 tree into the rollup state, it requires too many constraints to be used by most small users. 
 Therefore, we need to "convert" the tree into a tree using a more snark-friendly hash.
-This part is done in the [message compression circuits](./../rollup-circuits/message-compression.md).
+This part is done in the [tree parity circuits](./../rollup-circuits/tree-parity.md).
 
 Furthermore, to build the tree on L1, we need to put some storage on L1 such that the insertions don't need to provide a lot of merkle-related data which could be cumbersome to do and prone to race-conditions. 
 For example two insertions based on inclusion paths that are created at the same time will invalidate each other. 
@@ -420,6 +419,7 @@ class Outbox:
     inclusion_proof: bytes[]
   ):
     leaf = message.hash_to_field()
+    assert msg_sender == message.recipient.actor
     assert merkle_verify(
       self.roots[root_index].root,
       self.roots[root_index].height,
@@ -463,9 +463,7 @@ Also, some of the conditions are repetitions of what we saw earlier from the [st
   - The `(sender|recipient).version` MUST be the version of the state transitioner (the version of the L2 specified in the L1 contract)
   - The `content` MUST fit within a field element
   - For L1 to L2 messages:
-    - The `deadline` MUST be in the future, `> block.timestamp`
     - The `secretHash` MUST fit in a field element
-    - The caller MAY append a `fee` to incentivize the sequencer to pick up the message
 - **Moving tree roots**:
   - Moves MUST be atomic:
     - Any message that is inserted into an outbox MUST be consumed from the matching inbox

--- a/yellow-paper/docs/rollup-circuits/index.md
+++ b/yellow-paper/docs/rollup-circuits/index.md
@@ -16,7 +16,7 @@ This works very well for the case where we want many actors to be able to partic
 
 Note that we have two different types of "merger" circuits, depending on what they are combining. 
 
-For transaction compression we have:
+For transactions we have:
 - The `merge` rollup
   - Merges two `base` rollup proofs OR two `merge` rollup proofs
 - The `root` rollup
@@ -28,8 +28,6 @@ And for the message parity we have:
 - The `leaf` circuit
   - Merges `N` l1 to l2 messages in a subtree 
 
-In the diagram the sizes of the trees are limited for show.
-In reality larger trees would have more layers between the leafs and the root.
 In the diagram the size of the tree is limited for demonstration purposes, but a larger tree would have more layers of merge rollups proofs. 
 Circles mark the different types of proofs, while squares mark the different circuit types.
 

--- a/yellow-paper/docs/rollup-circuits/message-compression.md
+++ b/yellow-paper/docs/rollup-circuits/message-compression.md
@@ -1,0 +1,122 @@
+---
+title: Message Compression
+---
+
+To support easy consumption of l1 to l2 messages inside the proofs, we need to convert the tree of messages to a snark-friendly format.
+
+If you recall back in [L1 smart contracts](./../l1-smart-contracts/index.md#inbox) we were building a message tree on the L1.
+We used SHA256 to compute the tree which is cheap to compute on L1.
+As SHA256 is not snark-friendly, weak devices would not be able to prove inclusion of messages in the tree.
+
+This circuit is responsible for converting the tree such that users can easily build the proofs.
+We essentially use this circuit to front-load the work needed to prove the inclusion of messages in the tree.
+As earlier we are using a tree-like structure.
+
+```mermaid
+graph BT
+    R((compress 4))
+
+    T0[compress_leaf]
+    T1[compress_leaf]
+    T2[compress_leaf]
+    T3[compress_leaf]
+
+    T0_P((compress 0))
+    T1_P((compress 1))
+    T2_P((compress 2))
+    T3_P((compress 3))
+
+    T4[compress]
+
+    I0 --> T0
+    I1 --> T1
+    I2 --> T2
+    I3 --> T3
+
+    T0 --> T0_P
+    T1 --> T1_P
+    T2 --> T2_P
+    T3 --> T3_P
+
+    T0_P --> T4
+    T1_P --> T4
+    T2_P --> T4
+    T3_P --> T4
+
+    T4 --> R
+
+    I0((MSG 0-3))
+    I1((MSG 4-7))
+    I2((MSG 8-11))
+    I3((MSG 12-15))
+
+style R fill:#1976D2;
+style T0_P fill:#1976D2;
+style T1_P fill:#1976D2;
+style T2_P fill:#1976D2;
+style T3_P fill:#1976D2;
+style I0 fill:#1976D2;
+style I1 fill:#1976D2;
+style I2 fill:#1976D2;
+style I3 fill:#1976D2;
+```
+
+Practically, this will be using two circuits, similar to how we have the `base` and `merge` circuits for transactions.
+The output of the "combined" circuit will be the `converted_root` which is the root of the snark-friendly message tree.
+And the `sha_root` which must match the root of the sha256 message tree from the L1 Inbox.
+The circuit must simply compute the two trees using the same inputs, and then we ensure that the elements of the trees match the inbox later at the [state transitioner](./../l1-smart-contracts/index.md#overview).
+
+
+```mermaid
+classDiagram
+direction LR
+
+class CompressPublicInput {
+    aggregation_object: AggregationObject
+    sha_root: Fr[2]
+    converted_root: Fr
+}
+
+class CompressInput {
+    msgs: List~TreeConversionData~
+}
+CompressInput *-- TreeConversionData: msgs
+
+class TreeConversionData {
+    proof: Proof
+    public_inputs: CompressPublicInput
+}
+TreeConversionData *-- CompressPublicInput: public_inputs
+
+class CompressLeafInputs {
+    msgs: List~Fr[2]~
+}
+```
+The logic of the the circuits is quite simple.
+They simply progress building of two trees, the SHA tree and the snark-friendly tree. 
+For optimization purposes, it can be useful to have the layers take more than 2 inputs to increase the task of every layer.
+If each just take 2 inputs, the overhead of recursing through the layers might be higher than the actual work done.
+Recall that all the inputs are already chosen by the L1, so we don't need to worry about which to chose.
+
+```python
+def compress_leaf(msgs: List[Fr[2]]) -> CompressPublicInput:
+    sha_root = MERKLE_TREE(msgs, SHA256);
+    converted_root = MERKLE_TREE(msgs, SNARK_FRIENDLY_HASH_FUNCTION);
+    return CompressPublicInput(sha_root, converted_root)
+
+def compress(msgs: List[TreeConversionData]) -> CompressPublicInput:
+    for msg in msgs:
+        assert msg.proof.verify(msg.public_inputs);
+
+    sha_root = MERKLE_TREE(
+      [msg.public_inputs.sha_root for msg in msgs], 
+      SHA256
+    );
+    converted_root = MERKLE_TREE(
+      [msg.public_inputs.converted_root for msg in msgs], 
+      SNARK_FRIENDLY_HASH_FUNCTION
+    );
+    return CompressPublicInput(sha_root, converted_root)
+```
+
+

--- a/yellow-paper/docs/rollup-circuits/root-rollup.md
+++ b/yellow-paper/docs/rollup-circuits/root-rollup.md
@@ -131,29 +131,29 @@ class ChildRollupData {
 }
 ChildRollupData *-- BaseOrMergeRollupPublicInputs: public_inputs
 
-class CompressBaseInputs {
+
+class LeafParityInputs {
     msgs: List~Fr[2]~
 }
 
-class CompressPublicInput {
+class ParityPublicInputs {
     aggregation_object: AggregationObject
     sha_root: Fr[2]
     converted_root: Fr
 }
 
-class CompressInput {
-    msgs: List~CompressPublicInput~
+class RootParityInputs {
+    children: List~ParityPublicInputs~
 }
-CompressInput *-- CompressPublicInput: msgs
+RootParityInputs *-- ParityPublicInputs: children
 
-class TreeConversionData {
+class RootParityInput {
     proof: Proof
-    public_inputs: CompressPublicInput
+    public_inputs: ParityPublicInputs
 }
-TreeConversionData *-- CompressPublicInput: public_inputs
-
+RootParityInput *-- ParityPublicInputs: public_inputs
 class RootRollupInputs {
-    l1_to_l2_roots: TreeConversionData
+    l1_to_l2_roots: RootParityInput
     l1_to_l2_msgs_sibling_path: List~Fr~
     parent: Header,
     parent_sibling_path: List~Fr~
@@ -161,7 +161,7 @@ class RootRollupInputs {
     left: ChildRollupData
     right: ChildRollupData
 }
-RootRollupInputs *-- TreeConversionData: l1_to_l2_roots
+RootRollupInputs *-- RootParityInput: l1_to_l2_roots
 RootRollupInputs *-- ChildRollupData: left
 RootRollupInputs *-- ChildRollupData: right
 RootRollupInputs *-- Header : parent
@@ -178,7 +178,7 @@ RootRollupPublicInputs *--Header : header
 
 ```python
 def RootRollupCircuit(
-    l1_to_l2_roots: TreeConversionData,
+    l1_to_l2_roots: RootParityInput,
     l1_to_l2_msgs_sibling_path: List[Fr],
     parent: Header,
     parent_sibling_path: List[Fr],
@@ -218,7 +218,7 @@ def RootRollupCircuit(
         last_archive = left.public_inputs.constants.last_archive,
         content_commitment: ContentCommitment(
             tx_tree_height = left.public_inputs.height_in_block_tree + 1,
-            tsx_hash = SHA256(left.public_inputs.txs_hash | right.public_inputs.txs_hash),
+            txs_hash = SHA256(left.public_inputs.txs_hash | right.public_inputs.txs_hash),
             in_hash = l1_to_l2_roots.public_inputs.sha_root,
             out_hash = SHA256(left.public_inputs.out_hash | right.public_inputs.out_hash),
         ),

--- a/yellow-paper/docs/rollup-circuits/root-rollup.md
+++ b/yellow-paper/docs/rollup-circuits/root-rollup.md
@@ -131,13 +131,29 @@ class ChildRollupData {
 }
 ChildRollupData *-- BaseOrMergeRollupPublicInputs: public_inputs
 
-class MessageCompressionBaseOrMergePublicInputs {
+class CompressBaseInputs {
+    msgs: List~Fr[2]~
+}
+
+class CompressPublicInput {
+    aggregation_object: AggregationObject
     sha_root: Fr[2]
     converted_root: Fr
 }
 
+class CompressInput {
+    msgs: List~CompressPublicInput~
+}
+CompressInput *-- CompressPublicInput: msgs
+
+class TreeConversionData {
+    proof: Proof
+    public_inputs: CompressPublicInput
+}
+TreeConversionData *-- CompressPublicInput: public_inputs
+
 class RootRollupInputs {
-    l1_to_l2_roots: MessageCompressionBaseOrMergePublicInputs
+    l1_to_l2_roots: TreeConversionData
     l1_to_l2_msgs_sibling_path: List~Fr~
     parent: Header,
     parent_sibling_path: List~Fr~
@@ -145,7 +161,7 @@ class RootRollupInputs {
     left: ChildRollupData
     right: ChildRollupData
 }
-RootRollupInputs *-- MessageCompressionBaseOrMergePublicInputs: l1_to_l2_roots
+RootRollupInputs *-- TreeConversionData: l1_to_l2_roots
 RootRollupInputs *-- ChildRollupData: left
 RootRollupInputs *-- ChildRollupData: right
 RootRollupInputs *-- Header : parent
@@ -162,7 +178,7 @@ RootRollupPublicInputs *--Header : header
 
 ```python
 def RootRollupCircuit(
-    l1_to_l2_roots: MessageCompressionBaseOrMergePublicInputs,
+    l1_to_l2_roots: TreeConversionData,
     l1_to_l2_msgs_sibling_path: List[Fr],
     parent: Header,
     parent_sibling_path: List[Fr],
@@ -172,6 +188,7 @@ def RootRollupCircuit(
 ) -> RootRollupPublicInputs:
     assert left.proof.is_valid(left.public_inputs)
     assert right.proof.is_valid(right.public_inputs)
+    assert l1_to_l2_roots.proof.verify(l1_to_l2_roots.public_inputs)
 
     assert left.public_inputs.constants == right.public_inputs.constants
     assert left.public_inputs.end == right.public_inputs.start
@@ -191,7 +208,7 @@ def RootRollupCircuit(
     # Update the l1 to l2 msg tree
     l1_to_l2_msg_tree = merkle_insertion(
         parent.state.l1_to_l2_message_tree,
-        l1_to_l2_roots.converted_root,
+        l1_to_l2_roots.public_inputs.converted_root,
         l1_to_l2_msgs_sibling_path,
         L1_TO_L2_SUBTREE_HEIGHT,
         L1_To_L2_HEIGHT
@@ -201,8 +218,8 @@ def RootRollupCircuit(
         last_archive = left.public_inputs.constants.last_archive,
         content_commitment: ContentCommitment(
             tx_tree_height = left.public_inputs.height_in_block_tree + 1,
-            txs_hash = SHA256(left.public_inputs.txs_hash | right.public_inputs.txs_hash),
-            in_hash = l1_to_l2_roots.sha_root,
+            tsx_hash = SHA256(left.public_inputs.txs_hash | right.public_inputs.txs_hash),
+            in_hash = l1_to_l2_roots.public_inputs.sha_root,
             out_hash = SHA256(left.public_inputs.out_hash | right.public_inputs.out_hash),
         ),
         state = StateReference(

--- a/yellow-paper/docs/rollup-circuits/tree-parity.md
+++ b/yellow-paper/docs/rollup-circuits/tree-parity.md
@@ -65,7 +65,7 @@ style I3 fill:#1976D2;
 
 The output of the "combined" circuit will be the `converted_root` which is the root of the snark-friendly message tree.
 And the `sha_root` which must match the root of the sha256 message tree from the L1 Inbox.
-The circuit must simply compute the two trees using the same inputs, and then we ensure that the elements of the trees match the inbox later at the [state transitioner](./../l1-smart-contracts/index.md#overview).
+The circuit computes the two trees using the same inputs, and then we ensure that the elements of the trees match the inbox later in the [state transitioner](./../l1-smart-contracts/index.md#overview).
 It proves parity of the leaves in the two trees.
 
 

--- a/yellow-paper/sidebars.js
+++ b/yellow-paper/sidebars.js
@@ -190,7 +190,7 @@ const sidebars = {
       items: [
         "rollup-circuits/base-rollup",
         "rollup-circuits/merge-rollup",
-        "rollup-circuits/message-compression",
+        "rollup-circuits/tree-parity",
         "rollup-circuits/root-rollup",
       ],
     },

--- a/yellow-paper/sidebars.js
+++ b/yellow-paper/sidebars.js
@@ -190,6 +190,7 @@ const sidebars = {
       items: [
         "rollup-circuits/base-rollup",
         "rollup-circuits/merge-rollup",
+        "rollup-circuits/message-compression",
         "rollup-circuits/root-rollup",
       ],
     },


### PR DESCRIPTION
Fixes #4558.

Adds a section to the yellow-paper on message compression circuits for L1 -> L2 message following #4250 