### PR TITLE
chore(ci): add missing dependency to circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1346,6 +1346,7 @@ workflows:
       - barretenberg-acir-tests-bb: *bb_acir_tests
       - barretenberg-acir-tests-bb-sol:
           requires:
+            - barretenberg-x86_64-linux-clang-assert
             - barretenberg-x86_64-linux-clang-sol
             - noir-compile-acir-tests
           <<: *bb_acir_tests


### PR DESCRIPTION
`barretenberg-acir-tests-bb-sol` builds off of `barretenberg-x86_64-linux-clang-assert` but this isn't reflected in the circleci config.

See [workflow run](https://app.circleci.com/pipelines/github/AztecProtocol/aztec-packages/31002/workflows/c2b02460-8817-44c5-a609-573a03f8b3a0/jobs/1470037).