### PR TITLE
chore(avm): add tag checking and missing indirects

### DIFF
--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -435,7 +435,7 @@ fn handle_emit_unencrypted_log(
     destinations: &Vec<ValueOrArray>,
     inputs: &Vec<ValueOrArray>,
 ) {
-    if !destinations.is_empty() || inputs.len() != 2 {
+    if !destinations.is_empty() || inputs.len() != 3 {
         panic!(
             "Transpiler expects ForeignCall::EMITUNENCRYPTEDLOG to have 0 destinations and 3 inputs, got {} and {}",
             destinations.len(),
@@ -449,23 +449,20 @@ fn handle_emit_unencrypted_log(
             inputs[0]
         ),
     };
-    let (message_offset, message_size, message_offset_indirect) = match &inputs[1] {
-        ValueOrArray::HeapArray(array) => {
-            // Heap array, so offset to array is an indirect memory offset
-            (array.pointer.to_usize() as u32, array.size as u32, true)
-        }
-        ValueOrArray::MemoryAddress(single_val) => (single_val.to_usize() as u32, 1, false),
+    // The fields are a slice, and this is represented as a (length: Field, slice: HeapVector).
+    // The length field is redundant and we skipt it.
+    let (message_offset, message_size_offset) = match &inputs[2] {
+        ValueOrArray::HeapVector(vec) => (vec.pointer.to_usize() as u32, vec.size.0 as u32),
         _ => panic!("Unexpected inputs for ForeignCall::EMITUNENCRYPTEDLOG: {:?}", inputs),
     };
-    let indirect_flag = if message_offset_indirect { FIRST_OPERAND_INDIRECT } else { 0 };
     avm_instrs.push(AvmInstruction {
         opcode: AvmOpcode::EMITUNENCRYPTEDLOG,
         // The message array from Brillig is indirect.
-        indirect: Some(indirect_flag),
+        indirect: Some(FIRST_OPERAND_INDIRECT),
         operands: vec![
             AvmOperand::U32 { value: event_offset },
             AvmOperand::U32 { value: message_offset },
-            AvmOperand::U32 { value: message_size },
+            AvmOperand::U32 { value: message_size_offset },
         ],
         ..Default::default()
     });
@@ -971,7 +968,7 @@ fn handle_storage_read(
 
     avm_instrs.push(AvmInstruction {
         opcode: AvmOpcode::SLOAD,
-        indirect: Some(SECOND_OPERAND_INDIRECT),
+        indirect: Some(FIRST_OPERAND_INDIRECT),
         operands: vec![
             AvmOperand::U32 { value: slot_offset as u32 },
             AvmOperand::U32 { value: src_size as u32 },

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -1,6 +1,6 @@
 use crate::hash::{compute_secret_hash, compute_message_hash, compute_message_nullifier};
 use dep::protocol_types::address::{AztecAddress, EthAddress};
-use dep::protocol_types::traits::{Deserialize, Empty};
+use dep::protocol_types::traits::{Serialize, Deserialize, Empty};
 use dep::protocol_types::abis::function_selector::FunctionSelector;
 use crate::context::inputs::public_context_inputs::PublicContextInputs;
 use crate::context::gas::GasOpts;
@@ -28,11 +28,17 @@ impl PublicContext {
     *
     * @param event_selector The event selector for the log.
     * @param message The message to emit in the log.
-    * Should be automatically convertible to [Field; N]. For example str<N> works with
-    * one char per field. Otherwise you can use CompressedString.
     */
-    pub fn emit_unencrypted_log_with_selector<T>(&mut self, event_selector: Field, log: T) {
-        emit_unencrypted_log(event_selector, log);
+    pub fn emit_unencrypted_log_with_selector<T,N>(
+        &mut self,
+        event_selector: Field,
+        log: T
+    ) where T: Serialize<N> {
+        emit_unencrypted_log(event_selector, Serialize::serialize(log).as_slice());
+    }
+    // For compatibility with the selector-less API. We'll probably rename the above one.
+    pub fn emit_unencrypted_log<T,N>(&mut self, log: T) where T: Serialize<N> {
+        self.emit_unencrypted_log_with_selector(/*event_selector=*/ 5, log);
     }
     pub fn note_hash_exists(self, note_hash: Field, leaf_index: Field) -> bool {
         note_hash_exists(note_hash, leaf_index) == 1
@@ -55,11 +61,6 @@ impl PublicContext {
 
     fn nullifier_exists(self, unsiloed_nullifier: Field, address: AztecAddress) -> bool {
         nullifier_exists(unsiloed_nullifier, address.to_field()) == 1
-    }
-
-    fn emit_unencrypted_log<T, N, M>(&mut self, log: T) {
-        let event_selector = 5; // Matches current PublicContext.
-        self.emit_unencrypted_log_with_selector(event_selector, log);
     }
 
     fn consume_l1_to_l2_message(
@@ -234,7 +235,7 @@ unconstrained fn nullifier_exists(nullifier: Field, address: Field) -> u8 {
 unconstrained fn emit_nullifier(nullifier: Field) {
     emit_nullifier_opcode(nullifier)
 }
-unconstrained fn emit_unencrypted_log<T>(event_selector: Field, message: T) {
+unconstrained fn emit_unencrypted_log(event_selector: Field, message: [Field]) {
     emit_unencrypted_log_opcode(event_selector, message)
 }
 unconstrained fn l1_to_l2_msg_exists(msg_hash: Field, msg_leaf_index: Field) -> u8 {
@@ -319,7 +320,7 @@ fn nullifier_exists_opcode(nullifier: Field, address: Field) -> u8 {}
 fn emit_nullifier_opcode(nullifier: Field) {}
 
 #[oracle(amvOpcodeEmitUnencryptedLog)]
-fn emit_unencrypted_log_opcode<T>(event_selector: Field, message: T) {}
+fn emit_unencrypted_log_opcode(event_selector: Field, message: [Field]) {}
 
 #[oracle(avmOpcodeL1ToL2MsgExists)]
 fn l1_to_l2_msg_exists_opcode(msg_hash: Field, msg_leaf_index: Field) -> u8 {}

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -300,10 +300,10 @@ contract AvmTest {
 
     #[aztec(public)]
     fn emit_unencrypted_log() {
-        context.emit_unencrypted_log_with_selector(/*event_selector=*/ 5, /*message=*/ [10, 20, 30]);
-        context.emit_unencrypted_log_with_selector(/*event_selector=*/ 8, /*message=*/ "Hello, world!");
+        context.emit_unencrypted_log(/*message=*/ [10, 20, 30]);
+        context.emit_unencrypted_log(/*message=*/ "Hello, world!");
         let s: CompressedString<2,44> = CompressedString::from_string("A long time ago, in a galaxy far far away...");
-        context.emit_unencrypted_log_with_selector(/*event_selector=*/ 10, /*message=*/ s);
+        context.emit_unencrypted_log(/*message=*/ s);
     }
 
     #[aztec(public)]

--- a/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
@@ -32,7 +32,6 @@ contract StaticChild {
     fn pub_set_value(new_value: Field) -> Field {
         storage.current_value.write(new_value);
         context.emit_unencrypted_log(new_value);
-
         new_value
     }
 
@@ -86,7 +85,6 @@ contract StaticChild {
         let old_value = storage.current_value.read();
         storage.current_value.write(old_value + new_value);
         context.emit_unencrypted_log(new_value);
-
         new_value
     }
 
@@ -97,7 +95,6 @@ contract StaticChild {
         let old_value = storage.current_value.read();
         storage.current_value.write(old_value + new_value);
         context.emit_unencrypted_log(new_value);
-
         new_value
     }
 }

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -343,11 +343,12 @@ contract Test {
     // docs:end:is-time-equal
 
     #[aztec(public)]
-    fn emit_unencrypted(value: Field) -> Field {
+    fn emit_unencrypted(value: Field) {
         // docs:start:emit_unencrypted
-        context.emit_unencrypted_log(value);
+        context.emit_unencrypted_log(/*message=*/ value);
+        context.emit_unencrypted_log(/*message=*/ [10, 20, 30]);
+        context.emit_unencrypted_log(/*message=*/ "Hello, world!");
         // docs:end:emit_unencrypted
-        0
     }
 
     #[aztec(public)]

--- a/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
@@ -90,6 +90,11 @@ trait Serialize<N> {
 }
 // docs:end:serialize
 
+impl<N> Serialize<N> for [Field; N] {
+    fn serialize(self) -> [Field; N] {
+        self
+    }
+}
 impl<N> Serialize<N> for str<N> {
     fn serialize(self) -> [Field; N] {
         let mut result = [0; N];

--- a/yarn-project/simulator/src/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.test.ts
@@ -347,10 +347,10 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         ),
         new UnencryptedL2Log(
           context.environment.address,
-          new EventSelector(8),
+          new EventSelector(5),
           Buffer.concat(expectedString.map(f => f.toBuffer())),
         ),
-        new UnencryptedL2Log(context.environment.address, new EventSelector(10), expectedCompressedString),
+        new UnencryptedL2Log(context.environment.address, new EventSelector(5), expectedCompressedString),
       ]);
     });
 

--- a/yarn-project/simulator/src/avm/opcodes/arithmetic.ts
+++ b/yarn-project/simulator/src/avm/opcodes/arithmetic.ts
@@ -1,6 +1,7 @@
 import type { AvmContext } from '../avm_context.js';
 import { type Field, type MemoryValue, TypeTag } from '../avm_memory_types.js';
 import { Opcode, OperandType } from '../serialization/instruction_serialization.js';
+import { Addressing } from './addressing_mode.js';
 import { Instruction } from './instruction.js';
 import { ThreeOperandInstruction } from './instruction_impl.js';
 
@@ -10,13 +11,17 @@ export abstract class ThreeOperandArithmeticInstruction extends ThreeOperandInst
     const memory = context.machineState.memory.track(this.type);
     context.machineState.consumeGas(this.gasCost(memoryOperations));
 
-    memory.checkTags(this.inTag, this.aOffset, this.bOffset);
+    const [aOffset, bOffset, dstOffset] = Addressing.fromWire(this.indirect).resolve(
+      [this.aOffset, this.bOffset, this.dstOffset],
+      memory,
+    );
+    memory.checkTags(this.inTag, aOffset, bOffset);
 
-    const a = memory.get(this.aOffset);
-    const b = memory.get(this.bOffset);
+    const a = memory.get(aOffset);
+    const b = memory.get(bOffset);
 
     const dest = this.compute(a, b);
-    memory.set(this.dstOffset, dest);
+    memory.set(dstOffset, dest);
 
     memory.assert(memoryOperations);
     context.machineState.incrementPc();
@@ -83,13 +88,17 @@ export class FieldDiv extends Instruction {
     const memory = context.machineState.memory.track(this.type);
     context.machineState.consumeGas(this.gasCost(memoryOperations));
 
-    memory.checkTags(TypeTag.FIELD, this.aOffset, this.bOffset);
+    const [aOffset, bOffset, dstOffset] = Addressing.fromWire(this.indirect).resolve(
+      [this.aOffset, this.bOffset, this.dstOffset],
+      memory,
+    );
+    memory.checkTags(TypeTag.FIELD, aOffset, bOffset);
 
-    const a = memory.getAs<Field>(this.aOffset);
-    const b = memory.getAs<Field>(this.bOffset);
+    const a = memory.getAs<Field>(aOffset);
+    const b = memory.getAs<Field>(bOffset);
 
     const dest = a.fdiv(b);
-    memory.set(this.dstOffset, dest);
+    memory.set(dstOffset, dest);
 
     memory.assert(memoryOperations);
     context.machineState.incrementPc();

--- a/yarn-project/simulator/src/avm/opcodes/contract.ts
+++ b/yarn-project/simulator/src/avm/opcodes/contract.ts
@@ -1,7 +1,7 @@
 import { AztecAddress, Fr } from '@aztec/circuits.js';
 
 import type { AvmContext } from '../avm_context.js';
-import { Field } from '../avm_memory_types.js';
+import { Field, TypeTag } from '../avm_memory_types.js';
 import { Opcode, OperandType } from '../serialization/instruction_serialization.js';
 import { Addressing } from './addressing_mode.js';
 import { Instruction } from './instruction.js';
@@ -22,12 +22,17 @@ export class GetContractInstance extends Instruction {
   }
 
   async execute(context: AvmContext): Promise<void> {
+    const memoryOperations = { reads: 1, writes: 6, indirect: this.indirect };
+    const memory = context.machineState.memory.track(this.type);
+    context.machineState.consumeGas(this.gasCost(memoryOperations));
+
     const [addressOffset, dstOffset] = Addressing.fromWire(this.indirect).resolve(
       [this.addressOffset, this.dstOffset],
-      context.machineState.memory,
+      memory,
     );
+    memory.checkTag(TypeTag.FIELD, addressOffset);
 
-    const address = AztecAddress.fromField(context.machineState.memory.get(addressOffset).toFr());
+    const address = AztecAddress.fromField(memory.get(addressOffset).toFr());
     const instance = await context.persistableState.hostStorage.contractsDb.getContractInstance(address);
 
     const data =
@@ -49,8 +54,9 @@ export class GetContractInstance extends Instruction {
             instance.publicKeysHash,
           ].map(f => new Field(f));
 
-    context.machineState.memory.setSlice(dstOffset, data);
+    memory.setSlice(dstOffset, data);
 
+    memory.assert(memoryOperations);
     context.machineState.incrementPc();
   }
 }

--- a/yarn-project/simulator/src/avm/opcodes/control_flow.ts
+++ b/yarn-project/simulator/src/avm/opcodes/control_flow.ts
@@ -2,6 +2,7 @@ import type { AvmContext } from '../avm_context.js';
 import { type IntegralValue } from '../avm_memory_types.js';
 import { InstructionExecutionError } from '../errors.js';
 import { Opcode, OperandType } from '../serialization/instruction_serialization.js';
+import { Addressing } from './addressing_mode.js';
 import { Instruction } from './instruction.js';
 
 export class Jump extends Instruction {
@@ -44,7 +45,8 @@ export class JumpI extends Instruction {
     const memory = context.machineState.memory.track(this.type);
     context.machineState.consumeGas(this.gasCost(memoryOperations));
 
-    const condition = memory.getAs<IntegralValue>(this.condOffset);
+    const [condOffset] = Addressing.fromWire(this.indirect).resolve([this.condOffset], memory);
+    const condition = memory.getAs<IntegralValue>(condOffset);
 
     // TODO: reconsider this casting
     if (condition.toBigInt() == 0n) {

--- a/yarn-project/simulator/src/avm/opcodes/external_calls.ts
+++ b/yarn-project/simulator/src/avm/opcodes/external_calls.ts
@@ -4,7 +4,7 @@ import { padArrayEnd } from '@aztec/foundation/collection';
 import { convertAvmResultsToPxResult, createPublicExecution } from '../../public/transitional_adaptors.js';
 import type { AvmContext } from '../avm_context.js';
 import { gasLeftToGas } from '../avm_gas.js';
-import { Field, Uint8 } from '../avm_memory_types.js';
+import { Field, TypeTag, Uint8 } from '../avm_memory_types.js';
 import { type AvmContractCallResults } from '../avm_message_call_result.js';
 import { AvmSimulator } from '../avm_simulator.js';
 import { RethrownError } from '../errors.js';
@@ -53,9 +53,16 @@ abstract class ExternalCall extends Instruction {
       [this.gasOffset, this.addrOffset, this.argsOffset, this.argsSizeOffset, this.retOffset, this.successOffset],
       memory,
     );
+    memory.checkTags(TypeTag.FIELD, gasOffset, gasOffset + 1);
+    memory.checkTag(TypeTag.FIELD, addrOffset);
+    // TODO: Enable when Noir uses UINT32
+    // memory.checkTag(TypeTag.UINT32, argsSizeOffset);
+    memory.checkTag(TypeTag.FIELD, this.functionSelectorOffset);
+
+    const calldataSize = memory.get(argsSizeOffset).toNumber();
+    memory.checkTagsRange(TypeTag.FIELD, argsOffset, calldataSize);
 
     const callAddress = memory.getAs<Field>(addrOffset);
-    const calldataSize = memory.get(argsSizeOffset).toNumber();
     const calldata = memory.getSlice(argsOffset, calldataSize).map(f => f.toFr());
     const functionSelector = memory.getAs<Field>(this.functionSelectorOffset).toFr();
     // If we are already in a static call, we propagate the environment.

--- a/yarn-project/simulator/src/avm/opcodes/instruction_impl.ts
+++ b/yarn-project/simulator/src/avm/opcodes/instruction_impl.ts
@@ -1,6 +1,7 @@
 import { type AvmContext } from '../avm_context.js';
 import { type MemoryValue } from '../avm_memory_types.js';
 import { OperandType } from '../serialization/instruction_serialization.js';
+import { Addressing } from './addressing_mode.js';
 import { Instruction } from './instruction.js';
 
 /** Wire format that informs deserialization for instructions with two operands. */
@@ -72,7 +73,9 @@ export abstract class GetterInstruction extends Instruction {
     const memory = context.machineState.memory.track(this.type);
     context.machineState.consumeGas(this.gasCost(memoryOperations));
 
-    memory.set(this.dstOffset, this.getValue(context));
+    const [dstOffset] = Addressing.fromWire(this.indirect).resolve([this.dstOffset], memory);
+
+    memory.set(dstOffset, this.getValue(context));
 
     memory.assert(memoryOperations);
     context.machineState.incrementPc();

--- a/yarn-project/simulator/src/avm/opcodes/memory.ts
+++ b/yarn-project/simulator/src/avm/opcodes/memory.ts
@@ -114,12 +114,17 @@ export class CMov extends Instruction {
     const memory = context.machineState.memory.track(this.type);
     context.machineState.consumeGas(this.gasCost(memoryOperations));
 
-    const a = memory.get(this.aOffset);
-    const b = memory.get(this.bOffset);
-    const cond = memory.get(this.condOffset);
+    const [aOffset, bOffset, condOffset, dstOffset] = Addressing.fromWire(this.indirect).resolve(
+      [this.aOffset, this.bOffset, this.condOffset, this.dstOffset],
+      memory,
+    );
+
+    const a = memory.get(aOffset);
+    const b = memory.get(bOffset);
+    const cond = memory.get(condOffset);
 
     // TODO: reconsider toBigInt() here
-    memory.set(this.dstOffset, cond.toBigInt() > 0 ? a : b);
+    memory.set(dstOffset, cond.toBigInt() > 0 ? a : b);
 
     memory.assert(memoryOperations);
     context.machineState.incrementPc();
@@ -130,8 +135,8 @@ export class Cast extends TwoOperandInstruction {
   static readonly type: string = 'CAST';
   static readonly opcode = Opcode.CAST;
 
-  constructor(indirect: number, dstTag: number, aOffset: number, dstOffset: number) {
-    super(indirect, dstTag, aOffset, dstOffset);
+  constructor(indirect: number, dstTag: number, srcOffset: number, dstOffset: number) {
+    super(indirect, dstTag, srcOffset, dstOffset);
   }
 
   public async execute(context: AvmContext): Promise<void> {
@@ -139,13 +144,14 @@ export class Cast extends TwoOperandInstruction {
     const memory = context.machineState.memory.track(this.type);
     context.machineState.consumeGas(this.gasCost(memoryOperations));
 
-    const a = memory.get(this.aOffset);
+    const [srcOffset, dstOffset] = Addressing.fromWire(this.indirect).resolve([this.aOffset, this.dstOffset], memory);
 
-    // TODO: consider not using toBigInt()
+    const a = memory.get(srcOffset);
+
     const casted =
       this.inTag == TypeTag.FIELD ? new Field(a.toBigInt()) : TaggedMemory.integralFromTag(a.toBigInt(), this.inTag);
 
-    memory.set(this.dstOffset, casted);
+    memory.set(dstOffset, casted);
 
     memory.assert(memoryOperations);
     context.machineState.incrementPc();
@@ -204,10 +210,11 @@ export class CalldataCopy extends Instruction {
     const memory = context.machineState.memory.track(this.type);
     context.machineState.consumeGas(this.gasCost(memoryOperations));
 
-    const [dstOffset] = Addressing.fromWire(this.indirect).resolve([this.dstOffset], memory);
+    // We don't need to check tags here because: (1) the calldata is NOT in memory, and (2) we are the ones writing to destination.
+    const [cdOffset, dstOffset] = Addressing.fromWire(this.indirect).resolve([this.cdOffset, this.dstOffset], memory);
 
     const transformedData = context.environment.calldata
-      .slice(this.cdOffset, this.cdOffset + this.copySize)
+      .slice(cdOffset, cdOffset + this.copySize)
       .map(f => new Field(f));
 
     memory.setSlice(dstOffset, transformedData);


### PR DESCRIPTION
UINT32 memory offsets and length checks are commented out until Noir
uses UINT32 for memory.

Also change EMITUNENCRYPTEDLOG to actually take a slice of fields.
