### PR TITLE
feat(SimulateTx): simulate constrained transaction execution with return values

### DIFF
--- a/boxes/boxes/react/src/hooks/useNumber.tsx
+++ b/boxes/boxes/react/src/hooks/useNumber.tsx
@@ -11,7 +11,7 @@ export function useNumber({ contract }: { contract: Contract }) {
 
     setWait(true);
     const deployerWallet = await deployerEnv.getWallet();
-    const viewTxReceipt = await contract!.methods.getNumber(deployerWallet.getCompleteAddress()).view();
+    const viewTxReceipt = await contract!.methods.getNumber(deployerWallet.getCompleteAddress()).simulate();
     toast(`Number is: ${viewTxReceipt.value}`);
     setWait(false);
   };

--- a/boxes/boxes/react/tests/node.test.ts
+++ b/boxes/boxes/react/tests/node.test.ts
@@ -25,7 +25,7 @@ describe('BoxReact Contract Tests', () => {
   }, 40000);
 
   test('Can read a number', async () => {
-    const viewTxReceipt = await contract.methods.getNumber(wallet.getCompleteAddress()).view();
+    const viewTxReceipt = await contract.methods.getNumber(wallet.getCompleteAddress()).simulate();
     expect(numberToSet.toBigInt()).toEqual(viewTxReceipt.value);
   }, 40000);
 });

--- a/boxes/boxes/vanilla/src/index.ts
+++ b/boxes/boxes/vanilla/src/index.ts
@@ -42,6 +42,6 @@ document.querySelector('#set').addEventListener('submit', async (e: Event) => {
 });
 
 document.querySelector('#get').addEventListener('click', async () => {
-  const viewTxReceipt = await contract.methods.getNumber(wallet.getCompleteAddress().address).view();
+  const viewTxReceipt = await contract.methods.getNumber(wallet.getCompleteAddress().address).simulate();
   alert(`Number is: ${viewTxReceipt.value}`);
 });

--- a/docs/docs/developers/aztecjs/guides/call_view_function.md
+++ b/docs/docs/developers/aztecjs/guides/call_view_function.md
@@ -1,8 +1,8 @@
 ---
-title: How to Call a View Function
+title: How to Simulate a Function Call
 ---
 
-This guide explains how to call a `view` function using [Aztec.js](../main.md).
+This guide explains how to `simulate` a function call using [Aztec.js](../main.md).
 
 To do this from the CLI, go [here](../../sandbox/references/cli-commands.md#calling-an-unconstrained-view-function).
 
@@ -26,9 +26,13 @@ Get a previously deployed contract like this:
 
 #include_code get_contract yarn-project/end-to-end/src/docs_examples.test.ts typescript
 
-## Call view function
+## Simulating function calls
 
-Call the `view` function on the contract like this:
+Call the `simulate` function on the typescript contract wrapper like this:
 
-#include_code call_view_function yarn-project/end-to-end/src/docs_examples.test.ts typescript
+#include_code simulate_function yarn-project/end-to-end/src/docs_examples.test.ts typescript
 
+:::info Note
+- If the simulated function is `unconstrained` you will get a properly typed value.
+- If the simulated function is `public` or `private` it will return a Field array of size 4.
+:::

--- a/docs/docs/developers/tutorials/testing.md
+++ b/docs/docs/developers/tutorials/testing.md
@@ -140,7 +140,7 @@ WARN Error processing tx 06dc87c4d64462916ea58426ffcfaf20017880b353c9ec3e0f0ee5f
 
 ### State
 
-We can check private or public state directly rather than going through view-only methods, as we did in the initial example by calling `token.methods.balance().view()`. Bear in mind that directly accessing contract storage will break any kind of encapsulation.
+We can check private or public state directly rather than going through view-only methods, as we did in the initial example by calling `token.methods.balance().simulate()`. Bear in mind that directly accessing contract storage will break any kind of encapsulation.
 
 To query storage directly, you'll need to know the slot you want to access. This can be checked in the [contract's `Storage` definition](../contracts/writing_contracts/storage/main.md) directly for most data types. However, when it comes to mapping types, as in most EVM languages, we'll need to calculate the slot for a given key. To do this, we'll use the [`CheatCodes`](../sandbox/references/cheat_codes.md) utility class:
 

--- a/docs/docs/misc/migration_notes.md
+++ b/docs/docs/misc/migration_notes.md
@@ -17,6 +17,32 @@ This change was made to communicate that we do not constrain the value in circui
 + let random_value = unsafe_rand();
 ```
 
+### [AztecJS] Simulate and get return values for ANY call
+Historically it have been possible to "view" `unconstrained` functions to simulate them and get the return values, but not for `public` nor `private` functions.
+This have lead to a lot of bad code where we have the same function implemented thrice, once in `private`, once in `public` and once in `unconstrained`.
+It is not possible to call `simulate` on any call to get the return values! 
+However, beware that it currently always return a Field array of size 4 for private and public.
+This will change to become similar to the return values of the `unconstrained` with proper return times.
+
+```diff
+-    #[aztec(private)]
+-    fn get_shared_immutable_constrained_private() -> pub Leader {
+-        storage.shared_immutable.read_private()
+-    }
+-
+-    unconstrained fn get_shared_immutable() -> pub Leader {
+-        storage.shared_immutable.read_public()
+-    }
+
++    #[aztec(private)]
++    fn get_shared_immutable_private() -> pub Leader {
++        storage.shared_immutable.read_private()
++    }
+
+- const returnValues = await contract.methods.get_shared_immutable().view();
++ const returnValues = await contract.methods.get_shared_immutable_private().simulate();
+```
+
 ## 0.31.0
 
 ### [Aztec.nr] Public storage historical read API improvement

--- a/docs/docs/misc/migration_notes.md
+++ b/docs/docs/misc/migration_notes.md
@@ -19,10 +19,10 @@ This change was made to communicate that we do not constrain the value in circui
 
 ### [AztecJS] Simulate and get return values for ANY call
 Historically it have been possible to "view" `unconstrained` functions to simulate them and get the return values, but not for `public` nor `private` functions.
-This have lead to a lot of bad code where we have the same function implemented thrice, once in `private`, once in `public` and once in `unconstrained`.
+This has lead to a lot of bad code where we have the same function implemented thrice, once in `private`, once in `public` and once in `unconstrained`. 
 It is not possible to call `simulate` on any call to get the return values! 
-However, beware that it currently always return a Field array of size 4 for private and public.
-This will change to become similar to the return values of the `unconstrained` with proper return times.
+However, beware that it currently always returns a Field array of size 4 for private and public.  
+This will change to become similar to the return values of the `unconstrained` functions with proper return types.
 
 ```diff
 -    #[aztec(private)]

--- a/docs/docs/misc/migration_notes.md
+++ b/docs/docs/misc/migration_notes.md
@@ -935,13 +935,13 @@ To parse a `AztecAddress` to BigInt, use `.inner`
 Before:
 
 ```js
-const tokenBigInt = await bridge.methods.token().view();
+const tokenBigInt = await bridge.methods.token().simulate();
 ```
 
 Now:
 
 ```js
-const tokenBigInt = (await bridge.methods.token().view()).inner;
+const tokenBigInt = (await bridge.methods.token().simulate()).inner;
 ```
 
 ### [Aztec.nr] Add `protocol_types` to Nargo.toml

--- a/docs/internal_notes/building_dapps.md
+++ b/docs/internal_notes/building_dapps.md
@@ -22,7 +22,6 @@ Explain how to write a dapp using [`aztec.js`](https://github.com/AztecProtocol/
       - Instantiate a contract
       - Deploy a contract
       - How to generate a nice typescript interface for an Aztec.nr contract's functions (we have a little `.ts` program in `noir-contracts` to generate a types file at the moment... how would a user do this?)
-      - Call 'view' functions
       - Simulate functions (simulate the result, without sending to the 'network')
       - Execute functions (send them to the 'network')
       - Tx hashes and tx receipts

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -108,6 +108,44 @@ contract DocsExample {
         assert(read.points == expected.points, "Invalid points");
     }
 
+    #[aztec(private)]
+    fn multicall() -> pub AztecAddress {
+        AztecAddress::from_field(
+            context.call_private_function_no_args(
+                context.this_address(),
+                FunctionSelector::from_signature("get_message_sender()")
+            )[0]
+        )
+    }
+
+    #[aztec(private)]
+    fn multicall_public() {
+        context.call_public_function_no_args(
+            context.this_address(),
+            FunctionSelector::from_signature("get_message_sender_public()")
+        );
+    }
+
+    #[aztec(private)]
+    fn get_message_sender() -> pub AztecAddress {
+        context.msg_sender()
+    }
+
+    #[aztec(public)]
+    fn get_message_sender_public() -> pub AztecAddress {
+        context.msg_sender()
+    }
+
+    #[aztec(public)]
+    fn get_shared_immutable_constrained() -> pub Leader {
+        storage.shared_immutable.read_public()
+    }
+
+    #[aztec(private)]
+    fn get_shared_immutable_constrained_private() -> pub Leader {
+        storage.shared_immutable.read_private()
+    }
+
     unconstrained fn get_shared_immutable() -> pub Leader {
         storage.shared_immutable.read_public()
     }

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -109,31 +109,21 @@ contract DocsExample {
     }
 
     #[aztec(private)]
-    fn multicall() -> pub AztecAddress {
-        AztecAddress::from_field(
-            context.call_private_function_no_args(
-                context.this_address(),
-                FunctionSelector::from_signature("get_message_sender()")
-            )[0]
-        )
-    }
-
-    #[aztec(private)]
-    fn multicall_public() {
-        context.call_public_function_no_args(
+    fn get_shared_immutable_constrained_private_indirect() -> pub Leader {
+        let ret = context.call_private_function_no_args(
             context.this_address(),
-            FunctionSelector::from_signature("get_message_sender_public()")
+            FunctionSelector::from_signature("get_shared_immutable_constrained_private()")
         );
-    }
-
-    #[aztec(private)]
-    fn get_message_sender() -> pub AztecAddress {
-        context.msg_sender()
+        Leader::deserialize([ret[0], ret[1]])
     }
 
     #[aztec(public)]
-    fn get_message_sender_public() -> pub AztecAddress {
-        context.msg_sender()
+    fn get_shared_immutable_constrained_indirect() -> pub Leader {
+        let ret = context.call_public_function_no_args(
+            context.this_address(),
+            FunctionSelector::from_signature("get_shared_immutable_constrained()")
+        );
+        Leader::deserialize([ret[0], ret[1]])
     }
 
     #[aztec(public)]

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -110,6 +110,10 @@ contract DocsExample {
 
     #[aztec(private)]
     fn get_shared_immutable_constrained_private_indirect() -> pub Leader {
+        // This is a private function that calls another private function
+        // and returns the response.
+        // Used to test that we can retrieve values through calls and 
+        // correctly return them in the simulation
         let ret = context.call_private_function_no_args(
             context.this_address(),
             FunctionSelector::from_signature("get_shared_immutable_constrained_private()")
@@ -118,16 +122,20 @@ contract DocsExample {
     }
 
     #[aztec(public)]
-    fn get_shared_immutable_constrained_indirect() -> pub Leader {
+    fn get_shared_immutable_constrained_public_indirect() -> pub Leader {
+        // This is a public function that calls another public function
+        // and returns the response.
+        // Used to test that we can retrieve values through calls and 
+        // correctly return them in the simulation
         let ret = context.call_public_function_no_args(
             context.this_address(),
-            FunctionSelector::from_signature("get_shared_immutable_constrained()")
+            FunctionSelector::from_signature("get_shared_immutable_constrained_public()")
         );
         Leader::deserialize([ret[0], ret[1]])
     }
 
     #[aztec(public)]
-    fn get_shared_immutable_constrained() -> pub Leader {
+    fn get_shared_immutable_constrained_public() -> pub Leader {
         storage.shared_immutable.read_public()
     }
 

--- a/yarn-project/accounts/src/testing/configuration.ts
+++ b/yarn-project/accounts/src/testing/configuration.ts
@@ -68,7 +68,7 @@ export async function deployInitialTestAccounts(pxe: PXE) {
         skipPublicDeployment: true,
         universalDeploy: true,
       });
-      await deployMethod.simulate({});
+      await deployMethod.prove({});
       return deployMethod;
     }),
   );

--- a/yarn-project/accounts/src/testing/create_account.ts
+++ b/yarn-project/accounts/src/testing/create_account.ts
@@ -29,7 +29,7 @@ export async function createAccounts(pxe: PXE, numberOfAccounts = 1): Promise<Ac
     // the results get stored within the account object. By calling it here we increase the probability of all the
     // accounts being deployed in the same block because it makes the deploy() method basically instant.
     await account.getDeployMethod().then(d =>
-      d.simulate({
+      d.prove({
         contractAddressSalt: account.salt,
         skipClassRegistration: true,
         skipPublicDeployment: true,

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -663,7 +663,7 @@ export class AztecNodeService implements AztecNode {
       new WASMSimulator(),
     );
     const processor = await publicProcessorFactory.create(prevHeader, newGlobalVariables);
-    const [processedTxs, failedTxs] = await processor.process([tx]);
+    const [processedTxs, failedTxs, returns] = await processor.process([tx]);
     if (failedTxs.length) {
       this.log.warn(`Simulated tx ${tx.getTxHash()} fails: ${failedTxs[0].error}`);
       throw failedTxs[0].error;
@@ -674,6 +674,7 @@ export class AztecNodeService implements AztecNode {
       throw reverted[0].revertReason;
     }
     this.log.info(`Simulated tx ${tx.getTxHash()} succeeds`);
+    return returns;
   }
 
   public setConfig(config: Partial<SequencerConfig>): Promise<void> {

--- a/yarn-project/aztec.js/README.md
+++ b/yarn-project/aztec.js/README.md
@@ -31,12 +31,12 @@ const tx = await contract.methods.transfer(amount, recipientAddress).send().wait
 console.log(`Transferred ${amount} to ${recipientAddress} on block ${tx.blockNumber}`);
 ```
 
-### Call a view function
+### Simulate a function
 
 ```typescript
 import { Contract } from '@aztec/aztec.js';
 
 const contract = await Contract.at(contractAddress, MyContractArtifact, wallet);
-const balance = await contract.methods.get_balance(wallet.getAddress()).view();
+const balance = await contract.methods.get_balance(wallet.getAddress()).simulate();
 console.log(`Account balance is ${balance}`);
 ```

--- a/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
@@ -37,13 +37,13 @@ export abstract class BaseContractInteraction {
   public abstract create(options?: SendMethodOptions): Promise<TxExecutionRequest>;
 
   /**
-   * Simulates a transaction execution request and returns a tx object ready to be sent.
+   * Proves a transaction execution request and returns a tx object ready to be sent.
    * @param options - optional arguments to be used in the creation of the transaction
    * @returns The resulting transaction
    */
-  public async simulate(options: SendMethodOptions = {}): Promise<Tx> {
+  public async prove(options: SendMethodOptions = {}): Promise<Tx> {
     const txRequest = this.txRequest ?? (await this.create(options));
-    this.tx = await this.pxe.simulateTx(txRequest, !options.skipPublicSimulation);
+    this.tx = await this.pxe.proveTx(txRequest, !options.skipPublicSimulation);
     return this.tx;
   }
 
@@ -58,7 +58,7 @@ export abstract class BaseContractInteraction {
    */
   public send(options: SendMethodOptions = {}) {
     const promise = (async () => {
-      const tx = this.tx ?? (await this.simulate(options));
+      const tx = this.tx ?? (await this.prove(options));
       return this.pxe.sendTx(tx);
     })();
 

--- a/yarn-project/aztec.js/src/contract/contract.test.ts
+++ b/yarn-project/aztec.js/src/contract/contract.test.ts
@@ -1,7 +1,7 @@
 import { type Tx, type TxExecutionRequest, type TxHash, type TxReceipt } from '@aztec/circuit-types';
 import { AztecAddress, CompleteAddress, EthAddress } from '@aztec/circuits.js';
 import { type L1ContractAddresses } from '@aztec/ethereum';
-import { ABIParameterVisibility, type ContractArtifact, FunctionType } from '@aztec/foundation/abi';
+import { ABIParameterVisibility, type ContractArtifact, type DecodedReturn, FunctionType } from '@aztec/foundation/abi';
 import { type NodeInfo } from '@aztec/types/interfaces';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -113,10 +113,10 @@ describe('Contract Class', () => {
     wallet.createTxExecutionRequest.mockResolvedValue(mockTxRequest);
     wallet.getContractInstance.mockResolvedValue(contractInstance);
     wallet.sendTx.mockResolvedValue(mockTxHash);
-    wallet.viewTx.mockResolvedValue(mockViewResultValue);
+    wallet.viewTx.mockResolvedValue(mockViewResultValue as any as DecodedReturn);
     wallet.getTxReceipt.mockResolvedValue(mockTxReceipt);
     wallet.getNodeInfo.mockResolvedValue(mockNodeInfo);
-    wallet.simulateTx.mockResolvedValue(mockTx);
+    wallet.proveTx.mockResolvedValue(mockTx);
     wallet.getRegisteredAccounts.mockResolvedValue([account]);
   });
 
@@ -137,7 +137,7 @@ describe('Contract Class', () => {
 
   it('should call view on an unconstrained function', async () => {
     const fooContract = await Contract.at(contractAddress, defaultArtifact, wallet);
-    const result = await fooContract.methods.qux(123n).view({
+    const result = await fooContract.methods.qux(123n).simulate({
       from: account.address,
     });
     expect(wallet.viewTx).toHaveBeenCalledTimes(1);
@@ -148,11 +148,5 @@ describe('Contract Class', () => {
   it('should not call create on an unconstrained function', async () => {
     const fooContract = await Contract.at(contractAddress, defaultArtifact, wallet);
     await expect(fooContract.methods.qux().create()).rejects.toThrow();
-  });
-
-  it('should not call view on a secret or open function', async () => {
-    const fooContract = await Contract.at(contractAddress, defaultArtifact, wallet);
-    expect(() => fooContract.methods.bar().view()).toThrow();
-    expect(() => fooContract.methods.baz().view()).toThrow();
   });
 });

--- a/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
@@ -99,13 +99,13 @@ export class ContractFunctionInteraction extends BaseContractInteraction {
         packedArguments: [packedArgs],
         authWitnesses: [],
       });
-      const vue = await this.pxe.simulateTx(txRequest, false, options.from ?? this.wallet.getAddress());
-      return vue.privateReturnValues && vue.privateReturnValues[0];
+      const simulatedTx = await this.pxe.simulateTx(txRequest, false, options.from ?? this.wallet.getAddress());
+      return simulatedTx.privateReturnValues && simulatedTx.privateReturnValues[0];
     } else {
       const txRequest = await this.create();
-      const vue = await this.pxe.simulateTx(txRequest, true);
+      const simulatedTx = await this.pxe.simulateTx(txRequest, true);
       this.txRequest = undefined;
-      return vue.publicReturnValues && vue.publicReturnValues[0];
+      return simulatedTx.publicReturnValues && simulatedTx.publicReturnValues[0];
     }
   }
 }

--- a/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
@@ -100,12 +100,12 @@ export class ContractFunctionInteraction extends BaseContractInteraction {
         authWitnesses: [],
       });
       const simulatedTx = await this.pxe.simulateTx(txRequest, false, options.from ?? this.wallet.getAddress());
-      return simulatedTx.privateReturnValues && simulatedTx.privateReturnValues[0];
+      return simulatedTx.privateReturnValues?.[0];
     } else {
       const txRequest = await this.create();
       const simulatedTx = await this.pxe.simulateTx(txRequest, true);
       this.txRequest = undefined;
-      return simulatedTx.publicReturnValues && simulatedTx.publicReturnValues[0];
+      return simulatedTx.publicReturnValues?.[0];
     }
   }
 }

--- a/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
@@ -1,5 +1,5 @@
-import { type FunctionCall, type TxExecutionRequest } from '@aztec/circuit-types';
-import { type AztecAddress, FunctionData } from '@aztec/circuits.js';
+import { type FunctionCall, PackedArguments, TxExecutionRequest } from '@aztec/circuit-types';
+import { type AztecAddress, FunctionData, TxContext } from '@aztec/circuits.js';
 import { type FunctionAbi, FunctionType, encodeArguments } from '@aztec/foundation/abi';
 
 import { type Wallet } from '../account/wallet.js';
@@ -76,5 +76,46 @@ export class ContractFunctionInteraction extends BaseContractInteraction {
 
     const { from } = options;
     return this.wallet.viewTx(this.functionDao.name, this.args, this.contractAddress, from);
+  }
+
+  /**
+   * Execute a view (read-only) transaction on an unconstrained function.
+   * This method is used to call functions that do not modify the contract state and only return data.
+   * Throws an error if called on a non-unconstrained function.
+   * @param options - An optional object containing additional configuration for the transaction.
+   * @returns The result of the view transaction as returned by the contract function.
+   */
+  public async viewConstrained(options: ViewMethodOptions = {}) {
+    // We need to create the request, but we need to change the entry-point slightly I think :thinking:
+
+    const packedArgs = PackedArguments.fromArgs(encodeArguments(this.functionDao, this.args));
+
+    // I have forgotten what the hell origin is.
+
+    const nodeInfo = await this.wallet.getNodeInfo();
+
+    // We need to figure something better around for doing the simulation to have a origin and a to that is different
+    // such that we can actually replace the "msg_sender" etc
+
+    // Depending on public or not we need to do some changes.
+    const a = FunctionData.fromAbi(this.functionDao);
+
+    if (a.isPrivate) {
+      const txRequest = TxExecutionRequest.from({
+        argsHash: packedArgs.hash,
+        origin: this.contractAddress,
+        functionData: FunctionData.fromAbi(this.functionDao),
+        txContext: TxContext.empty(nodeInfo.chainId, nodeInfo.protocolVersion),
+        packedArguments: [packedArgs],
+        authWitnesses: [],
+      });
+
+      const vue = await this.pxe.simulateCall(txRequest, options.from ?? this.wallet.getAddress());
+      return vue.rv;
+    } else {
+      await this.create();
+      const vue = await this.pxe.simulateCall(this.txRequest!);
+      return vue.rv;
+    }
   }
 }

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -193,12 +193,12 @@ export class DeployMethod<TContract extends ContractBase = Contract> extends Bas
   }
 
   /**
-   * Simulate the request.
+   * Prove the request.
    * @param options - Deployment options.
-   * @returns The simulated tx.
+   * @returns The proven tx.
    */
-  public simulate(options: DeployOptions): Promise<Tx> {
-    return super.simulate(options);
+  public prove(options: DeployOptions): Promise<Tx> {
+    return super.prove(options);
   }
 
   /** Return this deployment address. */

--- a/yarn-project/aztec.js/src/contract/index.ts
+++ b/yarn-project/aztec.js/src/contract/index.ts
@@ -6,8 +6,8 @@
  *
  * The {@link Contract} class is the main class in this module, and provides static methods for deploying
  * a contract or interacting with an already deployed one. The `methods` property of the contract instance
- * provides access to private, public, and view methods, that can be invoked in a transaction via `send()`,
- * or can be queried via `view()`.
+ * provides access to private, public, and simulate methods, that can be invoked in a transaction via `send()`,
+ * or can be queried via `simulate()`.
  *
  * ```ts
  * const contract = await Contract.deploy(wallet, MyContractArtifact, [...constructorArgs]).send().deployed();
@@ -17,7 +17,7 @@
  * ```ts
  * const contract = await Contract.at(address, MyContractArtifact, wallet);
  * await contract.methods.mint(1000, owner).send().wait();
- * console.log(`Total supply is now ${await contract.methods.totalSupply().view()}`);
+ * console.log(`Total supply is now ${await contract.methods.totalSupply().simulate()}`);
  * ```
  *
  * The result of calling a method in a contract instance, such as `contract.methods.mint(1000, owner)`

--- a/yarn-project/aztec.js/src/rpc_clients/pxe_client.ts
+++ b/yarn-project/aztec.js/src/rpc_clients/pxe_client.ts
@@ -14,6 +14,7 @@ import {
   TxHash,
   TxReceipt,
   UnencryptedL2BlockL2Logs,
+  Vue,
 } from '@aztec/circuit-types';
 import {
   AztecAddress,
@@ -53,7 +54,7 @@ export const createPXEClient = (url: string, fetch = makeFetch([1, 2, 3], false)
       TxExecutionRequest,
       TxHash,
     },
-    { Tx, TxReceipt, EncryptedL2BlockL2Logs, UnencryptedL2BlockL2Logs, NullifierMembershipWitness },
+    { Tx, Vue, TxReceipt, EncryptedL2BlockL2Logs, UnencryptedL2BlockL2Logs, NullifierMembershipWitness },
     false,
     'pxe',
     fetch,

--- a/yarn-project/aztec.js/src/rpc_clients/pxe_client.ts
+++ b/yarn-project/aztec.js/src/rpc_clients/pxe_client.ts
@@ -8,13 +8,13 @@ import {
   Note,
   NullifierMembershipWitness,
   type PXE,
+  SimulatedTx,
   Tx,
   TxEffect,
   TxExecutionRequest,
   TxHash,
   TxReceipt,
   UnencryptedL2BlockL2Logs,
-  Vue,
 } from '@aztec/circuit-types';
 import {
   AztecAddress,
@@ -54,7 +54,7 @@ export const createPXEClient = (url: string, fetch = makeFetch([1, 2, 3], false)
       TxExecutionRequest,
       TxHash,
     },
-    { Tx, Vue, TxReceipt, EncryptedL2BlockL2Logs, UnencryptedL2BlockL2Logs, NullifierMembershipWitness },
+    { Tx, SimulatedTx, TxReceipt, EncryptedL2BlockL2Logs, UnencryptedL2BlockL2Logs, NullifierMembershipWitness },
     false,
     'pxe',
     fetch,

--- a/yarn-project/aztec.js/src/wallet/account_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/account_wallet.ts
@@ -161,7 +161,7 @@ export class AccountWallet extends BaseWallet {
       messageHash,
     ]);
 
-    const [isValidInPrivate, isValidInPublic] = await interaction.view();
+    const [isValidInPrivate, isValidInPublic] = (await interaction.simulate()) as [boolean, boolean];
     return { isValidInPrivate, isValidInPublic };
   }
 

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -102,11 +102,11 @@ export abstract class BaseWallet implements Wallet {
   getContracts(): Promise<AztecAddress[]> {
     return this.pxe.getContracts();
   }
-  simulateTx(txRequest: TxExecutionRequest, simulatePublic: boolean): Promise<Tx> {
-    return this.pxe.simulateTx(txRequest, simulatePublic);
+  proveTx(txRequest: TxExecutionRequest, simulatePublic: boolean): Promise<Tx> {
+    return this.pxe.proveTx(txRequest, simulatePublic);
   }
-  simulateCall(txRequest: TxExecutionRequest, msgSender: AztecAddress): Promise<Vue> {
-    return this.pxe.simulateCall(txRequest, msgSender);
+  simulateTx(txRequest: TxExecutionRequest, simulatePublic: boolean, msgSender: AztecAddress): Promise<Vue> {
+    return this.pxe.simulateTx(txRequest, simulatePublic, msgSender);
   }
   sendTx(tx: Tx): Promise<TxHash> {
     return this.pxe.sendTx(tx);

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -13,6 +13,7 @@ import {
   type TxExecutionRequest,
   type TxHash,
   type TxReceipt,
+  type Vue,
 } from '@aztec/circuit-types';
 import {
   type AztecAddress,
@@ -103,6 +104,9 @@ export abstract class BaseWallet implements Wallet {
   }
   simulateTx(txRequest: TxExecutionRequest, simulatePublic: boolean): Promise<Tx> {
     return this.pxe.simulateTx(txRequest, simulatePublic);
+  }
+  simulateCall(txRequest: TxExecutionRequest, msgSender: AztecAddress): Promise<Vue> {
+    return this.pxe.simulateCall(txRequest, msgSender);
   }
   sendTx(tx: Tx): Promise<TxHash> {
     return this.pxe.sendTx(tx);

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -7,13 +7,13 @@ import {
   type LogFilter,
   type NoteFilter,
   type PXE,
+  type SimulatedTx,
   type SyncStatus,
   type Tx,
   type TxEffect,
   type TxExecutionRequest,
   type TxHash,
   type TxReceipt,
-  type Vue,
 } from '@aztec/circuit-types';
 import {
   type AztecAddress,
@@ -105,7 +105,7 @@ export abstract class BaseWallet implements Wallet {
   proveTx(txRequest: TxExecutionRequest, simulatePublic: boolean): Promise<Tx> {
     return this.pxe.proveTx(txRequest, simulatePublic);
   }
-  simulateTx(txRequest: TxExecutionRequest, simulatePublic: boolean, msgSender: AztecAddress): Promise<Vue> {
+  simulateTx(txRequest: TxExecutionRequest, simulatePublic: boolean, msgSender: AztecAddress): Promise<SimulatedTx> {
     return this.pxe.simulateTx(txRequest, simulatePublic, msgSender);
   }
   sendTx(tx: Tx): Promise<TxHash> {

--- a/yarn-project/aztec/src/examples/token.ts
+++ b/yarn-project/aztec/src/examples/token.ts
@@ -75,7 +75,7 @@ async function main() {
   await tokenAlice.methods.redeem_shield(alice, ALICE_MINT_BALANCE, aliceSecret).send().wait();
   logger(`${ALICE_MINT_BALANCE} tokens were successfully minted and redeemed by Alice`);
 
-  const balanceAfterMint = await tokenAlice.methods.balance_of_private(alice).view();
+  const balanceAfterMint = await tokenAlice.methods.balance_of_private(alice).simulate();
   logger(`Tokens successfully minted. New Alice's balance: ${balanceAfterMint}`);
 
   // We will now transfer tokens from Alice to Bob
@@ -83,10 +83,10 @@ async function main() {
   await tokenAlice.methods.transfer(alice, bob, TRANSFER_AMOUNT, 0).send().wait();
 
   // Check the new balances
-  const aliceBalance = await tokenAlice.methods.balance_of_private(alice).view();
+  const aliceBalance = await tokenAlice.methods.balance_of_private(alice).simulate();
   logger(`Alice's balance ${aliceBalance}`);
 
-  const bobBalance = await tokenBob.methods.balance_of_private(bob).view();
+  const bobBalance = await tokenBob.methods.balance_of_private(bob).simulate();
   logger(`Bob's balance ${bobBalance}`);
 }
 

--- a/yarn-project/circuit-types/src/interfaces/aztec-node.ts
+++ b/yarn-project/circuit-types/src/interfaces/aztec-node.ts
@@ -7,6 +7,7 @@ import {
   type PUBLIC_DATA_TREE_HEIGHT,
 } from '@aztec/circuits.js';
 import { type L1ContractAddresses } from '@aztec/ethereum';
+import { type ProcessReturnValues } from '@aztec/foundation/abi';
 import { type AztecAddress } from '@aztec/foundation/aztec-address';
 import { type Fr } from '@aztec/foundation/fields';
 import { type ContractClassPublic, type ContractInstanceWithAddress } from '@aztec/types/contracts';
@@ -282,7 +283,7 @@ export interface AztecNode {
    * This currently just checks that the transaction execution succeeds.
    * @param tx - The transaction to simulate.
    **/
-  simulatePublicCalls(tx: Tx): Promise<void>;
+  simulatePublicCalls(tx: Tx): Promise<ProcessReturnValues[]>;
 
   /**
    * Updates the configuration of this node.

--- a/yarn-project/circuit-types/src/interfaces/pxe.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.ts
@@ -14,7 +14,7 @@ import { type L2Block } from '../l2_block.js';
 import { type GetUnencryptedLogsResponse, type LogFilter } from '../logs/index.js';
 import { type ExtendedNote } from '../notes/index.js';
 import { type NoteFilter } from '../notes/note_filter.js';
-import { type Tx, type TxHash, type TxReceipt, type Vue } from '../tx/index.js';
+import { type SimulatedTx, type Tx, type TxHash, type TxReceipt } from '../tx/index.js';
 import { type TxEffect } from '../tx_effect.js';
 import { type TxExecutionRequest } from '../tx_execution_request.js';
 import { type SyncStatus } from './sync-status.js';
@@ -146,7 +146,7 @@ export interface PXE {
    * Also throws if simulatePublic is true and public simulation reverts.
    */
   proveTx(txRequest: TxExecutionRequest, simulatePublic: boolean): Promise<Tx>;
-  simulateTx(txRequest: TxExecutionRequest, simulatePublic: boolean, msgSender?: AztecAddress): Promise<Vue>;
+  simulateTx(txRequest: TxExecutionRequest, simulatePublic: boolean, msgSender?: AztecAddress): Promise<SimulatedTx>;
 
   /**
    * Sends a transaction to an Aztec node to be broadcasted to the network and mined.

--- a/yarn-project/circuit-types/src/interfaces/pxe.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.ts
@@ -146,6 +146,26 @@ export interface PXE {
    * Also throws if simulatePublic is true and public simulation reverts.
    */
   proveTx(txRequest: TxExecutionRequest, simulatePublic: boolean): Promise<Tx>;
+
+  /**
+   * Simulates a transaction based on the provided preauthenticated execution request.
+   * This will run a local simulation of private execution (and optionally of public as well), assemble
+   * the zero-knowledge proof for the private execution, and return the transaction object along
+   * with simulation results (return values).
+   *
+   *
+   * Note that this is used with `ContractFunctionInteraction::simulateTx` to bypass certain checks.
+   * In that case, the transaction returned is only potentially ready to be sent to the network for execution.
+   *
+   *
+   * @param txRequest - An authenticated tx request ready for simulation
+   * @param simulatePublic - Whether to simulate the public part of the transaction.
+   * @param msgSender - (Optional) The message sender to use for the simulation.
+   * @returns A simulated transaction object that includes a transaction that is potentially ready
+   * to be sent to the network for execution, along with public and private return values.
+   * @throws If the code for the functions executed in this transaction has not been made available via `addContracts`.
+   * Also throws if simulatePublic is true and public simulation reverts.
+   */
   simulateTx(txRequest: TxExecutionRequest, simulatePublic: boolean, msgSender?: AztecAddress): Promise<SimulatedTx>;
 
   /**

--- a/yarn-project/circuit-types/src/interfaces/pxe.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.ts
@@ -5,7 +5,7 @@ import {
   type GrumpkinPrivateKey,
   type PartialAddress,
 } from '@aztec/circuits.js';
-import { DecodedReturn, type ContractArtifact } from '@aztec/foundation/abi';
+import { type ContractArtifact } from '@aztec/foundation/abi';
 import { type ContractClassWithId, type ContractInstanceWithAddress } from '@aztec/types/contracts';
 import { type NodeInfo } from '@aztec/types/interfaces';
 
@@ -14,14 +14,10 @@ import { type L2Block } from '../l2_block.js';
 import { type GetUnencryptedLogsResponse, type LogFilter } from '../logs/index.js';
 import { type ExtendedNote } from '../notes/index.js';
 import { type NoteFilter } from '../notes/note_filter.js';
-import { type Tx, type TxHash, type TxReceipt } from '../tx/index.js';
+import { type Tx, type TxHash, type TxReceipt, type Vue } from '../tx/index.js';
 import { type TxEffect } from '../tx_effect.js';
 import { type TxExecutionRequest } from '../tx_execution_request.js';
 import { type SyncStatus } from './sync-status.js';
-
-export class Vue {
-  constructor(public tx: Tx, public rv?: DecodedReturn) {}
-}
 
 // docs:start:pxe-interface
 /**
@@ -149,12 +145,12 @@ export interface PXE {
    * @throws If the code for the functions executed in this transaction has not been made available via `addContracts`.
    * Also throws if simulatePublic is true and public simulation reverts.
    */
-  simulateTx(txRequest: TxExecutionRequest, simulatePublic: boolean): Promise<Tx>;
-  simulateCall(txRequest: TxExecutionRequest, msgSender?: AztecAddress): Promise<Vue>;
+  proveTx(txRequest: TxExecutionRequest, simulatePublic: boolean): Promise<Tx>;
+  simulateTx(txRequest: TxExecutionRequest, simulatePublic: boolean, msgSender?: AztecAddress): Promise<Vue>;
 
   /**
    * Sends a transaction to an Aztec node to be broadcasted to the network and mined.
-   * @param tx - The transaction as created via `simulateTx`.
+   * @param tx - The transaction as created via `proveTx`.
    * @returns A hash of the transaction, used to identify it.
    */
   sendTx(tx: Tx): Promise<TxHash>;

--- a/yarn-project/circuit-types/src/interfaces/pxe.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.ts
@@ -5,7 +5,7 @@ import {
   type GrumpkinPrivateKey,
   type PartialAddress,
 } from '@aztec/circuits.js';
-import { type ContractArtifact } from '@aztec/foundation/abi';
+import { DecodedReturn, type ContractArtifact } from '@aztec/foundation/abi';
 import { type ContractClassWithId, type ContractInstanceWithAddress } from '@aztec/types/contracts';
 import { type NodeInfo } from '@aztec/types/interfaces';
 
@@ -18,6 +18,10 @@ import { type Tx, type TxHash, type TxReceipt } from '../tx/index.js';
 import { type TxEffect } from '../tx_effect.js';
 import { type TxExecutionRequest } from '../tx_execution_request.js';
 import { type SyncStatus } from './sync-status.js';
+
+export class Vue {
+  constructor(public tx: Tx, public rv?: DecodedReturn) {}
+}
 
 // docs:start:pxe-interface
 /**
@@ -146,6 +150,7 @@ export interface PXE {
    * Also throws if simulatePublic is true and public simulation reverts.
    */
   simulateTx(txRequest: TxExecutionRequest, simulatePublic: boolean): Promise<Tx>;
+  simulateCall(txRequest: TxExecutionRequest, msgSender?: AztecAddress): Promise<Vue>;
 
   /**
    * Sends a transaction to an Aztec node to be broadcasted to the network and mined.

--- a/yarn-project/circuit-types/src/mocks.ts
+++ b/yarn-project/circuit-types/src/mocks.ts
@@ -7,7 +7,7 @@ import {
   computeContractClassId,
   getContractClassFromArtifact,
 } from '@aztec/circuits.js';
-import { type ContractArtifact } from '@aztec/foundation/abi';
+import { type ContractArtifact, type DecodedReturn } from '@aztec/foundation/abi';
 import { makeTuple } from '@aztec/foundation/array';
 import { times } from '@aztec/foundation/collection';
 import { randomBytes } from '@aztec/foundation/crypto';
@@ -19,7 +19,7 @@ import { EncryptedL2Log } from './logs/encrypted_l2_log.js';
 import { EncryptedFunctionL2Logs, EncryptedTxL2Logs, Note, UnencryptedTxL2Logs } from './logs/index.js';
 import { makePrivateKernelTailCircuitPublicInputs, makePublicCallRequest } from './mocks_to_purge.js';
 import { ExtendedNote } from './notes/index.js';
-import { Tx, TxHash } from './tx/index.js';
+import { SimulatedTx, Tx, TxHash } from './tx/index.js';
 
 /**
  * Testing utility to create empty logs composed from a single empty log.
@@ -52,6 +52,12 @@ export const mockTx = (seed = 1, logs = true) => {
   ).reverse() as Tuple<CallRequest, typeof MAX_REVERTIBLE_PUBLIC_CALL_STACK_LENGTH_PER_TX>;
 
   return tx;
+};
+
+export const mockSimulatedTx = (seed = 1, logs = true) => {
+  const tx = mockTx(seed, logs);
+  const dec: DecodedReturn = [1n, 2n, 3n, 4n];
+  return new SimulatedTx(tx, dec, dec);
 };
 
 export const randomContractArtifact = (): ContractArtifact => ({

--- a/yarn-project/circuit-types/src/tx/index.ts
+++ b/yarn-project/circuit-types/src/tx/index.ts
@@ -1,4 +1,5 @@
 export * from './tx.js';
+export * from './simulated_tx.js';
 export * from './tx_hash.js';
 export * from './tx_receipt.js';
 export * from './processed_tx.js';

--- a/yarn-project/circuit-types/src/tx/simulated_tx.test.ts
+++ b/yarn-project/circuit-types/src/tx/simulated_tx.test.ts
@@ -1,0 +1,9 @@
+import { mockSimulatedTx } from '../mocks.js';
+import { SimulatedTx } from './simulated_tx.js';
+
+describe('simulated_tx', () => {
+  it('convert to and from json', () => {
+    const simulatedTx = mockSimulatedTx();
+    expect(SimulatedTx.fromJSON(simulatedTx.toJSON())).toEqual(simulatedTx);
+  });
+});

--- a/yarn-project/circuit-types/src/tx/simulated_tx.ts
+++ b/yarn-project/circuit-types/src/tx/simulated_tx.ts
@@ -1,0 +1,68 @@
+import { AztecAddress } from '@aztec/circuits.js';
+import { type ProcessReturnValues } from '@aztec/foundation/abi';
+
+import { Tx } from './tx.js';
+
+export class SimulatedTx {
+  constructor(
+    public tx: Tx,
+    public privateReturnValues?: ProcessReturnValues,
+    public publicReturnValues?: ProcessReturnValues,
+  ) {}
+
+  /**
+   * Convert a SimulatedTx class object to a plain JSON object.
+   * @returns A plain object with SimulatedTx properties.
+   */
+  public toJSON() {
+    const returnToJson = (data: ProcessReturnValues): string => {
+      const replacer = (key: string, value: any): any => {
+        if (typeof value === 'bigint') {
+          return value.toString() + 'n'; // Indicate bigint with "n"
+        } else if (value instanceof AztecAddress) {
+          return value.toString();
+        } else {
+          return value;
+        }
+      };
+      return JSON.stringify(data, replacer);
+    };
+
+    return {
+      tx: this.tx.toJSON(),
+      privateReturnValues: returnToJson(this.privateReturnValues),
+      publicReturnValues: returnToJson(this.publicReturnValues),
+    };
+  }
+
+  /**
+   * Convert a plain JSON object to a Tx class object.
+   * @param obj - A plain Tx JSON object.
+   * @returns A Tx class object.
+   */
+  public static fromJSON(obj: any) {
+    const returnFromJson = (json: string): ProcessReturnValues => {
+      if (json == undefined) {
+        return json;
+      }
+      const reviver = (key: string, value: any): any => {
+        if (typeof value === 'string') {
+          if (value.match(/\d+n$/)) {
+            // Detect bigint serialization
+            return BigInt(value.slice(0, -1));
+          } else if (value.match(/^0x[a-fA-F0-9]{64}$/)) {
+            return AztecAddress.fromString(value);
+          }
+        }
+        return value;
+      };
+      return JSON.parse(json, reviver);
+    };
+
+    const tx = Tx.fromJSON(obj.tx);
+    const privateReturnValues = returnFromJson(obj.privateReturnValues);
+    const publicReturnValues = returnFromJson(obj.publicReturnValues);
+
+    return new SimulatedTx(tx, privateReturnValues, publicReturnValues);
+  }
+}

--- a/yarn-project/circuit-types/src/tx/tx.ts
+++ b/yarn-project/circuit-types/src/tx/tx.ts
@@ -1,4 +1,5 @@
 import {
+  AztecAddress,
   ContractClassRegisteredEvent,
   PrivateKernelTailCircuitPublicInputs,
   Proof,
@@ -6,6 +7,7 @@ import {
   SideEffect,
   SideEffectLinkedToNoteHash,
 } from '@aztec/circuits.js';
+import { ProcessReturnValues } from '@aztec/foundation/abi';
 import { arrayNonEmptyLength } from '@aztec/foundation/collection';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
@@ -14,6 +16,70 @@ import { type L2LogsSource } from '../logs/l2_logs_source.js';
 import { EncryptedTxL2Logs, UnencryptedTxL2Logs } from '../logs/tx_l2_logs.js';
 import { type TxStats } from '../stats/stats.js';
 import { TxHash } from './tx_hash.js';
+
+export class Vue {
+  constructor(
+    public tx: Tx,
+    public privateReturnValues?: ProcessReturnValues,
+    public publicReturnValues?: ProcessReturnValues,
+  ) {}
+
+  /**
+   * Convert a Vue class object to a plain JSON object.
+   * @returns A plain object with Vue properties.
+   */
+  public toJSON() {
+    const returnToJson = (data: ProcessReturnValues): string => {
+      const replacer = (key: string, value: any): any => {
+        if (typeof value === 'bigint') {
+          return value.toString() + 'n'; // Indicate bigint with "n"
+        } else if (value instanceof AztecAddress) {
+          return value.toString();
+        } else {
+          return value;
+        }
+      };
+      return JSON.stringify(data, replacer);
+    };
+
+    return {
+      tx: this.tx.toJSON(),
+      privateReturnValues: returnToJson(this.privateReturnValues),
+      publicReturnValues: returnToJson(this.publicReturnValues),
+    };
+  }
+
+  /**
+   * Convert a plain JSON object to a Tx class object.
+   * @param obj - A plain Tx JSON object.
+   * @returns A Tx class object.
+   */
+  public static fromJSON(obj: any) {
+    const returnFromJson = (json: string): ProcessReturnValues => {
+      if (json == undefined) {
+        return json;
+      }
+      const reviver = (key: string, value: any): any => {
+        if (typeof value === 'string') {
+          if (value.match(/\d+n$/)) {
+            // Detect bigint serialization
+            return BigInt(value.slice(0, -1));
+          } else if (value.match(/^0x[a-fA-F0-9]{64}$/)) {
+            return AztecAddress.fromString(value);
+          }
+        }
+        return value;
+      };
+      return JSON.parse(json, reviver);
+    };
+
+    const tx = Tx.fromJSON(obj.tx);
+    const privateReturnValues = returnFromJson(obj.privateReturnValues);
+    const publicReturnValues = returnFromJson(obj.publicReturnValues);
+
+    return new Vue(tx, privateReturnValues, publicReturnValues);
+  }
+}
 
 /**
  * The interface of an L2 transaction.

--- a/yarn-project/circuit-types/src/tx/tx.ts
+++ b/yarn-project/circuit-types/src/tx/tx.ts
@@ -7,7 +7,7 @@ import {
   SideEffect,
   SideEffectLinkedToNoteHash,
 } from '@aztec/circuits.js';
-import { ProcessReturnValues } from '@aztec/foundation/abi';
+import { type ProcessReturnValues } from '@aztec/foundation/abi';
 import { arrayNonEmptyLength } from '@aztec/foundation/collection';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 

--- a/yarn-project/circuit-types/src/tx/tx.ts
+++ b/yarn-project/circuit-types/src/tx/tx.ts
@@ -17,7 +17,7 @@ import { EncryptedTxL2Logs, UnencryptedTxL2Logs } from '../logs/tx_l2_logs.js';
 import { type TxStats } from '../stats/stats.js';
 import { TxHash } from './tx_hash.js';
 
-export class Vue {
+export class SimulatedTx {
   constructor(
     public tx: Tx,
     public privateReturnValues?: ProcessReturnValues,
@@ -25,8 +25,8 @@ export class Vue {
   ) {}
 
   /**
-   * Convert a Vue class object to a plain JSON object.
-   * @returns A plain object with Vue properties.
+   * Convert a SimulatedTx class object to a plain JSON object.
+   * @returns A plain object with SimulatedTx properties.
    */
   public toJSON() {
     const returnToJson = (data: ProcessReturnValues): string => {
@@ -77,7 +77,7 @@ export class Vue {
     const privateReturnValues = returnFromJson(obj.privateReturnValues);
     const publicReturnValues = returnFromJson(obj.publicReturnValues);
 
-    return new Vue(tx, privateReturnValues, publicReturnValues);
+    return new SimulatedTx(tx, privateReturnValues, publicReturnValues);
   }
 }
 

--- a/yarn-project/circuit-types/src/tx/tx.ts
+++ b/yarn-project/circuit-types/src/tx/tx.ts
@@ -1,5 +1,4 @@
 import {
-  AztecAddress,
   ContractClassRegisteredEvent,
   PrivateKernelTailCircuitPublicInputs,
   Proof,
@@ -7,7 +6,6 @@ import {
   SideEffect,
   SideEffectLinkedToNoteHash,
 } from '@aztec/circuits.js';
-import { type ProcessReturnValues } from '@aztec/foundation/abi';
 import { arrayNonEmptyLength } from '@aztec/foundation/collection';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
@@ -16,70 +14,6 @@ import { type L2LogsSource } from '../logs/l2_logs_source.js';
 import { EncryptedTxL2Logs, UnencryptedTxL2Logs } from '../logs/tx_l2_logs.js';
 import { type TxStats } from '../stats/stats.js';
 import { TxHash } from './tx_hash.js';
-
-export class SimulatedTx {
-  constructor(
-    public tx: Tx,
-    public privateReturnValues?: ProcessReturnValues,
-    public publicReturnValues?: ProcessReturnValues,
-  ) {}
-
-  /**
-   * Convert a SimulatedTx class object to a plain JSON object.
-   * @returns A plain object with SimulatedTx properties.
-   */
-  public toJSON() {
-    const returnToJson = (data: ProcessReturnValues): string => {
-      const replacer = (key: string, value: any): any => {
-        if (typeof value === 'bigint') {
-          return value.toString() + 'n'; // Indicate bigint with "n"
-        } else if (value instanceof AztecAddress) {
-          return value.toString();
-        } else {
-          return value;
-        }
-      };
-      return JSON.stringify(data, replacer);
-    };
-
-    return {
-      tx: this.tx.toJSON(),
-      privateReturnValues: returnToJson(this.privateReturnValues),
-      publicReturnValues: returnToJson(this.publicReturnValues),
-    };
-  }
-
-  /**
-   * Convert a plain JSON object to a Tx class object.
-   * @param obj - A plain Tx JSON object.
-   * @returns A Tx class object.
-   */
-  public static fromJSON(obj: any) {
-    const returnFromJson = (json: string): ProcessReturnValues => {
-      if (json == undefined) {
-        return json;
-      }
-      const reviver = (key: string, value: any): any => {
-        if (typeof value === 'string') {
-          if (value.match(/\d+n$/)) {
-            // Detect bigint serialization
-            return BigInt(value.slice(0, -1));
-          } else if (value.match(/^0x[a-fA-F0-9]{64}$/)) {
-            return AztecAddress.fromString(value);
-          }
-        }
-        return value;
-      };
-      return JSON.parse(json, reviver);
-    };
-
-    const tx = Tx.fromJSON(obj.tx);
-    const privateReturnValues = returnFromJson(obj.privateReturnValues);
-    const publicReturnValues = returnFromJson(obj.publicReturnValues);
-
-    return new SimulatedTx(tx, privateReturnValues, publicReturnValues);
-  }
-}
 
 /**
  * The interface of an L2 transaction.

--- a/yarn-project/end-to-end/src/benchmarks/utils.ts
+++ b/yarn-project/end-to-end/src/benchmarks/utils.ts
@@ -88,7 +88,7 @@ export async function sendTxs(
   contract: BenchmarkingContract,
 ): Promise<SentTx[]> {
   const calls = times(txCount, index => makeCall(index, context, contract));
-  await Promise.all(calls.map(call => call.simulate({ skipPublicSimulation: true })));
+  await Promise.all(calls.map(call => call.prove({ skipPublicSimulation: true })));
   const sentTxs = calls.map(call => call.send());
 
   // Awaiting txHash waits until the aztec node has received the tx into its p2p pool

--- a/yarn-project/end-to-end/src/docs_examples.test.ts
+++ b/yarn-project/end-to-end/src/docs_examples.test.ts
@@ -44,7 +44,7 @@ describe('docs_examples', () => {
     // docs:end:send_transaction
 
     // docs:start:call_view_function
-    const balance = await contract.methods.balance_of_public(wallet.getAddress()).view();
+    const balance = await contract.methods.balance_of_public(wallet.getAddress()).simulate();
     expect(balance).toEqual(1n);
     // docs:end:call_view_function
   }, 120_000);

--- a/yarn-project/end-to-end/src/docs_examples.test.ts
+++ b/yarn-project/end-to-end/src/docs_examples.test.ts
@@ -43,9 +43,9 @@ describe('docs_examples', () => {
     const _tx = await contract.methods.mint_public(wallet.getAddress(), 1).send().wait();
     // docs:end:send_transaction
 
-    // docs:start:call_view_function
+    // docs:start:simulate_function
     const balance = await contract.methods.balance_of_public(wallet.getAddress()).simulate();
     expect(balance).toEqual(1n);
-    // docs:end:call_view_function
+    // docs:end:simulate_function
   }, 120_000);
 });

--- a/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
@@ -82,7 +82,7 @@ describe('e2e_2_pxes', () => {
 
     // Then check the balance
     const contractWithWallet = await TokenContract.at(tokenAddress, wallet);
-    const balance = await contractWithWallet.methods.balance_of_private(owner).view({ from: owner });
+    const balance = await contractWithWallet.methods.balance_of_private(owner).simulate({ from: owner });
     logger(`Account ${owner} balance: ${balance}`);
     expect(balance).toBe(expectedBalance);
   };

--- a/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
+++ b/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
@@ -60,7 +60,7 @@ function itShouldBehaveLikeAnAccountContract(
       const accountAddress = wallet.getCompleteAddress();
       const invalidWallet = await walletAt(context.pxe, getAccountContract(GrumpkinScalar.random()), accountAddress);
       const childWithInvalidWallet = await ChildContract.at(child.address, invalidWallet);
-      await expect(childWithInvalidWallet.methods.value(42).simulate()).rejects.toThrow(/Cannot satisfy constraint.*/);
+      await expect(childWithInvalidWallet.methods.value(42).prove()).rejects.toThrow(/Cannot satisfy constraint.*/);
     });
   });
 }

--- a/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
+++ b/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
@@ -32,14 +32,14 @@ describe('e2e_avm_simulator', () => {
 
     it('Modifies storage (Field)', async () => {
       await avmContact.methods.set_storage_single(20n).send().wait();
-      expect(await avmContact.methods.view_storage_single().view()).toEqual(20n);
+      expect(await avmContact.methods.view_storage_single().simulate()).toEqual(20n);
     });
 
     it('Modifies storage (Map)', async () => {
       const address = AztecAddress.fromBigInt(9090n);
       await avmContact.methods.set_storage_map(address, 100).send().wait();
       await avmContact.methods.add_storage_map(address, 100).send().wait();
-      expect(await avmContact.methods.view_storage_map(address).view()).toEqual(200n);
+      expect(await avmContact.methods.view_storage_map(address).simulate()).toEqual(200n);
     });
   });
 

--- a/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
+++ b/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
@@ -27,7 +27,7 @@ describe('e2e_avm_simulator', () => {
   describe('Storage', () => {
     // FIX: Enable once the contract function works.
     // it('Read immutable (initialized) storage (Field)', async () => {
-    //   expect(await avmContact.methods.view_storage_immutable().view()).toEqual(42n);
+    //   expect(await avmContact.methods.view_storage_immutable().simulate()).toEqual(42n);
     // });
 
     it('Modifies storage (Field)', async () => {

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -57,7 +57,7 @@ describe('e2e_block_building', () => {
           skipClassRegistration: true,
           skipPublicDeployment: true,
         });
-        await methods[i].simulate({});
+        await methods[i].prove({});
       }
 
       // Send them simultaneously to be picked up by the sequencer
@@ -95,8 +95,8 @@ describe('e2e_block_building', () => {
         [minter.getCompleteAddress(), true],
       );
 
-      await deployer.simulate({});
-      await callInteraction.simulate({
+      await deployer.prove({});
+      await callInteraction.prove({
         // we have to skip simulation of public calls simulation is done on individual transactions
         // and the tx deploying the contract might go in the same block as this one
         skipPublicSimulation: true,
@@ -129,7 +129,7 @@ describe('e2e_block_building', () => {
         const nullifier = Fr.random();
         const calls = times(2, () => contract.methods.emit_nullifier(nullifier));
         for (const call of calls) {
-          await call.simulate();
+          await call.prove();
         }
         const [tx1, tx2] = calls.map(call => call.send());
         await expectXorTx(tx1, tx2);
@@ -139,7 +139,7 @@ describe('e2e_block_building', () => {
         const secret = Fr.random();
         const calls = times(2, () => contract.methods.create_nullifier_public(140n, secret));
         for (const call of calls) {
-          await call.simulate();
+          await call.prove();
         }
         const [tx1, tx2] = calls.map(call => call.send());
         await expectXorTx(tx1, tx2);
@@ -162,7 +162,7 @@ describe('e2e_block_building', () => {
         ];
 
         for (const call of calls) {
-          await call.simulate();
+          await call.prove();
         }
         const [tx1, tx2] = calls.map(call => call.send());
         await expectXorTx(tx1, tx2);

--- a/yarn-project/end-to-end/src/e2e_card_game.test.ts
+++ b/yarn-project/end-to-end/src/e2e_card_game.test.ts
@@ -142,7 +142,7 @@ describe('e2e_card_game', () => {
   it('should be able to buy packs', async () => {
     const seed = 27n;
     await contract.methods.buy_pack(seed).send().wait();
-    const collection = await contract.methods.view_collection_cards(firstPlayer, 0).view({ from: firstPlayer });
+    const collection = await contract.methods.view_collection_cards(firstPlayer, 0).simulate({ from: firstPlayer });
     const expected = getPackedCards(0, seed);
     expect(unwrapOptions(collection)).toMatchObject(expected);
   }, 30_000);
@@ -157,7 +157,7 @@ describe('e2e_card_game', () => {
         contractAsSecondPlayer.methods.buy_pack(seed).send().wait(),
       ]);
       firstPlayerCollection = unwrapOptions(
-        await contract.methods.view_collection_cards(firstPlayer, 0).view({ from: firstPlayer }),
+        await contract.methods.view_collection_cards(firstPlayer, 0).simulate({ from: firstPlayer }),
       );
     }, 30_000);
 
@@ -174,11 +174,11 @@ describe('e2e_card_game', () => {
           .wait(),
       ).rejects.toThrow(`Assertion failed: Cannot return zero notes`);
 
-      const collection = await contract.methods.view_collection_cards(firstPlayer, 0).view({ from: firstPlayer });
+      const collection = await contract.methods.view_collection_cards(firstPlayer, 0).simulate({ from: firstPlayer });
       expect(unwrapOptions(collection)).toHaveLength(1);
       expect(unwrapOptions(collection)).toMatchObject([firstPlayerCollection[1]]);
 
-      expect((await contract.methods.view_game(GAME_ID).view({ from: firstPlayer })) as Game).toMatchObject({
+      expect((await contract.methods.view_game(GAME_ID).simulate({ from: firstPlayer })) as Game).toMatchObject({
         players: [
           {
             address: firstPlayer,
@@ -202,7 +202,7 @@ describe('e2e_card_game', () => {
       const secondPlayerCollection = unwrapOptions(
         (await contract.methods
           .view_collection_cards(secondPlayer, 0)
-          .view({ from: secondPlayer })) as NoirOption<Card>[],
+          .simulate({ from: secondPlayer })) as NoirOption<Card>[],
       );
 
       await Promise.all([
@@ -218,7 +218,7 @@ describe('e2e_card_game', () => {
 
       await contract.methods.start_game(GAME_ID).send().wait();
 
-      expect((await contract.methods.view_game(GAME_ID).view({ from: firstPlayer })) as Game).toMatchObject({
+      expect((await contract.methods.view_game(GAME_ID).simulate({ from: firstPlayer })) as Game).toMatchObject({
         players: expect.arrayContaining([
           {
             address: firstPlayer,
@@ -253,15 +253,15 @@ describe('e2e_card_game', () => {
       ]);
 
       firstPlayerCollection = unwrapOptions(
-        await contract.methods.view_collection_cards(firstPlayer, 0).view({ from: firstPlayer }),
+        await contract.methods.view_collection_cards(firstPlayer, 0).simulate({ from: firstPlayer }),
       );
 
       secondPlayerCollection = unwrapOptions(
-        await contract.methods.view_collection_cards(secondPlayer, 0).view({ from: secondPlayer }),
+        await contract.methods.view_collection_cards(secondPlayer, 0).simulate({ from: secondPlayer }),
       );
 
       thirdPlayerCOllection = unwrapOptions(
-        await contract.methods.view_collection_cards(thirdPlayer, 0).view({ from: thirdPlayer }),
+        await contract.methods.view_collection_cards(thirdPlayer, 0).simulate({ from: thirdPlayer }),
       );
     }, 60_000);
 
@@ -270,7 +270,7 @@ describe('e2e_card_game', () => {
     }
 
     async function playGame(playerDecks: { address: AztecAddress; deck: Card[] }[], id = GAME_ID) {
-      const initialGameState = (await contract.methods.view_game(id).view({ from: firstPlayer })) as Game;
+      const initialGameState = (await contract.methods.view_game(id).simulate({ from: firstPlayer })) as Game;
       const players = initialGameState.players.map(player => player.address);
       const cards = players.map(
         player => playerDecks.find(playerDeckEntry => playerDeckEntry.address.equals(player))!.deck,
@@ -284,7 +284,7 @@ describe('e2e_card_game', () => {
         }
       }
 
-      const finalGameState = (await contract.methods.view_game(id).view({ from: firstPlayer })) as Game;
+      const finalGameState = (await contract.methods.view_game(id).simulate({ from: firstPlayer })) as Game;
 
       expect(finalGameState.finished).toBe(true);
       return finalGameState;
@@ -315,7 +315,7 @@ describe('e2e_card_game', () => {
       await contractFor(winner).methods.claim_cards(GAME_ID, game.rounds_cards.map(cardToField)).send().wait();
 
       const winnerCollection = unwrapOptions(
-        (await contract.methods.view_collection_cards(winner, 0).view({ from: winner })) as NoirOption<Card>[],
+        (await contract.methods.view_collection_cards(winner, 0).simulate({ from: winner })) as NoirOption<Card>[],
       );
 
       const winnerGameDeck = [winnerCollection[0], winnerCollection[3]];

--- a/yarn-project/end-to-end/src/e2e_counter_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_counter_contract.test.ts
@@ -32,7 +32,7 @@ describe('e2e_counter_contract', () => {
   describe('increments', () => {
     it('counts', async () => {
       await counterContract.methods.increment(owner).send().wait();
-      expect(await counterContract.methods.get_counter(owner).view()).toBe(1n);
+      expect(await counterContract.methods.get_counter(owner).simulate()).toBe(1n);
     });
   });
 });

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging.test.ts
@@ -173,7 +173,7 @@ describe('e2e_cross_chain_messaging', () => {
       l2Bridge
         .withWallet(user2Wallet)
         .methods.claim_private(secretHashForL2MessageConsumption, bridgeAmount, secretForL2MessageConsumption)
-        .simulate(),
+        .prove(),
     ).rejects.toThrow(`No non-nullified L1 to L2 message found for message hash ${wrongMessage.hash().toString()}`);
 
     // send the right one -
@@ -210,7 +210,7 @@ describe('e2e_cross_chain_messaging', () => {
       l2Bridge
         .withWallet(user1Wallet)
         .methods.exit_to_l1_private(l2Token.address, ethAccount, withdrawAmount, EthAddress.ZERO, nonce)
-        .simulate(),
+        .prove(),
     ).rejects.toThrow(`Unknown auth witness for message hash ${expectedBurnMessageHash.toString()}`);
   }, 120_000);
 
@@ -250,7 +250,7 @@ describe('e2e_cross_chain_messaging', () => {
       l2Bridge
         .withWallet(user2Wallet)
         .methods.claim_public(ownerAddress, bridgeAmount, secretForL2MessageConsumption)
-        .simulate(),
+        .prove(),
     ).rejects.toThrow(`No non-nullified L1 to L2 message found for message hash ${wrongMessage.hash().toString()}`);
   }, 120_000);
 });

--- a/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
+++ b/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
@@ -231,12 +231,12 @@ describe('e2e_crowdfunding_and_claim', () => {
     }
 
     // Since the RWT is minted 1:1 with the DNT, the balance of the reward token should be equal to the donation amount
-    const balanceRWT = await rewardToken.methods.balance_of_public(donorWallets[0].getAddress()).view();
+    const balanceRWT = await rewardToken.methods.balance_of_public(donorWallets[0].getAddress()).simulate();
     expect(balanceRWT).toEqual(donationAmount);
 
     const balanceDNTBeforeWithdrawal = await donationToken.methods
       .balance_of_private(operatorWallet.getAddress())
-      .view();
+      .simulate();
     expect(balanceDNTBeforeWithdrawal).toEqual(0n);
 
     // 4) At last, we withdraw the raised funds from the crowdfunding contract to the operator's address
@@ -244,7 +244,7 @@ describe('e2e_crowdfunding_and_claim', () => {
 
     const balanceDNTAfterWithdrawal = await donationToken.methods
       .balance_of_private(operatorWallet.getAddress())
-      .view();
+      .simulate();
 
     // Operator should have all the DNT now
     expect(balanceDNTAfterWithdrawal).toEqual(donationAmount);

--- a/yarn-project/end-to-end/src/e2e_dapp_subscription.test.ts
+++ b/yarn-project/end-to-end/src/e2e_dapp_subscription.test.ts
@@ -209,11 +209,11 @@ describe('e2e_dapp_subscription', () => {
     const dappPayload = new DefaultDappEntrypoint(aliceAddress, aliceWallet, subscriptionContract.address);
     const action = counterContract.methods.increment(bobAddress).request();
     const txExReq = await dappPayload.createTxExecutionRequest([action]);
-    const tx = await pxe.simulateTx(txExReq, true);
+    const tx = await pxe.proveTx(txExReq, true);
     const sentTx = new SentTx(pxe, pxe.sendTx(tx));
     await sentTx.wait();
 
-    expect(await counterContract.methods.get_counter(bobAddress).view()).toBe(1n);
+    expect(await counterContract.methods.get_counter(bobAddress).simulate()).toBe(1n);
 
     await expectMapping(
       gasBalances,
@@ -264,7 +264,7 @@ describe('e2e_dapp_subscription', () => {
     const dappEntrypoint = new DefaultDappEntrypoint(aliceAddress, aliceWallet, subscriptionContract.address);
     const action = counterContract.methods.increment(bobAddress).request();
     const txExReq = await dappEntrypoint.createTxExecutionRequest([action]);
-    const tx = await pxe.simulateTx(txExReq, true);
+    const tx = await pxe.proveTx(txExReq, true);
     const sentTx = new SentTx(pxe, pxe.sendTx(tx));
     return sentTx.wait();
   }

--- a/yarn-project/end-to-end/src/e2e_delegate_calls.test.ts
+++ b/yarn-project/end-to-end/src/e2e_delegate_calls.test.ts
@@ -34,11 +34,11 @@ describe('e2e_delegate_calls', () => {
 
       const delegatorValue = await delegatorContract.methods
         .view_private_value(sentValue, wallet.getCompleteAddress().address)
-        .view();
+        .simulate();
 
       const delegatedOnValue = await delegatedOnContract.methods
         .view_private_value(sentValue, wallet.getCompleteAddress().address)
-        .view();
+        .simulate();
 
       expect(delegatedOnValue).toEqual(0n);
       expect(delegatorValue).toEqual(sentValue);
@@ -55,8 +55,8 @@ describe('e2e_delegate_calls', () => {
         .send()
         .wait();
 
-      const delegatorValue = await delegatorContract.methods.view_public_value().view();
-      const delegatedOnValue = await delegatedOnContract.methods.view_public_value().view();
+      const delegatorValue = await delegatorContract.methods.view_public_value().simulate();
+      const delegatedOnValue = await delegatedOnContract.methods.view_public_value().simulate();
 
       expect(delegatedOnValue).toEqual(0n);
       expect(delegatorValue).toEqual(sentValue);
@@ -71,8 +71,8 @@ describe('e2e_delegate_calls', () => {
         .send()
         .wait();
 
-      const delegatorValue = await delegatorContract.methods.view_public_value().view();
-      const delegatedOnValue = await delegatedOnContract.methods.view_public_value().view();
+      const delegatorValue = await delegatorContract.methods.view_public_value().simulate();
+      const delegatedOnValue = await delegatedOnContract.methods.view_public_value().simulate();
 
       expect(delegatedOnValue).toEqual(0n);
       expect(delegatorValue).toEqual(sentValue);

--- a/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract.test.ts
@@ -132,7 +132,7 @@ describe('e2e_deploy_contract', () => {
         const firstOpts = { skipPublicSimulation: true, skipClassRegistration: true, skipInstanceDeploy: true };
         const secondOpts = { skipPublicSimulation: true };
 
-        await Promise.all([goodDeploy.simulate(firstOpts), badDeploy.simulate(secondOpts)]);
+        await Promise.all([goodDeploy.prove(firstOpts), badDeploy.prove(secondOpts)]);
         const [goodTx, badTx] = [goodDeploy.send(firstOpts), badDeploy.send(secondOpts)];
         const [goodTxPromiseResult, badTxReceiptResult] = await Promise.allSettled([
           goodTx.wait(),
@@ -192,10 +192,10 @@ describe('e2e_deploy_contract', () => {
           .send()
           .wait();
         logger.info(`Checking if the constructor was run for ${contract.address}`);
-        expect(await contract.methods.summed_values(owner).view()).toEqual(42n);
+        expect(await contract.methods.summed_values(owner).simulate()).toEqual(42n);
         logger.info(`Calling a private function that requires initialization on ${contract.address}`);
         await contract.methods.create_note(owner, 10).send().wait();
-        expect(await contract.methods.summed_values(owner).view()).toEqual(52n);
+        expect(await contract.methods.summed_values(owner).simulate()).toEqual(52n);
       },
       30_000,
     );
@@ -209,8 +209,8 @@ describe('e2e_deploy_contract', () => {
       );
       const calls = contracts.map((c, i) => c.methods.constructor(...initArgss[i]).request());
       await new BatchCall(wallet, calls).send().wait();
-      expect(await contracts[0].methods.summed_values(owner).view()).toEqual(42n);
-      expect(await contracts[1].methods.summed_values(owner).view()).toEqual(52n);
+      expect(await contracts[0].methods.summed_values(owner).simulate()).toEqual(42n);
+      expect(await contracts[1].methods.summed_values(owner).simulate()).toEqual(52n);
     }, 30_000);
 
     // TODO(@spalladino): This won't work until we can read a nullifier in the same tx in which it was emitted.
@@ -224,7 +224,7 @@ describe('e2e_deploy_contract', () => {
       ]);
       logger.info(`Executing constructor and private function in batch at ${contract.address}`);
       await batch.send().wait();
-      expect(await contract.methods.summed_values(owner).view()).toEqual(52n);
+      expect(await contract.methods.summed_values(owner).simulate()).toEqual(52n);
     });
 
     it('refuses to initialize a contract twice', async () => {
@@ -256,7 +256,7 @@ describe('e2e_deploy_contract', () => {
     it('refuses to initialize a contract with incorrect args', async () => {
       const owner = await registerRandomAccount(pxe);
       const contract = await registerContract(wallet, StatefulTestContract, { initArgs: [owner, 42] });
-      await expect(contract.methods.constructor(owner, 43).simulate()).rejects.toThrow(
+      await expect(contract.methods.constructor(owner, 43).prove()).rejects.toThrow(
         /Initialization hash does not match/,
       );
     });
@@ -264,7 +264,7 @@ describe('e2e_deploy_contract', () => {
     it('refuses to initialize an instance from a different deployer', async () => {
       const owner = await registerRandomAccount(pxe);
       const contract = await registerContract(wallet, StatefulTestContract, { initArgs: [owner, 42], deployer: owner });
-      await expect(contract.methods.constructor(owner, 42).simulate()).rejects.toThrow(
+      await expect(contract.methods.constructor(owner, 42).prove()).rejects.toThrow(
         /Initializer address is not the contract deployer/i,
       );
     });
@@ -390,7 +390,7 @@ describe('e2e_deploy_contract', () => {
               .increment_public_value_no_init_check(whom, 10)
               .send({ skipPublicSimulation: true })
               .wait();
-            const stored = await contract.methods.get_public_value(whom).view();
+            const stored = await contract.methods.get_public_value(whom).simulate();
             expect(stored).toEqual(10n);
           }, 30_000);
 
@@ -403,11 +403,11 @@ describe('e2e_deploy_contract', () => {
             expect(receipt.status).toEqual(TxStatus.REVERTED);
 
             // Meanwhile we check we didn't increment the value
-            expect(await contract.methods.get_public_value(whom).view()).toEqual(0n);
+            expect(await contract.methods.get_public_value(whom).simulate()).toEqual(0n);
           }, 30_000);
 
           it('refuses to initialize the instance with wrong args via a private function', async () => {
-            await expect(contract.methods.constructor(AztecAddress.random(), 43).simulate()).rejects.toThrow(
+            await expect(contract.methods.constructor(AztecAddress.random(), 43).prove()).rejects.toThrow(
               /initialization hash does not match/i,
             );
           }, 30_000);
@@ -419,7 +419,7 @@ describe('e2e_deploy_contract', () => {
               .wait();
             const whom = AztecAddress.random();
             await contract.methods.increment_public_value(whom, 10).send({ skipPublicSimulation: true }).wait();
-            const stored = await contract.methods.get_public_value(whom).view();
+            const stored = await contract.methods.get_public_value(whom).simulate();
             expect(stored).toEqual(10n);
           }, 30_000);
 
@@ -445,7 +445,7 @@ describe('e2e_deploy_contract', () => {
               .send({ skipPublicSimulation: true })
               .wait({ dontThrowOnRevert: true });
             expect(receipt.status).toEqual(TxStatus.REVERTED);
-            expect(await contract.methods.get_public_value(whom).view()).toEqual(0n);
+            expect(await contract.methods.get_public_value(whom).simulate()).toEqual(0n);
           }, 30_000);
 
           it('initializes the contract and calls a public function', async () => {
@@ -455,7 +455,7 @@ describe('e2e_deploy_contract', () => {
               .wait();
             const whom = AztecAddress.random();
             await contract.methods.increment_public_value(whom, 10).send({ skipPublicSimulation: true }).wait();
-            const stored = await contract.methods.get_public_value(whom).view();
+            const stored = await contract.methods.get_public_value(whom).simulate();
             expect(stored).toEqual(10n);
           }, 30_000);
 
@@ -516,25 +516,25 @@ describe('e2e_deploy_contract', () => {
       const owner = accounts[0];
       logger.debug(`Deploying stateful test contract`);
       const contract = await StatefulTestContract.deploy(wallet, owner, 42).send().deployed();
-      expect(await contract.methods.summed_values(owner).view()).toEqual(42n);
+      expect(await contract.methods.summed_values(owner).simulate()).toEqual(42n);
       logger.debug(`Calling public method on stateful test contract at ${contract.address.toString()}`);
       await contract.methods.increment_public_value(owner, 84).send().wait();
-      expect(await contract.methods.get_public_value(owner).view()).toEqual(84n);
+      expect(await contract.methods.get_public_value(owner).simulate()).toEqual(84n);
     }, 60_000);
 
     it('publicly universally deploys and initializes a contract', async () => {
       const owner = accounts[0];
       const opts = { universalDeploy: true };
       const contract = await StatefulTestContract.deploy(wallet, owner, 42).send(opts).deployed();
-      expect(await contract.methods.summed_values(owner).view()).toEqual(42n);
+      expect(await contract.methods.summed_values(owner).simulate()).toEqual(42n);
       await contract.methods.increment_public_value(owner, 84).send().wait();
-      expect(await contract.methods.get_public_value(owner).view()).toEqual(84n);
+      expect(await contract.methods.get_public_value(owner).simulate()).toEqual(84n);
     }, 60_000);
 
     it('publicly deploys and calls a public function from the constructor', async () => {
       const owner = accounts[0];
       const token = await TokenContract.deploy(wallet, owner, 'TOKEN', 'TKN', 18).send().deployed();
-      expect(await token.methods.is_minter(owner).view()).toEqual(true);
+      expect(await token.methods.is_minter(owner).simulate()).toEqual(true);
     }, 60_000);
 
     it('publicly deploys and initializes via a public function', async () => {
@@ -543,10 +543,10 @@ describe('e2e_deploy_contract', () => {
       const contract = await StatefulTestContract.deployWithOpts({ wallet, method: 'public_constructor' }, owner, 42)
         .send()
         .deployed();
-      expect(await contract.methods.get_public_value(owner).view()).toEqual(42n);
+      expect(await contract.methods.get_public_value(owner).simulate()).toEqual(42n);
       logger.debug(`Calling a private function to ensure the contract was properly initialized`);
       await contract.methods.create_note(owner, 30).send().wait();
-      expect(await contract.methods.summed_values(owner).view()).toEqual(30n);
+      expect(await contract.methods.summed_values(owner).simulate()).toEqual(30n);
     }, 60_000);
 
     it('deploys a contract with a default initializer not named constructor', async () => {
@@ -555,7 +555,7 @@ describe('e2e_deploy_contract', () => {
       const contract = await CounterContract.deploy(wallet, 10, accounts[0]).send(opts).deployed();
       logger.debug(`Calling a function to ensure the contract was properly initialized`);
       await contract.methods.increment(accounts[0]).send().wait();
-      expect(await contract.methods.get_counter(accounts[0]).view()).toEqual(11n);
+      expect(await contract.methods.get_counter(accounts[0]).simulate()).toEqual(11n);
     });
 
     it('publicly deploys a contract with no constructor', async () => {
@@ -570,7 +570,7 @@ describe('e2e_deploy_contract', () => {
     it('refuses to deploy a contract with no constructor and no public deployment', async () => {
       logger.debug(`Deploying contract with no constructor and skipping public deploy`);
       const opts = { skipPublicDeployment: true, skipClassRegistration: true };
-      await expect(TestContract.deploy(wallet).simulate(opts)).rejects.toThrow(/no function calls needed/i);
+      await expect(TestContract.deploy(wallet).prove(opts)).rejects.toThrow(/no function calls needed/i);
     });
 
     it.skip('publicly deploys and calls a public function in the same batched call', async () => {

--- a/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
@@ -90,7 +90,7 @@ describe('e2e_escrow_contract', () => {
   afterEach(() => teardown(), 30_000);
 
   const expectBalance = async (who: AztecAddress, expectedBalance: bigint) => {
-    const balance = await token.methods.balance_of_private(who).view({ from: who });
+    const balance = await token.methods.balance_of_private(who).simulate({ from: who });
     logger(`Account ${who} balance: ${balance}`);
     expect(balance).toBe(expectedBalance);
   };
@@ -110,7 +110,7 @@ describe('e2e_escrow_contract', () => {
 
   it('refuses to withdraw funds as a non-owner', async () => {
     await expect(
-      escrowContract.withWallet(recipientWallet).methods.withdraw(token.address, 30, recipient).simulate(),
+      escrowContract.withWallet(recipientWallet).methods.withdraw(token.address, 30, recipient).prove(),
     ).rejects.toThrow();
   }, 60_000);
 

--- a/yarn-project/end-to-end/src/e2e_inclusion_proofs_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_inclusion_proofs_contract.test.ts
@@ -261,7 +261,7 @@ describe('e2e_inclusion_proofs_contract', () => {
 
       // Or that the positive call fails when trying to prove in the older block
       await expect(
-        contract.methods.test_contract_inclusion(address, olderBlock, testDeploy, testInit).simulate(),
+        contract.methods.test_contract_inclusion(address, olderBlock, testDeploy, testInit).prove(),
       ).rejects.toThrow(/not found/);
     };
 

--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -392,7 +392,7 @@ describe('e2e_lending_contract', () => {
         // Withdraw more than possible to test the revert.
         logger('Withdraw: trying to withdraw more than possible');
         await expect(
-          lendingContract.methods.withdraw_public(lendingAccount.address, 10n ** 9n).simulate(),
+          lendingContract.methods.withdraw_public(lendingAccount.address, 10n ** 9n).prove(),
         ).rejects.toThrow();
       });
     });

--- a/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
@@ -88,7 +88,7 @@ describe('e2e_multiple_accounts_1_enc_key', () => {
 
     // Then check the balance
     const contractWithWallet = await TokenContract.at(tokenAddress, wallet);
-    const balance = await contractWithWallet.methods.balance_of_private(owner).view({ from: owner.address });
+    const balance = await contractWithWallet.methods.balance_of_private(owner).simulate({ from: owner.address });
     logger(`Account ${owner} balance: ${balance}`);
     expect(balance).toBe(expectedBalance);
   };

--- a/yarn-project/end-to-end/src/e2e_nested_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_nested_contract.test.ts
@@ -69,7 +69,7 @@ describe('e2e_nested_contract', () => {
       await expect(
         parentContract.methods
           .entry_point(childContract.address, (childContract.methods as any).value_internal.selector)
-          .simulate(),
+          .prove(),
       ).rejects.toThrow(/Assertion failed: Function value_internal can only be called internally/);
     }, 100_000);
 
@@ -96,7 +96,7 @@ describe('e2e_nested_contract', () => {
             (childContract.methods as any).pub_inc_value_internal.selector,
             42n,
           )
-          .simulate(),
+          .prove(),
       ).rejects.toThrow(/Assertion failed: Function pub_inc_value_internal can only be called internally/);
     }, 100_000);
 

--- a/yarn-project/end-to-end/src/e2e_non_contract_account.test.ts
+++ b/yarn-project/end-to-end/src/e2e_non_contract_account.test.ts
@@ -93,6 +93,6 @@ describe('e2e_non_contract_account', () => {
     );
     await wallet.addNote(extendedNote);
 
-    expect(await contract.methods.get_constant().view()).toEqual(value);
+    expect(await contract.methods.get_constant().simulate()).toEqual(value);
   });
 });

--- a/yarn-project/end-to-end/src/e2e_note_getter.test.ts
+++ b/yarn-project/end-to-end/src/e2e_note_getter.test.ts
@@ -48,13 +48,13 @@ describe('e2e_note_getter', () => {
       await contract.methods.insert_note(5, Fr.ZERO).send().wait();
 
       const [returnEq, returnNeq, returnLt, returnGt, returnLte, returnGte] = await Promise.all([
-        contract.methods.read_note(5, Comparator.EQ).view(),
-        contract.methods.read_note(5, Comparator.NEQ).view(),
-        contract.methods.read_note(5, Comparator.LT).view(),
-        contract.methods.read_note(5, Comparator.GT).view(),
-        contract.methods.read_note(5, Comparator.LTE).view(),
+        contract.methods.read_note(5, Comparator.EQ).simulate(),
+        contract.methods.read_note(5, Comparator.NEQ).simulate(),
+        contract.methods.read_note(5, Comparator.LT).simulate(),
+        contract.methods.read_note(5, Comparator.GT).simulate(),
+        contract.methods.read_note(5, Comparator.LTE).simulate(),
         // docs:start:state_vars-NoteGetterOptionsComparatorExampleTs
-        contract.methods.read_note(5, Comparator.GTE).view(),
+        contract.methods.read_note(5, Comparator.GTE).simulate(),
         // docs:end:state_vars-NoteGetterOptionsComparatorExampleTs
       ]);
 
@@ -166,7 +166,7 @@ describe('e2e_note_getter', () => {
     });
 
     async function assertNoteIsReturned(storageSlot: number, expectedValue: number, activeOrNullified: boolean) {
-      const viewNotesResult = await contract.methods.call_view_notes(storageSlot, activeOrNullified).view();
+      const viewNotesResult = await contract.methods.call_view_notes(storageSlot, activeOrNullified).simulate();
       const getNotesResult = await callGetNotes(storageSlot, activeOrNullified);
 
       expect(viewNotesResult).toEqual(getNotesResult);
@@ -174,14 +174,16 @@ describe('e2e_note_getter', () => {
     }
 
     async function assertNoReturnValue(storageSlot: number, activeOrNullified: boolean) {
-      await expect(contract.methods.call_view_notes(storageSlot, activeOrNullified).view()).rejects.toThrow('is_some');
+      await expect(contract.methods.call_view_notes(storageSlot, activeOrNullified).simulate()).rejects.toThrow(
+        'is_some',
+      );
       await expect(contract.methods.call_get_notes(storageSlot, activeOrNullified).send().wait()).rejects.toThrow(
         `Assertion failed: Cannot return zero notes`,
       );
     }
 
     async function callGetNotes(storageSlot: number, activeOrNullified: boolean): Promise<bigint> {
-      // call_get_notes exposes the return value via an event since we cannot use view() with it.
+      // call_get_notes exposes the return value via an event since we cannot use simulate() with it.
       const tx = contract.methods.call_get_notes(storageSlot, activeOrNullified).send();
       await tx.wait();
 
@@ -192,7 +194,7 @@ describe('e2e_note_getter', () => {
     }
 
     async function callGetNotesMany(storageSlot: number, activeOrNullified: boolean): Promise<Array<bigint>> {
-      // call_get_notes_many exposes the return values via event since we cannot use view() with it.
+      // call_get_notes_many exposes the return values via event since we cannot use simulate() with it.
       const tx = contract.methods.call_get_notes_many(storageSlot, activeOrNullified).send();
       await tx.wait();
 
@@ -244,7 +246,9 @@ describe('e2e_note_getter', () => {
         await contract.methods.call_destroy_note(storageSlot).send().wait();
 
         // We now fetch multiple notes, and get both the active and the nullified one.
-        const viewNotesManyResult = await contract.methods.call_view_notes_many(storageSlot, activeOrNullified).view();
+        const viewNotesManyResult = await contract.methods
+          .call_view_notes_many(storageSlot, activeOrNullified)
+          .simulate();
         const getNotesManyResult = await callGetNotesMany(storageSlot, activeOrNullified);
 
         // We can't be sure in which order the notes will be returned, so we simply sort them to test equality. Note

--- a/yarn-project/end-to-end/src/e2e_ordering.test.ts
+++ b/yarn-project/end-to-end/src/e2e_ordering.test.ts
@@ -58,7 +58,7 @@ describe('e2e_ordering', () => {
         async method => {
           const expectedOrder = expectedOrders[method];
           const action = parent.methods[method](child.address, pubSetValueSelector);
-          const tx = await action.simulate();
+          const tx = await action.prove();
           expect(tx.data.needsSetup).toBe(false);
           expect(tx.data.needsAppLogic).toBe(true);
           expect(tx.data.needsTeardown).toBe(false);

--- a/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
@@ -33,7 +33,7 @@ describe('e2e_voting_contract', () => {
     it('votes', async () => {
       const candidate = new Fr(1);
       await votingContract.methods.cast_vote(candidate).send().wait();
-      expect(await votingContract.methods.get_vote(candidate).view()).toBe(1n);
+      expect(await votingContract.methods.get_vote(candidate).simulate()).toBe(1n);
     });
   });
 });

--- a/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging.test.ts
@@ -165,7 +165,7 @@ describe('e2e_public_cross_chain_messaging', () => {
 
     // user2 tries to consume this message and minting to itself -> should fail since the message is intended to be consumed only by owner.
     await expect(
-      l2Bridge.withWallet(user2Wallet).methods.claim_public(user2Wallet.getAddress(), bridgeAmount, secret).simulate(),
+      l2Bridge.withWallet(user2Wallet).methods.claim_public(user2Wallet.getAddress(), bridgeAmount, secret).prove(),
     ).rejects.toThrow(`No non-nullified L1 to L2 message found for message hash ${wrongMessage.hash().toString()}`);
 
     // user2 consumes owner's L1-> L2 message on bridge contract and mints public tokens on L2
@@ -187,7 +187,7 @@ describe('e2e_public_cross_chain_messaging', () => {
       l2Bridge
         .withWallet(user1Wallet)
         .methods.exit_to_l1_public(ethAccount, withdrawAmount, EthAddress.ZERO, nonce)
-        .simulate(),
+        .prove(),
     ).rejects.toThrow('Assertion failed: Message not authorized by account');
   }, 60_000);
 
@@ -215,7 +215,7 @@ describe('e2e_public_cross_chain_messaging', () => {
     );
 
     await expect(
-      l2Bridge.withWallet(user2Wallet).methods.claim_private(secretHash, bridgeAmount, secret).simulate(),
+      l2Bridge.withWallet(user2Wallet).methods.claim_private(secretHash, bridgeAmount, secret).prove(),
     ).rejects.toThrow(`No non-nullified L1 to L2 message found for message hash ${wrongMessage.hash().toString()}`);
   }, 60_000);
 

--- a/yarn-project/end-to-end/src/e2e_sandbox_example.test.ts
+++ b/yarn-project/end-to-end/src/e2e_sandbox_example.test.ts
@@ -101,10 +101,10 @@ describe('e2e_sandbox_example', () => {
     // Since we already have a token link, we can simply create a new instance of the contract linked to Bob's wallet
     const tokenContractBob = tokenContractAlice.withWallet(bobWallet);
 
-    let aliceBalance = await tokenContractAlice.methods.balance_of_private(alice).view();
+    let aliceBalance = await tokenContractAlice.methods.balance_of_private(alice).simulate();
     logger(`Alice's balance ${aliceBalance}`);
 
-    let bobBalance = await tokenContractBob.methods.balance_of_private(bob).view();
+    let bobBalance = await tokenContractBob.methods.balance_of_private(bob).simulate();
     logger(`Bob's balance ${bobBalance}`);
 
     // docs:end:Balance
@@ -121,10 +121,10 @@ describe('e2e_sandbox_example', () => {
     await tokenContractAlice.methods.transfer(alice, bob, transferQuantity, 0).send().wait();
 
     // Check the new balances
-    aliceBalance = await tokenContractAlice.methods.balance_of_private(alice).view();
+    aliceBalance = await tokenContractAlice.methods.balance_of_private(alice).simulate();
     logger(`Alice's balance ${aliceBalance}`);
 
-    bobBalance = await tokenContractBob.methods.balance_of_private(bob).view();
+    bobBalance = await tokenContractBob.methods.balance_of_private(bob).simulate();
     logger(`Bob's balance ${bobBalance}`);
     // docs:end:Transfer
 
@@ -162,10 +162,10 @@ describe('e2e_sandbox_example', () => {
     await tokenContractBob.methods.redeem_shield(bob, mintQuantity, bobSecret).send().wait();
 
     // Check the new balances
-    aliceBalance = await tokenContractAlice.methods.balance_of_private(alice).view();
+    aliceBalance = await tokenContractAlice.methods.balance_of_private(alice).simulate();
     logger(`Alice's balance ${aliceBalance}`);
 
-    bobBalance = await tokenContractBob.methods.balance_of_private(bob).view();
+    bobBalance = await tokenContractBob.methods.balance_of_private(bob).simulate();
     logger(`Bob's balance ${bobBalance}`);
     // docs:end:Mint
 

--- a/yarn-project/end-to-end/src/e2e_slow_tree.test.ts
+++ b/yarn-project/end-to-end/src/e2e_slow_tree.test.ts
@@ -73,8 +73,8 @@ describe('e2e_slow_tree', () => {
       _root: { before: bigint; after: bigint; next_change: bigint },
       _leaf: { before: bigint; after: bigint; next_change: bigint },
     ) => {
-      const root = await contract.methods.un_read_root(owner).view();
-      const leaf = await contract.methods.un_read_leaf_at(owner, key).view();
+      const root = await contract.methods.un_read_root(owner).simulate();
+      const leaf = await contract.methods.un_read_leaf_at(owner, key).simulate();
       expect(root).toEqual(_root);
       expect(leaf).toEqual(_leaf);
     };
@@ -128,7 +128,7 @@ describe('e2e_slow_tree', () => {
       `Tries to "read" tree[${zeroProof.index}] from the tree, but is rejected as value is not ${zeroProof.value}`,
     );
     await wallet.addCapsule(getMembershipCapsule({ ...zeroProof, value: new Fr(0) }));
-    await expect(contract.methods.read_at(key).simulate()).rejects.toThrow(
+    await expect(contract.methods.read_at(key).prove()).rejects.toThrow(
       /Assertion failed: Root does not match expected/,
     );
 

--- a/yarn-project/end-to-end/src/e2e_state_vars.test.ts
+++ b/yarn-project/end-to-end/src/e2e_state_vars.test.ts
@@ -34,6 +34,11 @@ describe('e2e_state_vars', () => {
     });
 
     it('private read of SharedImmutable', async () => {
+      // Initializes the shared immutable and then reads the value using an unconstrained function
+      // checking the return values with:
+      // 1. A constrained private function that reads it directly
+      // 2. A constrained private function that calls another private function that reads.
+
       await contract.methods.initialize_shared_immutable(1).send().wait();
 
       const a = await contract.methods.get_shared_immutable_constrained_private().simulate();
@@ -50,8 +55,12 @@ describe('e2e_state_vars', () => {
     });
 
     it('public read of SharedImmutable', async () => {
-      const a = await contract.methods.get_shared_immutable_constrained().simulate();
-      const b = await contract.methods.get_shared_immutable_constrained_indirect().simulate();
+      // Reads the value using an unconstrained function checking the return values with:
+      // 1. A constrained public function that reads it directly
+      // 2. A constrained public function that calls another public function that reads.
+
+      const a = await contract.methods.get_shared_immutable_constrained_public().simulate();
+      const b = await contract.methods.get_shared_immutable_constrained_public_indirect().simulate();
       const c = await contract.methods.get_shared_immutable().simulate();
 
       expect((a as any)[0]).toEqual((c as any)['account'].toBigInt());

--- a/yarn-project/end-to-end/src/e2e_state_vars.test.ts
+++ b/yarn-project/end-to-end/src/e2e_state_vars.test.ts
@@ -1,64 +1,67 @@
-import { DebugLogger, FunctionSelector, type Wallet } from '@aztec/aztec.js';
-import { decodeFunctionSignature } from '@aztec/foundation/abi';
+import { type Wallet } from '@aztec/aztec.js';
 import { DocsExampleContract } from '@aztec/noir-contracts.js';
+
+import { jest } from '@jest/globals';
 
 import { setup } from './fixtures/utils.js';
 
+const TIMEOUT = 100_000;
+
 describe('e2e_state_vars', () => {
+  jest.setTimeout(TIMEOUT);
+
   let wallet: Wallet;
 
   let teardown: () => Promise<void>;
   let contract: DocsExampleContract;
-  let logger: DebugLogger;
 
   const POINTS = 1n;
   const RANDOMNESS = 2n;
 
   beforeAll(async () => {
-    ({ teardown, wallet, logger } = await setup());
+    ({ teardown, wallet } = await setup());
     contract = await DocsExampleContract.deploy(wallet).send().deployed();
-  }, 25_000);
+  }, 30_000);
 
   afterAll(() => teardown());
 
   describe('SharedImmutable', () => {
-    it.only('private read of uninitialized SharedImmutable', async () => {
-      await contract.methods.initialize_shared_immutable(1).send().wait();
-      const returnsConstrained = await contract.methods.get_shared_immutable_constrained_private().viewConstrained();
-      const returnsUnconstrained = await contract.methods.get_shared_immutable().view();
-
-      console.log(`Return values from private constrained:`, returnsConstrained);
-      console.log(`Return values from unconstrained:`, returnsUnconstrained);
-
-      console.log(await contract.methods.get_message_sender().viewConstrained());
-
-      console.log(await contract.methods.multicall().viewConstrained());
-    });
-
-    it('public read of uninitialized SharedImmutable', async () => {
-      DocsExampleContract.artifact.functions.forEach(fn => {
-        const sig = decodeFunctionSignature(fn.name, fn.parameters);
-        logger(`Function ${sig} and the selector: ${FunctionSelector.fromNameAndParameters(fn.name, fn.parameters)}`);
-      });
-
-      // await contract.methods.initialize_shared_immutable(1).send().wait();
-      // console.log(await contract.methods.get_shared_immutable_constrained().viewConstrained());
-      console.log(await contract.methods.get_message_sender_public().viewConstrained());
-    });
-
     it('private read of uninitialized SharedImmutable', async () => {
-      const s = await contract.methods.get_shared_immutable().view();
+      const s = await contract.methods.get_shared_immutable().simulate();
 
       // Send the transaction and wait for it to be mined (wait function throws if the tx is not mined)
       await contract.methods.match_shared_immutable(s.account, s.points).send().wait();
     });
 
-    it('private read of initialized SharedImmutable', async () => {
+    it('private read of SharedImmutable', async () => {
       await contract.methods.initialize_shared_immutable(1).send().wait();
-      const s = await contract.methods.get_shared_immutable().view();
 
-      await contract.methods.match_shared_immutable(s.account, s.points).send().wait();
-    }, 200_000);
+      const a = await contract.methods.get_shared_immutable_constrained_private().simulate();
+      const b = await contract.methods.get_shared_immutable_constrained_private_indirect().simulate();
+      const c = await contract.methods.get_shared_immutable().simulate();
+
+      expect((a as any)[0]).toEqual((c as any)['account'].toBigInt());
+      expect((a as any)[1]).toEqual((c as any)['points']);
+      expect((b as any)[0]).toEqual((c as any)['account'].toBigInt());
+      expect((b as any)[1]).toEqual((c as any)['points']);
+
+      expect(a).toEqual(b);
+      await contract.methods.match_shared_immutable(c.account, c.points).send().wait();
+    });
+
+    it('public read of SharedImmutable', async () => {
+      const a = await contract.methods.get_shared_immutable_constrained().simulate();
+      const b = await contract.methods.get_shared_immutable_constrained_indirect().simulate();
+      const c = await contract.methods.get_shared_immutable().simulate();
+
+      expect((a as any)[0]).toEqual((c as any)['account'].toBigInt());
+      expect((a as any)[1]).toEqual((c as any)['points']);
+      expect((b as any)[0]).toEqual((c as any)['account'].toBigInt());
+      expect((b as any)[1]).toEqual((c as any)['points']);
+
+      expect(a).toEqual(b);
+      await contract.methods.match_shared_immutable(c.account, c.points).send().wait();
+    });
 
     it('initializing SharedImmutable the second time should fail', async () => {
       // Jest executes the tests sequentially and the first call to initialize_shared_immutable was executed
@@ -74,7 +77,7 @@ describe('e2e_state_vars', () => {
       const numPoints = 1n;
 
       await contract.methods.initialize_public_immutable(numPoints).send().wait();
-      const p = await contract.methods.get_public_immutable().view();
+      const p = await contract.methods.get_public_immutable().simulate();
 
       expect(p.account).toEqual(wallet.getCompleteAddress().address);
       expect(p.points).toEqual(numPoints);
@@ -91,36 +94,36 @@ describe('e2e_state_vars', () => {
 
   describe('PrivateMutable', () => {
     it('fail to read uninitialized PrivateMutable', async () => {
-      expect(await contract.methods.is_legendary_initialized().view()).toEqual(false);
-      await expect(contract.methods.get_legendary_card().view()).rejects.toThrow();
+      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(false);
+      await expect(contract.methods.get_legendary_card().simulate()).rejects.toThrow();
     });
 
     it('initialize PrivateMutable', async () => {
-      expect(await contract.methods.is_legendary_initialized().view()).toEqual(false);
+      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(false);
       // Send the transaction and wait for it to be mined (wait function throws if the tx is not mined)
       const { debugInfo } = await contract.methods.initialize_private(RANDOMNESS, POINTS).send().wait({ debug: true });
 
       // 1 for the tx, another for the initializer
       expect(debugInfo!.nullifiers.length).toEqual(2);
-      expect(await contract.methods.is_legendary_initialized().view()).toEqual(true);
+      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(true);
     });
 
     it('fail to reinitialize', async () => {
-      expect(await contract.methods.is_legendary_initialized().view()).toEqual(true);
+      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(true);
       await expect(contract.methods.initialize_private(RANDOMNESS, POINTS).send().wait()).rejects.toThrow();
-      expect(await contract.methods.is_legendary_initialized().view()).toEqual(true);
+      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(true);
     });
 
     it('read initialized PrivateMutable', async () => {
-      expect(await contract.methods.is_legendary_initialized().view()).toEqual(true);
-      const { points, randomness } = await contract.methods.get_legendary_card().view();
+      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(true);
+      const { points, randomness } = await contract.methods.get_legendary_card().simulate();
       expect(points).toEqual(POINTS);
       expect(randomness).toEqual(RANDOMNESS);
     });
 
     it('replace with same value', async () => {
-      expect(await contract.methods.is_legendary_initialized().view()).toEqual(true);
-      const noteBefore = await contract.methods.get_legendary_card().view();
+      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(true);
+      const noteBefore = await contract.methods.get_legendary_card().simulate();
       const { debugInfo } = await contract.methods
         .update_legendary_card(RANDOMNESS, POINTS)
         .send()
@@ -130,7 +133,7 @@ describe('e2e_state_vars', () => {
       // 1 for the tx, another for the nullifier of the previous note
       expect(debugInfo!.nullifiers.length).toEqual(2);
 
-      const noteAfter = await contract.methods.get_legendary_card().view();
+      const noteAfter = await contract.methods.get_legendary_card().simulate();
 
       expect(noteBefore.owner).toEqual(noteAfter.owner);
       expect(noteBefore.points).toEqual(noteAfter.points);
@@ -143,7 +146,7 @@ describe('e2e_state_vars', () => {
     });
 
     it('replace PrivateMutable with other values', async () => {
-      expect(await contract.methods.is_legendary_initialized().view()).toEqual(true);
+      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(true);
       const { debugInfo } = await contract.methods
         .update_legendary_card(RANDOMNESS + 2n, POINTS + 1n)
         .send()
@@ -153,21 +156,21 @@ describe('e2e_state_vars', () => {
       // 1 for the tx, another for the nullifier of the previous note
       expect(debugInfo!.nullifiers.length).toEqual(2);
 
-      const { points, randomness } = await contract.methods.get_legendary_card().view();
+      const { points, randomness } = await contract.methods.get_legendary_card().simulate();
       expect(points).toEqual(POINTS + 1n);
       expect(randomness).toEqual(RANDOMNESS + 2n);
     });
 
     it('replace PrivateMutable dependent on prior value', async () => {
-      expect(await contract.methods.is_legendary_initialized().view()).toEqual(true);
-      const noteBefore = await contract.methods.get_legendary_card().view();
+      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(true);
+      const noteBefore = await contract.methods.get_legendary_card().simulate();
       const { debugInfo } = await contract.methods.increase_legendary_points().send().wait({ debug: true });
 
       expect(debugInfo!.noteHashes.length).toEqual(1);
       // 1 for the tx, another for the nullifier of the previous note
       expect(debugInfo!.nullifiers.length).toEqual(2);
 
-      const { points, randomness } = await contract.methods.get_legendary_card().view();
+      const { points, randomness } = await contract.methods.get_legendary_card().simulate();
       expect(points).toEqual(noteBefore.points + 1n);
       expect(randomness).toEqual(noteBefore.randomness);
     });
@@ -175,12 +178,12 @@ describe('e2e_state_vars', () => {
 
   describe('PrivateImmutable', () => {
     it('fail to read uninitialized PrivateImmutable', async () => {
-      expect(await contract.methods.is_priv_imm_initialized().view()).toEqual(false);
-      await expect(contract.methods.view_imm_card().view()).rejects.toThrow();
+      expect(await contract.methods.is_priv_imm_initialized().simulate()).toEqual(false);
+      await expect(contract.methods.view_imm_card().simulate()).rejects.toThrow();
     });
 
     it('initialize PrivateImmutable', async () => {
-      expect(await contract.methods.is_priv_imm_initialized().view()).toEqual(false);
+      expect(await contract.methods.is_priv_imm_initialized().simulate()).toEqual(false);
       const { debugInfo } = await contract.methods
         .initialize_private_immutable(RANDOMNESS, POINTS)
         .send()
@@ -189,18 +192,18 @@ describe('e2e_state_vars', () => {
       expect(debugInfo!.noteHashes.length).toEqual(1);
       // 1 for the tx, another for the initializer
       expect(debugInfo!.nullifiers.length).toEqual(2);
-      expect(await contract.methods.is_priv_imm_initialized().view()).toEqual(true);
+      expect(await contract.methods.is_priv_imm_initialized().simulate()).toEqual(true);
     });
 
     it('fail to reinitialize', async () => {
-      expect(await contract.methods.is_priv_imm_initialized().view()).toEqual(true);
+      expect(await contract.methods.is_priv_imm_initialized().simulate()).toEqual(true);
       await expect(contract.methods.initialize_private_immutable(RANDOMNESS, POINTS).send().wait()).rejects.toThrow();
-      expect(await contract.methods.is_priv_imm_initialized().view()).toEqual(true);
+      expect(await contract.methods.is_priv_imm_initialized().simulate()).toEqual(true);
     });
 
     it('read initialized PrivateImmutable', async () => {
-      expect(await contract.methods.is_priv_imm_initialized().view()).toEqual(true);
-      const { points, randomness } = await contract.methods.view_imm_card().view();
+      expect(await contract.methods.is_priv_imm_initialized().simulate()).toEqual(true);
+      const { points, randomness } = await contract.methods.view_imm_card().simulate();
       expect(points).toEqual(POINTS);
       expect(randomness).toEqual(RANDOMNESS);
     });

--- a/yarn-project/end-to-end/src/e2e_token_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract.test.ts
@@ -82,7 +82,7 @@ describe('e2e_token_contract', () => {
       accounts.map(a => a.address),
     );
 
-    expect(await asset.methods.admin().view()).toBe(accounts[0].address.toBigInt());
+    expect(await asset.methods.admin().simulate()).toBe(accounts[0].address.toBigInt());
 
     badAccount = await DocsExampleContract.deploy(wallets[0]).send().deployed();
   }, 100_000);
@@ -108,32 +108,32 @@ describe('e2e_token_contract', () => {
           "Failed to solve brillig function, reason: explicit trap hit in brillig 'name.is_eq(_what)'",
         ],
       ])('name - %s', async (_type, method, errorMessage) => {
-        const t = toString(await asset.methods.un_get_name().view());
+        const t = toString(await asset.methods.un_get_name().simulate());
         expect(t).toBe(TOKEN_NAME);
 
         await reader.methods[method](asset.address, TOKEN_NAME).send().wait();
-        await expect(reader.methods[method](asset.address, 'WRONG_NAME').simulate()).rejects.toThrow(errorMessage);
+        await expect(reader.methods[method](asset.address, 'WRONG_NAME').prove()).rejects.toThrow(errorMessage);
       });
     });
 
     describe('symbol', () => {
       it('private', async () => {
-        const t = toString(await asset.methods.un_get_symbol().view());
+        const t = toString(await asset.methods.un_get_symbol().simulate());
         expect(t).toBe(TOKEN_SYMBOL);
 
         await reader.methods.check_symbol_private(asset.address, TOKEN_SYMBOL).send().wait();
 
-        await expect(reader.methods.check_symbol_private(asset.address, 'WRONG_SYMBOL').simulate()).rejects.toThrow(
+        await expect(reader.methods.check_symbol_private(asset.address, 'WRONG_SYMBOL').prove()).rejects.toThrow(
           "Cannot satisfy constraint 'symbol.is_eq(_what)'",
         );
       });
       it('public', async () => {
-        const t = toString(await asset.methods.un_get_symbol().view());
+        const t = toString(await asset.methods.un_get_symbol().simulate());
         expect(t).toBe(TOKEN_SYMBOL);
 
         await reader.methods.check_symbol_public(asset.address, TOKEN_SYMBOL).send().wait();
 
-        await expect(reader.methods.check_symbol_public(asset.address, 'WRONG_SYMBOL').simulate()).rejects.toThrow(
+        await expect(reader.methods.check_symbol_public(asset.address, 'WRONG_SYMBOL').prove()).rejects.toThrow(
           "Failed to solve brillig function, reason: explicit trap hit in brillig 'symbol.is_eq(_what)'",
         );
       });
@@ -141,23 +141,23 @@ describe('e2e_token_contract', () => {
 
     describe('decimals', () => {
       it('private', async () => {
-        const t = await asset.methods.un_get_decimals().view();
+        const t = await asset.methods.un_get_decimals().simulate();
         expect(t).toBe(TOKEN_DECIMALS);
 
         await reader.methods.check_decimals_private(asset.address, TOKEN_DECIMALS).send().wait();
 
-        await expect(reader.methods.check_decimals_private(asset.address, 99).simulate()).rejects.toThrow(
+        await expect(reader.methods.check_decimals_private(asset.address, 99).prove()).rejects.toThrow(
           "Cannot satisfy constraint 'ret[0] as u8 == what'",
         );
       });
 
       it('public', async () => {
-        const t = await asset.methods.un_get_decimals().view();
+        const t = await asset.methods.un_get_decimals().simulate();
         expect(t).toBe(TOKEN_DECIMALS);
 
         await reader.methods.check_decimals_public(asset.address, TOKEN_DECIMALS).send().wait();
 
-        await expect(reader.methods.check_decimals_public(asset.address, 99).simulate()).rejects.toThrow(
+        await expect(reader.methods.check_decimals_public(asset.address, 99).prove()).rejects.toThrow(
           "Failed to solve brillig function, reason: explicit trap hit in brillig 'ret[0] as u8 == what'",
         );
       });
@@ -167,27 +167,27 @@ describe('e2e_token_contract', () => {
   describe('Access controlled functions', () => {
     it('Set admin', async () => {
       await asset.methods.set_admin(accounts[1].address).send().wait();
-      expect(await asset.methods.admin().view()).toBe(accounts[1].address.toBigInt());
+      expect(await asset.methods.admin().simulate()).toBe(accounts[1].address.toBigInt());
     });
 
     it('Add minter as admin', async () => {
       await asset.withWallet(wallets[1]).methods.set_minter(accounts[1].address, true).send().wait();
-      expect(await asset.methods.is_minter(accounts[1].address).view()).toBe(true);
+      expect(await asset.methods.is_minter(accounts[1].address).simulate()).toBe(true);
     });
 
     it('Revoke minter as admin', async () => {
       await asset.withWallet(wallets[1]).methods.set_minter(accounts[1].address, false).send().wait();
-      expect(await asset.methods.is_minter(accounts[1].address).view()).toBe(false);
+      expect(await asset.methods.is_minter(accounts[1].address).simulate()).toBe(false);
     });
 
     describe('failure cases', () => {
       it('Set admin (not admin)', async () => {
-        await expect(asset.methods.set_admin(accounts[0].address).simulate()).rejects.toThrow(
+        await expect(asset.methods.set_admin(accounts[0].address).prove()).rejects.toThrow(
           'Assertion failed: caller is not admin',
         );
       });
       it('Revoke minter not as admin', async () => {
-        await expect(asset.methods.set_minter(accounts[0].address, false).simulate()).rejects.toThrow(
+        await expect(asset.methods.set_minter(accounts[0].address, false).prove()).rejects.toThrow(
           'Assertion failed: caller is not admin',
         );
       });
@@ -201,37 +201,37 @@ describe('e2e_token_contract', () => {
         await asset.methods.mint_public(accounts[0].address, amount).send().wait();
 
         tokenSim.mintPublic(accounts[0].address, amount);
-        expect(await asset.methods.balance_of_public(accounts[0].address).view()).toEqual(
+        expect(await asset.methods.balance_of_public(accounts[0].address).simulate()).toEqual(
           tokenSim.balanceOfPublic(accounts[0].address),
         );
-        expect(await asset.methods.total_supply().view()).toEqual(tokenSim.totalSupply);
+        expect(await asset.methods.total_supply().simulate()).toEqual(tokenSim.totalSupply);
       });
 
       describe('failure cases', () => {
         it('as non-minter', async () => {
           const amount = 10000n;
           await expect(
-            asset.withWallet(wallets[1]).methods.mint_public(accounts[0].address, amount).simulate(),
+            asset.withWallet(wallets[1]).methods.mint_public(accounts[0].address, amount).prove(),
           ).rejects.toThrow('Assertion failed: caller is not minter');
         });
 
         it('mint >u128 tokens to overflow', async () => {
           const amount = 2n ** 128n; // U128::max() + 1;
-          await expect(asset.methods.mint_public(accounts[0].address, amount).simulate()).rejects.toThrow(
+          await expect(asset.methods.mint_public(accounts[0].address, amount).prove()).rejects.toThrow(
             BITSIZE_TOO_BIG_ERROR,
           );
         });
 
         it('mint <u128 but recipient balance >u128', async () => {
           const amount = 2n ** 128n - tokenSim.balanceOfPublic(accounts[0].address);
-          await expect(asset.methods.mint_public(accounts[0].address, amount).simulate()).rejects.toThrow(
+          await expect(asset.methods.mint_public(accounts[0].address, amount).prove()).rejects.toThrow(
             U128_OVERFLOW_ERROR,
           );
         });
 
         it('mint <u128 but such that total supply >u128', async () => {
           const amount = 2n ** 128n - tokenSim.balanceOfPublic(accounts[0].address);
-          await expect(asset.methods.mint_public(accounts[1].address, amount).simulate()).rejects.toThrow(
+          await expect(asset.methods.mint_public(accounts[1].address, amount).prove()).rejects.toThrow(
             U128_OVERFLOW_ERROR,
           );
         });
@@ -274,33 +274,31 @@ describe('e2e_token_contract', () => {
           await expect(addPendingShieldNoteToPXE(0, amount, secretHash, txHash)).rejects.toThrow(
             'The note has been destroyed.',
           );
-          await expect(asset.methods.redeem_shield(accounts[0].address, amount, secret).simulate()).rejects.toThrow(
+          await expect(asset.methods.redeem_shield(accounts[0].address, amount, secret).prove()).rejects.toThrow(
             `Assertion failed: Cannot return zero notes`,
           );
         });
 
         it('mint_private as non-minter', async () => {
-          await expect(
-            asset.withWallet(wallets[1]).methods.mint_private(amount, secretHash).simulate(),
-          ).rejects.toThrow('Assertion failed: caller is not minter');
+          await expect(asset.withWallet(wallets[1]).methods.mint_private(amount, secretHash).prove()).rejects.toThrow(
+            'Assertion failed: caller is not minter',
+          );
         });
 
         it('mint >u128 tokens to overflow', async () => {
           const amount = 2n ** 128n; // U128::max() + 1;
-          await expect(asset.methods.mint_private(amount, secretHash).simulate()).rejects.toThrow(
-            BITSIZE_TOO_BIG_ERROR,
-          );
+          await expect(asset.methods.mint_private(amount, secretHash).prove()).rejects.toThrow(BITSIZE_TOO_BIG_ERROR);
         });
 
         it('mint <u128 but recipient balance >u128', async () => {
           const amount = 2n ** 128n - tokenSim.balanceOfPrivate(accounts[0].address);
           expect(amount).toBeLessThan(2n ** 128n);
-          await expect(asset.methods.mint_private(amount, secretHash).simulate()).rejects.toThrow(U128_OVERFLOW_ERROR);
+          await expect(asset.methods.mint_private(amount, secretHash).prove()).rejects.toThrow(U128_OVERFLOW_ERROR);
         });
 
         it('mint <u128 but such that total supply >u128', async () => {
           const amount = 2n ** 128n - tokenSim.totalSupply;
-          await expect(asset.methods.mint_private(amount, secretHash).simulate()).rejects.toThrow(U128_OVERFLOW_ERROR);
+          await expect(asset.methods.mint_private(amount, secretHash).prove()).rejects.toThrow(U128_OVERFLOW_ERROR);
         });
       });
     });
@@ -309,7 +307,7 @@ describe('e2e_token_contract', () => {
   describe('Transfer', () => {
     describe('public', () => {
       it('transfer less than balance', async () => {
-        const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
+        const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
         const amount = balance0 / 2n;
         expect(amount).toBeGreaterThan(0n);
         await asset.methods.transfer_public(accounts[0].address, accounts[1].address, amount, 0).send().wait();
@@ -318,7 +316,7 @@ describe('e2e_token_contract', () => {
       });
 
       it('transfer to self', async () => {
-        const balance = await asset.methods.balance_of_public(accounts[0].address).view();
+        const balance = await asset.methods.balance_of_public(accounts[0].address).simulate();
         const amount = balance / 2n;
         expect(amount).toBeGreaterThan(0n);
         await asset.methods.transfer_public(accounts[0].address, accounts[0].address, amount, 0).send().wait();
@@ -327,7 +325,7 @@ describe('e2e_token_contract', () => {
       });
 
       it('transfer on behalf of other', async () => {
-        const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
+        const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
         const amount = balance0 / 2n;
         expect(amount).toBeGreaterThan(0n);
         const nonce = Fr.random();
@@ -355,38 +353,38 @@ describe('e2e_token_contract', () => {
 
       describe('failure cases', () => {
         it('transfer more than balance', async () => {
-          const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
           const amount = balance0 + 1n;
           const nonce = 0;
           await expect(
-            asset.methods.transfer_public(accounts[0].address, accounts[1].address, amount, nonce).simulate(),
+            asset.methods.transfer_public(accounts[0].address, accounts[1].address, amount, nonce).prove(),
           ).rejects.toThrow(U128_UNDERFLOW_ERROR);
         });
 
         it('transfer on behalf of self with non-zero nonce', async () => {
-          const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
           const amount = balance0 - 1n;
           const nonce = 1;
           await expect(
-            asset.methods.transfer_public(accounts[0].address, accounts[1].address, amount, nonce).simulate(),
+            asset.methods.transfer_public(accounts[0].address, accounts[1].address, amount, nonce).prove(),
           ).rejects.toThrow('Assertion failed: invalid nonce');
         });
 
         it('transfer on behalf of other without "approval"', async () => {
-          const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
           const amount = balance0 + 1n;
           const nonce = Fr.random();
           await expect(
             asset
               .withWallet(wallets[1])
               .methods.transfer_public(accounts[0].address, accounts[1].address, amount, nonce)
-              .simulate(),
+              .prove(),
           ).rejects.toThrow('Assertion failed: Message not authorized by account');
         });
 
         it('transfer more than balance on behalf of other', async () => {
-          const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
-          const balance1 = await asset.methods.balance_of_public(accounts[1].address).view();
+          const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
+          const balance1 = await asset.methods.balance_of_public(accounts[1].address).simulate();
           const amount = balance0 + 1n;
           const nonce = Fr.random();
           expect(amount).toBeGreaterThan(0n);
@@ -413,15 +411,15 @@ describe('e2e_token_contract', () => {
           });
 
           // Perform the transfer
-          await expect(action.simulate()).rejects.toThrow(U128_UNDERFLOW_ERROR);
+          await expect(action.prove()).rejects.toThrow(U128_UNDERFLOW_ERROR);
 
-          expect(await asset.methods.balance_of_public(accounts[0].address).view()).toEqual(balance0);
-          expect(await asset.methods.balance_of_public(accounts[1].address).view()).toEqual(balance1);
+          expect(await asset.methods.balance_of_public(accounts[0].address).simulate()).toEqual(balance0);
+          expect(await asset.methods.balance_of_public(accounts[1].address).simulate()).toEqual(balance1);
         });
 
         it('transfer on behalf of other, wrong designated caller', async () => {
-          const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
-          const balance1 = await asset.methods.balance_of_public(accounts[1].address).view();
+          const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
+          const balance1 = await asset.methods.balance_of_public(accounts[1].address).simulate();
           const amount = balance0 + 2n;
           const nonce = Fr.random();
           expect(amount).toBeGreaterThan(0n);
@@ -434,15 +432,15 @@ describe('e2e_token_contract', () => {
           await wallets[0].setPublicAuthWit({ caller: accounts[0].address, action }, true).send().wait();
 
           // Perform the transfer
-          await expect(action.simulate()).rejects.toThrow('Assertion failed: Message not authorized by account');
+          await expect(action.prove()).rejects.toThrow('Assertion failed: Message not authorized by account');
 
-          expect(await asset.methods.balance_of_public(accounts[0].address).view()).toEqual(balance0);
-          expect(await asset.methods.balance_of_public(accounts[1].address).view()).toEqual(balance1);
+          expect(await asset.methods.balance_of_public(accounts[0].address).simulate()).toEqual(balance0);
+          expect(await asset.methods.balance_of_public(accounts[1].address).simulate()).toEqual(balance1);
         });
 
         it('transfer on behalf of other, wrong designated caller', async () => {
-          const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
-          const balance1 = await asset.methods.balance_of_public(accounts[1].address).view();
+          const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
+          const balance1 = await asset.methods.balance_of_public(accounts[1].address).simulate();
           const amount = balance0 + 2n;
           const nonce = Fr.random();
           expect(amount).toBeGreaterThan(0n);
@@ -454,14 +452,14 @@ describe('e2e_token_contract', () => {
           await wallets[0].setPublicAuthWit({ caller: accounts[0].address, action }, true).send().wait();
 
           // Perform the transfer
-          await expect(action.simulate()).rejects.toThrow('Assertion failed: Message not authorized by account');
+          await expect(action.prove()).rejects.toThrow('Assertion failed: Message not authorized by account');
 
-          expect(await asset.methods.balance_of_public(accounts[0].address).view()).toEqual(balance0);
-          expect(await asset.methods.balance_of_public(accounts[1].address).view()).toEqual(balance1);
+          expect(await asset.methods.balance_of_public(accounts[0].address).simulate()).toEqual(balance0);
+          expect(await asset.methods.balance_of_public(accounts[1].address).simulate()).toEqual(balance1);
         });
 
         it('transfer on behalf of other, cancelled authwit', async () => {
-          const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
           const amount = balance0 / 2n;
           expect(amount).toBeGreaterThan(0n);
           const nonce = Fr.random();
@@ -483,7 +481,7 @@ describe('e2e_token_contract', () => {
         });
 
         it('transfer on behalf of other, cancelled authwit, flow 2', async () => {
-          const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
           const amount = balance0 / 2n;
           expect(amount).toBeGreaterThan(0n);
           const nonce = Fr.random();
@@ -505,7 +503,7 @@ describe('e2e_token_contract', () => {
         });
 
         it('transfer on behalf of other, cancelled authwit, flow 3', async () => {
-          const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
           const amount = balance0 / 2n;
           expect(amount).toBeGreaterThan(0n);
           const nonce = Fr.random();
@@ -556,7 +554,7 @@ describe('e2e_token_contract', () => {
 
     describe('private', () => {
       it('transfer less than balance', async () => {
-        const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
+        const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
         const amount = balance0 / 2n;
         expect(amount).toBeGreaterThan(0n);
         await asset.methods.transfer(accounts[0].address, accounts[1].address, amount, 0).send().wait();
@@ -564,7 +562,7 @@ describe('e2e_token_contract', () => {
       });
 
       it('transfer to self', async () => {
-        const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
+        const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
         const amount = balance0 / 2n;
         expect(amount).toBeGreaterThan(0n);
         await asset.methods.transfer(accounts[0].address, accounts[0].address, amount, 0).send().wait();
@@ -572,7 +570,7 @@ describe('e2e_token_contract', () => {
       });
 
       it('transfer on behalf of other', async () => {
-        const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
+        const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
         const amount = balance0 / 2n;
         const nonce = Fr.random();
         expect(amount).toBeGreaterThan(0n);
@@ -607,26 +605,26 @@ describe('e2e_token_contract', () => {
 
       describe('failure cases', () => {
         it('transfer more than balance', async () => {
-          const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
           const amount = balance0 + 1n;
           expect(amount).toBeGreaterThan(0n);
           await expect(
-            asset.methods.transfer(accounts[0].address, accounts[1].address, amount, 0).simulate(),
+            asset.methods.transfer(accounts[0].address, accounts[1].address, amount, 0).prove(),
           ).rejects.toThrow('Assertion failed: Balance too low');
         });
 
         it('transfer on behalf of self with non-zero nonce', async () => {
-          const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
           const amount = balance0 - 1n;
           expect(amount).toBeGreaterThan(0n);
           await expect(
-            asset.methods.transfer(accounts[0].address, accounts[1].address, amount, 1).simulate(),
+            asset.methods.transfer(accounts[0].address, accounts[1].address, amount, 1).prove(),
           ).rejects.toThrow('Assertion failed: invalid nonce');
         });
 
         it('transfer more than balance on behalf of other', async () => {
-          const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
-          const balance1 = await asset.methods.balance_of_private(accounts[1].address).view();
+          const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
+          const balance1 = await asset.methods.balance_of_private(accounts[1].address).simulate();
           const amount = balance0 + 1n;
           const nonce = Fr.random();
           expect(amount).toBeGreaterThan(0n);
@@ -643,9 +641,9 @@ describe('e2e_token_contract', () => {
           await wallets[1].addAuthWitness(witness);
 
           // Perform the transfer
-          await expect(action.simulate()).rejects.toThrow('Assertion failed: Balance too low');
-          expect(await asset.methods.balance_of_private(accounts[0].address).view()).toEqual(balance0);
-          expect(await asset.methods.balance_of_private(accounts[1].address).view()).toEqual(balance1);
+          await expect(action.prove()).rejects.toThrow('Assertion failed: Balance too low');
+          expect(await asset.methods.balance_of_private(accounts[0].address).simulate()).toEqual(balance0);
+          expect(await asset.methods.balance_of_private(accounts[1].address).simulate()).toEqual(balance1);
         });
 
         it.skip('transfer into account to overflow', () => {
@@ -656,7 +654,7 @@ describe('e2e_token_contract', () => {
         });
 
         it('transfer on behalf of other without approval', async () => {
-          const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
           const amount = balance0 / 2n;
           const nonce = Fr.random();
           expect(amount).toBeGreaterThan(0n);
@@ -672,13 +670,13 @@ describe('e2e_token_contract', () => {
             action.request(),
           );
 
-          await expect(action.simulate()).rejects.toThrow(
+          await expect(action.prove()).rejects.toThrow(
             `Unknown auth witness for message hash ${messageHash.toString()}`,
           );
         });
 
         it('transfer on behalf of other, wrong designated caller', async () => {
-          const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
           const amount = balance0 / 2n;
           const nonce = Fr.random();
           expect(amount).toBeGreaterThan(0n);
@@ -697,14 +695,14 @@ describe('e2e_token_contract', () => {
           const witness = await wallets[0].createAuthWit({ caller: accounts[1].address, action });
           await wallets[2].addAuthWitness(witness);
 
-          await expect(action.simulate()).rejects.toThrow(
+          await expect(action.prove()).rejects.toThrow(
             `Unknown auth witness for message hash ${expectedMessageHash.toString()}`,
           );
-          expect(await asset.methods.balance_of_private(accounts[0].address).view()).toEqual(balance0);
+          expect(await asset.methods.balance_of_private(accounts[0].address).simulate()).toEqual(balance0);
         });
 
         it('transfer on behalf of other, cancelled authwit', async () => {
-          const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
           const amount = balance0 / 2n;
           const nonce = Fr.random();
           expect(amount).toBeGreaterThan(0n);
@@ -728,7 +726,7 @@ describe('e2e_token_contract', () => {
         });
 
         it('transfer on behalf of other, cancelled authwit, flow 2', async () => {
-          const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
           const amount = balance0 / 2n;
           const nonce = Fr.random();
           expect(amount).toBeGreaterThan(0n);
@@ -776,7 +774,7 @@ describe('e2e_token_contract', () => {
     });
 
     it('on behalf of self', async () => {
-      const balancePub = await asset.methods.balance_of_public(accounts[0].address).view();
+      const balancePub = await asset.methods.balance_of_public(accounts[0].address).simulate();
       const amount = balancePub / 2n;
       expect(amount).toBeGreaterThan(0n);
 
@@ -793,7 +791,7 @@ describe('e2e_token_contract', () => {
     });
 
     it('on behalf of other', async () => {
-      const balancePub = await asset.methods.balance_of_public(accounts[0].address).view();
+      const balancePub = await asset.methods.balance_of_public(accounts[0].address).simulate();
       const amount = balancePub / 2n;
       const nonce = Fr.random();
       expect(amount).toBeGreaterThan(0n);
@@ -823,27 +821,27 @@ describe('e2e_token_contract', () => {
 
     describe('failure cases', () => {
       it('on behalf of self (more than balance)', async () => {
-        const balancePub = await asset.methods.balance_of_public(accounts[0].address).view();
+        const balancePub = await asset.methods.balance_of_public(accounts[0].address).simulate();
         const amount = balancePub + 1n;
         expect(amount).toBeGreaterThan(0n);
 
-        await expect(asset.methods.shield(accounts[0].address, amount, secretHash, 0).simulate()).rejects.toThrow(
+        await expect(asset.methods.shield(accounts[0].address, amount, secretHash, 0).prove()).rejects.toThrow(
           U128_UNDERFLOW_ERROR,
         );
       });
 
       it('on behalf of self (invalid nonce)', async () => {
-        const balancePub = await asset.methods.balance_of_public(accounts[0].address).view();
+        const balancePub = await asset.methods.balance_of_public(accounts[0].address).simulate();
         const amount = balancePub + 1n;
         expect(amount).toBeGreaterThan(0n);
 
-        await expect(asset.methods.shield(accounts[0].address, amount, secretHash, 1).simulate()).rejects.toThrow(
+        await expect(asset.methods.shield(accounts[0].address, amount, secretHash, 1).prove()).rejects.toThrow(
           'Assertion failed: invalid nonce',
         );
       });
 
       it('on behalf of other (more than balance)', async () => {
-        const balancePub = await asset.methods.balance_of_public(accounts[0].address).view();
+        const balancePub = await asset.methods.balance_of_public(accounts[0].address).simulate();
         const amount = balancePub + 1n;
         const nonce = Fr.random();
         expect(amount).toBeGreaterThan(0n);
@@ -852,11 +850,11 @@ describe('e2e_token_contract', () => {
         const action = asset.withWallet(wallets[1]).methods.shield(accounts[0].address, amount, secretHash, nonce);
         await wallets[0].setPublicAuthWit({ caller: accounts[1].address, action }, true).send().wait();
 
-        await expect(action.simulate()).rejects.toThrow(U128_UNDERFLOW_ERROR);
+        await expect(action.prove()).rejects.toThrow(U128_UNDERFLOW_ERROR);
       });
 
       it('on behalf of other (wrong designated caller)', async () => {
-        const balancePub = await asset.methods.balance_of_public(accounts[0].address).view();
+        const balancePub = await asset.methods.balance_of_public(accounts[0].address).simulate();
         const amount = balancePub + 1n;
         const nonce = Fr.random();
         expect(amount).toBeGreaterThan(0n);
@@ -865,17 +863,17 @@ describe('e2e_token_contract', () => {
         const action = asset.withWallet(wallets[2]).methods.shield(accounts[0].address, amount, secretHash, nonce);
         await wallets[0].setPublicAuthWit({ caller: accounts[1].address, action }, true).send().wait();
 
-        await expect(action.simulate()).rejects.toThrow('Assertion failed: Message not authorized by account');
+        await expect(action.prove()).rejects.toThrow('Assertion failed: Message not authorized by account');
       });
 
       it('on behalf of other (without approval)', async () => {
-        const balance = await asset.methods.balance_of_public(accounts[0].address).view();
+        const balance = await asset.methods.balance_of_public(accounts[0].address).simulate();
         const amount = balance / 2n;
         const nonce = Fr.random();
         expect(amount).toBeGreaterThan(0n);
 
         await expect(
-          asset.withWallet(wallets[1]).methods.shield(accounts[0].address, amount, secretHash, nonce).simulate(),
+          asset.withWallet(wallets[1]).methods.shield(accounts[0].address, amount, secretHash, nonce).prove(),
         ).rejects.toThrow(`Assertion failed: Message not authorized by account`);
       });
     });
@@ -883,7 +881,7 @@ describe('e2e_token_contract', () => {
 
   describe('Unshielding', () => {
     it('on behalf of self', async () => {
-      const balancePriv = await asset.methods.balance_of_private(accounts[0].address).view();
+      const balancePriv = await asset.methods.balance_of_private(accounts[0].address).simulate();
       const amount = balancePriv / 2n;
       expect(amount).toBeGreaterThan(0n);
 
@@ -893,7 +891,7 @@ describe('e2e_token_contract', () => {
     });
 
     it('on behalf of other', async () => {
-      const balancePriv0 = await asset.methods.balance_of_private(accounts[0].address).view();
+      const balancePriv0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
       const amount = balancePriv0 / 2n;
       const nonce = Fr.random();
       expect(amount).toBeGreaterThan(0n);
@@ -921,27 +919,27 @@ describe('e2e_token_contract', () => {
 
     describe('failure cases', () => {
       it('on behalf of self (more than balance)', async () => {
-        const balancePriv = await asset.methods.balance_of_private(accounts[0].address).view();
+        const balancePriv = await asset.methods.balance_of_private(accounts[0].address).simulate();
         const amount = balancePriv + 1n;
         expect(amount).toBeGreaterThan(0n);
 
         await expect(
-          asset.methods.unshield(accounts[0].address, accounts[0].address, amount, 0).simulate(),
+          asset.methods.unshield(accounts[0].address, accounts[0].address, amount, 0).prove(),
         ).rejects.toThrow('Assertion failed: Balance too low');
       });
 
       it('on behalf of self (invalid nonce)', async () => {
-        const balancePriv = await asset.methods.balance_of_private(accounts[0].address).view();
+        const balancePriv = await asset.methods.balance_of_private(accounts[0].address).simulate();
         const amount = balancePriv + 1n;
         expect(amount).toBeGreaterThan(0n);
 
         await expect(
-          asset.methods.unshield(accounts[0].address, accounts[0].address, amount, 1).simulate(),
+          asset.methods.unshield(accounts[0].address, accounts[0].address, amount, 1).prove(),
         ).rejects.toThrow('Assertion failed: invalid nonce');
       });
 
       it('on behalf of other (more than balance)', async () => {
-        const balancePriv0 = await asset.methods.balance_of_private(accounts[0].address).view();
+        const balancePriv0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
         const amount = balancePriv0 + 2n;
         const nonce = Fr.random();
         expect(amount).toBeGreaterThan(0n);
@@ -956,11 +954,11 @@ describe('e2e_token_contract', () => {
         const witness = await wallets[0].createAuthWit({ caller: accounts[1].address, action });
         await wallets[1].addAuthWitness(witness);
 
-        await expect(action.simulate()).rejects.toThrow('Assertion failed: Balance too low');
+        await expect(action.prove()).rejects.toThrow('Assertion failed: Balance too low');
       });
 
       it('on behalf of other (invalid designated caller)', async () => {
-        const balancePriv0 = await asset.methods.balance_of_private(accounts[0].address).view();
+        const balancePriv0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
         const amount = balancePriv0 + 2n;
         const nonce = Fr.random();
         expect(amount).toBeGreaterThan(0n);
@@ -981,7 +979,7 @@ describe('e2e_token_contract', () => {
         const witness = await wallets[0].createAuthWit({ caller: accounts[1].address, action });
         await wallets[2].addAuthWitness(witness);
 
-        await expect(action.simulate()).rejects.toThrow(
+        await expect(action.prove()).rejects.toThrow(
           `Unknown auth witness for message hash ${expectedMessageHash.toString()}`,
         );
       });
@@ -991,7 +989,7 @@ describe('e2e_token_contract', () => {
   describe('Burn', () => {
     describe('public', () => {
       it('burn less than balance', async () => {
-        const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
+        const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
         const amount = balance0 / 2n;
         expect(amount).toBeGreaterThan(0n);
         await asset.methods.burn_public(accounts[0].address, amount, 0).send().wait();
@@ -1000,7 +998,7 @@ describe('e2e_token_contract', () => {
       });
 
       it('burn on behalf of other', async () => {
-        const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
+        const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
         const amount = balance0 / 2n;
         expect(amount).toBeGreaterThan(0n);
         const nonce = Fr.random();
@@ -1020,35 +1018,35 @@ describe('e2e_token_contract', () => {
 
       describe('failure cases', () => {
         it('burn more than balance', async () => {
-          const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
           const amount = balance0 + 1n;
           const nonce = 0;
-          await expect(asset.methods.burn_public(accounts[0].address, amount, nonce).simulate()).rejects.toThrow(
+          await expect(asset.methods.burn_public(accounts[0].address, amount, nonce).prove()).rejects.toThrow(
             U128_UNDERFLOW_ERROR,
           );
         });
 
         it('burn on behalf of self with non-zero nonce', async () => {
-          const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
           const amount = balance0 - 1n;
           expect(amount).toBeGreaterThan(0n);
           const nonce = 1;
-          await expect(asset.methods.burn_public(accounts[0].address, amount, nonce).simulate()).rejects.toThrow(
+          await expect(asset.methods.burn_public(accounts[0].address, amount, nonce).prove()).rejects.toThrow(
             'Assertion failed: invalid nonce',
           );
         });
 
         it('burn on behalf of other without "approval"', async () => {
-          const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
           const amount = balance0 + 1n;
           const nonce = Fr.random();
           await expect(
-            asset.withWallet(wallets[1]).methods.burn_public(accounts[0].address, amount, nonce).simulate(),
+            asset.withWallet(wallets[1]).methods.burn_public(accounts[0].address, amount, nonce).prove(),
           ).rejects.toThrow('Assertion failed: Message not authorized by account');
         });
 
         it('burn more than balance on behalf of other', async () => {
-          const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
           const amount = balance0 + 1n;
           const nonce = Fr.random();
           expect(amount).toBeGreaterThan(0n);
@@ -1057,11 +1055,11 @@ describe('e2e_token_contract', () => {
           const action = asset.withWallet(wallets[1]).methods.burn_public(accounts[0].address, amount, nonce);
           await wallets[0].setPublicAuthWit({ caller: accounts[1].address, action }, true).send().wait();
 
-          await expect(action.simulate()).rejects.toThrow(U128_UNDERFLOW_ERROR);
+          await expect(action.prove()).rejects.toThrow(U128_UNDERFLOW_ERROR);
         });
 
         it('burn on behalf of other, wrong designated caller', async () => {
-          const balance0 = await asset.methods.balance_of_public(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_public(accounts[0].address).simulate();
           const amount = balance0 + 2n;
           const nonce = Fr.random();
           expect(amount).toBeGreaterThan(0n);
@@ -1071,7 +1069,7 @@ describe('e2e_token_contract', () => {
           await wallets[0].setPublicAuthWit({ caller: accounts[0].address, action }, true).send().wait();
 
           await expect(
-            asset.withWallet(wallets[1]).methods.burn_public(accounts[0].address, amount, nonce).simulate(),
+            asset.withWallet(wallets[1]).methods.burn_public(accounts[0].address, amount, nonce).prove(),
           ).rejects.toThrow('Assertion failed: Message not authorized by account');
         });
       });
@@ -1079,7 +1077,7 @@ describe('e2e_token_contract', () => {
 
     describe('private', () => {
       it('burn less than balance', async () => {
-        const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
+        const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
         const amount = balance0 / 2n;
         expect(amount).toBeGreaterThan(0n);
         await asset.methods.burn(accounts[0].address, amount, 0).send().wait();
@@ -1087,7 +1085,7 @@ describe('e2e_token_contract', () => {
       });
 
       it('burn on behalf of other', async () => {
-        const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
+        const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
         const amount = balance0 / 2n;
         const nonce = Fr.random();
         expect(amount).toBeGreaterThan(0n);
@@ -1110,25 +1108,25 @@ describe('e2e_token_contract', () => {
 
       describe('failure cases', () => {
         it('burn more than balance', async () => {
-          const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
           const amount = balance0 + 1n;
           expect(amount).toBeGreaterThan(0n);
-          await expect(asset.methods.burn(accounts[0].address, amount, 0).simulate()).rejects.toThrow(
+          await expect(asset.methods.burn(accounts[0].address, amount, 0).prove()).rejects.toThrow(
             'Assertion failed: Balance too low',
           );
         });
 
         it('burn on behalf of self with non-zero nonce', async () => {
-          const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
           const amount = balance0 - 1n;
           expect(amount).toBeGreaterThan(0n);
-          await expect(asset.methods.burn(accounts[0].address, amount, 1).simulate()).rejects.toThrow(
+          await expect(asset.methods.burn(accounts[0].address, amount, 1).prove()).rejects.toThrow(
             'Assertion failed: invalid nonce',
           );
         });
 
         it('burn more than balance on behalf of other', async () => {
-          const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
           const amount = balance0 + 1n;
           const nonce = Fr.random();
           expect(amount).toBeGreaterThan(0n);
@@ -1141,11 +1139,11 @@ describe('e2e_token_contract', () => {
           const witness = await wallets[0].createAuthWit({ caller: accounts[1].address, action });
           await wallets[1].addAuthWitness(witness);
 
-          await expect(action.simulate()).rejects.toThrow('Assertion failed: Balance too low');
+          await expect(action.prove()).rejects.toThrow('Assertion failed: Balance too low');
         });
 
         it('burn on behalf of other without approval', async () => {
-          const balance0 = await asset.methods.balance_of_private(accounts[0].address).view();
+          const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
           const amount = balance0 / 2n;
           const nonce = Fr.random();
           expect(amount).toBeGreaterThan(0n);
@@ -1159,13 +1157,13 @@ describe('e2e_token_contract', () => {
             action.request(),
           );
 
-          await expect(action.simulate()).rejects.toThrow(
+          await expect(action.prove()).rejects.toThrow(
             `Unknown auth witness for message hash ${messageHash.toString()}`,
           );
         });
 
         it('on behalf of other (invalid designated caller)', async () => {
-          const balancePriv0 = await asset.methods.balance_of_private(accounts[0].address).view();
+          const balancePriv0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
           const amount = balancePriv0 + 2n;
           const nonce = Fr.random();
           expect(amount).toBeGreaterThan(0n);
@@ -1182,7 +1180,7 @@ describe('e2e_token_contract', () => {
           const witness = await wallets[0].createAuthWit({ caller: accounts[1].address, action });
           await wallets[2].addAuthWitness(witness);
 
-          await expect(action.simulate()).rejects.toThrow(
+          await expect(action.prove()).rejects.toThrow(
             `Unknown auth witness for message hash ${expectedMessageHash.toString()}`,
           );
         });

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -514,7 +514,7 @@ export function getBalancesFn(
   logger: any,
 ): (...addresses: AztecAddress[]) => Promise<bigint[]> {
   const balances = async (...addresses: AztecAddress[]) => {
-    const b = await Promise.all(addresses.map(address => method(address).view()));
+    const b = await Promise.all(addresses.map(address => method(address).simulate()));
     const debugString = `${symbol} balances: ${addresses.map((address, i) => `${address}: ${b[i]}`).join(', ')}`;
     logger(debugString);
     return b;

--- a/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
+++ b/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
@@ -43,7 +43,7 @@ describe('guides/dapp/testing', () => {
 
       it('increases recipient funds on mint', async () => {
         const recipientAddress = recipient.getAddress();
-        expect(await token.methods.balance_of_private(recipientAddress).view()).toEqual(0n);
+        expect(await token.methods.balance_of_private(recipientAddress).simulate()).toEqual(0n);
 
         const mintAmount = 20n;
         const secret = Fr.random();
@@ -65,7 +65,7 @@ describe('guides/dapp/testing', () => {
         await pxe.addNote(extendedNote);
 
         await token.methods.redeem_shield(recipientAddress, mintAmount, secret).send().wait();
-        expect(await token.methods.balance_of_private(recipientAddress).view()).toEqual(20n);
+        expect(await token.methods.balance_of_private(recipientAddress).simulate()).toEqual(20n);
       }, 30_000);
     });
     // docs:end:sandbox-example
@@ -87,7 +87,7 @@ describe('guides/dapp/testing', () => {
       }, 30_000);
 
       it('increases recipient funds on mint', async () => {
-        expect(await token.methods.balance_of_private(recipient.getAddress()).view()).toEqual(0n);
+        expect(await token.methods.balance_of_private(recipient.getAddress()).simulate()).toEqual(0n);
         const recipientAddress = recipient.getAddress();
         const mintAmount = 20n;
         const secret = Fr.random();
@@ -109,7 +109,7 @@ describe('guides/dapp/testing', () => {
         await pxe.addNote(extendedNote);
 
         await token.methods.redeem_shield(recipientAddress, mintAmount, secret).send().wait();
-        expect(await token.methods.balance_of_private(recipientAddress).view()).toEqual(20n);
+        expect(await token.methods.balance_of_private(recipientAddress).simulate()).toEqual(20n);
       }, 30_000);
     });
 
@@ -220,7 +220,7 @@ describe('guides/dapp/testing', () => {
       it('asserts a local transaction simulation fails by calling simulate', async () => {
         // docs:start:local-tx-fails
         const call = token.methods.transfer(owner.getAddress(), recipient.getAddress(), 200n, 0);
-        await expect(call.simulate()).rejects.toThrow(/Balance too low/);
+        await expect(call.prove()).rejects.toThrow(/Balance too low/);
         // docs:end:local-tx-fails
       }, 30_000);
 
@@ -236,8 +236,8 @@ describe('guides/dapp/testing', () => {
         const call1 = token.methods.transfer(owner.getAddress(), recipient.getAddress(), 80n, 0);
         const call2 = token.methods.transfer(owner.getAddress(), recipient.getAddress(), 50n, 0);
 
-        await call1.simulate();
-        await call2.simulate();
+        await call1.prove();
+        await call2.prove();
 
         await call1.send().wait();
         await expect(call2.send().wait()).rejects.toThrow(/dropped/);
@@ -247,7 +247,7 @@ describe('guides/dapp/testing', () => {
       it('asserts a simulation for a public function call fails', async () => {
         // docs:start:local-pub-fails
         const call = token.methods.transfer_public(owner.getAddress(), recipient.getAddress(), 1000n, 0);
-        await expect(call.simulate()).rejects.toThrow(U128_UNDERFLOW_ERROR);
+        await expect(call.prove()).rejects.toThrow(U128_UNDERFLOW_ERROR);
         // docs:end:local-pub-fails
       }, 30_000);
 

--- a/yarn-project/end-to-end/src/guides/writing_an_account_contract.test.ts
+++ b/yarn-project/end-to-end/src/guides/writing_an_account_contract.test.ts
@@ -82,7 +82,7 @@ describe('guides/writing_an_account_contract', () => {
 
     await token.methods.redeem_shield({ address }, mintAmount, secret).send().wait();
 
-    const balance = await token.methods.balance_of_private({ address }).view();
+    const balance = await token.methods.balance_of_private({ address }).simulate();
     logger(`Balance of wallet is now ${balance}`);
     // docs:end:account-contract-works
     expect(balance).toEqual(50n);
@@ -95,7 +95,7 @@ describe('guides/writing_an_account_contract', () => {
     const tokenWithWrongWallet = token.withWallet(wrongWallet);
 
     try {
-      await tokenWithWrongWallet.methods.mint_private(200, secretHash).simulate();
+      await tokenWithWrongWallet.methods.mint_private(200, secretHash).prove();
     } catch (err) {
       logger(`Failed to send tx: ${err}`);
     }

--- a/yarn-project/end-to-end/src/sample-dapp/index.mjs
+++ b/yarn-project/end-to-end/src/sample-dapp/index.mjs
@@ -20,7 +20,7 @@ async function showPrivateBalances(pxe) {
 
   for (const account of accounts) {
     // highlight-next-line:showPrivateBalances
-    const balance = await token.methods.balance_of_private(account.address).view();
+    const balance = await token.methods.balance_of_private(account.address).simulate();
     console.log(`Balance of ${account.address}: ${balance}`);
   }
   // docs:end:showPrivateBalances
@@ -79,7 +79,7 @@ async function showPublicBalances(pxe) {
 
   for (const account of accounts) {
     // highlight-next-line:showPublicBalances
-    const balance = await token.methods.balance_of_public(account.address).view();
+    const balance = await token.methods.balance_of_public(account.address).simulate();
     console.log(`Balance of ${account.address}: ${balance}`);
   }
   // docs:end:showPublicBalances

--- a/yarn-project/end-to-end/src/sample-dapp/index.test.mjs
+++ b/yarn-project/end-to-end/src/sample-dapp/index.test.mjs
@@ -49,9 +49,9 @@ describe('token', () => {
 
   // docs:start:test
   it('increases recipient funds on transfer', async () => {
-    expect(await token.methods.balance_of_private(recipient.getAddress()).view()).toEqual(0n);
+    expect(await token.methods.balance_of_private(recipient.getAddress()).simulate()).toEqual(0n);
     await token.methods.transfer(owner.getAddress(), recipient.getAddress(), 20n, 0).send().wait();
-    expect(await token.methods.balance_of_private(recipient.getAddress()).view()).toEqual(20n);
+    expect(await token.methods.balance_of_private(recipient.getAddress()).simulate()).toEqual(20n);
   }, 30_000);
   // docs:end:test
 });

--- a/yarn-project/end-to-end/src/shared/browser.ts
+++ b/yarn-project/end-to-end/src/shared/browser.ts
@@ -168,7 +168,7 @@ export const browserTestSuite = (
           const [wallet] = await getDeployedTestAccountsWallets(pxe);
           const owner = wallet.getCompleteAddress().address;
           const contract = await Contract.at(AztecAddress.fromString(contractAddress), TokenContractArtifact, wallet);
-          const balance = await contract.methods.balance_of_private(owner).view({ from: owner });
+          const balance = await contract.methods.balance_of_private(owner).simulate({ from: owner });
           return balance;
         },
         pxeURL,
@@ -199,7 +199,7 @@ export const browserTestSuite = (
             .send()
             .wait();
           console.log(`Transferred ${transferAmount} tokens to new Account`);
-          return await contract.methods.balance_of_private(receiverAddress).view({ from: receiverAddress });
+          return await contract.methods.balance_of_private(receiverAddress).simulate({ from: receiverAddress });
         },
         pxeURL,
         (await getTokenAddress()).toString(),

--- a/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
@@ -105,17 +105,17 @@ export async function deployAndInitializeTokenAndBridgeContracts(
     .send({ portalContract: tokenPortalAddress })
     .deployed();
 
-  if ((await token.methods.admin().view()) !== owner.toBigInt()) {
+  if ((await token.methods.admin().simulate()) !== owner.toBigInt()) {
     throw new Error(`Token admin is not ${owner}`);
   }
 
-  if (!(await bridge.methods.token().view()).equals(token.address)) {
+  if (!(await bridge.methods.token().simulate()).equals(token.address)) {
     throw new Error(`Bridge token is not ${token.address}`);
   }
 
   // make the bridge a minter on the token:
   await token.methods.set_minter(bridge.address, true).send().wait();
-  if ((await token.methods.is_minter(bridge.address).view()) === 1n) {
+  if ((await token.methods.is_minter(bridge.address).simulate()) === 1n) {
     throw new Error(`Bridge is not a minter`);
   }
 
@@ -344,7 +344,7 @@ export class CrossChainTestHarness {
   }
 
   async getL2PrivateBalanceOf(owner: AztecAddress) {
-    return await this.l2Token.methods.balance_of_private(owner).view({ from: owner });
+    return await this.l2Token.methods.balance_of_private(owner).simulate({ from: owner });
   }
 
   async expectPrivateBalanceOnL2(owner: AztecAddress, expectedBalance: bigint) {
@@ -354,7 +354,7 @@ export class CrossChainTestHarness {
   }
 
   async getL2PublicBalanceOf(owner: AztecAddress) {
-    return await this.l2Token.methods.balance_of_public(owner).view();
+    return await this.l2Token.methods.balance_of_public(owner).simulate();
   }
 
   async expectPublicBalanceOnL2(owner: AztecAddress, expectedBalance: bigint) {

--- a/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
@@ -208,7 +208,7 @@ class GasBridgingTestHarness implements IGasBridgingTestHarness {
   }
 
   async getL2PublicBalanceOf(owner: AztecAddress) {
-    return await this.l2Token.methods.balance_of_public(owner).view();
+    return await this.l2Token.methods.balance_of_public(owner).simulate();
   }
 
   async expectPublicBalanceOnL2(owner: AztecAddress, expectedBalance: bigint) {

--- a/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
+++ b/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
@@ -209,7 +209,7 @@ export const uniswapL1L2TestSuite = (
 
       // before swap - check nonce_for_burn_approval stored on uniswap
       // (which is used by uniswap to approve the bridge to burn funds on its behalf to exit to L1)
-      const nonceForBurnApprovalBeforeSwap = await uniswapL2Contract.methods.nonce_for_burn_approval().view();
+      const nonceForBurnApprovalBeforeSwap = await uniswapL2Contract.methods.nonce_for_burn_approval().simulate();
 
       // 3. Owner gives uniswap approval to unshield funds to self on its behalf
       logger('Approving uniswap to unshield funds to self on my behalf');
@@ -291,7 +291,7 @@ export const uniswapL1L2TestSuite = (
       // ensure that uniswap contract didn't eat the funds.
       await wethCrossChainHarness.expectPublicBalanceOnL2(uniswapL2Contract.address, 0n);
       // check burn approval nonce incremented:
-      const nonceForBurnApprovalAfterSwap = await uniswapL2Contract.methods.nonce_for_burn_approval().view();
+      const nonceForBurnApprovalAfterSwap = await uniswapL2Contract.methods.nonce_for_burn_approval().simulate();
       expect(nonceForBurnApprovalAfterSwap).toBe(nonceForBurnApprovalBeforeSwap + 1n);
 
       // 5. Consume L2 to L1 message by calling uniswapPortal.swap_private()
@@ -432,7 +432,7 @@ export const uniswapL1L2TestSuite = (
 
       // before swap - check nonce_for_burn_approval stored on uniswap
       // (which is used by uniswap to approve the bridge to burn funds on its behalf to exit to L1)
-      const nonceForBurnApprovalBeforeSwap = await uniswapL2Contract.methods.nonce_for_burn_approval().view();
+      const nonceForBurnApprovalBeforeSwap = await uniswapL2Contract.methods.nonce_for_burn_approval().simulate();
 
       // 4. Swap on L1 - sends L2 to L1 message to withdraw WETH to L1 and another message to swap assets.
       const [secretForDepositingSwappedDai, secretHashForDepositingSwappedDai] =
@@ -510,7 +510,7 @@ export const uniswapL1L2TestSuite = (
       await wethCrossChainHarness.expectPublicBalanceOnL2(ownerAddress, wethL2BalanceBeforeSwap - wethAmountToBridge);
 
       // check burn approval nonce incremented:
-      const nonceForBurnApprovalAfterSwap = await uniswapL2Contract.methods.nonce_for_burn_approval().view();
+      const nonceForBurnApprovalAfterSwap = await uniswapL2Contract.methods.nonce_for_burn_approval().simulate();
       expect(nonceForBurnApprovalAfterSwap).toBe(nonceForBurnApprovalBeforeSwap + 1n);
 
       // 5. Perform the swap on L1 with the `uniswapPortal.swap_private()` (consuming L2 to L1 messages)
@@ -632,7 +632,7 @@ export const uniswapL1L2TestSuite = (
             Fr.random(),
             ownerEthAddress,
           )
-          .simulate(),
+          .prove(),
       ).rejects.toThrow(`Unknown auth witness for message hash ${expectedMessageHash.toString()}`);
     });
 
@@ -672,7 +672,7 @@ export const uniswapL1L2TestSuite = (
             Fr.random(),
             ownerEthAddress,
           )
-          .simulate(),
+          .prove(),
       ).rejects.toThrow('Assertion failed: input_asset address is not the same as seen in the bridge contract');
     });
 
@@ -749,7 +749,7 @@ export const uniswapL1L2TestSuite = (
       await ownerWallet.setPublicAuthWit(swapMessageHash, true).send().wait();
 
       // Swap!
-      await expect(action.simulate()).rejects.toThrow(
+      await expect(action.prove()).rejects.toThrow(
         "Assertion failed: Message not authorized by account 'is_valid == true'",
       );
     });
@@ -783,7 +783,7 @@ export const uniswapL1L2TestSuite = (
             ownerEthAddress,
             Fr.ZERO,
           )
-          .simulate(),
+          .prove(),
       ).rejects.toThrow(`Assertion failed: Message not authorized by account 'is_valid == true'`);
     });
 

--- a/yarn-project/end-to-end/src/simulators/lending_simulator.ts
+++ b/yarn-project/end-to-end/src/simulators/lending_simulator.ts
@@ -165,7 +165,7 @@ export class LendingSimulator {
 
     expect(this.borrowed).toEqual(this.stableCoin.totalSupply - this.mintedOutside);
 
-    const asset = await this.lendingContract.methods.get_asset(0).view();
+    const asset = await this.lendingContract.methods.get_asset(0).simulate();
 
     const interestAccumulator = asset['interest_accumulator'];
     const interestAccumulatorBigint = BigInt(interestAccumulator.lo + interestAccumulator.hi * 2n ** 64n);
@@ -173,7 +173,7 @@ export class LendingSimulator {
     expect(asset['last_updated_ts']).toEqual(BigInt(this.time));
 
     for (const key of [this.account.address, this.account.key()]) {
-      const privatePos = await this.lendingContract.methods.get_position(key).view();
+      const privatePos = await this.lendingContract.methods.get_position(key).simulate();
       expect(new Fr(privatePos['collateral'])).toEqual(this.collateral[key.toString()] ?? Fr.ZERO);
       expect(new Fr(privatePos['static_debt'])).toEqual(this.staticDebt[key.toString()] ?? Fr.ZERO);
       expect(privatePos['debt']).toEqual(

--- a/yarn-project/end-to-end/src/simulators/token_simulator.ts
+++ b/yarn-project/end-to-end/src/simulators/token_simulator.ts
@@ -81,12 +81,14 @@ export class TokenSimulator {
   }
 
   public async check() {
-    expect(await this.token.methods.total_supply().view()).toEqual(this.totalSupply);
+    expect(await this.token.methods.total_supply().simulate()).toEqual(this.totalSupply);
 
     // Check that all our public matches
     for (const address of this.accounts) {
-      expect(await this.token.methods.balance_of_public({ address }).view()).toEqual(this.balanceOfPublic(address));
-      expect(await this.token.methods.balance_of_private({ address }).view()).toEqual(this.balanceOfPrivate(address));
+      expect(await this.token.methods.balance_of_public({ address }).simulate()).toEqual(this.balanceOfPublic(address));
+      expect(await this.token.methods.balance_of_private({ address }).simulate()).toEqual(
+        this.balanceOfPrivate(address),
+      );
     }
   }
 }

--- a/yarn-project/foundation/src/abi/decoder.ts
+++ b/yarn-project/foundation/src/abi/decoder.ts
@@ -7,6 +7,7 @@ import { isAztecAddressStruct } from './utils.js';
  * The type of our decoded ABI.
  */
 export type DecodedReturn = bigint | boolean | AztecAddress | DecodedReturn[] | { [key: string]: DecodedReturn };
+export type ProcessReturnValues = (DecodedReturn | undefined)[] | undefined;
 
 /**
  * Decodes return values from a function call.

--- a/yarn-project/pxe/src/pxe_http/pxe_http_server.ts
+++ b/yarn-project/pxe/src/pxe_http/pxe_http_server.ts
@@ -15,6 +15,7 @@ import {
   TxHash,
   TxReceipt,
   UnencryptedL2BlockL2Logs,
+  Vue,
 } from '@aztec/circuit-types';
 import { FunctionSelector } from '@aztec/circuits.js';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
@@ -49,7 +50,7 @@ export function createPXERpcServer(pxeService: PXE): JsonRpcServer {
       TxEffect,
       LogId,
     },
-    { Tx, TxReceipt, EncryptedL2BlockL2Logs, UnencryptedL2BlockL2Logs, NullifierMembershipWitness },
+    { Vue, Tx, TxReceipt, EncryptedL2BlockL2Logs, UnencryptedL2BlockL2Logs, NullifierMembershipWitness },
     ['start', 'stop'],
   );
 }

--- a/yarn-project/pxe/src/pxe_http/pxe_http_server.ts
+++ b/yarn-project/pxe/src/pxe_http/pxe_http_server.ts
@@ -9,13 +9,13 @@ import {
   Note,
   NullifierMembershipWitness,
   type PXE,
+  SimulatedTx,
   Tx,
   TxEffect,
   TxExecutionRequest,
   TxHash,
   TxReceipt,
   UnencryptedL2BlockL2Logs,
-  Vue,
 } from '@aztec/circuit-types';
 import { FunctionSelector } from '@aztec/circuits.js';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
@@ -50,7 +50,7 @@ export function createPXERpcServer(pxeService: PXE): JsonRpcServer {
       TxEffect,
       LogId,
     },
-    { Vue, Tx, TxReceipt, EncryptedL2BlockL2Logs, UnencryptedL2BlockL2Logs, NullifierMembershipWitness },
+    { SimulatedTx, Tx, TxReceipt, EncryptedL2BlockL2Logs, UnencryptedL2BlockL2Logs, NullifierMembershipWitness },
     ['start', 'stop'],
   );
 }

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -420,8 +420,8 @@ export class PXEService implements PXE {
       const simulatePublic = msgSender === undefined;
       const vue = await this.#simulateCall(txRequest, msgSender);
       if (simulatePublic) {
-        const returns = await this.#simulatePublicCalls(vue.tx);
-        console.log(returns);
+        await this.#simulatePublicCalls(vue.tx);
+        // console.log(returns);
         /*const t = returns[0];
         vue.rv = t && t[0];*/
       }

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -404,6 +404,11 @@ export class PXEService implements PXE {
     return await this.jobQueue.put(async () => {
       const timer = new Timer();
       const simulatedTx = await this.#simulateAndProve(txRequest, msgSender);
+      // We log only if the msgSender is undefined, as simulating with a different msgSender
+      // is unlikely to be a real transaction, and likely to be only used to read data.
+      // Meaning that it will not necessarily have produced a nullifier (and thus have no TxHash)
+      // If we log, the `getTxHash` function will throw.
+
       if (!msgSender) {
         this.log(`Processed private part of ${simulatedTx.tx.getTxHash()}`, {
           eventName: 'tx-pxe-processing',
@@ -619,6 +624,7 @@ export class PXEService implements PXE {
    *
    * @param txExecutionRequest - The transaction request to be simulated and proved.
    * @param signature - The ECDSA signature for the transaction request.
+   * @param msgSender - (Optional) The message sender to use for the simulation.
    * @returns An object tract contains:
    * A private transaction object containing the proof, public inputs, and encrypted logs.
    * The return values of the private execution

--- a/yarn-project/pxe/src/pxe_service/test/pxe_test_suite.ts
+++ b/yarn-project/pxe/src/pxe_service/test/pxe_test_suite.ts
@@ -135,12 +135,12 @@ export const pxeTestSuite = (testName: string, pxeSetup: () => Promise<PXE>) => 
         authWitnesses: [],
       });
 
-      await expect(async () => await pxe.simulateTx(txExecutionRequest, false)).rejects.toThrow(
+      await expect(async () => await pxe.proveTx(txExecutionRequest, false)).rejects.toThrow(
         'Public entrypoints are not allowed',
       );
     });
 
-    // Note: Not testing a successful run of `simulateTx`, `sendTx`, `getTxReceipt` and `viewTx` here as it requires
+    // Note: Not testing a successful run of `proveTx`, `sendTx`, `getTxReceipt` and `viewTx` here as it requires
     //       a larger setup and it's sufficiently tested in the e2e tests.
 
     it('throws when getting public storage for non-existent contract', async () => {

--- a/yarn-project/sequencer-client/src/sequencer/abstract_phase_manager.ts
+++ b/yarn-project/sequencer-client/src/sequencer/abstract_phase_manager.ts
@@ -42,6 +42,13 @@ import {
   makeEmptyProof,
 } from '@aztec/circuits.js';
 import { computeVarArgsHash } from '@aztec/circuits.js/hash';
+import {
+  ABIType,
+  DecodedReturn,
+  FunctionArtifact,
+  ProcessReturnValues,
+  decodeReturnValues,
+} from '@aztec/foundation/abi';
 import { arrayNonEmptyLength, padArrayEnd } from '@aztec/foundation/collection';
 import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import { type Tuple } from '@aztec/foundation/serialize';
@@ -110,6 +117,7 @@ export abstract class AbstractPhaseManager {
      * revert reason, if any
      */
     revertReason: SimulationError | undefined;
+    returnValues: ProcessReturnValues;
   }>;
 
   public static extractEnqueuedPublicCallsByPhase(
@@ -180,14 +188,22 @@ export abstract class AbstractPhaseManager {
     tx: Tx,
     previousPublicKernelOutput: PublicKernelCircuitPublicInputs,
     previousPublicKernelProof: Proof,
-  ): Promise<[PublicKernelCircuitPublicInputs, Proof, UnencryptedFunctionL2Logs[], SimulationError | undefined]> {
+  ): Promise<
+    [
+      PublicKernelCircuitPublicInputs,
+      Proof,
+      UnencryptedFunctionL2Logs[],
+      SimulationError | undefined,
+      ProcessReturnValues,
+    ]
+  > {
     let kernelOutput = previousPublicKernelOutput;
     let kernelProof = previousPublicKernelProof;
 
     const enqueuedCalls = this.extractEnqueuedPublicCalls(tx);
 
     if (!enqueuedCalls || !enqueuedCalls.length) {
-      return [kernelOutput, kernelProof, [], undefined];
+      return [kernelOutput, kernelProof, [], undefined, undefined];
     }
 
     const newUnencryptedFunctionLogs: UnencryptedFunctionL2Logs[] = [];
@@ -196,8 +212,12 @@ export abstract class AbstractPhaseManager {
     // separate public callstacks to be proven by separate public kernel sequences
     // and submitted separately to the base rollup?
 
+    const returns = [];
+
     for (const enqueuedCall of enqueuedCalls) {
       const executionStack: (PublicExecution | PublicExecutionResult)[] = [enqueuedCall];
+
+      let currentReturn: DecodedReturn | undefined = undefined;
 
       // Keep track of which result is for the top/enqueued call
       let enqueuedExecutionResult: PublicExecutionResult | undefined;
@@ -252,22 +272,34 @@ export abstract class AbstractPhaseManager {
               result.revertReason
             }`,
           );
-          return [kernelOutput, kernelProof, [], result.revertReason];
+          return [kernelOutput, kernelProof, [], result.revertReason, undefined];
         }
 
         if (!enqueuedExecutionResult) {
           enqueuedExecutionResult = result;
+
+          // Padding as the AVM is not always returning the expected return size (4)
+          // which is expected by the kernel.
+          const paddedReturn = padArrayEnd(result.returnValues, Fr.ZERO, RETURN_VALUES_LENGTH);
+
+          // TODO(#5450) Need to use the proper return values here
+          const returnTypes: ABIType[] = [{ kind: 'array', length: 4, type: { kind: 'field' } }];
+          const mockArtifact = { returnTypes } as any as FunctionArtifact;
+
+          currentReturn = decodeReturnValues(mockArtifact, paddedReturn);
         }
       }
       // HACK(#1622): Manually patches the ordering of public state actions
       // TODO(#757): Enforce proper ordering of public state actions
       patchPublicStorageActionOrdering(kernelOutput, enqueuedExecutionResult!, this.phase);
+
+      returns.push(currentReturn);
     }
 
     // TODO(#3675): This should be done in a public kernel circuit
     removeRedundantPublicDataWrites(kernelOutput);
 
-    return [kernelOutput, kernelProof, newUnencryptedFunctionLogs, undefined];
+    return [kernelOutput, kernelProof, newUnencryptedFunctionLogs, undefined, returns];
   }
 
   protected async runKernelCircuit(

--- a/yarn-project/sequencer-client/src/sequencer/abstract_phase_manager.ts
+++ b/yarn-project/sequencer-client/src/sequencer/abstract_phase_manager.ts
@@ -43,10 +43,10 @@ import {
 } from '@aztec/circuits.js';
 import { computeVarArgsHash } from '@aztec/circuits.js/hash';
 import {
-  ABIType,
-  DecodedReturn,
-  FunctionArtifact,
-  ProcessReturnValues,
+  type ABIType,
+  type DecodedReturn,
+  type FunctionArtifact,
+  type ProcessReturnValues,
   decodeReturnValues,
 } from '@aztec/foundation/abi';
 import { arrayNonEmptyLength, padArrayEnd } from '@aztec/foundation/collection';

--- a/yarn-project/sequencer-client/src/sequencer/app_logic_phase_manager.ts
+++ b/yarn-project/sequencer-client/src/sequencer/app_logic_phase_manager.ts
@@ -40,7 +40,7 @@ export class AppLogicPhaseManager extends AbstractPhaseManager {
     // TODO(@spalladino): Should we allow emitting contracts in the fee preparation phase?
     this.log(`Processing tx ${tx.getTxHash()}`);
     await this.publicContractsDB.addNewContracts(tx);
-    const [publicKernelOutput, publicKernelProof, newUnencryptedFunctionLogs, revertReason] =
+    const [publicKernelOutput, publicKernelProof, newUnencryptedFunctionLogs, revertReason, returnValues] =
       await this.processEnqueuedPublicCalls(tx, previousPublicKernelOutput, previousPublicKernelProof).catch(
         // if we throw for any reason other than simulation, we need to rollback and drop the TX
         async err => {
@@ -57,6 +57,6 @@ export class AppLogicPhaseManager extends AbstractPhaseManager {
       await this.publicStateDB.checkpoint();
     }
 
-    return { publicKernelOutput, publicKernelProof, revertReason };
+    return { publicKernelOutput, publicKernelProof, revertReason, returnValues };
   }
 }

--- a/yarn-project/sequencer-client/src/sequencer/public_processor.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/public_processor.test.ts
@@ -814,7 +814,7 @@ class PublicExecutionResultBuilder {
       nullifierReadRequests: [],
       nullifierNonExistentReadRequests: [],
       contractStorageUpdateRequests: this._contractStorageUpdateRequests,
-      returnValues: this._returnValues,
+      returnValues: padArrayEnd(this._returnValues, Fr.ZERO, 4), // TODO(#5450) Need to use the proper return values here
       newNoteHashes: [],
       newNullifiers: [],
       newL2ToL1Messages: [],

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -71,7 +71,7 @@ describe('sequencer', () => {
     });
 
     publicProcessor = mock<PublicProcessor>({
-      process: async txs => [await Promise.all(txs.map(tx => makeProcessedTx(tx))), []],
+      process: async txs => [await Promise.all(txs.map(tx => makeProcessedTx(tx))), [], []],
       makeEmptyProcessedTx: () => makeEmptyProcessedTx(Header.empty(), chainId, version),
     });
 

--- a/yarn-project/sequencer-client/src/sequencer/setup_phase_manager.ts
+++ b/yarn-project/sequencer-client/src/sequencer/setup_phase_manager.ts
@@ -45,6 +45,6 @@ export class SetupPhaseManager extends AbstractPhaseManager {
       );
     tx.unencryptedLogs.addFunctionLogs(newUnencryptedFunctionLogs);
     await this.publicStateDB.checkpoint();
-    return { publicKernelOutput, publicKernelProof, revertReason };
+    return { publicKernelOutput, publicKernelProof, revertReason, returnValues: undefined };
   }
 }

--- a/yarn-project/sequencer-client/src/sequencer/tail_phase_manager.ts
+++ b/yarn-project/sequencer-client/src/sequencer/tail_phase_manager.ts
@@ -42,6 +42,6 @@ export class TailPhaseManager extends AbstractPhaseManager {
     // commit the state updates from this transaction
     await this.publicStateDB.commit();
 
-    return { publicKernelOutput, publicKernelProof, revertReason: undefined };
+    return { publicKernelOutput, publicKernelProof, revertReason: undefined, returnValues: undefined };
   }
 }

--- a/yarn-project/sequencer-client/src/sequencer/teardown_phase_manager.ts
+++ b/yarn-project/sequencer-client/src/sequencer/teardown_phase_manager.ts
@@ -45,6 +45,6 @@ export class TeardownPhaseManager extends AbstractPhaseManager {
       );
     tx.unencryptedLogs.addFunctionLogs(newUnencryptedFunctionLogs);
     await this.publicStateDB.checkpoint();
-    return { publicKernelOutput, publicKernelProof, revertReason };
+    return { publicKernelOutput, publicKernelProof, revertReason, returnValues: undefined };
   }
 }

--- a/yarn-project/simulator/README.md
+++ b/yarn-project/simulator/README.md
@@ -28,13 +28,15 @@ They are run with the assistance of an oracle that provides any value read from 
 
 Public functions can call other public function, but no private functions.
 
-### Unconstrained (view) Functions
+### Unconstrained Functions
 
-Unconstrained functions are used to extract useful data for users, such as the user balance. They are not proved, and are simulated client-side.
+Unconstrained functions are useful to extract useful data for users that could produce very large execution traces - such as the summed balance of all a users notes
+They are not proved, and are simulated client-side.
 
 They are run with the assistance of a DB oracle that provides any private data requested by the function.
 
-At the moment, unconstrained functions cannot call any other function. It would be possible to allow them to call other unconstrained functions.
+At the moment, unconstrained functions cannot call any other function. 
+It would be possible to allow them to call other unconstrained functions.
 
 ## Usage
 

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -1011,7 +1011,7 @@ describe('Private Execution test suite', () => {
 
       oracle.getCompleteAddress.mockResolvedValue(completeAddress);
       const result = await runSimulator({ artifact, args });
-      expect(result.returnValues).toEqual([pubKey.x.value, pubKey.y.value]);
+      expect(result.returnValues).toEqual([pubKey.x.value, pubKey.y.value, 0n, 0n]);
     });
   });
 
@@ -1040,7 +1040,7 @@ describe('Private Execution test suite', () => {
       // Overwrite the oracle return value
       oracle.getPortalContractAddress.mockResolvedValue(portalContractAddress);
       const result = await runSimulator({ artifact, args });
-      expect(result.returnValues).toEqual(portalContractAddress.toField().value);
+      expect(result.returnValues).toEqual([portalContractAddress.toField().value, 0n, 0n, 0n]);
     });
 
     it('this_address should return the current context address', async () => {
@@ -1052,7 +1052,7 @@ describe('Private Execution test suite', () => {
 
       // Overwrite the oracle return value
       const result = await runSimulator({ artifact, args: [], contractAddress });
-      expect(result.returnValues).toEqual(contractAddress.toField().value);
+      expect(result.returnValues).toEqual([contractAddress.toField().value, 0n, 0n, 0n]);
     });
 
     it("this_portal_address should return the current context's portal address", async () => {
@@ -1064,7 +1064,7 @@ describe('Private Execution test suite', () => {
 
       // Overwrite the oracle return value
       const result = await runSimulator({ artifact, args: [], portalContractAddress });
-      expect(result.returnValues).toEqual(portalContractAddress.toField().value);
+      expect(result.returnValues).toEqual([portalContractAddress.toField().value, 0n, 0n, 0n]);
     });
   });
 

--- a/yarn-project/simulator/src/client/private_execution.ts
+++ b/yarn-project/simulator/src/client/private_execution.ts
@@ -1,5 +1,5 @@
 import { type FunctionData, PrivateCallStackItem, PrivateCircuitPublicInputs } from '@aztec/circuits.js';
-import { type FunctionArtifactWithDebugMetadata, decodeReturnValues, type ABIType } from '@aztec/foundation/abi';
+import { type ABIType, type FunctionArtifactWithDebugMetadata, decodeReturnValues } from '@aztec/foundation/abi';
 import { type AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
 import { createDebugLogger } from '@aztec/foundation/log';

--- a/yarn-project/simulator/src/client/private_execution.ts
+++ b/yarn-project/simulator/src/client/private_execution.ts
@@ -1,5 +1,5 @@
 import { type FunctionData, PrivateCallStackItem, PrivateCircuitPublicInputs } from '@aztec/circuits.js';
-import { type FunctionArtifactWithDebugMetadata, decodeReturnValues } from '@aztec/foundation/abi';
+import { type FunctionArtifactWithDebugMetadata, decodeReturnValues, type ABIType } from '@aztec/foundation/abi';
 import { type AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
 import { createDebugLogger } from '@aztec/foundation/log';
@@ -52,7 +52,13 @@ export async function executePrivateFunction(
   publicInputs.unencryptedLogPreimagesLength = new Fr(unencryptedLogs.getSerializedLength());
 
   const callStackItem = new PrivateCallStackItem(contractAddress, functionData, publicInputs);
-  const returnValues = decodeReturnValues(artifact, publicInputs.returnValues);
+
+  // Mocking the return type to be an array of 4 fields
+  // TODO: @LHerskind must be updated as we are progressing with the macros to get the information
+  const returnTypes: ABIType[] = [{ kind: 'array', length: 4, type: { kind: 'field' } }];
+  const mockArtifact = { ...artifact, returnTypes };
+  const returnValues = decodeReturnValues(mockArtifact, publicInputs.returnValues);
+
   const noteHashReadRequestPartialWitnesses = context.getNoteHashReadRequestPartialWitnesses(
     publicInputs.noteHashReadRequests,
   );


### PR DESCRIPTION
This PR replaces the old `view` function with a `simulate` that can be executed on `private`, `public` and `unconstrained` functions. 

It have a limitation in the format of the return values. Currently it is returning a size 4 array of Fields, as that is the return value that the artifact knows about. 

It is to be fixed as part of #5450 that will get the proper values into the artifacts such that we can decode it nicely. 

---

Why the name `vue`? I asked chatgpt for a short name that was not a real word, then realised later that there is a js library called vue 💀. Makes it easy to find and replace the naming.