### PR TITLE
fix: Estimate gas cost of contract deployment

### DIFF
--- a/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
@@ -95,7 +95,7 @@ export abstract class BaseContractInteraction {
    * @param request - Request to execute for this interaction.
    * @returns Fee options for the actual transaction.
    */
-  protected async getFeeOptions(request: ExecutionRequestInit) {
+  protected async getFeeOptionsFromEstimatedGas(request: ExecutionRequestInit) {
     const fee = request.fee;
     if (fee) {
       const txRequest = await this.wallet.createTxExecutionRequest(request);

--- a/yarn-project/aztec.js/src/contract/batch_call.ts
+++ b/yarn-project/aztec.js/src/contract/batch_call.ts
@@ -20,7 +20,7 @@ export class BatchCall extends BaseContractInteraction {
   public async create(opts?: SendMethodOptions): Promise<TxExecutionRequest> {
     if (!this.txRequest) {
       const calls = this.calls;
-      const fee = opts?.estimateGas ? await this.getFeeOptions({ calls, fee: opts?.fee }) : opts?.fee;
+      const fee = opts?.estimateGas ? await this.getFeeOptionsFromEstimatedGas({ calls, fee: opts?.fee }) : opts?.fee;
       this.txRequest = await this.wallet.createTxExecutionRequest({ calls, fee });
     }
     return this.txRequest;

--- a/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
@@ -54,7 +54,7 @@ export class ContractFunctionInteraction extends BaseContractInteraction {
     }
     if (!this.txRequest) {
       const calls = [this.request()];
-      const fee = opts?.estimateGas ? await this.getFeeOptions({ calls, fee: opts?.fee }) : opts?.fee;
+      const fee = opts?.estimateGas ? await this.getFeeOptionsFromEstimatedGas({ calls, fee: opts?.fee }) : opts?.fee;
       this.txRequest = await this.wallet.createTxExecutionRequest({ calls, fee });
     }
     return this.txRequest;

--- a/yarn-project/aztec.js/src/wallet/signerless_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/signerless_wallet.ts
@@ -24,26 +24,26 @@ export class SignerlessWallet extends BaseWallet {
   }
 
   getChainId(): Fr {
-    throw new Error('Method not implemented.');
+    throw new Error('SignerlessWallet: Method getChainId not implemented.');
   }
 
   getVersion(): Fr {
-    throw new Error('Method not implemented.');
+    throw new Error('SignerlessWallet: Method getVersion not implemented.');
   }
 
   getPublicKeysHash(): Fr {
-    throw new Error('Method not implemented.');
+    throw new Error('SignerlessWallet: Method getPublicKeysHash not implemented.');
   }
 
   getCompleteAddress(): CompleteAddress {
-    throw new Error('Method not implemented.');
+    throw new Error('SignerlessWallet: Method getCompleteAddress not implemented.');
   }
 
   createAuthWit(_messageHash: Fr): Promise<AuthWitness> {
-    throw new Error('Method not implemented.');
+    throw new Error('SignerlessWallet: Method createAuthWit not implemented.');
   }
 
   rotateNullifierKeys(_newNskM: Fq): Promise<void> {
-    throw new Error('Method not implemented.');
+    throw new Error('SignerlessWallet: Method rotateNullifierKeys not implemented.');
   }
 }

--- a/yarn-project/end-to-end/src/e2e_fees/gas_estimation.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/gas_estimation.test.ts
@@ -6,7 +6,10 @@ import {
   PublicFeePaymentMethod,
 } from '@aztec/aztec.js';
 import { GasFees, type GasSettings } from '@aztec/circuits.js';
-import { type TokenContract as BananaCoin, type FPCContract } from '@aztec/noir-contracts.js';
+import { type Logger } from '@aztec/foundation/log';
+import { TokenContract as BananaCoin, type FPCContract } from '@aztec/noir-contracts.js';
+
+import { inspect } from 'util';
 
 import { FeesTest } from './fees_test.js';
 
@@ -18,6 +21,7 @@ describe('e2e_fees gas_estimation', () => {
   let bananaFPC: FPCContract;
   let gasSettings: GasSettings;
   let teardownFixedFee: bigint;
+  let logger: Logger;
 
   const t = new FeesTest('gas_estimation');
 
@@ -26,7 +30,7 @@ describe('e2e_fees gas_estimation', () => {
     await t.applyFPCSetupSnapshot();
     await t.applyFundAliceWithBananas();
     await t.applyFundAliceWithGasToken();
-    ({ aliceWallet, aliceAddress, bobAddress, bananaCoin, bananaFPC, gasSettings } = await t.setup());
+    ({ aliceWallet, aliceAddress, bobAddress, bananaCoin, bananaFPC, gasSettings, logger } = await t.setup());
 
     teardownFixedFee = gasSettings.teardownGasLimits.computeFee(GasFees.default()).toBigInt();
   });
@@ -51,9 +55,17 @@ describe('e2e_fees gas_estimation', () => {
       .add(estimatedGas.teardownGasLimits.computeFee(GasFees.default()))
       .toBigInt();
 
+  const logGasEstimate = (estimatedGas: Pick<GasSettings, 'gasLimits' | 'teardownGasLimits'>) =>
+    logger.info(`Estimated gas at`, {
+      gasLimits: inspect(estimatedGas.gasLimits),
+      teardownGasLimits: inspect(estimatedGas.teardownGasLimits),
+    });
+
   it('estimates gas with native fee payment method', async () => {
     const paymentMethod = new NativeFeePaymentMethod(aliceAddress);
     const estimatedGas = await makeTransferRequest().estimateGas({ fee: { gasSettings, paymentMethod } });
+    logGasEstimate(estimatedGas);
+
     const [withEstimate, withoutEstimate] = await sendTransfers(paymentMethod);
     const actualFee = withEstimate.transactionFee!;
 
@@ -75,6 +87,8 @@ describe('e2e_fees gas_estimation', () => {
   it('estimates gas with public payment method', async () => {
     const paymentMethod = new PublicFeePaymentMethod(bananaCoin.address, bananaFPC.address, aliceWallet);
     const estimatedGas = await makeTransferRequest().estimateGas({ fee: { gasSettings, paymentMethod } });
+    logGasEstimate(estimatedGas);
+
     const [withEstimate, withoutEstimate] = await sendTransfers(paymentMethod);
     const actualFee = withEstimate.transactionFee!;
 
@@ -91,6 +105,38 @@ describe('e2e_fees gas_estimation', () => {
     // The actual fee should be under the estimate, but not too much
     // TODO(palla/gas): 3x is too much, find out why we cannot bring this down to 2x
     expect(feeFromEstimatedGas).toBeLessThan(actualFee * 3n);
+    expect(feeFromEstimatedGas).toBeGreaterThanOrEqual(actualFee);
+  });
+
+  it('estimates gas for public contract initialization with native fee payment method', async () => {
+    const paymentMethod = new NativeFeePaymentMethod(aliceAddress);
+    const deployMethod = () => BananaCoin.deploy(aliceWallet, aliceAddress, 'TKN', 'TKN', 8);
+    const deployOpts = { fee: { gasSettings, paymentMethod }, skipClassRegistration: true };
+    const estimatedGas = await deployMethod().estimateGas(deployOpts);
+    logGasEstimate(estimatedGas);
+
+    const [withEstimate, withoutEstimate] = await Promise.all([
+      deployMethod()
+        .send({ ...deployOpts, estimateGas: true })
+        .wait(),
+      deployMethod()
+        .send({ ...deployOpts, estimateGas: false })
+        .wait(),
+    ]);
+
+    // Estimation should yield that teardown has no cost, so should send the tx with zero for teardown
+    const actualFee = withEstimate.transactionFee!;
+    expect(actualFee + teardownFixedFee).toEqual(withoutEstimate.transactionFee!);
+
+    // Check that estimated gas for teardown are zero
+    expect(estimatedGas.teardownGasLimits.l2Gas).toEqual(0);
+    expect(estimatedGas.teardownGasLimits.daGas).toEqual(0);
+
+    // Check that the estimate was close to the actual gas used by recomputing the tx fee from it
+    const feeFromEstimatedGas = getFeeFromEstimatedGas(estimatedGas);
+
+    // The actual fee should be under the estimate, but not too much
+    expect(feeFromEstimatedGas).toBeLessThan(actualFee * 2n);
     expect(feeFromEstimatedGas).toBeGreaterThanOrEqual(actualFee);
   });
 });

--- a/yarn-project/foundation/src/serialize/serialize.ts
+++ b/yarn-project/foundation/src/serialize/serialize.ts
@@ -242,6 +242,8 @@ export function toFriendlyJSON(obj: object): string {
         ).toFriendlyJSON
       ) {
         return value.toFriendlyJSON();
+      } else if (value && value.type && ['Fr', 'Fq', 'AztecAddress'].includes(value.type)) {
+        return value.value;
       } else {
         return value;
       }


### PR DESCRIPTION
Fixes automatic gas estimation for contract deployments from aztecjs when the contract has a public initializer, as they would fail with an "unknown contract" during that simulation.