### PR TITLE
chore: Do not bootstrap cache if working copy is dirty

### DIFF
--- a/avm-transpiler/bootstrap_cache.sh
+++ b/avm-transpiler/bootstrap_cache.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 source ../build-system/scripts/setup_env '' '' mainframe_$USER > /dev/null
 
 echo -e "\033[1mRetrieving avm-transpiler from remote cache...\033[0m"
-extract_repo avm-transpiler \
+extract_repo_if_working_copy_clean avm-transpiler \
   /usr/src/avm-transpiler/target/release/avm-transpiler ./target/release/
 
 remove_old_images avm-transpiler

--- a/barretenberg/cpp/bootstrap_cache.sh
+++ b/barretenberg/cpp/bootstrap_cache.sh
@@ -5,11 +5,11 @@ cd "$(dirname "$0")"
 source ../../build-system/scripts/setup_env '' '' mainframe_$USER > /dev/null
 
 echo -e "\033[1mRetrieving bb binary from remote cache...\033[0m"
-extract_repo barretenberg-x86_64-linux-clang \
+extract_repo_if_working_copy_clean barretenberg-x86_64-linux-clang \
   /usr/src/barretenberg/cpp/build/bin ./build
 
 echo -e "\033[1mRetrieving bb.wasm from remote cache...\033[0m"
-extract_repo barretenberg-wasm-linux-clang \
+extract_repo_if_working_copy_clean barretenberg-wasm-linux-clang \
   /usr/src/barretenberg/cpp/build-wasm/bin ./build-wasm \
   /usr/src/barretenberg/cpp/build-wasm-threads/bin ./build-wasm-threads
 

--- a/barretenberg/ts/bootstrap_cache.sh
+++ b/barretenberg/ts/bootstrap_cache.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 source ../../build-system/scripts/setup_env '' '' mainframe_$USER > /dev/null
 
 echo -e "\033[1mRetrieving bb.js from remote cache...\033[0m"
-extract_repo bb.js /usr/src/barretenberg/ts/dest .
+extract_repo_if_working_copy_clean bb.js /usr/src/barretenberg/ts/dest .
 # Annoyingly we still need to install modules, so they can be found as part of module resolution when portalled.
 yarn install
 

--- a/build-system/scripts/check_working_copy_clean
+++ b/build-system/scripts/check_working_copy_clean
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# If this script fails (nonzero exit), then the working copy is not clean.
+
+[ -n "${BUILD_SYSTEM_DEBUG:-}" ] && set -x # conditionally trace
+set -eu
+
+REPOSITORY=$1
+
+# Get list of rebuild patterns, concat them with regex 'or' (|), and double escape \ for awk -v.
+AWK_PATTERN=$(query_manifest rebuildPatterns $REPOSITORY | tr '\n' '|' | sed 's/\\/\\\\/g')
+# Remove the trailing '|'.
+AWK_PATTERN=${AWK_PATTERN%|}
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Check if there is anything dirty in the local copy, if so, bail with non-zero exit code.
+CHANGED_FILES=$(git status --porcelain | awk -v pattern="($AWK_PATTERN)" '$2 ~ pattern {print $2}')
+if [ -n "$CHANGED_FILES" ]; then
+  echo $CHANGED_FILES
+  exit 1
+fi

--- a/build-system/scripts/extract_repo_if_working_copy_clean
+++ b/build-system/scripts/extract_repo_if_working_copy_clean
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Given a repository, extracts the builds entire /usr/src dir to the current path if the working copy is clean.
+[ -n "${BUILD_SYSTEM_DEBUG:-}" ] && set -x # conditionally trace
+set -eu
+
+REPOSITORY=$1
+
+if ! check_working_copy_clean $REPOSITORY; then 
+  echo "Aborting extraction of $REPOSITORY since the working copy one for it or one of its dependencies is not clean."
+  exit 1
+fi
+
+extract_repo $@

--- a/l1-contracts/bootstrap_cache.sh
+++ b/l1-contracts/bootstrap_cache.sh
@@ -5,6 +5,6 @@ cd "$(dirname "$0")"
 source ../build-system/scripts/setup_env '' '' mainframe_$USER > /dev/null
 
 echo -e "\033[1mRetrieving contracts from remote cache...\033[0m"
-extract_repo l1-contracts /usr/src/l1-contracts/out .
+extract_repo_if_working_copy_clean l1-contracts /usr/src/l1-contracts/out .
 
 remove_old_images l1-contracts

--- a/noir-projects/bootstrap_cache.sh
+++ b/noir-projects/bootstrap_cache.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 source ../build-system/scripts/setup_env '' '' mainframe_$USER > /dev/null
 
 echo -e "\033[1mRetrieving noir projects from remote cache...\033[0m"
-extract_repo noir-projects \
+extract_repo_if_working_copy_clean noir-projects \
   /usr/src/noir-projects/noir-contracts/target ./noir-contracts \
   /usr/src/noir-projects/noir-protocol-circuits/target ./noir-protocol-circuits
 

--- a/noir/bootstrap_cache.sh
+++ b/noir/bootstrap_cache.sh
@@ -5,9 +5,9 @@ cd "$(dirname "$0")"
 source ../build-system/scripts/setup_env '' '' mainframe_$USER > /dev/null
 
 echo -e "\033[1mRetrieving noir packages from remote cache...\033[0m"
-extract_repo noir-packages /usr/src/noir/packages ./
+extract_repo_if_working_copy_clean noir-packages /usr/src/noir/packages ./
 echo -e "\033[1mRetrieving nargo from remote cache...\033[0m"
-extract_repo noir /usr/src/noir/noir-repo/target/release ./noir-repo/target/
+extract_repo_if_working_copy_clean noir /usr/src/noir/noir-repo/target/release ./noir-repo/target/
 
 remove_old_images noir-packages
 remove_old_images noir


### PR DESCRIPTION
Another attempt at #5851 but not applies to all uses of `extract_repo`, since it was breaking eg docs deployments:

![screenshot_2024-04-18_at_6 20 28___pm](https://github.com/AztecProtocol/aztec-packages/assets/429604/9fe28488-643a-4737-b6dc-0f602b020691)
