### PR TITLE
chore: Specify rust-analyzer.linkedProjects after noir-repo move

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -155,5 +155,8 @@
   "C_Cpp.vcpkg.enabled": false,
   "C_Cpp.default.includePath": [
     "barretenberg/cpp/src"
-  ]
+  ],
+  "rust-analyzer.linkedProjects": [
+    "noir/noir-repo/Cargo.toml"
+  ] 
 }


### PR DESCRIPTION
rust-analyzer only is working when `noir-repo` is specified as the root project in VS code. rust-analyzer should work when `aztec-packages` is specified as the root. Sometimes when working on Noir we want to have `aztec-packages` as our root as we may be working across the Noir/barretenberg boundary. Now that `noir` is a subdirectory under `noir/noir-repo` we must specify it is a linked project in the VS code settings.


