### PR TITLE
fix: Increase the json limit for RPC requests

### DIFF
--- a/yarn-project/foundation/src/json-rpc/server/json_rpc_server.ts
+++ b/yarn-project/foundation/src/json-rpc/server/json_rpc_server.ts
@@ -73,7 +73,7 @@ export class JsonRpcServer {
     app.use(compress({ br: false } as any));
     app.use(
       bodyParser({
-        jsonLimit: '10mb',
+        jsonLimit: '50mb',
         enableTypes: ['json'],
         detectJSON: () => true,
       }),


### PR DESCRIPTION
This PR increases the json rpc payload size limit.
