### PR TITLE
chore: parallelise compilation of contracts and protocol circuits

### DIFF
--- a/noir-projects/Earthfile
+++ b/noir-projects/Earthfile
@@ -5,8 +5,6 @@ source:
 
   # Install nargo
   COPY ../noir/+nargo/nargo /usr/bin/nargo
-  # Install transpiler
-  COPY ../avm-transpiler/+build/avm-transpiler /usr/bin/avm-transpiler
 
   WORKDIR /usr/src/noir-projects
 
@@ -16,10 +14,28 @@ source:
   # for debugging rebuilds
   RUN echo CONTENT HASH $(find . -type f -exec sha256sum {} ';' | sort | sha256sum | awk '{print $1}') | tee .content-hash
 
+build-contracts:
+  FROM +source
+
+  # Install transpiler
+  COPY ../avm-transpiler/+build/avm-transpiler /usr/bin/avm-transpiler
+
+  RUN cd noir-contracts && NARGO=nargo TRANSPILER=avm-transpiler ./bootstrap.sh
+  SAVE ARTIFACT noir-contracts
+  
+build-protocol-circuits:
+  FROM +source
+  RUN cd noir-protocol-circuits && NARGO=nargo ./bootstrap.sh
+  SAVE ARTIFACT noir-protocol-circuits
+
 build:
   FROM +source
-  RUN cd noir-contracts && NARGO=nargo TRANSPILER=avm-transpiler ./bootstrap.sh
-  RUN cd noir-protocol-circuits && NARGO=nargo ./bootstrap.sh
+  BUILD +build-contracts
+  BUILD +build-protocol-circuits
+  
+  COPY +build-contracts/noir-contracts ./noir-contracts
+  COPY +build-protocol-circuits/noir-protocol-circuits ./noir-protocol-circuits
+  
   SAVE ARTIFACT aztec-nr
   SAVE ARTIFACT noir-contracts
   SAVE ARTIFACT noir-protocol-circuits


### PR DESCRIPTION
I'm looking to debug some issues in the protocol circuits but there's currently no way to build these without having to build the contract as well which leads to sadness.

This PR separates these two projects so we can build them individually, as a bonus we can now compile these in parallel.