### PR TITLE
fix(avm-simulator): rethrow nested assertions

### DIFF
--- a/noir-projects/noir-contracts/contracts/avm_nested_calls_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_nested_calls_test_contract/src/main.nr
@@ -26,6 +26,12 @@ contract AvmNestedCallsTest {
         arg_a + arg_b
     }
 
+    #[aztec(public-vm)]
+    fn assert_same(arg_a: Field, arg_b: Field) -> pub Field {
+        assert(arg_a == arg_b, "Values are not equal");
+        1
+    }
+
     // Use the standard context interface to emit a new nullifier
     #[aztec(public-vm)]
     fn new_nullifier(nullifier: Field) {

--- a/yarn-project/simulator/src/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.test.ts
@@ -842,7 +842,23 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       const results = await new AvmSimulator(context).executeBytecode(callBytecode);
 
       expect(results.reverted).toBe(true); // The outer call should revert.
-      expect(results.revertReason?.message).toMatch(/Nested static call failed/);
+      expect(results.revertReason?.message).toEqual('Static calls cannot alter storage');
+    });
+
+    it(`Nested calls rethrow exceptions`, async () => {
+      const calldata: Fr[] = [new Fr(1), new Fr(2)];
+      const callBytecode = getAvmNestedCallsTestContractBytecode('nested_call_to_add');
+      // We actually don't pass the function ADD, but it's ok because the signature is the same.
+      const nestedBytecode = getAvmNestedCallsTestContractBytecode('assert_same');
+      const context = initContext({ env: initExecutionEnvironment({ calldata }) });
+      jest
+        .spyOn(context.persistableState.hostStorage.contractsDb, 'getBytecode')
+        .mockReturnValue(Promise.resolve(nestedBytecode));
+
+      const results = await new AvmSimulator(context).executeBytecode(callBytecode);
+
+      expect(results.reverted).toBe(true); // The outer call should revert.
+      expect(results.revertReason?.message).toEqual('Assertion failed: Values are not equal');
     });
   });
 });

--- a/yarn-project/simulator/src/avm/opcodes/external_calls.ts
+++ b/yarn-project/simulator/src/avm/opcodes/external_calls.ts
@@ -7,6 +7,7 @@ import { gasLeftToGas, sumGas } from '../avm_gas.js';
 import { Field, Uint8 } from '../avm_memory_types.js';
 import { type AvmContractCallResults } from '../avm_message_call_result.js';
 import { AvmSimulator } from '../avm_simulator.js';
+import { AvmExecutionError } from '../errors.js';
 import { Opcode, OperandType } from '../serialization/instruction_serialization.js';
 import { Addressing } from './addressing_mode.js';
 import { Instruction } from './instruction.js';
@@ -98,6 +99,18 @@ abstract class ExternalCall extends Instruction {
     // const nestedCallResults: AvmContractCallResults = await new AvmSimulator(nestedContext).execute();
 
     const success = !nestedCallResults.reverted;
+
+    // TRANSITIONAL: We rethrow here so that the MESSAGE gets propagated.
+    if (!success) {
+      class RethrowedError extends AvmExecutionError {
+        constructor(message: string) {
+          super(message);
+          this.name = 'RethrowedError';
+        }
+      }
+
+      throw new RethrowedError(nestedCallResults.revertReason?.message || 'Unknown nested call error');
+    }
 
     // We only take as much data as was specified in the return size and pad with zeroes if the return data is smaller
     // than the specified size in order to prevent that memory to be left with garbage

--- a/yarn-project/simulator/src/avm/opcodes/external_calls.ts
+++ b/yarn-project/simulator/src/avm/opcodes/external_calls.ts
@@ -102,14 +102,14 @@ abstract class ExternalCall extends Instruction {
 
     // TRANSITIONAL: We rethrow here so that the MESSAGE gets propagated.
     if (!success) {
-      class RethrowedError extends AvmExecutionError {
+      class RethrownError extends AvmExecutionError {
         constructor(message: string) {
           super(message);
-          this.name = 'RethrowedError';
+          this.name = 'RethrownError';
         }
       }
 
-      throw new RethrowedError(nestedCallResults.revertReason?.message || 'Unknown nested call error');
+      throw new RethrownError(nestedCallResults.revertReason?.message || 'Unknown nested call error');
     }
 
     // We only take as much data as was specified in the return size and pad with zeroes if the return data is smaller


### PR DESCRIPTION
Transitional fix to conform to the ACVM behaviour.
