### PR TITLE
chore: fix migration notes

### DIFF
--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -8,7 +8,7 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 
 ## TBD
 
-### [Aztec.nr] Keys: Token note now stores an owner master nullifying public key hash instead of an owner address.
+### [Aztec.nr] Keys: Token note now stores an owner master nullifying public key hash instead of an owner address
 
 i.e.
 
@@ -22,6 +22,8 @@ struct TokenNote \{
 \}
 
 Computing the nullifier similarly changes to use this master nullifying public key hash.
+
+## 0.40.0
 
 ### [Aztec.nr] Debug logging
 


### PR DESCRIPTION
Naming one version was missed.
