### PR TITLE
fix: runs-on inconsistency, simplify concurrency keys, use capacity-optimized spot

### DIFF
--- a/.github/spot-runner-action/src/ec2.ts
+++ b/.github/spot-runner-action/src/ec2.ts
@@ -239,7 +239,7 @@ export class Ec2Instance {
       LaunchTemplateConfigs: [fleetLaunchConfig],
       ClientToken: this.config.clientToken || undefined,
       SpotOptions: {
-        AllocationStrategy: "price-capacity-optimized",
+        AllocationStrategy: "capacity-optimized",
       },
       TargetCapacitySpecification: {
         TotalTargetCapacity: 1,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         with: { ref: "${{ env.GIT_COMMIT }}" }
       - uses: ./.github/ci-setup-action
         with:
-          concurrency_key: build-${{ github.event.pull_request.user.login || github.actor }}-x86
+          concurrency_key: build-x86
       # prepare images locally, tagged by commit hash
       - name: "Build E2E Image"
         timeout-minutes: 40
@@ -131,7 +131,7 @@ jobs:
       - uses: ./.github/ci-setup-action
         with:
           dockerhub_password: "${{ secrets.DOCKERHUB_PASSWORD }}"
-          concurrency_key: build-${{ inputs.username || github.actor }}-x86
+          concurrency_key: build-x86
       - name: "Build and upload bench aggregate file"
         working-directory: ./yarn-project/scripts
         run: earthly-ci -P --secret AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} --secret AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} +bench-aggregate
@@ -156,7 +156,7 @@ jobs:
         with: { ref: "${{ env.GIT_COMMIT }}" }
       - uses: ./.github/ci-setup-action
         with:
-          concurrency_key: noir-format-${{ github.event.pull_request.user.login || github.actor }}-x86
+          concurrency_key: noir-format-x86
       - name: "Format Noir"
         working-directory: ./noir/
         timeout-minutes: 25
@@ -178,7 +178,7 @@ jobs:
       - uses: ./.github/ci-setup-action
         with:
           # must be globally unique for build x runner
-          concurrency_key: bb-native-tests-${{ github.event.pull_request.user.login || github.actor }}-x86
+          concurrency_key: bb-native-tests-x86
       - name: "Native Prover Tests"
         working-directory: ./barretenberg/cpp/
         timeout-minutes: 35
@@ -187,13 +187,13 @@ jobs:
 
   bb-js-test:
     needs: setup
-    runs-on: ${{ github.actor }}-x86
+    runs-on: ${{ github.event.pull_request.user.login || github.actor }}-x86
     steps:
       - uses: actions/checkout@v4
         with: { ref: "${{ env.GIT_COMMIT }}" }
       - uses: ./.github/ci-setup-action
         with:
-          concurrency_key: bb-js-test-${{ github.actor }}-x86
+          concurrency_key: bb-js-test-x86
       - name: "bb.js Tests"
         working-directory: ./barretenberg/ts/
         timeout-minutes: 25
@@ -207,7 +207,7 @@ jobs:
         with: { ref: "${{ env.GIT_COMMIT }}" }
       - uses: ./.github/ci-setup-action
         with:
-          concurrency_key: noir-${{ github.event.pull_request.user.login || github.actor }}-x86
+          concurrency_key: noir-x86
       - name: "Test Noir JS packages"
         run: earthly-ci --no-output ./noir+test
 
@@ -219,7 +219,7 @@ jobs:
         with: { ref: "${{ env.GIT_COMMIT }}" }
       - uses: ./.github/ci-setup-action
         with:
-          concurrency_key: noir-packages-${{ github.event.pull_request.user.login || github.actor }}-x86
+          concurrency_key: noir-packages-x86
       - name: "Test Noir JS packages"
         run: earthly-ci --no-output ./noir+packages-test
 
@@ -231,21 +231,21 @@ jobs:
         with: { ref: "${{ env.GIT_COMMIT }}" }
       - uses: ./.github/ci-setup-action
         with:
-          concurrency_key: noir-projects-${{ github.event.pull_request.user.login || github.actor }}-x86
+          concurrency_key: noir-projects-x86
       - name: "Noir Projects"
         timeout-minutes: 25
         run: earthly-ci --no-output ./noir-projects/+test
 
   yarn-project-formatting:
     needs: noir-projects
-    runs-on: ${{ github.actor }}-x86
+    runs-on: ${{ github.event.pull_request.user.login || github.actor }}-x86
     steps:
       - uses: actions/checkout@v4
         with: { ref: "${{ env.GIT_COMMIT }}" }
       # Only allow one memory-hunger prover test to use this runner
       - uses: ./.github/ci-setup-action
         with:
-          concurrency_key: yarn-project-formatting-${{ github.actor }}-x86
+          concurrency_key: yarn-project-formatting-x86
       - name: "Yarn Project Tests"
         timeout-minutes: 25
         run: earthly-ci --no-output ./yarn-project/+format-check
@@ -253,53 +253,53 @@ jobs:
   yarn-project-test:
     # quiet machine
     needs: [noir-projects, build, bb-native-tests]
-    runs-on: ${{ github.actor }}-x86
+    runs-on: ${{ github.event.pull_request.user.login || github.actor }}-x86
     steps:
       - uses: actions/checkout@v4
         with: { ref: "${{ env.GIT_COMMIT }}" }
       # Only allow one memory-hunger prover test to use this runner
       - uses: ./.github/ci-setup-action
         with:
-          concurrency_key: yarn-project-test-${{ github.actor }}-x86
+          concurrency_key: yarn-project-test-x86
       - name: "Yarn Project Tests"
         timeout-minutes: 30
         run: earthly-ci --no-output ./yarn-project/+test
 
   prover-client-test:
     needs: noir-projects
-    runs-on: ${{ github.actor }}-x86
+    runs-on: ${{ github.event.pull_request.user.login || github.actor }}-x86
     steps:
       - uses: actions/checkout@v4
         with: { ref: "${{ env.GIT_COMMIT }}" }
       - uses: ./.github/ci-setup-action
         with:
-          concurrency_key: prover-client-test-${{ github.actor }}-x86
+          concurrency_key: prover-client-test-x86
       - name: "Prover Client Tests"
         timeout-minutes: 35
         run: earthly-ci --no-output ./yarn-project/+prover-client-test
 
   build-acir-tests:
     needs: build
-    runs-on: ${{ github.actor }}-x86
+    runs-on: ${{ github.event.pull_request.user.login || github.actor }}-x86
     steps:
       - uses: actions/checkout@v4
         with: { ref: "${{ env.GIT_COMMIT }}" }
       - uses: ./.github/ci-setup-action
         with:
-          concurrency_key: build-acir-tests-${{ github.actor }}-x86
+          concurrency_key: build-acir-tests-x86
       - name: "Build Acir Tests"
         timeout-minutes: 25
         run: earthly-ci --no-output ./noir/+build-acir-tests
 
   barretenberg-acir-tests-bb:
     needs: build-acir-tests
-    runs-on: ${{ github.actor }}-x86
+    runs-on: ${{ github.event.pull_request.user.login || github.actor }}-x86
     steps:
       - uses: actions/checkout@v4
         with: { ref: "${{ env.GIT_COMMIT }}" }
       - uses: ./.github/ci-setup-action
         with:
-          concurrency_key: barretenberg-acir-tests-bb-${{ github.actor }}-x86
+          concurrency_key: barretenberg-acir-tests-bb-x86
       - name: "BB Native Acir Tests"
         working-directory: ./noir/
         timeout-minutes: 25
@@ -307,13 +307,13 @@ jobs:
 
   barretenberg-acir-tests-sol:
     needs: build-acir-tests
-    runs-on: ${{ github.actor }}-x86
+    runs-on: ${{ github.event.pull_request.user.login || github.actor }}-x86
     steps:
       - uses: actions/checkout@v4
         with: { ref: "${{ env.GIT_COMMIT }}" }
       - uses: ./.github/ci-setup-action
         with:
-          concurrency_key: barretenberg-acir-tests-sol-${{ github.actor }}-x86
+          concurrency_key: barretenberg-acir-tests-sol-x86
       - name: "BB Solidity Acir Tests"
         working-directory: ./noir/
         timeout-minutes: 25
@@ -321,13 +321,13 @@ jobs:
 
   barretenberg-acir-tests-bb-js:
     needs: build-acir-tests
-    runs-on: ${{ github.actor }}-x86
+    runs-on: ${{ github.event.pull_request.user.login || github.actor }}-x86
     steps:
       - uses: actions/checkout@v4
         with: { ref: "${{ env.GIT_COMMIT }}" }
       - uses: ./.github/ci-setup-action
         with:
-          concurrency_key: barretenberg-acir-tests-bb-js-${{ github.actor }}-x86
+          concurrency_key: barretenberg-acir-tests-bb-js-x86
       - name: "BB JS Acir Tests"
         working-directory: ./noir/
         timeout-minutes: 25
@@ -342,7 +342,7 @@ jobs:
         with: { ref: "${{ env.GIT_COMMIT }}" }
       - uses: ./.github/ci-setup-action
         with:
-          concurrency_key: docs-preview-${{ github.event.pull_request.user.login || github.actor }}-x86
+          concurrency_key: docs-preview-x86
       - name: "Docs Preview"
         timeout-minutes: 30
         run: earthly-ci --no-output ./docs/+deploy-preview --PR=${{ github.event.number }} --AZTEC_BOT_COMMENTER_GITHUB_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }} --NETLIFY_AUTH_TOKEN=${{ secrets.NETLIFY_AUTH_TOKEN }} --NETLIFY_SITE_ID=${{ secrets.NETLIFY_SITE_ID }}
@@ -382,7 +382,7 @@ jobs:
       # Only allow one memory-hunger prover test to use this runner
       - uses: ./.github/ci-setup-action
         with:
-          concurrency_key: protocol-circuits-gates-report-${{ github.event.pull_request.user.login || github.actor }}-x86
+          concurrency_key: protocol-circuits-gates-report-x86
       - name: "Noir Protocol Circuits Report"
         working-directory: ./noir-projects/
         timeout-minutes: 25


### PR DESCRIPTION
concurrency keys are just local file locks so don't need a global name
Also changes spot strategy to capacity-optimized to try and stem evicts before a robust solution