### PR TITLE
fix: Allow end-setup from any private function

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_circuit_public_inputs_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_circuit_public_inputs_composer.nr
@@ -110,12 +110,21 @@ impl PrivateKernelCircuitPublicInputsComposer {
         self.propagate_public_call_requests(source);
         self.propagate_public_teardown_call_request(source);
         self.propagate_fee_payer(source);
+        self.propagate_min_revertible_side_effect_counter(source);
 
         *self
     }
 
     pub fn finish(self) -> PrivateKernelCircuitPublicInputs {
         self.public_inputs.finish()
+    }
+
+    fn propagate_min_revertible_side_effect_counter(&mut self, source: DataSource) {
+        self.public_inputs.min_revertible_side_effect_counter = if self.public_inputs.min_revertible_side_effect_counter > 0 {
+            self.public_inputs.min_revertible_side_effect_counter
+        } else {
+            source.private_call_public_inputs.min_revertible_side_effect_counter
+        };
     }
 
     fn propagate_max_block_number(&mut self, source: DataSource) {

--- a/yarn-project/end-to-end/src/e2e_fees/account_init.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/account_init.test.ts
@@ -96,7 +96,7 @@ describe('e2e_fees account_init', () => {
       await expect(t.gasBalances(bobsAddress)).resolves.toEqual([bobsInitialGas - tx.transactionFee!]);
     });
 
-    it.skip('pays natively in the gas token by bridging funds themselves', async () => {
+    it('pays natively in the gas token by bridging funds themselves', async () => {
       const { secret } = await t.gasBridgeTestHarness.prepareTokensOnL1(
         t.INITIAL_GAS_BALANCE,
         t.INITIAL_GAS_BALANCE,

--- a/yarn-project/simulator/src/public/setup_phase_manager.ts
+++ b/yarn-project/simulator/src/public/setup_phase_manager.ts
@@ -26,6 +26,9 @@ export class SetupPhaseManager extends AbstractPhaseManager {
 
   override async handle(tx: Tx, previousPublicKernelOutput: PublicKernelCircuitPublicInputs) {
     this.log.verbose(`Processing tx ${tx.getTxHash()}`);
+    // TODO(#6464): Should we allow emitting contracts in the private setup phase?
+    // if so, this should only add contracts that were deployed during private app logic.
+    await this.publicContractsDB.addNewContracts(tx);
     const [kernelInputs, publicKernelOutput, newUnencryptedFunctionLogs, revertReason, _returnValues, gasUsed] =
       await this.processEnqueuedPublicCalls(tx, previousPublicKernelOutput).catch(
         // the abstract phase manager throws if simulation gives error in a non-revertible phase


### PR DESCRIPTION
This enables the flow where we claim bridged funds and pay for account contract initialization in the same tx.

Pending:
- Do not fail silently if someone ends setup when it has already ended
- Update protocol specs
- More tests!