### PR TITLE
fix: Copy and deploy complete contents of l1-contracts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1193,6 +1193,16 @@ jobs:
             should_release || exit 0
             yarn-project/deploy_npm.sh latest
       - run:
+          name: "Release canary to NPM: l1-contracts"
+          command: |
+            should_release || exit 0
+            deploy_npm l1-contracts canary
+      - run:
+          name: "Release latest to NPM: l1-contracts"
+          command: |
+            should_release || exit 0
+            deploy_npm l1-contracts latest
+      - run:
           name: "Deploy mainnet fork"
           command: |
             should_deploy || exit 0

--- a/l1-contracts/Dockerfile
+++ b/l1-contracts/Dockerfile
@@ -24,4 +24,4 @@ RUN yarn && yarn lint
 RUN forge build
 
 FROM scratch
-COPY --from=0 /usr/src/l1-contracts/out /usr/src/l1-contracts/out
+COPY --from=0 /usr/src/l1-contracts/ /usr/src/l1-contracts/


### PR DESCRIPTION
This PR attempts to fix deployments of l1-contracts by copying the entire package rather than simply the compiled artifacts.
