### PR TITLE
fix: set z_perm and lookup_inverses for proving key in ECCVM and Translator

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
@@ -85,6 +85,8 @@ template <IsECCVMFlavor Flavor> void ECCVMProver_<Flavor>::execute_log_derivativ
     // Compute inverse polynomial for our logarithmic-derivative lookup method
     compute_logderivative_inverse<Flavor, typename Flavor::LookupRelation>(
         prover_polynomials, relation_parameters, key->circuit_size);
+    key->lookup_inverses = prover_polynomials.lookup_inverses;
+
     transcript->send_to_verifier(commitment_labels.lookup_inverses, commitment_key->commit(key->lookup_inverses));
     prover_polynomials.lookup_inverses = key->lookup_inverses.share();
 }
@@ -97,7 +99,7 @@ template <IsECCVMFlavor Flavor> void ECCVMProver_<Flavor>::execute_grand_product
 {
     // Compute permutation grand product and their commitments
     compute_permutation_grand_products<Flavor>(key, prover_polynomials, relation_parameters);
-
+    key->z_perm = prover_polynomials.z_perm;
     transcript->send_to_verifier(commitment_labels.z_perm, commitment_key->commit(key->z_perm));
 }
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/goblin_translator_prover.cpp
@@ -291,6 +291,7 @@ void GoblinTranslatorProver::execute_grand_product_computation_round()
     }
     // Compute constraint permutation grand product
     compute_grand_products<Flavor>(*key, prover_polynomials, relation_parameters);
+    key->z_perm = prover_polynomials.z_perm;
 
     transcript->send_to_verifier(commitment_labels.z_perm, commitment_key->commit(key->z_perm));
 }


### PR DESCRIPTION
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
