### PR TITLE
chore: Deploy docs to production only on releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1144,22 +1144,13 @@ jobs:
           name: "Copy docs dockerignore"
           command: cp docs/.dockerignore .
       - run:
-          name: "Require released code"
-          command: |
-            LAST_TAG="aztec-packages-v$(jq -r '.["."]' .release-please-manifest.json)"
-            if git ls-remote --tags origin | grep "$LAST_TAG" > /dev/null; then
-              echo "Using code released from $LAST_TAG"
-              echo "INCLUDE_RELEASED_CODE=1" >> docs/.env
-              git fetch origin --refetch --no-filter refs/tags/$LAST_TAG:refs/tags/$LAST_TAG
-            else
-              echo "Skipping as $LAST_TAG is not yet published"
-            fi
-      - run:
           name: "Build docs"
           command: |
             echo "Building docs"
             build docs
-
+      - run:
+          name: "Deploy docs"
+          command: |
             echo "Deploying docs"
             docs/deploy_netlify.sh $BRANCH $PULL_REQUEST
 

--- a/docs/deploy_netlify.sh
+++ b/docs/deploy_netlify.sh
@@ -9,11 +9,11 @@ npm install netlify-cli -g
 
 DEPLOY_OUTPUT=""
 
-# Check if we're on master
-if [ "$1" = "master" ]; then
-    # Deploy to production if the argument is "master"
+if should_release; then
+    # Deploy to production only on a release
     DEPLOY_OUTPUT=$(netlify deploy --site aztec-docs-dev --prod)
-else
+elif [ "$1" != "master" ]; then
+    # Deploy preview on PRs
     # TODO we should prob see if check_rebuild can be used for this
     PR_URL="$2"
     API_URL="${PR_URL/github.com/api.github.com/repos}"

--- a/docs/docs/developers/contracts/writing_contracts/functions/compute_note_hash_and_nullifier.md
+++ b/docs/docs/developers/contracts/writing_contracts/functions/compute_note_hash_and_nullifier.md
@@ -17,22 +17,3 @@ The function should take 5 parameters:
 It should return `pub [Field; 4]` which is an array of 4 elements that tells the PXE how to handle the notes and nullifiers:
 
 #include_code compute_note_hash_and_nullifier_returns noir-projects/aztec-nr/aztec/src/note/utils.nr rust
-
-## Placeholder
-
-If you don't have any private state variables defined, you can use this placeholder function:
-
-#include_code compute_note_hash_and_nullifier_placeholder /noir-projects/noir-contracts/contracts/token_bridge_contract/src/main.nr rust
-
-## When using notes
- 
-If you are using custom notes or note types that come with Aztec.nr, you can call the util function `compute_note_hash_and_nulilfier` from the `aztec::utils` library in Aztec.nr. This will return the array needed.
-
-This function takes:
-
-#include_code compute_note_hash_and_nullifier_args /noir-projects/aztec-nr/aztec/src/note/utils.nr rust
-
-Here is an example from the [token contract](../../../tutorials/writing_token_contract.md):
-
-#include_code compute_note_hash_and_nullifier /noir-projects/noir-contracts/contracts/token_contract/src/main.nr rust
-

--- a/docs/src/preprocess/include_code.js
+++ b/docs/src/preprocess/include_code.js
@@ -1,6 +1,5 @@
 const fs = require("fs");
 const path = require("path");
-const childProcess = require("child_process");
 
 const getLineNumberFromIndex = (fileContent, index) => {
   return fileContent.substring(0, index).split("\n").length;
@@ -59,63 +58,6 @@ function processHighlighting(codeSnippet, identifier) {
   return result.trim();
 }
 
-let lastReleasedVersion;
-
-/** Returns the last released tag */
-function getLatestTag() {
-  if (!lastReleasedVersion) {
-    const manifest = path.resolve(
-      __dirname,
-      "../../../.release-please-manifest.json"
-    );
-    lastReleasedVersion = JSON.parse(fs.readFileSync(manifest).toString())["."];
-  }
-  return lastReleasedVersion
-    ? `aztec-packages-v${lastReleasedVersion}`
-    : undefined;
-}
-
-/** Returns whether to use the latest release or the current version of stuff. */
-function useLastRelease() {
-  return process.env.NETLIFY || process.env.INCLUDE_RELEASED_CODE;
-}
-
-/**
- * Returns the contents of a file. If the build is running for publishing, it will load the contents
- * of the file in the last released version.
- */
-function readFile(filePath, tag) {
-  if (tag && tag !== "master") {
-    try {
-      const root = path.resolve(__dirname, "../../../");
-      const relPath = path.relative(root, filePath);
-      return childProcess.execSync(`git show ${tag}:${relPath}`).toString();
-    } catch (err) {
-      console.error(
-        `Error reading file ${filePath} from version ${tag}. Falling back to current content.`
-      );
-    }
-  }
-  return fs.readFileSync(filePath, "utf-8");
-}
-
-/** Extracts a code snippet, trying with the last release if applicable, and falling back to current content. */
-function extractCodeSnippet(filePath, identifier, requesterFile) {
-  if (useLastRelease()) {
-    try {
-      return doExtractCodeSnippet(filePath, identifier, false);
-    } catch (err) {
-      console.error(
-        `Error extracting code snippet ${identifier} from ${path.basename(
-          filePath
-        )} requested by ${requesterFile}: ${err}. Falling back to current content.`
-      );
-    }
-  }
-
-  return doExtractCodeSnippet(filePath, identifier, true);
-}
-
 /**
  * Parse a code file, looking for identifiers of the form:
  * `docs:start:${identifier}` and `docs:end:{identifier}`.
@@ -126,9 +68,8 @@ function extractCodeSnippet(filePath, identifier, requesterFile) {
  * removes any which fall within the bounds of the code snippet for this particular `identifier` param.
  * @returns the code snippet, and start and end line numbers which can later be used for creating a link to github source code.
  */
-function doExtractCodeSnippet(filePath, identifier, useCurrent) {
-  const tag = useCurrent ? "master" : getLatestTag();
-  let fileContent = readFile(filePath, tag);
+function extractCodeSnippet(filePath, identifier) {
+  let fileContent = fs.readFileSync(filePath, "utf-8");
   let lineRemovalCount = 0;
   let linesToRemove = [];
 
@@ -227,7 +168,7 @@ function doExtractCodeSnippet(filePath, identifier, useCurrent) {
   // The code snippet might contain some docusaurus highlighting comments for other identifiers. We should remove those.
   codeSnippet = processHighlighting(codeSnippet, identifier);
 
-  return [codeSnippet, startLineNum, endLineNum, tag];
+  return [codeSnippet, startLineNum, endLineNum];
 }
 
 /**
@@ -287,28 +228,23 @@ async function preprocessIncludeCode(markdownContent, filePath, rootDir) {
       const absCodeFilePath = path.join(rootDir, codeFilePath);
 
       // Extract the code snippet between the specified comments
-      const extracted = extractCodeSnippet(
+      const [codeSnippet, startLine, endLine] = extractCodeSnippet(
         absCodeFilePath,
         identifier,
         filePath
       );
-      const [codeSnippet, startLine, endLine, tag] = extracted;
 
       const relativeCodeFilePath = path.resolve(rootDir, codeFilePath);
 
       let urlText = `${relativeCodeFilePath}#L${startLine}-L${endLine}`;
-      if (tag && tag !== "master") urlText += ` (${tag})`;
+      const tag = "master";
       const url = `https://github.com/AztecProtocol/aztec-packages/blob/${tag}/${relativeCodeFilePath}#L${startLine}-L${endLine}`;
 
       const title = noTitle ? "" : `title="${identifier}"`;
       const lineNumbers = noLineNumbers ? "" : "showLineNumbers";
-      const warn =
-        useLastRelease() && (!tag || tag === "master")
-          ? `<br/>This example references unreleased code. Code from released packages may be different. Use with care.`
-          : "";
       const source = noSourceLink
         ? ""
-        : `\n> <sup><sub><a href="${url}" target="_blank" rel="noopener noreferrer">Source code: ${urlText}</a>${warn}</sub></sup>`;
+        : `\n> <sup><sub><a href="${url}" target="_blank" rel="noopener noreferrer">Source code: ${urlText}</a></sub></sup>`;
       const replacement =
         language === "raw"
           ? codeSnippet


### PR DESCRIPTION
- Removes all logic to load code snippets from released versions
- Deploys docs to production only on releases
- Deploys previews on all branches but master
- Removes doc section that referenced removed code snippets (cc @AztecProtocol/devrel)