### PR TITLE
chore(avm-simulator): test improvements

### DIFF
--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -168,7 +168,7 @@ contract AvmTest {
         context.push_new_nullifier(nullifier, 0);
     }
 
-    // Use the standard context interface to emit a new nullifier
+    // Use the standard context interface to check for a nullifier
     #[aztec(public-vm)]
     fn nullifier_exists(nullifier: Field) -> pub u8 {
         context.nullifier_exists(nullifier)


### PR DESCRIPTION
Make tests more concise and remove some duplicated calls to `AvmSimulator.execute()`.
