### PR TITLE
fix: Use correct gates diff commit now that master has been reset

### DIFF
--- a/.github/workflows/protocol-circuits-gate-diff.yml
+++ b/.github/workflows/protocol-circuits-gate-diff.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Compare gates reports
         id: gates_diff
-        uses: TomAFrench/noir-gates-diff@df05f34e2ab275ddc4f2cac065df1c88f8a05e5d
+        uses: vezenovm/noir-gates-diff@45e9c9a21deb236fa7f38138b42b33ddaf7c0985
         with:
           report: protocol_circuits_report.json
           summaryQuantile: 0 # Display any diff in gate count

--- a/.github/workflows/protocol-circuits-gate-diff.yml
+++ b/.github/workflows/protocol-circuits-gate-diff.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Compare gates reports
         id: gates_diff
-        uses: vezenovm/noir-gates-diff@45e9c9a21deb236fa7f38138b42b33ddaf7c0985
+        uses: vezenovm/noir-gates-diff@acf12797860f237117e15c0d6e08d64253af52b6
         with:
           report: protocol_circuits_report.json
           summaryQuantile: 0 # Display any diff in gate count


### PR DESCRIPTION
Follow-up to https://github.com/AztecProtocol/aztec-packages/pull/6003. This PR simply updates to using a noir gates diff that expects an uncorrupted comparison report on master.
