### PR TITLE
feat(nargo): Mock oracle resolver

### DIFF
--- a/noir-projects/Dockerfile
+++ b/noir-projects/Dockerfile
@@ -14,11 +14,11 @@ WORKDIR /usr/src/noir-projects
 COPY . .
 # Build
 WORKDIR /usr/src/noir-projects/noir-contracts
-RUN ./bootstrap.sh && nargo test --silence-warnings
+RUN ./bootstrap.sh && nargo test --silence-warnings --mock-oracle-resolver
 WORKDIR /usr/src/noir-projects/noir-protocol-circuits
-RUN ./bootstrap.sh && nargo test --silence-warnings
+RUN ./bootstrap.sh && nargo test --silence-warnings --mock-oracle-resolver
 WORKDIR /usr/src/noir-projects/aztec-nr
-RUN nargo test --silence-warnings
+RUN nargo test --silence-warnings --mock-oracle-resolver
 
 FROM scratch
 COPY --from=builder /usr/src/noir-projects /usr/src/noir-projects

--- a/noir-projects/Earthfile
+++ b/noir-projects/Earthfile
@@ -26,6 +26,6 @@ build:
 
 test:
   FROM +build
-  RUN cd noir-protocol-circuits && nargo test --silence-warnings
-  RUN cd aztec-nr && nargo test --silence-warnings
-  RUN cd noir-contracts && nargo test --silence-warnings
+  RUN cd noir-protocol-circuits && nargo test --silence-warnings --mock-oracle-resolver
+  RUN cd aztec-nr && nargo test --silence-warnings --mock-oracle-resolver
+  RUN cd noir-contracts && nargo test --silence-warnings --mock-oracle-resolver

--- a/noir/noir-repo/docs/docs/noir/concepts/oracles.md
+++ b/noir/noir-repo/docs/docs/noir/concepts/oracles.md
@@ -29,3 +29,5 @@ unconstrained fn get_number_sequence(_size: Field) -> [Field] {}
 ```
 
 The timeout for when using an external RPC oracle resolver can be set with the `NARGO_FOREIGN_CALL_TIMEOUT` environment variable. This timeout is in units of milliseconds.
+
+Alternatively, a Noir program can be run with a mock oracle set up, which will default to answering every oracle call with a single zero-value `Field`. Note that this will work only for oracle calls that expect a return value of a single field element.

--- a/noir/noir-repo/tooling/debugger/src/foreign_calls.rs
+++ b/noir/noir-repo/tooling/debugger/src/foreign_calls.rs
@@ -5,7 +5,7 @@ use acvm::{
 };
 use nargo::{
     artifacts::debug::{DebugArtifact, DebugVars, StackFrame},
-    ops::{DefaultForeignCallExecutor, ForeignCallExecutor},
+    ops::{DefaultForeignCallExecutor, ForeignCallExecutor, ResolverOpts},
 };
 use noirc_errors::debug_info::{DebugFnId, DebugVarId};
 use noirc_printable_type::ForeignCallError;
@@ -51,7 +51,7 @@ pub struct DefaultDebugForeignCallExecutor {
 impl DefaultDebugForeignCallExecutor {
     pub fn new(show_output: bool) -> Self {
         Self {
-            executor: DefaultForeignCallExecutor::new(show_output, None),
+            executor: DefaultForeignCallExecutor::new(show_output, &ResolverOpts::none()),
             debug_vars: DebugVars::default(),
         }
     }

--- a/noir/noir-repo/tooling/lsp/src/requests/test_run.rs
+++ b/noir/noir-repo/tooling/lsp/src/requests/test_run.rs
@@ -3,7 +3,7 @@ use std::future::{self, Future};
 use async_lsp::{ErrorCode, ResponseError};
 use nargo::{
     insert_all_files_for_workspace_into_file_manager,
-    ops::{run_test, TestStatus},
+    ops::{run_test, ResolverOpts, TestStatus},
     prepare_package,
 };
 use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
@@ -86,7 +86,7 @@ fn on_test_run_request_inner(
                 &mut context,
                 &test_function,
                 false,
-                None,
+                &ResolverOpts::none(),
                 &CompileOptions::default(),
             );
             let result = match test_result {

--- a/noir/noir-repo/tooling/nargo/src/ops/mod.rs
+++ b/noir/noir-repo/tooling/nargo/src/ops/mod.rs
@@ -3,7 +3,9 @@ pub use self::compile::{
     compile_workspace, report_errors,
 };
 pub use self::execute::execute_program;
-pub use self::foreign_calls::{DefaultForeignCallExecutor, ForeignCall, ForeignCallExecutor};
+pub use self::foreign_calls::{
+    DefaultForeignCallExecutor, ForeignCall, ForeignCallExecutor, ResolverOpts,
+};
 pub use self::optimize::{optimize_contract, optimize_program};
 pub use self::transform::{transform_contract, transform_program};
 

--- a/noir/noir-repo/tooling/nargo/src/ops/test.rs
+++ b/noir/noir-repo/tooling/nargo/src/ops/test.rs
@@ -9,7 +9,7 @@ use noirc_frontend::hir::{def_map::TestFunction, Context};
 
 use crate::{errors::try_to_diagnose_runtime_error, NargoError};
 
-use super::{execute_program, DefaultForeignCallExecutor};
+use super::{execute_program, DefaultForeignCallExecutor, ResolverOpts};
 
 pub enum TestStatus {
     Pass,
@@ -28,7 +28,7 @@ pub fn run_test<B: BlackBoxFunctionSolver>(
     context: &mut Context,
     test_function: &TestFunction,
     show_output: bool,
-    foreign_call_resolver_url: Option<&str>,
+    resolver_opts: &ResolverOpts,
     config: &CompileOptions,
 ) -> TestStatus {
     let compiled_program = compile_no_check(context, config, test_function.get_id(), None, false);
@@ -40,7 +40,7 @@ pub fn run_test<B: BlackBoxFunctionSolver>(
                 &compiled_program.program,
                 WitnessMap::new(),
                 blackbox_solver,
-                &mut DefaultForeignCallExecutor::new(show_output, foreign_call_resolver_url),
+                &mut DefaultForeignCallExecutor::new(show_output, resolver_opts),
             );
             test_status_program_compile_pass(
                 test_function,

--- a/noir/noir-repo/tooling/nargo_cli/tests/stdlib-tests.rs
+++ b/noir/noir-repo/tooling/nargo_cli/tests/stdlib-tests.rs
@@ -5,7 +5,7 @@ use noirc_driver::{check_crate, file_manager_with_stdlib, CompileOptions};
 use noirc_frontend::hir::FunctionNameMatch;
 
 use nargo::{
-    ops::{report_errors, run_test, TestStatus},
+    ops::{report_errors, run_test, ResolverOpts, TestStatus},
     package::{Package, PackageType},
     parse_all, prepare_package,
 };
@@ -49,7 +49,7 @@ fn stdlib_noir_tests() {
                 &mut context,
                 &test_function,
                 false,
-                None,
+                &ResolverOpts::none(),
                 &CompileOptions::default(),
             );
 


### PR DESCRIPTION
Adds a `--mock-oracle-resolver` option to nargo, that responds to all oracle requests with a single zero-value field. Useful for allowing noop oracle calls, such as debug-log, when running circuits in aztec-packages, without breaking tests run via `nargo test`.
