### PR TITLE
feat: Return gas usage per phase from node tx simulation

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -668,6 +668,7 @@ export class AztecNodeService implements AztecNode {
     const processor = await publicProcessorFactory.create(prevHeader, newGlobalVariables);
     // REFACTOR: Consider merging ProcessReturnValues into ProcessedTx
     const [processedTxs, failedTxs, returns] = await processor.process([tx]);
+    // REFACTOR: Consider returning the error/revert rather than throwing
     if (failedTxs.length) {
       this.log.warn(`Simulated tx ${tx.getTxHash()} fails: ${failedTxs[0].error}`);
       throw failedTxs[0].error;
@@ -686,6 +687,7 @@ export class AztecNodeService implements AztecNode {
       end: processedTx.data.end,
       revertReason: processedTx.revertReason,
       publicReturnValues: returns[0],
+      gasUsed: processedTx.gasUsed,
     };
   }
 

--- a/yarn-project/circuit-types/src/mocks.ts
+++ b/yarn-project/circuit-types/src/mocks.ts
@@ -136,6 +136,7 @@ export const mockSimulatedTx = (seed = 1, hasLogs = true) => {
     end: makeCombinedAccumulatedData(),
     revertReason: undefined,
     publicReturnValues: dec,
+    gasUsed: {},
   };
   return new SimulatedTx(tx, dec, output);
 };

--- a/yarn-project/circuit-types/src/tx/processed_tx.ts
+++ b/yarn-project/circuit-types/src/tx/processed_tx.ts
@@ -9,6 +9,7 @@ import {
 } from '@aztec/circuit-types';
 import {
   Fr,
+  type Gas,
   type Header,
   KernelCircuitPublicInputs,
   type Proof,
@@ -68,6 +69,11 @@ export type ProcessedTx = Pick<Tx, 'proof' | 'encryptedLogs' | 'unencryptedLogs'
    * The collection of public kernel circuit inputs for simulation/proving
    */
   publicKernelRequests: PublicKernelRequest[];
+  /**
+   * Gas usage per public execution phase.
+   * Doesn't account for any base costs nor DA gas used in private execution.
+   */
+  gasUsed: Partial<Record<PublicKernelType, Gas>>;
 };
 
 export type RevertedTx = ProcessedTx & {
@@ -122,6 +128,7 @@ export function makeProcessedTx(
   proof: Proof,
   publicKernelRequests: PublicKernelRequest[],
   revertReason?: SimulationError,
+  gasUsed: ProcessedTx['gasUsed'] = {},
 ): ProcessedTx {
   return {
     hash: tx.getTxHash(),
@@ -132,6 +139,7 @@ export function makeProcessedTx(
     isEmpty: false,
     revertReason,
     publicKernelRequests,
+    gasUsed,
   };
 }
 
@@ -156,6 +164,7 @@ export function makeEmptyProcessedTx(header: Header, chainId: Fr, version: Fr): 
     isEmpty: true,
     revertReason: undefined,
     publicKernelRequests: [],
+    gasUsed: {},
   };
 }
 

--- a/yarn-project/circuit-types/src/tx/simulated_tx.test.ts
+++ b/yarn-project/circuit-types/src/tx/simulated_tx.test.ts
@@ -1,16 +1,59 @@
+import { Gas } from '@aztec/circuits.js';
+
 import { mockSimulatedTx } from '../mocks.js';
+import { PublicKernelType } from './processed_tx.js';
 import { SimulatedTx } from './simulated_tx.js';
 
 describe('simulated_tx', () => {
-  it('convert to and from json', () => {
-    const simulatedTx = mockSimulatedTx();
-    expect(SimulatedTx.fromJSON(simulatedTx.toJSON())).toEqual(simulatedTx);
+  let simulatedTx: SimulatedTx;
+
+  beforeEach(() => {
+    simulatedTx = mockSimulatedTx();
   });
 
-  it('convert undefined effects to and from json', () => {
-    const simulatedTx = mockSimulatedTx();
-    simulatedTx.privateReturnValues = undefined;
-    simulatedTx.publicOutput = undefined;
-    expect(SimulatedTx.fromJSON(simulatedTx.toJSON())).toEqual(simulatedTx);
+  describe('json', () => {
+    it('convert to and from json', () => {
+      expect(SimulatedTx.fromJSON(simulatedTx.toJSON())).toEqual(simulatedTx);
+    });
+
+    it('convert undefined effects to and from json', () => {
+      simulatedTx.privateReturnValues = undefined;
+      simulatedTx.publicOutput = undefined;
+      expect(SimulatedTx.fromJSON(simulatedTx.toJSON())).toEqual(simulatedTx);
+    });
+  });
+
+  describe('getGasLimits', () => {
+    beforeEach(() => {
+      simulatedTx.tx.data.publicInputs.end.gasUsed = Gas.from({ daGas: 100, l2Gas: 200 });
+      simulatedTx.publicOutput!.gasUsed = {
+        [PublicKernelType.SETUP]: Gas.from({ daGas: 10, l2Gas: 20 }),
+        [PublicKernelType.APP_LOGIC]: Gas.from({ daGas: 20, l2Gas: 40 }),
+        [PublicKernelType.TEARDOWN]: Gas.from({ daGas: 10, l2Gas: 20 }),
+      };
+    });
+
+    it('returns gas limits from private gas usage only', () => {
+      simulatedTx.publicOutput = undefined;
+      // Should be 110 and 220 but oh floating point
+      expect(simulatedTx.getGasLimits()).toEqual({
+        totalGas: Gas.from({ daGas: 111, l2Gas: 221 }),
+        teardownGas: Gas.empty(),
+      });
+    });
+
+    it('returns gas limits for private and public', () => {
+      expect(simulatedTx.getGasLimits()).toEqual({
+        totalGas: Gas.from({ daGas: 154, l2Gas: 308 }),
+        teardownGas: Gas.from({ daGas: 11, l2Gas: 22 }),
+      });
+    });
+
+    it('pads gas limits', () => {
+      expect(simulatedTx.getGasLimits(1)).toEqual({
+        totalGas: Gas.from({ daGas: 280, l2Gas: 560 }),
+        teardownGas: Gas.from({ daGas: 20, l2Gas: 40 }),
+      });
+    });
   });
 });

--- a/yarn-project/circuits.js/src/structs/gas.ts
+++ b/yarn-project/circuits.js/src/structs/gas.ts
@@ -83,4 +83,12 @@ export class Gas {
     const reader = FieldReader.asReader(fields);
     return new Gas(reader.readU32(), reader.readU32());
   }
+
+  toJSON() {
+    return { daGas: this.daGas, l2Gas: this.l2Gas };
+  }
+
+  static fromJSON(json: any) {
+    return new Gas(json.daGas, json.l2Gas);
+  }
 }

--- a/yarn-project/circuits.js/src/structs/kernel/private_kernel_tail_circuit_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/private_kernel_tail_circuit_public_inputs.ts
@@ -124,6 +124,10 @@ export class PrivateKernelTailCircuitPublicInputs {
     }
   }
 
+  get publicInputs(): PartialPrivateTailPublicInputsForPublic | PartialPrivateTailPublicInputsForRollup {
+    return (this.forPublic ?? this.forRollup)!;
+  }
+
   toPublicKernelCircuitPublicInputs() {
     if (!this.forPublic) {
       throw new Error('Private tail public inputs is not for public circuit.');

--- a/yarn-project/foundation/src/collection/index.ts
+++ b/yarn-project/foundation/src/collection/index.ts
@@ -1,1 +1,2 @@
 export * from './array.js';
+export * from './object.js';

--- a/yarn-project/foundation/src/collection/object.test.ts
+++ b/yarn-project/foundation/src/collection/object.test.ts
@@ -1,0 +1,30 @@
+import { mapValues } from './object.js';
+
+describe('mapValues', () => {
+  it('should return a new object with mapped values', () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const fn = (value: number) => value * 2;
+
+    const result = mapValues(obj, fn);
+
+    expect(result).toEqual({ a: 2, b: 4, c: 6 });
+  });
+
+  it('should handle an empty object', () => {
+    const obj = {};
+    const fn = (value: number) => value * 2;
+
+    const result = mapValues(obj, fn);
+
+    expect(result).toEqual({});
+  });
+
+  it('should handle different value types', () => {
+    const obj = { a: 'hello', b: true, c: [1, 2, 3] };
+    const fn = (value: any) => typeof value;
+
+    const result = mapValues(obj, fn);
+
+    expect(result).toEqual({ a: 'string', b: 'boolean', c: 'object' });
+  });
+});

--- a/yarn-project/foundation/src/collection/object.ts
+++ b/yarn-project/foundation/src/collection/object.ts
@@ -1,0 +1,19 @@
+/** Returns a new object with the same keys and where each value has been passed through the mapping function. */
+export function mapValues<K extends string | number | symbol, T, U>(
+  obj: Record<K, T>,
+  fn: (value: T) => U,
+): Record<K, U>;
+export function mapValues<K extends string | number | symbol, T, U>(
+  obj: Partial<Record<K, T>>,
+  fn: (value: T) => U,
+): Partial<Record<K, U>>;
+export function mapValues<K extends string | number | symbol, T, U>(
+  obj: Record<K, T>,
+  fn: (value: T) => U,
+): Record<K, U> {
+  const result: Record<K, U> = {} as Record<K, U>;
+  for (const key in obj) {
+    result[key] = fn(obj[key]);
+  }
+  return result;
+}

--- a/yarn-project/simulator/src/public/app_logic_phase_manager.ts
+++ b/yarn-project/simulator/src/public/app_logic_phase_manager.ts
@@ -47,6 +47,7 @@ export class AppLogicPhaseManager extends AbstractPhaseManager {
       newUnencryptedFunctionLogs,
       revertReason,
       returnValues,
+      gasUsed,
     ] = await this.processEnqueuedPublicCalls(tx, previousPublicKernelOutput, previousPublicKernelProof).catch(
       // if we throw for any reason other than simulation, we need to rollback and drop the TX
       async err => {
@@ -71,6 +72,6 @@ export class AppLogicPhaseManager extends AbstractPhaseManager {
       };
       return request;
     });
-    return { kernelRequests, publicKernelOutput, publicKernelProof, revertReason, returnValues };
+    return { kernelRequests, publicKernelOutput, publicKernelProof, revertReason, returnValues, gasUsed };
   }
 }

--- a/yarn-project/simulator/src/public/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor.ts
@@ -20,7 +20,11 @@ import { PublicExecutor, type PublicStateDB, type SimulationProvider } from '@az
 import { type ContractDataSource } from '@aztec/types/contracts';
 import { type MerkleTreeOperations } from '@aztec/world-state';
 
-import { type AbstractPhaseManager, PublicKernelPhase } from './abstract_phase_manager.js';
+import {
+  type AbstractPhaseManager,
+  PublicKernelPhase,
+  publicKernelPhaseToKernelType,
+} from './abstract_phase_manager.js';
 import { PhaseManagerFactory } from './phase_manager_factory.js';
 import { ContractsDataSourcePublicDB, WorldStateDB, WorldStatePublicDB } from './public_executor.js';
 import { RealPublicKernelCircuitSimulator } from './public_kernel.js';
@@ -169,8 +173,10 @@ export class PublicProcessor {
     let finalKernelOutput: KernelCircuitPublicInputs | undefined;
     let revertReason: SimulationError | undefined;
     const timer = new Timer();
+    const gasUsed: ProcessedTx['gasUsed'] = {};
     while (phase) {
       const output = await phase.handle(tx, publicKernelPublicInput, proof);
+      gasUsed[publicKernelPhaseToKernelType(phase.phase)] = output.gasUsed;
       if (phase.phase === PublicKernelPhase.APP_LOGIC) {
         returnValues = output.returnValues;
       }
@@ -196,7 +202,7 @@ export class PublicProcessor {
       throw new Error('Final public kernel was not executed.');
     }
 
-    const processedTx = makeProcessedTx(tx, finalKernelOutput, proof, publicRequests, revertReason);
+    const processedTx = makeProcessedTx(tx, finalKernelOutput, proof, publicRequests, revertReason, gasUsed);
 
     this.log.debug(`Processed public part of ${tx.getTxHash()}`, {
       eventName: 'tx-sequencer-processing',

--- a/yarn-project/simulator/src/public/setup_phase_manager.ts
+++ b/yarn-project/simulator/src/public/setup_phase_manager.ts
@@ -35,14 +35,21 @@ export class SetupPhaseManager extends AbstractPhaseManager {
     previousPublicKernelProof: Proof,
   ) {
     this.log.verbose(`Processing tx ${tx.getTxHash()}`);
-    const [kernelInputs, publicKernelOutput, publicKernelProof, newUnencryptedFunctionLogs, revertReason] =
-      await this.processEnqueuedPublicCalls(tx, previousPublicKernelOutput, previousPublicKernelProof).catch(
-        // the abstract phase manager throws if simulation gives error in a non-revertible phase
-        async err => {
-          await this.publicStateDB.rollbackToCommit();
-          throw err;
-        },
-      );
+    const [
+      kernelInputs,
+      publicKernelOutput,
+      publicKernelProof,
+      newUnencryptedFunctionLogs,
+      revertReason,
+      _returnValues,
+      gasUsed,
+    ] = await this.processEnqueuedPublicCalls(tx, previousPublicKernelOutput, previousPublicKernelProof).catch(
+      // the abstract phase manager throws if simulation gives error in a non-revertible phase
+      async err => {
+        await this.publicStateDB.rollbackToCommit();
+        throw err;
+      },
+    );
     tx.unencryptedLogs.addFunctionLogs(newUnencryptedFunctionLogs);
     await this.publicStateDB.checkpoint();
 
@@ -61,6 +68,7 @@ export class SetupPhaseManager extends AbstractPhaseManager {
       publicKernelProof,
       revertReason,
       returnValues: undefined,
+      gasUsed,
     };
   }
 }

--- a/yarn-project/simulator/src/public/tail_phase_manager.ts
+++ b/yarn-project/simulator/src/public/tail_phase_manager.ts
@@ -39,7 +39,11 @@ export class TailPhaseManager extends AbstractPhaseManager {
     super(db, publicExecutor, publicKernel, globalVariables, historicalHeader, phase);
   }
 
-  async handle(tx: Tx, previousPublicKernelOutput: PublicKernelCircuitPublicInputs, previousPublicKernelProof: Proof) {
+  override async handle(
+    tx: Tx,
+    previousPublicKernelOutput: PublicKernelCircuitPublicInputs,
+    previousPublicKernelProof: Proof,
+  ) {
     this.log.verbose(`Processing tx ${tx.getTxHash()}`);
     const [inputs, finalKernelOutput] = await this.runTailKernelCircuit(
       previousPublicKernelOutput,
@@ -67,6 +71,7 @@ export class TailPhaseManager extends AbstractPhaseManager {
       publicKernelProof: makeEmptyProof(),
       revertReason: undefined,
       returnValues: undefined,
+      gasUsed: undefined,
     };
   }
 

--- a/yarn-project/simulator/src/public/teardown_phase_manager.ts
+++ b/yarn-project/simulator/src/public/teardown_phase_manager.ts
@@ -39,14 +39,21 @@ export class TeardownPhaseManager extends AbstractPhaseManager {
     previousPublicKernelProof: Proof,
   ) {
     this.log.verbose(`Processing tx ${tx.getTxHash()}`);
-    const [kernelInputs, publicKernelOutput, publicKernelProof, newUnencryptedFunctionLogs, revertReason] =
-      await this.processEnqueuedPublicCalls(tx, previousPublicKernelOutput, previousPublicKernelProof).catch(
-        // the abstract phase manager throws if simulation gives error in a non-revertible phase
-        async err => {
-          await this.publicStateDB.rollbackToCommit();
-          throw err;
-        },
-      );
+    const [
+      kernelInputs,
+      publicKernelOutput,
+      publicKernelProof,
+      newUnencryptedFunctionLogs,
+      revertReason,
+      _returnValues,
+      gasUsed,
+    ] = await this.processEnqueuedPublicCalls(tx, previousPublicKernelOutput, previousPublicKernelProof).catch(
+      // the abstract phase manager throws if simulation gives error in a non-revertible phase
+      async err => {
+        await this.publicStateDB.rollbackToCommit();
+        throw err;
+      },
+    );
     tx.unencryptedLogs.addFunctionLogs(newUnencryptedFunctionLogs);
     await this.publicStateDB.checkpoint();
 
@@ -65,6 +72,7 @@ export class TeardownPhaseManager extends AbstractPhaseManager {
       publicKernelProof,
       revertReason,
       returnValues: undefined,
+      gasUsed,
     };
   }
 


### PR DESCRIPTION
Allows clients set their total and teardown gas limits accordingly before submitting a tx to the network.