### PR TITLE
fix: Intermittent invert 0 in Translator

### DIFF
--- a/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_composer.test.cpp
@@ -55,6 +55,8 @@ TEST_F(GoblinTranslatorComposerTests, Basic)
 
     // Add the same operations to the ECC op queue; the native computation is performed under the hood.
     auto op_queue = std::make_shared<bb::ECCOpQueue>();
+    op_queue->append_nonzero_ops();
+
     for (size_t i = 0; i < 500; i++) {
         op_queue->add_accumulate(P1);
         op_queue->mul_accumulate(P2, z);


### PR DESCRIPTION
https://github.com/AztecProtocol/aztec-packages/pull/5174 provided a general fix for this issue, but did not implement it in the particular case of the translator test, leading to a regression. We fix that.