### PR TITLE
fix: bigint corruption in lmdb

### DIFF
--- a/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
@@ -29,6 +29,7 @@ describe('e2e_2_pxes', () => {
   let walletB: Wallet;
   let logger: DebugLogger;
   let teardownA: () => Promise<void>;
+  let teardownB: () => Promise<void>;
 
   beforeEach(async () => {
     ({
@@ -42,14 +43,13 @@ describe('e2e_2_pxes', () => {
     ({
       pxe: pxeB,
       wallets: [walletB],
+      teardown: teardownB,
     } = await setupPXEService(1, aztecNode!, {}, undefined, true));
   }, 100_000);
 
   afterEach(async () => {
+    await teardownB();
     await teardownA();
-    if ((pxeB as any).stop) {
-      await (pxeB as any).stop();
-    }
   });
 
   const awaitUserSynchronized = async (wallet: Wallet, owner: AztecAddress) => {

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -196,16 +196,25 @@ export async function setupPXEService(
    * Logger instance named as the current test.
    */
   logger: DebugLogger;
+  /**
+   * Teardown function
+   */
+  teardown: () => Promise<void>;
 }> {
   const pxeServiceConfig = { ...getPXEServiceConfig(), ...opts };
   const pxe = await createPXEService(aztecNode, pxeServiceConfig, useLogSuffix);
 
   const wallets = await createAccounts(pxe, numberOfAccounts);
 
+  const teardown = async () => {
+    await pxe.stop();
+  };
+
   return {
     pxe,
     wallets,
     logger,
+    teardown,
   };
 }
 

--- a/yarn-project/pxe/src/database/kv_pxe_database.ts
+++ b/yarn-project/pxe/src/database/kv_pxe_database.ts
@@ -189,7 +189,7 @@ export class KVPxeDatabase implements PxeDatabase {
   removeDeferredNotesByContract(contractAddress: AztecAddress): Promise<DeferredNoteDao[]> {
     return this.#db.transaction(() => {
       const deferredNotes: DeferredNoteDao[] = [];
-      const indices = this.#deferredNotesByContract.getValues(contractAddress.toString());
+      const indices = Array.from(this.#deferredNotesByContract.getValues(contractAddress.toString()));
 
       for (const index of indices) {
         const deferredNoteBuffer = this.#deferredNotes.at(index);


### PR DESCRIPTION
An attempt at fixing the bigint decoding corruption that we've seen sporradically in CI.

The fix saves all of the deferred note ids linked to contract to an array before iterating them
