### PR TITLE
chore: stop building/publishing `acvm_backend.wasm`

### DIFF
--- a/.github/workflows/publish-bb.yml
+++ b/.github/workflows/publish-bb.yml
@@ -113,10 +113,6 @@ jobs:
         working-directory: barretenberg/cpp/build-wasm/bin
         run: tar -cvzf barretenberg.wasm.tar.gz barretenberg.wasm
 
-      - name: Tar and GZip acvm_backend.wasm
-        working-directory: barretenberg/cpp/build-wasm/bin
-        run: tar -cvzf acvm_backend.wasm.tar.gz acvm_backend.wasm
-
       # - name: Setup Node.js
       #   uses: actions/setup-node@v2
       #   with:
@@ -137,7 +133,6 @@ jobs:
           name: release-wasm
           path: |
             ./barretenberg/cpp/build-wasm/bin/barretenberg.wasm.tar.gz
-            ./barretenberg/cpp/build-wasm/bin/acvm_backend.wasm.tar.gz
 
   build-mac-intel:
     name: Build on Mac x86_64-apple-darwin
@@ -239,7 +234,6 @@ jobs:
           prerelease: true
           files: |
             barretenberg.wasm.tar.gz
-            acvm_backend.wasm.tar.gz
             barretenberg-x86_64-linux-gnu.tar.gz
             barretenberg-x86_64-apple-darwin.tar.gz
             barretenberg-aarch64-apple-darwin.tar.gz

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -480,7 +480,6 @@
       "jobs": 0,
       "targets": [
         "barretenberg.wasm",
-        "acvm_backend.wasm",
         "barretenberg",
         "wasi",
         "env"

--- a/barretenberg/cpp/src/CMakeLists.txt
+++ b/barretenberg/cpp/src/CMakeLists.txt
@@ -174,30 +174,10 @@ if(WASM)
         $<TARGET_OBJECTS:wasi_objects>
     )
 
-    add_executable(
-        acvm_backend.wasm
-        $<TARGET_OBJECTS:wasi_objects>
-        $<TARGET_OBJECTS:env_objects>
-        $<TARGET_OBJECTS:common_objects>
-        $<TARGET_OBJECTS:numeric_objects>
-        $<TARGET_OBJECTS:ecc_objects>
-        $<TARGET_OBJECTS:crypto_aes128_objects>
-        $<TARGET_OBJECTS:crypto_blake2s_objects>
-        $<TARGET_OBJECTS:crypto_keccak_objects>
-        $<TARGET_OBJECTS:crypto_schnorr_objects>
-        $<TARGET_OBJECTS:crypto_pedersen_hash_objects>
-        $<TARGET_OBJECTS:crypto_pedersen_commitment_objects>
-    )
-
     target_link_options(
         barretenberg.wasm
         PRIVATE
         -nostartfiles -Wl,--no-entry,--export-dynamic
     )
 
-    target_link_options(
-        acvm_backend.wasm
-        PRIVATE
-        -nostartfiles -Wl,--no-entry,--export-dynamic
-    )
 endif()


### PR DESCRIPTION
Noir no longer makes use of this wasm binary so we don't need to keep building/publishing it.

Resolves https://github.com/AztecProtocol/aztec-packages/issues/1832