### PR TITLE
fix: mainnet fork redeploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1244,7 +1244,7 @@ jobs:
             # Check if l1-contracts have changed
             if [ "$CONTRACTS_DEPLOYED" -eq 1 ]; then
               echo "Contracts have changed, taint nodes to force redeploy.."
-              deploy_terraform_services yarn-project/aztec-node aztec aztec-node "aws_ecs_task_definition.aztec-node[0],aws_ecs_task_definition.aztec-node[1]" 1
+              deploy_terraform_services yarn-project/aztec-node aztec aztec-node "aws_ecs_task_definition.aztec-node[0],aws_ecs_task_definition.aztec-node[1]"
             else
               deploy_terraform_services yarn-project/aztec-node aztec
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1183,6 +1183,11 @@ jobs:
             deploy_dockerhub aztec-faucet
             deploy_dockerhub mainnet-fork
       - run:
+          name: "Deploy mainnet fork"
+          command: |
+            should_deploy || exit 0
+            deploy_terraform_services iac/mainnet-fork
+      - run:
           name: "Release canary to NPM: bb.js"
           command: |
             should_release || exit 0
@@ -1213,11 +1218,6 @@ jobs:
             should_release || exit 0
             deploy_npm l1-contracts latest
       - run:
-          name: "Deploy mainnet fork"
-          command: |
-            should_deploy || exit 0
-            deploy_terraform_services iac/mainnet-fork mainnet-fork mainnet-fork aws_efs_file_system.aztec_mainnet_fork_data_store
-      - run:
           name: "Deploy L1 contracts to mainnet fork"
           working_directory: l1-contracts
           command: |
@@ -1244,7 +1244,7 @@ jobs:
             # Check if l1-contracts have changed
             if [ "$CONTRACTS_DEPLOYED" -eq 1 ]; then
               echo "Contracts have changed, taint nodes to force redeploy.."
-              deploy_terraform_services yarn-project/aztec-node aztec aztec-node "aws_ecs_task_definition.aztec-node[0],aws_ecs_task_definition.aztec-node[1]"
+              deploy_terraform_services yarn-project/aztec-node aztec aztec-node "aws_ecs_task_definition.aztec-node[0],aws_ecs_task_definition.aztec-node[1]" 1
             else
               deploy_terraform_services yarn-project/aztec-node aztec
             fi

--- a/iac/mainnet-fork/terraform/main.tf
+++ b/iac/mainnet-fork/terraform/main.tf
@@ -77,11 +77,16 @@ resource "aws_efs_file_system" "aztec_mainnet_fork_data_store" {
   creation_token = "${var.DEPLOY_TAG}-mainnet-fork-data"
 
   tags = {
-    Name = "${var.DEPLOY_TAG}-mainnet-fork-data"
+    Name              = "${var.DEPLOY_TAG}-mainnet-fork-data"
+    TaskDefinitionArn = "${aws_ecs_task_definition.aztec_mainnet_fork.arn}" # This line forces recreation on task definition change
   }
 
   lifecycle_policy {
     transition_to_ia = "AFTER_30_DAYS"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/l1-contracts/scripts/ci_deploy_contracts.sh
+++ b/l1-contracts/scripts/ci_deploy_contracts.sh
@@ -29,9 +29,15 @@ retry docker pull $CLI_IMAGE
 
 # remove 0x prefix from private key
 PRIVATE_KEY=${CONTRACT_PUBLISHER_PRIVATE_KEY#0x}
-retry docker run \
-  $CLI_IMAGE \
-  deploy-l1-contracts -u $ETHEREUM_HOST -p $PRIVATE_KEY | tee ./serve/contract_addresses.json
+
+# Retries up to 3 times with 10 second intervals
+ATTEMPTS=3
+for i in $(seq 1 $ATTEMPTS); do
+  docker run \
+    $CLI_IMAGE \
+    deploy-l1-contracts -u $ETHEREUM_HOST -p $PRIVATE_KEY | tee $FILE_PATH && break
+  [ "$i" != "$ATTEMPTS" ] && sleep 10
+done
 
 ## Result format is:
 # Rollup Address: 0xe33d37702bb94e83ca09e7dc804c9f4c4ab8ee4a

--- a/l1-contracts/scripts/ci_deploy_contracts.sh
+++ b/l1-contracts/scripts/ci_deploy_contracts.sh
@@ -29,7 +29,7 @@ retry docker pull $CLI_IMAGE
 
 # remove 0x prefix from private key
 PRIVATE_KEY=${CONTRACT_PUBLISHER_PRIVATE_KEY#0x}
-docker run \
+retry docker run \
   $CLI_IMAGE \
   deploy-l1-contracts -u $ETHEREUM_HOST -p $PRIVATE_KEY | tee ./serve/contract_addresses.json
 


### PR DESCRIPTION
- Different way to 'taint' mainnet fork's EFS storage so it doesn't redeploy on every commit to `master`
- Deploy fork earlier to ensure availability
- retry runing `deploy-l1-contracts` command in case service is not available yet