### PR TITLE
feat: separate nullfier_inclusion checks for private/public/avm

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/avm_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/avm_context.nr
@@ -52,9 +52,6 @@ impl AvmContext {
     pub fn l1_to_l2_msg_exists(self, msg_hash: Field, msg_leaf_index: Field) -> bool {
         l1_to_l2_msg_exists(msg_hash, msg_leaf_index) == 1
     }
-    pub fn nullifier_exists(self, nullifier: Field) -> bool {
-        nullifier_exists(nullifier) == 1
-    }
 
     fn call_public_function_raw<ARGS_COUNT, RET_COUNT>(
         self: &mut Self,
@@ -104,6 +101,10 @@ impl PublicContextInterface for AvmContext {
     fn fee_recipient(self) -> AztecAddress {
         assert(false, "'fee_recipient' not implemented!");
         AztecAddress::zero()
+    }
+
+    fn nullifier_exists(self, nullifier: Field) -> bool {
+        nullifier_exists(nullifier) == 1
     }
 
     fn push_nullifier_read_request(&mut self, nullifier: Field) {

--- a/noir-projects/aztec-nr/aztec/src/context/interface.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/interface.nr
@@ -52,4 +52,5 @@ trait PublicContextInterface {
         function_selector: FunctionSelector,
         args: [Field; ARGS_COUNT]
     ) -> [Field; RETURN_VALUES_LENGTH];
+    fn nullifier_exists(self, nullifier: Field) -> bool;
 }

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -220,6 +220,10 @@ impl PublicContextInterface for PublicContext {
         self.inputs.public_global_variables.fee_recipient
     }
 
+    fn nullifier_exists(self, nullifier: Field) -> bool {
+        nullifier_exists_oracle(nullifier) == 1
+    }
+
     fn push_nullifier_read_request(&mut self, nullifier: Field) {
         let request = ReadRequest { value: nullifier, counter: self.side_effect_counter };
         self.nullifier_read_requests.push(request);
@@ -302,3 +306,6 @@ impl PublicContextInterface for PublicContext {
         self.call_public_function_with_packed_args(contract_address, function_selector, args_hash, false, true)
     }
 }
+
+#[oracle(checkNullifierExists)]
+fn nullifier_exists_oracle(nullifier: Field) -> Field {}

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion.nr
@@ -2,8 +2,7 @@ use dep::std::merkle::compute_merkle_root;
 use dep::protocol_types::header::Header;
 
 use crate::{
-    context::{PrivateContext, ContextInterface},
-    oracle::get_nullifier_membership_witness::get_nullifier_membership_witness,
+    context::PrivateContext, oracle::get_nullifier_membership_witness::get_nullifier_membership_witness,
     note::{utils::compute_siloed_nullifier, note_interface::NoteInterface}
 };
 
@@ -26,10 +25,7 @@ fn _nullifier_inclusion(nullifier: Field, header: Header) {
     //     was included in the nullifier tree.
 }
 
-pub fn prove_nullifier_inclusion<TContext>(
-    nullifier: Field,
-    context: TContext
-) where TContext: ContextInterface {
+pub fn prove_nullifier_inclusion(nullifier: Field, context: PrivateContext) {
     _nullifier_inclusion(nullifier, context.get_header());
 }
 

--- a/noir-projects/aztec-nr/aztec/src/initializer.nr
+++ b/noir-projects/aztec-nr/aztec/src/initializer.nr
@@ -29,14 +29,14 @@ fn mark_as_initialized<TContext>(context: &mut TContext) where TContext: Context
 
 pub fn assert_is_initialized_public(context: &mut PublicContext) {
     let init_nullifier = compute_contract_initialization_nullifier(context.this_address());
-    prove_nullifier_inclusion(init_nullifier, *context);
+    assert(context.nullifier_exists(init_nullifier), "Not initialized");
 }
 
 pub fn assert_is_initialized_avm(context: &mut AvmContext) {
     // WARNING: the AVM always expects UNSILOED nullifiers!
     // TODO(fcarreiro@): Change current private/public to take unsiloed nullifiers and an address.
     let init_nullifier = compute_unsiloed_contract_initialization_nullifier(context.this_address());
-    assert(context.nullifier_exists(init_nullifier));
+    assert(context.nullifier_exists(init_nullifier), "Not initialized");
 }
 
 pub fn assert_is_initialized_private(context: &mut PrivateContext) {

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -141,9 +141,11 @@ unconstrained pub fn get_notes<Note, N, M, S, NS>(
     placeholder_opt_notes
 }
 
+// Only ever use this in private!
 #[oracle(checkNullifierExists)]
 fn check_nullifier_exists_oracle(_inner_nullifier: Field) -> Field {}
 
+// Only ever use this in private!
 unconstrained pub fn check_nullifier_exists(inner_nullifier: Field) -> bool {
     check_nullifier_exists_oracle(inner_nullifier) == 1
 }

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -199,7 +199,7 @@ contract AvmTest {
     fn assert_unsiloed_nullifier_acvm(nullifier: Field) {
         // ACVM requires siloed nullifier.
         let siloed_nullifier = silo_nullifier(context.this_address(), nullifier);
-        prove_nullifier_inclusion(siloed_nullifier, context);
+        assert(context.nullifier_exists(siloed_nullifier));
     }
 
     #[aztec(public-vm)]

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
@@ -201,7 +201,7 @@ contract InclusionProofs {
     // Proves nullifier existed at latest block
     #[aztec(public)]
     fn test_nullifier_inclusion_from_public(nullifier: Field) {
-        prove_nullifier_inclusion(nullifier, context);
+        assert(context.nullifier_exists(nullifier));
     }
 
     #[aztec(private)]

--- a/yarn-project/simulator/src/public/public_execution_context.ts
+++ b/yarn-project/simulator/src/public/public_execution_context.ts
@@ -250,6 +250,11 @@ export class PublicExecutionContext extends TypedOracle {
     return await this.commitmentsDb.getNullifierMembershipWitnessAtLatestBlock(nullifier);
   }
 
+  public async checkNullifierExists(nullifier: Fr): Promise<boolean> {
+    const witness = await this.commitmentsDb.getNullifierMembershipWitnessAtLatestBlock(nullifier);
+    return !!witness;
+  }
+
   public async getContractInstance(address: AztecAddress): Promise<ContractInstance> {
     // Note to AVM implementor: The wrapper of the oracle call get_contract_instance in aztec-nr
     // automatically checks that the returned instance is correct, by hashing it together back


### PR DESCRIPTION
* Public stops using/accepting a Header or blockNumber.
* I'm repurposing a `checkNullifierExists` oracle that was already defined in private/public.