### PR TITLE
chore: yarn build:dev don't clear terminal

### DIFF
--- a/yarn-project/watch.sh
+++ b/yarn-project/watch.sh
@@ -13,7 +13,7 @@ debounce() {
   local run_id=$(uuidgen)
   echo "$run_id" > ".debounce-$group_id"
   (
-    sleep $DEBOUNCE_DURATION; 
+    sleep $DEBOUNCE_DURATION;
     local current_id=$(cat ".debounce-$group_id");
     if [ "$run_id" = "${current_id}" ]; then
       "$@"
@@ -24,7 +24,7 @@ debounce() {
 # Start typescript watch process in the background and store process ID in a file
 start_tsc_watch() {
   local tsc_bin=$(yarn bin tsc)
-  $tsc_bin -b tsconfig.json --watch &
+  $tsc_bin -b tsconfig.json --watch --preserveWatchOutput &
   TSC_PID=$!
   echo "$TSC_PID" > .tsc.pid
 }


### PR DESCRIPTION
Small QoL improvement to not clear the console when running `yarn build:dev` in the root of the workspace
