### PR TITLE
feat: Enable merge recursive verifier in Goblin recursive verifier

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/client_ivc_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/client_ivc_recursive_verifier.cpp
@@ -2,6 +2,12 @@
 
 namespace bb::stdlib::recursion::honk {
 
+/**
+ * @brief Performs recursive verification of the Client IVC proof.
+ *
+ * @todo (https://github.com/AztecProtocol/barretenberg/issues/934):  Add logic for accumulating the pairing points
+ * produced by the verifiers (and potentially IPA accumulators for ECCVM verifier)
+ */
 void ClientIVCRecursiveVerifier::verify(const ClientIVC::Proof& proof)
 {
     // Perform recursive folding verification

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/client_ivc_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/client_ivc_recursive_verifier.test.cpp
@@ -88,6 +88,10 @@ TEST_F(ClientIVCRecursionTests, Basic)
     // Generate the recursive verification circuit
     verifier.verify(proof);
 
+    info("Recursive Verifier: num gates = ", builder->num_gates);
+
+    EXPECT_EQ(builder->failed(), false) << builder->err();
+
     EXPECT_TRUE(CircuitChecker::check(*builder));
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.cpp
@@ -28,9 +28,7 @@ void GoblinRecursiveVerifier::verify(const GoblinProof& proof)
         };
     translator_verifier.verify_translation(translation_evaluations);
 
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1024): Perform recursive merge verification once it
-    // works with Ultra arithmetization
-    // MergeVerifier merge_verified{ builder };
-    // [[maybe_unused]] auto merge_pairing_points = merge_verifier.verify_proof(proof.merge_proof);
+    MergeVerifier merge_verifier{ builder };
+    merge_verifier.verify_proof(proof.merge_proof);
 }
 } // namespace bb::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/goblin_recursive_verifier.cpp
@@ -2,6 +2,12 @@
 
 namespace bb::stdlib::recursion::honk {
 
+/**
+ * @brief Runs the Goblin recursive verifier consisting of ECCVM, Translator and Merge verifiers.
+ *
+ * @todo https://github.com/AztecProtocol/barretenberg/issues/934: Add logic for accumulating the pairing points
+ * produced by the translator and merge verifier (and potentially IPA accumulators for ECCVM verifier)
+ */
 void GoblinRecursiveVerifier::verify(const GoblinProof& proof)
 {
     // Run the ECCVM recursive verifier


### PR DESCRIPTION
Used to be disable because of an issue in biggroup but got subsequently fixed, resolves https://github.com/AztecProtocol/barretenberg/issues/1024.
```
Number of gates in ClientIVCRecursiveVerifier
Before: 12495384
After: 12638476
```