### PR TITLE
fix: watch less files.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -160,5 +160,14 @@
     "noir/noir-repo/Cargo.toml",
     "noir/noir-repo/acvm-repo/acvm_js/Cargo.toml",
     "avm-transpiler/Cargo.toml"
-  ]
+  ],
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true,
+    "**/node_modules/*/**": true,
+    "**/.hg/store/**": true,
+    "**/target/**": true,
+    "**/l1-contracts/lib/**": true,
+    "**/barretenberg/cpp/build*/**": true
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -164,7 +164,7 @@
   "files.watcherExclude": {
     "**/.git/objects/**": true,
     "**/.git/subtree-cache/**": true,
-    "**/node_modules/*/**": true,
+    "**/node_modules/**": true,
     "**/.hg/store/**": true,
     "**/target/**": true,
     "**/l1-contracts/lib/**": true,


### PR DESCRIPTION
Some users are running into "too many watched files" errors.
Mainframe has already had its watch limits raised to 1m.
Think i've identified a few troublesome folders. This PR tells vscode to stop watching so many files.
You can get an idea of how many files you're watching (on linux) using:
```
grep inotify /proc/*/fdinfo/* 2>/dev/null| wc -l 
```

This took me from 90k to about 10k after restarting vscode server (not sure if i needed to kill the server, but think i did).
To kill server run in your sysbox (save and quit vscode first):
```
pkill -f '.vscode-server'
```