### PR TITLE
chore(ci): add new e2e base target

### DIFF
--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -221,7 +221,7 @@ end-to-end-base:
     ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
     ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
     ENV PROVER_AGENT_CONCURRENCY=8
-    RUN mkdir -p $BB_WORKING_DIRECTORY $
+    RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY
 
     RUN ln -s /usr/src/yarn-project/.yarn/releases/yarn-3.6.3.cjs /usr/local/bin/yarn
 

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -202,7 +202,7 @@ anvil:
     FROM ../build-images+build
     SAVE ARTIFACT /opt/foundry/bin/anvil
 
-end-to-end:
+end-to-end-base:
     FROM ubuntu:noble
     # add repository for chromium
     RUN apt-get update && apt-get install -y software-properties-common \
@@ -220,11 +220,16 @@ end-to-end:
     ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
     ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
     ENV PROVER_AGENT_CONCURRENCY=8
-    RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY
+    RUN mkdir -p $BB_WORKING_DIRECTORY $
+
+    RUN ln -s /usr/src/yarn-project/.yarn/releases/yarn-3.6.3.cjs /usr/local/bin/yarn
+
+end-to-end:
+    FROM +end-to-end-base
+
     COPY +anvil/anvil /opt/foundry/bin/anvil
     COPY +end-to-end-prod/usr/src /usr/src
     WORKDIR /usr/src/yarn-project/end-to-end
-    RUN ln -s /usr/src/yarn-project/.yarn/releases/yarn-3.6.3.cjs /usr/local/bin/yarn
     ENTRYPOINT ["yarn", "test"]
 
 scripts-prod:

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -208,8 +208,7 @@ end-to-end-base:
     RUN apt-get update && apt-get install -y software-properties-common \
         && add-apt-repository ppa:xtradeb/apps -y && apt-get update \
         && apt-get install -y wget gnupg \
-        && rm -rf /var/lib/apt/lists/*
-    RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+        && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
         && echo "deb [arch=$(dpkg --print-architecture)] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
         && apt update && apt install curl chromium nodejs netcat-openbsd -y \
         && rm -rf /var/lib/apt/lists/*

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -208,7 +208,8 @@ end-to-end-base:
     RUN apt-get update && apt-get install -y software-properties-common \
         && add-apt-repository ppa:xtradeb/apps -y && apt-get update \
         && apt-get install -y wget gnupg \
-        && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+        && rm -rf /var/lib/apt/lists/*
+    RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
         && echo "deb [arch=$(dpkg --print-architecture)] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
         && apt update && apt install curl chromium nodejs netcat-openbsd -y \
         && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I've noticed that we have to do a fair amount of installing from apt relatively often which only happens once the `+build` target is done. Ideally we'd do this in parallel so I've split off a different target in order to try and get earthly to be more proactive.