### PR TITLE
fix: split setup/teardown functions when there's no public app logic

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/abstract_phase_manager.ts
+++ b/yarn-project/sequencer-client/src/sequencer/abstract_phase_manager.ts
@@ -155,6 +155,14 @@ export abstract class AbstractPhaseManager {
         [PublicKernelPhase.TEARDOWN]: [],
         [PublicKernelPhase.TAIL]: [],
       };
+    } else if (firstRevertibleCallIndex === -1) {
+      // there's no app logic, split the functions between setup (many) and teardown (just one function call)
+      return {
+        [PublicKernelPhase.SETUP]: publicCallsStack.slice(0, -1),
+        [PublicKernelPhase.APP_LOGIC]: [],
+        [PublicKernelPhase.TEARDOWN]: [publicCallsStack[publicCallsStack.length - 1]],
+        [PublicKernelPhase.TAIL]: [],
+      };
     } else {
       return {
         [PublicKernelPhase.SETUP]: publicCallsStack.slice(0, firstRevertibleCallIndex - 1),


### PR DESCRIPTION
This PR fixes an issue where the phase manager was incorrectly extracting setup and teardown enqueued public function calls when there was no app logic in between them.

Fix #5150 
Stacked on top of #5129