### PR TITLE
refactor: append-only merkle tree generics

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -79,6 +79,7 @@
     "erc",
     "falsey",
     "fargate",
+    "Fieldeable",
     "filestat",
     "flatmap",
     "foundryup",

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -458,8 +458,15 @@ export class AztecNodeService implements AztecNode {
 
     const treeHeight = Math.ceil(Math.log2(l2ToL1Messages.length));
     // The root of this tree is the out_hash calculated in Noir => we truncate to match Noir's SHA
-    const tree = new StandardTree(openTmpStore(true), new SHA256Trunc(), 'temp_outhash_sibling_path', treeHeight);
-    await tree.appendLeaves(l2ToL1Messages.map(l2ToL1Msg => l2ToL1Msg.toBuffer()));
+    const tree = new StandardTree(
+      openTmpStore(true),
+      new SHA256Trunc(),
+      'temp_outhash_sibling_path',
+      treeHeight,
+      0n,
+      Fr,
+    );
+    await tree.appendLeaves(l2ToL1Messages);
 
     return [indexOfL2ToL1Message, await tree.getSiblingPath(indexOfL2ToL1Message, true)];
   }

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract.test.ts
@@ -38,14 +38,14 @@ describe('e2e_blacklist_token_contract', () => {
 
   let tokenSim: TokenSimulator;
 
-  let slowUpdateTreeSimulator: SparseTree;
+  let slowUpdateTreeSimulator: SparseTree<Fr>;
 
   let cheatCodes: CheatCodes;
 
   const getMembershipProof = async (index: bigint, includeUncommitted: boolean) => {
     return {
       index,
-      value: Fr.fromBuffer(slowUpdateTreeSimulator.getLeafValue(index, includeUncommitted)!),
+      value: slowUpdateTreeSimulator.getLeafValue(index, includeUncommitted)!,
       // eslint-disable-next-line camelcase
       sibling_path: (await slowUpdateTreeSimulator.getSiblingPath(index, includeUncommitted)).toFields(),
     };
@@ -101,9 +101,9 @@ describe('e2e_blacklist_token_contract', () => {
     await wallets[accountIndex].addNote(extendedNote);
   };
 
-  const updateSlowTree = async (tree: SparseTree, wallet: Wallet, index: AztecAddress, value: bigint) => {
+  const updateSlowTree = async (tree: SparseTree<Fr>, wallet: Wallet, index: AztecAddress, value: bigint) => {
     await wallet.addCapsule(getUpdateCapsule(await getUpdateProof(value, index.toBigInt())));
-    await tree.updateLeaf(new Fr(value).toBuffer(), index.toBigInt());
+    await tree.updateLeaf(new Fr(value), index.toBigInt());
   };
 
   beforeAll(async () => {
@@ -113,7 +113,7 @@ describe('e2e_blacklist_token_contract', () => {
     slowTree = await SlowTreeContract.deploy(wallets[0]).send().deployed();
 
     const depth = 254;
-    slowUpdateTreeSimulator = await newTree(SparseTree, openTmpStore(), new Pedersen(), 'test', depth);
+    slowUpdateTreeSimulator = await newTree(SparseTree, openTmpStore(), new Pedersen(), 'test', Fr, depth);
 
     // Add account[0] as admin
     await updateSlowTree(slowUpdateTreeSimulator, wallets[0], accounts[0].address, 4n);

--- a/yarn-project/end-to-end/src/e2e_dapp_subscription.test.ts
+++ b/yarn-project/end-to-end/src/e2e_dapp_subscription.test.ts
@@ -28,7 +28,7 @@ import {
   setup,
 } from './fixtures/utils.js';
 
-jest.setTimeout(1_000_000);
+jest.setTimeout(100_000);
 
 const TOKEN_NAME = 'BananaCoin';
 const TOKEN_SYMBOL = 'BC';

--- a/yarn-project/end-to-end/src/e2e_slow_tree.test.ts
+++ b/yarn-project/end-to-end/src/e2e_slow_tree.test.ts
@@ -23,11 +23,11 @@ describe('e2e_slow_tree', () => {
 
   it('Messing around with noir slow tree', async () => {
     const depth = 254;
-    const slowUpdateTreeSimulator = await newTree(SparseTree, openTmpStore(), new Pedersen(), 'test', depth);
+    const slowUpdateTreeSimulator = await newTree(SparseTree, openTmpStore(), new Pedersen(), 'test', Fr, depth);
     const getMembershipProof = async (index: bigint, includeUncommitted: boolean) => {
       return {
         index,
-        value: Fr.fromBuffer(slowUpdateTreeSimulator.getLeafValue(index, includeUncommitted)!),
+        value: slowUpdateTreeSimulator.getLeafValue(index, includeUncommitted)!,
         // eslint-disable-next-line camelcase
         sibling_path: (await slowUpdateTreeSimulator.getSiblingPath(index, includeUncommitted)).toFields(),
       };
@@ -102,7 +102,7 @@ describe('e2e_slow_tree', () => {
       .update_at_public(await getUpdateProof(1n, key))
       .send()
       .wait();
-    await slowUpdateTreeSimulator.updateLeaf(new Fr(1).toBuffer(), key);
+    await slowUpdateTreeSimulator.updateLeaf(new Fr(1), key);
 
     // Update below.
     _root = {
@@ -140,7 +140,7 @@ describe('e2e_slow_tree', () => {
     const t2 = computeNextChange(BigInt(await cheatCodes.eth.timestamp()));
     await wallet.addCapsule(getUpdateCapsule(await getUpdateProof(4n, key)));
     await contract.methods.update_at_private(key, 4n).send().wait();
-    await slowUpdateTreeSimulator.updateLeaf(new Fr(4).toBuffer(), key);
+    await slowUpdateTreeSimulator.updateLeaf(new Fr(4), key);
     _root = {
       before: Fr.fromBuffer(slowUpdateTreeSimulator.getRoot(false)).toBigInt(),
       after: Fr.fromBuffer(slowUpdateTreeSimulator.getRoot(true)).toBigInt(),

--- a/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/integration_l1_publisher.test.ts
@@ -428,8 +428,15 @@ describe('L1Publisher integration', () => {
 
       const treeHeight = Math.ceil(Math.log2(newL2ToL1MsgsArray.length));
 
-      const tree = new StandardTree(openTmpStore(true), new SHA256Trunc(), 'temp_outhash_sibling_path', treeHeight);
-      await tree.appendLeaves(newL2ToL1MsgsArray.map(l2ToL1Msg => l2ToL1Msg.toBuffer()));
+      const tree = new StandardTree(
+        openTmpStore(true),
+        new SHA256Trunc(),
+        'temp_outhash_sibling_path',
+        treeHeight,
+        0n,
+        Fr,
+      );
+      await tree.appendLeaves(newL2ToL1MsgsArray);
 
       const expectedRoot = tree.getRoot(true);
       const [actualRoot] = await outbox.read.roots([block.header.globalVariables.blockNumber.toBigInt()]);

--- a/yarn-project/foundation/src/serialize/buffer_reader.ts
+++ b/yarn-project/foundation/src/serialize/buffer_reader.ts
@@ -312,3 +312,14 @@ export class BufferReader {
     return this.buffer.length;
   }
 }
+
+/**
+ * A deserializer
+ */
+export interface FromBuffer<T> {
+  /**
+   * Deserializes an object from a buffer
+   * @param buffer - The buffer to deserialize.
+   */
+  fromBuffer(buffer: Buffer): T;
+}

--- a/yarn-project/merkle-tree/src/interfaces/append_only_tree.ts
+++ b/yarn-project/merkle-tree/src/interfaces/append_only_tree.ts
@@ -1,13 +1,17 @@
-import { TreeSnapshotBuilder } from '../snapshots/snapshot_builder.js';
+import { Bufferable } from '@aztec/foundation/serialize';
+
+import { TreeSnapshot, TreeSnapshotBuilder } from '../snapshots/snapshot_builder.js';
 import { MerkleTree } from './merkle_tree.js';
 
 /**
  * A Merkle tree that supports only appending leaves and not updating existing leaves.
  */
-export interface AppendOnlyTree extends MerkleTree, TreeSnapshotBuilder {
+export interface AppendOnlyTree<T extends Bufferable = Buffer>
+  extends MerkleTree<T>,
+    TreeSnapshotBuilder<TreeSnapshot<T>> {
   /**
    * Appends a set of leaf values to the tree.
    * @param leaves - The set of leaves to be appended.
    */
-  appendLeaves(leaves: Buffer[]): Promise<void>;
+  appendLeaves(leaves: T[]): Promise<void>;
 }

--- a/yarn-project/merkle-tree/src/interfaces/indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/interfaces/indexed_tree.ts
@@ -1,7 +1,9 @@
 import { SiblingPath } from '@aztec/circuit-types';
 import { IndexedTreeLeaf, IndexedTreeLeafPreimage } from '@aztec/foundation/trees';
 
+import { IndexedTreeSnapshot, TreeSnapshot, TreeSnapshotBuilder } from '../snapshots/snapshot_builder.js';
 import { AppendOnlyTree } from './append_only_tree.js';
+import { MerkleTree } from './merkle_tree.js';
 
 /**
  * Factory for creating leaf preimages.
@@ -73,7 +75,10 @@ export interface BatchInsertionResult<TreeHeight extends number, SubtreeSiblingP
 /**
  * Indexed merkle tree.
  */
-export interface IndexedTree extends AppendOnlyTree<Buffer> {
+export interface IndexedTree
+  extends MerkleTree<Buffer>,
+    TreeSnapshotBuilder<IndexedTreeSnapshot>,
+    Omit<AppendOnlyTree<Buffer>, keyof TreeSnapshotBuilder<TreeSnapshot<Buffer>>> {
   /**
    * Finds the index of the largest leaf whose value is less than or equal to the provided value.
    * @param newValue - The new value to be inserted into the tree.

--- a/yarn-project/merkle-tree/src/interfaces/indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/interfaces/indexed_tree.ts
@@ -73,7 +73,7 @@ export interface BatchInsertionResult<TreeHeight extends number, SubtreeSiblingP
 /**
  * Indexed merkle tree.
  */
-export interface IndexedTree extends AppendOnlyTree {
+export interface IndexedTree extends AppendOnlyTree<Buffer> {
   /**
    * Finds the index of the largest leaf whose value is less than or equal to the provided value.
    * @param newValue - The new value to be inserted into the tree.

--- a/yarn-project/merkle-tree/src/interfaces/merkle_tree.ts
+++ b/yarn-project/merkle-tree/src/interfaces/merkle_tree.ts
@@ -1,4 +1,5 @@
 import { SiblingPath } from '@aztec/circuit-types';
+import { Bufferable } from '@aztec/foundation/serialize';
 
 /**
  * Defines the interface for a source of sibling paths.
@@ -15,7 +16,7 @@ export interface SiblingPathSource {
 /**
  * Defines the interface for a Merkle tree.
  */
-export interface MerkleTree extends SiblingPathSource {
+export interface MerkleTree<T extends Bufferable = Buffer> extends SiblingPathSource {
   /**
    * Returns the current root of the tree.
    * @param includeUncommitted - Set to true to include uncommitted updates in the calculated root.
@@ -48,7 +49,7 @@ export interface MerkleTree extends SiblingPathSource {
    * @param index - The index of the leaf value to be returned.
    * @param includeUncommitted - Set to true to include uncommitted updates in the data set.
    */
-  getLeafValue(index: bigint, includeUncommitted: boolean): Buffer | undefined;
+  getLeafValue(index: bigint, includeUncommitted: boolean): T | undefined;
 
   /**
    * Returns the index of a leaf given its value, or undefined if no leaf with that value is found.
@@ -56,7 +57,7 @@ export interface MerkleTree extends SiblingPathSource {
    * @param includeUncommitted - Indicates whether to include uncommitted data.
    * @returns The index of the first leaf found with a given value (undefined if not found).
    */
-  findLeafIndex(leaf: Buffer, includeUncommitted: boolean): bigint | undefined;
+  findLeafIndex(leaf: T, includeUncommitted: boolean): bigint | undefined;
 
   /**
    * Returns the first index containing a leaf value after `startIndex`.
@@ -65,5 +66,5 @@ export interface MerkleTree extends SiblingPathSource {
    * @param includeUncommitted - Indicates whether to include uncommitted data.
    * @returns The index of the first leaf found with a given value (undefined if not found).
    */
-  findLeafIndexAfter(leaf: Buffer, startIndex: bigint, includeUncommitted: boolean): bigint | undefined;
+  findLeafIndexAfter(leaf: T, startIndex: bigint, includeUncommitted: boolean): bigint | undefined;
 }

--- a/yarn-project/merkle-tree/src/interfaces/update_only_tree.ts
+++ b/yarn-project/merkle-tree/src/interfaces/update_only_tree.ts
@@ -1,14 +1,18 @@
-import { TreeSnapshotBuilder } from '../snapshots/snapshot_builder.js';
+import { Bufferable } from '@aztec/foundation/serialize';
+
+import { TreeSnapshot, TreeSnapshotBuilder } from '../snapshots/snapshot_builder.js';
 import { MerkleTree } from './merkle_tree.js';
 
 /**
  * A Merkle tree that supports updates at arbitrary indices but not appending.
  */
-export interface UpdateOnlyTree extends MerkleTree, TreeSnapshotBuilder {
+export interface UpdateOnlyTree<T extends Bufferable = Buffer>
+  extends MerkleTree<T>,
+    TreeSnapshotBuilder<TreeSnapshot<T>> {
   /**
    * Updates a leaf at a given index in the tree.
    * @param leaf - The leaf value to be updated.
    * @param index - The leaf to be updated.
    */
-  updateLeaf(leaf: Buffer, index: bigint): Promise<void>;
+  updateLeaf(leaf: T, index: bigint): Promise<void>;
 }

--- a/yarn-project/merkle-tree/src/load_tree.ts
+++ b/yarn-project/merkle-tree/src/load_tree.ts
@@ -1,3 +1,4 @@
+import { Bufferable, FromBuffer } from '@aztec/foundation/serialize';
 import { AztecKVStore } from '@aztec/kv-store';
 import { Hasher } from '@aztec/types/interfaces';
 
@@ -11,13 +12,22 @@ import { TreeBase, getTreeMeta } from './tree_base.js';
  * @param name - Name of the tree.
  * @returns The newly created tree.
  */
-export function loadTree<T extends TreeBase>(
-  c: new (store: AztecKVStore, hasher: Hasher, name: string, depth: number, size: bigint, root: Buffer) => T,
+export function loadTree<T extends TreeBase<Bufferable>, D extends FromBuffer<Bufferable>>(
+  c: new (
+    store: AztecKVStore,
+    hasher: Hasher,
+    name: string,
+    depth: number,
+    size: bigint,
+    deserializer: D,
+    root: Buffer,
+  ) => T,
   store: AztecKVStore,
   hasher: Hasher,
   name: string,
+  deserializer: D,
 ): Promise<T> {
   const { root, depth, size } = getTreeMeta(store, name);
-  const tree = new c(store, hasher, name, depth, size, root);
+  const tree = new c(store, hasher, name, depth, size, deserializer, root);
   return Promise.resolve(tree);
 }

--- a/yarn-project/merkle-tree/src/new_tree.ts
+++ b/yarn-project/merkle-tree/src/new_tree.ts
@@ -1,3 +1,4 @@
+import { Bufferable, FromBuffer } from '@aztec/foundation/serialize';
 import { AztecKVStore } from '@aztec/kv-store';
 import { Hasher } from '@aztec/types/interfaces';
 
@@ -13,15 +14,16 @@ import { TreeBase } from './tree_base.js';
  * @param prefilledSize - A number of leaves that are prefilled with values.
  * @returns The newly created tree.
  */
-export async function newTree<T extends TreeBase>(
-  c: new (store: AztecKVStore, hasher: Hasher, name: string, depth: number, size: bigint) => T,
+export async function newTree<T extends TreeBase<Bufferable>, D extends FromBuffer<Bufferable>>(
+  c: new (store: AztecKVStore, hasher: Hasher, name: string, depth: number, size: bigint, deserializer: D) => T,
   store: AztecKVStore,
   hasher: Hasher,
   name: string,
+  deserializer: D,
   depth: number,
   prefilledSize = 1,
 ): Promise<T> {
-  const tree = new c(store, hasher, name, depth, 0n);
+  const tree = new c(store, hasher, name, depth, 0n, deserializer);
   await tree.init(prefilledSize);
   return tree;
 }

--- a/yarn-project/merkle-tree/src/snapshots/append_only_snapshot.test.ts
+++ b/yarn-project/merkle-tree/src/snapshots/append_only_snapshot.test.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from '@aztec/foundation/crypto';
+import { FromBuffer } from '@aztec/foundation/serialize';
 import { AztecKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/utils';
 
@@ -8,14 +9,15 @@ import { describeSnapshotBuilderTestSuite } from './snapshot_builder_test_suite.
 
 describe('AppendOnlySnapshot', () => {
   let tree: StandardTree;
-  let snapshotBuilder: AppendOnlySnapshotBuilder;
+  let snapshotBuilder: AppendOnlySnapshotBuilder<Buffer>;
   let db: AztecKVStore;
 
   beforeEach(async () => {
     db = openTmpStore();
     const hasher = new Pedersen();
-    tree = await newTree(StandardTree, db, hasher, 'test', 4);
-    snapshotBuilder = new AppendOnlySnapshotBuilder(db, tree, hasher);
+    const deserializer: FromBuffer<Buffer> = { fromBuffer: b => b };
+    tree = await newTree(StandardTree, db, hasher, 'test', deserializer, 4);
+    snapshotBuilder = new AppendOnlySnapshotBuilder(db, tree, hasher, deserializer);
   });
 
   describeSnapshotBuilderTestSuite(

--- a/yarn-project/merkle-tree/src/snapshots/append_only_snapshot.ts
+++ b/yarn-project/merkle-tree/src/snapshots/append_only_snapshot.ts
@@ -1,4 +1,5 @@
 import { SiblingPath } from '@aztec/circuit-types';
+import { Bufferable, FromBuffer, serializeToBuffer } from '@aztec/foundation/serialize';
 import { AztecKVStore, AztecMap } from '@aztec/kv-store';
 import { Hasher } from '@aztec/types/interfaces';
 
@@ -37,19 +38,24 @@ type SnapshotMetadata = {
  *  Best case: O(H) database reads + O(1) hashes
  *  Worst case: O(H) database reads + O(H) hashes
  */
-export class AppendOnlySnapshotBuilder implements TreeSnapshotBuilder {
+export class AppendOnlySnapshotBuilder<T extends Bufferable> implements TreeSnapshotBuilder<TreeSnapshot<T>> {
   #nodeValue: AztecMap<ReturnType<typeof historicalNodeKey>, Buffer>;
   #nodeLastModifiedByBlock: AztecMap<ReturnType<typeof nodeModifiedAtBlockKey>, number>;
   #snapshotMetadata: AztecMap<number, SnapshotMetadata>;
 
-  constructor(private db: AztecKVStore, private tree: TreeBase & AppendOnlyTree, private hasher: Hasher) {
+  constructor(
+    private db: AztecKVStore,
+    private tree: TreeBase<T> & AppendOnlyTree<T>,
+    private hasher: Hasher,
+    private deserializer: FromBuffer<T>,
+  ) {
     const treeName = tree.getName();
     this.#nodeValue = db.openMap(`append_only_snapshot:${treeName}:node`);
     this.#nodeLastModifiedByBlock = db.openMap(`append_ony_snapshot:${treeName}:block`);
     this.#snapshotMetadata = db.openMap(`append_only_snapshot:${treeName}:snapshot_metadata`);
   }
 
-  getSnapshot(block: number): Promise<TreeSnapshot> {
+  getSnapshot(block: number): Promise<TreeSnapshot<T>> {
     const meta = this.#getSnapshotMeta(block);
 
     if (typeof meta === 'undefined') {
@@ -65,11 +71,12 @@ export class AppendOnlySnapshotBuilder implements TreeSnapshotBuilder {
         meta.root,
         this.tree,
         this.hasher,
+        this.deserializer,
       ),
     );
   }
 
-  snapshot(block: number): Promise<TreeSnapshot> {
+  snapshot(block: number): Promise<TreeSnapshot<T>> {
     return this.db.transaction(() => {
       const meta = this.#getSnapshotMeta(block);
       if (typeof meta !== 'undefined') {
@@ -82,6 +89,7 @@ export class AppendOnlySnapshotBuilder implements TreeSnapshotBuilder {
           meta.root,
           this.tree,
           this.hasher,
+          this.deserializer,
         );
       }
 
@@ -136,6 +144,7 @@ export class AppendOnlySnapshotBuilder implements TreeSnapshotBuilder {
         root,
         this.tree,
         this.hasher,
+        this.deserializer,
       );
     });
   }
@@ -148,15 +157,16 @@ export class AppendOnlySnapshotBuilder implements TreeSnapshotBuilder {
 /**
  * a
  */
-class AppendOnlySnapshot implements TreeSnapshot {
+class AppendOnlySnapshot<T extends Bufferable> implements TreeSnapshot<T> {
   constructor(
     private nodes: AztecMap<string, Buffer>,
     private nodeHistory: AztecMap<string, number>,
     private block: number,
     private leafCount: bigint,
     private historicalRoot: Buffer,
-    private tree: TreeBase & AppendOnlyTree,
+    private tree: TreeBase<T> & AppendOnlyTree<T>,
     private hasher: Hasher,
+    private deserializer: FromBuffer<T>,
   ) {}
 
   public getSiblingPath<N extends number>(index: bigint): SiblingPath<N> {
@@ -191,7 +201,7 @@ class AppendOnlySnapshot implements TreeSnapshot {
     return this.historicalRoot;
   }
 
-  getLeafValue(index: bigint): Buffer | undefined {
+  getLeafValue(index: bigint): T | undefined {
     const leafLevel = this.getDepth();
     const blockNumber = this.#getBlockNumberThatModifiedNode(leafLevel, index);
 
@@ -202,7 +212,8 @@ class AppendOnlySnapshot implements TreeSnapshot {
 
     // leaf was set some time in the past
     if (blockNumber <= this.block) {
-      return this.nodes.get(historicalNodeKey(leafLevel, index));
+      const val = this.nodes.get(historicalNodeKey(leafLevel, index));
+      return val ? this.deserializer.fromBuffer(val) : undefined;
     }
 
     // leaf has been set but in a block in the future
@@ -249,15 +260,16 @@ class AppendOnlySnapshot implements TreeSnapshot {
     return this.nodeHistory.get(nodeModifiedAtBlockKey(level, index));
   }
 
-  findLeafIndex(value: Buffer): bigint | undefined {
+  findLeafIndex(value: T): bigint | undefined {
     return this.findLeafIndexAfter(value, 0n);
   }
 
-  findLeafIndexAfter(value: Buffer, startIndex: bigint): bigint | undefined {
+  findLeafIndexAfter(value: T, startIndex: bigint): bigint | undefined {
+    const valueBuffer = serializeToBuffer(value);
     const numLeaves = this.getNumLeaves();
     for (let i = startIndex; i < numLeaves; i++) {
       const currentValue = this.getLeafValue(i);
-      if (currentValue && currentValue.equals(value)) {
+      if (currentValue && serializeToBuffer(currentValue).equals(valueBuffer)) {
         return i;
       }
     }

--- a/yarn-project/merkle-tree/src/snapshots/full_snapshot.test.ts
+++ b/yarn-project/merkle-tree/src/snapshots/full_snapshot.test.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from '@aztec/foundation/crypto';
+import { FromBuffer } from '@aztec/foundation/serialize';
 import { AztecKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/utils';
 
@@ -8,13 +9,14 @@ import { describeSnapshotBuilderTestSuite } from './snapshot_builder_test_suite.
 
 describe('FullSnapshotBuilder', () => {
   let tree: StandardTree;
-  let snapshotBuilder: FullTreeSnapshotBuilder;
+  let snapshotBuilder: FullTreeSnapshotBuilder<Buffer>;
   let db: AztecKVStore;
 
   beforeEach(async () => {
     db = openTmpStore();
-    tree = await newTree(StandardTree, db, new Pedersen(), 'test', 4);
-    snapshotBuilder = new FullTreeSnapshotBuilder(db, tree);
+    const deserializer: FromBuffer<Buffer> = { fromBuffer: b => b };
+    tree = await newTree(StandardTree, db, new Pedersen(), 'test', deserializer, 4);
+    snapshotBuilder = new FullTreeSnapshotBuilder(db, tree, deserializer);
   });
 
   describeSnapshotBuilderTestSuite(

--- a/yarn-project/merkle-tree/src/snapshots/full_snapshot.ts
+++ b/yarn-project/merkle-tree/src/snapshots/full_snapshot.ts
@@ -1,3 +1,6 @@
+import { Bufferable, FromBuffer } from '@aztec/foundation/serialize';
+import { AztecKVStore } from '@aztec/kv-store';
+
 import { TreeBase } from '../tree_base.js';
 import { BaseFullTreeSnapshot, BaseFullTreeSnapshotBuilder } from './base_full_snapshot.js';
 import { TreeSnapshot, TreeSnapshotBuilder } from './snapshot_builder.js';
@@ -16,11 +19,15 @@ import { TreeSnapshot, TreeSnapshotBuilder } from './snapshot_builder.js';
  * Worst case space complexity: O(N * M)
  * Sibling path access: O(H) database reads
  */
-export class FullTreeSnapshotBuilder
-  extends BaseFullTreeSnapshotBuilder<TreeBase, TreeSnapshot>
-  implements TreeSnapshotBuilder<TreeSnapshot>
+export class FullTreeSnapshotBuilder<T extends Bufferable>
+  extends BaseFullTreeSnapshotBuilder<TreeBase<T>, TreeSnapshot<T>>
+  implements TreeSnapshotBuilder<TreeSnapshot<T>>
 {
-  protected openSnapshot(root: Buffer, numLeaves: bigint): TreeSnapshot {
-    return new BaseFullTreeSnapshot(this.nodes, root, numLeaves, this.tree);
+  constructor(db: AztecKVStore, tree: TreeBase<T>, private deserializer: FromBuffer<T>) {
+    super(db, tree);
+  }
+
+  protected openSnapshot(root: Buffer, numLeaves: bigint): TreeSnapshot<T> {
+    return new BaseFullTreeSnapshot(this.nodes, root, numLeaves, this.tree, this.deserializer);
   }
 }

--- a/yarn-project/merkle-tree/src/snapshots/indexed_tree_snapshot.test.ts
+++ b/yarn-project/merkle-tree/src/snapshots/indexed_tree_snapshot.test.ts
@@ -9,7 +9,15 @@ import { IndexedTreeSnapshotBuilder } from './indexed_tree_snapshot.js';
 import { describeSnapshotBuilderTestSuite } from './snapshot_builder_test_suite.js';
 
 class NullifierTree extends StandardIndexedTreeWithAppend {
-  constructor(db: AztecKVStore, hasher: Hasher, name: string, depth: number, size: bigint = 0n, root?: Buffer) {
+  constructor(
+    db: AztecKVStore,
+    hasher: Hasher,
+    name: string,
+    depth: number,
+    size: bigint = 0n,
+    _noop: any,
+    root?: Buffer,
+  ) {
     super(db, hasher, name, depth, size, NullifierLeafPreimage, NullifierLeaf, root);
   }
 }
@@ -21,7 +29,7 @@ describe('IndexedTreeSnapshotBuilder', () => {
 
   beforeEach(async () => {
     db = openTmpStore();
-    tree = await newTree(NullifierTree, db, new Pedersen(), 'test', 4);
+    tree = await newTree(NullifierTree, db, new Pedersen(), 'test', { fromBuffer: (b: Buffer) => b }, 4);
     snapshotBuilder = new IndexedTreeSnapshotBuilder(db, tree, NullifierLeafPreimage);
   });
 

--- a/yarn-project/merkle-tree/src/snapshots/indexed_tree_snapshot.ts
+++ b/yarn-project/merkle-tree/src/snapshots/indexed_tree_snapshot.ts
@@ -10,11 +10,11 @@ const snapshotLeafValue = (node: Buffer, index: bigint) => 'snapshot:leaf:' + no
 
 /** a */
 export class IndexedTreeSnapshotBuilder
-  extends BaseFullTreeSnapshotBuilder<IndexedTree & TreeBase, IndexedTreeSnapshot>
+  extends BaseFullTreeSnapshotBuilder<IndexedTree & TreeBase<Buffer>, IndexedTreeSnapshot>
   implements TreeSnapshotBuilder<IndexedTreeSnapshot>
 {
   leaves: AztecMap<string, Buffer>;
-  constructor(store: AztecKVStore, tree: IndexedTree & TreeBase, private leafPreimageBuilder: PreimageFactory) {
+  constructor(store: AztecKVStore, tree: IndexedTree & TreeBase<Buffer>, private leafPreimageBuilder: PreimageFactory) {
     super(store, tree);
     this.leaves = store.openMap('indexed_tree_snapshot:' + tree.getName());
   }
@@ -32,16 +32,16 @@ export class IndexedTreeSnapshotBuilder
 }
 
 /** A snapshot of an indexed tree at a particular point in time */
-class IndexedTreeSnapshotImpl extends BaseFullTreeSnapshot implements IndexedTreeSnapshot {
+class IndexedTreeSnapshotImpl extends BaseFullTreeSnapshot<Buffer> implements IndexedTreeSnapshot {
   constructor(
     db: AztecMap<string, [Buffer, Buffer]>,
     private leaves: AztecMap<string, Buffer>,
     historicRoot: Buffer,
     numLeaves: bigint,
-    tree: IndexedTree & TreeBase,
+    tree: IndexedTree & TreeBase<Buffer>,
     private leafPreimageBuilder: PreimageFactory,
   ) {
-    super(db, historicRoot, numLeaves, tree);
+    super(db, historicRoot, numLeaves, tree, { fromBuffer: buf => buf });
   }
 
   getLeafValue(index: bigint): Buffer | undefined {

--- a/yarn-project/merkle-tree/src/snapshots/snapshot_builder.ts
+++ b/yarn-project/merkle-tree/src/snapshots/snapshot_builder.ts
@@ -1,10 +1,11 @@
 import { SiblingPath } from '@aztec/circuit-types';
+import { Bufferable } from '@aztec/foundation/serialize';
 import { IndexedTreeLeafPreimage } from '@aztec/foundation/trees';
 
 /**
  * An interface for a tree that can record snapshots of its contents.
  */
-export interface TreeSnapshotBuilder<S extends TreeSnapshot = TreeSnapshot> {
+export interface TreeSnapshotBuilder<S extends TreeSnapshot<Bufferable>> {
   /**
    * Creates a snapshot of the tree at the given version.
    * @param block - The version to snapshot the tree at.
@@ -21,7 +22,7 @@ export interface TreeSnapshotBuilder<S extends TreeSnapshot = TreeSnapshot> {
 /**
  * A tree snapshot
  */
-export interface TreeSnapshot {
+export interface TreeSnapshot<T extends Bufferable> {
   /**
    * Returns the current root of the tree.
    */
@@ -41,7 +42,7 @@ export interface TreeSnapshot {
    * Returns the value of a leaf at the specified index.
    * @param index - The index of the leaf value to be returned.
    */
-  getLeafValue(index: bigint): Buffer | undefined;
+  getLeafValue(index: bigint): T | undefined;
 
   /**
    * Returns the sibling path for a requested leaf index.
@@ -55,7 +56,7 @@ export interface TreeSnapshot {
    * @param value - The leaf value to look for.
    * @returns The index of the first leaf found with a given value (undefined if not found).
    */
-  findLeafIndex(value: Buffer): bigint | undefined;
+  findLeafIndex(value: T): bigint | undefined;
 
   /**
    * Returns the first index containing a leaf value after `startIndex`.
@@ -63,11 +64,11 @@ export interface TreeSnapshot {
    * @param startIndex - The index to start searching from (used when skipping nullified messages)
    * @returns The index of the first leaf found with a given value (undefined if not found).
    */
-  findLeafIndexAfter(leaf: Buffer, startIndex: bigint): bigint | undefined;
+  findLeafIndexAfter(leaf: T, startIndex: bigint): bigint | undefined;
 }
 
 /** A snapshot of an indexed tree */
-export interface IndexedTreeSnapshot extends TreeSnapshot {
+export interface IndexedTreeSnapshot extends TreeSnapshot<Buffer> {
   /**
    * Gets the historical data for a leaf
    * @param index - The index of the leaf to get the data for

--- a/yarn-project/merkle-tree/src/snapshots/snapshot_builder_test_suite.ts
+++ b/yarn-project/merkle-tree/src/snapshots/snapshot_builder_test_suite.ts
@@ -1,14 +1,18 @@
 import { randomBigInt } from '@aztec/foundation/crypto';
+import { Bufferable } from '@aztec/foundation/serialize';
+
+import { jest } from '@jest/globals';
 
 import { TreeBase } from '../tree_base.js';
-import { TreeSnapshotBuilder } from './snapshot_builder.js';
+import { TreeSnapshot, TreeSnapshotBuilder } from './snapshot_builder.js';
+
+jest.setTimeout(1_000_000);
 
 /** Creates a test suit for snapshots */
-export function describeSnapshotBuilderTestSuite<T extends TreeBase, S extends TreeSnapshotBuilder>(
-  getTree: () => T,
-  getSnapshotBuilder: () => S,
-  modifyTree: (tree: T) => Promise<void>,
-) {
+export function describeSnapshotBuilderTestSuite<
+  T extends TreeBase<Bufferable>,
+  S extends TreeSnapshotBuilder<TreeSnapshot<Bufferable>>,
+>(getTree: () => T, getSnapshotBuilder: () => S, modifyTree: (tree: T) => Promise<void>) {
   describe('SnapshotBuilder', () => {
     let tree: T;
     let snapshotBuilder: S;
@@ -34,7 +38,9 @@ export function describeSnapshotBuilderTestSuite<T extends TreeBase, S extends T
 
         const block = 1;
         const snapshot = await snapshotBuilder.snapshot(block);
-        await expect(snapshotBuilder.snapshot(block)).resolves.toEqual(snapshot);
+        const newSnapshot = await snapshotBuilder.snapshot(block);
+
+        expect(newSnapshot.getRoot()).toEqual(snapshot.getRoot());
       });
 
       it('returns the same path if tree has not diverged', async () => {

--- a/yarn-project/merkle-tree/src/snapshots/snapshot_builder_test_suite.ts
+++ b/yarn-project/merkle-tree/src/snapshots/snapshot_builder_test_suite.ts
@@ -6,7 +6,7 @@ import { jest } from '@jest/globals';
 import { TreeBase } from '../tree_base.js';
 import { TreeSnapshot, TreeSnapshotBuilder } from './snapshot_builder.js';
 
-jest.setTimeout(1_000_000);
+jest.setTimeout(50_000);
 
 /** Creates a test suit for snapshots */
 export function describeSnapshotBuilderTestSuite<

--- a/yarn-project/merkle-tree/src/sparse_tree/sparse_tree.test.ts
+++ b/yarn-project/merkle-tree/src/sparse_tree/sparse_tree.test.ts
@@ -15,12 +15,28 @@ import { SparseTree } from './sparse_tree.js';
 
 const log = createDebugLogger('aztec:sparse_tree_test');
 
-const createDb = async (db: AztecKVStore, hasher: Hasher, name: string, depth: number): Promise<UpdateOnlyTree> => {
-  return await newTree(SparseTree, db, hasher, name, depth);
+const createDb = async (
+  db: AztecKVStore,
+  hasher: Hasher,
+  name: string,
+  depth: number,
+): Promise<UpdateOnlyTree<Buffer>> => {
+  return await newTree(
+    SparseTree,
+    db,
+    hasher,
+    name,
+    {
+      fromBuffer: (buffer: Buffer): Buffer => buffer,
+    },
+    depth,
+  );
 };
 
-const createFromName = async (db: AztecKVStore, hasher: Hasher, name: string): Promise<UpdateOnlyTree> => {
-  return await loadTree(SparseTree, db, hasher, name);
+const createFromName = async (db: AztecKVStore, hasher: Hasher, name: string): Promise<UpdateOnlyTree<Buffer>> => {
+  return await loadTree(SparseTree, db, hasher, name, {
+    fromBuffer: (buffer: Buffer): Buffer => buffer,
+  });
 };
 
 const TEST_TREE_DEPTH = 3;

--- a/yarn-project/merkle-tree/src/sparse_tree/sparse_tree.ts
+++ b/yarn-project/merkle-tree/src/sparse_tree/sparse_tree.ts
@@ -1,3 +1,5 @@
+import { Bufferable, serializeToBuffer } from '@aztec/foundation/serialize';
+
 import { UpdateOnlyTree } from '../interfaces/update_only_tree.js';
 import { FullTreeSnapshotBuilder } from '../snapshots/full_snapshot.js';
 import { TreeSnapshot } from '../snapshots/snapshot_builder.js';
@@ -6,20 +8,21 @@ import { INITIAL_LEAF, TreeBase } from '../tree_base.js';
 /**
  * A Merkle tree implementation that uses a LevelDB database to store the tree.
  */
-export class SparseTree extends TreeBase implements UpdateOnlyTree {
-  #snapshotBuilder = new FullTreeSnapshotBuilder(this.store, this);
+export class SparseTree<T extends Bufferable> extends TreeBase<T> implements UpdateOnlyTree<T> {
+  #snapshotBuilder = new FullTreeSnapshotBuilder(this.store, this, this.deserializer);
   /**
    * Updates a leaf in the tree.
    * @param leaf - New contents of the leaf.
    * @param index - Index of the leaf to be updated.
    */
-  public updateLeaf(leaf: Buffer, index: bigint): Promise<void> {
+  public updateLeaf(value: T, index: bigint): Promise<void> {
     if (index > this.maxIndex) {
       throw Error(`Index out of bounds. Index ${index}, max index: ${this.maxIndex}.`);
     }
 
+    const leaf = serializeToBuffer(value);
     const insertingZeroElement = leaf.equals(INITIAL_LEAF);
-    const originallyZeroElement = this.getLeafValue(index, true)?.equals(INITIAL_LEAF);
+    const originallyZeroElement = this.getLeafBuffer(index, true)?.equals(INITIAL_LEAF);
     if (insertingZeroElement && originallyZeroElement) {
       return Promise.resolve();
     }
@@ -35,19 +38,19 @@ export class SparseTree extends TreeBase implements UpdateOnlyTree {
     return Promise.resolve();
   }
 
-  public snapshot(block: number): Promise<TreeSnapshot> {
+  public snapshot(block: number): Promise<TreeSnapshot<T>> {
     return this.#snapshotBuilder.snapshot(block);
   }
 
-  public getSnapshot(block: number): Promise<TreeSnapshot> {
+  public getSnapshot(block: number): Promise<TreeSnapshot<T>> {
     return this.#snapshotBuilder.getSnapshot(block);
   }
 
-  public findLeafIndex(_value: Buffer, _includeUncommitted: boolean): bigint | undefined {
+  public findLeafIndex(_value: T, _includeUncommitted: boolean): bigint | undefined {
     throw new Error('Finding leaf index is not supported for sparse trees');
   }
 
-  public findLeafIndexAfter(_value: Buffer, _startIndex: bigint, _includeUncommitted: boolean): bigint | undefined {
+  public findLeafIndexAfter(_value: T, _startIndex: bigint, _includeUncommitted: boolean): bigint | undefined {
     throw new Error('Finding leaf index is not supported for sparse trees');
   }
 }

--- a/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
@@ -1,6 +1,7 @@
 import { SiblingPath } from '@aztec/circuit-types';
 import { TreeInsertionStats } from '@aztec/circuit-types/stats';
 import { toBufferBE } from '@aztec/foundation/bigint-buffer';
+import { FromBuffer } from '@aztec/foundation/serialize';
 import { Timer } from '@aztec/foundation/timer';
 import { IndexedTreeLeaf, IndexedTreeLeafPreimage } from '@aztec/foundation/trees';
 import { AztecKVStore, AztecMap } from '@aztec/kv-store';
@@ -51,10 +52,14 @@ function getEmptyLowLeafWitness<N extends number>(
   };
 }
 
+export const noopDeserializer: FromBuffer<Buffer> = {
+  fromBuffer: (buf: Buffer) => buf,
+};
+
 /**
  * Standard implementation of an indexed tree.
  */
-export class StandardIndexedTree extends TreeBase implements IndexedTree {
+export class StandardIndexedTree extends TreeBase<Buffer> implements IndexedTree {
   #snapshotBuilder = new IndexedTreeSnapshotBuilder(this.store, this, this.leafPreimageFactory);
 
   protected cachedLeafPreimages: { [key: string]: IndexedTreeLeafPreimage } = {};
@@ -71,7 +76,7 @@ export class StandardIndexedTree extends TreeBase implements IndexedTree {
     protected leafFactory: LeafFactory,
     root?: Buffer,
   ) {
-    super(store, hasher, name, depth, size, root);
+    super(store, hasher, name, depth, size, noopDeserializer, root);
     this.leaves = store.openMap(`tree_${name}_leaves`);
     this.leafIndex = store.openMap(`tree_${name}_leaf_index`);
   }

--- a/yarn-project/merkle-tree/src/standard_indexed_tree/test/standard_indexed_tree.test.ts
+++ b/yarn-project/merkle-tree/src/standard_indexed_tree/test/standard_indexed_tree.test.ts
@@ -7,6 +7,7 @@ import {
   PublicDataTreeLeafPreimage,
 } from '@aztec/circuits.js';
 import { toBufferBE } from '@aztec/foundation/bigint-buffer';
+import { FromBuffer } from '@aztec/foundation/serialize';
 import { AztecKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/utils';
 import { Hasher } from '@aztec/types/interfaces';
@@ -16,23 +17,43 @@ import { treeTestSuite } from '../../test/test_suite.js';
 import { StandardIndexedTreeWithAppend } from './standard_indexed_tree_with_append.js';
 
 class NullifierTree extends StandardIndexedTreeWithAppend {
-  constructor(store: AztecKVStore, hasher: Hasher, name: string, depth: number, size: bigint = 0n, root?: Buffer) {
+  constructor(
+    store: AztecKVStore,
+    hasher: Hasher,
+    name: string,
+    depth: number,
+    size: bigint = 0n,
+    _noop: any,
+    root?: Buffer,
+  ) {
     super(store, hasher, name, depth, size, NullifierLeafPreimage, NullifierLeaf, root);
   }
 }
 
 class PublicDataTree extends StandardIndexedTreeWithAppend {
-  constructor(store: AztecKVStore, hasher: Hasher, name: string, depth: number, size: bigint = 0n, root?: Buffer) {
+  constructor(
+    store: AztecKVStore,
+    hasher: Hasher,
+    name: string,
+    depth: number,
+    size: bigint = 0n,
+    _noop: any,
+    root?: Buffer,
+  ) {
     super(store, hasher, name, depth, size, PublicDataTreeLeafPreimage, PublicDataTreeLeaf, root);
   }
 }
 
+const noopDeserializer: FromBuffer<Buffer> = {
+  fromBuffer: (buffer: Buffer) => buffer,
+};
+
 const createDb = async (store: AztecKVStore, hasher: Hasher, name: string, depth: number, prefilledSize = 1) => {
-  return await newTree(NullifierTree, store, hasher, name, depth, prefilledSize);
+  return await newTree(NullifierTree, store, hasher, name, noopDeserializer, depth, prefilledSize);
 };
 
 const createFromName = async (store: AztecKVStore, hasher: Hasher, name: string) => {
-  return await loadTree(NullifierTree, store, hasher, name);
+  return await loadTree(NullifierTree, store, hasher, name, noopDeserializer);
 };
 
 const createNullifierTreeLeafHashInputs = (value: number, nextIndex: number, nextValue: number) => {
@@ -521,7 +542,7 @@ describe('StandardIndexedTreeSpecific', () => {
     it('should be able to upsert leaves', async () => {
       // Create a depth-3 indexed merkle tree
       const db = openTmpStore();
-      const tree = await newTree(PublicDataTree, db, pedersen, 'test', 3, 1);
+      const tree = await newTree(PublicDataTree, db, pedersen, 'test', {}, 3, 1);
 
       /**
        * Initial state:

--- a/yarn-project/merkle-tree/src/standard_tree/standard_tree.test.ts
+++ b/yarn-project/merkle-tree/src/standard_tree/standard_tree.test.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from '@aztec/foundation/crypto';
+import { FromBuffer } from '@aztec/foundation/serialize';
 import { AztecKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/utils';
 import { Hasher } from '@aztec/types/interfaces';
@@ -11,12 +12,16 @@ import { PedersenWithCounter } from '../test/utils/pedersen_with_counter.js';
 import { INITIAL_LEAF } from '../tree_base.js';
 import { StandardTree } from './standard_tree.js';
 
+const noopDeserializer: FromBuffer<Buffer> = {
+  fromBuffer: (buffer: Buffer) => buffer,
+};
+
 const createDb = async (store: AztecKVStore, hasher: Hasher, name: string, depth: number) => {
-  return await newTree(StandardTree, store, hasher, name, depth);
+  return await newTree(StandardTree, store, hasher, name, noopDeserializer, depth);
 };
 
 const createFromName = async (store: AztecKVStore, hasher: Hasher, name: string) => {
-  return await loadTree(StandardTree, store, hasher, name);
+  return await loadTree(StandardTree, store, hasher, name, noopDeserializer);
 };
 
 treeTestSuite('StandardTree', createDb, createFromName);

--- a/yarn-project/noir-protocol-circuits-types/src/noir_test_gen.test.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/noir_test_gen.test.ts
@@ -98,7 +98,7 @@ describe('Data generation for noir tests', () => {
 
   it('Computes a note hash tree', async () => {
     const indexes = new Array(128).fill(null).map((_, i) => BigInt(i));
-    const leaves = indexes.map(i => new Fr(i + 1n).toBuffer());
+    const leaves = indexes.map(i => new Fr(i + 1n));
 
     const db = openTmpStore();
 
@@ -107,6 +107,8 @@ describe('Data generation for noir tests', () => {
       new Pedersen(),
       `${MerkleTreeId[MerkleTreeId.NOTE_HASH_TREE]}`,
       NOTE_HASH_TREE_HEIGHT,
+      0n,
+      Fr,
     );
 
     await noteHashTree.appendLeaves(leaves);

--- a/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
+++ b/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
@@ -94,7 +94,7 @@ export async function buildBaseRollupInput(
 
   // Update the note hash trees with the new items being inserted to get the new roots
   // that will be used by the next iteration of the base rollup circuit, skipping the empty ones
-  const newNoteHashes = tx.data.combinedData.newNoteHashes.map(x => x.value.toBuffer());
+  const newNoteHashes = tx.data.combinedData.newNoteHashes.map(x => x.value);
   await db.appendLeaves(MerkleTreeId.NOTE_HASH_TREE, newNoteHashes);
 
   // The read witnesses for a given TX should be generated before the writes of the same TX are applied.
@@ -214,10 +214,7 @@ export async function executeRootRollupCircuit(
   const rootInput = await getRootRollupInput(...left, ...right, l1ToL2Roots, newL1ToL2Messages, db);
 
   // Update the local trees to include the new l1 to l2 messages
-  await db.appendLeaves(
-    MerkleTreeId.L1_TO_L2_MESSAGE_TREE,
-    newL1ToL2Messages.map(m => m.toBuffer()),
-  );
+  await db.appendLeaves(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, newL1ToL2Messages);
 
   // Simulate and get proof for the root circuit
   const rootOutput = await simulator.rootRollupCircuit(rootInput);

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.test.ts
@@ -136,7 +136,7 @@ describe('prover/tx-prover', () => {
             .sort(sideEffectCmp),
           SideEffect.empty(),
           MAX_NEW_NOTE_HASHES_PER_TX,
-        ).map(l => l.value.toBuffer()),
+        ).map(l => l.value),
       ),
     );
     await expectsDb.batchInsert(

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -162,7 +162,7 @@ describe('sequencer', () => {
 
     // We make a nullifier from tx1 a part of the nullifier tree, so it gets rejected as double spend
     const doubleSpendNullifier = doubleSpendTx.data.end.newNullifiers[0].value.toBuffer();
-    merkleTreeOps.findLeafIndex.mockImplementation((treeId: MerkleTreeId, value: Buffer) => {
+    merkleTreeOps.findLeafIndex.mockImplementation((treeId: MerkleTreeId, value: any) => {
       return Promise.resolve(
         treeId === MerkleTreeId.NULLIFIER_TREE && value.equals(doubleSpendNullifier) ? 1n : undefined,
       );

--- a/yarn-project/sequencer-client/src/simulator/public_executor.ts
+++ b/yarn-project/sequencer-client/src/simulator/public_executor.ts
@@ -235,11 +235,7 @@ export class WorldStateDB implements CommitmentsDB {
     // We iterate over messages until we find one whose nullifier is not in the nullifier tree --> we need to check
     // for nullifiers because messages can have duplicates.
     do {
-      messageIndex = (await this.db.findLeafIndexAfter(
-        MerkleTreeId.L1_TO_L2_MESSAGE_TREE,
-        messageHash.toBuffer(),
-        startIndex,
-      ))!;
+      messageIndex = (await this.db.findLeafIndexAfter(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, messageHash, startIndex))!;
       if (messageIndex === undefined) {
         throw new Error(`No non-nullified L1 to L2 message found for message hash ${messageHash.toString()}`);
       }
@@ -259,7 +255,7 @@ export class WorldStateDB implements CommitmentsDB {
   }
 
   public async getCommitmentIndex(commitment: Fr): Promise<bigint | undefined> {
-    return await this.db.findLeafIndex(MerkleTreeId.NOTE_HASH_TREE, commitment.toBuffer());
+    return await this.db.findLeafIndex(MerkleTreeId.NOTE_HASH_TREE, commitment);
   }
 
   public async getNullifierIndex(nullifier: Fr): Promise<bigint | undefined> {

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -83,7 +83,7 @@ describe('Private Execution test suite', () => {
     l1ToL2Messages: L1_TO_L2_MSG_TREE_HEIGHT,
   };
 
-  let trees: { [name: keyof typeof treeHeights]: AppendOnlyTree } = {};
+  let trees: { [name: keyof typeof treeHeights]: AppendOnlyTree<Fr> } = {};
   const txContextFields: FieldsOf<TxContext> = {
     isFeePaymentTx: false,
     isRebatePaymentTx: false,
@@ -127,11 +127,11 @@ describe('Private Execution test suite', () => {
     if (!trees[name]) {
       const db = openTmpStore();
       const pedersen = new Pedersen();
-      trees[name] = await newTree(StandardTree, db, pedersen, name, treeHeights[name]);
+      trees[name] = await newTree(StandardTree, db, pedersen, name, Fr, treeHeights[name]);
     }
     const tree = trees[name];
 
-    await tree.appendLeaves(leaves.map(l => l.toBuffer()));
+    await tree.appendLeaves(leaves);
 
     // Create a new snapshot.
     const newSnap = new AppendOnlyTreeSnapshot(Fr.fromBuffer(tree.getRoot(true)), Number(tree.getNumLeaves(true)));

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
@@ -114,8 +114,10 @@ describe('server_world_state_synchronizer', () => {
       new SHA256Trunc(),
       'empty_subtree_in_hash',
       L1_TO_L2_MSG_SUBTREE_HEIGHT,
+      0n,
+      Fr,
     );
-    await tree.appendLeaves(l1ToL2Messages.map(msg => msg.toBuffer()));
+    await tree.appendLeaves(l1ToL2Messages);
     inHash = tree.getRoot(true);
   });
 

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -245,8 +245,10 @@ export class ServerWorldStateSynchronizer implements WorldStateSynchronizer {
       new SHA256Trunc(),
       'temp_in_hash_check',
       L1_TO_L2_MSG_SUBTREE_HEIGHT,
+      0n,
+      Fr,
     );
-    await tree.appendLeaves(l1ToL2Messages.map(msg => msg.toBuffer()));
+    await tree.appendLeaves(l1ToL2Messages);
 
     if (!tree.getRoot(true).equals(inHash)) {
       throw new Error('Obtained L1 to L2 messages failed to be hashed to the block inHash');

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
@@ -1,4 +1,5 @@
-import { MAX_NEW_NULLIFIERS_PER_TX, MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX } from '@aztec/circuits.js';
+import { MerkleTreeId } from '@aztec/circuit-types';
+import { Fr, MAX_NEW_NULLIFIERS_PER_TX, MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX } from '@aztec/circuits.js';
 import { IndexedTreeSnapshot, TreeSnapshot } from '@aztec/merkle-tree';
 
 import { MerkleTreeOperations } from './merkle_tree_operations.js';
@@ -40,6 +41,14 @@ type MerkleTreeSetters =
   | 'handleL2BlockAndMessages'
   | 'batchInsert';
 
+export type TreeSnapshots = {
+  [MerkleTreeId.NULLIFIER_TREE]: IndexedTreeSnapshot;
+  [MerkleTreeId.NOTE_HASH_TREE]: TreeSnapshot<Fr>;
+  [MerkleTreeId.PUBLIC_DATA_TREE]: IndexedTreeSnapshot;
+  [MerkleTreeId.L1_TO_L2_MESSAGE_TREE]: TreeSnapshot<Fr>;
+  [MerkleTreeId.ARCHIVE]: TreeSnapshot<Fr>;
+};
+
 /**
  * Defines the interface for operations on a set of Merkle Trees configuring whether to return committed or uncommitted data.
  */
@@ -52,5 +61,5 @@ export type MerkleTreeDb = {
      * Returns a snapshot of the current state of the trees.
      * @param block - The block number to take the snapshot at.
      */
-    getSnapshot(block: number): Promise<ReadonlyArray<TreeSnapshot | IndexedTreeSnapshot>>;
+    getSnapshot(block: number): Promise<TreeSnapshots>;
   };

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -524,17 +524,20 @@ export class MerkleTrees implements MerkleTreeDb {
   }
 
   public async getSnapshot(blockNumber: number): Promise<TreeSnapshots> {
-    // TODO #5448 fix "as any"
+    const snapshots = await Promise.all([
+      this.trees[MerkleTreeId.NULLIFIER_TREE].getSnapshot(blockNumber),
+      this.trees[MerkleTreeId.NOTE_HASH_TREE].getSnapshot(blockNumber),
+      this.trees[MerkleTreeId.PUBLIC_DATA_TREE].getSnapshot(blockNumber),
+      this.trees[MerkleTreeId.L1_TO_L2_MESSAGE_TREE].getSnapshot(blockNumber),
+      this.trees[MerkleTreeId.ARCHIVE].getSnapshot(blockNumber),
+    ]);
+
     return {
-      [MerkleTreeId.NULLIFIER_TREE]: (await this.trees[MerkleTreeId.NULLIFIER_TREE].getSnapshot(blockNumber)) as any,
-      [MerkleTreeId.NOTE_HASH_TREE]: await this.trees[MerkleTreeId.NOTE_HASH_TREE].getSnapshot(blockNumber),
-      [MerkleTreeId.PUBLIC_DATA_TREE]: (await this.trees[MerkleTreeId.PUBLIC_DATA_TREE].getSnapshot(
-        blockNumber,
-      )) as any,
-      [MerkleTreeId.L1_TO_L2_MESSAGE_TREE]: await this.trees[MerkleTreeId.L1_TO_L2_MESSAGE_TREE].getSnapshot(
-        blockNumber,
-      ),
-      [MerkleTreeId.ARCHIVE]: await this.trees[MerkleTreeId.ARCHIVE].getSnapshot(blockNumber),
+      [MerkleTreeId.NULLIFIER_TREE]: snapshots[0],
+      [MerkleTreeId.NOTE_HASH_TREE]: snapshots[1],
+      [MerkleTreeId.PUBLIC_DATA_TREE]: snapshots[2],
+      [MerkleTreeId.L1_TO_L2_MESSAGE_TREE]: snapshots[3],
+      [MerkleTreeId.ARCHIVE]: snapshots[4],
     };
   }
 

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -40,10 +40,17 @@ import {
 } from '@aztec/merkle-tree';
 import { Hasher } from '@aztec/types/interfaces';
 
-import { INITIAL_NULLIFIER_TREE_SIZE, INITIAL_PUBLIC_DATA_TREE_SIZE, MerkleTreeDb } from './merkle_tree_db.js';
+import {
+  INITIAL_NULLIFIER_TREE_SIZE,
+  INITIAL_PUBLIC_DATA_TREE_SIZE,
+  MerkleTreeDb,
+  TreeSnapshots,
+} from './merkle_tree_db.js';
 import {
   HandleL2BlockAndMessagesResult,
   IndexedTreeId,
+  MerkleTreeLeafType,
+  MerkleTreeMap,
   MerkleTreeOperations,
   TreeInfo,
 } from './merkle_tree_operations.js';
@@ -53,7 +60,15 @@ import { MerkleTreeOperationsFacade } from './merkle_tree_operations_facade.js';
  * The nullifier tree is an indexed tree.
  */
 class NullifierTree extends StandardIndexedTree {
-  constructor(store: AztecKVStore, hasher: Hasher, name: string, depth: number, size: bigint = 0n, root?: Buffer) {
+  constructor(
+    store: AztecKVStore,
+    hasher: Hasher,
+    name: string,
+    depth: number,
+    size: bigint = 0n,
+    _noop: any,
+    root?: Buffer,
+  ) {
     super(store, hasher, name, depth, size, NullifierLeafPreimage, NullifierLeaf, root);
   }
 }
@@ -62,7 +77,15 @@ class NullifierTree extends StandardIndexedTree {
  * The public data tree is an indexed tree.
  */
 class PublicDataTree extends StandardIndexedTree {
-  constructor(store: AztecKVStore, hasher: Hasher, name: string, depth: number, size: bigint = 0n, root?: Buffer) {
+  constructor(
+    store: AztecKVStore,
+    hasher: Hasher,
+    name: string,
+    depth: number,
+    size: bigint = 0n,
+    _noop: any,
+    root?: Buffer,
+  ) {
     super(store, hasher, name, depth, size, PublicDataTreeLeafPreimage, PublicDataTreeLeaf, root);
   }
 }
@@ -71,7 +94,8 @@ class PublicDataTree extends StandardIndexedTree {
  * A convenience class for managing multiple merkle trees.
  */
 export class MerkleTrees implements MerkleTreeDb {
-  private trees: (AppendOnlyTree | UpdateOnlyTree)[] = [];
+  // gets initialized in #init
+  private trees: MerkleTreeMap = null as any;
   private jobQueue = new SerialQueue();
 
   private constructor(private store: AztecKVStore, private log: DebugLogger) {}
@@ -101,14 +125,16 @@ export class MerkleTrees implements MerkleTreeDb {
       this.store,
       hasher,
       `${MerkleTreeId[MerkleTreeId.NULLIFIER_TREE]}`,
+      {},
       NULLIFIER_TREE_HEIGHT,
       INITIAL_NULLIFIER_TREE_SIZE,
     );
-    const noteHashTree: AppendOnlyTree = await initializeTree(
+    const noteHashTree: AppendOnlyTree<Fr> = await initializeTree(
       StandardTree,
       this.store,
       hasher,
       `${MerkleTreeId[MerkleTreeId.NOTE_HASH_TREE]}`,
+      Fr,
       NOTE_HASH_TREE_HEIGHT,
     );
     const publicDataTree = await initializeTree(
@@ -116,21 +142,24 @@ export class MerkleTrees implements MerkleTreeDb {
       this.store,
       hasher,
       `${MerkleTreeId[MerkleTreeId.PUBLIC_DATA_TREE]}`,
+      {},
       PUBLIC_DATA_TREE_HEIGHT,
       INITIAL_PUBLIC_DATA_TREE_SIZE,
     );
-    const l1Tol2MessageTree: AppendOnlyTree = await initializeTree(
+    const l1Tol2MessageTree: AppendOnlyTree<Fr> = await initializeTree(
       StandardTree,
       this.store,
       hasher,
       `${MerkleTreeId[MerkleTreeId.L1_TO_L2_MESSAGE_TREE]}`,
+      Fr,
       L1_TO_L2_MSG_TREE_HEIGHT,
     );
-    const archive: AppendOnlyTree = await initializeTree(
+    const archive: AppendOnlyTree<Fr> = await initializeTree(
       StandardTree,
       this.store,
       hasher,
       `${MerkleTreeId[MerkleTreeId.ARCHIVE]}`,
+      Fr,
       ARCHIVE_HEIGHT,
     );
     this.trees = [nullifierTree, noteHashTree, publicDataTree, l1Tol2MessageTree, archive];
@@ -230,7 +259,7 @@ export class MerkleTrees implements MerkleTreeDb {
     treeId: MerkleTreeId,
     index: bigint,
     includeUncommitted: boolean,
-  ): Promise<Buffer | undefined> {
+  ): Promise<MerkleTreeLeafType<typeof treeId> | undefined> {
     return await this.synchronize(() => Promise.resolve(this.trees[treeId].getLeafValue(index, includeUncommitted)));
   }
 
@@ -255,7 +284,7 @@ export class MerkleTrees implements MerkleTreeDb {
    * @param leaves - The leaves to append.
    * @returns Empty promise.
    */
-  public async appendLeaves(treeId: MerkleTreeId, leaves: Buffer[]): Promise<void> {
+  public async appendLeaves<ID extends MerkleTreeId>(treeId: ID, leaves: MerkleTreeLeafType<ID>[]): Promise<void> {
     return await this.synchronize(() => this.#appendLeaves(treeId, leaves));
   }
 
@@ -328,14 +357,15 @@ export class MerkleTrees implements MerkleTreeDb {
    * @param includeUncommitted - Indicates whether to include uncommitted data.
    * @returns The index of the first leaf found with a given value (undefined if not found).
    */
-  public async findLeafIndex(
-    treeId: MerkleTreeId,
-    value: Buffer,
+  public async findLeafIndex<ID extends MerkleTreeId>(
+    treeId: ID,
+    value: MerkleTreeLeafType<ID>,
     includeUncommitted: boolean,
   ): Promise<bigint | undefined> {
     return await this.synchronize(() => {
       const tree = this.trees[treeId];
-      return Promise.resolve(tree.findLeafIndex(value, includeUncommitted));
+      // TODO #5448 fix "as any"
+      return Promise.resolve(tree.findLeafIndex(value as any, includeUncommitted));
     });
   }
 
@@ -346,15 +376,16 @@ export class MerkleTrees implements MerkleTreeDb {
    * @param startIndex - The index to start searching from (used when skipping nullified messages)
    * @param includeUncommitted - Indicates whether to include uncommitted data.
    */
-  public async findLeafIndexAfter(
-    treeId: MerkleTreeId,
-    value: Buffer,
+  public async findLeafIndexAfter<ID extends MerkleTreeId>(
+    treeId: ID,
+    value: MerkleTreeLeafType<ID>,
     startIndex: bigint,
     includeUncommitted: boolean,
   ): Promise<bigint | undefined> {
     return await this.synchronize(() => {
       const tree = this.trees[treeId];
-      return Promise.resolve(tree.findLeafIndexAfter(value, startIndex, includeUncommitted));
+      // TODO #5448 fix "as any"
+      return Promise.resolve(tree.findLeafIndexAfter(value as any, startIndex, includeUncommitted));
     });
   }
 
@@ -391,7 +422,7 @@ export class MerkleTrees implements MerkleTreeDb {
     SubtreeHeight extends number,
     SubtreeSiblingPathHeight extends number,
   >(
-    treeId: MerkleTreeId,
+    treeId: IndexedTreeId,
     leaves: Buffer[],
     subtreeHeight: SubtreeHeight,
   ): Promise<BatchInsertionResult<TreeHeight, SubtreeSiblingPathHeight>> {
@@ -421,7 +452,7 @@ export class MerkleTrees implements MerkleTreeDb {
     }
 
     const blockHash = header.hash();
-    await this.#appendLeaves(MerkleTreeId.ARCHIVE, [blockHash.toBuffer()]);
+    await this.#appendLeaves(MerkleTreeId.ARCHIVE, [blockHash]);
   }
 
   /**
@@ -455,20 +486,21 @@ export class MerkleTrees implements MerkleTreeDb {
    * @param leaves - Leaves to append.
    * @returns Empty promise.
    */
-  async #appendLeaves(treeId: MerkleTreeId, leaves: Buffer[]): Promise<void> {
+  async #appendLeaves<ID extends MerkleTreeId>(treeId: ID, leaves: MerkleTreeLeafType<typeof treeId>[]): Promise<void> {
     const tree = this.trees[treeId];
     if (!('appendLeaves' in tree)) {
       throw new Error('Tree does not support `appendLeaves` method');
     }
-    return await tree.appendLeaves(leaves);
+    // TODO #5448 fix "as any"
+    return await tree.appendLeaves(leaves as any[]);
   }
 
-  async #updateLeaf(treeId: IndexedTreeId, leaf: Buffer, index: bigint): Promise<void> {
+  async #updateLeaf(treeId: IndexedTreeId, leaf: MerkleTreeLeafType<typeof treeId>, index: bigint): Promise<void> {
     const tree = this.trees[treeId];
     if (!('updateLeaf' in tree)) {
       throw new Error('Tree does not support `updateLeaf` method');
     }
-    return await tree.updateLeaf(leaf, index);
+    return await (tree as UpdateOnlyTree<typeof leaf>).updateLeaf(leaf, index);
   }
 
   /**
@@ -476,7 +508,7 @@ export class MerkleTrees implements MerkleTreeDb {
    * @returns Empty promise.
    */
   async #commit(): Promise<void> {
-    for (const tree of this.trees) {
+    for (const tree of Object.values(this.trees)) {
       await tree.commit();
     }
   }
@@ -486,17 +518,28 @@ export class MerkleTrees implements MerkleTreeDb {
    * @returns Empty promise.
    */
   async #rollback(): Promise<void> {
-    for (const tree of this.trees) {
+    for (const tree of Object.values(this.trees)) {
       await tree.rollback();
     }
   }
 
-  public getSnapshot(blockNumber: number) {
-    return Promise.all(this.trees.map(tree => tree.getSnapshot(blockNumber)));
+  public async getSnapshot(blockNumber: number): Promise<TreeSnapshots> {
+    // TODO #5448 fix "as any"
+    return {
+      [MerkleTreeId.NULLIFIER_TREE]: (await this.trees[MerkleTreeId.NULLIFIER_TREE].getSnapshot(blockNumber)) as any,
+      [MerkleTreeId.NOTE_HASH_TREE]: await this.trees[MerkleTreeId.NOTE_HASH_TREE].getSnapshot(blockNumber),
+      [MerkleTreeId.PUBLIC_DATA_TREE]: (await this.trees[MerkleTreeId.PUBLIC_DATA_TREE].getSnapshot(
+        blockNumber,
+      )) as any,
+      [MerkleTreeId.L1_TO_L2_MESSAGE_TREE]: await this.trees[MerkleTreeId.L1_TO_L2_MESSAGE_TREE].getSnapshot(
+        blockNumber,
+      ),
+      [MerkleTreeId.ARCHIVE]: await this.trees[MerkleTreeId.ARCHIVE].getSnapshot(blockNumber),
+    };
   }
 
   async #snapshot(blockNumber: number): Promise<void> {
-    for (const tree of this.trees) {
+    for (const tree of Object.values(this.trees)) {
       await tree.snapshot(blockNumber);
     }
   }
@@ -535,10 +578,7 @@ export class MerkleTrees implements MerkleTreeDb {
         [MerkleTreeId.NOTE_HASH_TREE, l2Block.body.txEffects.flatMap(txEffect => txEffect.noteHashes)],
         [MerkleTreeId.L1_TO_L2_MESSAGE_TREE, l1ToL2MessagesPadded],
       ] as const) {
-        await this.#appendLeaves(
-          tree,
-          leaves.map(fr => fr.toBuffer()),
-        );
+        await this.#appendLeaves(tree, leaves);
       }
 
       // Sync the indexed trees


### PR DESCRIPTION
Give Merkle Trees generic type arguments for the leaves they store.
