### PR TITLE
chore: redo typo PR

### DIFF
--- a/docs/docs/developers/tutorials/writing_token_contract.md
+++ b/docs/docs/developers/tutorials/writing_token_contract.md
@@ -176,7 +176,7 @@ Transactions are initiated in the private context, then move to the L2 public co
 
 Step 1. Private Execution
 
-Users provide inputs and execute locally on a their device for privacy reasons. Outputs of the private execution are commitment and nullifier updates, a proof of correct execution and any return data to pass to the public execution context.
+Users provide inputs and execute locally on their device for privacy reasons. Outputs of the private execution are commitment and nullifier updates, a proof of correct execution and any return data to pass to the public execution context.
 
 Step 2. Public Execution
 


### PR DESCRIPTION
Thanks satyambnsal for https://github.com/AztecProtocol/aztec-packages/pull/5769. Our policy is to redo typo changes to dissuade metric farming. This is an automated script.