### PR TITLE
feat: add serialisation methods

### DIFF
--- a/yarn-project/circuits.js/src/structs/parity/base_parity_inputs.test.ts
+++ b/yarn-project/circuits.js/src/structs/parity/base_parity_inputs.test.ts
@@ -8,4 +8,11 @@ describe('BaseParityInputs', () => {
     const res = BaseParityInputs.fromBuffer(buffer);
     expect(res).toEqual(expected);
   });
+
+  it(`serializes a BaseParityInputs to hex string and deserializes it back`, () => {
+    const expected = makeBaseParityInputs();
+    const str = expected.toString();
+    const res = BaseParityInputs.fromString(str);
+    expect(res).toEqual(expected);
+  });
 });

--- a/yarn-project/circuits.js/src/structs/parity/base_parity_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/parity/base_parity_inputs.ts
@@ -19,12 +19,31 @@ export class BaseParityInputs {
     return new BaseParityInputs(msgs as Tuple<Fr, typeof NUM_MSGS_PER_BASE_PARITY>);
   }
 
+  /** Serializes the inputs to a buffer. */
   toBuffer() {
     return serializeToBuffer(this.msgs);
   }
 
+  /** Serializes the inputs to a hex string. */
+  toString() {
+    return this.toBuffer().toString('hex');
+  }
+
+  /**
+   * Deserializes the inputs from a buffer.
+   * @param buffer - The buffer to deserialize from.
+   */
   static fromBuffer(buffer: Buffer | BufferReader) {
     const reader = BufferReader.asReader(buffer);
     return new BaseParityInputs(reader.readArray(NUM_MSGS_PER_BASE_PARITY, Fr));
+  }
+
+  /**
+   * Deserializes the inputs from a hex string.
+   * @param str - The hex string to deserialize from.
+   * @returns - The deserialized inputs.
+   */
+  static fromString(str: string) {
+    return BaseParityInputs.fromBuffer(Buffer.from(str, 'hex'));
   }
 }

--- a/yarn-project/circuits.js/src/structs/parity/parity_public_inputs.test.ts
+++ b/yarn-project/circuits.js/src/structs/parity/parity_public_inputs.test.ts
@@ -8,4 +8,11 @@ describe('ParityPublicInputs', () => {
     const res = ParityPublicInputs.fromBuffer(buffer);
     expect(res).toEqual(expected);
   });
+
+  it(`serializes a ParityPublicInputs to hex string and deserializes it back`, () => {
+    const expected = makeParityPublicInputs();
+    const str = expected.toString();
+    const res = ParityPublicInputs.fromString(str);
+    expect(res).toEqual(expected);
+  });
 });

--- a/yarn-project/circuits.js/src/structs/parity/parity_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/parity/parity_public_inputs.ts
@@ -18,20 +18,56 @@ export class ParityPublicInputs {
     }
   }
 
+  /**
+   * Serializes the inputs to a buffer.
+   * @returns The inputs serialized to a buffer.
+   */
   toBuffer() {
     return serializeToBuffer(...ParityPublicInputs.getFields(this));
   }
 
+  /**
+   * Serializes the inputs to a hex string.
+   * @returns The inputs serialized to a hex string.
+   */
+  toString() {
+    return this.toBuffer().toString('hex');
+  }
+
+  /**
+   * Creates a new ParityPublicInputs instance from the given fields.
+   * @param fields - The fields to create the instance from.
+   * @returns The instance.
+   */
   static from(fields: FieldsOf<ParityPublicInputs>): ParityPublicInputs {
     return new ParityPublicInputs(...ParityPublicInputs.getFields(fields));
   }
 
+  /**
+   * Extracts the fields from the given instance.
+   * @param fields - The instance to get the fields from.
+   * @returns The instance fields.
+   */
   static getFields(fields: FieldsOf<ParityPublicInputs>) {
     return [fields.aggregationObject, fields.shaRoot, fields.convertedRoot] as const;
   }
 
+  /**
+   * Deserializes the inputs from a buffer.
+   * @param buffer - The buffer to deserialize from.
+   * @returns A new ParityPublicInputs instance.
+   */
   static fromBuffer(buffer: Buffer | BufferReader) {
     const reader = BufferReader.asReader(buffer);
     return new ParityPublicInputs(reader.readObject(AggregationObject), reader.readObject(Fr), reader.readObject(Fr));
+  }
+
+  /**
+   * Deserializes the inputs from a hex string.
+   * @param str - The hex string to deserialize from.
+   * @returns A new ParityPublicInputs instance.
+   */
+  static fromString(str: string) {
+    return ParityPublicInputs.fromBuffer(Buffer.from(str, 'hex'));
   }
 }

--- a/yarn-project/circuits.js/src/structs/parity/root_parity_inputs.test.ts
+++ b/yarn-project/circuits.js/src/structs/parity/root_parity_inputs.test.ts
@@ -8,4 +8,11 @@ describe('RootParityInputs', () => {
     const res = RootParityInputs.fromBuffer(buffer);
     expect(res).toEqual(expected);
   });
+
+  it(`serializes a RootParityInputs to hex string and deserializes it back`, () => {
+    const expected = makeRootParityInputs();
+    const str = expected.toString();
+    const res = RootParityInputs.fromString(str);
+    expect(res).toEqual(expected);
+  });
 });

--- a/yarn-project/circuits.js/src/structs/parity/root_parity_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/parity/root_parity_inputs.ts
@@ -9,12 +9,38 @@ export class RootParityInputs {
     public readonly children: Tuple<RootParityInput, typeof NUM_BASE_PARITY_PER_ROOT_PARITY>,
   ) {}
 
+  /**
+   * Serializes the inputs to a buffer.
+   * @returns The inputs serialized to a buffer.
+   */
   toBuffer() {
     return serializeToBuffer(this.children);
   }
 
+  /**
+   * Serializes the inputs to a hex string.
+   * @returns The instance serialized to a hex string.
+   */
+  toString() {
+    return this.toBuffer().toString('hex');
+  }
+
+  /**
+   * Deserializes the inputs from a buffer.
+   * @param buffer - The buffer to deserialize from.
+   * @returns A new RootParityInputs instance.
+   */
   static fromBuffer(buffer: Buffer | BufferReader) {
     const reader = BufferReader.asReader(buffer);
     return new RootParityInputs(reader.readArray(NUM_BASE_PARITY_PER_ROOT_PARITY, RootParityInput));
+  }
+
+  /**
+   * Deserializes the inputs from a hex string.
+   * @param str - A hex string to deserialize from.
+   * @returns A new RootParityInputs instance.
+   */
+  static fromString(str: string) {
+    return RootParityInputs.fromBuffer(Buffer.from(str, 'hex'));
   }
 }

--- a/yarn-project/circuits.js/src/structs/proof.test.ts
+++ b/yarn-project/circuits.js/src/structs/proof.test.ts
@@ -1,0 +1,18 @@
+import { makeProof } from '../tests/factories.js';
+import { Proof } from './proof.js';
+
+describe('Proof', () => {
+  it('serializes to buffer and deserializes it back', () => {
+    const expected = makeProof();
+    const buffer = expected.toBuffer();
+    const res = Proof.fromBuffer(buffer);
+    expect(res).toEqual(expected);
+  });
+
+  it('serializes to hex string and deserializes it back', () => {
+    const expected = makeProof();
+    const str = expected.toString();
+    const res = Proof.fromString(str);
+    expect(res).toEqual(expected);
+  });
+});

--- a/yarn-project/circuits.js/src/structs/proof.ts
+++ b/yarn-project/circuits.js/src/structs/proof.ts
@@ -41,6 +41,23 @@ export class Proof {
   public toBuffer() {
     return serializeToBuffer(this.buffer.length, this.buffer);
   }
+
+  /**
+   * Serialize the Proof instance to a hex string.
+   * @returns The hex string representation of the proof data.
+   */
+  public toString() {
+    return this.toBuffer().toString('hex');
+  }
+
+  /**
+   * Deserialize a Proof instance from a hex string.
+   * @param str - A hex string to deserialize from.
+   * @returns - A new Proof instance.
+   */
+  static fromString(str: string) {
+    return Proof.fromBuffer(Buffer.from(str, 'hex'));
+  }
 }
 
 /**

--- a/yarn-project/circuits.js/src/structs/rollup/base_or_merge_rollup_public_inputs.test.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/base_or_merge_rollup_public_inputs.test.ts
@@ -8,4 +8,11 @@ describe('BaseRollupPublicInputs', () => {
     const res = BaseOrMergeRollupPublicInputs.fromBuffer(buffer);
     expect(res).toEqual(expected);
   });
+
+  it(`serializes to hex string and deserializes it back`, () => {
+    const expected = makeBaseOrMergeRollupPublicInputs();
+    const str = expected.toString();
+    const res = BaseOrMergeRollupPublicInputs.fromString(str);
+    expect(res).toEqual(expected);
+  });
 });

--- a/yarn-project/circuits.js/src/structs/rollup/base_or_merge_rollup_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/base_or_merge_rollup_public_inputs.ts
@@ -88,4 +88,21 @@ export class BaseOrMergeRollupPublicInputs {
       this.outHash,
     );
   }
+
+  /**
+   * Serialize this as a hex string.
+   * @returns - The hex string.
+   */
+  toString() {
+    return this.toBuffer().toString('hex');
+  }
+
+  /**
+   * Deserializes from a hex string.
+   * @param str - A hex string to deserialize from.
+   * @returns A new BaseOrMergeRollupPublicInputs instance.
+   */
+  static fromString(str: string) {
+    return BaseOrMergeRollupPublicInputs.fromBuffer(Buffer.from(str, 'hex'));
+  }
 }

--- a/yarn-project/circuits.js/src/structs/rollup/base_rollup.test.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/base_rollup.test.ts
@@ -1,0 +1,18 @@
+import { makeBaseRollupInputs } from '../../tests/factories.js';
+import { BaseRollupInputs } from './base_rollup.js';
+
+describe('BaseRollupInputs', () => {
+  it('serializes to buffer and deserializes it back', () => {
+    const expected = makeBaseRollupInputs();
+    const buffer = expected.toBuffer();
+    const res = BaseRollupInputs.fromBuffer(buffer);
+    expect(res).toEqual(expected);
+  });
+
+  it('serializes to hex string and deserializes it back', () => {
+    const expected = makeBaseRollupInputs();
+    const str = expected.toString();
+    const res = BaseRollupInputs.fromString(str);
+    expect(res).toEqual(expected);
+  });
+});

--- a/yarn-project/circuits.js/src/structs/rollup/merge_rollup.test.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/merge_rollup.test.ts
@@ -1,0 +1,18 @@
+import { makeMergeRollupInputs } from '../../tests/factories.js';
+import { MergeRollupInputs } from './merge_rollup.js';
+
+describe('MergeRollupInputs', () => {
+  it('serializes to buffer and deserializes it back', () => {
+    const expected = makeMergeRollupInputs();
+    const buffer = expected.toBuffer();
+    const res = MergeRollupInputs.fromBuffer(buffer);
+    expect(res).toEqual(expected);
+  });
+
+  it('serializes to hex string and deserializes it back', () => {
+    const expected = makeMergeRollupInputs();
+    const str = expected.toString();
+    const res = MergeRollupInputs.fromString(str);
+    expect(res).toEqual(expected);
+  });
+});

--- a/yarn-project/circuits.js/src/structs/rollup/merge_rollup.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/merge_rollup.ts
@@ -1,6 +1,6 @@
-import { serializeToBuffer } from '@aztec/foundation/serialize';
+import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
-import { type PreviousRollupData } from './previous_rollup_data.js';
+import { PreviousRollupData } from './previous_rollup_data.js';
 
 /**
  * Represents inputs of the merge rollup circuit.
@@ -13,7 +13,38 @@ export class MergeRollupInputs {
     public previousRollupData: [PreviousRollupData, PreviousRollupData],
   ) {}
 
+  /**
+   * Serializes the inputs to a buffer.
+   * @returns The inputs serialized to a buffer.
+   */
   toBuffer() {
     return serializeToBuffer(this.previousRollupData);
+  }
+
+  /**
+   * Serializes the inputs to a hex string.
+   * @returns The instance serialized to a hex string.
+   */
+  toString() {
+    return this.toBuffer().toString('hex');
+  }
+
+  /**
+   * Deserializes the inputs from a buffer.
+   * @param buffer - The buffer to deserialize from.
+   * @returns A new MergeRollupInputs instance.
+   */
+  static fromBuffer(buffer: Buffer | BufferReader) {
+    const reader = BufferReader.asReader(buffer);
+    return new MergeRollupInputs([reader.readObject(PreviousRollupData), reader.readObject(PreviousRollupData)]);
+  }
+
+  /**
+   * Deserializes the inputs from a hex string.
+   * @param str - A hex string to deserialize from.
+   * @returns A new MergeRollupInputs instance.
+   */
+  static fromString(str: string) {
+    return MergeRollupInputs.fromBuffer(Buffer.from(str, 'hex'));
   }
 }

--- a/yarn-project/circuits.js/src/structs/rollup/previous_rollup_data.test.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/previous_rollup_data.test.ts
@@ -1,0 +1,11 @@
+import { makePreviousRollupData } from '../../tests/factories.js';
+import { PreviousRollupData } from './previous_rollup_data.js';
+
+describe('PreviousRollupData', () => {
+  it('serializes to buffer and deserializes it back', () => {
+    const expected = makePreviousRollupData();
+    const buffer = expected.toBuffer();
+    const res = PreviousRollupData.fromBuffer(buffer);
+    expect(res).toEqual(expected);
+  });
+});

--- a/yarn-project/circuits.js/src/structs/rollup/previous_rollup_data.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/previous_rollup_data.ts
@@ -1,11 +1,11 @@
-import { serializeToBuffer } from '@aztec/foundation/serialize';
+import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
-import { type ROLLUP_VK_TREE_HEIGHT } from '../../constants.gen.js';
-import { type MembershipWitness } from '../membership_witness.js';
-import { type Proof } from '../proof.js';
+import { ROLLUP_VK_TREE_HEIGHT } from '../../constants.gen.js';
+import { MembershipWitness } from '../membership_witness.js';
+import { Proof } from '../proof.js';
 import { type UInt32 } from '../shared.js';
-import { type VerificationKey } from '../verification_key.js';
-import { type BaseOrMergeRollupPublicInputs } from './base_or_merge_rollup_public_inputs.js';
+import { VerificationKey } from '../verification_key.js';
+import { BaseOrMergeRollupPublicInputs } from './base_or_merge_rollup_public_inputs.js';
 
 /**
  * Represents the data of a previous merge or base rollup circuit.
@@ -40,5 +40,21 @@ export class PreviousRollupData {
    */
   public toBuffer(): Buffer {
     return serializeToBuffer(this.baseOrMergeRollupPublicInputs, this.proof, this.vk, this.vkIndex, this.vkSiblingPath);
+  }
+
+  /**
+   * Deserializes previous rollup data from a buffer.
+   * @param buffer - A buffer to deserialize from.
+   * @returns A new PreviousRollupData instance.
+   */
+  public static fromBuffer(buffer: Buffer | BufferReader): PreviousRollupData {
+    const reader = BufferReader.asReader(buffer);
+    return new PreviousRollupData(
+      reader.readObject(BaseOrMergeRollupPublicInputs),
+      reader.readObject(Proof),
+      reader.readObject(VerificationKey),
+      reader.readNumber(),
+      MembershipWitness.fromBuffer(reader, ROLLUP_VK_TREE_HEIGHT),
+    );
   }
 }

--- a/yarn-project/circuits.js/src/structs/rollup/public_data_leaf/index.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/public_data_leaf/index.ts
@@ -64,7 +64,7 @@ export class PublicDataTreeLeafPreimage implements IndexedTreeLeafPreimage {
     return new PublicDataTreeLeafPreimage(Fr.ZERO, Fr.ZERO, Fr.ZERO, 0n);
   }
 
-  static fromBuffer(buffer: Buffer): PublicDataTreeLeafPreimage {
+  static fromBuffer(buffer: Buffer | BufferReader): PublicDataTreeLeafPreimage {
     const reader = BufferReader.asReader(buffer);
     const slot = Fr.fromBuffer(reader);
     const value = Fr.fromBuffer(reader);

--- a/yarn-project/circuits.js/src/structs/rollup/root_rollup.test.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/root_rollup.test.ts
@@ -8,4 +8,11 @@ describe('structs/root_rollup', () => {
     const res = RootRollupPublicInputs.fromBuffer(buffer);
     expect(res).toEqual(expected);
   });
+
+  it(`serializes a RootRollupPublicInputs to hex string and deserializes it back`, () => {
+    const expected = makeRootRollupPublicInputs();
+    const str = expected.toString();
+    const res = RootRollupPublicInputs.fromString(str);
+    expect(res).toEqual(expected);
+  });
 });

--- a/yarn-project/circuits.js/src/structs/rollup/root_rollup.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/root_rollup.ts
@@ -1,17 +1,17 @@
-import { type Fr } from '@aztec/foundation/fields';
+import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, type Tuple, serializeToBuffer } from '@aztec/foundation/serialize';
 import { type FieldsOf } from '@aztec/foundation/types';
 
 import {
-  type ARCHIVE_HEIGHT,
-  type L1_TO_L2_MSG_SUBTREE_SIBLING_PATH_LENGTH,
-  type NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
+  ARCHIVE_HEIGHT,
+  L1_TO_L2_MSG_SUBTREE_SIBLING_PATH_LENGTH,
+  NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
 } from '../../constants.gen.js';
 import { AggregationObject } from '../aggregation_object.js';
 import { Header } from '../header.js';
-import { type RootParityInput } from '../parity/root_parity_input.js';
+import { RootParityInput } from '../parity/root_parity_input.js';
 import { AppendOnlyTreeSnapshot } from './append_only_tree_snapshot.js';
-import { type PreviousRollupData } from './previous_rollup_data.js';
+import { PreviousRollupData } from './previous_rollup_data.js';
 
 /**
  * Represents inputs of the root rollup circuit.
@@ -50,14 +50,36 @@ export class RootRollupInputs {
     public newArchiveSiblingPath: Tuple<Fr, typeof ARCHIVE_HEIGHT>,
   ) {}
 
+  /**
+   * Serializes the inputs to a buffer.
+   * @returns - The inputs serialized to a buffer.
+   */
   toBuffer() {
     return serializeToBuffer(...RootRollupInputs.getFields(this));
   }
 
+  /**
+   * Serializes the inputs to a hex string.
+   * @returns The instance serialized to a hex string.
+   */
+  toString() {
+    return this.toBuffer().toString('hex');
+  }
+
+  /**
+   * Creates a new instance from fields.
+   * @param fields - Fields to create the instance from.
+   * @returns A new RootRollupInputs instance.
+   */
   static from(fields: FieldsOf<RootRollupInputs>): RootRollupInputs {
     return new RootRollupInputs(...RootRollupInputs.getFields(fields));
   }
 
+  /**
+   * Extracts fields from an instance.
+   * @param fields - Fields to create the instance from.
+   * @returns An array of fields.
+   */
   static getFields(fields: FieldsOf<RootRollupInputs>) {
     return [
       fields.previousRollupData,
@@ -68,6 +90,33 @@ export class RootRollupInputs {
       fields.startArchiveSnapshot,
       fields.newArchiveSiblingPath,
     ] as const;
+  }
+
+  /**
+   * Deserializes the inputs from a buffer.
+   * @param buffer - A buffer to deserialize from.
+   * @returns A new RootRollupInputs instance.
+   */
+  static fromBuffer(buffer: Buffer | BufferReader): RootRollupInputs {
+    const reader = BufferReader.asReader(buffer);
+    return new RootRollupInputs(
+      [reader.readObject(PreviousRollupData), reader.readObject(PreviousRollupData)],
+      reader.readObject(RootParityInput),
+      reader.readArray(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, Fr),
+      reader.readArray(L1_TO_L2_MSG_SUBTREE_SIBLING_PATH_LENGTH, Fr),
+      reader.readObject(AppendOnlyTreeSnapshot),
+      reader.readObject(AppendOnlyTreeSnapshot),
+      reader.readArray(ARCHIVE_HEIGHT, Fr),
+    );
+  }
+
+  /**
+   * Deserializes the inputs from a hex string.
+   * @param str - A hex string to deserialize from.
+   * @returns A new RootRollupInputs instance.
+   */
+  static fromString(str: string) {
+    return RootRollupInputs.fromBuffer(Buffer.from(str, 'hex'));
   }
 }
 
@@ -110,5 +159,13 @@ export class RootRollupPublicInputs {
       reader.readObject(AppendOnlyTreeSnapshot),
       reader.readObject(Header),
     );
+  }
+
+  toString() {
+    return this.toBuffer().toString('hex');
+  }
+
+  static fromString(str: string) {
+    return RootRollupPublicInputs.fromBuffer(Buffer.from(str, 'hex'));
   }
 }

--- a/yarn-project/circuits.js/src/structs/rollup/state_diff_hints.test.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/state_diff_hints.test.ts
@@ -1,0 +1,11 @@
+import { makeStateDiffHints } from '../../tests/factories.js';
+import { StateDiffHints } from './state_diff_hints.js';
+
+describe('StateDiffHints', () => {
+  it('serializes to buffer and deserializes it back', () => {
+    const expected = makeStateDiffHints();
+    const buffer = expected.toBuffer();
+    const res = StateDiffHints.fromBuffer(buffer);
+    expect(res).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Adds `toString`/`toBuffer`/`fromString`/`fromBuffer` to a couple of classes that didn't have them. Also adds tests for the new functions.
This is needed for future work on proving where proving requests could be sent over the network.
