### PR TITLE
feat: Use bbs sha256.

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/sha256/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/sha256/c_bind.cpp
@@ -1,17 +1,17 @@
+#include "barretenberg/common/serialize.hpp"
 #include "barretenberg/common/wasm_export.hpp"
 #include "sha256.hpp"
 
 using namespace bb;
 
-WASM_EXPORT void sha256__hash(uint8_t* in, const size_t length, uint8_t* r)
+WASM_EXPORT void sha256__hash(uint8_t const* in, uint32_t const* length_ptr, out_buf32 r)
 {
+    auto length = ntohl(*length_ptr);
     std::vector<uint8_t> message;
     message.reserve(length);
     for (size_t i = 0; i < length; ++i) {
         message.emplace_back(in[i]);
     }
     const auto output = crypto::sha256(message);
-    for (size_t i = 0; i < 32; ++i) {
-        r[i] = output[i];
-    }
+    std::copy(output.begin(), output.end(), r);
 }

--- a/barretenberg/cpp/src/barretenberg/crypto/sha256/c_bind.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/sha256/c_bind.hpp
@@ -1,0 +1,5 @@
+#include "barretenberg/common/serialize.hpp"
+#include "barretenberg/common/wasm_export.hpp"
+#include <cstdint>
+
+WASM_EXPORT void sha256__hash(uint8_t const* input, uint32_t const* length_ptr, out_buf32 r);

--- a/barretenberg/exports.json
+++ b/barretenberg/exports.json
@@ -140,6 +140,26 @@
     "isAsync": false
   },
   {
+    "functionName": "sha256__hash",
+    "inArgs": [
+      {
+        "name": "input",
+        "type": "const uint8_t *"
+      },
+      {
+        "name": "length_ptr",
+        "type": "const uint32_t *"
+      }
+    ],
+    "outArgs": [
+      {
+        "name": "r",
+        "type": "out_buf32"
+      }
+    ],
+    "isAsync": false
+  },
+  {
     "functionName": "schnorr_compute_public_key",
     "inArgs": [
       {

--- a/barretenberg/scripts/c_bind_files.txt
+++ b/barretenberg/scripts/c_bind_files.txt
@@ -2,6 +2,7 @@
 ./cpp/src/barretenberg/crypto/pedersen_hash/c_bind.hpp
 ./cpp/src/barretenberg/crypto/poseidon2/c_bind.hpp
 ./cpp/src/barretenberg/crypto/blake2s/c_bind.hpp
+./cpp/src/barretenberg/crypto/sha256/c_bind.hpp
 ./cpp/src/barretenberg/crypto/schnorr/c_bind.hpp
 ./cpp/src/barretenberg/crypto/aes128/c_bind.hpp
 ./cpp/src/barretenberg/srs/c_bind.hpp

--- a/barretenberg/ts/src/barretenberg/sha256.test.ts
+++ b/barretenberg/ts/src/barretenberg/sha256.test.ts
@@ -1,0 +1,43 @@
+import { BarretenbergSync } from './index.js';
+import { Timer } from '../benchmark/timer.js';
+import { RawBuffer } from '../types/index.js';
+import { randomBytes } from '../random/index.js';
+import { createHash } from 'crypto';
+
+describe('sha256 sync', () => {
+  let api: BarretenbergSync;
+
+  beforeAll(async () => {
+    api = await BarretenbergSync.new();
+  });
+
+  it('sha256', () => {
+    const data = randomBytes(67);
+    const expected = createHash('sha256').update(data).digest();
+    const result = Buffer.from(api.sha256Hash(new RawBuffer(data), data.length).toBuffer());
+    expect(result).toEqual(expected);
+  });
+
+  it('sha256 perf test', () => {
+    const loops = 1024;
+    const data = randomBytes(67);
+
+    const t1 = new Timer();
+    for (let i = 0; i < loops; ++i) {
+      createHash('sha256').update(data).digest();
+    }
+    const jsMs = t1.ms();
+
+    const t2 = new Timer();
+    for (let i = 0; i < loops; ++i) {
+      api.sha256Hash(new RawBuffer(data), data.length);
+    }
+    const wasmMs = t2.ms();
+
+    console.log(
+      `Executed ${loops} hashes at an average ${wasmMs.toFixed(2)}ms / hash. (${((wasmMs / jsMs) * 100).toFixed(
+        2,
+      )}% faster than js.)`,
+    );
+  });
+});

--- a/barretenberg/ts/src/barretenberg_api/index.ts
+++ b/barretenberg/ts/src/barretenberg_api/index.ts
@@ -111,6 +111,18 @@ export class BarretenbergApi {
     return out[0];
   }
 
+  async sha256Hash(input: Uint8Array, lengthPtr: number): Promise<Buffer32> {
+    const inArgs = [input, lengthPtr].map(serializeBufferable);
+    const outTypes: OutputType[] = [Buffer32];
+    const result = await this.wasm.callWasmExport(
+      'sha256__hash',
+      inArgs,
+      outTypes.map(t => t.SIZE_IN_BYTES),
+    );
+    const out = result.map((r, i) => outTypes[i].fromBuffer(r));
+    return out[0];
+  }
+
   async schnorrComputePublicKey(privateKey: Fr): Promise<Point> {
     const inArgs = [privateKey].map(serializeBufferable);
     const outTypes: OutputType[] = [Point];
@@ -648,6 +660,18 @@ export class BarretenbergApiSync {
     const outTypes: OutputType[] = [Fr];
     const result = this.wasm.callWasmExport(
       'blake2s_to_field_',
+      inArgs,
+      outTypes.map(t => t.SIZE_IN_BYTES),
+    );
+    const out = result.map((r, i) => outTypes[i].fromBuffer(r));
+    return out[0];
+  }
+
+  sha256Hash(input: Uint8Array, lengthPtr: number): Buffer32 {
+    const inArgs = [input, lengthPtr].map(serializeBufferable);
+    const outTypes: OutputType[] = [Buffer32];
+    const result = this.wasm.callWasmExport(
+      'sha256__hash',
       inArgs,
       outTypes.map(t => t.SIZE_IN_BYTES),
     );

--- a/yarn-project/foundation/src/crypto/sha256/index.test.ts
+++ b/yarn-project/foundation/src/crypto/sha256/index.test.ts
@@ -3,7 +3,7 @@ import { createHash, randomBytes } from 'crypto';
 import { sha256 } from './index.js';
 
 describe('sha256', () => {
-  it('should correctly hash data using hash.js', () => {
+  it('should correctly hash data', () => {
     const data = randomBytes(67);
 
     const expected = createHash('sha256').update(data).digest();

--- a/yarn-project/foundation/src/crypto/sha256/index.ts
+++ b/yarn-project/foundation/src/crypto/sha256/index.ts
@@ -1,10 +1,12 @@
-import { default as hash } from 'hash.js';
+import { BarretenbergSync, RawBuffer } from '@aztec/bb.js';
 
 import { Fr } from '../../fields/fields.js';
 import { truncateAndPad } from '../../serialize/free_funcs.js';
 import { type Bufferable, serializeToBuffer } from '../../serialize/serialize.js';
 
-export const sha256 = (data: Buffer) => Buffer.from(hash.sha256().update(data).digest());
+export function sha256(data: Buffer) {
+  return Buffer.from(BarretenbergSync.getSingleton().sha256Hash(new RawBuffer(data), data.length).toBuffer());
+}
 
 export const sha256Trunc = (data: Buffer) => truncateAndPad(sha256(data));
 


### PR DESCRIPTION
Profiling a tx I noticed ~10% of time was taken inside sha256.
Our wasm version is about 3x faster (edit: no it isn't) so seemed like an easy performance win.
Not sure it'll translate that much into a noticeable performance improvement but every little helps.

edit: NOPE. I read the data wrong, wasm is actually 3x slower. Think due the various marshalling over the wasm boundary. Might be fixable but would then prob achieve parity with js version. Not a quick win. Closing.

![image](https://github.com/AztecProtocol/aztec-packages/assets/5764343/ec0305e2-7633-43f1-a4c4-e75f070c1230)

