### PR TITLE
feat: modified Ultra RAM relation to remove 1 gate per read/write

### DIFF
--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
@@ -212,9 +212,21 @@ void UltraCircuitChecker::populate_values(
         }
     };
 
+    auto memory_record_is_non_sorted_RAM_gate = [&block, &idx]() {
+        return block.q_m()[idx] == 1 && block.q_4()[idx] == 1;
+    };
+
+    auto compute_RAM_memory_record_term =
+        [](const FF& w_1, const FF& q_c, const FF& w_3, const FF& eta, const FF& eta_two, FF& eta_three) {
+            return (w_3 * eta_three + q_c * eta_two + w_1 * eta);
+        };
+
     // A lambda function for computing a memory record term of the form w3 * eta_three + w2 * eta_two + w1 * eta
     auto compute_memory_record_term =
-        [](const FF& w_1, const FF& w_2, const FF& w_3, const FF& eta, const FF& eta_two, FF& eta_three) {
+        [&](const FF& w_1, const FF& w_2, const FF& w_3, const FF& eta, const FF& eta_two, FF& eta_three) {
+            if (memory_record_is_non_sorted_RAM_gate()) {
+                return compute_RAM_memory_record_term(w_1, block.q_c()[idx], w_3, eta, eta_two, eta_three);
+            }
             return (w_3 * eta_three + w_2 * eta_two + w_1 * eta);
         };
 

--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/prover/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/prover/prover.cpp
@@ -552,22 +552,48 @@ template <typename settings> void ProverBase<settings>::add_plookup_memory_recor
     auto w_2 = key->polynomial_store.get("w_2_lagrange");
     auto w_3 = key->polynomial_store.get("w_3_lagrange");
     auto w_4 = key->polynomial_store.get("w_4_lagrange");
+    auto q_c = key->polynomial_store.get("q_c_lagrange");
+    auto q_4 = key->polynomial_store.get("q_4_lagrange");
+
     for (const auto& gate_idx : key->memory_read_records) {
-        w_4[gate_idx] += w_3[gate_idx];
-        w_4[gate_idx] *= eta;
-        w_4[gate_idx] += w_2[gate_idx];
-        w_4[gate_idx] *= eta;
-        w_4[gate_idx] += w_1[gate_idx];
-        w_4[gate_idx] *= eta;
+        // if q_4 is 1, this is a non-sorted RAM record, which uses a different formula to compute the record.
+        // (this is so that we can put the RAM timestamp value in a selector polynomial)
+        if (!q_4[gate_idx].is_zero()) {
+            w_4[gate_idx] += w_3[gate_idx];
+            w_4[gate_idx] *= eta;
+            w_4[gate_idx] += q_c[gate_idx];
+            w_4[gate_idx] *= eta;
+            w_4[gate_idx] += w_1[gate_idx];
+            w_4[gate_idx] *= eta;
+        } else {
+            w_4[gate_idx] += w_3[gate_idx];
+            w_4[gate_idx] *= eta;
+            w_4[gate_idx] += w_2[gate_idx];
+            w_4[gate_idx] *= eta;
+            w_4[gate_idx] += w_1[gate_idx];
+            w_4[gate_idx] *= eta;
+        }
     }
     for (const auto& gate_idx : key->memory_write_records) {
-        w_4[gate_idx] += w_3[gate_idx];
-        w_4[gate_idx] *= eta;
-        w_4[gate_idx] += w_2[gate_idx];
-        w_4[gate_idx] *= eta;
-        w_4[gate_idx] += w_1[gate_idx];
-        w_4[gate_idx] *= eta;
-        w_4[gate_idx] += 1;
+        // if q_4 is 1, this is a non-sorted RAM record, which uses a different formula to compute the record.
+        // (this is so that we can put the RAM timestamp value in a selector polynomial)
+        if (!q_4[gate_idx].is_zero()) {
+            w_4[gate_idx] += w_3[gate_idx];
+            w_4[gate_idx] *= eta;
+            w_4[gate_idx] += q_c[gate_idx];
+            w_4[gate_idx] *= eta;
+            w_4[gate_idx] += w_1[gate_idx];
+            w_4[gate_idx] *= eta;
+            w_4[gate_idx] += 1;
+        } else {
+            w_4[gate_idx] += w_3[gate_idx];
+            w_4[gate_idx] *= eta;
+            w_4[gate_idx] += w_2[gate_idx];
+            w_4[gate_idx] *= eta;
+            w_4[gate_idx] += w_1[gate_idx];
+            w_4[gate_idx] *= eta;
+            w_4[gate_idx] += 1;
+        }
     }
     key->polynomial_store.put("w_4_lagrange", std::move(w_4));
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -118,7 +118,10 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization_
             WRITE,
         };
         uint32_t index_witness = 0;
+        // timestamp is in w_2 for sorted records
         uint32_t timestamp_witness = 0;
+        // read/write bool is in w_2 (not for sorted records, only initial access gates)
+        uint32_t access_witness = 0;
         uint32_t value_witness = 0;
         uint32_t index = 0;
         uint32_t timestamp = 0;
@@ -132,7 +135,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization_
         }
         bool operator==(const RamRecord& other) const noexcept
         {
-            return index_witness == other.index_witness && timestamp_witness == other.timestamp_witness &&
+            return index_witness == other.index_witness && access_witness == other.access_witness &&
                    value_witness == other.value_witness && index == other.index && timestamp == other.timestamp &&
                    access_type == other.access_type && record_witness == other.record_witness &&
                    gate_index == other.gate_index;
@@ -505,6 +508,8 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization_
         size_t& count, size_t& rangecount, size_t& romcount, size_t& ramcount, size_t& nnfcount) const
     {
         count = this->num_gates;
+
+        std::cout << "initial count = " << count << std::endl;
         // each ROM gate adds +1 extra gate due to the rom reads being copied to a sorted list set
         for (size_t i = 0; i < rom_arrays.size(); ++i) {
             for (size_t j = 0; j < rom_arrays[i].state.size(); ++j) {
@@ -547,6 +552,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization_
             ram_range_sizes.push_back(ram_range_check_gate_count);
             ram_range_exists.push_back(false);
         }
+        std::cout << "ramcount = " << ramcount << std::endl;
         for (const auto& list : range_lists) {
             auto list_size = list.second.variable_indices.size();
             size_t padding = (NUM_WIRES - (list.second.variable_indices.size() % NUM_WIRES)) % NUM_WIRES;
@@ -756,7 +762,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization_
     /**
      * Custom Gate Selectors
      **/
-    void apply_aux_selectors(const AUX_SELECTORS type);
+    void apply_aux_selectors(const AUX_SELECTORS type, const uint32_t ram_timestamp = 0);
 
     /**
      * Non Native Field Arithmetic


### PR DESCRIPTION
When reading/writing from a RAM array, the current gate structure requires the `timestamp` value in the second gate wire, and a read/write boolean flag in the precomputed selector polynomial `q_c`.

When accessing a RAM array, the "timestamp" is a circuit constant. This means that, because timestamp is a witness value, an additional arithmetic gate is required for each unique timestamp value to constrain the timestamp wire to take the correct value.

This PR makes RAM read gates use `q_c` to store the timestamp value, and `w_2` stores the read/write boolean. While the read/write boolean is also a circuit constant - because its value is only [0,1], only 2 arithmetic gates are required regardless of the number of RAM array read/writes in a circuit.

Summary: Current cost = MAX(number of RAM read/writes across all RAM arrays), New cost = 2

This ensures reading/writing from a RAM array costs 3.25 gates and not 4.25 gates