### PR TITLE
chore(bb): hide `debug()` logs under `--debug` flag

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -970,7 +970,8 @@ int main(int argc, char* argv[])
 {
     try {
         std::vector<std::string> args(argv + 1, argv + argc);
-        verbose_logging = flag_present(args, "-v") || flag_present(args, "--verbose_logging");
+        debug_logging = flag_present(args, "-d") || flag_present(args, "--debug_logging");
+        verbose_logging = debug_logging || flag_present(args, "-v") || flag_present(args, "--verbose_logging");
         if (args.empty()) {
             std::cerr << "No command provided.\n";
             return 1;

--- a/barretenberg/cpp/src/barretenberg/common/log.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/log.cpp
@@ -1,2 +1,5 @@
 // Used for `vinfo` in log.hpp.
 bool verbose_logging = false;
+
+// Used for `debug` in log.hpp.
+bool debug_logging = false;

--- a/barretenberg/cpp/src/barretenberg/common/log.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/log.hpp
@@ -47,10 +47,13 @@ template <typename... Args> std::string benchmark_format(Args... args)
     return os.str();
 }
 
+extern bool debug_logging;
 #ifndef NDEBUG
 template <typename... Args> inline void debug(Args... args)
 {
-    logstr(format(args...).c_str());
+    if (debug_logging) {
+        logstr(format(args...).c_str());
+    }
 }
 #else
 template <typename... Args> inline void debug(Args... /*unused*/) {}


### PR DESCRIPTION
This helps because currently `bootstrap.sh` compiles with assertions,
and therefore outputs all debug logs without this change.