### PR TITLE
chore(avm): add debugging info and trace dump

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/log.hpp
+++ b/barretenberg/cpp/src/barretenberg/bb/log.hpp
@@ -1,15 +1,8 @@
 #pragma once
-#include <barretenberg/common/log.hpp>
+
+#include <cstdint>
 #include <iostream>
-
-extern bool verbose;
-
-template <typename... Args> inline void vinfo(Args... args)
-{
-    if (verbose) {
-        info(args...);
-    }
-}
+#include <vector>
 
 /**
  * @brief Writes raw bytes of the vector to stdout

--- a/barretenberg/cpp/src/barretenberg/common/log.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/log.cpp
@@ -1,0 +1,2 @@
+// Used for `vinfo` in log.hpp.
+bool verbose_logging = false;

--- a/barretenberg/cpp/src/barretenberg/common/log.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/log.hpp
@@ -47,7 +47,7 @@ template <typename... Args> std::string benchmark_format(Args... args)
     return os.str();
 }
 
-#if NDEBUG
+#ifndef NDEBUG
 template <typename... Args> inline void debug(Args... args)
 {
     logstr(format(args...).c_str());
@@ -59,6 +59,14 @@ template <typename... Args> inline void debug(Args... /*unused*/) {}
 template <typename... Args> inline void info(Args... args)
 {
     logstr(format(args...).c_str());
+}
+
+extern bool verbose_logging;
+template <typename... Args> inline void vinfo(Args... args)
+{
+    if (verbose_logging) {
+        info(args...);
+    }
 }
 
 template <typename... Args> inline void important(Args... args)

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_alu.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_alu.hpp
@@ -127,6 +127,8 @@ template <typename FF> struct Avm_aluRow {
     FF avm_alu_u8_r1{};
     FF avm_alu_u8_r1_shift{};
     FF avm_alu_u8_tag{};
+
+    [[maybe_unused]] static std::vector<std::string> names();
 };
 
 inline std::string get_relation_label_avm_alu(int index)

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_binary.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_binary.hpp
@@ -22,6 +22,8 @@ template <typename FF> struct Avm_binaryRow {
     FF avm_binary_mem_tag_ctr_shift{};
     FF avm_binary_op_id{};
     FF avm_binary_op_id_shift{};
+
+    [[maybe_unused]] static std::vector<std::string> names();
 };
 
 inline std::string get_relation_label_avm_binary(int index)

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_conversion.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_conversion.hpp
@@ -8,6 +8,8 @@ namespace bb::Avm_vm {
 
 template <typename FF> struct Avm_conversionRow {
     FF avm_conversion_to_radix_le_sel{};
+
+    [[maybe_unused]] static std::vector<std::string> names();
 };
 
 inline std::string get_relation_label_avm_conversion(int index)

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_keccakf1600.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_keccakf1600.hpp
@@ -8,6 +8,8 @@ namespace bb::Avm_vm {
 
 template <typename FF> struct Avm_keccakf1600Row {
     FF avm_keccakf1600_keccakf1600_sel{};
+
+    [[maybe_unused]] static std::vector<std::string> names();
 };
 
 inline std::string get_relation_label_avm_keccakf1600(int index)

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_kernel.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_kernel.hpp
@@ -38,6 +38,8 @@ template <typename FF> struct Avm_kernelRow {
     FF avm_main_sel_op_nullifier_exists{};
     FF avm_main_sel_op_sload{};
     FF avm_main_sel_op_sstore{};
+
+    [[maybe_unused]] static std::vector<std::string> names();
 };
 
 inline std::string get_relation_label_avm_kernel(int index)

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_main.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_main.hpp
@@ -119,6 +119,8 @@ template <typename FF> struct Avm_mainRow {
     FF avm_main_space_id{};
     FF avm_main_tag_err{};
     FF avm_main_w_in_tag{};
+
+    [[maybe_unused]] static std::vector<std::string> names();
 };
 
 inline std::string get_relation_label_avm_main(int index)

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_mem.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_mem.hpp
@@ -45,6 +45,8 @@ template <typename FF> struct Avm_memRow {
     FF avm_mem_val{};
     FF avm_mem_val_shift{};
     FF avm_mem_w_in_tag{};
+
+    [[maybe_unused]] static std::vector<std::string> names();
 };
 
 inline std::string get_relation_label_avm_mem(int index)

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_pedersen.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_pedersen.hpp
@@ -8,6 +8,8 @@ namespace bb::Avm_vm {
 
 template <typename FF> struct Avm_pedersenRow {
     FF avm_pedersen_pedersen_sel{};
+
+    [[maybe_unused]] static std::vector<std::string> names();
 };
 
 inline std::string get_relation_label_avm_pedersen(int index)

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_poseidon2.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_poseidon2.hpp
@@ -8,6 +8,8 @@ namespace bb::Avm_vm {
 
 template <typename FF> struct Avm_poseidon2Row {
     FF avm_poseidon2_poseidon_perm_sel{};
+
+    [[maybe_unused]] static std::vector<std::string> names();
 };
 
 inline std::string get_relation_label_avm_poseidon2(int index)

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_sha256.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/avm_sha256.hpp
@@ -8,6 +8,8 @@ namespace bb::Avm_vm {
 
 template <typename FF> struct Avm_sha256Row {
     FF avm_sha256_sha256_compression_sel{};
+
+    [[maybe_unused]] static std::vector<std::string> names();
 };
 
 inline std::string get_relation_label_avm_sha256(int index)

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_deserialization.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_deserialization.cpp
@@ -179,6 +179,8 @@ std::vector<Instruction> Deserialization::parse(std::vector<uint8_t> const& byte
     size_t pos = 0;
     const auto length = bytecode.size();
 
+    debug("------- PARSING BYTECODE -------");
+    debug("Parsing bytecode of length: " + std::to_string(length));
     while (pos < length) {
         const uint8_t opcode_byte = bytecode.at(pos);
 
@@ -242,12 +244,12 @@ std::vector<Instruction> Deserialization::parse(std::vector<uint8_t> const& byte
         }
 
         std::vector<Operand> operands;
-
         for (OperandType const& opType : inst_format) {
             // No underflow as while condition guarantees pos <= length (after pos++)
             if (length - pos < OPERAND_TYPE_SIZE.at(opType)) {
-                throw_or_abort("Operand is missing at position " + std::to_string(pos) +
-                               " for opcode: " + to_hex(opcode));
+                throw_or_abort("Operand is missing at position " + std::to_string(pos) + " for opcode " +
+                               to_hex(opcode) + " not enough bytes for operand type " +
+                               std::to_string(static_cast<int>(opType)));
             }
 
             switch (opType) {
@@ -298,7 +300,9 @@ std::vector<Instruction> Deserialization::parse(std::vector<uint8_t> const& byte
             }
             pos += OPERAND_TYPE_SIZE.at(opType);
         }
-        instructions.emplace_back(opcode, operands);
+        auto instruction = Instruction(opcode, operands);
+        debug(instruction.to_string());
+        instructions.emplace_back(std::move(instruction));
     }
     return instructions;
 };

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_helper.cpp
@@ -1,5 +1,6 @@
 #include "barretenberg/vm/avm_trace/avm_helper.hpp"
 #include "barretenberg/vm/avm_trace/avm_mem_trace.hpp"
+#include "barretenberg/vm/generated/avm_circuit_builder.hpp"
 
 namespace bb::avm_trace {
 
@@ -96,6 +97,21 @@ void log_avm_trace(std::vector<Row> const& trace, size_t beg, size_t end, bool e
             }
             info("\n");
         }
+    }
+}
+
+void dump_trace_as_csv(std::vector<Row> const& trace, std::filesystem::path const& filename)
+{
+    std::ofstream file;
+    file.open(filename);
+
+    for (const auto& row_name : Row::names()) {
+        file << row_name << ",";
+    }
+    file << std::endl;
+
+    for (const auto& row : trace) {
+        file << row << std::endl;
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_helper.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_helper.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <filesystem>
+
 #include "barretenberg/vm/avm_trace/avm_common.hpp"
 #include "barretenberg/vm/avm_trace/avm_trace.hpp"
 
 namespace bb::avm_trace {
 
 void log_avm_trace(std::vector<Row> const& trace, size_t beg, size_t end, bool enable_selectors = false);
+void dump_trace_as_csv(const std::vector<Row>& trace, const std::filesystem::path& filename);
 
 bool is_operand_indirect(uint8_t ind_value, uint8_t operand_idx);
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_instructions.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_instructions.hpp
@@ -5,6 +5,7 @@
 #include "barretenberg/vm/avm_trace/avm_opcode.hpp"
 
 #include <cstdint>
+#include <string>
 #include <variant>
 #include <vector>
 
@@ -21,6 +22,30 @@ class Instruction {
     explicit Instruction(OpCode op_code, std::vector<Operand> operands)
         : op_code(op_code)
         , operands(std::move(operands)){};
+
+    std::string to_string() const
+    {
+        std::string str = bb::avm_trace::to_string(op_code);
+        for (const auto& operand : operands) {
+            str += " ";
+            if (std::holds_alternative<AvmMemoryTag>(operand)) {
+                str += std::to_string(static_cast<int>(std::get<AvmMemoryTag>(operand)));
+            } else if (std::holds_alternative<uint8_t>(operand)) {
+                str += std::to_string(std::get<uint8_t>(operand));
+            } else if (std::holds_alternative<uint16_t>(operand)) {
+                str += std::to_string(std::get<uint16_t>(operand));
+            } else if (std::holds_alternative<uint32_t>(operand)) {
+                str += std::to_string(std::get<uint32_t>(operand));
+            } else if (std::holds_alternative<uint64_t>(operand)) {
+                str += std::to_string(std::get<uint64_t>(operand));
+            } else if (std::holds_alternative<uint128_t>(operand)) {
+                str += "someu128";
+            } else {
+                str += "unknown operand type";
+            }
+        }
+        return str;
+    }
 };
 
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.cpp
@@ -389,71 +389,6 @@ template <typename FF> std::vector<std::string> AvmFullRow<FF>::names()
              "lookup_div_u16_5_counts",
              "lookup_div_u16_6_counts",
              "lookup_div_u16_7_counts",
-             "avm_alu_a_hi_shift",
-             "avm_alu_a_lo_shift",
-             "avm_alu_alu_sel_shift",
-             "avm_alu_b_hi_shift",
-             "avm_alu_b_lo_shift",
-             "avm_alu_cmp_rng_ctr_shift",
-             "avm_alu_cmp_sel_shift",
-             "avm_alu_div_rng_chk_selector_shift",
-             "avm_alu_div_u16_r0_shift",
-             "avm_alu_div_u16_r1_shift",
-             "avm_alu_div_u16_r2_shift",
-             "avm_alu_div_u16_r3_shift",
-             "avm_alu_div_u16_r4_shift",
-             "avm_alu_div_u16_r5_shift",
-             "avm_alu_div_u16_r6_shift",
-             "avm_alu_div_u16_r7_shift",
-             "avm_alu_op_add_shift",
-             "avm_alu_op_cast_prev_shift",
-             "avm_alu_op_cast_shift",
-             "avm_alu_op_div_shift",
-             "avm_alu_op_mul_shift",
-             "avm_alu_op_shl_shift",
-             "avm_alu_op_shr_shift",
-             "avm_alu_op_sub_shift",
-             "avm_alu_p_sub_a_hi_shift",
-             "avm_alu_p_sub_a_lo_shift",
-             "avm_alu_p_sub_b_hi_shift",
-             "avm_alu_p_sub_b_lo_shift",
-             "avm_alu_rng_chk_lookup_selector_shift",
-             "avm_alu_rng_chk_sel_shift",
-             "avm_alu_u16_r0_shift",
-             "avm_alu_u16_r1_shift",
-             "avm_alu_u16_r2_shift",
-             "avm_alu_u16_r3_shift",
-             "avm_alu_u16_r4_shift",
-             "avm_alu_u16_r5_shift",
-             "avm_alu_u16_r6_shift",
-             "avm_alu_u8_r0_shift",
-             "avm_alu_u8_r1_shift",
-             "avm_binary_acc_ia_shift",
-             "avm_binary_acc_ib_shift",
-             "avm_binary_acc_ic_shift",
-             "avm_binary_mem_tag_ctr_shift",
-             "avm_binary_op_id_shift",
-             "avm_kernel_emit_l2_to_l1_msg_write_offset_shift",
-             "avm_kernel_emit_note_hash_write_offset_shift",
-             "avm_kernel_emit_nullifier_write_offset_shift",
-             "avm_kernel_emit_unencrypted_log_write_offset_shift",
-             "avm_kernel_l1_to_l2_msg_exists_write_offset_shift",
-             "avm_kernel_note_hash_exist_write_offset_shift",
-             "avm_kernel_nullifier_exists_write_offset_shift",
-             "avm_kernel_nullifier_non_exists_write_offset_shift",
-             "avm_kernel_side_effect_counter_shift",
-             "avm_kernel_sload_write_offset_shift",
-             "avm_kernel_sstore_write_offset_shift",
-             "avm_main_da_gas_remaining_shift",
-             "avm_main_internal_return_ptr_shift",
-             "avm_main_l2_gas_remaining_shift",
-             "avm_main_pc_shift",
-             "avm_mem_glob_addr_shift",
-             "avm_mem_mem_sel_shift",
-             "avm_mem_rw_shift",
-             "avm_mem_tag_shift",
-             "avm_mem_tsp_shift",
-             "avm_mem_val_shift",
              "" };
 }
 
@@ -666,50 +601,7 @@ template <typename FF> std::ostream& operator<<(std::ostream& os, AvmFullRow<FF>
            << field_to_string(row.lookup_div_u16_0_counts) << "," << field_to_string(row.lookup_div_u16_1_counts) << ","
            << field_to_string(row.lookup_div_u16_2_counts) << "," << field_to_string(row.lookup_div_u16_3_counts) << ","
            << field_to_string(row.lookup_div_u16_4_counts) << "," << field_to_string(row.lookup_div_u16_5_counts) << ","
-           << field_to_string(row.lookup_div_u16_6_counts) << "," << field_to_string(row.lookup_div_u16_7_counts) << ","
-           << field_to_string(row.avm_alu_a_hi_shift) << "," << field_to_string(row.avm_alu_a_lo_shift) << ","
-           << field_to_string(row.avm_alu_alu_sel_shift) << "," << field_to_string(row.avm_alu_b_hi_shift) << ","
-           << field_to_string(row.avm_alu_b_lo_shift) << "," << field_to_string(row.avm_alu_cmp_rng_ctr_shift) << ","
-           << field_to_string(row.avm_alu_cmp_sel_shift) << ","
-           << field_to_string(row.avm_alu_div_rng_chk_selector_shift) << ","
-           << field_to_string(row.avm_alu_div_u16_r0_shift) << "," << field_to_string(row.avm_alu_div_u16_r1_shift)
-           << "," << field_to_string(row.avm_alu_div_u16_r2_shift) << ","
-           << field_to_string(row.avm_alu_div_u16_r3_shift) << "," << field_to_string(row.avm_alu_div_u16_r4_shift)
-           << "," << field_to_string(row.avm_alu_div_u16_r5_shift) << ","
-           << field_to_string(row.avm_alu_div_u16_r6_shift) << "," << field_to_string(row.avm_alu_div_u16_r7_shift)
-           << "," << field_to_string(row.avm_alu_op_add_shift) << "," << field_to_string(row.avm_alu_op_cast_prev_shift)
-           << "," << field_to_string(row.avm_alu_op_cast_shift) << "," << field_to_string(row.avm_alu_op_div_shift)
-           << "," << field_to_string(row.avm_alu_op_mul_shift) << "," << field_to_string(row.avm_alu_op_shl_shift)
-           << "," << field_to_string(row.avm_alu_op_shr_shift) << "," << field_to_string(row.avm_alu_op_sub_shift)
-           << "," << field_to_string(row.avm_alu_p_sub_a_hi_shift) << ","
-           << field_to_string(row.avm_alu_p_sub_a_lo_shift) << "," << field_to_string(row.avm_alu_p_sub_b_hi_shift)
-           << "," << field_to_string(row.avm_alu_p_sub_b_lo_shift) << ","
-           << field_to_string(row.avm_alu_rng_chk_lookup_selector_shift) << ","
-           << field_to_string(row.avm_alu_rng_chk_sel_shift) << "," << field_to_string(row.avm_alu_u16_r0_shift) << ","
-           << field_to_string(row.avm_alu_u16_r1_shift) << "," << field_to_string(row.avm_alu_u16_r2_shift) << ","
-           << field_to_string(row.avm_alu_u16_r3_shift) << "," << field_to_string(row.avm_alu_u16_r4_shift) << ","
-           << field_to_string(row.avm_alu_u16_r5_shift) << "," << field_to_string(row.avm_alu_u16_r6_shift) << ","
-           << field_to_string(row.avm_alu_u8_r0_shift) << "," << field_to_string(row.avm_alu_u8_r1_shift) << ","
-           << field_to_string(row.avm_binary_acc_ia_shift) << "," << field_to_string(row.avm_binary_acc_ib_shift) << ","
-           << field_to_string(row.avm_binary_acc_ic_shift) << "," << field_to_string(row.avm_binary_mem_tag_ctr_shift)
-           << "," << field_to_string(row.avm_binary_op_id_shift) << ","
-           << field_to_string(row.avm_kernel_emit_l2_to_l1_msg_write_offset_shift) << ","
-           << field_to_string(row.avm_kernel_emit_note_hash_write_offset_shift) << ","
-           << field_to_string(row.avm_kernel_emit_nullifier_write_offset_shift) << ","
-           << field_to_string(row.avm_kernel_emit_unencrypted_log_write_offset_shift) << ","
-           << field_to_string(row.avm_kernel_l1_to_l2_msg_exists_write_offset_shift) << ","
-           << field_to_string(row.avm_kernel_note_hash_exist_write_offset_shift) << ","
-           << field_to_string(row.avm_kernel_nullifier_exists_write_offset_shift) << ","
-           << field_to_string(row.avm_kernel_nullifier_non_exists_write_offset_shift) << ","
-           << field_to_string(row.avm_kernel_side_effect_counter_shift) << ","
-           << field_to_string(row.avm_kernel_sload_write_offset_shift) << ","
-           << field_to_string(row.avm_kernel_sstore_write_offset_shift) << ","
-           << field_to_string(row.avm_main_da_gas_remaining_shift) << ","
-           << field_to_string(row.avm_main_internal_return_ptr_shift) << ","
-           << field_to_string(row.avm_main_l2_gas_remaining_shift) << "," << field_to_string(row.avm_main_pc_shift)
-           << "," << field_to_string(row.avm_mem_glob_addr_shift) << "," << field_to_string(row.avm_mem_mem_sel_shift)
-           << "," << field_to_string(row.avm_mem_rw_shift) << "," << field_to_string(row.avm_mem_tag_shift) << ","
-           << field_to_string(row.avm_mem_tsp_shift) << "," << field_to_string(row.avm_mem_val_shift)
+           << field_to_string(row.lookup_div_u16_6_counts) << "," << field_to_string(row.lookup_div_u16_7_counts)
            << ","
               "";
 }

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.cpp
@@ -1,0 +1,721 @@
+
+#include "barretenberg/vm/generated/avm_circuit_builder.hpp"
+
+namespace bb {
+namespace {
+
+template <typename FF> std::string field_to_string(const FF& ff)
+{
+    std::ostringstream os;
+    os << ff;
+    std::string raw = os.str();
+    auto first_not_zero = raw.find_first_not_of('0', 2);
+    std::string result = "0x" + (first_not_zero != std::string::npos ? raw.substr(first_not_zero) : "0");
+    return result;
+}
+
+} // namespace
+
+template <typename FF> std::vector<std::string> AvmFullRow<FF>::names()
+{
+    return { "avm_main_clk",
+             "avm_main_first",
+             "avm_alu_a_hi",
+             "avm_alu_a_lo",
+             "avm_alu_alu_sel",
+             "avm_alu_b_hi",
+             "avm_alu_b_lo",
+             "avm_alu_borrow",
+             "avm_alu_cf",
+             "avm_alu_clk",
+             "avm_alu_cmp_rng_ctr",
+             "avm_alu_cmp_sel",
+             "avm_alu_div_rng_chk_selector",
+             "avm_alu_div_u16_r0",
+             "avm_alu_div_u16_r1",
+             "avm_alu_div_u16_r2",
+             "avm_alu_div_u16_r3",
+             "avm_alu_div_u16_r4",
+             "avm_alu_div_u16_r5",
+             "avm_alu_div_u16_r6",
+             "avm_alu_div_u16_r7",
+             "avm_alu_divisor_hi",
+             "avm_alu_divisor_lo",
+             "avm_alu_ff_tag",
+             "avm_alu_ia",
+             "avm_alu_ib",
+             "avm_alu_ic",
+             "avm_alu_in_tag",
+             "avm_alu_op_add",
+             "avm_alu_op_cast",
+             "avm_alu_op_cast_prev",
+             "avm_alu_op_div",
+             "avm_alu_op_div_a_lt_b",
+             "avm_alu_op_div_std",
+             "avm_alu_op_eq",
+             "avm_alu_op_eq_diff_inv",
+             "avm_alu_op_lt",
+             "avm_alu_op_lte",
+             "avm_alu_op_mul",
+             "avm_alu_op_not",
+             "avm_alu_op_shl",
+             "avm_alu_op_shr",
+             "avm_alu_op_sub",
+             "avm_alu_p_a_borrow",
+             "avm_alu_p_b_borrow",
+             "avm_alu_p_sub_a_hi",
+             "avm_alu_p_sub_a_lo",
+             "avm_alu_p_sub_b_hi",
+             "avm_alu_p_sub_b_lo",
+             "avm_alu_partial_prod_hi",
+             "avm_alu_partial_prod_lo",
+             "avm_alu_quotient_hi",
+             "avm_alu_quotient_lo",
+             "avm_alu_remainder",
+             "avm_alu_res_hi",
+             "avm_alu_res_lo",
+             "avm_alu_rng_chk_lookup_selector",
+             "avm_alu_rng_chk_sel",
+             "avm_alu_shift_lt_bit_len",
+             "avm_alu_shift_sel",
+             "avm_alu_t_sub_s_bits",
+             "avm_alu_two_pow_s",
+             "avm_alu_two_pow_t_sub_s",
+             "avm_alu_u128_tag",
+             "avm_alu_u16_r0",
+             "avm_alu_u16_r1",
+             "avm_alu_u16_r10",
+             "avm_alu_u16_r11",
+             "avm_alu_u16_r12",
+             "avm_alu_u16_r13",
+             "avm_alu_u16_r14",
+             "avm_alu_u16_r2",
+             "avm_alu_u16_r3",
+             "avm_alu_u16_r4",
+             "avm_alu_u16_r5",
+             "avm_alu_u16_r6",
+             "avm_alu_u16_r7",
+             "avm_alu_u16_r8",
+             "avm_alu_u16_r9",
+             "avm_alu_u16_tag",
+             "avm_alu_u32_tag",
+             "avm_alu_u64_tag",
+             "avm_alu_u8_r0",
+             "avm_alu_u8_r1",
+             "avm_alu_u8_tag",
+             "avm_binary_acc_ia",
+             "avm_binary_acc_ib",
+             "avm_binary_acc_ic",
+             "avm_binary_bin_sel",
+             "avm_binary_clk",
+             "avm_binary_ia_bytes",
+             "avm_binary_ib_bytes",
+             "avm_binary_ic_bytes",
+             "avm_binary_in_tag",
+             "avm_binary_mem_tag_ctr",
+             "avm_binary_mem_tag_ctr_inv",
+             "avm_binary_op_id",
+             "avm_binary_start",
+             "avm_byte_lookup_bin_sel",
+             "avm_byte_lookup_table_byte_lengths",
+             "avm_byte_lookup_table_in_tags",
+             "avm_byte_lookup_table_input_a",
+             "avm_byte_lookup_table_input_b",
+             "avm_byte_lookup_table_op_id",
+             "avm_byte_lookup_table_output",
+             "avm_conversion_clk",
+             "avm_conversion_input",
+             "avm_conversion_num_limbs",
+             "avm_conversion_radix",
+             "avm_conversion_to_radix_le_sel",
+             "avm_gas_da_gas_fixed_table",
+             "avm_gas_gas_cost_sel",
+             "avm_gas_l2_gas_fixed_table",
+             "avm_keccakf1600_clk",
+             "avm_keccakf1600_input",
+             "avm_keccakf1600_keccakf1600_sel",
+             "avm_keccakf1600_output",
+             "avm_kernel_emit_l2_to_l1_msg_write_offset",
+             "avm_kernel_emit_note_hash_write_offset",
+             "avm_kernel_emit_nullifier_write_offset",
+             "avm_kernel_emit_unencrypted_log_write_offset",
+             "avm_kernel_kernel_in_offset",
+             "avm_kernel_kernel_inputs__is_public",
+             "avm_kernel_kernel_metadata_out__is_public",
+             "avm_kernel_kernel_out_offset",
+             "avm_kernel_kernel_side_effect_out__is_public",
+             "avm_kernel_kernel_value_out__is_public",
+             "avm_kernel_l1_to_l2_msg_exists_write_offset",
+             "avm_kernel_note_hash_exist_write_offset",
+             "avm_kernel_nullifier_exists_write_offset",
+             "avm_kernel_nullifier_non_exists_write_offset",
+             "avm_kernel_q_public_input_kernel_add_to_table",
+             "avm_kernel_q_public_input_kernel_out_add_to_table",
+             "avm_kernel_side_effect_counter",
+             "avm_kernel_sload_write_offset",
+             "avm_kernel_sstore_write_offset",
+             "avm_main_alu_in_tag",
+             "avm_main_alu_sel",
+             "avm_main_bin_op_id",
+             "avm_main_bin_sel",
+             "avm_main_call_ptr",
+             "avm_main_da_gas_op",
+             "avm_main_da_gas_remaining",
+             "avm_main_gas_cost_active",
+             "avm_main_ia",
+             "avm_main_ib",
+             "avm_main_ic",
+             "avm_main_id",
+             "avm_main_id_zero",
+             "avm_main_ind_a",
+             "avm_main_ind_b",
+             "avm_main_ind_c",
+             "avm_main_ind_d",
+             "avm_main_ind_op_a",
+             "avm_main_ind_op_b",
+             "avm_main_ind_op_c",
+             "avm_main_ind_op_d",
+             "avm_main_internal_return_ptr",
+             "avm_main_inv",
+             "avm_main_l2_gas_op",
+             "avm_main_l2_gas_remaining",
+             "avm_main_last",
+             "avm_main_mem_idx_a",
+             "avm_main_mem_idx_b",
+             "avm_main_mem_idx_c",
+             "avm_main_mem_idx_d",
+             "avm_main_mem_op_a",
+             "avm_main_mem_op_activate_gas",
+             "avm_main_mem_op_b",
+             "avm_main_mem_op_c",
+             "avm_main_mem_op_d",
+             "avm_main_op_err",
+             "avm_main_opcode_val",
+             "avm_main_pc",
+             "avm_main_q_kernel_lookup",
+             "avm_main_q_kernel_output_lookup",
+             "avm_main_r_in_tag",
+             "avm_main_rwa",
+             "avm_main_rwb",
+             "avm_main_rwc",
+             "avm_main_rwd",
+             "avm_main_sel_cmov",
+             "avm_main_sel_external_call",
+             "avm_main_sel_halt",
+             "avm_main_sel_internal_call",
+             "avm_main_sel_internal_return",
+             "avm_main_sel_jump",
+             "avm_main_sel_jumpi",
+             "avm_main_sel_mov",
+             "avm_main_sel_mov_a",
+             "avm_main_sel_mov_b",
+             "avm_main_sel_op_add",
+             "avm_main_sel_op_address",
+             "avm_main_sel_op_and",
+             "avm_main_sel_op_block_number",
+             "avm_main_sel_op_cast",
+             "avm_main_sel_op_chain_id",
+             "avm_main_sel_op_coinbase",
+             "avm_main_sel_op_dagasleft",
+             "avm_main_sel_op_div",
+             "avm_main_sel_op_emit_l2_to_l1_msg",
+             "avm_main_sel_op_emit_note_hash",
+             "avm_main_sel_op_emit_nullifier",
+             "avm_main_sel_op_emit_unencrypted_log",
+             "avm_main_sel_op_eq",
+             "avm_main_sel_op_fdiv",
+             "avm_main_sel_op_fee_per_da_gas",
+             "avm_main_sel_op_fee_per_l2_gas",
+             "avm_main_sel_op_get_contract_instance",
+             "avm_main_sel_op_keccak",
+             "avm_main_sel_op_l1_to_l2_msg_exists",
+             "avm_main_sel_op_l2gasleft",
+             "avm_main_sel_op_lt",
+             "avm_main_sel_op_lte",
+             "avm_main_sel_op_mul",
+             "avm_main_sel_op_not",
+             "avm_main_sel_op_note_hash_exists",
+             "avm_main_sel_op_nullifier_exists",
+             "avm_main_sel_op_or",
+             "avm_main_sel_op_pedersen",
+             "avm_main_sel_op_poseidon2",
+             "avm_main_sel_op_radix_le",
+             "avm_main_sel_op_sender",
+             "avm_main_sel_op_sha256",
+             "avm_main_sel_op_shl",
+             "avm_main_sel_op_shr",
+             "avm_main_sel_op_sload",
+             "avm_main_sel_op_sstore",
+             "avm_main_sel_op_storage_address",
+             "avm_main_sel_op_sub",
+             "avm_main_sel_op_timestamp",
+             "avm_main_sel_op_transaction_fee",
+             "avm_main_sel_op_version",
+             "avm_main_sel_op_xor",
+             "avm_main_sel_rng_16",
+             "avm_main_sel_rng_8",
+             "avm_main_space_id",
+             "avm_main_table_pow_2",
+             "avm_main_tag_err",
+             "avm_main_w_in_tag",
+             "avm_mem_addr",
+             "avm_mem_clk",
+             "avm_mem_diff_hi",
+             "avm_mem_diff_lo",
+             "avm_mem_diff_mid",
+             "avm_mem_glob_addr",
+             "avm_mem_ind_op_a",
+             "avm_mem_ind_op_b",
+             "avm_mem_ind_op_c",
+             "avm_mem_ind_op_d",
+             "avm_mem_last",
+             "avm_mem_lastAccess",
+             "avm_mem_mem_sel",
+             "avm_mem_one_min_inv",
+             "avm_mem_op_a",
+             "avm_mem_op_b",
+             "avm_mem_op_c",
+             "avm_mem_op_d",
+             "avm_mem_r_in_tag",
+             "avm_mem_rng_chk_sel",
+             "avm_mem_rw",
+             "avm_mem_sel_cmov",
+             "avm_mem_sel_mov_a",
+             "avm_mem_sel_mov_b",
+             "avm_mem_skip_check_tag",
+             "avm_mem_space_id",
+             "avm_mem_tag",
+             "avm_mem_tag_err",
+             "avm_mem_tsp",
+             "avm_mem_val",
+             "avm_mem_w_in_tag",
+             "avm_pedersen_clk",
+             "avm_pedersen_input",
+             "avm_pedersen_output",
+             "avm_pedersen_pedersen_sel",
+             "avm_poseidon2_clk",
+             "avm_poseidon2_input",
+             "avm_poseidon2_output",
+             "avm_poseidon2_poseidon_perm_sel",
+             "avm_sha256_clk",
+             "avm_sha256_input",
+             "avm_sha256_output",
+             "avm_sha256_sha256_compression_sel",
+             "avm_sha256_state",
+             "perm_main_alu",
+             "perm_main_bin",
+             "perm_main_conv",
+             "perm_main_pos2_perm",
+             "perm_main_pedersen",
+             "perm_main_mem_a",
+             "perm_main_mem_b",
+             "perm_main_mem_c",
+             "perm_main_mem_d",
+             "perm_main_mem_ind_a",
+             "perm_main_mem_ind_b",
+             "perm_main_mem_ind_c",
+             "perm_main_mem_ind_d",
+             "lookup_byte_lengths",
+             "lookup_byte_operations",
+             "lookup_opcode_gas",
+             "kernel_output_lookup",
+             "lookup_into_kernel",
+             "incl_main_tag_err",
+             "incl_mem_tag_err",
+             "lookup_mem_rng_chk_lo",
+             "lookup_mem_rng_chk_mid",
+             "lookup_mem_rng_chk_hi",
+             "lookup_pow_2_0",
+             "lookup_pow_2_1",
+             "lookup_u8_0",
+             "lookup_u8_1",
+             "lookup_u16_0",
+             "lookup_u16_1",
+             "lookup_u16_2",
+             "lookup_u16_3",
+             "lookup_u16_4",
+             "lookup_u16_5",
+             "lookup_u16_6",
+             "lookup_u16_7",
+             "lookup_u16_8",
+             "lookup_u16_9",
+             "lookup_u16_10",
+             "lookup_u16_11",
+             "lookup_u16_12",
+             "lookup_u16_13",
+             "lookup_u16_14",
+             "lookup_div_u16_0",
+             "lookup_div_u16_1",
+             "lookup_div_u16_2",
+             "lookup_div_u16_3",
+             "lookup_div_u16_4",
+             "lookup_div_u16_5",
+             "lookup_div_u16_6",
+             "lookup_div_u16_7",
+             "lookup_byte_lengths_counts",
+             "lookup_byte_operations_counts",
+             "lookup_opcode_gas_counts",
+             "kernel_output_lookup_counts",
+             "lookup_into_kernel_counts",
+             "incl_main_tag_err_counts",
+             "incl_mem_tag_err_counts",
+             "lookup_mem_rng_chk_lo_counts",
+             "lookup_mem_rng_chk_mid_counts",
+             "lookup_mem_rng_chk_hi_counts",
+             "lookup_pow_2_0_counts",
+             "lookup_pow_2_1_counts",
+             "lookup_u8_0_counts",
+             "lookup_u8_1_counts",
+             "lookup_u16_0_counts",
+             "lookup_u16_1_counts",
+             "lookup_u16_2_counts",
+             "lookup_u16_3_counts",
+             "lookup_u16_4_counts",
+             "lookup_u16_5_counts",
+             "lookup_u16_6_counts",
+             "lookup_u16_7_counts",
+             "lookup_u16_8_counts",
+             "lookup_u16_9_counts",
+             "lookup_u16_10_counts",
+             "lookup_u16_11_counts",
+             "lookup_u16_12_counts",
+             "lookup_u16_13_counts",
+             "lookup_u16_14_counts",
+             "lookup_div_u16_0_counts",
+             "lookup_div_u16_1_counts",
+             "lookup_div_u16_2_counts",
+             "lookup_div_u16_3_counts",
+             "lookup_div_u16_4_counts",
+             "lookup_div_u16_5_counts",
+             "lookup_div_u16_6_counts",
+             "lookup_div_u16_7_counts",
+             "avm_alu_a_hi_shift",
+             "avm_alu_a_lo_shift",
+             "avm_alu_alu_sel_shift",
+             "avm_alu_b_hi_shift",
+             "avm_alu_b_lo_shift",
+             "avm_alu_cmp_rng_ctr_shift",
+             "avm_alu_cmp_sel_shift",
+             "avm_alu_div_rng_chk_selector_shift",
+             "avm_alu_div_u16_r0_shift",
+             "avm_alu_div_u16_r1_shift",
+             "avm_alu_div_u16_r2_shift",
+             "avm_alu_div_u16_r3_shift",
+             "avm_alu_div_u16_r4_shift",
+             "avm_alu_div_u16_r5_shift",
+             "avm_alu_div_u16_r6_shift",
+             "avm_alu_div_u16_r7_shift",
+             "avm_alu_op_add_shift",
+             "avm_alu_op_cast_prev_shift",
+             "avm_alu_op_cast_shift",
+             "avm_alu_op_div_shift",
+             "avm_alu_op_mul_shift",
+             "avm_alu_op_shl_shift",
+             "avm_alu_op_shr_shift",
+             "avm_alu_op_sub_shift",
+             "avm_alu_p_sub_a_hi_shift",
+             "avm_alu_p_sub_a_lo_shift",
+             "avm_alu_p_sub_b_hi_shift",
+             "avm_alu_p_sub_b_lo_shift",
+             "avm_alu_rng_chk_lookup_selector_shift",
+             "avm_alu_rng_chk_sel_shift",
+             "avm_alu_u16_r0_shift",
+             "avm_alu_u16_r1_shift",
+             "avm_alu_u16_r2_shift",
+             "avm_alu_u16_r3_shift",
+             "avm_alu_u16_r4_shift",
+             "avm_alu_u16_r5_shift",
+             "avm_alu_u16_r6_shift",
+             "avm_alu_u8_r0_shift",
+             "avm_alu_u8_r1_shift",
+             "avm_binary_acc_ia_shift",
+             "avm_binary_acc_ib_shift",
+             "avm_binary_acc_ic_shift",
+             "avm_binary_mem_tag_ctr_shift",
+             "avm_binary_op_id_shift",
+             "avm_kernel_emit_l2_to_l1_msg_write_offset_shift",
+             "avm_kernel_emit_note_hash_write_offset_shift",
+             "avm_kernel_emit_nullifier_write_offset_shift",
+             "avm_kernel_emit_unencrypted_log_write_offset_shift",
+             "avm_kernel_l1_to_l2_msg_exists_write_offset_shift",
+             "avm_kernel_note_hash_exist_write_offset_shift",
+             "avm_kernel_nullifier_exists_write_offset_shift",
+             "avm_kernel_nullifier_non_exists_write_offset_shift",
+             "avm_kernel_side_effect_counter_shift",
+             "avm_kernel_sload_write_offset_shift",
+             "avm_kernel_sstore_write_offset_shift",
+             "avm_main_da_gas_remaining_shift",
+             "avm_main_internal_return_ptr_shift",
+             "avm_main_l2_gas_remaining_shift",
+             "avm_main_pc_shift",
+             "avm_mem_glob_addr_shift",
+             "avm_mem_mem_sel_shift",
+             "avm_mem_rw_shift",
+             "avm_mem_tag_shift",
+             "avm_mem_tsp_shift",
+             "avm_mem_val_shift",
+             "" };
+}
+
+template <typename FF> std::ostream& operator<<(std::ostream& os, AvmFullRow<FF> const& row)
+{
+    return os
+           << field_to_string(row.avm_main_clk) << "," << field_to_string(row.avm_main_first) << ","
+           << field_to_string(row.avm_alu_a_hi) << "," << field_to_string(row.avm_alu_a_lo) << ","
+           << field_to_string(row.avm_alu_alu_sel) << "," << field_to_string(row.avm_alu_b_hi) << ","
+           << field_to_string(row.avm_alu_b_lo) << "," << field_to_string(row.avm_alu_borrow) << ","
+           << field_to_string(row.avm_alu_cf) << "," << field_to_string(row.avm_alu_clk) << ","
+           << field_to_string(row.avm_alu_cmp_rng_ctr) << "," << field_to_string(row.avm_alu_cmp_sel) << ","
+           << field_to_string(row.avm_alu_div_rng_chk_selector) << "," << field_to_string(row.avm_alu_div_u16_r0) << ","
+           << field_to_string(row.avm_alu_div_u16_r1) << "," << field_to_string(row.avm_alu_div_u16_r2) << ","
+           << field_to_string(row.avm_alu_div_u16_r3) << "," << field_to_string(row.avm_alu_div_u16_r4) << ","
+           << field_to_string(row.avm_alu_div_u16_r5) << "," << field_to_string(row.avm_alu_div_u16_r6) << ","
+           << field_to_string(row.avm_alu_div_u16_r7) << "," << field_to_string(row.avm_alu_divisor_hi) << ","
+           << field_to_string(row.avm_alu_divisor_lo) << "," << field_to_string(row.avm_alu_ff_tag) << ","
+           << field_to_string(row.avm_alu_ia) << "," << field_to_string(row.avm_alu_ib) << ","
+           << field_to_string(row.avm_alu_ic) << "," << field_to_string(row.avm_alu_in_tag) << ","
+           << field_to_string(row.avm_alu_op_add) << "," << field_to_string(row.avm_alu_op_cast) << ","
+           << field_to_string(row.avm_alu_op_cast_prev) << "," << field_to_string(row.avm_alu_op_div) << ","
+           << field_to_string(row.avm_alu_op_div_a_lt_b) << "," << field_to_string(row.avm_alu_op_div_std) << ","
+           << field_to_string(row.avm_alu_op_eq) << "," << field_to_string(row.avm_alu_op_eq_diff_inv) << ","
+           << field_to_string(row.avm_alu_op_lt) << "," << field_to_string(row.avm_alu_op_lte) << ","
+           << field_to_string(row.avm_alu_op_mul) << "," << field_to_string(row.avm_alu_op_not) << ","
+           << field_to_string(row.avm_alu_op_shl) << "," << field_to_string(row.avm_alu_op_shr) << ","
+           << field_to_string(row.avm_alu_op_sub) << "," << field_to_string(row.avm_alu_p_a_borrow) << ","
+           << field_to_string(row.avm_alu_p_b_borrow) << "," << field_to_string(row.avm_alu_p_sub_a_hi) << ","
+           << field_to_string(row.avm_alu_p_sub_a_lo) << "," << field_to_string(row.avm_alu_p_sub_b_hi) << ","
+           << field_to_string(row.avm_alu_p_sub_b_lo) << "," << field_to_string(row.avm_alu_partial_prod_hi) << ","
+           << field_to_string(row.avm_alu_partial_prod_lo) << "," << field_to_string(row.avm_alu_quotient_hi) << ","
+           << field_to_string(row.avm_alu_quotient_lo) << "," << field_to_string(row.avm_alu_remainder) << ","
+           << field_to_string(row.avm_alu_res_hi) << "," << field_to_string(row.avm_alu_res_lo) << ","
+           << field_to_string(row.avm_alu_rng_chk_lookup_selector) << "," << field_to_string(row.avm_alu_rng_chk_sel)
+           << "," << field_to_string(row.avm_alu_shift_lt_bit_len) << "," << field_to_string(row.avm_alu_shift_sel)
+           << "," << field_to_string(row.avm_alu_t_sub_s_bits) << "," << field_to_string(row.avm_alu_two_pow_s) << ","
+           << field_to_string(row.avm_alu_two_pow_t_sub_s) << "," << field_to_string(row.avm_alu_u128_tag) << ","
+           << field_to_string(row.avm_alu_u16_r0) << "," << field_to_string(row.avm_alu_u16_r1) << ","
+           << field_to_string(row.avm_alu_u16_r10) << "," << field_to_string(row.avm_alu_u16_r11) << ","
+           << field_to_string(row.avm_alu_u16_r12) << "," << field_to_string(row.avm_alu_u16_r13) << ","
+           << field_to_string(row.avm_alu_u16_r14) << "," << field_to_string(row.avm_alu_u16_r2) << ","
+           << field_to_string(row.avm_alu_u16_r3) << "," << field_to_string(row.avm_alu_u16_r4) << ","
+           << field_to_string(row.avm_alu_u16_r5) << "," << field_to_string(row.avm_alu_u16_r6) << ","
+           << field_to_string(row.avm_alu_u16_r7) << "," << field_to_string(row.avm_alu_u16_r8) << ","
+           << field_to_string(row.avm_alu_u16_r9) << "," << field_to_string(row.avm_alu_u16_tag) << ","
+           << field_to_string(row.avm_alu_u32_tag) << "," << field_to_string(row.avm_alu_u64_tag) << ","
+           << field_to_string(row.avm_alu_u8_r0) << "," << field_to_string(row.avm_alu_u8_r1) << ","
+           << field_to_string(row.avm_alu_u8_tag) << "," << field_to_string(row.avm_binary_acc_ia) << ","
+           << field_to_string(row.avm_binary_acc_ib) << "," << field_to_string(row.avm_binary_acc_ic) << ","
+           << field_to_string(row.avm_binary_bin_sel) << "," << field_to_string(row.avm_binary_clk) << ","
+           << field_to_string(row.avm_binary_ia_bytes) << "," << field_to_string(row.avm_binary_ib_bytes) << ","
+           << field_to_string(row.avm_binary_ic_bytes) << "," << field_to_string(row.avm_binary_in_tag) << ","
+           << field_to_string(row.avm_binary_mem_tag_ctr) << "," << field_to_string(row.avm_binary_mem_tag_ctr_inv)
+           << "," << field_to_string(row.avm_binary_op_id) << "," << field_to_string(row.avm_binary_start) << ","
+           << field_to_string(row.avm_byte_lookup_bin_sel) << ","
+           << field_to_string(row.avm_byte_lookup_table_byte_lengths) << ","
+           << field_to_string(row.avm_byte_lookup_table_in_tags) << ","
+           << field_to_string(row.avm_byte_lookup_table_input_a) << ","
+           << field_to_string(row.avm_byte_lookup_table_input_b) << ","
+           << field_to_string(row.avm_byte_lookup_table_op_id) << ","
+           << field_to_string(row.avm_byte_lookup_table_output) << "," << field_to_string(row.avm_conversion_clk) << ","
+           << field_to_string(row.avm_conversion_input) << "," << field_to_string(row.avm_conversion_num_limbs) << ","
+           << field_to_string(row.avm_conversion_radix) << "," << field_to_string(row.avm_conversion_to_radix_le_sel)
+           << "," << field_to_string(row.avm_gas_da_gas_fixed_table) << "," << field_to_string(row.avm_gas_gas_cost_sel)
+           << "," << field_to_string(row.avm_gas_l2_gas_fixed_table) << "," << field_to_string(row.avm_keccakf1600_clk)
+           << "," << field_to_string(row.avm_keccakf1600_input) << ","
+           << field_to_string(row.avm_keccakf1600_keccakf1600_sel) << "," << field_to_string(row.avm_keccakf1600_output)
+           << "," << field_to_string(row.avm_kernel_emit_l2_to_l1_msg_write_offset) << ","
+           << field_to_string(row.avm_kernel_emit_note_hash_write_offset) << ","
+           << field_to_string(row.avm_kernel_emit_nullifier_write_offset) << ","
+           << field_to_string(row.avm_kernel_emit_unencrypted_log_write_offset) << ","
+           << field_to_string(row.avm_kernel_kernel_in_offset) << ","
+           << field_to_string(row.avm_kernel_kernel_inputs__is_public) << ","
+           << field_to_string(row.avm_kernel_kernel_metadata_out__is_public) << ","
+           << field_to_string(row.avm_kernel_kernel_out_offset) << ","
+           << field_to_string(row.avm_kernel_kernel_side_effect_out__is_public) << ","
+           << field_to_string(row.avm_kernel_kernel_value_out__is_public) << ","
+           << field_to_string(row.avm_kernel_l1_to_l2_msg_exists_write_offset) << ","
+           << field_to_string(row.avm_kernel_note_hash_exist_write_offset) << ","
+           << field_to_string(row.avm_kernel_nullifier_exists_write_offset) << ","
+           << field_to_string(row.avm_kernel_nullifier_non_exists_write_offset) << ","
+           << field_to_string(row.avm_kernel_q_public_input_kernel_add_to_table) << ","
+           << field_to_string(row.avm_kernel_q_public_input_kernel_out_add_to_table) << ","
+           << field_to_string(row.avm_kernel_side_effect_counter) << ","
+           << field_to_string(row.avm_kernel_sload_write_offset) << ","
+           << field_to_string(row.avm_kernel_sstore_write_offset) << "," << field_to_string(row.avm_main_alu_in_tag)
+           << "," << field_to_string(row.avm_main_alu_sel) << "," << field_to_string(row.avm_main_bin_op_id) << ","
+           << field_to_string(row.avm_main_bin_sel) << "," << field_to_string(row.avm_main_call_ptr) << ","
+           << field_to_string(row.avm_main_da_gas_op) << "," << field_to_string(row.avm_main_da_gas_remaining) << ","
+           << field_to_string(row.avm_main_gas_cost_active) << "," << field_to_string(row.avm_main_ia) << ","
+           << field_to_string(row.avm_main_ib) << "," << field_to_string(row.avm_main_ic) << ","
+           << field_to_string(row.avm_main_id) << "," << field_to_string(row.avm_main_id_zero) << ","
+           << field_to_string(row.avm_main_ind_a) << "," << field_to_string(row.avm_main_ind_b) << ","
+           << field_to_string(row.avm_main_ind_c) << "," << field_to_string(row.avm_main_ind_d) << ","
+           << field_to_string(row.avm_main_ind_op_a) << "," << field_to_string(row.avm_main_ind_op_b) << ","
+           << field_to_string(row.avm_main_ind_op_c) << "," << field_to_string(row.avm_main_ind_op_d) << ","
+           << field_to_string(row.avm_main_internal_return_ptr) << "," << field_to_string(row.avm_main_inv) << ","
+           << field_to_string(row.avm_main_l2_gas_op) << "," << field_to_string(row.avm_main_l2_gas_remaining) << ","
+           << field_to_string(row.avm_main_last) << "," << field_to_string(row.avm_main_mem_idx_a) << ","
+           << field_to_string(row.avm_main_mem_idx_b) << "," << field_to_string(row.avm_main_mem_idx_c) << ","
+           << field_to_string(row.avm_main_mem_idx_d) << "," << field_to_string(row.avm_main_mem_op_a) << ","
+           << field_to_string(row.avm_main_mem_op_activate_gas) << "," << field_to_string(row.avm_main_mem_op_b) << ","
+           << field_to_string(row.avm_main_mem_op_c) << "," << field_to_string(row.avm_main_mem_op_d) << ","
+           << field_to_string(row.avm_main_op_err) << "," << field_to_string(row.avm_main_opcode_val) << ","
+           << field_to_string(row.avm_main_pc) << "," << field_to_string(row.avm_main_q_kernel_lookup) << ","
+           << field_to_string(row.avm_main_q_kernel_output_lookup) << "," << field_to_string(row.avm_main_r_in_tag)
+           << "," << field_to_string(row.avm_main_rwa) << "," << field_to_string(row.avm_main_rwb) << ","
+           << field_to_string(row.avm_main_rwc) << "," << field_to_string(row.avm_main_rwd) << ","
+           << field_to_string(row.avm_main_sel_cmov) << "," << field_to_string(row.avm_main_sel_external_call) << ","
+           << field_to_string(row.avm_main_sel_halt) << "," << field_to_string(row.avm_main_sel_internal_call) << ","
+           << field_to_string(row.avm_main_sel_internal_return) << "," << field_to_string(row.avm_main_sel_jump) << ","
+           << field_to_string(row.avm_main_sel_jumpi) << "," << field_to_string(row.avm_main_sel_mov) << ","
+           << field_to_string(row.avm_main_sel_mov_a) << "," << field_to_string(row.avm_main_sel_mov_b) << ","
+           << field_to_string(row.avm_main_sel_op_add) << "," << field_to_string(row.avm_main_sel_op_address) << ","
+           << field_to_string(row.avm_main_sel_op_and) << "," << field_to_string(row.avm_main_sel_op_block_number)
+           << "," << field_to_string(row.avm_main_sel_op_cast) << "," << field_to_string(row.avm_main_sel_op_chain_id)
+           << "," << field_to_string(row.avm_main_sel_op_coinbase) << ","
+           << field_to_string(row.avm_main_sel_op_dagasleft) << "," << field_to_string(row.avm_main_sel_op_div) << ","
+           << field_to_string(row.avm_main_sel_op_emit_l2_to_l1_msg) << ","
+           << field_to_string(row.avm_main_sel_op_emit_note_hash) << ","
+           << field_to_string(row.avm_main_sel_op_emit_nullifier) << ","
+           << field_to_string(row.avm_main_sel_op_emit_unencrypted_log) << ","
+           << field_to_string(row.avm_main_sel_op_eq) << "," << field_to_string(row.avm_main_sel_op_fdiv) << ","
+           << field_to_string(row.avm_main_sel_op_fee_per_da_gas) << ","
+           << field_to_string(row.avm_main_sel_op_fee_per_l2_gas) << ","
+           << field_to_string(row.avm_main_sel_op_get_contract_instance) << ","
+           << field_to_string(row.avm_main_sel_op_keccak) << ","
+           << field_to_string(row.avm_main_sel_op_l1_to_l2_msg_exists) << ","
+           << field_to_string(row.avm_main_sel_op_l2gasleft) << "," << field_to_string(row.avm_main_sel_op_lt) << ","
+           << field_to_string(row.avm_main_sel_op_lte) << "," << field_to_string(row.avm_main_sel_op_mul) << ","
+           << field_to_string(row.avm_main_sel_op_not) << "," << field_to_string(row.avm_main_sel_op_note_hash_exists)
+           << "," << field_to_string(row.avm_main_sel_op_nullifier_exists) << ","
+           << field_to_string(row.avm_main_sel_op_or) << "," << field_to_string(row.avm_main_sel_op_pedersen) << ","
+           << field_to_string(row.avm_main_sel_op_poseidon2) << "," << field_to_string(row.avm_main_sel_op_radix_le)
+           << "," << field_to_string(row.avm_main_sel_op_sender) << "," << field_to_string(row.avm_main_sel_op_sha256)
+           << "," << field_to_string(row.avm_main_sel_op_shl) << "," << field_to_string(row.avm_main_sel_op_shr) << ","
+           << field_to_string(row.avm_main_sel_op_sload) << "," << field_to_string(row.avm_main_sel_op_sstore) << ","
+           << field_to_string(row.avm_main_sel_op_storage_address) << "," << field_to_string(row.avm_main_sel_op_sub)
+           << "," << field_to_string(row.avm_main_sel_op_timestamp) << ","
+           << field_to_string(row.avm_main_sel_op_transaction_fee) << ","
+           << field_to_string(row.avm_main_sel_op_version) << "," << field_to_string(row.avm_main_sel_op_xor) << ","
+           << field_to_string(row.avm_main_sel_rng_16) << "," << field_to_string(row.avm_main_sel_rng_8) << ","
+           << field_to_string(row.avm_main_space_id) << "," << field_to_string(row.avm_main_table_pow_2) << ","
+           << field_to_string(row.avm_main_tag_err) << "," << field_to_string(row.avm_main_w_in_tag) << ","
+           << field_to_string(row.avm_mem_addr) << "," << field_to_string(row.avm_mem_clk) << ","
+           << field_to_string(row.avm_mem_diff_hi) << "," << field_to_string(row.avm_mem_diff_lo) << ","
+           << field_to_string(row.avm_mem_diff_mid) << "," << field_to_string(row.avm_mem_glob_addr) << ","
+           << field_to_string(row.avm_mem_ind_op_a) << "," << field_to_string(row.avm_mem_ind_op_b) << ","
+           << field_to_string(row.avm_mem_ind_op_c) << "," << field_to_string(row.avm_mem_ind_op_d) << ","
+           << field_to_string(row.avm_mem_last) << "," << field_to_string(row.avm_mem_lastAccess) << ","
+           << field_to_string(row.avm_mem_mem_sel) << "," << field_to_string(row.avm_mem_one_min_inv) << ","
+           << field_to_string(row.avm_mem_op_a) << "," << field_to_string(row.avm_mem_op_b) << ","
+           << field_to_string(row.avm_mem_op_c) << "," << field_to_string(row.avm_mem_op_d) << ","
+           << field_to_string(row.avm_mem_r_in_tag) << "," << field_to_string(row.avm_mem_rng_chk_sel) << ","
+           << field_to_string(row.avm_mem_rw) << "," << field_to_string(row.avm_mem_sel_cmov) << ","
+           << field_to_string(row.avm_mem_sel_mov_a) << "," << field_to_string(row.avm_mem_sel_mov_b) << ","
+           << field_to_string(row.avm_mem_skip_check_tag) << "," << field_to_string(row.avm_mem_space_id) << ","
+           << field_to_string(row.avm_mem_tag) << "," << field_to_string(row.avm_mem_tag_err) << ","
+           << field_to_string(row.avm_mem_tsp) << "," << field_to_string(row.avm_mem_val) << ","
+           << field_to_string(row.avm_mem_w_in_tag) << "," << field_to_string(row.avm_pedersen_clk) << ","
+           << field_to_string(row.avm_pedersen_input) << "," << field_to_string(row.avm_pedersen_output) << ","
+           << field_to_string(row.avm_pedersen_pedersen_sel) << "," << field_to_string(row.avm_poseidon2_clk) << ","
+           << field_to_string(row.avm_poseidon2_input) << "," << field_to_string(row.avm_poseidon2_output) << ","
+           << field_to_string(row.avm_poseidon2_poseidon_perm_sel) << "," << field_to_string(row.avm_sha256_clk) << ","
+           << field_to_string(row.avm_sha256_input) << "," << field_to_string(row.avm_sha256_output) << ","
+           << field_to_string(row.avm_sha256_sha256_compression_sel) << "," << field_to_string(row.avm_sha256_state)
+           << "," << field_to_string(row.perm_main_alu) << "," << field_to_string(row.perm_main_bin) << ","
+           << field_to_string(row.perm_main_conv) << "," << field_to_string(row.perm_main_pos2_perm) << ","
+           << field_to_string(row.perm_main_pedersen) << "," << field_to_string(row.perm_main_mem_a) << ","
+           << field_to_string(row.perm_main_mem_b) << "," << field_to_string(row.perm_main_mem_c) << ","
+           << field_to_string(row.perm_main_mem_d) << "," << field_to_string(row.perm_main_mem_ind_a) << ","
+           << field_to_string(row.perm_main_mem_ind_b) << "," << field_to_string(row.perm_main_mem_ind_c) << ","
+           << field_to_string(row.perm_main_mem_ind_d) << "," << field_to_string(row.lookup_byte_lengths) << ","
+           << field_to_string(row.lookup_byte_operations) << "," << field_to_string(row.lookup_opcode_gas) << ","
+           << field_to_string(row.kernel_output_lookup) << "," << field_to_string(row.lookup_into_kernel) << ","
+           << field_to_string(row.incl_main_tag_err) << "," << field_to_string(row.incl_mem_tag_err) << ","
+           << field_to_string(row.lookup_mem_rng_chk_lo) << "," << field_to_string(row.lookup_mem_rng_chk_mid) << ","
+           << field_to_string(row.lookup_mem_rng_chk_hi) << "," << field_to_string(row.lookup_pow_2_0) << ","
+           << field_to_string(row.lookup_pow_2_1) << "," << field_to_string(row.lookup_u8_0) << ","
+           << field_to_string(row.lookup_u8_1) << "," << field_to_string(row.lookup_u16_0) << ","
+           << field_to_string(row.lookup_u16_1) << "," << field_to_string(row.lookup_u16_2) << ","
+           << field_to_string(row.lookup_u16_3) << "," << field_to_string(row.lookup_u16_4) << ","
+           << field_to_string(row.lookup_u16_5) << "," << field_to_string(row.lookup_u16_6) << ","
+           << field_to_string(row.lookup_u16_7) << "," << field_to_string(row.lookup_u16_8) << ","
+           << field_to_string(row.lookup_u16_9) << "," << field_to_string(row.lookup_u16_10) << ","
+           << field_to_string(row.lookup_u16_11) << "," << field_to_string(row.lookup_u16_12) << ","
+           << field_to_string(row.lookup_u16_13) << "," << field_to_string(row.lookup_u16_14) << ","
+           << field_to_string(row.lookup_div_u16_0) << "," << field_to_string(row.lookup_div_u16_1) << ","
+           << field_to_string(row.lookup_div_u16_2) << "," << field_to_string(row.lookup_div_u16_3) << ","
+           << field_to_string(row.lookup_div_u16_4) << "," << field_to_string(row.lookup_div_u16_5) << ","
+           << field_to_string(row.lookup_div_u16_6) << "," << field_to_string(row.lookup_div_u16_7) << ","
+           << field_to_string(row.lookup_byte_lengths_counts) << ","
+           << field_to_string(row.lookup_byte_operations_counts) << "," << field_to_string(row.lookup_opcode_gas_counts)
+           << "," << field_to_string(row.kernel_output_lookup_counts) << ","
+           << field_to_string(row.lookup_into_kernel_counts) << "," << field_to_string(row.incl_main_tag_err_counts)
+           << "," << field_to_string(row.incl_mem_tag_err_counts) << ","
+           << field_to_string(row.lookup_mem_rng_chk_lo_counts) << ","
+           << field_to_string(row.lookup_mem_rng_chk_mid_counts) << ","
+           << field_to_string(row.lookup_mem_rng_chk_hi_counts) << "," << field_to_string(row.lookup_pow_2_0_counts)
+           << "," << field_to_string(row.lookup_pow_2_1_counts) << "," << field_to_string(row.lookup_u8_0_counts) << ","
+           << field_to_string(row.lookup_u8_1_counts) << "," << field_to_string(row.lookup_u16_0_counts) << ","
+           << field_to_string(row.lookup_u16_1_counts) << "," << field_to_string(row.lookup_u16_2_counts) << ","
+           << field_to_string(row.lookup_u16_3_counts) << "," << field_to_string(row.lookup_u16_4_counts) << ","
+           << field_to_string(row.lookup_u16_5_counts) << "," << field_to_string(row.lookup_u16_6_counts) << ","
+           << field_to_string(row.lookup_u16_7_counts) << "," << field_to_string(row.lookup_u16_8_counts) << ","
+           << field_to_string(row.lookup_u16_9_counts) << "," << field_to_string(row.lookup_u16_10_counts) << ","
+           << field_to_string(row.lookup_u16_11_counts) << "," << field_to_string(row.lookup_u16_12_counts) << ","
+           << field_to_string(row.lookup_u16_13_counts) << "," << field_to_string(row.lookup_u16_14_counts) << ","
+           << field_to_string(row.lookup_div_u16_0_counts) << "," << field_to_string(row.lookup_div_u16_1_counts) << ","
+           << field_to_string(row.lookup_div_u16_2_counts) << "," << field_to_string(row.lookup_div_u16_3_counts) << ","
+           << field_to_string(row.lookup_div_u16_4_counts) << "," << field_to_string(row.lookup_div_u16_5_counts) << ","
+           << field_to_string(row.lookup_div_u16_6_counts) << "," << field_to_string(row.lookup_div_u16_7_counts) << ","
+           << field_to_string(row.avm_alu_a_hi_shift) << "," << field_to_string(row.avm_alu_a_lo_shift) << ","
+           << field_to_string(row.avm_alu_alu_sel_shift) << "," << field_to_string(row.avm_alu_b_hi_shift) << ","
+           << field_to_string(row.avm_alu_b_lo_shift) << "," << field_to_string(row.avm_alu_cmp_rng_ctr_shift) << ","
+           << field_to_string(row.avm_alu_cmp_sel_shift) << ","
+           << field_to_string(row.avm_alu_div_rng_chk_selector_shift) << ","
+           << field_to_string(row.avm_alu_div_u16_r0_shift) << "," << field_to_string(row.avm_alu_div_u16_r1_shift)
+           << "," << field_to_string(row.avm_alu_div_u16_r2_shift) << ","
+           << field_to_string(row.avm_alu_div_u16_r3_shift) << "," << field_to_string(row.avm_alu_div_u16_r4_shift)
+           << "," << field_to_string(row.avm_alu_div_u16_r5_shift) << ","
+           << field_to_string(row.avm_alu_div_u16_r6_shift) << "," << field_to_string(row.avm_alu_div_u16_r7_shift)
+           << "," << field_to_string(row.avm_alu_op_add_shift) << "," << field_to_string(row.avm_alu_op_cast_prev_shift)
+           << "," << field_to_string(row.avm_alu_op_cast_shift) << "," << field_to_string(row.avm_alu_op_div_shift)
+           << "," << field_to_string(row.avm_alu_op_mul_shift) << "," << field_to_string(row.avm_alu_op_shl_shift)
+           << "," << field_to_string(row.avm_alu_op_shr_shift) << "," << field_to_string(row.avm_alu_op_sub_shift)
+           << "," << field_to_string(row.avm_alu_p_sub_a_hi_shift) << ","
+           << field_to_string(row.avm_alu_p_sub_a_lo_shift) << "," << field_to_string(row.avm_alu_p_sub_b_hi_shift)
+           << "," << field_to_string(row.avm_alu_p_sub_b_lo_shift) << ","
+           << field_to_string(row.avm_alu_rng_chk_lookup_selector_shift) << ","
+           << field_to_string(row.avm_alu_rng_chk_sel_shift) << "," << field_to_string(row.avm_alu_u16_r0_shift) << ","
+           << field_to_string(row.avm_alu_u16_r1_shift) << "," << field_to_string(row.avm_alu_u16_r2_shift) << ","
+           << field_to_string(row.avm_alu_u16_r3_shift) << "," << field_to_string(row.avm_alu_u16_r4_shift) << ","
+           << field_to_string(row.avm_alu_u16_r5_shift) << "," << field_to_string(row.avm_alu_u16_r6_shift) << ","
+           << field_to_string(row.avm_alu_u8_r0_shift) << "," << field_to_string(row.avm_alu_u8_r1_shift) << ","
+           << field_to_string(row.avm_binary_acc_ia_shift) << "," << field_to_string(row.avm_binary_acc_ib_shift) << ","
+           << field_to_string(row.avm_binary_acc_ic_shift) << "," << field_to_string(row.avm_binary_mem_tag_ctr_shift)
+           << "," << field_to_string(row.avm_binary_op_id_shift) << ","
+           << field_to_string(row.avm_kernel_emit_l2_to_l1_msg_write_offset_shift) << ","
+           << field_to_string(row.avm_kernel_emit_note_hash_write_offset_shift) << ","
+           << field_to_string(row.avm_kernel_emit_nullifier_write_offset_shift) << ","
+           << field_to_string(row.avm_kernel_emit_unencrypted_log_write_offset_shift) << ","
+           << field_to_string(row.avm_kernel_l1_to_l2_msg_exists_write_offset_shift) << ","
+           << field_to_string(row.avm_kernel_note_hash_exist_write_offset_shift) << ","
+           << field_to_string(row.avm_kernel_nullifier_exists_write_offset_shift) << ","
+           << field_to_string(row.avm_kernel_nullifier_non_exists_write_offset_shift) << ","
+           << field_to_string(row.avm_kernel_side_effect_counter_shift) << ","
+           << field_to_string(row.avm_kernel_sload_write_offset_shift) << ","
+           << field_to_string(row.avm_kernel_sstore_write_offset_shift) << ","
+           << field_to_string(row.avm_main_da_gas_remaining_shift) << ","
+           << field_to_string(row.avm_main_internal_return_ptr_shift) << ","
+           << field_to_string(row.avm_main_l2_gas_remaining_shift) << "," << field_to_string(row.avm_main_pc_shift)
+           << "," << field_to_string(row.avm_mem_glob_addr_shift) << "," << field_to_string(row.avm_mem_mem_sel_shift)
+           << "," << field_to_string(row.avm_mem_rw_shift) << "," << field_to_string(row.avm_mem_tag_shift) << ","
+           << field_to_string(row.avm_mem_tsp_shift) << "," << field_to_string(row.avm_mem_val_shift)
+           << ","
+              "";
+}
+
+// Explicit template instantiation.
+template std::ostream& operator<<(std::ostream& os, AvmFullRow<bb::AvmFlavor::FF> const& row);
+template std::vector<std::string> AvmFullRow<bb::AvmFlavor::FF>::names();
+
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.hpp
@@ -517,7 +517,11 @@ template <typename FF> struct AvmFullRow {
     FF avm_mem_tag_shift{};
     FF avm_mem_tsp_shift{};
     FF avm_mem_val_shift{};
+
+    [[maybe_unused]] static std::vector<std::string> names();
 };
+
+template <typename FF> std::ostream& operator<<(std::ostream& os, AvmFullRow<FF> const& row);
 
 class AvmCircuitBuilder {
   public:

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_flavor.hpp
@@ -1,6 +1,6 @@
 
-
 #pragma once
+
 #include "barretenberg/commitment_schemes/kzg/kzg.hpp"
 #include "barretenberg/ecc/curves/bn254/g1.hpp"
 #include "barretenberg/flavor/relation_definitions.hpp"

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_verifier.cpp
@@ -757,7 +757,7 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
     }
 
     FF avm_kernel_kernel_metadata_out__is_public_evaluation =
-        evaluate_public_input_column(public_inputs[1], circuit_size, multivariate_challenge);
+        evaluate_public_input_column(public_inputs[3], circuit_size, multivariate_challenge);
     if (avm_kernel_kernel_metadata_out__is_public_evaluation !=
         claimed_evaluations.avm_kernel_kernel_metadata_out__is_public) {
         return false;
@@ -771,7 +771,7 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
     }
 
     FF avm_kernel_kernel_value_out__is_public_evaluation =
-        evaluate_public_input_column(public_inputs[3], circuit_size, multivariate_challenge);
+        evaluate_public_input_column(public_inputs[1], circuit_size, multivariate_challenge);
     if (avm_kernel_kernel_value_out__is_public_evaluation !=
         claimed_evaluations.avm_kernel_kernel_value_out__is_public) {
         return false;

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_verifier.cpp
@@ -757,7 +757,7 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
     }
 
     FF avm_kernel_kernel_metadata_out__is_public_evaluation =
-        evaluate_public_input_column(public_inputs[3], circuit_size, multivariate_challenge);
+        evaluate_public_input_column(public_inputs[1], circuit_size, multivariate_challenge);
     if (avm_kernel_kernel_metadata_out__is_public_evaluation !=
         claimed_evaluations.avm_kernel_kernel_metadata_out__is_public) {
         return false;
@@ -771,7 +771,7 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
     }
 
     FF avm_kernel_kernel_value_out__is_public_evaluation =
-        evaluate_public_input_column(public_inputs[1], circuit_size, multivariate_challenge);
+        evaluate_public_input_column(public_inputs[3], circuit_size, multivariate_challenge);
     if (avm_kernel_kernel_value_out__is_public_evaluation !=
         claimed_evaluations.avm_kernel_kernel_value_out__is_public) {
         return false;

--- a/yarn-project/bb-prover/src/avm_proving.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving.test.ts
@@ -52,7 +52,7 @@ import { SerializableContractInstance } from '../../types/src/contracts/contract
 import { type BBSuccess, BB_RESULT, generateAvmProof, verifyAvmProof } from './bb/execute.js';
 import { extractVkData } from './verification_key/verification_key_data.js';
 
-const TIMEOUT = 30_000;
+const TIMEOUT = 60_000;
 const TIMESTAMP = new Fr(99833);
 
 describe('AVM WitGen, proof generation and verification', () => {


### PR DESCRIPTION
Now if you pass `--avm-dump-trace /tmp/trace.csv` you'll get a dump of the whole trace.

You will also get extra debug logs _on debug builds_ once https://github.com/AztecProtocol/aztec-packages/issues/6978 is fixed.