### PR TITLE
fix(circuits.js): fix nullifier non existent hints

### DIFF
--- a/yarn-project/circuits.js/src/hints/build_nullifier_non_existent_read_request_hints.test.ts
+++ b/yarn-project/circuits.js/src/hints/build_nullifier_non_existent_read_request_hints.test.ts
@@ -131,6 +131,8 @@ describe('buildNullifierNonExistentReadRequestHints', () => {
 
     nonExistentReadRequests[0] = makeReadRequest(innerNullifier(2));
 
-    await expect(() => buildHints()).rejects.toThrow('Nullifier exists in the pending set.');
+    await expect(() => buildHints()).rejects.toThrow(
+      'Nullifier DOES exists in the pending set at the time of reading, but there is a NonExistentReadRequest for it.',
+    );
   });
 });

--- a/yarn-project/circuits.js/src/hints/build_nullifier_non_existent_read_request_hints.ts
+++ b/yarn-project/circuits.js/src/hints/build_nullifier_non_existent_read_request_hints.ts
@@ -71,8 +71,13 @@ export async function buildNullifierNonExistentReadRequestHints(
     let nextPendingValueIndex = sortedValues.findIndex(v => !v.value.lt(siloedValue));
     if (nextPendingValueIndex == -1) {
       nextPendingValueIndex = numPendingNullifiers;
-    } else if (sortedValues[nextPendingValueIndex].value.equals(siloedValue)) {
-      throw new Error('Nullifier exists in the pending set.');
+    } else if (
+      sortedValues[nextPendingValueIndex].value.equals(siloedValue) &&
+      sortedValues[nextPendingValueIndex].counter < readRequest.counter
+    ) {
+      throw new Error(
+        'Nullifier DOES exists in the pending set at the time of reading, but there is a NonExistentReadRequest for it.',
+      );
     }
 
     builder.addHint(membershipWitness, leafPreimage, nextPendingValueIndex);


### PR DESCRIPTION
If the nullifier got into the pending set AFTER the request, it's not a problem.
