### PR TITLE
fix: remove embedded srs

### DIFF
--- a/barretenberg/cpp/.gitignore
+++ b/barretenberg/cpp/.gitignore
@@ -4,6 +4,7 @@ src/wasi-sdk-*
 src/barretenberg/proof_system/proving_key/fixtures
 src/barretenberg/rollup/proofs/*/fixtures
 srs_db/*/*/transcript*
+srs_db/*/bn254_g*
 CMakeUserPresets.json
 .vscode/settings.json
 acir_tests

--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -474,7 +474,6 @@ void acvm_info(const std::string& output_path)
  */
 void avm_prove(const std::filesystem::path& bytecode_path,
                const std::filesystem::path& calldata_path,
-               const std::string& crs_path,
                const std::filesystem::path& output_path)
 {
     // Get Bytecode
@@ -485,7 +484,8 @@ void avm_prove(const std::filesystem::path& bytecode_path,
     }
     std::vector<fr> const call_data = many_from_buffer<fr>(call_data_bytes);
 
-    srs::init_crs_factory(crs_path);
+    // Hardcoded circuit size for now
+    init_bn254_crs(256);
 
     // Prove execution and return vk
     auto const [verification_key, proof] = avm_trace::Execution::prove(avm_bytecode, call_data);
@@ -601,9 +601,8 @@ int main(int argc, char* argv[])
         } else if (command == "avm_prove") {
             std::filesystem::path avm_bytecode_path = get_option(args, "-b", "./target/avm_bytecode.bin");
             std::filesystem::path calldata_path = get_option(args, "-d", "./target/call_data.bin");
-            std::string crs_path = get_option(args, "-c", "../srs_db/ignition");
             std::filesystem::path output_path = get_option(args, "-o", "./proofs/avm_proof");
-            avm_prove(avm_bytecode_path, calldata_path, crs_path, output_path);
+            avm_prove(avm_bytecode_path, calldata_path, output_path);
         } else if (command == "avm_verify") {
             std::filesystem::path proof_path = get_option(args, "-p", "./proofs/avm_proof");
             return avm_verify(proof_path) ? 0 : 1;

--- a/yarn-project/Dockerfile
+++ b/yarn-project/Dockerfile
@@ -17,10 +17,6 @@ COPY --from=noir-projects /usr/src/noir-projects /usr/src/noir-projects
 COPY --from=noir /usr/src/noir/noir-repo/target/release/acvm /usr/src/noir/noir-repo/target/release/acvm
 COPY --from=barretenberg /usr/src/barretenberg/cpp/build/bin/bb /usr/src/barretenberg/cpp/build/bin/bb
 
-COPY --from=barretenberg /usr/src/barretenberg/cpp/srs_db/ /usr/src/barretenberg/cpp/srs_db/
-WORKDIR /usr/src/barretenberg/cpp/srs_db
-RUN ./download_ignition.sh 0
-
 WORKDIR /usr/src/yarn-project
 COPY . .
 

--- a/yarn-project/Dockerfile.test
+++ b/yarn-project/Dockerfile.test
@@ -14,10 +14,6 @@ COPY --from=contracts /usr/src/l1-contracts /usr/src/l1-contracts
 COPY --from=noir-projects /usr/src/noir-projects /usr/src/noir-projects
 COPY --from=barretenberg /usr/src/barretenberg/cpp/build/bin/bb /usr/src/barretenberg/cpp/build/bin/bb
 
-COPY --from=barretenberg /usr/src/barretenberg/cpp/srs_db/ /usr/src/barretenberg/cpp/srs_db/
-WORKDIR /usr/src/barretenberg/cpp/srs_db
-RUN ./download_ignition.sh 0
-
 WORKDIR /usr/src/yarn-project
 COPY . .
 

--- a/yarn-project/simulator/src/public/executor.ts
+++ b/yarn-project/simulator/src/public/executor.ts
@@ -244,8 +244,6 @@ export class PublicExecutor {
    */
   public async getAvmProof(avmExecution: PublicExecution): Promise<Buffer[]> {
     // The paths for the barretenberg binary and the write path are hardcoded for now.
-    // We additionally need the path to a valid crs for proof generation.
-    // const bbPath = '../../barretenberg/cpp';
     const bbPath = path.resolve('../../barretenberg/cpp');
     const artifactsPath = path.resolve('target');
 
@@ -273,8 +271,6 @@ export class PublicExecutor {
       bytecodePath,
       '-d',
       calldataPath,
-      '-c',
-      path.join(bbPath, 'srs_db', 'ignition'),
       '-o',
       proofPath,
     ]);


### PR DESCRIPTION
Removes the embedding of the ignition srs in the dockerfile in favor of calling/downloading directly within bb.

Streamlines the bb-avm interface as we don't need the crs path anymore