### PR TITLE
fix(avm): correctly generate public inputs in verifier

### DIFF
--- a/barretenberg/cpp/pil/avm/avm_kernel.pil
+++ b/barretenberg/cpp/pil/avm/avm_kernel.pil
@@ -2,11 +2,11 @@ include "avm_main.pil";
 include "constants.pil";
 
 namespace avm_kernel(256);
-    pol public kernel_inputs;
+    pol public(/*idx=*/0) kernel_inputs;
 
-    pol public kernel_value_out;
-    pol public kernel_side_effect_out;
-    pol public kernel_metadata_out;
+    pol public(/*idx=*/1) kernel_value_out;
+    pol public(/*idx=*/2) kernel_side_effect_out;
+    pol public(/*idx=*/3) kernel_metadata_out;
 
     // TODO(https://github.com/AztecProtocol/aztec-packages/issues/6463): just use one col for both of these
     pol commit kernel_in_offset;

--- a/barretenberg/cpp/pil/avm/avm_main.pil
+++ b/barretenberg/cpp/pil/avm/avm_main.pil
@@ -650,11 +650,10 @@ namespace avm_main(256);
     KERNEL_OUTPUT_SELECTORS * (avm_kernel.side_effect_counter' - (avm_kernel.side_effect_counter + 1)) = 0;
 
     #[KERNEL_OUTPUT_LOOKUP]
-    q_kernel_output_lookup {avm_kernel.kernel_out_offset, ia, avm_kernel.side_effect_counter, ib} in avm_kernel.q_public_input_kernel_out_add_to_table {clk, avm_kernel.kernel_value_out__is_public, avm_kernel.kernel_side_effect_out__is_public, avm_kernel.kernel_metadata_out__is_public};
+    q_kernel_output_lookup {avm_kernel.kernel_out_offset, ia, avm_kernel.side_effect_counter, ib} in avm_kernel.q_public_input_kernel_out_add_to_table {clk, avm_kernel.kernel_value_out, avm_kernel.kernel_side_effect_out, avm_kernel.kernel_metadata_out};
 
     #[LOOKUP_INTO_KERNEL]
-    // TODO: FIX not having the trailing is_public breaking compilation :(
-    q_kernel_lookup { avm_main.ia, avm_kernel.kernel_in_offset } in avm_kernel.q_public_input_kernel_add_to_table { avm_kernel.kernel_inputs__is_public, clk };
+    q_kernel_lookup { avm_main.ia, avm_kernel.kernel_in_offset } in avm_kernel.q_public_input_kernel_add_to_table { avm_kernel.kernel_inputs, clk };
 
     //====== Inter-table Constraints ============================================
     #[INCL_MAIN_TAG_ERR]

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/declare_views.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/declare_views.hpp
@@ -128,14 +128,11 @@
     [[maybe_unused]] auto avm_kernel_emit_unencrypted_log_write_offset =                                               \
         View(new_term.avm_kernel_emit_unencrypted_log_write_offset);                                                   \
     [[maybe_unused]] auto avm_kernel_kernel_in_offset = View(new_term.avm_kernel_kernel_in_offset);                    \
-    [[maybe_unused]] auto avm_kernel_kernel_inputs__is_public = View(new_term.avm_kernel_kernel_inputs__is_public);    \
-    [[maybe_unused]] auto avm_kernel_kernel_metadata_out__is_public =                                                  \
-        View(new_term.avm_kernel_kernel_metadata_out__is_public);                                                      \
+    [[maybe_unused]] auto avm_kernel_kernel_inputs = View(new_term.avm_kernel_kernel_inputs);                          \
+    [[maybe_unused]] auto avm_kernel_kernel_metadata_out = View(new_term.avm_kernel_kernel_metadata_out);              \
     [[maybe_unused]] auto avm_kernel_kernel_out_offset = View(new_term.avm_kernel_kernel_out_offset);                  \
-    [[maybe_unused]] auto avm_kernel_kernel_side_effect_out__is_public =                                               \
-        View(new_term.avm_kernel_kernel_side_effect_out__is_public);                                                   \
-    [[maybe_unused]] auto avm_kernel_kernel_value_out__is_public =                                                     \
-        View(new_term.avm_kernel_kernel_value_out__is_public);                                                         \
+    [[maybe_unused]] auto avm_kernel_kernel_side_effect_out = View(new_term.avm_kernel_kernel_side_effect_out);        \
+    [[maybe_unused]] auto avm_kernel_kernel_value_out = View(new_term.avm_kernel_kernel_value_out);                    \
     [[maybe_unused]] auto avm_kernel_l1_to_l2_msg_exists_write_offset =                                                \
         View(new_term.avm_kernel_l1_to_l2_msg_exists_write_offset);                                                    \
     [[maybe_unused]] auto avm_kernel_note_hash_exist_write_offset =                                                    \

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/kernel_output_lookup.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/kernel_output_lookup.hpp
@@ -142,9 +142,9 @@ class kernel_output_lookup_lookup_settings {
                                      in.avm_kernel_side_effect_counter,
                                      in.avm_main_ib,
                                      in.avm_main_clk,
-                                     in.avm_kernel_kernel_value_out__is_public,
-                                     in.avm_kernel_kernel_side_effect_out__is_public,
-                                     in.avm_kernel_kernel_metadata_out__is_public);
+                                     in.avm_kernel_kernel_value_out,
+                                     in.avm_kernel_kernel_side_effect_out,
+                                     in.avm_kernel_kernel_metadata_out);
     }
 
     /**
@@ -166,9 +166,9 @@ class kernel_output_lookup_lookup_settings {
                                      in.avm_kernel_side_effect_counter,
                                      in.avm_main_ib,
                                      in.avm_main_clk,
-                                     in.avm_kernel_kernel_value_out__is_public,
-                                     in.avm_kernel_kernel_side_effect_out__is_public,
-                                     in.avm_kernel_kernel_metadata_out__is_public);
+                                     in.avm_kernel_kernel_value_out,
+                                     in.avm_kernel_kernel_side_effect_out,
+                                     in.avm_kernel_kernel_metadata_out);
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/lookup_into_kernel.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/lookup_into_kernel.hpp
@@ -139,7 +139,7 @@ class lookup_into_kernel_lookup_settings {
                                      in.avm_kernel_q_public_input_kernel_add_to_table,
                                      in.avm_main_ia,
                                      in.avm_kernel_kernel_in_offset,
-                                     in.avm_kernel_kernel_inputs__is_public,
+                                     in.avm_kernel_kernel_inputs,
                                      in.avm_main_clk);
     }
 
@@ -159,7 +159,7 @@ class lookup_into_kernel_lookup_settings {
                                      in.avm_kernel_q_public_input_kernel_add_to_table,
                                      in.avm_main_ia,
                                      in.avm_kernel_kernel_in_offset,
-                                     in.avm_kernel_kernel_inputs__is_public,
+                                     in.avm_kernel_kernel_inputs,
                                      in.avm_main_clk);
     }
 };

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_helper.cpp
@@ -1,4 +1,7 @@
 #include "barretenberg/vm/avm_trace/avm_helper.hpp"
+
+#include <cassert>
+
 #include "barretenberg/vm/avm_trace/avm_mem_trace.hpp"
 #include "barretenberg/vm/generated/avm_circuit_builder.hpp"
 
@@ -134,29 +137,25 @@ std::vector<std::vector<FF>> copy_public_inputs_columns(VmPublicInputs public_in
 {
     // We convert to a vector as the pil generated verifier is generic and unaware of the KERNEL_INPUTS_LENGTH
     // For each of the public input vectors
-    std::vector<FF> public_inputs_kernel_inputs(KERNEL_INPUTS_LENGTH);
-    std::vector<FF> public_inputs_kernel_value_outputs(KERNEL_OUTPUTS_LENGTH);
-    std::vector<FF> public_inputs_kernel_side_effect_outputs(KERNEL_OUTPUTS_LENGTH);
-    std::vector<FF> public_inputs_kernel_metadata_outputs(KERNEL_OUTPUTS_LENGTH);
+    std::vector<FF> public_inputs_kernel_inputs(std::get<KERNEL_INPUTS>(public_inputs).begin(),
+                                                std::get<KERNEL_INPUTS>(public_inputs).end());
+    std::vector<FF> public_inputs_kernel_value_outputs(std::get<KERNEL_OUTPUTS_VALUE>(public_inputs).begin(),
+                                                       std::get<KERNEL_OUTPUTS_VALUE>(public_inputs).end());
+    std::vector<FF> public_inputs_kernel_side_effect_outputs(
+        std::get<KERNEL_OUTPUTS_SIDE_EFFECT_COUNTER>(public_inputs).begin(),
+        std::get<KERNEL_OUTPUTS_SIDE_EFFECT_COUNTER>(public_inputs).end());
+    std::vector<FF> public_inputs_kernel_metadata_outputs(std::get<KERNEL_OUTPUTS_METADATA>(public_inputs).begin(),
+                                                          std::get<KERNEL_OUTPUTS_METADATA>(public_inputs).end());
 
-    std::copy(std::get<0>(public_inputs).begin(), std::get<0>(public_inputs).end(), public_inputs_kernel_inputs.data());
-    std::copy(std::get<1>(public_inputs).begin(),
-              std::get<1>(public_inputs).end(),
-              public_inputs_kernel_value_outputs.data());
-    std::copy(std::get<2>(public_inputs).begin(),
-              std::get<2>(public_inputs).end(),
-              public_inputs_kernel_side_effect_outputs.data());
-    std::copy(std::get<3>(public_inputs).begin(),
-              std::get<3>(public_inputs).end(),
-              public_inputs_kernel_metadata_outputs.data());
+    assert(public_inputs_kernel_inputs.size() == KERNEL_INPUTS_LENGTH);
+    assert(public_inputs_kernel_value_outputs.size() == KERNEL_OUTPUTS_LENGTH);
+    assert(public_inputs_kernel_side_effect_outputs.size() == KERNEL_OUTPUTS_LENGTH);
+    assert(public_inputs_kernel_metadata_outputs.size() == KERNEL_OUTPUTS_LENGTH);
 
-    std::vector<std::vector<FF>> public_inputs_as_vec(4);
-    public_inputs_as_vec[0] = public_inputs_kernel_inputs;
-    public_inputs_as_vec[1] = public_inputs_kernel_value_outputs;
-    public_inputs_as_vec[2] = public_inputs_kernel_side_effect_outputs;
-    public_inputs_as_vec[3] = public_inputs_kernel_metadata_outputs;
-
-    return public_inputs_as_vec;
+    return { std::move(public_inputs_kernel_inputs),
+             std::move(public_inputs_kernel_value_outputs),
+             std::move(public_inputs_kernel_side_effect_outputs),
+             std::move(public_inputs_kernel_metadata_outputs) };
 }
 
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.cpp
@@ -4508,8 +4508,7 @@ std::vector<Row> AvmTraceBuilder::finalize(uint32_t min_trace_size, bool range_c
 
     // Copy the kernel input public inputs
     for (size_t i = 0; i < KERNEL_INPUTS_LENGTH; i++) {
-        main_trace.at(i).avm_kernel_kernel_inputs__is_public =
-            std::get<KERNEL_INPUTS>(kernel_trace_builder.public_inputs).at(i);
+        main_trace.at(i).avm_kernel_kernel_inputs = std::get<KERNEL_INPUTS>(kernel_trace_builder.public_inputs).at(i);
     }
 
     // Write lookup counts for outputs
@@ -4524,13 +4523,13 @@ std::vector<Row> AvmTraceBuilder::finalize(uint32_t min_trace_size, bool range_c
 
     // Copy the kernel outputs counts into the main trace
     for (size_t i = 0; i < KERNEL_OUTPUTS_LENGTH; i++) {
-        main_trace.at(i).avm_kernel_kernel_value_out__is_public =
+        main_trace.at(i).avm_kernel_kernel_value_out =
             std::get<KERNEL_OUTPUTS_VALUE>(kernel_trace_builder.public_inputs).at(i);
 
-        main_trace.at(i).avm_kernel_kernel_side_effect_out__is_public =
+        main_trace.at(i).avm_kernel_kernel_side_effect_out =
             std::get<KERNEL_OUTPUTS_SIDE_EFFECT_COUNTER>(kernel_trace_builder.public_inputs).at(i);
 
-        main_trace.at(i).avm_kernel_kernel_metadata_out__is_public =
+        main_trace.at(i).avm_kernel_kernel_metadata_out =
             std::get<KERNEL_OUTPUTS_METADATA>(kernel_trace_builder.public_inputs).at(i);
     }
 

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.cpp
@@ -140,11 +140,11 @@ template <typename FF> std::vector<std::string> AvmFullRow<FF>::names()
              "avm_kernel_emit_nullifier_write_offset",
              "avm_kernel_emit_unencrypted_log_write_offset",
              "avm_kernel_kernel_in_offset",
-             "avm_kernel_kernel_inputs__is_public",
-             "avm_kernel_kernel_metadata_out__is_public",
+             "avm_kernel_kernel_inputs",
+             "avm_kernel_kernel_metadata_out",
              "avm_kernel_kernel_out_offset",
-             "avm_kernel_kernel_side_effect_out__is_public",
-             "avm_kernel_kernel_value_out__is_public",
+             "avm_kernel_kernel_side_effect_out",
+             "avm_kernel_kernel_value_out",
              "avm_kernel_l1_to_l2_msg_exists_write_offset",
              "avm_kernel_note_hash_exist_write_offset",
              "avm_kernel_nullifier_exists_write_offset",
@@ -154,6 +154,10 @@ template <typename FF> std::vector<std::string> AvmFullRow<FF>::names()
              "avm_kernel_side_effect_counter",
              "avm_kernel_sload_write_offset",
              "avm_kernel_sstore_write_offset",
+             "avm_main_abs_da_rem_gas_hi",
+             "avm_main_abs_da_rem_gas_lo",
+             "avm_main_abs_l2_rem_gas_hi",
+             "avm_main_abs_l2_rem_gas_lo",
              "avm_main_alu_in_tag",
              "avm_main_alu_sel",
              "avm_main_bin_op_id",
@@ -161,6 +165,7 @@ template <typename FF> std::vector<std::string> AvmFullRow<FF>::names()
              "avm_main_call_ptr",
              "avm_main_da_gas_op",
              "avm_main_da_gas_remaining",
+             "avm_main_da_out_of_gas",
              "avm_main_gas_cost_active",
              "avm_main_ia",
              "avm_main_ib",
@@ -179,6 +184,7 @@ template <typename FF> std::vector<std::string> AvmFullRow<FF>::names()
              "avm_main_inv",
              "avm_main_l2_gas_op",
              "avm_main_l2_gas_remaining",
+             "avm_main_l2_out_of_gas",
              "avm_main_last",
              "avm_main_mem_idx_a",
              "avm_main_mem_idx_b",
@@ -318,6 +324,10 @@ template <typename FF> std::vector<std::string> AvmFullRow<FF>::names()
              "lookup_byte_lengths",
              "lookup_byte_operations",
              "lookup_opcode_gas",
+             "range_check_l2_gas_hi",
+             "range_check_l2_gas_lo",
+             "range_check_da_gas_hi",
+             "range_check_da_gas_lo",
              "kernel_output_lookup",
              "lookup_into_kernel",
              "incl_main_tag_err",
@@ -355,6 +365,10 @@ template <typename FF> std::vector<std::string> AvmFullRow<FF>::names()
              "lookup_byte_lengths_counts",
              "lookup_byte_operations_counts",
              "lookup_opcode_gas_counts",
+             "range_check_l2_gas_hi_counts",
+             "range_check_l2_gas_lo_counts",
+             "range_check_da_gas_hi_counts",
+             "range_check_da_gas_lo_counts",
              "kernel_output_lookup_counts",
              "lookup_into_kernel_counts",
              "incl_main_tag_err_counts",
@@ -461,12 +475,11 @@ template <typename FF> std::ostream& operator<<(std::ostream& os, AvmFullRow<FF>
            << field_to_string(row.avm_kernel_emit_note_hash_write_offset) << ","
            << field_to_string(row.avm_kernel_emit_nullifier_write_offset) << ","
            << field_to_string(row.avm_kernel_emit_unencrypted_log_write_offset) << ","
-           << field_to_string(row.avm_kernel_kernel_in_offset) << ","
-           << field_to_string(row.avm_kernel_kernel_inputs__is_public) << ","
-           << field_to_string(row.avm_kernel_kernel_metadata_out__is_public) << ","
+           << field_to_string(row.avm_kernel_kernel_in_offset) << "," << field_to_string(row.avm_kernel_kernel_inputs)
+           << "," << field_to_string(row.avm_kernel_kernel_metadata_out) << ","
            << field_to_string(row.avm_kernel_kernel_out_offset) << ","
-           << field_to_string(row.avm_kernel_kernel_side_effect_out__is_public) << ","
-           << field_to_string(row.avm_kernel_kernel_value_out__is_public) << ","
+           << field_to_string(row.avm_kernel_kernel_side_effect_out) << ","
+           << field_to_string(row.avm_kernel_kernel_value_out) << ","
            << field_to_string(row.avm_kernel_l1_to_l2_msg_exists_write_offset) << ","
            << field_to_string(row.avm_kernel_note_hash_exist_write_offset) << ","
            << field_to_string(row.avm_kernel_nullifier_exists_write_offset) << ","
@@ -475,20 +488,24 @@ template <typename FF> std::ostream& operator<<(std::ostream& os, AvmFullRow<FF>
            << field_to_string(row.avm_kernel_q_public_input_kernel_out_add_to_table) << ","
            << field_to_string(row.avm_kernel_side_effect_counter) << ","
            << field_to_string(row.avm_kernel_sload_write_offset) << ","
-           << field_to_string(row.avm_kernel_sstore_write_offset) << "," << field_to_string(row.avm_main_alu_in_tag)
-           << "," << field_to_string(row.avm_main_alu_sel) << "," << field_to_string(row.avm_main_bin_op_id) << ","
+           << field_to_string(row.avm_kernel_sstore_write_offset) << ","
+           << field_to_string(row.avm_main_abs_da_rem_gas_hi) << "," << field_to_string(row.avm_main_abs_da_rem_gas_lo)
+           << "," << field_to_string(row.avm_main_abs_l2_rem_gas_hi) << ","
+           << field_to_string(row.avm_main_abs_l2_rem_gas_lo) << "," << field_to_string(row.avm_main_alu_in_tag) << ","
+           << field_to_string(row.avm_main_alu_sel) << "," << field_to_string(row.avm_main_bin_op_id) << ","
            << field_to_string(row.avm_main_bin_sel) << "," << field_to_string(row.avm_main_call_ptr) << ","
            << field_to_string(row.avm_main_da_gas_op) << "," << field_to_string(row.avm_main_da_gas_remaining) << ","
-           << field_to_string(row.avm_main_gas_cost_active) << "," << field_to_string(row.avm_main_ia) << ","
-           << field_to_string(row.avm_main_ib) << "," << field_to_string(row.avm_main_ic) << ","
-           << field_to_string(row.avm_main_id) << "," << field_to_string(row.avm_main_id_zero) << ","
-           << field_to_string(row.avm_main_ind_a) << "," << field_to_string(row.avm_main_ind_b) << ","
-           << field_to_string(row.avm_main_ind_c) << "," << field_to_string(row.avm_main_ind_d) << ","
-           << field_to_string(row.avm_main_ind_op_a) << "," << field_to_string(row.avm_main_ind_op_b) << ","
-           << field_to_string(row.avm_main_ind_op_c) << "," << field_to_string(row.avm_main_ind_op_d) << ","
-           << field_to_string(row.avm_main_internal_return_ptr) << "," << field_to_string(row.avm_main_inv) << ","
-           << field_to_string(row.avm_main_l2_gas_op) << "," << field_to_string(row.avm_main_l2_gas_remaining) << ","
-           << field_to_string(row.avm_main_last) << "," << field_to_string(row.avm_main_mem_idx_a) << ","
+           << field_to_string(row.avm_main_da_out_of_gas) << "," << field_to_string(row.avm_main_gas_cost_active) << ","
+           << field_to_string(row.avm_main_ia) << "," << field_to_string(row.avm_main_ib) << ","
+           << field_to_string(row.avm_main_ic) << "," << field_to_string(row.avm_main_id) << ","
+           << field_to_string(row.avm_main_id_zero) << "," << field_to_string(row.avm_main_ind_a) << ","
+           << field_to_string(row.avm_main_ind_b) << "," << field_to_string(row.avm_main_ind_c) << ","
+           << field_to_string(row.avm_main_ind_d) << "," << field_to_string(row.avm_main_ind_op_a) << ","
+           << field_to_string(row.avm_main_ind_op_b) << "," << field_to_string(row.avm_main_ind_op_c) << ","
+           << field_to_string(row.avm_main_ind_op_d) << "," << field_to_string(row.avm_main_internal_return_ptr) << ","
+           << field_to_string(row.avm_main_inv) << "," << field_to_string(row.avm_main_l2_gas_op) << ","
+           << field_to_string(row.avm_main_l2_gas_remaining) << "," << field_to_string(row.avm_main_l2_out_of_gas)
+           << "," << field_to_string(row.avm_main_last) << "," << field_to_string(row.avm_main_mem_idx_a) << ","
            << field_to_string(row.avm_main_mem_idx_b) << "," << field_to_string(row.avm_main_mem_idx_c) << ","
            << field_to_string(row.avm_main_mem_idx_d) << "," << field_to_string(row.avm_main_mem_op_a) << ","
            << field_to_string(row.avm_main_mem_op_activate_gas) << "," << field_to_string(row.avm_main_mem_op_b) << ","
@@ -564,6 +581,8 @@ template <typename FF> std::ostream& operator<<(std::ostream& os, AvmFullRow<FF>
            << field_to_string(row.perm_main_mem_ind_b) << "," << field_to_string(row.perm_main_mem_ind_c) << ","
            << field_to_string(row.perm_main_mem_ind_d) << "," << field_to_string(row.lookup_byte_lengths) << ","
            << field_to_string(row.lookup_byte_operations) << "," << field_to_string(row.lookup_opcode_gas) << ","
+           << field_to_string(row.range_check_l2_gas_hi) << "," << field_to_string(row.range_check_l2_gas_lo) << ","
+           << field_to_string(row.range_check_da_gas_hi) << "," << field_to_string(row.range_check_da_gas_lo) << ","
            << field_to_string(row.kernel_output_lookup) << "," << field_to_string(row.lookup_into_kernel) << ","
            << field_to_string(row.incl_main_tag_err) << "," << field_to_string(row.incl_mem_tag_err) << ","
            << field_to_string(row.lookup_mem_rng_chk_lo) << "," << field_to_string(row.lookup_mem_rng_chk_mid) << ","
@@ -583,11 +602,14 @@ template <typename FF> std::ostream& operator<<(std::ostream& os, AvmFullRow<FF>
            << field_to_string(row.lookup_div_u16_6) << "," << field_to_string(row.lookup_div_u16_7) << ","
            << field_to_string(row.lookup_byte_lengths_counts) << ","
            << field_to_string(row.lookup_byte_operations_counts) << "," << field_to_string(row.lookup_opcode_gas_counts)
-           << "," << field_to_string(row.kernel_output_lookup_counts) << ","
-           << field_to_string(row.lookup_into_kernel_counts) << "," << field_to_string(row.incl_main_tag_err_counts)
-           << "," << field_to_string(row.incl_mem_tag_err_counts) << ","
-           << field_to_string(row.lookup_mem_rng_chk_lo_counts) << ","
-           << field_to_string(row.lookup_mem_rng_chk_mid_counts) << ","
+           << "," << field_to_string(row.range_check_l2_gas_hi_counts) << ","
+           << field_to_string(row.range_check_l2_gas_lo_counts) << ","
+           << field_to_string(row.range_check_da_gas_hi_counts) << ","
+           << field_to_string(row.range_check_da_gas_lo_counts) << ","
+           << field_to_string(row.kernel_output_lookup_counts) << "," << field_to_string(row.lookup_into_kernel_counts)
+           << "," << field_to_string(row.incl_main_tag_err_counts) << ","
+           << field_to_string(row.incl_mem_tag_err_counts) << "," << field_to_string(row.lookup_mem_rng_chk_lo_counts)
+           << "," << field_to_string(row.lookup_mem_rng_chk_mid_counts) << ","
            << field_to_string(row.lookup_mem_rng_chk_hi_counts) << "," << field_to_string(row.lookup_pow_2_0_counts)
            << "," << field_to_string(row.lookup_pow_2_1_counts) << "," << field_to_string(row.lookup_u8_0_counts) << ","
            << field_to_string(row.lookup_u8_1_counts) << "," << field_to_string(row.lookup_u16_0_counts) << ","

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.hpp
@@ -207,11 +207,11 @@ template <typename FF> struct AvmFullRow {
     FF avm_kernel_emit_nullifier_write_offset{};
     FF avm_kernel_emit_unencrypted_log_write_offset{};
     FF avm_kernel_kernel_in_offset{};
-    FF avm_kernel_kernel_inputs__is_public{};
-    FF avm_kernel_kernel_metadata_out__is_public{};
+    FF avm_kernel_kernel_inputs{};
+    FF avm_kernel_kernel_metadata_out{};
     FF avm_kernel_kernel_out_offset{};
-    FF avm_kernel_kernel_side_effect_out__is_public{};
-    FF avm_kernel_kernel_value_out__is_public{};
+    FF avm_kernel_kernel_side_effect_out{};
+    FF avm_kernel_kernel_value_out{};
     FF avm_kernel_l1_to_l2_msg_exists_write_offset{};
     FF avm_kernel_note_hash_exist_write_offset{};
     FF avm_kernel_nullifier_exists_write_offset{};
@@ -691,12 +691,11 @@ class AvmCircuitBuilder {
             polys.avm_kernel_emit_unencrypted_log_write_offset[i] =
                 rows[i].avm_kernel_emit_unencrypted_log_write_offset;
             polys.avm_kernel_kernel_in_offset[i] = rows[i].avm_kernel_kernel_in_offset;
-            polys.avm_kernel_kernel_inputs__is_public[i] = rows[i].avm_kernel_kernel_inputs__is_public;
-            polys.avm_kernel_kernel_metadata_out__is_public[i] = rows[i].avm_kernel_kernel_metadata_out__is_public;
+            polys.avm_kernel_kernel_inputs[i] = rows[i].avm_kernel_kernel_inputs;
+            polys.avm_kernel_kernel_metadata_out[i] = rows[i].avm_kernel_kernel_metadata_out;
             polys.avm_kernel_kernel_out_offset[i] = rows[i].avm_kernel_kernel_out_offset;
-            polys.avm_kernel_kernel_side_effect_out__is_public[i] =
-                rows[i].avm_kernel_kernel_side_effect_out__is_public;
-            polys.avm_kernel_kernel_value_out__is_public[i] = rows[i].avm_kernel_kernel_value_out__is_public;
+            polys.avm_kernel_kernel_side_effect_out[i] = rows[i].avm_kernel_kernel_side_effect_out;
+            polys.avm_kernel_kernel_value_out[i] = rows[i].avm_kernel_kernel_value_out;
             polys.avm_kernel_l1_to_l2_msg_exists_write_offset[i] = rows[i].avm_kernel_l1_to_l2_msg_exists_write_offset;
             polys.avm_kernel_note_hash_exist_write_offset[i] = rows[i].avm_kernel_note_hash_exist_write_offset;
             polys.avm_kernel_nullifier_exists_write_offset[i] = rows[i].avm_kernel_nullifier_exists_write_offset;

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_flavor.hpp
@@ -376,11 +376,11 @@ class AvmFlavor {
                               avm_kernel_emit_nullifier_write_offset,
                               avm_kernel_emit_unencrypted_log_write_offset,
                               avm_kernel_kernel_in_offset,
-                              avm_kernel_kernel_inputs__is_public,
-                              avm_kernel_kernel_metadata_out__is_public,
+                              avm_kernel_kernel_inputs,
+                              avm_kernel_kernel_metadata_out,
                               avm_kernel_kernel_out_offset,
-                              avm_kernel_kernel_side_effect_out__is_public,
-                              avm_kernel_kernel_value_out__is_public,
+                              avm_kernel_kernel_side_effect_out,
+                              avm_kernel_kernel_value_out,
                               avm_kernel_l1_to_l2_msg_exists_write_offset,
                               avm_kernel_note_hash_exist_write_offset,
                               avm_kernel_nullifier_exists_write_offset,
@@ -762,11 +762,11 @@ class AvmFlavor {
                      avm_kernel_emit_nullifier_write_offset,
                      avm_kernel_emit_unencrypted_log_write_offset,
                      avm_kernel_kernel_in_offset,
-                     avm_kernel_kernel_inputs__is_public,
-                     avm_kernel_kernel_metadata_out__is_public,
+                     avm_kernel_kernel_inputs,
+                     avm_kernel_kernel_metadata_out,
                      avm_kernel_kernel_out_offset,
-                     avm_kernel_kernel_side_effect_out__is_public,
-                     avm_kernel_kernel_value_out__is_public,
+                     avm_kernel_kernel_side_effect_out,
+                     avm_kernel_kernel_value_out,
                      avm_kernel_l1_to_l2_msg_exists_write_offset,
                      avm_kernel_note_hash_exist_write_offset,
                      avm_kernel_nullifier_exists_write_offset,
@@ -1153,11 +1153,11 @@ class AvmFlavor {
                               avm_kernel_emit_nullifier_write_offset,
                               avm_kernel_emit_unencrypted_log_write_offset,
                               avm_kernel_kernel_in_offset,
-                              avm_kernel_kernel_inputs__is_public,
-                              avm_kernel_kernel_metadata_out__is_public,
+                              avm_kernel_kernel_inputs,
+                              avm_kernel_kernel_metadata_out,
                               avm_kernel_kernel_out_offset,
-                              avm_kernel_kernel_side_effect_out__is_public,
-                              avm_kernel_kernel_value_out__is_public,
+                              avm_kernel_kernel_side_effect_out,
+                              avm_kernel_kernel_value_out,
                               avm_kernel_l1_to_l2_msg_exists_write_offset,
                               avm_kernel_note_hash_exist_write_offset,
                               avm_kernel_nullifier_exists_write_offset,
@@ -1606,11 +1606,11 @@ class AvmFlavor {
                      avm_kernel_emit_nullifier_write_offset,
                      avm_kernel_emit_unencrypted_log_write_offset,
                      avm_kernel_kernel_in_offset,
-                     avm_kernel_kernel_inputs__is_public,
-                     avm_kernel_kernel_metadata_out__is_public,
+                     avm_kernel_kernel_inputs,
+                     avm_kernel_kernel_metadata_out,
                      avm_kernel_kernel_out_offset,
-                     avm_kernel_kernel_side_effect_out__is_public,
-                     avm_kernel_kernel_value_out__is_public,
+                     avm_kernel_kernel_side_effect_out,
+                     avm_kernel_kernel_value_out,
                      avm_kernel_l1_to_l2_msg_exists_write_offset,
                      avm_kernel_note_hash_exist_write_offset,
                      avm_kernel_nullifier_exists_write_offset,
@@ -2059,11 +2059,11 @@ class AvmFlavor {
                      avm_kernel_emit_nullifier_write_offset,
                      avm_kernel_emit_unencrypted_log_write_offset,
                      avm_kernel_kernel_in_offset,
-                     avm_kernel_kernel_inputs__is_public,
-                     avm_kernel_kernel_metadata_out__is_public,
+                     avm_kernel_kernel_inputs,
+                     avm_kernel_kernel_metadata_out,
                      avm_kernel_kernel_out_offset,
-                     avm_kernel_kernel_side_effect_out__is_public,
-                     avm_kernel_kernel_value_out__is_public,
+                     avm_kernel_kernel_side_effect_out,
+                     avm_kernel_kernel_value_out,
                      avm_kernel_l1_to_l2_msg_exists_write_offset,
                      avm_kernel_note_hash_exist_write_offset,
                      avm_kernel_nullifier_exists_write_offset,
@@ -2868,11 +2868,11 @@ class AvmFlavor {
             Base::avm_kernel_emit_nullifier_write_offset = "AVM_KERNEL_EMIT_NULLIFIER_WRITE_OFFSET";
             Base::avm_kernel_emit_unencrypted_log_write_offset = "AVM_KERNEL_EMIT_UNENCRYPTED_LOG_WRITE_OFFSET";
             Base::avm_kernel_kernel_in_offset = "AVM_KERNEL_KERNEL_IN_OFFSET";
-            Base::avm_kernel_kernel_inputs__is_public = "AVM_KERNEL_KERNEL_INPUTS__IS_PUBLIC";
-            Base::avm_kernel_kernel_metadata_out__is_public = "AVM_KERNEL_KERNEL_METADATA_OUT__IS_PUBLIC";
+            Base::avm_kernel_kernel_inputs = "AVM_KERNEL_KERNEL_INPUTS";
+            Base::avm_kernel_kernel_metadata_out = "AVM_KERNEL_KERNEL_METADATA_OUT";
             Base::avm_kernel_kernel_out_offset = "AVM_KERNEL_KERNEL_OUT_OFFSET";
-            Base::avm_kernel_kernel_side_effect_out__is_public = "AVM_KERNEL_KERNEL_SIDE_EFFECT_OUT__IS_PUBLIC";
-            Base::avm_kernel_kernel_value_out__is_public = "AVM_KERNEL_KERNEL_VALUE_OUT__IS_PUBLIC";
+            Base::avm_kernel_kernel_side_effect_out = "AVM_KERNEL_KERNEL_SIDE_EFFECT_OUT";
+            Base::avm_kernel_kernel_value_out = "AVM_KERNEL_KERNEL_VALUE_OUT";
             Base::avm_kernel_l1_to_l2_msg_exists_write_offset = "AVM_KERNEL_L1_TO_L2_MSG_EXISTS_WRITE_OFFSET";
             Base::avm_kernel_note_hash_exist_write_offset = "AVM_KERNEL_NOTE_HASH_EXIST_WRITE_OFFSET";
             Base::avm_kernel_nullifier_exists_write_offset = "AVM_KERNEL_NULLIFIER_EXISTS_WRITE_OFFSET";
@@ -3271,11 +3271,11 @@ class AvmFlavor {
         Commitment avm_kernel_emit_nullifier_write_offset;
         Commitment avm_kernel_emit_unencrypted_log_write_offset;
         Commitment avm_kernel_kernel_in_offset;
-        Commitment avm_kernel_kernel_inputs__is_public;
-        Commitment avm_kernel_kernel_metadata_out__is_public;
+        Commitment avm_kernel_kernel_inputs;
+        Commitment avm_kernel_kernel_metadata_out;
         Commitment avm_kernel_kernel_out_offset;
-        Commitment avm_kernel_kernel_side_effect_out__is_public;
-        Commitment avm_kernel_kernel_value_out__is_public;
+        Commitment avm_kernel_kernel_side_effect_out;
+        Commitment avm_kernel_kernel_value_out;
         Commitment avm_kernel_l1_to_l2_msg_exists_write_offset;
         Commitment avm_kernel_note_hash_exist_write_offset;
         Commitment avm_kernel_nullifier_exists_write_offset;
@@ -3678,15 +3678,12 @@ class AvmFlavor {
             avm_kernel_emit_unencrypted_log_write_offset =
                 deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_kernel_kernel_in_offset = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
-            avm_kernel_kernel_inputs__is_public =
-                deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
-            avm_kernel_kernel_metadata_out__is_public =
-                deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
+            avm_kernel_kernel_inputs = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
+            avm_kernel_kernel_metadata_out = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_kernel_kernel_out_offset = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
-            avm_kernel_kernel_side_effect_out__is_public =
+            avm_kernel_kernel_side_effect_out =
                 deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
-            avm_kernel_kernel_value_out__is_public =
-                deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
+            avm_kernel_kernel_value_out = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_kernel_l1_to_l2_msg_exists_write_offset =
                 deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             avm_kernel_note_hash_exist_write_offset =
@@ -4101,11 +4098,11 @@ class AvmFlavor {
             serialize_to_buffer<Commitment>(avm_kernel_emit_nullifier_write_offset, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_kernel_emit_unencrypted_log_write_offset, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_kernel_kernel_in_offset, Transcript::proof_data);
-            serialize_to_buffer<Commitment>(avm_kernel_kernel_inputs__is_public, Transcript::proof_data);
-            serialize_to_buffer<Commitment>(avm_kernel_kernel_metadata_out__is_public, Transcript::proof_data);
+            serialize_to_buffer<Commitment>(avm_kernel_kernel_inputs, Transcript::proof_data);
+            serialize_to_buffer<Commitment>(avm_kernel_kernel_metadata_out, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_kernel_kernel_out_offset, Transcript::proof_data);
-            serialize_to_buffer<Commitment>(avm_kernel_kernel_side_effect_out__is_public, Transcript::proof_data);
-            serialize_to_buffer<Commitment>(avm_kernel_kernel_value_out__is_public, Transcript::proof_data);
+            serialize_to_buffer<Commitment>(avm_kernel_kernel_side_effect_out, Transcript::proof_data);
+            serialize_to_buffer<Commitment>(avm_kernel_kernel_value_out, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_kernel_l1_to_l2_msg_exists_write_offset, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_kernel_note_hash_exist_write_offset, Transcript::proof_data);
             serialize_to_buffer<Commitment>(avm_kernel_nullifier_exists_write_offset, Transcript::proof_data);

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.cpp
@@ -184,15 +184,12 @@ void AvmProver::execute_wire_commitments_round()
     witness_commitments.avm_kernel_emit_unencrypted_log_write_offset =
         commitment_key->commit(key->avm_kernel_emit_unencrypted_log_write_offset);
     witness_commitments.avm_kernel_kernel_in_offset = commitment_key->commit(key->avm_kernel_kernel_in_offset);
-    witness_commitments.avm_kernel_kernel_inputs__is_public =
-        commitment_key->commit(key->avm_kernel_kernel_inputs__is_public);
-    witness_commitments.avm_kernel_kernel_metadata_out__is_public =
-        commitment_key->commit(key->avm_kernel_kernel_metadata_out__is_public);
+    witness_commitments.avm_kernel_kernel_inputs = commitment_key->commit(key->avm_kernel_kernel_inputs);
+    witness_commitments.avm_kernel_kernel_metadata_out = commitment_key->commit(key->avm_kernel_kernel_metadata_out);
     witness_commitments.avm_kernel_kernel_out_offset = commitment_key->commit(key->avm_kernel_kernel_out_offset);
-    witness_commitments.avm_kernel_kernel_side_effect_out__is_public =
-        commitment_key->commit(key->avm_kernel_kernel_side_effect_out__is_public);
-    witness_commitments.avm_kernel_kernel_value_out__is_public =
-        commitment_key->commit(key->avm_kernel_kernel_value_out__is_public);
+    witness_commitments.avm_kernel_kernel_side_effect_out =
+        commitment_key->commit(key->avm_kernel_kernel_side_effect_out);
+    witness_commitments.avm_kernel_kernel_value_out = commitment_key->commit(key->avm_kernel_kernel_value_out);
     witness_commitments.avm_kernel_l1_to_l2_msg_exists_write_offset =
         commitment_key->commit(key->avm_kernel_l1_to_l2_msg_exists_write_offset);
     witness_commitments.avm_kernel_note_hash_exist_write_offset =
@@ -556,16 +553,16 @@ void AvmProver::execute_wire_commitments_round()
                                  witness_commitments.avm_kernel_emit_unencrypted_log_write_offset);
     transcript->send_to_verifier(commitment_labels.avm_kernel_kernel_in_offset,
                                  witness_commitments.avm_kernel_kernel_in_offset);
-    transcript->send_to_verifier(commitment_labels.avm_kernel_kernel_inputs__is_public,
-                                 witness_commitments.avm_kernel_kernel_inputs__is_public);
-    transcript->send_to_verifier(commitment_labels.avm_kernel_kernel_metadata_out__is_public,
-                                 witness_commitments.avm_kernel_kernel_metadata_out__is_public);
+    transcript->send_to_verifier(commitment_labels.avm_kernel_kernel_inputs,
+                                 witness_commitments.avm_kernel_kernel_inputs);
+    transcript->send_to_verifier(commitment_labels.avm_kernel_kernel_metadata_out,
+                                 witness_commitments.avm_kernel_kernel_metadata_out);
     transcript->send_to_verifier(commitment_labels.avm_kernel_kernel_out_offset,
                                  witness_commitments.avm_kernel_kernel_out_offset);
-    transcript->send_to_verifier(commitment_labels.avm_kernel_kernel_side_effect_out__is_public,
-                                 witness_commitments.avm_kernel_kernel_side_effect_out__is_public);
-    transcript->send_to_verifier(commitment_labels.avm_kernel_kernel_value_out__is_public,
-                                 witness_commitments.avm_kernel_kernel_value_out__is_public);
+    transcript->send_to_verifier(commitment_labels.avm_kernel_kernel_side_effect_out,
+                                 witness_commitments.avm_kernel_kernel_side_effect_out);
+    transcript->send_to_verifier(commitment_labels.avm_kernel_kernel_value_out,
+                                 witness_commitments.avm_kernel_kernel_value_out);
     transcript->send_to_verifier(commitment_labels.avm_kernel_l1_to_l2_msg_exists_write_offset,
                                  witness_commitments.avm_kernel_l1_to_l2_msg_exists_write_offset);
     transcript->send_to_verifier(commitment_labels.avm_kernel_note_hash_exist_write_offset,

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_verifier.cpp
@@ -272,16 +272,16 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
         commitment_labels.avm_kernel_emit_unencrypted_log_write_offset);
     commitments.avm_kernel_kernel_in_offset =
         transcript->template receive_from_prover<Commitment>(commitment_labels.avm_kernel_kernel_in_offset);
-    commitments.avm_kernel_kernel_inputs__is_public =
-        transcript->template receive_from_prover<Commitment>(commitment_labels.avm_kernel_kernel_inputs__is_public);
-    commitments.avm_kernel_kernel_metadata_out__is_public = transcript->template receive_from_prover<Commitment>(
-        commitment_labels.avm_kernel_kernel_metadata_out__is_public);
+    commitments.avm_kernel_kernel_inputs =
+        transcript->template receive_from_prover<Commitment>(commitment_labels.avm_kernel_kernel_inputs);
+    commitments.avm_kernel_kernel_metadata_out =
+        transcript->template receive_from_prover<Commitment>(commitment_labels.avm_kernel_kernel_metadata_out);
     commitments.avm_kernel_kernel_out_offset =
         transcript->template receive_from_prover<Commitment>(commitment_labels.avm_kernel_kernel_out_offset);
-    commitments.avm_kernel_kernel_side_effect_out__is_public = transcript->template receive_from_prover<Commitment>(
-        commitment_labels.avm_kernel_kernel_side_effect_out__is_public);
-    commitments.avm_kernel_kernel_value_out__is_public =
-        transcript->template receive_from_prover<Commitment>(commitment_labels.avm_kernel_kernel_value_out__is_public);
+    commitments.avm_kernel_kernel_side_effect_out =
+        transcript->template receive_from_prover<Commitment>(commitment_labels.avm_kernel_kernel_side_effect_out);
+    commitments.avm_kernel_kernel_value_out =
+        transcript->template receive_from_prover<Commitment>(commitment_labels.avm_kernel_kernel_value_out);
     commitments.avm_kernel_l1_to_l2_msg_exists_write_offset = transcript->template receive_from_prover<Commitment>(
         commitment_labels.avm_kernel_l1_to_l2_msg_exists_write_offset);
     commitments.avm_kernel_note_hash_exist_write_offset =
@@ -778,30 +778,27 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
 
     // Public columns evaluation checks
 
-    FF avm_kernel_kernel_inputs__is_public_evaluation =
+    FF avm_kernel_kernel_inputs_evaluation =
         evaluate_public_input_column(public_inputs[0], circuit_size, multivariate_challenge);
-    if (avm_kernel_kernel_inputs__is_public_evaluation != claimed_evaluations.avm_kernel_kernel_inputs__is_public) {
+    if (avm_kernel_kernel_inputs_evaluation != claimed_evaluations.avm_kernel_kernel_inputs) {
         return false;
     }
 
-    FF avm_kernel_kernel_metadata_out__is_public_evaluation =
-        evaluate_public_input_column(public_inputs[3], circuit_size, multivariate_challenge);
-    if (avm_kernel_kernel_metadata_out__is_public_evaluation !=
-        claimed_evaluations.avm_kernel_kernel_metadata_out__is_public) {
-        return false;
-    }
-
-    FF avm_kernel_kernel_side_effect_out__is_public_evaluation =
-        evaluate_public_input_column(public_inputs[2], circuit_size, multivariate_challenge);
-    if (avm_kernel_kernel_side_effect_out__is_public_evaluation !=
-        claimed_evaluations.avm_kernel_kernel_side_effect_out__is_public) {
-        return false;
-    }
-
-    FF avm_kernel_kernel_value_out__is_public_evaluation =
+    FF avm_kernel_kernel_value_out_evaluation =
         evaluate_public_input_column(public_inputs[1], circuit_size, multivariate_challenge);
-    if (avm_kernel_kernel_value_out__is_public_evaluation !=
-        claimed_evaluations.avm_kernel_kernel_value_out__is_public) {
+    if (avm_kernel_kernel_value_out_evaluation != claimed_evaluations.avm_kernel_kernel_value_out) {
+        return false;
+    }
+
+    FF avm_kernel_kernel_side_effect_out_evaluation =
+        evaluate_public_input_column(public_inputs[2], circuit_size, multivariate_challenge);
+    if (avm_kernel_kernel_side_effect_out_evaluation != claimed_evaluations.avm_kernel_kernel_side_effect_out) {
+        return false;
+    }
+
+    FF avm_kernel_kernel_metadata_out_evaluation =
+        evaluate_public_input_column(public_inputs[3], circuit_size, multivariate_challenge);
+    if (avm_kernel_kernel_metadata_out_evaluation != claimed_evaluations.avm_kernel_kernel_metadata_out) {
         return false;
     }
 

--- a/barretenberg/cpp/src/barretenberg/vm/tests/avm_execution.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/tests/avm_execution.test.cpp
@@ -1753,8 +1753,8 @@ TEST_F(AvmExecutionTests, kernelOutputEmitOpcodes)
     uint32_t emit_note_hash_out_offset = AvmKernelTraceBuilder::START_EMIT_NOTE_HASH_WRITE_OFFSET;
     auto emit_note_hash_kernel_out_row = std::ranges::find_if(
         trace.begin(), trace.end(), [&](Row r) { return r.avm_main_clk == emit_note_hash_out_offset; });
-    EXPECT_EQ(emit_note_hash_kernel_out_row->avm_kernel_kernel_value_out__is_public, 1);
-    EXPECT_EQ(emit_note_hash_kernel_out_row->avm_kernel_kernel_side_effect_out__is_public, 0);
+    EXPECT_EQ(emit_note_hash_kernel_out_row->avm_kernel_kernel_value_out, 1);
+    EXPECT_EQ(emit_note_hash_kernel_out_row->avm_kernel_kernel_side_effect_out, 0);
 
     // CHECK EMIT NULLIFIER
     auto emit_nullifier_row =
@@ -1765,8 +1765,8 @@ TEST_F(AvmExecutionTests, kernelOutputEmitOpcodes)
     uint32_t emit_nullifier_out_offset = AvmKernelTraceBuilder::START_EMIT_NULLIFIER_WRITE_OFFSET;
     auto emit_nullifier_kernel_out_row = std::ranges::find_if(
         trace.begin(), trace.end(), [&](Row r) { return r.avm_main_clk == emit_nullifier_out_offset; });
-    EXPECT_EQ(emit_nullifier_kernel_out_row->avm_kernel_kernel_value_out__is_public, 1);
-    EXPECT_EQ(emit_nullifier_kernel_out_row->avm_kernel_kernel_side_effect_out__is_public, 1);
+    EXPECT_EQ(emit_nullifier_kernel_out_row->avm_kernel_kernel_value_out, 1);
+    EXPECT_EQ(emit_nullifier_kernel_out_row->avm_kernel_kernel_side_effect_out, 1);
 
     // CHECK EMIT UNENCRYPTED LOG
     auto emit_log_row = std::ranges::find_if(
@@ -1777,8 +1777,8 @@ TEST_F(AvmExecutionTests, kernelOutputEmitOpcodes)
     uint32_t emit_log_out_offset = AvmKernelTraceBuilder::START_EMIT_UNENCRYPTED_LOG_WRITE_OFFSET;
     auto emit_log_kernel_out_row =
         std::ranges::find_if(trace.begin(), trace.end(), [&](Row r) { return r.avm_main_clk == emit_log_out_offset; });
-    EXPECT_EQ(emit_log_kernel_out_row->avm_kernel_kernel_value_out__is_public, 1);
-    EXPECT_EQ(emit_log_kernel_out_row->avm_kernel_kernel_side_effect_out__is_public, 2);
+    EXPECT_EQ(emit_log_kernel_out_row->avm_kernel_kernel_value_out, 1);
+    EXPECT_EQ(emit_log_kernel_out_row->avm_kernel_kernel_side_effect_out, 2);
 
     // CHECK SEND L2 TO L1 MSG
     auto send_row = std::ranges::find_if(
@@ -1790,9 +1790,9 @@ TEST_F(AvmExecutionTests, kernelOutputEmitOpcodes)
     auto msg_out_row = std::ranges::find_if(trace.begin(), trace.end(), [&](Row r) {
         return r.avm_main_clk == AvmKernelTraceBuilder::START_L2_TO_L1_MSG_WRITE_OFFSET;
     });
-    EXPECT_EQ(msg_out_row->avm_kernel_kernel_value_out__is_public, 1);
-    EXPECT_EQ(msg_out_row->avm_kernel_kernel_side_effect_out__is_public, 3);
-    EXPECT_EQ(msg_out_row->avm_kernel_kernel_metadata_out__is_public, 1);
+    EXPECT_EQ(msg_out_row->avm_kernel_kernel_value_out, 1);
+    EXPECT_EQ(msg_out_row->avm_kernel_kernel_side_effect_out, 3);
+    EXPECT_EQ(msg_out_row->avm_kernel_kernel_metadata_out, 1);
 
     validate_trace(std::move(trace));
 }
@@ -1848,9 +1848,9 @@ TEST_F(AvmExecutionTests, kernelOutputStorageLoadOpcodeSimple)
     uint32_t sload_out_offset = AvmKernelTraceBuilder::START_SLOAD_WRITE_OFFSET;
     auto sload_kernel_out_row =
         std::ranges::find_if(trace.begin(), trace.end(), [&](Row r) { return r.avm_main_clk == sload_out_offset; });
-    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_value_out__is_public, 42); // value
-    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_side_effect_out__is_public, 0);
-    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_metadata_out__is_public, 9); // slot
+    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_value_out, 42); // value
+    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_side_effect_out, 0);
+    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_metadata_out, 9); // slot
 
     validate_trace(std::move(trace));
 }
@@ -1910,13 +1910,13 @@ TEST_F(AvmExecutionTests, kernelOutputStorageLoadOpcodeComplex)
     uint32_t sload_out_offset = AvmKernelTraceBuilder::START_SLOAD_WRITE_OFFSET;
     auto sload_kernel_out_row =
         std::ranges::find_if(trace.begin(), trace.end(), [&](Row r) { return r.avm_main_clk == sload_out_offset; });
-    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_value_out__is_public, 42); // value
-    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_side_effect_out__is_public, 0);
-    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_metadata_out__is_public, 9); // slot
+    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_value_out, 42); // value
+    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_side_effect_out, 0);
+    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_metadata_out, 9); // slot
     sload_kernel_out_row++;
-    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_value_out__is_public, 123); // value
-    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_side_effect_out__is_public, 1);
-    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_metadata_out__is_public, 10); // slot
+    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_value_out, 123); // value
+    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_side_effect_out, 1);
+    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_metadata_out, 10); // slot
 
     validate_trace(std::move(trace));
 }
@@ -1960,9 +1960,9 @@ TEST_F(AvmExecutionTests, kernelOutputStorageStoreOpcodeSimple)
     uint32_t sstore_out_offset = AvmKernelTraceBuilder::START_SSTORE_WRITE_OFFSET;
     auto sstore_kernel_out_row =
         std::ranges::find_if(trace.begin(), trace.end(), [&](Row r) { return r.avm_main_clk == sstore_out_offset; });
-    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_value_out__is_public, 42); // value
-    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_side_effect_out__is_public, 0);
-    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_metadata_out__is_public, 9); // slot
+    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_value_out, 42); // value
+    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_side_effect_out, 0);
+    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_metadata_out, 9); // slot
 
     validate_trace(std::move(trace));
 }
@@ -2016,13 +2016,13 @@ TEST_F(AvmExecutionTests, kernelOutputStorageStoreOpcodeComplex)
     uint32_t sstore_out_offset = AvmKernelTraceBuilder::START_SSTORE_WRITE_OFFSET;
     auto sstore_kernel_out_row =
         std::ranges::find_if(trace.begin(), trace.end(), [&](Row r) { return r.avm_main_clk == sstore_out_offset; });
-    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_value_out__is_public, 42); // value
-    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_side_effect_out__is_public, 0);
-    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_metadata_out__is_public, 9); // slot
+    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_value_out, 42); // value
+    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_side_effect_out, 0);
+    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_metadata_out, 9); // slot
     sstore_kernel_out_row++;
-    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_value_out__is_public, 123); // value
-    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_side_effect_out__is_public, 1);
-    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_metadata_out__is_public, 10); // slot
+    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_value_out, 123); // value
+    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_side_effect_out, 1);
+    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_metadata_out, 10); // slot
 
     validate_trace(std::move(trace));
 }
@@ -2083,9 +2083,9 @@ TEST_F(AvmExecutionTests, kernelOutputStorageOpcodes)
     uint32_t sload_out_offset = AvmKernelTraceBuilder::START_SLOAD_WRITE_OFFSET;
     auto sload_kernel_out_row =
         std::ranges::find_if(trace.begin(), trace.end(), [&](Row r) { return r.avm_main_clk == sload_out_offset; });
-    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_value_out__is_public, 42); // value
-    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_side_effect_out__is_public, 0);
-    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_metadata_out__is_public, 9); // slot
+    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_value_out, 42); // value
+    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_side_effect_out, 0);
+    EXPECT_EQ(sload_kernel_out_row->avm_kernel_kernel_metadata_out, 9); // slot
 
     // CHECK SSTORE
     auto sstore_row =
@@ -2098,9 +2098,9 @@ TEST_F(AvmExecutionTests, kernelOutputStorageOpcodes)
     uint32_t sstore_out_offset = AvmKernelTraceBuilder::START_SSTORE_WRITE_OFFSET;
     auto sstore_kernel_out_row =
         std::ranges::find_if(trace.begin(), trace.end(), [&](Row r) { return r.avm_main_clk == sstore_out_offset; });
-    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_value_out__is_public, 42); // value
-    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_side_effect_out__is_public, 1);
-    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_metadata_out__is_public, 9); // slot
+    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_value_out, 42); // value
+    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_side_effect_out, 1);
+    EXPECT_EQ(sstore_kernel_out_row->avm_kernel_kernel_metadata_out, 9); // slot
 
     validate_trace(std::move(trace));
 }
@@ -2162,9 +2162,9 @@ TEST_F(AvmExecutionTests, kernelOutputHashExistsOpcodes)
     auto note_hash_out_row = std::ranges::find_if(trace.begin(), trace.end(), [&](Row r) {
         return r.avm_main_clk == AvmKernelTraceBuilder::START_NOTE_HASH_EXISTS_WRITE_OFFSET;
     });
-    EXPECT_EQ(note_hash_out_row->avm_kernel_kernel_value_out__is_public, 1); // value
-    EXPECT_EQ(note_hash_out_row->avm_kernel_kernel_side_effect_out__is_public, 0);
-    EXPECT_EQ(note_hash_out_row->avm_kernel_kernel_metadata_out__is_public, 1); // exists
+    EXPECT_EQ(note_hash_out_row->avm_kernel_kernel_value_out, 1); // value
+    EXPECT_EQ(note_hash_out_row->avm_kernel_kernel_side_effect_out, 0);
+    EXPECT_EQ(note_hash_out_row->avm_kernel_kernel_metadata_out, 1); // exists
 
     // CHECK NULLIFIEREXISTS
     auto nullifier_row =
@@ -2176,9 +2176,9 @@ TEST_F(AvmExecutionTests, kernelOutputHashExistsOpcodes)
     auto nullifier_out_row = std::ranges::find_if(trace.begin(), trace.end(), [&](Row r) {
         return r.avm_main_clk == AvmKernelTraceBuilder::START_NULLIFIER_EXISTS_OFFSET;
     });
-    EXPECT_EQ(nullifier_out_row->avm_kernel_kernel_value_out__is_public, 1); // value
-    EXPECT_EQ(nullifier_out_row->avm_kernel_kernel_side_effect_out__is_public, 1);
-    EXPECT_EQ(nullifier_out_row->avm_kernel_kernel_metadata_out__is_public, 1); // exists
+    EXPECT_EQ(nullifier_out_row->avm_kernel_kernel_value_out, 1); // value
+    EXPECT_EQ(nullifier_out_row->avm_kernel_kernel_side_effect_out, 1);
+    EXPECT_EQ(nullifier_out_row->avm_kernel_kernel_metadata_out, 1); // exists
 
     // CHECK L1TOL2MSGEXISTS
     auto l1_to_l2_row = std::ranges::find_if(
@@ -2190,9 +2190,9 @@ TEST_F(AvmExecutionTests, kernelOutputHashExistsOpcodes)
     auto msg_out_row = std::ranges::find_if(trace.begin(), trace.end(), [&](Row r) {
         return r.avm_main_clk == AvmKernelTraceBuilder::START_L1_TO_L2_MSG_EXISTS_WRITE_OFFSET;
     });
-    EXPECT_EQ(msg_out_row->avm_kernel_kernel_value_out__is_public, 1); // value
-    EXPECT_EQ(msg_out_row->avm_kernel_kernel_side_effect_out__is_public, 2);
-    EXPECT_EQ(msg_out_row->avm_kernel_kernel_metadata_out__is_public, 1); // exists
+    EXPECT_EQ(msg_out_row->avm_kernel_kernel_value_out, 1); // value
+    EXPECT_EQ(msg_out_row->avm_kernel_kernel_side_effect_out, 2);
+    EXPECT_EQ(msg_out_row->avm_kernel_kernel_metadata_out, 1); // exists
 
     validate_trace(std::move(trace));
 }

--- a/barretenberg/cpp/src/barretenberg/vm/tests/avm_kernel.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/tests/avm_kernel.test.cpp
@@ -161,9 +161,9 @@ void expect_output_table_row_with_exists_metadata(std::vector<Row>::const_iterat
 
 void check_kernel_outputs(const Row& row, FF value, FF side_effect_counter, FF metadata)
 {
-    EXPECT_EQ(row.avm_kernel_kernel_value_out__is_public, value);
-    EXPECT_EQ(row.avm_kernel_kernel_side_effect_out__is_public, side_effect_counter);
-    EXPECT_EQ(row.avm_kernel_kernel_metadata_out__is_public, metadata);
+    EXPECT_EQ(row.avm_kernel_kernel_value_out, value);
+    EXPECT_EQ(row.avm_kernel_kernel_side_effect_out, side_effect_counter);
+    EXPECT_EQ(row.avm_kernel_kernel_metadata_out, metadata);
 }
 
 TEST_F(AvmKernelPositiveTests, kernelSender)


### PR DESCRIPTION
PIL must be compiled with: https://github.com/AztecProtocol/powdr/pull/69/

Now the `__is_public` suffix is also not needed.