### PR TITLE
chore: move alpine containers to ubuntu

### DIFF
--- a/barretenberg/acir_tests/Dockerfile.bb
+++ b/barretenberg/acir_tests/Dockerfile.bb
@@ -1,8 +1,8 @@
 FROM aztecprotocol/barretenberg-x86_64-linux-clang-assert
 FROM aztecprotocol/noir-compile-acir-tests as noir-acir-tests
 
-FROM node:18.19.0-alpine
-RUN apk update && apk add git bash curl jq coreutils
+FROM node:18.19.0
+RUN apt update && apt install git bash curl jq coreutils -y
 COPY --from=0 /usr/src/barretenberg/cpp/build /usr/src/barretenberg/cpp/build
 COPY --from=noir-acir-tests /usr/src/noir/noir-repo/test_programs /usr/src/noir/noir-repo/test_programs
 WORKDIR /usr/src/barretenberg/acir_tests

--- a/barretenberg/acir_tests/Dockerfile.bb.sol
+++ b/barretenberg/acir_tests/Dockerfile.bb.sol
@@ -22,4 +22,4 @@ COPY . .
 # produces SNARK recursion friendly proofs, while the solidity verifier expects proofs
 # whose transcript uses Keccak hashing. 
 RUN (cd sol-test && yarn)
-RUN PARALLEL=1 FLOW=sol ./run_acir_tests.sh
+RUN PARALLEL=1 FLOW=sol ./run_acir_tests.sh assert_statement double_verify_proof double_verify_nested_proof

--- a/barretenberg/acir_tests/Dockerfile.bb.sol
+++ b/barretenberg/acir_tests/Dockerfile.bb.sol
@@ -7,7 +7,6 @@ RUN apt update && apt install git bash curl jq -y
 COPY --from=0 /usr/src/barretenberg/cpp/build /usr/src/barretenberg/cpp/build
 COPY --from=1 /usr/src/barretenberg/sol/src/ultra/BaseUltraVerifier.sol /usr/src/barretenberg/sol/src/ultra/BaseUltraVerifier.sol
 COPY --from=noir-acir-tests /usr/src/noir/noir-repo/test_programs /usr/src/noir/noir-repo/test_programs
-# COPY --from=ghcr.io/foundry-rs/foundry:latest /usr/local/bin/anvil /usr/local/bin/anvil
 
 RUN curl -L https://foundry.paradigm.xyz | bash
 ENV PATH="${PATH}:/root/.foundry/bin"

--- a/barretenberg/cpp/dockerfiles/Dockerfile.bench
+++ b/barretenberg/cpp/dockerfiles/Dockerfile.bench
@@ -1,4 +1,4 @@
 FROM aztecprotocol/barretenberg-x86_64-linux-clang
 WORKDIR /usr/src/barretenberg/cpp
-RUN apk update && apk add curl libstdc++ jq
+RUN apt update && apt install curl libstdc++6 jq -y
 RUN ./scripts/ci/ultra_honk_bench.sh

--- a/barretenberg/cpp/dockerfiles/Dockerfile.x86_64-linux-clang
+++ b/barretenberg/cpp/dockerfiles/Dockerfile.x86_64-linux-clang
@@ -1,23 +1,32 @@
-FROM alpine:3.18 AS builder
-RUN apk update \
-    && apk upgrade \
-    && apk add --no-cache \
-        build-base \
-        clang16 \
-        cmake \
-        ninja \
-        git \
-        curl \
-        perl
+FROM ubuntu:lunar as builder
+
+RUN apt update && apt install -y \
+  build-essential \
+  curl \
+  git \
+  cmake \
+  lsb-release \
+  wget \
+  software-properties-common \
+  gnupg \
+  ninja-build \
+  npm \
+  libssl-dev \
+  jq \
+  bash \
+  libstdc++6
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16
+
 WORKDIR /usr/src/barretenberg/cpp
 COPY . .
 # Build bb binary and targets needed for benchmarking. 
 # Everything else is built as part linux-clang-assert.
 # Benchmark targets want to run without asserts, so get built alongside bb.
-RUN cmake --preset default
-RUN cmake --build --preset default --target ultra_honk_rounds_bench --target bb --target grumpkin_srs_gen
+RUN cmake --preset clang16
+RUN cmake --build --preset clang16 --target ultra_honk_rounds_bench --target bb --target grumpkin_srs_gen
 
-FROM alpine:3.18
+FROM ubuntu:lunar
 WORKDIR /usr/src/barretenberg/cpp
 COPY . .
 COPY --from=builder /usr/src/barretenberg/cpp/scripts/ci /usr/src/barretenberg/cpp/scripts/ci

--- a/barretenberg/cpp/dockerfiles/Dockerfile.x86_64-linux-clang-assert
+++ b/barretenberg/cpp/dockerfiles/Dockerfile.x86_64-linux-clang-assert
@@ -1,24 +1,33 @@
-# We have to stay on 3.17 for now, to get clang-format 15, as code is not yet formatted to 16.
-FROM alpine:3.17 AS builder
-RUN apk update \
-    && apk upgrade \
-    && apk add --no-cache \
-    build-base \
-    clang15 \
-    cmake \
-    ninja \
-    git \
-    curl \
-    perl \
-    clang-extra-tools \
-    bash
+FROM ubuntu:lunar as builder
+
+RUN apt update && apt install -y \
+  build-essential \
+  curl \
+  git \
+  cmake \
+  lsb-release \
+  wget \
+  software-properties-common \
+  gnupg \
+  ninja-build \
+  npm \
+  libssl-dev \
+  jq \
+  bash \
+  libstdc++6 \
+  clang-format
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16
+
 WORKDIR /usr/src/barretenberg/cpp
 COPY . .
 # Build everything to ensure everything builds. All tests will be run from the result of this build.
-RUN ./format.sh check && cmake --preset default -DCMAKE_BUILD_TYPE=RelWithAssert -DCI=ON && cmake --build --preset default
+RUN ./format.sh check && cmake --preset clang16 -DCMAKE_BUILD_TYPE=RelWithAssert -DCI=ON && cmake --build --preset clang16
 RUN srs_db/download_grumpkin.sh
 
-FROM alpine:3.17
-RUN apk update && apk add curl libstdc++
-COPY --from=builder /usr/src/barretenberg/cpp/srs_db /usr/src/barretenberg/cpp/srs_db
-COPY --from=builder /usr/src/barretenberg/cpp/build/bin /usr/src/barretenberg/cpp/build/bin
+CMD ["/bin/bash"]
+
+# FROM ubuntu:lunar
+# RUN apt update && apt install curl libstdc++6 -y
+# COPY --from=builder /usr/src/barretenberg/cpp/srs_db /usr/src/barretenberg/cpp/srs_db
+# COPY --from=builder /usr/src/barretenberg/cpp/build/bin /usr/src/barretenberg/cpp/build/bin

--- a/barretenberg/cpp/dockerfiles/Dockerfile.x86_64-linux-clang-assert
+++ b/barretenberg/cpp/dockerfiles/Dockerfile.x86_64-linux-clang-assert
@@ -25,9 +25,7 @@ COPY . .
 RUN ./format.sh check && cmake --preset clang16 -DCMAKE_BUILD_TYPE=RelWithAssert -DCI=ON && cmake --build --preset clang16
 RUN srs_db/download_grumpkin.sh
 
-CMD ["/bin/bash"]
-
-# FROM ubuntu:lunar
-# RUN apt update && apt install curl libstdc++6 -y
-# COPY --from=builder /usr/src/barretenberg/cpp/srs_db /usr/src/barretenberg/cpp/srs_db
-# COPY --from=builder /usr/src/barretenberg/cpp/build/bin /usr/src/barretenberg/cpp/build/bin
+FROM ubuntu:lunar
+RUN apt update && apt install curl libstdc++6 -y
+COPY --from=builder /usr/src/barretenberg/cpp/srs_db /usr/src/barretenberg/cpp/srs_db
+COPY --from=builder /usr/src/barretenberg/cpp/build/bin /usr/src/barretenberg/cpp/build/bin

--- a/barretenberg/cpp/dockerfiles/Dockerfile.x86_64-linux-clang-benchmarks
+++ b/barretenberg/cpp/dockerfiles/Dockerfile.x86_64-linux-clang-benchmarks
@@ -1,23 +1,29 @@
-FROM alpine:3.18 AS builder
-RUN apk update \
-    && apk upgrade \
-    && apk add --no-cache \
-        build-base \
-        clang16 \
-        openmp-dev \
-        cmake \
-        ninja \
-        git \
-        curl \
-        perl
+FROM ubuntu:lunar as builder
+
+RUN apt update && apt install -y \
+  build-essential \
+  curl \
+  git \
+  cmake \
+  lsb-release \
+  wget \
+  software-properties-common \
+  gnupg \
+  ninja-build \
+  npm \
+  libssl-dev \
+  jq \
+  bash \
+  libstdc++6
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16
 
 WORKDIR /usr/src/barretenberg/cpp
-
 COPY . .
 # Build everything to ensure everything builds. All tests will be run from the result of this build.
-RUN cmake --preset default && cmake --build --preset default --target external_bench
+RUN cmake --preset clang16 && cmake --build --preset clang16 --target external_bench
 
-FROM alpine:3.18
-RUN apk update && apk add curl openmp
+FROM ubuntu:lunar
+RUN apt update && apt install curl libomp-dev -y
 COPY --from=builder /usr/src/barretenberg/cpp/srs_db /usr/src/barretenberg/cpp/srs_db
 COPY --from=builder /usr/src/barretenberg/cpp/build/bin/*_bench /usr/src/barretenberg/cpp/build/bin/

--- a/barretenberg/cpp/dockerfiles/Dockerfile.x86_64-linux-clang-fuzzing
+++ b/barretenberg/cpp/dockerfiles/Dockerfile.x86_64-linux-clang-fuzzing
@@ -1,23 +1,28 @@
-FROM alpine:3.18 AS builder
-RUN apk update && \
-    apk upgrade && \
-    apk add --no-cache \
-        build-base \
-        clang16 \
-        compiler-rt \
-        openmp-dev \
-        cmake \
-        ninja \
-        git \
-        curl \
-        perl
+FROM ubuntu:lunar as builder
+
+RUN apt update && apt install -y \
+  build-essential \
+  curl \
+  git \
+  cmake \
+  lsb-release \
+  wget \
+  software-properties-common \
+  gnupg \
+  ninja-build \
+  npm \
+  libssl-dev \
+  jq \
+  bash \
+  libstdc++6
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16
 
 WORKDIR /usr/src/barretenberg/cpp
-
 COPY . .
-# Build the entire project, as we want to check everything builds under clang
+# Build the entire project, as we want to check everything builds under clang-fuzzing with clang-16.
 RUN cmake --preset fuzzing && cmake --build --preset fuzzing
 
-FROM alpine:3.18
-RUN apk update && apk add openmp
+FROM ubuntu:lunar
+RUN apt update && apt install libomp-dev -y
 COPY --from=builder /usr/src/barretenberg/cpp/srs_db /usr/src/barretenberg/cpp/srs_db

--- a/barretenberg/cpp/dockerfiles/Dockerfile.x86_64-linux-gcc
+++ b/barretenberg/cpp/dockerfiles/Dockerfile.x86_64-linux-gcc
@@ -1,17 +1,28 @@
-FROM alpine:3.18 AS builder
-RUN apk update \
-    && apk upgrade \
-    && apk add --no-cache \
-        build-base \
-        cmake \
-        ninja \
-        git \
-        curl
+FROM ubuntu:lunar as builder
+
+RUN apt update && apt install -y \
+  build-essential \
+  curl \
+  git \
+  cmake \
+  lsb-release \
+  wget \
+  software-properties-common \
+  gnupg \
+  ninja-build \
+  npm \
+  libssl-dev \
+  jq \
+  bash \
+  libstdc++6
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16
+
 WORKDIR /usr/src/barretenberg/cpp
 COPY . .
 # Build the entire project, as we want to check everything builds under gcc.
 RUN cmake --preset gcc -DCI=ON && cmake --build --preset gcc
 
-FROM alpine:3.18
-RUN apk update && apk add libstdc++
+FROM ubuntu:lunar
+RUN apt update && apt install libstdc++6 -y
 COPY --from=builder /usr/src/barretenberg/cpp/build-gcc/bin/bb /usr/src/barretenberg/cpp/build/bin/bb

--- a/barretenberg/sol/Dockerfile
+++ b/barretenberg/sol/Dockerfile
@@ -1,15 +1,22 @@
-FROM alpine:3.18
-RUN apk update \
-    && apk upgrade \
-    && apk add --no-cache \
-        build-base \
-        clang16 \
-        openmp-dev \
-        cmake \
-        ninja \
-        git \
-        curl \
-        perl
+FROM ubuntu:lunar as builder
+
+RUN apt update && apt install -y \
+  build-essential \
+  curl \
+  git \
+  cmake \
+  lsb-release \
+  wget \
+  software-properties-common \
+  gnupg \
+  ninja-build \
+  npm \
+  libssl-dev \
+  jq \
+  bash \
+  libstdc++6
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16
 
 WORKDIR /usr/src/barretenberg/cpp
 
@@ -17,16 +24,26 @@ COPY ./cpp .
 # Build everything to ensure everything builds. All tests will be run from the result of this build.
 RUN cmake --preset clang16  && cmake --build --preset clang16 --target solidity_key_gen solidity_proof_gen
 
-FROM docker.io/frolvlad/alpine-glibc:alpine-3.17_glibc-2.34 as builder
-RUN apk update && apk add git curl build-base openmp-dev bash
+# FROM docker.io/frolvlad/alpine-glibc:alpine-3.17_glibc-2.34 as builder
+# RUN apk update && apk add git curl build-base openmp-dev bash
+FROM ubuntu:lunar
+RUN apt update && apt install -y \
+  build-essential \
+  curl \
+  git \
+  bash \
+  libomp-dev
 
-COPY --from=0 /usr/src/barretenberg/cpp/build/bin /usr/src/barretenberg/cpp/build/bin
-COPY --from=0 /usr/src/barretenberg/cpp/srs_db /usr/src/barretenberg/cpp/srs_db
+COPY --from=builder /usr/src/barretenberg/cpp/build/bin /usr/src/barretenberg/cpp/build/bin
+COPY --from=builder /usr/src/barretenberg/cpp/srs_db /usr/src/barretenberg/cpp/srs_db
 WORKDIR /usr/src/barretenberg/sol
 COPY ./sol .
 
 # Copy forge binary directly from foundry
-COPY --from=ghcr.io/foundry-rs/foundry:latest /usr/local/bin/forge /usr/local/bin/forge
+# COPY --from=ghcr.io/foundry-rs/foundry:latest /usr/local/bin/forge /usr/local/bin/forge
+RUN curl -L https://foundry.paradigm.xyz | bash
+ENV PATH="${PATH}:/root/.foundry/bin"
+RUN foundryup
 
 RUN cd ../cpp/srs_db && ./download_ignition.sh 3 && cd ../../sol
 

--- a/barretenberg/sol/Dockerfile
+++ b/barretenberg/sol/Dockerfile
@@ -24,8 +24,6 @@ COPY ./cpp .
 # Build everything to ensure everything builds. All tests will be run from the result of this build.
 RUN cmake --preset clang16  && cmake --build --preset clang16 --target solidity_key_gen solidity_proof_gen
 
-# FROM docker.io/frolvlad/alpine-glibc:alpine-3.17_glibc-2.34 as builder
-# RUN apk update && apk add git curl build-base openmp-dev bash
 FROM ubuntu:lunar
 RUN apt update && apt install -y \
   build-essential \
@@ -39,8 +37,7 @@ COPY --from=builder /usr/src/barretenberg/cpp/srs_db /usr/src/barretenberg/cpp/s
 WORKDIR /usr/src/barretenberg/sol
 COPY ./sol .
 
-# Copy forge binary directly from foundry
-# COPY --from=ghcr.io/foundry-rs/foundry:latest /usr/local/bin/forge /usr/local/bin/forge
+# Download and install foundry
 RUN curl -L https://foundry.paradigm.xyz | bash
 ENV PATH="${PATH}:/root/.foundry/bin"
 RUN foundryup

--- a/barretenberg/ts/Dockerfile
+++ b/barretenberg/ts/Dockerfile
@@ -1,6 +1,6 @@
 FROM aztecprotocol/barretenberg-wasm-linux-clang
 
-FROM node:18.19.0-alpine
+FROM node:18.19.0
 COPY --from=0 /usr/src/barretenberg /usr/src/barretenberg
 
 # Create a standalone container that can run bb.js (and tests).

--- a/l1-contracts/Dockerfile
+++ b/l1-contracts/Dockerfile
@@ -1,18 +1,25 @@
 # Building requires foundry.
-# FROM ghcr.io/foundry-rs/foundry:nightly-4a643801d0b3855934cdec778e33e79c79971783
 FROM ubuntu:lunar
-RUN apt update && apt install git jq bash nodejs npm yarn python3 python3-pip -y && pip3 install slither-analyzer==0.10.0 slitherin==0.5.0
 
+RUN apt update && apt install curl git jq bash nodejs npm python3.11-full python3-pip -y
+
+# Use virtualenv, do not try to use pipx, it's not working.
+RUN python3 -m venv /root/.venv
+RUN /root/.venv/bin/pip3 install slither-analyzer==0.10.0 slitherin==0.5.0
 RUN curl -L https://foundry.paradigm.xyz | bash
-RUN source ~/.bashrc
-ENV PATH="~/.foundry/bin:${PATH}"
+
+# Set env variables for foundry and venv
+ENV PATH="${PATH}:/root/.foundry/bin:/root/.venv/bin"
 RUN foundryup
 
 WORKDIR /usr/src/l1-contracts
 COPY . .
 RUN git init
 RUN forge clean && forge fmt --check && forge build && forge test
+
+RUN npm install --global yarn
 RUN yarn && yarn lint
+
 RUN git add . && yarn slither && yarn slither-has-diff
 RUN forge build
 

--- a/l1-contracts/Dockerfile
+++ b/l1-contracts/Dockerfile
@@ -1,7 +1,7 @@
 # Building requires foundry.
 # FROM ghcr.io/foundry-rs/foundry:nightly-4a643801d0b3855934cdec778e33e79c79971783
 FROM ubuntu:lunar
-RUN apt update && apt install git jq bash nodejs npm yarn python3 py3-pip -y && pip3 install slither-analyzer==0.10.0 slitherin==0.5.0
+RUN apt update && apt install git jq bash nodejs npm yarn python3 python3-pip -y && pip3 install slither-analyzer==0.10.0 slitherin==0.5.0
 
 RUN curl -L https://foundry.paradigm.xyz | bash
 RUN source ~/.bashrc

--- a/l1-contracts/Dockerfile
+++ b/l1-contracts/Dockerfile
@@ -1,6 +1,13 @@
 # Building requires foundry.
-FROM ghcr.io/foundry-rs/foundry:nightly-4a643801d0b3855934cdec778e33e79c79971783
-RUN apk update && apk add git jq bash nodejs npm yarn python3 py3-pip && pip3 install slither-analyzer==0.10.0 slitherin==0.5.0
+# FROM ghcr.io/foundry-rs/foundry:nightly-4a643801d0b3855934cdec778e33e79c79971783
+FROM ubuntu:lunar
+RUN apt update && apt install git jq bash nodejs npm yarn python3 py3-pip -y && pip3 install slither-analyzer==0.10.0 slitherin==0.5.0
+
+RUN curl -L https://foundry.paradigm.xyz | bash
+RUN source ~/.bashrc
+ENV PATH="~/.foundry/bin:${PATH}"
+RUN foundryup
+
 WORKDIR /usr/src/l1-contracts
 COPY . .
 RUN git init

--- a/noir/Dockerfile.native
+++ b/noir/Dockerfile.native
@@ -7,7 +7,7 @@ COPY . .
 RUN ./scripts/bootstrap_native.sh
 
 # When running the container, mount the users home directory to same location.
-FROM ubuntu:focal
+FROM ubuntu:lunar
 # Install Tini as nargo doesn't handle signals properly.
 # Install git as nargo needs it to clone.
 RUN apt-get update && apt-get install -y git tini && rm -rf /var/lib/apt/lists/* && apt-get clean


### PR DESCRIPTION
Move bb alpine containers to be built in ubuntu so we can use the bb binary in `yarn-project`. This also shifts some noir containers to ubuntu that rely on the bb binary

Closes #4708