### PR TITLE
feat: process designated teardown function call

### DIFF
--- a/docs/docs/misc/glossary/call_types.md
+++ b/docs/docs/misc/glossary/call_types.md
@@ -112,7 +112,7 @@ Since public execution can only be performed by the sequencer, public functions 
 
 Since the public call is made asynchronously, any return values or side effects are not available during private execution. If the public function fails once executed, the entire transaction is reverted inncluding state changes caused by the private part, such as new notes or nullifiers. Note that this does result in gas being spent, like in the case of the EVM.
 
-#include_code enqueue_public /noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr rust
+#include_code enqueue_public /noir-projects/noir-contracts/contracts/lending_contract/src/main.nr rust
 
 It is also possible to create public functions that can _only_ be invoked by privately enqueing a call from the same contract, which can very useful to update public state after private exection (e.g. update a token's supply after privately minting). This is achieved by annotating functions with `#[aztec(internal)]`.
 

--- a/docs/docs/protocol-specs/gas-and-fees/kernel-tracking.md
+++ b/docs/docs/protocol-specs/gas-and-fees/kernel-tracking.md
@@ -26,6 +26,7 @@ PrivateContextInputs --> TxContext
 
 class PrivateCallData {
     +PrivateCallStackItem call_stack_item
+    +CallRequest public_teardown_call_request
 }
 PrivateCallData --> PrivateCallStackItem
 
@@ -295,7 +296,7 @@ class PublicKernelCircuitPublicInputs {
   +PublicAccumulatedData end
   +CombinedConstantData constants
   +AztecAddress fee_payer
-  +CallRequest public_teardown_call_request
+  +CallRequest[MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX] public_teardown_call_stack
   +u8 revert_code
 }
 PublicKernelCircuitPublicInputs --> PublicAccumulatedData

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -573,7 +573,6 @@ impl PrivateContext {
         assert(function_selector.eq(item.function_data.selector));
 
         assert_eq(item.public_inputs.call_context.side_effect_counter, self.side_effect_counter);
-        // We increment the sideffect counter by one, to account for the call itself being a side effect.
 
         assert(args_hash == item.public_inputs.args_hash);
 

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -48,10 +48,12 @@ contract AppSubscription {
         note.remaining_txs -= 1;
         storage.subscriptions.at(user_address).replace(&mut note, true);
 
-        // docs:start:enqueue_public
         let gas_limit = storage.gas_token_limit_per_tx.read_private();
-        GasToken::at(storage.gas_token_address.read_private()).pay_fee(gas_limit).enqueue(&mut context);
-        // docs:end:enqueue_public
+        context.set_public_teardown_function(
+            storage.gas_token_address.read_private(),
+            FunctionSelector::from_signature("pay_fee(Field)"),
+            [gas_limit]
+        );
 
         context.end_setup();
 

--- a/noir-projects/noir-contracts/contracts/fpc_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/fpc_contract/src/main.nr
@@ -22,13 +22,25 @@ contract FPC {
     fn fee_entrypoint_private(amount: Field, asset: AztecAddress, secret_hash: Field, nonce: Field) {
         assert(asset == storage.other_asset.read_private());
         Token::at(asset).unshield(context.msg_sender(), context.this_address(), amount, nonce).call(&mut context);
-        FPC::at(context.this_address()).pay_fee_with_shielded_rebate(amount, asset, secret_hash).enqueue(&mut context);
+        // Would like to get back to
+        // FPC::at(context.this_address()).pay_fee_with_shielded_rebate(amount, asset, secret_hash).set_public_teardown_function(&mut context);
+        context.set_public_teardown_function(
+            context.this_address(),
+            FunctionSelector::from_signature("pay_fee_with_shielded_rebate(Field,(Field),Field)"),
+            [amount, asset.to_field(), secret_hash]
+        );
     }
 
     #[aztec(private)]
     fn fee_entrypoint_public(amount: Field, asset: AztecAddress, nonce: Field) {
         FPC::at(context.this_address()).prepare_fee(context.msg_sender(), amount, asset, nonce).enqueue(&mut context);
-        FPC::at(context.this_address()).pay_fee(context.msg_sender(), amount, asset).enqueue(&mut context);
+        // TODO(#6277) for improving interface:
+        // FPC::at(context.this_address()).pay_fee(context.msg_sender(), amount, asset).set_public_teardown_function(&mut context);
+        context.set_public_teardown_function(
+            context.this_address(),
+            FunctionSelector::from_signature("pay_fee((Field),Field,(Field))"),
+            [context.msg_sender().to_field(), amount, asset.to_field()]
+        );
     }
 
     #[aztec(public)]

--- a/noir-projects/noir-contracts/contracts/lending_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/lending_contract/src/main.nr
@@ -104,11 +104,13 @@ contract Lending {
     ) {
         let on_behalf_of = compute_identifier(secret, on_behalf_of, context.msg_sender().to_field());
         let _res = Token::at(collateral_asset).unshield(from, context.this_address(), amount, nonce).call(&mut context);
+        // docs:start:enqueue_public
         Lending::at(context.this_address())._deposit(
             AztecAddress::from_field(on_behalf_of),
             amount,
             collateral_asset
         ).enqueue(&mut context);
+        // docs:end:enqueue_public
     }
 
     #[aztec(public)]

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -191,6 +191,15 @@ contract Test {
         args.hash()
     }
 
+    #[aztec(private)]
+    fn test_setting_teardown() {
+        context.set_public_teardown_function(
+            context.this_address(),
+            FunctionSelector::from_signature("dummy_public_call()"),
+            []
+        );
+    }
+
     // Purely exists for testing
     #[aztec(public)]
     fn create_l2_to_l1_message_public(amount: Field, secret_hash: Field, portal_address: EthAddress) {

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/common.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/common.nr
@@ -64,16 +64,20 @@ fn is_valid_caller(request_from_stack: CallRequest, fn_being_verified: PrivateCa
         & (request_from_stack.caller_context.is_empty() | valid_caller_context)
 }
 
+fn validate_call_request(request: CallRequest, hash: Field, private_call: PrivateCallData) {
+    if hash != 0 {
+        assert_eq(request.hash, hash, "call stack hash does not match call request hash");
+        assert(is_valid_caller(request, private_call), "invalid caller");
+    } else {
+        assert(is_empty(request), "call requests length does not match the expected length");
+    }
+}
+
 fn validate_call_requests<N>(call_requests: [CallRequest; N], hashes: [Field; N], private_call: PrivateCallData) {
     for i in 0..N {
         let hash = hashes[i];
         let request = call_requests[i];
-        if hash != 0 {
-            assert_eq(request.hash, hash, "call stack hash does not match call request hash");
-            assert(is_valid_caller(request, private_call), "invalid caller");
-        } else {
-            assert(is_empty(request), "call requests length does not match the expected length");
-        }
+        validate_call_request(request, hash, private_call);
     }
 }
 
@@ -98,6 +102,13 @@ pub fn validate_private_call_data(private_call: PrivateCallData) {
     validate_call_requests(
         private_call.public_call_stack,
         private_call_public_inputs.public_call_stack_hashes,
+        private_call
+    );
+
+    // Teardown call
+    validate_call_request(
+        private_call.public_teardown_call_request,
+        private_call_public_inputs.public_teardown_function_hash,
         private_call
     );
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/kernel_circuit_public_inputs_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/kernel_circuit_public_inputs_composer.nr
@@ -98,6 +98,7 @@ impl KernelCircuitPublicInputsComposer {
         let _ = self.compose();
 
         self.propagate_sorted_public_call_requests();
+        self.propagate_public_teardown_call_request();
 
         *self
     }
@@ -221,6 +222,10 @@ impl KernelCircuitPublicInputsComposer {
     fn propagate_sorted_public_call_requests(&mut self) {
         let accumulated_data = self.previous_kernel.public_inputs.end;
         self.public_inputs.end.public_call_stack = array_to_bounded_vec(accumulated_data.public_call_stack);
+    }
+
+    fn propagate_public_teardown_call_request(&mut self) {
+        self.public_inputs.public_teardown_call_request = self.previous_kernel.public_inputs.public_teardown_call_request;
     }
 
     fn squash_transient_data(&mut self) {

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_circuit_public_inputs_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_circuit_public_inputs_composer.nr
@@ -19,6 +19,7 @@ struct DataSource {
     note_hash_nullifier_counters: [u32; MAX_NEW_NOTE_HASHES_PER_CALL],
     private_call_requests: [CallRequest; MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL],
     public_call_requests: [CallRequest; MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL],
+    public_teardown_call_request: CallRequest,
 }
 
 struct PrivateKernelCircuitPublicInputsComposer {
@@ -70,6 +71,8 @@ impl PrivateKernelCircuitPublicInputsComposer {
         let _call_request = public_inputs.end.private_call_stack.pop();
         public_inputs.end.public_call_stack = array_to_bounded_vec(start.public_call_stack);
 
+        public_inputs.public_teardown_call_request = previous_kernel_public_inputs.public_teardown_call_request;
+
         PrivateKernelCircuitPublicInputsComposer { public_inputs }
     }
 
@@ -78,7 +81,8 @@ impl PrivateKernelCircuitPublicInputsComposer {
         private_call_public_inputs: PrivateCircuitPublicInputs,
         note_hash_nullifier_counters: [u32; MAX_NEW_NOTE_HASHES_PER_CALL],
         private_call_requests: [CallRequest; MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL],
-        public_call_requests: [CallRequest; MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL]
+        public_call_requests: [CallRequest; MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL],
+        public_teardown_call_request: CallRequest
     ) -> Self {
         let storage_contract_address = private_call_public_inputs.call_context.storage_contract_address;
         let source = DataSource {
@@ -86,7 +90,8 @@ impl PrivateKernelCircuitPublicInputsComposer {
             private_call_public_inputs,
             note_hash_nullifier_counters,
             private_call_requests,
-            public_call_requests
+            public_call_requests,
+            public_teardown_call_request
         };
 
         self.propagate_max_block_number(source);
@@ -99,6 +104,7 @@ impl PrivateKernelCircuitPublicInputsComposer {
         self.propagate_logs(source);
         self.propagate_private_call_requests(source);
         self.propagate_public_call_requests(source);
+        self.propagate_public_teardown_call_request(source);
 
         *self
     }
@@ -202,6 +208,16 @@ impl PrivateKernelCircuitPublicInputsComposer {
             if !is_empty(call_request) {
                 self.public_inputs.end.public_call_stack.push(call_request);
             }
+        }
+    }
+
+    fn propagate_public_teardown_call_request(&mut self, source: DataSource) {
+        let call_request = source.public_teardown_call_request;
+        if !is_empty(call_request) {
+            assert(
+                self.public_inputs.public_teardown_call_request.is_empty(), "Public teardown call request already set"
+            );
+            self.public_inputs.public_teardown_call_request = call_request;
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_init.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_init.nr
@@ -81,7 +81,8 @@ impl PrivateKernelInitCircuitPrivateInputs {
             private_call_public_inputs,
             self.hints.note_hash_nullifier_counters,
             self.private_call.private_call_stack,
-            self.private_call.public_call_stack
+            self.private_call.public_call_stack,
+            self.private_call.public_teardown_call_request
         ).finish()
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_inner.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_inner.nr
@@ -52,7 +52,8 @@ impl PrivateKernelInnerCircuitPrivateInputs {
             private_call_public_inputs,
             self.hints.note_hash_nullifier_counters,
             self.private_call.private_call_stack,
-            self.private_call.public_call_stack
+            self.private_call.public_call_stack,
+            self.private_call.public_teardown_call_request
         ).finish()
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
@@ -47,7 +47,9 @@ impl PrivateKernelTailCircuitPrivateInputs {
         assert_eq(
             array_length(previous_public_inputs.end.public_call_stack), 0, "Public call stack must be empty when executing the tail circuit"
         );
-        assert(is_empty(previous_public_inputs.public_teardown_call_request) == true, "Public teardown call request must be empty when executing the tail circuit");
+        assert(
+            is_empty(previous_public_inputs.public_teardown_call_request) == true, "Public teardown call request must be empty when executing the tail circuit"
+        );
 
         // verify/aggregate the previous kernel
         verify_previous_kernel_proof(self.previous_kernel);

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
@@ -10,7 +10,7 @@ use dep::types::{
     MAX_NEW_NOTE_HASHES_PER_TX, MAX_NEW_NULLIFIERS_PER_TX, MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
     MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_TX, MAX_ENCRYPTED_LOGS_PER_TX, MAX_UNENCRYPTED_LOGS_PER_TX
 },
-    grumpkin_private_key::GrumpkinPrivateKey, utils::arrays::array_length
+    grumpkin_private_key::GrumpkinPrivateKey, utils::arrays::array_length, traits::is_empty
 };
 
 // Can just be KernelCircuitPublicInputs.
@@ -47,6 +47,7 @@ impl PrivateKernelTailCircuitPrivateInputs {
         assert_eq(
             array_length(previous_public_inputs.end.public_call_stack), 0, "Public call stack must be empty when executing the tail circuit"
         );
+        assert(is_empty(previous_public_inputs.public_teardown_call_request) == true, "Public teardown call request must be empty when executing the tail circuit");
 
         // verify/aggregate the previous kernel
         verify_previous_kernel_proof(self.previous_kernel);
@@ -568,6 +569,13 @@ mod tests {
     unconstrained fn non_empty_public_call_stack_should_fail() {
         let mut builder = PrivateKernelTailInputsBuilder::new();
         builder.previous_kernel.push_public_call_request(1, false);
+        builder.failed();
+    }
+
+    #[test(should_fail_with="Public teardown call request must be empty when executing the tail circuit")]
+    unconstrained fn non_empty_public_teardown_call_request_should_fail() {
+        let mut builder = PrivateKernelTailInputsBuilder::new();
+        builder.previous_kernel.set_public_teardown_call_request(1, false);
         builder.failed();
     }
 

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail_to_public.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail_to_public.nr
@@ -10,7 +10,7 @@ use dep::types::{
     MAX_NEW_NOTE_HASHES_PER_TX, MAX_NEW_NULLIFIERS_PER_TX, MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
     MAX_NULLIFIER_KEY_VALIDATION_REQUESTS_PER_TX, MAX_ENCRYPTED_LOGS_PER_TX, MAX_UNENCRYPTED_LOGS_PER_TX
 },
-    grumpkin_private_key::GrumpkinPrivateKey, utils::arrays::array_length
+    grumpkin_private_key::GrumpkinPrivateKey, utils::arrays::array_length, traits::is_empty
 };
 
 // Can just be PublicKernelCircuitPublicInputs.
@@ -44,8 +44,10 @@ struct PrivateKernelTailToPublicCircuitPrivateInputs {
 impl PrivateKernelTailToPublicCircuitPrivateInputs {
     pub fn execute(self) -> PublicKernelCircuitPublicInputs {
         let previous_public_inputs = self.previous_kernel.public_inputs;
+        let mut total_public_calls = array_length(previous_public_inputs.end.public_call_stack);
+        total_public_calls += if is_empty(self.previous_kernel.public_inputs.public_teardown_call_request) {0} else {1};
         assert(
-            array_length(previous_public_inputs.end.public_call_stack) != 0, "Public call stack must not be empty when exporting public kernel data from the tail circuit"
+            total_public_calls != 0, "Must have public calls when exporting public kernel data from the tail circuit"
         );
 
         // verify/aggregate the previous kernel
@@ -465,11 +467,20 @@ mod tests {
         builder.failed();
     }
 
-    #[test(should_fail_with="Public call stack must not be empty when exporting public kernel data from the tail circuit")]
-    unconstrained fn empty_public_call_stack_should_fail() {
+    #[test(should_fail_with="Must have public calls when exporting public kernel data from the tail circuit")]
+    unconstrained fn no_public_calls_should_fail() {
         let mut builder = PrivateKernelTailToPublicInputsBuilder::new();
         builder.previous_kernel.public_call_stack = BoundedVec::new();
         builder.failed();
+    }
+
+    #[test]
+    unconstrained fn can_run_with_only_teardown() {
+        let mut builder = PrivateKernelTailToPublicInputsBuilder::new();
+        builder.previous_kernel.public_call_stack = BoundedVec::new();
+        builder.previous_kernel.set_public_teardown_call_request(1, false);
+
+        builder.succeeded();
     }
 
     #[test(should_fail_with="The 0th nullifier in the accumulated nullifier array is zero")]

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/common.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/common.nr
@@ -132,6 +132,8 @@ pub fn initialize_end_values(
     let start_non_revertible = previous_kernel.public_inputs.end_non_revertible;
     circuit_outputs.end_non_revertible.public_call_stack = array_to_bounded_vec(start_non_revertible.public_call_stack);
 
+    circuit_outputs.public_teardown_call_stack = array_to_bounded_vec(previous_kernel.public_inputs.public_teardown_call_stack);
+
     let start = previous_kernel.public_inputs.validation_requests;
     circuit_outputs.validation_requests.max_block_number = previous_kernel.public_inputs.validation_requests.for_rollup.max_block_number;
     circuit_outputs.validation_requests.nullifier_read_requests = array_to_bounded_vec(start.nullifier_read_requests);
@@ -173,6 +175,34 @@ fn is_valid_caller(request: CallRequest, public_call: PublicCallData) -> bool {
 
     request.caller_contract_address.eq(public_call.call_stack_item.contract_address)
         & (request.caller_context.is_empty() | valid_caller_context)
+}
+
+pub fn update_end_non_revertible_call_stack(
+    public_call: PublicCallData,
+    circuit_outputs: &mut PublicKernelCircuitPublicInputsBuilder
+) {
+    let requests = validate_public_call_stack(public_call);
+    circuit_outputs.end_non_revertible.public_call_stack.extend_from_bounded_vec(requests);
+}
+
+pub fn update_end_call_stack(
+    public_call: PublicCallData,
+    circuit_outputs: &mut PublicKernelCircuitPublicInputsBuilder
+) {
+    let requests = validate_public_call_stack(public_call);
+    circuit_outputs.end.public_call_stack.extend_from_bounded_vec(requests);
+}
+
+pub fn update_teardown_call_stack(public_call: PublicCallData, circuit_outputs: &mut PublicKernelCircuitPublicInputsBuilder) {
+    let requests = validate_public_call_stack(public_call);
+    circuit_outputs.public_teardown_call_stack.extend_from_bounded_vec(requests);
+}
+
+fn validate_public_call_stack(public_call: PublicCallData) -> BoundedVec<CallRequest, MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL> {
+    let public_call_requests = array_to_bounded_vec(public_call.public_call_stack);
+    let hashes = public_call.call_stack_item.public_inputs.public_call_stack_hashes;
+    validate_call_requests(public_call_requests, hashes, public_call);
+    public_call_requests
 }
 
 fn validate_call_requests<N>(
@@ -275,16 +305,10 @@ pub fn update_public_end_non_revertible_values(
     public_call: PublicCallData,
     circuit_outputs: &mut PublicKernelCircuitPublicInputsBuilder
 ) {
-    // Updates the circuit outputs with new state changes, call stack etc
+    // Updates the circuit outputs with new state changes
 
     // If this call is a static call, certain operations are disallowed, such as creating new state.
     perform_static_call_checks(public_call);
-
-    // Update public call stack.
-    let public_call_requests = array_to_bounded_vec(public_call.public_call_stack);
-    let hashes = public_call.call_stack_item.public_inputs.public_call_stack_hashes;
-    validate_call_requests(public_call_requests, hashes, public_call);
-    circuit_outputs.end_non_revertible.public_call_stack.extend_from_bounded_vec(public_call_requests);
 
     propagate_new_nullifiers_non_revertible(public_call, circuit_outputs);
     propagate_new_note_hashes_non_revertible(public_call, circuit_outputs);
@@ -294,20 +318,13 @@ pub fn update_public_end_non_revertible_values(
 }
 
 pub fn update_public_end_values(public_call: PublicCallData, circuit_outputs: &mut PublicKernelCircuitPublicInputsBuilder) {
-    // Updates the circuit outputs with new state changes, call stack etc
+    // Updates the circuit outputs with new state changes
 
     // If this call is a static call, certain operations are disallowed, such as creating new state.
     perform_static_call_checks(public_call);
 
-    // Update public call stack.
-    let public_call_requests = array_to_bounded_vec(public_call.public_call_stack);
-    let hashes = public_call.call_stack_item.public_inputs.public_call_stack_hashes;
-    validate_call_requests(public_call_requests, hashes, public_call);
-    circuit_outputs.end.public_call_stack.extend_from_bounded_vec(public_call_requests);
-
     propagate_new_nullifiers(public_call, circuit_outputs);
     propagate_new_note_hashes(public_call, circuit_outputs);
-
     propagate_new_l2_to_l1_messages(public_call, circuit_outputs);
     propagate_new_unencrypted_logs(public_call, circuit_outputs);
     propagate_valid_public_data_update_requests(public_call, circuit_outputs);

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_app_logic.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_app_logic.nr
@@ -47,6 +47,7 @@ impl PublicKernelAppLogicCircuitPrivateInputs {
             // Pops the item from the call stack and validates it against the current execution.
             let call_request = public_inputs.end.public_call_stack.pop();
             common::validate_call_against_request(self.public_call, call_request);
+            common::update_end_call_stack(self.public_call, &mut public_inputs);
             common::update_public_end_values(self.public_call, &mut public_inputs);
         } else {
             let mut remaining_calls = array_to_bounded_vec(self.previous_kernel.public_inputs.end.public_call_stack);

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_setup.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_setup.nr
@@ -54,6 +54,7 @@ impl PublicKernelSetupCircuitPrivateInputs {
 
         common::update_validation_requests(self.public_call, &mut public_inputs);
 
+        common::update_end_non_revertible_call_stack(self.public_call, &mut public_inputs);
         common::update_public_end_non_revertible_values(self.public_call, &mut public_inputs);
 
         public_inputs.finish()
@@ -405,23 +406,6 @@ mod tests {
 
     //     let _ = kernel.public_kernel_setup();
     // }
-
-    #[test(should_fail_with="Cannot run unnecessary setup circuit")]
-    fn unnecessary_public_kernel_setup_with_teardown_should_fail() {
-        let mut builder = PublicKernelSetupCircuitPrivateInputsBuilder::new();
-
-        // in this case, we only push a single call, which is interpreted as the teardown call
-        let teardown_call = builder.public_call.finish();
-        let teardown_call_hash = teardown_call.call_stack_item.hash();
-        let teardown_is_delegate_call = teardown_call.call_stack_item.public_inputs.call_context.is_delegate_call;
-        builder.previous_kernel.push_public_call_request(teardown_call_hash, teardown_is_delegate_call);
-        let previous_kernel = builder.previous_kernel.to_public_kernel_data(false);
-
-        // Run the kernel on the setup call
-        let kernel = PublicKernelSetupCircuitPrivateInputs { previous_kernel, public_call: teardown_call };
-
-        let _ = kernel.public_kernel_setup();
-    }
 
     #[test(should_fail_with="No contract storage update requests are allowed for static calls")]
     fn previous_private_kernel_fails_if_contract_storage_update_requests_on_static_call() {

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
@@ -14,8 +14,8 @@ impl PublicKernelTeardownCircuitPrivateInputs {
         // Currently the nested calls will be pushed to the public call stack and need_setup will return true.
         // This should not be the case when nested calls are handled in avm.
         // But we should also consider merging this and the setup circuit and have one circuit that deals with non-revertibles.
-        // let needs_setup = self.previous_kernel.public_inputs.needs_setup();
-        // assert(needs_setup == false, "Cannot run teardown circuit before setup circuit");
+        let needs_setup = self.previous_kernel.public_inputs.needs_setup();
+        assert(needs_setup == false, "Cannot run teardown circuit before setup circuit");
         let needs_app_logic = self.previous_kernel.public_inputs.needs_app_logic();
         assert(needs_app_logic == false, "Cannot run teardown circuit before app logic circuit");
         let needs_teardown = self.previous_kernel.public_inputs.needs_teardown();

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_teardown.nr
@@ -88,7 +88,7 @@ impl PublicKernelTeardownCircuitPrivateInputs {
         self.validate_inputs();
 
         // Pops the item from the call stack and validates it against the current execution.
-        let call_request = public_inputs.end_non_revertible.public_call_stack.pop();
+        let call_request = public_inputs.public_teardown_call_stack.pop();
         common::validate_call_against_request(self.public_call, call_request);
 
         self.validate_start_gas();
@@ -96,6 +96,7 @@ impl PublicKernelTeardownCircuitPrivateInputs {
 
         common::update_validation_requests(self.public_call, &mut public_inputs);
 
+        common::update_teardown_call_stack(self.public_call, &mut public_inputs);
         common::update_public_end_non_revertible_values(self.public_call, &mut public_inputs);
 
         public_inputs.finish()
@@ -163,7 +164,7 @@ mod tests {
             // Adjust the call stack item hash for the current call in the previous iteration.
             let hash = public_call.call_stack_item.hash();
             let is_delegate_call = public_call.call_stack_item.public_inputs.call_context.is_delegate_call;
-            self.previous_kernel.push_public_call_request(hash, is_delegate_call);
+            self.previous_kernel.set_public_teardown_call_request(hash, is_delegate_call);
             let mut previous_kernel = self.previous_kernel.to_public_kernel_data(false);
             previous_kernel.public_inputs.end = self.previous_revertible.to_public_accumulated_data();
 
@@ -220,7 +221,7 @@ mod tests {
 
         let hash = public_call.call_stack_item.hash();
         // Tweak the call stack item hash.
-        builder.previous_kernel.push_public_call_request(hash + 1, false);
+        builder.previous_kernel.set_public_teardown_call_request(hash + 1, false);
         let previous_kernel = builder.previous_kernel.to_public_kernel_data(false);
 
         let kernel = PublicKernelTeardownCircuitPrivateInputs { previous_kernel, public_call };
@@ -262,7 +263,7 @@ mod tests {
         let hash = public_call.call_stack_item.hash();
         // Caller context is empty for regular calls.
         let is_delegate_call = false;
-        builder.previous_kernel.push_public_call_request(hash, is_delegate_call);
+        builder.previous_kernel.set_public_teardown_call_request(hash, is_delegate_call);
         let previous_kernel = builder.previous_kernel.to_public_kernel_data(false);
 
         let kernel = PublicKernelTeardownCircuitPrivateInputs { previous_kernel, public_call };

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/private_kernel_circuit_public_inputs_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/private_kernel_circuit_public_inputs_builder.nr
@@ -9,7 +9,8 @@ use crate::{
     gas::Gas, validation_requests::validation_requests_builder::ValidationRequestsBuilder,
     call_request::CallRequest
 },
-    mocked::AggregationObject, partial_state_reference::PartialStateReference, traits::Empty
+    constants::MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX, mocked::AggregationObject,
+    partial_state_reference::PartialStateReference, traits::{Empty, is_empty}
 };
 
 // Builds:
@@ -51,6 +52,10 @@ impl PrivateKernelCircuitPublicInputsBuilder {
         min_revertible_side_effect_counter: u32
     ) -> PublicKernelCircuitPublicInputs {
         let (end_non_revertible, end) = self.end.split_to_public(min_revertible_side_effect_counter, teardown_gas);
+        let mut public_teardown_call_stack: BoundedVec<CallRequest, MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX> = BoundedVec::new();
+        if (!is_empty(self.public_teardown_call_request)) {
+            public_teardown_call_stack.push(self.public_teardown_call_request);
+        }
 
         PublicKernelCircuitPublicInputs {
             validation_requests: self.validation_requests.finish(),
@@ -58,7 +63,7 @@ impl PrivateKernelCircuitPublicInputsBuilder {
             end,
             constants: self.constants,
             revert_code: 0,
-            public_teardown_call_request: self.public_teardown_call_request
+            public_teardown_call_stack: public_teardown_call_stack.storage
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/public_kernel_circuit_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/public_kernel_circuit_public_inputs.nr
@@ -15,20 +15,19 @@ struct PublicKernelCircuitPublicInputs {
 
 impl PublicKernelCircuitPublicInputs {
     pub fn needs_setup(self) -> bool {
-        // By definition, the final non-revertible enqueued call is for teardown.
-        // since this is a stack, the teardown call would be the 0th element.
-        // So if we have more than one element, we need setup.
+        // public calls for setup are deposited in the non-revertible public call stack.
+        // if an element is present, we need to run setup
         !self.end_non_revertible.public_call_stack[0].is_empty()
     }
 
     pub fn needs_app_logic(self) -> bool {
-        // if we have any enqueued revertible public calls, we need to run the public app logic circuit.
+        // public calls for app logic are deposited in the revertible public call stack.
+        // if an element is present, we need to run app logic
         !self.end.public_call_stack[0].is_empty()
     }
 
     pub fn needs_teardown(self) -> bool {
-        // By definition, the final non-revertible enqueued call is for teardown.
-        // since this is a stack, the teardown call would be the 0th element.
+        // the public call specified for teardown, if any, is placed in the teardown call stack
         !self.public_teardown_call_stack[0].is_empty()
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/public_kernel_circuit_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/public_kernel_circuit_public_inputs.nr
@@ -2,6 +2,7 @@ use crate::abis::{
     accumulated_data::PublicAccumulatedData, combined_constant_data::CombinedConstantData,
     validation_requests::{RollupValidationRequests, ValidationRequests}, call_request::CallRequest
 };
+use crate::constants::MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX;
 
 struct PublicKernelCircuitPublicInputs {
     validation_requests: ValidationRequests,
@@ -9,7 +10,7 @@ struct PublicKernelCircuitPublicInputs {
     end: PublicAccumulatedData,
     constants: CombinedConstantData,
     revert_code: u8,
-    public_teardown_call_request: CallRequest,
+    public_teardown_call_stack: [CallRequest; MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX],
 }
 
 impl PublicKernelCircuitPublicInputs {
@@ -17,7 +18,7 @@ impl PublicKernelCircuitPublicInputs {
         // By definition, the final non-revertible enqueued call is for teardown.
         // since this is a stack, the teardown call would be the 0th element.
         // So if we have more than one element, we need setup.
-        !self.end_non_revertible.public_call_stack[1].is_empty()
+        !self.end_non_revertible.public_call_stack[0].is_empty()
     }
 
     pub fn needs_app_logic(self) -> bool {
@@ -28,6 +29,6 @@ impl PublicKernelCircuitPublicInputs {
     pub fn needs_teardown(self) -> bool {
         // By definition, the final non-revertible enqueued call is for teardown.
         // since this is a stack, the teardown call would be the 0th element.
-        !self.end_non_revertible.public_call_stack[0].is_empty()
+        !self.public_teardown_call_stack[0].is_empty()
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/public_kernel_circuit_public_inputs_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/public_kernel_circuit_public_inputs_builder.nr
@@ -5,7 +5,7 @@ use crate::{
     kernel_circuit_public_inputs::{public_kernel_circuit_public_inputs::PublicKernelCircuitPublicInputs},
     validation_requests::ValidationRequestsBuilder, call_request::CallRequest
 },
-    traits::Empty
+    constants::MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX, traits::Empty
 };
 
 struct PublicKernelCircuitPublicInputsBuilder {
@@ -14,7 +14,7 @@ struct PublicKernelCircuitPublicInputsBuilder {
     end: PublicAccumulatedDataBuilder,
     constants: CombinedConstantData,
     revert_code: u8,
-    public_teardown_call_request: CallRequest,
+    public_teardown_call_stack: BoundedVec<CallRequest, MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX>,
 }
 
 impl PublicKernelCircuitPublicInputsBuilder {
@@ -28,7 +28,7 @@ impl PublicKernelCircuitPublicInputsBuilder {
             end: self.end.finish(),
             constants: self.constants,
             revert_code: self.revert_code,
-            public_teardown_call_request: self.public_teardown_call_request
+            public_teardown_call_stack: self.public_teardown_call_stack.storage
         }
     }
 }
@@ -41,7 +41,7 @@ impl Empty for PublicKernelCircuitPublicInputsBuilder {
             end: PublicAccumulatedDataBuilder::empty(),
             constants: CombinedConstantData::empty(),
             revert_code: 0 as u8,
-            public_teardown_call_request: CallRequest::empty()
+            public_teardown_call_stack: BoundedVec::new()
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_kernel/private_call_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_kernel/private_call_data.nr
@@ -13,6 +13,7 @@ struct PrivateCallData {
 
     private_call_stack: [CallRequest; MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL],
     public_call_stack: [CallRequest; MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL],
+    public_teardown_call_request: CallRequest,
 
     proof: RecursiveProof,
     vk: VerificationKey,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -216,6 +216,8 @@ impl FixtureBuilder {
         };
         let validation_requests = self.to_validation_requests();
         let constants = self.to_constant_data();
+        let mut public_teardown_call_stack: BoundedVec<CallRequest, MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX> = BoundedVec::new();
+        public_teardown_call_stack.push(self.public_teardown_call_request);
 
         PublicKernelCircuitPublicInputs {
             end_non_revertible,
@@ -223,7 +225,7 @@ impl FixtureBuilder {
             validation_requests,
             constants,
             revert_code: self.revert_code,
-            public_teardown_call_request: self.public_teardown_call_request
+            public_teardown_call_stack: public_teardown_call_stack.storage
         }
     }
 
@@ -411,6 +413,10 @@ impl FixtureBuilder {
     pub fn push_public_call_request(&mut self, hash: Field, is_delegate_call: bool) {
         let call_stack_item = self.generate_call_request(hash, is_delegate_call);
         self.public_call_stack.push(call_stack_item);
+    }
+
+    pub fn set_public_teardown_call_request(&mut self, hash: Field, is_delegate_call: bool) {
+        self.public_teardown_call_request = self.generate_call_request(hash, is_delegate_call);
     }
 
     pub fn end_setup(&mut self) {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/private_call_data_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/private_call_data_builder.nr
@@ -22,6 +22,7 @@ struct PrivateCallDataBuilder {
     // The rest of the values of PrivateCallData.
     private_call_stack: BoundedVec<CallRequest, MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL>,
     public_call_stack: BoundedVec<CallRequest, MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL>,
+    public_teardown_call_request: CallRequest,
     proof: RecursiveProof,
     vk: VerificationKey,
     salted_initialization_hash: SaltedInitializationHash,
@@ -48,6 +49,7 @@ impl PrivateCallDataBuilder {
             function_data,
             private_call_stack: BoundedVec::new(),
             public_call_stack: BoundedVec::new(),
+            public_teardown_call_request: CallRequest::empty(),
             proof: RecursiveProof::empty(),
             vk: VerificationKey::empty(),
             function_leaf_membership_witness: contract_function.membership_witness,
@@ -169,6 +171,7 @@ impl PrivateCallDataBuilder {
             call_stack_item: self.build_call_stack_item(),
             private_call_stack: self.private_call_stack.storage,
             public_call_stack: self.public_call_stack.storage,
+            public_teardown_call_request: self.public_teardown_call_request,
             proof: self.proof,
             vk: self.vk,
             function_leaf_membership_witness: self.function_leaf_membership_witness,

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -146,7 +146,7 @@ run-e2e:
     ARG test
     ARG debug=""
     FROM +end-to-end
-    RUN DEBUG=$DEBUG yarn test $test
+    RUN DEBUG=$debug yarn test $test
 
 prover-client-test:
     FROM +build

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -144,9 +144,12 @@ test:
 
 run-e2e:
     ARG test
+    ARG debug=""
     FROM +end-to-end
-    RUN DEBUG=aztec:* yarn test $test
+    RUN DEBUG=$DEBUG yarn test $test
 
 prover-client-test:
     FROM +build
-    RUN cd prover-client && yarn test
+    ARG test
+    ARG debug=""
+    RUN cd prover-client && DEBUG=$debug yarn test $test

--- a/yarn-project/circuit-types/src/mocks.ts
+++ b/yarn-project/circuit-types/src/mocks.ts
@@ -89,7 +89,10 @@ export const mockTx = (
         : CallRequest.empty(),
     );
 
-    data.forPublic.publicTeardownCallRequest = publicTeardownCallRequest.toCallRequest();
+    data.forPublic.publicTeardownCallStack = makeTuple(MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX, () => CallRequest.empty());
+    data.forPublic.publicTeardownCallStack[0] = publicTeardownCallRequest.isEmpty()
+      ? CallRequest.empty()
+      : publicTeardownCallRequest.toCallRequest();
 
     if (hasLogs) {
       let i = 1; // 0 used in first nullifier

--- a/yarn-project/circuits.js/src/structs/kernel/private_call_data.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/private_call_data.ts
@@ -32,6 +32,10 @@ export class PrivateCallData {
      */
     public publicCallStack: Tuple<CallRequest, typeof MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL>,
     /**
+     * The public call request for the teardown function.
+     */
+    public publicTeardownCallRequest: CallRequest,
+    /**
      * The proof of the execution of this private call.
      */
     public proof: RecursiveProof<typeof RECURSIVE_PROOF_LENGTH>,
@@ -75,6 +79,7 @@ export class PrivateCallData {
       fields.callStackItem,
       fields.privateCallStack,
       fields.publicCallStack,
+      fields.publicTeardownCallRequest,
       fields.proof,
       fields.vk,
       fields.contractClassArtifactHash,
@@ -109,6 +114,7 @@ export class PrivateCallData {
       reader.readObject(PrivateCallStackItem),
       reader.readArray(MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL, CallRequest),
       reader.readArray(MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL, CallRequest),
+      reader.readObject(CallRequest),
       RecursiveProof.fromBuffer(reader, RECURSIVE_PROOF_LENGTH),
       reader.readObject(VerificationKeyAsFields),
       reader.readObject(Fr),

--- a/yarn-project/circuits.js/src/structs/public_call_request.ts
+++ b/yarn-project/circuits.js/src/structs/public_call_request.ts
@@ -3,6 +3,8 @@ import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import { type FieldsOf } from '@aztec/foundation/types';
 
+import { inspect } from 'util';
+
 import { computeVarArgsHash } from '../hash/hash.js';
 import { CallContext } from './call_context.js';
 import { CallRequest, CallerContext } from './call_request.js';
@@ -145,5 +147,14 @@ export class PublicCallRequest {
       this.parentCallContext.isEmpty() &&
       this.args.length === 0
     );
+  }
+
+  [inspect.custom]() {
+    return `PublicCallRequest {
+      contractAddress: ${this.contractAddress}
+      functionData: ${this.functionData}
+      callContext: ${this.callContext}
+      parentCallContext: ${this.parentCallContext}
+      args: ${this.args} }`;
   }
 }

--- a/yarn-project/circuits.js/src/tests/factories.ts
+++ b/yarn-project/circuits.js/src/tests/factories.ts
@@ -428,6 +428,7 @@ export function makePublicKernelCircuitPublicInputs(
   seed = 1,
   fullAccumulatedData = true,
 ): PublicKernelCircuitPublicInputs {
+  const tupleGenerator = fullAccumulatedData ? makeTuple : makeHalfFullTuple;
   return new PublicKernelCircuitPublicInputs(
     makeAggregationObject(seed),
     makeValidationRequests(seed),
@@ -435,7 +436,7 @@ export function makePublicKernelCircuitPublicInputs(
     makePublicAccumulatedData(seed, fullAccumulatedData),
     makeConstantData(seed + 0x100),
     RevertCode.OK,
-    makeCallRequest(seed + 0x200),
+    tupleGenerator(MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX, makeCallRequest, seed + 0x600, CallRequest.empty),
   );
 }
 
@@ -453,7 +454,7 @@ export function makePrivateKernelTailCircuitPublicInputs(
         ValidationRequests.empty(),
         makePublicAccumulatedData(seed + 0x100, false),
         makePublicAccumulatedData(seed + 0x200, false),
-        makeCallRequest(seed + 0x300),
+        makeHalfFullTuple(MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX, makeCallRequest, seed + 0x400, CallRequest.empty),
       )
     : undefined;
   const forRollup = !isForPublic
@@ -729,6 +730,7 @@ export function makePrivateCallData(seed = 1): PrivateCallData {
     callStackItem: makePrivateCallStackItem(seed),
     privateCallStack: makeTuple(MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL, makeCallRequest, seed + 0x10),
     publicCallStack: makeTuple(MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL, makeCallRequest, seed + 0x20),
+    publicTeardownCallRequest: makeCallRequest(seed + 0x30),
     proof: makeRecursiveProof<typeof RECURSIVE_PROOF_LENGTH>(RECURSIVE_PROOF_LENGTH, seed + 0x50),
     vk: makeVerificationKeyAsFields(),
     contractClassArtifactHash: fr(seed + 0x70),

--- a/yarn-project/noir-protocol-circuits-types/src/type_conversion.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/type_conversion.ts
@@ -786,6 +786,7 @@ export function mapPrivateCallDataToNoir(privateCallData: PrivateCallData): Priv
     call_stack_item: mapPrivateCallStackItemToNoir(privateCallData.callStackItem),
     private_call_stack: mapTuple(privateCallData.privateCallStack, mapCallRequestToNoir),
     public_call_stack: mapTuple(privateCallData.publicCallStack, mapCallRequestToNoir),
+    public_teardown_call_request: mapCallRequestToNoir(privateCallData.publicTeardownCallRequest),
     proof: mapRecursiveProofToNoir(privateCallData.proof),
     vk: mapVerificationKeyToNoir(privateCallData.vk),
     function_leaf_membership_witness: mapMembershipWitnessToNoir(privateCallData.functionLeafMembershipWitness),
@@ -1240,7 +1241,7 @@ export function mapPublicKernelCircuitPublicInputsToNoir(
     end: mapPublicAccumulatedDataToNoir(inputs.end),
     end_non_revertible: mapPublicAccumulatedDataToNoir(inputs.endNonRevertibleData),
     revert_code: mapRevertCodeToNoir(inputs.revertCode),
-    public_teardown_call_request: mapCallRequestToNoir(inputs.publicTeardownCallRequest),
+    public_teardown_call_stack: mapTuple(inputs.publicTeardownCallStack, mapCallRequestToNoir),
   };
 }
 
@@ -1360,7 +1361,7 @@ export function mapPrivateKernelTailCircuitPublicInputsForPublicFromNoir(
     mapValidationRequestsFromNoir(inputs.validation_requests),
     mapPublicAccumulatedDataFromNoir(inputs.end_non_revertible),
     mapPublicAccumulatedDataFromNoir(inputs.end),
-    mapCallRequestFromNoir(inputs.public_teardown_call_request),
+    mapTupleFromNoir(inputs.public_teardown_call_stack, MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX, mapCallRequestFromNoir),
   );
   return new PrivateKernelTailCircuitPublicInputs(
     AggregationObject.makeFake(),
@@ -1478,7 +1479,7 @@ export function mapPublicKernelCircuitPublicInputsFromNoir(
     mapPublicAccumulatedDataFromNoir(inputs.end),
     mapCombinedConstantDataFromNoir(inputs.constants),
     mapRevertCodeFromNoir(inputs.revert_code),
-    mapCallRequestFromNoir(inputs.public_teardown_call_request),
+    mapTupleFromNoir(inputs.public_teardown_call_stack, MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX, mapCallRequestFromNoir),
   );
 }
 

--- a/yarn-project/prover-client/src/mocks/test_context.ts
+++ b/yarn-project/prover-client/src/mocks/test_context.ts
@@ -134,14 +134,16 @@ export class TestContext {
       _sideEffectCounter?: number,
     ) => {
       for (const tx of txs) {
-        for (const request of tx.enqueuedPublicFunctionCalls) {
+        const allCalls = tx.publicTeardownFunctionCall.isEmpty()
+          ? tx.enqueuedPublicFunctionCalls
+          : [...tx.enqueuedPublicFunctionCalls, tx.publicTeardownFunctionCall];
+        for (const request of allCalls) {
           if (execution.contractAddress.equals(request.contractAddress)) {
             const result = PublicExecutionResultBuilder.fromPublicCallRequest({ request }).build({
               startGasLeft: availableGas,
               endGasLeft: availableGas,
               transactionFee,
             });
-            // result.unencryptedLogs = tx.unencryptedLogs.functionLogs[0];
             return Promise.resolve(result);
           }
         }

--- a/yarn-project/prover-client/src/prover/bb_prover_public_kernel.test.ts
+++ b/yarn-project/prover-client/src/prover/bb_prover_public_kernel.test.ts
@@ -1,5 +1,6 @@
 import { PublicKernelType, mockTx } from '@aztec/circuit-types';
 import { type Proof, makeEmptyProof } from '@aztec/circuits.js';
+import { makePublicCallRequest } from '@aztec/circuits.js/testing';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { type ServerProtocolArtifact } from '@aztec/noir-protocol-circuits-types';
 
@@ -29,9 +30,11 @@ describe('prover/bb_prover/public-kernel', () => {
   });
 
   it('proves the public kernel circuits', async () => {
+    const teardown = makePublicCallRequest();
     const tx = mockTx(1000, {
-      numberOfNonRevertiblePublicCallRequests: 2,
+      numberOfNonRevertiblePublicCallRequests: 1,
       numberOfRevertiblePublicCallRequests: 1,
+      publicTeardownCallRequest: teardown,
     });
     tx.data.constants.historicalHeader = await context.actualDb.buildInitialHeader();
 

--- a/yarn-project/pxe/src/kernel_prover/kernel_prover.test.ts
+++ b/yarn-project/pxe/src/kernel_prover/kernel_prover.test.ts
@@ -11,6 +11,7 @@ import {
   PrivateCircuitPublicInputs,
   PrivateKernelCircuitPublicInputs,
   PrivateKernelTailCircuitPublicInputs,
+  PublicCallRequest,
   RECURSIVE_PROOF_LENGTH,
   ScopedNoteHash,
   type TxRequest,
@@ -76,6 +77,7 @@ describe('Kernel Prover', () => {
       acir: Buffer.alloc(0),
       partialWitness: new Map(),
       enqueuedPublicFunctionCalls: [],
+      publicTeardownFunctionCall: PublicCallRequest.empty(),
       encryptedLogs: [],
       unencryptedLogs: [],
     };

--- a/yarn-project/pxe/src/kernel_prover/kernel_prover.ts
+++ b/yarn-project/pxe/src/kernel_prover/kernel_prover.ts
@@ -77,6 +77,9 @@ export class KernelProver {
         result.callStackItem.toCallRequest(currentExecution.callStackItem.publicInputs.callContext),
       );
       const publicCallRequests = currentExecution.enqueuedPublicFunctionCalls.map(result => result.toCallRequest());
+      const publicTeardownCallRequest = currentExecution.publicTeardownFunctionCall.isEmpty()
+        ? CallRequest.empty()
+        : currentExecution.publicTeardownFunctionCall.toCallRequest();
 
       const proofOutput = await this.proofCreator.createAppCircuitProof(
         currentExecution.partialWitness,
@@ -87,6 +90,7 @@ export class KernelProver {
         currentExecution,
         privateCallRequests,
         publicCallRequests,
+        publicTeardownCallRequest,
         proofOutput.proof,
         proofOutput.verificationKey,
       );
@@ -143,6 +147,7 @@ export class KernelProver {
     { callStackItem }: ExecutionResult,
     privateCallRequests: CallRequest[],
     publicCallRequests: CallRequest[],
+    publicTeardownCallRequest: CallRequest,
     proof: RecursiveProof<typeof RECURSIVE_PROOF_LENGTH>,
     vk: VerificationKeyAsFields,
   ) {
@@ -174,6 +179,7 @@ export class KernelProver {
       callStackItem,
       privateCallStack,
       publicCallStack,
+      publicTeardownCallRequest,
       proof,
       vk,
       publicKeysHash,

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -30,7 +30,7 @@ import {
   MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX,
   type PartialAddress,
   type PrivateKernelTailCircuitPublicInputs,
-  PublicCallRequest,
+  type PublicCallRequest,
   computeContractClassId,
   getContractClassFromArtifact,
 } from '@aztec/circuits.js';
@@ -45,6 +45,7 @@ import {
   type AcirSimulator,
   type ExecutionResult,
   collectEnqueuedPublicFunctionCalls,
+  collectPublicTeardownFunctionCall,
   collectSortedEncryptedLogs,
   collectSortedUnencryptedLogs,
   resolveOpcodeLocations,
@@ -677,7 +678,7 @@ export class PXEService implements PXE {
     const unencryptedLogs = new UnencryptedTxL2Logs([collectSortedUnencryptedLogs(executionResult)]);
     const encryptedLogs = new EncryptedTxL2Logs([collectSortedEncryptedLogs(executionResult)]);
     const enqueuedPublicFunctions = collectEnqueuedPublicFunctionCalls(executionResult);
-    const teardownPublicFunction = PublicCallRequest.empty();
+    const teardownPublicFunction = collectPublicTeardownFunctionCall(executionResult);
 
     // HACK(#1639): Manually patches the ordering of the public call stack
     // TODO(#757): Enforce proper ordering of enqueued public calls

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -153,6 +153,12 @@ function getDefaultAllowedSetupFunctions(): AllowedFunction[] {
       selector: FunctionSelector.fromSignature('approve_public_authwit(Field)'),
     },
 
+    // needed for native payments while they are not yet enshrined
+    {
+      classId: getContractClassFromArtifact(GasTokenContract.artifact).id,
+      selector: FunctionSelector.fromSignature('pay_fee(Field)'),
+    },
+
     // needed for private transfers via FPC
     {
       classId: getContractClassFromArtifact(TokenContractArtifact).id,

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -84,6 +84,7 @@ export class Sequencer {
     if (config.allowedFunctionsInSetup) {
       this.allowedFunctionsInSetup = config.allowedFunctionsInSetup;
     }
+    // TODO(#5917) remove this. it is no longer needed since we don't need to whitelist functions in teardown
     if (config.allowedFunctionsInTeardown) {
       this.allowedFunctionsInTeardown = config.allowedFunctionsInTeardown;
     }
@@ -187,11 +188,7 @@ export class Sequencer {
       // TODO: It should be responsibility of the P2P layer to validate txs before passing them on here
       const validTxs = await this.takeValidTxs(
         pendingTxs,
-        this.txValidatorFactory.validatorForNewTxs(
-          newGlobalVariables,
-          this.allowedFunctionsInSetup,
-          this.allowedFunctionsInTeardown,
-        ),
+        this.txValidatorFactory.validatorForNewTxs(newGlobalVariables, this.allowedFunctionsInSetup),
       );
       if (validTxs.length < this.minTxsPerBLock) {
         return;

--- a/yarn-project/sequencer-client/src/tx_validator/gas_validator.test.ts
+++ b/yarn-project/sequencer-client/src/tx_validator/gas_validator.test.ts
@@ -7,7 +7,7 @@ import { type MockProxy, mock, mockFn } from 'jest-mock-extended';
 
 import { GasTxValidator, type PublicStateSource } from './gas_validator.js';
 
-describe('GasTxValidator', () => {
+describe.skip('GasTxValidator', () => {
   let validator: GasTxValidator;
   let publicStateSource: MockProxy<PublicStateSource>;
   let gasTokenAddress: AztecAddress;

--- a/yarn-project/sequencer-client/src/tx_validator/phases_validator.test.ts
+++ b/yarn-project/sequencer-client/src/tx_validator/phases_validator.test.ts
@@ -14,14 +14,12 @@ describe('PhasesTxValidator', () => {
   let allowedContract: AztecAddress;
   let allowedSetupSelector1: FunctionSelector;
   let allowedSetupSelector2: FunctionSelector;
-  let allowedTeardownSelector: FunctionSelector;
 
   beforeEach(() => {
     allowedContractClass = Fr.random();
     allowedContract = makeAztecAddress();
     allowedSetupSelector1 = makeSelector(1);
     allowedSetupSelector2 = makeSelector(2);
-    allowedTeardownSelector = makeSelector(3);
 
     contractDataSource = mock<ContractDataSource>({
       getContract: mockFn().mockImplementation(() => {
@@ -31,86 +29,29 @@ describe('PhasesTxValidator', () => {
       }),
     });
 
-    txValidator = new PhasesTxValidator(
-      contractDataSource,
-      [
-        {
-          classId: allowedContractClass,
-          selector: allowedSetupSelector1,
-        },
-        {
-          address: allowedContract,
-          selector: allowedSetupSelector1,
-        },
-        {
-          classId: allowedContractClass,
-          selector: allowedSetupSelector2,
-        },
-        {
-          address: allowedContract,
-          selector: allowedSetupSelector2,
-        },
-      ],
-      [
-        {
-          classId: allowedContractClass,
-          selector: allowedTeardownSelector,
-        },
-        {
-          address: allowedContract,
-          selector: allowedTeardownSelector,
-        },
-      ],
-    );
-  });
-
-  it('allows teardown functions on the contracts allow list', async () => {
-    const tx = mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
-    patchNonRevertibleFn(tx, 0, { address: allowedContract, selector: allowedTeardownSelector });
-    await expect(txValidator.validateTxs([tx])).resolves.toEqual([[tx], []]);
-  });
-
-  it('allows teardown functions on the contracts class allow list', async () => {
-    const tx = mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
-    const { address } = patchNonRevertibleFn(tx, 0, { selector: allowedTeardownSelector });
-    contractDataSource.getContract.mockImplementationOnce(contractAddress => {
-      if (address.equals(contractAddress)) {
-        return Promise.resolve({
-          contractClassId: allowedContractClass,
-        } as any);
-      } else {
-        return Promise.resolve(undefined);
-      }
-    });
-
-    await expect(txValidator.validateTxs([tx])).resolves.toEqual([[tx], []]);
-  });
-
-  it('rejects teardown functions not on the contracts class list', async () => {
-    const tx = mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
-    // good selector, bad contract class
-    const { address } = patchNonRevertibleFn(tx, 0, { selector: allowedTeardownSelector });
-    contractDataSource.getContract.mockImplementationOnce(contractAddress => {
-      if (address.equals(contractAddress)) {
-        return Promise.resolve({
-          contractClassId: Fr.random(),
-        } as any);
-      } else {
-        return Promise.resolve(undefined);
-      }
-    });
-    await expect(txValidator.validateTxs([tx])).resolves.toEqual([[], [tx]]);
-  });
-
-  it('rejects teardown functions not on the selector allow list', async () => {
-    const tx = mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
-    await expect(txValidator.validateTxs([tx])).resolves.toEqual([[], [tx]]);
+    txValidator = new PhasesTxValidator(contractDataSource, [
+      {
+        classId: allowedContractClass,
+        selector: allowedSetupSelector1,
+      },
+      {
+        address: allowedContract,
+        selector: allowedSetupSelector1,
+      },
+      {
+        classId: allowedContractClass,
+        selector: allowedSetupSelector2,
+      },
+      {
+        address: allowedContract,
+        selector: allowedSetupSelector2,
+      },
+    ]);
   });
 
   it('allows setup functions on the contracts allow list', async () => {
     const tx = mockTx(1, { numberOfNonRevertiblePublicCallRequests: 2 });
     patchNonRevertibleFn(tx, 0, { address: allowedContract, selector: allowedSetupSelector1 });
-    patchNonRevertibleFn(tx, 1, { address: allowedContract, selector: allowedTeardownSelector });
 
     await expect(txValidator.validateTxs([tx])).resolves.toEqual([[tx], []]);
   });
@@ -118,7 +59,6 @@ describe('PhasesTxValidator', () => {
   it('allows setup functions on the contracts class allow list', async () => {
     const tx = mockTx(1, { numberOfNonRevertiblePublicCallRequests: 2 });
     const { address } = patchNonRevertibleFn(tx, 0, { selector: allowedSetupSelector1 });
-    patchNonRevertibleFn(tx, 1, { address: allowedContract, selector: allowedTeardownSelector });
 
     contractDataSource.getContract.mockImplementationOnce(contractAddress => {
       if (address.equals(contractAddress)) {
@@ -135,8 +75,6 @@ describe('PhasesTxValidator', () => {
 
   it('rejects txs with setup functions not on the allow list', async () => {
     const tx = mockTx(1, { numberOfNonRevertiblePublicCallRequests: 2 });
-    // only patch teardown
-    patchNonRevertibleFn(tx, 1, { address: allowedContract, selector: allowedTeardownSelector });
 
     await expect(txValidator.validateTxs([tx])).resolves.toEqual([[], [tx]]);
   });
@@ -145,7 +83,6 @@ describe('PhasesTxValidator', () => {
     const tx = mockTx(1, { numberOfNonRevertiblePublicCallRequests: 2 });
     // good selector, bad contract class
     const { address } = patchNonRevertibleFn(tx, 0, { selector: allowedSetupSelector1 });
-    patchNonRevertibleFn(tx, 1, { address: allowedContract, selector: allowedTeardownSelector });
     contractDataSource.getContract.mockImplementationOnce(contractAddress => {
       if (address.equals(contractAddress)) {
         return Promise.resolve({
@@ -162,7 +99,6 @@ describe('PhasesTxValidator', () => {
     const tx = mockTx(1, { numberOfNonRevertiblePublicCallRequests: 3 });
     patchNonRevertibleFn(tx, 0, { address: allowedContract, selector: allowedSetupSelector1 });
     patchNonRevertibleFn(tx, 1, { address: allowedContract, selector: allowedSetupSelector2 });
-    patchNonRevertibleFn(tx, 2, { address: allowedContract, selector: allowedTeardownSelector });
 
     await expect(txValidator.validateTxs([tx])).resolves.toEqual([[tx], []]);
   });
@@ -170,8 +106,6 @@ describe('PhasesTxValidator', () => {
   it('rejects if one setup functions is not on the allow list', async () => {
     const tx = mockTx(1, { numberOfNonRevertiblePublicCallRequests: 3 });
     patchNonRevertibleFn(tx, 0, { address: allowedContract, selector: allowedSetupSelector1 });
-    // don't patch index 1
-    patchNonRevertibleFn(tx, 2, { address: allowedContract, selector: allowedTeardownSelector });
 
     await expect(txValidator.validateTxs([tx])).resolves.toEqual([[], [tx]]);
   });

--- a/yarn-project/sequencer-client/src/tx_validator/tx_validator_factory.ts
+++ b/yarn-project/sequencer-client/src/tx_validator/tx_validator_factory.ts
@@ -18,15 +18,11 @@ export class TxValidatorFactory {
     private gasPortalAddress: EthAddress,
   ) {}
 
-  validatorForNewTxs(
-    globalVariables: GlobalVariables,
-    setupAllowList: AllowedFunction[],
-    teardownAllowList: AllowedFunction[],
-  ): TxValidator<Tx> {
+  validatorForNewTxs(globalVariables: GlobalVariables, setupAllowList: AllowedFunction[]): TxValidator<Tx> {
     return new AggregateTxValidator(
       new MetadataTxValidator(globalVariables),
       new DoubleSpendTxValidator(new WorldStateDB(this.merkleTreeDb)),
-      new PhasesTxValidator(this.contractDataSource, setupAllowList, teardownAllowList),
+      new PhasesTxValidator(this.contractDataSource, setupAllowList),
       new GasTxValidator(new WorldStatePublicDB(this.merkleTreeDb), getCanonicalGasTokenAddress(this.gasPortalAddress)),
     );
   }

--- a/yarn-project/simulator/src/acvm/oracle/oracle.ts
+++ b/yarn-project/simulator/src/acvm/oracle/oracle.ts
@@ -438,6 +438,25 @@ export class Oracle {
     return toAcvmEnqueuePublicFunctionResult(enqueuedRequest);
   }
 
+  async setPublicTeardownFunctionCall(
+    [contractAddress]: ACVMField[],
+    [functionSelector]: ACVMField[],
+    [argsHash]: ACVMField[],
+    [sideEffectCounter]: ACVMField[],
+    [isStaticCall]: ACVMField[],
+    [isDelegateCall]: ACVMField[],
+  ) {
+    const teardownRequest = await this.typedOracle.setPublicTeardownFunctionCall(
+      AztecAddress.fromString(contractAddress),
+      FunctionSelector.fromField(fromACVMField(functionSelector)),
+      fromACVMField(argsHash),
+      frToNumber(fromACVMField(sideEffectCounter)),
+      frToBoolean(fromACVMField(isStaticCall)),
+      frToBoolean(fromACVMField(isDelegateCall)),
+    );
+    return toAcvmEnqueuePublicFunctionResult(teardownRequest);
+  }
+
   aes128Encrypt(input: ACVMField[], initializationVector: ACVMField[], key: ACVMField[]): ACVMField[] {
     // Convert each field to a number and then to a buffer (1 byte is stored in 1 field)
     const processedInput = Buffer.from(input.map(fromACVMField).map(f => f.toNumber()));

--- a/yarn-project/simulator/src/acvm/oracle/typed_oracle.ts
+++ b/yarn-project/simulator/src/acvm/oracle/typed_oracle.ts
@@ -243,6 +243,17 @@ export abstract class TypedOracle {
     throw new OracleMethodNotAvailableError('enqueuePublicFunctionCall');
   }
 
+  setPublicTeardownFunctionCall(
+    _targetContractAddress: AztecAddress,
+    _functionSelector: FunctionSelector,
+    _argsHash: Fr,
+    _sideEffectCounter: number,
+    _isStaticCall: boolean,
+    _isDelegateCall: boolean,
+  ): Promise<PublicCallRequest> {
+    throw new OracleMethodNotAvailableError('setPublicTeardownFunctionCall');
+  }
+
   aes128Encrypt(_input: Buffer, _initializationVector: Buffer, _key: Buffer): Buffer {
     throw new OracleMethodNotAvailableError('encrypt');
   }

--- a/yarn-project/simulator/src/client/execution_result.test.ts
+++ b/yarn-project/simulator/src/client/execution_result.test.ts
@@ -1,4 +1,4 @@
-import { PrivateCallStackItem } from '@aztec/circuits.js';
+import { PrivateCallStackItem, PublicCallRequest } from '@aztec/circuits.js';
 
 import {
   type ExecutionResult,
@@ -18,6 +18,7 @@ function emptyExecutionResult(): ExecutionResult {
     returnValues: [],
     nestedExecutions: [],
     enqueuedPublicFunctionCalls: [],
+    publicTeardownFunctionCall: PublicCallRequest.empty(),
     encryptedLogs: [],
     unencryptedLogs: [],
   };

--- a/yarn-project/simulator/src/client/execution_result.ts
+++ b/yarn-project/simulator/src/client/execution_result.ts
@@ -132,21 +132,23 @@ export function collectEnqueuedPublicFunctionCalls(execResult: ExecutionResult):
   // as the kernel processes it like a stack, popping items off and pushing them to output
   return [
     ...execResult.enqueuedPublicFunctionCalls,
-    ...[...execResult.nestedExecutions].flatMap(collectEnqueuedPublicFunctionCalls),
+    ...execResult.nestedExecutions.flatMap(collectEnqueuedPublicFunctionCalls),
   ].sort((a, b) => b.callContext.sideEffectCounter - a.callContext.sideEffectCounter);
 }
 
 export function collectPublicTeardownFunctionCall(execResult: ExecutionResult): PublicCallRequest {
   const teardownCalls = [
     execResult.publicTeardownFunctionCall,
-    ...[...execResult.nestedExecutions].flatMap(collectPublicTeardownFunctionCall),
+    ...execResult.nestedExecutions.flatMap(collectPublicTeardownFunctionCall),
   ].filter(call => !call.isEmpty());
+
+  if (teardownCalls.length === 1) {
+    return teardownCalls[0];
+  }
 
   if (teardownCalls.length > 1) {
     throw new Error('Multiple public teardown calls detected');
-  } else if (teardownCalls.length === 0) {
-    return PublicCallRequest.empty();
-  } else {
-    return teardownCalls[0];
   }
+
+  return PublicCallRequest.empty();
 }

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -853,6 +853,17 @@ describe('Private Execution test suite', () => {
     });
   });
 
+  describe('setting teardown function', () => {
+    it('should be able to set a teardown function', async () => {
+      const entrypoint = getFunctionArtifact(TestContractArtifact, 'test_setting_teardown');
+      const teardown = getFunctionArtifact(TestContractArtifact, 'dummy_public_call');
+      oracle.getFunctionArtifact.mockImplementation(() => Promise.resolve({ ...teardown }));
+      const result = await runSimulator({ artifact: entrypoint });
+      expect(result.publicTeardownFunctionCall.isEmpty()).toBeFalsy();
+      expect(result.publicTeardownFunctionCall.functionData).toEqual(FunctionData.fromAbi(teardown));
+    });
+  });
+
   describe('pending note hashes contract', () => {
     beforeEach(() => {
       oracle.getCompleteAddress.mockImplementation((address: AztecAddress) => {

--- a/yarn-project/simulator/src/client/private_execution.ts
+++ b/yarn-project/simulator/src/client/private_execution.ts
@@ -54,6 +54,7 @@ export async function executePrivateFunction(
   const nullifiedNoteHashCounters = context.getNullifiedNoteHashCounters();
   const nestedExecutions = context.getNestedExecutions();
   const enqueuedPublicFunctionCalls = context.getEnqueuedPublicFunctionCalls();
+  const publicTeardownFunctionCall = context.getPublicTeardownFunctionCall();
 
   log.debug(`Returning from call to ${contractAddress.toString()}:${functionSelector}`);
 
@@ -68,6 +69,7 @@ export async function executePrivateFunction(
     vk: Buffer.from(artifact.verificationKey!, 'hex'),
     nestedExecutions,
     enqueuedPublicFunctionCalls,
+    publicTeardownFunctionCall,
     encryptedLogs,
     unencryptedLogs,
   };

--- a/yarn-project/simulator/src/public/abstract_phase_manager.ts
+++ b/yarn-project/simulator/src/public/abstract_phase_manager.ts
@@ -32,7 +32,6 @@ import {
   MembershipWitness,
   NoteHash,
   Nullifier,
-  type PrivateKernelTailCircuitPublicInputs,
   type Proof,
   PublicCallData,
   type PublicCallRequest,
@@ -146,11 +145,8 @@ export abstract class AbstractPhaseManager {
     gasUsed: Gas | undefined;
   }>;
 
-  public static extractEnqueuedPublicCallsByPhase(
-    publicInputs: PrivateKernelTailCircuitPublicInputs,
-    enqueuedPublicFunctionCalls: PublicCallRequest[],
-  ): Record<PublicKernelPhase, PublicCallRequest[]> {
-    const data = publicInputs.forPublic;
+  public static extractEnqueuedPublicCallsByPhase(tx: Tx): Record<PublicKernelPhase, PublicCallRequest[]> {
+    const data = tx.data.forPublic;
     if (!data) {
       return {
         [PublicKernelPhase.SETUP]: [],
@@ -159,7 +155,7 @@ export abstract class AbstractPhaseManager {
         [PublicKernelPhase.TAIL]: [],
       };
     }
-    const publicCallsStack = enqueuedPublicFunctionCalls.slice().reverse();
+    const publicCallsStack = tx.enqueuedPublicFunctionCalls.slice().reverse();
     const nonRevertibleCallStack = data.endNonRevertibleData.publicCallStack.filter(i => !i.isEmpty());
     const revertibleCallStack = data.end.publicCallStack.filter(i => !i.isEmpty());
 
@@ -186,35 +182,37 @@ export abstract class AbstractPhaseManager {
       c => revertibleCallStack.findIndex(p => p.equals(c)) !== -1,
     );
 
+    const teardownCallStackLength = arrayNonEmptyLength(data.publicTeardownCallStack, f => f.isEmpty());
+
+    const teardownCallStack = teardownCallStackLength === 0 ? [] : [tx.publicTeardownFunctionCall];
+
     if (firstRevertibleCallIndex === 0) {
       return {
         [PublicKernelPhase.SETUP]: [],
         [PublicKernelPhase.APP_LOGIC]: publicCallsStack,
-        [PublicKernelPhase.TEARDOWN]: [],
+        [PublicKernelPhase.TEARDOWN]: teardownCallStack,
         [PublicKernelPhase.TAIL]: [],
       };
     } else if (firstRevertibleCallIndex === -1) {
       // there's no app logic, split the functions between setup (many) and teardown (just one function call)
       return {
-        [PublicKernelPhase.SETUP]: publicCallsStack.slice(0, -1),
+        [PublicKernelPhase.SETUP]: publicCallsStack,
         [PublicKernelPhase.APP_LOGIC]: [],
-        [PublicKernelPhase.TEARDOWN]: [publicCallsStack[publicCallsStack.length - 1]],
+        [PublicKernelPhase.TEARDOWN]: teardownCallStack,
         [PublicKernelPhase.TAIL]: [],
       };
     } else {
       return {
-        [PublicKernelPhase.SETUP]: publicCallsStack.slice(0, firstRevertibleCallIndex - 1),
+        [PublicKernelPhase.SETUP]: publicCallsStack.slice(0, firstRevertibleCallIndex),
         [PublicKernelPhase.APP_LOGIC]: publicCallsStack.slice(firstRevertibleCallIndex),
-        [PublicKernelPhase.TEARDOWN]: [publicCallsStack[firstRevertibleCallIndex - 1]],
+        [PublicKernelPhase.TEARDOWN]: teardownCallStack,
         [PublicKernelPhase.TAIL]: [],
       };
     }
   }
 
   protected extractEnqueuedPublicCalls(tx: Tx): PublicCallRequest[] {
-    const calls = AbstractPhaseManager.extractEnqueuedPublicCallsByPhase(tx.data, tx.enqueuedPublicFunctionCalls)[
-      this.phase
-    ];
+    const calls = AbstractPhaseManager.extractEnqueuedPublicCallsByPhase(tx)[this.phase];
 
     return calls;
   }

--- a/yarn-project/simulator/src/public/abstract_phase_manager.ts
+++ b/yarn-project/simulator/src/public/abstract_phase_manager.ts
@@ -182,9 +182,7 @@ export abstract class AbstractPhaseManager {
       c => revertibleCallStack.findIndex(p => p.equals(c)) !== -1,
     );
 
-    const teardownCallStackLength = arrayNonEmptyLength(data.publicTeardownCallStack, f => f.isEmpty());
-
-    const teardownCallStack = teardownCallStackLength === 0 ? [] : [tx.publicTeardownFunctionCall];
+    const teardownCallStack = tx.publicTeardownFunctionCall.isEmpty() ? [] : [tx.publicTeardownFunctionCall];
 
     if (firstRevertibleCallIndex === 0) {
       return {


### PR DESCRIPTION
### Deviations from [the spec](https://docs.aztec.network/protocol-specs/gas-and-fees/kernel-tracking):

I needed to create a new stack for processing the teardown calls, instead of storing a single call. I.e.
```diff
class PublicKernelCircuitPublicInputs {
    // ... other fields
--- +CallRequest public_teardown_call_request
+++ +CallRequest[MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX] public_teardown_call_stack
}
```

This is because a teardown function can call a nested function, and, similar to the current design for public/private calls,
we need a way to keep track of our execution stack.

Further, in order to pass in the CallRequest to the private kernel circuits, I needed to add a new parameter to the PrivateCallData.

### Overview

We designate a function to be run for teardown as:

```
context.set_public_teardown_function(
    context.this_address(),
    FunctionSelector::from_signature("pay_fee_with_shielded_rebate(Field,(Field),Field)"),
    [amount, asset.to_field(), secret_hash]
);
```

As I note in a comment, I created #6277 for getting back to something like:
```
FPC::at(context.this_address()).pay_fee_with_shielded_rebate(amount, asset, secret_hash).set_public_teardown_function(&mut context)
```

This sets `publicTeardownFunctionCall: PublicCallRequest` in the encapsulating `ClientExecutionContext`, which defaults to `PublicCallRequest.empty()`.

When private simulation is finished, we collect an array of all the public teardown functions that were set during the simulation.

We assert that the length of that array is 0 or 1.

When proving, we convert the `publicTeardownFunctionCall` to a `CallRequest` if it is not empty, otherwise we use `CallRequest.empty()`.

This is specified in the `PrivateCallData` which is passed to the private kernel circuit.

In the private kernel circuits, we assert that if the `public_teardown_function_hash` is not zero on the `PrivateCircuitPublicInputs`, then it matches the hash of the `publicTeardownFunctionCall` in the `PrivateCallData`.

Further, we assert that if the teardown call request in the `PrivateCallData` is not empty, then the teardown call request from the previous kernel *is* empty. 

In the private kernel tail, we assert that the public teardown call request is empty.

In private kernel tail to public, we initialize the teardown call stack to have the single element corresponding to the call request if it is not empty, and initialize it to an empty array otherwise.

Since teardown now has its own stack, we update the logic for how to know when we are in the different phases to simply look at each of their stacks:
- setup uses end_non_revertible.public_call_stack
- app logic uses end.public_call_stack
- teardown uses public_teardown_call_stack

### Note:

This does not change the fact that teardown is still non-revertible. That is covered by #5924


