### PR TITLE
docs: update LSP instructions

### DIFF
--- a/docs/docs/developers/contracts/main.md
+++ b/docs/docs/developers/contracts/main.md
@@ -20,6 +20,8 @@ An **Aztec smart contract** is a smart contract with **private** state variables
 
 **Aztec.nr** is a framework for writing Aztec smart contracts, written in Noir.
 
+Futher Nomenclature can be found [here](https://github.com/AztecProtocol/dev-rel/blob/main/NOMENCLATURE.md).
+
 # Getting started
 
 ## Install aztec-nargo
@@ -34,7 +36,12 @@ For those coming from vanilla Noir, the version used for aztec.nr is tracked sep
 
 Install the [Noir Language Support extension](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir) to get syntax highlighting, syntax error detection and go-to definitions for your Aztec contracts.
 
-Once the extension is installed, go to your VSCode settings, search for "noir" and update the `Noir: Nargo Path` field to point to your `aztec-nargo` executable.
+Once the extension is installed, check your nargo binary by hovering over `Nargo` in the status bar. Then click to set this to choose the path to `aztec-nargo`.
+
+:::tip
+To specify a custom nargo executable, go to the VSCode settings and search for "noir", or click extension settings on the `noir-lang` LSP plugin.
+Update the `Noir: Nargo Path` field to point to your desired `aztec-nargo` executable.
+:::tip
 
 You can print the path of your `aztec-nargo` executable by running:
 

--- a/docs/docs/developers/contracts/main.md
+++ b/docs/docs/developers/contracts/main.md
@@ -36,7 +36,7 @@ For those coming from vanilla Noir, the version used for aztec.nr is tracked sep
 
 Install the [Noir Language Support extension](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir) to get syntax highlighting, syntax error detection and go-to definitions for your Aztec contracts.
 
-Once the extension is installed, check your nargo binary by hovering over `Nargo` in the status bar. Then click to set this to choose the path to `aztec-nargo`.
+Once the extension is installed, check your nargo binary by hovering over `Nargo` in the status bar. Then click to choose the (default) path to `aztec-nargo`.
 
 :::tip
 To specify a custom nargo executable, go to the VSCode settings and search for "noir", or click extension settings on the `noir-lang` LSP plugin.

--- a/docs/docs/developers/contracts/main.md
+++ b/docs/docs/developers/contracts/main.md
@@ -36,7 +36,7 @@ For those coming from vanilla Noir, the version used for aztec.nr is tracked sep
 
 Install the [Noir Language Support extension](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir) to get syntax highlighting, syntax error detection and go-to definitions for your Aztec contracts.
 
-Once the extension is installed, check your nargo binary by hovering over `Nargo` in the status bar. Then click to choose the (default) path to `aztec-nargo`.
+Once the extension is installed, check your nargo binary by hovering over `Nargo` in the status bar on the bottom right of the application window. Click to choose the path to `aztec-nargo` (or regular `nargo`, if you have that installed).
 
 :::tip
 To specify a custom nargo executable, go to the VSCode settings and search for "noir", or click extension settings on the `noir-lang` LSP plugin.

--- a/docs/docs/developers/contracts/main.md
+++ b/docs/docs/developers/contracts/main.md
@@ -38,16 +38,14 @@ Install the [Noir Language Support extension](https://marketplace.visualstudio.c
 
 Once the extension is installed, check your nargo binary by hovering over `Nargo` in the status bar on the bottom right of the application window. Click to choose the path to `aztec-nargo` (or regular `nargo`, if you have that installed).
 
-:::tip
-To specify a custom nargo executable, go to the VSCode settings and search for "noir", or click extension settings on the `noir-lang` LSP plugin.
-Update the `Noir: Nargo Path` field to point to your desired `aztec-nargo` executable.
-:::tip
-
 You can print the path of your `aztec-nargo` executable by running:
 
 ```bash
 which aztec-nargo
 ```
+
+To specify a custom nargo executable, go to the VSCode settings and search for "noir", or click extension settings on the `noir-lang` LSP plugin.
+Update the `Noir: Nargo Path` field to point to your desired `aztec-nargo` executable.
 
 ## Install Noir tooling
 

--- a/docs/docs/developers/getting_started/aztecnr-getting-started.md
+++ b/docs/docs/developers/getting_started/aztecnr-getting-started.md
@@ -197,7 +197,12 @@ Congratulations, you have now written, compiled, and deployed your first Aztec.n
 
 Install the [Noir Language Support extension](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir) to get syntax highlighting, syntax error detection and go-to definitions for your Aztec contracts.
 
-Once the extension is installed, go to your VSCode settings, search for "noir" and update the `Noir: Nargo Path` field to point to your `aztec-nargo` executable.
+Once the extension is installed, check your nargo binary by hovering over `Nargo` in the status bar. Then click to set this to choose the path to `aztec-nargo`.
+
+:::tip
+To specify a custom nargo executable, go to the VSCode settings and search for "noir", or click extension settings on the `noir-lang` LSP plugin.
+Update the `Noir: Nargo Path` field to point to your desired `aztec-nargo` executable.
+:::tip
 
 You can print the path of your `aztec-nargo` executable by running:
 

--- a/docs/docs/developers/getting_started/aztecnr-getting-started.md
+++ b/docs/docs/developers/getting_started/aztecnr-getting-started.md
@@ -197,7 +197,7 @@ Congratulations, you have now written, compiled, and deployed your first Aztec.n
 
 Install the [Noir Language Support extension](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir) to get syntax highlighting, syntax error detection and go-to definitions for your Aztec contracts.
 
-Once the extension is installed, check your nargo binary by hovering over `Nargo` in the status bar. Then click to choose the (default) path to `aztec-nargo`.
+Once the extension is installed, check your nargo binary by hovering over `Nargo` in the status bar on the bottom right of the application window. Click to choose the path to `aztec-nargo` (or regular `nargo`, if you have that installed).
 
 :::tip
 To specify a custom nargo executable, go to the VSCode settings and search for "noir", or click extension settings on the `noir-lang` LSP plugin.

--- a/docs/docs/developers/getting_started/aztecnr-getting-started.md
+++ b/docs/docs/developers/getting_started/aztecnr-getting-started.md
@@ -199,16 +199,14 @@ Install the [Noir Language Support extension](https://marketplace.visualstudio.c
 
 Once the extension is installed, check your nargo binary by hovering over `Nargo` in the status bar on the bottom right of the application window. Click to choose the path to `aztec-nargo` (or regular `nargo`, if you have that installed).
 
-:::tip
-To specify a custom nargo executable, go to the VSCode settings and search for "noir", or click extension settings on the `noir-lang` LSP plugin.
-Update the `Noir: Nargo Path` field to point to your desired `aztec-nargo` executable.
-:::tip
-
 You can print the path of your `aztec-nargo` executable by running:
 
 ```bash
 which aztec-nargo
 ```
+
+To specify a custom nargo executable, go to the VSCode settings and search for "noir", or click extension settings on the `noir-lang` LSP plugin.
+Update the `Noir: Nargo Path` field to point to your desired `aztec-nargo` executable.
 
 ## What's next?
 

--- a/docs/docs/developers/getting_started/aztecnr-getting-started.md
+++ b/docs/docs/developers/getting_started/aztecnr-getting-started.md
@@ -197,7 +197,7 @@ Congratulations, you have now written, compiled, and deployed your first Aztec.n
 
 Install the [Noir Language Support extension](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir) to get syntax highlighting, syntax error detection and go-to definitions for your Aztec contracts.
 
-Once the extension is installed, check your nargo binary by hovering over `Nargo` in the status bar. Then click to set this to choose the path to `aztec-nargo`.
+Once the extension is installed, check your nargo binary by hovering over `Nargo` in the status bar. Then click to choose the (default) path to `aztec-nargo`.
 
 :::tip
 To specify a custom nargo executable, go to the VSCode settings and search for "noir", or click extension settings on the `noir-lang` LSP plugin.


### PR DESCRIPTION
Context: version of Noir LSP extension was updated (0.0.11) to have better nargo executable visibility/selection.