### PR TITLE
chore(ci): fix running out of disk

### DIFF
--- a/.github/ensure-builder/action.yml
+++ b/.github/ensure-builder/action.yml
@@ -25,7 +25,7 @@ runs:
         echo "runner_label=$USERNAME-$runner_type" >> $GITHUB_OUTPUT
         if [[ $TYPE == builder-x86 ]]; then
           # 128-core x86 instance types, aws chooses for us based on capacity
-          echo "instance_type=m6a.32xlarge m6i.32xlarge m6in.32xlarge m7a.32xlarge r6a.32xlarge r6i.32xlarge r6in.32xlarge r7iz.32xlarge" >> $GITHUB_OUTPUT
+          echo "instance_type=m6a.32xlarge m6i.32xlarge m6in.32xlarge m7a.32xlarge r6a.32xlarge r6i.32xlarge r6in.32xlarge" >> $GITHUB_OUTPUT
           echo "ami_id=ami-04d8422a9ba4de80f" >> $GITHUB_OUTPUT
           echo "ebs_cache_size=256" >> $GITHUB_OUTPUT
           echo "runner_concurrency=20" >> $GITHUB_OUTPUT

--- a/.github/ensure-tester/action.yml
+++ b/.github/ensure-tester/action.yml
@@ -38,7 +38,7 @@ runs:
         elif [[ $TYPE == 128core-* ]]; then
           SIZE=32xlarge
         fi
-        echo "instance_type=i4i.$SIZE m6a.$SIZE m6i.$SIZE m6id.$SIZE m6idn.$SIZE m6in.$SIZE m7a.$SIZE r6a.$SIZE r6i.$SIZE r6id.$SIZE r6in.$SIZE r7iz.$SIZE" >> $GITHUB_OUTPUT
+        echo "instance_type=m6a.$SIZE m6in.$SIZE r6a.$SIZE r6i.$SIZE r6in.$SIZE" >> $GITHUB_OUTPUT
 
     - name: Start Tester
       uses: ./.github/spot-runner-action

--- a/.github/spot-runner-action/src/ec2.ts
+++ b/.github/spot-runner-action/src/ec2.ts
@@ -198,7 +198,7 @@ export class Ec2Instance {
           {
             DeviceName: "/dev/sda1",
             Ebs: {
-              VolumeSize: 32,
+              VolumeSize: 64,
               VolumeType: 'gp3',
               Throughput: 1000,
               Iops: 5000


### PR DESCRIPTION
These runner folders can take up a bunch of room
Also drop some expensive instance types