### PR TITLE
chore: integrating natspec-smells tool

### DIFF
--- a/l1-contracts/natspec-smells.config.js
+++ b/l1-contracts/natspec-smells.config.js
@@ -1,0 +1,8 @@
+/**
+ * List of supported options: https://github.com/defi-wonderland/natspec-smells?tab=readme-ov-file#options
+ */
+
+/** @type {import('@defi-wonderland/natspec-smells').Config} */
+module.exports = {
+    include: 'src/core/**/*.sol',
+  };

--- a/l1-contracts/package.json
+++ b/l1-contracts/package.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0",
   "description": "Aztec contracts for the Ethereum mainnet and testnets",
   "devDependencies": {
+    "@defi-wonderland/natspec-smells": "^1.1.1",
     "solhint": "https://github.com/LHerskind/solhint#master"
   },
   "scripts": {

--- a/l1-contracts/slither_output.md
+++ b/l1-contracts/slither_output.md
@@ -315,13 +315,13 @@ src/core/messagebridge/Inbox.sol#L148-L153
 ## similar-names
 Impact: Informational
 Confidence: Medium
- - [ ] ID-31
+ - [ ] ID-34
 Variable [Constants.LOGS_HASHES_NUM_BYTES_PER_BASE_ROLLUP](src/core/libraries/ConstantsGen.sol#L129) is too similar to [Constants.NOTE_HASHES_NUM_BYTES_PER_BASE_ROLLUP](src/core/libraries/ConstantsGen.sol#L122)
 
 src/core/libraries/ConstantsGen.sol#L129
 
 
- - [ ] ID-32
+ - [ ] ID-35
 Variable [Constants.L1_TO_L2_MESSAGE_LENGTH](src/core/libraries/ConstantsGen.sol#L109) is too similar to [Constants.L2_TO_L1_MESSAGE_LENGTH](src/core/libraries/ConstantsGen.sol#L110)
 
 src/core/libraries/ConstantsGen.sol#L109

--- a/l1-contracts/slither_output.md
+++ b/l1-contracts/slither_output.md
@@ -132,7 +132,7 @@ src/core/messagebridge/Inbox.sol#L122-L143
 Impact: Low
 Confidence: Medium
  - [ ] ID-12
-[NewInbox.constructor(address,uint256,bytes32)._rollup](src/core/messagebridge/NewInbox.sol#L40) lacks a zero-check on :
+[NewInbox.constructor(address,uint256)._rollup](src/core/messagebridge/NewInbox.sol#L40) lacks a zero-check on :
 		- [ROLLUP = _rollup](src/core/messagebridge/NewInbox.sol#L41)
 
 src/core/messagebridge/NewInbox.sol#L40
@@ -142,6 +142,16 @@ src/core/messagebridge/NewInbox.sol#L40
 Impact: Low
 Confidence: Medium
  - [ ] ID-13
+Reentrancy in [NewInbox.sendL2Message(DataStructures.L2Actor,bytes32,bytes32)](src/core/messagebridge/NewInbox.sol#L61-L98):
+	External calls:
+	- [nextIndex = currentTree.insertLeaf(leaf)](src/core/messagebridge/NewInbox.sol#L94)
+	Event emitted after the call(s):
+	- [LeafInserted(inProgress,nextIndex - 1,leaf)](src/core/messagebridge/NewInbox.sol#L95)
+
+src/core/messagebridge/NewInbox.sol#L61-L98
+
+
+ - [ ] ID-14
 Reentrancy in [Rollup.process(bytes,bytes32,bytes,bytes)](src/core/Rollup.sol#L53-L91):
 	External calls:
 	- [inbox.batchConsume(l1ToL2Msgs,msg.sender)](src/core/Rollup.sol#L85)
@@ -150,16 +160,6 @@ Reentrancy in [Rollup.process(bytes,bytes32,bytes,bytes)](src/core/Rollup.sol#L5
 	- [L2BlockProcessed(header.globalVariables.blockNumber)](src/core/Rollup.sol#L90)
 
 src/core/Rollup.sol#L53-L91
-
-
- - [ ] ID-14
-Reentrancy in [NewInbox.insert(DataStructures.L2Actor,bytes32,bytes32)](src/core/messagebridge/NewInbox.sol#L59-L96):
-	External calls:
-	- [nextIndex = currentTree.insertLeaf(leaf)](src/core/messagebridge/NewInbox.sol#L91)
-	Event emitted after the call(s):
-	- [LeafInserted(inProgress,nextIndex,leaf)](src/core/messagebridge/NewInbox.sol#L92)
-
-src/core/messagebridge/NewInbox.sol#L59-L96
 
 
 ## timestamp
@@ -201,34 +201,27 @@ src/core/messagebridge/Inbox.sol#L102-L113
 Impact: Low
 Confidence: Medium
  - [ ] ID-19
-The following public functions could be turned into external in [NewInbox](src/core/messagebridge/NewInbox.sol#L24-L120) contract:
-	[NewInbox.constructor(address,uint256,bytes32)](src/core/messagebridge/NewInbox.sol#L40-L49)
-
-src/core/messagebridge/NewInbox.sol#L24-L120
-
-
- - [ ] ID-20
 The following public functions could be turned into external in [FrontierMerkle](src/core/messagebridge/frontier_tree/Frontier.sol#L7-L91) contract:
 	[FrontierMerkle.constructor(uint256)](src/core/messagebridge/frontier_tree/Frontier.sol#L19-L27)
 
 src/core/messagebridge/frontier_tree/Frontier.sol#L7-L91
 
 
- - [ ] ID-21
+ - [ ] ID-20
 The following public functions could be turned into external in [Registry](src/core/messagebridge/Registry.sol#L22-L129) contract:
 	[Registry.constructor()](src/core/messagebridge/Registry.sol#L29-L33)
 
 src/core/messagebridge/Registry.sol#L22-L129
 
 
- - [ ] ID-22
+ - [ ] ID-21
 The following public functions could be turned into external in [Rollup](src/core/Rollup.sol#L27-L100) contract:
 	[Rollup.constructor(IRegistry,IAvailabilityOracle)](src/core/Rollup.sol#L39-L44)
 
 src/core/Rollup.sol#L27-L100
 
 
- - [ ] ID-23
+ - [ ] ID-22
 The following public functions could be turned into external in [Outbox](src/core/messagebridge/Outbox.sol#L21-L148) contract:
 	[Outbox.constructor(address)](src/core/messagebridge/Outbox.sol#L29-L31)
 	[Outbox.get(bytes32)](src/core/messagebridge/Outbox.sol#L77-L84)
@@ -237,12 +230,19 @@ The following public functions could be turned into external in [Outbox](src/cor
 src/core/messagebridge/Outbox.sol#L21-L148
 
 
- - [ ] ID-24
+ - [ ] ID-23
 The following public functions could be turned into external in [Inbox](src/core/messagebridge/Inbox.sol#L21-L231) contract:
 	[Inbox.constructor(address)](src/core/messagebridge/Inbox.sol#L30-L32)
 	[Inbox.contains(bytes32)](src/core/messagebridge/Inbox.sol#L174-L176)
 
 src/core/messagebridge/Inbox.sol#L21-L231
+
+
+ - [ ] ID-24
+The following public functions could be turned into external in [NewInbox](src/core/messagebridge/NewInbox.sol#L24-L127) contract:
+	[NewInbox.constructor(address,uint256)](src/core/messagebridge/NewInbox.sol#L40-L51)
+
+src/core/messagebridge/NewInbox.sol#L24-L127
 
 
 ## assembly
@@ -346,38 +346,38 @@ src/core/Rollup.sol#L37
 Impact: Optimization
 Confidence: High
  - [ ] ID-38
+In a function [NewInbox.sendL2Message(DataStructures.L2Actor,bytes32,bytes32)](src/core/messagebridge/NewInbox.sol#L61-L98) variable [NewInbox.inProgress](src/core/messagebridge/NewInbox.sol#L34) is read multiple times
+
+src/core/messagebridge/NewInbox.sol#L61-L98
+
+
+ - [ ] ID-39
 In a function [FrontierMerkle.root()](src/core/messagebridge/frontier_tree/Frontier.sol#L41-L74) variable [FrontierMerkle.HEIGHT](src/core/messagebridge/frontier_tree/Frontier.sol#L8) is read multiple times
 
 src/core/messagebridge/frontier_tree/Frontier.sol#L41-L74
 
 
- - [ ] ID-39
-In a function [NewInbox.consume()](src/core/messagebridge/NewInbox.sol#L103-L119) variable [NewInbox.toInclude](src/core/messagebridge/NewInbox.sol#L33) is read multiple times
-
-src/core/messagebridge/NewInbox.sol#L103-L119
-
-
  - [ ] ID-40
-In a function [NewInbox.consume()](src/core/messagebridge/NewInbox.sol#L103-L119) variable [NewInbox.inProgress](src/core/messagebridge/NewInbox.sol#L34) is read multiple times
+In a function [NewInbox.consume()](src/core/messagebridge/NewInbox.sol#L107-L126) variable [NewInbox.toInclude](src/core/messagebridge/NewInbox.sol#L33) is read multiple times
 
-src/core/messagebridge/NewInbox.sol#L103-L119
+src/core/messagebridge/NewInbox.sol#L107-L126
 
 
  - [ ] ID-41
+In a function [NewInbox.consume()](src/core/messagebridge/NewInbox.sol#L107-L126) variable [NewInbox.inProgress](src/core/messagebridge/NewInbox.sol#L34) is read multiple times
+
+src/core/messagebridge/NewInbox.sol#L107-L126
+
+
+ - [ ] ID-42
 In a function [FrontierMerkle.insertLeaf(bytes32)](src/core/messagebridge/frontier_tree/Frontier.sol#L29-L39) variable [FrontierMerkle.nextIndex](src/core/messagebridge/frontier_tree/Frontier.sol#L11) is read multiple times
 
 src/core/messagebridge/frontier_tree/Frontier.sol#L29-L39
 
 
- - [ ] ID-42
+ - [ ] ID-43
 In a function [FrontierMerkle.root()](src/core/messagebridge/frontier_tree/Frontier.sol#L41-L74) variable [FrontierMerkle.frontier](src/core/messagebridge/frontier_tree/Frontier.sol#L13) is read multiple times
 
 src/core/messagebridge/frontier_tree/Frontier.sol#L41-L74
-
-
- - [ ] ID-43
-In a function [NewInbox.insert(DataStructures.L2Actor,bytes32,bytes32)](src/core/messagebridge/NewInbox.sol#L59-L96) variable [NewInbox.inProgress](src/core/messagebridge/NewInbox.sol#L34) is read multiple times
-
-src/core/messagebridge/NewInbox.sol#L59-L96
 
 

--- a/l1-contracts/slither_output.md
+++ b/l1-contracts/slither_output.md
@@ -132,23 +132,23 @@ src/core/messagebridge/Inbox.sol#L122-L143
 Impact: Low
 Confidence: Medium
  - [ ] ID-12
-[NewInbox.constructor(address,uint256)._rollup](src/core/messagebridge/NewInbox.sol#L40) lacks a zero-check on :
-		- [ROLLUP = _rollup](src/core/messagebridge/NewInbox.sol#L41)
+[NewInbox.constructor(address,uint256)._rollup](src/core/messagebridge/NewInbox.sol#L39) lacks a zero-check on :
+		- [ROLLUP = _rollup](src/core/messagebridge/NewInbox.sol#L40)
 
-src/core/messagebridge/NewInbox.sol#L40
+src/core/messagebridge/NewInbox.sol#L39
 
 
 ## reentrancy-events
 Impact: Low
 Confidence: Medium
  - [ ] ID-13
-Reentrancy in [NewInbox.sendL2Message(DataStructures.L2Actor,bytes32,bytes32)](src/core/messagebridge/NewInbox.sol#L61-L98):
+Reentrancy in [NewInbox.sendL2Message(DataStructures.L2Actor,bytes32,bytes32)](src/core/messagebridge/NewInbox.sol#L60-L97):
 	External calls:
-	- [nextIndex = currentTree.insertLeaf(leaf)](src/core/messagebridge/NewInbox.sol#L94)
+	- [nextIndex = currentTree.insertLeaf(leaf)](src/core/messagebridge/NewInbox.sol#L93)
 	Event emitted after the call(s):
-	- [LeafInserted(inProgress,nextIndex - 1,leaf)](src/core/messagebridge/NewInbox.sol#L95)
+	- [LeafInserted(inProgress,nextIndex - 1,leaf)](src/core/messagebridge/NewInbox.sol#L94)
 
-src/core/messagebridge/NewInbox.sol#L61-L98
+src/core/messagebridge/NewInbox.sol#L60-L97
 
 
  - [ ] ID-14
@@ -239,10 +239,10 @@ src/core/messagebridge/Inbox.sol#L21-L231
 
 
  - [ ] ID-24
-The following public functions could be turned into external in [NewInbox](src/core/messagebridge/NewInbox.sol#L24-L127) contract:
-	[NewInbox.constructor(address,uint256)](src/core/messagebridge/NewInbox.sol#L40-L51)
+The following public functions could be turned into external in [NewInbox](src/core/messagebridge/NewInbox.sol#L25-L126) contract:
+	[NewInbox.constructor(address,uint256)](src/core/messagebridge/NewInbox.sol#L39-L50)
 
-src/core/messagebridge/NewInbox.sol#L24-L127
+src/core/messagebridge/NewInbox.sol#L25-L126
 
 
 ## assembly
@@ -346,9 +346,9 @@ src/core/Rollup.sol#L37
 Impact: Optimization
 Confidence: High
  - [ ] ID-38
-In a function [NewInbox.sendL2Message(DataStructures.L2Actor,bytes32,bytes32)](src/core/messagebridge/NewInbox.sol#L61-L98) variable [NewInbox.inProgress](src/core/messagebridge/NewInbox.sol#L34) is read multiple times
+In a function [NewInbox.sendL2Message(DataStructures.L2Actor,bytes32,bytes32)](src/core/messagebridge/NewInbox.sol#L60-L97) variable [NewInbox.inProgress](src/core/messagebridge/NewInbox.sol#L35) is read multiple times
 
-src/core/messagebridge/NewInbox.sol#L61-L98
+src/core/messagebridge/NewInbox.sol#L60-L97
 
 
  - [ ] ID-39
@@ -358,15 +358,15 @@ src/core/messagebridge/frontier_tree/Frontier.sol#L41-L74
 
 
  - [ ] ID-40
-In a function [NewInbox.consume()](src/core/messagebridge/NewInbox.sol#L107-L126) variable [NewInbox.inProgress](src/core/messagebridge/NewInbox.sol#L34) is read multiple times
+In a function [NewInbox.consume()](src/core/messagebridge/NewInbox.sol#L106-L125) variable [NewInbox.inProgress](src/core/messagebridge/NewInbox.sol#L35) is read multiple times
 
-src/core/messagebridge/NewInbox.sol#L107-L126
+src/core/messagebridge/NewInbox.sol#L106-L125
 
 
  - [ ] ID-41
-In a function [NewInbox.consume()](src/core/messagebridge/NewInbox.sol#L107-L126) variable [NewInbox.toConsume](src/core/messagebridge/NewInbox.sol#L33) is read multiple times
+In a function [NewInbox.consume()](src/core/messagebridge/NewInbox.sol#L106-L125) variable [NewInbox.toConsume](src/core/messagebridge/NewInbox.sol#L34) is read multiple times
 
-src/core/messagebridge/NewInbox.sol#L107-L126
+src/core/messagebridge/NewInbox.sol#L106-L125
 
 
  - [ ] ID-42

--- a/l1-contracts/slither_output.md
+++ b/l1-contracts/slither_output.md
@@ -358,13 +358,13 @@ src/core/messagebridge/frontier_tree/Frontier.sol#L41-L74
 
 
  - [ ] ID-40
-In a function [NewInbox.consume()](src/core/messagebridge/NewInbox.sol#L107-L126) variable [NewInbox.toInclude](src/core/messagebridge/NewInbox.sol#L33) is read multiple times
+In a function [NewInbox.consume()](src/core/messagebridge/NewInbox.sol#L107-L126) variable [NewInbox.inProgress](src/core/messagebridge/NewInbox.sol#L34) is read multiple times
 
 src/core/messagebridge/NewInbox.sol#L107-L126
 
 
  - [ ] ID-41
-In a function [NewInbox.consume()](src/core/messagebridge/NewInbox.sol#L107-L126) variable [NewInbox.inProgress](src/core/messagebridge/NewInbox.sol#L34) is read multiple times
+In a function [NewInbox.consume()](src/core/messagebridge/NewInbox.sol#L107-L126) variable [NewInbox.toConsume](src/core/messagebridge/NewInbox.sol#L33) is read multiple times
 
 src/core/messagebridge/NewInbox.sol#L107-L126
 

--- a/l1-contracts/slither_output.md
+++ b/l1-contracts/slither_output.md
@@ -13,7 +13,7 @@ Summary
  - [low-level-calls](#low-level-calls) (1 results) (Informational)
  - [similar-names](#similar-names) (3 results) (Informational)
  - [constable-states](#constable-states) (1 results) (Optimization)
- - [pess-multiple-storage-read](#pess-multiple-storage-read) (6 results) (Optimization)
+ - [pess-multiple-storage-read](#pess-multiple-storage-read) (5 results) (Optimization)
 ## pess-unprotected-setter
 Impact: High
 Confidence: Medium
@@ -128,7 +128,7 @@ Dubious typecast in [Inbox.batchConsume(bytes32[],address)](src/core/messagebrid
 src/core/messagebridge/Inbox.sol#L122-L143
 
 
-## reentrancy-events
+## missing-zero-check
 Impact: Low
 Confidence: Medium
  - [ ] ID-12
@@ -144,9 +144,9 @@ Confidence: Medium
  - [ ] ID-13
 Reentrancy in [NewInbox.sendL2Message(DataStructures.L2Actor,bytes32,bytes32)](src/core/messagebridge/NewInbox.sol#L60-L97):
 	External calls:
-	- [nextIndex = currentTree.insertLeaf(leaf)](src/core/messagebridge/NewInbox.sol#L93)
+	- [index = currentTree.insertLeaf(leaf)](src/core/messagebridge/NewInbox.sol#L93)
 	Event emitted after the call(s):
-	- [LeafInserted(inProgress,nextIndex - 1,leaf)](src/core/messagebridge/NewInbox.sol#L94)
+	- [LeafInserted(inProgress,index,leaf)](src/core/messagebridge/NewInbox.sol#L94)
 
 src/core/messagebridge/NewInbox.sol#L60-L97
 
@@ -201,10 +201,10 @@ src/core/messagebridge/Inbox.sol#L102-L113
 Impact: Low
 Confidence: Medium
  - [ ] ID-19
-The following public functions could be turned into external in [FrontierMerkle](src/core/messagebridge/frontier_tree/Frontier.sol#L7-L91) contract:
+The following public functions could be turned into external in [FrontierMerkle](src/core/messagebridge/frontier_tree/Frontier.sol#L7-L90) contract:
 	[FrontierMerkle.constructor(uint256)](src/core/messagebridge/frontier_tree/Frontier.sol#L19-L27)
 
-src/core/messagebridge/frontier_tree/Frontier.sol#L7-L91
+src/core/messagebridge/frontier_tree/Frontier.sol#L7-L90
 
 
  - [ ] ID-20
@@ -248,7 +248,7 @@ src/core/messagebridge/NewInbox.sol#L25-L126
 ## assembly
 Impact: Informational
 Confidence: High
- - [ ] ID-22
+ - [ ] ID-25
 [MessagesDecoder.decode(bytes)](src/core/libraries/decoders/MessagesDecoder.sol#L60-L150) uses assembly
 	- [INLINE ASM](src/core/libraries/decoders/MessagesDecoder.sol#L79-L81)
 	- [INLINE ASM](src/core/libraries/decoders/MessagesDecoder.sol#L112-L118)
@@ -256,7 +256,7 @@ Confidence: High
 src/core/libraries/decoders/MessagesDecoder.sol#L60-L150
 
 
- - [ ] ID-23
+ - [ ] ID-26
 [TxsDecoder.computeRoot(bytes32[])](src/core/libraries/decoders/TxsDecoder.sol#L291-L310) uses assembly
 	- [INLINE ASM](src/core/libraries/decoders/TxsDecoder.sol#L298-L300)
 
@@ -352,9 +352,9 @@ src/core/messagebridge/NewInbox.sol#L60-L97
 
 
  - [ ] ID-39
-In a function [FrontierMerkle.root()](src/core/messagebridge/frontier_tree/Frontier.sol#L41-L74) variable [FrontierMerkle.HEIGHT](src/core/messagebridge/frontier_tree/Frontier.sol#L8) is read multiple times
+In a function [FrontierMerkle.root()](src/core/messagebridge/frontier_tree/Frontier.sol#L40-L73) variable [FrontierMerkle.HEIGHT](src/core/messagebridge/frontier_tree/Frontier.sol#L8) is read multiple times
 
-src/core/messagebridge/frontier_tree/Frontier.sol#L41-L74
+src/core/messagebridge/frontier_tree/Frontier.sol#L40-L73
 
 
  - [ ] ID-40
@@ -370,14 +370,8 @@ src/core/messagebridge/NewInbox.sol#L106-L125
 
 
  - [ ] ID-42
-In a function [FrontierMerkle.insertLeaf(bytes32)](src/core/messagebridge/frontier_tree/Frontier.sol#L29-L39) variable [FrontierMerkle.nextIndex](src/core/messagebridge/frontier_tree/Frontier.sol#L11) is read multiple times
+In a function [FrontierMerkle.root()](src/core/messagebridge/frontier_tree/Frontier.sol#L40-L73) variable [FrontierMerkle.frontier](src/core/messagebridge/frontier_tree/Frontier.sol#L13) is read multiple times
 
-src/core/messagebridge/frontier_tree/Frontier.sol#L29-L39
-
-
- - [ ] ID-43
-In a function [FrontierMerkle.root()](src/core/messagebridge/frontier_tree/Frontier.sol#L41-L74) variable [FrontierMerkle.frontier](src/core/messagebridge/frontier_tree/Frontier.sol#L13) is read multiple times
-
-src/core/messagebridge/frontier_tree/Frontier.sol#L41-L74
+src/core/messagebridge/frontier_tree/Frontier.sol#L40-L73
 
 

--- a/l1-contracts/slither_output.md
+++ b/l1-contracts/slither_output.md
@@ -3,16 +3,17 @@ Summary
  - [uninitialized-local](#uninitialized-local) (2 results) (Medium)
  - [unused-return](#unused-return) (1 results) (Medium)
  - [pess-dubious-typecast](#pess-dubious-typecast) (8 results) (Medium)
- - [reentrancy-events](#reentrancy-events) (1 results) (Low)
+ - [missing-zero-check](#missing-zero-check) (1 results) (Low)
+ - [reentrancy-events](#reentrancy-events) (2 results) (Low)
  - [timestamp](#timestamp) (4 results) (Low)
- - [pess-public-vs-external](#pess-public-vs-external) (5 results) (Low)
+ - [pess-public-vs-external](#pess-public-vs-external) (6 results) (Low)
  - [assembly](#assembly) (2 results) (Informational)
  - [dead-code](#dead-code) (5 results) (Informational)
  - [solc-version](#solc-version) (1 results) (Informational)
  - [low-level-calls](#low-level-calls) (1 results) (Informational)
  - [similar-names](#similar-names) (3 results) (Informational)
  - [constable-states](#constable-states) (1 results) (Optimization)
- - [pess-multiple-storage-read](#pess-multiple-storage-read) (2 results) (Optimization)
+ - [pess-multiple-storage-read](#pess-multiple-storage-read) (6 results) (Optimization)
 ## pess-unprotected-setter
 Impact: High
 Confidence: Medium
@@ -131,6 +132,16 @@ src/core/messagebridge/Inbox.sol#L122-L143
 Impact: Low
 Confidence: Medium
  - [ ] ID-12
+[NewInbox.constructor(address,uint256,bytes32)._rollup](src/core/messagebridge/NewInbox.sol#L40) lacks a zero-check on :
+		- [ROLLUP = _rollup](src/core/messagebridge/NewInbox.sol#L41)
+
+src/core/messagebridge/NewInbox.sol#L40
+
+
+## reentrancy-events
+Impact: Low
+Confidence: Medium
+ - [ ] ID-13
 Reentrancy in [Rollup.process(bytes,bytes32,bytes,bytes)](src/core/Rollup.sol#L53-L91):
 	External calls:
 	- [inbox.batchConsume(l1ToL2Msgs,msg.sender)](src/core/Rollup.sol#L85)
@@ -141,10 +152,20 @@ Reentrancy in [Rollup.process(bytes,bytes32,bytes,bytes)](src/core/Rollup.sol#L5
 src/core/Rollup.sol#L53-L91
 
 
+ - [ ] ID-14
+Reentrancy in [NewInbox.insert(DataStructures.L2Actor,bytes32,bytes32)](src/core/messagebridge/NewInbox.sol#L59-L96):
+	External calls:
+	- [nextIndex = currentTree.insertLeaf(leaf)](src/core/messagebridge/NewInbox.sol#L91)
+	Event emitted after the call(s):
+	- [LeafInserted(inProgress,nextIndex,leaf)](src/core/messagebridge/NewInbox.sol#L92)
+
+src/core/messagebridge/NewInbox.sol#L59-L96
+
+
 ## timestamp
 Impact: Low
 Confidence: Medium
- - [ ] ID-13
+ - [ ] ID-15
 [Inbox.batchConsume(bytes32[],address)](src/core/messagebridge/Inbox.sol#L122-L143) uses timestamp for comparisons
 	Dangerous comparisons:
 	- [block.timestamp > entry.deadline](src/core/messagebridge/Inbox.sol#L136)
@@ -152,7 +173,7 @@ Confidence: Medium
 src/core/messagebridge/Inbox.sol#L122-L143
 
 
- - [ ] ID-14
+ - [ ] ID-16
 [HeaderLib.validate(HeaderLib.Header,uint256,uint256,bytes32)](src/core/libraries/HeaderLib.sol#L108-L138) uses timestamp for comparisons
 	Dangerous comparisons:
 	- [_header.globalVariables.timestamp > block.timestamp](src/core/libraries/HeaderLib.sol#L122)
@@ -160,7 +181,7 @@ src/core/messagebridge/Inbox.sol#L122-L143
 src/core/libraries/HeaderLib.sol#L108-L138
 
 
- - [ ] ID-15
+ - [ ] ID-17
 [Inbox.sendL2Message(DataStructures.L2Actor,uint32,bytes32,bytes32)](src/core/messagebridge/Inbox.sol#L45-L91) uses timestamp for comparisons
 	Dangerous comparisons:
 	- [_deadline <= block.timestamp](src/core/messagebridge/Inbox.sol#L54)
@@ -168,7 +189,7 @@ src/core/libraries/HeaderLib.sol#L108-L138
 src/core/messagebridge/Inbox.sol#L45-L91
 
 
- - [ ] ID-16
+ - [ ] ID-18
 [Inbox.cancelL2Message(DataStructures.L1ToL2Msg,address)](src/core/messagebridge/Inbox.sol#L102-L113) uses timestamp for comparisons
 	Dangerous comparisons:
 	- [block.timestamp <= _message.deadline](src/core/messagebridge/Inbox.sol#L108)
@@ -179,28 +200,35 @@ src/core/messagebridge/Inbox.sol#L102-L113
 ## pess-public-vs-external
 Impact: Low
 Confidence: Medium
- - [ ] ID-17
-The following public functions could be turned into external in [FrontierMerkle](src/core/messagebridge/frontier_tree/Frontier.sol#L7-L85) contract:
+ - [ ] ID-19
+The following public functions could be turned into external in [NewInbox](src/core/messagebridge/NewInbox.sol#L24-L120) contract:
+	[NewInbox.constructor(address,uint256,bytes32)](src/core/messagebridge/NewInbox.sol#L40-L49)
+
+src/core/messagebridge/NewInbox.sol#L24-L120
+
+
+ - [ ] ID-20
+The following public functions could be turned into external in [FrontierMerkle](src/core/messagebridge/frontier_tree/Frontier.sol#L7-L91) contract:
 	[FrontierMerkle.constructor(uint256)](src/core/messagebridge/frontier_tree/Frontier.sol#L19-L27)
 
-src/core/messagebridge/frontier_tree/Frontier.sol#L7-L85
+src/core/messagebridge/frontier_tree/Frontier.sol#L7-L91
 
 
- - [ ] ID-18
+ - [ ] ID-21
 The following public functions could be turned into external in [Registry](src/core/messagebridge/Registry.sol#L22-L129) contract:
 	[Registry.constructor()](src/core/messagebridge/Registry.sol#L29-L33)
 
 src/core/messagebridge/Registry.sol#L22-L129
 
 
- - [ ] ID-19
+ - [ ] ID-22
 The following public functions could be turned into external in [Rollup](src/core/Rollup.sol#L27-L100) contract:
 	[Rollup.constructor(IRegistry,IAvailabilityOracle)](src/core/Rollup.sol#L39-L44)
 
 src/core/Rollup.sol#L27-L100
 
 
- - [ ] ID-20
+ - [ ] ID-23
 The following public functions could be turned into external in [Outbox](src/core/messagebridge/Outbox.sol#L21-L148) contract:
 	[Outbox.constructor(address)](src/core/messagebridge/Outbox.sol#L29-L31)
 	[Outbox.get(bytes32)](src/core/messagebridge/Outbox.sol#L77-L84)
@@ -209,7 +237,7 @@ The following public functions could be turned into external in [Outbox](src/cor
 src/core/messagebridge/Outbox.sol#L21-L148
 
 
- - [ ] ID-21
+ - [ ] ID-24
 The following public functions could be turned into external in [Inbox](src/core/messagebridge/Inbox.sol#L21-L231) contract:
 	[Inbox.constructor(address)](src/core/messagebridge/Inbox.sol#L30-L32)
 	[Inbox.contains(bytes32)](src/core/messagebridge/Inbox.sol#L174-L176)
@@ -238,31 +266,31 @@ src/core/libraries/decoders/TxsDecoder.sol#L291-L310
 ## dead-code
 Impact: Informational
 Confidence: Medium
- - [ ] ID-24
+ - [ ] ID-27
 [Inbox._errIncompatibleEntryArguments(bytes32,uint64,uint64,uint32,uint32,uint32,uint32)](src/core/messagebridge/Inbox.sol#L212-L230) is never used and should be removed
 
 src/core/messagebridge/Inbox.sol#L212-L230
 
 
- - [ ] ID-25
+ - [ ] ID-28
 [Outbox._errNothingToConsume(bytes32)](src/core/messagebridge/Outbox.sol#L114-L116) is never used and should be removed
 
 src/core/messagebridge/Outbox.sol#L114-L116
 
 
- - [ ] ID-26
+ - [ ] ID-29
 [Hash.sha256ToField(bytes32)](src/core/libraries/Hash.sol#L59-L61) is never used and should be removed
 
 src/core/libraries/Hash.sol#L59-L61
 
 
- - [ ] ID-27
+ - [ ] ID-30
 [Inbox._errNothingToConsume(bytes32)](src/core/messagebridge/Inbox.sol#L197-L199) is never used and should be removed
 
 src/core/messagebridge/Inbox.sol#L197-L199
 
 
- - [ ] ID-28
+ - [ ] ID-31
 [Outbox._errIncompatibleEntryArguments(bytes32,uint64,uint64,uint32,uint32,uint32,uint32)](src/core/messagebridge/Outbox.sol#L129-L147) is never used and should be removed
 
 src/core/messagebridge/Outbox.sol#L129-L147
@@ -271,13 +299,13 @@ src/core/messagebridge/Outbox.sol#L129-L147
 ## solc-version
 Impact: Informational
 Confidence: High
- - [ ] ID-29
+ - [ ] ID-32
 solc-0.8.21 is not recommended for deployment
 
 ## low-level-calls
 Impact: Informational
 Confidence: High
- - [ ] ID-30
+ - [ ] ID-33
 Low level call in [Inbox.withdrawFees()](src/core/messagebridge/Inbox.sol#L148-L153):
 	- [(success) = msg.sender.call{value: balance}()](src/core/messagebridge/Inbox.sol#L151)
 
@@ -299,7 +327,7 @@ Variable [Constants.L1_TO_L2_MESSAGE_LENGTH](src/core/libraries/ConstantsGen.sol
 src/core/libraries/ConstantsGen.sol#L109
 
 
- - [ ] ID-33
+ - [ ] ID-36
 Variable [Rollup.AVAILABILITY_ORACLE](src/core/Rollup.sol#L30) is too similar to [Rollup.constructor(IRegistry,IAvailabilityOracle)._availabilityOracle](src/core/Rollup.sol#L39)
 
 src/core/Rollup.sol#L30
@@ -308,7 +336,7 @@ src/core/Rollup.sol#L30
 ## constable-states
 Impact: Optimization
 Confidence: High
- - [ ] ID-34
+ - [ ] ID-37
 [Rollup.lastWarpedBlockTs](src/core/Rollup.sol#L37) should be constant 
 
 src/core/Rollup.sol#L37
@@ -317,15 +345,39 @@ src/core/Rollup.sol#L37
 ## pess-multiple-storage-read
 Impact: Optimization
 Confidence: High
- - [ ] ID-35
-In a function [FrontierMerkle.root()](src/core/messagebridge/frontier_tree/Frontier.sol#L39-L72) variable [FrontierMerkle.DEPTH](src/core/messagebridge/frontier_tree/Frontier.sol#L8) is read multiple times
+ - [ ] ID-38
+In a function [FrontierMerkle.root()](src/core/messagebridge/frontier_tree/Frontier.sol#L41-L74) variable [FrontierMerkle.HEIGHT](src/core/messagebridge/frontier_tree/Frontier.sol#L8) is read multiple times
 
-src/core/messagebridge/frontier_tree/Frontier.sol#L39-L72
+src/core/messagebridge/frontier_tree/Frontier.sol#L41-L74
 
 
- - [ ] ID-36
-In a function [FrontierMerkle.root()](src/core/messagebridge/frontier_tree/Frontier.sol#L39-L72) variable [FrontierMerkle.frontier](src/core/messagebridge/frontier_tree/Frontier.sol#L13) is read multiple times
+ - [ ] ID-39
+In a function [NewInbox.consume()](src/core/messagebridge/NewInbox.sol#L103-L119) variable [NewInbox.toInclude](src/core/messagebridge/NewInbox.sol#L33) is read multiple times
 
-src/core/messagebridge/frontier_tree/Frontier.sol#L39-L72
+src/core/messagebridge/NewInbox.sol#L103-L119
+
+
+ - [ ] ID-40
+In a function [NewInbox.consume()](src/core/messagebridge/NewInbox.sol#L103-L119) variable [NewInbox.inProgress](src/core/messagebridge/NewInbox.sol#L34) is read multiple times
+
+src/core/messagebridge/NewInbox.sol#L103-L119
+
+
+ - [ ] ID-41
+In a function [FrontierMerkle.insertLeaf(bytes32)](src/core/messagebridge/frontier_tree/Frontier.sol#L29-L39) variable [FrontierMerkle.nextIndex](src/core/messagebridge/frontier_tree/Frontier.sol#L11) is read multiple times
+
+src/core/messagebridge/frontier_tree/Frontier.sol#L29-L39
+
+
+ - [ ] ID-42
+In a function [FrontierMerkle.root()](src/core/messagebridge/frontier_tree/Frontier.sol#L41-L74) variable [FrontierMerkle.frontier](src/core/messagebridge/frontier_tree/Frontier.sol#L13) is read multiple times
+
+src/core/messagebridge/frontier_tree/Frontier.sol#L41-L74
+
+
+ - [ ] ID-43
+In a function [NewInbox.insert(DataStructures.L2Actor,bytes32,bytes32)](src/core/messagebridge/NewInbox.sol#L59-L96) variable [NewInbox.inProgress](src/core/messagebridge/NewInbox.sol#L34) is read multiple times
+
+src/core/messagebridge/NewInbox.sol#L59-L96
 
 

--- a/l1-contracts/src/core/interfaces/messagebridge/IFrontier.sol
+++ b/l1-contracts/src/core/interfaces/messagebridge/IFrontier.sol
@@ -3,9 +3,22 @@
 pragma solidity >=0.8.18;
 
 interface IFrontier {
+  /**
+   * @notice Inserts a new leaf into the frontier tree and returns its index
+   * @param _leaf - The leaf to insert
+   * @return The index of the leaf in the tree
+   */
   function insertLeaf(bytes32 _leaf) external returns (uint256);
 
+  /**
+   * @notice Returns the root of the frontier tree
+   * @return The root of the tree
+   */
   function root() external view returns (bytes32);
 
+  /**
+   * @notice Returns whether the tree is full
+   * @return Whether the tree is full
+   */
   function isFull() external view returns (bool);
 }

--- a/l1-contracts/src/core/interfaces/messagebridge/IFrontier.sol
+++ b/l1-contracts/src/core/interfaces/messagebridge/IFrontier.sol
@@ -3,7 +3,9 @@
 pragma solidity >=0.8.18;
 
 interface IFrontier {
-  function insertLeaf(bytes32 _leaf) external;
+  function insertLeaf(bytes32 _leaf) external returns (uint256);
 
   function root() external view returns (bytes32);
+
+  function isFull() external view returns (bool);
 }

--- a/l1-contracts/src/core/interfaces/messagebridge/INewInbox.sol
+++ b/l1-contracts/src/core/interfaces/messagebridge/INewInbox.sol
@@ -13,7 +13,6 @@ import {DataStructures} from "../../libraries/DataStructures.sol";
 interface INewInbox {
   event LeafInserted(uint256 indexed blockNumber, uint256 index, bytes32 value);
 
-  // docs:start:send_l1_to_l2_message
   /**
    * @notice Inserts a new message into the Inbox
    * @dev Emits `LeafInserted` with data for easy access by the sequencer
@@ -27,9 +26,7 @@ interface INewInbox {
     bytes32 _content,
     bytes32 _secretHash
   ) external returns (bytes32);
-  // docs:end:send_l1_to_l2_message
 
-  // docs:start:inbox_batch_consume
   /**
    * @notice Consumes the current tree, and starts a new one if needed
    * @dev Only callable by the rollup contract
@@ -38,5 +35,4 @@ interface INewInbox {
    * @return The root of the consumed tree
    */
   function consume() external returns (bytes32);
-  // docs:end:inbox_batch_consume
 }

--- a/l1-contracts/src/core/interfaces/messagebridge/INewInbox.sol
+++ b/l1-contracts/src/core/interfaces/messagebridge/INewInbox.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 Aztec Labs.
+pragma solidity >=0.8.18;
+
+import {DataStructures} from "../../libraries/DataStructures.sol";
+
+/**
+ * @title Inbox
+ * @author Aztec Labs
+ * @notice Lives on L1 and is used to pass messages into the rollup, e.g., L1 -> L2 messages.
+ */
+// TODO: rename to IInbox once all the pieces of the new message model are in place.
+interface INewInbox {
+  event LeafInserted(uint256 indexed blockNumber, uint256 index, bytes32 value);
+
+  // docs:start:send_l1_to_l2_message
+  /**
+   * @notice Inserts a new message into the Inbox
+   * @dev Emits `LeafInserted` with data for easy access by the sequencer
+   * @param _recipient - The recipient of the message
+   * @param _content - The content of the message (application specific)
+   * @param _secretHash - The secret hash of the message (make it possible to hide when a specific message is consumed on L2)
+   * @return The key of the message in the set
+   */
+  function sendL2Message(
+    DataStructures.L2Actor memory _recipient,
+    bytes32 _content,
+    bytes32 _secretHash
+  ) external returns (bytes32);
+  // docs:end:send_l1_to_l2_message
+
+  // docs:start:inbox_batch_consume
+  /**
+   * @notice Consumes the current tree, and starts a new one if needed
+   * @dev Only callable by the rollup contract
+   * @dev In the first iteration we return empty tree root because first block's messages tree is always
+   * empty because there has to be a 1 block lag to prevent sequencer DOS attacks
+   * @return The root of the consumed tree
+   */
+  function consume() external returns (bytes32);
+  // docs:end:inbox_batch_consume
+}

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 Aztec Labs.
+pragma solidity >=0.8.18;
+
+// Interfaces
+import {IInbox} from "../interfaces/messagebridge/IInbox.sol";
+import {IRegistry} from "../interfaces/messagebridge/IRegistry.sol";
+
+// Libraries
+import {Constants} from "../libraries/ConstantsGen.sol";
+import {DataStructures} from "../libraries/DataStructures.sol";
+import {Errors} from "../libraries/Errors.sol";
+import {Hash} from "../libraries/Hash.sol";
+import {MessageBox} from "../libraries/MessageBox.sol";
+
+/**
+ * @title Inbox
+ * @author Aztec Labs
+ * @notice Lives on L1 and is used to pass messages into the rollup, e.g., L1 -> L2 messages.
+ */
+// TODO: rename to Inbox once all the pieces of the new message model are in place.
+contract NewInbox {
+  IRegistry public immutable REGISTRY;
+
+  event LeafInserted(uint256 indexed treeNumber, uint256 indexed index, bytes32 value);
+
+  constructor(address _registry) {
+    REGISTRY = IRegistry(_registry);
+  }
+}

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -85,7 +85,7 @@ contract NewInbox {
       content: _content,
       secretHash: _secretHash,
       // TODO: nuke the following 2 values from the struct once the new message model is in place
-      deadline: 0,
+      deadline: 2 ** 32 - 1,
       fee: 0
     });
 

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -58,10 +58,11 @@ contract NewInbox {
    * @param _secretHash - The secret hash of the message (make it possible to hide when a specific message is consumed on L2)
    * @return The key of the message in the set
    */
-  function insert(DataStructures.L2Actor memory _recipient, bytes32 _content, bytes32 _secretHash)
-    external
-    returns (bytes32)
-  {
+  function sendL2Message(
+    DataStructures.L2Actor memory _recipient,
+    bytes32 _content,
+    bytes32 _secretHash
+  ) external returns (bytes32) {
     if (uint256(_recipient.actor) > Constants.MAX_FIELD_VALUE) {
       revert Errors.Inbox__ActorTooLarge(_recipient.actor);
     }

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -30,7 +30,7 @@ contract NewInbox {
   uint256 internal immutable SIZE;
   bytes32 internal immutable EMPTY_ROOT; // The root of an empty frontier tree
 
-  uint256 internal toInclude = 1;
+  uint256 internal toConsume = 1;
   uint256 internal inProgress = 2;
 
   mapping(uint256 blockNumber => IFrontier tree) internal trees;
@@ -110,17 +110,17 @@ contract NewInbox {
     }
 
     bytes32 root = EMPTY_ROOT;
-    if (toInclude > Constants.INITIAL_L2_BLOCK_NUM) {
-      root = trees[toInclude].root();
+    if (toConsume > Constants.INITIAL_L2_BLOCK_NUM) {
+      root = trees[toConsume].root();
     }
 
     // If we are "catching up" we skip the tree creation as it is already there
-    if (toInclude + 1 == inProgress) {
+    if (toConsume + 1 == inProgress) {
       inProgress += 1;
       trees[inProgress] = IFrontier(new FrontierMerkle(HEIGHT));
     }
 
-    toInclude += 1;
+    toConsume += 1;
 
     return root;
   }

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -35,7 +35,7 @@ contract NewInbox {
 
   mapping(uint256 treeNumber => IFrontier tree) public frontier;
 
-  event LeafInserted(uint256 indexed treeNumber, uint256 indexed index, bytes32 value);
+  event LeafInserted(uint256 treeNumber, uint256 index, bytes32 value);
 
   constructor(address _rollup, uint256 _height, bytes32 _zero) {
     ROLLUP = _rollup;
@@ -72,14 +72,16 @@ contract NewInbox {
       recipient: _recipient,
       content: _content,
       secretHash: _secretHash,
-      deadline: 0, // TODO: nuke this (there will no longer be fees for messages)
-      fee: 0 // TODO: nuke this (there will no longer be fees for messages)
+      // TODO: nuke the following 2 values from the struct once the new message model is in place
+      deadline: 0,
+      fee: 0
     });
 
     bytes32 leaf = message.sha256ToField();
     uint256 nextIndex = currentTree.insertLeaf(leaf);
     emit LeafInserted(inProgress, nextIndex, leaf);
 
+    // TODO: do we really need to return this?
     return leaf;
   }
 

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -52,18 +52,14 @@ contract NewInbox {
    * @notice Inserts an entry into the Inbox
    * @dev Will emit `LeafInserted` with data for easy access by the sequencer
    * @param _recipient - The recipient of the entry
-   * @param _deadline - The deadline to consume a message. Only after it, can a message be cancelled.
-   * it is uint32 to for slot packing of the Entry struct. Should work until Feb 2106.
    * @param _content - The content of the entry (application specific)
    * @param _secretHash - The secret hash of the entry (make it possible to hide when a specific entry is consumed on L2)
    * @return The key of the entry in the set
    */
-  function insert(
-    DataStructures.L2Actor memory _recipient,
-    uint32 _deadline,
-    bytes32 _content,
-    bytes32 _secretHash
-  ) external returns (bytes32) {
+  function insert(DataStructures.L2Actor memory _recipient, bytes32 _content, bytes32 _secretHash)
+    external
+    returns (bytes32)
+  {
     IFrontier currentTree = frontier[inProgress];
     if (currentTree.isFull()) {
       inProgress += 1;
@@ -76,7 +72,7 @@ contract NewInbox {
       recipient: _recipient,
       content: _content,
       secretHash: _secretHash,
-      deadline: _deadline,
+      deadline: 0, // TODO: nuke this (there will no longer be fees for messages)
       fee: 0 // TODO: nuke this (there will no longer be fees for messages)
     });
 

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -84,7 +84,7 @@ contract NewInbox is INewInbox {
       recipient: _recipient,
       content: _content,
       secretHash: _secretHash,
-      // TODO: nuke the following 2 values from the struct once the new message model is in place
+      // TODO(#4833): nuke the following 2 values from the struct once the new message model is in place
       deadline: type(uint32).max,
       fee: 0
     });

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -31,7 +31,7 @@ contract NewInbox is INewInbox {
   uint256 internal immutable SIZE;
   bytes32 internal immutable EMPTY_ROOT; // The root of an empty frontier tree
 
-  uint256 internal toConsume = 1;
+  uint256 internal toConsume = Constants.INITIAL_L2_BLOCK_NUM;
   uint256 internal inProgress = 2;
 
   mapping(uint256 blockNumber => IFrontier tree) internal trees;

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -90,8 +90,8 @@ contract NewInbox is INewInbox {
     });
 
     bytes32 leaf = message.sha256ToField();
-    uint256 nextIndex = currentTree.insertLeaf(leaf);
-    emit LeafInserted(inProgress, nextIndex - 1, leaf);
+    uint256 index = currentTree.insertLeaf(leaf);
+    emit LeafInserted(inProgress, index, leaf);
 
     return leaf;
   }

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -114,7 +114,7 @@ contract NewInbox {
     }
 
     // If we are "catching up" we skip the tree creation as it is already there
-    if (toInclude == inProgress) {
+    if (toInclude + 1 == inProgress) {
       inProgress += 1;
       frontier[inProgress] = IFrontier(new FrontierMerkle(HEIGHT));
     }

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -22,9 +22,76 @@ import {MessageBox} from "../libraries/MessageBox.sol";
 contract NewInbox {
   IRegistry public immutable REGISTRY;
 
+  uint256 public immutable HEIGHT;
+  uint256 public immutable SIZE;
+  bytes32 private immutable ZERO;
+
+  uint256 private toInclude = 0;
+  uint256 private inProgress = 1;
+
+  mapping(uint256 treeNumber => address tree) public frontier;
+
   event LeafInserted(uint256 indexed treeNumber, uint256 indexed index, bytes32 value);
 
-  constructor(address _registry) {
+  constructor(address _registry, uint256 _height, bytes32 _zero) {
     REGISTRY = IRegistry(_registry);
+
+    HEIGHT = _height;
+    SIZE = 2**_height;
+    ZERO = _zero;
   }
 }
+
+// class Inbox:
+//   STATE_TRANSITIONER: immutable(address)
+//   ZERO: immutable(bytes32)
+
+//   HEIGHT: immutable(uint256)
+//   SIZE: immutable(uint256)
+
+//   trees: HashMap[uint256, FrontierTree]
+
+//   to_include: uint256 = 0
+//   in_progress: uint256 = 1
+
+//   def __init__(self, _height: uint256, _zero: bytes32, _state_transitioner: address):
+//     self.HEIGHT = _height
+//     self.SIZE = 2**_height
+//     self.ZERO = _zero
+//     self.STATE_TRANSITIONER = _state_transitioner
+
+//     self.trees[1] = FrontierTree(self.HEIGHT)
+ 
+//   def insert(self, message: L1ToL2Message) -> bytes32:
+//     '''
+//     Insert into the next FrontierTree. If the tree is full, creates a new one
+//     '''
+//     if self.trees[self.in_progress].next_index == 2**self.HEIGHT:
+//       self.in_progress += 1
+//       self.trees[self.in_progress] = FrontierTree(self.HEIGHT)
+
+//     message.sender.actor = msg.sender
+//     message.sender.chain_id = block.chainid
+
+//     leaf = message.hash_to_field()
+//     self.trees[self.in_progress].insert(leaf)
+//     return leaf
+
+//   def consume(self) -> bytes32:
+//     '''
+//     Consumes the current tree, and starts a new one if needed
+//     '''
+//     assert msg.sender == self.STATE_TRANSITIONER
+
+//     root = self.ZERO
+//     if self.to_include > 0:
+//       root = self.trees[self.to_include].root()
+
+//     # If we are "catching up" we can skip the creation as it is already there
+//     if self.to_include + 1 == self.in_progress:
+//       self.in_progress += 1
+//       self.trees[self.in_progress] = FrontierTree(self.HEIGHT)
+
+//     self.to_include += 1
+
+//     return root

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -91,7 +91,7 @@ contract NewInbox {
 
     bytes32 leaf = message.sha256ToField();
     uint256 nextIndex = currentTree.insertLeaf(leaf);
-    emit LeafInserted(inProgress, nextIndex, leaf);
+    emit LeafInserted(inProgress, nextIndex - 1, leaf);
 
     return leaf;
   }

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -51,12 +51,12 @@ contract NewInbox {
   }
 
   /**
-   * @notice Inserts an entry into the Inbox
-   * @dev Will emit `LeafInserted` with data for easy access by the sequencer
-   * @param _recipient - The recipient of the entry
-   * @param _content - The content of the entry (application specific)
-   * @param _secretHash - The secret hash of the entry (make it possible to hide when a specific entry is consumed on L2)
-   * @return The key of the entry in the set
+   * @notice Inserts a new message into the Inbox
+   * @dev Emits `LeafInserted` with data for easy access by the sequencer
+   * @param _recipient - The recipient of the message
+   * @param _content - The content of the message (application specific)
+   * @param _secretHash - The secret hash of the message (make it possible to hide when a specific message is consumed on L2)
+   * @return The key of the message in the set
    */
   function insert(DataStructures.L2Actor memory _recipient, bytes32 _content, bytes32 _secretHash)
     external
@@ -100,7 +100,7 @@ contract NewInbox {
    * @notice Consumes the current tree, and starts a new one if needed
    * @dev Only callable by the rollup contract
    * @dev In the first iteration we return empty tree root because first block's messages tree is always
-   * empty because there has to be a 1 block lag to prevent sequencer DOS attacks.
+   * empty because there has to be a 1 block lag to prevent sequencer DOS attacks
    * @return The root of the consumed tree
    */
   function consume() external returns (bytes32) {
@@ -113,7 +113,7 @@ contract NewInbox {
       root = frontier[toInclude].root();
     }
 
-    // If we are "catching up" we can skip the creation as it is already there
+    // If we are "catching up" we skip the tree creation as it is already there
     if (toInclude == inProgress) {
       inProgress += 1;
       frontier[inProgress] = IFrontier(new FrontierMerkle(HEIGHT));

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -30,7 +30,7 @@ contract NewInbox {
   uint256 public immutable SIZE;
   bytes32 private immutable ZERO;
 
-  uint256 private toInclude = 0;
+  uint256 private toInclude = 1;
   uint256 private inProgress = 1;
 
   mapping(uint256 treeNumber => IFrontier tree) public frontier;
@@ -105,13 +105,10 @@ contract NewInbox {
       revert Errors.Inbox__Unauthorized();
     }
 
-    bytes32 root = ZERO;
-    if (toInclude > 0) {
-      root = frontier[toInclude].root();
-    }
+    bytes32 root = frontier[toInclude].root();
 
     // If we are "catching up" we can skip the creation as it is already there
-    if (toInclude + 1 == inProgress) {
+    if (toInclude == inProgress) {
       inProgress += 1;
       frontier[inProgress] = IFrontier(new FrontierMerkle(HEIGHT));
     }

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -60,6 +60,16 @@ contract NewInbox {
     external
     returns (bytes32)
   {
+    if (uint256(_recipient.actor) > Constants.MAX_FIELD_VALUE) {
+      revert Errors.Inbox__ActorTooLarge(_recipient.actor);
+    }
+    if (uint256(_content) > Constants.MAX_FIELD_VALUE) {
+      revert Errors.Inbox__ContentTooLarge(_content);
+    }
+    if (uint256(_secretHash) > Constants.MAX_FIELD_VALUE) {
+      revert Errors.Inbox__SecretHashTooLarge(_secretHash);
+    }
+
     IFrontier currentTree = frontier[inProgress];
     if (currentTree.isFull()) {
       inProgress += 1;

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -85,7 +85,7 @@ contract NewInbox {
       content: _content,
       secretHash: _secretHash,
       // TODO: nuke the following 2 values from the struct once the new message model is in place
-      deadline: 2 ** 32 - 1,
+      deadline: type(uint32).max,
       fee: 0
     });
 

--- a/l1-contracts/src/core/messagebridge/NewInbox.sol
+++ b/l1-contracts/src/core/messagebridge/NewInbox.sol
@@ -30,12 +30,12 @@ contract NewInbox {
   uint256 public immutable SIZE;
   bytes32 private immutable EMPTY_ROOT; // The root of an empty frontier tree
 
-  uint256 private toInclude = 0;
-  uint256 private inProgress = 1;
+  uint256 private toInclude = 1;
+  uint256 private inProgress = 2;
 
-  mapping(uint256 treeNumber => IFrontier tree) public frontier;
+  mapping(uint256 blockNumber => IFrontier tree) public frontier;
 
-  event LeafInserted(uint256 treeNumber, uint256 index, bytes32 value);
+  event LeafInserted(uint256 indexed blockNumber, uint256 index, bytes32 value);
 
   constructor(address _rollup, uint256 _height) {
     ROLLUP = _rollup;
@@ -109,7 +109,7 @@ contract NewInbox {
     }
 
     bytes32 root = EMPTY_ROOT;
-    if (toInclude > 0) {
+    if (toInclude > Constants.INITIAL_L2_BLOCK_NUM) {
       root = frontier[toInclude].root();
     }
 

--- a/l1-contracts/src/core/messagebridge/frontier_tree/Frontier.sol
+++ b/l1-contracts/src/core/messagebridge/frontier_tree/Frontier.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.8.18;
 import {IFrontier} from "../../interfaces/messagebridge/IFrontier.sol";
 
 contract FrontierMerkle is IFrontier {
-  uint256 public immutable DEPTH;
+  uint256 public immutable HEIGHT;
   uint256 public immutable SIZE;
 
   uint256 internal nextIndex = 0;
@@ -16,12 +16,12 @@ contract FrontierMerkle is IFrontier {
   // for the zeros at each level. This would save gas on computations
   mapping(uint256 level => bytes32 zero) public zeros;
 
-  constructor(uint256 _depth) {
-    DEPTH = _depth;
-    SIZE = 2 ** _depth;
+  constructor(uint256 _height) {
+    HEIGHT = _height;
+    SIZE = 2 ** _height;
 
     zeros[0] = bytes32(0);
-    for (uint256 i = 1; i <= DEPTH; i++) {
+    for (uint256 i = 1; i <= HEIGHT; i++) {
       zeros[i] = sha256(bytes.concat(zeros[i - 1], zeros[i - 1]));
     }
   }
@@ -39,10 +39,10 @@ contract FrontierMerkle is IFrontier {
   function root() external view override(IFrontier) returns (bytes32) {
     uint256 next = nextIndex;
     if (next == 0) {
-      return zeros[DEPTH];
+      return zeros[HEIGHT];
     }
     if (next == SIZE) {
-      return frontier[DEPTH];
+      return frontier[HEIGHT];
     }
 
     uint256 index = next - 1;
@@ -52,7 +52,7 @@ contract FrontierMerkle is IFrontier {
     bytes32 temp = frontier[level];
 
     uint256 bits = index >> level;
-    for (uint256 i = level; i < DEPTH; i++) {
+    for (uint256 i = level; i < HEIGHT; i++) {
       bool isRight = bits & 1 == 1;
       if (isRight) {
         if (frontier[i] == temp) {

--- a/l1-contracts/src/core/messagebridge/frontier_tree/Frontier.sol
+++ b/l1-contracts/src/core/messagebridge/frontier_tree/Frontier.sol
@@ -26,7 +26,7 @@ contract FrontierMerkle is IFrontier {
     }
   }
 
-  function insertLeaf(bytes32 _leaf) external override(IFrontier) {
+  function insertLeaf(bytes32 _leaf) external override(IFrontier) returns (uint256) {
     uint256 level = _computeLevel(nextIndex);
     bytes32 right = _leaf;
     for (uint256 i = 0; i < level; i++) {
@@ -34,6 +34,8 @@ contract FrontierMerkle is IFrontier {
     }
     frontier[level] = right;
     nextIndex++;
+
+    return nextIndex;
   }
 
   function root() external view override(IFrontier) returns (bytes32) {
@@ -69,6 +71,10 @@ contract FrontierMerkle is IFrontier {
     }
 
     return temp;
+  }
+
+  function isFull() external view override(IFrontier) returns (bool) {
+    return nextIndex == SIZE;
   }
 
   function _computeLevel(uint256 _leafIndex) internal pure returns (uint256) {

--- a/l1-contracts/src/core/messagebridge/frontier_tree/Frontier.sol
+++ b/l1-contracts/src/core/messagebridge/frontier_tree/Frontier.sol
@@ -33,9 +33,8 @@ contract FrontierMerkle is IFrontier {
       right = sha256(bytes.concat(frontier[i], right));
     }
     frontier[level] = right;
-    nextIndex++;
 
-    return nextIndex;
+    return nextIndex++;
   }
 
   function root() external view override(IFrontier) returns (bytes32) {

--- a/l1-contracts/test/NewInbox.t.sol
+++ b/l1-contracts/test/NewInbox.t.sol
@@ -62,7 +62,7 @@ contract NewInboxTest is Test {
     // update version
     _message.recipient.version = version;
 
-    // TODO: nuke the following 2 values from the struct once the new message model is in place
+    // TODO(#4833): nuke the following 2 values from the struct once the new message model is in place
     _message.deadline = type(uint32).max;
     _message.fee = 0;
 

--- a/l1-contracts/test/NewInbox.t.sol
+++ b/l1-contracts/test/NewInbox.t.sol
@@ -3,15 +3,12 @@
 pragma solidity >=0.8.18;
 
 import {Test} from "forge-std/Test.sol";
+
 import {NewInbox} from "../src/core/messagebridge/NewInbox.sol";
 import {Constants} from "../src/core/libraries/ConstantsGen.sol";
 import {Errors} from "../src/core/libraries/Errors.sol";
 import {Hash} from "../src/core/libraries/Hash.sol";
-
 import {DataStructures} from "../src/core/libraries/DataStructures.sol";
-import {IFrontier} from "../src/core/interfaces/messagebridge/IFrontier.sol";
-
-import "forge-std/console.sol";
 
 contract NewInboxTest is Test {
   using Hash for DataStructures.L1ToL2Msg;
@@ -167,7 +164,7 @@ contract NewInboxTest is Test {
     // Now we consume the trees
     for (uint256 i = 0; i < numTreesToConsume; i++) {
       bytes32 root = inbox.consume();
-      if (i < numTrees) {
+      if (i < numTrees && _messages.length > 0) {
         assertNotEq(root, emptyTreeRoot, "Root should not be zero");
       } else {
         assertEq(root, emptyTreeRoot, "Root should be zero");

--- a/l1-contracts/test/NewInbox.t.sol
+++ b/l1-contracts/test/NewInbox.t.sol
@@ -66,4 +66,18 @@ contract NewInboxTest is Test {
 
     assertEq(insertedLeaf, leaf);
   }
+
+  function testSendMultipleSameL2Messages() public {
+    DataStructures.L1ToL2Msg memory message = _fakeMessage();
+    bytes32 leaf1 = inbox.insert(message.recipient, message.content, message.secretHash);
+    bytes32 leaf2 = inbox.insert(message.recipient, message.content, message.secretHash);
+    bytes32 leaf3 = inbox.insert(message.recipient, message.content, message.secretHash);
+
+    assertEq(address(inbox.frontier(0)), address(0));
+    assertNotEq(address(inbox.frontier(1)), address(0));
+    assertEq(address(inbox.frontier(2)), address(0));
+
+    assertEq(leaf1, leaf2);
+    assertEq(leaf2, leaf3);
+  }
 }

--- a/l1-contracts/test/NewInbox.t.sol
+++ b/l1-contracts/test/NewInbox.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 Aztec Labs.
+pragma solidity >=0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+import {NewInbox} from "../src/core/messagebridge/NewInbox.sol";
+import {Constants} from "../src/core/libraries/ConstantsGen.sol";
+import {Errors} from "../src/core/libraries/Errors.sol";
+
+import {DataStructures} from "../src/core/libraries/DataStructures.sol";
+
+contract NewInboxTest is Test {
+  NewInbox internal inbox;
+  uint256 internal version = 0;
+
+  function setUp() public {
+    address rollup = address(this);
+    inbox = new NewInbox(rollup, 10, 0);
+  }
+
+  function _fakeMessage() internal view returns (DataStructures.L1ToL2Msg memory) {
+    return DataStructures.L1ToL2Msg({
+      sender: DataStructures.L1Actor({actor: address(this), chainId: block.chainid}),
+      recipient: DataStructures.L2Actor({
+        actor: 0x1000000000000000000000000000000000000000000000000000000000000000,
+        version: version
+      }),
+      content: 0x2000000000000000000000000000000000000000000000000000000000000000,
+      secretHash: 0x3000000000000000000000000000000000000000000000000000000000000000,
+      fee: 0,
+      deadline: 0
+    });
+  }
+
+  function testRevertIfNotConsumingFromRollup() public {
+    vm.prank(address(0x1));
+    vm.expectRevert(Errors.Inbox__Unauthorized.selector);
+    inbox.consume();
+  }
+}

--- a/l1-contracts/test/NewInbox.t.sol
+++ b/l1-contracts/test/NewInbox.t.sol
@@ -196,7 +196,12 @@ contract NewInboxTest is Test {
 
     // Now we consume the trees
     for (uint256 i = 0; i < numTreesToConsume; i++) {
+      uint256 expectedNumTrees =
+        (inbox.getToConsume() + 1 == inbox.getInProgress()) ? numTrees + 1 : numTrees;
       bytes32 root = inbox.consume();
+
+      // We perform this check to verify that new tree initialization works as expected
+      assertEq(inbox.getNumTrees(), expectedNumTrees, "Unexptected number of trees");
 
       // We perform empty roots check only after first batch because after second one the following simple accounting
       // does not work

--- a/l1-contracts/test/NewInbox.t.sol
+++ b/l1-contracts/test/NewInbox.t.sol
@@ -149,21 +149,21 @@ contract NewInboxTest is Test {
 
   function _send(DataStructures.L1ToL2Msg[] memory _messages) internal {
     bool isFirstRun = inbox.getInProgress() == inbox.FIRST_REAL_TREE_NUM();
-    bytes32 toIncludeRoot = inbox.getToIncludeRoot();
+    bytes32 toConsumeRoot = inbox.getToConsumeRoot();
 
     for (uint256 i = 0; i < _messages.length; i++) {
       DataStructures.L1ToL2Msg memory message = _boundMessage(_messages[i]);
 
-      // We send the message and check that toInclude root did not change.
+      // We send the message and check that toConsume root did not change.
       inbox.sendL2Message(message.recipient, message.content, message.secretHash);
     }
 
-    // Root of a tree waiting to be included should not change because we introduced a 1 block lag to prevent sequencer
+    // Root of a tree waiting to be consumed should not change because we introduced a 1 block lag to prevent sequencer
     // DOS attacks
     assertEq(
-      inbox.getToIncludeRoot(),
-      toIncludeRoot,
-      "Root of a tree waiting to be included should not change"
+      inbox.getToConsumeRoot(),
+      toConsumeRoot,
+      "Root of a tree waiting to be consumed should not change"
     );
 
     // We perform expected num trees check only after first batch because after second one the following accounting
@@ -180,7 +180,7 @@ contract NewInboxTest is Test {
   }
 
   function _consume(uint256 _numTreesToConsume, uint256 _numMessages) internal {
-    bool isFirstRun = inbox.getToInclude() == Constants.INITIAL_L2_BLOCK_NUM;
+    bool isFirstRun = inbox.getToConsume() == Constants.INITIAL_L2_BLOCK_NUM;
     uint256 numTrees = inbox.getNumTrees();
 
     // We use (numTrees * 2) as upper bound here because we want to test the case where we go beyond the currently

--- a/l1-contracts/test/NewInbox.t.sol
+++ b/l1-contracts/test/NewInbox.t.sol
@@ -21,8 +21,8 @@ contract NewInboxTest is Test {
 
   function setUp() public {
     address rollup = address(this);
-    // We set low depth (5) to ensure we sufficiently test tree transitions
-    inbox = new NewInbox(rollup, 5, 0);
+    // We set low depth (5) to ensure we sufficiently test the tree transitions
+    inbox = new NewInbox(rollup, 5);
     emptyTreeRoot = inbox.frontier(1).root();
   }
 
@@ -164,7 +164,12 @@ contract NewInboxTest is Test {
     // Now we consume the trees
     for (uint256 i = 0; i < numTreesToConsume; i++) {
       bytes32 root = inbox.consume();
-      if (i < numTrees && _messages.length > 0) {
+
+      // Notes:
+      // 1) For i = 0 we should always get empty tree root because first block's messages tree is always
+      // empty because we introduced a 1 block lag to prevent sequencer DOS attacks.
+      // 2) For _messages.length = 0 and i = 1 we get empty root as well
+      if (i != 0 && i <= numTrees && _messages.length > 0) {
         assertNotEq(root, emptyTreeRoot, "Root should not be zero");
       } else {
         assertEq(root, emptyTreeRoot, "Root should be zero");

--- a/l1-contracts/test/NewInbox.t.sol
+++ b/l1-contracts/test/NewInbox.t.sol
@@ -58,7 +58,7 @@ contract NewInboxTest is Test {
     inbox.consume();
   }
 
-  function testFuzzSendL2Msg(DataStructures.L1ToL2Msg memory _message) public {
+  function testFuzzInsert(DataStructures.L1ToL2Msg memory _message) public {
     // fix message.sender and deadline:
     _message.sender = DataStructures.L1Actor({actor: address(this), chainId: block.chainid});
     // ensure actor fits in a field
@@ -69,7 +69,7 @@ contract NewInboxTest is Test {
     _message.secretHash = bytes32(uint256(_message.secretHash) % Constants.P);
 
     // TODO: nuke the following 2 values from the struct once the new message model is in place
-    _message.deadline = 0;
+    _message.deadline = 2 ** 32 - 1;
     _message.fee = 0;
 
     bytes32 leaf = _message.sha256ToField();
@@ -142,7 +142,7 @@ contract NewInboxTest is Test {
       message.recipient.version = version;
 
       // TODO: nuke the following 2 values from the struct once the new message model is in place
-      message.deadline = 0;
+      message.deadline = 2 ** 32 - 1;
       message.fee = 0;
 
       inbox.insert(message.recipient, message.content, message.secretHash);

--- a/l1-contracts/test/NewInbox.t.sol
+++ b/l1-contracts/test/NewInbox.t.sol
@@ -188,14 +188,15 @@ contract NewInboxTest is Test {
 
   function _consume(uint256 _numTreesToConsume, uint256 _numMessages) internal checkInvariant {
     bool isFirstRun = inbox.getToConsume() == Constants.INITIAL_L2_BLOCK_NUM;
-    uint256 numTrees = inbox.getNumTrees();
 
-    // We use (numTrees * 2) as upper bound here because we want to test the case where we go beyond the currently
-    // initalized number of trees. When consuming the newly initialized trees we should get zero roots.
-    uint256 numTreesToConsume = bound(_numTreesToConsume, 1, numTrees * 2);
+    uint256 initialNumTrees = inbox.getNumTrees();
+    // We use (initialNumTrees * 2) as upper bound here because we want to test the case where we go beyond
+    // the currently initalized number of trees. When consuming the newly initialized trees we should get zero roots.
+    uint256 numTreesToConsume = bound(_numTreesToConsume, 1, initialNumTrees * 2);
 
     // Now we consume the trees
     for (uint256 i = 0; i < numTreesToConsume; i++) {
+      uint256 numTrees = inbox.getNumTrees();
       uint256 expectedNumTrees =
         (inbox.getToConsume() + 1 == inbox.getInProgress()) ? numTrees + 1 : numTrees;
       bytes32 root = inbox.consume();
@@ -210,7 +211,7 @@ contract NewInboxTest is Test {
         // 1) For i = 0 we should always get empty tree root because first block's messages tree is always
         // empty because we introduced a 1 block lag to prevent sequencer DOS attacks.
         // 2) For _numMessages = 0 and i = 1 we get empty root as well
-        if (i != 0 && i <= numTrees && _numMessages > 0) {
+        if (i != 0 && i <= initialNumTrees && _numMessages > 0) {
           assertNotEq(root, emptyTreeRoot, "Root should not be zero");
         } else {
           assertEq(root, emptyTreeRoot, "Root should be zero");

--- a/l1-contracts/test/NewInbox.t.sol
+++ b/l1-contracts/test/NewInbox.t.sol
@@ -77,7 +77,7 @@ contract NewInboxTest is Test {
     bytes32 leaf = _message.sha256ToField();
     vm.expectEmit(true, true, true, true);
     // event we expect
-    emit LeafInserted(FIRST_REAL_TREE_NUM, 1, leaf);
+    emit LeafInserted(FIRST_REAL_TREE_NUM, 0, leaf);
     // event we will get
     bytes32 insertedLeaf = inbox.insert(_message.recipient, _message.content, _message.secretHash);
 

--- a/l1-contracts/test/NewInbox.t.sol
+++ b/l1-contracts/test/NewInbox.t.sol
@@ -16,7 +16,7 @@ contract NewInboxTest is Test {
   NewInbox internal inbox;
   uint256 internal version = 0;
 
-  event LeafInserted(uint256 indexed treeNumber, uint256 indexed index, bytes32 value);
+  event LeafInserted(uint256 treeNumber, uint256 index, bytes32 value);
 
   function setUp() public {
     address rollup = address(this);

--- a/l1-contracts/test/NewInbox.t.sol
+++ b/l1-contracts/test/NewInbox.t.sol
@@ -158,10 +158,10 @@ contract NewInboxTest is Test {
     bool isFirstRun = inbox.getInProgress() == inbox.FIRST_REAL_TREE_NUM();
     bytes32 toConsumeRoot = inbox.getToConsumeRoot();
 
+    // We send the messages and then check that toConsume root did not change.
     for (uint256 i = 0; i < _messages.length; i++) {
       DataStructures.L1ToL2Msg memory message = _boundMessage(_messages[i]);
 
-      // We send the message and check that toConsume root did not change.
       inbox.sendL2Message(message.recipient, message.content, message.secretHash);
     }
 

--- a/l1-contracts/test/NewInbox.t.sol
+++ b/l1-contracts/test/NewInbox.t.sol
@@ -38,7 +38,7 @@ contract NewInboxTest is Test {
       content: 0x2000000000000000000000000000000000000000000000000000000000000000,
       secretHash: 0x3000000000000000000000000000000000000000000000000000000000000000,
       fee: 0,
-      deadline: 0
+      deadline: type(uint32).max
     });
   }
 
@@ -71,7 +71,7 @@ contract NewInboxTest is Test {
     _message.secretHash = bytes32(uint256(_message.secretHash) % Constants.P);
 
     // TODO: nuke the following 2 values from the struct once the new message model is in place
-    _message.deadline = 2 ** 32 - 1;
+    _message.deadline = type(uint32).max;
     _message.fee = 0;
 
     bytes32 leaf = _message.sha256ToField();
@@ -144,7 +144,7 @@ contract NewInboxTest is Test {
       message.recipient.version = version;
 
       // TODO: nuke the following 2 values from the struct once the new message model is in place
-      message.deadline = 2 ** 32 - 1;
+      message.deadline = type(uint32).max;
       message.fee = 0;
 
       inbox.insert(message.recipient, message.content, message.secretHash);

--- a/l1-contracts/test/harnesses/NewInboxHarness.sol
+++ b/l1-contracts/test/harnesses/NewInboxHarness.sol
@@ -29,6 +29,10 @@ contract NewInboxHarness is NewInbox {
     return inProgress;
   }
 
+  function treeInProgressFull() external view returns (bool) {
+    return trees[inProgress].isFull();
+  }
+
   function getToConsumeRoot() external view returns (bytes32) {
     bytes32 root = EMPTY_ROOT;
     if (toConsume > Constants.INITIAL_L2_BLOCK_NUM) {

--- a/l1-contracts/test/harnesses/NewInboxHarness.sol
+++ b/l1-contracts/test/harnesses/NewInboxHarness.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 Aztec Labs.
+pragma solidity >=0.8.18;
+
+import {NewInbox} from "../../src/core/messagebridge/NewInbox.sol";
+
+// Libraries
+import {Constants} from "../../src/core/libraries/ConstantsGen.sol";
+
+// TODO: rename to InboxHarness once all the pieces of the new message model are in place.
+contract NewInboxHarness is NewInbox {
+  uint256 public constant FIRST_REAL_TREE_NUM = Constants.INITIAL_L2_BLOCK_NUM + 1;
+
+  constructor(address _rollup, uint256 _height) NewInbox(_rollup, _height) {}
+
+  function getSize() external view returns (uint256) {
+    return SIZE;
+  }
+
+  function getEmptyRoot() external view returns (bytes32) {
+    return EMPTY_ROOT;
+  }
+
+  function getToIncludeRoot() external view returns (bytes32) {
+    bytes32 root = EMPTY_ROOT;
+    if (toInclude > Constants.INITIAL_L2_BLOCK_NUM) {
+      root = trees[toInclude].root();
+    }
+    return root;
+  }
+
+  function getNumTrees() external view returns (uint256) {
+    uint256 blockNumber = FIRST_REAL_TREE_NUM;
+    while (address(trees[blockNumber]) != address(0)) {
+      blockNumber++;
+    }
+    return blockNumber - 2; // -2 because first real tree is included in block 2
+  }
+}

--- a/l1-contracts/test/harnesses/NewInboxHarness.sol
+++ b/l1-contracts/test/harnesses/NewInboxHarness.sol
@@ -38,10 +38,6 @@ contract NewInboxHarness is NewInbox {
   }
 
   function getNumTrees() external view returns (uint256) {
-    uint256 blockNumber = FIRST_REAL_TREE_NUM;
-    while (address(trees[blockNumber]) != address(0)) {
-      blockNumber++;
-    }
-    return blockNumber - 2; // - 2 because first real tree is included in block 2
+    return inProgress - 1; // -1 because tree number 1 is not real
   }
 }

--- a/l1-contracts/test/harnesses/NewInboxHarness.sol
+++ b/l1-contracts/test/harnesses/NewInboxHarness.sol
@@ -21,6 +21,14 @@ contract NewInboxHarness is NewInbox {
     return EMPTY_ROOT;
   }
 
+  function getToInclude() external view returns (uint256) {
+    return toInclude;
+  }
+
+  function getInProgress() external view returns (uint256) {
+    return inProgress;
+  }
+
   function getToIncludeRoot() external view returns (bytes32) {
     bytes32 root = EMPTY_ROOT;
     if (toInclude > Constants.INITIAL_L2_BLOCK_NUM) {

--- a/l1-contracts/test/harnesses/NewInboxHarness.sol
+++ b/l1-contracts/test/harnesses/NewInboxHarness.sol
@@ -42,6 +42,6 @@ contract NewInboxHarness is NewInbox {
     while (address(trees[blockNumber]) != address(0)) {
       blockNumber++;
     }
-    return blockNumber - 2; // -2 because first real tree is included in block 2
+    return blockNumber - 2; // - 2 because first real tree is included in block 2
   }
 }

--- a/l1-contracts/test/harnesses/NewInboxHarness.sol
+++ b/l1-contracts/test/harnesses/NewInboxHarness.sol
@@ -21,18 +21,18 @@ contract NewInboxHarness is NewInbox {
     return EMPTY_ROOT;
   }
 
-  function getToInclude() external view returns (uint256) {
-    return toInclude;
+  function getToConsume() external view returns (uint256) {
+    return toConsume;
   }
 
   function getInProgress() external view returns (uint256) {
     return inProgress;
   }
 
-  function getToIncludeRoot() external view returns (bytes32) {
+  function getToConsumeRoot() external view returns (bytes32) {
     bytes32 root = EMPTY_ROOT;
-    if (toInclude > Constants.INITIAL_L2_BLOCK_NUM) {
-      root = trees[toInclude].root();
+    if (toConsume > Constants.INITIAL_L2_BLOCK_NUM) {
+      root = trees[toConsume].root();
     }
     return root;
   }


### PR DESCRIPTION
Solhint does not support checking natspec because the tool is strictly AST based. For this reason I am adding another tool to perform the check.
