### PR TITLE
chore(avm-simulator): pull out public storage caching and merging from the state journal

### DIFF
--- a/yarn-project/simulator/src/avm/journal/journal.test.ts
+++ b/yarn-project/simulator/src/avm/journal/journal.test.ts
@@ -20,47 +20,6 @@ describe('journal', () => {
   });
 
   describe('Public Storage', () => {
-    it('Should cache write to storage', () => {
-      // When writing to storage we should write to the storage writes map
-      const contractAddress = new Fr(1);
-      const key = new Fr(2);
-      const value = new Fr(3);
-
-      journal.writeStorage(contractAddress, key, value);
-
-      const journalUpdates: JournalData = journal.flush();
-      expect(journalUpdates.currentStorageValue.get(contractAddress.toBigInt())?.get(key.toBigInt())).toEqual(value);
-    });
-
-    it('When reading from storage, should check the parent first', async () => {
-      // Store a different value in storage vs the cache, and make sure the cache is returned
-      const contractAddress = new Fr(1);
-      const key = new Fr(2);
-      const storedValue = new Fr(420);
-      const parentValue = new Fr(69);
-      const cachedValue = new Fr(1337);
-
-      publicDb.storageRead.mockResolvedValue(Promise.resolve(storedValue));
-
-      const childJournal = new AvmWorldStateJournal(journal.hostStorage, journal);
-
-      // Get the cache miss
-      const cacheMissResult = await childJournal.readStorage(contractAddress, key);
-      expect(cacheMissResult).toEqual(storedValue);
-
-      // Write to storage
-      journal.writeStorage(contractAddress, key, parentValue);
-      const parentResult = await childJournal.readStorage(contractAddress, key);
-      expect(parentResult).toEqual(parentValue);
-
-      // Get the parent value
-      childJournal.writeStorage(contractAddress, key, cachedValue);
-
-      // Get the storage value
-      const cachedResult = await childJournal.readStorage(contractAddress, key);
-      expect(cachedResult).toEqual(cachedValue);
-    });
-
     it('When reading from storage, should check the cache first, and be appended to read/write journal', async () => {
       // Store a different value in storage vs the cache, and make sure the cache is returned
       const contractAddress = new Fr(1);

--- a/yarn-project/simulator/src/avm/journal/public_storage.test.ts
+++ b/yarn-project/simulator/src/avm/journal/public_storage.test.ts
@@ -1,0 +1,116 @@
+import { Fr } from '@aztec/foundation/fields';
+
+import { MockProxy, mock } from 'jest-mock-extended';
+
+import { PublicStateDB } from '../../index.js';
+import { PublicStorage } from './public_storage.js';
+
+describe('avm public storage', () => {
+  let publicDb: MockProxy<PublicStateDB>;
+  let publicStorage: PublicStorage;
+
+  beforeEach(() => {
+    publicDb = mock<PublicStateDB>();
+    publicStorage = new PublicStorage(publicDb);
+  });
+
+  describe('AVM Public Storage', () => {
+    it('Reading an unwritten slot works (gets zero & DNE)', async () => {
+      const contractAddress = new Fr(1);
+      const slot = new Fr(2);
+      // never written!
+      const [exists, gotValue] = await publicStorage.read(contractAddress, slot);
+      // doesn't exist, value is zero
+      expect(exists).toEqual(false);
+      expect(gotValue).toEqual(Fr.ZERO);
+    });
+    it('Should cache storage write, reading works after write', async () => {
+      const contractAddress = new Fr(1);
+      const slot = new Fr(2);
+      const value = new Fr(3);
+      // Write to cache
+      publicStorage.write(contractAddress, slot, value);
+      const [exists, gotValue] = await publicStorage.read(contractAddress, slot);
+      // exists because it was previously written
+      expect(exists).toEqual(true);
+      expect(gotValue).toEqual(value);
+    });
+    it('Reading works on fallback to host (gets value & exists)', async () => {
+      const contractAddress = new Fr(1);
+      const slot = new Fr(2);
+      const storedValue = new Fr(420);
+      // ensure that fallback to host gets a value
+      publicDb.storageRead.mockResolvedValue(Promise.resolve(storedValue));
+
+      const [exists, gotValue] = await publicStorage.read(contractAddress, slot);
+      // it exists in the host, so it must've been written before
+      expect(exists).toEqual(true);
+      expect(gotValue).toEqual(storedValue);
+    });
+    it('Reading works on fallback to parent (gets value & exists)', async () => {
+      const contractAddress = new Fr(1);
+      const slot = new Fr(2);
+      const value = new Fr(3);
+      const childStorage = new PublicStorage(publicDb, publicStorage);
+
+      publicStorage.write(contractAddress, slot, value);
+      const [exists, gotValue] = await childStorage.read(contractAddress, slot);
+      // exists because it was previously written!
+      expect(exists).toEqual(true);
+      expect(gotValue).toEqual(value);
+    });
+    it('When reading from storage, should check cache, then parent, then host', async () => {
+      // Store a different value in storage vs the cache, and make sure the cache is returned
+      const contractAddress = new Fr(1);
+      const slot = new Fr(2);
+      const storedValue = new Fr(420);
+      const parentValue = new Fr(69);
+      const cachedValue = new Fr(1337);
+
+      publicDb.storageRead.mockResolvedValue(Promise.resolve(storedValue));
+      const childStorage = new PublicStorage(publicDb, publicStorage);
+
+      // Cache miss falls back to host
+      const [, cacheMissResult] = await childStorage.read(contractAddress, slot);
+      expect(cacheMissResult).toEqual(storedValue);
+
+      // Write to storage
+      publicStorage.write(contractAddress, slot, parentValue);
+      // Reading from child should give value written in parent
+      const [, valueFromParent] = await childStorage.read(contractAddress, slot);
+      expect(valueFromParent).toEqual(parentValue);
+
+      // Now write a value directly in child
+      childStorage.write(contractAddress, slot, cachedValue);
+
+      // Reading should now give the value written in child
+      const [, cachedResult] = await childStorage.read(contractAddress, slot);
+      expect(cachedResult).toEqual(cachedValue);
+    });
+  });
+
+  it('Should be able to merge two public storages together', async () => {
+    // Checking that child's writes take precedence on marge
+    const contractAddress = new Fr(1);
+    const slot = new Fr(2);
+    // value written initially in parent
+    const value = new Fr(1);
+    // value overwritten in child and later merged into parent
+    const valueT1 = new Fr(2);
+
+    // Write initial value to parent
+    publicStorage.write(contractAddress, slot, value);
+
+    const childStorage = new PublicStorage(publicDb, publicStorage);
+    // Write valueT1 to child
+    childStorage.write(contractAddress, slot, valueT1);
+
+    // Parent accepts child's staged writes
+    publicStorage.acceptAndMerge(childStorage);
+
+    // Read from parent gives latest value written in child before merge (valueT1)
+    const [exists, result] = await publicStorage.read(contractAddress, slot);
+    expect(exists).toEqual(true);
+    expect(result).toEqual(valueT1);
+  });
+});

--- a/yarn-project/simulator/src/avm/journal/public_storage.ts
+++ b/yarn-project/simulator/src/avm/journal/public_storage.ts
@@ -1,0 +1,149 @@
+import { Fr } from '@aztec/foundation/fields';
+
+import type { PublicStateDB } from '../../index.js';
+
+/**
+ * A class to manage public storage reads and writes during a contract call's AVM simulation.
+ * Maintains a storage write cache, and ensures that reads fall back to the correct source.
+ * When a contract call completes, its storage cache can be merged into its parent's.
+ */
+export class PublicStorage {
+  /** Cached storage writes. */
+  private cache: PublicStorageCache;
+  /** Parent's storage cache. Checked on cache-miss. */
+  private readonly parentCache: PublicStorageCache | undefined;
+  /** Reference to node storage. Checked on parent cache-miss. */
+  private readonly hostPublicStorage: PublicStateDB;
+
+  constructor(hostPublicStorage: PublicStateDB, parent?: PublicStorage) {
+    this.hostPublicStorage = hostPublicStorage;
+    this.parentCache = parent?.cache;
+    this.cache = new PublicStorageCache();
+  }
+
+  /**
+   * Get the pending storage.
+   */
+  public getCache() {
+    return this.cache;
+  }
+
+  /**
+   * Read a value from storage.
+   * 1. Check cache.
+   * 2. Check parent's cache.
+   * 3. Fall back to the host state.
+   * 4. Not found! Value has never been written to before. Flag it as non-existent and return value zero.
+   *
+   * @param storageAddress - the address of the contract whose storage is being read from
+   * @param slot - the slot in the contract's storage being read from
+   * @returns exists: whether the slot has EVER been written to before, value: the latest value written to slot, or 0 if never written to before
+   */
+  public async read(storageAddress: Fr, slot: Fr): Promise<[/*exists=*/ boolean, /*value=*/ Fr]> {
+    // First try check this storage cache
+    let value = this.cache.read(storageAddress, slot);
+    // Then try parent's storage cache (if it exists / written to earlier in this TX)
+    if (!value && this.parentCache) {
+      value = this.parentCache?.read(storageAddress, slot);
+    }
+    // Finally try the host's Aztec state (a trip to the database)
+    if (!value) {
+      value = await this.hostPublicStorage.storageRead(storageAddress, slot);
+    }
+    // if value is undefined, that means this slot has never been written to!
+    const exists = value !== undefined;
+    const valueOrZero = exists ? value : Fr.ZERO;
+    return Promise.resolve([exists, valueOrZero]);
+  }
+
+  /**
+   * Stage a storage write.
+   *
+   * @param storageAddress - the address of the contract whose storage is being written to
+   * @param slot - the slot in the contract's storage being written to
+   * @param value - the value being written to the slot
+   */
+  public write(storageAddress: Fr, key: Fr, value: Fr) {
+    this.cache.write(storageAddress, key, value);
+  }
+
+  /**
+   * Merges another PublicStorage's cache (pending writes) into this one.
+   *
+   * @param incomingPublicStorage - the incoming public storage to merge into this instance's
+   */
+  public acceptAndMerge(incomingPublicStorage: PublicStorage) {
+    this.cache.acceptAndMerge(incomingPublicStorage.cache);
+  }
+}
+
+/**
+ * A class to cache writes to public storage during a contract call's AVM simulation.
+ * "Writes" update a map, "reads" check that map or return undefined.
+ * An instance of this class can merge another instance's staged writes into its own.
+ */
+class PublicStorageCache {
+  /**
+   * Map for staging storage writes.
+   * One inner-map per contract storage address,
+   * mapping storage slot to latest staged write value.
+   */
+  public cachePerContract: Map<bigint, Map<bigint, Fr>> = new Map();
+  // FIXME: storage ^ should be private, but its value is used in tests for "currentStorageValue"
+
+  /**
+   * Read a staged value from storage, if it has been previously written to.
+   *
+   * @param storageAddress - the address of the contract whose storage is being read from
+   * @param slot - the slot in the contract's storage being read from
+   * @returns the latest value written to slot, or undefined if no value has been written
+   */
+  public read(storageAddress: Fr, slot: Fr): Fr | undefined {
+    return this.cachePerContract.get(storageAddress.toBigInt())?.get(slot.toBigInt());
+  }
+
+  /**
+   * Stage a storage write.
+   *
+   * @param storageAddress - the address of the contract whose storage is being written to
+   * @param slot - the slot in the contract's storage being written to
+   * @param value - the value being written to the slot
+   */
+  public write(storageAddress: Fr, slot: Fr, value: Fr) {
+    let cacheAtContract = this.cachePerContract.get(storageAddress.toBigInt());
+    if (!cacheAtContract) {
+      // If this contract's storage has no staged modifications, create a new inner map to store them
+      cacheAtContract = new Map();
+      this.cachePerContract.set(storageAddress.toBigInt(), cacheAtContract);
+    }
+    cacheAtContract.set(slot.toBigInt(), value);
+  }
+
+  /**
+   * Merges another cache's staged writes into this instance's cache.
+   *
+   * Staged modifications in "incoming" take precedence over those
+   * present in "this" as they are assumed to occur after this' writes.
+   *
+   * In practice, "this" is a parent call's storage cache, and "incoming" is a nested call's.
+   *
+   * @param incomingStorageCache - the incoming storage write cache to merge into this instance's
+   */
+  public acceptAndMerge(incomingStorageCache: PublicStorageCache) {
+    // Iterate over all incoming contracts with staged writes.
+    for (const [incomingAddress, incomingCacheAtContract] of incomingStorageCache.cachePerContract) {
+      const thisCacheAtContract = this.cachePerContract.get(incomingAddress);
+      if (!thisCacheAtContract) {
+        // The contract has no storage writes staged here
+        // so just accept the incoming cache as-is for this contract.
+        this.cachePerContract.set(incomingAddress, incomingCacheAtContract);
+      } else {
+        // "Incoming" and "this" both have staged writes for this contract.
+        // Merge in incoming staged writes, giving them precedence over this'.
+        for (const [slot, value] of incomingCacheAtContract) {
+          thisCacheAtContract.set(slot, value);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Moved the public storage / current-value-mapping out of the journal. Created two classes:

1. PublicStorage: forwards writes to PublicStorageCache, makes sure that reads fall back to the proper place (cache, then parent, then host)
1. PublicStorageCache: a slim cache that tracks pending writes per slot and handles cache merges.

I have done something similar (but _different_) with nullifiers, and I have a bunch of other changes I'm trying to layer on top of this.