### PR TITLE
feat: abort ongoing proving jobs

### DIFF
--- a/yarn-project/circuit-types/src/interfaces/proving-job.ts
+++ b/yarn-project/circuit-types/src/interfaces/proving-job.ts
@@ -102,7 +102,7 @@ export type ProvingRequestPublicInputs = {
 export type ProvingRequestResult<T extends ProvingRequestType> = ProvingRequestPublicInputs[T];
 
 export interface ProvingJobSource {
-  getProvingJob(): Promise<ProvingJob<ProvingRequest> | null>;
+  getProvingJob(): Promise<ProvingJob<ProvingRequest> | undefined>;
 
   resolveProvingJob<T extends ProvingRequestType>(jobId: string, result: ProvingRequestResult<T>): Promise<void>;
 

--- a/yarn-project/foundation/src/error/index.ts
+++ b/yarn-project/foundation/src/error/index.ts
@@ -9,3 +9,8 @@ export class InterruptError extends Error {}
  * An error thrown when an action times out.
  */
 export class TimeoutError extends Error {}
+
+/**
+ * Represents an error thrown when an operation is aborted.
+ */
+export class AbortedError extends Error {}

--- a/yarn-project/prover-client/src/dummy-prover.ts
+++ b/yarn-project/prover-client/src/dummy-prover.ts
@@ -66,8 +66,8 @@ export class DummyProver implements ProverClient {
 }
 
 class DummyProvingJobSource implements ProvingJobSource {
-  getProvingJob(): Promise<ProvingJob<ProvingRequest> | null> {
-    return Promise.resolve(null);
+  getProvingJob(): Promise<ProvingJob<ProvingRequest> | undefined> {
+    return Promise.resolve(undefined);
   }
 
   rejectProvingJob(): Promise<void> {

--- a/yarn-project/prover-client/src/prover-pool/memory-proving-queue.test.ts
+++ b/yarn-project/prover-client/src/prover-pool/memory-proving-queue.test.ts
@@ -27,8 +27,8 @@ describe('MemoryProvingQueue', () => {
     expect(job2?.request.type).toEqual(ProvingRequestType.BASE_ROLLUP);
   });
 
-  it('returns null when no jobs are available', async () => {
-    await expect(queue.getProvingJob({ timeoutSec: 0 })).resolves.toBeNull();
+  it('returns undefined when no jobs are available', async () => {
+    await expect(queue.getProvingJob({ timeoutSec: 0 })).resolves.toBeUndefined();
   });
 
   it('notifies of completion', async () => {

--- a/yarn-project/prover-client/src/prover-pool/memory-proving-queue.ts
+++ b/yarn-project/prover-client/src/prover-pool/memory-proving-queue.ts
@@ -22,7 +22,7 @@ import type {
   RootRollupInputs,
   RootRollupPublicInputs,
 } from '@aztec/circuits.js';
-import { TimeoutError } from '@aztec/foundation/error';
+import { AbortedError, TimeoutError } from '@aztec/foundation/error';
 import { MemoryFifo } from '@aztec/foundation/fifo';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { type PromiseWithResolvers, promiseWithResolvers } from '@aztec/foundation/promise';
@@ -32,6 +32,7 @@ import { type CircuitProver } from '../prover/interface.js';
 type ProvingJobWithResolvers<T extends ProvingRequest = ProvingRequest> = {
   id: string;
   request: T;
+  signal?: AbortSignal;
 } & PromiseWithResolvers<ProvingRequestResult<T['type']>>;
 
 export class MemoryProvingQueue implements CircuitProver, ProvingJobSource {
@@ -40,11 +41,16 @@ export class MemoryProvingQueue implements CircuitProver, ProvingJobSource {
   private queue = new MemoryFifo<ProvingJobWithResolvers>();
   private jobsInProgress = new Map<string, ProvingJobWithResolvers>();
 
-  async getProvingJob({ timeoutSec = 1 } = {}): Promise<ProvingJob<ProvingRequest> | null> {
+  async getProvingJob({ timeoutSec = 1 } = {}): Promise<ProvingJob<ProvingRequest> | undefined> {
     try {
       const job = await this.queue.get(timeoutSec);
       if (!job) {
-        return null;
+        return undefined;
+      }
+
+      if (job.signal?.aborted) {
+        this.log.debug(`Job ${job.id} type=${job.request.type} has been aborted`);
+        return undefined;
       }
 
       this.jobsInProgress.set(job.id, job);
@@ -54,7 +60,7 @@ export class MemoryProvingQueue implements CircuitProver, ProvingJobSource {
       };
     } catch (err) {
       if (err instanceof TimeoutError) {
-        return null;
+        return undefined;
       }
 
       throw err;
@@ -68,6 +74,11 @@ export class MemoryProvingQueue implements CircuitProver, ProvingJobSource {
     }
 
     this.jobsInProgress.delete(jobId);
+
+    if (job.signal?.aborted) {
+      return Promise.resolve();
+    }
+
     job.resolve(result);
     return Promise.resolve();
   }
@@ -79,19 +90,32 @@ export class MemoryProvingQueue implements CircuitProver, ProvingJobSource {
     }
 
     this.jobsInProgress.delete(jobId);
+
+    if (job.signal?.aborted) {
+      return Promise.resolve();
+    }
+
     job.reject(err);
     return Promise.resolve();
   }
 
-  private enqueue<T extends ProvingRequest>(request: T): Promise<ProvingRequestResult<T['type']>> {
+  private enqueue<T extends ProvingRequest>(
+    request: T,
+    signal?: AbortSignal,
+  ): Promise<ProvingRequestResult<T['type']>> {
     const { promise, resolve, reject } = promiseWithResolvers<ProvingRequestResult<T['type']>>();
     const item: ProvingJobWithResolvers<T> = {
       id: String(this.jobId++),
       request,
+      signal,
       promise,
       resolve,
       reject,
     };
+
+    if (signal) {
+      signal.addEventListener('abort', () => reject(new AbortedError('Operation has been aborted')));
+    }
 
     this.log.info(`Adding ${ProvingRequestType[request.type]} proving job to queue`);
     // TODO (alexg) remove the `any`
@@ -106,55 +130,85 @@ export class MemoryProvingQueue implements CircuitProver, ProvingJobSource {
    * Creates a proof for the given input.
    * @param input - Input to the circuit.
    */
-  getBaseParityProof(inputs: BaseParityInputs): Promise<RootParityInput<typeof RECURSIVE_PROOF_LENGTH>> {
-    return this.enqueue({
-      type: ProvingRequestType.BASE_PARITY,
-      inputs,
-    });
+  getBaseParityProof(
+    inputs: BaseParityInputs,
+    signal?: AbortSignal,
+  ): Promise<RootParityInput<typeof RECURSIVE_PROOF_LENGTH>> {
+    return this.enqueue(
+      {
+        type: ProvingRequestType.BASE_PARITY,
+        inputs,
+      },
+      signal,
+    );
   }
 
   /**
    * Creates a proof for the given input.
    * @param input - Input to the circuit.
    */
-  getRootParityProof(inputs: RootParityInputs): Promise<RootParityInput<typeof NESTED_RECURSIVE_PROOF_LENGTH>> {
-    return this.enqueue({
-      type: ProvingRequestType.ROOT_PARITY,
-      inputs,
-    });
+  getRootParityProof(
+    inputs: RootParityInputs,
+    signal?: AbortSignal,
+  ): Promise<RootParityInput<typeof NESTED_RECURSIVE_PROOF_LENGTH>> {
+    return this.enqueue(
+      {
+        type: ProvingRequestType.ROOT_PARITY,
+        inputs,
+      },
+      signal,
+    );
   }
 
   /**
    * Creates a proof for the given input.
    * @param input - Input to the circuit.
    */
-  getBaseRollupProof(input: BaseRollupInputs): Promise<PublicInputsAndProof<BaseOrMergeRollupPublicInputs>> {
-    return this.enqueue({
-      type: ProvingRequestType.BASE_ROLLUP,
-      inputs: input,
-    });
+  getBaseRollupProof(
+    input: BaseRollupInputs,
+    signal?: AbortSignal,
+  ): Promise<PublicInputsAndProof<BaseOrMergeRollupPublicInputs>> {
+    return this.enqueue(
+      {
+        type: ProvingRequestType.BASE_ROLLUP,
+        inputs: input,
+      },
+      signal,
+    );
   }
 
   /**
    * Creates a proof for the given input.
    * @param input - Input to the circuit.
    */
-  getMergeRollupProof(input: MergeRollupInputs): Promise<PublicInputsAndProof<BaseOrMergeRollupPublicInputs>> {
-    return this.enqueue({
-      type: ProvingRequestType.MERGE_ROLLUP,
-      inputs: input,
-    });
+  getMergeRollupProof(
+    input: MergeRollupInputs,
+    signal?: AbortSignal,
+  ): Promise<PublicInputsAndProof<BaseOrMergeRollupPublicInputs>> {
+    return this.enqueue(
+      {
+        type: ProvingRequestType.MERGE_ROLLUP,
+        inputs: input,
+      },
+      signal,
+    );
   }
 
   /**
    * Creates a proof for the given input.
    * @param input - Input to the circuit.
    */
-  getRootRollupProof(input: RootRollupInputs): Promise<PublicInputsAndProof<RootRollupPublicInputs>> {
-    return this.enqueue({
-      type: ProvingRequestType.ROOT_ROLLUP,
-      inputs: input,
-    });
+  getRootRollupProof(
+    input: RootRollupInputs,
+    signal?: AbortSignal,
+  ): Promise<PublicInputsAndProof<RootRollupPublicInputs>> {
+    return this.enqueue(
+      {
+        type: ProvingRequestType.ROOT_ROLLUP,
+        inputs: input,
+      },
+      signal,
+    );
   }
 
   /**
@@ -163,31 +217,40 @@ export class MemoryProvingQueue implements CircuitProver, ProvingJobSource {
    */
   getPublicKernelProof(
     kernelRequest: PublicKernelNonTailRequest,
+    signal?: AbortSignal,
   ): Promise<PublicInputsAndProof<PublicKernelCircuitPublicInputs>> {
-    return this.enqueue({
-      type: ProvingRequestType.PUBLIC_KERNEL_NON_TAIL,
-      kernelType: kernelRequest.type,
-      inputs: kernelRequest.inputs,
-    });
+    return this.enqueue(
+      {
+        type: ProvingRequestType.PUBLIC_KERNEL_NON_TAIL,
+        kernelType: kernelRequest.type,
+        inputs: kernelRequest.inputs,
+      },
+      signal,
+    );
   }
 
   /**
    * Create a public kernel tail proof.
    * @param kernelRequest - Object containing the details of the proof required
    */
-  getPublicTailProof(kernelRequest: PublicKernelTailRequest): Promise<PublicInputsAndProof<KernelCircuitPublicInputs>> {
-    return this.enqueue({
-      type: ProvingRequestType.PUBLIC_KERNEL_TAIL,
-      kernelType: kernelRequest.type,
-      inputs: kernelRequest.inputs,
-    });
+  getPublicTailProof(
+    kernelRequest: PublicKernelTailRequest,
+    signal?: AbortSignal,
+  ): Promise<PublicInputsAndProof<KernelCircuitPublicInputs>> {
+    return this.enqueue(
+      {
+        type: ProvingRequestType.PUBLIC_KERNEL_TAIL,
+        kernelType: kernelRequest.type,
+        inputs: kernelRequest.inputs,
+      },
+      signal,
+    );
   }
 
   /**
    * Verifies a circuit proof
    */
   verifyProof(): Promise<void> {
-    // no-op
-    return Promise.resolve();
+    return Promise.reject('not implemented');
   }
 }

--- a/yarn-project/prover-client/src/prover/interface.ts
+++ b/yarn-project/prover-client/src/prover/interface.ts
@@ -69,31 +69,46 @@ export interface CircuitProver {
    * Creates a proof for the given input.
    * @param input - Input to the circuit.
    */
-  getBaseParityProof(inputs: BaseParityInputs): Promise<RootParityInput<typeof RECURSIVE_PROOF_LENGTH>>;
+  getBaseParityProof(
+    inputs: BaseParityInputs,
+    signal?: AbortSignal,
+  ): Promise<RootParityInput<typeof RECURSIVE_PROOF_LENGTH>>;
 
   /**
    * Creates a proof for the given input.
    * @param input - Input to the circuit.
    */
-  getRootParityProof(inputs: RootParityInputs): Promise<RootParityInput<typeof NESTED_RECURSIVE_PROOF_LENGTH>>;
+  getRootParityProof(
+    inputs: RootParityInputs,
+    signal?: AbortSignal,
+  ): Promise<RootParityInput<typeof NESTED_RECURSIVE_PROOF_LENGTH>>;
 
   /**
    * Creates a proof for the given input.
    * @param input - Input to the circuit.
    */
-  getBaseRollupProof(input: BaseRollupInputs): Promise<PublicInputsAndProof<BaseOrMergeRollupPublicInputs>>;
+  getBaseRollupProof(
+    input: BaseRollupInputs,
+    signal?: AbortSignal,
+  ): Promise<PublicInputsAndProof<BaseOrMergeRollupPublicInputs>>;
 
   /**
    * Creates a proof for the given input.
    * @param input - Input to the circuit.
    */
-  getMergeRollupProof(input: MergeRollupInputs): Promise<PublicInputsAndProof<BaseOrMergeRollupPublicInputs>>;
+  getMergeRollupProof(
+    input: MergeRollupInputs,
+    signal?: AbortSignal,
+  ): Promise<PublicInputsAndProof<BaseOrMergeRollupPublicInputs>>;
 
   /**
    * Creates a proof for the given input.
    * @param input - Input to the circuit.
    */
-  getRootRollupProof(input: RootRollupInputs): Promise<PublicInputsAndProof<RootRollupPublicInputs>>;
+  getRootRollupProof(
+    input: RootRollupInputs,
+    signal?: AbortSignal,
+  ): Promise<PublicInputsAndProof<RootRollupPublicInputs>>;
 
   /**
    * Create a public kernel proof.
@@ -101,18 +116,22 @@ export interface CircuitProver {
    */
   getPublicKernelProof(
     kernelRequest: PublicKernelNonTailRequest,
+    signal?: AbortSignal,
   ): Promise<PublicInputsAndProof<PublicKernelCircuitPublicInputs>>;
 
   /**
    * Create a public kernel tail proof.
    * @param kernelRequest - Object containing the details of the proof required
    */
-  getPublicTailProof(kernelRequest: PublicKernelTailRequest): Promise<PublicInputsAndProof<KernelCircuitPublicInputs>>;
+  getPublicTailProof(
+    kernelRequest: PublicKernelTailRequest,
+    signal?: AbortSignal,
+  ): Promise<PublicInputsAndProof<KernelCircuitPublicInputs>>;
 
   /**
    * Verifies a circuit proof
    */
-  verifyProof(artifact: ServerProtocolArtifact, proof: Proof): Promise<void>;
+  verifyProof(artifact: ServerProtocolArtifact, proof: Proof, signal?: AbortSignal): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
Pass an `AbortSignal` to circuit provers to notify of job cancellation
