### PR TITLE
chore: prefetch noir deps in earthly for caching

### DIFF
--- a/noir/Earthfile
+++ b/noir/Earthfile
@@ -18,6 +18,9 @@ nargo-src:
       noir-repo/.github \
       noir-repo
 
+    # Fetch any dependencies so that they can be cached
+    RUN cd noir-repo && cargo fetch
+
     # NOTE: we use a fake commit hash here
     # we don't want Noir to rebuild everytime the parent repo changes
     # just only when it changes

--- a/noir/Earthfile
+++ b/noir/Earthfile
@@ -19,7 +19,7 @@ nargo-src:
       noir-repo
 
     # Fetch any dependencies so that they can be cached
-    RUN cd noir-repo && cargo fetch
+    RUN cd noir-repo && cargo fetch && cd ../
 
     # NOTE: we use a fake commit hash here
     # we don't want Noir to rebuild everytime the parent repo changes


### PR DESCRIPTION
This is a small optimisation to compilation of nargo in earthly by downloading any dependencies before we get further into the compilation.