### PR TITLE
chore(ci): more spot retry

### DIFF
--- a/.github/spot-runner-action/src/main.ts
+++ b/.github/spot-runner-action/src/main.ts
@@ -88,8 +88,10 @@ async function requestAndWaitForSpot(config: ActionConfig): Promise<string> {
       // wait 10 seconds
       await new Promise((r) => setTimeout(r, 5000 * 2 ** backoff));
       backoff += 1;
-      core.info("Polling to see if we somehow have an instance up");
-      instanceId = await ec2Client.getInstancesForTags("running")[0]?.instanceId;
+      if (config.githubActionRunnerConcurrency > 0) {
+        core.info("Polling to see if we somehow have an instance up");
+        instanceId = await ec2Client.getInstancesForTags("running")[0]?.instanceId;
+      }
     }
     if (instanceId) {
       core.info("Successfully requested/found instance with ID " + instanceId);

--- a/.github/spot-runner-action/src/main.ts
+++ b/.github/spot-runner-action/src/main.ts
@@ -63,7 +63,7 @@ async function requestAndWaitForSpot(config: ActionConfig): Promise<string> {
   for (const ec2Strategy of ec2SpotStrategies) {
     let backoff = 0;
     core.info(`Starting instance with ${ec2Strategy} strategy`);
-    const MAX_ATTEMPTS = 3; // uses exponential backoff
+    const MAX_ATTEMPTS = 5; // uses exponential backoff
     for (let i = 0; i < MAX_ATTEMPTS; i++) {
       // Start instance
       const instanceIdOrError =


### PR DESCRIPTION
https://github.com/AztecProtocol/aztec-packages/actions/runs/9116396206 this build https://github.com/AztecProtocol/aztec-packages/actions/runs/9116396206/job/25065337404 only waited 35 seconds total for conditions to clear, use 190 seconds total

also don't look for an instance by the tag if running a tester