### PR TITLE
chore(github): Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug Report
+description: Report an unexpected behavior.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Description
+  - type: textarea
+    id: aim
+    attributes:
+      label: Aim
+      description: Describe what you tried to achieve.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: Describe what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: bug
+    attributes:
+      label: Bug
+      description: Describe the bug. Supply error codes / terminal logs if applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To Reproduce
+      description: Describe the steps to reproduce the behavior.
+      value: |
+        1.
+        2.
+        3.
+        4.
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Describe the versions of Aztec software you are on.
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Project Impact
+      description: How does this affect a project you or others are working on?
+      options:
+        - "Nice-to-have"
+        - "Blocker"
+  - type: textarea
+    id: impact_context
+    attributes:
+      label: Impact Context
+      description: If a nice-to-have / blocker, supplement how does this Issue affect the project.
+  - type: dropdown
+    id: workaround
+    attributes:
+      label: Workaround
+      description: Is there a workaround for this Issue?
+      options:
+        - "Yes"
+  - type: textarea
+    id: workaround_description
+    attributes:
+      label: Workaround Description
+      description: If yes, supplement how could the Issue be worked around.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Supplement further information if applicable.
+  - type: markdown
+    attributes:
+      value: |
+        ## Pull Request
+  - type: dropdown
+    id: pr_preference
+    attributes:
+      label: Would you like to submit a PR for this Issue?
+      description: Fellow contributors are happy to provide support where applicable.
+      options:
+        - "Maybe"
+        - "Yes"
+  - type: textarea
+    id: pr_support
+    attributes:
+      label: Support Needs
+      description: Support from other contributors you are looking for to create a PR for this Issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,70 @@
+name: Feature Request
+description: Suggest an idea for this project.
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Description
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe what you feel lacking. Supply code / step-by-step examples if applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Happy Case
+      description: Describe how you think it should work. Supply pseudocode / step-by-step examples if applicable.
+    validations:
+      required: true
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Project Impact
+      description: How does this affect a project you or others are working on?
+      options:
+        - "Nice-to-have"
+        - "Blocker"
+  - type: textarea
+    id: impact_context
+    attributes:
+      label: Impact Context
+      description: If a nice-to-have / blocker, supplement how does this Issue affect the project.
+  - type: dropdown
+    id: workaround
+    attributes:
+      label: Workaround
+      description: Is there a workaround for this Issue?
+      options:
+        - "Yes"
+  - type: textarea
+    id: workaround_description
+    attributes:
+      label: Workaround Description
+      description: If yes, supplement how could the Issue be worked around.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Supplement further information if applicable.
+  - type: markdown
+    attributes:
+      value: |
+        ## Pull Request
+  - type: dropdown
+    id: pr-preference
+    attributes:
+      label: Would you like to submit a PR for this Issue?
+      description: Fellow contributors are happy to provide support where applicable.
+      multiple: false
+      options:
+        - "Maybe"
+        - "Yes"
+  - type: textarea
+    id: pr-support
+    attributes:
+      label: Support Needs
+      description: Support from other contributors you are looking for to create a PR for this Issue.


### PR DESCRIPTION
Resolves https://github.com/AztecProtocol/aztec-packages/issues/1480.

## Description

With https://github.com/noir-lang/noir/issues/4960, there could be more bug reports and feature requests from our community moving forward (on for example `bb` and `bb.js`).

This PR adds Issue templates to facilitate management of Issues in this repo. They were adapted from [Noir's](https://github.com/noir-lang/noir/tree/1a794e312159d54a2bf21ae5f61a3de6fa688127/.github/ISSUE_TEMPLATE) with minor changes to better fit aztec-packages' context.

## Demo

https://github.com/Savio-Sou/aztec-packages/issues/new/choose