### PR TITLE
fix(cli): Support initializers not named constructor in cli

### DIFF
--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -5,7 +5,7 @@ import {
   getContractClassFromArtifact,
   getContractInstanceFromDeployParams,
 } from '@aztec/circuits.js';
-import { ContractArtifact, FunctionArtifact, getDefaultInitializer } from '@aztec/foundation/abi';
+import { ContractArtifact, FunctionArtifact, getInitializer } from '@aztec/foundation/abi';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { createDebugLogger } from '@aztec/foundation/log';
@@ -63,16 +63,10 @@ export class DeployMethod<TContract extends ContractBase = Contract> extends Bas
     private artifact: ContractArtifact,
     private postDeployCtor: (address: AztecAddress, wallet: Wallet) => Promise<TContract>,
     private args: any[] = [],
-    constructorName?: string,
+    constructorNameOrArtifact?: string | FunctionArtifact,
   ) {
     super(wallet);
-    this.constructorArtifact = constructorName
-      ? artifact.functions.find(f => f.name === constructorName)
-      : getDefaultInitializer(artifact);
-
-    if (constructorName && !this.constructorArtifact) {
-      throw new Error(`Constructor method ${constructorName} not found in contract artifact`);
-    }
+    this.constructorArtifact = getInitializer(artifact, constructorNameOrArtifact);
   }
 
   /**

--- a/yarn-project/cli/src/index.ts
+++ b/yarn-project/cli/src/index.ts
@@ -156,6 +156,7 @@ export function getProgram(log: LogFn, debugLogger: DebugLogger): Command {
       '<artifact>',
       "A compiled Aztec.nr contract's artifact in JSON format or name of a contract artifact exported by @aztec/noir-contracts.js",
     )
+    .option('--initializer <string>', 'The contract initializer function to call')
     .option('-a, --args <constructorArgs...>', 'Contract constructor arguments', [])
     .addOption(pxeOption)
     .option(
@@ -178,23 +179,29 @@ export function getProgram(log: LogFn, debugLogger: DebugLogger): Command {
     // `options.wait` is default true. Passing `--no-wait` will set it to false.
     // https://github.com/tj/commander.js#other-option-types-negatable-boolean-and-booleanvalue
     .option('--no-wait', 'Skip waiting for the contract to be deployed. Print the hash of deployment transaction')
-    .action(async (artifactPath, { json, rpcUrl, publicKey, args: rawArgs, portalAddress, salt, wait, privateKey }) => {
-      const { deploy } = await import('./cmds/deploy.js');
-      await deploy(
+    .action(
+      async (
         artifactPath,
-        json,
-        rpcUrl,
-        publicKey,
-        rawArgs,
-        portalAddress,
-        salt,
-        privateKey,
-        wait,
-        debugLogger,
-        log,
-        logJson,
-      );
-    });
+        { json, rpcUrl, publicKey, args: rawArgs, portalAddress, salt, wait, privateKey, initializer },
+      ) => {
+        const { deploy } = await import('./cmds/deploy.js');
+        await deploy(
+          artifactPath,
+          json,
+          rpcUrl,
+          publicKey,
+          rawArgs,
+          portalAddress,
+          salt,
+          privateKey,
+          initializer,
+          wait,
+          debugLogger,
+          log,
+          logJson,
+        );
+      },
+    );
 
   program
     .command('check-deploy')

--- a/yarn-project/end-to-end/src/shared/cli.ts
+++ b/yarn-project/end-to-end/src/shared/cli.ts
@@ -8,16 +8,7 @@ const TRANSFER_BALANCE = 3000;
 
 export const cliTestSuite = (
   name: string,
-  setup: () => Promise<{
-    /**
-     * The PXE instance.
-     */
-    pxe: PXE;
-    /**
-     * The URL of the PXE RPC server.
-     */
-    rpcURL: string;
-  }>,
+  setup: () => Promise<{ pxe: PXE; rpcURL: string }>,
   cleanup: () => Promise<void>,
   debug: DebugLogger,
 ) =>
@@ -117,6 +108,38 @@ export const cliTestSuite = (
       await run(`get-account ${newAddress.toString()}`);
       const fetchedAddress = findInLogs(/Public Key:\s+(?<address>0x[a-fA-F0-9]+)/)?.groups?.address;
       expect(fetchedAddress).toEqual(newCompleteAddress.publicKey.toString());
+    });
+
+    // Regression test for deploy cmd with a constructor not named "constructor"
+    it('deploys a contract using a public initializer', async () => {
+      debug('Create an account using a private key');
+      await run('generate-private-key', false);
+      const privKey = findInLogs(/Private\sKey:\s+0x(?<privKey>[a-fA-F0-9]+)/)?.groups?.privKey;
+      expect(privKey).toHaveLength(64);
+      await run(`create-account --private-key ${privKey}`);
+      const foundAddress = findInLogs(/Address:\s+(?<address>0x[a-fA-F0-9]+)/)?.groups?.address;
+      expect(foundAddress).toBeDefined();
+      const ownerAddress = AztecAddress.fromString(foundAddress!);
+      const salt = 42;
+
+      debug('Deploy StatefulTestContract with public_constructor using created account.');
+      await run(
+        `deploy StatefulTestContractArtifact --private-key ${privKey} --salt ${salt} --initializer public_constructor --args ${ownerAddress} 100`,
+      );
+      const loggedAddress = findInLogs(/Contract\sdeployed\sat\s+(?<address>0x[a-fA-F0-9]+)/)?.groups?.address;
+      expect(loggedAddress).toBeDefined();
+      contractAddress = AztecAddress.fromString(loggedAddress!);
+
+      const deployedContract = await pxe.getContractInstance(contractAddress);
+      expect(deployedContract?.address).toEqual(contractAddress);
+
+      clearLogs();
+      await run(
+        `call get_public_value --args ${ownerAddress} --contract-artifact StatefulTestContractArtifact --contract-address ${contractAddress.toString()}`,
+      );
+
+      const balance = findInLogs(/View\sresult:\s+(?<data>\S+)/)?.groups?.data;
+      expect(balance!).toEqual(`${BigInt(100).toString()}n`);
     });
 
     it.each([

--- a/yarn-project/end-to-end/src/shared/cli.ts
+++ b/yarn-project/end-to-end/src/shared/cli.ts
@@ -140,7 +140,7 @@ export const cliTestSuite = (
 
       const balance = findInLogs(/View\sresult:\s+(?<data>\S+)/)?.groups?.data;
       expect(balance!).toEqual(`${BigInt(100).toString()}n`);
-    });
+    }, 60_000);
 
     it.each([
       ['an example Token contract', 'TokenContractArtifact', '0'],

--- a/yarn-project/foundation/src/abi/abi.test.ts
+++ b/yarn-project/foundation/src/abi/abi.test.ts
@@ -1,0 +1,114 @@
+import { ContractArtifact, FunctionArtifact, FunctionType, getDefaultInitializer, getInitializer } from './abi.js';
+
+describe('abi', () => {
+  describe('getDefaultInitializer', () => {
+    it('does not return non initializer functions', () => {
+      const contract = { functions: [{ isInitializer: false }] } as ContractArtifact;
+      expect(getDefaultInitializer(contract)).toBeUndefined();
+    });
+
+    it('returns the single initializer in a contract', () => {
+      const contract = {
+        functions: [
+          { name: 'non-init', isInitializer: false },
+          { name: 'init', isInitializer: true },
+        ],
+      } as ContractArtifact;
+      expect(getDefaultInitializer(contract)?.name).toEqual('init');
+    });
+
+    it('prefers functions based on name', () => {
+      const contract = {
+        functions: [
+          { name: 'foo', isInitializer: true },
+          { name: 'constructor', isInitializer: true },
+        ],
+      } as ContractArtifact;
+      expect(getDefaultInitializer(contract)?.name).toEqual('constructor');
+    });
+
+    it('prefers functions based on parameter length', () => {
+      const contract = {
+        functions: [
+          { name: 'foo', parameters: [{}], isInitializer: true },
+          { name: 'bar', parameters: [], isInitializer: true },
+        ],
+      } as ContractArtifact;
+      expect(getDefaultInitializer(contract)?.name).toEqual('bar');
+    });
+
+    it('prefers functions based on type', () => {
+      const contract = {
+        functions: [
+          { name: 'foo', isInitializer: true, functionType: FunctionType.OPEN },
+          { name: 'bar', isInitializer: true, functionType: FunctionType.SECRET },
+        ],
+      } as ContractArtifact;
+      expect(getDefaultInitializer(contract)?.name).toEqual('bar');
+    });
+
+    it('returns an initializer if there is any', () => {
+      const contract = {
+        functions: [
+          { name: 'foo', isInitializer: true },
+          { name: 'bar', isInitializer: true },
+        ],
+      } as ContractArtifact;
+      expect(getDefaultInitializer(contract)?.name).toBeDefined();
+    });
+  });
+
+  describe('getInitializer', () => {
+    it('returns initializer based on name', () => {
+      const contract = {
+        functions: [
+          { name: 'foo', isInitializer: true },
+          { name: 'bar', isInitializer: true },
+        ],
+      } as ContractArtifact;
+      expect(getInitializer(contract, 'bar')?.name).toEqual('bar');
+    });
+
+    it('fails if named initializer not found', () => {
+      const contract = {
+        functions: [
+          { name: 'foo', isInitializer: true },
+          { name: 'bar', isInitializer: true },
+        ],
+      } as ContractArtifact;
+      expect(() => getInitializer(contract, 'baz')).toThrow();
+    });
+
+    it('fails if named initializer not an initializer', () => {
+      const contract = {
+        functions: [
+          { name: 'foo', isInitializer: true },
+          { name: 'bar', isInitializer: false },
+        ],
+      } as ContractArtifact;
+      expect(() => getInitializer(contract, 'bar')).toThrow();
+    });
+
+    it('falls back to default initializer on undefined argument', () => {
+      const contract = {
+        functions: [
+          { name: 'foo', isInitializer: true },
+          { name: 'initializer', isInitializer: true },
+        ],
+      } as ContractArtifact;
+      expect(getInitializer(contract, undefined)?.name).toEqual('initializer');
+    });
+
+    it('passes artifact through', () => {
+      const contract = {} as ContractArtifact;
+      const artifact = { name: 'foo', isInitializer: true } as FunctionArtifact;
+      expect(getInitializer(contract, artifact)?.name).toEqual('foo');
+    });
+
+    it('validates artifact is initializer', () => {
+      const contract = {} as ContractArtifact;
+      const artifact = { name: 'foo', isInitializer: false } as FunctionArtifact;
+      expect(() => getInitializer(contract, artifact)).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Adds a new `--initializer` option to CLI deploy for specifying the name of the initializer function, otherwise falls back to fetching the default initializer (based on name, visibility, param length, etc).

Fixes issue reported by @signorecello.