### PR TITLE
feat: Further ClientIVC breakdown

### DIFF
--- a/barretenberg/cpp/scripts/analyze_client_ivc_bench.py
+++ b/barretenberg/cpp/scripts/analyze_client_ivc_bench.py
@@ -27,13 +27,13 @@ bench_components = dict(filter(lambda x: x[0] in to_keep, bench.items()))
 # For each kept time, get the proportion over all kept times.
 sum_of_kept_times_ms = sum(float(time)
                            for _, time in bench_components.items())/1e6
-MAX_LABEL_LENGTH = max(len(label) for label in to_keep)
+max_label_length = max(len(label) for label in to_keep)
 column = {"function": "function", "ms": "ms", "%": "% sum"}
 print(
-    f"{column['function']:<{MAX_LABEL_LENGTH}}{column['ms']:>8}  {column['%']:>8}")
+    f"{column['function']:<{max_label_length}}{column['ms']:>8}  {column['%']:>8}")
 for key in to_keep:
     time_ms = bench[key]/1e6
-    print(f"{key:<{MAX_LABEL_LENGTH}}{time_ms:>8.0f}  {time_ms/sum_of_kept_times_ms:>8.2%}")
+    print(f"{key:<{max_label_length}}{time_ms:>8.0f}  {time_ms/sum_of_kept_times_ms:>8.2%}")
 
 # Validate that kept times account for most of the total measured time.
 total_time_ms = bench["real_time"]
@@ -42,8 +42,31 @@ totals = totals.format(
     sum_of_kept_times_ms, total_time_ms, sum_of_kept_times_ms/total_time_ms)
 print(totals)
 
+print("\nMajor contributors:")
+print(
+    f"{column['function']:<{max_label_length}}{column['ms']:>8}  {column['%']:>7}")
+for key in ['commit(t)', 'compute_combiner(t)', 'compute_perturbator(t)', 'compute_univariate(t)']:
+    time_ms = bench[key]/1e6
+    print(f"{key:<{max_label_length}}{time_ms:>8.0f} {time_ms/sum_of_kept_times_ms:>8.2%}")
+
+
 print('\nBreakdown of ECCVMProver::create_prover:')
 for key in ["ECCVMComposer::compute_witness(t)", "ECCVMComposer::create_proving_key(t)"]:
     time_ms = bench[key]/1e6
     total_time_ms = bench["ECCVMComposer::create_prover(t)"]/1e6
-    print(f"{key:<{MAX_LABEL_LENGTH}}{time_ms:>8.0f}  {time_ms/total_time_ms:>8.2%}")
+    print(f"{key:<{max_label_length}}{time_ms:>8.0f}  {time_ms/total_time_ms:>8.2%}")
+
+print('\nBreakdown of ProtogalaxyProver::fold_instances:')
+protogalaxy_round_labels = [
+    "ProtoGalaxyProver_::preparation_round(t)", 
+    "ProtoGalaxyProver_::perturbator_round(t)", 
+    "ProtoGalaxyProver_::combiner_quotient_round(t)", 
+    "ProtoGalaxyProver_::accumulator_update_round(t)"
+]
+max_label_length = max(len(label) for label in protogalaxy_round_labels)
+for key in protogalaxy_round_labels:
+    time_ms = bench[key]/1e6
+    total_time_ms = bench["ProtogalaxyProver::fold_instances(t)"]/1e6
+    print(f"{key:<{max_label_length}}{time_ms:>8.0f}  {time_ms/total_time_ms:>8.2%}")
+
+

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.cpp
@@ -199,11 +199,13 @@ std::shared_ptr<typename ProverInstances::Instance> ProtoGalaxyProver_<ProverIns
 
 template <class ProverInstances> void ProtoGalaxyProver_<ProverInstances>::preparation_round()
 {
+    BB_OP_COUNT_TIME_NAME("ProtoGalaxyProver_::preparation_round");
     prepare_for_folding();
 };
 
 template <class ProverInstances> void ProtoGalaxyProver_<ProverInstances>::perturbator_round()
 {
+    BB_OP_COUNT_TIME_NAME("ProtoGalaxyProver_::perturbator_round");
     state.accumulator = get_accumulator();
     FF delta = transcript->template get_challenge<FF>("delta");
     state.deltas = compute_round_challenge_pows(state.accumulator->proving_key->log_circuit_size, delta);
@@ -221,6 +223,7 @@ template <class ProverInstances> void ProtoGalaxyProver_<ProverInstances>::pertu
 
 template <class ProverInstances> void ProtoGalaxyProver_<ProverInstances>::combiner_quotient_round()
 {
+    BB_OP_COUNT_TIME_NAME("ProtoGalaxyProver_::combiner_quotient_round");
     auto perturbator_challenge = transcript->template get_challenge<FF>("perturbator_challenge");
     instances.next_gate_challenges =
         update_gate_challenges(perturbator_challenge, state.accumulator->gate_challenges, state.deltas);
@@ -239,6 +242,7 @@ template <class ProverInstances> void ProtoGalaxyProver_<ProverInstances>::combi
 
 template <class ProverInstances> void ProtoGalaxyProver_<ProverInstances>::accumulator_update_round()
 {
+    BB_OP_COUNT_TIME_NAME("ProtoGalaxyProver_::accumulator_update_round");
     FF combiner_challenge = transcript->template get_challenge<FF>("combiner_quotient_challenge");
     std::shared_ptr<Instance> next_accumulator =
         compute_next_accumulator(instances, state.combiner_quotient, combiner_challenge, state.compressed_perturbator);

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
@@ -106,6 +106,8 @@ template <typename Flavor> class SumcheckProverRound {
         const bb::PowPolynomial<FF>& pow_polynomial,
         const RelationSeparator alpha)
     {
+        BB_OP_COUNT_TIME();
+
         // Compute the constant contribution of pow polynomials for each edge. This is  the product of the partial
         // evaluation result c_l (i.e. pow(u_0,...,u_{l-1})) where u_0,...,u_{l-1} are the verifier challenges from
         // previous rounds) and the elements of pow(\vec{β}) not containing β_0,..., β_l.


### PR DESCRIPTION
Further breakdown of the ClientIVC benchmarks, showing the contributions of major operations (e.g. commitments, combiner computation), and breaking down Protogalaxy prover and ECCVM prover construction costs.

```
Benchmarking lock created at ~/BENCHMARK_IN_PROGRESS.
client_ivc_bench                                                              100%   15MB  48.4MB/s   00:00    
2024-03-12T03:38:23+00:00
Running ./client_ivc_bench
Run on (16 X 3000 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 36608 KiB (x1)
Load Average: 0.00, 0.00, 0.11
--------------------------------------------------------------------------------
Benchmark                      Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------
ClientIVCBench/Full/6      29446 ms        24872 ms            1 Decider::construct_proof=1 Decider::construct_proof(t)=753.082M ECCVMComposer::compute_commitment_key=1 ECCVMComposer::compute_commitment_key(t)=3.78026M ECCVMComposer::compute_witness=1 ECCVMComposer::compute_witness(t)=1.73739G ECCVMComposer::create_prover=1 ECCVMComposer::create_prover(t)=3.40893G ECCVMComposer::create_proving_key=1 ECCVMComposer::create_proving_key(t)=1.66752G ECCVMProver::construct_proof=1 ECCVMProver::construct_proof(t)=1.76066G Goblin::merge=11 Goblin::merge(t)=128.627M GoblinTranslatorCircuitBuilder::constructor=1 GoblinTranslatorCircuitBuilder::constructor(t)=56.5845M GoblinTranslatorComposer::create_prover=1 GoblinTranslatorComposer::create_prover(t)=123.279M GoblinTranslatorProver::construct_proof=1 GoblinTranslatorProver::construct_proof(t)=927.524M ProtoGalaxyProver_::accumulator_update_round=10 ProtoGalaxyProver_::accumulator_update_round(t)=3.46156G ProtoGalaxyProver_::combiner_quotient_round=10 ProtoGalaxyProver_::combiner_quotient_round(t)=7.17713G ProtoGalaxyProver_::perturbator_round=10 ProtoGalaxyProver_::perturbator_round(t)=1.38221G ProtoGalaxyProver_::preparation_round=10 ProtoGalaxyProver_::preparation_round(t)=4.1G ProtogalaxyProver::fold_instances=10 ProtogalaxyProver::fold_instances(t)=16.1209G ProverInstance(Circuit&)=11 ProverInstance(Circuit&)(t)=1.945G batch_mul_with_endomorphism=30 batch_mul_with_endomorphism(t)=562.528M commit=425 commit(t)=3.96966G compute_combiner=10 compute_combiner(t)=7.175G compute_perturbator=9 compute_perturbator(t)=1.38188G compute_univariate=48 compute_univariate(t)=1.41821G construct_circuits=6 construct_circuits(t)=4.20217G
Benchmarking lock deleted.
client_ivc_bench.json                                                         100% 4015   130.4KB/s   00:00    
function                                        ms     % sum
construct_circuits(t)                         4202    14.31%
ProverInstance(Circuit&)(t)                   1945     6.62%
ProtogalaxyProver::fold_instances(t)         16121    54.89%
Decider::construct_proof(t)                    753     2.56%
ECCVMComposer::create_prover(t)               3409    11.61%
GoblinTranslatorComposer::create_prover(t)     123     0.42%
ECCVMProver::construct_proof(t)               1761     5.99%
GoblinTranslatorProver::construct_proof(t)     928     3.16%
Goblin::merge(t)                               129     0.44%

Total time accounted for: 29370ms/29446ms = 99.74%

Major contributors:
function                                        ms    % sum
commit(t)                                     3970   13.52%
compute_combiner(t)                           7175   24.43%
compute_perturbator(t)                        1382    4.71%
compute_univariate(t)                         1418    4.83%

Breakdown of ECCVMProver::create_prover:
ECCVMComposer::compute_witness(t)             1737    50.97%
ECCVMComposer::create_proving_key(t)          1668    48.92%

Breakdown of ProtogalaxyProver::fold_instances:
ProtoGalaxyProver_::preparation_round(t)           4100    25.43%
ProtoGalaxyProver_::perturbator_round(t)           1382     8.57%
ProtoGalaxyProver_::combiner_quotient_round(t)     7177    44.52%
ProtoGalaxyProver_::accumulator_update_round(t)    3462    21.47%
```