### PR TITLE
refactor: Move vk computation out of Honk Ultra composer

### DIFF
--- a/barretenberg/cpp/scripts/analyze_client_ivc_bench.py
+++ b/barretenberg/cpp/scripts/analyze_client_ivc_bench.py
@@ -9,7 +9,7 @@ BENCHMARK = "ClientIVCBench/Full/6"
 to_keep = [
     "construct_mock_function_circuit(t)",
     "construct_mock_folding_kernel(t)",
-    "UltraComposer::create_prover_instance(t)",
+    "ProverInstance(Circuit&)(t)",
     "ProtogalaxyProver::fold_instances(t)",
     "Decider::construct_proof(t)",
     "ECCVMComposer::create_prover(t)",

--- a/barretenberg/cpp/src/barretenberg/benchmark/ipa_bench/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ipa_bench/CMakeLists.txt
@@ -1,1 +1,1 @@
-barretenberg_module(ipa_bench ultra_honk)
+barretenberg_module(ipa_bench commitment_schemes)

--- a/barretenberg/cpp/src/barretenberg/benchmark/ipa_bench/ipa.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ipa_bench/ipa.bench.cpp
@@ -13,7 +13,7 @@ constexpr size_t MAX_POLYNOMIAL_DEGREE_LOG2 = 16;
 std::shared_ptr<bb::srs::factories::CrsFactory<curve::Grumpkin>> crs_factory(
     new bb::srs::factories::FileCrsFactory<curve::Grumpkin>("../srs_db/grumpkin", 1 << 16));
 
-auto ck = std::make_shared<CommitmentKey<Curve>>(1 << MAX_POLYNOMIAL_DEGREE_LOG2, crs_factory);
+auto ck = std::make_shared<CommitmentKey<Curve>>(1 << MAX_POLYNOMIAL_DEGREE_LOG2);
 auto vk = std::make_shared<VerifierCommitmentKey<Curve>>(1 << MAX_POLYNOMIAL_DEGREE_LOG2, crs_factory);
 
 std::vector<std::shared_ptr<NativeTranscript>> prover_transcripts(MAX_POLYNOMIAL_DEGREE_LOG2 -

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commit.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commit.bench.cpp
@@ -8,14 +8,7 @@ namespace bb {
 template <typename Curve> std::shared_ptr<CommitmentKey<Curve>> create_commitment_key(const size_t num_points)
 {
     std::string srs_path;
-    if constexpr (std::same_as<Curve, curve::BN254>) {
-        srs_path = "../srs_db/ignition";
-    } else {
-        static_assert(std::same_as<Curve, curve::Grumpkin>);
-        srs_path = "../srs_db/grumpkin";
-    }
-    auto crs_factory = std::make_shared<bb::srs::factories::FileCrsFactory<Curve>>(srs_path, num_points);
-    return std::make_shared<CommitmentKey<Curve>>(num_points, crs_factory);
+    return std::make_shared<CommitmentKey<Curve>>(num_points);
 }
 
 constexpr size_t MAX_LOG_NUM_POINTS = 24;

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
@@ -51,14 +51,7 @@ template <class Curve> class CommitmentKey {
      */
     CommitmentKey(const size_t num_points)
         : pippenger_runtime_state(num_points)
-        , crs_factory([]() {
-            if constexpr (std::same_as<Curve, curve::BN254>) {
-                return srs::get_crs_factory();
-            } else {
-                static_assert(std::same_as<Curve, curve::Grumpkin>);
-                return srs::get_grumpkin_crs_factory();
-            }
-        }())
+        , crs_factory(srs::get_crs_factory<Curve>())
         , srs(crs_factory->get_prover_crs(num_points))
     {}
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
@@ -36,6 +36,10 @@ template <class Curve> class CommitmentKey {
     using Commitment = typename Curve::AffineElement;
 
   public:
+    scalar_multiplication::pippenger_runtime_state<Curve> pippenger_runtime_state;
+    std::shared_ptr<srs::factories::CrsFactory<Curve>> crs_factory;
+    std::shared_ptr<srs::factories::ProverCrs<Curve>> srs;
+
     CommitmentKey() = delete;
 
     /**
@@ -45,14 +49,21 @@ template <class Curve> class CommitmentKey {
      * @param path
      *
      */
-    CommitmentKey(const size_t num_points,
-                  std::shared_ptr<bb::srs::factories::CrsFactory<Curve>> crs_factory = bb::srs::get_crs_factory())
+    CommitmentKey(const size_t num_points)
         : pippenger_runtime_state(num_points)
+        , crs_factory([]() {
+            if constexpr (std::same_as<Curve, curve::BN254>) {
+                return srs::get_crs_factory();
+            } else {
+                static_assert(std::same_as<Curve, curve::Grumpkin>);
+                return srs::get_grumpkin_crs_factory();
+            }
+        }())
         , srs(crs_factory->get_prover_crs(num_points))
     {}
 
-    // Note: This constructor is used only by Plonk; For Honk the srs is extracted by the CommitmentKey
-    CommitmentKey(const size_t num_points, std::shared_ptr<bb::srs::factories::ProverCrs<Curve>> prover_crs)
+    // Note: This constructor is to be used only by Plonk; For Honk the srs lifes in the CommitmentKey
+    CommitmentKey(const size_t num_points, std::shared_ptr<srs::factories::ProverCrs<Curve>> prover_crs)
         : pippenger_runtime_state(num_points)
         , srs(prover_crs)
     {}
@@ -68,12 +79,9 @@ template <class Curve> class CommitmentKey {
         BB_OP_COUNT_TIME();
         const size_t degree = polynomial.size();
         ASSERT(degree <= srs->get_monomial_size());
-        return bb::scalar_multiplication::pippenger_unsafe<Curve>(
+        return scalar_multiplication::pippenger_unsafe<Curve>(
             const_cast<Fr*>(polynomial.data()), srs->get_monomial_points(), degree, pippenger_runtime_state);
     };
-
-    bb::scalar_multiplication::pippenger_runtime_state<Curve> pippenger_runtime_state;
-    std::shared_ptr<bb::srs::factories::ProverCrs<Curve>> srs;
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
@@ -55,7 +55,7 @@ template <class Curve> class CommitmentKey {
         , srs(crs_factory->get_prover_crs(num_points))
     {}
 
-    // Note: This constructor is to be used only by Plonk; For Honk the srs lifes in the CommitmentKey
+    // Note: This constructor is to be used only by Plonk; For Honk the srs lives in the CommitmentKey
     CommitmentKey(const size_t num_points, std::shared_ptr<srs::factories::ProverCrs<Curve>> prover_crs)
         : pippenger_runtime_state(num_points)
         , srs(prover_crs)

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.test.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.test.hpp
@@ -22,7 +22,7 @@ template <> inline std::shared_ptr<CommitmentKey<curve::BN254>> CreateCommitment
     constexpr size_t n = 4096;
     std::shared_ptr<bb::srs::factories::CrsFactory<curve::BN254>> crs_factory(
         new bb::srs::factories::FileCrsFactory<curve::BN254>("../srs_db/ignition", 4096));
-    return std::make_shared<CommitmentKey<curve::BN254>>(n, crs_factory);
+    return std::make_shared<CommitmentKey<curve::BN254>>(n);
 }
 // For IPA
 template <> inline std::shared_ptr<CommitmentKey<curve::Grumpkin>> CreateCommitmentKey<CommitmentKey<curve::Grumpkin>>()
@@ -30,7 +30,7 @@ template <> inline std::shared_ptr<CommitmentKey<curve::Grumpkin>> CreateCommitm
     constexpr size_t n = 4096;
     std::shared_ptr<bb::srs::factories::CrsFactory<curve::Grumpkin>> crs_factory(
         new bb::srs::factories::FileCrsFactory<curve::Grumpkin>("../srs_db/grumpkin", 4096));
-    return std::make_shared<CommitmentKey<curve::Grumpkin>>(n, crs_factory);
+    return std::make_shared<CommitmentKey<curve::Grumpkin>>(n);
 }
 
 template <typename CK> inline std::shared_ptr<CK> CreateCommitmentKey()

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.test.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.test.hpp
@@ -19,17 +19,15 @@ template <class CK> inline std::shared_ptr<CK> CreateCommitmentKey();
 
 template <> inline std::shared_ptr<CommitmentKey<curve::BN254>> CreateCommitmentKey<CommitmentKey<curve::BN254>>()
 {
+    srs::init_crs_factory("../srs_db/ignition");
     constexpr size_t n = 4096;
-    std::shared_ptr<bb::srs::factories::CrsFactory<curve::BN254>> crs_factory(
-        new bb::srs::factories::FileCrsFactory<curve::BN254>("../srs_db/ignition", 4096));
     return std::make_shared<CommitmentKey<curve::BN254>>(n);
 }
 // For IPA
 template <> inline std::shared_ptr<CommitmentKey<curve::Grumpkin>> CreateCommitmentKey<CommitmentKey<curve::Grumpkin>>()
 {
+    srs::init_grumpkin_crs_factory("../srs_db/grumpkin");
     constexpr size_t n = 4096;
-    std::shared_ptr<bb::srs::factories::CrsFactory<curve::Grumpkin>> crs_factory(
-        new bb::srs::factories::FileCrsFactory<curve::Grumpkin>("../srs_db/grumpkin", 4096));
     return std::make_shared<CommitmentKey<curve::Grumpkin>>(n);
 }
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.test.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.test.hpp
@@ -6,10 +6,6 @@
 #include "barretenberg/polynomials/polynomial.hpp"
 #include "barretenberg/srs/factories/file_crs_factory.hpp"
 #include "claim.hpp"
-#include <algorithm>
-#include <concepts>
-#include <memory>
-#include <string_view>
 
 #include <gtest/gtest.h>
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/verification_key.hpp
@@ -43,7 +43,7 @@ template <> class VerifierCommitmentKey<curve::BN254> {
      * @param num_points
      * @param srs verifier G2 point
      */
-    VerifierCommitmentKey([[maybe_unused]] size_t num_points,
+    VerifierCommitmentKey([[maybe_unused]] size_t num_points, // WORKTODO
                           std::shared_ptr<bb::srs::factories::CrsFactory<Curve>> crs_factory)
         : srs(crs_factory->get_verifier_crs())
     {}

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/verification_key.hpp
@@ -43,8 +43,9 @@ template <> class VerifierCommitmentKey<curve::BN254> {
      * @param num_points
      * @param srs verifier G2 point
      */
-    VerifierCommitmentKey([[maybe_unused]] size_t num_points, // WORKTODO
-                          std::shared_ptr<bb::srs::factories::CrsFactory<Curve>> crs_factory)
+    VerifierCommitmentKey(
+        [[maybe_unused]] size_t num_points, // TODO(https://github.com/AztecProtocol/barretenberg/issues/874)
+        std::shared_ptr<bb::srs::factories::CrsFactory<Curve>> crs_factory)
         : srs(crs_factory->get_verifier_crs())
     {}
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/acir_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/acir_composer.cpp
@@ -77,8 +77,8 @@ std::shared_ptr<bb::plonk::verification_key> AcirComposer::init_verification_key
 
 void AcirComposer::load_verification_key(bb::plonk::verification_key_data&& data)
 {
-    verification_key_ =
-        std::make_shared<bb::plonk::verification_key>(std::move(data), srs::get_crs_factory()->get_verifier_crs());
+    verification_key_ = std::make_shared<bb::plonk::verification_key>(std::move(data),
+                                                                      srs::get_bn254_crs_factory()->get_verifier_crs());
 }
 
 bool AcirComposer::verify_proof(std::vector<uint8_t> const& proof)

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.hpp
@@ -70,7 +70,7 @@ template <IsECCVMFlavor Flavor> class ECCVMComposer_ {
 
     void compute_commitment_key(size_t circuit_size)
     {
-        commitment_key = std::make_shared<CommitmentKey>(circuit_size, crs_factory_);
+        commitment_key = std::make_shared<CommitmentKey>(circuit_size);
     };
 };
 

--- a/barretenberg/cpp/src/barretenberg/flavor/ecc_vm.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ecc_vm.hpp
@@ -310,10 +310,10 @@ template <typename CycleGroup_T, typename Curve_T, typename PCS_T> class ECCVMBa
      * @note TODO(Cody): Maybe multiple inheritance is the right thing here. In that case, nothing should eve
      * inherit from ProvingKey.
      */
-    class ProvingKey : public ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>> {
+    class ProvingKey : public ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey> {
       public:
         // Expose constructors on the base class
-        using Base = ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>>;
+        using Base = ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey>;
         using Base::Base;
 
         auto get_to_be_shifted() { return ECCVMBase::get_to_be_shifted<Polynomial>(*this); }

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -150,6 +150,12 @@ template <typename PrecomputedCommitments> class VerificationKey_ : public Preco
         this->log_circuit_size = numeric::get_msb(circuit_size);
         this->num_public_inputs = num_public_inputs;
     };
+    template <typename ProvingKeyPtr> VerificationKey_(const ProvingKeyPtr& proving_key)
+    {
+        for (auto [polynomial, commitment] : zip_view(proving_key->get_precomputed_polynomials(), this->get_all())) {
+            commitment = proving_key->commitment_key->commit(polynomial);
+        }
+    }
 };
 
 // Because of how Gemini is written, is importat to put the polynomials out in this order.

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -103,6 +103,7 @@ class ProvingKey_ : public PrecomputedPolynomials, public WitnessPolynomials {
     using Polynomial = typename PrecomputedPolynomials::DataType;
     using FF = typename Polynomial::FF;
 
+    size_t circuit_size;
     bool contains_recursive_proof;
     std::vector<uint32_t> recursive_proof_public_input_indices;
     bb::EvaluationDomain<FF> evaluation_domain;
@@ -122,7 +123,7 @@ class ProvingKey_ : public PrecomputedPolynomials, public WitnessPolynomials {
     {
         this->commitment_key = std::make_shared<CommitmentKey_>(circuit_size + 1);
         this->evaluation_domain = bb::EvaluationDomain<FF>(circuit_size, circuit_size);
-        PrecomputedPolynomials::circuit_size = circuit_size;
+        this->circuit_size = circuit_size;
         this->log_circuit_size = numeric::get_msb(circuit_size);
         this->num_public_inputs = num_public_inputs;
         // Allocate memory for precomputed polynomials
@@ -152,6 +153,10 @@ template <typename PrecomputedCommitments> class VerificationKey_ : public Preco
     };
     template <typename ProvingKeyPtr> VerificationKey_(const ProvingKeyPtr& proving_key)
     {
+        this->circuit_size = proving_key->circuit_size;
+        this->log_circuit_size = numeric::get_msb(this->circuit_size);
+        this->num_public_inputs = proving_key->num_public_inputs;
+
         for (auto [polynomial, commitment] : zip_view(proving_key->get_precomputed_polynomials(), this->get_all())) {
             commitment = proving_key->commitment_key->commit(polynomial);
         }

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -97,7 +97,7 @@ class PrecomputedEntitiesBase {
  * @tparam FF The scalar field on which we will encode our polynomial data. When instantiating, this may be extractable
  * from the other template paramter.
  */
-template <typename PrecomputedPolynomials, typename WitnessPolynomials>
+template <typename PrecomputedPolynomials, typename WitnessPolynomials, typename CommitmentKey_>
 class ProvingKey_ : public PrecomputedPolynomials, public WitnessPolynomials {
   public:
     using Polynomial = typename PrecomputedPolynomials::DataType;
@@ -106,6 +106,7 @@ class ProvingKey_ : public PrecomputedPolynomials, public WitnessPolynomials {
     bool contains_recursive_proof;
     std::vector<uint32_t> recursive_proof_public_input_indices;
     bb::EvaluationDomain<FF> evaluation_domain;
+    std::shared_ptr<CommitmentKey_> commitment_key;
 
     std::vector<std::string> get_labels() const
     {
@@ -119,6 +120,7 @@ class ProvingKey_ : public PrecomputedPolynomials, public WitnessPolynomials {
     ProvingKey_() = default;
     ProvingKey_(const size_t circuit_size, const size_t num_public_inputs)
     {
+        this->commitment_key = std::make_shared<CommitmentKey_>(circuit_size + 1);
         this->evaluation_domain = bb::EvaluationDomain<FF>(circuit_size, circuit_size);
         PrecomputedPolynomials::circuit_size = circuit_size;
         this->log_circuit_size = numeric::get_msb(circuit_size);

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.test.cpp
@@ -8,6 +8,7 @@ using namespace bb;
 
 TEST(Flavor, Getters)
 {
+    srs::init_crs_factory("../srs_db/ignition");
     using Flavor = UltraFlavor;
     using FF = Flavor::FF;
     using ProvingKey = typename Flavor::ProvingKey;

--- a/barretenberg/cpp/src/barretenberg/flavor/generated/avm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/generated/avm_flavor.hpp
@@ -504,10 +504,10 @@ class AvmFlavor {
     };
 
   public:
-    class ProvingKey : public ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>> {
+    class ProvingKey : public ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey> {
       public:
         // Expose constructors on the base class
-        using Base = ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>>;
+        using Base = ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey>;
         using Base::Base;
 
         auto get_to_be_shifted()

--- a/barretenberg/cpp/src/barretenberg/flavor/generated/toy_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/generated/toy_flavor.hpp
@@ -200,10 +200,10 @@ class ToyFlavor {
     };
 
   public:
-    class ProvingKey : public ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>> {
+    class ProvingKey : public ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey> {
       public:
         // Expose constructors on the base class
-        using Base = ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>>;
+        using Base = ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey>;
         using Base::Base;
 
         auto get_to_be_shifted() { return RefArray<DataType, 0>{}; };

--- a/barretenberg/cpp/src/barretenberg/flavor/goblin_translator.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/goblin_translator.hpp
@@ -895,14 +895,14 @@ class GoblinTranslatorFlavor {
      * @note TODO(Cody): Maybe multiple inheritance is the right thing here. In that case, nothing should eve
      * inherit from ProvingKey.
      */
-    class ProvingKey : public ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>> {
+    class ProvingKey : public ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey> {
       public:
         BF batching_challenge_v = { 0 };
         BF evaluation_input_x = { 0 };
         ProvingKey() = default;
 
         // Expose constructors on the base class
-        using Base = ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>>;
+        using Base = ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey>;
         using Base::Base;
 
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/810): get around this by properly having
@@ -919,7 +919,7 @@ class GoblinTranslatorFlavor {
         }
 
         ProvingKey(const size_t circuit_size)
-            : ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>>(circuit_size, 0)
+            : ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey>(circuit_size, 0)
 
             , batching_challenge_v(0)
             , evaluation_input_x(0)

--- a/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra.hpp
@@ -289,11 +289,6 @@ class GoblinUltraFlavor {
      */
     using VerificationKey = VerificationKey_<PrecomputedEntities<Commitment>>;
 
-    static std::shared_ptr<VerificationKey> compute_verification_key(const std::shared_ptr<ProvingKey>& proving_key)
-    {
-        return std::make_shared<VerificationKey>(proving_key);
-    }
-
     /**
      * @brief A container for storing the partially evaluated multivariates produced by sumcheck.
      */

--- a/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra.hpp
@@ -285,47 +285,17 @@ class GoblinUltraFlavor {
      * @note Note the discrepancy with what sort of data is stored here vs in the proving key. We may want to resolve
      * that, and split out separate PrecomputedPolynomials/Commitments data for clarity but also for portability of our
      * circuits.
+     * @todo TODO(https://github.com/AztecProtocol/barretenberg/issues/876)
      */
     using VerificationKey = VerificationKey_<PrecomputedEntities<Commitment>>;
 
     static std::shared_ptr<VerificationKey> compute_verification_key(const std::shared_ptr<ProvingKey>& proving_key)
     {
         auto result = std::make_shared<VerificationKey>(proving_key->circuit_size, proving_key->num_public_inputs);
-        std::shared_ptr<CommitmentKey>& commitment_key = proving_key->commitment_key;
 
-        result->q_m = commitment_key->commit(proving_key->q_m);
-        result->q_l = commitment_key->commit(proving_key->q_l);
-        result->q_r = commitment_key->commit(proving_key->q_r);
-        result->q_o = commitment_key->commit(proving_key->q_o);
-        result->q_c = commitment_key->commit(proving_key->q_c);
-        result->sigma_1 = commitment_key->commit(proving_key->sigma_1);
-        result->sigma_2 = commitment_key->commit(proving_key->sigma_2);
-        result->sigma_3 = commitment_key->commit(proving_key->sigma_3);
-        result->id_1 = commitment_key->commit(proving_key->id_1);
-        result->id_2 = commitment_key->commit(proving_key->id_2);
-        result->id_3 = commitment_key->commit(proving_key->id_3);
-        result->lagrange_first = commitment_key->commit(proving_key->lagrange_first);
-        result->lagrange_last = commitment_key->commit(proving_key->lagrange_last);
-        result->q_4 = commitment_key->commit(proving_key->q_4);
-        result->q_arith = commitment_key->commit(proving_key->q_arith);
-        result->q_sort = commitment_key->commit(proving_key->q_sort);
-        result->q_elliptic = commitment_key->commit(proving_key->q_elliptic);
-        result->q_aux = commitment_key->commit(proving_key->q_aux);
-        result->q_lookup = commitment_key->commit(proving_key->q_lookup);
-        result->sigma_4 = commitment_key->commit(proving_key->sigma_4);
-        result->id_4 = commitment_key->commit(proving_key->id_4);
-        result->table_1 = commitment_key->commit(proving_key->table_1);
-        result->table_2 = commitment_key->commit(proving_key->table_2);
-        result->table_3 = commitment_key->commit(proving_key->table_3);
-        result->table_4 = commitment_key->commit(proving_key->table_4);
-
-        // TODO(luke): Similar to the lagrange_first/last polynomials, we dont really need to commit to these
-        // polynomials due to their simple structure.
-        result->lagrange_ecc_op = commitment_key->commit(proving_key->lagrange_ecc_op);
-        result->q_busread = commitment_key->commit(proving_key->q_busread);
-        result->databus_id = commitment_key->commit(proving_key->databus_id);
-        result->q_poseidon2_external = commitment_key->commit(proving_key->q_poseidon2_external);
-        result->q_poseidon2_internal = commitment_key->commit(proving_key->q_poseidon2_internal);
+        for (auto [polynomial, commitment] : zip_view(proving_key->get_precomputed_polynomials(), result->get_all())) {
+            commitment = proving_key->commitment_key->commit(polynomial);
+        }
 
         return result;
     }

--- a/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra.hpp
@@ -291,13 +291,7 @@ class GoblinUltraFlavor {
 
     static std::shared_ptr<VerificationKey> compute_verification_key(const std::shared_ptr<ProvingKey>& proving_key)
     {
-        auto result = std::make_shared<VerificationKey>(proving_key->circuit_size, proving_key->num_public_inputs);
-
-        for (auto [polynomial, commitment] : zip_view(proving_key->get_precomputed_polynomials(), result->get_all())) {
-            commitment = proving_key->commitment_key->commit(polynomial);
-        }
-
-        return result;
+        return std::make_shared<VerificationKey>(proving_key);
     }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra.hpp
@@ -258,10 +258,10 @@ class GoblinUltraFlavor {
      * @note TODO(Cody): Maybe multiple inheritance is the right thing here. In that case, nothing should eve inherit
      * from ProvingKey.
      */
-    class ProvingKey : public ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>> {
+    class ProvingKey : public ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey> {
       public:
         // Expose constructors on the base class
-        using Base = ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>>;
+        using Base = ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey>;
         using Base::Base;
 
         std::vector<uint32_t> memory_read_records;
@@ -287,6 +287,48 @@ class GoblinUltraFlavor {
      * circuits.
      */
     using VerificationKey = VerificationKey_<PrecomputedEntities<Commitment>>;
+
+    static std::shared_ptr<VerificationKey> compute_verification_key(const std::shared_ptr<ProvingKey>& proving_key)
+    {
+        auto result = std::make_shared<VerificationKey>(proving_key->circuit_size, proving_key->num_public_inputs);
+        std::shared_ptr<CommitmentKey>& commitment_key = proving_key->commitment_key;
+
+        result->q_m = commitment_key->commit(proving_key->q_m);
+        result->q_l = commitment_key->commit(proving_key->q_l);
+        result->q_r = commitment_key->commit(proving_key->q_r);
+        result->q_o = commitment_key->commit(proving_key->q_o);
+        result->q_c = commitment_key->commit(proving_key->q_c);
+        result->sigma_1 = commitment_key->commit(proving_key->sigma_1);
+        result->sigma_2 = commitment_key->commit(proving_key->sigma_2);
+        result->sigma_3 = commitment_key->commit(proving_key->sigma_3);
+        result->id_1 = commitment_key->commit(proving_key->id_1);
+        result->id_2 = commitment_key->commit(proving_key->id_2);
+        result->id_3 = commitment_key->commit(proving_key->id_3);
+        result->lagrange_first = commitment_key->commit(proving_key->lagrange_first);
+        result->lagrange_last = commitment_key->commit(proving_key->lagrange_last);
+        result->q_4 = commitment_key->commit(proving_key->q_4);
+        result->q_arith = commitment_key->commit(proving_key->q_arith);
+        result->q_sort = commitment_key->commit(proving_key->q_sort);
+        result->q_elliptic = commitment_key->commit(proving_key->q_elliptic);
+        result->q_aux = commitment_key->commit(proving_key->q_aux);
+        result->q_lookup = commitment_key->commit(proving_key->q_lookup);
+        result->sigma_4 = commitment_key->commit(proving_key->sigma_4);
+        result->id_4 = commitment_key->commit(proving_key->id_4);
+        result->table_1 = commitment_key->commit(proving_key->table_1);
+        result->table_2 = commitment_key->commit(proving_key->table_2);
+        result->table_3 = commitment_key->commit(proving_key->table_3);
+        result->table_4 = commitment_key->commit(proving_key->table_4);
+
+        // TODO(luke): Similar to the lagrange_first/last polynomials, we dont really need to commit to these
+        // polynomials due to their simple structure.
+        result->lagrange_ecc_op = commitment_key->commit(proving_key->lagrange_ecc_op);
+        result->q_busread = commitment_key->commit(proving_key->q_busread);
+        result->databus_id = commitment_key->commit(proving_key->databus_id);
+        result->q_poseidon2_external = commitment_key->commit(proving_key->q_poseidon2_external);
+        result->q_poseidon2_internal = commitment_key->commit(proving_key->q_poseidon2_internal);
+
+        return result;
+    }
 
     /**
      * @brief A container for storing the partially evaluated multivariates produced by sumcheck.

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra.hpp
@@ -292,11 +292,6 @@ class UltraFlavor {
      */
     using VerificationKey = VerificationKey_<PrecomputedEntities<Commitment>>;
 
-    static std::shared_ptr<VerificationKey> compute_verification_key(const std::shared_ptr<ProvingKey>& proving_key)
-    {
-        return std::make_shared<VerificationKey>(proving_key);
-    }
-
     /**
      * @brief A field element for each entity of the flavor. These entities represent the prover polynomials
      * evaluated at one point.

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra.hpp
@@ -264,10 +264,10 @@ class UltraFlavor {
      * @note TODO(Cody): Maybe multiple inheritance is the right thing here. In that case, nothing should eve inherit
      * from ProvingKey.
      */
-    class ProvingKey : public ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>> {
+    class ProvingKey : public ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey> {
       public:
         // Expose constructors on the base class
-        using Base = ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>>;
+        using Base = ProvingKey_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey>;
         using Base::Base;
 
         std::vector<uint32_t> memory_read_records;
@@ -291,6 +291,40 @@ class UltraFlavor {
      * circuits.
      */
     using VerificationKey = VerificationKey_<PrecomputedEntities<Commitment>>;
+
+    static std::shared_ptr<VerificationKey> compute_verification_key(const std::shared_ptr<ProvingKey>& proving_key)
+    {
+        auto result = std::make_shared<VerificationKey>(proving_key->circuit_size, proving_key->num_public_inputs);
+        std::shared_ptr<CommitmentKey>& commitment_key = proving_key->commitment_key;
+
+        result->q_m = commitment_key->commit(proving_key->q_m);
+        result->q_l = commitment_key->commit(proving_key->q_l);
+        result->q_r = commitment_key->commit(proving_key->q_r);
+        result->q_o = commitment_key->commit(proving_key->q_o);
+        result->q_c = commitment_key->commit(proving_key->q_c);
+        result->sigma_1 = commitment_key->commit(proving_key->sigma_1);
+        result->sigma_2 = commitment_key->commit(proving_key->sigma_2);
+        result->sigma_3 = commitment_key->commit(proving_key->sigma_3);
+        result->id_1 = commitment_key->commit(proving_key->id_1);
+        result->id_2 = commitment_key->commit(proving_key->id_2);
+        result->id_3 = commitment_key->commit(proving_key->id_3);
+        result->lagrange_first = commitment_key->commit(proving_key->lagrange_first);
+        result->lagrange_last = commitment_key->commit(proving_key->lagrange_last);
+        result->q_4 = commitment_key->commit(proving_key->q_4);
+        result->q_arith = commitment_key->commit(proving_key->q_arith);
+        result->q_sort = commitment_key->commit(proving_key->q_sort);
+        result->q_elliptic = commitment_key->commit(proving_key->q_elliptic);
+        result->q_aux = commitment_key->commit(proving_key->q_aux);
+        result->q_lookup = commitment_key->commit(proving_key->q_lookup);
+        result->sigma_4 = commitment_key->commit(proving_key->sigma_4);
+        result->id_4 = commitment_key->commit(proving_key->id_4);
+        result->table_1 = commitment_key->commit(proving_key->table_1);
+        result->table_2 = commitment_key->commit(proving_key->table_2);
+        result->table_3 = commitment_key->commit(proving_key->table_3);
+        result->table_4 = commitment_key->commit(proving_key->table_4);
+
+        return result;
+    }
 
     /**
      * @brief A field element for each entity of the flavor. These entities represent the prover polynomials

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra.hpp
@@ -294,13 +294,7 @@ class UltraFlavor {
 
     static std::shared_ptr<VerificationKey> compute_verification_key(const std::shared_ptr<ProvingKey>& proving_key)
     {
-        auto result = std::make_shared<VerificationKey>(proving_key->circuit_size, proving_key->num_public_inputs);
-
-        for (auto [polynomial, commitment] : zip_view(proving_key->get_precomputed_polynomials(), result->get_all())) {
-            commitment = proving_key->commitment_key->commit(polynomial);
-        }
-
-        return result;
+        return std::make_shared<VerificationKey>(proving_key);
     }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra.hpp
@@ -295,33 +295,10 @@ class UltraFlavor {
     static std::shared_ptr<VerificationKey> compute_verification_key(const std::shared_ptr<ProvingKey>& proving_key)
     {
         auto result = std::make_shared<VerificationKey>(proving_key->circuit_size, proving_key->num_public_inputs);
-        std::shared_ptr<CommitmentKey>& commitment_key = proving_key->commitment_key;
 
-        result->q_m = commitment_key->commit(proving_key->q_m);
-        result->q_l = commitment_key->commit(proving_key->q_l);
-        result->q_r = commitment_key->commit(proving_key->q_r);
-        result->q_o = commitment_key->commit(proving_key->q_o);
-        result->q_c = commitment_key->commit(proving_key->q_c);
-        result->sigma_1 = commitment_key->commit(proving_key->sigma_1);
-        result->sigma_2 = commitment_key->commit(proving_key->sigma_2);
-        result->sigma_3 = commitment_key->commit(proving_key->sigma_3);
-        result->id_1 = commitment_key->commit(proving_key->id_1);
-        result->id_2 = commitment_key->commit(proving_key->id_2);
-        result->id_3 = commitment_key->commit(proving_key->id_3);
-        result->lagrange_first = commitment_key->commit(proving_key->lagrange_first);
-        result->lagrange_last = commitment_key->commit(proving_key->lagrange_last);
-        result->q_4 = commitment_key->commit(proving_key->q_4);
-        result->q_arith = commitment_key->commit(proving_key->q_arith);
-        result->q_sort = commitment_key->commit(proving_key->q_sort);
-        result->q_elliptic = commitment_key->commit(proving_key->q_elliptic);
-        result->q_aux = commitment_key->commit(proving_key->q_aux);
-        result->q_lookup = commitment_key->commit(proving_key->q_lookup);
-        result->sigma_4 = commitment_key->commit(proving_key->sigma_4);
-        result->id_4 = commitment_key->commit(proving_key->id_4);
-        result->table_1 = commitment_key->commit(proving_key->table_1);
-        result->table_2 = commitment_key->commit(proving_key->table_2);
-        result->table_3 = commitment_key->commit(proving_key->table_3);
-        result->table_4 = commitment_key->commit(proving_key->table_4);
+        for (auto [polynomial, commitment] : zip_view(proving_key->get_precomputed_polynomials(), result->get_all())) {
+            commitment = proving_key->commitment_key->commit(polynomial);
+        }
 
         return result;
     }

--- a/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
@@ -134,8 +134,7 @@ class GoblinMockCircuits {
         op_queue->set_size_data();
 
         // Manually compute the op queue transcript commitments (which would normally be done by the merge prover)
-        auto crs_factory_ = bb::srs::get_crs_factory();
-        auto commitment_key = CommitmentKey(op_queue->get_current_size(), crs_factory_);
+        auto commitment_key = CommitmentKey(op_queue->get_current_size());
         std::array<Point, Flavor::NUM_WIRES> op_queue_commitments;
         size_t idx = 0;
         for (auto& entry : op_queue->get_aggregate_transcript()) {

--- a/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.cpp
+++ b/barretenberg/cpp/src/barretenberg/join_split_example/proofs/join_split/join_split.cpp
@@ -47,7 +47,7 @@ void init_verification_key()
     }
 
     verification_key =
-        bb::plonk::compute_verification_key_common(proving_key, srs::get_crs_factory()->get_verifier_crs());
+        bb::plonk::compute_verification_key_common(proving_key, srs::get_bn254_crs_factory()->get_verifier_crs());
 }
 
 Prover new_join_split_prover(join_split_tx const& tx, bool mock)

--- a/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.cpp
@@ -35,7 +35,7 @@ std::shared_ptr<plonk::proving_key> StandardComposer::compute_proving_key(Circui
         circuit_constructor.num_gates + circuit_constructor.public_inputs.size() + NUM_RESERVED_GATES;
     const size_t subgroup_size = circuit_constructor.get_circuit_subgroup_size(total_num_gates); // next power of 2
 
-    auto crs = srs::get_crs_factory()->get_prover_crs(subgroup_size + 1);
+    auto crs = srs::get_bn254_crs_factory()->get_prover_crs(subgroup_size + 1);
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/392): Composer type
     circuit_proving_key = std::make_shared<plonk::proving_key>(
         subgroup_size, circuit_constructor.public_inputs.size(), crs, CircuitType::STANDARD);

--- a/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/composer/standard_composer.hpp
@@ -30,7 +30,7 @@ class StandardComposer {
 
     bool computed_witness = false;
 
-    StandardComposer() { crs_factory_ = bb::srs::get_crs_factory(); }
+    StandardComposer() { crs_factory_ = bb::srs::get_bn254_crs_factory(); }
     StandardComposer(std::shared_ptr<bb::srs::factories::CrsFactory<curve::BN254>> crs_factory)
         : crs_factory_(std::move(crs_factory))
     {}

--- a/barretenberg/cpp/src/barretenberg/plonk/composer/ultra_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/composer/ultra_composer.cpp
@@ -160,7 +160,7 @@ std::shared_ptr<proving_key> UltraComposer::compute_proving_key(CircuitBuilder& 
 
     const size_t subgroup_size = compute_dyadic_circuit_size(circuit);
 
-    auto crs = srs::get_crs_factory()->get_prover_crs(subgroup_size + 1);
+    auto crs = srs::get_bn254_crs_factory()->get_prover_crs(subgroup_size + 1);
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/392): Composer type
     circuit_proving_key =
         std::make_shared<plonk::proving_key>(subgroup_size, circuit.public_inputs.size(), crs, CircuitType::ULTRA);
@@ -209,7 +209,7 @@ std::shared_ptr<plonk::verification_key> UltraComposer::compute_verification_key
         compute_proving_key(circuit_constructor);
     }
     circuit_verification_key =
-        compute_verification_key_common(circuit_proving_key, srs::get_crs_factory()->get_verifier_crs());
+        compute_verification_key_common(circuit_proving_key, srs::get_bn254_crs_factory()->get_verifier_crs());
 
     circuit_verification_key->circuit_type = CircuitType::ULTRA;
 

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/verification_key.hpp
@@ -120,7 +120,7 @@ struct verification_key {
     void msgpack_unpack(auto obj)
     {
         verification_key_data data = obj;
-        *this = verification_key{ std::move(data), bb::srs::get_crs_factory()->get_verifier_crs() };
+        *this = verification_key{ std::move(data), bb::srs::get_bn254_crs_factory()->get_verifier_crs() };
     }
     // Alias verification_key as verification_key_data in the schema
     void msgpack_schema(auto& packer) const { packer.pack_schema(bb::plonk::verification_key_data{}); }
@@ -131,7 +131,7 @@ template <typename B> inline void read(B& buf, verification_key& key)
     using serialize::read;
     verification_key_data vk_data;
     read(buf, vk_data);
-    key = verification_key{ std::move(vk_data), bb::srs::get_crs_factory()->get_verifier_crs() };
+    key = verification_key{ std::move(vk_data), bb::srs::get_bn254_crs_factory()->get_verifier_crs() };
 }
 
 template <typename B> inline void read(B& buf, std::shared_ptr<verification_key>& key)
@@ -139,7 +139,7 @@ template <typename B> inline void read(B& buf, std::shared_ptr<verification_key>
     using serialize::read;
     verification_key_data vk_data;
     read(buf, vk_data);
-    key = std::make_shared<verification_key>(std::move(vk_data), bb::srs::get_crs_factory()->get_verifier_crs());
+    key = std::make_shared<verification_key>(std::move(vk_data), bb::srs::get_bn254_crs_factory()->get_verifier_crs());
 }
 
 template <typename B> inline void write(B& buf, verification_key const& key)

--- a/barretenberg/cpp/src/barretenberg/proof_system/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/proof_system/CMakeLists.txt
@@ -1,1 +1,1 @@
-barretenberg_module(proof_system relations crypto_pedersen_commitment crypto_pedersen_hash)
+barretenberg_module(proof_system relations crypto_pedersen_hash srs)

--- a/barretenberg/cpp/src/barretenberg/proof_system/composer/permutation_lib.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/composer/permutation_lib.test.cpp
@@ -2,7 +2,7 @@
 #include "barretenberg/flavor/ultra.hpp"
 #include "barretenberg/proof_system/composer/composer_lib.hpp"
 #include "barretenberg/proof_system/types/circuit_type.hpp"
-#include "barretenberg/srs/factories/crs_factory.hpp"
+#include "barretenberg/srs/global_crs.hpp"
 #include <array>
 #include <gtest/gtest.h>
 
@@ -14,11 +14,11 @@ class PermutationHelperTests : public ::testing::Test {
     using FF = typename Flavor::FF;
     using ProvingKey = Flavor::ProvingKey;
     Flavor::CircuitBuilder circuit_constructor;
-    srs::factories::CrsFactory<curve::BN254> crs_factory = srs::factories::CrsFactory<curve::BN254>();
     std::shared_ptr<Flavor::ProvingKey> proving_key;
 
     virtual void SetUp()
     {
+        srs::init_crs_factory("../srs_db/ignition");
         circuit_constructor.add_public_variable(1024);
         circuit_constructor.add_public_variable(1025);
 

--- a/barretenberg/cpp/src/barretenberg/proof_system/library/grand_product_library.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/proof_system/library/grand_product_library.test.cpp
@@ -13,6 +13,7 @@ template <class FF> class GrandProductTests : public testing::Test {
     using Polynomial = bb::Polynomial<FF>;
 
   public:
+    void SetUp() { srs::init_crs_factory("../srs_db/ignition"); }
     /**
      * @brief Get a random polynomial
      *

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/decider_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/decider_verifier.cpp
@@ -14,7 +14,7 @@ DeciderVerifier_<Flavor>::DeciderVerifier_(const std::shared_ptr<Transcript>& tr
 {}
 template <typename Flavor>
 DeciderVerifier_<Flavor>::DeciderVerifier_()
-    : pcs_verification_key(std::make_unique<VerifierCommitmentKey>(0, bb::srs::get_crs_factory()))
+    : pcs_verification_key(std::make_unique<VerifierCommitmentKey>(0, bb::srs::get_bn254_crs_factory()))
     , transcript(std::make_shared<Transcript>())
 {}
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
@@ -66,8 +66,7 @@ template <class ProverInstances_> class ProtoGalaxyProver_ {
     ProtogalaxyProofConstructionState<ProverInstances> state;
 
     ProtoGalaxyProver_() = default;
-    ProtoGalaxyProver_(const std::vector<std::shared_ptr<Instance>>& insts,
-                       [[maybe_unused]] const std::shared_ptr<CommitmentKey>& commitment_key) // WORKTODO
+    ProtoGalaxyProver_(const std::vector<std::shared_ptr<Instance>>& insts)
         : instances(ProverInstances(insts))
         , commitment_key(instances[1]->proving_key->commitment_key){}; // WORKTODO: [1] is wack; too much partial
                                                                        // initialization/hidden state in all of this

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
@@ -68,8 +68,8 @@ template <class ProverInstances_> class ProtoGalaxyProver_ {
     ProtoGalaxyProver_() = default;
     ProtoGalaxyProver_(const std::vector<std::shared_ptr<Instance>>& insts)
         : instances(ProverInstances(insts))
-        , commitment_key(instances[1]->proving_key->commitment_key){}; // WORKTODO: [1] is wack; too much partial
-                                                                       // initialization/hidden state in all of this
+        // TODO(https://github.com/AztecProtocol/barretenberg/issues/878)
+        , commitment_key(instances[1]->proving_key->commitment_key){};
     ~ProtoGalaxyProver_() = default;
 
     /**

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
@@ -67,9 +67,10 @@ template <class ProverInstances_> class ProtoGalaxyProver_ {
 
     ProtoGalaxyProver_() = default;
     ProtoGalaxyProver_(const std::vector<std::shared_ptr<Instance>>& insts,
-                       const std::shared_ptr<CommitmentKey>& commitment_key)
+                       [[maybe_unused]] const std::shared_ptr<CommitmentKey>& commitment_key) // WORKTODO
         : instances(ProverInstances(insts))
-        , commitment_key(std::move(commitment_key)){};
+        , commitment_key(instances[1]->proving_key->commitment_key){}; // WORKTODO: [1] is wack; too much partial
+                                                                       // initialization/hidden state in all of this
     ~ProtoGalaxyProver_() = default;
 
     /**

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/recursive_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/recursive_circuit.hpp
@@ -150,7 +150,7 @@ template <typename OuterBuilder> class RecursiveCircuit {
     }
     static void check_pairing(const circuit_outputs& circuit_output)
     {
-        auto g2_lines = bb::srs::get_crs_factory()->get_verifier_crs()->get_precomputed_g2_lines();
+        auto g2_lines = bb::srs::get_bn254_crs_factory()->get_verifier_crs()->get_precomputed_g2_lines();
         g1::affine_element P[2];
         P[0].x = outer_scalar_field(circuit_output.aggregation_state.P0.x.get_value().lo);
         P[0].y = outer_scalar_field(circuit_output.aggregation_state.P0.y.get_value().lo);

--- a/barretenberg/cpp/src/barretenberg/srs/global_crs.cpp
+++ b/barretenberg/cpp/src/barretenberg/srs/global_crs.cpp
@@ -41,7 +41,7 @@ void init_grumpkin_crs_factory(std::string crs_path)
     grumpkin_crs_factory = std::make_shared<factories::FileCrsFactory<curve::Grumpkin>>(crs_path);
 }
 
-std::shared_ptr<factories::CrsFactory<curve::BN254>> get_crs_factory()
+std::shared_ptr<factories::CrsFactory<curve::BN254>> get_bn254_crs_factory()
 {
     if (!crs_factory) {
         throw_or_abort("You need to initalize the global CRS with a call to init_crs_factory(...)!");
@@ -56,4 +56,15 @@ std::shared_ptr<factories::CrsFactory<curve::Grumpkin>> get_grumpkin_crs_factory
     }
     return grumpkin_crs_factory;
 }
+
+template <> std::shared_ptr<factories::CrsFactory<curve::BN254>> get_crs_factory()
+{
+    return get_bn254_crs_factory();
+}
+
+template <> std::shared_ptr<factories::CrsFactory<curve::Grumpkin>> get_crs_factory()
+{
+    return get_grumpkin_crs_factory();
+}
+
 } // namespace bb::srs

--- a/barretenberg/cpp/src/barretenberg/srs/global_crs.hpp
+++ b/barretenberg/cpp/src/barretenberg/srs/global_crs.hpp
@@ -12,7 +12,9 @@ void init_grumpkin_crs_factory(std::string crs_path);
 void init_grumpkin_crs_factory(std::vector<curve::Grumpkin::AffineElement> const& points);
 void init_crs_factory(std::vector<bb::g1::affine_element> const& points, bb::g2::affine_element const g2_point);
 
-std::shared_ptr<bb::srs::factories::CrsFactory<curve::BN254>> get_crs_factory();
-std::shared_ptr<bb::srs::factories::CrsFactory<curve::Grumpkin>> get_grumpkin_crs_factory();
+std::shared_ptr<factories::CrsFactory<curve::BN254>> get_bn254_crs_factory();
+std::shared_ptr<factories::CrsFactory<curve::Grumpkin>> get_grumpkin_crs_factory();
+
+template <typename Curve> std::shared_ptr<factories::CrsFactory<Curve>> get_crs_factory();
 
 } // namespace bb::srs

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/merge_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/honk/verifier/merge_verifier.test.cpp
@@ -65,7 +65,7 @@ class RecursiveMergeVerifierTest : public testing::Test {
         // verifier and check that the result agrees.
         MergeVerifier native_verifier;
         bool verified_native = native_verifier.verify_proof(merge_proof);
-        VerifierCommitmentKey pcs_verification_key(0, srs::get_crs_factory());
+        VerifierCommitmentKey pcs_verification_key(0, srs::get_bn254_crs_factory());
         auto verified_recursive =
             pcs_verification_key.pairing_check(pairing_points[0].get_value(), pairing_points[1].get_value());
         EXPECT_EQ(verified_native, verified_recursive);

--- a/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/recursion/verifier/verifier.test.cpp
@@ -333,7 +333,7 @@ template <typename OuterComposer> class stdlib_verifier : public testing::Test {
 
     static void check_pairing(const circuit_outputs& circuit_output)
     {
-        auto g2_lines = srs::get_crs_factory()->get_verifier_crs()->get_precomputed_g2_lines();
+        auto g2_lines = srs::get_bn254_crs_factory()->get_verifier_crs()->get_precomputed_g2_lines();
         g1::affine_element P[2];
         P[0].x = outer_scalar_field(circuit_output.aggregation_state.P0.x.get_value().lo);
         P[0].y = outer_scalar_field(circuit_output.aggregation_state.P0.y.get_value().lo);
@@ -348,7 +348,7 @@ template <typename OuterComposer> class stdlib_verifier : public testing::Test {
         info("number of gates in recursive verification circuit = ", outer_circuit.get_num_gates());
         bool result = outer_circuit.check_circuit();
         EXPECT_EQ(result, expected_result);
-        auto g2_lines = srs::get_crs_factory()->get_verifier_crs()->get_precomputed_g2_lines();
+        auto g2_lines = srs::get_bn254_crs_factory()->get_verifier_crs()->get_precomputed_g2_lines();
         EXPECT_EQ(check_recursive_proof_public_inputs(outer_circuit, g2_lines), true);
     }
 

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
@@ -64,6 +64,10 @@ template <class Flavor> class ProverInstance_ {
 
     ProverInstance_(Circuit& circuit)
     {
+        BB_OP_COUNT_TIME_NAME("UltraComposer::create_prover_instance"); // WORKTODO
+        circuit.add_gates_to_ensure_all_polys_are_non_zero();
+        circuit.finalize_circuit();
+
         dyadic_circuit_size = compute_dyadic_size(circuit);
 
         proving_key = std::make_shared<ProvingKey>(dyadic_circuit_size, circuit.public_inputs.size());
@@ -87,6 +91,8 @@ template <class Flavor> class ProverInstance_ {
         sorted_polynomials = construct_sorted_list_polynomials<Flavor>(circuit, dyadic_circuit_size);
 
         populate_memory_read_write_records<Flavor>(circuit, proving_key);
+
+        verification_key = std::move(Flavor::compute_verification_key(proving_key));
     }
 
     ProverInstance_() = default;

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
@@ -64,7 +64,7 @@ template <class Flavor> class ProverInstance_ {
 
     ProverInstance_(Circuit& circuit)
     {
-        BB_OP_COUNT_TIME_NAME("UltraComposer::create_prover_instance"); // WORKTODO
+        BB_OP_COUNT_TIME_NAME("ProverInstance(Circuit&)");
         circuit.add_gates_to_ensure_all_polys_are_non_zero();
         circuit.finalize_circuit();
 

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
@@ -92,7 +92,7 @@ template <class Flavor> class ProverInstance_ {
 
         populate_memory_read_write_records<Flavor>(circuit, proving_key);
 
-        verification_key = std::move(Flavor::compute_verification_key(proving_key));
+        verification_key = std::make_shared<VerificationKey>(proving_key);
     }
 
     ProverInstance_() = default;

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.test.cpp
@@ -45,6 +45,8 @@ template <class Flavor> class InstanceTests : public testing::Test {
      */
     static void test_sorted_list_accumulator_construction()
     {
+        srs::init_crs_factory("../srs_db/ignition");
+
         // Construct a simple circuit of size n = 8 (i.e. the minimum circuit size)
         Builder builder;
 

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -65,7 +65,6 @@ template <typename Flavor> class SumcheckProver {
         , round(multivariate_n)
         , partially_evaluated_polynomials(multivariate_n){};
 
-    // WORKTODO delete this
     /**
      * @brief Compute univariate restriction place in transcript, generate challenge, partially evaluate,... repeat
      * until final round, then compute multivariate evaluations and place in transcript.

--- a/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.hpp
@@ -67,7 +67,7 @@ class GoblinTranslatorComposer {
             return commitment_key;
         }
 
-        commitment_key = std::make_shared<CommitmentKey>(circuit_size, crs_factory_);
+        commitment_key = std::make_shared<CommitmentKey>(circuit_size);
         return commitment_key;
     };
 };

--- a/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.hpp
@@ -40,7 +40,7 @@ class GoblinTranslatorComposer {
     size_t mini_circuit_dyadic_size = 0; // The size of the small circuit that contains non-range constraint relations
 
     // We only need the standard crs factory. GoblinTranslatorFlavor is not supposed to be used with Grumpkin
-    GoblinTranslatorComposer() { crs_factory_ = bb::srs::get_crs_factory(); }
+    GoblinTranslatorComposer() { crs_factory_ = bb::srs::get_bn254_crs_factory(); }
 
     GoblinTranslatorComposer(std::shared_ptr<ProvingKey> p_key, std::shared_ptr<VerificationKey> v_key)
         : proving_key(std::move(p_key))

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/goblin_ultra_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/goblin_ultra_composer.test.cpp
@@ -206,8 +206,7 @@ TEST_F(GoblinUltraHonkComposerTests, MultipleCircuitsHonkAndMerge)
     // Compute the commitments to the aggregate op queue directly and check that they match those that were computed
     // iteratively during transcript aggregation by the provers and stored in the op queue.
     size_t aggregate_op_queue_size = op_queue->current_ultra_ops_size;
-    auto crs_factory = std::make_shared<bb::srs::factories::FileCrsFactory<Curve>>("../srs_db/ignition");
-    auto commitment_key = std::make_shared<CommitmentKey>(aggregate_op_queue_size, crs_factory);
+    auto commitment_key = std::make_shared<CommitmentKey>(aggregate_op_queue_size);
     size_t idx = 0;
     for (auto& result : op_queue->ultra_ops_commitments) {
         auto expected = commitment_key->commit(op_queue->ultra_ops[idx++]);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
@@ -5,7 +5,7 @@ namespace bb {
 template <typename Flavor>
 MergeVerifier_<Flavor>::MergeVerifier_()
     : transcript(std::make_shared<Transcript>())
-    , pcs_verification_key(std::make_unique<VerifierCommitmentKey>(0, bb::srs::get_crs_factory())){};
+    , pcs_verification_key(std::make_unique<VerifierCommitmentKey>(0, bb::srs::get_bn254_crs_factory())){};
 
 /**
  * @brief Verify proper construction of the aggregate Goblin ECC op queue polynomials T_i^(j), j = 1,2,3,4.

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.cpp
@@ -20,15 +20,7 @@ void UltraComposer_<Flavor>::compute_verification_key(const std::shared_ptr<Prov
 template <IsUltraFlavor Flavor>
 std::shared_ptr<ProverInstance_<Flavor>> UltraComposer_<Flavor>::create_instance(CircuitBuilder& circuit)
 {
-    BB_OP_COUNT_TIME_NAME("UltraComposer::create_prover_instance");
-
-    circuit.add_gates_to_ensure_all_polys_are_non_zero();
-    circuit.finalize_circuit();
-    auto instance = std::make_shared<Instance>(circuit);
-    commitment_key = compute_commitment_key(instance->proving_key->circuit_size);
-
-    compute_verification_key(instance);
-    return instance;
+    return std::make_shared<Instance>(circuit);
 }
 
 template <IsUltraFlavor Flavor>

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.cpp
@@ -14,54 +14,7 @@ namespace bb {
 template <IsUltraFlavor Flavor>
 void UltraComposer_<Flavor>::compute_verification_key(const std::shared_ptr<ProverInstance_<Flavor>>& instance)
 {
-    if (instance->verification_key) {
-        return;
-    }
-
-    auto& proving_key = instance->proving_key;
-
-    auto verification_key =
-        std::make_shared<typename Flavor::VerificationKey>(proving_key->circuit_size, proving_key->num_public_inputs);
-
-    // Compute and store commitments to all precomputed polynomials
-    verification_key->q_m = commitment_key->commit(proving_key->q_m);
-    verification_key->q_l = commitment_key->commit(proving_key->q_l);
-    verification_key->q_r = commitment_key->commit(proving_key->q_r);
-    verification_key->q_o = commitment_key->commit(proving_key->q_o);
-    verification_key->q_c = commitment_key->commit(proving_key->q_c);
-    verification_key->sigma_1 = commitment_key->commit(proving_key->sigma_1);
-    verification_key->sigma_2 = commitment_key->commit(proving_key->sigma_2);
-    verification_key->sigma_3 = commitment_key->commit(proving_key->sigma_3);
-    verification_key->id_1 = commitment_key->commit(proving_key->id_1);
-    verification_key->id_2 = commitment_key->commit(proving_key->id_2);
-    verification_key->id_3 = commitment_key->commit(proving_key->id_3);
-    verification_key->lagrange_first = commitment_key->commit(proving_key->lagrange_first);
-    verification_key->lagrange_last = commitment_key->commit(proving_key->lagrange_last);
-
-    verification_key->q_4 = commitment_key->commit(proving_key->q_4);
-    verification_key->q_arith = commitment_key->commit(proving_key->q_arith);
-    verification_key->q_sort = commitment_key->commit(proving_key->q_sort);
-    verification_key->q_elliptic = commitment_key->commit(proving_key->q_elliptic);
-    verification_key->q_aux = commitment_key->commit(proving_key->q_aux);
-    verification_key->q_lookup = commitment_key->commit(proving_key->q_lookup);
-    verification_key->sigma_4 = commitment_key->commit(proving_key->sigma_4);
-    verification_key->id_4 = commitment_key->commit(proving_key->id_4);
-    verification_key->table_1 = commitment_key->commit(proving_key->table_1);
-    verification_key->table_2 = commitment_key->commit(proving_key->table_2);
-    verification_key->table_3 = commitment_key->commit(proving_key->table_3);
-    verification_key->table_4 = commitment_key->commit(proving_key->table_4);
-
-    // TODO(luke): Similar to the lagrange_first/last polynomials, we dont really need to commit to these polynomials
-    // due to their simple structure.
-    if constexpr (IsGoblinFlavor<Flavor>) {
-        verification_key->lagrange_ecc_op = commitment_key->commit(proving_key->lagrange_ecc_op);
-        verification_key->q_busread = commitment_key->commit(proving_key->q_busread);
-        verification_key->databus_id = commitment_key->commit(proving_key->databus_id);
-        verification_key->q_poseidon2_external = commitment_key->commit(proving_key->q_poseidon2_external);
-        verification_key->q_poseidon2_internal = commitment_key->commit(proving_key->q_poseidon2_internal);
-    }
-
-    instance->verification_key = std::move(verification_key);
+    instance->verification_key = std::move(Flavor::compute_verification_key(instance->proving_key));
 }
 
 template <IsUltraFlavor Flavor>

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.cpp
@@ -6,17 +6,6 @@
 
 namespace bb {
 
-/**
- * Compute verification key consisting of selector precommitments.
- *
- * @return Pointer to the resulting verification key of the Instance.
- * */
-template <IsUltraFlavor Flavor>
-void UltraComposer_<Flavor>::compute_verification_key(const std::shared_ptr<ProverInstance_<Flavor>>& instance)
-{
-    instance->verification_key = std::move(Flavor::compute_verification_key(instance->proving_key));
-}
-
 template <IsUltraFlavor Flavor>
 std::shared_ptr<ProverInstance_<Flavor>> UltraComposer_<Flavor>::create_instance(CircuitBuilder& circuit)
 {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.cpp
@@ -16,7 +16,7 @@ template <IsUltraFlavor Flavor>
 UltraProver_<Flavor> UltraComposer_<Flavor>::create_prover(const std::shared_ptr<Instance>& instance,
                                                            const std::shared_ptr<Transcript>& transcript)
 {
-    UltraProver_<Flavor> output_state(instance, commitment_key, transcript);
+    UltraProver_<Flavor> output_state(instance, transcript);
 
     return output_state;
 }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.hpp
@@ -96,13 +96,6 @@ template <IsUltraFlavor Flavor_> class UltraComposer_ {
 
         return output_state;
     };
-
-    /**
-     * @brief Compute the verification key of an Instance, produced from a finalised circuit.
-     *
-     * @param inst
-     */
-    void compute_verification_key(const std::shared_ptr<Instance>&);
 };
 
 // TODO(#532): this pattern is weird; is this not instantiating the templates?

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.hpp
@@ -40,7 +40,7 @@ template <IsUltraFlavor Flavor_> class UltraComposer_ {
     // The commitment key is passed to the prover but also used herein to compute the verfication key commitments
     std::shared_ptr<CommitmentKey> commitment_key;
 
-    UltraComposer_() { crs_factory_ = bb::srs::get_crs_factory(); }
+    UltraComposer_() { crs_factory_ = bb::srs::get_bn254_crs_factory(); }
 
     explicit UltraComposer_(std::shared_ptr<CRSFactory> crs_factory)
         : crs_factory_(std::move(crs_factory))

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.hpp
@@ -84,7 +84,7 @@ template <IsUltraFlavor Flavor_> class UltraComposer_ {
 
     ProtoGalaxyProver_<ProverInstances> create_folding_prover(const std::vector<std::shared_ptr<Instance>>& instances)
     {
-        ProtoGalaxyProver_<ProverInstances> output_state(instances, commitment_key);
+        ProtoGalaxyProver_<ProverInstances> output_state(instances);
 
         return output_state;
     };

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_composer.test.cpp
@@ -137,7 +137,7 @@ TEST_F(UltraHonkComposerTests, XorConstraint)
     circuit_builder.create_gates_from_plookup_accumulators(
         plookup::MultiTableId::UINT32_XOR, lookup_accumulators, left_witness_index, right_witness_index);
 
-    auto composer = UltraComposer(bb::srs::get_crs_factory());
+    auto composer = UltraComposer(bb::srs::get_bn254_crs_factory());
     prove_and_verify(circuit_builder, composer, /*expected_result=*/true);
 }
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
@@ -11,9 +11,7 @@ namespace bb {
  * @tparam a type of UltraFlavor
  * */
 template <IsUltraFlavor Flavor>
-UltraProver_<Flavor>::UltraProver_(const std::shared_ptr<Instance>& inst,
-                                   [[maybe_unused]] const std::shared_ptr<CommitmentKey>& commitment_key, // WORKTODO
-                                   const std::shared_ptr<Transcript>& transcript)
+UltraProver_<Flavor>::UltraProver_(const std::shared_ptr<Instance>& inst, const std::shared_ptr<Transcript>& transcript)
     : instance(std::move(inst))
     , transcript(transcript)
     , commitment_key(instance->proving_key->commitment_key)

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
@@ -12,11 +12,11 @@ namespace bb {
  * */
 template <IsUltraFlavor Flavor>
 UltraProver_<Flavor>::UltraProver_(const std::shared_ptr<Instance>& inst,
-                                   const std::shared_ptr<CommitmentKey>& commitment_key,
+                                   [[maybe_unused]] const std::shared_ptr<CommitmentKey>& commitment_key, // WORKTODO
                                    const std::shared_ptr<Transcript>& transcript)
     : instance(std::move(inst))
     , transcript(transcript)
-    , commitment_key(commitment_key)
+    , commitment_key(instance->proving_key->commitment_key)
 {
     instance->initialize_prover_polynomials();
 }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.hpp
@@ -24,7 +24,6 @@ template <IsUltraFlavor Flavor> class UltraProver_ {
 
   public:
     explicit UltraProver_(const std::shared_ptr<Instance>&,
-                          const std::shared_ptr<CommitmentKey>&,
                           const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());
 
     BB_PROFILE void execute_preamble_round();

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
@@ -20,7 +20,7 @@ UltraVerifier_<Flavor>::UltraVerifier_(const std::shared_ptr<Transcript>& transc
 template <typename Flavor>
 UltraVerifier_<Flavor>::UltraVerifier_(const std::shared_ptr<VerificationKey>& verifier_key)
     : key(verifier_key)
-    , pcs_verification_key(std::make_unique<VerifierCommitmentKey>(0, bb::srs::get_crs_factory()))
+    , pcs_verification_key(std::make_unique<VerifierCommitmentKey>(0, bb::srs::get_bn254_crs_factory()))
     , transcript(std::make_shared<Transcript>())
 {}
 

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_composer.hpp
@@ -62,7 +62,7 @@ class AvmComposer {
 
     void compute_commitment_key(size_t circuit_size)
     {
-        commitment_key = std::make_shared<CommitmentKey>(circuit_size, crs_factory_);
+        commitment_key = std::make_shared<CommitmentKey>(circuit_size);
     };
 };
 

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_composer.hpp
@@ -37,7 +37,7 @@ class AvmComposer {
     bool contains_recursive_proof = false;
     bool computed_witness = false;
 
-    AvmComposer() { crs_factory_ = bb::srs::get_crs_factory(); }
+    AvmComposer() { crs_factory_ = bb::srs::get_bn254_crs_factory(); }
 
     AvmComposer(std::shared_ptr<ProvingKey> p_key, std::shared_ptr<VerificationKey> v_key)
         : proving_key(std::move(p_key))

--- a/barretenberg/cpp/src/barretenberg/vm/generated/toy_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/toy_composer.hpp
@@ -62,7 +62,7 @@ class ToyComposer {
 
     void compute_commitment_key(size_t circuit_size)
     {
-        commitment_key = std::make_shared<CommitmentKey>(circuit_size, crs_factory_);
+        commitment_key = std::make_shared<CommitmentKey>(circuit_size);
     };
 };
 

--- a/barretenberg/cpp/src/barretenberg/vm/generated/toy_composer.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/toy_composer.hpp
@@ -37,7 +37,7 @@ class ToyComposer {
     bool contains_recursive_proof = false;
     bool computed_witness = false;
 
-    ToyComposer() { crs_factory_ = bb::srs::get_crs_factory(); }
+    ToyComposer() { crs_factory_ = bb::srs::get_bn254_crs_factory(); }
 
     ToyComposer(std::shared_ptr<ProvingKey> p_key, std::shared_ptr<VerificationKey> v_key)
         : proving_key(std::move(p_key))


### PR DESCRIPTION
This is the first step in a series of PRs to get rid of the Honk composer classes. The goal is to delete the `compute_verification_key` functions from the Honk composers. Since this function uses the commitment key, we must also change how that is initialized. We aim to move logic into the proving key and other flavor classes.