### PR TITLE
refactor: moving wit comms and witness and comm labels from instance to oink

### DIFF
--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
@@ -25,8 +25,6 @@ template <class Flavor> class ProverInstance_ {
     using FF = typename Flavor::FF;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     using Polynomial = typename Flavor::Polynomial;
-    using WitnessCommitments = typename Flavor::WitnessCommitments;
-    using CommitmentLabels = typename Flavor::CommitmentLabels;
     using RelationSeparator = typename Flavor::RelationSeparator;
 
     using Trace = ExecutionTrace_<Flavor>;

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
@@ -34,8 +34,6 @@ template <class Flavor> class ProverInstance_ {
   public:
     std::shared_ptr<ProvingKey> proving_key;
     ProverPolynomials prover_polynomials;
-    WitnessCommitments witness_commitments;
-    CommitmentLabels commitment_labels;
 
     std::array<Polynomial, 4> sorted_polynomials;
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
@@ -27,6 +27,8 @@ template <IsUltraFlavor Flavor> class OinkProver {
     std::shared_ptr<Transcript> transcript;
     std::shared_ptr<CommitmentKey> commitment_key;
     std::string domain_separator;
+    typename Flavor::WitnessCommitments witness_commitments;
+    typename Flavor::CommitmentLabels commitment_labels;
 
     OinkProver(const std::shared_ptr<ProverInstance_<Flavor>>& inst,
                const std::shared_ptr<typename Flavor::CommitmentKey>& commitment_key,
@@ -36,6 +38,7 @@ template <IsUltraFlavor Flavor> class OinkProver {
         , transcript(transcript)
         , commitment_key(commitment_key)
         , domain_separator(std::move(domain_separator))
+        , commitment_labels()
     {
         instance->initialize_prover_polynomials();
     }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
@@ -38,7 +38,6 @@ template <IsUltraFlavor Flavor> class OinkProver {
         , transcript(transcript)
         , commitment_key(commitment_key)
         , domain_separator(std::move(domain_separator))
-        , commitment_labels()
     {
         instance->initialize_prover_polynomials();
     }


### PR DESCRIPTION
Continues the refactoring of instance by moving witness_commitments and commitment_labels to oink prover.

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
