### PR TITLE
feat: GoblinUltra Bench

### DIFF
--- a/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_round_bench/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_round_bench/CMakeLists.txt
@@ -1,1 +1,0 @@
-barretenberg_module(protogalaxy_rounds_bench ultra_honk protogalaxy stdlib_primitives)

--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/goblin_ultra_honk.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/goblin_ultra_honk.bench.cpp
@@ -1,0 +1,54 @@
+#include <benchmark/benchmark.h>
+
+#include "barretenberg/benchmark/ultra_bench/mock_proofs.hpp"
+#include "barretenberg/proof_system/circuit_builder/goblin_ultra_circuit_builder.hpp"
+#include "barretenberg/ultra_honk/ultra_composer.hpp"
+
+using namespace benchmark;
+using namespace bb;
+
+/**
+ * @brief Benchmark: Construction of a Ultra Honk proof for a circuit determined by the provided circuit function
+ */
+static void construct_proof_goblinultrahonk(State& state,
+                                            void (*test_circuit_function)(GoblinUltraCircuitBuilder&, size_t)) noexcept
+{
+    size_t num_iterations = 10; // 10x the circuit
+    bb::mock_proofs::construct_proof_with_specified_num_iterations<GoblinUltraComposer>(
+        state, test_circuit_function, num_iterations);
+}
+
+/**
+ * @brief Benchmark: Construction of a Ultra Plonk proof with 2**n gates
+ */
+static void construct_proof_goblinultrahonk_power_of_2(State& state) noexcept
+{
+    auto log2_of_gates = static_cast<size_t>(state.range(0));
+    bb::mock_proofs::construct_proof_with_specified_num_iterations<GoblinUltraComposer>(
+        state, &bb::mock_proofs::generate_basic_arithmetic_circuit<GoblinUltraCircuitBuilder>, log2_of_gates);
+}
+
+// Define benchmarks
+BENCHMARK_CAPTURE(construct_proof_goblinultrahonk,
+                  sha256,
+                  &stdlib::generate_sha256_test_circuit<GoblinUltraCircuitBuilder>)
+    ->Unit(kMillisecond);
+BENCHMARK_CAPTURE(construct_proof_goblinultrahonk,
+                  keccak,
+                  &stdlib::generate_keccak_test_circuit<GoblinUltraCircuitBuilder>)
+    ->Unit(kMillisecond);
+BENCHMARK_CAPTURE(construct_proof_goblinultrahonk,
+                  ecdsa_verification,
+                  &stdlib::generate_ecdsa_verification_test_circuit<GoblinUltraCircuitBuilder>)
+    ->Unit(kMillisecond);
+BENCHMARK_CAPTURE(construct_proof_goblinultrahonk,
+                  merkle_membership,
+                  &stdlib::generate_merkle_membership_test_circuit<GoblinUltraCircuitBuilder>)
+    ->Unit(kMillisecond);
+
+BENCHMARK(construct_proof_goblinultrahonk_power_of_2)
+    // 2**15 gates to 2**20 gates
+    ->DenseRange(15, 20)
+    ->Unit(kMillisecond);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
Add benchmarks of GoblinUltraHonk. Results

```
goblin_ultra_honk_bench                                                                                                                                     100%   11MB  41.4MB/s   00:00    
2024-02-19T18:52:47+00:00
Running ./goblin_ultra_honk_bench
Run on (16 X 3000 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 36608 KiB (x1)
Load Average: 0.00, 0.56, 0.55
---------------------------------------------------------------------------------------------
Benchmark                                                   Time             CPU   Iterations
---------------------------------------------------------------------------------------------
construct_proof_goblinultrahonk/sha256                    717 ms          669 ms            1
construct_proof_goblinultrahonk/keccak                   2819 ms         2609 ms            1
construct_proof_goblinultrahonk/ecdsa_verification       5275 ms         4958 ms            1
construct_proof_goblinultrahonk/merkle_membership         374 ms          340 ms            2
construct_proof_goblinultrahonk_power_of_2/15             382 ms          349 ms            2
construct_proof_goblinultrahonk_power_of_2/16             751 ms          702 ms            1
construct_proof_goblinultrahonk_power_of_2/17            1454 ms         1372 ms            1
construct_proof_goblinultrahonk_power_of_2/18            2938 ms         2738 ms            1
construct_proof_goblinultrahonk_power_of_2/19            5710 ms         5361 ms            1
construct_proof_goblinultrahonk_power_of_2/20           11496 ms        10855 ms            1
Benchmarking lock deleted.
```