### PR TITLE
chore(ci): more spot retry

### DIFF
--- a/.github/spot-runner-action/src/main.ts
+++ b/.github/spot-runner-action/src/main.ts
@@ -63,7 +63,7 @@ async function requestAndWaitForSpot(config: ActionConfig): Promise<string> {
   for (const ec2Strategy of ec2SpotStrategies) {
     let backoff = 0;
     core.info(`Starting instance with ${ec2Strategy} strategy`);
-    const MAX_ATTEMPTS = 3; // uses exponential backoff
+    const MAX_ATTEMPTS = 6; // uses exponential backoff
     for (let i = 0; i < MAX_ATTEMPTS; i++) {
       // Start instance
       const instanceIdOrError =


### PR DESCRIPTION
We were not getting an instance when requested
We should move away from instant createfleet likely but this is a short term fix