### PR TITLE
fix: Calculate tx fee using current constants in public kernel

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
@@ -32,11 +32,11 @@ impl PublicKernelTeardownCircuitPrivateInputs {
     }
 
     // Validates the transaction fee injected into the app circuit is properly computed from gas_used and block gas_fees
-    fn validate_transaction_fee(self) {
+    fn validate_transaction_fee(self, public_inputs: PublicKernelCircuitPublicInputsBuilder) {
         let transaction_fee = self.public_call.call_stack_item.public_inputs.transaction_fee;
         // Note that teardown_gas is already included in end.gas_used as it was injected by the private kernel
         let total_gas_used = self.previous_kernel.public_inputs.end.gas_used.add(self.previous_kernel.public_inputs.end_non_revertible.gas_used);
-        let block_gas_fees = self.previous_kernel.public_inputs.constants.global_variables.gas_fees;
+        let block_gas_fees = public_inputs.constants.global_variables.gas_fees;
         let inclusion_fee = self.previous_kernel.public_inputs.constants.tx_context.gas_settings.inclusion_fee;
         let computed_transaction_fee = total_gas_used.compute_fee(block_gas_fees) + inclusion_fee;
 
@@ -84,7 +84,7 @@ impl PublicKernelTeardownCircuitPrivateInputs {
         common::validate_call_against_request(self.public_call, call_request);
 
         self.validate_start_gas();
-        self.validate_transaction_fee();
+        self.validate_transaction_fee(public_inputs);
 
         common::update_validation_requests(self.public_call, &mut public_inputs);
 

--- a/yarn-project/end-to-end/src/benchmarks/bench_tx_size_fees.test.ts
+++ b/yarn-project/end-to-end/src/benchmarks/bench_tx_size_fees.test.ts
@@ -61,12 +61,12 @@ describe('benchmarks/tx_size_fees', () => {
     await token.methods.mint_public(aliceWallet.getAddress(), 100e9).send().wait();
   });
 
-  it.each<() => Promise<FeePaymentMethod | undefined>>([
-    () => Promise.resolve(undefined),
-    () => NativeFeePaymentMethod.create(aliceWallet),
-    () => Promise.resolve(new PublicFeePaymentMethod(token.address, fpc.address, aliceWallet)),
-    () => Promise.resolve(new PrivateFeePaymentMethod(token.address, fpc.address, aliceWallet)),
-  ])('sends a tx with a fee', async createPaymentMethod => {
+  it.each<[string, () => Promise<FeePaymentMethod | undefined>]>([
+    ['no', () => Promise.resolve(undefined)],
+    ['native fee', () => NativeFeePaymentMethod.create(aliceWallet)],
+    ['public fee', () => Promise.resolve(new PublicFeePaymentMethod(token.address, fpc.address, aliceWallet))],
+    ['private fee', () => Promise.resolve(new PrivateFeePaymentMethod(token.address, fpc.address, aliceWallet))],
+  ] as const)('sends a tx with a fee with %s payment method', async (_name, createPaymentMethod) => {
     const paymentMethod = await createPaymentMethod();
     const gasSettings = GasSettings.default();
     const tx = await token.methods

--- a/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
@@ -86,11 +86,17 @@ export class SimpleTestGlobalVariableBuilder implements GlobalVariableBuilder {
       lastTimestamp = new Fr(lastTimestamp.value + 1n);
     }
 
-    this.log.debug(
-      `Built global variables for block ${blockNumber}: (${chainId}, ${version}, ${blockNumber}, ${lastTimestamp}, ${coinbase}, ${feeRecipient})`,
-    );
-
     const gasFees = GasFees.default();
+    const globalVariables = new GlobalVariables(
+      chainId,
+      version,
+      blockNumber,
+      lastTimestamp,
+      coinbase,
+      feeRecipient,
+      gasFees,
+    );
+    this.log.debug(`Built global variables for block ${blockNumber}`, globalVariables.toJSON());
     return new GlobalVariables(chainId, version, blockNumber, lastTimestamp, coinbase, feeRecipient, gasFees);
   }
 }


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/AztecProtocol/aztec-packages/pull/6031. If the tx _only_ has a teardown public function, then the global variables will still be empty on the previous-kernel of the public kernel teardown (since it's actually a private-kernel-tail), so the block fees will be empty.