### PR TITLE
chore(avm): better error msgs and some cpp nits

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_alu_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_alu_trace.cpp
@@ -1,5 +1,4 @@
-#include "avm_alu_trace.hpp"
-#include "barretenberg/numeric/uint256/uint256.hpp"
+#include "barretenberg/vm/avm_trace/avm_alu_trace.hpp"
 
 namespace bb::avm_trace {
 
@@ -1062,4 +1061,5 @@ FF AvmAluTraceBuilder::op_div(FF const& a, FF const& b, AvmMemoryTag in_tag, uin
     alu_trace.insert(alu_trace.end(), rows.begin(), rows.end());
     return c_u256;
 }
+
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_alu_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_alu_trace.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
-#include "avm_common.hpp"
+#include "barretenberg/numeric/uint256/uint256.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
+#include <array>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
 
 namespace bb::avm_trace {
 
@@ -102,4 +107,5 @@ class AvmAluTraceBuilder {
     template <typename T> std::tuple<uint8_t, uint8_t, std::array<uint16_t, 15>> to_alu_slice_registers(T a);
     std::vector<AluTraceEntry> cmp_range_check_helper(AluTraceEntry row, std::vector<uint256_t> hi_lo_limbs);
 };
+
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_binary_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_binary_trace.cpp
@@ -1,7 +1,7 @@
-
-#include "avm_binary_trace.hpp"
+#include "barretenberg/vm/avm_trace/avm_binary_trace.hpp"
 #include "barretenberg/numeric/uint128/uint128.hpp"
 #include "barretenberg/vm/avm_trace/avm_common.hpp"
+
 #include <algorithm>
 #include <array>
 #include <cmath>

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_binary_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_binary_trace.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include "avm_common.hpp"
 #include "barretenberg/numeric/uint128/uint128.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
+
 #include <unordered_map>
 
 namespace bb::avm_trace {
+
 class AvmBinaryTraceBuilder {
   public:
     struct BinaryTraceEntry {
@@ -48,4 +50,5 @@ class AvmBinaryTraceBuilder {
                        uint32_t clk,
                        uint8_t op_id);
 };
+
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_common.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_common.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
-#include "barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp"
-#include "barretenberg/vm/generated/avm_circuit_builder.hpp"
-#include "constants.hpp"
+#include "barretenberg/vm/avm_trace/constants.hpp"
+#include "barretenberg/vm/generated/avm_flavor.hpp"
+
+#include <array>
 #include <cstdint>
 
 namespace bb::avm_trace {
 
 using Flavor = bb::AvmFlavor;
 using FF = Flavor::FF;
-using Row = bb::AvmFullRow<bb::fr>;
 
 // There are 4 public input columns, 1 for context inputs, and 3 for emitting side effects
 using VmPublicInputs = std::tuple<std::array<FF, KERNEL_INPUTS_LENGTH>,   // Input: Kernel context inputs

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_deserialization.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_deserialization.hpp
@@ -1,13 +1,8 @@
 #pragma once
 
-#include "barretenberg/numeric/uint128/uint128.hpp"
-#include "barretenberg/vm/avm_trace/avm_common.hpp"
 #include "barretenberg/vm/avm_trace/avm_instructions.hpp"
-#include "barretenberg/vm/avm_trace/avm_opcode.hpp"
-#include <cstddef>
+
 #include <cstdint>
-#include <unordered_map>
-#include <variant>
 #include <vector>
 
 namespace bb::avm_trace {

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_execution.cpp
@@ -1,7 +1,8 @@
-#include "avm_execution.hpp"
+#include "barretenberg/vm/avm_trace/avm_execution.hpp"
 #include "barretenberg/common/serialize.hpp"
 #include "barretenberg/vm/avm_trace/avm_common.hpp"
 #include "barretenberg/vm/avm_trace/avm_deserialization.hpp"
+#include "barretenberg/vm/avm_trace/avm_helper.hpp"
 #include "barretenberg/vm/avm_trace/avm_instructions.hpp"
 #include "barretenberg/vm/avm_trace/avm_kernel_trace.hpp"
 #include "barretenberg/vm/avm_trace/avm_opcode.hpp"
@@ -11,6 +12,7 @@
 #include "barretenberg/vm/generated/avm_circuit_builder.hpp"
 #include "barretenberg/vm/generated/avm_composer.hpp"
 #include "barretenberg/vm/generated/avm_flavor.hpp"
+
 #include <cassert>
 #include <cstddef>
 #include <cstdint>

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_execution.hpp
@@ -2,9 +2,9 @@
 
 #include "barretenberg/honk/proof_system/types/proof.hpp"
 #include "barretenberg/vm/avm_trace/avm_common.hpp"
-#include "barretenberg/vm/avm_trace/avm_helper.hpp"
 #include "barretenberg/vm/avm_trace/avm_instructions.hpp"
 #include "barretenberg/vm/avm_trace/avm_trace.hpp"
+
 #include <cstddef>
 #include <cstdint>
 #include <vector>

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_gas_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_gas_trace.cpp
@@ -1,4 +1,4 @@
-#include "avm_gas_trace.hpp"
+#include "barretenberg/vm/avm_trace/avm_gas_trace.hpp"
 
 namespace bb::avm_trace {
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_gas_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_gas_trace.hpp
@@ -1,5 +1,4 @@
-
-#include "avm_common.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
 #include "barretenberg/vm/avm_trace/avm_opcode.hpp"
 
 namespace bb::avm_trace {
@@ -141,4 +140,5 @@ class AvmGasTraceBuilder {
     uint32_t remaining_l2_gas = 0;
     uint32_t remaining_da_gas = 0;
 };
+
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_helper.cpp
@@ -1,4 +1,4 @@
-#include "avm_helper.hpp"
+#include "barretenberg/vm/avm_trace/avm_helper.hpp"
 #include "barretenberg/vm/avm_trace/avm_mem_trace.hpp"
 
 namespace bb::avm_trace {

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_helper.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_helper.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "avm_common.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
+#include "barretenberg/vm/avm_trace/avm_trace.hpp"
 
 namespace bb::avm_trace {
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_instructions.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_instructions.hpp
@@ -3,6 +3,7 @@
 #include "barretenberg/numeric/uint128/uint128.hpp"
 #include "barretenberg/vm/avm_trace/avm_common.hpp"
 #include "barretenberg/vm/avm_trace/avm_opcode.hpp"
+
 #include <cstdint>
 #include <variant>
 #include <vector>

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_kernel_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_kernel_trace.cpp
@@ -1,5 +1,9 @@
-#include "avm_kernel_trace.hpp"
+#include "barretenberg/vm/avm_trace/avm_kernel_trace.hpp"
 #include "barretenberg/vm/avm_trace/avm_common.hpp"
+#include "barretenberg/vm/avm_trace/avm_trace.hpp"
+#include "constants.hpp"
+
+#include <cstdint>
 #include <sys/types.h>
 
 // For the meantime, we do not fire around the public inputs as a vector or otherwise

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_kernel_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_kernel_trace.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
-#include "avm_common.hpp"
 #include "barretenberg/numeric/uint128/uint128.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
+#include "constants.hpp"
+
 #include <cstdint>
 #include <unordered_map>
+#include <vector>
 
 inline const uint32_t SENDER_SELECTOR = 0;
 inline const uint32_t ADDRESS_SELECTOR = 1;

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_mem_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_mem_trace.cpp
@@ -1,6 +1,7 @@
-#include "avm_mem_trace.hpp"
+#include "barretenberg/vm/avm_trace/avm_mem_trace.hpp"
 #include "barretenberg/vm/avm_trace/avm_common.hpp"
 #include "barretenberg/vm/avm_trace/avm_trace.hpp"
+
 #include <cstdint>
 
 namespace bb::avm_trace {

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_mem_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_mem_trace.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "avm_common.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
+
 #include <cstdint>
 
 namespace bb::avm_trace {

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_opcode.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_opcode.cpp
@@ -1,4 +1,6 @@
-#include "avm_opcode.hpp"
+#include "barretenberg/vm/avm_trace/avm_opcode.hpp"
+#include "barretenberg/common/log.hpp"
+#include "barretenberg/common/serialize.hpp"
 
 namespace bb::avm_trace {
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_opcode.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_opcode.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
-#include "barretenberg/common/log.hpp"
-#include "barretenberg/common/serialize.hpp"
+#include "barretenberg/numeric/uint128/uint128.hpp"
+
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <iomanip>
 #include <sstream>
 #include <string>
-#include <unordered_map>
 
 namespace bb::avm_trace {
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.cpp
@@ -11,12 +11,10 @@
 #include <sys/types.h>
 #include <vector>
 
-#include "avm_common.hpp"
-#include "avm_helper.hpp"
-#include "avm_mem_trace.hpp"
-#include "avm_trace.hpp"
-#include "barretenberg/vm/avm_trace/avm_kernel_trace.hpp"
+#include "barretenberg/common/throw_or_abort.hpp"
+#include "barretenberg/vm/avm_trace/avm_helper.hpp"
 #include "barretenberg/vm/avm_trace/avm_opcode.hpp"
+#include "barretenberg/vm/avm_trace/avm_trace.hpp"
 
 namespace bb::avm_trace {
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.hpp
@@ -2,23 +2,23 @@
 
 #include <stack>
 
-#include "avm_alu_trace.hpp"
-#include "avm_binary_trace.hpp"
-#include "avm_common.hpp"
-#include "avm_gas_trace.hpp"
-#include "avm_instructions.hpp"
-#include "avm_mem_trace.hpp"
-#include "barretenberg/common/throw_or_abort.hpp"
-#include "barretenberg/relations/generated/avm/avm_main.hpp"
+#include "barretenberg/vm/avm_trace/avm_alu_trace.hpp"
+#include "barretenberg/vm/avm_trace/avm_binary_trace.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
+#include "barretenberg/vm/avm_trace/avm_gas_trace.hpp"
 #include "barretenberg/vm/avm_trace/avm_kernel_trace.hpp"
+#include "barretenberg/vm/avm_trace/avm_mem_trace.hpp"
+#include "barretenberg/vm/avm_trace/constants.hpp"
 #include "barretenberg/vm/avm_trace/gadgets/avm_conversion_trace.hpp"
 #include "barretenberg/vm/avm_trace/gadgets/avm_keccak.hpp"
 #include "barretenberg/vm/avm_trace/gadgets/avm_pedersen.hpp"
 #include "barretenberg/vm/avm_trace/gadgets/avm_poseidon2.hpp"
 #include "barretenberg/vm/avm_trace/gadgets/avm_sha256.hpp"
-#include "constants.hpp"
+#include "barretenberg/vm/generated/avm_circuit_builder.hpp"
 
 namespace bb::avm_trace {
+
+using Row = bb::AvmFullRow<bb::fr>;
 
 // This is the internal context that we keep along the lifecycle of bytecode execution
 // to iteratively build the whole trace. This is effectively performing witness generation.
@@ -281,4 +281,5 @@ class AvmTraceBuilder {
                                FF internal_return_ptr,
                                std::vector<FF> const& slice);
 };
+
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/aztec_constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/aztec_constants.hpp
@@ -1,5 +1,6 @@
 // GENERATED FILE - DO NOT EDIT, RUN yarn remake-constants in circuits.js
 #pragma once
+
 #include <cstddef>
 
 const size_t MAX_NEW_NOTE_HASHES_PER_CALL = 16;

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/constants.hpp
@@ -1,5 +1,7 @@
 #pragma once
+
 #include "aztec_constants.hpp"
+
 #include <cstdint>
 
 // NOTE(MD): for now we will only include the public inputs that are included in call_context

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_conversion_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_conversion_trace.cpp
@@ -1,6 +1,5 @@
 
-#include "avm_conversion_trace.hpp"
-#include "../avm_common.hpp"
+#include "barretenberg/vm/avm_trace/gadgets/avm_conversion_trace.hpp"
 
 namespace bb::avm_trace {
 
@@ -58,4 +57,5 @@ std::vector<uint8_t> AvmConversionTraceBuilder::op_to_radix_le(FF const& a,
 
     return bytes;
 }
+
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_conversion_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_conversion_trace.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
-#include "../avm_common.hpp"
 #include "barretenberg/numeric/uint128/uint128.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
+
 #include <cstdint>
 #include <unordered_map>
+#include <vector>
 
 namespace bb::avm_trace {
+
 class AvmConversionTraceBuilder {
   public:
     struct ConversionTraceEntry {
@@ -27,4 +30,5 @@ class AvmConversionTraceBuilder {
   private:
     std::vector<ConversionTraceEntry> conversion_trace;
 };
+
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_keccak.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_keccak.cpp
@@ -1,10 +1,10 @@
-
-
 #include "barretenberg/vm/avm_trace/gadgets/avm_keccak.hpp"
 #include "barretenberg/crypto/hashers/hashers.hpp"
 #include "barretenberg/crypto/keccak/keccak.hpp"
+
 #include <algorithm>
 #include <cstdint>
+
 namespace bb::avm_trace {
 
 AvmKeccakTraceBuilder::AvmKeccakTraceBuilder()
@@ -80,4 +80,5 @@ std::array<uint8_t, 32> AvmKeccakTraceBuilder::keccak(uint32_t clk, std::vector<
     });
     return output_bytes;
 }
+
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_keccak.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_keccak.hpp
@@ -1,10 +1,13 @@
-
 #pragma once
 
-#include "../avm_common.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
+
+#include <array>
 #include <cstdint>
+#include <vector>
 
 namespace bb::avm_trace {
+
 class AvmKeccakTraceBuilder {
   public:
     struct KeccakTraceEntry {
@@ -26,4 +29,5 @@ class AvmKeccakTraceBuilder {
   private:
     std::vector<KeccakTraceEntry> keccak_trace;
 };
+
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_pedersen.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_pedersen.cpp
@@ -1,7 +1,6 @@
-
-#include "avm_pedersen.hpp"
-#include "../avm_common.hpp"
+#include "barretenberg/vm/avm_trace/gadgets/avm_pedersen.hpp"
 #include "barretenberg/crypto/pedersen_hash/pedersen.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
 
 namespace bb::avm_trace {
 
@@ -30,4 +29,5 @@ FF AvmPedersenTraceBuilder::pedersen_hash(const std::vector<FF>& inputs, uint32_
 
     return output;
 }
+
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_pedersen.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_pedersen.hpp
@@ -1,9 +1,12 @@
-
 #pragma once
 
-#include "../avm_common.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
+
+#include <cstdint>
+#include <vector>
 
 namespace bb::avm_trace {
+
 class AvmPedersenTraceBuilder {
   public:
     struct PedersenTraceEntry {
@@ -25,4 +28,5 @@ class AvmPedersenTraceBuilder {
   private:
     std::vector<PedersenTraceEntry> pedersen_trace;
 };
+
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_poseidon2.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_poseidon2.cpp
@@ -1,7 +1,6 @@
-#include "avm_poseidon2.hpp"
-#include "../avm_common.hpp"
-#include "barretenberg/crypto/poseidon2/poseidon2_permutation.hpp"
 #include "barretenberg/vm/avm_trace/gadgets/avm_poseidon2.hpp"
+#include "barretenberg/crypto/poseidon2/poseidon2_permutation.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
 
 namespace bb::avm_trace {
 
@@ -29,4 +28,5 @@ std::array<FF, 4> AvmPoseidon2TraceBuilder::poseidon2_permutation(const std::arr
 
     return output;
 }
+
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_poseidon2.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_poseidon2.hpp
@@ -1,8 +1,10 @@
-
 #pragma once
 
-#include "../avm_common.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
+
+#include <array>
 #include <cstdint>
+#include <vector>
 
 namespace bb::avm_trace {
 class AvmPoseidon2TraceBuilder {

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_sha256.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_sha256.cpp
@@ -1,7 +1,8 @@
-#include "avm_sha256.hpp"
-#include "../avm_common.hpp"
+#include "barretenberg/vm/avm_trace/gadgets/avm_sha256.hpp"
 #include "barretenberg/crypto/sha256/sha256.hpp"
 #include "barretenberg/numeric/uint128/uint128.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
+
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -128,4 +129,5 @@ std::array<uint8_t, 32> AvmSha256TraceBuilder::sha256(const std::vector<uint8_t>
     sha256_trace.push_back(Sha256TraceEntry{ clk, {}, {}, {} });
     return output;
 }
+
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_sha256.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/gadgets/avm_sha256.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "../avm_common.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
+
+#include <array>
 #include <cstdint>
+#include <vector>
 
 namespace bb::avm_trace {
 class AvmSha256TraceBuilder {
@@ -26,4 +29,5 @@ class AvmSha256TraceBuilder {
   private:
     std::vector<Sha256TraceEntry> sha256_trace;
 };
+
 } // namespace bb::avm_trace

--- a/yarn-project/circuits.js/src/scripts/constants.in.ts
+++ b/yarn-project/circuits.js/src/scripts/constants.in.ts
@@ -147,6 +147,7 @@ function generateTypescriptConstants({ constants, generatorIndexEnum }: ParsedCo
 function generateCppConstants({ constants }: ParsedContent, targetPath: string) {
   const resultCpp: string = `// GENERATED FILE - DO NOT EDIT, RUN yarn remake-constants in circuits.js
 #pragma once
+
 #include <cstddef>
 
 ${processConstantsCpp(constants)}


### PR DESCRIPTION
First pass at unwinding headers as well.

Policy:
* Include as little as possible in .hpp files. Only enough for the types of what is there. Include the rest in the cpp.
* Include always what you use. 
* Do not depend on transitive includes (only exception: in the .cpp file you can assume the includes of your own .hpp file)
* Use full path.