### PR TITLE
fix!: move fixtures to @aztec/circuits.js/testing/fixtures

### DIFF
--- a/yarn-project/circuits.js/package.json
+++ b/yarn-project/circuits.js/package.json
@@ -11,6 +11,7 @@
     "./hash": "./dest/hash/index.js",
     "./barretenberg": "./dest/barretenberg/index.js",
     "./testing": "./dest/tests/index.js",
+    "./testing/fixtures": "./dest/tests/fixtures.js",
     "./interfaces": "./dest/interfaces/index.js",
     "./utils": "./dest/utils/index.js",
     "./types": "./dest/types/index.js",

--- a/yarn-project/circuits.js/src/tests/index.ts
+++ b/yarn-project/circuits.js/src/tests/index.ts
@@ -1,2 +1,1 @@
-export * from './fixtures.js';
 export * from './factories.js';


### PR DESCRIPTION
Moves circuits.js' fixtures to their own export since they only work in a nodejs environment.
