### PR TITLE
feat!: try out unconstrained wrapper

### DIFF
--- a/noir-projects/aztec-nr/Nargo.toml
+++ b/noir-projects/aztec-nr/Nargo.toml
@@ -6,5 +6,6 @@ members = [
   "compressed-string",
   "easy-private-state",
   "value-note",
+  "unsafe",
   "tests",
 ]

--- a/noir-projects/aztec-nr/aztec/Nargo.toml
+++ b/noir-projects/aztec-nr/aztec/Nargo.toml
@@ -6,3 +6,4 @@ type = "lib"
 
 [dependencies]
 protocol_types = { path = "../../noir-protocol-circuits/crates/types" }
+unsafe = { path = "../unsafe" }

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
@@ -1,4 +1,5 @@
 use dep::protocol_types::{constants::{MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, GET_NOTES_ORACLE_RETURN_LENGTH}};
+use dep::unsafe::Unconstrained;
 use crate::context::PrivateContext;
 use crate::note::{
     constants::{GET_NOTE_ORACLE_RETURN_LENGTH, MAX_NOTES_PER_PAGE, VIEW_NOTE_ORACLE_RETURN_LENGTH},
@@ -88,14 +89,16 @@ pub fn get_note<Note, N, M>(
     context: &mut PrivateContext,
     storage_slot: Field
 ) -> Note where Note: NoteInterface<N, M> {
-    let note = get_note_internal(storage_slot);
+    let unsafe_note = get_note_internal(storage_slot);
+    unsafe_note.make_constrained(
+        |note| {
+        check_note_header(*context, storage_slot, note);
+        let note_hash_for_read_request = compute_note_hash_for_read_request(note);
+        context.push_note_hash_read_request(note_hash_for_read_request);
 
-    check_note_header(*context, storage_slot, note);
-
-    let note_hash_for_read_request = compute_note_hash_for_read_request(note);
-
-    context.push_note_hash_read_request(note_hash_for_read_request);
-    note
+        note
+    }
+    )
 }
 
 pub fn get_notes<Note, N, M, FILTER_ARGS>(
@@ -103,9 +106,15 @@ pub fn get_notes<Note, N, M, FILTER_ARGS>(
     storage_slot: Field,
     options: NoteGetterOptions<Note, N, M, FILTER_ARGS>
 ) -> [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] where Note: NoteInterface<N, M> {
-    let opt_notes = get_notes_internal(storage_slot, options);
+    get_notes_internal(storage_slot, options).make_constrained(
+        |opt_notes| {
+            let filter = options.filter;
+            let filter_args = options.filter_args;
+            let filtered = filter(opt_notes, filter_args);
 
-    _get_notes_constrain_get_notes_internal(context, storage_slot, opt_notes, options)
+            _get_notes_constrain_get_notes_internal(context, storage_slot, filtered, options)
+        }
+    )
 }
 
 pub fn _get_notes_constrain_get_notes_internal<Note, N, M, FILTER_ARGS>(
@@ -150,10 +159,11 @@ pub fn _get_notes_constrain_get_notes_internal<Note, N, M, FILTER_ARGS>(
     returned_notes
 }
 
-unconstrained fn get_note_internal<Note, N, M>(storage_slot: Field) -> Note where Note: NoteInterface<N, M> {
+unconstrained fn get_note_internal<Note, N, M>(storage_slot: Field) -> Unconstrained<Note> where Note: NoteInterface<N, M> {
     let placeholder_note = [Option::none()];
     let placeholder_fields = [0; GET_NOTE_ORACLE_RETURN_LENGTH];
     let placeholder_note_length = [0; N];
+
     oracle::notes::get_notes(
         storage_slot,
         0,
@@ -172,50 +182,21 @@ unconstrained fn get_note_internal<Note, N, M>(storage_slot: Field) -> Note wher
         placeholder_note,
         placeholder_fields,
         placeholder_note_length
-    )[0].unwrap() // Notice: we don't allow dummies to be returned from get_note (singular).
+    ).transform(
+        |opt_notes: [Option<Note>; 1]|
+        opt_notes[0].unwrap() // Notice: we don't allow dummies to be returned from get_note (singular)
+    )
 }
 
 unconstrained fn get_notes_internal<Note, N, M, FILTER_ARGS>(
     storage_slot: Field,
     options: NoteGetterOptions<Note, N, M, FILTER_ARGS>
-) -> [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] where Note: NoteInterface<N, M> {
+) -> Unconstrained<[Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL]> where Note: NoteInterface<N, M> {
     let (num_selects, select_by_indexes, select_by_offsets, select_by_lengths, select_values, select_comparators, sort_by_indexes, sort_by_offsets, sort_by_lengths, sort_order) = flatten_options(options.selects, options.sorts);
     let placeholder_opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
     let placeholder_fields = [0; GET_NOTES_ORACLE_RETURN_LENGTH];
     let placeholder_note_length = [0; N];
-    let opt_notes = oracle::notes::get_notes(
-        storage_slot,
-        num_selects,
-        select_by_indexes,
-        select_by_offsets,
-        select_by_lengths,
-        select_values,
-        select_comparators,
-        sort_by_indexes,
-        sort_by_offsets,
-        sort_by_lengths,
-        sort_order,
-        options.limit,
-        options.offset,
-        options.status,
-        placeholder_opt_notes,
-        placeholder_fields,
-        placeholder_note_length
-    );
 
-    let filter = options.filter;
-    let filter_args = options.filter_args;
-    filter(opt_notes, filter_args)
-}
-
-unconstrained pub fn view_notes<Note, N, M>(
-    storage_slot: Field,
-    options: NoteViewerOptions<Note, N, M>
-) -> [Option<Note>; MAX_NOTES_PER_PAGE] where Note: NoteInterface<N, M> {
-    let (num_selects, select_by_indexes, select_by_offsets, select_by_lengths, select_values, select_comparators, sort_by_indexes, sort_by_offsets, sort_by_lengths, sort_order) = flatten_options(options.selects, options.sorts);
-    let placeholder_opt_notes = [Option::none(); MAX_NOTES_PER_PAGE];
-    let placeholder_fields = [0; VIEW_NOTE_ORACLE_RETURN_LENGTH];
-    let placeholder_note_length = [0; N];
     oracle::notes::get_notes(
         storage_slot,
         num_selects,
@@ -235,6 +216,36 @@ unconstrained pub fn view_notes<Note, N, M>(
         placeholder_fields,
         placeholder_note_length
     )
+}
+
+unconstrained pub fn view_notes<Note, N, M>(
+    storage_slot: Field,
+    options: NoteViewerOptions<Note, N, M>
+) -> [Option<Note>; MAX_NOTES_PER_PAGE] where Note: NoteInterface<N, M> {
+    let (num_selects, select_by_indexes, select_by_offsets, select_by_lengths, select_values, select_comparators, sort_by_indexes, sort_by_offsets, sort_by_lengths, sort_order) = flatten_options(options.selects, options.sorts);
+    let placeholder_opt_notes = [Option::none(); MAX_NOTES_PER_PAGE];
+    let placeholder_fields = [0; VIEW_NOTE_ORACLE_RETURN_LENGTH];
+    let placeholder_note_length = [0; N];
+
+    oracle::notes::get_notes(
+        storage_slot,
+        num_selects,
+        select_by_indexes,
+        select_by_offsets,
+        select_by_lengths,
+        select_values,
+        select_comparators,
+        sort_by_indexes,
+        sort_by_offsets,
+        sort_by_lengths,
+        sort_order,
+        options.limit,
+        options.offset,
+        options.status,
+        placeholder_opt_notes,
+        placeholder_fields,
+        placeholder_note_length
+    ).make_constrained(|opt_notes| opt_notes) // <- we're not constraining anything, but we don't want to pollute the API
 }
 
 unconstrained fn flatten_options<Note, N>(

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -1,6 +1,6 @@
 use crate::note::{note_header::NoteHeader, note_interface::NoteInterface};
-
 use dep::protocol_types::{address::AztecAddress, utils::arr_copy_slice};
+use dep::unsafe::Unconstrained;
 
 #[oracle(notifyCreatedNote)]
 fn notify_created_note_oracle<N>(
@@ -118,7 +118,7 @@ unconstrained pub fn get_notes<Note, N, NB, M, S, NS>(
     mut placeholder_opt_notes: [Option<Note>; S], // TODO: Remove it and use `limit` to initialize the note array.
     placeholder_fields: [Field; NS], // TODO: Remove it and use `limit` to initialize the note array.
     _placeholder_note_length: [Field; N] // Turbofish hack? Compiler breaks calculating read_offset unless we add this parameter
-) -> [Option<Note>; S] where Note: NoteInterface<N, NB> {
+) -> Unconstrained<[Option<Note>; S]> where Note: NoteInterface<N, NB> {
     let fields = get_notes_oracle_wrapper(
         storage_slot,
         num_selects,
@@ -154,7 +154,8 @@ unconstrained pub fn get_notes<Note, N, NB, M, S, NS>(
             placeholder_opt_notes[i] = Option::some(note);
         };
     }
-    placeholder_opt_notes
+
+    Unconstrained::new(placeholder_opt_notes)
 }
 
 // Only ever use this in private!

--- a/noir-projects/aztec-nr/unsafe/Nargo.toml
+++ b/noir-projects/aztec-nr/unsafe/Nargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "unsafe"
+authors = ["aztec-labs"]
+compiler_version = ">=0.18.0"
+type = "lib"

--- a/noir-projects/aztec-nr/unsafe/src/lib.nr
+++ b/noir-projects/aztec-nr/unsafe/src/lib.nr
@@ -1,0 +1,17 @@
+struct Unconstrained<T> {
+    _value: T,
+}
+
+impl<T> Unconstrained<T> {
+    fn new(value: T) -> Self {
+        Self { _value: value }
+    }
+
+    unconstrained fn transform<Env, T2>(self, transformer: fn[Env](T) -> T2) -> Unconstrained<T2> {
+        Unconstrained::new(transformer(self._value))
+    }
+
+    fn make_constrained<Env>(self, constrainer: fn[Env](T) -> T) -> T {
+        constrainer(self._value)
+    }
+}


### PR DESCRIPTION
This is an exploration of @TomAFrench's suggested alternative approach to https://github.com/noir-lang/noir/issues/4442, namely as mentioned in [this comment](https://github.com/noir-lang/noir/issues/4442#issuecomment-2122814832).

It adds the following small library:

```rust
struct Unconstrained<T> {
    _value: T,
}

impl<T> Unconstrained<T> {
    fn new(value: T) -> Self {
        Self { _value: value }
    }

    fn make_constrained<Env>(self, constrainer: fn[Env](T) -> T) -> T {
        constrainer(self._value)
    }
}
```

With it, we can wrap oracle return values as `Unconstrained<T>`, and make the constraining step explicit. This nicely detects the bug we currently have in `note_getter`, where the `filter` function is called in an unconstrained environment. The new pattern forces us to move this inside the `make_constrained` closure. Even if it didn't force the move, it'd at least clearly delineate which exactly are the constraints being applied.

## Unconstrained work

However, there's some issues. In some cases we perform some unconstrained computation, reducing circuit size. An example is `get_note_internal`, which reduces the array of `Option<Note>` to a single concrete `Note` which is later constrained.

A utility function lets us do this:

```rust
impl<T> Unconstrained<T> {
    unconstrained fn transform<Env, T2>(self, transformer: fn[Env](T) -> T2) -> Unconstrained<T2> {
        Unconstrained::new(transformer(self._value))
    }
}

fn get_note_internal(...) -> Note {
    oracle::notes::get_notes(...).transform(
        |opt_notes: [Option<Note>; 1]|
            opt_notes[0].unwrap()
    )
}
```

## Unconstrained API

The above was slightly annoying, but not unreasonable. The real issue is that our API also includes unconstrained functions (e.g. `view_notes`), which are in turn used by state variables in unconstrained contexts. Doing any kind of computation in these environments would require that we annotate all return values with `Unconstrained` and use `transform` whenever we use a value.

Moreover, all of these `transform` calls are ultimately unnecessary. We absolutely do not care what happens inside unconstrained functions: we only care about crossing the unconstrained <> constrained boundary. But because we cannot know _when_ an unconstrained value will be used, the only way to be sure a constrained caller will get a wrapped value is to make _all_ unconstrained functions return wrapped values and `transform` them as they go all the call stack.

**The only way I can see to solve this situation is with language support: we need something automatic that triggers when crossing domains.** This can be an `unsafe` block, automatic wrapping in `Unconstrained` when calling from a constrained function or some third alternative, but we cannot detect these problematic callsites in advance given current language tools.