### PR TITLE
fix: `CombinedConstantData` not registered for serialization

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/http_rpc_server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/http_rpc_server.ts
@@ -5,8 +5,8 @@ import {
   L2Block,
   LogId,
   NullifierMembershipWitness,
-  ProcessOutput,
   PublicDataWitness,
+  PublicSimulationOutput,
   SiblingPath,
   Tx,
   TxEffect,
@@ -42,7 +42,14 @@ export function createAztecNodeRpcServer(node: AztecNode) {
       PublicDataWitness,
       SiblingPath,
     },
-    { ProcessOutput, Tx, TxReceipt, EncryptedL2BlockL2Logs, UnencryptedL2BlockL2Logs, NullifierMembershipWitness },
+    {
+      PublicSimulationOutput,
+      Tx,
+      TxReceipt,
+      EncryptedL2BlockL2Logs,
+      UnencryptedL2BlockL2Logs,
+      NullifierMembershipWitness,
+    },
     // disable methods not part of the AztecNode interface
     ['start', 'stop'],
   );

--- a/yarn-project/aztec-node/src/aztec-node/http_rpc_server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/http_rpc_server.ts
@@ -5,6 +5,7 @@ import {
   L2Block,
   LogId,
   NullifierMembershipWitness,
+  ProcessOutput,
   PublicDataWitness,
   SiblingPath,
   Tx,
@@ -41,7 +42,7 @@ export function createAztecNodeRpcServer(node: AztecNode) {
       PublicDataWitness,
       SiblingPath,
     },
-    { Tx, TxReceipt, EncryptedL2BlockL2Logs, UnencryptedL2BlockL2Logs, NullifierMembershipWitness },
+    { ProcessOutput, Tx, TxReceipt, EncryptedL2BlockL2Logs, UnencryptedL2BlockL2Logs, NullifierMembershipWitness },
     // disable methods not part of the AztecNode interface
     ['start', 'stop'],
   );

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -13,10 +13,10 @@ import {
   LogType,
   MerkleTreeId,
   NullifierMembershipWitness,
-  ProcessOutput,
   type ProverClient,
   type ProverConfig,
   PublicDataWitness,
+  PublicSimulationOutput,
   type SequencerConfig,
   type SiblingPath,
   type Tx,
@@ -634,7 +634,7 @@ export class AztecNodeService implements AztecNode {
    * Simulates the public part of a transaction with the current state.
    * @param tx - The transaction to simulate.
    **/
-  public async simulatePublicCalls(tx: Tx): Promise<ProcessOutput> {
+  public async simulatePublicCalls(tx: Tx): Promise<PublicSimulationOutput> {
     this.log.info(`Simulating tx ${tx.getTxHash()}`);
     const blockNumber = (await this.blockSource.getBlockNumber()) + 1;
 
@@ -674,7 +674,7 @@ export class AztecNodeService implements AztecNode {
     }
     this.log.debug(`Simulated tx ${tx.getTxHash()} succeeds`);
     const [processedTx] = processedTxs;
-    return new ProcessOutput(
+    return new PublicSimulationOutput(
       processedTx.encryptedLogs,
       processedTx.unencryptedLogs,
       processedTx.revertReason,

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -13,7 +13,7 @@ import {
   LogType,
   MerkleTreeId,
   NullifierMembershipWitness,
-  type ProcessOutput,
+  ProcessOutput,
   type ProverClient,
   type ProverConfig,
   PublicDataWitness,
@@ -674,15 +674,15 @@ export class AztecNodeService implements AztecNode {
     }
     this.log.debug(`Simulated tx ${tx.getTxHash()} succeeds`);
     const [processedTx] = processedTxs;
-    return {
-      constants: processedTx.data.constants,
-      encryptedLogs: processedTx.encryptedLogs,
-      unencryptedLogs: processedTx.unencryptedLogs,
-      end: processedTx.data.end,
-      revertReason: processedTx.revertReason,
-      publicReturnValues: returns[0],
-      gasUsed: processedTx.gasUsed,
-    };
+    return new ProcessOutput(
+      processedTx.encryptedLogs,
+      processedTx.unencryptedLogs,
+      processedTx.revertReason,
+      processedTx.data.constants,
+      processedTx.data.end,
+      returns[0],
+      processedTx.gasUsed,
+    );
   }
 
   public async setConfig(config: Partial<SequencerConfig & ProverConfig>): Promise<void> {

--- a/yarn-project/circuit-types/src/aztec_node/rpc/aztec_node_client.ts
+++ b/yarn-project/circuit-types/src/aztec_node/rpc/aztec_node_client.ts
@@ -9,6 +9,7 @@ import { type AztecNode } from '../../interfaces/aztec-node.js';
 import { NullifierMembershipWitness } from '../../interfaces/nullifier_tree.js';
 import { L2Block } from '../../l2_block.js';
 import { EncryptedL2BlockL2Logs, ExtendedUnencryptedL2Log, LogId, UnencryptedL2BlockL2Logs } from '../../logs/index.js';
+import { PublicDataWitness } from '../../public_data_witness.js';
 import { SiblingPath } from '../../sibling_path/index.js';
 import { Tx, TxHash, TxReceipt } from '../../tx/index.js';
 import { TxEffect } from '../../tx_effect.js';
@@ -34,6 +35,7 @@ export function createAztecNodeClient(url: string, fetch = defaultFetch): AztecN
       TxEffect,
       LogId,
       TxHash,
+      PublicDataWitness,
       SiblingPath,
     },
     { Tx, TxReceipt, EncryptedL2BlockL2Logs, UnencryptedL2BlockL2Logs, NullifierMembershipWitness },

--- a/yarn-project/circuit-types/src/aztec_node/rpc/aztec_node_client.ts
+++ b/yarn-project/circuit-types/src/aztec_node/rpc/aztec_node_client.ts
@@ -11,7 +11,7 @@ import { L2Block } from '../../l2_block.js';
 import { EncryptedL2BlockL2Logs, ExtendedUnencryptedL2Log, LogId, UnencryptedL2BlockL2Logs } from '../../logs/index.js';
 import { PublicDataWitness } from '../../public_data_witness.js';
 import { SiblingPath } from '../../sibling_path/index.js';
-import { ProcessOutput, Tx, TxHash, TxReceipt } from '../../tx/index.js';
+import { PublicSimulationOutput, Tx, TxHash, TxReceipt } from '../../tx/index.js';
 import { TxEffect } from '../../tx_effect.js';
 
 /**
@@ -38,7 +38,14 @@ export function createAztecNodeClient(url: string, fetch = defaultFetch): AztecN
       PublicDataWitness,
       SiblingPath,
     },
-    { ProcessOutput, Tx, TxReceipt, EncryptedL2BlockL2Logs, UnencryptedL2BlockL2Logs, NullifierMembershipWitness },
+    {
+      PublicSimulationOutput,
+      Tx,
+      TxReceipt,
+      EncryptedL2BlockL2Logs,
+      UnencryptedL2BlockL2Logs,
+      NullifierMembershipWitness,
+    },
     false,
     'node',
     fetch,

--- a/yarn-project/circuit-types/src/aztec_node/rpc/aztec_node_client.ts
+++ b/yarn-project/circuit-types/src/aztec_node/rpc/aztec_node_client.ts
@@ -11,7 +11,7 @@ import { L2Block } from '../../l2_block.js';
 import { EncryptedL2BlockL2Logs, ExtendedUnencryptedL2Log, LogId, UnencryptedL2BlockL2Logs } from '../../logs/index.js';
 import { PublicDataWitness } from '../../public_data_witness.js';
 import { SiblingPath } from '../../sibling_path/index.js';
-import { Tx, TxHash, TxReceipt } from '../../tx/index.js';
+import { ProcessOutput, Tx, TxHash, TxReceipt } from '../../tx/index.js';
 import { TxEffect } from '../../tx_effect.js';
 
 /**
@@ -38,7 +38,7 @@ export function createAztecNodeClient(url: string, fetch = defaultFetch): AztecN
       PublicDataWitness,
       SiblingPath,
     },
-    { Tx, TxReceipt, EncryptedL2BlockL2Logs, UnencryptedL2BlockL2Logs, NullifierMembershipWitness },
+    { ProcessOutput, Tx, TxReceipt, EncryptedL2BlockL2Logs, UnencryptedL2BlockL2Logs, NullifierMembershipWitness },
     false,
     'node',
     fetch,

--- a/yarn-project/circuit-types/src/interfaces/aztec-node.ts
+++ b/yarn-project/circuit-types/src/interfaces/aztec-node.ts
@@ -22,7 +22,7 @@ import {
 import { type MerkleTreeId } from '../merkle_tree_id.js';
 import { type PublicDataWitness } from '../public_data_witness.js';
 import { type SiblingPath } from '../sibling_path/index.js';
-import { type ProcessOutput, type Tx, type TxHash, type TxReceipt } from '../tx/index.js';
+import { type PublicSimulationOutput, type Tx, type TxHash, type TxReceipt } from '../tx/index.js';
 import { type TxEffect } from '../tx_effect.js';
 import { type SequencerConfig } from './configs.js';
 import { type L2BlockNumber } from './l2_block_number.js';
@@ -283,7 +283,7 @@ export interface AztecNode {
    * This currently just checks that the transaction execution succeeds.
    * @param tx - The transaction to simulate.
    **/
-  simulatePublicCalls(tx: Tx): Promise<ProcessOutput>;
+  simulatePublicCalls(tx: Tx): Promise<PublicSimulationOutput>;
 
   /**
    * Updates the configuration of this node.

--- a/yarn-project/circuit-types/src/mocks.ts
+++ b/yarn-project/circuit-types/src/mocks.ts
@@ -27,7 +27,7 @@ import { type ContractInstanceWithAddress, SerializableContractInstance } from '
 import { EncryptedL2Log } from './logs/encrypted_l2_log.js';
 import { EncryptedFunctionL2Logs, EncryptedTxL2Logs, Note, UnencryptedTxL2Logs } from './logs/index.js';
 import { ExtendedNote } from './notes/index.js';
-import { ProcessOutput, type ProcessReturnValues, SimulatedTx, Tx, TxHash } from './tx/index.js';
+import { type ProcessReturnValues, PublicSimulationOutput, SimulatedTx, Tx, TxHash } from './tx/index.js';
 
 /**
  * Testing utility to create empty logs composed from a single empty log.
@@ -129,7 +129,7 @@ export const mockTxForRollup = (seed = 1, { hasLogs = false }: { hasLogs?: boole
 export const mockSimulatedTx = (seed = 1, hasLogs = true) => {
   const tx = mockTx(seed, { hasLogs });
   const dec: ProcessReturnValues = [new Fr(1n), new Fr(2n), new Fr(3n), new Fr(4n)];
-  const output = new ProcessOutput(
+  const output = new PublicSimulationOutput(
     tx.encryptedLogs,
     tx.unencryptedLogs,
     undefined,

--- a/yarn-project/circuit-types/src/mocks.ts
+++ b/yarn-project/circuit-types/src/mocks.ts
@@ -27,7 +27,7 @@ import { type ContractInstanceWithAddress, SerializableContractInstance } from '
 import { EncryptedL2Log } from './logs/encrypted_l2_log.js';
 import { EncryptedFunctionL2Logs, EncryptedTxL2Logs, Note, UnencryptedTxL2Logs } from './logs/index.js';
 import { ExtendedNote } from './notes/index.js';
-import { type ProcessOutput, type ProcessReturnValues, SimulatedTx, Tx, TxHash } from './tx/index.js';
+import { ProcessOutput, type ProcessReturnValues, SimulatedTx, Tx, TxHash } from './tx/index.js';
 
 /**
  * Testing utility to create empty logs composed from a single empty log.
@@ -129,15 +129,15 @@ export const mockTxForRollup = (seed = 1, { hasLogs = false }: { hasLogs?: boole
 export const mockSimulatedTx = (seed = 1, hasLogs = true) => {
   const tx = mockTx(seed, { hasLogs });
   const dec: ProcessReturnValues = [new Fr(1n), new Fr(2n), new Fr(3n), new Fr(4n)];
-  const output: ProcessOutput = {
-    constants: makeCombinedConstantData(),
-    encryptedLogs: tx.encryptedLogs,
-    unencryptedLogs: tx.unencryptedLogs,
-    end: makeCombinedAccumulatedData(),
-    revertReason: undefined,
-    publicReturnValues: dec,
-    gasUsed: {},
-  };
+  const output = new ProcessOutput(
+    tx.encryptedLogs,
+    tx.unencryptedLogs,
+    undefined,
+    makeCombinedConstantData(),
+    makeCombinedAccumulatedData(),
+    dec,
+    {},
+  );
   return new SimulatedTx(tx, dec, output);
 };
 

--- a/yarn-project/circuit-types/src/tx/index.ts
+++ b/yarn-project/circuit-types/src/tx/index.ts
@@ -3,4 +3,5 @@ export * from './simulated_tx.js';
 export * from './tx_hash.js';
 export * from './tx_receipt.js';
 export * from './processed_tx.js';
+export * from './public_simulation_output.js';
 export * from './tx_validator.js';

--- a/yarn-project/circuit-types/src/tx/public_simulation_output.ts
+++ b/yarn-project/circuit-types/src/tx/public_simulation_output.ts
@@ -1,0 +1,48 @@
+import { CombinedAccumulatedData, CombinedConstantData, Fr, Gas } from '@aztec/circuits.js';
+import { mapValues } from '@aztec/foundation/collection';
+
+import { EncryptedTxL2Logs, UnencryptedTxL2Logs } from '../logs/tx_l2_logs.js';
+import { type SimulationError } from '../simulation_error.js';
+import { type PublicKernelType } from './processed_tx.js';
+
+/** Return values of simulating a circuit. */
+export type ProcessReturnValues = Fr[] | undefined;
+
+/**
+ * Outputs of processing the public component of a transaction.
+ */
+export class PublicSimulationOutput {
+  constructor(
+    public encryptedLogs: EncryptedTxL2Logs,
+    public unencryptedLogs: UnencryptedTxL2Logs,
+    public revertReason: SimulationError | undefined,
+    public constants: CombinedConstantData,
+    public end: CombinedAccumulatedData,
+    public publicReturnValues: ProcessReturnValues,
+    public gasUsed: Partial<Record<PublicKernelType, Gas>>,
+  ) {}
+
+  toJSON() {
+    return {
+      encryptedLogs: this.encryptedLogs.toJSON(),
+      unencryptedLogs: this.unencryptedLogs.toJSON(),
+      revertReason: this.revertReason,
+      constants: this.constants.toBuffer().toString('hex'),
+      end: this.end.toBuffer().toString('hex'),
+      publicReturnValues: this.publicReturnValues?.map(fr => fr.toString()),
+      gasUsed: mapValues(this.gasUsed, gas => gas?.toJSON()),
+    };
+  }
+
+  static fromJSON(json: any): PublicSimulationOutput {
+    return new PublicSimulationOutput(
+      EncryptedTxL2Logs.fromJSON(json.encryptedLogs),
+      UnencryptedTxL2Logs.fromJSON(json.unencryptedLogs),
+      json.revertReason,
+      CombinedConstantData.fromBuffer(Buffer.from(json.constants, 'hex')),
+      CombinedAccumulatedData.fromBuffer(Buffer.from(json.end, 'hex')),
+      json.publicReturnValues?.map(Fr.fromString),
+      mapValues(json.gasUsed, gas => (gas ? Gas.fromJSON(gas) : undefined)),
+    );
+  }
+}

--- a/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
@@ -111,7 +111,7 @@ describe('e2e_2_pxes', () => {
     await contract.methods.redeem_shield(recipient, balance, secret).send().wait();
   };
 
-  it.only('transfers funds from user A to B via PXE A followed by transfer from B to A via PXE B', async () => {
+  it('transfers funds from user A to B via PXE A followed by transfer from B to A via PXE B', async () => {
     const initialBalance = 987n;
     const transferAmount1 = 654n;
     const transferAmount2 = 323n;

--- a/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
@@ -111,7 +111,7 @@ describe('e2e_2_pxes', () => {
     await contract.methods.redeem_shield(recipient, balance, secret).send().wait();
   };
 
-  it('transfers funds from user A to B via PXE A followed by transfer from B to A via PXE B', async () => {
+  it.only('transfers funds from user A to B via PXE A followed by transfer from B to A via PXE B', async () => {
     const initialBalance = 987n;
     const transferAmount1 = 654n;
     const transferAmount2 = 323n;


### PR DESCRIPTION
Fixes:
<img width="634" alt="image" src="https://github.com/AztecProtocol/aztec-packages/assets/13470840/e4707b61-1e26-4b3c-b880-9f5b1bf85e4e">

I decided to not register `CombinedConstantData` directly on JsonRpc server and client since that would just make it all much less readable because CombinedConstantData is not a return value itself on any of AztecNode methods. And since I am a fan of nice readable encapsulated classes instead of the `Pick` type typescript freestyle I refactored ProcessOutput such that we can register that directly on the Json RPC server.