### PR TITLE
chore: Delete redundant CircleCI GCC job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,18 +105,6 @@ jobs:
           command: cond_spot_run_build barretenberg-wasm-linux-clang 128
           aztec_manifest_key: barretenberg-wasm-linux-clang
 
-  barretenberg-x86_64-linux-gcc:
-    docker:
-      - image: aztecprotocol/alpine-build-image
-    resource_class: small
-    steps:
-      - *checkout
-      - *setup_env
-      - run:
-          name: "Build"
-          command: cond_spot_run_build barretenberg-x86_64-linux-gcc 128
-          aztec_manifest_key: barretenberg-x86_64-linux-gcc
-
   barretenberg-x86_64-linux-clang:
     docker:
       - image: aztecprotocol/alpine-build-image
@@ -505,7 +493,6 @@ workflows:
       - avm-transpiler: *defaults
 
       # Barretenberg
-      - barretenberg-x86_64-linux-gcc: *defaults
       - barretenberg-x86_64-linux-clang: *defaults
       - barretenberg-x86_64-linux-clang-assert: *defaults
       # - barretenberg-x86_64-linux-clang-fuzzing: *defaults
@@ -555,7 +542,6 @@ workflows:
       # Everything that must complete before deployment.
       - end:
           requires:
-            - barretenberg-x86_64-linux-gcc
             - barretenberg-x86_64-linux-clang
             - barretenberg-x86_64-linux-clang-assert
             # - barretenberg-x86_64-linux-clang-fuzzing

--- a/build_manifest.yml
+++ b/build_manifest.yml
@@ -84,12 +84,6 @@ barretenberg-x86_64-linux-clang-fuzzing:
   dockerfile: dockerfiles/Dockerfile.x86_64-linux-clang-fuzzing
   rebuildPatterns: .rebuild_patterns
 
-# Builds all of barretenberg with gcc. Ensures compiler compatibility.
-barretenberg-x86_64-linux-gcc:
-  buildDir: barretenberg/cpp
-  dockerfile: dockerfiles/Dockerfile.x86_64-linux-gcc
-  rebuildPatterns: .rebuild_patterns
-
 # Builds barretenberg.wasm (single and multithreaded builds).
 barretenberg-wasm-linux-clang:
   buildDir: barretenberg/cpp


### PR DESCRIPTION
In our switch to Earthly we have introduced a job to build Barretenberg using GCC-13, the goal being to ensure that our code is not overly clang-specific. Given the goal, is it unnecessary to keep building with GCC-12 in our  backup CircleCI setup. This CirclCI job has recently broken due to a difference in settings. It is not a goal of ours to support old versions of GCC, so we delete the job.