### PR TITLE
chore: Build nargo against Ubuntu 20 for better compatability

### DIFF
--- a/noir/Dockerfile
+++ b/noir/Dockerfile
@@ -1,10 +1,10 @@
-FROM rust:bookworm
+FROM rust:bullseye
 WORKDIR /usr/src/noir
 COPY . .
 RUN ./scripts/bootstrap_native.sh
 
 # When running the container, mount the users home directory to same location.
-FROM ubuntu:lunar
+FROM ubuntu:focal
 # Install Tini as nargo doesn't handle signals properly.
 # Install git as nargo needs it to clone.
 RUN apt-get update && apt-get install -y git tini && rm -rf /var/lib/apt/lists/* && apt-get clean


### PR DESCRIPTION
As title.

This means the bootstrap_cache scripts pull a version of nargo that will run on mainframe.