### PR TITLE
feat: fold proving key polys instead of prover polys

### DIFF
--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.cpp
@@ -127,6 +127,9 @@ std::shared_ptr<typename ProverInstances::Instance> ProtoGalaxyProver_<ProverIns
         combined_relation_parameters.lookup_grand_product_delta.evaluate(challenge),
     };
     next_accumulator->relation_parameters = folded_relation_parameters;
+    // Derive the prover polynomials from the proving key polynomials since we only fold the unshifted polynomials. This
+    // is extremely cheap since we only call .share() and .shifted() polynomial functions. We need the folded prover
+    // polynomials for the decider.
     next_accumulator->prover_polynomials = ProverPolynomials(next_accumulator->proving_key);
     return next_accumulator;
 }

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.cpp
@@ -67,16 +67,16 @@ std::shared_ptr<typename ProverInstances::Instance> ProtoGalaxyProver_<ProverIns
     next_accumulator->gate_challenges = instances.next_gate_challenges;
 
     // Initialize prover polynomials
-    ProverPolynomials acc_prover_polynomials;
-    for (auto& polynomial : acc_prover_polynomials.get_all()) {
+    ProvingKey acc_proving_key_polys;
+    for (auto& polynomial : acc_proving_key_polys.get_all()) {
         polynomial = typename Flavor::Polynomial(instances[0]->proving_key->circuit_size);
     }
 
-    // Fold the prover polynomials
+    // Fold the prover key polynomials
     for (size_t inst_idx = 0; inst_idx < ProverInstances::NUM; inst_idx++) {
-        auto accumulator_polys = acc_prover_polynomials.get_all();
-        auto input_polys = instances[inst_idx]->prover_polynomials.get_all();
-        run_loop_in_parallel(Flavor::NUM_ALL_ENTITIES, [&](size_t start_idx, size_t end_idx) {
+        auto accumulator_polys = acc_proving_key_polys.get_all();
+        auto input_polys = instances[inst_idx]->proving_key->get_all();
+        run_loop_in_parallel(Flavor::NUM_FOLDED_ENTITIES, [&](size_t start_idx, size_t end_idx) {
             for (size_t poly_idx = start_idx; poly_idx < end_idx; poly_idx++) {
                 auto& acc_poly = accumulator_polys[poly_idx];
                 auto& inst_poly = input_polys[poly_idx];
@@ -86,7 +86,10 @@ std::shared_ptr<typename ProverInstances::Instance> ProtoGalaxyProver_<ProverIns
             }
         });
     }
-    next_accumulator->prover_polynomials = std::move(acc_prover_polynomials);
+    for (auto [next_acc_poly, acc_poly] :
+         zip_view(next_accumulator->proving_key->get_all(), acc_proving_key_polys.get_all())) {
+        next_acc_poly = std::move(acc_poly);
+    }
 
     // Fold public data ϕ from all instances to produce ϕ* and add it to the transcript. As part of the folding
     // verification, the verifier will produce ϕ* as well and check it against what was sent by the prover.
@@ -124,6 +127,7 @@ std::shared_ptr<typename ProverInstances::Instance> ProtoGalaxyProver_<ProverIns
         combined_relation_parameters.lookup_grand_product_delta.evaluate(challenge),
     };
     next_accumulator->relation_parameters = folded_relation_parameters;
+    next_accumulator->prover_polynomials = ProverPolynomials(next_accumulator->proving_key);
     return next_accumulator;
 }
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
@@ -34,6 +34,7 @@ template <class ProverInstances_> class ProtoGalaxyProver_ {
     using Instance = typename ProverInstances::Instance;
     using Utils = bb::RelationUtils<Flavor>;
     using RowEvaluations = typename Flavor::AllValues;
+    using ProvingKey = typename Flavor::ProvingKey;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     using Relations = typename Flavor::Relations;
     using RelationSeparator = typename Flavor::RelationSeparator;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/goblin_ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/goblin_ultra_flavor.hpp
@@ -46,6 +46,8 @@ class GoblinUltraFlavor {
     static constexpr size_t NUM_PRECOMPUTED_ENTITIES = 30;
     // The total number of witness entities not including shifts.
     static constexpr size_t NUM_WITNESS_ENTITIES = 14;
+    // Total number of folded polynomials, which is just all polynomials except the shifts
+    static constexpr size_t NUM_FOLDED_ENTITIES = NUM_PRECOMPUTED_ENTITIES + NUM_WITNESS_ENTITIES;
 
     using GrandProductRelations = std::tuple<bb::UltraPermutationRelation<FF>, bb::LookupRelation<FF>>;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
@@ -43,6 +43,8 @@ class UltraFlavor {
     static constexpr size_t NUM_PRECOMPUTED_ENTITIES = 25;
     // The total number of witness entities not including shifts.
     static constexpr size_t NUM_WITNESS_ENTITIES = 7;
+    // Total number of folded polynomials, which is just all polynomials except the shifts
+    static constexpr size_t NUM_FOLDED_ENTITIES = NUM_PRECOMPUTED_ENTITIES + NUM_WITNESS_ENTITIES;
 
     using GrandProductRelations = std::tuple<bb::UltraPermutationRelation<FF>, bb::LookupRelation<FF>>;
     // define the tuple of Relations that comprise the Sumcheck relation


### PR DESCRIPTION
The prover folds the proving key polynomials instead of the prover polynomials, where the difference is only in the shifted polynomials. The prover will derive the shifted polynomials from the proving key polynomials instead. This results in a ~200ms improvement in Client IVC Bench, with the vast majority coming from the 20% reduction (55 to 44 polynomials) in polynomials that the prover folds while computing the next accumulator.

High level differences in benchmark:
Total time: 23750->23573ms
accumulator_update_round: 724ms->570ms
```
--------------------------------------------------------------------------------
Benchmark                      Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------
ClientIVCBench/Full/6      23573 ms        18649 ms            1 Decider::construct_proof=1 Decider::construct_proof(t)=750.843M ECCVMComposer::compute_commitment_key=1 ECCVMComposer::compute_commitment_key(t)=3.68625M ECCVMComposer::compute_witness=1 ECCVMComposer::compute_witness(t)=128.974M ECCVMComposer::create_prover=1 ECCVMComposer::create_prover(t)=148.813M ECCVMComposer::create_proving_key=1 ECCVMComposer::create_proving_key(t)=15.9237M ECCVMProver::construct_proof=1 ECCVMProver::construct_proof(t)=1.75397G Goblin::merge=11 Goblin::merge(t)=135.218M GoblinTranslatorCircuitBuilder::constructor=1 GoblinTranslatorCircuitBuilder::constructor(t)=57.2252M GoblinTranslatorProver=1 GoblinTranslatorProver(t)=120.492M GoblinTranslatorProver::construct_proof=1 GoblinTranslatorProver::construct_proof(t)=944.363M ProtoGalaxyProver_::accumulator_update_round=10 ProtoGalaxyProver_::accumulator_update_round(t)=570.325M ProtoGalaxyProver_::combiner_quotient_round=10 ProtoGalaxyProver_::combiner_quotient_round(t)=7.19019G ProtoGalaxyProver_::perturbator_round=10 ProtoGalaxyProver_::perturbator_round(t)=1.31137G ProtoGalaxyProver_::preparation_round=10 ProtoGalaxyProver_::preparation_round(t)=4.13424G ProtogalaxyProver::fold_instances=10 ProtogalaxyProver::fold_instances(t)=13.2061G ProverInstance(Circuit&)=11 ProverInstance(Circuit&)(t)=1.95959G batch_mul_with_endomorphism=30 batch_mul_with_endomorphism(t)=563.661M commit=426 commit(t)=4.00095G compute_combiner=10 compute_combiner(t)=7.18806G compute_perturbator=9 compute_perturbator(t)=1.31106G compute_univariate=48 compute_univariate(t)=1.41724G construct_circuits=6 construct_circuits(t)=4.47437G
Benchmarking lock deleted.
client_ivc_bench.json                                              100% 3993   122.1KB/s   00:00    
function                                        ms     % sum
construct_circuits(t)                         4474    19.14%
ProverInstance(Circuit&)(t)                   1960     8.38%
ProtogalaxyProver::fold_instances(t)         13206    56.50%
Decider::construct_proof(t)                    751     3.21%
ECCVMComposer::create_prover(t)                149     0.64%
ECCVMProver::construct_proof(t)               1754     7.50%
GoblinTranslatorProver::construct_proof(t)     944     4.04%
Goblin::merge(t)                               135     0.58%

Total time accounted for: 23373ms/23573ms = 99.15%

Major contributors:
function                                        ms    % sum
commit(t)                                     4001   17.12%
compute_combiner(t)                           7188   30.75%
compute_perturbator(t)                        1311    5.61%
compute_univariate(t)                         1417    6.06%

Breakdown of ProtogalaxyProver::fold_instances:
ProtoGalaxyProver_::preparation_round(t)           4134    31.31%
ProtoGalaxyProver_::perturbator_round(t)           1311     9.93%
ProtoGalaxyProver_::combiner_quotient_round(t)     7190    54.45%
ProtoGalaxyProver_::accumulator_update_round(t)     570     4.32%
```

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
