### PR TITLE
fix(ci): error in spot

### DIFF
--- a/.github/workflows/setup-runner.yml
+++ b/.github/workflows/setup-runner.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Start EC2 runner
-        uses: AztecProtocol/ec2-action-builder@v0.4
+        uses: AztecProtocol/ec2-action-builder@v0.5
         with:
           github_token: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Ssh'ing into the spot it was clear the mistake, it was encoding at script creation time and bringing down spot https://github.com/AztecProtocol/ec2-action-builder/commit/e6e779be5e182d6f4688258c526c74913bca336c

