### PR TITLE
chore: dedup public data writes in kernel

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -63,6 +63,7 @@
     "Datas",
     "dbanks",
     "decrementation",
+    "deduped",
     "defi",
     "delegatecall",
     "delegatecalls",
@@ -296,7 +297,5 @@
     "lib",
     "*.cmake"
   ],
-  "flagWords": [
-    "anonymous"
-  ]
+  "flagWords": ["anonymous"]
 }

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_tail.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_tail.nr
@@ -119,8 +119,8 @@ mod tests {
         hash::{silo_nullifier, sha256_to_field},
         public_data_tree_leaf_preimage::PublicDataTreeLeafPreimage,
         tests::{fixture_builder::FixtureBuilder, merkle_tree_utils::NonEmptyMerkleTree, sort::sort_get_sorted_hints},
-        traits::is_empty, partial_state_reference::PartialStateReference, utils::arrays::array_merge,
-        merkle_tree::MembershipWitness
+        traits::is_empty, partial_state_reference::PartialStateReference,
+        utils::arrays::{array_length, array_merge}, merkle_tree::MembershipWitness
     };
 
     fn build_nullifier_tree<N>() -> NonEmptyMerkleTree<MAX_NEW_NULLIFIERS_PER_TX, NULLIFIER_TREE_HEIGHT, NULLIFIER_SUBTREE_SIBLING_PATH_LENGTH, NULLIFIER_SUBTREE_HEIGHT> {
@@ -322,20 +322,26 @@ mod tests {
                 previous_kernel.public_inputs.end_non_revertible.public_data_update_requests,
                 previous_kernel.public_inputs.end.public_data_update_requests
             );
-            let sorted = sort_get_sorted_hints(
-                merged,
-                |a: PublicDataUpdateRequest, b: PublicDataUpdateRequest| a.counter() < b.counter()
-            );
-            let sorted_public_data_update_requests = sorted.sorted_array;
-            let sorted_public_data_update_requests_indexes = sorted.sorted_index_hints;
+
+            let mut deduped_public_data_update_requests_runs = [0; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX];
+            let mut sorted_public_data_update_requests_indexes = [0; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX];
+            let array_length = array_length(merged);
+            for i in 0..MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX {
+                if i < array_length {
+                    deduped_public_data_update_requests_runs[i] = 1;
+                    sorted_public_data_update_requests_indexes[i] = i;
+                }
+            }
 
             let combine_hints = CombineHints {
                 sorted_note_hashes,
                 sorted_note_hashes_indexes,
                 sorted_unencrypted_logs_hashes,
                 sorted_unencrypted_logs_hashes_indexes,
-                sorted_public_data_update_requests,
-                sorted_public_data_update_requests_indexes
+                sorted_public_data_update_requests: merged,
+                sorted_public_data_update_requests_indexes,
+                deduped_public_data_update_requests: merged,
+                deduped_public_data_update_requests_runs
             };
 
             let kernel = PublicKernelTailCircuitPrivateInputs {

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_tail.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/public_kernel_tail.nr
@@ -329,8 +329,8 @@ mod tests {
             for i in 0..MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX {
                 if i < array_length {
                     deduped_public_data_update_requests_runs[i] = 1;
-                    sorted_public_data_update_requests_indexes[i] = i;
                 }
+                sorted_public_data_update_requests_indexes[i] = i;
             }
 
             let combine_hints = CombineHints {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/combined_accumulated_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/combined_accumulated_data.nr
@@ -3,14 +3,14 @@ use crate::{
     abis::{
     accumulated_data::public_accumulated_data::PublicAccumulatedData, note_hash::NoteHash,
     nullifier::Nullifier, public_data_update_request::PublicDataUpdateRequest,
-    log_hash::{LogHash, NoteLogHash}, gas::Gas, side_effect::Ordered
+    log_hash::{LogHash, NoteLogHash}, gas::Gas, side_effect::{Ordered, Positioned}
 },
     constants::{
     MAX_NEW_NOTE_HASHES_PER_TX, MAX_NEW_NULLIFIERS_PER_TX, MAX_NEW_L2_TO_L1_MSGS_PER_TX,
     MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX, COMBINED_ACCUMULATED_DATA_LENGTH,
     MAX_UNENCRYPTED_LOGS_PER_TX
 },
-    utils::{arrays::{array_merge, assert_sorted_array}, reader::Reader},
+    utils::{arrays::{array_merge, assert_sorted_array, assert_deduped_array}, reader::Reader},
     traits::{Empty, Serialize, Deserialize}
 };
 
@@ -19,8 +19,12 @@ struct CombineHints {
     sorted_note_hashes_indexes: [u64; MAX_NEW_NOTE_HASHES_PER_TX],
     sorted_unencrypted_logs_hashes: [LogHash; MAX_UNENCRYPTED_LOGS_PER_TX],
     sorted_unencrypted_logs_hashes_indexes: [u64; MAX_UNENCRYPTED_LOGS_PER_TX],
+    // the public data update requests are sorted by their leaf index AND counter
     sorted_public_data_update_requests: [PublicDataUpdateRequest; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX],
     sorted_public_data_update_requests_indexes: [u64; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX],
+    // THEN deduplicated based on their leaf slot
+    deduped_public_data_update_requests: [PublicDataUpdateRequest; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX],
+    deduped_public_data_update_requests_runs: [u64; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX],
 }
 
 struct CombinedAccumulatedData {
@@ -65,11 +69,22 @@ impl CombinedAccumulatedData {
             non_revertible.public_data_update_requests,
             revertible.public_data_update_requests
         );
+
+        // by using a dummy function that always returns true, 
+        // we can check that the arrays are permutations of each other.
+        // We use this rather than the permutation check because this allows for zero padded permutations.
+        // Also, just check a permutation here,
+        // because the ordering checks are done in the dedup check.
         assert_sorted_array(
             merged_public_data_update_requests,
             combine_hints.sorted_public_data_update_requests,
             combine_hints.sorted_public_data_update_requests_indexes,
-            asc_sort_by_counters
+            |_,_| true
+        );
+        assert_deduped_array(
+            combine_hints.sorted_public_data_update_requests,
+            combine_hints.deduped_public_data_update_requests,
+            combine_hints.deduped_public_data_update_requests_runs
         );
 
         // TODO(Miranda): Hash here or elsewhere?
@@ -117,7 +132,7 @@ impl CombinedAccumulatedData {
             note_encrypted_log_preimages_length,
             encrypted_log_preimages_length,
             unencrypted_log_preimages_length,
-            public_data_update_requests: combine_hints.sorted_public_data_update_requests,
+            public_data_update_requests: combine_hints.deduped_public_data_update_requests,
             gas_used: revertible.gas_used + non_revertible.gas_used
         }
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/combined_accumulated_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/combined_accumulated_data.nr
@@ -10,7 +10,10 @@ use crate::{
     MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX, COMBINED_ACCUMULATED_DATA_LENGTH,
     MAX_UNENCRYPTED_LOGS_PER_TX
 },
-    utils::{arrays::{array_merge, assert_sorted_array, assert_deduped_array}, reader::Reader},
+    utils::{
+    arrays::{array_merge, assert_sorted_array, assert_deduped_array, check_padded_permutation},
+    reader::Reader
+},
     traits::{Empty, Serialize, Deserialize}
 };
 
@@ -70,17 +73,13 @@ impl CombinedAccumulatedData {
             revertible.public_data_update_requests
         );
 
-        // by using a dummy function that always returns true, 
-        // we can check that the arrays are permutations of each other.
-        // We use this rather than the permutation check because this allows for zero padded permutations.
-        // Also, just check a permutation here,
-        // because the ordering checks are done in the dedup check.
-        assert_sorted_array(
+        // Just check a permutation here...
+        check_padded_permutation(
             merged_public_data_update_requests,
             combine_hints.sorted_public_data_update_requests,
-            combine_hints.sorted_public_data_update_requests_indexes,
-            |_,_| true
+            combine_hints.sorted_public_data_update_requests_indexes
         );
+        // ...because the ordering checks are done here.
         assert_deduped_array(
             combine_hints.sorted_public_data_update_requests,
             combine_hints.deduped_public_data_update_requests,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/combined_accumulated_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/accumulated_data/combined_accumulated_data.nr
@@ -10,10 +10,7 @@ use crate::{
     MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX, COMBINED_ACCUMULATED_DATA_LENGTH,
     MAX_UNENCRYPTED_LOGS_PER_TX
 },
-    utils::{
-    arrays::{array_merge, assert_sorted_array, assert_deduped_array, check_padded_permutation},
-    reader::Reader
-},
+    utils::{arrays::{array_merge, assert_sorted_array, assert_deduped_array, check_permutation}, reader::Reader},
     traits::{Empty, Serialize, Deserialize}
 };
 
@@ -74,7 +71,7 @@ impl CombinedAccumulatedData {
         );
 
         // Just check a permutation here...
-        check_padded_permutation(
+        check_permutation(
             merged_public_data_update_requests,
             combine_hints.sorted_public_data_update_requests,
             combine_hints.sorted_public_data_update_requests_indexes

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_data_update_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_data_update_request.nr
@@ -5,7 +5,7 @@ use crate::public_data_tree_leaf::PublicDataTreeLeaf;
 use crate::address::AztecAddress;
 use crate::contrakt::storage_update_request::StorageUpdateRequest;
 use crate::data::hash::{compute_public_data_tree_value, compute_public_data_tree_index};
-use crate::abis::side_effect::Ordered;
+use crate::abis::side_effect::{Ordered, Positioned};
 
 struct PublicDataUpdateRequest {
     leaf_slot : Field,
@@ -23,6 +23,12 @@ impl PublicDataUpdateRequest {
             new_value: compute_public_data_tree_value(update_request.new_value),
             counter: update_request.counter
         }
+    }
+}
+
+impl Positioned for PublicDataUpdateRequest {
+    fn position(self) -> Field {
+        self.leaf_slot
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/side_effect.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/side_effect.nr
@@ -20,6 +20,11 @@ trait Scoped<T> where T: Eq {
     fn inner(self) -> T;
 }
 
+trait Positioned {
+    // Like a storage slot
+    fn position(self) -> Field;
+}
+
 trait Readable {
     fn assert_match_read_request(self, read_request: ScopedReadRequest);
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
@@ -180,7 +180,6 @@ pub fn assert_sorted_array<T, N, Env>(
     }
 }
 
-// C for container, T for type, N for length
 pub fn assert_deduped_array<T, N, Env>(
     original_array: [T; N],
     deduped_array: [T; N],

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
@@ -156,6 +156,26 @@ pub fn check_permutation<T, N>(
     }
 }
 
+pub fn check_padded_permutation<T, N>(
+    original_array: [T; N],
+    permuted_array: [T; N],
+    original_indexes: [u64; N]
+) where T: Eq + Empty {
+    let mut seen_empty = false;
+    for i in 0..N {
+        let original_value = original_array[i];
+        if is_empty(original_value) {
+            seen_empty = true;
+            assert(is_empty(permuted_array[i]), "Empty values must not be mixed with sorted values");
+        } else {
+            assert(!seen_empty, "Empty values must be padded to the right");
+
+            let index = original_indexes[i];
+            assert(permuted_array[index].eq(original_value), "Invalid index");
+        }
+    }
+}
+
 pub fn assert_sorted_array<T, N, Env>(
     original_array: [T; N],
     sorted_array: [T; N],
@@ -211,6 +231,10 @@ pub fn assert_deduped_array<T, N, Env>(
     [ (1,2,4), (2,3,3), (3,6,6), (4,8,9), (5,9,7), (0,0,0), ... padding with zeros ]
     */
 
+    let deduped_len = validate_array(deduped_array); // This also makes sure that the array is padded with empty items.  
+    let run_lengths_len = array_length(run_lengths); // Don't have to be a "validated" array because non zero padded values don't hurt.  
+    assert_eq(deduped_len, run_lengths_len, "Deduped array length does not match number of run lengths");
+
     let mut seen_empty = false;
     // container at the start of the current run
     let mut start_run_index = 0;
@@ -246,16 +270,7 @@ pub fn assert_deduped_array<T, N, Env>(
         }
     }
 
-    assert_eq(deduped_index, array_length(deduped_array), "Deduped array length does not match run lengths");
-
-    for i in 0..N {
-        if i + deduped_index < N {
-            assert(
-                is_empty(deduped_array[i + deduped_index]), "Empty values must be padded to the right in padding"
-            );
-            assert(run_lengths[i + deduped_index] == 0, "Invalid run length for padding");
-        }
-    }
+    assert_eq(deduped_index, deduped_len, "Final deduped index does not match deduped array length");
 }
 
 mod tests {
@@ -446,6 +461,7 @@ mod tests {
         let run_lengths = [3, 1, 1, 0];
         assert_deduped_array(original_array, deduped_array, run_lengths);
     }
+
     #[test(should_fail_with = "The container we are collapsing into must match the current container")]
     fn test_mismatched_deduped_value() {
         let original_array = [
@@ -463,7 +479,8 @@ mod tests {
         let run_lengths = [2, 1, 1, 0];
         assert_deduped_array(original_array, deduped_array, run_lengths);
     }
-    #[test(should_fail_with = "Invalid run length for padding")]
+
+    #[test(should_fail_with = "Deduped array length does not match number of run lengths")]
     fn test_run_lengths_not_zero_padded() {
         let original_array = [
             TestContainer { value: 1, position: 1, counter: 1 },
@@ -480,7 +497,8 @@ mod tests {
         let run_lengths = [2, 1, 1, 1]; // Last element should be 0
         assert_deduped_array(original_array, deduped_array, run_lengths);
     }
-    #[test(should_fail_with = "Deduped array length does not match run lengths")]
+
+    #[test(should_fail_with = "Deduped array length does not match number of run lengths")]
     fn test_deduped_padding_not_zero_padded() {
         let original_array = [
             TestContainer { value: 1, position: 1, counter: 1 },

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
@@ -1,6 +1,7 @@
 use dep::std::array;
 use dep::std::cmp::Eq;
 use crate::traits::{Empty, is_empty};
+use crate::abis::side_effect::{Positioned, Ordered};
 
 pub fn array_to_bounded_vec<T, N>(array: [T; N]) -> BoundedVec<T, N> where T: Empty + Eq {
     let mut len = 0;
@@ -176,6 +177,326 @@ pub fn assert_sorted_array<T, N, Env>(
                 assert(ordering(sorted_array[i - 1], sorted_array[i]), "Values not sorted");
             }
         }
+    }
+}
+
+// C for container, T for type, N for length
+pub fn assert_deduped_array<T, N, Env>(
+    original_array: [T; N],
+    deduped_array: [T; N],
+    run_lengths: [u64; N]
+) where T: Positioned + Ordered + Empty + Eq {
+    /*
+    The original_array here needs to be sorted based on the `position` field of the container,
+    *and* a secondary sort based on the `counter` field of the container. 
+
+    For example, the storage slot in the case of public data update requests.
+    The run_lengths array should contain the length of each run of the original_array.
+    The deduped_array should contain the deduplicated array.
+
+    For example, if the original array is writing `(position,value,counter)`s:
+    [ (1,1,1), (1,2,4), (2,3,3), (3,4,2), (3,5,5), (3,6,6), (4,7,8), (4,8,9), (5,9,7), (0,0,0), ... padding with zeros ]
+    then run_lengths array is:
+    [
+        2, // run of 1s
+        1, // run of 2
+        3, // run of 3s
+        2, // run of 4s
+        1, // run of 5
+        0,
+        0,
+        ... padding with zeros
+    ]
+    
+    then the deduped_array should be:
+    [ (1,2,4), (2,3,3), (3,6,6), (4,8,9), (5,9,7), (0,0,0), ... padding with zeros ]
+    */
+
+    let mut seen_empty = false;
+    // container at the start of the current run
+    let mut start_run_index = 0;
+    // the index we are collapsing into
+    let mut deduped_index = 0;
+    // the length of the current run we are collapsing
+    let mut run_counter = run_lengths[deduped_index];
+    for i in 0..N {
+        let current_container = original_array[i];
+        if is_empty(current_container) {
+            seen_empty = true;
+        } else {
+            assert(!seen_empty, "Empty values must be padded to the right");
+            assert(run_counter > 0, "Invalid run length");
+            assert(
+                current_container.position().eq(original_array[start_run_index].position()), "The position of the current container must match the start of the run"
+            );
+            run_counter -= 1;
+            if run_counter == 0 {
+                assert(
+                    deduped_array[deduped_index].eq(current_container), "The container we are collapsing into must match the current container"
+                );
+                start_run_index = i + 1;
+                deduped_index += 1;
+                run_counter = run_lengths[deduped_index];
+            } else {
+                // we're in a run, so this container must have a lower counter.
+                // note we don't check for overflow here, as the run_lengths array must be correct.
+                assert(
+                    current_container.counter() <= original_array[i + 1].counter(), "Containers in a run must be sorted by counter"
+                );
+            }
+        }
+    }
+
+    assert_eq(deduped_index, array_length(deduped_array), "Deduped array length does not match run lengths");
+
+    for i in 0..N {
+        if i + deduped_index < N {
+            assert(
+                is_empty(deduped_array[i + deduped_index]), "Empty values must be padded to the right in padding"
+            );
+            assert(run_lengths[i + deduped_index] == 0, "Invalid run length for padding");
+        }
+    }
+}
+
+mod tests {
+
+    use crate::utils::arrays::assert_deduped_array;
+    use crate::abis::side_effect::{Positioned, Ordered};
+    use crate::traits::{Empty, is_empty};
+
+    struct TestContainer {
+        value: Field,
+        position: Field,
+        counter: u32,
+    }
+
+    impl Positioned for TestContainer {
+        fn position(self) -> Field {
+            self.position
+        }
+    }
+
+    impl Ordered for TestContainer {
+        fn counter(self) -> u32 {
+            self.counter
+        }
+    }
+
+    impl Empty for TestContainer {
+        fn empty() -> Self {
+            TestContainer { value: 0, position: 0, counter: 0 }
+        }
+    }
+
+    impl Eq for TestContainer {
+        fn eq(self, other: Self) -> bool {
+            self.value.eq(other.value) & self.position.eq(other.position) & self.counter.eq(other.counter)
+        }
+    }
+
+    #[test]
+    fn assert_deduped_array_basic_test() {
+        let original_array = [
+            TestContainer { value: 1, position: 1, counter: 1 },
+            TestContainer { value: 2, position: 1, counter: 4 },
+            TestContainer { value: 3, position: 2, counter: 3 },
+            TestContainer { value: 4, position: 3, counter: 2 },
+            TestContainer { value: 5, position: 3, counter: 5 },
+            TestContainer { value: 6, position: 3, counter: 6 },
+            TestContainer { value: 7, position: 4, counter: 8 },
+            TestContainer { value: 8, position: 4, counter: 9 },
+            TestContainer { value: 9, position: 5, counter: 7 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 }
+        ];
+        let deduped_array = [
+            TestContainer { value: 2, position: 1, counter: 4 },
+            TestContainer { value: 3, position: 2, counter: 3 },
+            TestContainer { value: 6, position: 3, counter: 6 },
+            TestContainer { value: 8, position: 4, counter: 9 },
+            TestContainer { value: 9, position: 5, counter: 7 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 }
+        ];
+        let run_lengths = [2, 1, 3, 2, 1, 0, 0, 0, 0, 0, 0, 0];
+        assert_deduped_array(original_array, deduped_array, run_lengths);
+    }
+
+    #[test]
+    fn assert_deduped_array_empty_arrays() {
+        let original_array = [TestContainer { value: 0, position: 0, counter: 0 }; 12];
+        let deduped_array = [TestContainer { value: 0, position: 0, counter: 0 }; 12];
+        let run_lengths = [0; 12];
+        assert_deduped_array(original_array, deduped_array, run_lengths);
+    }
+
+    #[test]
+    fn assert_deduped_array_no_duplicates() {
+        let original_array = [
+            TestContainer { value: 1, position: 1, counter: 1 },
+            TestContainer { value: 2, position: 2, counter: 2 },
+            TestContainer { value: 3, position: 3, counter: 3 },
+            TestContainer { value: 4, position: 4, counter: 4 },
+            TestContainer { value: 5, position: 5, counter: 5 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 }
+        ];
+        let deduped_array = original_array;
+        let run_lengths = [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0];
+        assert_deduped_array(original_array, deduped_array, run_lengths);
+    }
+
+    #[test]
+    fn assert_deduped_array_single_run_at_end() {
+        let original_array = [
+            TestContainer { value: 1, position: 1, counter: 1 },
+            TestContainer { value: 2, position: 2, counter: 2 },
+            TestContainer { value: 3, position: 3, counter: 3 },
+            TestContainer { value: 4, position: 4, counter: 4 },
+            TestContainer { value: 5, position: 5, counter: 5 },
+            TestContainer { value: 6, position: 6, counter: 7 },
+            TestContainer { value: 7, position: 6, counter: 8 },
+            TestContainer { value: 8, position: 6, counter: 9 }
+        ];
+        let deduped_array = [
+            TestContainer { value: 1, position: 1, counter: 1 },
+            TestContainer { value: 2, position: 2, counter: 2 },
+            TestContainer { value: 3, position: 3, counter: 3 },
+            TestContainer { value: 4, position: 4, counter: 4 },
+            TestContainer { value: 5, position: 5, counter: 5 },
+            TestContainer { value: 8, position: 6, counter: 9 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 }
+        ];
+        let run_lengths = [1, 1, 1, 1, 1, 3, 0, 0];
+        assert_deduped_array(original_array, deduped_array, run_lengths);
+    }
+
+    #[test]
+    fn assert_deduped_array_all_duplicates() {
+        let original_array = [
+            TestContainer { value: 1, position: 1, counter: 1 },
+            TestContainer { value: 2, position: 1, counter: 2 },
+            TestContainer { value: 3, position: 1, counter: 3 },
+            TestContainer { value: 4, position: 1, counter: 4 },
+            TestContainer { value: 5, position: 1, counter: 5 },
+            TestContainer { value: 6, position: 1, counter: 6 },
+            TestContainer { value: 7, position: 1, counter: 7 },
+            TestContainer { value: 8, position: 1, counter: 8 },
+            TestContainer { value: 9, position: 1, counter: 9 }
+        ];
+        let deduped_array = [
+            TestContainer { value: 9, position: 1, counter: 9 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 }
+        ];
+        let run_lengths = [9, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_deduped_array(original_array, deduped_array, run_lengths);
+    }
+
+    #[test(should_fail_with = "Empty values must be padded to the right")]
+    fn test_empty_not_padded_right() {
+        let original_array = [
+            TestContainer { value: 1, position: 1, counter: 1 },
+            TestContainer { value: 2, position: 1, counter: 2 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 3, position: 2, counter: 3 }
+        ];
+        let deduped_array = [
+            TestContainer { value: 2, position: 1, counter: 2 },
+            TestContainer { value: 3, position: 2, counter: 3 },
+            TestContainer { value: 0, position: 0, counter: 0 },
+            TestContainer { value: 0, position: 0, counter: 0 }
+        ];
+        let run_lengths = [2, 1, 0, 0];
+        assert_deduped_array(original_array, deduped_array, run_lengths);
+    }
+
+    #[test(should_fail_with = "The position of the current container must match the start of the run")]
+    fn test_mismatched_position_in_run() {
+        let original_array = [
+            TestContainer { value: 1, position: 1, counter: 1 },
+            TestContainer { value: 2, position: 1, counter: 2 },
+            TestContainer { value: 3, position: 2, counter: 3 },
+            TestContainer { value: 4, position: 3, counter: 4 }
+        ];
+        let deduped_array = [
+            TestContainer { value: 2, position: 1, counter: 2 },
+            TestContainer { value: 3, position: 2, counter: 3 },
+            TestContainer { value: 4, position: 3, counter: 4 },
+            TestContainer { value: 0, position: 0, counter: 0 }
+        ];
+        let run_lengths = [3, 1, 1, 0];
+        assert_deduped_array(original_array, deduped_array, run_lengths);
+    }
+    #[test(should_fail_with = "The container we are collapsing into must match the current container")]
+    fn test_mismatched_deduped_value() {
+        let original_array = [
+            TestContainer { value: 1, position: 1, counter: 1 },
+            TestContainer { value: 2, position: 1, counter: 2 },
+            TestContainer { value: 3, position: 2, counter: 3 },
+            TestContainer { value: 4, position: 3, counter: 4 }
+        ];
+        let deduped_array = [
+            TestContainer { value: 1, position: 1, counter: 1 },
+            TestContainer { value: 3, position: 2, counter: 3 },
+            TestContainer { value: 4, position: 3, counter: 4 },
+            TestContainer { value: 0, position: 0, counter: 0 }
+        ];
+        let run_lengths = [2, 1, 1, 0];
+        assert_deduped_array(original_array, deduped_array, run_lengths);
+    }
+    #[test(should_fail_with = "Invalid run length for padding")]
+    fn test_run_lengths_not_zero_padded() {
+        let original_array = [
+            TestContainer { value: 1, position: 1, counter: 1 },
+            TestContainer { value: 2, position: 1, counter: 2 },
+            TestContainer { value: 3, position: 2, counter: 3 },
+            TestContainer { value: 4, position: 3, counter: 4 }
+        ];
+        let deduped_array = [
+            TestContainer { value: 2, position: 1, counter: 2 },
+            TestContainer { value: 3, position: 2, counter: 3 },
+            TestContainer { value: 4, position: 3, counter: 4 },
+            TestContainer { value: 0, position: 0, counter: 0 }
+        ];
+        let run_lengths = [2, 1, 1, 1]; // Last element should be 0
+        assert_deduped_array(original_array, deduped_array, run_lengths);
+    }
+    #[test(should_fail_with = "Deduped array length does not match run lengths")]
+    fn test_deduped_padding_not_zero_padded() {
+        let original_array = [
+            TestContainer { value: 1, position: 1, counter: 1 },
+            TestContainer { value: 2, position: 1, counter: 2 },
+            TestContainer { value: 3, position: 2, counter: 3 },
+            TestContainer { value: 4, position: 3, counter: 4 }
+        ];
+        let deduped_array = [
+            TestContainer { value: 2, position: 1, counter: 2 },
+            TestContainer { value: 3, position: 2, counter: 3 },
+            TestContainer { value: 4, position: 3, counter: 4 },
+            TestContainer { value: 1, position: 1, counter: 1 }// Last element should be 0
+        ];
+        let run_lengths = [2, 1, 1, 0];
+        assert_deduped_array(original_array, deduped_array, run_lengths);
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
@@ -156,26 +156,6 @@ pub fn check_permutation<T, N>(
     }
 }
 
-pub fn check_padded_permutation<T, N>(
-    original_array: [T; N],
-    permuted_array: [T; N],
-    original_indexes: [u64; N]
-) where T: Eq + Empty {
-    let mut seen_empty = false;
-    for i in 0..N {
-        let original_value = original_array[i];
-        if is_empty(original_value) {
-            seen_empty = true;
-            assert(is_empty(permuted_array[i]), "Empty values must not be mixed with sorted values");
-        } else {
-            assert(!seen_empty, "Empty values must be padded to the right");
-
-            let index = original_indexes[i];
-            assert(permuted_array[index].eq(original_value), "Invalid index");
-        }
-    }
-}
-
 pub fn assert_sorted_array<T, N, Env>(
     original_array: [T; N],
     sorted_array: [T; N],

--- a/yarn-project/aztec.js/src/contract/get_gas_limits.test.ts
+++ b/yarn-project/aztec.js/src/contract/get_gas_limits.test.ts
@@ -1,5 +1,5 @@
 import { PublicKernelType, type SimulatedTx, mockSimulatedTx } from '@aztec/circuit-types';
-import { Gas } from '@aztec/circuits.js';
+import { type CombinedAccumulatedData, Gas } from '@aztec/circuits.js';
 
 import { getGasLimits } from './get_gas_limits.js';
 
@@ -9,7 +9,10 @@ describe('getGasLimits', () => {
 
   beforeEach(() => {
     simulatedTx = mockSimulatedTx();
-    simulatedTx.tx.data.publicInputs.end.gasUsed = Gas.from({ daGas: 100, l2Gas: 200 });
+
+    const data: CombinedAccumulatedData = simulatedTx.tx.data.publicInputs.end as CombinedAccumulatedData;
+    data.gasUsed = Gas.from({ daGas: 100, l2Gas: 200 });
+    simulatedTx.tx.data.publicInputs.end = data;
     simulatedTx.publicOutput!.gasUsed = {
       [PublicKernelType.SETUP]: Gas.from({ daGas: 10, l2Gas: 20 }),
       [PublicKernelType.APP_LOGIC]: Gas.from({ daGas: 20, l2Gas: 40 }),

--- a/yarn-project/circuits.js/src/hints/build_public_data_hints.ts
+++ b/yarn-project/circuits.js/src/hints/build_public_data_hints.ts
@@ -29,7 +29,7 @@ export async function buildPublicDataHints(
   oracle: PublicDataMembershipWitnessOracle,
   publicDataReads: Tuple<PublicDataRead, typeof MAX_PUBLIC_DATA_READS_PER_TX>,
   publicDataUpdateRequests: Tuple<PublicDataUpdateRequest, typeof MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX>,
-) {
+): Promise<Tuple<PublicDataHint, typeof MAX_PUBLIC_DATA_HINTS>> {
   const publicDataLeafSlots = [...publicDataReads, ...publicDataUpdateRequests]
     .filter(r => !r.isEmpty())
     .map(r => r.leafSlot.toBigInt());

--- a/yarn-project/circuits.js/src/interfaces/index.ts
+++ b/yarn-project/circuits.js/src/interfaces/index.ts
@@ -1,7 +1,13 @@
+import type { Fr } from '@aztec/foundation/fields';
+
 export interface IsEmpty {
   isEmpty: () => boolean;
 }
 
 export interface Ordered {
   counter: number;
+}
+
+export interface Positioned {
+  position: Fr;
 }

--- a/yarn-project/circuits.js/src/structs/kernel/combine_hints.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/combine_hints.ts
@@ -11,7 +11,7 @@ import {
   MAX_UNENCRYPTED_LOGS_PER_TX,
 } from '../../constants.gen.js';
 import {
-  deduplicateArray,
+  deduplicateSortedArray,
   getNonEmptyItems,
   mergeAccumulatedData,
   sortByCounterGetSortedHints,
@@ -113,7 +113,7 @@ export class CombineHints {
     const [sortedPublicDataUpdateRequests, sortedPublicDataUpdateRequestsIndexes] =
       sortByPositionThenCounterGetSortedHints(publicDataUpdateRequests, MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX);
 
-    const [dedupedPublicDataUpdateRequests, dedupedPublicDataUpdateRequestsRuns] = deduplicateArray(
+    const [dedupedPublicDataUpdateRequests, dedupedPublicDataUpdateRequestsRuns] = deduplicateSortedArray(
       sortedPublicDataUpdateRequests,
       MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
       () => PublicDataUpdateRequest.empty(),

--- a/yarn-project/circuits.js/src/structs/kernel/combine_hints.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/combine_hints.ts
@@ -10,7 +10,13 @@ import {
   MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
   MAX_UNENCRYPTED_LOGS_PER_TX,
 } from '../../constants.gen.js';
-import { getNonEmptyItems, mergeAccumulatedData, sortByCounterGetSortedHints } from '../../utils/index.js';
+import {
+  deduplicateArray,
+  getNonEmptyItems,
+  mergeAccumulatedData,
+  sortByCounterGetSortedHints,
+  sortByPositionThenCounterGetSortedHints,
+} from '../../utils/index.js';
 import { LogHash } from '../log_hash.js';
 import { NoteHash } from '../note_hash.js';
 import { PublicDataUpdateRequest } from '../public_data_update_request.js';
@@ -27,6 +33,11 @@ export class CombineHints {
       typeof MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX
     >,
     public readonly sortedPublicDataUpdateRequestsIndexes: Tuple<number, typeof MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX>,
+    public readonly dedupedPublicDataUpdateRequests: Tuple<
+      PublicDataUpdateRequest,
+      typeof MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX
+    >,
+    public readonly dedupedPublicDataUpdateRequestsRuns: Tuple<number, typeof MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX>,
   ) {}
 
   static getFields(fields: FieldsOf<CombineHints>) {
@@ -37,6 +48,8 @@ export class CombineHints {
       fields.sortedUnencryptedLogsHashesIndexes,
       fields.sortedPublicDataUpdateRequests,
       fields.sortedPublicDataUpdateRequestsIndexes,
+      fields.dedupedPublicDataUpdateRequests,
+      fields.dedupedPublicDataUpdateRequestsRuns,
     ] as const;
   }
 
@@ -55,6 +68,8 @@ export class CombineHints {
       reader.readNumbers(MAX_NEW_NOTE_HASHES_PER_TX),
       reader.readArray(MAX_UNENCRYPTED_LOGS_PER_TX, LogHash),
       reader.readNumbers(MAX_UNENCRYPTED_LOGS_PER_TX),
+      reader.readArray(MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX, PublicDataUpdateRequest),
+      reader.readNumbers(MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX),
       reader.readArray(MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX, PublicDataUpdateRequest),
       reader.readNumbers(MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX),
     );
@@ -95,9 +110,13 @@ export class CombineHints {
       MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
     );
 
-    const [sortedPublicDataUpdateRequests, sortedPublicDataUpdateRequestsIndexes] = sortByCounterGetSortedHints(
-      publicDataUpdateRequests,
+    const [sortedPublicDataUpdateRequests, sortedPublicDataUpdateRequestsIndexes] =
+      sortByPositionThenCounterGetSortedHints(publicDataUpdateRequests, MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX);
+
+    const [dedupedPublicDataUpdateRequests, dedupedPublicDataUpdateRequestsRuns] = deduplicateArray(
+      sortedPublicDataUpdateRequests,
       MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
+      () => PublicDataUpdateRequest.empty(),
     );
 
     return CombineHints.from({
@@ -107,6 +126,8 @@ export class CombineHints {
       sortedUnencryptedLogsHashesIndexes,
       sortedPublicDataUpdateRequests,
       sortedPublicDataUpdateRequestsIndexes,
+      dedupedPublicDataUpdateRequests,
+      dedupedPublicDataUpdateRequestsRuns,
     });
   }
 
@@ -123,7 +144,11 @@ export class CombineHints {
   sortedPublicDataUpdateRequests: ${getNonEmptyItems(this.sortedPublicDataUpdateRequests)
     .map(h => inspect(h))
     .join(', ')},
-  sortedPublicDataUpdateRequestsIndexes: ${this.sortedPublicDataUpdateRequestsIndexes}
+  sortedPublicDataUpdateRequestsIndexes: ${this.sortedPublicDataUpdateRequestsIndexes},
+  dedupedPublicDataUpdateRequests: ${getNonEmptyItems(this.dedupedPublicDataUpdateRequests)
+    .map(h => inspect(h))
+    .join(', ')},
+  dedupedPublicDataUpdateRequestsRuns: ${this.dedupedPublicDataUpdateRequestsRuns},
 }`;
   }
 }

--- a/yarn-project/circuits.js/src/structs/kernel/combine_hints.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/combine_hints.ts
@@ -110,8 +110,19 @@ export class CombineHints {
       MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
     );
 
+    // Since we're using `check_permutation` in the circuit, we need index hints based on the original array.
     const [sortedPublicDataUpdateRequests, sortedPublicDataUpdateRequestsIndexes] =
-      sortByPositionThenCounterGetSortedHints(publicDataUpdateRequests, MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX);
+      sortByPositionThenCounterGetSortedHints(publicDataUpdateRequests, MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX, {
+        ascending: true,
+        hintIndexesBy: 'original',
+      });
+
+    // further, we need to fill in the rest of the hints with an identity mapping
+    for (let i = 0; i < MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX; i++) {
+      if (publicDataUpdateRequests[i].isEmpty()) {
+        sortedPublicDataUpdateRequestsIndexes[i] = i;
+      }
+    }
 
     const [dedupedPublicDataUpdateRequests, dedupedPublicDataUpdateRequestsRuns] = deduplicateSortedArray(
       sortedPublicDataUpdateRequests,

--- a/yarn-project/circuits.js/src/structs/kernel/public_accumulated_data.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/public_accumulated_data.ts
@@ -31,21 +31,21 @@ export class PublicAccumulatedData {
     /**
      * The new nullifiers made in this transaction.
      */
-    public newNullifiers: Tuple<Nullifier, typeof MAX_NEW_NULLIFIERS_PER_TX>,
+    public readonly newNullifiers: Tuple<Nullifier, typeof MAX_NEW_NULLIFIERS_PER_TX>,
     /**
      * All the new L2 to L1 messages created in this transaction.
      */
-    public newL2ToL1Msgs: Tuple<Fr, typeof MAX_NEW_L2_TO_L1_MSGS_PER_CALL>,
+    public readonly newL2ToL1Msgs: Tuple<Fr, typeof MAX_NEW_L2_TO_L1_MSGS_PER_CALL>,
     /**
      * Accumulated encrypted note logs hashes from all the previous kernel iterations.
      * Note: Truncated to 31 bytes to fit in Fr.
      */
-    public noteEncryptedLogsHashes: Tuple<LogHash, typeof MAX_NOTE_ENCRYPTED_LOGS_PER_TX>,
+    public readonly noteEncryptedLogsHashes: Tuple<LogHash, typeof MAX_NOTE_ENCRYPTED_LOGS_PER_TX>,
     /**
      * Accumulated encrypted logs hashes from all the previous kernel iterations.
      * Note: Truncated to 31 bytes to fit in Fr.
      */
-    public encryptedLogsHashes: Tuple<LogHash, typeof MAX_ENCRYPTED_LOGS_PER_TX>,
+    public readonly encryptedLogsHashes: Tuple<LogHash, typeof MAX_ENCRYPTED_LOGS_PER_TX>,
     /**
      * Accumulated unencrypted logs hashes from all the previous kernel iterations.
      * Note: Truncated to 31 bytes to fit in Fr.
@@ -64,7 +64,7 @@ export class PublicAccumulatedData {
     public readonly publicCallStack: Tuple<CallRequest, typeof MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX>,
 
     /** Gas used so far by the transaction. */
-    public gasUsed: Gas,
+    public readonly gasUsed: Gas,
   ) {}
 
   toBuffer() {

--- a/yarn-project/circuits.js/src/structs/public_data_update_request.ts
+++ b/yarn-project/circuits.js/src/structs/public_data_update_request.ts
@@ -44,6 +44,10 @@ export class PublicDataUpdateRequest {
     return this.sideEffectCounter;
   }
 
+  get position() {
+    return this.leafSlot;
+  }
+
   toBuffer() {
     return serializeToBuffer(this.leafSlot, this.newValue, this.sideEffectCounter);
   }

--- a/yarn-project/circuits.js/src/tests/factories.ts
+++ b/yarn-project/circuits.js/src/tests/factories.ts
@@ -683,6 +683,12 @@ export function makeCombineHints(seed = 1): CombineHints {
       seed + 0x300,
     ),
     sortedPublicDataUpdateRequestsIndexes: makeTuple(MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX, i => i, seed + 0x400),
+    dedupedPublicDataUpdateRequests: makeTuple(
+      MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
+      makePublicDataUpdateRequest,
+      seed + 0x500,
+    ),
+    dedupedPublicDataUpdateRequestsRuns: makeTuple(MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX, i => i, seed + 0x600),
   });
 }
 

--- a/yarn-project/circuits.js/src/utils/index.ts
+++ b/yarn-project/circuits.js/src/utils/index.ts
@@ -56,12 +56,26 @@ export function compareByCounter<T extends Ordered>(a: T, b: T): number {
   return a.counter - b.counter;
 }
 
+export function sortByCounter<T extends Ordered & IsEmpty, N extends number>(
+  arr: Tuple<T, N>,
+  ascending: boolean = true,
+): Tuple<T, N> {
+  return genericSort(arr, compareByCounter, ascending);
+}
+
 export function compareByPositionThenCounter<T extends Ordered & Positioned>(a: T, b: T): number {
   const positionComp = a.position.cmp(b.position);
   if (positionComp !== 0) {
     return positionComp;
   }
   return a.counter - b.counter;
+}
+
+export function sortByPositionThenCounter<T extends Ordered & Positioned & IsEmpty, N extends number>(
+  arr: Tuple<T, N>,
+  ascending: boolean = true,
+): Tuple<T, N> {
+  return genericSort(arr, compareByPositionThenCounter, ascending);
 }
 
 export function sortAndGetSortedHints<T extends IsEmpty, N extends number>(
@@ -105,7 +119,13 @@ export function sortByPositionThenCounterGetSortedHints<T extends Ordered & Posi
   return sortAndGetSortedHints(arr, compareByPositionThenCounter, length, ascending);
 }
 
-export function deduplicateArray<T extends Ordered & IsEmpty & Positioned, N extends number>(
+/**
+ * @param arr An array sorted on position then counter.
+ * @param length for type inference.
+ * @param getEmptyItem helper function to get an empty item.
+ * @returns the array deduplicated by position, and the original run lengths of each position.
+ */
+export function deduplicateSortedArray<T extends Ordered & IsEmpty & Positioned, N extends number>(
   arr: Tuple<T, N>,
   length: N = arr.length as N,
   getEmptyItem: () => T,

--- a/yarn-project/circuits.js/src/utils/index.ts
+++ b/yarn-project/circuits.js/src/utils/index.ts
@@ -35,7 +35,7 @@ export function mergeAccumulatedData<T extends IsEmpty, N extends number>(
   return arr;
 }
 
-// Sort items by their counters in ascending order. All empty items (counter === 0) are padded to the right.
+// Sort items by a provided compare function. All empty items are padded to the right.
 export function genericSort<T extends IsEmpty, N extends number>(
   arr: Tuple<T, N>,
   compareFn: (a: T, b: T) => number,

--- a/yarn-project/end-to-end/src/benchmarks/bench_prover.test.ts
+++ b/yarn-project/end-to-end/src/benchmarks/bench_prover.test.ts
@@ -1,7 +1,7 @@
 import { getSchnorrAccount, getSchnorrWallet } from '@aztec/accounts/schnorr';
-import { TxStatus } from '@aztec/aztec.js';
+import { PrivateFeePaymentMethod, PublicFeePaymentMethod, TxStatus } from '@aztec/aztec.js';
 import { type AccountWallet } from '@aztec/aztec.js/wallet';
-import { CompleteAddress, Fq, Fr } from '@aztec/circuits.js';
+import { CompleteAddress, Fq, Fr, GasSettings } from '@aztec/circuits.js';
 import { FPCContract, GasTokenContract, TestContract, TokenContract } from '@aztec/noir-contracts.js';
 import { GasTokenAddress } from '@aztec/protocol-contracts/gas-token';
 import { type PXEService, createPXEService } from '@aztec/pxe';
@@ -160,58 +160,54 @@ describe('benchmarks/proving', () => {
     ctx.logger.info('+----------------------+');
 
     const fnCalls = [
-      //(await getTestContractOnPXE(1)).methods.emit_unencrypted(43),
-      //(await getTestContractOnPXE(2)).methods.create_l2_to_l1_message_public(45, 46, EthAddress.random()),
       (await getTokenContract(0)).methods.transfer_public(schnorrWalletAddress.address, recipient.address, 1000, 0),
       (await getTokenContract(1)).methods.transfer(schnorrWalletAddress.address, recipient.address, 1000, 0),
+      // (await getTestContractOnPXE(2)).methods.emit_unencrypted(43),
+      // (await getTestContractOnPXE(3)).methods.create_l2_to_l1_message_public(45, 46, EthAddress.random()),
     ];
 
-    // const feeFnCall1 = {
-    //   gasSettings: GasSettings.default(),
-    //   paymentMethod: new PublicFeePaymentMethod(
-    //     initialTokenContract.address,
-    //     initialFpContract.address,
-    //     await getWalletOnPxe(2),
-    //   ),
-    // };
+    const feeFnCall0 = {
+      gasSettings: GasSettings.default(),
+      paymentMethod: new PublicFeePaymentMethod(
+        initialTokenContract.address,
+        initialFpContract.address,
+        await getWalletOnPxe(0),
+      ),
+    };
 
-    // const feeFnCall3 = {
-    //   gasSettings: GasSettings.default(),
-    //   paymentMethod: new PrivateFeePaymentMethod(
-    //     initialTokenContract.address,
-    //     initialFpContract.address,
-    //     await getWalletOnPxe(2),
-    //   ),
-    // };
+    const feeFnCall1 = {
+      gasSettings: GasSettings.default(),
+      paymentMethod: new PrivateFeePaymentMethod(
+        initialTokenContract.address,
+        initialFpContract.address,
+        await getWalletOnPxe(1),
+      ),
+    };
 
-    ctx.logger.info('Proving first two transactions');
+    ctx.logger.info('Proving transactions');
     await Promise.all([
-      // fnCalls[0].prove({
-      //   fee: feeFnCall1,
-      // }),
-      fnCalls[0].prove(),
-      fnCalls[1].prove(),
+      fnCalls[0].prove({
+        fee: feeFnCall0,
+      }),
+      fnCalls[1].prove({
+        fee: feeFnCall1,
+      }),
+      // fnCalls[2].prove(),
+      // fnCalls[3].prove(),
     ]);
 
-    // ctx.logger.info('Proving the next transactions');
-    // await Promise.all([
-    //   fnCalls[2].prove(),
-    //   fnCalls[3].prove({
-    //     fee: feeFnCall3,
-    //   }),
-    // ]);
-
-    ctx.logger.info('Finished proving all transactions');
+    ctx.logger.info('Finished proving');
 
     ctx.logger.info('Sending transactions');
     const txs = [
-      // fnCalls[0].send({
-      //   fee: feeFnCall1,
-      // }),
-      fnCalls[0].send(),
-      fnCalls[1].send(),
+      fnCalls[0].send({
+        fee: feeFnCall0,
+      }),
+      fnCalls[1].send({
+        fee: feeFnCall1,
+      }),
       // fnCalls[2].send(),
-      // fnCalls[3].send({ fee: feeFnCall3 }),
+      // fnCalls[3].send(),
     ];
 
     const receipts = await Promise.all(txs.map(tx => tx.wait({ timeout: txTimeoutSec })));

--- a/yarn-project/noir-protocol-circuits-types/src/type_conversion.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/type_conversion.ts
@@ -1770,6 +1770,14 @@ export function mapCombineHintsToNoir(combineHints: CombineHints): CombineHintsN
       combineHints.sortedPublicDataUpdateRequestsIndexes,
       mapNumberToNoir,
     ),
+    deduped_public_data_update_requests: mapTuple(
+      combineHints.dedupedPublicDataUpdateRequests,
+      mapPublicDataUpdateRequestToNoir,
+    ),
+    deduped_public_data_update_requests_runs: mapTuple(
+      combineHints.dedupedPublicDataUpdateRequestsRuns,
+      mapNumberToNoir,
+    ),
   };
 }
 

--- a/yarn-project/pxe/src/kernel_prover/private_inputs_builders/build_private_kernel_tail_hints.ts
+++ b/yarn-project/pxe/src/kernel_prover/private_inputs_builders/build_private_kernel_tail_hints.ts
@@ -39,7 +39,10 @@ export function buildPrivateKernelTailHints(publicInputs: PrivateKernelCircuitPu
   const [sortedCallRequests, sortedCallRequestsIndexes] = sortByCounterGetSortedHints(
     publicInputs.end.publicCallStack,
     MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX,
-    /* ascending */ false,
+    {
+      ascending: false,
+      hintIndexesBy: 'sorted',
+    },
   );
 
   return new PrivateKernelTailHints(

--- a/yarn-project/simulator/src/mocks/fixtures.ts
+++ b/yarn-project/simulator/src/mocks/fixtures.ts
@@ -3,6 +3,7 @@ import {
   ARGS_LENGTH,
   type AztecAddress,
   CallContext,
+  type ContractStorageRead,
   type ContractStorageUpdateRequest,
   Fr,
   Gas,
@@ -18,6 +19,7 @@ export class PublicExecutionResultBuilder {
   private _execution: PublicExecution;
   private _nestedExecutions: PublicExecutionResult[] = [];
   private _contractStorageUpdateRequests: ContractStorageUpdateRequest[] = [];
+  private _contractStorageReads: ContractStorageRead[] = [];
   private _returnValues: Fr[] = [];
   private _reverted = false;
   private _revertReason: SimulationError | undefined = undefined;
@@ -31,18 +33,21 @@ export class PublicExecutionResultBuilder {
     returnValues = [new Fr(1n)],
     nestedExecutions = [],
     contractStorageUpdateRequests = [],
+    contractStorageReads = [],
     revertReason = undefined,
   }: {
     request: PublicCallRequest;
     returnValues?: Fr[];
     nestedExecutions?: PublicExecutionResult[];
     contractStorageUpdateRequests?: ContractStorageUpdateRequest[];
+    contractStorageReads?: ContractStorageRead[];
     revertReason?: SimulationError;
   }): PublicExecutionResultBuilder {
     const builder = new PublicExecutionResultBuilder(request);
 
     builder.withNestedExecutions(...nestedExecutions);
     builder.withContractStorageUpdateRequest(...contractStorageUpdateRequests);
+    builder.withContractStorageRead(...contractStorageReads);
     builder.withReturnValues(...returnValues);
     if (revertReason) {
       builder.withReverted(revertReason);
@@ -57,6 +62,7 @@ export class PublicExecutionResultBuilder {
     returnValues = [new Fr(1n)],
     nestedExecutions = [],
     contractStorageUpdateRequests = [],
+    contractStorageReads = [],
     revertReason,
   }: {
     from: AztecAddress;
@@ -64,6 +70,7 @@ export class PublicExecutionResultBuilder {
     returnValues?: Fr[];
     nestedExecutions?: PublicExecutionResult[];
     contractStorageUpdateRequests?: ContractStorageUpdateRequest[];
+    contractStorageReads?: ContractStorageRead[];
     revertReason?: SimulationError;
   }) {
     const builder = new PublicExecutionResultBuilder({
@@ -75,6 +82,7 @@ export class PublicExecutionResultBuilder {
 
     builder.withNestedExecutions(...nestedExecutions);
     builder.withContractStorageUpdateRequest(...contractStorageUpdateRequests);
+    builder.withContractStorageRead(...contractStorageReads);
     builder.withReturnValues(...returnValues);
     if (revertReason) {
       builder.withReverted(revertReason);
@@ -90,6 +98,11 @@ export class PublicExecutionResultBuilder {
 
   withContractStorageUpdateRequest(...request: ContractStorageUpdateRequest[]): PublicExecutionResultBuilder {
     this._contractStorageUpdateRequests.push(...request);
+    return this;
+  }
+
+  withContractStorageRead(...reads: ContractStorageRead[]): PublicExecutionResultBuilder {
+    this._contractStorageReads.push(...reads);
     return this;
   }
 

--- a/yarn-project/simulator/src/public/abstract_phase_manager.ts
+++ b/yarn-project/simulator/src/public/abstract_phase_manager.ts
@@ -28,7 +28,6 @@ import {
   MAX_NULLIFIER_READ_REQUESTS_PER_CALL,
   MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL,
   MAX_PUBLIC_DATA_READS_PER_CALL,
-  MAX_PUBLIC_DATA_READS_PER_TX,
   MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_CALL,
   MAX_UNENCRYPTED_LOGS_PER_CALL,
   MembershipWitness,
@@ -39,7 +38,6 @@ import {
   type PublicCallRequest,
   PublicCallStackItem,
   PublicCircuitPublicInputs,
-  PublicDataRead,
   PublicKernelCircuitPrivateInputs,
   type PublicKernelCircuitPublicInputs,
   PublicKernelData,
@@ -51,14 +49,13 @@ import {
   makeEmptyRecursiveProof,
 } from '@aztec/circuits.js';
 import { computeVarArgsHash } from '@aztec/circuits.js/hash';
-import { arrayNonEmptyLength, padArrayEnd } from '@aztec/foundation/collection';
+import { padArrayEnd } from '@aztec/foundation/collection';
 import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import {
   type PublicExecution,
   type PublicExecutionResult,
   type PublicExecutor,
   accumulateReturnValues,
-  collectPublicDataReads,
   isPublicExecutionResult,
 } from '@aztec/simulator';
 import { type MerkleTreeOperations } from '@aztec/world-state';
@@ -335,9 +332,6 @@ export abstract class AbstractPhaseManager {
 
         enqueuedCallResults.push(accumulateReturnValues(enqueuedExecutionResult));
       }
-      // HACK(#1622): Manually patches the ordering of public state actions
-      // TODO(#757): Enforce proper ordering of public state actions
-      this.patchPublicStorageActionOrdering(kernelOutput, enqueuedExecutionResult!);
     }
 
     return [publicKernelInputs, kernelOutput, newUnencryptedFunctionLogs, undefined, enqueuedCallResults, gasUsed];
@@ -494,45 +488,5 @@ export abstract class AbstractPhaseManager {
     );
     const publicCallStack = padArrayEnd(publicCallRequests, CallRequest.empty(), MAX_PUBLIC_CALL_STACK_LENGTH_PER_CALL);
     return new PublicCallData(callStackItem, publicCallStack, makeEmptyProof(), bytecodeHash);
-  }
-
-  // HACK(#1622): this is a hack to fix ordering of public state in the call stack. Since the private kernel
-  // cannot keep track of side effects that happen after or before a nested call, we override the public
-  // state actions it emits with whatever we got from the simulator. As a sanity check, we at least verify
-  // that the elements are the same, so we are only tweaking their ordering.
-  // See yarn-project/end-to-end/src/e2e_ordering.test.ts
-  // See https://github.com/AztecProtocol/aztec-packages/issues/1616
-  // TODO(#757): Enforce proper ordering of public state actions
-  /**
-   * Patch the ordering of storage actions output from the public kernel.
-   * @param publicInputs - to be patched here: public inputs to the kernel iteration up to this point
-   * @param execResult - result of the top/first execution for this enqueued public call
-   */
-  private patchPublicStorageActionOrdering(
-    publicInputs: PublicKernelCircuitPublicInputs,
-    execResult: PublicExecutionResult,
-  ) {
-    const { publicDataReads } = publicInputs.validationRequests;
-
-    // Convert ContractStorage* objects to PublicData* objects and sort them in execution order.
-    // Note, this only pulls simulated reads/writes from the current phase,
-    // so the returned result will be a subset of the public kernel output.
-
-    const simPublicDataReads = collectPublicDataReads(execResult);
-
-    // We only want to reorder the items from the public inputs of the
-    // most recently processed top/enqueued call.
-
-    const numReadsInKernel = arrayNonEmptyLength(publicDataReads, f => f.isEmpty());
-    const numReadsBeforeThisEnqueuedCall = numReadsInKernel - simPublicDataReads.length;
-    publicInputs.validationRequests.publicDataReads = padArrayEnd(
-      [
-        // do not mess with items from previous top/enqueued calls in kernel output
-        ...publicInputs.validationRequests.publicDataReads.slice(0, numReadsBeforeThisEnqueuedCall),
-        ...simPublicDataReads,
-      ],
-      PublicDataRead.empty(),
-      MAX_PUBLIC_DATA_READS_PER_TX,
-    );
   }
 }

--- a/yarn-project/simulator/src/public/abstract_phase_manager.ts
+++ b/yarn-project/simulator/src/public/abstract_phase_manager.ts
@@ -30,7 +30,6 @@ import {
   MAX_PUBLIC_DATA_READS_PER_CALL,
   MAX_PUBLIC_DATA_READS_PER_TX,
   MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_CALL,
-  MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
   MAX_UNENCRYPTED_LOGS_PER_CALL,
   MembershipWitness,
   NESTED_RECURSIVE_PROOF_LENGTH,
@@ -41,7 +40,6 @@ import {
   PublicCallStackItem,
   PublicCircuitPublicInputs,
   PublicDataRead,
-  PublicDataUpdateRequest,
   PublicKernelCircuitPrivateInputs,
   type PublicKernelCircuitPublicInputs,
   PublicKernelData,
@@ -55,7 +53,6 @@ import {
 import { computeVarArgsHash } from '@aztec/circuits.js/hash';
 import { arrayNonEmptyLength, padArrayEnd } from '@aztec/foundation/collection';
 import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
-import { type Tuple } from '@aztec/foundation/serialize';
 import {
   type PublicExecution,
   type PublicExecutionResult,
@@ -538,23 +535,4 @@ export abstract class AbstractPhaseManager {
       MAX_PUBLIC_DATA_READS_PER_TX,
     );
   }
-}
-
-export function removeRedundantPublicDataWrites(
-  writes: Tuple<PublicDataUpdateRequest, typeof MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX>,
-) {
-  const lastWritesMap = new Map<string, boolean>();
-  const patch = <N extends number>(requests: Tuple<PublicDataUpdateRequest, N>) =>
-    requests.filter(write => {
-      const leafSlot = write.leafSlot.toString();
-      const exists = lastWritesMap.get(leafSlot);
-      lastWritesMap.set(leafSlot, true);
-      return !exists;
-    });
-
-  return padArrayEnd(
-    patch(writes.reverse()).reverse(),
-    PublicDataUpdateRequest.empty(),
-    MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
-  );
 }

--- a/yarn-project/simulator/src/public/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   AppendOnlyTreeSnapshot,
   AztecAddress,
+  ContractStorageRead,
   ContractStorageUpdateRequest,
   Fr,
   Gas,
@@ -24,6 +25,7 @@ import {
   PUBLIC_DATA_TREE_HEIGHT,
   PartialStateReference,
   type Proof,
+  PublicAccumulatedDataBuilder,
   PublicCallRequest,
   PublicDataTreeLeafPreimage,
   PublicDataUpdateRequest,
@@ -848,8 +850,14 @@ describe('public_processor', () => {
       });
 
       // Private kernel tail to public pushes teardown gas allocation into revertible gas used
-      tx.data.forPublic!.end.gasUsed = teardownGas;
-      tx.data.forPublic!.endNonRevertibleData.gasUsed = Gas.empty();
+      tx.data.forPublic!.end = PublicAccumulatedDataBuilder.fromPublicAccumulatedData(tx.data.forPublic!.end)
+        .withGasUsed(teardownGas)
+        .build();
+      tx.data.forPublic!.endNonRevertibleData = PublicAccumulatedDataBuilder.fromPublicAccumulatedData(
+        tx.data.forPublic!.endNonRevertibleData,
+      )
+        .withGasUsed(Gas.empty())
+        .build();
 
       const contractSlotA = fr(0x100);
       const contractSlotB = fr(0x150);
@@ -887,6 +895,7 @@ describe('public_processor', () => {
             new ContractStorageUpdateRequest(contractSlotA, fr(0x101), 10, baseContractAddress),
             new ContractStorageUpdateRequest(contractSlotB, fr(0x151), 11, baseContractAddress),
           ],
+          contractStorageReads: [new ContractStorageRead(contractSlotA, fr(0x100), 19, baseContractAddress)],
         }).build({
           startGasLeft: afterSetupGas,
           endGasLeft: afterAppGas,
@@ -900,17 +909,19 @@ describe('public_processor', () => {
               from: teardown!.contractAddress,
               tx: makeFunctionCall('', baseContractAddress, makeSelector(5)),
               contractStorageUpdateRequests: [
-                new ContractStorageUpdateRequest(contractSlotA, fr(0x103), 14, baseContractAddress),
-                new ContractStorageUpdateRequest(contractSlotC, fr(0x201), 15, baseContractAddress),
+                new ContractStorageUpdateRequest(contractSlotA, fr(0x103), 16, baseContractAddress),
+                new ContractStorageUpdateRequest(contractSlotC, fr(0x201), 17, baseContractAddress),
               ],
+              contractStorageReads: [new ContractStorageRead(contractSlotA, fr(0x102), 15, baseContractAddress)],
             }).build({ startGasLeft: teardownGas, endGasLeft: teardownGas, transactionFee }),
             PublicExecutionResultBuilder.fromFunctionCall({
               from: teardown!.contractAddress,
               tx: makeFunctionCall('', baseContractAddress, makeSelector(5)),
               contractStorageUpdateRequests: [
-                new ContractStorageUpdateRequest(contractSlotA, fr(0x102), 12, baseContractAddress),
-                new ContractStorageUpdateRequest(contractSlotB, fr(0x152), 13, baseContractAddress),
+                new ContractStorageUpdateRequest(contractSlotA, fr(0x102), 13, baseContractAddress),
+                new ContractStorageUpdateRequest(contractSlotB, fr(0x152), 14, baseContractAddress),
               ],
+              contractStorageReads: [new ContractStorageRead(contractSlotA, fr(0x101), 12, baseContractAddress)],
             }).build({ startGasLeft: teardownGas, endGasLeft: teardownGas, transactionFee }),
           ],
         }).build({
@@ -932,6 +943,7 @@ describe('public_processor', () => {
       const setupSpy = jest.spyOn(publicKernel, 'publicKernelCircuitSetup');
       const appLogicSpy = jest.spyOn(publicKernel, 'publicKernelCircuitAppLogic');
       const teardownSpy = jest.spyOn(publicKernel, 'publicKernelCircuitTeardown');
+      const tailSpy = jest.spyOn(publicKernel, 'publicKernelCircuitTail');
 
       const [processed, failed] = await processor.process([tx], 1, prover);
 
@@ -942,6 +954,7 @@ describe('public_processor', () => {
       expect(setupSpy).toHaveBeenCalledTimes(1);
       expect(appLogicSpy).toHaveBeenCalledTimes(1);
       expect(teardownSpy).toHaveBeenCalledTimes(3);
+      expect(tailSpy).toHaveBeenCalledTimes(1);
 
       const expectedSimulateCall = (availableGas: Partial<FieldsOf<Gas>>, txFee: number) => [
         expect.anything(), // PublicExecution

--- a/yarn-project/simulator/src/public/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor.test.ts
@@ -456,7 +456,7 @@ describe('public_processor', () => {
         new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotA), fr(0x101)),
       );
       expect(txEffect.publicDataWrites[1]).toEqual(
-        new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotC), fr(0x201)),
+        new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotF), fr(0x351)),
       );
       expect(txEffect.publicDataWrites[2]).toEqual(
         new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotD), fr(0x251)),
@@ -465,7 +465,7 @@ describe('public_processor', () => {
         new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotE), fr(0x301)),
       );
       expect(txEffect.publicDataWrites[4]).toEqual(
-        new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotF), fr(0x351)),
+        new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotC), fr(0x201)),
       );
       expect(txEffect.encryptedLogs.getTotalLogCount()).toBe(0);
       expect(txEffect.unencryptedLogs.getTotalLogCount()).toBe(0);
@@ -682,10 +682,10 @@ describe('public_processor', () => {
       const txEffect = toTxEffect(processed[0], GasFees.default());
       expect(arrayNonEmptyLength(txEffect.publicDataWrites, PublicDataWrite.isEmpty)).toEqual(2);
       expect(txEffect.publicDataWrites[0]).toEqual(
-        new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotA), fr(0x102)),
+        new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotB), fr(0x151)),
       );
       expect(txEffect.publicDataWrites[1]).toEqual(
-        new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotB), fr(0x151)),
+        new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotA), fr(0x102)),
       );
       expect(txEffect.encryptedLogs.getTotalLogCount()).toBe(0);
       expect(txEffect.unencryptedLogs.getTotalLogCount()).toBe(0);
@@ -805,10 +805,10 @@ describe('public_processor', () => {
       const txEffect = toTxEffect(processed[0], GasFees.default());
       expect(arrayNonEmptyLength(txEffect.publicDataWrites, PublicDataWrite.isEmpty)).toEqual(2);
       expect(txEffect.publicDataWrites[0]).toEqual(
-        new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotA), fr(0x102)),
+        new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotB), fr(0x151)),
       );
       expect(txEffect.publicDataWrites[1]).toEqual(
-        new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotB), fr(0x151)),
+        new PublicDataWrite(computePublicDataTreeLeafSlot(baseContractAddress, contractSlotA), fr(0x102)),
       );
       expect(txEffect.encryptedLogs.getTotalLogCount()).toBe(0);
       expect(txEffect.unencryptedLogs.getTotalLogCount()).toBe(0);

--- a/yarn-project/simulator/src/public/tail_phase_manager.ts
+++ b/yarn-project/simulator/src/public/tail_phase_manager.ts
@@ -13,7 +13,7 @@ import {
 import { type PublicExecutor, type PublicStateDB } from '@aztec/simulator';
 import { type MerkleTreeOperations } from '@aztec/world-state';
 
-import { AbstractPhaseManager, PublicKernelPhase, removeRedundantPublicDataWrites } from './abstract_phase_manager.js';
+import { AbstractPhaseManager, PublicKernelPhase } from './abstract_phase_manager.js';
 import { type ContractsDataSourcePublicDB } from './public_executor.js';
 import { type PublicKernelCircuitSimulator } from './public_kernel_circuit_simulator.js';
 
@@ -39,11 +39,6 @@ export class TailPhaseManager extends AbstractPhaseManager {
         await this.publicStateDB.rollbackToCommit();
         throw err;
       },
-    );
-
-    // TODO(#3675): This should be done in a public kernel circuit
-    finalKernelOutput.end.publicDataUpdateRequests = removeRedundantPublicDataWrites(
-      finalKernelOutput.end.publicDataUpdateRequests,
     );
 
     // Return a tail proving request


### PR DESCRIPTION
We now dedup public data writes in the public kernel tail. We do this by first sorting them in TS based FIRST on leaf index, and next on side effect counter, and get hints for that reordering (which we assert in the kernel).

We then deduplicate by keeping the update request with the highest side effect counter for each leaf index. The "hints" in this case are the number of times that each leaf index appears which we use in the circuit with a new "assert_deduped_array" function.

NOTE: You'll notice that the expected orderings of update requests as emitted by the tail is different now. That's because we sort by leaf index, then side effect counter. I didn't see why we actually needed to maintain the ordering across different slot. For example, what I've done assumes it is okay if we have writes of (leaf, value, counter):
- (2, 2, 1)
- (1, 1, 2)
to have final output of 
- (1, 1, 2)
- (2, 2, 1)

If that is not okay and for some reason we need to still have the writes in their counter order after deduping then this will just make the typescript initial sort slightly more complicated since we'll need to arrange the slots such that they're sorted on side effect counter after deduping.
