### PR TITLE
chore: address warnings in noir test suite

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/common.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/common.nr
@@ -363,7 +363,7 @@ fn propagate_new_nullifiers(
 fn propagate_new_l2_to_l1_messages(public_call: PublicCallData, public_inputs: &mut PublicKernelCircuitPublicInputsBuilder) {
     // new l2 to l1 messages
     let public_call_public_inputs = public_call.call_stack_item.public_inputs;
-    let portal_contract_address = public_call.portal_contract_address;
+    // let portal_contract_address = public_call.portal_contract_address;
     let storage_contract_address = public_call_public_inputs.call_context.storage_contract_address;
 
     let new_l2_to_l1_msgs = public_call_public_inputs.new_l2_to_l1_msgs;

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/common.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/common.nr
@@ -363,7 +363,6 @@ fn propagate_new_nullifiers(
 fn propagate_new_l2_to_l1_messages(public_call: PublicCallData, public_inputs: &mut PublicKernelCircuitPublicInputsBuilder) {
     // new l2 to l1 messages
     let public_call_public_inputs = public_call.call_stack_item.public_inputs;
-    // let portal_contract_address = public_call.portal_contract_address;
     let storage_contract_address = public_call_public_inputs.call_context.storage_contract_address;
 
     let new_l2_to_l1_msgs = public_call_public_inputs.new_l2_to_l1_msgs;

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_setup.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_setup.nr
@@ -412,11 +412,11 @@ mod tests {
 
         builder.public_call.append_update_requests(2);
         let storage = builder.get_current_public_data_update_requests();
-        let update_requests = [storage[0], storage[1]];
+        let _update_requests = [storage[0], storage[1]];
 
         builder.public_call.append_public_data_read_requests(3);
         let storage = builder.get_current_public_data_reads();
-        let read_requests = [storage[0], storage[1], storage[2]];
+        let _read_requests = [storage[0], storage[1], storage[2]];
 
         // Push the public call on top of the teardown call.
         let setup_call = builder.public_call.finish();

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/base_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/base_rollup_inputs.nr
@@ -152,6 +152,8 @@ impl BaseRollupInputs {
 
     // Cpp code says calculate_contract_subtree, so I'm leaving it as is for now
     fn calculate_contract_subtree_root(self, leaves: [Field; MAX_NEW_CONTRACTS_PER_TX]) -> Field {
+        // Silence warning for unused self, pending proper fix.
+        let _  = self;
         assert_eq(leaves.len(), 1);
         leaves[0]
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/merkle_tree_utils.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/merkle_tree_utils.nr
@@ -154,6 +154,8 @@ impl<SUBTREE_ITEMS, TREE_HEIGHT, SUPERTREE_HEIGHT, SUBTREE_HEIGHT> NonEmptyMerkl
     }
 
     pub fn get_next_available_index(self) -> Field {
+        // Silence warning for unused self, pending proper fix.
+        let _  = self;
         SUBTREE_ITEMS
     }
 }


### PR DESCRIPTION
This PR addresses various warnings to prevent them from showing up in the test output.