### PR TITLE
chore: remove unused closing tag from `indexed_merkle_tree.mdx`

### DIFF
--- a/docs/docs/aztec/concepts/storage/trees/indexed_merkle_tree.mdx
+++ b/docs/docs/aztec/concepts/storage/trees/indexed_merkle_tree.mdx
@@ -384,4 +384,4 @@ Despite offering large performance improvements within the circuits, these come 
 
 #### Closing Notes
 
-We have been working with these new trees in order to reduce the proving time for our rollups in Aztec, however we think EVERY protocol leveraging nullifier trees should know about these trees as their performance benefit is considerable. \*/}
+We have been working with these new trees in order to reduce the proving time for our rollups in Aztec, however we think EVERY protocol leveraging nullifier trees should know about these trees as their performance benefit is considerable.


### PR DESCRIPTION
Quick fix for some crud which seems to be there by accident.