### PR TITLE
fix: use specific slither and slitherin versions

### DIFF
--- a/l1-contracts/Dockerfile
+++ b/l1-contracts/Dockerfile
@@ -1,6 +1,6 @@
 # Building requires foundry.
 FROM ghcr.io/foundry-rs/foundry:nightly-4a643801d0b3855934cdec778e33e79c79971783
-RUN apk update && apk add git jq bash nodejs npm yarn python3 py3-pip && pip3 install slither-analyzer slitherin
+RUN apk update && apk add git jq bash nodejs npm yarn python3 py3-pip && pip3 install slither-analyzer==0.10.0 slitherin==0.5.0
 WORKDIR /usr/src/l1-contracts
 COPY . .
 RUN git init

--- a/l1-contracts/README.md
+++ b/l1-contracts/README.md
@@ -85,6 +85,6 @@ yarn slither
 
 When this command is run in CI, it will fail if the markdown file generated in docker don't match the one in the repository. 
 
-We assume that you already have slither installed. You can install it with `pip3 install slither-analyzer slitherin`. It is kept out of the bootstrap script as it is not a requirement for people who just want to run tests or are uninterested in the contracts.
+We assume that you already have slither installed. You can install it with `pip3 install slither-analyzer==0.10.0 slitherin==0.5.0`. It is kept out of the bootstrap script as it is not a requirement for people who just want to run tests or are uninterested in the contracts.
 
 > We are not running the `naming-convention` detector because we have our own rules for naming which is enforced by the linter.


### PR DESCRIPTION
A new version of slitherin made the ci fail. This version fixes the version of slither and slitherin to `0.10.0` and `0.5.0` respectively.