### PR TITLE
chore: Fix benchmark comparison with master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,10 +148,10 @@ jobs:
               --secret AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
               --secret AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
               --no-output \
-              +bench-publish-acir-bb         
+              +bench-publish-acir-bb
 
   bench-summary:
-    needs: 
+    needs:
       - acir-bench
       - bench-e2e
     runs-on: ${{ inputs.username || github.actor }}-x86
@@ -178,7 +178,7 @@ jobs:
           mkdir -p $BENCH_FOLDER
           ./scripts/logs/download_base_benchmark_from_s3.sh
           # Package it into an earthly artifact to read from bench-comment
-          earthly-ci -P ./scripts/logs+pack-base-benchmark --LOCAL_BENCH_FOLDER=./tmp/bench
+          earthly-ci -P ./scripts/logs+pack-base-benchmark
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/scripts/logs/Earthfile
+++ b/scripts/logs/Earthfile
@@ -12,8 +12,8 @@ pack-base-benchmark:
   # the cache of yarn-project+build since it does a `COPY . .`, and we cannot add the bench file to
   # earthlyignore or we would not be able to copy it from anywhere. So we need to place this target
   # outside yarn-project altogether, since that folder should not be modified.
-  ARG LOCAL_BENCH_FOLDER
   FROM scratch
+  LET LOCAL_BENCH_FOLDER=./tmp/bench
   LET BENCH_FOLDER=/usr/var/bench
   COPY $LOCAL_BENCH_FOLDER $BENCH_FOLDER
   SAVE ARTIFACT $BENCH_FOLDER bench


### PR DESCRIPTION
The base benchmark from master was being downloaded, but not picked up by the bench-comment job. This is an attempt to fix that.
