### PR TITLE
fix(avm-context): enqueueing of public from private

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/interface.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/interface.nr
@@ -1,6 +1,6 @@
 use dep::protocol_types::{abis::function_selector::FunctionSelector, address::{AztecAddress, EthAddress}, traits::Deserialize};
 
-use crate::hash::hash_args;
+use crate::oracle::arguments;
 use crate::context::private_context::PrivateContext;
 use crate::context::public_context::PublicContext;
 use crate::context::avm_context::AvmContext;
@@ -118,7 +118,6 @@ struct PublicCallInterface<T> {
 }
 
 impl<T> PublicCallInterface<T> {
-
     pub fn call<N>(self, context: &mut PublicContext) -> T where T: Deserialize<N> {
         let returns = context.call_public_function_with_packed_args(
             self.target_contract,
@@ -232,18 +231,39 @@ impl<T> AvmCallInterface<T> {
     }
 
     pub fn enqueue(self, context: &mut PrivateContext) {
-        let args_hash = hash_args(self.args);
-        context.call_public_function_with_packed_args(self.target_contract, self.selector, args_hash, false, false)
+        // This packing is only here because PrivateContext's call_public* functions do not accept a slice for the args.
+        let args_hash = arguments::pack_arguments(self.args);
+        context.call_public_function_with_packed_args(
+            self.target_contract,
+            self.selector,
+            args_hash,
+            /*static=*/ false,
+            /*delegate=*/ false
+        )
     }
 
     pub fn static_enqueue(self, context: &mut PrivateContext) {
-        let args_hash = hash_args(self.args);
-        context.call_public_function_with_packed_args(self.target_contract, self.selector, args_hash, true, false)
+        // This packing is only here because PrivateContext's call_public* functions do not accept a slice for the args.
+        let args_hash = arguments::pack_arguments(self.args);
+        context.call_public_function_with_packed_args(
+            self.target_contract,
+            self.selector,
+            args_hash,
+            /*static=*/ true,
+            /*delegate=*/ false
+        )
     }
 
     pub fn delegate_enqueue(self, context: &mut PrivateContext) {
-        let args_hash = hash_args(self.args);
-        context.call_public_function_with_packed_args(self.target_contract, self.selector, args_hash, false, true)
+        // This packing is only here because PrivateContext's call_public* functions do not accept a slice for the args.
+        let args_hash = arguments::pack_arguments(self.args);
+        context.call_public_function_with_packed_args(
+            self.target_contract,
+            self.selector,
+            args_hash,
+            /*static=*/ false,
+            /*delegate=*/ true
+        )
     }
 }
 
@@ -276,17 +296,38 @@ impl AvmVoidCallInterface {
     }
 
     pub fn enqueue(self, context: &mut PrivateContext) {
-        let args_hash = hash_args(self.args);
-        context.call_public_function_with_packed_args(self.target_contract, self.selector, args_hash, false, false)
+        // This packing is only here because PrivateContext's call_public* functions do not accept a slice for the args.
+        let args_hash = arguments::pack_arguments(self.args);
+        context.call_public_function_with_packed_args(
+            self.target_contract,
+            self.selector,
+            args_hash,
+            /*static=*/ false,
+            /*delegate=*/ false
+        )
     }
 
     pub fn static_enqueue(self, context: &mut PrivateContext) {
-        let args_hash = hash_args(self.args);
-        context.call_public_function_with_packed_args(self.target_contract, self.selector, args_hash, true, false)
+        // This packing is only here because PrivateContext's call_public* functions do not accept a slice for the args.
+        let args_hash = arguments::pack_arguments(self.args);
+        context.call_public_function_with_packed_args(
+            self.target_contract,
+            self.selector,
+            args_hash,
+            /*static=*/ true,
+            /*delegate=*/ false
+        )
     }
 
     pub fn delegate_enqueue(self, context: &mut PrivateContext) {
-        let args_hash = hash_args(self.args);
-        context.call_public_function_with_packed_args(self.target_contract, self.selector, args_hash, false, true)
+        // This packing is only here because PrivateContext's call_public* functions do not accept a slice for the args.
+        let args_hash = arguments::pack_arguments(self.args);
+        context.call_public_function_with_packed_args(
+            self.target_contract,
+            self.selector,
+            args_hash,
+            /*static=*/ false,
+            /*delegate=*/ true
+        )
     }
 }

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -153,6 +153,12 @@ contract AvmTest {
         U128::from_integer(should_overflow)
     }
 
+    #[aztec(private)]
+    fn enqueue_public_from_private() {
+        AvmTest::at(context.this_address()).set_opcode_u8().static_enqueue(&mut context);
+        AvmTest::at(context.this_address()).set_read_storage_single(5).enqueue(&mut context);
+    }
+
     /************************************************************************
      * Hashing functions
      ************************************************************************/

--- a/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
+++ b/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
@@ -41,6 +41,12 @@ describe('e2e_avm_simulator', () => {
       });
     });
 
+    describe('From private', () => {
+      it('Should enqueue a public function correctly', async () => {
+        await avmContract.methods.enqueue_public_from_private().simulate();
+      });
+    });
+
     describe('Gas metering', () => {
       it('Tracks L2 gas usage on simulation', async () => {
         const request = await avmContract.methods.add_args_return(20n, 30n).create();

--- a/yarn-project/simulator/src/avm/journal/journal.ts
+++ b/yarn-project/simulator/src/avm/journal/journal.ts
@@ -119,7 +119,8 @@ export class AvmPersistableStateManager {
       contractStorageUpdateRequests: [],
       unencryptedLogsHashes: [],
       unencryptedLogs: [],
-      unencryptedLogPreimagesLength: new Fr(0),
+      // The length starts at 4 because it will always include the size.
+      unencryptedLogPreimagesLength: new Fr(4),
       allUnencryptedLogs: [],
       nestedExecutions: [],
     };


### PR DESCRIPTION
Fixes

```
e2e_token_contract burn › private › burn less than balance
    Simulation error: Packed values for hash 0x237f08330472d6db6fdd49901b949f2d7fbdbdc3062ef5339753f8c6bd784d15 not found in cache
```

Also fix calculation of unencrypted log length since after fixing the packing I was getting "No unencrypted logs are allowed for static calls".