### PR TITLE
fix: duplicate factory code temporarily to unblock

### DIFF
--- a/yarn-project/circuit-types/src/l2_block.ts
+++ b/yarn-project/circuit-types/src/l2_block.ts
@@ -1,9 +1,10 @@
 import { Body, TxEffect, TxHash } from '@aztec/circuit-types';
 import { AppendOnlyTreeSnapshot, Header, STRING_ENCODING } from '@aztec/circuits.js';
-import { makeAppendOnlyTreeSnapshot, makeHeader } from '@aztec/circuits.js/testing';
 import { sha256 } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
+
+import { makeAppendOnlyTreeSnapshot, makeHeader } from './l2_block_code_to_purge.js';
 
 /**
  * The data that makes up the rollup proof, with encoder decoder functions.

--- a/yarn-project/circuit-types/src/l2_block_code_to_purge.ts
+++ b/yarn-project/circuit-types/src/l2_block_code_to_purge.ts
@@ -1,0 +1,101 @@
+import {
+  AppendOnlyTreeSnapshot,
+  AztecAddress,
+  ContentCommitment,
+  EthAddress,
+  Fr,
+  GlobalVariables,
+  Header,
+  NUM_BYTES_PER_SHA256,
+  PartialStateReference,
+  StateReference,
+} from '@aztec/circuits.js';
+import { toBufferBE } from '@aztec/foundation/bigint-buffer';
+
+/**
+ * Makes header.
+ */
+export function makeHeader(
+  seed = 0,
+  blockNumber: number | undefined = undefined,
+  txsEffectsHash: Buffer | undefined = undefined,
+): Header {
+  return new Header(
+    makeAppendOnlyTreeSnapshot(seed + 0x100),
+    makeContentCommitment(seed + 0x200, txsEffectsHash),
+    makeStateReference(seed + 0x600),
+    makeGlobalVariables((seed += 0x700), blockNumber),
+  );
+}
+
+/**
+ * Makes arbitrary append only tree snapshot.
+ * @param seed - The seed to use for generating the append only tree snapshot.
+ * @returns An append only tree snapshot.
+ */
+export function makeAppendOnlyTreeSnapshot(seed = 1): AppendOnlyTreeSnapshot {
+  return new AppendOnlyTreeSnapshot(new Fr(seed), seed);
+}
+
+/**
+ * Makes content commitment
+ */
+function makeContentCommitment(seed = 0, txsEffectsHash: Buffer | undefined = undefined): ContentCommitment {
+  return new ContentCommitment(
+    new Fr(seed),
+    txsEffectsHash ?? toBufferBE(BigInt(seed + 0x100), NUM_BYTES_PER_SHA256),
+    toBufferBE(BigInt(seed + 0x200), NUM_BYTES_PER_SHA256),
+    toBufferBE(BigInt(seed + 0x300), NUM_BYTES_PER_SHA256),
+  );
+}
+
+/**
+ * Makes arbitrary state reference.
+ * @param seed - The seed to use for generating the state reference.
+ * @returns A state reference.
+ */
+function makeStateReference(seed = 0): StateReference {
+  return new StateReference(makeAppendOnlyTreeSnapshot(seed), makePartialStateReference(seed + 1));
+}
+
+/**
+ * Makes arbitrary partial state reference.
+ * @param seed - The seed to use for generating the partial state reference.
+ * @returns A partial state reference.
+ */
+function makePartialStateReference(seed = 0): PartialStateReference {
+  return new PartialStateReference(
+    makeAppendOnlyTreeSnapshot(seed),
+    makeAppendOnlyTreeSnapshot(seed + 1),
+    makeAppendOnlyTreeSnapshot(seed + 2),
+    makeAppendOnlyTreeSnapshot(seed + 3),
+  );
+}
+
+/**
+ * Makes global variables.
+ * @param seed - The seed to use for generating the global variables.
+ * @param blockNumber - The block number to use for generating the global variables.
+ * If blockNumber is undefined, it will be set to seed + 2.
+ * @returns Global variables.
+ */
+export function makeGlobalVariables(seed = 1, blockNumber: number | undefined = undefined): GlobalVariables {
+  if (blockNumber !== undefined) {
+    return new GlobalVariables(
+      new Fr(seed),
+      new Fr(seed + 1),
+      new Fr(blockNumber),
+      new Fr(seed + 3),
+      EthAddress.fromField(new Fr(seed + 4)),
+      AztecAddress.fromField(new Fr(seed + 5)),
+    );
+  }
+  return new GlobalVariables(
+    new Fr(seed),
+    new Fr(seed + 1),
+    new Fr(seed + 2),
+    new Fr(seed + 3),
+    EthAddress.fromField(new Fr(seed + 4)),
+    AztecAddress.fromField(new Fr(seed + 5)),
+  );
+}

--- a/yarn-project/circuit-types/src/mocks.ts
+++ b/yarn-project/circuit-types/src/mocks.ts
@@ -7,7 +7,6 @@ import {
   MAX_REVERTIBLE_PUBLIC_CALL_STACK_LENGTH_PER_TX,
   Proof,
 } from '@aztec/circuits.js';
-import { makePrivateKernelTailCircuitPublicInputs, makePublicCallRequest } from '@aztec/circuits.js/testing';
 import { ContractArtifact } from '@aztec/foundation/abi';
 import { makeTuple } from '@aztec/foundation/array';
 import { times } from '@aztec/foundation/collection';
@@ -18,6 +17,7 @@ import { ContractInstanceWithAddress, SerializableContractInstance } from '@azte
 import { ExtendedContractData } from './contract_data.js';
 import { DeployedContract } from './interfaces/index.js';
 import { FunctionL2Logs, Note, TxL2Logs } from './logs/index.js';
+import { makePrivateKernelTailCircuitPublicInputs, makePublicCallRequest } from './mocks_to_purge.js';
 import { ExtendedNote } from './notes/index.js';
 import { Tx, TxHash } from './tx/index.js';
 

--- a/yarn-project/circuit-types/src/mocks_to_purge.ts
+++ b/yarn-project/circuit-types/src/mocks_to_purge.ts
@@ -1,0 +1,270 @@
+import {
+  ARGS_LENGTH,
+  AggregationObject,
+  AztecAddress,
+  CallContext,
+  CallRequest,
+  CallerContext,
+  CombinedConstantData,
+  ContractDeploymentData,
+  EthAddress,
+  Fq,
+  Fr,
+  FunctionData,
+  FunctionSelector,
+  G1AffineElement,
+  MAX_NEW_CONTRACTS_PER_TX,
+  MAX_NEW_L2_TO_L1_MSGS_PER_TX,
+  MAX_NON_REVERTIBLE_NOTE_HASHES_PER_TX,
+  MAX_NON_REVERTIBLE_NULLIFIERS_PER_TX,
+  MAX_NON_REVERTIBLE_PUBLIC_CALL_STACK_LENGTH_PER_TX,
+  MAX_PRIVATE_CALL_STACK_LENGTH_PER_TX,
+  MAX_REVERTIBLE_NOTE_HASHES_PER_TX,
+  MAX_REVERTIBLE_NULLIFIERS_PER_TX,
+  MAX_REVERTIBLE_PUBLIC_CALL_STACK_LENGTH_PER_TX,
+  NewContractData,
+  Point,
+  PrivateAccumulatedNonRevertibleData,
+  PrivateAccumulatedRevertibleData,
+  PrivateKernelTailCircuitPublicInputs,
+  PublicCallRequest,
+  SideEffect,
+  SideEffectLinkedToNoteHash,
+  TxContext,
+} from '@aztec/circuits.js';
+import { makeHalfFullTuple, makeTuple, range } from '@aztec/foundation/array';
+
+import { makeHeader } from './l2_block_code_to_purge.js';
+
+/**
+ * Creates arbitrary private kernel tail circuit public inputs.
+ * @param seed - The seed to use for generating the kernel circuit public inputs.
+ * @returns Private kernel tail circuit public inputs.
+ */
+export function makePrivateKernelTailCircuitPublicInputs(seed = 1, full = true): PrivateKernelTailCircuitPublicInputs {
+  return new PrivateKernelTailCircuitPublicInputs(
+    makeAggregationObject(seed),
+    makeAccumulatedNonRevertibleData(seed + 0x100, full),
+    makeFinalAccumulatedData(seed + 0x200, full),
+    makeConstantData(seed + 0x300),
+    true,
+    true,
+    true,
+  );
+}
+
+/**
+ * TODO: Since the max value check is currently disabled this function is pointless. Should it be removed?
+ * Test only. Easy to identify big endian field serialize.
+ * @param n - The number.
+ * @returns The field.
+ */
+export function fr(n: number): Fr {
+  return new Fr(BigInt(n));
+}
+/**
+ * Creates arbitrary aggregation object.
+ * @param seed - The seed to use for generating the aggregation object.
+ * @returns An aggregation object.
+ */
+export function makeAggregationObject(seed = 1): AggregationObject {
+  return new AggregationObject(
+    new G1AffineElement(new Fq(BigInt(seed)), new Fq(BigInt(seed + 1))),
+    new G1AffineElement(new Fq(BigInt(seed + 0x100)), new Fq(BigInt(seed + 0x101))),
+    makeTuple(4, fr, seed + 2),
+    range(6, seed + 6),
+  );
+}
+
+/**
+ * Creates arbitrary accumulated data for a Tx's non-revertible side effects.
+ * @param seed - The seed to use for generating the data.
+ * @returns An instance of AccumulatedNonRevertibleData.
+ */
+export function makeAccumulatedNonRevertibleData(seed = 1, full = false): PrivateAccumulatedNonRevertibleData {
+  const tupleGenerator = full ? makeTuple : makeHalfFullTuple;
+
+  return new PrivateAccumulatedNonRevertibleData(
+    tupleGenerator(MAX_NON_REVERTIBLE_NOTE_HASHES_PER_TX, sideEffectFromNumber, seed + 0x101),
+    tupleGenerator(MAX_NON_REVERTIBLE_NULLIFIERS_PER_TX, sideEffectLinkedFromNumber, seed + 0x201),
+    tupleGenerator(MAX_NON_REVERTIBLE_PUBLIC_CALL_STACK_LENGTH_PER_TX, makeCallRequest, seed + 0x501),
+  );
+}
+
+export function sideEffectFromNumber(n: number): SideEffect {
+  return new SideEffect(new Fr(BigInt(n)), Fr.zero());
+}
+
+/**
+ * Test only. Easy to identify big endian side-effect serialize.
+ * @param n - The number.
+ * @returns The SideEffect instance.
+ */
+export function sideEffectLinkedFromNumber(n: number): SideEffectLinkedToNoteHash {
+  return new SideEffectLinkedToNoteHash(new Fr(BigInt(n)), Fr.zero(), Fr.zero());
+}
+
+/**
+ * Makes arbitrary call stack item.
+ * @param seed - The seed to use for generating the call stack item.
+ * @returns A call stack item.
+ */
+export function makeCallRequest(seed = 1): CallRequest {
+  return new CallRequest(fr(seed), makeAztecAddress(seed + 0x1), makeCallerContext(seed + 0x2), fr(0), fr(0));
+}
+
+/**
+ * Makes arbitrary aztec address.
+ * @param seed - The seed to use for generating the aztec address.
+ * @returns An aztec address.
+ */
+export function makeAztecAddress(seed = 1): AztecAddress {
+  return AztecAddress.fromField(fr(seed));
+}
+
+/**
+ * Makes arbitrary call stack item.
+ * @param seed - The seed to use for generating the call stack item.
+ * @returns A call stack item.
+ */
+export function makeCallerContext(seed = 1): CallerContext {
+  return new CallerContext(makeAztecAddress(seed), makeAztecAddress(seed + 0x1));
+}
+
+/**
+ * Creates arbitrary final accumulated data.
+ * @param seed - The seed to use for generating the final accumulated data.
+ * @returns A final accumulated data.
+ */
+export function makeFinalAccumulatedData(seed = 1, full = false): PrivateAccumulatedRevertibleData {
+  const tupleGenerator = full ? makeTuple : makeHalfFullTuple;
+
+  return new PrivateAccumulatedRevertibleData(
+    tupleGenerator(MAX_REVERTIBLE_NOTE_HASHES_PER_TX, sideEffectFromNumber, seed + 0x100),
+    tupleGenerator(MAX_REVERTIBLE_NULLIFIERS_PER_TX, sideEffectLinkedFromNumber, seed + 0x200),
+    tupleGenerator(MAX_PRIVATE_CALL_STACK_LENGTH_PER_TX, makeCallRequest, seed + 0x400),
+    tupleGenerator(MAX_REVERTIBLE_PUBLIC_CALL_STACK_LENGTH_PER_TX, makeCallRequest, seed + 0x500),
+    tupleGenerator(MAX_NEW_L2_TO_L1_MSGS_PER_TX, fr, seed + 0x600),
+    tupleGenerator(2, fr, seed + 0x700), // encrypted logs hash
+    tupleGenerator(2, fr, seed + 0x800), // unencrypted logs hash
+    fr(seed + 0x900), // encrypted_log_preimages_length
+    fr(seed + 0xa00), // unencrypted_log_preimages_length
+    tupleGenerator(MAX_NEW_CONTRACTS_PER_TX, makeNewContractData, seed + 0xb00),
+  );
+}
+
+/**
+ * Creates arbitrary contract data.
+ * @param seed - The seed to use for generating the contract data.
+ * @returns A contract data.
+ */
+export function makeNewContractData(seed = 1): NewContractData {
+  return new NewContractData(makeAztecAddress(seed), makeEthAddress(seed + 1), fr(seed + 2));
+}
+
+/**
+ * Makes arbitrary eth address.
+ * @param seed - The seed to use for generating the eth address.
+ * @returns An eth address.
+ */
+export function makeEthAddress(seed = 1): EthAddress {
+  return EthAddress.fromField(fr(seed));
+}
+
+/**
+ * Creates arbitrary constant data with the given seed.
+ * @param seed - The seed to use for generating the constant data.
+ * @returns A constant data object.
+ */
+export function makeConstantData(seed = 1): CombinedConstantData {
+  return new CombinedConstantData(makeHeader(seed, undefined), makeTxContext(seed + 4));
+}
+
+/**
+ * Creates an arbitrary tx context with the given seed.
+ * @param seed - The seed to use for generating the tx context.
+ * @returns A tx context.
+ */
+export function makeTxContext(seed: number): TxContext {
+  // @todo @LHerskind should probably take value for chainId as it will be verified later.
+  // @todo @LHerskind should probably take value for version as it will be verified later.
+  return new TxContext(false, false, true, makeContractDeploymentData(seed), Fr.ZERO, Fr.ZERO);
+}
+
+/**
+ * Makes arbitrary contract deployment data.
+ * @param seed - The seed to use for generating the contract deployment data.
+ * @returns A contract deployment data.
+ */
+export function makeContractDeploymentData(seed = 1) {
+  return new ContractDeploymentData(
+    makePoint(seed),
+    fr(seed + 1),
+    fr(seed + 2),
+    fr(seed + 3),
+    makeEthAddress(seed + 4),
+  );
+}
+
+/**
+ * Creates an arbitrary point in a curve.
+ * @param seed - Seed to generate the point values.
+ * @returns A point.
+ */
+export function makePoint(seed = 1): Point {
+  return new Point(fr(seed), fr(seed + 1));
+}
+
+/**
+ * Creates a public call request for testing.
+ * @param seed - The seed.
+ * @returns Public call request.
+ */
+export function makePublicCallRequest(seed = 1): PublicCallRequest {
+  const childCallContext = makeCallContext(seed + 0x2, makeAztecAddress(seed));
+  const parentCallContext = CallContext.from({
+    msgSender: makeAztecAddress(seed + 0x3),
+    storageContractAddress: childCallContext.msgSender,
+    portalContractAddress: makeEthAddress(seed + 2),
+    functionSelector: makeSelector(seed + 3),
+    isStaticCall: false,
+    isDelegateCall: false,
+    isContractDeployment: false,
+    startSideEffectCounter: 0,
+  });
+  return new PublicCallRequest(
+    makeAztecAddress(seed),
+    new FunctionData(makeSelector(seed + 0x1), false, false, false),
+    childCallContext,
+    parentCallContext,
+    makeTuple(ARGS_LENGTH, fr, seed + 0x10),
+  );
+}
+
+/**
+ * Creates arbitrary call context.
+ * @param seed - The seed to use for generating the call context.
+ * @param storageContractAddress - The storage contract address set on the call context.
+ * @returns A call context.
+ */
+export function makeCallContext(seed = 0, storageContractAddress = makeAztecAddress(seed + 1)): CallContext {
+  return new CallContext(
+    makeAztecAddress(seed),
+    storageContractAddress,
+    makeEthAddress(seed + 2),
+    makeSelector(seed + 3),
+    false,
+    false,
+    false,
+    0,
+  );
+}
+
+/**
+ * Creates arbitrary selector from the given seed.
+ * @param seed - The seed to use for generating the selector.
+ * @returns A selector.
+ */
+export function makeSelector(seed: number): FunctionSelector {
+  return new FunctionSelector(seed);
+}


### PR DESCRIPTION
A temporary crime against humanity to fix #5094 without making it a pain for @spalladino to finish what he is working on.

The purge files are to be deleted when a cleanup is performed.
