### PR TITLE
fix: CCI jobs for avm-transpiler and aztec-nargo should require job noir as prereq

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -485,8 +485,10 @@ workflows:
     #   # This is rewritten to 'system' on the real workflow (otherwise this is ignored by circleci)
     #   equal: [NEVER, << pipeline.parameters.workflow >>]
     when:
-      and:
+      # Run if branch is master or branch name contains 'circle-ci'
+      or:
         - equal: [ master, << pipeline.git.branch >> ]
+        - matches: { pattern: ".*circle-ci.*", value: << pipeline.git.branch >> }
     jobs:
       # Noir
       - noir-x86_64: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,10 +502,16 @@ workflows:
           <<: *defaults
 
       # Transpiler
-      - avm-transpiler: *defaults
+      - avm-transpiler:
+          requires:
+            - noir-ecr-manifest
+          <<: *defaults
 
       # aztec-nargo (nargo & transpiler)
-      - aztec-nargo: *defaults
+      - aztec-nargo:
+          requires:
+            - avm-transpiler
+          <<: *defaults
 
       # Barretenberg
       - barretenberg-x86_64-linux-clang: *defaults


### PR DESCRIPTION
Also, circle-ci triggered if branch name contains `circle-ci`