### PR TITLE
feat(avm-simulator): implement EMITUNENCRYPTEDLOG

### DIFF
--- a/avm-transpiler/src/instructions.rs
+++ b/avm-transpiler/src/instructions.rs
@@ -7,7 +7,7 @@ use crate::opcodes::AvmOpcode;
 pub const ALL_DIRECT: u8 = 0b00000000;
 pub const ZEROTH_OPERAND_INDIRECT: u8 = 0b00000001;
 pub const FIRST_OPERAND_INDIRECT: u8 = 0b00000010;
-pub const ZEROTH_FIRST_OPERANDS_INDIRECT: u8 = 0b00000011;
+pub const ZEROTH_FIRST_OPERANDS_INDIRECT: u8 = ZEROTH_OPERAND_INDIRECT | FIRST_OPERAND_INDIRECT;
 
 /// A simple representation of an AVM instruction for the purpose
 /// of generating an AVM bytecode from Brillig.

--- a/noir-projects/aztec-nr/aztec/src/context/avm.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/avm.nr
@@ -1,4 +1,5 @@
 use dep::protocol_types::{address::{AztecAddress, EthAddress}, constants::L1_TO_L2_MESSAGE_LENGTH};
+use dep::protocol_types::traits::{Serialize};
 
 // Getters that will be converted by the transpiler into their
 // own opcodes
@@ -61,6 +62,17 @@ impl AVMContext {
 
     #[oracle(avmOpcodeEmitNullifier)]
     pub fn emit_nullifier(self, nullifier: Field) {}
+
+    /**
+     * Emit a log with the given event selector and message.
+     *
+     * @param event_selector The event selector for the log.
+     * @param message The message to emit in the log.
+     * Should be automatically convertible to [Field; N]. For example str<N> works with
+     * one char per field. Otherwise you can use CompressedString.
+     */
+    #[oracle(amvOpcodeEmitUnencryptedLog)]
+    pub fn emit_unencrypted_log<T>(self, event_selector: Field, message: T) {}
 
     #[oracle(avmOpcodeL1ToL2MsgExists)]
     pub fn l1_to_l2_msg_exists(self, msg_hash: Field, msg_leaf_index: Field) -> u8 {}

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/Nargo.toml
@@ -6,3 +6,4 @@ type = "contract"
 
 [dependencies]
 aztec = { path = "../../../aztec-nr/aztec" }
+compressed_string = { path = "../../../aztec-nr/compressed-string" }

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -1,6 +1,7 @@
 contract AvmTest {
     // Libs
     use dep::aztec::protocol_types::{address::{AztecAddress, EthAddress}, constants::L1_TO_L2_MESSAGE_LENGTH};
+    use dep::compressed_string::CompressedString;
 
     // avm lib
     use dep::aztec::avm::hash::{keccak256, poseidon, sha256};
@@ -139,6 +140,16 @@ contract AvmTest {
     // fn getContractCallDepth() -> pub Field {
     //     context.contract_call_depth()
     // }
+
+    #[aztec(public-vm)]
+    fn emit_unencrypted_log() {
+        context.emit_unencrypted_log(/*event_selector=*/ 5, /*message=*/ [10, 20, 30]);
+        context.emit_unencrypted_log(/*event_selector=*/ 8, /*message=*/ "Hello, world!");
+        // FIXME: Try this once Brillig codegen produces uniform bit sizes for LT
+        // FIXME: TagCheckError: Tag mismatch at offset 22, got UINT64, expected UINT32
+        // let s: CompressedString<1,13> = CompressedString::from_string("Hello, world!");
+        // context.emit_unencrypted_log(/*event_selector=*/ 10, /*message=*/ s);
+    }
 
     #[aztec(public-vm)]
     fn note_hash_exists(note_hash: Field, leaf_index: Field) -> pub u8 {

--- a/yarn-project/simulator/src/avm/avm_simulator.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.ts
@@ -35,7 +35,7 @@ export class AvmSimulator {
         const instruction = instructions[this.context.machineState.pc];
         assert(!!instruction); // This should never happen
 
-        this.log(`Executing PC=${this.context.machineState.pc}: ${instruction.toString()}`);
+        this.log.debug(`@${this.context.machineState.pc} ${instruction.toString()}`);
         // Execute the instruction.
         // Normal returns and reverts will return normally here.
         // "Exceptional halts" will throw.

--- a/yarn-project/simulator/src/avm/journal/journal.test.ts
+++ b/yarn-project/simulator/src/avm/journal/journal.test.ts
@@ -1,4 +1,6 @@
-import { EthAddress } from '@aztec/circuits.js';
+import { UnencryptedL2Log } from '@aztec/circuit-types';
+import { AztecAddress, EthAddress } from '@aztec/circuits.js';
+import { EventSelector } from '@aztec/foundation/abi';
 import { Fr } from '@aztec/foundation/fields';
 
 import { MockProxy, mock } from 'jest-mock-extended';
@@ -150,15 +152,15 @@ describe('journal', () => {
     const recipient = EthAddress.fromField(new Fr(42));
     const commitment = new Fr(10);
     const commitmentT1 = new Fr(20);
-    const logs = [new Fr(1), new Fr(2)];
-    const logsT1 = [new Fr(3), new Fr(4)];
+    const log = { address: 10n, selector: 5, data: [new Fr(5), new Fr(6)] };
+    const logT1 = { address: 20n, selector: 8, data: [new Fr(7), new Fr(8)] };
     const index = new Fr(42);
     const indexT1 = new Fr(24);
 
     journal.writeStorage(contractAddress, key, value);
     await journal.readStorage(contractAddress, key);
     journal.writeNoteHash(commitment);
-    journal.writeLog(logs);
+    journal.writeLog(new Fr(log.address), new Fr(log.selector), log.data);
     journal.writeL1Message(recipient, commitment);
     await journal.writeNullifier(contractAddress, commitment);
     await journal.checkNullifierExists(contractAddress, commitment);
@@ -168,7 +170,7 @@ describe('journal', () => {
     childJournal.writeStorage(contractAddress, key, valueT1);
     await childJournal.readStorage(contractAddress, key);
     childJournal.writeNoteHash(commitmentT1);
-    childJournal.writeLog(logsT1);
+    childJournal.writeLog(new Fr(logT1.address), new Fr(logT1.selector), logT1.data);
     childJournal.writeL1Message(recipient, commitmentT1);
     await childJournal.writeNullifier(contractAddress, commitmentT1);
     await childJournal.checkNullifierExists(contractAddress, commitmentT1);
@@ -195,7 +197,18 @@ describe('journal', () => {
     expect(slotWrites).toEqual([value, valueT1]);
 
     expect(journalUpdates.newNoteHashes).toEqual([commitment, commitmentT1]);
-    expect(journalUpdates.newLogs).toEqual([logs, logsT1]);
+    expect(journalUpdates.newLogs).toEqual([
+      new UnencryptedL2Log(
+        AztecAddress.fromBigInt(log.address),
+        new EventSelector(log.selector),
+        Buffer.concat(log.data.map(f => f.toBuffer())),
+      ),
+      new UnencryptedL2Log(
+        AztecAddress.fromBigInt(logT1.address),
+        new EventSelector(logT1.selector),
+        Buffer.concat(logT1.data.map(f => f.toBuffer())),
+      ),
+    ]);
     expect(journalUpdates.newL1Messages).toEqual([
       { recipient, content: commitment },
       { recipient, content: commitmentT1 },
@@ -228,8 +241,8 @@ describe('journal', () => {
     const recipient = EthAddress.fromField(new Fr(42));
     const commitment = new Fr(10);
     const commitmentT1 = new Fr(20);
-    const logs = [new Fr(1), new Fr(2)];
-    const logsT1 = [new Fr(3), new Fr(4)];
+    const log = { address: 10n, selector: 5, data: [new Fr(5), new Fr(6)] };
+    const logT1 = { address: 20n, selector: 8, data: [new Fr(7), new Fr(8)] };
     const index = new Fr(42);
     const indexT1 = new Fr(24);
 
@@ -239,7 +252,7 @@ describe('journal', () => {
     await journal.writeNullifier(contractAddress, commitment);
     await journal.checkNullifierExists(contractAddress, commitment);
     await journal.checkL1ToL2MessageExists(commitment, index);
-    journal.writeLog(logs);
+    journal.writeLog(new Fr(log.address), new Fr(log.selector), log.data);
     journal.writeL1Message(recipient, commitment);
 
     const childJournal = new AvmPersistableStateManager(journal.hostStorage, journal);
@@ -249,7 +262,7 @@ describe('journal', () => {
     await childJournal.writeNullifier(contractAddress, commitmentT1);
     await childJournal.checkNullifierExists(contractAddress, commitmentT1);
     await journal.checkL1ToL2MessageExists(commitmentT1, indexT1);
-    childJournal.writeLog(logsT1);
+    childJournal.writeLog(new Fr(logT1.address), new Fr(logT1.selector), logT1.data);
     childJournal.writeL1Message(recipient, commitmentT1);
 
     journal.rejectNestedCallState(childJournal);
@@ -285,7 +298,13 @@ describe('journal', () => {
     ]);
 
     // Check that rejected Accrued Substate is absent
-    expect(journalUpdates.newLogs).toEqual([logs]);
+    expect(journalUpdates.newLogs).toEqual([
+      new UnencryptedL2Log(
+        AztecAddress.fromBigInt(log.address),
+        new EventSelector(log.selector),
+        Buffer.concat(log.data.map(f => f.toBuffer())),
+      ),
+    ]);
     expect(journalUpdates.newL1Messages).toEqual([{ recipient, content: commitment }]);
   });
 

--- a/yarn-project/simulator/src/avm/opcodes/accrued_substate.ts
+++ b/yarn-project/simulator/src/avm/opcodes/accrued_substate.ts
@@ -3,6 +3,7 @@ import { Uint8 } from '../avm_memory_types.js';
 import { InstructionExecutionError } from '../errors.js';
 import { NullifierCollisionError } from '../journal/nullifiers.js';
 import { Opcode, OperandType } from '../serialization/instruction_serialization.js';
+import { Addressing } from './addressing_mode.js';
 import { Instruction } from './instruction.js';
 import { StaticCallStorageAlterError } from './storage.js';
 
@@ -153,9 +154,20 @@ export class EmitUnencryptedLog extends Instruction {
   static type: string = 'EMITUNENCRYPTEDLOG';
   static readonly opcode: Opcode = Opcode.EMITUNENCRYPTEDLOG;
   // Informs (de)serialization. See Instruction.deserialize.
-  static readonly wireFormat = [OperandType.UINT8, OperandType.UINT8, OperandType.UINT32, OperandType.UINT32];
+  static readonly wireFormat = [
+    OperandType.UINT8,
+    OperandType.UINT8,
+    OperandType.UINT32,
+    OperandType.UINT32,
+    OperandType.UINT32,
+  ];
 
-  constructor(private indirect: number, private logOffset: number, private logSize: number) {
+  constructor(
+    private indirect: number,
+    private eventSelectorOffset: number,
+    private logOffset: number,
+    private logSize: number,
+  ) {
     super();
   }
 
@@ -164,8 +176,15 @@ export class EmitUnencryptedLog extends Instruction {
       throw new StaticCallStorageAlterError();
     }
 
-    const log = context.machineState.memory.getSlice(this.logOffset, this.logSize).map(f => f.toFr());
-    context.persistableState.writeLog(log);
+    const [eventSelectorOffset, logOffset] = Addressing.fromWire(this.indirect).resolve(
+      [this.eventSelectorOffset, this.logOffset],
+      context.machineState.memory,
+    );
+
+    const contractAddress = context.environment.address;
+    const event = context.machineState.memory.get(eventSelectorOffset).toFr();
+    const log = context.machineState.memory.getSlice(logOffset, this.logSize).map(f => f.toFr());
+    context.persistableState.writeLog(contractAddress, event, log);
 
     context.machineState.incrementPc();
   }

--- a/yellow-paper/docs/public-vm/gen/_instruction-set.mdx
+++ b/yellow-paper/docs/public-vm/gen/_instruction-set.mdx
@@ -391,6 +391,7 @@ if exists:
 {`context.accruedSubstate.unencryptedLogs.append(
     UnencryptedLog {
         address: context.environment.address,
+        eventSelector: M[eventSelectorOffset],
         log: M[logOffset:logOffset+logSize],
     }
 )`}
@@ -1566,6 +1567,7 @@ Emit an unencrypted log
 - **Flags**: 
 	- **indirect**: Toggles whether each memory-offset argument is an indirect offset. Rightmost bit corresponds to 0th offset arg, etc. Indirect offsets result in memory accesses like `M[M[offset]]` instead of the more standard `M[offset]`.
 - **Args**: 
+	- **eventSelectorOffset**: memory offset of the event selector
 	- **logOffset**: memory offset of the data to log
 	- **logSize**: number of words to log
 - **Expression**: 
@@ -1573,11 +1575,12 @@ Emit an unencrypted log
 {`context.accruedSubstate.unencryptedLogs.append(
     UnencryptedLog {
         address: context.environment.address,
+        eventSelector: M[eventSelectorOffset],
         log: M[logOffset:logOffset+logSize],
     }
 )`}
 </CodeBlock>
-- **Bit-size**: 88
+- **Bit-size**: 120
 
 [![](./images/bit-formats/EMITUNENCRYPTEDLOG.png)](./images/bit-formats/EMITUNENCRYPTEDLOG.png)
 

--- a/yellow-paper/src/preprocess/InstructionSet/InstructionSet.js
+++ b/yellow-paper/src/preprocess/InstructionSet/InstructionSet.js
@@ -1028,6 +1028,7 @@ T[dstOffset] = field
             {"name": "indirect", "description": INDIRECT_FLAG_DESCRIPTION},
         ],
         "Args": [
+            {"name": "eventSelectorOffset", "description": "memory offset of the event selector"},
             {"name": "logOffset", "description": "memory offset of the data to log"},
             {"name": "logSize", "description": "number of words to log", "mode": "immediate", "type": "u32"},
         ],
@@ -1035,6 +1036,7 @@ T[dstOffset] = field
 context.accruedSubstate.unencryptedLogs.append(
     UnencryptedLog {
         address: context.environment.address,
+        eventSelector: M[eventSelectorOffset],
         log: M[logOffset:logOffset+logSize],
     }
 )


### PR DESCRIPTION
* Implements `EMITUNENCRYPTEDLOG` opcode in the simulator (including `event_selector` which was previously missing)
* Adds `emit_unencrypted_log<T>` to `avm.nr` (the new public context).
  * Observe that this function takes any type `T` that noir is happy to autoconvert to `[Field; N]`
  * Observe that it does NOT take an `address`. Instead the simulator uses `context.environment.address`. See [this thread](https://aztecprotocol.slack.com/archives/C03P17YHVK8/p1709326971482429).
  * This function is tested with fields and raw strings. I think it would also probably work with `CompressedString` and other serializable types, but I can't test it now due to Brillig problems.
* Updated spec.

Closes #4838.