### PR TITLE
chore: Do not download foundry during L1 contracts fast bootstrap

### DIFF
--- a/l1-contracts/bootstrap.sh
+++ b/l1-contracts/bootstrap.sh
@@ -15,11 +15,12 @@ if [ -n "$CMD" ]; then
   fi
 fi
 
-# Install foundry.
-. ./scripts/install_foundry.sh
 
 # Attempt to just pull artefacts from CI and exit on success.
 [ -n "${USE_CACHE:-}" ] && ./bootstrap_cache.sh && exit
+
+# Install foundry.
+. ./scripts/install_foundry.sh
 
 # Clean
 rm -rf broadcast cache out serve


### PR DESCRIPTION
We're downloading the pre-built artifacts after-all, so no point in installing Foundry.