### PR TITLE
refactor: clean up compute_next_accumulator

### DIFF
--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.cpp
@@ -55,9 +55,8 @@ std::shared_ptr<typename ProverInstances::Instance> ProtoGalaxyProver_<ProverIns
     std::vector<FF> lagranges{ FF(1) - challenge, challenge };
 
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/881): bad pattern
-    auto next_accumulator = std::make_shared<Instance>();
+    auto next_accumulator = std::move(instances[0]);
     next_accumulator->is_accumulator = true;
-    next_accumulator->proving_key = instances[0]->proving_key;
 
     // Compute the next target sum and send the next folding parameters to the verifier
     FF next_target_sum =
@@ -66,15 +65,19 @@ std::shared_ptr<typename ProverInstances::Instance> ProtoGalaxyProver_<ProverIns
     next_accumulator->target_sum = next_target_sum;
     next_accumulator->gate_challenges = instances.next_gate_challenges;
 
-    // Initialize prover polynomials
-    ProvingKey acc_proving_key_polys;
-    for (auto& polynomial : acc_proving_key_polys.get_all()) {
-        polynomial = typename Flavor::Polynomial(instances[0]->proving_key->circuit_size);
-    }
+    // Initialize accumulator proving key polynomials
+    auto accumulator_polys = next_accumulator->proving_key->get_all();
+    run_loop_in_parallel(Flavor::NUM_FOLDED_ENTITIES, [&](size_t start_idx, size_t end_idx) {
+        for (size_t poly_idx = start_idx; poly_idx < end_idx; poly_idx++) {
+            auto& acc_poly = accumulator_polys[poly_idx];
+            for (auto& acc_el : acc_poly) {
+                acc_el = acc_el * lagranges[0];
+            }
+        }
+    });
 
-    // Fold the prover key polynomials
-    for (size_t inst_idx = 0; inst_idx < ProverInstances::NUM; inst_idx++) {
-        auto accumulator_polys = acc_proving_key_polys.get_all();
+    // Fold the proving key polynomials
+    for (size_t inst_idx = 1; inst_idx < ProverInstances::NUM; inst_idx++) {
         auto input_polys = instances[inst_idx]->proving_key->get_all();
         run_loop_in_parallel(Flavor::NUM_FOLDED_ENTITIES, [&](size_t start_idx, size_t end_idx) {
             for (size_t poly_idx = start_idx; poly_idx < end_idx; poly_idx++) {
@@ -86,20 +89,17 @@ std::shared_ptr<typename ProverInstances::Instance> ProtoGalaxyProver_<ProverIns
             }
         });
     }
-    for (auto [next_acc_poly, acc_poly] :
-         zip_view(next_accumulator->proving_key->get_all(), acc_proving_key_polys.get_all())) {
-        next_acc_poly = std::move(acc_poly);
-    }
 
     // Fold public data ϕ from all instances to produce ϕ* and add it to the transcript. As part of the folding
     // verification, the verifier will produce ϕ* as well and check it against what was sent by the prover.
 
     // Fold the public inputs and send to the verifier
-    next_accumulator->proving_key->public_inputs = std::vector<FF>(instances[0]->proving_key->public_inputs.size(), 0);
     size_t el_idx = 0;
     for (auto& el : next_accumulator->proving_key->public_inputs) {
+        el = el * lagranges[0];
         size_t inst = 0;
-        for (auto& instance : instances) {
+        for (size_t inst_idx = 1; inst_idx < ProverInstances::NUM; inst_idx++) {
+            auto& instance = instances[inst_idx];
             // TODO(https://github.com/AztecProtocol/barretenberg/issues/830)
             if (instance->proving_key->num_public_inputs >= next_accumulator->proving_key->num_public_inputs) {
                 el += instance->proving_key->public_inputs[el_idx] * lagranges[inst];


### PR DESCRIPTION
Partially addresses https://github.com/AztecProtocol/barretenberg/issues/881.

Cuts down on accumulator_update_round time by 300ms!

```
--------------------------------------------------------------------------------
Benchmark                      Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------
ClientIVCBench/Full/6      22272 ms        17339 ms            1 Decider::construct_proof=1 Decider::construct_proof(t)=752.81M ECCVMComposer::compute_commitment_key=1 ECCVMComposer::compute_commitment_key(t)=3.74397M ECCVMComposer::compute_witness=1 ECCVMComposer::compute_witness(t)=131.409M ECCVMComposer::create_prover=1 ECCVMComposer::create_prover(t)=151.452M ECCVMComposer::create_proving_key=1 ECCVMComposer::create_proving_key(t)=16.0709M ECCVMProver::construct_proof=1 ECCVMProver::construct_proof(t)=1.76787G Goblin::merge=11 Goblin::merge(t)=144.332M GoblinTranslatorCircuitBuilder::constructor=1 GoblinTranslatorCircuitBuilder::constructor(t)=58.9093M GoblinTranslatorProver=1 GoblinTranslatorProver(t)=164.575M GoblinTranslatorProver::construct_proof=1 GoblinTranslatorProver::construct_proof(t)=958.34M ProtoGalaxyProver_::accumulator_update_round=10 ProtoGalaxyProver_::accumulator_update_round(t)=292.705M ProtoGalaxyProver_::combiner_quotient_round=10 ProtoGalaxyProver_::combiner_quotient_round(t)=5.96917G ProtoGalaxyProver_::perturbator_round=10 ProtoGalaxyProver_::perturbator_round(t)=1.30937G ProtoGalaxyProver_::preparation_round=10 ProtoGalaxyProver_::preparation_round(t)=4.18574G ProtogalaxyProver::fold_instances=10 ProtogalaxyProver::fold_instances(t)=11.757G ProverInstance(Circuit&)=11 ProverInstance(Circuit&)(t)=1.99482G batch_mul_with_endomorphism=30 batch_mul_with_endomorphism(t)=566.111M commit=426 commit(t)=4.0365G compute_combiner=10 compute_combiner(t)=5.96705G compute_perturbator=9 compute_perturbator(t)=1.30905G compute_univariate=48 compute_univariate(t)=1.42119G construct_circuits=6 construct_circuits(t)=4.49152G
Benchmarking lock deleted.
client_ivc_bench.json                                                            100% 3992   123.3KB/s   00:00    
function                                        ms     % sum
construct_circuits(t)                         4492    20.40%
ProverInstance(Circuit&)(t)                   1995     9.06%
ProtogalaxyProver::fold_instances(t)         11757    53.40%
Decider::construct_proof(t)                    753     3.42%
ECCVMComposer::create_prover(t)                151     0.69%
ECCVMProver::construct_proof(t)               1768     8.03%
GoblinTranslatorProver::construct_proof(t)     958     4.35%
Goblin::merge(t)                               144     0.66%

Total time accounted for: 22018ms/22272ms = 98.86%

Major contributors:
function                                        ms    % sum
commit(t)                                     4037   18.33%
compute_combiner(t)                           5967   27.10%
compute_perturbator(t)                        1309    5.95%
compute_univariate(t)                         1421    6.45%

Breakdown of ProtogalaxyProver::fold_instances:
ProtoGalaxyProver_::preparation_round(t)           4186    35.60%
ProtoGalaxyProver_::perturbator_round(t)           1309    11.14%
ProtoGalaxyProver_::combiner_quotient_round(t)     5969    50.77%
ProtoGalaxyProver_::accumulator_update_round(t)     293     2.49%
```

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
