### PR TITLE
fix: Docs links URL missing a letter

### DIFF
--- a/docs/src/preprocess/include_code.js
+++ b/docs/src/preprocess/include_code.js
@@ -239,7 +239,7 @@ async function preprocessIncludeCode(markdownContent, filePath, rootDir) {
         .replace(/^\//, "");
       const urlText = `${relativeCodeFilePath}#L${startLine}-L${endLine}`;
       const tag = process.env.COMMIT_TAG
-        ? `aztec-packages-${process.env.COMMIT_TAG}`
+        ? `aztec-packages-v${process.env.COMMIT_TAG}`
         : "master";
       const url = `https://github.com/AztecProtocol/aztec-packages/blob/${tag}/${urlText}`;
 


### PR DESCRIPTION
Seems like COMMIT_TAG strips the leading `v` as well. This seems to contradict what we're seeing here, but oh well.

https://github.com/AztecProtocol/aztec-packages/blob/37bdc1820f92ad2cc545e6843a0dd90273c21e0e/build-system/scripts/setup_env#L17