### PR TITLE
refactor: add gas portal to l1 contract addresses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,9 +71,9 @@ setup_env: &setup_env
     command: ./build-system/scripts/setup_env "$CIRCLE_SHA1" "$CIRCLE_TAG" "$CIRCLE_JOB" "$CIRCLE_REPOSITORY_URL" "$CIRCLE_BRANCH" "$CIRCLE_PULL_REQUEST"
 
 defaults_e2e_test: &defaults_e2e_test
-    docker:
-      - image: aztecprotocol/alpine-build-image
-    resource_class: small
+  docker:
+    - image: aztecprotocol/alpine-build-image
+  resource_class: small
 
 jobs:
   # Dynamically filter our code, quickly figuring out which jobs we can skip.
@@ -868,7 +868,6 @@ jobs:
           aztec_manifest_key: end-to-end
     <<: *defaults_e2e_test
 
-  
   e2e-outbox:
     docker:
       - image: aztecprotocol/alpine-build-image
@@ -958,7 +957,7 @@ jobs:
       - *setup_env
       - run:
           name: "Test"
-          command: cond_spot_run_compose end-to-end 4 ./scripts/docker-compose.yml TEST=e2e_fees.test.ts
+          command: cond_spot_run_compose end-to-end 4 ./scripts/docker-compose.yml TEST=e2e_fees.test.ts ENABLE_GAS=1
           aztec_manifest_key: end-to-end
     <<: *defaults_e2e_test
 
@@ -968,7 +967,7 @@ jobs:
       - *setup_env
       - run:
           name: "Test"
-          command: cond_spot_run_compose end-to-end 4 ./scripts/docker-compose.yml TEST=e2e_dapp_subscription.test.ts
+          command: cond_spot_run_compose end-to-end 4 ./scripts/docker-compose.yml TEST=e2e_dapp_subscription.test.ts ENABLE_GAS=1
           aztec_manifest_key: end-to-end
     <<: *defaults_e2e_test
 
@@ -1221,7 +1220,7 @@ defaults: &defaults
     - slack/notify:
         event: fail
         branch_pattern: "master"
-      
+
 bb_acir_tests: &bb_acir_tests
   requires:
     - barretenberg-x86_64-linux-clang-assert

--- a/yarn-project/archiver/src/archiver/config.ts
+++ b/yarn-project/archiver/src/archiver/config.ts
@@ -62,6 +62,8 @@ export function getConfigEnvVars(): ArchiverConfig {
     INBOX_CONTRACT_ADDRESS,
     OUTBOX_CONTRACT_ADDRESS,
     REGISTRY_CONTRACT_ADDRESS,
+    GAS_TOKEN_CONTRACT_ADDRESS,
+    GAS_PORTAL_CONTRACT_ADDRESS,
     DATA_DIRECTORY,
   } = process.env;
   // Populate the relevant addresses for use by the archiver.
@@ -73,6 +75,10 @@ export function getConfigEnvVars(): ArchiverConfig {
     registryAddress: REGISTRY_CONTRACT_ADDRESS ? EthAddress.fromString(REGISTRY_CONTRACT_ADDRESS) : EthAddress.ZERO,
     inboxAddress: INBOX_CONTRACT_ADDRESS ? EthAddress.fromString(INBOX_CONTRACT_ADDRESS) : EthAddress.ZERO,
     outboxAddress: OUTBOX_CONTRACT_ADDRESS ? EthAddress.fromString(OUTBOX_CONTRACT_ADDRESS) : EthAddress.ZERO,
+    gasTokenAddress: GAS_TOKEN_CONTRACT_ADDRESS ? EthAddress.fromString(GAS_TOKEN_CONTRACT_ADDRESS) : EthAddress.ZERO,
+    gasPortalAddress: GAS_PORTAL_CONTRACT_ADDRESS
+      ? EthAddress.fromString(GAS_PORTAL_CONTRACT_ADDRESS)
+      : EthAddress.ZERO,
   };
   return {
     rpcUrl: ETHEREUM_HOST || 'http://127.0.0.1:8545/',

--- a/yarn-project/aztec.js/src/contract/contract.test.ts
+++ b/yarn-project/aztec.js/src/contract/contract.test.ts
@@ -27,6 +27,8 @@ describe('Contract Class', () => {
     registryAddress: EthAddress.random(),
     inboxAddress: EthAddress.random(),
     outboxAddress: EthAddress.random(),
+    gasTokenAddress: EthAddress.random(),
+    gasPortalAddress: EthAddress.random(),
   };
   const mockNodeInfo: NodeInfo = {
     nodeVersion: 'vx.x.x',

--- a/yarn-project/aztec/package.json
+++ b/yarn-project/aztec/package.json
@@ -40,6 +40,7 @@
     "@aztec/noir-compiler": "workspace:^",
     "@aztec/noir-contracts.js": "workspace:^",
     "@aztec/p2p": "workspace:^",
+    "@aztec/protocol-contracts": "workspace:^",
     "@aztec/pxe": "workspace:^",
     "abitype": "^0.8.11",
     "commander": "^11.1.0",

--- a/yarn-project/aztec/src/bin/index.ts
+++ b/yarn-project/aztec/src/bin/index.ts
@@ -20,7 +20,7 @@ const debugLogger = createDebugLogger('aztec:cli');
 const packageJsonPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../package.json');
 const cliVersion: string = JSON.parse(readFileSync(packageJsonPath).toString()).version;
 
-const { TEST_ACCOUNTS = 'true', PORT = '8080' } = process.env;
+const { TEST_ACCOUNTS = 'true', PORT = '8080', ENABLE_GAS = '' } = process.env;
 
 /** CLI & full node main entrypoint */
 async function main() {
@@ -32,7 +32,9 @@ async function main() {
     // If no CLI arguments were provided, run aztec full node for sandbox usage.
     userLog(`${splash}\n${github}\n\n`);
     userLog(`Setting up Aztec Sandbox v${cliVersion}, please stand by...`);
-    const { aztecNodeConfig, node, pxe, stop } = await createSandbox();
+    const { aztecNodeConfig, node, pxe, stop } = await createSandbox({
+      enableGas: ['true', '1'].includes(ENABLE_GAS),
+    });
     installSignalHandlers(userLog, [stop]);
 
     // Deploy test accounts by default

--- a/yarn-project/aztec/src/sandbox.ts
+++ b/yarn-project/aztec/src/sandbox.ts
@@ -1,8 +1,11 @@
 #!/usr/bin/env -S node --no-warnings
 import { AztecNodeConfig, AztecNodeService, getConfigEnvVars } from '@aztec/aztec-node';
+import { AztecAddress, SignerlessWallet, Wallet } from '@aztec/aztec.js';
+import { deployInstance, registerContractClass } from '@aztec/aztec.js/deployment';
 import { AztecNode } from '@aztec/circuit-types';
 import {
   DeployL1Contracts,
+  L1ContractAddresses,
   L1ContractArtifactsForDeployment,
   NULL_KEY,
   createEthereumChain,
@@ -13,18 +16,23 @@ import { retryUntil } from '@aztec/foundation/retry';
 import {
   AvailabilityOracleAbi,
   AvailabilityOracleBytecode,
+  GasPortalAbi,
+  GasPortalBytecode,
   InboxAbi,
   InboxBytecode,
   OutboxAbi,
   OutboxBytecode,
+  PortalERC20Abi,
+  PortalERC20Bytecode,
   RegistryAbi,
   RegistryBytecode,
   RollupAbi,
   RollupBytecode,
 } from '@aztec/l1-artifacts';
+import { getCanonicalGasToken } from '@aztec/protocol-contracts/gas-token';
 import { PXEServiceConfig, createPXEService, getPXEServiceConfig } from '@aztec/pxe';
 
-import { HDAccount, PrivateKeyAccount, createPublicClient, http as httpViemTransport } from 'viem';
+import { HDAccount, PrivateKeyAccount, createPublicClient, getContract, http as httpViemTransport } from 'viem';
 import { mnemonicToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
 
@@ -98,21 +106,77 @@ export async function deployContractsToL1(
       contractAbi: RollupAbi,
       contractBytecode: RollupBytecode,
     },
+    gasToken: {
+      contractAbi: PortalERC20Abi,
+      contractBytecode: PortalERC20Bytecode,
+    },
+    gasPortal: {
+      contractAbi: GasPortalAbi,
+      contractBytecode: GasPortalBytecode,
+    },
   };
 
-  aztecNodeConfig.l1Contracts = (
-    await waitThenDeploy(aztecNodeConfig, () =>
-      deployL1Contracts(aztecNodeConfig.rpcUrl, hdAccount, localAnvil, contractDeployLogger, l1Artifacts),
-    )
-  ).l1ContractAddresses;
+  const l1Contracts = await waitThenDeploy(aztecNodeConfig, () =>
+    deployL1Contracts(aztecNodeConfig.rpcUrl, hdAccount, localAnvil, contractDeployLogger, l1Artifacts),
+  );
+  await initL1GasPortal(l1Contracts, getCanonicalGasToken(l1Contracts.l1ContractAddresses.gasPortalAddress).address);
+
+  aztecNodeConfig.l1Contracts = l1Contracts.l1ContractAddresses;
 
   return aztecNodeConfig.l1Contracts;
+}
+
+/**
+ * Initializes the portal between L1 and L2 used to pay for gas.
+ * @param l1Data - The deployed L1 data.
+ */
+async function initL1GasPortal(
+  { walletClient, l1ContractAddresses }: DeployL1Contracts,
+  l2GasTokenAddress: AztecAddress,
+) {
+  const gasPortal = getContract({
+    address: l1ContractAddresses.gasPortalAddress.toString(),
+    abi: GasPortalAbi,
+    client: walletClient,
+  });
+
+  await gasPortal.write.initialize(
+    [
+      l1ContractAddresses.registryAddress.toString(),
+      l1ContractAddresses.gasTokenAddress.toString(),
+      l2GasTokenAddress.toString(),
+    ],
+    {} as any,
+  );
+
+  logger(
+    `Initialized Gas Portal at ${l1ContractAddresses.gasPortalAddress} to bridge between L1 ${l1ContractAddresses.gasTokenAddress} to L2 ${l2GasTokenAddress}`,
+  );
+}
+
+/**
+ * Deploys the contract to pay for gas on L2.
+ */
+async function deployCanonicalL2GasToken(deployer: Wallet, l1ContractAddresses: L1ContractAddresses) {
+  const gasPortalAddress = l1ContractAddresses.gasPortalAddress;
+  const canonicalGasToken = getCanonicalGasToken(gasPortalAddress);
+
+  if (await deployer.isContractClassPubliclyRegistered(canonicalGasToken.contractClass.id)) {
+    return;
+  }
+
+  await (await registerContractClass(deployer, canonicalGasToken.artifact)).send().wait();
+  await deployInstance(deployer, canonicalGasToken.instance).send().wait();
+
+  logger(`Deployed Gas Token on L2 at ${canonicalGasToken.address}`);
 }
 
 /** Sandbox settings. */
 export type SandboxConfig = AztecNodeConfig & {
   /** Mnemonic used to derive the L1 deployer private key.*/
   l1Mnemonic: string;
+  /** Enable the contracts to track and pay for gas */
+  enableGas: boolean;
 };
 
 /**
@@ -134,6 +198,11 @@ export async function createSandbox(config: Partial<SandboxConfig> = {}) {
 
   const node = await createAztecNode(aztecNodeConfig);
   const pxe = await createAztecPXE(node);
+
+  if (config.enableGas) {
+    const deployer = new SignerlessWallet(pxe);
+    await deployCanonicalL2GasToken(deployer, aztecNodeConfig.l1Contracts);
+  }
 
   const stop = async () => {
     await pxe.stop();

--- a/yarn-project/aztec/tsconfig.json
+++ b/yarn-project/aztec/tsconfig.json
@@ -46,6 +46,9 @@
       "path": "../p2p"
     },
     {
+      "path": "../protocol-contracts"
+    },
+    {
       "path": "../pxe"
     }
   ],

--- a/yarn-project/cli/src/utils.ts
+++ b/yarn-project/cli/src/utils.ts
@@ -4,7 +4,14 @@ import { type L1ContractArtifactsForDeployment } from '@aztec/aztec.js/ethereum'
 import { type PXE } from '@aztec/aztec.js/interfaces/pxe';
 import { DebugLogger, LogFn } from '@aztec/foundation/log';
 import { NoirPackageConfig } from '@aztec/foundation/noir';
-import { AvailabilityOracleAbi, AvailabilityOracleBytecode } from '@aztec/l1-artifacts';
+import {
+  AvailabilityOracleAbi,
+  AvailabilityOracleBytecode,
+  GasPortalAbi,
+  GasPortalBytecode,
+  PortalERC20Abi,
+  PortalERC20Bytecode,
+} from '@aztec/l1-artifacts';
 
 import TOML from '@iarna/toml';
 import { CommanderError, InvalidArgumentError } from 'commander';
@@ -84,6 +91,14 @@ export async function deployAztecContracts(
     rollup: {
       contractAbi: RollupAbi,
       contractBytecode: RollupBytecode,
+    },
+    gasToken: {
+      contractAbi: PortalERC20Abi,
+      contractBytecode: PortalERC20Bytecode,
+    },
+    gasPortal: {
+      contractAbi: GasPortalAbi,
+      contractBytecode: GasPortalBytecode,
     },
   };
   return await deployL1Contracts(chain.rpcUrl, account, chain.chainInfo, debugLogger, l1Artifacts);

--- a/yarn-project/end-to-end/Earthfile
+++ b/yarn-project/end-to-end/Earthfile
@@ -105,9 +105,11 @@ e2e-avm-simulator:
   DO +E2E_TEST --test=e2e_avm_simulator.test.ts
 
 e2e-fees:
+  ENV ENABLE_GAS=1
   DO +E2E_TEST --test=e2e_fees.test.ts
 
 e2e-dapp-subscription:
+  ENV ENABLE_GAS=1
   DO +E2E_TEST --test=e2e_dapp_subscription.test.ts
 
 pxe:

--- a/yarn-project/end-to-end/scripts/docker-compose.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       PXE_BLOCK_POLLING_INTERVAL_MS: 50
       ARCHIVER_VIEM_POLLING_INTERVAL_MS: 500
       AVM_ENABLED: ${AVM_ENABLED:-}
+      ENABLE_GAS: ${ENABLE_GAS:-}
     ports:
       - '8080:8080'
 

--- a/yarn-project/end-to-end/src/e2e_dapp_subscription.test.ts
+++ b/yarn-project/end-to-end/src/e2e_dapp_subscription.test.ts
@@ -15,7 +15,7 @@ import {
   FPCContract,
   GasTokenContract,
 } from '@aztec/noir-contracts.js';
-import { GasTokenAddress } from '@aztec/protocol-contracts/gas-token';
+import { getCanonicalGasTokenAddress } from '@aztec/protocol-contracts/gas-token';
 
 import { jest } from '@jest/globals';
 
@@ -62,13 +62,16 @@ describe('e2e_dapp_subscription', () => {
 
   beforeAll(async () => {
     process.env.PXE_URL = '';
-    e2eContext = await setup(3, { deployProtocolContracts: true });
+    e2eContext = await setup(3);
     await publicDeployAccounts(e2eContext.wallet, e2eContext.accounts);
 
-    const { wallets, accounts, aztecNode } = e2eContext;
+    const { wallets, accounts, aztecNode, deployL1ContractsValues } = e2eContext;
 
     // this should be a SignerlessWallet but that can't call public functions directly
-    gasTokenContract = await GasTokenContract.at(GasTokenAddress, wallets[0]);
+    gasTokenContract = await GasTokenContract.at(
+      getCanonicalGasTokenAddress(deployL1ContractsValues.l1ContractAddresses.gasPortalAddress),
+      wallets[0],
+    );
 
     aliceAddress = accounts.at(0)!.address;
     bobAddress = accounts.at(1)!.address;

--- a/yarn-project/end-to-end/src/e2e_fees.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees.test.ts
@@ -59,7 +59,6 @@ describe('e2e_fees', () => {
   let bananaPrivateBalances: BalancesFn;
 
   beforeAll(async () => {
-    process.env.PXE_URL = '';
     e2eContext = await setup(3);
 
     const { accounts, logger, aztecNode, pxe, deployL1ContractsValues, wallets } = e2eContext;

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -76,6 +76,14 @@ export interface L1ContractArtifactsForDeployment {
    * Rollup contract artifacts
    */
   rollup: ContractArtifacts;
+  /**
+   * The token to pay for gas. This will be bridged to L2 via the gasPortal below
+   */
+  gasToken: ContractArtifacts;
+  /**
+   * Gas portal contract artifacts. Optional for now as gas is not strictly enforced
+   */
+  gasPortal: ContractArtifacts;
 }
 
 /**
@@ -162,12 +170,34 @@ export const deployL1Contracts = async (
     { account },
   );
 
+  // this contract remains uninitialized because at this point we don't know the address of the gas token on L2
+  const gasTokenAddress = await deployL1Contract(
+    walletClient,
+    publicClient,
+    contractsToDeploy.gasToken.contractAbi,
+    contractsToDeploy.gasToken.contractBytecode,
+  );
+
+  logger(`Deployed Gas Token at ${gasTokenAddress}`);
+
+  // this contract remains uninitialized because at this point we don't know the address of the gas token on L2
+  const gasPortalAddress = await deployL1Contract(
+    walletClient,
+    publicClient,
+    contractsToDeploy.gasPortal.contractAbi,
+    contractsToDeploy.gasPortal.contractBytecode,
+  );
+
+  logger(`Deployed Gas Portal at ${gasPortalAddress}`);
+
   const l1Contracts: L1ContractAddresses = {
     availabilityOracleAddress,
     rollupAddress,
     registryAddress,
     inboxAddress,
     outboxAddress,
+    gasTokenAddress,
+    gasPortalAddress,
   };
 
   return {

--- a/yarn-project/ethereum/src/l1_contract_addresses.ts
+++ b/yarn-project/ethereum/src/l1_contract_addresses.ts
@@ -6,6 +6,8 @@ export const l1ContractsNames = [
   'registryAddress',
   'inboxAddress',
   'outboxAddress',
+  'gasTokenAddress',
+  'gasPortalAddress',
 ] as const;
 
 /**

--- a/yarn-project/protocol-contracts/src/gas-token/index.test.ts
+++ b/yarn-project/protocol-contracts/src/gas-token/index.test.ts
@@ -1,8 +1,9 @@
+import { EthAddress } from '@aztec/circuits.js';
 import { setupCustomSnapshotSerializers } from '@aztec/foundation/testing';
 
 import omit from 'lodash.omit';
 
-import { GasTokenAddress, getCanonicalGasToken } from './index.js';
+import { getCanonicalGasToken } from './index.js';
 
 describe('GasToken', () => {
   setupCustomSnapshotSerializers(expect);
@@ -10,7 +11,7 @@ describe('GasToken', () => {
     // if you're updating the snapshots here then you'll also have to update CANONICAL_GAS_TOKEN_ADDRESS in
     // - noir-projects/noir-contracts/contracts/fpc_contract/src/main.nr
     // - noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
-    const contract = getCanonicalGasToken();
+    const contract = getCanonicalGasToken(EthAddress.ZERO);
     expect(omit(contract, ['artifact', 'contractClass'])).toMatchSnapshot();
 
     // bytecode is very large
@@ -19,6 +20,5 @@ describe('GasToken', () => {
     // this contract has public bytecode
     expect(contract.contractClass.publicFunctions.map(x => omit(x, 'bytecode'))).toMatchSnapshot();
     expect(contract.contractClass.packedBytecode.length).toBeGreaterThan(0);
-    expect(contract.address.toString()).toEqual(GasTokenAddress.toString());
   });
 });

--- a/yarn-project/protocol-contracts/src/gas-token/index.ts
+++ b/yarn-project/protocol-contracts/src/gas-token/index.ts
@@ -1,11 +1,13 @@
-import { EthAddress, Point } from '@aztec/circuits.js';
+import { AztecAddress, EthAddress, Point } from '@aztec/circuits.js';
 
 import { ProtocolContract, getCanonicalProtocolContract } from '../protocol_contract.js';
 import { GasTokenArtifact } from './artifact.js';
 
 /** Returns the canonical deployment of the gas token. */
-export function getCanonicalGasToken(): ProtocolContract {
-  return getCanonicalProtocolContract(GasTokenArtifact, 1, [], Point.ZERO, EthAddress.ZERO);
+export function getCanonicalGasToken(l1Bridge: EthAddress): ProtocolContract {
+  return getCanonicalProtocolContract(GasTokenArtifact, 1, [], Point.ZERO, l1Bridge);
 }
 
-export const GasTokenAddress = getCanonicalGasToken().address;
+export function getCanonicalGasTokenAddress(l1Bridge: EthAddress): AztecAddress {
+  return getCanonicalGasToken(l1Bridge).address;
+}

--- a/yarn-project/pxe/src/pxe_service/create_pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/create_pxe_service.ts
@@ -43,7 +43,11 @@ export async function createPXEService(
   const db = new KVPxeDatabase(await initStoreForRollup(AztecLmdbStore.open(pxeDbPath), l1Contracts.rollupAddress));
 
   const server = new PXEService(keyStore, aztecNode, db, config, logSuffix);
-  for (const contract of [getCanonicalClassRegisterer(), getCanonicalInstanceDeployer(), getCanonicalGasToken()]) {
+  for (const contract of [
+    getCanonicalClassRegisterer(),
+    getCanonicalInstanceDeployer(),
+    getCanonicalGasToken(l1Contracts.gasPortalAddress),
+  ]) {
     await server.registerContract(contract);
   }
 

--- a/yarn-project/pxe/src/pxe_service/test/pxe_service.test.ts
+++ b/yarn-project/pxe/src/pxe_service/test/pxe_service.test.ts
@@ -31,6 +31,8 @@ function createPXEService(): Promise<PXE> {
     registryAddress: EthAddress.random(),
     inboxAddress: EthAddress.random(),
     outboxAddress: EthAddress.random(),
+    gasTokenAddress: EthAddress.random(),
+    gasPortalAddress: EthAddress.random(),
   };
   node.getL1ContractAddresses.mockResolvedValue(mockedContracts);
 

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -45,6 +45,8 @@ export function getConfigEnvVars(): SequencerClientConfig {
     REGISTRY_CONTRACT_ADDRESS,
     INBOX_CONTRACT_ADDRESS,
     OUTBOX_CONTRACT_ADDRESS,
+    GAS_TOKEN_CONTRACT_ADDRESS,
+    GAS_PORTAL_CONTRACT_ADDRESS,
     COINBASE,
     FEE_RECIPIENT,
     ACVM_WORKING_DIRECTORY,
@@ -63,6 +65,10 @@ export function getConfigEnvVars(): SequencerClientConfig {
     registryAddress: REGISTRY_CONTRACT_ADDRESS ? EthAddress.fromString(REGISTRY_CONTRACT_ADDRESS) : EthAddress.ZERO,
     inboxAddress: INBOX_CONTRACT_ADDRESS ? EthAddress.fromString(INBOX_CONTRACT_ADDRESS) : EthAddress.ZERO,
     outboxAddress: OUTBOX_CONTRACT_ADDRESS ? EthAddress.fromString(OUTBOX_CONTRACT_ADDRESS) : EthAddress.ZERO,
+    gasTokenAddress: GAS_TOKEN_CONTRACT_ADDRESS ? EthAddress.fromString(GAS_TOKEN_CONTRACT_ADDRESS) : EthAddress.ZERO,
+    gasPortalAddress: GAS_PORTAL_CONTRACT_ADDRESS
+      ? EthAddress.fromString(GAS_PORTAL_CONTRACT_ADDRESS)
+      : EthAddress.ZERO,
   };
 
   return {

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -233,6 +233,7 @@ __metadata:
     "@aztec/noir-compiler": "workspace:^"
     "@aztec/noir-contracts.js": "workspace:^"
     "@aztec/p2p": "workspace:^"
+    "@aztec/protocol-contracts": "workspace:^"
     "@aztec/pxe": "workspace:^"
     "@jest/globals": ^29.5.0
     "@types/jest": ^29.5.0


### PR DESCRIPTION
Add `gasPortalAddress` to config and optionally deploy the portal and gas token at bootstrap. This enables reading the correct canonical gas token everywhere.

Fix #5022 