### PR TITLE
fix: don't filter AVM changes for running e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,10 @@ jobs:
               - 'noir-projects/**'
             non-barretenberg-cpp:
               - '!(barretenberg/cpp/**)'
+              # don't consider AVM stuff 'core bb'
+              - barretenberg/cpp/pil/**
+              - barretenberg/cpp/src/barretenberg/vm/**
+              - barretenberg/cpp/src/barretenberg/**/generated/*
             non-docs:
               - '!(docs/**)'
             non-misc-ci:


### PR DESCRIPTION
AVM changes still should trigger e2e