### PR TITLE
chore: remove knowledge of aztec function types from compiler

### DIFF
--- a/noir/noir-repo/aztec_macros/src/lib.rs
+++ b/noir/noir-repo/aztec_macros/src/lib.rs
@@ -663,11 +663,10 @@ fn transform_function(
     let inputs_name = format!("{}ContextInputs", ty);
     let return_type_name = format!("{}CircuitPublicInputs", ty);
 
-    // Add check that msg sender equals this address and flag function as internal
+    // Add check that msg sender equals this address
     if is_internal {
         let is_internal_check = create_internal_check(func.name());
         func.def.body.0.insert(0, is_internal_check);
-        func.def.is_internal = true;
     }
 
     // Add initialization check
@@ -717,7 +716,7 @@ fn transform_function(
     // Public functions should have open auto-inferred
     match ty {
         "Private" => func.def.return_distinctness = Distinctness::Distinct,
-        "Public" => func.def.is_open = true,
+        "Public" => func.def.is_unconstrained = true,
         _ => (),
     }
 
@@ -734,7 +733,7 @@ fn transform_vm_function(
     func.def.body.0.insert(0, create_context);
 
     // We want the function to be seen as a public function
-    func.def.is_open = true;
+    func.def.is_unconstrained = true;
 
     // NOTE: the line below is a temporary hack to trigger external transpilation tools
     // It will be removed once the transpiler is integrated into the Noir compiler

--- a/noir/noir-repo/aztec_macros/src/lib.rs
+++ b/noir/noir-repo/aztec_macros/src/lib.rs
@@ -713,7 +713,7 @@ fn transform_function(
     func.def.return_visibility = Visibility::Public;
 
     // Distinct return types are only required for private functions
-    // Public functions should have open auto-inferred
+    // Public functions should have unconstrained auto-inferred
     match ty {
         "Private" => func.def.return_distinctness = Distinctness::Distinct,
         "Public" => func.def.is_unconstrained = true,

--- a/noir/noir-repo/compiler/noirc_driver/src/contract.rs
+++ b/noir/noir-repo/compiler/noirc_driver/src/contract.rs
@@ -9,23 +9,6 @@ use noirc_evaluator::errors::SsaReport;
 
 use super::debug::DebugFile;
 
-/// Describes the types of smart contract functions that are allowed.
-/// Unlike the similar enum in noirc_frontend, 'open' and 'unconstrained'
-/// are mutually exclusive here. In the case a function is both, 'unconstrained'
-/// takes precedence.
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
-pub enum ContractFunctionType {
-    /// This function will be executed in a private
-    /// context.
-    Secret,
-    /// This function will be executed in a public
-    /// context.
-    Open,
-    /// This function cannot constrain any values and can use nondeterministic features
-    /// like arrays of a dynamic size.
-    Unconstrained,
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CompiledContract {
     pub noir_version: String,
@@ -55,9 +38,7 @@ pub struct CompiledContract {
 pub struct ContractFunction {
     pub name: String,
 
-    pub function_type: ContractFunctionType,
-
-    pub is_internal: bool,
+    pub custom_attributes: Vec<String>,
 
     pub abi: Abi,
 
@@ -68,14 +49,4 @@ pub struct ContractFunction {
     pub bytecode: Circuit,
 
     pub debug: DebugInfo,
-}
-
-impl ContractFunctionType {
-    pub(super) fn new(kind: noirc_frontend::ContractFunctionType, is_unconstrained: bool) -> Self {
-        match (kind, is_unconstrained) {
-            (_, true) => Self::Unconstrained,
-            (noirc_frontend::ContractFunctionType::Secret, false) => Self::Secret,
-            (noirc_frontend::ContractFunctionType::Open, false) => Self::Open,
-        }
-    }
 }

--- a/noir/noir-repo/compiler/noirc_driver/src/lib.rs
+++ b/noir/noir-repo/compiler/noirc_driver/src/lib.rs
@@ -18,6 +18,7 @@ use noirc_frontend::hir::Context;
 use noirc_frontend::macros_api::MacroProcessor;
 use noirc_frontend::monomorphization::{monomorphize, monomorphize_debug, MonomorphizationError};
 use noirc_frontend::node_interner::FuncId;
+use noirc_frontend::token::SecondaryAttribute;
 use std::path::Path;
 use thiserror::Error;
 use tracing::info;
@@ -30,7 +31,7 @@ mod stdlib;
 
 use debug::filter_relevant_files;
 
-pub use contract::{CompiledContract, ContractFunction, ContractFunctionType};
+pub use contract::{CompiledContract, ContractFunction};
 pub use debug::DebugFile;
 pub use program::CompiledProgram;
 
@@ -404,16 +405,20 @@ fn compile_contract_inner(
         };
         warnings.extend(function.warnings);
         let modifiers = context.def_interner.function_modifiers(&function_id);
-        let func_type = modifiers
-            .contract_function_type
-            .expect("Expected contract function to have a contract visibility");
 
-        let function_type = ContractFunctionType::new(func_type, modifiers.is_unconstrained);
+        let custom_attributes = modifiers
+            .attributes
+            .secondary
+            .iter()
+            .filter_map(
+                |attr| if let SecondaryAttribute::Custom(tag) = attr { Some(tag) } else { None },
+            )
+            .cloned()
+            .collect();
 
         functions.push(ContractFunction {
             name,
-            function_type,
-            is_internal: modifiers.is_internal.unwrap_or(false),
+            custom_attributes,
             abi: function.abi,
             bytecode: function.circuit,
             debug: function.debug,

--- a/noir/noir-repo/compiler/noirc_frontend/src/ast/expression.rs
+++ b/noir/noir-repo/compiler/noirc_frontend/src/ast/expression.rs
@@ -369,11 +369,6 @@ pub struct FunctionDefinition {
     // and `secondary` attributes (ones that do not change the function kind)
     pub attributes: Attributes,
 
-    /// True if this function was defined with the 'open' keyword
-    pub is_open: bool,
-
-    pub is_internal: bool,
-
     /// True if this function was defined with the 'unconstrained' keyword
     pub is_unconstrained: bool,
 
@@ -404,18 +399,6 @@ pub enum FunctionReturnType {
     Default(Span),
     /// Everything else.
     Ty(UnresolvedType),
-}
-
-/// Describes the types of smart contract functions that are allowed.
-/// - All Noir programs in the non-contract context can be seen as `Secret`.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum ContractFunctionType {
-    /// This function will be executed in a private
-    /// context.
-    Secret,
-    /// This function will be executed in a public
-    /// context.
-    Open,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -674,8 +657,6 @@ impl FunctionDefinition {
         FunctionDefinition {
             name: name.clone(),
             attributes: Attributes::empty(),
-            is_open: false,
-            is_internal: false,
             is_unconstrained: false,
             visibility: FunctionVisibility::Private,
             generics: generics.clone(),

--- a/noir/noir-repo/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/noir/noir-repo/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -398,8 +398,6 @@ impl<'a> ModCollector<'a> {
                             // TODO(Maddiaa): Investigate trait implementations with attributes see: https://github.com/noir-lang/noir/issues/2629
                             attributes: crate::token::Attributes::empty(),
                             is_unconstrained: false,
-                            contract_function_type: None,
-                            is_internal: None,
                         };
 
                         let location = Location::new(name.span(), self.file_id);

--- a/noir/noir-repo/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/noir/noir-repo/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -64,8 +64,6 @@ pub enum ResolverError {
     IncorrectGenericCount { span: Span, item_name: String, actual: usize, expected: usize },
     #[error("{0}")]
     ParserError(Box<ParserError>),
-    #[error("Function is not defined in a contract yet sets its contract visibility")]
-    ContractFunctionTypeInNormalFunction { span: Span },
     #[error("Cannot create a mutable reference to {variable}, it was declared to be immutable")]
     MutableReferenceToImmutableVariable { variable: String, span: Span },
     #[error("Mutable references to array indices are unsupported")]
@@ -278,11 +276,6 @@ impl From<ResolverError> for Diagnostic {
                 )
             }
             ResolverError::ParserError(error) => (*error).into(),
-            ResolverError::ContractFunctionTypeInNormalFunction { span } => Diagnostic::simple_error(
-                "Only functions defined within contracts can set their contract function type".into(),
-                "Non-contract functions cannot be 'open'".into(),
-                span,
-            ),
             ResolverError::MutableReferenceToImmutableVariable { variable, span } => {
                 Diagnostic::simple_error(format!("Cannot mutably reference the immutable variable {variable}"), format!("{variable} is immutable"), span)
             },

--- a/noir/noir-repo/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/noir/noir-repo/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -28,8 +28,8 @@ use crate::{
     },
     node_interner::{self, DefinitionKind, NodeInterner, StmtId, TraitImplKind, TraitMethodId},
     token::FunctionAttribute,
-    ContractFunctionType, FunctionKind, IntegerBitSize, Signedness, Type, TypeBinding,
-    TypeBindings, TypeVariable, TypeVariableKind, UnaryOp, Visibility,
+    FunctionKind, IntegerBitSize, Signedness, Type, TypeBinding, TypeBindings, TypeVariable,
+    TypeVariableKind, UnaryOp, Visibility,
 };
 
 use self::ast::{Definition, FuncId, Function, LocalId, Program};
@@ -310,8 +310,7 @@ impl<'interner> Monomorphizer<'interner> {
             Type::TraitAsType(..) => &body_return_type,
             _ => meta.return_type(),
         });
-        let unconstrained = modifiers.is_unconstrained
-            || matches!(modifiers.contract_function_type, Some(ContractFunctionType::Open));
+        let unconstrained = modifiers.is_unconstrained;
 
         let parameters = self.parameters(&meta.parameters);
         let body = self.expr(body_expr_id)?;

--- a/noir/noir-repo/compiler/noirc_frontend/src/node_interner.rs
+++ b/noir/noir-repo/compiler/noirc_frontend/src/node_interner.rs
@@ -28,8 +28,8 @@ use crate::hir_def::{
 };
 use crate::token::{Attributes, SecondaryAttribute};
 use crate::{
-    BinaryOpKind, ContractFunctionType, FunctionDefinition, FunctionVisibility, Generics, Shared,
-    TypeAlias, TypeBindings, TypeVariable, TypeVariableId, TypeVariableKind,
+    BinaryOpKind, FunctionDefinition, FunctionVisibility, Generics, Shared, TypeAlias,
+    TypeBindings, TypeVariable, TypeVariableId, TypeVariableKind,
 };
 
 /// An arbitrary number to limit the recursion depth when searching for trait impls.
@@ -241,15 +241,6 @@ pub struct FunctionModifiers {
     pub attributes: Attributes,
 
     pub is_unconstrained: bool,
-
-    /// This function's type in its contract.
-    /// If this function is not in a contract, this is always 'Secret'.
-    pub contract_function_type: Option<ContractFunctionType>,
-
-    /// This function's contract visibility.
-    /// If this function is internal can only be called by itself.
-    /// Will be None if not in contract.
-    pub is_internal: Option<bool>,
 }
 
 impl FunctionModifiers {
@@ -262,8 +253,6 @@ impl FunctionModifiers {
             visibility: FunctionVisibility::Public,
             attributes: Attributes::empty(),
             is_unconstrained: false,
-            is_internal: None,
-            contract_function_type: None,
         }
     }
 }
@@ -759,8 +748,6 @@ impl NodeInterner {
         module: ModuleId,
         location: Location,
     ) -> DefinitionId {
-        use ContractFunctionType::*;
-
         // We're filling in contract_function_type and is_internal now, but these will be verified
         // later during name resolution.
         let modifiers = FunctionModifiers {
@@ -768,8 +755,6 @@ impl NodeInterner {
             visibility: function.visibility,
             attributes: function.attributes.clone(),
             is_unconstrained: function.is_unconstrained,
-            contract_function_type: Some(if function.is_open { Open } else { Secret }),
-            is_internal: Some(function.is_internal),
         };
         self.push_function_definition(id, modifiers, module, location)
     }

--- a/noir/noir-repo/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/noir/noir-repo/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -36,9 +36,6 @@ pub(super) fn function_definition(allow_self: bool) -> impl NoirParser<NoirFunct
                 name,
                 attributes,
                 is_unconstrained: modifiers.0,
-                // Whether a function is internal or is open is now set through `aztec_macros`
-                is_open: false,
-                is_internal: false,
                 visibility: modifiers.1,
                 generics,
                 parameters,

--- a/noir/noir-repo/compiler/noirc_frontend/src/parser/parser/traits.rs
+++ b/noir/noir-repo/compiler/noirc_frontend/src/parser/parser/traits.rs
@@ -120,11 +120,7 @@ pub(super) fn trait_implementation() -> impl NoirParser<TopLevelStatement> {
 
 fn trait_implementation_body() -> impl NoirParser<Vec<TraitImplItem>> {
     let function = function::function_definition(true).validate(|mut f, span, emit| {
-        if f.def().is_internal
-            || f.def().is_unconstrained
-            || f.def().is_open
-            || f.def().visibility != FunctionVisibility::Private
-        {
+        if f.def().is_unconstrained || f.def().visibility != FunctionVisibility::Private {
             emit(ParserError::with_reason(ParserErrorReason::TraitImplFunctionModifiers, span));
         }
         // Trait impl functions are always public

--- a/noir/noir-repo/compiler/wasm/src/types/noir_artifact.ts
+++ b/noir/noir-repo/compiler/wasm/src/types/noir_artifact.ts
@@ -32,9 +32,6 @@ export interface EventAbi {
   fields: ABIVariable[];
 }
 
-/** The Noir function types. */
-export type NoirFunctionType = 'Open' | 'Secret' | 'Unconstrained';
-
 /**
  * The compilation result of an Noir function.
  */
@@ -42,9 +39,7 @@ export interface NoirFunctionEntry {
   /** The name of the function. */
   name: string;
   /** The type of the function. */
-  function_type: NoirFunctionType;
-  /** Whether the function is internal. */
-  is_internal: boolean;
+  custom_attributes: string[];
   /** The ABI of the function. */
   abi: Abi;
   /** The bytecode of the function in base64. */

--- a/noir/noir-repo/compiler/wasm/src/types/noir_artifact.ts
+++ b/noir/noir-repo/compiler/wasm/src/types/noir_artifact.ts
@@ -38,7 +38,7 @@ export interface EventAbi {
 export interface NoirFunctionEntry {
   /** The name of the function. */
   name: string;
-  /** The type of the function. */
+  /** The custom attributes applied to the function. */
   custom_attributes: string[];
   /** The ABI of the function. */
   abi: Abi;

--- a/noir/noir-repo/tooling/nargo/src/artifacts/contract.rs
+++ b/noir/noir-repo/tooling/nargo/src/artifacts/contract.rs
@@ -1,6 +1,6 @@
 use acvm::acir::circuit::Circuit;
 use noirc_abi::{Abi, ContractEvent};
-use noirc_driver::{CompiledContract, ContractFunction, ContractFunctionType};
+use noirc_driver::{CompiledContract, ContractFunction};
 use serde::{Deserialize, Serialize};
 
 use noirc_driver::DebugFile;
@@ -43,9 +43,7 @@ impl From<CompiledContract> for ContractArtifact {
 pub struct ContractFunctionArtifact {
     pub name: String,
 
-    pub function_type: ContractFunctionType,
-
-    pub is_internal: bool,
+    pub custom_attributes: Vec<String>,
 
     pub abi: Abi,
 
@@ -66,8 +64,7 @@ impl From<ContractFunction> for ContractFunctionArtifact {
     fn from(func: ContractFunction) -> Self {
         ContractFunctionArtifact {
             name: func.name,
-            function_type: func.function_type,
-            is_internal: func.is_internal,
+            custom_attributes: func.custom_attributes,
             abi: func.abi,
             bytecode: func.bytecode,
             debug_symbols: func.debug,


### PR DESCRIPTION
This PR removes the concept of a function being internal or "open" from the Noir compiler as these are now concepts which are aztec specific. We instead attach all of a contract functions custom attributes to it in the build artifact so aztec can parse these to determine whether a function is open or secret, etc.

@spalladino This follows on from #4967 but I've made this as a separate PR into yours as I don't want to hijack it.