### PR TITLE
refactor: renaming rand() as unsafe_rand()

### DIFF
--- a/docs/docs/misc/migration_notes.md
+++ b/docs/docs/misc/migration_notes.md
@@ -6,6 +6,17 @@ keywords: [sandbox, cli, aztec, notes, migration, updating, upgrading]
 
 Aztec is in full-speed development. Literally every version breaks compatibility with the previous ones. This page attempts to target errors and difficulties you might encounter when upgrading, and how to resolve them.
 
+## TBD
+
+### [Aztec.nr] rand oracle is now called unsafe_rand
+`oracle::rand::rand` has been renamed to `oracle::unsafe_rand::unsafe_rand`.
+This change was made to communicate that we do not constrain the value in circuit and instead we just trust our PXE.
+
+```diff
+- let random_value = rand();
++ let random_value = unsafe_rand();
+```
+
 ## 0.31.0
 
 ### [Aztec.nr] Public storage historical read API improvement

--- a/noir-projects/aztec-nr/address-note/src/address_note.nr
+++ b/noir-projects/aztec-nr/address-note/src/address_note.nr
@@ -4,7 +4,7 @@ use dep::aztec::log::emit_encrypted_log;
 use dep::aztec::{
     protocol_types::{address::AztecAddress, traits::Empty},
     note::{note_header::NoteHeader, note_interface::NoteInterface, utils::compute_note_hash_for_consumption},
-    oracle::{rand::rand, nullifier_key::get_nullifier_secret_key, get_public_key::get_public_key},
+    oracle::{unsafe_rand::unsafe_rand, nullifier_key::get_nullifier_secret_key, get_public_key::get_public_key},
     hash::pedersen_hash, context::PrivateContext
 };
 
@@ -61,7 +61,7 @@ impl NoteInterface<ADDRESS_NOTE_LEN>  for AddressNote {
 
 impl AddressNote {
     pub fn new(address: AztecAddress, owner: AztecAddress) -> Self {
-        let randomness = rand();
+        let randomness = unsafe_rand();
         AddressNote { address, owner, randomness, header: NoteHeader::empty() }
     }
     // docs:end:address_note_def

--- a/noir-projects/aztec-nr/aztec/src/oracle.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle.nr
@@ -14,7 +14,7 @@ mod get_membership_witness;
 mod get_public_key;
 mod nullifier_key;
 mod get_sibling_path;
-mod rand;
+mod unsafe_rand;
 mod enqueue_public_function_call;
 mod header;
 mod public_call;

--- a/noir-projects/aztec-nr/aztec/src/oracle/rand.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/rand.nr
@@ -1,6 +1,0 @@
-#[oracle(getRandomField)]
-fn rand_oracle() -> Field {}
-
-unconstrained pub fn rand() -> Field {
-    rand_oracle()
-}

--- a/noir-projects/aztec-nr/aztec/src/oracle/unsafe_rand.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/unsafe_rand.nr
@@ -2,8 +2,8 @@
 fn rand_oracle() -> Field {}
 
 
-// Called `unsafe_rand` because we do not constrain in circuit that we are dealing with an actual random value but
-// instead we just trust our PXE.
+// Called `unsafe_rand` because we do not constrain in circuit that we are dealing with an actual random value.
+// Instead we just trust our PXE.
 unconstrained pub fn unsafe_rand() -> Field {
     rand_oracle()
 }

--- a/noir-projects/aztec-nr/aztec/src/oracle/unsafe_rand.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/unsafe_rand.nr
@@ -1,0 +1,9 @@
+#[oracle(getRandomField)]
+fn rand_oracle() -> Field {}
+
+
+// Called `unsafe_rand` because we do not constrain in circuit that we are dealing with an actual random value but
+// instead we just trust our PXE.
+unconstrained pub fn unsafe_rand() -> Field {
+    rand_oracle()
+}

--- a/noir-projects/aztec-nr/value-note/src/value_note.nr
+++ b/noir-projects/aztec-nr/value-note/src/value_note.nr
@@ -1,7 +1,7 @@
 use dep::aztec::{
     protocol_types::{address::AztecAddress, traits::{Deserialize, Serialize}},
     note::{note_header::NoteHeader, note_interface::NoteInterface, utils::compute_note_hash_for_consumption},
-    oracle::{rand::rand, nullifier_key::get_nullifier_secret_key, get_public_key::get_public_key},
+    oracle::{unsafe_rand::unsafe_rand, nullifier_key::get_nullifier_secret_key, get_public_key::get_public_key},
     log::emit_encrypted_log, hash::pedersen_hash, context::PrivateContext
 };
 
@@ -59,7 +59,7 @@ impl NoteInterface<VALUE_NOTE_LEN> for ValueNote {
 
 impl ValueNote {
     pub fn new(value: Field, owner: AztecAddress) -> Self {
-        let randomness = rand();
+        let randomness = unsafe_rand();
         let header = NoteHeader::empty();
         ValueNote { value, owner, randomness, header }
     }

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -21,7 +21,7 @@ contract Test {
         note_getter_options::NoteStatus
     },
         deploy::deploy_contract as aztec_deploy_contract,
-        oracle::{get_public_key::get_public_key as get_public_key_oracle, context::get_portal_address, rand::rand},
+        oracle::{get_public_key::get_public_key as get_public_key_oracle, context::get_portal_address, unsafe_rand::unsafe_rand},
         log::emit_unencrypted_log_from_private
     };
     use dep::token_portal_content_hash_lib::{get_mint_private_content_hash, get_mint_public_content_hash};
@@ -379,7 +379,7 @@ contract Test {
 
     // Purely exists for testing
     unconstrained fn get_random(kinda_seed: Field) -> pub Field {
-        kinda_seed * rand()
+        kinda_seed * unsafe_rand()
     }
 
     struct DummyNote {

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/token_note.nr
@@ -1,6 +1,6 @@
 use dep::aztec::prelude::{AztecAddress, NoteHeader, NoteInterface, PrivateContext, emit_encrypted_log};
 use dep::aztec::{note::utils::compute_note_hash_for_consumption, hash::pedersen_hash};
-use dep::aztec::oracle::{rand::rand, nullifier_key::get_nullifier_secret_key, get_public_key::get_public_key};
+use dep::aztec::oracle::{unsafe_rand::unsafe_rand, nullifier_key::get_nullifier_secret_key, get_public_key::get_public_key};
 
 trait OwnedNote {
     fn new(amount: U128, owner: AztecAddress) -> Self;
@@ -69,7 +69,7 @@ impl OwnedNote for TokenNote {
         Self {
             amount,
             owner,
-            randomness: rand(),
+            randomness: unsafe_rand(),
             header: NoteHeader::empty(),
         }
     }

--- a/noir-projects/noir-contracts/contracts/token_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/types/token_note.nr
@@ -3,7 +3,7 @@ use dep::aztec::prelude::{
     PrivateSet, Map, emit_encrypted_log
 };
 use dep::aztec::{note::utils::compute_note_hash_for_consumption, hash::pedersen_hash};
-use dep::aztec::oracle::{rand::rand, nullifier_key::get_nullifier_secret_key, get_public_key::get_public_key};
+use dep::aztec::oracle::{unsafe_rand::unsafe_rand, nullifier_key::get_nullifier_secret_key, get_public_key::get_public_key};
 
 trait OwnedNote {
     fn new(amount: U128, owner: AztecAddress) -> Self;
@@ -72,7 +72,7 @@ impl OwnedNote for TokenNote {
         Self {
             amount,
             owner,
-            randomness: rand(),
+            randomness: unsafe_rand(),
             header: NoteHeader::empty(),
         }
     }


### PR DESCRIPTION
Fixes #3746
