### PR TITLE
feat: Breakdown of ClientIVCBench in WASM

### DIFF
--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -296,6 +296,26 @@
       }
     },
     {
+      "name": "wasm-op-count",
+      "displayName": "Release build with operation counts",
+      "description": "Build with op counting",
+      "inherits": "wasm-threads",
+      "binaryDir": "build-wasm-op-count",
+      "environment": {
+        "CXXFLAGS": "-DBB_USE_OP_COUNT -DBB_USE_OP_COUNT_TRACK_ONLY"
+      }
+    },
+    {
+      "name": "wasm-op-count-time",
+      "displayName": "Release build with time and clock counts",
+      "description": "Build with op counting",
+      "inherits": "wasm-threads",
+      "binaryDir": "build-wasm-op-count-time",
+      "environment": {
+        "CXXFLAGS": "-DBB_USE_OP_COUNT -DBB_USE_OP_COUNT_TIME_ONLY"
+      }
+    },
+    {
       "name": "xray",
       "displayName": "Build with multi-threaded XRay Profiling",
       "description": "Build with Clang and enable multi-threaded LLVM XRay for profiling",
@@ -463,6 +483,24 @@
     {
       "name": "wasm-threads",
       "configurePreset": "wasm-threads",
+      "inheritConfigureEnvironment": true,
+      "jobs": 0,
+      "targets": [
+        "barretenberg.wasm"
+      ]
+    },
+    {
+      "name": "wasm-op-count-time",
+      "configurePreset": "wasm-op-count-time",
+      "inheritConfigureEnvironment": true,
+      "jobs": 0,
+      "targets": [
+        "barretenberg.wasm"
+      ]
+    },
+    {
+      "name": "wasm-op-count",
+      "configurePreset": "wasm-op-count",
       "inheritConfigureEnvironment": true,
       "jobs": 0,
       "targets": [

--- a/barretenberg/cpp/scripts/analyze_client_ivc_bench.py
+++ b/barretenberg/cpp/scripts/analyze_client_ivc_bench.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-PREFIX = Path("build-op-count-time")
+PREFIX = Path("build-wasm-op-count-time")
 IVC_BENCH_JSON = Path("client_ivc_bench.json")
 BENCHMARK = "ClientIVCBench/Full/6"
 

--- a/barretenberg/cpp/scripts/benchmark_client_ivc.sh
+++ b/barretenberg/cpp/scripts/benchmark_client_ivc.sh
@@ -11,14 +11,14 @@ cd $(dirname $0)/..
 # Measure the benchmarks with ops time counting
 ./scripts/benchmark_remote.sh client_ivc_bench\
                               "./client_ivc_bench --benchmark_filter=$FILTER\
-                                                  --benchmark_out=$TARGET.json\
+                                                  --benchmark_out=../$TARGET.json\
                                                   --benchmark_out_format=json"\
                               op-count-time\
                               build-op-count-time
 
 # Retrieve output from benching instance
 cd $BUILD_DIR
-scp $BB_SSH_KEY $BB_SSH_INSTANCE:$BB_SSH_CPP_PATH/build/$TARGET.json .
+scp $BB_SSH_KEY $BB_SSH_INSTANCE:$BB_SSH_CPP_PATH/$TARGET.json .
 
 # Analyze the results
 cd ../

--- a/barretenberg/cpp/scripts/benchmark_client_ivc_wasm.sh
+++ b/barretenberg/cpp/scripts/benchmark_client_ivc_wasm.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -eu
+
+TARGET="client_ivc_bench"
+BENCHMARK_OUT=$TARGET
+FILTER="ClientIVCBench/Full/6$"
+BUILD_DIR=build-wasm-op-count-time
+
+# Move above script dir.
+cd $(dirname $0)/..
+
+# Measure the benchmarks with ops time counting
+./scripts/benchmark_wasm_remote.sh client_ivc_bench\
+                                    "./client_ivc_bench --benchmark_filter=$FILTER\
+                                                        --benchmark_out=../$TARGET.json\
+                                                        --benchmark_out_format=json"\
+                                                        wasm-op-count-time\
+                                                        build-wasm-op-count-time
+
+# Retrieve output from benching instance
+cd $BUILD_DIR
+scp $BB_SSH_KEY $BB_SSH_INSTANCE:$BB_SSH_CPP_PATH/$TARGET.json .
+
+# Analyze the results
+cd ../
+python3 ./scripts/analyze_client_ivc_bench.py

--- a/barretenberg/cpp/scripts/benchmark_client_ivc_wasm.sh
+++ b/barretenberg/cpp/scripts/benchmark_client_ivc_wasm.sh
@@ -10,16 +10,16 @@ BUILD_DIR=build-wasm-op-count-time
 cd $(dirname $0)/..
 
 # Measure the benchmarks with ops time counting
-./scripts/benchmark_wasm_remote.sh client_ivc_bench\
+./scripts/benchmark_wasm.sh client_ivc_bench\
                                     "./client_ivc_bench --benchmark_filter=$FILTER\
                                                         --benchmark_out=../$TARGET.json\
                                                         --benchmark_out_format=json"\
                                                         wasm-op-count-time\
                                                         build-wasm-op-count-time
 
-# Retrieve output from benching instance
-cd $BUILD_DIR
-scp $BB_SSH_KEY $BB_SSH_INSTANCE:$BB_SSH_CPP_PATH/$TARGET.json .
+# # Retrieve output from benching instance
+# cd $BUILD_DIR
+# scp $BB_SSH_KEY $BB_SSH_INSTANCE:$BB_SSH_CPP_PATH/$TARGET.json .
 
 # Analyze the results
 cd ../

--- a/barretenberg/cpp/scripts/benchmark_wasm.sh
+++ b/barretenberg/cpp/scripts/benchmark_wasm.sh
@@ -2,17 +2,19 @@
 set -eu
 
 BENCHMARK=${1:-goblin_bench}
-COMMAND=${2:-./bin/$BENCHMARK}
+COMMAND=${2:-./$BENCHMARK}
+PRESET=${3:-wasm-threads}
+BUILD_DIR=${4:-build-wasm-threads}
 HARDWARE_CONCURRENCY=${HARDWARE_CONCURRENCY:-16}
 
 # Move above script dir.
 cd $(dirname $0)/..
 
 # Configure and build.
-cmake --preset wasm-threads
-cmake --build --preset wasm-threads --target $BENCHMARK
+cmake --preset $PRESET
+cmake --build --preset $PRESET --target $BENCHMARK
 
-cd build-wasm-threads
+cd $BUILD_DIR
 # Consistency with _wasm.sh targets / shorter $COMMAND.
 cp ./bin/$BENCHMARK .
 wasmtime run --env HARDWARE_CONCURRENCY=$HARDWARE_CONCURRENCY -Wthreads=y -Sthreads=y --dir=.. $COMMAND

--- a/build-images/Dockerfile
+++ b/build-images/Dockerfile
@@ -125,6 +125,9 @@ RUN apt update && \
         python3-blessed \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Install wasmtime for running tests in WASM
+RUN curl https://wasmtime.dev/install.sh -sSf | bash
+
 # Install earthly.
 RUN wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-$(dpkg --print-architecture) -O /usr/local/bin/earthly && \
     chmod +x /usr/local/bin/earthly


### PR DESCRIPTION
Formerly we only had an x86 version. I added presents to allow using op counts and timers in WASM, then added a script to breakdown WASM performance. This is analogous to existing work in x86. Results (it's not working yet...):

```
ninja: no work to do.
Benchmarking lock created at ~/BENCHMARK_IN_PROGRESS.
client_ivc_bench                                                                                   100%   33MB  41.0MB/s   00:00    
failed to open /proc/cpuinfo
***WARNING*** Failed to set thread affinity. Estimated CPU frequency may be incorrect.
2024-05-01T22:37:37+00:00
Running client_ivc_bench
Run on (-1 X 0.999999 MHz CPU )
--------------------------------------------------------------------------------
Benchmark                      Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------
ClientIVCBench/Full/6      79294 ms   7.9294e+10 ms            1 Decider::construct_proof=1 Decider::construct_proof(t)=2.44514G ECCVMProver(CircuitBuilder&)=1 ECCVMProver(CircuitBuilder&)(t)=436.777M ECCVMProver::construct_proof=1 ECCVMProver::construct_proof(t)=3.39246G Goblin::merge=11 Goblin::merge(t)=620.455M GoblinTranslatorCircuitBuilder::constructor=1 GoblinTranslatorCircuitBuilder::constructor(t)=201.064M GoblinTranslatorProver=1 GoblinTranslatorProver(t)=118.379M GoblinTranslatorProver::construct_proof=1 GoblinTranslatorProver::construct_proof(t)=3.20773G ProtoGalaxyProver_::accumulator_update_round=10 ProtoGalaxyProver_::accumulator_update_round(t)=1.47687G ProtoGalaxyProver_::combiner_quotient_round=10 ProtoGalaxyProver_::combiner_quotient_round(t)=1.43934G ProtoGalaxyProver_::perturbator_round=10 ProtoGalaxyProver_::perturbator_round(t)=421.187M ProtoGalaxyProver_::preparation_round=10 ProtoGalaxyProver_::preparation_round(t)=3.51813G ProtogalaxyProver::fold_instances=10 ProtogalaxyProver::fold_instances(t)=2.56063G ProverInstance(Circuit&)=11 ProverInstance(Circuit&)(t)=4.1237G batch_mul_with_endomorphism=30 batch_mul_with_endomorphism(t)=2.50039G commit=459 commit(t)=1.14372G compute_combiner=10 compute_combiner(t)=1.43129G compute_perturbator=9 compute_perturbator(t)=420.407M compute_univariate=48 compute_univariate(t)=593.251M construct_circuits=6 construct_circuits(t)=2.0494G
Benchmarking lock deleted.
client_ivc_bench.json                                                                              100% 3051    89.4KB/s   00:00    
function                                        ms     % sum
construct_circuits(t)                         2049    10.88%
ProverInstance(Circuit&)(t)                   4124    21.89%
ProtogalaxyProver::fold_instances(t)          2561    13.59%
Decider::construct_proof(t)                   2445    12.98%
ECCVMProver(CircuitBuilder&)(t)                437     2.32%
ECCVMProver::construct_proof(t)               3392    18.01%
GoblinTranslatorProver::construct_proof(t)    3208    17.03%
Goblin::merge(t)                               620     3.29%

Total time accounted for: 18836ms/79294ms = 23.76%

Major contributors:
function                                        ms    % sum
commit(t)                                     1144    6.07%
compute_combiner(t)                           1431    7.60%
compute_perturbator(t)                         420    2.23%
compute_univariate(t)                          593    3.15%

Breakdown of ProtogalaxyProver::fold_instances:
ProtoGalaxyProver_::preparation_round(t)           3518   137.39%
ProtoGalaxyProver_::perturbator_round(t)            421    16.45%
ProtoGalaxyProver_::combiner_quotient_round(t)     1439    56.21%
ProtoGalaxyProver_::accumulator_update_round(t)    1477    57.68%
```