### PR TITLE
feat: add flag to not mask address in siloing enc log

### DIFF
--- a/docs/docs/guides/js_apps/test.md
+++ b/docs/docs/guides/js_apps/test.md
@@ -118,7 +118,7 @@ Private state in the Aztec is represented via sets of [private notes](../../azte
 
 ### Logs
 
-You can check the logs of [events](../smart_contracts/writing_contracts/how_to_emit_event.md) emitted by contracts. Contracts in Aztec can emit both [encrypted](../smart_contracts/writing_contracts/how_to_emit_event.md#call-emit_encrypted_log) and [unencrypted](../smart_contracts/writing_contracts/how_to_emit_event.md#call-emit_unencrypted_log) events.
+You can check the logs of [events](../smart_contracts/writing_contracts/how_to_emit_event.md) emitted by contracts. Contracts in Aztec can emit both [encrypted](../smart_contracts/writing_contracts/how_to_emit_event.md#call-encrypt_and_emit_note) and [unencrypted](../smart_contracts/writing_contracts/how_to_emit_event.md#call-emit_unencrypted_log) events.
 
 #### Querying unencrypted logs
 

--- a/docs/docs/guides/js_apps/test.md
+++ b/docs/docs/guides/js_apps/test.md
@@ -118,7 +118,7 @@ Private state in the Aztec is represented via sets of [private notes](../../azte
 
 ### Logs
 
-You can check the logs of [events](../smart_contracts/writing_contracts/how_to_emit_event.md) emitted by contracts. Contracts in Aztec can emit both [encrypted](../smart_contracts/writing_contracts/how_to_emit_event.md#call-encrypt_and_emit_note) and [unencrypted](../smart_contracts/writing_contracts/how_to_emit_event.md#call-emit_unencrypted_log) events.
+You can check the logs of [events](../smart_contracts/writing_contracts/how_to_emit_event.md) emitted by contracts. Contracts in Aztec can emit both [encrypted](../smart_contracts/writing_contracts/how_to_emit_event.md#Encrypted-Events) and [unencrypted](../smart_contracts/writing_contracts/how_to_emit_event.md#Unencrypted-Events) events.
 
 #### Querying unencrypted logs
 

--- a/docs/docs/guides/smart_contracts/writing_contracts/common_patterns/index.md
+++ b/docs/docs/guides/smart_contracts/writing_contracts/common_patterns/index.md
@@ -90,8 +90,8 @@ This pattern is discussed in detail in [writing a token contract section in the 
 
 When you send someone a note, the note hash gets added to the [note hash tree](../../../../aztec/concepts/storage/trees/index.md#note-hash-tree). To spend the note, the receiver needs to get the note itself (the note hash preimage). There are two ways you can get a hold of your notes:
 
-1. When sending someone a note, use `emit_encrypted_log` (the function encrypts the log in such a way that only a recipient can decrypt it). PXE then tries to decrypt all the encrypted logs, and stores the successfully decrypted one. [More info here](../how_to_emit_event.md)
-2. Manually using `pxe.addNote()` - If you choose to not emit logs to save gas or when creating a note in the public domain and want to consume it in private domain (`emit_encrypted_log` shouldn't be called in the public domain because everything is public), like in the previous section where we created a TransparentNote in public.
+1. When sending someone a note, use `encrypt_and_emit_note` (the function encrypts the log in such a way that only a recipient can decrypt it). PXE then tries to decrypt all the encrypted logs, and stores the successfully decrypted one. [More info here](../how_to_emit_event.md)
+2. Manually using `pxe.addNote()` - If you choose to not emit logs to save gas or when creating a note in the public domain and want to consume it in private domain (`encrypt_and_emit_note` shouldn't be called in the public domain because everything is public), like in the previous section where we created a TransparentNote in public.
 
 #include_code pxe_add_note yarn-project/end-to-end/src/e2e_cheat_codes.test.ts typescript
 

--- a/docs/docs/guides/smart_contracts/writing_contracts/how_to_emit_event.md
+++ b/docs/docs/guides/smart_contracts/writing_contracts/how_to_emit_event.md
@@ -31,15 +31,11 @@ Then to register the recipient's [complete address](../../../aztec/concepts/acco
 
 :::info
 If a note recipient is one of the accounts inside the PXE, we don't need to register it as a recipient because we already have the public key available. You can register a recipient as shown [here](../how_to_deploy_contract.md)
-
-At this point the Sandbox only enables the emitting of encrypted note preimages through encrypted events.
-In the future we will allow emitting arbitrary information.
-(If you currently emit arbitrary information, PXE will fail to decrypt, process and store this data, so it will not be queryable).
 :::
 
-### Call emit_encrypted_log
+### Call encrypt_and_emit_note
 
-To emit encrypted logs you don't need to import any library. You call the context method `emit_encrypted_log`:
+To emit encrypted logs you don't need to import any library. You call the context method `encrypt_and_emit_note`:
 
 #include_code encrypted /noir-projects/aztec-nr/address-note/src/address_note.nr rust
 
@@ -53,6 +49,11 @@ If the decryption fails, the specific log will be discarded.
 For the PXE to successfully process the decrypted note we need to compute the note's 'note hash' and 'nullifier'.
 Aztec.nr enables smart contract developers to design custom notes, meaning developers can also customize how a note's note hash and nullifier should be computed. Because of this customizability, and because there will be a potentially-unlimited number of smart contracts deployed to Aztec, an PXE needs to be 'taught' how to compute the custom note hashes and nullifiers for a particular contract. This is done by a function called `compute_note_hash_and_nullifier`, which is automatically injected into every contract when compiled.
 
+## Encrypted Events
+
+To emit generic event information as an encrypted log, call the context method `encrypt_and_emit_note`. Currently, only arrays of 
+fields are supported, and the PXE will fail to decrypt, process and store this data, so it will not be queryable automatically.
+
 ## Unencrypted Events
 
 Unencrypted events are events which can be read by anyone.
@@ -60,7 +61,6 @@ They can be emitted by both public and private functions.
 
 :::danger
 - Emitting unencrypted events from private function is a significant privacy leak and it should be considered by the developer whether it is acceptable.
-- Unencrypted events are currently **NOT** linked to the contract emitting them, so it is practically a [`debug_log`](../../../aztec/concepts/smart_contracts/oracles/index.md#a-few-useful-inbuilt-oracles).
 
 :::
 

--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -8,6 +8,20 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 
 ## 0.42.0
 
+### [Aztec.nr] Emitting encrypted notes and logs
+
+The `emit_encrypted_log` context function is now `encrypt_and_emit_log` or `encrypt_and_emit_note`.
+
+```diff
+- context.emit_encrypted_log(log1);
++ context.encrypt_and_emit_log(log1);
++ context.encrypt_and_emit_note(note1);
+```
+Broadcasting a note will call `encrypt_and_emit_note` in the background. To broadcast a generic event, use `encrypt_and_emit_log`
+with the same encryption parameters as notes require. Currently, only fields and arrays of fields are supported as events.
+
+By default, logs emitted via `encrypt_and_emit_log` will be siloed with a _masked_ contract address. To force the contract address to be revealed, so everyone can check it rather than just the log recipient, provide `randomness = 0`.
+
 ## Public execution migrated to the Aztec Virtual Machine
 
 **What does this mean for me?**

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -299,6 +299,8 @@ impl PrivateContext {
         self.unencrypted_logs_hashes.push(side_effect);
     }
 
+    // NB: A randomness value of 0 signals that the kernels should not mask the contract address
+    // used in siloing later on e.g. 'handshaking' contract w/ known address.
     pub fn encrypt_and_emit_log<N, M>(
         &mut self,
         contract_address: AztecAddress,

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -262,7 +262,7 @@ contract Test {
             Test::at(context.this_address()).emit_array_as_encrypted_log([0, 0, 0, 0, 0], owner, false).call(&mut context);
             context.encrypt_and_emit_log(
                 context.this_address(),
-                6, // testing only - this should be a secret random value to salt the addr
+                0, // testing only - this signals to the kerels to not mask the address
                 1,
                 owner_ivpk_m,
                 [1, 2, 3, 4, 5]

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
@@ -270,6 +270,51 @@ mod tests {
     }
 
     #[test]
+    unconstrained fn encrypted_logs_are_hashed_as_expected() {
+        let mut builder = PrivateKernelTailInputsBuilder::new();
+        // Logs for the previous call stack.
+        let prev_encrypted_logs_hash = 80;
+        let prev_encrypted_log_preimages_length = 13;
+        builder.previous_kernel.set_encrypted_logs(prev_encrypted_logs_hash, prev_encrypted_log_preimages_length);
+
+        // Set the randomness to 0 to signal not masking the address to silo with
+        builder.previous_kernel.encrypted_logs_hashes.storage[0].log_hash.randomness = 0;
+
+        let new_encrypted_logs_hash = 26;
+        let new_encrypted_log_preimages_length = 50;
+        builder.previous_kernel.set_encrypted_logs(new_encrypted_logs_hash, new_encrypted_log_preimages_length);
+
+        let public_inputs = builder.execute();
+
+        assert_eq(
+            public_inputs.end.encrypted_log_preimages_length, prev_encrypted_log_preimages_length + new_encrypted_log_preimages_length
+        );
+
+        let siloed_encrypted_logs_hash = silo_encrypted_log(
+            builder.previous_kernel.storage_contract_address,
+            builder.previous_kernel.encrypted_logs_hashes.storage[0].log_hash.randomness,
+            prev_encrypted_logs_hash
+        );
+
+        let siloed_hash_bytes: [u8; 64] = builder.previous_kernel.storage_contract_address.to_field().to_be_bytes(32).append(prev_encrypted_logs_hash.to_be_bytes(32)).as_array();
+        assert_eq(siloed_encrypted_logs_hash, sha256_to_field(siloed_hash_bytes));
+
+        let new_siloed_encrypted_logs_hash = silo_encrypted_log(
+            builder.previous_kernel.storage_contract_address,
+            builder.previous_kernel.encrypted_logs_hashes.storage[1].log_hash.randomness,
+            new_encrypted_logs_hash
+        );
+        // noir-fmt:ignore
+        let hash_bytes: [u8; MAX_ENCRYPTED_LOGS_PER_TX * 32] = siloed_encrypted_logs_hash
+            .to_be_bytes(32)
+            .append(new_siloed_encrypted_logs_hash.to_be_bytes(32))
+            .append(&[0; MAX_ENCRYPTED_LOGS_PER_TX * 32 - 64])
+            .as_array();
+        let expected_encrypted_logs_hash = sha256_to_field(hash_bytes);
+        assert_eq(public_inputs.end.encrypted_logs_hash, expected_encrypted_logs_hash);
+    }
+
+    #[test]
     unconstrained fn ordering_of_note_hashes_and_nullifiers() {
         let mut builder = PrivateKernelTailInputsBuilder::new();
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
@@ -77,7 +77,13 @@ pub fn silo_nullifier(address: AztecAddress, nullifier: Field) -> Field {
 pub fn silo_encrypted_log(address: AztecAddress, randomness: Field, log_hash: Field) -> Field {
     // TODO: Using 0 GENERATOR_INDEX here as interim before we move to posiedon
     // NB: A unique separator will be needed for masked_contract_address
-    let masked_contract_address = pedersen_hash([address.to_field(), randomness], 0);
+    let mut masked_contract_address = pedersen_hash([address.to_field(), randomness], 0);
+    if randomness == 0 {
+        // In some cases, we actually want to reveal the contract address we are siloing with:
+        // e.g. 'handshaking' contract w/ known address
+        // An app providing randomness = 0 signals to not mask the address.
+        masked_contract_address = address.to_field();
+    }
     accumulate_sha256([masked_contract_address, log_hash])
 }
 

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -299,7 +299,8 @@ describe('e2e_block_building', () => {
       const encryptedLogs = tx.encryptedLogs.unrollLogs();
       expect(encryptedLogs[0].maskedContractAddress).toEqual(pedersenHash([testContract.address, new Fr(5)], 0));
       expect(encryptedLogs[1].maskedContractAddress).toEqual(pedersenHash([testContract.address, new Fr(5)], 0));
-      expect(encryptedLogs[2].maskedContractAddress).toEqual(pedersenHash([testContract.address, new Fr(6)], 0));
+      // Setting randomness = 0 in app means 'do not mask the address'
+      expect(encryptedLogs[2].maskedContractAddress).toEqual(testContract.address.toField());
       const expectedEncryptedLogsHash = tx.encryptedLogs.hash();
       expect(tx.data.forRollup?.end.encryptedLogsHash).toEqual(new Fr(expectedEncryptedLogsHash));
 

--- a/yarn-project/simulator/src/client/client_execution_context.ts
+++ b/yarn-project/simulator/src/client/client_execution_context.ts
@@ -365,7 +365,12 @@ export class ClientExecutionContext extends ViewDataOracle {
     encryptedData: Buffer,
     counter: number,
   ) {
-    const maskedContractAddress = pedersenHash([contractAddress, randomness], 0);
+    // In some cases, we actually want to reveal the contract address we are siloing with:
+    // e.g. 'handshaking' contract w/ known address
+    // An app providing randomness = 0 signals to not mask the address.
+    const maskedContractAddress = randomness.isZero()
+      ? contractAddress.toField()
+      : pedersenHash([contractAddress, randomness], 0);
     const encryptedLog = new CountedLog(new EncryptedL2Log(encryptedData, maskedContractAddress), counter);
     this.encryptedLogs.push(encryptedLog);
   }


### PR DESCRIPTION
In some cases, encrypted event logs are intended to be broadcast with their contract address publicly known.

To hide the address, we by default mask it (`masked_contract_address = pedersen(addr, randomness)`), then use it to silo encrypted event logs. To allow an app to optionally reveal the address by siloing the log with it unmasked, it can provide a `randomness` value of 0.

Added docs, a test in private tail, and modified the existing tests in `e2e_block_building` to include this case.
