### PR TITLE
fix: don't refcount spot

### DIFF
--- a/.github/workflows/setup-runner.yml
+++ b/.github/workflows/setup-runner.yml
@@ -57,7 +57,7 @@ jobs:
       group: start-builder-${{ inputs.runner_label }}
     steps:
       - name: Start EC2 runner
-        uses: AztecProtocol/ec2-action-builder@v0.12
+        uses: AztecProtocol/ec2-action-builder@v0.13
         with:
           github_token: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
This logic has proven tricky and is taking down builds early.

I may have found the mistake, but its best to make sure everything is stable without this https://github.com/AztecProtocol/ec2-action-builder/commit/95568a191495422eee22a20e48c9d4995aa32538
