### PR TITLE
feat: logging deployed contract address to help debug e2e account test

### DIFF
--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -169,7 +169,11 @@ export class DeployMethod<TContract extends ContractBase = Contract> extends Bas
    */
   public send(options: DeployOptions = {}): DeploySentTx<TContract> {
     const txHashPromise = super.send(options).getTxHash();
-    return new DeploySentTx(this.pxe, txHashPromise, this.postDeployCtor, this.getInstance(options));
+    const instance = this.getInstance(options);
+    this.log(
+      `Sent deployment tx of ${this.artifact.name} contract with deployment address ${instance.address.toString()}`,
+    );
+    return new DeploySentTx(this.pxe, txHashPromise, this.postDeployCtor, instance);
   }
 
   /**

--- a/yarn-project/aztec.js/src/contract/deploy_sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_sent_tx.ts
@@ -1,5 +1,6 @@
 import { type PXE, type TxHash, type TxReceipt } from '@aztec/circuit-types';
 import { type AztecAddress } from '@aztec/circuits.js';
+import { createDebugLogger } from '@aztec/foundation/log';
 import { type FieldsOf } from '@aztec/foundation/types';
 import { type ContractInstanceWithAddress } from '@aztec/types/contracts';
 
@@ -24,6 +25,8 @@ export type DeployTxReceipt<TContract extends ContractBase = Contract> = FieldsO
  * A contract deployment transaction sent to the network, extending SentTx with methods to create a contract instance.
  */
 export class DeploySentTx<TContract extends Contract = Contract> extends SentTx {
+  private log = createDebugLogger('aztec:js:deploy_sent_tx');
+
   constructor(
     wallet: PXE | Wallet,
     txHashPromise: Promise<TxHash>,
@@ -41,6 +44,7 @@ export class DeploySentTx<TContract extends Contract = Contract> extends SentTx 
    */
   public async deployed(opts?: DeployedWaitOpts): Promise<TContract> {
     const receipt = await this.wait(opts);
+    this.log(`Contract ${this.instance.address.toString()} successfully deployed.`);
     return receipt.contract;
   }
 

--- a/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
+++ b/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
@@ -6,6 +6,7 @@ import {
   AccountManager,
   AccountWallet,
   type CompleteAddress,
+  type DebugLogger,
   Fr,
   type GrumpkinPrivateKey,
   GrumpkinScalar,
@@ -27,29 +28,31 @@ function itShouldBehaveLikeAnAccountContract(
   walletAt: (pxe: PXE, accountContract: AccountContract, address: CompleteAddress) => Promise<Wallet>,
 ) {
   describe(`behaves like an account contract`, () => {
-    let context: Awaited<ReturnType<typeof setup>>;
     let child: ChildContract;
     let wallet: Wallet;
     let encryptionPrivateKey: GrumpkinPrivateKey;
 
+    let pxe: PXE;
+    let logger: DebugLogger;
+    let teardown: () => Promise<void>;
+
     beforeEach(async () => {
-      context = await setup(0);
+      ({ logger, pxe, teardown } = await setup(0));
       encryptionPrivateKey = GrumpkinScalar.random();
 
-      wallet = await walletSetup(context.pxe, encryptionPrivateKey, getAccountContract(encryptionPrivateKey));
+      wallet = await walletSetup(pxe, encryptionPrivateKey, getAccountContract(encryptionPrivateKey));
       child = await ChildContract.deploy(wallet).send().deployed();
+      logger(`Deployed child contract at ${child.address}.`);
     }, 60_000);
 
-    afterEach(() => context.teardown());
+    afterEach(() => teardown());
 
     it('calls a private function', async () => {
-      const { logger } = context;
       logger('Calling private function...');
       await child.methods.value(42).send().wait({ interval: 0.1 });
     }, 60_000);
 
     it('calls a public function', async () => {
-      const { logger, pxe } = context;
       logger('Calling public function...');
       await child.methods.pub_inc_value(42).send().wait({ interval: 0.1 });
       const storedValue = await pxe.getPublicStorageAt(child.address, new Fr(1));
@@ -58,7 +61,7 @@ function itShouldBehaveLikeAnAccountContract(
 
     it('fails to call a function using an invalid signature', async () => {
       const accountAddress = wallet.getCompleteAddress();
-      const invalidWallet = await walletAt(context.pxe, getAccountContract(GrumpkinScalar.random()), accountAddress);
+      const invalidWallet = await walletAt(pxe, getAccountContract(GrumpkinScalar.random()), accountAddress);
       const childWithInvalidWallet = await ChildContract.at(child.address, invalidWallet);
       await expect(childWithInvalidWallet.methods.value(42).prove()).rejects.toThrow(/Cannot satisfy constraint.*/);
     });

--- a/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
+++ b/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
@@ -42,7 +42,7 @@ function itShouldBehaveLikeAnAccountContract(
 
       wallet = await walletSetup(pxe, encryptionPrivateKey, getAccountContract(encryptionPrivateKey));
       child = await ChildContract.deploy(wallet).send().deployed();
-      logger(`Deployed child contract at ${child.address}.`);
+      logger(`Deployed Child contract at ${child.address}.`);
     }, 60_000);
 
     afterEach(() => teardown());

--- a/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
+++ b/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
@@ -42,7 +42,6 @@ function itShouldBehaveLikeAnAccountContract(
 
       wallet = await walletSetup(pxe, encryptionPrivateKey, getAccountContract(encryptionPrivateKey));
       child = await ChildContract.deploy(wallet).send().deployed();
-      logger(`Deployed Child contract at ${child.address}.`);
     }, 60_000);
 
     afterEach(() => teardown());


### PR DESCRIPTION
I added these logs to help determine which contract which fails to be registered in the PXE db.
