### PR TITLE
feat: AES oracle padding

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/oracle/encryption.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/encryption.nr
@@ -1,7 +1,7 @@
 
 #[oracle(aes128Encrypt)]
-pub fn aes128_encrypt_oracle<N>(input: [u8; N], iv: [u8; 16], key: [u8; 16]) -> [u8; N] {}
+pub fn aes128_encrypt_oracle<N, M>(input: [u8; N], iv: [u8; 16], key: [u8; 16]) -> [u8; M] {}
 
-unconstrained pub fn aes128_encrypt<N>(input: [u8; N], iv: [u8; 16], key: [u8; 16]) -> [u8; N] {
+unconstrained pub fn aes128_encrypt<N, M>(input: [u8; N], iv: [u8; 16], key: [u8; 16]) -> [u8; M] {
     aes128_encrypt_oracle(input, iv, key)
 }

--- a/noir-projects/aztec-nr/aztec/src/oracle/encryption.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/encryption.nr
@@ -2,6 +2,8 @@
 #[oracle(aes128Encrypt)]
 pub fn aes128_encrypt_oracle<N, M>(input: [u8; N], iv: [u8; 16], key: [u8; 16]) -> [u8; M] {}
 
+// AES 128 CBC with PKCS7 is padding to multiples of 16 bytes so M has to be a multiple of 16!
+// (e.g. from 65 bytes long input you get 80 bytes long output and M has to be set to `80`)
 unconstrained pub fn aes128_encrypt<N, M>(input: [u8; N], iv: [u8; 16], key: [u8; 16]) -> [u8; M] {
     aes128_encrypt_oracle(input, iv, key)
 }

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -314,6 +314,11 @@ contract Test {
         aes128_encrypt(input, iv, key)
     }
 
+    #[aztec(private)]
+    fn encrypt_with_padding(input: [u8; 65], iv: [u8; 16], key: [u8; 16]) -> [u8; 80] {
+        aes128_encrypt(input, iv, key)
+    }
+
     #[aztec(public)]
     fn assert_public_global_vars(
         chain_id: Field,

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -310,9 +310,8 @@ contract Test {
     }
 
     #[aztec(private)]
-    fn encrypt(input: [u8; 64], iv: [u8; 16], key: [u8; 16]) {
-        let result = aes128_encrypt(input, iv, key);
-        context.emit_unencrypted_log(result);
+    fn encrypt(input: [u8; 64], iv: [u8; 16], key: [u8; 16]) -> [u8; 64] {
+        aes128_encrypt(input, iv, key)
     }
 
     #[aztec(public)]

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -110,7 +110,14 @@
         "@swc/jest"
       ]
     },
-    "reporters": [["default", {"summaryThreshold": 9999}]],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
+    ],
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.[cm]?js$": "$1"
     },

--- a/yarn-project/end-to-end/src/e2e_encryption.test.ts
+++ b/yarn-project/end-to-end/src/e2e_encryption.test.ts
@@ -21,14 +21,34 @@ describe('e2e_encryption', () => {
 
   afterAll(() => teardown());
 
-  it('encrypts 🔒📄🔑💻', async () => {
+  it('🔒📄🔑💻', async () => {
     const input = randomBytes(64);
     const iv = randomBytes(16);
     const key = randomBytes(16);
 
     const expectedCiphertext = aes128.encryptBufferCBC(input, iv, key);
 
-    const ciphertext = await contract.methods.encrypt(Array.from(input), Array.from(iv), Array.from(key)).simulate();
+    const ciphertextAsBigInts = await contract.methods
+      .encrypt(Array.from(input), Array.from(iv), Array.from(key))
+      .simulate();
+    const ciphertext = Buffer.from(ciphertextAsBigInts.map((x: bigint) => Number(x)));
+
+    expect(ciphertext).toEqual(expectedCiphertext);
+  });
+
+  it('🔒📄🔑💻 with padding', async () => {
+    const input = randomBytes(65);
+    const iv = randomBytes(16);
+    const key = randomBytes(16);
+
+    const expectedCiphertext = aes128.encryptBufferCBC(input, iv, key);
+    // AES 128 CBC with PKCS7 is padding to multiples of 16 bytes so from 65 bytes long input we get 80 bytes long output
+    expect(expectedCiphertext.length).toBe(80);
+
+    const ciphertextAsBigInts = await contract.methods
+      .encrypt_with_padding(Array.from(input), Array.from(iv), Array.from(key))
+      .simulate();
+    const ciphertext = Buffer.from(ciphertextAsBigInts.map((x: bigint) => Number(x)));
 
     expect(ciphertext).toEqual(expectedCiphertext);
   });

--- a/yarn-project/end-to-end/src/e2e_encryption.test.ts
+++ b/yarn-project/end-to-end/src/e2e_encryption.test.ts
@@ -21,21 +21,15 @@ describe('e2e_encryption', () => {
 
   afterAll(() => teardown());
 
-  it('encrypts', async () => {
+  it('encrypts 🔒📄🔑💻', async () => {
     const input = randomBytes(64);
     const iv = randomBytes(16);
     const key = randomBytes(16);
 
     const expectedCiphertext = aes128.encryptBufferCBC(input, iv, key);
 
-    const logs = await contract.methods
-      .encrypt(Array.from(input), Array.from(iv), Array.from(key))
-      .send()
-      .getUnencryptedLogs();
-    // Each byte of encrypted data is in its own field and it's all serialized into a long buffer so we simply extract
-    // each 32nd byte from the buffer to get the encrypted data
-    const recoveredCiphertext = logs.logs[0].log.data.filter((_, i) => (i + 1) % 32 === 0);
+    const ciphertext = await contract.methods.encrypt(Array.from(input), Array.from(iv), Array.from(key)).simulate();
 
-    expect(recoveredCiphertext).toEqual(expectedCiphertext);
+    expect(ciphertext).toEqual(expectedCiphertext);
   });
 });

--- a/yarn-project/end-to-end/src/e2e_encryption.test.ts
+++ b/yarn-project/end-to-end/src/e2e_encryption.test.ts
@@ -21,7 +21,7 @@ describe('e2e_encryption', () => {
 
   afterAll(() => teardown());
 
-  it('🔒📄🔑💻', async () => {
+  it('encrypts 🔒📄🔑💻', async () => {
     const input = randomBytes(64);
     const iv = randomBytes(16);
     const key = randomBytes(16);
@@ -36,7 +36,7 @@ describe('e2e_encryption', () => {
     expect(ciphertext).toEqual(expectedCiphertext);
   });
 
-  it('🔒📄🔑💻 with padding', async () => {
+  it('encrypts with padding 🔒📄🔑💻 ➕ 📦', async () => {
     const input = randomBytes(65);
     const iv = randomBytes(16);
     const key = randomBytes(16);


### PR DESCRIPTION
Supporting PCKS#7 padding in AES oracle. Making boss not angry and using return values instead of unencrypted log.

@signorecello I didn't use slices like [you mentioned yesterday](https://aztecprotocol.slack.com/archives/C04PUD9AA4W/p1713952777399339?thread_ts=1713952573.202899&cid=C04PUD9AA4W) and instead I forced the dev to set the return length via generics because:
1. It's simple,
2. we will most likely want to have note ciphertexts of fixed length anyway to not leak privacy so the dev might not need to be forced to count the ciphertext length and manually set and instead would use some constant.