### PR TITLE
refactor(aztec-nr)!: unencrypted logs go behind context

### DIFF
--- a/docs/docs/developers/contracts/writing_contracts/events/emit_event.md
+++ b/docs/docs/developers/contracts/writing_contracts/events/emit_event.md
@@ -96,15 +96,9 @@ They can be emitted by both public and private functions.
 - Unencrypted events are currently **NOT** linked to the contract emitting them, so it is practically a [`debug_log`](../oracles/main.md#a-few-useful-inbuilt-oracles).
   :::
 
-### Import library
-
-To emit unencrypted logs first import the `emit_unencrypted_log` utility function inside your contract:
-
-#include_code unencrypted_import /noir-projects/noir-contracts/contracts/test_contract/src/main.nr rust
-
 ### Call emit_unencrypted_log
 
-After importing, you can call the function:
+To emit unencrypted logs you don't need to import any library. You call the context method `emit_unencrypted_log`:
 
 #include_code emit_unencrypted /noir-projects/noir-contracts/contracts/test_contract/src/main.nr rust
 

--- a/docs/docs/misc/migration_notes.md
+++ b/docs/docs/misc/migration_notes.md
@@ -117,6 +117,20 @@ Note that gas limits are not yet enforced. For now, it is suggested you use `dep
 
 Note that this is not required when enqueuing a public function from a private one, since top-level enqueued public functions will always consume all gas available for the transaction, as it is not possible to handle any out-of-gas errors.
 
+### [Aztec.nr] Emmiting unencrypted logs
+
+The `emit_unencrypted_logs` function is now a context method.
+
+```diff
+- use dep::aztec::log::emit_unencrypted_log;
+- use dep::aztec::log::emit_unencrypted_log_from_private;
+
+- emit_unencrypted_log(context, log1);
+- emit_unencrypted_log_from_private(context, log2);
++ context.emit_unencrypted_log(log1);
++ context.emit_unencrypted_log(log2);
+```
+
 ## 0.33
 
 ### [Aztec.nr] Storage struct annotation

--- a/noir-projects/aztec-nr/aztec/src/context/avm_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/avm_context.nr
@@ -121,12 +121,8 @@ impl PublicContextInterface for AvmContext {
     }
 
     fn emit_unencrypted_log<T>(&mut self, log: T) {
-        let event_selector = 0;
+        let event_selector = 5;  // Matches current PublicContext.
         self.emit_unencrypted_log(event_selector, log);
-    }
-
-    fn push_unencrypted_log(&mut self, log_hash: Field) {
-        assert(false, "'push_unencrypted_log' not required for avm - use emit_unencrypted_log!");
     }
 
     fn consume_l1_to_l2_message(&mut self, content: Field, secret: Field, sender: EthAddress, leaf_index: Field) {

--- a/noir-projects/aztec-nr/aztec/src/context/interface.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/interface.nr
@@ -35,9 +35,6 @@ trait PublicContextInterface {
     fn message_portal(&mut self, recipient: EthAddress, content: Field);
     fn consume_l1_to_l2_message(&mut self, content: Field, secret: Field, sender: EthAddress, leaf_index: Field);
     fn emit_unencrypted_log<T>(&mut self, log: T);
-    // TODO(1165) Merge push_unencrypted_log into emit_unencrypted_log, since oracle call
-    // in PublicContext will no longer be needed for extracting log hash
-    fn push_unencrypted_log(&mut self, log_hash: Field);
     fn call_public_function<RETURNS_COUNT>(
         self: &mut Self,
         contract_address: AztecAddress,

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -3,8 +3,8 @@ use crate::{
     messaging::process_l1_to_l2_message, hash::{hash_args_array, ArgsHasher},
     oracle::{
     arguments, returns, call_private_function::call_private_function_internal,
-    enqueue_public_function_call::enqueue_public_function_call_internal,
-    header::get_header_at, nullifier_key::{get_nullifier_keys, NullifierKeys}
+    enqueue_public_function_call::enqueue_public_function_call_internal, header::get_header_at,
+    nullifier_key::{get_nullifier_keys, NullifierKeys}
 }
 };
 use dep::protocol_types::{
@@ -272,7 +272,14 @@ impl PrivateContext {
         // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1165)
     }
 
-    pub fn push_unencrypted_log(&mut self, log_hash: Field) {
+    // TODO: We might want to remove this since emitting unencrypted logs from private functions is violating privacy.
+    // --> might be a better approach to force devs to make a public function call that emits the log if needed then
+    // it would be less easy to accidentally leak information.
+    // If we decide to keep this function around would make sense to wait for traits and then merge it with emit_unencrypted_log.
+    pub fn emit_unencrypted_log<T>(&mut self, log: T) {
+        let event_selector = 5; // TODO: compute actual event selector.
+        let log_hash = emit_unencrypted_log_private_internal(self.this_address(), event_selector, log);
+
         let side_effect = SideEffect { value: log_hash, counter: self.side_effect_counter };
         self.unencrypted_logs_hashes.push(side_effect);
         self.side_effect_counter = self.side_effect_counter + 1;
@@ -589,4 +596,20 @@ impl PackedReturns {
         let unpacked: [Field; N] = self.unpack();
         Deserialize::deserialize(unpacked)
     }
+}
+
+#[oracle(emitUnencryptedLog)]
+fn emit_unencrypted_log_oracle_private<T>(
+    _contract_address: AztecAddress,
+    _event_selector: Field,
+    _message: T
+) -> Field {}
+
+unconstrained pub fn emit_unencrypted_log_private_internal<T>(
+    contract_address: AztecAddress,
+    event_selector: Field,
+    message: T
+) -> Field {
+    // https://github.com/AztecProtocol/aztec-packages/issues/885
+    emit_unencrypted_log_oracle_private(contract_address, event_selector, message)
 }

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -281,14 +281,11 @@ impl PublicContextInterface for PublicContext {
     }
 
     fn emit_unencrypted_log<T>(&mut self, log: T) {
-        let _void1 = self;
-        let _void2 = log;
+        let event_selector = 5;
+        let log_hash = emit_unencrypted_log_oracle(self.this_address(), event_selector, log);
         // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1165)
         // Once we hash inside circuits, this replaces push_unencrypted_log
         // For now we need an oracle to get the hash
-    }
-
-    fn push_unencrypted_log(&mut self, log_hash: Field) {
         let side_effect = SideEffect { value: log_hash, counter: self.side_effect_counter };
         self.unencrypted_logs_hashes.push(side_effect);
         self.side_effect_counter = self.side_effect_counter + 1;
@@ -356,6 +353,13 @@ impl Empty for PublicContext {
 
 #[oracle(checkNullifierExists)]
 fn nullifier_exists_oracle(nullifier: Field) -> Field {}
+
+#[oracle(emitUnencryptedLog)]
+fn emit_unencrypted_log_oracle<T>(
+    _contract_address: AztecAddress,
+    _event_selector: Field,
+    _message: T
+) -> Field {}
 
 struct FunctionReturns<N> {
     values: [Field; N]

--- a/noir-projects/aztec-nr/aztec/src/log.nr
+++ b/noir-projects/aztec-nr/aztec/src/log.nr
@@ -19,22 +19,3 @@ pub fn emit_encrypted_log<N>(
     );
     context.push_encrypted_log(log_hash);
 }
-
-pub fn emit_unencrypted_log<T>(context: &mut PublicContext, log: T) {
-    let contract_address = context.this_address();
-    let event_selector = 5; // TODO: compute actual event selector.
-    let log_hash = oracle::logs::emit_unencrypted_log(contract_address, event_selector, log);
-    context.push_unencrypted_log(log_hash);
-}
-
-// TODO: We might want to remove this since emitting unencrypted logs from private functions is violating privacy.
-// --> might be a better approach to force devs to make a public function call that emits the log if needed then
-// it would be less easy to accidentally leak information.
-// If we decide to keep this function around would make sense to wait for traits and then merge it with emit_unencrypted_log.
-pub fn emit_unencrypted_log_from_private<T>(context: &mut PrivateContext, log: T) {
-    let contract_address = context.this_address();
-    let event_selector = 5; // TODO: compute actual event selector.
-    let log_hash = oracle::logs::emit_unencrypted_log(contract_address, event_selector, log);
-    context.push_unencrypted_log(log_hash);
-    // context.accumulate_unencrypted_logs(log);
-}

--- a/noir-projects/aztec-nr/aztec/src/oracle/logs.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/logs.nr
@@ -25,19 +25,3 @@ unconstrained pub fn emit_encrypted_log<N>(
         preimage
     )
 }
-
-#[oracle(emitUnencryptedLog)]
-fn emit_unencrypted_log_oracle<T>(
-    _contract_address: AztecAddress,
-    _event_selector: Field,
-    _message: T
-) -> Field {}
-
-unconstrained pub fn emit_unencrypted_log<T>(
-    contract_address: AztecAddress,
-    event_selector: Field,
-    message: T
-) -> Field {
-    // https://github.com/AztecProtocol/aztec-packages/issues/885
-    emit_unencrypted_log_oracle(contract_address, event_selector, message)
-}

--- a/noir-projects/aztec-nr/aztec/src/prelude.nr
+++ b/noir-projects/aztec-nr/aztec/src/prelude.nr
@@ -9,8 +9,7 @@ use crate::{
     public_immutable::PublicImmutable, public_mutable::PublicMutable, private_set::PrivateSet,
     shared_immutable::SharedImmutable, storage::Storable
 },
-    log::{emit_unencrypted_log, emit_encrypted_log},
-    context::{PrivateContext, PackedReturns, FunctionReturns},
+    log::emit_encrypted_log, context::{PrivateContext, PackedReturns, FunctionReturns},
     note::{
     note_header::NoteHeader, note_interface::NoteInterface, note_getter_options::NoteGetterOptions,
     note_viewer_options::NoteViewerOptions,

--- a/noir-projects/noir-contracts/contracts/auth_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/auth_contract/src/main.nr
@@ -2,10 +2,7 @@
 // publicly store the address of an authorized account that can call private functions.
 contract Auth {
     use dep::aztec::protocol_types::address::AztecAddress;
-    use dep::aztec::{
-        log::{emit_unencrypted_log, emit_unencrypted_log_from_private},
-        state_vars::{PublicImmutable, SharedMutable}
-    };
+    use dep::aztec::state_vars::{PublicImmutable, SharedMutable};
 
     // Authorizing a new address has a certain block delay before it goes into effect.
     global CHANGE_AUTHORIZED_DELAY_BLOCKS = 5;

--- a/noir-projects/noir-contracts/contracts/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/benchmarking_contract/src/main.nr
@@ -4,10 +4,7 @@
 // subject being tested as unmodified as possible so we can detect metric changes that
 
 contract Benchmarking {
-    use dep::aztec::prelude::{
-        AztecAddress, FunctionSelector, NoteHeader, NoteGetterOptions, emit_unencrypted_log, Map,
-        PublicMutable, PrivateSet
-    };
+    use dep::aztec::prelude::{AztecAddress, FunctionSelector, NoteHeader, NoteGetterOptions, Map, PublicMutable, PrivateSet};
     use dep::value_note::{utils::{increment, decrement}, value_note::ValueNote};
 
     use dep::aztec::{context::{Context, gas::GasOpts}};
@@ -50,6 +47,6 @@ contract Benchmarking {
     // Emits a public log.
     #[aztec(public)]
     fn broadcast(owner: AztecAddress) {
-        emit_unencrypted_log(&mut context, storage.balances.at(owner).read());
+        context.emit_unencrypted_log(storage.balances.at(owner).read());
     }
 }

--- a/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
@@ -1,9 +1,6 @@
 // A contract used along with `Parent` contract to test nested calls.
 contract Child {
-    use dep::aztec::prelude::{
-        AztecAddress, FunctionSelector, PublicMutable, PrivateSet, PrivateContext, emit_unencrypted_log,
-        Deserialize
-    };
+    use dep::aztec::prelude::{AztecAddress, FunctionSelector, PublicMutable, PrivateSet, PrivateContext, Deserialize};
 
     use dep::aztec::{
         context::{PublicContext, Context, gas::GasOpts},
@@ -47,7 +44,7 @@ contract Child {
     #[aztec(public)]
     fn pub_set_value(new_value: Field) -> Field {
         storage.current_value.write(new_value);
-        emit_unencrypted_log(&mut context, new_value);
+        context.emit_unencrypted_log(new_value);
 
         new_value
     }
@@ -76,7 +73,7 @@ contract Child {
     fn pub_inc_value(new_value: Field) -> Field {
         let old_value = storage.current_value.read();
         storage.current_value.write(old_value + new_value);
-        emit_unencrypted_log(&mut context, new_value);
+        context.emit_unencrypted_log(new_value);
 
         new_value
     }
@@ -87,7 +84,7 @@ contract Child {
     fn pub_inc_value_internal(new_value: Field) -> Field {
         let old_value = storage.current_value.read();
         storage.current_value.write(old_value + new_value);
-        emit_unencrypted_log(&mut context, new_value);
+        context.emit_unencrypted_log(new_value);
 
         new_value
     }
@@ -96,13 +93,13 @@ contract Child {
     fn set_value_twice_with_nested_first() {
         let _result = Child::at(context.this_address()).pub_set_value(10).call(&mut context);
         storage.current_value.write(20);
-        emit_unencrypted_log(&mut context, 20);
+        context.emit_unencrypted_log(20);
     }
 
     #[aztec(public)]
     fn set_value_twice_with_nested_last() {
         storage.current_value.write(20);
-        emit_unencrypted_log(&mut context, 20);
+        context.emit_unencrypted_log(20);
         let _result = Child::at(context.this_address()).pub_set_value(10).call(&mut context);
     }
 }

--- a/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/main.nr
@@ -2,7 +2,7 @@ mod events;
 mod capsule;
 
 contract ContractClassRegisterer {
-    use dep::aztec::prelude::{AztecAddress, EthAddress, FunctionSelector, emit_unencrypted_log};
+    use dep::aztec::prelude::{AztecAddress, EthAddress, FunctionSelector};
     use dep::aztec::protocol_types::{
         contract_class_id::ContractClassId,
         constants::{
@@ -11,8 +11,6 @@ contract ContractClassRegisterer {
     },
         traits::Serialize
     };
-
-    use dep::aztec::log::emit_unencrypted_log_from_private;
 
     use crate::events::{
         class_registered::ContractClassRegistered,
@@ -50,7 +48,7 @@ contract ContractClassRegisterer {
             public_bytecode_commitment
         ]
         );
-        emit_unencrypted_log_from_private(&mut context, event.serialize());
+        context.emit_unencrypted_log(event.serialize());
     }
 
     #[aztec(private)]
@@ -85,7 +83,7 @@ contract ContractClassRegisterer {
             function_data.metadata_hash
         ]
         );
-        emit_unencrypted_log_from_private(&mut context, event.serialize());
+        context.emit_unencrypted_log(event.serialize());
     }
 
     #[aztec(private)]
@@ -115,6 +113,6 @@ contract ContractClassRegisterer {
             function_data.metadata_hash
         ]
         );
-        emit_unencrypted_log_from_private(&mut context, event.serialize());
+        context.emit_unencrypted_log(event.serialize());
     }
 }

--- a/noir-projects/noir-contracts/contracts/contract_instance_deployer_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/contract_instance_deployer_contract/src/main.nr
@@ -7,8 +7,6 @@ contract ContractInstanceDeployer {
         traits::Serialize
     };
 
-    use dep::aztec::log::{emit_unencrypted_log, emit_unencrypted_log_from_private};
-
     use crate::events::{instance_deployed::ContractInstanceDeployed};
 
     #[aztec(private)]
@@ -54,6 +52,6 @@ contract ContractInstanceDeployer {
         };
         let event_payload = event.serialize();
         dep::aztec::oracle::debug_log::debug_log_array_with_prefix("ContractInstanceDeployed", event_payload);
-        emit_unencrypted_log_from_private(&mut context, event_payload);
+        context.emit_unencrypted_log(event_payload);
     }
 }

--- a/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
@@ -1,7 +1,6 @@
 contract Crowdfunding {
 
     use dep::aztec::{
-        log::emit_unencrypted_log_from_private,
         protocol_types::{abis::function_selector::FunctionSelector, address::AztecAddress, traits::Serialize},
         state_vars::{PrivateSet, PublicImmutable, SharedImmutable}
     };
@@ -78,6 +77,6 @@ contract Crowdfunding {
 
         // 3) Emit an unencrypted event so that anyone can audit how much the operator has withdrawn
         let event = WithdrawalProcessed { amount, who: operator_address };
-        emit_unencrypted_log_from_private(&mut context, event.serialize());
+        context.emit_unencrypted_log(event.serialize());
     }
 }

--- a/noir-projects/noir-contracts/contracts/delegated_on_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/delegated_on_contract/src/main.nr
@@ -1,8 +1,8 @@
 // A contract used along with `Parent` contract to test nested calls.
 contract DelegatedOn {
     use dep::aztec::prelude::{
-        AztecAddress, FunctionSelector, NoteHeader, NoteGetterOptions, NoteViewerOptions,
-        emit_unencrypted_log, PublicMutable, PrivateSet, PrivateContext
+        AztecAddress, FunctionSelector, NoteHeader, NoteGetterOptions, NoteViewerOptions, PublicMutable,
+        PrivateSet, PrivateContext
     };
     use dep::value_note::value_note::ValueNote;
 

--- a/noir-projects/noir-contracts/contracts/delegator_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/delegator_contract/src/main.nr
@@ -1,9 +1,6 @@
 // A contract used along with `Parent` contract to test nested calls.
 contract Delegator {
-    use dep::aztec::prelude::{
-        AztecAddress, FunctionSelector, NoteHeader, NoteViewerOptions, emit_unencrypted_log,
-        PublicMutable, PrivateSet, Deserialize
-    };
+    use dep::aztec::prelude::{AztecAddress, FunctionSelector, NoteHeader, NoteViewerOptions, PublicMutable, PrivateSet, Deserialize};
     use dep::value_note::value_note::ValueNote;
     use dep::delegated_on::DelegatedOn;
 

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -7,16 +7,12 @@ contract Test {
 
     use dep::aztec::protocol_types::{
         abis::private_circuit_public_inputs::PrivateCircuitPublicInputs,
-        constants::{MAX_NOTE_HASH_READ_REQUESTS_PER_CALL}, traits::Serialize
+        constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, traits::Serialize
     };
 
     use dep::aztec::note::constants::MAX_NOTES_PER_PAGE;
 
     use dep::aztec::state_vars::shared_mutable::SharedMutablePrivateGetter;
-
-    // docs:start:unencrypted_import
-    use dep::aztec::prelude::emit_unencrypted_log;
-    // docs:end:unencrypted_import
 
     use dep::aztec::{
         context::{Context, inputs::private_context_inputs::PrivateContextInputs},
@@ -26,11 +22,7 @@ contract Test {
         note_getter_options::NoteStatus
     },
         deploy::deploy_contract as aztec_deploy_contract,
-        oracle::{
-        get_public_key::get_public_key as get_public_key_oracle,
-        unsafe_rand::unsafe_rand
-    },
-        log::emit_unencrypted_log_from_private
+        oracle::{get_public_key::get_public_key as get_public_key_oracle, unsafe_rand::unsafe_rand}
     };
     use dep::token_portal_content_hash_lib::{get_mint_private_content_hash, get_mint_public_content_hash};
     use dep::field_note::field_note::FieldNote;
@@ -240,13 +232,13 @@ contract Test {
 
     #[aztec(private)]
     fn emit_msg_sender() {
-        // Note: don't use emit_unencrypted_log_from_private in production code
-        emit_unencrypted_log_from_private(&mut context, context.msg_sender());
+        // Note: don't use emit_unencrypted_log from private in production code
+        context.emit_unencrypted_log(context.msg_sender());
     }
 
     #[aztec(private)]
     fn emit_array_as_unencrypted_log(fields: [Field; 5]) {
-        emit_unencrypted_log_from_private(&mut context, fields);
+        context.emit_unencrypted_log(fields);
     }
 
     // docs:start:is-time-equal
@@ -260,7 +252,7 @@ contract Test {
     #[aztec(public)]
     fn emit_unencrypted(value: Field) -> Field {
         // docs:start:emit_unencrypted
-        emit_unencrypted_log(&mut context, value);
+        context.emit_unencrypted_log(value);
         // docs:end:emit_unencrypted
         0
     }
@@ -389,36 +381,40 @@ contract Test {
     fn test_shared_mutable_private_getter_for_registry_contract(
         contract_address_to_read: AztecAddress,
         storage_slot_of_shared_mutable: Field,
-        address_to_get_in_registry: AztecAddress,
+        address_to_get_in_registry: AztecAddress
     ) {
         // We have to derive this slot to get the location of the shared mutable inside the Map
-        let derived_slot = dep::aztec::hash::pedersen_hash([storage_slot_of_shared_mutable, address_to_get_in_registry.to_field()], 0);
+        let derived_slot = dep::aztec::hash::pedersen_hash(
+            [storage_slot_of_shared_mutable, address_to_get_in_registry.to_field()],
+            0
+        );
         // It's a bit wonky because we need to know the delay for get_current_value_in_private to work correctly
         let registry_private_getter: SharedMutablePrivateGetter<AztecAddress, 5> = SharedMutablePrivateGetter::new(context, contract_address_to_read, derived_slot);
         let nullifier_public_key = registry_private_getter.get_current_value_in_private();
 
-        emit_unencrypted_log_from_private(&mut context, nullifier_public_key);
+        context.emit_unencrypted_log(nullifier_public_key);
     }
 
     #[aztec(private)]
     fn test_shared_mutable_private_getter(
         contract_address_to_read: AztecAddress,
-        storage_slot_of_shared_mutable: Field,
+        storage_slot_of_shared_mutable: Field
     ) {
         // It's a bit wonky because we need to know the delay for get_current_value_in_private to work correctly
-        let test: SharedMutablePrivateGetter<AztecAddress, 5> = SharedMutablePrivateGetter::new(context, contract_address_to_read, storage_slot_of_shared_mutable);
+        let test: SharedMutablePrivateGetter<AztecAddress, 5> = SharedMutablePrivateGetter::new(
+            context,
+            contract_address_to_read,
+            storage_slot_of_shared_mutable
+        );
         let authorized = test.get_current_value_in_private();
 
-        emit_unencrypted_log_from_private(&mut context, authorized);
+        context.emit_unencrypted_log(authorized);
     }
 
     #[aztec(public)]
     fn delay() {
         // We use this as a util function to "mine a block"
-        dep::aztec::log::emit_unencrypted_log(
-            &mut context,
-            "dummy"
-        );
+        context.emit_unencrypted_log("dummy");
     }
 
     // Purely exists for testing


### PR DESCRIPTION
Moving unencrypted logs behind context.
