### PR TITLE
chore(avm-simulator): create a dedicated component just for tracing world state accesses

### DIFF
--- a/yarn-project/simulator/src/avm/avm_context.test.ts
+++ b/yarn-project/simulator/src/avm/avm_context.test.ts
@@ -26,7 +26,7 @@ describe('Avm Context', () => {
     );
 
     // We stringify to remove circular references (parentJournal)
-    expect(JSON.stringify(newContext.worldState)).toEqual(JSON.stringify(context.worldState.fork()));
+    expect(JSON.stringify(newContext.persistableState)).toEqual(JSON.stringify(context.persistableState.fork()));
   });
 
   it('New static call should fork context correctly', () => {
@@ -52,6 +52,6 @@ describe('Avm Context', () => {
     );
 
     // We stringify to remove circular references (parentJournal)
-    expect(JSON.stringify(newContext.worldState)).toEqual(JSON.stringify(context.worldState.fork()));
+    expect(JSON.stringify(newContext.persistableState)).toEqual(JSON.stringify(context.persistableState.fork()));
   });
 });

--- a/yarn-project/simulator/src/avm/avm_context.ts
+++ b/yarn-project/simulator/src/avm/avm_context.ts
@@ -3,7 +3,7 @@ import { Fr } from '@aztec/foundation/fields';
 
 import { AvmExecutionEnvironment } from './avm_execution_environment.js';
 import { AvmMachineState } from './avm_machine_state.js';
-import { AvmWorldStateJournal } from './journal/journal.js';
+import { AvmPersistableStateManager } from './journal/journal.js';
 
 /**
  * An execution context includes the information necessary to initiate AVM
@@ -12,13 +12,13 @@ import { AvmWorldStateJournal } from './journal/journal.js';
 export class AvmContext {
   /**
    * Create a new AVM context
-   * @param worldState - Manages mutable state during execution - (caching, fetching)
+   * @param persistableState - Manages world state and accrued substate during execution - (caching, fetching, tracing)
    * @param environment - Contains constant variables provided by the kernel
    * @param machineState - VM state that is modified on an instruction-by-instruction basis
    * @returns new AvmContext instance
    */
   constructor(
-    public worldState: AvmWorldStateJournal,
+    public persistableState: AvmPersistableStateManager,
     public environment: AvmExecutionEnvironment,
     public machineState: AvmMachineState,
   ) {}
@@ -37,7 +37,7 @@ export class AvmContext {
    */
   public createNestedContractCallContext(address: AztecAddress, calldata: Fr[]): AvmContext {
     const newExecutionEnvironment = this.environment.deriveEnvironmentForNestedCall(address, calldata);
-    const forkedWorldState = this.worldState.fork();
+    const forkedWorldState = this.persistableState.fork();
     const machineState = AvmMachineState.fromState(this.machineState);
     return new AvmContext(forkedWorldState, newExecutionEnvironment, machineState);
   }
@@ -56,7 +56,7 @@ export class AvmContext {
    */
   public createNestedContractStaticCallContext(address: AztecAddress, calldata: Fr[]): AvmContext {
     const newExecutionEnvironment = this.environment.deriveEnvironmentForNestedStaticCall(address, calldata);
-    const forkedWorldState = this.worldState.fork();
+    const forkedWorldState = this.persistableState.fork();
     const machineState = AvmMachineState.fromState(this.machineState);
     return new AvmContext(forkedWorldState, newExecutionEnvironment, machineState);
   }

--- a/yarn-project/simulator/src/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.test.ts
@@ -24,7 +24,9 @@ describe('AVM simulator', () => {
     ]);
 
     const context = initContext({ env: initExecutionEnvironment({ calldata }) });
-    jest.spyOn(context.worldState.hostStorage.contractsDb, 'getBytecode').mockReturnValue(Promise.resolve(bytecode));
+    jest
+      .spyOn(context.persistableState.hostStorage.contractsDb, 'getBytecode')
+      .mockReturnValue(Promise.resolve(bytecode));
 
     const results = await new AvmSimulator(context).execute();
 
@@ -46,7 +48,9 @@ describe('AVM simulator', () => {
       const bytecode = Buffer.from(addArtifact.bytecode, 'base64');
 
       const context = initContext({ env: initExecutionEnvironment({ calldata }) });
-      jest.spyOn(context.worldState.hostStorage.contractsDb, 'getBytecode').mockReturnValue(Promise.resolve(bytecode));
+      jest
+        .spyOn(context.persistableState.hostStorage.contractsDb, 'getBytecode')
+        .mockReturnValue(Promise.resolve(bytecode));
 
       const results = await new AvmSimulator(context).execute();
 
@@ -71,7 +75,7 @@ describe('AVM simulator', () => {
 
         const context = initContext();
         jest
-          .spyOn(context.worldState.hostStorage.contractsDb, 'getBytecode')
+          .spyOn(context.persistableState.hostStorage.contractsDb, 'getBytecode')
           .mockReturnValue(Promise.resolve(bytecode));
 
         const results = await new AvmSimulator(context).execute();
@@ -99,7 +103,7 @@ describe('AVM simulator', () => {
 
         const context = initContext({ env: initExecutionEnvironment({ calldata }) });
         jest
-          .spyOn(context.worldState.hostStorage.contractsDb, 'getBytecode')
+          .spyOn(context.persistableState.hostStorage.contractsDb, 'getBytecode')
           .mockReturnValue(Promise.resolve(bytecode));
 
         const results = await new AvmSimulator(context).execute();
@@ -131,7 +135,7 @@ describe('AVM simulator', () => {
 
         const context = initContext({ env: initExecutionEnvironment({ calldata }) });
         jest
-          .spyOn(context.worldState.hostStorage.contractsDb, 'getBytecode')
+          .spyOn(context.persistableState.hostStorage.contractsDb, 'getBytecode')
           .mockReturnValue(Promise.resolve(bytecode));
 
         const results = await new AvmSimulator(context).execute();
@@ -160,7 +164,7 @@ describe('AVM simulator', () => {
         // Decode bytecode into instructions
         const bytecode = Buffer.from(getterArtifact.bytecode, 'base64');
         jest
-          .spyOn(context.worldState.hostStorage.contractsDb, 'getBytecode')
+          .spyOn(context.persistableState.hostStorage.contractsDb, 'getBytecode')
           .mockReturnValue(Promise.resolve(bytecode));
         // Execute
 

--- a/yarn-project/simulator/src/avm/avm_simulator.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.ts
@@ -73,7 +73,7 @@ export class AvmSimulator {
     // NOTE: the following is mocked as getPublicBytecode does not exist yet
 
     const selector = this.context.environment.temporaryFunctionSelector;
-    const bytecode = await this.context.worldState.hostStorage.contractsDb.getBytecode(
+    const bytecode = await this.context.persistableState.hostStorage.contractsDb.getBytecode(
       this.context.environment.address,
       selector,
     );

--- a/yarn-project/simulator/src/avm/fixtures/index.ts
+++ b/yarn-project/simulator/src/avm/fixtures/index.ts
@@ -12,13 +12,13 @@ import { AvmContext } from '../avm_context.js';
 import { AvmExecutionEnvironment } from '../avm_execution_environment.js';
 import { AvmMachineState } from '../avm_machine_state.js';
 import { HostStorage } from '../journal/host_storage.js';
-import { AvmWorldStateJournal } from '../journal/journal.js';
+import { AvmPersistableStateManager } from '../journal/journal.js';
 
 /**
  * Create a new AVM context with default values.
  */
 export function initContext(overrides?: {
-  worldState?: AvmWorldStateJournal;
+  worldState?: AvmPersistableStateManager;
   env?: AvmExecutionEnvironment;
   machineState?: AvmMachineState;
 }): AvmContext {
@@ -30,9 +30,9 @@ export function initContext(overrides?: {
 }
 
 /** Creates an empty world state with mocked storage. */
-export function initMockWorldStateJournal(): AvmWorldStateJournal {
+export function initMockWorldStateJournal(): AvmPersistableStateManager {
   const hostStorage = new HostStorage(mock<PublicStateDB>(), mock<PublicContractsDB>(), mock<CommitmentsDB>());
-  return new AvmWorldStateJournal(hostStorage);
+  return new AvmPersistableStateManager(hostStorage);
 }
 
 /**

--- a/yarn-project/simulator/src/avm/journal/journal.ts
+++ b/yarn-project/simulator/src/avm/journal/journal.ts
@@ -2,6 +2,7 @@ import { Fr } from '@aztec/foundation/fields';
 
 import { HostStorage } from './host_storage.js';
 import { PublicStorage } from './public_storage.js';
+import { WorldStateAccessTrace } from './trace.js';
 
 /**
  * Data held within the journal
@@ -22,43 +23,42 @@ export type JournalData = {
 };
 
 /**
- * A cache of the current state of the AVM
- * The interpreter should make any state queries through this object
+ * A class to manage persistable AVM state for contract calls.
+ * Maintains a cache of the current world state,
+ * a trace of all world state accesses, and a list of accrued substate items.
  *
- * When a nested context succeeds, it's journal is merge into the parent
- * When a call fails, it's journal is discarded and the parent is used from this point forward
- * When a call succeeds's we can merge a child into its parent
+ * The simulator should make any world state and accrued substate queries through this object.
+ *
+ * Manages merging of successful/reverted child state into current state.
  */
-export class AvmWorldStateJournal {
+export class AvmPersistableStateManager {
   /** Reference to node storage */
   public readonly hostStorage: HostStorage;
 
-  /** World State's public storage, including cached writes */
+  /** World State */
+  /** Public storage, including cached writes */
   private publicStorage: PublicStorage;
+  ///** Nullifier set, including cached/recently-emitted nullifiers */
+  //private nullifiers: NullifiersDB;
 
-  // Reading state - must be tracked for vm execution
-  // contract address -> key -> value[] (array stored in order of reads)
-  private storageReads: Map<bigint, Map<bigint, Fr[]>> = new Map();
-  private storageWrites: Map<bigint, Map<bigint, Fr[]>> = new Map();
+  /** World State Access Trace */
+  private trace: WorldStateAccessTrace;
 
-  // New written state
-  private newNoteHashes: Fr[] = [];
-  private newNullifiers: Fr[] = [];
-
-  // New Substate
+  /** Accrued Substate **/
   private newL1Messages: Fr[][] = [];
   private newLogs: Fr[][] = [];
 
-  constructor(hostStorage: HostStorage, parentJournal?: AvmWorldStateJournal) {
+  constructor(hostStorage: HostStorage, parent?: AvmPersistableStateManager) {
     this.hostStorage = hostStorage;
-    this.publicStorage = new PublicStorage(hostStorage.publicStateDb, parentJournal?.publicStorage);
+    this.publicStorage = new PublicStorage(hostStorage.publicStateDb, parent?.publicStorage);
+    this.trace = new WorldStateAccessTrace(parent?.trace);
   }
 
   /**
-   * Create a new world state journal forked from this one
+   * Create a new state manager forked from this one
    */
   public fork() {
-    return new AvmWorldStateJournal(this.hostStorage, this);
+    return new AvmPersistableStateManager(this.hostStorage, this);
   }
 
   /**
@@ -71,11 +71,11 @@ export class AvmWorldStateJournal {
   public writeStorage(storageAddress: Fr, slot: Fr, value: Fr) {
     this.publicStorage.write(storageAddress, slot, value);
     // We want to keep track of all performed writes in the journal
-    this.journalWrite(storageAddress, slot, value);
+    this.trace.tracePublicStorageWrite(storageAddress, slot, value);
   }
 
   /**
-   * Read from public storage, journal/trace the read.
+   * Read from public storage, trace the read.
    *
    * @param storageAddress - the address of the contract whose storage is being read from
    * @param slot - the slot in the contract's storage being read from
@@ -83,49 +83,22 @@ export class AvmWorldStateJournal {
    */
   public async readStorage(storageAddress: Fr, slot: Fr): Promise<Fr> {
     const [_exists, value] = await this.publicStorage.read(storageAddress, slot);
-    // We want to keep track of all performed reads in the journal
-    this.journalRead(storageAddress, slot, value);
+    // We want to keep track of all performed reads
+    this.trace.tracePublicStorageRead(storageAddress, slot, value);
     return Promise.resolve(value);
   }
 
-  /**
-   * We want to keep track of all performed reads in the journal
-   * This information is hinted to the avm circuit
-
-   * @param contractAddress -
-   * @param key -
-   * @param value -
-   */
-  journalUpdate(map: Map<bigint, Map<bigint, Fr[]>>, contractAddress: Fr, key: Fr, value: Fr): void {
-    let contractMap = map.get(contractAddress.toBigInt());
-    if (!contractMap) {
-      contractMap = new Map<bigint, Array<Fr>>();
-      map.set(contractAddress.toBigInt(), contractMap);
-    }
-
-    let accessArray = contractMap.get(key.toBigInt());
-    if (!accessArray) {
-      accessArray = new Array<Fr>();
-      contractMap.set(key.toBigInt(), accessArray);
-    }
-    accessArray.push(value);
+  public writeNoteHash(noteHash: Fr) {
+    this.trace.traceNewNoteHash(/*storageAddress*/ Fr.ZERO, noteHash);
   }
 
-  // Create an instance of journalUpdate that appends to the read array
-  private journalRead = this.journalUpdate.bind(this, this.storageReads);
-  // Create an instance of journalUpdate that appends to the writes array
-  private journalWrite = this.journalUpdate.bind(this, this.storageWrites);
-
-  public writeNoteHash(noteHash: Fr) {
-    this.newNoteHashes.push(noteHash);
+  public writeNullifier(nullifier: Fr) {
+    // TODO track pending nullifiers in set per-contract
+    this.trace.traceNewNullifier(/*storageAddress*/ Fr.ZERO, nullifier);
   }
 
   public writeL1Message(message: Fr[]) {
     this.newL1Messages.push(message);
-  }
-
-  public writeNullifier(nullifier: Fr) {
-    this.newNullifiers.push(nullifier);
   }
 
   public writeLog(log: Fr[]) {
@@ -133,36 +106,26 @@ export class AvmWorldStateJournal {
   }
 
   /**
-   * Accept nested world state, merging in its journal, and accepting its state modifications
-   * - Utxo objects are concatenated
-   * - Public state changes are merged, with the value in the incoming journal taking precedent
-   * - Public state journals (r/w logs), with the accessing being appended in chronological order
+   * Accept nested world state modifications, merging in its trace and accrued substate
    */
-  public acceptNestedWorldState(nestedJournal: AvmWorldStateJournal) {
+  public acceptNestedCallState(nestedJournal: AvmPersistableStateManager) {
     // Merge Public Storage
     this.publicStorage.acceptAndMerge(nestedJournal.publicStorage);
 
-    // Merge UTXOs
-    this.newNoteHashes = this.newNoteHashes.concat(nestedJournal.newNoteHashes);
-    this.newL1Messages = this.newL1Messages.concat(nestedJournal.newL1Messages);
-    this.newNullifiers = this.newNullifiers.concat(nestedJournal.newNullifiers);
-    this.newLogs = this.newLogs.concat(nestedJournal.newLogs);
+    // Merge World State Access Trace
+    this.trace.acceptAndMerge(nestedJournal.trace);
 
-    // Merge storage read and write journals
-    mergeContractJournalMaps(this.storageReads, nestedJournal.storageReads);
-    mergeContractJournalMaps(this.storageWrites, nestedJournal.storageWrites);
+    // Accrued Substate
+    this.newL1Messages = this.newL1Messages.concat(nestedJournal.newL1Messages);
+    this.newLogs = this.newLogs.concat(nestedJournal.newLogs);
   }
 
   /**
-   * Reject nested world state, merging in its journal, but not accepting its state modifications
-   * - Utxo objects are concatenated
-   * - Public state changes are dropped
-   * - Public state journals (r/w logs) are maintained, with the accessing being appended in chronological order
+   * Reject nested world state, merging in its trace, but not accepting any state modifications
    */
-  public rejectNestedWorldState(nestedJournal: AvmWorldStateJournal) {
-    // Merge storage read and write journals
-    mergeContractJournalMaps(this.storageReads, nestedJournal.storageReads);
-    mergeContractJournalMaps(this.storageWrites, nestedJournal.storageWrites);
+  public rejectNestedCallState(nestedJournal: AvmPersistableStateManager) {
+    // Merge World State Access Trace
+    this.trace.acceptAndMerge(nestedJournal.trace);
   }
 
   /**
@@ -172,46 +135,13 @@ export class AvmWorldStateJournal {
    */
   public flush(): JournalData {
     return {
-      newNoteHashes: this.newNoteHashes,
-      newNullifiers: this.newNullifiers,
+      newNoteHashes: this.trace.newNoteHashes,
+      newNullifiers: this.trace.newNullifiers,
       newL1Messages: this.newL1Messages,
       newLogs: this.newLogs,
       currentStorageValue: this.publicStorage.getCache().cachePerContract,
-      storageReads: this.storageReads,
-      storageWrites: this.storageWrites,
+      storageReads: this.trace.publicStorageReads,
+      storageWrites: this.trace.publicStorageWrites,
     };
-  }
-}
-
-/**
- * Merges two contract journalling maps together
- * For read maps, we just append the childMap arrays into the host map arrays, as the order is important
- *
- * @param hostMap - The map to be merged into
- * @param childMap - The map to be merged from
- */
-function mergeContractJournalMaps(hostMap: Map<bigint, Map<bigint, Fr[]>>, childMap: Map<bigint, Map<bigint, Fr[]>>) {
-  for (const [key, value] of childMap) {
-    const map1Value = hostMap.get(key);
-    if (!map1Value) {
-      hostMap.set(key, value);
-    } else {
-      mergeStorageJournalMaps(map1Value, value);
-    }
-  }
-}
-
-/**
- * @param hostMap - The map to be merge into
- * @param childMap - The map to be merged from
- */
-function mergeStorageJournalMaps(hostMap: Map<bigint, Fr[]>, childMap: Map<bigint, Fr[]>) {
-  for (const [key, value] of childMap) {
-    const readArr = hostMap.get(key);
-    if (!readArr) {
-      hostMap.set(key, value);
-    } else {
-      hostMap.set(key, readArr?.concat(...value));
-    }
   }
 }

--- a/yarn-project/simulator/src/avm/journal/trace.test.ts
+++ b/yarn-project/simulator/src/avm/journal/trace.test.ts
@@ -1,0 +1,61 @@
+import { Fr } from '@aztec/foundation/fields';
+
+import { WorldStateAccessTrace } from './trace.js';
+
+describe('world state access trace', () => {
+  let trace: WorldStateAccessTrace;
+
+  beforeEach(() => {
+    trace = new WorldStateAccessTrace();
+  });
+
+  describe('UTXOs', () => {
+    it('Should trace commitments', () => {
+      const contractAddress = new Fr(1);
+      const utxo = new Fr(2);
+      trace.traceNewNoteHash(contractAddress, utxo);
+      expect(trace.newNoteHashes).toEqual([utxo]);
+      expect(trace.getAccessCounter()).toEqual(1);
+    });
+
+    it('Should trace nullifiers', () => {
+      const contractAddress = new Fr(1);
+      const utxo = new Fr(2);
+      trace.traceNewNullifier(contractAddress, utxo);
+      expect(trace.newNullifiers).toEqual([utxo]);
+      expect(trace.getAccessCounter()).toEqual(1);
+    });
+  });
+
+  it('Should merge two traces together', () => {
+    const contractAddress = new Fr(1);
+    const slot = new Fr(2);
+    const value = new Fr(1);
+    const valueT1 = new Fr(2);
+    const commitment = new Fr(10);
+    const commitmentT1 = new Fr(20);
+
+    trace.tracePublicStorageWrite(contractAddress, slot, value);
+    trace.tracePublicStorageRead(contractAddress, slot, value);
+    trace.traceNewNoteHash(contractAddress, commitment);
+    trace.traceNewNullifier(contractAddress, commitment);
+    expect(trace.getAccessCounter()).toEqual(4);
+
+    const childTrace = new WorldStateAccessTrace(trace);
+    childTrace.tracePublicStorageWrite(contractAddress, slot, valueT1);
+    childTrace.tracePublicStorageRead(contractAddress, slot, valueT1);
+    childTrace.traceNewNoteHash(contractAddress, commitmentT1);
+    childTrace.traceNewNullifier(contractAddress, commitmentT1);
+    expect(childTrace.getAccessCounter()).toEqual(8);
+
+    trace.acceptAndMerge(childTrace);
+    expect(trace.getAccessCounter()).toEqual(8);
+
+    const slotReads = trace.publicStorageReads?.get(contractAddress.toBigInt())?.get(slot.toBigInt());
+    const slotWrites = trace.publicStorageWrites?.get(contractAddress.toBigInt())?.get(slot.toBigInt());
+    expect(slotReads).toEqual([value, valueT1]);
+    expect(slotWrites).toEqual([value, valueT1]);
+    expect(trace.newNoteHashes).toEqual([commitment, commitmentT1]);
+    expect(trace.newNullifiers).toEqual([commitment, commitmentT1]);
+  });
+});

--- a/yarn-project/simulator/src/avm/journal/trace.ts
+++ b/yarn-project/simulator/src/avm/journal/trace.ts
@@ -1,0 +1,175 @@
+import { Fr } from '@aztec/foundation/fields';
+
+export class WorldStateAccessTrace {
+  public accessCounter: number;
+  //public contractCalls: Array<TracedContractCall> = [];
+
+  //public publicStorageReads: Array<TracedPublicStorageRead> = [];
+  public publicStorageReads: Map<bigint, Map<bigint, Fr[]>> = new Map();
+  //public publicStorageWrites: Array<TracedPublicStorageWrite> = [];
+  public publicStorageWrites: Map<bigint, Map<bigint, Fr[]>> = new Map();
+
+  //public noteHashChecks: TracedNoteHashCheck[] = [];
+  //public newNoteHashes: TracedNoteHash[] = [];
+  public newNoteHashes: Fr[] = [];
+  //public nullifierChecks: TracedNullifierCheck[] = [];
+  //public newNullifiers: TracedNullifier[] = [];
+  public newNullifiers: Fr[] = [];
+  //public l1toL2MessageReads: TracedL1toL2MessageRead[] = [];
+  //public archiveChecks: TracedArchiveLeafCheck[] = [];
+
+  constructor(parentTrace?: WorldStateAccessTrace) {
+    this.accessCounter = parentTrace ? parentTrace.accessCounter : 0;
+  }
+
+  public getAccessCounter() {
+    return this.accessCounter;
+  }
+
+  public tracePublicStorageRead(storageAddress: Fr, slot: Fr, value: Fr /*, _exists: boolean*/) {
+    // TODO: check if some threshold is reached for max storage reads
+    // (need access to parent length, or trace needs to be initialized with parent's contents)
+    //const traced: TracedPublicStorageRead = {
+    //  callPointer: Fr.ZERO,
+    //  storageAddress,
+    //  slot,
+    //  value,
+    //  exists,
+    //  counter: new Fr(this.accessCounter),
+    //  endLifetime: Fr.ZERO,
+    //};
+    //this.publicStorageReads.push(traced);
+    this.journalRead(storageAddress, slot, value);
+    this.incrementAccessCounter();
+  }
+
+  public tracePublicStorageWrite(storageAddress: Fr, slot: Fr, value: Fr) {
+    // TODO: check if some threshold is reached for max storage writes
+    // (need access to parent length, or trace needs to be initialized with parent's contents)
+    //const traced: TracedPublicStorageWrite = {
+    //  callPointer: Fr.ZERO,
+    //  storageAddress,
+    //  slot,
+    //  value,
+    //  counter: new Fr(this.accessCounter),
+    //  endLifetime: Fr.ZERO,
+    //};
+    //this.publicStorageWrites.push(traced);
+    this.journalWrite(storageAddress, slot, value);
+    this.incrementAccessCounter();
+  }
+
+  public traceNewNoteHash(_storageAddress: Fr, noteHash: Fr) {
+    // TODO: check if some threshold is reached for max new note hash
+    //const traced: TracedNoteHash = {
+    //  callPointer: Fr.ZERO,
+    //  storageAddress,
+    //  noteHash,
+    //  counter: new Fr(this.accessCounter),
+    //  endLifetime: Fr.ZERO,
+    //};
+    //this.newNoteHashes.push(traced);
+    this.newNoteHashes.push(noteHash);
+    this.incrementAccessCounter();
+  }
+
+  public traceNewNullifier(_storageAddress: Fr, nullifier: Fr) {
+    // TODO: check if some threshold is reached for max new nullifier
+    //const traced: TracedNullifier = {
+    //  callPointer: Fr.ZERO,
+    //  storageAddress,
+    //  nullifier,
+    //  counter: new Fr(this.accessCounter),
+    //  endLifetime: Fr.ZERO,
+    //};
+    //this.newNullifiers.push(traced);
+    this.newNullifiers.push(nullifier);
+    this.incrementAccessCounter();
+  }
+
+  private incrementAccessCounter() {
+    this.accessCounter++;
+  }
+
+  /**
+   * Merges another trace into this one
+   *
+   * - Public state journals (r/w logs), with the accessing being appended in chronological order
+   * - Utxo objects are concatenated
+   *
+   * @param incomingTrace - the incoming trace to merge into this instance
+   */
+  public acceptAndMerge(incomingTrace: WorldStateAccessTrace) {
+    // Merge storage read and write journals
+    mergeContractJournalMaps(this.publicStorageReads, incomingTrace.publicStorageReads);
+    mergeContractJournalMaps(this.publicStorageWrites, incomingTrace.publicStorageWrites);
+    // Merge new note hashes and nullifiers
+    this.newNoteHashes = this.newNoteHashes.concat(incomingTrace.newNoteHashes);
+    this.newNullifiers = this.newNullifiers.concat(incomingTrace.newNullifiers);
+    // it is assumed that the incoming trace was initialized with this as parent, so accept counter
+    this.accessCounter = incomingTrace.accessCounter;
+  }
+
+  /**
+   * We want to keep track of all performed reads in the journal
+   * This information is hinted to the avm circuit
+
+   * @param contractAddress -
+   * @param key -
+   * @param value -
+   */
+  journalUpdate(map: Map<bigint, Map<bigint, Fr[]>>, contractAddress: Fr, key: Fr, value: Fr): void {
+    let contractMap = map.get(contractAddress.toBigInt());
+    if (!contractMap) {
+      contractMap = new Map<bigint, Array<Fr>>();
+      map.set(contractAddress.toBigInt(), contractMap);
+    }
+
+    let accessArray = contractMap.get(key.toBigInt());
+    if (!accessArray) {
+      accessArray = new Array<Fr>();
+      contractMap.set(key.toBigInt(), accessArray);
+    }
+    accessArray.push(value);
+  }
+
+  // Create an instance of journalUpdate that appends to the read array
+  private journalRead = this.journalUpdate.bind(this, this.publicStorageReads);
+  // Create an instance of journalUpdate that appends to the writes array
+  private journalWrite = this.journalUpdate.bind(this, this.publicStorageWrites);
+}
+
+/**
+ * Merges two contract journalling maps together
+ * For read maps, we just append the childMap arrays into the host map arrays, as the order is important
+ *
+ * @param hostMap - The map to be merged into
+ * @param childMap - The map to be merged from
+ */
+function mergeContractJournalMaps(hostMap: Map<bigint, Map<bigint, Fr[]>>, childMap: Map<bigint, Map<bigint, Fr[]>>) {
+  for (const [key, value] of childMap) {
+    const map1Value = hostMap.get(key);
+    if (!map1Value) {
+      hostMap.set(key, value);
+    } else {
+      mergeStorageJournalMaps(map1Value, value);
+    }
+  }
+}
+
+/**
+ * Merge two storage journalling maps together (for a particular contract).
+ *
+ * @param hostMap - The map to be merge into
+ * @param childMap - The map to be merged from
+ */
+function mergeStorageJournalMaps(hostMap: Map<bigint, Fr[]>, childMap: Map<bigint, Fr[]>) {
+  for (const [key, value] of childMap) {
+    const readArr = hostMap.get(key);
+    if (!readArr) {
+      hostMap.set(key, value);
+    } else {
+      hostMap.set(key, readArr?.concat(...value));
+    }
+  }
+}

--- a/yarn-project/simulator/src/avm/opcodes/accrued_substate.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/accrued_substate.test.ts
@@ -30,7 +30,7 @@ describe('Accrued Substate', () => {
 
       await new EmitNoteHash(/*indirect=*/ 0, /*offset=*/ 0).execute(context);
 
-      const journalState = context.worldState.flush();
+      const journalState = context.persistableState.flush();
       const expected = [value.toFr()];
       expect(journalState.newNoteHashes).toEqual(expected);
     });
@@ -55,7 +55,7 @@ describe('Accrued Substate', () => {
 
       await new EmitNullifier(/*indirect=*/ 0, /*offset=*/ 0).execute(context);
 
-      const journalState = context.worldState.flush();
+      const journalState = context.persistableState.flush();
       const expected = [value.toFr()];
       expect(journalState.newNullifiers).toEqual(expected);
     });
@@ -85,7 +85,7 @@ describe('Accrued Substate', () => {
 
       await new EmitUnencryptedLog(/*indirect=*/ 0, /*offset=*/ startOffset, length).execute(context);
 
-      const journalState = context.worldState.flush();
+      const journalState = context.persistableState.flush();
       const expected = values.map(v => v.toFr());
       expect(journalState.newLogs).toEqual([expected]);
     });
@@ -115,7 +115,7 @@ describe('Accrued Substate', () => {
 
       await new SendL2ToL1Message(/*indirect=*/ 0, /*offset=*/ startOffset, length).execute(context);
 
-      const journalState = context.worldState.flush();
+      const journalState = context.persistableState.flush();
       const expected = values.map(v => v.toFr());
       expect(journalState.newL1Messages).toEqual([expected]);
     });

--- a/yarn-project/simulator/src/avm/opcodes/accrued_substate.ts
+++ b/yarn-project/simulator/src/avm/opcodes/accrued_substate.ts
@@ -19,7 +19,7 @@ export class EmitNoteHash extends Instruction {
     }
 
     const noteHash = context.machineState.memory.get(this.noteHashOffset).toFr();
-    context.worldState.writeNoteHash(noteHash);
+    context.persistableState.writeNoteHash(noteHash);
 
     context.machineState.incrementPc();
   }
@@ -41,7 +41,7 @@ export class EmitNullifier extends Instruction {
     }
 
     const nullifier = context.machineState.memory.get(this.nullifierOffset).toFr();
-    context.worldState.writeNullifier(nullifier);
+    context.persistableState.writeNullifier(nullifier);
 
     context.machineState.incrementPc();
   }
@@ -63,7 +63,7 @@ export class EmitUnencryptedLog extends Instruction {
     }
 
     const log = context.machineState.memory.getSlice(this.logOffset, this.logSize).map(f => f.toFr());
-    context.worldState.writeLog(log);
+    context.persistableState.writeLog(log);
 
     context.machineState.incrementPc();
   }
@@ -85,7 +85,7 @@ export class SendL2ToL1Message extends Instruction {
     }
 
     const msg = context.machineState.memory.getSlice(this.msgOffset, this.msgSize).map(f => f.toFr());
-    context.worldState.writeL1Message(msg);
+    context.persistableState.writeL1Message(msg);
 
     context.machineState.incrementPc();
   }

--- a/yarn-project/simulator/src/avm/opcodes/external_calls.ts
+++ b/yarn-project/simulator/src/avm/opcodes/external_calls.ts
@@ -54,9 +54,9 @@ export class Call extends Instruction {
     context.machineState.memory.setSlice(this.retOffset, convertedReturnData);
 
     if (success) {
-      context.worldState.acceptNestedWorldState(nestedContext.worldState);
+      context.persistableState.acceptNestedCallState(nestedContext.persistableState);
     } else {
-      context.worldState.rejectNestedWorldState(nestedContext.worldState);
+      context.persistableState.rejectNestedCallState(nestedContext.persistableState);
     }
 
     context.machineState.incrementPc();
@@ -112,9 +112,9 @@ export class StaticCall extends Instruction {
     context.machineState.memory.setSlice(this.retOffset, convertedReturnData);
 
     if (success) {
-      context.worldState.acceptNestedWorldState(nestedContext.worldState);
+      context.persistableState.acceptNestedCallState(nestedContext.persistableState);
     } else {
-      context.worldState.rejectNestedWorldState(nestedContext.worldState);
+      context.persistableState.rejectNestedCallState(nestedContext.persistableState);
     }
 
     context.machineState.incrementPc();

--- a/yarn-project/simulator/src/avm/opcodes/storage.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/storage.test.ts
@@ -6,16 +6,16 @@ import { MockProxy, mock } from 'jest-mock-extended';
 import { AvmContext } from '../avm_context.js';
 import { Field } from '../avm_memory_types.js';
 import { initContext, initExecutionEnvironment } from '../fixtures/index.js';
-import { AvmWorldStateJournal } from '../journal/journal.js';
+import { AvmPersistableStateManager } from '../journal/journal.js';
 import { SLoad, SStore, StaticCallStorageAlterError } from './storage.js';
 
 describe('Storage Instructions', () => {
   let context: AvmContext;
-  let journal: MockProxy<AvmWorldStateJournal>;
+  let journal: MockProxy<AvmPersistableStateManager>;
   const address = AztecAddress.random();
 
   beforeEach(async () => {
-    journal = mock<AvmWorldStateJournal>();
+    journal = mock<AvmPersistableStateManager>();
     context = initContext({ worldState: journal, env: initExecutionEnvironment({ address, storageAddress: address }) });
   });
 

--- a/yarn-project/simulator/src/avm/opcodes/storage.ts
+++ b/yarn-project/simulator/src/avm/opcodes/storage.ts
@@ -36,7 +36,7 @@ export class SStore extends BaseStorageInstruction {
     const slot = context.machineState.memory.get(this.aOffset);
     const data = context.machineState.memory.get(this.bOffset);
 
-    context.worldState.writeStorage(
+    context.persistableState.writeStorage(
       context.environment.storageAddress,
       new Fr(slot.toBigInt()),
       new Fr(data.toBigInt()),
@@ -57,7 +57,10 @@ export class SLoad extends BaseStorageInstruction {
   async execute(context: AvmContext): Promise<void> {
     const slot = context.machineState.memory.get(this.aOffset);
 
-    const data: Fr = await context.worldState.readStorage(context.environment.storageAddress, new Fr(slot.toBigInt()));
+    const data: Fr = await context.persistableState.readStorage(
+      context.environment.storageAddress,
+      new Fr(slot.toBigInt()),
+    );
 
     context.machineState.memory.set(this.bOffset, new Field(data));
 

--- a/yarn-project/simulator/src/public/executor.ts
+++ b/yarn-project/simulator/src/public/executor.ts
@@ -6,7 +6,7 @@ import { AvmContext } from '../avm/avm_context.js';
 import { AvmMachineState } from '../avm/avm_machine_state.js';
 import { AvmSimulator } from '../avm/avm_simulator.js';
 import { HostStorage } from '../avm/journal/host_storage.js';
-import { AvmWorldStateJournal } from '../avm/journal/index.js';
+import { AvmPersistableStateManager } from '../avm/journal/index.js';
 import {
   temporaryConvertAvmResults,
   temporaryCreateAvmExecutionEnvironment,
@@ -158,7 +158,7 @@ export class PublicExecutor {
     // Temporary code to construct the AVM context
     // These data structures will permiate across the simulator when the public executor is phased out
     const hostStorage = new HostStorage(this.stateDb, this.contractsDb, this.commitmentsDb);
-    const worldStateJournal = new AvmWorldStateJournal(hostStorage);
+    const worldStateJournal = new AvmPersistableStateManager(hostStorage);
     const executionEnv = temporaryCreateAvmExecutionEnvironment(execution, globalVariables);
     const machineState = new AvmMachineState(0, 0, 0);
 
@@ -166,7 +166,7 @@ export class PublicExecutor {
     const simulator = new AvmSimulator(context);
 
     const result = await simulator.execute();
-    const newWorldState = context.worldState.flush();
+    const newWorldState = context.persistableState.flush();
     return temporaryConvertAvmResults(execution, newWorldState, result);
   }
 }


### PR DESCRIPTION
Breaks up the journal further into:
1. a "persistable state manager" that manages world state caching/merging, world state access tracing, accrued substate
1. a "world state access trace" that just traces accesses with a counter (will grow in coming PRs)

Did some renaming as well since AvmContext's "worldState" was more than just world state.

I have been considering accrued substate to only be logs and l2tol1 messages. They are different from the rest of world state as they are never relevant to later calls/TXs. I am open to renaming, but for now thought that "Persistable State" is an okay term to cover world state + accrued substate.

*Note: I _am_ open to scrapping this PR!* I think it includes some objectively good content, but the splitting of "tracing" into its own class is kind of just an experiment. I personally like that it is a small simple class just for tracing, but I'd be okay with taking some of my tweaks and including it all in the top level class (similar to how it is before this PR).