### PR TITLE
chore(ci): make syncing out to Noir manual

### DIFF
--- a/.github/workflows/mirror-noir-subrepo.yml
+++ b/.github/workflows/mirror-noir-subrepo.yml
@@ -9,12 +9,6 @@ concurrency:
   cancel-in-progress: false
 on:
   workflow_dispatch: {}
-  push:
-    branches:
-      - master
-    paths:
-      - "noir/noir-repo/**"
-      - "!noir/noir-repo/.gitrepo"
 
 jobs:
   mirror_repo:


### PR DESCRIPTION
Most of the sync PRs being pushed into Noir are massive and revert significant amounts of Noir development.

In order to sync from aztec-packages without having to manually separate out all of these reversions, it's required to do a manual sync from the main noir repo  into aztec-packages first and then sync out again. We should then make this second sync manual as well.