### PR TITLE
chore: Pin Foundry version

### DIFF
--- a/l1-contracts/scripts/install_foundry.sh
+++ b/l1-contracts/scripts/install_foundry.sh
@@ -6,6 +6,7 @@ FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 BIN_URL="https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup"
 BIN_PATH="$FOUNDRY_BIN_DIR/foundryup"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
+FOUNDRY_VERSION="nightly-5c3b075f6e2adbba6089d15b383450930de283e7"
 
 # Clean
 rm -rf $FOUNDRY_DIR
@@ -18,4 +19,4 @@ chmod +x $BIN_PATH
 export PATH=$FOUNDRY_BIN_DIR:$PATH
 
 # Use version.
-foundryup
+foundryup -v $FOUNDRY_VERSION

--- a/yarn-project/aztec/docker-compose.yml
+++ b/yarn-project/aztec/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   ethereum:
-    image: ghcr.io/foundry-rs/foundry@sha256:29ba6e34379e79c342ec02d437beb7929c9e254261e8032b17e187be71a2609f
+    image: ghcr.io/foundry-rs/foundry:nightly-5c3b075f6e2adbba6089d15b383450930de283e7
     entrypoint: >
       sh -c '
       if [ -n "$FORK_BLOCK_NUMBER" ] && [ -n "$FORK_URL" ]; then

--- a/yarn-project/end-to-end/scripts/docker-compose-anvil.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose-anvil.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: ghcr.io/foundry-rs/foundry:nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43
+    image: ghcr.io/foundry-rs/foundry:nightly-5c3b075f6e2adbba6089d15b383450930de283e7
     entrypoint: 'anvil -p 8545 --host 0.0.0.0 --chain-id 31337'
     ports:
       - '8545:8545'

--- a/yarn-project/end-to-end/scripts/docker-compose-no-sandbox.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose-no-sandbox.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: ghcr.io/foundry-rs/foundry:nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43
+    image: ghcr.io/foundry-rs/foundry:nightly-5c3b075f6e2adbba6089d15b383450930de283e7
     entrypoint: >
       sh -c '
       if [ -n "$FORK_BLOCK_NUMBER" ] && [ -n "$FORK_URL" ]; then

--- a/yarn-project/end-to-end/scripts/docker-compose-p2p.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose-p2p.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: ghcr.io/foundry-rs/foundry:nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43
+    image: ghcr.io/foundry-rs/foundry:nightly-5c3b075f6e2adbba6089d15b383450930de283e7
     entrypoint: 'anvil -p 8545 --host 0.0.0.0 --chain-id 31337'
     ports:
       - '8545:8545'

--- a/yarn-project/end-to-end/scripts/docker-compose.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: ghcr.io/foundry-rs/foundry:nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43
+    image: ghcr.io/foundry-rs/foundry:nightly-5c3b075f6e2adbba6089d15b383450930de283e7
     entrypoint: >
       sh -c '
       if [ -n "$FORK_BLOCK_NUMBER" ] && [ -n "$FORK_URL" ]; then


### PR DESCRIPTION
We were using different Foundry versions locally and on CI. This PR pins the same version for both CI (in docker-compose files) and for local development (in bootstrap.sh). 

Note that we are not pinning to the latest one since it's not currently working, but rather we're pinning `anvil 0.2.0 (5c3b075 2024-03-08T00:17:08.007462509Z)`.