### PR TITLE
chore: pin foundry

### DIFF
--- a/barretenberg/sol/scripts/install_foundry.sh
+++ b/barretenberg/sol/scripts/install_foundry.sh
@@ -6,6 +6,7 @@ FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 BIN_URL="https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup"
 BIN_PATH="$FOUNDRY_BIN_DIR/foundryup"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
+FOUNDRY_VERSION="nightly-de33b6af53005037b463318d2628b5cfcaf39916"
 
 # Clean
 rm -rf $FOUNDRY_DIR
@@ -18,4 +19,4 @@ chmod +x $BIN_PATH
 export PATH=$FOUNDRY_BIN_DIR:$PATH
 
 # Use version.
-foundryup
+foundryup --version $FOUNDRY_VERSION

--- a/iac/mainnet-fork/scripts/install_foundry.sh
+++ b/iac/mainnet-fork/scripts/install_foundry.sh
@@ -6,6 +6,7 @@ FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 BIN_URL="https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup"
 BIN_PATH="$FOUNDRY_BIN_DIR/foundryup"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
+FOUNDRY_VERSION="nightly-de33b6af53005037b463318d2628b5cfcaf39916"
 
 # Clean
 rm -rf $FOUNDRY_DIR
@@ -18,4 +19,4 @@ chmod +x $BIN_PATH
 export PATH=$FOUNDRY_BIN_DIR:$PATH
 
 # Use version.
-foundryup
+foundryup --version $FOUNDRY_VERSION

--- a/l1-contracts/scripts/install_foundry.sh
+++ b/l1-contracts/scripts/install_foundry.sh
@@ -6,7 +6,7 @@ FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 BIN_URL="https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup"
 BIN_PATH="$FOUNDRY_BIN_DIR/foundryup"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
-FOUNDRY_VERSION="nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a"
+FOUNDRY_VERSION="nightly-de33b6af53005037b463318d2628b5cfcaf39916"
 
 # Clean
 rm -rf $FOUNDRY_DIR

--- a/l1-contracts/scripts/install_foundry.sh
+++ b/l1-contracts/scripts/install_foundry.sh
@@ -6,6 +6,7 @@ FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 BIN_URL="https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup"
 BIN_PATH="$FOUNDRY_BIN_DIR/foundryup"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
+FOUNDRY_VERSION="nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a"
 
 # Clean
 rm -rf $FOUNDRY_DIR

--- a/l1-contracts/scripts/install_foundry.sh
+++ b/l1-contracts/scripts/install_foundry.sh
@@ -19,4 +19,4 @@ chmod +x $BIN_PATH
 export PATH=$FOUNDRY_BIN_DIR:$PATH
 
 # Use version.
-foundryup
+foundryup --version $FOUNDRY_VERSION

--- a/yarn-project/aztec/docker-compose.yml
+++ b/yarn-project/aztec/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   ethereum:
-    image: ghcr.io/foundry-rs/foundry:nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a
+    image: ghcr.io/foundry-rs/foundry:nightly-de33b6af53005037b463318d2628b5cfcaf39916
     entrypoint: >
       sh -c '
       if [ -n "$FORK_BLOCK_NUMBER" ] && [ -n "$FORK_URL" ]; then

--- a/yarn-project/aztec/docker-compose.yml
+++ b/yarn-project/aztec/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   ethereum:
-    image: ghcr.io/foundry-rs/foundry@sha256:29ba6e34379e79c342ec02d437beb7929c9e254261e8032b17e187be71a2609f
+    image: ghcr.io/foundry-rs/foundry:nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a
     entrypoint: >
       sh -c '
       if [ -n "$FORK_BLOCK_NUMBER" ] && [ -n "$FORK_URL" ]; then

--- a/yarn-project/end-to-end/scripts/docker-compose-anvil.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose-anvil.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: ghcr.io/foundry-rs/foundry:nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a
+    image: ghcr.io/foundry-rs/foundry:nightly-de33b6af53005037b463318d2628b5cfcaf39916
     entrypoint: 'anvil -p 8545 --host 0.0.0.0 --chain-id 31337'
     ports:
       - '8545:8545'

--- a/yarn-project/end-to-end/scripts/docker-compose-anvil.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose-anvil.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: ghcr.io/foundry-rs/foundry:nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43
+    image: ghcr.io/foundry-rs/foundry:nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a
     entrypoint: 'anvil -p 8545 --host 0.0.0.0 --chain-id 31337'
     ports:
       - '8545:8545'

--- a/yarn-project/end-to-end/scripts/docker-compose-no-sandbox.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose-no-sandbox.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: ghcr.io/foundry-rs/foundry:nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43
+    image: ghcr.io/foundry-rs/foundry:nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a
     entrypoint: >
       sh -c '
       if [ -n "$FORK_BLOCK_NUMBER" ] && [ -n "$FORK_URL" ]; then

--- a/yarn-project/end-to-end/scripts/docker-compose-no-sandbox.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose-no-sandbox.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: ghcr.io/foundry-rs/foundry:nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a
+    image: ghcr.io/foundry-rs/foundry:nightly-de33b6af53005037b463318d2628b5cfcaf39916
     entrypoint: >
       sh -c '
       if [ -n "$FORK_BLOCK_NUMBER" ] && [ -n "$FORK_URL" ]; then

--- a/yarn-project/end-to-end/scripts/docker-compose-p2p.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose-p2p.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: ghcr.io/foundry-rs/foundry:nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a
+    image: ghcr.io/foundry-rs/foundry:nightly-de33b6af53005037b463318d2628b5cfcaf39916
     entrypoint: 'anvil -p 8545 --host 0.0.0.0 --chain-id 31337'
     ports:
       - '8545:8545'

--- a/yarn-project/end-to-end/scripts/docker-compose-p2p.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose-p2p.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: ghcr.io/foundry-rs/foundry:nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43
+    image: ghcr.io/foundry-rs/foundry:nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a
     entrypoint: 'anvil -p 8545 --host 0.0.0.0 --chain-id 31337'
     ports:
       - '8545:8545'

--- a/yarn-project/end-to-end/scripts/docker-compose.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: ghcr.io/foundry-rs/foundry:nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43
+    image: ghcr.io/foundry-rs/foundry:nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a
     entrypoint: >
       sh -c '
       if [ -n "$FORK_BLOCK_NUMBER" ] && [ -n "$FORK_URL" ]; then

--- a/yarn-project/end-to-end/scripts/docker-compose.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: ghcr.io/foundry-rs/foundry:nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a
+    image: ghcr.io/foundry-rs/foundry:nightly-de33b6af53005037b463318d2628b5cfcaf39916
     entrypoint: >
       sh -c '
       if [ -n "$FORK_BLOCK_NUMBER" ] && [ -n "$FORK_URL" ]; then


### PR DESCRIPTION
I tried increasing gas limit of anvil and disabling it altogether (--disable-block-gas-limit flag) but it didn't help. In `forge` there is a `--memory-limit` which is supposed to directly affect this value but this flag is not exposed on anvil. What is weird that the issue occurs when running "empty block" test case in `integration_l1_publisher.test.ts` but it doesn't occur for the bloated one. This makes me think that it probably really is some kind of bug and not just a gas limit issue.

What is also weird is that for a [version from 4 days ago](https://github.com/foundry-rs/foundry/releases/tag/nightly-9ec42d6f03bafbd3b9bb8e258ca67d7887b1f2e7) I was getting the error as well. I would not expect this given that the issue started occurring yesterday. I [asked on Foundry support channel](https://t.me/foundry_support/51173) and hopefully we will get some feedback.

In the meanwhile I found a version for which all seems to work so I would merge this PR to not waste too much time on this. We can just revert it in the future.