### PR TITLE
chore: Check working copy is clean before extract-repo

### DIFF
--- a/build-system/scripts/check_working_copy_clean
+++ b/build-system/scripts/check_working_copy_clean
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# If this script fails (nonzero exit), then the working copy is not clean.
+
+[ -n "${BUILD_SYSTEM_DEBUG:-}" ] && set -x # conditionally trace
+set -eu
+
+REPOSITORY=$1
+
+# Get list of rebuild patterns, concat them with regex 'or' (|), and double escape \ for awk -v.
+AWK_PATTERN=$(query_manifest rebuildPatterns $REPOSITORY | tr '\n' '|' | sed 's/\\/\\\\/g')
+# Remove the trailing '|'.
+AWK_PATTERN=${AWK_PATTERN%|}
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Check if there is anything dirty in the local copy, if so, bail with non-zero exit code.
+CHANGED_FILES=$(git status --porcelain | awk -v pattern="($AWK_PATTERN)" '$2 ~ pattern {print $2}')
+if [ -n "$CHANGED_FILES" ]; then
+  echo $CHANGED_FILES
+  exit 1
+fi

--- a/build-system/scripts/extract_repo
+++ b/build-system/scripts/extract_repo
@@ -7,6 +7,11 @@ set -eu
 REPOSITORY=$1
 shift
 
+if ! check_working_copy_clean $REPOSITORY; then 
+  echo "The working copy for $REPOSITORY or one of its dependencies as listed in build manifest is not clean. Aborting extract_repo."
+  exit 1
+fi
+
 IMAGE_COMMIT_URI=$(calculate_image_uri $REPOSITORY)
 if docker image ls --format "{{.Repository}}:{{.Tag}}" | grep -q -w "$IMAGE_COMMIT_URI$"; then
   echo -e "Image exists locally. No need to pull."


### PR DESCRIPTION
This prevents bootstrap fast from downloading artifacts that do not match the source currently in the working copy.
