### PR TITLE
chore: bootstrap noir natively if nargo is invalid

### DIFF
--- a/noir/bootstrap.sh
+++ b/noir/bootstrap.sh
@@ -15,8 +15,11 @@ if [ -n "$CMD" ]; then
   fi
 fi
 
-# Attempt to just pull artefacts from CI and exit on success.
-[ -n "${USE_CACHE:-}" ] && ./bootstrap_cache.sh && exit
+# Attempt to pull artifacts from CI if USE_CACHE is set and verify nargo usability.
+if [ -n "${USE_CACHE:-}" ]; then
+    ./bootstrap_cache.sh && ./noir-repo/target/release/nargo --version >/dev/null 2>&1 && exit 0
+fi
 
+# Continue with native bootstrapping if the cache was not used or nargo verification failed.
 ./scripts/bootstrap_native.sh
 ./scripts/bootstrap_packages.sh


### PR DESCRIPTION
On mac, after bootstrap with cache, if one runs
```
❯ ./noir/noir-repo/target/release/nargo
zsh: exec format error: ./noir/noir-repo/target/release/nargo
```
So check to see that our cached version of nargo is compatible, and build if need be.
