### PR TITLE
fix(avm-transpiler): RETURN is direct

### DIFF
--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -194,7 +194,7 @@ pub fn brillig_to_avm(brillig: &Brillig) -> Vec<u8> {
             BrilligOpcode::Stop { return_data_offset, return_data_size } => {
                 avm_instrs.push(AvmInstruction {
                     opcode: AvmOpcode::RETURN,
-                    indirect: Some(ZEROTH_OPERAND_INDIRECT),
+                    indirect: Some(ALL_DIRECT),
                     operands: vec![
                         AvmOperand::U32 { value: *return_data_offset as u32 },
                         AvmOperand::U32 { value: *return_data_size as u32 },

--- a/yarn-project/simulator/src/avm/opcodes/external_calls.ts
+++ b/yarn-project/simulator/src/avm/opcodes/external_calls.ts
@@ -165,14 +165,16 @@ export class Return extends Instruction {
   }
 
   async execute(context: AvmContext): Promise<void> {
-    const output = context.machineState.memory.getSlice(this.returnOffset, this.copySize).map(word => word.toFr());
+    const [returnOffset] = Addressing.fromWire(this.indirect).resolve([this.returnOffset], context.machineState.memory);
+
+    const output = context.machineState.memory.getSlice(returnOffset, this.copySize).map(word => word.toFr());
 
     context.machineState.return(output);
   }
 }
 
 export class Revert extends Instruction {
-  static type: string = 'RETURN';
+  static type: string = 'REVERT';
   static readonly opcode: Opcode = Opcode.REVERT;
   // Informs (de)serialization. See Instruction.deserialize.
   static readonly wireFormat: OperandType[] = [
@@ -187,9 +189,9 @@ export class Revert extends Instruction {
   }
 
   async execute(context: AvmContext): Promise<void> {
-    const output = context.machineState.memory
-      .getSlice(this.returnOffset, this.returnOffset + this.retSize)
-      .map(word => word.toFr());
+    const [returnOffset] = Addressing.fromWire(this.indirect).resolve([this.returnOffset], context.machineState.memory);
+
+    const output = context.machineState.memory.getSlice(returnOffset, this.retSize).map(word => word.toFr());
 
     context.machineState.revert(output);
   }

--- a/yarn-project/simulator/src/avm/opcodes/memory.ts
+++ b/yarn-project/simulator/src/avm/opcodes/memory.ts
@@ -183,11 +183,13 @@ export class CalldataCopy extends Instruction {
   }
 
   async execute(context: AvmContext): Promise<void> {
+    const [dstOffset] = Addressing.fromWire(this.indirect).resolve([this.dstOffset], context.machineState.memory);
+
     const transformedData = context.environment.calldata
       .slice(this.cdOffset, this.cdOffset + this.copySize)
       .map(f => new Field(f));
 
-    context.machineState.memory.setSlice(this.dstOffset, transformedData);
+    context.machineState.memory.setSlice(dstOffset, transformedData);
 
     context.machineState.incrementPc();
   }


### PR DESCRIPTION
* Brillig's `STOP` uses direct memory access, so it should be transpiled with `ALL_DIRECT`.
* Implement indirect support for `RETURN`, `REVERT`, `CALLDATACOPY` for the future.

cc @sirasistant 