### PR TITLE
feat(yp): Add algolia search to the yellow paper

### DIFF
--- a/yellow-paper/docusaurus.config.js
+++ b/yellow-paper/docusaurus.config.js
@@ -108,6 +108,11 @@ const config = {
         ],
       },
 
+      algolia: {
+        appId: "6RXKCCZJK7",
+        apiKey: "d0dc44e75dba0e82247eea041300ae4b",
+        indexName: "yp-aztec",
+      },
       footer: {
         style: "dark",
         links: [

--- a/yellow-paper/docusaurus.config.js
+++ b/yellow-paper/docusaurus.config.js
@@ -85,8 +85,11 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      // Replace with your project's social card
-      // image: "img/docusaurus-social-card.jpg",
+      algolia: {
+        appId: "6RXKCCZJK7",
+        apiKey: "d0dc44e75dba0e82247eea041300ae4b",
+        indexName: "yp-aztec",
+      },
       navbar: {
         title: "Home",
         // logo: {
@@ -106,11 +109,6 @@ const config = {
             position: "right",
           },
         ],
-      },
-      algolia: {
-        appId: "6RXKCCZJK7",
-        apiKey: "d0dc44e75dba0e82247eea041300ae4b",
-        indexName: "yp-aztec",
       },
       footer: {
         style: "dark",

--- a/yellow-paper/docusaurus.config.js
+++ b/yellow-paper/docusaurus.config.js
@@ -107,7 +107,6 @@ const config = {
           },
         ],
       },
-
       algolia: {
         appId: "6RXKCCZJK7",
         apiKey: "d0dc44e75dba0e82247eea041300ae4b",


### PR DESCRIPTION
This adds search to the yellow paper site.

Note: Algolia search config will need to be updated when the domain name of the site changes (e.g. https://yp-aztec.netlify.app/ --> https://yellow-paper.aztec.network)