### PR TITLE
feat: Reduce stack size after optimizations

### DIFF
--- a/noir/noir-repo/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
+++ b/noir/noir-repo/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use acvm::{acir::brillig::MemoryAddress, FieldElement};
 
-pub(crate) const MAX_STACK_SIZE: usize = 3072;
+pub(crate) const MAX_STACK_SIZE: usize = 2048;
 
 impl BrilligContext {
     /// Creates an entry point artifact that will jump to the function label provided.


### PR DESCRIPTION
After [this PR](https://github.com/noir-lang/noir/pull/5097) we should be able to set the stack size back down to the previous value.