### PR TITLE
fix(bb): cvc5 linking

### DIFF
--- a/barretenberg/cpp/Earthfile
+++ b/barretenberg/cpp/Earthfile
@@ -118,8 +118,6 @@ bench-client-ivc:
 
 build: # default target
     BUILD +preset-release
-    RUN sleep 10
-    RUN false
 
 # Functions
 RUN_CMAKE:

--- a/barretenberg/cpp/Earthfile
+++ b/barretenberg/cpp/Earthfile
@@ -118,6 +118,8 @@ bench-client-ivc:
 
 build: # default target
     BUILD +preset-release
+    RUN sleep 10
+    RUN false
 
 # Functions
 RUN_CMAKE:

--- a/barretenberg/cpp/src/barretenberg/smt_verification/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CVC5_PREFIX "${CMAKE_BINARY_DIR}/_deps/cvc5")
 set(CVC5_BUILD "${CVC5_PREFIX}/src/cvc5-build")
 
 ExternalProject_Add(
-    cvc5-download
+    cvc5
     PREFIX ${CVC5_PREFIX}
     GIT_REPOSITORY "https://github.com/cvc5/cvc5.git"
     GIT_TAG main
@@ -18,9 +18,10 @@ ExternalProject_Add(
 
 set(CVC5_INCLUDE "${CVC5_BUILD}/include")
 set(CVC5_LIB "${CVC5_BUILD}/lib/libcvc5.so")
-
 include_directories(${CVC5_INCLUDE})
-add_library(cvc5 SHARED IMPORTED)
 set_target_properties(cvc5 PROPERTIES IMPORTED_LOCATION ${CVC5_LIB})
 
-barretenberg_module(smt_verification common proof_system stdlib_primitives stdlib_sha256 circuit_checker cvc5)
+barretenberg_module(smt_verification common proof_system stdlib_primitives stdlib_sha256 circuit_checker)
+add_dependencies(smt_verification cvc5)
+add_dependencies(smt_verification_objects cvc5)
+add_dependencies(smt_verification_tests cvc5)

--- a/barretenberg/cpp/src/barretenberg/smt_verification/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/CMakeLists.txt
@@ -3,6 +3,7 @@ include(ExternalProject)
 # External project: Download cvc5 from GitHub
 set(CVC5_PREFIX "${CMAKE_BINARY_DIR}/_deps/cvc5")
 set(CVC5_BUILD "${CVC5_PREFIX}/src/cvc5-build")
+set(CVC5_LIB "${CVC5_BUILD}/lib/libcvc5.so")
 
 ExternalProject_Add(
     cvc5
@@ -14,14 +15,13 @@ ExternalProject_Add(
     BUILD_COMMAND make -C build
     INSTALL_COMMAND make -C build install
     UPDATE_COMMAND ""     # No update step
+    BUILD_BYPRODUCTS ${CVC5_LIB}
 )
 
 set(CVC5_INCLUDE "${CVC5_BUILD}/include")
-set(CVC5_LIB "${CVC5_BUILD}/lib/libcvc5.so")
+add_library(cvc5-lib SHARED IMPORTED)
+add_dependencies(cvc5-lib cvc5)
 include_directories(${CVC5_INCLUDE})
-set_target_properties(cvc5 PROPERTIES IMPORTED_LOCATION ${CVC5_LIB})
+set_target_properties(cvc5-lib PROPERTIES IMPORTED_LOCATION ${CVC5_LIB})
 
-barretenberg_module(smt_verification common proof_system stdlib_primitives stdlib_sha256 circuit_checker)
-add_dependencies(smt_verification cvc5)
-add_dependencies(smt_verification_objects cvc5)
-add_dependencies(smt_verification_tests cvc5)
+barretenberg_module(smt_verification common proof_system stdlib_primitives stdlib_sha256 circuit_checker transcript plonk cvc5-lib)

--- a/barretenberg/cpp/src/barretenberg/smt_verification/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/CMakeLists.txt
@@ -4,6 +4,7 @@ include(ExternalProject)
 set(CVC5_PREFIX "${CMAKE_BINARY_DIR}/_deps/cvc5")
 set(CVC5_BUILD "${CVC5_PREFIX}/src/cvc5-build")
 set(CVC5_LIB "${CVC5_BUILD}/lib/libcvc5.so")
+set(CVC5_INCLUDE "${CVC5_BUILD}/include")
 
 ExternalProject_Add(
     cvc5
@@ -15,13 +16,19 @@ ExternalProject_Add(
     BUILD_COMMAND make -C build
     INSTALL_COMMAND make -C build install
     UPDATE_COMMAND ""     # No update step
-    BUILD_BYPRODUCTS ${CVC5_LIB}
+    # needed by ninja
+    # See https://stackoverflow.com/questions/48142082/cmake-externalproject-add-project-not-building-before-targets-that-depend-on-it
+    BUILD_BYPRODUCTS ${CVC5_LIB} ${CVC5_INCLUDE}
 )
 
-set(CVC5_INCLUDE "${CVC5_BUILD}/include")
 add_library(cvc5-lib SHARED IMPORTED)
 add_dependencies(cvc5-lib cvc5)
 include_directories(${CVC5_INCLUDE})
 set_target_properties(cvc5-lib PROPERTIES IMPORTED_LOCATION ${CVC5_LIB})
 
 barretenberg_module(smt_verification common proof_system stdlib_primitives stdlib_sha256 circuit_checker transcript plonk cvc5-lib)
+# We have no easy way to add a dependency to an external target, we list the built targets explicit. Could be cleaner.
+add_dependencies(smt_verification cvc5)
+add_dependencies(smt_verification_objects cvc5)
+add_dependencies(smt_verification_tests cvc5)
+add_dependencies(smt_verification_test_objects cvc5)


### PR DESCRIPTION
 This correctly makes the barretenberg_module targets depend on the cmake ExternalProject