### PR TITLE
chore: small logging changes

### DIFF
--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src \"!src/web/main.js\" && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "LOG_LEVEL=verbose NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --runInBand --testTimeout=60000 --forceExit",
+    "test": "LOG_LEVEL=${LOG_LEVEL:-verbose} NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --runInBand --testTimeout=60000 --forceExit",
     "test:integration": "concurrently -k -s first -c reset,dim -n test,anvil \"yarn test:integration:run\" \"anvil\"",
     "test:integration:run": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --no-cache --runInBand --config jest.integration.config.json"
   },

--- a/yarn-project/end-to-end/package.local.json
+++ b/yarn-project/end-to-end/package.local.json
@@ -2,6 +2,6 @@
   "scripts": {
     "build": "yarn clean && tsc -b && webpack",
     "formatting": "run -T prettier --check ./src \"!src/web/main.js\" && run -T eslint ./src",
-    "test": "LOG_LEVEL=verbose NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --runInBand --testTimeout=60000 --forceExit"
+    "test": "LOG_LEVEL=${LOG_LEVEL:-verbose} NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --runInBand --testTimeout=60000 --forceExit"
   }
 }

--- a/yarn-project/simulator/src/acvm/acvm.ts
+++ b/yarn-project/simulator/src/acvm/acvm.ts
@@ -95,7 +95,7 @@ export async function acvm(
     initialWitness,
     async (name: string, args: ForeignCallInput[]) => {
       try {
-        logger.verbose(`Oracle callback ${name}`);
+        logger.debug(`Oracle callback ${name}`);
         const oracleFunction = callback[name as ORACLE_NAMES];
         if (!oracleFunction) {
           throw new Error(`Oracle callback ${name} not found`);

--- a/yarn-project/simulator/src/avm/avm_memory_types.ts
+++ b/yarn-project/simulator/src/avm/avm_memory_types.ts
@@ -240,7 +240,7 @@ export class TaggedMemory implements TaggedMemoryInterface {
     const word = this._mem[offset];
     TaggedMemory.log.debug(`get(${offset}) = ${word}`);
     if (word === undefined) {
-      TaggedMemory.log.warn(`Memory at offset ${offset} is undefined! This might be OK if it's stack dumping.`);
+      TaggedMemory.log.debug(`WARNING: Memory at offset ${offset} is undefined!`);
     }
     return word as T;
   }

--- a/yarn-project/simulator/src/avm/avm_simulator.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.ts
@@ -62,7 +62,7 @@ export class AvmSimulator {
         );
 
         const gasLeft = `l1=${machineState.l1GasLeft} l2=${machineState.l2GasLeft} da=${machineState.daGasLeft}`;
-        this.log.debug(`@${machineState.pc} (${gasLeft}) ${instruction.toString()}`);
+        this.log.debug(`@${machineState.pc} ${instruction.toString()} (${gasLeft})`);
         // Execute the instruction.
         // Normal returns and reverts will return normally here.
         // "Exceptional halts" will throw.

--- a/yarn-project/simulator/src/public/executor.ts
+++ b/yarn-project/simulator/src/public/executor.ts
@@ -75,7 +75,9 @@ async function executePublicFunctionAvm(executionContext: PublicExecutionContext
   const result = await simulator.execute();
   const newWorldState = context.persistableState.flush();
 
-  log.verbose(`[AVM] ${address.toString()}:${selector} returned, reverted: ${result.reverted}.`);
+  log.verbose(
+    `[AVM] ${address.toString()}:${selector} returned, reverted: ${result.reverted}, reason: ${result.revertReason}.`,
+  );
 
   // TODO(@spalladino) Read gas left from machineState and return it
   return await convertAvmResults(executionContext, newWorldState, result);


### PR DESCRIPTION
* Use environment LOG_LEVEL if defined, otherwise verbose (this lets you run `LOG_LEVEL=sth yarn test src/e2e_test`)
* Small changes and additions of logging to AVM/public.