### PR TITLE
chore: updating viem

### DIFF
--- a/yarn-project/archiver/package.json
+++ b/yarn-project/archiver/package.json
@@ -48,7 +48,7 @@
     "lodash.omit": "^4.5.0",
     "tsc-watch": "^6.0.0",
     "tslib": "^2.5.0",
-    "viem": "1.4.2",
+    "viem": "^2.7.15",
     "ws": "^8.13.0"
   },
   "devDependencies": {

--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -271,7 +271,7 @@ function makeL2BlockProcessedEvent(l1BlockNum: bigint, l2BlockNum: bigint) {
     blockNumber: l1BlockNum,
     args: { blockNumber: l2BlockNum },
     transactionHash: `0x${l2BlockNum}`,
-  } as Log<bigint, number, undefined, true, typeof RollupAbi, 'L2BlockProcessed'>;
+  } as Log<bigint, number, false, undefined, true, typeof RollupAbi, 'L2BlockProcessed'>;
 }
 
 /**
@@ -296,7 +296,7 @@ function makeContractDeploymentEvent(l1BlockNum: bigint, l2Block: L2Block) {
       acir: '0x' + acir,
     },
     transactionHash: `0x${l2Block.number}`,
-  } as Log<bigint, number, undefined, true, typeof ContractDeploymentEmitterAbi, 'ContractDeployment'>;
+  } as Log<bigint, number, false, undefined, true, typeof ContractDeploymentEmitterAbi, 'ContractDeployment'>;
 }
 
 /**
@@ -321,7 +321,7 @@ function makeL1ToL2MessageAddedEvents(l1BlockNum: bigint, entryKeys: string[]) {
         entryKey: entryKey,
       },
       transactionHash: `0x${l1BlockNum}`,
-    } as Log<bigint, number, undefined, true, typeof InboxAbi, 'MessageAdded'>;
+    } as Log<bigint, number, false, undefined, true, typeof InboxAbi, 'MessageAdded'>;
   });
 }
 
@@ -339,7 +339,7 @@ function makeL1ToL2MessageCancelledEvents(l1BlockNum: bigint, entryKeys: string[
         entryKey,
       },
       transactionHash: `0x${l1BlockNum}`,
-    } as Log<bigint, number, undefined, true, typeof InboxAbi, 'L1ToL2MessageCancelled'>;
+    } as Log<bigint, number, false, undefined, true, typeof InboxAbi, 'L1ToL2MessageCancelled'>;
   });
 }
 

--- a/yarn-project/archiver/src/archiver/eth_log_handlers.ts
+++ b/yarn-project/archiver/src/archiver/eth_log_handlers.ts
@@ -129,21 +129,18 @@ async function getBlockFromCallData(
  * @param toBlock - Last block to get logs from (inclusive).
  * @returns An array of `L2BlockProcessed` logs.
  */
-export async function getL2BlockProcessedLogs(
+export function getL2BlockProcessedLogs(
   publicClient: PublicClient,
   rollupAddress: EthAddress,
   fromBlock: bigint,
   toBlock: bigint,
-) {
-  // Note: For some reason the return type of `getLogs` would not get correctly derived if I didn't set the abiItem
-  //       as a standalone constant.
-  const abiItem = getAbiItem({
-    abi: RollupAbi,
-    name: 'L2BlockProcessed',
-  });
-  return await publicClient.getLogs<typeof abiItem, undefined, true>({
+): Promise<Log<bigint, number, false, undefined, true, typeof RollupAbi, 'L2BlockProcessed'>[]> {
+  return publicClient.getLogs({
     address: getAddress(rollupAddress.toString()),
-    event: abiItem,
+    event: getAbiItem({
+      abi: RollupAbi,
+      name: 'L2BlockProcessed',
+    }),
     fromBlock,
     toBlock: toBlock + 1n, // the toBlock argument in getLogs is exclusive
   });
@@ -157,19 +154,18 @@ export async function getL2BlockProcessedLogs(
  * @param toBlock - Last block to get logs from (inclusive).
  * @returns An array of `ContractDeployment` logs.
  */
-export async function getContractDeploymentLogs(
+export function getContractDeploymentLogs(
   publicClient: PublicClient,
   contractDeploymentEmitterAddress: EthAddress,
   fromBlock: bigint,
   toBlock: bigint,
 ): Promise<Log<bigint, number, false, undefined, true, typeof ContractDeploymentEmitterAbi, 'ContractDeployment'>[]> {
-  const abiItem = getAbiItem({
-    abi: ContractDeploymentEmitterAbi,
-    name: 'ContractDeployment',
-  });
-  return await publicClient.getLogs({
+  return publicClient.getLogs({
     address: getAddress(contractDeploymentEmitterAddress.toString()),
-    event: abiItem,
+    event: getAbiItem({
+      abi: ContractDeploymentEmitterAbi,
+      name: 'ContractDeployment',
+    }),
     fromBlock,
     toBlock: toBlock + 1n, // the toBlock argument in getLogs is exclusive
   });
@@ -223,19 +219,18 @@ export function processContractDeploymentLogs(
  * @param toBlock - Last block to get logs from (inclusive).
  * @returns An array of `MessageAdded` logs.
  */
-export async function getPendingL1ToL2MessageLogs(
+export function getPendingL1ToL2MessageLogs(
   publicClient: PublicClient,
   inboxAddress: EthAddress,
   fromBlock: bigint,
   toBlock: bigint,
 ): Promise<Log<bigint, number, false, undefined, true, typeof InboxAbi, 'MessageAdded'>[]> {
-  const abiItem = getAbiItem({
-    abi: InboxAbi,
-    name: 'MessageAdded',
-  });
-  return await publicClient.getLogs({
+  return publicClient.getLogs({
     address: getAddress(inboxAddress.toString()),
-    event: abiItem,
+    event: getAbiItem({
+      abi: InboxAbi,
+      name: 'MessageAdded',
+    }),
     fromBlock,
     toBlock: toBlock + 1n, // the toBlock argument in getLogs is exclusive
   });
@@ -249,19 +244,18 @@ export async function getPendingL1ToL2MessageLogs(
  * @param toBlock - Last block to get logs from (inclusive).
  * @returns An array of `L1ToL2MessageCancelled` logs.
  */
-export async function getL1ToL2MessageCancelledLogs(
+export function getL1ToL2MessageCancelledLogs(
   publicClient: PublicClient,
   inboxAddress: EthAddress,
   fromBlock: bigint,
   toBlock: bigint,
 ): Promise<Log<bigint, number, false, undefined, true, typeof InboxAbi, 'L1ToL2MessageCancelled'>[]> {
-  const abiItem = getAbiItem({
-    abi: InboxAbi,
-    name: 'L1ToL2MessageCancelled',
-  });
-  return await publicClient.getLogs({
+  return publicClient.getLogs({
     address: getAddress(inboxAddress.toString()),
-    event: abiItem,
+    event: getAbiItem({
+      abi: InboxAbi,
+      name: 'L1ToL2MessageCancelled',
+    }),
     fromBlock,
     toBlock: toBlock + 1n, // the toBlock argument in getLogs is exclusive
   });

--- a/yarn-project/archiver/src/archiver/eth_log_handlers.ts
+++ b/yarn-project/archiver/src/archiver/eth_log_handlers.ts
@@ -21,7 +21,7 @@ import { Hex, Log, PublicClient, decodeFunctionData, getAbiItem, getAddress, hex
  * @returns Array of all Pending L1 to L2 messages that were processed
  */
 export function processPendingL1ToL2MessageAddedLogs(
-  logs: Log<bigint, number, undefined, true, typeof InboxAbi, 'MessageAdded'>[],
+  logs: Log<bigint, number, false, undefined, true, typeof InboxAbi, 'MessageAdded'>[],
 ): [L1ToL2Message, bigint][] {
   const l1ToL2Messages: [L1ToL2Message, bigint][] = [];
   for (const log of logs) {
@@ -49,7 +49,7 @@ export function processPendingL1ToL2MessageAddedLogs(
  * @returns Array of message keys of the L1 to L2 messages that were cancelled
  */
 export function processCancelledL1ToL2MessagesLogs(
-  logs: Log<bigint, number, undefined, true, typeof InboxAbi, 'L1ToL2MessageCancelled'>[],
+  logs: Log<bigint, number, false, undefined, true, typeof InboxAbi, 'L1ToL2MessageCancelled'>[],
 ): [Fr, bigint][] {
   const cancelledL1ToL2Messages: [Fr, bigint][] = [];
   for (const log of logs) {
@@ -67,7 +67,7 @@ export function processCancelledL1ToL2MessagesLogs(
 export async function processBlockLogs(
   publicClient: PublicClient,
   expectedL2BlockNumber: bigint,
-  logs: Log<bigint, number, undefined, true, typeof RollupAbi, 'L2BlockProcessed'>[],
+  logs: Log<bigint, number, false, undefined, true, typeof RollupAbi, 'L2BlockProcessed'>[],
 ): Promise<L2Block[]> {
   const retrievedBlocks: L2Block[] = [];
   for (const log of logs) {
@@ -141,7 +141,7 @@ export async function getL2BlockProcessedLogs(
     abi: RollupAbi,
     name: 'L2BlockProcessed',
   });
-  return await publicClient.getLogs<typeof abiItem, true>({
+  return await publicClient.getLogs<typeof abiItem, undefined, true>({
     address: getAddress(rollupAddress.toString()),
     event: abiItem,
     fromBlock,
@@ -162,7 +162,7 @@ export async function getContractDeploymentLogs(
   contractDeploymentEmitterAddress: EthAddress,
   fromBlock: bigint,
   toBlock: bigint,
-): Promise<Log<bigint, number, undefined, true, typeof ContractDeploymentEmitterAbi, 'ContractDeployment'>[]> {
+): Promise<Log<bigint, number, false, undefined, true, typeof ContractDeploymentEmitterAbi, 'ContractDeployment'>[]> {
   const abiItem = getAbiItem({
     abi: ContractDeploymentEmitterAbi,
     name: 'ContractDeployment',
@@ -183,7 +183,7 @@ export async function getContractDeploymentLogs(
  */
 export function processContractDeploymentLogs(
   blockNumberToBodyHash: { [key: number]: Buffer | undefined },
-  logs: Log<bigint, number, undefined, true, typeof ContractDeploymentEmitterAbi, 'ContractDeployment'>[],
+  logs: Log<bigint, number, false, undefined, true, typeof ContractDeploymentEmitterAbi, 'ContractDeployment'>[],
 ): [ExtendedContractData[], number][] {
   const extendedContractData: [ExtendedContractData[], number][] = [];
   for (let i = 0; i < logs.length; i++) {
@@ -228,7 +228,7 @@ export async function getPendingL1ToL2MessageLogs(
   inboxAddress: EthAddress,
   fromBlock: bigint,
   toBlock: bigint,
-): Promise<Log<bigint, number, undefined, true, typeof InboxAbi, 'MessageAdded'>[]> {
+): Promise<Log<bigint, number, false, undefined, true, typeof InboxAbi, 'MessageAdded'>[]> {
   const abiItem = getAbiItem({
     abi: InboxAbi,
     name: 'MessageAdded',
@@ -254,7 +254,7 @@ export async function getL1ToL2MessageCancelledLogs(
   inboxAddress: EthAddress,
   fromBlock: bigint,
   toBlock: bigint,
-): Promise<Log<bigint, number, undefined, true, typeof InboxAbi, 'L1ToL2MessageCancelled'>[]> {
+): Promise<Log<bigint, number, false, undefined, true, typeof InboxAbi, 'L1ToL2MessageCancelled'>[]> {
   const abiItem = getAbiItem({
     abi: InboxAbi,
     name: 'L1ToL2MessageCancelled',

--- a/yarn-project/archiver/src/archiver/eth_log_handlers.ts
+++ b/yarn-project/archiver/src/archiver/eth_log_handlers.ts
@@ -99,9 +99,8 @@ async function getBlockFromCallData(
   l2BlockNum: bigint,
 ): Promise<L2Block> {
   const { input: data } = await publicClient.getTransaction({ hash: txHash });
-  // TODO: File a bug in viem who complains if we dont remove the ctor from the abi here
   const { functionName, args } = decodeFunctionData({
-    abi: RollupAbi.filter(item => item.type.toString() !== 'constructor'),
+    abi: RollupAbi,
     data,
   });
   if (functionName !== 'process') {

--- a/yarn-project/aztec-faucet/package.json
+++ b/yarn-project/aztec-faucet/package.json
@@ -37,7 +37,7 @@
     "koa": "^2.14.2",
     "koa-cors": "^0.0.16",
     "koa-router": "^12.0.0",
-    "viem": "^1.2.5"
+    "viem": "^2.7.15"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/yarn-project/aztec/package.json
+++ b/yarn-project/aztec/package.json
@@ -45,7 +45,7 @@
     "commander": "^11.1.0",
     "koa": "^2.14.2",
     "koa-router": "^12.0.0",
-    "viem": "^1.2.5",
+    "viem": "^2.7.15",
     "winston": "^3.10.0",
     "winston-daily-rotate-file": "^4.7.1"
   },

--- a/yarn-project/cli/package.json
+++ b/yarn-project/cli/package.json
@@ -53,7 +53,7 @@
     "semver": "^7.5.4",
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
-    "viem": "^1.2.5"
+    "viem": "^2.7.15"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -68,7 +68,7 @@
     "tty-browserify": "^0.0.1",
     "typescript": "^5.0.4",
     "util": "^0.12.5",
-    "viem": "^1.2.5",
+    "viem": "^2.7.15",
     "webpack": "^5.88.2",
     "webpack-cli": "^5.1.4",
     "winston": "^3.10.0"

--- a/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
@@ -160,7 +160,11 @@ describe('e2e_cheat_codes', () => {
         await cc.aztec.warp(newTimestamp);
 
         // ensure rollup contract is correctly updated
-        const rollup = getContract({ address: getAddress(rollupAddress.toString()), abi: RollupAbi, publicClient });
+        const rollup = getContract({
+          address: getAddress(rollupAddress.toString()),
+          abi: RollupAbi,
+          client: publicClient,
+        });
         expect(Number(await rollup.read.lastBlockTs())).toEqual(newTimestamp);
         expect(Number(await rollup.read.lastWarpedBlockTs())).toEqual(newTimestamp);
 

--- a/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
@@ -82,11 +82,7 @@ describe('L1Publisher integration', () => {
   let outboxAddress: Address;
 
   let rollup: GetContractReturnType<typeof RollupAbi, PublicClient<HttpTransport, Chain>>;
-  let inbox: GetContractReturnType<
-    typeof InboxAbi,
-    PublicClient<HttpTransport, Chain>,
-    WalletClient<HttpTransport, Chain>
-  >;
+  let inbox: GetContractReturnType<typeof InboxAbi, WalletClient<HttpTransport, Chain>>;
   let outbox: GetContractReturnType<typeof OutboxAbi, PublicClient<HttpTransport, Chain>>;
 
   let publisher: L1Publisher;
@@ -123,18 +119,17 @@ describe('L1Publisher integration', () => {
     rollup = getContract({
       address: rollupAddress,
       abi: RollupAbi,
-      publicClient,
+      client: publicClient,
     });
     inbox = getContract({
       address: inboxAddress,
       abi: InboxAbi,
-      publicClient,
-      walletClient,
+      client: walletClient,
     });
     outbox = getContract({
       address: outboxAddress,
       abi: OutboxAbi,
-      publicClient,
+      client: publicClient,
     });
 
     builderDb = await MerkleTrees.new(openTmpStore()).then(t => t.asLatest());

--- a/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
@@ -73,8 +73,7 @@ export async function deployAndInitializeTokenAndBridgeContracts(
   const underlyingERC20 = getContract({
     address: underlyingERC20Address.toString(),
     abi: PortalERC20Abi,
-    walletClient,
-    publicClient,
+    client: walletClient,
   });
 
   // deploy the token portal
@@ -82,8 +81,7 @@ export async function deployAndInitializeTokenAndBridgeContracts(
   const tokenPortal = getContract({
     address: tokenPortalAddress.toString(),
     abi: TokenPortalAbi,
-    walletClient,
-    publicClient,
+    client: walletClient,
   });
 
   // deploy l2 token
@@ -138,15 +136,13 @@ export class CrossChainTestHarness {
     const inbox = getContract({
       address: l1ContractAddresses.inboxAddress.toString(),
       abi: InboxAbi,
-      walletClient,
-      publicClient,
+      client: walletClient,
     });
 
     const outbox = getContract({
       address: l1ContractAddresses.outboxAddress.toString(),
       abi: OutboxAbi,
-      walletClient,
-      publicClient,
+      client: walletClient,
     });
 
     // Deploy and initialize all required contracts

--- a/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
@@ -56,8 +56,7 @@ export async function deployAndInitializeTokenAndBridgeContracts(
   const gasL1 = getContract({
     address: underlyingERC20Address.toString(),
     abi: PortalERC20Abi,
-    walletClient,
-    publicClient,
+    client: walletClient,
   });
 
   // deploy the gas portal
@@ -65,8 +64,7 @@ export async function deployAndInitializeTokenAndBridgeContracts(
   const gasPortal = getContract({
     address: gasPortalAddress.toString(),
     abi: GasPortalAbi,
-    walletClient,
-    publicClient,
+    client: walletClient,
   });
 
   // deploy l2 token
@@ -107,8 +105,7 @@ export class GasBridgingTestHarness {
     const outbox = getContract({
       address: l1ContractAddresses.outboxAddress.toString(),
       abi: OutboxAbi,
-      walletClient,
-      publicClient,
+      client: walletClient,
     });
 
     // Deploy and initialize all required contracts

--- a/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
+++ b/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
@@ -126,8 +126,7 @@ export const uniswapL1L2TestSuite = (
       uniswapPortal = getContract({
         address: uniswapPortalAddress.toString(),
         abi: UniswapPortalAbi,
-        walletClient,
-        publicClient,
+        client: walletClient,
       });
       // deploy l2 uniswap contract and attach to portal
       uniswapL2Contract = await UniswapContract.deploy(ownerWallet)

--- a/yarn-project/ethereum/package.json
+++ b/yarn-project/ethereum/package.json
@@ -27,7 +27,7 @@
     "@aztec/foundation": "workspace:^",
     "dotenv": "^16.0.3",
     "tslib": "^2.4.0",
-    "viem": "^1.2.5"
+    "viem": "^2.7.15"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -157,8 +157,7 @@ export const deployL1Contracts = async (
   const registryContract = getContract({
     address: getAddress(registryAddress.toString()),
     abi: contractsToDeploy.registry.contractAbi,
-    publicClient,
-    walletClient,
+    client: walletClient,
   });
   await registryContract.write.upgrade(
     [getAddress(rollupAddress.toString()), getAddress(inboxAddress.toString()), getAddress(outboxAddress.toString())],

--- a/yarn-project/ethereum/src/testnet.ts
+++ b/yarn-project/ethereum/src/testnet.ts
@@ -8,7 +8,7 @@ export const createTestnetChain = (apiKey: string) => {
   const chain: Chain = {
     id: +CHAIN_ID,
     name: 'testnet',
-    network: 'aztec',
+    testnet: true,
     nativeCurrency: {
       name: 'Ether',
       symbol: 'ETH',

--- a/yarn-project/pxe/package.json
+++ b/yarn-project/pxe/package.json
@@ -49,7 +49,7 @@
     "lodash.omit": "^4.5.0",
     "sha3": "^2.1.4",
     "tslib": "^2.4.0",
-    "viem": "^1.2.5"
+    "viem": "^2.7.15"
   },
   "devDependencies": {
     "@aztec/noir-contracts.js": "workspace:^",

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -36,7 +36,7 @@
     "lodash.chunk": "^4.2.0",
     "lodash.pick": "^4.4.0",
     "tslib": "^2.4.0",
-    "viem": "^1.2.5"
+    "viem": "^2.7.15"
   },
   "devDependencies": {
     "@aztec/kv-store": "workspace:^",

--- a/yarn-project/sequencer-client/src/global_variable_builder/viem-reader.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/viem-reader.ts
@@ -35,7 +35,7 @@ export class ViemReader implements L1GlobalReader {
     this.rollupContract = getContract({
       address: getAddress(l1Contracts.rollupAddress.toString()),
       abi: RollupAbi,
-      publicClient: this.publicClient,
+      client: this.publicClient,
     });
   }
 

--- a/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
+++ b/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
@@ -33,17 +33,14 @@ import {
 export class ViemTxSender implements L1PublisherTxSender {
   private availabilityOracleContract: GetContractReturnType<
     typeof AvailabilityOracleAbi,
-    PublicClient<HttpTransport, chains.Chain>,
     WalletClient<HttpTransport, chains.Chain, PrivateKeyAccount>
   >;
   private rollupContract: GetContractReturnType<
     typeof RollupAbi,
-    PublicClient<HttpTransport, chains.Chain>,
     WalletClient<HttpTransport, chains.Chain, PrivateKeyAccount>
   >;
   private contractDeploymentEmitterContract: GetContractReturnType<
     typeof ContractDeploymentEmitterAbi,
-    PublicClient<HttpTransport, chains.Chain>,
     WalletClient<HttpTransport, chains.Chain, PrivateKeyAccount>
   >;
 
@@ -69,20 +66,17 @@ export class ViemTxSender implements L1PublisherTxSender {
     this.availabilityOracleContract = getContract({
       address: getAddress(l1Contracts.availabilityOracleAddress.toString()),
       abi: AvailabilityOracleAbi,
-      publicClient: this.publicClient,
-      walletClient,
+      client: walletClient,
     });
     this.rollupContract = getContract({
       address: getAddress(l1Contracts.rollupAddress.toString()),
       abi: RollupAbi,
-      publicClient: this.publicClient,
-      walletClient,
+      client: walletClient,
     });
     this.contractDeploymentEmitterContract = getContract({
       address: getAddress(l1Contracts.contractDeploymentEmitterAddress.toString()),
       abi: ContractDeploymentEmitterAbi,
-      publicClient: this.publicClient,
-      walletClient,
+      client: walletClient,
     });
   }
 

--- a/yarn-project/simulator/package.json
+++ b/yarn-project/simulator/package.json
@@ -54,7 +54,7 @@
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4",
-    "viem": "^1.2.5"
+    "viem": "^2.7.15"
   },
   "files": [
     "dest",

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -47,13 +47,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adraffy/ens-normalize@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@adraffy/ens-normalize@npm:1.9.0"
-  checksum: a8d47f85db7a0bba01227fae8781a3245a4517875503d6848a47ca29e7f7da271742a2f93b55afc1b9201e74eda1fd1f1e6e79e70f967359fd7f6ec3d45bf243
-  languageName: node
-  linkType: hard
-
 "@ampproject/remapping@npm:^2.2.0":
   version: 2.2.1
   resolution: "@ampproject/remapping@npm:2.2.1"
@@ -117,7 +110,7 @@ __metadata:
     tsc-watch: ^6.0.0
     tslib: ^2.5.0
     typescript: ^5.0.4
-    viem: 1.4.2
+    viem: ^2.7.15
     ws: ^8.13.0
   languageName: unknown
   linkType: soft
@@ -138,7 +131,7 @@ __metadata:
     ts-jest: ^29.1.0
     ts-node: ^10.9.1
     typescript: ^5.0.4
-    viem: ^1.2.5
+    viem: ^2.7.15
   bin:
     aztec-faucet: ./dest/bin/index.js
   languageName: unknown
@@ -252,7 +245,7 @@ __metadata:
     ts-jest: ^29.1.0
     ts-node: ^10.9.1
     typescript: ^5.0.4
-    viem: ^1.2.5
+    viem: ^2.7.15
     winston: ^3.10.0
     winston-daily-rotate-file: ^4.7.1
   bin:
@@ -356,7 +349,7 @@ __metadata:
     ts-node: ^10.9.1
     tslib: ^2.4.0
     typescript: ^5.0.4
-    viem: ^1.2.5
+    viem: ^2.7.15
   bin:
     aztec-cli: ./dest/bin/index.js
   languageName: unknown
@@ -427,7 +420,7 @@ __metadata:
     tty-browserify: ^0.0.1
     typescript: ^5.0.4
     util: ^0.12.5
-    viem: ^1.2.5
+    viem: ^2.7.15
     webpack: ^5.88.2
     webpack-cli: ^5.1.4
     winston: ^3.10.0
@@ -466,7 +459,7 @@ __metadata:
     ts-node: ^10.9.1
     tslib: ^2.4.0
     typescript: ^5.0.4
-    viem: ^1.2.5
+    viem: ^2.7.15
   languageName: unknown
   linkType: soft
 
@@ -798,7 +791,7 @@ __metadata:
     ts-node: ^10.9.1
     tslib: ^2.4.0
     typescript: ^5.0.4
-    viem: ^1.2.5
+    viem: ^2.7.15
   bin:
     pxe: ./dest/bin/index.js
   languageName: unknown
@@ -865,7 +858,7 @@ __metadata:
     ts-node: ^10.9.1
     tslib: ^2.4.0
     typescript: ^5.0.4
-    viem: ^1.2.5
+    viem: ^2.7.15
   languageName: unknown
   linkType: soft
 
@@ -895,7 +888,7 @@ __metadata:
     ts-node: ^10.9.1
     tslib: ^2.4.0
     typescript: ^5.0.4
-    viem: ^1.2.5
+    viem: ^2.7.15
   languageName: unknown
   linkType: soft
 
@@ -2727,15 +2720,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:1.0.0, @noble/curves@npm:~1.0.0":
-  version: 1.0.0
-  resolution: "@noble/curves@npm:1.0.0"
-  dependencies:
-    "@noble/hashes": 1.3.0
-  checksum: 6bcef44d626c640dc8961819d68dd67dffb907e3b973b7c27efe0ecdd9a5c6ce62c7b9e3dfc930c66605dced7f1ec0514d191c09a2ce98d6d52b66e3315ffa79
-  languageName: node
-  linkType: hard
-
 "@noble/curves@npm:1.2.0, @noble/curves@npm:~1.2.0":
   version: 1.2.0
   resolution: "@noble/curves@npm:1.2.0"
@@ -2751,13 +2735,6 @@ __metadata:
   dependencies:
     "@noble/hashes": 1.3.3
   checksum: b65342ee66c4a440eee2978524412eabba9a9efdd16d6370e15218c6a7d80bddf35e66bb57ed52c0dfd32cb9a717b439ab3a72db618f1a0066dfebe3fd12a421
-  languageName: node
-  linkType: hard
-
-"@noble/hashes@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@noble/hashes@npm:1.3.0"
-  checksum: d7ddb6d7c60f1ce1f87facbbef5b724cdea536fc9e7f59ae96e0fc9de96c8f1a2ae2bdedbce10f7dcc621338dfef8533daa73c873f2b5c87fa1a4e05a95c2e2e
   languageName: node
   linkType: hard
 
@@ -2896,17 +2873,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@scure/bip32@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@scure/bip32@npm:1.3.0"
-  dependencies:
-    "@noble/curves": ~1.0.0
-    "@noble/hashes": ~1.3.0
-    "@scure/base": ~1.1.0
-  checksum: 6eae997f9bdf41fe848134898960ac48e645fa10e63d579be965ca331afd0b7c1b8ebac170770d237ab4099dafc35e5a82995384510025ccf2abe669f85e8918
-  languageName: node
-  linkType: hard
-
 "@scure/bip32@npm:1.3.2":
   version: 1.3.2
   resolution: "@scure/bip32@npm:1.3.2"
@@ -2915,16 +2881,6 @@ __metadata:
     "@noble/hashes": ~1.3.2
     "@scure/base": ~1.1.2
   checksum: c5ae84fae43490853693b481531132b89e056d45c945fc8b92b9d032577f753dfd79c5a7bbcbf0a7f035951006ff0311b6cf7a389e26c9ec6335e42b20c53157
-  languageName: node
-  linkType: hard
-
-"@scure/bip39@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@scure/bip39@npm:1.2.0"
-  dependencies:
-    "@noble/hashes": ~1.3.0
-    "@scure/base": ~1.1.0
-  checksum: 980d761f53e63de04a9e4db840eb13bfb1bd1b664ecb04a71824c12c190f4972fd84146f3ed89b2a8e4c6bd2c17c15f8b592b7ac029e903323b0f9e2dae6916b
   languageName: node
   linkType: hard
 
@@ -3963,18 +3919,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wagmi/chains@npm:1.6.0":
-  version: 1.6.0
-  resolution: "@wagmi/chains@npm:1.6.0"
-  peerDependencies:
-    typescript: ">=5.0.4"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 6c3d477936622f763b9e44c4a66c080020f1119165c8f6b840c51f5822880fedd5031036461d4b28df5cf1ae19cb12e139e4a4b3c129b475f0363fd9c4c8bb0d
-  languageName: node
-  linkType: hard
-
 "@webassemblyjs/ast@npm:1.11.6, @webassemblyjs/ast@npm:^1.11.5":
   version: 1.11.6
   resolution: "@webassemblyjs/ast@npm:1.11.6"
@@ -4180,33 +4124,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abitype@npm:0.9.3":
-  version: 0.9.3
-  resolution: "abitype@npm:0.9.3"
+"abitype@npm:1.0.0":
+  version: 1.0.0
+  resolution: "abitype@npm:1.0.0"
   peerDependencies:
     typescript: ">=5.0.4"
-    zod: ^3 >=3.19.1
+    zod: ^3 >=3.22.0
   peerDependenciesMeta:
     typescript:
       optional: true
     zod:
       optional: true
-  checksum: f97c5a118180563b9ed8b97da492a82d3ce53dcd7d96c87764e90dbe84c04ae72dd5703d1ed5a54601033ab1772b8a235a1b5aadaf7aad6c4b5fdad7fd3a69a7
-  languageName: node
-  linkType: hard
-
-"abitype@npm:0.9.8":
-  version: 0.9.8
-  resolution: "abitype@npm:0.9.8"
-  peerDependencies:
-    typescript: ">=5.0.4"
-    zod: ^3 >=3.19.1
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-    zod:
-      optional: true
-  checksum: d7d887f29d6821e3f7a400de9620511b80ead3f85c5c87308aaec97965d3493e6687ed816e88722b4f512249bd66dee9e69231b49af0e1db8f69400a62c87cf6
+  checksum: ea2c0548c3ba58c37a6de7483d63389074da498e63d803b742bbe94eb4eaa1f51a35d000c424058b2583aef56698cf07c696eb3bc4dd0303bc20c6f0826a241a
   languageName: node
   linkType: hard
 
@@ -8312,15 +8241,6 @@ __metadata:
   version: 3.0.1
   resolution: "isobject@npm:3.0.1"
   checksum: db85c4c970ce30693676487cca0e61da2ca34e8d4967c2e1309143ff910c207133a969f9e4ddb2dc6aba670aabce4e0e307146c310350b298e74a31f7d464703
-  languageName: node
-  linkType: hard
-
-"isomorphic-ws@npm:5.0.0":
-  version: 5.0.0
-  resolution: "isomorphic-ws@npm:5.0.0"
-  peerDependencies:
-    ws: "*"
-  checksum: e20eb2aee09ba96247465fda40c6d22c1153394c0144fa34fe6609f341af4c8c564f60ea3ba762335a7a9c306809349f9b863c8beedf2beea09b299834ad5398
   languageName: node
   linkType: hard
 
@@ -13438,38 +13358,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"viem@npm:1.4.2":
-  version: 1.4.2
-  resolution: "viem@npm:1.4.2"
-  dependencies:
-    "@adraffy/ens-normalize": 1.9.0
-    "@noble/curves": 1.0.0
-    "@noble/hashes": 1.3.0
-    "@scure/bip32": 1.3.0
-    "@scure/bip39": 1.2.0
-    "@wagmi/chains": 1.6.0
-    abitype: 0.9.3
-    isomorphic-ws: 5.0.0
-    ws: 8.12.0
-  peerDependencies:
-    typescript: ">=5.0.4"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 225f11847d4b4c1d19ada3d29638e138034702f251f955707766ef24e2a438effcc9130f3465d38657e5e88af19cf331a9eca9f40d4a6460454068be765babc1
-  languageName: node
-  linkType: hard
-
-"viem@npm:^1.2.5":
-  version: 1.21.4
-  resolution: "viem@npm:1.21.4"
+"viem@npm:^2.7.15":
+  version: 2.7.15
+  resolution: "viem@npm:2.7.15"
   dependencies:
     "@adraffy/ens-normalize": 1.10.0
     "@noble/curves": 1.2.0
     "@noble/hashes": 1.3.2
     "@scure/bip32": 1.3.2
     "@scure/bip39": 1.2.1
-    abitype: 0.9.8
+    abitype: 1.0.0
     isows: 1.0.3
     ws: 8.13.0
   peerDependencies:
@@ -13477,7 +13375,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: c351fdea2d53d2d781ac73c964348b3b9fc5dd46f9eb53903e867705fc9e30a893cb9f2c8d7a00acdcdeca27d14eeebf976eed9f948c28c47018dc9211369117
+  checksum: d0d3a9b48fcf64298c08d57dd782fdf6f21538c6472ebc87953928d860f5fd6296a7e22f46f230d68b667df6505fa472414cc3d8e7a041ea2a7f1fd45bc013de
   languageName: node
   linkType: hard
 
@@ -13832,21 +13730,6 @@ __metadata:
     imurmurhash: ^0.1.4
     signal-exit: ^3.0.7
   checksum: 5da60bd4eeeb935eec97ead3df6e28e5917a6bd317478e4a85a5285e8480b8ed96032bbcc6ecd07b236142a24f3ca871c924ec4a6575e623ec1b11bf8c1c253c
-  languageName: node
-  linkType: hard
-
-"ws@npm:8.12.0":
-  version: 8.12.0
-  resolution: "ws@npm:8.12.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 818ff3f8749c172a95a114cceb8b89cedd27e43a82d65c7ad0f7882b1e96a2ee6709e3746a903c3fa88beec0c8bae9a9fcd75f20858b32a166dfb7519316a5d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`e2e-public-cross-chain-messaging` is flaky and it's caused by a failure to retrieve logs from anvil. The low hanging fruit here was to try to update viem and see whether by any chance this gets resolved. I don't think viem is the culprit but given that the version we used now was ancient, they fixed a lot of bugs and we'll need to do the update anyway to get blobs support it made sense to just do it.