### PR TITLE
fix: Docs example e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1033,7 +1033,7 @@ jobs:
       - *setup_env
       - run:
           name: "Test"
-          command: cond_spot_run_compose end-to-end 4 ./scripts/docker-compose.yml TEST=docs_examples_test.ts
+          command: cond_spot_run_compose end-to-end 4 ./scripts/docker-compose.yml TEST=docs_examples.test.ts
           aztec_manifest_key: end-to-end
     <<: *defaults_e2e_test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1013,7 +1013,7 @@ jobs:
       - *setup_env
       - run:
           name: "Test"
-          command: cond_spot_run_compose end-to-end 4 ./scripts/docker-compose.yml TEST=pxe_sandbox.test.ts
+          command: cond_spot_run_compose end-to-end 4 ./scripts/docker-compose.yml TEST=pxe.test.ts
           aztec_manifest_key: end-to-end
     <<: *defaults_e2e_test
 

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -11,7 +11,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src \"!src/web/main.js\" && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "DEBUG='aztec:*' NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --runInBand --passWithNoTests --testTimeout=15000 --forceExit",
+    "test": "DEBUG='aztec:*' NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --runInBand --testTimeout=60000 --forceExit",
     "test:integration": "concurrently -k -s first -c reset,dim -n test,anvil \"yarn test:integration:run\" \"anvil\"",
     "test:integration:run": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --no-cache --runInBand --config jest.integration.config.json"
   },

--- a/yarn-project/end-to-end/src/docs_examples.test.ts
+++ b/yarn-project/end-to-end/src/docs_examples.test.ts
@@ -10,37 +10,42 @@ import { TokenContract, TokenContractArtifact } from '@aztec/noir-contracts.js/T
 
 // docs:end:import_token_contract
 
-// docs:start:define_account_vars
-const PXE_URL = process.env.PXE_URL || 'http://localhost:8080';
-const encryptionPrivateKey = GrumpkinScalar.random();
-const signingPrivateKey = GrumpkinScalar.random();
-const pxe = createPXEClient(PXE_URL);
-// docs:end:define_account_vars
+describe('docs_examples', () => {
+  it('deploys and interacts with a token contract', async () => {
+    // docs:start:define_account_vars
+    const PXE_URL = process.env.PXE_URL || 'http://localhost:8080';
+    const encryptionPrivateKey = GrumpkinScalar.random();
+    const signingPrivateKey = GrumpkinScalar.random();
+    const pxe = createPXEClient(PXE_URL);
+    // docs:end:define_account_vars
 
-// docs:start:create_wallet
-const wallet = await getSchnorrAccount(pxe, encryptionPrivateKey, signingPrivateKey).waitSetup();
-// docs:end:create_wallet
+    // docs:start:create_wallet
+    const wallet = await getSchnorrAccount(pxe, encryptionPrivateKey, signingPrivateKey).waitSetup();
+    // docs:end:create_wallet
 
-// docs:start:deploy_contract
-const deployedContract = await TokenContract.deploy(
-  wallet, // wallet instance
-  wallet.getAddress(), // account
-  'TokenName', // constructor arg1
-  'TokenSymbol', // constructor arg2
-  18,
-) // constructor arg3
-  .send()
-  .deployed();
-// docs:end:deploy_contract
+    // docs:start:deploy_contract
+    const deployedContract = await TokenContract.deploy(
+      wallet, // wallet instance
+      wallet.getAddress(), // account
+      'TokenName', // constructor arg1
+      'TokenSymbol', // constructor arg2
+      18,
+    ) // constructor arg3
+      .send()
+      .deployed();
+    // docs:end:deploy_contract
 
-// docs:start:get_contract
-const contract = await Contract.at(deployedContract.address, TokenContractArtifact, wallet);
-// docs:end:get_contract
+    // docs:start:get_contract
+    const contract = await Contract.at(deployedContract.address, TokenContractArtifact, wallet);
+    // docs:end:get_contract
 
-// docs:start:send_transaction
-const _tx = await contract.methods.transfer(1, wallet).send().wait();
-// docs:end:send_transaction
+    // docs:start:send_transaction
+    const _tx = await contract.methods.mint_public(wallet.getAddress(), 1).send().wait();
+    // docs:end:send_transaction
 
-// docs:start:call_view_function
-const _balance = await contract.methods.get_balance(wallet.getAddress()).view();
-// docs:end:call_view_function
+    // docs:start:call_view_function
+    const balance = await contract.methods.balance_of_public(wallet.getAddress()).view();
+    expect(balance).toEqual(1n);
+    // docs:end:call_view_function
+  }, 120_000);
+});


### PR DESCRIPTION
The docs example script was not running in CCI due to a misconfigured test name in the ci configuration. On top of that, the test command for e2e tests had a passWithNoTests flag, so this failed silently. Also, there were no tests defined on the test file, as it was just a script and the describe block was missing. And last, the test was outdated, as it was calling a function with a wrong number of arguments and another function that no longer existed in the token contract.

This PR fixes all of the above.