### PR TITLE
feat(avm): Track gas usage based on memory accesses

### DIFF
--- a/yarn-project/simulator/src/avm/avm_gas.test.ts
+++ b/yarn-project/simulator/src/avm/avm_gas.test.ts
@@ -6,16 +6,16 @@ import { encodeToBytecode } from './serialization/bytecode_serialization.js';
 
 describe('AVM simulator: dynamic gas costs per instruction', () => {
   it.each([
-    [new SetInstruction(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT8, /*value=*/ 1, /*dstOffset=*/ 0), [100, 0, 0]],
-    [new SetInstruction(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1, /*dstOffset=*/ 0), [400, 0, 0]],
-    [new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ TypeTag.UINT8, /*copySize=*/ 1, /*dstOffset=*/ 0), [10, 0, 0]],
-    [new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ TypeTag.UINT8, /*copySize=*/ 5, /*dstOffset=*/ 0), [50, 0, 0]],
-    [new Add(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [10, 0, 0]],
-    [new Add(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT32, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [40, 0, 0]],
-    [new Add(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [20, 0, 0]],
-    [new Sub(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [20, 0, 0]],
-    [new Mul(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [20, 0, 0]],
-    [new Div(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [20, 0, 0]],
+    [new SetInstruction(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT8, /*value=*/ 1, /*dstOffset=*/ 0), [110, 0, 0]],
+    [new SetInstruction(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1, /*dstOffset=*/ 0), [110]],
+    [new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ TypeTag.UINT8, /*copySize=*/ 1, /*dstOffset=*/ 0), [110]],
+    [new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ TypeTag.UINT8, /*copySize=*/ 5, /*dstOffset=*/ 0), [550]],
+    [new Add(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [130]],
+    [new Add(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT32, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [160]],
+    [new Add(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
+    [new Sub(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
+    [new Mul(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
+    [new Div(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
   ] as const)('computes gas cost for %s', async (instruction, [l2GasCost, l1GasCost, daGasCost]) => {
     const bytecode = encodeToBytecode([instruction]);
     const context = initContext();
@@ -27,8 +27,8 @@ describe('AVM simulator: dynamic gas costs per instruction', () => {
 
     await new AvmSimulator(context).executeBytecode(bytecode);
 
-    expect(initialL2GasLeft - context.machineState.l2GasLeft).toEqual(l2GasCost);
-    expect(initialL1GasLeft - context.machineState.l1GasLeft).toEqual(l1GasCost);
-    expect(initialDaGasLeft - context.machineState.daGasLeft).toEqual(daGasCost);
+    expect(initialL2GasLeft - context.machineState.l2GasLeft).toEqual(l2GasCost ?? 0);
+    expect(initialL1GasLeft - context.machineState.l1GasLeft).toEqual(l1GasCost ?? 0);
+    expect(initialDaGasLeft - context.machineState.daGasLeft).toEqual(daGasCost ?? 0);
   });
 });

--- a/yarn-project/simulator/src/avm/avm_machine_state.ts
+++ b/yarn-project/simulator/src/avm/avm_machine_state.ts
@@ -1,7 +1,7 @@
 import { Fr } from '@aztec/circuits.js';
 
 import { Gas, GasDimensions } from './avm_gas.js';
-import { TaggedMemory } from './avm_memory_types.js';
+import { MeteredTaggedMemory } from './avm_memory_types.js';
 import { AvmContractCallResults } from './avm_message_call_result.js';
 import { OutOfGasError } from './errors.js';
 
@@ -32,7 +32,7 @@ export class AvmMachineState {
   public internalCallStack: number[] = [];
 
   /** Memory accessible to user code */
-  public readonly memory: TaggedMemory = new TaggedMemory();
+  public readonly memory: MeteredTaggedMemory = new MeteredTaggedMemory();
 
   /**
    * Signals that execution should end.

--- a/yarn-project/simulator/src/avm/avm_memory_types.test.ts
+++ b/yarn-project/simulator/src/avm/avm_memory_types.test.ts
@@ -1,4 +1,13 @@
-import { Field, TaggedMemory, Uint8, Uint16, Uint32, Uint64, Uint128 } from './avm_memory_types.js';
+import {
+  Field,
+  MeteredTaggedMemory,
+  TaggedMemory,
+  Uint8,
+  Uint16,
+  Uint32,
+  Uint64,
+  Uint128,
+} from './avm_memory_types.js';
 
 describe('TaggedMemory', () => {
   it('Elements should be undefined after construction', () => {
@@ -34,6 +43,48 @@ describe('TaggedMemory', () => {
     mem.setSlice(10, val);
 
     expect(mem.getSlice(10, /*size=*/ 2)).toStrictEqual(val);
+  });
+});
+
+describe('MeteredTaggedMemory', () => {
+  let mem: MeteredTaggedMemory;
+
+  beforeEach(() => {
+    mem = new MeteredTaggedMemory();
+  });
+
+  it(`Counts reads`, () => {
+    mem.get(10);
+    mem.getAs(20);
+    expect(mem.getStats()).toEqual({ reads: 2, writes: 0 });
+  });
+
+  it(`Counts reading slices`, () => {
+    const val = [new Field(5), new Field(6), new Field(7)];
+    mem.setSlice(10, val);
+    mem.clearStats();
+
+    mem.getSlice(10, 3);
+    mem.getSliceAs(11, 2);
+    expect(mem.getStats()).toEqual({ reads: 5, writes: 0 });
+  });
+
+  it(`Counts writes`, () => {
+    mem.set(10, new Uint8(5));
+    expect(mem.getStats()).toEqual({ reads: 0, writes: 1 });
+  });
+
+  it(`Counts writing slices`, () => {
+    mem.setSlice(10, [new Field(5), new Field(6)]);
+    expect(mem.getStats()).toEqual({ reads: 0, writes: 2 });
+  });
+
+  it(`Clears stats`, () => {
+    mem.get(10);
+    mem.set(20, new Uint8(5));
+    expect(mem.getStats()).toEqual({ reads: 1, writes: 1 });
+    mem.clearStats();
+    expect(mem.getStats()).toEqual({ reads: 0, writes: 0 });
   });
 });
 

--- a/yarn-project/simulator/src/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.test.ts
@@ -44,7 +44,7 @@ describe('AVM simulator: injected bytecode', () => {
 
     expect(results.reverted).toBe(false);
     expect(results.output).toEqual([new Fr(3)]);
-    expect(context.machineState.l2GasLeft).toEqual(initialL2GasLeft - 350);
+    expect(context.machineState.l2GasLeft).toEqual(initialL2GasLeft - 680);
   });
 
   it('Should halt if runs out of gas', async () => {

--- a/yarn-project/simulator/src/avm/opcodes/accrued_substate.ts
+++ b/yarn-project/simulator/src/avm/opcodes/accrued_substate.ts
@@ -42,6 +42,10 @@ export class NoteHashExists extends FixedGasInstruction {
 
     context.machineState.incrementPc();
   }
+
+  protected memoryOperations() {
+    return { reads: 2, writes: 1 };
+  }
 }
 
 export class EmitNoteHash extends FixedGasInstruction {
@@ -64,6 +68,10 @@ export class EmitNoteHash extends FixedGasInstruction {
 
     context.machineState.incrementPc();
   }
+
+  protected memoryOperations() {
+    return { reads: 1 };
+  }
 }
 
 export class NullifierExists extends FixedGasInstruction {
@@ -83,6 +91,10 @@ export class NullifierExists extends FixedGasInstruction {
     context.machineState.memory.set(this.existsOffset, exists ? new Uint8(1) : new Uint8(0));
 
     context.machineState.incrementPc();
+  }
+
+  protected memoryOperations() {
+    return { reads: 1, writes: 1 };
   }
 }
 
@@ -117,6 +129,10 @@ export class EmitNullifier extends FixedGasInstruction {
 
     context.machineState.incrementPc();
   }
+
+  protected memoryOperations() {
+    return { reads: 1 };
+  }
 }
 
 export class L1ToL2MessageExists extends FixedGasInstruction {
@@ -147,6 +163,10 @@ export class L1ToL2MessageExists extends FixedGasInstruction {
     context.machineState.memory.set(this.existsOffset, exists ? new Uint8(1) : new Uint8(0));
 
     context.machineState.incrementPc();
+  }
+
+  protected memoryOperations() {
+    return { reads: 2, writes: 1 };
   }
 }
 
@@ -188,6 +208,10 @@ export class EmitUnencryptedLog extends FixedGasInstruction {
 
     context.machineState.incrementPc();
   }
+
+  protected memoryOperations() {
+    return { reads: 1 + this.logSize };
+  }
 }
 
 export class SendL2ToL1Message extends FixedGasInstruction {
@@ -210,5 +234,9 @@ export class SendL2ToL1Message extends FixedGasInstruction {
     context.persistableState.writeL1Message(recipient, content);
 
     context.machineState.incrementPc();
+  }
+
+  protected memoryOperations() {
+    return { reads: 2 };
   }
 }

--- a/yarn-project/simulator/src/avm/opcodes/addressing_mode.ts
+++ b/yarn-project/simulator/src/avm/opcodes/addressing_mode.ts
@@ -12,7 +12,7 @@ export enum AddressingMode {
 export class Addressing {
   public constructor(
     /** The addressing mode for each operand. The length of this array is the number of operands of the instruction. */
-    public readonly modePerOperand: AddressingMode[],
+    private readonly modePerOperand: AddressingMode[],
   ) {
     assert(modePerOperand.length <= 8, 'At most 8 operands are supported');
   }
@@ -37,6 +37,11 @@ export class Addressing {
       }
     }
     return wire;
+  }
+
+  /** Returns how many operands use the given addressing mode. */
+  public count(mode: AddressingMode): number {
+    return this.modePerOperand.filter(m => m === mode).length;
   }
 
   /**

--- a/yarn-project/simulator/src/avm/opcodes/bitwise.ts
+++ b/yarn-project/simulator/src/avm/opcodes/bitwise.ts
@@ -3,66 +3,68 @@ import { IntegralValue } from '../avm_memory_types.js';
 import { Opcode } from '../serialization/instruction_serialization.js';
 import { ThreeOperandFixedGasInstruction, TwoOperandFixedGasInstruction } from './instruction_impl.js';
 
-export class And extends ThreeOperandFixedGasInstruction {
+abstract class ThreeOperandBitwiseInstruction extends ThreeOperandFixedGasInstruction {
+  protected async internalExecute(context: AvmContext): Promise<void> {
+    context.machineState.memory.checkTags(this.inTag, this.aOffset, this.bOffset);
+
+    const a = context.machineState.memory.getAs<IntegralValue>(this.aOffset);
+    const b = context.machineState.memory.getAs<IntegralValue>(this.bOffset);
+
+    const res = this.compute(a, b);
+    context.machineState.memory.set(this.dstOffset, res);
+
+    context.machineState.incrementPc();
+  }
+
+  protected abstract compute(a: IntegralValue, b: IntegralValue): IntegralValue;
+
+  protected memoryOperations() {
+    return { reads: 2, writes: 1 };
+  }
+}
+
+export class And extends ThreeOperandBitwiseInstruction {
   static readonly type: string = 'AND';
   static readonly opcode = Opcode.AND;
 
-  constructor(indirect: number, inTag: number, aOffset: number, bOffset: number, dstOffset: number) {
-    super(indirect, inTag, aOffset, bOffset, dstOffset);
-  }
-
-  protected async internalExecute(context: AvmContext): Promise<void> {
-    context.machineState.memory.checkTags(this.inTag, this.aOffset, this.bOffset);
-
-    const a = context.machineState.memory.getAs<IntegralValue>(this.aOffset);
-    const b = context.machineState.memory.getAs<IntegralValue>(this.bOffset);
-
-    const res = a.and(b);
-    context.machineState.memory.set(this.dstOffset, res);
-
-    context.machineState.incrementPc();
+  protected compute(a: IntegralValue, b: IntegralValue): IntegralValue {
+    return a.and(b);
   }
 }
 
-export class Or extends ThreeOperandFixedGasInstruction {
+export class Or extends ThreeOperandBitwiseInstruction {
   static readonly type: string = 'OR';
   static readonly opcode = Opcode.OR;
 
-  constructor(indirect: number, inTag: number, aOffset: number, bOffset: number, dstOffset: number) {
-    super(indirect, inTag, aOffset, bOffset, dstOffset);
-  }
-
-  protected async internalExecute(context: AvmContext): Promise<void> {
-    context.machineState.memory.checkTags(this.inTag, this.aOffset, this.bOffset);
-
-    const a = context.machineState.memory.getAs<IntegralValue>(this.aOffset);
-    const b = context.machineState.memory.getAs<IntegralValue>(this.bOffset);
-
-    const res = a.or(b);
-    context.machineState.memory.set(this.dstOffset, res);
-
-    context.machineState.incrementPc();
+  protected compute(a: IntegralValue, b: IntegralValue): IntegralValue {
+    return a.or(b);
   }
 }
 
-export class Xor extends ThreeOperandFixedGasInstruction {
+export class Xor extends ThreeOperandBitwiseInstruction {
   static readonly type: string = 'XOR';
   static readonly opcode = Opcode.XOR;
 
-  constructor(indirect: number, inTag: number, aOffset: number, bOffset: number, dstOffset: number) {
-    super(indirect, inTag, aOffset, bOffset, dstOffset);
+  protected compute(a: IntegralValue, b: IntegralValue): IntegralValue {
+    return a.xor(b);
   }
+}
 
-  protected async internalExecute(context: AvmContext): Promise<void> {
-    context.machineState.memory.checkTags(this.inTag, this.aOffset, this.bOffset);
+export class Shl extends ThreeOperandBitwiseInstruction {
+  static readonly type: string = 'SHL';
+  static readonly opcode = Opcode.SHL;
 
-    const a = context.machineState.memory.getAs<IntegralValue>(this.aOffset);
-    const b = context.machineState.memory.getAs<IntegralValue>(this.bOffset);
+  protected compute(a: IntegralValue, b: IntegralValue): IntegralValue {
+    return a.shl(b);
+  }
+}
 
-    const res = a.xor(b);
-    context.machineState.memory.set(this.dstOffset, res);
+export class Shr extends ThreeOperandBitwiseInstruction {
+  static readonly type: string = 'SHR';
+  static readonly opcode = Opcode.SHR;
 
-    context.machineState.incrementPc();
+  protected compute(a: IntegralValue, b: IntegralValue): IntegralValue {
+    return a.shr(b);
   }
 }
 
@@ -84,46 +86,8 @@ export class Not extends TwoOperandFixedGasInstruction {
 
     context.machineState.incrementPc();
   }
-}
 
-export class Shl extends ThreeOperandFixedGasInstruction {
-  static readonly type: string = 'SHL';
-  static readonly opcode = Opcode.SHL;
-
-  constructor(indirect: number, inTag: number, aOffset: number, bOffset: number, dstOffset: number) {
-    super(indirect, inTag, aOffset, bOffset, dstOffset);
-  }
-
-  protected async internalExecute(context: AvmContext): Promise<void> {
-    context.machineState.memory.checkTags(this.inTag, this.aOffset, this.bOffset);
-
-    const a = context.machineState.memory.getAs<IntegralValue>(this.aOffset);
-    const b = context.machineState.memory.getAs<IntegralValue>(this.bOffset);
-
-    const res = a.shl(b);
-    context.machineState.memory.set(this.dstOffset, res);
-
-    context.machineState.incrementPc();
-  }
-}
-
-export class Shr extends ThreeOperandFixedGasInstruction {
-  static readonly type: string = 'SHR';
-  static readonly opcode = Opcode.SHR;
-
-  constructor(indirect: number, inTag: number, aOffset: number, bOffset: number, dstOffset: number) {
-    super(indirect, inTag, aOffset, bOffset, dstOffset);
-  }
-
-  protected async internalExecute(context: AvmContext): Promise<void> {
-    context.machineState.memory.checkTags(this.inTag, this.aOffset, this.bOffset);
-
-    const a = context.machineState.memory.getAs<IntegralValue>(this.aOffset);
-    const b = context.machineState.memory.getAs<IntegralValue>(this.bOffset);
-
-    const res = a.shr(b);
-    context.machineState.memory.set(this.dstOffset, res);
-
-    context.machineState.incrementPc();
+  protected memoryOperations() {
+    return { reads: 1, writes: 1 };
   }
 }

--- a/yarn-project/simulator/src/avm/opcodes/comparators.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/comparators.test.ts
@@ -36,11 +36,15 @@ describe('Comparators', () => {
     it('Works on integral types', async () => {
       context.machineState.memory.setSlice(0, [new Uint32(1), new Uint32(2), new Uint32(3), new Uint32(1)]);
 
-      [
+      const ops = [
         new Eq(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
         new Eq(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 11),
         new Eq(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 3, /*dstOffset=*/ 12),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(0), new Uint8(0), new Uint8(1)]);
@@ -49,11 +53,15 @@ describe('Comparators', () => {
     it('Works on field elements', async () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Field(2), new Field(3), new Field(1)]);
 
-      [
+      const ops = [
         new Eq(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
         new Eq(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 11),
         new Eq(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 3, /*dstOffset=*/ 12),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(0), new Uint8(0), new Uint8(1)]);
@@ -70,7 +78,7 @@ describe('Comparators', () => {
       ];
 
       for (const o of ops) {
-        await expect(() => o.execute(context)).rejects.toThrow(TagCheckError);
+        await expect(async () => await o.execute(context)).rejects.toThrow(TagCheckError);
       }
     });
   });
@@ -100,11 +108,15 @@ describe('Comparators', () => {
     it('Works on integral types', async () => {
       context.machineState.memory.setSlice(0, [new Uint32(1), new Uint32(2), new Uint32(0)]);
 
-      [
+      const ops = [
         new Lt(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
         new Lt(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
         new Lt(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(0), new Uint8(1), new Uint8(0)]);
@@ -113,11 +125,15 @@ describe('Comparators', () => {
     it('Works on field elements', async () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Field(2), new Field(0)]);
 
-      [
+      const ops = [
         new Lt(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
         new Lt(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
         new Lt(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(0), new Uint8(1), new Uint8(0)]);
@@ -134,7 +150,7 @@ describe('Comparators', () => {
       ];
 
       for (const o of ops) {
-        await expect(() => o.execute(context)).rejects.toThrow(TagCheckError);
+        await expect(async () => await o.execute(context)).rejects.toThrow(TagCheckError);
       }
     });
   });
@@ -164,11 +180,15 @@ describe('Comparators', () => {
     it('Works on integral types', async () => {
       context.machineState.memory.setSlice(0, [new Uint32(1), new Uint32(2), new Uint32(0)]);
 
-      [
+      const ops = [
         new Lte(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
         new Lte(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
         new Lte(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(1), new Uint8(1), new Uint8(0)]);
@@ -177,11 +197,15 @@ describe('Comparators', () => {
     it('Works on field elements', async () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Field(2), new Field(0)]);
 
-      [
+      const ops = [
         new Lte(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
         new Lte(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
         new Lte(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(1), new Uint8(1), new Uint8(0)]);
@@ -198,7 +222,7 @@ describe('Comparators', () => {
       ];
 
       for (const o of ops) {
-        await expect(() => o.execute(context)).rejects.toThrow(TagCheckError);
+        await expect(async () => await o.execute(context)).rejects.toThrow(TagCheckError);
       }
     });
   });

--- a/yarn-project/simulator/src/avm/opcodes/comparators.ts
+++ b/yarn-project/simulator/src/avm/opcodes/comparators.ts
@@ -1,67 +1,51 @@
 import type { AvmContext } from '../avm_context.js';
-import { Uint8 } from '../avm_memory_types.js';
+import { MemoryValue, Uint8 } from '../avm_memory_types.js';
 import { Opcode } from '../serialization/instruction_serialization.js';
 import { ThreeOperandFixedGasInstruction } from './instruction_impl.js';
 
-export class Eq extends ThreeOperandFixedGasInstruction {
+abstract class ComparatorInstruction extends ThreeOperandFixedGasInstruction {
+  protected async internalExecute(context: AvmContext): Promise<void> {
+    context.machineState.memory.checkTags(this.inTag, this.aOffset, this.bOffset);
+
+    const a = context.machineState.memory.get(this.aOffset);
+    const b = context.machineState.memory.get(this.bOffset);
+
+    const dest = new Uint8(this.compare(a, b) ? 1 : 0);
+    context.machineState.memory.set(this.dstOffset, dest);
+
+    context.machineState.incrementPc();
+  }
+
+  protected memoryOperations() {
+    return { reads: 2, writes: 1 };
+  }
+
+  protected abstract compare(a: MemoryValue, b: MemoryValue): boolean;
+}
+
+export class Eq extends ComparatorInstruction {
   static readonly type: string = 'EQ';
   static readonly opcode = Opcode.EQ;
 
-  constructor(indirect: number, inTag: number, aOffset: number, bOffset: number, dstOffset: number) {
-    super(indirect, inTag, aOffset, bOffset, dstOffset);
-  }
-
-  protected async internalExecute(context: AvmContext): Promise<void> {
-    context.machineState.memory.checkTags(this.inTag, this.aOffset, this.bOffset);
-
-    const a = context.machineState.memory.get(this.aOffset);
-    const b = context.machineState.memory.get(this.bOffset);
-
-    const dest = new Uint8(a.equals(b) ? 1 : 0);
-    context.machineState.memory.set(this.dstOffset, dest);
-
-    context.machineState.incrementPc();
+  protected compare(a: MemoryValue, b: MemoryValue): boolean {
+    return a.equals(b);
   }
 }
 
-export class Lt extends ThreeOperandFixedGasInstruction {
+export class Lt extends ComparatorInstruction {
   static readonly type: string = 'LT';
   static readonly opcode = Opcode.LT;
 
-  constructor(indirect: number, inTag: number, aOffset: number, bOffset: number, dstOffset: number) {
-    super(indirect, inTag, aOffset, bOffset, dstOffset);
-  }
-
-  protected async internalExecute(context: AvmContext): Promise<void> {
-    context.machineState.memory.checkTags(this.inTag, this.aOffset, this.bOffset);
-
-    const a = context.machineState.memory.get(this.aOffset);
-    const b = context.machineState.memory.get(this.bOffset);
-
-    const dest = new Uint8(a.lt(b) ? 1 : 0);
-    context.machineState.memory.set(this.dstOffset, dest);
-
-    context.machineState.incrementPc();
+  protected compare(a: MemoryValue, b: MemoryValue): boolean {
+    return a.lt(b);
   }
 }
 
-export class Lte extends ThreeOperandFixedGasInstruction {
+export class Lte extends ComparatorInstruction {
   static readonly type: string = 'LTE';
   static readonly opcode = Opcode.LTE;
 
-  constructor(indirect: number, inTag: number, aOffset: number, bOffset: number, dstOffset: number) {
-    super(indirect, inTag, aOffset, bOffset, dstOffset);
-  }
-
-  protected async internalExecute(context: AvmContext): Promise<void> {
-    context.machineState.memory.checkTags(this.inTag, this.aOffset, this.bOffset);
-
-    const a = context.machineState.memory.get(this.aOffset);
-    const b = context.machineState.memory.get(this.bOffset);
-
-    const dest = new Uint8(a.lt(b) || a.equals(b) ? 1 : 0);
-    context.machineState.memory.set(this.dstOffset, dest);
-
-    context.machineState.incrementPc();
+  protected compare(a: MemoryValue, b: MemoryValue): boolean {
+    return a.lt(b) || a.equals(b);
   }
 }

--- a/yarn-project/simulator/src/avm/opcodes/control_flow.ts
+++ b/yarn-project/simulator/src/avm/opcodes/control_flow.ts
@@ -45,6 +45,10 @@ export class JumpI extends FixedGasInstruction {
       context.machineState.pc = this.loc;
     }
   }
+
+  protected memoryOperations() {
+    return { reads: 1 };
+  }
 }
 
 export class InternalCall extends FixedGasInstruction {

--- a/yarn-project/simulator/src/avm/opcodes/dynamic_gas_instruction.ts
+++ b/yarn-project/simulator/src/avm/opcodes/dynamic_gas_instruction.ts
@@ -1,0 +1,83 @@
+import type { AvmContext } from '../avm_context.js';
+import { Gas, getBaseGasCost, getMemoryGasCost, sumGas } from '../avm_gas.js';
+import { MemoryOperations } from '../avm_memory_types.js';
+import { Instruction } from './instruction.js';
+
+/**
+ * Base class for AVM instructions with a variable gas cost that depends on data read during execution.
+ * Orchestrates execution by running the following operations during `execute`:
+ * - Invokes `loadInputs` to load from memory the inpiuts needed for execution.
+ * - Requests the expected number of `memoryOperations` to compute the `memoryGasCost`.
+ * - Computes `gasCost` based on the loaded inputs, using the sum of `baseGasCost` and `memoryGasCost`.
+ * - Consumes gas based on the computed gas cost, throwing an exceptional halt if not enough.
+ * - Executes actual logic from `internalExecute`.
+ * - Asserts the expected memory operations against the actual memory operations.
+ */
+export abstract class DynamicGasInstruction<TInputs> extends Instruction {
+  /**
+   * Consumes gas and executes the instruction.
+   * This is the main entry point for the instruction.
+   * @param context - The AvmContext in which the instruction executes.
+   */
+  public async execute(context: AvmContext): Promise<void> {
+    context.machineState.memory.clearStats();
+    const inputs = this.loadInputs(context);
+    const gasCost = this.gasCost(inputs);
+    context.machineState.consumeGas(gasCost);
+
+    await this.internalExecute(context, inputs);
+
+    this.assertMemoryOperations(context, inputs);
+  }
+
+  /** Loads state for execution and gas metering from memory. */
+  protected abstract loadInputs(context: AvmContext): TInputs;
+
+  /** Computes gas cost based on loaded state. */
+  protected gasCost(inputs: TInputs): Gas {
+    return sumGas(this.baseGasCost(inputs), this.memoryGasCost(inputs));
+  }
+
+  /** Returns the base gas cost for this operation as read from the GasCosts table. */
+  protected baseGasCost(_inputs: TInputs): Gas {
+    return getBaseGasCost(this.opcode);
+  }
+
+  /** Returns the memory reads and writes gas cost for this operation as defined by expectedMemoryOperations. */
+  protected memoryGasCost(inputs: TInputs): Gas {
+    return getMemoryGasCost({ indirectFlags: this.getIndirectFlags(), ...this.memoryOperations(inputs) });
+  }
+
+  /**
+   * Returns the expected read and write operations for this instruction.
+   * Subclasses must override if they access memory.
+   * Used for computing gas cost and validating correctness against the MeteredTaggedMemory.
+   */
+  protected memoryOperations(_inputs: TInputs): Partial<MemoryOperations> {
+    return { reads: 0, writes: 0 };
+  }
+
+  /**
+   * Execute the instruction.
+   * Instruction sub-classes must implement this.
+   * As an AvmContext executes its contract code, it calls this function for
+   * each instruction until the machine state signals "halted".
+   * @param inputs - The state loaded from memory and operands.
+   * @param context - The AvmContext in which the instruction executes.
+   */
+  protected abstract internalExecute(context: AvmContext, inputs: TInputs): Promise<void>;
+
+  /**
+   * Returns the indirect addressing flags for this instruction if exist, zero otherwise.
+   * Used for computing memory costs.
+   */
+  private getIndirectFlags() {
+    return 'indirect' in this ? (this.indirect as number) : 0;
+  }
+
+  /** Verifies the memory operations executed match the ones expected from `memoryOperations`. */
+  protected assertMemoryOperations(context: AvmContext, inputs: TInputs) {
+    const expected = { reads: 0, writes: 0, indirectFlags: this.getIndirectFlags(), ...this.memoryOperations(inputs) };
+    context.machineState.memory.assertStats(expected, this.type);
+  }
+}

--- a/yarn-project/simulator/src/avm/opcodes/environment_getters.ts
+++ b/yarn-project/simulator/src/avm/opcodes/environment_getters.ts
@@ -20,6 +20,10 @@ abstract class GetterInstruction extends FixedGasInstruction {
     context.machineState.incrementPc();
   }
 
+  protected memoryOperations() {
+    return { writes: 1 };
+  }
+
   protected abstract getIt(env: AvmExecutionEnvironment): Fr | number | bigint;
 }
 

--- a/yarn-project/simulator/src/avm/opcodes/external_calls.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/external_calls.test.ts
@@ -71,7 +71,7 @@ describe('External Calls', () => {
       const retSize = 2;
       const successOffset = 7;
 
-      const otherContextInstructionsL2GasCost = 60; // Includes the cost of the call itself
+      const otherContextInstructionsL2GasCost = 780; // Includes the cost of the call itself
       const otherContextInstructionsBytecode = encodeToBytecode([
         new CalldataCopy(
           /*indirect=*/ 0,

--- a/yarn-project/simulator/src/avm/opcodes/fixed_gas_instruction.ts
+++ b/yarn-project/simulator/src/avm/opcodes/fixed_gas_instruction.ts
@@ -1,40 +1,10 @@
 import type { AvmContext } from '../avm_context.js';
-import { DynamicGasCost, Gas, GasCosts } from '../avm_gas.js';
-import { Instruction } from './instruction.js';
+import { DynamicGasInstruction } from './dynamic_gas_instruction.js';
 
 /**
- * Base class for AVM instructions with a fixed gas cost or computed directly from its operands without requiring memory access.
+ * Base class for AVM instructions with a fixed gas cost or computed directly from its operands.
  * Implements execution by consuming gas and calling the abstract internal execute function.
  */
-export abstract class FixedGasInstruction extends Instruction {
-  /**
-   * Consumes gas and executes the instruction.
-   * This is the main entry point for the instruction.
-   * @param context - The AvmContext in which the instruction executes.
-   */
-  public execute(context: AvmContext): Promise<void> {
-    context.machineState.consumeGas(this.gasCost());
-    return this.internalExecute(context);
-  }
-
-  /**
-   * Loads default gas cost for the instruction from the GasCosts table.
-   * Instruction sub-classes can override this if their gas cost is not fixed.
-   */
-  protected gasCost(): Gas {
-    const gasCost = GasCosts[this.opcode];
-    if (gasCost === DynamicGasCost) {
-      throw new Error(`Instruction ${this.type} must define its own gas cost`);
-    }
-    return gasCost;
-  }
-
-  /**
-   * Execute the instruction.
-   * Instruction sub-classes must implement this.
-   * As an AvmContext executes its contract code, it calls this function for
-   * each instruction until the machine state signals "halted".
-   * @param context - The AvmContext in which the instruction executes.
-   */
-  protected abstract internalExecute(context: AvmContext): Promise<void>;
+export abstract class FixedGasInstruction extends DynamicGasInstruction<void> {
+  protected loadInputs(_context: AvmContext): void {}
 }

--- a/yarn-project/simulator/src/avm/opcodes/memory.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/memory.test.ts
@@ -161,20 +161,24 @@ describe('Memory instructions', () => {
       expect(inst.serialize()).toEqual(buf);
     });
 
-    it('Should upcast between integral types', () => {
+    it('Should upcast between integral types', async () => {
       context.machineState.memory.set(0, new Uint8(20n));
       context.machineState.memory.set(1, new Uint16(65000n));
       context.machineState.memory.set(2, new Uint32(1n << 30n));
       context.machineState.memory.set(3, new Uint64(1n << 50n));
       context.machineState.memory.set(4, new Uint128(1n << 100n));
 
-      [
+      const ops = [
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.UINT16, /*aOffset=*/ 0, /*dstOffset=*/ 10),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.UINT32, /*aOffset=*/ 1, /*dstOffset=*/ 11),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.UINT64, /*aOffset=*/ 2, /*dstOffset=*/ 12),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.UINT128, /*aOffset=*/ 3, /*dstOffset=*/ 13),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.UINT128, /*aOffset=*/ 4, /*dstOffset=*/ 14),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 5);
       expect(actual).toEqual([
@@ -188,20 +192,24 @@ describe('Memory instructions', () => {
       expect(tags).toEqual([TypeTag.UINT16, TypeTag.UINT32, TypeTag.UINT64, TypeTag.UINT128, TypeTag.UINT128]);
     });
 
-    it('Should downcast (truncating) between integral types', () => {
+    it('Should downcast (truncating) between integral types', async () => {
       context.machineState.memory.set(0, new Uint8(20n));
       context.machineState.memory.set(1, new Uint16(65000n));
       context.machineState.memory.set(2, new Uint32((1n << 30n) - 1n));
       context.machineState.memory.set(3, new Uint64((1n << 50n) - 1n));
       context.machineState.memory.set(4, new Uint128((1n << 100n) - 1n));
 
-      [
+      const ops = [
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.UINT8, /*aOffset=*/ 0, /*dstOffset=*/ 10),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*dstOffset=*/ 11),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.UINT16, /*aOffset=*/ 2, /*dstOffset=*/ 12),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.UINT32, /*aOffset=*/ 3, /*dstOffset=*/ 13),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.UINT64, /*aOffset=*/ 4, /*dstOffset=*/ 14),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 5);
       expect(actual).toEqual([
@@ -215,19 +223,24 @@ describe('Memory instructions', () => {
       expect(tags).toEqual([TypeTag.UINT8, TypeTag.UINT8, TypeTag.UINT16, TypeTag.UINT32, TypeTag.UINT64]);
     });
 
-    it('Should upcast from integral types to field', () => {
+    it('Should upcast from integral types to field', async () => {
       context.machineState.memory.set(0, new Uint8(20n));
       context.machineState.memory.set(1, new Uint16(65000n));
       context.machineState.memory.set(2, new Uint32(1n << 30n));
       context.machineState.memory.set(3, new Uint64(1n << 50n));
       context.machineState.memory.set(4, new Uint128(1n << 100n));
-      [
+
+      const ops = [
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.FIELD, /*aOffset=*/ 0, /*dstOffset=*/ 10),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.FIELD, /*aOffset=*/ 1, /*dstOffset=*/ 11),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.FIELD, /*aOffset=*/ 2, /*dstOffset=*/ 12),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.FIELD, /*aOffset=*/ 3, /*dstOffset=*/ 13),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.FIELD, /*aOffset=*/ 4, /*dstOffset=*/ 14),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 5);
       expect(actual).toEqual([
@@ -241,20 +254,24 @@ describe('Memory instructions', () => {
       expect(tags).toEqual([TypeTag.FIELD, TypeTag.FIELD, TypeTag.FIELD, TypeTag.FIELD, TypeTag.FIELD]);
     });
 
-    it('Should downcast (truncating) from field to integral types', () => {
+    it('Should downcast (truncating) from field to integral types', async () => {
       context.machineState.memory.set(0, new Field((1n << 200n) - 1n));
       context.machineState.memory.set(1, new Field((1n << 200n) - 1n));
       context.machineState.memory.set(2, new Field((1n << 200n) - 1n));
       context.machineState.memory.set(3, new Field((1n << 200n) - 1n));
       context.machineState.memory.set(4, new Field((1n << 200n) - 1n));
 
-      [
+      const ops = [
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.UINT8, /*aOffset=*/ 0, /*dstOffset=*/ 10),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.UINT16, /*aOffset=*/ 1, /*dstOffset=*/ 11),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.UINT32, /*aOffset=*/ 2, /*dstOffset=*/ 12),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.UINT64, /*aOffset=*/ 3, /*dstOffset=*/ 13),
         new Cast(/*indirect=*/ 0, /*dstTag=*/ TypeTag.UINT128, /*aOffset=*/ 4, /*dstOffset=*/ 14),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 5);
       expect(actual).toEqual([

--- a/yarn-project/simulator/src/avm/opcodes/storage.ts
+++ b/yarn-project/simulator/src/avm/opcodes/storage.ts
@@ -1,6 +1,7 @@
 import { Fr } from '@aztec/foundation/fields';
 
 import type { AvmContext } from '../avm_context.js';
+import { Gas, getBaseGasCost, makeGas } from '../avm_gas.js';
 import { Field } from '../avm_memory_types.js';
 import { InstructionExecutionError } from '../errors.js';
 import { Opcode, OperandType } from '../serialization/instruction_serialization.js';
@@ -55,6 +56,15 @@ export class SStore extends BaseStorageInstruction {
 
     context.machineState.incrementPc();
   }
+
+  protected baseGasCost(): Gas {
+    const base = getBaseGasCost(this.opcode);
+    return makeGas({ ...base, l2Gas: base.l2Gas * this.size });
+  }
+
+  protected memoryOperations() {
+    return { reads: this.size + 1 };
+  }
 }
 
 export class SLoad extends BaseStorageInstruction {
@@ -84,6 +94,15 @@ export class SLoad extends BaseStorageInstruction {
     }
 
     context.machineState.incrementPc();
+  }
+
+  protected baseGasCost(): Gas {
+    const base = getBaseGasCost(this.opcode);
+    return makeGas({ ...base, l2Gas: base.l2Gas * this.size });
+  }
+
+  protected memoryOperations() {
+    return { reads: 1, writes: this.size };
   }
 }
 


### PR DESCRIPTION
Defines gas cost for each instruction based on its memory accesses: reads, indirect reads (priced as 2 reads), writes. Each instruction defines its expected number of memory operations, and gas cost is computed based on that and a base gas cost defined in the gas cost table. There is an additional check after the instruction is run that verifies that the number of memory operations matches the ones declared by the instruction. Note that, since we need to charge gas _before_ execution (as specified in the yellow paper), we cannot just track accesses during execution and then charge that.

The new workflow for an instruction, which no instruction needs to fully override, is:

- Invokes `loadInputs` to load from memory the inpiuts needed for execution (not needed if ops can compute their gas cost from their wires only)
- Requests the expected number of `memoryOperations` to compute the `memoryGasCost` (defaults to zero)
- Computes `gasCost` based on the loaded inputs, using the sum of `baseGasCost` and `memoryGasCost` (no need to override unless there's an additional gas component)
- Consumes gas based on the computed gas cost, throwing an exceptional halt if not enough
- Executes actual logic from `internalExecute` (all instructions override)
- Asserts the expected memory operations against the actual memory operations (can be turned off for performance if we wanted to)

This needs a bunch more tests, but I can add them in a subsequent PR.