### PR TITLE
feat: add batched signerless contract calls

### DIFF
--- a/noir-projects/noir-contracts/Nargo.toml
+++ b/noir-projects/noir-contracts/Nargo.toml
@@ -36,4 +36,5 @@ members = [
     "contracts/token_bridge_contract",
     "contracts/uniswap_contract",
     "contracts/reader_contract",
+    "contracts/multi_call_entrypoint_contract",
 ]

--- a/noir-projects/noir-contracts/contracts/multi_call_entrypoint_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/multi_call_entrypoint_contract/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "multi_call_entrypoint_contract"
+authors = [""]
+compiler_version = ">=0.18.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../aztec-nr/aztec" }
+authwit = { path = "../../../aztec-nr/authwit" }

--- a/noir-projects/noir-contracts/contracts/multi_call_entrypoint_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/multi_call_entrypoint_contract/src/main.nr
@@ -1,0 +1,13 @@
+// An entrypoint contract that allows everything to go through. Only used for testing
+// Pair this with SignerlessWallet to perform multiple actions before any account contracts are deployed (and without authentication)
+contract MultiCallEntrypoint {
+    use dep::std;
+
+    use dep::aztec::prelude::AztecAddress;
+    use dep::authwit::entrypoint::app::AppPayload;
+
+    #[aztec(private)]
+    fn entrypoint(app_payload: pub AppPayload) {
+        app_payload.execute_calls(&mut context);
+    }
+}

--- a/yarn-project/accounts/src/defaults/account_interface.ts
+++ b/yarn-project/accounts/src/defaults/account_interface.ts
@@ -1,4 +1,5 @@
-import { AccountInterface, AuthWitnessProvider, EntrypointInterface, FeeOptions } from '@aztec/aztec.js/account';
+import { AccountInterface, AuthWitnessProvider } from '@aztec/aztec.js/account';
+import { EntrypointInterface, FeeOptions } from '@aztec/aztec.js/entrypoint';
 import { AuthWitness, FunctionCall, TxExecutionRequest } from '@aztec/circuit-types';
 import { AztecAddress, CompleteAddress, Fr } from '@aztec/circuits.js';
 import { DefaultAccountEntrypoint } from '@aztec/entrypoints/account';

--- a/yarn-project/aztec.js/package.json
+++ b/yarn-project/aztec.js/package.json
@@ -10,6 +10,7 @@
     "./account": "./dest/api/account.js",
     "./aztec_address": "./dest/api/aztec_address.js",
     "./deployment": "./dest/api/deployment.js",
+    "./entrypoint": "./dest/api/entrypoint.js",
     "./eth_address": "./dest/api/eth_address.js",
     "./ethereum": "./dest/api/ethereum.js",
     "./fee": "./dest/api/fee.js",

--- a/yarn-project/aztec.js/src/account/index.ts
+++ b/yarn-project/aztec.js/src/account/index.ts
@@ -9,7 +9,7 @@
 import { Fr } from '@aztec/circuits.js';
 
 export { AccountContract } from './contract.js';
-export { AccountInterface, AuthWitnessProvider, EntrypointInterface, FeeOptions } from './interface.js';
+export { AccountInterface, AuthWitnessProvider } from './interface.js';
 export * from './wallet.js';
 
 /** A contract deployment salt. */

--- a/yarn-project/aztec.js/src/account/interface.ts
+++ b/yarn-project/aztec.js/src/account/interface.ts
@@ -1,19 +1,9 @@
-import { AuthWitness, CompleteAddress, FunctionCall, TxExecutionRequest } from '@aztec/circuit-types';
+import { AuthWitness, CompleteAddress, FunctionCall } from '@aztec/circuit-types';
 import { AztecAddress } from '@aztec/circuits.js';
 import { Fr } from '@aztec/foundation/fields';
 
 import { ContractFunctionInteraction } from '../contract/contract_function_interaction.js';
-import { FeePaymentMethod } from '../fee/fee_payment_method.js';
-
-/**
- * Fee payment options for a transaction.
- */
-export type FeeOptions = {
-  /** The fee payment method to use */
-  paymentMethod: FeePaymentMethod;
-  /** The fee limit to pay */
-  maxFee: bigint | number | Fr;
-};
+import { EntrypointInterface } from '../entrypoint/entrypoint.js';
 
 // docs:start:account-interface
 /** Creates authorization witnesses. */
@@ -42,17 +32,6 @@ export interface AuthWitnessProvider {
           version?: Fr;
         },
   ): Promise<AuthWitness>;
-}
-
-/** Creates transaction execution requests out of a set of function calls. */
-export interface EntrypointInterface {
-  /**
-   * Generates an authenticated request out of set of function calls.
-   * @param executions - The execution intents to be run.
-   * @param feeOpts - The fee to be paid for the transaction.
-   * @returns The authenticated transaction execution request.
-   */
-  createTxExecutionRequest(executions: FunctionCall[], feeOpts?: FeeOptions): Promise<TxExecutionRequest>;
 }
 
 /**

--- a/yarn-project/aztec.js/src/api/account.ts
+++ b/yarn-project/aztec.js/src/api/account.ts
@@ -1,12 +1,4 @@
-export {
-  AccountContract,
-  AccountInterface,
-  AuthWitnessProvider,
-  EntrypointInterface,
-  Salt,
-  Wallet,
-  FeeOptions,
-} from '../account/index.js';
+export { AccountContract, AccountInterface, AuthWitnessProvider, Salt, Wallet } from '../account/index.js';
 
 export { AccountManager } from '../account_manager/index.js';
 

--- a/yarn-project/aztec.js/src/api/entrypoint.ts
+++ b/yarn-project/aztec.js/src/api/entrypoint.ts
@@ -1,0 +1,1 @@
+export * from '../entrypoint/entrypoint.js';

--- a/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
@@ -1,6 +1,6 @@
 import { PXE, Tx, TxExecutionRequest } from '@aztec/circuit-types';
 
-import { FeeOptions } from '../account/interface.js';
+import { FeeOptions } from '../entrypoint/entrypoint.js';
 import { SentTx } from './sent_tx.js';
 
 /**

--- a/yarn-project/aztec.js/src/entrypoint/default_entrypoint.ts
+++ b/yarn-project/aztec.js/src/entrypoint/default_entrypoint.ts
@@ -1,0 +1,27 @@
+import { FunctionCall, PackedArguments, TxExecutionRequest } from '@aztec/circuit-types';
+import { TxContext } from '@aztec/circuits.js';
+
+import { EntrypointInterface } from './entrypoint.js';
+
+/**
+ * Default implementation of the entrypoint interface. It calls a function on a contract directly
+ */
+export class DefaultEntrypoint implements EntrypointInterface {
+  constructor(private chainId: number, private protocolVersion: number) {}
+
+  createTxExecutionRequest(executions: FunctionCall[]): Promise<TxExecutionRequest> {
+    const [execution] = executions;
+    const packedArguments = PackedArguments.fromArgs(execution.args);
+    const txContext = TxContext.empty(this.chainId, this.protocolVersion);
+    return Promise.resolve(
+      new TxExecutionRequest(
+        execution.to,
+        execution.functionData,
+        packedArguments.hash,
+        txContext,
+        [packedArguments],
+        [],
+      ),
+    );
+  }
+}

--- a/yarn-project/aztec.js/src/entrypoint/entrypoint.ts
+++ b/yarn-project/aztec.js/src/entrypoint/entrypoint.ts
@@ -1,0 +1,25 @@
+import { FunctionCall, TxExecutionRequest } from '@aztec/circuit-types';
+import { Fr } from '@aztec/foundation/fields';
+
+import { FeePaymentMethod } from '../fee/fee_payment_method.js';
+
+/**
+ * Fee payment options for a transaction.
+ */
+export type FeeOptions = {
+  /** The fee payment method to use */
+  paymentMethod: FeePaymentMethod;
+  /** The fee limit to pay */
+  maxFee: bigint | number | Fr;
+};
+
+/** Creates transaction execution requests out of a set of function calls. */
+export interface EntrypointInterface {
+  /**
+   * Generates an execution request out of set of function calls.
+   * @param executions - The execution intents to be run.
+   * @param feeOpts - The fee to be paid for the transaction.
+   * @returns The authenticated transaction execution request.
+   */
+  createTxExecutionRequest(executions: FunctionCall[], feeOpts?: FeeOptions): Promise<TxExecutionRequest>;
+}

--- a/yarn-project/aztec.js/src/wallet/account_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/account_wallet.ts
@@ -2,8 +2,9 @@ import { AuthWitness, FunctionCall, PXE, TxExecutionRequest } from '@aztec/circu
 import { AztecAddress, Fr } from '@aztec/circuits.js';
 import { ABIParameterVisibility, FunctionAbi, FunctionType } from '@aztec/foundation/abi';
 
-import { AccountInterface, FeeOptions } from '../account/interface.js';
+import { AccountInterface } from '../account/interface.js';
 import { ContractFunctionInteraction } from '../contract/contract_function_interaction.js';
+import { FeeOptions } from '../entrypoint/entrypoint.js';
 import { computeAuthWitMessageHash } from '../utils/authwit.js';
 import { BaseWallet } from './base_wallet.js';
 

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -19,9 +19,9 @@ import { ContractArtifact } from '@aztec/foundation/abi';
 import { ContractClassWithId, ContractInstanceWithAddress } from '@aztec/types/contracts';
 import { NodeInfo } from '@aztec/types/interfaces';
 
-import { FeeOptions } from '../account/interface.js';
 import { Wallet } from '../account/wallet.js';
 import { ContractFunctionInteraction } from '../contract/contract_function_interaction.js';
+import { FeeOptions } from '../entrypoint/entrypoint.js';
 
 /**
  * A base class for Wallet implementations

--- a/yarn-project/aztec.js/src/wallet/signerless_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/signerless_wallet.ts
@@ -1,30 +1,26 @@
-import { AuthWitness, FunctionCall, PackedArguments, TxExecutionRequest } from '@aztec/circuit-types';
-import { CompleteAddress, Fr, TxContext } from '@aztec/circuits.js';
+import { AuthWitness, FunctionCall, PXE, TxExecutionRequest } from '@aztec/circuit-types';
+import { CompleteAddress, Fr } from '@aztec/circuits.js';
 
+import { DefaultEntrypoint } from '../entrypoint/default_entrypoint.js';
+import { EntrypointInterface } from '../entrypoint/entrypoint.js';
 import { BaseWallet } from './base_wallet.js';
 
 /**
  * Wallet implementation which creates a transaction request directly to the requested contract without any signing.
  */
 export class SignerlessWallet extends BaseWallet {
+  constructor(pxe: PXE, private entrypoint?: EntrypointInterface) {
+    super(pxe);
+  }
+
   async createTxExecutionRequest(executions: FunctionCall[]): Promise<TxExecutionRequest> {
-    if (executions.length !== 1) {
-      throw new Error(`Unexpected number of executions. Expected 1 but received ${executions.length}.`);
+    let entrypoint = this.entrypoint;
+    if (!entrypoint) {
+      const { chainId, protocolVersion } = await this.pxe.getNodeInfo();
+      entrypoint = new DefaultEntrypoint(chainId, protocolVersion);
     }
-    const [execution] = executions;
-    const packedArguments = PackedArguments.fromArgs(execution.args);
-    const { chainId, protocolVersion } = await this.pxe.getNodeInfo();
-    const txContext = TxContext.empty(chainId, protocolVersion);
-    return Promise.resolve(
-      new TxExecutionRequest(
-        execution.to,
-        execution.functionData,
-        packedArguments.hash,
-        txContext,
-        [packedArguments],
-        [],
-      ),
-    );
+
+    return entrypoint.createTxExecutionRequest(executions);
   }
 
   getChainId(): Fr {

--- a/yarn-project/aztec/package.json
+++ b/yarn-project/aztec/package.json
@@ -33,6 +33,7 @@
     "@aztec/aztec.js": "workspace:^",
     "@aztec/circuit-types": "workspace:^",
     "@aztec/circuits.js": "workspace:^",
+    "@aztec/entrypoints": "workspace:^",
     "@aztec/ethereum": "workspace:^",
     "@aztec/foundation": "workspace:^",
     "@aztec/kv-store": "workspace:^",

--- a/yarn-project/aztec/tsconfig.json
+++ b/yarn-project/aztec/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "../circuits.js"
     },
     {
+      "path": "../entrypoints"
+    },
+    {
       "path": "../ethereum"
     },
     {

--- a/yarn-project/end-to-end/src/cli_docs_sandbox.test.ts
+++ b/yarn-project/end-to-end/src/cli_docs_sandbox.test.ts
@@ -117,6 +117,7 @@ GasTokenContractArtifact
 ImportTestContractArtifact
 InclusionProofsContractArtifact
 LendingContractArtifact
+MultiCallEntrypointContractArtifact
 ParentContractArtifact
 PendingNoteHashesContractArtifact
 PriceFeedContractArtifact

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -17,6 +17,7 @@ import {
   LogType,
   PXE,
   SentTx,
+  SignerlessWallet,
   Wallet,
   createAztecNodeClient,
   createDebugLogger,
@@ -27,6 +28,7 @@ import {
   waitForPXE,
 } from '@aztec/aztec.js';
 import { deployInstance, registerContractClass } from '@aztec/aztec.js/deployment';
+import { DefaultMultiCallEntrypoint } from '@aztec/entrypoints/multi-call';
 import { randomBytes } from '@aztec/foundation/crypto';
 import {
   AvailabilityOracleAbi,
@@ -264,7 +266,7 @@ async function setupWithRemoteEnvironment(
   if (['1', 'true'].includes(ENABLE_GAS)) {
     // this contract might already have been deployed
     // the following function is idempotent
-    await deployCanonicalGasToken(wallets[0]);
+    await deployCanonicalGasToken(new SignerlessWallet(pxeClient, new DefaultMultiCallEntrypoint()));
   }
 
   return {
@@ -370,9 +372,7 @@ export async function setup(
   const { pxe, accounts, wallets } = await setupPXEService(numberOfAccounts, aztecNode!, pxeOpts, logger);
 
   if (['1', 'true'].includes(ENABLE_GAS)) {
-    // this should be a neutral wallet, but the SignerlessWallet only accepts a single function call
-    // and this needs two: one to register the class and another to deploy the instance
-    await deployCanonicalGasToken(wallets[0]);
+    await deployCanonicalGasToken(new SignerlessWallet(pxe, new DefaultMultiCallEntrypoint()));
   }
 
   const cheatCodes = CheatCodes.create(config.rpcUrl, pxe!);

--- a/yarn-project/entrypoints/package.json
+++ b/yarn-project/entrypoints/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "exports": {
     "./dapp": "./dest/dapp_entrypoint.js",
-    "./account": "./dest/account_entrypoint.js"
+    "./account": "./dest/account_entrypoint.js",
+    "./multi-call": "./dest/multi_call_entrypoint.js"
   },
   "typedocOptions": {
     "entryPoints": [
@@ -40,6 +41,7 @@
     "@aztec/circuit-types": "workspace:^",
     "@aztec/circuits.js": "workspace:^",
     "@aztec/foundation": "workspace:^",
+    "@aztec/protocol-contracts": "workspace:^",
     "tslib": "^2.4.0"
   },
   "devDependencies": {

--- a/yarn-project/entrypoints/src/account_entrypoint.ts
+++ b/yarn-project/entrypoints/src/account_entrypoint.ts
@@ -1,4 +1,5 @@
-import { AuthWitnessProvider, EntrypointInterface, FeeOptions } from '@aztec/aztec.js/account';
+import { AuthWitnessProvider } from '@aztec/aztec.js/account';
+import { EntrypointInterface, FeeOptions } from '@aztec/aztec.js/entrypoint';
 import { FunctionCall, PackedArguments, TxExecutionRequest } from '@aztec/circuit-types';
 import { AztecAddress, FunctionData, GeneratorIndex, TxContext } from '@aztec/circuits.js';
 import { FunctionAbi, encodeArguments } from '@aztec/foundation/abi';

--- a/yarn-project/entrypoints/src/entrypoint_payload.ts
+++ b/yarn-project/entrypoints/src/entrypoint_payload.ts
@@ -1,4 +1,4 @@
-import { FeeOptions } from '@aztec/aztec.js/account';
+import { FeeOptions } from '@aztec/aztec.js/entrypoint';
 import { Fr } from '@aztec/aztec.js/fields';
 import { FunctionCall, PackedArguments, emptyFunctionCall } from '@aztec/circuit-types';
 import { AztecAddress } from '@aztec/circuits.js';

--- a/yarn-project/entrypoints/tsconfig.json
+++ b/yarn-project/entrypoints/tsconfig.json
@@ -17,6 +17,9 @@
     },
     {
       "path": "../foundation"
+    },
+    {
+      "path": "../protocol-contracts"
     }
   ],
   "include": ["src", "src/**/*.json"]

--- a/yarn-project/package.json
+++ b/yarn-project/package.json
@@ -32,6 +32,7 @@
     "cli",
     "docs",
     "end-to-end",
+    "entrypoints",
     "ethereum",
     "foundation",
     "key-store",

--- a/yarn-project/protocol-contracts/scripts/copy-contracts.sh
+++ b/yarn-project/protocol-contracts/scripts/copy-contracts.sh
@@ -6,6 +6,7 @@ contracts=(
   contract_class_registerer_contract-ContractClassRegisterer
   contract_instance_deployer_contract-ContractInstanceDeployer
   gas_token_contract-GasToken
+  multi_call_entrypoint_contract-MultiCallEntrypoint
 )
 
 for contract in "${contracts[@]}"; do

--- a/yarn-project/protocol-contracts/src/multi-call-entrypoint/artifact.ts
+++ b/yarn-project/protocol-contracts/src/multi-call-entrypoint/artifact.ts
@@ -1,0 +1,6 @@
+import { loadContractArtifact } from '@aztec/types/abi';
+import { NoirCompiledContract } from '@aztec/types/noir';
+
+import MultiCallEntrypoint from '../artifacts/MultiCallEntrypoint.json' assert { type: 'json' };
+
+export const MultiCallEntrypointArtifact = loadContractArtifact(MultiCallEntrypoint as NoirCompiledContract);

--- a/yarn-project/protocol-contracts/src/multi-call-entrypoint/index.test.ts
+++ b/yarn-project/protocol-contracts/src/multi-call-entrypoint/index.test.ts
@@ -1,0 +1,11 @@
+import { computeContractAddressFromInstance, getContractClassFromArtifact } from '@aztec/circuits.js';
+
+import { getCanonicalMultiCallEntrypointContract } from './index.js';
+
+describe('MultiCallEntrypoint', () => {
+  it('returns canonical protocol contract', () => {
+    const contract = getCanonicalMultiCallEntrypointContract();
+    expect(computeContractAddressFromInstance(contract.instance)).toEqual(contract.address);
+    expect(getContractClassFromArtifact(contract.artifact).id).toEqual(contract.contractClass.id);
+  });
+});

--- a/yarn-project/protocol-contracts/src/multi-call-entrypoint/index.ts
+++ b/yarn-project/protocol-contracts/src/multi-call-entrypoint/index.ts
@@ -1,0 +1,12 @@
+import { AztecAddress, EthAddress, Point } from '@aztec/circuits.js';
+
+import { ProtocolContract, getCanonicalProtocolContract } from '../protocol_contract.js';
+import { MultiCallEntrypointArtifact } from './artifact.js';
+
+export function getCanonicalMultiCallEntrypointContract(): ProtocolContract {
+  return getCanonicalProtocolContract(MultiCallEntrypointArtifact, 1, [], Point.ZERO, EthAddress.ZERO);
+}
+
+export function getCanonicalMultiCallEntrypointAddress(): AztecAddress {
+  return getCanonicalMultiCallEntrypointContract().address;
+}

--- a/yarn-project/pxe/src/pxe_service/create_pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/create_pxe_service.ts
@@ -7,6 +7,7 @@ import { initStoreForRollup } from '@aztec/kv-store/utils';
 import { getCanonicalClassRegisterer } from '@aztec/protocol-contracts/class-registerer';
 import { getCanonicalGasToken } from '@aztec/protocol-contracts/gas-token';
 import { getCanonicalInstanceDeployer } from '@aztec/protocol-contracts/instance-deployer';
+import { getCanonicalMultiCallEntrypointContract } from '@aztec/protocol-contracts/multi-call-entrypoint';
 
 import { join } from 'path';
 
@@ -46,6 +47,7 @@ export async function createPXEService(
   for (const contract of [
     getCanonicalClassRegisterer(),
     getCanonicalInstanceDeployer(),
+    getCanonicalMultiCallEntrypointContract(),
     getCanonicalGasToken(l1Contracts.gasPortalAddress),
   ]) {
     await server.registerContract(contract);

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -228,6 +228,7 @@ __metadata:
     "@aztec/aztec.js": "workspace:^"
     "@aztec/circuit-types": "workspace:^"
     "@aztec/circuits.js": "workspace:^"
+    "@aztec/entrypoints": "workspace:^"
     "@aztec/ethereum": "workspace:^"
     "@aztec/foundation": "workspace:^"
     "@aztec/kv-store": "workspace:^"
@@ -441,6 +442,7 @@ __metadata:
     "@aztec/circuit-types": "workspace:^"
     "@aztec/circuits.js": "workspace:^"
     "@aztec/foundation": "workspace:^"
+    "@aztec/protocol-contracts": "workspace:^"
     "@jest/globals": ^29.5.0
     "@types/jest": ^29.5.0
     jest: ^29.5.0


### PR DESCRIPTION
Adds a dedicated entrypoint for calls into contracts done from outside the context of an account contract.

Previously we had just the `SignerlessWallet` that provided this functionality but it was limited to only one private function call per tx. This PR adds a dedicated contract to act as an entrypoint that takes the same payload as normal account contracts and calls external functions without doing any auth checks.
