### PR TITLE
chore: remove last impls of compute_note_hash_and_nullifier

### DIFF
--- a/noir-projects/noir-contracts/contracts/delegated_on_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/delegated_on_contract/src/main.nr
@@ -38,15 +38,4 @@ contract DelegatedOn {
     unconstrained fn view_public_value() -> pub Field {
         storage.current_value.read()
     }
-
-    // TODO: remove this placeholder once https://github.com/AztecProtocol/aztec-packages/issues/2918 is implemented
-    unconstrained fn compute_note_hash_and_nullifier(
-        contract_address: AztecAddress,
-        nonce: Field,
-        storage_slot: Field,
-        note_type_id: Field,
-        serialized_note: [Field; 0]
-    ) -> pub [Field; 4] {
-        [0, 0, 0, 0]
-    }
 }

--- a/noir-projects/noir-contracts/contracts/delegator_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/delegator_contract/src/main.nr
@@ -54,16 +54,4 @@ contract Delegator {
     unconstrained fn view_public_value() -> pub Field {
         storage.current_value.read()
     }
-
-    // TODO: remove this placeholder once https://github.com/AztecProtocol/aztec-packages/issues/2918 is implemented
-    unconstrained fn compute_note_hash_and_nullifier(
-        contract_address: AztecAddress,
-        nonce: Field,
-        storage_slot: Field,
-        note_type_id: Field,
-        serialized_note: [Field; VALUE_NOTE_LEN]
-    ) -> pub [Field; 4] {
-        let note_header = NoteHeader::new(contract_address, nonce, storage_slot);
-        dep::aztec::note::utils::compute_note_hash_and_nullifier(ValueNote::deserialize_content, note_header, serialized_note)
-    }
 }


### PR DESCRIPTION
These are stragglers that should've been removed in https://github.com/AztecProtocol/aztec-packages/pull/4610. I have not found any remaining instances. Thanks @TomAFrench for pointing them out.