### PR TITLE
chore: Reduce bench history from 10 to 5 blocks

### DIFF
--- a/yarn-project/circuit-types/src/stats/index.ts
+++ b/yarn-project/circuit-types/src/stats/index.ts
@@ -15,4 +15,4 @@ export const BENCHMARK_HISTORY_BLOCK_SIZE = process.env.BENCHMARK_HISTORY_BLOCK_
 /** Chain lengths to test for history processing benchmarks. */
 export const BENCHMARK_HISTORY_CHAIN_LENGTHS = process.env.BENCHMARK_HISTORY_CHAIN_LENGTHS
   ? process.env.BENCHMARK_HISTORY_CHAIN_LENGTHS.split(',').map(x => Number(x))
-  : [5, 10];
+  : [3, 5];


### PR DESCRIPTION
To reduce running time
