### PR TITLE
fix(ci): Always run merge-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,15 +210,24 @@ jobs:
   merge-check:
     runs-on: ubuntu-latest
     needs:
-      [
-        e2e,
-        bb-native-tests,
-        bb-bench,
-        yarn-project-formatting,
-        yarn-project-test,
-      ]
+      - e2e
+      - bb-native-tests
+      - bb-bench
+      - yarn-project-formatting
+      - yarn-project-test
+    if: always()
     steps:
-      - run: echo Pull request merging now allowed.
+      - run: |
+          echo "e2e status: ${{ needs.e2e.result }}"
+          echo "bb-native-tests status: ${{ needs.bb-native-tests.result }}"
+          echo "bb-bench status: ${{ needs.bb-bench.result }}"
+          echo "yarn-project-formatting status: ${{ needs.yarn-project-formatting.result }}"
+          echo "yarn-project-test status: ${{ needs.yarn-project-test.result }}"
+          if [[ "${{ needs.e2e.result }}" != 'success' || "${{ needs.bb-native-tests.result }}" != 'success' || "${{ needs.bb-bench.result }}" != 'success' || "${{ needs.yarn-project-formatting.result }}" != 'success' || "${{ needs.yarn-project-test.result }}" != 'success' ]]; then
+            echo "Pull request merging not allowed due to failures."
+            exit 1
+          fi
+          echo "Pull request merging now allowed."
 
   notify:
     needs:


### PR DESCRIPTION
Reintroduces the fix from https://github.com/AztecProtocol/aztec-packages/pull/5873 which was accidentally removed in https://github.com/AztecProtocol/aztec-packages/pull/5889