### PR TITLE
fix: Fix for the flaky issue (I hope)

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1943,8 +1943,9 @@ template <typename Builder, typename T> void bigfield<Builder, T>::assert_equal(
             const uint512_t modulus(target_basis.modulus);
 
             const auto [quotient_512, remainder_512] = (diff_val).divmod(modulus);
-            if (remainder_512 != 0)
+            if (remainder_512 != 0) {
                 std::cerr << "bigfield: remainder not zero!" << std::endl;
+            }
             ASSERT(remainder_512 == 0);
             bigfield quotient;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_edgecase_handling.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_edgecase_handling.hpp
@@ -56,7 +56,7 @@ std::pair<std::vector<element<C, Fq, Fr, G>>, std::vector<Fr>> element<C, Fq, Fr
     // Add a scalar -(<(1,2,4,...,2ⁿ⁻¹ ),(scalar₀,...,scalarₙ₋₁)> / 2ⁿ)
     scalars.push_back(-last_scalar);
     if constexpr (Fr::is_composite) {
-        scalars[scalars.size() - 1].self_reduce();
+        scalars.back().self_reduce();
     }
     // Add in-circuit G_offset to points
     points.push_back(element(native_offset_generator * generator_coefficient));

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_edgecase_handling.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_edgecase_handling.hpp
@@ -55,6 +55,9 @@ std::pair<std::vector<element<C, Fq, Fr, G>>, std::vector<Fr>> element<C, Fq, Fr
 
     // Add a scalar -(<(1,2,4,...,2ⁿ⁻¹ ),(scalar₀,...,scalarₙ₋₁)> / 2ⁿ)
     scalars.push_back(-last_scalar);
+    if constexpr (Fr::is_composite) {
+        scalars[scalars.size() - 1].self_reduce();
+    }
     // Add in-circuit G_offset to points
     points.push_back(element(native_offset_generator * generator_coefficient));
 
@@ -91,8 +94,8 @@ std::pair<std::vector<element<C, Fq, Fr, G>>, std::vector<Fr>> element<C, Fq, Fr
 
         points.push_back(point);
         scalars.push_back(scalar);
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1002): if both point and scalar are constant, don't
-        // bother adding constraints
+        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1002): if both point and scalar are constant,
+        // don't bother adding constraints
     }
 
     return { points, scalars };


### PR DESCRIPTION
There was a flaky assert_equal problem in bigfield in biggroup batch mul with masking (not in the code we actually use, just for tests). Reducing the scalar helped get rid of the problem (I ran the test in a loop and it didn't appear).