### PR TITLE
chore: fix compilation error due to missing import

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/constants.hpp
@@ -2,6 +2,7 @@
 
 #include "aztec_constants.hpp"
 
+#include <cstddef>
 #include <cstdint>
 
 // NOTE(MD): for now we will only include the public inputs that are included in call_context


### PR DESCRIPTION
Was missing this import somehow. Crashed local build on master.