### PR TITLE
fix: add registry contract to list

### DIFF
--- a/yarn-project/aztec/src/cli/util.ts
+++ b/yarn-project/aztec/src/cli/util.ts
@@ -13,6 +13,7 @@ const l1ContractsNames = [
   'outboxAddress',
   'contractDeploymentEmitterAddress',
   'availabilityOracleAddress',
+  'registryAddress',
 ];
 
 /**

--- a/yarn-project/aztec/src/cli/util.ts
+++ b/yarn-project/aztec/src/cli/util.ts
@@ -1,20 +1,11 @@
 import { ArchiverConfig } from '@aztec/archiver';
 import { AztecNodeConfig } from '@aztec/aztec-node';
 import { AccountManager } from '@aztec/aztec.js';
-import { L1ContractAddresses } from '@aztec/ethereum';
+import { L1ContractAddresses, l1ContractsNames } from '@aztec/ethereum';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { LogFn, createConsoleLogger } from '@aztec/foundation/log';
 import { P2PConfig } from '@aztec/p2p';
 import { GrumpkinScalar, PXEService, PXEServiceConfig } from '@aztec/pxe';
-
-const l1ContractsNames = [
-  'rollupAddress',
-  'inboxAddress',
-  'outboxAddress',
-  'contractDeploymentEmitterAddress',
-  'availabilityOracleAddress',
-  'registryAddress',
-];
 
 /**
  * Checks if the object has l1Contracts property

--- a/yarn-project/ethereum/src/l1_contract_addresses.ts
+++ b/yarn-project/ethereum/src/l1_contract_addresses.ts
@@ -1,31 +1,17 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
 
+export const l1ContractsNames = [
+  'availabilityOracleAddress',
+  'rollupAddress',
+  'registryAddress',
+  'inboxAddress',
+  'outboxAddress',
+  'contractDeploymentEmitterAddress',
+];
+
 /**
  * Provides the directory of current L1 contract addresses
  */
-export interface L1ContractAddresses {
-  /**
-   * Availability Oracle Address.
-   */
-  availabilityOracleAddress: EthAddress;
-  /**
-   * Rollup Address.
-   */
-  rollupAddress: EthAddress;
-  /**
-   * Registry Address.
-   */
-  registryAddress: EthAddress;
-  /**
-   * Inbox Address.
-   */
-  inboxAddress: EthAddress;
-  /**
-   * Outbox Address.
-   */
-  outboxAddress: EthAddress;
-  /**
-   * Data Emitter Address.
-   */
-  contractDeploymentEmitterAddress: EthAddress;
-}
+export type L1ContractAddresses = {
+  [K in (typeof l1ContractsNames)[number]]: EthAddress;
+};


### PR DESCRIPTION
registry contract was missing from list of l1 contracts required to run `aztec` command