### PR TITLE
refactor: global telemetry client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       PEER_ID_PRIVATE_KEY:
       AZTEC_PORT: 8999
       TEL_COLLECTOR_BASE_URL: ${TEL_COLLECTOR_BASE_URL:-http://otel-collector:4318}
+      TEL_SERVICE_NAME: aztec-node
     secrets:
       - ethereum-host
       - p2p-boot-node

--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -10,7 +10,6 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { sleep } from '@aztec/foundation/sleep';
 import { AvailabilityOracleAbi, type InboxAbi, RollupAbi } from '@aztec/l1-artifacts';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 import {
@@ -50,7 +49,6 @@ describe('Archiver', () => {
       registryAddress,
       archiverStore,
       1000,
-      new NoopTelemetryClient(),
     );
 
     let latestBlockNum = await archiver.getBlockNumber();
@@ -154,7 +152,6 @@ describe('Archiver', () => {
       registryAddress,
       archiverStore,
       1000,
-      new NoopTelemetryClient(),
     );
 
     let latestBlockNum = await archiver.getBlockNumber();

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -29,7 +29,7 @@ import { Fr } from '@aztec/foundation/fields';
 import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { ClassRegistererAddress } from '@aztec/protocol-contracts/class-registerer';
-import { type TelemetryClient } from '@aztec/telemetry-client';
+import { getTelemetryClient } from '@aztec/telemetry-client/global';
 import {
   type ContractClassPublic,
   type ContractDataSource,
@@ -89,10 +89,9 @@ export class Archiver implements ArchiveSource {
     private readonly registryAddress: EthAddress,
     private readonly store: ArchiverDataStore,
     private readonly pollingIntervalMs = 10_000,
-    telemetry: TelemetryClient,
     private readonly log: DebugLogger = createDebugLogger('aztec:archiver'),
   ) {
-    this.instrumentation = new ArchiverInstrumentation(telemetry);
+    this.instrumentation = new ArchiverInstrumentation(getTelemetryClient());
   }
 
   /**
@@ -105,7 +104,6 @@ export class Archiver implements ArchiveSource {
   public static async createAndSync(
     config: ArchiverConfig,
     archiverStore: ArchiverDataStore,
-    telemetry: TelemetryClient,
     blockUntilSynced = true,
   ): Promise<Archiver> {
     const chain = createEthereumChain(config.rpcUrl, config.apiKey);
@@ -123,7 +121,6 @@ export class Archiver implements ArchiveSource {
       config.l1Contracts.registryAddress,
       archiverStore,
       config.archiverPollingIntervalMS,
-      telemetry,
     );
     await archiver.start(blockUntilSynced);
     return archiver;

--- a/yarn-project/archiver/src/archiver/instrumentation.ts
+++ b/yarn-project/archiver/src/archiver/instrumentation.ts
@@ -1,11 +1,12 @@
 import { type L2Block } from '@aztec/circuit-types';
 import { type Gauge, type Histogram, Metrics, type TelemetryClient, ValueType } from '@aztec/telemetry-client';
+import { getTelemetryClient } from '@aztec/telemetry-client/global';
 
 export class ArchiverInstrumentation {
   private blockHeight: Gauge;
   private blockSize: Histogram;
 
-  constructor(telemetry: TelemetryClient) {
+  constructor(telemetry: TelemetryClient = getTelemetryClient()) {
     const meter = telemetry.getMeter('Archiver');
     this.blockHeight = meter.createGauge(Metrics.ARCHIVER_BLOCK_HEIGHT, {
       description: 'The height of the latest block processed by the archiver',

--- a/yarn-project/archiver/src/index.ts
+++ b/yarn-project/archiver/src/index.ts
@@ -1,6 +1,5 @@
 import { createDebugLogger } from '@aztec/foundation/log';
 import { fileURLToPath } from '@aztec/foundation/url';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { createPublicClient, http } from 'viem';
 import { localhost } from 'viem/chains';
@@ -36,7 +35,6 @@ async function main() {
     l1Contracts.registryAddress,
     archiverStore,
     1000,
-    new NoopTelemetryClient(),
   );
 
   const shutdown = async () => {

--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -1,5 +1,4 @@
 import { createEthereumChain } from '@aztec/ethereum';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { type AztecNodeConfig, AztecNodeService } from '../index.js';
 
@@ -11,9 +10,7 @@ describe('aztec node service', () => {
       chainId: 12345, // not the testnet chain id
     };
     const ethereumChain = createEthereumChain(config.rpcUrl!, config.apiKey);
-    await expect(() =>
-      AztecNodeService.createAndSync(config as AztecNodeConfig, new NoopTelemetryClient()),
-    ).rejects.toThrow(
+    await expect(() => AztecNodeService.createAndSync(config as AztecNodeConfig)).rejects.toThrow(
       `RPC URL configured for chain id ${ethereumChain.chainInfo.id} but expected id ${config.chainId}`,
     );
   });

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -63,8 +63,6 @@ import { getCanonicalMultiCallEntrypointAddress } from '@aztec/protocol-contract
 import { TxProver } from '@aztec/prover-client';
 import { type GlobalVariableBuilder, SequencerClient, getGlobalVariableBuilder } from '@aztec/sequencer-client';
 import { PublicProcessorFactory, WASMSimulator } from '@aztec/simulator';
-import { type TelemetryClient } from '@aztec/telemetry-client';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 import {
   type ContractClassPublic,
   type ContractDataSource,
@@ -106,7 +104,6 @@ export class AztecNodeService implements AztecNode {
     protected readonly merkleTreesDb: AztecKVStore,
     private readonly prover: ProverClient | undefined,
     private txValidator: TxValidator,
-    private telemetry: TelemetryClient,
     private log = createDebugLogger('aztec:node'),
   ) {
     this.packageVersion = getPackageInfo().version;
@@ -127,11 +124,9 @@ export class AztecNodeService implements AztecNode {
    */
   public static async createAndSync(
     config: AztecNodeConfig,
-    telemetry?: TelemetryClient,
     log = createDebugLogger('aztec:node'),
     storeLog = createDebugLogger('aztec:node:lmdb'),
   ): Promise<AztecNodeService> {
-    telemetry ??= new NoopTelemetryClient();
     const ethereumChain = createEthereumChain(config.rpcUrl, config.apiKey);
     //validate that the actual chain id matches that specified in configuration
     if (config.chainId !== ethereumChain.chainInfo.id) {
@@ -150,7 +145,7 @@ export class AztecNodeService implements AztecNode {
     if (!config.archiverUrl) {
       // first create and sync the archiver
       const archiverStore = new KVArchiverDataStore(store, config.maxLogs);
-      archiver = await Archiver.createAndSync(config, archiverStore, telemetry, true);
+      archiver = await Archiver.createAndSync(config, archiverStore, true);
     } else {
       archiver = createArchiverClient(config.archiverUrl);
     }
@@ -160,7 +155,7 @@ export class AztecNodeService implements AztecNode {
     config.transactionProtocol = `/aztec/tx/${config.l1Contracts.rollupAddress.toString()}`;
 
     // create the tx pool and the p2p client, which will need the l2 block source
-    const p2pClient = await createP2PClient(store, config, new AztecKVTxPool(store, telemetry), archiver);
+    const p2pClient = await createP2PClient(store, config, new AztecKVTxPool(store), archiver);
 
     // now create the merkle trees and the world state synchronizer
     const merkleTrees = await MerkleTrees.new(store);
@@ -184,7 +179,6 @@ export class AztecNodeService implements AztecNode {
           config,
           await proofVerifier.getVerificationKeys(),
           worldStateSynchronizer,
-          telemetry,
           await archiver
             .getBlock(-1)
             .then(b => b?.header ?? worldStateSynchronizer.getCommitted().buildInitialHeader()),
@@ -206,7 +200,6 @@ export class AztecNodeService implements AztecNode {
           archiver,
           prover!,
           simulationProvider,
-          telemetry,
         );
 
     return new AztecNodeService(
@@ -225,7 +218,6 @@ export class AztecNodeService implements AztecNode {
       store,
       prover,
       txValidator,
-      telemetry,
       log,
     );
   }
@@ -764,7 +756,6 @@ export class AztecNodeService implements AztecNode {
       merkleTrees.asLatest(),
       this.contractDataSource,
       new WASMSimulator(),
-      this.telemetry,
     );
     const processor = await publicProcessorFactory.create(prevHeader, newGlobalVariables);
     // REFACTOR: Consider merging ProcessReturnValues into ProcessedTx

--- a/yarn-project/aztec-node/src/bin/index.ts
+++ b/yarn-project/aztec-node/src/bin/index.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env -S node --no-warnings
 import { createDebugLogger } from '@aztec/foundation/log';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import http from 'http';
 
@@ -16,7 +15,7 @@ const logger = createDebugLogger('aztec:node');
 async function createAndDeployAztecNode() {
   const aztecNodeConfig: AztecNodeConfig = { ...getConfigEnvVars() };
 
-  return await AztecNodeService.createAndSync(aztecNodeConfig, new NoopTelemetryClient());
+  return await AztecNodeService.createAndSync(aztecNodeConfig);
 }
 
 /**

--- a/yarn-project/aztec/src/cli/cmds/start_archiver.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_archiver.ts
@@ -9,14 +9,13 @@ import { createDebugLogger } from '@aztec/aztec.js';
 import { type ServerList } from '@aztec/foundation/json-rpc/server';
 import { AztecLmdbStore } from '@aztec/kv-store/lmdb';
 import { initStoreForRollup } from '@aztec/kv-store/utils';
-import {
-  createAndStartTelemetryClient,
-  getConfigEnvVars as getTelemetryClientConfig,
-} from '@aztec/telemetry-client/start';
 
+import { initTelemetryClient } from '../telemetry.js';
 import { mergeEnvVarsAndCliOptions, parseModuleOptions } from '../util.js';
 
 export const startArchiver = async (options: any, signalHandlers: (() => Promise<void>)[]) => {
+  initTelemetryClient();
+
   const services: ServerList = [];
   // Start a standalone archiver.
   // get env vars first
@@ -34,8 +33,7 @@ export const startArchiver = async (options: any, signalHandlers: (() => Promise
   );
   const archiverStore = new KVArchiverDataStore(store, archiverConfig.maxLogs);
 
-  const telemetry = createAndStartTelemetryClient(getTelemetryClientConfig());
-  const archiver = await Archiver.createAndSync(archiverConfig, archiverStore, telemetry, true);
+  const archiver = await Archiver.createAndSync(archiverConfig, archiverStore, true);
   const archiverServer = createArchiverRpcServer(archiver);
   services.push({ archiver: archiverServer });
   signalHandlers.push(archiver.stop);

--- a/yarn-project/aztec/src/cli/cmds/start_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_node.ts
@@ -8,14 +8,11 @@ import { type ServerList } from '@aztec/foundation/json-rpc/server';
 import { type LogFn } from '@aztec/foundation/log';
 import { createProvingJobSourceServer } from '@aztec/prover-client/prover-agent';
 import { type PXEServiceConfig, createPXERpcServer, getPXEServiceConfig } from '@aztec/pxe';
-import {
-  createAndStartTelemetryClient,
-  getConfigEnvVars as getTelemetryClientConfig,
-} from '@aztec/telemetry-client/start';
 
 import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
 
 import { MNEMONIC, createAztecNode, createAztecPXE, deployContractsToL1 } from '../../sandbox.js';
+import { initTelemetryClient } from '../telemetry.js';
 import { mergeEnvVarsAndCliOptions, parseModuleOptions } from '../util.js';
 
 const { DEPLOY_AZTEC_CONTRACTS } = process.env;
@@ -25,6 +22,8 @@ export const startNode = async (
   signalHandlers: (() => Promise<void>)[],
   userLog: LogFn,
 ): Promise<ServerList> => {
+  initTelemetryClient();
+
   // Services that will be started in a single multi-rpc server
   const services: ServerList = [];
   // get env vars first
@@ -85,8 +84,7 @@ export const startNode = async (
   }
 
   // Create and start Aztec Node.
-  const telemetryClient = createAndStartTelemetryClient(getTelemetryClientConfig());
-  const node = await createAztecNode(telemetryClient, nodeConfig);
+  const node = await createAztecNode(nodeConfig);
   const nodeServer = createAztecNodeRpcServer(node);
 
   // Add node to services list

--- a/yarn-project/aztec/src/cli/telemetry.ts
+++ b/yarn-project/aztec/src/cli/telemetry.ts
@@ -1,0 +1,12 @@
+import { OpenTelemetryClient, getConfigEnvVars } from '@aztec/telemetry-client';
+import { setTelemetryClient } from '@aztec/telemetry-client/global';
+
+export function initTelemetryClient() {
+  const config = getConfigEnvVars();
+
+  if (config.collectorBaseUrl) {
+    setTelemetryClient(
+      OpenTelemetryClient.createAndStart(config.serviceName, config.serviceVersion, config.collectorBaseUrl),
+    );
+  }
+}

--- a/yarn-project/aztec/src/sandbox.ts
+++ b/yarn-project/aztec/src/sandbox.ts
@@ -36,8 +36,6 @@ import { getCanonicalAuthRegistry } from '@aztec/protocol-contracts/auth-registr
 import { GasTokenAddress, getCanonicalGasToken } from '@aztec/protocol-contracts/gas-token';
 import { getCanonicalKeyRegistry } from '@aztec/protocol-contracts/key-registry';
 import { type PXEServiceConfig, createPXEService, getPXEServiceConfig } from '@aztec/pxe';
-import { type TelemetryClient } from '@aztec/telemetry-client';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { type HDAccount, type PrivateKeyAccount, createPublicClient, http as httpViemTransport } from 'viem';
 import { mnemonicToAccount } from 'viem/accounts';
@@ -254,7 +252,7 @@ export async function createSandbox(config: Partial<SandboxConfig> = {}) {
     await deployContractsToL1(aztecNodeConfig, hdAccount);
   }
 
-  const node = await createAztecNode(new NoopTelemetryClient(), aztecNodeConfig);
+  const node = await createAztecNode(aztecNodeConfig);
   const pxe = await createAztecPXE(node);
 
   await deployCanonicalKeyRegistry(
@@ -283,9 +281,9 @@ export async function createSandbox(config: Partial<SandboxConfig> = {}) {
  * Create and start a new Aztec RPC HTTP Server
  * @param config - Optional Aztec node settings.
  */
-export async function createAztecNode(telemetryClient: TelemetryClient, config: Partial<AztecNodeConfig> = {}) {
+export async function createAztecNode(config: Partial<AztecNodeConfig> = {}) {
   const aztecNodeConfig: AztecNodeConfig = { ...getConfigEnvVars(), ...config };
-  const node = await AztecNodeService.createAndSync(aztecNodeConfig, telemetryClient);
+  const node = await AztecNodeService.createAndSync(aztecNodeConfig);
   return node;
 }
 

--- a/yarn-project/bb-prover/src/instrumentation.ts
+++ b/yarn-project/bb-prover/src/instrumentation.ts
@@ -1,14 +1,7 @@
 import { type CircuitName } from '@aztec/circuit-types/stats';
 import { type Timer } from '@aztec/foundation/timer';
-import {
-  Attributes,
-  type Gauge,
-  type Histogram,
-  Metrics,
-  type TelemetryClient,
-  type Tracer,
-  ValueType,
-} from '@aztec/telemetry-client';
+import { Attributes, type Gauge, type Histogram, Metrics, type Tracer, ValueType } from '@aztec/telemetry-client';
+import { getTelemetryClient } from '@aztec/telemetry-client/global';
 
 /**
  * Instrumentation class for Prover implementations.
@@ -27,7 +20,7 @@ export class ProverInstrumentation {
 
   public readonly tracer: Tracer;
 
-  constructor(telemetry: TelemetryClient, name: string) {
+  constructor(name: string, telemetry = getTelemetryClient()) {
     this.tracer = telemetry.getTracer(name);
     const meter = telemetry.getMeter(name);
 

--- a/yarn-project/bb-prover/src/prover/bb_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_prover.ts
@@ -57,7 +57,7 @@ import {
   convertRootRollupOutputsFromWitnessMap,
 } from '@aztec/noir-protocol-circuits-types';
 import { NativeACVMSimulator } from '@aztec/simulator';
-import { Attributes, type TelemetryClient, trackSpan } from '@aztec/telemetry-client';
+import { Attributes, trackSpan } from '@aztec/telemetry-client';
 
 import { abiEncode } from '@noir-lang/noirc_abi';
 import { type Abi, type WitnessMap } from '@noir-lang/types';
@@ -107,15 +107,15 @@ export class BBNativeRollupProver implements ServerCircuitProver {
 
   private instrumentation: ProverInstrumentation;
 
-  constructor(private config: BBProverConfig, telemetry: TelemetryClient) {
-    this.instrumentation = new ProverInstrumentation(telemetry, 'BBNativeRollupProver');
+  constructor(private config: BBProverConfig) {
+    this.instrumentation = new ProverInstrumentation('BBNativeRollupProver');
   }
 
   get tracer() {
     return this.instrumentation.tracer;
   }
 
-  static async new(config: BBProverConfig, telemetry: TelemetryClient) {
+  static async new(config: BBProverConfig) {
     await fs.access(config.acvmBinaryPath, fs.constants.R_OK);
     await fs.mkdir(config.acvmWorkingDirectory, { recursive: true });
     await fs.access(config.bbBinaryPath, fs.constants.R_OK);
@@ -123,7 +123,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
     logger.info(`Using native BB at ${config.bbBinaryPath} and working directory ${config.bbWorkingDirectory}`);
     logger.info(`Using native ACVM at ${config.acvmBinaryPath} and working directory ${config.acvmWorkingDirectory}`);
 
-    return new BBNativeRollupProver(config, telemetry);
+    return new BBNativeRollupProver(config);
   }
 
   /**

--- a/yarn-project/bb-prover/src/test/test_circuit_prover.ts
+++ b/yarn-project/bb-prover/src/test/test_circuit_prover.ts
@@ -57,7 +57,7 @@ import {
   convertSimulatedPublicTailOutputFromWitnessMap,
 } from '@aztec/noir-protocol-circuits-types';
 import { type SimulationProvider, WASMSimulator, emitCircuitSimulationStats } from '@aztec/simulator';
-import { type TelemetryClient, trackSpan } from '@aztec/telemetry-client';
+import { trackSpan } from '@aztec/telemetry-client';
 
 import { ProverInstrumentation } from '../instrumentation.js';
 import { SimulatedPublicKernelArtifactMapping } from '../mappings/mappings.js';
@@ -86,11 +86,10 @@ export class TestCircuitProver implements ServerCircuitProver {
   private instrumentation: ProverInstrumentation;
 
   constructor(
-    telemetry: TelemetryClient,
     private simulationProvider?: SimulationProvider,
     private logger = createDebugLogger('aztec:test-prover'),
   ) {
-    this.instrumentation = new ProverInstrumentation(telemetry, 'TestCircuitProver');
+    this.instrumentation = new ProverInstrumentation('TestCircuitProver');
   }
 
   get tracer() {

--- a/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
@@ -40,7 +40,6 @@ import { AvailabilityOracleAbi, InboxAbi, OutboxAbi, RollupAbi } from '@aztec/l1
 import { SHA256Trunc, StandardTree } from '@aztec/merkle-tree';
 import { TxProver } from '@aztec/prover-client';
 import { type L1Publisher, getL1Publisher } from '@aztec/sequencer-client';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 import { MerkleTrees, ServerWorldStateSynchronizer, type WorldStateConfig } from '@aztec/world-state';
 
 import { beforeEach, describe, expect, it } from '@jest/globals';
@@ -146,7 +145,7 @@ describe('L1Publisher integration', () => {
     };
     const worldStateSynchronizer = new ServerWorldStateSynchronizer(tmpStore, builderDb, blockSource, worldStateConfig);
     await worldStateSynchronizer.start();
-    builder = await TxProver.new(config, getMockVerificationKeys(), worldStateSynchronizer, new NoopTelemetryClient());
+    builder = await TxProver.new(config, getMockVerificationKeys(), worldStateSynchronizer);
     l2Proof = makeEmptyProof();
 
     publisher = getL1Publisher({

--- a/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
@@ -13,7 +13,6 @@ import {
 } from '@aztec/aztec.js';
 import { type BootNodeConfig, BootstrapNode, createLibP2PPeerId } from '@aztec/p2p';
 import { type PXEService, createPXEService, getPXEServiceConfig as getRpcConfig } from '@aztec/pxe';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import fs from 'fs';
 import { mnemonicToAccount } from 'viem/accounts';
@@ -206,7 +205,7 @@ describe('e2e_p2p_network', () => {
     };
     return await AztecNodeService.createAndSync(
       newConfig,
-      new NoopTelemetryClient(),
+
       createDebugLogger(`aztec:node-${tcpListenPort}`),
     );
   };

--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -20,7 +20,6 @@ import { type Logger, createDebugLogger } from '@aztec/foundation/log';
 import { makeBackoff, retry } from '@aztec/foundation/retry';
 import { resolver, reviver } from '@aztec/foundation/serialize';
 import { type PXEService, createPXEService, getPXEServiceConfig } from '@aztec/pxe';
-import { createAndStartTelemetryClient, getConfigEnvVars as getTelemetryConfig } from '@aztec/telemetry-client/start';
 
 import { type Anvil, createAnvil } from '@viem/anvil';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
@@ -271,9 +270,8 @@ async function setupFromFresh(statePath: string | undefined, logger: Logger): Pr
     aztecNodeConfig.bbWorkingDirectory = bbConfig.bbWorkingDirectory;
   }
 
-  const telemetry = createAndStartTelemetryClient(getTelemetryConfig());
   logger.verbose('Creating and synching an aztec node...');
-  const aztecNode = await AztecNodeService.createAndSync(aztecNodeConfig, telemetry);
+  const aztecNode = await AztecNodeService.createAndSync(aztecNodeConfig);
 
   logger.verbose('Creating pxe...');
   const pxeConfig = getPXEServiceConfig();
@@ -345,8 +343,7 @@ async function setupFromState(statePath: string, logger: Logger): Promise<Subsys
   const { publicClient, walletClient } = createL1Clients(aztecNodeConfig.rpcUrl, mnemonicToAccount(MNEMONIC));
 
   logger.verbose('Creating aztec node...');
-  const telemetry = createAndStartTelemetryClient(getTelemetryConfig());
-  const aztecNode = await AztecNodeService.createAndSync(aztecNodeConfig, telemetry);
+  const aztecNode = await AztecNodeService.createAndSync(aztecNodeConfig);
 
   logger.verbose('Creating pxe...');
   const pxeConfig = getPXEServiceConfig();

--- a/yarn-project/end-to-end/src/fixtures/telemetry.ts
+++ b/yarn-project/end-to-end/src/fixtures/telemetry.ts
@@ -1,0 +1,24 @@
+import { InMemoryTelemetryClient, OpenTelemetryClient, getConfigEnvVars } from '@aztec/telemetry-client';
+import { setTelemetryClient } from '@aztec/telemetry-client/global';
+
+// guard against calling init multiple times (e.g. calling setup in beforeEach)
+let telemetryClient: InMemoryTelemetryClient | OpenTelemetryClient | undefined;
+export function initTelemetry() {
+  if (telemetryClient) {
+    return;
+  }
+
+  const config = getConfigEnvVars();
+  if (config.collectorBaseUrl) {
+    telemetryClient = OpenTelemetryClient.createAndStart(
+      config.serviceName,
+      config.serviceVersion,
+      config.collectorBaseUrl,
+    );
+  } else {
+    // TODO (alexg): consider using test name instead of service name (or add the test name as an attribute on the resource)
+    telemetryClient = InMemoryTelemetryClient.createAndStart(config.serviceName, config.serviceVersion);
+  }
+
+  setTelemetryClient(telemetryClient);
+}

--- a/yarn-project/p2p/src/tx_pool/aztec_kv_tx_pool.test.ts
+++ b/yarn-project/p2p/src/tx_pool/aztec_kv_tx_pool.test.ts
@@ -1,5 +1,4 @@
 import { openTmpStore } from '@aztec/kv-store/utils';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { AztecKVTxPool } from './aztec_kv_tx_pool.js';
 import { describeTxPool } from './tx_pool_test_suite.js';
@@ -7,7 +6,7 @@ import { describeTxPool } from './tx_pool_test_suite.js';
 describe('In-Memory TX pool', () => {
   let txPool: AztecKVTxPool;
   beforeEach(() => {
-    txPool = new AztecKVTxPool(openTmpStore(), new NoopTelemetryClient());
+    txPool = new AztecKVTxPool(openTmpStore());
   });
 
   describeTxPool(() => txPool);

--- a/yarn-project/p2p/src/tx_pool/aztec_kv_tx_pool.ts
+++ b/yarn-project/p2p/src/tx_pool/aztec_kv_tx_pool.ts
@@ -2,7 +2,6 @@ import { Tx, TxHash } from '@aztec/circuit-types';
 import { type TxAddedToPoolStats } from '@aztec/circuit-types/stats';
 import { type Logger, createDebugLogger } from '@aztec/foundation/log';
 import { type AztecKVStore, type AztecMap } from '@aztec/kv-store';
-import { type TelemetryClient } from '@aztec/telemetry-client';
 
 import { TxPoolInstrumentation } from './instrumentation.js';
 import { type TxPool } from './tx_pool.js';
@@ -27,11 +26,11 @@ export class AztecKVTxPool implements TxPool {
    * @param store - A KV store.
    * @param log - A logger.
    */
-  constructor(store: AztecKVStore, telemetry: TelemetryClient, log = createDebugLogger('aztec:tx_pool')) {
+  constructor(store: AztecKVStore, log = createDebugLogger('aztec:tx_pool')) {
     this.#txs = store.openMap('txs');
     this.#store = store;
     this.#log = log;
-    this.#metrics = new TxPoolInstrumentation(telemetry, 'AztecKVTxPool');
+    this.#metrics = new TxPoolInstrumentation('AztecKVTxPool');
   }
 
   /**

--- a/yarn-project/p2p/src/tx_pool/instrumentation.ts
+++ b/yarn-project/p2p/src/tx_pool/instrumentation.ts
@@ -1,5 +1,6 @@
 import { type Tx } from '@aztec/circuit-types';
-import { type Histogram, Metrics, type TelemetryClient, type UpDownCounter } from '@aztec/telemetry-client';
+import { type Histogram, Metrics, type UpDownCounter } from '@aztec/telemetry-client';
+import { getTelemetryClient } from '@aztec/telemetry-client/global';
 
 /**
  * Instrumentation class for the TxPool.
@@ -10,7 +11,7 @@ export class TxPoolInstrumentation {
   /** Tracks tx size */
   private txSize: Histogram;
 
-  constructor(telemetry: TelemetryClient, name: string) {
+  constructor(name: string, telemetry = getTelemetryClient()) {
     const meter = telemetry.getMeter(name);
     this.txInMempool = meter.createUpDownCounter(Metrics.MEMPOOL_TX_COUNT, {
       description: 'The current number of transactions in the mempool',

--- a/yarn-project/p2p/src/tx_pool/memory_tx_pool.test.ts
+++ b/yarn-project/p2p/src/tx_pool/memory_tx_pool.test.ts
@@ -1,12 +1,10 @@
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
-
 import { InMemoryTxPool } from './index.js';
 import { describeTxPool } from './tx_pool_test_suite.js';
 
 describe('In-Memory TX pool', () => {
   let inMemoryTxPool: InMemoryTxPool;
   beforeEach(() => {
-    inMemoryTxPool = new InMemoryTxPool(new NoopTelemetryClient());
+    inMemoryTxPool = new InMemoryTxPool();
   });
 
   describeTxPool(() => inMemoryTxPool);

--- a/yarn-project/p2p/src/tx_pool/memory_tx_pool.ts
+++ b/yarn-project/p2p/src/tx_pool/memory_tx_pool.ts
@@ -1,7 +1,6 @@
 import { Tx, TxHash } from '@aztec/circuit-types';
 import { type TxAddedToPoolStats } from '@aztec/circuit-types/stats';
 import { createDebugLogger } from '@aztec/foundation/log';
-import { type TelemetryClient } from '@aztec/telemetry-client';
 
 import { TxPoolInstrumentation } from './instrumentation.js';
 import { type TxPool } from './tx_pool.js';
@@ -21,9 +20,9 @@ export class InMemoryTxPool implements TxPool {
    * Class constructor for in-memory TxPool. Initiates our transaction pool as a JS Map.
    * @param log - A logger.
    */
-  constructor(telemetry: TelemetryClient, private log = createDebugLogger('aztec:tx_pool')) {
+  constructor(private log = createDebugLogger('aztec:tx_pool')) {
     this.txs = new Map<bigint, Tx>();
-    this.metrics = new TxPoolInstrumentation(telemetry, 'InMemoryTxPool');
+    this.metrics = new TxPoolInstrumentation('InMemoryTxPool');
   }
 
   /**

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -55,7 +55,8 @@ import { createDebugLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { BufferReader, type Tuple } from '@aztec/foundation/serialize';
 import { pushTestData } from '@aztec/foundation/testing';
-import { Attributes, type TelemetryClient, type Tracer, trackSpan, wrapCallbackInSpan } from '@aztec/telemetry-client';
+import { Attributes, type Tracer, trackSpan, wrapCallbackInSpan } from '@aztec/telemetry-client';
+import { getTelemetryClient } from '@aztec/telemetry-client/global';
 import { type MerkleTreeOperations } from '@aztec/world-state';
 
 import { inspect } from 'util';
@@ -96,13 +97,8 @@ export class ProvingOrchestrator {
 
   public readonly tracer: Tracer;
 
-  constructor(
-    private db: MerkleTreeOperations,
-    private prover: ServerCircuitProver,
-    telemetryClient: TelemetryClient,
-    private initialHeader?: Header,
-  ) {
-    this.tracer = telemetryClient.getTracer('ProvingOrchestrator');
+  constructor(private db: MerkleTreeOperations, private prover: ServerCircuitProver, private initialHeader?: Header) {
+    this.tracer = getTelemetryClient().getTracer('ProvingOrchestrator');
   }
 
   /**

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_failures.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_failures.test.ts
@@ -2,7 +2,6 @@ import { PROVING_STATUS, type ServerCircuitProver } from '@aztec/circuit-types';
 import { getMockVerificationKeys } from '@aztec/circuits.js';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { WASMSimulator } from '@aztec/simulator';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { jest } from '@jest/globals';
 
@@ -29,8 +28,8 @@ describe('prover/orchestrator/failures', () => {
     let mockProver: ServerCircuitProver;
 
     beforeEach(() => {
-      mockProver = new TestCircuitProver(new NoopTelemetryClient(), new WASMSimulator());
-      orchestrator = new ProvingOrchestrator(context.actualDb, mockProver, new NoopTelemetryClient());
+      mockProver = new TestCircuitProver(new WASMSimulator());
+      orchestrator = new ProvingOrchestrator(context.actualDb, mockProver);
     });
 
     it.each([

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_lifecycle.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_lifecycle.test.ts
@@ -10,7 +10,6 @@ import { range } from '@aztec/foundation/array';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { type PromiseWithResolvers, promiseWithResolvers } from '@aztec/foundation/promise';
 import { sleep } from '@aztec/foundation/sleep';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { jest } from '@jest/globals';
 
@@ -142,8 +141,8 @@ describe('prover/orchestrator/lifecycle', () => {
     }, 60000);
 
     it('cancels proving requests', async () => {
-      const prover: ServerCircuitProver = new TestCircuitProver(new NoopTelemetryClient());
-      const orchestrator = new ProvingOrchestrator(context.actualDb, prover, new NoopTelemetryClient());
+      const prover: ServerCircuitProver = new TestCircuitProver();
+      const orchestrator = new ProvingOrchestrator(context.actualDb, prover);
 
       const spy = jest.spyOn(prover, 'getBaseParityProof');
       const deferredPromises: PromiseWithResolvers<any>[] = [];

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_workflow.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_workflow.test.ts
@@ -11,7 +11,6 @@ import { makeGlobalVariables, makeRootParityInput } from '@aztec/circuits.js/tes
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { sleep } from '@aztec/foundation/sleep';
 import { openTmpStore } from '@aztec/kv-store/utils';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 import { type MerkleTreeOperations, MerkleTrees } from '@aztec/world-state';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -26,7 +25,7 @@ describe('prover/orchestrator', () => {
     beforeEach(async () => {
       actualDb = await MerkleTrees.new(openTmpStore()).then(t => t.asLatest());
       mockProver = mock<ServerCircuitProver>();
-      orchestrator = new ProvingOrchestrator(actualDb, mockProver, new NoopTelemetryClient());
+      orchestrator = new ProvingOrchestrator(actualDb, mockProver);
     });
 
     it('calls root parity circuit only when ready', async () => {

--- a/yarn-project/prover-client/src/test/bb_prover_base_rollup.test.ts
+++ b/yarn-project/prover-client/src/test/bb_prover_base_rollup.test.ts
@@ -1,7 +1,6 @@
 import { BBNativeRollupProver, type BBProverConfig } from '@aztec/bb-prover';
 import { makePaddingProcessedTx } from '@aztec/circuit-types';
 import { createDebugLogger } from '@aztec/foundation/log';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { TestContext } from '../mocks/test_context.js';
 import { buildBaseRollupInput } from '../orchestrator/block-building-helpers.js';
@@ -14,7 +13,7 @@ describe('prover/bb_prover/base-rollup', () => {
 
   beforeAll(async () => {
     const buildProver = async (bbConfig: BBProverConfig) => {
-      prover = await BBNativeRollupProver.new(bbConfig, new NoopTelemetryClient());
+      prover = await BBNativeRollupProver.new(bbConfig);
       return prover;
     };
     context = await TestContext.new(logger, 1, buildProver);

--- a/yarn-project/prover-client/src/test/bb_prover_full_rollup.test.ts
+++ b/yarn-project/prover-client/src/test/bb_prover_full_rollup.test.ts
@@ -4,7 +4,6 @@ import { Fr, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, getMockVerificationKeys } from
 import { makeTuple } from '@aztec/foundation/array';
 import { times } from '@aztec/foundation/collection';
 import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { TestContext } from '../mocks/test_context.js';
 
@@ -15,7 +14,7 @@ describe('prover/bb_prover/full-rollup', () => {
 
   beforeAll(async () => {
     const buildProver = async (bbConfig: BBProverConfig) => {
-      prover = await BBNativeRollupProver.new(bbConfig, new NoopTelemetryClient());
+      prover = await BBNativeRollupProver.new(bbConfig);
       return prover;
     };
     logger = createDebugLogger('aztec:bb-prover-full-rollup');

--- a/yarn-project/prover-client/src/test/bb_prover_parity.test.ts
+++ b/yarn-project/prover-client/src/test/bb_prover_parity.test.ts
@@ -15,7 +15,6 @@ import { makeTuple } from '@aztec/foundation/array';
 import { randomBytes } from '@aztec/foundation/crypto';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { type Tuple } from '@aztec/foundation/serialize';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { TestContext } from '../mocks/test_context.js';
 
@@ -28,7 +27,7 @@ describe('prover/bb_prover/parity', () => {
   beforeAll(async () => {
     const buildProver = async (bbConfig: BBProverConfig) => {
       bbConfig.circuitFilter = ['BaseParityArtifact', 'RootParityArtifact'];
-      bbProver = await BBNativeRollupProver.new(bbConfig, new NoopTelemetryClient());
+      bbProver = await BBNativeRollupProver.new(bbConfig);
       return bbProver;
     };
     context = await TestContext.new(logger, 1, buildProver);

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -2,7 +2,6 @@ import { type L1ToL2MessageSource, type L2BlockSource } from '@aztec/circuit-typ
 import { type BlockProver } from '@aztec/circuit-types/interfaces';
 import { type P2P } from '@aztec/p2p';
 import { PublicProcessorFactory, type SimulationProvider } from '@aztec/simulator';
-import { type TelemetryClient } from '@aztec/telemetry-client';
 import { type ContractDataSource } from '@aztec/types/contracts';
 import { type WorldStateSynchronizer } from '@aztec/world-state';
 
@@ -39,18 +38,12 @@ export class SequencerClient {
     l1ToL2MessageSource: L1ToL2MessageSource,
     prover: BlockProver,
     simulationProvider: SimulationProvider,
-    telemetryClient: TelemetryClient,
   ) {
     const publisher = getL1Publisher(config);
     const globalsBuilder = getGlobalVariableBuilder(config);
     const merkleTreeDb = worldStateSynchronizer.getLatest();
 
-    const publicProcessorFactory = new PublicProcessorFactory(
-      merkleTreeDb,
-      contractDataSource,
-      simulationProvider,
-      telemetryClient,
-    );
+    const publicProcessorFactory = new PublicProcessorFactory(merkleTreeDb, contractDataSource, simulationProvider);
 
     const sequencer = new Sequencer(
       publisher,
@@ -62,7 +55,6 @@ export class SequencerClient {
       l1ToL2MessageSource,
       publicProcessorFactory,
       new TxValidatorFactory(merkleTreeDb, contractDataSource, !!config.enforceFees),
-      telemetryClient,
       config,
     );
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -27,7 +27,6 @@ import { randomBytes } from '@aztec/foundation/crypto';
 import { type Writeable } from '@aztec/foundation/types';
 import { type P2P, P2PClientState } from '@aztec/p2p';
 import { type PublicProcessor, type PublicProcessorFactory } from '@aztec/simulator';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 import { type ContractDataSource } from '@aztec/types/contracts';
 import { type MerkleTreeOperations, WorldStateRunningState, type WorldStateSynchronizer } from '@aztec/world-state';
 
@@ -116,7 +115,6 @@ describe('sequencer', () => {
       l1ToL2MessageSource,
       publicProcessorFactory,
       new TxValidatorFactory(merkleTreeOps, contractSource, false),
-      new NoopTelemetryClient(),
     );
   });
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -20,7 +20,8 @@ import { RunningPromise } from '@aztec/foundation/running-promise';
 import { Timer, elapsed } from '@aztec/foundation/timer';
 import { type P2P } from '@aztec/p2p';
 import { type PublicProcessorFactory } from '@aztec/simulator';
-import { Attributes, type TelemetryClient, type Tracer, trackSpan } from '@aztec/telemetry-client';
+import { Attributes, type Tracer, trackSpan } from '@aztec/telemetry-client';
+import { getTelemetryClient } from '@aztec/telemetry-client/global';
 import { type WorldStateStatus, type WorldStateSynchronizer } from '@aztec/world-state';
 
 import { type GlobalVariableBuilder } from '../global_variable_builder/global_builder.js';
@@ -63,12 +64,11 @@ export class Sequencer {
     private l1ToL2MessageSource: L1ToL2MessageSource,
     private publicProcessorFactory: PublicProcessorFactory,
     private txValidatorFactory: TxValidatorFactory,
-    telemetry: TelemetryClient,
     config: SequencerConfig = {},
     private log = createDebugLogger('aztec:sequencer'),
   ) {
     this.updateConfig(config);
-    this.tracer = telemetry.getTracer('Sequencer');
+    this.tracer = getTelemetryClient().getTracer('Sequencer');
     this.log.verbose(`Initialized sequencer with ${this.minTxsPerBLock}-${this.maxTxsPerBlock} txs per block.`);
   }
 

--- a/yarn-project/simulator/src/public/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor.test.ts
@@ -45,7 +45,6 @@ import {
   WASMSimulator,
   computeFeePayerBalanceLeafSlot,
 } from '@aztec/simulator';
-import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 import { type MerkleTreeOperations, type TreeInfo } from '@aztec/world-state';
 
 import { jest } from '@jest/globals';
@@ -96,7 +95,6 @@ describe('public_processor', () => {
         Header.empty(),
         publicContractsDB,
         publicWorldStateDB,
-        new NoopTelemetryClient(),
       );
     });
 
@@ -221,7 +219,6 @@ describe('public_processor', () => {
         header,
         publicContractsDB,
         publicWorldStateDB,
-        new NoopTelemetryClient(),
       );
     });
 

--- a/yarn-project/simulator/src/public/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor.ts
@@ -30,7 +30,8 @@ import {
   computeFeePayerBalanceLeafSlot,
   computeFeePayerBalanceStorageSlot,
 } from '@aztec/simulator';
-import { Attributes, type TelemetryClient, type Tracer, trackSpan } from '@aztec/telemetry-client';
+import { Attributes, type Tracer, trackSpan } from '@aztec/telemetry-client';
+import { getTelemetryClient } from '@aztec/telemetry-client/global';
 import { type ContractDataSource } from '@aztec/types/contracts';
 import { type MerkleTreeOperations } from '@aztec/world-state';
 
@@ -48,7 +49,6 @@ export class PublicProcessorFactory {
     private merkleTree: MerkleTreeOperations,
     private contractDataSource: ContractDataSource,
     private simulator: SimulationProvider,
-    private telemetryClient: TelemetryClient,
   ) {}
 
   /**
@@ -76,7 +76,6 @@ export class PublicProcessorFactory {
       historicalHeader,
       publicContractsDB,
       worldStatePublicDB,
-      this.telemetryClient,
     );
   }
 }
@@ -95,10 +94,9 @@ export class PublicProcessor {
     protected historicalHeader: Header,
     protected publicContractsDB: ContractsDataSourcePublicDB,
     protected publicStateDB: PublicStateDB,
-    telemetryClient: TelemetryClient,
     private log = createDebugLogger('aztec:sequencer:public-processor'),
   ) {
-    this.tracer = telemetryClient.getTracer('PublicProcessor');
+    this.tracer = getTelemetryClient().getTracer('PublicProcessor');
   }
 
   /**

--- a/yarn-project/telemetry-client/package.json
+++ b/yarn-project/telemetry-client/package.json
@@ -6,8 +6,7 @@
   "type": "module",
   "exports": {
     ".": "./dest/index.js",
-    "./start": "./dest/start.js",
-    "./noop": "./dest/noop.js"
+    "./global": "./dest/global.js"
   },
   "scripts": {
     "build": "yarn clean && tsc -b",
@@ -28,6 +27,7 @@
   "dependencies": {
     "@aztec/foundation": "workspace:^",
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/context-async-hooks": "^1.25.1",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.52.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.52.0",
     "@opentelemetry/host-metrics": "^0.35.2",

--- a/yarn-project/telemetry-client/src/config.ts
+++ b/yarn-project/telemetry-client/src/config.ts
@@ -1,19 +1,7 @@
-import { NoopTelemetryClient } from './noop.js';
-import { OpenTelemetryClient } from './otel.js';
-import { type TelemetryClient } from './telemetry.js';
-
 export interface TelemetryClientConfig {
   collectorBaseUrl?: URL;
   serviceName: string;
   serviceVersion: string;
-}
-
-export function createAndStartTelemetryClient(config: TelemetryClientConfig): TelemetryClient {
-  if (config.collectorBaseUrl) {
-    return OpenTelemetryClient.createAndStart(config.serviceName, config.serviceVersion, config.collectorBaseUrl);
-  } else {
-    return new NoopTelemetryClient();
-  }
 }
 
 export function getConfigEnvVars(): TelemetryClientConfig {

--- a/yarn-project/telemetry-client/src/global.ts
+++ b/yarn-project/telemetry-client/src/global.ts
@@ -1,0 +1,17 @@
+import { NoopTelemetryClient } from './noop.js';
+import { type TelemetryClient } from './telemetry.js';
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+declare namespace globalThis {
+  let telemetryClient: TelemetryClient;
+}
+
+globalThis.telemetryClient ??= new NoopTelemetryClient();
+
+export function getTelemetryClient(): TelemetryClient {
+  return globalThis.telemetryClient;
+}
+
+export function setTelemetryClient(client: TelemetryClient): void {
+  globalThis.telemetryClient = client;
+}

--- a/yarn-project/telemetry-client/src/index.ts
+++ b/yarn-project/telemetry-client/src/index.ts
@@ -1,1 +1,5 @@
 export * from './telemetry.js';
+export * from './config.js';
+export * from './otel.js';
+export * from './noop.js';
+export * from './mem.js';

--- a/yarn-project/telemetry-client/src/mem.ts
+++ b/yarn-project/telemetry-client/src/mem.ts
@@ -1,0 +1,44 @@
+import { Resource } from '@opentelemetry/resources';
+import { AggregationTemporality, InMemoryMetricExporter, type ResourceMetrics } from '@opentelemetry/sdk-metrics';
+import { InMemorySpanExporter, type ReadableSpan } from '@opentelemetry/sdk-trace-node';
+import { SEMRESATTRS_SERVICE_NAME, SEMRESATTRS_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
+
+import { OpenTelemetryClient } from './otel.js';
+
+export class InMemoryTelemetryClient extends OpenTelemetryClient {
+  private constructor(
+    resource: Resource,
+    private metricExporter: InMemoryMetricExporter,
+    private spanExporter: InMemorySpanExporter,
+  ) {
+    super(resource, metricExporter, spanExporter, false);
+  }
+
+  getMetrics(): ResourceMetrics[] {
+    return this.metricExporter.getMetrics();
+  }
+
+  getFinishedSpans(): ReadableSpan[] {
+    return this.spanExporter.getFinishedSpans();
+  }
+
+  reset() {
+    this.metricExporter.reset();
+    this.spanExporter.reset();
+  }
+
+  public static override createAndStart(name: string, version: string): InMemoryTelemetryClient {
+    const resource = new Resource({
+      [SEMRESATTRS_SERVICE_NAME]: name,
+      [SEMRESATTRS_SERVICE_VERSION]: version,
+    });
+
+    const metricExporter = new InMemoryMetricExporter(AggregationTemporality.DELTA);
+    const spanExporter = new InMemorySpanExporter();
+
+    const client = new InMemoryTelemetryClient(resource, metricExporter, spanExporter);
+    client.start();
+
+    return client;
+  }
+}

--- a/yarn-project/telemetry-client/src/otel.ts
+++ b/yarn-project/telemetry-client/src/otel.ts
@@ -1,41 +1,63 @@
-import { type Meter, type Tracer, type TracerProvider } from '@opentelemetry/api';
+import { type Meter, type Tracer } from '@opentelemetry/api';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { HostMetrics } from '@opentelemetry/host-metrics';
 import { Resource } from '@opentelemetry/resources';
-import { MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
-import { BatchSpanProcessor, NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { MeterProvider, PeriodicExportingMetricReader, type PushMetricExporter } from '@opentelemetry/sdk-metrics';
+import { BatchSpanProcessor, NodeTracerProvider, type SpanExporter } from '@opentelemetry/sdk-trace-node';
 import { SEMRESATTRS_SERVICE_NAME, SEMRESATTRS_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 
 import { type TelemetryClient } from './telemetry.js';
 
 export class OpenTelemetryClient implements TelemetryClient {
-  hostMetrics: HostMetrics | undefined;
-  protected constructor(
-    private resource: Resource,
-    private meterProvider: MeterProvider,
-    private traceProvider: TracerProvider,
-  ) {}
+  private hostMetrics: HostMetrics | undefined;
+  private tracerProvider: NodeTracerProvider;
+  private meterProvider: MeterProvider;
+
+  constructor(
+    protected resource: Resource,
+    metricExporter: PushMetricExporter,
+    spanExporter: SpanExporter,
+    private reportHostMetrics = true,
+  ) {
+    this.tracerProvider = new NodeTracerProvider({
+      resource,
+    });
+    this.tracerProvider.addSpanProcessor(new BatchSpanProcessor(spanExporter));
+
+    this.meterProvider = new MeterProvider({
+      resource,
+      readers: [
+        new PeriodicExportingMetricReader({
+          exporter: metricExporter,
+        }),
+      ],
+    });
+  }
 
   getMeter(name: string): Meter {
     return this.meterProvider.getMeter(name, this.resource.attributes[SEMRESATTRS_SERVICE_VERSION] as string);
   }
 
   getTracer(name: string): Tracer {
-    return this.traceProvider.getTracer(name, this.resource.attributes[SEMRESATTRS_SERVICE_VERSION] as string);
+    return this.tracerProvider.getTracer(name, this.resource.attributes[SEMRESATTRS_SERVICE_VERSION] as string);
   }
 
   public start() {
-    this.hostMetrics = new HostMetrics({
-      name: this.resource.attributes[SEMRESATTRS_SERVICE_NAME] as string,
-      meterProvider: this.meterProvider,
-    });
+    this.tracerProvider.register();
 
-    this.hostMetrics.start();
+    if (this.reportHostMetrics) {
+      this.hostMetrics = new HostMetrics({
+        name: this.resource.attributes[SEMRESATTRS_SERVICE_NAME] as string,
+        meterProvider: this.meterProvider,
+      });
+
+      this.hostMetrics.start();
+    }
   }
 
   public async stop() {
-    await Promise.all([this.meterProvider.shutdown()]);
+    await Promise.all([this.meterProvider.shutdown(), this.tracerProvider.shutdown()]);
   }
 
   public static createAndStart(name: string, version: string, collectorBaseUrl: URL): OpenTelemetryClient {
@@ -44,28 +66,13 @@ export class OpenTelemetryClient implements TelemetryClient {
       [SEMRESATTRS_SERVICE_VERSION]: version,
     });
 
-    const tracerProvider = new NodeTracerProvider({
+    const client = new OpenTelemetryClient(
       resource,
-    });
-    tracerProvider.addSpanProcessor(
-      new BatchSpanProcessor(new OTLPTraceExporter({ url: new URL('/v1/traces', collectorBaseUrl).href })),
+      new OTLPMetricExporter({ url: new URL('/v1/metrics', collectorBaseUrl).href }),
+      new OTLPTraceExporter({ url: new URL('/v1/traces', collectorBaseUrl).href }),
     );
-    tracerProvider.register();
 
-    const meterProvider = new MeterProvider({
-      resource,
-      readers: [
-        new PeriodicExportingMetricReader({
-          exporter: new OTLPMetricExporter({
-            url: new URL('/v1/metrics', collectorBaseUrl).href,
-          }),
-        }),
-      ],
-    });
-
-    const service = new OpenTelemetryClient(resource, meterProvider, tracerProvider);
-    service.start();
-
-    return service;
+    client.start();
+    return client;
   }
 }

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -947,6 +947,7 @@ __metadata:
     "@aztec/foundation": "workspace:^"
     "@jest/globals": ^29.5.0
     "@opentelemetry/api": ^1.9.0
+    "@opentelemetry/context-async-hooks": ^1.25.1
     "@opentelemetry/exporter-metrics-otlp-http": ^0.52.0
     "@opentelemetry/exporter-trace-otlp-http": ^0.52.0
     "@opentelemetry/host-metrics": ^0.35.2
@@ -3077,6 +3078,15 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   checksum: f50f6ef621b6cfaa1d0919e4470b7c8326371beaf6be9a635c6f3221677bf9f5429a81a29b5518a41d3c002e35d4a89cb748ae61f650d61aa2ae3cbe123c0301
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/context-async-hooks@npm:^1.25.1":
+  version: 1.25.1
+  resolution: "@opentelemetry/context-async-hooks@npm:1.25.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: fb2ac7381ea8203a1321e2a4989c193b6eede0b0f46bafc150e452ac5fc4645127f0ca66f60e44ff2816032afc68cbe3ab9cf235fbdffb0ad83f484729b70e82
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds a global telemetry client instead of manually injecting it everywhere it's needed. Also adds an "in-memory" variant that could be used inside tests to export stats to a file.
