### PR TITLE
fix: Disable buggy ClientIVC tests

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -119,7 +119,7 @@ TEST_F(ClientIVCTests, BasicFailure)
  * @brief Prove and verify accumulation of an arbitrary set of circuits
  *
  */
-TEST_F(ClientIVCTests, BasicLarge)
+TEST_F(ClientIVCTests, DISABLED_BasicLarge)
 {
     ClientIVC ivc;
 
@@ -142,7 +142,7 @@ TEST_F(ClientIVCTests, BasicLarge)
  * @brief Using a structured trace allows for the accumulation of circuits of varying size
  *
  */
-TEST_F(ClientIVCTests, BasicStructured)
+TEST_F(ClientIVCTests, DISABLED_BasicStructured)
 {
     ClientIVC ivc;
     ivc.structured_flag = true;


### PR DESCRIPTION
Tests that had been disabled were replaced by #6429. Two of those tests now fail intermittently and will be fixed by the upcoming series of work #6391 and #6388. 