### PR TITLE
fix(avm-simulator): correctly create call stack in shallow assertions

### DIFF
--- a/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
+++ b/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
@@ -33,6 +33,14 @@ describe('e2e_avm_simulator', () => {
       avmContract = await AvmTestContract.deploy(wallet).send().deployed();
     });
 
+    describe('Assertions', () => {
+      it('Processes assertions in the PXE', async () => {
+        await expect(avmContract.methods.assert_nullifier_exists(123).simulate()).rejects.toThrow(
+          "Assertion failed: Nullifier doesn't exist!",
+        );
+      });
+    });
+
     describe('Gas metering', () => {
       it('Tracks L2 gas usage on simulation', async () => {
         const request = await avmContract.methods.add_args_return(20n, 30n).create();

--- a/yarn-project/simulator/src/avm/avm_machine_state.ts
+++ b/yarn-project/simulator/src/avm/avm_machine_state.ts
@@ -138,12 +138,12 @@ export class AvmMachineState {
     let revertReason = undefined;
     if (this.reverted && this.output.length > 0) {
       try {
+        // We remove the first element which is the 'error selector'.
+        const revertOutput = this.output.slice(1);
         // Try to interpret the output as a text string.
-        revertReason = new Error(
-          'Reverted with output: ' + String.fromCharCode(...this.output.slice(1).map(fr => fr.toNumber())),
-        );
+        revertReason = new Error('Assertion failed: ' + String.fromCharCode(...revertOutput.map(fr => fr.toNumber())));
       } catch (e) {
-        revertReason = new Error('Reverted with non-string output');
+        revertReason = new Error('<no output>');
       }
     }
     return new AvmContractCallResults(this.reverted, this.output, revertReason);

--- a/yarn-project/simulator/src/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.test.ts
@@ -111,7 +111,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
     const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
     expect(results.reverted).toBe(true);
-    expect(results.revertReason?.message).toEqual("Reverted with output: Nullifier doesn't exist!");
+    expect(results.revertReason?.message).toEqual("Assertion failed: Nullifier doesn't exist!");
     expect(results.output).toEqual([
       new Fr(0),
       ...[..."Nullifier doesn't exist!"].flatMap(c => new Fr(c.charCodeAt(0))),

--- a/yarn-project/simulator/src/avm/opcodes/external_calls.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/external_calls.test.ts
@@ -315,7 +315,7 @@ describe('External Calls', () => {
       expect(context.machineState.halted).toBe(true);
       expect(context.machineState.getResults()).toEqual({
         reverted: true,
-        revertReason: new Error('Reverted with output: assert message'),
+        revertReason: new Error('Assertion failed: assert message'),
         output: returnData.map(f => f.toFr()),
       });
     });


### PR DESCRIPTION
This makes the PXE correctly interpret assertions from the AVM simulator. Work is still needed for nested assertions.

I also change the revert message to conform to the ACVM one.