### PR TITLE
chore: improve authwit comments/docs

### DIFF
--- a/docs/docs/guides/js_apps/authwit.md
+++ b/docs/docs/guides/js_apps/authwit.md
@@ -15,7 +15,6 @@ These are all the libraries you might need for using authwits in Aztec.js:
 import {
   computeAuthWitMessageHash,
   computeInnerAuthWitHash,
-  computeOuterAuthWitHash,
 } from "@aztec/aztec.js";
 ```
 
@@ -63,9 +62,9 @@ You can hash your own authwit message by creating an inner hash with the data, l
 
 #include_code compute_inner_authwit_hash yarn-project/end-to-end/src/e2e_authwit.test.ts typescript
 
-Then create the outer hash by hashing the inner hash with the authwit receiver address, chainId, and version:
+Then create the message hash by hashing the inner hash with the authwit receiver address, chainId, and version:
 
-#include_code compute_outer_authwit_hash yarn-project/end-to-end/src/e2e_authwit.test.ts typescript
+#include_code compute_arbitrary_authwit_hash yarn-project/end-to-end/src/e2e_authwit.test.ts typescript
 
 ## Create the authwit
 
@@ -89,9 +88,9 @@ In this example,
 - `wallets[1]` is the authwit reciever and caller of the function
 - `action` was [defined previously](#define-the-action)
 
-If you created an artbitrary message, you can create the authwit by replacing these params with the outer hash:
+If you created an arbitrary message, you can create the authwit by replacing these params with the outer hash:
 
-#include_code compute_outer_authwit_hash yarn-project/end-to-end/src/e2e_authwit.test.ts typescript
+#include_code compute_arbitrary_authwit_hash yarn-project/end-to-end/src/e2e_authwit.test.ts typescript
 
 Then add it to the wallet of the authwit receiver (the caller of the function):
 

--- a/docs/docs/guides/smart_contracts/writing_contracts/authwit.md
+++ b/docs/docs/guides/smart_contracts/writing_contracts/authwit.md
@@ -91,7 +91,7 @@ For our purposes here (not building a wallet), the most important part of the li
 
 ### General utilities
 
-The primary general utility is the `compute_call_authwit_hash` function which computes the action hash from its components. This is useful for when you need to generate a hash that is not for the current call, such as when you want to update a public approval state value that is later used for [authentication in public](#updating-approval-state-in-noir). You can view the implementation of this function [here](https://github.com/AztecProtocol/aztec-packages/blob/master/noir-projects/aztec-nr/authwit/src/auth.nr).
+The primary general utility is the `compute_authwit_message_hash_from_call` function which computes the action hash from its components. This is useful for when you need to generate a hash that is not for the current call, such as when you want to update a public approval state value that is later used for [authentication in public](#updating-approval-state-in-noir). You can view the implementation of this function [here](https://github.com/AztecProtocol/aztec-packages/blob/master/noir-projects/aztec-nr/authwit/src/auth.nr).
 
 #### TypeScript utilities
 
@@ -174,7 +174,7 @@ In the snippet below, this is done as a separate contract call, but can also be 
 
 We have cases where we need a non-wallet contract to approve an action to be executed by another contract. One of the cases could be when making more complex defi where funds are passed along. When doing so, we need the intermediate contracts to support approving of actions on their behalf.
 
-This is fairly straight forward to do using the `auth` library which include logic for updating values in the public auth registry. Namely, you can prepare the `message_hash` using `compute_call_authwit_hash` and then simply feed it into the `set_authorized` function (both are in `auth` library) to update the value. 
+This is fairly straight forward to do using the `auth` library which include logic for updating values in the public auth registry. Namely, you can prepare the `message_hash` using `compute_authwit_message_hash_from_call` and then simply feed it into the `set_authorized` function (both are in `auth` library) to update the value. 
 
 When another contract later is consuming the authwit using `assert_current_call_valid_authwit_public` it will be calling the registry, and spend that authwit.
 

--- a/docs/docs/guides/smart_contracts/writing_contracts/authwit.md
+++ b/docs/docs/guides/smart_contracts/writing_contracts/authwit.md
@@ -174,7 +174,7 @@ In the snippet below, this is done as a separate contract call, but can also be 
 
 We have cases where we need a non-wallet contract to approve an action to be executed by another contract. One of the cases could be when making more complex defi where funds are passed along. When doing so, we need the intermediate contracts to support approving of actions on their behalf.
 
-This is fairly straight forward to do using the `auth` library which include logic for updating values in the public auth registry. Namely, you can prepare the `message_hash` using `compute_authwit_message_hash_from_call` and then simply feed it into the `set_authorized` function (both are in `auth` library) to update the value. 
+This is fairly straight forward to do using the `auth` library which includes logic for updating values in the public auth registry. Namely, you can prepare the `message_hash` using `compute_authwit_message_hash_from_call` and then simply feed it into the `set_authorized` function (both are in `auth` library) to update the value. 
 
 When another contract later is consuming the authwit using `assert_current_call_valid_authwit_public` it will be calling the registry, and spend that authwit.
 

--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -109,7 +109,7 @@ const innerHash = computeInnerAuthWitHash([Fr.ZERO, functionSelector.toField(), 
 -    new Fr(this.version),
 -    innerHash,
 -);
-+const outerHash = computeAuthWitMessageHash(
++const messageHash = computeAuthWitMessageHash(
 +    { consumer: this.dappEntrypointAddress, innerHash },
 +    { chainId: new Fr(this.chainId), version: new Fr(this.version) },
 +);

--- a/noir-projects/aztec-nr/authwit/src/account.nr
+++ b/noir-projects/aztec-nr/authwit/src/account.nr
@@ -2,7 +2,7 @@ use dep::aztec::context::{PrivateContext, PublicContext};
 use dep::aztec::protocol_types::{address::AztecAddress, abis::function_selector::FunctionSelector, hash::pedersen_hash};
 
 use crate::entrypoint::{app::AppPayload, fee::FeePayload};
-use crate::auth::{IS_VALID_SELECTOR, compute_outer_authwit_hash};
+use crate::auth::{IS_VALID_SELECTOR, compute_authwit_message_hash};
 
 struct AccountActions<Context> {
   context: Context,
@@ -15,7 +15,22 @@ impl<Context> AccountActions<Context> {
     }
 }
 
+/**
+ * An implementation of the Account Action struct for the private context.
+ * 
+ * Implements logic to verify authorization and execute payloads.
+ */
 impl AccountActions<&mut PrivateContext> {
+
+    /** 
+     * Verifies that the `app_hash` and `fee_hash` are authorized and then executes them.
+     * 
+     * Executes the `fee_payload` and `app_payload` in sequence.
+     * Will execute the `fee_payload` as part of the setup, and then enter the app phase.
+     * 
+     * @param app_payload The payload that contains the calls to be executed in the app phase.
+     * @param fee_payload The payload that contains the calls to be executed in the setup phase.
+     */
     // docs:start:entrypoint
     pub fn entrypoint(self, app_payload: AppPayload, fee_payload: FeePayload) {
         let valid_fn = self.is_valid_impl;
@@ -31,12 +46,22 @@ impl AccountActions<&mut PrivateContext> {
     }
     // docs:end:entrypoint
 
+    /**
+     * Verifies that the `msg_sender` is authorized to consume `inner_hash` by the account.
+     * 
+     * Computes the `message_hash` using the `msg_sender`, `chain_id`, `version` and `inner_hash`.
+     * Then executes the `is_valid_impl` function to verify that the message is authorized.
+     * 
+     * Will revert if the message is not authorized. 
+     * 
+     * @param inner_hash The hash of the message that the `msg_sender` is trying to consume.
+     */
     // docs:start:verify_private_authwit
     pub fn verify_private_authwit(self, inner_hash: Field) -> Field {
         // The `inner_hash` is "siloed" with the `msg_sender` to ensure that only it can 
         // consume the message.
         // This ensures that contracts cannot consume messages that are not intended for them.
-        let message_hash = compute_outer_authwit_hash(
+        let message_hash = compute_authwit_message_hash(
             self.context.msg_sender(),
             self.context.chain_id(),
             self.context.version(),

--- a/noir-projects/aztec-nr/authwit/src/auth.nr
+++ b/noir-projects/aztec-nr/authwit/src/auth.nr
@@ -8,16 +8,213 @@ use dep::aztec::protocol_types::{
 };
 use dep::aztec::{prelude::Deserialize, context::{PrivateContext, PublicContext, gas::GasOpts}, hash::hash_args_array};
 
+/**
+ * Authenticaion witness helper library
+ *
+ * Authentication Witness is a scheme for authenticating actions on Aztec, so users can allow third-parties 
+ * (eg protocols or other users) to execute an action on their behalf.
+ * 
+ * This library provides helper functions to manage such witnesses.
+ * The authentication witness, is some "witness" (data) that authenticates a `message_hash`.
+ * The simples example of an authentication witness, is a signature. The signature is the "evidence",
+ * that the signer have seen the message, agrees with it, and have allowed it.
+ * It does not strictly need to be a signature. It could be any kind of "proof" that the message is allowed.
+ * Another proof could be knowing some kind of secret, or having some kind of "token" that allows the message.
+ *
+ * The `message_hash` is a hash of the following structure:
+ * hash(consumer, chain_id, version, inner_hash)
+ * - consumer: the address of the contract that is "consuming" the message,
+ * - chain_id: the chain id of the chain that the message is being consumed on,
+ * - version: the version of the chain that the message is being consumed on,
+ * - inner_hash: the hash of the "inner" message that is being consumed, this is the "actual" message or action.
+ *
+ * While the `inner_hash` could be anything, such as showing your signed a specific message, it will often be 
+ * a hash of the "action" to approve, along with who made the call. As part of this library, we provide a few 
+ * helper functions to deal with "what" these messages are.
+ *
+ * For example, we provide helper functions that is used for checking that the message is encoding the current call.
+ * This can be used to let some contract "allow" another contract to act on its behalf, as long as it can 
+ * show that it is acting on behalf of the contract.
+ *
+ * If we take a case of allowing a contract to transfer tokens on behalf of an account, the `inner_hash` can be 
+ * derived as:
+ * inner_hash = hash(caller, "transfer", hash(to, amount))
+ * 
+ * Where the `caller` would be the address of the contract that is trying to transfer the tokens, and `to` and `amount`
+ * the arguments for the transfer. 
+ * 
+ * Note that we have both a `caller` and a `consumer`, the `consumer` will be the contract that is consuming the message,
+ * in the case of the transfer, it would be the `Token` contract itself, while the caller, will be the actor that is 
+ * allowed to transfer the tokens.
+ *
+ *
+ * The authentication mechanism works differently in public and private contexts. In private, we recall that everything
+ * is executed at the user device, so we can use `oracles` to "ask" the user (not contract) for information. In public
+ * we cannot do this, since it is executed by the sequencer (someone else). Therefore we can instead use a "registry"
+ * to store the messages that we have approved.
+ * 
+ * A simple example would be a "token" that is being "pulled" from one account into another. We will first outline 
+ * how this would look in private, and then in public later. 
+ *
+ * Say that a user `Alice` want to deposit some tokens into a defi protocol (say a DEX). 
+ * `Alice` would make a `deposit` transaction, that she is executing using her account contract. 
+ * The account would call the `DeFi` contract to execute `deposit`, which would try to pull funds from the `Token` 
+ * contract. Since the `DeFi` contract is trying to pull funds from an account that is not its own, it needs to 
+ * convince the `Token` contract that it is allowed to do so. 
+ * 
+ * This is where the authentication witness comes in! The `Token` contract computes a `message_hash` from the 
+ * `transfer` call, and then asks `Alice Account` contract to verify that the `DeFi` contract is allowed to 
+ * exeucte that call.
+ * 
+ * `Alice Account` contract can then ask `Alice` if she wants to allow the `DeFi` contract to pull funds from her 
+ * account. If she does, she will sign the `message_hash` and return the signature to the `Alice Account` which
+ * will validate it and return success to the `Token` contract which will then allow the `DeFi` contract to pull
+ * funds from `Alice`.
+ * 
+ * To ensure that the same "approval" cannot be used multiple times, we also compute a `nullifier` for the
+ * authentication witness, and emit it from the `Token` contract (consumer).
+ * 
+ * Note that we can do this flow as we are in private were we can do oracle calls out from contracts. 
+ * 
+ *
+ *  Person          Contract              Contract               Contract
+ *  Alice          Alice Account          Token                   DeFi
+ *   |                  |                  |                      |
+ *   | Defi.deposit(Token, 1000)           |                      |
+ *   |----------------->|                  |                      |
+ *   |                  | deposit(Token, 1000)                    |
+ *   |                  |---------------------------------------->|
+ *   |                  |                  |                      |
+ *   |                  |                  | transfer(Alice, Defi, 1000)
+ *   |                  |                  |<---------------------|
+ *   |                  |                  |                      |
+ *   |                  | Check if Defi may call transfer(Alice, Defi, 1000)
+ *   |                  |<-----------------|                      |
+ *   |                  |                  |                      |
+ *   | Please give me AuthWit for DeFi     |                      |
+ *   | calling transfer(Alice, Defi, 1000) |                      |
+ *   |<-----------------|                  |                      |
+ *   |                  |                  |                      |
+ *   |                  |                  |                      |
+ *   | AuthWit for transfer(Alice, Defi, 1000)                    |
+ *   |----------------->|                  |                      |
+ *   |                  | AuthWit validity |                      |
+ *   |                  |----------------->|                      |
+ *   |                  |                  |                      |
+ *   |                  |       throw if invalid AuthWit          |
+ *   |                  |                  |                      |
+ *   |                  |       emit AuthWit nullifier            |
+ *   |                  |                  |                      |
+ *   |                  |       transfer(Alice, Defi, 1000)       |
+ *   |                  |                  |                      |
+ *   |                  |                  |                      |
+ *   |                  |                  | success              |
+ *   |                  |                  |--------------------->|
+ *   |                  |                  |                      |
+ *   |                  |                  |                      |
+ *   |                  |                  |           deposit(Token, 1000)
+ *   |                  |                  |                      |
+ *   |                  |                  |                      |
+ *
+ *  
+ * If we instead were in public, we cannot do the same flow. Instead we would use a authentication registry to store 
+ * the messages that we have approved. 
+ * 
+ * To approve a message, `Alice Account` can make a `set_authorized` call to the registry, to set a `message_hash`
+ * as authorized. This is essentially a mapping from `message_hash` to `true` for `Alice Contract`. Every account
+ * have its own map in the registry, so `Alice` cannot approve a message for `Bob`.
+ *
+ * The `Token` contract can then try to "spend" the approval by calling `consume` on the registry. If the message
+ * was approved, the value is updated to `false`, and we return the success flag. For more information on the
+ * registry, see `main.nr` in `auth_registry_contract`.
+ *
+ * Person          Contract              Contract            Contract               Contract
+ * Alice          Alice Account          Registry             Token                   DeFi
+ *   |                  |                    |                   |                      |
+ *   | Registry.set_authorized(..., true)    |                   |                      |
+ *   |----------------->|                    |                   |                      |
+ *   |                  | set_authorized(..., true)              |                      |
+ *   |                  |------------------->|                   |                      |
+ *   |                  |                    |                   |                      |
+ *   |                  |         set authorized to true         |                      |
+ *   |                  |                    |                   |                      |
+ *   |                  |                    |                   |                      |
+ *   | Defi.deposit(Token, 1000)             |                   |                      |
+ *   |----------------->|                    |                   |                      |
+ *   |                  | deposit(Token, 1000)                   |                      |
+ *   |                  |-------------------------------------------------------------->|
+ *   |                  |                    |                   |                      |
+ *   |                  |                    |              transfer(Alice, Defi, 1000) |
+ *   |                  |                    |                   |<---------------------|
+ *   |                  |                    |                   |                      |
+ *   |                  |                    | Check if Defi may call transfer(Alice, Defi, 1000)
+ *   |                  |                    |<------------------|                      |
+ *   |                  |                    |                   |                      |
+ *   |                  |          throw if invalid AuthWit      |                      |
+ *   |                  |                    |                   |                      |
+ *   |                  |                    |                   |                      |
+ *   |                  |           set authorized to false      |                      |
+ *   |                  |                    |                   |                      |
+ *   |                  |                    |                   |                      |
+ *   |                  |                    | AuthWit validity  |                      |
+ *   |                  |                    |------------------>|                      |
+ *   |                  |                    |                   |                      |
+ *   |                  |                    |                   | transfer(Alice, Defi, 1000)
+ *   |                  |                    |                   |<-------------------->|
+ *   |                  |                    |                   |                      |
+ *   |                  |                    |                   | success              |
+ *   |                  |                    |                   |--------------------->|
+ *   |                  |                    |                   |                      |
+ *   |                  |                    |                   |     deposit(Token, 1000)
+ *   |                  |                    |                   |                      |
+ *
+ *
+ * --- FAQ ---
+ * Q:   Why are we using a success flag of `keccak256("IS_VALID()")` instead of just returning a boolean?
+ * A:   We want to make sure that we don't accidentally return `true` if there is a collision in the function selector.
+ *      By returning a hash of `IS_VALID()`, it becomes very unlikely that there is both a colission and we return 
+ *      a success flag.
+ * 
+ * Q:   Why are we using static calls?
+ * A:   We are using static calls to ensure that the account contract cannot re-enter. If it was a normal call, it
+ *      could make a new call and do a re-entry attack. Using a static ensures that it cannot update any state.
+ *
+ * Q:   Would it not be cheaper to use a nullifier instead of updating state in public?
+ * A:   At a quick glance, a public state update + nullifier is 96 bytes, but two state updates are 128, so it would be 
+ *      cheaper to use a nullifier, if this is the way it would always be done. However, if both the approval and the 
+ *      consumption is done in the same transaction, then we will be able to squash the updates, and now it is cheaper.
+ * 
+ * Q:   Why is the chain id and the version part of the message hash?
+ * A:   The chain id and the version is part of the message hash to ensure that the message is only valid on a specific
+ *      chain to avoid a case where the same message could be used across multiple chains. 
+ */
+
 global IS_VALID_SELECTOR = 0xabf64ad4; // 4 first bytes of keccak256("IS_VALID()")
 
+/** 
+ * Assert that `on_behalf_of` have authorized the current call with a valid authentication witness
+ * 
+ * Computing the `inner_hash` using the `msg_sender`, `selector` and `args_hash` and then making a call out to the 
+ * `on_behalf_of` contract to verify that the `inner_hash` is valid.
+ * 
+ * @param on_behalf_of The address that have authorized the current call
+ */
 // docs:start:assert_current_call_valid_authwit
-// Assert that `on_behalf_of` have authorized the current call with a valid authentication witness
 pub fn assert_current_call_valid_authwit(context: &mut PrivateContext, on_behalf_of: AztecAddress) {
     let inner_hash = compute_inner_authwit_hash([context.msg_sender().to_field(), context.selector().to_field(), context.args_hash]);
     assert_inner_hash_valid_authwit(context, on_behalf_of, inner_hash);
 }
 // docs:end:assert_current_call_valid_authwit
 
+/** 
+ * Assert that a specific `inner_hash` is valid for the `on_behalf_of` address
+ * 
+ * Used as an internal function for `assert_current_call_valid_authwit` and can be used as a standalone function when
+ * the `inner_hash` is from a different source, e.g., say a block of text etc.
+ * 
+ * @param on_behalf_of The address that have authorized the current call
+ * @param inner_hash The hash of the message to authorize  
+ */
 pub fn assert_inner_hash_valid_authwit(context: &mut PrivateContext, on_behalf_of: AztecAddress, inner_hash: Field) {
     // We perform a static call here and not a standard one to ensure that the account contract cannot re-enter.
     let result: Field = context.static_call_private_function(
@@ -32,8 +229,18 @@ pub fn assert_inner_hash_valid_authwit(context: &mut PrivateContext, on_behalf_o
     context.push_new_nullifier(nullifier, 0);
 }
 
+/** 
+ * Assert that `on_behalf_of` have authorized the current call in the authentication registry
+ * 
+ * Computing the `inner_hash` using the `msg_sender`, `selector` and `args_hash` and then making a call out to the 
+ * `on_behalf_of` contract to verify that the `inner_hash` is valid.
+ * 
+ * Note that the authentication registry will take the `msg_sender` into account as the consumer, so this will only
+ * work if the `msg_sender` is the same as the `consumer` when the `message_hash` was inserted into the registry.
+ * 
+ * @param on_behalf_of The address that have authorized the current call
+ */
 // docs:start:assert_current_call_valid_authwit_public
-// Assert that `on_behalf_of` have authorized the current call in a public context
 pub fn assert_current_call_valid_authwit_public(context: &mut PublicContext, on_behalf_of: AztecAddress) {
     let inner_hash = compute_inner_authwit_hash(
         [(*context).msg_sender().to_field(), (*context).selector().to_field(), (*context).get_args_hash()]
@@ -42,6 +249,17 @@ pub fn assert_current_call_valid_authwit_public(context: &mut PublicContext, on_
 }
 // docs:end:assert_current_call_valid_authwit_public
 
+/** 
+ * Assert that `on_behalf_of` have authorized a speicifc `inner_hash` in the authentication registry
+ * 
+ * Computing the `inner_hash` using the `msg_sender`, `selector` and `args_hash` and then making a call out to the 
+ * `on_behalf_of` contract to verify that the `inner_hash` is valid.
+ *
+ * Note that the authentication registry will take the `msg_sender` into account as the consumer, so this will only
+ * work if the `msg_sender` is the same as the `consumer` when the `message_hash` was inserted into the registry.
+ * 
+ * @param on_behalf_of The address that have authorized the the `inner_hash`
+ */
 pub fn assert_inner_hash_valid_authwit_public(context: &mut PublicContext, on_behalf_of: AztecAddress, inner_hash: Field) {
     let result: Field = context.call_public_function(
         AztecAddress::from_field(CANONICAL_AUTH_REGISTRY_ADDRESS),
@@ -52,9 +270,22 @@ pub fn assert_inner_hash_valid_authwit_public(context: &mut PublicContext, on_be
     assert(result == IS_VALID_SELECTOR, "Message not authorized by account");
 }
 
-// docs:start:compute_call_authwit_hash
-// Compute the message hash to be used by an authentication witness 
-pub fn compute_call_authwit_hash<N>(
+/**
+ * Compute the `message_hash` from a function call to be used by an authentication witness 
+ * 
+ * Useful for when you need a non-account contract to approve during execution. For example if you need a contract
+ * to make a call to nested contract, e.g., contract A want to exit token T to L1 using bridge B, so it need to allow
+ * B to transfer T on its behalf.
+ * 
+ * @param caller The address of the contract that is calling the function, in the example above, this would be B
+ * @param consumer The address of the contract that is consuming the message, in the example above, this would be T
+ * @param chain_id The chain id of the chain that the message is being consumed on
+ * @param version The version of the chain that the message is being consumed on
+ * @param selector The function selector of the function that is being called
+ * @param args The arguments of the function that is being called
+ */
+// docs:start:compute_authwit_message_hash_from_call
+pub fn compute_authwit_message_hash_from_call<N>(
     caller: AztecAddress,
     consumer: AztecAddress,
     chain_id: Field,
@@ -64,14 +295,30 @@ pub fn compute_call_authwit_hash<N>(
 ) -> Field {
     let args_hash = hash_args_array(args);
     let inner_hash = compute_inner_authwit_hash([caller.to_field(), selector.to_field(), args_hash]);
-    compute_outer_authwit_hash(consumer, chain_id, version, inner_hash)
+    compute_authwit_message_hash(consumer, chain_id, version, inner_hash)
 }
-// docs:end:compute_call_authwit_hash
+// docs:end:compute_authwit_message_hash_from_call
 
+/**
+ * Computes the `inner_hash` of the authentication witness
+ * 
+ * This is used internally, but also useful in cases where you want to compute the `inner_hash` for a specific message
+ * that is not necessarily a call, but just some "bytes" or text.
+ * 
+ * @param args The arguments to hash
+ */
 pub fn compute_inner_authwit_hash<N>(args: [Field; N]) -> Field {
     pedersen_hash(args, GENERATOR_INDEX__AUTHWIT_INNER)
 }
 
+/** 
+ * Computs the `authwit_nullifier` for a specific `on_behalf_of` and `inner_hash`
+ * 
+ * Using the `on_behalf_of` and the `inner_hash` to ensure that the nullifier is siloed for a specific `on_behalf_of`.
+ * 
+ * @param on_behalf_of The address that have authorized the the `inner_hash`
+ * @param inner_hash The hash of the message to authorize
+ */
 pub fn compute_authwit_nullifier(on_behalf_of: AztecAddress, inner_hash: Field) -> Field {
     pedersen_hash(
         [on_behalf_of.to_field(), inner_hash],
@@ -79,12 +326,15 @@ pub fn compute_authwit_nullifier(on_behalf_of: AztecAddress, inner_hash: Field) 
     )
 }
 
-pub fn compute_outer_authwit_hash(
-    consumer: AztecAddress,
-    chain_id: Field,
-    version: Field,
-    inner_hash: Field
-) -> Field {
+/**
+ * Computes the `message_hash` for the authentication witness
+ * 
+ * @param consumer The address of the contract that is consuming the message
+ * @param chain_id The chain id of the chain that the message is being consumed on
+ * @param version The version of the chain that the message is being consumed on
+ * @param inner_hash The hash of the "inner" message that is being consumed
+ */
+pub fn compute_authwit_message_hash(consumer: AztecAddress, chain_id: Field, version: Field, inner_hash: Field) -> Field {
     pedersen_hash(
         [
         consumer.to_field(),
@@ -98,6 +348,8 @@ pub fn compute_outer_authwit_hash(
 
 /**
  * Helper function to set the authorization status of a message hash
+ * 
+ * Wraps a public call to the authentication registry to set the authorization status of a `message_hash`
  * 
  * @param message_hash The hash of the message to authorize
  * @param authorize True if the message should be authorized, false if it should be revoked
@@ -113,6 +365,8 @@ pub fn set_authorized(context: &mut PublicContext, message_hash: Field, authoriz
 
 /**
  * Helper function to reject all authwits
+ * 
+ * Wraps a public call to the authentication registry to set the `reject_all` flag
  *
  * @param reject True if all authwits should be rejected, false otherwise 
  */

--- a/noir-projects/aztec-nr/authwit/src/auth.nr
+++ b/noir-projects/aztec-nr/authwit/src/auth.nr
@@ -12,13 +12,13 @@ use dep::aztec::{prelude::Deserialize, context::{PrivateContext, PublicContext, 
  * Authenticaion witness helper library
  *
  * Authentication Witness is a scheme for authenticating actions on Aztec, so users can allow third-parties 
- * (eg protocols or other users) to execute an action on their behalf.
+ * (e.g. protocols or other users) to execute an action on their behalf.
  * 
  * This library provides helper functions to manage such witnesses.
  * The authentication witness, is some "witness" (data) that authenticates a `message_hash`.
- * The simples example of an authentication witness, is a signature. The signature is the "evidence",
- * that the signer have seen the message, agrees with it, and have allowed it.
- * It does not strictly need to be a signature. It could be any kind of "proof" that the message is allowed.
+ * The simplest example of an authentication witness, is a signature. The signature is the "evidence",
+ * that the signer has seen the message, agrees with it, and has allowed it.
+ * It does not need to be a signature. It could be any kind of "proof" that the message is allowed.
  * Another proof could be knowing some kind of secret, or having some kind of "token" that allows the message.
  *
  * The `message_hash` is a hash of the following structure:
@@ -28,11 +28,11 @@ use dep::aztec::{prelude::Deserialize, context::{PrivateContext, PublicContext, 
  * - version: the version of the chain that the message is being consumed on,
  * - inner_hash: the hash of the "inner" message that is being consumed, this is the "actual" message or action.
  *
- * While the `inner_hash` could be anything, such as showing your signed a specific message, it will often be 
+ * While the `inner_hash` could be anything, such as showing you signed a specific message, it will often be 
  * a hash of the "action" to approve, along with who made the call. As part of this library, we provide a few 
- * helper functions to deal with "what" these messages are.
+ * helper functions to deal with such messages.
  *
- * For example, we provide helper functions that is used for checking that the message is encoding the current call.
+ * For example, we provide helper function that is used for checking that the message is an encoding of the current call.
  * This can be used to let some contract "allow" another contract to act on its behalf, as long as it can 
  * show that it is acting on behalf of the contract.
  *
@@ -49,14 +49,14 @@ use dep::aztec::{prelude::Deserialize, context::{PrivateContext, PublicContext, 
  *
  *
  * The authentication mechanism works differently in public and private contexts. In private, we recall that everything
- * is executed at the user device, so we can use `oracles` to "ask" the user (not contract) for information. In public
+ * is executed on the user's device, so we can use `oracles` to "ask" the user (not contract) for information. In public
  * we cannot do this, since it is executed by the sequencer (someone else). Therefore we can instead use a "registry"
  * to store the messages that we have approved.
  * 
  * A simple example would be a "token" that is being "pulled" from one account into another. We will first outline 
  * how this would look in private, and then in public later. 
  *
- * Say that a user `Alice` want to deposit some tokens into a defi protocol (say a DEX). 
+ * Say that a user `Alice` wants to deposit some tokens into a DeFi protocol (say a DEX). 
  * `Alice` would make a `deposit` transaction, that she is executing using her account contract. 
  * The account would call the `DeFi` contract to execute `deposit`, which would try to pull funds from the `Token` 
  * contract. Since the `DeFi` contract is trying to pull funds from an account that is not its own, it needs to 
@@ -64,7 +64,7 @@ use dep::aztec::{prelude::Deserialize, context::{PrivateContext, PublicContext, 
  * 
  * This is where the authentication witness comes in! The `Token` contract computes a `message_hash` from the 
  * `transfer` call, and then asks `Alice Account` contract to verify that the `DeFi` contract is allowed to 
- * exeucte that call.
+ * execute that call.
  * 
  * `Alice Account` contract can then ask `Alice` if she wants to allow the `DeFi` contract to pull funds from her 
  * account. If she does, she will sign the `message_hash` and return the signature to the `Alice Account` which
@@ -117,12 +117,12 @@ use dep::aztec::{prelude::Deserialize, context::{PrivateContext, PublicContext, 
  *   |                  |                  |                      |
  *
  *  
- * If we instead were in public, we cannot do the same flow. Instead we would use a authentication registry to store 
+ * If we instead were in public, we cannot do the same flow. Instead we would use an authentication registry to store 
  * the messages that we have approved. 
  * 
  * To approve a message, `Alice Account` can make a `set_authorized` call to the registry, to set a `message_hash`
  * as authorized. This is essentially a mapping from `message_hash` to `true` for `Alice Contract`. Every account
- * have its own map in the registry, so `Alice` cannot approve a message for `Bob`.
+ * has its own map in the registry, so `Alice` cannot approve a message for `Bob`.
  *
  * The `Token` contract can then try to "spend" the approval by calling `consume` on the registry. If the message
  * was approved, the value is updated to `false`, and we return the success flag. For more information on the
@@ -182,7 +182,7 @@ use dep::aztec::{prelude::Deserialize, context::{PrivateContext, PublicContext, 
  * Q:   Would it not be cheaper to use a nullifier instead of updating state in public?
  * A:   At a quick glance, a public state update + nullifier is 96 bytes, but two state updates are 128, so it would be 
  *      cheaper to use a nullifier, if this is the way it would always be done. However, if both the approval and the 
- *      consumption is done in the same transaction, then we will be able to squash the updates, and now it is cheaper.
+ *      consumption is done in the same transaction, then we will be able to squash the updates (only final tx state diff is posted to DA), and now it is cheaper.
  * 
  * Q:   Why is the chain id and the version part of the message hash?
  * A:   The chain id and the version is part of the message hash to ensure that the message is only valid on a specific
@@ -274,7 +274,7 @@ pub fn assert_inner_hash_valid_authwit_public(context: &mut PublicContext, on_be
  * Compute the `message_hash` from a function call to be used by an authentication witness 
  * 
  * Useful for when you need a non-account contract to approve during execution. For example if you need a contract
- * to make a call to nested contract, e.g., contract A want to exit token T to L1 using bridge B, so it need to allow
+ * to make a call to nested contract, e.g., contract A wants to exit token T to L1 using bridge B, so it needs to allow
  * B to transfer T on its behalf.
  * 
  * @param caller The address of the contract that is calling the function, in the example above, this would be B

--- a/noir-projects/aztec-nr/authwit/src/auth_witness.nr
+++ b/noir-projects/aztec-nr/authwit/src/auth_witness.nr
@@ -1,6 +1,12 @@
 #[oracle(getAuthWitness)]
 unconstrained fn get_auth_witness_oracle<N>(_message_hash: Field) -> [Field; N] {}
 
+/**
+ * Oracle wrapper to fetch an `auth_witness` for a given `message_hash` from the PXE.
+ * 
+ * @param message_hash The hash of the message for which the `auth_witness` is to be fetched.
+ * @return The `auth_witness` for the given `message_hash` as Field array.
+ */
 unconstrained pub fn get_auth_witness<N>(message_hash: Field) -> [Field; N] {
     get_auth_witness_oracle(message_hash)
 }

--- a/noir-projects/noir-contracts/contracts/auth_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/auth_registry_contract/src/main.nr
@@ -1,6 +1,6 @@
 contract AuthRegistry {
     use dep::aztec::{state_vars::{PublicMutable, Map}, protocol_types::address::AztecAddress};
-    use dep::authwit::auth::{IS_VALID_SELECTOR, compute_outer_authwit_hash, assert_current_call_valid_authwit};
+    use dep::authwit::auth::{IS_VALID_SELECTOR, compute_authwit_message_hash, assert_current_call_valid_authwit};
 
     #[aztec(storage)]
     struct Storage {
@@ -46,7 +46,7 @@ contract AuthRegistry {
     fn consume(on_behalf_of: AztecAddress, inner_hash: Field) -> Field {
         assert_eq(false, storage.reject_all.at(on_behalf_of).read(), "rejecting all");
 
-        let message_hash = compute_outer_authwit_hash(
+        let message_hash = compute_authwit_message_hash(
             context.msg_sender(),
             context.chain_id(),
             context.version(),

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -9,7 +9,7 @@ contract SchnorrAccount {
     use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt;
     use dep::authwit::{
         entrypoint::{app::AppPayload, fee::FeePayload}, account::AccountActions,
-        auth_witness::get_auth_witness, auth::{compute_authwit_nullifier, compute_outer_authwit_hash}
+        auth_witness::get_auth_witness, auth::{compute_authwit_nullifier, compute_authwit_message_hash}
     };
     use dep::aztec::hash::compute_siloed_nullifier;
     use dep::aztec::oracle::get_nullifier_membership_witness::get_low_nullifier_membership_witness;
@@ -92,7 +92,7 @@ contract SchnorrAccount {
     unconstrained fn lookup_validity(consumer: AztecAddress, inner_hash: Field) -> pub bool {
         let public_key = storage.signing_public_key.view_note();
 
-        let message_hash = compute_outer_authwit_hash(consumer, context.chain_id(), context.version(), inner_hash);
+        let message_hash = compute_authwit_message_hash(consumer, context.chain_id(), context.version(), inner_hash);
 
         let witness: [Field; 64] = get_auth_witness(message_hash);
         let mut signature: [u8; 64] = [0; 64];

--- a/noir-projects/noir-contracts/contracts/uniswap_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/uniswap_contract/src/main.nr
@@ -9,8 +9,8 @@ contract Uniswap {
     use dep::aztec::context::gas::GasOpts;
 
     use dep::authwit::auth::{
-        IS_VALID_SELECTOR, assert_current_call_valid_authwit_public, compute_call_authwit_hash,
-        compute_outer_authwit_hash, set_authorized
+        IS_VALID_SELECTOR, assert_current_call_valid_authwit_public, compute_authwit_message_hash_from_call,
+        compute_authwit_message_hash, set_authorized
     };
 
     use dep::token::Token;
@@ -166,7 +166,7 @@ contract Uniswap {
         let nonce = 0xdeadbeef;
 
         let selector = FunctionSelector::from_signature("burn_public((Field),Field,Field)");
-        let message_hash = compute_call_authwit_hash(
+        let message_hash = compute_authwit_message_hash_from_call(
             token_bridge,
             token,
             context.chain_id(),

--- a/yarn-project/end-to-end/src/e2e_authwit.test.ts
+++ b/yarn-project/end-to-end/src/e2e_authwit.test.ts
@@ -36,8 +36,8 @@ describe('e2e_authwit_tests', () => {
       it('happy path', async () => {
         // What are we doing here:
         // 1. We compute an inner hash which is here just a hash of random data
-        // 2. We then compute the outer, which is binding it to a "consumer" (here the "auth" contract)
-        // 3. We then create an authwit for this outer hash.
+        // 2. We then compute the message hash, which is binding it to a "consumer" (here the "auth" contract)
+        // 3. We then create an authwit for this message hash.
         // 4. We add this authwit to the wallet[1]
         // 5. We check that the authwit is valid in private for wallet[0] (check that it is signed by 0)
         // 6. We check that the authwit is NOT valid in private for wallet[1] (check that it is not signed by 1)
@@ -45,10 +45,10 @@ describe('e2e_authwit_tests', () => {
         // docs:start:compute_inner_authwit_hash
         const innerHash = computeInnerAuthWitHash([Fr.fromString('0xdead')]);
         // docs:end:compute_inner_authwit_hash
-        // docs:start:compute_outer_authwit_hash
+        // docs:start:compute_arbitrary_authwit_hash
 
         const intent = { consumer: auth.address, innerHash };
-        // docs:end:compute_outer_authwit_hash
+        // docs:end:compute_arbitrary_authwit_hash
         // docs:start:create_authwit
         const witness = await wallets[0].createAuthWit(intent);
         // docs:end:create_authwit


### PR DESCRIPTION
Extending comments related to the authwit sections of the code to make it more clear what is going on, and hopefully making it understandable without leaving the code.

Alters the function names slightly to get rid of the `outer_hash` since it is only a name we really need internally and can then use `message_hash` for the actual value.