### PR TITLE
refactor: removing redundant receipts check

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -62,7 +62,7 @@ export function describeArchiverDataStore(testName: string, getStore: () => Arch
       });
 
       it('throws an error if limit is invalid', async () => {
-        await expect(store.getBlocks(1, 0)).rejects.toThrowError('Invalid limit: 0');
+        await expect(store.getBlocks(1, 0)).rejects.toThrow('Invalid limit: 0');
       });
 
       it('resets `from` to the first block if it is out of range', async () => {

--- a/yarn-project/aztec.js/src/contract/checker.test.ts
+++ b/yarn-project/aztec.js/src/contract/checker.test.ts
@@ -7,12 +7,12 @@ describe('abiChecker', () => {
     abi = {
       name: 'TEST_ABI',
     };
-    expect(() => abiChecker(abi)).toThrowError('artifact has no functions');
+    expect(() => abiChecker(abi)).toThrow('artifact has no functions');
     abi = {
       name: 'TEST_ABI',
       functions: [],
     };
-    expect(() => abiChecker(abi)).toThrowError('artifact has no functions');
+    expect(() => abiChecker(abi)).toThrow('artifact has no functions');
   });
 
   it('should error if ABI has no names', () => {
@@ -20,7 +20,7 @@ describe('abiChecker', () => {
       name: 'TEST_ABI',
       functions: [{ bytecode: '0af', parameters: [{ type: { kind: 'test' } }] }],
     };
-    expect(() => abiChecker(abi)).toThrowError('ABI function has no name');
+    expect(() => abiChecker(abi)).toThrow('ABI function has no name');
   });
 
   it('should error if ABI function has unrecognized type', () => {
@@ -34,7 +34,7 @@ describe('abiChecker', () => {
         },
       ],
     };
-    expect(() => abiChecker(abi)).toThrowError('ABI function parameter has an unrecognized type');
+    expect(() => abiChecker(abi)).toThrow('ABI function parameter has an unrecognized type');
   });
 
   it('should error if integer is incorrectly formed', () => {
@@ -48,7 +48,7 @@ describe('abiChecker', () => {
         },
       ],
     };
-    expect(() => abiChecker(abi)).toThrowError('Unrecognized attribute on type integer');
+    expect(() => abiChecker(abi)).toThrow('Unrecognized attribute on type integer');
   });
 
   it('should error if string is incorrectly formed', () => {
@@ -62,7 +62,7 @@ describe('abiChecker', () => {
         },
       ],
     };
-    expect(() => abiChecker(abi)).toThrowError('Unrecognized attribute on type string');
+    expect(() => abiChecker(abi)).toThrow('Unrecognized attribute on type string');
   });
 
   it('should error if struct is incorrectly formed', () => {
@@ -82,7 +82,7 @@ describe('abiChecker', () => {
         },
       ],
     };
-    expect(() => abiChecker(abi)).toThrowError('Unrecognized attribute on type struct');
+    expect(() => abiChecker(abi)).toThrow('Unrecognized attribute on type struct');
   });
 
   it('should error if array is incorrectly formed', () => {
@@ -112,7 +112,7 @@ describe('abiChecker', () => {
         },
       ],
     };
-    expect(() => abiChecker(abi)).toThrowError('ABI function parameter has an incorrectly formed array');
+    expect(() => abiChecker(abi)).toThrow('ABI function parameter has an incorrectly formed array');
   });
 
   it('valid matrix should pass checker', () => {

--- a/yarn-project/aztec.js/src/contract/sent_tx.test.ts
+++ b/yarn-project/aztec.js/src/contract/sent_tx.test.ts
@@ -34,7 +34,7 @@ describe('SentTx', () => {
 
     it('fails if an account is not synced', async () => {
       pxe.getSyncStatus.mockResolvedValue({ blocks: 25, notes: { '0x1': 19, '0x2': 20 } });
-      await expect(sentTx.wait({ timeout: 1, interval: 0.4 })).rejects.toThrowError(/timeout/i);
+      await expect(sentTx.wait({ timeout: 1, interval: 0.4 })).rejects.toThrow(/timeout/i);
     });
 
     it('does not wait for notes sync', async () => {
@@ -46,7 +46,7 @@ describe('SentTx', () => {
     it('throws if tx is dropped', async () => {
       pxe.getTxReceipt.mockResolvedValue({ ...txReceipt, status: TxStatus.DROPPED } as TxReceipt);
       pxe.getSyncStatus.mockResolvedValue({ blocks: 19, notes: { '0x1': 19, '0x2': 19 } });
-      await expect(sentTx.wait({ timeout: 1, interval: 0.4 })).rejects.toThrowError(/dropped/);
+      await expect(sentTx.wait({ timeout: 1, interval: 0.4 })).rejects.toThrow(/dropped/);
     });
   });
 });

--- a/yarn-project/circuits.js/src/structs/complete_address.test.ts
+++ b/yarn-project/circuits.js/src/structs/complete_address.test.ts
@@ -5,7 +5,7 @@ import { CompleteAddress } from './complete_address.js';
 
 describe('CompleteAddress', () => {
   it('refuses to add an account with incorrect address for given partial address and pubkey', () => {
-    expect(() => CompleteAddress.create(AztecAddress.random(), Point.random(), Fr.random())).toThrowError(
+    expect(() => CompleteAddress.create(AztecAddress.random(), Point.random(), Fr.random())).toThrow(
       /cannot be derived/,
     );
   });

--- a/yarn-project/cli/src/client.test.ts
+++ b/yarn-project/cli/src/client.test.ts
@@ -20,16 +20,12 @@ describe('client', () => {
 
     it('reports mismatch on older pxe version', async () => {
       pxe.getNodeInfo.mockResolvedValue({ nodeVersion: '0.1.0-alpha47' } as NodeInfo);
-      await expect(checkServerVersion(pxe, '0.1.0-alpha48')).rejects.toThrowError(
-        /is older than the expected by this CLI/,
-      );
+      await expect(checkServerVersion(pxe, '0.1.0-alpha48')).rejects.toThrow(/is older than the expected by this CLI/);
     });
 
     it('reports mismatch on newer pxe version', async () => {
       pxe.getNodeInfo.mockResolvedValue({ nodeVersion: '0.1.0-alpha48' } as NodeInfo);
-      await expect(checkServerVersion(pxe, '0.1.0-alpha47')).rejects.toThrowError(
-        /is newer than the expected by this CLI/,
-      );
+      await expect(checkServerVersion(pxe, '0.1.0-alpha47')).rejects.toThrow(/is newer than the expected by this CLI/);
     });
   });
 });

--- a/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
+++ b/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
@@ -60,9 +60,7 @@ function itShouldBehaveLikeAnAccountContract(
       const accountAddress = wallet.getCompleteAddress();
       const invalidWallet = await walletAt(context.pxe, getAccountContract(GrumpkinScalar.random()), accountAddress);
       const childWithInvalidWallet = await ChildContract.at(child.address, invalidWallet);
-      await expect(childWithInvalidWallet.methods.value(42).simulate()).rejects.toThrowError(
-        /Cannot satisfy constraint.*/,
-      );
+      await expect(childWithInvalidWallet.methods.value(42).simulate()).rejects.toThrow(/Cannot satisfy constraint.*/);
     });
   });
 }

--- a/yarn-project/end-to-end/src/e2e_authwit.test.ts
+++ b/yarn-project/end-to-end/src/e2e_authwit.test.ts
@@ -43,7 +43,7 @@ describe('e2e_authwit_tests', () => {
           const c = await SchnorrAccountContract.at(wallets[0].getAddress(), wallets[0]);
           const txCancelledAuthwit = c.withWallet(wallets[1]).methods.spend_private_authwit(innerHash).send();
           // The transaction should be dropped because of a cancelled authwit (duplicate nullifier)
-          await expect(txCancelledAuthwit.wait()).rejects.toThrowError('Transaction ');
+          await expect(txCancelledAuthwit.wait()).rejects.toThrow('Transaction ');
         });
       });
     });
@@ -73,7 +73,7 @@ describe('e2e_authwit_tests', () => {
           const c = await SchnorrAccountContract.at(wallets[0].getAddress(), wallets[0]);
           const txCancelledAuthwit = c.withWallet(wallets[1]).methods.spend_public_authwit(innerHash).send();
           // The transaction should be dropped because of a cancelled authwit (duplicate nullifier)
-          await expect(txCancelledAuthwit.wait()).rejects.toThrowError('Transaction ');
+          await expect(txCancelledAuthwit.wait()).rejects.toThrow('Transaction ');
         });
       });
     });

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract.test.ts
@@ -9,7 +9,6 @@ import {
   FunctionSelector,
   Note,
   TxHash,
-  TxStatus,
   Wallet,
   computeAuthWitMessageHash,
   computeMessageSecretHash,
@@ -174,8 +173,7 @@ describe('e2e_blacklist_token_contract', () => {
         getMembershipCapsule(await getMembershipProof(accounts[0].address.toBigInt(), false)),
       );
 
-      const tx = await asset.methods.update_roles(newMinter, newRoles).send().wait();
-      expect(tx.status).toBe(TxStatus.MINED);
+      await asset.methods.update_roles(newMinter, newRoles).send().wait();
       await slowUpdateTreeSimulator.commit();
 
       const afterLeaf = await slowTree.methods.un_read_leaf_at(asset.address, newMinter).view();
@@ -186,9 +184,7 @@ describe('e2e_blacklist_token_contract', () => {
       const time = await cheatCodes.eth.timestamp();
       await cheatCodes.aztec.warp(time + 200);
 
-      /*      const tx = asset.withWallet(wallets[1]).methods.set_minter(accounts[1].address, true).send();
-      const receipt = await tx.wait();
-      expect(receipt.status).toBe(TxStatus.MINED);
+      /* asset.withWallet(wallets[1]).methods.set_minter(accounts[1].address, true).send().wait();
       expect(await asset.methods.is_minter(accounts[1].address).view()).toBe(true);*/
     });
 
@@ -205,8 +201,7 @@ describe('e2e_blacklist_token_contract', () => {
         getMembershipCapsule(await getMembershipProof(accounts[0].address.toBigInt(), false)),
       );
 
-      const tx = await asset.methods.update_roles(newAdmin, newRoles).send().wait();
-      expect(tx.status).toBe(TxStatus.MINED);
+      await asset.methods.update_roles(newAdmin, newRoles).send().wait();
       await slowUpdateTreeSimulator.commit();
 
       v = await slowTree.methods.un_read_leaf_at(asset.address, newAdmin).view();
@@ -235,8 +230,7 @@ describe('e2e_blacklist_token_contract', () => {
         getMembershipCapsule(await getMembershipProof(accounts[0].address.toBigInt(), false)),
       );
 
-      const tx = await asset.methods.update_roles(actor, newRoles).send().wait();
-      expect(tx.status).toBe(TxStatus.MINED);
+      await asset.methods.update_roles(actor, newRoles).send().wait();
       await slowUpdateTreeSimulator.commit();
 
       const afterLeaf = await slowTree.methods.un_read_leaf_at(asset.address, actor).view();
@@ -248,9 +242,7 @@ describe('e2e_blacklist_token_contract', () => {
       await cheatCodes.aztec.warp(time + 200);
 
       /*
-      const tx = asset.withWallet(wallets[1]).methods.set_minter(accounts[1].address, false).send();
-      const receipt = await tx.wait();
-      expect(receipt.status).toBe(TxStatus.MINED);
+      asset.withWallet(wallets[1]).methods.set_minter(accounts[1].address, false).send().wait();
       expect(await asset.methods.is_minter(accounts[1].address).view()).toBe(false);*/
     });
 
@@ -264,8 +256,7 @@ describe('e2e_blacklist_token_contract', () => {
         getMembershipCapsule(await getMembershipProof(accounts[0].address.toBigInt(), false)),
       );
 
-      const tx = await asset.methods.update_roles(accounts[3].address, 1n).send().wait();
-      expect(tx.status).toBe(TxStatus.MINED);
+      await asset.methods.update_roles(accounts[3].address, 1n).send().wait();
       await slowUpdateTreeSimulator.commit();
 
       v = await slowTree.methods.un_read_leaf_at(asset.address, accounts[3].address).view();
@@ -324,9 +315,7 @@ describe('e2e_blacklist_token_contract', () => {
     describe('Public', () => {
       it('as minter', async () => {
         const amount = 10000n;
-        const tx = asset.methods.mint_public(accounts[0].address, amount).send();
-        const receipt = await tx.wait();
-        expect(receipt.status).toBe(TxStatus.MINED);
+        await asset.methods.mint_public(accounts[0].address, amount).send().wait();
 
         tokenSim.mintPublic(accounts[0].address, amount);
         expect(await asset.methods.balance_of_public(accounts[0].address).view()).toEqual(
@@ -384,9 +373,7 @@ describe('e2e_blacklist_token_contract', () => {
 
       describe('Mint flow', () => {
         it('mint_private as minter', async () => {
-          const tx = asset.methods.mint_private(amount, secretHash).send();
-          const receipt = await tx.wait();
-          expect(receipt.status).toBe(TxStatus.MINED);
+          const receipt = await asset.methods.mint_private(amount, secretHash).send().wait();
           tokenSim.mintPrivate(amount);
           txHash = receipt.txHash;
         });
@@ -396,9 +383,10 @@ describe('e2e_blacklist_token_contract', () => {
           await wallets[0].addCapsule(
             getMembershipCapsule(await getMembershipProof(accounts[0].address.toBigInt(), true)),
           );
-          const txClaim = asset.methods.redeem_shield(accounts[0].address, amount, secret).send();
-          const receiptClaim = await txClaim.wait({ debug: true });
-          expect(receiptClaim.status).toBe(TxStatus.MINED);
+          const receiptClaim = await asset.methods
+            .redeem_shield(accounts[0].address, amount, secret)
+            .send()
+            .wait({ debug: true });
           tokenSim.redeemShield(accounts[0].address, amount);
           // 1 note should be created containing `amount` of tokens
           const { visibleNotes } = receiptClaim.debugInfo!;
@@ -467,9 +455,7 @@ describe('e2e_blacklist_token_contract', () => {
         const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
         const amount = balance0 / 2n;
         expect(amount).toBeGreaterThan(0n);
-        const tx = asset.methods.transfer_public(accounts[0].address, accounts[1].address, amount, 0).send();
-        const receipt = await tx.wait();
-        expect(receipt.status).toBe(TxStatus.MINED);
+        await asset.methods.transfer_public(accounts[0].address, accounts[1].address, amount, 0).send().wait();
 
         tokenSim.transferPublic(accounts[0].address, accounts[1].address, amount);
       });
@@ -478,9 +464,7 @@ describe('e2e_blacklist_token_contract', () => {
         const balance = await asset.methods.balance_of_public(accounts[0].address).view();
         const amount = balance / 2n;
         expect(amount).toBeGreaterThan(0n);
-        const tx = asset.methods.transfer_public(accounts[0].address, accounts[0].address, amount, 0).send();
-        const receipt = await tx.wait();
-        expect(receipt.status).toBe(TxStatus.MINED);
+        await asset.methods.transfer_public(accounts[0].address, accounts[0].address, amount, 0).send().wait();
 
         tokenSim.transferPublic(accounts[0].address, accounts[0].address, amount);
       });
@@ -501,9 +485,7 @@ describe('e2e_blacklist_token_contract', () => {
         // docs:end:authwit_public_transfer_example
 
         // Perform the transfer
-        const tx = action.send();
-        const receipt = await tx.wait();
-        expect(receipt.status).toBe(TxStatus.MINED);
+        await action.send().wait();
 
         tokenSim.transferPublic(accounts[0].address, accounts[1].address, amount);
 
@@ -643,9 +625,7 @@ describe('e2e_blacklist_token_contract', () => {
         await wallets[0].addCapsule(
           getMembershipCapsule(await getMembershipProof(accounts[0].address.toBigInt(), true)),
         );
-        const tx = asset.methods.transfer(accounts[0].address, accounts[1].address, amount, 0).send();
-        const receipt = await tx.wait();
-        expect(receipt.status).toBe(TxStatus.MINED);
+        await asset.methods.transfer(accounts[0].address, accounts[1].address, amount, 0).send().wait();
         tokenSim.transferPrivate(accounts[0].address, accounts[1].address, amount);
       });
 
@@ -659,9 +639,7 @@ describe('e2e_blacklist_token_contract', () => {
         await wallets[0].addCapsule(
           getMembershipCapsule(await getMembershipProof(accounts[0].address.toBigInt(), true)),
         );
-        const tx = asset.methods.transfer(accounts[0].address, accounts[0].address, amount, 0).send();
-        const receipt = await tx.wait();
-        expect(receipt.status).toBe(TxStatus.MINED);
+        await asset.methods.transfer(accounts[0].address, accounts[0].address, amount, 0).send().wait();
         tokenSim.transferPrivate(accounts[0].address, accounts[0].address, amount);
       });
 
@@ -691,9 +669,7 @@ describe('e2e_blacklist_token_contract', () => {
         );
 
         // Perform the transfer
-        const tx = action.send();
-        const receipt = await tx.wait();
-        expect(receipt.status).toBe(TxStatus.MINED);
+        await action.send().wait();
         tokenSim.transferPrivate(accounts[0].address, accounts[1].address, amount);
 
         await wallets[1].addCapsule(
@@ -871,9 +847,7 @@ describe('e2e_blacklist_token_contract', () => {
       const amount = balancePub / 2n;
       expect(amount).toBeGreaterThan(0n);
 
-      const tx = asset.methods.shield(accounts[0].address, amount, secretHash, 0).send();
-      const receipt = await tx.wait();
-      expect(receipt.status).toBe(TxStatus.MINED);
+      const receipt = await asset.methods.shield(accounts[0].address, amount, secretHash, 0).send().wait();
 
       tokenSim.shield(accounts[0].address, amount);
       await tokenSim.check();
@@ -881,9 +855,7 @@ describe('e2e_blacklist_token_contract', () => {
       // Redeem it
       await addPendingShieldNoteToPXE(0, amount, secretHash, receipt.txHash);
       await wallets[0].addCapsule(getMembershipCapsule(await getMembershipProof(accounts[0].address.toBigInt(), true)));
-      const txClaim = asset.methods.redeem_shield(accounts[0].address, amount, secret).send();
-      const receiptClaim = await txClaim.wait();
-      expect(receiptClaim.status).toBe(TxStatus.MINED);
+      await asset.methods.redeem_shield(accounts[0].address, amount, secret).send().wait();
 
       tokenSim.redeemShield(accounts[0].address, amount);
     });
@@ -899,9 +871,7 @@ describe('e2e_blacklist_token_contract', () => {
       const messageHash = computeAuthWitMessageHash(accounts[1].address, action.request());
       await wallets[0].setPublicAuth(messageHash, true).send().wait();
 
-      const tx = action.send();
-      const receipt = await tx.wait();
-      expect(receipt.status).toBe(TxStatus.MINED);
+      const receipt = await action.send().wait();
 
       tokenSim.shield(accounts[0].address, amount);
       await tokenSim.check();
@@ -916,9 +886,7 @@ describe('e2e_blacklist_token_contract', () => {
       // Redeem it
       await addPendingShieldNoteToPXE(0, amount, secretHash, receipt.txHash);
       await wallets[0].addCapsule(getMembershipCapsule(await getMembershipProof(accounts[0].address.toBigInt(), true)));
-      const txClaim = asset.methods.redeem_shield(accounts[0].address, amount, secret).send();
-      const receiptClaim = await txClaim.wait();
-      expect(receiptClaim.status).toBe(TxStatus.MINED);
+      await asset.methods.redeem_shield(accounts[0].address, amount, secret).send().wait();
 
       tokenSim.redeemShield(accounts[0].address, amount);
     });
@@ -1002,9 +970,7 @@ describe('e2e_blacklist_token_contract', () => {
 
       await wallets[1].addCapsule(getMembershipCapsule(await getMembershipProof(accounts[0].address.toBigInt(), true)));
       await wallets[1].addCapsule(getMembershipCapsule(await getMembershipProof(accounts[0].address.toBigInt(), true)));
-      const tx = asset.methods.unshield(accounts[0].address, accounts[0].address, amount, 0).send();
-      const receipt = await tx.wait();
-      expect(receipt.status).toBe(TxStatus.MINED);
+      await asset.methods.unshield(accounts[0].address, accounts[0].address, amount, 0).send().wait();
 
       tokenSim.unshield(accounts[0].address, accounts[0].address, amount);
     });
@@ -1029,9 +995,7 @@ describe('e2e_blacklist_token_contract', () => {
       const witness = await wallets[0].createAuthWitness(messageHash);
       await wallets[1].addAuthWitness(witness);
 
-      const tx = action.send();
-      const receipt = await tx.wait();
-      expect(receipt.status).toBe(TxStatus.MINED);
+      await action.send().wait();
       tokenSim.unshield(accounts[0].address, accounts[1].address, amount);
 
       // Perform the transfer again, should fail
@@ -1169,9 +1133,7 @@ describe('e2e_blacklist_token_contract', () => {
         const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
         const amount = balance0 / 2n;
         expect(amount).toBeGreaterThan(0n);
-        const tx = asset.methods.burn_public(accounts[0].address, amount, 0).send();
-        const receipt = await tx.wait();
-        expect(receipt.status).toBe(TxStatus.MINED);
+        await asset.methods.burn_public(accounts[0].address, amount, 0).send().wait();
 
         tokenSim.burnPublic(accounts[0].address, amount);
       });
@@ -1187,9 +1149,7 @@ describe('e2e_blacklist_token_contract', () => {
         const messageHash = computeAuthWitMessageHash(accounts[1].address, action.request());
         await wallets[0].setPublicAuth(messageHash, true).send().wait();
 
-        const tx = action.send();
-        const receipt = await tx.wait();
-        expect(receipt.status).toBe(TxStatus.MINED);
+        await action.send().wait();
 
         tokenSim.burnPublic(accounts[0].address, amount);
 
@@ -1273,9 +1233,7 @@ describe('e2e_blacklist_token_contract', () => {
         await wallets[0].addCapsule(
           getMembershipCapsule(await getMembershipProof(accounts[0].address.toBigInt(), true)),
         );
-        const tx = asset.methods.burn(accounts[0].address, amount, 0).send();
-        const receipt = await tx.wait();
-        expect(receipt.status).toBe(TxStatus.MINED);
+        await asset.methods.burn(accounts[0].address, amount, 0).send().wait();
         tokenSim.burnPrivate(accounts[0].address, amount);
       });
 
@@ -1298,9 +1256,7 @@ describe('e2e_blacklist_token_contract', () => {
           getMembershipCapsule(await getMembershipProof(accounts[0].address.toBigInt(), true)),
         );
 
-        const tx = asset.withWallet(wallets[1]).methods.burn(accounts[0].address, amount, nonce).send();
-        const receipt = await tx.wait();
-        expect(receipt.status).toBe(TxStatus.MINED);
+        await asset.withWallet(wallets[1]).methods.burn(accounts[0].address, amount, nonce).send().wait();
         tokenSim.burnPrivate(accounts[0].address, amount);
 
         // Perform the transfer again, should fail

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract.test.ts
@@ -183,9 +183,6 @@ describe('e2e_blacklist_token_contract', () => {
 
       const time = await cheatCodes.eth.timestamp();
       await cheatCodes.aztec.warp(time + 200);
-
-      /* asset.withWallet(wallets[1]).methods.set_minter(accounts[1].address, true).send().wait();
-      expect(await asset.methods.is_minter(accounts[1].address).view()).toBe(true);*/
     });
 
     it('Make account[1] admin', async () => {
@@ -240,10 +237,6 @@ describe('e2e_blacklist_token_contract', () => {
 
       const time = await cheatCodes.eth.timestamp();
       await cheatCodes.aztec.warp(time + 200);
-
-      /*
-      asset.withWallet(wallets[1]).methods.set_minter(accounts[1].address, false).send().wait();
-      expect(await asset.methods.is_minter(accounts[1].address).view()).toBe(false);*/
     });
 
     it('Add account[3] to blacklist', async () => {
@@ -282,10 +275,6 @@ describe('e2e_blacklist_token_contract', () => {
         await expect(asset.withWallet(wallets[3]).methods.update_roles(account, newRoles).simulate()).rejects.toThrow(
           "Assertion failed: caller is not admin 'caller_roles.is_admin'",
         );
-
-        /*        await expect(asset.methods.set_admin(accounts[0].address).simulate()).rejects.toThrow(
-          'Assertion failed: caller is not admin',
-        );*/
       });
 
       it('Revoke minter not as admin', async () => {
@@ -303,10 +292,6 @@ describe('e2e_blacklist_token_contract', () => {
         await expect(
           asset.withWallet(wallets[3]).methods.update_roles(adminAccount, newRoles).simulate(),
         ).rejects.toThrow("Assertion failed: caller is not admin 'caller_roles.is_admin'");
-
-        /* await expect(asset.methods.set_minter(accounts[0].address, false).simulate()).rejects.toThrow(
-          'Assertion failed: caller is not admin',
-        );*/
       });
     });
   });

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -9,7 +9,6 @@ import {
   PXE,
   SentTx,
   TxReceipt,
-  TxStatus,
   Wallet,
 } from '@aztec/aztec.js';
 import { times } from '@aztec/foundation/collection';
@@ -69,7 +68,6 @@ describe('e2e_block_building', () => {
 
       // Await txs to be mined and assert they are all mined on the same block
       const receipts = await Promise.all(txs.map(tx => tx.wait()));
-      expect(receipts.map(r => r.status)).toEqual(times(TX_COUNT, () => TxStatus.MINED));
       expect(receipts.map(r => r.blockNumber)).toEqual(times(TX_COUNT, () => receipts[0].blockNumber));
 
       // Assert all contracts got deployed

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -146,7 +146,7 @@ describe('e2e_block_building', () => {
     it('drops tx with two equal nullifiers', async () => {
       const nullifier = Fr.random();
       const calls = times(2, () => contract.methods.emit_nullifier(nullifier).request());
-      await expect(new BatchCall(owner, calls).send().wait()).rejects.toThrowError(/dropped/);
+      await expect(new BatchCall(owner, calls).send().wait()).rejects.toThrow(/dropped/);
     }, 30_000);
 
     it('drops tx with private nullifier already emitted from public on the same block', async () => {

--- a/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
@@ -6,7 +6,6 @@ import {
   Fr,
   Note,
   PXE,
-  TxStatus,
   Wallet,
   computeMessageSecretHash,
 } from '@aztec/aztec.js';
@@ -168,15 +167,14 @@ describe('e2e_cheat_codes', () => {
         expect(Number(await rollup.read.lastBlockTs())).toEqual(newTimestamp);
         expect(Number(await rollup.read.lastWarpedBlockTs())).toEqual(newTimestamp);
 
-        const txIsTimeEqual = contract.methods.is_time_equal(newTimestamp).send();
-        const isTimeEqualReceipt = await txIsTimeEqual.wait({ interval: 0.1 });
-        expect(isTimeEqualReceipt.status).toBe(TxStatus.MINED);
+        await contract.methods.is_time_equal(newTimestamp).send().wait({ interval: 0.1 });
 
         // Since last rollup block was warped, txs for this rollup will have time incremented by 1
         // See https://github.com/AztecProtocol/aztec-packages/issues/1614 for details
-        const txTimeNotEqual = contract.methods.is_time_equal(newTimestamp + 1).send();
-        const isTimeNotEqualReceipt = await txTimeNotEqual.wait({ interval: 0.1 });
-        expect(isTimeNotEqualReceipt.status).toBe(TxStatus.MINED);
+        await contract.methods
+          .is_time_equal(newTimestamp + 1)
+          .send()
+          .wait({ interval: 0.1 });
         // block is published at t >= newTimestamp + 1.
         expect(Number(await rollup.read.lastBlockTs())).toBeGreaterThanOrEqual(newTimestamp + 1);
       }, 50_000);

--- a/yarn-project/end-to-end/src/e2e_counter_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_counter_contract.test.ts
@@ -1,4 +1,4 @@
-import { AccountWallet, AztecAddress, CompleteAddress, DebugLogger, TxStatus } from '@aztec/aztec.js';
+import { AccountWallet, AztecAddress, CompleteAddress, DebugLogger } from '@aztec/aztec.js';
 import { CounterContract } from '@aztec/noir-contracts.js/Counter';
 
 import { setup } from './fixtures/utils.js';
@@ -31,8 +31,7 @@ describe('e2e_counter_contract', () => {
 
   describe('increments', () => {
     it('counts', async () => {
-      const receipt = await counterContract.methods.increment(owner).send().wait();
-      expect(receipt.status).toBe(TxStatus.MINED);
+      await counterContract.methods.increment(owner).send().wait();
       expect(await counterContract.methods.get_counter(owner).view()).toBe(1n);
     });
   });

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
@@ -7,7 +7,6 @@ import {
   L1Actor,
   L1ToL2Message,
   L2Actor,
-  TxStatus,
   computeAuthWitMessageHash,
 } from '@aztec/aztec.js';
 import { sha256 } from '@aztec/foundation/crypto';
@@ -168,12 +167,11 @@ describe('e2e_cross_chain_messaging', () => {
     ).rejects.toThrow(`L1 to L2 message index not found in the store for message ${wrongMessage.hash().toString()}`);
 
     // send the right one -
-    const consumptionTx = l2Bridge
+    const consumptionReceipt = await l2Bridge
       .withWallet(user2Wallet)
       .methods.claim_private(secretHashForRedeemingMintedNotes, bridgeAmount, secretForL2MessageConsumption)
-      .send();
-    const consumptionReceipt = await consumptionTx.wait();
-    expect(consumptionReceipt.status).toBe(TxStatus.MINED);
+      .send()
+      .wait();
 
     // Now user1 can claim the notes that user2 minted on their behalf.
     await crossChainTestHarness.addPendingShieldNoteToPXE(

--- a/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
@@ -111,7 +111,7 @@ describe('e2e_escrow_contract', () => {
   it('refuses to withdraw funds as a non-owner', async () => {
     await expect(
       escrowContract.withWallet(recipientWallet).methods.withdraw(token.address, 30, recipient).simulate(),
-    ).rejects.toThrowError();
+    ).rejects.toThrow();
   }, 60_000);
 
   it('moves funds using multiple keys on the same tx (#1010)', async () => {

--- a/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
@@ -11,7 +11,6 @@ import {
   Note,
   PXE,
   PublicKey,
-  TxStatus,
   computeMessageSecretHash,
   generatePublicKey,
 } from '@aztec/aztec.js';
@@ -70,7 +69,6 @@ describe('e2e_escrow_contract', () => {
     const secretHash = computeMessageSecretHash(secret);
 
     const receipt = await token.methods.mint_private(mintAmount, secretHash).send().wait();
-    expect(receipt.status).toEqual(TxStatus.MINED);
 
     const note = new Note([new Fr(mintAmount), secretHash]);
 
@@ -84,9 +82,7 @@ describe('e2e_escrow_contract', () => {
     );
     await pxe.addNote(extendedNote);
 
-    expect(
-      (await token.methods.redeem_shield(escrowContract.address, mintAmount, secret).send().wait()).status,
-    ).toEqual(TxStatus.MINED);
+    await token.methods.redeem_shield(escrowContract.address, mintAmount, secret).send().wait();
 
     logger(`Token contract deployed at ${token.address}`);
   }, 100_000);
@@ -125,7 +121,6 @@ describe('e2e_escrow_contract', () => {
     const secretHash = computeMessageSecretHash(secret);
 
     const receipt = await token.methods.mint_private(mintAmount, secretHash).send().wait();
-    expect(receipt.status).toEqual(TxStatus.MINED);
 
     const note = new Note([new Fr(mintAmount), secretHash]);
     const extendedNote = new ExtendedNote(
@@ -138,7 +133,7 @@ describe('e2e_escrow_contract', () => {
     );
     await pxe.addNote(extendedNote);
 
-    expect((await token.methods.redeem_shield(owner, mintAmount, secret).send().wait()).status).toEqual(TxStatus.MINED);
+    await token.methods.redeem_shield(owner, mintAmount, secret).send().wait();
 
     await expectBalance(owner, 50n);
 

--- a/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
@@ -9,7 +9,6 @@ import {
   GrumpkinScalar,
   Note,
   PXE,
-  TxStatus,
   Wallet,
   computeMessageSecretHash,
   generatePublicKey,
@@ -63,7 +62,6 @@ describe('e2e_multiple_accounts_1_enc_key', () => {
     const secretHash = computeMessageSecretHash(secret);
 
     const receipt = await token.methods.mint_private(initialBalance, secretHash).send().wait();
-    expect(receipt.status).toEqual(TxStatus.MINED);
 
     const storageSlot = new Fr(5);
     const noteTypeId = new Fr(84114971101151129711410111011678111116101n); // TransparentNote
@@ -79,9 +77,7 @@ describe('e2e_multiple_accounts_1_enc_key', () => {
     );
     await pxe.addNote(extendedNote);
 
-    expect((await token.methods.redeem_shield(accounts[0], initialBalance, secret).send().wait()).status).toEqual(
-      TxStatus.MINED,
-    );
+    await token.methods.redeem_shield(accounts[0], initialBalance, secret).send().wait();
   }, 100_000);
 
   afterEach(() => teardown());
@@ -110,8 +106,7 @@ describe('e2e_multiple_accounts_1_enc_key', () => {
 
     const contractWithWallet = await TokenContract.at(tokenAddress, wallets[senderIndex]);
 
-    const receipt = await contractWithWallet.methods.transfer(sender, receiver, transferAmount, 0).send().wait();
-    expect(receipt.status).toBe(TxStatus.MINED);
+    await contractWithWallet.methods.transfer(sender, receiver, transferAmount, 0).send().wait();
 
     for (let i = 0; i < expectedBalances.length; i++) {
       await expectBalance(i, expectedBalances[i]);

--- a/yarn-project/end-to-end/src/e2e_ordering.test.ts
+++ b/yarn-project/end-to-end/src/e2e_ordering.test.ts
@@ -1,5 +1,5 @@
 // Test suite for testing proper ordering of side effects
-import { Fr, FunctionSelector, PXE, TxStatus, Wallet, toBigIntBE } from '@aztec/aztec.js';
+import { Fr, FunctionSelector, PXE, Wallet, toBigIntBE } from '@aztec/aztec.js';
 import { ChildContract } from '@aztec/noir-contracts.js/Child';
 import { ParentContract } from '@aztec/noir-contracts.js/Parent';
 
@@ -100,9 +100,7 @@ describe('e2e_ordering', () => {
         async method => {
           const expectedOrder = expectedOrders[method];
 
-          const tx = child.methods[method]().send();
-          const receipt = await tx.wait();
-          expect(receipt.status).toBe(TxStatus.MINED);
+          await child.methods[method]().send().wait();
 
           const value = await pxe.getPublicStorageAt(child.address, new Fr(1));
           expect(value.value).toBe(expectedOrder[1]); // final state should match last value set
@@ -119,9 +117,7 @@ describe('e2e_ordering', () => {
       it.each(['setValueTwiceWithNestedLast'] as const)('orders unencrypted logs in %s', async method => {
         const expectedOrder = expectedOrders[method];
 
-        const tx = child.methods[method]().send();
-        const receipt = await tx.wait();
-        expect(receipt.status).toBe(TxStatus.MINED);
+        await child.methods[method]().send().wait();
 
         // Logs are emitted in the expected order
         await expectLogsFromLastBlockToBe(expectedOrder);

--- a/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
@@ -60,12 +60,7 @@ describe('e2e_p2p_network', () => {
     }
 
     // now ensure that all txs were successfully mined
-    for (const context of contexts) {
-      for (const tx of context.txs) {
-        const receipt = await tx.wait();
-        expect(receipt.status).toBe(TxStatus.MINED);
-      }
-    }
+    await Promise.all(contexts.flatMap(context => context.txs.map(tx => tx.wait())));
 
     // shutdown all nodes.
     for (const context of contexts) {

--- a/yarn-project/end-to-end/src/e2e_pending_note_hashes_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_pending_note_hashes_contract.test.ts
@@ -1,4 +1,4 @@
-import { AztecAddress, AztecNode, CompleteAddress, DebugLogger, Fr, TxStatus, Wallet } from '@aztec/aztec.js';
+import { AztecAddress, AztecNode, CompleteAddress, DebugLogger, Fr, Wallet } from '@aztec/aztec.js';
 import { PendingNoteHashesContract } from '@aztec/noir-contracts.js/PendingNoteHashes';
 
 import { setup } from './fixtures/utils.js';
@@ -63,11 +63,7 @@ describe('e2e_pending_note_hashes_contract', () => {
 
     const deployedContract = await deployContract();
 
-    const receipt = await deployedContract.methods
-      .test_insert_then_get_then_nullify_flat(mintAmount, owner)
-      .send()
-      .wait();
-    expect(receipt.status).toBe(TxStatus.MINED);
+    await deployedContract.methods.test_insert_then_get_then_nullify_flat(mintAmount, owner).send().wait();
   }, 60_000);
 
   it('Squash! Aztec.nr function can "create" and "nullify" note in the same TX', async () => {
@@ -77,7 +73,7 @@ describe('e2e_pending_note_hashes_contract', () => {
 
     const deployedContract = await deployContract();
 
-    const receipt = await deployedContract.methods
+    await deployedContract.methods
       .test_insert_then_get_then_nullify_all_in_nested_calls(
         mintAmount,
         owner,
@@ -87,8 +83,6 @@ describe('e2e_pending_note_hashes_contract', () => {
       )
       .send()
       .wait();
-
-    expect(receipt.status).toBe(TxStatus.MINED);
 
     await expectNoteHashesSquashedExcept(0);
     await expectNullifiersSquashedExcept(0);
@@ -101,7 +95,7 @@ describe('e2e_pending_note_hashes_contract', () => {
 
     const deployedContract = await deployContract();
 
-    const receipt = await deployedContract.methods
+    await deployedContract.methods
       .test_insert2_then_get2_then_nullify2_all_in_nested_calls(
         mintAmount,
         owner,
@@ -110,8 +104,6 @@ describe('e2e_pending_note_hashes_contract', () => {
       )
       .send()
       .wait();
-
-    expect(receipt.status).toBe(TxStatus.MINED);
 
     await expectNoteHashesSquashedExcept(0);
     await expectNullifiersSquashedExcept(0);
@@ -125,7 +117,7 @@ describe('e2e_pending_note_hashes_contract', () => {
 
     const deployedContract = await deployContract();
 
-    const receipt = await deployedContract.methods
+    await deployedContract.methods
       .test_insert2_then_get2_then_nullify1_all_in_nested_calls(
         mintAmount,
         owner,
@@ -134,8 +126,6 @@ describe('e2e_pending_note_hashes_contract', () => {
       )
       .send()
       .wait();
-
-    expect(receipt.status).toBe(TxStatus.MINED);
 
     await expectNoteHashesSquashedExcept(1);
     await expectNullifiersSquashedExcept(0);
@@ -152,14 +142,13 @@ describe('e2e_pending_note_hashes_contract', () => {
     const deployedContract = await deployContract();
 
     // create persistent note
-    const receipt0 = await deployedContract.methods.insert_note(mintAmount, owner).send().wait();
-    expect(receipt0.status).toBe(TxStatus.MINED);
+    await deployedContract.methods.insert_note(mintAmount, owner).send().wait();
 
     await expectNoteHashesSquashedExcept(1); // first TX just creates 1 persistent note
     await expectNullifiersSquashedExcept(0);
 
     // create another note, and nullify it and AND nullify the above-created note in the same TX
-    const receipt1 = await deployedContract.methods
+    await deployedContract.methods
       .test_insert1_then_get2_then_nullify2_all_in_nested_calls(
         mintAmount,
         owner,
@@ -169,8 +158,6 @@ describe('e2e_pending_note_hashes_contract', () => {
       )
       .send()
       .wait();
-
-    expect(receipt1.status).toBe(TxStatus.MINED);
 
     // second TX creates 1 note, but it is squashed!
     await expectNoteHashesSquashedExcept(0);
@@ -188,14 +175,12 @@ describe('e2e_pending_note_hashes_contract', () => {
     const mintAmount = 65n;
 
     const deployedContract = await deployContract();
-    const receipt = await deployedContract.methods.insert_note(mintAmount, owner).send().wait();
-
-    expect(receipt.status).toBe(TxStatus.MINED);
+    await deployedContract.methods.insert_note(mintAmount, owner).send().wait();
 
     // There is a single new note hash.
     await expectNoteHashesSquashedExcept(1);
 
-    const receipt2 = await deployedContract.methods
+    await deployedContract.methods
       .test_insert_then_get_then_nullify_all_in_nested_calls(
         mintAmount,
         owner,
@@ -205,8 +190,6 @@ describe('e2e_pending_note_hashes_contract', () => {
       )
       .send()
       .wait();
-
-    expect(receipt2.status).toBe(TxStatus.MINED);
 
     // There is a single new nullifier.
     await expectNullifiersSquashedExcept(1);

--- a/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
@@ -1,4 +1,4 @@
-import { AccountWallet, AztecAddress, CompleteAddress, DebugLogger, Fr, TxStatus } from '@aztec/aztec.js';
+import { AccountWallet, AztecAddress, CompleteAddress, DebugLogger, Fr } from '@aztec/aztec.js';
 import { EasyPrivateVotingContract } from '@aztec/noir-contracts.js/EasyPrivateVoting';
 
 import { setup } from './fixtures/utils.js';
@@ -32,9 +32,7 @@ describe('e2e_voting_contract', () => {
   describe('votes', () => {
     it('votes', async () => {
       const candidate = new Fr(1);
-      const tx = votingContract.methods.cast_vote(candidate).send();
-      const receipt = await tx.wait();
-      expect(receipt.status).toBe(TxStatus.MINED);
+      await votingContract.methods.cast_vote(candidate).send().wait();
       expect(await votingContract.methods.get_vote(candidate).view()).toBe(1n);
     });
   });

--- a/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
@@ -181,7 +181,7 @@ describe('e2e_public_cross_chain_messaging', () => {
         .withWallet(user1Wallet)
         .methods.exit_to_l1_public(ethAccount, withdrawAmount, EthAddress.ZERO, nonce)
         .simulate(),
-    ).rejects.toThrowError('Assertion failed: Message not authorized by account');
+    ).rejects.toThrow('Assertion failed: Message not authorized by account');
   }, 60_000);
 
   it("can't claim funds privately which were intended for public deposit from the token portal", async () => {
@@ -212,9 +212,7 @@ describe('e2e_public_cross_chain_messaging', () => {
 
     await expect(
       l2Bridge.withWallet(user2Wallet).methods.claim_private(secretHash, bridgeAmount, secret).simulate(),
-    ).rejects.toThrowError(
-      `L1 to L2 message index not found in the store for message ${wrongMessage.hash().toString()}`,
-    );
+    ).rejects.toThrow(`L1 to L2 message index not found in the store for message ${wrongMessage.hash().toString()}`);
   }, 60_000);
 
   // Note: We register one portal address when deploying contract but that address is no-longer the only address

--- a/yarn-project/end-to-end/src/e2e_slow_tree.test.ts
+++ b/yarn-project/end-to-end/src/e2e_slow_tree.test.ts
@@ -128,7 +128,7 @@ describe('e2e_slow_tree', () => {
       `Tries to "read" tree[${zeroProof.index}] from the tree, but is rejected as value is not ${zeroProof.value}`,
     );
     await wallet.addCapsule(getMembershipCapsule({ ...zeroProof, value: new Fr(0) }));
-    await expect(contract.methods.read_at(key).simulate()).rejects.toThrowError(
+    await expect(contract.methods.read_at(key).simulate()).rejects.toThrow(
       /Assertion failed: Root does not match expected/,
     );
 

--- a/yarn-project/end-to-end/src/e2e_state_vars.test.ts
+++ b/yarn-project/end-to-end/src/e2e_state_vars.test.ts
@@ -37,7 +37,7 @@ describe('e2e_state_vars', () => {
     it('initializing SharedImmutable the second time should fail', async () => {
       // Jest executes the tests sequentially and the first call to initialize_shared_immutable was executed
       // in the previous test, so the call bellow should fail.
-      await expect(contract.methods.initialize_shared_immutable(1).send().wait()).rejects.toThrowError(
+      await expect(contract.methods.initialize_shared_immutable(1).send().wait()).rejects.toThrow(
         "Assertion failed: SharedImmutable already initialized 'fields_read[0] == 0'",
       );
     }, 100_000);
@@ -57,7 +57,7 @@ describe('e2e_state_vars', () => {
     it('initializing PublicImmutable the second time should fail', async () => {
       // Jest executes the tests sequentially and the first call to initialize_public_immutable was executed
       // in the previous test, so the call bellow should fail.
-      await expect(contract.methods.initialize_public_immutable(1).send().wait()).rejects.toThrowError(
+      await expect(contract.methods.initialize_public_immutable(1).send().wait()).rejects.toThrow(
         "Assertion failed: PublicImmutable already initialized 'fields_read[0] == 0'",
       );
     }, 100_000);
@@ -66,7 +66,7 @@ describe('e2e_state_vars', () => {
   describe('PrivateMutable', () => {
     it('fail to read uninitialized PrivateMutable', async () => {
       expect(await contract.methods.is_legendary_initialized().view()).toEqual(false);
-      await expect(contract.methods.get_legendary_card().view()).rejects.toThrowError();
+      await expect(contract.methods.get_legendary_card().view()).rejects.toThrow();
     });
 
     it('initialize PrivateMutable', async () => {
@@ -81,7 +81,7 @@ describe('e2e_state_vars', () => {
 
     it('fail to reinitialize', async () => {
       expect(await contract.methods.is_legendary_initialized().view()).toEqual(true);
-      await expect(contract.methods.initialize_private(RANDOMNESS, POINTS).send().wait()).rejects.toThrowError();
+      await expect(contract.methods.initialize_private(RANDOMNESS, POINTS).send().wait()).rejects.toThrow();
       expect(await contract.methods.is_legendary_initialized().view()).toEqual(true);
     });
 
@@ -150,7 +150,7 @@ describe('e2e_state_vars', () => {
   describe('PrivateImmutable', () => {
     it('fail to read uninitialized PrivateImmutable', async () => {
       expect(await contract.methods.is_priv_imm_initialized().view()).toEqual(false);
-      await expect(contract.methods.view_imm_card().view()).rejects.toThrowError();
+      await expect(contract.methods.view_imm_card().view()).rejects.toThrow();
     });
 
     it('initialize PrivateImmutable', async () => {
@@ -168,9 +168,7 @@ describe('e2e_state_vars', () => {
 
     it('fail to reinitialize', async () => {
       expect(await contract.methods.is_priv_imm_initialized().view()).toEqual(true);
-      await expect(
-        contract.methods.initialize_private_immutable(RANDOMNESS, POINTS).send().wait(),
-      ).rejects.toThrowError();
+      await expect(contract.methods.initialize_private_immutable(RANDOMNESS, POINTS).send().wait()).rejects.toThrow();
       expect(await contract.methods.is_priv_imm_initialized().view()).toEqual(true);
     });
 

--- a/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
+++ b/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
@@ -219,14 +219,14 @@ describe('guides/dapp/testing', () => {
       it('asserts a local transaction simulation fails by calling simulate', async () => {
         // docs:start:local-tx-fails
         const call = token.methods.transfer(owner.getAddress(), recipient.getAddress(), 200n, 0);
-        await expect(call.simulate()).rejects.toThrowError(/Balance too low/);
+        await expect(call.simulate()).rejects.toThrow(/Balance too low/);
         // docs:end:local-tx-fails
       }, 30_000);
 
       it('asserts a local transaction simulation fails by calling send', async () => {
         // docs:start:local-tx-fails-send
         const call = token.methods.transfer(owner.getAddress(), recipient.getAddress(), 200n, 0);
-        await expect(call.send().wait()).rejects.toThrowError(/Balance too low/);
+        await expect(call.send().wait()).rejects.toThrow(/Balance too low/);
         // docs:end:local-tx-fails-send
       }, 30_000);
 
@@ -239,14 +239,14 @@ describe('guides/dapp/testing', () => {
         await call2.simulate();
 
         await call1.send().wait();
-        await expect(call2.send().wait()).rejects.toThrowError(/dropped/);
+        await expect(call2.send().wait()).rejects.toThrow(/dropped/);
         // docs:end:tx-dropped
       }, 30_000);
 
       it('asserts a simulation for a public function call fails', async () => {
         // docs:start:local-pub-fails
         const call = token.methods.transfer_public(owner.getAddress(), recipient.getAddress(), 1000n, 0);
-        await expect(call.simulate()).rejects.toThrowError(U128_UNDERFLOW_ERROR);
+        await expect(call.simulate()).rejects.toThrow(U128_UNDERFLOW_ERROR);
         // docs:end:local-pub-fails
       }, 30_000);
 

--- a/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
+++ b/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
@@ -6,7 +6,6 @@ import {
   Fr,
   Note,
   PXE,
-  TxStatus,
   computeMessageSecretHash,
   createPXEClient,
   waitForPXE,
@@ -255,8 +254,7 @@ describe('guides/dapp/testing', () => {
       it('asserts a transaction with a failing public call is included (with no state changes)', async () => {
         // docs:start:pub-reverted
         const call = token.methods.transfer_public(owner.getAddress(), recipient.getAddress(), 1000n, 0);
-        const receipt = await call.send({ skipPublicSimulation: true }).wait();
-        expect(receipt.status).toEqual(TxStatus.MINED);
+        await call.send({ skipPublicSimulation: true }).wait();
         const ownerPublicBalanceSlot = cheats.aztec.computeSlotInMap(6n, owner.getAddress());
         const balance = await pxe.getPublicStorageAt(token.address, ownerPublicBalanceSlot);
         expect(balance.value).toEqual(100n);

--- a/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
@@ -4,7 +4,6 @@ import {
   EthAddress,
   Fr,
   PXE,
-  TxStatus,
   Wallet,
   computeMessageSecretHash,
   deployL1Contract,
@@ -257,9 +256,7 @@ class GasBridgingTestHarness implements IGasBridgingTestHarness {
   async consumeMessageOnAztecAndMintPublicly(bridgeAmount: bigint, owner: AztecAddress, secret: Fr) {
     this.logger('Consuming messages on L2 Publicly');
     // Call the mint tokens function on the Aztec.nr contract
-    const tx = this.l2Token.methods.claim_public(owner, bridgeAmount, secret).send();
-    const receipt = await tx.wait();
-    expect(receipt.status).toBe(TxStatus.MINED);
+    await this.l2Token.methods.claim_public(owner, bridgeAmount, secret).send().wait();
   }
 
   async getL2PublicBalanceOf(owner: AztecAddress) {

--- a/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
+++ b/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
@@ -475,7 +475,7 @@ export const uniswapL1L2TestSuite = (
             ownerEthAddress,
           )
           .simulate(),
-      ).rejects.toThrowError(`Unknown auth witness for message hash ${expectedMessageHash.toString()}`);
+      ).rejects.toThrow(`Unknown auth witness for message hash ${expectedMessageHash.toString()}`);
     });
 
     it("can't swap if user passes a token different to what the bridge tracks", async () => {
@@ -513,7 +513,7 @@ export const uniswapL1L2TestSuite = (
             ownerEthAddress,
           )
           .simulate(),
-      ).rejects.toThrowError('Assertion failed: input_asset address is not the same as seen in the bridge contract');
+      ).rejects.toThrow('Assertion failed: input_asset address is not the same as seen in the bridge contract');
     });
 
     // edge cases for public flow:
@@ -614,7 +614,7 @@ export const uniswapL1L2TestSuite = (
             Fr.ZERO,
           )
           .simulate(),
-      ).rejects.toThrowError(`Assertion failed: Message not authorized by account 'is_valid == true'`);
+      ).rejects.toThrow(`Assertion failed: Message not authorized by account 'is_valid == true'`);
     });
 
     // tests when trying to mix private and public flows:
@@ -676,7 +676,7 @@ export const uniswapL1L2TestSuite = (
         uniswapPortal.simulate.swapPublic(swapArgs, {
           account: ownerEthAddress.toString(),
         } as any),
-      ).rejects.toThrowError('The contract function "swapPublic" reverted.');
+      ).rejects.toThrow('The contract function "swapPublic" reverted.');
     });
 
     it("can't call swap_private on L1 if called swap_public on L2", async () => {
@@ -731,7 +731,7 @@ export const uniswapL1L2TestSuite = (
         uniswapPortal.simulate.swapPrivate(swapArgs, {
           account: ownerEthAddress.toString(),
         } as any),
-      ).rejects.toThrowError('The contract function "swapPrivate" reverted.');
+      ).rejects.toThrow('The contract function "swapPrivate" reverted.');
     });
   });
 };

--- a/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
+++ b/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
@@ -6,7 +6,6 @@ import {
   EthAddress,
   Fr,
   PXE,
-  TxStatus,
   computeAuthWitMessageHash,
 } from '@aztec/aztec.js';
 import { deployL1Contract } from '@aztec/ethereum';
@@ -218,7 +217,7 @@ export const uniswapL1L2TestSuite = (
         daiCrossChainHarness.generateClaimSecret();
       const [secretForRedeemingDai, secretHashForRedeemingDai] = daiCrossChainHarness.generateClaimSecret();
 
-      const withdrawReceipt = await uniswapL2Contract.methods
+      await uniswapL2Contract.methods
         .swap_private(
           wethCrossChainHarness.l2Token.address,
           wethCrossChainHarness.l2Bridge.address,
@@ -233,7 +232,6 @@ export const uniswapL1L2TestSuite = (
         )
         .send()
         .wait();
-      expect(withdrawReceipt.status).toBe(TxStatus.MINED);
       // ensure that user's funds were burnt
       await wethCrossChainHarness.expectPrivateBalanceOnL2(ownerAddress, wethL2BalanceBeforeSwap - wethAmountToBridge);
       // ensure that uniswap contract didn't eat the funds.
@@ -378,8 +376,7 @@ export const uniswapL1L2TestSuite = (
       await ownerWallet.setPublicAuth(swapMessageHash, true).send().wait();
 
       // 4.2 Call swap_public from user2 on behalf of owner
-      const withdrawReceipt = await action.send().wait();
-      expect(withdrawReceipt.status).toBe(TxStatus.MINED);
+      await action.send().wait();
 
       // check weth balance of owner on L2 (we first bridged `wethAmountToBridge` into L2 and now withdrew it!)
       await wethCrossChainHarness.expectPublicBalanceOnL2(ownerAddress, wethL2BalanceBeforeSwap - wethAmountToBridge);
@@ -538,7 +535,7 @@ export const uniswapL1L2TestSuite = (
       // No approval to call `swap` but should work even without it:
       const [_, secretHashForDepositingSwappedDai] = daiCrossChainHarness.generateClaimSecret();
 
-      const withdrawReceipt = await uniswapL2Contract.methods
+      await uniswapL2Contract.methods
         .swap_public(
           ownerAddress,
           wethCrossChainHarness.l2Bridge.address,
@@ -554,7 +551,6 @@ export const uniswapL1L2TestSuite = (
         )
         .send()
         .wait();
-      expect(withdrawReceipt.status).toBe(TxStatus.MINED);
       // check weth balance of owner on L2 (we first bridged `wethAmountToBridge` into L2 and now withdrew it!)
       await wethCrossChainHarness.expectPublicBalanceOnL2(ownerAddress, 0n);
     });
@@ -646,7 +642,7 @@ export const uniswapL1L2TestSuite = (
       logger('Withdrawing weth to L1 and sending message to swap to dai');
       const secretHashForDepositingSwappedDai = Fr.random();
 
-      const withdrawReceipt = await uniswapL2Contract.methods
+      await uniswapL2Contract.methods
         .swap_private(
           wethCrossChainHarness.l2Token.address,
           wethCrossChainHarness.l2Bridge.address,
@@ -661,7 +657,6 @@ export const uniswapL1L2TestSuite = (
         )
         .send()
         .wait();
-      expect(withdrawReceipt.status).toBe(TxStatus.MINED);
       // ensure that user's funds were burnt
       await wethCrossChainHarness.expectPrivateBalanceOnL2(ownerAddress, wethL2BalanceBeforeSwap - wethAmountToBridge);
 
@@ -700,7 +695,7 @@ export const uniswapL1L2TestSuite = (
 
       // Call swap_public on L2
       const secretHashForDepositingSwappedDai = Fr.random();
-      const withdrawReceipt = await uniswapL2Contract.methods
+      await uniswapL2Contract.methods
         .swap_public(
           ownerAddress,
           wethCrossChainHarness.l2Bridge.address,
@@ -716,7 +711,6 @@ export const uniswapL1L2TestSuite = (
         )
         .send()
         .wait();
-      expect(withdrawReceipt.status).toBe(TxStatus.MINED);
       // check weth balance of owner on L2 (we first bridged `wethAmountToBridge` into L2 and now withdrew it!)
       await wethCrossChainHarness.expectPublicBalanceOnL2(ownerAddress, 0n);
 

--- a/yarn-project/foundation/src/abi/encoder.test.ts
+++ b/yarn-project/foundation/src/abi/encoder.test.ts
@@ -161,7 +161,7 @@ describe('abi/encoder', () => {
     };
     const args = ['garbage'];
 
-    expect(() => encodeArguments(testFunctionAbi, args)).toThrowError('Invalid argument "garbage" of type field');
+    expect(() => encodeArguments(testFunctionAbi, args)).toThrow('Invalid argument "garbage" of type field');
   });
 
   it('throws when passing string argument as integer', () => {
@@ -184,7 +184,7 @@ describe('abi/encoder', () => {
       returnTypes: [],
     };
     const args = ['garbage'];
-    expect(() => encodeArguments(testFunctionAbi, args)).toThrowError(
+    expect(() => encodeArguments(testFunctionAbi, args)).toThrow(
       `Type 'string' with value 'garbage' passed to BaseField ctor.`,
     );
   });
@@ -212,8 +212,6 @@ describe('abi/encoder', () => {
       },
     ];
 
-    expect(() => encodeArguments(testFunctionAbi, args)).toThrowError(
-      'Argument for owner cannot be serialized to a field',
-    );
+    expect(() => encodeArguments(testFunctionAbi, args)).toThrow('Argument for owner cannot be serialized to a field');
   });
 });

--- a/yarn-project/foundation/src/bigint-buffer/bigint-buffer.test.ts
+++ b/yarn-project/foundation/src/bigint-buffer/bigint-buffer.test.ts
@@ -36,12 +36,12 @@ describe('bigint-buffer', () => {
 
     it('should throw an error for an invalid hex string', () => {
       const invalidHexString = '0x12345G';
-      expect(() => fromHex(invalidHexString)).toThrowError('Invalid hex string: 0x12345G');
+      expect(() => fromHex(invalidHexString)).toThrow('Invalid hex string: 0x12345G');
     });
 
     it('should throw an error for an odd-length hex string', () => {
       const oddLengthHexString = '0x1234567';
-      expect(() => fromHex(oddLengthHexString)).toThrowError('Invalid hex string: 0x1234567');
+      expect(() => fromHex(oddLengthHexString)).toThrow('Invalid hex string: 0x1234567');
     });
 
     it('should handle an empty hex string', () => {

--- a/yarn-project/foundation/src/fields/fields.test.ts
+++ b/yarn-project/foundation/src/fields/fields.test.ts
@@ -168,7 +168,7 @@ describe('Bn254 arithmetic', () => {
       const a = new Fr(10);
       const b = Fr.ZERO;
 
-      expect(() => a.div(b)).toThrowError();
+      expect(() => a.div(b)).toThrow();
     });
   });
 

--- a/yarn-project/foundation/src/json-rpc/convert.test.ts
+++ b/yarn-project/foundation/src/json-rpc/convert.test.ts
@@ -67,11 +67,11 @@ it('converts a plain object', () => {
 
 it('refuses to convert to json an unknown class', () => {
   const cc = new ClassConverter();
-  expect(() => convertToJsonObj(cc, { content: new ToStringClassA('a', 'b') })).toThrowError(/not registered/);
+  expect(() => convertToJsonObj(cc, { content: new ToStringClassA('a', 'b') })).toThrow(/not registered/);
 });
 
 it('refuses to convert from json an unknown class', () => {
   const cc = new ClassConverter({ ToStringClass: ToStringClassA });
   const serialized = convertToJsonObj(cc, { content: new ToStringClassA('a', 'b') });
-  expect(() => convertFromJsonObj(new ClassConverter(), serialized)).toThrowError(/not registered/);
+  expect(() => convertFromJsonObj(new ClassConverter(), serialized)).toThrow(/not registered/);
 });

--- a/yarn-project/pxe/src/pxe_service/test/pxe_service.test.ts
+++ b/yarn-project/pxe/src/pxe_service/test/pxe_service.test.ts
@@ -60,6 +60,6 @@ describe('PXEService', () => {
     node.getTxEffect.mockResolvedValue(settledTx);
 
     const pxe = new PXEService(keyStore, node, db, config);
-    await expect(pxe.sendTx(duplicateTx)).rejects.toThrowError(/A settled tx with equal hash/);
+    await expect(pxe.sendTx(duplicateTx)).rejects.toThrow(/A settled tx with equal hash/);
   });
 });

--- a/yarn-project/simulator/src/avm/journal/nullifiers.test.ts
+++ b/yarn-project/simulator/src/avm/journal/nullifiers.test.ts
@@ -74,7 +74,7 @@ describe('avm nullifier caching', () => {
       // Append a nullifier to cache
       await nullifiers.append(contractAddress, nullifier);
       // Can't append again
-      await expect(nullifiers.append(contractAddress, nullifier)).rejects.toThrowError(
+      await expect(nullifiers.append(contractAddress, nullifier)).rejects.toThrow(
         `Nullifier ${nullifier} at contract ${contractAddress} already exists in parent cache or host.`,
       );
     });
@@ -86,7 +86,7 @@ describe('avm nullifier caching', () => {
       await nullifiers.append(contractAddress, nullifier);
       const childNullifiers = new Nullifiers(commitmentsDb, nullifiers);
       // Can't append again in child
-      await expect(childNullifiers.append(contractAddress, nullifier)).rejects.toThrowError(
+      await expect(childNullifiers.append(contractAddress, nullifier)).rejects.toThrow(
         `Nullifier ${nullifier} at contract ${contractAddress} already exists in parent cache or host.`,
       );
     });
@@ -98,7 +98,7 @@ describe('avm nullifier caching', () => {
       // Nullifier exists in host
       commitmentsDb.getNullifierIndex.mockResolvedValue(Promise.resolve(storedLeafIndex));
       // Can't append to cache
-      await expect(nullifiers.append(contractAddress, nullifier)).rejects.toThrowError(
+      await expect(nullifiers.append(contractAddress, nullifier)).rejects.toThrow(
         `Nullifier ${nullifier} at contract ${contractAddress} already exists in parent cache or host.`,
       );
     });
@@ -139,7 +139,7 @@ describe('avm nullifier caching', () => {
       await childNullifiers.append(contractAddress, nullifier);
 
       // Parent accepts child's nullifiers
-      expect(() => nullifiers.acceptAndMerge(childNullifiers)).toThrowError(
+      expect(() => nullifiers.acceptAndMerge(childNullifiers)).toThrow(
         `Failed to accept child call's nullifiers. Nullifier ${nullifier.toBigInt()} already exists at contract ${contractAddress.toBigInt()}.`,
       );
     });

--- a/yarn-project/simulator/src/avm/opcodes/accrued_substate.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/accrued_substate.test.ts
@@ -252,7 +252,7 @@ describe('Accrued Substate', () => {
       context.machineState.memory.set(0, value);
 
       await new EmitNullifier(/*indirect=*/ 0, /*offset=*/ 0).execute(context);
-      await expect(new EmitNullifier(/*indirect=*/ 0, /*offset=*/ 0).execute(context)).rejects.toThrowError(
+      await expect(new EmitNullifier(/*indirect=*/ 0, /*offset=*/ 0).execute(context)).rejects.toThrow(
         new InstructionExecutionError(
           `Attempted to emit duplicate nullifier ${value.toFr()} (storage address: ${
             context.environment.storageAddress
@@ -272,7 +272,7 @@ describe('Accrued Substate', () => {
       context = initContext({ persistableState: new AvmPersistableStateManager(hostStorage) });
 
       context.machineState.memory.set(0, value);
-      await expect(new EmitNullifier(/*indirect=*/ 0, /*offset=*/ 0).execute(context)).rejects.toThrowError(
+      await expect(new EmitNullifier(/*indirect=*/ 0, /*offset=*/ 0).execute(context)).rejects.toThrow(
         new InstructionExecutionError(
           `Attempted to emit duplicate nullifier ${value.toFr()} (storage address: ${
             context.environment.storageAddress

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -603,7 +603,7 @@ describe('Private Execution test suite', () => {
             portalContractAddress: crossChainMsgSender ?? preimage.sender.sender,
             txContext: { version: new Fr(1n), chainId: new Fr(1n) },
           }),
-        ).rejects.toThrowError('Message not in state');
+        ).rejects.toThrow('Message not in state');
       });
 
       it('Invalid recipient', async () => {
@@ -625,7 +625,7 @@ describe('Private Execution test suite', () => {
             portalContractAddress: crossChainMsgSender ?? preimage.sender.sender,
             txContext: { version: new Fr(1n), chainId: new Fr(1n) },
           }),
-        ).rejects.toThrowError('Message not in state');
+        ).rejects.toThrow('Message not in state');
       });
 
       it('Invalid sender', async () => {
@@ -646,7 +646,7 @@ describe('Private Execution test suite', () => {
             portalContractAddress: crossChainMsgSender ?? preimage.sender.sender,
             txContext: { version: new Fr(1n), chainId: new Fr(1n) },
           }),
-        ).rejects.toThrowError('Message not in state');
+        ).rejects.toThrow('Message not in state');
       });
 
       it('Invalid chainid', async () => {
@@ -666,7 +666,7 @@ describe('Private Execution test suite', () => {
             portalContractAddress: crossChainMsgSender ?? preimage.sender.sender,
             txContext: { version: new Fr(1n), chainId: new Fr(2n) },
           }),
-        ).rejects.toThrowError('Message not in state');
+        ).rejects.toThrow('Message not in state');
       });
 
       it('Invalid version', async () => {
@@ -686,7 +686,7 @@ describe('Private Execution test suite', () => {
             portalContractAddress: crossChainMsgSender ?? preimage.sender.sender,
             txContext: { version: new Fr(2n), chainId: new Fr(1n) },
           }),
-        ).rejects.toThrowError('Message not in state');
+        ).rejects.toThrow('Message not in state');
       });
 
       it('Invalid content', async () => {
@@ -707,7 +707,7 @@ describe('Private Execution test suite', () => {
             portalContractAddress: crossChainMsgSender ?? preimage.sender.sender,
             txContext: { version: new Fr(1n), chainId: new Fr(1n) },
           }),
-        ).rejects.toThrowError('Message not in state');
+        ).rejects.toThrow('Message not in state');
       });
 
       it('Invalid Secret', async () => {
@@ -728,7 +728,7 @@ describe('Private Execution test suite', () => {
             portalContractAddress: crossChainMsgSender ?? preimage.sender.sender,
             txContext: { version: new Fr(1n), chainId: new Fr(1n) },
           }),
-        ).rejects.toThrowError('Message not in state');
+        ).rejects.toThrow('Message not in state');
       });
     });
 
@@ -1136,7 +1136,7 @@ describe('Private Execution test suite', () => {
       const unexpectedChainId = Fr.random();
       await expect(
         runSimulator({ artifact, msgSender: owner, args, txContext: { chainId: unexpectedChainId, version } }),
-      ).rejects.toThrowError('Invalid chain id');
+      ).rejects.toThrow('Invalid chain id');
     });
 
     it('Throws when version is incorrectly set', async () => {
@@ -1144,7 +1144,7 @@ describe('Private Execution test suite', () => {
       const unexpectedVersion = Fr.random();
       await expect(
         runSimulator({ artifact, msgSender: owner, args, txContext: { chainId, version: unexpectedVersion } }),
-      ).rejects.toThrowError('Invalid version');
+      ).rejects.toThrow('Invalid version');
     });
   });
 
@@ -1171,7 +1171,7 @@ describe('Private Execution test suite', () => {
       const unexpectedHeaderHash = Fr.random();
       const args = [unexpectedHeaderHash];
 
-      await expect(runSimulator({ artifact, msgSender: owner, args })).rejects.toThrowError('Invalid header hash');
+      await expect(runSimulator({ artifact, msgSender: owner, args })).rejects.toThrow('Invalid header hash');
     });
   });
 });

--- a/yarn-project/simulator/src/client/simulator.test.ts
+++ b/yarn-project/simulator/src/client/simulator.test.ts
@@ -76,7 +76,7 @@ describe('Simulator', () => {
       const note = createNote();
       await expect(
         simulator.computeNoteHashAndNullifier(contractAddress, nonce, storageSlot, noteTypeId, note),
-      ).rejects.toThrowError(/Mandatory implementation of "compute_note_hash_and_nullifier" missing/);
+      ).rejects.toThrow(/Mandatory implementation of "compute_note_hash_and_nullifier" missing/);
     });
 
     it('throw if "compute_note_hash_and_nullifier" has the wrong number of parameters', async () => {
@@ -90,7 +90,7 @@ describe('Simulator', () => {
 
       await expect(
         simulator.computeNoteHashAndNullifier(contractAddress, nonce, storageSlot, noteTypeId, note),
-      ).rejects.toThrowError(
+      ).rejects.toThrow(
         new RegExp(
           `Expected 5 parameters in mandatory implementation of "compute_note_hash_and_nullifier", but found 4 in noir contract ${contractAddress}.`,
         ),
@@ -122,7 +122,7 @@ describe('Simulator', () => {
 
       await expect(
         simulator.computeNoteHashAndNullifier(contractAddress, nonce, storageSlot, noteTypeId, note),
-      ).rejects.toThrowError(
+      ).rejects.toThrow(
         new RegExp(`"compute_note_hash_and_nullifier" can only handle a maximum of ${wrongPreimageLength} fields`),
       );
     });


### PR DESCRIPTION
All around our codebase we were doing redundant receipts checks so I removed them. The receipts checks are not needed because wait function throws if the the receipts status is not mined. I also replaced the now deprecated toThrowError function with toThrow. I think it's good to have this cleaned up as the tests are used as a reference by devs.
