### PR TITLE
fix(avm): Do not scale CALLDATACOPY base cost with size

### DIFF
--- a/yarn-project/simulator/src/avm/avm_gas.test.ts
+++ b/yarn-project/simulator/src/avm/avm_gas.test.ts
@@ -13,7 +13,7 @@ describe('AVM simulator: dynamic gas costs per instruction', () => {
     // BASE_GAS(10) * 1 + MEMORY_WRITE(100) = 110
     [new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ TypeTag.UINT8, /*copySize=*/ 1, /*dstOffset=*/ 0), [110]],
     // BASE_GAS(10) * 5 + MEMORY_WRITE(100) * 5 = 550
-    [new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ TypeTag.UINT8, /*copySize=*/ 5, /*dstOffset=*/ 0), [550]],
+    [new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ TypeTag.UINT8, /*copySize=*/ 5, /*dstOffset=*/ 0), [510]],
     // BASE_GAS(10) * 1 + MEMORY_READ(10) * 2 + MEMORY_WRITE(100) = 130
     [new Add(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [130]],
     // BASE_GAS(10) * 4 + MEMORY_READ(10) * 2 + MEMORY_WRITE(100) = 160

--- a/yarn-project/simulator/src/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.test.ts
@@ -50,7 +50,7 @@ describe('AVM simulator: injected bytecode', () => {
 
     expect(results.reverted).toBe(false);
     expect(results.output).toEqual([new Fr(3)]);
-    expect(context.machineState.l2GasLeft).toEqual(initialL2GasLeft - 680);
+    expect(context.machineState.l2GasLeft).toEqual(initialL2GasLeft - 670);
   });
 
   it('Should halt if runs out of gas', async () => {

--- a/yarn-project/simulator/src/avm/opcodes/memory.ts
+++ b/yarn-project/simulator/src/avm/opcodes/memory.ts
@@ -1,5 +1,5 @@
 import type { AvmContext } from '../avm_context.js';
-import { getBaseGasCost, getMemoryGasCost, mulGas, sumGas } from '../avm_gas.js';
+import { getBaseGasCost, getMemoryGasCost, sumGas } from '../avm_gas.js';
 import { Field, type MemoryOperations, TaggedMemory, TypeTag } from '../avm_memory_types.js';
 import { InstructionExecutionError } from '../errors.js';
 import { BufferCursor } from '../serialization/buffer_cursor.js';
@@ -218,7 +218,7 @@ export class CalldataCopy extends Instruction {
   }
 
   protected override gasCost(memoryOps: Partial<MemoryOperations & { indirect: number }> = {}) {
-    const baseGasCost = mulGas(getBaseGasCost(this.opcode), this.copySize);
+    const baseGasCost = getBaseGasCost(this.opcode);
     const memoryGasCost = getMemoryGasCost(memoryOps);
     return sumGas(baseGasCost, memoryGasCost);
   }


### PR DESCRIPTION
As discussed with @fcarreiro, base gas cost should only scale if we do _something_ with the data. If we're just copying it, then the additional memory accesses take care of reflecting the additional effort.