### PR TITLE
fix(ci): builder types

### DIFF
--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI (ARM)
 on:
   push:
     branches: [master]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
     with:
       runner_label: ${{ github.actor }}-x86
       ebs_cache_size_gb: 128
-      runner_concurrency: 8
-      ec2_instance_type: r6g.32xlarge
+      runner_concurrency: 50
+      ec2_instance_type: m6a.32xlarge
       ec2_ami_id: ami-0d8a9b0419ddb331a
       ec2_instance_ttl: 40 # refreshed by jobs
     secrets: inherit
@@ -94,7 +94,7 @@ jobs:
           concurrency_key: bb-native-tests-${{ github.actor }}-x86
       - name: "Native Prover Tests"
         working-directory: ./barretenberg/cpp/
-        timeout-minutes: 25
+        timeout-minutes: 15
         run: earthly --no-output +test
 
   # push benchmarking binaries to dockerhub registry
@@ -111,7 +111,7 @@ jobs:
           concurrency_key: bb-bench-binaries-${{ github.actor }}-x86
       - name: Build and Push Binaries
         if: ${{ github.event.inputs.just_start_spot != 'true' }}
-        timeout-minutes: 25
+        timeout-minutes: 15
         working-directory: ./barretenberg/cpp/
         run: earthly --push +bench-binaries
 
@@ -122,7 +122,7 @@ jobs:
       runner_label: ${{ github.actor }}-bench-x86
       ebs_cache_size_gb: 32
       runner_concurrency: 1
-      ec2_instance_type: r6g.4xlarge
+      ec2_instance_type: m6a.4xlarge
       ec2_ami_id: ami-0d8a9b0419ddb331a
       ec2_instance_ttl: 15 # refreshed by jobs
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           concurrency_key: bb-native-tests-${{ github.actor }}-x86
       - name: "Native Prover Tests"
         working-directory: ./barretenberg/cpp/
-        timeout-minutes: 15
+        timeout-minutes: 25
         run: earthly --no-output +test
 
   # push benchmarking binaries to dockerhub registry
@@ -111,7 +111,7 @@ jobs:
           concurrency_key: bb-bench-binaries-${{ github.actor }}-x86
       - name: Build and Push Binaries
         if: ${{ github.event.inputs.just_start_spot != 'true' }}
-        timeout-minutes: 15
+        timeout-minutes: 25
         working-directory: ./barretenberg/cpp/
         run: earthly --push +bench-binaries
 


### PR DESCRIPTION
The builder types were previously wrong arm machines / ami's from the refactor. This also explains why there was timeouts (underspec'd arm)