### PR TITLE
feat: configure prover as separate process

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/config.ts
+++ b/yarn-project/aztec-node/src/aztec-node/config.ts
@@ -17,6 +17,8 @@ export type AztecNodeConfig = ArchiverConfig &
 
     /** A URL for an archiver service that the node will use. */
     archiverUrl?: string;
+
+    proverAgents: number;
   };
 
 /**
@@ -24,15 +26,21 @@ export type AztecNodeConfig = ArchiverConfig &
  * @returns A valid aztec node config.
  */
 export function getConfigEnvVars(): AztecNodeConfig {
-  const { SEQ_DISABLED, PROVER_DISABLED } = process.env;
+  const { SEQ_DISABLED, PROVER_DISABLED, ARCHIVER_URL, PROVER_AGENTS = '1' } = process.env;
+  let proverAgents = parseInt(PROVER_AGENTS, 10);
+  if (Number.isNaN(proverAgents)) {
+    proverAgents = 1;
+  }
+
   const allEnvVars: AztecNodeConfig = {
     ...getSequencerVars(),
     ...getArchiverVars(),
     ...getP2PConfigEnvVars(),
     ...getWorldStateVars(),
     disableSequencer: !!SEQ_DISABLED,
-    disableProver: !!PROVER_DISABLED,
-    archiverUrl: process.env.ARCHIVER_URL,
+    archiverUrl: ARCHIVER_URL,
+    disableProver: PROVER_DISABLED === '1',
+    proverAgents,
   };
 
   return allEnvVars;

--- a/yarn-project/aztec-node/src/aztec-node/config.ts
+++ b/yarn-project/aztec-node/src/aztec-node/config.ts
@@ -1,5 +1,6 @@
 import { type ArchiverConfig, getConfigEnvVars as getArchiverVars } from '@aztec/archiver';
 import { type P2PConfig, getP2PConfigEnvVars } from '@aztec/p2p';
+import { type ProverConfig, getProverEnvVars } from '@aztec/prover-client';
 import { type SequencerClientConfig, getConfigEnvVars as getSequencerVars } from '@aztec/sequencer-client';
 import { getConfigEnvVars as getWorldStateVars } from '@aztec/world-state';
 
@@ -8,6 +9,7 @@ import { getConfigEnvVars as getWorldStateVars } from '@aztec/world-state';
  */
 export type AztecNodeConfig = ArchiverConfig &
   SequencerClientConfig &
+  ProverConfig &
   P2PConfig & {
     /** Whether the sequencer is disabled for this node. */
     disableSequencer: boolean;
@@ -17,8 +19,6 @@ export type AztecNodeConfig = ArchiverConfig &
 
     /** A URL for an archiver service that the node will use. */
     archiverUrl?: string;
-
-    proverAgents: number;
   };
 
 /**
@@ -26,21 +26,17 @@ export type AztecNodeConfig = ArchiverConfig &
  * @returns A valid aztec node config.
  */
 export function getConfigEnvVars(): AztecNodeConfig {
-  const { SEQ_DISABLED, PROVER_DISABLED, ARCHIVER_URL, PROVER_AGENTS = '1' } = process.env;
-  let proverAgents = parseInt(PROVER_AGENTS, 10);
-  if (Number.isNaN(proverAgents)) {
-    proverAgents = 1;
-  }
+  const { SEQ_DISABLED, PROVER_DISABLED, ARCHIVER_URL } = process.env;
 
   const allEnvVars: AztecNodeConfig = {
     ...getSequencerVars(),
     ...getArchiverVars(),
     ...getP2PConfigEnvVars(),
     ...getWorldStateVars(),
+    ...getProverEnvVars(),
     disableSequencer: !!SEQ_DISABLED,
     archiverUrl: ARCHIVER_URL,
     disableProver: PROVER_DISABLED === '1',
-    proverAgents,
   };
 
   return allEnvVars;

--- a/yarn-project/aztec-node/src/aztec-node/config.ts
+++ b/yarn-project/aztec-node/src/aztec-node/config.ts
@@ -26,7 +26,7 @@ export type AztecNodeConfig = ArchiverConfig &
  * @returns A valid aztec node config.
  */
 export function getConfigEnvVars(): AztecNodeConfig {
-  const { SEQ_DISABLED, PROVER_DISABLED, ARCHIVER_URL } = process.env;
+  const { SEQ_DISABLED, PROVER_DISABLED = '', ARCHIVER_URL } = process.env;
 
   const allEnvVars: AztecNodeConfig = {
     ...getSequencerVars(),
@@ -36,7 +36,7 @@ export function getConfigEnvVars(): AztecNodeConfig {
     ...getProverEnvVars(),
     disableSequencer: !!SEQ_DISABLED,
     archiverUrl: ARCHIVER_URL,
-    disableProver: PROVER_DISABLED === '1',
+    disableProver: ['1', 'true'].includes(PROVER_DISABLED),
   };
 
   return allEnvVars;

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -52,7 +52,6 @@ import { initStoreForRollup, openTmpStore } from '@aztec/kv-store/utils';
 import { SHA256Trunc, StandardTree } from '@aztec/merkle-tree';
 import { AztecKVTxPool, type P2P, createP2PClient } from '@aztec/p2p';
 import { DummyProver, TxProver } from '@aztec/prover-client';
-import { ProverPool } from '@aztec/prover-client/prover-pool';
 import { type GlobalVariableBuilder, SequencerClient, getGlobalVariableBuilder } from '@aztec/sequencer-client';
 import { PublicProcessorFactory, WASMSimulator } from '@aztec/simulator';
 import {
@@ -152,7 +151,7 @@ export class AztecNodeService implements AztecNode {
     const simulationProvider = await getSimulationProvider(config, log);
     const prover = config.disableProver
       ? await DummyProver.new()
-      : await TxProver.new(worldStateSynchronizer, ProverPool.testPool(simulationProvider, config.proverAgents));
+      : await TxProver.new(config, simulationProvider, worldStateSynchronizer);
 
     // now create the sequencer
     const sequencer = config.disableSequencer

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -52,6 +52,7 @@ import { initStoreForRollup, openTmpStore } from '@aztec/kv-store/utils';
 import { SHA256Trunc, StandardTree } from '@aztec/merkle-tree';
 import { AztecKVTxPool, type P2P, createP2PClient } from '@aztec/p2p';
 import { DummyProver, TxProver } from '@aztec/prover-client';
+import { ProverPool } from '@aztec/prover-client/prover-pool';
 import { type GlobalVariableBuilder, SequencerClient, getGlobalVariableBuilder } from '@aztec/sequencer-client';
 import { PublicProcessorFactory, WASMSimulator } from '@aztec/simulator';
 import {
@@ -151,7 +152,7 @@ export class AztecNodeService implements AztecNode {
     const simulationProvider = await getSimulationProvider(config, log);
     const prover = config.disableProver
       ? await DummyProver.new()
-      : await TxProver.new(config, worldStateSynchronizer, simulationProvider);
+      : await TxProver.new(worldStateSynchronizer, ProverPool.testPool(simulationProvider, config.proverAgents));
 
     // now create the sequencer
     const sequencer = config.disableSequencer
@@ -192,6 +193,10 @@ export class AztecNodeService implements AztecNode {
    */
   public getSequencer(): SequencerClient | undefined {
     return this.sequencer;
+  }
+
+  public getProver(): ProverClient {
+    return this.prover;
   }
 
   /**

--- a/yarn-project/aztec/package.json
+++ b/yarn-project/aztec/package.json
@@ -42,6 +42,7 @@
     "@aztec/noir-contracts.js": "workspace:^",
     "@aztec/p2p": "workspace:^",
     "@aztec/protocol-contracts": "workspace:^",
+    "@aztec/prover-client": "workspace:^",
     "@aztec/pxe": "workspace:^",
     "abitype": "^0.8.11",
     "commander": "^11.1.0",

--- a/yarn-project/aztec/src/cli/cli.ts
+++ b/yarn-project/aztec/src/cli/cli.ts
@@ -56,6 +56,9 @@ export function getProgram(userLog: LogFn, debugLogger: DebugLogger): Command {
       } else if (options.p2pBootstrap) {
         const { startP2PBootstrap } = await import('./cmds/start_p2p_bootstrap.js');
         await startP2PBootstrap(options, signalHandlers, userLog, debugLogger);
+      } else if (options.prover) {
+        const { startProver } = await import('./cmds/start_prover.js');
+        services = await startProver(options, signalHandlers, userLog);
       }
       if (services.length) {
         const rpcServer = createNamespacedJsonRpcServer(services, debugLogger);

--- a/yarn-project/aztec/src/cli/cmds/start_prover.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover.ts
@@ -1,0 +1,50 @@
+import { type ProvingJobSource } from '@aztec/circuit-types';
+import { ProverPool, createProvingJobSourceClient } from '@aztec/prover-client/prover-pool';
+
+import { type ServiceStarter, parseModuleOptions } from '../util.js';
+
+type ProverOptions = Partial<{
+  proverUrl: string;
+  agents: string;
+  acvmBinaryPath?: string;
+  bbBinaryPath?: string;
+  simulate?: string;
+}>;
+
+export const startProver: ServiceStarter = async (options, signalHandlers, logger) => {
+  const proverOptions: ProverOptions = parseModuleOptions(options.prover);
+  let source: ProvingJobSource;
+
+  if (typeof proverOptions.proverUrl === 'string') {
+    logger(`Connecting to prover at ${proverOptions.proverUrl}`);
+    source = createProvingJobSourceClient(proverOptions.proverUrl, 'provingJobSource');
+  } else {
+    throw new Error('Starting prover without an orchestrator is not supported');
+  }
+
+  const agentCount = proverOptions.agents ? parseInt(proverOptions.agents, 10) : 1;
+  if (agentCount === 0 || !Number.isSafeInteger(agentCount)) {
+    throw new Error('Cannot start prover without agents');
+  }
+
+  let pool: ProverPool;
+  if (proverOptions.simulate) {
+    pool = ProverPool.testPool(undefined, agentCount);
+  } else if (proverOptions.acvmBinaryPath && proverOptions.bbBinaryPath) {
+    pool = ProverPool.nativePool(
+      {
+        acvmBinaryPath: proverOptions.acvmBinaryPath,
+        bbBinaryPath: proverOptions.bbBinaryPath,
+      },
+      agentCount,
+    );
+  } else {
+    throw new Error('Cannot start prover without simulation or native prover options');
+  }
+
+  logger(`Starting ${agentCount} prover agents`);
+  await pool.start(source);
+  signalHandlers.push(() => pool.stop());
+
+  return Promise.resolve([]);
+};

--- a/yarn-project/aztec/src/cli/util.ts
+++ b/yarn-project/aztec/src/cli/util.ts
@@ -3,9 +3,14 @@ import { type AztecNodeConfig } from '@aztec/aztec-node';
 import { type AccountManager, type Fr } from '@aztec/aztec.js';
 import { type L1ContractAddresses, l1ContractsNames } from '@aztec/ethereum';
 import { EthAddress } from '@aztec/foundation/eth-address';
+import { type ServerList } from '@aztec/foundation/json-rpc/server';
 import { type LogFn, createConsoleLogger } from '@aztec/foundation/log';
 import { type P2PConfig } from '@aztec/p2p';
 import { type PXEService, type PXEServiceConfig } from '@aztec/pxe';
+
+export interface ServiceStarter<T = any> {
+  (options: T, signalHandlers: (() => Promise<void>)[], logger: LogFn): Promise<ServerList>;
+}
 
 /**
  * Checks if the object has l1Contracts property

--- a/yarn-project/aztec/tsconfig.json
+++ b/yarn-project/aztec/tsconfig.json
@@ -52,6 +52,9 @@
       "path": "../protocol-contracts"
     },
     {
+      "path": "../prover-client"
+    },
+    {
       "path": "../pxe"
     }
   ],

--- a/yarn-project/circuit-types/src/interfaces/prover-client.ts
+++ b/yarn-project/circuit-types/src/interfaces/prover-client.ts
@@ -1,4 +1,5 @@
 import { type BlockProver } from './block-prover.js';
+import { type ProvingJobSource } from './proving-job.js';
 
 /**
  * The interface to the prover client.
@@ -8,4 +9,6 @@ export interface ProverClient extends BlockProver {
   start(): Promise<void>;
 
   stop(): Promise<void>;
+
+  getProvingJobSource(): ProvingJobSource;
 }

--- a/yarn-project/circuits.js/src/structs/kernel/kernel_circuit_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/kernel_circuit_public_inputs.ts
@@ -78,4 +78,12 @@ export class KernelCircuitPublicInputs {
       RevertCode.OK,
     );
   }
+
+  toString() {
+    return this.toBuffer().toString('hex');
+  }
+
+  static fromString(str: string) {
+    return KernelCircuitPublicInputs.fromBuffer(Buffer.from(str, 'hex'));
+  }
 }

--- a/yarn-project/circuits.js/src/structs/kernel/public_kernel_circuit_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/public_kernel_circuit_public_inputs.ts
@@ -51,6 +51,14 @@ export class PublicKernelCircuitPublicInputs {
     );
   }
 
+  toString() {
+    return this.toBuffer().toString('hex');
+  }
+
+  static fromString(str: string) {
+    return PublicKernelCircuitPublicInputs.fromBuffer(Buffer.from(str, 'hex'));
+  }
+
   get needsSetup() {
     return !this.endNonRevertibleData.publicCallStack[1].isEmpty();
   }

--- a/yarn-project/circuits.js/src/structs/kernel/public_kernel_tail_circuit_private_inputs.test.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/public_kernel_tail_circuit_private_inputs.test.ts
@@ -14,4 +14,11 @@ describe('PublicKernelTailCircuitPrivateInputs', () => {
     expect(original).toEqual(serialized);
     expect(original).not.toBe(serialized);
   });
+
+  it('serializes to string and back', () => {
+    const original = makePublicKernelTailCircuitPrivateInputs(123);
+    const str = original.toString();
+    const deserialized = PublicKernelTailCircuitPrivateInputs.fromString(str);
+    expect(original).toEqual(deserialized);
+  });
 });

--- a/yarn-project/circuits.js/src/structs/kernel/public_kernel_tail_circuit_private_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/public_kernel_tail_circuit_private_inputs.ts
@@ -41,6 +41,14 @@ export class PublicKernelTailCircuitPrivateInputs {
     );
   }
 
+  toString() {
+    return this.toBuffer().toString('hex');
+  }
+
+  static fromString(str: string) {
+    return PublicKernelTailCircuitPrivateInputs.fromBuffer(Buffer.from(str, 'hex'));
+  }
+
   static fromBuffer(buffer: Buffer | BufferReader) {
     const reader = BufferReader.asReader(buffer);
     return new PublicKernelTailCircuitPrivateInputs(

--- a/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
@@ -36,7 +36,6 @@ import { openTmpStore } from '@aztec/kv-store/utils';
 import { AvailabilityOracleAbi, InboxAbi, OutboxAbi, RollupAbi } from '@aztec/l1-artifacts';
 import { SHA256Trunc, StandardTree } from '@aztec/merkle-tree';
 import { TxProver } from '@aztec/prover-client';
-import { ProverPool } from '@aztec/prover-client/prover-pool';
 import { type L1Publisher, getL1Publisher } from '@aztec/sequencer-client';
 import { WASMSimulator } from '@aztec/simulator';
 import { MerkleTrees, ServerWorldStateSynchronizer, type WorldStateConfig } from '@aztec/world-state';
@@ -144,7 +143,7 @@ describe('L1Publisher integration', () => {
     };
     const worldStateSynchronizer = new ServerWorldStateSynchronizer(tmpStore, builderDb, blockSource, worldStateConfig);
     await worldStateSynchronizer.start();
-    builder = await TxProver.new(worldStateSynchronizer, ProverPool.testPool(new WASMSimulator(), 4));
+    builder = await TxProver.new(config, new WASMSimulator(), worldStateSynchronizer);
     l2Proof = Buffer.alloc(0);
 
     publisher = getL1Publisher({

--- a/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
@@ -36,6 +36,7 @@ import { openTmpStore } from '@aztec/kv-store/utils';
 import { AvailabilityOracleAbi, InboxAbi, OutboxAbi, RollupAbi } from '@aztec/l1-artifacts';
 import { SHA256Trunc, StandardTree } from '@aztec/merkle-tree';
 import { TxProver } from '@aztec/prover-client';
+import { ProverPool } from '@aztec/prover-client/prover-pool';
 import { type L1Publisher, getL1Publisher } from '@aztec/sequencer-client';
 import { WASMSimulator } from '@aztec/simulator';
 import { MerkleTrees, ServerWorldStateSynchronizer, type WorldStateConfig } from '@aztec/world-state';
@@ -143,7 +144,7 @@ describe('L1Publisher integration', () => {
     };
     const worldStateSynchronizer = new ServerWorldStateSynchronizer(tmpStore, builderDb, blockSource, worldStateConfig);
     await worldStateSynchronizer.start();
-    builder = await TxProver.new({}, worldStateSynchronizer, new WASMSimulator());
+    builder = await TxProver.new(worldStateSynchronizer, ProverPool.testPool(new WASMSimulator(), 4));
     l2Proof = Buffer.alloc(0);
 
     publisher = getL1Publisher({

--- a/yarn-project/prover-client/package.json
+++ b/yarn-project/prover-client/package.json
@@ -2,7 +2,10 @@
   "name": "@aztec/prover-client",
   "version": "0.1.0",
   "type": "module",
-  "exports": "./dest/index.js",
+  "exports": {
+    ".": "./dest/index.js",
+    "./prover-pool": "./dest/prover-pool/index.js"
+  },
   "bin": {
     "bb-cli": "./dest/bb/index.js"
   },

--- a/yarn-project/prover-client/src/config.ts
+++ b/yarn-project/prover-client/src/config.ts
@@ -1,11 +1,21 @@
+import { tmpdir } from 'os';
+
 /**
  * The prover configuration.
  */
 export interface ProverConfig {
   /** The working directory to use for simulation/proving */
-  acvmWorkingDirectory?: string;
+  acvmWorkingDirectory: string;
   /** The path to the ACVM binary */
-  acvmBinaryPath?: string;
+  acvmBinaryPath: string;
+  /** The working directory to for proving */
+  bbWorkingDirectory: string;
+  /** The path to the bb binary */
+  bbBinaryPath: string;
+  /** How many agents to start */
+  proverAgents: number;
+  /** Enable proving. If true, must set bb env vars */
+  realProofs: boolean;
 }
 
 /**
@@ -13,10 +23,25 @@ export interface ProverConfig {
  * Note: If an environment variable is not set, the default value is used.
  * @returns The prover configuration.
  */
-export function getConfigEnvVars(): ProverConfig {
-  const { ACVM_WORKING_DIRECTORY, ACVM_BINARY_PATH } = process.env;
+export function getProverEnvVars(): ProverConfig {
+  const {
+    ACVM_WORKING_DIRECTORY = tmpdir(),
+    ACVM_BINARY_PATH = '',
+    BB_WORKING_DIRECTORY = tmpdir(),
+    BB_BINARY_PATH = '',
+    PROVER_AGENTS = '1',
+    PROVER_REAL_PROOFS = '',
+  } = process.env;
+
+  const parsedProverAgents = parseInt(PROVER_AGENTS, 10);
+  const proverAgents = Number.isSafeInteger(parsedProverAgents) ? parsedProverAgents : 0;
+
   return {
-    acvmWorkingDirectory: ACVM_WORKING_DIRECTORY ? ACVM_WORKING_DIRECTORY : undefined,
-    acvmBinaryPath: ACVM_BINARY_PATH ? ACVM_BINARY_PATH : undefined,
+    acvmWorkingDirectory: ACVM_WORKING_DIRECTORY,
+    acvmBinaryPath: ACVM_BINARY_PATH,
+    bbBinaryPath: BB_BINARY_PATH,
+    bbWorkingDirectory: BB_WORKING_DIRECTORY,
+    proverAgents,
+    realProofs: PROVER_REAL_PROOFS === '1',
   };
 }

--- a/yarn-project/prover-client/src/config.ts
+++ b/yarn-project/prover-client/src/config.ts
@@ -42,6 +42,6 @@ export function getProverEnvVars(): ProverConfig {
     bbBinaryPath: BB_BINARY_PATH,
     bbWorkingDirectory: BB_WORKING_DIRECTORY,
     proverAgents,
-    realProofs: PROVER_REAL_PROOFS === '1',
+    realProofs: ['1', 'true'].includes(PROVER_REAL_PROOFS),
   };
 }

--- a/yarn-project/prover-client/src/dummy-prover.ts
+++ b/yarn-project/prover-client/src/dummy-prover.ts
@@ -4,6 +4,9 @@ import {
   PROVING_STATUS,
   type ProcessedTx,
   type ProverClient,
+  type ProvingJob,
+  type ProvingJobSource,
+  type ProvingRequest,
   type ProvingSuccess,
   type ProvingTicket,
 } from '@aztec/circuit-types';
@@ -11,6 +14,8 @@ import { type GlobalVariables, makeEmptyProof } from '@aztec/circuits.js';
 import { type Fr } from '@aztec/foundation/fields';
 
 export class DummyProver implements ProverClient {
+  jobs = new DummyProvingJobSource();
+
   public start(): Promise<void> {
     return Promise.resolve();
   }
@@ -52,6 +57,24 @@ export class DummyProver implements ProverClient {
   }
 
   setBlockCompleted(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  getProvingJobSource(): ProvingJobSource {
+    return this.jobs;
+  }
+}
+
+class DummyProvingJobSource implements ProvingJobSource {
+  getProvingJob(): Promise<ProvingJob<ProvingRequest> | null> {
+    return Promise.resolve(null);
+  }
+
+  rejectProvingJob(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  resolveProvingJob(): Promise<void> {
     return Promise.resolve();
   }
 }

--- a/yarn-project/prover-client/src/prover-pool/index.ts
+++ b/yarn-project/prover-client/src/prover-pool/index.ts
@@ -1,3 +1,4 @@
 export * from './prover-agent.js';
 export * from './memory-proving-queue.js';
 export * from './prover-pool.js';
+export * from './rpc.js';

--- a/yarn-project/prover-client/src/prover-pool/prover-agent.ts
+++ b/yarn-project/prover-client/src/prover-pool/prover-agent.ts
@@ -47,7 +47,7 @@ export class ProverAgent {
         this.log.error(
           `Error processing proving job id=${job.id} type=${ProvingRequestType[job.request.type]}: ${err}`,
         );
-        await queue.rejectProvingJob(job.id, new ProvingError(String(err)));
+        await queue.rejectProvingJob(job.id, new ProvingError((err as any)?.message ?? String(err)));
       }
     }, this.intervalMs);
 

--- a/yarn-project/prover-client/src/prover-pool/prover-agent.ts
+++ b/yarn-project/prover-client/src/prover-pool/prover-agent.ts
@@ -11,6 +11,7 @@ import { RunningPromise } from '@aztec/foundation/running-promise';
 import { elapsed } from '@aztec/foundation/timer';
 
 import { type CircuitProver } from '../prover/interface.js';
+import { ProvingError } from './proving-error.js';
 
 export class ProverAgent {
   private runningPromise?: RunningPromise;
@@ -46,7 +47,7 @@ export class ProverAgent {
         this.log.error(
           `Error processing proving job id=${job.id} type=${ProvingRequestType[job.request.type]}: ${err}`,
         );
-        await queue.rejectProvingJob(job.id, err as Error);
+        await queue.rejectProvingJob(job.id, new ProvingError(String(err)));
       }
     }, this.intervalMs);
 

--- a/yarn-project/prover-client/src/prover-pool/proving-error.ts
+++ b/yarn-project/prover-client/src/prover-pool/proving-error.ts
@@ -1,0 +1,9 @@
+export class ProvingError extends Error {
+  override toString() {
+    return this.message;
+  }
+
+  static fromString(message: string) {
+    return new ProvingError(message);
+  }
+}

--- a/yarn-project/prover-client/src/prover-pool/rpc.ts
+++ b/yarn-project/prover-client/src/prover-pool/rpc.ts
@@ -1,0 +1,73 @@
+import { type ProvingJobSource } from '@aztec/circuit-types';
+import {
+  BaseOrMergeRollupPublicInputs,
+  BaseParityInputs,
+  BaseRollupInputs,
+  KernelCircuitPublicInputs,
+  MergeRollupInputs,
+  ParityPublicInputs,
+  Proof,
+  PublicKernelCircuitPrivateInputs,
+  PublicKernelCircuitPublicInputs,
+  PublicKernelTailCircuitPrivateInputs,
+  RootParityInputs,
+  RootRollupInputs,
+  RootRollupPublicInputs,
+} from '@aztec/circuits.js';
+import { createJsonRpcClient, makeFetch } from '@aztec/foundation/json-rpc/client';
+import { JsonRpcServer } from '@aztec/foundation/json-rpc/server';
+
+import { ProvingError } from './proving-error.js';
+
+export function createProvingJobSourceServer(queue: ProvingJobSource): JsonRpcServer {
+  return new JsonRpcServer(
+    queue,
+    {
+      BaseParityInputs,
+      BaseOrMergeRollupPublicInputs,
+      BaseRollupInputs,
+      MergeRollupInputs,
+      ParityPublicInputs,
+      Proof,
+      RootParityInputs,
+      RootRollupInputs,
+      RootRollupPublicInputs,
+      PublicKernelCircuitPrivateInputs,
+      PublicKernelCircuitPublicInputs,
+      PublicKernelTailCircuitPrivateInputs,
+      KernelCircuitPublicInputs,
+      ProvingError,
+    },
+    {},
+  );
+}
+
+export function createProvingJobSourceClient(
+  url: string,
+  namespace?: string,
+  fetch = makeFetch([1, 2, 3], false),
+): ProvingJobSource {
+  return createJsonRpcClient(
+    url,
+    {
+      BaseParityInputs,
+      BaseOrMergeRollupPublicInputs,
+      BaseRollupInputs,
+      MergeRollupInputs,
+      ParityPublicInputs,
+      Proof,
+      RootParityInputs,
+      RootRollupInputs,
+      RootRollupPublicInputs,
+      PublicKernelCircuitPrivateInputs,
+      PublicKernelCircuitPublicInputs,
+      PublicKernelTailCircuitPrivateInputs,
+      KernelCircuitPublicInputs,
+      ProvingError,
+    },
+    {},
+    false,
+    namespace,
+    fetch,
+  ) as ProvingJobSource;
+}

--- a/yarn-project/prover-client/src/prover/test_circuit_prover.ts
+++ b/yarn-project/prover-client/src/prover/test_circuit_prover.ts
@@ -71,7 +71,7 @@ export class TestCircuitProver implements CircuitProver {
   private wasmSimulator = new WASMSimulator();
 
   constructor(
-    private simulationProvider: SimulationProvider,
+    private simulationProvider?: SimulationProvider,
     private logger = createDebugLogger('aztec:test-prover'),
   ) {}
 
@@ -131,7 +131,8 @@ export class TestCircuitProver implements CircuitProver {
   ): Promise<PublicInputsAndProof<BaseOrMergeRollupPublicInputs>> {
     const witnessMap = convertSimulatedBaseRollupInputsToWitnessMap(input);
 
-    const witness = await this.simulationProvider.simulateCircuit(witnessMap, SimulatedBaseRollupArtifact);
+    const simulationProvider = this.simulationProvider ?? this.wasmSimulator;
+    const witness = await simulationProvider.simulateCircuit(witnessMap, SimulatedBaseRollupArtifact);
 
     const result = convertSimulatedBaseRollupOutputsFromWitnessMap(witness);
 

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -207,6 +207,7 @@ __metadata:
     "@aztec/noir-contracts.js": "workspace:^"
     "@aztec/p2p": "workspace:^"
     "@aztec/protocol-contracts": "workspace:^"
+    "@aztec/prover-client": "workspace:^"
     "@aztec/pxe": "workspace:^"
     "@jest/globals": ^29.5.0
     "@types/jest": ^29.5.0


### PR DESCRIPTION
Update the `aztec` command to allow running as an independent prover connected to a prover pool
