### PR TITLE
DO NOT MERGE: bug field asm num registers

### DIFF
--- a/barretenberg/cpp/pil/avm/avm_alu.pil
+++ b/barretenberg/cpp/pil/avm/avm_alu.pil
@@ -17,6 +17,7 @@ namespace avm_alu(256);
     pol commit op_div;
     pol commit op_not;
     pol commit op_eq;
+    pol commit op_cast;
     pol commit alu_sel; // Predicate to activate the copy of intermediate registers to ALU table.
     pol commit op_lt;
     pol commit op_lte;
@@ -59,7 +60,7 @@ namespace avm_alu(256);
     pol commit cf;
 
     // Compute predicate telling whether there is a row entry in the ALU table.
-    alu_sel = op_add + op_sub + op_mul + op_not + op_eq + op_lt + op_lte;
+    alu_sel = op_add + op_sub + op_mul + op_not + op_eq + op_cast + op_lt + op_lte;
     cmp_sel = op_lt + op_lte;
 
     // ========= Type Constraints =============================================
@@ -265,6 +266,20 @@ namespace avm_alu(256);
     #[ALU_OP_EQ]
     op_eq * (DIFF * (ic * (1 - op_eq_diff_inv) + op_eq_diff_inv) - 1 + ic) = 0;
 
+    // ========= CAST Operation Constraints ===============================
+    // We handle the input ia independently of its tag, i.e., we suppose it can take
+    // any value between 0 and p-1.
+    // We decompose the input ia in 8-bit/16-bit limbs and prove that the decomposition
+    // sums up to ia over the integers (i.e., no modulo p wrapping). To prove this,
+    // we perform a "school subtraction" (borrowing) over 128-bit limbs.
+    // The input I is written I = I_l + I_h * 2^128 and the field order P = P_l + P_h * 2^128.
+    // The school subtraction result is D = D_l + D_h * 2^128 and we prove the correctness
+    // through: P_l - I_l - CF * 2^128 == D_l AND P_h - I_h + CF == D_h
+    // where CF is a carry/borrowing bit. CF == 1 <==> P_l < I_l.
+
+    #[ALU_OP_CAST]
+    op_cast * (SUM_TAG + ff_tag * ia - ic) = 0;
+
     // ========= LT/LTE Operation Constraints ===============================
     // There are two routines that we utilise as part of this LT/LTE check
     // (1) Decomposition into two 128-bit limbs, lo and hi respectively and a borrow (1 or 0);
@@ -282,7 +297,7 @@ namespace avm_alu(256);
     // (x - y - 1) * q + (y - x) (1 - q) = result
 
     // If LT, then swap ia and ib else keep the same
-    pol INPUT_IA  = op_lt * ib + op_lte * ia;
+    pol INPUT_IA  = op_lt * ib + (op_lte + op_cast) * ia;
     pol INPUT_IB  = op_lt * ia + op_lte * ib;
 
     pol commit borrow;
@@ -290,7 +305,7 @@ namespace avm_alu(256);
     pol commit a_hi;
     // Check INPUT_IA is well formed from its lo and hi limbs
     #[INPUT_DECOMP_1]
-    INPUT_IA = (a_lo + 2 ** 128 * a_hi) * cmp_sel;
+    INPUT_IA = (a_lo + 2 ** 128 * a_hi) * (cmp_sel + op_cast);
 
     pol commit b_lo;
     pol commit b_hi;
@@ -311,9 +326,9 @@ namespace avm_alu(256);
     // First condition is if borrow = 0, second condition is if borrow = 1
     // This underflow check is done by the 128-bit check that is performed on each of these lo and hi limbs.
     #[SUB_LO_1]
-    (p_sub_a_lo  - (53438638232309528389504892708671455232 - a_lo + p_a_borrow * 2 ** 128)) * cmp_sel = 0;
+    (p_sub_a_lo  - (53438638232309528389504892708671455232 - a_lo + p_a_borrow * 2 ** 128)) * (cmp_sel + op_cast) = 0;
     #[SUB_HI_1]
-    (p_sub_a_hi - (64323764613183177041862057485226039389 - a_hi - p_a_borrow)) * cmp_sel = 0;
+    (p_sub_a_hi - (64323764613183177041862057485226039389 - a_hi - p_a_borrow)) * (cmp_sel + op_cast) = 0;
 
     pol commit p_sub_b_lo;
     pol commit p_sub_b_hi;
@@ -436,11 +451,11 @@ namespace avm_alu(256);
 
     pol commit rng_chk_lookup_selector;
     #[RNG_CHK_LOOKUP_SELECTOR]
-    rng_chk_lookup_selector' = cmp_sel' + rng_chk_sel' + op_add' + op_sub' + op_mul' + op_mul * u128_tag;
+    rng_chk_lookup_selector' = cmp_sel' + rng_chk_sel' + op_add' + op_sub' + op_mul' + op_mul * u128_tag + op_cast';
 
     // Perform 128-bit range check on lo part
     #[LOWER_CMP_RNG_CHK]
-    a_lo = SUM_128 * RNG_CHK_OP;
+    a_lo = SUM_128 * (RNG_CHK_OP + op_cast);
 
     // Perform 128-bit range check on hi part
     #[UPPER_CMP_RNG_CHK]

--- a/barretenberg/cpp/pil/avm/avm_alu.pil
+++ b/barretenberg/cpp/pil/avm/avm_alu.pil
@@ -18,11 +18,12 @@ namespace avm_alu(256);
     pol commit op_not;
     pol commit op_eq;
     pol commit op_cast;
+    pol commit op_cast_prev; // Predicate on whether op_cast is enabled at previous row
     pol commit alu_sel; // Predicate to activate the copy of intermediate registers to ALU table.
     pol commit op_lt;
     pol commit op_lte;
     pol commit cmp_sel; // Predicate if LT or LTE is set
-    pol commit rng_chk_sel; // Predicate representing a range check row.
+    pol commit rng_chk_sel; // Predicate representing a range check row used in LT/LTE.
 
     // Instruction tag (1: u8, 2: u16, 3: u32, 4: u64, 5: u128, 6: field) copied from Main table
     pol commit in_tag;
@@ -266,20 +267,6 @@ namespace avm_alu(256);
     #[ALU_OP_EQ]
     op_eq * (DIFF * (ic * (1 - op_eq_diff_inv) + op_eq_diff_inv) - 1 + ic) = 0;
 
-    // ========= CAST Operation Constraints ===============================
-    // We handle the input ia independently of its tag, i.e., we suppose it can take
-    // any value between 0 and p-1.
-    // We decompose the input ia in 8-bit/16-bit limbs and prove that the decomposition
-    // sums up to ia over the integers (i.e., no modulo p wrapping). To prove this,
-    // we perform a "school subtraction" (borrowing) over 128-bit limbs.
-    // The input I is written I = I_l + I_h * 2^128 and the field order P = P_l + P_h * 2^128.
-    // The school subtraction result is D = D_l + D_h * 2^128 and we prove the correctness
-    // through: P_l - I_l - CF * 2^128 == D_l AND P_h - I_h + CF == D_h
-    // where CF is a carry/borrowing bit. CF == 1 <==> P_l < I_l.
-
-    #[ALU_OP_CAST]
-    op_cast * (SUM_TAG + ff_tag * ia - ic) = 0;
-
     // ========= LT/LTE Operation Constraints ===============================
     // There are two routines that we utilise as part of this LT/LTE check
     // (1) Decomposition into two 128-bit limbs, lo and hi respectively and a borrow (1 or 0);
@@ -447,15 +434,15 @@ namespace avm_alu(256);
     cmp_rng_ctr * ((1 - rng_chk_sel) * (1 -  op_eq_diff_inv) +  op_eq_diff_inv) - rng_chk_sel = 0;
 
     // We perform a range check if we have some range checks remaining or we are performing a comparison op
-    pol RNG_CHK_OP = rng_chk_sel + cmp_sel;
+    pol RNG_CHK_OP = rng_chk_sel + cmp_sel + op_cast + op_cast_prev;
 
     pol commit rng_chk_lookup_selector;
     #[RNG_CHK_LOOKUP_SELECTOR]
-    rng_chk_lookup_selector' = cmp_sel' + rng_chk_sel' + op_add' + op_sub' + op_mul' + op_mul * u128_tag + op_cast';
+    rng_chk_lookup_selector' = cmp_sel' + rng_chk_sel' + op_add' + op_sub' + op_mul' + op_mul * u128_tag + op_cast' + op_cast_prev';
 
     // Perform 128-bit range check on lo part
     #[LOWER_CMP_RNG_CHK]
-    a_lo = SUM_128 * (RNG_CHK_OP + op_cast);
+    a_lo = SUM_128 * RNG_CHK_OP;
 
     // Perform 128-bit range check on hi part
     #[UPPER_CMP_RNG_CHK]
@@ -482,3 +469,44 @@ namespace avm_alu(256);
     (p_sub_b_lo' - res_lo) * rng_chk_sel'= 0;
     (p_sub_b_hi' - res_hi) * rng_chk_sel'= 0;
 
+
+    // ========= CAST Operation Constraints ===============================
+    // We handle the input ia independently of its tag, i.e., we suppose it can take
+    // any value between 0 and p-1.
+    // We decompose the input ia in 8-bit/16-bit limbs and prove that the decomposition
+    // sums up to ia over the integers (i.e., no modulo p wrapping). To prove this, we
+    // re-use techniques above from LT/LTE opcode. The following relations are toggled for CAST:
+    // - #[INPUT_DECOMP_1] shows a = a_lo + 2 ** 128 * a_hi
+    // - #[SUB_LO_1] and #[SUB_LO_1] shows that the above does not overflow modulo p.
+    // - We toggle RNG_CHK_OP with op_cast to show that a_lo, a_hi are correctly decomposed
+    //   over the 8/16-bit ALU registers in #[LOWER_CMP_RNG_CHK] and #[UPPER_CMP_RNG_CHK].
+    // - The 128-bit range checks for a_lo, a_hi are activated in #[RNG_CHK_LOOKUP_SELECTOR].
+    // - We copy p_sub_a_lo resp. p_sub_a_hi into next row in columns a_lo resp. a_hi so
+    //   that decomposition into the 8/16-bit ALU registers and range checks are performed.
+    //   Copy is done in #[OP_CAST_RNG_CHECK_P_SUB_A_LOW/HIGH] below.
+    //   Activation of decomposition and range check is achieved by adding op_cast_prev in
+    //   #[LOWER_CMP_RNG_CHK], #[UPPER_CMP_RNG_CHK] and #[RNG_CHK_LOOKUP_SELECTOR].
+    // - Finally, the truncated result SUM_TAG is copied in ic as part of #[ALU_OP_CAST] below.
+    // - Note that the tag of return value must be constrained to be in_tag and is enforced in
+    //   the main and memory traces.
+    //
+    // TODO: Potential optimization is to un-toggle all CAST relevant operations when ff_tag is
+    //       enabled. In this case, ic = ia trivially.
+    //       Another one is to activate range checks in a more granular way depending on the tag.
+
+    #[OP_CAST_PREV_LINE]
+    op_cast_prev' = op_cast;
+
+    // TODO: If a lookup selector with value > 1 is enabled, then we do not need this constraint.
+    //       Otherwise, melding two op_cast with a common row might lead to disabling
+    #[OP_CAST_PREV_MUT_EXCL]
+    op_cast_prev * op_cast = 0;
+
+    #[ALU_OP_CAST]
+    op_cast * (SUM_TAG + ff_tag * ia - ic) = 0;
+
+    #[OP_CAST_RNG_CHECK_P_SUB_A_LOW]
+    op_cast * (a_lo' - p_sub_a_lo) = 0;
+
+    #[OP_CAST_RNG_CHECK_P_SUB_A_HIGH]
+    op_cast * (a_hi' - p_sub_a_hi) = 0;

--- a/barretenberg/cpp/pil/avm/avm_main.pil
+++ b/barretenberg/cpp/pil/avm/avm_main.pil
@@ -316,10 +316,13 @@ namespace avm_main(256);
 
     #[PERM_MAIN_ALU]
     alu_sel {clk, ia, ib, ic, sel_op_add, sel_op_sub,
-             sel_op_mul, sel_op_eq, sel_op_not, sel_op_lt, sel_op_lte, alu_in_tag}
+             sel_op_mul, sel_op_eq, sel_op_not, sel_op_cast,
+             sel_op_lt, sel_op_lte, alu_in_tag}
     is
     avm_alu.alu_sel {avm_alu.clk, avm_alu.ia, avm_alu.ib, avm_alu.ic, avm_alu.op_add, avm_alu.op_sub,
-                     avm_alu.op_mul, avm_alu.op_eq, avm_alu.op_not, avm_alu.op_lt, avm_alu.op_lte, avm_alu.in_tag};
+                     avm_alu.op_mul, avm_alu.op_eq, avm_alu.op_not, avm_alu.op_cast,
+                     avm_alu.op_lt, avm_alu.op_lte, avm_alu.in_tag};
+
     // Based on the boolean selectors, we derive the binary op id to lookup in the table;
     // TODO: Check if having 4 columns (op_id + 3 boolean selectors) is more optimal that just using the op_id
     // but with a higher degree constraint: op_id * (op_id - 1) * (op_id - 2)

--- a/barretenberg/cpp/pil/avm/avm_main.pil
+++ b/barretenberg/cpp/pil/avm/avm_main.pil
@@ -54,6 +54,8 @@ namespace avm_main(256);
     pol commit sel_op_or;
     // XOR
     pol commit sel_op_xor;
+    // CAST
+    pol commit sel_op_cast;
     // LT
     pol commit sel_op_lt;
     // LTE
@@ -68,6 +70,7 @@ namespace avm_main(256);
     // Instruction memory tags read/write (1: u8, 2: u16, 3: u32, 4: u64, 5: u128, 6: field)
     pol commit r_in_tag;
     pol commit w_in_tag;
+    pol commit alu_in_tag; // Copy of r_in_tag or w_in_tag depending of the operation. It is sent to ALU trace.
 
     // Errors
     pol commit op_err; // Boolean flag pertaining to an operation error
@@ -121,7 +124,8 @@ namespace avm_main(256);
     pol commit last;
     
     // Relations on type constraints
-
+    // TODO: Very likely, we can remove these constraints as the selectors should be derived during
+    // opcode decomposition.
     sel_op_add * (1 - sel_op_add) = 0;
     sel_op_sub * (1 - sel_op_sub) = 0;
     sel_op_mul * (1 - sel_op_mul) = 0;
@@ -131,6 +135,7 @@ namespace avm_main(256);
     sel_op_and * (1 - sel_op_and) = 0;
     sel_op_or * (1 - sel_op_or) = 0;
     sel_op_xor * (1 - sel_op_xor) = 0;
+    sel_op_cast * (1 - sel_op_cast) = 0;
     sel_op_lt * (1 - sel_op_lt) = 0;
     sel_op_lte * (1 - sel_op_lte) = 0;
 
@@ -243,7 +248,8 @@ namespace avm_main(256);
 
     //===== CONTROL_FLOW_CONSISTENCY ============================================
     pol INTERNAL_CALL_STACK_SELECTORS = (first + sel_internal_call + sel_internal_return + sel_halt);
-    pol OPCODE_SELECTORS = (sel_op_add + sel_op_sub + sel_op_div + sel_op_mul + sel_op_not + sel_op_eq + sel_op_and + sel_op_or + sel_op_xor);
+    pol OPCODE_SELECTORS = (sel_op_add + sel_op_sub + sel_op_div + sel_op_mul + sel_op_not
+                          + sel_op_eq + sel_op_and + sel_op_or + sel_op_xor + sel_op_cast);
 
     // Program counter must increment if not jumping or returning
     #[PC_INCREMENT]
@@ -287,6 +293,20 @@ namespace avm_main(256);
     #[MOV_MAIN_SAME_TAG]
     (sel_mov + sel_cmov) * (r_in_tag - w_in_tag) = 0;
 
+    //===== ALU CONSTRAINTS =====================================================
+    // TODO: when division is moved to the alu, we will need to add the selector in the list below.
+    pol ALU_R_TAG_SEL = sel_op_add + sel_op_sub + sel_op_mul + sel_op_not + sel_op_eq + sel_op_lt + sel_op_lte;
+    pol ALU_W_TAG_SEL = sel_op_cast;
+    pol ALU_ALL_SEL = ALU_R_TAG_SEL + ALU_W_TAG_SEL;
+
+    // Predicate to activate the copy of intermediate registers to ALU table. If tag_err == 1,
+    // the operation is not copied to the ALU table.
+    alu_sel = ALU_ALL_SEL * (1 - tag_err);
+
+    // Dispatch the correct in_tag for alu
+    ALU_R_TAG_SEL * (alu_in_tag - r_in_tag) = 0;
+    ALU_W_TAG_SEL * (alu_in_tag - w_in_tag) = 0;
+
     //====== Inter-table Constraints ============================================
     #[INCL_MAIN_TAG_ERR]
     avm_mem.tag_err {avm_mem.clk} in tag_err {clk};
@@ -294,18 +314,12 @@ namespace avm_main(256);
     #[INCL_MEM_TAG_ERR]
     tag_err {clk} in avm_mem.tag_err {avm_mem.clk};
 
-    // Predicate to activate the copy of intermediate registers to ALU table. If tag_err == 1,
-    // the operation is not copied to the ALU table.
-    // TODO: when division is moved to the alu, we will need to add the selector in the list below:
-    alu_sel = (sel_op_add + sel_op_sub + sel_op_mul + sel_op_not + sel_op_eq + sel_op_lt + sel_op_lte) * (1 - tag_err);
-
     #[PERM_MAIN_ALU]
     alu_sel {clk, ia, ib, ic, sel_op_add, sel_op_sub,
-             sel_op_mul, sel_op_eq, sel_op_not, sel_op_lt, sel_op_lte, r_in_tag}
+             sel_op_mul, sel_op_eq, sel_op_not, sel_op_lt, sel_op_lte, alu_in_tag}
     is
     avm_alu.alu_sel {avm_alu.clk, avm_alu.ia, avm_alu.ib, avm_alu.ic, avm_alu.op_add, avm_alu.op_sub,
                      avm_alu.op_mul, avm_alu.op_eq, avm_alu.op_not, avm_alu.op_lt, avm_alu.op_lte, avm_alu.in_tag};
-
     // Based on the boolean selectors, we derive the binary op id to lookup in the table;
     // TODO: Check if having 4 columns (op_id + 3 boolean selectors) is more optimal that just using the op_id
     // but with a higher degree constraint: op_id * (op_id - 1) * (op_id - 2)

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
@@ -119,6 +119,18 @@ template <class Params_> struct alignas(32) field {
         return static_cast<bool>(out.data[0]);
     }
 
+    constexpr explicit operator uint8_t() const
+    {
+        field out = from_montgomery_form();
+        return static_cast<uint8_t>(out.data[0]);
+    }
+
+    constexpr explicit operator uint16_t() const
+    {
+        field out = from_montgomery_form();
+        return static_cast<uint16_t>(out.data[0]);
+    }
+
     constexpr explicit operator uint32_t() const
     {
         field out = from_montgomery_form();

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_alu.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_alu.hpp
@@ -30,6 +30,8 @@ template <typename FF> struct Avm_aluRow {
     FF avm_alu_op_add{};
     FF avm_alu_op_add_shift{};
     FF avm_alu_op_cast{};
+    FF avm_alu_op_cast_prev{};
+    FF avm_alu_op_cast_prev_shift{};
     FF avm_alu_op_cast_shift{};
     FF avm_alu_op_eq{};
     FF avm_alu_op_eq_diff_inv{};
@@ -122,61 +124,73 @@ inline std::string get_relation_label_avm_alu(int index)
         return "ALU_OP_EQ";
 
     case 23:
-        return "ALU_OP_CAST";
-
-    case 24:
         return "INPUT_DECOMP_1";
 
-    case 25:
+    case 24:
         return "INPUT_DECOMP_2";
 
-    case 27:
+    case 26:
         return "SUB_LO_1";
 
-    case 28:
+    case 27:
         return "SUB_HI_1";
 
-    case 30:
+    case 29:
         return "SUB_LO_2";
 
-    case 31:
+    case 30:
         return "SUB_HI_2";
 
-    case 32:
+    case 31:
         return "RES_LO";
 
-    case 33:
+    case 32:
         return "RES_HI";
 
-    case 34:
+    case 33:
         return "CMP_CTR_REL_1";
 
-    case 35:
+    case 34:
         return "CMP_CTR_REL_2";
 
-    case 38:
+    case 37:
         return "CTR_NON_ZERO_REL";
 
-    case 39:
+    case 38:
         return "RNG_CHK_LOOKUP_SELECTOR";
 
-    case 40:
+    case 39:
         return "LOWER_CMP_RNG_CHK";
 
-    case 41:
+    case 40:
         return "UPPER_CMP_RNG_CHK";
 
-    case 42:
+    case 41:
         return "SHIFT_RELS_0";
 
-    case 44:
+    case 43:
         return "SHIFT_RELS_1";
 
-    case 46:
+    case 45:
         return "SHIFT_RELS_2";
 
-    case 48:
+    case 47:
         return "SHIFT_RELS_3";
+
+    case 49:
+        return "OP_CAST_PREV_LINE";
+
+    case 50:
+        return "OP_CAST_PREV_MUT_EXCL";
+
+    case 51:
+        return "ALU_OP_CAST";
+
+    case 52:
+        return "OP_CAST_RNG_CHECK_P_SUB_A_LOW";
+
+    case 53:
+        return "OP_CAST_RNG_CHECK_P_SUB_A_HIGH";
     }
     return std::to_string(index);
 }
@@ -185,9 +199,9 @@ template <typename FF_> class avm_aluImpl {
   public:
     using FF = FF_;
 
-    static constexpr std::array<size_t, 50> SUBRELATION_PARTIAL_LENGTHS{
-        2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 5, 5, 5, 5, 6, 6, 8, 3, 4, 4, 5, 5, 4,
-        4, 3, 4, 3, 3, 4, 3, 6, 5, 3, 3, 3, 3, 4, 3, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3,
+    static constexpr std::array<size_t, 54> SUBRELATION_PARTIAL_LENGTHS{
+        2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 5, 5, 5, 5, 6, 6, 8, 3, 4, 4, 5, 4, 4, 3, 4,
+        3, 3, 4, 3, 6, 5, 3, 3, 3, 3, 4, 3, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3, 2, 3, 5, 3, 3,
     };
 
     template <typename ContainerOverSubrelations, typename AllEntities>
@@ -484,6 +498,279 @@ template <typename FF_> class avm_aluImpl {
         {
             Avm_DECLARE_VIEWS(23);
 
+            auto tmp = (((avm_alu_op_lt * avm_alu_ib) + ((avm_alu_op_lte + avm_alu_op_cast) * avm_alu_ia)) -
+                        ((avm_alu_a_lo + (avm_alu_a_hi * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) *
+                         (avm_alu_cmp_sel + avm_alu_op_cast)));
+            tmp *= scaling_factor;
+            std::get<23>(evals) += tmp;
+        }
+        // Contribution 24
+        {
+            Avm_DECLARE_VIEWS(24);
+
+            auto tmp = (((avm_alu_op_lt * avm_alu_ia) + (avm_alu_op_lte * avm_alu_ib)) -
+                        ((avm_alu_b_lo + (avm_alu_b_hi * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) * avm_alu_cmp_sel));
+            tmp *= scaling_factor;
+            std::get<24>(evals) += tmp;
+        }
+        // Contribution 25
+        {
+            Avm_DECLARE_VIEWS(25);
+
+            auto tmp = (avm_alu_p_a_borrow * (-avm_alu_p_a_borrow + FF(1)));
+            tmp *= scaling_factor;
+            std::get<25>(evals) += tmp;
+        }
+        // Contribution 26
+        {
+            Avm_DECLARE_VIEWS(26);
+
+            auto tmp = ((avm_alu_p_sub_a_lo -
+                         ((-avm_alu_a_lo + FF(uint256_t{ 4891460686036598784UL, 2896914383306846353UL, 0UL, 0UL })) +
+                          (avm_alu_p_a_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL })))) *
+                        (avm_alu_cmp_sel + avm_alu_op_cast));
+            tmp *= scaling_factor;
+            std::get<26>(evals) += tmp;
+        }
+        // Contribution 27
+        {
+            Avm_DECLARE_VIEWS(27);
+
+            auto tmp = ((avm_alu_p_sub_a_hi -
+                         ((-avm_alu_a_hi + FF(uint256_t{ 13281191951274694749UL, 3486998266802970665UL, 0UL, 0UL })) -
+                          avm_alu_p_a_borrow)) *
+                        (avm_alu_cmp_sel + avm_alu_op_cast));
+            tmp *= scaling_factor;
+            std::get<27>(evals) += tmp;
+        }
+        // Contribution 28
+        {
+            Avm_DECLARE_VIEWS(28);
+
+            auto tmp = (avm_alu_p_b_borrow * (-avm_alu_p_b_borrow + FF(1)));
+            tmp *= scaling_factor;
+            std::get<28>(evals) += tmp;
+        }
+        // Contribution 29
+        {
+            Avm_DECLARE_VIEWS(29);
+
+            auto tmp = ((avm_alu_p_sub_b_lo -
+                         ((-avm_alu_b_lo + FF(uint256_t{ 4891460686036598784UL, 2896914383306846353UL, 0UL, 0UL })) +
+                          (avm_alu_p_b_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL })))) *
+                        avm_alu_cmp_sel);
+            tmp *= scaling_factor;
+            std::get<29>(evals) += tmp;
+        }
+        // Contribution 30
+        {
+            Avm_DECLARE_VIEWS(30);
+
+            auto tmp = ((avm_alu_p_sub_b_hi -
+                         ((-avm_alu_b_hi + FF(uint256_t{ 13281191951274694749UL, 3486998266802970665UL, 0UL, 0UL })) -
+                          avm_alu_p_b_borrow)) *
+                        avm_alu_cmp_sel);
+            tmp *= scaling_factor;
+            std::get<30>(evals) += tmp;
+        }
+        // Contribution 31
+        {
+            Avm_DECLARE_VIEWS(31);
+
+            auto tmp =
+                ((avm_alu_res_lo -
+                  (((((avm_alu_a_lo - avm_alu_b_lo) - FF(1)) + (avm_alu_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) *
+                    ((avm_alu_op_lt * avm_alu_ic) + ((-avm_alu_ic + FF(1)) * avm_alu_op_lte))) +
+                   (((avm_alu_b_lo - avm_alu_a_lo) + (avm_alu_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) *
+                    (-((avm_alu_op_lt * avm_alu_ic) + ((-avm_alu_ic + FF(1)) * avm_alu_op_lte)) + FF(1))))) *
+                 avm_alu_cmp_sel);
+            tmp *= scaling_factor;
+            std::get<31>(evals) += tmp;
+        }
+        // Contribution 32
+        {
+            Avm_DECLARE_VIEWS(32);
+
+            auto tmp = ((avm_alu_res_hi -
+                         ((((avm_alu_a_hi - avm_alu_b_hi) - avm_alu_borrow) *
+                           ((avm_alu_op_lt * avm_alu_ic) + ((-avm_alu_ic + FF(1)) * avm_alu_op_lte))) +
+                          (((avm_alu_b_hi - avm_alu_a_hi) - avm_alu_borrow) *
+                           (-((avm_alu_op_lt * avm_alu_ic) + ((-avm_alu_ic + FF(1)) * avm_alu_op_lte)) + FF(1))))) *
+                        avm_alu_cmp_sel);
+            tmp *= scaling_factor;
+            std::get<32>(evals) += tmp;
+        }
+        // Contribution 33
+        {
+            Avm_DECLARE_VIEWS(33);
+
+            auto tmp = (((avm_alu_cmp_rng_ctr_shift - avm_alu_cmp_rng_ctr) + FF(1)) * avm_alu_cmp_rng_ctr);
+            tmp *= scaling_factor;
+            std::get<33>(evals) += tmp;
+        }
+        // Contribution 34
+        {
+            Avm_DECLARE_VIEWS(34);
+
+            auto tmp = ((avm_alu_cmp_rng_ctr_shift - FF(4)) * avm_alu_cmp_sel);
+            tmp *= scaling_factor;
+            std::get<34>(evals) += tmp;
+        }
+        // Contribution 35
+        {
+            Avm_DECLARE_VIEWS(35);
+
+            auto tmp = (avm_alu_rng_chk_sel * (-avm_alu_rng_chk_sel + FF(1)));
+            tmp *= scaling_factor;
+            std::get<35>(evals) += tmp;
+        }
+        // Contribution 36
+        {
+            Avm_DECLARE_VIEWS(36);
+
+            auto tmp = (avm_alu_rng_chk_sel * avm_alu_cmp_sel);
+            tmp *= scaling_factor;
+            std::get<36>(evals) += tmp;
+        }
+        // Contribution 37
+        {
+            Avm_DECLARE_VIEWS(37);
+
+            auto tmp = ((avm_alu_cmp_rng_ctr * (((-avm_alu_rng_chk_sel + FF(1)) * (-avm_alu_op_eq_diff_inv + FF(1))) +
+                                                avm_alu_op_eq_diff_inv)) -
+                        avm_alu_rng_chk_sel);
+            tmp *= scaling_factor;
+            std::get<37>(evals) += tmp;
+        }
+        // Contribution 38
+        {
+            Avm_DECLARE_VIEWS(38);
+
+            auto tmp = (avm_alu_rng_chk_lookup_selector_shift -
+                        (((((((avm_alu_cmp_sel_shift + avm_alu_rng_chk_sel_shift) + avm_alu_op_add_shift) +
+                             avm_alu_op_sub_shift) +
+                            avm_alu_op_mul_shift) +
+                           (avm_alu_op_mul * avm_alu_u128_tag)) +
+                          avm_alu_op_cast_shift) +
+                         avm_alu_op_cast_prev_shift));
+            tmp *= scaling_factor;
+            std::get<38>(evals) += tmp;
+        }
+        // Contribution 39
+        {
+            Avm_DECLARE_VIEWS(39);
+
+            auto tmp =
+                (avm_alu_a_lo - (((((((((avm_alu_u8_r0 + (avm_alu_u8_r1 * FF(256))) + (avm_alu_u16_r0 * FF(65536))) +
+                                       (avm_alu_u16_r1 * FF(4294967296UL))) +
+                                      (avm_alu_u16_r2 * FF(281474976710656UL))) +
+                                     (avm_alu_u16_r3 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
+                                    (avm_alu_u16_r4 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
+                                   (avm_alu_u16_r5 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
+                                  (avm_alu_u16_r6 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))) *
+                                 (((avm_alu_rng_chk_sel + avm_alu_cmp_sel) + avm_alu_op_cast) + avm_alu_op_cast_prev)));
+            tmp *= scaling_factor;
+            std::get<39>(evals) += tmp;
+        }
+        // Contribution 40
+        {
+            Avm_DECLARE_VIEWS(40);
+
+            auto tmp = (avm_alu_a_hi -
+                        ((((((((avm_alu_u16_r7 + (avm_alu_u16_r8 * FF(65536))) + (avm_alu_u16_r9 * FF(4294967296UL))) +
+                              (avm_alu_u16_r10 * FF(281474976710656UL))) +
+                             (avm_alu_u16_r11 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
+                            (avm_alu_u16_r12 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
+                           (avm_alu_u16_r13 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
+                          (avm_alu_u16_r14 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))) *
+                         (((avm_alu_rng_chk_sel + avm_alu_cmp_sel) + avm_alu_op_cast) + avm_alu_op_cast_prev)));
+            tmp *= scaling_factor;
+            std::get<40>(evals) += tmp;
+        }
+        // Contribution 41
+        {
+            Avm_DECLARE_VIEWS(41);
+
+            auto tmp = ((avm_alu_a_lo_shift - avm_alu_b_lo) * avm_alu_rng_chk_sel_shift);
+            tmp *= scaling_factor;
+            std::get<41>(evals) += tmp;
+        }
+        // Contribution 42
+        {
+            Avm_DECLARE_VIEWS(42);
+
+            auto tmp = ((avm_alu_a_hi_shift - avm_alu_b_hi) * avm_alu_rng_chk_sel_shift);
+            tmp *= scaling_factor;
+            std::get<42>(evals) += tmp;
+        }
+        // Contribution 43
+        {
+            Avm_DECLARE_VIEWS(43);
+
+            auto tmp = ((avm_alu_b_lo_shift - avm_alu_p_sub_a_lo) * avm_alu_rng_chk_sel_shift);
+            tmp *= scaling_factor;
+            std::get<43>(evals) += tmp;
+        }
+        // Contribution 44
+        {
+            Avm_DECLARE_VIEWS(44);
+
+            auto tmp = ((avm_alu_b_hi_shift - avm_alu_p_sub_a_hi) * avm_alu_rng_chk_sel_shift);
+            tmp *= scaling_factor;
+            std::get<44>(evals) += tmp;
+        }
+        // Contribution 45
+        {
+            Avm_DECLARE_VIEWS(45);
+
+            auto tmp = ((avm_alu_p_sub_a_lo_shift - avm_alu_p_sub_b_lo) * avm_alu_rng_chk_sel_shift);
+            tmp *= scaling_factor;
+            std::get<45>(evals) += tmp;
+        }
+        // Contribution 46
+        {
+            Avm_DECLARE_VIEWS(46);
+
+            auto tmp = ((avm_alu_p_sub_a_hi_shift - avm_alu_p_sub_b_hi) * avm_alu_rng_chk_sel_shift);
+            tmp *= scaling_factor;
+            std::get<46>(evals) += tmp;
+        }
+        // Contribution 47
+        {
+            Avm_DECLARE_VIEWS(47);
+
+            auto tmp = ((avm_alu_p_sub_b_lo_shift - avm_alu_res_lo) * avm_alu_rng_chk_sel_shift);
+            tmp *= scaling_factor;
+            std::get<47>(evals) += tmp;
+        }
+        // Contribution 48
+        {
+            Avm_DECLARE_VIEWS(48);
+
+            auto tmp = ((avm_alu_p_sub_b_hi_shift - avm_alu_res_hi) * avm_alu_rng_chk_sel_shift);
+            tmp *= scaling_factor;
+            std::get<48>(evals) += tmp;
+        }
+        // Contribution 49
+        {
+            Avm_DECLARE_VIEWS(49);
+
+            auto tmp = (avm_alu_op_cast_prev_shift - avm_alu_op_cast);
+            tmp *= scaling_factor;
+            std::get<49>(evals) += tmp;
+        }
+        // Contribution 50
+        {
+            Avm_DECLARE_VIEWS(50);
+
+            auto tmp = (avm_alu_op_cast_prev * avm_alu_op_cast);
+            tmp *= scaling_factor;
+            std::get<50>(evals) += tmp;
+        }
+        // Contribution 51
+        {
+            Avm_DECLARE_VIEWS(51);
+
             auto tmp =
                 (avm_alu_op_cast *
                  (((((((avm_alu_u8_tag * avm_alu_u8_r0) +
@@ -504,263 +791,23 @@ template <typename FF_> class avm_aluImpl {
                    (avm_alu_ff_tag * avm_alu_ia)) -
                   avm_alu_ic));
             tmp *= scaling_factor;
-            std::get<23>(evals) += tmp;
+            std::get<51>(evals) += tmp;
         }
-        // Contribution 24
+        // Contribution 52
         {
-            Avm_DECLARE_VIEWS(24);
+            Avm_DECLARE_VIEWS(52);
 
-            auto tmp = (((avm_alu_op_lt * avm_alu_ib) + ((avm_alu_op_lte + avm_alu_op_cast) * avm_alu_ia)) -
-                        ((avm_alu_a_lo + (avm_alu_a_hi * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) *
-                         (avm_alu_cmp_sel + avm_alu_op_cast)));
+            auto tmp = (avm_alu_op_cast * (avm_alu_a_lo_shift - avm_alu_p_sub_a_lo));
             tmp *= scaling_factor;
-            std::get<24>(evals) += tmp;
+            std::get<52>(evals) += tmp;
         }
-        // Contribution 25
+        // Contribution 53
         {
-            Avm_DECLARE_VIEWS(25);
+            Avm_DECLARE_VIEWS(53);
 
-            auto tmp = (((avm_alu_op_lt * avm_alu_ia) + (avm_alu_op_lte * avm_alu_ib)) -
-                        ((avm_alu_b_lo + (avm_alu_b_hi * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) * avm_alu_cmp_sel));
+            auto tmp = (avm_alu_op_cast * (avm_alu_a_hi_shift - avm_alu_p_sub_a_hi));
             tmp *= scaling_factor;
-            std::get<25>(evals) += tmp;
-        }
-        // Contribution 26
-        {
-            Avm_DECLARE_VIEWS(26);
-
-            auto tmp = (avm_alu_p_a_borrow * (-avm_alu_p_a_borrow + FF(1)));
-            tmp *= scaling_factor;
-            std::get<26>(evals) += tmp;
-        }
-        // Contribution 27
-        {
-            Avm_DECLARE_VIEWS(27);
-
-            auto tmp = ((avm_alu_p_sub_a_lo -
-                         ((-avm_alu_a_lo + FF(uint256_t{ 4891460686036598784UL, 2896914383306846353UL, 0UL, 0UL })) +
-                          (avm_alu_p_a_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL })))) *
-                        (avm_alu_cmp_sel + avm_alu_op_cast));
-            tmp *= scaling_factor;
-            std::get<27>(evals) += tmp;
-        }
-        // Contribution 28
-        {
-            Avm_DECLARE_VIEWS(28);
-
-            auto tmp = ((avm_alu_p_sub_a_hi -
-                         ((-avm_alu_a_hi + FF(uint256_t{ 13281191951274694749UL, 3486998266802970665UL, 0UL, 0UL })) -
-                          avm_alu_p_a_borrow)) *
-                        (avm_alu_cmp_sel + avm_alu_op_cast));
-            tmp *= scaling_factor;
-            std::get<28>(evals) += tmp;
-        }
-        // Contribution 29
-        {
-            Avm_DECLARE_VIEWS(29);
-
-            auto tmp = (avm_alu_p_b_borrow * (-avm_alu_p_b_borrow + FF(1)));
-            tmp *= scaling_factor;
-            std::get<29>(evals) += tmp;
-        }
-        // Contribution 30
-        {
-            Avm_DECLARE_VIEWS(30);
-
-            auto tmp = ((avm_alu_p_sub_b_lo -
-                         ((-avm_alu_b_lo + FF(uint256_t{ 4891460686036598784UL, 2896914383306846353UL, 0UL, 0UL })) +
-                          (avm_alu_p_b_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL })))) *
-                        avm_alu_cmp_sel);
-            tmp *= scaling_factor;
-            std::get<30>(evals) += tmp;
-        }
-        // Contribution 31
-        {
-            Avm_DECLARE_VIEWS(31);
-
-            auto tmp = ((avm_alu_p_sub_b_hi -
-                         ((-avm_alu_b_hi + FF(uint256_t{ 13281191951274694749UL, 3486998266802970665UL, 0UL, 0UL })) -
-                          avm_alu_p_b_borrow)) *
-                        avm_alu_cmp_sel);
-            tmp *= scaling_factor;
-            std::get<31>(evals) += tmp;
-        }
-        // Contribution 32
-        {
-            Avm_DECLARE_VIEWS(32);
-
-            auto tmp =
-                ((avm_alu_res_lo -
-                  (((((avm_alu_a_lo - avm_alu_b_lo) - FF(1)) + (avm_alu_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) *
-                    ((avm_alu_op_lt * avm_alu_ic) + ((-avm_alu_ic + FF(1)) * avm_alu_op_lte))) +
-                   (((avm_alu_b_lo - avm_alu_a_lo) + (avm_alu_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) *
-                    (-((avm_alu_op_lt * avm_alu_ic) + ((-avm_alu_ic + FF(1)) * avm_alu_op_lte)) + FF(1))))) *
-                 avm_alu_cmp_sel);
-            tmp *= scaling_factor;
-            std::get<32>(evals) += tmp;
-        }
-        // Contribution 33
-        {
-            Avm_DECLARE_VIEWS(33);
-
-            auto tmp = ((avm_alu_res_hi -
-                         ((((avm_alu_a_hi - avm_alu_b_hi) - avm_alu_borrow) *
-                           ((avm_alu_op_lt * avm_alu_ic) + ((-avm_alu_ic + FF(1)) * avm_alu_op_lte))) +
-                          (((avm_alu_b_hi - avm_alu_a_hi) - avm_alu_borrow) *
-                           (-((avm_alu_op_lt * avm_alu_ic) + ((-avm_alu_ic + FF(1)) * avm_alu_op_lte)) + FF(1))))) *
-                        avm_alu_cmp_sel);
-            tmp *= scaling_factor;
-            std::get<33>(evals) += tmp;
-        }
-        // Contribution 34
-        {
-            Avm_DECLARE_VIEWS(34);
-
-            auto tmp = (((avm_alu_cmp_rng_ctr_shift - avm_alu_cmp_rng_ctr) + FF(1)) * avm_alu_cmp_rng_ctr);
-            tmp *= scaling_factor;
-            std::get<34>(evals) += tmp;
-        }
-        // Contribution 35
-        {
-            Avm_DECLARE_VIEWS(35);
-
-            auto tmp = ((avm_alu_cmp_rng_ctr_shift - FF(4)) * avm_alu_cmp_sel);
-            tmp *= scaling_factor;
-            std::get<35>(evals) += tmp;
-        }
-        // Contribution 36
-        {
-            Avm_DECLARE_VIEWS(36);
-
-            auto tmp = (avm_alu_rng_chk_sel * (-avm_alu_rng_chk_sel + FF(1)));
-            tmp *= scaling_factor;
-            std::get<36>(evals) += tmp;
-        }
-        // Contribution 37
-        {
-            Avm_DECLARE_VIEWS(37);
-
-            auto tmp = (avm_alu_rng_chk_sel * avm_alu_cmp_sel);
-            tmp *= scaling_factor;
-            std::get<37>(evals) += tmp;
-        }
-        // Contribution 38
-        {
-            Avm_DECLARE_VIEWS(38);
-
-            auto tmp = ((avm_alu_cmp_rng_ctr * (((-avm_alu_rng_chk_sel + FF(1)) * (-avm_alu_op_eq_diff_inv + FF(1))) +
-                                                avm_alu_op_eq_diff_inv)) -
-                        avm_alu_rng_chk_sel);
-            tmp *= scaling_factor;
-            std::get<38>(evals) += tmp;
-        }
-        // Contribution 39
-        {
-            Avm_DECLARE_VIEWS(39);
-
-            auto tmp = (avm_alu_rng_chk_lookup_selector_shift -
-                        ((((((avm_alu_cmp_sel_shift + avm_alu_rng_chk_sel_shift) + avm_alu_op_add_shift) +
-                            avm_alu_op_sub_shift) +
-                           avm_alu_op_mul_shift) +
-                          (avm_alu_op_mul * avm_alu_u128_tag)) +
-                         avm_alu_op_cast_shift));
-            tmp *= scaling_factor;
-            std::get<39>(evals) += tmp;
-        }
-        // Contribution 40
-        {
-            Avm_DECLARE_VIEWS(40);
-
-            auto tmp =
-                (avm_alu_a_lo - (((((((((avm_alu_u8_r0 + (avm_alu_u8_r1 * FF(256))) + (avm_alu_u16_r0 * FF(65536))) +
-                                       (avm_alu_u16_r1 * FF(4294967296UL))) +
-                                      (avm_alu_u16_r2 * FF(281474976710656UL))) +
-                                     (avm_alu_u16_r3 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
-                                    (avm_alu_u16_r4 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
-                                   (avm_alu_u16_r5 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
-                                  (avm_alu_u16_r6 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))) *
-                                 ((avm_alu_rng_chk_sel + avm_alu_cmp_sel) + avm_alu_op_cast)));
-            tmp *= scaling_factor;
-            std::get<40>(evals) += tmp;
-        }
-        // Contribution 41
-        {
-            Avm_DECLARE_VIEWS(41);
-
-            auto tmp = (avm_alu_a_hi -
-                        ((((((((avm_alu_u16_r7 + (avm_alu_u16_r8 * FF(65536))) + (avm_alu_u16_r9 * FF(4294967296UL))) +
-                              (avm_alu_u16_r10 * FF(281474976710656UL))) +
-                             (avm_alu_u16_r11 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
-                            (avm_alu_u16_r12 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
-                           (avm_alu_u16_r13 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
-                          (avm_alu_u16_r14 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))) *
-                         (avm_alu_rng_chk_sel + avm_alu_cmp_sel)));
-            tmp *= scaling_factor;
-            std::get<41>(evals) += tmp;
-        }
-        // Contribution 42
-        {
-            Avm_DECLARE_VIEWS(42);
-
-            auto tmp = ((avm_alu_a_lo_shift - avm_alu_b_lo) * avm_alu_rng_chk_sel_shift);
-            tmp *= scaling_factor;
-            std::get<42>(evals) += tmp;
-        }
-        // Contribution 43
-        {
-            Avm_DECLARE_VIEWS(43);
-
-            auto tmp = ((avm_alu_a_hi_shift - avm_alu_b_hi) * avm_alu_rng_chk_sel_shift);
-            tmp *= scaling_factor;
-            std::get<43>(evals) += tmp;
-        }
-        // Contribution 44
-        {
-            Avm_DECLARE_VIEWS(44);
-
-            auto tmp = ((avm_alu_b_lo_shift - avm_alu_p_sub_a_lo) * avm_alu_rng_chk_sel_shift);
-            tmp *= scaling_factor;
-            std::get<44>(evals) += tmp;
-        }
-        // Contribution 45
-        {
-            Avm_DECLARE_VIEWS(45);
-
-            auto tmp = ((avm_alu_b_hi_shift - avm_alu_p_sub_a_hi) * avm_alu_rng_chk_sel_shift);
-            tmp *= scaling_factor;
-            std::get<45>(evals) += tmp;
-        }
-        // Contribution 46
-        {
-            Avm_DECLARE_VIEWS(46);
-
-            auto tmp = ((avm_alu_p_sub_a_lo_shift - avm_alu_p_sub_b_lo) * avm_alu_rng_chk_sel_shift);
-            tmp *= scaling_factor;
-            std::get<46>(evals) += tmp;
-        }
-        // Contribution 47
-        {
-            Avm_DECLARE_VIEWS(47);
-
-            auto tmp = ((avm_alu_p_sub_a_hi_shift - avm_alu_p_sub_b_hi) * avm_alu_rng_chk_sel_shift);
-            tmp *= scaling_factor;
-            std::get<47>(evals) += tmp;
-        }
-        // Contribution 48
-        {
-            Avm_DECLARE_VIEWS(48);
-
-            auto tmp = ((avm_alu_p_sub_b_lo_shift - avm_alu_res_lo) * avm_alu_rng_chk_sel_shift);
-            tmp *= scaling_factor;
-            std::get<48>(evals) += tmp;
-        }
-        // Contribution 49
-        {
-            Avm_DECLARE_VIEWS(49);
-
-            auto tmp = ((avm_alu_p_sub_b_hi_shift - avm_alu_res_hi) * avm_alu_rng_chk_sel_shift);
-            tmp *= scaling_factor;
-            std::get<49>(evals) += tmp;
+            std::get<53>(evals) += tmp;
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_main.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_main.hpp
@@ -65,43 +65,52 @@ template <typename FF> struct Avm_mainRow {
 inline std::string get_relation_label_avm_main(int index)
 {
     switch (index) {
-    case 25:
-        return "EQ_OUTPUT_U8";
+    case 33:
+        return "OUTPUT_U8";
 
-    case 26:
+    case 34:
         return "SUBOP_DIVISION_FF";
 
-    case 27:
+    case 35:
         return "SUBOP_DIVISION_ZERO_ERR1";
 
-    case 28:
+    case 36:
         return "SUBOP_DIVISION_ZERO_ERR2";
 
-    case 29:
+    case 37:
         return "SUBOP_ERROR_RELEVANT_OP";
 
-    case 31:
+    case 39:
         return "RETURN_POINTER_INCREMENT";
 
-    case 37:
+    case 45:
         return "RETURN_POINTER_DECREMENT";
 
-    case 42:
+    case 50:
         return "PC_INCREMENT";
 
-    case 43:
+    case 51:
         return "INTERNAL_RETURN_POINTER_CONSISTENCY";
 
-    case 44:
-        return "MOV_SAME_VALUE";
+    case 52:
+        return "CMOV_CONDITION_RES_1";
 
-    case 45:
+    case 53:
+        return "CMOV_CONDITION_RES_2";
+
+    case 56:
+        return "MOV_SAME_VALUE_A";
+
+    case 57:
+        return "MOV_SAME_VALUE_B";
+
+    case 58:
         return "MOV_MAIN_SAME_TAG";
 
-    case 47:
+    case 62:
         return "BIN_SEL_1";
 
-    case 48:
+    case 63:
         return "BIN_SEL_2";
     }
     return std::to_string(index);
@@ -111,9 +120,9 @@ template <typename FF_> class avm_mainImpl {
   public:
     using FF = FF_;
 
-    static constexpr std::array<size_t, 49> SUBRELATION_PARTIAL_LENGTHS{
-        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-        3, 5, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 5, 3, 3, 3, 3, 3, 2,
+    static constexpr std::array<size_t, 64> SUBRELATION_PARTIAL_LENGTHS{
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 5, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 5, 3, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2,
     };
 
     template <typename ContainerOverSubrelations, typename AllEntities>
@@ -199,7 +208,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(9);
 
-            auto tmp = (avm_main_sel_internal_call * (-avm_main_sel_internal_call + FF(1)));
+            auto tmp = (avm_main_sel_op_cast * (-avm_main_sel_op_cast + FF(1)));
             tmp *= scaling_factor;
             std::get<9>(evals) += tmp;
         }
@@ -207,7 +216,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(10);
 
-            auto tmp = (avm_main_sel_internal_return * (-avm_main_sel_internal_return + FF(1)));
+            auto tmp = (avm_main_sel_op_lt * (-avm_main_sel_op_lt + FF(1)));
             tmp *= scaling_factor;
             std::get<10>(evals) += tmp;
         }
@@ -215,7 +224,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(11);
 
-            auto tmp = (avm_main_sel_jump * (-avm_main_sel_jump + FF(1)));
+            auto tmp = (avm_main_sel_op_lte * (-avm_main_sel_op_lte + FF(1)));
             tmp *= scaling_factor;
             std::get<11>(evals) += tmp;
         }
@@ -223,7 +232,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(12);
 
-            auto tmp = (avm_main_sel_halt * (-avm_main_sel_halt + FF(1)));
+            auto tmp = (avm_main_sel_internal_call * (-avm_main_sel_internal_call + FF(1)));
             tmp *= scaling_factor;
             std::get<12>(evals) += tmp;
         }
@@ -231,7 +240,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(13);
 
-            auto tmp = (avm_main_sel_mov * (-avm_main_sel_mov + FF(1)));
+            auto tmp = (avm_main_sel_internal_return * (-avm_main_sel_internal_return + FF(1)));
             tmp *= scaling_factor;
             std::get<13>(evals) += tmp;
         }
@@ -239,7 +248,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(14);
 
-            auto tmp = (avm_main_op_err * (-avm_main_op_err + FF(1)));
+            auto tmp = (avm_main_sel_jump * (-avm_main_sel_jump + FF(1)));
             tmp *= scaling_factor;
             std::get<14>(evals) += tmp;
         }
@@ -247,7 +256,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(15);
 
-            auto tmp = (avm_main_tag_err * (-avm_main_tag_err + FF(1)));
+            auto tmp = (avm_main_sel_halt * (-avm_main_sel_halt + FF(1)));
             tmp *= scaling_factor;
             std::get<15>(evals) += tmp;
         }
@@ -255,7 +264,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(16);
 
-            auto tmp = (avm_main_mem_op_a * (-avm_main_mem_op_a + FF(1)));
+            auto tmp = (avm_main_sel_mov * (-avm_main_sel_mov + FF(1)));
             tmp *= scaling_factor;
             std::get<16>(evals) += tmp;
         }
@@ -263,7 +272,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(17);
 
-            auto tmp = (avm_main_mem_op_b * (-avm_main_mem_op_b + FF(1)));
+            auto tmp = (avm_main_sel_cmov * (-avm_main_sel_cmov + FF(1)));
             tmp *= scaling_factor;
             std::get<17>(evals) += tmp;
         }
@@ -271,7 +280,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(18);
 
-            auto tmp = (avm_main_mem_op_c * (-avm_main_mem_op_c + FF(1)));
+            auto tmp = (avm_main_op_err * (-avm_main_op_err + FF(1)));
             tmp *= scaling_factor;
             std::get<18>(evals) += tmp;
         }
@@ -279,7 +288,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(19);
 
-            auto tmp = (avm_main_rwa * (-avm_main_rwa + FF(1)));
+            auto tmp = (avm_main_tag_err * (-avm_main_tag_err + FF(1)));
             tmp *= scaling_factor;
             std::get<19>(evals) += tmp;
         }
@@ -287,7 +296,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(20);
 
-            auto tmp = (avm_main_rwb * (-avm_main_rwb + FF(1)));
+            auto tmp = (avm_main_id_zero * (-avm_main_id_zero + FF(1)));
             tmp *= scaling_factor;
             std::get<20>(evals) += tmp;
         }
@@ -295,7 +304,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(21);
 
-            auto tmp = (avm_main_rwc * (-avm_main_rwc + FF(1)));
+            auto tmp = (avm_main_mem_op_a * (-avm_main_mem_op_a + FF(1)));
             tmp *= scaling_factor;
             std::get<21>(evals) += tmp;
         }
@@ -303,7 +312,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(22);
 
-            auto tmp = (avm_main_ind_op_a * (-avm_main_ind_op_a + FF(1)));
+            auto tmp = (avm_main_mem_op_b * (-avm_main_mem_op_b + FF(1)));
             tmp *= scaling_factor;
             std::get<22>(evals) += tmp;
         }
@@ -311,7 +320,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(23);
 
-            auto tmp = (avm_main_ind_op_b * (-avm_main_ind_op_b + FF(1)));
+            auto tmp = (avm_main_mem_op_c * (-avm_main_mem_op_c + FF(1)));
             tmp *= scaling_factor;
             std::get<23>(evals) += tmp;
         }
@@ -319,7 +328,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(24);
 
-            auto tmp = (avm_main_ind_op_c * (-avm_main_ind_op_c + FF(1)));
+            auto tmp = (avm_main_mem_op_d * (-avm_main_mem_op_d + FF(1)));
             tmp *= scaling_factor;
             std::get<24>(evals) += tmp;
         }
@@ -327,7 +336,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(25);
 
-            auto tmp = (avm_main_sel_op_eq * (avm_main_w_in_tag - FF(1)));
+            auto tmp = (avm_main_rwa * (-avm_main_rwa + FF(1)));
             tmp *= scaling_factor;
             std::get<25>(evals) += tmp;
         }
@@ -335,8 +344,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(26);
 
-            auto tmp =
-                ((avm_main_sel_op_div * (-avm_main_op_err + FF(1))) * ((avm_main_ic * avm_main_ib) - avm_main_ia));
+            auto tmp = (avm_main_rwb * (-avm_main_rwb + FF(1)));
             tmp *= scaling_factor;
             std::get<26>(evals) += tmp;
         }
@@ -344,7 +352,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(27);
 
-            auto tmp = (avm_main_sel_op_div * (((avm_main_ib * avm_main_inv) - FF(1)) + avm_main_op_err));
+            auto tmp = (avm_main_rwc * (-avm_main_rwc + FF(1)));
             tmp *= scaling_factor;
             std::get<27>(evals) += tmp;
         }
@@ -352,7 +360,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(28);
 
-            auto tmp = ((avm_main_sel_op_div * avm_main_op_err) * (-avm_main_inv + FF(1)));
+            auto tmp = (avm_main_rwd * (-avm_main_rwd + FF(1)));
             tmp *= scaling_factor;
             std::get<28>(evals) += tmp;
         }
@@ -360,7 +368,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(29);
 
-            auto tmp = (avm_main_op_err * (avm_main_sel_op_div - FF(1)));
+            auto tmp = (avm_main_ind_op_a * (-avm_main_ind_op_a + FF(1)));
             tmp *= scaling_factor;
             std::get<29>(evals) += tmp;
         }
@@ -368,7 +376,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(30);
 
-            auto tmp = (avm_main_sel_jump * (avm_main_pc_shift - avm_main_ia));
+            auto tmp = (avm_main_ind_op_b * (-avm_main_ind_op_b + FF(1)));
             tmp *= scaling_factor;
             std::get<30>(evals) += tmp;
         }
@@ -376,8 +384,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(31);
 
-            auto tmp = (avm_main_sel_internal_call *
-                        (avm_main_internal_return_ptr_shift - (avm_main_internal_return_ptr + FF(1))));
+            auto tmp = (avm_main_ind_op_c * (-avm_main_ind_op_c + FF(1)));
             tmp *= scaling_factor;
             std::get<31>(evals) += tmp;
         }
@@ -385,7 +392,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(32);
 
-            auto tmp = (avm_main_sel_internal_call * (avm_main_internal_return_ptr - avm_main_mem_idx_b));
+            auto tmp = (avm_main_ind_op_d * (-avm_main_ind_op_d + FF(1)));
             tmp *= scaling_factor;
             std::get<32>(evals) += tmp;
         }
@@ -393,7 +400,8 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(33);
 
-            auto tmp = (avm_main_sel_internal_call * (avm_main_pc_shift - avm_main_ia));
+            auto tmp =
+                (((avm_main_sel_op_eq + avm_main_sel_op_lte) + avm_main_sel_op_lt) * (avm_main_w_in_tag - FF(1)));
             tmp *= scaling_factor;
             std::get<33>(evals) += tmp;
         }
@@ -401,7 +409,8 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(34);
 
-            auto tmp = (avm_main_sel_internal_call * ((avm_main_pc + FF(1)) - avm_main_ib));
+            auto tmp =
+                ((avm_main_sel_op_div * (-avm_main_op_err + FF(1))) * ((avm_main_ic * avm_main_ib) - avm_main_ia));
             tmp *= scaling_factor;
             std::get<34>(evals) += tmp;
         }
@@ -409,7 +418,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(35);
 
-            auto tmp = (avm_main_sel_internal_call * (avm_main_rwb - FF(1)));
+            auto tmp = (avm_main_sel_op_div * (((avm_main_ib * avm_main_inv) - FF(1)) + avm_main_op_err));
             tmp *= scaling_factor;
             std::get<35>(evals) += tmp;
         }
@@ -417,7 +426,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(36);
 
-            auto tmp = (avm_main_sel_internal_call * (avm_main_mem_op_b - FF(1)));
+            auto tmp = ((avm_main_sel_op_div * avm_main_op_err) * (-avm_main_inv + FF(1)));
             tmp *= scaling_factor;
             std::get<36>(evals) += tmp;
         }
@@ -425,8 +434,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(37);
 
-            auto tmp = (avm_main_sel_internal_return *
-                        (avm_main_internal_return_ptr_shift - (avm_main_internal_return_ptr - FF(1))));
+            auto tmp = (avm_main_op_err * (avm_main_sel_op_div - FF(1)));
             tmp *= scaling_factor;
             std::get<37>(evals) += tmp;
         }
@@ -434,7 +442,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(38);
 
-            auto tmp = (avm_main_sel_internal_return * ((avm_main_internal_return_ptr - FF(1)) - avm_main_mem_idx_a));
+            auto tmp = (avm_main_sel_jump * (avm_main_pc_shift - avm_main_ia));
             tmp *= scaling_factor;
             std::get<38>(evals) += tmp;
         }
@@ -442,7 +450,8 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(39);
 
-            auto tmp = (avm_main_sel_internal_return * (avm_main_pc_shift - avm_main_ia));
+            auto tmp = (avm_main_sel_internal_call *
+                        (avm_main_internal_return_ptr_shift - (avm_main_internal_return_ptr + FF(1))));
             tmp *= scaling_factor;
             std::get<39>(evals) += tmp;
         }
@@ -450,7 +459,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(40);
 
-            auto tmp = (avm_main_sel_internal_return * avm_main_rwa);
+            auto tmp = (avm_main_sel_internal_call * (avm_main_internal_return_ptr - avm_main_mem_idx_b));
             tmp *= scaling_factor;
             std::get<40>(evals) += tmp;
         }
@@ -458,7 +467,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(41);
 
-            auto tmp = (avm_main_sel_internal_return * (avm_main_mem_op_a - FF(1)));
+            auto tmp = (avm_main_sel_internal_call * (avm_main_pc_shift - avm_main_ia));
             tmp *= scaling_factor;
             std::get<41>(evals) += tmp;
         }
@@ -466,15 +475,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(42);
 
-            auto tmp =
-                ((((-avm_main_first + FF(1)) * (-avm_main_sel_halt + FF(1))) *
-                  ((((((((avm_main_sel_op_add + avm_main_sel_op_sub) + avm_main_sel_op_div) + avm_main_sel_op_mul) +
-                       avm_main_sel_op_not) +
-                      avm_main_sel_op_eq) +
-                     avm_main_sel_op_and) +
-                    avm_main_sel_op_or) +
-                   avm_main_sel_op_xor)) *
-                 (avm_main_pc_shift - (avm_main_pc + FF(1))));
+            auto tmp = (avm_main_sel_internal_call * ((avm_main_pc + FF(1)) - avm_main_ib));
             tmp *= scaling_factor;
             std::get<42>(evals) += tmp;
         }
@@ -482,10 +483,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(43);
 
-            auto tmp = ((-(((avm_main_first + avm_main_sel_internal_call) + avm_main_sel_internal_return) +
-                           avm_main_sel_halt) +
-                         FF(1)) *
-                        (avm_main_internal_return_ptr_shift - avm_main_internal_return_ptr));
+            auto tmp = (avm_main_sel_internal_call * (avm_main_rwb - FF(1)));
             tmp *= scaling_factor;
             std::get<43>(evals) += tmp;
         }
@@ -493,7 +491,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(44);
 
-            auto tmp = (avm_main_sel_mov * (avm_main_ia - avm_main_ic));
+            auto tmp = (avm_main_sel_internal_call * (avm_main_mem_op_b - FF(1)));
             tmp *= scaling_factor;
             std::get<44>(evals) += tmp;
         }
@@ -501,7 +499,8 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(45);
 
-            auto tmp = (avm_main_sel_mov * (avm_main_r_in_tag - avm_main_w_in_tag));
+            auto tmp = (avm_main_sel_internal_return *
+                        (avm_main_internal_return_ptr_shift - (avm_main_internal_return_ptr - FF(1))));
             tmp *= scaling_factor;
             std::get<45>(evals) += tmp;
         }
@@ -509,10 +508,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(46);
 
-            auto tmp = (avm_main_alu_sel -
-                        (((((avm_main_sel_op_add + avm_main_sel_op_sub) + avm_main_sel_op_mul) + avm_main_sel_op_not) +
-                          avm_main_sel_op_eq) *
-                         (-avm_main_tag_err + FF(1))));
+            auto tmp = (avm_main_sel_internal_return * ((avm_main_internal_return_ptr - FF(1)) - avm_main_mem_idx_a));
             tmp *= scaling_factor;
             std::get<46>(evals) += tmp;
         }
@@ -520,7 +516,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(47);
 
-            auto tmp = (avm_main_bin_op_id - (avm_main_sel_op_or + (avm_main_sel_op_xor * FF(2))));
+            auto tmp = (avm_main_sel_internal_return * (avm_main_pc_shift - avm_main_ia));
             tmp *= scaling_factor;
             std::get<47>(evals) += tmp;
         }
@@ -528,9 +524,152 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(48);
 
-            auto tmp = (avm_main_bin_sel - ((avm_main_sel_op_and + avm_main_sel_op_or) + avm_main_sel_op_xor));
+            auto tmp = (avm_main_sel_internal_return * avm_main_rwa);
             tmp *= scaling_factor;
             std::get<48>(evals) += tmp;
+        }
+        // Contribution 49
+        {
+            Avm_DECLARE_VIEWS(49);
+
+            auto tmp = (avm_main_sel_internal_return * (avm_main_mem_op_a - FF(1)));
+            tmp *= scaling_factor;
+            std::get<49>(evals) += tmp;
+        }
+        // Contribution 50
+        {
+            Avm_DECLARE_VIEWS(50);
+
+            auto tmp =
+                ((((-avm_main_first + FF(1)) * (-avm_main_sel_halt + FF(1))) *
+                  (((((((((avm_main_sel_op_add + avm_main_sel_op_sub) + avm_main_sel_op_div) + avm_main_sel_op_mul) +
+                        avm_main_sel_op_not) +
+                       avm_main_sel_op_eq) +
+                      avm_main_sel_op_and) +
+                     avm_main_sel_op_or) +
+                    avm_main_sel_op_xor) +
+                   avm_main_sel_op_cast)) *
+                 (avm_main_pc_shift - (avm_main_pc + FF(1))));
+            tmp *= scaling_factor;
+            std::get<50>(evals) += tmp;
+        }
+        // Contribution 51
+        {
+            Avm_DECLARE_VIEWS(51);
+
+            auto tmp = ((-(((avm_main_first + avm_main_sel_internal_call) + avm_main_sel_internal_return) +
+                           avm_main_sel_halt) +
+                         FF(1)) *
+                        (avm_main_internal_return_ptr_shift - avm_main_internal_return_ptr));
+            tmp *= scaling_factor;
+            std::get<51>(evals) += tmp;
+        }
+        // Contribution 52
+        {
+            Avm_DECLARE_VIEWS(52);
+
+            auto tmp = (avm_main_sel_cmov * (((avm_main_id * avm_main_inv) - FF(1)) + avm_main_id_zero));
+            tmp *= scaling_factor;
+            std::get<52>(evals) += tmp;
+        }
+        // Contribution 53
+        {
+            Avm_DECLARE_VIEWS(53);
+
+            auto tmp = ((avm_main_sel_cmov * avm_main_id_zero) * (-avm_main_inv + FF(1)));
+            tmp *= scaling_factor;
+            std::get<53>(evals) += tmp;
+        }
+        // Contribution 54
+        {
+            Avm_DECLARE_VIEWS(54);
+
+            auto tmp = (avm_main_sel_mov_a - (avm_main_sel_mov + (avm_main_sel_cmov * (-avm_main_id_zero + FF(1)))));
+            tmp *= scaling_factor;
+            std::get<54>(evals) += tmp;
+        }
+        // Contribution 55
+        {
+            Avm_DECLARE_VIEWS(55);
+
+            auto tmp = (avm_main_sel_mov_b - (avm_main_sel_cmov * avm_main_id_zero));
+            tmp *= scaling_factor;
+            std::get<55>(evals) += tmp;
+        }
+        // Contribution 56
+        {
+            Avm_DECLARE_VIEWS(56);
+
+            auto tmp = (avm_main_sel_mov_a * (avm_main_ia - avm_main_ic));
+            tmp *= scaling_factor;
+            std::get<56>(evals) += tmp;
+        }
+        // Contribution 57
+        {
+            Avm_DECLARE_VIEWS(57);
+
+            auto tmp = (avm_main_sel_mov_b * (avm_main_ib - avm_main_ic));
+            tmp *= scaling_factor;
+            std::get<57>(evals) += tmp;
+        }
+        // Contribution 58
+        {
+            Avm_DECLARE_VIEWS(58);
+
+            auto tmp = ((avm_main_sel_mov + avm_main_sel_cmov) * (avm_main_r_in_tag - avm_main_w_in_tag));
+            tmp *= scaling_factor;
+            std::get<58>(evals) += tmp;
+        }
+        // Contribution 59
+        {
+            Avm_DECLARE_VIEWS(59);
+
+            auto tmp =
+                (avm_main_alu_sel -
+                 ((((((((avm_main_sel_op_add + avm_main_sel_op_sub) + avm_main_sel_op_mul) + avm_main_sel_op_not) +
+                      avm_main_sel_op_eq) +
+                     avm_main_sel_op_lt) +
+                    avm_main_sel_op_lte) +
+                   avm_main_sel_op_cast) *
+                  (-avm_main_tag_err + FF(1))));
+            tmp *= scaling_factor;
+            std::get<59>(evals) += tmp;
+        }
+        // Contribution 60
+        {
+            Avm_DECLARE_VIEWS(60);
+
+            auto tmp = (((((((avm_main_sel_op_add + avm_main_sel_op_sub) + avm_main_sel_op_mul) + avm_main_sel_op_not) +
+                           avm_main_sel_op_eq) +
+                          avm_main_sel_op_lt) +
+                         avm_main_sel_op_lte) *
+                        (avm_main_alu_in_tag - avm_main_r_in_tag));
+            tmp *= scaling_factor;
+            std::get<60>(evals) += tmp;
+        }
+        // Contribution 61
+        {
+            Avm_DECLARE_VIEWS(61);
+
+            auto tmp = (avm_main_sel_op_cast * (avm_main_alu_in_tag - avm_main_w_in_tag));
+            tmp *= scaling_factor;
+            std::get<61>(evals) += tmp;
+        }
+        // Contribution 62
+        {
+            Avm_DECLARE_VIEWS(62);
+
+            auto tmp = (avm_main_bin_op_id - (avm_main_sel_op_or + (avm_main_sel_op_xor * FF(2))));
+            tmp *= scaling_factor;
+            std::get<62>(evals) += tmp;
+        }
+        // Contribution 63
+        {
+            Avm_DECLARE_VIEWS(63);
+
+            auto tmp = (avm_main_bin_sel - ((avm_main_sel_op_and + avm_main_sel_op_or) + avm_main_sel_op_xor));
+            tmp *= scaling_factor;
+            std::get<63>(evals) += tmp;
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_main.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_main.hpp
@@ -7,6 +7,7 @@
 namespace bb::Avm_vm {
 
 template <typename FF> struct Avm_mainRow {
+    FF avm_main_alu_in_tag{};
     FF avm_main_alu_sel{};
     FF avm_main_bin_op_id{};
     FF avm_main_bin_sel{};
@@ -47,6 +48,7 @@ template <typename FF> struct Avm_mainRow {
     FF avm_main_sel_mov_b{};
     FF avm_main_sel_op_add{};
     FF avm_main_sel_op_and{};
+    FF avm_main_sel_op_cast{};
     FF avm_main_sel_op_div{};
     FF avm_main_sel_op_eq{};
     FF avm_main_sel_op_lt{};
@@ -63,52 +65,43 @@ template <typename FF> struct Avm_mainRow {
 inline std::string get_relation_label_avm_main(int index)
 {
     switch (index) {
-    case 32:
-        return "OUTPUT_U8";
+    case 25:
+        return "EQ_OUTPUT_U8";
 
-    case 33:
+    case 26:
         return "SUBOP_DIVISION_FF";
 
-    case 34:
+    case 27:
         return "SUBOP_DIVISION_ZERO_ERR1";
 
-    case 35:
+    case 28:
         return "SUBOP_DIVISION_ZERO_ERR2";
 
-    case 36:
+    case 29:
         return "SUBOP_ERROR_RELEVANT_OP";
 
-    case 38:
+    case 31:
         return "RETURN_POINTER_INCREMENT";
 
-    case 44:
+    case 37:
         return "RETURN_POINTER_DECREMENT";
 
-    case 49:
+    case 42:
         return "PC_INCREMENT";
 
-    case 50:
+    case 43:
         return "INTERNAL_RETURN_POINTER_CONSISTENCY";
 
-    case 51:
-        return "CMOV_CONDITION_RES_1";
+    case 44:
+        return "MOV_SAME_VALUE";
 
-    case 52:
-        return "CMOV_CONDITION_RES_2";
-
-    case 55:
-        return "MOV_SAME_VALUE_A";
-
-    case 56:
-        return "MOV_SAME_VALUE_B";
-
-    case 57:
+    case 45:
         return "MOV_MAIN_SAME_TAG";
 
-    case 59:
+    case 47:
         return "BIN_SEL_1";
 
-    case 60:
+    case 48:
         return "BIN_SEL_2";
     }
     return std::to_string(index);
@@ -118,9 +111,9 @@ template <typename FF_> class avm_mainImpl {
   public:
     using FF = FF_;
 
-    static constexpr std::array<size_t, 61> SUBRELATION_PARTIAL_LENGTHS{
-        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-        3, 3, 5, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 5, 3, 4, 4, 3, 3, 3, 3, 3, 3, 3, 2,
+    static constexpr std::array<size_t, 49> SUBRELATION_PARTIAL_LENGTHS{
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 5, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 5, 3, 3, 3, 3, 3, 2,
     };
 
     template <typename ContainerOverSubrelations, typename AllEntities>
@@ -206,7 +199,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(9);
 
-            auto tmp = (avm_main_sel_op_lt * (-avm_main_sel_op_lt + FF(1)));
+            auto tmp = (avm_main_sel_internal_call * (-avm_main_sel_internal_call + FF(1)));
             tmp *= scaling_factor;
             std::get<9>(evals) += tmp;
         }
@@ -214,7 +207,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(10);
 
-            auto tmp = (avm_main_sel_op_lte * (-avm_main_sel_op_lte + FF(1)));
+            auto tmp = (avm_main_sel_internal_return * (-avm_main_sel_internal_return + FF(1)));
             tmp *= scaling_factor;
             std::get<10>(evals) += tmp;
         }
@@ -222,7 +215,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(11);
 
-            auto tmp = (avm_main_sel_internal_call * (-avm_main_sel_internal_call + FF(1)));
+            auto tmp = (avm_main_sel_jump * (-avm_main_sel_jump + FF(1)));
             tmp *= scaling_factor;
             std::get<11>(evals) += tmp;
         }
@@ -230,7 +223,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(12);
 
-            auto tmp = (avm_main_sel_internal_return * (-avm_main_sel_internal_return + FF(1)));
+            auto tmp = (avm_main_sel_halt * (-avm_main_sel_halt + FF(1)));
             tmp *= scaling_factor;
             std::get<12>(evals) += tmp;
         }
@@ -238,7 +231,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(13);
 
-            auto tmp = (avm_main_sel_jump * (-avm_main_sel_jump + FF(1)));
+            auto tmp = (avm_main_sel_mov * (-avm_main_sel_mov + FF(1)));
             tmp *= scaling_factor;
             std::get<13>(evals) += tmp;
         }
@@ -246,7 +239,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(14);
 
-            auto tmp = (avm_main_sel_halt * (-avm_main_sel_halt + FF(1)));
+            auto tmp = (avm_main_op_err * (-avm_main_op_err + FF(1)));
             tmp *= scaling_factor;
             std::get<14>(evals) += tmp;
         }
@@ -254,7 +247,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(15);
 
-            auto tmp = (avm_main_sel_mov * (-avm_main_sel_mov + FF(1)));
+            auto tmp = (avm_main_tag_err * (-avm_main_tag_err + FF(1)));
             tmp *= scaling_factor;
             std::get<15>(evals) += tmp;
         }
@@ -262,7 +255,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(16);
 
-            auto tmp = (avm_main_sel_cmov * (-avm_main_sel_cmov + FF(1)));
+            auto tmp = (avm_main_mem_op_a * (-avm_main_mem_op_a + FF(1)));
             tmp *= scaling_factor;
             std::get<16>(evals) += tmp;
         }
@@ -270,7 +263,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(17);
 
-            auto tmp = (avm_main_op_err * (-avm_main_op_err + FF(1)));
+            auto tmp = (avm_main_mem_op_b * (-avm_main_mem_op_b + FF(1)));
             tmp *= scaling_factor;
             std::get<17>(evals) += tmp;
         }
@@ -278,7 +271,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(18);
 
-            auto tmp = (avm_main_tag_err * (-avm_main_tag_err + FF(1)));
+            auto tmp = (avm_main_mem_op_c * (-avm_main_mem_op_c + FF(1)));
             tmp *= scaling_factor;
             std::get<18>(evals) += tmp;
         }
@@ -286,7 +279,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(19);
 
-            auto tmp = (avm_main_id_zero * (-avm_main_id_zero + FF(1)));
+            auto tmp = (avm_main_rwa * (-avm_main_rwa + FF(1)));
             tmp *= scaling_factor;
             std::get<19>(evals) += tmp;
         }
@@ -294,7 +287,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(20);
 
-            auto tmp = (avm_main_mem_op_a * (-avm_main_mem_op_a + FF(1)));
+            auto tmp = (avm_main_rwb * (-avm_main_rwb + FF(1)));
             tmp *= scaling_factor;
             std::get<20>(evals) += tmp;
         }
@@ -302,7 +295,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(21);
 
-            auto tmp = (avm_main_mem_op_b * (-avm_main_mem_op_b + FF(1)));
+            auto tmp = (avm_main_rwc * (-avm_main_rwc + FF(1)));
             tmp *= scaling_factor;
             std::get<21>(evals) += tmp;
         }
@@ -310,7 +303,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(22);
 
-            auto tmp = (avm_main_mem_op_c * (-avm_main_mem_op_c + FF(1)));
+            auto tmp = (avm_main_ind_op_a * (-avm_main_ind_op_a + FF(1)));
             tmp *= scaling_factor;
             std::get<22>(evals) += tmp;
         }
@@ -318,7 +311,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(23);
 
-            auto tmp = (avm_main_mem_op_d * (-avm_main_mem_op_d + FF(1)));
+            auto tmp = (avm_main_ind_op_b * (-avm_main_ind_op_b + FF(1)));
             tmp *= scaling_factor;
             std::get<23>(evals) += tmp;
         }
@@ -326,7 +319,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(24);
 
-            auto tmp = (avm_main_rwa * (-avm_main_rwa + FF(1)));
+            auto tmp = (avm_main_ind_op_c * (-avm_main_ind_op_c + FF(1)));
             tmp *= scaling_factor;
             std::get<24>(evals) += tmp;
         }
@@ -334,7 +327,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(25);
 
-            auto tmp = (avm_main_rwb * (-avm_main_rwb + FF(1)));
+            auto tmp = (avm_main_sel_op_eq * (avm_main_w_in_tag - FF(1)));
             tmp *= scaling_factor;
             std::get<25>(evals) += tmp;
         }
@@ -342,7 +335,8 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(26);
 
-            auto tmp = (avm_main_rwc * (-avm_main_rwc + FF(1)));
+            auto tmp =
+                ((avm_main_sel_op_div * (-avm_main_op_err + FF(1))) * ((avm_main_ic * avm_main_ib) - avm_main_ia));
             tmp *= scaling_factor;
             std::get<26>(evals) += tmp;
         }
@@ -350,7 +344,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(27);
 
-            auto tmp = (avm_main_rwd * (-avm_main_rwd + FF(1)));
+            auto tmp = (avm_main_sel_op_div * (((avm_main_ib * avm_main_inv) - FF(1)) + avm_main_op_err));
             tmp *= scaling_factor;
             std::get<27>(evals) += tmp;
         }
@@ -358,7 +352,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(28);
 
-            auto tmp = (avm_main_ind_op_a * (-avm_main_ind_op_a + FF(1)));
+            auto tmp = ((avm_main_sel_op_div * avm_main_op_err) * (-avm_main_inv + FF(1)));
             tmp *= scaling_factor;
             std::get<28>(evals) += tmp;
         }
@@ -366,7 +360,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(29);
 
-            auto tmp = (avm_main_ind_op_b * (-avm_main_ind_op_b + FF(1)));
+            auto tmp = (avm_main_op_err * (avm_main_sel_op_div - FF(1)));
             tmp *= scaling_factor;
             std::get<29>(evals) += tmp;
         }
@@ -374,7 +368,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(30);
 
-            auto tmp = (avm_main_ind_op_c * (-avm_main_ind_op_c + FF(1)));
+            auto tmp = (avm_main_sel_jump * (avm_main_pc_shift - avm_main_ia));
             tmp *= scaling_factor;
             std::get<30>(evals) += tmp;
         }
@@ -382,7 +376,8 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(31);
 
-            auto tmp = (avm_main_ind_op_d * (-avm_main_ind_op_d + FF(1)));
+            auto tmp = (avm_main_sel_internal_call *
+                        (avm_main_internal_return_ptr_shift - (avm_main_internal_return_ptr + FF(1))));
             tmp *= scaling_factor;
             std::get<31>(evals) += tmp;
         }
@@ -390,8 +385,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(32);
 
-            auto tmp =
-                (((avm_main_sel_op_eq + avm_main_sel_op_lte) + avm_main_sel_op_lt) * (avm_main_w_in_tag - FF(1)));
+            auto tmp = (avm_main_sel_internal_call * (avm_main_internal_return_ptr - avm_main_mem_idx_b));
             tmp *= scaling_factor;
             std::get<32>(evals) += tmp;
         }
@@ -399,8 +393,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(33);
 
-            auto tmp =
-                ((avm_main_sel_op_div * (-avm_main_op_err + FF(1))) * ((avm_main_ic * avm_main_ib) - avm_main_ia));
+            auto tmp = (avm_main_sel_internal_call * (avm_main_pc_shift - avm_main_ia));
             tmp *= scaling_factor;
             std::get<33>(evals) += tmp;
         }
@@ -408,7 +401,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(34);
 
-            auto tmp = (avm_main_sel_op_div * (((avm_main_ib * avm_main_inv) - FF(1)) + avm_main_op_err));
+            auto tmp = (avm_main_sel_internal_call * ((avm_main_pc + FF(1)) - avm_main_ib));
             tmp *= scaling_factor;
             std::get<34>(evals) += tmp;
         }
@@ -416,7 +409,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(35);
 
-            auto tmp = ((avm_main_sel_op_div * avm_main_op_err) * (-avm_main_inv + FF(1)));
+            auto tmp = (avm_main_sel_internal_call * (avm_main_rwb - FF(1)));
             tmp *= scaling_factor;
             std::get<35>(evals) += tmp;
         }
@@ -424,7 +417,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(36);
 
-            auto tmp = (avm_main_op_err * (avm_main_sel_op_div - FF(1)));
+            auto tmp = (avm_main_sel_internal_call * (avm_main_mem_op_b - FF(1)));
             tmp *= scaling_factor;
             std::get<36>(evals) += tmp;
         }
@@ -432,7 +425,8 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(37);
 
-            auto tmp = (avm_main_sel_jump * (avm_main_pc_shift - avm_main_ia));
+            auto tmp = (avm_main_sel_internal_return *
+                        (avm_main_internal_return_ptr_shift - (avm_main_internal_return_ptr - FF(1))));
             tmp *= scaling_factor;
             std::get<37>(evals) += tmp;
         }
@@ -440,8 +434,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(38);
 
-            auto tmp = (avm_main_sel_internal_call *
-                        (avm_main_internal_return_ptr_shift - (avm_main_internal_return_ptr + FF(1))));
+            auto tmp = (avm_main_sel_internal_return * ((avm_main_internal_return_ptr - FF(1)) - avm_main_mem_idx_a));
             tmp *= scaling_factor;
             std::get<38>(evals) += tmp;
         }
@@ -449,7 +442,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(39);
 
-            auto tmp = (avm_main_sel_internal_call * (avm_main_internal_return_ptr - avm_main_mem_idx_b));
+            auto tmp = (avm_main_sel_internal_return * (avm_main_pc_shift - avm_main_ia));
             tmp *= scaling_factor;
             std::get<39>(evals) += tmp;
         }
@@ -457,7 +450,7 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(40);
 
-            auto tmp = (avm_main_sel_internal_call * (avm_main_pc_shift - avm_main_ia));
+            auto tmp = (avm_main_sel_internal_return * avm_main_rwa);
             tmp *= scaling_factor;
             std::get<40>(evals) += tmp;
         }
@@ -465,70 +458,13 @@ template <typename FF_> class avm_mainImpl {
         {
             Avm_DECLARE_VIEWS(41);
 
-            auto tmp = (avm_main_sel_internal_call * ((avm_main_pc + FF(1)) - avm_main_ib));
+            auto tmp = (avm_main_sel_internal_return * (avm_main_mem_op_a - FF(1)));
             tmp *= scaling_factor;
             std::get<41>(evals) += tmp;
         }
         // Contribution 42
         {
             Avm_DECLARE_VIEWS(42);
-
-            auto tmp = (avm_main_sel_internal_call * (avm_main_rwb - FF(1)));
-            tmp *= scaling_factor;
-            std::get<42>(evals) += tmp;
-        }
-        // Contribution 43
-        {
-            Avm_DECLARE_VIEWS(43);
-
-            auto tmp = (avm_main_sel_internal_call * (avm_main_mem_op_b - FF(1)));
-            tmp *= scaling_factor;
-            std::get<43>(evals) += tmp;
-        }
-        // Contribution 44
-        {
-            Avm_DECLARE_VIEWS(44);
-
-            auto tmp = (avm_main_sel_internal_return *
-                        (avm_main_internal_return_ptr_shift - (avm_main_internal_return_ptr - FF(1))));
-            tmp *= scaling_factor;
-            std::get<44>(evals) += tmp;
-        }
-        // Contribution 45
-        {
-            Avm_DECLARE_VIEWS(45);
-
-            auto tmp = (avm_main_sel_internal_return * ((avm_main_internal_return_ptr - FF(1)) - avm_main_mem_idx_a));
-            tmp *= scaling_factor;
-            std::get<45>(evals) += tmp;
-        }
-        // Contribution 46
-        {
-            Avm_DECLARE_VIEWS(46);
-
-            auto tmp = (avm_main_sel_internal_return * (avm_main_pc_shift - avm_main_ia));
-            tmp *= scaling_factor;
-            std::get<46>(evals) += tmp;
-        }
-        // Contribution 47
-        {
-            Avm_DECLARE_VIEWS(47);
-
-            auto tmp = (avm_main_sel_internal_return * avm_main_rwa);
-            tmp *= scaling_factor;
-            std::get<47>(evals) += tmp;
-        }
-        // Contribution 48
-        {
-            Avm_DECLARE_VIEWS(48);
-
-            auto tmp = (avm_main_sel_internal_return * (avm_main_mem_op_a - FF(1)));
-            tmp *= scaling_factor;
-            std::get<48>(evals) += tmp;
-        }
-        // Contribution 49
-        {
-            Avm_DECLARE_VIEWS(49);
 
             auto tmp =
                 ((((-avm_main_first + FF(1)) * (-avm_main_sel_halt + FF(1))) *
@@ -540,104 +476,61 @@ template <typename FF_> class avm_mainImpl {
                    avm_main_sel_op_xor)) *
                  (avm_main_pc_shift - (avm_main_pc + FF(1))));
             tmp *= scaling_factor;
-            std::get<49>(evals) += tmp;
+            std::get<42>(evals) += tmp;
         }
-        // Contribution 50
+        // Contribution 43
         {
-            Avm_DECLARE_VIEWS(50);
+            Avm_DECLARE_VIEWS(43);
 
             auto tmp = ((-(((avm_main_first + avm_main_sel_internal_call) + avm_main_sel_internal_return) +
                            avm_main_sel_halt) +
                          FF(1)) *
                         (avm_main_internal_return_ptr_shift - avm_main_internal_return_ptr));
             tmp *= scaling_factor;
-            std::get<50>(evals) += tmp;
+            std::get<43>(evals) += tmp;
         }
-        // Contribution 51
+        // Contribution 44
         {
-            Avm_DECLARE_VIEWS(51);
+            Avm_DECLARE_VIEWS(44);
 
-            auto tmp = (avm_main_sel_cmov * (((avm_main_id * avm_main_inv) - FF(1)) + avm_main_id_zero));
+            auto tmp = (avm_main_sel_mov * (avm_main_ia - avm_main_ic));
             tmp *= scaling_factor;
-            std::get<51>(evals) += tmp;
+            std::get<44>(evals) += tmp;
         }
-        // Contribution 52
+        // Contribution 45
         {
-            Avm_DECLARE_VIEWS(52);
+            Avm_DECLARE_VIEWS(45);
 
-            auto tmp = ((avm_main_sel_cmov * avm_main_id_zero) * (-avm_main_inv + FF(1)));
+            auto tmp = (avm_main_sel_mov * (avm_main_r_in_tag - avm_main_w_in_tag));
             tmp *= scaling_factor;
-            std::get<52>(evals) += tmp;
+            std::get<45>(evals) += tmp;
         }
-        // Contribution 53
+        // Contribution 46
         {
-            Avm_DECLARE_VIEWS(53);
+            Avm_DECLARE_VIEWS(46);
 
-            auto tmp = (avm_main_sel_mov_a - (avm_main_sel_mov + (avm_main_sel_cmov * (-avm_main_id_zero + FF(1)))));
+            auto tmp = (avm_main_alu_sel -
+                        (((((avm_main_sel_op_add + avm_main_sel_op_sub) + avm_main_sel_op_mul) + avm_main_sel_op_not) +
+                          avm_main_sel_op_eq) *
+                         (-avm_main_tag_err + FF(1))));
             tmp *= scaling_factor;
-            std::get<53>(evals) += tmp;
+            std::get<46>(evals) += tmp;
         }
-        // Contribution 54
+        // Contribution 47
         {
-            Avm_DECLARE_VIEWS(54);
-
-            auto tmp = (avm_main_sel_mov_b - (avm_main_sel_cmov * avm_main_id_zero));
-            tmp *= scaling_factor;
-            std::get<54>(evals) += tmp;
-        }
-        // Contribution 55
-        {
-            Avm_DECLARE_VIEWS(55);
-
-            auto tmp = (avm_main_sel_mov_a * (avm_main_ia - avm_main_ic));
-            tmp *= scaling_factor;
-            std::get<55>(evals) += tmp;
-        }
-        // Contribution 56
-        {
-            Avm_DECLARE_VIEWS(56);
-
-            auto tmp = (avm_main_sel_mov_b * (avm_main_ib - avm_main_ic));
-            tmp *= scaling_factor;
-            std::get<56>(evals) += tmp;
-        }
-        // Contribution 57
-        {
-            Avm_DECLARE_VIEWS(57);
-
-            auto tmp = ((avm_main_sel_mov + avm_main_sel_cmov) * (avm_main_r_in_tag - avm_main_w_in_tag));
-            tmp *= scaling_factor;
-            std::get<57>(evals) += tmp;
-        }
-        // Contribution 58
-        {
-            Avm_DECLARE_VIEWS(58);
-
-            auto tmp =
-                (avm_main_alu_sel -
-                 (((((((avm_main_sel_op_add + avm_main_sel_op_sub) + avm_main_sel_op_mul) + avm_main_sel_op_not) +
-                     avm_main_sel_op_eq) +
-                    avm_main_sel_op_lt) +
-                   avm_main_sel_op_lte) *
-                  (-avm_main_tag_err + FF(1))));
-            tmp *= scaling_factor;
-            std::get<58>(evals) += tmp;
-        }
-        // Contribution 59
-        {
-            Avm_DECLARE_VIEWS(59);
+            Avm_DECLARE_VIEWS(47);
 
             auto tmp = (avm_main_bin_op_id - (avm_main_sel_op_or + (avm_main_sel_op_xor * FF(2))));
             tmp *= scaling_factor;
-            std::get<59>(evals) += tmp;
+            std::get<47>(evals) += tmp;
         }
-        // Contribution 60
+        // Contribution 48
         {
-            Avm_DECLARE_VIEWS(60);
+            Avm_DECLARE_VIEWS(48);
 
             auto tmp = (avm_main_bin_sel - ((avm_main_sel_op_and + avm_main_sel_op_or) + avm_main_sel_op_xor));
             tmp *= scaling_factor;
-            std::get<60>(evals) += tmp;
+            std::get<48>(evals) += tmp;
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/declare_views.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/declare_views.hpp
@@ -20,6 +20,7 @@
     [[maybe_unused]] auto avm_alu_ic = View(new_term.avm_alu_ic);                                                      \
     [[maybe_unused]] auto avm_alu_in_tag = View(new_term.avm_alu_in_tag);                                              \
     [[maybe_unused]] auto avm_alu_op_add = View(new_term.avm_alu_op_add);                                              \
+    [[maybe_unused]] auto avm_alu_op_cast = View(new_term.avm_alu_op_cast);                                            \
     [[maybe_unused]] auto avm_alu_op_div = View(new_term.avm_alu_op_div);                                              \
     [[maybe_unused]] auto avm_alu_op_eq = View(new_term.avm_alu_op_eq);                                                \
     [[maybe_unused]] auto avm_alu_op_eq_diff_inv = View(new_term.avm_alu_op_eq_diff_inv);                              \
@@ -222,6 +223,7 @@
     [[maybe_unused]] auto avm_alu_cmp_rng_ctr_shift = View(new_term.avm_alu_cmp_rng_ctr_shift);                        \
     [[maybe_unused]] auto avm_alu_cmp_sel_shift = View(new_term.avm_alu_cmp_sel_shift);                                \
     [[maybe_unused]] auto avm_alu_op_add_shift = View(new_term.avm_alu_op_add_shift);                                  \
+    [[maybe_unused]] auto avm_alu_op_cast_shift = View(new_term.avm_alu_op_cast_shift);                                \
     [[maybe_unused]] auto avm_alu_op_mul_shift = View(new_term.avm_alu_op_mul_shift);                                  \
     [[maybe_unused]] auto avm_alu_op_sub_shift = View(new_term.avm_alu_op_sub_shift);                                  \
     [[maybe_unused]] auto avm_alu_p_sub_a_hi_shift = View(new_term.avm_alu_p_sub_a_hi_shift);                          \

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/declare_views.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/declare_views.hpp
@@ -21,6 +21,7 @@
     [[maybe_unused]] auto avm_alu_in_tag = View(new_term.avm_alu_in_tag);                                              \
     [[maybe_unused]] auto avm_alu_op_add = View(new_term.avm_alu_op_add);                                              \
     [[maybe_unused]] auto avm_alu_op_cast = View(new_term.avm_alu_op_cast);                                            \
+    [[maybe_unused]] auto avm_alu_op_cast_prev = View(new_term.avm_alu_op_cast_prev);                                  \
     [[maybe_unused]] auto avm_alu_op_div = View(new_term.avm_alu_op_div);                                              \
     [[maybe_unused]] auto avm_alu_op_eq = View(new_term.avm_alu_op_eq);                                                \
     [[maybe_unused]] auto avm_alu_op_eq_diff_inv = View(new_term.avm_alu_op_eq_diff_inv);                              \
@@ -223,6 +224,7 @@
     [[maybe_unused]] auto avm_alu_cmp_rng_ctr_shift = View(new_term.avm_alu_cmp_rng_ctr_shift);                        \
     [[maybe_unused]] auto avm_alu_cmp_sel_shift = View(new_term.avm_alu_cmp_sel_shift);                                \
     [[maybe_unused]] auto avm_alu_op_add_shift = View(new_term.avm_alu_op_add_shift);                                  \
+    [[maybe_unused]] auto avm_alu_op_cast_prev_shift = View(new_term.avm_alu_op_cast_prev_shift);                      \
     [[maybe_unused]] auto avm_alu_op_cast_shift = View(new_term.avm_alu_op_cast_shift);                                \
     [[maybe_unused]] auto avm_alu_op_mul_shift = View(new_term.avm_alu_op_mul_shift);                                  \
     [[maybe_unused]] auto avm_alu_op_sub_shift = View(new_term.avm_alu_op_sub_shift);                                  \

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/declare_views.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/declare_views.hpp
@@ -80,6 +80,7 @@
     [[maybe_unused]] auto avm_byte_lookup_table_input_b = View(new_term.avm_byte_lookup_table_input_b);                \
     [[maybe_unused]] auto avm_byte_lookup_table_op_id = View(new_term.avm_byte_lookup_table_op_id);                    \
     [[maybe_unused]] auto avm_byte_lookup_table_output = View(new_term.avm_byte_lookup_table_output);                  \
+    [[maybe_unused]] auto avm_main_alu_in_tag = View(new_term.avm_main_alu_in_tag);                                    \
     [[maybe_unused]] auto avm_main_alu_sel = View(new_term.avm_main_alu_sel);                                          \
     [[maybe_unused]] auto avm_main_bin_op_id = View(new_term.avm_main_bin_op_id);                                      \
     [[maybe_unused]] auto avm_main_bin_sel = View(new_term.avm_main_bin_sel);                                          \
@@ -124,6 +125,7 @@
     [[maybe_unused]] auto avm_main_sel_mov_b = View(new_term.avm_main_sel_mov_b);                                      \
     [[maybe_unused]] auto avm_main_sel_op_add = View(new_term.avm_main_sel_op_add);                                    \
     [[maybe_unused]] auto avm_main_sel_op_and = View(new_term.avm_main_sel_op_and);                                    \
+    [[maybe_unused]] auto avm_main_sel_op_cast = View(new_term.avm_main_sel_op_cast);                                  \
     [[maybe_unused]] auto avm_main_sel_op_div = View(new_term.avm_main_sel_op_div);                                    \
     [[maybe_unused]] auto avm_main_sel_op_eq = View(new_term.avm_main_sel_op_eq);                                      \
     [[maybe_unused]] auto avm_main_sel_op_lt = View(new_term.avm_main_sel_op_lt);                                      \

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/perm_main_alu.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/perm_main_alu.hpp
@@ -12,7 +12,7 @@ namespace bb {
 class perm_main_alu_permutation_settings {
   public:
     // This constant defines how many columns are bundled together to form each set.
-    constexpr static size_t COLUMNS_PER_SET = 12;
+    constexpr static size_t COLUMNS_PER_SET = 13;
 
     /**
      * @brief If this method returns true on a row of values, then the inverse polynomial at this index. Otherwise the
@@ -59,13 +59,10 @@ class perm_main_alu_permutation_settings {
                                      in.avm_main_sel_op_mul,
                                      in.avm_main_sel_op_eq,
                                      in.avm_main_sel_op_not,
-<<<<<<< HEAD
+                                     in.avm_main_sel_op_cast,
                                      in.avm_main_sel_op_lt,
                                      in.avm_main_sel_op_lte,
-                                     in.avm_main_r_in_tag,
-=======
                                      in.avm_main_alu_in_tag,
->>>>>>> a83ef175e (5466 - introduce in_tag dispatching to the ALU)
                                      in.avm_alu_clk,
                                      in.avm_alu_ia,
                                      in.avm_alu_ib,
@@ -75,6 +72,7 @@ class perm_main_alu_permutation_settings {
                                      in.avm_alu_op_mul,
                                      in.avm_alu_op_eq,
                                      in.avm_alu_op_not,
+                                     in.avm_alu_op_cast,
                                      in.avm_alu_op_lt,
                                      in.avm_alu_op_lte,
                                      in.avm_alu_in_tag);
@@ -113,13 +111,10 @@ class perm_main_alu_permutation_settings {
                                      in.avm_main_sel_op_mul,
                                      in.avm_main_sel_op_eq,
                                      in.avm_main_sel_op_not,
-<<<<<<< HEAD
+                                     in.avm_main_sel_op_cast,
                                      in.avm_main_sel_op_lt,
                                      in.avm_main_sel_op_lte,
-                                     in.avm_main_r_in_tag,
-=======
                                      in.avm_main_alu_in_tag,
->>>>>>> a83ef175e (5466 - introduce in_tag dispatching to the ALU)
                                      in.avm_alu_clk,
                                      in.avm_alu_ia,
                                      in.avm_alu_ib,
@@ -129,6 +124,7 @@ class perm_main_alu_permutation_settings {
                                      in.avm_alu_op_mul,
                                      in.avm_alu_op_eq,
                                      in.avm_alu_op_not,
+                                     in.avm_alu_op_cast,
                                      in.avm_alu_op_lt,
                                      in.avm_alu_op_lte,
                                      in.avm_alu_in_tag);

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/perm_main_alu.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/perm_main_alu.hpp
@@ -59,9 +59,13 @@ class perm_main_alu_permutation_settings {
                                      in.avm_main_sel_op_mul,
                                      in.avm_main_sel_op_eq,
                                      in.avm_main_sel_op_not,
+<<<<<<< HEAD
                                      in.avm_main_sel_op_lt,
                                      in.avm_main_sel_op_lte,
                                      in.avm_main_r_in_tag,
+=======
+                                     in.avm_main_alu_in_tag,
+>>>>>>> a83ef175e (5466 - introduce in_tag dispatching to the ALU)
                                      in.avm_alu_clk,
                                      in.avm_alu_ia,
                                      in.avm_alu_ib,
@@ -109,9 +113,13 @@ class perm_main_alu_permutation_settings {
                                      in.avm_main_sel_op_mul,
                                      in.avm_main_sel_op_eq,
                                      in.avm_main_sel_op_not,
+<<<<<<< HEAD
                                      in.avm_main_sel_op_lt,
                                      in.avm_main_sel_op_lte,
                                      in.avm_main_r_in_tag,
+=======
+                                     in.avm_main_alu_in_tag,
+>>>>>>> a83ef175e (5466 - introduce in_tag dispatching to the ALU)
                                      in.avm_alu_clk,
                                      in.avm_alu_ia,
                                      in.avm_alu_ib,

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_alu_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_alu_trace.cpp
@@ -675,6 +675,7 @@ FF AvmAluTraceBuilder::op_lte(FF const& a, FF const& b, AvmMemoryTag in_tag, uin
  */
 FF AvmAluTraceBuilder::op_cast(FF const& a, AvmMemoryTag in_tag, uint32_t clk)
 {
+    info("THIS IS SOLVING A STRANGE COMPILATION ISSUE");
     // Get the decomposition of a
     auto [a_lo, a_hi] = decompose(uint256_t(a));
     // Decomposition of p-a

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_alu_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_alu_trace.cpp
@@ -608,7 +608,7 @@ FF AvmAluTraceBuilder::op_lt(FF const& a, FF const& b, AvmMemoryTag in_tag, uint
     std::vector<AvmAluTraceBuilder::AluTraceEntry> rows = cmp_range_check_helper(row, hi_lo_limbs);
     // Append the rows to the alu_trace
     alu_trace.insert(alu_trace.end(), rows.begin(), rows.end());
-    return { static_cast<int>(c) };
+    return FF{ static_cast<int>(c) };
 }
 
 /**
@@ -662,6 +662,70 @@ FF AvmAluTraceBuilder::op_lte(FF const& a, FF const& b, AvmMemoryTag in_tag, uin
     // Update the row and add new rows with the correct hi_lo limbs
     std::vector<AvmAluTraceBuilder::AluTraceEntry> rows = cmp_range_check_helper(row, hi_lo_limbs);
     alu_trace.insert(alu_trace.end(), rows.begin(), rows.end());
-    return { static_cast<int>(c) };
+    return FF{ static_cast<int>(c) };
 }
+
+/**
+ * @brief Build ALU trace for the CAST opcode.
+ *
+ * @param a Input value to be casted. Tag of the input is not taken into account.
+ * @param in_tag Tag specifying the type for the input to be casted into.
+ * @param clk Clock referring to the operation in the main trace.
+ * @return The casted value as a finite field element.
+ */
+FF AvmAluTraceBuilder::op_cast(FF const& a, AvmMemoryTag in_tag, uint32_t clk)
+{
+    // Get the decomposition of a
+    auto [a_lo, a_hi] = decompose(uint256_t(a));
+    // Decomposition of p-a
+    auto [p_sub_a_lo, p_sub_a_hi, p_a_borrow] = gt_witness(FF::modulus, a);
+    auto [u8_r0, u8_r1, u16_reg] = to_alu_slice_registers(uint256_t(a));
+
+    alu_trace.push_back(AvmAluTraceBuilder::AluTraceEntry{
+        .alu_clk = clk,
+        .alu_op_cast = true,
+        .alu_ff_tag = in_tag == AvmMemoryTag::FF,
+        .alu_u8_tag = in_tag == AvmMemoryTag::U8,
+        .alu_u16_tag = in_tag == AvmMemoryTag::U16,
+        .alu_u32_tag = in_tag == AvmMemoryTag::U32,
+        .alu_u64_tag = in_tag == AvmMemoryTag::U64,
+        .alu_u128_tag = in_tag == AvmMemoryTag::U128,
+        .alu_ia = a,
+        .alu_ic = 0,
+        .alu_u8_r0 = u8_r0,
+        .alu_u8_r1 = u8_r1,
+        .alu_u16_reg = u16_reg,
+        .hi_lo_limbs = { a_lo, a_hi, p_sub_a_lo, p_sub_a_hi },
+        .p_a_borrow = p_a_borrow,
+    });
+
+    FF c;
+
+    switch (in_tag) {
+    case AvmMemoryTag::U8:
+        c = FF(uint8_t(a));
+        break;
+    case AvmMemoryTag::U16:
+        c = FF(uint16_t(a));
+        break;
+    case AvmMemoryTag::U32:
+        c = FF(uint32_t(a));
+        break;
+    case AvmMemoryTag::U64:
+        c = FF(uint64_t(a));
+        break;
+    case AvmMemoryTag::U128:
+        c = FF(uint256_t::from_uint128(uint128_t(a)));
+        break;
+    case AvmMemoryTag::FF:
+        c = a;
+        break;
+    default:
+        c = 0;
+        break;
+    }
+
+    return c;
+}
+
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_alu_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_alu_trace.hpp
@@ -21,6 +21,7 @@ class AvmAluTraceBuilder {
         bool alu_op_eq = false;
         bool alu_op_lt = false;
         bool alu_op_lte = false;
+        bool alu_op_cast = false;
 
         bool alu_ff_tag = false;
         bool alu_u8_tag = false;
@@ -66,6 +67,7 @@ class AvmAluTraceBuilder {
     FF op_eq(FF const& a, FF const& b, AvmMemoryTag in_tag, uint32_t clk);
     FF op_lt(FF const& a, FF const& b, AvmMemoryTag in_tag, uint32_t clk);
     FF op_lte(FF const& a, FF const& b, AvmMemoryTag in_tag, uint32_t clk);
+    FF op_cast(FF const& a, AvmMemoryTag in_tag, uint32_t clk);
 
     bool is_range_check_required() const;
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_mem_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_mem_trace.cpp
@@ -179,10 +179,10 @@ void AvmMemTraceBuilder::store_in_mem_trace(
 }
 
 /**
- * @brief Handle a read memory operation specific to MOV opcode. Load the corresponding
+ * @brief Handle a read memory operation without any tag check. Load the corresponding
  *        value to the intermediate register ia. A memory trace entry for the load
  *        operation is added. It is permissive in the sense that we do not enforce tag
- *        matching with against any instruction tag. In addition, the specific selector
+ *        matching with against any instruction tag. Optionally, a specific selector
  *        for MOV opcode is enabled.
  *
  * @param clk Main clock
@@ -191,7 +191,9 @@ void AvmMemTraceBuilder::store_in_mem_trace(
  * @return Result of the read operation containing the value and the tag of the memory cell
  *         at the supplied address.
  */
-AvmMemTraceBuilder::MemEntry AvmMemTraceBuilder::read_and_load_mov_opcode(uint32_t const clk, uint32_t const addr)
+AvmMemTraceBuilder::MemEntry AvmMemTraceBuilder::read_and_load_no_tag_check(uint32_t const clk,
+                                                                            uint32_t const addr,
+                                                                            bool is_mov)
 {
     MemEntry mem_entry = memory.contains(addr) ? memory.at(addr) : MemEntry{};
 
@@ -203,7 +205,7 @@ AvmMemTraceBuilder::MemEntry AvmMemTraceBuilder::read_and_load_mov_opcode(uint32
         .m_tag = mem_entry.tag,
         .r_in_tag = mem_entry.tag,
         .w_in_tag = mem_entry.tag,
-        .m_sel_mov_a = true,
+        .m_sel_mov_a = is_mov,
     });
 
     return mem_entry;

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_mem_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_mem_trace.hpp
@@ -87,7 +87,7 @@ class AvmMemTraceBuilder {
 
     std::vector<MemoryTraceEntry> finalize();
 
-    MemEntry read_and_load_mov_opcode(uint32_t clk, uint32_t addr);
+    MemEntry read_and_load_no_tag_check(uint32_t clk, uint32_t addr, bool is_mov);
     std::array<MemEntry, 3> read_and_load_cmov_opcode(uint32_t clk,
                                                       uint32_t a_addr,
                                                       uint32_t b_addr,

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.cpp
@@ -814,7 +814,7 @@ void AvmTraceBuilder::op_mov(uint8_t indirect, uint32_t src_offset, uint32_t dst
     }
 
     // Reading from memory and loading into ia without tag check.
-    auto const [val, tag] = mem_trace_builder.read_and_load_mov_opcode(clk, direct_src_offset);
+    auto const [val, tag] = mem_trace_builder.read_and_load_no_tag_check(clk, direct_src_offset, true);
 
     // Write into memory from intermediate register ic.
     mem_trace_builder.write_into_memory(clk, IntermRegister::IC, direct_dst_offset, val, tag, tag);
@@ -946,6 +946,73 @@ void AvmTraceBuilder::op_cmov(
         .avm_main_sel_mov_b = static_cast<uint32_t>(id_zero),
         .avm_main_tag_err = static_cast<uint32_t>(!tag_match),
         .avm_main_w_in_tag = static_cast<uint32_t>(tag),
+    });
+}
+
+/**
+ * @brief Cast an element pointed by the address a_offset into type specified by dst_tag and
+          store the result in address given by dst_offset.
+ *
+ * @param indirect A byte encoding information about indirect/direct memory access.
+ * @param a_offset Offset of source memory cell.
+ * @param dst_offset Offset of destination memory cell.
+ * @param dst_tag Destination tag specifying the type the source value must be casted to.
+ */
+void AvmTraceBuilder::op_cast(uint8_t indirect, uint32_t a_offset, uint32_t dst_offset, AvmMemoryTag dst_tag)
+{
+    auto const clk = static_cast<uint32_t>(main_trace.size());
+    bool tag_match = true;
+    uint32_t direct_a_offset = a_offset;
+    uint32_t direct_dst_offset = dst_offset;
+
+    bool indirect_a_flag = is_operand_indirect(indirect, 0);
+    bool indirect_dst_flag = is_operand_indirect(indirect, 1);
+
+    if (indirect_a_flag) {
+        auto read_ind_a = mem_trace_builder.indirect_read_and_load_from_memory(clk, IndirectRegister::IND_A, a_offset);
+        direct_a_offset = uint32_t(read_ind_a.val);
+        tag_match = tag_match && read_ind_a.tag_match;
+    }
+
+    if (indirect_dst_flag) {
+        auto read_ind_c =
+            mem_trace_builder.indirect_read_and_load_from_memory(clk, IndirectRegister::IND_C, dst_offset);
+        direct_dst_offset = uint32_t(read_ind_c.val);
+        tag_match = tag_match && read_ind_c.tag_match;
+    }
+
+    // Reading from memory and loading into ia
+    auto memEntry = mem_trace_builder.read_and_load_no_tag_check(clk, direct_a_offset, false);
+    FF a = memEntry.val;
+
+    // In case of a memory tag error, we do not perform the computation.
+    // Therefore, we do not create any entry in ALU table and store the value 0 as
+    // output (c) in memory.
+    FF c = tag_match ? alu_trace_builder.op_cast(a, dst_tag, clk) : FF(0);
+
+    // Write into memory value c from intermediate register ic.
+    mem_trace_builder.write_into_memory(clk, IntermRegister::IC, direct_dst_offset, c, memEntry.tag, dst_tag);
+
+    main_trace.push_back(Row{
+        .avm_main_clk = clk,
+        .avm_main_alu_in_tag = FF(static_cast<uint32_t>(dst_tag)),
+        .avm_main_ia = a,
+        .avm_main_ic = c,
+        .avm_main_ind_a = indirect_a_flag ? FF(a_offset) : FF(0),
+        .avm_main_ind_c = indirect_dst_flag ? FF(dst_offset) : FF(0),
+        .avm_main_ind_op_a = FF(static_cast<uint32_t>(indirect_a_flag)),
+        .avm_main_ind_op_c = FF(static_cast<uint32_t>(indirect_dst_flag)),
+        .avm_main_internal_return_ptr = FF(internal_return_ptr),
+        .avm_main_mem_idx_a = FF(direct_a_offset),
+        .avm_main_mem_idx_c = FF(direct_dst_offset),
+        .avm_main_mem_op_a = FF(1),
+        .avm_main_mem_op_c = FF(1),
+        .avm_main_pc = FF(pc++),
+        .avm_main_r_in_tag = FF(static_cast<uint32_t>(memEntry.tag)),
+        .avm_main_rwc = FF(1),
+        .avm_main_sel_op_cast = FF(1),
+        .avm_main_tag_err = FF(static_cast<uint32_t>(!tag_match)),
+        .avm_main_w_in_tag = FF(static_cast<uint32_t>(dst_tag)),
     });
 }
 
@@ -1448,6 +1515,7 @@ std::vector<Row> AvmTraceBuilder::finalize()
         dest.avm_alu_op_eq = FF(static_cast<uint32_t>(src.alu_op_eq));
         dest.avm_alu_op_lt = FF(static_cast<uint32_t>(src.alu_op_lt));
         dest.avm_alu_op_lte = FF(static_cast<uint32_t>(src.alu_op_lte));
+        dest.avm_alu_op_cast = FF(static_cast<uint32_t>(src.alu_op_cast));
         dest.avm_alu_cmp_sel = FF(static_cast<uint8_t>(src.alu_op_lt) + static_cast<uint8_t>(src.alu_op_lte));
         dest.avm_alu_rng_chk_sel = FF(static_cast<uint8_t>(src.rng_chk_sel));
 
@@ -1493,9 +1561,10 @@ std::vector<Row> AvmTraceBuilder::finalize()
         // multiplication over u128 is taking two lines.
         if (dest.avm_alu_op_add == FF(1) || dest.avm_alu_op_sub == FF(1) || dest.avm_alu_op_mul == FF(1) ||
             dest.avm_alu_op_eq == FF(1) || dest.avm_alu_op_not == FF(1) || dest.avm_alu_op_lt == FF(1) ||
-            dest.avm_alu_op_lte == FF(1)) {
+            dest.avm_alu_op_lte == FF(1) || dest.avm_alu_op_cast == FF(1)) {
             dest.avm_alu_alu_sel = FF(1);
         }
+
         if (dest.avm_alu_cmp_sel == FF(1) || dest.avm_alu_rng_chk_sel == FF(1)) {
             dest.avm_alu_a_lo = FF(src.hi_lo_limbs.at(0));
             dest.avm_alu_a_hi = FF(src.hi_lo_limbs.at(1));
@@ -1516,6 +1585,14 @@ std::vector<Row> AvmTraceBuilder::finalize()
         }
 
         if (dest.avm_alu_op_add == FF(1) || dest.avm_alu_op_sub == FF(1) || dest.avm_alu_op_mul == FF(1)) {
+            dest.avm_alu_rng_chk_lookup_selector = FF(1);
+        }
+
+        if (dest.avm_alu_op_cast == FF(1)) {
+            dest.avm_alu_a_lo = FF(src.hi_lo_limbs.at(0));
+            dest.avm_alu_a_hi = FF(src.hi_lo_limbs.at(1));
+            dest.avm_alu_p_sub_a_lo = FF(src.hi_lo_limbs.at(2));
+            dest.avm_alu_p_sub_a_hi = FF(src.hi_lo_limbs.at(3));
             dest.avm_alu_rng_chk_lookup_selector = FF(1);
         }
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.cpp
@@ -118,6 +118,7 @@ void AvmTraceBuilder::op_add(
 
     main_trace.push_back(Row{
         .avm_main_clk = clk,
+        .avm_main_alu_in_tag = FF(static_cast<uint32_t>(in_tag)),
         .avm_main_ia = a,
         .avm_main_ib = b,
         .avm_main_ic = c,
@@ -181,6 +182,7 @@ void AvmTraceBuilder::op_sub(
 
     main_trace.push_back(Row{
         .avm_main_clk = clk,
+        .avm_main_alu_in_tag = FF(static_cast<uint32_t>(in_tag)),
         .avm_main_ia = a,
         .avm_main_ib = b,
         .avm_main_ic = c,
@@ -244,6 +246,7 @@ void AvmTraceBuilder::op_mul(
 
     main_trace.push_back(Row{
         .avm_main_clk = clk,
+        .avm_main_alu_in_tag = FF(static_cast<uint32_t>(in_tag)),
         .avm_main_ia = a,
         .avm_main_ib = b,
         .avm_main_ic = c,
@@ -390,6 +393,7 @@ void AvmTraceBuilder::op_not(uint8_t indirect, uint32_t a_offset, uint32_t dst_o
 
     main_trace.push_back(Row{
         .avm_main_clk = clk,
+        .avm_main_alu_in_tag = FF(static_cast<uint32_t>(in_tag)),
         .avm_main_ia = a,
         .avm_main_ic = c,
         .avm_main_ind_a = indirect_a_flag ? FF(a_offset) : FF(0),
@@ -447,6 +451,7 @@ void AvmTraceBuilder::op_eq(
 
     main_trace.push_back(Row{
         .avm_main_clk = clk,
+        .avm_main_alu_in_tag = FF(static_cast<uint32_t>(in_tag)),
         .avm_main_ia = a,
         .avm_main_ib = b,
         .avm_main_ic = c,

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.cpp
@@ -658,6 +658,7 @@ void AvmTraceBuilder::op_lt(
 
     main_trace.push_back(Row{
         .avm_main_clk = clk,
+        .avm_main_alu_in_tag = FF(static_cast<uint32_t>(in_tag)),
         .avm_main_ia = a,
         .avm_main_ib = b,
         .avm_main_ic = c,
@@ -708,6 +709,7 @@ void AvmTraceBuilder::op_lte(
 
     main_trace.push_back(Row{
         .avm_main_clk = clk,
+        .avm_main_alu_in_tag = FF(static_cast<uint32_t>(in_tag)),
         .avm_main_ia = a,
         .avm_main_ib = b,
         .avm_main_ic = c,

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.hpp
@@ -72,6 +72,10 @@ class AvmTraceBuilder {
     // is determined conditionally based on a conditional value determined by cond_offset.
     void op_cmov(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t cond_offset, uint32_t dst_offset);
 
+    // Cast an element pointed by the address a_offset into type specified by dst_tag and
+    // store the result in address given by dst_offset.
+    void op_cast(uint8_t indirect, uint32_t a_offset, uint32_t dst_offset, AvmMemoryTag dst_tag);
+
     // Jump to a given program counter.
     void jump(uint32_t jmp_dest);
 

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.hpp
@@ -69,6 +69,7 @@ template <typename FF> struct AvmFullRow {
     FF avm_alu_ic{};
     FF avm_alu_in_tag{};
     FF avm_alu_op_add{};
+    FF avm_alu_op_cast{};
     FF avm_alu_op_div{};
     FF avm_alu_op_eq{};
     FF avm_alu_op_eq_diff_inv{};
@@ -271,6 +272,7 @@ template <typename FF> struct AvmFullRow {
     FF avm_alu_cmp_rng_ctr_shift{};
     FF avm_alu_cmp_sel_shift{};
     FF avm_alu_op_add_shift{};
+    FF avm_alu_op_cast_shift{};
     FF avm_alu_op_mul_shift{};
     FF avm_alu_op_sub_shift{};
     FF avm_alu_p_sub_a_hi_shift{};
@@ -311,13 +313,8 @@ class AvmCircuitBuilder {
     using Polynomial = Flavor::Polynomial;
     using ProverPolynomials = Flavor::ProverPolynomials;
 
-<<<<<<< HEAD
-    static constexpr size_t num_fixed_columns = 246;
-    static constexpr size_t num_polys = 211;
-=======
-    static constexpr size_t num_fixed_columns = 152;
-    static constexpr size_t num_polys = 133;
->>>>>>> a83ef175e (5466 - introduce in_tag dispatching to the ALU)
+    static constexpr size_t num_fixed_columns = 250;
+    static constexpr size_t num_polys = 214;
     std::vector<Row> rows;
 
     void set_trace(std::vector<Row>&& trace) { rows = std::move(trace); }
@@ -351,6 +348,7 @@ class AvmCircuitBuilder {
             polys.avm_alu_ic[i] = rows[i].avm_alu_ic;
             polys.avm_alu_in_tag[i] = rows[i].avm_alu_in_tag;
             polys.avm_alu_op_add[i] = rows[i].avm_alu_op_add;
+            polys.avm_alu_op_cast[i] = rows[i].avm_alu_op_cast;
             polys.avm_alu_op_div[i] = rows[i].avm_alu_op_div;
             polys.avm_alu_op_eq[i] = rows[i].avm_alu_op_eq;
             polys.avm_alu_op_eq_diff_inv[i] = rows[i].avm_alu_op_eq_diff_inv;
@@ -524,6 +522,7 @@ class AvmCircuitBuilder {
         polys.avm_alu_cmp_rng_ctr_shift = Polynomial(polys.avm_alu_cmp_rng_ctr.shifted());
         polys.avm_alu_cmp_sel_shift = Polynomial(polys.avm_alu_cmp_sel.shifted());
         polys.avm_alu_op_add_shift = Polynomial(polys.avm_alu_op_add.shifted());
+        polys.avm_alu_op_cast_shift = Polynomial(polys.avm_alu_op_cast.shifted());
         polys.avm_alu_op_mul_shift = Polynomial(polys.avm_alu_op_mul.shifted());
         polys.avm_alu_op_sub_shift = Polynomial(polys.avm_alu_op_sub.shifted());
         polys.avm_alu_p_sub_a_hi_shift = Polynomial(polys.avm_alu_p_sub_a_hi.shifted());

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.hpp
@@ -70,6 +70,7 @@ template <typename FF> struct AvmFullRow {
     FF avm_alu_in_tag{};
     FF avm_alu_op_add{};
     FF avm_alu_op_cast{};
+    FF avm_alu_op_cast_prev{};
     FF avm_alu_op_div{};
     FF avm_alu_op_eq{};
     FF avm_alu_op_eq_diff_inv{};
@@ -272,6 +273,7 @@ template <typename FF> struct AvmFullRow {
     FF avm_alu_cmp_rng_ctr_shift{};
     FF avm_alu_cmp_sel_shift{};
     FF avm_alu_op_add_shift{};
+    FF avm_alu_op_cast_prev_shift{};
     FF avm_alu_op_cast_shift{};
     FF avm_alu_op_mul_shift{};
     FF avm_alu_op_sub_shift{};
@@ -313,8 +315,8 @@ class AvmCircuitBuilder {
     using Polynomial = Flavor::Polynomial;
     using ProverPolynomials = Flavor::ProverPolynomials;
 
-    static constexpr size_t num_fixed_columns = 250;
-    static constexpr size_t num_polys = 214;
+    static constexpr size_t num_fixed_columns = 252;
+    static constexpr size_t num_polys = 215;
     std::vector<Row> rows;
 
     void set_trace(std::vector<Row>&& trace) { rows = std::move(trace); }
@@ -349,6 +351,7 @@ class AvmCircuitBuilder {
             polys.avm_alu_in_tag[i] = rows[i].avm_alu_in_tag;
             polys.avm_alu_op_add[i] = rows[i].avm_alu_op_add;
             polys.avm_alu_op_cast[i] = rows[i].avm_alu_op_cast;
+            polys.avm_alu_op_cast_prev[i] = rows[i].avm_alu_op_cast_prev;
             polys.avm_alu_op_div[i] = rows[i].avm_alu_op_div;
             polys.avm_alu_op_eq[i] = rows[i].avm_alu_op_eq;
             polys.avm_alu_op_eq_diff_inv[i] = rows[i].avm_alu_op_eq_diff_inv;
@@ -522,6 +525,7 @@ class AvmCircuitBuilder {
         polys.avm_alu_cmp_rng_ctr_shift = Polynomial(polys.avm_alu_cmp_rng_ctr.shifted());
         polys.avm_alu_cmp_sel_shift = Polynomial(polys.avm_alu_cmp_sel.shifted());
         polys.avm_alu_op_add_shift = Polynomial(polys.avm_alu_op_add.shifted());
+        polys.avm_alu_op_cast_prev_shift = Polynomial(polys.avm_alu_op_cast_prev.shifted());
         polys.avm_alu_op_cast_shift = Polynomial(polys.avm_alu_op_cast.shifted());
         polys.avm_alu_op_mul_shift = Polynomial(polys.avm_alu_op_mul.shifted());
         polys.avm_alu_op_sub_shift = Polynomial(polys.avm_alu_op_sub.shifted());

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.hpp
@@ -129,6 +129,7 @@ template <typename FF> struct AvmFullRow {
     FF avm_byte_lookup_table_input_b{};
     FF avm_byte_lookup_table_op_id{};
     FF avm_byte_lookup_table_output{};
+    FF avm_main_alu_in_tag{};
     FF avm_main_alu_sel{};
     FF avm_main_bin_op_id{};
     FF avm_main_bin_sel{};
@@ -173,6 +174,7 @@ template <typename FF> struct AvmFullRow {
     FF avm_main_sel_mov_b{};
     FF avm_main_sel_op_add{};
     FF avm_main_sel_op_and{};
+    FF avm_main_sel_op_cast{};
     FF avm_main_sel_op_div{};
     FF avm_main_sel_op_eq{};
     FF avm_main_sel_op_lt{};
@@ -309,8 +311,13 @@ class AvmCircuitBuilder {
     using Polynomial = Flavor::Polynomial;
     using ProverPolynomials = Flavor::ProverPolynomials;
 
+<<<<<<< HEAD
     static constexpr size_t num_fixed_columns = 246;
     static constexpr size_t num_polys = 211;
+=======
+    static constexpr size_t num_fixed_columns = 152;
+    static constexpr size_t num_polys = 133;
+>>>>>>> a83ef175e (5466 - introduce in_tag dispatching to the ALU)
     std::vector<Row> rows;
 
     void set_trace(std::vector<Row>&& trace) { rows = std::move(trace); }
@@ -404,6 +411,7 @@ class AvmCircuitBuilder {
             polys.avm_byte_lookup_table_input_b[i] = rows[i].avm_byte_lookup_table_input_b;
             polys.avm_byte_lookup_table_op_id[i] = rows[i].avm_byte_lookup_table_op_id;
             polys.avm_byte_lookup_table_output[i] = rows[i].avm_byte_lookup_table_output;
+            polys.avm_main_alu_in_tag[i] = rows[i].avm_main_alu_in_tag;
             polys.avm_main_alu_sel[i] = rows[i].avm_main_alu_sel;
             polys.avm_main_bin_op_id[i] = rows[i].avm_main_bin_op_id;
             polys.avm_main_bin_sel[i] = rows[i].avm_main_bin_sel;
@@ -448,6 +456,7 @@ class AvmCircuitBuilder {
             polys.avm_main_sel_mov_b[i] = rows[i].avm_main_sel_mov_b;
             polys.avm_main_sel_op_add[i] = rows[i].avm_main_sel_op_add;
             polys.avm_main_sel_op_and[i] = rows[i].avm_main_sel_op_and;
+            polys.avm_main_sel_op_cast[i] = rows[i].avm_main_sel_op_cast;
             polys.avm_main_sel_op_div[i] = rows[i].avm_main_sel_op_div;
             polys.avm_main_sel_op_eq[i] = rows[i].avm_main_sel_op_eq;
             polys.avm_main_sel_op_lt[i] = rows[i].avm_main_sel_op_lt;

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_flavor.hpp
@@ -69,6 +69,7 @@ class AvmFlavor {
     using RelationSeparator = FF;
 
     static constexpr size_t NUM_PRECOMPUTED_ENTITIES = 2;
+<<<<<<< HEAD
     static constexpr size_t NUM_WITNESS_ENTITIES = 209;
     static constexpr size_t NUM_WIRES = NUM_WITNESS_ENTITIES + NUM_PRECOMPUTED_ENTITIES;
     // We have two copies of the witness entities, so we subtract the number of fixed ones (they have no shift), one for
@@ -106,6 +107,13 @@ class AvmFlavor {
                                              lookup_u16_12_relation<FF>,
                                              lookup_u16_13_relation<FF>,
                                              lookup_u16_14_relation<FF>>;
+=======
+    static constexpr size_t NUM_WITNESS_ENTITIES = 131;
+    static constexpr size_t NUM_WIRES = NUM_WITNESS_ENTITIES + NUM_PRECOMPUTED_ENTITIES;
+    // We have two copies of the witness entities, so we subtract the number of fixed ones (they have no shift), one for
+    // the unshifted and one for the shifted
+    static constexpr size_t NUM_ALL_ENTITIES = 152;
+>>>>>>> a83ef175e (5466 - introduce in_tag dispatching to the ALU)
 
     using Relations = std::tuple<Avm_vm::avm_alu<FF>,
                                  Avm_vm::avm_binary<FF>,
@@ -251,6 +259,7 @@ class AvmFlavor {
                               avm_byte_lookup_table_input_b,
                               avm_byte_lookup_table_op_id,
                               avm_byte_lookup_table_output,
+                              avm_main_alu_in_tag,
                               avm_main_alu_sel,
                               avm_main_bin_op_id,
                               avm_main_bin_sel,
@@ -295,6 +304,7 @@ class AvmFlavor {
                               avm_main_sel_mov_b,
                               avm_main_sel_op_add,
                               avm_main_sel_op_and,
+                              avm_main_sel_op_cast,
                               avm_main_sel_op_div,
                               avm_main_sel_op_eq,
                               avm_main_sel_op_lt,
@@ -463,6 +473,7 @@ class AvmFlavor {
                      avm_byte_lookup_table_input_b,
                      avm_byte_lookup_table_op_id,
                      avm_byte_lookup_table_output,
+                     avm_main_alu_in_tag,
                      avm_main_alu_sel,
                      avm_main_bin_op_id,
                      avm_main_bin_sel,
@@ -507,6 +518,7 @@ class AvmFlavor {
                      avm_main_sel_mov_b,
                      avm_main_sel_op_add,
                      avm_main_sel_op_and,
+                     avm_main_sel_op_cast,
                      avm_main_sel_op_div,
                      avm_main_sel_op_eq,
                      avm_main_sel_op_lt,
@@ -680,6 +692,7 @@ class AvmFlavor {
                               avm_byte_lookup_table_input_b,
                               avm_byte_lookup_table_op_id,
                               avm_byte_lookup_table_output,
+                              avm_main_alu_in_tag,
                               avm_main_alu_sel,
                               avm_main_bin_op_id,
                               avm_main_bin_sel,
@@ -724,6 +737,7 @@ class AvmFlavor {
                               avm_main_sel_mov_b,
                               avm_main_sel_op_add,
                               avm_main_sel_op_and,
+                              avm_main_sel_op_cast,
                               avm_main_sel_op_div,
                               avm_main_sel_op_eq,
                               avm_main_sel_op_lt,
@@ -929,6 +943,7 @@ class AvmFlavor {
                      avm_byte_lookup_table_input_b,
                      avm_byte_lookup_table_op_id,
                      avm_byte_lookup_table_output,
+                     avm_main_alu_in_tag,
                      avm_main_alu_sel,
                      avm_main_bin_op_id,
                      avm_main_bin_sel,
@@ -973,6 +988,7 @@ class AvmFlavor {
                      avm_main_sel_mov_b,
                      avm_main_sel_op_add,
                      avm_main_sel_op_and,
+                     avm_main_sel_op_cast,
                      avm_main_sel_op_div,
                      avm_main_sel_op_eq,
                      avm_main_sel_op_lt,
@@ -1178,6 +1194,7 @@ class AvmFlavor {
                      avm_byte_lookup_table_input_b,
                      avm_byte_lookup_table_op_id,
                      avm_byte_lookup_table_output,
+                     avm_main_alu_in_tag,
                      avm_main_alu_sel,
                      avm_main_bin_op_id,
                      avm_main_bin_sel,
@@ -1222,6 +1239,7 @@ class AvmFlavor {
                      avm_main_sel_mov_b,
                      avm_main_sel_op_add,
                      avm_main_sel_op_and,
+                     avm_main_sel_op_cast,
                      avm_main_sel_op_div,
                      avm_main_sel_op_eq,
                      avm_main_sel_op_lt,
@@ -1621,6 +1639,7 @@ class AvmFlavor {
             Base::avm_byte_lookup_table_input_b = "AVM_BYTE_LOOKUP_TABLE_INPUT_B";
             Base::avm_byte_lookup_table_op_id = "AVM_BYTE_LOOKUP_TABLE_OP_ID";
             Base::avm_byte_lookup_table_output = "AVM_BYTE_LOOKUP_TABLE_OUTPUT";
+            Base::avm_main_alu_in_tag = "AVM_MAIN_ALU_IN_TAG";
             Base::avm_main_alu_sel = "AVM_MAIN_ALU_SEL";
             Base::avm_main_bin_op_id = "AVM_MAIN_BIN_OP_ID";
             Base::avm_main_bin_sel = "AVM_MAIN_BIN_SEL";
@@ -1665,6 +1684,7 @@ class AvmFlavor {
             Base::avm_main_sel_mov_b = "AVM_MAIN_SEL_MOV_B";
             Base::avm_main_sel_op_add = "AVM_MAIN_SEL_OP_ADD";
             Base::avm_main_sel_op_and = "AVM_MAIN_SEL_OP_AND";
+            Base::avm_main_sel_op_cast = "AVM_MAIN_SEL_OP_CAST";
             Base::avm_main_sel_op_div = "AVM_MAIN_SEL_OP_DIV";
             Base::avm_main_sel_op_eq = "AVM_MAIN_SEL_OP_EQ";
             Base::avm_main_sel_op_lt = "AVM_MAIN_SEL_OP_LT";
@@ -1849,6 +1869,7 @@ class AvmFlavor {
         Commitment avm_byte_lookup_table_input_b;
         Commitment avm_byte_lookup_table_op_id;
         Commitment avm_byte_lookup_table_output;
+        Commitment avm_main_alu_in_tag;
         Commitment avm_main_alu_sel;
         Commitment avm_main_bin_op_id;
         Commitment avm_main_bin_sel;
@@ -1893,6 +1914,7 @@ class AvmFlavor {
         Commitment avm_main_sel_mov_b;
         Commitment avm_main_sel_op_add;
         Commitment avm_main_sel_op_and;
+        Commitment avm_main_sel_op_cast;
         Commitment avm_main_sel_op_div;
         Commitment avm_main_sel_op_eq;
         Commitment avm_main_sel_op_lt;
@@ -2078,6 +2100,7 @@ class AvmFlavor {
             avm_byte_lookup_table_input_b = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_byte_lookup_table_op_id = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_byte_lookup_table_output = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
+            avm_main_alu_in_tag = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_main_alu_sel = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_main_bin_op_id = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_main_bin_sel = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
@@ -2122,6 +2145,7 @@ class AvmFlavor {
             avm_main_sel_mov_b = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_main_sel_op_add = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_main_sel_op_and = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
+            avm_main_sel_op_cast = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_main_sel_op_div = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_main_sel_op_eq = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_main_sel_op_lt = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
@@ -2310,6 +2334,7 @@ class AvmFlavor {
             serialize_to_buffer<Commitment>(avm_byte_lookup_table_input_b, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_byte_lookup_table_op_id, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_byte_lookup_table_output, Transcript::proof_data);
+            serialize_to_buffer<Commitment>(avm_main_alu_in_tag, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_main_alu_sel, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_main_bin_op_id, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_main_bin_sel, Transcript::proof_data);
@@ -2354,6 +2379,7 @@ class AvmFlavor {
             serialize_to_buffer<Commitment>(avm_main_sel_mov_b, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_main_sel_op_add, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_main_sel_op_and, Transcript::proof_data);
+            serialize_to_buffer<Commitment>(avm_main_sel_op_cast, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_main_sel_op_div, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_main_sel_op_eq, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_main_sel_op_lt, Transcript::proof_data);

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_flavor.hpp
@@ -69,12 +69,11 @@ class AvmFlavor {
     using RelationSeparator = FF;
 
     static constexpr size_t NUM_PRECOMPUTED_ENTITIES = 2;
-<<<<<<< HEAD
-    static constexpr size_t NUM_WITNESS_ENTITIES = 209;
+    static constexpr size_t NUM_WITNESS_ENTITIES = 212;
     static constexpr size_t NUM_WIRES = NUM_WITNESS_ENTITIES + NUM_PRECOMPUTED_ENTITIES;
     // We have two copies of the witness entities, so we subtract the number of fixed ones (they have no shift), one for
     // the unshifted and one for the shifted
-    static constexpr size_t NUM_ALL_ENTITIES = 246;
+    static constexpr size_t NUM_ALL_ENTITIES = 250;
 
     using GrandProductRelations = std::tuple<perm_main_alu_relation<FF>,
                                              perm_main_bin_relation<FF>,
@@ -107,13 +106,6 @@ class AvmFlavor {
                                              lookup_u16_12_relation<FF>,
                                              lookup_u16_13_relation<FF>,
                                              lookup_u16_14_relation<FF>>;
-=======
-    static constexpr size_t NUM_WITNESS_ENTITIES = 131;
-    static constexpr size_t NUM_WIRES = NUM_WITNESS_ENTITIES + NUM_PRECOMPUTED_ENTITIES;
-    // We have two copies of the witness entities, so we subtract the number of fixed ones (they have no shift), one for
-    // the unshifted and one for the shifted
-    static constexpr size_t NUM_ALL_ENTITIES = 152;
->>>>>>> a83ef175e (5466 - introduce in_tag dispatching to the ALU)
 
     using Relations = std::tuple<Avm_vm::avm_alu<FF>,
                                  Avm_vm::avm_binary<FF>,
@@ -199,6 +191,7 @@ class AvmFlavor {
                               avm_alu_ic,
                               avm_alu_in_tag,
                               avm_alu_op_add,
+                              avm_alu_op_cast,
                               avm_alu_op_div,
                               avm_alu_op_eq,
                               avm_alu_op_eq_diff_inv,
@@ -413,6 +406,7 @@ class AvmFlavor {
                      avm_alu_ic,
                      avm_alu_in_tag,
                      avm_alu_op_add,
+                     avm_alu_op_cast,
                      avm_alu_op_div,
                      avm_alu_op_eq,
                      avm_alu_op_eq_diff_inv,
@@ -632,6 +626,7 @@ class AvmFlavor {
                               avm_alu_ic,
                               avm_alu_in_tag,
                               avm_alu_op_add,
+                              avm_alu_op_cast,
                               avm_alu_op_div,
                               avm_alu_op_eq,
                               avm_alu_op_eq_diff_inv,
@@ -834,6 +829,7 @@ class AvmFlavor {
                               avm_alu_cmp_rng_ctr_shift,
                               avm_alu_cmp_sel_shift,
                               avm_alu_op_add_shift,
+                              avm_alu_op_cast_shift,
                               avm_alu_op_mul_shift,
                               avm_alu_op_sub_shift,
                               avm_alu_p_sub_a_hi_shift,
@@ -883,6 +879,7 @@ class AvmFlavor {
                      avm_alu_ic,
                      avm_alu_in_tag,
                      avm_alu_op_add,
+                     avm_alu_op_cast,
                      avm_alu_op_div,
                      avm_alu_op_eq,
                      avm_alu_op_eq_diff_inv,
@@ -1085,6 +1082,7 @@ class AvmFlavor {
                      avm_alu_cmp_rng_ctr_shift,
                      avm_alu_cmp_sel_shift,
                      avm_alu_op_add_shift,
+                     avm_alu_op_cast_shift,
                      avm_alu_op_mul_shift,
                      avm_alu_op_sub_shift,
                      avm_alu_p_sub_a_hi_shift,
@@ -1134,6 +1132,7 @@ class AvmFlavor {
                      avm_alu_ic,
                      avm_alu_in_tag,
                      avm_alu_op_add,
+                     avm_alu_op_cast,
                      avm_alu_op_div,
                      avm_alu_op_eq,
                      avm_alu_op_eq_diff_inv,
@@ -1332,44 +1331,80 @@ class AvmFlavor {
         };
         RefVector<DataType> get_to_be_shifted()
         {
-            return { avm_alu_a_hi,        avm_alu_a_lo,
-                     avm_alu_b_hi,        avm_alu_b_lo,
-                     avm_alu_cmp_rng_ctr, avm_alu_cmp_sel,
-                     avm_alu_op_add,      avm_alu_op_mul,
-                     avm_alu_op_sub,      avm_alu_p_sub_a_hi,
-                     avm_alu_p_sub_a_lo,  avm_alu_p_sub_b_hi,
-                     avm_alu_p_sub_b_lo,  avm_alu_rng_chk_lookup_selector,
-                     avm_alu_rng_chk_sel, avm_alu_u16_r0,
-                     avm_alu_u16_r1,      avm_alu_u16_r2,
-                     avm_alu_u16_r3,      avm_alu_u16_r4,
-                     avm_alu_u16_r5,      avm_alu_u16_r6,
-                     avm_alu_u8_r0,       avm_alu_u8_r1,
-                     avm_binary_acc_ia,   avm_binary_acc_ib,
-                     avm_binary_acc_ic,   avm_binary_mem_tag_ctr,
-                     avm_binary_op_id,    avm_main_internal_return_ptr,
-                     avm_main_pc,         avm_mem_addr,
-                     avm_mem_rw,          avm_mem_tag,
+            return { avm_alu_a_hi,
+                     avm_alu_a_lo,
+                     avm_alu_b_hi,
+                     avm_alu_b_lo,
+                     avm_alu_cmp_rng_ctr,
+                     avm_alu_cmp_sel,
+                     avm_alu_op_add,
+                     avm_alu_op_cast,
+                     avm_alu_op_mul,
+                     avm_alu_op_sub,
+                     avm_alu_p_sub_a_hi,
+                     avm_alu_p_sub_a_lo,
+                     avm_alu_p_sub_b_hi,
+                     avm_alu_p_sub_b_lo,
+                     avm_alu_rng_chk_lookup_selector,
+                     avm_alu_rng_chk_sel,
+                     avm_alu_u16_r0,
+                     avm_alu_u16_r1,
+                     avm_alu_u16_r2,
+                     avm_alu_u16_r3,
+                     avm_alu_u16_r4,
+                     avm_alu_u16_r5,
+                     avm_alu_u16_r6,
+                     avm_alu_u8_r0,
+                     avm_alu_u8_r1,
+                     avm_binary_acc_ia,
+                     avm_binary_acc_ib,
+                     avm_binary_acc_ic,
+                     avm_binary_mem_tag_ctr,
+                     avm_binary_op_id,
+                     avm_main_internal_return_ptr,
+                     avm_main_pc,
+                     avm_mem_addr,
+                     avm_mem_rw,
+                     avm_mem_tag,
                      avm_mem_val };
         };
         RefVector<DataType> get_shifted()
         {
-            return { avm_alu_a_hi_shift,        avm_alu_a_lo_shift,
-                     avm_alu_b_hi_shift,        avm_alu_b_lo_shift,
-                     avm_alu_cmp_rng_ctr_shift, avm_alu_cmp_sel_shift,
-                     avm_alu_op_add_shift,      avm_alu_op_mul_shift,
-                     avm_alu_op_sub_shift,      avm_alu_p_sub_a_hi_shift,
-                     avm_alu_p_sub_a_lo_shift,  avm_alu_p_sub_b_hi_shift,
-                     avm_alu_p_sub_b_lo_shift,  avm_alu_rng_chk_lookup_selector_shift,
-                     avm_alu_rng_chk_sel_shift, avm_alu_u16_r0_shift,
-                     avm_alu_u16_r1_shift,      avm_alu_u16_r2_shift,
-                     avm_alu_u16_r3_shift,      avm_alu_u16_r4_shift,
-                     avm_alu_u16_r5_shift,      avm_alu_u16_r6_shift,
-                     avm_alu_u8_r0_shift,       avm_alu_u8_r1_shift,
-                     avm_binary_acc_ia_shift,   avm_binary_acc_ib_shift,
-                     avm_binary_acc_ic_shift,   avm_binary_mem_tag_ctr_shift,
-                     avm_binary_op_id_shift,    avm_main_internal_return_ptr_shift,
-                     avm_main_pc_shift,         avm_mem_addr_shift,
-                     avm_mem_rw_shift,          avm_mem_tag_shift,
+            return { avm_alu_a_hi_shift,
+                     avm_alu_a_lo_shift,
+                     avm_alu_b_hi_shift,
+                     avm_alu_b_lo_shift,
+                     avm_alu_cmp_rng_ctr_shift,
+                     avm_alu_cmp_sel_shift,
+                     avm_alu_op_add_shift,
+                     avm_alu_op_cast_shift,
+                     avm_alu_op_mul_shift,
+                     avm_alu_op_sub_shift,
+                     avm_alu_p_sub_a_hi_shift,
+                     avm_alu_p_sub_a_lo_shift,
+                     avm_alu_p_sub_b_hi_shift,
+                     avm_alu_p_sub_b_lo_shift,
+                     avm_alu_rng_chk_lookup_selector_shift,
+                     avm_alu_rng_chk_sel_shift,
+                     avm_alu_u16_r0_shift,
+                     avm_alu_u16_r1_shift,
+                     avm_alu_u16_r2_shift,
+                     avm_alu_u16_r3_shift,
+                     avm_alu_u16_r4_shift,
+                     avm_alu_u16_r5_shift,
+                     avm_alu_u16_r6_shift,
+                     avm_alu_u8_r0_shift,
+                     avm_alu_u8_r1_shift,
+                     avm_binary_acc_ia_shift,
+                     avm_binary_acc_ib_shift,
+                     avm_binary_acc_ic_shift,
+                     avm_binary_mem_tag_ctr_shift,
+                     avm_binary_op_id_shift,
+                     avm_main_internal_return_ptr_shift,
+                     avm_main_pc_shift,
+                     avm_mem_addr_shift,
+                     avm_mem_rw_shift,
+                     avm_mem_tag_shift,
                      avm_mem_val_shift };
         };
     };
@@ -1383,23 +1418,41 @@ class AvmFlavor {
 
         RefVector<DataType> get_to_be_shifted()
         {
-            return { avm_alu_a_hi,        avm_alu_a_lo,
-                     avm_alu_b_hi,        avm_alu_b_lo,
-                     avm_alu_cmp_rng_ctr, avm_alu_cmp_sel,
-                     avm_alu_op_add,      avm_alu_op_mul,
-                     avm_alu_op_sub,      avm_alu_p_sub_a_hi,
-                     avm_alu_p_sub_a_lo,  avm_alu_p_sub_b_hi,
-                     avm_alu_p_sub_b_lo,  avm_alu_rng_chk_lookup_selector,
-                     avm_alu_rng_chk_sel, avm_alu_u16_r0,
-                     avm_alu_u16_r1,      avm_alu_u16_r2,
-                     avm_alu_u16_r3,      avm_alu_u16_r4,
-                     avm_alu_u16_r5,      avm_alu_u16_r6,
-                     avm_alu_u8_r0,       avm_alu_u8_r1,
-                     avm_binary_acc_ia,   avm_binary_acc_ib,
-                     avm_binary_acc_ic,   avm_binary_mem_tag_ctr,
-                     avm_binary_op_id,    avm_main_internal_return_ptr,
-                     avm_main_pc,         avm_mem_addr,
-                     avm_mem_rw,          avm_mem_tag,
+            return { avm_alu_a_hi,
+                     avm_alu_a_lo,
+                     avm_alu_b_hi,
+                     avm_alu_b_lo,
+                     avm_alu_cmp_rng_ctr,
+                     avm_alu_cmp_sel,
+                     avm_alu_op_add,
+                     avm_alu_op_cast,
+                     avm_alu_op_mul,
+                     avm_alu_op_sub,
+                     avm_alu_p_sub_a_hi,
+                     avm_alu_p_sub_a_lo,
+                     avm_alu_p_sub_b_hi,
+                     avm_alu_p_sub_b_lo,
+                     avm_alu_rng_chk_lookup_selector,
+                     avm_alu_rng_chk_sel,
+                     avm_alu_u16_r0,
+                     avm_alu_u16_r1,
+                     avm_alu_u16_r2,
+                     avm_alu_u16_r3,
+                     avm_alu_u16_r4,
+                     avm_alu_u16_r5,
+                     avm_alu_u16_r6,
+                     avm_alu_u8_r0,
+                     avm_alu_u8_r1,
+                     avm_binary_acc_ia,
+                     avm_binary_acc_ib,
+                     avm_binary_acc_ic,
+                     avm_binary_mem_tag_ctr,
+                     avm_binary_op_id,
+                     avm_main_internal_return_ptr,
+                     avm_main_pc,
+                     avm_mem_addr,
+                     avm_mem_rw,
+                     avm_mem_tag,
                      avm_mem_val };
         };
 
@@ -1579,6 +1632,7 @@ class AvmFlavor {
             Base::avm_alu_ic = "AVM_ALU_IC";
             Base::avm_alu_in_tag = "AVM_ALU_IN_TAG";
             Base::avm_alu_op_add = "AVM_ALU_OP_ADD";
+            Base::avm_alu_op_cast = "AVM_ALU_OP_CAST";
             Base::avm_alu_op_div = "AVM_ALU_OP_DIV";
             Base::avm_alu_op_eq = "AVM_ALU_OP_EQ";
             Base::avm_alu_op_eq_diff_inv = "AVM_ALU_OP_EQ_DIFF_INV";
@@ -1809,6 +1863,7 @@ class AvmFlavor {
         Commitment avm_alu_ic;
         Commitment avm_alu_in_tag;
         Commitment avm_alu_op_add;
+        Commitment avm_alu_op_cast;
         Commitment avm_alu_op_div;
         Commitment avm_alu_op_eq;
         Commitment avm_alu_op_eq_diff_inv;
@@ -2039,6 +2094,7 @@ class AvmFlavor {
             avm_alu_ic = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_alu_in_tag = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_alu_op_add = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
+            avm_alu_op_cast = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_alu_op_div = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_alu_op_eq = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_alu_op_eq_diff_inv = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
@@ -2274,6 +2330,7 @@ class AvmFlavor {
             serialize_to_buffer<Commitment>(avm_alu_ic, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_alu_in_tag, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_alu_op_add, Transcript::proof_data);
+            serialize_to_buffer<Commitment>(avm_alu_op_cast, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_alu_op_div, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_alu_op_eq, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_alu_op_eq_diff_inv, Transcript::proof_data);

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_flavor.hpp
@@ -69,11 +69,11 @@ class AvmFlavor {
     using RelationSeparator = FF;
 
     static constexpr size_t NUM_PRECOMPUTED_ENTITIES = 2;
-    static constexpr size_t NUM_WITNESS_ENTITIES = 212;
+    static constexpr size_t NUM_WITNESS_ENTITIES = 213;
     static constexpr size_t NUM_WIRES = NUM_WITNESS_ENTITIES + NUM_PRECOMPUTED_ENTITIES;
     // We have two copies of the witness entities, so we subtract the number of fixed ones (they have no shift), one for
     // the unshifted and one for the shifted
-    static constexpr size_t NUM_ALL_ENTITIES = 250;
+    static constexpr size_t NUM_ALL_ENTITIES = 252;
 
     using GrandProductRelations = std::tuple<perm_main_alu_relation<FF>,
                                              perm_main_bin_relation<FF>,
@@ -192,6 +192,7 @@ class AvmFlavor {
                               avm_alu_in_tag,
                               avm_alu_op_add,
                               avm_alu_op_cast,
+                              avm_alu_op_cast_prev,
                               avm_alu_op_div,
                               avm_alu_op_eq,
                               avm_alu_op_eq_diff_inv,
@@ -407,6 +408,7 @@ class AvmFlavor {
                      avm_alu_in_tag,
                      avm_alu_op_add,
                      avm_alu_op_cast,
+                     avm_alu_op_cast_prev,
                      avm_alu_op_div,
                      avm_alu_op_eq,
                      avm_alu_op_eq_diff_inv,
@@ -627,6 +629,7 @@ class AvmFlavor {
                               avm_alu_in_tag,
                               avm_alu_op_add,
                               avm_alu_op_cast,
+                              avm_alu_op_cast_prev,
                               avm_alu_op_div,
                               avm_alu_op_eq,
                               avm_alu_op_eq_diff_inv,
@@ -829,6 +832,7 @@ class AvmFlavor {
                               avm_alu_cmp_rng_ctr_shift,
                               avm_alu_cmp_sel_shift,
                               avm_alu_op_add_shift,
+                              avm_alu_op_cast_prev_shift,
                               avm_alu_op_cast_shift,
                               avm_alu_op_mul_shift,
                               avm_alu_op_sub_shift,
@@ -880,6 +884,7 @@ class AvmFlavor {
                      avm_alu_in_tag,
                      avm_alu_op_add,
                      avm_alu_op_cast,
+                     avm_alu_op_cast_prev,
                      avm_alu_op_div,
                      avm_alu_op_eq,
                      avm_alu_op_eq_diff_inv,
@@ -1082,6 +1087,7 @@ class AvmFlavor {
                      avm_alu_cmp_rng_ctr_shift,
                      avm_alu_cmp_sel_shift,
                      avm_alu_op_add_shift,
+                     avm_alu_op_cast_prev_shift,
                      avm_alu_op_cast_shift,
                      avm_alu_op_mul_shift,
                      avm_alu_op_sub_shift,
@@ -1133,6 +1139,7 @@ class AvmFlavor {
                      avm_alu_in_tag,
                      avm_alu_op_add,
                      avm_alu_op_cast,
+                     avm_alu_op_cast_prev,
                      avm_alu_op_div,
                      avm_alu_op_eq,
                      avm_alu_op_eq_diff_inv,
@@ -1331,80 +1338,37 @@ class AvmFlavor {
         };
         RefVector<DataType> get_to_be_shifted()
         {
-            return { avm_alu_a_hi,
-                     avm_alu_a_lo,
-                     avm_alu_b_hi,
-                     avm_alu_b_lo,
-                     avm_alu_cmp_rng_ctr,
-                     avm_alu_cmp_sel,
-                     avm_alu_op_add,
-                     avm_alu_op_cast,
-                     avm_alu_op_mul,
-                     avm_alu_op_sub,
-                     avm_alu_p_sub_a_hi,
-                     avm_alu_p_sub_a_lo,
-                     avm_alu_p_sub_b_hi,
-                     avm_alu_p_sub_b_lo,
-                     avm_alu_rng_chk_lookup_selector,
-                     avm_alu_rng_chk_sel,
-                     avm_alu_u16_r0,
-                     avm_alu_u16_r1,
-                     avm_alu_u16_r2,
-                     avm_alu_u16_r3,
-                     avm_alu_u16_r4,
-                     avm_alu_u16_r5,
-                     avm_alu_u16_r6,
-                     avm_alu_u8_r0,
-                     avm_alu_u8_r1,
-                     avm_binary_acc_ia,
-                     avm_binary_acc_ib,
-                     avm_binary_acc_ic,
-                     avm_binary_mem_tag_ctr,
-                     avm_binary_op_id,
-                     avm_main_internal_return_ptr,
-                     avm_main_pc,
-                     avm_mem_addr,
-                     avm_mem_rw,
-                     avm_mem_tag,
+            return { avm_alu_a_hi,        avm_alu_a_lo,           avm_alu_b_hi,       avm_alu_b_lo,
+                     avm_alu_cmp_rng_ctr, avm_alu_cmp_sel,        avm_alu_op_add,     avm_alu_op_cast_prev,
+                     avm_alu_op_cast,     avm_alu_op_mul,         avm_alu_op_sub,     avm_alu_p_sub_a_hi,
+                     avm_alu_p_sub_a_lo,  avm_alu_p_sub_b_hi,     avm_alu_p_sub_b_lo, avm_alu_rng_chk_lookup_selector,
+                     avm_alu_rng_chk_sel, avm_alu_u16_r0,         avm_alu_u16_r1,     avm_alu_u16_r2,
+                     avm_alu_u16_r3,      avm_alu_u16_r4,         avm_alu_u16_r5,     avm_alu_u16_r6,
+                     avm_alu_u8_r0,       avm_alu_u8_r1,          avm_binary_acc_ia,  avm_binary_acc_ib,
+                     avm_binary_acc_ic,   avm_binary_mem_tag_ctr, avm_binary_op_id,   avm_main_internal_return_ptr,
+                     avm_main_pc,         avm_mem_addr,           avm_mem_rw,         avm_mem_tag,
                      avm_mem_val };
         };
         RefVector<DataType> get_shifted()
         {
-            return { avm_alu_a_hi_shift,
-                     avm_alu_a_lo_shift,
-                     avm_alu_b_hi_shift,
-                     avm_alu_b_lo_shift,
-                     avm_alu_cmp_rng_ctr_shift,
-                     avm_alu_cmp_sel_shift,
-                     avm_alu_op_add_shift,
-                     avm_alu_op_cast_shift,
-                     avm_alu_op_mul_shift,
-                     avm_alu_op_sub_shift,
-                     avm_alu_p_sub_a_hi_shift,
-                     avm_alu_p_sub_a_lo_shift,
-                     avm_alu_p_sub_b_hi_shift,
-                     avm_alu_p_sub_b_lo_shift,
-                     avm_alu_rng_chk_lookup_selector_shift,
-                     avm_alu_rng_chk_sel_shift,
-                     avm_alu_u16_r0_shift,
-                     avm_alu_u16_r1_shift,
-                     avm_alu_u16_r2_shift,
-                     avm_alu_u16_r3_shift,
-                     avm_alu_u16_r4_shift,
-                     avm_alu_u16_r5_shift,
-                     avm_alu_u16_r6_shift,
-                     avm_alu_u8_r0_shift,
-                     avm_alu_u8_r1_shift,
-                     avm_binary_acc_ia_shift,
-                     avm_binary_acc_ib_shift,
-                     avm_binary_acc_ic_shift,
-                     avm_binary_mem_tag_ctr_shift,
-                     avm_binary_op_id_shift,
-                     avm_main_internal_return_ptr_shift,
-                     avm_main_pc_shift,
-                     avm_mem_addr_shift,
-                     avm_mem_rw_shift,
-                     avm_mem_tag_shift,
+            return { avm_alu_a_hi_shift,        avm_alu_a_lo_shift,
+                     avm_alu_b_hi_shift,        avm_alu_b_lo_shift,
+                     avm_alu_cmp_rng_ctr_shift, avm_alu_cmp_sel_shift,
+                     avm_alu_op_add_shift,      avm_alu_op_cast_prev_shift,
+                     avm_alu_op_cast_shift,     avm_alu_op_mul_shift,
+                     avm_alu_op_sub_shift,      avm_alu_p_sub_a_hi_shift,
+                     avm_alu_p_sub_a_lo_shift,  avm_alu_p_sub_b_hi_shift,
+                     avm_alu_p_sub_b_lo_shift,  avm_alu_rng_chk_lookup_selector_shift,
+                     avm_alu_rng_chk_sel_shift, avm_alu_u16_r0_shift,
+                     avm_alu_u16_r1_shift,      avm_alu_u16_r2_shift,
+                     avm_alu_u16_r3_shift,      avm_alu_u16_r4_shift,
+                     avm_alu_u16_r5_shift,      avm_alu_u16_r6_shift,
+                     avm_alu_u8_r0_shift,       avm_alu_u8_r1_shift,
+                     avm_binary_acc_ia_shift,   avm_binary_acc_ib_shift,
+                     avm_binary_acc_ic_shift,   avm_binary_mem_tag_ctr_shift,
+                     avm_binary_op_id_shift,    avm_main_internal_return_ptr_shift,
+                     avm_main_pc_shift,         avm_mem_addr_shift,
+                     avm_mem_rw_shift,          avm_mem_tag_shift,
                      avm_mem_val_shift };
         };
     };
@@ -1418,41 +1382,15 @@ class AvmFlavor {
 
         RefVector<DataType> get_to_be_shifted()
         {
-            return { avm_alu_a_hi,
-                     avm_alu_a_lo,
-                     avm_alu_b_hi,
-                     avm_alu_b_lo,
-                     avm_alu_cmp_rng_ctr,
-                     avm_alu_cmp_sel,
-                     avm_alu_op_add,
-                     avm_alu_op_cast,
-                     avm_alu_op_mul,
-                     avm_alu_op_sub,
-                     avm_alu_p_sub_a_hi,
-                     avm_alu_p_sub_a_lo,
-                     avm_alu_p_sub_b_hi,
-                     avm_alu_p_sub_b_lo,
-                     avm_alu_rng_chk_lookup_selector,
-                     avm_alu_rng_chk_sel,
-                     avm_alu_u16_r0,
-                     avm_alu_u16_r1,
-                     avm_alu_u16_r2,
-                     avm_alu_u16_r3,
-                     avm_alu_u16_r4,
-                     avm_alu_u16_r5,
-                     avm_alu_u16_r6,
-                     avm_alu_u8_r0,
-                     avm_alu_u8_r1,
-                     avm_binary_acc_ia,
-                     avm_binary_acc_ib,
-                     avm_binary_acc_ic,
-                     avm_binary_mem_tag_ctr,
-                     avm_binary_op_id,
-                     avm_main_internal_return_ptr,
-                     avm_main_pc,
-                     avm_mem_addr,
-                     avm_mem_rw,
-                     avm_mem_tag,
+            return { avm_alu_a_hi,        avm_alu_a_lo,           avm_alu_b_hi,       avm_alu_b_lo,
+                     avm_alu_cmp_rng_ctr, avm_alu_cmp_sel,        avm_alu_op_add,     avm_alu_op_cast_prev,
+                     avm_alu_op_cast,     avm_alu_op_mul,         avm_alu_op_sub,     avm_alu_p_sub_a_hi,
+                     avm_alu_p_sub_a_lo,  avm_alu_p_sub_b_hi,     avm_alu_p_sub_b_lo, avm_alu_rng_chk_lookup_selector,
+                     avm_alu_rng_chk_sel, avm_alu_u16_r0,         avm_alu_u16_r1,     avm_alu_u16_r2,
+                     avm_alu_u16_r3,      avm_alu_u16_r4,         avm_alu_u16_r5,     avm_alu_u16_r6,
+                     avm_alu_u8_r0,       avm_alu_u8_r1,          avm_binary_acc_ia,  avm_binary_acc_ib,
+                     avm_binary_acc_ic,   avm_binary_mem_tag_ctr, avm_binary_op_id,   avm_main_internal_return_ptr,
+                     avm_main_pc,         avm_mem_addr,           avm_mem_rw,         avm_mem_tag,
                      avm_mem_val };
         };
 
@@ -1633,6 +1571,7 @@ class AvmFlavor {
             Base::avm_alu_in_tag = "AVM_ALU_IN_TAG";
             Base::avm_alu_op_add = "AVM_ALU_OP_ADD";
             Base::avm_alu_op_cast = "AVM_ALU_OP_CAST";
+            Base::avm_alu_op_cast_prev = "AVM_ALU_OP_CAST_PREV";
             Base::avm_alu_op_div = "AVM_ALU_OP_DIV";
             Base::avm_alu_op_eq = "AVM_ALU_OP_EQ";
             Base::avm_alu_op_eq_diff_inv = "AVM_ALU_OP_EQ_DIFF_INV";
@@ -1864,6 +1803,7 @@ class AvmFlavor {
         Commitment avm_alu_in_tag;
         Commitment avm_alu_op_add;
         Commitment avm_alu_op_cast;
+        Commitment avm_alu_op_cast_prev;
         Commitment avm_alu_op_div;
         Commitment avm_alu_op_eq;
         Commitment avm_alu_op_eq_diff_inv;
@@ -2095,6 +2035,7 @@ class AvmFlavor {
             avm_alu_in_tag = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_alu_op_add = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_alu_op_cast = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
+            avm_alu_op_cast_prev = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_alu_op_div = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_alu_op_eq = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_alu_op_eq_diff_inv = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
@@ -2331,6 +2272,7 @@ class AvmFlavor {
             serialize_to_buffer<Commitment>(avm_alu_in_tag, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_alu_op_add, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_alu_op_cast, Transcript::proof_data);
+            serialize_to_buffer<Commitment>(avm_alu_op_cast_prev, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_alu_op_div, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_alu_op_eq, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_alu_op_eq_diff_inv, Transcript::proof_data);

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.cpp
@@ -76,6 +76,7 @@ void AvmProver::execute_wire_commitments_round()
     witness_commitments.avm_alu_in_tag = commitment_key->commit(key->avm_alu_in_tag);
     witness_commitments.avm_alu_op_add = commitment_key->commit(key->avm_alu_op_add);
     witness_commitments.avm_alu_op_cast = commitment_key->commit(key->avm_alu_op_cast);
+    witness_commitments.avm_alu_op_cast_prev = commitment_key->commit(key->avm_alu_op_cast_prev);
     witness_commitments.avm_alu_op_div = commitment_key->commit(key->avm_alu_op_div);
     witness_commitments.avm_alu_op_eq = commitment_key->commit(key->avm_alu_op_eq);
     witness_commitments.avm_alu_op_eq_diff_inv = commitment_key->commit(key->avm_alu_op_eq_diff_inv);
@@ -260,6 +261,7 @@ void AvmProver::execute_wire_commitments_round()
     transcript->send_to_verifier(commitment_labels.avm_alu_in_tag, witness_commitments.avm_alu_in_tag);
     transcript->send_to_verifier(commitment_labels.avm_alu_op_add, witness_commitments.avm_alu_op_add);
     transcript->send_to_verifier(commitment_labels.avm_alu_op_cast, witness_commitments.avm_alu_op_cast);
+    transcript->send_to_verifier(commitment_labels.avm_alu_op_cast_prev, witness_commitments.avm_alu_op_cast_prev);
     transcript->send_to_verifier(commitment_labels.avm_alu_op_div, witness_commitments.avm_alu_op_div);
     transcript->send_to_verifier(commitment_labels.avm_alu_op_eq, witness_commitments.avm_alu_op_eq);
     transcript->send_to_verifier(commitment_labels.avm_alu_op_eq_diff_inv, witness_commitments.avm_alu_op_eq_diff_inv);

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.cpp
@@ -75,6 +75,7 @@ void AvmProver::execute_wire_commitments_round()
     witness_commitments.avm_alu_ic = commitment_key->commit(key->avm_alu_ic);
     witness_commitments.avm_alu_in_tag = commitment_key->commit(key->avm_alu_in_tag);
     witness_commitments.avm_alu_op_add = commitment_key->commit(key->avm_alu_op_add);
+    witness_commitments.avm_alu_op_cast = commitment_key->commit(key->avm_alu_op_cast);
     witness_commitments.avm_alu_op_div = commitment_key->commit(key->avm_alu_op_div);
     witness_commitments.avm_alu_op_eq = commitment_key->commit(key->avm_alu_op_eq);
     witness_commitments.avm_alu_op_eq_diff_inv = commitment_key->commit(key->avm_alu_op_eq_diff_inv);
@@ -136,6 +137,7 @@ void AvmProver::execute_wire_commitments_round()
     witness_commitments.avm_byte_lookup_table_input_b = commitment_key->commit(key->avm_byte_lookup_table_input_b);
     witness_commitments.avm_byte_lookup_table_op_id = commitment_key->commit(key->avm_byte_lookup_table_op_id);
     witness_commitments.avm_byte_lookup_table_output = commitment_key->commit(key->avm_byte_lookup_table_output);
+    witness_commitments.avm_main_alu_in_tag = commitment_key->commit(key->avm_main_alu_in_tag);
     witness_commitments.avm_main_alu_sel = commitment_key->commit(key->avm_main_alu_sel);
     witness_commitments.avm_main_bin_op_id = commitment_key->commit(key->avm_main_bin_op_id);
     witness_commitments.avm_main_bin_sel = commitment_key->commit(key->avm_main_bin_sel);
@@ -180,6 +182,7 @@ void AvmProver::execute_wire_commitments_round()
     witness_commitments.avm_main_sel_mov_b = commitment_key->commit(key->avm_main_sel_mov_b);
     witness_commitments.avm_main_sel_op_add = commitment_key->commit(key->avm_main_sel_op_add);
     witness_commitments.avm_main_sel_op_and = commitment_key->commit(key->avm_main_sel_op_and);
+    witness_commitments.avm_main_sel_op_cast = commitment_key->commit(key->avm_main_sel_op_cast);
     witness_commitments.avm_main_sel_op_div = commitment_key->commit(key->avm_main_sel_op_div);
     witness_commitments.avm_main_sel_op_eq = commitment_key->commit(key->avm_main_sel_op_eq);
     witness_commitments.avm_main_sel_op_lt = commitment_key->commit(key->avm_main_sel_op_lt);
@@ -256,6 +259,7 @@ void AvmProver::execute_wire_commitments_round()
     transcript->send_to_verifier(commitment_labels.avm_alu_ic, witness_commitments.avm_alu_ic);
     transcript->send_to_verifier(commitment_labels.avm_alu_in_tag, witness_commitments.avm_alu_in_tag);
     transcript->send_to_verifier(commitment_labels.avm_alu_op_add, witness_commitments.avm_alu_op_add);
+    transcript->send_to_verifier(commitment_labels.avm_alu_op_cast, witness_commitments.avm_alu_op_cast);
     transcript->send_to_verifier(commitment_labels.avm_alu_op_div, witness_commitments.avm_alu_op_div);
     transcript->send_to_verifier(commitment_labels.avm_alu_op_eq, witness_commitments.avm_alu_op_eq);
     transcript->send_to_verifier(commitment_labels.avm_alu_op_eq_diff_inv, witness_commitments.avm_alu_op_eq_diff_inv);
@@ -325,6 +329,7 @@ void AvmProver::execute_wire_commitments_round()
                                  witness_commitments.avm_byte_lookup_table_op_id);
     transcript->send_to_verifier(commitment_labels.avm_byte_lookup_table_output,
                                  witness_commitments.avm_byte_lookup_table_output);
+    transcript->send_to_verifier(commitment_labels.avm_main_alu_in_tag, witness_commitments.avm_main_alu_in_tag);
     transcript->send_to_verifier(commitment_labels.avm_main_alu_sel, witness_commitments.avm_main_alu_sel);
     transcript->send_to_verifier(commitment_labels.avm_main_bin_op_id, witness_commitments.avm_main_bin_op_id);
     transcript->send_to_verifier(commitment_labels.avm_main_bin_sel, witness_commitments.avm_main_bin_sel);
@@ -372,6 +377,7 @@ void AvmProver::execute_wire_commitments_round()
     transcript->send_to_verifier(commitment_labels.avm_main_sel_mov_b, witness_commitments.avm_main_sel_mov_b);
     transcript->send_to_verifier(commitment_labels.avm_main_sel_op_add, witness_commitments.avm_main_sel_op_add);
     transcript->send_to_verifier(commitment_labels.avm_main_sel_op_and, witness_commitments.avm_main_sel_op_and);
+    transcript->send_to_verifier(commitment_labels.avm_main_sel_op_cast, witness_commitments.avm_main_sel_op_cast);
     transcript->send_to_verifier(commitment_labels.avm_main_sel_op_div, witness_commitments.avm_main_sel_op_div);
     transcript->send_to_verifier(commitment_labels.avm_main_sel_op_eq, witness_commitments.avm_main_sel_op_eq);
     transcript->send_to_verifier(commitment_labels.avm_main_sel_op_lt, witness_commitments.avm_main_sel_op_lt);

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_verifier.cpp
@@ -70,6 +70,8 @@ bool AvmVerifier::verify_proof(const HonkProof& proof)
     commitments.avm_alu_ic = transcript->template receive_from_prover<Commitment>(commitment_labels.avm_alu_ic);
     commitments.avm_alu_in_tag = transcript->template receive_from_prover<Commitment>(commitment_labels.avm_alu_in_tag);
     commitments.avm_alu_op_add = transcript->template receive_from_prover<Commitment>(commitment_labels.avm_alu_op_add);
+    commitments.avm_alu_op_cast =
+        transcript->template receive_from_prover<Commitment>(commitment_labels.avm_alu_op_cast);
     commitments.avm_alu_op_div = transcript->template receive_from_prover<Commitment>(commitment_labels.avm_alu_op_div);
     commitments.avm_alu_op_eq = transcript->template receive_from_prover<Commitment>(commitment_labels.avm_alu_op_eq);
     commitments.avm_alu_op_eq_diff_inv =

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_verifier.cpp
@@ -72,6 +72,8 @@ bool AvmVerifier::verify_proof(const HonkProof& proof)
     commitments.avm_alu_op_add = transcript->template receive_from_prover<Commitment>(commitment_labels.avm_alu_op_add);
     commitments.avm_alu_op_cast =
         transcript->template receive_from_prover<Commitment>(commitment_labels.avm_alu_op_cast);
+    commitments.avm_alu_op_cast_prev =
+        transcript->template receive_from_prover<Commitment>(commitment_labels.avm_alu_op_cast_prev);
     commitments.avm_alu_op_div = transcript->template receive_from_prover<Commitment>(commitment_labels.avm_alu_op_div);
     commitments.avm_alu_op_eq = transcript->template receive_from_prover<Commitment>(commitment_labels.avm_alu_op_eq);
     commitments.avm_alu_op_eq_diff_inv =

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_verifier.cpp
@@ -167,6 +167,8 @@ bool AvmVerifier::verify_proof(const HonkProof& proof)
         transcript->template receive_from_prover<Commitment>(commitment_labels.avm_byte_lookup_table_op_id);
     commitments.avm_byte_lookup_table_output =
         transcript->template receive_from_prover<Commitment>(commitment_labels.avm_byte_lookup_table_output);
+    commitments.avm_main_alu_in_tag =
+        transcript->template receive_from_prover<Commitment>(commitment_labels.avm_main_alu_in_tag);
     commitments.avm_main_alu_sel =
         transcript->template receive_from_prover<Commitment>(commitment_labels.avm_main_alu_sel);
     commitments.avm_main_bin_op_id =
@@ -240,6 +242,8 @@ bool AvmVerifier::verify_proof(const HonkProof& proof)
         transcript->template receive_from_prover<Commitment>(commitment_labels.avm_main_sel_op_add);
     commitments.avm_main_sel_op_and =
         transcript->template receive_from_prover<Commitment>(commitment_labels.avm_main_sel_op_and);
+    commitments.avm_main_sel_op_cast =
+        transcript->template receive_from_prover<Commitment>(commitment_labels.avm_main_sel_op_cast);
     commitments.avm_main_sel_op_div =
         transcript->template receive_from_prover<Commitment>(commitment_labels.avm_main_sel_op_div);
     commitments.avm_main_sel_op_eq =


### PR DESCRIPTION
Sole purpose of this PR is to reproduce a compilation error related to inline assembly and number of registers:

https://app.circleci.com/pipelines/github/AztecProtocol/aztec-packages/35601/workflows/1275d5df-1b6a-4a88-80db-d2be3fe41812/jobs/1662120?invite=true#step-103-454781_69


`#12 96.19 /usr/src/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/../../fields/./field_impl_x64.hpp:29:13: fatal error: inline assembly requires more registers than available
#12 96.19     __asm__(MUL("0(%0)", "8(%0)", "16(%0)", "24(%0)", "%1")
#12 96.19             ^
#12 96.19 /usr/src/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/../../fields/asm_macros.hpp:654:9: note: expanded from macro 'MUL'
#12 96.19         "movq " a1 ", %%rdx                        \n\t" /* load a[0] into %rdx                                     */  \
#12 96.19         ^`