### PR TITLE
chore(avm-simulator): update e2e test

### DIFF
--- a/avm-transpiler/src/main.rs
+++ b/avm-transpiler/src/main.rs
@@ -29,6 +29,14 @@ fn main() {
         warn!("Contract already transpiled. Skipping.");
         return;
     }
+
+    // Backup the original file
+    std::fs::copy(
+        Path::new(in_contract_artifact_path),
+        Path::new(&(in_contract_artifact_path.clone() + ".bak")),
+    )
+    .expect("Unable to backup file");
+
     // Parse json into contract object
     let contract: CompiledAcirContract =
         serde_json::from_str(&contract_json).expect("Unable to parse json");

--- a/avm-transpiler/src/transpile_contract.rs
+++ b/avm-transpiler/src/transpile_contract.rs
@@ -77,14 +77,11 @@ impl From<CompiledAcirContract> for TranspiledContract {
     fn from(contract: CompiledAcirContract) -> Self {
         let mut functions = Vec::new();
 
-        // Note, in aztec_macros/lib.rs, avm_ prefix is pushed to function names with the #[aztec(public-vm)] tag
-        let re = Regex::new(r"avm_.*$").unwrap();
         for function in contract.functions {
             // TODO(4269): once functions are tagged for transpilation to AVM, check tag
             if function
                 .custom_attributes
                 .contains(&"aztec(public-vm)".to_string())
-                && re.is_match(function.name.as_str())
             {
                 info!(
                     "Transpiling AVM function {} on contract {}",

--- a/noir-projects/Dockerfile
+++ b/noir-projects/Dockerfile
@@ -2,6 +2,7 @@ FROM aztecprotocol/noir as noir
 FROM aztecprotocol/avm-transpiler as transpiler
 
 FROM ubuntu:lunar AS builder
+RUN apt-get update && apt-get install -y parallel
 # Copy in nargo
 COPY --from=noir /usr/src/noir/noir-repo/target/release/nargo /usr/src/noir/noir-repo/target/release/nargo
 ENV PATH="/usr/src/noir/noir-repo/target/release:${PATH}"

--- a/noir-projects/Earthfile
+++ b/noir-projects/Earthfile
@@ -11,6 +11,7 @@ WORKDIR /build
 COPY --dir aztec-nr noir-contracts noir-protocol-circuits .
 
 build:
+  RUN apt-get update && apt-get install -y parallel
   RUN cd noir-contracts && NARGO=nargo TRANSPILER=avm-transpiler ./bootstrap.sh
   RUN cd noir-protocol-circuits && NARGO=nargo ./bootstrap.sh
   SAVE ARTIFACT aztec-nr

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -19,9 +19,6 @@ echo "Compiling contracts..."
 NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
 $NARGO compile --silence-warnings
 
-echo "Transpiling avm contracts..."
-for contract_json in target/avm_test_*.json; do
-  echo Transpiling $contract_json...
-  TRANSPILER=${TRANSPILER:-../../avm-transpiler/target/release/avm-transpiler}
-  $TRANSPILER $contract_json $contract_json
-done
+echo "Transpiling avm contracts... (only '#[aztec(public-vm)]')"
+TRANSPILER=${TRANSPILER:-../../avm-transpiler/target/release/avm-transpiler}
+ls target/avm_*.json | parallel -L8 "$TRANSPILER {} {}"

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -19,7 +19,7 @@ impl Deserialize<2> for Note {
 
 contract AvmTest {
     use crate::Note;
-    
+
     global big_field_128_bits: Field = 0x001234567890abcdef1234567890abcdef;
     global big_field_136_bits: Field = 0x991234567890abcdef1234567890abcdef;
 
@@ -28,7 +28,7 @@ contract AvmTest {
     use dep::aztec::state_vars::PublicMutable;
     use dep::aztec::protocol_types::{address::{AztecAddress, EthAddress}, constants::L1_TO_L2_MESSAGE_LENGTH};
     use dep::aztec::protocol_types::abis::function_selector::FunctionSelector;
-    use dep::aztec::protocol_types::{hash::pedersen_hash, traits::{ToField}};
+    use dep::aztec::protocol_types::traits::{ToField};
     use dep::compressed_string::CompressedString;
 
     // avm lib
@@ -40,91 +40,109 @@ contract AvmTest {
         map: Map<AztecAddress, PublicMutable<u32>>,
     }
 
+    /************************************************************************
+     * Storage
+     ************************************************************************/
+    unconstrained fn view_storage_single() -> pub Field {
+        storage.single.read()
+    }
+
+    unconstrained fn view_storage_list() -> pub [Field; 2] {
+        storage.list.read().serialize()
+    }
+
+    unconstrained fn view_storage_map(address: AztecAddress) -> pub u32 {
+        storage.map.at(address).read()
+    }
+
     #[aztec(public-vm)]
-    fn setStorageSingle(a: Field) {
+    fn set_storage_single(a: Field) {
         storage.single.write(a);
     }
 
     #[aztec(public-vm)]
-    fn readStorageSingle() -> pub Field {
+    fn read_storage_single() -> pub Field {
         storage.single.read()
     }
 
     #[aztec(public-vm)]
-    fn setReadStorageSingle(a: Field) -> pub Field {
+    fn set_read_storage_single(a: Field) -> pub Field {
         storage.single.write(a);
         storage.single.read()
     }
 
     #[aztec(public-vm)]
-    fn setStorageList(a: Field, b: Field) {
+    fn set_storage_list(a: Field, b: Field) {
         storage.list.write(Note { a, b });
     }
 
     #[aztec(public-vm)]
-    fn readStorageList() -> pub [Field; 2] {
+    fn read_storage_list() -> pub [Field; 2] {
         let note: Note = storage.list.read();
         note.serialize()
     }
 
     #[aztec(public-vm)]
-    fn setStorageMap(to: AztecAddress, amount: u32) -> pub Field {
+    fn set_storage_map(to: AztecAddress, amount: u32) -> pub Field {
         storage.map.at(to).write(amount);
         // returns storage slot for key
-        pedersen_hash([storage.map.storage_slot, to.to_field()], 0)
+        dep::std::hash::pedersen_hash([storage.map.storage_slot, to.to_field()])
     }
 
     #[aztec(public-vm)]
-    fn addStorageMap(to: AztecAddress, amount: u32) -> pub Field {
+    fn add_storage_map(to: AztecAddress, amount: u32) -> pub Field {
         let new_balance = storage.map.at(to).read().add(amount);
         storage.map.at(to).write(new_balance);
         // returns storage slot for key
-        pedersen_hash([storage.map.storage_slot, to.to_field()], 0)
+        dep::std::hash::pedersen_hash([storage.map.storage_slot, to.to_field()])
     }
 
     #[aztec(public-vm)]
-    fn readStorageMap(address: AztecAddress) -> pub u32 {
+    fn read_storage_map(address: AztecAddress) -> pub u32 {
         storage.map.at(address).read()
     }
 
     #[aztec(public-vm)]
-    fn addArgsReturn(argA: Field, argB: Field) -> pub Field {
-        argA + argB
+    fn add_args_return(arg_a: Field, arg_b: Field) -> pub Field {
+        arg_a + arg_b
     }
 
+    /************************************************************************
+     * General Opcodes
+     ************************************************************************/
     #[aztec(public-vm)]
-    fn setOpcodeUint8() -> pub u8 {
+    fn set_opcode_u8() -> pub u8 {
         8 as u8
     }
 
     #[aztec(public-vm)]
-    fn setOpcodeUint32() -> pub u32 {
+    fn set_opcode_u32() -> pub u32 {
         1 << 30 as u32
     }
 
     #[aztec(public-vm)]
-    fn setOpcodeUint64() -> pub u64 {
+    fn set_opcode_u64() -> pub u64 {
         1 << 60 as u64
     }
 
     #[aztec(public-vm)]
-    fn setOpcodeSmallField() -> pub Field {
+    fn set_opcode_small_field() -> pub Field {
         big_field_128_bits
     }
 
     #[aztec(public-vm)]
-    fn setOpcodeBigField() -> pub Field {
+    fn set_opcode_big_field() -> pub Field {
         big_field_136_bits
     }
 
     #[aztec(public-vm)]
-    fn addU128(a: U128, b: U128) -> pub U128 {
+    fn add_u128(a: U128, b: U128) -> pub U128 {
         a + b
     }
 
-    // /************************************************************************
-    //  * Hashing functions
-    //  ************************************************************************/
+    /************************************************************************
+     * Hashing functions
+     ************************************************************************/
     #[aztec(public-vm)]
     fn keccak_hash(data: [Field; 3]) -> pub [Field; 2] {
         keccak256(data)
@@ -145,71 +163,71 @@ contract AvmTest {
         dep::std::hash::pedersen_hash(data)
     }
 
-    // /************************************************************************
-    //  * AvmContext functions
-    //  ************************************************************************/
+    /************************************************************************
+     * AvmContext functions
+     ************************************************************************/
     #[aztec(public-vm)]
-    fn getAddress() -> pub AztecAddress {
+    fn get_address() -> pub AztecAddress {
         context.address()
     }
 
     #[aztec(public-vm)]
-    fn getStorageAddress() -> pub AztecAddress {
+    fn get_storage_address() -> pub AztecAddress {
         context.storage_address()
     }
 
     #[aztec(public-vm)]
-    fn getSender() -> pub AztecAddress {
+    fn get_sender() -> pub AztecAddress {
         context.sender()
     }
 
     #[aztec(public-vm)]
-    fn getOrigin() -> pub AztecAddress {
+    fn get_origin() -> pub AztecAddress {
         context.origin()
     }
 
     #[aztec(public-vm)]
-    fn getPortal() -> pub EthAddress {
+    fn get_portal() -> pub EthAddress {
         context.portal()
     }
 
     #[aztec(public-vm)]
-    fn getFeePerL1Gas() -> pub Field {
+    fn get_fee_per_l1_gas() -> pub Field {
         context.fee_per_l1_gas()
     }
 
     #[aztec(public-vm)]
-    fn getFeePerL2Gas() -> pub Field {
+    fn get_fee_per_l2_gas() -> pub Field {
         context.fee_per_l2_gas()
     }
 
     #[aztec(public-vm)]
-    fn getFeePerDaGas() -> pub Field {
+    fn get_fee_per_da_gas() -> pub Field {
         context.fee_per_da_gas()
     }
 
     #[aztec(public-vm)]
-    fn getChainId() -> pub Field {
+    fn get_chain_id() -> pub Field {
         context.chain_id()
     }
 
     #[aztec(public-vm)]
-    fn getVersion() -> pub Field {
+    fn get_version() -> pub Field {
         context.version()
     }
 
     #[aztec(public-vm)]
-    fn getBlockNumber() -> pub Field {
+    fn get_block_number() -> pub Field {
         context.block_number()
     }
 
     #[aztec(public-vm)]
-    fn getTimestamp() -> pub Field {
+    fn get_timestamp() -> pub Field {
         context.timestamp()
     }
 
     // #[aztec(public-vm)]
-    // fn getContractCallDepth() -> pub Field {
+    // fn get_contract_call_depth() -> pub Field {
     //     context.contract_call_depth()
     // }
 
@@ -273,7 +291,7 @@ contract AvmTest {
     // Directly call the external call opcode to initiate a nested call to the add function
     #[aztec(public-vm)]
     fn raw_nested_call_to_add(argA: Field, argB: Field) -> pub Field {
-        let selector = FunctionSelector::from_signature("avm_addArgsReturn(Field,Field)").to_field();
+        let selector = FunctionSelector::from_signature("add_args_return(Field,Field)").to_field();
         let gas = [/*l1Gas*/42, /*l2Gas*/24, /*daGas*/420];
 
         // Nested call
@@ -292,7 +310,7 @@ contract AvmTest {
     // Use the `call_public_function` wrapper to initiate a nested call to the add function
     #[aztec(public-vm)]
     fn nested_call_to_add(argA: Field, argB: Field) -> pub Field {
-        let selector = FunctionSelector::from_signature("avm_addArgsReturn(Field,Field)");
+        let selector = FunctionSelector::from_signature("add_args_return(Field,Field)");
 
         // Nested call using standard context interface function
         let returnData: [Field; 1] = context.call_public_function(context.address(), selector, [argA, argB]);
@@ -306,7 +324,7 @@ contract AvmTest {
     // Directly call_static the external call opcode to initiate a nested call to the add function
     #[aztec(public-vm)]
     fn raw_nested_static_call_to_add(argA: Field, argB: Field) -> pub (Field, u8) {
-        let selector = FunctionSelector::from_signature("avm_addArgsReturn(Field,Field)").to_field();
+        let selector = FunctionSelector::from_signature("add_args_return(Field,Field)").to_field();
         let gas = [/*l1Gas*/42, /*l2Gas*/24, /*daGas*/420];
 
         let (resultData, success): ([Field; 1], u8) = context.call_static(gas, context.address(), [argA, argB], selector);
@@ -314,13 +332,14 @@ contract AvmTest {
         (resultData[0], success)
     }
 
-    // Directly call_static setAdmin. Should fail since it's accessing storage.
+    // Directly call_static `set_storage_single`. Should fail since it's accessing storage.
     #[aztec(public-vm)]
-    fn raw_nested_static_call_to_set_admin() -> pub u8 {
-        let selector = FunctionSelector::from_signature("avm_setAdmin()").to_field();
+    fn raw_nested_static_call_to_set_storage() -> pub u8 {
+        let selector = FunctionSelector::from_signature("set_storage_single(Field)").to_field();
         let gas = [/*l1Gas*/42, /*l2Gas*/24, /*daGas*/420];
+        let calldata: [Field; 1] = [20];
 
-        let (_returnData, success): ([Field; 0], u8) = context.call_static(gas, context.address(), [], selector);
+        let (_returnData, success): ([Field; 0], u8) = context.call_static(gas, context.address(), calldata, selector);
 
         success
     }
@@ -328,18 +347,19 @@ contract AvmTest {
     // Indirectly call_static the external call opcode to initiate a nested call to the add function
     #[aztec(public-vm)]
     fn nested_static_call_to_add(argA: Field, argB: Field) -> pub Field {
-        let selector = FunctionSelector::from_signature("avm_addArgsReturn(Field,Field)");
+        let selector = FunctionSelector::from_signature("add_args_return(Field,Field)");
 
         let resultData: [Field; 1] = context.static_call_public_function(context.address(), selector, [argA, argB]);
 
         resultData[0]
     }
 
-    // Indirectly call_static setAdmin. Should revert since it's accessing storage.
+    // Indirectly call_static `set_storage_single`. Should revert since it's accessing storage.
     #[aztec(public-vm)]
-    fn nested_static_call_to_set_admin() {
-        let selector = FunctionSelector::from_signature("avm_setAdmin()");
+    fn nested_static_call_to_set_storage() {
+        let selector = FunctionSelector::from_signature("set_storage_single(Field)");
+        let calldata: [Field; 1] = [20];
 
-        let _resultData: [Field; 0] = context.static_call_public_function(context.address(), selector, []);
+        let _resultData: [Field; 0] = context.static_call_public_function(context.address(), selector, calldata);
     }
 }

--- a/noir/noir-repo/aztec_macros/src/transforms/functions.rs
+++ b/noir/noir-repo/aztec_macros/src/transforms/functions.rs
@@ -119,9 +119,6 @@ pub fn transform_vm_function(
     // We want the function to be seen as a public function
     func.def.is_unconstrained = true;
 
-    // NOTE: the line below is a temporary hack to trigger external transpilation tools
-    // It will be removed once the transpiler is integrated into the Noir compiler
-    func.def.name.0.contents = format!("avm_{}", func.def.name.0.contents);
     Ok(())
 }
 

--- a/yarn-project/simulator/src/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.test.ts
@@ -20,15 +20,6 @@ import {
 import { Add, CalldataCopy, Return } from './opcodes/index.js';
 import { encodeToBytecode } from './serialization/bytecode_serialization.js';
 
-function getAvmTestContractBytecode(functionName: string): Buffer {
-  const artifact = AvmTestContractArtifact.functions.find(f => f.name === functionName)!;
-  assert(
-    !!artifact?.bytecode,
-    `No bytecode found for function ${functionName}. Try re-running bootstrap.sh on the repository root.`,
-  );
-  return Buffer.from(artifact.bytecode, 'base64');
-}
-
 describe('AVM simulator', () => {
   it('Should execute bytecode that performs basic addition', async () => {
     const calldata: Fr[] = [new Fr(1), new Fr(2)];
@@ -52,7 +43,7 @@ describe('AVM simulator', () => {
       const calldata: Fr[] = [new Fr(1), new Fr(2)];
       const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
-      const bytecode = getAvmTestContractBytecode('avm_addArgsReturn');
+      const bytecode = getAvmTestContractBytecode('add_args_return');
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
       expect(results.reverted).toBe(false);
@@ -70,7 +61,7 @@ describe('AVM simulator', () => {
       ];
       const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
-      const bytecode = getAvmTestContractBytecode('avm_addU128');
+      const bytecode = getAvmTestContractBytecode('add_u128');
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
       expect(results.reverted).toBe(false);
@@ -78,11 +69,11 @@ describe('AVM simulator', () => {
     });
 
     describe.each([
-      ['avm_setOpcodeUint8', 8n],
-      ['avm_setOpcodeUint32', 1n << 30n],
-      ['avm_setOpcodeUint64', 1n << 60n],
-      ['avm_setOpcodeSmallField', 0x001234567890abcdef1234567890abcdefn],
-      ['avm_setOpcodeBigField', 0x991234567890abcdef1234567890abcdefn],
+      ['set_opcode_u8', 8n],
+      ['set_opcode_u32', 1n << 30n],
+      ['set_opcode_u64', 1n << 60n],
+      ['set_opcode_small_field', 0x001234567890abcdef1234567890abcdefn],
+      ['set_opcode_big_field', 0x991234567890abcdef1234567890abcdefn],
     ])('Should execute contract SET functions', (name: string, res: bigint) => {
       it(`Should execute contract function '${name}'`, async () => {
         const context = initContext();
@@ -95,8 +86,8 @@ describe('AVM simulator', () => {
     });
 
     describe.each([
-      ['avm_sha256_hash', sha256],
-      ['avm_keccak_hash', keccak],
+      ['sha256_hash', sha256],
+      ['keccak_hash', keccak],
     ])('Hashes with 2 fields returned in noir contracts', (name: string, hashFunction: (data: Buffer) => Buffer) => {
       it(`Should execute contract function that performs ${name} hash`, async () => {
         const calldata = [new Fr(1), new Fr(2), new Fr(3)];
@@ -112,8 +103,8 @@ describe('AVM simulator', () => {
     });
 
     describe.each([
-      ['avm_poseidon_hash', poseidonHash],
-      ['avm_pedersen_hash', pedersenHash],
+      ['poseidon_hash', poseidonHash],
+      ['pedersen_hash', pedersenHash],
     ])('Hashes with field returned in noir contracts', (name: string, hashFunction: (data: Buffer[]) => Fr) => {
       it(`Should execute contract function that performs ${name} hash`, async () => {
         const calldata = [new Fr(1), new Fr(2), new Fr(3)];
@@ -150,62 +141,62 @@ describe('AVM simulator', () => {
 
       it('address', async () => {
         const address = AztecAddress.fromField(new Fr(1));
-        await testEnvGetter('address', address, 'avm_getAddress');
+        await testEnvGetter('address', address, 'get_address');
       });
 
       it('storageAddress', async () => {
         const storageAddress = AztecAddress.fromField(new Fr(1));
-        await testEnvGetter('storageAddress', storageAddress, 'avm_getStorageAddress');
+        await testEnvGetter('storageAddress', storageAddress, 'get_storage_address');
       });
 
       it('sender', async () => {
         const sender = AztecAddress.fromField(new Fr(1));
-        await testEnvGetter('sender', sender, 'avm_getSender');
+        await testEnvGetter('sender', sender, 'get_sender');
       });
 
       it('origin', async () => {
         const origin = AztecAddress.fromField(new Fr(1));
-        await testEnvGetter('origin', origin, 'avm_getOrigin');
+        await testEnvGetter('origin', origin, 'get_origin');
       });
 
       it('portal', async () => {
         const portal = EthAddress.fromField(new Fr(1));
-        await testEnvGetter('portal', portal, 'avm_getPortal');
+        await testEnvGetter('portal', portal, 'get_portal');
       });
 
       it('getFeePerL1Gas', async () => {
         const fee = new Fr(1);
-        await testEnvGetter('feePerL1Gas', fee, 'avm_getFeePerL1Gas');
+        await testEnvGetter('feePerL1Gas', fee, 'get_fee_per_l1_gas');
       });
 
       it('getFeePerL2Gas', async () => {
         const fee = new Fr(1);
-        await testEnvGetter('feePerL2Gas', fee, 'avm_getFeePerL2Gas');
+        await testEnvGetter('feePerL2Gas', fee, 'get_fee_per_l2_gas');
       });
 
       it('getFeePerDaGas', async () => {
         const fee = new Fr(1);
-        await testEnvGetter('feePerDaGas', fee, 'avm_getFeePerDaGas');
+        await testEnvGetter('feePerDaGas', fee, 'get_fee_per_da_gas');
       });
 
       it('chainId', async () => {
         const chainId = new Fr(1);
-        await testEnvGetter('chainId', chainId, 'avm_getChainId', /*globalVar=*/ true);
+        await testEnvGetter('chainId', chainId, 'get_chain_id', /*globalVar=*/ true);
       });
 
       it('version', async () => {
         const version = new Fr(1);
-        await testEnvGetter('version', version, 'avm_getVersion', /*globalVar=*/ true);
+        await testEnvGetter('version', version, 'get_version', /*globalVar=*/ true);
       });
 
       it('blockNumber', async () => {
         const blockNumber = new Fr(1);
-        await testEnvGetter('blockNumber', blockNumber, 'avm_getBlockNumber', /*globalVar=*/ true);
+        await testEnvGetter('blockNumber', blockNumber, 'get_block_number', /*globalVar=*/ true);
       });
 
       it('timestamp', async () => {
         const timestamp = new Fr(1);
-        await testEnvGetter('timestamp', timestamp, 'avm_getTimestamp', /*globalVar=*/ true);
+        await testEnvGetter('timestamp', timestamp, 'get_timestamp', /*globalVar=*/ true);
       });
     });
 
@@ -216,7 +207,7 @@ describe('AVM simulator', () => {
         const calldata = [noteHash, leafIndex];
 
         const context = initContext({ env: initExecutionEnvironment({ calldata }) });
-        const bytecode = getAvmTestContractBytecode('avm_note_hash_exists');
+        const bytecode = getAvmTestContractBytecode('note_hash_exists');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -237,7 +228,7 @@ describe('AVM simulator', () => {
         jest
           .spyOn(context.persistableState.hostStorage.commitmentsDb, 'getCommitmentIndex')
           .mockReturnValue(Promise.resolve(BigInt(7)));
-        const bytecode = getAvmTestContractBytecode('avm_note_hash_exists');
+        const bytecode = getAvmTestContractBytecode('note_hash_exists');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -250,7 +241,7 @@ describe('AVM simulator', () => {
 
       it(`Should execute contract function to emit unencrypted logs (should be traced)`, async () => {
         const context = initContext();
-        const bytecode = getAvmTestContractBytecode('avm_emit_unencrypted_log');
+        const bytecode = getAvmTestContractBytecode('emit_unencrypted_log');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -280,7 +271,7 @@ describe('AVM simulator', () => {
         const calldata = [utxo];
 
         const context = initContext({ env: initExecutionEnvironment({ calldata }) });
-        const bytecode = getAvmTestContractBytecode('avm_new_note_hash');
+        const bytecode = getAvmTestContractBytecode('new_note_hash');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -293,7 +284,7 @@ describe('AVM simulator', () => {
         const calldata = [utxo];
 
         const context = initContext({ env: initExecutionEnvironment({ calldata }) });
-        const bytecode = getAvmTestContractBytecode('avm_new_nullifier');
+        const bytecode = getAvmTestContractBytecode('new_nullifier');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -306,7 +297,7 @@ describe('AVM simulator', () => {
         const calldata = [utxo];
 
         const context = initContext({ env: initExecutionEnvironment({ calldata }) });
-        const bytecode = getAvmTestContractBytecode('avm_nullifier_exists');
+        const bytecode = getAvmTestContractBytecode('nullifier_exists');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -327,7 +318,7 @@ describe('AVM simulator', () => {
         jest
           .spyOn(context.persistableState.hostStorage.commitmentsDb, 'getNullifierIndex')
           .mockReturnValue(Promise.resolve(BigInt(42)));
-        const bytecode = getAvmTestContractBytecode('avm_nullifier_exists');
+        const bytecode = getAvmTestContractBytecode('nullifier_exists');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -344,7 +335,7 @@ describe('AVM simulator', () => {
         const calldata = [utxo];
 
         const context = initContext({ env: initExecutionEnvironment({ calldata }) });
-        const bytecode = getAvmTestContractBytecode('avm_emit_nullifier_and_check');
+        const bytecode = getAvmTestContractBytecode('emit_nullifier_and_check');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -360,7 +351,7 @@ describe('AVM simulator', () => {
         const calldata = [utxo];
 
         const context = initContext({ env: initExecutionEnvironment({ calldata }) });
-        const bytecode = getAvmTestContractBytecode('avm_nullifier_collision');
+        const bytecode = getAvmTestContractBytecode('nullifier_collision');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(true);
@@ -376,7 +367,7 @@ describe('AVM simulator', () => {
         const calldata = [msgHash, leafIndex];
 
         const context = initContext({ env: initExecutionEnvironment({ calldata }) });
-        const bytecode = getAvmTestContractBytecode('avm_l1_to_l2_msg_exists');
+        const bytecode = getAvmTestContractBytecode('l1_to_l2_msg_exists');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -396,7 +387,7 @@ describe('AVM simulator', () => {
         jest
           .spyOn(context.persistableState.hostStorage.commitmentsDb, 'getL1ToL2MembershipWitness')
           .mockResolvedValue(initL1ToL2MessageOracleInput(leafIndex.toBigInt()));
-        const bytecode = getAvmTestContractBytecode('avm_l1_to_l2_msg_exists');
+        const bytecode = getAvmTestContractBytecode('l1_to_l2_msg_exists');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -411,8 +402,8 @@ describe('AVM simulator', () => {
     describe('Test nested external calls from noir contract', () => {
       it(`Should execute contract function that makes a nested call`, async () => {
         const calldata: Fr[] = [new Fr(1), new Fr(2)];
-        const callBytecode = getAvmTestContractBytecode('avm_raw_nested_call_to_add');
-        const addBytecode = getAvmTestContractBytecode('avm_addArgsReturn');
+        const callBytecode = getAvmTestContractBytecode('raw_nested_call_to_add');
+        const addBytecode = getAvmTestContractBytecode('add_args_return');
         const context = initContext({ env: initExecutionEnvironment({ calldata }) });
         jest
           .spyOn(context.persistableState.hostStorage.contractsDb, 'getBytecode')
@@ -426,8 +417,8 @@ describe('AVM simulator', () => {
 
       it(`Should execute contract function that makes a nested call through the old interface`, async () => {
         const calldata: Fr[] = [new Fr(1), new Fr(2)];
-        const callBytecode = getAvmTestContractBytecode('avm_nested_call_to_add');
-        const addBytecode = getAvmTestContractBytecode('avm_addArgsReturn');
+        const callBytecode = getAvmTestContractBytecode('nested_call_to_add');
+        const addBytecode = getAvmTestContractBytecode('add_args_return');
         const context = initContext({ env: initExecutionEnvironment({ calldata }) });
         jest
           .spyOn(context.persistableState.hostStorage.contractsDb, 'getBytecode')
@@ -441,8 +432,8 @@ describe('AVM simulator', () => {
 
       it(`Should execute contract function that makes a nested static call`, async () => {
         const calldata: Fr[] = [new Fr(1), new Fr(2)];
-        const callBytecode = getAvmTestContractBytecode('avm_raw_nested_static_call_to_add');
-        const addBytecode = getAvmTestContractBytecode('avm_addArgsReturn');
+        const callBytecode = getAvmTestContractBytecode('raw_nested_static_call_to_add');
+        const addBytecode = getAvmTestContractBytecode('add_args_return');
         const context = initContext({ env: initExecutionEnvironment({ calldata }) });
         jest
           .spyOn(context.persistableState.hostStorage.contractsDb, 'getBytecode')
@@ -455,8 +446,8 @@ describe('AVM simulator', () => {
       });
 
       it(`Should execute contract function that makes a nested static call which modifies storage`, async () => {
-        const callBytecode = getAvmTestContractBytecode('avm_raw_nested_static_call_to_set_admin');
-        const nestedBytecode = getAvmTestContractBytecode('avm_setStorageSingle');
+        const callBytecode = getAvmTestContractBytecode('raw_nested_static_call_to_set_storage');
+        const nestedBytecode = getAvmTestContractBytecode('set_storage_single');
         const context = initContext();
         jest
           .spyOn(context.persistableState.hostStorage.contractsDb, 'getBytecode')
@@ -470,8 +461,8 @@ describe('AVM simulator', () => {
 
       it(`Should execute contract function that makes a nested static call (old interface)`, async () => {
         const calldata: Fr[] = [new Fr(1), new Fr(2)];
-        const callBytecode = getAvmTestContractBytecode('avm_nested_static_call_to_add');
-        const addBytecode = getAvmTestContractBytecode('avm_addArgsReturn');
+        const callBytecode = getAvmTestContractBytecode('nested_static_call_to_add');
+        const addBytecode = getAvmTestContractBytecode('add_args_return');
         const context = initContext({ env: initExecutionEnvironment({ calldata }) });
         jest
           .spyOn(context.persistableState.hostStorage.contractsDb, 'getBytecode')
@@ -484,8 +475,8 @@ describe('AVM simulator', () => {
       });
 
       it(`Should execute contract function that makes a nested static call which modifies storage (old interface)`, async () => {
-        const callBytecode = getAvmTestContractBytecode('avm_nested_static_call_to_set_admin');
-        const nestedBytecode = getAvmTestContractBytecode('avm_setStorageSingle');
+        const callBytecode = getAvmTestContractBytecode('nested_static_call_to_set_storage');
+        const nestedBytecode = getAvmTestContractBytecode('set_storage_single');
         const context = initContext();
         jest
           .spyOn(context.persistableState.hostStorage.contractsDb, 'getBytecode')
@@ -507,7 +498,7 @@ describe('AVM simulator', () => {
         const context = initContext({
           env: initExecutionEnvironment({ calldata, address, storageAddress: address }),
         });
-        const bytecode = getAvmTestContractBytecode('avm_setStorageSingle');
+        const bytecode = getAvmTestContractBytecode('set_storage_single');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -536,7 +527,7 @@ describe('AVM simulator', () => {
         jest
           .spyOn(context.persistableState.hostStorage.publicStateDb, 'storageRead')
           .mockImplementation((_address, slot) => Promise.resolve(storage.get(slot.toBigInt())!));
-        const bytecode = getAvmTestContractBytecode('avm_readStorageSingle');
+        const bytecode = getAvmTestContractBytecode('read_storage_single');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         // Get contract function artifact
@@ -559,7 +550,7 @@ describe('AVM simulator', () => {
         const context = initContext({
           env: initExecutionEnvironment({ calldata, address, storageAddress: address }),
         });
-        const bytecode = getAvmTestContractBytecode('avm_setReadStorageSingle');
+        const bytecode = getAvmTestContractBytecode('set_read_storage_single');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -586,7 +577,7 @@ describe('AVM simulator', () => {
         const context = initContext({
           env: initExecutionEnvironment({ sender, address, calldata, storageAddress: address }),
         });
-        const bytecode = getAvmTestContractBytecode('avm_setStorageList');
+        const bytecode = getAvmTestContractBytecode('set_storage_list');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -617,7 +608,7 @@ describe('AVM simulator', () => {
         jest
           .spyOn(context.persistableState.hostStorage.publicStateDb, 'storageRead')
           .mockImplementation((_address, slot) => Promise.resolve(storage.get(slot.toBigInt())!));
-        const bytecode = getAvmTestContractBytecode('avm_readStorageList');
+        const bytecode = getAvmTestContractBytecode('read_storage_list');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -638,7 +629,7 @@ describe('AVM simulator', () => {
         const context = initContext({
           env: initExecutionEnvironment({ address, calldata, storageAddress: address }),
         });
-        const bytecode = getAvmTestContractBytecode('avm_setStorageMap');
+        const bytecode = getAvmTestContractBytecode('set_storage_map');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -662,7 +653,7 @@ describe('AVM simulator', () => {
         const context = initContext({
           env: initExecutionEnvironment({ address, calldata, storageAddress: address }),
         });
-        const bytecode = getAvmTestContractBytecode('avm_addStorageMap');
+        const bytecode = getAvmTestContractBytecode('add_storage_map');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
@@ -691,7 +682,7 @@ describe('AVM simulator', () => {
         jest
           .spyOn(context.persistableState.hostStorage.publicStateDb, 'storageRead')
           .mockReturnValue(Promise.resolve(value));
-        const bytecode = getAvmTestContractBytecode('avm_readStorageMap');
+        const bytecode = getAvmTestContractBytecode('read_storage_map');
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         // Get contract function artifact
@@ -706,3 +697,12 @@ describe('AVM simulator', () => {
     });
   });
 });
+
+function getAvmTestContractBytecode(functionName: string): Buffer {
+  const artifact = AvmTestContractArtifact.functions.find(f => f.name === functionName)!;
+  assert(
+    !!artifact?.bytecode,
+    `No bytecode found for function ${functionName}. Try re-running bootstrap.sh on the repository root.`,
+  );
+  return Buffer.from(artifact.bytecode, 'base64');
+}

--- a/yarn-project/simulator/src/public/avm_executor.test.ts
+++ b/yarn-project/simulator/src/public/avm_executor.test.ts
@@ -57,7 +57,7 @@ describe('AVM WitGen and Proof Generation', () => {
   it.skip('Should prove valid execution contract function that performs addition', async () => {
     const args: Fr[] = [new Fr(1), new Fr(2)];
 
-    const addArtifact = AvmTestContractArtifact.functions.find(f => f.name === 'avm_addArgsReturn')!;
+    const addArtifact = AvmTestContractArtifact.functions.find(f => f.name === 'add_args_return')!;
     const bytecode = Buffer.from(addArtifact.bytecode, 'base64');
     publicContracts.getBytecode.mockResolvedValue(bytecode);
     const functionData = FunctionData.fromAbi(addArtifact);


### PR DESCRIPTION
* Add storage e2e tests
* Convert test contract methods to snake case to match other contracts.
* Remove `avm_` requirement in function names for transpilation. It's not needed, we rely on `#[aztec(public-vm)]`.
* Prepare ground in bootstrap.sh to transpile all files in parallel. It works but I'm being overly cautious and not enabling it on all files until I need it.
* Backup original contract before transpiling.