### PR TITLE
chore(ci): automatically retry from failed once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,9 +522,15 @@ jobs:
         env:
           # We treat any skipped or failing jobs as a failure for the workflow as a whole.
           FAIL: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [[ $FAIL == true ]]; then
               echo "At least one job failed (or skipped/cancelled), merging not allowed."
+              if [[ $RUN_ATTEMPT -lt 2 ]] ; then
+                echo "Retrying first workflow failure. This is a stop-gap until things are more stable."
+                gh workflow run rerun.yml -F run_id=${{ github.run_id }}
+              fi
               exit 1
           else
               echo "All jobs succeeded, merge allowed."

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,0 +1,18 @@
+# from https://github.com/orgs/community/discussions/67654
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        required: true
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: rerun ${{ inputs.run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run_id }} --failed


### PR DESCRIPTION
This is a stopgap until resources can be put into making the situation more stable

Copied from https://github.com/orgs/community/discussions/67654
I think exporting GITHUB_TOKEN and GITHUB_REPO is unnecessary but I rather copy paste something I know works right now
