### PR TITLE
fix: set client ivc test vkeys properly

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -125,12 +125,13 @@ TEST_F(ClientIVCTests, Full)
     auto intermediary_acc = update_accumulator_and_decide_native(
         ivc.prover_fold_output.accumulator, kernel_fold_proof, foo_verifier_instance, kernel_vk);
 
-    VerifierFoldData kernel_fold_output = { kernel_fold_proof, function_vk_with_merge };
+    VerifierFoldData kernel_fold_output = { kernel_fold_proof, kernel_vk };
     size_t NUM_CIRCUITS = 1;
     for (size_t circuit_idx = 0; circuit_idx < NUM_CIRCUITS; ++circuit_idx) {
         // Accumulate function circuit
         Builder function_circuit = create_mock_circuit(ivc);
         FoldProof function_fold_proof = ivc.accumulate(function_circuit);
+        function_vk_with_merge = std::make_shared<VerificationKey>(ivc.prover_instance->proving_key);
 
         intermediary_acc = update_accumulator_and_decide_native(
             ivc.prover_fold_output.accumulator, function_fold_proof, intermediary_acc, function_vk_with_merge);

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -15,11 +15,12 @@ void ProtoGalaxyVerifier_<VerifierInstances>::receive_and_finalise_instance(cons
         transcript->template receive_from_prover<uint32_t>(domain_separator + "_public_input_size");
     inst->verification_key->pub_inputs_offset =
         transcript->template receive_from_prover<uint32_t>(domain_separator + "_pub_inputs_offset");
-    inst->verification_key->public_inputs.clear();
+    std::vector<FF> public_inputs;
     for (size_t i = 0; i < inst->verification_key->num_public_inputs; ++i) {
         auto public_input_i =
             transcript->template receive_from_prover<FF>(domain_separator + "_public_input_" + std::to_string(i));
-        inst->verification_key->public_inputs.emplace_back(public_input_i);
+        public_inputs.emplace_back(public_input_i);
+        ASSERT(public_input_i == inst->verification_key->public_inputs[i]);
     }
 
     // Get commitments to first three wire polynomials

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
@@ -74,6 +74,9 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const HonkP
     for (size_t i = 0; i < public_input_size; ++i) {
         auto public_input_i = transcript->template receive_from_prover<FF>("public_input_" + std::to_string(i));
         public_inputs.emplace_back(public_input_i);
+        if (public_input_i != key->public_inputs[i]) {
+            return false;
+        }
     }
 
     // Get commitments to first three wire polynomials


### PR DESCRIPTION
This fix sets the verification key in client_ivc.test.cpp correctly for function circuits. Previously, the verification key was not being updated properly for the new function circuits.
```

--------------------------------------------------------------------------------
Benchmark                      Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------
ClientIVCBench/Full/6      27297 ms        22546 ms            1 Decider::construct_proof=1 Decider::construct_proof(t)=776.493M ECCVMComposer::compute_commitment_key=1 ECCVMComposer::compute_commitment_key(t)=3.78121M ECCVMComposer::compute_witness=1 ECCVMComposer::compute_witness(t)=1.77129G ECCVMComposer::create_prover=1 ECCVMComposer::create_prover(t)=3.47306G ECCVMComposer::create_proving_key=1 ECCVMComposer::create_proving_key(t)=1.69774G ECCVMProver::construct_proof=1 ECCVMProver::construct_proof(t)=1.78864G Goblin::merge=11 Goblin::merge(t)=130.126M GoblinTranslatorCircuitBuilder::constructor=1 GoblinTranslatorCircuitBuilder::constructor(t)=59.0199M GoblinTranslatorComposer::create_prover=1 GoblinTranslatorComposer::create_prover(t)=119.07M GoblinTranslatorProver::construct_proof=1 GoblinTranslatorProver::construct_proof(t)=934.749M ProtoGalaxyProver_::accumulator_update_round=10 ProtoGalaxyProver_::accumulator_update_round(t)=720.581M ProtoGalaxyProver_::combiner_quotient_round=10 ProtoGalaxyProver_::combiner_quotient_round(t)=7.38002G ProtoGalaxyProver_::perturbator_round=10 ProtoGalaxyProver_::perturbator_round(t)=1.35437G ProtoGalaxyProver_::preparation_round=10 ProtoGalaxyProver_::preparation_round(t)=4.22303G ProtogalaxyProver::fold_instances=10 ProtogalaxyProver::fold_instances(t)=13.678G ProverInstance(Circuit&)=11 ProverInstance(Circuit&)(t)=1.98771G batch_mul_with_endomorphism=30 batch_mul_with_endomorphism(t)=569.263M commit=425 commit(t)=4.05584G compute_combiner=10 compute_combiner(t)=7.3778G compute_perturbator=9 compute_perturbator(t)=1.35396G compute_univariate=48 compute_univariate(t)=1.45556G construct_circuits=6 construct_circuits(t)=4.32967G
Benchmarking lock deleted.
client_ivc_bench.json                  100% 4008   109.7KB/s   00:00    
function                                        ms     % sum
construct_circuits(t)                         4330    15.91%
ProverInstance(Circuit&)(t)                   1988     7.30%
ProtogalaxyProver::fold_instances(t)         13678    50.25%
Decider::construct_proof(t)                    776     2.85%
ECCVMComposer::create_prover(t)               3473    12.76%
GoblinTranslatorComposer::create_prover(t)     119     0.44%
ECCVMProver::construct_proof(t)               1789     6.57%
GoblinTranslatorProver::construct_proof(t)     935     3.43%
Goblin::merge(t)                               130     0.48%

Total time accounted for: 27218ms/27297ms = 99.71%

Major contributors:
function                                        ms    % sum
commit(t)                                     4056   14.90%
compute_combiner(t)                           7378   27.11%
compute_perturbator(t)                        1354    4.97%
compute_univariate(t)                         1456    5.35%

Breakdown of ECCVMProver::create_prover:
ECCVMComposer::compute_witness(t)             1771    51.00%
ECCVMComposer::create_proving_key(t)          1698    48.88%

Breakdown of ProtogalaxyProver::fold_instances:
ProtoGalaxyProver_::preparation_round(t)           4223    30.87%
ProtoGalaxyProver_::perturbator_round(t)           1354     9.90%
ProtoGalaxyProver_::combiner_quotient_round(t)     7380    53.96%
ProtoGalaxyProver_::accumulator_update_round(t)     721     5.27%

```
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
