### PR TITLE
refactor: simplify lookup validity for account builders

### DIFF
--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -82,38 +82,4 @@ contract SchnorrAccount {
         // docs:end:entrypoint
         true
     }
-
-    /**
-    * @notice Helper function to check validity of private authwitnesses
-    * @param consumer The address of the consumer of the message
-    * @param message_hash The message hash of the message to check the validity
-    * @return True if the message_hash can be consumed, false otherwise
-    */
-    unconstrained fn lookup_validity(consumer: AztecAddress, inner_hash: Field) -> pub bool {
-        let public_key = storage.signing_public_key.view_note();
-
-        let message_hash = compute_outer_authwit_hash(consumer, context.chain_id(), context.version(), inner_hash);
-
-        let witness: [Field; 64] = get_auth_witness(message_hash);
-        let mut signature: [u8; 64] = [0; 64];
-        for i in 0..64 {
-            signature[i] = witness[i] as u8;
-        }
-        let valid_in_private = std::schnorr::verify_signature_slice(
-            public_key.x,
-            public_key.y,
-            signature,
-            message_hash.to_be_bytes(32)
-        );
-
-        // Compute the nullifier and check if it is spent
-        // This will BLINDLY TRUST the oracle, but the oracle is us, and
-        // it is not as part of execution of the contract, so we are good.
-        let nullifier = compute_authwit_nullifier(context.this_address(), inner_hash);
-        let siloed_nullifier = compute_siloed_nullifier(consumer, nullifier);
-        let lower_wit = get_low_nullifier_membership_witness(context.block_number(), siloed_nullifier);
-        let is_spent = lower_wit.leaf_preimage.nullifier == siloed_nullifier;
-
-        !is_spent & valid_in_private
-    }
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator.nr
@@ -129,7 +129,6 @@ impl PrivateCallDataValidator {
         let public_inputs = self.data.call_stack_item.public_inputs;
         let call_context = public_inputs.call_context;
         assert(call_context.is_delegate_call == false, "Users cannot make a delegatecall");
-        assert(call_context.is_static_call == false, "Users cannot make a static call");
 
         let min_revertible_side_effect_counter = public_inputs.min_revertible_side_effect_counter;
         // No need to check that the min_revertible_side_effect_counter falls in the counter range of the private call.

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_call_data_validator_builder/validate_as_first_call.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_call_data_validator_builder/validate_as_first_call.nr
@@ -26,12 +26,6 @@ fn validate_as_first_call_regular_call_succeeds() {
     builder.validate_as_first_call();
 }
 
-#[test(should_fail_with="Users cannot make a static call")]
-fn validate_as_first_call_static_call_fails() {
-    let builder = PrivateCallDataValidatorBuilder::new().is_static_call();
-    builder.validate_as_first_call();
-}
-
 #[test(should_fail_with="Users cannot make a delegatecall")]
 fn validate_as_first_call_delegate_call_fails() {
     let builder = PrivateCallDataValidatorBuilder::new().is_delegate_call();

--- a/yarn-project/aztec.js/src/utils/authwit.ts
+++ b/yarn-project/aztec.js/src/utils/authwit.ts
@@ -101,3 +101,14 @@ export const computeInnerAuthWitHash = (args: Fr[]) => {
 const computeOuterAuthWitHash = (consumer: AztecAddress, chainId: Fr, version: Fr, innerHash: Fr) => {
   return pedersenHash([consumer.toField(), chainId, version, innerHash], GeneratorIndex.AUTHWIT_OUTER);
 };
+
+/**
+ * Compute the nullifier for an authentication witness.
+ *
+ * @param onBehalfOf - The address that the inner hash is on behalf of
+ * @param innerHash - The inner hash
+ * @returns
+ */
+export const computeAuthwitNullifier = (onBehalfOf: AztecAddress, innerHash: Fr) => {
+  return pedersenHash([onBehalfOf.toField(), innerHash], GeneratorIndex.AUTHWIT_NULLIFIER);
+};

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -5,7 +5,9 @@ import {
   type GetUnencryptedLogsResponse,
   type IncomingNotesFilter,
   type L2Block,
+  type L2BlockNumber,
   type LogFilter,
+  type NullifierMembershipWitness,
   type OutgoingNotesFilter,
   type PXE,
   type PXEInfo,
@@ -188,5 +190,12 @@ export abstract class BaseWallet implements Wallet {
     ivpk: Point = this.getCompleteAddress().publicKeys.masterIncomingViewingPublicKey,
   ): Promise<T[]> {
     return this.pxe.getEvents(from, limit, eventMetadata, ivpk);
+  }
+
+  public getLowNullifierMembershipWitness(
+    blockNumber: L2BlockNumber,
+    nullifier: Fr,
+  ): Promise<NullifierMembershipWitness | undefined> {
+    return this.pxe.getLowNullifierMembershipWitness(blockNumber, nullifier);
   }
 }

--- a/yarn-project/circuit-types/src/interfaces/pxe.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.ts
@@ -23,6 +23,8 @@ import { type NoteProcessorStats } from '../stats/stats.js';
 import { type SimulatedTx, type Tx, type TxHash, type TxReceipt } from '../tx/index.js';
 import { type TxEffect } from '../tx_effect.js';
 import { type TxExecutionRequest } from '../tx_execution_request.js';
+import { type L2BlockNumber } from './l2_block_number.js';
+import { type NullifierMembershipWitness } from './nullifier_tree.js';
 import { type SyncStatus } from './sync-status.js';
 
 // docs:start:pxe-interface
@@ -389,6 +391,20 @@ export interface PXE {
    * @returns - The deserialized events.
    */
   getEvents<T>(from: number, limit: number, eventMetadata: EventMetadata<T>, ivpk: Point): Promise<T[]>;
+
+  /**
+   * Returns a low nullifier membership witness for a given nullifier at a given block.
+   * @param blockNumber - The block number at which to get the data.
+   * @param nullifier - Nullifier we try to find the low nullifier witness for.
+   * @returns The low nullifier membership witness (if found).
+   * @remarks Low nullifier witness can be used to perform a nullifier non-inclusion proof by leveraging the "linked
+   * list structure" of leaves and proving that a lower nullifier is pointing to a bigger next value than the nullifier
+   * we are trying to prove non-inclusion for.
+   */
+  getLowNullifierMembershipWitness(
+    blockNumber: L2BlockNumber,
+    nullifier: Fr,
+  ): Promise<NullifierMembershipWitness | undefined>;
 }
 // docs:end:pxe-interface
 

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -10,8 +10,10 @@ import {
   type IncomingNotesFilter,
   L1EventPayload,
   type L2Block,
+  type L2BlockNumber,
   type LogFilter,
   MerkleTreeId,
+  type NullifierMembershipWitness,
   type OutgoingNotesFilter,
   type PXE,
   type PXEInfo,
@@ -879,5 +881,12 @@ export class PXEService implements PXE {
       .filter(visibleEvent => visibleEvent !== undefined) as T[];
 
     return decodedEvents;
+  }
+
+  public async getLowNullifierMembershipWitness(
+    blockNumber: L2BlockNumber,
+    nullifier: Fr,
+  ): Promise<NullifierMembershipWitness | undefined> {
+    return await this.node.getLowNullifierMembershipWitness(blockNumber, nullifier);
   }
 }


### PR DESCRIPTION
This PR is currently slightly experimental. It is removing the constraint that a the initial call must be static (thereby allowing costly no-ops with user mistakes), but using it to simplify how `lookupValidity` for an authwit it done. 

Instead of needing a full `lookup_validity` function at the account, the `verify_private_authwit` function is used directly, meaning that the old `lookup_validity` can be completely purged from the account contracts. 

This means that the number of necessary unconstrained functions on the account contract is 0, and there are no more duplication to check the validity.