### PR TITLE
fix: fail transaction if we revert in setup or teardown

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -38,6 +38,7 @@
     "chainsafe",
     "cheatcode",
     "cheatcodes",
+    "checkpointed",
     "checksummed",
     "cimg",
     "ciphertext",

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/common.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/common.nr
@@ -35,6 +35,10 @@ pub fn validate_inputs(public_call: PublicCallData) {
     assert(public_call.bytecode_hash != 0, "Bytecode hash cannot be zero");
 }
 
+pub fn validate_public_call_non_revert(public_call: PublicCallData) {
+    assert(public_call.call_stack_item.public_inputs.reverted == false, "Public call cannot be reverted");
+}
+
 pub fn initialize_reverted_flag(
     previous_kernel: PublicKernelData,
     public_call: PublicCallData,

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_setup.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_setup.nr
@@ -38,6 +38,8 @@ impl PublicKernelSetupCircuitPrivateInputs {
     fn public_kernel_setup(self) -> PublicKernelCircuitPublicInputs {
         // construct the circuit outputs
         let mut public_inputs: PublicKernelCircuitPublicInputsBuilder = unsafe::zeroed();
+        // since this phase is non-revertible, we must assert the public call did not revert
+        common::validate_public_call_non_revert(self.public_call);
         common::initialize_reverted_flag(self.previous_kernel, self.public_call, &mut public_inputs);
 
         // initialise the end state with our provided previous kernel state
@@ -522,5 +524,13 @@ mod tests {
         assert_eq(request_context.value, request_1.value);
         assert_eq(request_context.counter, request_1.counter);
         assert_eq(request_context.contract_address, storage_contract_address);
+    }
+
+    #[test(should_fail_with="Public call cannot be reverted")]
+    fn fails_if_public_call_reverted() {
+        let mut builder = PublicKernelSetupCircuitPrivateInputsBuilder::new();
+        builder.public_call.public_inputs.reverted = true;
+
+        builder.failed();
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
@@ -26,6 +26,8 @@ impl PublicKernelTeardownCircuitPrivateInputs {
     fn public_kernel_teardown(self) -> PublicKernelCircuitPublicInputs {
         // construct the circuit outputs
         let mut public_inputs: PublicKernelCircuitPublicInputsBuilder = unsafe::zeroed();
+        // since this phase is non-revertible, we must assert the public call did not revert
+        common::validate_public_call_non_revert(self.public_call);
         common::initialize_reverted_flag(self.previous_kernel, self.public_call, &mut public_inputs);
 
         // initialise the end state with our provided previous kernel state
@@ -389,5 +391,13 @@ mod tests {
 
         let expected_unencrypted_logs_hash = compute_logs_hash(prev_unencrypted_logs_hash, unencrypted_logs_hash);
         assert_eq(public_inputs.end.unencrypted_logs_hash, expected_unencrypted_logs_hash);
+    }
+
+    #[test(should_fail_with="Public call cannot be reverted")]
+    fn fails_if_public_call_reverted() {
+        let mut builder = PublicKernelTeardownCircuitPrivateInputsBuilder::new();
+        builder.public_call.public_inputs.reverted = true;
+
+        builder.failed();
     }
 }

--- a/yarn-project/aztec.js/src/contract/sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract/sent_tx.ts
@@ -64,7 +64,9 @@ export class SentTx {
     }
     const receipt = await this.waitForReceipt(opts);
     if (receipt.status !== TxStatus.MINED) {
-      throw new Error(`Transaction ${await this.getTxHash()} was ${receipt.status}`);
+      throw new Error(
+        `Transaction ${await this.getTxHash()} was ${receipt.status}. Reason: ${receipt.error ?? 'unknown'}`,
+      );
     }
     if (opts?.debug) {
       const txHash = await this.getTxHash();

--- a/yarn-project/aztec.js/src/fee/public_fee_payment_method.ts
+++ b/yarn-project/aztec.js/src/fee/public_fee_payment_method.ts
@@ -16,16 +16,16 @@ export class PublicFeePaymentMethod implements FeePaymentMethod {
     /**
      * The asset used to pay the fee.
      */
-    private asset: AztecAddress,
+    protected asset: AztecAddress,
     /**
      * Address which will hold the fee payment.
      */
-    private paymentContract: AztecAddress,
+    protected paymentContract: AztecAddress,
 
     /**
      * An auth witness provider to authorize fee payments
      */
-    private wallet: AccountWallet,
+    protected wallet: AccountWallet,
   ) {}
 
   /**

--- a/yarn-project/sequencer-client/src/sequencer/public_processor.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/public_processor.test.ts
@@ -164,7 +164,7 @@ describe('public_processor', () => {
       expect(failed[0].tx).toEqual(tx);
       expect(failed[0].error).toEqual(new SimulationError(`Failed`, []));
       expect(publicWorldStateDB.commit).toHaveBeenCalledTimes(0);
-      expect(publicWorldStateDB.rollback).toHaveBeenCalledTimes(0);
+      expect(publicWorldStateDB.rollbackToCommit).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -233,8 +233,8 @@ describe('public_processor', () => {
       expect(processed).toEqual([expectedTxByHash(tx)]);
       expect(failed).toHaveLength(0);
       expect(publicExecutor.simulate).toHaveBeenCalledTimes(2);
-      expect(publicWorldStateDB.commit).toHaveBeenCalledTimes(2);
-      expect(publicWorldStateDB.rollback).toHaveBeenCalledTimes(0);
+      expect(publicWorldStateDB.commit).toHaveBeenCalledTimes(1);
+      expect(publicWorldStateDB.rollbackToCommit).toHaveBeenCalledTimes(0);
     });
 
     it('runs a tx with an enqueued public call with nested execution', async function () {
@@ -277,8 +277,10 @@ describe('public_processor', () => {
       expect(processed).toEqual([expectedTxByHash(tx)]);
       expect(failed).toHaveLength(0);
       expect(publicExecutor.simulate).toHaveBeenCalledTimes(1);
-      expect(publicWorldStateDB.commit).toHaveBeenCalledTimes(2);
-      expect(publicWorldStateDB.rollback).toHaveBeenCalledTimes(0);
+      expect(publicWorldStateDB.checkpoint).toHaveBeenCalledTimes(1);
+      expect(publicWorldStateDB.rollbackToCheckpoint).toHaveBeenCalledTimes(0);
+      expect(publicWorldStateDB.commit).toHaveBeenCalledTimes(1);
+      expect(publicWorldStateDB.rollbackToCommit).toHaveBeenCalledTimes(0);
     });
 
     it('rolls back app logic db updates on failed public execution, but persists setup/teardown', async function () {
@@ -378,8 +380,10 @@ describe('public_processor', () => {
       expect(appLogicSpy).toHaveBeenCalledTimes(2);
       expect(teardownSpy).toHaveBeenCalledTimes(2);
       expect(publicExecutor.simulate).toHaveBeenCalledTimes(3);
-      expect(publicWorldStateDB.commit).toHaveBeenCalledTimes(3);
-      expect(publicWorldStateDB.rollback).toHaveBeenCalledTimes(1);
+      expect(publicWorldStateDB.checkpoint).toHaveBeenCalledTimes(2);
+      expect(publicWorldStateDB.rollbackToCheckpoint).toHaveBeenCalledTimes(1);
+      expect(publicWorldStateDB.commit).toHaveBeenCalledTimes(1);
+      expect(publicWorldStateDB.rollbackToCommit).toHaveBeenCalledTimes(0);
 
       expect(arrayNonEmptyLength(processed[0].data.combinedData.publicCallStack, i => i.isEmpty())).toEqual(0);
 
@@ -393,6 +397,215 @@ describe('public_processor', () => {
       );
       expect(txEffect.encryptedLogs.getTotalLogCount()).toBe(0);
       expect(txEffect.unencryptedLogs.getTotalLogCount()).toBe(0);
+    });
+
+    it('fails a transaction that reverts in setup', async function () {
+      const baseContractAddressSeed = 0x200;
+      const baseContractAddress = makeAztecAddress(baseContractAddressSeed);
+      const callRequests: PublicCallRequest[] = [
+        baseContractAddressSeed,
+        baseContractAddressSeed,
+        baseContractAddressSeed,
+      ].map(makePublicCallRequest);
+      callRequests[0].callContext.startSideEffectCounter = 2;
+      callRequests[1].callContext.startSideEffectCounter = 3;
+      callRequests[2].callContext.startSideEffectCounter = 4;
+
+      const kernelOutput = makePrivateKernelTailCircuitPublicInputs(0x10);
+      kernelOutput.end.unencryptedLogsHash = [Fr.ZERO, Fr.ZERO];
+
+      addKernelPublicCallStack(kernelOutput, {
+        setupCalls: [callRequests[0]],
+        appLogicCalls: [callRequests[2]],
+        teardownCall: callRequests[1],
+      });
+
+      const tx = new Tx(
+        kernelOutput,
+        proof,
+        TxL2Logs.empty(),
+        TxL2Logs.empty(),
+        // reverse because `enqueuedPublicFunctions` expects the last element to be the front of the queue
+        callRequests.slice().reverse(),
+        [ExtendedContractData.random()],
+      );
+
+      const contractSlotA = fr(0x100);
+      const contractSlotB = fr(0x150);
+      const contractSlotC = fr(0x200);
+
+      let simulatorCallCount = 0;
+      const simulatorResults: PublicExecutionResult[] = [
+        // Setup
+        PublicExecutionResultBuilder.fromPublicCallRequest({
+          request: callRequests[0],
+          contractStorageUpdateRequests: [new ContractStorageUpdateRequest(contractSlotA, fr(0x101))],
+          nestedExecutions: [
+            PublicExecutionResultBuilder.fromFunctionCall({
+              from: callRequests[1].contractAddress,
+              tx: makeFunctionCall(baseContractAddress, makeSelector(5)),
+              contractStorageUpdateRequests: [
+                new ContractStorageUpdateRequest(contractSlotA, fr(0x102)),
+                new ContractStorageUpdateRequest(contractSlotB, fr(0x151)),
+              ],
+            }).build(),
+            PublicExecutionResultBuilder.fromFunctionCall({
+              from: callRequests[1].contractAddress,
+              tx: makeFunctionCall(baseContractAddress, makeSelector(5)),
+              revertReason: new SimulationError('Simulation Failed', []),
+            }).build(),
+          ],
+        }).build(),
+
+        // App Logic
+        PublicExecutionResultBuilder.fromPublicCallRequest({
+          request: callRequests[2],
+        }).build(),
+
+        // Teardown
+        PublicExecutionResultBuilder.fromPublicCallRequest({
+          request: callRequests[1],
+          nestedExecutions: [
+            PublicExecutionResultBuilder.fromFunctionCall({
+              from: callRequests[1].contractAddress,
+              tx: makeFunctionCall(baseContractAddress, makeSelector(5)),
+              contractStorageUpdateRequests: [new ContractStorageUpdateRequest(contractSlotC, fr(0x201))],
+            }).build(),
+          ],
+        }).build(),
+      ];
+
+      publicExecutor.simulate.mockImplementation(execution => {
+        if (simulatorCallCount < simulatorResults.length) {
+          return Promise.resolve(simulatorResults[simulatorCallCount++]);
+        } else {
+          throw new Error(`Unexpected execution request: ${execution}, call count: ${simulatorCallCount}`);
+        }
+      });
+
+      const setupSpy = jest.spyOn(publicKernel, 'publicKernelCircuitSetup');
+      const appLogicSpy = jest.spyOn(publicKernel, 'publicKernelCircuitAppLogic');
+      const teardownSpy = jest.spyOn(publicKernel, 'publicKernelCircuitTeardown');
+
+      const [processed, failed] = await processor.process([tx]);
+
+      expect(processed).toHaveLength(0);
+      expect(failed).toHaveLength(1);
+      expect(failed[0].tx.getTxHash()).toEqual(tx.getTxHash());
+
+      expect(setupSpy).toHaveBeenCalledTimes(1);
+      expect(appLogicSpy).toHaveBeenCalledTimes(0);
+      expect(teardownSpy).toHaveBeenCalledTimes(0);
+      expect(publicExecutor.simulate).toHaveBeenCalledTimes(1);
+
+      expect(publicWorldStateDB.checkpoint).toHaveBeenCalledTimes(0);
+      expect(publicWorldStateDB.rollbackToCheckpoint).toHaveBeenCalledTimes(0);
+      expect(publicWorldStateDB.commit).toHaveBeenCalledTimes(0);
+      expect(publicWorldStateDB.rollbackToCommit).toHaveBeenCalledTimes(1);
+    });
+
+    it('fails a transaction that reverts in teardown', async function () {
+      const baseContractAddressSeed = 0x200;
+      const baseContractAddress = makeAztecAddress(baseContractAddressSeed);
+      const callRequests: PublicCallRequest[] = [
+        baseContractAddressSeed,
+        baseContractAddressSeed,
+        baseContractAddressSeed,
+      ].map(makePublicCallRequest);
+      callRequests[0].callContext.startSideEffectCounter = 2;
+      callRequests[1].callContext.startSideEffectCounter = 3;
+      callRequests[2].callContext.startSideEffectCounter = 4;
+
+      const kernelOutput = makePrivateKernelTailCircuitPublicInputs(0x10);
+      kernelOutput.end.unencryptedLogsHash = [Fr.ZERO, Fr.ZERO];
+
+      addKernelPublicCallStack(kernelOutput, {
+        setupCalls: [callRequests[0]],
+        appLogicCalls: [callRequests[2]],
+        teardownCall: callRequests[1],
+      });
+
+      const tx = new Tx(
+        kernelOutput,
+        proof,
+        TxL2Logs.empty(),
+        TxL2Logs.empty(),
+        // reverse because `enqueuedPublicFunctions` expects the last element to be the front of the queue
+        callRequests.slice().reverse(),
+        [ExtendedContractData.random()],
+      );
+
+      const contractSlotA = fr(0x100);
+      const contractSlotB = fr(0x150);
+      const contractSlotC = fr(0x200);
+
+      let simulatorCallCount = 0;
+      const simulatorResults: PublicExecutionResult[] = [
+        // Setup
+        PublicExecutionResultBuilder.fromPublicCallRequest({
+          request: callRequests[0],
+          contractStorageUpdateRequests: [new ContractStorageUpdateRequest(contractSlotA, fr(0x101))],
+          nestedExecutions: [
+            PublicExecutionResultBuilder.fromFunctionCall({
+              from: callRequests[1].contractAddress,
+              tx: makeFunctionCall(baseContractAddress, makeSelector(5)),
+              contractStorageUpdateRequests: [
+                new ContractStorageUpdateRequest(contractSlotA, fr(0x102)),
+                new ContractStorageUpdateRequest(contractSlotB, fr(0x151)),
+              ],
+            }).build(),
+          ],
+        }).build(),
+
+        // App Logic
+        PublicExecutionResultBuilder.fromPublicCallRequest({
+          request: callRequests[2],
+        }).build(),
+
+        // Teardown
+        PublicExecutionResultBuilder.fromPublicCallRequest({
+          request: callRequests[1],
+          nestedExecutions: [
+            PublicExecutionResultBuilder.fromFunctionCall({
+              from: callRequests[1].contractAddress,
+              tx: makeFunctionCall(baseContractAddress, makeSelector(5)),
+              revertReason: new SimulationError('Simulation Failed', []),
+            }).build(),
+            PublicExecutionResultBuilder.fromFunctionCall({
+              from: callRequests[1].contractAddress,
+              tx: makeFunctionCall(baseContractAddress, makeSelector(5)),
+              contractStorageUpdateRequests: [new ContractStorageUpdateRequest(contractSlotC, fr(0x201))],
+            }).build(),
+          ],
+        }).build(),
+      ];
+
+      publicExecutor.simulate.mockImplementation(execution => {
+        if (simulatorCallCount < simulatorResults.length) {
+          return Promise.resolve(simulatorResults[simulatorCallCount++]);
+        } else {
+          throw new Error(`Unexpected execution request: ${execution}, call count: ${simulatorCallCount}`);
+        }
+      });
+
+      const setupSpy = jest.spyOn(publicKernel, 'publicKernelCircuitSetup');
+      const appLogicSpy = jest.spyOn(publicKernel, 'publicKernelCircuitAppLogic');
+      const teardownSpy = jest.spyOn(publicKernel, 'publicKernelCircuitTeardown');
+
+      const [processed, failed] = await processor.process([tx]);
+
+      expect(processed).toHaveLength(0);
+      expect(failed).toHaveLength(1);
+      expect(failed[0].tx.getTxHash()).toEqual(tx.getTxHash());
+
+      expect(setupSpy).toHaveBeenCalledTimes(2);
+      expect(appLogicSpy).toHaveBeenCalledTimes(1);
+      expect(teardownSpy).toHaveBeenCalledTimes(2);
+      expect(publicExecutor.simulate).toHaveBeenCalledTimes(3);
+      expect(publicWorldStateDB.checkpoint).toHaveBeenCalledTimes(2);
+      expect(publicWorldStateDB.rollbackToCheckpoint).toHaveBeenCalledTimes(0);
+      expect(publicWorldStateDB.commit).toHaveBeenCalledTimes(0);
+      expect(publicWorldStateDB.rollbackToCommit).toHaveBeenCalledTimes(1);
     });
 
     it('runs a tx with setup and teardown phases', async function () {
@@ -487,8 +700,10 @@ describe('public_processor', () => {
       expect(appLogicSpy).toHaveBeenCalledTimes(1);
       expect(teardownSpy).toHaveBeenCalledTimes(3);
       expect(publicExecutor.simulate).toHaveBeenCalledTimes(3);
-      expect(publicWorldStateDB.commit).toHaveBeenCalledTimes(4);
-      expect(publicWorldStateDB.rollback).toHaveBeenCalledTimes(0);
+      expect(publicWorldStateDB.checkpoint).toHaveBeenCalledTimes(3);
+      expect(publicWorldStateDB.rollbackToCheckpoint).toHaveBeenCalledTimes(0);
+      expect(publicWorldStateDB.commit).toHaveBeenCalledTimes(1);
+      expect(publicWorldStateDB.rollbackToCommit).toHaveBeenCalledTimes(0);
 
       const txEffect = toTxEffect(processed[0]);
       expect(arrayNonEmptyLength(txEffect.publicDataWrites, PublicDataWrite.isEmpty)).toEqual(3);

--- a/yarn-project/sequencer-client/src/sequencer/public_processor.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/public_processor.test.ts
@@ -407,9 +407,9 @@ describe('public_processor', () => {
         baseContractAddressSeed,
         baseContractAddressSeed,
       ].map(makePublicCallRequest);
-      callRequests[0].callContext.startSideEffectCounter = 2;
-      callRequests[1].callContext.startSideEffectCounter = 3;
-      callRequests[2].callContext.startSideEffectCounter = 4;
+      callRequests[0].callContext.sideEffectCounter = 2;
+      callRequests[1].callContext.sideEffectCounter = 3;
+      callRequests[2].callContext.sideEffectCounter = 4;
 
       const kernelOutput = makePrivateKernelTailCircuitPublicInputs(0x10);
       kernelOutput.end.unencryptedLogsHash = [Fr.ZERO, Fr.ZERO];
@@ -511,9 +511,9 @@ describe('public_processor', () => {
         baseContractAddressSeed,
         baseContractAddressSeed,
       ].map(makePublicCallRequest);
-      callRequests[0].callContext.startSideEffectCounter = 2;
-      callRequests[1].callContext.startSideEffectCounter = 3;
-      callRequests[2].callContext.startSideEffectCounter = 4;
+      callRequests[0].callContext.sideEffectCounter = 2;
+      callRequests[1].callContext.sideEffectCounter = 3;
+      callRequests[2].callContext.sideEffectCounter = 4;
 
       const kernelOutput = makePrivateKernelTailCircuitPublicInputs(0x10);
       kernelOutput.end.unencryptedLogsHash = [Fr.ZERO, Fr.ZERO];

--- a/yarn-project/sequencer-client/src/sequencer/public_processor.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/public_processor.test.ts
@@ -427,7 +427,6 @@ describe('public_processor', () => {
         TxL2Logs.empty(),
         // reverse because `enqueuedPublicFunctions` expects the last element to be the front of the queue
         callRequests.slice().reverse(),
-        [ExtendedContractData.random()],
       );
 
       const contractSlotA = fr(0x100);
@@ -532,7 +531,6 @@ describe('public_processor', () => {
         TxL2Logs.empty(),
         // reverse because `enqueuedPublicFunctions` expects the last element to be the front of the queue
         callRequests.slice().reverse(),
-        [ExtendedContractData.random()],
       );
 
       const contractSlotA = fr(0x100);

--- a/yarn-project/sequencer-client/src/sequencer/setup_phase_manager.ts
+++ b/yarn-project/sequencer-client/src/sequencer/setup_phase_manager.ts
@@ -7,7 +7,6 @@ import { PublicProver } from '../prover/index.js';
 import { PublicKernelCircuitSimulator } from '../simulator/index.js';
 import { ContractsDataSourcePublicDB } from '../simulator/public_executor.js';
 import { AbstractPhaseManager, PublicKernelPhase } from './abstract_phase_manager.js';
-import { FailedTx } from './processed_tx.js';
 
 /**
  * The phase manager responsible for performing the fee preparation phase.
@@ -34,21 +33,15 @@ export class SetupPhaseManager extends AbstractPhaseManager {
   ) {
     this.log(`Processing tx ${tx.getTxHash()}`);
     const [publicKernelOutput, publicKernelProof, newUnencryptedFunctionLogs, revertReason] =
-      await this.processEnqueuedPublicCalls(tx, previousPublicKernelOutput, previousPublicKernelProof);
+      await this.processEnqueuedPublicCalls(tx, previousPublicKernelOutput, previousPublicKernelProof).catch(
+        // the abstract phase manager throws if simulation gives error in a non-revertible phase
+        async err => {
+          await this.publicStateDB.rollbackToCommit();
+          throw err;
+        },
+      );
     tx.unencryptedLogs.addFunctionLogs(newUnencryptedFunctionLogs);
-
-    // commit the state updates from this transaction
-    await this.publicStateDB.commit();
-
+    await this.publicStateDB.checkpoint();
     return { publicKernelOutput, publicKernelProof, revertReason };
-  }
-
-  async rollback(tx: Tx, err: unknown): Promise<FailedTx> {
-    this.log.warn(`Error processing tx ${tx.getTxHash()}: ${err}`);
-    await this.publicStateDB.rollback();
-    return {
-      tx,
-      error: err instanceof Error ? err : new Error('Unknown error'),
-    };
   }
 }

--- a/yarn-project/sequencer-client/src/sequencer/tail_phase_manager.ts
+++ b/yarn-project/sequencer-client/src/sequencer/tail_phase_manager.ts
@@ -7,7 +7,6 @@ import { PublicProver } from '../prover/index.js';
 import { PublicKernelCircuitSimulator } from '../simulator/index.js';
 import { ContractsDataSourcePublicDB } from '../simulator/public_executor.js';
 import { AbstractPhaseManager, PublicKernelPhase } from './abstract_phase_manager.js';
-import { FailedTx } from './processed_tx.js';
 
 export class TailPhaseManager extends AbstractPhaseManager {
   constructor(
@@ -26,24 +25,20 @@ export class TailPhaseManager extends AbstractPhaseManager {
 
   async handle(tx: Tx, previousPublicKernelOutput: PublicKernelCircuitPublicInputs, previousPublicKernelProof: Proof) {
     this.log(`Processing tx ${tx.getTxHash()}`);
-    this.log(`Executing tail circuit for tx ${tx.getTxHash()}`);
     const [publicKernelOutput, publicKernelProof] = await this.runKernelCircuit(
       previousPublicKernelOutput,
       previousPublicKernelProof,
+    ).catch(
+      // the abstract phase manager throws if simulation gives error in non-revertible phase
+      async err => {
+        await this.publicStateDB.rollbackToCommit();
+        throw err;
+      },
     );
 
     // commit the state updates from this transaction
     await this.publicStateDB.commit();
 
     return { publicKernelOutput, publicKernelProof, revertReason: undefined };
-  }
-
-  async rollback(tx: Tx, err: unknown): Promise<FailedTx> {
-    this.log.warn(`Error processing tx ${tx.getTxHash()}: ${err}`);
-    await this.publicStateDB.rollback();
-    return {
-      tx,
-      error: err instanceof Error ? err : new Error('Unknown error'),
-    };
   }
 }

--- a/yarn-project/sequencer-client/src/simulator/public_executor.ts
+++ b/yarn-project/sequencer-client/src/simulator/public_executor.ts
@@ -130,9 +130,9 @@ export class ContractsDataSourcePublicDB implements PublicContractsDB {
  * Implements the PublicStateDB using a world-state database.
  */
 export class WorldStatePublicDB implements PublicStateDB {
-  private commitedWriteCache: Map<bigint, Fr> = new Map();
+  private committedWriteCache: Map<bigint, Fr> = new Map();
   private checkpointedWriteCache: Map<bigint, Fr> = new Map();
-  private uncommitedWriteCache: Map<bigint, Fr> = new Map();
+  private uncommittedWriteCache: Map<bigint, Fr> = new Map();
 
   constructor(private db: MerkleTreeOperations) {}
 
@@ -144,13 +144,17 @@ export class WorldStatePublicDB implements PublicStateDB {
    */
   public async storageRead(contract: AztecAddress, slot: Fr): Promise<Fr> {
     const leafSlot = computePublicDataTreeLeafSlot(contract, slot).value;
-    const uncommited = this.uncommitedWriteCache.get(leafSlot);
-    if (uncommited !== undefined) {
-      return uncommited;
+    const uncommitted = this.uncommittedWriteCache.get(leafSlot);
+    if (uncommitted !== undefined) {
+      return uncommitted;
     }
-    const commited = this.commitedWriteCache.get(leafSlot);
-    if (commited !== undefined) {
-      return commited;
+    const checkpointed = this.checkpointedWriteCache.get(leafSlot);
+    if (checkpointed !== undefined) {
+      return checkpointed;
+    }
+    const committed = this.committedWriteCache.get(leafSlot);
+    if (committed !== undefined) {
+      return committed;
     }
 
     const lowLeafResult = await this.db.getPreviousValueIndex(MerkleTreeId.PUBLIC_DATA_TREE, leafSlot);
@@ -174,7 +178,7 @@ export class WorldStatePublicDB implements PublicStateDB {
    */
   public storageWrite(contract: AztecAddress, slot: Fr, newValue: Fr): Promise<void> {
     const index = computePublicDataTreeLeafSlot(contract, slot).value;
-    this.uncommitedWriteCache.set(index, newValue);
+    this.uncommittedWriteCache.set(index, newValue);
     return Promise.resolve();
   }
 
@@ -183,8 +187,13 @@ export class WorldStatePublicDB implements PublicStateDB {
    * @returns Nothing.
    */
   commit(): Promise<void> {
-    for (const [k, v] of this.uncommitedWriteCache) {
-      this.commitedWriteCache.set(k, v);
+    for (const [k, v] of this.checkpointedWriteCache) {
+      this.committedWriteCache.set(k, v);
+    }
+    // uncommitted writes take precedence over checkpointed writes
+    // since they are the most recent
+    for (const [k, v] of this.uncommittedWriteCache) {
+      this.committedWriteCache.set(k, v);
     }
     return this.rollbackToCommit();
   }
@@ -193,16 +202,21 @@ export class WorldStatePublicDB implements PublicStateDB {
    * Rollback the pending changes.
    * @returns Nothing.
    */
-  rollbackToCommit(): Promise<void> {
-    this.uncommitedWriteCache = new Map<bigint, Fr>();
+  async rollbackToCommit(): Promise<void> {
+    await this.rollbackToCheckpoint();
+    this.checkpointedWriteCache = new Map<bigint, Fr>();
     return Promise.resolve();
   }
 
   checkpoint(): Promise<void> {
-    return Promise.resolve();
+    for (const [k, v] of this.uncommittedWriteCache) {
+      this.checkpointedWriteCache.set(k, v);
+    }
+    return this.rollbackToCheckpoint();
   }
 
   rollbackToCheckpoint(): Promise<void> {
+    this.uncommittedWriteCache = new Map<bigint, Fr>();
     return Promise.resolve();
   }
 }

--- a/yarn-project/sequencer-client/src/simulator/public_executor.ts
+++ b/yarn-project/sequencer-client/src/simulator/public_executor.ts
@@ -131,6 +131,7 @@ export class ContractsDataSourcePublicDB implements PublicContractsDB {
  */
 export class WorldStatePublicDB implements PublicStateDB {
   private commitedWriteCache: Map<bigint, Fr> = new Map();
+  private checkpointedWriteCache: Map<bigint, Fr> = new Map();
   private uncommitedWriteCache: Map<bigint, Fr> = new Map();
 
   constructor(private db: MerkleTreeOperations) {}
@@ -185,15 +186,23 @@ export class WorldStatePublicDB implements PublicStateDB {
     for (const [k, v] of this.uncommitedWriteCache) {
       this.commitedWriteCache.set(k, v);
     }
-    return this.rollback();
+    return this.rollbackToCommit();
   }
 
   /**
    * Rollback the pending changes.
    * @returns Nothing.
    */
-  rollback(): Promise<void> {
+  rollbackToCommit(): Promise<void> {
     this.uncommitedWriteCache = new Map<bigint, Fr>();
+    return Promise.resolve();
+  }
+
+  checkpoint(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  rollbackToCheckpoint(): Promise<void> {
     return Promise.resolve();
   }
 }

--- a/yarn-project/sequencer-client/src/simulator/world_state_public_db.test.ts
+++ b/yarn-project/sequencer-client/src/simulator/world_state_public_db.test.ts
@@ -210,4 +210,48 @@ describe('world_state_public_db', () => {
     // should read back the previously committed value
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(newValue);
   });
+
+  it('can use checkpoints', async function () {
+    const publicStateDb = new WorldStatePublicDB(db);
+    const read = () => publicStateDb.storageRead(addresses[0], slots[0]);
+    const write = (value: Fr) => publicStateDb.storageWrite(addresses[0], slots[0], value);
+
+    const newValue = new Fr(dbValues[0].toBigInt() + 1n);
+    const newValue2 = new Fr(dbValues[0].toBigInt() + 2n);
+    const newValue3 = new Fr(dbValues[0].toBigInt() + 3n);
+    const newValue4 = new Fr(dbValues[0].toBigInt() + 4n);
+    const newValue5 = new Fr(dbValues[0].toBigInt() + 5n);
+    const newValue6 = new Fr(dbValues[0].toBigInt() + 6n);
+
+    // basic
+    expect(await read()).toEqual(dbValues[0]);
+    await write(newValue);
+    await publicStateDb.checkpoint();
+    await write(newValue2);
+    await publicStateDb.rollbackToCheckpoint();
+    expect(await read()).toEqual(newValue);
+    await publicStateDb.rollbackToCommit();
+    expect(await read()).toEqual(dbValues[0]);
+
+    // write, checkpoint, commit, rollback to checkpoint, rollback to commit
+    await write(newValue3);
+    await publicStateDb.checkpoint();
+    await publicStateDb.rollbackToCheckpoint();
+    expect(await read()).toEqual(newValue3);
+    await publicStateDb.commit();
+    await publicStateDb.rollbackToCommit();
+    expect(await read()).toEqual(newValue3);
+
+    // writes after checkpoint take precedence
+    await write(newValue4);
+    await publicStateDb.checkpoint();
+    await write(newValue5);
+    await publicStateDb.commit();
+    expect(await read()).toEqual(newValue5);
+
+    // rollback to checkpoint does not cross commit boundaries
+    await write(newValue6);
+    await publicStateDb.rollbackToCheckpoint();
+    expect(await read()).toEqual(newValue5);
+  });
 });

--- a/yarn-project/sequencer-client/src/simulator/world_state_public_db.test.ts
+++ b/yarn-project/sequencer-client/src/simulator/world_state_public_db.test.ts
@@ -104,14 +104,14 @@ describe('world_state_public_db', () => {
     // commit the data
     await publicStateDb.commit();
 
-    // should read back the commited value
+    // should read back the committed value
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(newValue);
 
     // other slots should be unchanged
     expect(await publicStateDb.storageRead(addresses[1], slots[1])).toEqual(dbValues[1]);
   });
 
-  it('will not rollback a commited value', async function () {
+  it('will not rollback a committed value', async function () {
     const publicStateDb = new WorldStatePublicDB(db);
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(dbValues[0]);
 
@@ -123,12 +123,12 @@ describe('world_state_public_db', () => {
     // commit the data
     await publicStateDb.commit();
 
-    // should read back the commited value
+    // should read back the committed value
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(newValue);
 
-    await publicStateDb.rollback();
+    await publicStateDb.rollbackToCommit();
 
-    // should still read back the commited value
+    // should still read back the committed value
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(newValue);
   });
 
@@ -145,7 +145,7 @@ describe('world_state_public_db', () => {
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(newValue);
 
     // now rollback
-    await publicStateDb.rollback();
+    await publicStateDb.rollbackToCommit();
 
     // should now read the original value
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(dbValues[0]);
@@ -163,7 +163,7 @@ describe('world_state_public_db', () => {
     // commit the data
     await publicStateDb.commit();
 
-    // should read back the commited value
+    // should read back the committed value
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(newValue);
 
     // other slots should be unchanged
@@ -178,7 +178,7 @@ describe('world_state_public_db', () => {
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(newValue2);
   });
 
-  it('rolls back to previously commited value', async function () {
+  it('rolls back to previously committed value', async function () {
     const publicStateDb = new WorldStatePublicDB(db);
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(dbValues[0]);
 
@@ -190,7 +190,7 @@ describe('world_state_public_db', () => {
     // commit the data
     await publicStateDb.commit();
 
-    // should read back the commited value
+    // should read back the committed value
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(newValue);
 
     // other slots should be unchanged
@@ -201,13 +201,13 @@ describe('world_state_public_db', () => {
     // write a new value to our first value
     await publicStateDb.storageWrite(addresses[0], slots[0], newValue2);
 
-    // should read back the uncommited value
+    // should read back the uncommitted value
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(newValue2);
 
     // rollback
-    await publicStateDb.rollback();
+    await publicStateDb.rollbackToCommit();
 
-    // should read back the previously commited value
+    // should read back the previously committed value
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(newValue);
   });
 });

--- a/yarn-project/sequencer-client/src/simulator/world_state_public_db.test.ts
+++ b/yarn-project/sequencer-client/src/simulator/world_state_public_db.test.ts
@@ -85,7 +85,7 @@ describe('world_state_public_db', () => {
     // write a new value to our first value
     await publicStateDb.storageWrite(addresses[0], slots[0], newValue);
 
-    // should read back the uncommited value
+    // should read back the uncommitted value
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(newValue);
 
     // other slots should be unchanged
@@ -132,7 +132,7 @@ describe('world_state_public_db', () => {
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(newValue);
   });
 
-  it('reads original value if rolled back uncommited value', async function () {
+  it('reads original value if rolled back uncommitted value', async function () {
     const publicStateDb = new WorldStatePublicDB(db);
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(dbValues[0]);
 
@@ -141,7 +141,7 @@ describe('world_state_public_db', () => {
     // write a new value to our first value
     await publicStateDb.storageWrite(addresses[0], slots[0], newValue);
 
-    // should read back the uncommited value
+    // should read back the uncommitted value
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(newValue);
 
     // now rollback
@@ -174,7 +174,7 @@ describe('world_state_public_db', () => {
     // write a new value to our first value
     await publicStateDb.storageWrite(addresses[0], slots[0], newValue2);
 
-    // should read back the uncommited value
+    // should read back the uncommitted value
     expect(await publicStateDb.storageRead(addresses[0], slots[0])).toEqual(newValue2);
   });
 

--- a/yarn-project/simulator/src/public/db.ts
+++ b/yarn-project/simulator/src/public/db.ts
@@ -28,38 +28,25 @@ export interface PublicStateDB {
   storageWrite(contract: AztecAddress, slot: Fr, newValue: Fr): Promise<void>;
 
   /**
-   * Commit the pending changes to the DB.
-   * @returns Nothing.
+   * Mark the uncommitted changes in this TX as a checkpoint.
+   */
+  checkpoint(): Promise<void>;
+
+  /**
+   * Rollback to the last checkpoint.
+   */
+  rollbackToCheckpoint(): Promise<void>;
+
+  /**
+   * Commit the changes in this TX. Includes all changes since the last commit,
+   * even if they haven't been covered by a checkpoint.
    */
   commit(): Promise<void>;
 
   /**
-   * Rollback the pending changes.
-   * @returns Nothing.
+   * Rollback to the last commit.
    */
-  rollback(): Promise<void>;
-
-  // Proposed interface changes:
-  // /**
-  //  * Mark the uncommitted changes in this TX as a checkpoint.
-  //  */
-  // checkpoint(): Promise<void>;
-
-  // /**
-  //  * Rollback to the last checkpoint.
-  //  */
-  // rollbackToCheckpoint(): Promise<void>;
-
-  // /**
-  //  * Commit the changes in this TX. Includes all changes since the last commit,
-  //  * even if they haven't been covered by a checkpoint.
-  //  */
-  // commit(): Promise<void>;
-
-  // /**
-  //  * Rollback to the last commit.
-  //  */
-  // rollbackToCommit(): Promise<void>;
+  rollbackToCommit(): Promise<void>;
 }
 
 /**

--- a/yarn-project/simulator/src/public/db.ts
+++ b/yarn-project/simulator/src/public/db.ts
@@ -33,6 +33,12 @@ export interface PublicStateDB {
    */
   commit(): Promise<void>;
 
+  /**
+   * Rollback the pending changes.
+   * @returns Nothing.
+   */
+  rollback(): Promise<void>;
+
   // Proposed interface changes:
   // /**
   //  * Mark the uncommitted changes in this TX as a checkpoint.

--- a/yarn-project/simulator/src/public/db.ts
+++ b/yarn-project/simulator/src/public/db.ts
@@ -33,11 +33,27 @@ export interface PublicStateDB {
    */
   commit(): Promise<void>;
 
-  /**
-   * Rollback the pending changes.
-   * @returns Nothing.
-   */
-  rollback(): Promise<void>;
+  // Proposed interface changes:
+  // /**
+  //  * Mark the uncommitted changes in this TX as a checkpoint.
+  //  */
+  // checkpoint(): Promise<void>;
+
+  // /**
+  //  * Rollback to the last checkpoint.
+  //  */
+  // rollbackToCheckpoint(): Promise<void>;
+
+  // /**
+  //  * Commit the changes in this TX. Includes all changes since the last commit,
+  //  * even if they haven't been covered by a checkpoint.
+  //  */
+  // commit(): Promise<void>;
+
+  // /**
+  //  * Rollback to the last commit.
+  //  */
+  // rollbackToCommit(): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
# Introduction

The work done in https://github.com/AztecProtocol/aztec-packages/issues/4971 made it so that if a transaction reverts while executing the "app logic" phase of a transaction, we no longer drop the transaction and instead include it but drop all the revertible side effects.

This work ensures that we do in fact **drop** the transaction if it gives an error in any non-revertible phases, as this would render the transaction invalid.

For more context, see https://github.com/AztecProtocol/aztec-packages/issues/4096.

# Design

We need sequencer and public kernel circuit changes to support this.

## Updates to the public processor and phase managers

At present, we `publicStateDB.commit()` at the end of each phase. This is a problem because if we revert in the teardown phase, we will have already committed the setup phase.

But we need to somehow commit the setup phase, because if we revert in the app logic phase, we need to keep the setup phase.

Broadly, we need to be able to "soft commit" to changes that occur during a phase.

I will call that "soft commit" a "checkpoint".

We then need the ability to `rollback` either to the last `checkpoint`, or to the last `commit`.

To do this, we can modify the `PublicStateDB` interface:

```ts
/**
 * Mark the uncommitted changes in this TX as a checkpoint.
 */
checkpoint(): Promise<void>

/**
 * Rollback to the last checkpoint.
 */
rollbackToCheckpoint(): Promise<void>

/**
 * Commit the changes in this TX. Includes all changes since the last commit,
 * even if they haven't been covered by a checkpoint.
 */
commit(): Promise<void>

/**
 * Rollback to the last commit.
 */
rollbackToCommit(): Promise<void>
```

Under the hood in `WorldStatePublicDB`, all updates will still initially go into the `uncommitedWriteCache`, but we'll just add a new `checkpointedWriteCache`. Only downside is that `storageRead` will need to check both caches, but they should stay small, so it should be fine.

In the `setup_phase_manager` and `teardown_phase_manager` we can do:

```ts
const [
  publicKernelOutput,
  publicKernelProof,
  newUnencryptedFunctionLogs,
  revertReason,
] = await this.processEnqueuedPublicCalls(
  tx,
  previousPublicKernelOutput,
  previousPublicKernelProof
).catch(
  // the abstract phase manager throws if simulation gives error in a non-revertible phase
  async (err) => {
    await this.publicStateDB.rollbackToCommit();
    throw err;
  }
);
tx.unencryptedLogs.addFunctionLogs(newUnencryptedFunctionLogs);
await this.publicStateDB.checkpoint();
return { publicKernelOutput, publicKernelProof, revertReason };
```

In `app_logic_phase_manager`, we can do:

```ts
const [
  publicKernelOutput,
  publicKernelProof,
  newUnencryptedFunctionLogs,
  revertReason,
] = await this.processEnqueuedPublicCalls(
  tx,
  previousPublicKernelOutput,
  previousPublicKernelProof
).catch(
  // if we throw for any reason other than simulation, we need to rollback and drop the TX
  async (err) => {
    await this.publicStateDB.rollbackToCommit();
    throw err;
  }
);

if (revertReason) {
  await this.publicContractsDB.removeNewContracts(tx);
  await this.publicStateDB.rollbackToCheckpoint();
} else {
  tx.unencryptedLogs.addFunctionLogs(newUnencryptedFunctionLogs);
  await this.publicStateDB.checkpoint();
}
return { publicKernelOutput, publicKernelProof, revertReason };
```

And finally in `tail_phase_manager`:

```ts
const [publicKernelOutput, publicKernelProof] = await this.runKernelCircuit(
  previousPublicKernelOutput,
  previousPublicKernelProof
).catch(
  // the abstract phase manager throws if simulation gives error in non-revertible phase
  async (err) => {
    await this.publicStateDB.rollbackToCommit();
    throw err;
  }
);

// commit the state updates from this transaction
await this.publicStateDB.commit();

return { publicKernelOutput, publicKernelProof, revertReason: undefined };
```

## Circuit changes

As a sanity check, we need to verify in the public kernel setup and teardown that the public call did not revert.

# Test Plan

## Unit Tests

Add to `public_processor.test.ts`: show that if a transaction reverts in the setup or teardown phase, it is "Failed" and not "Reverted".

Add to `world_state_public_db.test.ts`: show that the `rollbackToCheckpoint` and `rollbackToCommit` methods work as expected.

Add to setup and teardown public kernel circuits to show that they fail assertions if the public call is `reverted`.

## E2E Tests

In `e2e_fees.test.ts`, we can add bugged `FeePaymentMethod`s that:

- take too much of a fee in setup
- distribute too much of a fee in teardown

# Especially Relevant Parties

- @alexghr
- @PhilWindle
- @LeilaWang

# Plan Approvals

Please add a +1 or comment to express your approval or disapproval of the plan above.
