### PR TITLE
fix: Do not release docs on every commit to master

### DIFF
--- a/docs/deploy_netlify.sh
+++ b/docs/deploy_netlify.sh
@@ -11,6 +11,10 @@ DEPLOY_OUTPUT=""
 
 if should_release; then
     # Deploy to production only on a release
+    if [ -z "$COMMIT_TAG" ]; then
+        echo "No commit tag, not deploying to npm."
+        exit 0
+    fi
     DEPLOY_OUTPUT=$(netlify deploy --site aztec-docs-dev --prod)
 elif [ "$1" != "master" ]; then
     # Deploy preview on PRs


### PR DESCRIPTION
Copied code from `yarn-project/deploy_npm.sh` to prevent publishing docs on every commit to master instead of just on tagged releases.
