### PR TITLE
fix: Validate EthAddress size in aztec-nr

### DIFF
--- a/noir-projects/noir-contracts/contracts/contract_instance_deployer_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/contract_instance_deployer_contract/src/main.nr
@@ -24,7 +24,6 @@ contract ContractInstanceDeployer {
         universal_deploy: bool
     ) {
         // TODO(@spalladino): assert nullifier_exists silo(contract_class_id, ContractClassRegisterer)
-        // TODO(@spalladino): assert is_valid_eth_address(portal_contract_address)
 
         // TODO(#4434) Add deployer field to instance calculation
         // let deployer = if universal_deploy { Field::zero() } else { context.msg_sender() };

--- a/noir-projects/noir-protocol-circuits/crates/types/src/address/eth_address.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/address/eth_address.nr
@@ -35,9 +35,7 @@ impl Serialize<ETH_ADDRESS_LENGTH> for EthAddress {
 
 impl Deserialize<ETH_ADDRESS_LENGTH> for EthAddress {
     fn deserialize(fields: [Field; ETH_ADDRESS_LENGTH]) -> Self {
-        Self {
-            inner: fields[0]
-        }
+        EthAddress::from_field(fields[0])
     }
 }
 
@@ -47,6 +45,7 @@ impl EthAddress {
     }
 
     pub fn from_field(field: Field) -> Self {
+        field.assert_max_bit_size(160);
         Self { inner: field }
     }
 


### PR DESCRIPTION
Ensure the field element backing an EthAddress in aztec-nr is no larger than 20 bytes.