### PR TITLE
chore: build avm transpiler if we are on mac

### DIFF
--- a/avm-transpiler/bootstrap.sh
+++ b/avm-transpiler/bootstrap.sh
@@ -17,7 +17,7 @@ if [ -n "$CMD" ]; then
 fi
 
 # Attempt to just pull artefacts from CI and exit on success.
-if [ "$(uname)" != "Darwin" ] && [ -n "${USE_CACHE:-}" ]; then
+if [[ "$OSTYPE" != "darwin"* ]] && [ -n "${USE_CACHE:-}" ]; then
   ./bootstrap_cache.sh && exit
 fi
 

--- a/avm-transpiler/bootstrap.sh
+++ b/avm-transpiler/bootstrap.sh
@@ -17,6 +17,8 @@ if [ -n "$CMD" ]; then
 fi
 
 # Attempt to just pull artefacts from CI and exit on success.
-[ -n "${USE_CACHE:-}" ] && ./bootstrap_cache.sh && exit
+if [ "$(uname)" != "Darwin" ] && [ -n "${USE_CACHE:-}" ]; then
+  ./bootstrap_cache.sh && exit
+fi
 
 ./scripts/bootstrap_native.sh


### PR DESCRIPTION
We don't cache avm transpiler builds for mac. so we cannot use the cache.