### PR TITLE
chore: improve caching in noir Earthfile

### DIFF
--- a/noir/Earthfile
+++ b/noir/Earthfile
@@ -28,13 +28,14 @@ nargo:
 packages:
     FROM node:20
 
+    RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+    RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
+    RUN apt update && apt install -y jq libc++1
+
     # `noir-repo` is nested inside of `noir` so we copy `bb.js` as such to account 
     # for the extra nested folder specified in portalled package paths
     COPY ../barretenberg/ts/+build/build /build/../barretenberg/ts
 
-    RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-    RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
-    RUN apt update && apt install -y jq libc++1
     WORKDIR /build
 
     # Relevant source (TODO finer-grained)


### PR DESCRIPTION
We can install rust + other deps before pulling in bb.js so we can use cached versions even if bb.js changes.