### PR TITLE
chore: Reset noir-gates-diff report on master 

### DIFF
--- a/.github/workflows/protocol-circuits-gate-diff.yml
+++ b/.github/workflows/protocol-circuits-gate-diff.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Compare gates reports
         id: gates_diff
-        uses: TomAFrench/noir-gates-diff@df05f34e2ab275ddc4f2cac065df1c88f8a05e5d
+        uses: vezenovm/noir-gates-diff@45e9c9a21deb236fa7f38138b42b33ddaf7c0985
         with:
           report: protocol_circuits_report.json
           summaryQuantile: 0 # Display any diff in gate count


### PR DESCRIPTION
Similarly to https://github.com/noir-lang/noir/pull/4878 the gates diff report got corrupted following changes to `nargo info`. This PR simply resets the gates diff so it is expected to see really large gates differences. You can look into the Noir PR for more info. There will be a followup which sets back to the correct noir-gates-diff commit. Without this reset we will not be able to get accurate gate diffs based off of master.
