### PR TITLE
fix(ci): Install fixed foundry version in CI

### DIFF
--- a/l1-contracts/Dockerfile
+++ b/l1-contracts/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -L https://foundry.paradigm.xyz | bash
 
 # Set env variables for foundry and venv
 ENV PATH="${PATH}:/root/.foundry/bin:/root/.venv/bin"
-RUN foundryup
+RUN foundryup --version nightly-de33b6af53005037b463318d2628b5cfcaf39916
 
 WORKDIR /usr/src/l1-contracts
 COPY . .

--- a/l1-contracts/Earthfile
+++ b/l1-contracts/Earthfile
@@ -9,7 +9,7 @@ RUN curl -L https://foundry.paradigm.xyz | bash
 
 # Set env variables for foundry and venv
 ENV PATH="${PATH}:/root/.foundry/bin:/root/.venv/bin"
-RUN foundryup
+RUN foundryup --version nightly-de33b6af53005037b463318d2628b5cfcaf39916
 
 # Install yarn and solhint.
 RUN npm install --global yarn solhint


### PR DESCRIPTION
We were using different foundry versions locally and on CI. This was the cause of CI errors since formatting didn't match between our pinned version locally and the one run on CI.