### PR TITLE
fix: remove hard coded canonical gas address

### DIFF
--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -31,7 +31,6 @@ contract AppSubscription {
 
     global SUBSCRIPTION_DURATION_IN_BLOCKS = 5;
     global SUBSCRIPTION_TXS = 5;
-    global CANONICAL_GAS_TOKEN_ADDRESS = AztecAddress::from_field(10518537853519909204957666322334442672584410385979059968848104222965977783517);
 
     #[aztec(private)]
     fn entrypoint(payload: pub DAppPayload, user_address: pub AztecAddress) {
@@ -82,12 +81,7 @@ contract AppSubscription {
         storage.subscription_recipient_address.initialize(subscription_recipient_address);
         storage.subscription_price.initialize(subscription_price);
 
-        let actual_gas_token_address = if is_empty(gas_token_address) {
-            CANONICAL_GAS_TOKEN_ADDRESS
-        } else {
-            gas_token_address
-        };
-        storage.gas_token_address.initialize(actual_gas_token_address);
+        storage.gas_token_address.initialize(gas_token_address);
     }
 
     #[aztec(public)]

--- a/noir-projects/noir-contracts/contracts/fpc_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/fpc_contract/src/main.nr
@@ -11,19 +11,11 @@ contract FPC {
         gas_token_address: SharedImmutable<AztecAddress>,
     }
 
-    global CANONICAL_GAS_TOKEN_ADDRESS = AztecAddress::from_field(10518537853519909204957666322334442672584410385979059968848104222965977783517);
-
     #[aztec(public)]
     #[aztec(initializer)]
     fn constructor(other_asset: AztecAddress, gas_token_address: AztecAddress) {
-        let actual_gas_token_address = if is_empty(gas_token_address) {
-            CANONICAL_GAS_TOKEN_ADDRESS
-        } else {
-            gas_token_address
-        };
-
         storage.other_asset.initialize(other_asset);
-        storage.gas_token_address.initialize(actual_gas_token_address);
+        storage.gas_token_address.initialize(gas_token_address);
     }
 
     #[aztec(private)]

--- a/yarn-project/end-to-end/src/e2e_dapp_subscription.test.ts
+++ b/yarn-project/end-to-end/src/e2e_dapp_subscription.test.ts
@@ -84,7 +84,7 @@ describe('e2e_dapp_subscription', () => {
     bananaCoin = await BananaCoin.deploy(aliceWallet, aliceAddress, TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS)
       .send()
       .deployed();
-    bananaFPC = await FPCContract.deploy(aliceWallet, bananaCoin.address, AztecAddress.ZERO).send().deployed();
+    bananaFPC = await FPCContract.deploy(aliceWallet, bananaCoin.address, gasTokenContract.address).send().deployed();
 
     counterContract = await CounterContract.deploy(bobWallet, 0, bobAddress).send().deployed();
 
@@ -95,7 +95,7 @@ describe('e2e_dapp_subscription', () => {
       // anyone can purchase a subscription for 100 test tokens
       bananaCoin.address,
       SUBSCRIPTION_AMOUNT,
-      AztecAddress.ZERO,
+      gasTokenContract.address,
     )
       .send()
       .deployed();


### PR DESCRIPTION
Remove canonical gas token address from noir contract and always read it from storage.


