### PR TITLE
fix: `test_native.sh` not running all noir tests

### DIFF
--- a/noir/scripts/test_native.sh
+++ b/noir/scripts/test_native.sh
@@ -14,4 +14,4 @@ RUSTFLAGS=-Dwarnings cargo clippy --workspace --locked --release
 ./.github/scripts/cargo-binstall-install.sh
 cargo-binstall cargo-nextest --version 0.9.67 -y --secure
 
-cargo nextest run --locked --release -E '!test(hello_world_example) & !test(simple_verifier_codegen)'
+cargo nextest run --workspace --locked --release -E '!test(hello_world_example) & !test(simple_verifier_codegen)'


### PR DESCRIPTION
Not all noir tests were run in CI. This PR fixes it.

See the [noir-test CI pipeline](https://app.circleci.com/pipelines/github/AztecProtocol/aztec-packages/37253/workflows/d4efc4c5-124a-41d6-9b6e-47d1578ea468/jobs/1715266) for a proof that the issue got fixed.