### PR TITLE
chore: fix issue #6929 (off-by-one error in `UltraCircuitBuilder::create_range_constraint`)

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -470,7 +470,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization_
                 .q_o = 0,
                 .q_c = 0,
             });
-            create_new_range_constraint(variable_index, 1ULL << num_bits, msg);
+            create_new_range_constraint(variable_index, (1ULL << num_bits) - 1, msg);
         } else {
             decompose_into_default_range(variable_index, num_bits, DEFAULT_PLOOKUP_RANGE_BITNUM, msg);
         }


### PR DESCRIPTION
Fix small bug that creates innaccurate range constraints for small scalar values in UltraCircuitBuilder