### PR TITLE
chore(avm-simulator): formatting and fixes

### DIFF
--- a/avm-transpiler/src/opcodes.rs
+++ b/avm-transpiler/src/opcodes.rs
@@ -2,27 +2,20 @@
 /// Keep updated with TS and yellow paper!
 #[derive(Copy, Clone)]
 pub enum AvmOpcode {
-    // Compute
-    // Compute - Arithmetic
     ADD,
     SUB,
     MUL,
     DIV,
-    // Compute - Comparators
     EQ,
     LT,
     LTE,
-    // Compute - Bitwise
     AND,
     OR,
     XOR,
     NOT,
     SHL,
     SHR,
-    // Compute - Type Conversions
     CAST,
-
-    // Execution Environment
     ADDRESS,
     STORAGEADDRESS,
     ORIGIN,
@@ -32,7 +25,6 @@ pub enum AvmOpcode {
     FEEPERL2GAS,
     FEEPERDAGAS,
     CONTRACTCALLDEPTH,
-    // Execution Environment - Globals
     CHAINID,
     VERSION,
     BLOCKNUMBER,
@@ -41,25 +33,17 @@ pub enum AvmOpcode {
     BLOCKL1GASLIMIT,
     BLOCKL2GASLIMIT,
     BLOCKDAGASLIMIT,
-    // Execution Environment - Calldata
     CALLDATACOPY,
-
-    // Machine State
-    // Machine State - Gas
     L1GASLEFT,
     L2GASLEFT,
     DAGASLEFT,
-    // Machine State - Internal Control Flow
     JUMP,
     JUMPI,
     INTERNALCALL,
     INTERNALRETURN,
-    // Machine State - Memory
     SET,
     MOV,
     CMOV,
-
-    // World State
     SLOAD,           // Public Storage
     SSTORE,          // Public Storage
     NOTEHASHEXISTS,  // Notes & Nullifiers
@@ -68,19 +52,13 @@ pub enum AvmOpcode {
     EMITNULLIFIER,   // Notes & Nullifiers
     L1TOL2MSGEXISTS, // Messages
     HEADERMEMBER,    // Archive tree & Headers
-
-    // Accrued Substate
     EMITUNENCRYPTEDLOG,
     SENDL2TOL1MSG,
-
-    // Control Flow - Contract Calls
     CALL,
     STATICCALL,
     DELEGATECALL,
     RETURN,
     REVERT,
-
-    // Gadgets
     KECCAK,
     POSEIDON,
     SHA256,

--- a/avm-transpiler/src/opcodes.rs
+++ b/avm-transpiler/src/opcodes.rs
@@ -2,6 +2,7 @@
 /// Keep updated with TS and yellow paper!
 #[derive(Copy, Clone)]
 pub enum AvmOpcode {
+    // Compute
     ADD,
     SUB,
     MUL,
@@ -16,6 +17,7 @@ pub enum AvmOpcode {
     SHL,
     SHR,
     CAST,
+    // Execution environment
     ADDRESS,
     STORAGEADDRESS,
     ORIGIN,
@@ -34,35 +36,41 @@ pub enum AvmOpcode {
     BLOCKL2GASLIMIT,
     BLOCKDAGASLIMIT,
     CALLDATACOPY,
+    // Gas
     L1GASLEFT,
     L2GASLEFT,
     DAGASLEFT,
+    // Control flow
     JUMP,
     JUMPI,
     INTERNALCALL,
     INTERNALRETURN,
+    // Memory
     SET,
     MOV,
     CMOV,
-    SLOAD,           // Public Storage
-    SSTORE,          // Public Storage
-    NOTEHASHEXISTS,  // Notes & Nullifiers
-    EMITNOTEHASH,    // Notes & Nullifiers
-    NULLIFIEREXISTS, // Notes & Nullifiers
-    EMITNULLIFIER,   // Notes & Nullifiers
-    L1TOL2MSGEXISTS, // Messages
-    HEADERMEMBER,    // Archive tree & Headers
+    // World state
+    SLOAD,
+    SSTORE,
+    NOTEHASHEXISTS,
+    EMITNOTEHASH,
+    NULLIFIEREXISTS,
+    EMITNULLIFIER,
+    L1TOL2MSGEXISTS,
+    HEADERMEMBER,
     EMITUNENCRYPTEDLOG,
     SENDL2TOL1MSG,
+    // External calls
     CALL,
     STATICCALL,
     DELEGATECALL,
     RETURN,
     REVERT,
+    // Gadgets
     KECCAK,
     POSEIDON,
-    SHA256,
-    PEDERSEN,
+    SHA256,   // temp - may be removed, but alot of contracts rely on it
+    PEDERSEN, // temp - may be removed, but alot of contracts rely on it
 }
 
 impl AvmOpcode {

--- a/yarn-project/simulator/src/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.test.ts
@@ -23,7 +23,7 @@ import { encodeToBytecode } from './serialization/bytecode_serialization.js';
 function getAvmTestContractBytecode(functionName: string): Buffer {
   const artifact = AvmTestContractArtifact.functions.find(f => f.name === functionName)!;
   assert(
-    !!artifact.bytecode,
+    !!artifact?.bytecode,
     `No bytecode found for function ${functionName}. Try re-running bootstraph.sh on the repository root.`,
   );
   return Buffer.from(artifact.bytecode, 'base64');

--- a/yarn-project/simulator/src/avm/avm_simulator.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.ts
@@ -9,9 +9,13 @@ import type { Instruction } from './opcodes/index.js';
 import { decodeFromBytecode } from './serialization/bytecode_serialization.js';
 
 export class AvmSimulator {
-  private log: DebugLogger = createDebugLogger('aztec:avm_simulator');
+  private log: DebugLogger;
 
-  constructor(private context: AvmContext) {}
+  constructor(private context: AvmContext) {
+    this.log = createDebugLogger(
+      `aztec:avm_simulator:core(f:${context.environment.temporaryFunctionSelector.toString()})`,
+    );
+  }
 
   /**
    * Fetch the bytecode and execute it in the current context.
@@ -52,7 +56,10 @@ export class AvmSimulator {
       // continuing until the machine state signifies a halt
       while (!this.context.machineState.halted) {
         const instruction = instructions[this.context.machineState.pc];
-        assert(!!instruction); // This should never happen
+        assert(
+          !!instruction,
+          'AVM attempted to execute non-existent instruction. This should never happen (invalid bytecode or AVM simulator bug)!',
+        );
 
         this.log.debug(`@${this.context.machineState.pc} ${instruction.toString()}`);
         // Execute the instruction.

--- a/yarn-project/simulator/src/avm/opcodes/arithmetic.ts
+++ b/yarn-project/simulator/src/avm/opcodes/arithmetic.ts
@@ -11,6 +11,8 @@ export class Add extends ThreeOperandInstruction {
   }
 
   async execute(context: AvmContext): Promise<void> {
+    context.machineState.memory.checkTags(this.inTag, this.aOffset, this.bOffset);
+
     const a = context.machineState.memory.get(this.aOffset);
     const b = context.machineState.memory.get(this.bOffset);
 

--- a/yarn-project/simulator/src/avm/opcodes/comparators.ts
+++ b/yarn-project/simulator/src/avm/opcodes/comparators.ts
@@ -1,4 +1,5 @@
 import type { AvmContext } from '../avm_context.js';
+import { TaggedMemory } from '../avm_memory_types.js';
 import { Opcode } from '../serialization/instruction_serialization.js';
 import { ThreeOperandInstruction } from './instruction_impl.js';
 
@@ -16,8 +17,7 @@ export class Eq extends ThreeOperandInstruction {
     const a = context.machineState.memory.get(this.aOffset);
     const b = context.machineState.memory.get(this.bOffset);
 
-    // Result will be of the same type as 'a'.
-    const dest = a.build(a.equals(b) ? 1n : 0n);
+    const dest = TaggedMemory.buildFromTagOrDie(a.equals(b) ? 1n : 0n, this.inTag);
     context.machineState.memory.set(this.dstOffset, dest);
 
     context.machineState.incrementPc();
@@ -38,8 +38,7 @@ export class Lt extends ThreeOperandInstruction {
     const a = context.machineState.memory.get(this.aOffset);
     const b = context.machineState.memory.get(this.bOffset);
 
-    // Result will be of the same type as 'a'.
-    const dest = a.build(a.lt(b) ? 1n : 0n);
+    const dest = TaggedMemory.buildFromTagOrDie(a.lt(b) ? 1n : 0n, this.inTag);
     context.machineState.memory.set(this.dstOffset, dest);
 
     context.machineState.incrementPc();
@@ -60,8 +59,7 @@ export class Lte extends ThreeOperandInstruction {
     const a = context.machineState.memory.get(this.aOffset);
     const b = context.machineState.memory.get(this.bOffset);
 
-    // Result will be of the same type as 'a'.
-    const dest = a.build(a.equals(b) || a.lt(b) ? 1n : 0n);
+    const dest = TaggedMemory.buildFromTagOrDie(a.lt(b) || a.equals(b) ? 1n : 0n, this.inTag);
     context.machineState.memory.set(this.dstOffset, dest);
 
     context.machineState.incrementPc();

--- a/yarn-project/simulator/src/avm/opcodes/control_flow.ts
+++ b/yarn-project/simulator/src/avm/opcodes/control_flow.ts
@@ -4,52 +4,6 @@ import { InstructionExecutionError } from '../errors.js';
 import { Opcode, OperandType } from '../serialization/instruction_serialization.js';
 import { Instruction } from './instruction.js';
 
-export class Return extends Instruction {
-  static type: string = 'RETURN';
-  static readonly opcode: Opcode = Opcode.RETURN;
-  // Informs (de)serialization. See Instruction.deserialize.
-  static readonly wireFormat: OperandType[] = [
-    OperandType.UINT8,
-    OperandType.UINT8,
-    OperandType.UINT32,
-    OperandType.UINT32,
-  ];
-
-  constructor(private indirect: number, private returnOffset: number, private copySize: number) {
-    super();
-  }
-
-  async execute(context: AvmContext): Promise<void> {
-    const output = context.machineState.memory.getSlice(this.returnOffset, this.copySize).map(word => word.toFr());
-
-    context.machineState.return(output);
-  }
-}
-
-export class Revert extends Instruction {
-  static type: string = 'RETURN';
-  static readonly opcode: Opcode = Opcode.REVERT;
-  // Informs (de)serialization. See Instruction.deserialize.
-  static readonly wireFormat: OperandType[] = [
-    OperandType.UINT8,
-    OperandType.UINT8,
-    OperandType.UINT32,
-    OperandType.UINT32,
-  ];
-
-  constructor(private indirect: number, private returnOffset: number, private retSize: number) {
-    super();
-  }
-
-  async execute(context: AvmContext): Promise<void> {
-    const output = context.machineState.memory
-      .getSlice(this.returnOffset, this.returnOffset + this.retSize)
-      .map(word => word.toFr());
-
-    context.machineState.revert(output);
-  }
-}
-
 export class Jump extends Instruction {
   static type: string = 'JUMP';
   static readonly opcode: Opcode = Opcode.JUMP;
@@ -122,7 +76,7 @@ export class InternalReturn extends Instruction {
   async execute(context: AvmContext): Promise<void> {
     const jumpOffset = context.machineState.internalCallStack.pop();
     if (jumpOffset === undefined) {
-      throw new InstructionExecutionError('Internal call empty!');
+      throw new InstructionExecutionError('Internal call stack empty!');
     }
     context.machineState.pc = jumpOffset;
   }

--- a/yarn-project/simulator/src/avm/opcodes/external_calls.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/external_calls.test.ts
@@ -5,13 +5,12 @@ import { mock } from 'jest-mock-extended';
 
 import { CommitmentsDB, PublicContractsDB, PublicStateDB } from '../../index.js';
 import { AvmContext } from '../avm_context.js';
-import { Field } from '../avm_memory_types.js';
+import { Field, Uint8 } from '../avm_memory_types.js';
 import { initContext } from '../fixtures/index.js';
 import { HostStorage } from '../journal/host_storage.js';
 import { AvmPersistableStateManager } from '../journal/journal.js';
 import { encodeToBytecode } from '../serialization/bytecode_serialization.js';
-import { Return } from './control_flow.js';
-import { Call, StaticCall } from './external_calls.js';
+import { Call, Return, Revert, StaticCall } from './external_calls.js';
 import { Instruction } from './instruction.js';
 import { CalldataCopy } from './memory.js';
 import { SStore } from './storage.js';
@@ -94,7 +93,7 @@ describe('External Calls', () => {
       await instruction.execute(context);
 
       const successValue = context.machineState.memory.get(successOffset);
-      expect(successValue).toEqual(new Field(1n));
+      expect(successValue).toEqual(new Uint8(1n));
 
       const retValue = context.machineState.memory.getSlice(retOffset, retSize);
       expect(retValue).toEqual([new Field(1n), new Field(2n)]);
@@ -182,7 +181,71 @@ describe('External Calls', () => {
 
       // No revert has occurred, but the nested execution has failed
       const successValue = context.machineState.memory.get(successOffset);
-      expect(successValue).toEqual(new Field(0n));
+      expect(successValue).toEqual(new Uint8(0n));
+    });
+  });
+
+  describe('RETURN', () => {
+    it('Should (de)serialize correctly', () => {
+      const buf = Buffer.from([
+        Return.opcode, // opcode
+        0x01, // indirect
+        ...Buffer.from('12345678', 'hex'), // returnOffset
+        ...Buffer.from('a2345678', 'hex'), // copySize
+      ]);
+      const inst = new Return(/*indirect=*/ 0x01, /*returnOffset=*/ 0x12345678, /*copySize=*/ 0xa2345678);
+
+      expect(Return.deserialize(buf)).toEqual(inst);
+      expect(inst.serialize()).toEqual(buf);
+    });
+
+    it('Should return data from the return opcode', async () => {
+      const returnData = [new Fr(1n), new Fr(2n), new Fr(3n)];
+
+      context.machineState.memory.set(0, new Field(1n));
+      context.machineState.memory.set(1, new Field(2n));
+      context.machineState.memory.set(2, new Field(3n));
+
+      const instruction = new Return(/*indirect=*/ 0, /*returnOffset=*/ 0, returnData.length);
+      await instruction.execute(context);
+
+      expect(context.machineState.halted).toBe(true);
+      expect(context.machineState.getResults()).toEqual({
+        reverted: false,
+        output: returnData,
+      });
+    });
+  });
+
+  describe('REVERT', () => {
+    it('Should (de)serialize correctly', () => {
+      const buf = Buffer.from([
+        Revert.opcode, // opcode
+        0x01, // indirect
+        ...Buffer.from('12345678', 'hex'), // returnOffset
+        ...Buffer.from('a2345678', 'hex'), // retSize
+      ]);
+      const inst = new Revert(/*indirect=*/ 0x01, /*returnOffset=*/ 0x12345678, /*retSize=*/ 0xa2345678);
+
+      expect(Revert.deserialize(buf)).toEqual(inst);
+      expect(inst.serialize()).toEqual(buf);
+    });
+
+    it('Should return data and revert from the revert opcode', async () => {
+      const returnData = [new Fr(1n), new Fr(2n), new Fr(3n)];
+
+      context.machineState.memory.set(0, new Field(1n));
+      context.machineState.memory.set(1, new Field(2n));
+      context.machineState.memory.set(2, new Field(3n));
+
+      const instruction = new Revert(/*indirect=*/ 0, /*returnOffset=*/ 0, returnData.length);
+      await instruction.execute(context);
+
+      expect(context.machineState.halted).toBe(true);
+      expect(context.machineState.getResults()).toEqual({
+        reverted: true,
+        output: returnData,
+      });
     });
   });
 });

--- a/yarn-project/simulator/src/avm/serialization/instruction_serialization.ts
+++ b/yarn-project/simulator/src/avm/serialization/instruction_serialization.ts
@@ -66,7 +66,6 @@ export enum Opcode {
   REVERT,
   KECCAK,
   POSEIDON,
-  // Add new opcodes before this
   SHA256, // temp - may be removed, but alot of contracts rely on it
   PEDERSEN, // temp - may be removed, but alot of contracts rely on it
   TOTAL_OPCODES_NUMBER,

--- a/yarn-project/simulator/src/avm/serialization/instruction_serialization.ts
+++ b/yarn-project/simulator/src/avm/serialization/instruction_serialization.ts
@@ -7,6 +7,7 @@ import { BufferCursor } from './buffer_cursor.js';
  * Source: https://yp-aztec.netlify.app/docs/public-vm/instruction-set
  */
 export enum Opcode {
+  // Compute
   ADD,
   SUB,
   MUL,
@@ -21,6 +22,7 @@ export enum Opcode {
   SHL,
   SHR,
   CAST,
+  // Execution environment
   ADDRESS,
   STORAGEADDRESS,
   ORIGIN,
@@ -39,16 +41,20 @@ export enum Opcode {
   BLOCKL2GASLIMIT,
   BLOCKDAGASLIMIT,
   CALLDATACOPY,
+  // Gas
   L1GASLEFT,
   L2GASLEFT,
   DAGASLEFT,
+  // Control flow
   JUMP,
   JUMPI,
   INTERNALCALL,
   INTERNALRETURN,
+  // Memory
   SET,
   MOV,
   CMOV,
+  // World state
   SLOAD,
   SSTORE,
   NOTEHASHEXISTS,
@@ -59,16 +65,17 @@ export enum Opcode {
   HEADERMEMBER,
   EMITUNENCRYPTEDLOG,
   SENDL2TOL1MSG,
+  // External calls
   CALL,
   STATICCALL,
   DELEGATECALL,
   RETURN,
   REVERT,
+  // Gadgets
   KECCAK,
   POSEIDON,
   SHA256, // temp - may be removed, but alot of contracts rely on it
   PEDERSEN, // temp - may be removed, but alot of contracts rely on it
-  TOTAL_OPCODES_NUMBER,
 }
 
 // Possible types for an instruction's operand in its wire format. (Keep in sync with CPP code.


### PR DESCRIPTION
* Logging
* `Call` and `StaticCall` were returning Field while per YP should be Uint8.
* I'm also moving the RETURN and REVERT opcodes to `external_calls.ts` (from `control_flow.ts`).

Relates to #4313, #4127.
