### PR TITLE
feat(avm): Track gas from memory accesses explicitly

### DIFF
--- a/yarn-project/foundation/src/types/index.ts
+++ b/yarn-project/foundation/src/types/index.ts
@@ -4,5 +4,11 @@ export type FieldsOf<T> = {
   [P in keyof T as T[P] extends Function ? never : P]: T[P];
 };
 
+/** Extracts methods of a type. */
+export type FunctionsOf<T> = {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  [P in keyof T as T[P] extends Function ? P : never]: T[P];
+};
+
 /** Marks a set of properties of a type as optional. */
 export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/yarn-project/simulator/src/avm/avm_gas.test.ts
+++ b/yarn-project/simulator/src/avm/avm_gas.test.ts
@@ -6,16 +6,23 @@ import { encodeToBytecode } from './serialization/bytecode_serialization.js';
 
 describe('AVM simulator: dynamic gas costs per instruction', () => {
   it.each([
-    [new SetInstruction(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT8, /*value=*/ 1, /*dstOffset=*/ 0), [100, 0, 0]],
-    [new SetInstruction(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1, /*dstOffset=*/ 0), [400, 0, 0]],
-    [new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ TypeTag.UINT8, /*copySize=*/ 1, /*dstOffset=*/ 0), [10, 0, 0]],
-    [new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ TypeTag.UINT8, /*copySize=*/ 5, /*dstOffset=*/ 0), [50, 0, 0]],
-    [new Add(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [10, 0, 0]],
-    [new Add(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT32, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [40, 0, 0]],
-    [new Add(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [20, 0, 0]],
-    [new Sub(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [20, 0, 0]],
-    [new Mul(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [20, 0, 0]],
-    [new Div(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [20, 0, 0]],
+    // BASE_GAS(10) * 1 + MEMORY_WRITE(100) = 110
+    [new SetInstruction(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT8, /*value=*/ 1, /*dstOffset=*/ 0), [110, 0, 0]],
+    // BASE_GAS(10) * 1 + MEMORY_WRITE(100) = 110
+    [new SetInstruction(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1, /*dstOffset=*/ 0), [110]],
+    // BASE_GAS(10) * 1 + MEMORY_WRITE(100) = 110
+    [new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ TypeTag.UINT8, /*copySize=*/ 1, /*dstOffset=*/ 0), [110]],
+    // BASE_GAS(10) * 5 + MEMORY_WRITE(100) * 5 = 550
+    [new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ TypeTag.UINT8, /*copySize=*/ 5, /*dstOffset=*/ 0), [550]],
+    // BASE_GAS(10) * 1 + MEMORY_READ(10) * 2 + MEMORY_WRITE(100) = 130
+    [new Add(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [130]],
+    // BASE_GAS(10) * 4 + MEMORY_READ(10) * 2 + MEMORY_WRITE(100) = 160
+    [new Add(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT32, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [160]],
+    // BASE_GAS(10) * 1 + MEMORY_READ(10) * 2 + MEMORY_INDIRECT_READ_PENALTY(10) * 2 + MEMORY_WRITE(100) = 150
+    [new Add(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
+    [new Sub(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
+    [new Mul(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
+    [new Div(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
   ] as const)('computes gas cost for %s', async (instruction, [l2GasCost, l1GasCost, daGasCost]) => {
     const bytecode = encodeToBytecode([instruction]);
     const context = initContext();
@@ -27,8 +34,8 @@ describe('AVM simulator: dynamic gas costs per instruction', () => {
 
     await new AvmSimulator(context).executeBytecode(bytecode);
 
-    expect(initialL2GasLeft - context.machineState.l2GasLeft).toEqual(l2GasCost);
-    expect(initialL1GasLeft - context.machineState.l1GasLeft).toEqual(l1GasCost);
-    expect(initialDaGasLeft - context.machineState.daGasLeft).toEqual(daGasCost);
+    expect(initialL2GasLeft - context.machineState.l2GasLeft).toEqual(l2GasCost ?? 0);
+    expect(initialL1GasLeft - context.machineState.l1GasLeft).toEqual(l1GasCost ?? 0);
+    expect(initialDaGasLeft - context.machineState.daGasLeft).toEqual(daGasCost ?? 0);
   });
 });

--- a/yarn-project/simulator/src/avm/avm_gas.ts
+++ b/yarn-project/simulator/src/avm/avm_gas.ts
@@ -1,4 +1,5 @@
 import { TypeTag } from './avm_memory_types.js';
+import { InstructionExecutionError } from './errors.js';
 import { Addressing, AddressingMode } from './opcodes/addressing_mode.js';
 import { Opcode } from './serialization/instruction_serialization.js';
 
@@ -20,7 +21,7 @@ export function gasLeftToGas(gasLeft: { l1GasLeft: number; l2GasLeft: number; da
 }
 
 /** Creates a new instance with all values set to zero except the ones set. */
-export function makeGasCost(gasCost: Partial<Gas>) {
+export function makeGas(gasCost: Partial<Gas>) {
   return { ...EmptyGas, ...gasCost };
 }
 
@@ -34,6 +35,11 @@ export function sumGas(...gases: Partial<Gas>[]) {
     }),
     EmptyGas,
   );
+}
+
+/** Multiplies a gas instance by a scalar. */
+export function mulGas(gas: Partial<Gas>, scalar: number) {
+  return { l1Gas: (gas.l1Gas ?? 0) * scalar, l2Gas: (gas.l2Gas ?? 0) * scalar, daGas: (gas.daGas ?? 0) * scalar };
 }
 
 /** Zero gas across all gas dimensions. */
@@ -52,12 +58,12 @@ export const DynamicGasCost = Symbol('DynamicGasCost');
 /** Temporary default gas cost. We should eventually remove all usage of this variable in favor of actual gas for each opcode. */
 const TemporaryDefaultGasCost = { l1Gas: 0, l2Gas: 10, daGas: 0 };
 
-/** Gas costs for each instruction. */
-export const GasCosts = {
-  [Opcode.ADD]: DynamicGasCost,
-  [Opcode.SUB]: DynamicGasCost,
-  [Opcode.MUL]: DynamicGasCost,
-  [Opcode.DIV]: DynamicGasCost,
+/** Base gas costs for each instruction. Additional gas cost may be added on top due to memory or storage accesses, etc. */
+export const GasCosts: Record<Opcode, Gas | typeof DynamicGasCost> = {
+  [Opcode.ADD]: TemporaryDefaultGasCost,
+  [Opcode.SUB]: TemporaryDefaultGasCost,
+  [Opcode.MUL]: TemporaryDefaultGasCost,
+  [Opcode.DIV]: TemporaryDefaultGasCost,
   [Opcode.FDIV]: TemporaryDefaultGasCost,
   [Opcode.EQ]: TemporaryDefaultGasCost,
   [Opcode.LT]: TemporaryDefaultGasCost,
@@ -87,7 +93,7 @@ export const GasCosts = {
   [Opcode.BLOCKL1GASLIMIT]: TemporaryDefaultGasCost,
   [Opcode.BLOCKL2GASLIMIT]: TemporaryDefaultGasCost,
   [Opcode.BLOCKDAGASLIMIT]: TemporaryDefaultGasCost,
-  [Opcode.CALLDATACOPY]: DynamicGasCost,
+  [Opcode.CALLDATACOPY]: TemporaryDefaultGasCost,
   // Gas
   [Opcode.L1GASLEFT]: TemporaryDefaultGasCost,
   [Opcode.L2GASLEFT]: TemporaryDefaultGasCost,
@@ -98,7 +104,7 @@ export const GasCosts = {
   [Opcode.INTERNALCALL]: TemporaryDefaultGasCost,
   [Opcode.INTERNALRETURN]: TemporaryDefaultGasCost,
   // Memory
-  [Opcode.SET]: DynamicGasCost,
+  [Opcode.SET]: TemporaryDefaultGasCost,
   [Opcode.MOV]: TemporaryDefaultGasCost,
   [Opcode.CMOV]: TemporaryDefaultGasCost,
   // World state
@@ -124,10 +130,10 @@ export const GasCosts = {
   [Opcode.POSEIDON]: TemporaryDefaultGasCost,
   [Opcode.SHA256]: TemporaryDefaultGasCost, // temp - may be removed, but alot of contracts rely on i: TemporaryDefaultGasCost,
   [Opcode.PEDERSEN]: TemporaryDefaultGasCost, // temp - may be removed, but alot of contracts rely on i: TemporaryDefaultGasCost,t
-} as const;
+};
 
-/** Returns the fixed gas cost for a given opcode, or throws if set to dynamic. */
-export function getFixedGasCost(opcode: Opcode): Gas {
+/** Returns the fixed base gas cost for a given opcode, or throws if set to dynamic. */
+export function getBaseGasCost(opcode: Opcode): Gas {
   const cost = GasCosts[opcode];
   if (cost === DynamicGasCost) {
     throw new Error(`Opcode ${Opcode[opcode]} has dynamic gas cost`);
@@ -135,24 +141,31 @@ export function getFixedGasCost(opcode: Opcode): Gas {
   return cost;
 }
 
-/** Returns the additional cost from indirect accesses to memory. */
-export function getCostFromIndirectAccess(indirect: number): Partial<Gas> {
-  const indirectCount = Addressing.fromWire(indirect).modePerOperand.filter(
-    mode => mode === AddressingMode.INDIRECT,
-  ).length;
-  return { l2Gas: indirectCount * GasCostConstants.COST_PER_INDIRECT_ACCESS };
+/** Returns the gas cost associated with the memory operations performed. */
+export function getMemoryGasCost(args: { reads?: number; writes?: number; indirect?: number }) {
+  const { reads, writes, indirect } = args;
+  const indirectCount = Addressing.fromWire(indirect ?? 0).count(AddressingMode.INDIRECT);
+  const l2MemoryGasCost =
+    (reads ?? 0) * GasCostConstants.MEMORY_READ +
+    (writes ?? 0) * GasCostConstants.MEMORY_WRITE +
+    indirectCount * GasCostConstants.MEMORY_INDIRECT_READ_PENALTY;
+  return makeGas({ l2Gas: l2MemoryGasCost });
 }
 
 /** Constants used in base cost calculations. */
 export const GasCostConstants = {
-  SET_COST_PER_BYTE: 100,
-  CALLDATACOPY_COST_PER_BYTE: 10,
-  ARITHMETIC_COST_PER_BYTE: 10,
-  COST_PER_INDIRECT_ACCESS: 5,
+  MEMORY_READ: 10,
+  MEMORY_INDIRECT_READ_PENALTY: 10,
+  MEMORY_WRITE: 100,
 };
 
+/** Returns gas cost for an operation on a given type tag based on the base cost per byte. */
+export function getGasCostForTypeTag(tag: TypeTag, baseCost: Gas) {
+  return mulGas(baseCost, getGasCostMultiplierFromTypeTag(tag));
+}
+
 /** Returns a multiplier based on the size of the type represented by the tag. Throws on uninitialized or invalid. */
-export function getGasCostMultiplierFromTypeTag(tag: TypeTag) {
+function getGasCostMultiplierFromTypeTag(tag: TypeTag) {
   switch (tag) {
     case TypeTag.UINT8:
       return 1;
@@ -168,6 +181,6 @@ export function getGasCostMultiplierFromTypeTag(tag: TypeTag) {
       return 32;
     case TypeTag.INVALID:
     case TypeTag.UNINITIALIZED:
-      throw new Error(`Invalid tag type for gas cost multiplier: ${TypeTag[tag]}`);
+      throw new InstructionExecutionError(`Invalid tag type for gas cost multiplier: ${TypeTag[tag]}`);
   }
 }

--- a/yarn-project/simulator/src/avm/avm_memory_types.test.ts
+++ b/yarn-project/simulator/src/avm/avm_memory_types.test.ts
@@ -1,4 +1,13 @@
-import { Field, TaggedMemory, Uint8, Uint16, Uint32, Uint64, Uint128 } from './avm_memory_types.js';
+import {
+  Field,
+  MeteredTaggedMemory,
+  TaggedMemory,
+  Uint8,
+  Uint16,
+  Uint32,
+  Uint64,
+  Uint128,
+} from './avm_memory_types.js';
 
 describe('TaggedMemory', () => {
   it('Elements should be undefined after construction', () => {
@@ -34,6 +43,58 @@ describe('TaggedMemory', () => {
     mem.setSlice(10, val);
 
     expect(mem.getSlice(10, /*size=*/ 2)).toStrictEqual(val);
+  });
+});
+
+describe('MeteredTaggedMemory', () => {
+  let mem: MeteredTaggedMemory;
+
+  beforeEach(() => {
+    mem = new MeteredTaggedMemory(new TaggedMemory());
+  });
+
+  it(`Counts reads`, () => {
+    mem.get(10);
+    mem.getAs(20);
+    expect(mem.reset()).toEqual({ reads: 2, writes: 0 });
+  });
+
+  it(`Counts reading slices`, () => {
+    const val = [new Field(5), new Field(6), new Field(7)];
+    mem.setSlice(10, val);
+    mem.reset();
+
+    mem.getSlice(10, 3);
+    mem.getSliceAs(11, 2);
+    expect(mem.reset()).toEqual({ reads: 5, writes: 0 });
+  });
+
+  it(`Counts writes`, () => {
+    mem.set(10, new Uint8(5));
+    expect(mem.reset()).toEqual({ reads: 0, writes: 1 });
+  });
+
+  it(`Counts writing slices`, () => {
+    mem.setSlice(10, [new Field(5), new Field(6)]);
+    expect(mem.reset()).toEqual({ reads: 0, writes: 2 });
+  });
+
+  it(`Clears stats`, () => {
+    mem.get(10);
+    mem.set(20, new Uint8(5));
+    expect(mem.reset()).toEqual({ reads: 1, writes: 1 });
+    expect(mem.reset()).toEqual({ reads: 0, writes: 0 });
+  });
+
+  it(`Asserts stats`, () => {
+    mem.get(10);
+    mem.set(20, new Uint8(5));
+    expect(() => mem.assert({ reads: 1, writes: 1 })).not.toThrow();
+  });
+
+  it(`Throws on failed stat assertion`, () => {
+    mem.get(10);
+    expect(() => mem.assert({ reads: 1, writes: 1 })).toThrow();
   });
 });
 

--- a/yarn-project/simulator/src/avm/avm_memory_types.ts
+++ b/yarn-project/simulator/src/avm/avm_memory_types.ts
@@ -1,10 +1,12 @@
 import { toBufferBE } from '@aztec/foundation/bigint-buffer';
 import { Fr } from '@aztec/foundation/fields';
 import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type FunctionsOf } from '@aztec/foundation/types';
 
 import { strict as assert } from 'assert';
 
-import { TagCheckError } from './errors.js';
+import { InstructionExecutionError, TagCheckError } from './errors.js';
+import { Addressing, AddressingMode } from './opcodes/addressing_mode.js';
 
 /** MemoryValue gathers the common operations for all memory types. */
 export abstract class MemoryValue {
@@ -203,9 +205,15 @@ export enum TypeTag {
   INVALID,
 }
 
+// Lazy interface definition for tagged memory
+export type TaggedMemoryInterface = FunctionsOf<TaggedMemory>;
+
 // TODO: Consider automatic conversion when getting undefined values.
-export class TaggedMemory {
+export class TaggedMemory implements TaggedMemoryInterface {
   static readonly log: DebugLogger = createDebugLogger('aztec:avm_simulator:memory');
+
+  // Whether to track and validate memory accesses for each instruction.
+  static readonly TRACK_MEMORY_ACCESSES = process.env.NODE_ENV === 'test';
 
   // FIXME: memory should be 2^32, but TS doesn't allow for arrays that big.
   static readonly MAX_MEMORY_SIZE = Number((1n << 32n) - 2n);
@@ -214,6 +222,11 @@ export class TaggedMemory {
   constructor() {
     // We do not initialize memory size here because otherwise tests blow up when diffing.
     this._mem = [];
+  }
+
+  /** Returns a MeteredTaggedMemory instance to track the number of reads and writes if TRACK_MEMORY_ACCESSES is set. */
+  public track(type: string = 'instruction') {
+    return TaggedMemory.TRACK_MEMORY_ACCESSES ? new MeteredTaggedMemory(this, type) : this;
   }
 
   public get(offset: number): MemoryValue {
@@ -376,4 +389,110 @@ export class TaggedMemory {
         throw new Error(`${TypeTag[tag]} is not a valid integral type.`);
     }
   }
+
+  /** No-op. Implemented here for compatibility with the MeteredTaggedMemory. */
+  public assert(_operations: Partial<MemoryOperations & { indirect: number }>) {}
 }
+
+/** Tagged memory wrapper with metering for each memory read and write operation. */
+export class MeteredTaggedMemory implements TaggedMemoryInterface {
+  private reads: number = 0;
+  private writes: number = 0;
+
+  constructor(private wrapped: TaggedMemory, private type: string = 'instruction') {}
+
+  /** Returns the number of reads and writes tracked so far and resets them to zero. */
+  public reset(): MemoryOperations {
+    const stats = { reads: this.reads, writes: this.writes };
+    this.reads = 0;
+    this.writes = 0;
+    return stats;
+  }
+
+  /**
+   * Asserts that the exact number of memory operations have been performed.
+   * Indirect represents the flags for indirect accesses: each bit set to one counts as an extra read.
+   */
+  public assert(operations: Partial<MemoryOperations & { indirect: number }>) {
+    const { reads: expectedReads, writes: expectedWrites, indirect } = { reads: 0, writes: 0, ...operations };
+
+    const totalExpectedReads = expectedReads + Addressing.fromWire(indirect ?? 0).count(AddressingMode.INDIRECT);
+    const { reads: actualReads, writes: actualWrites } = this.reset();
+    if (actualReads !== totalExpectedReads) {
+      throw new InstructionExecutionError(
+        `Incorrect number of memory reads for ${this.type}: expected ${totalExpectedReads} but executed ${actualReads}`,
+      );
+    }
+    if (actualWrites !== expectedWrites) {
+      throw new InstructionExecutionError(
+        `Incorrect number of memory writes for ${this.type}: expected ${expectedWrites} but executed ${actualWrites}`,
+      );
+    }
+  }
+
+  public track(type: string = 'instruction'): MeteredTaggedMemory {
+    return new MeteredTaggedMemory(this.wrapped, type);
+  }
+
+  public get(offset: number): MemoryValue {
+    this.reads++;
+    return this.wrapped.get(offset);
+  }
+
+  public getSliceAs<T>(offset: number, size: number): T[] {
+    this.reads += size;
+    return this.wrapped.getSliceAs<T>(offset, size);
+  }
+
+  public getAs<T>(offset: number): T {
+    this.reads++;
+    return this.wrapped.getAs(offset);
+  }
+
+  public getSlice(offset: number, size: number): MemoryValue[] {
+    this.reads += size;
+    return this.wrapped.getSlice(offset, size);
+  }
+
+  public set(offset: number, v: MemoryValue): void {
+    this.writes++;
+    this.wrapped.set(offset, v);
+  }
+
+  public setSlice(offset: number, vs: MemoryValue[]): void {
+    this.writes += vs.length;
+    this.wrapped.setSlice(offset, vs);
+  }
+
+  public getSliceTags(offset: number, size: number): TypeTag[] {
+    return this.wrapped.getSliceTags(offset, size);
+  }
+
+  public getTag(offset: number): TypeTag {
+    return this.wrapped.getTag(offset);
+  }
+
+  public checkTag(tag: TypeTag, offset: number): void {
+    this.wrapped.checkTag(tag, offset);
+  }
+
+  public checkIsValidMemoryOffsetTag(offset: number): void {
+    this.wrapped.checkIsValidMemoryOffsetTag(offset);
+  }
+
+  public checkTags(tag: TypeTag, ...offsets: number[]): void {
+    this.wrapped.checkTags(tag, ...offsets);
+  }
+
+  public checkTagsRange(tag: TypeTag, startOffset: number, size: number): void {
+    this.wrapped.checkTagsRange(tag, startOffset, size);
+  }
+}
+
+/** Tracks number of memory reads and writes. */
+export type MemoryOperations = {
+  /** How many total reads are performed. Slice reads are count as one per element. */
+  reads: number;
+  /** How many total writes are performed. Slice writes are count as one per element. */
+  writes: number;
+};

--- a/yarn-project/simulator/src/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.test.ts
@@ -49,7 +49,7 @@ describe('AVM simulator: injected bytecode', () => {
 
     expect(results.reverted).toBe(false);
     expect(results.output).toEqual([new Fr(3)]);
-    expect(context.machineState.l2GasLeft).toEqual(initialL2GasLeft - 350);
+    expect(context.machineState.l2GasLeft).toEqual(initialL2GasLeft - 680);
   });
 
   it('Should halt if runs out of gas', async () => {

--- a/yarn-project/simulator/src/avm/avm_simulator.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.ts
@@ -64,7 +64,7 @@ export class AvmSimulator {
         // Execute the instruction.
         // Normal returns and reverts will return normally here.
         // "Exceptional halts" will throw.
-        await instruction.run(this.context);
+        await instruction.execute(this.context);
 
         if (this.context.machineState.pc >= instructions.length) {
           this.log('Passed end of program!');

--- a/yarn-project/simulator/src/avm/opcodes/addressing_mode.ts
+++ b/yarn-project/simulator/src/avm/opcodes/addressing_mode.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert';
 
-import { type TaggedMemory } from '../avm_memory_types.js';
+import { type TaggedMemoryInterface } from '../avm_memory_types.js';
 
 export enum AddressingMode {
   DIRECT,
@@ -12,7 +12,7 @@ export enum AddressingMode {
 export class Addressing {
   public constructor(
     /** The addressing mode for each operand. The length of this array is the number of operands of the instruction. */
-    public readonly modePerOperand: AddressingMode[],
+    private readonly modePerOperand: AddressingMode[],
   ) {
     assert(modePerOperand.length <= 8, 'At most 8 operands are supported');
   }
@@ -39,13 +39,18 @@ export class Addressing {
     return wire;
   }
 
+  /** Returns how many operands use the given addressing mode. */
+  public count(mode: AddressingMode): number {
+    return this.modePerOperand.filter(m => m === mode).length;
+  }
+
   /**
    * Resolves the offsets using the addressing mode.
    * @param offsets The offsets to resolve.
    * @param mem The memory to use for resolution.
    * @returns The resolved offsets. The length of the returned array is the same as the length of the input array.
    */
-  public resolve(offsets: number[], mem: TaggedMemory): number[] {
+  public resolve(offsets: number[], mem: TaggedMemoryInterface): number[] {
     assert(offsets.length <= this.modePerOperand.length);
     const resolved = new Array(offsets.length);
     for (const [i, offset] of offsets.entries()) {

--- a/yarn-project/simulator/src/avm/opcodes/comparators.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/comparators.test.ts
@@ -36,11 +36,15 @@ describe('Comparators', () => {
     it('Works on integral types', async () => {
       context.machineState.memory.setSlice(0, [new Uint32(1), new Uint32(2), new Uint32(3), new Uint32(1)]);
 
-      [
+      const ops = [
         new Eq(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
         new Eq(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 11),
         new Eq(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 3, /*dstOffset=*/ 12),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(0), new Uint8(0), new Uint8(1)]);
@@ -49,11 +53,15 @@ describe('Comparators', () => {
     it('Works on field elements', async () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Field(2), new Field(3), new Field(1)]);
 
-      [
+      const ops = [
         new Eq(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
         new Eq(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 11),
         new Eq(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 3, /*dstOffset=*/ 12),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(0), new Uint8(0), new Uint8(1)]);
@@ -70,7 +78,7 @@ describe('Comparators', () => {
       ];
 
       for (const o of ops) {
-        await expect(() => o.execute(context)).rejects.toThrow(TagCheckError);
+        await expect(async () => await o.execute(context)).rejects.toThrow(TagCheckError);
       }
     });
   });
@@ -100,11 +108,15 @@ describe('Comparators', () => {
     it('Works on integral types', async () => {
       context.machineState.memory.setSlice(0, [new Uint32(1), new Uint32(2), new Uint32(0)]);
 
-      [
+      const ops = [
         new Lt(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
         new Lt(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
         new Lt(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(0), new Uint8(1), new Uint8(0)]);
@@ -113,11 +125,15 @@ describe('Comparators', () => {
     it('Works on field elements', async () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Field(2), new Field(0)]);
 
-      [
+      const ops = [
         new Lt(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
         new Lt(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
         new Lt(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(0), new Uint8(1), new Uint8(0)]);
@@ -134,7 +150,7 @@ describe('Comparators', () => {
       ];
 
       for (const o of ops) {
-        await expect(() => o.execute(context)).rejects.toThrow(TagCheckError);
+        await expect(async () => await o.execute(context)).rejects.toThrow(TagCheckError);
       }
     });
   });
@@ -164,11 +180,15 @@ describe('Comparators', () => {
     it('Works on integral types', async () => {
       context.machineState.memory.setSlice(0, [new Uint32(1), new Uint32(2), new Uint32(0)]);
 
-      [
+      const ops = [
         new Lte(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
         new Lte(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
         new Lte(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(1), new Uint8(1), new Uint8(0)]);
@@ -177,11 +197,15 @@ describe('Comparators', () => {
     it('Works on field elements', async () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Field(2), new Field(0)]);
 
-      [
+      const ops = [
         new Lte(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
         new Lte(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
         new Lte(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
-      ].forEach(i => i.execute(context));
+      ];
+
+      for (const op of ops) {
+        await op.execute(context);
+      }
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 10, /*size=*/ 3);
       expect(actual).toEqual([new Uint8(1), new Uint8(1), new Uint8(0)]);
@@ -198,7 +222,7 @@ describe('Comparators', () => {
       ];
 
       for (const o of ops) {
-        await expect(() => o.execute(context)).rejects.toThrow(TagCheckError);
+        await expect(async () => await o.execute(context)).rejects.toThrow(TagCheckError);
       }
     });
   });

--- a/yarn-project/simulator/src/avm/opcodes/comparators.ts
+++ b/yarn-project/simulator/src/avm/opcodes/comparators.ts
@@ -1,67 +1,52 @@
 import type { AvmContext } from '../avm_context.js';
-import { Uint8 } from '../avm_memory_types.js';
+import { type MemoryValue, Uint8 } from '../avm_memory_types.js';
 import { Opcode } from '../serialization/instruction_serialization.js';
 import { ThreeOperandInstruction } from './instruction_impl.js';
 
-export class Eq extends ThreeOperandInstruction {
+abstract class ComparatorInstruction extends ThreeOperandInstruction {
+  public async execute(context: AvmContext): Promise<void> {
+    const memoryOperations = { reads: 2, writes: 1, indirect: this.indirect };
+    const memory = context.machineState.memory.track(this.type);
+    context.machineState.consumeGas(this.gasCost(memoryOperations));
+
+    memory.checkTags(this.inTag, this.aOffset, this.bOffset);
+
+    const a = memory.get(this.aOffset);
+    const b = memory.get(this.bOffset);
+
+    const dest = new Uint8(this.compare(a, b) ? 1 : 0);
+    memory.set(this.dstOffset, dest);
+
+    memory.assert(memoryOperations);
+    context.machineState.incrementPc();
+  }
+
+  protected abstract compare(a: MemoryValue, b: MemoryValue): boolean;
+}
+
+export class Eq extends ComparatorInstruction {
   static readonly type: string = 'EQ';
   static readonly opcode = Opcode.EQ;
 
-  constructor(indirect: number, inTag: number, aOffset: number, bOffset: number, dstOffset: number) {
-    super(indirect, inTag, aOffset, bOffset, dstOffset);
-  }
-
-  async execute(context: AvmContext): Promise<void> {
-    context.machineState.memory.checkTags(this.inTag, this.aOffset, this.bOffset);
-
-    const a = context.machineState.memory.get(this.aOffset);
-    const b = context.machineState.memory.get(this.bOffset);
-
-    const dest = new Uint8(a.equals(b) ? 1 : 0);
-    context.machineState.memory.set(this.dstOffset, dest);
-
-    context.machineState.incrementPc();
+  protected compare(a: MemoryValue, b: MemoryValue): boolean {
+    return a.equals(b);
   }
 }
 
-export class Lt extends ThreeOperandInstruction {
+export class Lt extends ComparatorInstruction {
   static readonly type: string = 'LT';
   static readonly opcode = Opcode.LT;
 
-  constructor(indirect: number, inTag: number, aOffset: number, bOffset: number, dstOffset: number) {
-    super(indirect, inTag, aOffset, bOffset, dstOffset);
-  }
-
-  async execute(context: AvmContext): Promise<void> {
-    context.machineState.memory.checkTags(this.inTag, this.aOffset, this.bOffset);
-
-    const a = context.machineState.memory.get(this.aOffset);
-    const b = context.machineState.memory.get(this.bOffset);
-
-    const dest = new Uint8(a.lt(b) ? 1 : 0);
-    context.machineState.memory.set(this.dstOffset, dest);
-
-    context.machineState.incrementPc();
+  protected compare(a: MemoryValue, b: MemoryValue): boolean {
+    return a.lt(b);
   }
 }
 
-export class Lte extends ThreeOperandInstruction {
+export class Lte extends ComparatorInstruction {
   static readonly type: string = 'LTE';
   static readonly opcode = Opcode.LTE;
 
-  constructor(indirect: number, inTag: number, aOffset: number, bOffset: number, dstOffset: number) {
-    super(indirect, inTag, aOffset, bOffset, dstOffset);
-  }
-
-  async execute(context: AvmContext): Promise<void> {
-    context.machineState.memory.checkTags(this.inTag, this.aOffset, this.bOffset);
-
-    const a = context.machineState.memory.get(this.aOffset);
-    const b = context.machineState.memory.get(this.bOffset);
-
-    const dest = new Uint8(a.lt(b) || a.equals(b) ? 1 : 0);
-    context.machineState.memory.set(this.dstOffset, dest);
-
-    context.machineState.incrementPc();
+  protected compare(a: MemoryValue, b: MemoryValue): boolean {
+    return a.lt(b) || a.equals(b);
   }
 }

--- a/yarn-project/simulator/src/avm/opcodes/environment_getters.ts
+++ b/yarn-project/simulator/src/avm/opcodes/environment_getters.ts
@@ -14,9 +14,15 @@ abstract class GetterInstruction extends Instruction {
     super();
   }
 
-  async execute(context: AvmContext): Promise<void> {
+  public async execute(context: AvmContext): Promise<void> {
+    const memoryOperations = { writes: 1, indirect: this.indirect };
+    const memory = context.machineState.memory.track(this.type);
+    context.machineState.consumeGas(this.gasCost(memoryOperations));
+
     const res = new Field(this.getIt(context.environment));
-    context.machineState.memory.set(this.dstOffset, res);
+    memory.set(this.dstOffset, res);
+
+    memory.assert(memoryOperations);
     context.machineState.incrementPc();
   }
 

--- a/yarn-project/simulator/src/avm/opcodes/external_calls.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/external_calls.test.ts
@@ -71,7 +71,7 @@ describe('External Calls', () => {
       const retSize = 2;
       const successOffset = 7;
 
-      const otherContextInstructionsL2GasCost = 60; // Includes the cost of the call itself
+      const otherContextInstructionsL2GasCost = 780; // Includes the cost of the call itself
       const otherContextInstructionsBytecode = encodeToBytecode([
         new CalldataCopy(
           /*indirect=*/ 0,
@@ -105,7 +105,7 @@ describe('External Calls', () => {
         successOffset,
         /*temporaryFunctionSelectorOffset=*/ 0,
       );
-      await instruction.run(context);
+      await instruction.execute(context);
 
       const successValue = context.machineState.memory.get(successOffset);
       expect(successValue).toEqual(new Uint8(1n));
@@ -166,7 +166,7 @@ describe('External Calls', () => {
         /*temporaryFunctionSelectorOffset=*/ 0,
       );
 
-      await expect(() => instruction.run(context)).rejects.toThrow(/Not enough.*gas left/i);
+      await expect(() => instruction.execute(context)).rejects.toThrow(/Not enough.*gas left/i);
     });
   });
 
@@ -244,7 +244,7 @@ describe('External Calls', () => {
         successOffset,
         /*temporaryFunctionSelectorOffset=*/ 0,
       );
-      await instruction.run(context);
+      await instruction.execute(context);
 
       // No revert has occurred, but the nested execution has failed
       const successValue = context.machineState.memory.get(successOffset);

--- a/yarn-project/simulator/src/avm/opcodes/external_calls.ts
+++ b/yarn-project/simulator/src/avm/opcodes/external_calls.ts
@@ -1,7 +1,8 @@
 import { FunctionSelector } from '@aztec/circuits.js';
+import { padArrayEnd } from '@aztec/foundation/collection';
 
 import type { AvmContext } from '../avm_context.js';
-import { type Gas, gasLeftToGas, getCostFromIndirectAccess, getFixedGasCost, sumGas } from '../avm_gas.js';
+import { gasLeftToGas, sumGas } from '../avm_gas.js';
 import { Field, Uint8 } from '../avm_memory_types.js';
 import { AvmSimulator } from '../avm_simulator.js';
 import { Opcode, OperandType } from '../serialization/instruction_serialization.js';
@@ -41,24 +42,24 @@ abstract class ExternalCall extends Instruction {
     super();
   }
 
-  async run(context: AvmContext): Promise<void> {
+  public async execute(context: AvmContext) {
+    const memory = context.machineState.memory.track(this.type);
     const [gasOffset, addrOffset, argsOffset, retOffset, successOffset] = Addressing.fromWire(this.indirect).resolve(
       [this.gasOffset, this.addrOffset, this.argsOffset, this.retOffset, this.successOffset],
-      context.machineState.memory,
+      memory,
     );
 
-    const callAddress = context.machineState.memory.getAs<Field>(addrOffset);
-    const calldata = context.machineState.memory.getSlice(argsOffset, this.argsSize).map(f => f.toFr());
-    const l1Gas = context.machineState.memory.get(gasOffset).toNumber();
-    const l2Gas = context.machineState.memory.getAs<Field>(gasOffset + 1).toNumber();
-    const daGas = context.machineState.memory.getAs<Field>(gasOffset + 2).toNumber();
-    const functionSelector = context.machineState.memory.getAs<Field>(this.temporaryFunctionSelectorOffset).toFr();
+    const callAddress = memory.getAs<Field>(addrOffset);
+    const calldata = memory.getSlice(argsOffset, this.argsSize).map(f => f.toFr());
+    const l1Gas = memory.get(gasOffset).toNumber();
+    const l2Gas = memory.getAs<Field>(gasOffset + 1).toNumber();
+    const daGas = memory.getAs<Field>(gasOffset + 2).toNumber();
+    const functionSelector = memory.getAs<Field>(this.temporaryFunctionSelectorOffset).toFr();
 
-    // Consume a base fixed gas cost for the call opcode, plus whatever is allocated for the nested call
-    const baseGas = getFixedGasCost(this.opcode);
-    const addressingGasCost = getCostFromIndirectAccess(this.indirect);
     const allocatedGas = { l1Gas, l2Gas, daGas };
-    context.machineState.consumeGas(sumGas(baseGas, addressingGasCost, allocatedGas));
+    const memoryOperations = { reads: this.argsSize + 5, writes: 1 + this.retSize, indirect: this.indirect };
+    const totalGas = sumGas(this.gasCost(memoryOperations), allocatedGas);
+    context.machineState.consumeGas(totalGas);
 
     const nestedContext = context.createNestedContractCallContext(
       callAddress.toFr(),
@@ -71,13 +72,18 @@ abstract class ExternalCall extends Instruction {
     const nestedCallResults = await new AvmSimulator(nestedContext).execute();
     const success = !nestedCallResults.reverted;
 
-    // We only take as much data as was specified in the return size -> TODO: should we be reverting here
+    // We only take as much data as was specified in the return size and pad with zeroes if the return data is smaller
+    // than the specified size in order to prevent that memory to be left with garbage
     const returnData = nestedCallResults.output.slice(0, this.retSize);
-    const convertedReturnData = returnData.map(f => new Field(f));
+    const convertedReturnData = padArrayEnd(
+      returnData.map(f => new Field(f)),
+      new Field(0),
+      this.retSize,
+    );
 
     // Write our return data into memory
-    context.machineState.memory.set(successOffset, new Uint8(success ? 1 : 0));
-    context.machineState.memory.setSlice(retOffset, convertedReturnData);
+    memory.set(successOffset, new Uint8(success ? 1 : 0));
+    memory.setSlice(retOffset, convertedReturnData);
 
     // Refund unused gas
     context.machineState.refundGas(gasLeftToGas(nestedContext.machineState));
@@ -89,20 +95,11 @@ abstract class ExternalCall extends Instruction {
       context.persistableState.rejectNestedCallState(nestedContext.persistableState);
     }
 
+    memory.assert(memoryOperations);
     context.machineState.incrementPc();
   }
 
   public abstract get type(): 'CALL' | 'STATICCALL';
-
-  protected execute(_context: AvmContext): Promise<void> {
-    throw new Error(
-      `Instructions with dynamic gas calculation run all logic on the main execute function and do not override the internal execute.`,
-    );
-  }
-
-  protected gasCost(): Gas {
-    throw new Error(`Instructions with dynamic gas calculation compute gas as part of the main execute function.`);
-  }
 }
 
 export class Call extends ExternalCall {
@@ -138,12 +135,17 @@ export class Return extends Instruction {
     super();
   }
 
-  async execute(context: AvmContext): Promise<void> {
-    const [returnOffset] = Addressing.fromWire(this.indirect).resolve([this.returnOffset], context.machineState.memory);
+  public async execute(context: AvmContext): Promise<void> {
+    const memoryOperations = { reads: this.copySize, indirect: this.indirect };
+    const memory = context.machineState.memory.track(this.type);
+    context.machineState.consumeGas(this.gasCost(memoryOperations));
 
-    const output = context.machineState.memory.getSlice(returnOffset, this.copySize).map(word => word.toFr());
+    const [returnOffset] = Addressing.fromWire(this.indirect).resolve([this.returnOffset], memory);
+
+    const output = memory.getSlice(returnOffset, this.copySize).map(word => word.toFr());
 
     context.machineState.return(output);
+    memory.assert(memoryOperations);
   }
 }
 
@@ -162,11 +164,16 @@ export class Revert extends Instruction {
     super();
   }
 
-  async execute(context: AvmContext): Promise<void> {
-    const [returnOffset] = Addressing.fromWire(this.indirect).resolve([this.returnOffset], context.machineState.memory);
+  public async execute(context: AvmContext): Promise<void> {
+    const memoryOperations = { reads: this.retSize, indirect: this.indirect };
+    const memory = context.machineState.memory.track(this.type);
+    context.machineState.consumeGas(this.gasCost(memoryOperations));
 
-    const output = context.machineState.memory.getSlice(returnOffset, this.retSize).map(word => word.toFr());
+    const [returnOffset] = Addressing.fromWire(this.indirect).resolve([this.returnOffset], memory);
+
+    const output = memory.getSlice(returnOffset, this.retSize).map(word => word.toFr());
 
     context.machineState.revert(output);
+    memory.assert(memoryOperations);
   }
 }

--- a/yarn-project/simulator/src/avm/opcodes/instruction_impl.ts
+++ b/yarn-project/simulator/src/avm/opcodes/instruction_impl.ts
@@ -1,19 +1,32 @@
 import { OperandType } from '../serialization/instruction_serialization.js';
 import { Instruction } from './instruction.js';
 
+/** Wire format that informs deserialization for instructions with two operands. */
+export const TwoOperandWireFormat = [
+  OperandType.UINT8,
+  OperandType.UINT8,
+  OperandType.UINT8,
+  OperandType.UINT32,
+  OperandType.UINT32,
+];
+
+/** Wire format that informs deserialization for instructions with three operands. */
+export const ThreeOperandWireFormat = [
+  OperandType.UINT8,
+  OperandType.UINT8,
+  OperandType.UINT8,
+  OperandType.UINT32,
+  OperandType.UINT32,
+  OperandType.UINT32,
+];
+
 /**
  * Covers (de)serialization for an instruction with:
  * indirect, inTag, and two UINT32s.
  */
 export abstract class TwoOperandInstruction extends Instruction {
   // Informs (de)serialization. See Instruction.deserialize.
-  static readonly wireFormat: OperandType[] = [
-    OperandType.UINT8,
-    OperandType.UINT8,
-    OperandType.UINT8,
-    OperandType.UINT32,
-    OperandType.UINT32,
-  ];
+  static readonly wireFormat: OperandType[] = TwoOperandWireFormat;
 
   constructor(
     protected indirect: number,
@@ -31,14 +44,7 @@ export abstract class TwoOperandInstruction extends Instruction {
  */
 export abstract class ThreeOperandInstruction extends Instruction {
   // Informs (de)serialization. See Instruction.deserialize.
-  static readonly wireFormat: OperandType[] = [
-    OperandType.UINT8,
-    OperandType.UINT8,
-    OperandType.UINT8,
-    OperandType.UINT32,
-    OperandType.UINT32,
-    OperandType.UINT32,
-  ];
+  static readonly wireFormat: OperandType[] = ThreeOperandWireFormat;
 
   constructor(
     protected indirect: number,


### PR DESCRIPTION
Tracks gas usage for all AVM instructions based on memory consumption. Adds an optional wrapper for TaggedMemory (enabled on test only) that tracks all memory reads and writes to validate that the number of memory operations charged match the actual ones.

Replaces existing #5514 and #5518 in favor of a more explicit approach, at the expense of more duplicated code in each instruction, but flattening the instruction hierarchy.

Closes #5518 
Closes #5514 