### PR TITLE
fix: aztec-run not exposing port for builder

### DIFF
--- a/aztec-up/bin/.aztec-run
+++ b/aztec-up/bin/.aztec-run
@@ -98,9 +98,9 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
-# Dynamic port assignment based on IMAGE containing '/aztec'
+# Dynamic port assignment based on IMAGE containing '/aztec' and not containing 'builder' (to exclude aztec-builder)
 port_assignment=""
-if [[ "$IMAGE" == *"/aztec"* ]]; then
+if [[ "$IMAGE" == *"/aztec"* ]] && [[ "$IMAGE" != *"builder"* ]]; then
   port_assignment="-p $AZTEC_PORT:$AZTEC_PORT"
 fi
 


### PR DESCRIPTION
When starting aztec-builder while having sandbox running the command failed with an error because it tried to bind to the same port. This PR fixes it by not binding to any port when $IMAGE contains "builder" string. See relevant discussion [here](https://aztecprotocol.slack.com/archives/C04PUD9AA4W/p1714990013906089).
