### PR TITLE
chore(ci): remove devnet deployments (for now)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -443,30 +443,6 @@ jobs:
           command: build aztec
           aztec_manifest_key: aztec
 
-  mainnet-fork:
-    machine:
-      image: default
-    resource_class: large
-    steps:
-      - *checkout
-      - *setup_env
-      - run:
-          name: "Build"
-          command: build mainnet-fork | add_timestamps
-          aztec_manifest_key: mainnet-fork
-
-  aztec-faucet:
-    machine:
-      image: default
-    resource_class: large
-    steps:
-      - *checkout
-      - *setup_env
-      - run:
-          name: "Build and test"
-          command: build aztec-faucet | add_timestamps
-          aztec_manifest_key: aztec-faucet
-
   boxes:
     docker:
       - image: aztecprotocol/alpine-build-image
@@ -609,14 +585,6 @@ jobs:
             should_release || exit 0
             deploy_dockerhub noir
             deploy_dockerhub aztec
-            deploy_dockerhub aztec-faucet
-            deploy_dockerhub mainnet-fork
-      - run:
-          name: "Deploy mainnet fork"
-          command: |
-            should_deploy || exit 0
-            deploy_terraform_services iac/mainnet-fork mainnet-fork mainnet-fork aws_efs_file_system.aztec_mainnet_fork_data_store
-            ./iac/mainnet-fork/scripts/wait_for_fork
       - run:
           name: "Release canary to NPM: bb.js"
           command: |
@@ -647,43 +615,6 @@ jobs:
           command: |
             should_release || exit 0
             deploy_npm l1-contracts latest
-      - run:
-          name: "Deploy L1 contracts to mainnet fork"
-          working_directory: l1-contracts
-          command: |
-            should_deploy || exit 0
-            ./scripts/ci_deploy_contracts.sh
-      - run:
-          name: "Deploy P2P bootstrap servers to AWS"
-          command: |
-            should_deploy 0 || exit 0
-            # Export variables for Terraform.
-            export TF_VAR_BOOTNODE_1_PRIVATE_KEY=$BOOTNODE_1_PRIVATE_KEY
-            export TF_VAR_BOOTNODE_2_PRIVATE_KEY=$BOOTNODE_2_PRIVATE_KEY
-            deploy_terraform_services yarn-project/p2p-bootstrap aztec
-      - run:
-          name: "Deploy Aztec Nodes to AWS"
-          command: |
-            should_deploy 0 || exit 0
-            export TF_VAR_BOOTNODE_1_PEER_ID=$BOOTNODE_1_PEER_ID
-            export TF_VAR_BOOTNODE_2_PEER_ID=$BOOTNODE_2_PEER_ID
-            export TF_VAR_SEQ_1_PUBLISHER_PRIVATE_KEY=$SEQ_1_PUBLISHER_PRIVATE_KEY
-            export TF_VAR_SEQ_2_PUBLISHER_PRIVATE_KEY=$SEQ_2_PUBLISHER_PRIVATE_KEY
-            export TF_VAR_NODE_1_PRIVATE_KEY=$NODE_1_PRIVATE_KEY
-            export TF_VAR_NODE_2_PRIVATE_KEY=$NODE_2_PRIVATE_KEY
-            # Check if l1-contracts have changed
-            if [ "$CONTRACTS_DEPLOYED" -eq 1 ]; then
-              echo "Contracts have changed, taint nodes to force redeploy.."
-              deploy_terraform_services yarn-project/aztec-node aztec aztec-node "aws_ecs_task_definition.aztec-node[0],aws_ecs_task_definition.aztec-node[1]" 1
-            else
-              deploy_terraform_services yarn-project/aztec-node aztec
-            fi
-      - run:
-          name: "Deploy Aztec Faucet to AWS"
-          command: |
-            should_deploy 0 || exit 0
-            export TF_VAR_FAUCET_PRIVATE_KEY=$FAUCET_PRIVATE_KEY
-            deploy_terraform_services yarn-project/aztec-faucet aztec
 
 # Repeatable config for defining the workflow below.
 defaults: &defaults
@@ -807,8 +738,6 @@ workflows:
 
       - l1-contracts: *defaults
 
-      - mainnet-fork: *defaults
-
       - noir-projects:
           requires:
             - avm-transpiler
@@ -824,7 +753,6 @@ workflows:
             - noir-projects
           <<: *defaults
       - end-to-end: *defaults_yarn_project
-      - aztec-faucet: *defaults_yarn_project_pre_join
       - build-docs: *defaults_yarn_project_pre_join
       - prover-client-test: *defaults_yarn_project
       - yarn-project-test: *defaults_yarn_project
@@ -873,7 +801,6 @@ workflows:
             - barretenberg-acir-tests-bb-sol
             - barretenberg-docs
             - build-docs
-            - mainnet-fork
             - boxes-vanilla
             - boxes-react
             - noir-packages-tests

--- a/build_manifest.yml
+++ b/build_manifest.yml
@@ -201,14 +201,6 @@ aztec:
     - yarn-project
   multiarch: buildx
 
-# Aztec faucet server. Has these dependencies because it's part of workspace. Consider moving out?
-aztec-faucet:
-  buildDir: yarn-project
-  projectDir: yarn-project/aztec-faucet
-  dependencies:
-    - bb.js
-    - noir-packages
-
 # Builds all the boxes. They are then independently tested in the container.
 boxes:
   buildDir: boxes
@@ -233,10 +225,6 @@ end-to-end:
     - yarn-project
   runDependencies:
     - aztec
-
-mainnet-fork:
-  buildDir: iac/mainnet-fork
-  projectDir: iac/mainnet-fork
 
 docs:
   buildDir: .


### PR DESCRIPTION
Removing all CI devnet deployments for now.
- Not being used but still causing CI pains by showing red when something fails
- new P2P changes will break how aztec nodes are currently setup on AWS

We'll be looking to introduce a better lifecycle that probably doesn't deploy on every change to `master` as that will make the devnet pretty unusable.