### PR TITLE
feat: simplify public input copy cycles

### DIFF
--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.test.cpp
@@ -707,7 +707,7 @@ TEST_F(join_split_tests, test_0_input_notes_and_detect_circuit_change)
     // The below part detects any changes in the join-split circuit
     constexpr uint32_t CIRCUIT_GATE_COUNT = 49492;
     constexpr uint32_t GATES_NEXT_POWER_OF_TWO = 65535;
-    const uint256_t VK_HASH("e253629a7f74dd33ac4288473df5fac928aae029cb8f5867bb413366b54c02ba");
+    const uint256_t VK_HASH("c1032f787036ac943a5f064e599772d255423a221bba2af98ebce3baf2b53f56");
 
     auto number_of_gates_js = result.number_of_gates;
     std::cout << get_verification_key()->sha256_hash() << std::endl;

--- a/barretenberg/cpp/src/barretenberg/proof_system/execution_trace/execution_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/execution_trace/execution_trace.cpp
@@ -67,12 +67,7 @@ typename ExecutionTrace_<Flavor>::TraceData ExecutionTrace_<Flavor>::construct_t
                 // Insert the real witness values from this block into the wire polys at the correct offset
                 trace_data.wires[wire_idx][trace_row_idx] = builder.get_variable(var_idx);
                 // Add the address of the witness value to its corresponding copy cycle
-                // NB: Not adding cycles for wires 3 and 4 here is only needed in order to maintain consistency with old
-                // version. We can remove this special case and the result is simply that all the zeros in wires 3 and 4
-                // over the PI range are copy constrained together, but this changes sigma/id which changes the vkey.
-                if (!(block.is_public_input && wire_idx > 1)) {
-                    trace_data.copy_cycles[real_var_idx].emplace_back(cycle_node{ wire_idx, trace_row_idx });
-                }
+                trace_data.copy_cycles[real_var_idx].emplace_back(cycle_node{ wire_idx, trace_row_idx });
             }
         }
 


### PR DESCRIPTION
Our public input mechanism involves copying the PI into the first two wires. The third and fourth are zero over this range. Historically, each of these zeros has been in its own copy cycle. This change makes it so that all of those zeros are copy constrained together. Neither is inherently better but the latter allows the removal of special treatment for the PI when constructing the copy cycles. This change effects the sigma polynomials and thus changes the VK. I've updated the VK-consistency test in the join-split suite accordingly. (I'm making this small change in isolation because I rely on the consistency of the VK in some of my larger PRs in this series to give the reviewer confidence that nothing has changed unexpectedly).