### PR TITLE
feat: account contracts pay fee through FPC

### DIFF
--- a/noir-projects/noir-contracts/contracts/ecdsa_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_account_contract/src/main.nr
@@ -42,7 +42,13 @@ contract EcdsaAccount {
     }
 
     #[aztec(private)]
+    #[aztec(noinitcheck)]
     fn spend_private_authwit(inner_hash: Field) -> Field {
+        // TODO Remove noinitcheck and this get_note call once we can read nullifiers emitted in the same tx
+        // This function disables the init check because it could get called in the same tx
+        // the contract is initialized in (e.g. for fee payments)
+        // Manually check that the note exists. If the note does not exit, this reverts
+        let _ = storage.public_key.get_note();
         let actions = AccountActions::private(&mut context, ACCOUNT_ACTIONS_STORAGE_SLOT, is_valid_impl);
         actions.spend_private_authwit(inner_hash)
     }

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -54,7 +54,14 @@ contract SchnorrAccount {
     }
 
     #[aztec(private)]
+    #[aztec(noinitcheck)]
     fn spend_private_authwit(inner_hash: Field) -> Field {
+        // TODO Remove noinitcheck and this get_note call once we can read nullifiers emitted in the same tx
+        // This function disables the init check because it could get called in the same tx
+        // the contract is initialized in (e.g. for fee payments)
+        // Manually check that the note exists. If the note does not exit, this reverts
+        let _ = storage.signing_public_key.get_note();
+
         let actions = AccountActions::private(
             &mut context,
             storage.approved_actions.storage_slot,

--- a/noir-projects/noir-contracts/contracts/schnorr_hardcoded_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_hardcoded_account_contract/src/main.nr
@@ -29,6 +29,7 @@ contract SchnorrHardcodedAccount {
     }
 
     #[aztec(private)]
+    #[aztec(noinitcheck)]
     fn spend_private_authwit(inner_hash: Field) -> Field {
         let actions = AccountActions::private(&mut context, ACCOUNT_ACTIONS_STORAGE_SLOT, is_valid_impl);
         actions.spend_private_authwit(inner_hash)

--- a/noir-projects/noir-contracts/contracts/schnorr_single_key_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_single_key_account_contract/src/main.nr
@@ -25,6 +25,7 @@ contract SchnorrSingleKeyAccount {
     }
 
     #[aztec(private)]
+    #[aztec(noinitcheck)]
     fn spend_private_authwit(inner_hash: Field) -> Field {
         let actions = AccountActions::private(&mut context, ACCOUNT_ACTIONS_STORAGE_SLOT, is_valid_impl);
         actions.spend_private_authwit(inner_hash)


### PR DESCRIPTION
This PR builds on top of the previous one to enable account contracts to pay for their deployment through an FPC privately

Fix #5191 