### PR TITLE
chore(ci): allow updating lockfile in `sync-fixup.sh`

### DIFF
--- a/noir/scripts/sync-fixup.sh
+++ b/noir/scripts/sync-fixup.sh
@@ -7,8 +7,9 @@ tmp=$(mktemp)
 BACKEND_BARRETENBERG_PACKAGE_JSON=./tooling/noir_js_backend_barretenberg/package.json
 jq '.dependencies."@aztec/bb.js" = "portal:../../../../barretenberg/ts"' $BACKEND_BARRETENBERG_PACKAGE_JSON > $tmp && mv $tmp $BACKEND_BARRETENBERG_PACKAGE_JSON
 
-# update yarn.lock
-yarn install
+# This script runs in CI which enforces immutable installs by default,
+# we then must turn this off in order to update yarn.lock. 
+YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
 
 # Remove requirement for `wasm-opt` to be installed
 sed -i "s/^require_command wasm-opt/#require_command wasm-opt/" ./tooling/noirc_abi_wasm/build.sh


### PR DESCRIPTION
We're running into issues where yarn is recognising that it's running in CI and refusing to update the lockfile, which in this case is something that we want. This PR turns this behaviour off.