### PR TITLE
chore(docs): Remove 'yellow paper' reference from protocol specs

### DIFF
--- a/docs/docs/protocol-specs/intro.md
+++ b/docs/docs/protocol-specs/intro.md
@@ -1,8 +1,8 @@
 # Editorial guidelines
 
-This "yellow paper" is a first attempt to describe the Aztec protocol in its entirety.
+This protocol specification is a first attempt to describe the Aztec protocol in its entirety.
 
-It'll be more 'beige' than a yellow paper, initially. For example, we haven't settled on exact hashes, or encryption schemes, or gas metering schedules yet, so it won't contain such exact details as the Ethereum yellow paper.
+It is still a work in progress. For example, we haven't settled on exact hashes, or encryption schemes, or gas metering schedules yet, so it won't contain such exact details as the Ethereum yellow paper.
 
 ## Target audience
 


### PR DESCRIPTION
Edits a couple of lines on the landing page of the protocol specs to remove reference to "yellow paper".