### PR TITLE
chore: move `UPLOAD_LOGS` into root earthfile

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -40,10 +40,11 @@ UPLOAD_LOGS:
     ARG PULL_REQUEST
     ARG BRANCH
     ARG COMMIT_HASH
+    ARG LOG_FILE=./log
     LOCALLY
     LET COMMIT_HASH="${COMMIT_HASH:-$(git rev-parse HEAD)}"
     FROM +base-log-uploader
-    COPY ./log /usr/var/log
+    COPY $LOG_FILE /usr/var/log
     ENV PULL_REQUEST=$PULL_REQUEST
     ENV BRANCH=$BRANCH
     ENV COMMIT_HASH=$COMMIT_HASH

--- a/Earthfile
+++ b/Earthfile
@@ -34,3 +34,29 @@ scripts:
     FROM scratch
     COPY scripts /usr/src/scripts
     SAVE ARTIFACT /usr/src/scripts scripts
+
+UPLOAD_LOGS:
+    FUNCTION
+    ARG PULL_REQUEST
+    ARG BRANCH
+    ARG COMMIT_HASH
+    LOCALLY
+    LET COMMIT_HASH="${COMMIT_HASH:-$(git rev-parse HEAD)}"
+    FROM +base-log-uploader
+    COPY ./log /usr/var/log
+    ENV PULL_REQUEST=$PULL_REQUEST
+    ENV BRANCH=$BRANCH
+    ENV COMMIT_HASH=$COMMIT_HASH
+    RUN --secret AWS_ACCESS_KEY_ID --secret AWS_SECRET_ACCESS_KEY /usr/src/scripts/logs/upload_logs_to_s3.sh /usr/var/log
+    
+base-log-uploader:
+    # Install awscli on a fresh ubuntu, and copy the repo "scripts" folder, which we'll use to upload logs
+    # Note that we cannot do this LOCALLY because Earthly does not support using secrets locally
+    FROM ubuntu:noble
+    RUN apt update && \
+        apt install -y curl git jq unzip
+    RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
+        unzip awscliv2.zip && \
+        ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update && \
+        rm -rf aws awscliv2.zip
+    COPY +scripts/scripts /usr/src/scripts

--- a/yarn-project/end-to-end/Earthfile
+++ b/yarn-project/end-to-end/Earthfile
@@ -43,32 +43,6 @@ E2E_TEST:
   # Run our docker compose, ending whenever sandbox ends, filtering out noisy eth_getLogs
   RUN docker run --rm aztecprotocol/end-to-end:$AZTEC_DOCKER_TAG $test || $allow_fail
 
-UPLOAD_LOGS:
-  FUNCTION
-  ARG PULL_REQUEST
-  ARG BRANCH
-  ARG COMMIT_HASH
-  LOCALLY
-  LET COMMIT_HASH="${COMMIT_HASH:-$(git rev-parse HEAD)}"
-  FROM +base-log-uploader
-  COPY ./log /usr/var/log
-  ENV PULL_REQUEST=$PULL_REQUEST
-  ENV BRANCH=$BRANCH
-  ENV COMMIT_HASH=$COMMIT_HASH
-  RUN --secret AWS_ACCESS_KEY_ID --secret AWS_SECRET_ACCESS_KEY /usr/src/scripts/logs/upload_logs_to_s3.sh /usr/var/log
-
-base-log-uploader:
-  # Install awscli on a fresh ubuntu, and copy the repo "scripts" folder, which we'll use to upload logs
-  # Note that we cannot do this LOCALLY because Earthly does not support using secrets locally
-  FROM ubuntu:noble
-  RUN apt update && \
-      apt install -y curl git jq unzip
-  RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
-      unzip awscliv2.zip && \
-      ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update && \
-      rm -rf aws awscliv2.zip
-  COPY ../../+scripts/scripts /usr/src/scripts
-
 e2e-2-pxes:
   DO +E2E_TEST --test=./src/e2e_2_pxes.test.ts
 
@@ -208,25 +182,25 @@ bench-publish-rollup:
   ARG BRANCH
   ARG COMMIT_HASH
   DO +E2E_COMPOSE_TEST --test=benchmarks/bench_publish_rollup.test.ts --debug="aztec:benchmarks:*,aztec:sequencer,aztec:sequencer:*,aztec:world_state,aztec:merkle_trees" --compose_file=./scripts/docker-compose-no-sandbox.yml
-  DO +UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH
+  DO ../scripts/+UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH
 
 bench-process-history:
   ARG PULL_REQUEST
   ARG BRANCH
   ARG COMMIT_HASH
   DO +E2E_COMPOSE_TEST --test=benchmarks/bench_process_history.test.ts --debug="aztec:benchmarks:*,aztec:sequencer,aztec:sequencer:*,aztec:world_state,aztec:merkle_trees" --compose_file=./scripts/docker-compose-no-sandbox.yml
-  DO +UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH
+  DO ../scripts/+UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH
 
 bench-tx-size:
   ARG PULL_REQUEST
   ARG BRANCH
   ARG COMMIT_HASH
   DO +E2E_COMPOSE_TEST --test=benchmarks/bench_tx_size_fees.test.ts --debug="aztec:benchmarks:*,aztec:sequencer,aztec:sequencer:*,aztec:world_state,aztec:merkle_trees" --enable_gas=1 --compose_file=./scripts/docker-compose-no-sandbox.yml
-  DO +UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH
+  DO ../scripts/+UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH
 
 bench-proving:
   ARG PULL_REQUEST
   ARG BRANCH
   ARG COMMIT_HASH
   DO +E2E_COMPOSE_TEST --test=bench_proving --debug="aztec:benchmarks:*,aztec:prover*,aztec:bb*" --enable_gas=1 --compose_file=./scripts/docker-compose-no-sandbox.yml
-  DO +UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH
+  DO ../scripts/+UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH

--- a/yarn-project/end-to-end/Earthfile
+++ b/yarn-project/end-to-end/Earthfile
@@ -182,25 +182,25 @@ bench-publish-rollup:
   ARG BRANCH
   ARG COMMIT_HASH
   DO +E2E_COMPOSE_TEST --test=benchmarks/bench_publish_rollup.test.ts --debug="aztec:benchmarks:*,aztec:sequencer,aztec:sequencer:*,aztec:world_state,aztec:merkle_trees" --compose_file=./scripts/docker-compose-no-sandbox.yml
-  DO ../scripts/+UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH
+  DO ../../+UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH
 
 bench-process-history:
   ARG PULL_REQUEST
   ARG BRANCH
   ARG COMMIT_HASH
   DO +E2E_COMPOSE_TEST --test=benchmarks/bench_process_history.test.ts --debug="aztec:benchmarks:*,aztec:sequencer,aztec:sequencer:*,aztec:world_state,aztec:merkle_trees" --compose_file=./scripts/docker-compose-no-sandbox.yml
-  DO ../scripts/+UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH
+  DO ../../+UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH
 
 bench-tx-size:
   ARG PULL_REQUEST
   ARG BRANCH
   ARG COMMIT_HASH
   DO +E2E_COMPOSE_TEST --test=benchmarks/bench_tx_size_fees.test.ts --debug="aztec:benchmarks:*,aztec:sequencer,aztec:sequencer:*,aztec:world_state,aztec:merkle_trees" --enable_gas=1 --compose_file=./scripts/docker-compose-no-sandbox.yml
-  DO ../scripts/+UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH
+  DO ../../+UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH
 
 bench-proving:
   ARG PULL_REQUEST
   ARG BRANCH
   ARG COMMIT_HASH
   DO +E2E_COMPOSE_TEST --test=bench_proving --debug="aztec:benchmarks:*,aztec:prover*,aztec:bb*" --enable_gas=1 --compose_file=./scripts/docker-compose-no-sandbox.yml
-  DO ../scripts/+UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH
+  DO ../../+UPLOAD_LOGS --PULL_REQUEST=$PULL_REQUEST --BRANCH=$BRANCH --COMMIT_HASH=$COMMIT_HASH

--- a/yarn-project/scripts/Earthfile
+++ b/yarn-project/scripts/Earthfile
@@ -91,4 +91,4 @@ base-log-uploader:
       unzip awscliv2.zip && \
       ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update && \
       rm -rf aws awscliv2.zip
-  COPY +scripts/scripts /usr/src/scripts
+  COPY ../../+scripts/scripts /usr/src/scripts

--- a/yarn-project/scripts/Earthfile
+++ b/yarn-project/scripts/Earthfile
@@ -67,28 +67,3 @@ bench-comment:
       && (cd /usr/src/yarn-project/scripts && AZTEC_BOT_COMMENTER_GITHUB_TOKEN=$AZTEC_BOT_COMMENTER_GITHUB_TOKEN yarn bench-comment) \
       || echo "No benchmark file found in $BENCH_FOLDER"
   
-UPLOAD_LOGS:
-  FUNCTION
-  ARG PULL_REQUEST
-  ARG BRANCH
-  ARG COMMIT_HASH
-  LOCALLY
-  LET COMMIT_HASH="${COMMIT_HASH:-$(git rev-parse HEAD)}"
-  FROM +base-log-uploader
-  COPY ./log /usr/var/log
-  ENV PULL_REQUEST=$PULL_REQUEST
-  ENV BRANCH=$BRANCH
-  ENV COMMIT_HASH=$COMMIT_HASH
-  RUN --secret AWS_ACCESS_KEY_ID --secret AWS_SECRET_ACCESS_KEY /usr/src/scripts/logs/upload_logs_to_s3.sh /usr/var/log
-
-base-log-uploader:
-  # Install awscli on a fresh ubuntu, and copy the repo "scripts" folder, which we'll use to upload logs
-  # Note that we cannot do this LOCALLY because Earthly does not support using secrets locally
-  FROM ubuntu:noble
-  RUN apt update && \
-      apt install -y curl git jq unzip
-  RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
-      unzip awscliv2.zip && \
-      ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update && \
-      rm -rf aws awscliv2.zip
-  COPY ../../+scripts/scripts /usr/src/scripts

--- a/yarn-project/scripts/Earthfile
+++ b/yarn-project/scripts/Earthfile
@@ -67,3 +67,28 @@ bench-comment:
       && (cd /usr/src/yarn-project/scripts && AZTEC_BOT_COMMENTER_GITHUB_TOKEN=$AZTEC_BOT_COMMENTER_GITHUB_TOKEN yarn bench-comment) \
       || echo "No benchmark file found in $BENCH_FOLDER"
   
+UPLOAD_LOGS:
+  FUNCTION
+  ARG PULL_REQUEST
+  ARG BRANCH
+  ARG COMMIT_HASH
+  LOCALLY
+  LET COMMIT_HASH="${COMMIT_HASH:-$(git rev-parse HEAD)}"
+  FROM +base-log-uploader
+  COPY ./log /usr/var/log
+  ENV PULL_REQUEST=$PULL_REQUEST
+  ENV BRANCH=$BRANCH
+  ENV COMMIT_HASH=$COMMIT_HASH
+  RUN --secret AWS_ACCESS_KEY_ID --secret AWS_SECRET_ACCESS_KEY /usr/src/scripts/logs/upload_logs_to_s3.sh /usr/var/log
+
+base-log-uploader:
+  # Install awscli on a fresh ubuntu, and copy the repo "scripts" folder, which we'll use to upload logs
+  # Note that we cannot do this LOCALLY because Earthly does not support using secrets locally
+  FROM ubuntu:noble
+  RUN apt update && \
+      apt install -y curl git jq unzip
+  RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
+      unzip awscliv2.zip && \
+      ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update && \
+      rm -rf aws awscliv2.zip
+  COPY +scripts/scripts /usr/src/scripts


### PR DESCRIPTION
I'm moving this function closer to the other logs-related targets as we're going to be uploading logs from non-e2e earthfiles in future.