### PR TITLE
chore(ci): address start-runner edge-cases

### DIFF
--- a/.github/workflows/setup-runner.yml
+++ b/.github/workflows/setup-runner.yml
@@ -58,7 +58,7 @@ jobs:
       group: start-builder-${{ inputs.runner_label }}
     steps:
       - name: Start EC2 runner
-        uses: AztecProtocol/ec2-action-builder@v0.14e
+        uses: AztecProtocol/ec2-action-builder@v0.15
         with:
           github_token: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
https://github.com/AztecProtocol/ec2-action-builder/commit/a576467b9f0f86edaebf171399b6b0684d1aff1f

- Tries to address runner finding unusable spot, we now stop it and restart. Not fully sure why this would be the case, but it came up and allows for recovery. Also poll less in case it was a rate limit issue.

- Add a minute polling logic around both creating spot and then creating on-demand. This might add a minute to most builds - so will be monitoring - but should be no different than our old spot start times with circleci