### PR TITLE
chore: extract bb binary in bs fast

### DIFF
--- a/barretenberg/cpp/bootstrap_cache.sh
+++ b/barretenberg/cpp/bootstrap_cache.sh
@@ -4,9 +4,13 @@ set -eu
 cd "$(dirname "$0")"
 source ../../build-system/scripts/setup_env '' '' mainframe_$USER > /dev/null
 
+echo -e "\033[1mRetrieving bb binary from remote cache...\033[0m"
+extract_repo barretenberg-x86_64-linux-clang \
+  /usr/src/barretenberg/cpp/build/bin ./build
+
 echo -e "\033[1mRetrieving bb.wasm from remote cache...\033[0m"
 extract_repo barretenberg-wasm-linux-clang \
-  /usr/src/barretenberg/cpp/build-wasm/bin ./cpp/build-wasm \
-  /usr/src/barretenberg/cpp/build-wasm-threads/bin ./cpp/build-wasm-threads
+  /usr/src/barretenberg/cpp/build-wasm/bin ./build-wasm \
+  /usr/src/barretenberg/cpp/build-wasm-threads/bin ./build-wasm-threads
 
 remove_old_images barretenberg-wasm-linux-clang


### PR DESCRIPTION
* Extract `bb` binary in bootstrap fast (simulator tests were failing locally)
* Remove extra `cpp` in extraction directory: `cpp/cpp/build-*` was being created where the original source had only `cpp/build-*`. Weird that nothing was failing downstream. Does nothing depend on the wasm build right now? Probably it was just being extracted from the docker image as well.
