### PR TITLE
chore: redo typo PR by dufucun

### DIFF
--- a/docs/docs/aztec/concepts/accounts/keys.md
+++ b/docs/docs/aztec/concepts/accounts/keys.md
@@ -91,7 +91,7 @@ Typically, `Npk_m` is stored in a note and later on, the note is nullified using
 Validity of `nsk_app` is verified by our [protocol kernel circuits](../../../protocol-specs/circuits/private-kernel-tail#verifying-and-splitting-ordered-data).
 
 ## Incoming viewing keys
-The app-siloed version of public key (denoted `Ivpk_app`) is used to encrypt a note for a recipient and the the corresponding secret key (`ivsk_app`) is used by recipient during decryption.
+The app-siloed version of public key (denoted `Ivpk_app`) is used to encrypt a note for a recipient and the corresponding secret key (`ivsk_app`) is used by recipient during decryption.
 
 ## Outgoing viewing keys
 App-siloed versions of outgoing viewing keys are denoted `ovsk_app` and `Ovpk_app`.

--- a/noir/noir-repo/tooling/debugger/src/context.rs
+++ b/noir/noir-repo/tooling/debugger/src/context.rs
@@ -296,7 +296,7 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> DebugContext<'a, B> {
                 self.handle_foreign_call(foreign_call)
             }
             Err(err) => DebugCommandResult::Error(NargoError::ExecutionError(
-                // TODO: debugger does not not handle multiple acir calls
+                // TODO: debugger does not handle multiple acir calls
                 ExecutionError::SolvingError(err, None),
             )),
         }
@@ -340,7 +340,7 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> DebugContext<'a, B> {
                 }
             }
             ACVMStatus::Failure(error) => DebugCommandResult::Error(NargoError::ExecutionError(
-                // TODO: debugger does not not handle multiple acir calls
+                // TODO: debugger does not handle multiple acir calls
                 ExecutionError::SolvingError(error, None),
             )),
             ACVMStatus::RequiresForeignCall(_) => {

--- a/scripts/redo-typo-pr
+++ b/scripts/redo-typo-pr
@@ -27,6 +27,6 @@ gh pr create --base master --head $NEW_BRANCH --title "chore: redo typo PR by $A
 
 # Step 5: Close the original PR
 echo "Closing original PR #$ORIGINAL_PR_NUMBER"
-gh pr close $ORIGINAL_PR_NUMBER --delete-branch
+gh pr close $ORIGINAL_PR_NUMBER
 
 echo "Script completed."


### PR DESCRIPTION
Thanks dufucun for https://github.com/AztecProtocol/aztec-packages/pull/6820. Our policy is to redo typo changes to dissuade metric farming. This is an automated script.