### PR TITLE
chore(avm-simulator): TraceArray type that enforces maximum per-call and per-tx lengths

### DIFF
--- a/yarn-project/simulator/src/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.test.ts
@@ -303,7 +303,9 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       // Note hash existence check should be in trace
       const trace = context.persistableState.flush();
-      expect(trace.noteHashChecks).toEqual([expect.objectContaining({ noteHash, leafIndex, exists: false })]);
+      expect(trace.noteHashChecks).toEqual(
+        expect.arrayContaining([expect.objectContaining({ noteHash, leafIndex, exists: false })]),
+      );
     });
 
     it(`Note hash exists (it does)`, async () => {
@@ -324,7 +326,9 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       // Note hash existence check should be in trace
       const trace = context.persistableState.flush();
-      expect(trace.noteHashChecks).toEqual([expect.objectContaining({ noteHash, leafIndex, exists: true })]);
+      expect(trace.noteHashChecks).toEqual(
+        expect.arrayContaining([expect.objectContaining({ noteHash, leafIndex, exists: true })]),
+      );
     });
 
     it(`Emit unencrypted logs (should be traced)`, async () => {
@@ -339,19 +343,21 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       const expectedCompressedString = Buffer.from(
         '\0A long time ago, in a galaxy fa' + '\0r far away...\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',
       );
-      expect(context.persistableState.flush().newLogs).toEqual([
-        new UnencryptedL2Log(
-          context.environment.address,
-          new EventSelector(5),
-          Buffer.concat(expectedFields.map(f => f.toBuffer())),
-        ),
-        new UnencryptedL2Log(
-          context.environment.address,
-          new EventSelector(8),
-          Buffer.concat(expectedString.map(f => f.toBuffer())),
-        ),
-        new UnencryptedL2Log(context.environment.address, new EventSelector(10), expectedCompressedString),
-      ]);
+      expect(context.persistableState.flush().newLogs).toEqual(
+        expect.arrayContaining([
+          new UnencryptedL2Log(
+            context.environment.address,
+            new EventSelector(5),
+            Buffer.concat(expectedFields.map(f => f.toBuffer())),
+          ),
+          new UnencryptedL2Log(
+            context.environment.address,
+            new EventSelector(8),
+            Buffer.concat(expectedString.map(f => f.toBuffer())),
+          ),
+          new UnencryptedL2Log(context.environment.address, new EventSelector(10), expectedCompressedString),
+        ]),
+      );
     });
 
     it(`Emit note hash (should be traced)`, async () => {
@@ -364,12 +370,14 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       expect(results.reverted).toBe(false);
 
-      expect(context.persistableState.flush().newNoteHashes).toEqual([
-        expect.objectContaining({
-          storageAddress: context.environment.storageAddress,
-          noteHash: utxo,
-        }),
-      ]);
+      expect(context.persistableState.flush().newNoteHashes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: context.environment.storageAddress,
+            noteHash: utxo,
+          }),
+        ]),
+      );
     });
 
     it(`Emit nullifier (should be traced)`, async () => {
@@ -382,12 +390,14 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       expect(results.reverted).toBe(false);
 
-      expect(context.persistableState.flush().newNullifiers).toEqual([
-        expect.objectContaining({
-          storageAddress: context.environment.storageAddress,
-          nullifier: utxo,
-        }),
-      ]);
+      expect(context.persistableState.flush().newNullifiers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: context.environment.storageAddress,
+            nullifier: utxo,
+          }),
+        ]),
+      );
     });
 
     it(`Nullifier exists (it does not)`, async () => {
@@ -403,16 +413,18 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       // Nullifier existence check should be in trace
       const trace = context.persistableState.flush();
-      expect(trace.nullifierChecks).toEqual([
-        expect.objectContaining({
-          storageAddress: context.environment.storageAddress,
-          nullifier: utxo,
-          exists: false,
-          counter: expect.any(Fr),
-          isPending: false,
-          leafIndex: expect.any(Fr),
-        }),
-      ]);
+      expect(trace.nullifierChecks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: context.environment.storageAddress,
+            nullifier: utxo,
+            exists: false,
+            counter: expect.any(Fr),
+            isPending: false,
+            leafIndex: expect.any(Fr),
+          }),
+        ]),
+      );
     });
 
     it(`Nullifier exists (it does)`, async () => {
@@ -432,16 +444,18 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       // Nullifier existence check should be in trace
       const trace = context.persistableState.flush();
-      expect(trace.nullifierChecks).toEqual([
-        expect.objectContaining({
-          storageAddress: context.environment.storageAddress,
-          nullifier: utxo,
-          exists: true,
-          counter: expect.any(Fr),
-          isPending: false,
-          leafIndex: expect.any(Fr),
-        }),
-      ]);
+      expect(trace.nullifierChecks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: context.environment.storageAddress,
+            nullifier: utxo,
+            exists: true,
+            counter: expect.any(Fr),
+            isPending: false,
+            leafIndex: expect.any(Fr),
+          }),
+        ]),
+      );
     });
 
     it(`Emits a nullifier and checks its existence`, async () => {
@@ -455,22 +469,26 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       expect(results.reverted).toBe(false);
       // Nullifier existence check should be in trace
       const trace = context.persistableState.flush();
-      expect(trace.newNullifiers).toEqual([
-        expect.objectContaining({
-          storageAddress: context.environment.storageAddress,
-          nullifier: utxo,
-        }),
-      ]);
-      expect(trace.nullifierChecks).toEqual([
-        expect.objectContaining({
-          storageAddress: context.environment.storageAddress,
-          nullifier: utxo,
-          exists: true,
-          counter: expect.any(Fr),
-          isPending: true,
-          leafIndex: expect.any(Fr),
-        }),
-      ]);
+      expect(trace.newNullifiers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: context.environment.storageAddress,
+            nullifier: utxo,
+          }),
+        ]),
+      );
+      expect(trace.nullifierChecks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: context.environment.storageAddress,
+            nullifier: utxo,
+            exists: true,
+            counter: expect.any(Fr),
+            isPending: true,
+            leafIndex: expect.any(Fr),
+          }),
+        ]),
+      );
     });
 
     it(`Emits same nullifier twice (should fail)`, async () => {
@@ -484,12 +502,14 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       expect(results.reverted).toBe(true);
       expect(results.revertReason?.message).toMatch(/Attempted to emit duplicate nullifier/);
       // Only the first nullifier should be in the trace, second one failed to add
-      expect(context.persistableState.flush().newNullifiers).toEqual([
-        expect.objectContaining({
-          storageAddress: context.environment.storageAddress,
-          nullifier: utxo,
-        }),
-      ]);
+      expect(context.persistableState.flush().newNullifiers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: context.environment.storageAddress,
+            nullifier: utxo,
+          }),
+        ]),
+      );
     });
   });
 
@@ -552,13 +572,15 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       expect(adminSlotValue).toEqual(value);
 
       // Tracing
-      expect(worldState.storageWrites).toEqual([
-        expect.objectContaining({
-          storageAddress: address,
-          slot: new Fr(slot),
-          value: value,
-        }),
-      ]);
+      expect(worldState.storageWrites).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: address,
+            slot: new Fr(slot),
+            value: value,
+          }),
+        ]),
+      );
     });
 
     it('Should read value in storage (single)', async () => {
@@ -582,14 +604,16 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       // Tracing
       const worldState = context.persistableState.flush();
-      expect(worldState.storageReads).toEqual([
-        expect.objectContaining({
-          storageAddress: address,
-          slot: new Fr(slot),
-          value: value,
-          exists: true,
-        }),
-      ]);
+      expect(worldState.storageReads).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: address,
+            slot: new Fr(slot),
+            value: value,
+            exists: true,
+          }),
+        ]),
+      );
     });
 
     it('Should set and read a value from storage (single)', async () => {
@@ -609,21 +633,25 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       // Test read trace
       const worldState = context.persistableState.flush();
-      expect(worldState.storageReads).toEqual([
-        expect.objectContaining({
-          storageAddress: address,
-          slot: new Fr(slot),
-          value: value,
-          exists: true,
-        }),
-      ]);
-      expect(worldState.storageWrites).toEqual([
-        expect.objectContaining({
-          storageAddress: address,
-          slot: new Fr(slot),
-          value: value,
-        }),
-      ]);
+      expect(worldState.storageReads).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: address,
+            slot: new Fr(slot),
+            value: value,
+            exists: true,
+          }),
+        ]),
+      );
+      expect(worldState.storageWrites).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: address,
+            slot: new Fr(slot),
+            value: value,
+          }),
+        ]),
+      );
     });
 
     it('Should set a value in storage (list)', async () => {
@@ -646,18 +674,20 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       expect(storageSlot.get(slot + 1n)).toEqual(calldata[1]);
 
       // Tracing
-      expect(worldState.storageWrites).toEqual([
-        expect.objectContaining({
-          storageAddress: address,
-          slot: new Fr(slot),
-          value: calldata[0],
-        }),
-        expect.objectContaining({
-          storageAddress: address,
-          slot: new Fr(slot + 1n),
-          value: calldata[1],
-        }),
-      ]);
+      expect(worldState.storageWrites).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: address,
+            slot: new Fr(slot),
+            value: calldata[0],
+          }),
+          expect.objectContaining({
+            storageAddress: address,
+            slot: new Fr(slot + 1n),
+            value: calldata[1],
+          }),
+        ]),
+      );
     });
 
     it('Should read a value in storage (list)', async () => {
@@ -683,20 +713,22 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       // Tracing
       const worldState = context.persistableState.flush();
-      expect(worldState.storageReads).toEqual([
-        expect.objectContaining({
-          storageAddress: address,
-          slot: new Fr(slot),
-          value: values[0],
-          exists: true,
-        }),
-        expect.objectContaining({
-          storageAddress: address,
-          slot: new Fr(slot + 1n),
-          value: values[1],
-          exists: true,
-        }),
-      ]);
+      expect(worldState.storageReads).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: address,
+            slot: new Fr(slot),
+            value: values[0],
+            exists: true,
+          }),
+          expect.objectContaining({
+            storageAddress: address,
+            slot: new Fr(slot + 1n),
+            value: values[1],
+            exists: true,
+          }),
+        ]),
+      );
     });
 
     it('Should set a value in storage (map)', async () => {
@@ -719,13 +751,15 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       expect(storageSlot.get(slotNumber)).toEqual(value);
 
       // Tracing
-      expect(worldState.storageWrites).toEqual([
-        expect.objectContaining({
-          storageAddress: address,
-          slot: new Fr(slotNumber),
-          value: value,
-        }),
-      ]);
+      expect(worldState.storageWrites).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: address,
+            slot: new Fr(slotNumber),
+            value: value,
+          }),
+        ]),
+      );
     });
 
     it('Should read-add-set a value in storage (map)', async () => {
@@ -748,21 +782,25 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       expect(storageSlot.get(slotNumber)).toEqual(value);
 
       // Tracing
-      expect(worldState.storageReads).toEqual([
-        expect.objectContaining({
-          storageAddress: address,
-          slot: new Fr(slotNumber),
-          value: Fr.ZERO,
-          exists: false,
-        }),
-      ]);
-      expect(worldState.storageWrites).toEqual([
-        expect.objectContaining({
-          storageAddress: address,
-          slot: new Fr(slotNumber),
-          value: value,
-        }),
-      ]);
+      expect(worldState.storageReads).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: address,
+            slot: new Fr(slotNumber),
+            value: Fr.ZERO,
+            exists: false,
+          }),
+        ]),
+      );
+      expect(worldState.storageWrites).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: address,
+            slot: new Fr(slotNumber),
+            value: value,
+          }),
+        ]),
+      );
     });
 
     it('Should read value in storage (map)', async () => {
@@ -785,14 +823,16 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       // Tracing
       const worldState = context.persistableState.flush();
-      expect(worldState.storageReads).toEqual([
-        expect.objectContaining({
-          storageAddress: address,
-          // slot depends on pedersen hash of key, etc.
-          value: value,
-          exists: true,
-        }),
-      ]);
+      expect(worldState.storageReads).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: address,
+            // slot depends on pedersen hash of key, etc.
+            value: value,
+            exists: true,
+          }),
+        ]),
+      );
     });
   });
 

--- a/yarn-project/simulator/src/avm/journal/trace.ts
+++ b/yarn-project/simulator/src/avm/journal/trace.ts
@@ -1,5 +1,24 @@
 import { type UnencryptedL2Log } from '@aztec/circuit-types';
-import { type EthAddress, L2ToL1Message, LogHash } from '@aztec/circuits.js';
+import {
+  type EthAddress,
+  L2ToL1Message,
+  LogHash,
+  MAX_NEW_L2_TO_L1_MSGS_PER_CALL,
+  MAX_NEW_L2_TO_L1_MSGS_PER_TX,
+  MAX_NEW_NOTE_HASHES_PER_CALL,
+  MAX_NEW_NOTE_HASHES_PER_TX,
+  MAX_NEW_NULLIFIERS_PER_CALL,
+  MAX_NEW_NULLIFIERS_PER_TX,
+  MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
+  MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
+  MAX_NULLIFIER_READ_REQUESTS_PER_TX,
+  MAX_PUBLIC_DATA_READS_PER_CALL,
+  MAX_PUBLIC_DATA_READS_PER_TX,
+  MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_CALL,
+  MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
+  MAX_UNENCRYPTED_LOGS_PER_CALL,
+  MAX_UNENCRYPTED_LOGS_PER_TX,
+} from '@aztec/circuits.js';
 import { Fr } from '@aztec/foundation/fields';
 
 import {
@@ -12,29 +31,130 @@ import {
   type TracedPublicStorageWrite,
 } from './trace_types.js';
 
+export class TraceArray<T> extends Array<T> {
+  /** items explicitly pushed to this instance, not including parent's, not including items "merged" in */
+  public thisLength: number = 0;
+
+  constructor(
+    private name: string,
+    private maxThisLen: number,
+    private maxTotalLen: number,
+    private parent?: TraceArray<T>,
+  ) {
+    super();
+  }
+
+  pushItem(item: T): number {
+    if (this.thisLength >= this.maxThisLen) {
+      throw new TooManyAccessesError(this.name, this.maxThisLen, 'per call');
+    }
+    if (this.totalLength() >= this.maxTotalLen) {
+      throw new TooManyAccessesError(this.name, this.maxThisLen, 'per tx');
+    }
+    super.push(item);
+    this.thisLength++;
+    return this.thisLength;
+  }
+
+  merge(incoming: TraceArray<T>) {
+    // Note: we don't use incoming.totalLength() as incoming will likely have 'this' as parent
+    const newTotalLength = this.totalLength() + incoming.length;
+    if (newTotalLength > this.maxTotalLen) {
+      throw new TooManyAccessesError(this.name, this.maxTotalLen, 'per tx (when merging in child trace)');
+    }
+    this.push(...incoming);
+  }
+
+  /** including parent length */
+  totalLength(): number {
+    let len = this.length;
+    if (this.parent) {
+      len += this.parent.totalLength();
+    }
+    return len;
+  }
+}
+
 export class WorldStateAccessTrace {
   public accessCounter: number;
 
-  public publicStorageReads: TracedPublicStorageRead[] = [];
-  public publicStorageWrites: TracedPublicStorageWrite[] = [];
+  public publicStorageReads: TraceArray<TracedPublicStorageRead>;
+  public publicStorageWrites: TraceArray<TracedPublicStorageWrite>;
 
-  public noteHashChecks: TracedNoteHashCheck[] = [];
-  public newNoteHashes: TracedNoteHash[] = [];
-  public nullifierChecks: TracedNullifierCheck[] = [];
-  public newNullifiers: TracedNullifier[] = [];
-  public l1ToL2MessageChecks: TracedL1toL2MessageCheck[] = [];
+  public noteHashChecks: TraceArray<TracedNoteHashCheck>;
+  public newNoteHashes: TraceArray<TracedNoteHash>;
+  public nullifierChecks: TraceArray<TracedNullifierCheck>;
+  public newNullifiers: TraceArray<TracedNullifier>;
+  public l1ToL2MessageChecks: TraceArray<TracedL1toL2MessageCheck>;
 
   /** Accrued Substate **/
-  public newL2ToL1Messages: L2ToL1Message[] = [];
-  public newUnencryptedLogs: UnencryptedL2Log[] = [];
-  public newUnencryptedLogsHashes: LogHash[] = [];
+  public newL2ToL1Messages: TraceArray<L2ToL1Message>;
+  public newUnencryptedLogs: TraceArray<UnencryptedL2Log>;
+  public newUnencryptedLogsHashes: TraceArray<LogHash>;
 
   //public contractCalls: TracedContractCall[] = [];
   //public archiveChecks: TracedArchiveLeafCheck[] = [];
 
   constructor(parentTrace?: WorldStateAccessTrace) {
     this.accessCounter = parentTrace ? parentTrace.accessCounter : 0;
-    // TODO(4805): consider tracking the parent's trace vector lengths so we can enforce limits
+
+    this.publicStorageReads = new TraceArray(
+      'public storage reads',
+      MAX_PUBLIC_DATA_READS_PER_CALL,
+      MAX_PUBLIC_DATA_READS_PER_TX,
+      parentTrace?.publicStorageReads,
+    );
+    this.publicStorageWrites = new TraceArray(
+      'public storage writes',
+      MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_CALL,
+      MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
+      parentTrace?.publicStorageWrites,
+    );
+    this.noteHashChecks = new TraceArray(
+      'note hash checks',
+      MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
+      MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
+      parentTrace?.noteHashChecks,
+    );
+    this.newNoteHashes = new TraceArray(
+      'new note hashes',
+      MAX_NEW_NOTE_HASHES_PER_CALL,
+      MAX_NEW_NOTE_HASHES_PER_TX,
+      parentTrace?.newNoteHashes,
+    );
+    // TODO:(5818): two types of nullifier checks?
+    this.nullifierChecks = new TraceArray(
+      'nullifier checks',
+      MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
+      MAX_NULLIFIER_READ_REQUESTS_PER_TX,
+      parentTrace?.nullifierChecks,
+    );
+    this.newNullifiers = new TraceArray(
+      'new nullifiers',
+      MAX_NEW_NULLIFIERS_PER_CALL,
+      MAX_NEW_NULLIFIERS_PER_TX,
+      parentTrace?.newNullifiers,
+    );
+    // TODO:(5818): rebase onto message check PR
+    this.l1ToL2MessageChecks = new TraceArray('l1 to l2 message checks', 16, 64, parentTrace?.l1ToL2MessageChecks);
+    this.newL2ToL1Messages = new TraceArray(
+      'new l2 to l1 messages',
+      MAX_NEW_L2_TO_L1_MSGS_PER_CALL,
+      MAX_NEW_L2_TO_L1_MSGS_PER_TX,
+      parentTrace?.newL2ToL1Messages,
+    );
+    this.newUnencryptedLogs = new TraceArray(
+      'new unencrypted logs',
+      MAX_UNENCRYPTED_LOGS_PER_CALL,
+      MAX_UNENCRYPTED_LOGS_PER_TX,
+      parentTrace?.newUnencryptedLogs,
+    );
+    this.newUnencryptedLogsHashes = new TraceArray(
+      'new unencrypted logs hashes',
+      MAX_UNENCRYPTED_LOGS_PER_CALL,
+      MAX_UNENCRYPTED_LOGS_PER_TX,
+      parentTrace?.newUnencryptedLogsHashes,
+    );
   }
 
   public getAccessCounter() {
@@ -42,8 +162,6 @@ export class WorldStateAccessTrace {
   }
 
   public tracePublicStorageRead(storageAddress: Fr, slot: Fr, value: Fr, exists: boolean, cached: boolean) {
-    // TODO(4805): check if some threshold is reached for max storage reads
-    // (need access to parent length, or trace needs to be initialized with parent's contents)
     const traced: TracedPublicStorageRead = {
       //  callPointer: Fr.ZERO,
       storageAddress,
@@ -54,13 +172,11 @@ export class WorldStateAccessTrace {
       counter: new Fr(this.accessCounter),
       //  endLifetime: Fr.ZERO,
     };
-    this.publicStorageReads.push(traced);
+    this.publicStorageReads.pushItem(traced);
     this.incrementAccessCounter();
   }
 
   public tracePublicStorageWrite(storageAddress: Fr, slot: Fr, value: Fr) {
-    // TODO(4805): check if some threshold is reached for max storage writes
-    // (need access to parent length, or trace needs to be initialized with parent's contents)
     const traced: TracedPublicStorageWrite = {
       //  callPointer: Fr.ZERO,
       storageAddress,
@@ -69,7 +185,7 @@ export class WorldStateAccessTrace {
       counter: new Fr(this.accessCounter),
       //  endLifetime: Fr.ZERO,
     };
-    this.publicStorageWrites.push(traced);
+    this.publicStorageWrites.pushItem(traced);
     this.incrementAccessCounter();
   }
 
@@ -83,12 +199,11 @@ export class WorldStateAccessTrace {
       // endLifetime: Fr.ZERO,
       leafIndex,
     };
-    this.noteHashChecks.push(traced);
+    this.noteHashChecks.pushItem(traced);
     this.incrementAccessCounter();
   }
 
   public traceNewNoteHash(storageAddress: Fr, noteHash: Fr) {
-    // TODO(4805): check if some threshold is reached for max new note hash
     const traced: TracedNoteHash = {
       //  callPointer: Fr.ZERO,
       storageAddress,
@@ -96,12 +211,11 @@ export class WorldStateAccessTrace {
       counter: new Fr(this.accessCounter),
       //  endLifetime: Fr.ZERO,
     };
-    this.newNoteHashes.push(traced);
+    this.newNoteHashes.pushItem(traced);
     this.incrementAccessCounter();
   }
 
   public traceNullifierCheck(storageAddress: Fr, nullifier: Fr, exists: boolean, isPending: boolean, leafIndex: Fr) {
-    // TODO(4805): check if some threshold is reached for max new nullifier
     const traced: TracedNullifierCheck = {
       // callPointer: Fr.ZERO,
       storageAddress,
@@ -112,7 +226,7 @@ export class WorldStateAccessTrace {
       isPending,
       leafIndex,
     };
-    this.nullifierChecks.push(traced);
+    this.nullifierChecks.pushItem(traced);
     this.incrementAccessCounter();
   }
 
@@ -125,12 +239,11 @@ export class WorldStateAccessTrace {
       counter: new Fr(this.accessCounter),
       // endLifetime: Fr.ZERO,
     };
-    this.newNullifiers.push(tracedNullifier);
+    this.newNullifiers.pushItem(tracedNullifier);
     this.incrementAccessCounter();
   }
 
   public traceL1ToL2MessageCheck(msgHash: Fr, msgLeafIndex: Fr, exists: boolean) {
-    // TODO(4805): check if some threshold is reached for max message reads
     const traced: TracedL1toL2MessageCheck = {
       //callPointer: Fr.ZERO, // FIXME
       leafIndex: msgLeafIndex,
@@ -138,22 +251,21 @@ export class WorldStateAccessTrace {
       exists: exists,
       //endLifetime: Fr.ZERO, // FIXME
     };
-    this.l1ToL2MessageChecks.push(traced);
+    this.l1ToL2MessageChecks.pushItem(traced);
     this.incrementAccessCounter();
   }
 
   public traceL2ToL1Message(recipient: EthAddress, content: Fr) {
     const traced = new L2ToL1Message(recipient, content, this.accessCounter);
-    this.newL2ToL1Messages.push(traced);
+    this.newL2ToL1Messages.pushItem(traced);
     this.incrementAccessCounter();
   }
 
   public traceUnencryptedLog(ulog: UnencryptedL2Log, logHash: Fr) {
     // TODO(6578): explain magic number 4 here
-    // TODO(4805): check if some threshold is reached for max logs
     const traced = new LogHash(logHash, this.accessCounter, new Fr(ulog.length + 4));
-    this.newUnencryptedLogs.push(ulog);
-    this.newUnencryptedLogsHashes.push(traced);
+    this.newUnencryptedLogs.pushItem(ulog);
+    this.newUnencryptedLogsHashes.pushItem(traced);
     this.incrementAccessCounter();
   }
 
@@ -168,25 +280,34 @@ export class WorldStateAccessTrace {
    */
   public merge(incomingTrace: WorldStateAccessTrace, rejectIncomingAccruedSubstate: boolean = false) {
     // Merge storage read and write journals
-    this.publicStorageReads.push(...incomingTrace.publicStorageReads);
-    this.publicStorageWrites.push(...incomingTrace.publicStorageWrites);
+    this.publicStorageReads.merge(incomingTrace.publicStorageReads);
+    this.publicStorageWrites.merge(incomingTrace.publicStorageWrites);
     // Merge new note hashes and nullifiers
-    this.noteHashChecks.push(...incomingTrace.noteHashChecks);
-    this.newNoteHashes.push(...incomingTrace.newNoteHashes);
-    this.nullifierChecks.push(...incomingTrace.nullifierChecks);
-    this.newNullifiers.push(...incomingTrace.newNullifiers);
-    this.l1ToL2MessageChecks.push(...incomingTrace.l1ToL2MessageChecks);
+    this.noteHashChecks.merge(incomingTrace.noteHashChecks);
+    this.newNoteHashes.merge(incomingTrace.newNoteHashes);
+    this.nullifierChecks.merge(incomingTrace.nullifierChecks);
+    this.newNullifiers.merge(incomingTrace.newNullifiers);
+    this.l1ToL2MessageChecks.merge(incomingTrace.l1ToL2MessageChecks);
 
     // We keep track of ALL state accesses (even those that are reverted),
     // but we don't keep track of reverted accrued substate (new messages and logs)
     if (!rejectIncomingAccruedSubstate) {
       // Accrued Substate
-      this.newL2ToL1Messages.push(...incomingTrace.newL2ToL1Messages);
-      this.newUnencryptedLogs.push(...incomingTrace.newUnencryptedLogs);
-      this.newUnencryptedLogsHashes.push(...incomingTrace.newUnencryptedLogsHashes);
+      this.newL2ToL1Messages.merge(incomingTrace.newL2ToL1Messages);
+      this.newUnencryptedLogs.merge(incomingTrace.newUnencryptedLogs);
+      this.newUnencryptedLogsHashes.merge(incomingTrace.newUnencryptedLogsHashes);
     }
 
     // it is assumed that the incoming trace was initialized with this as parent, so accept counter
     this.accessCounter = incomingTrace.accessCounter;
+  }
+}
+
+export class TooManyAccessesError extends Error {
+  constructor(accessType: string, limit: number, mode: string) {
+    // accessType: public storage reads / ...
+    // mode: per call / per tx
+    super(`Surpassed limit of ${limit} "${accessType}" accesses ${mode}`);
+    this.name = 'TooManyAccessesError';
   }
 }

--- a/yarn-project/simulator/src/avm/opcodes/accrued_substate.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/accrued_substate.test.ts
@@ -68,9 +68,11 @@ describe('Accrued Substate', () => {
       expect(exists).toEqual(new Uint8(0));
 
       const journalState = context.persistableState.flush();
-      expect(journalState.noteHashChecks).toEqual([
-        expect.objectContaining({ exists: false, leafIndex: leafIndex.toFr(), noteHash: noteHash.toFr() }),
-      ]);
+      expect(journalState.noteHashChecks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ exists: false, leafIndex: leafIndex.toFr(), noteHash: noteHash.toFr() }),
+        ]),
+      );
     });
 
     it('Should correctly return false when note hash exists at a different leaf index', async () => {
@@ -94,9 +96,11 @@ describe('Accrued Substate', () => {
       expect(exists).toEqual(new Uint8(0));
 
       const journalState = context.persistableState.flush();
-      expect(journalState.noteHashChecks).toEqual([
-        expect.objectContaining({ exists: false, leafIndex: leafIndex.toFr(), noteHash: noteHash.toFr() }),
-      ]);
+      expect(journalState.noteHashChecks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ exists: false, leafIndex: leafIndex.toFr(), noteHash: noteHash.toFr() }),
+        ]),
+      );
     });
 
     it('Should correctly return true when note hash exists at the given leaf index', async () => {
@@ -120,9 +124,11 @@ describe('Accrued Substate', () => {
       expect(exists).toEqual(new Uint8(1));
 
       const journalState = context.persistableState.flush();
-      expect(journalState.noteHashChecks).toEqual([
-        expect.objectContaining({ exists: true, leafIndex: leafIndex.toFr(), noteHash: noteHash.toFr() }),
-      ]);
+      expect(journalState.noteHashChecks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ exists: true, leafIndex: leafIndex.toFr(), noteHash: noteHash.toFr() }),
+        ]),
+      );
     });
   });
 
@@ -146,12 +152,14 @@ describe('Accrued Substate', () => {
       await new EmitNoteHash(/*indirect=*/ 0, /*offset=*/ 0).execute(context);
 
       const journalState = context.persistableState.flush();
-      expect(journalState.newNoteHashes).toEqual([
-        expect.objectContaining({
-          storageAddress: context.environment.storageAddress,
-          noteHash: value.toFr(),
-        }),
-      ]);
+      expect(journalState.newNoteHashes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: context.environment.storageAddress,
+            noteHash: value.toFr(),
+          }),
+        ]),
+      );
     });
   });
 
@@ -196,9 +204,11 @@ describe('Accrued Substate', () => {
       expect(exists).toEqual(new Uint8(0));
 
       const journalState = context.persistableState.flush();
-      expect(journalState.nullifierChecks).toEqual([
-        expect.objectContaining({ nullifier: value.toFr(), storageAddress: address.toFr(), exists: false }),
-      ]);
+      expect(journalState.nullifierChecks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ nullifier: value.toFr(), storageAddress: address.toFr(), exists: false }),
+        ]),
+      );
     });
 
     it('Should correctly show true when nullifier exists', async () => {
@@ -223,9 +233,11 @@ describe('Accrued Substate', () => {
       expect(exists).toEqual(new Uint8(1));
 
       const journalState = context.persistableState.flush();
-      expect(journalState.nullifierChecks).toEqual([
-        expect.objectContaining({ nullifier: value.toFr(), storageAddress: address.toFr(), exists: true }),
-      ]);
+      expect(journalState.nullifierChecks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ nullifier: value.toFr(), storageAddress: address.toFr(), exists: true }),
+        ]),
+      );
     });
   });
 
@@ -249,12 +261,14 @@ describe('Accrued Substate', () => {
       await new EmitNullifier(/*indirect=*/ 0, /*offset=*/ 0).execute(context);
 
       const journalState = context.persistableState.flush();
-      expect(journalState.newNullifiers).toEqual([
-        expect.objectContaining({
-          storageAddress: context.environment.storageAddress.toField(),
-          nullifier: value.toFr(),
-        }),
-      ]);
+      expect(journalState.newNullifiers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            storageAddress: context.environment.storageAddress.toField(),
+            nullifier: value.toFr(),
+          }),
+        ]),
+      );
     });
 
     it('Nullifier collision reverts (same nullifier emitted twice)', async () => {
@@ -328,9 +342,11 @@ describe('Accrued Substate', () => {
       expect(exists).toEqual(new Uint8(0));
 
       const journalState = context.persistableState.flush();
-      expect(journalState.l1ToL2MessageChecks).toEqual([
-        expect.objectContaining({ leafIndex: leafIndex.toFr(), msgHash: msgHash.toFr(), exists: false }),
-      ]);
+      expect(journalState.l1ToL2MessageChecks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ leafIndex: leafIndex.toFr(), msgHash: msgHash.toFr(), exists: false }),
+        ]),
+      );
     });
 
     it('Should correctly show true when L1ToL2 message exists', async () => {
@@ -354,9 +370,11 @@ describe('Accrued Substate', () => {
       expect(exists).toEqual(new Uint8(1));
 
       const journalState = context.persistableState.flush();
-      expect(journalState.l1ToL2MessageChecks).toEqual([
-        expect.objectContaining({ leafIndex: leafIndex.toFr(), msgHash: msgHash.toFr(), exists: true }),
-      ]);
+      expect(journalState.l1ToL2MessageChecks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ leafIndex: leafIndex.toFr(), msgHash: msgHash.toFr(), exists: true }),
+        ]),
+      );
     });
 
     it('Should correctly show false when another L1ToL2 message exists at that index', async () => {
@@ -380,9 +398,11 @@ describe('Accrued Substate', () => {
       expect(exists).toEqual(new Uint8(0));
 
       const journalState = context.persistableState.flush();
-      expect(journalState.l1ToL2MessageChecks).toEqual([
-        expect.objectContaining({ leafIndex: leafIndex.toFr(), msgHash: msgHash.toFr(), exists: false }),
-      ]);
+      expect(journalState.l1ToL2MessageChecks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ leafIndex: leafIndex.toFr(), msgHash: msgHash.toFr(), exists: false }),
+        ]),
+      );
     });
   });
 
@@ -424,9 +444,11 @@ describe('Accrued Substate', () => {
 
       const journalState = context.persistableState.flush();
       const expectedLog = Buffer.concat(values.map(v => v.toFr().toBuffer()));
-      expect(journalState.newLogs).toEqual([
-        new UnencryptedL2Log(context.environment.address, new EventSelector(eventSelector), expectedLog),
-      ]);
+      expect(journalState.newLogs).toEqual(
+        expect.arrayContaining([
+          new UnencryptedL2Log(context.environment.address, new EventSelector(eventSelector), expectedLog),
+        ]),
+      );
     });
   });
 
@@ -464,9 +486,9 @@ describe('Accrued Substate', () => {
       ).execute(context);
 
       const journalState = context.persistableState.flush();
-      expect(journalState.newL1Messages).toEqual([
-        expect.objectContaining({ recipient: EthAddress.fromField(recipient), content }),
-      ]);
+      expect(journalState.newL1Messages).toEqual(
+        expect.arrayContaining([expect.objectContaining({ recipient: EthAddress.fromField(recipient), content })]),
+      );
     });
   });
 


### PR DESCRIPTION
Resolves https://github.com/AztecProtocol/aztec-packages/issues/4805