### PR TITLE
chore(avm): separate some fixed tables

### DIFF
--- a/barretenberg/cpp/pil/avm/binary.pil
+++ b/barretenberg/cpp/pil/avm/binary.pil
@@ -1,6 +1,4 @@
-
-include "byte_lookup.pil";
-include "main.pil";
+include "fixed/byte_lookup.pil";
 
 namespace binary(256);
 

--- a/barretenberg/cpp/pil/avm/fixed/byte_lookup.pil
+++ b/barretenberg/cpp/pil/avm/fixed/byte_lookup.pil
@@ -1,4 +1,3 @@
-
 namespace byte_lookup(256);
     // These columns are commited for now, but will be migrated to constant/fixed when
     // we support more *exotic* code generation options

--- a/barretenberg/cpp/pil/avm/fixed/gas.pil
+++ b/barretenberg/cpp/pil/avm/fixed/gas.pil
@@ -6,3 +6,8 @@ namespace gas(256);
     // TODO(ISSUE_NUMBER): Constrain variable gas costs
     pol commit l2_gas_fixed_table;
     pol commit da_gas_fixed_table;
+
+    // DUMMY RELATIONS to force creation of hpp.
+    sel_gas_cost - sel_gas_cost = 0;
+    l2_gas_fixed_table - l2_gas_fixed_table = 0;
+    da_gas_fixed_table - da_gas_fixed_table = 0;

--- a/barretenberg/cpp/pil/avm/fixed/powers.pil
+++ b/barretenberg/cpp/pil/avm/fixed/powers.pil
@@ -1,0 +1,9 @@
+// This table should eventually be fixed.
+// Contains 256 rows with the powers of 2 for 8-bit numbers.
+// power_of_2 = 1 << clk;
+namespace powers(256);
+    // clk will be the implicit power.
+    pol commit power_of_2;
+
+    // DUMMY RELATION to force creation of hpp.
+    power_of_2 - power_of_2 = 0;

--- a/barretenberg/cpp/pil/avm/main.pil
+++ b/barretenberg/cpp/pil/avm/main.pil
@@ -3,7 +3,8 @@ include "alu.pil";
 include "binary.pil";
 include "constants.pil";
 include "kernel.pil";
-include "gas.pil";
+include "fixed/gas.pil";
+include "fixed/powers.pil";
 include "gadgets/conversion.pil";
 include "gadgets/sha256.pil";
 include "gadgets/poseidon2.pil";
@@ -138,9 +139,6 @@ namespace main(256);
     // We re-use the clk column for the lookup values of 8-bit resp. 16-bit range check.
     pol commit sel_rng_8;  // Boolean selector for the  8-bit range check lookup
     pol commit sel_rng_16; // Boolean selector for the 16-bit range check lookup
-
-    //===== Lookup table powers of 2 =============================================
-    pol commit table_pow_2; // Table of powers of 2 for 8-bit numbers. 
 
     //===== CONTROL FLOW ==========================================================
     // Program counter
@@ -773,11 +771,11 @@ namespace main(256);
 
     // Lookup for 2**(ib)
     #[LOOKUP_POW_2_0]
-    alu.sel_shift_which {alu.ib, alu.two_pow_s} in sel_rng_8 {clk, table_pow_2};
+    alu.sel_shift_which {alu.ib, alu.two_pow_s} in sel_rng_8 {clk, powers.power_of_2};
 
     // Lookup for 2**(t-ib)
     #[LOOKUP_POW_2_1]
-    alu.sel_shift_which {alu.t_sub_s_bits , alu.two_pow_t_sub_s} in sel_rng_8 {clk, table_pow_2};
+    alu.sel_shift_which {alu.t_sub_s_bits , alu.two_pow_t_sub_s} in sel_rng_8 {clk, powers.power_of_2};
 
     //====== Inter-table Constraints (Range Checks) ============================================
     // TODO: Investigate optimising these range checks. Handling non-FF elements should require less range checks.

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/declare_views.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/declare_views.hpp
@@ -251,7 +251,6 @@
     [[maybe_unused]] auto main_sel_rng_16 = View(new_term.main_sel_rng_16);                                            \
     [[maybe_unused]] auto main_sel_rng_8 = View(new_term.main_sel_rng_8);                                              \
     [[maybe_unused]] auto main_space_id = View(new_term.main_space_id);                                                \
-    [[maybe_unused]] auto main_table_pow_2 = View(new_term.main_table_pow_2);                                          \
     [[maybe_unused]] auto main_tag_err = View(new_term.main_tag_err);                                                  \
     [[maybe_unused]] auto main_w_in_tag = View(new_term.main_w_in_tag);                                                \
     [[maybe_unused]] auto mem_addr = View(new_term.mem_addr);                                                          \
@@ -293,6 +292,7 @@
     [[maybe_unused]] auto poseidon2_input = View(new_term.poseidon2_input);                                            \
     [[maybe_unused]] auto poseidon2_output = View(new_term.poseidon2_output);                                          \
     [[maybe_unused]] auto poseidon2_sel_poseidon_perm = View(new_term.poseidon2_sel_poseidon_perm);                    \
+    [[maybe_unused]] auto powers_power_of_2 = View(new_term.powers_power_of_2);                                        \
     [[maybe_unused]] auto sha256_clk = View(new_term.sha256_clk);                                                      \
     [[maybe_unused]] auto sha256_input = View(new_term.sha256_input);                                                  \
     [[maybe_unused]] auto sha256_output = View(new_term.sha256_output);                                                \

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/gas.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/gas.hpp
@@ -1,0 +1,69 @@
+
+#pragma once
+#include "../../relation_parameters.hpp"
+#include "../../relation_types.hpp"
+#include "./declare_views.hpp"
+
+namespace bb::Avm_vm {
+
+template <typename FF> struct GasRow {
+    FF gas_da_gas_fixed_table{};
+    FF gas_l2_gas_fixed_table{};
+    FF gas_sel_gas_cost{};
+
+    [[maybe_unused]] static std::vector<std::string> names();
+};
+
+inline std::string get_relation_label_gas(int index)
+{
+    switch (index) {}
+    return std::to_string(index);
+}
+
+template <typename FF_> class gasImpl {
+  public:
+    using FF = FF_;
+
+    static constexpr std::array<size_t, 3> SUBRELATION_PARTIAL_LENGTHS{
+        2,
+        2,
+        2,
+    };
+
+    template <typename ContainerOverSubrelations, typename AllEntities>
+    void static accumulate(ContainerOverSubrelations& evals,
+                           const AllEntities& new_term,
+                           [[maybe_unused]] const RelationParameters<FF>&,
+                           [[maybe_unused]] const FF& scaling_factor)
+    {
+
+        // Contribution 0
+        {
+            Avm_DECLARE_VIEWS(0);
+
+            auto tmp = (gas_sel_gas_cost - gas_sel_gas_cost);
+            tmp *= scaling_factor;
+            std::get<0>(evals) += tmp;
+        }
+        // Contribution 1
+        {
+            Avm_DECLARE_VIEWS(1);
+
+            auto tmp = (gas_l2_gas_fixed_table - gas_l2_gas_fixed_table);
+            tmp *= scaling_factor;
+            std::get<1>(evals) += tmp;
+        }
+        // Contribution 2
+        {
+            Avm_DECLARE_VIEWS(2);
+
+            auto tmp = (gas_da_gas_fixed_table - gas_da_gas_fixed_table);
+            tmp *= scaling_factor;
+            std::get<2>(evals) += tmp;
+        }
+    }
+};
+
+template <typename FF> using gas = Relation<gasImpl<FF>>;
+
+} // namespace bb::Avm_vm

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/lookup_pow_2_0.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/lookup_pow_2_0.hpp
@@ -140,7 +140,7 @@ class lookup_pow_2_0_lookup_settings {
                                      in.alu_ib,
                                      in.alu_two_pow_s,
                                      in.main_clk,
-                                     in.main_table_pow_2);
+                                     in.powers_power_of_2);
     }
 
     /**
@@ -160,7 +160,7 @@ class lookup_pow_2_0_lookup_settings {
                                      in.alu_ib,
                                      in.alu_two_pow_s,
                                      in.main_clk,
-                                     in.main_table_pow_2);
+                                     in.powers_power_of_2);
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/lookup_pow_2_1.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/lookup_pow_2_1.hpp
@@ -140,7 +140,7 @@ class lookup_pow_2_1_lookup_settings {
                                      in.alu_t_sub_s_bits,
                                      in.alu_two_pow_t_sub_s,
                                      in.main_clk,
-                                     in.main_table_pow_2);
+                                     in.powers_power_of_2);
     }
 
     /**
@@ -160,7 +160,7 @@ class lookup_pow_2_1_lookup_settings {
                                      in.alu_t_sub_s_bits,
                                      in.alu_two_pow_t_sub_s,
                                      in.main_clk,
-                                     in.main_table_pow_2);
+                                     in.powers_power_of_2);
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/powers.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/powers.hpp
@@ -1,0 +1,49 @@
+
+#pragma once
+#include "../../relation_parameters.hpp"
+#include "../../relation_types.hpp"
+#include "./declare_views.hpp"
+
+namespace bb::Avm_vm {
+
+template <typename FF> struct PowersRow {
+    FF powers_power_of_2{};
+
+    [[maybe_unused]] static std::vector<std::string> names();
+};
+
+inline std::string get_relation_label_powers(int index)
+{
+    switch (index) {}
+    return std::to_string(index);
+}
+
+template <typename FF_> class powersImpl {
+  public:
+    using FF = FF_;
+
+    static constexpr std::array<size_t, 1> SUBRELATION_PARTIAL_LENGTHS{
+        2,
+    };
+
+    template <typename ContainerOverSubrelations, typename AllEntities>
+    void static accumulate(ContainerOverSubrelations& evals,
+                           const AllEntities& new_term,
+                           [[maybe_unused]] const RelationParameters<FF>&,
+                           [[maybe_unused]] const FF& scaling_factor)
+    {
+
+        // Contribution 0
+        {
+            Avm_DECLARE_VIEWS(0);
+
+            auto tmp = (powers_power_of_2 - powers_power_of_2);
+            tmp *= scaling_factor;
+            std::get<0>(evals) += tmp;
+        }
+    }
+};
+
+template <typename FF> using powers = Relation<powersImpl<FF>>;
+
+} // namespace bb::Avm_vm

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_gas_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_gas_trace.cpp
@@ -1,5 +1,10 @@
 #include "barretenberg/vm/avm_trace/avm_gas_trace.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
 #include "barretenberg/vm/avm_trace/avm_opcode.hpp"
+#include "barretenberg/vm/avm_trace/fixed_gas.hpp"
 
 namespace bb::avm_trace {
 
@@ -39,8 +44,9 @@ void AvmGasTraceBuilder::constrain_gas_lookup(uint32_t clk, OpCode opcode)
     gas_opcode_lookup_counter[opcode]++;
 
     // Get the gas prices for this opcode
-    uint32_t l2_gas_cost = GAS_COST_TABLE.at(opcode).l2_fixed_gas_cost;
-    uint32_t da_gas_cost = GAS_COST_TABLE.at(opcode).da_fixed_gas_cost;
+    const auto& GAS_COST_TABLE = FixedGasTable::get();
+    auto l2_gas_cost = static_cast<uint32_t>(GAS_COST_TABLE.at(opcode).gas_l2_gas_fixed_table);
+    auto da_gas_cost = static_cast<uint32_t>(GAS_COST_TABLE.at(opcode).gas_da_gas_fixed_table);
 
     remaining_l2_gas -= l2_gas_cost;
     remaining_da_gas -= da_gas_cost;
@@ -69,8 +75,9 @@ void AvmGasTraceBuilder::constrain_gas_for_external_call(uint32_t clk,
     // gas_opcode_lookup_counter[opcode]++;
 
     // Get the gas prices for this opcode
-    uint32_t opcode_l2_gas_cost = GAS_COST_TABLE.at(opcode).l2_fixed_gas_cost;
-    uint32_t opcode_da_gas_cost = GAS_COST_TABLE.at(opcode).da_fixed_gas_cost;
+    const auto& GAS_COST_TABLE = FixedGasTable::get();
+    auto opcode_l2_gas_cost = static_cast<uint32_t>(GAS_COST_TABLE.at(opcode).gas_l2_gas_fixed_table);
+    auto opcode_da_gas_cost = static_cast<uint32_t>(GAS_COST_TABLE.at(opcode).gas_da_gas_fixed_table);
 
     remaining_l2_gas -= opcode_l2_gas_cost + nested_l2_gas_cost;
     remaining_da_gas -= opcode_da_gas_cost + nested_da_gas_cost;

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_gas_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_gas_trace.hpp
@@ -1,120 +1,17 @@
-#include "barretenberg/vm/avm_trace/avm_common.hpp"
-#include "barretenberg/vm/avm_trace/avm_opcode.hpp"
+#pragma once
+
 #include <cstdint>
 
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
+#include "barretenberg/vm/avm_trace/avm_opcode.hpp"
+
 namespace bb::avm_trace {
-
-struct GasTableEntry {
-    uint32_t l2_fixed_gas_cost = 0;
-    uint32_t da_fixed_gas_cost = 0;
-};
-
-// Temporary values until the definitive gas cost values are settled.
-// See TS counterpart constant TemporaryDefaultGasCost in avm_gas.ts
-static const inline GasTableEntry temp_default_gas_entry{ .l2_fixed_gas_cost = 10, .da_fixed_gas_cost = 2 };
-
-static const inline std::unordered_map<OpCode, GasTableEntry> GAS_COST_TABLE = {
-    // Compute
-    // Compute - Arithmetic
-    { OpCode::ADD, temp_default_gas_entry },
-    { OpCode::SUB, temp_default_gas_entry },
-    { OpCode::MUL, temp_default_gas_entry },
-    { OpCode::DIV, temp_default_gas_entry },
-    { OpCode::FDIV, temp_default_gas_entry },
-    // Compute - Comparators
-    { OpCode::EQ, temp_default_gas_entry },
-    { OpCode::LT, temp_default_gas_entry },
-    { OpCode::LTE, temp_default_gas_entry },
-    // Compute - Bitwise
-    { OpCode::AND, temp_default_gas_entry },
-    { OpCode::OR, temp_default_gas_entry },
-    { OpCode::XOR, temp_default_gas_entry },
-    { OpCode::NOT, temp_default_gas_entry },
-    { OpCode::SHL, temp_default_gas_entry },
-    { OpCode::SHR, temp_default_gas_entry },
-    // Compute - Type Conversions
-    { OpCode::CAST, temp_default_gas_entry },
-
-    // Execution Environment
-    { OpCode::ADDRESS, temp_default_gas_entry },
-    { OpCode::STORAGEADDRESS, temp_default_gas_entry },
-    { OpCode::SENDER, temp_default_gas_entry },
-    { OpCode::FEEPERL2GAS, temp_default_gas_entry },
-    { OpCode::FEEPERDAGAS, temp_default_gas_entry },
-    { OpCode::TRANSACTIONFEE, temp_default_gas_entry },
-    { OpCode::CONTRACTCALLDEPTH, temp_default_gas_entry },
-    // Execution Environment - Globals
-    { OpCode::CHAINID, temp_default_gas_entry },
-    { OpCode::VERSION, temp_default_gas_entry },
-    { OpCode::BLOCKNUMBER, temp_default_gas_entry },
-    { OpCode::TIMESTAMP, temp_default_gas_entry },
-    { OpCode::COINBASE, temp_default_gas_entry },
-    { OpCode::BLOCKL2GASLIMIT, temp_default_gas_entry },
-    { OpCode::BLOCKDAGASLIMIT, temp_default_gas_entry },
-    // Execution Environment - Calldata
-    { OpCode::CALLDATACOPY, temp_default_gas_entry },
-
-    // Machine State
-    // Machine State - Gas
-    { OpCode::L2GASLEFT, temp_default_gas_entry },
-    { OpCode::DAGASLEFT, temp_default_gas_entry },
-    // Machine State - Internal Control Flow
-    { OpCode::JUMP, temp_default_gas_entry },
-    { OpCode::JUMPI, temp_default_gas_entry },
-    { OpCode::INTERNALCALL, temp_default_gas_entry },
-    { OpCode::INTERNALRETURN, temp_default_gas_entry },
-    // Machine State - Memory
-    { OpCode::SET, temp_default_gas_entry },
-    { OpCode::MOV, temp_default_gas_entry },
-    { OpCode::CMOV, temp_default_gas_entry },
-
-    // World State
-    { OpCode::SLOAD, temp_default_gas_entry },
-    { OpCode::SSTORE, temp_default_gas_entry },
-    { OpCode::NOTEHASHEXISTS, temp_default_gas_entry },
-    { OpCode::EMITNOTEHASH, temp_default_gas_entry },
-    { OpCode::NULLIFIEREXISTS, temp_default_gas_entry },
-    { OpCode::EMITNULLIFIER, temp_default_gas_entry },
-    { OpCode::L1TOL2MSGEXISTS, temp_default_gas_entry },
-    { OpCode::HEADERMEMBER, temp_default_gas_entry },
-    { OpCode::GETCONTRACTINSTANCE, temp_default_gas_entry },
-
-    // Accrued Substate
-    { OpCode::EMITUNENCRYPTEDLOG, temp_default_gas_entry },
-    { OpCode::SENDL2TOL1MSG, temp_default_gas_entry },
-
-    // Control Flow - Contract Calls
-    { OpCode::CALL, temp_default_gas_entry },
-    { OpCode::STATICCALL, temp_default_gas_entry },
-    { OpCode::DELEGATECALL, temp_default_gas_entry },
-    { OpCode::RETURN, temp_default_gas_entry },
-    { OpCode::REVERT, temp_default_gas_entry },
-
-    // Misc
-    { OpCode::DEBUGLOG, temp_default_gas_entry },
-
-    // Gadgets
-    { OpCode::KECCAK, temp_default_gas_entry },
-    { OpCode::POSEIDON2, temp_default_gas_entry },
-    { OpCode::SHA256, temp_default_gas_entry },
-    { OpCode::PEDERSEN, temp_default_gas_entry },
-    { OpCode::ECADD, temp_default_gas_entry },
-
-    // Conversions
-    { OpCode::TORADIXLE, temp_default_gas_entry },
-
-    // Future Gadgets -- pending changes in noir
-    { OpCode::SHA256COMPRESSION, temp_default_gas_entry },
-    { OpCode::KECCAKF1600, temp_default_gas_entry }, // Here for when we eventually support this
-    // Sentinel
-    // LAST_OPCODE_SENTINEL,
-};
 
 class AvmGasTraceBuilder {
   public:
     struct GasTraceEntry {
         uint32_t clk = 0;
-        OpCode opcode = OpCode::ADD; // 0
+        OpCode opcode;
         uint32_t l2_gas_cost = 0;
         uint32_t da_gas_cost = 0;
         uint32_t remaining_l2_gas = 0;

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/fixed_gas.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/fixed_gas.cpp
@@ -1,0 +1,23 @@
+#include "barretenberg/vm/avm_trace/fixed_gas.hpp"
+
+namespace bb::avm_trace {
+
+FixedGasTable::FixedGasTable()
+{
+    for (int i = 0; i < static_cast<int>(OpCode::LAST_OPCODE_SENTINEL); i++) {
+        table_rows.push_back(GasRow{
+            .gas_da_gas_fixed_table = FF(2),
+            .gas_l2_gas_fixed_table = FF(10),
+            .gas_sel_gas_cost = FF(1),
+        });
+    }
+}
+
+// Singleton.
+const FixedGasTable& FixedGasTable::get()
+{
+    static FixedGasTable table;
+    return table;
+}
+
+} // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/fixed_gas.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/fixed_gas.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "barretenberg/relations/generated/avm/gas.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
+#include "barretenberg/vm/avm_trace/avm_opcode.hpp"
+
+namespace bb::avm_trace {
+
+class FixedGasTable {
+  public:
+    using GasRow = bb::Avm_vm::GasRow<FF>;
+
+    static const FixedGasTable& get();
+
+    size_t size() const { return table_rows.size(); }
+    const GasRow& at(size_t i) const { return table_rows.at(i); }
+    const GasRow& at(OpCode o) const { return at(static_cast<size_t>(o)); }
+
+  private:
+    FixedGasTable();
+
+    std::vector<GasRow> table_rows;
+};
+
+template <typename DestRow> void merge_into(DestRow& dest, FixedGasTable::GasRow const& src)
+{
+    dest.gas_sel_gas_cost = src.gas_sel_gas_cost;
+    dest.gas_l2_gas_fixed_table = src.gas_l2_gas_fixed_table;
+    dest.gas_da_gas_fixed_table = src.gas_da_gas_fixed_table;
+}
+
+} // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/fixed_powers.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/fixed_powers.cpp
@@ -1,0 +1,25 @@
+#include "barretenberg/vm/avm_trace/fixed_powers.hpp"
+
+#include <cstdint>
+
+#include "barretenberg/numeric/uint256/uint256.hpp"
+
+namespace bb::avm_trace {
+
+FixedPowersTable::FixedPowersTable()
+{
+    for (uint64_t i = 0; i < 256; i++) {
+        table_rows.push_back(PowersRow{
+            .powers_power_of_2 = FF(uint256_t(1) << uint256_t(i)),
+        });
+    }
+}
+
+// Singleton.
+const FixedPowersTable& FixedPowersTable::get()
+{
+    static FixedPowersTable table;
+    return table;
+}
+
+} // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/fixed_powers.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/fixed_powers.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "barretenberg/relations/generated/avm/powers.hpp"
+#include "barretenberg/vm/avm_trace/avm_common.hpp"
+
+namespace bb::avm_trace {
+
+class FixedPowersTable {
+  public:
+    using PowersRow = bb::Avm_vm::PowersRow<FF>;
+
+    static const FixedPowersTable& get();
+
+    size_t size() const { return table_rows.size(); }
+    const PowersRow& at(size_t i) const { return table_rows.at(i); }
+
+  private:
+    FixedPowersTable();
+
+    std::vector<PowersRow> table_rows;
+};
+
+template <typename DestRow> void merge_into(DestRow& dest, FixedPowersTable::PowersRow const& src)
+{
+    dest.powers_power_of_2 = src.powers_power_of_2;
+}
+
+} // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_circuit_builder.cpp
@@ -261,7 +261,6 @@ template <typename FF> std::vector<std::string> AvmFullRow<FF>::names()
              "main_sel_rng_16",
              "main_sel_rng_8",
              "main_space_id",
-             "main_table_pow_2",
              "main_tag_err",
              "main_w_in_tag",
              "mem_addr",
@@ -303,6 +302,7 @@ template <typename FF> std::vector<std::string> AvmFullRow<FF>::names()
              "poseidon2_input",
              "poseidon2_output",
              "poseidon2_sel_poseidon_perm",
+             "powers_power_of_2",
              "sha256_clk",
              "sha256_input",
              "sha256_output",
@@ -541,38 +541,38 @@ template <typename FF> std::ostream& operator<<(std::ostream& os, AvmFullRow<FF>
            << field_to_string(row.main_sel_resolve_ind_addr_c) << ","
            << field_to_string(row.main_sel_resolve_ind_addr_d) << "," << field_to_string(row.main_sel_rng_16) << ","
            << field_to_string(row.main_sel_rng_8) << "," << field_to_string(row.main_space_id) << ","
-           << field_to_string(row.main_table_pow_2) << "," << field_to_string(row.main_tag_err) << ","
-           << field_to_string(row.main_w_in_tag) << "," << field_to_string(row.mem_addr) << ","
-           << field_to_string(row.mem_clk) << "," << field_to_string(row.mem_diff_hi) << ","
-           << field_to_string(row.mem_diff_lo) << "," << field_to_string(row.mem_diff_mid) << ","
-           << field_to_string(row.mem_glob_addr) << "," << field_to_string(row.mem_last) << ","
-           << field_to_string(row.mem_lastAccess) << "," << field_to_string(row.mem_one_min_inv) << ","
-           << field_to_string(row.mem_r_in_tag) << "," << field_to_string(row.mem_rw) << ","
-           << field_to_string(row.mem_sel_mem) << "," << field_to_string(row.mem_sel_mov_ia_to_ic) << ","
-           << field_to_string(row.mem_sel_mov_ib_to_ic) << "," << field_to_string(row.mem_sel_op_a) << ","
-           << field_to_string(row.mem_sel_op_b) << "," << field_to_string(row.mem_sel_op_c) << ","
-           << field_to_string(row.mem_sel_op_cmov) << "," << field_to_string(row.mem_sel_op_d) << ","
-           << field_to_string(row.mem_sel_resolve_ind_addr_a) << "," << field_to_string(row.mem_sel_resolve_ind_addr_b)
-           << "," << field_to_string(row.mem_sel_resolve_ind_addr_c) << ","
-           << field_to_string(row.mem_sel_resolve_ind_addr_d) << "," << field_to_string(row.mem_sel_rng_chk) << ","
-           << field_to_string(row.mem_skip_check_tag) << "," << field_to_string(row.mem_space_id) << ","
+           << field_to_string(row.main_tag_err) << "," << field_to_string(row.main_w_in_tag) << ","
+           << field_to_string(row.mem_addr) << "," << field_to_string(row.mem_clk) << ","
+           << field_to_string(row.mem_diff_hi) << "," << field_to_string(row.mem_diff_lo) << ","
+           << field_to_string(row.mem_diff_mid) << "," << field_to_string(row.mem_glob_addr) << ","
+           << field_to_string(row.mem_last) << "," << field_to_string(row.mem_lastAccess) << ","
+           << field_to_string(row.mem_one_min_inv) << "," << field_to_string(row.mem_r_in_tag) << ","
+           << field_to_string(row.mem_rw) << "," << field_to_string(row.mem_sel_mem) << ","
+           << field_to_string(row.mem_sel_mov_ia_to_ic) << "," << field_to_string(row.mem_sel_mov_ib_to_ic) << ","
+           << field_to_string(row.mem_sel_op_a) << "," << field_to_string(row.mem_sel_op_b) << ","
+           << field_to_string(row.mem_sel_op_c) << "," << field_to_string(row.mem_sel_op_cmov) << ","
+           << field_to_string(row.mem_sel_op_d) << "," << field_to_string(row.mem_sel_resolve_ind_addr_a) << ","
+           << field_to_string(row.mem_sel_resolve_ind_addr_b) << "," << field_to_string(row.mem_sel_resolve_ind_addr_c)
+           << "," << field_to_string(row.mem_sel_resolve_ind_addr_d) << "," << field_to_string(row.mem_sel_rng_chk)
+           << "," << field_to_string(row.mem_skip_check_tag) << "," << field_to_string(row.mem_space_id) << ","
            << field_to_string(row.mem_tag) << "," << field_to_string(row.mem_tag_err) << ","
            << field_to_string(row.mem_tsp) << "," << field_to_string(row.mem_val) << ","
            << field_to_string(row.mem_w_in_tag) << "," << field_to_string(row.pedersen_clk) << ","
            << field_to_string(row.pedersen_input) << "," << field_to_string(row.pedersen_output) << ","
            << field_to_string(row.pedersen_sel_pedersen) << "," << field_to_string(row.poseidon2_clk) << ","
            << field_to_string(row.poseidon2_input) << "," << field_to_string(row.poseidon2_output) << ","
-           << field_to_string(row.poseidon2_sel_poseidon_perm) << "," << field_to_string(row.sha256_clk) << ","
-           << field_to_string(row.sha256_input) << "," << field_to_string(row.sha256_output) << ","
-           << field_to_string(row.sha256_sel_sha256_compression) << "," << field_to_string(row.sha256_state) << ","
-           << field_to_string(row.perm_main_alu) << "," << field_to_string(row.perm_main_bin) << ","
-           << field_to_string(row.perm_main_conv) << "," << field_to_string(row.perm_main_pos2_perm) << ","
-           << field_to_string(row.perm_main_pedersen) << "," << field_to_string(row.perm_main_mem_a) << ","
-           << field_to_string(row.perm_main_mem_b) << "," << field_to_string(row.perm_main_mem_c) << ","
-           << field_to_string(row.perm_main_mem_d) << "," << field_to_string(row.perm_main_mem_ind_addr_a) << ","
-           << field_to_string(row.perm_main_mem_ind_addr_b) << "," << field_to_string(row.perm_main_mem_ind_addr_c)
-           << "," << field_to_string(row.perm_main_mem_ind_addr_d) << "," << field_to_string(row.lookup_byte_lengths)
-           << "," << field_to_string(row.lookup_byte_operations) << "," << field_to_string(row.lookup_opcode_gas) << ","
+           << field_to_string(row.poseidon2_sel_poseidon_perm) << "," << field_to_string(row.powers_power_of_2) << ","
+           << field_to_string(row.sha256_clk) << "," << field_to_string(row.sha256_input) << ","
+           << field_to_string(row.sha256_output) << "," << field_to_string(row.sha256_sel_sha256_compression) << ","
+           << field_to_string(row.sha256_state) << "," << field_to_string(row.perm_main_alu) << ","
+           << field_to_string(row.perm_main_bin) << "," << field_to_string(row.perm_main_conv) << ","
+           << field_to_string(row.perm_main_pos2_perm) << "," << field_to_string(row.perm_main_pedersen) << ","
+           << field_to_string(row.perm_main_mem_a) << "," << field_to_string(row.perm_main_mem_b) << ","
+           << field_to_string(row.perm_main_mem_c) << "," << field_to_string(row.perm_main_mem_d) << ","
+           << field_to_string(row.perm_main_mem_ind_addr_a) << "," << field_to_string(row.perm_main_mem_ind_addr_b)
+           << "," << field_to_string(row.perm_main_mem_ind_addr_c) << ","
+           << field_to_string(row.perm_main_mem_ind_addr_d) << "," << field_to_string(row.lookup_byte_lengths) << ","
+           << field_to_string(row.lookup_byte_operations) << "," << field_to_string(row.lookup_opcode_gas) << ","
            << field_to_string(row.range_check_l2_gas_hi) << "," << field_to_string(row.range_check_l2_gas_lo) << ","
            << field_to_string(row.range_check_da_gas_hi) << "," << field_to_string(row.range_check_da_gas_lo) << ","
            << field_to_string(row.kernel_output_lookup) << "," << field_to_string(row.lookup_into_kernel) << ","

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_flavor.hpp
@@ -16,6 +16,7 @@
 #include "barretenberg/relations/generated/avm/alu.hpp"
 #include "barretenberg/relations/generated/avm/binary.hpp"
 #include "barretenberg/relations/generated/avm/conversion.hpp"
+#include "barretenberg/relations/generated/avm/gas.hpp"
 #include "barretenberg/relations/generated/avm/incl_main_tag_err.hpp"
 #include "barretenberg/relations/generated/avm/incl_mem_tag_err.hpp"
 #include "barretenberg/relations/generated/avm/keccakf1600.hpp"
@@ -72,6 +73,7 @@
 #include "barretenberg/relations/generated/avm/perm_main_pedersen.hpp"
 #include "barretenberg/relations/generated/avm/perm_main_pos2_perm.hpp"
 #include "barretenberg/relations/generated/avm/poseidon2.hpp"
+#include "barretenberg/relations/generated/avm/powers.hpp"
 #include "barretenberg/relations/generated/avm/range_check_da_gas_hi.hpp"
 #include "barretenberg/relations/generated/avm/range_check_da_gas_lo.hpp"
 #include "barretenberg/relations/generated/avm/range_check_l2_gas_hi.hpp"
@@ -162,12 +164,14 @@ class AvmFlavor {
     using Relations = std::tuple<Avm_vm::alu<FF>,
                                  Avm_vm::binary<FF>,
                                  Avm_vm::conversion<FF>,
+                                 Avm_vm::gas<FF>,
                                  Avm_vm::keccakf1600<FF>,
                                  Avm_vm::kernel<FF>,
                                  Avm_vm::main<FF>,
                                  Avm_vm::mem<FF>,
                                  Avm_vm::pedersen<FF>,
                                  Avm_vm::poseidon2<FF>,
+                                 Avm_vm::powers<FF>,
                                  Avm_vm::sha256<FF>,
                                  perm_main_alu_relation<FF>,
                                  perm_main_bin_relation<FF>,
@@ -497,7 +501,6 @@ class AvmFlavor {
                               main_sel_rng_16,
                               main_sel_rng_8,
                               main_space_id,
-                              main_table_pow_2,
                               main_tag_err,
                               main_w_in_tag,
                               mem_addr,
@@ -539,6 +542,7 @@ class AvmFlavor {
                               poseidon2_input,
                               poseidon2_output,
                               poseidon2_sel_poseidon_perm,
+                              powers_power_of_2,
                               sha256_clk,
                               sha256_input,
                               sha256_output,
@@ -883,7 +887,6 @@ class AvmFlavor {
                      main_sel_rng_16,
                      main_sel_rng_8,
                      main_space_id,
-                     main_table_pow_2,
                      main_tag_err,
                      main_w_in_tag,
                      mem_addr,
@@ -925,6 +928,7 @@ class AvmFlavor {
                      poseidon2_input,
                      poseidon2_output,
                      poseidon2_sel_poseidon_perm,
+                     powers_power_of_2,
                      sha256_clk,
                      sha256_input,
                      sha256_output,
@@ -1274,7 +1278,6 @@ class AvmFlavor {
                               main_sel_rng_16,
                               main_sel_rng_8,
                               main_space_id,
-                              main_table_pow_2,
                               main_tag_err,
                               main_w_in_tag,
                               mem_addr,
@@ -1316,6 +1319,7 @@ class AvmFlavor {
                               poseidon2_input,
                               poseidon2_output,
                               poseidon2_sel_poseidon_perm,
+                              powers_power_of_2,
                               sha256_clk,
                               sha256_input,
                               sha256_output,
@@ -1727,7 +1731,6 @@ class AvmFlavor {
                      main_sel_rng_16,
                      main_sel_rng_8,
                      main_space_id,
-                     main_table_pow_2,
                      main_tag_err,
                      main_w_in_tag,
                      mem_addr,
@@ -1769,6 +1772,7 @@ class AvmFlavor {
                      poseidon2_input,
                      poseidon2_output,
                      poseidon2_sel_poseidon_perm,
+                     powers_power_of_2,
                      sha256_clk,
                      sha256_input,
                      sha256_output,
@@ -2180,7 +2184,6 @@ class AvmFlavor {
                      main_sel_rng_16,
                      main_sel_rng_8,
                      main_space_id,
-                     main_table_pow_2,
                      main_tag_err,
                      main_w_in_tag,
                      mem_addr,
@@ -2222,6 +2225,7 @@ class AvmFlavor {
                      poseidon2_input,
                      poseidon2_output,
                      poseidon2_sel_poseidon_perm,
+                     powers_power_of_2,
                      sha256_clk,
                      sha256_input,
                      sha256_output,
@@ -2989,7 +2993,6 @@ class AvmFlavor {
             Base::main_sel_rng_16 = "MAIN_SEL_RNG_16";
             Base::main_sel_rng_8 = "MAIN_SEL_RNG_8";
             Base::main_space_id = "MAIN_SPACE_ID";
-            Base::main_table_pow_2 = "MAIN_TABLE_POW_2";
             Base::main_tag_err = "MAIN_TAG_ERR";
             Base::main_w_in_tag = "MAIN_W_IN_TAG";
             Base::mem_addr = "MEM_ADDR";
@@ -3031,6 +3034,7 @@ class AvmFlavor {
             Base::poseidon2_input = "POSEIDON2_INPUT";
             Base::poseidon2_output = "POSEIDON2_OUTPUT";
             Base::poseidon2_sel_poseidon_perm = "POSEIDON2_SEL_POSEIDON_PERM";
+            Base::powers_power_of_2 = "POWERS_POWER_OF_2";
             Base::sha256_clk = "SHA256_CLK";
             Base::sha256_input = "SHA256_INPUT";
             Base::sha256_output = "SHA256_OUTPUT";
@@ -3391,7 +3395,6 @@ class AvmFlavor {
         Commitment main_sel_rng_16;
         Commitment main_sel_rng_8;
         Commitment main_space_id;
-        Commitment main_table_pow_2;
         Commitment main_tag_err;
         Commitment main_w_in_tag;
         Commitment mem_addr;
@@ -3433,6 +3436,7 @@ class AvmFlavor {
         Commitment poseidon2_input;
         Commitment poseidon2_output;
         Commitment poseidon2_sel_poseidon_perm;
+        Commitment powers_power_of_2;
         Commitment sha256_clk;
         Commitment sha256_input;
         Commitment sha256_output;
@@ -3805,7 +3809,6 @@ class AvmFlavor {
             main_sel_rng_16 = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             main_sel_rng_8 = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             main_space_id = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
-            main_table_pow_2 = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             main_tag_err = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             main_w_in_tag = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             mem_addr = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
@@ -3847,6 +3850,7 @@ class AvmFlavor {
             poseidon2_input = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             poseidon2_output = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             poseidon2_sel_poseidon_perm = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
+            powers_power_of_2 = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             sha256_clk = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             sha256_input = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
             sha256_output = deserialize_from_buffer<Commitment>(Transcript::proof_data, num_frs_read);
@@ -4211,7 +4215,6 @@ class AvmFlavor {
             serialize_to_buffer<Commitment>(main_sel_rng_16, Transcript::proof_data);
             serialize_to_buffer<Commitment>(main_sel_rng_8, Transcript::proof_data);
             serialize_to_buffer<Commitment>(main_space_id, Transcript::proof_data);
-            serialize_to_buffer<Commitment>(main_table_pow_2, Transcript::proof_data);
             serialize_to_buffer<Commitment>(main_tag_err, Transcript::proof_data);
             serialize_to_buffer<Commitment>(main_w_in_tag, Transcript::proof_data);
             serialize_to_buffer<Commitment>(mem_addr, Transcript::proof_data);
@@ -4253,6 +4256,7 @@ class AvmFlavor {
             serialize_to_buffer<Commitment>(poseidon2_input, Transcript::proof_data);
             serialize_to_buffer<Commitment>(poseidon2_output, Transcript::proof_data);
             serialize_to_buffer<Commitment>(poseidon2_sel_poseidon_perm, Transcript::proof_data);
+            serialize_to_buffer<Commitment>(powers_power_of_2, Transcript::proof_data);
             serialize_to_buffer<Commitment>(sha256_clk, Transcript::proof_data);
             serialize_to_buffer<Commitment>(sha256_input, Transcript::proof_data);
             serialize_to_buffer<Commitment>(sha256_output, Transcript::proof_data);

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.cpp
@@ -312,7 +312,6 @@ void AvmProver::execute_wire_commitments_round()
     witness_commitments.main_sel_rng_16 = commitment_key->commit(key->main_sel_rng_16);
     witness_commitments.main_sel_rng_8 = commitment_key->commit(key->main_sel_rng_8);
     witness_commitments.main_space_id = commitment_key->commit(key->main_space_id);
-    witness_commitments.main_table_pow_2 = commitment_key->commit(key->main_table_pow_2);
     witness_commitments.main_tag_err = commitment_key->commit(key->main_tag_err);
     witness_commitments.main_w_in_tag = commitment_key->commit(key->main_w_in_tag);
     witness_commitments.mem_addr = commitment_key->commit(key->mem_addr);
@@ -354,6 +353,7 @@ void AvmProver::execute_wire_commitments_round()
     witness_commitments.poseidon2_input = commitment_key->commit(key->poseidon2_input);
     witness_commitments.poseidon2_output = commitment_key->commit(key->poseidon2_output);
     witness_commitments.poseidon2_sel_poseidon_perm = commitment_key->commit(key->poseidon2_sel_poseidon_perm);
+    witness_commitments.powers_power_of_2 = commitment_key->commit(key->powers_power_of_2);
     witness_commitments.sha256_clk = commitment_key->commit(key->sha256_clk);
     witness_commitments.sha256_input = commitment_key->commit(key->sha256_input);
     witness_commitments.sha256_output = commitment_key->commit(key->sha256_output);
@@ -694,7 +694,6 @@ void AvmProver::execute_wire_commitments_round()
     transcript->send_to_verifier(commitment_labels.main_sel_rng_16, witness_commitments.main_sel_rng_16);
     transcript->send_to_verifier(commitment_labels.main_sel_rng_8, witness_commitments.main_sel_rng_8);
     transcript->send_to_verifier(commitment_labels.main_space_id, witness_commitments.main_space_id);
-    transcript->send_to_verifier(commitment_labels.main_table_pow_2, witness_commitments.main_table_pow_2);
     transcript->send_to_verifier(commitment_labels.main_tag_err, witness_commitments.main_tag_err);
     transcript->send_to_verifier(commitment_labels.main_w_in_tag, witness_commitments.main_w_in_tag);
     transcript->send_to_verifier(commitment_labels.mem_addr, witness_commitments.mem_addr);
@@ -741,6 +740,7 @@ void AvmProver::execute_wire_commitments_round()
     transcript->send_to_verifier(commitment_labels.poseidon2_output, witness_commitments.poseidon2_output);
     transcript->send_to_verifier(commitment_labels.poseidon2_sel_poseidon_perm,
                                  witness_commitments.poseidon2_sel_poseidon_perm);
+    transcript->send_to_verifier(commitment_labels.powers_power_of_2, witness_commitments.powers_power_of_2);
     transcript->send_to_verifier(commitment_labels.sha256_clk, witness_commitments.sha256_clk);
     transcript->send_to_verifier(commitment_labels.sha256_input, witness_commitments.sha256_input);
     transcript->send_to_verifier(commitment_labels.sha256_output, witness_commitments.sha256_output);

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_verifier.cpp
@@ -452,8 +452,6 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
         transcript->template receive_from_prover<Commitment>(commitment_labels.main_sel_rng_16);
     commitments.main_sel_rng_8 = transcript->template receive_from_prover<Commitment>(commitment_labels.main_sel_rng_8);
     commitments.main_space_id = transcript->template receive_from_prover<Commitment>(commitment_labels.main_space_id);
-    commitments.main_table_pow_2 =
-        transcript->template receive_from_prover<Commitment>(commitment_labels.main_table_pow_2);
     commitments.main_tag_err = transcript->template receive_from_prover<Commitment>(commitment_labels.main_tag_err);
     commitments.main_w_in_tag = transcript->template receive_from_prover<Commitment>(commitment_labels.main_w_in_tag);
     commitments.mem_addr = transcript->template receive_from_prover<Commitment>(commitment_labels.mem_addr);
@@ -510,6 +508,8 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
         transcript->template receive_from_prover<Commitment>(commitment_labels.poseidon2_output);
     commitments.poseidon2_sel_poseidon_perm =
         transcript->template receive_from_prover<Commitment>(commitment_labels.poseidon2_sel_poseidon_perm);
+    commitments.powers_power_of_2 =
+        transcript->template receive_from_prover<Commitment>(commitment_labels.powers_power_of_2);
     commitments.sha256_clk = transcript->template receive_from_prover<Commitment>(commitment_labels.sha256_clk);
     commitments.sha256_input = transcript->template receive_from_prover<Commitment>(commitment_labels.sha256_input);
     commitments.sha256_output = transcript->template receive_from_prover<Commitment>(commitment_labels.sha256_output);

--- a/barretenberg/cpp/src/barretenberg/vm/tests/avm_bitwise.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/tests/avm_bitwise.test.cpp
@@ -346,20 +346,15 @@ std::vector<Row> gen_mutated_trace_bit(std::vector<Row> trace,
 
 class AvmBitwiseTests : public ::testing::Test {
   public:
-    AvmTraceBuilder trace_builder;
-    VmPublicInputs public_inputs{};
-
-  protected:
-    // TODO(640): The Standard Honk on Grumpkin test suite fails unless the SRS is initialised for every test.
-    void SetUp() override
+    AvmBitwiseTests()
+        : public_inputs(generate_base_public_inputs())
+        , trace_builder(AvmTraceBuilder(public_inputs))
     {
         srs::init_crs_factory("../srs_db/ignition");
-        std::array<FF, KERNEL_INPUTS_LENGTH> kernel_inputs{};
-        kernel_inputs.at(DA_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_DA_GAS;
-        kernel_inputs.at(L2_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_L2_GAS;
-        std::get<0>(public_inputs) = kernel_inputs;
-        trace_builder = AvmTraceBuilder(public_inputs);
-    };
+    }
+
+    VmPublicInputs public_inputs;
+    AvmTraceBuilder trace_builder;
 
     std::vector<Row> gen_mutated_trace_not(FF const& a, FF const& c_mutated, avm_trace::AvmMemoryTag tag)
     {

--- a/barretenberg/cpp/src/barretenberg/vm/tests/avm_cast.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/tests/avm_cast.test.cpp
@@ -13,24 +13,21 @@ using namespace bb::avm_trace;
 using namespace testing;
 
 class AvmCastTests : public ::testing::Test {
-  protected:
-    VmPublicInputs public_inputs{};
+  public:
+    AvmCastTests()
+        : public_inputs(generate_base_public_inputs())
+        , trace_builder(AvmTraceBuilder(public_inputs))
+    {
+        srs::init_crs_factory("../srs_db/ignition");
+    }
+
+    VmPublicInputs public_inputs;
     AvmTraceBuilder trace_builder;
+
     std::vector<Row> trace;
     size_t main_addr;
     size_t alu_addr;
     size_t mem_addr_c;
-
-    // TODO(640): The Standard Honk on Grumpkin test suite fails unless the SRS is initialised for every test.
-    void SetUp() override
-    {
-        srs::init_crs_factory("../srs_db/ignition");
-        std::array<FF, KERNEL_INPUTS_LENGTH> kernel_inputs{};
-        kernel_inputs.at(DA_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_DA_GAS;
-        kernel_inputs.at(L2_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_L2_GAS;
-        std::get<0>(public_inputs) = kernel_inputs;
-        trace_builder = AvmTraceBuilder(public_inputs);
-    };
 
     void gen_trace(
         uint128_t const& a, uint32_t src_address, uint32_t dst_address, AvmMemoryTag src_tag, AvmMemoryTag dst_tag)

--- a/barretenberg/cpp/src/barretenberg/vm/tests/avm_comparison.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/tests/avm_comparison.test.cpp
@@ -80,23 +80,20 @@ std::vector<ThreeOpParam> positive_op_lte_test_values = {
 std::vector<AvmMemoryTag> mem_tag_arr{
     { AvmMemoryTag::U8, AvmMemoryTag::U16, AvmMemoryTag::U32, AvmMemoryTag::U64, AvmMemoryTag::U128 }
 };
+
 class AvmCmpTests : public ::testing::Test {
   public:
-    AvmTraceBuilder trace_builder;
-    VmPublicInputs public_inputs{};
-
-  protected:
-    // TODO(640): The Standard Honk on Grumpkin test suite fails unless the SRS is initialised for every test.
-    void SetUp() override
+    AvmCmpTests()
+        : public_inputs(generate_base_public_inputs())
+        , trace_builder(AvmTraceBuilder(public_inputs))
     {
         srs::init_crs_factory("../srs_db/ignition");
-        std::array<FF, KERNEL_INPUTS_LENGTH> kernel_inputs{};
-        kernel_inputs.at(DA_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_DA_GAS;
-        kernel_inputs.at(L2_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_L2_GAS;
-        std::get<0>(public_inputs) = kernel_inputs;
-        trace_builder = AvmTraceBuilder(public_inputs);
-    };
+    }
+
+    VmPublicInputs public_inputs;
+    AvmTraceBuilder trace_builder;
 };
+
 class AvmCmpTestsLT : public AvmCmpTests, public testing::WithParamInterface<ThreeOpParamRow> {};
 class AvmCmpTestsLTE : public AvmCmpTests, public testing::WithParamInterface<ThreeOpParamRow> {};
 

--- a/barretenberg/cpp/src/barretenberg/vm/tests/avm_control_flow.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/tests/avm_control_flow.test.cpp
@@ -38,20 +38,15 @@ void validate_internal_return(Row const& row, uint32_t current_pc, uint32_t retu
 
 class AvmControlFlowTests : public ::testing::Test {
   public:
-    AvmTraceBuilder trace_builder;
-    VmPublicInputs public_inputs{};
-
-  protected:
-    // TODO(640): The Standard Honk on Grumpkin test suite fails unless the SRS is initialised for every test.
-    void SetUp() override
+    AvmControlFlowTests()
+        : public_inputs(generate_base_public_inputs())
+        , trace_builder(AvmTraceBuilder(public_inputs))
     {
         srs::init_crs_factory("../srs_db/ignition");
-        std::array<FF, KERNEL_INPUTS_LENGTH> kernel_inputs{};
-        kernel_inputs.at(DA_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_DA_GAS;
-        kernel_inputs.at(L2_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_L2_GAS;
-        std::get<0>(public_inputs) = kernel_inputs;
-        trace_builder = AvmTraceBuilder(public_inputs);
-    };
+    }
+
+    VmPublicInputs public_inputs;
+    AvmTraceBuilder trace_builder;
 };
 
 /******************************************************************************

--- a/barretenberg/cpp/src/barretenberg/vm/tests/avm_gas.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/tests/avm_gas.test.cpp
@@ -9,7 +9,6 @@ using namespace bb;
 using namespace bb::avm_trace;
 
 class AvmGasTests : public ::testing::Test {
-
   protected:
     // TODO(640): The Standard Honk on Grumpkin test suite fails unless the SRS is initialised for every test.
     void SetUp() override { srs::init_crs_factory("../srs_db/ignition"); };
@@ -34,7 +33,7 @@ void test_gas(StartGas startGas, OpcodesFunc apply_opcodes, CheckFunc check_trac
     kernel_inputs[L2_GAS_LEFT_CONTEXT_INPUTS_OFFSET] = FF(startGas.l2_gas);
     kernel_inputs[DA_GAS_LEFT_CONTEXT_INPUTS_OFFSET] = FF(startGas.da_gas);
 
-    VmPublicInputs public_inputs{};
+    VmPublicInputs public_inputs;
     std::get<0>(public_inputs) = kernel_inputs;
     AvmTraceBuilder trace_builder(public_inputs);
 

--- a/barretenberg/cpp/src/barretenberg/vm/tests/avm_indirect_mem.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/tests/avm_indirect_mem.test.cpp
@@ -7,20 +7,15 @@ using namespace bb::avm_trace;
 
 class AvmIndirectMemTests : public ::testing::Test {
   public:
-    AvmTraceBuilder trace_builder;
-    VmPublicInputs public_inputs{};
-
-  protected:
-    // TODO(640): The Standard Honk on Grumpkin test suite fails unless the SRS is initialised for every test.
-    void SetUp() override
+    AvmIndirectMemTests()
+        : public_inputs(generate_base_public_inputs())
+        , trace_builder(AvmTraceBuilder(public_inputs))
     {
         srs::init_crs_factory("../srs_db/ignition");
-        std::array<FF, KERNEL_INPUTS_LENGTH> kernel_inputs{};
-        kernel_inputs.at(DA_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_DA_GAS;
-        kernel_inputs.at(L2_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_L2_GAS;
-        std::get<0>(public_inputs) = kernel_inputs;
-        trace_builder = AvmTraceBuilder(public_inputs);
-    };
+    }
+
+    VmPublicInputs public_inputs;
+    AvmTraceBuilder trace_builder;
 };
 
 /******************************************************************************

--- a/barretenberg/cpp/src/barretenberg/vm/tests/avm_inter_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/tests/avm_inter_table.test.cpp
@@ -14,20 +14,15 @@ using namespace bb::avm_trace;
 
 class AvmInterTableTests : public ::testing::Test {
   public:
-    AvmTraceBuilder trace_builder;
-    VmPublicInputs public_inputs{};
-
-  protected:
-    // TODO(640): The Standard Honk on Grumpkin test suite fails unless the SRS is initialised for every test.
-    void SetUp() override
+    AvmInterTableTests()
+        : public_inputs(generate_base_public_inputs())
+        , trace_builder(AvmTraceBuilder(public_inputs))
     {
         srs::init_crs_factory("../srs_db/ignition");
-        std::array<FF, KERNEL_INPUTS_LENGTH> kernel_inputs{};
-        kernel_inputs.at(DA_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_DA_GAS;
-        kernel_inputs.at(L2_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_L2_GAS;
-        std::get<0>(public_inputs) = kernel_inputs;
-        trace_builder = AvmTraceBuilder(public_inputs);
-    };
+    }
+
+    VmPublicInputs public_inputs;
+    AvmTraceBuilder trace_builder;
 };
 
 /******************************************************************************

--- a/barretenberg/cpp/src/barretenberg/vm/tests/avm_kernel.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/tests/avm_kernel.test.cpp
@@ -12,7 +12,6 @@ using namespace bb;
 using namespace bb::avm_trace;
 
 class AvmKernelTests : public ::testing::Test {
-
   protected:
     // TODO(640): The Standard Honk on Grumpkin test suite fails unless the SRS is initialised for every test.
     void SetUp() override { srs::init_crs_factory("../srs_db/ignition"); };

--- a/barretenberg/cpp/src/barretenberg/vm/tests/avm_mem_opcodes.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/tests/avm_mem_opcodes.test.cpp
@@ -17,8 +17,15 @@ using namespace testing;
 
 class AvmMemOpcodeTests : public ::testing::Test {
   public:
+    AvmMemOpcodeTests()
+        : public_inputs(generate_base_public_inputs())
+        , trace_builder(AvmTraceBuilder(public_inputs))
+    {
+        srs::init_crs_factory("../srs_db/ignition");
+    }
+
+    VmPublicInputs public_inputs;
     AvmTraceBuilder trace_builder;
-    VmPublicInputs public_inputs{};
 
   protected:
     std::vector<Row> trace;
@@ -31,17 +38,6 @@ class AvmMemOpcodeTests : public ::testing::Test {
     size_t mem_ind_b_addr;
     size_t mem_ind_c_addr;
     size_t mem_ind_d_addr;
-
-    // TODO(640): The Standard Honk on Grumpkin test suite fails unless the SRS is initialised for every test.
-    void SetUp() override
-    {
-        srs::init_crs_factory("../srs_db/ignition");
-        std::array<FF, KERNEL_INPUTS_LENGTH> kernel_inputs{};
-        kernel_inputs.at(DA_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_DA_GAS;
-        kernel_inputs.at(L2_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_L2_GAS;
-        std::get<0>(public_inputs) = kernel_inputs;
-        trace_builder = AvmTraceBuilder(public_inputs);
-    };
 
     void build_mov_trace(bool indirect,
                          uint128_t const& val,

--- a/barretenberg/cpp/src/barretenberg/vm/tests/avm_memory.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/tests/avm_memory.test.cpp
@@ -2,25 +2,21 @@
 #include "barretenberg/vm/avm_trace/avm_common.hpp"
 
 namespace tests_avm {
+
 using namespace bb;
 using namespace bb::avm_trace;
 
 class AvmMemoryTests : public ::testing::Test {
   public:
-    AvmTraceBuilder trace_builder;
-    VmPublicInputs public_inputs{};
-
-  protected:
-    // TODO(640): The Standard Honk on Grumpkin test suite fails unless the SRS is initialised for every test.
-    void SetUp() override
+    AvmMemoryTests()
+        : public_inputs(generate_base_public_inputs())
+        , trace_builder(AvmTraceBuilder(public_inputs))
     {
         srs::init_crs_factory("../srs_db/ignition");
-        std::array<FF, KERNEL_INPUTS_LENGTH> kernel_inputs{};
-        kernel_inputs.at(DA_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_DA_GAS;
-        kernel_inputs.at(L2_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_L2_GAS;
-        std::get<0>(public_inputs) = kernel_inputs;
-        trace_builder = AvmTraceBuilder(public_inputs);
-    };
+    }
+
+    VmPublicInputs public_inputs;
+    AvmTraceBuilder trace_builder;
 };
 
 /******************************************************************************

--- a/barretenberg/cpp/src/barretenberg/vm/tests/helpers.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/tests/helpers.test.cpp
@@ -5,8 +5,8 @@
 #include "barretenberg/vm/generated/avm_flavor.hpp"
 #include <bits/utility.h>
 
-using namespace bb;
 namespace tests_avm {
+
 using namespace bb;
 
 std::vector<ThreeOpParamRow> gen_three_op_params(std::vector<ThreeOpParam> operands,
@@ -239,6 +239,16 @@ void clear_range_check_counters(std::vector<Row>& trace, uint256_t previous_valu
     // Decrement the counter
     trace.at(lookup_value).lookup_u16_14_counts = trace.at(lookup_value).lookup_u16_14_counts - 1;
     previous_value >>= 16;
+}
+
+VmPublicInputs generate_base_public_inputs()
+{
+    VmPublicInputs public_inputs;
+    std::array<FF, KERNEL_INPUTS_LENGTH> kernel_inputs{};
+    kernel_inputs.at(DA_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_DA_GAS;
+    kernel_inputs.at(L2_GAS_LEFT_CONTEXT_INPUTS_OFFSET) = DEFAULT_INITIAL_L2_GAS;
+    std::get<0>(public_inputs) = kernel_inputs;
+    return public_inputs;
 }
 
 } // namespace tests_avm

--- a/barretenberg/cpp/src/barretenberg/vm/tests/helpers.test.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/tests/helpers.test.hpp
@@ -41,4 +41,6 @@ void update_slice_registers(Row& row, uint256_t a);
 std::vector<ThreeOpParamRow> gen_three_op_params(std::vector<std::array<FF, 3>> operands,
                                                  std::vector<bb::avm_trace::AvmMemoryTag> mem_tags);
 
+VmPublicInputs generate_base_public_inputs();
+
 } // namespace tests_avm


### PR DESCRIPTION
An experiment in separating fixed tables and (for now mannually)
creating a `merge_into` function to merge them into the main trace.

TODO:
* Avoid having to create dummy relations
* autogen merge_into
* apply concept to other non-fixed tables