### PR TITLE
fix: taint fork file storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1216,7 +1216,7 @@ jobs:
           name: "Deploy mainnet fork"
           command: |
             should_deploy || exit 0
-            deploy_terraform_services iac/mainnet-fork
+            deploy_terraform_services iac/mainnet-fork mainnet-fork mainnet-fork aws_efs_file_system.aztec_mainnet_fork_data_store
       - run:
           name: "Deploy L1 contracts to mainnet fork"
           working_directory: l1-contracts


### PR DESCRIPTION
Taint mainnet fork's EFS storage to ensure it's redeployed when mainnet fork service is redeployed.