### PR TITLE
fix(bb): mac build

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -490,7 +490,7 @@ void avm_prove(const std::filesystem::path& bytecode_path,
     // Prove execution and return vk
     auto const [verification_key, proof] = avm_trace::Execution::prove(avm_bytecode, call_data);
     // TODO(ilyas): <#4887>: Currently we only need these two parts of the vk, look into pcs_verification key reqs
-    std::vector<size_t> vk_vector = { verification_key.circuit_size, verification_key.num_public_inputs };
+    std::vector<uint64_t> vk_vector = { verification_key.circuit_size, verification_key.num_public_inputs };
 
     std::filesystem::path output_vk_path = output_path.parent_path() / "vk";
     write_file(output_vk_path, to_buffer(vk_vector));


### PR DESCRIPTION
We should always use uint64_t if we want one, and not rely on size_t