### PR TITLE
fix: addressing flakiness of `uniswap_trade_on_l1_from_l2.test.ts`

### DIFF
--- a/yarn-project/aztec-faucet/src/bin/index.ts
+++ b/yarn-project/aztec-faucet/src/bin/index.ts
@@ -7,7 +7,7 @@ import http from 'http';
 import Koa from 'koa';
 import cors from 'koa-cors';
 import Router from 'koa-router';
-import { Hex, http as ViemHttp, createWalletClient, parseEther } from 'viem';
+import { Hex, http as ViemHttp, createPublicClient, createWalletClient, parseEther } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 
 const {
@@ -68,6 +68,10 @@ async function transferEth(address: string) {
     chain: chain.chainInfo,
     transport: ViemHttp(chain.rpcUrl),
   });
+  const publicClient = createPublicClient({
+    chain: chain.chainInfo,
+    transport: ViemHttp(chain.rpcUrl),
+  });
   const hexAddress = createHex(address);
   checkThrottle(hexAddress);
   try {
@@ -76,6 +80,7 @@ async function transferEth(address: string) {
       to: hexAddress,
       value: parseEther(ETH_AMOUNT),
     });
+    await publicClient.waitForTransactionReceipt({ hash });
     mapping[hexAddress] = new Date();
     logger.info(`Sent ${ETH_AMOUNT} ETH to ${hexAddress} in tx ${hash}`);
   } catch (error) {

--- a/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
+++ b/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
@@ -155,24 +155,24 @@ export const uniswapL1L2TestSuite = (
         [registryAddress.toString(), uniswapL2Contract.address.toString()],
         {} as any,
       );
-    });
 
-    beforeEach(async () => {
       // Give me some WETH so I can deposit to L2 and do the swap...
       logger('Getting some weth');
-      await walletClient.sendTransaction({ to: WETH9_ADDRESS.toString(), value: parseEther('1') });
+      const hash = await walletClient.sendTransaction({ to: WETH9_ADDRESS.toString(), value: parseEther('1000') });
+      await publicClient.waitForTransactionReceipt({ hash });
+
+      const wethBalance = await wethCrossChainHarness.getL1BalanceOf(ownerEthAddress);
+      expect(wethBalance).toBe(parseEther('1000'));
     });
     // docs:end:uniswap_l1_l2_test_beforeAll
 
     afterAll(async () => {
       await cleanup();
     });
+
     // docs:start:uniswap_private
     it('should uniswap trade on L1 from L2 funds privately (swaps WETH -> DAI)', async () => {
       const wethL1BeforeBalance = await wethCrossChainHarness.getL1BalanceOf(ownerEthAddress);
-      if (wethL1BeforeBalance < wethAmountToBridge) {
-        throw new Error('Not enough WETH to run this test. Try restarting anvil.');
-      }
 
       // 1. Approve and deposit weth to the portal and move to L2
       const [secretForMintingWeth, secretHashForMintingWeth] = wethCrossChainHarness.generateClaimSecret();


### PR DESCRIPTION
A PR which hopefully addresses flakiness of uniswap l1 l2 test. In this [failing test run](https://app.circleci.com/pipelines/github/AztecProtocol/aztec-packages/31051/workflows/776653ec-d6e1-448f-8faa-217d038f8f8c/jobs/1473726/parallel-runs/0/steps/0-103) the first test case to fail fails because the account used is not seeded with enough WETH. I think the reason for this failure was that we did not wait for the tx to be mined. For this reason I now wait for a tx receipt. I've also moved sending the mint tx from `beforeEach` to `beforeAll` and now I simply mint there more ETH. Minting before each test case just wastes time.

The second and third failing test case seems to be unrelated to the first run and I am not sure if this will fix them but I think it makes sense to wait for this to be merged and spend time on it if they fail again.

I also went through all the occurrences of ".sendTransaction(" in the codebase and ensured that we always wait for the tx to be mined.