### PR TITLE
feat: add public teardown to circuit structs

### DIFF
--- a/docs/docs/protocol-specs/gas-and-fees/kernel-tracking.md
+++ b/docs/docs/protocol-specs/gas-and-fees/kernel-tracking.md
@@ -48,7 +48,7 @@ PrivateCircuitPublicInputs --> Header
 class PrivateKernelCircuitPublicInputs {
     +u32 min_revertible_side_effect_counter
     +AztecAddress fee_payer
-    +Field public_teardown_function_hash
+    +CallRequest public_teardown_call_request
     +PrivateAccumulatedData end
     +CombinedConstantData constants
 }
@@ -208,6 +208,7 @@ It must:
 - compute gas used for the revertible and non-revertible. Both sets can have a DA component, but the revertible set will also include the teardown gas allocations the user specified (if any). This ensures that the user effectively pre-pays for the gas consumed in teardown.
 - ensure the gas used (across revertible and non-revertible) is less than the gas limits
 - ensure that `fee_payer` is set, and set it in the `PublicKernelCircuitPublicInputs`
+- set the `public_teardown_call_request` in the `PublicKernelCircuitPublicInputs`
 - copy the constants from the `PrivateKernelData` to the `PublicKernelCircuitPublicInputs.constants`
 
 # Mempool/Node Validation
@@ -292,7 +293,8 @@ class PublicKernelCircuitPublicInputs {
   +PublicAccumulatedData end_non_revertible
   +PublicAccumulatedData end
   +CombinedConstantData constants
-  +PublicConstantData public_constants
+  +AztecAddress fee_payer
+  +CallRequest public_teardown_call_request
   +u8 revert_code
 }
 PublicKernelCircuitPublicInputs --> PublicAccumulatedData
@@ -302,11 +304,6 @@ class CombinedConstantData {
     +Header historical_header
     +TxContext tx_context
     +GlobalVariables global_variables
-}
-
-class PublicConstantData {
-    +AztecAddress fee_payer
-    +Field public_teardown_function_hash
 }
 
 class PublicAccumulatedData {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/private_kernel_circuit_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/private_kernel_circuit_public_inputs.nr
@@ -1,6 +1,6 @@
 use crate::abis::{
     accumulated_data::PrivateAccumulatedData, combined_constant_data::CombinedConstantData,
-    validation_requests::ValidationRequests
+    validation_requests::ValidationRequests, call_request::CallRequest
 };
 use crate::mocked::AggregationObject;
 
@@ -10,4 +10,5 @@ struct PrivateKernelCircuitPublicInputs {
     validation_requests: ValidationRequests,
     end: PrivateAccumulatedData,
     constants: CombinedConstantData,
+    public_teardown_call_request: CallRequest,
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/private_kernel_circuit_public_inputs_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/private_kernel_circuit_public_inputs_builder.nr
@@ -6,7 +6,8 @@ use crate::{
     private_kernel_circuit_public_inputs::PrivateKernelCircuitPublicInputs,
     public_kernel_circuit_public_inputs::PublicKernelCircuitPublicInputs
 },
-    gas::Gas, validation_requests::validation_requests_builder::ValidationRequestsBuilder
+    gas::Gas, validation_requests::validation_requests_builder::ValidationRequestsBuilder,
+    call_request::CallRequest
 },
     mocked::AggregationObject, partial_state_reference::PartialStateReference, traits::Empty
 };
@@ -21,6 +22,7 @@ struct PrivateKernelCircuitPublicInputsBuilder {
     validation_requests: ValidationRequestsBuilder,
     end: PrivateAccumulatedDataBuilder,
     constants: CombinedConstantData,
+    public_teardown_call_request: CallRequest,
 }
 
 impl PrivateKernelCircuitPublicInputsBuilder {
@@ -30,7 +32,8 @@ impl PrivateKernelCircuitPublicInputsBuilder {
             min_revertible_side_effect_counter: self.min_revertible_side_effect_counter,
             validation_requests: self.validation_requests.finish(),
             end: self.end.finish(),
-            constants: self.constants
+            constants: self.constants,
+            public_teardown_call_request: self.public_teardown_call_request
         }
     }
 
@@ -58,7 +61,8 @@ impl PrivateKernelCircuitPublicInputsBuilder {
             end_non_revertible,
             end,
             constants: self.constants,
-            revert_code: 0
+            revert_code: 0,
+            public_teardown_call_request: self.public_teardown_call_request
         }
     }
 }
@@ -71,6 +75,7 @@ impl Empty for PrivateKernelCircuitPublicInputsBuilder {
             validation_requests: ValidationRequestsBuilder::empty(),
             end: PrivateAccumulatedDataBuilder::empty(),
             constants: CombinedConstantData::empty(),
+            public_teardown_call_request: CallRequest::empty()
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/public_kernel_circuit_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/public_kernel_circuit_public_inputs.nr
@@ -1,6 +1,6 @@
 use crate::abis::{
     accumulated_data::PublicAccumulatedData, combined_constant_data::CombinedConstantData,
-    validation_requests::{RollupValidationRequests, ValidationRequests}
+    validation_requests::{RollupValidationRequests, ValidationRequests}, call_request::CallRequest
 };
 use crate::mocked::AggregationObject;
 
@@ -11,6 +11,7 @@ struct PublicKernelCircuitPublicInputs {
     end: PublicAccumulatedData,
     constants: CombinedConstantData,
     revert_code: u8,
+    public_teardown_call_request: CallRequest,
 }
 
 impl PublicKernelCircuitPublicInputs {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/public_kernel_circuit_public_inputs_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/public_kernel_circuit_public_inputs_builder.nr
@@ -3,7 +3,7 @@ use crate::{
     accumulated_data::{CombinedAccumulatedData, PublicAccumulatedDataBuilder},
     combined_constant_data::CombinedConstantData,
     kernel_circuit_public_inputs::{public_kernel_circuit_public_inputs::PublicKernelCircuitPublicInputs},
-    validation_requests::ValidationRequestsBuilder
+    validation_requests::ValidationRequestsBuilder, call_request::CallRequest
 },
     mocked::AggregationObject, traits::Empty
 };
@@ -15,6 +15,7 @@ struct PublicKernelCircuitPublicInputsBuilder {
     end: PublicAccumulatedDataBuilder,
     constants: CombinedConstantData,
     revert_code: u8,
+    public_teardown_call_request: CallRequest,
 }
 
 impl PublicKernelCircuitPublicInputsBuilder {
@@ -28,7 +29,8 @@ impl PublicKernelCircuitPublicInputsBuilder {
             end_non_revertible: self.end_non_revertible.finish(),
             end: self.end.finish(),
             constants: self.constants,
-            revert_code: self.revert_code
+            revert_code: self.revert_code,
+            public_teardown_call_request: self.public_teardown_call_request
         }
     }
 }
@@ -42,6 +44,7 @@ impl Empty for PublicKernelCircuitPublicInputsBuilder {
             end: PublicAccumulatedDataBuilder::empty(),
             constants: CombinedConstantData::empty(),
             revert_code: 0 as u8,
+            public_teardown_call_request: CallRequest::empty()
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -34,6 +34,7 @@ struct FixtureBuilder {
     historical_header: Header,
     tx_context: TxContext,
     global_variables: GlobalVariables,
+    public_teardown_call_request: CallRequest,
     
     // Accumulated data.
     new_note_hashes: BoundedVec<NoteHashContext, MAX_NEW_NOTE_HASHES_PER_TX>,
@@ -111,7 +112,8 @@ impl FixtureBuilder {
             start_state: PartialStateReference::empty(),
             gas_used: Gas::empty(),
             non_revertible_gas_used: Gas::empty(),
-            global_variables: GlobalVariables::empty()
+            global_variables: GlobalVariables::empty(),
+            public_teardown_call_request: CallRequest::empty()
         }
     }
 
@@ -189,7 +191,8 @@ impl FixtureBuilder {
             min_revertible_side_effect_counter: self.min_revertible_side_effect_counter,
             end,
             validation_requests,
-            constants
+            constants,
+            public_teardown_call_request: self.public_teardown_call_request
         }
     }
 
@@ -219,7 +222,8 @@ impl FixtureBuilder {
             end,
             validation_requests,
             constants,
-            revert_code: self.revert_code
+            revert_code: self.revert_code,
+            public_teardown_call_request: self.public_teardown_call_request
         }
     }
 
@@ -479,6 +483,7 @@ impl Empty for FixtureBuilder {
             start_state: PartialStateReference::empty(),
             gas_used: Gas::empty(),
             non_revertible_gas_used: Gas::empty(),
+            public_teardown_call_request: CallRequest::empty()
         }
     }
 }

--- a/yarn-project/circuit-types/src/tx/tx.ts
+++ b/yarn-project/circuit-types/src/tx/tx.ts
@@ -38,6 +38,10 @@ export class Tx {
      * Preimages of the public call stack entries from the private kernel circuit output.
      */
     public readonly enqueuedPublicFunctionCalls: PublicCallRequest[],
+    /**
+     * Public function call to be run by the sequencer as part of teardown.
+     */
+    public readonly publicTeardownFunctionCall: PublicCallRequest,
   ) {
     const kernelPublicCallStackSize = data.numberOfPublicCallRequests();
     if (kernelPublicCallStackSize !== enqueuedPublicFunctionCalls.length) {
@@ -65,6 +69,7 @@ export class Tx {
       reader.readObject(EncryptedTxL2Logs),
       reader.readObject(UnencryptedTxL2Logs),
       reader.readArray(reader.readNumber(), PublicCallRequest),
+      reader.readObject(PublicCallRequest),
     );
   }
 
@@ -80,6 +85,7 @@ export class Tx {
       this.unencryptedLogs,
       this.enqueuedPublicFunctionCalls.length,
       this.enqueuedPublicFunctionCalls,
+      this.publicTeardownFunctionCall,
     ]);
   }
 
@@ -94,6 +100,7 @@ export class Tx {
       unencryptedLogs: this.unencryptedLogs.toBuffer().toString('hex'),
       proof: this.proof.toBuffer().toString('hex'),
       enqueuedPublicFunctions: this.enqueuedPublicFunctionCalls.map(f => f.toBuffer().toString('hex')) ?? [],
+      publicTeardownFunctionCall: this.publicTeardownFunctionCall.toBuffer().toString('hex'),
     };
   }
 
@@ -119,7 +126,15 @@ export class Tx {
     const enqueuedPublicFunctions = obj.enqueuedPublicFunctions
       ? obj.enqueuedPublicFunctions.map((x: string) => PublicCallRequest.fromBuffer(Buffer.from(x, 'hex')))
       : [];
-    return new Tx(publicInputs, Proof.fromBuffer(proof), encryptedLogs, unencryptedLogs, enqueuedPublicFunctions);
+    const publicTeardownFunctionCall = PublicCallRequest.fromBuffer(Buffer.from(obj.publicTeardownFunctionCall, 'hex'));
+    return new Tx(
+      publicInputs,
+      Proof.fromBuffer(proof),
+      encryptedLogs,
+      unencryptedLogs,
+      enqueuedPublicFunctions,
+      publicTeardownFunctionCall,
+    );
   }
 
   /**
@@ -198,7 +213,15 @@ export class Tx {
     const enqueuedPublicFunctions = tx.enqueuedPublicFunctionCalls.map(x => {
       return PublicCallRequest.fromBuffer(x.toBuffer());
     });
-    return new Tx(publicInputs, proof, encryptedLogs, unencryptedLogs, enqueuedPublicFunctions);
+    const publicTeardownFunctionCall = PublicCallRequest.fromBuffer(tx.publicTeardownFunctionCall.toBuffer());
+    return new Tx(
+      publicInputs,
+      proof,
+      encryptedLogs,
+      unencryptedLogs,
+      enqueuedPublicFunctions,
+      publicTeardownFunctionCall,
+    );
   }
 }
 

--- a/yarn-project/circuits.js/src/structs/kernel/private_kernel_circuit_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/private_kernel_circuit_public_inputs.ts
@@ -2,6 +2,7 @@ import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
 import { AggregationObject } from '../aggregation_object.js';
+import { CallRequest } from '../call_request.js';
 import { ValidationRequests } from '../validation_requests.js';
 import { CombinedConstantData } from './combined_constant_data.js';
 import { PrivateAccumulatedData } from './private_accumulated_data.js';
@@ -31,6 +32,10 @@ export class PrivateKernelCircuitPublicInputs {
      * Data which is not modified by the circuits.
      */
     public constants: CombinedConstantData,
+    /**
+     * The call request for the public teardown function
+     */
+    public publicTeardownCallRequest: CallRequest,
   ) {}
 
   toBuffer() {
@@ -40,6 +45,7 @@ export class PrivateKernelCircuitPublicInputs {
       this.validationRequests,
       this.end,
       this.constants,
+      this.publicTeardownCallRequest,
     );
   }
 
@@ -56,6 +62,7 @@ export class PrivateKernelCircuitPublicInputs {
       reader.readObject(ValidationRequests),
       reader.readObject(PrivateAccumulatedData),
       reader.readObject(CombinedConstantData),
+      reader.readObject(CallRequest),
     );
   }
 
@@ -66,6 +73,7 @@ export class PrivateKernelCircuitPublicInputs {
       ValidationRequests.empty(),
       PrivateAccumulatedData.empty(),
       CombinedConstantData.empty(),
+      CallRequest.empty(),
     );
   }
 }

--- a/yarn-project/circuits.js/src/structs/kernel/private_kernel_tail_circuit_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/private_kernel_tail_circuit_public_inputs.ts
@@ -2,6 +2,7 @@ import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
 import { countAccumulatedItems, mergeAccumulatedData } from '../../utils/index.js';
 import { AggregationObject } from '../aggregation_object.js';
+import { CallRequest } from '../call_request.js';
 import { PartialStateReference } from '../partial_state_reference.js';
 import { RevertCode } from '../revert_code.js';
 import { RollupValidationRequests } from '../rollup_validation_requests.js';
@@ -26,6 +27,10 @@ export class PartialPrivateTailPublicInputsForPublic {
      * Data accumulated from both public and private circuits.
      */
     public end: PublicAccumulatedData,
+    /**
+     * Call request for the public teardown function.
+     */
+    public publicTeardownCallRequest: CallRequest,
   ) {}
 
   get needsSetup() {
@@ -46,11 +51,17 @@ export class PartialPrivateTailPublicInputsForPublic {
       reader.readObject(ValidationRequests),
       reader.readObject(PublicAccumulatedData),
       reader.readObject(PublicAccumulatedData),
+      reader.readObject(CallRequest),
     );
   }
 
   toBuffer() {
-    return serializeToBuffer(this.validationRequests, this.endNonRevertibleData, this.end);
+    return serializeToBuffer(
+      this.validationRequests,
+      this.endNonRevertibleData,
+      this.end,
+      this.publicTeardownCallRequest,
+    );
   }
 
   static empty() {
@@ -58,6 +69,7 @@ export class PartialPrivateTailPublicInputsForPublic {
       ValidationRequests.empty(),
       PublicAccumulatedData.empty(),
       PublicAccumulatedData.empty(),
+      CallRequest.empty(),
     );
   }
 }
@@ -123,6 +135,7 @@ export class PrivateKernelTailCircuitPublicInputs {
       this.forPublic.end,
       this.constants,
       this.revertCode,
+      this.forPublic.publicTeardownCallRequest,
     );
   }
 

--- a/yarn-project/circuits.js/src/structs/kernel/public_kernel_circuit_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/public_kernel_circuit_public_inputs.ts
@@ -3,6 +3,7 @@ import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import { inspect } from 'util';
 
 import { AggregationObject } from '../aggregation_object.js';
+import { CallRequest } from '../call_request.js';
 import { RevertCode } from '../revert_code.js';
 import { ValidationRequests } from '../validation_requests.js';
 import { CombinedConstantData } from './combined_constant_data.js';
@@ -38,6 +39,10 @@ export class PublicKernelCircuitPublicInputs {
      * Indicates whether execution of the public circuit reverted.
      */
     public revertCode: RevertCode,
+    /**
+     * The call request for the public teardown function
+     */
+    public publicTeardownCallRequest: CallRequest,
   ) {}
 
   toBuffer() {
@@ -48,6 +53,7 @@ export class PublicKernelCircuitPublicInputs {
       this.end,
       this.constants,
       this.revertCode,
+      this.publicTeardownCallRequest,
     );
   }
 
@@ -85,6 +91,7 @@ export class PublicKernelCircuitPublicInputs {
       reader.readObject(PublicAccumulatedData),
       reader.readObject(CombinedConstantData),
       reader.readObject(RevertCode),
+      reader.readObject(CallRequest),
     );
   }
 
@@ -96,6 +103,7 @@ export class PublicKernelCircuitPublicInputs {
       PublicAccumulatedData.empty(),
       CombinedConstantData.empty(),
       RevertCode.OK,
+      CallRequest.empty(),
     );
   }
 
@@ -106,7 +114,8 @@ export class PublicKernelCircuitPublicInputs {
       endNonRevertibleData: ${inspect(this.endNonRevertibleData)},
       end: ${inspect(this.end)},
       constants: ${inspect(this.constants)},
-      revertCode: ${this.revertCode}
+      revertCode: ${this.revertCode},
+      publicTeardownCallRequest: ${inspect(this.publicTeardownCallRequest)}
       }`;
   }
 }

--- a/yarn-project/circuits.js/src/structs/public_call_request.ts
+++ b/yarn-project/circuits.js/src/structs/public_call_request.ts
@@ -132,4 +132,18 @@ export class PublicCallRequest {
   getArgsHash() {
     return computeVarArgsHash(this.args);
   }
+
+  static empty() {
+    return new PublicCallRequest(AztecAddress.ZERO, FunctionData.empty(), CallContext.empty(), CallContext.empty(), []);
+  }
+
+  isEmpty(): boolean {
+    return (
+      this.contractAddress.isZero() &&
+      this.functionData.isEmpty() &&
+      this.callContext.isEmpty() &&
+      this.parentCallContext.isEmpty() &&
+      this.args.length === 0
+    );
+  }
 }

--- a/yarn-project/circuits.js/src/tests/factories.ts
+++ b/yarn-project/circuits.js/src/tests/factories.ts
@@ -470,6 +470,7 @@ export function makePublicKernelCircuitPublicInputs(
     makePublicAccumulatedData(seed, fullAccumulatedData),
     makeConstantData(seed + 0x100),
     RevertCode.OK,
+    makeCallRequest(seed + 0x200),
   );
 }
 
@@ -485,6 +486,7 @@ export function makePrivateKernelCircuitPublicInputs(seed = 1, full = true): Pri
     makeValidationRequests(seed),
     makePrivateAccumulatedData(seed, full),
     makeConstantData(seed + 0x100),
+    makeCallRequest(seed + 0x200),
   );
 }
 
@@ -502,6 +504,7 @@ export function makePrivateKernelTailCircuitPublicInputs(
         ValidationRequests.empty(),
         makePublicAccumulatedData(seed + 0x100, false),
         makePublicAccumulatedData(seed + 0x200, false),
+        makeCallRequest(seed + 0x300),
       )
     : undefined;
   const forRollup = !isForPublic

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -197,7 +197,7 @@ describe('e2e_block_building', () => {
       ({ teardown, pxe, logger, wallet: owner } = await setup(1));
       logger.info(`Deploying test contract`);
       testContract = await TestContract.deploy(owner).send().deployed();
-    }, 30_000);
+    }, 60_000);
 
     it('calls a method with nested unencrypted logs', async () => {
       const tx = await testContract.methods.emit_unencrypted_logs_nested([1, 2, 3, 4, 5]).send().wait();

--- a/yarn-project/noir-protocol-circuits-types/src/type_conversion.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/type_conversion.ts
@@ -1251,6 +1251,7 @@ export function mapPublicKernelCircuitPublicInputsToNoir(
     end: mapPublicAccumulatedDataToNoir(inputs.end),
     end_non_revertible: mapPublicAccumulatedDataToNoir(inputs.endNonRevertibleData),
     revert_code: mapRevertCodeToNoir(inputs.revertCode),
+    public_teardown_call_request: mapCallRequestToNoir(inputs.publicTeardownCallRequest),
   };
 }
 
@@ -1317,6 +1318,7 @@ export function mapPrivateKernelCircuitPublicInputsFromNoir(
     mapValidationRequestsFromNoir(inputs.validation_requests),
     mapPrivateAccumulatedDataFromNoir(inputs.end),
     mapCombinedConstantDataFromNoir(inputs.constants),
+    mapCallRequestFromNoir(inputs.public_teardown_call_request),
   );
 }
 
@@ -1329,6 +1331,7 @@ export function mapPrivateKernelCircuitPublicInputsToNoir(
     validation_requests: mapValidationRequestsToNoir(inputs.validationRequests),
     end: mapPrivateAccumulatedDataToNoir(inputs.end),
     min_revertible_side_effect_counter: mapFieldToNoir(inputs.minRevertibleSideEffectCounter),
+    public_teardown_call_request: mapCallRequestToNoir(inputs.publicTeardownCallRequest),
   };
 }
 
@@ -1370,6 +1373,7 @@ export function mapPrivateKernelTailCircuitPublicInputsForPublicFromNoir(
     mapValidationRequestsFromNoir(inputs.validation_requests),
     mapPublicAccumulatedDataFromNoir(inputs.end_non_revertible),
     mapPublicAccumulatedDataFromNoir(inputs.end),
+    mapCallRequestFromNoir(inputs.public_teardown_call_request),
   );
   return new PrivateKernelTailCircuitPublicInputs(
     AggregationObject.makeFake(),
@@ -1487,6 +1491,7 @@ export function mapPublicKernelCircuitPublicInputsFromNoir(
     mapPublicAccumulatedDataFromNoir(inputs.end),
     mapCombinedConstantDataFromNoir(inputs.constants),
     mapRevertCodeFromNoir(inputs.revert_code),
+    mapCallRequestFromNoir(inputs.public_teardown_call_request),
   );
 }
 

--- a/yarn-project/p2p/src/service/tx_messages.ts
+++ b/yarn-project/p2p/src/service/tx_messages.ts
@@ -146,6 +146,7 @@ export function toTxMessage(tx: Tx): Buffer {
     createMessageComponent(tx.encryptedLogs),
     createMessageComponent(tx.unencryptedLogs),
     createMessageComponents(tx.enqueuedPublicFunctionCalls),
+    createMessageComponent(tx.publicTeardownFunctionCall),
   ]);
   const messageLength = numToUInt32BE(messageBuffer.length);
   return Buffer.concat([messageLength, messageBuffer]);
@@ -198,5 +199,14 @@ export function fromTxMessage(buffer: Buffer): Tx {
   }
 
   const publicCalls = toObjectArray(unencryptedLogs.remainingData, PublicCallRequest);
-  return new Tx(publicInputs.obj!, proof.obj!, encryptedLogs.obj, unencryptedLogs.obj, publicCalls.objects);
+
+  const publicTeardownCall = toObject(publicCalls.remainingData, PublicCallRequest);
+  return new Tx(
+    publicInputs.obj!,
+    proof.obj!,
+    encryptedLogs.obj,
+    unencryptedLogs.obj,
+    publicCalls.objects,
+    publicTeardownCall.obj!,
+  );
 }

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -30,7 +30,7 @@ import {
   MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX,
   type PartialAddress,
   type PrivateKernelTailCircuitPublicInputs,
-  type PublicCallRequest,
+  PublicCallRequest,
   computeContractClassId,
   getContractClassFromArtifact,
 } from '@aztec/circuits.js';
@@ -670,12 +670,20 @@ export class PXEService implements PXE {
     const unencryptedLogs = new UnencryptedTxL2Logs([collectSortedUnencryptedLogs(executionResult)]);
     const encryptedLogs = new EncryptedTxL2Logs([collectSortedEncryptedLogs(executionResult)]);
     const enqueuedPublicFunctions = collectEnqueuedPublicFunctionCalls(executionResult);
+    const teardownPublicFunction = PublicCallRequest.empty();
 
     // HACK(#1639): Manually patches the ordering of the public call stack
     // TODO(#757): Enforce proper ordering of enqueued public calls
     await this.patchPublicCallStackOrdering(publicInputs, enqueuedPublicFunctions);
 
-    const tx = new Tx(publicInputs, proof, encryptedLogs, unencryptedLogs, enqueuedPublicFunctions);
+    const tx = new Tx(
+      publicInputs,
+      proof,
+      encryptedLogs,
+      unencryptedLogs,
+      enqueuedPublicFunctions,
+      teardownPublicFunction,
+    );
     return new SimulatedTx(tx, executionResult.returnValues);
   }
 


### PR DESCRIPTION
See [spec](https://66352ac52788c434c51f41cb--aztec-docs-dev.netlify.app/protocol-specs/gas-and-fees/kernel-tracking).

Only deviation is that I dropped the notion of PublicConstantData because we were pushing `fee_payer` into it for `PublicKernelCircuitPublicInputs`, only to lift it back to the top level of `KernelCircuitPublicInputs`. So this simplifies the structs a bit.