### PR TITLE
chore(ci): don't run multiple spot if ssh fails

### DIFF
--- a/.github/spot-runner-action/src/main.ts
+++ b/.github/spot-runner-action/src/main.ts
@@ -88,9 +88,11 @@ async function requestAndWaitForSpot(config: ActionConfig): Promise<string> {
       // wait 10 seconds
       await new Promise((r) => setTimeout(r, 5000 * 2 ** backoff));
       backoff += 1;
+      core.info("Polling to see if we somehow have an instance up");
+      instanceId = await ec2Client.getInstancesForTags("running")[0]?.instanceId;
     }
     if (instanceId) {
-      core.info("Successfully requested instance with ID " + instanceId);
+      core.info("Successfully requested/found instance with ID " + instanceId);
       break;
     }
   }


### PR DESCRIPTION
This was an oversight, add a slightly longer timeout and don't create multiple in this case