### PR TITLE
feat(avm-simulator): plumb noir assertion messages

### DIFF
--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -185,7 +185,7 @@ contract AvmTest {
     #[aztec(public-vm)]
     fn test_get_contract_instance() {
         let ci = get_contract_instance_avm(context.this_address());
-        assert(ci.is_some());
+        assert(ci.is_some(), "Contract instance not found!");
     }
 
     /************************************************************************
@@ -258,7 +258,9 @@ contract AvmTest {
 
     #[aztec(public-vm)]
     fn check_selector() {
-        assert(context.selector() == FunctionSelector::from_signature("check_selector()"));
+        assert(
+            context.selector() == FunctionSelector::from_signature("check_selector()"), "Unexpected selector!"
+        );
     }
 
     #[aztec(public-vm)]
@@ -299,7 +301,7 @@ contract AvmTest {
 
     #[aztec(public-vm)]
     fn assert_nullifier_exists(nullifier: Field) {
-        assert(context.nullifier_exists(nullifier, context.this_address()));
+        assert(context.nullifier_exists(nullifier, context.this_address()), "Nullifier doesn't exist!");
     }
 
     // Use the standard context interface to emit a new nullifier

--- a/yarn-project/simulator/src/avm/avm_machine_state.ts
+++ b/yarn-project/simulator/src/avm/avm_machine_state.ts
@@ -128,6 +128,17 @@ export class AvmMachineState {
     if (!this.halted) {
       throw new Error('Execution results are not ready! Execution is ongoing.');
     }
-    return new AvmContractCallResults(this.reverted, this.output);
+    let revertReason = undefined;
+    if (this.reverted && this.output.length > 0) {
+      try {
+        // Try to interpret the output as a text string.
+        revertReason = new Error(
+          'Reverted with output: ' + String.fromCharCode(...this.output.map(fr => fr.toNumber())),
+        );
+      } catch (e) {
+        revertReason = new Error('Reverted with non-string output');
+      }
+    }
+    return new AvmContractCallResults(this.reverted, this.output, revertReason);
   }
 }

--- a/yarn-project/simulator/src/avm/opcodes/external_calls.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/external_calls.test.ts
@@ -304,11 +304,9 @@ describe('External Calls', () => {
     });
 
     it('Should return data and revert from the revert opcode', async () => {
-      const returnData = [new Fr(1n), new Fr(2n), new Fr(3n)];
+      const returnData = [...'assert message'].flatMap(c => new Field(c.charCodeAt(0)));
 
-      context.machineState.memory.set(0, new Field(1n));
-      context.machineState.memory.set(1, new Field(2n));
-      context.machineState.memory.set(2, new Field(3n));
+      context.machineState.memory.setSlice(0, returnData);
 
       const instruction = new Revert(/*indirect=*/ 0, /*returnOffset=*/ 0, returnData.length);
       await instruction.execute(context);
@@ -316,7 +314,8 @@ describe('External Calls', () => {
       expect(context.machineState.halted).toBe(true);
       expect(context.machineState.getResults()).toEqual({
         reverted: true,
-        output: returnData,
+        revertReason: new Error('Reverted with output: assert message'),
+        output: returnData.map(f => f.toFr()),
       });
     });
   });


### PR DESCRIPTION
Enable recovering Noir assertion messages in the avm simulator.

We had discussed propagating (re-throwing) nested call assertions to callers, to match the current Public behaviour, but I'm not doing it here so that I don't clash with David's work on nested calls. Moreover, the behaviour of reverting if a nested call reverts is currently happening (see `call_public` in AvmContext in noir). The only difference is really that the messsage propagated is different: in current public you get the assertion message from the nested call (I think but I should double check) and in the AVM simulator you'd get "Nested (static) call failed!". We can discuss if we want to change this.
