### PR TITLE
chore(ci): Notify internal Slack channel when CI breaks on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
 
   notify:
     needs: [e2e, bb-native-tests, bb-bench]
+    runs-on: ${{ github.actor }}-x86
     if: ${{ github.ref == 'refs/heads/master' && failure() }}
     steps:
       - name: Send notification to aztec3-ci channel if workflow failed on master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
 
   notify:
     needs: [e2e, bb-native-tests, bb-bench]
-    runs-on: ${{ github.actor }}-x86
+    runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/master' && failure() }}
     steps:
       - name: Send notification to aztec3-ci channel if workflow failed on master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,3 +149,17 @@ jobs:
     needs: [e2e, bb-native-tests, bb-bench]
     steps:
       - run: echo Pull request merging now allowed.
+
+  notify:
+    needs: [e2e, bb-native-tests, bb-bench]
+    if: ${{ github.ref == 'refs/heads/master' && failure() }}
+    steps:
+      - name: Send notification to aztec3-ci channel if workflow failed on master
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFY_WORKFLOW_TRIGGER_URL }}


### PR DESCRIPTION
Uses the official Slack github action with the recommended "workflow" flow. @ludamad, @charlielye, and @PhilWindle are admins of the workflow in Slack.