### PR TITLE
chore(ci): prevent haywire logs

### DIFF
--- a/yarn-project/accounts/package.json
+++ b/yarn-project/accounts/package.json
@@ -31,7 +31,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo ./src/artifacts",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json",
@@ -50,6 +50,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/accounts/package.json
+++ b/yarn-project/accounts/package.json
@@ -31,7 +31,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo ./src/artifacts",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "inherits": [
     "../package.common.json",

--- a/yarn-project/archiver/package.json
+++ b/yarn-project/archiver/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
     "start": "node ./dest",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'",
     "test:integration": "concurrently -k -s first -c reset,dim -n test,anvil \"yarn test:integration:run\" \"anvil\"",

--- a/yarn-project/archiver/package.json
+++ b/yarn-project/archiver/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
     "start": "node ./dest",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'",
     "test:integration": "concurrently -k -s first -c reset,dim -n test,anvil \"yarn test:integration:run\" \"anvil\"",
@@ -39,6 +39,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/aztec-faucet/package.json
+++ b/yarn-project/aztec-faucet/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"
@@ -36,6 +36,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/aztec-faucet/package.json
+++ b/yarn-project/aztec-faucet/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/aztec-node/package.json
+++ b/yarn-project/aztec-node/package.json
@@ -19,7 +19,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"
@@ -37,6 +37,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/aztec-node/package.json
+++ b/yarn-project/aztec-node/package.json
@@ -19,7 +19,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/aztec.js/package.json
+++ b/yarn-project/aztec.js/package.json
@@ -35,7 +35,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo ./src/account_contract/artifacts",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json",
@@ -54,6 +54,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/aztec.js/package.json
+++ b/yarn-project/aztec.js/package.json
@@ -35,7 +35,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo ./src/account_contract/artifacts",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "inherits": [
     "../package.common.json",

--- a/yarn-project/aztec/package.json
+++ b/yarn-project/aztec/package.json
@@ -20,7 +20,7 @@
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "build:dev": "tsc -b --watch",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
     "run:example:token": "DEBUG='aztec:*' node ./dest/examples/token.js"
   },
   "inherits": [

--- a/yarn-project/aztec/package.json
+++ b/yarn-project/aztec/package.json
@@ -20,7 +20,7 @@
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "build:dev": "tsc -b --watch",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
     "run:example:token": "DEBUG='aztec:*' node ./dest/examples/token.js"
   },
   "inherits": [
@@ -78,6 +78,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "engines": {

--- a/yarn-project/builder/package.json
+++ b/yarn-project/builder/package.json
@@ -23,7 +23,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"
@@ -46,6 +46,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/builder/package.json
+++ b/yarn-project/builder/package.json
@@ -23,7 +23,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/circuit-types/package.json
+++ b/yarn-project/circuit-types/package.json
@@ -23,7 +23,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/circuit-types/package.json
+++ b/yarn-project/circuit-types/package.json
@@ -23,7 +23,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"
@@ -41,6 +41,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/circuits.js/package.json
+++ b/yarn-project/circuits.js/package.json
@@ -36,7 +36,7 @@
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "remake-constants": "node --loader ts-node/esm src/scripts/constants.in.ts && prettier -w src/constants.gen.ts && cd ../../l1-contracts && ../foundry/bin/forge fmt",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "dependencies": {
     "@aztec/bb.js": "portal:../../barretenberg/ts",
@@ -78,6 +78,14 @@
       "^(\\.{1,2}/.*)\\.[cm]?js$": "$1"
     },
     "testRegex": "./src/.*\\.test\\.(js|mjs|ts)$",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
+    ]
   }
 }

--- a/yarn-project/circuits.js/package.json
+++ b/yarn-project/circuits.js/package.json
@@ -36,7 +36,7 @@
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "remake-constants": "node --loader ts-node/esm src/scripts/constants.in.ts && prettier -w src/constants.gen.ts && cd ../../l1-contracts && ../foundry/bin/forge fmt",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "dependencies": {
     "@aztec/bb.js": "portal:../../barretenberg/ts",

--- a/yarn-project/end-to-end/jest.integration.config.json
+++ b/yarn-project/end-to-end/jest.integration.config.json
@@ -6,6 +6,7 @@
   "moduleNameMapper": {
     "^(\\.{1,2}/.*)\\.js$": "$1"
   },
+  "reporters": [["default", {"summaryThreshold": 9999}]],
   "testRegex": "./src/.*\\.test\\.ts$",
   "rootDir": "./src"
 }

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src \"!src/web/main.js\" && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "LOG_LEVEL=${LOG_LEVEL:-silent} DEBUG_COLORS=1 NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=120000 --forceExit",
+    "test": "LOG_LEVEL=${LOG_LEVEL:-silent} DEBUG_COLORS=1 NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=120000 --forceExit --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}'",
     "test:integration": "concurrently -k -s first -c reset,dim -n test,anvil \"yarn test:integration:run\" \"anvil\"",
     "test:integration:run": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --no-cache --runInBand --config jest.integration.config.json"
   },

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src \"!src/web/main.js\" && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "LOG_LEVEL=${LOG_LEVEL:-silent} DEBUG_COLORS=1 NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=120000 --forceExit --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}'",
+    "test": "LOG_LEVEL=${LOG_LEVEL:-silent} DEBUG_COLORS=1 NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=120000 --forceExit",
     "test:integration": "concurrently -k -s first -c reset,dim -n test,anvil \"yarn test:integration:run\" \"anvil\"",
     "test:integration:run": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --no-cache --runInBand --config jest.integration.config.json"
   },
@@ -110,6 +110,7 @@
         "@swc/jest"
       ]
     },
+    "reporters": [["default", {"summaryThreshold": 9999}]],
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.[cm]?js$": "$1"
     },

--- a/yarn-project/end-to-end/package.local.json
+++ b/yarn-project/end-to-end/package.local.json
@@ -2,6 +2,6 @@
   "scripts": {
     "build": "yarn clean && tsc -b && webpack",
     "formatting": "run -T prettier --check ./src \"!src/web/main.js\" && run -T eslint ./src",
-    "test": "LOG_LEVEL=${LOG_LEVEL:-silent} DEBUG_COLORS=1 NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=120000 --forceExit --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}'"
+    "test": "LOG_LEVEL=${LOG_LEVEL:-silent} DEBUG_COLORS=1 NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=120000 --forceExit"
   }
 }

--- a/yarn-project/end-to-end/package.local.json
+++ b/yarn-project/end-to-end/package.local.json
@@ -2,6 +2,6 @@
   "scripts": {
     "build": "yarn clean && tsc -b && webpack",
     "formatting": "run -T prettier --check ./src \"!src/web/main.js\" && run -T eslint ./src",
-    "test": "LOG_LEVEL=${LOG_LEVEL:-silent} DEBUG_COLORS=1 NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=120000 --forceExit"
+    "test": "LOG_LEVEL=${LOG_LEVEL:-silent} DEBUG_COLORS=1 NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=120000 --forceExit --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}'"
   }
 }

--- a/yarn-project/entrypoints/package.json
+++ b/yarn-project/entrypoints/package.json
@@ -22,7 +22,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"
@@ -40,6 +40,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/entrypoints/package.json
+++ b/yarn-project/entrypoints/package.json
@@ -22,7 +22,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/ethereum/package.json
+++ b/yarn-project/ethereum/package.json
@@ -18,7 +18,7 @@
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'",
     "start": "node ./dest/index.js",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"
@@ -56,6 +56,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "engines": {

--- a/yarn-project/ethereum/package.json
+++ b/yarn-project/ethereum/package.json
@@ -18,7 +18,7 @@
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'",
     "start": "node ./dest/index.js",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -49,7 +49,7 @@
     "generate": "true",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"
@@ -67,6 +67,14 @@
     "rootDir": "./src",
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -49,7 +49,7 @@
     "generate": "true",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/key-store/package.json
+++ b/yarn-project/key-store/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"
@@ -34,6 +34,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/key-store/package.json
+++ b/yarn-project/key-store/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/kv-store/package.json
+++ b/yarn-project/kv-store/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
     "start": "DEBUG='aztec:*' && node ./dest/bin/index.js"
   },
   "inherits": [
@@ -33,6 +33,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/kv-store/package.json
+++ b/yarn-project/kv-store/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
     "start": "DEBUG='aztec:*' && node ./dest/bin/index.js"
   },
   "inherits": [

--- a/yarn-project/merkle-tree/package.json
+++ b/yarn-project/merkle-tree/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json",
@@ -36,6 +36,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/merkle-tree/package.json
+++ b/yarn-project/merkle-tree/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "inherits": [
     "../package.common.json",

--- a/yarn-project/noir-contracts.js/package.json
+++ b/yarn-project/noir-contracts.js/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf .tsbuildinfo ./artifacts ./codegenCache.json",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
     "generate": "yarn generate:noir-contracts",
     "generate:noir-contracts": "./scripts/generate-types.sh && run -T prettier -w ./src --loglevel warn"
   },
@@ -34,6 +34,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/noir-contracts.js/package.json
+++ b/yarn-project/noir-contracts.js/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf .tsbuildinfo ./artifacts ./codegenCache.json",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
     "generate": "yarn generate:noir-contracts",
     "generate:noir-contracts": "./scripts/generate-types.sh && run -T prettier -w ./src --loglevel warn"
   },

--- a/yarn-project/noir-protocol-circuits-types/package.json
+++ b/yarn-project/noir-protocol-circuits-types/package.json
@@ -18,7 +18,7 @@
     "formatting:fix:types": "NODE_OPTIONS='--max-old-space-size=8096' run -T eslint --fix ./src/types && run -T prettier -w ./src/types",
     "generate": "yarn generate:noir-circuits",
     "generate:noir-circuits": "mkdir -p ./src/target && cp ../../noir-projects/noir-protocol-circuits/target/* ./src/target && node --no-warnings --loader ts-node/esm src/scripts/generate_ts_from_abi.ts && run -T prettier -w ./src/types",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
     "build:dev": "tsc -b --watch"
   },
   "jest": {
@@ -34,7 +34,15 @@
       "^.+\\.tsx?$": [
         "@swc/jest"
       ]
-    }
+    },
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
+    ]
   },
   "dependencies": {
     "@aztec/builder": "workspace:^",

--- a/yarn-project/noir-protocol-circuits-types/package.json
+++ b/yarn-project/noir-protocol-circuits-types/package.json
@@ -18,7 +18,7 @@
     "formatting:fix:types": "NODE_OPTIONS='--max-old-space-size=8096' run -T eslint --fix ./src/types && run -T prettier -w ./src/types",
     "generate": "yarn generate:noir-circuits",
     "generate:noir-circuits": "mkdir -p ./src/target && cp ../../noir-projects/noir-protocol-circuits/target/* ./src/target && node --no-warnings --loader ts-node/esm src/scripts/generate_ts_from_abi.ts && run -T prettier -w ./src/types",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
     "build:dev": "tsc -b --watch"
   },
   "jest": {

--- a/yarn-project/p2p-bootstrap/package.json
+++ b/yarn-project/p2p-bootstrap/package.json
@@ -18,7 +18,7 @@
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'",
     "start": "node ./dest/index.js",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"
@@ -56,6 +56,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "engines": {

--- a/yarn-project/p2p-bootstrap/package.json
+++ b/yarn-project/p2p-bootstrap/package.json
@@ -18,7 +18,7 @@
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'",
     "start": "node ./dest/index.js",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/p2p/package.json
+++ b/yarn-project/p2p/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
     "start": "node ./dest",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'"
   },

--- a/yarn-project/p2p/package.json
+++ b/yarn-project/p2p/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
     "start": "node ./dest",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'"
   },
@@ -36,6 +36,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/package.common.json
+++ b/yarn-project/package.common.json
@@ -5,7 +5,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "engines": {
     "node": ">=18"

--- a/yarn-project/package.common.json
+++ b/yarn-project/package.common.json
@@ -5,7 +5,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "engines": {
     "node": ">=18"
@@ -24,6 +24,7 @@
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.[cm]?js$": "$1"
     },
+    "reporters": [["default", {"summaryThreshold": 9999}]],
     "testRegex": "./src/.*\\.test\\.(js|mjs|ts)$",
     "rootDir": "./src"
   }

--- a/yarn-project/protocol-contracts/package.json
+++ b/yarn-project/protocol-contracts/package.json
@@ -26,7 +26,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo ./src/artifacts",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "inherits": [
     "../package.common.json",

--- a/yarn-project/protocol-contracts/package.json
+++ b/yarn-project/protocol-contracts/package.json
@@ -26,7 +26,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo ./src/artifacts",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json",
@@ -45,6 +45,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/prover-client/package.json
+++ b/yarn-project/prover-client/package.json
@@ -20,7 +20,7 @@
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "bb": "node --no-warnings ./dest/bb/index.js",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
     "generate-and-test": "yarn bb-cli write-server-vks && yarn test"
   },
   "inherits": [
@@ -39,6 +39,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/prover-client/package.json
+++ b/yarn-project/prover-client/package.json
@@ -20,7 +20,7 @@
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "bb": "node --no-warnings ./dest/bb/index.js",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
     "generate-and-test": "yarn bb-cli write-server-vks && yarn test"
   },
   "inherits": [

--- a/yarn-project/pxe/package.json
+++ b/yarn-project/pxe/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
     "start": "DEBUG='aztec:*' && node ./dest/bin/index.js"
   },
   "inherits": [

--- a/yarn-project/pxe/package.json
+++ b/yarn-project/pxe/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
     "start": "DEBUG='aztec:*' && node ./dest/bin/index.js"
   },
   "inherits": [
@@ -37,6 +37,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/pxe/tsconfig.json
+++ b/yarn-project/pxe/tsconfig.json
@@ -7,6 +7,9 @@
   },
   "references": [
     {
+      "path": "../builder"
+    },
+    {
       "path": "../circuit-types"
     },
     {
@@ -23,9 +26,6 @@
     },
     {
       "path": "../kv-store"
-    },
-    {
-      "path": "../builder"
     },
     {
       "path": "../noir-protocol-circuits-types"

--- a/yarn-project/pxe/tsconfig.json
+++ b/yarn-project/pxe/tsconfig.json
@@ -7,9 +7,6 @@
   },
   "references": [
     {
-      "path": "../builder"
-    },
-    {
       "path": "../circuit-types"
     },
     {
@@ -26,6 +23,9 @@
     },
     {
       "path": "../kv-store"
+    },
+    {
+      "path": "../builder"
     },
     {
       "path": "../noir-protocol-circuits-types"

--- a/yarn-project/scripts/package.json
+++ b/yarn-project/scripts/package.json
@@ -18,7 +18,7 @@
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'",
     "start": "node ./dest/index.js",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
     "generate:noir-circuits": "echo Noop",
     "generate:noir-contracts": "echo Noop",
     "generate:l1-contracts": "echo Noop",
@@ -64,6 +64,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "engines": {

--- a/yarn-project/scripts/package.json
+++ b/yarn-project/scripts/package.json
@@ -18,7 +18,7 @@
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'",
     "start": "node ./dest/index.js",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
     "generate:noir-circuits": "echo Noop",
     "generate:noir-contracts": "echo Noop",
     "generate:l1-contracts": "echo Noop",

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -19,7 +19,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
     "test:integration": "concurrently -k -s first -c reset,dim -n test,anvil \"yarn test:integration:run\" \"anvil\"",
     "test:integration:run": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --no-cache --config jest.integration.config.json"
   },

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -19,7 +19,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
     "test:integration": "concurrently -k -s first -c reset,dim -n test,anvil \"yarn test:integration:run\" \"anvil\"",
     "test:integration:run": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --no-cache --config jest.integration.config.json"
   },
@@ -85,6 +85,14 @@
       "^(\\.{1,2}/.*)\\.[cm]?js$": "$1"
     },
     "testRegex": "./src/.*\\.test\\.(js|mjs|ts)$",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
+    ]
   }
 }

--- a/yarn-project/simulator/package.json
+++ b/yarn-project/simulator/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"
@@ -34,6 +34,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/simulator/package.json
+++ b/yarn-project/simulator/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/types/package.json
+++ b/yarn-project/types/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
     "generate": "yarn generate:noir-contracts",
     "generate:noir-contracts": "./scripts/copy-contracts.sh"
   },

--- a/yarn-project/types/package.json
+++ b/yarn-project/types/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
     "generate": "yarn generate:noir-contracts",
     "generate:noir-contracts": "./scripts/copy-contracts.sh"
   },
@@ -39,6 +39,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/world-state/package.json
+++ b/yarn-project/world-state/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"
@@ -34,6 +34,14 @@
     },
     "extensionsToTreatAsEsm": [
       ".ts"
+    ],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
     ]
   },
   "dependencies": {

--- a/yarn-project/world-state/package.json
+++ b/yarn-project/world-state/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --config '{\"reporters\": [[\"default\", {\"summaryThreshold\": 9999}]]}' --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"


### PR DESCRIPTION
Note: code in json sorta sucks, I couldn't comment why this is used.
There is a bad interaction between earthly x github actions x jest summary reporter. As far as I can see, it's this combination and not any piece alone (something something ansi codes, but not entirely sure). This seems like simplest fix.

Without this, it was causing a lot of duplicated lines. But this particularly interacted with the poor rendering performance of github actions logs.

The other piece is that its rendering is just slow in chrome for 10,000K+ lines. use raw logs, or another browser like safari