### PR TITLE
feat: track timeout status of proving jobs

### DIFF
--- a/yarn-project/circuit-types/src/interfaces/prover-client.ts
+++ b/yarn-project/circuit-types/src/interfaces/prover-client.ts
@@ -18,6 +18,10 @@ export type ProverConfig = {
   proverAgentPollInterval: number;
   /** The maximum number of proving jobs to be run in parallel */
   proverAgentConcurrency: number;
+  /** Jobs are retried if not kept alive for this long */
+  proverJobTimeoutMs: number;
+  /** The interval to check job health status */
+  proverJobPollIntervalMs: number;
 };
 
 /**

--- a/yarn-project/circuit-types/src/interfaces/proving-job.ts
+++ b/yarn-project/circuit-types/src/interfaces/proving-job.ts
@@ -124,6 +124,8 @@ export type ProvingRequestResult<T extends ProvingRequestType> = ProvingRequestP
 export interface ProvingJobSource {
   getProvingJob(): Promise<ProvingJob<ProvingRequest> | undefined>;
 
+  heartbeat(jobId: string): Promise<void>;
+
   resolveProvingJob<T extends ProvingRequestType>(jobId: string, result: ProvingRequestResult<T>): Promise<void>;
 
   rejectProvingJob(jobId: string, reason: Error): Promise<void>;

--- a/yarn-project/circuit-types/src/interfaces/proving-job.ts
+++ b/yarn-project/circuit-types/src/interfaces/proving-job.ts
@@ -122,11 +122,30 @@ export type ProvingRequestPublicInputs = {
 export type ProvingRequestResult<T extends ProvingRequestType> = ProvingRequestPublicInputs[T];
 
 export interface ProvingJobSource {
+  /**
+   * Gets the next proving job. `heartbeat` must be called periodically to keep the job alive.
+   * @returns The proving job, or undefined if there are no jobs available.
+   */
   getProvingJob(): Promise<ProvingJob<ProvingRequest> | undefined>;
 
+  /**
+   * Keeps the job alive. If this isn't called regularly then the job will be
+   * considered abandoned and re-queued for another consumer to pick up
+   * @param jobId The ID of the job to heartbeat.
+   */
   heartbeat(jobId: string): Promise<void>;
 
+  /**
+   * Resolves a proving job.
+   * @param jobId - The ID of the job to resolve.
+   * @param result - The result of the proving job.
+   */
   resolveProvingJob<T extends ProvingRequestType>(jobId: string, result: ProvingRequestResult<T>): Promise<void>;
 
+  /**
+   * Rejects a proving job.
+   * @param jobId - The ID of the job to reject.
+   * @param reason - The reason for rejecting the job.
+   */
   rejectProvingJob(jobId: string, reason: Error): Promise<void>;
 }

--- a/yarn-project/foundation/src/error/index.ts
+++ b/yarn-project/foundation/src/error/index.ts
@@ -13,4 +13,4 @@ export class TimeoutError extends Error {}
 /**
  * Represents an error thrown when an operation is aborted.
  */
-export class AbortedError extends Error {}
+export class AbortError extends Error {}

--- a/yarn-project/foundation/src/promise/running-promise.ts
+++ b/yarn-project/foundation/src/promise/running-promise.ts
@@ -10,7 +10,7 @@ export class RunningPromise {
   private runningPromise = Promise.resolve();
   private interruptibleSleep = new InterruptibleSleep();
 
-  constructor(private fn: () => Promise<void>, private pollingIntervalMS = 10000) {}
+  constructor(private fn: () => void | Promise<void>, private pollingIntervalMS = 10000) {}
 
   /**
    * Starts the running promise.

--- a/yarn-project/prover-client/src/config.ts
+++ b/yarn-project/prover-client/src/config.ts
@@ -35,7 +35,7 @@ export function getProverEnvVars(): ProverClientConfig {
     PROVER_AGENT_POLL_INTERVAL_MS = '100',
     PROVER_REAL_PROOFS = '',
     PROVER_JOB_TIMEOUT_MS = '60000',
-    PROVER_JOB_POLL_INTERVAL_MS = '100',
+    PROVER_JOB_POLL_INTERVAL_MS = '1000',
   } = process.env;
 
   const realProofs = ['1', 'true'].includes(PROVER_REAL_PROOFS);
@@ -43,7 +43,7 @@ export function getProverEnvVars(): ProverClientConfig {
   const proverAgentConcurrency = safeParseNumber(PROVER_AGENT_CONCURRENCY, 1);
   const proverAgentPollInterval = safeParseNumber(PROVER_AGENT_POLL_INTERVAL_MS, 100);
   const proverJobTimeoutMs = safeParseNumber(PROVER_JOB_TIMEOUT_MS, 60000);
-  const proverJobPollIntervalMs = safeParseNumber(PROVER_JOB_POLL_INTERVAL_MS, 100);
+  const proverJobPollIntervalMs = safeParseNumber(PROVER_JOB_POLL_INTERVAL_MS, 1000);
 
   return {
     acvmWorkingDirectory: ACVM_WORKING_DIRECTORY,

--- a/yarn-project/prover-client/src/config.ts
+++ b/yarn-project/prover-client/src/config.ts
@@ -34,16 +34,16 @@ export function getProverEnvVars(): ProverClientConfig {
     PROVER_AGENT_CONCURRENCY = PROVER_AGENTS,
     PROVER_AGENT_POLL_INTERVAL_MS = '100',
     PROVER_REAL_PROOFS = '',
+    PROVER_JOB_TIMEOUT_MS = '60000',
+    PROVER_JOB_POLL_INTERVAL_MS = '100',
   } = process.env;
 
   const realProofs = ['1', 'true'].includes(PROVER_REAL_PROOFS);
   const proverAgentEnabled = ['1', 'true'].includes(PROVER_AGENT_ENABLED);
-  const parsedProverConcurrency = parseInt(PROVER_AGENT_CONCURRENCY, 10);
-  const proverAgentConcurrency = Number.isSafeInteger(parsedProverConcurrency) ? parsedProverConcurrency : 1;
-  const parsedProverAgentPollInterval = parseInt(PROVER_AGENT_POLL_INTERVAL_MS, 10);
-  const proverAgentPollInterval = Number.isSafeInteger(parsedProverAgentPollInterval)
-    ? parsedProverAgentPollInterval
-    : 100;
+  const proverAgentConcurrency = safeParseNumber(PROVER_AGENT_CONCURRENCY, 1);
+  const proverAgentPollInterval = safeParseNumber(PROVER_AGENT_POLL_INTERVAL_MS, 100);
+  const proverJobTimeoutMs = safeParseNumber(PROVER_JOB_TIMEOUT_MS, 60000);
+  const proverJobPollIntervalMs = safeParseNumber(PROVER_JOB_POLL_INTERVAL_MS, 100);
 
   return {
     acvmWorkingDirectory: ACVM_WORKING_DIRECTORY,
@@ -55,5 +55,12 @@ export function getProverEnvVars(): ProverClientConfig {
     proverAgentPollInterval,
     proverAgentConcurrency,
     nodeUrl: AZTEC_NODE_URL,
+    proverJobPollIntervalMs,
+    proverJobTimeoutMs,
   };
+}
+
+function safeParseNumber(value: string, defaultValue: number): number {
+  const parsedValue = parseInt(value, 10);
+  return Number.isSafeInteger(parsedValue) ? parsedValue : defaultValue;
 }

--- a/yarn-project/prover-client/src/mocks/test_context.ts
+++ b/yarn-project/prover-client/src/mocks/test_context.ts
@@ -127,6 +127,7 @@ export class TestContext {
     const orchestrator = new ProvingOrchestrator(actualDb, queue);
     const agent = new ProverAgent(localProver, proverCount);
 
+    queue.start();
     agent.start(queue);
 
     return new this(

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -48,7 +48,7 @@ import {
 } from '@aztec/circuits.js';
 import { makeTuple } from '@aztec/foundation/array';
 import { padArrayEnd } from '@aztec/foundation/collection';
-import { AbortedError } from '@aztec/foundation/error';
+import { AbortError } from '@aztec/foundation/error';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { BufferReader, type Tuple } from '@aztec/foundation/serialize';
@@ -475,7 +475,7 @@ export class ProvingOrchestrator {
 
         await callback(result);
       } catch (err) {
-        if (err instanceof AbortedError) {
+        if (err instanceof AbortError) {
           // operation was cancelled, probably because the block was cancelled
           // drop this result
           return;

--- a/yarn-project/prover-client/src/prover-agent/agent-queue-integration.test.ts
+++ b/yarn-project/prover-client/src/prover-agent/agent-queue-integration.test.ts
@@ -1,0 +1,99 @@
+import { type ServerCircuitProver } from '@aztec/circuit-types';
+import { RECURSIVE_PROOF_LENGTH, type RootParityInput } from '@aztec/circuits.js';
+import { makeBaseParityInputs, makeRootParityInput } from '@aztec/circuits.js/testing';
+import { AbortError } from '@aztec/foundation/error';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
+import { sleep } from '@aztec/foundation/sleep';
+
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+import { MemoryProvingQueue } from './memory-proving-queue.js';
+import { ProverAgent } from './prover-agent.js';
+
+describe('Prover agent <-> queue integration', () => {
+  let queue: MemoryProvingQueue;
+  let agent: ProverAgent;
+  let prover: MockProxy<ServerCircuitProver>;
+  let agentPollInterval: number;
+  let queuePollInterval: number;
+  let queueJobTimeout: number;
+
+  beforeEach(() => {
+    prover = mock<ServerCircuitProver>();
+
+    queueJobTimeout = 100;
+    queuePollInterval = 10;
+    queue = new MemoryProvingQueue(queueJobTimeout, queuePollInterval);
+
+    agentPollInterval = 10;
+    agent = new ProverAgent(prover, 1, agentPollInterval);
+
+    queue.start();
+    agent.start(queue);
+  });
+
+  afterEach(async () => {
+    await agent.stop();
+    await queue.stop();
+  });
+
+  it('picks up jobs from the queue', async () => {
+    const { promise, resolve } = promiseWithResolvers<RootParityInput<typeof RECURSIVE_PROOF_LENGTH>>();
+    const output = makeRootParityInput(RECURSIVE_PROOF_LENGTH, 1);
+    prover.getBaseParityProof.mockResolvedValueOnce(promise);
+    const proofPromise = queue.getBaseParityProof(makeBaseParityInputs());
+
+    await sleep(agentPollInterval);
+    resolve(output);
+    await expect(proofPromise).resolves.toEqual(output);
+  });
+
+  it('keeps job alive', async () => {
+    const { promise, resolve } = promiseWithResolvers<RootParityInput<typeof RECURSIVE_PROOF_LENGTH>>();
+    const output = makeRootParityInput(RECURSIVE_PROOF_LENGTH, 1);
+    prover.getBaseParityProof.mockResolvedValueOnce(promise);
+    const proofPromise = queue.getBaseParityProof(makeBaseParityInputs());
+
+    await sleep(2 * queueJobTimeout);
+    resolve(output);
+    await expect(proofPromise).resolves.toEqual(output);
+  });
+
+  it('reports cancellations', async () => {
+    const { promise, resolve } = promiseWithResolvers<RootParityInput<typeof RECURSIVE_PROOF_LENGTH>>();
+    const output = makeRootParityInput(RECURSIVE_PROOF_LENGTH, 1);
+    prover.getBaseParityProof.mockResolvedValueOnce(promise);
+    const controller = new AbortController();
+    const proofPromise = queue.getBaseParityProof(makeBaseParityInputs(), controller.signal);
+    await sleep(agentPollInterval);
+    controller.abort();
+    resolve(output);
+    await expect(proofPromise).rejects.toThrow(AbortError);
+  });
+
+  it('re-queues timed out jobs', async () => {
+    const firstRun = promiseWithResolvers<RootParityInput<typeof RECURSIVE_PROOF_LENGTH>>();
+    const output = makeRootParityInput(RECURSIVE_PROOF_LENGTH, 1);
+    prover.getBaseParityProof.mockResolvedValueOnce(firstRun.promise);
+    const proofPromise = queue.getBaseParityProof(makeBaseParityInputs());
+
+    // stop the agent to simulate a machine going down
+    await agent.stop();
+
+    // give the queue a chance to figure out the node is timed out and re-queue the job
+    await sleep(queueJobTimeout);
+    // reset the mock
+    const secondRun = promiseWithResolvers<RootParityInput<typeof RECURSIVE_PROOF_LENGTH>>();
+    prover.getBaseParityProof.mockResolvedValueOnce(secondRun.promise);
+    const newAgent = new ProverAgent(prover, 1, agentPollInterval);
+    newAgent.start(queue);
+    // test that the job is re-queued and kept alive by the new agent
+    await sleep(queueJobTimeout * 2);
+    secondRun.resolve(output);
+    await expect(proofPromise).resolves.toEqual(output);
+
+    firstRun.reject(new Error('stop this promise otherwise it hangs jest'));
+
+    await newAgent.stop();
+  });
+});

--- a/yarn-project/prover-client/src/prover-agent/memory-proving-queue.ts
+++ b/yarn-project/prover-client/src/prover-agent/memory-proving-queue.ts
@@ -27,21 +27,23 @@ import type {
   RootRollupPublicInputs,
 } from '@aztec/circuits.js';
 import { randomBytes } from '@aztec/foundation/crypto';
-import { AbortedError, TimeoutError } from '@aztec/foundation/error';
+import { AbortError, TimeoutError } from '@aztec/foundation/error';
 import { MemoryFifo } from '@aztec/foundation/fifo';
 import { createDebugLogger } from '@aztec/foundation/log';
-import { type PromiseWithResolvers, promiseWithResolvers } from '@aztec/foundation/promise';
+import { type PromiseWithResolvers, RunningPromise, promiseWithResolvers } from '@aztec/foundation/promise';
 
 type ProvingJobWithResolvers<T extends ProvingRequest = ProvingRequest> = {
   id: string;
   request: T;
   signal?: AbortSignal;
   attempts: number;
+  heartbeat: number;
 } & PromiseWithResolvers<ProvingRequestResult<T['type']>>;
 
 const MAX_RETRIES = 3;
 
 const defaultIdGenerator = () => randomBytes(4).toString('hex');
+const defaultTimeSource = () => Date.now();
 
 /**
  * A helper class that sits in between services that need proofs created and agents that can create them.
@@ -52,20 +54,55 @@ export class MemoryProvingQueue implements ServerCircuitProver, ProvingJobSource
   private queue = new MemoryFifo<ProvingJobWithResolvers>();
   private jobsInProgress = new Map<string, ProvingJobWithResolvers>();
 
-  constructor(private generateId = defaultIdGenerator) {}
+  private runningPromise: RunningPromise;
 
-  async getProvingJob({ timeoutSec = 1 } = {}): Promise<ProvingJob<ProvingRequest> | undefined> {
+  constructor(
+    /** Timeout the job if an agent doesn't report back in this time */
+    private jobTimeoutMs = 60 * 1000,
+    /** How often to check for timed out jobs */
+    pollingIntervalMs = 1000,
+    private generateId = defaultIdGenerator,
+    private timeSource = defaultTimeSource,
+  ) {
+    this.runningPromise = new RunningPromise(this.poll, pollingIntervalMs);
+  }
+
+  public start() {
+    if (this.runningPromise.isRunning()) {
+      this.log.warn('Proving queue is already running');
+      return;
+    }
+
+    this.runningPromise.start();
+    this.log.info('Proving queue started');
+  }
+
+  public async stop() {
+    if (!this.runningPromise.isRunning()) {
+      this.log.warn('Proving queue is already stopped');
+      return;
+    }
+
+    await this.runningPromise.stop();
+    this.log.info('Proving queue stopped');
+  }
+
+  public async getProvingJob({ timeoutSec = 1 } = {}): Promise<ProvingJob<ProvingRequest> | undefined> {
+    if (!this.runningPromise.isRunning()) {
+      throw new Error('Proving queue is not running. Start the queue before getting jobs.');
+    }
+
     try {
       const job = await this.queue.get(timeoutSec);
       if (!job) {
         return undefined;
       }
 
-      if (job.signal?.aborted) {
-        this.log.debug(`Job ${job.id} type=${job.request.type} has been aborted`);
+      if (this.rejectIfAborted(job)) {
         return undefined;
       }
 
+      job.heartbeat = this.timeSource();
       this.jobsInProgress.set(job.id, job);
       return {
         id: job.id,
@@ -81,30 +118,40 @@ export class MemoryProvingQueue implements ServerCircuitProver, ProvingJobSource
   }
 
   resolveProvingJob<T extends ProvingRequestType>(jobId: string, result: ProvingRequestResult<T>): Promise<void> {
-    const job = this.jobsInProgress.get(jobId);
-    if (!job) {
-      return Promise.reject(new Error('Job not found'));
+    if (!this.runningPromise.isRunning()) {
+      throw new Error('Proving queue is not running.');
     }
 
-    this.jobsInProgress.delete(jobId);
-
-    if (job.signal?.aborted) {
+    const job = this.jobsInProgress.get(jobId);
+    if (!job) {
+      this.log.warn(`Job id=${jobId} not found. Can't resolve`);
       return Promise.resolve();
     }
 
-    job.resolve(result);
-    return Promise.resolve();
+    this.jobsInProgress.delete(jobId);
+
+    if (this.rejectIfAborted(job)) {
+      return Promise.resolve();
+    } else {
+      job.resolve(result);
+      return Promise.resolve();
+    }
   }
 
   rejectProvingJob(jobId: string, err: any): Promise<void> {
+    if (!this.runningPromise.isRunning()) {
+      throw new Error('Proving queue is not running.');
+    }
+
     const job = this.jobsInProgress.get(jobId);
     if (!job) {
-      return Promise.reject(new Error('Job not found'));
+      this.log.warn(`Job id=${jobId} not found. Can't reject`);
+      return Promise.resolve();
     }
 
     this.jobsInProgress.delete(jobId);
 
-    if (job.signal?.aborted) {
+    if (this.rejectIfAborted(job)) {
       return Promise.resolve();
     }
 
@@ -123,10 +170,49 @@ export class MemoryProvingQueue implements ServerCircuitProver, ProvingJobSource
     return Promise.resolve();
   }
 
+  public heartbeat(jobId: string): Promise<void> {
+    if (!this.runningPromise.isRunning()) {
+      throw new Error('Proving queue is not running.');
+    }
+
+    const job = this.jobsInProgress.get(jobId);
+    if (job) {
+      job.heartbeat = this.timeSource();
+    }
+
+    return Promise.resolve();
+  }
+
+  public isJobRunning(jobId: string): boolean {
+    return this.jobsInProgress.has(jobId);
+  }
+
+  private poll = () => {
+    const now = this.timeSource();
+
+    for (const job of this.jobsInProgress.values()) {
+      if (this.rejectIfAborted(job)) {
+        continue;
+      }
+
+      if (job.heartbeat + this.jobTimeoutMs < now) {
+        this.log.warn(`Job ${job.id} type=${ProvingRequestType[job.request.type]} has timed out`);
+
+        this.jobsInProgress.delete(job.id);
+        job.heartbeat = 0;
+        this.queue.put(job);
+      }
+    }
+  };
+
   private enqueue<T extends ProvingRequest>(
     request: T,
     signal?: AbortSignal,
   ): Promise<ProvingRequestResult<T['type']>> {
+    if (!this.runningPromise.isRunning()) {
+      return Promise.reject(new Error('Proving queue is not running.'));
+    }
+
     const { promise, resolve, reject } = promiseWithResolvers<ProvingRequestResult<T['type']>>();
     const item: ProvingJobWithResolvers<T> = {
       id: this.generateId(),
@@ -136,10 +222,11 @@ export class MemoryProvingQueue implements ServerCircuitProver, ProvingJobSource
       resolve,
       reject,
       attempts: 1,
+      heartbeat: 0,
     };
 
     if (signal) {
-      signal.addEventListener('abort', () => reject(new AbortedError('Operation has been aborted')));
+      signal.addEventListener('abort', () => reject(new AbortError('Operation has been aborted')));
     }
 
     this.log.debug(
@@ -299,5 +386,15 @@ export class MemoryProvingQueue implements ServerCircuitProver, ProvingJobSource
    */
   verifyProof(): Promise<void> {
     return Promise.reject('not implemented');
+  }
+
+  private rejectIfAborted(job: ProvingJobWithResolvers): boolean {
+    if (job.signal?.aborted) {
+      this.log.debug(`Job ${job.id} type=${ProvingRequestType[job.request.type]} has been aborted`);
+      job.reject(new AbortError('Proving job has been aborted'));
+      return true;
+    }
+
+    return false;
   }
 }

--- a/yarn-project/prover-client/src/prover-agent/prover-agent.test.ts
+++ b/yarn-project/prover-client/src/prover-agent/prover-agent.test.ts
@@ -24,11 +24,13 @@ describe('ProverAgent', () => {
   });
 
   beforeEach(() => {
+    queue.start();
     agent.start(queue);
   });
 
   afterEach(async () => {
     await agent.stop();
+    await queue.stop();
   });
 
   it('takes jobs from the queue', async () => {


### PR DESCRIPTION
This PR modifies the proving queue to expect regular heartbeats from its consumers. If a job becomes stale because the agent processing it goes away then it will get re-queued and ready to be picked up by another agent.
