### PR TITLE
feat: Add estimateGas to aztec-js

### DIFF
--- a/yarn-project/aztec.js/src/contract/get_gas_limits.test.ts
+++ b/yarn-project/aztec.js/src/contract/get_gas_limits.test.ts
@@ -5,6 +5,7 @@ import { getGasLimits } from './get_gas_limits.js';
 
 describe('getGasLimits', () => {
   let simulatedTx: SimulatedTx;
+  let simulationTeardownGasLimits: Gas;
 
   beforeEach(() => {
     simulatedTx = mockSimulatedTx();
@@ -14,28 +15,37 @@ describe('getGasLimits', () => {
       [PublicKernelType.APP_LOGIC]: Gas.from({ daGas: 20, l2Gas: 40 }),
       [PublicKernelType.TEARDOWN]: Gas.from({ daGas: 10, l2Gas: 20 }),
     };
+    simulationTeardownGasLimits = Gas.empty();
   });
 
   it('returns gas limits from private gas usage only', () => {
     simulatedTx.publicOutput = undefined;
     // Should be 110 and 220 but oh floating point
-    expect(getGasLimits(simulatedTx)).toEqual({
+    expect(getGasLimits(simulatedTx, simulationTeardownGasLimits)).toEqual({
       totalGas: Gas.from({ daGas: 111, l2Gas: 221 }),
       teardownGas: Gas.empty(),
     });
   });
 
   it('returns gas limits for private and public', () => {
-    expect(getGasLimits(simulatedTx)).toEqual({
+    expect(getGasLimits(simulatedTx, simulationTeardownGasLimits)).toEqual({
       totalGas: Gas.from({ daGas: 154, l2Gas: 308 }),
       teardownGas: Gas.from({ daGas: 11, l2Gas: 22 }),
     });
   });
 
   it('pads gas limits', () => {
-    expect(getGasLimits(simulatedTx, 1)).toEqual({
+    expect(getGasLimits(simulatedTx, simulationTeardownGasLimits, 1)).toEqual({
       totalGas: Gas.from({ daGas: 280, l2Gas: 560 }),
       teardownGas: Gas.from({ daGas: 20, l2Gas: 40 }),
+    });
+  });
+
+  it('subtracts input teardown gas limits', () => {
+    simulationTeardownGasLimits = Gas.from({ daGas: 80, l2Gas: 200 });
+    expect(getGasLimits(simulatedTx, simulationTeardownGasLimits)).toEqual({
+      totalGas: Gas.from({ daGas: 66, l2Gas: 88 }),
+      teardownGas: Gas.from({ daGas: 11, l2Gas: 22 }),
     });
   });
 });

--- a/yarn-project/aztec.js/src/contract/get_gas_limits.ts
+++ b/yarn-project/aztec.js/src/contract/get_gas_limits.ts
@@ -6,8 +6,10 @@ import { Gas } from '@aztec/circuits.js';
  * Note that public gas usage is only accounted for if the publicOutput is present.
  * @param pad - Percentage to pad the suggested gas limits by, defaults to 10%.
  */
-export function getGasLimits(simulatedTx: SimulatedTx, pad = 0.1) {
-  const privateGasUsed = simulatedTx.tx.data.publicInputs.end.gasUsed;
+export function getGasLimits(simulatedTx: SimulatedTx, simulationTeardownGasLimits: Gas, pad = 0.1) {
+  const privateGasUsed = simulatedTx.tx.data.publicInputs.end.gasUsed
+    .sub(simulationTeardownGasLimits)
+    .add(simulatedTx.tx.data.forPublic?.endNonRevertibleData.gasUsed ?? Gas.empty());
   if (simulatedTx.publicOutput) {
     const publicGasUsed = Object.values(simulatedTx.publicOutput.gasUsed)
       .filter(Boolean)
@@ -19,6 +21,5 @@ export function getGasLimits(simulatedTx: SimulatedTx, pad = 0.1) {
       teardownGas: teardownGas.mul(1 + pad),
     };
   }
-
   return { totalGas: privateGasUsed.mul(1 + pad), teardownGas: Gas.empty() };
 }

--- a/yarn-project/end-to-end/src/e2e_fees/gas_estimation.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/gas_estimation.test.ts
@@ -35,33 +35,62 @@ describe('e2e_fees gas_estimation', () => {
     await t.teardown();
   });
 
+  const makeTransferRequest = () => bananaCoin.methods.transfer_public(aliceAddress, bobAddress, 1n, 0n);
+
   // Sends two tx with transfers of public tokens: one with estimateGas on, one with estimateGas off
   const sendTransfers = (paymentMethod: FeePaymentMethod) =>
     Promise.all(
       [true, false].map(estimateGas =>
-        bananaCoin.methods
-          .transfer_public(aliceAddress, bobAddress, 1n, 0n)
-          .send({ estimateGas, fee: { gasSettings, paymentMethod } })
-          .wait(),
+        makeTransferRequest().send({ estimateGas, fee: { gasSettings, paymentMethod } }).wait(),
       ),
     );
 
+  const getFeeFromEstimatedGas = (estimatedGas: Pick<GasSettings, 'gasLimits' | 'teardownGasLimits'>) =>
+    gasSettings.inclusionFee
+      .add(estimatedGas.gasLimits.computeFee(GasFees.default()))
+      .add(estimatedGas.teardownGasLimits.computeFee(GasFees.default()))
+      .toBigInt();
+
   it('estimates gas with native fee payment method', async () => {
     const paymentMethod = new NativeFeePaymentMethod(aliceAddress);
+    const estimatedGas = await makeTransferRequest().estimateGas({ fee: { gasSettings, paymentMethod } });
     const [withEstimate, withoutEstimate] = await sendTransfers(paymentMethod);
+    const actualFee = withEstimate.transactionFee!;
 
     // Estimation should yield that teardown has no cost, so should send the tx with zero for teardown
-    expect(withEstimate.transactionFee! + teardownFixedFee).toEqual(withoutEstimate.transactionFee!);
+    expect(actualFee + teardownFixedFee).toEqual(withoutEstimate.transactionFee!);
+
+    // Check that estimated gas for teardown are zero
+    expect(estimatedGas.teardownGasLimits.l2Gas).toEqual(0);
+    expect(estimatedGas.teardownGasLimits.daGas).toEqual(0);
+
+    // Check that the estimate was close to the actual gas used by recomputing the tx fee from it
+    const feeFromEstimatedGas = getFeeFromEstimatedGas(estimatedGas);
+
+    // The actual fee should be under the estimate, but not too much
+    expect(feeFromEstimatedGas).toBeLessThan(actualFee * 2n);
+    expect(feeFromEstimatedGas).toBeGreaterThanOrEqual(actualFee);
   });
 
   it('estimates gas with public payment method', async () => {
     const paymentMethod = new PublicFeePaymentMethod(bananaCoin.address, bananaFPC.address, aliceWallet);
+    const estimatedGas = await makeTransferRequest().estimateGas({ fee: { gasSettings, paymentMethod } });
     const [withEstimate, withoutEstimate] = await sendTransfers(paymentMethod);
+    const actualFee = withEstimate.transactionFee!;
 
     // Estimation should yield that teardown has reduced cost, but is not zero
-    // TODO(palla/gas): We set toBeGreaterThanOrEqual because gas in public functions is zero for now (we only meter on AVM).
-    // We should be able to change this to a strict equality once we meter gas in public functions or we replace brillig with the AVM.
     expect(withEstimate.transactionFee!).toBeLessThan(withoutEstimate.transactionFee!);
-    expect(withEstimate.transactionFee! + teardownFixedFee).toBeGreaterThanOrEqual(withoutEstimate.transactionFee!);
+    expect(withEstimate.transactionFee! + teardownFixedFee).toBeGreaterThan(withoutEstimate.transactionFee!);
+
+    // Check that estimated gas for teardown are not zero since we're doing work there
+    expect(estimatedGas.teardownGasLimits.l2Gas).toBeGreaterThan(0);
+
+    // Check that the estimate was close to the actual gas used by recomputing the tx fee from it
+    const feeFromEstimatedGas = getFeeFromEstimatedGas(estimatedGas);
+
+    // The actual fee should be under the estimate, but not too much
+    // TODO(palla/gas): 3x is too much, find out why we cannot bring this down to 2x
+    expect(feeFromEstimatedGas).toBeLessThan(actualFee * 3n);
+    expect(feeFromEstimatedGas).toBeGreaterThanOrEqual(actualFee);
   });
 });


### PR DESCRIPTION
Add an `estimateGas` public method to all contract-function-interactions (invoking a contract method, deploying a contract, or deploying an account contract). Since we're at it, fixes gas estimation in that: 1) it wasn't considering non-revertible private gas and 2) it was adding the teardown gas limits to the total gas estimate.