### PR TITLE
fix: false decryption

### DIFF
--- a/yarn-project/circuit-types/src/logs/l1_payload/tagged_log.ts
+++ b/yarn-project/circuit-types/src/logs/l1_payload/tagged_log.ts
@@ -85,7 +85,6 @@ export class TaggedLog<Payload extends L1NotePayload | L1EventPayload> {
     // as some field will likely end up not being in the field etc.
     try {
       if (payloadType === L1EventPayload) {
-        console.log("decrypting as L1EventPayload");
         const reader = BufferReader.asReader((data as EncryptedL2Log).data);
         const incomingTag = Fr.fromBuffer(reader);
         const outgoingTag = Fr.fromBuffer(reader);

--- a/yarn-project/circuit-types/src/logs/l1_payload/tagged_log.ts
+++ b/yarn-project/circuit-types/src/logs/l1_payload/tagged_log.ts
@@ -1,11 +1,11 @@
 import { AztecAddress, type GrumpkinPrivateKey, type KeyValidationRequest, type PublicKey } from '@aztec/circuits.js';
 import { Fr } from '@aztec/foundation/fields';
+import { createDebugLogger } from '@aztec/foundation/log';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
 import { type EncryptedL2Log } from '../encrypted_l2_log.js';
 import { L1EventPayload } from './l1_event_payload.js';
 import { L1NotePayload } from './l1_note_payload.js';
-import { createDebugLogger } from '@aztec/foundation/log';
 
 // placeholder value until tagging is implemented
 const PLACEHOLDER_TAG = new Fr(33);

--- a/yarn-project/pxe/src/note_processor/note_processor.ts
+++ b/yarn-project/pxe/src/note_processor/note_processor.ts
@@ -156,7 +156,11 @@ export class NoteProcessor {
                 outgoingTaggedNote &&
                 !incomingTaggedNote.payload.equals(outgoingTaggedNote.payload)
               ) {
-                throw new Error('Incoming and outgoing note payloads do not match.');
+                throw new Error(
+                  `Incoming and outgoing note payloads do not match.\nIncoming: ${JSON.stringify(
+                    incomingTaggedNote.payload,
+                  )},\nOutgoing: ${JSON.stringify(outgoingTaggedNote.payload)}`,
+                );
               }
 
               const payload = incomingTaggedNote?.payload || outgoingTaggedNote?.payload;


### PR DESCRIPTION
We get incorrect decryption when a note is empty because the overflow check fails.
