### PR TITLE
chore: rename capture to end_setup

### DIFF
--- a/noir-projects/aztec-nr/authwit/src/account.nr
+++ b/noir-projects/aztec-nr/authwit/src/account.nr
@@ -62,7 +62,7 @@ impl AccountActions {
         let fee_hash = fee_payload.hash();
         assert(valid_fn(private_context, fee_hash));
         fee_payload.execute_calls(private_context);
-        private_context.capture_min_revertible_side_effect_counter();
+        private_context.end_setup();
 
         let app_hash = app_payload.hash();
         assert(valid_fn(private_context, app_hash));

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -192,7 +192,7 @@ impl PrivateContext {
         priv_circuit_pub_inputs
     }
 
-    pub fn capture_min_revertible_side_effect_counter(&mut self) {
+    pub fn end_setup(&mut self) {
         self.min_revertible_side_effect_counter = self.side_effect_counter;
     }
 

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -49,7 +49,7 @@ contract AppSubscription {
 
         GasToken::at(storage.gas_token_address.read_private()).pay_fee(42).enqueue(&mut context);
 
-        context.capture_min_revertible_side_effect_counter();
+        context.end_setup();
 
         AppSubscription::at(context.this_address()).assert_not_expired(note.expiry_block_number).enqueue(&mut context);
 

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail_to_public.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail_to_public.nr
@@ -57,7 +57,7 @@ impl PrivateKernelTailToPublicCircuitPrivateInputs {
             self.sorted_encrypted_log_hashes,
             self.sorted_encrypted_log_hashes_indexes,
             self.sorted_unencrypted_log_hashes,
-            self.sorted_unencrypted_log_hashes_indexes,
+            self.sorted_unencrypted_log_hashes_indexes
         );
         composer.compose_public().finish_to_public()
     }
@@ -196,7 +196,7 @@ mod tests {
                 sorted_encrypted_log_hashes_indexes,
                 sorted_unencrypted_log_hashes,
                 sorted_unencrypted_log_hashes_indexes,
-                master_nullifier_secret_keys: [GrumpkinPrivateKey::empty(); MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_TX],
+                master_nullifier_secret_keys: [GrumpkinPrivateKey::empty(); MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_TX]
             };
             kernel.execute()
         }
@@ -465,7 +465,7 @@ mod tests {
         let mut builder = PrivateKernelTailToPublicInputsBuilder::new();
         // expect 3 non-revertible nullifiers: the tx nullifier + 2 new ones
         builder.previous_kernel.append_new_nullifiers(2);
-        builder.previous_kernel.capture_min_revertible_side_effect_counter();
+        builder.previous_kernel.end_setup();
 
         // expect 2 revertible nullifiers
         builder.previous_kernel.append_new_nullifiers(2);
@@ -494,7 +494,7 @@ mod tests {
 
         // expect 2 non-revertible commitments
         builder.previous_kernel.append_new_note_hashes(2);
-        builder.previous_kernel.capture_min_revertible_side_effect_counter();
+        builder.previous_kernel.end_setup();
 
         // expect 2 revertible commitments
         builder.previous_kernel.append_new_note_hashes(2);
@@ -525,7 +525,7 @@ mod tests {
 
         // add one hash in non-revertible part
         builder.previous_kernel.append_new_note_hashes(1);
-        builder.previous_kernel.capture_min_revertible_side_effect_counter();
+        builder.previous_kernel.end_setup();
 
         // nullify it in revertible part
         builder.previous_kernel.append_new_nullifiers(1);

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -374,7 +374,7 @@ impl FixtureBuilder {
         self.public_call_stack.push(call_stack_item);
     }
 
-    pub fn capture_min_revertible_side_effect_counter(&mut self) {
+    pub fn end_setup(&mut self) {
         self.min_revertible_side_effect_counter = self.counter;
     }
 


### PR DESCRIPTION
Rename `capture_min_revertible_side_effect_counter` to `end_setup`