### PR TITLE
feat: Optimise relations

### DIFF
--- a/barretenberg/cpp/src/barretenberg/relations/auxiliary_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/auxiliary_relation.hpp
@@ -249,11 +249,14 @@ template <typename FF_> class AuxiliaryRelationImpl {
 
         auto adjacent_values_match_if_adjacent_indices_match = (-index_delta + FF(1)) * record_delta; // deg 2
 
+        auto q_aux_by_scaling = q_aux * scaling_factor;
+        auto q_one_by_two = q_1 * q_2;
+        auto q_one_by_two_by_aux_by_scaling = q_one_by_two * q_aux_by_scaling;
+
         std::get<1>(accumulators) +=
-            adjacent_values_match_if_adjacent_indices_match * (q_1 * q_2) * (q_aux * scaling_factor); // deg 5
-        std::get<2>(accumulators) +=
-            index_is_monotonically_increasing * (q_1 * q_2) * (q_aux * scaling_factor); // deg 5
-        auto ROM_consistency_check_identity = memory_record_check * (q_1 * q_2);        // deg 3 or 4
+            adjacent_values_match_if_adjacent_indices_match * q_one_by_two_by_aux_by_scaling;            // deg 5
+        std::get<2>(accumulators) += index_is_monotonically_increasing * q_one_by_two_by_aux_by_scaling; // deg 5
+        auto ROM_consistency_check_identity = memory_record_check * q_one_by_two;                        // deg 3 or 4
 
         /**
          * RAM Consistency Check
@@ -295,14 +298,14 @@ template <typename FF_> class AuxiliaryRelationImpl {
         // deg 2 or 4
         auto next_gate_access_type_is_boolean = next_gate_access_type * next_gate_access_type - next_gate_access_type;
 
+        auto q_arith_by_aux_and_scaling = q_arith * q_aux_by_scaling;
         // Putting it all together...
         std::get<3>(accumulators) +=
-            adjacent_values_match_if_adjacent_indices_match_and_next_access_is_a_read_operation * (q_arith) *
-            (q_aux * scaling_factor); // deg 5 or 6
-        std::get<4>(accumulators) += index_is_monotonically_increasing * (q_arith) * (q_aux * scaling_factor); // deg 4
-        std::get<5>(accumulators) +=
-            next_gate_access_type_is_boolean * (q_arith) * (q_aux * scaling_factor); // deg 4 or 6
-        auto RAM_consistency_check_identity = access_check * (q_arith);              // deg 3 or 5
+            adjacent_values_match_if_adjacent_indices_match_and_next_access_is_a_read_operation *
+            q_arith_by_aux_and_scaling;                                                              // deg 5 or 6
+        std::get<4>(accumulators) += index_is_monotonically_increasing * q_arith_by_aux_and_scaling; // deg 4
+        std::get<5>(accumulators) += next_gate_access_type_is_boolean * q_arith_by_aux_and_scaling;  // deg 4 or 6
+        auto RAM_consistency_check_identity = access_check * (q_arith);                              // deg 3 or 5
 
         /**
          * RAM Timestamp Consistency Check
@@ -329,7 +332,7 @@ template <typename FF_> class AuxiliaryRelationImpl {
 
         // (deg 3 or 5) + (deg 4) + (deg 3)
         auto auxiliary_identity = memory_identity + non_native_field_identity + limb_accumulator_identity;
-        auxiliary_identity *= (q_aux * scaling_factor); // deg 5 or 6
+        auxiliary_identity *= q_aux_by_scaling; // deg 5 or 6
         std::get<0>(accumulators) += auxiliary_identity;
     };
 };

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_op_queue_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_op_queue_relation.hpp
@@ -57,7 +57,7 @@ template <typename FF_> class EccOpQueueRelationImpl {
         auto lagrange_ecc_op = View(in.lagrange_ecc_op);
 
         // If lagrange_ecc_op is the indicator for ecc_op_gates, this is the indicator for the complement
-        auto complement_ecc_op = lagrange_ecc_op * FF(-1) + FF(1);
+        auto complement_ecc_op = -lagrange_ecc_op + FF(1);
 
         // Contribution (1)
         auto tmp = op_wire_1 - w_1;

--- a/barretenberg/cpp/src/barretenberg/relations/elliptic_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/elliptic_relation.hpp
@@ -67,31 +67,36 @@ template <typename FF_> class EllipticRelationImpl {
         auto y1_sqr = (y_1 * y_1);
         auto y1y2 = y_1 * y_2 * q_sign;
         auto x_add_identity = (x_3 + x_2 + x_1) * x_diff * x_diff - y2_sqr - y1_sqr + y1y2 + y1y2;
-        std::get<0>(accumulators) += x_add_identity * scaling_factor * q_elliptic * (-q_is_double + 1);
+
+        auto q_elliptic_by_scaling = q_elliptic * scaling_factor;
+        auto q_elliptic_q_double_scaling = q_elliptic_by_scaling * q_is_double;
+        auto q_elliptic_not_double_scaling = q_elliptic_by_scaling - q_elliptic_q_double_scaling;
+        std::get<0>(accumulators) += x_add_identity * q_elliptic_not_double_scaling;
 
         // Contribution (2) point addition, x-coordinate check
         // q_elliptic * (q_sign * y1 + y3)(x2 - x1) + (x3 - x1)(y2 - q_sign * y1) = 0
         auto y1_plus_y3 = y_1 + y_3;
         auto y_diff = y_2 * q_sign - y_1;
         auto y_add_identity = y1_plus_y3 * x_diff + (x_3 - x_1) * y_diff;
-        std::get<1>(accumulators) += y_add_identity * scaling_factor * q_elliptic * (-q_is_double + 1);
+        std::get<1>(accumulators) += y_add_identity * q_elliptic_not_double_scaling;
 
         // Contribution (3) point doubling, x-coordinate check
         // (x3 + x1 + x1) (4y1*y1) - 9 * x1 * x1 * x1 * x1 = 0
         // N.B. we're using the equivalence x1*x1*x1 === y1*y1 - curve_b to reduce degree by 1
         const auto curve_b = get_curve_b();
-        auto x_pow_4 = (y1_sqr - curve_b) * x_1;
+        auto x1_mul_3 = (x_1 + x_1 + x_1);
+        auto x_pow_4_mul_3 = (y1_sqr - curve_b) * x1_mul_3;
         auto y1_sqr_mul_4 = y1_sqr + y1_sqr;
         y1_sqr_mul_4 += y1_sqr_mul_4;
-        auto x1_pow_4_mul_9 = x_pow_4 * 9;
+        auto x1_pow_4_mul_9 = x_pow_4_mul_3 + x_pow_4_mul_3 + x_pow_4_mul_3;
         auto x_double_identity = (x_3 + x_1 + x_1) * y1_sqr_mul_4 - x1_pow_4_mul_9;
-        std::get<0>(accumulators) += x_double_identity * scaling_factor * q_elliptic * q_is_double;
+        std::get<0>(accumulators) += x_double_identity * q_elliptic_q_double_scaling;
 
         // Contribution (4) point doubling, y-coordinate check
         // (y1 + y1) (2y1) - (3 * x1 * x1)(x1 - x3) = 0
-        auto x1_sqr_mul_3 = (x_1 + x_1 + x_1) * x_1;
-        auto y_double_identity = x1_sqr_mul_3 * (x_1 - x_3) - (y_1 + y_1) * (y_1 + y_3);
-        std::get<1>(accumulators) += y_double_identity * scaling_factor * q_elliptic * q_is_double;
+        auto x1_sqr_mul_3 = x1_mul_3 * x_1;
+        auto y_double_identity = x1_sqr_mul_3 * (x_1 - x_3) - (y_1 + y_1) * (y1_plus_y3);
+        std::get<1>(accumulators) += y_double_identity * q_elliptic_q_double_scaling;
     };
 };
 

--- a/barretenberg/cpp/src/barretenberg/relations/poseidon2_external_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/poseidon2_external_relation.hpp
@@ -95,20 +95,17 @@ template <typename FF_> class Poseidon2ExternalRelationImpl {
         auto v1 = t3 + v2; // 5u_1 + 7u_2 + u_3 + 3u_4
         auto v3 = t2 + v4; // u_1 + 3u_2 + 5u_3 + 7u_4
 
-        auto tmp = q_poseidon2_external * (v1 - w_l_shift);
-        tmp *= scaling_factor;
+        auto q_pos_by_scaling = q_poseidon2_external * scaling_factor;
+        auto tmp = q_pos_by_scaling * (v1 - w_l_shift);
         std::get<0>(evals) += tmp;
 
-        tmp = q_poseidon2_external * (v2 - w_r_shift);
-        tmp *= scaling_factor;
+        tmp = q_pos_by_scaling * (v2 - w_r_shift);
         std::get<1>(evals) += tmp;
 
-        tmp = q_poseidon2_external * (v3 - w_o_shift);
-        tmp *= scaling_factor;
+        tmp = q_pos_by_scaling * (v3 - w_o_shift);
         std::get<2>(evals) += tmp;
 
-        tmp = q_poseidon2_external * (v4 - w_4_shift);
-        tmp *= scaling_factor;
+        tmp = q_pos_by_scaling * (v4 - w_4_shift);
         std::get<3>(evals) += tmp;
     };
 };

--- a/barretenberg/cpp/src/barretenberg/relations/poseidon2_internal_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/poseidon2_internal_relation.hpp
@@ -67,28 +67,26 @@ template <typename FF_> class Poseidon2InternalRelationImpl {
         // matrix mul with v = M_I * u 4 muls and 7 additions
         auto sum = u1 + u2 + u3 + u4;
 
+        auto q_pos_by_scaling = q_poseidon2_internal * scaling_factor;
+
         auto v1 = u1 * crypto::Poseidon2Bn254ScalarFieldParams::internal_matrix_diagonal[0];
         v1 += sum;
-        auto tmp = q_poseidon2_internal * (v1 - w_l_shift);
-        tmp *= scaling_factor;
+        auto tmp = q_pos_by_scaling * (v1 - w_l_shift);
         std::get<0>(evals) += tmp;
 
         auto v2 = u2 * crypto::Poseidon2Bn254ScalarFieldParams::internal_matrix_diagonal[1];
         v2 += sum;
-        tmp = q_poseidon2_internal * (v2 - w_r_shift);
-        tmp *= scaling_factor;
+        tmp = q_pos_by_scaling * (v2 - w_r_shift);
         std::get<1>(evals) += tmp;
 
         auto v3 = u3 * crypto::Poseidon2Bn254ScalarFieldParams::internal_matrix_diagonal[2];
         v3 += sum;
-        tmp = q_poseidon2_internal * (v3 - w_o_shift);
-        tmp *= scaling_factor;
+        tmp = q_pos_by_scaling * (v3 - w_o_shift);
         std::get<2>(evals) += tmp;
 
         auto v4 = u4 * crypto::Poseidon2Bn254ScalarFieldParams::internal_matrix_diagonal[3];
         v4 += sum;
-        tmp = q_poseidon2_internal * (v4 - w_4_shift);
-        tmp *= scaling_factor;
+        tmp = q_pos_by_scaling * (v4 - w_4_shift);
         std::get<3>(evals) += tmp;
     };
 }; // namespace bb


### PR DESCRIPTION
There were several cases where we were computing relations inefficiently (mostly the issue was recomputing the values). This PR removes those inefficiencies. It removes > 2% off benchmarks.

New x86 benchmark:
![image](https://github.com/AztecProtocol/aztec-packages/assets/4798775/7744e10e-7768-4406-92d4-d7623aa9f628)
New wasm benchmark:
![image](https://github.com/AztecProtocol/aztec-packages/assets/4798775/27a90b74-04c8-4ccc-b3f3-74d5025fc5a7)

