### PR TITLE
fix: enable log filtering with the DEBUG variable

### DIFF
--- a/boxes/boxes/react/package.json
+++ b/boxes/boxes/react/package.json
@@ -76,7 +76,6 @@
     "ts-jest": "^29.1.0",
     "ts-loader": "^9.4.4",
     "ts-node": "^10.9.1",
-    "tty-browserify": "^0.0.1",
     "typescript": "^5.0.4",
     "util": "^0.12.5",
     "webpack": "^5.88.2",

--- a/boxes/boxes/react/webpack.config.js
+++ b/boxes/boxes/react/webpack.config.js
@@ -48,7 +48,6 @@ export default (_, argv) => ({
       util: require.resolve('util/'),
       stream: require.resolve('stream-browserify'),
       string_decoder: require.resolve('string_decoder/'),
-      tty: require.resolve('tty-browserify'),
     },
   },
   devServer: {

--- a/boxes/boxes/vanilla/package.json
+++ b/boxes/boxes/vanilla/package.json
@@ -28,7 +28,6 @@
     "html-webpack-plugin": "^5.6.0",
     "stream-browserify": "^3.0.0",
     "ts-loader": "^9.5.1",
-    "tty-browserify": "^0.0.1",
     "typescript": "^5.0.4",
     "util": "^0.12.5",
     "webpack": "^5.90.1",

--- a/boxes/boxes/vanilla/webpack.config.js
+++ b/boxes/boxes/vanilla/webpack.config.js
@@ -44,7 +44,6 @@ export default (_, argv) => ({
       util: require.resolve('util/'),
       stream: require.resolve('stream-browserify'),
       string_decoder: require.resolve('string_decoder/'),
-      tty: require.resolve('tty-browserify'),
     },
   },
   devServer: {

--- a/boxes/contract-only/package.json
+++ b/boxes/contract-only/package.json
@@ -43,7 +43,6 @@
     "jest": "^29.6.4",
     "stream-browserify": "^3.0.0",
     "ts-loader": "^9.5.1",
-    "tty-browserify": "^0.0.1",
     "typescript": "^5.0.4",
     "util": "^0.12.5",
     "webpack": "^5.90.1",

--- a/boxes/yarn.lock
+++ b/boxes/yarn.lock
@@ -104,7 +104,6 @@ __metadata:
     ts-jest: "npm:^29.1.0"
     ts-loader: "npm:^9.4.4"
     ts-node: "npm:^10.9.1"
-    tty-browserify: "npm:^0.0.1"
     typescript: "npm:^5.0.4"
     util: "npm:^0.12.5"
     webpack: "npm:^5.88.2"
@@ -133,7 +132,6 @@ __metadata:
     html-webpack-plugin: "npm:^5.6.0"
     stream-browserify: "npm:^3.0.0"
     ts-loader: "npm:^9.5.1"
-    tty-browserify: "npm:^0.0.1"
     typescript: "npm:^5.0.4"
     util: "npm:^0.12.5"
     webpack: "npm:^5.90.1"
@@ -8954,13 +8952,6 @@ __metadata:
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: e03a8a4271152c8b26604ed45535954c0a45296e32445b4b87f8a5abdb2421f40b59b4ca437c4346af0f28179780d604094eb64546bee2019d903d01c6c19bdb
-  languageName: node
-  linkType: hard
-
-"tty-browserify@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "tty-browserify@npm:0.0.1"
-  checksum: 5e34883388eb5f556234dae75b08e069b9e62de12bd6d87687f7817f5569430a6dfef550b51dbc961715ae0cd0eb5a059e6e3fc34dc127ea164aa0f9b5bb033d
   languageName: node
   linkType: hard
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     # need to run bb for proofs and bb is only built for x86
     platform: linux/amd64
     environment:
-      LOG_LEVEL: info
-      DEBUG: aztec:*
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      DEBUG: ${DEBUG:-aztec:*,-json-rpc:*,-aztec:circuits:artifact_hash,-aztec:randomness_singleton}
       DEBUG_COLORS: 1
       CHAIN_ID: 31337
       VERSION: 1
@@ -34,8 +34,8 @@ services:
     # need to run bb for proofs and bb is only built for x86
     platform: linux/amd64
     environment:
-      LOG_LEVEL: info
-      DEBUG: aztec:*
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      DEBUG: ${DEBUG:-aztec:*,-json-rpc:*,-aztec:circuits:artifact_hash,-aztec:randomness_singleton,-aztec:avm_simulator:*}
       DEBUG_COLORS: 1
       CHAIN_ID: 31337
       VERSION: 1

--- a/yarn-project/aztec.js/package.json
+++ b/yarn-project/aztec.js/package.json
@@ -86,7 +86,6 @@
     "stream-browserify": "^3.0.0",
     "ts-loader": "^9.4.4",
     "ts-node": "^10.9.1",
-    "tty-browserify": "^0.0.1",
     "typescript": "^5.0.4",
     "util": "^0.12.5",
     "webpack": "^5.88.2",

--- a/yarn-project/aztec.js/webpack.config.js
+++ b/yarn-project/aztec.js/webpack.config.js
@@ -66,7 +66,6 @@ export default {
       buffer: require.resolve('buffer/'),
       util: require.resolve('util/'),
       stream: require.resolve('stream-browserify'),
-      tty: require.resolve('tty-browserify'),
     },
   },
 };

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -79,7 +79,6 @@
     "ts-loader": "^9.4.4",
     "ts-node": "^10.9.1",
     "tslib": "^2.4.0",
-    "tty-browserify": "^0.0.1",
     "typescript": "^5.0.4",
     "util": "^0.12.5",
     "viem": "^2.7.15",

--- a/yarn-project/end-to-end/webpack.config.js
+++ b/yarn-project/end-to-end/webpack.config.js
@@ -64,7 +64,6 @@ export default {
       buffer: require.resolve('buffer/'),
       util: require.resolve('util/'),
       stream: require.resolve('stream-browserify'),
-      tty: require.resolve('tty-browserify'),
     },
   },
 };

--- a/yarn-project/foundation/src/crypto/random/randomness_singleton.ts
+++ b/yarn-project/foundation/src/crypto/random/randomness_singleton.ts
@@ -18,10 +18,10 @@ export class RandomnessSingleton {
     private readonly log = createDebugLogger('aztec:randomness_singleton'),
   ) {
     if (seed !== undefined) {
-      this.log.verbose(`Using pseudo-randomness with seed: ${seed}`);
+      this.log.debug(`Using pseudo-randomness with seed: ${seed}`);
       this.counter = seed;
     } else {
-      this.log.verbose('Using true randomness');
+      this.log.debug('Using true randomness');
     }
   }
 

--- a/yarn-project/foundation/src/json-rpc/server/json_rpc_server.ts
+++ b/yarn-project/foundation/src/json-rpc/server/json_rpc_server.ts
@@ -25,7 +25,7 @@ export class JsonRpcServer {
     private objectClassMap: JsonClassConverterInput,
     /** List of methods to disallow from calling remotely */
     public readonly disallowedMethods: string[] = [],
-    private log = createDebugLogger('aztec:foundation:json-rpc:server'),
+    private log = createDebugLogger('json-rpc:server'),
   ) {
     this.proxy = new JsonProxy(handler, stringClassMap, objectClassMap);
   }
@@ -226,7 +226,7 @@ export type ServerList = {
  */
 export function createNamespacedJsonRpcServer(
   servers: ServerList,
-  log = createDebugLogger('aztec:foundation:json-rpc:multi-server'),
+  log = createDebugLogger('json-rpc:multi-server'),
 ): JsonRpcServer {
   const handler = {} as any;
   const disallowedMethods: string[] = [];

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -158,7 +158,6 @@ __metadata:
     ts-loader: ^9.4.4
     ts-node: ^10.9.1
     tslib: ^2.4.0
-    tty-browserify: ^0.0.1
     typescript: ^5.0.4
     util: ^0.12.5
     webpack: ^5.88.2
@@ -464,7 +463,6 @@ __metadata:
     ts-loader: ^9.4.4
     ts-node: ^10.9.1
     tslib: ^2.4.0
-    tty-browserify: ^0.0.1
     typescript: ^5.0.4
     util: ^0.12.5
     viem: ^2.7.15
@@ -13605,13 +13603,6 @@ __metadata:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 1843f4c1b2e0f975e08c4c21caa4af4f7f65a12ac1b81b3b8489366826259323feb3fc7a243123453d2d1a02314205a7634e048d4a8009921da19f99755cdc48
-  languageName: node
-  linkType: hard
-
-"tty-browserify@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "tty-browserify@npm:0.0.1"
-  checksum: 93b745d43fa5a7d2b948fa23be8d313576d1d884b48acd957c07710bac1c0d8ac34c0556ad4c57c73d36e11741763ef66b3fb4fb97b06b7e4d525315a3cd45f5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replaces our custom logging to stderr in favor of always using the `debug` package. This allows us to filter both by `LOG_LEVEL` and by namespace with `DEBUG=aztec:*,-aztec:sequencer:*`. This also enables to remove one dependency from the browser bundle.
