### PR TITLE
refactor: initial error consolidation

### DIFF
--- a/yarn-project/archiver/package.json
+++ b/yarn-project/archiver/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@aztec/circuit-types": "workspace:^",
     "@aztec/circuits.js": "workspace:^",
+    "@aztec/errors": "workspace:^",
     "@aztec/ethereum": "workspace:^",
     "@aztec/foundation": "workspace:^",
     "@aztec/kv-store": "workspace:^",

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -267,7 +267,7 @@ export class Archiver implements ArchiveSource {
     const blockBodiesFromStore = await this.store.getBlockBodies(retrievedBodyHashes);
 
     if (retrievedBlockMetadata.retrievedData.length !== blockBodiesFromStore.length) {
-      throw new Error('Block headers length does not equal block bodies length');
+      throw ArchiverError.inconsistentSizes(retrievedBlockMetadata.retrievedData.length, blockBodiesFromStore.length);
     }
 
     const retrievedBlocks = {

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -19,6 +19,7 @@ import {
 } from '@aztec/circuit-types';
 import { ContractClassRegisteredEvent, FunctionSelector } from '@aztec/circuits.js';
 import { ContractInstanceDeployedEvent } from '@aztec/circuits.js/contract';
+import { ArchiverError } from '@aztec/errors';
 import { createEthereumChain } from '@aztec/ethereum';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -129,7 +130,7 @@ export class Archiver implements ArchiveSource {
    */
   public async start(blockUntilSynced: boolean): Promise<void> {
     if (this.runningPromise) {
-      throw new Error('Archiver is already running');
+      throw ArchiverError.alreadyRunning();
     }
 
     if (blockUntilSynced) {

--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -12,6 +12,7 @@ import {
 import '@aztec/circuit-types/jest';
 import { AztecAddress, Fr } from '@aztec/circuits.js';
 import { makeContractClassPublic } from '@aztec/circuits.js/testing';
+import { ArchiverError } from '@aztec/errors';
 import { randomBytes } from '@aztec/foundation/crypto';
 import { ContractClassPublic, ContractInstanceWithAddress, SerializableContractInstance } from '@aztec/types/contracts';
 
@@ -72,7 +73,7 @@ export function describeArchiverDataStore(testName: string, getStore: () => Arch
       });
 
       it('throws an error if limit is invalid', async () => {
-        await expect(store.getBlocks(1, 0)).rejects.toThrowError('Invalid limit: 0');
+        await expect(store.getBlocks(1, 0)).rejects.toThrow(ArchiverError.invalidBlockRange(1, 0));
       });
 
       it('resets `from` to the first block if it is out of range', async () => {

--- a/yarn-project/archiver/src/archiver/eth_log_handlers.ts
+++ b/yarn-project/archiver/src/archiver/eth_log_handlers.ts
@@ -8,6 +8,7 @@ import {
   L2Actor,
 } from '@aztec/circuit-types';
 import { AppendOnlyTreeSnapshot, Header } from '@aztec/circuits.js';
+import { ArchiverError } from '@aztec/errors';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
@@ -75,7 +76,7 @@ export async function processL2BlockProcessedLogs(
   for (const log of logs) {
     const blockNum = log.args.blockNumber;
     if (blockNum !== expectedL2BlockNumber) {
-      throw new Error('Block number mismatch. Expected: ' + expectedL2BlockNumber + ' but got: ' + blockNum + '.');
+      throw ArchiverError.blockNumberMismatch(expectedL2BlockNumber, blockNum);
     }
     // TODO: Fetch blocks from calldata in parallel
     const [header, archive] = await getBlockMetadataFromRollupTx(
@@ -125,7 +126,7 @@ async function getBlockMetadataFromRollupTx(
   });
 
   if (functionName !== 'process') {
-    throw new Error(`Unexpected method called ${functionName}`);
+    throw ArchiverError.unexpectedMethodCall(functionName);
   }
   const [headerHex, archiveRootHex] = args! as readonly [Hex, Hex, Hex, Hex];
 
@@ -134,7 +135,7 @@ async function getBlockMetadataFromRollupTx(
   const blockNumberFromHeader = header.globalVariables.blockNumber.toBigInt();
 
   if (blockNumberFromHeader !== l2BlockNum) {
-    throw new Error(`Block number mismatch: expected ${l2BlockNum} but got ${blockNumberFromHeader}`);
+    throw ArchiverError.blockNumberMismatch(l2BlockNum, blockNumberFromHeader);
   }
 
   const archive = AppendOnlyTreeSnapshot.fromBuffer(
@@ -166,7 +167,7 @@ async function getBlockBodiesFromAvailabilityOracleTx(
   });
 
   if (functionName !== 'publish') {
-    throw new Error(`Unexpected method called ${functionName}`);
+    throw ArchiverError.unexpectedMethodCall(functionName);
   }
 
   const [bodyHex] = args! as [Hex];

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/block_body_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/block_body_store.ts
@@ -1,4 +1,5 @@
 import { Body } from '@aztec/circuit-types';
+import { ArchiverError } from '@aztec/errors';
 import { AztecKVStore, AztecMap } from '@aztec/kv-store';
 
 export class BlockBodyStore {
@@ -33,12 +34,12 @@ export class BlockBodyStore {
     const blockBodiesBuffer = await this.db.transaction(() =>
       txsHashes.map(txsHash => this.#blockBodies.get(txsHash.toString('hex'))),
     );
-
-    if (blockBodiesBuffer.some(bodyBuffer => bodyBuffer === undefined)) {
-      throw new Error('Block body buffer is undefined');
-    }
-
-    return blockBodiesBuffer.map(blockBodyBuffer => Body.fromBuffer(blockBodyBuffer!));
+    return blockBodiesBuffer.map((blockBodyBuffer, index) => {
+      if (blockBodyBuffer === undefined) {
+        throw ArchiverError.bodyNotFound(txsHashes[index]);
+      }
+      return Body.fromBuffer(blockBodyBuffer);
+    });
   }
 
   /**

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
@@ -1,5 +1,6 @@
 import { INITIAL_L2_BLOCK_NUM, L2Block, TxEffect, TxHash, TxReceipt, TxStatus } from '@aztec/circuit-types';
 import { AppendOnlyTreeSnapshot, AztecAddress, Header } from '@aztec/circuits.js';
+import { ArchiverError } from '@aztec/errors';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { AztecKVStore, AztecMap, Range } from '@aztec/kv-store';
 
@@ -188,7 +189,7 @@ export class BlockStore {
 
   #computeBlockRange(start: number, limit: number): Required<Pick<Range<number>, 'start' | 'end'>> {
     if (limit < 1) {
-      throw new Error(`Invalid limit: ${limit}`);
+      throw ArchiverError.invalidBlockRange(start, limit);
     }
 
     if (start < INITIAL_L2_BLOCK_NUM) {

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
@@ -107,7 +107,7 @@ export class BlockStore {
     const body = this.#blockBodyStore.getBlockBody(header.contentCommitment.txsHash);
 
     if (body === undefined) {
-      throw new Error('Body is not able to be retrieved from BodyStore');
+      throw ArchiverError.bodyNotFound(header.contentCommitment.txsHash);
     }
 
     return L2Block.fromFields({

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/contract_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/contract_store.ts
@@ -1,4 +1,5 @@
 import { ContractData, ExtendedContractData } from '@aztec/circuit-types';
+import { ArchiverError } from '@aztec/errors';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { AztecKVStore, AztecMap } from '@aztec/kv-store';
@@ -79,7 +80,7 @@ export class ContractStore {
     const block = this.#blockStore.getBlock(blockNumber);
 
     if (block?.body.txEffects[index].contractData.length !== 1) {
-      throw new Error(`Contract data at block: ${blockNumber}, tx: ${index} does not have length of 1`);
+      throw ArchiverError.contractDataNotFound(blockNumber, index);
     }
 
     return block?.body.txEffects[index].contractData[0];

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/log_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/log_store.ts
@@ -8,6 +8,7 @@ import {
   LogType,
   UnencryptedL2Log,
 } from '@aztec/circuit-types';
+import { ArchiverError } from '@aztec/errors';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { AztecKVStore, AztecMap } from '@aztec/kv-store';
 
@@ -85,7 +86,7 @@ export class LogStore {
 
   #filterUnencryptedLogsOfTx(filter: LogFilter): GetUnencryptedLogsResponse {
     if (!filter.txHash) {
-      throw new Error('Missing txHash');
+      throw ArchiverError.missingTxHash();
     }
 
     const [blockNumber, txIndex] = this.blockStore.getTxLocation(filter.txHash) ?? [];

--- a/yarn-project/archiver/src/archiver/memory_archiver_store/l1_to_l2_message_store.test.ts
+++ b/yarn-project/archiver/src/archiver/memory_archiver_store/l1_to_l2_message_store.test.ts
@@ -1,4 +1,5 @@
 import { L1Actor, L1ToL2Message, L2Actor } from '@aztec/circuit-types';
+import { MessageBoxError } from '@aztec/errors';
 import { Fr } from '@aztec/foundation/fields';
 
 import { L1ToL2MessageStore, PendingL1ToL2MessageStore } from './l1_to_l2_message_store.js';
@@ -48,7 +49,7 @@ describe('pending_l1_to_l2_message_store', () => {
   it("handles case when removing a message that doesn't exist", () => {
     expect(() => store.removeMessage(new Fr(0))).not.toThrow();
     const one = new Fr(1);
-    expect(() => store.removeMessage(one)).toThrow(`Message with key ${one.value} not found in store`);
+    expect(() => store.removeMessage(one)).toThrow(MessageBoxError.messageCannotBeRemoved(one));
   });
 
   it('removeMessage decrements the count if the message is already in the store', () => {

--- a/yarn-project/archiver/src/archiver/memory_archiver_store/l1_to_l2_message_store.ts
+++ b/yarn-project/archiver/src/archiver/memory_archiver_store/l1_to_l2_message_store.ts
@@ -1,4 +1,5 @@
 import { L1ToL2Message } from '@aztec/circuit-types';
+import { MessageBoxError } from '@aztec/errors';
 import { Fr } from '@aztec/foundation/fields';
 
 /**
@@ -66,7 +67,7 @@ export class PendingL1ToL2MessageStore extends L1ToL2MessageStore {
     const entryKeyBigInt = entryKey.value;
     const msgAndCount = this.store.get(entryKeyBigInt);
     if (!msgAndCount) {
-      throw new Error(`Unable to remove message: L1 to L2 Message with key ${entryKeyBigInt} not found in store`);
+      throw MessageBoxError.messageCannotBeRemoved(entryKey);
     }
     if (msgAndCount.count > 1) {
       msgAndCount.count--;

--- a/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
@@ -148,12 +148,14 @@ export class MemoryArchiverStore implements ArchiverDataStore {
    */
   getBlockBodies(txsHashes: Buffer[]): Promise<Body[]> {
     const blockBodies = txsHashes.map(txsHash => this.l2BlockBodies.get(txsHash.toString('hex')));
-
-    if (blockBodies.some(bodyBuffer => bodyBuffer === undefined)) {
-      throw new Error('Block body is undefined');
-    }
-
-    return Promise.resolve(blockBodies as Body[]);
+    return Promise.resolve(
+      blockBodies.map((blockBody, index) => {
+        if (blockBody === undefined) {
+          throw ArchiverError.bodyNotFound(txsHashes[index]);
+        }
+        return blockBody;
+      }),
+    );
   }
 
   /**

--- a/yarn-project/archiver/tsconfig.json
+++ b/yarn-project/archiver/tsconfig.json
@@ -29,6 +29,9 @@
     },
     {
       "path": "../types"
+    },
+    {
+      "path": "../errors"
     }
   ],
   "include": ["src"]

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -24,6 +24,7 @@
     "@aztec/circuits.js": "workspace:^",
     "@aztec/cli": "workspace:^",
     "@aztec/entrypoints": "workspace:^",
+    "@aztec/errors": "workspace:^",
     "@aztec/ethereum": "workspace:^",
     "@aztec/foundation": "workspace:^",
     "@aztec/kv-store": "workspace:^",

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
@@ -10,6 +10,7 @@ import {
   TxStatus,
   computeAuthWitMessageHash,
 } from '@aztec/aztec.js';
+import { MessageBoxError } from '@aztec/errors';
 import { keccak, sha256 } from '@aztec/foundation/crypto';
 import { serializeToBuffer } from '@aztec/foundation/serialize';
 import { TokenBridgeContract, TokenContract } from '@aztec/noir-contracts.js';
@@ -182,7 +183,7 @@ describe('e2e_cross_chain_messaging', () => {
           secretForL2MessageConsumption,
         )
         .simulate(),
-    ).rejects.toThrowError(`Message ${wrongMessage.hash().toString()} not found`);
+    ).rejects.toThrow(MessageBoxError.messageNotFound(wrongMessage.hash()).message);
 
     // send the right one -
     const consumptionTx = l2Bridge
@@ -267,6 +268,6 @@ describe('e2e_cross_chain_messaging', () => {
         .withWallet(user2Wallet)
         .methods.claim_public(ownerAddress, bridgeAmount, ethAccount, secretForL2MessageConsumption)
         .simulate(),
-    ).rejects.toThrowError(`Message ${wrongMessage.hash().toString()} not found`);
+    ).rejects.toThrow(MessageBoxError.messageNotFound(wrongMessage.hash()).message);
   }, 120_000);
 });

--- a/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
@@ -15,6 +15,7 @@ import {
   computeMessageSecretHash,
   sleep,
 } from '@aztec/aztec.js';
+import { MessageBoxError } from '@aztec/errors';
 import { keccak, sha256 } from '@aztec/foundation/crypto';
 import { serializeToBuffer } from '@aztec/foundation/serialize';
 import { InboxAbi, OutboxAbi } from '@aztec/l1-artifacts';
@@ -175,7 +176,7 @@ describe('e2e_public_cross_chain_messaging', () => {
         .withWallet(user2Wallet)
         .methods.claim_public(user2Wallet.getAddress(), bridgeAmount, ethAccount, secret)
         .simulate(),
-    ).rejects.toThrow(`Message ${wrongMessage.hash().toString()} not found`);
+    ).rejects.toThrow(MessageBoxError.messageNotFound(wrongMessage.hash()).message);
 
     // user2 consumes owner's L1-> L2 message on bridge contract and mints public tokens on L2
     logger("user2 consumes owner's message on L2 Publicly");
@@ -239,7 +240,7 @@ describe('e2e_public_cross_chain_messaging', () => {
 
     await expect(
       l2Bridge.withWallet(user2Wallet).methods.claim_private(secretHash, bridgeAmount, ethAccount, secret).simulate(),
-    ).rejects.toThrowError(`Message ${wrongMessage.hash().toString()} not found`);
+    ).rejects.toThrow(MessageBoxError.messageNotFound(wrongMessage.hash()).message);
   }, 60_000);
 
   // Note: We register one portal address when deploying contract but that address is no-longer the only address

--- a/yarn-project/end-to-end/tsconfig.json
+++ b/yarn-project/end-to-end/tsconfig.json
@@ -31,6 +31,9 @@
       "path": "../entrypoints"
     },
     {
+      "path": "../errors"
+    },
+    {
       "path": "../ethereum"
     },
     {

--- a/yarn-project/errors/.eslintrc.cjs
+++ b/yarn-project/errors/.eslintrc.cjs
@@ -1,0 +1,1 @@
+module.exports = require('@aztec/foundation/eslint');

--- a/yarn-project/errors/README.md
+++ b/yarn-project/errors/README.md
@@ -1,0 +1,2 @@
+# Errors
+A package containing error classes that are used throughout the Aztec Typescript codebase to improve consistency.

--- a/yarn-project/errors/package.json
+++ b/yarn-project/errors/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@aztec/errors",
+  "version": "0.1.0",
+  "packageManager": "yarn@3.4.1",
+  "type": "module",
+  "main": "./dest/index.js",
+  "types": "./dest/index.d.ts",
+  "exports": {
+    ".": "./dest/index.js"
+  },
+  "scripts": {
+    "build": "yarn clean && tsc -b",
+    "build:dev": "tsc -b --watch",
+    "clean": "rm -rf ./dest .tsbuildinfo",
+    "formatting": "run -T prettier --check ./src && run -T eslint ./src",
+    "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
+    "test:light": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --passWithNoTests"
+  },
+  "inherits": [
+    "../package.common.json"
+  ],
+  "jest": {
+    "preset": "ts-jest/presets/default-esm",
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.[cm]?js$": "$1"
+    },
+    "testRegex": "./src/.*\\.test\\.(js|mjs|ts)$",
+    "rootDir": "./src"
+  },
+  "dependencies": {
+    "@aztec/foundation": "workspace:^"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.5.0",
+    "@types/debug": "^4.1.7",
+    "@types/detect-node": "^2.0.0",
+    "@types/jest": "^29.5.0",
+    "@types/supertest": "^2.0.12",
+    "@typescript-eslint/eslint-plugin": "^6.2.1",
+    "@typescript-eslint/parser": "^6.2.1",
+    "comlink": "^4.4.1",
+    "eslint": "^8.21.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-jsdoc": "^40.1.0",
+    "eslint-plugin-no-only-tests": "^3.1.0",
+    "eslint-plugin-tsdoc": "^0.2.17",
+    "jest": "^29.5.0",
+    "prettier": "^2.7.1",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.4"
+  },
+  "files": [
+    "dest",
+    "src",
+    "!*.test.*"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/yarn-project/errors/src/index.ts
+++ b/yarn-project/errors/src/index.ts
@@ -68,4 +68,12 @@ export class ArchiverError extends BaseError {
   static contractDataNotFound(blockNumber: number, txIndex: number): ArchiverError {
     return new ArchiverError(`Contract data not found. Block number: ${blockNumber}, tx-index: ${txIndex}`);
   }
+
+  static bodyNotFound(txsHash: Buffer): ArchiverError {
+    return new ArchiverError(`Block body not found. TxsHash: ${txsHash.toString('hex')}`);
+  }
+
+  static inconsistentSizes(sizeA: number, sizeB: number): ArchiverError {
+    return new ArchiverError(`Inconsistent sizes. ${sizeA} != ${sizeB}`);
+  }
 }

--- a/yarn-project/errors/src/index.ts
+++ b/yarn-project/errors/src/index.ts
@@ -1,0 +1,71 @@
+export class BaseError extends Error {
+  constructor(name: string, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = name;
+
+    // Capture the stack trace, excluding the constructor call itself.
+    Error.captureStackTrace?.(this, this.constructor);
+
+    // Optionally, adjust the stack trace further to remove static method frames.
+    this.adjustStackTrace();
+  }
+
+  private adjustStackTrace() {
+    if (this.stack) {
+      const stack = this.stack.split('\n');
+      this.stack = [stack[0], ...stack.slice(2)].join('\n');
+    }
+  }
+}
+
+export class MessageBoxError extends BaseError {
+  constructor(message: string, options?: ErrorOptions) {
+    super('MessageBoxes', message, options);
+  }
+
+  static messageNotFound(entryKey: { toString(): string } | string): MessageBoxError {
+    return new MessageBoxError(`Message not found. EntryKey ${entryKey.toString()}`);
+  }
+
+  static messageNotConfirmed(entryKey: { toString(): string } | string): MessageBoxError {
+    return new MessageBoxError(`Message not confirmed. EntryKey: ${entryKey.toString()}`);
+  }
+
+  static messageUndefinedEntryKey(): MessageBoxError {
+    return new MessageBoxError('Message does not have an entry key');
+  }
+
+  static messageCannotBeRemoved(entryKey: { toString(): string } | string): MessageBoxError {
+    return new MessageBoxError(`Message cannot be removed as it is not in the store. EntryKey: ${entryKey.toString()}`);
+  }
+}
+
+export class ArchiverError extends BaseError {
+  constructor(message: string, options?: ErrorOptions) {
+    super('Archiver', message, options);
+  }
+
+  static alreadyRunning(): ArchiverError {
+    return new ArchiverError('Archiver is already running');
+  }
+
+  static blockNumberMismatch(expected: bigint, real: bigint): ArchiverError {
+    return new ArchiverError(`Block number mismatch. Expected value: ${expected}, actual value: ${real}`);
+  }
+
+  static missingTxHash(): ArchiverError {
+    return new ArchiverError('Missing Transaction Hash');
+  }
+
+  static unexpectedMethodCall(method: string): ArchiverError {
+    return new ArchiverError(`Unexpected method call. Method name: ${method}`);
+  }
+
+  static invalidBlockRange(start: number, limit: number): ArchiverError {
+    return new ArchiverError(`Invalid block range. Start: ${start}, limit: ${limit}`);
+  }
+
+  static contractDataNotFound(blockNumber: number, txIndex: number): ArchiverError {
+    return new ArchiverError(`Contract data not found. Block number: ${blockNumber}, tx-index: ${txIndex}`);
+  }
+}

--- a/yarn-project/errors/tsconfig.json
+++ b/yarn-project/errors/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "..",
+  "compilerOptions": {
+    "outDir": "dest",
+    "rootDir": "src",
+    "tsBuildInfoFile": ".tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../foundation"
+    }
+  ]
+}

--- a/yarn-project/package.json
+++ b/yarn-project/package.json
@@ -31,6 +31,7 @@
     "docs",
     "end-to-end",
     "ethereum",
+    "errors",
     "foundation",
     "key-store",
     "kv-store",

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@aztec/circuit-types": "workspace:^",
     "@aztec/circuits.js": "workspace:^",
+    "@aztec/errors": "workspace:^",
     "@aztec/ethereum": "workspace:^",
     "@aztec/foundation": "workspace:^",
     "@aztec/l1-artifacts": "workspace:^",

--- a/yarn-project/sequencer-client/src/simulator/public_executor.ts
+++ b/yarn-project/sequencer-client/src/simulator/public_executor.ts
@@ -17,6 +17,7 @@ import {
   PublicDataTreeLeafPreimage,
 } from '@aztec/circuits.js';
 import { computePublicDataTreeLeafSlot } from '@aztec/circuits.js/hash';
+import { MessageBoxError } from '@aztec/errors';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { ClassRegistererAddress } from '@aztec/protocol-contracts/class-registerer';
 import { InstanceDeployerAddress } from '@aztec/protocol-contracts/instance-deployer';
@@ -222,6 +223,7 @@ export class WorldStateDB implements CommitmentsDB {
   ): Promise<MessageLoadOracleInputs<typeof L1_TO_L2_MSG_TREE_HEIGHT>> {
     const index = (await this.db.findLeafIndex(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, entryKey.toBuffer()))!;
     if (index === undefined) {
+      throw MessageBoxError.messageNotFound(entryKey);
       throw new Error(`Message ${entryKey.toString()} not found`);
     }
     const siblingPath = await this.db.getSiblingPath<typeof L1_TO_L2_MSG_TREE_HEIGHT>(

--- a/yarn-project/sequencer-client/tsconfig.json
+++ b/yarn-project/sequencer-client/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../circuits.js"
     },
     {
+      "path": "../errors"
+    },
+    {
       "path": "../ethereum"
     },
     {

--- a/yarn-project/tsconfig.json
+++ b/yarn-project/tsconfig.json
@@ -45,7 +45,8 @@
     { "path": "types/tsconfig.json" },
     { "path": "world-state/tsconfig.json" },
     { "path": "scripts/tsconfig.json" },
-    { "path": "entrypoints/tsconfig.json" }
+    { "path": "entrypoints/tsconfig.json" },
+    { "path": "errors/tsconfig.json" }
   ],
   "files": ["./@types/jest/index.d.ts"]
 }

--- a/yarn-project/typedoc.json
+++ b/yarn-project/typedoc.json
@@ -17,6 +17,7 @@
     "aztec-node",
     "sequencer-client",
     "types",
+    "errors",
     "world-state",
     "merkle-tree"
   ]

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -87,6 +87,7 @@ __metadata:
   dependencies:
     "@aztec/circuit-types": "workspace:^"
     "@aztec/circuits.js": "workspace:^"
+    "@aztec/errors": "workspace:^"
     "@aztec/ethereum": "workspace:^"
     "@aztec/foundation": "workspace:^"
     "@aztec/kv-store": "workspace:^"
@@ -375,6 +376,7 @@ __metadata:
     "@aztec/circuits.js": "workspace:^"
     "@aztec/cli": "workspace:^"
     "@aztec/entrypoints": "workspace:^"
+    "@aztec/errors": "workspace:^"
     "@aztec/ethereum": "workspace:^"
     "@aztec/foundation": "workspace:^"
     "@aztec/kv-store": "workspace:^"
@@ -441,6 +443,33 @@ __metadata:
     ts-jest: ^29.1.0
     ts-node: ^10.9.1
     tslib: ^2.4.0
+    typescript: ^5.0.4
+  languageName: unknown
+  linkType: soft
+
+"@aztec/errors@workspace:^, @aztec/errors@workspace:errors":
+  version: 0.0.0-use.local
+  resolution: "@aztec/errors@workspace:errors"
+  dependencies:
+    "@aztec/foundation": "workspace:^"
+    "@jest/globals": ^29.5.0
+    "@types/debug": ^4.1.7
+    "@types/detect-node": ^2.0.0
+    "@types/jest": ^29.5.0
+    "@types/supertest": ^2.0.12
+    "@typescript-eslint/eslint-plugin": ^6.2.1
+    "@typescript-eslint/parser": ^6.2.1
+    comlink: ^4.4.1
+    eslint: ^8.21.0
+    eslint-config-prettier: ^8.5.0
+    eslint-plugin-jsdoc: ^40.1.0
+    eslint-plugin-no-only-tests: ^3.1.0
+    eslint-plugin-tsdoc: ^0.2.17
+    jest: ^29.5.0
+    prettier: ^2.7.1
+    supertest: ^6.3.3
+    ts-jest: ^29.1.0
+    ts-node: ^10.9.1
     typescript: ^5.0.4
   languageName: unknown
   linkType: soft
@@ -826,6 +855,7 @@ __metadata:
   dependencies:
     "@aztec/circuit-types": "workspace:^"
     "@aztec/circuits.js": "workspace:^"
+    "@aztec/errors": "workspace:^"
     "@aztec/ethereum": "workspace:^"
     "@aztec/foundation": "workspace:^"
     "@aztec/kv-store": "workspace:^"


### PR DESCRIPTION
Initial playing around with consolidating errors in one location and then using them throughout. 

Essentially, I was dying inside when I see the duplicated strings around the codebase. They make it cumbersome to alter the error structures and error prone when writing failing tests.

Instead I propose that we are writing them in one place like:
```typescript
export class ArchiverError extends BaseError {
  constructor(message: string, options?: ErrorOptions) {
    super('Archiver', message, options);
  }
  static alreadyRunning(): ArchiverError {
    return new ArchiverError('Archiver is already running');
  }
}
```

This we can then reuse which should make it less error prone and easier to figure out where the errors are used. Also makes it easy to figure out what error messages are never explicitly tested so we can add those easily.

--- 

# Issues encountered:

Errors are inconsistently passed along, which makes interaction and testing a little strange.  

For example, the following code will do as expected, and the test will pass 

```typescriot
    await expect(
      l2Bridge
        .withWallet(user2Wallet)
        .methods.claim_public(user2Wallet.getAddress(), bridgeAmount, ethAccount, secret)
        .simulate(),
    ).rejects.toThrow(MessageBoxError.messageNotFound(wrongMessage.hash()));
```

However, if using a private function instead, it will fail, with an error around the message and cause received being different to expected. 

```typescript
await expect(
      l2Bridge
        .withWallet(user2Wallet)
        .methods.claim_private(
          secretHashForL2MessageConsumption,
          bridgeAmount,
          ethAccount,
          secretForL2MessageConsumption,
        )
        .simulate(),
    ).rejects.toThrow(MessageBoxError.messageNotFound(wrongMessage.hash()));
```

But if only looking at the message, it passes just fine.

```typescript
await expect(
      l2Bridge
        .withWallet(user2Wallet)
        .methods.claim_private(
          secretHashForL2MessageConsumption,
          bridgeAmount,
          ethAccount,
          secretForL2MessageConsumption,
        )
        .simulate(),
    ).rejects.toThrow(MessageBoxError.messageNotFound(wrongMessage.hash()).message);
```