### PR TITLE
chore: track avm proving time

### DIFF
--- a/yarn-project/bb-prover/src/avm_proving.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving.test.ts
@@ -248,12 +248,14 @@ const proveAndVerifyAvmTestContract = async (
     startGas,
     context,
     simulator.getBytecode(),
+    functionName,
   );
   // TODO(dbanks12): public inputs should not be empty.... Need to construct them from AvmContext?
   const uncompressedBytecode = simulator.getBytecode()!;
   const publicInputs = getPublicInputs(pxResult);
 
   const avmCircuitInputs = new AvmCircuitInputs(
+    functionName,
     uncompressedBytecode,
     context.environment.calldata,
     publicInputs,

--- a/yarn-project/circuit-types/src/tx/processed_tx.ts
+++ b/yarn-project/circuit-types/src/tx/processed_tx.ts
@@ -54,6 +54,7 @@ export const AVM_REQUEST = 'AVM' as const;
 
 export type AvmProvingRequest = {
   type: typeof AVM_REQUEST;
+  functionName: string; // informational only
   bytecode: Buffer;
   calldata: Fr[];
   avmHints: AvmExecutionHints;

--- a/yarn-project/circuits.js/src/structs/avm/avm.ts
+++ b/yarn-project/circuits.js/src/structs/avm/avm.ts
@@ -367,6 +367,7 @@ export class AvmExecutionHints {
 
 export class AvmCircuitInputs {
   constructor(
+    public readonly functionName: string, // only informational
     public readonly bytecode: Buffer,
     public readonly calldata: Fr[],
     public readonly publicInputs: PublicCircuitPublicInputs,
@@ -378,7 +379,10 @@ export class AvmCircuitInputs {
    * @returns - The inputs serialized to a buffer.
    */
   toBuffer() {
+    const functionNameBuffer = Buffer.from(this.functionName);
     return serializeToBuffer(
+      functionNameBuffer.length,
+      functionNameBuffer,
       this.bytecode.length,
       this.bytecode,
       this.calldata.length,
@@ -402,7 +406,11 @@ export class AvmCircuitInputs {
    */
   isEmpty(): boolean {
     return (
-      this.bytecode.length == 0 && this.calldata.length == 0 && this.publicInputs.isEmpty() && this.avmHints.isEmpty()
+      this.functionName.length == 0 &&
+      this.bytecode.length == 0 &&
+      this.calldata.length == 0 &&
+      this.publicInputs.isEmpty() &&
+      this.avmHints.isEmpty()
     );
   }
 
@@ -421,7 +429,7 @@ export class AvmCircuitInputs {
    * @returns An array of fields.
    */
   static getFields(fields: FieldsOf<AvmCircuitInputs>) {
-    return [fields.bytecode, fields.calldata, fields.publicInputs, fields.avmHints] as const;
+    return [fields.functionName, fields.bytecode, fields.calldata, fields.publicInputs, fields.avmHints] as const;
   }
 
   /**
@@ -432,8 +440,9 @@ export class AvmCircuitInputs {
   static fromBuffer(buff: Buffer | BufferReader): AvmCircuitInputs {
     const reader = BufferReader.asReader(buff);
     return new AvmCircuitInputs(
-      reader.readBuffer(),
-      reader.readVector(Fr),
+      /*functionName=*/ reader.readBuffer().toString(),
+      /*bytecode=*/ reader.readBuffer(),
+      /*calldata=*/ reader.readVector(Fr),
       PublicCircuitPublicInputs.fromBuffer(reader),
       AvmExecutionHints.fromBuffer(reader),
     );

--- a/yarn-project/circuits.js/src/tests/factories.ts
+++ b/yarn-project/circuits.js/src/tests/factories.ts
@@ -1336,6 +1336,7 @@ export function makeAvmExecutionHints(
  */
 export function makeAvmCircuitInputs(seed = 0, overrides: Partial<FieldsOf<AvmCircuitInputs>> = {}): AvmCircuitInputs {
   return AvmCircuitInputs.from({
+    functionName: `function${seed}`,
     bytecode: makeBytes((seed % 100) + 100, seed),
     calldata: makeArray((seed % 100) + 10, i => new Fr(i), seed + 0x1000),
     publicInputs: makePublicCircuitPublicInputs(seed + 0x2000),

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -772,6 +772,7 @@ export class ProvingOrchestrator {
       // Nothing downstream depends on the AVM proof yet. So having this mode lets us incrementally build the AVM circuit.
       const doAvmProving = async (signal: AbortSignal) => {
         const inputs: AvmCircuitInputs = new AvmCircuitInputs(
+          publicFunction.vmRequest!.functionName,
           publicFunction.vmRequest!.bytecode,
           publicFunction.vmRequest!.calldata,
           publicFunction.vmRequest!.kernelRequest.inputs.publicCall.callStackItem.publicInputs,

--- a/yarn-project/scripts/src/benchmarks/aggregate.ts
+++ b/yarn-project/scripts/src/benchmarks/aggregate.ts
@@ -134,14 +134,25 @@ function processCircuitSimulation(entry: CircuitSimulationStats, results: Benchm
  */
 function processCircuitProving(entry: CircuitProvingStats, results: BenchmarkCollectedResults) {
   if (entry.circuitName === 'app-circuit') {
-    const bucket = entry.appCircuitName;
-    if (!bucket) {
+    if (!entry.appCircuitName) {
       return;
     }
+    const bucket = entry.appCircuitName;
     append(results, 'app_circuit_proving_time_in_ms', bucket, entry.duration);
     append(results, 'app_circuit_proof_size_in_bytes', bucket, entry.proofSize);
     append(results, 'app_circuit_size_in_gates', bucket, entry.circuitSize);
     append(results, 'app_circuit_num_public_inputs', bucket, entry.numPublicInputs);
+  } else if (entry.circuitName === 'avm-circuit') {
+    if (!entry.appCircuitName) {
+      return;
+    }
+    const bucket = `${entry.appCircuitName} (avm)`;
+    append(results, 'app_circuit_proving_time_in_ms', bucket, entry.duration);
+    append(results, 'app_circuit_proof_size_in_bytes', bucket, entry.proofSize);
+    append(results, 'app_circuit_input_size_in_bytes', bucket, entry.inputSize);
+    // These are not yet correctly passed in bb_prover.ts.
+    // append(results, 'app_circuit_size_in_gates', bucket, entry.circuitSize);
+    // append(results, 'app_circuit_num_public_inputs', bucket, entry.numPublicInputs);
   } else {
     const bucket = entry.circuitName;
     append(results, 'protocol_circuit_proving_time_in_ms', bucket, entry.duration);

--- a/yarn-project/simulator/src/avm/opcodes/external_calls.ts
+++ b/yarn-project/simulator/src/avm/opcodes/external_calls.ts
@@ -94,6 +94,11 @@ abstract class ExternalCall extends Instruction {
     const oldStyleExecution = createPublicExecution(startSideEffectCounter, nestedContext.environment, calldata);
     const simulator = new AvmSimulator(nestedContext);
     const nestedCallResults: AvmContractCallResults = await simulator.execute();
+    const functionName =
+      (await nestedContext.persistableState.hostStorage.contractsDb.getDebugFunctionName(
+        nestedContext.environment.address,
+        nestedContext.environment.temporaryFunctionSelector,
+      )) ?? `${nestedContext.environment.address}:${nestedContext.environment.temporaryFunctionSelector}`;
     const pxResults = convertAvmResultsToPxResult(
       nestedCallResults,
       startSideEffectCounter,
@@ -101,6 +106,7 @@ abstract class ExternalCall extends Instruction {
       Gas.from(allocatedGas),
       nestedContext,
       simulator.getBytecode(),
+      functionName,
     );
     // store the old PublicExecutionResult object to maintain a recursive data structure for the old kernel
     context.persistableState.transitionalExecutionResult.nestedExecutions.push(pxResults);

--- a/yarn-project/simulator/src/mocks/fixtures.ts
+++ b/yarn-project/simulator/src/mocks/fixtures.ts
@@ -144,6 +144,7 @@ export class PublicExecutionResultBuilder {
       transactionFee: Fr.ZERO,
       calldata: [],
       avmHints: AvmExecutionHints.empty(),
+      functionName: 'unknown',
       ...overrides,
     };
   }

--- a/yarn-project/simulator/src/public/execution.ts
+++ b/yarn-project/simulator/src/public/execution.ts
@@ -77,6 +77,8 @@ export interface PublicExecutionResult {
   calldata: Fr[];
   /** Hints for proving AVM execution. */
   avmHints: AvmExecutionHints;
+  /** The name of the function that was executed. Only used for logging. */
+  functionName: string;
 }
 
 /**

--- a/yarn-project/simulator/src/public/executor.ts
+++ b/yarn-project/simulator/src/public/executor.ts
@@ -43,7 +43,7 @@ export class PublicExecutor {
     const address = execution.contractAddress;
     const selector = execution.functionSelector;
     const startGas = availableGas;
-    const fnName = await this.contractsDb.getDebugFunctionName(address, selector);
+    const fnName = (await this.contractsDb.getDebugFunctionName(address, selector)) ?? `${address}:${selector}`;
 
     PublicExecutor.log.verbose(`[AVM] Executing public external function ${fnName}.`);
     const timer = new Timer();
@@ -83,7 +83,7 @@ export class PublicExecutor {
       }.`,
       {
         eventName: 'avm-simulation',
-        appCircuitName: fnName ?? 'unknown',
+        appCircuitName: fnName,
         duration: timer.ms(),
         bytecodeSize: bytecode!.length,
       } satisfies AvmSimulationStats,
@@ -96,6 +96,7 @@ export class PublicExecutor {
       startGas,
       avmContext,
       bytecode,
+      fnName,
     );
 
     // TODO(https://github.com/AztecProtocol/aztec-packages/issues/5818): is this really needed?

--- a/yarn-project/simulator/src/public/transitional_adaptors.ts
+++ b/yarn-project/simulator/src/public/transitional_adaptors.ts
@@ -114,12 +114,14 @@ export function convertAvmResultsToPxResult(
   startGas: Gas,
   endAvmContext: AvmContext,
   bytecode: Buffer | undefined,
+  functionName: string,
 ): PublicExecutionResult {
   const endPersistableState = endAvmContext.persistableState;
   const endMachineState = endAvmContext.machineState;
 
   return {
     ...endPersistableState.transitionalExecutionResult, // includes nestedExecutions
+    functionName: functionName,
     execution: fromPx,
     returnValues: avmResult.output,
     startSideEffectCounter: new Fr(startSideEffectCounter),


### PR DESCRIPTION
Almost all that was missing was having an `appCircuitName` when avm-proving.