### PR TITLE
chore: Remove unneeded public input folding

### DIFF
--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy.test.cpp
@@ -311,6 +311,34 @@ template <typename Flavor> class ProtoGalaxyTests : public testing::Test {
     }
 
     /**
+     * @brief Testing one valid round of folding followed by the decider.
+     * @brief For additional robustness we give one of the circuits more public inputs than the other
+     *
+     */
+    static void test_full_protogalaxy_simple()
+    {
+        // Construct a first circuit with some public inputs
+        Builder builder1;
+        construct_circuit(builder1);
+        bb::MockCircuits::add_arithmetic_gates_with_public_inputs(builder1, /*num_gates=*/4);
+
+        // Construct a second circuit with no public inputs
+        Builder builder2;
+        construct_circuit(builder2);
+
+        // Construct the prover/verifier instances for each
+        TupleOfInstances instances;
+        construct_prover_and_verifier_instance(instances, builder1);
+        construct_prover_and_verifier_instance(instances, builder2);
+
+        // Perform prover and verifier folding
+        auto [prover_accumulator, verifier_accumulator] = fold_and_verify(get<0>(instances), get<1>(instances));
+        check_accumulator_target_sum_manual(prover_accumulator, true);
+
+        decide_and_verify(prover_accumulator, verifier_accumulator, true);
+    }
+
+    /**
      * @brief Testing two valid rounds of folding followed by the decider.
      *
      */
@@ -487,6 +515,11 @@ TYPED_TEST(ProtoGalaxyTests, CombineRelationParameters)
 TYPED_TEST(ProtoGalaxyTests, CombineAlpha)
 {
     TestFixture::test_combine_alpha();
+}
+
+TYPED_TEST(ProtoGalaxyTests, FullProtogalaxySimple)
+{
+    TestFixture::test_full_protogalaxy_simple();
 }
 
 TYPED_TEST(ProtoGalaxyTests, FullProtogalaxyTest)

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -104,22 +104,6 @@ std::shared_ptr<typename ProverInstances::Instance> ProtoGalaxyProver_<ProverIns
         });
     }
 
-    // Fold the public inputs and send to the verifier
-    size_t el_idx = 0;
-    for (auto& el : next_accumulator->proving_key.public_inputs) {
-        el *= lagranges[0];
-        size_t inst = 0;
-        for (size_t inst_idx = 1; inst_idx < ProverInstances::NUM; inst_idx++) {
-            auto& instance = instances[inst_idx];
-            // TODO(https://github.com/AztecProtocol/barretenberg/issues/830)
-            if (instance->proving_key.num_public_inputs >= next_accumulator->proving_key.num_public_inputs) {
-                el += instance->proving_key.public_inputs[el_idx] * lagranges[inst];
-                inst++;
-            };
-        }
-        el_idx++;
-    }
-
     // Evaluate the combined batching  α_i univariate at challenge to obtain next α_i and send it to the
     // verifier, where i ∈ {0,...,NUM_SUBRELATIONS - 1}
     auto& folded_alphas = next_accumulator->alphas;

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -115,19 +115,7 @@ std::shared_ptr<typename VerifierInstances::Instance> ProtoGalaxyVerifier_<Verif
     next_accumulator->verification_key->num_public_inputs = accumulator->verification_key->num_public_inputs;
     next_accumulator->public_inputs =
         std::vector<FF>(static_cast<size_t>(next_accumulator->verification_key->num_public_inputs), 0);
-    size_t public_input_idx = 0;
-    for (auto& public_input : next_accumulator->public_inputs) {
-        size_t inst = 0;
-        for (auto& instance : instances) {
-            // TODO(https://github.com/AztecProtocol/barretenberg/issues/830)
-            if (instance->verification_key->num_public_inputs >=
-                next_accumulator->verification_key->num_public_inputs) {
-                public_input += instance->public_inputs[public_input_idx] * lagranges[inst];
-                inst++;
-            }
-        }
-        public_input_idx++;
-    }
+
     next_accumulator->is_accumulator = true;
 
     // Compute next folding parameters

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/protogalaxy_recursive_verifier.cpp
@@ -177,21 +177,6 @@ std::shared_ptr<typename VerifierInstances::Instance> ProtoGalaxyRecursiveVerifi
     // Compute ϕ
     fold_commitments(lagranges, instances, next_accumulator);
 
-    next_accumulator->public_inputs =
-        std::vector<FF>(static_cast<size_t>(next_accumulator->verification_key->num_public_inputs), 0);
-    size_t public_input_idx = 0;
-    for (auto& public_input : next_accumulator->public_inputs) {
-        size_t inst = 0;
-        for (auto& instance : instances) {
-            if (instance->verification_key->num_public_inputs >=
-                next_accumulator->verification_key->num_public_inputs) {
-                public_input += instance->public_inputs[public_input_idx] * lagranges[inst];
-                inst++;
-            };
-        }
-        public_input_idx++;
-    }
-
     size_t alpha_idx = 0;
     for (auto& alpha : next_accumulator->alphas) {
         alpha = FF(0);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
@@ -49,7 +49,7 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const HonkP
     transcript = std::make_shared<Transcript>(proof);
     VerifierCommitments commitments{ key };
     OinkVerifier<Flavor> oink_verifier{ key, transcript };
-    auto [relation_parameters, witness_commitments, _, alphas] = oink_verifier.verify();
+    auto [relation_parameters, witness_commitments, public_inputs, alphas] = oink_verifier.verify();
 
     // Copy the witness_commitments over to the VerifierCommitments
     for (auto [wit_comm_1, wit_comm_2] : zip_view(commitments.get_witness(), witness_commitments.get_all())) {


### PR DESCRIPTION
The public inputs are contained in the wire polynomials and are thus folded with the polynomials. We do not need to fold the circuit `public_inputs` separately. For good measure I also added a simply PG test that folds instances with different numbers of PI, which was previously only tested (I believe) in more complex tests such as ClientIvc.