### PR TITLE
chore: switch over to constructing gates report in bash

### DIFF
--- a/noir-projects/Earthfile
+++ b/noir-projects/Earthfile
@@ -44,10 +44,12 @@ format:
 
 gates-report:
   FROM +build
-  WORKDIR /usr/src/noir-projects/noir-protocol-circuits
+  WORKDIR /usr/src/noir-projects
 
+  COPY ./gates_report.sh ./gates_report.sh
   COPY ../barretenberg/cpp/+preset-clang-assert/bin/bb /usr/src/barretenberg/cpp/build/bin/bb
 
-  RUN  NARGO_BACKEND_PATH=/usr/src/barretenberg/cpp/build/bin/bb nargo info --json > gates_report.json
+  ENV BB_BIN /usr/src/barretenberg/cpp/build/bin/bb
+  RUN ./gates_report.sh
    
-  SAVE ARTIFACT gates_report.json gates_report.json
+  SAVE ARTIFACT ./noir-protocol-circuits/gates_report.json gates_report.json

--- a/noir-projects/gates_report.sh
+++ b/noir-projects/gates_report.sh
@@ -5,27 +5,23 @@ set -eu
 # The script needs some slight updating as `nargo info` expects a complete JSON object, while this script expects a single object field
 # representing a list of circuit reports for a program. 
 # The ACIR tests in barretenberg also expect every target bytecode to have the name `acir.gz` while this script expects the same name of the package
-echo "Compile noir-protocol-circuits for gates report..."
 cd noir-protocol-circuits
 PROTOCOL_CIRCUITS_DIR=$PWD
-
-# Compile programs into artifacts that the backend expects
-NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
-$NARGO compile --only-acir
 
 BB_BIN=${BB_BIN:-../../barretenberg/cpp/build/bin/bb}
 
 echo "{\"programs\": [" > gates_report.json
 
 # Bound for checking where to place last parentheses 
-NUM_ARTIFACTS=$(ls -1q "$PROTOCOL_CIRCUITS_DIR/target"/*.gz | wc -l)
+NUM_ARTIFACTS=$(ls -1q "$PROTOCOL_CIRCUITS_DIR/target"/*.json | wc -l)
 
 ITER="1"
-for pathname in "$PROTOCOL_CIRCUITS_DIR/target"/*.gz; do    
-    ARTIFACT_NAME=$(basename -s .gz "$pathname")
+for pathname in "$PROTOCOL_CIRCUITS_DIR/target"/*.json; do    
+    ARTIFACT_NAME=$(basename -s .json "$pathname")
 
-    echo "{\"package_name\": \"$ARTIFACT_NAME\"," >> gates_report.json
-    $BB_BIN gates -b "./target/$ARTIFACT_NAME.gz" >> gates_report.json
+    GATES_INFO=$($BB_BIN gates -b "./target/$ARTIFACT_NAME.json")
+    MAIN_FUNCTION_INFO=$(echo $GATES_INFO | jq -r '.functions[0] | .name = "main"')
+    echo "{\"package_name\": \"$ARTIFACT_NAME\", \"functions\": [$MAIN_FUNCTION_INFO]" >> gates_report.json
 
     if (($ITER == $NUM_ARTIFACTS)); then
         echo "}" >> gates_report.json


### PR DESCRIPTION
This PR switches us over to using `gates_report.sh` rather than `nargo info`