### PR TITLE
chore: try to see if 128 cores helps e2e-prover at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
         timeout-minutes: 40
         uses: ./.github/ensure-tester-with-images
         with:
-          runner_type: ${{ contains(matrix.test, 'prover') && '64core-tester-x86' || '8core-tester-x86' }}
+          runner_type: ${{ contains(matrix.test, 'prover') && '128core-tester-x86' || '8core-tester-x86' }}
           builder_type: builder-x86
           # these are copied to the tester and expected by the earthly command below
           # if they fail to copy, it will try to build them on the tester and fail


### PR DESCRIPTION
It's not clear it would, but this time is getting long enough it's worth trying
