### PR TITLE
chore: Small fixes for the tube flows

### DIFF
--- a/barretenberg/Earthfile
+++ b/barretenberg/Earthfile
@@ -42,6 +42,8 @@ barretenberg-acir-tests-bb:
     RUN FLOW=prove_and_verify_mega_honk_program ./run_acir_tests.sh
     # Fold and verify an ACIR program stack using ClientIvc
     RUN FLOW=fold_and_verify_program ./run_acir_tests.sh fold_basic
+     # Fold and verify an ACIR program stack using ClientIvc
+    RUN FLOW=prove_then_verify_tube ./run_acir_tests.sh fold_basic
     # Construct and separately verify a UltraHonk proof for a single program that recursively verifies a Honk proof
     RUN FLOW=prove_then_verify_ultra_honk ./run_acir_tests.sh verify_honk_proof
     # Construct and verify a UltraHonk proof for a single program that recursively verifies a Honk proof

--- a/barretenberg/Earthfile
+++ b/barretenberg/Earthfile
@@ -42,7 +42,7 @@ barretenberg-acir-tests-bb:
     RUN FLOW=prove_and_verify_mega_honk_program ./run_acir_tests.sh
     # Fold and verify an ACIR program stack using ClientIvc
     RUN FLOW=fold_and_verify_program ./run_acir_tests.sh fold_basic
-     # Fold and verify an ACIR program stack using ClientIvc
+     # Fold and verify an ACIR program stack using ClientIvc, recursively verify as part of the Tube circuit and produce and verify a Honk proof
     RUN FLOW=prove_then_verify_tube ./run_acir_tests.sh fold_basic
     # Construct and separately verify a UltraHonk proof for a single program that recursively verifies a Honk proof
     RUN FLOW=prove_then_verify_ultra_honk ./run_acir_tests.sh verify_honk_proof

--- a/barretenberg/acir_tests/flows/prove_then_verify_mega_honk.sh
+++ b/barretenberg/acir_tests/flows/prove_then_verify_mega_honk.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -eu
 
+mkdir -p ./proofs
+
 VFLAG=${VERBOSE:+-v}
 BFLAG="-b ./target/program.json"
 FLAGS="-c $CRS_PATH $VFLAG"

--- a/barretenberg/acir_tests/flows/prove_then_verify_tube.sh
+++ b/barretenberg/acir_tests/flows/prove_then_verify_tube.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -eux
 
+mkdir -p ./proofs
+
 VFLAG=${VERBOSE:+-v}
 
 $BIN client_ivc_prove_output_all $VFLAG -c $CRS_PATH -b ./target/program.json

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/zeromorph/zeromorph.hpp
@@ -40,8 +40,9 @@ template <typename PCS> class ZeroMorphProver_ {
     using Polynomial = bb::Polynomial<FF>;
 
     // TODO(#742): Set this N_max to be the number of G1 elements in the mocked zeromorph SRS once it's in place.
-    // (Then, eventually, set it based on the real SRS). For now we set it to be large but more or less arbitrary.
-    static const size_t N_max = 1 << 23;
+    // (Then, eventually, set it based on the real SRS). For now we set it to be larger then the Client IVC recursive
+    // verifier circuit.
+    static const size_t N_max = 1 << 25;
 
   public:
     /**

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
@@ -21,12 +21,6 @@ bool ECCVMVerifier::verify_proof(const HonkProof& proof)
 
     for (auto [comm, label] : zip_view(commitments.get_wires(), commitment_labels.get_wires())) {
         comm = transcript->template receive_from_prover<Commitment>(label);
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1017): This is a hack to ensure zero commitments
-        // are still on curve as the transcript doesn't currently support a point at infinity representation for
-        // cycle_group
-        if (!comm.on_curve()) {
-            comm.self_set_infinity();
-        }
     }
 
     // Get challenge for sorted list batching and wire four memory records


### PR DESCRIPTION
Small fixes for #6934 

Remove TODO + hack in ECCVM Verifier which was resolved by #6963 and add the `prove_then_verify_tube` to the Earthfile for testing.