### PR TITLE
chore: redo typo PR

### DIFF
--- a/noir-projects/noir-contracts/contracts/auth_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/auth_contract/src/main.nr
@@ -20,7 +20,7 @@ contract Auth {
         assert(!admin.is_zero(), "invalid admin");
         storage.admin.initialize(admin);
         // Note that we don't initialize authorized with any value: because storage defaults to 0 it'll have a 'post'
-        // value of 0 and block of change 0, meaning it is effectively autoinitialized at the zero adddress.
+        // value of 0 and block of change 0, meaning it is effectively autoinitialized at the zero address.
     }
 
     #[aztec(public)]

--- a/noir/noir-repo/tooling/nargo/src/ops/execute.rs
+++ b/noir/noir-repo/tooling/nargo/src/ops/execute.rs
@@ -106,7 +106,7 @@ impl<'a, B: BlackBoxFunctionSolver, F: ForeignCallExecutor> ProgramExecutor<'a, 
                     return Err(NargoError::ExecutionError(match call_stack {
                         Some(call_stack) => {
                             // First check whether we have a runtime assertion message that should be resolved on an ACVM failure
-                            // If we do not have a runtime assertion message, we check wether the error is a brillig error with a user-defined message,
+                            // If we do not have a runtime assertion message, we check weather the error is a brillig error with a user-defined message,
                             // and finally we should check whether the circuit has any hardcoded messages associated with a specific `OpcodeLocation`.
                             // Otherwise return the provided opcode resolution error.
                             if let Some(assert_message) = assert_message {

--- a/noir/noir-repo/tooling/nargo/src/ops/execute.rs
+++ b/noir/noir-repo/tooling/nargo/src/ops/execute.rs
@@ -106,7 +106,7 @@ impl<'a, B: BlackBoxFunctionSolver, F: ForeignCallExecutor> ProgramExecutor<'a, 
                     return Err(NargoError::ExecutionError(match call_stack {
                         Some(call_stack) => {
                             // First check whether we have a runtime assertion message that should be resolved on an ACVM failure
-                            // If we do not have a runtime assertion message, we check weather the error is a brillig error with a user-defined message,
+                            // If we do not have a runtime assertion message, we check whether the error is a brillig error with a user-defined message,
                             // and finally we should check whether the circuit has any hardcoded messages associated with a specific `OpcodeLocation`.
                             // Otherwise return the provided opcode resolution error.
                             if let Some(assert_message) = assert_message {


### PR DESCRIPTION
Thanks @dockercui for https://github.com/AztecProtocol/aztec-packages/pull/5913. Our policy is to redo typo changes to dissuade metric farming. This is an automated script.