### PR TITLE
refactor: moving public inputs back to instance

### DIFF
--- a/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra.hpp
@@ -287,20 +287,7 @@ class GoblinUltraFlavor {
      * circuits.
      * @todo TODO(https://github.com/AztecProtocol/barretenberg/issues/876)
      */
-    class VerificationKey : public VerificationKey_<PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
-      public:
-        std::vector<FF> public_inputs;
-
-        VerificationKey(const size_t circuit_size, const size_t num_public_inputs)
-            : VerificationKey_(circuit_size, num_public_inputs)
-        {}
-
-        template <typename ProvingKeyPtr>
-        VerificationKey(const ProvingKeyPtr& proving_key)
-            : VerificationKey_(proving_key)
-            , public_inputs(proving_key->public_inputs)
-        {}
-    };
+    using VerificationKey = VerificationKey_<PrecomputedEntities<Commitment>, VerifierCommitmentKey>;
 
     /**
      * @brief A container for storing the partially evaluated multivariates produced by sumcheck.

--- a/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra_recursive.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/goblin_ultra_recursive.hpp
@@ -100,8 +100,6 @@ template <typename BuilderType> class GoblinUltraRecursiveFlavor_ {
     class VerificationKey
         : public VerificationKey_<GoblinUltraFlavor::PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
-        std::vector<FF> public_inputs;
-
         VerificationKey(const size_t circuit_size, const size_t num_public_inputs)
         {
             this->circuit_size = circuit_size;
@@ -122,10 +120,6 @@ template <typename BuilderType> class GoblinUltraRecursiveFlavor_ {
             this->log_circuit_size = numeric::get_msb(this->circuit_size);
             this->num_public_inputs = native_key->num_public_inputs;
             this->pub_inputs_offset = native_key->pub_inputs_offset;
-            this->public_inputs = std::vector<FF>(native_key->num_public_inputs);
-            for (auto [public_input, native_public_input] : zip_view(this->public_inputs, native_key->public_inputs)) {
-                public_input = FF::from_witness(builder, native_public_input);
-            }
             this->q_m = Commitment::from_witness(builder, native_key->q_m);
             this->q_l = Commitment::from_witness(builder, native_key->q_l);
             this->q_r = Commitment::from_witness(builder, native_key->q_r);

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra.hpp
@@ -290,20 +290,7 @@ class UltraFlavor {
      * that, and split out separate PrecomputedPolynomials/Commitments data for clarity but also for portability of our
      * circuits.
      */
-    class VerificationKey : public VerificationKey_<PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
-      public:
-        std::vector<FF> public_inputs;
-
-        VerificationKey(const size_t circuit_size, const size_t num_public_inputs)
-            : VerificationKey_(circuit_size, num_public_inputs)
-        {}
-
-        template <typename ProvingKeyPtr>
-        VerificationKey(const ProvingKeyPtr& proving_key)
-            : VerificationKey_(proving_key)
-            , public_inputs(proving_key->public_inputs)
-        {}
-    };
+    using VerificationKey = VerificationKey_<PrecomputedEntities<Commitment>, VerifierCommitmentKey>;
 
     /**
      * @brief A field element for each entity of the flavor. These entities represent the prover polynomials

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_recursive.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_recursive.hpp
@@ -272,8 +272,6 @@ template <typename BuilderType> class UltraRecursiveFlavor_ {
      */
     class VerificationKey : public VerificationKey_<PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
-        std::vector<FF> public_inputs;
-
         VerificationKey(const size_t circuit_size, const size_t num_public_inputs)
         {
             this->circuit_size = circuit_size;
@@ -293,10 +291,6 @@ template <typename BuilderType> class UltraRecursiveFlavor_ {
             this->log_circuit_size = numeric::get_msb(this->circuit_size);
             this->num_public_inputs = native_key->num_public_inputs;
             this->pub_inputs_offset = native_key->pub_inputs_offset;
-            this->public_inputs = std::vector<FF>(native_key->num_public_inputs);
-            for (auto [public_input, native_public_input] : zip_view(this->public_inputs, native_key->public_inputs)) {
-                public_input = FF::from_witness(builder, native_public_input);
-            }
             this->q_m = Commitment::from_witness(builder, native_key->q_m);
             this->q_l = Commitment::from_witness(builder, native_key->q_l);
             this->q_r = Commitment::from_witness(builder, native_key->q_r);

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -96,16 +96,15 @@ std::shared_ptr<typename VerifierInstances::Instance> ProtoGalaxyVerifier_<Verif
         vk_idx++;
     }
     next_accumulator->verification_key->num_public_inputs = accumulator->verification_key->num_public_inputs;
-    next_accumulator->verification_key->public_inputs =
-        std::vector<FF>(next_accumulator->verification_key->num_public_inputs, 0);
+    next_accumulator->public_inputs = std::vector<FF>(next_accumulator->verification_key->num_public_inputs, 0);
     size_t public_input_idx = 0;
-    for (auto& public_input : next_accumulator->verification_key->public_inputs) {
+    for (auto& public_input : next_accumulator->public_inputs) {
         size_t inst = 0;
         for (auto& instance : instances) {
             // TODO(https://github.com/AztecProtocol/barretenberg/issues/830)
             if (instance->verification_key->num_public_inputs >=
                 next_accumulator->verification_key->num_public_inputs) {
-                public_input += instance->verification_key->public_inputs[public_input_idx] * lagranges[inst];
+                public_input += instance->public_inputs[public_input_idx] * lagranges[inst];
                 inst++;
             }
         }

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -9,9 +9,10 @@ void ProtoGalaxyVerifier_<VerifierInstances>::receive_and_finalise_instance(cons
 {
     auto& key = inst->verification_key;
     OinkVerifier<Flavor> oink_verifier{ key, transcript, domain_separator + '_' };
-    auto [relation_parameters, witness_commitments] = oink_verifier.verify();
-    inst->relation_parameters = relation_parameters;
-    inst->witness_commitments = witness_commitments;
+    auto [relation_parameters, witness_commitments, public_inputs] = oink_verifier.verify();
+    inst->relation_parameters = std::move(relation_parameters);
+    inst->witness_commitments = std::move(witness_commitments);
+    inst->public_inputs = std::move(public_inputs);
 
     // Get the relation separation challenges
     for (size_t idx = 0; idx < NUM_SUBRELATIONS - 1; idx++) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/recursive_verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/recursive_verifier_instance.hpp
@@ -29,6 +29,7 @@ template <IsRecursiveFlavor Flavor> class RecursiveVerifierInstance_ {
     RelationParameters<FF> relation_parameters;
     RelationSeparator alphas;
     bool is_accumulator = false;
+    std::vector<FF> public_inputs;
 
     // The folding parameters (\vec{β}, e) which are set for accumulators (i.e. relaxed instances).
     std::vector<FF> gate_challenges;
@@ -48,13 +49,13 @@ template <IsRecursiveFlavor Flavor> class RecursiveVerifierInstance_ {
         : verification_key(std::make_shared<VerificationKey>(instance->verification_key->circuit_size,
                                                              instance->verification_key->num_public_inputs))
         , is_accumulator(bool(instance->is_accumulator))
+        , public_inputs(std::vector<FF>(instance->verification_key->num_public_inputs))
     {
 
         verification_key->pub_inputs_offset = instance->verification_key->pub_inputs_offset;
         verification_key->pcs_verification_key = instance->verification_key->pcs_verification_key;
-        verification_key->public_inputs = std::vector<FF>(instance->verification_key->num_public_inputs);
-        for (auto [public_input, native_public_input] :
-             zip_view(verification_key->public_inputs, instance->verification_key->public_inputs)) {
+
+        for (auto [public_input, native_public_input] : zip_view(public_inputs, instance->public_inputs)) {
             public_input = FF::from_witness(builder, native_public_input);
         }
 
@@ -110,9 +111,8 @@ template <IsRecursiveFlavor Flavor> class RecursiveVerifierInstance_ {
         VerifierInstance inst(inst_verification_key);
         inst.is_accumulator = is_accumulator;
 
-        inst.verification_key->public_inputs = std::vector<NativeFF>(verification_key->num_public_inputs);
-        for (auto [public_input, inst_public_input] :
-             zip_view(verification_key->public_inputs, inst.verification_key->public_inputs)) {
+        inst.public_inputs = std::vector<NativeFF>(verification_key->num_public_inputs);
+        for (auto [public_input, inst_public_input] : zip_view(public_inputs, inst.public_inputs)) {
             inst_public_input = public_input.get_value();
         }
 

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/verifier_instance.hpp
@@ -23,6 +23,7 @@ template <class Flavor, size_t NUM_ = 2> class VerifierInstance_ {
     RelationParameters<FF> relation_parameters;
     RelationSeparator alphas;
     bool is_accumulator = false;
+    std::vector<FF> public_inputs;
 
     // The folding parameters (\vec{β}, e) which are set for accumulators (i.e. relaxed instances).
     std::vector<FF> gate_challenges;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
@@ -17,10 +17,9 @@ template <IsUltraFlavor Flavor> OinkOutput<Flavor> OinkVerifier<Flavor>::verify(
     execute_log_derivative_inverse_round();
     execute_grand_product_computation_round();
 
-    return OinkOutput<Flavor>{
-        .relation_parameters = relation_parameters,
-        .commitments = witness_comms,
-    };
+    return OinkOutput<Flavor>{ .relation_parameters = std::move(relation_parameters),
+                               .commitments = std::move(witness_comms),
+                               .public_inputs = std::move(public_inputs) };
 }
 
 /**
@@ -115,11 +114,8 @@ template <IsUltraFlavor Flavor> void OinkVerifier<Flavor>::execute_log_derivativ
  */
 template <IsUltraFlavor Flavor> void OinkVerifier<Flavor>::execute_grand_product_computation_round()
 {
-    const FF public_input_delta = compute_public_input_delta<Flavor>(key->public_inputs,
-                                                                     relation_parameters.beta,
-                                                                     relation_parameters.gamma,
-                                                                     key->circuit_size,
-                                                                     key->pub_inputs_offset);
+    const FF public_input_delta = compute_public_input_delta<Flavor>(
+        public_inputs, relation_parameters.beta, relation_parameters.gamma, key->circuit_size, key->pub_inputs_offset);
     const FF lookup_grand_product_delta =
         compute_lookup_grand_product_delta<FF>(relation_parameters.beta, relation_parameters.gamma, key->circuit_size);
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
@@ -40,11 +40,10 @@ template <IsUltraFlavor Flavor> void OinkVerifier<Flavor>::execute_preamble_roun
     ASSERT(public_input_size == key->num_public_inputs);
     ASSERT(pub_inputs_offset == key->pub_inputs_offset);
 
-    key->public_inputs.clear();
     for (size_t i = 0; i < public_input_size; ++i) {
         auto public_input_i =
             transcript->template receive_from_prover<FF>(domain_separator + "public_input_" + std::to_string(i));
-        key->public_inputs.emplace_back(public_input_i);
+        public_inputs.emplace_back(public_input_i);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
@@ -17,9 +17,9 @@ template <IsUltraFlavor Flavor> OinkOutput<Flavor> OinkVerifier<Flavor>::verify(
     execute_log_derivative_inverse_round();
     execute_grand_product_computation_round();
 
-    return OinkOutput<Flavor>{ .relation_parameters = std::move(relation_parameters),
-                               .commitments = std::move(witness_comms),
-                               .public_inputs = std::move(public_inputs) };
+    return OinkOutput<Flavor>{ .relation_parameters = relation_parameters,
+                               .commitments = witness_comms,
+                               .public_inputs = public_inputs };
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.hpp
@@ -11,6 +11,7 @@ namespace bb {
 template <IsUltraFlavor Flavor> struct OinkOutput {
     bb::RelationParameters<typename Flavor::FF> relation_parameters;
     typename Flavor::WitnessCommitments commitments;
+    std::vector<typename Flavor::FF> public_inputs;
 };
 
 /**
@@ -36,6 +37,7 @@ template <IsUltraFlavor Flavor> class OinkVerifier {
     typename Flavor::CommitmentLabels comm_labels;
     bb::RelationParameters<FF> relation_parameters;
     WitnessCommitments witness_comms;
+    std::vector<FF> public_inputs;
 
     OinkVerifier(const std::shared_ptr<VerificationKey>& verifier_key,
                  const std::shared_ptr<Transcript>& transcript,

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
@@ -49,7 +49,7 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const HonkP
     transcript = std::make_shared<Transcript>(proof);
     VerifierCommitments commitments{ key };
     OinkVerifier<Flavor> oink_verifier{ key, transcript };
-    auto [relation_parameters, witness_commitments, public_inputs] = oink_verifier.verify();
+    auto [relation_parameters, witness_commitments, _] = oink_verifier.verify();
 
     // Copy the witness_commitments over to the VerifierCommitments
     for (auto [wit_comm_1, wit_comm_2] : zip_view(commitments.get_witness(), witness_commitments.get_all())) {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
@@ -49,7 +49,7 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const HonkP
     transcript = std::make_shared<Transcript>(proof);
     VerifierCommitments commitments{ key };
     OinkVerifier<Flavor> oink_verifier{ key, transcript };
-    auto [relation_parameters, witness_commitments] = oink_verifier.verify();
+    auto [relation_parameters, witness_commitments, public_inputs] = oink_verifier.verify();
 
     // Copy the witness_commitments over to the VerifierCommitments
     for (auto [wit_comm_1, wit_comm_2] : zip_view(commitments.get_witness(), witness_commitments.get_all())) {


### PR DESCRIPTION
Previously I moved the verifier public inputs from the verifier instance to the verification key since I was mirroring the Prover side. However, this asymmetry is what we actually want. The verification key should store only circuit related data, and the verifier should receive the public inputs through the proof.

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
