### PR TITLE
chore: make coinbase and fee_recipient inaccessible

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -225,11 +225,13 @@ impl PublicContextInterface for PublicContext {
     }
 
     fn coinbase(self) -> EthAddress {
-        self.inputs.public_global_variables.coinbase
+        assert(false, "'coinbase' not implemented!");
+        EthAddress::zero()
     }
 
     fn fee_recipient(self) -> AztecAddress {
-        self.inputs.public_global_variables.fee_recipient
+        assert(false, "'fee_recipient' not implemented!");
+        AztecAddress::zero()
     }
 
     fn fee_per_da_gas(self) -> Field {

--- a/noir-projects/noir-contracts/contracts/gas_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/gas_token_contract/src/main.nr
@@ -65,9 +65,6 @@ contract GasToken {
         let sender_new_balance = storage.balances.at(context.msg_sender()).read() - fee;
         storage.balances.at(context.msg_sender()).write(sender_new_balance);
 
-        let recipient_new_balance = storage.balances.at(context.fee_recipient()).read() + fee;
-        storage.balances.at(context.fee_recipient()).write(recipient_new_balance);
-
         let rebate = fee_limit_u128 - fee;
         rebate.to_field()
     }

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -375,8 +375,6 @@ contract Test {
         version: Field,
         block_number: Field,
         timestamp: u64,
-        coinbase: EthAddress,
-        fee_recipient: AztecAddress,
         fee_per_da_gas: Field,
         fee_per_l2_gas: Field
     ) {
@@ -384,8 +382,6 @@ contract Test {
         assert(context.version() == version, "Invalid version");
         assert(context.block_number() == block_number, "Invalid block number");
         assert(context.timestamp() == timestamp, "Invalid timestamp");
-        assert(context.coinbase() == coinbase, "Invalid coinbase");
-        assert(context.fee_recipient() == fee_recipient, "Invalid fee recipient");
         assert(context.fee_per_da_gas() == fee_per_da_gas, "Invalid fee per da gas");
         assert(context.fee_per_l2_gas() == fee_per_l2_gas, "Invalid fee per l2 gas");
     }

--- a/yarn-project/end-to-end/src/e2e_fees/dapp_subscription.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/dapp_subscription.test.ts
@@ -114,7 +114,7 @@ describe('e2e_fees dapp_subscription', () => {
     await expectMapping(
       t.gasBalances,
       [sequencerAddress, bananaFPC.address],
-      [initialSequencerGasBalance + transactionFee!, initialFPCGasBalance - transactionFee!],
+      [initialSequencerGasBalance, initialFPCGasBalance - transactionFee!],
     );
 
     // alice, bob, fpc
@@ -143,7 +143,7 @@ describe('e2e_fees dapp_subscription', () => {
     await expectMapping(
       t.gasBalances,
       [sequencerAddress, bananaFPC.address],
-      [initialSequencerGasBalance + transactionFee!, initialFPCGasBalance - transactionFee!],
+      [initialSequencerGasBalance, initialFPCGasBalance - transactionFee!],
     );
 
     // alice, bob, fpc
@@ -156,9 +156,7 @@ describe('e2e_fees dapp_subscription', () => {
 
   it('should call dapp subscription entrypoint', async () => {
     // Subscribe again, so this test does not depend on the previous ones being run.
-    const { transactionFee: subscriptionTxFee } = await subscribe(
-      new PrivateFeePaymentMethod(bananaCoin.address, bananaFPC.address, aliceWallet),
-    );
+    await subscribe(new PrivateFeePaymentMethod(bananaCoin.address, bananaFPC.address, aliceWallet));
 
     expect(await subscriptionContract.methods.is_initialized(aliceAddress).simulate()).toBe(true);
 
@@ -174,10 +172,7 @@ describe('e2e_fees dapp_subscription', () => {
     await expectMapping(
       t.gasBalances,
       [sequencerAddress, subscriptionContract.address],
-      [
-        initialSequencerGasBalance + transactionFee! + subscriptionTxFee!,
-        initialSubscriptionContractGasBalance - transactionFee!,
-      ],
+      [initialSequencerGasBalance, initialSubscriptionContractGasBalance - transactionFee!],
     );
   });
 

--- a/yarn-project/end-to-end/src/e2e_fees/private_payments.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/private_payments.test.ts
@@ -147,7 +147,7 @@ describe('e2e_fees private_payment', () => {
     await expectMapping(
       t.gasBalances,
       [aliceAddress, bananaFPC.address, sequencerAddress],
-      [InitialAliceGas, InitialFPCGas - feeAmount, InitialSequencerGas + feeAmount],
+      [InitialAliceGas, InitialFPCGas - feeAmount, InitialSequencerGas],
     );
 
     await expect(
@@ -207,7 +207,7 @@ describe('e2e_fees private_payment', () => {
     await expectMapping(
       t.gasBalances,
       [aliceAddress, bananaFPC.address, sequencerAddress],
-      [InitialAliceGas, InitialFPCGas - feeAmount, InitialSequencerGas + feeAmount],
+      [InitialAliceGas, InitialFPCGas - feeAmount, InitialSequencerGas],
     );
 
     await expect(
@@ -270,7 +270,7 @@ describe('e2e_fees private_payment', () => {
     await expectMapping(
       t.gasBalances,
       [aliceAddress, bananaFPC.address, sequencerAddress],
-      [InitialAliceGas, InitialFPCGas - feeAmount, InitialSequencerGas + feeAmount],
+      [InitialAliceGas, InitialFPCGas - feeAmount, InitialSequencerGas],
     );
 
     await expect(
@@ -346,7 +346,7 @@ describe('e2e_fees private_payment', () => {
     await expectMapping(
       t.gasBalances,
       [aliceAddress, bananaFPC.address, sequencerAddress],
-      [InitialAliceGas, InitialFPCGas - feeAmount, InitialSequencerGas + feeAmount],
+      [InitialAliceGas, InitialFPCGas - feeAmount, InitialSequencerGas],
     );
 
     await expect(

--- a/yarn-project/simulator/src/public/index.test.ts
+++ b/yarn-project/simulator/src/public/index.test.ts
@@ -674,12 +674,6 @@ describe('ACIR public execution simulator', () => {
       { value: new Fr(1), invalidValue: Fr.random(), description: 'Version' },
       { value: new Fr(1), invalidValue: Fr.random(), description: 'Block number' },
       { value: new Fr(1), invalidValue: Fr.random(), description: 'Timestamp' },
-      { value: EthAddress.random(), invalidValue: EthAddress.random(), description: 'Coinbase' },
-      {
-        value: AztecAddress.random(),
-        invalidValue: AztecAddress.random(),
-        description: 'Fee recipient',
-      },
       { value: new Fr(1), invalidValue: Fr.random(), description: 'Fee per DA gas' },
       { value: new Fr(1), invalidValue: Fr.random(), description: 'Fee per L2 gas' },
     ];


### PR DESCRIPTION
The AVM does not have immediate plans to support access to `coinbase`, nor `fee_recipient`. So make access to these fields impossible from the public interface. 

This involves updating the gas token contract to "not pay fee". This is fine because [it will be done in the base rollup](https://github.com/AztecProtocol/aztec-packages/issues/5006). 

Closes #6336.