### PR TITLE
feat(avm): Track gas usage in AVM simulator

### DIFF
--- a/yarn-project/simulator/src/avm/avm_gas_cost.ts
+++ b/yarn-project/simulator/src/avm/avm_gas_cost.ts
@@ -1,0 +1,94 @@
+import { Opcode } from './serialization/instruction_serialization.js';
+
+/** Gas cost in L1, L2, and DA for a given instruction. */
+export type GasCost = {
+  l1Gas: number;
+  l2Gas: number;
+  daGas: number;
+};
+
+/** Gas cost of zero across all gas dimensions. */
+export const EmptyGasCost = {
+  l1Gas: 0,
+  l2Gas: 0,
+  daGas: 0,
+};
+
+/** Dimensions of gas usage: L1, L2, and DA */
+export const GasDimensions = ['l1Gas', 'l2Gas', 'daGas'] as const;
+
+/** Temporary default gas cost. We should eventually remove all usage of this variable in favor of actual gas for each opcode. */
+const TemporaryDefaultGasCost = { l1Gas: 0, l2Gas: 10, daGas: 0 };
+
+/** Gas costs for each instruction. */
+export const GasCosts: Record<Opcode, GasCost> = {
+  [Opcode.ADD]: TemporaryDefaultGasCost,
+  [Opcode.SUB]: TemporaryDefaultGasCost,
+  [Opcode.MUL]: TemporaryDefaultGasCost,
+  [Opcode.DIV]: TemporaryDefaultGasCost,
+  [Opcode.FDIV]: TemporaryDefaultGasCost,
+  [Opcode.EQ]: TemporaryDefaultGasCost,
+  [Opcode.LT]: TemporaryDefaultGasCost,
+  [Opcode.LTE]: TemporaryDefaultGasCost,
+  [Opcode.AND]: TemporaryDefaultGasCost,
+  [Opcode.OR]: TemporaryDefaultGasCost,
+  [Opcode.XOR]: TemporaryDefaultGasCost,
+  [Opcode.NOT]: TemporaryDefaultGasCost,
+  [Opcode.SHL]: TemporaryDefaultGasCost,
+  [Opcode.SHR]: TemporaryDefaultGasCost,
+  [Opcode.CAST]: TemporaryDefaultGasCost,
+  // Execution environment
+  [Opcode.ADDRESS]: TemporaryDefaultGasCost,
+  [Opcode.STORAGEADDRESS]: TemporaryDefaultGasCost,
+  [Opcode.ORIGIN]: TemporaryDefaultGasCost,
+  [Opcode.SENDER]: TemporaryDefaultGasCost,
+  [Opcode.PORTAL]: TemporaryDefaultGasCost,
+  [Opcode.FEEPERL1GAS]: TemporaryDefaultGasCost,
+  [Opcode.FEEPERL2GAS]: TemporaryDefaultGasCost,
+  [Opcode.FEEPERDAGAS]: TemporaryDefaultGasCost,
+  [Opcode.CONTRACTCALLDEPTH]: TemporaryDefaultGasCost,
+  [Opcode.CHAINID]: TemporaryDefaultGasCost,
+  [Opcode.VERSION]: TemporaryDefaultGasCost,
+  [Opcode.BLOCKNUMBER]: TemporaryDefaultGasCost,
+  [Opcode.TIMESTAMP]: TemporaryDefaultGasCost,
+  [Opcode.COINBASE]: TemporaryDefaultGasCost,
+  [Opcode.BLOCKL1GASLIMIT]: TemporaryDefaultGasCost,
+  [Opcode.BLOCKL2GASLIMIT]: TemporaryDefaultGasCost,
+  [Opcode.BLOCKDAGASLIMIT]: TemporaryDefaultGasCost,
+  [Opcode.CALLDATACOPY]: TemporaryDefaultGasCost,
+  // Gas
+  [Opcode.L1GASLEFT]: TemporaryDefaultGasCost,
+  [Opcode.L2GASLEFT]: TemporaryDefaultGasCost,
+  [Opcode.DAGASLEFT]: TemporaryDefaultGasCost,
+  // Control flow
+  [Opcode.JUMP]: TemporaryDefaultGasCost,
+  [Opcode.JUMPI]: TemporaryDefaultGasCost,
+  [Opcode.INTERNALCALL]: TemporaryDefaultGasCost,
+  [Opcode.INTERNALRETURN]: TemporaryDefaultGasCost,
+  // Memory
+  [Opcode.SET]: TemporaryDefaultGasCost,
+  [Opcode.MOV]: TemporaryDefaultGasCost,
+  [Opcode.CMOV]: TemporaryDefaultGasCost,
+  // World state
+  [Opcode.SLOAD]: TemporaryDefaultGasCost,
+  [Opcode.SSTORE]: TemporaryDefaultGasCost,
+  [Opcode.NOTEHASHEXISTS]: TemporaryDefaultGasCost,
+  [Opcode.EMITNOTEHASH]: TemporaryDefaultGasCost,
+  [Opcode.NULLIFIEREXISTS]: TemporaryDefaultGasCost,
+  [Opcode.EMITNULLIFIER]: TemporaryDefaultGasCost,
+  [Opcode.L1TOL2MSGEXISTS]: TemporaryDefaultGasCost,
+  [Opcode.HEADERMEMBER]: TemporaryDefaultGasCost,
+  [Opcode.EMITUNENCRYPTEDLOG]: TemporaryDefaultGasCost,
+  [Opcode.SENDL2TOL1MSG]: TemporaryDefaultGasCost,
+  // External calls
+  [Opcode.CALL]: TemporaryDefaultGasCost,
+  [Opcode.STATICCALL]: TemporaryDefaultGasCost,
+  [Opcode.DELEGATECALL]: TemporaryDefaultGasCost,
+  [Opcode.RETURN]: TemporaryDefaultGasCost,
+  [Opcode.REVERT]: TemporaryDefaultGasCost,
+  // Gadgets
+  [Opcode.KECCAK]: TemporaryDefaultGasCost,
+  [Opcode.POSEIDON]: TemporaryDefaultGasCost,
+  [Opcode.SHA256]: TemporaryDefaultGasCost, // temp - may be removed, but alot of contracts rely on i: TemporaryDefaultGasCost,
+  [Opcode.PEDERSEN]: TemporaryDefaultGasCost, // temp - may be removed, but alot of contracts rely on i: TemporaryDefaultGasCost,t
+};

--- a/yarn-project/simulator/src/avm/avm_simulator.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.ts
@@ -50,7 +50,6 @@ export class AvmSimulator {
    */
   public async executeInstructions(instructions: Instruction[]): Promise<AvmContractCallResults> {
     assert(instructions.length > 0);
-
     try {
       // Execute instruction pointed to by the current program counter
       // continuing until the machine state signifies a halt
@@ -65,7 +64,7 @@ export class AvmSimulator {
         // Execute the instruction.
         // Normal returns and reverts will return normally here.
         // "Exceptional halts" will throw.
-        await instruction.execute(this.context);
+        await instruction.run(this.context);
 
         if (this.context.machineState.pc >= instructions.length) {
           this.log('Passed end of program!');

--- a/yarn-project/simulator/src/avm/errors.ts
+++ b/yarn-project/simulator/src/avm/errors.ts
@@ -55,3 +55,11 @@ export class TagCheckError extends AvmExecutionError {
     this.name = 'TagCheckError';
   }
 }
+
+/** Error thrown when out of gas. */
+export class OutOfGasError extends AvmExecutionError {
+  constructor(dimensions: string[]) {
+    super(`Not enough ${dimensions.map(d => d.toUpperCase()).join(', ')} gas left`);
+    this.name = 'OutOfGasError';
+  }
+}

--- a/yarn-project/simulator/src/avm/fixtures/index.ts
+++ b/yarn-project/simulator/src/avm/fixtures/index.ts
@@ -85,13 +85,13 @@ export function initGlobalVariables(overrides?: Partial<GlobalVariables>): Globa
 }
 
 /**
- * Create an empty instance of the Machine State where all values are zero, unless overridden in the overrides object
+ * Create an empty instance of the Machine State where all values are set to a large enough amount, unless overridden in the overrides object
  */
 export function initMachineState(overrides?: Partial<AvmMachineState>): AvmMachineState {
   return AvmMachineState.fromState({
-    l1GasLeft: overrides?.l1GasLeft ?? 0,
-    l2GasLeft: overrides?.l2GasLeft ?? 0,
-    daGasLeft: overrides?.daGasLeft ?? 0,
+    l1GasLeft: overrides?.l1GasLeft ?? 1e6,
+    l2GasLeft: overrides?.l2GasLeft ?? 1e6,
+    daGasLeft: overrides?.daGasLeft ?? 1e6,
   });
 }
 

--- a/yarn-project/simulator/src/public/executor.ts
+++ b/yarn-project/simulator/src/public/executor.ts
@@ -229,13 +229,15 @@ export class PublicExecutor {
     const hostStorage = new HostStorage(this.stateDb, this.contractsDb, this.commitmentsDb);
     const worldStateJournal = new AvmPersistableStateManager(hostStorage);
     const executionEnv = temporaryCreateAvmExecutionEnvironment(execution, globalVariables);
-    const machineState = new AvmMachineState(0, 0, 0);
+    // TODO(@spalladino) Load initial gas from the public execution request
+    const machineState = new AvmMachineState(100_000, 100_000, 100_000);
 
     const context = new AvmContext(worldStateJournal, executionEnv, machineState);
     const simulator = new AvmSimulator(context);
 
     const result = await simulator.execute();
     const newWorldState = context.persistableState.flush();
+    // TODO(@spalladino) Read gas left from machineState and return it
     return temporaryConvertAvmResults(execution, newWorldState, result);
   }
 


### PR DESCRIPTION
Adds gas tracking for AVM instructions to the simulator. For now, every instruction consumes the same amount of gas, and executions start with an arbitrary amount of gas. If gas is exhausted, it triggers an exceptional halt as defined in the yp.

