### PR TITLE
refactor: extract tx validation to separate class

### DIFF
--- a/yarn-project/circuit-types/src/tx/tx.ts
+++ b/yarn-project/circuit-types/src/tx/tx.ts
@@ -176,7 +176,6 @@ export class Tx {
    * @returns - The hash.
    */
   static getHash(tx: Tx | HasHash): TxHash {
-    const hasHash = (tx: Tx | HasHash): tx is HasHash => (tx as HasHash).hash !== undefined;
     return hasHash(tx) ? tx.hash : tx.getTxHash();
   }
 
@@ -186,7 +185,7 @@ export class Tx {
    * @returns The corresponding array of hashes.
    */
   static getHashes(txs: (Tx | HasHash)[]): TxHash[] {
-    return txs.map(tx => Tx.getHash(tx));
+    return txs.map(Tx.getHash);
   }
 
   /**
@@ -208,3 +207,7 @@ export class Tx {
 
 /** Utility type for an entity that has a hash property for a txhash */
 type HasHash = { /** The tx hash */ hash: TxHash };
+
+function hasHash(tx: Tx | HasHash): tx is HasHash {
+  return (tx as HasHash).hash !== undefined;
+}

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -132,7 +132,7 @@ describe('sequencer', () => {
     );
 
     // We make a nullifier from tx1 a part of the nullifier tree, so it gets rejected as double spend
-    const doubleSpendNullifier = doubleSpendTx.data.end.newNullifiers[0].toBuffer();
+    const doubleSpendNullifier = doubleSpendTx.data.end.newNullifiers[0].value.toBuffer();
     merkleTreeOps.findLeafIndex.mockImplementation((treeId: MerkleTreeId, value: Buffer) => {
       return Promise.resolve(
         treeId === MerkleTreeId.NULLIFIER_TREE && value.equals(doubleSpendNullifier) ? 1n : undefined,

--- a/yarn-project/sequencer-client/src/sequencer/tx_validator.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/tx_validator.test.ts
@@ -1,0 +1,77 @@
+import { mockTx as baseMockTx } from '@aztec/circuit-types';
+import { Fr, GlobalVariables } from '@aztec/circuits.js';
+import { makeGlobalVariables } from '@aztec/circuits.js/testing';
+
+import { MockProxy, mock, mockFn } from 'jest-mock-extended';
+
+import { NullifierSource, TxValidator } from './tx_validator.js';
+
+describe('TxValidator', () => {
+  let validator: TxValidator;
+  let globalVariables: GlobalVariables;
+  let nullifierSource: MockProxy<NullifierSource>;
+
+  beforeEach(() => {
+    nullifierSource = mock<NullifierSource>({
+      getNullifierIndex: mockFn().mockImplementation(() => {
+        return Promise.resolve(undefined);
+      }),
+    });
+    globalVariables = makeGlobalVariables();
+    validator = new TxValidator(nullifierSource, globalVariables);
+  });
+
+  describe('inspects tx metadata', () => {
+    it('allows only transactions for the right chain', async () => {
+      const goodTx = mockTx();
+      const badTx = mockTx();
+      badTx.data.constants.txContext.chainId = Fr.random();
+
+      await expect(validator.validateTxs([goodTx, badTx])).resolves.toEqual([[goodTx], [badTx]]);
+    });
+  });
+
+  describe('inspects tx nullifiers', () => {
+    it('rejects duplicates in non revertible data', async () => {
+      const badTx = mockTx();
+      badTx.data.endNonRevertibleData.newNullifiers[1] = badTx.data.endNonRevertibleData.newNullifiers[0];
+      await expect(validator.validateTxs([badTx])).resolves.toEqual([[], [badTx]]);
+    });
+
+    it('rejects duplicates in revertible data', async () => {
+      const badTx = mockTx();
+      badTx.data.end.newNullifiers[1] = badTx.data.end.newNullifiers[0];
+      await expect(validator.validateTxs([badTx])).resolves.toEqual([[], [badTx]]);
+    });
+
+    it('rejects duplicates across phases', async () => {
+      const badTx = mockTx();
+      badTx.data.end.newNullifiers[0] = badTx.data.endNonRevertibleData.newNullifiers[0];
+      await expect(validator.validateTxs([badTx])).resolves.toEqual([[], [badTx]]);
+    });
+
+    it('rejects duplicates across txs', async () => {
+      const firstTx = mockTx();
+      const secondTx = mockTx();
+      secondTx.data.end.newNullifiers[0] = firstTx.data.end.newNullifiers[0];
+      await expect(validator.validateTxs([firstTx, secondTx])).resolves.toEqual([[firstTx], [secondTx]]);
+    });
+
+    it('rejects duplicates against history', async () => {
+      const badTx = mockTx();
+      nullifierSource.getNullifierIndex.mockReturnValueOnce(Promise.resolve(1n));
+      await expect(validator.validateTxs([badTx])).resolves.toEqual([[], [badTx]]);
+    });
+  });
+
+  // get unique txs that are also stable across test runs
+  let txSeed = 1;
+  /** Creates a mock tx for the current chain */
+  function mockTx() {
+    const tx = baseMockTx(txSeed++, false);
+    tx.data.constants.txContext.chainId = globalVariables.chainId;
+    tx.data.constants.txContext.version = globalVariables.version;
+
+    return tx;
+  }
+});

--- a/yarn-project/sequencer-client/src/sequencer/tx_validator.ts
+++ b/yarn-project/sequencer-client/src/sequencer/tx_validator.ts
@@ -1,0 +1,128 @@
+import { Tx } from '@aztec/circuit-types';
+import { Fr, GlobalVariables } from '@aztec/circuits.js';
+import { Logger, createDebugLogger } from '@aztec/foundation/log';
+
+import { ProcessedTx } from './processed_tx.js';
+
+export interface NullifierSource {
+  getNullifierIndex: (nullifier: Fr) => Promise<bigint | undefined>;
+}
+
+// prefer symbols over booleans so it's clear what the intention is
+// vs returning true/false is tied to the function name
+// eg. isDoubleSpend vs isValidChain assign different meanings to booleans
+const VALID_TX = Symbol('valid_tx');
+const INVALID_TX = Symbol('invalid_tx');
+
+type TxValidationStatus = typeof VALID_TX | typeof INVALID_TX;
+
+export class TxValidator {
+  #log: Logger;
+  #globalVariables: GlobalVariables;
+  #nullifierSource: NullifierSource;
+
+  constructor(
+    nullifierSource: NullifierSource,
+    globalVariables: GlobalVariables,
+    log = createDebugLogger('aztec:sequencer:tx_validator'),
+  ) {
+    this.#nullifierSource = nullifierSource;
+    this.#globalVariables = globalVariables;
+
+    this.#log = log;
+  }
+
+  /**
+   * Validates a list of transactions.
+   * @param txs - The transactions to validate.
+   * @returns A tuple of valid and invalid transactions.
+   */
+  public async validateTxs<T extends Tx | ProcessedTx>(txs: T[]): Promise<[validTxs: T[], invalidTxs: T[]]> {
+    const validTxs: T[] = [];
+    const invalidTxs: T[] = [];
+    const thisBlockNullifiers = new Set<bigint>();
+
+    for (const tx of txs) {
+      if (this.#validateMetadata(tx) === INVALID_TX) {
+        invalidTxs.push(tx);
+        continue;
+      }
+
+      if ((await this.#validateNullifiers(tx, thisBlockNullifiers)) === INVALID_TX) {
+        invalidTxs.push(tx);
+        continue;
+      }
+
+      validTxs.push(tx);
+    }
+
+    return [validTxs, invalidTxs];
+  }
+
+  /**
+   * It rejects transactions with the wrong chain id.
+   * @param tx - The transaction.
+   * @returns Whether the transaction is valid.
+   */
+  #validateMetadata(tx: Tx | ProcessedTx): TxValidationStatus {
+    if (!tx.data.constants.txContext.chainId.equals(this.#globalVariables.chainId)) {
+      this.#log.warn(
+        `Rejecting tx ${Tx.getHash(
+          tx,
+        )} because of incorrect chain ${tx.data.constants.txContext.chainId.toString()} != ${this.#globalVariables.chainId.toString()}`,
+      );
+      return INVALID_TX;
+    }
+
+    return VALID_TX;
+  }
+
+  /**
+   * It looks for duplicate nullifiers:
+   * - in the same transaction
+   * - in the same block
+   * - in the nullifier tree
+   *
+   * Nullifiers prevent double spends in a private context.
+   *
+   * @param tx - The transaction.
+   * @returns Whether this is a problematic double spend that the L1 contract would reject.
+   */
+  async #validateNullifiers(tx: Tx | ProcessedTx, thisBlockNullifiers: Set<bigint>): Promise<TxValidationStatus> {
+    const newNullifiers = TxValidator.#extractNullifiers(tx);
+
+    // Ditch this tx if it has a repeated nullifiers
+    const uniqueNullifiers = new Set(newNullifiers);
+    if (uniqueNullifiers.size !== newNullifiers.length) {
+      this.#log.warn(`Rejecting tx for emitting duplicate nullifiers, tx hash ${Tx.getHash(tx)}`);
+      return INVALID_TX;
+    }
+
+    for (const nullifier of newNullifiers) {
+      if (thisBlockNullifiers.has(nullifier)) {
+        this.#log.warn(`Rejecting tx for repeating a in the same block, tx hash ${Tx.getHash(tx)}`);
+        return INVALID_TX;
+      }
+
+      thisBlockNullifiers.add(nullifier);
+    }
+
+    const nullifierIndexes = await Promise.all(
+      newNullifiers.map(n => this.#nullifierSource.getNullifierIndex(new Fr(n))),
+    );
+
+    const hasDuplicates = nullifierIndexes.some(index => index !== undefined);
+    if (hasDuplicates) {
+      this.#log.warn(`Rejecting tx for repeating nullifiers from the past, tx hash ${Tx.getHash(tx)}`);
+      return INVALID_TX;
+    }
+
+    return VALID_TX;
+  }
+
+  static #extractNullifiers(tx: Tx | ProcessedTx): bigint[] {
+    return [...tx.data.endNonRevertibleData.newNullifiers, ...tx.data.end.newNullifiers]
+      .filter(x => !x.isEmpty())
+      .map(x => x.value.toBigInt());
+  }
+}


### PR DESCRIPTION
Refactor tx validation the sequencer did to a separate class so it's easier to extend.

