### PR TITLE
chore: lookups cleanup/documentation

### DIFF
--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
@@ -25,7 +25,7 @@ template <typename Builder> bool UltraCircuitChecker::check(const Builder& build
     LookupHashTable lookup_hash_table;
     for (const auto& table : builder.lookup_tables) {
         const FF table_index(table.table_index);
-        for (size_t i = 0; i < table.size; ++i) {
+        for (size_t i = 0; i < table.size(); ++i) {
             lookup_hash_table.insert({ table.column_1[i], table.column_2[i], table.column_3[i], table_index });
         }
     }

--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/composer/composer_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/composer/composer_lib.hpp
@@ -26,7 +26,7 @@ void construct_lookup_table_polynomials(RefArray<typename Flavor::Polynomial, 4>
     for (const auto& table : circuit.lookup_tables) {
         const fr table_index(table.table_index);
 
-        for (size_t i = 0; i < table.size; ++i) {
+        for (size_t i = 0; i < table.size(); ++i) {
             table_polynomials[0][offset] = table.column_1[i];
             table_polynomials[1][offset] = table.column_2[i];
             table_polynomials[2][offset] = table.column_3[i];
@@ -67,7 +67,7 @@ std::array<typename Flavor::Polynomial, 4> construct_sorted_list_polynomials(typ
     for (auto& table : circuit.lookup_tables) {
         const fr table_index(table.table_index);
         auto& lookup_gates = table.lookup_gates;
-        for (size_t i = 0; i < table.size; ++i) {
+        for (size_t i = 0; i < table.size(); ++i) {
             if (table.use_twin_keys) {
                 lookup_gates.push_back({
                     {

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
@@ -126,7 +126,7 @@ field_t<Builder> keccak<Builder>::normalize_and_rotate(const field_ct& limb, fie
             // We need to provide a key/value object for this lookup in order for the Builder
             // to compute the plookup sorted list commitment
             const auto [input_quotient, input_slice] = input.divmod(divisor);
-            lookup.key_entries.push_back(
+            lookup.lookup_entries.push_back(
                 { { static_cast<uint64_t>(input_slice), 0 }, { normalized_slice, normalized_msb } });
 
             // reduce the input and output by 11^{bit_slice}

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/plookup/plookup.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/plookup/plookup.cpp
@@ -77,7 +77,7 @@ field_t<Builder> plookup_read<Builder>::read_from_2_to_1_table(const MultiTableI
                                                                const field_t<Builder>& key_a,
                                                                const field_t<Builder>& key_b)
 {
-    const auto lookup = get_lookup_accumulators(id, key_a, key_b, true);
+    const auto lookup = get_lookup_accumulators(id, key_a, key_b, /*is_2_to_1_lookup=*/true);
 
     return lookup[ColumnIdx::C3][0];
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/aes128.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/aes128.hpp
@@ -25,9 +25,9 @@ inline BasicTable generate_aes_sparse_table(BasicTableId id, const size_t table_
     BasicTable table;
     table.id = id;
     table.table_index = table_index;
-    table.size = 256;
+    size_t table_size = 256;
     table.use_twin_keys = true;
-    for (uint64_t i = 0; i < table.size; ++i) {
+    for (uint64_t i = 0; i < table_size; ++i) {
         uint64_t left = i;
         const auto right = numeric::map_into_sparse_form<AES_BASE>((uint8_t)i);
         table.column_1.emplace_back(bb::fr(left));
@@ -74,7 +74,6 @@ inline BasicTable generate_aes_sparse_normalization_table(BasicTableId id, const
             }
         }
     }
-    table.size = table.column_1.size();
     table.use_twin_keys = false;
     table.get_values_from_key = &get_aes_sparse_normalization_values_from_key;
 
@@ -137,9 +136,9 @@ inline BasicTable generate_aes_sbox_table(BasicTableId id, const size_t table_in
     BasicTable table;
     table.id = id;
     table.table_index = table_index;
-    table.size = 256;
+    size_t table_size = 256;
     table.use_twin_keys = false;
-    for (uint64_t i = 0; i < table.size; ++i) {
+    for (uint64_t i = 0; i < table_size; ++i) {
         const auto first = numeric::map_into_sparse_form<AES_BASE>((uint8_t)i);
         uint8_t sbox_value = crypto::aes128_sbox[(uint8_t)i];
         uint8_t swizzled = ((uint8_t)(sbox_value << 1) ^ (uint8_t)(((sbox_value >> 7) & 1) * 0x1b));

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/aes128.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/aes128.hpp
@@ -102,7 +102,7 @@ inline MultiTable get_aes_normalization_table(const MultiTableId id = AES_NORMAL
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(AES_BASE * AES_BASE * AES_BASE * AES_BASE);
-        table.lookup_ids.emplace_back(AES_SPARSE_NORMALIZE);
+        table.basic_table_ids.emplace_back(AES_SPARSE_NORMALIZE);
         table.get_table_values.emplace_back(&get_aes_sparse_normalization_values_from_key);
     }
     return table;
@@ -117,7 +117,7 @@ inline MultiTable get_aes_input_table(const MultiTableId id = AES_INPUT)
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(256);
-        table.lookup_ids.emplace_back(AES_SPARSE_MAP);
+        table.basic_table_ids.emplace_back(AES_SPARSE_MAP);
         table.get_table_values.emplace_back(&sparse_tables::get_sparse_table_with_rotation_values<AES_BASE, 0>);
     }
     return table;
@@ -167,7 +167,7 @@ inline MultiTable get_aes_sbox_table(const MultiTableId id = AES_SBOX)
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(numeric::pow64(AES_BASE, 8));
-        table.lookup_ids.emplace_back(AES_SBOX_MAP);
+        table.basic_table_ids.emplace_back(AES_SBOX_MAP);
         table.get_table_values.emplace_back(&get_aes_sbox_values_from_key);
     }
     return table;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/blake2s.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/blake2s.hpp
@@ -35,7 +35,6 @@ inline BasicTable generate_xor_rotate_table(BasicTableId id, const size_t table_
     BasicTable table;
     table.id = id;
     table.table_index = table_index;
-    table.size = base * base;
     table.use_twin_keys = true;
 
     for (uint64_t i = 0; i < base; ++i) {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/blake2s.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/blake2s.hpp
@@ -95,12 +95,12 @@ inline MultiTable get_blake2s_xor_table(const MultiTableId id = BLAKE_XOR)
     table.id = id;
     for (size_t i = 0; i < num_entries - 1; ++i) {
         table.slice_sizes.emplace_back(base);
-        table.lookup_ids.emplace_back(BLAKE_XOR_ROTATE0);
+        table.basic_table_ids.emplace_back(BLAKE_XOR_ROTATE0);
         table.get_table_values.emplace_back(&get_xor_rotate_values_from_key<6, 0>);
     }
 
     table.slice_sizes.emplace_back(SIZE_OF_LAST_SLICE);
-    table.lookup_ids.emplace_back(BLAKE_XOR_ROTATE0_SLICE5_MOD4);
+    table.basic_table_ids.emplace_back(BLAKE_XOR_ROTATE0_SLICE5_MOD4);
     table.get_table_values.emplace_back(&get_xor_rotate_values_from_key<BITS_IN_LAST_SLICE, 0, true>);
 
     return table;
@@ -128,8 +128,8 @@ inline MultiTable get_blake2s_xor_rotate_16_table(const MultiTableId id = BLAKE_
 
     table.id = id;
     table.slice_sizes = { base, base, base, base, base, SIZE_OF_LAST_SLICE };
-    table.lookup_ids = { BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE4,
-                         BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE0_SLICE5_MOD4 };
+    table.basic_table_ids = { BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE4,
+                              BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE0_SLICE5_MOD4 };
 
     table.get_table_values.emplace_back(&get_xor_rotate_values_from_key<6, 0>);
     table.get_table_values.emplace_back(&get_xor_rotate_values_from_key<6, 0>);
@@ -163,8 +163,8 @@ inline MultiTable get_blake2s_xor_rotate_8_table(const MultiTableId id = BLAKE_X
 
     table.id = id;
     table.slice_sizes = { base, base, base, base, base, SIZE_OF_LAST_SLICE };
-    table.lookup_ids = { BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE2, BLAKE_XOR_ROTATE0,
-                         BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE0_SLICE5_MOD4 };
+    table.basic_table_ids = { BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE2, BLAKE_XOR_ROTATE0,
+                              BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE0_SLICE5_MOD4 };
 
     table.get_table_values.emplace_back(&get_xor_rotate_values_from_key<6, 0>);
     table.get_table_values.emplace_back(&get_xor_rotate_values_from_key<6, 2>);
@@ -198,8 +198,8 @@ inline MultiTable get_blake2s_xor_rotate_7_table(const MultiTableId id = BLAKE_X
 
     table.id = id;
     table.slice_sizes = { base, base, base, base, base, SIZE_OF_LAST_SLICE };
-    table.lookup_ids = { BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE1, BLAKE_XOR_ROTATE0,
-                         BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE0_SLICE5_MOD4 };
+    table.basic_table_ids = { BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE1, BLAKE_XOR_ROTATE0,
+                              BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE0, BLAKE_XOR_ROTATE0_SLICE5_MOD4 };
 
     table.get_table_values.emplace_back(&get_xor_rotate_values_from_key<6, 0>);
     table.get_table_values.emplace_back(&get_xor_rotate_values_from_key<6, 1>);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/dummy.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/dummy.hpp
@@ -49,7 +49,6 @@ inline BasicTable generate_honk_dummy_table(const BasicTableId id, const size_t 
     BasicTable table;
     table.id = id;
     table.table_index = table_index;
-    table.size = base * base;
     table.use_twin_keys = true;
     for (uint64_t i = 0; i < base; ++i) {
         for (uint64_t j = 0; j < base; ++j) {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/dummy.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/dummy.hpp
@@ -85,10 +85,10 @@ inline MultiTable get_honk_dummy_multitable()
                      number_of_lookups);
     table.id = id;
     table.slice_sizes.emplace_back(number_of_elements_in_argument);
-    table.lookup_ids.emplace_back(HONK_DUMMY_BASIC1);
+    table.basic_table_ids.emplace_back(HONK_DUMMY_BASIC1);
     table.get_table_values.emplace_back(&get_value_from_key<HONK_DUMMY_BASIC1>);
     table.slice_sizes.emplace_back(number_of_elements_in_argument);
-    table.lookup_ids.emplace_back(HONK_DUMMY_BASIC2);
+    table.basic_table_ids.emplace_back(HONK_DUMMY_BASIC2);
     table.get_table_values.emplace_back(&get_value_from_key<HONK_DUMMY_BASIC2>);
     return table;
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/fixed_base/fixed_base.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/fixed_base/fixed_base.cpp
@@ -197,12 +197,11 @@ BasicTable table::generate_basic_fixed_base_table(BasicTableId id, size_t basic_
     BasicTable table;
     table.id = id;
     table.table_index = basic_table_index;
-    table.size = table_size;
     table.use_twin_keys = false;
 
     const auto& basic_table = fixed_base_tables[multitable_index][table_index];
 
-    for (size_t i = 0; i < table.size; ++i) {
+    for (size_t i = 0; i < table_size; ++i) {
         table.column_1.emplace_back(i);
         table.column_2.emplace_back(basic_table[i].x);
         table.column_3.emplace_back(basic_table[i].y);
@@ -213,7 +212,7 @@ BasicTable table::generate_basic_fixed_base_table(BasicTableId id, size_t basic_
     table.get_values_from_key = get_values_from_key_table[multitable_index][table_index];
 
     ASSERT(table.get_values_from_key != nullptr);
-    table.column_1_step_size = table.size;
+    table.column_1_step_size = table_size;
     table.column_2_step_size = 0;
     table.column_3_step_size = 0;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/fixed_base/fixed_base.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/fixed_base/fixed_base.cpp
@@ -243,13 +243,13 @@ template <size_t multitable_index, size_t num_bits> MultiTable table::get_fixed_
     MultiTable table(MAX_TABLE_SIZE, 0, 0, NUM_TABLES);
     table.id = id;
     table.get_table_values.resize(NUM_TABLES);
-    table.lookup_ids.resize(NUM_TABLES);
+    table.basic_table_ids.resize(NUM_TABLES);
     for (size_t i = 0; i < NUM_TABLES; ++i) {
         table.slice_sizes.emplace_back(MAX_TABLE_SIZE);
         table.get_table_values[i] = get_values_from_key_table[multitable_index][i];
         static_assert(multitable_index < NUM_FIXED_BASE_MULTI_TABLES);
         size_t idx = i + static_cast<size_t>(basic_table_ids[multitable_index]);
-        table.lookup_ids[i] = static_cast<plookup::BasicTableId>(idx);
+        table.basic_table_ids[i] = static_cast<plookup::BasicTableId>(idx);
     }
     return table;
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_chi.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_chi.hpp
@@ -169,11 +169,11 @@ class Chi {
         table.id = id;
         table.table_index = table_index;
         table.use_twin_keys = false;
-        table.size = numeric::pow64(static_cast<uint64_t>(EFFECTIVE_BASE), TABLE_BITS);
+        auto table_size = numeric::pow64(static_cast<uint64_t>(EFFECTIVE_BASE), TABLE_BITS);
 
         std::array<size_t, TABLE_BITS> counts{};
         std::array<uint64_t, 3> column_values{ 0, 0, 0 };
-        for (size_t i = 0; i < table.size; ++i) {
+        for (size_t i = 0; i < table_size; ++i) {
             table.column_1.emplace_back(column_values[0]);
             table.column_2.emplace_back(column_values[1]);
             table.column_3.emplace_back(column_values[2]);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_chi.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_chi.hpp
@@ -242,7 +242,7 @@ class Chi {
         table.id = id;
         for (size_t i = 0; i < num_tables_per_multitable; ++i) {
             table.slice_sizes.emplace_back(numeric::pow64(BASE, TABLE_BITS));
-            table.lookup_ids.emplace_back(KECCAK_CHI);
+            table.basic_table_ids.emplace_back(KECCAK_CHI);
             table.get_table_values.emplace_back(&get_chi_renormalization_values);
         }
         return table;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_input.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_input.hpp
@@ -132,7 +132,7 @@ class KeccakInput {
         table.id = id;
         for (size_t i = 0; i < num_entries; ++i) {
             table.slice_sizes.emplace_back(1 << 8);
-            table.lookup_ids.emplace_back(KECCAK_INPUT);
+            table.basic_table_ids.emplace_back(KECCAK_INPUT);
             table.get_table_values.emplace_back(&get_keccak_input_values);
         }
         return table;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_input.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_input.hpp
@@ -57,11 +57,11 @@ class KeccakInput {
         BasicTable table;
         table.id = id;
         table.table_index = table_index;
-        table.size = (1U << TABLE_BITS);
+        auto table_size = (1U << TABLE_BITS);
         table.use_twin_keys = false;
         constexpr size_t msb_shift = (64 % TABLE_BITS == 0) ? TABLE_BITS - 1 : (64 % TABLE_BITS) - 1;
 
-        for (uint64_t i = 0; i < table.size; ++i) {
+        for (uint64_t i = 0; i < table_size; ++i) {
             const uint64_t source = i;
             const auto target = numeric::map_into_sparse_form<BASE>(source);
             table.column_1.emplace_back(bb::fr(source));

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_output.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_output.hpp
@@ -91,12 +91,12 @@ class KeccakOutput {
         table.id = id;
         table.table_index = table_index;
         table.use_twin_keys = false;
-        table.size = numeric::pow64(static_cast<uint64_t>(EFFECTIVE_BASE), TABLE_BITS);
+        auto table_size = numeric::pow64(static_cast<uint64_t>(EFFECTIVE_BASE), TABLE_BITS);
 
         std::array<size_t, TABLE_BITS> counts{};
         std::array<uint64_t, 2> column_values{ 0, 0 };
 
-        for (size_t i = 0; i < table.size; ++i) {
+        for (size_t i = 0; i < table_size; ++i) {
             table.column_1.emplace_back(column_values[0]);
             table.column_2.emplace_back(column_values[1]);
             table.column_3.emplace_back(0);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_output.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_output.hpp
@@ -162,7 +162,7 @@ class KeccakOutput {
         table.id = id;
         for (size_t i = 0; i < num_tables_per_multitable; ++i) {
             table.slice_sizes.emplace_back(numeric::pow64(BASE, TABLE_BITS));
-            table.lookup_ids.emplace_back(KECCAK_OUTPUT);
+            table.basic_table_ids.emplace_back(KECCAK_OUTPUT);
             table.get_table_values.emplace_back(
                 &sparse_tables::get_sparse_normalization_values<BASE, OUTPUT_NORMALIZATION_TABLE>);
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_rho.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_rho.hpp
@@ -170,12 +170,12 @@ template <size_t TABLE_BITS = 0, size_t LANE_INDEX = 0> class Rho {
         table.id = id;
         table.table_index = table_index;
         table.use_twin_keys = false;
-        table.size = numeric::pow64(static_cast<uint64_t>(EFFECTIVE_BASE), TABLE_BITS);
+        auto table_size = numeric::pow64(static_cast<uint64_t>(EFFECTIVE_BASE), TABLE_BITS);
 
         std::array<size_t, TABLE_BITS> counts{};
         std::array<uint64_t, 3> column_values{ 0, 0, 0 };
 
-        for (size_t i = 0; i < table.size; ++i) {
+        for (size_t i = 0; i < table_size; ++i) {
             table.column_1.emplace_back(column_values[0]);
             table.column_2.emplace_back(column_values[1]);
             table.column_3.emplace_back(column_values[2]);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_rho.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_rho.hpp
@@ -264,7 +264,7 @@ template <size_t TABLE_BITS = 0, size_t LANE_INDEX = 0> class Rho {
 
             table.slice_sizes.push_back(scaled_base);
             table.get_table_values.emplace_back(&get_rho_renormalization_values);
-            table.lookup_ids.push_back((BasicTableId)((size_t)KECCAK_RHO_1 + (bit_slice - 1)));
+            table.basic_table_ids.push_back((BasicTableId)((size_t)KECCAK_RHO_1 + (bit_slice - 1)));
         });
 
         // generate table selector values for the 'left' slice
@@ -284,7 +284,7 @@ template <size_t TABLE_BITS = 0, size_t LANE_INDEX = 0> class Rho {
 
             table.slice_sizes.push_back(scaled_base);
             table.get_table_values.emplace_back(&get_rho_renormalization_values);
-            table.lookup_ids.push_back((BasicTableId)((size_t)KECCAK_RHO_1 + (bit_slice - 1)));
+            table.basic_table_ids.push_back((BasicTableId)((size_t)KECCAK_RHO_1 + (bit_slice - 1)));
         });
 
         return table;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_theta.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_theta.hpp
@@ -171,12 +171,12 @@ class Theta {
         table.id = id;
         table.table_index = table_index;
         table.use_twin_keys = false;
-        table.size = numeric::pow64(static_cast<uint64_t>(BASE), TABLE_BITS);
+        auto table_size = numeric::pow64(static_cast<uint64_t>(BASE), TABLE_BITS);
 
         std::array<size_t, TABLE_BITS> counts{};
         std::array<uint64_t, 2> column_values{ 0, 0 };
 
-        for (size_t i = 0; i < table.size; ++i) {
+        for (size_t i = 0; i < table_size; ++i) {
             table.column_1.emplace_back(column_values[0]);
             table.column_2.emplace_back(column_values[1]);
             table.column_3.emplace_back(0);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_theta.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_theta.hpp
@@ -244,7 +244,7 @@ class Theta {
         table.id = id;
         for (size_t i = 0; i < num_tables_per_multitable; ++i) {
             table.slice_sizes.emplace_back(numeric::pow64(BASE, TABLE_BITS));
-            table.lookup_ids.emplace_back(KECCAK_THETA);
+            table.basic_table_ids.emplace_back(KECCAK_THETA);
             table.get_table_values.emplace_back(&get_theta_renormalization_values);
         }
         return table;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/non_native_group_generator.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/non_native_group_generator.cpp
@@ -374,7 +374,7 @@ MultiTable ecc_generator_table<G1>::get_xlo_table(const MultiTableId id, const B
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(512);
-        table.lookup_ids.emplace_back(basic_id);
+        table.basic_table_ids.emplace_back(basic_id);
         table.get_table_values.emplace_back(&get_xlo_values);
     }
     return table;
@@ -389,7 +389,7 @@ MultiTable ecc_generator_table<G1>::get_xhi_table(const MultiTableId id, const B
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(512);
-        table.lookup_ids.emplace_back(basic_id);
+        table.basic_table_ids.emplace_back(basic_id);
         table.get_table_values.emplace_back(&get_xhi_values);
     }
     return table;
@@ -404,7 +404,7 @@ MultiTable ecc_generator_table<G1>::get_xlo_endo_table(const MultiTableId id, co
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(512);
-        table.lookup_ids.emplace_back(basic_id);
+        table.basic_table_ids.emplace_back(basic_id);
         table.get_table_values.emplace_back(&get_xlo_endo_values);
     }
     return table;
@@ -419,7 +419,7 @@ MultiTable ecc_generator_table<G1>::get_xhi_endo_table(const MultiTableId id, co
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(512);
-        table.lookup_ids.emplace_back(basic_id);
+        table.basic_table_ids.emplace_back(basic_id);
         table.get_table_values.emplace_back(&get_xhi_endo_values);
     }
     return table;
@@ -434,7 +434,7 @@ MultiTable ecc_generator_table<G1>::get_ylo_table(const MultiTableId id, const B
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(512);
-        table.lookup_ids.emplace_back(basic_id);
+        table.basic_table_ids.emplace_back(basic_id);
         table.get_table_values.emplace_back(&get_ylo_values);
     }
     return table;
@@ -449,7 +449,7 @@ MultiTable ecc_generator_table<G1>::get_yhi_table(const MultiTableId id, const B
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(512);
-        table.lookup_ids.emplace_back(basic_id);
+        table.basic_table_ids.emplace_back(basic_id);
         table.get_table_values.emplace_back(&get_yhi_values);
     }
     return table;
@@ -464,7 +464,7 @@ MultiTable ecc_generator_table<G1>::get_xyprime_table(const MultiTableId id, con
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(512);
-        table.lookup_ids.emplace_back(basic_id);
+        table.basic_table_ids.emplace_back(basic_id);
         table.get_table_values.emplace_back(&get_xyprime_values);
     }
     return table;
@@ -479,7 +479,7 @@ MultiTable ecc_generator_table<G1>::get_xyprime_endo_table(const MultiTableId id
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(512);
-        table.lookup_ids.emplace_back(basic_id);
+        table.basic_table_ids.emplace_back(basic_id);
         table.get_table_values.emplace_back(&get_xyprime_endo_values);
     }
     return table;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/non_native_group_generator.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/non_native_group_generator.cpp
@@ -182,10 +182,10 @@ template <typename G1> BasicTable ecc_generator_table<G1>::generate_xlo_table(Ba
     BasicTable table;
     table.id = id;
     table.table_index = table_index;
-    table.size = 256;
+    size_t table_size = 256;
     table.use_twin_keys = false;
 
-    for (size_t i = 0; i < table.size; ++i) {
+    for (size_t i = 0; i < table_size; ++i) {
         table.column_1.emplace_back((i));
         table.column_2.emplace_back(ecc_generator_table<G1>::generator_xlo_table[i].first);
         table.column_3.emplace_back(ecc_generator_table<G1>::generator_xlo_table[i].second);
@@ -205,10 +205,10 @@ template <typename G1> BasicTable ecc_generator_table<G1>::generate_xhi_table(Ba
     BasicTable table;
     table.id = id;
     table.table_index = table_index;
-    table.size = 256;
+    size_t table_size = 256;
     table.use_twin_keys = false;
 
-    for (size_t i = 0; i < table.size; ++i) {
+    for (size_t i = 0; i < table_size; ++i) {
         table.column_1.emplace_back((i));
         table.column_2.emplace_back(ecc_generator_table<G1>::generator_xhi_table[i].first);
         table.column_3.emplace_back(ecc_generator_table<G1>::generator_xhi_table[i].second);
@@ -229,10 +229,10 @@ BasicTable ecc_generator_table<G1>::generate_xlo_endo_table(BasicTableId id, con
     BasicTable table;
     table.id = id;
     table.table_index = table_index;
-    table.size = 256;
+    size_t table_size = 256;
     table.use_twin_keys = false;
 
-    for (size_t i = 0; i < table.size; ++i) {
+    for (size_t i = 0; i < table_size; ++i) {
         table.column_1.emplace_back((i));
         table.column_2.emplace_back(ecc_generator_table<G1>::generator_endo_xlo_table[i].first);
         table.column_3.emplace_back(ecc_generator_table<G1>::generator_endo_xlo_table[i].second);
@@ -253,10 +253,10 @@ BasicTable ecc_generator_table<G1>::generate_xhi_endo_table(BasicTableId id, con
     BasicTable table;
     table.id = id;
     table.table_index = table_index;
-    table.size = 256;
+    size_t table_size = 256;
     table.use_twin_keys = false;
 
-    for (size_t i = 0; i < table.size; ++i) {
+    for (size_t i = 0; i < table_size; ++i) {
         table.column_1.emplace_back((i));
         table.column_2.emplace_back(ecc_generator_table<G1>::generator_endo_xhi_table[i].first);
         table.column_3.emplace_back(ecc_generator_table<G1>::generator_endo_xhi_table[i].second);
@@ -276,10 +276,10 @@ template <typename G1> BasicTable ecc_generator_table<G1>::generate_ylo_table(Ba
     BasicTable table;
     table.id = id;
     table.table_index = table_index;
-    table.size = 256;
+    size_t table_size = 256;
     table.use_twin_keys = false;
 
-    for (size_t i = 0; i < table.size; ++i) {
+    for (size_t i = 0; i < table_size; ++i) {
         table.column_1.emplace_back((i));
         table.column_2.emplace_back(ecc_generator_table<G1>::generator_ylo_table[i].first);
         table.column_3.emplace_back(ecc_generator_table<G1>::generator_ylo_table[i].second);
@@ -299,10 +299,10 @@ template <typename G1> BasicTable ecc_generator_table<G1>::generate_yhi_table(Ba
     BasicTable table;
     table.id = id;
     table.table_index = table_index;
-    table.size = 256;
+    size_t table_size = 256;
     table.use_twin_keys = false;
 
-    for (size_t i = 0; i < table.size; ++i) {
+    for (size_t i = 0; i < table_size; ++i) {
         table.column_1.emplace_back((i));
         table.column_2.emplace_back(ecc_generator_table<G1>::generator_yhi_table[i].first);
         table.column_3.emplace_back(ecc_generator_table<G1>::generator_yhi_table[i].second);
@@ -323,10 +323,10 @@ BasicTable ecc_generator_table<G1>::generate_xyprime_table(BasicTableId id, cons
     BasicTable table;
     table.id = id;
     table.table_index = table_index;
-    table.size = 256;
+    size_t table_size = 256;
     table.use_twin_keys = false;
 
-    for (size_t i = 0; i < table.size; ++i) {
+    for (size_t i = 0; i < table_size; ++i) {
         table.column_1.emplace_back((i));
         table.column_2.emplace_back(ecc_generator_table<G1>::generator_xyprime_table[i].first);
         table.column_3.emplace_back(ecc_generator_table<G1>::generator_xyprime_table[i].second);
@@ -347,10 +347,10 @@ BasicTable ecc_generator_table<G1>::generate_xyprime_endo_table(BasicTableId id,
     BasicTable table;
     table.id = id;
     table.table_index = table_index;
-    table.size = 256;
+    size_t table_size = 256;
     table.use_twin_keys = false;
 
-    for (size_t i = 0; i < table.size; ++i) {
+    for (size_t i = 0; i < table_size; ++i) {
         table.column_1.emplace_back((i));
         table.column_2.emplace_back(ecc_generator_table<G1>::generator_endo_xyprime_table[i].first);
         table.column_3.emplace_back(ecc_generator_table<G1>::generator_endo_xyprime_table[i].second);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/plookup_tables.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/plookup_tables.cpp
@@ -176,14 +176,14 @@ ReadData<bb::fr> get_lookup_accumulators(const MultiTableId id,
     std::vector<fr> column_3_raw_values;
 
     for (size_t i = 0; i < num_lookups; ++i) {
-        // get i-th table query function and then submit query
+        // compute the value(s) corresponding to the key(s) using on the i-th basic table query function
         const auto values = multi_table.get_table_values[i]({ key_a_slices[i], key_b_slices[i] });
         // store all query data in raw columns and key entry
         column_1_raw_values.emplace_back(key_a_slices[i]);
         column_2_raw_values.emplace_back(is_2_to_1_lookup ? key_b_slices[i] : values[0]);
         column_3_raw_values.emplace_back(is_2_to_1_lookup ? values[0] : values[1]);
 
-        // Question: why are we storing the key slices twice? // WORKTODO: resolve question?
+        // Store the lookup entries for use in constructing the sorted table/lookup polynomials later on
         const BasicTable::LookupEntry lookup_entry{ { key_a_slices[i], key_b_slices[i] }, values };
         lookup.lookup_entries.emplace_back(lookup_entry);
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/plookup_tables.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/plookup_tables.hpp
@@ -4,7 +4,7 @@
 
 namespace bb::plookup {
 
-const MultiTable& create_table(MultiTableId id);
+const MultiTable& get_multitable(MultiTableId id);
 
 ReadData<bb::fr> get_lookup_accumulators(MultiTableId id,
                                          const bb::fr& key_a,

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/sha256.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/sha256.hpp
@@ -116,7 +116,7 @@ inline MultiTable get_witness_extension_output_table(const MultiTableId id = SHA
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(numeric::pow64(16, 3));
-        table.lookup_ids.emplace_back(SHA256_WITNESS_NORMALIZE);
+        table.basic_table_ids.emplace_back(SHA256_WITNESS_NORMALIZE);
         table.get_table_values.emplace_back(
             &sparse_tables::get_sparse_normalization_values<16, witness_extension_normalization_table>);
     }
@@ -132,7 +132,7 @@ inline MultiTable get_choose_output_table(const MultiTableId id = SHA256_CH_OUTP
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(numeric::pow64(28, 2));
-        table.lookup_ids.emplace_back(SHA256_CH_NORMALIZE);
+        table.basic_table_ids.emplace_back(SHA256_CH_NORMALIZE);
         table.get_table_values.emplace_back(
             &sparse_tables::get_sparse_normalization_values<28, choose_normalization_table>);
     }
@@ -148,7 +148,7 @@ inline MultiTable get_majority_output_table(const MultiTableId id = SHA256_MAJ_O
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(numeric::pow64(16, 3));
-        table.lookup_ids.emplace_back(SHA256_MAJ_NORMALIZE);
+        table.basic_table_ids.emplace_back(SHA256_MAJ_NORMALIZE);
         table.get_table_values.emplace_back(
             &sparse_tables::get_sparse_normalization_values<16, majority_normalization_table>);
     }
@@ -223,10 +223,10 @@ inline MultiTable get_witness_extension_input_table(const MultiTableId id = SHA2
     MultiTable table(column_1_coefficients, column_2_coefficients, column_3_coefficients);
     table.id = id;
     table.slice_sizes = { (1 << 3), (1 << 7), (1 << 8), (1 << 18) };
-    table.lookup_ids = { SHA256_WITNESS_SLICE_3,
-                         SHA256_WITNESS_SLICE_7_ROTATE_4,
-                         SHA256_WITNESS_SLICE_8_ROTATE_7,
-                         SHA256_WITNESS_SLICE_14_ROTATE_1 };
+    table.basic_table_ids = { SHA256_WITNESS_SLICE_3,
+                              SHA256_WITNESS_SLICE_7_ROTATE_4,
+                              SHA256_WITNESS_SLICE_8_ROTATE_7,
+                              SHA256_WITNESS_SLICE_14_ROTATE_1 };
 
     table.get_table_values = {
         &sparse_tables::get_sparse_table_with_rotation_values<16, 0>,
@@ -321,7 +321,7 @@ inline MultiTable get_choose_input_table(const MultiTableId id = SHA256_CH_INPUT
     MultiTable table(column_1_coefficients, column_2_coefficients, column_3_coefficients);
     table.id = id;
     table.slice_sizes = { (1 << 11), (1 << 11), (1 << 10) };
-    table.lookup_ids = { SHA256_BASE28_ROTATE6, SHA256_BASE28, SHA256_BASE28_ROTATE3 };
+    table.basic_table_ids = { SHA256_BASE28_ROTATE6, SHA256_BASE28, SHA256_BASE28_ROTATE3 };
 
     table.get_table_values.push_back(&sparse_tables::get_sparse_table_with_rotation_values<28, 6>);
     table.get_table_values.push_back(&sparse_tables::get_sparse_table_with_rotation_values<28, 0>);
@@ -380,7 +380,7 @@ inline MultiTable get_majority_input_table(const MultiTableId id = SHA256_MAJ_IN
     MultiTable table(column_1_coefficients, column_2_coefficients, column_3_coefficients);
     table.id = id;
     table.slice_sizes = { (1 << 11), (1 << 11), (1 << 10) };
-    table.lookup_ids = { SHA256_BASE16_ROTATE2, SHA256_BASE16_ROTATE2, SHA256_BASE16 };
+    table.basic_table_ids = { SHA256_BASE16_ROTATE2, SHA256_BASE16_ROTATE2, SHA256_BASE16 };
     table.get_table_values = {
         &sparse_tables::get_sparse_table_with_rotation_values<16, 2>,
         &sparse_tables::get_sparse_table_with_rotation_values<16, 2>,

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/sparse.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/sparse.hpp
@@ -28,10 +28,10 @@ inline BasicTable generate_sparse_table_with_rotation(BasicTableId id, const siz
     BasicTable table;
     table.id = id;
     table.table_index = table_index;
-    table.size = (1U << bits_per_slice);
+    auto table_size = (1U << bits_per_slice);
     table.use_twin_keys = false;
 
-    for (uint64_t i = 0; i < table.size; ++i) {
+    for (uint64_t i = 0; i < table_size; ++i) {
         const uint64_t source = i;
         const auto target = numeric::map_into_sparse_form<base>(source);
         table.column_1.emplace_back(bb::fr(source));
@@ -89,11 +89,11 @@ inline BasicTable generate_sparse_normalization_table(BasicTableId id, const siz
     table.id = id;
     table.table_index = table_index;
     table.use_twin_keys = false;
-    table.size = numeric::pow64(static_cast<uint64_t>(base), num_bits);
+    auto table_size = numeric::pow64(static_cast<uint64_t>(base), num_bits);
 
     numeric::sparse_int<base, num_bits> accumulator(0);
     numeric::sparse_int<base, num_bits> to_add(1);
-    for (size_t i = 0; i < table.size; ++i) {
+    for (size_t i = 0; i < table_size; ++i) {
         const auto& limbs = accumulator.get_limbs();
         uint64_t key = 0;
         for (size_t j = 0; j < num_bits; ++j) {
@@ -109,7 +109,7 @@ inline BasicTable generate_sparse_normalization_table(BasicTableId id, const siz
 
     table.get_values_from_key = &get_sparse_normalization_values<base, base_table>;
 
-    table.column_1_step_size = bb::fr(table.size);
+    table.column_1_step_size = bb::fr(table_size);
     table.column_2_step_size = bb::fr(((uint64_t)1 << num_bits));
     table.column_3_step_size = bb::fr(0);
     return table;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/types.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/types.hpp
@@ -317,7 +317,11 @@ struct BasicTable {
 
     bool operator==(const BasicTable& other) const = default;
 
-    size_t size() const { return column_1.size(); }
+    size_t size() const
+    {
+        ASSERT(column_1.size() == column_2.size() && column_2.size() == column_3.size());
+        return column_1.size();
+    }
 };
 
 enum ColumnIdx { C1, C2, C3 };

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/types.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/types.hpp
@@ -123,7 +123,7 @@ enum MultiTableId {
 
 /**
  * @brief Container for managing multiple BasicTables plus the data needed to combine basic table outputs (limbs) into
- * accumulators
+ * accumulators. Does not store actual raw table data.
  * @details As a simple example, consider using lookups to compute XOR on uint32_t inputs. To do this we decompose the
  * inputs into 6 limbs and use a BasicTable for 6-bit XOR lookups. In this case the MultiTable simply manages 6 basic
  * tables, all of which are the XOR BasicTable. (In many cases all of the BasicTables managed by a MultiTable are
@@ -140,7 +140,7 @@ struct MultiTable {
     std::vector<bb::fr> column_2_coefficients;
     std::vector<bb::fr> column_3_coefficients;
     MultiTableId id;
-    std::vector<BasicTableId> lookup_ids;
+    std::vector<BasicTableId> basic_table_ids;
     std::vector<uint64_t> slice_sizes;
     std::vector<bb::fr> column_1_step_sizes;
     std::vector<bb::fr> column_2_step_sizes;
@@ -341,7 +341,7 @@ template <class DataType> class ReadData {
     std::vector<DataType>& operator[](ColumnIdx idx) { return columns[static_cast<size_t>(idx)]; };
     const std::vector<DataType>& operator[](ColumnIdx idx) const { return columns[static_cast<size_t>(idx)]; };
 
-    std::vector<BasicTable::LookupEntry> key_entries;
+    std::vector<BasicTable::LookupEntry> lookup_entries;
 
   private:
     std::array<std::vector<DataType>, 3> columns;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/types.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/types.hpp
@@ -302,8 +302,6 @@ struct BasicTable {
     // Unique id of the table which is used to look it up, when we need its functionality. One of BasicTableId enum
     BasicTableId id;
     size_t table_index;
-    // The size of the table
-    size_t size;
     // This means that we are using two inputs to look up stuff, not translate a single entry into another one.
     bool use_twin_keys;
 
@@ -318,6 +316,8 @@ struct BasicTable {
     std::array<bb::fr, 2> (*get_values_from_key)(const std::array<uint64_t, 2>);
 
     bool operator==(const BasicTable& other) const = default;
+
+    size_t size() const { return column_1.size(); }
 };
 
 enum ColumnIdx { C1, C2, C3 };

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/uint.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/uint.hpp
@@ -81,7 +81,7 @@ inline MultiTable get_uint32_xor_table(const MultiTableId id = UINT32_XOR)
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(base);
-        table.lookup_ids.emplace_back(UINT_XOR_ROTATE0);
+        table.basic_table_ids.emplace_back(UINT_XOR_ROTATE0);
         table.get_table_values.emplace_back(&get_xor_rotate_values_from_key<6, 0>);
     }
     return table;
@@ -96,7 +96,7 @@ inline MultiTable get_uint32_and_table(const MultiTableId id = UINT32_AND)
     table.id = id;
     for (size_t i = 0; i < num_entries; ++i) {
         table.slice_sizes.emplace_back(base);
-        table.lookup_ids.emplace_back(UINT_AND_ROTATE0);
+        table.basic_table_ids.emplace_back(UINT_AND_ROTATE0);
         table.get_table_values.emplace_back(&get_and_rotate_values_from_key<6, 0>);
     }
     return table;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/uint.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/uint.hpp
@@ -19,7 +19,6 @@ inline BasicTable generate_xor_rotate_table(BasicTableId id, const size_t table_
     BasicTable table;
     table.id = id;
     table.table_index = table_index;
-    table.size = base * base;
     table.use_twin_keys = true;
 
     for (uint64_t i = 0; i < base; ++i) {
@@ -52,7 +51,6 @@ inline BasicTable generate_and_rotate_table(BasicTableId id, const size_t table_
     BasicTable table;
     table.id = id;
     table.table_index = table_index;
-    table.size = base * base;
     table.use_twin_keys = true;
 
     for (uint64_t i = 0; i < base; ++i) {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -2815,7 +2815,7 @@ template <typename Arithmetization> msgpack::sbuffer UltraCircuitBuilder_<Arithm
         const FF table_index(table.table_index);
         info("Table no: ", table.table_index);
         std::vector<std::vector<FF>> tmp_table;
-        for (size_t i = 0; i < table.size; ++i) {
+        for (size_t i = 0; i < table.size(); ++i) {
             tmp_table.push_back({ table.column_1[i], table.column_2[i], table.column_3[i] });
         }
         cir.lookup_tables.push_back(tmp_table);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -633,13 +633,14 @@ plookup::ReadData<uint32_t> UltraCircuitBuilder_<Arithmetization>::create_gates_
     const uint32_t key_a_index,
     std::optional<uint32_t> key_b_index)
 {
-    const auto& multi_table = plookup::create_table(id);
+    const auto& multi_table = plookup::get_multitable(id);
     const size_t num_lookups = read_values[plookup::ColumnIdx::C1].size();
     plookup::ReadData<uint32_t> read_data;
     for (size_t i = 0; i < num_lookups; ++i) {
-        auto& table = get_table(multi_table.lookup_ids[i]);
+        // get basic lookup table; construct and add to builder.lookup_tables if not already present
+        auto& table = get_table(multi_table.basic_table_ids[i]);
 
-        table.lookup_gates.emplace_back(read_values.key_entries[i]);
+        table.lookup_gates.emplace_back(read_values.lookup_entries[i]);
 
         const auto first_idx = (i == 0) ? key_a_index : this->add_variable(read_values[plookup::ColumnIdx::C1][i]);
         const auto second_idx = (i == 0 && (key_b_index.has_value()))

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -648,7 +648,7 @@ plookup::ReadData<uint32_t> UltraCircuitBuilder_<Arithmetization>::create_gates_
         // get basic lookup table; construct and add to builder.lookup_tables if not already present
         auto& table = get_table(multi_table.basic_table_ids[i]);
 
-        table.lookup_gates.emplace_back(read_values.lookup_entries[i]);
+        table.lookup_gates.emplace_back(read_values.lookup_entries[i]); // used for constructing sorted polynomials
 
         const auto first_idx = (i == 0) ? key_a_index : this->add_variable(read_values[plookup::ColumnIdx::C1][i]);
         const auto second_idx = (i == 0 && (key_b_index.has_value()))

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -609,6 +609,14 @@ uint32_t UltraCircuitBuilder_<Arithmetization>::put_constant_variable(const FF& 
     }
 }
 
+/**
+ * @brief Get the basic table with provided ID from the set of tables for the present circuit; create it if it doesnt
+ * yet exist
+ *
+ * @tparam Arithmetization
+ * @param id
+ * @return plookup::BasicTable&
+ */
 template <typename Arithmetization>
 plookup::BasicTable& UltraCircuitBuilder_<Arithmetization>::get_table(const plookup::BasicTableId id)
 {
@@ -619,7 +627,7 @@ plookup::BasicTable& UltraCircuitBuilder_<Arithmetization>::get_table(const ploo
     }
     // Table doesn't exist! So try to create it.
     lookup_tables.emplace_back(plookup::create_basic_table(id, lookup_tables.size()));
-    return lookup_tables[lookup_tables.size() - 1];
+    return lookup_tables.back();
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -630,7 +630,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization_
     {
         size_t tables_size = 0;
         for (const auto& table : lookup_tables) {
-            tables_size += table.size;
+            tables_size += table.size();
         }
         return tables_size;
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -702,7 +702,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization_
                                       std::array<FF, 2> (*get_values_from_key)(const std::array<uint64_t, 2>));
 
     plookup::BasicTable& get_table(const plookup::BasicTableId id);
-    plookup::MultiTable& create_table(const plookup::MultiTableId id);
+    plookup::MultiTable& get_multitable(const plookup::MultiTableId id);
 
     plookup::ReadData<uint32_t> create_gates_from_plookup_accumulators(
         const plookup::MultiTableId& id,

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -281,8 +281,9 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization_
     // TODO(#216)(Adrian): Why is this not in CircuitBuilderBase
     std::map<FF, uint32_t> constant_variable_indices;
 
+    // The set of lookup tables used by the circuit, plus the gate data for the lookups from each table
     std::vector<plookup::BasicTable> lookup_tables;
-    std::vector<plookup::MultiTable> lookup_multi_tables;
+
     std::map<uint64_t, RangeList> range_lists; // DOCTODO: explain this.
 
     /**
@@ -367,7 +368,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization_
         constant_variable_indices = other.constant_variable_indices;
 
         lookup_tables = other.lookup_tables;
-        lookup_multi_tables = other.lookup_multi_tables;
         range_lists = other.range_lists;
         ram_arrays = other.ram_arrays;
         rom_arrays = other.rom_arrays;
@@ -384,7 +384,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization_
         constant_variable_indices = other.constant_variable_indices;
 
         lookup_tables = other.lookup_tables;
-        lookup_multi_tables = other.lookup_multi_tables;
         range_lists = other.range_lists;
         ram_arrays = other.ram_arrays;
         rom_arrays = other.rom_arrays;


### PR DESCRIPTION
Adding some comments and improving some naming in code having to do with lookups. 

Note: the BasicTable struct had a `size` member that had to be set manually. This seems extremely error prone. I updated this to use a `size()` method that checks the size of the first table column.

(This work stems from notes-to-self that I made while perusing the lookup code in preparation to convert to a log-derivative argument).