### PR TITLE
refactor: split log emission to encrypt and a log, remove address input

### DIFF
--- a/noir-projects/aztec-nr/address-note/src/address_note.nr
+++ b/noir-projects/aztec-nr/address-note/src/address_note.nr
@@ -47,7 +47,6 @@ impl NoteInterface<ADDRESS_NOTE_LEN, ADDRESS_NOTE_BYTES_LEN> for AddressNote {
     fn broadcast(self, context: &mut PrivateContext, slot: Field, ovpk_m: GrumpkinPoint, ivpk_m: GrumpkinPoint) {
         // docs:start:encrypted
         context.encrypt_and_emit_note(
-            (*context).this_address(),
             slot,
             ovpk_m,
             ivpk_m,

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -333,10 +333,10 @@ impl PrivateContext {
             preimage
         );
 
-        self.emit_raw_log_with_masked_address(randomness, encrypted_log);
+        self.emit_raw_event_log_with_masked_address(randomness, encrypted_log);
     }
 
-    pub fn emit_raw_log_with_masked_address<M>(
+    pub fn emit_raw_event_log_with_masked_address<M>(
         &mut self,
         randomness: Field,
         encrypted_log: [u8; M]
@@ -370,20 +370,11 @@ impl PrivateContext {
         let contract_address = self.this_address();
         let ovsk_app = self.request_ovsk_app(ovpk_m.hash());
 
-        // Current unoptimized size of the encrypted log
-        // incoming_tag (32 bytes)
-        // outgoing_tag (32 bytes)
-        // eph_pk (64 bytes)
-        // incoming_header (48 bytes)
-        // outgoing_header (48 bytes)
-        // outgoing_body (176 bytes)
-        // incoming_body_fixed (64 bytes)
-        // incoming_body_variable (N * 32 bytes + 16 bytes padding) 
         let encrypted_log: [u8; M] = compute_encrypted_note_log(contract_address, storage_slot, ovsk_app, ovpk_m, ivpk_m, note);
-        self.emit_raw_log(note_hash_counter, encrypted_log);
+        self.emit_raw_note_log(note_hash_counter, encrypted_log);
     }
 
-    pub fn emit_raw_log<M>(&mut self, note_hash_counter: u32, encrypted_log: [u8; M]) {
+    pub fn emit_raw_note_log<M>(&mut self, note_hash_counter: u32, encrypted_log: [u8; M]) {
         let counter = self.next_counter();
         let len = encrypted_log.len() as Field + 4;
         let log_hash = sha256_to_field(encrypted_log);

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -313,7 +313,6 @@ impl PrivateContext {
     // used in siloing later on e.g. 'handshaking' contract w/ known address.
     pub fn encrypt_and_emit_event<N, M>(
         &mut self,
-        contract_address: AztecAddress,
         randomness: Field, // Secret random value used later for masked_contract_address
         event_type_id: Field,
         ovpk_m: GrumpkinPoint,
@@ -321,9 +320,9 @@ impl PrivateContext {
         preimage: [Field; N]
     ) where [Field; N]: LensForEncryptedLog<N, M> {
         let ovsk_app = self.request_ovsk_app(ovpk_m.hash());
+        let contract_address = self.this_address();
 
         // We are currently just encrypting it unconstrained, but otherwise the same way as if it was a note.
-        let counter = self.next_counter();
         let encrypted_log: [u8; M] = compute_encrypted_event_log(
             contract_address,
             randomness,
@@ -333,16 +332,27 @@ impl PrivateContext {
             ivpk_m,
             preimage
         );
-        emit_encrypted_event_log(contract_address, randomness, encrypted_log, counter);
-        let len = 32 + 32 + 64 + 48 + 48 + 176 + 64 + (preimage.len() as Field * 32) + 16 + 4;
+
+        self.emit_raw_log_with_masked_address(randomness, encrypted_log);
+    }
+
+    pub fn emit_raw_log_with_masked_address<M>(
+        &mut self,
+        randomness: Field,
+        encrypted_log: [u8; M]
+    ) {
+        let counter = self.next_counter();
+        let contract_address = self.this_address();
+        let len = encrypted_log.len() as Field + 4;
         let log_hash = sha256_to_field(encrypted_log);
         let side_effect = EncryptedLogHash { value: log_hash, counter, length: len, randomness };
         self.encrypted_logs_hashes.push(side_effect);
+
+        emit_encrypted_event_log(contract_address, randomness, encrypted_log, counter);
     }
 
     pub fn encrypt_and_emit_note<Note, N, NB, M>(
         &mut self,
-        contract_address: AztecAddress,
         storage_slot: Field,
         ovpk_m: GrumpkinPoint,
         ivpk_m: GrumpkinPoint,
@@ -357,8 +367,7 @@ impl PrivateContext {
             note_exists_index as u32 != MAX_NEW_NOTE_HASHES_PER_CALL, "Can only emit a note log for an existing note."
         );
 
-        let counter = self.next_counter();
-
+        let contract_address = self.this_address();
         let ovsk_app = self.request_ovsk_app(ovpk_m.hash());
 
         // Current unoptimized size of the encrypted log
@@ -371,14 +380,17 @@ impl PrivateContext {
         // incoming_body_fixed (64 bytes)
         // incoming_body_variable (N * 32 bytes + 16 bytes padding) 
         let encrypted_log: [u8; M] = compute_encrypted_note_log(contract_address, storage_slot, ovsk_app, ovpk_m, ivpk_m, note);
-        emit_encrypted_note_log(note_hash_counter, encrypted_log, counter);
+        self.emit_raw_log(note_hash_counter, encrypted_log);
+    }
 
-        // len of processed log (4 bytes)
+    pub fn emit_raw_log<M>(&mut self, note_hash_counter: u32, encrypted_log: [u8; M]) {
+        let counter = self.next_counter();
         let len = encrypted_log.len() as Field + 4;
-
         let log_hash = sha256_to_field(encrypted_log);
         let side_effect = NoteLogHash { value: log_hash, counter, length: len, note_hash_counter };
         self.note_encrypted_logs_hashes.push(side_effect);
+
+        emit_encrypted_note_log(note_hash_counter, encrypted_log, counter);
     }
 
     pub fn call_private_function<ARGS_COUNT>(

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
@@ -59,6 +59,15 @@ pub fn compute_encrypted_note_log<Note, N, NB, M>(
         encrypted_bytes[400 + i] = incoming_body_ciphertext[i];
     }
 
+    // Current unoptimized size of the encrypted log
+    // incoming_tag (32 bytes)
+    // outgoing_tag (32 bytes)
+    // eph_pk (64 bytes)
+    // incoming_header (48 bytes)
+    // outgoing_header (48 bytes)
+    // outgoing_body (176 bytes)
+    // incoming_body_fixed (64 bytes)
+    // incoming_body_variable (N * 32 bytes + 16 bytes padding)
     encrypted_bytes
 }
 

--- a/noir-projects/aztec-nr/value-note/src/value_note.nr
+++ b/noir-projects/aztec-nr/value-note/src/value_note.nr
@@ -49,7 +49,6 @@ impl NoteInterface<VALUE_NOTE_LEN, VALUE_NOTE_BYTES_LEN> for ValueNote {
     // Broadcasts the note as an encrypted log on L1.
     fn broadcast(self, context: &mut PrivateContext, slot: Field, ovpk_m: GrumpkinPoint, ivpk_m: GrumpkinPoint) {
         context.encrypt_and_emit_note(
-            (*context).this_address(),
             slot,
             ovpk_m,
             ivpk_m,

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/subscription_note.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/subscription_note.nr
@@ -42,7 +42,6 @@ impl NoteInterface<SUBSCRIPTION_NOTE_LEN, SUBSCRIPTION_NOTE_BYTES_LEN> for Subsc
     // Broadcasts the note as an encrypted log on L1.
     fn broadcast(self, context: &mut PrivateContext, slot: Field, ovpk_m: GrumpkinPoint, ivpk_m: GrumpkinPoint) {
         context.encrypt_and_emit_note(
-            (*context).this_address(),
             slot,
             ovpk_m,
             ivpk_m,

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/types/card_note.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/types/card_note.nr
@@ -53,7 +53,6 @@ impl NoteInterface<CARD_NOTE_LEN, CARD_NOTE_BYTES_LEN> for CardNote {
     // Broadcasts the note as an encrypted log on L1.
     fn broadcast(self, context: &mut PrivateContext, slot: Field, ovpk_m: GrumpkinPoint, ivpk_m: GrumpkinPoint) {
         context.encrypt_and_emit_note(
-            (*context).this_address(),
             slot,
             ovpk_m,
             ivpk_m,

--- a/noir-projects/noir-contracts/contracts/ecdsa_account_contract/src/ecdsa_public_key_note.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_account_contract/src/ecdsa_public_key_note.nr
@@ -88,7 +88,6 @@ impl NoteInterface<ECDSA_PUBLIC_KEY_NOTE_LEN, ECDSA_PUBLIC_KEY_NOTE_BYTES_LEN> f
     // Broadcasts the note as an encrypted log on L1.
     fn broadcast(self, context: &mut PrivateContext, slot: Field, ovpk_m: GrumpkinPoint, ivpk_m: GrumpkinPoint) {
         context.encrypt_and_emit_note(
-            (*context).this_address(),
             slot,
             ovpk_m,
             ivpk_m,

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
@@ -136,7 +136,6 @@ contract PendingNoteHashes {
 
         // Emit note again
         context.encrypt_and_emit_note(
-            context.this_address(),
             note.get_header().storage_slot,
             outgoing_viewer_ovpk_m,
             owner_ivpk_m,
@@ -369,7 +368,6 @@ contract PendingNoteHashes {
         bad_note.set_header(existing_note_header);
 
         context.encrypt_and_emit_note(
-            context.this_address(),
             existing_note_header.storage_slot,
             outgoing_viewer_ovpk_m,
             owner_ivpk_m,

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/public_key_note.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/public_key_note.nr
@@ -42,7 +42,6 @@ impl NoteInterface<PUBLIC_KEY_NOTE_LEN, PUBLIC_KEY_NOTE_BYTES_LEN> for PublicKey
     // Broadcasts the note as an encrypted log on L1.
     fn broadcast(self, context: &mut PrivateContext, slot: Field, ovpk_m: GrumpkinPoint, ivpk_m: GrumpkinPoint) {
         context.encrypt_and_emit_note(
-            (*context).this_address(),
             slot,
             ovpk_m,
             ivpk_m,

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -270,7 +270,6 @@ contract Test {
         let outgoing_viewer_ovpk_m = header.get_ovpk_m(&mut context, outgoing_viewer);
         let owner_ivpk_m = header.get_ivpk_m(&mut context, owner);
         context.encrypt_and_emit_event(
-            context.this_address(),
             5, // testing only - this should be a secret random value to salt the addr
             1,
             outgoing_viewer_ovpk_m,
@@ -282,7 +281,6 @@ contract Test {
         if nest {
             Test::at(context.this_address()).emit_array_as_encrypted_log([0, 0, 0, 0, 0], owner, outgoing_viewer, false).call(&mut context);
             context.encrypt_and_emit_event(
-                context.this_address(),
                 0, // testing only - this signals to the kerels to not mask the address
                 1,
                 outgoing_viewer_ovpk_m,

--- a/noir-projects/noir-contracts/contracts/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_log_contract/src/main.nr
@@ -93,7 +93,6 @@ contract TestLog {
         let msg_sender_ovpk_m = header.get_ovpk_m(&mut context, context.msg_sender());
 
         context.encrypt_and_emit_event(
-            context.this_address(),
             randomness,
             event_type_id,
             msg_sender_ovpk_m,
@@ -109,7 +108,6 @@ contract TestLog {
         let msg_sender_ovpk_m = header.get_ovpk_m(&mut context, context.msg_sender());
 
         context.encrypt_and_emit_event(
-            context.this_address(),
             randomness[0],
             ExampleEvent0::selector().to_field(),
             msg_sender_ovpk_m,
@@ -118,7 +116,6 @@ contract TestLog {
         );
 
         context.encrypt_and_emit_event(
-            context.this_address(),
             randomness[1],
             ExampleEvent1::selector().to_field(),
             msg_sender_ovpk_m,

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/token_note.nr
@@ -54,7 +54,6 @@ impl NoteInterface<TOKEN_NOTE_LEN, TOKEN_NOTE_BYTES_LEN> for TokenNote {
       // TODO: (#5901) This will be changed a lot, as it should use the updated encrypted log format
       if !(self.amount == U128::from_integer(0)) {
           context.encrypt_and_emit_note(
-              (*context).this_address(),
               slot,
               ovpk_m,
               ivpk_m,

--- a/noir-projects/noir-contracts/contracts/token_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/types/token_note.nr
@@ -54,7 +54,6 @@ impl NoteInterface<TOKEN_NOTE_LEN, TOKEN_NOTE_BYTES_LEN> for TokenNote {
       // TODO: (#5901) This will be changed a lot, as it should use the updated encrypted log format
       if !(self.amount == U128::from_integer(0)) {
           context.encrypt_and_emit_note(
-              (*context).this_address(),
               slot,
               ovpk_m,
               ivpk_m,


### PR DESCRIPTION
Removes the `contract_address` input from the context emission functions as it is always the contract itself if honest, so can just as well be auto populated for less error.

Split the log emission into two variants, namely one that is just emitting whatever passed, and another that is encrypting first. This is to make it straight forward to encrypt with a different scheme if desired.