### PR TITLE
feat: Use gas estimation in aztecjs contract function interactions

### DIFF
--- a/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
@@ -1,6 +1,8 @@
-import { type PXE, type Tx, type TxExecutionRequest } from '@aztec/circuit-types';
+import { type Tx, type TxExecutionRequest } from '@aztec/circuit-types';
+import { GasSettings } from '@aztec/circuits.js';
 
-import { type FeeOptions } from '../entrypoint/entrypoint.js';
+import { type Wallet } from '../account/wallet.js';
+import { type ExecutionRequestInit, type FeeOptions } from '../entrypoint/entrypoint.js';
 import { SentTx } from './sent_tx.js';
 
 /**
@@ -8,15 +10,12 @@ import { SentTx } from './sent_tx.js';
  * Allows the user to specify the sender address and nonce for a transaction.
  */
 export type SendMethodOptions = {
-  /**
-   * Wether to skip the simulation of the public part of the transaction.
-   */
+  /** Wether to skip the simulation of the public part of the transaction. */
   skipPublicSimulation?: boolean;
-
-  /**
-   * The fee options for the transaction.
-   */
+  /** The fee options for the transaction. */
   fee?: FeeOptions;
+  /** Whether to run an initial simulation of the tx with high gas limit to figure out actual gas settings (will default to true later down the road). */
+  estimateGas?: boolean;
 };
 
 /**
@@ -27,7 +26,7 @@ export abstract class BaseContractInteraction {
   protected tx?: Tx;
   protected txRequest?: TxExecutionRequest;
 
-  constructor(protected pxe: PXE) {}
+  constructor(protected wallet: Wallet) {}
 
   /**
    * Create a transaction execution request ready to be simulated.
@@ -43,7 +42,7 @@ export abstract class BaseContractInteraction {
    */
   public async prove(options: SendMethodOptions = {}): Promise<Tx> {
     const txRequest = this.txRequest ?? (await this.create(options));
-    this.tx = await this.pxe.proveTx(txRequest, !options.skipPublicSimulation);
+    this.tx = await this.wallet.proveTx(txRequest, !options.skipPublicSimulation);
     return this.tx;
   }
 
@@ -59,9 +58,37 @@ export abstract class BaseContractInteraction {
   public send(options: SendMethodOptions = {}) {
     const promise = (async () => {
       const tx = this.tx ?? (await this.prove(options));
-      return this.pxe.sendTx(tx);
+      return this.wallet.sendTx(tx);
     })();
 
-    return new SentTx(this.pxe, promise);
+    return new SentTx(this.wallet, promise);
+  }
+
+  /**
+   * Estimates gas for a given tx request and returns defaults gas settings for it.
+   * @param txRequest - Transaction execution request to process.
+   * @returns Gas settings.
+   */
+  protected async estimateGas(txRequest: TxExecutionRequest) {
+    const simulationResult = await this.wallet.simulateTx(txRequest, true);
+    const { totalGas: gasLimits, teardownGas: teardownGasLimits } = simulationResult.getGasLimits();
+    return GasSettings.default({ gasLimits, teardownGasLimits });
+  }
+
+  /**
+   * Helper method to return fee options based on the user opts, estimating tx gas if needed.
+   * @param request - Request to execute for this interaction.
+   * @returns Fee options for the actual transaction.
+   */
+  protected async getFeeOptions(request: ExecutionRequestInit) {
+    const fee = request.fee;
+    if (fee) {
+      const txRequest = await this.wallet.createTxExecutionRequest(request);
+      const simulationResult = await this.wallet.simulateTx(txRequest, true);
+      const { totalGas: gasLimits, teardownGas: teardownGasLimits } = simulationResult.getGasLimits();
+      const gasSettings = GasSettings.default({ ...fee.gasSettings, gasLimits, teardownGasLimits });
+      return { ...fee, gasSettings };
+    }
+    return fee;
   }
 }

--- a/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
@@ -3,6 +3,7 @@ import { GasSettings } from '@aztec/circuits.js';
 
 import { type Wallet } from '../account/wallet.js';
 import { type ExecutionRequestInit, type FeeOptions } from '../entrypoint/entrypoint.js';
+import { getGasLimits } from './get_gas_limits.js';
 import { SentTx } from './sent_tx.js';
 
 /**
@@ -71,7 +72,7 @@ export abstract class BaseContractInteraction {
    */
   protected async estimateGas(txRequest: TxExecutionRequest) {
     const simulationResult = await this.wallet.simulateTx(txRequest, true);
-    const { totalGas: gasLimits, teardownGas: teardownGasLimits } = simulationResult.getGasLimits();
+    const { totalGas: gasLimits, teardownGas: teardownGasLimits } = getGasLimits(simulationResult);
     return GasSettings.default({ gasLimits, teardownGasLimits });
   }
 
@@ -84,8 +85,7 @@ export abstract class BaseContractInteraction {
     const fee = request.fee;
     if (fee) {
       const txRequest = await this.wallet.createTxExecutionRequest(request);
-      const simulationResult = await this.wallet.simulateTx(txRequest, true);
-      const { totalGas: gasLimits, teardownGas: teardownGasLimits } = simulationResult.getGasLimits();
+      const { gasLimits, teardownGasLimits } = await this.estimateGas(txRequest);
       const gasSettings = GasSettings.default({ ...fee.gasSettings, gasLimits, teardownGasLimits });
       return { ...fee, gasSettings };
     }

--- a/yarn-project/aztec.js/src/contract/batch_call.ts
+++ b/yarn-project/aztec.js/src/contract/batch_call.ts
@@ -5,7 +5,7 @@ import { BaseContractInteraction, type SendMethodOptions } from './base_contract
 
 /** A batch of function calls to be sent as a single transaction through a wallet. */
 export class BatchCall extends BaseContractInteraction {
-  constructor(protected wallet: Wallet, protected calls: FunctionCall[]) {
+  constructor(wallet: Wallet, protected calls: FunctionCall[]) {
     super(wallet);
   }
 
@@ -17,10 +17,9 @@ export class BatchCall extends BaseContractInteraction {
    */
   public async create(opts?: SendMethodOptions): Promise<TxExecutionRequest> {
     if (!this.txRequest) {
-      this.txRequest = await this.wallet.createTxExecutionRequest({
-        calls: this.calls,
-        fee: opts?.fee,
-      });
+      const calls = this.calls;
+      const fee = opts?.estimateGas ? await this.getFeeOptions({ calls, fee: opts?.fee }) : opts?.fee;
+      this.txRequest = await this.wallet.createTxExecutionRequest({ calls, fee });
     }
     return this.txRequest;
   }

--- a/yarn-project/aztec.js/src/contract/get_gas_limits.test.ts
+++ b/yarn-project/aztec.js/src/contract/get_gas_limits.test.ts
@@ -1,0 +1,41 @@
+import { PublicKernelType, type SimulatedTx, mockSimulatedTx } from '@aztec/circuit-types';
+import { Gas } from '@aztec/circuits.js';
+
+import { getGasLimits } from './get_gas_limits.js';
+
+describe('getGasLimits', () => {
+  let simulatedTx: SimulatedTx;
+
+  beforeEach(() => {
+    simulatedTx = mockSimulatedTx();
+    simulatedTx.tx.data.publicInputs.end.gasUsed = Gas.from({ daGas: 100, l2Gas: 200 });
+    simulatedTx.publicOutput!.gasUsed = {
+      [PublicKernelType.SETUP]: Gas.from({ daGas: 10, l2Gas: 20 }),
+      [PublicKernelType.APP_LOGIC]: Gas.from({ daGas: 20, l2Gas: 40 }),
+      [PublicKernelType.TEARDOWN]: Gas.from({ daGas: 10, l2Gas: 20 }),
+    };
+  });
+
+  it('returns gas limits from private gas usage only', () => {
+    simulatedTx.publicOutput = undefined;
+    // Should be 110 and 220 but oh floating point
+    expect(getGasLimits(simulatedTx)).toEqual({
+      totalGas: Gas.from({ daGas: 111, l2Gas: 221 }),
+      teardownGas: Gas.empty(),
+    });
+  });
+
+  it('returns gas limits for private and public', () => {
+    expect(getGasLimits(simulatedTx)).toEqual({
+      totalGas: Gas.from({ daGas: 154, l2Gas: 308 }),
+      teardownGas: Gas.from({ daGas: 11, l2Gas: 22 }),
+    });
+  });
+
+  it('pads gas limits', () => {
+    expect(getGasLimits(simulatedTx, 1)).toEqual({
+      totalGas: Gas.from({ daGas: 280, l2Gas: 560 }),
+      teardownGas: Gas.from({ daGas: 20, l2Gas: 40 }),
+    });
+  });
+});

--- a/yarn-project/aztec.js/src/contract/get_gas_limits.ts
+++ b/yarn-project/aztec.js/src/contract/get_gas_limits.ts
@@ -1,0 +1,24 @@
+import { PublicKernelType, type SimulatedTx } from '@aztec/circuit-types';
+import { Gas } from '@aztec/circuits.js';
+
+/**
+ * Returns suggested total and teardown gas limits for a simulated tx.
+ * Note that public gas usage is only accounted for if the publicOutput is present.
+ * @param pad - Percentage to pad the suggested gas limits by, defaults to 10%.
+ */
+export function getGasLimits(simulatedTx: SimulatedTx, pad = 0.1) {
+  const privateGasUsed = simulatedTx.tx.data.publicInputs.end.gasUsed;
+  if (simulatedTx.publicOutput) {
+    const publicGasUsed = Object.values(simulatedTx.publicOutput.gasUsed)
+      .filter(Boolean)
+      .reduce((total, current) => total.add(current), Gas.empty());
+    const teardownGas = simulatedTx.publicOutput.gasUsed[PublicKernelType.TEARDOWN] ?? Gas.empty();
+
+    return {
+      totalGas: privateGasUsed.add(publicGasUsed).mul(1 + pad),
+      teardownGas: teardownGas.mul(1 + pad),
+    };
+  }
+
+  return { totalGas: privateGasUsed.mul(1 + pad), teardownGas: Gas.empty() };
+}

--- a/yarn-project/circuit-types/src/tx/simulated_tx.test.ts
+++ b/yarn-project/circuit-types/src/tx/simulated_tx.test.ts
@@ -1,7 +1,4 @@
-import { Gas } from '@aztec/circuits.js';
-
 import { mockSimulatedTx } from '../mocks.js';
-import { PublicKernelType } from './processed_tx.js';
 import { SimulatedTx } from './simulated_tx.js';
 
 describe('simulated_tx', () => {
@@ -20,40 +17,6 @@ describe('simulated_tx', () => {
       simulatedTx.privateReturnValues = undefined;
       simulatedTx.publicOutput = undefined;
       expect(SimulatedTx.fromJSON(simulatedTx.toJSON())).toEqual(simulatedTx);
-    });
-  });
-
-  describe('getGasLimits', () => {
-    beforeEach(() => {
-      simulatedTx.tx.data.publicInputs.end.gasUsed = Gas.from({ daGas: 100, l2Gas: 200 });
-      simulatedTx.publicOutput!.gasUsed = {
-        [PublicKernelType.SETUP]: Gas.from({ daGas: 10, l2Gas: 20 }),
-        [PublicKernelType.APP_LOGIC]: Gas.from({ daGas: 20, l2Gas: 40 }),
-        [PublicKernelType.TEARDOWN]: Gas.from({ daGas: 10, l2Gas: 20 }),
-      };
-    });
-
-    it('returns gas limits from private gas usage only', () => {
-      simulatedTx.publicOutput = undefined;
-      // Should be 110 and 220 but oh floating point
-      expect(simulatedTx.getGasLimits()).toEqual({
-        totalGas: Gas.from({ daGas: 111, l2Gas: 221 }),
-        teardownGas: Gas.empty(),
-      });
-    });
-
-    it('returns gas limits for private and public', () => {
-      expect(simulatedTx.getGasLimits()).toEqual({
-        totalGas: Gas.from({ daGas: 154, l2Gas: 308 }),
-        teardownGas: Gas.from({ daGas: 11, l2Gas: 22 }),
-      });
-    });
-
-    it('pads gas limits', () => {
-      expect(simulatedTx.getGasLimits(1)).toEqual({
-        totalGas: Gas.from({ daGas: 280, l2Gas: 560 }),
-        teardownGas: Gas.from({ daGas: 20, l2Gas: 40 }),
-      });
     });
   });
 });

--- a/yarn-project/circuit-types/src/tx/simulated_tx.ts
+++ b/yarn-project/circuit-types/src/tx/simulated_tx.ts
@@ -1,6 +1,5 @@
-import { Fr, Gas } from '@aztec/circuits.js';
+import { Fr } from '@aztec/circuits.js';
 
-import { PublicKernelType } from './processed_tx.js';
 import { type ProcessReturnValues, PublicSimulationOutput } from './public_simulation_output.js';
 import { Tx } from './tx.js';
 
@@ -16,29 +15,6 @@ export class SimulatedTx {
     public privateReturnValues?: ProcessReturnValues,
     public publicOutput?: PublicSimulationOutput,
   ) {}
-
-  /**
-   * Returns suggested total and teardown gas limits for the simulated tx.
-   * Note that public gas usage is only accounted for if the publicOutput is present.
-   * @param pad - Percentage to pad the suggested gas limits by, defaults to 10%.
-   */
-  public getGasLimits(pad = 0.1) {
-    const privateGasUsed = this.tx.data.publicInputs.end.gasUsed;
-    if (this.publicOutput) {
-      const publicGasUsed = Object.values(this.publicOutput.gasUsed).reduce(
-        (total, current) => total.add(current),
-        Gas.empty(),
-      );
-      const teardownGas = this.publicOutput.gasUsed[PublicKernelType.TEARDOWN] ?? Gas.empty();
-
-      return {
-        totalGas: privateGasUsed.add(publicGasUsed).mul(1 + pad),
-        teardownGas: teardownGas.mul(1 + pad),
-      };
-    }
-
-    return { totalGas: privateGasUsed.mul(1 + pad), teardownGas: Gas.empty() };
-  }
 
   /**
    * Convert a SimulatedTx class object to a plain JSON object.

--- a/yarn-project/circuits.js/src/structs/gas_settings.ts
+++ b/yarn-project/circuits.js/src/structs/gas_settings.ts
@@ -62,13 +62,14 @@ export class GasSettings {
   }
 
   /** Default gas settings to use when user has not provided them. */
-  static default() {
-    return new GasSettings(
-      new Gas(DEFAULT_GAS_LIMIT, DEFAULT_GAS_LIMIT),
-      new Gas(DEFAULT_TEARDOWN_GAS_LIMIT, DEFAULT_TEARDOWN_GAS_LIMIT),
-      new GasFees(new Fr(DEFAULT_MAX_FEE_PER_GAS), new Fr(DEFAULT_MAX_FEE_PER_GAS)),
-      new Fr(DEFAULT_INCLUSION_FEE),
-    );
+  static default(overrides?: Partial<FieldsOf<GasSettings>>) {
+    return GasSettings.from({
+      gasLimits: { l2Gas: DEFAULT_GAS_LIMIT, daGas: DEFAULT_GAS_LIMIT },
+      teardownGasLimits: { l2Gas: DEFAULT_TEARDOWN_GAS_LIMIT, daGas: DEFAULT_TEARDOWN_GAS_LIMIT },
+      maxFeesPerGas: { feePerL2Gas: new Fr(DEFAULT_MAX_FEE_PER_GAS), feePerDaGas: new Fr(DEFAULT_MAX_FEE_PER_GAS) },
+      inclusionFee: new Fr(DEFAULT_INCLUSION_FEE),
+      ...overrides,
+    });
   }
 
   /** Gas settings to use for simulating a contract call. */

--- a/yarn-project/end-to-end/src/e2e_fees/dapp_subscription.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/dapp_subscription.test.ts
@@ -44,7 +44,7 @@ describe('e2e_fees dapp_subscription', () => {
 
   beforeAll(async () => {
     await t.applyBaseSnapshots();
-    await t.applyFundAlice();
+    await t.applyFundAliceWithBananas();
     await t.applySetupSubscription();
 
     ({

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -203,12 +203,22 @@ export class FeesTest {
     );
   }
 
-  public async applyFundAlice() {
+  public async applyFundAliceWithBananas() {
     await this.snapshotManager.snapshot(
       'fund_alice',
       async () => {
         await this.mintPrivate(BigInt(this.ALICE_INITIAL_BANANAS), this.aliceAddress);
         await this.bananaCoin.methods.mint_public(this.aliceAddress, this.ALICE_INITIAL_BANANAS).send().wait();
+      },
+      () => Promise.resolve(),
+    );
+  }
+
+  public async applyFundAliceWithGasToken() {
+    await this.snapshotManager.snapshot(
+      'fund_alice_with_gas_token',
+      async () => {
+        await this.gasTokenContract.methods.mint_public(this.aliceAddress, this.INITIAL_GAS_BALANCE).send().wait();
       },
       () => Promise.resolve(),
     );

--- a/yarn-project/end-to-end/src/e2e_fees/gas_estimation.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/gas_estimation.test.ts
@@ -1,0 +1,66 @@
+import {
+  type AccountWallet,
+  type AztecAddress,
+  type FeePaymentMethod,
+  NativeFeePaymentMethod,
+  PublicFeePaymentMethod,
+} from '@aztec/aztec.js';
+import { GasFees, type GasSettings } from '@aztec/circuits.js';
+import { type TokenContract as BananaCoin, type FPCContract } from '@aztec/noir-contracts.js';
+
+import { FeesTest } from './fees_test.js';
+
+describe('e2e_fees gas_estimation', () => {
+  let aliceWallet: AccountWallet;
+  let aliceAddress: AztecAddress;
+  let bobAddress: AztecAddress;
+  let bananaCoin: BananaCoin;
+  let bananaFPC: FPCContract;
+  let gasSettings: GasSettings;
+  let teardownFixedFee: bigint;
+
+  const t = new FeesTest('gas_estimation');
+
+  beforeAll(async () => {
+    await t.applyBaseSnapshots();
+    await t.applyFundAliceWithBananas();
+    await t.applyFundAliceWithGasToken();
+    ({ aliceWallet, aliceAddress, bobAddress, bananaCoin, bananaFPC, gasSettings } = await t.setup());
+
+    teardownFixedFee = gasSettings.teardownGasLimits.computeFee(GasFees.default()).toBigInt();
+  });
+
+  afterAll(async () => {
+    await t.teardown();
+  });
+
+  // Sends two tx with transfers of public tokens: one with estimateGas on, one with estimateGas off
+  const sendTransfers = (paymentMethod: FeePaymentMethod) =>
+    Promise.all(
+      [true, false].map(estimateGas =>
+        bananaCoin.methods
+          .transfer_public(aliceAddress, bobAddress, 1n, 0n)
+          .send({ estimateGas, fee: { gasSettings, paymentMethod } })
+          .wait(),
+      ),
+    );
+
+  it('estimates gas with native fee payment method', async () => {
+    const paymentMethod = await NativeFeePaymentMethod.create(aliceWallet);
+    const [withEstimate, withoutEstimate] = await sendTransfers(paymentMethod);
+
+    // Estimation should yield that teardown has no cost, so should send the tx with zero for teardown
+    expect(withEstimate.transactionFee! + teardownFixedFee).toEqual(withoutEstimate.transactionFee!);
+  });
+
+  it('estimates gas with public payment method', async () => {
+    const paymentMethod = new PublicFeePaymentMethod(bananaCoin.address, bananaFPC.address, aliceWallet);
+    const [withEstimate, withoutEstimate] = await sendTransfers(paymentMethod);
+
+    // Estimation should yield that teardown has reduced cost, but is not zero
+    // TODO(palla/gas): We set toBeGreaterThanOrEqual because gas in public functions is zero for now (we only meter on AVM).
+    // We should be able to change this to a strict equality once we meter gas in public functions or we replace brillig with the AVM.
+    expect(withEstimate.transactionFee!).toBeLessThan(withoutEstimate.transactionFee!);
+    expect(withEstimate.transactionFee! + teardownFixedFee).toBeGreaterThanOrEqual(withoutEstimate.transactionFee!);
+  });
+});

--- a/yarn-project/end-to-end/src/e2e_fees/private_payments.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/private_payments.test.ts
@@ -27,7 +27,7 @@ describe('e2e_fees private_payment', () => {
 
   beforeAll(async () => {
     await t.applyBaseSnapshots();
-    await t.applyFundAlice();
+    await t.applyFundAliceWithBananas();
     ({ aliceWallet, aliceAddress, bobAddress, sequencerAddress, gasTokenContract, bananaCoin, bananaFPC, gasSettings } =
       await t.setup());
   });

--- a/yarn-project/p2p/package.json
+++ b/yarn-project/p2p/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests --timeout 15000",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
     "start": "node ./dest",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'"
   },
@@ -44,7 +44,8 @@
           "summaryThreshold": 9999
         }
       ]
-    ]
+    ],
+    "testTimeout": 15000
   },
   "dependencies": {
     "@aztec/circuit-types": "workspace:^",

--- a/yarn-project/p2p/package.json
+++ b/yarn-project/p2p/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests --timeout 15000",
     "start": "node ./dest",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'"
   },


### PR DESCRIPTION
Adds an `estimateGas` flag to the `send` method of contract function interactions (defaulting to false for now) to run an initial simulate on the request to get the gas limits before actually sending the tx.