### PR TITLE
fix: Remove l1 contracts publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1225,16 +1225,6 @@ jobs:
             should_release || exit 0
             yarn-project/deploy_npm.sh latest
       - run:
-          name: "Release canary to NPM: l1-contracts"
-          command: |
-            should_release || exit 0
-            deploy_npm l1-contracts canary
-      - run:
-          name: "Release latest to NPM: l1-contracts"
-          command: |
-            should_release || exit 0
-            deploy_npm l1-contracts latest
-      - run:
           name: "Deploy mainnet fork"
           command: |
             should_deploy || exit 0


### PR DESCRIPTION
This PR removes the publishing of L1 contracts package to NPM
