### PR TITLE
chore: bump bb.js timeouts

### DIFF
--- a/barretenberg/ts/src/barretenberg/common.test.ts
+++ b/barretenberg/ts/src/barretenberg/common.test.ts
@@ -5,10 +5,12 @@ describe('env', () => {
 
   beforeAll(async () => {
     api = await Barretenberg.new({ threads: 3 });
-  }, 15000);
+  }, 30000);
 
   afterAll(async () => {
-    await api.destroy();
+    if (api) {
+      await api.destroy();
+    }
   });
 
   it('thread test', async () => {

--- a/barretenberg/ts/src/examples/simple.test.ts
+++ b/barretenberg/ts/src/examples/simple.test.ts
@@ -14,7 +14,7 @@ describe('simple', () => {
 
     const crs = await Crs.new(2 ** 19 + 1);
     await api.srsInitSrs(new RawBuffer(crs.getG1Data()), crs.numPoints, new RawBuffer(crs.getG2Data()));
-  }, 30000);
+  }, 60000);
 
   afterAll(async () => {
     await api.destroy();


### PR DESCRIPTION
Seem to be hitting timeouts with new bb.js tests. This is a big worrying, means builds could be interfering with each other, but doing this for stability