### PR TITLE
fix(docs): Remove prefix in link to code snippet source

### DIFF
--- a/docs/src/preprocess/include_code.js
+++ b/docs/src/preprocess/include_code.js
@@ -257,7 +257,7 @@ async function preprocessIncludeCode(markdownContent, filePath, rootDir) {
         .replace(/^\//, "");
       const urlText = `${relativeCodeFilePath}#L${startLine}-L${endLine}`;
       const tag = process.env.COMMIT_TAG
-        ? `aztec-packages-v${process.env.COMMIT_TAG}`
+        ? `${process.env.COMMIT_TAG}`
         : "master";
       const url = `https://github.com/AztecProtocol/aztec-packages/blob/${tag}/${urlText}`;
 


### PR DESCRIPTION
The COMMIT_TAG being passed into `process.env` via earthly has change to include `aztec-packges-v`, so removing it from the include_code macro