### PR TITLE
chore: Log aliases for contracts instances and classes on pxe

### DIFF
--- a/yarn-project/foundation/src/log/logger.ts
+++ b/yarn-project/foundation/src/log/logger.ts
@@ -66,6 +66,20 @@ export function onLog(handler: LogHandler) {
   logHandlers.push(handler);
 }
 
+/** Register an alias for a keyword, will get replaced from all logs. */
+export function setAlias(text: string, alias: string) {
+  aliases[text] = alias;
+}
+
+const aliases: Record<string, string> = {};
+
+function replaceAliases(input: string) {
+  for (const [text, alias] of Object.entries(aliases)) {
+    input = input.replaceAll(text, `${alias}(${text})`);
+  }
+  return input;
+}
+
 /**
  * Logs args to npm debug if enabled or log level is debug, console.error otherwise.
  * @param debug - Instance of npm debug.
@@ -77,7 +91,9 @@ function logWithDebug(debug: debug.Debugger, level: LogLevel, msg: string, data?
     handler(level, debug.namespace, msg, data);
   }
 
+  msg = replaceAliases(msg);
   msg = data ? `${msg} ${fmtLogData(data)}` : msg;
+
   if (debug.enabled) {
     if (level !== 'debug') {
       msg = `${level.toUpperCase()} ${msg}`;

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -33,7 +33,7 @@ import { computeNoteHashNonce, siloNullifier } from '@aztec/circuits.js/hash';
 import { type ContractArtifact, type DecodedReturn, FunctionSelector, encodeArguments } from '@aztec/foundation/abi';
 import { type Fq, Fr } from '@aztec/foundation/fields';
 import { SerialQueue } from '@aztec/foundation/fifo';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type DebugLogger, createDebugLogger, setAlias } from '@aztec/foundation/log';
 import { type KeyStore } from '@aztec/key-store';
 import {
   type AcirSimulator,
@@ -237,6 +237,7 @@ export class PXEService implements PXE {
     const contractClassId = computeContractClassId(getContractClassFromArtifact(artifact));
     await this.db.addContractArtifact(contractClassId, artifact);
     this.log.info(`Added contract class ${artifact.name} with id ${contractClassId}`);
+    setAlias(contractClassId.toString(), `${artifact.name}Class`);
   }
 
   public async registerContract(contract: { instance: ContractInstanceWithAddress; artifact?: ContractArtifact }) {
@@ -252,6 +253,7 @@ export class PXEService implements PXE {
         );
       }
       await this.db.addContractArtifact(contractClassId, artifact);
+      setAlias(contractClassId.toString(), `${artifact.name}Class`);
     } else {
       // Otherwise, make sure there is an artifact already registered for that class id
       artifact = await this.db.getContractArtifact(instance.contractClassId);
@@ -263,6 +265,7 @@ export class PXEService implements PXE {
     }
 
     this.log.info(`Added contract ${artifact.name} at ${instance.address.toString()}`);
+    setAlias(instance.address.toString(), `${artifact.name}Instance`);
     await this.db.addContractInstance(instance);
     await this.synchronizer.reprocessDeferredNotesForContract(instance.address);
   }


### PR DESCRIPTION
Allows registering aliases for strings in the logger which get replaced on print. We use them in the pxe for aliasing contracts instances and classes to include the artifact name to make it easier to spot them.

```
note_processor Added note for contract SchnorrAccountInstance(0x1afd7788120bc4cf09ec5e947e325e0ff41f16cff2b9b6f1544341cf13d0f1e4) at slot 0x0000000000000000000000000000000000000000000000000000000000000001 with nullifier 0x1ca1afd8b27bff04f9f1ff5df72f7e62779cdf2874d5ae7959eeebeb6e0df3a5
```