### PR TITLE
feat: Goblin Recursive Verifier

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
@@ -491,7 +491,7 @@ template <typename Curve_> class IPA {
                                        // to a bb::fr, not a grumpkin::fr, which is a BaseField element for
                                        // Grumpkin
 
-        // Ensure polynomial length cannot be changed from it's genuine value
+        // Ensure polynomial length cannot be changed from its default specified valued
         poly_length_var.fix_witness();
 
         const uint32_t poly_length = static_cast<uint32_t>(poly_length_var.get_value());

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
@@ -186,6 +186,11 @@ class GoblinVerifier {
     using TranslatorVerificationKey = bb::TranslatorFlavor::VerificationKey;
     using MergeVerifier = bb::MergeVerifier_<MegaFlavor>;
 
+    struct VerifierInput {
+        std::shared_ptr<ECCVMVerificationKey> eccvm_verification_key;
+        std::shared_ptr<TranslatorVerificationKey> translator_verification_key;
+    };
+
   private:
     std::shared_ptr<ECCVMVerificationKey> eccvm_verification_key;
     std::shared_ptr<TranslatorVerificationKey> translator_verification_key;
@@ -195,6 +200,11 @@ class GoblinVerifier {
                    std::shared_ptr<TranslatorVerificationKey> translator_verification_key)
         : eccvm_verification_key(eccvm_verification_key)
         , translator_verification_key(translator_verification_key)
+    {}
+
+    GoblinVerifier(VerifierInput input)
+        : eccvm_verification_key(input.eccvm_verification_key)
+        , translator_verification_key(input.translator_verification_key)
     {}
 
     /**

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/CMakeLists.txt
@@ -6,5 +6,8 @@ barretenberg_module(
     ultra_honk
     stdlib_poseidon2
     protogalaxy
+    goblin
+    translator_vm_recursion
+    eccvm_recursion
     client_ivc
 )

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.cpp
@@ -28,7 +28,8 @@ void GoblinRecursiveVerifier::verify(GoblinProof& proof)
         };
     translator_verifier.verify_translation(translation_evaluations);
 
-    // WORKTODO: Perform recursive merge verification once it works with Ultra arithmetization (fingers crossed)
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1024): Perform recursive merge verification once it
+    // works with Ultra arithmetization
     // MergeVerifier merge_verified{ builder };
     // [[maybe_unused]] auto merge_pairing_points = merge_verifier.verify_proof(proof.merge_proof);
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.cpp
@@ -1,0 +1,35 @@
+#include "barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.hpp"
+
+namespace bb::stdlib::recursion::honk {
+
+void GoblinRecursiveVerifier::verify(GoblinProof& proof)
+{
+    // Run the ECCVM recursive verifier
+    ECCVMVerifier eccvm_verifier{ builder, verification_keys.eccvm_verification_key };
+    eccvm_verifier.verify_proof(proof.eccvm_proof);
+
+    // Run the Translator recursive verifier
+    TranslatorVerifier translator_verifier{ builder,
+                                            verification_keys.translator_verification_key,
+                                            eccvm_verifier.transcript };
+    translator_verifier.verify_proof(proof.translator_proof);
+
+    // Verify the consistency between the ECCVM and Translator transcript polynomial evaluations
+    // In reality the Goblin Proof is going to already be a stdlib proof and this conversion is not going to happen here
+    // (see https://github.com/AztecProtocol/barretenberg/issues/991)
+    auto native_translation_evaluations = proof.translation_evaluations;
+    auto translation_evaluations =
+        TranslationEvaluations{ TranslatorBF::from_witness(builder, native_translation_evaluations.op),
+                                TranslatorBF::from_witness(builder, native_translation_evaluations.Px),
+                                TranslatorBF::from_witness(builder, native_translation_evaluations.Py),
+                                TranslatorBF::from_witness(builder, native_translation_evaluations.z1),
+                                TranslatorBF::from_witness(builder, native_translation_evaluations.z2)
+
+        };
+    translator_verifier.verify_translation(translation_evaluations);
+
+    // WORKTODO: Perform recursive merge verification once it works with Ultra arithmetization (fingers crossed)
+    // MergeVerifier merge_verified{ builder };
+    // [[maybe_unused]] auto merge_pairing_points = merge_verifier.verify_proof(proof.merge_proof);
+}
+} // namespace bb::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include "barretenberg/eccvm_recursion/eccvm_recursive_verifier.hpp"
+#include "barretenberg/goblin/goblin.hpp"
+#include "barretenberg/stdlib/honk_recursion/verifier/merge_recursive_verifier.hpp"
+#include "barretenberg/translator_vm_recursion/translator_recursive_verifier.hpp"
+
+namespace bb::stdlib::recursion::honk {
+class GoblinRecursiveVerifier {
+  public:
+    // Goblin Recursive Verifier circuit is using Ultra arithmetisation
+    using Builder = UltraCircuitBuilder;
+    using MergeVerifier = goblin::MergeRecursiveVerifier_<Builder>;
+
+    using TranslatorFlavor = TranslatorRecursiveFlavor_<Builder>;
+    using TranslatorVerifier = TranslatorRecursiveVerifier_<TranslatorFlavor>;
+    using TranslationEvaluations = TranslatorVerifier::TranslationEvaluations;
+    using TranslatorBF = TranslatorFlavor::BF;
+
+    using ECCVMFlavor = ECCVMRecursiveFlavor_<Builder>;
+    using ECCVMVerifier = ECCVMRecursiveVerifier_<ECCVMFlavor>;
+
+    // ECCVM and Translator verification keys
+    using VerifierInput = GoblinVerifier::VerifierInput;
+
+    GoblinRecursiveVerifier(Builder* builder, VerifierInput& verification_keys)
+        : builder(builder)
+        , verification_keys(verification_keys){};
+
+    /**
+     * @brief Construct a Goblin recursive verifier circuit
+     * @details Contains three recursive verifiers: Merge, ECCVM, and Translator
+     * @todohttps://github.com/AztecProtocol/barretenberg/issues/1021): The values returned by the recursive verifiers
+     * are not aggregated here. We need to aggregate and return the pairing points from Merge/Translator plus deal with
+     * the IPA accumulator from ECCVM.
+     *
+     * @todo(https://github.com/AztecProtocol/barretenberg/issues/991): The GoblinProof should aleady be a stdlib proof
+     */
+    void verify(GoblinProof&);
+
+  private:
+    Builder* builder;
+    VerifierInput verification_keys; // ECCVM and Translator verification keys
+};
+
+} // namespace bb::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.hpp
@@ -29,7 +29,7 @@ class GoblinRecursiveVerifier {
     /**
      * @brief Construct a Goblin recursive verifier circuit
      * @details Contains three recursive verifiers: Merge, ECCVM, and Translator
-     * @todohttps://github.com/AztecProtocol/barretenberg/issues/1021): The values returned by the recursive verifiers
+     * @todo(https://github.com/AztecProtocol/barretenberg/issues/1021): The values returned by the recursive verifiers
      * are not aggregated here. We need to aggregate and return the pairing points from Merge/Translator plus deal with
      * the IPA accumulator from ECCVM.
      *

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.test.cpp
@@ -1,0 +1,106 @@
+#include "barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.hpp"
+#include "barretenberg/circuit_checker/circuit_checker.hpp"
+#include "barretenberg/common/test.hpp"
+#include "barretenberg/goblin/goblin.hpp"
+#include "barretenberg/ultra_honk/ultra_prover.hpp"
+#include "barretenberg/ultra_honk/ultra_verifier.hpp"
+
+namespace bb::stdlib::recursion::honk {
+class GoblinRecursiveVerifierTests : public testing::Test {
+  public:
+    using Builder = GoblinRecursiveVerifier::Builder;
+    using ECCVMVK = GoblinVerifier::ECCVMVerificationKey;
+    using TranslatorVK = GoblinVerifier::TranslatorVerificationKey;
+
+    using OuterFlavor = UltraFlavor;
+    using OuterProver = UltraProver_<OuterFlavor>;
+    using OuterVerifier = UltraVerifier_<OuterFlavor>;
+    using OuterProverInstance = ProverInstance_<OuterFlavor>;
+
+    static void SetUpTestSuite()
+    {
+        bb::srs::init_crs_factory("../srs_db/ignition");
+        bb::srs::init_grumpkin_crs_factory("../srs_db/grumpkin");
+    }
+
+    static MegaCircuitBuilder construct_mock_circuit(std::shared_ptr<ECCOpQueue> op_queue)
+    {
+        MegaCircuitBuilder circuit{ op_queue };
+        MockCircuits::construct_arithmetic_circuit(circuit, /*target_log2_dyadic_size=*/8);
+        MockCircuits::construct_goblin_ecc_op_circuit(circuit);
+        return circuit;
+    }
+
+    struct ProverOutput {
+        GoblinProof proof;
+        GoblinVerifier::VerifierInput verfier_input;
+    };
+
+    /**
+     * @brief Create a goblin proof and the VM verification keys needed by the goblin recursive verifier
+     *
+     * @return ProverOutput
+     */
+    ProverOutput create_goblin_prover_output()
+    {
+        GoblinProver goblin;
+
+        // Construct and accumulate multiple circuits
+        size_t NUM_CIRCUITS = 3;
+        for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
+            auto circuit = construct_mock_circuit(goblin.op_queue);
+            goblin.merge(circuit); // appends a recurisve merge verifier if a merge proof exists
+        }
+
+        // Output is a goblin proof plus ECCVM/Translator verification keys
+        return { goblin.prove(),
+                 { std::make_shared<ECCVMVK>(goblin.get_eccvm_proving_key()),
+                   std::make_shared<TranslatorVK>(goblin.get_translator_proving_key()) } };
+    }
+};
+
+/**
+ * @brief Ensure the Goblin proof produced by the test method can be natively verified
+ *
+ */
+TEST_F(GoblinRecursiveVerifierTests, NativeVerification)
+{
+    auto [proof, verifier_input] = create_goblin_prover_output();
+
+    GoblinVerifier verifier{ verifier_input };
+
+    EXPECT_TRUE(verifier.verify(proof));
+}
+
+/**
+ * @brief Construct and check a goblin recursive verification circuit
+ *
+ */
+TEST_F(GoblinRecursiveVerifierTests, Basic)
+{
+    auto [proof, verifier_input] = create_goblin_prover_output();
+
+    Builder builder;
+    GoblinRecursiveVerifier verifier{ &builder, verifier_input };
+    verifier.verify(proof);
+
+    info("Recursive Verifier: num gates = ", builder.num_gates);
+
+    EXPECT_EQ(builder.failed(), false) << builder.err();
+
+    EXPECT_TRUE(CircuitChecker::check(builder));
+
+    // Construct and verify a proof for the Goblin Recursive Verifier circuit
+    {
+        auto instance = std::make_shared<OuterProverInstance>(builder);
+        OuterProver prover(instance);
+        auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(instance->proving_key);
+        OuterVerifier verifier(verification_key);
+        auto proof = prover.construct_proof();
+        bool verified = verifier.verify_proof(proof);
+
+        ASSERT(verified);
+    }
+}
+
+} // namespace bb::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/merge_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/merge_verifier.test.cpp
@@ -1,4 +1,5 @@
 #include "barretenberg/ultra_honk/merge_verifier.hpp"
+#include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/common/test.hpp"
 #include "barretenberg/goblin/mock_circuits.hpp"
 #include "barretenberg/stdlib/honk_recursion/verifier/merge_recursive_verifier.hpp"
@@ -16,10 +17,9 @@ namespace bb::stdlib::recursion::goblin {
  *
  * @tparam Builder
  */
-class RecursiveMergeVerifierTest : public testing::Test {
+template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public testing::Test {
 
     // Types for recursive verifier circuit
-    using RecursiveBuilder = MegaCircuitBuilder;
     using RecursiveMergeVerifier = MergeRecursiveVerifier_<RecursiveBuilder>;
 
     // Define types relevant for inner circuit
@@ -82,23 +82,21 @@ class RecursiveMergeVerifierTest : public testing::Test {
             EXPECT_EQ(recursive_manifest[i], native_manifest[i]);
         }
 
-        // Check 3: Construct and verify a (goblin) ultra honk proof of the Merge recursive verifier circuit
-        {
-            auto instance = std::make_shared<InnerProverInstance>(outer_circuit);
-            MegaProver prover(instance);
-            auto verification_key = std::make_shared<MegaFlavor::VerificationKey>(instance->proving_key);
-            MegaVerifier verifier(verification_key);
-            auto proof = prover.construct_proof();
-            bool verified = verifier.verify_proof(proof);
-
-            EXPECT_TRUE(verified);
-        }
+        // Check the recursive merge verifier circuit
+        CircuitChecker::check(outer_circuit);
     }
 };
 
-TEST_F(RecursiveMergeVerifierTest, SingleRecursiveVerification)
+// Run the recursive verifier tests with Ultra and Mega builders
+using Builders = testing::Types<MegaCircuitBuilder>;
+// WORKTODO: Ultra fails, possibly due to repeated points in batch mul?
+// using Builders = testing::Types<MegaCircuitBuilder, UltraCircuitBuilder>;
+
+TYPED_TEST_SUITE(RecursiveMergeVerifierTest, Builders);
+
+TYPED_TEST(RecursiveMergeVerifierTest, SingleRecursiveVerification)
 {
-    RecursiveMergeVerifierTest::test_recursive_merge_verification();
+    TestFixture::test_recursive_merge_verification();
 };
 
 } // namespace bb::stdlib::recursion::goblin

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/merge_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/merge_verifier.test.cpp
@@ -88,9 +88,10 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
 };
 
 // Run the recursive verifier tests with Ultra and Mega builders
-using Builders = testing::Types<MegaCircuitBuilder>;
-// WORKTODO: Ultra fails, possibly due to repeated points in batch mul?
+// TODO(https://github.com/AztecProtocol/barretenberg/issues/1024): Ultra fails, possibly due to repeated points in
+// batch mul?
 // using Builders = testing::Types<MegaCircuitBuilder, UltraCircuitBuilder>;
+using Builders = testing::Types<MegaCircuitBuilder>;
 
 TYPED_TEST_SUITE(RecursiveMergeVerifierTest, Builders);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
@@ -672,7 +672,6 @@ template <typename Builder> bb::fr field_t<Builder>::get_value() const
 template <typename Builder> bool_t<Builder> field_t<Builder>::operator==(const field_t& other) const
 {
     Builder* ctx = (context == nullptr) ? other.context : context;
-
     if (is_constant() && other.is_constant()) {
         return (get_value() == other.get_value());
     }

--- a/barretenberg/cpp/src/barretenberg/translator_vm_recursion/translator_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm_recursion/translator_recursive_verifier.hpp
@@ -21,7 +21,7 @@ template <typename Flavor> class TranslatorRecursiveVerifier_ {
     using RelationSeparator = typename Flavor::RelationSeparator;
     using PairingPoints = std::array<GroupElement, 2>;
     using TranslationEvaluations = TranslationEvaluations_<BF, FF>;
-    using Transcript = bb::BaseTranscript<bb::stdlib::recursion::honk::StdlibTranscriptParams<Builder>>;
+    using Transcript = typename Flavor::Transcript;
     using RelationParams = ::bb::RelationParameters<FF>;
 
     BF evaluation_input_x = 0;
@@ -35,7 +35,9 @@ template <typename Flavor> class TranslatorRecursiveVerifier_ {
 
     RelationParams relation_parameters;
 
-    TranslatorRecursiveVerifier_(Builder* builder, const std::shared_ptr<NativeVerificationKey>& native_verifier_key);
+    TranslatorRecursiveVerifier_(Builder* builder,
+                                 const std::shared_ptr<NativeVerificationKey>& native_verifier_key,
+                                 const std::shared_ptr<Transcript>& transcript);
 
     void put_translation_data_in_relation_parameters(const BF& evaluation_input_x,
                                                      const BF& batching_challenge_v,


### PR DESCRIPTION
Implements a Goblin Recursive Verifier without the Merge. Removes hack in Translator Recursive Verifier and ensures we are able to pass the Transcript from ECCVM to Translator Recursive Verifier.
