### PR TITLE
chore: Skip foundry install if possible

### DIFF
--- a/l1-contracts/scripts/install_foundry.sh
+++ b/l1-contracts/scripts/install_foundry.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -eu
 
 export FOUNDRY_DIR="$PWD/.foundry"
@@ -7,6 +7,14 @@ BIN_URL="https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/f
 BIN_PATH="$FOUNDRY_BIN_DIR/foundryup"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 FOUNDRY_VERSION="nightly-de33b6af53005037b463318d2628b5cfcaf39916"
+FOUNDRY_SHORT_VERSION=$(echo "${FOUNDRY_VERSION#*-}" | cut -c1-6)
+echo "$FOUNDRY_SHORT_VERSION"
+
+# Check if forge is installed and matches the expected version
+if command -v "forge" > /dev/null 2>&1 && [[ "$(forge --version)" == *"$FOUNDRY_SHORT_VERSION"* ]]; then
+    echo "Foundry is already installed and at the correct version."
+    exit 0
+fi
 
 # Clean
 rm -rf $FOUNDRY_DIR


### PR DESCRIPTION
Checks if binary exists and is at the same version for skipping. Should help in speeding up local bootstraps.
