### PR TITLE
chore(avm-simulator): make sure we support Map storage

### DIFF
--- a/avm-transpiler/src/opcodes.rs
+++ b/avm-transpiler/src/opcodes.rs
@@ -1,6 +1,6 @@
 /// All AVM opcodes
 /// Keep updated with TS and yellow paper!
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum AvmOpcode {
     // Compute
     ADD,

--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -58,6 +58,10 @@ pub fn brillig_to_avm(brillig: &Brillig) -> Vec<u8> {
                         },
                     ],
                 });
+                // Brillig currently expects comparison instructions to return an u1 (for us, an u8).
+                if avm_opcode == AvmOpcode::EQ {
+                    avm_instrs.push(generate_cast_instruction(destination.to_usize() as u32, destination.to_usize() as u32, AvmTypeTag::UINT8));
+                }
             }
             BrilligOpcode::BinaryIntOp {
                 destination,
@@ -114,6 +118,10 @@ pub fn brillig_to_avm(brillig: &Brillig) -> Vec<u8> {
                         },
                     ],
                 });
+                // Brillig currently expects comparison instructions to return an u1 (for us, an u8).
+                if avm_opcode == AvmOpcode::EQ || avm_opcode == AvmOpcode::LT || avm_opcode == AvmOpcode::LTE {
+                    avm_instrs.push(generate_cast_instruction(destination.to_usize() as u32, destination.to_usize() as u32, AvmTypeTag::UINT8));
+                }
             }
             BrilligOpcode::CalldataCopy { destination_address, size, offset } => {
                 avm_instrs.push(AvmInstruction {
@@ -1005,6 +1013,15 @@ fn map_brillig_pcs_to_avm_pcs(initial_offset: usize, brillig: &Brillig) -> Vec<u
     for i in 0..brillig.bytecode.len() - 1 {
         let num_avm_instrs_for_this_brillig_instr = match &brillig.bytecode[i] {
             BrilligOpcode::Const { bit_size: 254, .. } => 2,
+            // Brillig currently expects comparison instructions to return an u1 (for us, an u8).
+            BrilligOpcode::BinaryIntOp {
+                op: BinaryIntOp::Equals | BinaryIntOp::LessThan | BinaryIntOp::LessThanEquals,
+                ..
+            } => 2,
+            BrilligOpcode::BinaryFieldOp {
+                op: BinaryFieldOp::Equals,
+                ..
+            } => 2,
             _ => 1,
         };
         // next Brillig pc will map to an AVM pc offset by the

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -21,9 +21,11 @@ contract AvmTest {
     use crate::Note;
 
     // Libs
+    use dep::aztec::prelude::Map;
     use dep::aztec::state_vars::PublicMutable;
     use dep::aztec::protocol_types::{address::{AztecAddress, EthAddress}, constants::L1_TO_L2_MESSAGE_LENGTH};
     use dep::aztec::protocol_types::abis::function_selector::FunctionSelector;
+    use dep::aztec::protocol_types::{hash::pedersen_hash, traits::{ToField}};
     use dep::compressed_string::CompressedString;
 
     // avm lib
@@ -35,6 +37,7 @@ contract AvmTest {
     struct Storage {
         single: PublicMutable<Field>,
         list: PublicMutable<Note>,
+        map: Map<AztecAddress, PublicMutable<u32>>,
     }
 
     #[aztec(public-vm)]
@@ -62,6 +65,26 @@ contract AvmTest {
     fn readStorageList() -> pub [Field; 2] {
         let note: Note = storage.list.read();
         note.serialize()
+    }
+
+    #[aztec(public-vm)]
+    fn setStorageMap(to: AztecAddress, amount: u32) -> pub Field {
+        storage.map.at(to).write(amount);
+        // returns storage slot for key
+        pedersen_hash([storage.map.storage_slot, to.to_field()], 0)
+    }
+
+    #[aztec(public-vm)]
+    fn addStorageMap(to: AztecAddress, amount: u32) -> pub Field {
+        let new_balance = storage.map.at(to).read().add(amount);
+        storage.map.at(to).write(new_balance);
+        // returns storage slot for key
+        pedersen_hash([storage.map.storage_slot, to.to_field()], 0)
+    }
+
+    #[aztec(public-vm)]
+    fn readStorageMap(address: AztecAddress) -> pub u32 {
+        storage.map.at(address).read()
     }
 
     #[aztec(public-vm)]


### PR DESCRIPTION
Brillig expects comparison operations to return `u1`. The AVM returns the type of the input operands. I'm fixing this by adding a cast in the transpiler but I think that longer term we should also return u1 (well, u8) in the AVM.
