### PR TITLE
fix: add acir tests circleci requires

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1229,6 +1229,12 @@ defaults: &defaults
     - slack/notify:
         event: fail
         branch_pattern: "master"
+      
+bb_acir_tests: &bb_acir_tests
+  requires:
+    - barretenberg-x86_64-linux-clang-assert
+    - noir-compile-acir-tests
+  <<: *defaults
 
 defaults_yarn_project_pre_join: &defaults_yarn_project_pre_join
   requires:
@@ -1305,11 +1311,8 @@ workflows:
       - barretenberg-stdlib-tests: *bb_test
       - barretenberg-stdlib-recursion-ultra-tests: *bb_test
       - barretenberg-join-split-tests: *bb_test
-      - barretenberg-acir-tests-bb:
-          requires:
-            - barretenberg-x86_64-linux-clang-assert
-            - noir-compile-acir-tests
-          <<: *defaults
+      - barretenberg-acir-tests-bb: *bb_acir_tests
+      - barretenberg-acir-tests-bb-sol: *bb_acir_tests
       - barretenberg-docs: *defaults
       - bb-js:
           requires:
@@ -1445,6 +1448,7 @@ workflows:
             - barretenberg-stdlib-recursion-ultra-tests
             - barretenberg-join-split-tests
             - barretenberg-acir-tests-bb
+            - barretenberg-acir-tests-bb-sol
             - barretenberg-docs
             - build-docs
             - mainnet-fork


### PR DESCRIPTION
Stacked ontop of #5065. Adds the job to the system job graph.