### PR TITLE
chore: sync external contributions

### DIFF
--- a/yarn-project/foundation/src/timer/timer.ts
+++ b/yarn-project/foundation/src/timer/timer.ts
@@ -14,7 +14,7 @@ export class Timer {
   private start: number;
 
   constructor() {
-    this.start = performance.now();
+    this.start = performance ? performance.now() : Date.now();
   }
 
   /**
@@ -32,7 +32,7 @@ export class Timer {
    * @returns The elapsed time in milliseconds.
    */
   public ms() {
-    return performance.now() - this.start;
+    return (performance ? performance.now() : Date.now()) - this.start;
   }
 
   /**


### PR DESCRIPTION
This is a workaround for CI not triggering secrets on external PRs. In the future we should perhaps automate this.

Features:
```
fix: Use Date.now() in case performance.now() is undefined (https://github.com/AztecProtocol/aztec-packages/pull/6982)
It seems like `performance.now()` used in `foundation/timer.ts` isn't
supported in specific environment, such as certain browser extension
apps, web workers, embedded browsers, etc... In my case, Metamask's Snap
server app doesn't support it, causing an error in initiating a
transaction. I [patched
it](https://github.com/porco-rosso-j/aztec-snap/tree/0.41.0/patches) but
thought it'd be good to add the fix here as other developers might face
it.

<img width="590" alt="Screenshot 2024-06-08 at 20 09 39"
src="https://github.com/AztecProtocol/aztec-packages/assets/88586592/fdc8ddae-f7f9-4161-9cd4-e87357f4bed3">

This PR doesn't replace `performance.now()` but lets Timer class's
methods switch to use `Date.now()` when `peformance` is undefined.
```