### PR TITLE
chore: Load bb benches into aggregate benchmark

### DIFF
--- a/yarn-project/circuit-types/src/stats/metrics.ts
+++ b/yarn-project/circuit-types/src/stats/metrics.ts
@@ -7,7 +7,8 @@ export type MetricGroupBy =
   | 'circuit-name'
   | 'classes-registered'
   | 'leaf-count'
-  | 'data-writes';
+  | 'data-writes'
+  | 'circuit-size-in-gates';
 
 /** Definition of a metric to track in benchmarks. */
 export interface Metric {
@@ -23,6 +24,18 @@ export interface Metric {
 
 /** Metric definitions to track from benchmarks. */
 export const Metrics = [
+  {
+    name: 'client_ivc_proving_time_in_ms',
+    groupBy: 'circuit-size-in-gates',
+    description: 'Proving time for ClientIVC grouped by circuit size.',
+    events: [],
+  },
+  {
+    name: 'ultrahonk_proving_time_in_ms',
+    groupBy: 'circuit-size-in-gates',
+    description: 'Proving time for UltraHonk grouped by circuit size.',
+    events: [],
+  },
   {
     name: 'l1_rollup_calldata_size_in_bytes',
     groupBy: 'block-size',

--- a/yarn-project/scripts/src/benchmarks/aggregate.ts
+++ b/yarn-project/scripts/src/benchmarks/aggregate.ts
@@ -219,6 +219,15 @@ function processEntry(entry: Stats, results: BenchmarkCollectedResults) {
   }
 }
 
+function getBarretenbergMetric(context: { executable?: string }): MetricName | undefined {
+  if (context.executable?.includes('ultra_honk')) {
+    return 'ultrahonk_proving_time_in_ms';
+  } else if (context.executable?.includes('client_ivc')) {
+    return 'client_ivc_proving_time_in_ms';
+  }
+  return undefined;
+}
+
 /** Array of collected raw results for a given metric. */
 type BenchmarkCollectedMetricResults = Record<string, number[]>;
 
@@ -258,6 +267,28 @@ export async function main() {
       }
       resultMetric[bucketName] = avg;
     }
+  }
+
+  // Add google benchmark json files, which have data already averaged
+  const googleBenchmarkFiles = fs.readdirSync(LogsDir).filter(f => f.endsWith('.json'));
+  for (const file of googleBenchmarkFiles) {
+    const data = JSON.parse(fs.readFileSync(path.join(LogsDir, file), 'utf-8'));
+    if (!data.context || !data.benchmarks) {
+      log(`Invalid google benchmark file: ${file}`);
+      continue;
+    }
+    const metric = getBarretenbergMetric(data.context);
+    if (!metric) {
+      log(`Unknown executable in benchmark file ${file}: ${data.context.executable}`);
+      continue;
+    }
+    const circuitSize = '2^20'; // Where to load size from?
+    const value = data.benchmarks[0]?.real_time;
+    if (value === undefined) {
+      log(`Couldn't find real_time in benchmark file ${file}`);
+      continue;
+    }
+    results[metric] = { [circuitSize]: value };
   }
 
   const timestampedResults: BenchmarkResultsWithTimestamp = { ...results, timestamp: new Date().toISOString() };

--- a/yarn-project/scripts/src/benchmarks/markdown.ts
+++ b/yarn-project/scripts/src/benchmarks/markdown.ts
@@ -188,6 +188,7 @@ export function getMarkdown() {
   const metricsByCircuitName = Metrics.filter(m => m.groupBy === 'circuit-name').map(m => m.name);
   const metricsByClassesRegistered = Metrics.filter(m => m.groupBy === 'classes-registered').map(m => m.name);
   const metricsByLeafCount = Metrics.filter(m => m.groupBy === 'leaf-count').map(m => m.name);
+  const metricsByCircuitSize = Metrics.filter(m => m.groupBy === 'circuit-size-in-gates').map(m => m.name);
 
   const metricsTxPxeProcessing = Metrics.filter(m => m.name === 'tx_pxe_processing_time_ms').map(m => m.name);
   const metricsTxSeqProcessing = Metrics.filter(m => m.name === 'tx_sequencer_processing_time_ms').map(m => m.name);
@@ -213,9 +214,14 @@ ${getWarningsSummary(benchmark, baseBenchmark)}
 
 <summary>Detailed results</summary>
 
-All benchmarks are run on txs on the \`Benchmarking\` contract on the repository. Each tx consists of a batch call  to \`create_note\` and \`increment_balance\`, which guarantees that each tx has a private call, a nested private call, a public call, and a nested public call, as well as an emitted private note, an unencrypted log, and public storage read and write.
+Except for proving times, all benchmarks are run on txs on the \`Benchmarking\` contract on the repository. Each tx consists of a batch call  to \`create_note\` and \`increment_balance\`, which guarantees that each tx has a private call, a nested private call, a public call, and a nested public call, as well as an emitted private note, an unencrypted log, and public storage read and write.
 ${prSourceDataText}
 ${baseCommitText}
+
+### Proving times
+
+Average proving times for benchmarks measured in bb.
+${getTableContent(pick(benchmark, metricsByCircuitSize), baseBenchmark, 'gates', 'Circuit')}
 
 ### L2 block published to L1
 


### PR DESCRIPTION
Loads any json files in google benchmark format and adds them to the bench aggregation and to the markdown comment. For instance, given a file for ultrahonk, the markdown shows:

```
Average proving times for benchmarks measured in bb.

| Circuit | 2^20 gates |
| - | - |
<span title="Proving time for UltraHonk grouped by circuit size.">ultrahonk_proving_time_in_ms</span> | 29.9 |
```
