### PR TITLE
fix: release from CCI for 0.42.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -489,6 +489,7 @@ workflows:
       or:
         - equal: [ master, << pipeline.git.branch >> ]
         - matches: { pattern: ".*circle-ci.*", value: << pipeline.git.branch >> }
+        - matches: { pattern: ".*", value: << pipeline.git.tag >> }
     jobs:
       # Noir
       - noir-x86_64: *defaults

--- a/yarn-project/deploy_npm.sh
+++ b/yarn-project/deploy_npm.sh
@@ -94,15 +94,14 @@ deploy_package builder
 deploy_package noir-contracts.js
 deploy_package kv-store
 deploy_package merkle-tree
-deploy_package world-state
 deploy_package noir-protocol-circuits-types
+deploy_package world-state
 deploy_package simulator
 deploy_package bb-prover
 deploy_package key-store
 deploy_package pxe
 deploy_package archiver
 deploy_package p2p
-deploy_package world-state
 deploy_package prover-client
 deploy_package sequencer-client
 deploy_package aztec-node

--- a/yarn-project/deploy_npm.sh
+++ b/yarn-project/deploy_npm.sh
@@ -94,6 +94,7 @@ deploy_package builder
 deploy_package noir-contracts.js
 deploy_package kv-store
 deploy_package merkle-tree
+deploy_package world-state
 deploy_package noir-protocol-circuits-types
 deploy_package simulator
 deploy_package bb-prover
@@ -102,5 +103,6 @@ deploy_package pxe
 deploy_package archiver
 deploy_package p2p
 deploy_package world-state
+deploy_package prover-client
 deploy_package sequencer-client
 deploy_package aztec-node


### PR DESCRIPTION
This PR is intended to fix release issues for 0.42.0. GA Release should be introduced before 0.43.0
- Release prover-client & world-state packages
- Trigger CCI at new tags