### PR TITLE
fix: Fixing 0 naf

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -1278,11 +1278,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, batch_mul_edge_case_set1)
 
 HEAVY_TYPED_TEST(stdlib_biggroup, batch_mul_edge_case_set2)
 {
-    if constexpr (HasGoblinBuilder<TypeParam>) {
-        TestFixture::test_batch_mul_edge_case_set2();
-    } else {
-        GTEST_SKIP() << "https://github.com/AztecProtocol/barretenberg/issues/1000";
-    };
+    TestFixture::test_batch_mul_edge_case_set2();
 }
 HEAVY_TYPED_TEST(stdlib_biggroup, chain_add)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
@@ -485,6 +485,10 @@ std::vector<bool_t<C>> element<C, Fq, Fr, G>::compute_naf(const Fr& scalar, cons
     C* ctx = scalar.context;
     uint512_t scalar_multiplier_512 = uint512_t(uint256_t(scalar.get_value()) % Fr::modulus);
     uint256_t scalar_multiplier = scalar_multiplier_512.lo;
+    // NAF can't handl 0
+    if (scalar_multiplier == 0) {
+        scalar_multiplier = Fr::modulus;
+    }
 
     const size_t num_rounds = (max_num_bits == 0) ? Fr::modulus.get_msb() + 1 : max_num_bits;
     std::vector<bool_ct> naf_entries(num_rounds + 1);


### PR DESCRIPTION
Creating a naf in biggroup for 0 was incorrect because of the intricasies of NAF construction. I change the uint to be equal to the modulus in case of 0 and it worked
