### PR TITLE
chore: replace use of PublicContext with interface

### DIFF
--- a/noir-projects/noir-contracts/contracts/fpc_contract/src/fee.nr
+++ b/noir-projects/noir-contracts/contracts/fpc_contract/src/fee.nr
@@ -1,5 +1,5 @@
-use dep::aztec::context::PublicContext;
+use dep::aztec::context::interface::PublicContextInterface;
 
-pub fn calculate_fee(_context: PublicContext) -> U128 {
+pub fn calculate_fee<TPublicContext>(_context: TPublicContext) -> U128 where TPublicContext: PublicContextInterface {
     U128::from_integer(1)
 }

--- a/noir-projects/noir-contracts/contracts/gas_token_contract/src/lib.nr
+++ b/noir-projects/noir-contracts/contracts/gas_token_contract/src/lib.nr
@@ -1,9 +1,8 @@
 use dep::aztec::prelude::{AztecAddress, EthAddress};
-use dep::aztec::context::PublicContext;
+use dep::aztec::context::interface::PublicContextInterface;
 use dep::aztec::protocol_types::hash::sha256_to_field;
 
-pub fn calculate_fee(_context: PublicContext) -> U128 {
-    // TODO(palla/gas-in-circuits): Use the transaction_fee injected into the context
+pub fn calculate_fee<TPublicContext>(_context: TPublicContext) -> U128 where TPublicContext: PublicContextInterface {
     U128::from_integer(1)
 }
 


### PR DESCRIPTION
Towards AVM migrations.
