### PR TITLE
refactor: chopping transient logs in ts

### DIFF
--- a/yarn-project/simulator/src/client/client_execution_context.ts
+++ b/yarn-project/simulator/src/client/client_execution_context.ts
@@ -137,13 +137,6 @@ export class ClientExecutionContext extends ViewDataOracle {
   }
 
   /**
-   * Return the note encrypted logs emitted during this execution and nested executions.
-   */
-  public getAllNoteEncryptedLogs() {
-    return this.noteCache.getLogs();
-  }
-
-  /**
    * Return the encrypted logs emitted during this execution.
    */
   public getEncryptedLogs() {

--- a/yarn-project/simulator/src/client/client_execution_context.ts
+++ b/yarn-project/simulator/src/client/client_execution_context.ts
@@ -2,7 +2,6 @@ import {
   type AuthWitness,
   type AztecNode,
   EncryptedL2Log,
-  EncryptedL2NoteLog,
   L1NotePayload,
   Note,
   type NoteStatus,
@@ -29,7 +28,7 @@ import { type NoteData, toACVMWitness } from '../acvm/index.js';
 import { type PackedValuesCache } from '../common/packed_values_cache.js';
 import { type DBOracle } from './db_oracle.js';
 import { type ExecutionNoteCache } from './execution_note_cache.js';
-import { CountedLog, type ExecutionResult, type NoteAndSlot } from './execution_result.js';
+import { CountedLog, type CountedNoteLog, type ExecutionResult, type NoteAndSlot } from './execution_result.js';
 import { pickNotes } from './pick_notes.js';
 import { executePrivateFunction } from './private_execution.js';
 import { ViewDataOracle } from './view_data_oracle.js';
@@ -57,7 +56,7 @@ export class ClientExecutionContext extends ViewDataOracle {
    */
   private noteHashLeafIndexMap: Map<bigint, bigint> = new Map();
   private nullifiedNoteHashCounters: Map<number, number> = new Map();
-  private noteEncryptedLogs: CountedLog<EncryptedL2NoteLog>[] = [];
+  private noteEncryptedLogs: CountedNoteLog[] = [];
   private encryptedLogs: CountedLog<EncryptedL2Log>[] = [];
   private unencryptedLogs: CountedLog<UnencryptedL2Log>[] = [];
   private nestedExecutions: ExecutionResult[] = [];
@@ -135,26 +134,6 @@ export class ClientExecutionContext extends ViewDataOracle {
    */
   public getNoteEncryptedLogs() {
     return this.noteEncryptedLogs;
-  }
-
-  /**
-   * Sometimes notes can be chopped after a nested execution is complete.
-   * This means finished nested executions still hold transient logs. This method removes them.
-   * TODO(Miranda): is there a cleaner solution?
-   */
-  public chopNoteEncryptedLogs() {
-    // Do not return logs that have been chopped in the cache
-    const allNoteLogs = this.noteCache.getLogs();
-    this.noteEncryptedLogs = this.noteEncryptedLogs.filter(l => allNoteLogs.includes(l));
-    const chop = (thing: any) =>
-      thing.nestedExecutions.forEach((result: ExecutionResult) => {
-        if (!result.noteEncryptedLogs[0]?.isEmpty()) {
-          // The execution has note logs
-          result.noteEncryptedLogs = result.noteEncryptedLogs.filter(l => allNoteLogs.includes(l));
-        }
-        chop(result);
-      });
-    chop(this);
   }
 
   /**
@@ -382,9 +361,8 @@ export class ClientExecutionContext extends ViewDataOracle {
    * @param counter - The effects counter.
    */
   public override emitEncryptedNoteLog(noteHash: Fr, encryptedNote: Buffer, counter: number) {
-    const encryptedLog = new CountedLog(new EncryptedL2NoteLog(encryptedNote), counter);
+    const encryptedLog = this.noteCache.addNewLog(encryptedNote, counter, noteHash);
     this.noteEncryptedLogs.push(encryptedLog);
-    this.noteCache.addNewLog(encryptedLog, noteHash);
   }
 
   /**

--- a/yarn-project/simulator/src/client/execution_note_cache.ts
+++ b/yarn-project/simulator/src/client/execution_note_cache.ts
@@ -30,13 +30,6 @@ export class ExecutionNoteCache {
   private nullifiers: Map<bigint, Set<bigint>> = new Map();
 
   /**
-   * The list of encrypted logs linked to note hashes created in this transaction.
-   * This mapping maps from inner note hash to log(s) emitted for that note hash.
-   * Note that their value (bigint representation) is used because Frs cannot be looked up in Sets.
-   */
-  private logs: Map<bigint, CountedNoteLog[]> = new Map();
-
-  /**
    * Add a new note to cache.
    * @param note - New note created during execution.
    */
@@ -47,11 +40,12 @@ export class ExecutionNoteCache {
   }
 
   /**
-   * Add a new note to cache.
-   * @param note - New note created during execution.
+   * Create a new log linked to a note in this cache.
+   * @param encryptedNote - Encrypted new note created during execution.
+   * @param counter - Counter of the log.
+   * @param innerNoteHash - Hashed new note created during execution.
    */
   public addNewLog(encryptedNote: Buffer, counter: number, innerNoteHash: Fr) {
-    const logs = this.logs.get(innerNoteHash.toBigInt()) ?? [];
     const note = Array.from(this.newNotes.values())
       .flat()
       .find(n => n.note.innerNoteHash.equals(innerNoteHash));
@@ -59,8 +53,6 @@ export class ExecutionNoteCache {
       throw new Error('Attempt to add a note log for note that does not exist.');
     }
     const log = new CountedNoteLog(new EncryptedL2NoteLog(encryptedNote), counter, note.counter);
-    logs.push(log);
-    this.logs.set(innerNoteHash.toBigInt(), logs);
     return log;
   }
 
@@ -89,8 +81,6 @@ export class ExecutionNoteCache {
       const note = notes.splice(noteIndexToRemove, 1)[0];
       nullifiedNoteHashCounter = note.counter;
       this.newNotes.set(contractAddress.toBigInt(), notes);
-      // If a log linked to the note hash does not exist, this method just does nothing
-      this.logs.delete(innerNoteHash.toBigInt());
     }
 
     return nullifiedNoteHashCounter;
@@ -124,12 +114,5 @@ export class ExecutionNoteCache {
    */
   public getNullifiers(contractAddress: AztecAddress): Set<bigint> {
     return this.nullifiers.get(contractAddress.toBigInt()) ?? new Set();
-  }
-
-  /**
-   * Return all note logs emitted from a contract.
-   */
-  public getLogs(): CountedNoteLog[] {
-    return Array.from(this.logs.values()).flat();
   }
 }

--- a/yarn-project/simulator/src/client/execution_result.ts
+++ b/yarn-project/simulator/src/client/execution_result.ts
@@ -32,6 +32,11 @@ export class CountedLog<TLog extends UnencryptedL2Log | EncryptedL2NoteLog | Enc
   }
 }
 
+export class CountedNoteLog extends CountedLog<EncryptedL2NoteLog> {
+  constructor(log: EncryptedL2NoteLog, counter: number, public noteHashCounter: number) {
+    super(log, counter);
+  }
+}
 /**
  * The result of executing a private function.
  */
@@ -64,7 +69,7 @@ export interface ExecutionResult {
    * Encrypted note logs emitted during execution of this function call.
    * Note: These are preimages to `noteEncryptedLogsHashes`.
    */
-  noteEncryptedLogs: CountedLog<EncryptedL2NoteLog>[];
+  noteEncryptedLogs: CountedNoteLog[];
   /**
    * Encrypted logs emitted during execution of this function call.
    * Note: These are preimages to `encryptedLogsHashes`.
@@ -94,8 +99,14 @@ export function collectNullifiedNoteHashCounters(execResult: ExecutionResult, ac
  * @param execResult - The topmost execution result.
  * @returns All encrypted logs.
  */
-function collectNoteEncryptedLogs(execResult: ExecutionResult): CountedLog<EncryptedL2NoteLog>[] {
-  return [execResult.noteEncryptedLogs, ...execResult.nestedExecutions.flatMap(collectNoteEncryptedLogs)].flat();
+function collectNoteEncryptedLogs(
+  execResult: ExecutionResult,
+  nullifiedNoteHashCounters: number[],
+): CountedLog<EncryptedL2NoteLog>[] {
+  return [
+    execResult.noteEncryptedLogs.filter(noteLog => !nullifiedNoteHashCounters.includes(noteLog.noteHashCounter)),
+    ...execResult.nestedExecutions.flatMap(res => collectNoteEncryptedLogs(res, nullifiedNoteHashCounters)),
+  ].flat();
 }
 
 /**
@@ -104,7 +115,8 @@ function collectNoteEncryptedLogs(execResult: ExecutionResult): CountedLog<Encry
  * @returns All encrypted logs.
  */
 export function collectSortedNoteEncryptedLogs(execResult: ExecutionResult): EncryptedNoteFunctionL2Logs {
-  const allLogs = collectNoteEncryptedLogs(execResult);
+  const nullifiedNoteHashCounters = Array.from(collectNullifiedNoteHashCounters(execResult).keys()).flat();
+  const allLogs = collectNoteEncryptedLogs(execResult, nullifiedNoteHashCounters);
   const sortedLogs = sortByCounter(allLogs);
   return new EncryptedNoteFunctionL2Logs(sortedLogs.map(l => l.log));
 }

--- a/yarn-project/simulator/src/client/execution_result.ts
+++ b/yarn-project/simulator/src/client/execution_result.ts
@@ -101,10 +101,10 @@ export function collectNullifiedNoteHashCounters(execResult: ExecutionResult, ac
  */
 function collectNoteEncryptedLogs(
   execResult: ExecutionResult,
-  nullifiedNoteHashCounters: number[],
+  nullifiedNoteHashCounters: Map<number, number>,
 ): CountedLog<EncryptedL2NoteLog>[] {
   return [
-    execResult.noteEncryptedLogs.filter(noteLog => !nullifiedNoteHashCounters.includes(noteLog.noteHashCounter)),
+    execResult.noteEncryptedLogs.filter(noteLog => !nullifiedNoteHashCounters.has(noteLog.noteHashCounter)),
     ...execResult.nestedExecutions.flatMap(res => collectNoteEncryptedLogs(res, nullifiedNoteHashCounters)),
   ].flat();
 }
@@ -115,7 +115,7 @@ function collectNoteEncryptedLogs(
  * @returns All encrypted logs.
  */
 export function collectSortedNoteEncryptedLogs(execResult: ExecutionResult): EncryptedNoteFunctionL2Logs {
-  const nullifiedNoteHashCounters = Array.from(collectNullifiedNoteHashCounters(execResult).keys()).flat();
+  const nullifiedNoteHashCounters = collectNullifiedNoteHashCounters(execResult);
   const allLogs = collectNoteEncryptedLogs(execResult, nullifiedNoteHashCounters);
   const sortedLogs = sortByCounter(allLogs);
   return new EncryptedNoteFunctionL2Logs(sortedLogs.map(l => l.log));

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -970,9 +970,8 @@ describe('Private Execution test suite', () => {
 
       const [encryptedLog] = newEncryptedLogs;
       expect(encryptedLog.noteHashCounter).toEqual(newNoteHashes[0].counter);
-      // We expect the note log to be chopped in ts.
-      // (note logs are chopped in kernel tail, so will still exist in the call stack item)
-      expect(result.noteEncryptedLogs).toHaveLength(0);
+      expect(encryptedLog.noteHashCounter).toEqual(result.noteEncryptedLogs[0].noteHashCounter);
+      expect(encryptedLog.value).toEqual(Fr.fromBuffer(result.noteEncryptedLogs[0].log.hash()));
 
       // read request should match innerNoteHash for pending notes (there is no nonce, so can't compute "unique" hash)
       const readRequest = getNonEmptyItems(result.callStackItem.publicInputs.noteHashReadRequests)[0];
@@ -1049,9 +1048,8 @@ describe('Private Execution test suite', () => {
 
       const [encryptedLog] = newEncryptedLogs;
       expect(encryptedLog.noteHashCounter).toEqual(newNoteHashes[0].counter);
-      // We expect the note log to be chopped in ts.
-      // (note logs are chopped in kernel tail, so will still exist in the call stack item)
-      expect(execInsert.noteEncryptedLogs).toHaveLength(0);
+      expect(encryptedLog.noteHashCounter).toEqual(execInsert.noteEncryptedLogs[0].noteHashCounter);
+      expect(encryptedLog.value).toEqual(Fr.fromBuffer(execInsert.noteEncryptedLogs[0].log.hash()));
 
       // read request should match innerNoteHash for pending notes (there is no nonce, so can't compute "unique" hash)
       const readRequest = execGetThenNullify.callStackItem.publicInputs.noteHashReadRequests[0];

--- a/yarn-project/simulator/src/client/private_execution.ts
+++ b/yarn-project/simulator/src/client/private_execution.ts
@@ -54,7 +54,6 @@ export async function executePrivateFunction(
     appCircuitName: functionName,
   } satisfies CircuitWitnessGenerationStats);
 
-  context.chopNoteEncryptedLogs();
   const noteEncryptedLogs = context.getNoteEncryptedLogs();
   const encryptedLogs = context.getEncryptedLogs();
   const unencryptedLogs = context.getUnencryptedLogs();


### PR DESCRIPTION
This PR moves where we chop transient note logs in ts from `private_execution -> executePrivateFunction()` to `pxe_service -> collectSortedNoteEncryptedLogs()`. It is required as note logs emitted in a completed nested execution may be chopped later in the parent execution, and the `tx` will still contain incorrect logs. Since the `tx` struct does not contain `.notes` or `.nullifiers`, we only need to do this for note logs.

This change means the logs in `ExecutionResult.noteEncryptedLogs` and `.callStackItem` are in sync which otherwise may be confusing. It also uses the existing `nullifiedNoteHashCounters` to filter chopped logs.
