### PR TITLE
chore(avm-transpiler): prefix AVM opcode oracles with avmOpcode

### DIFF
--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -239,19 +239,19 @@ fn handle_foreign_call(
 ) {
     match function {
         "avmOpcodeNoteHashExists" => handle_note_hash_exists(avm_instrs, destinations, inputs),
-        "emitNoteHash" | "emitNullifier" => handle_emit_note_hash_or_nullifier(
-            function == "emitNullifier",
+        "avmOpcodeEmitNoteHash" | "avmOpcodeEmitNullifier" => handle_emit_note_hash_or_nullifier(
+            function == "avmOpcodeEmitNullifier",
             avm_instrs,
             destinations,
             inputs,
         ),
-        "nullifierExists" => handle_nullifier_exists(avm_instrs, destinations, inputs),
-        "l1ToL2MsgExists" => handle_l1_to_l2_msg_exists(avm_instrs, destinations, inputs),
-        "sendL2ToL1Msg" => handle_send_l2_to_l1_msg(avm_instrs, destinations, inputs),
-        "keccak256" | "sha256" => {
+        "avmOpcodeNullifierExists" => handle_nullifier_exists(avm_instrs, destinations, inputs),
+        "avmOpcodeL1ToL2MsgExists" => handle_l1_to_l2_msg_exists(avm_instrs, destinations, inputs),
+        "avmOpcodeSendL2ToL1Msg" => handle_send_l2_to_l1_msg(avm_instrs, destinations, inputs),
+        "avmOpcodeKeccak256" | "avmOpcodeSha256" => {
             handle_2_field_hash_instruction(avm_instrs, function, destinations, inputs)
         }
-        "poseidon" => {
+        "avmOpcodePoseidon" => {
             handle_single_field_hash_instruction(avm_instrs, function, destinations, inputs)
         }
         // Getters.
@@ -509,8 +509,8 @@ fn handle_2_field_hash_instruction(
     };
 
     let opcode = match function {
-        "keccak256" => AvmOpcode::KECCAK,
-        "sha256" => AvmOpcode::SHA256,
+        "avmOpcodeKeccak256" => AvmOpcode::KECCAK,
+        "avmOpcodeSha256" => AvmOpcode::SHA256,
         _ => panic!(
             "Transpiler doesn't know how to process ForeignCall function {:?}",
             function
@@ -565,7 +565,7 @@ fn handle_single_field_hash_instruction(
     };
 
     let opcode = match function {
-        "poseidon" => AvmOpcode::POSEIDON,
+        "avmOpcodePoseidon" => AvmOpcode::POSEIDON,
         _ => panic!(
             "Transpiler doesn't know how to process ForeignCall function {:?}",
             function
@@ -615,18 +615,18 @@ fn handle_getter_instruction(
     };
 
     let opcode = match function {
-        "address" => AvmOpcode::ADDRESS,
-        "storageAddress" => AvmOpcode::STORAGEADDRESS,
-        "origin" => AvmOpcode::ORIGIN,
-        "sender" => AvmOpcode::SENDER,
-        "portal" => AvmOpcode::PORTAL,
-        "feePerL1Gas" => AvmOpcode::FEEPERL1GAS,
-        "feePerL2Gas" => AvmOpcode::FEEPERL2GAS,
-        "feePerDaGas" => AvmOpcode::FEEPERDAGAS,
-        "chainId" => AvmOpcode::CHAINID,
-        "version" => AvmOpcode::VERSION,
-        "blockNumber" => AvmOpcode::BLOCKNUMBER,
-        "timestamp" => AvmOpcode::TIMESTAMP,
+        "avmOpcodeAddress" => AvmOpcode::ADDRESS,
+        "avmOpcodeStorageAddress" => AvmOpcode::STORAGEADDRESS,
+        "avmOpcodeOrigin" => AvmOpcode::ORIGIN,
+        "avmOpcodeSender" => AvmOpcode::SENDER,
+        "avmOpcodePortal" => AvmOpcode::PORTAL,
+        "avmOpcodeFeePerL1Gas" => AvmOpcode::FEEPERL1GAS,
+        "avmOpcodeFeePerL2Gas" => AvmOpcode::FEEPERL2GAS,
+        "avmOpcodeFeePerDaGas" => AvmOpcode::FEEPERDAGAS,
+        "avmOpcodeChainId" => AvmOpcode::CHAINID,
+        "avmOpcodeVersion" => AvmOpcode::VERSION,
+        "avmOpcodeBlockNumber" => AvmOpcode::BLOCKNUMBER,
+        "avmOpcodeTimestamp" => AvmOpcode::TIMESTAMP,
         // "callStackDepth" => AvmOpcode::CallStackDepth,
         _ => panic!(
             "Transpiler doesn't know how to process ForeignCall function {:?}",

--- a/noir-projects/aztec-nr/aztec/src/avm/hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/avm/hash.nr
@@ -1,8 +1,8 @@
-#[oracle(keccak256)]
+#[oracle(avmOpcodeKeccak256)]
 pub fn keccak256<N>(input: [Field; N]) -> [Field; 2] {}
 
-#[oracle(poseidon)]
+#[oracle(avmOpcodePoseidon)]
 pub fn poseidon<N>(input: [Field; N]) -> Field {}
 
-#[oracle(sha256)]
+#[oracle(avmOpcodeSha256)]
 pub fn sha256<N>(input: [Field; N]) -> [Field; 2] {}

--- a/noir-projects/aztec-nr/aztec/src/context/avm.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/avm.nr
@@ -11,61 +11,61 @@ impl AVMContext {
     }
 
     // OPCODES
-    #[oracle(address)]
+    #[oracle(avmOpcodeAddress)]
     pub fn address(self) -> AztecAddress {}
 
-    #[oracle(storageAddress)]
+    #[oracle(avmOpcodeStorageAddress)]
     pub fn storage_address(self) -> AztecAddress {}
 
-    #[oracle(origin)]
+    #[oracle(avmOpcodeOrigin)]
     pub fn origin(self) -> AztecAddress {}
 
-    #[oracle(sender)]
+    #[oracle(avmOpcodeSender)]
     pub fn sender(self) -> AztecAddress {}
 
-    #[oracle(portal)]
+    #[oracle(avmOpcodePortal)]
     pub fn portal(self) -> EthAddress {}
 
-    #[oracle(feePerL1Gas)]
+    #[oracle(avmOpcodeFeePerL1Gas)]
     pub fn fee_per_l1_gas(self) -> Field {}
 
-    #[oracle(feePerL2Gas)]
+    #[oracle(avmOpcodeFeePerL2Gas)]
     pub fn fee_per_l2_gas(self) -> Field {}
 
-    #[oracle(feePerDaGas)]
+    #[oracle(avmOpcodeFeePerDaGas)]
     pub fn fee_per_da_gas(self) -> Field {}
 
-    #[oracle(chainId)]
+    #[oracle(avmOpcodeChainId)]
     pub fn chain_id(self) -> Field {}
 
-    #[oracle(version)]
+    #[oracle(avmOpcodeVersion)]
     pub fn version(self) -> Field {}
 
-    #[oracle(blockNumber)]
+    #[oracle(avmOpcodeBlockNumber)]
     pub fn block_number(self) -> Field {}
 
-    #[oracle(timestamp)]
+    #[oracle(avmOpcodeTimestamp)]
     pub fn timestamp(self) -> Field {}
 
-    // #[oracle(contractCallDepth)]
+    // #[oracle(avmOpcodeContractCallDepth)]
     // pub fn contract_call_depth(self) -> Field {}
 
     #[oracle(avmOpcodeNoteHashExists)]
     pub fn note_hash_exists(self, note_hash: Field, leaf_index: Field) -> u8 {}
 
-    #[oracle(emitNoteHash)]
+    #[oracle(avmOpcodeEmitNoteHash)]
     pub fn emit_note_hash(self, note_hash: Field) {}
 
-    #[oracle(nullifierExists)]
+    #[oracle(avmOpcodeNullifierExists)]
     pub fn nullifier_exists(self, nullifier: Field) -> u8 {}
 
-    #[oracle(emitNullifier)]
+    #[oracle(avmOpcodeEmitNullifier)]
     pub fn emit_nullifier(self, nullifier: Field) {}
 
-    #[oracle(l1ToL2MsgExists)]
+    #[oracle(avmOpcodeL1ToL2MsgExists)]
     pub fn l1_to_l2_msg_exists(self, msg_hash: Field, msg_leaf_index: Field) -> u8 {}
 
-    #[oracle(sendL2ToL1Msg)]
+    #[oracle(avmOpcodeSendL2ToL1Msg)]
     pub fn send_l2_to_l1_msg(self, recipient: EthAddress, content: Field) {}
 
     ///////////////////////////////////////////////////////////////////////////
@@ -75,7 +75,7 @@ impl AVMContext {
         self.address()
     }
 
-    #[oracle(sendL2ToL1Msg)]
+    #[oracle(avmOpcodeSendL2ToL1Msg)]
     pub fn message_portal(&mut self, recipient: EthAddress, content: Field) {}
 
     pub fn consume_l1_to_l2_message(
@@ -88,7 +88,7 @@ impl AVMContext {
         assert(false, "Not implemented!");
     }
 
-    #[oracle(emitNoteHash)]
+    #[oracle(avmOpcodeEmitNoteHash)]
     pub fn push_new_note_hash(self: &mut Self, note_hash: Field) {}
 
     pub fn push_new_nullifier(self: &mut Self, nullifier: Field, _nullified_commitment: Field) {


### PR DESCRIPTION
Prefixing all noir oracles that should be transpiled to AVM opcodes with "avmOpcode" to make it super clear what it is.