### PR TITLE
chore(ci): don't fail creating launch template

### DIFF
--- a/.github/spot-runner-action/src/ec2.ts
+++ b/.github/spot-runner-action/src/ec2.ts
@@ -219,7 +219,7 @@ export class Ec2Instance {
         // Ignore if it is already created
         return launchTemplateName;
       }
-      throw error;
+      core.warning("Ignoring:" + JSON.stringify(error));
     }
     return launchTemplateName;
   }


### PR DESCRIPTION
This is mostly ensuring it was created, don't fail