### PR TITLE
chore: Bump timeout for after-hook for data store test

### DIFF
--- a/yarn-project/p2p/src/service/data_store.test.ts
+++ b/yarn-project/p2p/src/service/data_store.test.ts
@@ -17,6 +17,8 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string';
 
 import { AztecDatastore } from './data_store.js';
 
+const CLEANUP_TIMEOUT = 30_000;
+
 describe('AztecDatastore with AztecLmdbStore', () => {
   let datastore: AztecDatastore;
   let aztecStore: AztecLmdbStore;
@@ -177,7 +179,7 @@ export function interfaceDatastoreTests<D extends Datastore = Datastore>(test: I
 
     afterEach(async () => {
       await cleanup(store);
-    }, 30_000);
+    }, CLEANUP_TIMEOUT);
 
     it('simple', async () => {
       const k = new Key('/z/key');
@@ -213,7 +215,7 @@ export function interfaceDatastoreTests<D extends Datastore = Datastore>(test: I
 
     afterEach(async () => {
       await cleanup(store);
-    });
+    }, CLEANUP_TIMEOUT);
 
     it('streaming', async () => {
       const data: Pair[] = [];
@@ -244,7 +246,7 @@ export function interfaceDatastoreTests<D extends Datastore = Datastore>(test: I
 
     afterEach(async () => {
       await cleanup(store);
-    });
+    }, CLEANUP_TIMEOUT);
 
     it('simple', async () => {
       const k = new Key('/z/one');
@@ -274,7 +276,7 @@ export function interfaceDatastoreTests<D extends Datastore = Datastore>(test: I
 
     afterEach(async () => {
       await cleanup(store);
-    });
+    }, CLEANUP_TIMEOUT);
 
     it('streaming', async () => {
       const k = new Key('/z/one');
@@ -308,7 +310,7 @@ export function interfaceDatastoreTests<D extends Datastore = Datastore>(test: I
 
     afterEach(async () => {
       await cleanup(store);
-    }, 10_000);
+    }, CLEANUP_TIMEOUT);
 
     it('simple', async () => {
       const k = new Key('/z/one');
@@ -354,7 +356,7 @@ export function interfaceDatastoreTests<D extends Datastore = Datastore>(test: I
 
     afterEach(async () => {
       await cleanup(store);
-    });
+    }, CLEANUP_TIMEOUT);
 
     it('streaming', async () => {
       const data = [];
@@ -390,7 +392,7 @@ export function interfaceDatastoreTests<D extends Datastore = Datastore>(test: I
 
     afterEach(async () => {
       await cleanup(store);
-    });
+    }, CLEANUP_TIMEOUT);
 
     it('simple', async () => {
       const b = store.batch();
@@ -481,7 +483,7 @@ export function interfaceDatastoreTests<D extends Datastore = Datastore>(test: I
 
     afterAll(async () => {
       await cleanup(store);
-    });
+    }, CLEANUP_TIMEOUT);
 
     tests.forEach(([name, query, expected]) =>
       it(name, async () => {
@@ -604,7 +606,7 @@ export function interfaceDatastoreTests<D extends Datastore = Datastore>(test: I
 
     afterAll(async () => {
       await cleanup(store);
-    });
+    }, CLEANUP_TIMEOUT);
 
     tests.forEach(([name, query, expected]) =>
       it(name, async () => {

--- a/yarn-project/p2p/src/service/data_store.test.ts
+++ b/yarn-project/p2p/src/service/data_store.test.ts
@@ -177,7 +177,7 @@ export function interfaceDatastoreTests<D extends Datastore = Datastore>(test: I
 
     afterEach(async () => {
       await cleanup(store);
-    });
+    }, 30_000);
 
     it('simple', async () => {
       const k = new Key('/z/key');


### PR DESCRIPTION
This was [timing out on CI](https://github.com/AztecProtocol/aztec-packages/actions/runs/9062310974/job/24896050730#step:5:687):

```
 ./yarn-project+test | [@aztec/p2p]:  FAIL  src/service/data_store.test.ts (17.411 s)
 ./yarn-project+test | [@aztec/p2p]:   ● AztecDatastore with AztecLmdbStore › interface-datastore compliance tests › batch › many (3 * 400)
 ./yarn-project+test | [@aztec/p2p]: 
 ./yarn-project+test | [@aztec/p2p]:     thrown: "Exceeded timeout of 5000 ms for a hook.
 ./yarn-project+test | [@aztec/p2p]:     Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."
 ./yarn-project+test | [@aztec/p2p]: 
 ./yarn-project+test | [@aztec/p2p]:       389 |     });
 ./yarn-project+test | [@aztec/p2p]:       390 |
 ./yarn-project+test | [@aztec/p2p]:     > 391 |     afterEach(async () => {
 ./yarn-project+test | [@aztec/p2p]:           |     ^
 ./yarn-project+test | [@aztec/p2p]:       392 |       await cleanup(store);
 ./yarn-project+test | [@aztec/p2p]:       393 |     });
 ./yarn-project+test | [@aztec/p2p]:       394 |
 ./yarn-project+test | [@aztec/p2p]: 
 ./yarn-project+test | [@aztec/p2p]:       at afterEach (service/data_store.test.ts:xxxxx@aztec/p2p]:       at describe (service/data_store.test.ts:xxxxx@aztec/p2p]:       at interfaceDatastoreTests (service/data_store.test.ts:xxxxx@aztec/p2p]:       at describe (service/data_store.test.ts:xxxxx@aztec/p2p]:       at describe (service/data_store.test.ts:xxxxx@aztec/p2p]: 
```