### PR TITLE
feat: Add code-workspace and update build dirs

### DIFF
--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -71,7 +71,7 @@
       "displayName": "Debugging build with Clang-16",
       "description": "Build with globally installed Clang-16 in debug mode",
       "inherits": "clang16",
-      "binaryDir": "build",
+      "binaryDir": "build-debug",
       "environment": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CFLAGS": "-gdwarf-4",
@@ -88,6 +88,7 @@
       "displayName": "Optimized debug build with Clang-16",
       "description": "Build with globally installed Clang-16 in optimized debug mode",
       "inherits": "clang16-dbg",
+      "binaryDir": "build-debug-fast",
       "environment": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CFLAGS": "-O2 -gdwarf",
@@ -97,6 +98,7 @@
     },
     {
       "name": "clang16-assert",
+      "binaryDir": "build-assert",
       "displayName": "Build with Clang-16 using RelWithAssert",
       "description": "Build with globally installed Clang-16 in release with ASSERTs mode",
       "inherits": "clang16",

--- a/proving-systems.code-workspace
+++ b/proving-systems.code-workspace
@@ -1,0 +1,150 @@
+{
+    // Each "folder" can define a different project in the main repo,  
+    // relative to `.code-workspace`.
+    "folders": [
+        {
+            "name": "aztec-packages",
+            "path": "./"
+        },
+    ],
+    // List recommended extensions for the whole workspace.
+    "extensions": {
+        "recommendations": [
+            "GitHub.vscode-pull-request-github",
+            // Enables CMake integration and configuration
+            // for easier building
+            "ms-vscode.cmake-tools",
+            // Provides a nice UI for listing all Google Test
+            // tests, including launching a debug session
+            // for a specific test directly.
+            // Also provides buttons alongside test definitions.
+            "matepek.vscode-catch2-test-adapter",
+            // Integrates the `clangd` language server for
+            // - code formatting (clang-format)
+            // - static analysis (clang-tidy)
+            // - hints, tooltips, and more.
+            "llvm-vs-code-extensions.vscode-clangd",
+            // Better syntax highlighting for C++.
+            // Make sure to select one of the themes suggested
+            // (e.g. "Dark+")
+            "jeff-hykin.better-cpp-syntax",
+            // Handle CMakeLists.txt editing
+            "twxs.cmake",
+            // Integrates LLDB debugger
+            "vadimcn.vscode-lldb",
+            // Generate nicer Doxygen comments
+            "cschlosser.doxdocgen",
+            // Makes the CMake build output slightly
+            // prettier.
+            "IBM.output-colorizer",
+            "eamodio.gitlens",
+            "esbenp.prettier-vscode"
+        ],
+        "unwantedRecommendations": [
+            // The following may have been installed
+            // and cause some confusion when running
+            // tests.
+            // The options provided by C++ TestMate
+            // should be good enough.
+            "ms-vscode.cpptools-themes",
+            "hbenl.vscode-test-explorer",
+            "ms-vscode.test-adapter-converter",
+            "fredericbonnet.cmake-test-adapter",
+            "ms-vscode.cpptools-extension-pack",
+            // Used to enable GDB debugging
+            // Most features are disabled in `settings.json`
+            // which confict with `clangd`
+            // Since we ignore GDB, we no longer need this extension
+            "ms-vscode.cpptools"
+        ]
+    },
+    // Global settings which will apply to all subprojects.
+    // Each subproject may have their own `.vscode/settings.json`
+    // for configuring extensions which are specific to a certain project.
+    // Some settings can only be configured here.
+    "settings": {
+        "files.associations": {
+            "*.tcc": "cpp",
+          },
+        //
+        // Clangd. Note that this setting may be overridden by  user settings
+        // to the default value "clangd".
+        //
+        "clangd.path": "clangd-16",
+        // We should disable automatic inclusion of headers unless we decif6de to follow "WhyIWYU".
+        "clangd.arguments": [
+            "-header-insertion=never"
+        ],
+        //
+        // CMake
+        //
+        // Location of base CMakeLists file
+        "cmake.sourceDirectory": "${workspaceFolder}/barretenberg/cpp/",
+        //
+        // C/C++ (should be disabled)
+        //
+        // Make sure all C++ IntelliSense features are disabled
+        // and don't interfere with clangd
+        "C_Cpp.intelliSenseEngine": "disabled",
+        "C_Cpp.autocomplete": "disabled",
+        "C_Cpp.codeAnalysis.clangTidy.codeAction.formatFixes": false,
+        "C_Cpp.codeAnalysis.runAutomatically": false,
+        "C_Cpp.configurationWarnings": "disabled",
+        "C_Cpp.debugShortcut": false,
+        "C_Cpp.default.enableConfigurationSquiggles": false,
+        "C_Cpp.formatting": "disabled",
+        "C_Cpp.vcpkg.enabled": false,
+        //
+        // TestMate
+        //
+        // Ensures tests are run from the `build` directory
+        // which ensures SRS can be read
+        "testMate.cpp.test.workingDirectory": "${command:cmake.buildDirectory}",
+        // Filter all binaries that are not tests or benchmarks
+        "testMate.cpp.test.executables": "${command:cmake.buildDirectory}/bin/*{test,Test,TEST,bench}*",
+        //
+        // Other
+        //
+        "editor.tokenColorCustomizations": {
+            "textMateRules": [
+                {
+                    "scope": "googletest.failed",
+                    "settings": {
+                        "foreground": "#f00"
+                    }
+                },
+                {
+                    "scope": "googletest.passed",
+                    "settings": {
+                        "foreground": "#0f0"
+                    }
+                },
+                {
+                    "scope": "googletest.run",
+                    "settings": {
+                        "foreground": "#0f0"
+                    }
+                }
+            ]
+        },
+        "[cpp]": {
+            "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
+        },
+        "cmake.configureArgs": [
+            "-G Ninja"
+        ],
+        "cmake.useCMakePresets": "always",
+        "editor.inlayHints.enabled": "offUnlessPressed",
+        "git.detectSubmodules": false,
+        "testMate.cpp.discovery.loadOnStartup": false,
+        "testMate.cpp.debug.configTemplate": {
+            "type": "lldb",
+            "MIMode": "lldb",
+            "program": "${exec}",
+            "args": "${argsArray}",
+            "cwd": "${command:cmake.buildDirectory}",
+            "internalConsoleOptions": "openOnSessionStart",
+            "console": "internalConsole",
+        }    
+    },
+}


### PR DESCRIPTION
Adds a set of VS Code settings in proving-systems.code-workspace akin to what we have in barretenberg.code-workspace, but situated at the top of the monorepo so that it's easier to work across the full stack. It also changes the build dir for debug and with-asserts builds to give a better incremental workflow.