### PR TITLE
chore: partial workaround earthly graph bug

### DIFF
--- a/.github/earthly-ci-config.yml
+++ b/.github/earthly-ci-config.yml
@@ -1,5 +1,5 @@
 global:
     cache_size_pct: 50
-    buildkit_max_parallelism: 10
+    buildkit_max_parallelism: 5
     container_frontend: docker-shell
 buildkit_additional_args: ["-e", "BUILDKIT_STEP_LOG_MAX_SIZE=-1"]


### PR DESCRIPTION
I give us about two weeks before we're confident with earthly's fix here (see https://github.com/AztecProtocol/aztec-packages/pull/6648, working with earthly on it). In the meantime, one thing reported to hit the bug less often is reducing parallelism. For the most part, 5 should be plenty as we do not currently do more than 5 long-running tasks anyway.
