### PR TITLE
chore: disable `hello_world_example` noir test in aztec-packages CI

### DIFF
--- a/noir/.rebuild_patterns_native
+++ b/noir/.rebuild_patterns_native
@@ -1,4 +1,5 @@
 ^noir/Dockerfile
+^noir/scripts
 ^noir/noir-repo/acvm-repo
 ^noir/noir-repo/compiler
 ^noir/noir-repo/aztec_macros

--- a/noir/.rebuild_patterns_native
+++ b/noir/.rebuild_patterns_native
@@ -1,5 +1,6 @@
 ^noir/Dockerfile
-^noir/scripts
+^noir/scripts/bootstrap_native.sh
+^noir/scripts/test_native.sh
 ^noir/noir-repo/acvm-repo
 ^noir/noir-repo/compiler
 ^noir/noir-repo/aztec_macros

--- a/noir/.rebuild_patterns_packages
+++ b/noir/.rebuild_patterns_packages
@@ -1,5 +1,6 @@
 ^noir/Dockerfile.packages
-^noir/scripts
+^noir/scripts/bootstrap_packages.sh
+^noir/scripts/test_js_packages.sh
 ^noir/noir-repo/.yarn
 ^noir/noir-repo/.yarnrc.yml
 ^noir/noir-repo/package.json

--- a/noir/.rebuild_patterns_packages
+++ b/noir/.rebuild_patterns_packages
@@ -1,4 +1,5 @@
 ^noir/Dockerfile.packages
+^noir/scripts
 ^noir/noir-repo/.yarn
 ^noir/noir-repo/.yarnrc.yml
 ^noir/noir-repo/package.json

--- a/noir/scripts/test_native.sh
+++ b/noir/scripts/test_native.sh
@@ -10,4 +10,8 @@ export GIT_COMMIT=${COMMIT_HASH:-$(git rev-parse --verify HEAD)}
 
 cargo fmt --all --check
 cargo clippy --workspace --locked --release
-cargo test --workspace --locked --release
+
+./.github/scripts/cargo-binstall-install.sh
+cargo-binstall cargo-nextest --version 0.9.67 -y --secure
+
+cargo nextest run --locked --release -E '!test(hello_world_example)'


### PR DESCRIPTION
This PR disables the `hello_world_example` test in `aztec-packages` and only in `aztec-packages`. This is because it relies on nargo producing ACIR which is compatible with the last released version of `bb` whereas this is not a given in this repository. In the main noir repo however we want/need to be able to download a compatible version of `bb` in order to be able to make releases so we must enforce this test case.

In order to be able to disable a single test case I've switched over to using nextest rather than the standard cargo test runner.