### PR TITLE
fix: Cl/split out e2e tests

### DIFF
--- a/.github/workflows/start-spot.yml
+++ b/.github/workflows/start-spot.yml
@@ -16,7 +16,7 @@ jobs:
     with:
       runner_label: ${{ inputs.username || github.actor }}-x86
       ebs_cache_size_gb: 256
-      runner_concurrency: 20
+      runner_concurrency: 50
       subaction: ${{ inputs.action }}
       # Use instance types with low interruption rate in us-east-2 https://aws.amazon.com/ec2/spot/instance-advisor/
       ec2_instance_type: r6in.32xlarge r6a.32xlarge i4i.32xlarge r7iz.32xlarge

--- a/yarn-project/end-to-end/Earthfile
+++ b/yarn-project/end-to-end/Earthfile
@@ -42,10 +42,141 @@ UPLOAD_LOGS:
   ENV COMMIT_HASH=$COMMIT_HASH
   RUN --secret AWS_ACCESS_KEY_ID --secret AWS_SECRET_ACCESS_KEY /usr/src/scripts/logs/upload_logs_to_s3.sh /usr/var/log
 
-# Define e2e tests
-e2e-tests:
+e2e_2_pxes:
   FROM ../+end-to-end
-  RUN yarn test ./src/e2e
+  RUN yarn test ./src/e2e_2_pxes.test.ts
+
+e2e_account_contracts:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_account_contracts.test.ts
+
+e2e_auth_contract:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_auth_contract.test.ts
+
+e2e_authwit:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_authwit.test.ts
+
+e2e_avm_simulator:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_avm_simulator.test.ts
+
+e2e_blacklist_token_contract:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_blacklist_token_contract
+
+e2e_block_building:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_block_building.test.ts
+
+e2e_card_game:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_card_game.test.ts
+
+e2e_cheat_codes:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_cheat_codes.test.ts
+
+e2e_counter_contract:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_counter_contract.test.ts
+
+e2e_cross_chain_messaging:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_cross_chain_messaging.test.ts
+
+e2e_crowdfunding_and_claim:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_crowdfunding_and_claim.test.ts
+
+e2e_dapp_subscription:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_dapp_subscription.test.ts
+
+e2e_delegate_calls:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_delegate_calls
+
+e2e_deploy_contract:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_deploy_contract
+
+e2e_encryption:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_encryption.test.ts
+
+e2e_escrow_contract:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_escrow_contract.test.ts
+
+e2e_fees:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_fees.test.ts
+
+e2e_key_registry:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_key_registry.test.ts
+
+e2e_lending_contract:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_lending_contract.test.ts
+
+e2e_max_block_number:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_max_block_number.test.ts
+
+e2e_multiple_accounts_1_enc_key:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_multiple_accounts_1_enc_key.test.ts
+
+e2e_nested_contract:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_nested_contract
+
+e2e_non_contract_account:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_non_contract_account.test.ts
+
+e2e_note_getter:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_note_getter.test.ts
+
+e2e_ordering:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_ordering.test.ts
+
+e2e_outbox:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_outbox.test.ts
+
+e2e_pending_note_hashes_contract:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_pending_note_hashes_contract.test.ts
+
+e2e_private_voting_contract:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_private_voting_contract.test.ts
+
+e2e_public_cross_chain_messaging:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_public_cross_chain_messaging
+
+e2e_public_to_private_messaging:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_public_to_private_messaging.test.ts
+
+e2e_state_vars:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_state_vars.test.ts
+
+e2e_static_calls:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_static_calls.test.ts
+
+e2e_token_contract:
+  FROM ../+end-to-end
+  RUN yarn test ./src/e2e_token_contract
 
 flakey-e2e-tests:
   FROM ../+end-to-end

--- a/yarn-project/end-to-end/Earthfile
+++ b/yarn-project/end-to-end/Earthfile
@@ -15,16 +15,15 @@ E2E_COMPOSE_TEST:
   ELSE
     LET CMD="docker-compose"
   END
-  # In CI, we do an optimization to push these images to docker once
-  # We still want the default code path to work with no faff locally
-  # To not rebuild unnecessarily, we pass --skip_build=true in CI
-  IF [ $skip_build != "true" ]
+  # Let docker compose know about the pushed tags above
+  ENV AZTEC_DOCKER_TAG=$(git rev-parse HEAD)
+  # Optimize to not cause serial behavior if image already exists
+  IF ! docker image ls --format '{{.Repository}}:{{.Tag}}' | grep "aztecprotocol/aztec:$AZTEC_DOCKER_TAG" && \
+       docker image ls --format '{{.Repository}}:{{.Tag}}' | grep "aztecprotocol/end-to-end:$AZTEC_DOCKER_TAG"
     WAIT
       BUILD ../+export-e2e-test-images
     END
   END
-  # Let docker compose know about the pushed tags above
-  ENV AZTEC_DOCKER_TAG=$(git rev-parse HEAD)
   # Run our docker compose, ending whenever sandbox ends, filtering out noisy eth_getLogs
   RUN $CMD -p $project_name -f $compose_file up --exit-code-from=end-to-end --force-recreate
 

--- a/yarn-project/end-to-end/Earthfile
+++ b/yarn-project/end-to-end/Earthfile
@@ -90,10 +90,6 @@ e2e-crowdfunding-and-claim:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_crowdfunding_and_claim.test.ts
 
-e2e-dapp-subscription:
-  FROM ../+end-to-end
-  RUN yarn test ./src/e2e_dapp_subscription.test.ts
-
 e2e-delegate-calls:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_delegate_calls
@@ -109,10 +105,6 @@ e2e-encryption:
 e2e-escrow-contract:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_escrow_contract.test.ts
-
-e2e-fees:
-  FROM ../+end-to-end
-  RUN yarn test ./src/e2e_fees.test.ts
 
 e2e-key-registry:
   FROM ../+end-to-end

--- a/yarn-project/end-to-end/Earthfile
+++ b/yarn-project/end-to-end/Earthfile
@@ -42,139 +42,139 @@ UPLOAD_LOGS:
   ENV COMMIT_HASH=$COMMIT_HASH
   RUN --secret AWS_ACCESS_KEY_ID --secret AWS_SECRET_ACCESS_KEY /usr/src/scripts/logs/upload_logs_to_s3.sh /usr/var/log
 
-e2e_2_pxes:
+e2e-2-pxes:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_2_pxes.test.ts
 
-e2e_account_contracts:
+e2e-account-contracts:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_account_contracts.test.ts
 
-e2e_auth_contract:
+e2e-auth-contract:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_auth_contract.test.ts
 
-e2e_authwit:
+e2e-authwit:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_authwit.test.ts
 
-e2e_avm_simulator:
+e2e-avm-simulator:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_avm_simulator.test.ts
 
-e2e_blacklist_token_contract:
+e2e-blacklist-token-contract:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_blacklist_token_contract
 
-e2e_block_building:
+e2e-block-building:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_block_building.test.ts
 
-e2e_card_game:
+e2e-card-game:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_card_game.test.ts
 
-e2e_cheat_codes:
+e2e-cheat-codes:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_cheat_codes.test.ts
 
-e2e_counter_contract:
+e2e-counter-contract:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_counter_contract.test.ts
 
-e2e_cross_chain_messaging:
+e2e-cross-chain-messaging:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_cross_chain_messaging.test.ts
 
-e2e_crowdfunding_and_claim:
+e2e-crowdfunding-and-claim:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_crowdfunding_and_claim.test.ts
 
-e2e_dapp_subscription:
+e2e-dapp-subscription:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_dapp_subscription.test.ts
 
-e2e_delegate_calls:
+e2e-delegate-calls:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_delegate_calls
 
-e2e_deploy_contract:
+e2e-deploy-contract:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_deploy_contract
 
-e2e_encryption:
+e2e-encryption:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_encryption.test.ts
 
-e2e_escrow_contract:
+e2e-escrow-contract:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_escrow_contract.test.ts
 
-e2e_fees:
+e2e-fees:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_fees.test.ts
 
-e2e_key_registry:
+e2e-key-registry:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_key_registry.test.ts
 
-e2e_lending_contract:
+e2e-lending-contract:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_lending_contract.test.ts
 
-e2e_max_block_number:
+e2e-max-block-number:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_max_block_number.test.ts
 
-e2e_multiple_accounts_1_enc_key:
+e2e-multiple-accounts-1-enc-key:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_multiple_accounts_1_enc_key.test.ts
 
-e2e_nested_contract:
+e2e-nested-contract:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_nested_contract
 
-e2e_non_contract_account:
+e2e-non-contract-account:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_non_contract_account.test.ts
 
-e2e_note_getter:
+e2e-note-getter:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_note_getter.test.ts
 
-e2e_ordering:
+e2e-ordering:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_ordering.test.ts
 
-e2e_outbox:
+e2e-outbox:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_outbox.test.ts
 
-e2e_pending_note_hashes_contract:
+e2e-pending-note-hashes-contract:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_pending_note_hashes_contract.test.ts
 
-e2e_private_voting_contract:
+e2e-private-voting-contract:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_private_voting_contract.test.ts
 
-e2e_public_cross_chain_messaging:
+e2e-public-cross-chain-messaging:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_public_cross_chain_messaging
 
-e2e_public_to_private_messaging:
+e2e-public-to-private-messaging:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_public_to_private_messaging.test.ts
 
-e2e_state_vars:
+e2e-state-vars:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_state_vars.test.ts
 
-e2e_static_calls:
+e2e-static-calls:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_static_calls.test.ts
 
-e2e_token_contract:
+e2e-token-contract:
   FROM ../+end-to-end
   RUN yarn test ./src/e2e_token_contract
 

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src \"!src/web/main.js\" && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "LOG_LEVEL=${LOG_LEVEL:-silent} DEBUG_COLORS=1 NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=300000 --forceExit",
+    "test": "LOG_LEVEL=${LOG_LEVEL:-verbose} DEBUG_COLORS=1 NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=300000 --forceExit",
     "test:integration": "concurrently -k -s first -c reset,dim -n test,anvil \"yarn test:integration:run\" \"anvil\"",
     "test:integration:run": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --no-cache --runInBand --config jest.integration.config.json"
   },

--- a/yarn-project/end-to-end/package.local.json
+++ b/yarn-project/end-to-end/package.local.json
@@ -2,6 +2,6 @@
   "scripts": {
     "build": "yarn clean && tsc -b && webpack",
     "formatting": "run -T prettier --check ./src \"!src/web/main.js\" && run -T eslint ./src",
-    "test": "LOG_LEVEL=${LOG_LEVEL:-silent} DEBUG_COLORS=1 NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=300000 --forceExit"
+    "test": "LOG_LEVEL=${LOG_LEVEL:-verbose} DEBUG_COLORS=1 NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=300000 --forceExit"
   }
 }


### PR DESCRIPTION
Give the e2e tests their own jobs and turn logging back on. They still just run as individual jest tests rather than previously when they all ran through compose.

Hopefully we can get more insights to any CI instability.