### PR TITLE
fix: disable flakey vanilla recursion test

### DIFF
--- a/barretenberg/cpp/src/barretenberg/goblin/goblin_recursion.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin_recursion.test.cpp
@@ -36,7 +36,7 @@ class GoblinRecursionTests : public ::testing::Test {
  * @brief A full Goblin test that mimicks the basic aztec client architecture
  * @details
  */
-TEST_F(GoblinRecursionTests, Vanilla)
+TEST_F(GoblinRecursionTests, DISABLED_Vanilla)
 {
     Goblin goblin;
 

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin_recursion.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin_recursion.test.cpp
@@ -36,6 +36,8 @@ class GoblinRecursionTests : public ::testing::Test {
  * @brief A full Goblin test that mimicks the basic aztec client architecture
  * @details
  */
+// TODO fix with https://github.com/AztecProtocol/barretenberg/issues/930
+// intermittent failures, presumably due to uninitialized memory
 TEST_F(GoblinRecursionTests, DISABLED_Vanilla)
 {
     Goblin goblin;


### PR DESCRIPTION
TODO fix with https://github.com/AztecProtocol/barretenberg/issues/930
