### PR TITLE
chore: Use slices for computing args hash in class registerer [WIP]

### DIFF
--- a/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/main.nr
@@ -5,7 +5,7 @@ contract ContractClassRegisterer {
     use dep::aztec::context::PrivateContext;
     use dep::aztec::prelude::{AztecAddress, EthAddress, FunctionSelector, emit_unencrypted_log};
     use dep::aztec::protocol_types::{
-        hash::hash_args, contract_class_id::ContractClassId,
+        contract_class_id::ContractClassId,
         constants::{
         ARTIFACT_FUNCTION_TREE_MAX_HEIGHT, FUNCTION_TREE_HEIGHT,
         MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS, REGISTERER_CONTRACT_CLASS_REGISTERED_MAGIC_VALUE
@@ -37,7 +37,7 @@ contract ContractClassRegisterer {
         hasher_slice = hasher_slice.push_front(public_bytecode_commitment);
         hasher_slice = hasher_slice.push_front(private_functions_root);
         hasher_slice = hasher_slice.push_front(artifact_hash);
-        let mut context = PrivateContext::new(inputs, hash_args(hasher_slice));
+        let mut context = PrivateContext::new(inputs, 0);
 
         // TODO: Validate public_bytecode_commitment is the correct commitment of packed_public_bytecode
         // TODO: Validate packed_public_bytecode is legit public bytecode

--- a/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/main.nr
@@ -2,9 +2,10 @@ mod events;
 mod capsule;
 
 contract ContractClassRegisterer {
+    use dep::aztec::context::PrivateContext;
     use dep::aztec::prelude::{AztecAddress, EthAddress, FunctionSelector, emit_unencrypted_log};
     use dep::aztec::protocol_types::{
-        contract_class_id::ContractClassId,
+        hash::hash_args, contract_class_id::ContractClassId,
         constants::{
         ARTIFACT_FUNCTION_TREE_MAX_HEIGHT, FUNCTION_TREE_HEIGHT,
         MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS, REGISTERER_CONTRACT_CLASS_REGISTERED_MAGIC_VALUE
@@ -23,11 +24,23 @@ contract ContractClassRegisterer {
     use crate::capsule::pop_capsule;
 
     #[aztec(private)]
-    fn register(artifact_hash: Field, private_functions_root: Field, public_bytecode_commitment: Field) {
+    #[aztec(nocontextcreation)]
+    fn register(
+        artifact_hash: Field,
+        private_functions_root: Field,
+        public_bytecode_commitment: Field,
+        packed_public_bytecode: [Field; MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS]
+    ) {
+        // We manually create the context so we can manually hash the args using the bytecode array as slice
+        // See https://github.com/noir-lang/noir/issues/4395#issuecomment-2007694169 for context
+        let mut hasher_slice = packed_public_bytecode.as_slice();
+        hasher_slice = hasher_slice.push_front(public_bytecode_commitment);
+        hasher_slice = hasher_slice.push_front(private_functions_root);
+        hasher_slice = hasher_slice.push_front(artifact_hash);
+        let mut context = PrivateContext::new(inputs, hash_args(hasher_slice));
+
         // TODO: Validate public_bytecode_commitment is the correct commitment of packed_public_bytecode
         // TODO: Validate packed_public_bytecode is legit public bytecode
-
-        let packed_public_bytecode: [Field; MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS] = pop_capsule();
 
         // Compute contract class id from preimage
         let contract_class_id = ContractClassId::compute(

--- a/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/main.nr
@@ -5,7 +5,7 @@ contract ContractClassRegisterer {
     use dep::aztec::context::PrivateContext;
     use dep::aztec::prelude::{AztecAddress, EthAddress, FunctionSelector, emit_unencrypted_log};
     use dep::aztec::protocol_types::{
-        contract_class_id::ContractClassId,
+        hash::hash_args_slice, contract_class_id::ContractClassId,
         constants::{
         ARTIFACT_FUNCTION_TREE_MAX_HEIGHT, FUNCTION_TREE_HEIGHT,
         MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS, REGISTERER_CONTRACT_CLASS_REGISTERED_MAGIC_VALUE
@@ -37,7 +37,7 @@ contract ContractClassRegisterer {
         hasher_slice = hasher_slice.push_front(public_bytecode_commitment);
         hasher_slice = hasher_slice.push_front(private_functions_root);
         hasher_slice = hasher_slice.push_front(artifact_hash);
-        let mut context = PrivateContext::new(inputs, 0);
+        let mut context = PrivateContext::new(inputs, hash_args_slice(hasher_slice));
 
         // TODO: Validate public_bytecode_commitment is the correct commitment of packed_public_bytecode
         // TODO: Validate packed_public_bytecode is legit public bytecode

--- a/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
@@ -29,6 +29,30 @@ pub fn hash_args_array<N>(args: [Field; N]) -> Field {
     hash_args(args_vec)
 }
 
+pub fn hash_args_slice(args: [Field]) -> Field {
+    if args.len() == 0 {
+        0
+    } else {
+        let mut chunks_hashes = [0; ARGS_HASH_CHUNK_COUNT];
+        for i in 0..ARGS_HASH_CHUNK_COUNT {
+            let mut chunk_hash = 0;
+            let start_chunk_index = i * ARGS_HASH_CHUNK_LENGTH;
+            if start_chunk_index < args.len() {
+                let mut chunk_args = [0; ARGS_HASH_CHUNK_LENGTH];
+                for j in 0..ARGS_HASH_CHUNK_LENGTH {
+                    let item_index = i * ARGS_HASH_CHUNK_LENGTH + j;
+                    if item_index < args.len() {
+                        chunk_args[j] = args[item_index];
+                    }
+                }
+                chunk_hash = pedersen_hash(chunk_args, GENERATOR_INDEX__FUNCTION_ARGS);
+            }
+            chunks_hashes[i] = chunk_hash;
+        }
+        pedersen_hash(chunks_hashes, GENERATOR_INDEX__FUNCTION_ARGS)
+    }
+}
+
 pub fn hash_args(args: BoundedVec<Field, MAX_ARGS_LENGTH>) -> Field {
     if args.len() == 0 {
         0

--- a/noir/noir-repo/aztec_macros/src/lib.rs
+++ b/noir/noir-repo/aztec_macros/src/lib.rs
@@ -119,6 +119,7 @@ fn transform_module(module: &mut SortedModule) -> Result<bool, AztecMacroError> 
         let mut is_initializer = false;
         let mut is_internal = false;
         let mut insert_init_check = has_initializer;
+        let mut insert_context_creation = true;
 
         for secondary_attribute in func.def.attributes.secondary.clone() {
             if is_custom_attribute(&secondary_attribute, "aztec(private)") {
@@ -134,6 +135,8 @@ fn transform_module(module: &mut SortedModule) -> Result<bool, AztecMacroError> 
                 is_public = true;
             } else if is_custom_attribute(&secondary_attribute, "aztec(public-vm)") {
                 is_public_vm = true;
+            } else if is_custom_attribute(&secondary_attribute, "aztec(nocontextcreation)") {
+                insert_context_creation = false;
             }
         }
 
@@ -146,6 +149,7 @@ fn transform_module(module: &mut SortedModule) -> Result<bool, AztecMacroError> 
                 is_initializer,
                 insert_init_check,
                 is_internal,
+                insert_context_creation,
             )?;
             has_transformed_module = true;
         } else if is_public_vm {

--- a/noir/noir-repo/aztec_macros/src/transforms/functions.rs
+++ b/noir/noir-repo/aztec_macros/src/transforms/functions.rs
@@ -31,6 +31,7 @@ pub fn transform_function(
     is_initializer: bool,
     insert_init_check: bool,
     is_internal: bool,
+    insert_context_creation: bool,
 ) -> Result<(), AztecMacroError> {
     let context_name = format!("{}Context", ty);
     let inputs_name = format!("{}ContextInputs", ty);
@@ -60,8 +61,10 @@ pub fn transform_function(
     }
 
     // Insert the context creation as the first action
-    let create_context = create_context(&context_name, &func.def.parameters)?;
-    func.def.body.statements.splice(0..0, (create_context).iter().cloned());
+    if insert_context_creation {
+        let create_context = create_context(&context_name, &func.def.parameters)?;
+        func.def.body.statements.splice(0..0, (create_context).iter().cloned());
+    }
 
     // Add the inputs to the params
     let input = create_inputs(&inputs_name);


### PR DESCRIPTION
To remove capsule usage without getting 7-minute build times.
