### PR TITLE
feat: add TimeoutError

### DIFF
--- a/yarn-project/foundation/src/error/index.ts
+++ b/yarn-project/foundation/src/error/index.ts
@@ -4,3 +4,8 @@
  * can be used to handle cases where a process or task is terminated before completion.
  */
 export class InterruptError extends Error {}
+
+/**
+ * An error thrown when an action times out.
+ */
+export class TimeoutError extends Error {}

--- a/yarn-project/foundation/src/fifo/memory_fifo.ts
+++ b/yarn-project/foundation/src/fifo/memory_fifo.ts
@@ -1,3 +1,4 @@
+import { TimeoutError } from '../error/index.js';
 import { createDebugLogger } from '../log/index.js';
 
 /**
@@ -46,7 +47,7 @@ export class MemoryFifo<T> {
           const index = this.waiting.findIndex(r => r === resolve);
           if (index > -1) {
             this.waiting.splice(index, 1);
-            const err = new Error('Timeout getting item from queue.');
+            const err = new TimeoutError('Timeout getting item from queue.');
             reject(err);
           }
         }, timeout * 1000);

--- a/yarn-project/foundation/src/index.ts
+++ b/yarn-project/foundation/src/index.ts
@@ -6,7 +6,7 @@ export * as bigintBuffer from './bigint-buffer/index.js';
 export * as collection from './collection/index.js';
 export * as committable from './committable/index.js';
 export * as crypto from './crypto/index.js';
-export * as errors from './errors/index.js';
+export * as errors from './error/index.js';
 export * as ethAddress from './eth-address/index.js';
 export * as fields from './fields/index.js';
 export * as fifo from './fifo/index.js';

--- a/yarn-project/foundation/src/sleep/index.ts
+++ b/yarn-project/foundation/src/sleep/index.ts
@@ -1,4 +1,4 @@
-import { InterruptError } from '../errors/index.js';
+import { InterruptError } from '../error/index.js';
 
 /**
  * InterruptibleSleep is a utility class that allows you to create an interruptible sleep function.

--- a/yarn-project/foundation/src/sleep/sleep.test.ts
+++ b/yarn-project/foundation/src/sleep/sleep.test.ts
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals';
 
-import { InterruptError } from '../errors/index.js';
+import { InterruptError } from '../error/index.js';
 import { InterruptibleSleep } from './index.js';
 
 describe('InterruptibleSleep', () => {


### PR DESCRIPTION
Adds `TimeoutError` and updates `MemoryFifo` to throw a `TimeoutError` when getting an item from the queue times out.

Renames `errors` to just `error` to match the sub-module exported in `package.json`