### PR TITLE
chore: Fix logs upload to S3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
             set -eux
             cd ./yarn-project/end-to-end/
             export FORCE_COLOR=1
+            export EARTHLY_BUILD_ARGS="${{ env.EARTHLY_BUILD_ARGS }}"
             ../../scripts/earthly-ci -P \
               --secret AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
               --secret AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \


### PR DESCRIPTION
As e2es were moved to a remote runner, they no longer inherit the env from github, so EARTHLY_BUILD_ARGS were not passed, so the target folder for uploading logs was unset.
