### PR TITLE
chore: update min compiler version of contracts

### DIFF
--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "app_subscription_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "avm_test_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/benchmarking_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/benchmarking_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "benchmarking_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/card_game_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "card_game_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/child_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/child_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "child_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/claim_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/claim_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "claim_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contract_class_registerer_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/contract_instance_deployer_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/contract_instance_deployer_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contract_instance_deployer_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/counter_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/counter_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "counter_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/crowdfunding_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/crowdfunding_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crowdfunding_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/delegated_on_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/delegated_on_contract/Nargo.toml
@@ -2,7 +2,7 @@
 name = "delegated_on_contract"
 type = "contract"
 authors = [""]
-compiler_version = ">=0.23.0"
+compiler_version = ">=0.25.0"
 
 [dependencies]
 aztec = { path = "../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts/contracts/delegator_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/delegator_contract/Nargo.toml
@@ -2,7 +2,7 @@
 name = "delegator_contract"
 type = "contract"
 authors = [""]
-compiler_version = ">=0.23.0"
+compiler_version = ">=0.25.0"
 
 [dependencies]
 aztec = { path = "../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "docs_example_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/easy_private_token_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/easy_private_token_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "easy_private_token_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/easy_private_voting_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/easy_private_voting_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "easy_private_voting_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/ecdsa_account_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/ecdsa_account_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ecdsa_account_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/escrow_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/escrow_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "escrow_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/fpc_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/fpc_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fpc_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/gas_token_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/gas_token_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gas_token_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/import_test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/import_test_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "import_test_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "inclusion_proofs_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/lending_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/lending_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lending_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/parent_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/parent_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parent_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pending_note_hashes_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/price_feed_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/price_feed_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "price_feed_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/reader_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/reader_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reader_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "schnorr_account_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/schnorr_hardcoded_account_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/schnorr_hardcoded_account_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "schnorr_hardcoded_account_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/schnorr_single_key_account_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/schnorr_single_key_account_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "schnorr_single_key_account_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/slow_tree_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/slow_tree_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "slow_tree_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/stateful_test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/stateful_test_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stateful_test_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "token_blacklist_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/token_bridge_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/token_bridge_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "token_bridge_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/token_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/token_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "token_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/token_portal_content_hash_lib/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/token_portal_content_hash_lib/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "token_portal_content_hash_lib"
 authors = ["aztec-labs"]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "lib"
 
 [dependencies]

--- a/noir-projects/noir-contracts/contracts/uniswap_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/uniswap_contract/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniswap_contract"
 authors = [""]
-compiler_version = ">=0.18.0"
+compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]


### PR DESCRIPTION
With the recent `initializer` tag (`constructor` dethrowning), example contracts won't compile with older versions of `aztec-nargo` (because they use older versions of `aztec-nr`). Bumping all examples to `>=0.25.0`