### PR TITLE
chore(token-contract-tests): change intrinsic assertion messages

### DIFF
--- a/yarn-project/end-to-end/src/e2e_token_contract/reading_constants.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/reading_constants.test.ts
@@ -76,7 +76,7 @@ describe('e2e_token_contract reading constants', () => {
     await reader.methods.check_symbol_private(t.asset.address, TOKEN_SYMBOL).send().wait();
 
     await expect(reader.methods.check_symbol_private(t.asset.address, 'WRONG_SYMBOL').simulate()).rejects.toThrow(
-      "Cannot satisfy constraint 'symbol.is_eq(_what)'",
+      "'symbol.is_eq(_what)'",
     );
   });
 
@@ -87,7 +87,7 @@ describe('e2e_token_contract reading constants', () => {
     await reader.methods.check_symbol_public(t.asset.address, TOKEN_SYMBOL).send().wait();
 
     await expect(reader.methods.check_symbol_public(t.asset.address, 'WRONG_SYMBOL').simulate()).rejects.toThrow(
-      "Failed to solve brillig function 'symbol.is_eq(_what)'",
+      "'symbol.is_eq(_what)'",
     );
   });
 
@@ -108,8 +108,6 @@ describe('e2e_token_contract reading constants', () => {
 
     await reader.methods.check_decimals_public(t.asset.address, TOKEN_DECIMALS).send().wait();
 
-    await expect(reader.methods.check_decimals_public(t.asset.address, 99).simulate()).rejects.toThrow(
-      "Failed to solve brillig function 'ret == what'",
-    );
+    await expect(reader.methods.check_decimals_public(t.asset.address, 99).simulate()).rejects.toThrow("'ret == what'");
   });
 });

--- a/yarn-project/end-to-end/src/fixtures/fixtures.ts
+++ b/yarn-project/end-to-end/src/fixtures/fixtures.ts
@@ -5,7 +5,6 @@ export const privateKey2 = Buffer.from('59c6995e998f97a5a0044966f0945389dc9e86da
 /// Common errors
 export const U128_UNDERFLOW_ERROR = "Assertion failed: attempt to subtract with underflow 'hi == high'";
 export const U128_OVERFLOW_ERROR = "Assertion failed: attempt to add with overflow 'hi == high'";
-export const BITSIZE_TOO_BIG_ERROR =
-  "Assertion failed: call to assert_max_bit_size 'self.__assert_max_bit_size(bit_size)'";
+export const BITSIZE_TOO_BIG_ERROR = "'self.__assert_max_bit_size(bit_size)'";
 // TODO(https://github.com/AztecProtocol/aztec-packages/issues/5818): Make this a fixed error after transition.
 export const DUPLICATE_NULLIFIER_ERROR = /Transaction .*|.*duplicate nullifier.*/;


### PR DESCRIPTION
In preparation for AVM simulator switch.

Makes e2e_token_contract tests pass.

![Screenshot 2024-05-14 at 12.23.09.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/mO08Q17TCoHzVKYudUJh/e830dcd1-bb12-4881-ab88-f24d4b4438ed.png)

