### PR TITLE
fix: `l1-contracts/bootstrap.sh`

### DIFF
--- a/l1-contracts/scripts/install_foundry.sh
+++ b/l1-contracts/scripts/install_foundry.sh
@@ -13,18 +13,17 @@ echo "$FOUNDRY_SHORT_VERSION"
 # Check if forge is installed and matches the expected version
 if command -v "forge" > /dev/null 2>&1 && [[ "$(forge --version)" == *"$FOUNDRY_SHORT_VERSION"* ]]; then
     echo "Foundry is already installed and at the correct version."
-    exit 0
+else
+    # Clean
+    rm -rf $FOUNDRY_DIR
+
+    # Install foundryup.
+    mkdir -p $FOUNDRY_BIN_DIR
+    mkdir -p $FOUNDRY_MAN_DIR
+    curl -# -L $BIN_URL -o $BIN_PATH
+    chmod +x $BIN_PATH
+    export PATH=$FOUNDRY_BIN_DIR:$PATH
+
+    # Use version.
+    foundryup --version $FOUNDRY_VERSION
 fi
-
-# Clean
-rm -rf $FOUNDRY_DIR
-
-# Install foundryup.
-mkdir -p $FOUNDRY_BIN_DIR
-mkdir -p $FOUNDRY_MAN_DIR
-curl -# -L $BIN_URL -o $BIN_PATH
-chmod +x $BIN_PATH
-export PATH=$FOUNDRY_BIN_DIR:$PATH
-
-# Use version.
-foundryup --version $FOUNDRY_VERSION

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -137,7 +137,7 @@ export class Archiver implements ArchiveSource {
   }
 
   /**
-   * Fetches `L2BlockProcessed` and `ContractDeployment` logs from `nextL2BlockFromBlock` and processes them.
+   * Fetches logs from L1 contracts and processes them.
    * @param blockUntilSynced - If true, blocks until the archiver has fully synced.
    */
   private async sync(blockUntilSynced: boolean) {


### PR DESCRIPTION
bootstrap.sh in l1-contracts failed to rebuild contracts when foundry was already installed. This PR fixes it.
