### PR TITLE
refactor: note hashing gate optimizations

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/note/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/utils.nr
@@ -70,10 +70,14 @@ pub fn compute_note_hash_for_insertion<Note, N, M>(note: Note) -> Field where No
 pub fn compute_note_hash_for_read_request<Note, N, M>(note: Note) -> Field where Note: NoteInterface<N, M> {
     let header = note.get_header();
 
-    if (header.nonce != 0) {
-        compute_unique_note_hash(note)
+    let inner_note_hash = compute_inner_note_hash(note);
+
+    // TODO(#1386): This if-else can be nuked once we have nonces injected from public
+    if (header.nonce == 0) {
+        // If nonce is zero, that means we are reading a public note.
+        inner_note_hash
     } else {
-        compute_inner_note_hash(note)
+        compute_unique_hash(header.nonce, inner_note_hash)
     }
 }
 

--- a/noir-projects/aztec-nr/aztec/src/note/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/utils.nr
@@ -116,8 +116,7 @@ pub fn compute_note_hash_and_optionally_a_nullifier<T, N, M, S>(
     serialized_note: [Field; S] // docs:end:compute_note_hash_and_optionally_a_nullifier_args
 ) -> [Field; 4] where T: NoteInterface<N, M> {
     let mut note = deserialize_content(arr_copy_slice(serialized_note, [0; N], 0));
-    // TODO: change this to note.set_header(header) once https://github.com/noir-lang/noir/issues/4095 is fixed
-    T::set_header((&mut note), note_header);
+    note.set_header(note_header);
 
     let inner_note_hash = compute_inner_note_hash(note);
 

--- a/noir-projects/aztec-nr/aztec/src/note/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/utils.nr
@@ -38,17 +38,9 @@ fn compute_unique_note_hash<Note, N, M>(note_with_header: Note) -> Field where N
 }
 
 fn compute_siloed_note_hash<Note, N, M>(note_with_header: Note) -> Field where Note: NoteInterface<N, M> {
+    let unique_note_hash = compute_note_hash_for_read_request(note_with_header);
+
     let header = note_with_header.get_header();
-
-    let unique_note_hash = if (header.nonce == 0) {
-        // If nonce is zero, that means we are reading a public note.
-        // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1386)
-        // Remove this once notes added from public also include nonces.
-        compute_inner_note_hash(note_with_header)
-    } else {
-        compute_unique_note_hash(note_with_header)
-    };
-
     compute_siloed_hash(header.contract_address, unique_note_hash)
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
@@ -45,6 +45,8 @@ pub fn compute_note_hash_nonce(first_nullifier: Field, note_hash_index: u32) -> 
     )
 }
 
+// TODO(benesjan): some of these functions seem to be duplicate to the ones in
+// noir-projects/aztec-nr/aztec/src/note/utils.nr NUKE!
 fn compute_unique_note_hash(nonce: Field, note_hash: Field) -> Field {
     pedersen_hash(
         [


### PR DESCRIPTION
Optimization of `compute_note_hash_for_read_request` function as proposed by Leila [here](https://github.com/AztecProtocol/aztec-packages/pull/6310/files#r1646209448)

![image](https://github.com/AztecProtocol/aztec-packages/assets/13470840/0e7c7ae6-df7c-442a-a361-7f4e65304ed5)

![image](https://github.com/AztecProtocol/aztec-packages/assets/13470840/ede8f2ed-b9d5-4361-b79d-d4efdda0cc76)

148160-87456=**60704 gates saved**

Since the function was called from multiple places in the transfer function the savings are larger for the whole token transfer:

![image](https://github.com/AztecProtocol/aztec-packages/assets/13470840/8589519e-6d2a-49c8-b0f7-70afc9bef487)

<img width="337" alt="image" src="https://github.com/AztecProtocol/aztec-packages/assets/13470840/2cbde0a7-7f16-43b5-8d73-be20861e4ef8">

1412919-1291447=**121472 gates saved**

Optimization of `compute_siloed_note_hash`:

We could do the same optimizations to `compute_siloed_note_hash(...)`
<img width="316" alt="image" src="https://github.com/AztecProtocol/aztec-packages/assets/13470840/cedd257c-a739-4881-95f4-0d9eba7a0423">

which resulted in additional drop of `60736` gates for the transfer function.

**Overall drop of 173208 gates.**