### PR TITLE
feat: Standard form for cycle_group

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
@@ -181,7 +181,16 @@ template <typename Builder> void cycle_group<Builder>::validate_is_on_curve() co
     res *= !is_point_at_infinity();
     res.assert_is_zero();
 }
-
+/**
+ * @brief  Get point in standard form. If the point is a point at infinity, ensure the coordinates are (0,0)
+ *
+ */
+template <typename Builder> cycle_group<Builder> cycle_group<Builder>::get_standard_form() const
+{
+    return cycle_group(field_t::conditional_assign(_is_infinity, 0, x),
+                       field_t::conditional_assign(_is_infinity, 0, y),
+                       is_point_at_infinity());
+}
 /**
  * @brief Evaluates a doubling. Does not use Ultra double gate
  *

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
@@ -184,6 +184,7 @@ template <typename Builder> class cycle_group {
     [[nodiscard]] bool is_constant() const { return _is_constant; }
     bool_t is_point_at_infinity() const { return _is_infinity; }
     void set_point_at_infinity(const bool_t& is_infinity) { _is_infinity = is_infinity; }
+    cycle_group get_standard_form() const;
     void validate_is_on_curve() const;
     cycle_group dbl() const
         requires IsUltraArithmetic<Builder>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
@@ -105,6 +105,36 @@ TYPED_TEST(CycleGroupTest, TestValidateOnCurveFail)
     EXPECT_FALSE(CircuitChecker::check(builder));
 }
 
+TYPED_TEST(CycleGroupTest, TestStandardForm)
+{
+    STDLIB_TYPE_ALIASES;
+    auto builder = Builder();
+
+    size_t num_repetitions = 5;
+    for (size_t i = 0; i < num_repetitions; ++i) {
+        cycle_group_ct input_a(Element::random_element());
+        cycle_group_ct input_b(Element::random_element());
+        input_b.set_point_at_infinity(true);
+        auto standard_a = input_a.get_standard_form();
+        auto standard_b = input_b.get_standard_form();
+        EXPECT_EQ(standard_a.is_point_at_infinity().get_value(), false);
+        EXPECT_EQ(standard_b.is_point_at_infinity().get_value(), true);
+        auto input_a_x = input_a.x.get_value();
+        auto input_a_y = input_a.y.get_value();
+
+        auto standard_a_x = standard_a.x.get_value();
+        auto standard_a_y = standard_a.y.get_value();
+
+        auto standard_b_x = standard_b.x.get_value();
+        auto standard_b_y = standard_b.y.get_value();
+
+        EXPECT_EQ(input_a_x, standard_a_x);
+        EXPECT_EQ(input_a_y, standard_a_y);
+        EXPECT_EQ(standard_b_x, 0);
+        EXPECT_EQ(standard_b_y, 0);
+    }
+    EXPECT_TRUE(CircuitChecker::check(builder));
+}
 TYPED_TEST(CycleGroupTest, TestDbl)
 {
     STDLIB_TYPE_ALIASES;


### PR DESCRIPTION
Create an implementation of get_standard_form function for cycle group. The point is to ensure that the point at infinity has (0,0) coordinates
