### PR TITLE
docs: clarify comment on collapse

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils.nr
@@ -56,9 +56,9 @@ fn verify_collapse_hints<T, N>(
             }
             last_index = Option::some(input_index);
         } else {
-            // We don't technically need to check past the length of the BoundedVec since those slots should not be
-            // accessible, but its fairly cheap to prevent dirty data from being stored there.
-            assert_eq(collapsed.get_unchecked(i), dep::std::unsafe::zeroed(), "Dirty collapsed vec");
+            // BoundedVec assumes that the unused parts of the storage are zeroed out (e.g. in the Eq impl), so we make
+            // sure that this property holds.
+            assert_eq(collapsed.get_unchecked(i), dep::std::unsafe::zeroed(), "Dirty collapsed vec storage");
         }
     }
     // We now know that:

--- a/noir-projects/aztec-nr/aztec/src/utils/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/test.nr
@@ -111,7 +111,7 @@ fn verify_collapse_hints_wrong_vec_order() {
     verify_collapse_hints(original, collapsed, collapsed_to_input_index_mapping);
 }
 
-#[test(should_fail_with="Dirty collapsed vec")]
+#[test(should_fail_with="Dirty collapsed vec storage")]
 fn verify_collapse_hints_dirty_storage() {
     let original = [Option::some(7), Option::none(), Option::some(3)];
 


### PR DESCRIPTION
Turns out it's very important to make sure the storage is indeed clean - otherwise we could have `eq` return false for equivalent arrays.