### PR TITLE
refactor: note hashes cleanup + optimization

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -5,7 +5,7 @@ use crate::{
     messaging::process_l1_to_l2_message,
     hash::{hash_args_array, ArgsHasher, compute_unencrypted_log_hash},
     keys::constants::{NULLIFIER_INDEX, OUTGOING_INDEX, NUM_KEY_TYPES, sk_generators},
-    note::{note_interface::NoteInterface, utils::compute_note_hash_for_insertion},
+    note::note_interface::NoteInterface,
     oracle::{
     key_validation_request::get_key_validation_request, arguments, returns::pack_returns,
     call_private_function::call_private_function_internal, header::get_header_at,

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/incoming_body.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/incoming_body.nr
@@ -42,7 +42,7 @@ mod test {
     };
 
     use crate::{
-        note::{note_header::NoteHeader, note_interface::NoteInterface, utils::compute_note_hash_for_consumption},
+        note::{note_header::NoteHeader, note_interface::NoteInterface},
         event::event_interface::EventInterface, oracle::unsafe_rand::unsafe_rand,
         context::PrivateContext
     };

--- a/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
@@ -46,8 +46,7 @@ pub fn create_note_hash_from_public<Note, N, M>(
     let contract_address = (*context).this_address();
     // Public note hashes are transient, but have no side effect counters, so we just need note_hash_counter != 0
     let header = NoteHeader { contract_address, storage_slot, nonce: 0, note_hash_counter: 1 };
-    // TODO: change this to note.set_header(header) once https://github.com/noir-lang/noir/issues/4095 is fixed
-    Note::set_header(note, header);
+    note.set_header(header);
     let inner_note_hash = compute_note_hash_for_insertion(*note);
 
     context.push_new_note_hash(inner_note_hash);

--- a/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
@@ -2,8 +2,7 @@ use dep::protocol_types::grumpkin_point::GrumpkinPoint;
 use crate::context::{PrivateContext, PublicContext};
 use crate::note::{
     note_header::NoteHeader, note_interface::NoteInterface,
-    utils::{compute_note_hash_for_insertion, compute_note_hash_for_consumption},
-    note_emission::NoteEmission
+    utils::{compute_inner_note_hash, compute_note_hash_for_consumption}, note_emission::NoteEmission
 };
 use crate::oracle::notes::{notify_created_note, notify_nullified_note};
 
@@ -18,7 +17,7 @@ pub fn create_note<Note, N, M>(
     let header = NoteHeader { contract_address, storage_slot, nonce: 0, note_hash_counter };
     // TODO: change this to note.set_header(header) once https://github.com/noir-lang/noir/issues/4095 is fixed
     Note::set_header(note, header);
-    let inner_note_hash = compute_note_hash_for_insertion(*note);
+    let inner_note_hash = compute_inner_note_hash(*note);
 
     // TODO: Strong typing required because of https://github.com/noir-lang/noir/issues/4088
     let serialized_note: [Field; N] = Note::serialize_content(*note);
@@ -47,7 +46,7 @@ pub fn create_note_hash_from_public<Note, N, M>(
     // Public note hashes are transient, but have no side effect counters, so we just need note_hash_counter != 0
     let header = NoteHeader { contract_address, storage_slot, nonce: 0, note_hash_counter: 1 };
     note.set_header(header);
-    let inner_note_hash = compute_note_hash_for_insertion(*note);
+    let inner_note_hash = compute_inner_note_hash(*note);
 
     context.push_new_note_hash(inner_note_hash);
 }

--- a/noir-projects/aztec-nr/aztec/src/note/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/utils.nr
@@ -43,8 +43,8 @@ fn compute_note_hash_for_read_request_from_innter_and_nonce(
 }
 
 pub fn compute_note_hash_for_read_request<Note, N, M>(note: Note) -> Field where Note: NoteInterface<N, M> {
-    let nonce = note.get_header().nonce;
     let inner_note_hash = compute_inner_note_hash(note);
+    let nonce = note.get_header().nonce;
 
     compute_note_hash_for_read_request_from_innter_and_nonce(inner_note_hash, nonce)
 }
@@ -80,25 +80,16 @@ pub fn compute_note_hash_for_consumption<Note, N, M>(note: Note) -> Field where 
 }
 
 pub fn compute_note_hash_and_optionally_a_nullifier<T, N, M, S>(
-    // docs:start:compute_note_hash_and_optionally_a_nullifier_args
     deserialize_content: fn([Field; N]) -> T,
     note_header: NoteHeader,
     compute_nullifier: bool,
-    serialized_note: [Field; S] // docs:end:compute_note_hash_and_optionally_a_nullifier_args
+    serialized_note: [Field; S]
 ) -> [Field; 4] where T: NoteInterface<N, M> {
     let mut note = deserialize_content(arr_copy_slice(serialized_note, [0; N], 0));
     note.set_header(note_header);
 
     let inner_note_hash = compute_inner_note_hash(note);
-
-    // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1386)
-    // Should always be calling compute_unique_note_hash() once notes added from public also include nonces.
-    let unique_note_hash = if note_header.nonce != 0 {
-        compute_unique_note_hash(note_header.nonce, inner_note_hash)
-    } else {
-        inner_note_hash
-    };
-
+    let unique_note_hash = compute_note_hash_for_read_request_from_innter_and_nonce(inner_note_hash, note_header.nonce);
     let siloed_note_hash = compute_siloed_note_hash(note_header.contract_address, unique_note_hash);
 
     let inner_nullifier = if compute_nullifier {

--- a/noir-projects/aztec-nr/aztec/src/note/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/utils.nr
@@ -3,8 +3,7 @@ use crate::{context::PrivateContext, note::{note_header::NoteHeader, note_interf
 use dep::protocol_types::{
     constants::GENERATOR_INDEX__INNER_NOTE_HASH,
     hash::{
-    pedersen_hash, compute_unique_note_hash,
-    compute_siloed_note_hash as compute_siloed_note_hash_from_preimage,
+    pedersen_hash, compute_unique_note_hash, compute_siloed_note_hash as compute_siloed_note_hash,
     compute_siloed_nullifier as compute_siloed_nullifier_from_preimage
 },
     utils::arr_copy_slice
@@ -20,13 +19,6 @@ fn compute_inner_note_hash<Note, N, M>(note: Note) -> Field where Note: NoteInte
     )
 }
 
-fn compute_siloed_note_hash<Note, N, M>(note_with_header: Note) -> Field where Note: NoteInterface<N, M> {
-    let unique_note_hash = compute_note_hash_for_read_request(note_with_header);
-
-    let header = note_with_header.get_header();
-    compute_siloed_note_hash_from_preimage(header.contract_address, unique_note_hash)
-}
-
 pub fn compute_siloed_nullifier<Note, N, M>(
     note_with_header: Note,
     context: &mut PrivateContext
@@ -37,18 +29,24 @@ pub fn compute_siloed_nullifier<Note, N, M>(
     compute_siloed_nullifier_from_preimage(header.contract_address, inner_nullifier)
 }
 
-pub fn compute_note_hash_for_read_request<Note, N, M>(note: Note) -> Field where Note: NoteInterface<N, M> {
-    let header = note.get_header();
-
-    let inner_note_hash = compute_inner_note_hash(note);
-
+fn compute_note_hash_for_read_request_from_innter_and_nonce(
+    inner_note_hash: Field,
+    nonce: Field
+) -> Field {
     // TODO(#1386): This if-else can be nuked once we have nonces injected from public
-    if (header.nonce == 0) {
+    if (nonce == 0) {
         // If nonce is zero, that means we are reading a public note.
         inner_note_hash
     } else {
-        compute_unique_note_hash(header.nonce, inner_note_hash)
+        compute_unique_note_hash(nonce, inner_note_hash)
     }
+}
+
+pub fn compute_note_hash_for_read_request<Note, N, M>(note: Note) -> Field where Note: NoteInterface<N, M> {
+    let nonce = note.get_header().nonce;
+    let inner_note_hash = compute_inner_note_hash(note);
+
+    compute_note_hash_for_read_request_from_innter_and_nonce(inner_note_hash, nonce)
 }
 
 pub fn compute_note_hash_for_consumption<Note, N, M>(note: Note) -> Field where Note: NoteInterface<N, M> {
@@ -58,15 +56,18 @@ pub fn compute_note_hash_for_consumption<Note, N, M>(note: Note) -> Field where 
     // 2. The note was inserted in a previous transaction, and was inserted in public
     // 3. The note was inserted in a previous transaction, and was inserted in private
 
+    let inner_note_hash = compute_inner_note_hash(note);
+
     if (header.note_hash_counter != 0) {
         // If a note is transient, we just read the inner_note_hash (kernel will silo by contract address).
-        compute_inner_note_hash(note)
+        inner_note_hash
     } else {
         // If a note is not transient, that means we are reading a settled note (from tree) created in a
         // previous TX. So we need the siloed_note_hash which has already been hashed with
         // nonce and then contract address. This hash will match the existing leaf in the note hash
         // tree, so the kernel can just perform a membership check directly on this hash/leaf.
-        compute_siloed_note_hash(note)
+        let unique_note_hash = compute_note_hash_for_read_request_from_innter_and_nonce(inner_note_hash, header.nonce);
+        compute_siloed_note_hash(header.contract_address, unique_note_hash)
         // IMPORTANT NOTE ON REDUNDANT SILOING BY CONTRACT ADDRESS: The note hash computed above is
         // "siloed" by contract address. When a note hash is computed solely for the purpose of
         // nullification, it is not strictly necessary to silo the note hash before computing
@@ -98,7 +99,7 @@ pub fn compute_note_hash_and_optionally_a_nullifier<T, N, M, S>(
         inner_note_hash
     };
 
-    let siloed_note_hash = compute_siloed_note_hash_from_preimage(note_header.contract_address, unique_note_hash);
+    let siloed_note_hash = compute_siloed_note_hash(note_header.contract_address, unique_note_hash);
 
     let inner_nullifier = if compute_nullifier {
         let (_, nullifier) = note.compute_note_hash_and_nullifier_without_context();

--- a/noir-projects/aztec-nr/aztec/src/note/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/utils.nr
@@ -37,10 +37,6 @@ pub fn compute_siloed_nullifier<Note, N, M>(
     compute_siloed_nullifier_from_preimage(header.contract_address, inner_nullifier)
 }
 
-pub fn compute_note_hash_for_insertion<Note, N, M>(note: Note) -> Field where Note: NoteInterface<N, M> {
-    compute_inner_note_hash(note)
-}
-
 pub fn compute_note_hash_for_read_request<Note, N, M>(note: Note) -> Field where Note: NoteInterface<N, M> {
     let header = note.get_header();
 

--- a/noir-projects/aztec-nr/aztec/src/note/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/utils.nr
@@ -1,23 +1,14 @@
 use crate::{context::PrivateContext, note::{note_header::NoteHeader, note_interface::NoteInterface}};
 
 use dep::protocol_types::{
-    address::AztecAddress,
-    constants::{
-    GENERATOR_INDEX__OUTER_NULLIFIER, GENERATOR_INDEX__UNIQUE_NOTE_HASH,
-    GENERATOR_INDEX__SILOED_NOTE_HASH, GENERATOR_INDEX__INNER_NOTE_HASH
+    constants::GENERATOR_INDEX__INNER_NOTE_HASH,
+    hash::{
+    pedersen_hash, compute_unique_note_hash,
+    compute_siloed_note_hash as compute_siloed_note_hash_from_preimage,
+    compute_siloed_nullifier as compute_siloed_nullifier_from_preimage
 },
-    hash::pedersen_hash, utils::arr_copy_slice
+    utils::arr_copy_slice
 };
-
-fn compute_siloed_hash(contract_address: AztecAddress, unique_note_hash: Field) -> Field {
-    let inputs = [contract_address.to_field(), unique_note_hash];
-    pedersen_hash(inputs, GENERATOR_INDEX__SILOED_NOTE_HASH)
-}
-
-fn compute_unique_hash(nonce: Field, inner_note_hash: Field) -> Field {
-    let inputs = [nonce, inner_note_hash];
-    pedersen_hash(inputs, GENERATOR_INDEX__UNIQUE_NOTE_HASH)
-}
 
 fn compute_inner_note_hash<Note, N, M>(note: Note) -> Field where Note: NoteInterface<N, M> {
     let header = note.get_header();
@@ -29,19 +20,11 @@ fn compute_inner_note_hash<Note, N, M>(note: Note) -> Field where Note: NoteInte
     )
 }
 
-fn compute_unique_note_hash<Note, N, M>(note_with_header: Note) -> Field where Note: NoteInterface<N, M> {
-    let header = note_with_header.get_header();
-
-    let inner_note_hash = compute_inner_note_hash(note_with_header);
-
-    compute_unique_hash(header.nonce, inner_note_hash)
-}
-
 fn compute_siloed_note_hash<Note, N, M>(note_with_header: Note) -> Field where Note: NoteInterface<N, M> {
     let unique_note_hash = compute_note_hash_for_read_request(note_with_header);
 
     let header = note_with_header.get_header();
-    compute_siloed_hash(header.contract_address, unique_note_hash)
+    compute_siloed_note_hash_from_preimage(header.contract_address, unique_note_hash)
 }
 
 pub fn compute_siloed_nullifier<Note, N, M>(
@@ -51,8 +34,7 @@ pub fn compute_siloed_nullifier<Note, N, M>(
     let header = note_with_header.get_header();
     let (_, inner_nullifier) = note_with_header.compute_note_hash_and_nullifier(context);
 
-    let input = [header.contract_address.to_field(), inner_nullifier];
-    pedersen_hash(input, GENERATOR_INDEX__OUTER_NULLIFIER)
+    compute_siloed_nullifier_from_preimage(header.contract_address, inner_nullifier)
 }
 
 pub fn compute_note_hash_for_insertion<Note, N, M>(note: Note) -> Field where Note: NoteInterface<N, M> {
@@ -69,7 +51,7 @@ pub fn compute_note_hash_for_read_request<Note, N, M>(note: Note) -> Field where
         // If nonce is zero, that means we are reading a public note.
         inner_note_hash
     } else {
-        compute_unique_hash(header.nonce, inner_note_hash)
+        compute_unique_note_hash(header.nonce, inner_note_hash)
     }
 }
 
@@ -113,14 +95,14 @@ pub fn compute_note_hash_and_optionally_a_nullifier<T, N, M, S>(
     let inner_note_hash = compute_inner_note_hash(note);
 
     // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1386)
-    // Should always be calling compute_unique_hash() once notes added from public also include nonces.
+    // Should always be calling compute_unique_note_hash() once notes added from public also include nonces.
     let unique_note_hash = if note_header.nonce != 0 {
-        compute_unique_hash(note_header.nonce, inner_note_hash)
+        compute_unique_note_hash(note_header.nonce, inner_note_hash)
     } else {
         inner_note_hash
     };
 
-    let siloed_note_hash = compute_siloed_hash(note_header.contract_address, unique_note_hash);
+    let siloed_note_hash = compute_siloed_note_hash_from_preimage(note_header.contract_address, unique_note_hash);
 
     let inner_nullifier = if compute_nullifier {
         let (_, nullifier) = note.compute_note_hash_and_nullifier_without_context();

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -14,7 +14,7 @@ use crate::hash::hash_args;
 
 use crate::note::{
     note_header::NoteHeader, note_interface::NoteInterface,
-    utils::{compute_note_hash_for_insertion, compute_note_hash_for_consumption}
+    utils::{compute_inner_note_hash, compute_note_hash_for_consumption}
 };
 use crate::oracle::notes::notify_created_note;
 
@@ -188,7 +188,7 @@ impl TestEnvironment {
         let header = NoteHeader { contract_address, storage_slot, nonce: 0, note_hash_counter };
         // TODO: change this to note.set_header(header) once https://github.com/noir-lang/noir/issues/4095 is fixed
         Note::set_header(note, header);
-        let inner_note_hash = compute_note_hash_for_insertion(*note);
+        let inner_note_hash = compute_inner_note_hash(*note);
 
         // TODO: Strong typing required because of https://github.com/noir-lang/noir/issues/4088
         let serialized_note: [Field; N] = Note::serialize_content(*note);

--- a/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
@@ -45,22 +45,15 @@ pub fn compute_note_hash_nonce(first_nullifier: Field, note_hash_index: u32) -> 
     )
 }
 
-// TODO(benesjan): some of these functions seem to be duplicate to the ones in
-// noir-projects/aztec-nr/aztec/src/note/utils.nr NUKE!
-fn compute_unique_note_hash(nonce: Field, note_hash: Field) -> Field {
-    pedersen_hash(
-        [
-        nonce,
-        note_hash
-    ],
-        GENERATOR_INDEX__UNIQUE_NOTE_HASH
-    )
+pub fn compute_unique_note_hash(nonce: Field, inner_note_hash: Field) -> Field {
+    let inputs = [nonce, inner_note_hash];
+    pedersen_hash(inputs, GENERATOR_INDEX__UNIQUE_NOTE_HASH)
 }
 
-pub fn compute_siloed_note_hash(address: AztecAddress, unique_note_hash: Field) -> Field {
+pub fn compute_siloed_note_hash(app: AztecAddress, unique_note_hash: Field) -> Field {
     pedersen_hash(
         [
-        address.to_field(),
+        app.to_field(),
         unique_note_hash
     ],
         GENERATOR_INDEX__SILOED_NOTE_HASH
@@ -77,10 +70,10 @@ pub fn silo_note_hash(note_hash: ScopedNoteHash, first_nullifier: Field, index: 
     }
 }
 
-pub fn compute_siloed_nullifier(address: AztecAddress, nullifier: Field) -> Field {
+pub fn compute_siloed_nullifier(app: AztecAddress, nullifier: Field) -> Field {
     pedersen_hash(
         [
-        address.to_field(),
+        app.to_field(),
         nullifier
     ],
         GENERATOR_INDEX__OUTER_NULLIFIER


### PR DESCRIPTION
Note hashing functionality had duplicates between hash.nr in protocol circuits and note utils in aztec-nr. This is not only messy but also very bug prone because hash mismatches are pain to debug. This PR addresses it.

Note that the resulting functions are still quite messy and the naming is 💩 . But I think it makes sense to tackle once we tackle [this ancient issue](https://github.com/AztecProtocol/aztec-packages/issues/1386) because then we'll be able to nuke some of the functions (due to the flow being simplified as public notes will not have the different flow).

Also did an optimization of `compute_note_hash_for_consumption(...)`. Just like in the PR down the stack we had doubled gate counts because of if-else.

<img width="321" alt="image" src="https://github.com/AztecProtocol/aztec-packages/assets/13470840/c1c1cea7-0a2e-415c-ad00-8feaee0237c8">


<img width="322" alt="image" src="https://github.com/AztecProtocol/aztec-packages/assets/13470840/dcd71e41-fbff-4e19-be4b-6a36babc4eda">

Gate drop of **60736 gates**