### PR TITLE
chore: Remove unused boolean return values from stores

### DIFF
--- a/yarn-project/archiver/src/archiver/kv_archiver_store/contract_class_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/contract_class_store.ts
@@ -17,7 +17,7 @@ export class ContractClassStore {
     this.#contractClasses = db.openMap('archiver_contract_classes');
   }
 
-  addContractClass(contractClass: ContractClassPublic): Promise<boolean> {
+  addContractClass(contractClass: ContractClassPublic): Promise<void> {
     return this.#contractClasses.set(contractClass.id.toString(), serializeContractClassPublic(contractClass));
   }
 

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/contract_instance_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/contract_instance_store.ts
@@ -12,7 +12,7 @@ export class ContractInstanceStore {
     this.#contractInstances = db.openMap('archiver_contract_instances');
   }
 
-  addContractInstance(contractInstance: ContractInstanceWithAddress): Promise<boolean> {
+  addContractInstance(contractInstance: ContractInstanceWithAddress): Promise<void> {
     return this.#contractInstances.set(
       contractInstance.address.toString(),
       new SerializableContractInstance(contractInstance).toBuffer(),

--- a/yarn-project/kv-store/src/interfaces/counter.ts
+++ b/yarn-project/kv-store/src/interfaces/counter.ts
@@ -12,7 +12,7 @@ export interface AztecCounter<K extends Key = Key> {
    * @param key - The key to reset
    * @param value - The value to reset the key to
    */
-  set(key: K, value: number): Promise<boolean>;
+  set(key: K, value: number): Promise<void>;
 
   /**
    * Updates the count of the given key by the given delta. This can be used to increment or decrement the count.
@@ -21,7 +21,7 @@ export interface AztecCounter<K extends Key = Key> {
    * @param key - The key to update
    * @param delta - The amount to modify the key by
    */
-  update(key: K, delta: number): Promise<boolean>;
+  update(key: K, delta: number): Promise<void>;
 
   /**
    * Gets the current count.

--- a/yarn-project/kv-store/src/interfaces/map.ts
+++ b/yarn-project/kv-store/src/interfaces/map.ts
@@ -22,14 +22,14 @@ export interface AztecMap<K extends Key, V> {
    * @param key - The key to set the value at
    * @param val - The value to set
    */
-  set(key: K, val: V): Promise<boolean>;
+  set(key: K, val: V): Promise<void>;
 
   /**
    * Atomically swap the value at the given key
    * @param key - The key to swap the value at
    * @param fn - The function to swap the value with
    */
-  swap(key: K, fn: (val: V | undefined) => V): Promise<boolean>;
+  swap(key: K, fn: (val: V | undefined) => V): Promise<void>;
 
   /**
    * Sets the value at the given key if it does not already exist.
@@ -42,7 +42,7 @@ export interface AztecMap<K extends Key, V> {
    * Deletes the value at the given key.
    * @param key - The key to delete the value at
    */
-  delete(key: K): Promise<boolean>;
+  delete(key: K): Promise<void>;
 
   /**
    * Iterates over the map's key-value entries in the key's natural order

--- a/yarn-project/kv-store/src/lmdb/counter.ts
+++ b/yarn-project/kv-store/src/lmdb/counter.ts
@@ -18,11 +18,11 @@ export class LmdbAztecCounter<K extends Key> implements AztecCounter<K> {
     this.#map = new LmdbAztecMap(db, name);
   }
 
-  set(key: K, value: number): Promise<boolean> {
-    return this.#map.set(key, value);
+  async set(key: K, value: number): Promise<void> {
+    await this.#map.set(key, value);
   }
 
-  update(key: K, delta = 1): Promise<boolean> {
+  update(key: K, delta = 1): Promise<void> {
     return this.#db.childTransaction(() => {
       const current = this.#map.get(key) ?? 0;
       const next = current + delta;
@@ -38,8 +38,6 @@ export class LmdbAztecCounter<K extends Key> implements AztecCounter<K> {
         // of the key when iterating over the database
         void this.#map.set(key, next);
       }
-
-      return true;
     });
   }
 

--- a/yarn-project/kv-store/src/lmdb/map.test.ts
+++ b/yarn-project/kv-store/src/lmdb/map.test.ts
@@ -31,7 +31,7 @@ describe('LmdbAztecMap', () => {
     await map.set('foo', 'bar');
     await map.set('baz', 'qux');
 
-    expect(await map.delete('foo')).toEqual(true);
+    await map.delete('foo');
 
     expect(map.get('foo')).toEqual(undefined);
     expect(map.get('baz')).toEqual('qux');

--- a/yarn-project/kv-store/src/lmdb/map.ts
+++ b/yarn-project/kv-store/src/lmdb/map.ts
@@ -46,17 +46,15 @@ export class LmdbAztecMap<K extends Key, V> implements AztecMultiMap<K, V> {
     return this.db.doesExist(this.#slot(key));
   }
 
-  set(key: K, val: V): Promise<boolean> {
-    return this.db.put(this.#slot(key), [key, val]);
+  async set(key: K, val: V): Promise<void> {
+    await this.db.put(this.#slot(key), [key, val]);
   }
 
-  swap(key: K, fn: (val: V | undefined) => V): Promise<boolean> {
+  swap(key: K, fn: (val: V | undefined) => V): Promise<void> {
     return this.db.childTransaction(() => {
       const slot = this.#slot(key);
       const entry = this.db.get(slot);
       void this.db.put(slot, [key, fn(entry?.[1])]);
-
-      return true;
     });
   }
 
@@ -67,8 +65,8 @@ export class LmdbAztecMap<K extends Key, V> implements AztecMultiMap<K, V> {
     });
   }
 
-  delete(key: K): Promise<boolean> {
-    return this.db.remove(this.#slot(key));
+  async delete(key: K): Promise<void> {
+    await this.db.remove(this.#slot(key));
   }
 
   async deleteValue(key: K, val: V): Promise<void> {

--- a/yarn-project/pxe/src/database/kv_pxe_database.ts
+++ b/yarn-project/pxe/src/database/kv_pxe_database.ts
@@ -391,7 +391,7 @@ export class KVPxeDatabase implements PxeDatabase {
     return this.#syncedBlockPerPublicKey.get(publicKey.toString());
   }
 
-  setSynchedBlockNumberForPublicKey(publicKey: Point, blockNumber: number): Promise<boolean> {
+  setSynchedBlockNumberForPublicKey(publicKey: Point, blockNumber: number): Promise<void> {
     return this.#syncedBlockPerPublicKey.set(publicKey.toString(), blockNumber);
   }
 

--- a/yarn-project/pxe/src/database/pxe_database.ts
+++ b/yarn-project/pxe/src/database/pxe_database.ts
@@ -150,7 +150,7 @@ export interface PxeDatabase extends ContractArtifactDatabase, ContractInstanceD
    * @param publicKey - The public key to set the synched block number for.
    * @param blockNumber - The block number to set.
    */
-  setSynchedBlockNumberForPublicKey(publicKey: PublicKey, blockNumber: number): Promise<boolean>;
+  setSynchedBlockNumberForPublicKey(publicKey: PublicKey, blockNumber: number): Promise<void>;
 
   /**
    * Get the synched block number for a given public key.


### PR DESCRIPTION
LMDB operations return a false boolean if an insert or delete operation fails due to a failed version check, which we are not using. So we just turn every return value to void.

Context [here](https://github.com/AztecProtocol/aztec-packages/pull/5318#discussion_r1535471877).