### PR TITLE
feat: Check initialization arguments in constructors

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/interface.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/interface.nr
@@ -9,5 +9,6 @@ trait ContextInterface {
     fn chain_id(self) -> Field;
     fn version(self) -> Field;
     fn selector(self) -> FunctionSelector;
+    fn get_args_hash(self) -> Field;
     fn get_header(self) -> Header;
 }

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -92,6 +92,10 @@ impl ContextInterface for PrivateContext {
         self.inputs.call_context.function_selector
     }
 
+    fn get_args_hash(self) -> Field {
+        self.args_hash
+    }
+
     // Returns the header of a block whose state is used during private execution (not the block the transaction is
     // included in).
     pub fn get_header(self) -> Header {

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -74,6 +74,10 @@ impl ContextInterface for PublicContext {
         self.inputs.call_context.function_selector
     }
 
+    fn get_args_hash(self) -> Field {
+        self.args_hash
+    }
+
     fn get_header(self) -> Header {
         self.historical_header
     }

--- a/noir-projects/aztec-nr/aztec/src/initializer.nr
+++ b/noir-projects/aztec-nr/aztec/src/initializer.nr
@@ -1,6 +1,14 @@
-use dep::protocol_types::hash::silo_nullifier;
-use crate::context::{PrivateContext, PublicContext, ContextInterface};
-use crate::history::nullifier_inclusion::prove_nullifier_inclusion;
+use dep::protocol_types::{
+    hash::{silo_nullifier, pedersen_hash},
+    constants::GENERATOR_INDEX__CONSTRUCTOR,
+    abis::function_selector::FunctionSelector,
+};
+
+use crate::{
+    context::{PrivateContext, PublicContext, ContextInterface},
+    oracle::get_contract_instance::get_contract_instance,
+    history::nullifier_inclusion::prove_nullifier_inclusion,
+};
 
 pub fn mark_as_initialized<TContext>(context: &mut TContext) where TContext: ContextInterface {
     let init_nullifier = compute_unsiloed_contract_initialization_nullifier(*context);
@@ -22,4 +30,15 @@ pub fn compute_contract_initialization_nullifier<TContext>(context: TContext) ->
 
 pub fn compute_unsiloed_contract_initialization_nullifier<TContext>(context: TContext) -> Field where TContext: ContextInterface {
     context.this_address().to_field()
+}
+
+pub fn assert_initialization_args_match_address_preimage<TContext>(context: TContext) where TContext: ContextInterface {
+    let address = context.this_address(); 
+    let instance = get_contract_instance(address);
+    let expected_init = compute_initialization_hash(context.selector(), context.get_args_hash());
+    assert(instance.initialization_hash == expected_init, "Initialization hash does not match");
+}
+
+pub fn compute_initialization_hash(init_selector: FunctionSelector, init_args: Field) -> Field {
+    pedersen_hash([init_selector.to_field(), init_args], GENERATOR_INDEX__CONSTRUCTOR)
 }

--- a/noir-projects/aztec-nr/aztec/src/initializer.nr
+++ b/noir-projects/aztec-nr/aztec/src/initializer.nr
@@ -39,6 +39,6 @@ pub fn assert_initialization_args_match_address_preimage<TContext>(context: TCon
     assert(instance.initialization_hash == expected_init, "Initialization hash does not match");
 }
 
-pub fn compute_initialization_hash(init_selector: FunctionSelector, init_args: Field) -> Field {
-    pedersen_hash([init_selector.to_field(), init_args], GENERATOR_INDEX__CONSTRUCTOR)
+pub fn compute_initialization_hash(init_selector: FunctionSelector, init_args_hash: Field) -> Field {
+    pedersen_hash([init_selector.to_field(), init_args_hash], GENERATOR_INDEX__CONSTRUCTOR)
 }

--- a/noir-projects/noir-contracts/contracts/stateful_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/stateful_test_contract/src/main.nr
@@ -5,7 +5,7 @@ contract StatefulTest {
     use dep::aztec::{
         deploy::{deploy_contract as aztec_deploy_contract}, context::{PublicContext, Context},
         oracle::get_contract_instance::get_contract_instance,
-        initializer::{mark_as_initialized, assert_is_initialized, assert_initialization_args_match_address_preimage}
+        initializer::assert_is_initialized,
     };
 
     struct Storage {
@@ -16,7 +16,6 @@ contract StatefulTest {
     #[aztec(private)]
     #[aztec(initializer)]
     fn constructor(owner: AztecAddress, value: Field) {
-        assert_initialization_args_match_address_preimage(context);
         let selector = FunctionSelector::from_signature("create_note_no_init_check((Field),Field)");
         let _res = context.call_private_function(context.this_address(), selector, [owner.to_field(), value]);
     }
@@ -24,7 +23,6 @@ contract StatefulTest {
     #[aztec(public)]
     #[aztec(initializer)]
     fn public_constructor(owner: AztecAddress, value: Field) {
-        assert_initialization_args_match_address_preimage(context);
         let selector = FunctionSelector::from_signature("increment_public_value_no_init_check((Field),Field)");
         let _res = context.call_public_function(context.this_address(), selector, [owner.to_field(), value]);
     }

--- a/noir-projects/noir-contracts/contracts/stateful_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/stateful_test_contract/src/main.nr
@@ -5,7 +5,7 @@ contract StatefulTest {
     use dep::aztec::{
         deploy::{deploy_contract as aztec_deploy_contract}, context::{PublicContext, Context},
         oracle::get_contract_instance::get_contract_instance,
-        initializer::{mark_as_initialized, assert_is_initialized}
+        initializer::{mark_as_initialized, assert_is_initialized, assert_initialization_args_match_address_preimage}
     };
 
     struct Storage {
@@ -16,6 +16,7 @@ contract StatefulTest {
     #[aztec(private)]
     #[aztec(initializer)]
     fn constructor(owner: AztecAddress, value: Field) {
+        assert_initialization_args_match_address_preimage(context);
         let selector = FunctionSelector::from_signature("create_note_no_init_check((Field),Field)");
         let _res = context.call_private_function(context.this_address(), selector, [owner.to_field(), value]);
     }
@@ -23,6 +24,7 @@ contract StatefulTest {
     #[aztec(public)]
     #[aztec(initializer)]
     fn public_constructor(owner: AztecAddress, value: Field) {
+        assert_initialization_args_match_address_preimage(context);
         let selector = FunctionSelector::from_signature("increment_public_value_no_init_check((Field),Field)");
         let _res = context.call_public_function(context.this_address(), selector, [owner.to_field(), value]);
     }

--- a/noir/noir-repo/aztec_macros/src/transforms/functions.rs
+++ b/noir/noir-repo/aztec_macros/src/transforms/functions.rs
@@ -213,17 +213,20 @@ fn create_internal_check(fname: &str) -> Statement {
 
 /// Creates a call to assert_initialization_args_match_address_preimage to ensure
 /// the initialization arguments used in the init call match the address preimage.
-/// 
+///
 /// ```noir
 /// assert_initialization_args_match_address_preimage(context);
 /// ```
 fn create_assert_init_args() -> Statement {
     make_statement(StatementKind::Expression(call(
-        variable_path(chained_dep!("aztec", "initializer", "assert_initialization_args_match_address_preimage")),
+        variable_path(chained_dep!(
+            "aztec",
+            "initializer",
+            "assert_initialization_args_match_address_preimage"
+        )),
         vec![variable("context")],
     )))
 }
-
 
 /// Creates the private context object to be accessed within the function, the parameters need to be extracted to be
 /// appended into the args hash object.

--- a/noir/noir-repo/aztec_macros/src/transforms/functions.rs
+++ b/noir/noir-repo/aztec_macros/src/transforms/functions.rs
@@ -48,6 +48,12 @@ pub fn transform_function(
         func.def.body.0.insert(0, init_check);
     }
 
+    // Add assertion for initialization arguments
+    if is_initializer {
+        let assert_init_args = create_assert_init_args();
+        func.def.body.0.insert(0, assert_init_args);
+    }
+
     // Add access to the storage struct
     if storage_defined {
         let storage_def = abstract_storage(&ty.to_lowercase(), false);
@@ -204,6 +210,20 @@ fn create_internal_check(fname: &str) -> Statement {
         ConstrainKind::Assert,
     )))
 }
+
+/// Creates a call to assert_initialization_args_match_address_preimage to ensure
+/// the initialization arguments used in the init call match the address preimage.
+/// 
+/// ```noir
+/// assert_initialization_args_match_address_preimage(context);
+/// ```
+fn create_assert_init_args() -> Statement {
+    make_statement(StatementKind::Expression(call(
+        variable_path(chained_dep!("aztec", "initializer", "assert_initialization_args_match_address_preimage")),
+        vec![variable("context")],
+    )))
+}
+
 
 /// Creates the private context object to be accessed within the function, the parameters need to be extracted to be
 /// appended into the args hash object.

--- a/yarn-project/aztec.js/src/account_manager/index.ts
+++ b/yarn-project/aztec.js/src/account_manager/index.ts
@@ -77,14 +77,11 @@ export class AccountManager {
   public getInstance(): ContractInstanceWithAddress {
     if (!this.instance) {
       const encryptionPublicKey = generatePublicKey(this.encryptionPrivateKey);
-      const portalAddress = EthAddress.ZERO;
-      this.instance = getContractInstanceFromDeployParams(
-        this.accountContract.getContractArtifact(),
-        this.accountContract.getDeploymentArgs(),
-        this.salt,
-        encryptionPublicKey,
-        portalAddress,
-      );
+      this.instance = getContractInstanceFromDeployParams(this.accountContract.getContractArtifact(), {
+        constructorArgs: this.accountContract.getDeploymentArgs(),
+        salt: this.salt,
+        publicKey: encryptionPublicKey,
+      });
     }
     return this.instance;
   }

--- a/yarn-project/aztec.js/src/account_manager/index.ts
+++ b/yarn-project/aztec.js/src/account_manager/index.ts
@@ -1,5 +1,5 @@
 import { CompleteAddress, GrumpkinPrivateKey, PXE } from '@aztec/circuit-types';
-import { EthAddress, PublicKey, getContractInstanceFromDeployParams } from '@aztec/circuits.js';
+import { PublicKey, getContractInstanceFromDeployParams } from '@aztec/circuits.js';
 import { Fr } from '@aztec/foundation/fields';
 import { ContractInstanceWithAddress } from '@aztec/types/contracts';
 

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -163,10 +163,13 @@ export class DeployMethod<TContract extends ContractBase = Contract> extends Bas
    */
   public getInstance(options: DeployOptions = {}): ContractInstanceWithAddress {
     if (!this.instance) {
-      const portalContract = options.portalContract ?? EthAddress.ZERO;
-      const contractAddressSalt = options.contractAddressSalt ?? Fr.random();
-      const deployParams = [this.artifact, this.args, contractAddressSalt, this.publicKey, portalContract] as const;
-      this.instance = getContractInstanceFromDeployParams(...deployParams);
+      this.instance = getContractInstanceFromDeployParams(this.artifact, {
+        constructorArgs: this.args,
+        salt: options.contractAddressSalt,
+        portalAddress: options.portalContract,
+        publicKey: this.publicKey,
+        constructorName: this.constructorArtifact.name,
+      });
     }
     return this.instance;
   }

--- a/yarn-project/circuits.js/src/contract/contract_tree/contract_tree.ts
+++ b/yarn-project/circuits.js/src/contract/contract_tree/contract_tree.ts
@@ -20,7 +20,7 @@ export function hashVKStr(vk: string) {
  * Determine if the given function is a constructor.
  * This utility function checks if the 'name' property of the input object is "constructor".
  * Returns true if the function is a constructor, false otherwise.
- *
+ * TODO(palla/purge-old-contract-deploy): Remove me
  * @param Object - An object containing a 'name' property.
  * @returns Boolean indicating if the function is a constructor.
  */

--- a/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
+++ b/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
@@ -14,7 +14,7 @@ import {
   generatePublicKey,
   getContractInstanceFromDeployParams,
 } from '@aztec/aztec.js';
-import { EthAddress, computePartialAddress } from '@aztec/circuits.js';
+import { computePartialAddress } from '@aztec/circuits.js';
 import { InclusionProofsContract } from '@aztec/noir-contracts.js';
 import { ClaimContract } from '@aztec/noir-contracts.js/Claim';
 import { CrowdfundingContract, CrowdfundingContractArtifact } from '@aztec/noir-contracts.js/Crowdfunding';
@@ -108,13 +108,11 @@ describe('e2e_crowdfunding_and_claim', () => {
     const salt = Fr.random();
 
     const args = [donationToken.address, operatorWallet.getAddress(), deadline];
-    const deployInfo = getContractInstanceFromDeployParams(
-      CrowdfundingContractArtifact,
-      args,
+    const deployInfo = getContractInstanceFromDeployParams(CrowdfundingContractArtifact, {
+      constructorArgs: args,
       salt,
-      crowdfundingPublicKey,
-      EthAddress.ZERO,
-    );
+      publicKey: crowdfundingPublicKey,
+    });
     await pxe.registerAccount(crowdfundingPrivateKey, computePartialAddress(deployInfo));
 
     crowdfundingContract = await CrowdfundingContract.deployWithPublicKey(

--- a/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
@@ -13,7 +13,6 @@ import {
   Fr,
   PXE,
   SignerlessWallet,
-  TxStatus,
   Wallet,
   getContractClassFromArtifact,
   getContractInstanceFromDeployParams,
@@ -179,7 +178,7 @@ describe('e2e_deploy_contract', () => {
         const testWallet = kind === 'as entrypoint' ? new SignerlessWallet(pxe) : wallet;
         const owner = await registerRandomAccount(pxe);
         const initArgs: StatefulContractCtorArgs = [owner, 42];
-        const contract = await registerContract(testWallet, StatefulTestContract, initArgs);
+        const contract = await registerContract(testWallet, StatefulTestContract, { initArgs });
         logger.info(`Calling the constructor for ${contract.address}`);
         await contract.methods
           .constructor(...initArgs)
@@ -197,9 +196,11 @@ describe('e2e_deploy_contract', () => {
     // Tests privately initializing multiple undeployed contracts on the same tx through an account contract.
     it('initializes multiple undeployed contracts in a single tx', async () => {
       const owner = await registerRandomAccount(pxe);
-      const initArgs: StatefulContractCtorArgs[] = [42, 52].map(value => [owner, value]);
-      const contracts = await Promise.all(initArgs.map(args => registerContract(wallet, StatefulTestContract, args)));
-      const calls = contracts.map((c, i) => c.methods.constructor(...initArgs[i]).request());
+      const initArgss: StatefulContractCtorArgs[] = [42, 52].map(value => [owner, value]);
+      const contracts = await Promise.all(
+        initArgss.map(initArgs => registerContract(wallet, StatefulTestContract, { initArgs })),
+      );
+      const calls = contracts.map((c, i) => c.methods.constructor(...initArgss[i]).request());
       await new BatchCall(wallet, calls).send().wait();
       expect(await contracts[0].methods.summed_values(owner).view()).toEqual(42n);
       expect(await contracts[1].methods.summed_values(owner).view()).toEqual(52n);
@@ -209,7 +210,7 @@ describe('e2e_deploy_contract', () => {
     it.skip('initializes and calls a private function in a single tx', async () => {
       const owner = await registerRandomAccount(pxe);
       const initArgs: StatefulContractCtorArgs = [owner, 42];
-      const contract = await registerContract(wallet, StatefulTestContract, initArgs);
+      const contract = await registerContract(wallet, StatefulTestContract, { initArgs });
       const batch = new BatchCall(wallet, [
         contract.methods.constructor(...initArgs).request(),
         contract.methods.create_note(owner, 10).request(),
@@ -222,7 +223,7 @@ describe('e2e_deploy_contract', () => {
     it('refuses to initialize a contract twice', async () => {
       const owner = await registerRandomAccount(pxe);
       const initArgs: StatefulContractCtorArgs = [owner, 42];
-      const contract = await registerContract(wallet, StatefulTestContract, initArgs);
+      const contract = await registerContract(wallet, StatefulTestContract, { initArgs });
       await contract.methods
         .constructor(...initArgs)
         .send()
@@ -238,7 +239,7 @@ describe('e2e_deploy_contract', () => {
     it('refuses to call a private function that requires initialization', async () => {
       const owner = await registerRandomAccount(pxe);
       const initArgs: StatefulContractCtorArgs = [owner, 42];
-      const contract = await registerContract(wallet, StatefulTestContract, initArgs);
+      const contract = await registerContract(wallet, StatefulTestContract, { initArgs });
       // TODO(@spalladino): It'd be nicer to be able to fail the assert with a more descriptive message.
       await expect(contract.methods.create_note(owner, 10).send().wait()).rejects.toThrow(
         /nullifier witness not found/i,
@@ -247,7 +248,7 @@ describe('e2e_deploy_contract', () => {
 
     it('refuses to initialize a contract with incorrect args', async () => {
       const owner = await registerRandomAccount(pxe);
-      const contract = await registerContract(wallet, StatefulTestContract, [owner, 42]);
+      const contract = await registerContract(wallet, StatefulTestContract, { initArgs: [owner, 42] });
       await expect(contract.methods.constructor(owner, 43).simulate()).rejects.toThrow(
         /Initialization hash does not match/,
       );
@@ -301,7 +302,7 @@ describe('e2e_deploy_contract', () => {
         let initArgs: StatefulContractCtorArgs;
         let contract: StatefulTestContract;
 
-        const deployInstance = async () => {
+        const deployInstance = async (opts: { constructorName?: string } = {}) => {
           const initArgs = [accounts[0].address, 42] as StatefulContractCtorArgs;
           const salt = Fr.random();
           const portalAddress = EthAddress.random();
@@ -311,6 +312,7 @@ describe('e2e_deploy_contract', () => {
             salt,
             publicKey,
             portalAddress,
+            constructorName: opts.constructorName,
           });
           const { address, contractClassId } = instance;
           logger(`Deploying contract instance at ${address.toString()} class id ${contractClassId.toString()}`);
@@ -325,95 +327,113 @@ describe('e2e_deploy_contract', () => {
           // we are not going to run those - but this may require registering "partial" contracts in the pxe.
           // Anyway, when we implement that, we should be able to replace this `registerContract` with
           // a simpler `Contract.at(instance.address, wallet)`.
-          const registered = await registerContract(wallet, StatefulTestContract, initArgs, {
+          const registered = await registerContract(wallet, StatefulTestContract, {
+            constructorName: opts.constructorName,
             salt: instance.salt,
             portalAddress: instance.portalContractAddress,
             publicKey,
+            initArgs,
           });
           expect(registered.address).toEqual(instance.address);
           const contract = await StatefulTestContract.at(instance.address, wallet);
           return { contract, initArgs, instance, publicKey };
         };
 
-        beforeAll(async () => {
-          ({ instance, initArgs, contract } = await deployInstance());
-        }, 60_000);
+        describe('using a private constructor', () => {
+          beforeAll(async () => {
+            ({ instance, initArgs, contract } = await deployInstance());
+          }, 60_000);
 
-        it('stores contract instance in the aztec node', async () => {
-          const deployed = await aztecNode.getContract(instance.address);
-          expect(deployed).toBeDefined();
-          expect(deployed!.address).toEqual(instance.address);
-          expect(deployed!.contractClassId).toEqual(contractClass.id);
-          expect(deployed!.initializationHash).toEqual(instance.initializationHash);
-          expect(deployed!.portalContractAddress).toEqual(instance.portalContractAddress);
-          expect(deployed!.publicKeysHash).toEqual(instance.publicKeysHash);
-          expect(deployed!.salt).toEqual(instance.salt);
+          it('stores contract instance in the aztec node', async () => {
+            const deployed = await aztecNode.getContract(instance.address);
+            expect(deployed).toBeDefined();
+            expect(deployed!.address).toEqual(instance.address);
+            expect(deployed!.contractClassId).toEqual(contractClass.id);
+            expect(deployed!.initializationHash).toEqual(instance.initializationHash);
+            expect(deployed!.portalContractAddress).toEqual(instance.portalContractAddress);
+            expect(deployed!.publicKeysHash).toEqual(instance.publicKeysHash);
+            expect(deployed!.salt).toEqual(instance.salt);
+          });
+
+          it('calls a public function with no init check on the deployed instance', async () => {
+            const whom = AztecAddress.random();
+            await contract.methods
+              .increment_public_value_no_init_check(whom, 10)
+              .send({ skipPublicSimulation: true })
+              .wait();
+            const stored = await contract.methods.get_public_value(whom).view();
+            expect(stored).toEqual(10n);
+          }, 30_000);
+
+          it('refuses to call a public function with init check if the instance is not initialized', async () => {
+            const whom = AztecAddress.random();
+            await contract.methods.increment_public_value(whom, 10).send({ skipPublicSimulation: true }).wait();
+
+            // TODO(#4972) check for reverted flag
+            // Meanwhile we check we didn't increment the value
+            expect(await contract.methods.get_public_value(whom).view()).toEqual(0n);
+          }, 30_000);
+
+          it('refuses to initialize the instance with wrong args via a private function', async () => {
+            await expect(contract.methods.constructor(AztecAddress.random(), 43).simulate()).rejects.toThrow(
+              /initialization hash does not match/i,
+            );
+          }, 30_000);
+
+          it('initializes the contract and calls a public function', async () => {
+            await contract.methods
+              .constructor(...initArgs)
+              .send()
+              .wait();
+            const whom = AztecAddress.random();
+            await contract.methods.increment_public_value(whom, 10).send({ skipPublicSimulation: true }).wait();
+            const stored = await contract.methods.get_public_value(whom).view();
+            expect(stored).toEqual(10n);
+          }, 30_000);
+
+          it('refuses to reinitialize the contract', async () => {
+            await expect(
+              contract.methods
+                .constructor(...initArgs)
+                .send({ skipPublicSimulation: true })
+                .wait(),
+            ).rejects.toThrow(/dropped/i);
+          }, 30_000);
         });
 
-        it('calls a public function with no init check on the deployed instance', async () => {
-          const whom = AztecAddress.random();
-          await contract.methods
-            .increment_public_value_no_init_check(whom, 10)
-            .send({ skipPublicSimulation: true })
-            .wait();
-          const stored = await contract.methods.get_public_value(whom).view();
-          expect(stored).toEqual(10n);
-        }, 30_000);
+        describe('using a public constructor', () => {
+          beforeAll(async () => {
+            ({ instance, initArgs, contract } = await deployInstance({ constructorName: 'public_constructor' }));
+          }, 60_000);
 
-        it('refuses to call a public function with init check if the instance is not initialized', async () => {
-          // TODO(#4972) check for reverted flag
-          const receipt = await contract.methods
-            .increment_public_value(AztecAddress.random(), 10)
-            .send({ skipPublicSimulation: true })
-            .wait();
+          it('refuses to initialize the instance with wrong args via a public function', async () => {
+            // TODO(@spalladino): This tx is mined but reverts, we need to check revert flag once it's available
+            // Meanwhile, we check that its side effects did not come through as a means to assert it reverted
+            const whom = AztecAddress.random();
+            await contract.methods.public_constructor(whom, 43).send({ skipPublicSimulation: true }).wait();
+            expect(await contract.methods.get_public_value(whom).view()).toEqual(0n);
+          }, 30_000);
 
-          expect(receipt.status).toEqual(TxStatus.MINED);
-        }, 30_000);
-
-        it('refuses to initialize the instance with wrong args via a public function', async () => {
-          const whom = AztecAddress.random();
-          // TODO(@spalladino): This tx is mined but reverts, we need to check revert flag once it's available
-          // Meanwhile, we check that its side effects did not come through as a means to assert it reverted
-          await contract.methods.public_constructor(whom, 43).send({ skipPublicSimulation: true }).wait();
-          expect(await contract.methods.get_public_value(whom).view()).toEqual(0n);
-        }, 30_000);
-
-        it('calls a public function with init check after initialization', async () => {
-          await contract.methods
-            .constructor(...initArgs)
-            .send()
-            .wait();
-          const whom = AztecAddress.random();
-          await contract.methods.increment_public_value(whom, 10).send({ skipPublicSimulation: true }).wait();
-          const stored = await contract.methods.get_public_value(whom).view();
-          expect(stored).toEqual(10n);
-        }, 30_000);
-
-        it('refuses to reinitialize the contract', async () => {
-          await expect(
-            contract.methods
+          it('initializes the contract and calls a public function', async () => {
+            await contract.methods
               .public_constructor(...initArgs)
-              .send({ skipPublicSimulation: true })
-              .wait(),
-          ).rejects.toThrow(/dropped/i);
-        }, 30_000);
+              .send()
+              .wait();
+            const whom = AztecAddress.random();
+            await contract.methods.increment_public_value(whom, 10).send({ skipPublicSimulation: true }).wait();
+            const stored = await contract.methods.get_public_value(whom).view();
+            expect(stored).toEqual(10n);
+          }, 30_000);
 
-        it('initializes a new instance of the contract via a public function', async () => {
-          const { contract, initArgs } = await deployInstance();
-          const whom = initArgs[0];
-          logger.info(`Initializing contract at ${contract.address} via a public function`);
-          await contract.methods
-            .public_constructor(...initArgs)
-            .send({ skipPublicSimulation: true })
-            .wait();
-          expect(await contract.methods.get_public_value(whom).view()).toEqual(42n);
-          logger.info(`Calling a public function that requires initialization on ${contract.address}`);
-          await contract.methods.increment_public_value(whom, 10).send().wait();
-          expect(await contract.methods.get_public_value(whom).view()).toEqual(52n);
-          logger.info(`Calling a private function that requires initialization on ${contract.address}`);
-          await contract.methods.create_note(whom, 10).send().wait();
-          expect(await contract.methods.summed_values(whom).view()).toEqual(10n);
-        }, 90_000);
+          it('refuses to reinitialize the contract', async () => {
+            await expect(
+              contract.methods
+                .public_constructor(...initArgs)
+                .send({ skipPublicSimulation: true })
+                .wait(),
+            ).rejects.toThrow(/dropped/i);
+          }, 30_000);
+        });
       });
 
     testDeployingAnInstance('from a wallet', async instance => {
@@ -492,12 +512,12 @@ type ContractArtifactClass<T extends ContractBase> = {
 async function registerContract<T extends ContractBase>(
   wallet: Wallet,
   contractArtifact: ContractArtifactClass<T>,
-  args: any[] = [],
-  opts: { salt?: Fr; publicKey?: Point; portalAddress?: EthAddress } = {},
+  opts: { salt?: Fr; publicKey?: Point; portalAddress?: EthAddress; initArgs?: any[]; constructorName?: string } = {},
 ): Promise<T> {
-  const { salt, publicKey, portalAddress } = opts;
+  const { salt, publicKey, portalAddress, initArgs, constructorName } = opts;
   const instance = getContractInstanceFromDeployParams(contractArtifact.artifact, {
-    constructorArgs: args,
+    constructorArgs: initArgs ?? [],
+    constructorName,
     salt,
     publicKey,
     portalAddress,

--- a/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
@@ -454,7 +454,7 @@ describe('e2e_deploy_contract', () => {
       expect(await token.methods.is_minter(owner).view()).toEqual(true);
     }, 60_000);
 
-    it.only('publicly deploys and initializes via a public function', async () => {
+    it('publicly deploys and initializes via a public function', async () => {
       const owner = accounts[0];
       logger.debug(`Deploying contract via a public constructor`);
       const contract = await StatefulTestContract.deployWithOpts({ wallet, method: 'public_constructor' }, owner, 42)

--- a/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
@@ -4,7 +4,6 @@ import {
   BatchCall,
   CompleteAddress,
   DebugLogger,
-  EthAddress,
   ExtendedNote,
   Fr,
   GrumpkinPrivateKey,
@@ -59,13 +58,11 @@ describe('e2e_escrow_contract', () => {
     escrowPrivateKey = GrumpkinScalar.random();
     escrowPublicKey = generatePublicKey(escrowPrivateKey);
     const salt = Fr.random();
-    const deployInfo = getContractInstanceFromDeployParams(
-      EscrowContractArtifact,
-      [owner],
+    const deployInfo = getContractInstanceFromDeployParams(EscrowContractArtifact, {
+      constructorArgs: [owner],
       salt,
-      escrowPublicKey,
-      EthAddress.ZERO,
-    );
+      publicKey: escrowPublicKey,
+    });
     await pxe.registerAccount(escrowPrivateKey, computePartialAddress(deployInfo));
 
     escrowContract = await EscrowContract.deployWithPublicKey(escrowPublicKey, wallet, owner)

--- a/yarn-project/end-to-end/src/e2e_inclusion_proofs_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_inclusion_proofs_contract.test.ts
@@ -273,7 +273,7 @@ describe('e2e_inclusion_proofs_contract', () => {
     it('proves public deployment of a contract', async () => {
       // Publicly deploy another contract (so we don't test on the same contract)
       const initArgs = [accounts[0], 42n];
-      const instance = getContractInstanceFromDeployParams(StatefulTestContractArtifact, initArgs);
+      const instance = getContractInstanceFromDeployParams(StatefulTestContractArtifact, { constructorArgs: initArgs });
       await (await registerContractClass(wallets[0], StatefulTestContractArtifact)).send().wait();
       const receipt = await deployInstance(wallets[0], instance).send().wait();
 

--- a/yarn-project/end-to-end/src/sample-dapp/index.mjs
+++ b/yarn-project/end-to-end/src/sample-dapp/index.mjs
@@ -103,7 +103,7 @@ async function mintPublicFunds(pxe) {
   // docs:start:showLogs
   const blockNumber = await pxe.getBlockNumber();
   const logs = (await pxe.getUnencryptedLogs(blockNumber, 1)).logs;
-  const textLogs = logs.map(extendedLog => extendedLog.log.data.toString('ascii'));
+  const textLogs = logs.map(extendedLog => extendedLog.toHumanReadable().slice(0, 200));
   for (const log of textLogs) console.log(`Log emitted: ${log}`);
   // docs:end:showLogs
 }

--- a/yarn-project/protocol-contracts/src/protocol_contract.ts
+++ b/yarn-project/protocol-contracts/src/protocol_contract.ts
@@ -24,19 +24,18 @@ export interface ProtocolContract {
 export function getCanonicalProtocolContract(
   artifact: ContractArtifact,
   salt: Fr | number | bigint,
-  initArgs: any[] = [],
+  constructorArgs: any[] = [],
   publicKey: Point = Point.ZERO,
-  portalContractAddress = EthAddress.ZERO,
+  portalAddress = EthAddress.ZERO,
 ): ProtocolContract {
   // TODO(@spalladino): This computes the contract class from the artifact twice.
   const contractClass = getContractClassFromArtifact(artifact);
-  const instance = getContractInstanceFromDeployParams(
-    artifact,
-    initArgs,
-    new Fr(salt),
+  const instance = getContractInstanceFromDeployParams(artifact, {
+    constructorArgs,
+    salt: new Fr(salt),
     publicKey,
-    portalContractAddress,
-  );
+    portalAddress,
+  });
   return {
     instance,
     contractClass,

--- a/yarn-project/sequencer-client/src/simulator/public_executor.ts
+++ b/yarn-project/sequencer-client/src/simulator/public_executor.ts
@@ -79,6 +79,10 @@ export class ContractsDataSourcePublicDB implements PublicContractsDB {
     return Promise.resolve();
   }
 
+  public async getContractInstance(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
+    return this.instanceCache.get(address.toString()) ?? (await this.db.getContract(address));
+  }
+
   async getBytecode(address: AztecAddress, selector: FunctionSelector): Promise<Buffer | undefined> {
     const contract = await this.#getContract(address);
     return contract?.getPublicFunction(selector)?.bytecode;

--- a/yarn-project/simulator/src/acvm/oracle/typed_oracle.ts
+++ b/yarn-project/simulator/src/acvm/oracle/typed_oracle.ts
@@ -69,6 +69,12 @@ export class MessageLoadOracleInputs<N extends number> {
   }
 }
 
+class OracleMethodNotAvailableError extends Error {
+  constructor(methodName: string) {
+    super(`Oracle method ${methodName} is not available.`);
+  }
+}
+
 /**
  * Oracle with typed parameters and typed return values.
  * Methods that require read and/or write will have to be implemented based on the context (public, private, or view)
@@ -80,58 +86,58 @@ export abstract class TypedOracle {
   }
 
   packArguments(_args: Fr[]): Promise<Fr> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('packArguments');
   }
 
   getNullifierKeyPair(_accountAddress: AztecAddress): Promise<KeyPair> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('getNullifierKeyPair');
   }
 
   getPublicKeyAndPartialAddress(_address: AztecAddress): Promise<Fr[] | undefined> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('getPublicKeyAndPartialAddress');
   }
 
   getContractInstance(_address: AztecAddress): Promise<ContractInstance> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('getContractInstance');
   }
 
   getMembershipWitness(_blockNumber: number, _treeId: MerkleTreeId, _leafValue: Fr): Promise<Fr[] | undefined> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('getMembershipWitness');
   }
 
   getSiblingPath(_blockNumber: number, _treeId: MerkleTreeId, _leafIndex: Fr): Promise<Fr[]> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('getSiblingPath');
   }
 
   getNullifierMembershipWitness(_blockNumber: number, _nullifier: Fr): Promise<NullifierMembershipWitness | undefined> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('getNullifierMembershipWitness');
   }
 
   getPublicDataTreeWitness(_blockNumber: number, _leafSlot: Fr): Promise<PublicDataWitness | undefined> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('getPublicDataTreeWitness');
   }
 
   getLowNullifierMembershipWitness(
     _blockNumber: number,
     _nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('getLowNullifierMembershipWitness');
   }
 
   getHeader(_blockNumber: number): Promise<Header | undefined> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('getHeader');
   }
 
   getCompleteAddress(_address: AztecAddress): Promise<CompleteAddress> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('getCompleteAddress');
   }
 
   getAuthWitness(_messageHash: Fr): Promise<Fr[] | undefined> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('getAuthWitness');
   }
 
   popCapsule(): Promise<Fr[]> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('popCapsule');
   }
 
   getNotes(
@@ -146,35 +152,35 @@ export abstract class TypedOracle {
     _offset: number,
     _status: NoteStatus,
   ): Promise<NoteData[]> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('getNotes');
   }
 
   notifyCreatedNote(_storageSlot: Fr, _noteTypeId: Fr, _note: Fr[], _innerNoteHash: Fr): void {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('notifyCreatedNote');
   }
 
   notifyNullifiedNote(_innerNullifier: Fr, _innerNoteHash: Fr): Promise<void> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('notifyNullifiedNote');
   }
 
   checkNullifierExists(_innerNullifier: Fr): Promise<boolean> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('checkNullifierExists');
   }
 
   getL1ToL2MembershipWitness(_entryKey: Fr): Promise<MessageLoadOracleInputs<typeof L1_TO_L2_MSG_TREE_HEIGHT>> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('getL1ToL2MembershipWitness');
   }
 
   getPortalContractAddress(_contractAddress: AztecAddress): Promise<EthAddress> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('getPortalContractAddress');
   }
 
   storageRead(_startStorageSlot: Fr, _numberOfElements: number): Promise<Fr[]> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('storageRead');
   }
 
   storageWrite(_startStorageSlot: Fr, _values: Fr[]): Promise<Fr[]> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('storageWrite');
   }
 
   emitEncryptedLog(
@@ -184,11 +190,11 @@ export abstract class TypedOracle {
     _publicKey: PublicKey,
     _log: Fr[],
   ): void {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('emitEncryptedLog');
   }
 
   emitUnencryptedLog(_log: UnencryptedL2Log): void {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('emitUnencryptedLog');
   }
 
   callPrivateFunction(
@@ -199,7 +205,7 @@ export abstract class TypedOracle {
     _isStaticCall: boolean,
     _isDelegateCall: boolean,
   ): Promise<PrivateCallStackItem> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('callPrivateFunction');
   }
 
   callPublicFunction(
@@ -209,7 +215,7 @@ export abstract class TypedOracle {
     _isStaticCall: boolean,
     _isDelegateCall: boolean,
   ): Promise<Fr[]> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('callPublicFunction');
   }
 
   enqueuePublicFunctionCall(
@@ -220,6 +226,6 @@ export abstract class TypedOracle {
     _isStaticCall: boolean,
     _isDelegateCall: boolean,
   ): Promise<PublicCallRequest> {
-    throw new Error('Not available.');
+    throw new OracleMethodNotAvailableError('enqueuePublicFunctionCall');
   }
 }

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -293,10 +293,11 @@ describe('Private Execution test suite', () => {
     });
 
     it('should have a constructor with arguments that inserts notes', async () => {
-      const instance = getContractInstanceFromDeployParams(StatefulTestContractArtifact, [owner, 140]);
+      const initArgs = [owner, 140];
+      const instance = getContractInstanceFromDeployParams(StatefulTestContractArtifact, { constructorArgs: initArgs });
       oracle.getContractInstance.mockResolvedValue(instance);
       const artifact = getFunctionArtifact(StatefulTestContractArtifact, 'constructor');
-      const topLevelResult = await runSimulator({ args: [owner, 140], artifact, contractAddress: instance.address });
+      const topLevelResult = await runSimulator({ args: initArgs, artifact, contractAddress: instance.address });
       const result = topLevelResult.nestedExecutions[0];
 
       expect(result.newNotes).toHaveLength(1);

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -15,6 +15,7 @@ import {
   computeNullifierSecretKey,
   computeSiloedNullifierSecretKey,
   derivePublicKey,
+  getContractInstanceFromDeployParams,
   nonEmptySideEffects,
   sideEffectArrayToValueArray,
 } from '@aztec/circuits.js';
@@ -117,13 +118,7 @@ describe('Private Execution test suite', () => {
       authWitnesses: [],
     });
 
-    return acirSimulator.run(
-      txRequest,
-      artifact,
-      functionData.isConstructor ? AztecAddress.ZERO : contractAddress,
-      portalContractAddress,
-      msgSender,
-    );
+    return acirSimulator.run(txRequest, artifact, contractAddress, portalContractAddress, msgSender);
   };
 
   const insertLeaves = async (leaves: Fr[], name = 'noteHash') => {
@@ -298,8 +293,10 @@ describe('Private Execution test suite', () => {
     });
 
     it('should have a constructor with arguments that inserts notes', async () => {
+      const instance = getContractInstanceFromDeployParams(StatefulTestContractArtifact, [owner, 140]);
+      oracle.getContractInstance.mockResolvedValue(instance);
       const artifact = getFunctionArtifact(StatefulTestContractArtifact, 'constructor');
-      const topLevelResult = await runSimulator({ args: [owner, 140], artifact });
+      const topLevelResult = await runSimulator({ args: [owner, 140], artifact, contractAddress: instance.address });
       const result = topLevelResult.nestedExecutions[0];
 
       expect(result.newNotes).toHaveLength(1);

--- a/yarn-project/simulator/src/public/db.ts
+++ b/yarn-project/simulator/src/public/db.ts
@@ -2,6 +2,7 @@ import { NullifierMembershipWitness } from '@aztec/circuit-types';
 import { EthAddress, FunctionSelector, L1_TO_L2_MSG_TREE_HEIGHT } from '@aztec/circuits.js';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
+import { ContractInstanceWithAddress } from '@aztec/types/contracts';
 
 import { MessageLoadOracleInputs } from '../acvm/index.js';
 
@@ -65,6 +66,13 @@ export interface PublicContractsDB {
    * @returns The portal contract address or undefined if not found.
    */
   getPortalContractAddress(address: AztecAddress): Promise<EthAddress | undefined>;
+
+  /**
+   * Returns a publicly deployed contract instance.
+   * @param address - Address of the contract.
+   * @returns The contract instance or undefined if not found.
+   */
+  getContractInstance(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined>;
 }
 
 /** Database interface for providing access to commitment tree, l1 to l2 message tree, and nullifier tree. */

--- a/yarn-project/simulator/src/public/public_execution_context.ts
+++ b/yarn-project/simulator/src/public/public_execution_context.ts
@@ -4,6 +4,7 @@ import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { createDebugLogger } from '@aztec/foundation/log';
+import { ContractInstance } from '@aztec/types/contracts';
 
 import { TypedOracle, toACVMWitness } from '../acvm/index.js';
 import { PackedArgsCache, SideEffectCounter } from '../common/index.js';
@@ -236,5 +237,13 @@ export class PublicExecutionContext extends TypedOracle {
       throw new Error(`Public execution oracle can only access nullifier membership witnesses for the current block`);
     }
     return await this.commitmentsDb.getNullifierMembershipWitnessAtLatestBlock(nullifier);
+  }
+
+  public async getContractInstance(address: AztecAddress): Promise<ContractInstance> {
+    const instance = await this.contractsDb.getContractInstance(address);
+    if (!instance) {
+      throw new Error(`Contract instance at ${address} not found`);
+    }
+    return instance;
   }
 }

--- a/yarn-project/simulator/src/public/public_execution_context.ts
+++ b/yarn-project/simulator/src/public/public_execution_context.ts
@@ -240,6 +240,11 @@ export class PublicExecutionContext extends TypedOracle {
   }
 
   public async getContractInstance(address: AztecAddress): Promise<ContractInstance> {
+    // Note to AVM implementor: The wrapper of the oracle call get_contract_instance in aztec-nr
+    // automatically checks that the returned instance is correct, by hashing it together back
+    // into the address. However, in the AVM, we also need to prove the negative, otherwise a malicious
+    // sequencer could just lie about not having the instance available in its local db. We can do this
+    // by using the prove_contract_non_deployment_at method if the contract is not found in the db.
     const instance = await this.contractsDb.getContractInstance(address);
     if (!instance) {
       throw new Error(`Contract instance at ${address} not found`);


### PR DESCRIPTION
The responsibility to check that the initialization arguments used when calling the initializer as correct is responsibility of the initializer itself. Without this check, a deployer could commit to a set of init args in the address preimage, but then call the initializer using something totally different.

Fixes #5154