### PR TITLE
fix: refuse to start sequencer without a prover

### DIFF
--- a/yarn-project/aztec/src/cli/cmds/start_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_node.ts
@@ -67,6 +67,10 @@ export const startNode = async (
     nodeConfig.disableProver = true;
   }
 
+  if (!nodeConfig.disableSequencer && nodeConfig.disableProver) {
+    throw new Error('Cannot run a sequencer without a prover');
+  }
+
   // Create and start Aztec Node.
   const node = await createAztecNode(nodeConfig);
   const nodeServer = createAztecNodeRpcServer(node);


### PR DESCRIPTION
Avoids a bad situation where a sequencer node produces empty blocks that fail to validate in the rollup contract.
