### PR TITLE
fix(ci): use larger memory runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       ebs_cache_size_gb: 256
       runner_concurrency: 20
       subaction: ${{ github.event.inputs.runner_action || 'start' }}
-      ec2_instance_type: m6a.32xlarge
+      ec2_instance_type: r6a.32xlarge
       ec2_ami_id: ami-04d8422a9ba4de80f
       ec2_instance_ttl: 40 # refreshed by jobs
     secrets: inherit
@@ -119,7 +119,7 @@ jobs:
       ebs_cache_size_gb: 64
       runner_concurrency: 1
       subaction: ${{ github.event.inputs.runner_action || 'start' }}
-      ec2_instance_type: m6a.4xlarge
+      ec2_instance_type: r6a.4xlarge
       ec2_ami_id: ami-04d8422a9ba4de80f
       ec2_instance_ttl: 15 # refreshed by jobs
     secrets: inherit

--- a/.github/workflows/start-spot.yml
+++ b/.github/workflows/start-spot.yml
@@ -10,7 +10,7 @@ jobs:
       ebs_cache_size_gb: 256
       runner_concurrency: 20
       subaction: start
-      ec2_instance_type: m6a.32xlarge
+      ec2_instance_type: r6a.32xlarge
       ec2_ami_id: ami-04d8422a9ba4de80f
       ec2_instance_ttl: 40 # refreshed by jobs
     secrets: inherit
@@ -22,7 +22,7 @@ jobs:
       ebs_cache_size_gb: 64
       runner_concurrency: 1
       subaction: start
-      ec2_instance_type: m6a.4xlarge
+      ec2_instance_type: r6a.4xlarge
       ec2_ami_id: ami-04d8422a9ba4de80f
       ec2_instance_ttl: 15 # refreshed by jobs
     secrets: inherit

--- a/.github/workflows/stop-spot.yml
+++ b/.github/workflows/stop-spot.yml
@@ -11,7 +11,7 @@ jobs:
       # not used:
       ebs_cache_size_gb: 128
       runner_concurrency: 20
-      ec2_instance_type: m6a.32xlarge
+      ec2_instance_type: r6a.32xlarge
       ec2_ami_id: ami-0d8a9b0419ddb331a
       ec2_instance_ttl: 40
     secrets: inherit
@@ -24,7 +24,7 @@ jobs:
       # not used:
       ebs_cache_size_gb: 32
       runner_concurrency: 1
-      ec2_instance_type: m6a.4xlarge
+      ec2_instance_type: r6a.4xlarge
       ec2_ami_id: ami-0d8a9b0419ddb331a
       ec2_instance_ttl: 15
     secrets: inherit


### PR DESCRIPTION
Seeing memory exhaustion in a PR, while using too much memory is an issue we should worry about, having it not take down CI is good. These have 1TB memory https://aws.amazon.com/ec2/instance-types/r6a/

