### PR TITLE
refactor: inject fetcher instead of using global

### DIFF
--- a/noir/noir-repo/compiler/wasm/src/noir/dependencies/github-dependency-resolver.ts
+++ b/noir/noir-repo/compiler/wasm/src/noir/dependencies/github-dependency-resolver.ts
@@ -12,10 +12,12 @@ import { LogData } from '../../utils';
  */
 export class GithubDependencyResolver implements DependencyResolver {
   #fm: FileManager;
+  #fetch: typeof fetch;
   #log;
 
-  constructor(fm: FileManager) {
+  constructor(fm: FileManager, fetcher: typeof fetch) {
     this.#fm = fm;
+    this.#fetch = fetcher;
     this.#log = (msg: string, _data?: LogData) => {
       console.log(msg);
     };
@@ -56,7 +58,7 @@ export class GithubDependencyResolver implements DependencyResolver {
       return localArchivePath;
     }
 
-    const response = await fetch(url, {
+    const response = await this.#fetch(url, {
       method: 'GET',
     });
 

--- a/noir/noir-repo/compiler/wasm/src/noir/noir-wasm-compiler.ts
+++ b/noir/noir-repo/compiler/wasm/src/noir/noir-wasm-compiler.ts
@@ -72,7 +72,8 @@ export class NoirWasmCompiler {
     const dependencyManager = new DependencyManager(
       [
         new LocalDependencyResolver(fileManager),
-        new GithubCodeArchiveDependencyResolver(fileManager),
+        // use node's global fetch
+        new GithubCodeArchiveDependencyResolver(fileManager, fetch),
         // TODO support actual Git repositories
       ],
       noirPackage,

--- a/noir/noir-repo/compiler/wasm/test/dependencies/github-dependency-resolver.test.ts
+++ b/noir/noir-repo/compiler/wasm/test/dependencies/github-dependency-resolver.test.ts
@@ -31,7 +31,7 @@ describe('GithubDependencyResolver', () => {
   let fetchStub: SinonStub | undefined;
 
   beforeEach(() => {
-    fetchStub = Sinon.stub(globalThis, 'fetch');
+    fetchStub = Sinon.stub();
     fm = createMemFSFileManager(createFsFromVolume(new Volume()), '/');
 
     libDependency = {
@@ -50,14 +50,10 @@ describe('GithubDependencyResolver', () => {
       },
     });
 
-    resolver = new GithubDependencyResolver(fm);
+    resolver = new GithubDependencyResolver(fm, fetchStub);
 
     // cut off outside access
     fetchStub.onCall(0).throws(new Error());
-  });
-
-  afterEach(() => {
-    fetchStub?.restore();
   });
 
   it("returns null if it can't resolve a dependency", async () => {


### PR DESCRIPTION
This PR refactors the GithubDependencyResolver to take a fetch implementation instead of always using the global default
