### PR TITLE
fix: Univariate evals not set in ECCVM prover

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
@@ -174,6 +174,9 @@ template <IsECCVMFlavor Flavor> void ECCVMProver_<Flavor>::execute_transcript_co
     RefArray univariate_polynomials{ key->transcript_op, key->transcript_Px, key->transcript_Py,
                                      key->transcript_z1, key->transcript_z2, hack };
     std::array<FF, univariate_polynomials.size()> univariate_evaluations;
+    for (auto [eval, polynomial] : zip_view(univariate_evaluations, univariate_polynomials)) {
+        eval = polynomial.evaluate(evaluation_challenge_x);
+    }
 
     // Construct the batched polynomial and batched evaluation
     Polynomial batched_univariate{ key->circuit_size };


### PR DESCRIPTION
We had intermittent failures due to these lines being dropped here https://github.com/AztecProtocol/aztec-packages/pull/3332/files#diff-1099ba7caf338825359bedc113356ebec68afbcdd38e9b89e3d32c1b88c12ef1L330. We also need to figure out why all tests pass without these.