### PR TITLE
fix: Point docs links to current tag if available

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -29,6 +29,10 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 WORKDIR /usr/src/yarn-project
 RUN ./bootstrap.sh
 
+# Make COMMIT_TAG visible to build scripts
+ARG COMMIT_TAG=""
+ENV COMMIT_TAG=$COMMIT_TAG
+
 WORKDIR /usr/src/docs
 RUN yarn && yarn build
 

--- a/docs/src/preprocess/include_code.js
+++ b/docs/src/preprocess/include_code.js
@@ -234,11 +234,14 @@ async function preprocessIncludeCode(markdownContent, filePath, rootDir) {
         filePath
       );
 
-      const relativeCodeFilePath = path.resolve(rootDir, codeFilePath);
-
-      let urlText = `${relativeCodeFilePath}#L${startLine}-L${endLine}`;
-      const tag = "master";
-      const url = `https://github.com/AztecProtocol/aztec-packages/blob/${tag}/${relativeCodeFilePath}#L${startLine}-L${endLine}`;
+      const relativeCodeFilePath = path
+        .resolve(rootDir, codeFilePath)
+        .replace(/^\//, "");
+      const urlText = `${relativeCodeFilePath}#L${startLine}-L${endLine}`;
+      const tag = process.env.COMMIT_TAG
+        ? `aztec-packages-${process.env.COMMIT_TAG}`
+        : "master";
+      const url = `https://github.com/AztecProtocol/aztec-packages/blob/${tag}/${urlText}`;
 
       const title = noTitle ? "" : `title="${identifier}"`;
       const lineNumbers = noLineNumbers ? "" : "showLineNumbers";


### PR DESCRIPTION
Instead of pointing to master, load the current tag if it's available on the environment and use it for redirecting to github.
