### PR TITLE
fix: Do not use kernel constants for computing tx fee

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -186,6 +186,7 @@ impl PrivateContext {
     }
 
     pub fn set_as_fee_payer(&mut self) {
+        dep::protocol_types::debug_log::debug_log_format("Setting {0} as fee payer", [self.this_address().to_field()]);
         self.is_fee_payer = true;
     }
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/base_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/base_rollup_inputs.nr
@@ -110,7 +110,8 @@ impl BaseRollupInputs {
         let protocol_public_data_update_requests = [self.build_payment_update_request()];
         let end_public_data_tree_snapshot = self.validate_and_process_public_state(protocol_public_data_update_requests);
 
-        let transaction_fee = self.kernel_data.public_inputs.compute_transaction_fee();
+        let gas_fees = self.constants.global_variables.gas_fees;
+        let transaction_fee = self.kernel_data.public_inputs.compute_transaction_fee(gas_fees);
 
         // Calculate the tx effects hash of the transaction
         let tx_effects_hash = compute_tx_effects_hash(
@@ -242,7 +243,8 @@ impl BaseRollupInputs {
             read_hint.validate(self.start.public_data_tree.root);
 
             // Compute tx fee to charge
-            let tx_fee = self.kernel_data.public_inputs.compute_transaction_fee();
+            let gas_fees = self.constants.global_variables.gas_fees;
+            let tx_fee = self.kernel_data.public_inputs.compute_transaction_fee(gas_fees);
             assert(!read_hint.value.lt(tx_fee), "Not enough balance for fee payer to pay for transaction");
 
             // Get slot for the fee payer balance

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/kernel_circuit_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_circuit_public_inputs/kernel_circuit_public_inputs.nr
@@ -1,7 +1,7 @@
 use crate::{
     abis::{
     accumulated_data::CombinedAccumulatedData, combined_constant_data::CombinedConstantData,
-    validation_requests::RollupValidationRequests, gas::Gas
+    validation_requests::RollupValidationRequests, gas::Gas, gas_fees::GasFees
 },
     address::AztecAddress, partial_state_reference::PartialStateReference,
     traits::{Empty, Eq, Serialize, Deserialize}, constants::KERNEL_CIRCUIT_PUBLIC_INPUTS_LENGTH,
@@ -18,8 +18,7 @@ struct KernelCircuitPublicInputs {
 }
 
 impl KernelCircuitPublicInputs {
-    pub fn compute_transaction_fee(self) -> Field {
-        let gas_fees = self.constants.global_variables.gas_fees;
+    pub fn compute_transaction_fee(self, gas_fees: GasFees) -> Field {
         let inclusion_fee = self.constants.tx_context.gas_settings.inclusion_fee;
         inclusion_fee + self.end.gas_used.compute_fee(gas_fees)
     }
@@ -95,7 +94,7 @@ mod tests {
     #[test]
     unconstrained fn empty_has_zero_gas_and_fee() {
         let empty = KernelCircuitPublicInputs::empty();
-        assert_eq(empty.compute_transaction_fee(), 0);
+        assert_eq(empty.compute_transaction_fee(GasFees::empty()), 0);
     }
 
     #[test]
@@ -116,12 +115,8 @@ mod tests {
 
         inputs.constants.tx_context.gas_settings.inclusion_fee = 42;
 
-        inputs.constants.global_variables.gas_fees = GasFees {
-            fee_per_da_gas: 2,
-            fee_per_l2_gas: 3
-        };
-
-        let transaction_fee = inputs.compute_transaction_fee();
+        let gas_fees = GasFees { fee_per_da_gas: 2, fee_per_l2_gas: 3 };
+        let transaction_fee = inputs.compute_transaction_fee(gas_fees);
         assert_eq(transaction_fee, 42 + 2 * 10 + 3 * 20);
     }
 

--- a/yarn-project/circuit-types/src/tx/processed_tx.ts
+++ b/yarn-project/circuit-types/src/tx/processed_tx.ts
@@ -10,6 +10,7 @@ import {
 import {
   Fr,
   type Gas,
+  type GasFees,
   type Header,
   KernelCircuitPublicInputs,
   type Proof,
@@ -175,10 +176,10 @@ export function makeEmptyProcessedTx(header: Header, chainId: Fr, version: Fr): 
   };
 }
 
-export function toTxEffect(tx: ProcessedTx): TxEffect {
+export function toTxEffect(tx: ProcessedTx, gasFees: GasFees): TxEffect {
   return new TxEffect(
     tx.data.revertCode,
-    tx.data.transactionFee,
+    tx.data.getTransactionFee(gasFees),
     tx.data.end.newNoteHashes.filter(h => !h.isZero()),
     tx.data.end.newNullifiers.filter(h => !h.isZero()),
     tx.data.end.newL2ToL1Msgs.filter(h => !h.isZero()),

--- a/yarn-project/circuit-types/src/tx/tx_receipt.ts
+++ b/yarn-project/circuit-types/src/tx/tx_receipt.ts
@@ -20,6 +20,8 @@ export enum TxStatus {
 /**
  * Represents a transaction receipt in the Aztec network.
  * Contains essential information about the transaction including its status, origin, and associated addresses.
+ * REFACTOR: TxReceipt should be returned only once the tx is mined, and all its fields should be required.
+ * We should not be using a TxReceipt to answer a query for a pending or dropped tx.
  */
 export class TxReceipt {
   constructor(

--- a/yarn-project/circuits.js/src/structs/kernel/kernel_circuit_public_inputs.test.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/kernel_circuit_public_inputs.test.ts
@@ -18,7 +18,7 @@ describe('KernelCircuitPublicInputs', () => {
   describe('Gas and Fees', () => {
     it('empty is empty', () => {
       const i = KernelCircuitPublicInputs.empty();
-      expect(i.transactionFee).toEqual(Fr.ZERO);
+      expect(i.getTransactionFee(GasFees.empty())).toEqual(Fr.ZERO);
     });
 
     it('non-empty is correct', () => {
@@ -46,9 +46,9 @@ describe('KernelCircuitPublicInputs', () => {
       );
 
       i.end.gasUsed = Gas.from({ daGas: 10, l2Gas: 20 });
-      i.constants.globalVariables.gasFees = GasFees.from({ feePerDaGas: new Fr(2), feePerL2Gas: new Fr(3) });
+      const gasFees = GasFees.from({ feePerDaGas: new Fr(2), feePerL2Gas: new Fr(3) });
 
-      expect(i.transactionFee).toEqual(new Fr(42 + 2 * 10 + 3 * 20));
+      expect(i.getTransactionFee(gasFees)).toEqual(new Fr(42 + 2 * 10 + 3 * 20));
     });
   });
 });

--- a/yarn-project/end-to-end/src/benchmarks/bench_tx_size_fees.test.ts
+++ b/yarn-project/end-to-end/src/benchmarks/bench_tx_size_fees.test.ts
@@ -57,7 +57,7 @@ describe('benchmarks/tx_size_fees', () => {
   });
 
   it.each<[string, () => FeePaymentMethod | undefined, bigint]>([
-    ['no', () => undefined, 0n],
+    ['no', () => undefined, 200021120n],
     // TODO(palla/gas): Fix and reenable
     // [
     //   'native fee',

--- a/yarn-project/end-to-end/src/e2e_counter_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_counter_contract.test.ts
@@ -25,8 +25,9 @@ describe('e2e_counter_contract', () => {
 
   describe('increments', () => {
     it('counts', async () => {
-      await counterContract.methods.increment(owner).send().wait();
+      const receipt = await counterContract.methods.increment(owner).send().wait();
       expect(await counterContract.methods.get_counter(owner).simulate()).toBe(1n);
+      expect(receipt.transactionFee).toBeGreaterThan(0n);
     });
   });
 });

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -253,8 +253,9 @@ export class ProvingOrchestrator {
     await validateRootOutput(rootRollupOutputs, this.db);
 
     // Collect all new nullifiers, commitments, and contracts from all txs in this block
+    const gasFees = this.provingState.globalVariables.gasFees;
     const nonEmptyTxEffects: TxEffect[] = this.provingState!.allTxs.map(txProvingState =>
-      toTxEffect(txProvingState.processedTx),
+      toTxEffect(txProvingState.processedTx, gasFees),
     ).filter(txEffect => !txEffect.isEmpty());
     const blockBody = new Body(nonEmptyTxEffects);
 

--- a/yarn-project/simulator/src/public/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor.test.ts
@@ -457,7 +457,7 @@ describe('public_processor', () => {
       expect(publicWorldStateDB.commit).toHaveBeenCalledTimes(1);
       expect(publicWorldStateDB.rollbackToCommit).toHaveBeenCalledTimes(0);
 
-      const txEffect = toTxEffect(processed[0]);
+      const txEffect = toTxEffect(processed[0], GasFees.default());
       expect(arrayNonEmptyLength(txEffect.publicDataWrites, PublicDataWrite.isEmpty)).toEqual(5);
       expect(txEffect.publicDataWrites[0]).toEqual(
         new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotA), fr(0x101)),
@@ -686,7 +686,7 @@ describe('public_processor', () => {
       expect(publicWorldStateDB.commit).toHaveBeenCalledTimes(1);
       expect(publicWorldStateDB.rollbackToCommit).toHaveBeenCalledTimes(0);
 
-      const txEffect = toTxEffect(processed[0]);
+      const txEffect = toTxEffect(processed[0], GasFees.default());
       expect(arrayNonEmptyLength(txEffect.publicDataWrites, PublicDataWrite.isEmpty)).toEqual(2);
       expect(txEffect.publicDataWrites[0]).toEqual(
         new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotA), fr(0x102)),
@@ -809,7 +809,7 @@ describe('public_processor', () => {
       expect(publicWorldStateDB.commit).toHaveBeenCalledTimes(1);
       expect(publicWorldStateDB.rollbackToCommit).toHaveBeenCalledTimes(0);
 
-      const txEffect = toTxEffect(processed[0]);
+      const txEffect = toTxEffect(processed[0], GasFees.default());
       expect(arrayNonEmptyLength(txEffect.publicDataWrites, PublicDataWrite.isEmpty)).toEqual(2);
       expect(txEffect.publicDataWrites[0]).toEqual(
         new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotA), fr(0x102)),
@@ -977,7 +977,7 @@ describe('public_processor', () => {
       expect(processed[0].gasUsed[PublicKernelType.TAIL]).toBeUndefined();
       expect(processed[0].gasUsed[PublicKernelType.NON_PUBLIC]).toBeUndefined();
 
-      const txEffect = toTxEffect(processed[0]);
+      const txEffect = toTxEffect(processed[0], GasFees.default());
       expect(arrayNonEmptyLength(txEffect.publicDataWrites, PublicDataWrite.isEmpty)).toEqual(3);
       expect(txEffect.publicDataWrites[0]).toEqual(
         new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotC), fr(0x201)),


### PR DESCRIPTION
We were using the `CombinedConstantData` from the kernel public inputs for getting the block fees and computing the txFee. However, the `globals.gasFees` in the `CombinedConstantData` that come from a `PrivateKernelTail` are empty, so we were always computing a zero fee for txs without a public component.

This PR changes it so we always have to inject the block gas fees to compute the actual tx fee.

---

This hints at another problem we may have: we have fields in our circuits structs that are sometimes safe to use, and sometimes not. Should we rethink our structs so we don't accidentally run into this situation again? Another example that comes to mind is the `transaction_fee` field which is only set during teardown.