### PR TITLE
chore: Add custom inspect for base types

### DIFF
--- a/yarn-project/foundation/src/abi/selector.ts
+++ b/yarn-project/foundation/src/abi/selector.ts
@@ -1,3 +1,5 @@
+import { inspect } from 'util';
+
 import { toBufferBE } from '../bigint-buffer/index.js';
 import { Fr } from '../fields/index.js';
 
@@ -34,7 +36,11 @@ export abstract class Selector {
    * @returns The string.
    */
   toString(): string {
-    return this.toBuffer().toString('hex');
+    return '0x' + this.toBuffer().toString('hex');
+  }
+
+  [inspect.custom]() {
+    return `Selector<${this.toString()}>`;
   }
 
   /**

--- a/yarn-project/foundation/src/aztec-address/index.ts
+++ b/yarn-project/foundation/src/aztec-address/index.ts
@@ -1,3 +1,5 @@
+import { inspect } from 'util';
+
 import { Fr, fromBuffer } from '../fields/index.js';
 import { BufferReader, FieldReader } from '../serialize/index.js';
 
@@ -14,6 +16,10 @@ export class AztecAddress extends Fr {
       throw new Error(`Invalid AztecAddress length ${buffer.length}.`);
     }
     super(buffer);
+  }
+
+  [inspect.custom]() {
+    return `AztecAddress<${this.toString()}>`;
   }
 
   static ZERO = new AztecAddress(Buffer.alloc(32));

--- a/yarn-project/foundation/src/eth-address/index.ts
+++ b/yarn-project/foundation/src/eth-address/index.ts
@@ -1,3 +1,5 @@
+import { inspect } from 'util';
+
 import { keccak256String } from '../crypto/keccak/index.js';
 import { randomBytes } from '../crypto/random/index.js';
 import { Fr } from '../fields/index.js';
@@ -156,6 +158,10 @@ export class EthAddress {
    */
   public toString() {
     return `0x${this.buffer.toString('hex')}` as `0x${string}`;
+  }
+
+  [inspect.custom]() {
+    return `EthAddress<${this.toString()}>`;
   }
 
   /**

--- a/yarn-project/foundation/src/fields/fields.ts
+++ b/yarn-project/foundation/src/fields/fields.ts
@@ -1,3 +1,5 @@
+import { inspect } from 'util';
+
 import { toBigIntBE, toBufferBE } from '../bigint-buffer/index.js';
 import { randomBytes } from '../crypto/random/index.js';
 import { BufferReader } from '../serialize/buffer_reader.js';
@@ -185,6 +187,10 @@ export class Fr extends BaseField {
     super(value);
   }
 
+  [inspect.custom]() {
+    return `Fr<${this.toString()}>`;
+  }
+
   protected modulus() {
     return Fr.MODULUS;
   }
@@ -250,6 +256,10 @@ export class Fq extends BaseField {
   static MODULUS = 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47n;
   private static HIGH_SHIFT = BigInt((BaseField.SIZE_IN_BYTES / 2) * 8);
   private static LOW_MASK = (1n << Fq.HIGH_SHIFT) - 1n;
+
+  [inspect.custom]() {
+    return `Fq<${this.toString()}>`;
+  }
 
   get low(): Fr {
     return new Fr(this.toBigInt() & Fq.LOW_MASK);


### PR DESCRIPTION
Improves display of custom types when debugging to make them less verbose.

Before:
```
AztecAddress {
        asBuffer: Buffer(32) [Uint8Array] [
           31,  83, 136, 221,  86,  24, 222, 199,
          209,  84, 126,  88, 242,  65, 241, 120,
           45, 175, 195, 124, 100,  32, 173,  65,
          113, 136, 197, 249,  19, 163, 103,  97
        ],
        asBigInt: 14169291217176329001256622499166672439531577110004770510807332793442883561313n
      },
```

After:
```
AztecAddress<0x2ea8404477a7858b3978fedd1cd98c216212fba0e44ff40e12f4cf3bfc2546e4>
```

