### PR TITLE
refactor: replacing old pub key oracle with get_ivpk_m

### DIFF
--- a/docs/docs/misc/migration_notes.md
+++ b/docs/docs/misc/migration_notes.md
@@ -12,9 +12,22 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 
 The type signature for `SharedMutable` changed from `SharedMutable<T, DELAY>` to `SharedMutable<T, INITIAL_DELAY>`. The behavior is the same as before, except the delay can now be changed after deployment by calling `schedule_delay_change`.
 
+### [Aztec.nr] get_public_key oracle replaced with get_ivpk_m
+
+When implementing changes according to a [new key scheme](https://yp-aztec.netlify.app/docs/addresses-and-keys/keys) we had to change oracles.
+What used to be called encryption public key is now master incoming viewing public key.
+
+```diff
+- use dep::aztec::oracles::get_public_key::get_public_key;
++ use dep::aztec::keys::getters::get_ivpk_m;
+
+- let encryption_pub_key = get_public_key(self.owner);
++ let ivpk_m = get_ivpk_m(context, self.owner);
+```
+
 ## 0.38.0
 
-### [Aztec.nr] Emmiting encrypted logs
+### [Aztec.nr] Emitting encrypted logs
 
 The `emit_encrypted_log` function is now a context method.
 

--- a/noir-projects/aztec-nr/address-note/src/address_note.nr
+++ b/noir-projects/aztec-nr/address-note/src/address_note.nr
@@ -1,7 +1,8 @@
 use dep::aztec::{
+    keys::getters::get_ivpk_m,
     protocol_types::{address::AztecAddress, traits::Empty, constants::GENERATOR_INDEX__NOTE_NULLIFIER},
     note::{note_header::NoteHeader, note_interface::NoteInterface, utils::compute_note_hash_for_consumption},
-    oracle::{unsafe_rand::unsafe_rand, nullifier_key::get_app_nullifier_secret_key, get_public_key::get_public_key},
+    oracle::{unsafe_rand::unsafe_rand, nullifier_key::get_app_nullifier_secret_key},
     context::PrivateContext, hash::poseidon2_hash
 };
 
@@ -40,13 +41,13 @@ impl NoteInterface<ADDRESS_NOTE_LEN> for AddressNote {
 
     // Broadcasts the note as an encrypted log on L1.
     fn broadcast(self, context: &mut PrivateContext, slot: Field) {
-        let encryption_pub_key = get_public_key(self.owner);
+        let ivpk_m = get_ivpk_m(context, self.owner);
         // docs:start:encrypted
         context.emit_encrypted_log(
             (*context).this_address(),
             slot,
             Self::get_note_type_id(),
-            encryption_pub_key,
+            ivpk_m,
             self.serialize_content(),
         );
         // docs:end:encrypted

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -286,7 +286,7 @@ impl PrivateContext {
         contract_address: AztecAddress,
         storage_slot: Field,
         note_type_id: Field,
-        encryption_pub_key: GrumpkinPoint,
+        ivpk_m: GrumpkinPoint,
         preimage: [Field; N]
     ) where [Field; N]: LensForEncryptedLog<N, M, L> {
         // TODO(1139): perform encryption in the circuit
@@ -296,7 +296,7 @@ impl PrivateContext {
             contract_address,
             storage_slot,
             note_type_id,
-            encryption_pub_key,
+            ivpk_m,
             preimage,
             counter
         );

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/body.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/body.nr
@@ -67,7 +67,7 @@ mod test {
 
     use crate::{
         note::{note_header::NoteHeader, note_interface::NoteInterface, utils::compute_note_hash_for_consumption},
-        oracle::{unsafe_rand::unsafe_rand, nullifier_key::get_app_nullifier_secret_key, get_public_key::get_public_key},
+        oracle::{unsafe_rand::unsafe_rand, nullifier_key::get_app_nullifier_secret_key},
         context::PrivateContext, hash::poseidon2_hash
     };
 

--- a/noir-projects/aztec-nr/aztec/src/oracle.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle.nr
@@ -10,7 +10,6 @@ mod get_l1_to_l2_membership_witness;
 mod get_nullifier_membership_witness;
 mod get_public_data_witness;
 mod get_membership_witness;
-mod get_public_key;
 mod keys;
 mod nullifier_key;
 mod get_sibling_path;

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_public_key.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_public_key.nr
@@ -1,8 +1,0 @@
-use dep::protocol_types::{address::AztecAddress, grumpkin_point::GrumpkinPoint};
-use crate::oracle::keys::get_public_keys_and_partial_address;
-
-// To be nuked in my next PR: https://github.com/AztecProtocol/aztec-packages/pull/6219
-pub fn get_public_key(address: AztecAddress) -> GrumpkinPoint {
-    let result = get_public_keys_and_partial_address(address);
-    result.0[1]
-}

--- a/noir-projects/aztec-nr/aztec/src/oracle/keys.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/keys.nr
@@ -1,7 +1,5 @@
 use dep::protocol_types::{address::{AztecAddress, PartialAddress}, grumpkin_point::GrumpkinPoint};
 
-use crate::hash::poseidon2_hash;
-
 #[oracle(getPublicKeysAndPartialAddress)]
 fn get_public_keys_and_partial_address_oracle(_address: AztecAddress) -> [Field; 9] {}
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/logs.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/logs.nr
@@ -17,7 +17,7 @@ unconstrained pub fn emit_encrypted_log<N, M>(
     contract_address: AztecAddress,
     storage_slot: Field,
     note_type_id: Field,
-    encryption_pub_key: GrumpkinPoint,
+    ivpk_m: GrumpkinPoint,
     preimage: [Field; N],
     counter: u32
 ) -> [Field; M] {
@@ -25,7 +25,7 @@ unconstrained pub fn emit_encrypted_log<N, M>(
         contract_address,
         storage_slot,
         note_type_id,
-        encryption_pub_key,
+        ivpk_m,
         preimage,
         counter
     )

--- a/noir-projects/aztec-nr/value-note/src/utils.nr
+++ b/noir-projects/aztec-nr/value-note/src/utils.nr
@@ -1,6 +1,6 @@
 use dep::aztec::prelude::{AztecAddress, PrivateContext, PrivateSet, NoteGetterOptions};
 use dep::aztec::note::note_getter_options::SortOrder;
-use dep::aztec::oracle::get_public_key::get_public_key;
+use dep::aztec::keys::getters::get_ivpk_m;
 use crate::{filter::filter_notes_min_sum, value_note::{ValueNote, VALUE_NOTE_LEN}};
 
 // Sort the note values (0th field) in descending order.

--- a/noir-projects/aztec-nr/value-note/src/utils.nr
+++ b/noir-projects/aztec-nr/value-note/src/utils.nr
@@ -1,6 +1,5 @@
 use dep::aztec::prelude::{AztecAddress, PrivateContext, PrivateSet, NoteGetterOptions};
 use dep::aztec::note::note_getter_options::SortOrder;
-use dep::aztec::keys::getters::get_ivpk_m;
 use crate::{filter::filter_notes_min_sum, value_note::{ValueNote, VALUE_NOTE_LEN}};
 
 // Sort the note values (0th field) in descending order.

--- a/noir-projects/aztec-nr/value-note/src/value_note.nr
+++ b/noir-projects/aztec-nr/value-note/src/value_note.nr
@@ -1,9 +1,6 @@
 use dep::aztec::{
     keys::getters::get_ivpk_m,
-    protocol_types::{
-    address::AztecAddress, traits::{Deserialize, Serialize},
-    constants::GENERATOR_INDEX__NOTE_NULLIFIER
-},
+    protocol_types::{address::AztecAddress, traits::{Deserialize, Serialize}, constants::GENERATOR_INDEX__NOTE_NULLIFIER},
     note::{note_header::NoteHeader, note_interface::NoteInterface, utils::compute_note_hash_for_consumption},
     oracle::{unsafe_rand::unsafe_rand, nullifier_key::get_app_nullifier_secret_key},
     hash::poseidon2_hash, context::PrivateContext

--- a/noir-projects/aztec-nr/value-note/src/value_note.nr
+++ b/noir-projects/aztec-nr/value-note/src/value_note.nr
@@ -1,7 +1,11 @@
 use dep::aztec::{
-    protocol_types::{address::AztecAddress, traits::{Deserialize, Serialize}, constants::GENERATOR_INDEX__NOTE_NULLIFIER},
+    keys::getters::get_ivpk_m,
+    protocol_types::{
+    address::AztecAddress, traits::{Deserialize, Serialize},
+    constants::GENERATOR_INDEX__NOTE_NULLIFIER
+},
     note::{note_header::NoteHeader, note_interface::NoteInterface, utils::compute_note_hash_for_consumption},
-    oracle::{unsafe_rand::unsafe_rand, nullifier_key::get_app_nullifier_secret_key, get_public_key::get_public_key},
+    oracle::{unsafe_rand::unsafe_rand, nullifier_key::get_app_nullifier_secret_key},
     hash::poseidon2_hash, context::PrivateContext
 };
 
@@ -43,12 +47,12 @@ impl NoteInterface<VALUE_NOTE_LEN> for ValueNote {
 
     // Broadcasts the note as an encrypted log on L1.
     fn broadcast(self, context: &mut PrivateContext, slot: Field) {
-        let encryption_pub_key = get_public_key(self.owner);
+        let ivpk_m = get_ivpk_m(context, self.owner);
         context.emit_encrypted_log(
             (*context).this_address(),
             slot,
             Self::get_note_type_id(),
-            encryption_pub_key,
+            ivpk_m,
             self.serialize_content(),
         );
     }

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -12,7 +12,7 @@ contract AppSubscription {
 
     use dep::aztec::protocol_types::traits::is_empty;
 
-    use dep::aztec::{context::Context, oracle::get_public_key::get_public_key};
+    use dep::aztec::{context::Context, keys::getters::get_ivpk_m};
     use dep::authwit::{account::AccountActions, auth_witness::get_auth_witness, auth::assert_current_call_valid_authwit};
 
     use crate::subscription_note::{SubscriptionNote, SUBSCRIPTION_NOTE_LEN};

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -2,23 +2,18 @@ mod subscription_note;
 mod dapp_payload;
 
 contract AppSubscription {
-    use dep::std;
-    use crate::dapp_payload::DAppPayload;
-
-    use dep::aztec::prelude::{
+    use crate::{dapp_payload::DAppPayload, subscription_note::{SubscriptionNote, SUBSCRIPTION_NOTE_LEN}};
+    use dep::{
+        aztec::{
+        prelude::{
         AztecAddress, FunctionSelector, PrivateContext, NoteHeader, Map, PrivateMutable, PublicMutable,
         SharedImmutable
+    },
+        protocol_types::traits::is_empty
+    },
+        authwit::{account::AccountActions, auth_witness::get_auth_witness, auth::assert_current_call_valid_authwit},
+        gas_token::GasToken, token::Token
     };
-
-    use dep::aztec::protocol_types::traits::is_empty;
-
-    use dep::aztec::{context::Context, keys::getters::get_ivpk_m};
-    use dep::authwit::{account::AccountActions, auth_witness::get_auth_witness, auth::assert_current_call_valid_authwit};
-
-    use crate::subscription_note::{SubscriptionNote, SUBSCRIPTION_NOTE_LEN};
-
-    use dep::gas_token::GasToken;
-    use dep::token::Token;
 
     #[aztec(storage)]
     struct Storage {

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/subscription_note.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/subscription_note.nr
@@ -1,8 +1,8 @@
 use dep::aztec::prelude::{AztecAddress, PrivateContext, NoteHeader, NoteInterface};
 use dep::aztec::{
-    protocol_types::constants::GENERATOR_INDEX__NOTE_NULLIFIER,
+    keys::getters::get_ivpk_m, protocol_types::constants::GENERATOR_INDEX__NOTE_NULLIFIER,
     note::utils::compute_note_hash_for_consumption, hash::poseidon2_hash,
-    oracle::{nullifier_key::get_app_nullifier_secret_key, get_public_key::get_public_key}
+    oracle::{nullifier_key::get_app_nullifier_secret_key}
 };
 
 global SUBSCRIPTION_NOTE_LEN: Field = 3;
@@ -39,12 +39,12 @@ impl NoteInterface<SUBSCRIPTION_NOTE_LEN> for SubscriptionNote {
 
     // Broadcasts the note as an encrypted log on L1.
     fn broadcast(self, context: &mut PrivateContext, slot: Field) {
-        let encryption_pub_key = get_public_key(self.owner);
+        let ivpk_m = get_ivpk_m(context, self.owner);
         context.emit_encrypted_log(
             (*context).this_address(),
             slot,
             Self::get_note_type_id(),
-            encryption_pub_key,
+            ivpk_m,
             self.serialize_content(),
         );
     }

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/types/card_note.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/types/card_note.nr
@@ -1,8 +1,8 @@
 use dep::aztec::prelude::{AztecAddress, NoteInterface, NoteHeader, PrivateContext};
 use dep::aztec::{
-    note::{utils::compute_note_hash_for_consumption},
-    oracle::{nullifier_key::get_app_nullifier_secret_key, get_public_key::get_public_key},
-    hash::poseidon2_hash, protocol_types::{traits::Empty, constants::GENERATOR_INDEX__NOTE_NULLIFIER}
+    keys::getters::get_ivpk_m, note::{utils::compute_note_hash_for_consumption},
+    oracle::nullifier_key::get_app_nullifier_secret_key, hash::poseidon2_hash,
+    protocol_types::{traits::Empty, constants::GENERATOR_INDEX__NOTE_NULLIFIER}
 };
 
 // Shows how to create a custom note
@@ -47,12 +47,12 @@ impl NoteInterface<CARD_NOTE_LEN> for CardNote {
 
     // Broadcasts the note as an encrypted log on L1.
     fn broadcast(self, context: &mut PrivateContext, slot: Field) {
-        let encryption_pub_key = get_public_key(self.owner);
+        let ivpk_m = get_ivpk_m(context, self.owner);
         context.emit_encrypted_log(
             (*context).this_address(),
             slot,
             Self::get_note_type_id(),
-            encryption_pub_key,
+            ivpk_m,
             self.serialize_content(),
         );
     }

--- a/noir-projects/noir-contracts/contracts/ecdsa_account_contract/src/ecdsa_public_key_note.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_account_contract/src/ecdsa_public_key_note.nr
@@ -1,9 +1,9 @@
 use dep::aztec::prelude::{AztecAddress, FunctionSelector, NoteHeader, NoteInterface, NoteGetterOptions, PrivateContext};
 
 use dep::aztec::{
-    note::utils::compute_note_hash_for_consumption,
-    oracle::{nullifier_key::get_app_nullifier_secret_key, get_public_key::get_public_key},
-    hash::poseidon2_hash, protocol_types::constants::GENERATOR_INDEX__NOTE_NULLIFIER
+    keys::getters::get_ivpk_m, note::utils::compute_note_hash_for_consumption,
+    oracle::nullifier_key::get_app_nullifier_secret_key, hash::poseidon2_hash,
+    protocol_types::constants::GENERATOR_INDEX__NOTE_NULLIFIER
 };
 
 global ECDSA_PUBLIC_KEY_NOTE_LEN: Field = 5;
@@ -85,12 +85,12 @@ impl NoteInterface<ECDSA_PUBLIC_KEY_NOTE_LEN> for EcdsaPublicKeyNote {
 
     // Broadcasts the note as an encrypted log on L1.
     fn broadcast(self, context: &mut PrivateContext, slot: Field) {
-        let encryption_pub_key = get_public_key(self.owner);
+        let ivpk_m = get_ivpk_m(context, self.owner);
         context.emit_encrypted_log(
             (*context).this_address(),
             slot,
             Self::get_note_type_id(),
-            encryption_pub_key,
+            ivpk_m,
             self.serialize_content(),
         );
     }

--- a/noir-projects/noir-contracts/contracts/ecdsa_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_account_contract/src/main.nr
@@ -8,7 +8,7 @@ contract EcdsaAccount {
     use dep::aztec::protocol_types::abis::call_context::CallContext;
     use dep::std;
 
-    use dep::aztec::{context::{PublicContext, Context}, oracle::get_public_key::get_public_key};
+    use dep::aztec::context::Context;
     use dep::authwit::{
         entrypoint::{app::AppPayload, fee::FeePayload}, account::AccountActions,
         auth_witness::get_auth_witness

--- a/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
@@ -2,7 +2,7 @@
 contract Escrow {
     use dep::aztec::prelude::{AztecAddress, EthAddress, FunctionSelector, NoteHeader, PrivateContext, PrivateImmutable};
 
-    use dep::aztec::{context::{PublicContext, Context}, oracle::get_public_key::get_public_key};
+    use dep::aztec::context::{PublicContext, Context};
 
     use dep::address_note::address_note::AddressNote;
 

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -7,7 +7,7 @@ contract SchnorrAccount {
 
     use dep::aztec::prelude::{AztecAddress, FunctionSelector, NoteHeader, PrivateContext, PrivateImmutable};
     use dep::aztec::state_vars::{Map, PublicMutable};
-    use dep::aztec::{context::Context, oracle::get_public_key::get_public_key};
+    use dep::aztec::context::Context;
     use dep::authwit::{
         entrypoint::{app::AppPayload, fee::FeePayload}, account::AccountActions,
         auth_witness::get_auth_witness

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/public_key_note.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/public_key_note.nr
@@ -1,7 +1,7 @@
 use dep::aztec::prelude::{AztecAddress, NoteHeader, NoteInterface, PrivateContext};
 use dep::aztec::{
-    note::utils::compute_note_hash_for_consumption, hash::poseidon2_hash,
-    oracle::{nullifier_key::get_app_nullifier_secret_key, get_public_key::get_public_key},
+    keys::getters::get_ivpk_m, note::utils::compute_note_hash_for_consumption, hash::poseidon2_hash,
+    oracle::{nullifier_key::get_app_nullifier_secret_key},
     protocol_types::constants::GENERATOR_INDEX__NOTE_NULLIFIER
 };
 
@@ -39,12 +39,12 @@ impl NoteInterface<PUBLIC_KEY_NOTE_LEN> for PublicKeyNote {
 
     // Broadcasts the note as an encrypted log on L1.
     fn broadcast(self, context: &mut PrivateContext, slot: Field) {
-        let encryption_pub_key = get_public_key(self.owner);
+        let ivpk_m = get_ivpk_m(context, self.owner);
         context.emit_encrypted_log(
             (*context).this_address(),
             slot,
             Self::get_note_type_id(),
-            encryption_pub_key,
+            ivpk_m,
             self.serialize_content(),
         );
     }

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -23,18 +23,15 @@ contract Test {
     use dep::aztec::state_vars::{shared_mutable::SharedMutablePrivateGetter, map::derive_storage_slot_in_map};
 
     use dep::aztec::{
-        keys::getters::get_npk_m,
+        keys::getters::{get_npk_m, get_ivpk_m},
         context::{Context, inputs::private_context_inputs::PrivateContextInputs},
-        hash::{pedersen_hash, poseidon2_hash, compute_secret_hash, ArgsHasher},
+        hash::{pedersen_hash, compute_secret_hash, ArgsHasher},
         note::{
         lifecycle::{create_note, destroy_note}, note_getter::{get_notes, view_notes},
         note_getter_options::NoteStatus
     },
         deploy::deploy_contract as aztec_deploy_contract,
-        oracle::{
-        encryption::aes128_encrypt, get_public_key::get_public_key as get_public_key_oracle,
-        unsafe_rand::unsafe_rand
-    }
+        oracle::{encryption::aes128_encrypt, unsafe_rand::unsafe_rand}
     };
     use dep::token_portal_content_hash_lib::{get_mint_private_content_hash, get_mint_public_content_hash};
     use dep::value_note::value_note::ValueNote;
@@ -53,8 +50,8 @@ contract Test {
     }
 
     #[aztec(private)]
-    fn get_public_key(address: AztecAddress) -> [Field; 2] {
-        let pub_key = get_public_key_oracle(address);
+    fn get_master_incoming_viewing_public_key(address: AztecAddress) -> [Field; 2] {
+        let pub_key = get_ivpk_m(&mut context, address);
 
         [pub_key.x, pub_key.y]
     }

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/token_note.nr
@@ -1,8 +1,8 @@
 use dep::aztec::{
-    prelude::{AztecAddress, NoteHeader, NoteInterface, PrivateContext},
+    keys::getters::get_ivpk_m, prelude::{AztecAddress, NoteHeader, NoteInterface, PrivateContext},
     protocol_types::constants::GENERATOR_INDEX__NOTE_NULLIFIER,
     note::utils::compute_note_hash_for_consumption, hash::poseidon2_hash,
-    oracle::{unsafe_rand::unsafe_rand, nullifier_key::get_app_nullifier_secret_key, get_public_key::get_public_key}
+    oracle::{unsafe_rand::unsafe_rand, nullifier_key::get_app_nullifier_secret_key}
 };
 
 trait OwnedNote {
@@ -52,12 +52,12 @@ impl NoteInterface<TOKEN_NOTE_LEN> for TokenNote {
     fn broadcast(self, context: &mut PrivateContext, slot: Field) {
       // We only bother inserting the note if non-empty to save funds on gas.
       if !(self.amount == U128::from_integer(0)) {
-          let encryption_pub_key = get_public_key(self.owner);
+          let ivpk_m = get_ivpk_m(context, self.owner);
           context.emit_encrypted_log(
               (*context).this_address(),
               slot,
               Self::get_note_type_id(),
-              encryption_pub_key,
+              ivpk_m,
               self.serialize_content(),
           );
       }

--- a/noir-projects/noir-contracts/contracts/token_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/types/token_note.nr
@@ -1,8 +1,8 @@
 use dep::aztec::{
-    prelude::{AztecAddress, NoteHeader, NoteInterface, PrivateContext},
+    keys::getters::get_ivpk_m, prelude::{AztecAddress, NoteHeader, NoteInterface, PrivateContext},
     protocol_types::constants::GENERATOR_INDEX__NOTE_NULLIFIER,
     note::utils::compute_note_hash_for_consumption, hash::poseidon2_hash,
-    oracle::{unsafe_rand::unsafe_rand, nullifier_key::get_app_nullifier_secret_key, get_public_key::get_public_key}
+    oracle::{unsafe_rand::unsafe_rand, nullifier_key::get_app_nullifier_secret_key}
 };
 
 trait OwnedNote {
@@ -52,12 +52,12 @@ impl NoteInterface<TOKEN_NOTE_LEN> for TokenNote {
     fn broadcast(self, context: &mut PrivateContext, slot: Field) {
       // We only bother inserting the note if non-empty to save funds on gas.
       if !(self.amount == U128::from_integer(0)) {
-          let encryption_pub_key = get_public_key(self.owner);
+          let ivpk_m = get_ivpk_m(context, self.owner);
           context.emit_encrypted_log(
               (*context).this_address(),
               slot,
               Self::get_note_type_id(),
-              encryption_pub_key,
+              ivpk_m,
               self.serialize_content(),
           );
       }

--- a/yarn-project/circuits.js/src/structs/private_circuit_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/private_circuit_public_inputs.ts
@@ -39,7 +39,6 @@ import { TxContext } from './tx_context.js';
 
 /**
  * Public inputs to a private circuit.
- * @see abis/private_circuit_public_inputs.hpp.
  */
 export class PrivateCircuitPublicInputs {
   constructor(

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/legacy.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/legacy.test.ts
@@ -68,7 +68,7 @@ describe('e2e_deploy_contract legacy', () => {
       logger.info(`Deploying contract ${index + 1}...`);
       const receipt = await deployer.deploy().send({ contractAddressSalt: Fr.random() }).wait({ wallet });
       logger.info(`Sending TX to contract ${index + 1}...`);
-      await receipt.contract.methods.get_public_key(wallet.getAddress()).send().wait();
+      await receipt.contract.methods.get_master_incoming_viewing_public_key(wallet.getAddress()).send().wait();
     }
   });
 

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -221,7 +221,7 @@ describe('Private Execution test suite', () => {
       throw new Error(`Unknown address ${address}`);
     });
     // This oracle gets called when reading ivpk_m from key registry --> we return zero witness indicating that
-    // the keys were not registered. This triggers non-registered keys flows in which getCompleteAddress oracle
+    // the keys were not registered. This triggers non-registered keys flow in which getCompleteAddress oracle
     // gets called and we constrain the result by hashing address preimage and checking it matches.
     oracle.getPublicDataTreeWitness.mockResolvedValue(
       new PublicDataWitness(

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -4,6 +4,8 @@ import {
   type L1ToL2Message,
   Note,
   PackedValues,
+  PublicDataWitness,
+  SiblingPath,
   TxExecutionRequest,
 } from '@aztec/circuit-types';
 import {
@@ -13,13 +15,13 @@ import {
   FunctionData,
   GasSettings,
   GeneratorIndex,
-  type GrumpkinPrivateKey,
   Header,
   L1_TO_L2_MSG_TREE_HEIGHT,
   NOTE_HASH_TREE_HEIGHT,
+  PUBLIC_DATA_TREE_HEIGHT,
   PartialStateReference,
   PublicCallRequest,
-  type PublicKey,
+  PublicDataTreeLeafPreimage,
   StateReference,
   TxContext,
   computeAppNullifierSecretKey,
@@ -39,7 +41,7 @@ import { Fr } from '@aztec/foundation/fields';
 import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import { type FieldsOf } from '@aztec/foundation/types';
 import { openTmpStore } from '@aztec/kv-store/utils';
-import { type AppendOnlyTree, Pedersen, StandardTree, newTree } from '@aztec/merkle-tree';
+import { type AppendOnlyTree, INITIAL_LEAF, Pedersen, StandardTree, newTree } from '@aztec/merkle-tree';
 import {
   ChildContractArtifact,
   ImportTestContractArtifact,
@@ -79,14 +81,14 @@ describe('Private Execution test suite', () => {
   let ownerCompleteAddress: CompleteAddress;
   let recipientCompleteAddress: CompleteAddress;
 
-  let ownerMasterNullifierPublicKey: PublicKey;
-  let recipientMasterNullifierPublicKey: PublicKey;
-  let ownerMasterNullifierSecretKey: GrumpkinPrivateKey;
-  let recipientMasterNullifierSecretKey: GrumpkinPrivateKey;
+  // TODO(#5834): Nuke the following once complete address is refactored
+  let allOwnerKeys: any;
+  let allRecipientKeys: any;
 
   const treeHeights: { [name: string]: number } = {
     noteHash: NOTE_HASH_TREE_HEIGHT,
     l1ToL2Messages: L1_TO_L2_MSG_TREE_HEIGHT,
+    publicData: PUBLIC_DATA_TREE_HEIGHT,
   };
 
   let trees: { [name: keyof typeof treeHeights]: AppendOnlyTree<Fr> } = {};
@@ -139,7 +141,7 @@ describe('Private Execution test suite', () => {
     // Create a new snapshot.
     const newSnap = new AppendOnlyTreeSnapshot(Fr.fromBuffer(tree.getRoot(true)), Number(tree.getNumLeaves(true)));
 
-    if (name === 'noteHash' || name === 'l1ToL2Messages') {
+    if (name === 'noteHash' || name === 'l1ToL2Messages' || 'publicData') {
       header = new Header(
         header.lastArchive,
         header.contentCommitment,
@@ -148,7 +150,7 @@ describe('Private Execution test suite', () => {
           new PartialStateReference(
             name === 'noteHash' ? newSnap : header.state.partial.noteHashTree,
             header.state.partial.nullifierTree,
-            header.state.partial.publicDataTree,
+            name === 'publicData' ? newSnap : header.state.partial.publicDataTree,
           ),
         ),
         header.globalVariables,
@@ -175,41 +177,82 @@ describe('Private Execution test suite', () => {
 
     const ownerPartialAddress = Fr.random();
     ownerCompleteAddress = CompleteAddress.fromSecretKeyAndPartialAddress(ownerSk, ownerPartialAddress);
-
-    const allOwnerKeys = deriveKeys(ownerSk);
-    ownerMasterNullifierPublicKey = allOwnerKeys.masterNullifierPublicKey;
-    ownerMasterNullifierSecretKey = allOwnerKeys.masterNullifierSecretKey;
+    allOwnerKeys = deriveKeys(ownerSk);
 
     const recipientPartialAddress = Fr.random();
     recipientCompleteAddress = CompleteAddress.fromSecretKeyAndPartialAddress(recipientSk, recipientPartialAddress);
-
-    const allRecipientKeys = deriveKeys(recipientSk);
-    recipientMasterNullifierPublicKey = allRecipientKeys.masterNullifierPublicKey;
-    recipientMasterNullifierSecretKey = allRecipientKeys.masterNullifierSecretKey;
+    allRecipientKeys = deriveKeys(recipientSk);
 
     owner = ownerCompleteAddress.address;
     recipient = recipientCompleteAddress.address;
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     trees = {};
     oracle = mock<DBOracle>();
     oracle.getNullifierKeys.mockImplementation((accountAddress: AztecAddress, contractAddress: AztecAddress) => {
       if (accountAddress.equals(ownerCompleteAddress.address)) {
         return Promise.resolve({
-          masterNullifierPublicKey: ownerMasterNullifierPublicKey,
-          appNullifierSecretKey: computeAppNullifierSecretKey(ownerMasterNullifierSecretKey, contractAddress),
+          masterNullifierPublicKey: allOwnerKeys.masterNullifierPublicKey,
+          appNullifierSecretKey: computeAppNullifierSecretKey(allOwnerKeys.masterNullifierSecretKey, contractAddress),
         });
       }
       if (accountAddress.equals(recipientCompleteAddress.address)) {
         return Promise.resolve({
-          masterNullifierPublicKey: recipientMasterNullifierPublicKey,
-          appNullifierSecretKey: computeAppNullifierSecretKey(recipientMasterNullifierSecretKey, contractAddress),
+          masterNullifierPublicKey: allRecipientKeys.masterNullifierPublicKey,
+          appNullifierSecretKey: computeAppNullifierSecretKey(
+            allRecipientKeys.masterNullifierSecretKey,
+            contractAddress,
+          ),
         });
       }
       throw new Error(`Unknown address ${accountAddress}`);
     });
+
+    // We call insertLeaves here with no leaves to populate empty public data tree root --> this is necessary to be
+    // able to get ivpk_m during execution
+    await insertLeaves([], 'publicData');
     oracle.getHeader.mockResolvedValue(header);
+
+    oracle.getCompleteAddress.mockImplementation((address: AztecAddress) => {
+      if (address.equals(owner)) {
+        return Promise.resolve(ownerCompleteAddress);
+      }
+      if (address.equals(recipient)) {
+        return Promise.resolve(recipientCompleteAddress);
+      }
+      throw new Error(`Unknown address ${address}`);
+    });
+    // TODO(#5834): The following oracle should be unnecessary
+    oracle.getPublicKeysForAddress.mockImplementation((address: AztecAddress) => {
+      if (address.equals(owner)) {
+        return Promise.resolve([
+          allOwnerKeys.masterNullifierPublicKey,
+          allOwnerKeys.masterIncomingViewingPublicKey,
+          allOwnerKeys.masterOutgoingViewingPublicKey,
+          allOwnerKeys.masterTaggingPublicKey,
+        ]);
+      }
+      if (address.equals(recipient)) {
+        return Promise.resolve([
+          allRecipientKeys.masterNullifierPublicKey,
+          allRecipientKeys.masterIncomingViewingPublicKey,
+          allRecipientKeys.masterOutgoingViewingPublicKey,
+          allRecipientKeys.masterTaggingPublicKey,
+        ]);
+      }
+      throw new Error(`Unknown address ${address}`);
+    });
+    // This oracle gets called when reading ivpk_m from key registry --> we return zero witness indicating that
+    // the keys were not registered. This triggers non-registered keys flows in which getCompleteAddress oracle
+    // gets called and we constrain the result by hashing address preimage and checking it matches.
+    oracle.getPublicDataTreeWitness.mockResolvedValue(
+      new PublicDataWitness(
+        0n,
+        PublicDataTreeLeafPreimage.empty(),
+        SiblingPath.ZERO(PUBLIC_DATA_TREE_HEIGHT, INITIAL_LEAF, new Pedersen()),
+      ),
+    );
 
     acirSimulator = new AcirSimulator(oracle, node);
   });
@@ -286,16 +329,6 @@ describe('Private Execution test suite', () => {
     };
 
     beforeEach(() => {
-      oracle.getCompleteAddress.mockImplementation((address: AztecAddress) => {
-        if (address.equals(owner)) {
-          return Promise.resolve(ownerCompleteAddress);
-        }
-        if (address.equals(recipient)) {
-          return Promise.resolve(recipientCompleteAddress);
-        }
-        throw new Error(`Unknown address ${address}`);
-      });
-
       oracle.getFunctionArtifactByName.mockImplementation((_, functionName: string) =>
         Promise.resolve(getFunctionArtifact(StatefulTestContractArtifact, functionName)),
       );
@@ -940,7 +973,7 @@ describe('Private Execution test suite', () => {
       const nullifier = result.callStackItem.publicInputs.newNullifiers[0];
       const expectedNullifier = poseidon2Hash([
         innerNoteHash,
-        computeAppNullifierSecretKey(ownerMasterNullifierSecretKey, contractAddress),
+        computeAppNullifierSecretKey(allOwnerKeys.masterNullifierSecretKey, contractAddress),
         GeneratorIndex.NOTE_NULLIFIER,
       ]);
       expect(nullifier.value).toEqual(expectedNullifier);
@@ -1019,7 +1052,7 @@ describe('Private Execution test suite', () => {
       const nullifier = execGetThenNullify.callStackItem.publicInputs.newNullifiers[0];
       const expectedNullifier = poseidon2Hash([
         innerNoteHash,
-        computeAppNullifierSecretKey(ownerMasterNullifierSecretKey, contractAddress),
+        computeAppNullifierSecretKey(allOwnerKeys.masterNullifierSecretKey, contractAddress),
         GeneratorIndex.NOTE_NULLIFIER,
       ]);
       expect(nullifier.value).toEqual(expectedNullifier);
@@ -1045,17 +1078,16 @@ describe('Private Execution test suite', () => {
     });
   });
 
-  describe('get public key', () => {
+  describe('get master incoming viewing public key', () => {
     it('gets the public key for an address', async () => {
       // Tweak the contract artifact so we can extract return values
-      const artifact = getFunctionArtifact(TestContractArtifact, 'get_public_key');
+      const artifact = getFunctionArtifact(TestContractArtifact, 'get_master_incoming_viewing_public_key');
 
       // Generate a partial address, pubkey, and resulting address
       const completeAddress = CompleteAddress.random();
       const args = [completeAddress.address];
       const pubKey = completeAddress.masterIncomingViewingPublicKey;
 
-      oracle.getCompleteAddress.mockResolvedValue(completeAddress);
       const result = await runSimulator({ artifact, args });
       expect(result.returnValues).toEqual([pubKey.x, pubKey.y]);
     });

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -565,15 +565,6 @@ describe('Private Execution test suite', () => {
   describe('consuming messages', () => {
     const contractAddress = defaultContractAddress;
 
-    beforeEach(() => {
-      oracle.getCompleteAddress.mockImplementation((address: AztecAddress) => {
-        if (address.equals(recipient)) {
-          return Promise.resolve(recipientCompleteAddress);
-        }
-        throw new Error(`Unknown address ${address}`);
-      });
-    });
-
     describe('L1 to L2', () => {
       const artifact = getFunctionArtifact(TestContractArtifact, 'consume_mint_private_message');
       let bridgedAmount = 100n;
@@ -876,15 +867,6 @@ describe('Private Execution test suite', () => {
 
   describe('pending note hashes contract', () => {
     beforeEach(() => {
-      oracle.getCompleteAddress.mockImplementation((address: AztecAddress) => {
-        if (address.equals(owner)) {
-          return Promise.resolve(ownerCompleteAddress);
-        }
-        throw new Error(`Unknown address ${address}`);
-      });
-    });
-
-    beforeEach(() => {
       oracle.getFunctionArtifact.mockImplementation((_, selector) =>
         Promise.resolve(getFunctionArtifact(PendingNoteHashesContractArtifact, selector)),
       );
@@ -1065,6 +1047,7 @@ describe('Private Execution test suite', () => {
       const args = [completeAddress.address];
       const pubKey = completeAddress.masterIncomingViewingPublicKey;
 
+      oracle.getCompleteAddress.mockResolvedValue(completeAddress);
       const result = await runSimulator({ artifact, args });
       expect(result.returnValues).toEqual([pubKey.x, pubKey.y]);
     });


### PR DESCRIPTION
Replaces use of old `get_public_key` oracle with new `get_ivsk_m`. Most of the complexity in this PR is related to updated test setups --> those became more complicated as the new oracle/getter itself is more complicated than the old one.

Fixes first half of https://github.com/AztecProtocol/aztec-packages/issues/5830