### PR TITLE
refactor: improved naming in `TxExecutionRequest`

### DIFF
--- a/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
@@ -91,11 +91,11 @@ export class ContractFunctionInteraction extends BaseContractInteraction {
       const gasSettings = options.gasSettings ?? GasSettings.simulation();
 
       const txRequest = TxExecutionRequest.from({
-        argsHash: packedArgs.hash,
+        firstCallArgsHash: packedArgs.hash,
         origin: this.contractAddress,
         functionData: FunctionData.fromAbi(this.functionDao),
         txContext: new TxContext(nodeInfo.chainId, nodeInfo.protocolVersion, gasSettings),
-        packedArguments: [packedArgs],
+        argsOfCalls: [packedArgs],
         authWitnesses: [],
       });
       const simulatedTx = await this.pxe.simulateTx(txRequest, true, options.from ?? this.wallet.getAddress());

--- a/yarn-project/aztec.js/src/entrypoint/default_multi_call_entrypoint.ts
+++ b/yarn-project/aztec.js/src/entrypoint/default_multi_call_entrypoint.ts
@@ -22,11 +22,11 @@ export class DefaultMultiCallEntrypoint implements EntrypointInterface {
     const gasSettings = executions.fee?.gasSettings ?? GasSettings.default();
 
     const txRequest = TxExecutionRequest.from({
-      argsHash: entrypointPackedArgs.hash,
+      firstCallArgsHash: entrypointPackedArgs.hash,
       origin: this.address,
       functionData: FunctionData.fromAbi(abi),
       txContext: new TxContext(this.chainId, this.version, gasSettings),
-      packedArguments: [...payload.packedArguments, ...packedArguments, entrypointPackedArgs],
+      argsOfCalls: [...payload.packedArguments, ...packedArguments, entrypointPackedArgs],
       authWitnesses,
     });
 

--- a/yarn-project/circuit-types/src/packed_values.ts
+++ b/yarn-project/circuit-types/src/packed_values.ts
@@ -7,15 +7,15 @@ import { type FieldsOf } from '@aztec/foundation/types';
  * Packs a set of values into a hash.
  */
 export class PackedValues {
-  constructor(
+  private constructor(
     /**
      *  Raw values.
      */
-    public values: Fr[],
+    public readonly values: Fr[],
     /**
      * The hash of the raw values
      */
-    public hash: Fr,
+    public readonly hash: Fr,
   ) {}
 
   static getFields(fields: FieldsOf<PackedValues>) {

--- a/yarn-project/circuit-types/src/packed_values.ts
+++ b/yarn-project/circuit-types/src/packed_values.ts
@@ -1,7 +1,6 @@
 import { Fr, Vector } from '@aztec/circuits.js';
 import { computeVarArgsHash } from '@aztec/circuits.js/hash';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
-import { type FieldsOf } from '@aztec/foundation/types';
 
 /**
  * Packs a set of values into a hash.
@@ -17,14 +16,6 @@ export class PackedValues {
      */
     public readonly hash: Fr,
   ) {}
-
-  static getFields(fields: FieldsOf<PackedValues>) {
-    return [fields.values, fields.hash] as const;
-  }
-
-  static from(fields: FieldsOf<PackedValues>): PackedValues {
-    return new PackedValues(...PackedValues.getFields(fields));
-  }
 
   static fromValues(values: Fr[]) {
     return new PackedValues(values, computeVarArgsHash(values));

--- a/yarn-project/circuit-types/src/tx_execution_request.ts
+++ b/yarn-project/circuit-types/src/tx_execution_request.ts
@@ -20,19 +20,20 @@ export class TxExecutionRequest {
      */
     public functionData: FunctionData,
     /**
-     * The hash of the entry point arguments.
+     * The hash of arguments of first call to be executed (usually account entrypoint).
+     * @dev This hash is a pointer to `argsOfCalls` unordered array.
      */
-    public argsHash: Fr,
+    public firstCallArgsHash: Fr,
     /**
      * Transaction context.
      */
     public txContext: TxContext,
     /**
-     * These packed arguments will be used during transaction simulation.
-     * For example, a call to an account contract might contain as many packed arguments
-     * as relayed function calls, and one for the entrypoint.
+     * An unordered array of packed arguments for each call in the transaction.
+     * @dev These arguments are accessed in Noir via oracle and constrained against the args hash. The length of
+     * the array is equal to the number of function calls in the transaction (1 args per 1 call).
      */
-    public packedArguments: PackedValues[],
+    public argsOfCalls: PackedValues[],
     /**
      * Transient authorization witnesses for authorizing the execution of one or more actions during this tx.
      * These witnesses are not expected to be stored in the local witnesses database of the PXE.
@@ -41,16 +42,16 @@ export class TxExecutionRequest {
   ) {}
 
   toTxRequest(): TxRequest {
-    return new TxRequest(this.origin, this.functionData, this.argsHash, this.txContext);
+    return new TxRequest(this.origin, this.functionData, this.firstCallArgsHash, this.txContext);
   }
 
   static getFields(fields: FieldsOf<TxExecutionRequest>) {
     return [
       fields.origin,
       fields.functionData,
-      fields.argsHash,
+      fields.firstCallArgsHash,
       fields.txContext,
-      fields.packedArguments,
+      fields.argsOfCalls,
       fields.authWitnesses,
     ] as const;
   }
@@ -67,9 +68,9 @@ export class TxExecutionRequest {
     return serializeToBuffer(
       this.origin,
       this.functionData,
-      this.argsHash,
+      this.firstCallArgsHash,
       this.txContext,
-      new Vector(this.packedArguments),
+      new Vector(this.argsOfCalls),
       new Vector(this.authWitnesses),
     );
   }

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -110,7 +110,14 @@
         "@swc/jest"
       ]
     },
-    "reporters": [["default", {"summaryThreshold": 9999}]],
+    "reporters": [
+      [
+        "default",
+        {
+          "summaryThreshold": 9999
+        }
+      ]
+    ],
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.[cm]?js$": "$1"
     },

--- a/yarn-project/entrypoints/src/account_entrypoint.ts
+++ b/yarn-project/entrypoints/src/account_entrypoint.ts
@@ -31,11 +31,11 @@ export class DefaultAccountEntrypoint implements EntrypointInterface {
     const feeAuthWitness = await this.auth.createAuthWit(feePayload.hash());
 
     const txRequest = TxExecutionRequest.from({
-      argsHash: entrypointPackedArgs.hash,
+      firstCallArgsHash: entrypointPackedArgs.hash,
       origin: this.address,
       functionData: FunctionData.fromAbi(abi),
       txContext: new TxContext(this.chainId, this.version, gasSettings),
-      packedArguments: [...appPayload.packedArguments, ...feePayload.packedArguments, entrypointPackedArgs],
+      argsOfCalls: [...appPayload.packedArguments, ...feePayload.packedArguments, entrypointPackedArgs],
       authWitnesses: [appAuthWitness, feeAuthWitness],
     });
 

--- a/yarn-project/entrypoints/src/dapp_entrypoint.ts
+++ b/yarn-project/entrypoints/src/dapp_entrypoint.ts
@@ -44,11 +44,11 @@ export class DefaultDappEntrypoint implements EntrypointInterface {
     const authWitness = await this.userAuthWitnessProvider.createAuthWit(outerHash);
 
     const txRequest = TxExecutionRequest.from({
-      argsHash: entrypointPackedArgs.hash,
+      firstCallArgsHash: entrypointPackedArgs.hash,
       origin: this.dappEntrypointAddress,
       functionData,
       txContext: new TxContext(this.chainId, this.version, gasSettings),
-      packedArguments: [...payload.packedArguments, entrypointPackedArgs],
+      argsOfCalls: [...payload.packedArguments, entrypointPackedArgs],
       authWitnesses: [authWitness],
     });
 

--- a/yarn-project/pxe/src/pxe_service/test/pxe_test_suite.ts
+++ b/yarn-project/pxe/src/pxe_service/test/pxe_test_suite.ts
@@ -125,10 +125,10 @@ export const pxeTestSuite = (testName: string, pxeSetup: () => Promise<PXE>) => 
       functionData.isPrivate = false;
       const txExecutionRequest = TxExecutionRequest.from({
         origin: AztecAddress.random(),
-        argsHash: new Fr(0),
+        firstCallArgsHash: new Fr(0),
         functionData,
         txContext: TxContext.empty(),
-        packedArguments: [],
+        argsOfCalls: [],
         authWitnesses: [],
       });
 

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -113,10 +113,10 @@ describe('Private Execution test suite', () => {
     const functionData = FunctionData.fromAbi(artifact);
     const txRequest = TxExecutionRequest.from({
       origin: contractAddress,
-      argsHash: packedArguments.hash,
+      firstCallArgsHash: packedArguments.hash,
       functionData,
       txContext: TxContext.from({ ...txContextFields, ...txContext }),
-      packedArguments: [packedArguments],
+      argsOfCalls: [packedArguments],
       authWitnesses: [],
     });
 

--- a/yarn-project/simulator/src/client/simulator.ts
+++ b/yarn-project/simulator/src/client/simulator.ts
@@ -96,12 +96,12 @@ export class AcirSimulator {
     );
     const context = new ClientExecutionContext(
       contractAddress,
-      request.argsHash,
+      request.firstCallArgsHash,
       request.txContext,
       callContext,
       header,
       request.authWitnesses,
-      PackedValuesCache.create(request.packedArguments),
+      PackedValuesCache.create(request.argsOfCalls),
       new ExecutionNoteCache(),
       this.db,
       curve,


### PR DESCRIPTION
Improved naming based on [this discussion](https://aztecprotocol.slack.com/archives/C02M7VC7TN0/p1713943047832089).

I went with `argsOfCalls` since I think it's a bit more readable than `callsArgs`.