### PR TITLE
chore: Use random tmp directory and cleanup afterwards

### DIFF
--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -27,6 +27,7 @@ import {
   waitForPXE,
 } from '@aztec/aztec.js';
 import { deployInstance, registerContractClass } from '@aztec/aztec.js/deployment';
+import { randomBytes } from '@aztec/foundation/crypto';
 import {
   AvailabilityOracleAbi,
   AvailabilityOracleBytecode,
@@ -88,10 +89,15 @@ const getACVMConfig = async (logger: DebugLogger) => {
       ? ACVM_BINARY_PATH
       : `${path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../noir/', NOIR_RELEASE_DIR)}/acvm`;
     await fs.access(expectedAcvmPath, fs.constants.R_OK);
-    const acvmWorkingDirectory = ACVM_WORKING_DIRECTORY ? ACVM_WORKING_DIRECTORY : `${TEMP_DIR}/acvm`;
+    const tempWorkingDirectory = `${TEMP_DIR}/${randomBytes(4).toString('hex')}`;
+    const acvmWorkingDirectory = ACVM_WORKING_DIRECTORY ? ACVM_WORKING_DIRECTORY : `${tempWorkingDirectory}/acvm`;
     await fs.mkdir(acvmWorkingDirectory, { recursive: true });
     logger(`Using native ACVM binary at ${expectedAcvmPath} with working directory ${acvmWorkingDirectory}`);
-    return { acvmWorkingDirectory, expectedAcvmPath };
+    return {
+      acvmWorkingDirectory,
+      expectedAcvmPath,
+      directoryToCleanup: ACVM_WORKING_DIRECTORY ? undefined : tempWorkingDirectory,
+    };
   } catch (err) {
     logger(`Native ACVM not available, error: ${err}`);
     return undefined;
@@ -377,6 +383,12 @@ export async function setup(
     }
     if (pxe instanceof PXEService) {
       await pxe?.stop();
+    }
+
+    if (acvmConfig?.directoryToCleanup) {
+      // remove the temp
+      logger(`Cleaning up ACVM temp directory ${acvmConfig.directoryToCleanup}`);
+      await fs.rm(acvmConfig.directoryToCleanup, { recursive: true, force: true });
     }
   };
 

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -386,7 +386,7 @@ export async function setup(
     }
 
     if (acvmConfig?.directoryToCleanup) {
-      // remove the temp
+      // remove the temp directory created for the acvm
       logger(`Cleaning up ACVM temp directory ${acvmConfig.directoryToCleanup}`);
       await fs.rm(acvmConfig.directoryToCleanup, { recursive: true, force: true });
     }

--- a/yarn-project/sequencer-client/src/simulator/acvm_native.ts
+++ b/yarn-project/sequencer-client/src/simulator/acvm_native.ts
@@ -27,7 +27,7 @@ function parseIntoWitnessMap(outputString: string) {
 /**
  *
  * @param inputWitness - The circuit's input witness
- * @param bytecode - The circuit buytecode
+ * @param bytecode - The circuit bytecode
  * @param workingDirectory - A directory to use for temporary files by the ACVM
  * @param pathToAcvm - The path to the ACVm binary
  * @returns The completed partial witness outputted from the circuit


### PR DESCRIPTION
End to end tests fail to run due to conflicts on `/tmp/acvm/`. This PR introduces a random directory to use instead and cleans it up after the test finishes.
