### PR TITLE
feat: benchmark tx size with fee

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1097,6 +1097,16 @@ jobs:
           aztec_manifest_key: end-to-end
     <<: *defaults_e2e_test
 
+  bench-tx-size:
+    steps:
+      - *checkout
+      - *setup_env
+      - run:
+          name: "Benchmark"
+          command: cond_spot_run_compose end-to-end 4 ./scripts/docker-compose-no-sandbox.yml TEST=benchmarks/bench_tx_size_fees.test.ts ENABLE_GAS=1 DEBUG=aztec:benchmarks:*,aztec:sequencer,aztec:sequencer:*,aztec:world_state,aztec:merkle_trees
+          aztec_manifest_key: end-to-end
+    <<: *defaults_e2e_test
+
   build-docs:
     machine:
       image: default
@@ -1551,10 +1561,12 @@ workflows:
       # Benchmark jobs.
       - bench-publish-rollup: *e2e_test
       - bench-process-history: *e2e_test
+      - bench-tx-size: *e2e_test
       - bench-summary:
           requires:
             - bench-publish-rollup
             - bench-process-history
+            - bench-tx-size
           <<: *defaults
 
       # Production releases.

--- a/yarn-project/aztec.js/src/fee/native_fee_payment_method.ts
+++ b/yarn-project/aztec.js/src/fee/native_fee_payment_method.ts
@@ -55,11 +55,6 @@ export class NativeFeePaymentMethod implements FeePaymentMethod {
     return Promise.resolve([
       {
         to: this.#gasTokenAddress,
-        functionData: new FunctionData(FunctionSelector.fromSignature('check_balance(Field)'), false),
-        args: [feeLimit],
-      },
-      {
-        to: this.#gasTokenAddress,
         functionData: new FunctionData(FunctionSelector.fromSignature('pay_fee(Field)'), false),
         args: [feeLimit],
       },

--- a/yarn-project/circuit-types/src/stats/metrics.ts
+++ b/yarn-project/circuit-types/src/stats/metrics.ts
@@ -7,7 +7,8 @@ export type MetricGroupBy =
   | 'circuit-name'
   | 'classes-registered'
   | 'leaf-count'
-  | 'data-writes';
+  | 'data-writes'
+  | 'fee-payment-method';
 
 /** Definition of a metric to track in benchmarks. */
 export interface Metric {
@@ -131,6 +132,12 @@ export const Metrics = [
     name: 'tx_size_in_bytes',
     groupBy: 'classes-registered',
     description: 'Size of txs received in the mempool.',
+    events: ['tx-added-to-pool'],
+  },
+  {
+    name: 'tx_with_fee_size_in_bytes',
+    groupBy: 'fee-payment-method',
+    description: 'Size of txs after fully processing them (including fee payment).',
     events: ['tx-added-to-pool'],
   },
   {

--- a/yarn-project/circuit-types/src/stats/stats.ts
+++ b/yarn-project/circuit-types/src/stats/stats.ts
@@ -146,6 +146,8 @@ export type TxStats = {
   newNullifierCount: number;
   /** How many classes were registered through the canonical class registerer. */
   classRegisteredCount: number;
+  /** How this tx pays for its fee */
+  feePaymentMethod: 'none' | 'native' | 'fpc_public' | 'fpc_private';
 };
 
 /**
@@ -168,7 +170,8 @@ export type TxSequencerProcessingStats = {
   duration: number;
   /** Count of how many public writes this tx has made. Acts as a proxy for how 'heavy' this tx */
   publicDataUpdateRequests: number;
-} & TxStats;
+  effectsSize: number;
+} & Pick<TxStats, 'classRegisteredCount' | 'newCommitmentCount' | 'feePaymentMethod'>;
 
 /**
  * Stats for tree insertions

--- a/yarn-project/circuit-types/src/tx/tx.ts
+++ b/yarn-project/circuit-types/src/tx/tx.ts
@@ -165,6 +165,18 @@ export class Tx {
 
       proofSize: this.proof.buffer.length,
       size: this.toBuffer().length,
+
+      feePaymentMethod:
+        // needsTeardown? then we pay a fee
+        this.data.needsTeardown
+          ? // needsSetup? then we pay through a fee payment contract
+            this.data.needsSetup
+            ? // if the first call is to `approve_public_authwit`, then it's a public payment
+              this.enqueuedPublicFunctionCalls.at(-1)!.functionData.selector.toField().toBigInt() === 0x43417bb1n
+              ? 'fpc_public'
+              : 'fpc_private'
+            : 'native'
+          : 'none',
       classRegisteredCount: this.unencryptedLogs
         .unrollLogs()
         .map(log => UnencryptedL2Log.fromBuffer(log))

--- a/yarn-project/end-to-end/scripts/docker-compose-no-sandbox.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose-no-sandbox.yml
@@ -26,6 +26,8 @@ services:
       WS_BLOCK_CHECK_INTERVAL_MS: 50
       PXE_BLOCK_POLLING_INTERVAL_MS: 50
       ARCHIVER_VIEM_POLLING_INTERVAL_MS: 500
+      ENABLE_GAS: ${ENABLE_GAS:-''}
+      JOB_NAME: ${JOB_NAME:-''}
     command: ${TEST:-./src/e2e_deploy_contract.test.ts}
     volumes:
       - ../log:/usr/src/yarn-project/end-to-end/log:rw

--- a/yarn-project/end-to-end/src/benchmarks/bench_tx_size_fees.test.ts
+++ b/yarn-project/end-to-end/src/benchmarks/bench_tx_size_fees.test.ts
@@ -1,0 +1,84 @@
+import {
+  AccountWalletWithPrivateKey,
+  AztecAddress,
+  FeePaymentMethod,
+  NativeFeePaymentMethod,
+  PrivateFeePaymentMethod,
+  PublicFeePaymentMethod,
+  TxStatus,
+} from '@aztec/aztec.js';
+import { FPCContract, GasTokenContract, TokenContract } from '@aztec/noir-contracts.js';
+import { getCanonicalGasTokenAddress } from '@aztec/protocol-contracts/gas-token';
+
+import { jest } from '@jest/globals';
+
+import { EndToEndContext, publicDeployAccounts, setup } from '../fixtures/utils.js';
+
+jest.setTimeout(50_000);
+
+describe('benchmarks/tx_size_fees', () => {
+  let ctx: EndToEndContext;
+  let aliceWallet: AccountWalletWithPrivateKey;
+  let bobAddress: AztecAddress;
+  let sequencerAddress: AztecAddress;
+  let gas: GasTokenContract;
+  let fpc: FPCContract;
+  let token: TokenContract;
+
+  // setup the environment
+  beforeAll(async () => {
+    ctx = await setup(3);
+    aliceWallet = ctx.wallets[0];
+    bobAddress = ctx.wallets[1].getAddress();
+    sequencerAddress = ctx.wallets[2].getAddress();
+
+    await ctx.aztecNode.setConfig({
+      feeRecipient: sequencerAddress,
+    });
+
+    await publicDeployAccounts(aliceWallet, ctx.accounts);
+  });
+
+  // deploy the contracts
+  beforeAll(async () => {
+    gas = await GasTokenContract.at(
+      getCanonicalGasTokenAddress(ctx.deployL1ContractsValues.l1ContractAddresses.gasPortalAddress),
+      aliceWallet,
+    );
+    token = await TokenContract.deploy(aliceWallet, aliceWallet.getAddress(), 'test', 'test', 18).send().deployed();
+    fpc = await FPCContract.deploy(aliceWallet, token.address, gas.address).send().deployed();
+  });
+
+  // mint tokens
+  beforeAll(async () => {
+    await Promise.all([
+      gas.methods.mint_public(aliceWallet.getAddress(), 1000n).send().wait(),
+      token.methods.privately_mint_private_note(1000n).send().wait(),
+      token.methods.mint_public(aliceWallet.getAddress(), 1000n).send().wait(),
+
+      gas.methods.mint_public(fpc.address, 1000n).send().wait(),
+    ]);
+  });
+
+  it.each<() => Promise<FeePaymentMethod | undefined>>([
+    () => Promise.resolve(undefined),
+    () => NativeFeePaymentMethod.create(aliceWallet),
+    () => Promise.resolve(new PublicFeePaymentMethod(token.address, fpc.address, aliceWallet)),
+    () => Promise.resolve(new PrivateFeePaymentMethod(token.address, fpc.address, aliceWallet)),
+  ])('sends a tx with a fee', async createPaymentMethod => {
+    const paymentMethod = await createPaymentMethod();
+    const tx = await token.methods
+      .transfer(aliceWallet.getAddress(), bobAddress, 1n, 0)
+      .send({
+        fee: paymentMethod
+          ? {
+              maxFee: 3n,
+              paymentMethod,
+            }
+          : undefined,
+      })
+      .wait();
+
+    expect(tx.status).toEqual(TxStatus.MINED);
+  });
+});

--- a/yarn-project/scripts/src/benchmarks/markdown.ts
+++ b/yarn-project/scripts/src/benchmarks/markdown.ts
@@ -187,6 +187,7 @@ export function getMarkdown() {
   const metricsByChainLength = Metrics.filter(m => m.groupBy === 'chain-length').map(m => m.name);
   const metricsByCircuitName = Metrics.filter(m => m.groupBy === 'circuit-name').map(m => m.name);
   const metricsByClassesRegistered = Metrics.filter(m => m.groupBy === 'classes-registered').map(m => m.name);
+  const metricsByFeePaymentMethod = Metrics.filter(m => m.groupBy === 'fee-payment-method').map(m => m.name);
   const metricsByLeafCount = Metrics.filter(m => m.groupBy === 'leaf-count').map(m => m.name);
 
   const metricsTxPxeProcessing = Metrics.filter(m => m.name === 'tx_pxe_processing_time_ms').map(m => m.name);
@@ -241,6 +242,9 @@ ${getTableContent(pick(benchmark, metricsByLeafCount), baseBenchmark, 'leaves')}
 
 Transaction sizes based on how many contract classes are registered in the tx.
 ${getTableContent(pick(benchmark, metricsByClassesRegistered), baseBenchmark, 'registered classes')}
+
+Transaction size based on fee payment method
+${getTableContent(pick(benchmark, metricsByFeePaymentMethod), baseBenchmark, 'fee payment method')}
 
 Transaction processing duration by data writes.
 ${getTableContent(pick(benchmark, metricsTxPxeProcessing), baseBenchmark, 'new note hashes')}

--- a/yarn-project/sequencer-client/src/sequencer/public_processor.ts
+++ b/yarn-project/sequencer-client/src/sequencer/public_processor.ts
@@ -7,6 +7,7 @@ import {
   getPreviousOutputAndProof,
   makeEmptyProcessedTx,
   makeProcessedTx,
+  toTxEffect,
   validateProcessedTx,
 } from '@aztec/circuit-types';
 import { TxSequencerProcessingStats } from '@aztec/circuit-types/stats';
@@ -133,6 +134,7 @@ export class PublicProcessor {
         this.log(`Processed public part of ${tx.data.endNonRevertibleData.newNullifiers[0].value}`, {
           eventName: 'tx-sequencer-processing',
           duration: timer.ms(),
+          effectsSize: toTxEffect(processedTransaction).toBuffer().length,
           publicDataUpdateRequests:
             processedTransaction.data.combinedData.publicDataUpdateRequests.filter(x => !x.leafSlot.isZero()).length ??
             0,


### PR DESCRIPTION
This PR adds new benchmarks to compare tx size with different fee payment methods.

The tx type chosen for this benchmark is a simple private transfer: `token_contract.transfer(alice, bob, 1n, 0)` . This is expected to (1) nullify one of Alice's note (2) create a note for Bob with the amount and (3) create a note for Alice with the left over from the nullified note. On top of this base we add the costs of paying the fee in public/private

Fix #5403
