### PR TITLE
chore(ci): fail on clippy warnings in noir

### DIFF
--- a/noir/noir-repo/tooling/acvm_cli/src/cli/execute_cmd.rs
+++ b/noir/noir-repo/tooling/acvm_cli/src/cli/execute_cmd.rs
@@ -62,18 +62,17 @@ pub(crate) fn run(args: ExecuteCommand) -> Result<String, CliError> {
 
 pub(crate) fn execute_program_from_witness(
     inputs_map: &WitnessMap,
-    bytecode: &Vec<u8>,
+    bytecode: &[u8],
     foreign_call_resolver_url: Option<&str>,
 ) -> Result<WitnessMap, CliError> {
     let blackbox_solver = Bn254BlackBoxSolver::new();
-    let circuit: Circuit = Circuit::deserialize_circuit(&bytecode)
+    let circuit: Circuit = Circuit::deserialize_circuit(bytecode)
         .map_err(|_| CliError::CircuitDeserializationError())?;
-    let result = execute_circuit(
+    execute_circuit(
         &circuit,
         inputs_map.clone(),
         &blackbox_solver,
         &mut DefaultForeignCallExecutor::new(true, foreign_call_resolver_url),
     )
-    .map_err(|e| CliError::CircuitExecutionError(e));
-    result
+    .map_err(CliError::CircuitExecutionError)
 }

--- a/noir/scripts/test_native.sh
+++ b/noir/scripts/test_native.sh
@@ -9,7 +9,7 @@ export GIT_DIRTY=false
 export GIT_COMMIT=${COMMIT_HASH:-$(git rev-parse --verify HEAD)}
 
 cargo fmt --all --check
-cargo clippy --workspace --locked --release
+RUSTFLAGS=-Dwarnings cargo clippy --workspace --locked --release
 
 ./.github/scripts/cargo-binstall-install.sh
 cargo-binstall cargo-nextest --version 0.9.67 -y --secure


### PR DESCRIPTION
Followup to #4763 as we're not failing on clippy warnings.