### PR TITLE
fix(bb): initialize element::infinity()

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -494,7 +494,7 @@ template <class Fq, class Fr, class T> constexpr element<Fq, Fr, T> element<Fq, 
 
 template <class Fq, class Fr, class T> element<Fq, Fr, T> element<Fq, Fr, T>::infinity()
 {
-    element<Fq, Fr, T> e;
+    element<Fq, Fr, T> e{};
     e.self_set_infinity();
     return e;
 }


### PR DESCRIPTION
Points at infinity are rare enough that we can initialize this to reduce MSAN (C++ memory sanitizer) noise without performance loss. Caused uninitialized memory errors in kzg test (which likely shouldn't be creating points at infinity, anyway)