### PR TITLE
fix: set up the ci runner for doc deployment

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || env.GITHUB_REF }}
+      - uses: ./.github/ci-setup-action
+        with:
+          dockerhub_password: "${{ secrets.DOCKERHUB_PASSWORD }}"
+          concurrency_key: docs-preview-${{ inputs.username || github.actor }}-x86
 
       - timeout-minutes: 25
         run: earthly --no-output ./docs/+deploy-prod --NETLIFY_AUTH_TOKEN=${{ secrets.NETLIFY_AUTH_TOKEN }} --NETLIFY_SITE_ID=${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
