### PR TITLE
fix: configurable ttl for test runners

### DIFF
--- a/.github/ensure-tester-with-images/action.yml
+++ b/.github/ensure-tester-with-images/action.yml
@@ -13,6 +13,10 @@ inputs:
     required: true
   run:
     required: true
+  tester_ttl:
+    required: false
+    description: "Time to live for the tester instance in minutes"
+    default: 30
 runs:
   # define an action, runs in OS of caller
   using: composite
@@ -55,6 +59,7 @@ runs:
       if: ${{ env.CACHE_SUCCESS != 'true' }}
       with:
         runner_type: ${{ inputs.runner_type}}
+        ttl: ${{ inputs.tester_ttl }}
         run: |
           set -eux
           export BUILDER_SPOT_IP=${{ env.BUILDER_SPOT_IP }}

--- a/.github/ensure-tester/action.yml
+++ b/.github/ensure-tester/action.yml
@@ -8,6 +8,11 @@ inputs:
   run:
     # command to run once tester available
     required: false
+
+  ttl:
+    required: false
+    description: "Time to live for the tester instance in minutes"
+    default: 30
 runs:
   # define an action, runs in OS of caller
   using: composite
@@ -23,7 +28,7 @@ runs:
         echo "ami_id=ami-04d8422a9ba4de80f" >> $GITHUB_OUTPUT
         # no github runners, 'bare spot' in action code
         echo "runner_concurrency=0" >> $GITHUB_OUTPUT
-        echo "ttl=30" >> $GITHUB_OUTPUT
+        echo "ttl=${{ inputs.ttl }}" >> $GITHUB_OUTPUT
         SIZE=large
         if [[ $TYPE == 4core-* ]]; then
           SIZE=large
@@ -50,7 +55,7 @@ runs:
         aws_access_key_id: ${{ env.AWS_ACCESS_KEY_ID }}
         aws_secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
         ec2_key: ${{ env.BUILD_INSTANCE_SSH_KEY }}
-        client_token: ''
+        client_token: ""
         # constants:
         runner_concurrency: ${{ steps.select_instance.outputs.runner_concurrency }}
         ec2_instance_type: ${{ steps.select_instance.outputs.instance_type }}
@@ -61,7 +66,7 @@ runs:
         ec2_subnet_id: subnet-4cfabd25
         ec2_security_group_id: sg-0ccd4e5df0dcca0c9
         ec2_key_name: "build-instance"
-        ec2_instance_tags: '[]'
+        ec2_instance_tags: "[]"
 
     # Set up a context for this run
     - name: Copy Repo to Tester

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,6 @@ jobs:
         with:
           runner_type: ${{ contains(matrix.test, 'prover') && '64core-tester-x86' || '16core-tester-x86' }}
           builder_type: builder-x86
-          tester_ttl: 40
           # these are copied to the tester and expected by the earthly command below
           # if they fail to copy, it will try to build them on the tester and fail
           builder_images_to_copy: aztecprotocol/aztec:${{ env.GIT_COMMIT }} aztecprotocol/end-to-end:${{ env.GIT_COMMIT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
         with:
           runner_type: ${{ contains(matrix.test, 'prover') && '64core-tester-x86' || '16core-tester-x86' }}
           builder_type: builder-x86
+          tester_ttl: 40
           # these are copied to the tester and expected by the earthly command below
           # if they fail to copy, it will try to build them on the tester and fail
           builder_images_to_copy: aztecprotocol/aztec:${{ env.GIT_COMMIT }} aztecprotocol/end-to-end:${{ env.GIT_COMMIT }}


### PR DESCRIPTION
Allow jobs to specify TTL for instances to prevent jobs from being cancelled by machines shutting down.
