### PR TITLE
refactor: replacing unsafe::zeroed()

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/globals/private_global_variables.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/globals/private_global_variables.nr
@@ -1,4 +1,4 @@
-use dep::protocol_types::traits::Serialize;
+use dep::protocol_types::traits::{Serialize, Empty};
 
 global PRIVATE_GLOBAL_VARIABLES_LENGTH: u64 = 2;
 
@@ -13,5 +13,14 @@ struct PrivateGlobalVariables {
 impl Serialize<PRIVATE_GLOBAL_VARIABLES_LENGTH> for PrivateGlobalVariables {
     fn serialize(self) -> [Field; PRIVATE_GLOBAL_VARIABLES_LENGTH] {
         [self.chain_id, self.version]
+    }
+}
+
+impl Empty for PrivateGlobalVariables {
+    fn empty() -> Self {
+        PrivateGlobalVariables {
+            chain_id: 0,
+            version: 0,
+        }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/context/inputs/private_context_inputs.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/inputs/private_context_inputs.nr
@@ -1,5 +1,6 @@
-use dep::protocol_types::{abis::call_context::CallContext, header::Header};
+use dep::protocol_types::{abis::call_context::CallContext, header::Header, traits::Empty};
 use crate::context::globals::private_global_variables::PrivateGlobalVariables;
+
 
 // PrivateContextInputs are expected to be provided to each private function
 // docs:start:private-context-inputs
@@ -10,3 +11,14 @@ struct PrivateContextInputs {
     start_side_effect_counter: u32,
 }
 // docs:end:private-context-inputs
+
+impl Empty for PrivateContextInputs {
+    fn empty() -> Self {
+        PrivateContextInputs {
+            call_context : CallContext::empty(),
+            historical_header: Header::empty(),
+            private_global_variables: PrivateGlobalVariables::empty(),
+            start_side_effect_counter: 0 as u32,
+        }
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/context/inputs/public_context_inputs.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/inputs/public_context_inputs.nr
@@ -1,6 +1,6 @@
 use crate::context::globals::public_global_variables::PublicGlobalVariables;
 
-use dep::protocol_types::{abis::call_context::CallContext, header::Header};
+use dep::protocol_types::{abis::call_context::CallContext, header::Header, traits::Empty};
 
 // PublicContextInputs are expected to be provided to each public function
 // docs:start:public-context-inputs
@@ -13,3 +13,14 @@ struct PublicContextInputs {
     start_side_effect_counter: u32,
 }
 // docs:end:public-context-inputs
+
+impl Empty for PublicContextInputs {
+    fn empty() -> Self {
+        PublicContextInputs {
+            call_context: CallContext::empty(),
+            historical_header: Header::empty(),
+            public_global_variables: PublicGlobalVariables::empty(),
+            start_side_effect_counter: 0 as u32,
+        }
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -28,7 +28,7 @@ use dep::protocol_types::{
 },
     contrakt::{storage_read::StorageRead, storage_update_request::StorageUpdateRequest},
     grumpkin_private_key::GrumpkinPrivateKey, header::Header,
-    messaging::l2_to_l1_message::L2ToL1Message, utils::reader::Reader, traits::{is_empty, Deserialize}
+    messaging::l2_to_l1_message::L2ToL1Message, utils::reader::Reader, traits::{is_empty, Deserialize, Empty}
 };
 
 // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1165)
@@ -528,6 +528,29 @@ impl PrivateContext {
         }
 
         self.public_call_stack_hashes.push(item.hash());
+    }
+}
+
+impl Empty for PrivateContext {
+    fn empty() -> Self {
+        PrivateContext {
+            inputs: PrivateContextInputs::empty(),
+            side_effect_counter: 0 as u32,
+            min_revertible_side_effect_counter: 0 as u32,
+            args_hash : 0,
+            return_hash : 0,
+            max_block_number: MaxBlockNumber::empty(),
+            note_hash_read_requests: BoundedVec::new(),
+            nullifier_read_requests: BoundedVec::new(),
+            nullifier_key_validation_requests: BoundedVec::new(),
+            new_note_hashes: BoundedVec::new(),
+            new_nullifiers: BoundedVec::new(),
+            private_call_stack_hashes : BoundedVec::new(),
+            public_call_stack_hashes : BoundedVec::new(),
+            new_l2_to_l1_msgs : BoundedVec::new(),
+            historical_header: Header::empty(),
+            nullifier_key: Option::none(),
+        }
     }
 }
 

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -130,7 +130,7 @@ impl PrivateContext {
             min_revertible_side_effect_counter,
             args_hash,
             return_hash: 0,
-            max_block_number: MaxBlockNumber::default(),
+            max_block_number: MaxBlockNumber::empty(),
             note_hash_read_requests: BoundedVec::new(),
             nullifier_read_requests: BoundedVec::new(),
             nullifier_key_validation_requests: BoundedVec::new(),

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -23,7 +23,7 @@ use dep::protocol_types::{
     MAX_NULLIFIER_READ_REQUESTS_PER_CALL, MAX_NULLIFIER_NON_EXISTENT_READ_REQUESTS_PER_CALL
 },
     contrakt::{storage_read::StorageRead, storage_update_request::StorageUpdateRequest}, header::Header,
-    messaging::l2_to_l1_message::L2ToL1Message, utils::reader::Reader, traits::Deserialize
+    messaging::l2_to_l1_message::L2ToL1Message, utils::reader::Reader, traits::{Deserialize, Empty}
 };
 
 struct PublicContext {
@@ -313,6 +313,29 @@ impl PublicContextInterface for PublicContext {
         let args_hash = hash_args_array(args);
         assert(args_hash == arguments::pack_arguments(args));
         self.call_public_function_with_packed_args(contract_address, function_selector, args_hash, false, true)
+    }
+}
+
+impl Empty for PublicContext {
+    fn empty() -> Self {
+        PublicContext {
+            inputs: PublicContextInputs::empty(),
+            side_effect_counter: 0 as u32,
+            args_hash : 0,
+            return_hash : 0,
+            nullifier_read_requests: BoundedVec::new(),
+            nullifier_non_existent_read_requests: BoundedVec::new(),
+            contract_storage_update_requests: BoundedVec::new(),
+            contract_storage_reads: BoundedVec::new(),
+            public_call_stack_hashes: BoundedVec::new(),
+            new_note_hashes: BoundedVec::new(),
+            new_nullifiers: BoundedVec::new(),
+            new_l2_to_l1_msgs: BoundedVec::new(),
+            unencrypted_logs_hash: 0,
+            unencrypted_logs_preimages_length: 0,
+            historical_header: Header::empty(),
+            prover_address: AztecAddress::zero(),
+        }
     }
 }
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/shared_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/shared_mutable.nr
@@ -116,7 +116,7 @@ mod test {
 
     fn create_context(block_number: Field, private: bool) -> Context {
         if private {
-            let mut private_context: PrivateContext = unsafe::zeroed();
+            let mut private_context = PrivateContext::empty();
             private_context.historical_header.global_variables.block_number = block_number;
             Context::private(&mut private_context)
         } else {

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/shared_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/shared_mutable.nr
@@ -91,7 +91,7 @@ impl<T, DELAY> SharedMutable<T, DELAY> {
 }
 
 mod test {
-    use dep::std::{unsafe, merkle::compute_merkle_root, test::OracleMock};
+    use dep::std::{merkle::compute_merkle_root, test::OracleMock};
 
     use crate::{
         context::{PublicContext, PrivateContext, Context},
@@ -120,7 +120,7 @@ mod test {
             private_context.historical_header.global_variables.block_number = block_number;
             Context::private(&mut private_context)
         } else {
-            let mut public_context: PublicContext = unsafe::zeroed();
+            let mut public_context = PublicContext::empty();
             public_context.inputs.public_global_variables.block_number = block_number;
             Context::public(&mut public_context)
         }

--- a/noir-projects/aztec-nr/tests/src/note_getter_test.nr
+++ b/noir-projects/aztec-nr/tests/src/note_getter_test.nr
@@ -10,7 +10,7 @@ use crate::mock::test_note::TestNote;
 
 #[test]
 fn sets_note_manually_and_fetches_it() {
-    let mut context: PrivateContext = dep::std::unsafe::zeroed();
+    let mut context = PrivateContext::empty();
     context.inputs.call_context.storage_contract_address = AztecAddress::from_field(69);
 
     let mut test_note = TestNote::new(1337);
@@ -28,7 +28,7 @@ fn sets_note_manually_and_fetches_it() {
 
 #[test(should_fail)]
 fn cannot_return_zero_notes() {
-    let mut context: PrivateContext = dep::std::unsafe::zeroed();
+    let mut context = PrivateContext::empty();
     let storage_slot: Field = 0;
     let mut opt_notes: [Option<TestNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
 
@@ -38,7 +38,7 @@ fn cannot_return_zero_notes() {
 
 #[test(should_fail)]
 fn mismatched_address() {
-    let mut context: PrivateContext = dep::std::unsafe::zeroed();
+    let mut context = PrivateContext::empty();
     context.inputs.call_context.storage_contract_address = AztecAddress::from_field(1);
 
     let storage_slot: Field = 0;
@@ -51,7 +51,7 @@ fn mismatched_address() {
 
 #[test(should_fail)]
 fn mismatched_storage_slot() {
-    let mut context: PrivateContext = dep::std::unsafe::zeroed();
+    let mut context = PrivateContext::empty();
     context.inputs.call_context.storage_contract_address = AztecAddress::from_field(1);
 
     let mut test_note = TestNote::new(1);
@@ -68,7 +68,7 @@ fn mismatched_storage_slot() {
 
 #[test(should_fail)]
 fn invalid_selector() {
-    let mut context: PrivateContext = dep::std::unsafe::zeroed();
+    let mut context = PrivateContext::empty();
     context.inputs.call_context.storage_contract_address = AztecAddress::from_field(1);
 
     let mut test_note = TestNote::new(1);
@@ -90,7 +90,7 @@ fn invalid_selector() {
 
 #[test(should_fail)]
 fn invalid_note_order() {
-    let mut context: PrivateContext = dep::std::unsafe::zeroed();
+    let mut context = PrivateContext::empty();
 
     let mut opt_notes: [Option<TestNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
     opt_notes[0] = Option::some(TestNote::new(1));
@@ -108,7 +108,7 @@ fn invalid_note_order() {
 
 #[test]
 fn sparse_notes_array() {
-    let mut context: PrivateContext = dep::std::unsafe::zeroed();
+    let mut context = PrivateContext::empty();
 
     let mut opt_notes: [Option<TestNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
     opt_notes[1] = Option::some(TestNote::new(0));

--- a/noir-projects/noir-protocol-circuits/crates/parity-lib/src/parity_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/parity-lib/src/parity_public_inputs.nr
@@ -1,7 +1,17 @@
-use dep::types::{mocked::AggregationObject};
+use dep::types::{mocked::AggregationObject, traits::Empty};
 
 struct ParityPublicInputs {
     aggregation_object: AggregationObject,
     sha_root: Field,
     converted_root: Field,
+}
+
+impl Empty for ParityPublicInputs {
+    fn empty() -> Self {
+        ParityPublicInputs {
+            aggregation_object: AggregationObject::empty(),
+            sha_root: 0,
+            converted_root: 0,
+        }
+    }
 }

--- a/noir-projects/noir-protocol-circuits/crates/parity-lib/src/root/root_parity_input.nr
+++ b/noir-projects/noir-protocol-circuits/crates/parity-lib/src/root/root_parity_input.nr
@@ -1,7 +1,19 @@
-use dep::types::mocked::Proof;
+use dep::types::{
+    mocked::Proof,
+    traits::Empty
+};
 use crate::parity_public_inputs::ParityPublicInputs;
 
 struct RootParityInput {
     proof: Proof,
     public_inputs: ParityPublicInputs,
+}
+
+impl Empty for RootParityInput {
+    fn empty() -> Self {
+        RootParityInput {
+            proof: Proof::empty(),
+            public_inputs: ParityPublicInputs::empty(),
+        }
+    }
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/kernel_circuit_public_inputs_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/kernel_circuit_public_inputs_composer.nr
@@ -1,5 +1,5 @@
 use crate::common;
-use dep::std::{cmp::Eq, option::Option, unsafe};
+use dep::std::{cmp::Eq, option::Option};
 use dep::reset_kernel_lib::{NullifierReadRequestHints, PrivateValidationRequestProcessor};
 use dep::types::{
     abis::{

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/kernel_circuit_public_inputs_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/kernel_circuit_public_inputs_composer.nr
@@ -40,7 +40,7 @@ impl KernelCircuitPublicInputsComposer {
         sorted_nullifiers_indexes: [u64; MAX_NEW_NULLIFIERS_PER_TX],
         transient_note_hash_index_hints: [u64; MAX_NEW_NULLIFIERS_PER_TX]
     ) -> Self {
-        let public_inputs: PrivateKernelCircuitPublicInputsBuilder = unsafe::zeroed();
+        let public_inputs = PrivateKernelCircuitPublicInputsBuilder::empty();
 
         KernelCircuitPublicInputsComposer {
             public_inputs,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_init.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_init.nr
@@ -1,5 +1,4 @@
 use crate::common;
-use dep::std::unsafe;
 use dep::types::{
     abis::{
     combined_constant_data::CombinedConstantData, private_kernel::private_call_data::PrivateCallData,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_init.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_init.nr
@@ -77,7 +77,7 @@ impl PrivateKernelInitCircuitPrivateInputs {
     }
 
     pub fn native_private_kernel_circuit_initial(self) -> PrivateKernelCircuitPublicInputs {
-        let mut public_inputs: PrivateKernelCircuitPublicInputsBuilder = unsafe::zeroed();
+        let mut public_inputs = PrivateKernelCircuitPublicInputsBuilder::empty();
 
         self.initialize_end_values(&mut public_inputs);
 

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_inner.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_inner.nr
@@ -27,7 +27,7 @@ impl PrivateKernelInnerCircuitPrivateInputs {
     }
 
     pub fn native_private_kernel_circuit_inner(self) -> PrivateKernelCircuitPublicInputs {
-        let mut public_inputs : PrivateKernelCircuitPublicInputsBuilder = unsafe::zeroed();
+        let mut public_inputs  = PrivateKernelCircuitPublicInputsBuilder::empty();
 
         common::validate_previous_kernel_values(self.previous_kernel.public_inputs.end);
 

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_inner.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_inner.nr
@@ -1,5 +1,4 @@
 use crate::common;
-use dep::std::unsafe;
 use dep::types::{
     abis::{
     kernel_data::PrivateKernelData, private_kernel::private_call_data::PrivateCallData,
@@ -73,7 +72,6 @@ mod tests {
         messaging::l2_to_l1_message::L2ToL1Message, utils::{arrays::array_length},
         tests::{private_call_data_builder::PrivateCallDataBuilder, fixture_builder::FixtureBuilder}
     };
-    use dep::std::unsafe;
 
     struct PrivateKernelInnerInputsBuilder {
         previous_kernel: FixtureBuilder,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
@@ -56,7 +56,6 @@ impl PrivateKernelTailCircuitPrivateInputs {
 }
 
 mod tests {
-    use dep::std::unsafe;
     use crate::private_kernel_tail::PrivateKernelTailCircuitPrivateInputs;
     use dep::reset_kernel_lib::{
         tests::nullifier_read_request_hints_builder::NullifierReadRequestHintsBuilder,
@@ -64,13 +63,14 @@ mod tests {
     };
     use dep::types::constants::{
         MAX_NOTE_HASH_READ_REQUESTS_PER_TX, MAX_NEW_NOTE_HASHES_PER_TX, MAX_NEW_NULLIFIERS_PER_TX,
-        MAX_NULLIFIER_READ_REQUESTS_PER_TX
+        MAX_NULLIFIER_READ_REQUESTS_PER_TX, MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_TX
     };
     use dep::types::{
         abis::{
         kernel_circuit_public_inputs::KernelCircuitPublicInputs, max_block_number::MaxBlockNumber,
         side_effect::{SideEffect, SideEffectLinkedToNoteHash, Ordered}
     },
+        grumpkin_private_key::GrumpkinPrivateKey,
         hash::{compute_note_hash_nonce, compute_unique_siloed_note_hash},
         tests::{fixture_builder::FixtureBuilder, sort::sort_get_sorted_hints},
         utils::{arrays::{array_eq, array_length}}, traits::{Empty, is_empty, is_empty_array}
@@ -163,7 +163,7 @@ mod tests {
                 sorted_new_nullifiers_indexes,
                 nullifier_read_request_hints: self.nullifier_read_request_hints_builder.to_hints(),
                 nullifier_commitment_hints: sorted_nullifier_commitment_hints,
-                master_nullifier_secret_keys: unsafe::zeroed()
+                master_nullifier_secret_keys: [GrumpkinPrivateKey::empty(); MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_TX]
             };
             kernel.native_private_kernel_circuit_tail()
         }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail_to_public.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail_to_public.nr
@@ -56,7 +56,6 @@ impl PrivateKernelTailToPublicCircuitPrivateInputs {
 }
 
 mod tests {
-    use dep::std::unsafe;
     use crate::private_kernel_tail_to_public::PrivateKernelTailToPublicCircuitPrivateInputs;
     use dep::reset_kernel_lib::{
         tests::nullifier_read_request_hints_builder::NullifierReadRequestHintsBuilder,
@@ -64,13 +63,14 @@ mod tests {
     };
     use dep::types::constants::{
         MAX_NOTE_HASH_READ_REQUESTS_PER_TX, MAX_NEW_NOTE_HASHES_PER_TX, MAX_NEW_NULLIFIERS_PER_TX,
-        MAX_NULLIFIER_READ_REQUESTS_PER_TX
+        MAX_NULLIFIER_READ_REQUESTS_PER_TX, MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_TX
     };
     use dep::types::{
         abis::{
         kernel_circuit_public_inputs::PublicKernelCircuitPublicInputs,
         side_effect::{SideEffect, SideEffectLinkedToNoteHash, Ordered}
     },
+        grumpkin_private_key::GrumpkinPrivateKey,
         hash::{compute_note_hash_nonce, compute_unique_siloed_note_hash},
         tests::{fixture_builder::FixtureBuilder, sort::sort_get_sorted_hints},
         utils::{arrays::{array_eq, array_length}}, traits::is_empty_array
@@ -170,7 +170,7 @@ mod tests {
                 sorted_new_nullifiers_indexes,
                 nullifier_read_request_hints: self.nullifier_read_request_hints_builder.to_hints(),
                 nullifier_commitment_hints: sorted_nullifier_commitment_hints,
-                master_nullifier_secret_keys: unsafe::zeroed()
+                master_nullifier_secret_keys: [GrumpkinPrivateKey::empty(); MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_TX],
             };
             kernel.execute()
         }

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_app_logic.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_app_logic.nr
@@ -4,7 +4,6 @@ use dep::types::PublicKernelCircuitPublicInputs;
 use dep::types::abis::kernel_circuit_public_inputs::PublicKernelCircuitPublicInputsBuilder;
 use dep::types::utils::arrays::array_to_bounded_vec;
 use crate::common;
-use dep::std::unsafe;
 
 struct PublicKernelAppLogicCircuitPrivateInputs {
     previous_kernel: PublicKernelData,

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_app_logic.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_app_logic.nr
@@ -22,7 +22,7 @@ impl PublicKernelAppLogicCircuitPrivateInputs {
 
     fn public_kernel_app_logic(self) -> PublicKernelCircuitPublicInputs {
         // construct the circuit outputs
-        let mut public_inputs: PublicKernelCircuitPublicInputsBuilder = unsafe::zeroed();
+        let mut public_inputs = PublicKernelCircuitPublicInputsBuilder::empty();
         common::initialize_revert_code(self.previous_kernel, self.public_call, &mut public_inputs);
 
         // initialise the end state with our provided previous kernel state

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_setup.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_setup.nr
@@ -26,7 +26,7 @@ impl PublicKernelSetupCircuitPrivateInputs {
 
     fn public_kernel_setup(self) -> PublicKernelCircuitPublicInputs {
         // construct the circuit outputs
-        let mut public_inputs: PublicKernelCircuitPublicInputsBuilder = unsafe::zeroed();
+        let mut public_inputs = PublicKernelCircuitPublicInputsBuilder::empty();
         // since this phase is non-revertible, we must assert the public call did not revert
         common::validate_public_call_non_revert(self.public_call);
         common::initialize_revert_code(self.previous_kernel, self.public_call, &mut public_inputs);

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_setup.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_setup.nr
@@ -3,7 +3,6 @@ use dep::types::abis::{
     kernel_circuit_public_inputs::{PublicKernelCircuitPublicInputs, PublicKernelCircuitPublicInputsBuilder},
     kernel_data::PublicKernelData, public_call_data::PublicCallData
 };
-use dep::std::unsafe;
 
 struct PublicKernelSetupCircuitPrivateInputs {
     // Note: One might think that our previous_kernel ought to be

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_tail.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_tail.nr
@@ -12,7 +12,6 @@ use dep::types::{
     utils::{arrays::{array_length, array_merge, array_to_bounded_vec, assert_sorted_array}},
     hash::silo_nullifier, traits::is_empty
 };
-use dep::std::unsafe;
 
 struct PublicKernelTailCircuitPrivateInputs {
     previous_kernel: PublicKernelData,

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_tail.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_tail.nr
@@ -101,7 +101,7 @@ impl PublicKernelTailCircuitPrivateInputs {
     }
 
     pub fn public_kernel_tail(self) -> KernelCircuitPublicInputs {
-        let mut public_inputs: PublicKernelCircuitPublicInputsBuilder = unsafe::zeroed();
+        let mut public_inputs = PublicKernelCircuitPublicInputsBuilder::empty();
 
         self.validate_inputs();
 

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
@@ -25,7 +25,7 @@ impl PublicKernelTeardownCircuitPrivateInputs {
 
     fn public_kernel_teardown(self) -> PublicKernelCircuitPublicInputs {
         // construct the circuit outputs
-        let mut public_inputs: PublicKernelCircuitPublicInputsBuilder = unsafe::zeroed();
+        let mut public_inputs = PublicKernelCircuitPublicInputsBuilder::empty();
         // since this phase is non-revertible, we must assert the public call did not revert
         common::validate_public_call_non_revert(self.public_call);
         common::initialize_revert_code(self.previous_kernel, self.public_call, &mut public_inputs);

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
@@ -3,7 +3,6 @@ use dep::types::abis::{
     kernel_circuit_public_inputs::{PublicKernelCircuitPublicInputs, PublicKernelCircuitPublicInputsBuilder},
     kernel_data::PublicKernelData, public_call_data::PublicCallData
 };
-use dep::std::unsafe;
 
 struct PublicKernelTeardownCircuitPrivateInputs {
     previous_kernel: PublicKernelData,

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/nullifier_read_request_reset.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/nullifier_read_request_reset.nr
@@ -1,6 +1,5 @@
 // This will be moved to a separate Read Request Reset Circuit.
 use crate::read_request_reset::{PendingReadHint, ReadRequestStatus, ReadValueHint, SettledReadHint};
-use dep::std::unsafe;
 use dep::types::{
     abis::{nullifier_leaf_preimage::NullifierLeafPreimage},
     constants::{MAX_NULLIFIER_READ_REQUESTS_PER_TX, NULLIFIER_TREE_HEIGHT},
@@ -31,7 +30,7 @@ impl SettledReadHint<NULLIFIER_TREE_HEIGHT, NullifierLeafPreimage> for Nullifier
     fn nada(read_request_len: u64) -> Self {
         NullifierSettledReadHint {
             read_request_index: read_request_len,
-            membership_witness: unsafe::zeroed(),
+            membership_witness: MembershipWitness::empty(),
             leaf_preimage: NullifierLeafPreimage::empty()
         }
     }

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/read_request_reset.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/read_request_reset.nr
@@ -159,11 +159,11 @@ mod tests {
         propagate_unverified_read_requests, reset_read_requests, validate_pending_read_requests,
         validate_settled_read_requests
     };
-    use dep::std::{hash::pedersen_hash, unsafe};
+    use dep::std::hash::pedersen_hash;
     use dep::types::{
         address::AztecAddress, abis::{read_request::ReadRequestContext, side_effect::SideEffect},
         merkle_tree::{LeafPreimage, MembershipWitness}, hash::silo_nullifier,
-        tests::merkle_tree_utils::NonEmptyMerkleTree
+        tests::merkle_tree_utils::NonEmptyMerkleTree, traits::Empty
     };
 
     struct TestLeafPreimage {
@@ -177,6 +177,14 @@ mod tests {
 
         fn as_leaf(self) -> Field {
             pedersen_hash([self.value])
+        }
+    }
+
+    impl Empty for TestLeafPreimage {
+        fn empty() -> Self {
+            TestLeafPreimage {
+                value: 0
+            }
         }
     }
 
@@ -204,8 +212,8 @@ mod tests {
         fn nada(read_request_len: u64) -> Self {
             TestSettledReadHint {
                 read_request_index: read_request_len,
-                membership_witness: unsafe::zeroed(),
-                leaf_preimage: unsafe::zeroed()
+                membership_witness: MembershipWitness::empty(),
+                leaf_preimage: TestLeafPreimage::empty()
             }
         }
     }

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/tests/nullifier_non_existent_read_request_hints_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/tests/nullifier_non_existent_read_request_hints_builder.nr
@@ -9,7 +9,6 @@ use dep::types::{
     tests::{merkle_tree_utils::NonEmptyMerkleTree, sort::sort_get_sorted_hints},
     utils::{arrays::find_index, field::full_field_greater_than}
 };
-use dep::std::unsafe;
 
 struct NullifierNonExistentReadRequestHintsBuilder {
     nullifier_tree: NonEmptyMerkleTree<MAX_NEW_NULLIFIERS_PER_TX, NULLIFIER_TREE_HEIGHT, NULLIFIER_SUBTREE_SIBLING_PATH_LENGTH, NULLIFIER_SUBTREE_HEIGHT>,
@@ -21,7 +20,7 @@ struct NullifierNonExistentReadRequestHintsBuilder {
 impl NullifierNonExistentReadRequestHintsBuilder {
     pub fn new() -> Self {
         NullifierNonExistentReadRequestHintsBuilder {
-            nullifier_tree: unsafe::zeroed(),
+            nullifier_tree: NonEmptyMerkleTree::empty(),
             non_membership_hints: BoundedVec::new(),
             read_values: BoundedVec::new(),
             pending_nullifiers: [SideEffectLinkedToNoteHash::empty(); MAX_NEW_NULLIFIERS_PER_TX]

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/base_or_merge_rollup_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/base_or_merge_rollup_public_inputs.nr
@@ -1,9 +1,10 @@
 use dep::types::{
     abis::append_only_tree_snapshot::AppendOnlyTreeSnapshot,
-    partial_state_reference::PartialStateReference
+    partial_state_reference::PartialStateReference,
+    mocked::AggregationObject,
+    traits::Empty
 };
 use crate::abis::constant_rollup_data::ConstantRollupData;
-use dep::types::mocked::AggregationObject;
 
 global BASE_ROLLUP_TYPE = 0;
 global MERGE_ROLLUP_TYPE = 1;
@@ -28,4 +29,19 @@ struct BaseOrMergeRollupPublicInputs {
     // We hash public inputs to make them constant-sized (to then be unpacked on-chain)
     txs_effects_hash : Field,
     out_hash : Field, 
+}
+
+impl Empty for BaseOrMergeRollupPublicInputs {
+    fn empty() -> Self {
+        BaseOrMergeRollupPublicInputs {
+            rollup_type : 0 as u32,
+            height_in_block_tree : 0,
+            aggregation_object : AggregationObject::empty(),
+            constants : ConstantRollupData::empty(),
+            start: PartialStateReference::empty(),
+            end: PartialStateReference::empty(),
+            txs_effects_hash : 0,
+            out_hash : 0, 
+        }
+    }
 }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/constant_rollup_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/constant_rollup_data.nr
@@ -32,7 +32,7 @@ impl Eq for ConstantRollupData {
 impl Empty for ConstantRollupData {
     fn empty() -> Self {
         ConstantRollupData {
-            last_archive: AppendOnlyTreeSnapshot::empty(),
+            last_archive: AppendOnlyTreeSnapshot::zero(),
             private_kernel_vk_tree_root: 0,
             public_kernel_vk_tree_root: 0,
             base_rollup_vk_hash: 0,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/constant_rollup_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/constant_rollup_data.nr
@@ -1,5 +1,8 @@
 use dep::std::cmp::Eq;
-use dep::types::abis::{global_variables::GlobalVariables, append_only_tree_snapshot::AppendOnlyTreeSnapshot};
+use dep::types::{
+    abis::{global_variables::GlobalVariables, append_only_tree_snapshot::AppendOnlyTreeSnapshot},
+    traits::Empty
+};
 
 struct ConstantRollupData {
     // Archive tree snapshot at the very beginning of the entire rollup.
@@ -23,5 +26,18 @@ impl Eq for ConstantRollupData {
         (self.public_kernel_vk_tree_root == other.public_kernel_vk_tree_root) &
         (self.base_rollup_vk_hash == other.base_rollup_vk_hash) &
         (self.merge_rollup_vk_hash == other.merge_rollup_vk_hash)
+    }
+}
+
+impl Empty for ConstantRollupData {
+    fn empty() -> Self {
+        ConstantRollupData {
+            last_archive: AppendOnlyTreeSnapshot::empty(),
+            private_kernel_vk_tree_root: 0,
+            public_kernel_vk_tree_root: 0,
+            base_rollup_vk_hash: 0,
+            merge_rollup_vk_hash: 0,
+            global_variables: GlobalVariables::empty(),
+        }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/previous_rollup_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/previous_rollup_data.nr
@@ -1,7 +1,10 @@
 use crate::abis::base_or_merge_rollup_public_inputs::BaseOrMergeRollupPublicInputs;
-use dep::types::abis::membership_witness::VKMembershipWitness;
-use dep::types::constants::ROLLUP_VK_TREE_HEIGHT;
-use dep::types::mocked::{Proof, VerificationKey};
+use dep::types::{
+    abis::membership_witness::VKMembershipWitness,
+    constants::ROLLUP_VK_TREE_HEIGHT,
+    mocked::{Proof, VerificationKey},
+    traits::Empty
+};
 
 struct PreviousRollupData{
     base_or_merge_rollup_public_inputs : BaseOrMergeRollupPublicInputs,
@@ -9,4 +12,16 @@ struct PreviousRollupData{
     vk : VerificationKey,
     vk_index : u32,
     vk_sibling_path : VKMembershipWitness,
+}
+
+impl Empty for PreviousRollupData {
+    fn empty() -> Self {
+        PreviousRollupData {
+            base_or_merge_rollup_public_inputs: BaseOrMergeRollupPublicInputs::empty(),
+            proof : Proof::empty(),
+            vk : VerificationKey::empty(),
+            vk_index : 0 as u32,
+            vk_sibling_path : VKMembershipWitness::empty(),
+        }
+    }
 }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/base_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/base_rollup_inputs.nr
@@ -431,13 +431,13 @@ mod tests {
         snapshot: AppendOnlyTreeSnapshot,
         public_data_writes: BoundedVec<(u64, PublicDataTreeLeaf), 2>,
         mut pre_existing_public_data: [PublicDataTreeLeafPreimage; EXISTING_LEAVES]
-    ) -> ([Field; PUBLIC_DATA_SUBTREE_SIBLING_PATH_LENGTH], [PublicDataTreeLeaf; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX], [u64; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX], [PublicDataTreeLeafPreimage; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX], [PublicDataMembershipWitness; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX], [PublicDataTreeLeafPreimage; EXISTING_LEAVES]) {
-        let mut subtree_path: [Field; PUBLIC_DATA_SUBTREE_SIBLING_PATH_LENGTH] = dep::std::unsafe::zeroed();
-        let mut sorted_public_data_writes: [PublicDataTreeLeaf; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX] = dep::std::unsafe::zeroed();
-        let mut sorted_public_data_writes_indexes: [u64; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX] = dep::std::unsafe::zeroed();
-        let mut low_public_data_writes_preimages: [PublicDataTreeLeafPreimage; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX] = dep::std::unsafe::zeroed();
-        let mut low_public_data_writes_witnesses: [PublicDataMembershipWitness; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX] = dep::std::unsafe::zeroed();
-        let mut new_subtree: [PublicDataTreeLeafPreimage; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX] = dep::std::unsafe::zeroed();
+    ) -> ([Field; 35], [PublicDataTreeLeaf; 32], [u64; 32], [PublicDataTreeLeafPreimage; 32], [PublicDataMembershipWitness; 32], [PublicDataTreeLeafPreimage; EXISTING_LEAVES]) {
+        let mut subtree_path = [0; PUBLIC_DATA_SUBTREE_SIBLING_PATH_LENGTH];
+        let mut sorted_public_data_writes = [PublicDataTreeLeaf::empty(); MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX];
+        let mut sorted_public_data_writes_indexes = [0 as u64; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX];
+        let mut low_public_data_writes_preimages = [PublicDataTreeLeafPreimage::empty(); MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX];
+        let mut low_public_data_writes_witnesses = [PublicDataMembershipWitness::empty(); MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX];
+        let mut new_subtree = [PublicDataTreeLeafPreimage::empty(); MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX];
 
         for i in 0..MAX_PUBLIC_DATA_WRITES_PER_TEST {
             if i < (public_data_writes.len()) {

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/base_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/base_rollup_inputs.nr
@@ -413,7 +413,8 @@ mod tests {
         fixture_builder::FixtureBuilder, merkle_tree_utils::{NonEmptyMerkleTree, compute_zero_hashes},
         sort::sort_high_to_low
     },
-        utils::{field::{full_field_less_than, field_from_bytes_32_trunc, field_from_bytes}, uint256::U256}
+        utils::{field::{full_field_less_than, field_from_bytes_32_trunc, field_from_bytes}, uint256::U256},
+        traits::Empty
     };
 
     struct NullifierInsertion {
@@ -522,7 +523,7 @@ mod tests {
 
     impl BaseRollupInputsBuilder {
         fn new() -> Self {
-            let mut inputs: BaseRollupInputsBuilder = dep::std::unsafe::zeroed();
+            let mut inputs = BaseRollupInputsBuilder::empty();
             inputs.kernel_data = FixtureBuilder::new();
             inputs.constants.global_variables.chain_id = 1;
             inputs.constants.global_variables.version = 0;
@@ -549,8 +550,8 @@ mod tests {
             kernel_data: &mut KernelData,
             start_nullifier_tree_snapshot: AppendOnlyTreeSnapshot
         ) -> ([NullifierLeafPreimage; MAX_NEW_NULLIFIERS_PER_TX], [NullifierMembershipWitness; MAX_NEW_NULLIFIERS_PER_TX], [Field; MAX_NEW_NULLIFIERS_PER_TX], [u64; MAX_NEW_NULLIFIERS_PER_TX]) {
-            let mut nullifier_predecessor_preimages: [NullifierLeafPreimage; MAX_NEW_NULLIFIERS_PER_TX] = dep::std::unsafe::zeroed();
-            let mut low_nullifier_membership_witness: [NullifierMembershipWitness; MAX_NEW_NULLIFIERS_PER_TX] = dep::std::unsafe::zeroed();
+            let mut nullifier_predecessor_preimages = [NullifierLeafPreimage::empty(); MAX_NEW_NULLIFIERS_PER_TX];
+            let mut low_nullifier_membership_witness = [NullifierMembershipWitness::empty(); MAX_NEW_NULLIFIERS_PER_TX];
 
             let sorted_new_nullifier_tuples = sort_high_to_low(
                 self.new_nullifiers.storage.map(|insertion: NullifierInsertion| insertion.value),
@@ -724,6 +725,23 @@ mod tests {
 
         fn fails(self) {
             let _ = self.execute();
+        }
+    }
+
+    impl Empty for BaseRollupInputsBuilder {
+        fn empty() -> Self {
+            BaseRollupInputsBuilder {
+                kernel_data: FixtureBuilder::new(),
+                pre_existing_notes: [0; MAX_NEW_NOTE_HASHES_PER_TX],
+                pre_existing_nullifiers: [NullifierLeafPreimage::empty(); MAX_NEW_NULLIFIERS_PER_TX],
+                pre_existing_contracts: [0; 2],
+                pre_existing_public_data: [PublicDataTreeLeafPreimage::empty(); MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX],
+                pre_existing_blocks: [0; 2],
+                public_data_reads: BoundedVec::new(),
+                public_data_writes:BoundedVec::new(),
+                new_nullifiers: BoundedVec::new(),
+                constants: ConstantRollupData::empty(),
+            }
         }
     }
 
@@ -955,7 +973,7 @@ mod tests {
 
     #[test]
     unconstrained fn nonempty_block_out_hash() {
-        let mut end: CombinedAccumulatedData = dep::std::unsafe::zeroed();
+        let mut end = CombinedAccumulatedData::empty();
         end.new_l2_to_l1_msgs[MAX_NEW_L2_TO_L1_MSGS_PER_TX - 1] = 123;
 
         let out_hash = compute_kernel_out_hash(end);

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/merge/merge_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/merge/merge_rollup_inputs.nr
@@ -1,10 +1,19 @@
+use dep::types::traits::Empty;
 use crate::abis::previous_rollup_data::PreviousRollupData;
 use crate::abis::base_or_merge_rollup_public_inputs::{BaseOrMergeRollupPublicInputs, MERGE_ROLLUP_TYPE};
 use crate::components;
 
-struct MergeRollupInputs{
+struct MergeRollupInputs {
     // TODO(Kev): Why is this 2?
     previous_rollup_data : [PreviousRollupData; 2]
+}
+
+impl Empty for MergeRollupInputs {
+    fn empty() -> Self {
+        MergeRollupInputs {
+            previous_rollup_data: [PreviousRollupData::empty(); 2]
+        }
+    }
 }
 
 impl MergeRollupInputs {

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_inputs.nr
@@ -12,7 +12,8 @@ use dep::{
 },
     header::Header, content_commitment::ContentCommitment,
     merkle_tree::{append_only_tree, calculate_subtree_root, calculate_empty_tree_root},
-    state_reference::StateReference
+    state_reference::StateReference,
+    traits::Empty,
 }
 };
 
@@ -85,5 +86,19 @@ impl RootRollupInputs {
         );
 
         RootRollupPublicInputs { aggregation_object, archive, header }
+    }
+}
+
+impl Empty for RootRollupInputs {
+    fn empty() -> Self {
+        RootRollupInputs {
+            previous_rollup_data : [PreviousRollupData::empty(); 2],
+            l1_to_l2_roots: RootParityInput::empty(),
+            new_l1_to_l2_messages : [0; NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP],
+            new_l1_to_l2_message_tree_root_sibling_path : [0; L1_TO_L2_MSG_SUBTREE_SIBLING_PATH_LENGTH],
+            start_l1_to_l2_message_tree_snapshot : AppendOnlyTreeSnapshot::empty(),
+            start_archive_snapshot : AppendOnlyTreeSnapshot::empty(),
+            new_archive_sibling_path : [0; ARCHIVE_HEIGHT],
+        }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_inputs.nr
@@ -96,8 +96,8 @@ impl Empty for RootRollupInputs {
             l1_to_l2_roots: RootParityInput::empty(),
             new_l1_to_l2_messages : [0; NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP],
             new_l1_to_l2_message_tree_root_sibling_path : [0; L1_TO_L2_MSG_SUBTREE_SIBLING_PATH_LENGTH],
-            start_l1_to_l2_message_tree_snapshot : AppendOnlyTreeSnapshot::empty(),
-            start_archive_snapshot : AppendOnlyTreeSnapshot::empty(),
+            start_l1_to_l2_message_tree_snapshot : AppendOnlyTreeSnapshot::zero(),
+            start_archive_snapshot : AppendOnlyTreeSnapshot::zero(),
             new_archive_sibling_path : [0; ARCHIVE_HEIGHT],
         }
     }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/merge_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/merge_rollup_inputs.nr
@@ -4,7 +4,7 @@ use dep::types::abis::append_only_tree_snapshot::AppendOnlyTreeSnapshot;
 use crate::tests::previous_rollup_data::default_previous_rollup_data;
 
 pub fn default_merge_rollup_inputs() -> MergeRollupInputs {
-    let mut inputs: MergeRollupInputs = dep::std::unsafe::zeroed();
+    let mut inputs = MergeRollupInputs::empty();
 
     inputs.previous_rollup_data = default_previous_rollup_data();
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/previous_rollup_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/previous_rollup_data.nr
@@ -3,7 +3,7 @@ use crate::abis::previous_rollup_data::PreviousRollupData;
 use dep::types::abis::append_only_tree_snapshot::AppendOnlyTreeSnapshot;
 
 pub fn default_previous_rollup_data() -> [PreviousRollupData; 2] {
-    let mut previous_rollup_data: [PreviousRollupData; 2] = dep::std::unsafe::zeroed();
+    let mut previous_rollup_data = [PreviousRollupData::empty(); 2];
 
     previous_rollup_data[0].base_or_merge_rollup_public_inputs.start.note_hash_tree = AppendOnlyTreeSnapshot {
         root: 0,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/root_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/root_rollup_inputs.nr
@@ -35,7 +35,7 @@ pub fn compute_archive_snapshot() -> (AppendOnlyTreeSnapshot, [Field; ARCHIVE_HE
 }
 
 pub fn default_root_rollup_inputs() -> RootRollupInputs {
-    let mut inputs: RootRollupInputs = dep::std::unsafe::zeroed();
+    let mut inputs = RootRollupInputs::empty();
     let (l1_l2_empty_snapshot, l1_l2_empty_sibling_path) = compute_l1_l2_empty_snapshot();
 
     inputs.new_l1_to_l2_message_tree_root_sibling_path = l1_l2_empty_sibling_path;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/combined_accumulated_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/combined_accumulated_data.nr
@@ -8,7 +8,8 @@ use crate::{
     MAX_NEW_NOTE_HASHES_PER_TX, MAX_NEW_NULLIFIERS_PER_TX, MAX_NEW_L2_TO_L1_MSGS_PER_TX,
     MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX
 },
-    utils::arrays::array_merge
+    utils::arrays::array_merge,
+    traits::Empty
 };
 
 struct CombinedAccumulatedData {
@@ -41,6 +42,21 @@ impl CombinedAccumulatedData {
                 non_revertible.public_data_update_requests,
                 revertible.public_data_update_requests
             )
+        }
+    }
+}
+
+impl Empty for CombinedAccumulatedData {
+    fn empty() -> Self {
+        CombinedAccumulatedData {
+            new_note_hashes: [0; MAX_NEW_NOTE_HASHES_PER_TX],
+            new_nullifiers: [0; MAX_NEW_NULLIFIERS_PER_TX],
+            new_l2_to_l1_msgs: [0; MAX_NEW_L2_TO_L1_MSGS_PER_TX],
+            encrypted_logs_hash: 0,
+            unencrypted_logs_hash: 0,
+            encrypted_log_preimages_length: 0,
+            unencrypted_log_preimages_length: 0,
+            public_data_update_requests: [PublicDataUpdateRequest::empty(); MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX],
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/private_accumulated_data_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/private_accumulated_data_builder.nr
@@ -15,7 +15,6 @@ use crate::{
 },
 traits::Empty
 };
-use dep::std::unsafe;
 
 struct PrivateAccumulatedDataBuilder {
     new_note_hashes: BoundedVec<SideEffect, MAX_NEW_NOTE_HASHES_PER_TX>,
@@ -58,7 +57,7 @@ impl PrivateAccumulatedDataBuilder {
             unencrypted_logs_hash: self.unencrypted_logs_hash,
             encrypted_log_preimages_length: self.encrypted_log_preimages_length,
             unencrypted_log_preimages_length: self.unencrypted_log_preimages_length,
-            public_data_update_requests: unsafe::zeroed()
+            public_data_update_requests: [PublicDataUpdateRequest::empty(); MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX],
         }
     }
 
@@ -115,7 +114,6 @@ mod tests {
     },
         address::AztecAddress, utils::arrays::array_eq
     };
-    use dep::std::unsafe;
 
     #[test]
     unconstrained fn splits_revertible_and_non_revertible() {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/private_accumulated_data_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/private_accumulated_data_builder.nr
@@ -66,8 +66,8 @@ impl PrivateAccumulatedDataBuilder {
         self,
         min_revertible_side_effect_counter: u32
     ) -> (PublicAccumulatedData, PublicAccumulatedData) {
-        let mut non_revertible_builder: PublicAccumulatedDataBuilder = unsafe::zeroed();
-        let mut revertible_builder: PublicAccumulatedDataBuilder = unsafe::zeroed();
+        let mut non_revertible_builder = PublicAccumulatedDataBuilder::empty();
+        let mut revertible_builder = PublicAccumulatedDataBuilder::empty();
 
         for i in 0..MAX_NEW_NOTE_HASHES_PER_TX {
             let note_hash = self.new_note_hashes.storage[i];
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     unconstrained fn splits_revertible_and_non_revertible() {
-        let mut builder: PrivateAccumulatedDataBuilder = unsafe::zeroed();
+        let mut builder = PrivateAccumulatedDataBuilder::empty();
 
         let non_revertible_commitments = [
             SideEffect { value: 1, counter: 1 },

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/private_accumulated_data_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/private_accumulated_data_builder.nr
@@ -12,7 +12,8 @@ use crate::{
     MAX_NEW_NOTE_HASHES_PER_TX, MAX_NEW_NULLIFIERS_PER_TX, MAX_PRIVATE_CALL_STACK_LENGTH_PER_TX,
     MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX, MAX_NEW_L2_TO_L1_MSGS_PER_TX,
     MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX
-}
+},
+traits::Empty
 };
 use dep::std::unsafe;
 
@@ -185,5 +186,21 @@ mod tests {
         assert(array_eq(revertible.new_note_hashes, revertible_commitments));
         assert(array_eq(revertible.new_nullifiers, revertible_nullifiers));
         assert(array_eq(revertible.public_call_stack, revertible_public_call_stack));
+    }
+}
+
+impl Empty for PrivateAccumulatedDataBuilder {
+    fn empty() -> Self {
+        PrivateAccumulatedDataBuilder {
+            new_note_hashes: BoundedVec::new(),
+            new_nullifiers: BoundedVec::new(),
+            new_l2_to_l1_msgs: BoundedVec::new(),
+            encrypted_logs_hash: 0,
+            unencrypted_logs_hash: 0,
+            encrypted_log_preimages_length: 0,
+            unencrypted_log_preimages_length: 0,
+            private_call_stack: BoundedVec::new(),
+            public_call_stack: BoundedVec::new(),
+        }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/public_accumulated_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/public_accumulated_data.nr
@@ -6,7 +6,8 @@ use crate::{
     constants::{
     MAX_NEW_NOTE_HASHES_PER_TX, MAX_NEW_NULLIFIERS_PER_TX, MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX,
     MAX_NEW_L2_TO_L1_MSGS_PER_TX, MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX
-}
+},
+traits::Empty
 };
 
 struct PublicAccumulatedData {
@@ -25,4 +26,20 @@ struct PublicAccumulatedData {
     public_data_update_requests: [PublicDataUpdateRequest; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX],
 
     public_call_stack: [CallRequest; MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX],
+}
+
+impl Empty for PublicAccumulatedData {
+    fn empty() -> Self {
+        PublicAccumulatedData {
+            new_note_hashes: [SideEffect::empty(); MAX_NEW_NOTE_HASHES_PER_TX],
+            new_nullifiers: [SideEffectLinkedToNoteHash::empty(); MAX_NEW_NULLIFIERS_PER_TX],
+            new_l2_to_l1_msgs: [0; MAX_NEW_L2_TO_L1_MSGS_PER_TX],
+            encrypted_logs_hash: 0,
+            unencrypted_logs_hash: 0,
+            encrypted_log_preimages_length: 0,
+            unencrypted_log_preimages_length: 0,
+            public_data_update_requests: [PublicDataUpdateRequest::empty(); MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX],
+            public_call_stack: [CallRequest::empty(); MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX],
+        }
+    }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/public_accumulated_data_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/public_accumulated_data_builder.nr
@@ -7,7 +7,8 @@ use crate::{
     constants::{
     MAX_NEW_NOTE_HASHES_PER_TX, MAX_NEW_NULLIFIERS_PER_TX, MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX,
     MAX_NEW_L2_TO_L1_MSGS_PER_TX, MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX
-}
+},
+traits::Empty
 };
 
 struct PublicAccumulatedDataBuilder {
@@ -40,6 +41,22 @@ impl PublicAccumulatedDataBuilder {
             unencrypted_log_preimages_length: self.unencrypted_log_preimages_length,
             public_data_update_requests: self.public_data_update_requests.storage,
             public_call_stack: self.public_call_stack.storage
+        }
+    }
+}
+
+impl Empty for PublicAccumulatedDataBuilder {
+    fn empty() -> Self {
+        PublicAccumulatedDataBuilder {
+            new_note_hashes: BoundedVec::new(),
+            new_nullifiers: BoundedVec::new(),
+            new_l2_to_l1_msgs: BoundedVec::new(),
+            encrypted_logs_hash: 0,
+            unencrypted_logs_hash: 0,
+            encrypted_log_preimages_length: 0,
+            unencrypted_log_preimages_length: 0,
+            public_data_update_requests: BoundedVec::new(),
+            public_call_stack: BoundedVec::new(),
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/append_only_tree_snapshot.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/append_only_tree_snapshot.nr
@@ -1,5 +1,4 @@
 use dep::std::cmp::Eq;
-use crate::traits::Empty;
 
 struct AppendOnlyTreeSnapshot {
     root : Field,
@@ -26,11 +25,5 @@ impl AppendOnlyTreeSnapshot {
 impl Eq for AppendOnlyTreeSnapshot {
     fn eq(self, other : AppendOnlyTreeSnapshot) -> bool {
         (self.root == other.root) & (self.next_available_leaf_index == other.next_available_leaf_index)
-    }
-}
-
-impl Empty for AppendOnlyTreeSnapshot {
-    fn empty() -> Self {
-        Self { root: 0, next_available_leaf_index: 0 }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/append_only_tree_snapshot.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/append_only_tree_snapshot.nr
@@ -1,4 +1,5 @@
 use dep::std::cmp::Eq;
+use crate::traits::Empty;
 
 struct AppendOnlyTreeSnapshot {
     root : Field,
@@ -25,5 +26,11 @@ impl AppendOnlyTreeSnapshot {
 impl Eq for AppendOnlyTreeSnapshot {
     fn eq(self, other : AppendOnlyTreeSnapshot) -> bool {
         (self.root == other.root) & (self.next_available_leaf_index == other.next_available_leaf_index)
+    }
+}
+
+impl Empty for AppendOnlyTreeSnapshot {
+    fn empty() -> Self {
+        Self { root: 0, next_available_leaf_index: 0 }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/call_context.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/call_context.nr
@@ -1,7 +1,7 @@
 use crate::{
     abis::function_selector::FunctionSelector, address::{EthAddress, AztecAddress},
     constants::{CALL_CONTEXT_LENGTH, GENERATOR_INDEX__CALL_CONTEXT}, hash::pedersen_hash,
-    traits::{Deserialize, Hash, Serialize}, abis::side_effect::Ordered
+    traits::{Deserialize, Hash, Serialize, Empty}, abis::side_effect::Ordered
 };
 
 // docs:start:call-context
@@ -69,9 +69,23 @@ impl Deserialize<CALL_CONTEXT_LENGTH> for CallContext {
     }
 }
 
+impl Empty for CallContext {
+    fn empty() -> Self {
+        CallContext {
+            msg_sender: AztecAddress::empty(),
+            storage_contract_address: AztecAddress::empty(),
+            portal_contract_address: EthAddress::empty(),
+            function_selector: FunctionSelector::empty(),
+            is_delegate_call: false,
+            is_static_call: false,
+            side_effect_counter: 0,
+        }
+    }
+}
+
 #[test]
 fn serialize_deserialize_of_empty() {
-    let context: CallContext = dep::std::unsafe::zeroed();
+    let context = CallContext::empty();
     let serialized = context.serialize();
     let deserialized = CallContext::deserialize(serialized);
     assert(context.eq(deserialized));
@@ -79,13 +93,13 @@ fn serialize_deserialize_of_empty() {
 
 #[test]
 fn assert_is_zero() {
-    let context: CallContext = dep::std::unsafe::zeroed();
+    let context = CallContext::empty();
     context.assert_is_zero();
 }
 
 #[test(should_fail)]
 fn not_zero_assert_is_zero() {
-    let mut context: CallContext = dep::std::unsafe::zeroed();
+    let mut context = CallContext::empty();
     context.is_delegate_call = true;
     context.assert_is_zero();
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/call_context.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/call_context.nr
@@ -106,8 +106,8 @@ fn not_zero_assert_is_zero() {
 
 #[test]
 fn test_eq() {
-    let mut context1: CallContext = dep::std::unsafe::zeroed();
-    let mut context2: CallContext = dep::std::unsafe::zeroed();
+    let mut context1 = CallContext::empty();
+    let mut context2 = CallContext::empty();
 
     context1.is_delegate_call = true;
     context2.is_delegate_call = true;
@@ -121,8 +121,8 @@ fn test_eq() {
 
 #[test(should_fail)]
 fn not_eq_test_eq() {
-    let mut context1: CallContext = dep::std::unsafe::zeroed();
-    let mut context2: CallContext = dep::std::unsafe::zeroed();
+    let mut context1 = CallContext::empty();
+    let mut context2 = CallContext::empty();
 
     context1.is_delegate_call = true;
     context2.is_delegate_call = false;
@@ -138,6 +138,6 @@ fn not_eq_test_eq() {
 
 #[test]
 fn hash_smoke() {
-    let context: CallContext = dep::std::unsafe::zeroed();
+    let context = CallContext::empty();
     let _hashed = context.hash();
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/combined_constant_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/combined_constant_data.nr
@@ -1,5 +1,6 @@
 use crate::transaction::tx_context::TxContext;
 use crate::header::Header;
+use crate::traits::Empty;
 
 struct CombinedConstantData {
     historical_header: Header,
@@ -8,4 +9,13 @@ struct CombinedConstantData {
     // a situation we could be using header from a block before the upgrade took place but be using the updated
     // protocol to execute and prove the transaction.
     tx_context: TxContext,
+}
+
+impl Empty for CombinedConstantData {
+    fn empty() -> Self {
+        CombinedConstantData {
+            historical_header: Header::empty(),
+            tx_context: TxContext::empty(),
+        }
+    }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/function_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/function_data.nr
@@ -1,7 +1,7 @@
 use crate::{
     abis::function_selector::FunctionSelector,
     constants::{GENERATOR_INDEX__FUNCTION_DATA, FUNCTION_DATA_LENGTH}, hash::pedersen_hash,
-    traits::{Serialize, Hash, Deserialize}
+    traits::{Serialize, Hash, Deserialize, Empty}
 };
 
 struct FunctionData {
@@ -43,9 +43,18 @@ impl Hash for FunctionData {
     }
 }
 
+impl Empty for FunctionData {
+    fn empty() -> Self {
+        FunctionData {
+            selector: FunctionSelector::empty(),
+            is_private: false,
+        }
+    }
+}
+
 #[test]
 fn serialization_of_empty() {
-    let data: FunctionData = dep::std::unsafe::zeroed();
+    let data = FunctionData::empty();
     let serialized = data.serialize();
     let deserialized = FunctionData::deserialize(serialized);
     assert(data.eq(deserialized));
@@ -53,7 +62,7 @@ fn serialization_of_empty() {
 
 #[test]
 fn empty_hash() {
-    let data: FunctionData = dep::std::unsafe::zeroed();
+    let data = FunctionData::empty();
     let hash = data.hash();
 
     // Value from function_data.test.ts "computes empty item hash" test

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/function_selector.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/function_selector.nr
@@ -1,6 +1,6 @@
 use crate::utils::field::field_from_bytes;
 use dep::std::cmp::Eq;
-use crate::traits::{Serialize, Deserialize, FromField, ToField};
+use crate::traits::{Serialize, Deserialize, FromField, ToField, Empty};
 
 global SELECTOR_SIZE = 4;
 
@@ -38,6 +38,12 @@ impl FromField for FunctionSelector {
 impl ToField for FunctionSelector {
     fn to_field(self) -> Field {
         self.inner as Field
+    }
+}
+
+impl Empty for FunctionSelector {
+    fn empty() -> Self {
+        Self { inner: 0 as u32 }
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/global_variables.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/global_variables.nr
@@ -68,7 +68,7 @@ impl Empty for GlobalVariables {
 
 #[test]
 fn serialization_of_empty() {
-    let vars: GlobalVariables = dep::std::unsafe::zeroed();
+    let vars = GlobalVariables::empty();
     let _serialized = vars.serialize();
     let _deserialized = GlobalVariables::deserialize(_serialized);
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/private_kernel_circuit_public_inputs_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/private_kernel_circuit_public_inputs_builder.nr
@@ -1,4 +1,5 @@
-use crate::abis::{
+use crate::{
+    abis::{
     accumulated_data::PrivateAccumulatedDataBuilder, combined_constant_data::CombinedConstantData,
     kernel_circuit_public_inputs::{
     kernel_circuit_public_inputs::KernelCircuitPublicInputs,
@@ -6,9 +7,10 @@ use crate::abis::{
     public_kernel_circuit_public_inputs::PublicKernelCircuitPublicInputs
 },
     validation_requests::validation_requests_builder::ValidationRequestsBuilder
+},
+mocked::AggregationObject,
+traits::Empty
 };
-use crate::mocked::AggregationObject;
-use dep::std::unsafe;
 
 struct PrivateKernelCircuitPublicInputsBuilder {
     aggregation_object: AggregationObject,
@@ -49,6 +51,18 @@ impl PrivateKernelCircuitPublicInputsBuilder {
             end,
             constants: self.constants,
             revert_code: 0
+        }
+    }
+}
+
+impl Empty for PrivateKernelCircuitPublicInputsBuilder {
+    fn empty() -> Self {
+        PrivateKernelCircuitPublicInputsBuilder {
+            aggregation_object: AggregationObject::empty(),
+            min_revertible_side_effect_counter: 0 as u32,
+            validation_requests: ValidationRequestsBuilder::empty(),
+            end: PrivateAccumulatedDataBuilder::empty(),
+            constants: CombinedConstantData::empty(),
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/public_kernel_circuit_public_inputs_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/public_kernel_circuit_public_inputs_builder.nr
@@ -1,4 +1,5 @@
-use crate::abis::{
+use crate::{
+    abis::{
     accumulated_data::{CombinedAccumulatedData, PublicAccumulatedDataBuilder},
     combined_constant_data::CombinedConstantData,
     kernel_circuit_public_inputs::{
@@ -6,8 +7,10 @@ use crate::abis::{
     public_kernel_circuit_public_inputs::PublicKernelCircuitPublicInputs
 },
     validation_requests::ValidationRequestsBuilder
+},
+mocked::AggregationObject,
+traits::Empty
 };
-use crate::mocked::AggregationObject;
 
 struct PublicKernelCircuitPublicInputsBuilder {
     aggregation_object: AggregationObject,
@@ -41,6 +44,19 @@ impl PublicKernelCircuitPublicInputsBuilder {
             end: CombinedAccumulatedData::recombine(self.end_non_revertible.finish(), self.end.finish()),
             constants: self.constants,
             revert_code: self.revert_code
+        }
+    }
+}
+
+impl Empty for PublicKernelCircuitPublicInputsBuilder {
+    fn empty() -> Self {
+        PublicKernelCircuitPublicInputsBuilder {
+            aggregation_object: AggregationObject::empty(),
+            validation_requests: ValidationRequestsBuilder::empty(),
+            end_non_revertible: PublicAccumulatedDataBuilder::empty(),
+            end: PublicAccumulatedDataBuilder::empty(),
+            constants: CombinedConstantData::empty(),
+            revert_code: 0 as u8,
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/max_block_number.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/max_block_number.nr
@@ -1,4 +1,4 @@
-use crate::{constants::MAX_BLOCK_NUMBER_LENGTH, traits::{Deserialize, Serialize}};
+use crate::{constants::MAX_BLOCK_NUMBER_LENGTH, traits::{Deserialize, Serialize, Empty}};
 
 struct MaxBlockNumber {
     _opt: Option<u32>
@@ -6,6 +6,12 @@ struct MaxBlockNumber {
 
 impl Default for MaxBlockNumber {
     fn default() -> Self {
+        Self { _opt: Option::none() }
+    }
+}
+
+impl Empty for MaxBlockNumber {
+    fn empty() -> Self {
         Self { _opt: Option::none() }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/max_block_number.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/max_block_number.nr
@@ -84,7 +84,7 @@ fn zeroed_is_none() {
     // Large parts of the kernel rely on zeroed to initialize structs. This conveniently matches what `default` does,
     // and though we should eventually move everything to use `default`, it's good to check for now that both are
     // equivalent.
-    let a: MaxBlockNumber = dep::std::unsafe::zeroed();
+    let a = MaxBlockNumber::default();
     assert(a.is_none());
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/max_block_number.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/max_block_number.nr
@@ -4,12 +4,6 @@ struct MaxBlockNumber {
     _opt: Option<u32>
 }
 
-impl Default for MaxBlockNumber {
-    fn default() -> Self {
-        Self { _opt: Option::none() }
-    }
-}
-
 impl Empty for MaxBlockNumber {
     fn empty() -> Self {
         Self { _opt: Option::none() }
@@ -84,13 +78,13 @@ fn zeroed_is_none() {
     // Large parts of the kernel rely on zeroed to initialize structs. This conveniently matches what `default` does,
     // and though we should eventually move everything to use `default`, it's good to check for now that both are
     // equivalent.
-    let a = MaxBlockNumber::default();
+    let a = MaxBlockNumber::empty();
     assert(a.is_none());
 }
 
 #[test]
 fn serde_default() {
-    let a = MaxBlockNumber::default();
+    let a = MaxBlockNumber::empty();
     let b = MaxBlockNumber::deserialize(a.serialize());
     assert(b.is_none());
 }
@@ -104,21 +98,21 @@ fn serde_some() {
 
 #[test(should_fail)]
 fn default_unwrap_panics() {
-    let a = MaxBlockNumber::default();
+    let a = MaxBlockNumber::empty();
     let _ = a.unwrap();
 }
 
 #[test]
 fn min_default_default() {
-    let a = MaxBlockNumber::default();
-    let b = MaxBlockNumber::default();
+    let a = MaxBlockNumber::empty();
+    let b = MaxBlockNumber::empty();
 
     assert(MaxBlockNumber::min(a, b).is_none());
 }
 
 #[test]
 fn min_default_some() {
-    let a = MaxBlockNumber::default();
+    let a = MaxBlockNumber::empty();
     let b = MaxBlockNumber::new(13);
 
     assert_eq(MaxBlockNumber::min(a, b).unwrap(), 13);
@@ -136,7 +130,7 @@ fn min_some_some() {
 
 #[test]
 fn min_with_u32_default() {
-    let a = MaxBlockNumber::default();
+    let a = MaxBlockNumber::empty();
     let b = 42;
 
     assert_eq(MaxBlockNumber::min_with_u32(a, b).unwrap(), 42);

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/membership_witness.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/membership_witness.nr
@@ -1,6 +1,9 @@
-use crate::constants::{
+use crate::{
+    constants::{
     FUNCTION_TREE_HEIGHT, NULLIFIER_TREE_HEIGHT, NOTE_HASH_TREE_HEIGHT, ROLLUP_VK_TREE_HEIGHT,
     ARCHIVE_HEIGHT, PUBLIC_DATA_TREE_HEIGHT
+},
+traits::Empty
 };
 
 // TODO(Kev): Instead of doing `MembershipWitness<FUNCTION_TREE_HEIGHT>` we are forced 
@@ -40,4 +43,31 @@ struct NoteHashReadRequestMembershipWitness {
     // hint to point kernel to the commitment this rr corresponds to
     is_transient: bool,
     hint_to_note_hash: Field,
+}
+
+impl Empty for VKMembershipWitness {
+    fn empty() -> Self {
+        VKMembershipWitness {
+            leaf_index: 0,
+            sibling_path: [0; ROLLUP_VK_TREE_HEIGHT]
+        }
+    }
+}
+
+impl Empty for NullifierMembershipWitness {
+    fn empty() -> Self {
+        NullifierMembershipWitness {
+            leaf_index: 0,
+            sibling_path: [0; NULLIFIER_TREE_HEIGHT]
+        }
+    }
+}
+
+impl Empty for PublicDataMembershipWitness {
+    fn empty() -> Self {
+        PublicDataMembershipWitness {
+            leaf_index: 0,
+            sibling_path: [0; PUBLIC_DATA_TREE_HEIGHT]
+        }
+    }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_call_stack_item.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_call_stack_item.nr
@@ -72,7 +72,7 @@ impl Empty for PrivateCallStackItem {
 
 #[test]
 fn serialization_of_empty() {
-    let item: PrivateCallStackItem = dep::std::unsafe::zeroed();
+    let item = PrivateCallStackItem::empty();
     let serialized = item.serialize();
     let deserialized = PrivateCallStackItem::deserialize(serialized);
     assert(item.eq(deserialized));
@@ -80,7 +80,7 @@ fn serialization_of_empty() {
 
 #[test]
 fn empty_hash() {
-    let mut item: PrivateCallStackItem = dep::std::unsafe::zeroed();
+    let mut item = PrivateCallStackItem::empty();
     item.function_data.is_private = true;
     let hash = item.hash();
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_call_stack_item.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_call_stack_item.nr
@@ -2,7 +2,7 @@ use crate::{
     abis::{function_data::FunctionData, private_circuit_public_inputs::PrivateCircuitPublicInputs},
     address::AztecAddress,
     constants::{GENERATOR_INDEX__CALL_STACK_ITEM, PRIVATE_CALL_STACK_ITEM_LENGTH}, hash::pedersen_hash,
-    traits::{Deserialize, Hash, Serialize}, utils::reader::Reader
+    traits::{Deserialize, Hash, Serialize, Empty}, utils::reader::Reader
 };
 
 struct PrivateCallStackItem {
@@ -57,6 +57,16 @@ impl Deserialize<PRIVATE_CALL_STACK_ITEM_LENGTH> for PrivateCallStackItem {
 impl Hash for PrivateCallStackItem {
     fn hash(self) -> Field {
         pedersen_hash(self.serialize(), GENERATOR_INDEX__CALL_STACK_ITEM)
+    }
+}
+
+impl Empty for PrivateCallStackItem {
+    fn empty() -> Self {
+        PrivateCallStackItem {
+            contract_address: AztecAddress::empty(),
+            function_data: FunctionData::empty(),
+            public_inputs: PrivateCircuitPublicInputs::empty(),
+        }
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_circuit_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_circuit_public_inputs.nr
@@ -200,7 +200,7 @@ impl Empty for PrivateCircuitPublicInputs {
 
 #[test]
 fn serialization_of_empty() {
-    let pcpi: PrivateCircuitPublicInputs = dep::std::unsafe::zeroed();
+    let pcpi = PrivateCircuitPublicInputs::empty();
     let serialized = pcpi.serialize();
     let deserialized = PrivateCircuitPublicInputs::deserialize(serialized);
     assert(pcpi.eq(deserialized));
@@ -208,7 +208,7 @@ fn serialization_of_empty() {
 
 #[test]
 fn empty_hash() {
-    let inputs: PrivateCircuitPublicInputs = dep::std::unsafe::zeroed();
+    let inputs = PrivateCircuitPublicInputs::empty();
     let hash = inputs.hash();
 
     // Value from private_circuit_public_inputs.test.ts "computes empty item hash" test

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_circuit_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_circuit_public_inputs.nr
@@ -12,7 +12,7 @@ use crate::{
     PRIVATE_CIRCUIT_PUBLIC_INPUTS_LENGTH, GENERATOR_INDEX__PRIVATE_CIRCUIT_PUBLIC_INPUTS
 },
     header::Header, hash::pedersen_hash, messaging::l2_to_l1_message::L2ToL1Message,
-    traits::{Deserialize, Hash, Serialize}, utils::reader::Reader
+    traits::{Deserialize, Hash, Serialize, Empty}, utils::reader::Reader
 };
 
 struct PrivateCircuitPublicInputs {
@@ -165,6 +165,36 @@ impl Deserialize<PRIVATE_CIRCUIT_PUBLIC_INPUTS_LENGTH> for PrivateCircuitPublicI
 impl Hash for PrivateCircuitPublicInputs {
     fn hash(self) -> Field {
         pedersen_hash(self.serialize(), GENERATOR_INDEX__PRIVATE_CIRCUIT_PUBLIC_INPUTS)
+    }
+}
+
+
+impl Empty for PrivateCircuitPublicInputs {
+    fn empty() -> Self {
+        PrivateCircuitPublicInputs {
+            call_context: CallContext::empty(),
+            args_hash: 0,
+            return_values: [0; RETURN_VALUES_LENGTH],
+            min_revertible_side_effect_counter: 0 as u32,
+            max_block_number: MaxBlockNumber::empty(),
+            note_hash_read_requests: [SideEffect::empty(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+            nullifier_read_requests: [ReadRequest::empty(); MAX_NULLIFIER_READ_REQUESTS_PER_CALL],
+            nullifier_key_validation_requests: [NullifierKeyValidationRequest::empty(); MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_CALL],
+            new_note_hashes: [SideEffect::empty(); MAX_NEW_NOTE_HASHES_PER_CALL],
+            new_nullifiers: [SideEffectLinkedToNoteHash::empty(); MAX_NEW_NULLIFIERS_PER_CALL],
+            private_call_stack_hashes: [0; MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL],
+            public_call_stack_hashes: [0; MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL],
+            new_l2_to_l1_msgs: [L2ToL1Message::empty(); MAX_NEW_L2_TO_L1_MSGS_PER_CALL],
+            start_side_effect_counter : 0 as u32,
+            end_side_effect_counter : 0 as u32,
+            encrypted_logs_hash: 0,
+            unencrypted_logs_hash: 0,
+            encrypted_log_preimages_length: 0,
+            unencrypted_log_preimages_length: 0,
+            historical_header: Header::empty(),
+            chain_id: 0,
+            version: 0,
+        }
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_circuit_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_circuit_public_inputs.nr
@@ -174,7 +174,7 @@ impl Empty for PrivateCircuitPublicInputs {
         PrivateCircuitPublicInputs {
             call_context: CallContext::empty(),
             args_hash: 0,
-            return_values: [0; RETURN_VALUES_LENGTH],
+            returns_hash: 0,
             min_revertible_side_effect_counter: 0 as u32,
             max_block_number: MaxBlockNumber::empty(),
             note_hash_read_requests: [SideEffect::empty(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_call_stack_item.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_call_stack_item.nr
@@ -31,7 +31,7 @@ impl Hash for PublicCallStackItem {
 impl PublicCallStackItem {
     fn as_execution_request(self) -> Self {
         let public_inputs = self.public_inputs;
-        let mut request_public_inputs: PublicCircuitPublicInputs = dep::std::unsafe::zeroed();
+        let mut request_public_inputs = PublicCircuitPublicInputs::empty();
         request_public_inputs.call_context = public_inputs.call_context;
         request_public_inputs.args_hash = public_inputs.args_hash;
 
@@ -60,7 +60,7 @@ mod tests {
         let contract_address = AztecAddress::from_field(1);
         let function_data = FunctionData { selector: FunctionSelector::from_u32(2), is_private: false };
 
-        let mut public_inputs: PublicCircuitPublicInputs = dep::std::unsafe::zeroed();
+        let mut public_inputs = PublicCircuitPublicInputs::empty();
         public_inputs.new_note_hashes[0] = SideEffect{
             value: 1,
             counter: 0,
@@ -78,7 +78,7 @@ mod tests {
         let contract_address = AztecAddress::from_field(1);
         let function_data = FunctionData { selector: FunctionSelector::from_u32(2), is_private: false };
 
-        let mut public_inputs: PublicCircuitPublicInputs = dep::std::unsafe::zeroed();
+        let mut public_inputs = PublicCircuitPublicInputs::empty();
         public_inputs.new_note_hashes[0] = SideEffect{
             value: 1,
             counter: 0,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_circuit_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_circuit_public_inputs.nr
@@ -13,7 +13,7 @@ use crate::{
 },
     contrakt::{storage_read::StorageRead, storage_update_request::StorageUpdateRequest},
     hash::pedersen_hash, header::Header, messaging::l2_to_l1_message::L2ToL1Message,
-    traits::{Hash, Serialize, Deserialize}, utils::reader::Reader
+    traits::{Hash, Serialize, Deserialize, Empty}, utils::reader::Reader
 };
 
 struct PublicCircuitPublicInputs{
@@ -132,6 +132,31 @@ impl Deserialize<PUBLIC_CIRCUIT_PUBLIC_INPUTS_LENGTH> for PublicCircuitPublicInp
 impl Hash for PublicCircuitPublicInputs {
     fn hash(self) -> Field {
         pedersen_hash(self.serialize(), GENERATOR_INDEX__PUBLIC_CIRCUIT_PUBLIC_INPUTS)
+    }
+}
+
+impl Empty for PublicCircuitPublicInputs {
+    fn empty() -> Self {
+        PublicCircuitPublicInputs {
+            call_context: CallContext::empty(),
+            args_hash: 0,
+            return_values: [0; RETURN_VALUES_LENGTH],
+            nullifier_read_requests: [ReadRequest::empty(); MAX_NULLIFIER_READ_REQUESTS_PER_CALL],
+            nullifier_non_existent_read_requests: [ReadRequest::empty(); MAX_NULLIFIER_NON_EXISTENT_READ_REQUESTS_PER_CALL],
+            contract_storage_update_requests: [StorageUpdateRequest::empty(); MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_CALL],
+            contract_storage_reads: [StorageRead::empty(); MAX_PUBLIC_DATA_READS_PER_CALL],
+            public_call_stack_hashes: [0; MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL],
+            new_note_hashes: [SideEffect::empty(); MAX_NEW_NOTE_HASHES_PER_CALL],
+            new_nullifiers: [SideEffectLinkedToNoteHash::empty(); MAX_NEW_NULLIFIERS_PER_CALL],
+            new_l2_to_l1_msgs: [L2ToL1Message::empty(); MAX_NEW_L2_TO_L1_MSGS_PER_CALL],
+            start_side_effect_counter: 0 as u32,
+            end_side_effect_counter: 0 as u32,
+            unencrypted_logs_hash: 0,
+            unencrypted_log_preimages_length: 0,
+            historical_header: Header::empty(),
+            prover_address: AztecAddress::zero(),
+            revert_code: 0 as u8,
+        }
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_circuit_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_circuit_public_inputs.nr
@@ -140,7 +140,7 @@ impl Empty for PublicCircuitPublicInputs {
         PublicCircuitPublicInputs {
             call_context: CallContext::empty(),
             args_hash: 0,
-            return_values: [0; RETURN_VALUES_LENGTH],
+            returns_hash: 0,
             nullifier_read_requests: [ReadRequest::empty(); MAX_NULLIFIER_READ_REQUESTS_PER_CALL],
             nullifier_non_existent_read_requests: [ReadRequest::empty(); MAX_NULLIFIER_NON_EXISTENT_READ_REQUESTS_PER_CALL],
             contract_storage_update_requests: [StorageUpdateRequest::empty(); MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_CALL],
@@ -162,7 +162,7 @@ impl Empty for PublicCircuitPublicInputs {
 
 #[test]
 fn serialization_of_empty() {
-    let pcpi: PublicCircuitPublicInputs = dep::std::unsafe::zeroed();
+    let pcpi = PublicCircuitPublicInputs::empty();
     let serialized = pcpi.serialize();
     let deserialized = PublicCircuitPublicInputs::deserialize(serialized);
     assert(pcpi.eq(deserialized));
@@ -170,7 +170,7 @@ fn serialization_of_empty() {
 
 #[test]
 fn empty_hash() {
-    let inputs: PublicCircuitPublicInputs = dep::std::unsafe::zeroed();
+    let inputs = PublicCircuitPublicInputs::empty();
     let hash = inputs.hash();
 
     // Value from public_circuit_public_inputs.test.ts "computes empty item hash" test

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/validation_requests/validation_requests_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/validation_requests/validation_requests_builder.nr
@@ -10,7 +10,8 @@ use crate::{
     MAX_NOTE_HASH_READ_REQUESTS_PER_TX, MAX_NULLIFIER_READ_REQUESTS_PER_TX,
     MAX_NULLIFIER_NON_EXISTENT_READ_REQUESTS_PER_TX, MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_TX,
     MAX_PUBLIC_DATA_READS_PER_TX
-}
+},
+traits::Empty,
 };
 
 struct ValidationRequestsBuilder {
@@ -36,5 +37,18 @@ impl ValidationRequestsBuilder {
 
     pub fn to_rollup(self) -> RollupValidationRequests {
         RollupValidationRequests { max_block_number: self.max_block_number }
+    }
+}
+
+impl Empty for ValidationRequestsBuilder {
+    fn empty() -> Self {
+        ValidationRequestsBuilder {
+            max_block_number: MaxBlockNumber::empty(),
+            note_hash_read_requests: BoundedVec::new(),
+            nullifier_read_requests: BoundedVec::new(),
+            nullifier_non_existent_read_requests: BoundedVec::new(),
+            nullifier_key_validation_requests: BoundedVec::new(),
+            public_data_reads: BoundedVec::new(),
+        }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/grumpkin_private_key.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/grumpkin_private_key.nr
@@ -1,5 +1,8 @@
 use dep::std::{cmp::Eq, grumpkin_scalar::GrumpkinScalar, grumpkin_scalar_mul::grumpkin_fixed_base};
-use crate::grumpkin_point::GrumpkinPoint;
+use crate::{
+    grumpkin_point::GrumpkinPoint,
+    traits::Empty
+};
 
 global GRUMPKIN_PRIVATE_KEY_SERIALIZED_LEN: Field = 2;
 
@@ -11,6 +14,12 @@ struct GrumpkinPrivateKey {
 impl Eq for GrumpkinPrivateKey {
     fn eq(self, key: GrumpkinPrivateKey) -> bool {
         (key.high == self.high) & (key.low == self.low)
+    }
+}
+
+impl Empty for GrumpkinPrivateKey {
+    fn empty() -> Self {
+        Self { high: 0, low: 0 }
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/header.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/header.nr
@@ -82,7 +82,7 @@ impl Hash for Header {
 
 #[test]
 fn serialization_of_empty() {
-    let header: Header = dep::std::unsafe::zeroed();
+    let header = Header::empty();
     let serialized = header.serialize();
     let deserialized = Header::deserialize(serialized);
     assert(header.eq(deserialized));
@@ -90,13 +90,13 @@ fn serialization_of_empty() {
 
 #[test]
 fn hash_smoke() {
-    let header: Header = dep::std::unsafe::zeroed();
+    let header = Header::empty();
     let _hashed = header.hash();
 }
 
 #[test]
 fn empty_hash_is_zero() {
-    let header: Header = dep::std::unsafe::zeroed();
+    let header = Header::empty();
     let hash = header.hash();
 
     // Value from new_contract_data.test.ts "computes empty hash" test

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/indexed_tree.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/indexed_tree.nr
@@ -20,13 +20,13 @@ pub fn batch_insert<Value, Leaf, SubtreeWidth, SiblingPathLength, SubtreeHeight,
     build_insertion_leaf: fn(Value, Leaf) -> Leaf,
     _subtree_height: [Field; SubtreeHeight],
     _tree_height: [Field; TreeHeight]
-) -> AppendOnlyTreeSnapshot where Value: Eq + Empty, Leaf: Hash {
+) -> AppendOnlyTreeSnapshot where Value: Eq + Empty, Leaf: Hash + Empty {
     // A permutation to the values is provided to make the insertion use only one insertion strategy
     check_permutation(values_to_insert, sorted_values, sorted_values_indexes);
 
     // Now, update the existing leaves with the new leaves
     let mut current_tree_root = start_snapshot.root;
-    let mut insertion_subtree: [Leaf; SubtreeWidth] = dep::std::unsafe::zeroed();
+    let mut insertion_subtree = [Leaf::empty(); SubtreeWidth];
     let start_insertion_index = start_snapshot.next_available_leaf_index;
 
     for i in 0..sorted_values.len() {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/membership.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/membership.nr
@@ -1,8 +1,17 @@
-use crate::{merkle_tree::{leaf_preimage::IndexedTreeLeafPreimage, root::root_from_sibling_path}};
+use crate::{merkle_tree::{leaf_preimage::IndexedTreeLeafPreimage, root::root_from_sibling_path}, traits::Empty};
 
 struct MembershipWitness<N> {
     leaf_index: Field,
     sibling_path: [Field; N]
+}
+
+impl<N> Empty for MembershipWitness<N> {
+    fn empty() -> Self {
+        MembershipWitness {
+            leaf_index: 0,
+            sibling_path: [0; N]
+        }
+    }
 }
 
 pub fn check_membership<N>(leaf: Field, index: Field, sibling_path: [Field; N], root: Field) -> bool {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/merkle_tree.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/merkle_tree.nr
@@ -1,6 +1,17 @@
+use crate::traits::Empty;
+
 struct MerkleTree<N> {
     leaves: [Field; N],
     nodes: [Field; N],
+}
+
+impl<N> Empty for MerkleTree<N> {
+    fn empty() -> Self {
+        MerkleTree {
+            leaves: [0; N],
+            nodes: [0; N]
+        }
+    }
 }
 
 impl<N> MerkleTree<N> {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/mocked.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/mocked.nr
@@ -1,11 +1,31 @@
 // This file contains items which are mocked because 
 // they need the proof system.
+use crate::traits::Empty;
+
 
 struct AggregationObject{}
 
 struct Proof{}
 
 struct VerificationKey{}
+
+impl Empty for AggregationObject {
+    fn empty() -> Self {
+        AggregationObject {}
+    }
+}
+
+impl Empty for Proof {
+    fn empty() -> Self {
+        Proof {}
+    }
+}
+
+impl Empty for VerificationKey {
+    fn empty() -> Self {
+        VerificationKey {}
+    }
+}
 
 // Perform recursive verification of the previous kernel proof and private call
 // proof.

--- a/noir-projects/noir-protocol-circuits/crates/types/src/partial_state_reference.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/partial_state_reference.nr
@@ -62,7 +62,7 @@ impl Empty for PartialStateReference {
 
 #[test]
 fn serialization_of_empty() {
-    let partial: PartialStateReference = dep::std::unsafe::zeroed();
+    let partial = PartialStateReference::empty();
     let _serialized = partial.serialize();
     let _deserialized = PartialStateReference::deserialize(_serialized);
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/state_reference.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/state_reference.nr
@@ -55,7 +55,7 @@ impl Empty for StateReference {
 
 #[test]
 fn serialization_of_empty() {
-    let state: StateReference = dep::std::unsafe::zeroed();
+    let state = StateReference::empty();
     let _serialized = state.serialize();
     let _deserialized = StateReference::deserialize(_serialized);
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -23,7 +23,8 @@ use crate::{
     VK_TREE_HEIGHT
 },
     hash::silo_nullifier, header::Header, mocked::{AggregationObject, Proof, VerificationKey},
-    tests::fixtures, transaction::tx_context::TxContext
+    tests::fixtures, transaction::tx_context::TxContext,
+    traits::Empty
 };
 use dep::std::unsafe;
 
@@ -86,7 +87,7 @@ impl FixtureBuilder {
             public_data_update_requests: BoundedVec::new(),
             private_call_stack: BoundedVec::new(),
             public_call_stack: BoundedVec::new(),
-            max_block_number: MaxBlockNumber::default(),
+            max_block_number: MaxBlockNumber::empty(),
             note_hash_read_requests: BoundedVec::new(),
             nullifier_read_requests: BoundedVec::new(),
             nullifier_non_existent_read_requests: BoundedVec::new(),
@@ -233,7 +234,7 @@ impl FixtureBuilder {
         let mocked_value_offset = self.new_note_hashes.len() + 1;
         for i in 0..MAX_NEW_NOTE_HASHES_PER_TX {
             if i < num_new_note_hashes {
-                // The default value is its index + 1.
+                // The empty value is its index + 1.
                 self.new_note_hashes.push(
                     SideEffect { value: (i + mocked_value_offset) as Field, counter: self.next_counter() }
                 );
@@ -261,9 +262,9 @@ impl FixtureBuilder {
         for i in 0..MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX {
             if i < num_updates {
                 let update_request = PublicDataUpdateRequest {
-                    // The default leaf index is its index + 23.
+                    // The empty leaf index is its index + 23.
                     leaf_slot: (value_offset + i + 23) as Field,
-                    // The default value is its index + 678.
+                    // The empty value is its index + 678.
                     new_value: (value_offset + i + 678) as Field
                 };
                 self.public_data_update_requests.push(update_request);
@@ -276,9 +277,9 @@ impl FixtureBuilder {
         for i in 0..MAX_PUBLIC_DATA_READS_PER_TX {
             if i < num_reads {
                 let read_request = PublicDataRead {
-                    // The default leaf index is its index + 34.
+                    // The empty leaf index is its index + 34.
                     leaf_slot: (value_offset + i + 34) as Field,
-                    // The default value is its index + 5566.
+                    // The empty value is its index + 5566.
                     value: (value_offset + i + 5566) as Field
                 };
                 self.public_data_reads.push(read_request);
@@ -375,5 +376,39 @@ impl FixtureBuilder {
         let counter = self.counter;
         self.counter += 1;
         counter
+    }
+}
+
+impl Empty for FixtureBuilder {
+    fn empty() -> Self {
+        FixtureBuilder {
+            contract_address: AztecAddress::zero(),
+            storage_contract_address: AztecAddress::zero(),
+            historical_header: Header::empty(),
+            tx_context: TxContext::empty(),
+            new_note_hashes: BoundedVec::new(),
+            new_nullifiers: BoundedVec::new(),
+            new_l2_to_l1_msgs: BoundedVec::new(),
+            encrypted_logs_hash: 0,
+            unencrypted_logs_hash: 0,
+            encrypted_log_preimages_length: 0,
+            unencrypted_log_preimages_length: 0,
+            public_data_update_requests: BoundedVec::new(),
+            private_call_stack: BoundedVec::new(),
+            public_call_stack: BoundedVec::new(),
+            max_block_number: MaxBlockNumber::empty(),
+            note_hash_read_requests: BoundedVec::new(),
+            nullifier_read_requests: BoundedVec::new(),
+            nullifier_non_existent_read_requests: BoundedVec::new(),
+            nullifier_key_validation_requests: BoundedVec::new(),
+            public_data_reads: BoundedVec::new(),
+            proof: Proof::empty(),
+            vk: VerificationKey::empty(),
+            vk_index: 0,
+            vk_path: [0; VK_TREE_HEIGHT],
+            revert_code: 0,
+            min_revertible_side_effect_counter: 0,
+            counter: 0
+        }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -26,7 +26,6 @@ use crate::{
     tests::fixtures, transaction::tx_context::TxContext,
     traits::Empty
 };
-use dep::std::unsafe;
 
 struct FixtureBuilder {
     contract_address: AztecAddress,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -262,9 +262,9 @@ impl FixtureBuilder {
         for i in 0..MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX {
             if i < num_updates {
                 let update_request = PublicDataUpdateRequest {
-                    // The empty leaf index is its index + 23.
+                    // The default leaf index is its index + 23.
                     leaf_slot: (value_offset + i + 23) as Field,
-                    // The empty value is its index + 678.
+                    // The default value is its index + 678.
                     new_value: (value_offset + i + 678) as Field
                 };
                 self.public_data_update_requests.push(update_request);
@@ -277,9 +277,9 @@ impl FixtureBuilder {
         for i in 0..MAX_PUBLIC_DATA_READS_PER_TX {
             if i < num_reads {
                 let read_request = PublicDataRead {
-                    // The empty leaf index is its index + 34.
+                    // The default leaf index is its index + 34.
                     leaf_slot: (value_offset + i + 34) as Field,
-                    // The empty value is its index + 5566.
+                    // The default value is its index + 5566.
                     value: (value_offset + i + 5566) as Field
                 };
                 self.public_data_reads.push(read_request);

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -184,14 +184,14 @@ impl FixtureBuilder {
     pub fn to_public_kernel_circuit_public_inputs(self, revertible: bool) -> PublicKernelCircuitPublicInputs {
         let accumulated_data = self.to_public_accumulated_data();
         let end_non_revertible = if revertible {
-            unsafe::zeroed()
+            PublicAccumulatedData::empty()
         } else {
             accumulated_data
         };
         let end = if revertible {
             accumulated_data
         } else {
-            unsafe::zeroed()
+            PublicAccumulatedData::empty()
         };
         let validation_requests = self.to_validation_requests();
         let constants = self.to_constant_data();

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/merkle_tree_utils.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/merkle_tree_utils.nr
@@ -1,4 +1,7 @@
-use crate::merkle_tree::{MerkleTree, calculate_empty_tree_root};
+use crate::{
+    merkle_tree::{MerkleTree, calculate_empty_tree_root},
+    traits::Empty
+};
 
 pub fn compute_zero_hashes<N>(mut hashes: [Field; N]) -> [Field; N] {
     hashes[0] = dep::std::hash::pedersen_hash([0, 0]);
@@ -74,6 +77,17 @@ struct NonEmptyMerkleTree<SUBTREE_ITEMS, TREE_HEIGHT, SUPERTREE_HEIGHT, SUBTREE_
     zero_hashes: [Field; TREE_HEIGHT],
     left_supertree_branch: [Field; SUPERTREE_HEIGHT],
     _phantom_subtree_height: [Field; SUBTREE_HEIGHT],
+}
+
+impl<SUBTREE_ITEMS, TREE_HEIGHT, SUPERTREE_HEIGHT, SUBTREE_HEIGHT> Empty for NonEmptyMerkleTree<SUBTREE_ITEMS, TREE_HEIGHT, SUPERTREE_HEIGHT, SUBTREE_HEIGHT> {
+    fn empty() -> Self {
+        NonEmptyMerkleTree {
+            subtree: MerkleTree::empty(),
+            zero_hashes: [0; TREE_HEIGHT],
+            left_supertree_branch: [0; SUPERTREE_HEIGHT],
+            _phantom_subtree_height: [0; SUBTREE_HEIGHT],
+        }
+    }
 }
 
 impl<SUBTREE_ITEMS, TREE_HEIGHT, SUPERTREE_HEIGHT, SUBTREE_HEIGHT> NonEmptyMerkleTree<SUBTREE_ITEMS, TREE_HEIGHT, SUPERTREE_HEIGHT, SUBTREE_HEIGHT> {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/private_call_data_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/private_call_data_builder.nr
@@ -53,8 +53,8 @@ impl PrivateCallDataBuilder {
             public_inputs,
             is_execution_request: false,
             function_data,
-            private_call_stack: dep::std::unsafe::zeroed(),
-            public_call_stack: dep::std::unsafe::zeroed(),
+            private_call_stack: BoundedVec::new(),
+            public_call_stack: BoundedVec::new(),
             proof: Proof {},
             vk: VerificationKey {},
             function_leaf_membership_witness: contract_function.membership_witness,
@@ -62,7 +62,7 @@ impl PrivateCallDataBuilder {
             public_keys_hash: contract_data.public_keys_hash,
             contract_class_artifact_hash: contract_data.artifact_hash,
             contract_class_public_bytecode_commitment: contract_data.public_bytecode_commitment,
-            note_hash_read_request_membership_witnesses: dep::std::unsafe::zeroed(),
+            note_hash_read_request_membership_witnesses: BoundedVec::new(),
             portal_contract_address: public_inputs.call_context.portal_contract_address,
             acir_hash: contract_function.acir_hash
         }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/private_circuit_public_inputs_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/private_circuit_public_inputs_builder.nr
@@ -57,10 +57,10 @@ impl PrivateCircuitPublicInputsBuilder {
 
         let args_hash = 0;
 
-        let contract_data = fixtures::contracts::empty_contract;
+        let contract_data = fixtures::contracts::default_contract;
         let portal_contract_address = contract_data.portal_contract_address;
 
-        let contract_function = fixtures::contract_functions::empty_private_function;
+        let contract_function = fixtures::contract_functions::default_private_function;
         let function_data = contract_function.data;
 
         let contract_address = contract_data.address;
@@ -116,7 +116,7 @@ impl Empty for PrivateCircuitPublicInputsBuilder {
         PrivateCircuitPublicInputsBuilder {
             call_context: CallContext::empty(),
             args_hash: 0,
-            return_values: BoundedVec::new(),
+            returns_hash: 0,
             min_revertible_side_effect_counter: 0 as u32,
             max_block_number: MaxBlockNumber::empty(),
             note_hash_read_requests: BoundedVec::new(),

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/private_circuit_public_inputs_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/private_circuit_public_inputs_builder.nr
@@ -8,11 +8,14 @@ use crate::{
     address::{AztecAddress, compute_initialization_hash}, header::Header,
     messaging::l2_to_l1_message::L2ToL1Message, tests::fixtures
 };
-use crate::constants::{
+use crate::{
+    constants::{
     MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, MAX_NULLIFIER_READ_REQUESTS_PER_CALL,
     MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_CALL, MAX_NEW_NOTE_HASHES_PER_CALL,
     MAX_NEW_NULLIFIERS_PER_CALL, MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL,
     MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL, MAX_NEW_L2_TO_L1_MSGS_PER_CALL
+    },
+    traits::Empty
 };
 
 struct PrivateCircuitPublicInputsBuilder {
@@ -50,14 +53,14 @@ struct PrivateCircuitPublicInputsBuilder {
 
 impl PrivateCircuitPublicInputsBuilder {
     pub fn new() -> Self {
-        let mut public_inputs: PrivateCircuitPublicInputsBuilder = dep::std::unsafe::zeroed();
+        let mut public_inputs = PrivateCircuitPublicInputsBuilder::empty();
 
         let args_hash = 0;
 
-        let contract_data = fixtures::contracts::default_contract;
+        let contract_data = fixtures::contracts::empty_contract;
         let portal_contract_address = contract_data.portal_contract_address;
 
-        let contract_function = fixtures::contract_functions::default_private_function;
+        let contract_function = fixtures::contract_functions::empty_private_function;
         let function_data = contract_function.data;
 
         let contract_address = contract_data.address;
@@ -104,6 +107,33 @@ impl PrivateCircuitPublicInputsBuilder {
             historical_header: self.historical_header,
             chain_id: self.chain_id,
             version: self.version
+        }
+    }
+}
+
+impl Empty for PrivateCircuitPublicInputsBuilder {
+    fn empty() -> Self {
+        PrivateCircuitPublicInputsBuilder {
+            call_context: CallContext::empty(),
+            args_hash: 0,
+            return_values: BoundedVec::new(),
+            min_revertible_side_effect_counter: 0 as u32,
+            max_block_number: MaxBlockNumber::empty(),
+            note_hash_read_requests: BoundedVec::new(),
+            nullifier_read_requests: BoundedVec::new(),
+            nullifier_key_validation_requests: BoundedVec::new(),
+            new_note_hashes: BoundedVec::new(),
+            new_nullifiers: BoundedVec::new(),
+            private_call_stack_hashes: BoundedVec::new(),
+            public_call_stack_hashes: BoundedVec::new(),
+            new_l2_to_l1_msgs: BoundedVec::new(),
+            encrypted_logs_hash: 0,
+            unencrypted_logs_hash: 0,
+            encrypted_log_preimages_length: 0,
+            unencrypted_log_preimages_length: 0,
+            historical_header: Header::empty(),
+            chain_id: 0,
+            version: 0,
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/public_call_data_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/public_call_data_builder.nr
@@ -50,7 +50,7 @@ impl PublicCallDataBuilder {
             public_inputs,
             is_execution_request: false,
             function_data,
-            public_call_stack: dep::std::unsafe::zeroed(),
+            public_call_stack: BoundedVec::new(),
             proof: Proof {},
             portal_contract_address,
             bytecode_hash: contract_function.acir_hash

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/public_circuit_public_inputs_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/public_circuit_public_inputs_builder.nr
@@ -14,7 +14,7 @@ use crate::{
     MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL, MAX_PUBLIC_DATA_READS_PER_CALL,
     MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_CALL
 },
-traits::Empty
+traits::Empty,
 };
 
 struct PublicCircuitPublicInputsBuilder {
@@ -75,7 +75,7 @@ impl Empty for PublicCircuitPublicInputsBuilder {
         PublicCircuitPublicInputsBuilder {
             call_context: CallContext::empty(),
             args_hash: 0,
-            return_values: BoundedVec::new(),
+            returns_hash: 0,
             nullifier_read_requests: BoundedVec::new(),
             nullifier_non_existent_read_requests: BoundedVec::new(),
             contract_storage_update_requests: BoundedVec::new(),
@@ -89,7 +89,7 @@ impl Empty for PublicCircuitPublicInputsBuilder {
             unencrypted_logs_hash: 0,
             unencrypted_log_preimages_length: 0,
             historical_header: Header::empty(),
-            prover_address: AztecAddress::zero(),ř
+            prover_address: AztecAddress::zero(),
             revert_code: 0 as u8,
         }
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/public_circuit_public_inputs_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/public_circuit_public_inputs_builder.nr
@@ -7,11 +7,14 @@ use crate::{
     contrakt::{storage_read::StorageRead, storage_update_request::StorageUpdateRequest}, header::Header,
     messaging::l2_to_l1_message::L2ToL1Message, tests::fixtures
 };
-use crate::constants::{
+use crate::{
+    constants::{
     MAX_NEW_NOTE_HASHES_PER_CALL, MAX_NEW_L2_TO_L1_MSGS_PER_CALL, MAX_NEW_NULLIFIERS_PER_CALL,
     MAX_NULLIFIER_READ_REQUESTS_PER_CALL, MAX_NULLIFIER_NON_EXISTENT_READ_REQUESTS_PER_CALL,
     MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL, MAX_PUBLIC_DATA_READS_PER_CALL,
     MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_CALL
+},
+traits::Empty
 };
 
 struct PublicCircuitPublicInputsBuilder {
@@ -37,7 +40,7 @@ struct PublicCircuitPublicInputsBuilder {
 
 impl PublicCircuitPublicInputsBuilder {
     pub fn new() -> Self {
-        let mut public_inputs: PublicCircuitPublicInputsBuilder = dep::std::unsafe::zeroed();
+        let mut public_inputs = PublicCircuitPublicInputsBuilder::empty();
         public_inputs.call_context.msg_sender = fixtures::MSG_SENDER;
         public_inputs.historical_header = fixtures::HEADER;
         public_inputs
@@ -63,6 +66,31 @@ impl PublicCircuitPublicInputsBuilder {
             historical_header: self.historical_header,
             prover_address: self.prover_address,
             revert_code: self.revert_code
+        }
+    }
+}
+
+impl Empty for PublicCircuitPublicInputsBuilder {
+    fn empty() -> Self {
+        PublicCircuitPublicInputsBuilder {
+            call_context: CallContext::empty(),
+            args_hash: 0,
+            return_values: BoundedVec::new(),
+            nullifier_read_requests: BoundedVec::new(),
+            nullifier_non_existent_read_requests: BoundedVec::new(),
+            contract_storage_update_requests: BoundedVec::new(),
+            contract_storage_reads: BoundedVec::new(),
+            public_call_stack_hashes: BoundedVec::new(),
+            new_note_hashes: BoundedVec::new(),
+            new_nullifiers: BoundedVec::new(),
+            new_l2_to_l1_msgs: BoundedVec::new(),
+            start_side_effect_counter: 0 as u32,
+            end_side_effect_counter: 0 as u32,
+            unencrypted_logs_hash: 0,
+            unencrypted_log_preimages_length: 0,
+            historical_header: Header::empty(),
+            prover_address: AztecAddress::zero(),ř
+            revert_code: 0 as u8,
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/transaction/tx_context.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/transaction/tx_context.nr
@@ -1,6 +1,6 @@
 use crate::{
     constants::{GENERATOR_INDEX__TX_CONTEXT, TX_CONTEXT_DATA_LENGTH}, hash::pedersen_hash,
-    traits::{Deserialize, Hash, Serialize}, utils::reader::Reader
+    traits::{Deserialize, Hash, Serialize, Empty}, utils::reader::Reader
 };
 
 struct TxContext {
@@ -17,6 +17,17 @@ impl Eq for TxContext {
         (self.is_rebate_payment_tx == other.is_rebate_payment_tx) &
         (self.chain_id == other.chain_id) &
         (self.version == other.version)
+    }
+}
+
+impl Empty for TxContext {
+    fn empty() -> Self {
+        TxContext {
+            is_fee_payment_tx : false,
+            is_rebate_payment_tx : false,
+            chain_id : 0,
+            version : 0,
+        }
     }
 }
 
@@ -60,7 +71,7 @@ impl Hash for TxContext {
 
 #[test]
 fn serialization_of_empty() {
-    let context: TxContext = dep::std::unsafe::zeroed();
+    let context = TxContext::empty();
     let serialized = context.serialize();
     let deserialized = TxContext::deserialize(serialized);
     assert(context.eq(deserialized));
@@ -68,7 +79,7 @@ fn serialization_of_empty() {
 
 #[test]
 fn empty_hash() {
-    let inputs: TxContext = dep::std::unsafe::zeroed();
+    let inputs = TxContext::empty();
     let hash = inputs.hash();
 
     // Value from tx_context.test.ts "computes empty item hash" test

--- a/noir-projects/noir-protocol-circuits/crates/types/src/transaction/tx_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/transaction/tx_request.nr
@@ -78,8 +78,7 @@ mod tests {
 
     #[test]
     fn serialization_of_empty() {
-        // Assuming a zeroed initialization for simplicity
-        let request: TxRequest = dep::std::unsafe::zeroed();
+        let request = TxRequest::empty();
         let serialized = request.serialize();
         let deserialized = TxRequest::deserialize(serialized);
         assert(request.eq(deserialized));

--- a/noir-projects/noir-protocol-circuits/crates/types/src/transaction/tx_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/transaction/tx_request.nr
@@ -1,7 +1,7 @@
 use crate::{
     address::AztecAddress, abis::function_data::FunctionData,
     constants::{GENERATOR_INDEX__TX_REQUEST, TX_REQUEST_LENGTH}, hash::pedersen_hash,
-    traits::{Hash, Serialize, Deserialize}, transaction::tx_context::TxContext, utils::reader::Reader
+    traits::{Hash, Serialize, Deserialize, Empty}, transaction::tx_context::TxContext, utils::reader::Reader
 };
 
 struct TxRequest {
@@ -9,6 +9,17 @@ struct TxRequest {
     args_hash: Field,
     tx_context: TxContext,
     function_data: FunctionData,
+}
+
+impl Empty for TxRequest {
+    fn empty() -> Self {
+        TxRequest {
+            origin: AztecAddress::empty(),
+            args_hash: 0,
+            tx_context: TxContext::empty(),
+            function_data: FunctionData::empty()
+        }
+    }
 }
 
 impl Eq for TxRequest {


### PR DESCRIPTION
Replacement of https://github.com/AztecProtocol/aztec-packages/pull/5628 . This one uses the old `Empty` naming but replaces the use of unsafe::zeroed() with the code @sklppy88 created.

In some situations it would be better to use `zero()` instead of `empty()` but I think it doesn't matter that much. This has become too much of a time sink given how low priority it is.

Anyway, renamed AppendOnlyTreeSnapshot::empty() to AppendOnlyTreeSnapshot::zero() in Noir, because we had it named like that in TS and that's one of the cases were it's confusing (is it a snapshot of a zeroed out tree or of a correctly hashed tree that has zero leaves?).