### PR TITLE
chore(aztec-nr): create a 'with_selector' version of `emit_unencrypted_log` in avm context

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/avm_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/avm_context.nr
@@ -38,7 +38,7 @@ impl AvmContext {
     * Should be automatically convertible to [Field; N]. For example str<N> works with
     * one char per field. Otherwise you can use CompressedString.
     */
-    pub fn emit_unencrypted_log<T>(&mut self, event_selector: Field, log: T) {
+    pub fn emit_unencrypted_log_with_selector<T>(&mut self, event_selector: Field, log: T) {
         emit_unencrypted_log(event_selector, log);
     }
     pub fn note_hash_exists(self, note_hash: Field, leaf_index: Field) -> bool {
@@ -88,7 +88,7 @@ impl PublicContextInterface for AvmContext {
 
     fn emit_unencrypted_log<T,N,M>(&mut self, log: T) {
         let event_selector = 5;  // Matches current PublicContext.
-        self.emit_unencrypted_log(event_selector, log);
+        self.emit_unencrypted_log_with_selector(event_selector, log);
     }
 
     fn consume_l1_to_l2_message(&mut self, content: Field, secret: Field, sender: EthAddress, leaf_index: Field) {

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -261,10 +261,10 @@ contract AvmTest {
 
     #[aztec(public-vm)]
     fn emit_unencrypted_log() {
-        context.emit_unencrypted_log(/*event_selector=*/ 5, /*message=*/ [10, 20, 30]);
-        context.emit_unencrypted_log(/*event_selector=*/ 8, /*message=*/ "Hello, world!");
+        context.emit_unencrypted_log_with_selector(/*event_selector=*/ 5, /*message=*/ [10, 20, 30]);
+        context.emit_unencrypted_log_with_selector(/*event_selector=*/ 8, /*message=*/ "Hello, world!");
         let s: CompressedString<2,44> = CompressedString::from_string("A long time ago, in a galaxy far far away...");
-        context.emit_unencrypted_log(/*event_selector=*/ 10, /*message=*/ s);
+        context.emit_unencrypted_log_with_selector(/*event_selector=*/ 10, /*message=*/ s);
     }
 
     #[aztec(public-vm)]


### PR DESCRIPTION
This is necessary since most of the codebase uses a version of this function without a selector arg. It can probably be removed eventually when we settle on an interface.