### PR TITLE
chore: Debug log oracle calls return nothing

### DIFF
--- a/noir-projects/noir-contracts/contracts/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/counter_contract/src/main.nr
@@ -26,6 +26,7 @@ contract Counter {
     // docs:start:increment
     #[aztec(private)]
     fn increment(owner: AztecAddress) {
+        dep::aztec::oracle::debug_log::debug_log_format("Incrementing counter for owner {0}", [owner.to_field()]);
         let counters = storage.counters;
         counters.at(owner).add(1, owner);
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/debug_log.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/debug_log.nr
@@ -2,21 +2,21 @@
 // WARNING: sometimes when using debug logs the ACVM errors with: `thrown: "solver opcode resolution error: cannot solve opcode: expression has too many unknowns x155"`
 
 #[oracle(debugLog)]
-fn debug_log_oracle<T, N>(_msg: T, _num_args: Field) -> Field {}
+fn debug_log_oracle<T, N>(_msg: T, _num_args: Field) {}
 #[oracle(debugLog)]
-fn debug_log_format_oracle<T, N>(_msg: T, _args: [Field; N], _num_args: Field) -> Field {}
+fn debug_log_format_oracle<T, N>(_msg: T, _args: [Field; N], _num_args: Field) {}
 #[oracle(debugLog)]
-fn debug_log_field_oracle(_field: Field) -> Field {}
+fn debug_log_field_oracle(_field: Field) {}
 #[oracle(debugLog)]
-fn debug_log_array_oracle<T, N>(_arbitrary_array: [T; N]) -> Field {}
+fn debug_log_array_oracle<T, N>(_arbitrary_array: [T; N]) {}
 #[oracle(debugLogWithPrefix)]
-fn debug_log_array_with_prefix_oracle<S, T, N>(_prefix: S, _arbitrary_array: [T; N]) -> Field {}
+fn debug_log_array_with_prefix_oracle<S, T, N>(_prefix: S, _arbitrary_array: [T; N]) {}
 
 /// NOTE: call this with a str<N> msg of length > 1
 /// Example:
 /// `debug_log("blah blah this is a debug string");`
 unconstrained pub fn debug_log<T>(msg: T) {
-    assert(debug_log_oracle(msg, 0) == 0);
+    debug_log_oracle(msg, 0);
 }
 
 /// NOTE: call this with a str<N> msg of form
@@ -26,23 +26,23 @@ unconstrained pub fn debug_log<T>(msg: T) {
 /// Example:
 /// debug_log_format("get_2(slot:{0}) =>\n\t0:{1}\n\t1:{2}", [storage_slot, note0_hash, note1_hash]);
 unconstrained pub fn debug_log_format<T, N>(msg: T, args: [Field; N]) {
-    assert(debug_log_format_oracle(msg, args, args.len() as Field) == 0);
+    debug_log_format_oracle(msg, args, args.len() as Field);
 }
 
 /// Example:
 /// `debug_log_field(my_field);`
 unconstrained pub fn debug_log_field(field: Field) {
-    assert(debug_log_field_oracle(field) == 0);
+    debug_log_field_oracle(field);
 }
 
 /// Example:
 /// `debug_log_array(my_array);`
 unconstrained fn debug_log_array<T, N>(arbitrary_array: [T; N]) {
-    assert(debug_log_array_oracle(arbitrary_array) == 0);
+    debug_log_array_oracle(arbitrary_array);
 }
 
 /// Example:
 /// `debug_log_array_with_prefix("Prefix", my_array);`
 unconstrained pub fn debug_log_array_with_prefix<S, T, N>(prefix: S, arbitrary_array: [T; N]) {
-    assert(debug_log_array_with_prefix_oracle(prefix, arbitrary_array) == 0);
+    debug_log_array_with_prefix_oracle(prefix, arbitrary_array);
 }

--- a/yarn-project/noir-protocol-circuits-types/src/index.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/index.ts
@@ -2,7 +2,6 @@ import {
   type BaseOrMergeRollupPublicInputs,
   type BaseParityInputs,
   type BaseRollupInputs,
-  Fr,
   type KernelCircuitPublicInputs,
   type MergeRollupInputs,
   type ParityPublicInputs,
@@ -25,6 +24,7 @@ import { type NoirCompiledCircuit } from '@aztec/types/noir';
 
 import {
   type ForeignCallInput,
+  type ForeignCallOutput,
   type WasmBlackBoxFunctionSolver,
   createBlackBoxSolver,
   executeCircuitWithBlackBoxSolver,
@@ -755,7 +755,7 @@ async function executePrivateKernelTailToPublicWithACVM(
   return decodedInputs.return_value as PublicPublicPreviousReturnType;
 }
 
-export const foreignCallHandler = (name: string, args: ForeignCallInput[]) => {
+export function foreignCallHandler(name: string, args: ForeignCallInput[]): Promise<ForeignCallOutput[]> {
   const log = createDebugLogger('aztec:noir-protocol-circuits:oracle');
 
   if (name === 'debugLog') {
@@ -766,5 +766,5 @@ export const foreignCallHandler = (name: string, args: ForeignCallInput[]) => {
     throw Error(`unexpected oracle during execution: ${name}`);
   }
 
-  return Promise.resolve([`0x${Buffer.alloc(Fr.SIZE_IN_BYTES).toString('hex')}`]);
-};
+  return Promise.resolve([]);
+}

--- a/yarn-project/simulator/src/acvm/acvm.ts
+++ b/yarn-project/simulator/src/acvm/acvm.ts
@@ -105,7 +105,7 @@ export async function acvm(
         }
 
         const result = await oracleFunction.call(callback, ...args);
-        return [result];
+        return Array.isArray(result) && result.length === 0 ? [] : [result];
       } catch (err) {
         let typedError: Error;
         if (err instanceof Error) {

--- a/yarn-project/simulator/src/acvm/acvm.ts
+++ b/yarn-project/simulator/src/acvm/acvm.ts
@@ -19,7 +19,7 @@ import { type ORACLE_NAMES } from './oracle/index.js';
  */
 type ACIRCallback = Record<
   ORACLE_NAMES,
-  (...args: ForeignCallInput[]) => ForeignCallOutput | Promise<ForeignCallOutput>
+  (...args: ForeignCallInput[]) => void | ForeignCallOutput | Promise<ForeignCallOutput>
 >;
 
 /**
@@ -105,7 +105,7 @@ export async function acvm(
         }
 
         const result = await oracleFunction.call(callback, ...args);
-        return Array.isArray(result) && result.length === 0 ? [] : [result];
+        return typeof result === 'undefined' ? [] : [result];
       } catch (err) {
         let typedError: Error;
         if (err instanceof Error) {

--- a/yarn-project/simulator/src/acvm/oracle/oracle.ts
+++ b/yarn-project/simulator/src/acvm/oracle/oracle.ts
@@ -373,14 +373,14 @@ export class Oracle {
     return toACVMField(logHash);
   }
 
-  debugLog(...args: ACVMField[][]): ACVMField {
+  debugLog(...args: ACVMField[][]): ACVMField[] {
     this.log.verbose(oracleDebugCallToFormattedStr(args));
-    return toACVMField(0);
+    return [];
   }
 
-  debugLogWithPrefix(arg0: ACVMField[], ...args: ACVMField[][]): ACVMField {
+  debugLogWithPrefix(arg0: ACVMField[], ...args: ACVMField[][]): ACVMField[] {
     this.log.verbose(`${acvmFieldMessageToString(arg0)}: ${oracleDebugCallToFormattedStr(args)}`);
-    return toACVMField(0);
+    return [];
   }
 
   async callPrivateFunction(

--- a/yarn-project/simulator/src/acvm/oracle/oracle.ts
+++ b/yarn-project/simulator/src/acvm/oracle/oracle.ts
@@ -373,14 +373,12 @@ export class Oracle {
     return toACVMField(logHash);
   }
 
-  debugLog(...args: ACVMField[][]): ACVMField[] {
+  debugLog(...args: ACVMField[][]): void {
     this.log.verbose(oracleDebugCallToFormattedStr(args));
-    return [];
   }
 
-  debugLogWithPrefix(arg0: ACVMField[], ...args: ACVMField[][]): ACVMField[] {
+  debugLogWithPrefix(arg0: ACVMField[], ...args: ACVMField[][]): void {
     this.log.verbose(`${acvmFieldMessageToString(arg0)}: ${oracleDebugCallToFormattedStr(args)}`);
-    return [];
   }
 
   async callPrivateFunction(


### PR DESCRIPTION
After https://github.com/noir-lang/noir/pull/4959 lands in aztec-packages, we should be able to keep debug_log calls in protocol-circuits without breaking nargo test there. A prerequisite for that is ensuring that debug log calls do not return anything. I understand they were returning zero because of legacy issues, but according to @TomFrench that should not be needed.

This PR updates debug calls so they return no values.
