### PR TITLE
feat(avm): support preserving BB working dir for better debugging

### DIFF
--- a/yarn-project/bb-prover/src/prover/bb_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_prover.ts
@@ -464,7 +464,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
   private async generateAvmProofWithBB(input: AvmCircuitInputs, workingDirectory: string): Promise<BBSuccess> {
     logger.debug(`Proving avm-circuit...`);
 
-    const provingResult = await generateAvmProof(this.config.bbBinaryPath, workingDirectory, input, logger.debug);
+    const provingResult = await generateAvmProof(this.config.bbBinaryPath, workingDirectory, input, logger.verbose);
 
     if (provingResult.status === BB_RESULT.FAILURE) {
       logger.error(`Failed to generate proof for avm-circuit: ${provingResult.reason}`);
@@ -475,7 +475,11 @@ export class BBNativeRollupProver implements ServerCircuitProver {
   }
 
   private async createAvmProof(input: AvmCircuitInputs): Promise<ProofAndVerificationKey> {
+    const cleanupDir: boolean = !process.env.AVM_PROVING_PRESERVE_WORKING_DIR;
     const operation = async (bbWorkingDirectory: string): Promise<ProofAndVerificationKey> => {
+      if (!cleanupDir) {
+        logger.info(`Preserving working directory ${bbWorkingDirectory}`);
+      }
       const provingResult = await this.generateAvmProofWithBB(input, bbWorkingDirectory);
 
       const rawProof = await fs.readFile(provingResult.proofPath!);
@@ -503,7 +507,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
 
       return { proof, verificationKey };
     };
-    return await runInDirectory(this.config.bbWorkingDirectory, operation);
+    return await runInDirectory(this.config.bbWorkingDirectory, operation, cleanupDir);
   }
 
   /**

--- a/yarn-project/foundation/src/fs/run_in_dir.ts
+++ b/yarn-project/foundation/src/fs/run_in_dir.ts
@@ -1,18 +1,23 @@
-import { randomBytes } from 'crypto';
 import * as fs from 'fs/promises';
+import * as path from 'path';
 
 // Create a random directory underneath a 'base' directory
 // Calls a provided method, ensures the random directory is cleaned up afterwards
-export async function runInDirectory<T>(workingDirBase: string, fn: (dir: string) => Promise<T>): Promise<T> {
+export async function runInDirectory<T>(
+  workingDirBase: string,
+  fn: (dir: string) => Promise<T>,
+  cleanup: boolean = true,
+): Promise<T> {
   // Create random directory to be used for temp files
-  const workingDirectory = `${workingDirBase}/${randomBytes(8).toString('hex')}`;
-  await fs.mkdir(workingDirectory, { recursive: true });
+  const workingDirectory = await fs.mkdtemp(path.join(workingDirBase, 'tmp-'));
 
   await fs.access(workingDirectory);
 
   try {
     return await fn(workingDirectory);
   } finally {
-    await fs.rm(workingDirectory, { recursive: true, force: true });
+    if (cleanup) {
+      await fs.rm(workingDirectory, { recursive: true, force: true });
+    }
   }
 }


### PR DESCRIPTION
`AVM_PROVING_PRESERVE_WORKING_DIR=1 yarn test src/e2e_prover/full.test.ts`

will now preserve the working dir, so that later you can just run the bb command

```
  bb-prover INFO Preserving working directory /tmp/bb-XXgzVD/tmp-WrMwBo
  bb-prover AvmCircuit (prove) BB out - Executing BB with: avm_prove --avm-bytecode /tmp/bb-XXgzVD/tmp-WrMwBo/avm_bytecode.bin --avm-calldata /tmp/bb-XXgzVD/tmp-WrMwBo/avm_calldata.bin --avm-public-inputs /tmp/bb-XXgzVD/tmp-WrMwBo/avm_public_inputs.bin --avm-hints /tmp/bb-XXgzVD/tmp-WrMwBo/avm_hints.bin -o /tmp/bb-XXgzVD/tmp-WrMwBo
  bb-prover AvmCircuit (prove) BB out - terminate called after throwing an instance of 'std::out_of_range'
  what():  unordered_map::at
  bb-prover ERROR Failed to generate proof for avm-circuit: Failed to generate proof. Exit code null. Signal SIGABRT.
```
