### PR TITLE
fix: check if a runner is available + safer refcount for spot life

### DIFF
--- a/.github/workflows/setup-runner.yml
+++ b/.github/workflows/setup-runner.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Start EC2 runner
-        uses: AztecProtocol/ec2-action-builder@v0.8
+        uses: AztecProtocol/ec2-action-builder@v0.10
         with:
           github_token: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
See commits for action https://github.com/AztecProtocol/ec2-action-builder/compare/v0.8...v0.10
This should cause less trying to contact a dying spot + spot dying incorrectly
TODO probably bundle action into monorepo at this point