### PR TITLE
fix(avm-simulator): hashing opcodes indirection

### DIFF
--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -642,8 +642,8 @@ fn handle_2_field_hash_instruction(
     inputs: &[ValueOrArray],
 ) {
     // handle field returns differently
-    let hash_offset_maybe = inputs[0];
-    let (hash_offset, hash_size) = match hash_offset_maybe {
+    let message_offset_maybe = inputs[0];
+    let (message_offset, message_size) = match message_offset_maybe {
         ValueOrArray::HeapArray(HeapArray { pointer, size }) => (pointer.0, size),
         _ => panic!("Keccak | Sha256 address inputs destination should be a single value"),
     };
@@ -669,16 +669,16 @@ fn handle_2_field_hash_instruction(
 
     avm_instrs.push(AvmInstruction {
         opcode,
-        indirect: Some(3), // 11 - addressing mode, indirect for input and output
+        indirect: Some(ZEROTH_OPERAND_INDIRECT | FIRST_OPERAND_INDIRECT),
         operands: vec![
             AvmOperand::U32 {
                 value: dest_offset as u32,
             },
             AvmOperand::U32 {
-                value: hash_offset as u32,
+                value: message_offset as u32,
             },
             AvmOperand::U32 {
-                value: hash_size as u32,
+                value: message_size as u32,
             },
         ],
         ..Default::default()
@@ -701,8 +701,8 @@ fn handle_single_field_hash_instruction(
     inputs: &[ValueOrArray],
 ) {
     // handle field returns differently
-    let hash_offset_maybe = inputs[0];
-    let (hash_offset, hash_size) = match hash_offset_maybe {
+    let message_offset_maybe = inputs[0];
+    let (message_offset, message_size) = match message_offset_maybe {
         ValueOrArray::HeapArray(HeapArray { pointer, size }) => (pointer.0, size),
         _ => panic!("Poseidon address inputs destination should be a single value"),
     };
@@ -724,16 +724,16 @@ fn handle_single_field_hash_instruction(
 
     avm_instrs.push(AvmInstruction {
         opcode,
-        indirect: Some(1),
+        indirect: Some(FIRST_OPERAND_INDIRECT),
         operands: vec![
             AvmOperand::U32 {
                 value: dest_offset as u32,
             },
             AvmOperand::U32 {
-                value: hash_offset as u32,
+                value: message_offset as u32,
             },
             AvmOperand::U32 {
-                value: hash_size as u32,
+                value: message_size as u32,
             },
         ],
         ..Default::default()
@@ -882,23 +882,23 @@ fn handle_black_box_function(avm_instrs: &mut Vec<AvmInstruction>, operation: &B
             domain_separator: _,
             output,
         } => {
-            let hash_offset = inputs.pointer.0;
-            let hash_size = inputs.size.0;
+            let message_offset = inputs.pointer.0;
+            let message_size_offset = inputs.size.0;
 
             let dest_offset = output.0;
 
             avm_instrs.push(AvmInstruction {
                 opcode: AvmOpcode::PEDERSEN,
-                indirect: Some(1),
+                indirect: Some(FIRST_OPERAND_INDIRECT),
                 operands: vec![
                     AvmOperand::U32 {
                         value: dest_offset as u32,
                     },
                     AvmOperand::U32 {
-                        value: hash_offset as u32,
+                        value: message_offset as u32,
                     },
                     AvmOperand::U32 {
-                        value: hash_size as u32,
+                        value: message_size_offset as u32,
                     },
                 ],
                 ..Default::default()

--- a/yarn-project/simulator/src/avm/avm_memory_types.test.ts
+++ b/yarn-project/simulator/src/avm/avm_memory_types.test.ts
@@ -18,13 +18,13 @@ describe('TaggedMemory', () => {
     expect(mem.get(10)).toStrictEqual(new Field(5));
   });
 
-  it(`Should getSlice beyond current size`, () => {
+  it(`Should fail getSlice on unset elements`, () => {
     const mem = new TaggedMemory();
-    const val = [new Field(5), new Field(6)];
 
-    mem.setSlice(10, val);
+    mem.set(10, new Field(10));
+    mem.set(12, new Field(12));
 
-    expect(mem.getSlice(10, /*size=*/ 4)).toEqual([...val, undefined, undefined]);
+    expect(() => mem.getSlice(10, /*size=*/ 4)).toThrow(/size/);
   });
 
   it(`Should set and get slices`, () => {

--- a/yarn-project/simulator/src/avm/avm_memory_types.ts
+++ b/yarn-project/simulator/src/avm/avm_memory_types.ts
@@ -229,6 +229,7 @@ export class TaggedMemory {
     assert(offset + size < TaggedMemory.MAX_MEMORY_SIZE);
     const value = this._mem.slice(offset, offset + size);
     TaggedMemory.log(`getSlice(${offset}, ${size}) = ${value}`);
+    assert(value.length === size, `Expected slice of size ${size}, got ${value.length}.`);
     return value;
   }
 

--- a/yarn-project/simulator/src/avm/opcodes/comparators.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/comparators.test.ts
@@ -42,7 +42,7 @@ describe('Comparators', () => {
         new Eq(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 3, /*dstOffset=*/ 12),
       ].forEach(i => i.execute(context));
 
-      const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 4);
+      const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(0), new Uint8(0), new Uint8(1)]);
     });
 
@@ -55,7 +55,7 @@ describe('Comparators', () => {
         new Eq(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 3, /*dstOffset=*/ 12),
       ].forEach(i => i.execute(context));
 
-      const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 4);
+      const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(0), new Uint8(0), new Uint8(1)]);
     });
 
@@ -106,7 +106,7 @@ describe('Comparators', () => {
         new Lt(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
       ].forEach(i => i.execute(context));
 
-      const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 4);
+      const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(0), new Uint8(1), new Uint8(0)]);
     });
 
@@ -119,7 +119,7 @@ describe('Comparators', () => {
         new Lt(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
       ].forEach(i => i.execute(context));
 
-      const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 4);
+      const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(0), new Uint8(1), new Uint8(0)]);
     });
 
@@ -170,7 +170,7 @@ describe('Comparators', () => {
         new Lte(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
       ].forEach(i => i.execute(context));
 
-      const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 4);
+      const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(1), new Uint8(1), new Uint8(0)]);
     });
 
@@ -183,7 +183,7 @@ describe('Comparators', () => {
         new Lte(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
       ].forEach(i => i.execute(context));
 
-      const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 4);
+      const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(1), new Uint8(1), new Uint8(0)]);
     });
 

--- a/yarn-project/simulator/src/avm/opcodes/hashing.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/hashing.test.ts
@@ -3,6 +3,7 @@ import { keccak, pedersenHash, poseidonHash, sha256 } from '@aztec/foundation/cr
 import { AvmContext } from '../avm_context.js';
 import { Field, Uint32 } from '../avm_memory_types.js';
 import { initContext } from '../fixtures/index.js';
+import { Addressing, AddressingMode } from './addressing_mode.js';
 import { Keccak, Pedersen, Poseidon2, Sha256 } from './hashing.js';
 
 describe('Hashing Opcodes', () => {
@@ -18,13 +19,13 @@ describe('Hashing Opcodes', () => {
         Poseidon2.opcode, // opcode
         1, // indirect
         ...Buffer.from('12345678', 'hex'), // dstOffset
-        ...Buffer.from('23456789', 'hex'), // hashOffset
+        ...Buffer.from('23456789', 'hex'), // messageOffset
         ...Buffer.from('3456789a', 'hex'), // hashSize
       ]);
       const inst = new Poseidon2(
         /*indirect=*/ 1,
         /*dstOffset=*/ 0x12345678,
-        /*hashOffset=*/ 0x23456789,
+        /*messageOffset=*/ 0x23456789,
         /*hashSize=*/ 0x3456789a,
       );
 
@@ -35,13 +36,13 @@ describe('Hashing Opcodes', () => {
     it('Should hash correctly - direct', async () => {
       const indirect = 0;
       const args = [new Field(1n), new Field(2n), new Field(3n)];
-      const hashOffset = 0;
-      context.machineState.memory.setSlice(hashOffset, args);
+      const messageOffset = 0;
+      context.machineState.memory.setSlice(messageOffset, args);
 
       const dstOffset = 3;
 
       const expectedHash = poseidonHash(args.map(field => field.toBuffer()));
-      await new Poseidon2(indirect, dstOffset, hashOffset, args.length).execute(context);
+      await new Poseidon2(indirect, dstOffset, messageOffset, args.length).execute(context);
 
       const result = context.machineState.memory.get(dstOffset);
       expect(result).toEqual(new Field(expectedHash));
@@ -49,17 +50,20 @@ describe('Hashing Opcodes', () => {
 
     it('Should hash correctly - indirect', async () => {
       const args = [new Field(1n), new Field(2n), new Field(3n)];
-      const indirect = 1;
-      const hashOffset = 0;
+      const indirect = new Addressing([
+        /*dstOffset=*/ AddressingMode.DIRECT,
+        /*messageOffset*/ AddressingMode.INDIRECT,
+      ]).toWire();
+      const messageOffset = 0;
       const realLocation = 4;
 
-      context.machineState.memory.set(hashOffset, new Uint32(realLocation));
+      context.machineState.memory.set(messageOffset, new Uint32(realLocation));
       context.machineState.memory.setSlice(realLocation, args);
 
       const dstOffset = 3;
 
       const expectedHash = poseidonHash(args.map(field => field.toBuffer()));
-      await new Poseidon2(indirect, dstOffset, hashOffset, args.length).execute(context);
+      await new Poseidon2(indirect, dstOffset, messageOffset, args.length).execute(context);
 
       const result = context.machineState.memory.get(dstOffset);
       expect(result).toEqual(new Field(expectedHash));
@@ -72,13 +76,13 @@ describe('Hashing Opcodes', () => {
         Keccak.opcode, // opcode
         1, // indirect
         ...Buffer.from('12345678', 'hex'), // dstOffset
-        ...Buffer.from('23456789', 'hex'), // hashOffset
+        ...Buffer.from('23456789', 'hex'), // messageOffset
         ...Buffer.from('3456789a', 'hex'), // hashSize
       ]);
       const inst = new Keccak(
         /*indirect=*/ 1,
         /*dstOffset=*/ 0x12345678,
-        /*hashOffset=*/ 0x23456789,
+        /*messageOffset=*/ 0x23456789,
         /*hashSize=*/ 0x3456789a,
       );
 
@@ -89,14 +93,14 @@ describe('Hashing Opcodes', () => {
     it('Should hash correctly - direct', async () => {
       const args = [new Field(1n), new Field(2n), new Field(3n)];
       const indirect = 0;
-      const hashOffset = 0;
-      context.machineState.memory.setSlice(hashOffset, args);
+      const messageOffset = 0;
+      context.machineState.memory.setSlice(messageOffset, args);
 
       const dstOffset = 3;
 
       const inputBuffer = Buffer.concat(args.map(field => field.toBuffer()));
       const expectedHash = keccak(inputBuffer);
-      await new Keccak(indirect, dstOffset, hashOffset, args.length).execute(context);
+      await new Keccak(indirect, dstOffset, messageOffset, args.length).execute(context);
 
       const result = context.machineState.memory.getSliceAs<Field>(dstOffset, 2);
       const combined = Buffer.concat([result[0].toBuffer().subarray(16, 32), result[1].toBuffer().subarray(16, 32)]);
@@ -106,20 +110,23 @@ describe('Hashing Opcodes', () => {
 
     it('Should hash correctly - indirect', async () => {
       const args = [new Field(1n), new Field(2n), new Field(3n)];
-      const indirect = 3; // dest and return are indirect
-      const hashOffset = 0;
+      const indirect = new Addressing([
+        /*dstOffset=*/ AddressingMode.INDIRECT,
+        /*messageOffset*/ AddressingMode.INDIRECT,
+      ]).toWire();
+      const messageOffset = 0;
       const argsLocation = 4;
 
       const dstOffset = 2;
       const readLocation = 6;
 
-      context.machineState.memory.set(hashOffset, new Uint32(argsLocation));
+      context.machineState.memory.set(messageOffset, new Uint32(argsLocation));
       context.machineState.memory.set(dstOffset, new Uint32(readLocation));
       context.machineState.memory.setSlice(argsLocation, args);
 
       const inputBuffer = Buffer.concat(args.map(field => field.toBuffer()));
       const expectedHash = keccak(inputBuffer);
-      await new Keccak(indirect, dstOffset, hashOffset, args.length).execute(context);
+      await new Keccak(indirect, dstOffset, messageOffset, args.length).execute(context);
 
       const result = context.machineState.memory.getSliceAs<Field>(readLocation, 2);
       const combined = Buffer.concat([result[0].toBuffer().subarray(16, 32), result[1].toBuffer().subarray(16, 32)]);
@@ -134,13 +141,13 @@ describe('Hashing Opcodes', () => {
         Sha256.opcode, // opcode
         1, // indirect
         ...Buffer.from('12345678', 'hex'), // dstOffset
-        ...Buffer.from('23456789', 'hex'), // hashOffset
+        ...Buffer.from('23456789', 'hex'), // messageOffset
         ...Buffer.from('3456789a', 'hex'), // hashSize
       ]);
       const inst = new Sha256(
         /*indirect=*/ 1,
         /*dstOffset=*/ 0x12345678,
-        /*hashOffset=*/ 0x23456789,
+        /*messageOffset=*/ 0x23456789,
         /*hashSize=*/ 0x3456789a,
       );
 
@@ -150,15 +157,15 @@ describe('Hashing Opcodes', () => {
 
     it('Should hash correctly - direct', async () => {
       const args = [new Field(1n), new Field(2n), new Field(3n)];
-      const hashOffset = 0;
+      const messageOffset = 0;
       const indirect = 0;
-      context.machineState.memory.setSlice(hashOffset, args);
+      context.machineState.memory.setSlice(messageOffset, args);
 
       const dstOffset = 3;
 
       const inputBuffer = Buffer.concat(args.map(field => field.toBuffer()));
       const expectedHash = sha256(inputBuffer);
-      await new Sha256(indirect, dstOffset, hashOffset, args.length).execute(context);
+      await new Sha256(indirect, dstOffset, messageOffset, args.length).execute(context);
 
       const result = context.machineState.memory.getSliceAs<Field>(dstOffset, 2);
       const combined = Buffer.concat([result[0].toBuffer().subarray(16, 32), result[1].toBuffer().subarray(16, 32)]);
@@ -168,20 +175,23 @@ describe('Hashing Opcodes', () => {
 
     it('Should hash correctly - indirect', async () => {
       const args = [new Field(1n), new Field(2n), new Field(3n)];
-      const indirect = 3; // dest and return are indirect
-      const hashOffset = 0;
+      const indirect = new Addressing([
+        /*dstOffset=*/ AddressingMode.INDIRECT,
+        /*messageOffset*/ AddressingMode.INDIRECT,
+      ]).toWire();
+      const messageOffset = 0;
       const argsLocation = 4;
 
       const dstOffset = 2;
       const readLocation = 6;
 
-      context.machineState.memory.set(hashOffset, new Uint32(argsLocation));
+      context.machineState.memory.set(messageOffset, new Uint32(argsLocation));
       context.machineState.memory.set(dstOffset, new Uint32(readLocation));
       context.machineState.memory.setSlice(argsLocation, args);
 
       const inputBuffer = Buffer.concat(args.map(field => field.toBuffer()));
       const expectedHash = sha256(inputBuffer);
-      await new Sha256(indirect, dstOffset, hashOffset, args.length).execute(context);
+      await new Sha256(indirect, dstOffset, messageOffset, args.length).execute(context);
 
       const result = context.machineState.memory.getSliceAs<Field>(readLocation, 2);
       const combined = Buffer.concat([result[0].toBuffer().subarray(16, 32), result[1].toBuffer().subarray(16, 32)]);
@@ -196,31 +206,34 @@ describe('Hashing Opcodes', () => {
         Pedersen.opcode, // opcode
         1, // indirect
         ...Buffer.from('12345678', 'hex'), // dstOffset
-        ...Buffer.from('23456789', 'hex'), // hashOffset
+        ...Buffer.from('23456789', 'hex'), // messageOffset
         ...Buffer.from('3456789a', 'hex'), // hashSize
       ]);
       const inst = new Pedersen(
         /*indirect=*/ 1,
         /*dstOffset=*/ 0x12345678,
-        /*hashOffset=*/ 0x23456789,
-        /*hashSize=*/ 0x3456789a,
+        /*messageOffset=*/ 0x23456789,
+        /*hashSizeOffset=*/ 0x3456789a,
       );
 
-      expect(Sha256.deserialize(buf)).toEqual(inst);
+      expect(Pedersen.deserialize(buf)).toEqual(inst);
       expect(inst.serialize()).toEqual(buf);
     });
 
     it('Should hash correctly - direct', async () => {
       const args = [new Field(1n), new Field(2n), new Field(3n)];
-      const hashOffset = 0;
+      const messageOffset = 0;
+      const sizeOffset = 10;
       const indirect = 0;
-      context.machineState.memory.setSlice(hashOffset, args);
+
+      context.machineState.memory.setSlice(messageOffset, args);
+      context.machineState.memory.set(sizeOffset, new Uint32(args.length));
 
       const dstOffset = 3;
 
       const inputBuffer = args.map(field => field.toBuffer());
       const expectedHash = pedersenHash(inputBuffer);
-      await new Pedersen(indirect, dstOffset, hashOffset, args.length).execute(context);
+      await new Pedersen(indirect, dstOffset, messageOffset, sizeOffset).execute(context);
 
       const result = context.machineState.memory.get(dstOffset);
       expect(result).toEqual(new Field(expectedHash));
@@ -228,18 +241,26 @@ describe('Hashing Opcodes', () => {
 
     it('Should hash correctly - indirect', async () => {
       const args = [new Field(1n), new Field(2n), new Field(3n)];
-      const indirect = 1;
-      const hashOffset = 0;
+      const indirect = new Addressing([
+        /*dstOffset=*/ AddressingMode.DIRECT,
+        /*messageOffset*/ AddressingMode.INDIRECT,
+        /*messageSizeOffset*/ AddressingMode.INDIRECT,
+      ]).toWire();
+      const messageOffset = 0;
+      const sizeOffset = 10;
       const realLocation = 4;
+      const realSizeLocation = 20;
 
-      context.machineState.memory.set(hashOffset, new Uint32(realLocation));
+      context.machineState.memory.set(messageOffset, new Uint32(realLocation));
+      context.machineState.memory.set(sizeOffset, new Uint32(realSizeLocation));
       context.machineState.memory.setSlice(realLocation, args);
+      context.machineState.memory.set(realSizeLocation, new Uint32(args.length));
 
-      const dstOffset = 3;
+      const dstOffset = 300;
 
       const inputBuffer = args.map(field => field.toBuffer());
       const expectedHash = pedersenHash(inputBuffer);
-      await new Pedersen(indirect, dstOffset, hashOffset, args.length).execute(context);
+      await new Pedersen(indirect, dstOffset, messageOffset, sizeOffset).execute(context);
 
       const result = context.machineState.memory.get(dstOffset);
       expect(result).toEqual(new Field(expectedHash));


### PR DESCRIPTION
**Situation for hashes before this PR**

The hash situation is quite peculiar. Noir defines its hashes as _black box functions_ in the [stdlib](https://github.com/AztecProtocol/aztec-packages/blob/25caf4d8050cc7446595fcb159f140e7fbee6767/noir/noir-repo/noir_stdlib/src/hash.nr). However, the signature for most of them is not really good for bytecode/avm. E.g., they take and/or return `u8`s instead of Fields, some of them are permutations, others have separators, etc.

Moreover, Brillig preprocessing changes the signature to accept vectors (variable size at runtime) vs arrays (size known at runtime) for some of the black box functions.

The AVM defines:
* [pedersen](https://github.com/AztecProtocol/aztec-packages/blob/25caf4d8050cc7446595fcb159f140e7fbee6767/avm-transpiler/src/transpile.rs#L880): it implements the blackbox function.
* the rest, are defined as [oracles](https://github.com/AztecProtocol/aztec-packages/blob/8a7606875fbb7d3eb15b6d8eaa7e297e1a8838ea/noir-projects/aztec-nr/aztec/src/avm/hash.nr). This means that if a contract uses the stdlib (blackbox) hashes for these functions, it will not currently work with the avm. The definition as oracles is to have a (likely temporary) better signature for the hashes.

Some of the indirections in our pedersen opcode were handled incorrectly (the transpiler was assuming an array, not a vector).

**After the PR**

I started implementing all of the hashing opcodes from the blackbox functions but this was quite difficult to quickly do in TS. So for the moment I'm just fixing the indirection problems.

I also restricted `getSlice` to fail if called on undefined areas, which uncovered a few other bugs in tests.