### PR TITLE
feat(avm): add Header to AvmExecutionEnvironment

### DIFF
--- a/yarn-project/simulator/src/avm/avm_execution_environment.ts
+++ b/yarn-project/simulator/src/avm/avm_execution_environment.ts
@@ -1,4 +1,4 @@
-import { FunctionSelector, type GlobalVariables } from '@aztec/circuits.js';
+import { FunctionSelector, type GlobalVariables, type Header } from '@aztec/circuits.js';
 import { computeVarArgsHash } from '@aztec/circuits.js/hash';
 import { type AztecAddress } from '@aztec/foundation/aztec-address';
 import { type EthAddress } from '@aztec/foundation/eth-address';
@@ -22,29 +22,18 @@ export class AvmContextInputs {
 export class AvmExecutionEnvironment {
   constructor(
     public readonly address: AztecAddress,
-
     public readonly storageAddress: AztecAddress,
-
     public readonly origin: AztecAddress,
-
     public readonly sender: AztecAddress,
-
     public readonly portal: EthAddress,
-
     public readonly feePerL1Gas: Fr,
-
     public readonly feePerL2Gas: Fr,
-
     public readonly feePerDaGas: Fr,
-
     public readonly contractCallDepth: Fr,
-
+    public readonly header: Header,
     public readonly globals: GlobalVariables,
-
     public readonly isStaticCall: boolean,
-
     public readonly isDelegateCall: boolean,
-
     public readonly calldata: Fr[],
 
     // Function selector is temporary since eventually public contract bytecode will be one blob
@@ -73,6 +62,7 @@ export class AvmExecutionEnvironment {
       this.feePerL2Gas,
       this.feePerDaGas,
       this.contractCallDepth,
+      this.header,
       this.globals,
       this.isStaticCall,
       this.isDelegateCall,
@@ -96,6 +86,7 @@ export class AvmExecutionEnvironment {
       this.feePerL2Gas,
       this.feePerDaGas,
       this.contractCallDepth,
+      this.header,
       this.globals,
       /*isStaticCall=*/ true,
       this.isDelegateCall,
@@ -119,6 +110,7 @@ export class AvmExecutionEnvironment {
       this.feePerL2Gas,
       this.feePerDaGas,
       this.contractCallDepth,
+      this.header,
       this.globals,
       this.isStaticCall,
       /*isDelegateCall=*/ true,

--- a/yarn-project/simulator/src/avm/fixtures/index.ts
+++ b/yarn-project/simulator/src/avm/fixtures/index.ts
@@ -1,5 +1,5 @@
 import { SiblingPath } from '@aztec/circuit-types';
-import { GlobalVariables, L1_TO_L2_MSG_TREE_HEIGHT } from '@aztec/circuits.js';
+import { GlobalVariables, Header, L1_TO_L2_MSG_TREE_HEIGHT } from '@aztec/circuits.js';
 import { FunctionSelector } from '@aztec/foundation/abi';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -67,6 +67,7 @@ export function initExecutionEnvironment(overrides?: Partial<AvmExecutionEnviron
     overrides?.feePerL2Gas ?? Fr.zero(),
     overrides?.feePerDaGas ?? Fr.zero(),
     overrides?.contractCallDepth ?? Fr.zero(),
+    overrides?.header ?? Header.empty(),
     overrides?.globals ?? GlobalVariables.empty(),
     overrides?.isStaticCall ?? false,
     overrides?.isDelegateCall ?? false,

--- a/yarn-project/simulator/src/avm/temporary_executor_migration.ts
+++ b/yarn-project/simulator/src/avm/temporary_executor_migration.ts
@@ -4,6 +4,7 @@ import {
   ContractStorageRead,
   ContractStorageUpdateRequest,
   type GlobalVariables,
+  type Header,
   L2ToL1Message,
   type ReadRequest,
   SideEffect,
@@ -28,6 +29,7 @@ import { Mov } from './opcodes/memory.js';
  */
 export function temporaryCreateAvmExecutionEnvironment(
   current: PublicExecution,
+  header: Header,
   globalVariables: GlobalVariables,
 ): AvmExecutionEnvironment {
   // Function selector is included temporarily until noir codegens public contract bytecode in a single blob
@@ -41,6 +43,7 @@ export function temporaryCreateAvmExecutionEnvironment(
     /*feePerL2Gas=*/ Fr.zero(),
     /*feePerDaGas=*/ Fr.zero(),
     /*contractCallDepth=*/ Fr.zero(),
+    header,
     globalVariables,
     current.callContext.isStaticCall,
     current.callContext.isDelegateCall,

--- a/yarn-project/simulator/src/public/executor.ts
+++ b/yarn-project/simulator/src/public/executor.ts
@@ -254,7 +254,7 @@ export class PublicExecutor {
     // These data structures will permeate across the simulator when the public executor is phased out
     const hostStorage = new HostStorage(this.stateDb, this.contractsDb, this.commitmentsDb);
     const worldStateJournal = new AvmPersistableStateManager(hostStorage);
-    const executionEnv = temporaryCreateAvmExecutionEnvironment(execution, globalVariables);
+    const executionEnv = temporaryCreateAvmExecutionEnvironment(execution, this.header, globalVariables);
     // TODO(@spalladino) Load initial gas from the public execution request
     const machineState = new AvmMachineState(1e10, 1e10, 1e10);
 


### PR DESCRIPTION
This is not currently used in the AVM-simulator, but it's needed to have interoperability with the ACVM. In any case, we might use it for HEADERMEMBER.