### PR TITLE
fix(avm-simulator): fix message sender

### DIFF
--- a/yarn-project/simulator/src/avm/avm_execution_environment.test.ts
+++ b/yarn-project/simulator/src/avm/avm_execution_environment.test.ts
@@ -1,3 +1,4 @@
+import { FunctionSelector } from '@aztec/circuits.js';
 import { Fr } from '@aztec/foundation/fields';
 
 import { allSameExcept, anyAvmContextInputs, initExecutionEnvironment } from './fixtures/index.js';
@@ -5,10 +6,11 @@ import { allSameExcept, anyAvmContextInputs, initExecutionEnvironment } from './
 describe('Execution Environment', () => {
   const newAddress = new Fr(123456n);
   const calldata = [new Fr(1n), new Fr(2n), new Fr(3n)];
+  const selector = FunctionSelector.empty();
 
   it('New call should fork execution environment correctly', () => {
     const executionEnvironment = initExecutionEnvironment();
-    const newExecutionEnvironment = executionEnvironment.deriveEnvironmentForNestedCall(newAddress, calldata);
+    const newExecutionEnvironment = executionEnvironment.deriveEnvironmentForNestedCall(newAddress, calldata, selector);
 
     expect(newExecutionEnvironment).toEqual(
       allSameExcept(executionEnvironment, {
@@ -22,7 +24,7 @@ describe('Execution Environment', () => {
 
   it('New delegate call should fork execution environment correctly', () => {
     const executionEnvironment = initExecutionEnvironment();
-    const newExecutionEnvironment = executionEnvironment.newDelegateCall(newAddress, calldata);
+    const newExecutionEnvironment = executionEnvironment.newDelegateCall(newAddress, calldata, selector);
 
     expect(newExecutionEnvironment).toEqual(
       allSameExcept(executionEnvironment, {
@@ -36,7 +38,11 @@ describe('Execution Environment', () => {
 
   it('New static call call should fork execution environment correctly', () => {
     const executionEnvironment = initExecutionEnvironment();
-    const newExecutionEnvironment = executionEnvironment.deriveEnvironmentForNestedStaticCall(newAddress, calldata);
+    const newExecutionEnvironment = executionEnvironment.deriveEnvironmentForNestedStaticCall(
+      newAddress,
+      calldata,
+      selector,
+    );
 
     expect(newExecutionEnvironment).toEqual(
       allSameExcept(executionEnvironment, {

--- a/yarn-project/simulator/src/avm/avm_execution_environment.test.ts
+++ b/yarn-project/simulator/src/avm/avm_execution_environment.test.ts
@@ -22,7 +22,8 @@ describe('Execution Environment', () => {
     );
   });
 
-  it('New delegate call should fork execution environment correctly', () => {
+  // Delegate calls not supported.
+  it.skip('New delegate call should fork execution environment correctly', () => {
     const executionEnvironment = initExecutionEnvironment();
     const newExecutionEnvironment = executionEnvironment.newDelegateCall(newAddress, calldata, selector);
 

--- a/yarn-project/simulator/src/avm/avm_execution_environment.ts
+++ b/yarn-project/simulator/src/avm/avm_execution_environment.ts
@@ -45,72 +45,64 @@ export class AvmExecutionEnvironment {
     this.calldata = [...inputs.toFields(), ...calldata];
   }
 
-  public deriveEnvironmentForNestedCall(
+  private deriveEnvironmentForNestedCallInternal(
     targetAddress: AztecAddress,
     calldata: Fr[],
-    temporaryFunctionSelector: FunctionSelector = FunctionSelector.empty(),
-  ): AvmExecutionEnvironment {
+    functionSelector: FunctionSelector,
+    isStaticCall: boolean,
+    isDelegateCall: boolean,
+  ) {
     return new AvmExecutionEnvironment(
-      targetAddress,
+      /*address=*/ targetAddress,
       /*storageAddress=*/ targetAddress,
-      this.address,
+      /*sender=*/ this.address,
       this.feePerL2Gas,
       this.feePerDaGas,
       this.contractCallDepth,
       this.header,
       this.globals,
-      this.isStaticCall,
-      this.isDelegateCall,
+      isStaticCall,
+      isDelegateCall,
       calldata,
       this.gasSettings,
       this.transactionFee,
-      temporaryFunctionSelector,
+      functionSelector,
+    );
+  }
+
+  public deriveEnvironmentForNestedCall(
+    targetAddress: AztecAddress,
+    calldata: Fr[],
+    functionSelector: FunctionSelector = FunctionSelector.empty(),
+  ): AvmExecutionEnvironment {
+    return this.deriveEnvironmentForNestedCallInternal(
+      targetAddress,
+      calldata,
+      functionSelector,
+      /*isStaticCall=*/ false,
+      /*isDelegateCall=*/ false,
     );
   }
 
   public deriveEnvironmentForNestedStaticCall(
-    address: AztecAddress,
+    targetAddress: AztecAddress,
     calldata: Fr[],
-    temporaryFunctionSelector: FunctionSelector = FunctionSelector.empty(),
+    functionSelector: FunctionSelector,
   ): AvmExecutionEnvironment {
-    return new AvmExecutionEnvironment(
-      address,
-      /*storageAddress=*/ address,
-      this.sender,
-      this.feePerL2Gas,
-      this.feePerDaGas,
-      this.contractCallDepth,
-      this.header,
-      this.globals,
-      /*isStaticCall=*/ true,
-      this.isDelegateCall,
+    return this.deriveEnvironmentForNestedCallInternal(
+      targetAddress,
       calldata,
-      this.gasSettings,
-      this.transactionFee,
-      temporaryFunctionSelector,
+      functionSelector,
+      /*isStaticCall=*/ true,
+      /*isDelegateCall=*/ false,
     );
   }
 
   public newDelegateCall(
-    address: AztecAddress,
-    calldata: Fr[],
-    temporaryFunctionSelector: FunctionSelector = FunctionSelector.empty(),
+    _targetAddress: AztecAddress,
+    _calldata: Fr[],
+    _functionSelector: FunctionSelector,
   ): AvmExecutionEnvironment {
-    return new AvmExecutionEnvironment(
-      address,
-      this.storageAddress,
-      this.sender,
-      this.feePerL2Gas,
-      this.feePerDaGas,
-      this.contractCallDepth,
-      this.header,
-      this.globals,
-      this.isStaticCall,
-      /*isDelegateCall=*/ true,
-      calldata,
-      this.gasSettings,
-      this.transactionFee,
-      temporaryFunctionSelector,
-    );
+    throw new Error('Delegate calls not supported!');
   }
 }


### PR DESCRIPTION
It was already fixed for non-static calls, but not for static...

Fixes `e2e_state_vars.test.ts` under AVM (except for the assertion expression-related failures).