### PR TITLE
refactor: Use context interface in mark-as-initialized

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/initializer.nr
+++ b/noir-projects/aztec-nr/aztec/src/initializer.nr
@@ -2,17 +2,9 @@ use dep::protocol_types::hash::silo_nullifier;
 use crate::context::{PrivateContext, PublicContext, ContextInterface};
 use crate::history::nullifier_inclusion::prove_nullifier_inclusion;
 
-pub fn mark_as_initialized(context: &mut PrivateContext) {
+pub fn mark_as_initialized<TContext>(context: &mut TContext) where TContext: ContextInterface {
     let init_nullifier = compute_unsiloed_contract_initialization_nullifier(*context);
-    context.push_new_nullifier(init_nullifier, 0);
-}
-
-// TODO(@spalladino): Using the trait here fails with "No matching impl found for `&mut TContext: ContextInterface`" 
-// on the `push_new_nullifier` call. Remove this method in favor of a single method that uses the trait (and update 
-// the noir compiler macro accordingly) once we sort it out.
-pub fn mark_as_initialized_public(context: &mut PublicContext) {
-    let init_nullifier = compute_unsiloed_contract_initialization_nullifier(*context);
-    context.push_new_nullifier(init_nullifier, 0);
+    ContextInterface::push_new_nullifier(context, init_nullifier, 0);
 }
 
 pub fn assert_is_initialized<TContext>(context: &mut TContext) where TContext: ContextInterface {

--- a/noir/noir-repo/aztec_macros/src/transforms/functions.rs
+++ b/noir/noir-repo/aztec_macros/src/transforms/functions.rs
@@ -74,7 +74,7 @@ pub fn transform_function(
 
     // Before returning mark the contract as initialized
     if is_initializer {
-        let mark_initialized = create_mark_as_initialized(ty);
+        let mark_initialized = create_mark_as_initialized();
         func.def.body.0.push(mark_initialized);
     }
 
@@ -180,10 +180,9 @@ fn create_init_check() -> Statement {
 /// ```noir
 /// mark_as_initialized(&mut context);
 /// ```
-fn create_mark_as_initialized(ty: &str) -> Statement {
-    let name = if ty == "Public" { "mark_as_initialized_public" } else { "mark_as_initialized" };
+fn create_mark_as_initialized() -> Statement {
     make_statement(StatementKind::Expression(call(
-        variable_path(chained_dep!("aztec", "initializer", name)),
+        variable_path(chained_dep!("aztec", "initializer", "mark_as_initialized")),
         vec![mutable_reference("context")],
     )))
 }


### PR DESCRIPTION
Removes duplicate mark_as_initialized_public method by using the context interface via the trait function syntax. Props to @jfecher for the tip on how to solve it.
