### PR TITLE
feat: Wire gas from public execution to kernels

### DIFF
--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -20,5 +20,4 @@ NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
 $NARGO compile --silence-warnings
 
 echo "Transpiling avm contracts... (only '#[aztec(public-vm)]')"
-TRANSPILER=${TRANSPILER:-../../avm-transpiler/target/release/avm-transpiler}
-ls target/avm_*.json | parallel "$TRANSPILER {} {}"
+scripts/transpile.sh

--- a/noir-projects/noir-contracts/scripts/transpile.sh
+++ b/noir-projects/noir-contracts/scripts/transpile.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eu
+
+TRANSPILER=${TRANSPILER:-../../avm-transpiler/target/release/avm-transpiler}
+ls target/avm_*.json | parallel "$TRANSPILER {} {}"

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/kernel_circuit_public_inputs_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/kernel_circuit_public_inputs_composer.nr
@@ -22,6 +22,9 @@ fn asc_sort_by_counters<T>(a: T, b: T) -> bool where T: Ordered {
     a.counter() < b.counter()
 }
 
+// Builds:
+// .finish -> KernelCircuitPublicInputs (from PrivateKernelTailCircuitPrivateInputs)
+// .finish_to_public -> PublicKernelCircuitPublicInputs (from PrivateKernelTailToPublicCircuitPrivateInputs)
 struct KernelCircuitPublicInputsComposer {
     public_inputs: PrivateKernelCircuitPublicInputsBuilder,
     previous_kernel: PrivateKernelData,
@@ -47,7 +50,7 @@ impl KernelCircuitPublicInputsComposer {
         sorted_encrypted_log_hashes: [SideEffect; MAX_ENCRYPTED_LOGS_PER_TX],
         sorted_encrypted_log_hashes_indexes: [u64; MAX_ENCRYPTED_LOGS_PER_TX],
         sorted_unencrypted_log_hashes: [SideEffect; MAX_UNENCRYPTED_LOGS_PER_TX],
-        sorted_unencrypted_log_hashes_indexes: [u64; MAX_UNENCRYPTED_LOGS_PER_TX],
+        sorted_unencrypted_log_hashes_indexes: [u64; MAX_UNENCRYPTED_LOGS_PER_TX]
     ) -> Self {
         let public_inputs = PrivateKernelCircuitPublicInputsBuilder::empty();
 
@@ -62,7 +65,7 @@ impl KernelCircuitPublicInputsComposer {
             sorted_encrypted_log_hashes,
             sorted_encrypted_log_hashes_indexes,
             sorted_unencrypted_log_hashes,
-            sorted_unencrypted_log_hashes_indexes,
+            sorted_unencrypted_log_hashes_indexes
         }
     }
 
@@ -82,6 +85,8 @@ impl KernelCircuitPublicInputsComposer {
 
         self.silo_values();
 
+        self.set_gas_used();
+
         *self
     }
 
@@ -100,6 +105,12 @@ impl KernelCircuitPublicInputsComposer {
     pub fn finish_to_public(self) -> PublicKernelCircuitPublicInputs {
         let min_revertible_side_effect_counter = self.previous_kernel.public_inputs.min_revertible_side_effect_counter;
         self.public_inputs.finish_to_public(min_revertible_side_effect_counter)
+    }
+
+    fn set_gas_used(&mut self) {
+        // TODO(gas): Compute DA gas used here and add to public_inputs.(end,end_non_revertible).gas_used
+        let teardown_gas = self.previous_kernel.public_inputs.constants.tx_context.gas_settings.teardown_gas_limits;
+        self.public_inputs.end.gas_used = teardown_gas;
     }
 
     fn silo_values(&mut self) {

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_init.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_init.nr
@@ -50,6 +50,10 @@ impl PrivateKernelInitCircuitPrivateInputs {
         // Ensure we are passing the correct arguments to the function.
         let args_match = tx_request.args_hash == call_stack_item.public_inputs.args_hash;
         assert(args_match, "noir function args passed to tx_request must match args in the call_stack_item");
+        //
+        // Ensure we are passing the correct tx context
+        let tx_context_matches = tx_request.tx_context == call_stack_item.public_inputs.tx_context;
+        assert(tx_context_matches, "tx_context in tx_request must match tx_context in call_stack_item");
     }
 
     fn validate_inputs(self) {

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
@@ -57,7 +57,7 @@ impl PrivateKernelTailCircuitPrivateInputs {
             self.sorted_encrypted_log_hashes,
             self.sorted_encrypted_log_hashes_indexes,
             self.sorted_unencrypted_log_hashes,
-            self.sorted_unencrypted_log_hashes_indexes,
+            self.sorted_unencrypted_log_hashes_indexes
         );
         composer.compose().finish()
     }
@@ -76,7 +76,7 @@ mod tests {
     use dep::types::{
         abis::{
         kernel_circuit_public_inputs::KernelCircuitPublicInputs, max_block_number::MaxBlockNumber,
-        side_effect::{SideEffect, SideEffectLinkedToNoteHash, Ordered}
+        side_effect::{SideEffect, SideEffectLinkedToNoteHash, Ordered}, gas::Gas
     },
         grumpkin_private_key::GrumpkinPrivateKey,
         hash::{compute_note_hash_nonce, compute_unique_siloed_note_hash, accumulate_sha256},
@@ -189,7 +189,7 @@ mod tests {
                 sorted_encrypted_log_hashes_indexes,
                 sorted_unencrypted_log_hashes,
                 sorted_unencrypted_log_hashes_indexes,
-                master_nullifier_secret_keys: [GrumpkinPrivateKey::empty(); MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_TX],
+                master_nullifier_secret_keys: [GrumpkinPrivateKey::empty(); MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_TX]
             };
             kernel.native_private_kernel_circuit_tail()
         }
@@ -487,5 +487,15 @@ mod tests {
         let mut builder = PrivateKernelTailInputsBuilder::new();
         builder.previous_kernel.new_nullifiers = BoundedVec::new();
         builder.failed();
+    }
+
+    #[test]
+    unconstrained fn set_teardown_gas_as_gas_used() {
+        // TODO(gas): When we compute DA gas used, we'll have to include it here as well.
+        let mut builder = PrivateKernelTailInputsBuilder::new();
+        builder.previous_kernel.tx_context.gas_settings.teardown_gas_limits = Gas::new(300, 300, 300);
+        let public_inputs = builder.execute();
+
+        assert_eq(public_inputs.end.gas_used, Gas::new(300, 300, 300));
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail_to_public.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail_to_public.nr
@@ -57,7 +57,7 @@ impl PrivateKernelTailToPublicCircuitPrivateInputs {
             self.sorted_encrypted_log_hashes,
             self.sorted_encrypted_log_hashes_indexes,
             self.sorted_unencrypted_log_hashes,
-            self.sorted_unencrypted_log_hashes_indexes,
+            self.sorted_unencrypted_log_hashes_indexes
         );
         composer.compose_public().finish_to_public()
     }
@@ -75,7 +75,7 @@ mod tests {
     };
     use dep::types::{
         abis::{
-        kernel_circuit_public_inputs::PublicKernelCircuitPublicInputs,
+        kernel_circuit_public_inputs::PublicKernelCircuitPublicInputs, gas::Gas,
         side_effect::{SideEffect, SideEffectLinkedToNoteHash, Ordered}
     },
         grumpkin_private_key::GrumpkinPrivateKey,
@@ -196,7 +196,7 @@ mod tests {
                 sorted_encrypted_log_hashes_indexes,
                 sorted_unencrypted_log_hashes,
                 sorted_unencrypted_log_hashes_indexes,
-                master_nullifier_secret_keys: [GrumpkinPrivateKey::empty(); MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_TX],
+                master_nullifier_secret_keys: [GrumpkinPrivateKey::empty(); MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_TX]
             };
             kernel.execute()
         }
@@ -537,5 +537,15 @@ mod tests {
         assert(is_empty_array(public_inputs.end_non_revertible.new_note_hashes));
         assert(is_empty_array(public_inputs.end.new_note_hashes));
         assert(is_empty_array(public_inputs.end.new_nullifiers));
+    }
+
+    #[test]
+    unconstrained fn set_teardown_gas_as_gas_used() {
+        // TODO(gas): When we compute DA gas used, we'll have to include it here as well.
+        let mut builder = PrivateKernelTailToPublicInputsBuilder::new();
+        builder.previous_kernel.tx_context.gas_settings.teardown_gas_limits = Gas::new(300, 300, 300);
+        let public_inputs = builder.execute();
+
+        assert_eq(public_inputs.end.gas_used, Gas::new(300, 300, 300));
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/common.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/common.nr
@@ -229,6 +229,22 @@ pub fn update_non_revertible_gas_used(public_call: PublicCallData, circuit_outpu
         .sub(accum_end_gas_used);
 }
 
+// Validates that the start gas injected into the app circuit matches the remaining gas
+pub fn validate_start_gas(public_call: PublicCallData, previous_kernel: PublicKernelData) {
+    let public_call_start_gas = public_call.call_stack_item.public_inputs.start_gas_left;
+    let tx_gas_limits = previous_kernel.public_inputs.constants.tx_context.gas_settings.gas_limits;
+    let computed_start_gas = tx_gas_limits.sub(previous_kernel.public_inputs.end.gas_used).sub(previous_kernel.public_inputs.end_non_revertible.gas_used);
+    assert(
+        public_call_start_gas == computed_start_gas, "Start gas for public phase does not match transaction gas left"
+    );
+}
+
+// Validates the transaction fee injected into the app circuit is zero for non-teardown phases
+pub fn validate_transaction_fee_is_zero(public_call: PublicCallData) {
+    let transaction_fee = public_call.call_stack_item.public_inputs.transaction_fee;
+    assert(transaction_fee == 0, "Transaction fee must be zero on setup and app phases");
+}
+
 pub fn update_public_end_non_revertible_values(
     public_call: PublicCallData,
     circuit_outputs: &mut PublicKernelCircuitPublicInputsBuilder

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_app_logic.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_app_logic.nr
@@ -33,6 +33,9 @@ impl PublicKernelAppLogicCircuitPrivateInputs {
         // validate the inputs unique to having a previous public kernel
         self.validate_inputs();
 
+        common::validate_start_gas(self.public_call, self.previous_kernel);
+        common::validate_transaction_fee_is_zero(self.public_call);
+
         common::update_validation_requests(self.public_call, &mut public_inputs);
 
         common::update_revertible_gas_used(self.public_call, &mut public_inputs);
@@ -463,5 +466,23 @@ mod tests {
         let output = builder.execute();
         assert_eq(output.end.gas_used, Gas::new(500, 500, 500));
         assert_eq(output.end_non_revertible.gas_used, Gas::new(0, 0, 0));
+    }
+
+    #[test(should_fail_with="Start gas for public phase does not match transaction gas left")]
+    fn validates_start_gas() {
+        let mut builder = PublicKernelAppLogicCircuitPrivateInputsBuilder::new();
+
+        builder.public_call.public_inputs.start_gas_left = Gas::new(200, 100, 100);
+
+        builder.failed();
+    }
+
+    #[test(should_fail_with="Transaction fee must be zero on setup and app phases")]
+    fn validates_transaction_fee() {
+        let mut builder = PublicKernelAppLogicCircuitPrivateInputsBuilder::new();
+
+        builder.public_call.public_inputs.transaction_fee = 10;
+
+        builder.failed();
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_setup.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_setup.nr
@@ -39,6 +39,9 @@ impl PublicKernelSetupCircuitPrivateInputs {
         // validate the inputs unique to having a previous private kernel
         self.validate_inputs();
 
+        common::validate_start_gas(self.public_call, self.previous_kernel);
+        common::validate_transaction_fee_is_zero(self.public_call);
+
         common::update_non_revertible_gas_used(self.public_call, &mut public_inputs);
 
         // Pops the item from the call stack and validates it against the current execution.
@@ -518,5 +521,23 @@ mod tests {
         let output = builder.execute();
         assert_eq(output.end_non_revertible.gas_used, Gas::new(500, 500, 500));
         assert_eq(output.end.gas_used, Gas::new(100, 100, 100));
+    }
+
+    #[test(should_fail_with="Start gas for public phase does not match transaction gas left")]
+    fn validates_start_gas() {
+        let mut builder = PublicKernelSetupCircuitPrivateInputsBuilder::new();
+
+        builder.public_call.public_inputs.start_gas_left = Gas::new(200, 100, 100);
+
+        builder.failed();
+    }
+
+    #[test(should_fail_with="Transaction fee must be zero on setup and app phases")]
+    fn validates_transaction_fee() {
+        let mut builder = PublicKernelSetupCircuitPrivateInputsBuilder::new();
+
+        builder.public_call.public_inputs.transaction_fee = 10;
+
+        builder.failed();
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
@@ -40,6 +40,22 @@ impl PublicKernelTeardownCircuitPrivateInputs {
         let block_gas_fees = GasFees::default();
         let inclusion_fee = self.previous_kernel.public_inputs.constants.tx_context.gas_settings.inclusion_fee;
         let computed_transaction_fee = total_gas_used.reduce(block_gas_fees) + inclusion_fee;
+
+        // dep::types::debug_log::debug_log_format(
+        //     "Validating tx fee: total_gas_used.da={0} total_gas_used.l1={1} total_gas_used.l2={2} block_fee_per_gas.da={3} block_fee_per_gas.l1={4} block_fee_per_gas.l2={5} inclusion_fee={6} computed={7} actual={8}",
+        //     [
+        //     total_gas_used.da_gas as Field,
+        //     total_gas_used.l1_gas as Field,
+        //     total_gas_used.l2_gas as Field,
+        //     block_gas_fees.fee_per_da_gas as Field,
+        //     block_gas_fees.fee_per_l1_gas as Field,
+        //     block_gas_fees.fee_per_l2_gas as Field,
+        //     inclusion_fee,
+        //     computed_transaction_fee,
+        //     transaction_fee
+        // ]
+        // );
+
         assert(
             transaction_fee == computed_transaction_fee, "Transaction fee on teardown phase does not match expected value"
         );

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
@@ -1,7 +1,7 @@
 use crate::common;
 use dep::types::abis::{
     kernel_circuit_public_inputs::{PublicKernelCircuitPublicInputs, PublicKernelCircuitPublicInputsBuilder},
-    kernel_data::PublicKernelData, public_call_data::PublicCallData
+    kernel_data::PublicKernelData, public_call_data::PublicCallData, gas_fees::GasFees
 };
 
 struct PublicKernelTeardownCircuitPrivateInputs {
@@ -20,6 +20,29 @@ impl PublicKernelTeardownCircuitPrivateInputs {
         assert(needs_app_logic == false, "Cannot run teardown circuit before app logic circuit");
         let needs_teardown = self.previous_kernel.public_inputs.needs_teardown();
         assert(needs_teardown == true, "Cannot run unnecessary teardown circuit");
+    }
+
+    // Validates that the start gas injected into the app circuit matches the teardown gas limits set by the user
+    fn validate_start_gas(self) {
+        let public_call_start_gas = self.public_call.call_stack_item.public_inputs.start_gas_left;
+        let teardown_gas_limit = self.previous_kernel.public_inputs.constants.tx_context.gas_settings.teardown_gas_limits;
+        assert(
+            public_call_start_gas == teardown_gas_limit, "Start gas for teardown phase does not match teardown gas allocation"
+        );
+    }
+
+    // Validates the transaction fee injected into the app circuit is properly computed from gas_used and block gas_fees
+    fn validate_transaction_fee(self) {
+        let transaction_fee = self.public_call.call_stack_item.public_inputs.transaction_fee;
+        // Note that teardown_gas is already included in end.gas_used as it was injected by the private kernel
+        let total_gas_used = self.previous_kernel.public_inputs.end.gas_used.add(self.previous_kernel.public_inputs.end_non_revertible.gas_used);
+        // TODO(palla/gas): Load gas fees from a PublicConstantData struct that's currently missing
+        let block_gas_fees = GasFees::default();
+        let inclusion_fee = self.previous_kernel.public_inputs.constants.tx_context.gas_settings.inclusion_fee;
+        let computed_transaction_fee = total_gas_used.reduce(block_gas_fees) + inclusion_fee;
+        assert(
+            transaction_fee == computed_transaction_fee, "Transaction fee on teardown phase does not match expected value"
+        );
     }
 
     fn public_kernel_teardown(self) -> PublicKernelCircuitPublicInputs {
@@ -42,6 +65,9 @@ impl PublicKernelTeardownCircuitPrivateInputs {
         let call_request = public_inputs.end_non_revertible.public_call_stack.pop();
         common::validate_call_against_request(self.public_call, call_request);
 
+        self.validate_start_gas();
+        self.validate_transaction_fee();
+
         common::update_validation_requests(self.public_call, &mut public_inputs);
 
         common::update_public_end_non_revertible_values(self.public_call, &mut public_inputs);
@@ -60,7 +86,7 @@ mod tests {
     };
     use dep::types::{
         abis::{
-        call_request::CallRequest, function_selector::FunctionSelector,
+        call_request::CallRequest, function_selector::FunctionSelector, gas::Gas,
         kernel_circuit_public_inputs::PublicKernelCircuitPublicInputs, public_data_read::PublicDataRead,
         public_data_update_request::PublicDataUpdateRequest
     },
@@ -347,12 +373,16 @@ mod tests {
 
         let public_inputs = builder.execute();
 
-        assert_eq(public_inputs.end_non_revertible.encrypted_log_preimages_length, prev_encrypted_log_preimages_length);
+        assert_eq(
+            public_inputs.end_non_revertible.encrypted_log_preimages_length, prev_encrypted_log_preimages_length
+        );
         assert_eq(
             public_inputs.end_non_revertible.unencrypted_log_preimages_length, unencrypted_log_preimages_length + prev_unencrypted_log_preimages_length
         );
         assert_eq(public_inputs.end_non_revertible.encrypted_logs_hashes[0].value, prev_encrypted_logs_hash);
-        assert_eq(public_inputs.end_non_revertible.unencrypted_logs_hashes[0].value, prev_unencrypted_logs_hash);
+        assert_eq(
+            public_inputs.end_non_revertible.unencrypted_logs_hashes[0].value, prev_unencrypted_logs_hash
+        );
         assert_eq(public_inputs.end_non_revertible.unencrypted_logs_hashes[1].value, unencrypted_logs_hash);
     }
 
@@ -360,6 +390,22 @@ mod tests {
     fn fails_if_public_call_reverted() {
         let mut builder = PublicKernelTeardownCircuitPrivateInputsBuilder::new();
         builder.public_call.public_inputs.revert_code = 1;
+
+        builder.failed();
+    }
+
+    #[test(should_fail_with="Start gas for teardown phase does not match teardown gas allocation")]
+    fn validates_start_gas() {
+        let mut builder = PublicKernelTeardownCircuitPrivateInputsBuilder::new();
+        builder.public_call.public_inputs.start_gas_left = Gas::new(10, 20, 30);
+
+        builder.failed();
+    }
+
+    #[test(should_fail_with="Transaction fee on teardown phase does not match expected value")]
+    fn validates_transaction_fee() {
+        let mut builder = PublicKernelTeardownCircuitPrivateInputsBuilder::new();
+        builder.public_call.public_inputs.transaction_fee = 1234;
 
         builder.failed();
     }

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
@@ -39,7 +39,7 @@ impl PublicKernelTeardownCircuitPrivateInputs {
         // TODO(palla/gas): Load gas fees from a PublicConstantData struct that's currently missing
         let block_gas_fees = GasFees::default();
         let inclusion_fee = self.previous_kernel.public_inputs.constants.tx_context.gas_settings.inclusion_fee;
-        let computed_transaction_fee = total_gas_used.reduce(block_gas_fees) + inclusion_fee;
+        let computed_transaction_fee = total_gas_used.compute_fee(block_gas_fees) + inclusion_fee;
 
         // dep::types::debug_log::debug_log_format(
         //     "Validating tx fee: total_gas_used.da={0} total_gas_used.l1={1} total_gas_used.l2={2} block_fee_per_gas.da={3} block_fee_per_gas.l1={4} block_fee_per_gas.l2={5} inclusion_fee={6} computed={7} actual={8}",

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/private_accumulated_data_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/private_accumulated_data_builder.nr
@@ -18,6 +18,10 @@ use crate::{
     traits::Empty
 };
 
+// Builds via PrivateKernelCircuitPublicInputsBuilder:
+// .finish: PrivateKernelCircuitPublicInputs.end
+// .to_combined: KernelCircuitPublicInputs.end
+// .split_to_public: PublicKernelCircuitPublicInputs.(end,end_non_revertible)
 struct PrivateAccumulatedDataBuilder {
     new_note_hashes: BoundedVec<SideEffect, MAX_NEW_NOTE_HASHES_PER_TX>,
     new_nullifiers: BoundedVec<SideEffectLinkedToNoteHash, MAX_NEW_NULLIFIERS_PER_TX>,
@@ -35,10 +39,14 @@ struct PrivateAccumulatedDataBuilder {
     public_call_stack: BoundedVec<CallRequest, MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX>,
 
     gas_used: Gas,
+    non_revertible_gas_used: Gas,
 }
 
 impl PrivateAccumulatedDataBuilder {
     pub fn finish(self) -> PrivateAccumulatedData {
+        assert(self.gas_used.is_empty());
+        assert(self.non_revertible_gas_used.is_empty());
+
         PrivateAccumulatedData {
             new_note_hashes: self.new_note_hashes.storage,
             new_nullifiers: self.new_nullifiers.storage,
@@ -66,7 +74,7 @@ impl PrivateAccumulatedDataBuilder {
             encrypted_log_preimages_length: self.encrypted_log_preimages_length,
             unencrypted_log_preimages_length: self.unencrypted_log_preimages_length,
             public_data_update_requests: [PublicDataUpdateRequest::empty(); MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX],
-            gas_used: self.gas_used
+            gas_used: self.gas_used.add(self.non_revertible_gas_used)
         }
     }
 
@@ -127,6 +135,8 @@ impl PrivateAccumulatedDataBuilder {
         revertible_builder.encrypted_log_preimages_length =  self.encrypted_log_preimages_length;
         revertible_builder.unencrypted_log_preimages_length = self.unencrypted_log_preimages_length;
 
+        revertible_builder.gas_used = self.gas_used;
+        non_revertible_builder.gas_used = self.non_revertible_gas_used;
         (non_revertible_builder.finish(), revertible_builder.finish())
     }
 }
@@ -134,7 +144,7 @@ impl PrivateAccumulatedDataBuilder {
 mod tests {
     use crate::{
         abis::{
-        accumulated_data::private_accumulated_data_builder::PrivateAccumulatedDataBuilder,
+        accumulated_data::private_accumulated_data_builder::PrivateAccumulatedDataBuilder, gas::Gas,
         call_request::CallRequest, caller_context::CallerContext,
         public_data_update_request::PublicDataUpdateRequest,
         side_effect::{SideEffect, SideEffectLinkedToNoteHash}
@@ -202,6 +212,9 @@ mod tests {
         builder.public_call_stack.extend_from_array(non_revertible_public_stack);
         builder.public_call_stack.extend_from_array(revertible_public_call_stack);
 
+        builder.gas_used = Gas::new(20,20,20);
+        builder.non_revertible_gas_used = Gas::new(10,10,10);
+
         let (non_revertible, revertible) = builder.split_to_public(7);
 
         assert(array_eq(non_revertible.new_note_hashes, non_revertible_commitments));
@@ -211,6 +224,9 @@ mod tests {
         assert(array_eq(revertible.new_note_hashes, revertible_commitments));
         assert(array_eq(revertible.new_nullifiers, revertible_nullifiers));
         assert(array_eq(revertible.public_call_stack, revertible_public_call_stack));
+
+        assert_eq(revertible.gas_used, Gas::new(20, 20, 20));
+        assert_eq(non_revertible.gas_used, Gas::new(10, 10, 10));
     }
 }
 
@@ -227,6 +243,7 @@ impl Empty for PrivateAccumulatedDataBuilder {
             private_call_stack: BoundedVec::new(),
             public_call_stack: BoundedVec::new(),
             gas_used: Gas::empty(),
+            non_revertible_gas_used: Gas::empty(),
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/gas.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/gas.nr
@@ -31,7 +31,7 @@ impl Gas {
         )
     }
 
-    pub fn reduce(self, fees: GasFees) -> Field {
+    pub fn compute_fee(self, fees: GasFees) -> Field {
         (self.da_gas as Field) * fees.fee_per_da_gas
             + (self.l1_gas as Field) * fees.fee_per_l1_gas
             + (self.l2_gas as Field) * fees.fee_per_l2_gas

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/gas.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/gas.nr
@@ -1,7 +1,7 @@
 use crate::{
     abis::function_selector::FunctionSelector, address::{EthAddress, AztecAddress},
     constants::GAS_LENGTH, hash::pedersen_hash, traits::{Deserialize, Hash, Serialize, Empty},
-    abis::side_effect::Ordered, utils::reader::Reader
+    abis::side_effect::Ordered, utils::reader::Reader, abis::gas_fees::GasFees
 };
 
 struct Gas {
@@ -29,6 +29,12 @@ impl Gas {
             self.l1_gas - other.l1_gas,
             self.l2_gas - other.l2_gas
         )
+    }
+
+    pub fn reduce(self, fees: GasFees) -> Field {
+        (self.da_gas as Field) * fees.fee_per_da_gas
+            + (self.l1_gas as Field) * fees.fee_per_l1_gas
+            + (self.l2_gas as Field) * fees.fee_per_l2_gas
     }
 
     pub fn is_empty(self) -> bool {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/gas.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/gas.nr
@@ -15,7 +15,7 @@ impl Gas {
         Self { da_gas, l1_gas, l2_gas }
     }
 
-    fn add(self, other: Gas) -> Self {
+    pub fn add(self, other: Gas) -> Self {
         Gas::new(
             self.da_gas + other.da_gas,
             self.l1_gas + other.l1_gas,
@@ -23,12 +23,16 @@ impl Gas {
         )
     }
 
-    fn sub(self, other: Gas) -> Self {
+    pub fn sub(self, other: Gas) -> Self {
         Gas::new(
             self.da_gas - other.da_gas,
             self.l1_gas - other.l1_gas,
             self.l2_gas - other.l2_gas
         )
+    }
+
+    pub fn is_empty(self) -> bool {
+        (self.da_gas == 0) & (self.l1_gas == 0) & (self.l2_gas == 0)
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/gas_fees.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/gas_fees.nr
@@ -14,6 +14,10 @@ impl GasFees {
     pub fn new(fee_per_da_gas: Field, fee_per_l1_gas: Field, fee_per_l2_gas: Field) -> Self {
         Self { fee_per_da_gas, fee_per_l1_gas, fee_per_l2_gas }
     }
+
+    pub fn default() -> Self {
+        GasFees::new(1, 1, 1)
+    }
 }
 
 impl Serialize<GAS_FEES_LENGTH> for GasFees {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/private_kernel_circuit_public_inputs_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/private_kernel_circuit_public_inputs_builder.nr
@@ -11,6 +11,10 @@ use crate::{
     mocked::AggregationObject, partial_state_reference::PartialStateReference, traits::Empty
 };
 
+// Builds:
+// .finish: PrivateKernelCircuitPublicInputs
+// .finish_tail: KernelCircuitPublicInputs (from KernelCircuitPublicInputsComposer)
+// .finish_to_public: PublicKernelCircuitPublicInputs (from KernelCircuitPublicInputsComposer)
 struct PrivateKernelCircuitPublicInputsBuilder {
     aggregation_object: AggregationObject,
     min_revertible_side_effect_counter: u32,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -50,6 +50,7 @@ struct FixtureBuilder {
     private_call_stack: BoundedVec<CallRequest, MAX_PRIVATE_CALL_STACK_LENGTH_PER_TX>,
     public_call_stack: BoundedVec<CallRequest, MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX>,
     gas_used: Gas,
+    non_revertible_gas_used: Gas,
 
     // Validation requests.
     max_block_number: MaxBlockNumber,
@@ -109,7 +110,8 @@ impl FixtureBuilder {
             min_revertible_side_effect_counter: 0,
             counter: 0,
             start_state: PartialStateReference::empty(),
-            gas_used: Gas::empty()
+            gas_used: Gas::empty(),
+            non_revertible_gas_used: Gas::empty()
         }
     }
 
@@ -128,7 +130,8 @@ impl FixtureBuilder {
             unencrypted_log_preimages_length: self.unencrypted_log_preimages_length,
             private_call_stack: self.private_call_stack,
             public_call_stack: self.public_call_stack,
-            gas_used: self.gas_used
+            gas_used: self.gas_used,
+            non_revertible_gas_used: self.non_revertible_gas_used
         };
         public_inputs.finish()
     }
@@ -451,6 +454,7 @@ impl Empty for FixtureBuilder {
             counter: 0,
             start_state: PartialStateReference::empty(),
             gas_used: Gas::empty(),
+            non_revertible_gas_used: Gas::empty(),
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/private_call_data_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/private_call_data_builder.nr
@@ -89,7 +89,7 @@ impl PrivateCallDataBuilder {
     }
 
     pub fn build_tx_context(self) -> TxContext {
-        TxContext { chain_id: 1, version: 0, gas_settings: self.gas_settings }
+        self.public_inputs.build_tx_context()
     }
 
     pub fn append_private_call_requests(&mut self, num_requests: u64, is_delegate_call: bool) {
@@ -170,24 +170,21 @@ impl PrivateCallDataBuilder {
         self.public_inputs.unencrypted_log_preimages_length += preimages_length;
     }
 
-    pub fn get_call_stack_item_hash(self) -> Field {
-        let call_stack_item = PrivateCallStackItem {
+    fn build_call_stack_item(self) -> PrivateCallStackItem {
+        PrivateCallStackItem {
             contract_address: self.contract_address,
             function_data: self.function_data,
             public_inputs: self.public_inputs.finish()
-        };
-        call_stack_item.hash()
+        }
+    }
+
+    pub fn get_call_stack_item_hash(self) -> Field {
+        self.build_call_stack_item().hash()
     }
 
     pub fn finish(self) -> PrivateCallData {
-        let call_stack_item = PrivateCallStackItem {
-            contract_address: self.contract_address,
-            function_data: self.function_data,
-            public_inputs: self.public_inputs.finish()
-        };
-
         PrivateCallData {
-            call_stack_item,
+            call_stack_item: self.build_call_stack_item(),
             private_call_stack: self.private_call_stack.storage,
             public_call_stack: self.public_call_stack.storage,
             proof: self.proof,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/private_circuit_public_inputs_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/private_circuit_public_inputs_builder.nr
@@ -85,6 +85,10 @@ impl PrivateCircuitPublicInputsBuilder {
         public_inputs
     }
 
+    pub fn build_tx_context(self) -> TxContext {
+        TxContext::new(self.chain_id, self.version, self.gas_settings)
+    }
+
     pub fn finish(self) -> PrivateCircuitPublicInputs {
         PrivateCircuitPublicInputs {
             call_context: self.call_context,
@@ -107,7 +111,7 @@ impl PrivateCircuitPublicInputsBuilder {
             encrypted_log_preimages_length: self.encrypted_log_preimages_length,
             unencrypted_log_preimages_length: self.unencrypted_log_preimages_length,
             historical_header: self.historical_header,
-            tx_context: TxContext::new(self.chain_id, self.version, self.gas_settings)
+            tx_context: self.build_tx_context()
         }
     }
 }

--- a/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
@@ -105,7 +105,7 @@ export class ContractFunctionInteraction extends BaseContractInteraction {
       const txRequest = await this.create();
       const simulatedTx = await this.pxe.simulateTx(txRequest, true);
       this.txRequest = undefined;
-      const flattened = simulatedTx.publicReturnValues;
+      const flattened = simulatedTx.publicOutput?.publicReturnValues;
       return flattened ? decodeReturnValues(this.functionDao, flattened) : [];
     }
   }

--- a/yarn-project/circuit-types/src/interfaces/aztec-node.ts
+++ b/yarn-project/circuit-types/src/interfaces/aztec-node.ts
@@ -21,7 +21,7 @@ import {
 } from '../logs/index.js';
 import { type MerkleTreeId } from '../merkle_tree_id.js';
 import { type SiblingPath } from '../sibling_path/index.js';
-import { type ProcessReturnValues, type Tx, type TxHash, type TxReceipt } from '../tx/index.js';
+import { type ProcessOutput, type Tx, type TxHash, type TxReceipt } from '../tx/index.js';
 import { type TxEffect } from '../tx_effect.js';
 import { type SequencerConfig } from './configs.js';
 import { type L2BlockNumber } from './l2_block_number.js';
@@ -282,7 +282,7 @@ export interface AztecNode {
    * This currently just checks that the transaction execution succeeds.
    * @param tx - The transaction to simulate.
    **/
-  simulatePublicCalls(tx: Tx): Promise<ProcessReturnValues>;
+  simulatePublicCalls(tx: Tx): Promise<ProcessOutput>;
 
   /**
    * Updates the configuration of this node.

--- a/yarn-project/circuit-types/src/mocks.ts
+++ b/yarn-project/circuit-types/src/mocks.ts
@@ -12,7 +12,11 @@ import {
   computeContractClassId,
   getContractClassFromArtifact,
 } from '@aztec/circuits.js';
-import { makePublicCallRequest } from '@aztec/circuits.js/testing';
+import {
+  makeCombinedAccumulatedData,
+  makeCombinedConstantData,
+  makePublicCallRequest,
+} from '@aztec/circuits.js/testing';
 import { type ContractArtifact } from '@aztec/foundation/abi';
 import { makeTuple } from '@aztec/foundation/array';
 import { times } from '@aztec/foundation/collection';
@@ -23,7 +27,7 @@ import { type ContractInstanceWithAddress, SerializableContractInstance } from '
 import { EncryptedL2Log } from './logs/encrypted_l2_log.js';
 import { EncryptedFunctionL2Logs, EncryptedTxL2Logs, Note, UnencryptedTxL2Logs } from './logs/index.js';
 import { ExtendedNote } from './notes/index.js';
-import { type ProcessReturnValues, SimulatedTx, Tx, TxHash } from './tx/index.js';
+import { type ProcessOutput, type ProcessReturnValues, SimulatedTx, Tx, TxHash } from './tx/index.js';
 
 /**
  * Testing utility to create empty logs composed from a single empty log.
@@ -114,7 +118,15 @@ export const mockTxForRollup = (seed = 1, { hasLogs = false }: { hasLogs?: boole
 export const mockSimulatedTx = (seed = 1, hasLogs = true) => {
   const tx = mockTx(seed, { hasLogs });
   const dec: ProcessReturnValues = [new Fr(1n), new Fr(2n), new Fr(3n), new Fr(4n)];
-  return new SimulatedTx(tx, dec, dec);
+  const output: ProcessOutput = {
+    constants: makeCombinedConstantData(),
+    encryptedLogs: tx.encryptedLogs,
+    unencryptedLogs: tx.unencryptedLogs,
+    end: makeCombinedAccumulatedData(),
+    revertReason: undefined,
+    publicReturnValues: dec,
+  };
+  return new SimulatedTx(tx, dec, output);
 };
 
 export const randomContractArtifact = (): ContractArtifact => ({

--- a/yarn-project/circuit-types/src/tx/simulated_tx.test.ts
+++ b/yarn-project/circuit-types/src/tx/simulated_tx.test.ts
@@ -10,7 +10,7 @@ describe('simulated_tx', () => {
   it('convert undefined effects to and from json', () => {
     const simulatedTx = mockSimulatedTx();
     simulatedTx.privateReturnValues = undefined;
-    simulatedTx.publicReturnValues = undefined;
+    simulatedTx.publicOutput = undefined;
     expect(SimulatedTx.fromJSON(simulatedTx.toJSON())).toEqual(simulatedTx);
   });
 });

--- a/yarn-project/circuit-types/src/tx/simulated_tx.ts
+++ b/yarn-project/circuit-types/src/tx/simulated_tx.ts
@@ -1,32 +1,59 @@
-import { Fr } from '@aztec/circuits.js';
+import { CombinedAccumulatedData, CombinedConstantData, Fr } from '@aztec/circuits.js';
 
+import { EncryptedTxL2Logs, UnencryptedTxL2Logs } from '../logs/index.js';
+import { type ProcessedTx } from './processed_tx.js';
 import { Tx } from './tx.js';
 
+/** Return values of simulating a circuit. */
 export type ProcessReturnValues = Fr[] | undefined;
 
+/**
+ * Outputs of processing the public component of a transaction.
+ * REFACTOR: Rename.
+ */
+export type ProcessOutput = Pick<ProcessedTx, 'encryptedLogs' | 'unencryptedLogs' | 'revertReason'> &
+  Pick<ProcessedTx['data'], 'constants' | 'end'> & { publicReturnValues: ProcessReturnValues };
+
+function processOutputToJSON(output: ProcessOutput) {
+  return {
+    encryptedLogs: output.encryptedLogs.toJSON(),
+    unencryptedLogs: output.unencryptedLogs.toJSON(),
+    revertReason: output.revertReason,
+    constants: output.constants.toBuffer().toString('hex'),
+    end: output.end.toBuffer().toString('hex'),
+    publicReturnValues: output.publicReturnValues?.map(fr => fr.toString()),
+  };
+}
+
+function processOutputFromJSON(json: any): ProcessOutput {
+  return {
+    encryptedLogs: EncryptedTxL2Logs.fromJSON(json.encryptedLogs),
+    unencryptedLogs: UnencryptedTxL2Logs.fromJSON(json.unencryptedLogs),
+    revertReason: json.revertReason,
+    constants: CombinedConstantData.fromBuffer(Buffer.from(json.constants, 'hex')),
+    end: CombinedAccumulatedData.fromBuffer(Buffer.from(json.end, 'hex')),
+    publicReturnValues: json.publicReturnValues?.map(Fr.fromString),
+  };
+}
+
+// REFACTOR: Review what we need to expose to the user when running a simulation.
+// Eg tx already has encrypted and unencrypted logs, but those cover only the ones
+// emitted during private. We need the ones from ProcessOutput to include the public
+// ones as well. However, those would only be present if the user chooses to simulate
+// the public side of things. This also points at this class needing to be split into
+// two: one with just private simulation, and one that also includes public simulation.
 export class SimulatedTx {
-  constructor(
-    public tx: Tx,
-    public privateReturnValues?: ProcessReturnValues,
-    public publicReturnValues?: ProcessReturnValues,
-  ) {}
+  constructor(public tx: Tx, public privateReturnValues?: ProcessReturnValues, public publicOutput?: ProcessOutput) {}
 
   /**
    * Convert a SimulatedTx class object to a plain JSON object.
    * @returns A plain object with SimulatedTx properties.
    */
   public toJSON() {
-    const returnToJson = (data: ProcessReturnValues | undefined): string => {
-      if (data === undefined) {
-        return JSON.stringify(data);
-      }
-      return JSON.stringify(data.map(fr => fr.toString()));
-    };
-
     return {
       tx: this.tx.toJSON(),
-      privateReturnValues: returnToJson(this.privateReturnValues),
-      publicReturnValues: returnToJson(this.publicReturnValues),
+      privateReturnValues: this.privateReturnValues?.map(fr => fr.toString()),
+      publicOutput: this.publicOutput && processOutputToJSON(this.publicOutput),
     };
   }
 
@@ -36,17 +63,10 @@ export class SimulatedTx {
    * @returns A Tx class object.
    */
   public static fromJSON(obj: any) {
-    const returnFromJson = (json: string): ProcessReturnValues | undefined => {
-      if (json === undefined) {
-        return json;
-      }
-      return JSON.parse(json).map(Fr.fromString);
-    };
-
     const tx = Tx.fromJSON(obj.tx);
-    const privateReturnValues = returnFromJson(obj.privateReturnValues);
-    const publicReturnValues = returnFromJson(obj.publicReturnValues);
+    const publicOutput = obj.publicOutput ? processOutputFromJSON(obj.publicOutput) : undefined;
+    const privateReturnValues = obj.privateReturnValues?.map(Fr.fromString);
 
-    return new SimulatedTx(tx, privateReturnValues, publicReturnValues);
+    return new SimulatedTx(tx, privateReturnValues, publicOutput);
   }
 }

--- a/yarn-project/circuits.js/src/structs/gas.ts
+++ b/yarn-project/circuits.js/src/structs/gas.ts
@@ -26,8 +26,8 @@ export class Gas {
     return this.daGas === other.daGas && this.l1Gas === other.l1Gas && this.l2Gas === other.l2Gas;
   }
 
-  static from(fields: FieldsOf<Gas>) {
-    return new Gas(fields.daGas, fields.l1Gas, fields.l2Gas);
+  static from(fields: Partial<FieldsOf<Gas>>) {
+    return new Gas(fields.daGas ?? 0, fields.l1Gas ?? 0, fields.l2Gas ?? 0);
   }
 
   static empty() {

--- a/yarn-project/circuits.js/src/structs/gas.ts
+++ b/yarn-project/circuits.js/src/structs/gas.ts
@@ -1,9 +1,10 @@
-import { type Fr } from '@aztec/foundation/fields';
+import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, FieldReader, serializeToBuffer, serializeToFields } from '@aztec/foundation/serialize';
 import { type FieldsOf } from '@aztec/foundation/types';
 
 import { inspect } from 'util';
 
+import { type GasFees } from './gas_fees.js';
 import { type UInt32 } from './shared.js';
 
 export const GasDimensions = ['da', 'l1', 'l2'] as const;
@@ -65,6 +66,13 @@ export class Gas {
 
   mul(scalar: number) {
     return new Gas(Math.ceil(this.daGas * scalar), Math.ceil(this.l1Gas * scalar), Math.ceil(this.l2Gas * scalar));
+  }
+
+  reduce(gasFees: GasFees) {
+    return GasDimensions.reduce(
+      (acc, dimension) => acc.add(gasFees.get(dimension).mul(new Fr(this.get(dimension)))),
+      Fr.ZERO,
+    );
   }
 
   toFields() {

--- a/yarn-project/circuits.js/src/structs/gas.ts
+++ b/yarn-project/circuits.js/src/structs/gas.ts
@@ -68,7 +68,7 @@ export class Gas {
     return new Gas(Math.ceil(this.daGas * scalar), Math.ceil(this.l1Gas * scalar), Math.ceil(this.l2Gas * scalar));
   }
 
-  reduce(gasFees: GasFees) {
+  computeFee(gasFees: GasFees) {
     return GasDimensions.reduce(
       (acc, dimension) => acc.add(gasFees.get(dimension).mul(new Fr(this.get(dimension)))),
       Fr.ZERO,

--- a/yarn-project/circuits.js/src/tests/factories.ts
+++ b/yarn-project/circuits.js/src/tests/factories.ts
@@ -292,6 +292,10 @@ export function makeRollupValidationRequests(seed = 1) {
   return new RollupValidationRequests(new MaxBlockNumber(true, new Fr(seed + 0x31415)));
 }
 
+export function makeCombinedConstantData(seed = 1): CombinedConstantData {
+  return new CombinedConstantData(makeHeader(seed), makeTxContext(seed + 0x100));
+}
+
 /**
  * Creates arbitrary accumulated data.
  * @param seed - The seed to use for generating the accumulated data.

--- a/yarn-project/circuits.js/src/tests/factories.ts
+++ b/yarn-project/circuits.js/src/tests/factories.ts
@@ -169,7 +169,7 @@ export function makeNewSideEffectLinkedToNoteHash(seed: number): SideEffectLinke
  * @param seed - The seed to use for generating the tx context.
  * @returns A tx context.
  */
-export function makeTxContext(seed: number): TxContext {
+export function makeTxContext(seed: number = 1): TxContext {
   // @todo @LHerskind should probably take value for chainId as it will be verified later.
   return new TxContext(new Fr(seed), Fr.ZERO, makeGasSettings());
 }

--- a/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
+++ b/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
@@ -32,6 +32,19 @@ describe('e2e_avm_simulator', () => {
       avmContract = await AvmTestContract.deploy(wallet).send().deployed();
     }, 50_000);
 
+    describe('Gas metering', () => {
+      it('Tracks L2 gas usage on simulation', async () => {
+        const request = await avmContract.methods.add_args_return(20n, 30n).create();
+        const simulation = await wallet.simulateTx(request, true, wallet.getAddress());
+        const l2GasUsed = simulation.publicOutput?.end.gasUsed.l2Gas;
+        // L2 gas used will vary a lot depending on codegen and other factors,
+        // so we just set a wide range for it, and check it's not a suspiciously round number.
+        expect(l2GasUsed).toBeGreaterThan(1e3);
+        expect(l2GasUsed).toBeLessThan(1e6);
+        expect(l2GasUsed! % 1000).not.toEqual(0);
+      });
+    });
+
     describe('Storage', () => {
       it('Modifies storage (Field)', async () => {
         await avmContract.methods.set_storage_single(20n).send().wait();

--- a/yarn-project/prover-client/src/mocks/test_context.ts
+++ b/yarn-project/prover-client/src/mocks/test_context.ts
@@ -125,15 +125,19 @@ export class TestContext {
     const defaultExecutorImplementation = (
       execution: PublicExecution,
       _globalVariables: GlobalVariables,
-      _availableGas: Gas,
+      availableGas: Gas,
       _txContext: TxContext,
-      _transactionFee?: Fr,
+      transactionFee?: Fr,
       _sideEffectCounter?: number,
     ) => {
       for (const tx of txs) {
         for (const request of tx.enqueuedPublicFunctionCalls) {
           if (execution.contractAddress.equals(request.contractAddress)) {
-            const result = PublicExecutionResultBuilder.fromPublicCallRequest({ request }).build();
+            const result = PublicExecutionResultBuilder.fromPublicCallRequest({ request }).build({
+              startGasLeft: availableGas,
+              endGasLeft: availableGas,
+              transactionFee,
+            });
             // result.unencryptedLogs = tx.unencryptedLogs.functionLogs[0];
             return Promise.resolve(result);
           }

--- a/yarn-project/prover-client/src/mocks/test_context.ts
+++ b/yarn-project/prover-client/src/mocks/test_context.ts
@@ -1,5 +1,6 @@
 import { type BlockProver, type ProcessedTx, type Tx, type TxValidator } from '@aztec/circuit-types';
-import { GlobalVariables, Header } from '@aztec/circuits.js';
+import { type Gas, GlobalVariables, Header, type TxContext } from '@aztec/circuits.js';
+import { type Fr } from '@aztec/foundation/fields';
 import { type DebugLogger } from '@aztec/foundation/log';
 import { openTmpStore } from '@aztec/kv-store/utils';
 import {
@@ -121,7 +122,14 @@ export class TestContext {
     blockProver?: BlockProver,
     txValidator?: TxValidator<ProcessedTx>,
   ) {
-    const defaultExecutorImplementation = (execution: PublicExecution, _1: GlobalVariables, _2?: number) => {
+    const defaultExecutorImplementation = (
+      execution: PublicExecution,
+      _globalVariables: GlobalVariables,
+      _availableGas: Gas,
+      _txContext: TxContext,
+      _transactionFee?: Fr,
+      _sideEffectCounter?: number,
+    ) => {
       for (const tx of txs) {
         for (const request of tx.enqueuedPublicFunctionCalls) {
           if (execution.contractAddress.equals(request.contractAddress)) {
@@ -150,6 +158,9 @@ export class TestContext {
     executorMock?: (
       execution: PublicExecution,
       globalVariables: GlobalVariables,
+      availableGas: Gas,
+      txContext: TxContext,
+      transactionFee?: Fr,
       sideEffectCounter?: number,
     ) => Promise<PublicExecutionResult>,
   ) {

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -420,7 +420,7 @@ export class PXEService implements PXE {
     txRequest: TxExecutionRequest,
     simulatePublic: boolean,
     msgSender: AztecAddress | undefined = undefined,
-  ) {
+  ): Promise<SimulatedTx> {
     if (!txRequest.functionData.isPrivate) {
       throw new Error(`Public entrypoints are not allowed`);
     }
@@ -441,7 +441,7 @@ export class PXEService implements PXE {
       }
 
       if (simulatePublic) {
-        simulatedTx.publicReturnValues = await this.#simulatePublicCalls(simulatedTx.tx);
+        simulatedTx.publicOutput = await this.#simulatePublicCalls(simulatedTx.tx);
       }
 
       if (!msgSender) {

--- a/yarn-project/simulator/src/mocks/fixtures.ts
+++ b/yarn-project/simulator/src/mocks/fixtures.ts
@@ -120,7 +120,9 @@ export class PublicExecutionResultBuilder {
       endSideEffectCounter: Fr.ZERO,
       reverted: this._reverted,
       revertReason: this._revertReason,
-      gasLeft: Gas.test(), // TODO(palla/gas): Set a proper value
+      startGasLeft: Gas.test(),
+      endGasLeft: Gas.test(),
+      transactionFee: Fr.ZERO,
     };
   }
 }

--- a/yarn-project/simulator/src/mocks/fixtures.ts
+++ b/yarn-project/simulator/src/mocks/fixtures.ts
@@ -102,7 +102,7 @@ export class PublicExecutionResultBuilder {
     return this;
   }
 
-  build(): PublicExecutionResult {
+  build(overrides: Partial<PublicExecutionResult> = {}): PublicExecutionResult {
     return {
       execution: this._execution,
       nestedExecutions: this._nestedExecutions,
@@ -123,6 +123,7 @@ export class PublicExecutionResultBuilder {
       startGasLeft: Gas.test(),
       endGasLeft: Gas.test(),
       transactionFee: Fr.ZERO,
+      ...overrides,
     };
   }
 }

--- a/yarn-project/simulator/src/public/abstract_phase_manager.ts
+++ b/yarn-project/simulator/src/public/abstract_phase_manager.ts
@@ -227,6 +227,9 @@ export abstract class AbstractPhaseManager {
 
     const newUnencryptedFunctionLogs: UnencryptedFunctionL2Logs[] = [];
 
+    // Transaction fee is zero for all phases except teardown
+    const transactionFee = this.getTransactionFee(tx, previousPublicKernelOutput);
+
     // TODO(#1684): Should multiple separately enqueued public calls be treated as
     // separate public callstacks to be proven by separate public kernel sequences
     // and submitted separately to the base rollup?
@@ -243,9 +246,17 @@ export abstract class AbstractPhaseManager {
         const current = executionStack.pop()!;
         const isExecutionRequest = !isPublicExecutionResult(current);
         const sideEffectCounter = lastSideEffectCounter(tx) + 1;
+        const availableGas = this.getAvailableGas(tx, previousPublicKernelOutput);
 
         const result = isExecutionRequest
-          ? await this.publicExecutor.simulate(current, this.globalVariables, sideEffectCounter)
+          ? await this.publicExecutor.simulate(
+              current,
+              this.globalVariables,
+              availableGas,
+              tx.data.constants.txContext,
+              transactionFee,
+              sideEffectCounter,
+            )
           : current;
 
         const functionSelector = result.execution.functionData.selector.toString();
@@ -308,6 +319,18 @@ export abstract class AbstractPhaseManager {
     return [publicKernelInputs, kernelOutput, kernelProof, newUnencryptedFunctionLogs, undefined, returns];
   }
 
+  protected getAvailableGas(tx: Tx, previousPublicKernelOutput: PublicKernelCircuitPublicInputs) {
+    // TODO(palla/gas): This is injected as startGas and needs to be validated on the kernel
+    return tx.data.constants.txContext.gasSettings
+      .getLimits() // No need to subtract teardown limits since they are already included in end.gasUsed
+      .sub(previousPublicKernelOutput.end.gasUsed)
+      .sub(previousPublicKernelOutput.endNonRevertibleData.gasUsed);
+  }
+
+  protected getTransactionFee(_tx: Tx, _previousPublicKernelOutput: PublicKernelCircuitPublicInputs) {
+    return Fr.ZERO;
+  }
+
   protected async runKernelCircuit(
     previousOutput: PublicKernelCircuitPublicInputs,
     previousProof: Proof,
@@ -348,7 +371,7 @@ export abstract class AbstractPhaseManager {
     return new PublicKernelData(previousOutput, previousProof, vk, vkIndex, vkSiblingPath);
   }
 
-  protected async getPublicCircuitPublicInputs(result: PublicExecutionResult) {
+  protected async getPublicCallStackItem(result: PublicExecutionResult, isExecutionRequest = false) {
     const publicDataTreeInfo = await this.db.getTreeInfo(MerkleTreeId.PUBLIC_DATA_TREE);
     this.historicalHeader.state.partial.publicDataTree.root = Fr.fromBuffer(publicDataTreeInfo.root);
 
@@ -361,7 +384,7 @@ export abstract class AbstractPhaseManager {
 
     const unencryptedLogPreimagesLength = new Fr(result.unencryptedLogs.getSerializedLength());
 
-    return PublicCircuitPublicInputs.from({
+    const publicCircuitPublicInputs = PublicCircuitPublicInputs.from({
       callContext: result.execution.callContext,
       proverAddress: AztecAddress.ZERO,
       argsHash: computeVarArgsHash(result.execution.args),
@@ -399,20 +422,17 @@ export abstract class AbstractPhaseManager {
       ),
       unencryptedLogPreimagesLength,
       historicalHeader: this.historicalHeader,
+      startGasLeft: Gas.from(result.startGasLeft),
+      endGasLeft: Gas.from(result.endGasLeft),
+      transactionFee: result.transactionFee,
       // TODO(@just-mitch): need better mapping from simulator to revert code.
       revertCode: result.reverted ? RevertCode.REVERTED : RevertCode.OK,
-      // TODO(palla/gas): Set proper values
-      startGasLeft: Gas.test(),
-      endGasLeft: Gas.test(),
-      transactionFee: Fr.ZERO,
     });
-  }
 
-  protected async getPublicCallStackItem(result: PublicExecutionResult, isExecutionRequest = false) {
     return new PublicCallStackItem(
       result.execution.contractAddress,
       result.execution.functionData,
-      await this.getPublicCircuitPublicInputs(result),
+      publicCircuitPublicInputs,
       isExecutionRequest,
     );
   }

--- a/yarn-project/simulator/src/public/abstract_phase_manager.ts
+++ b/yarn-project/simulator/src/public/abstract_phase_manager.ts
@@ -320,7 +320,6 @@ export abstract class AbstractPhaseManager {
   }
 
   protected getAvailableGas(tx: Tx, previousPublicKernelOutput: PublicKernelCircuitPublicInputs) {
-    // TODO(palla/gas): This is injected as startGas and needs to be validated on the kernel
     return tx.data.constants.txContext.gasSettings
       .getLimits() // No need to subtract teardown limits since they are already included in end.gasUsed
       .sub(previousPublicKernelOutput.end.gasUsed)

--- a/yarn-project/simulator/src/public/execution.ts
+++ b/yarn-project/simulator/src/public/execution.ts
@@ -61,8 +61,12 @@ export interface PublicExecutionResult {
    * The revert reason if the execution reverted.
    */
   revertReason: SimulationError | undefined;
+  /** How much gas was available for this public execution. */
+  startGasLeft: Gas;
   /** How much gas was left after this public execution. */
-  gasLeft: Gas; // TODO(palla/gas): Check this field
+  endGasLeft: Gas;
+  /** Transaction fee set for this tx. */
+  transactionFee: Fr;
 }
 
 /**

--- a/yarn-project/simulator/src/public/public_execution_context.ts
+++ b/yarn-project/simulator/src/public/public_execution_context.ts
@@ -3,7 +3,8 @@ import {
   CallContext,
   FunctionData,
   type FunctionSelector,
-  Gas,
+  type Gas,
+  type GasSettings,
   type GlobalVariables,
   type Header,
   PublicContextInputs,
@@ -40,6 +41,9 @@ export class PublicExecutionContext extends TypedOracle {
     public readonly stateDb: PublicStateDB,
     public readonly contractsDb: PublicContractsDB,
     public readonly commitmentsDb: CommitmentsDB,
+    public readonly availableGas: Gas,
+    public readonly transactionFee: Fr,
+    public readonly gasSettings: GasSettings,
     private log = createDebugLogger('aztec:simulator:public_execution_context'),
   ) {
     super();
@@ -62,8 +66,8 @@ export class PublicExecutionContext extends TypedOracle {
       this.header,
       this.globalVariables,
       this.sideEffectCounter.current(),
-      Gas.test(), // TODO(palla/gas): Set proper values
-      new Fr(0),
+      this.availableGas,
+      this.transactionFee,
     );
     const fields = [...publicContextInputs.toFields(), ...args];
     return toACVMWitness(witnessStartIndex, fields);
@@ -222,6 +226,9 @@ export class PublicExecutionContext extends TypedOracle {
       this.stateDb,
       this.contractsDb,
       this.commitmentsDb,
+      this.availableGas,
+      this.transactionFee,
+      this.gasSettings,
       this.log,
     );
 

--- a/yarn-project/simulator/src/public/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor.test.ts
@@ -349,6 +349,9 @@ describe('public_processor', () => {
         publicCallRequests,
       });
 
+      const teardownGas = tx.data.constants.txContext.gasSettings.getTeardownLimits();
+      const teardownResultSettings = { startGasLeft: teardownGas, endGasLeft: teardownGas };
+
       const contractSlotA = fr(0x100);
       const contractSlotB = fr(0x150);
       const contractSlotC = fr(0x200);
@@ -393,9 +396,9 @@ describe('public_processor', () => {
               contractStorageUpdateRequests: [
                 new ContractStorageUpdateRequest(contractSlotC, fr(0x201), 12, baseContractAddress),
               ],
-            }).build(),
+            }).build(teardownResultSettings),
           ],
-        }).build(),
+        }).build(teardownResultSettings),
       ];
 
       publicExecutor.simulate.mockImplementation(execution => {
@@ -555,6 +558,9 @@ describe('public_processor', () => {
         publicCallRequests,
       });
 
+      const teardownGas = tx.data.constants.txContext.gasSettings.getTeardownLimits();
+      const teardownResultSettings = { startGasLeft: teardownGas, endGasLeft: teardownGas };
+
       const contractSlotA = fr(0x100);
       const contractSlotB = fr(0x150);
       const contractSlotC = fr(0x200);
@@ -592,16 +598,16 @@ describe('public_processor', () => {
               from: publicCallRequests[1].contractAddress,
               tx: makeFunctionCall(baseContractAddress, makeSelector(5)),
               revertReason: new SimulationError('Simulation Failed', []),
-            }).build(),
+            }).build(teardownResultSettings),
             PublicExecutionResultBuilder.fromFunctionCall({
               from: publicCallRequests[1].contractAddress,
               tx: makeFunctionCall(baseContractAddress, makeSelector(5)),
               contractStorageUpdateRequests: [
                 new ContractStorageUpdateRequest(contractSlotC, fr(0x201), 14, baseContractAddress),
               ],
-            }).build(),
+            }).build(teardownResultSettings),
           ],
-        }).build(),
+        }).build(teardownResultSettings),
       ];
 
       publicExecutor.simulate.mockImplementation(execution => {
@@ -682,6 +688,7 @@ describe('public_processor', () => {
 
       // Inclusion fee plus block gas fees times total gas used
       const expectedTxFee = 1e4 + (1e7 + 1e6 + 2e6) * 1 + (1e7 + 2e6) * 1 + 1e7 * 1;
+      const transactionFee = new Fr(expectedTxFee);
 
       const simulatorResults: PublicExecutionResult[] = [
         // Setup
@@ -713,18 +720,19 @@ describe('public_processor', () => {
                 new ContractStorageUpdateRequest(contractSlotA, fr(0x101), 11, baseContractAddress),
                 new ContractStorageUpdateRequest(contractSlotC, fr(0x201), 12, baseContractAddress),
               ],
-            }).build({ startGasLeft: teardownGas, endGasLeft: teardownGas }),
+            }).build({ startGasLeft: teardownGas, endGasLeft: teardownGas, transactionFee }),
             PublicExecutionResultBuilder.fromFunctionCall({
               from: publicCallRequests[1].contractAddress,
               tx: makeFunctionCall(baseContractAddress, makeSelector(5)),
               contractStorageUpdateRequests: [
                 new ContractStorageUpdateRequest(contractSlotA, fr(0x102), 13, baseContractAddress),
               ],
-            }).build({ startGasLeft: teardownGas, endGasLeft: teardownGas }),
+            }).build({ startGasLeft: teardownGas, endGasLeft: teardownGas, transactionFee }),
           ],
         }).build({
           startGasLeft: teardownGas,
           endGasLeft: afterTeardownGas,
+          transactionFee,
         }),
       ];
 

--- a/yarn-project/simulator/src/public/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor.test.ts
@@ -12,6 +12,9 @@ import {
   AppendOnlyTreeSnapshot,
   ContractStorageUpdateRequest,
   Fr,
+  Gas,
+  GasFees,
+  GasSettings,
   GlobalVariables,
   Header,
   PUBLIC_DATA_TREE_HEIGHT,
@@ -25,6 +28,7 @@ import {
 import { computePublicDataTreeLeafSlot } from '@aztec/circuits.js/hash';
 import { fr, makeAztecAddress, makePublicCallRequest, makeSelector } from '@aztec/circuits.js/testing';
 import { arrayNonEmptyLength } from '@aztec/foundation/collection';
+import { type FieldsOf } from '@aztec/foundation/types';
 import { openTmpStore } from '@aztec/kv-store/utils';
 import { type AppendOnlyTree, Pedersen, StandardTree, newTree } from '@aztec/merkle-tree';
 import { type PublicExecutionResult, type PublicExecutor, WASMSimulator } from '@aztec/simulator';
@@ -197,7 +201,7 @@ describe('public_processor', () => {
         db,
         publicExecutor,
         publicKernel,
-        GlobalVariables.empty(),
+        GlobalVariables.from({ ...GlobalVariables.empty(), gasFees: GasFees.default() }),
         header,
         publicContractsDB,
         publicWorldStateDB,
@@ -648,15 +652,43 @@ describe('public_processor', () => {
         publicCallRequests,
       });
 
-      // const baseContractAddress = makeAztecAddress(30);
+      const gasLimits = Gas.from({ l1Gas: 1e9, l2Gas: 1e9, daGas: 1e9 });
+      const teardownGas = Gas.from({ l1Gas: 1e7, l2Gas: 1e7, daGas: 1e7 });
+      tx.data.constants.txContext.gasSettings = GasSettings.from({
+        gasLimits: gasLimits,
+        teardownGasLimits: teardownGas,
+        inclusionFee: new Fr(1e4),
+        maxFeesPerGas: { feePerDaGas: new Fr(10), feePerL1Gas: new Fr(10), feePerL2Gas: new Fr(10) },
+      });
+
+      // Private kernel tail to public pushes teardown gas allocation into revertible gas used
+      tx.data.forPublic!.end.gasUsed = teardownGas;
+      tx.data.forPublic!.endNonRevertibleData.gasUsed = Gas.empty();
+
       const contractSlotA = fr(0x100);
       const contractSlotB = fr(0x150);
       const contractSlotC = fr(0x200);
 
       let simulatorCallCount = 0;
+
+      const initialGas = gasLimits.sub(teardownGas);
+      const afterSetupGas = initialGas.sub(Gas.from({ l2Gas: 1e6 }));
+      const afterAppGas = afterSetupGas.sub(Gas.from({ l2Gas: 2e6, daGas: 2e6 }));
+      const afterTeardownGas = teardownGas.sub(Gas.from({ l2Gas: 3e6, daGas: 3e6 }));
+
+      // Total gas used is the sum of teardown gas allocation plus all expenditures along the way,
+      // without including the gas used in the teardown phase (since that's consumed entirely up front).
+      const expectedTotalGasUsed = { l2Gas: 1e7 + 1e6 + 2e6, daGas: 1e7 + 2e6, l1Gas: 1e7 };
+
+      // Inclusion fee plus block gas fees times total gas used
+      const expectedTxFee = 1e4 + (1e7 + 1e6 + 2e6) * 1 + (1e7 + 2e6) * 1 + 1e7 * 1;
+
       const simulatorResults: PublicExecutionResult[] = [
         // Setup
-        PublicExecutionResultBuilder.fromPublicCallRequest({ request: publicCallRequests[0] }).build(),
+        PublicExecutionResultBuilder.fromPublicCallRequest({ request: publicCallRequests[0] }).build({
+          startGasLeft: initialGas,
+          endGasLeft: afterSetupGas,
+        }),
 
         // App Logic
         PublicExecutionResultBuilder.fromPublicCallRequest({
@@ -665,7 +697,10 @@ describe('public_processor', () => {
             new ContractStorageUpdateRequest(contractSlotA, fr(0x101), 14, baseContractAddress),
             new ContractStorageUpdateRequest(contractSlotB, fr(0x151), 15, baseContractAddress),
           ],
-        }).build(),
+        }).build({
+          startGasLeft: afterSetupGas,
+          endGasLeft: afterAppGas,
+        }),
 
         // Teardown
         PublicExecutionResultBuilder.fromPublicCallRequest({
@@ -678,21 +713,25 @@ describe('public_processor', () => {
                 new ContractStorageUpdateRequest(contractSlotA, fr(0x101), 11, baseContractAddress),
                 new ContractStorageUpdateRequest(contractSlotC, fr(0x201), 12, baseContractAddress),
               ],
-            }).build(),
+            }).build({ startGasLeft: teardownGas, endGasLeft: teardownGas }),
             PublicExecutionResultBuilder.fromFunctionCall({
               from: publicCallRequests[1].contractAddress,
               tx: makeFunctionCall(baseContractAddress, makeSelector(5)),
               contractStorageUpdateRequests: [
                 new ContractStorageUpdateRequest(contractSlotA, fr(0x102), 13, baseContractAddress),
               ],
-            }).build(),
+            }).build({ startGasLeft: teardownGas, endGasLeft: teardownGas }),
           ],
-        }).build(),
+        }).build({
+          startGasLeft: teardownGas,
+          endGasLeft: afterTeardownGas,
+        }),
       ];
 
       publicExecutor.simulate.mockImplementation(execution => {
         if (simulatorCallCount < simulatorResults.length) {
-          return Promise.resolve(simulatorResults[simulatorCallCount++]);
+          const result = simulatorResults[simulatorCallCount++];
+          return Promise.resolve(result);
         } else {
           throw new Error(`Unexpected execution request: ${execution}, call count: ${simulatorCallCount}`);
         }
@@ -711,11 +750,27 @@ describe('public_processor', () => {
       expect(setupSpy).toHaveBeenCalledTimes(1);
       expect(appLogicSpy).toHaveBeenCalledTimes(1);
       expect(teardownSpy).toHaveBeenCalledTimes(3);
+
+      const expectedSimulateCall = (availableGas: Partial<FieldsOf<Gas>>, txFee: number) => [
+        expect.anything(), // PublicExecution
+        expect.anything(), // GlobalVariables
+        Gas.from(availableGas),
+        expect.anything(), // TxContext
+        new Fr(txFee),
+        expect.anything(), // SideEffectCounter
+      ];
+
       expect(publicExecutor.simulate).toHaveBeenCalledTimes(3);
+      expect(publicExecutor.simulate).toHaveBeenNthCalledWith(1, ...expectedSimulateCall(initialGas, 0));
+      expect(publicExecutor.simulate).toHaveBeenNthCalledWith(2, ...expectedSimulateCall(afterSetupGas, 0));
+      expect(publicExecutor.simulate).toHaveBeenNthCalledWith(3, ...expectedSimulateCall(teardownGas, expectedTxFee));
+
       expect(publicWorldStateDB.checkpoint).toHaveBeenCalledTimes(3);
       expect(publicWorldStateDB.rollbackToCheckpoint).toHaveBeenCalledTimes(0);
       expect(publicWorldStateDB.commit).toHaveBeenCalledTimes(1);
       expect(publicWorldStateDB.rollbackToCommit).toHaveBeenCalledTimes(0);
+
+      expect(processed[0].data.end.gasUsed).toEqual(Gas.from(expectedTotalGasUsed));
 
       const txEffect = toTxEffect(processed[0]);
       expect(arrayNonEmptyLength(txEffect.publicDataWrites, PublicDataWrite.isEmpty)).toEqual(3);

--- a/yarn-project/simulator/src/public/teardown_phase_manager.ts
+++ b/yarn-project/simulator/src/public/teardown_phase_manager.ts
@@ -73,7 +73,7 @@ export class TeardownPhaseManager extends AbstractPhaseManager {
     const gasFees = this.globalVariables.gasFees;
     // No need to add teardown limits since they are already included in end.gasUsed
     const gasUsed = previousPublicKernelOutput.end.gasUsed.add(previousPublicKernelOutput.endNonRevertibleData.gasUsed);
-    const txFee = gasSettings.inclusionFee.add(gasUsed.reduce(gasFees));
+    const txFee = gasSettings.inclusionFee.add(gasUsed.computeFee(gasFees));
     this.log.debug(`Computed tx fee`, { txFee, gasUsed: inspect(gasUsed), gasFees: inspect(gasFees) });
     return txFee;
   }

--- a/yarn-project/simulator/src/public/teardown_phase_manager.ts
+++ b/yarn-project/simulator/src/public/teardown_phase_manager.ts
@@ -67,7 +67,6 @@ export class TeardownPhaseManager extends AbstractPhaseManager {
   }
 
   protected override getTransactionFee(tx: Tx, previousPublicKernelOutput: PublicKernelCircuitPublicInputs): Fr {
-    // TODO(palla/gas): This needs to be verified on the kernel teardown
     const gasSettings = tx.data.constants.txContext.gasSettings;
     const gasFees = this.globalVariables.gasFees;
     // No need to add teardown limits since they are already included in end.gasUsed

--- a/yarn-project/simulator/src/public/teardown_phase_manager.ts
+++ b/yarn-project/simulator/src/public/teardown_phase_manager.ts
@@ -10,6 +10,8 @@ import {
 import { type PublicExecutor, type PublicStateDB } from '@aztec/simulator';
 import { type MerkleTreeOperations } from '@aztec/world-state';
 
+import { inspect } from 'util';
+
 import { AbstractPhaseManager, PublicKernelPhase } from './abstract_phase_manager.js';
 import { type ContractsDataSourcePublicDB } from './public_executor.js';
 import { type PublicKernelCircuitSimulator } from './public_kernel_circuit_simulator.js';
@@ -71,7 +73,9 @@ export class TeardownPhaseManager extends AbstractPhaseManager {
     const gasFees = this.globalVariables.gasFees;
     // No need to add teardown limits since they are already included in end.gasUsed
     const gasUsed = previousPublicKernelOutput.end.gasUsed.add(previousPublicKernelOutput.endNonRevertibleData.gasUsed);
-    return gasSettings.inclusionFee.add(gasUsed.reduce(gasFees));
+    const txFee = gasSettings.inclusionFee.add(gasUsed.reduce(gasFees));
+    this.log.debug(`Computed tx fee`, { txFee, gasUsed: inspect(gasUsed), gasFees: inspect(gasFees) });
+    return txFee;
   }
 
   protected override getAvailableGas(tx: Tx, _previousPublicKernelOutput: PublicKernelCircuitPublicInputs): Gas {


### PR DESCRIPTION
Sets gas used and transaction fee in the public executor and public kernels. Implements changes as defined in https://github.com/AztecProtocol/aztec-packages/pull/5855/ except for those related to enshrining fee payment (eg `fee_payer`).  

Suggested reviewing per-commit.