### PR TITLE
fix: update transcript conversions to handle point at infinity

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.cpp
@@ -25,9 +25,6 @@ grumpkin::fr convert_grumpkin_fr_from_bn254_frs(std::span<const bb::fr> fr_vec)
     // Combines the two elements into one uint256_t, and then convert that to a grumpkin::fr
     ASSERT(uint256_t(fr_vec[0]) < (uint256_t(1) << (NUM_LIMB_BITS * 2)));              // lower 136 bits
     ASSERT(uint256_t(fr_vec[1]) < (uint256_t(1) << (TOTAL_BITS - NUM_LIMB_BITS * 2))); // upper 254-136=118 bits
-    auto tmp1 = uint256_t(fr_vec[0]);
-    auto tmp2 = uint256_t(fr_vec[1]) << (NUM_LIMB_BITS * 2);
-    info("tmp1 = {}, tmp2 = {}", tmp1, tmp2);
     uint256_t value = uint256_t(fr_vec[0]) + (uint256_t(fr_vec[1]) << (NUM_LIMB_BITS * 2));
     grumpkin::fr result(value);
     return result;

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.cpp
@@ -25,6 +25,9 @@ grumpkin::fr convert_grumpkin_fr_from_bn254_frs(std::span<const bb::fr> fr_vec)
     // Combines the two elements into one uint256_t, and then convert that to a grumpkin::fr
     ASSERT(uint256_t(fr_vec[0]) < (uint256_t(1) << (NUM_LIMB_BITS * 2)));              // lower 136 bits
     ASSERT(uint256_t(fr_vec[1]) < (uint256_t(1) << (TOTAL_BITS - NUM_LIMB_BITS * 2))); // upper 254-136=118 bits
+    auto tmp1 = uint256_t(fr_vec[0]);
+    auto tmp2 = uint256_t(fr_vec[1]) << (NUM_LIMB_BITS * 2);
+    info("tmp1 = {}, tmp2 = {}", tmp1, tmp2);
     uint256_t value = uint256_t(fr_vec[0]) + (uint256_t(fr_vec[1]) << (NUM_LIMB_BITS * 2));
     grumpkin::fr result(value);
     return result;

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.hpp
@@ -58,7 +58,8 @@ template <typename T> T convert_from_bn254_frs(std::span<const bb::fr> fr_vec)
         using BaseField = typename T::Fq;
         constexpr size_t BASE_FIELD_SCALAR_SIZE = calc_num_bn254_frs<BaseField>();
         ASSERT(fr_vec.size() == 2 * BASE_FIELD_SCALAR_SIZE);
-        // check if all zeros
+        // check if all zeros, which is how we represent the point at infinity
+        // this representation is sound because (0, 0) is not on either curve
         bool all_zeros = true;
         for (auto x : fr_vec) {
             all_zeros = all_zeros && (x == 0);
@@ -106,6 +107,8 @@ template <typename T> std::vector<bb::fr> convert_to_bn254_frs(const T& val)
         return convert_grumpkin_fr_to_bn254_frs(val);
     } else if constexpr (IsAnyOf<T, curve::BN254::AffineElement, curve::Grumpkin::AffineElement>) {
         if (val.is_point_at_infinity()) {
+            // if its a point at infinity, represent it as a vector of 0s
+            // this cannot coincide for an actual point on the curve since (0, 0) is not on the curve
             std::vector<bb::fr> fr_vec(calc_num_bn254_frs<T>(), 0);
             return fr_vec;
         }

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.test.cpp
@@ -53,11 +53,6 @@ TEST_F(FieldConversionTest, FieldConversionGrumpkinFr)
 {
     grumpkin::fr x1(std::string("9a807b615c4d3e2fa0b1c2d3e4f56789fedcba9876543210abcdef0123456789")); // 256 bits
     check_conversion(x1);
-
-    grumpkin::fr x2(15230403791020821917UL, 754611498739239741UL, 7381016538464732716UL, 9223372036854775808UL);
-    // x2.self_from_montgomery_form();
-    // x2.self_to_montgomery_form();
-    check_conversion(x2);
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.test.cpp
@@ -11,10 +11,6 @@ class FieldConversionTest : public ::testing::Test {
         auto frs = bb::field_conversion::convert_to_bn254_frs(x);
         EXPECT_EQ(len, frs.size());
         auto y = bb::field_conversion::convert_from_bn254_frs<T>(frs);
-        if constexpr (std::is_same_v<T, curve::BN254::AffineElement>) {
-            auto tmp1 = uint256_t(x.x);
-            auto tmp2 = uint256_t(y.x);
-        }
         EXPECT_EQ(x, y);
     }
 };
@@ -40,8 +36,6 @@ TEST_F(FieldConversionTest, FieldConversionFr)
     check_conversion(x2);
 
     bb::fr x3(curve::Grumpkin::Group::affine_point_at_infinity.x);
-    // x3.self_from_montgomery_form();
-    // x3.self_to_montgomery_form();
     check_conversion(x3);
 }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.test.cpp
@@ -11,6 +11,10 @@ class FieldConversionTest : public ::testing::Test {
         auto frs = bb::field_conversion::convert_to_bn254_frs(x);
         EXPECT_EQ(len, frs.size());
         auto y = bb::field_conversion::convert_from_bn254_frs<T>(frs);
+        if constexpr (std::is_same_v<T, curve::BN254::AffineElement>) {
+            auto tmp1 = uint256_t(x.x);
+            auto tmp2 = uint256_t(y.x);
+        }
         EXPECT_EQ(x, y);
     }
 };
@@ -34,6 +38,11 @@ TEST_F(FieldConversionTest, FieldConversionFr)
 
     bb::fr x2(bb::fr::modulus_minus_two); // modulus - 2
     check_conversion(x2);
+
+    bb::fr x3(curve::Grumpkin::Group::affine_point_at_infinity.x);
+    // x3.self_from_montgomery_form();
+    // x3.self_to_montgomery_form();
+    check_conversion(x3);
 }
 
 /**
@@ -44,6 +53,11 @@ TEST_F(FieldConversionTest, FieldConversionGrumpkinFr)
 {
     grumpkin::fr x1(std::string("9a807b615c4d3e2fa0b1c2d3e4f56789fedcba9876543210abcdef0123456789")); // 256 bits
     check_conversion(x1);
+
+    grumpkin::fr x2(15230403791020821917UL, 754611498739239741UL, 7381016538464732716UL, 9223372036854775808UL);
+    // x2.self_from_montgomery_form();
+    // x2.self_to_montgomery_form();
+    check_conversion(x2);
 }
 
 /**
@@ -57,6 +71,9 @@ TEST_F(FieldConversionTest, FieldConversionBN254AffineElement)
 
     curve::BN254::AffineElement x2(grumpkin::fr::modulus_minus_two, grumpkin::fr::modulus_minus_two);
     check_conversion(x2);
+
+    curve::BN254::AffineElement x3(curve::BN254::Group::affine_point_at_infinity);
+    check_conversion(x3);
 }
 
 /**
@@ -69,6 +86,9 @@ TEST_F(FieldConversionTest, FieldConversionGrumpkinAffineElement)
 
     curve::Grumpkin::AffineElement x2(bb::fr::modulus_minus_two, bb::fr::modulus_minus_two);
     check_conversion(x2);
+
+    curve::Grumpkin::AffineElement x3(curve::Grumpkin::Group::affine_point_at_infinity);
+    check_conversion(x3);
 }
 
 /**


### PR DESCRIPTION
This PR adds to native and stdlib field conversion tests for the converting the point at infinity on both Grumpkin and BN254. It fixes how the transcript handles the point at infinity by encoding it as a vector of 0s in the transcript.

The original error happens because when we set a point to the point at infinity, we modify the x-coordinate a group element while its in Montgomery form. As a result, when we transform it back to normal form (when calling from_montgomery_form()), and then convert it back to Montgomery form (calling to_montgomery_form()), we don't get the same value as what we started with. Normally, we don't run into this problem because we don't fiddle around with values while they are in Montgomery form, except in this case.

Addresses https://github.com/AztecProtocol/barretenberg/issues/866.
