### PR TITLE
chore(public): remove getNullifierMembershipWitness

### DIFF
--- a/yarn-project/simulator/src/public/public_execution_context.ts
+++ b/yarn-project/simulator/src/public/public_execution_context.ts
@@ -1,8 +1,4 @@
-import {
-  type NullifierMembershipWitness,
-  UnencryptedFunctionL2Logs,
-  type UnencryptedL2Log,
-} from '@aztec/circuit-types';
+import { UnencryptedFunctionL2Logs, type UnencryptedL2Log } from '@aztec/circuit-types';
 import {
   CallContext,
   FunctionData,
@@ -257,16 +253,6 @@ export class PublicExecutionContext extends TypedOracle {
     this.log.debug(`Returning from nested call: ret=${childExecutionResult.returnValues.join(', ')}`);
 
     return childExecutionResult.returnValues;
-  }
-
-  public async getNullifierMembershipWitness(
-    blockNumber: number,
-    nullifier: Fr,
-  ): Promise<NullifierMembershipWitness | undefined> {
-    if (!this.header.globalVariables.blockNumber.equals(new Fr(blockNumber))) {
-      throw new Error(`Public execution oracle can only access nullifier membership witnesses for the current block`);
-    }
-    return await this.commitmentsDb.getNullifierMembershipWitnessAtLatestBlock(nullifier);
   }
 
   public async checkNullifierExists(nullifier: Fr): Promise<boolean> {


### PR DESCRIPTION
Remove getNullifierMembershipWitness oracle implementation from PUBLIC since it should not be used there. Nullifier checks are done through checkNullifierExists.
