### PR TITLE
chore: Add avm team to codeowners for public context

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,5 @@
 /build-system/ @charlielye
 /build_manifest.yml @charlielye
+
+# Notify the AVM team of any changes to public oracle.
+/yarn-project/simulator/src/public/public_execution_context.ts @Maddiaa0 @fcarreiro


### PR DESCRIPTION
So they are notified of any changes to public oracles.
