### PR TITLE
chore: Validate instance deployer address every time we request it

### DIFF
--- a/yarn-project/protocol-contracts/src/instance-deployer/index.ts
+++ b/yarn-project/protocol-contracts/src/instance-deployer/index.ts
@@ -5,7 +5,13 @@ import { ContractInstanceDeployerArtifact } from './artifact.js';
 
 /** Returns the canonical deployment of the instance deployer contract. */
 export function getCanonicalInstanceDeployer(): ProtocolContract {
-  return getCanonicalProtocolContract(ContractInstanceDeployerArtifact, 1);
+  const contract = getCanonicalProtocolContract(ContractInstanceDeployerArtifact, 1);
+  if (!contract.address.equals(InstanceDeployerAddress)) {
+    throw new Error(
+      `Incorrect address for contract deployer (got ${contract.address.toString()} but expected (${InstanceDeployerAddress.toString()}). Check DEPLOYER_CONTRACT_ADDRESS is set to the correct value in the constants files and run the protocol-contracts package tests.`,
+    );
+  }
+  return contract;
 }
 
 export const InstanceDeployerAddress = AztecAddress.fromBigInt(DEPLOYER_CONTRACT_ADDRESS);


### PR DESCRIPTION
Prevents deep errors in e2e tests where we fail to find a publicly deployed contract because the address of the deployer does not match.
