### PR TITLE
chore: Add missing jobs to CI end

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1514,6 +1514,7 @@ workflows:
             - barretenberg-join-split-tests
             - barretenberg-acir-tests-bb
             - barretenberg-docs
+            - build-docs
             - mainnet-fork
             - e2e-2-pxes
             - e2e-note-getter
@@ -1560,6 +1561,7 @@ workflows:
             - guides-sample-dapp
             - guides-up-quick-start
             - yellow-paper
+            - yarn-project-test
           <<: *defaults
 
       # Benchmark jobs.


### PR DESCRIPTION
`build-docs` and `yarn-project-test` were not requirements of `end`, which is the job that signals that the CI ended successfully. This caused PRs to be auto-merged with failing unit tests.

Alternatively, we could flag these two jobs as required in the branch protection rules for `master` in the project settings, but I'm unsure how that would play with the workflow auto-generation if those jobs are not required to run.
