### PR TITLE
fix: dapp sub test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -711,7 +711,6 @@ jobs:
           command: cond_spot_run_compose end-to-end 4 ./scripts/docker-compose.yml TEST=e2e_authwit.test.ts
           aztec_manifest_key: end-to-end
 
-
   e2e-blacklist-token-contract:
     docker:
       - image: aztecprotocol/alpine-build-image
@@ -1023,6 +1022,18 @@ jobs:
       - run:
           name: "Test"
           command: cond_spot_run_compose end-to-end 4 ./scripts/docker-compose.yml TEST=e2e_fees.test.ts
+          aztec_manifest_key: end-to-end
+
+  e2e-dapp-subscription:
+    docker:
+      - image: aztecprotocol/alpine-build-image
+    resource_class: small
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Test"
+          command: cond_spot_run_compose end-to-end 4 ./scripts/docker-compose.yml TEST=e2e_dapp_subscription.test.ts
           aztec_manifest_key: end-to-end
 
   pxe:
@@ -1496,6 +1507,7 @@ workflows:
       - e2e-card-game: *e2e_test
       - e2e-avm-simulator: *e2e_test
       - e2e-fees: *e2e_test
+      - e2e-dapp-subscription: *e2e_test
       - pxe: *e2e_test
       - cli-docs-sandbox: *e2e_test
       - e2e-docs-examples: *e2e_test
@@ -1542,6 +1554,7 @@ workflows:
             - e2e-card-game
             - e2e-avm-simulator
             - e2e-fees
+            - e2e-dapp-subscription
             - pxe
             - boxes-vanilla
             - boxes-react

--- a/yarn-project/aztec.js/src/fee/public_fee_payment_method.ts
+++ b/yarn-project/aztec.js/src/fee/public_fee_payment_method.ts
@@ -5,7 +5,7 @@ import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
 
 import { computeAuthWitMessageHash } from '../utils/authwit.js';
-import { AccountWalletWithPrivateKey } from '../wallet/account_wallet_with_private_key.js';
+import { AccountWallet } from '../wallet/account_wallet.js';
 import { FeePaymentMethod } from './fee_payment_method.js';
 
 /**
@@ -25,7 +25,7 @@ export class PublicFeePaymentMethod implements FeePaymentMethod {
     /**
      * An auth witness provider to authorize fee payments
      */
-    private wallet: AccountWalletWithPrivateKey,
+    private wallet: AccountWallet,
   ) {}
 
   /**

--- a/yarn-project/end-to-end/src/e2e_dapp_subscription.test.ts
+++ b/yarn-project/end-to-end/src/e2e_dapp_subscription.test.ts
@@ -19,7 +19,14 @@ import {
 
 import { jest } from '@jest/globals';
 
-import { BalancesFn, EndToEndContext, expectMapping, getBalancesFn, setup } from './fixtures/utils.js';
+import {
+  BalancesFn,
+  EndToEndContext,
+  expectMapping,
+  getBalancesFn,
+  publicDeployAccounts,
+  setup,
+} from './fixtures/utils.js';
 import { GasPortalTestingHarnessFactory, IGasBridgingTestHarness } from './shared/gas_portal_test_harness.js';
 
 jest.setTimeout(1_000_000);
@@ -118,6 +125,8 @@ describe('e2e_dapp_subscription', () => {
       [aliceAddress, sequencerAddress, subscriptionContract.address, bananaFPC.address],
       [0n, 0n, BRIDGED_GAS_BALANCE, BRIDGED_GAS_BALANCE],
     );
+
+    await publicDeployAccounts(e2eContext.wallet, e2eContext.accounts);
   });
 
   it('should allow Alice to subscribe by paying privately with bananas', async () => {


### PR DESCRIPTION
This PR updates the dapp entrypoint e2e test to work with the latest authwit and contract deployment changes and adds it to the CCI config.
