### PR TITLE
fix: PXE devnet connectivity

### DIFF
--- a/yarn-project/aztec.js/src/rpc_clients/pxe_client.ts
+++ b/yarn-project/aztec.js/src/rpc_clients/pxe_client.ts
@@ -32,28 +32,28 @@ import { createJsonRpcClient, makeFetch } from '@aztec/foundation/json-rpc/clien
  * @param fetch - The fetch implementation to use.
  * @returns A JSON-RPC client of PXE.
  */
-export const createPXEClient = (url: string, fetch = makeFetch([1, 2, 3], true)): PXE =>
+export const createPXEClient = (url: string, fetch = makeFetch([1, 2, 3], false)): PXE =>
   createJsonRpcClient<PXE>(
     url,
     {
-      CompleteAddress,
-      FunctionSelector,
+      AuthWitness,
       AztecAddress,
-      TxExecutionRequest,
+      CompleteAddress,
       ContractData,
-      ExtendedContractData,
-      ExtendedUnencryptedL2Log,
-      TxHash,
+      FunctionSelector,
       EthAddress,
-      Point,
+      ExtendedContractData,
+      ExtendedNote,
+      ExtendedUnencryptedL2Log,
       Fr,
       GrumpkinScalar,
-      Note,
-      ExtendedNote,
-      AuthWitness,
+      L2Block,
       L2Tx,
       LogId,
-      L2Block,
+      Note,
+      Point,
+      TxExecutionRequest,
+      TxHash,
     },
     { Tx, TxReceipt, L2BlockL2Logs },
     false,

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -19,6 +19,7 @@ import {
   createDebugLogger,
   createPXEClient,
   deployL1Contracts,
+  makeFetch,
   waitForPXE,
 } from '@aztec/aztec.js';
 import {
@@ -164,7 +165,7 @@ async function setupWithRemoteEnvironment(
   logger(`Creating Aztec Node client to remote host ${aztecNodeUrl}`);
   const aztecNode = createAztecNodeClient(aztecNodeUrl);
   logger(`Creating PXE client to remote host ${PXE_URL}`);
-  const pxeClient = createPXEClient(PXE_URL);
+  const pxeClient = createPXEClient(PXE_URL, makeFetch([1, 2, 3], true));
   await waitForPXE(pxeClient, logger);
   logger('JSON RPC client connected to PXE');
   logger(`Retrieving contract addresses from ${PXE_URL}`);

--- a/yarn-project/foundation/src/json-rpc/client/json_rpc_client.ts
+++ b/yarn-project/foundation/src/json-rpc/client/json_rpc_client.ts
@@ -77,7 +77,7 @@ export function makeFetch(retries: number[], noRetry: boolean, log?: DebugLogger
   return async (host: string, rpcMethod: string, body: any, useApiEndpoints: boolean) => {
     return await retry(
       () => defaultFetch(host, rpcMethod, body, useApiEndpoints, noRetry),
-      `JsonRpcClient request to ${host}`,
+      `JsonRpcClient request ${rpcMethod} to ${host}`,
       makeBackoff(retries),
       log,
       true,

--- a/yarn-project/pxe/src/pxe_http/pxe_http_server.ts
+++ b/yarn-project/pxe/src/pxe_http/pxe_http_server.ts
@@ -20,7 +20,7 @@ import { FunctionSelector } from '@aztec/circuits.js';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr, GrumpkinScalar, Point } from '@aztec/foundation/fields';
-import { JsonRpcServer } from '@aztec/foundation/json-rpc/server';
+import { JsonRpcServer, createNamespacedJsonRpcServer } from '@aztec/foundation/json-rpc/server';
 
 import http from 'http';
 
@@ -63,7 +63,8 @@ export function createPXERpcServer(pxeService: PXE): JsonRpcServer {
  * @returns A running http server.
  */
 export function startPXEHttpServer(pxeService: PXE, port: string | number): http.Server {
-  const rpcServer = createPXERpcServer(pxeService);
+  const pxeServer = createPXERpcServer(pxeService);
+  const rpcServer = createNamespacedJsonRpcServer([{ pxe: pxeServer }]);
 
   const app = rpcServer.getApp();
   const httpServer = http.createServer(app.callback());


### PR DESCRIPTION
- Turn on retries for PXE client talking to Aztec node
- turn on `pxe_` namespacing by default when running PXE outside of the `aztec` binary context