### PR TITLE
fix: use empty artifact in test

### DIFF
--- a/yarn-project/circuits.js/src/contract/artifact_hash.test.ts
+++ b/yarn-project/circuits.js/src/contract/artifact_hash.test.ts
@@ -1,11 +1,20 @@
-import { getBenchmarkContractArtifact } from '../tests/fixtures.js';
+import { type ContractArtifact } from '@aztec/foundation/abi';
+
 import { computeArtifactHash } from './artifact_hash.js';
 
 describe('ArtifactHash', () => {
   it('calculates the artifact hash', () => {
-    const artifact = getBenchmarkContractArtifact();
-    expect(computeArtifactHash(artifact).toString()).toMatchInlineSnapshot(
-      `"0x077417e7303df9113d0d0947b9dc8a06903cd8aa963a31891e2f28ce121d753e"`,
+    const emptyArtifact: ContractArtifact = {
+      fileMap: [],
+      functions: [],
+      name: 'Test',
+      outputs: {
+        globals: {},
+        structs: {},
+      },
+    };
+    expect(computeArtifactHash(emptyArtifact).toString()).toMatchInlineSnapshot(
+      `"0x0dea64e7fa0688017f77bcb7075485485afb4a5f1f8508483398869439f82fdf"`,
     );
   });
 });


### PR DESCRIPTION
This PR replaces the benchmark artifact used in the artifact_hash test with an empty artifact.
