### PR TITLE
chore(aztec-nr): minor public interface changes

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/avm_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/avm_context.nr
@@ -122,14 +122,6 @@ impl PublicContextInterface for AvmContext {
         nullifier_exists(unsiloed_nullifier, address.to_field()) == 1
     }
 
-    fn push_nullifier_read_request(&mut self, nullifier: Field) {
-        assert(false, "'push_nullifier_read_request' not implemented!");
-    }
-
-    fn push_nullifier_non_existent_read_request(&mut self, nullifier: Field) {
-        assert(false, "'push_nullifier_non_existent_read_request' not implemented!");
-    }
-
     fn accumulate_encrypted_logs<N>(&mut self, log: [Field; N]) {
         assert(false, "'accumulate_encrypted_logs' not implemented!");
     }
@@ -221,10 +213,6 @@ impl ContextInterface for AvmContext {
     }
     fn selector(self) -> FunctionSelector {
         FunctionSelector::from_field(self.inputs.selector)
-    }
-    fn get_header(self) -> Header {
-        assert(false, "'get_header' not implemented!");
-        Header::empty()
     }
     fn get_args_hash(self) -> Field {
         self.inputs.args_hash

--- a/noir-projects/aztec-nr/aztec/src/context/interface.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/interface.nr
@@ -13,7 +13,6 @@ trait ContextInterface {
     fn version(self) -> Field;
     fn selector(self) -> FunctionSelector;
     fn get_args_hash(self) -> Field;
-    fn get_header(self) -> Header;
 }
 
 // TEMPORARY: This trait is to promote sharing of the current public context
@@ -27,8 +26,6 @@ trait PublicContextInterface {
     fn fee_per_da_gas(self) -> Field;
     fn fee_per_l1_gas(self) -> Field;
     fn fee_per_l2_gas(self) -> Field;
-    fn push_nullifier_read_request(&mut self, nullifier: Field);
-    fn push_nullifier_non_existent_read_request(&mut self, nullifier: Field);
     fn message_portal(&mut self, recipient: EthAddress, content: Field);
     fn consume_l1_to_l2_message(&mut self, content: Field, secret: Field, sender: EthAddress);
     fn accumulate_encrypted_logs<N>(&mut self, log: [Field; N]);

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -99,12 +99,6 @@ impl ContextInterface for PrivateContext {
         self.args_hash
     }
 
-    // Returns the header of a block whose state is used during private execution (not the block the transaction is
-    // included in).
-    fn get_header(self) -> Header {
-        self.historical_header
-    }
-
     fn push_new_note_hash(&mut self, note_hash: Field) {
         let side_effect = SideEffect { value: note_hash, counter: self.side_effect_counter };
         self.new_note_hashes.push(side_effect);
@@ -146,6 +140,12 @@ impl PrivateContext {
             // unencrypted_logs_preimages: Vec::new(),
             nullifier_key: Option::none()
         }
+    }
+
+    // Returns the header of a block whose state is used during private execution (not the block the transaction is
+    // included in).
+    fn get_header(self) -> Header {
+        self.historical_header
     }
 
     // Returns the header of an arbitrary block whose block number is less than or equal to the block number

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -130,6 +130,20 @@ impl PublicContext {
         self.return_hash = returns_hasher.hash();
     }
 
+    // Keep private or ask the AVM team if you want to change it.
+    fn push_nullifier_read_request(&mut self, nullifier: Field) {
+        let request = ReadRequest { value: nullifier, counter: self.side_effect_counter };
+        self.nullifier_read_requests.push(request);
+        self.side_effect_counter = self.side_effect_counter + 1;
+    }
+
+    // Keep private or ask the AVM team if you want to change it.
+    fn push_nullifier_non_existent_read_request(&mut self, nullifier: Field) {
+        let request = ReadRequest { value: nullifier, counter: self.side_effect_counter };
+        self.nullifier_non_existent_read_requests.push(request);
+        self.side_effect_counter = self.side_effect_counter + 1;
+    }
+
     pub fn finish(self) -> PublicCircuitPublicInputs {
         // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1165)
         let unencrypted_logs_hash = 0;
@@ -189,10 +203,6 @@ impl ContextInterface for PublicContext {
         self.args_hash
     }
 
-    fn get_header(self) -> Header {
-        self.historical_header
-    }
-
     fn push_new_note_hash(&mut self, note_hash: Field) {
         let side_effect = SideEffect { value: note_hash, counter: self.side_effect_counter };
         self.new_note_hashes.push(side_effect);
@@ -243,18 +253,6 @@ impl PublicContextInterface for PublicContext {
         // Current public can only check for settled nullifiers, so we always silo.
         let siloed_nullifier = silo_nullifier(address, unsiloed_nullifier);
         nullifier_exists_oracle(siloed_nullifier) == 1
-    }
-
-    fn push_nullifier_read_request(&mut self, nullifier: Field) {
-        let request = ReadRequest { value: nullifier, counter: self.side_effect_counter };
-        self.nullifier_read_requests.push(request);
-        self.side_effect_counter = self.side_effect_counter + 1;
-    }
-
-    fn push_nullifier_non_existent_read_request(&mut self, nullifier: Field) {
-        let request = ReadRequest { value: nullifier, counter: self.side_effect_counter };
-        self.nullifier_non_existent_read_requests.push(request);
-        self.side_effect_counter = self.side_effect_counter + 1;
     }
 
     fn message_portal(&mut self, recipient: EthAddress, content: Field) {

--- a/noir-projects/aztec-nr/aztec/src/oracle/create_commitment.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/create_commitment.nr
@@ -1,6 +1,0 @@
-#[oracle(createCommitment)]
-fn create_commitment_oracle(_commitment: Field) -> Field {}
-
-unconstrained pub fn create_commitment(commitment: Field) {
-    assert(create_commitment_oracle(commitment) == 0);
-}


### PR DESCRIPTION
The purpose of this PR is to minimize the possible change surface on public interfaces, so that moving to the AVM simulator is easier.

* Removed `get_header()` from PublicContext(Interface). It's currently unused, and the AVM does not support it as is. It CAN be added to the AvmContext if needed. However, as we are not using it now, and the AVM form is not clear (HEADERMEMBER? or whole header?) then it's better to discourage its use.
* Moved `push_*_read_request` from PublicContextInterface to the PublicContext iself, as PRIVATE methods: These methods are currently unused, and IIUC, will not be used in the AVM. The only use case for these in current public would be to push read request in `PublicContext::nullifier_exists`.
* Remove unused `createCommitment` oracle.