### PR TITLE
chore(ci): test noir-projects in CI

### DIFF
--- a/noir-projects/Dockerfile
+++ b/noir-projects/Dockerfile
@@ -12,10 +12,10 @@ WORKDIR /usr/src/noir-projects
 COPY . .
 # Build
 WORKDIR /usr/src/noir-projects/noir-contracts
-RUN ./scripts/compile.sh && ./scripts/transpile.sh && ../../noir/target/release/nargo test
+RUN ./scripts/compile.sh && ./scripts/transpile.sh && ../../noir/target/release/nargo test --silence-warnings
 
 WORKDIR /usr/src/noir-projects/noir-protocol-circuits
-RUN cd src && ../../../noir/target/release/nargo compile --silence-warnings && ../../../noir/target/release/nargo test
+RUN cd src && ../../../noir/target/release/nargo compile --silence-warnings && ../../../noir/target/release/nargo test --silence-warnings
 
 WORKDIR /usr/src/noir-projects/aztec-nr
-RUN ../../noir/target/release/nargo compile --silence-warnings && ../../noir/target/release/nargo test
+RUN ../../noir/target/release/nargo compile --silence-warnings && ../../noir/target/release/nargo test --silence-warnings

--- a/noir-projects/Dockerfile
+++ b/noir-projects/Dockerfile
@@ -12,7 +12,10 @@ WORKDIR /usr/src/noir-projects
 COPY . .
 # Build
 WORKDIR /usr/src/noir-projects/noir-contracts
-RUN ./scripts/compile.sh && ./scripts/transpile.sh
+RUN ./scripts/compile.sh && ./scripts/transpile.sh && ../../noir/target/release/nargo test
 
 WORKDIR /usr/src/noir-projects/noir-protocol-circuits
-RUN cd src && ../../../noir/target/release/nargo compile --silence-warnings
+RUN cd src && ../../../noir/target/release/nargo compile --silence-warnings && ../../../noir/target/release/nargo test
+
+WORKDIR /usr/src/noir-projects/aztec-nr
+RUN ../../noir/target/release/nargo compile --silence-warnings && ../../noir/target/release/nargo test

--- a/noir-projects/aztec-nr/Nargo.toml
+++ b/noir-projects/aztec-nr/Nargo.toml
@@ -1,0 +1,12 @@
+[workspace]
+members = [
+  "address-note",
+  "authwit",
+  "aztec",
+  "compressed-string",
+  "easy-private-state",
+  "field-note",
+  "safe-math",
+  "slow-updates-tree",
+  "value-note",
+]


### PR DESCRIPTION
Fixes #4601 

Note: I added a Nargo.toml file at the root of aztec-nr so it can find the project tests, please LMK if there's any reason to not have that