### PR TITLE
feat: `add` and `sub` methods of `EasyPrivateUint` throw when called in public

### DIFF
--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -14,13 +14,14 @@ struct EasyPrivateUint {
 impl EasyPrivateUint {
     pub fn new(context: Context, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
-        assert(context.public.is_none(), "EasyPrivateUint can be initialized from private only.");
         let set = PrivateSet { context, storage_slot };
         EasyPrivateUint { context, set, storage_slot }
     }
 
     // Very similar to `value_note::utils::increment`.
     pub fn add(self, addend: u64, owner: AztecAddress) {
+        assert(self.context.public.is_none(), "EasyPrivateUint::add can be called from private only.");
+
         // Creates new note for the owner.
         let mut addend_note = ValueNote::new(addend as Field, owner);
 
@@ -32,6 +33,8 @@ impl EasyPrivateUint {
 
     // Very similar to `value_note::utils::decrement`.
     pub fn sub(self, subtrahend: u64, owner: AztecAddress) {
+        assert(self.context.public.is_none(), "EasyPrivateUint::sub can be called from private only.");
+
         // docs:start:get_notes
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, subtrahend as Field);
         let maybe_notes = self.set.get_notes(options);

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -14,6 +14,7 @@ struct EasyPrivateUint {
 impl EasyPrivateUint {
     pub fn new(context: Context, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
+        assert(context.public.is_none(), "EasyPrivateUint can be initialized from private only.");
         let set = PrivateSet { context, storage_slot };
         EasyPrivateUint { context, set, storage_slot }
     }


### PR DESCRIPTION
A user got confused when he tried to use EasyPrivateUint from public. This PR adds checks which throw understandable error when trying to do so.