### PR TITLE
fix: Track class registered count in tx stats

### DIFF
--- a/yarn-project/circuit-types/src/tx/tx.ts
+++ b/yarn-project/circuit-types/src/tx/tx.ts
@@ -9,6 +9,7 @@ import {
 import { arrayNonEmptyLength } from '@aztec/foundation/collection';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
+import { UnencryptedL2Log } from '../index.js';
 import { GetUnencryptedLogsResponse } from '../logs/get_unencrypted_logs_response.js';
 import { L2LogsSource } from '../logs/l2_logs_source.js';
 import { TxL2Logs } from '../logs/tx_l2_logs.js';
@@ -166,7 +167,8 @@ export class Tx {
       size: this.toBuffer().length,
       classRegisteredCount: this.unencryptedLogs
         .unrollLogs()
-        .filter(log => ContractClassRegisteredEvent.isContractClassRegisteredEvent(log)).length,
+        .map(log => UnencryptedL2Log.fromBuffer(log))
+        .filter(log => ContractClassRegisteredEvent.isContractClassRegisteredEvent(log.data)).length,
     };
   }
 


### PR DESCRIPTION
We were incorrectly deserializing log elements from txs, so the class registered count was always zero. Thanks @alexghr for reporting.
