### PR TITLE
chore(avm-simulator): enable compressed strings unencrypted log test

### DIFF
--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -161,10 +161,8 @@ contract AvmTest {
     fn emit_unencrypted_log() {
         context.emit_unencrypted_log(/*event_selector=*/ 5, /*message=*/ [10, 20, 30]);
         context.emit_unencrypted_log(/*event_selector=*/ 8, /*message=*/ "Hello, world!");
-        // FIXME: Try this once Brillig codegen produces uniform bit sizes for LT
-        // FIXME: TagCheckError: Tag mismatch at offset 22, got UINT64, expected UINT32
-        // let s: CompressedString<1,13> = CompressedString::from_string("Hello, world!");
-        // context.emit_unencrypted_log(/*event_selector=*/ 10, /*message=*/ s);
+        let s: CompressedString<2,44> = CompressedString::from_string("A long time ago, in a galaxy far far away...");
+        context.emit_unencrypted_log(/*event_selector=*/ 10, /*message=*/ s);
     }
 
     #[aztec(public-vm)]

--- a/yarn-project/simulator/src/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.test.ts
@@ -240,8 +240,9 @@ describe('AVM simulator', () => {
 
         const expectedFields = [new Fr(10), new Fr(20), new Fr(30)];
         const expectedString = 'Hello, world!'.split('').map(c => new Fr(c.charCodeAt(0)));
-        // FIXME: Try this once Brillig codegen produces uniform bit sizes for LT
-        // const expectedCompressedString = Buffer.from('Hello, world!');
+        const expectedCompressedString = Buffer.from(
+          '\0A long time ago, in a galaxy fa' + '\0r far away...\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',
+        );
         expect(context.persistableState.flush().newLogs).toEqual([
           new UnencryptedL2Log(
             context.environment.address,
@@ -253,11 +254,7 @@ describe('AVM simulator', () => {
             new EventSelector(8),
             Buffer.concat(expectedString.map(f => f.toBuffer())),
           ),
-          // new UnencryptedL2Log(
-          //   context.environment.address,
-          //   new EventSelector(10),
-          //   expectedCompressedString,
-          // ),
+          new UnencryptedL2Log(context.environment.address, new EventSelector(10), expectedCompressedString),
         ]);
       });
 


### PR DESCRIPTION
Now that Brillig behaves better, we can enable the compressed strings test for unencrypted logs.

Ref: #4838.
