### PR TITLE
refactor: dropping 'new' from TxEffect's properties

### DIFF
--- a/yarn-project/aztec.js/src/contract/sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract/sent_tx.ts
@@ -77,8 +77,6 @@ export class SentTx {
         l2ToL1Msgs: tx.l2ToL1Msgs.filter(l => !l.isZero()),
         contractsLeaves: tx.contractLeaves.filter(c => !c.isZero()),
         contractData: tx.contractData.filter(c => !c.isEmpty()),
-        encryptedLogs: tx.encryptedLogs.unrollLogs(),
-        unencryptedLogs: tx.unencryptedLogs.unrollLogs(),
         visibleNotes,
       };
     }

--- a/yarn-project/aztec.js/src/contract/sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract/sent_tx.ts
@@ -77,6 +77,8 @@ export class SentTx {
         l2ToL1Msgs: tx.l2ToL1Msgs.filter(l => !l.isZero()),
         contractsLeaves: tx.contractLeaves.filter(c => !c.isZero()),
         contractData: tx.contractData.filter(c => !c.isEmpty()),
+        encryptedLogs: tx.encryptedLogs.unrollLogs(),
+        unencryptedLogs: tx.unencryptedLogs.unrollLogs(),
         visibleNotes,
       };
     }

--- a/yarn-project/aztec.js/src/contract/sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract/sent_tx.ts
@@ -71,12 +71,12 @@ export class SentTx {
       const tx = (await this.pxe.getTxEffect(txHash))!;
       const visibleNotes = await this.pxe.getNotes({ txHash });
       receipt.debugInfo = {
-        newNoteHashes: tx.newNoteHashes.filter(n => !n.isZero()),
-        newNullifiers: tx.newNullifiers.filter(n => !n.isZero()),
-        newPublicDataWrites: tx.newPublicDataWrites.filter(p => !p.isEmpty()),
-        newL2ToL1Msgs: tx.newL2ToL1Msgs.filter(l => !l.isZero()),
-        newContracts: tx.contractLeaves.filter(c => !c.isZero()),
-        newContractData: tx.contractData.filter(c => !c.isEmpty()),
+        noteHashes: tx.noteHashes.filter(n => !n.isZero()),
+        nullifiers: tx.nullifiers.filter(n => !n.isZero()),
+        publicDataWrites: tx.publicDataWrites.filter(p => !p.isEmpty()),
+        l2ToL1Msgs: tx.l2ToL1Msgs.filter(l => !l.isZero()),
+        contractsLeaves: tx.contractLeaves.filter(c => !c.isZero()),
+        contractData: tx.contractData.filter(c => !c.isEmpty()),
         visibleNotes,
       };
     }

--- a/yarn-project/circuit-types/src/body.ts
+++ b/yarn-project/circuit-types/src/body.ts
@@ -74,7 +74,7 @@ export class Body {
 
   get numberOfTxs() {
     // We gather all the txEffects that are not empty (the ones that have been padded by checking the first newNullifier of the txEffect);
-    return this.txEffects.reduce((acc, txEffect) => (!txEffect.newNullifiers[0].equals(Fr.ZERO) ? acc + 1 : acc), 0);
+    return this.txEffects.reduce((acc, txEffect) => (!txEffect.nullifiers[0].equals(Fr.ZERO) ? acc + 1 : acc), 0);
   }
 
   static random(

--- a/yarn-project/circuit-types/src/l2_block.ts
+++ b/yarn-project/circuit-types/src/l2_block.ts
@@ -250,7 +250,7 @@ export class L2Block {
     this.assertIndexInRange(txIndex);
 
     // Gets the first nullifier of the tx specified by txIndex
-    const firstNullifier = this.body.txEffects[txIndex].newNullifiers[0];
+    const firstNullifier = this.body.txEffects[txIndex].nullifiers[0];
 
     return new TxHash(firstNullifier.toBuffer());
   }

--- a/yarn-project/circuit-types/src/tx/tx_receipt.ts
+++ b/yarn-project/circuit-types/src/tx/tx_receipt.ts
@@ -105,11 +105,6 @@ interface DebugInfo {
    */
   contractData: ContractData[];
   /**
-   * The logs emitted by the tx
-   */
-  encryptedLogs: Buffer[];
-  unencryptedLogs: Buffer[];
-  /**
    * Notes created in this tx which belong to accounts which are registered in the PXE which was used to submit the
    * tx. You will not receive notes of accounts which are not registered in the PXE here even though they were
    * created in this tx.

--- a/yarn-project/circuit-types/src/tx/tx_receipt.ts
+++ b/yarn-project/circuit-types/src/tx/tx_receipt.ts
@@ -83,27 +83,27 @@ interface DebugInfo {
   /**
    * New note hashes created by the transaction.
    */
-  newNoteHashes: Fr[];
+  noteHashes: Fr[];
   /**
    * New nullifiers created by the transaction.
    */
-  newNullifiers: Fr[];
+  nullifiers: Fr[];
   /**
    * New public data writes created by the transaction.
    */
-  newPublicDataWrites: PublicDataWrite[];
+  publicDataWrites: PublicDataWrite[];
   /**
    * New L2 to L1 messages created by the transaction.
    */
-  newL2ToL1Msgs: Fr[];
+  l2ToL1Msgs: Fr[];
   /**
-   * New contracts leafs created by the transaction to be inserted into the contract tree.
+   * New contracts leaves created by the transaction to be inserted into the contract tree.
    */
-  newContracts: Fr[];
+  contractsLeaves: Fr[];
   /**
    * New contract data created by the transaction.
    */
-  newContractData: ContractData[];
+  contractData: ContractData[];
   /**
    * Notes created in this tx which belong to accounts which are registered in the PXE which was used to submit the
    * tx. You will not receive notes of accounts which are not registered in the PXE here even though they were

--- a/yarn-project/circuit-types/src/tx/tx_receipt.ts
+++ b/yarn-project/circuit-types/src/tx/tx_receipt.ts
@@ -105,6 +105,11 @@ interface DebugInfo {
    */
   contractData: ContractData[];
   /**
+   * The logs emitted by the tx
+   */
+  encryptedLogs: Buffer[];
+  unencryptedLogs: Buffer[];
+  /**
    * Notes created in this tx which belong to accounts which are registered in the PXE which was used to submit the
    * tx. You will not receive notes of accounts which are not registered in the PXE here even though they were
    * created in this tx.

--- a/yarn-project/circuit-types/src/tx_effect.ts
+++ b/yarn-project/circuit-types/src/tx_effect.ts
@@ -17,19 +17,19 @@ export class TxEffect {
     /**
      * The note hashes to be inserted into the note hash tree.
      */
-    public newNoteHashes: Tuple<Fr, typeof MAX_NEW_NOTE_HASHES_PER_TX>,
+    public noteHashes: Tuple<Fr, typeof MAX_NEW_NOTE_HASHES_PER_TX>,
     /**
      * The nullifiers to be inserted into the nullifier tree.
      */
-    public newNullifiers: Tuple<Fr, typeof MAX_NEW_NULLIFIERS_PER_TX>,
+    public nullifiers: Tuple<Fr, typeof MAX_NEW_NULLIFIERS_PER_TX>,
     /**
      * The L2 to L1 messages to be inserted into the messagebox on L1.
      */
-    public newL2ToL1Msgs: Tuple<Fr, typeof MAX_NEW_L2_TO_L1_MSGS_PER_TX>,
+    public l2ToL1Msgs: Tuple<Fr, typeof MAX_NEW_L2_TO_L1_MSGS_PER_TX>,
     /**
      * The public data writes to be inserted into the public data tree.
      */
-    public newPublicDataWrites: Tuple<PublicDataWrite, typeof MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX>,
+    public publicDataWrites: Tuple<PublicDataWrite, typeof MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX>,
     /**
      * The leaves of the new contract data that will be inserted into the contracts tree.
      */
@@ -46,10 +46,10 @@ export class TxEffect {
   ) {}
 
   toBuffer(): Buffer {
-    const nonZeroNoteHashes = this.newNoteHashes.filter(h => !h.isZero());
-    const nonZeroNullifiers = this.newNullifiers.filter(h => !h.isZero());
-    const nonZeroL2ToL1Msgs = this.newL2ToL1Msgs.filter(h => !h.isZero());
-    const nonZeroPublicDataWrites = this.newPublicDataWrites.filter(h => !h.isEmpty());
+    const nonZeroNoteHashes = this.noteHashes.filter(h => !h.isZero());
+    const nonZeroNullifiers = this.nullifiers.filter(h => !h.isZero());
+    const nonZeroL2ToL1Msgs = this.l2ToL1Msgs.filter(h => !h.isZero());
+    const nonZeroPublicDataWrites = this.publicDataWrites.filter(h => !h.isEmpty());
     const nonZeroContractLeaves = this.contractLeaves.filter(h => !h.isZero());
     const nonZeroContractData = this.contractData.filter(h => !h.isEmpty());
 
@@ -97,10 +97,10 @@ export class TxEffect {
   }
 
   hash() {
-    const noteHashesBuffer = Buffer.concat(this.newNoteHashes.map(x => x.toBuffer()));
-    const nullifiersBuffer = Buffer.concat(this.newNullifiers.map(x => x.toBuffer()));
-    const newL2ToL1MsgsBuffer = Buffer.concat(this.newL2ToL1Msgs.map(x => x.toBuffer()));
-    const publicDataUpdateRequestsBuffer = Buffer.concat(this.newPublicDataWrites.map(x => x.toBuffer()));
+    const noteHashesBuffer = Buffer.concat(this.noteHashes.map(x => x.toBuffer()));
+    const nullifiersBuffer = Buffer.concat(this.nullifiers.map(x => x.toBuffer()));
+    const newL2ToL1MsgsBuffer = Buffer.concat(this.l2ToL1Msgs.map(x => x.toBuffer()));
+    const publicDataUpdateRequestsBuffer = Buffer.concat(this.publicDataWrites.map(x => x.toBuffer()));
     const encryptedLogsHashKernel0 = this.encryptedLogs.hash();
     const unencryptedLogsHashKernel0 = this.unencryptedLogs.hash();
 
@@ -159,6 +159,6 @@ export class TxEffect {
   }
 
   get txHash(): TxHash {
-    return new TxHash(this.newNullifiers[0].toBuffer());
+    return new TxHash(this.nullifiers[0].toBuffer());
   }
 }

--- a/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
@@ -181,7 +181,7 @@ describe('e2e_deploy_contract', () => {
         const contract = await registerContract(testWallet, TestContract);
         const receipt = await contract.methods.emit_nullifier(10).send().wait({ debug: true });
         const expected = siloNullifier(contract.address, new Fr(10));
-        expect(receipt.debugInfo?.newNullifiers[1]).toEqual(expected);
+        expect(receipt.debugInfo?.nullifiers[1]).toEqual(expected);
       },
       30_000,
     );

--- a/yarn-project/end-to-end/src/e2e_inclusion_proofs_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_inclusion_proofs_contract.test.ts
@@ -54,7 +54,7 @@ describe('e2e_inclusion_proofs_contract', () => {
     describe('proves note existence and its nullifier non-existence and nullifier non-existence failure case', () => {
       // Owner of a note
       let noteCreationBlockNumber: number;
-      let newNoteHashes, visibleNotes: any;
+      let noteHashes, visibleNotes: any;
       const value = 100n;
       let validNoteBlockNumber: any;
 
@@ -63,11 +63,11 @@ describe('e2e_inclusion_proofs_contract', () => {
         const receipt = await contract.methods.create_note(owner, value).send().wait({ debug: true });
 
         noteCreationBlockNumber = receipt.blockNumber!;
-        ({ newNoteHashes, visibleNotes } = receipt.debugInfo!);
+        ({ noteHashes, visibleNotes } = receipt.debugInfo!);
       });
 
       it('should return the correct values for creating a note', () => {
-        expect(newNoteHashes.length).toBe(1);
+        expect(noteHashes.length).toBe(1);
         expect(visibleNotes.length).toBe(1);
         const [receivedValue, receivedOwner, _randomness] = visibleNotes[0].note.items;
         expect(receivedValue.toBigInt()).toBe(value);
@@ -158,7 +158,7 @@ describe('e2e_inclusion_proofs_contract', () => {
         const receipt = await contract.methods.create_note(owner, value).send().wait({ debug: true });
 
         noteCreationBlockNumber = receipt.blockNumber!;
-        const { newNoteHashes, visibleNotes } = receipt.debugInfo!;
+        const { noteHashes: newNoteHashes, visibleNotes } = receipt.debugInfo!;
 
         expect(newNoteHashes.length).toBe(1);
         expect(visibleNotes.length).toBe(1);
@@ -224,7 +224,7 @@ describe('e2e_inclusion_proofs_contract', () => {
       // Choose random block number between deployment and current block number to test archival node
       const blockNumber = await getRandomBlockNumberSinceDeployment();
       const block = await pxe.getBlock(blockNumber);
-      const nullifier = block?.body.txEffects[0].newNullifiers[0];
+      const nullifier = block?.body.txEffects[0].nullifiers[0];
 
       await contract.methods.test_nullifier_inclusion(nullifier!, true, blockNumber).send().wait();
       await contract.methods.test_nullifier_inclusion(nullifier!, false, 0n).send().wait();

--- a/yarn-project/end-to-end/src/e2e_non_contract_account.test.ts
+++ b/yarn-project/end-to-end/src/e2e_non_contract_account.test.ts
@@ -47,7 +47,7 @@ describe('e2e_non_contract_account', () => {
 
     const tx = await aztecNode!.getTxEffect(receipt.txHash);
     const expectedSiloedNullifier = siloNullifier(contract.address, nullifier);
-    const siloedNullifier = tx!.newNullifiers[1];
+    const siloedNullifier = tx!.nullifiers[1];
 
     expect(siloedNullifier.equals(expectedSiloedNullifier)).toBeTruthy();
   }, 120_000);
@@ -77,7 +77,7 @@ describe('e2e_non_contract_account', () => {
 
     // check that 1 note hash was created
     const tx = await pxe.getTxEffect(receipt.txHash);
-    const nonZeroNoteHashes = tx?.newNoteHashes.filter(c => c.value > 0);
+    const nonZeroNoteHashes = tx?.noteHashes.filter(c => c.value > 0);
     expect(nonZeroNoteHashes?.length).toBe(1);
 
     // Add the note

--- a/yarn-project/end-to-end/src/e2e_pending_commitments_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_pending_commitments_contract.test.ts
@@ -23,7 +23,7 @@ describe('e2e_pending_commitments_contract', () => {
     const blockNum = await aztecNode!.getBlockNumber();
     const block = (await aztecNode!.getBlocks(blockNum, 1))[0];
 
-    const commitmentsArray = block.body.txEffects.flatMap(txEffect => txEffect.newNoteHashes);
+    const commitmentsArray = block.body.txEffects.flatMap(txEffect => txEffect.noteHashes);
 
     // all new commitments should be zero (should be squashed)
     for (let c = 0; c < exceptFirstFew; c++) {
@@ -39,7 +39,7 @@ describe('e2e_pending_commitments_contract', () => {
     const blockNum = await aztecNode!.getBlockNumber();
     const block = (await aztecNode!.getBlocks(blockNum, 1))[0];
 
-    const nullifierArray = block.body.txEffects.flatMap(txEffect => txEffect.newNullifiers);
+    const nullifierArray = block.body.txEffects.flatMap(txEffect => txEffect.nullifiers);
 
     // 0th nullifier should be nonzero (txHash), all others should be zero (should be squashed)
     for (let n = 0; n < exceptFirstFew + 1; n++) {

--- a/yarn-project/end-to-end/src/e2e_state_vars.test.ts
+++ b/yarn-project/end-to-end/src/e2e_state_vars.test.ts
@@ -75,9 +75,9 @@ describe('e2e_state_vars', () => {
       const receipt = await contract.methods.initialize_private(RANDOMNESS, POINTS).send().wait();
 
       const tx = await wallet.getTxEffect(receipt.txHash);
-      expect(tx?.newNoteHashes.length).toEqual(1);
+      expect(tx?.noteHashes.length).toEqual(1);
       // 1 for the tx, another for the initializer
-      expect(tx?.newNullifiers.length).toEqual(2);
+      expect(tx?.nullifiers.length).toEqual(2);
       expect(await contract.methods.is_legendary_initialized().view()).toEqual(true);
     });
 
@@ -100,9 +100,9 @@ describe('e2e_state_vars', () => {
       const receipt = await contract.methods.update_legendary_card(RANDOMNESS, POINTS).send().wait();
 
       const tx = await wallet.getTxEffect(receipt.txHash);
-      expect(tx?.newNoteHashes.length).toEqual(1);
+      expect(tx?.noteHashes.length).toEqual(1);
       // 1 for the tx, another for the nullifier of the previous note
-      expect(tx?.newNullifiers.length).toEqual(2);
+      expect(tx?.nullifiers.length).toEqual(2);
 
       const noteAfter = await contract.methods.get_legendary_card().view();
 
@@ -123,9 +123,9 @@ describe('e2e_state_vars', () => {
         .send()
         .wait();
       const tx = await wallet.getTxEffect(receipt.txHash);
-      expect(tx?.newNoteHashes.length).toEqual(1);
+      expect(tx?.noteHashes.length).toEqual(1);
       // 1 for the tx, another for the nullifier of the previous note
-      expect(tx?.newNullifiers.length).toEqual(2);
+      expect(tx?.nullifiers.length).toEqual(2);
 
       const { points, randomness } = await contract.methods.get_legendary_card().view();
       expect(points).toEqual(POINTS + 1n);
@@ -137,9 +137,9 @@ describe('e2e_state_vars', () => {
       const noteBefore = await contract.methods.get_legendary_card().view();
       const receipt = await contract.methods.increase_legendary_points().send().wait();
       const tx = await wallet.getTxEffect(receipt.txHash);
-      expect(tx?.newNoteHashes.length).toEqual(1);
+      expect(tx?.noteHashes.length).toEqual(1);
       // 1 for the tx, another for the nullifier of the previous note
-      expect(tx?.newNullifiers.length).toEqual(2);
+      expect(tx?.nullifiers.length).toEqual(2);
 
       const { points, randomness } = await contract.methods.get_legendary_card().view();
       expect(points).toEqual(noteBefore.points + 1n);
@@ -158,9 +158,9 @@ describe('e2e_state_vars', () => {
       const receipt = await contract.methods.initialize_private_immutable(RANDOMNESS, POINTS).send().wait();
 
       const tx = await wallet.getTxEffect(receipt.txHash);
-      expect(tx?.newNoteHashes.length).toEqual(1);
+      expect(tx?.noteHashes.length).toEqual(1);
       // 1 for the tx, another for the initializer
-      expect(tx?.newNullifiers.length).toEqual(2);
+      expect(tx?.nullifiers.length).toEqual(2);
       expect(await contract.methods.is_priv_imm_initialized().view()).toEqual(true);
     });
 

--- a/yarn-project/end-to-end/src/e2e_state_vars.test.ts
+++ b/yarn-project/end-to-end/src/e2e_state_vars.test.ts
@@ -72,12 +72,10 @@ describe('e2e_state_vars', () => {
     it('initialize PrivateMutable', async () => {
       expect(await contract.methods.is_legendary_initialized().view()).toEqual(false);
       // Send the transaction and wait for it to be mined (wait function throws if the tx is not mined)
-      const receipt = await contract.methods.initialize_private(RANDOMNESS, POINTS).send().wait();
+      const { debugInfo } = await contract.methods.initialize_private(RANDOMNESS, POINTS).send().wait({ debug: true });
 
-      const tx = await wallet.getTxEffect(receipt.txHash);
-      expect(tx?.noteHashes.length).toEqual(1);
       // 1 for the tx, another for the initializer
-      expect(tx?.nullifiers.length).toEqual(2);
+      expect(debugInfo!.nullifiers.length).toEqual(2);
       expect(await contract.methods.is_legendary_initialized().view()).toEqual(true);
     });
 
@@ -97,12 +95,14 @@ describe('e2e_state_vars', () => {
     it('replace with same value', async () => {
       expect(await contract.methods.is_legendary_initialized().view()).toEqual(true);
       const noteBefore = await contract.methods.get_legendary_card().view();
-      const receipt = await contract.methods.update_legendary_card(RANDOMNESS, POINTS).send().wait();
+      const { debugInfo } = await contract.methods
+        .update_legendary_card(RANDOMNESS, POINTS)
+        .send()
+        .wait({ debug: true });
 
-      const tx = await wallet.getTxEffect(receipt.txHash);
-      expect(tx?.noteHashes.length).toEqual(1);
+      expect(debugInfo!.noteHashes.length).toEqual(1);
       // 1 for the tx, another for the nullifier of the previous note
-      expect(tx?.nullifiers.length).toEqual(2);
+      expect(debugInfo!.nullifiers.length).toEqual(2);
 
       const noteAfter = await contract.methods.get_legendary_card().view();
 
@@ -118,14 +118,14 @@ describe('e2e_state_vars', () => {
 
     it('replace PrivateMutable with other values', async () => {
       expect(await contract.methods.is_legendary_initialized().view()).toEqual(true);
-      const receipt = await contract.methods
+      const { debugInfo } = await contract.methods
         .update_legendary_card(RANDOMNESS + 2n, POINTS + 1n)
         .send()
-        .wait();
-      const tx = await wallet.getTxEffect(receipt.txHash);
-      expect(tx?.noteHashes.length).toEqual(1);
+        .wait({ debug: true });
+
+      expect(debugInfo!.noteHashes.length).toEqual(1);
       // 1 for the tx, another for the nullifier of the previous note
-      expect(tx?.nullifiers.length).toEqual(2);
+      expect(debugInfo!.nullifiers.length).toEqual(2);
 
       const { points, randomness } = await contract.methods.get_legendary_card().view();
       expect(points).toEqual(POINTS + 1n);
@@ -135,11 +135,11 @@ describe('e2e_state_vars', () => {
     it('replace PrivateMutable dependent on prior value', async () => {
       expect(await contract.methods.is_legendary_initialized().view()).toEqual(true);
       const noteBefore = await contract.methods.get_legendary_card().view();
-      const receipt = await contract.methods.increase_legendary_points().send().wait();
-      const tx = await wallet.getTxEffect(receipt.txHash);
-      expect(tx?.noteHashes.length).toEqual(1);
+      const { debugInfo } = await contract.methods.increase_legendary_points().send().wait({ debug: true });
+
+      expect(debugInfo!.noteHashes.length).toEqual(1);
       // 1 for the tx, another for the nullifier of the previous note
-      expect(tx?.nullifiers.length).toEqual(2);
+      expect(debugInfo!.nullifiers.length).toEqual(2);
 
       const { points, randomness } = await contract.methods.get_legendary_card().view();
       expect(points).toEqual(noteBefore.points + 1n);
@@ -155,12 +155,14 @@ describe('e2e_state_vars', () => {
 
     it('initialize PrivateImmutable', async () => {
       expect(await contract.methods.is_priv_imm_initialized().view()).toEqual(false);
-      const receipt = await contract.methods.initialize_private_immutable(RANDOMNESS, POINTS).send().wait();
+      const { debugInfo } = await contract.methods
+        .initialize_private_immutable(RANDOMNESS, POINTS)
+        .send()
+        .wait({ debug: true });
 
-      const tx = await wallet.getTxEffect(receipt.txHash);
-      expect(tx?.noteHashes.length).toEqual(1);
+      expect(debugInfo!.noteHashes.length).toEqual(1);
       // 1 for the tx, another for the initializer
-      expect(tx?.nullifiers.length).toEqual(2);
+      expect(debugInfo!.nullifiers.length).toEqual(2);
       expect(await contract.methods.is_priv_imm_initialized().view()).toEqual(true);
     });
 

--- a/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
@@ -258,7 +258,7 @@ describe('L1Publisher integration', () => {
       messages: {
         l1ToL2Messages: l1ToL2Messages.map(m => `0x${m.toBuffer().toString('hex').padStart(64, '0')}`),
         l2ToL1Messages: block.body.txEffects
-          .flatMap(txEffect => txEffect.newL2ToL1Msgs)
+          .flatMap(txEffect => txEffect.l2ToL1Msgs)
           .map(m => `0x${m.toBuffer().toString('hex').padStart(64, '0')}`),
       },
       block: {
@@ -415,7 +415,7 @@ describe('L1Publisher integration', () => {
         expect(await inbox.read.contains([l1ToL2Messages[j].toString()])).toBeTruthy();
       }
 
-      const newL2ToL1MsgsArray = block.body.txEffects.flatMap(txEffect => txEffect.newL2ToL1Msgs);
+      const newL2ToL1MsgsArray = block.body.txEffects.flatMap(txEffect => txEffect.l2ToL1Msgs);
 
       // check that values are not in the outbox
       for (let j = 0; j < newL2ToL1MsgsArray.length; j++) {

--- a/yarn-project/pxe/src/note_processor/note_processor.test.ts
+++ b/yarn-project/pxe/src/note_processor/note_processor.test.ts
@@ -107,7 +107,7 @@ describe('Note Processor', () => {
       encryptedLogsArr.push(encryptedLogs);
       ownedL1NotePayloads.push(...payloads);
       for (let i = 0; i < TXS_PER_BLOCK; i++) {
-        block.body.txEffects[i].newNoteHashes = newNotes
+        block.body.txEffects[i].noteHashes = newNotes
           .map(n => computeMockNoteHash(n.note))
           .slice(i * MAX_NEW_NOTE_HASHES_PER_TX, (i + 1) * MAX_NEW_NOTE_HASHES_PER_TX) as Tuple<
           Fr,

--- a/yarn-project/pxe/src/note_processor/note_processor.ts
+++ b/yarn-project/pxe/src/note_processor/note_processor.ts
@@ -124,7 +124,7 @@ export class NoteProcessor {
         this.stats.txs++;
         const dataStartIndexForTx =
           dataEndIndexForBlock - (txLogs.length - indexOfTxInABlock) * MAX_NEW_NOTE_HASHES_PER_TX;
-        const newNoteHashes = block.body.txEffects[indexOfTxInABlock].newNoteHashes;
+        const newNoteHashes = block.body.txEffects[indexOfTxInABlock].noteHashes;
         // Note: Each tx generates a `TxL2Logs` object and for this reason we can rely on its index corresponding
         //       to the index of a tx in a block.
         const txFunctionLogs = txLogs[indexOfTxInABlock].functionLogs;
@@ -211,7 +211,7 @@ export class NoteProcessor {
     }
 
     const newNullifiers: Fr[] = blocksAndNotes.flatMap(b =>
-      b.blockContext.block.body.txEffects.flatMap(txEffect => txEffect.newNullifiers),
+      b.blockContext.block.body.txEffects.flatMap(txEffect => txEffect.nullifiers),
     );
     const removedNotes = await this.db.removeNullifiedNotes(newNullifiers, this.publicKey);
     removedNotes.forEach(noteDao => {

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -341,8 +341,8 @@ export class PXEService implements PXE {
     }
 
     const nonces: Fr[] = [];
-    const firstNullifier = tx.newNullifiers[0];
-    const hashes = tx.newNoteHashes;
+    const firstNullifier = tx.nullifiers[0];
+    const hashes = tx.noteHashes;
     for (let i = 0; i < hashes.length; ++i) {
       const hash = hashes[i];
       if (hash.equals(Fr.ZERO)) {

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -510,7 +510,7 @@ export class MerkleTrees implements MerkleTreeDb {
       // Sync the append only trees
       for (const [tree, leaves] of [
         [MerkleTreeId.CONTRACT_TREE, l2Block.body.txEffects.flatMap(txEffect => txEffect.contractLeaves)],
-        [MerkleTreeId.NOTE_HASH_TREE, l2Block.body.txEffects.flatMap(txEffect => txEffect.newNoteHashes)],
+        [MerkleTreeId.NOTE_HASH_TREE, l2Block.body.txEffects.flatMap(txEffect => txEffect.noteHashes)],
         [MerkleTreeId.L1_TO_L2_MESSAGE_TREE, l2Block.body.l1ToL2Messages],
       ] as const) {
         await this.#appendLeaves(
@@ -521,13 +521,13 @@ export class MerkleTrees implements MerkleTreeDb {
 
       // Sync the indexed trees
       await (this.trees[MerkleTreeId.NULLIFIER_TREE] as StandardIndexedTree).batchInsert(
-        l2Block.body.txEffects.flatMap(txEffect => txEffect.newNullifiers.map(nullifier => nullifier.toBuffer())),
+        l2Block.body.txEffects.flatMap(txEffect => txEffect.nullifiers.map(nullifier => nullifier.toBuffer())),
         NULLIFIER_SUBTREE_HEIGHT,
       );
 
       const publicDataTree = this.trees[MerkleTreeId.PUBLIC_DATA_TREE] as StandardIndexedTree;
 
-      const publicDataWrites = l2Block.body.txEffects.flatMap(txEffect => txEffect.newPublicDataWrites);
+      const publicDataWrites = l2Block.body.txEffects.flatMap(txEffect => txEffect.publicDataWrites);
 
       // We insert the public data tree leaves with one batch per tx to avoid updating the same key twice
       for (let i = 0; i < publicDataWrites.length / MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX; i++) {


### PR DESCRIPTION
Having "new" in the naming of tx effect properties is not necessary as it's clear that the values are related to the given tx effect. This PR does the renamings.
