### PR TITLE
fix: Fix Translator composer test instability

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.hpp
@@ -95,7 +95,6 @@ template <typename T> std::vector<bb::fr> convert_to_bn254_frs(const T& val)
     } else if constexpr (IsAnyOf<T, grumpkin::fr>) {
         return convert_grumpkin_fr_to_bn254_frs(val);
     } else if constexpr (IsAnyOf<T, curve::BN254::AffineElement, curve::Grumpkin::AffineElement>) {
-        ASSERT(!val.is_point_at_infinity());
         auto fr_vec_x = convert_to_bn254_frs(val.x);
         auto fr_vec_y = convert_to_bn254_frs(val.y);
         std::vector<bb::fr> fr_vec(fr_vec_x.begin(), fr_vec_x.end());

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.hpp
@@ -95,6 +95,7 @@ template <typename T> std::vector<bb::fr> convert_to_bn254_frs(const T& val)
     } else if constexpr (IsAnyOf<T, grumpkin::fr>) {
         return convert_grumpkin_fr_to_bn254_frs(val);
     } else if constexpr (IsAnyOf<T, curve::BN254::AffineElement, curve::Grumpkin::AffineElement>) {
+        ASSERT(!val.is_point_at_infinity());
         auto fr_vec_x = convert_to_bn254_frs(val.x);
         auto fr_vec_y = convert_to_bn254_frs(val.y);
         std::vector<bb::fr> fr_vec(fr_vec_x.begin(), fr_vec_x.end());

--- a/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.test.cpp
@@ -49,7 +49,7 @@ TEST_F(GoblinTranslatorComposerTests, Basic)
     using Fr = fr;
     using Fq = fq;
 
-    // And an element and scalar the accumulation of which leaves no Point-at-Infinity commitments
+    // Add an element and scalar the accumulation of which leaves no Point-at-Infinity commitments
     const auto x = uint256_t(0xd3c208c16d87cfd3, 0xd97816a916871ca8, 0x9b85045b68181585, 0x30644e72e131a02);
     const auto y = uint256_t(0x3ce1cc9c7e645a83, 0x2edac647851e3ac5, 0xd0cbe61fced2bc53, 0x1a76dae6d3272396);
     auto padding_element = G1(x, y);
@@ -62,7 +62,8 @@ TEST_F(GoblinTranslatorComposerTests, Basic)
     // Add the same operations to the ECC op queue; the native computation is performed under the hood.
     auto op_queue = std::make_shared<bb::ECCOpQueue>();
 
-    // Accumulate padding for non-PI commitments
+    // Accumulate padding so that we don't produce Point-at-Infinity commitments. Currently our transcript can't handle
+    // them
     op_queue->mul_accumulate(padding_element, padding_scalar);
 
     // Push everything else

--- a/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.test.cpp
@@ -49,12 +49,23 @@ TEST_F(GoblinTranslatorComposerTests, Basic)
     using Fr = fr;
     using Fq = fq;
 
+    // And an element and scalar the accumulation of which leaves no Point-at-Infinity commitments
+    const auto x = uint256_t(0xd3c208c16d87cfd3, 0xd97816a916871ca8, 0x9b85045b68181585, 0x30644e72e131a02);
+    const auto y = uint256_t(0x3ce1cc9c7e645a83, 0x2edac647851e3ac5, 0xd0cbe61fced2bc53, 0x1a76dae6d3272396);
+    auto padding_element = G1(x, y);
+    auto padding_scalar = -Fr::one();
+
     auto P1 = G1::random_element();
     auto P2 = G1::random_element();
     auto z = Fr::random_element();
 
     // Add the same operations to the ECC op queue; the native computation is performed under the hood.
     auto op_queue = std::make_shared<bb::ECCOpQueue>();
+
+    // Accumulate padding for non-PI commitments
+    op_queue->mul_accumulate(padding_element, padding_scalar);
+
+    // Push everything else
     for (size_t i = 0; i < 500; i++) {
         op_queue->add_accumulate(P1);
         op_queue->mul_accumulate(P2, z);


### PR DESCRIPTION
Pads the test with values that produce non-point-at-infinity commitments. I tried to add an ASSERT to detect when those values are trying to get into the transcript, but then AVM starts failing.
