### PR TITLE
chore: checkout sync fix script from master

### DIFF
--- a/.github/workflows/pull-noir.yml
+++ b/.github/workflows/pull-noir.yml
@@ -101,6 +101,7 @@ jobs:
               git commit -am "[$LINES changes] $COMMIT_MESSAGE"
 
               # There's various changes which we need to make to account for CI differences so we run this script to apply them.
+              git checkout origin/master -- noir/scripts/sync-fixup.sh
               noir/scripts/sync-fixup.sh
               git commit -am "chore: apply sync fixes"
 


### PR DESCRIPTION
This PR pulls `noir/scripts/sync-fixup.sh` from master when syncing the Noir repository