### PR TITLE
chore: replicate noir-lang/noir#4946

### DIFF
--- a/noir-projects/aztec-nr/authwit/src/cheatcodes.nr
+++ b/noir-projects/aztec-nr/authwit/src/cheatcodes.nr
@@ -4,7 +4,7 @@ use dep::aztec::{
     hash::hash_args
 };
 
-use crate::auth::{compute_inner_authwit_hash, compute_outer_authwit_hash, set_authorized};
+use crate::auth::{compute_inner_authwit_hash, compute_authwit_message_hash, set_authorized};
 
 pub fn add_private_authwit_from_call_interface<C, M, T, P, Env>(
     on_behalf_of: AztecAddress,
@@ -18,7 +18,7 @@ pub fn add_private_authwit_from_call_interface<C, M, T, P, Env>(
     let args_hash = hash_args(call_interface.get_args());
     let selector = call_interface.get_selector();
     let inner_hash = compute_inner_authwit_hash([caller.to_field(), selector.to_field(), args_hash]);
-    let message_hash = compute_outer_authwit_hash(target, chain_id, version, inner_hash);
+    let message_hash = compute_authwit_message_hash(target, chain_id, version, inner_hash);
     cheatcodes::add_authwit(on_behalf_of, message_hash);
 }
 
@@ -36,7 +36,7 @@ pub fn add_public_authwit_from_call_interface<C, M, T, P, Env>(
     let args_hash = hash_args(call_interface.get_args());
     let selector = call_interface.get_selector();
     let inner_hash = compute_inner_authwit_hash([caller.to_field(), selector.to_field(), args_hash]);
-    let message_hash = compute_outer_authwit_hash(target, chain_id, version, inner_hash);
+    let message_hash = compute_authwit_message_hash(target, chain_id, version, inner_hash);
     let mut inputs = cheatcodes::get_public_context_inputs();
     let mut context = PublicContext::new(inputs);
     set_authorized(&mut context, message_hash, true);

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/header.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/header.nr
@@ -2,7 +2,7 @@ use dep::protocol_types::{address::AztecAddress, grumpkin_private_key::GrumpkinP
 
 use crate::keys::point_to_symmetric_key::point_to_symmetric_key;
 
-use dep::std::aes128::aes128_encrypt;
+use std::aes128::aes128_encrypt;
 
 struct EncryptedLogHeader {
     address: AztecAddress,

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/incoming_body.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/incoming_body.nr
@@ -2,7 +2,7 @@ use crate::note::note_interface::NoteInterface;
 use crate::event::event_interface::EventInterface;
 use dep::protocol_types::{grumpkin_private_key::GrumpkinPrivateKey, grumpkin_point::GrumpkinPoint};
 
-use dep::std::aes128::aes128_encrypt;
+use std::aes128::aes128_encrypt;
 use crate::keys::point_to_symmetric_key::point_to_symmetric_key;
 
 struct EncryptedLogIncomingBody<M> {

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/outgoing_body.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/outgoing_body.nr
@@ -3,8 +3,7 @@ use dep::protocol_types::{
     constants::GENERATOR_INDEX__SYMMETRIC_KEY, hash::poseidon2_hash
 };
 
-use dep::std::aes128::aes128_encrypt;
-use dep::std::println;
+use std::aes128::aes128_encrypt;
 
 use crate::keys::point_to_symmetric_key::point_to_symmetric_key;
 

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
@@ -3,7 +3,7 @@ use dep::protocol_types::{
     constants::{GENERATOR_INDEX__IVSK_M, GENERATOR_INDEX__OVSK_M}, hash::poseidon2_hash
 };
 
-use dep::std::{embedded_curve_ops::{embedded_curve_add, EmbeddedCurvePoint}, field::bytes32_to_field};
+use std::{embedded_curve_ops::{embedded_curve_add, EmbeddedCurvePoint}, field::bytes32_to_field};
 
 use crate::oracle::unsafe_rand::unsafe_rand;
 

--- a/noir-projects/aztec-nr/aztec/src/history/note_inclusion.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/note_inclusion.nr
@@ -1,4 +1,4 @@
-use dep::std::merkle::compute_merkle_root;
+use std::merkle::compute_merkle_root;
 use dep::protocol_types::header::Header;
 
 use crate::{

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion.nr
@@ -1,4 +1,4 @@
-use dep::std::merkle::compute_merkle_root;
+use std::merkle::compute_merkle_root;
 use dep::protocol_types::header::Header;
 
 use crate::{

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion.nr
@@ -1,4 +1,4 @@
-use dep::std::merkle::compute_merkle_root;
+use std::merkle::compute_merkle_root;
 use dep::protocol_types::{header::Header, utils::field::{full_field_less_than, full_field_greater_than}};
 use crate::{
     context::PrivateContext, note::{utils::compute_siloed_nullifier, note_interface::NoteInterface},

--- a/noir-projects/aztec-nr/aztec/src/history/public_storage.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/public_storage.nr
@@ -2,7 +2,7 @@ use dep::protocol_types::{
     constants::GENERATOR_INDEX__PUBLIC_LEAF_INDEX, hash::pedersen_hash, address::AztecAddress,
     header::Header, utils::field::full_field_less_than
 };
-use dep::std::merkle::compute_merkle_root;
+use std::merkle::compute_merkle_root;
 
 use crate::{context::PrivateContext, oracle::get_public_data_witness::get_public_data_witness};
 

--- a/noir-projects/aztec-nr/aztec/src/keys/point_to_symmetric_key.nr
+++ b/noir-projects/aztec-nr/aztec/src/keys/point_to_symmetric_key.nr
@@ -2,7 +2,7 @@ use dep::protocol_types::{
     constants::GENERATOR_INDEX__SYMMETRIC_KEY, grumpkin_private_key::GrumpkinPrivateKey,
     grumpkin_point::GrumpkinPoint, utils::arr_copy_slice
 };
-use dep::std::{hash::sha256, embedded_curve_ops::{EmbeddedCurvePoint, EmbeddedCurveScalar, multi_scalar_mul}};
+use std::{hash::sha256, embedded_curve_ops::{EmbeddedCurvePoint, EmbeddedCurveScalar, multi_scalar_mul}};
 
 // TODO(#5726): This function is called deriveAESSecret in TS. I don't like point_to_symmetric_key name much since
 // point is not the only input of the function. Unify naming with TS once we have a better name.

--- a/noir-projects/aztec-nr/aztec/src/messaging.nr
+++ b/noir-projects/aztec-nr/aztec/src/messaging.nr
@@ -3,7 +3,7 @@ use crate::{
     oracle::get_l1_to_l2_membership_witness::get_l1_to_l2_membership_witness
 };
 
-use dep::std::merkle::compute_merkle_root;
+use std::merkle::compute_merkle_root;
 use dep::protocol_types::{constants::L1_TO_L2_MSG_TREE_HEIGHT, address::{AztecAddress, EthAddress}, utils::arr_copy_slice};
 
 pub fn process_l1_to_l2_message(

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter_options.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter_options.nr
@@ -1,4 +1,4 @@
-use dep::std::option::Option;
+use std::option::Option;
 use dep::protocol_types::{constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, traits::ToField};
 use crate::note::note_interface::NoteInterface;
 

--- a/noir-projects/aztec-nr/aztec/src/note/note_viewer_options.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_viewer_options.nr
@@ -1,4 +1,4 @@
-use dep::std::option::Option;
+use std::option::Option;
 use crate::note::note_getter_options::{PropertySelector, Select, Sort, Comparator, NoteStatus};
 use dep::protocol_types::traits::ToField;
 use crate::note::note_interface::NoteInterface;

--- a/noir-projects/aztec-nr/aztec/src/oracle/header.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/header.nr
@@ -1,4 +1,4 @@
-use dep::std::merkle::compute_merkle_root;
+use std::merkle::compute_merkle_root;
 use dep::protocol_types::{constants::HEADER_LENGTH, header::Header};
 
 use crate::{context::PrivateContext, oracle::get_membership_witness::get_archive_membership_witness};

--- a/noir-projects/aztec-nr/aztec/src/public_storage.nr
+++ b/noir-projects/aztec-nr/aztec/src/public_storage.nr
@@ -26,7 +26,7 @@ pub fn write<T, N>(storage_slot: Field, value: T) where T: Serialize<N> {
 // }
 
 mod tests {
-    use dep::std::test::OracleMock;
+    use std::test::OracleMock;
     use dep::protocol_types::traits::{Deserialize, Serialize};
     use crate::public_storage;
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
@@ -1,7 +1,7 @@
 use dep::protocol_types::{address::AztecAddress, grumpkin_point::GrumpkinPoint};
 use crate::{context::PrivateContext, state_vars::private_mutable::PrivateMutable};
 use crate::test::{mocks::mock_note::MockNote, helpers::{cheatcodes, test_environment::TestEnvironment}};
-use dep::std::{unsafe::zeroed, test::OracleMock};
+use std::{unsafe::zeroed, test::OracleMock};
 
 global storage_slot = 17;
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/scheduled_delay_change.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/scheduled_delay_change.nr
@@ -1,5 +1,5 @@
 use dep::protocol_types::traits::{Serialize, Deserialize, FromField, ToField};
-use dep::std::cmp::min;
+use std::cmp::min;
 
 mod test;
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/scheduled_value_change.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/scheduled_value_change.nr
@@ -1,5 +1,5 @@
 use dep::protocol_types::traits::{Serialize, Deserialize, FromField, ToField};
-use dep::std::cmp::min;
+use std::cmp::min;
 
 mod test;
 

--- a/noir-projects/aztec-nr/aztec/src/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils.nr
@@ -58,7 +58,7 @@ fn verify_collapse_hints<T, N>(
         } else {
             // BoundedVec assumes that the unused parts of the storage are zeroed out (e.g. in the Eq impl), so we make
             // sure that this property holds.
-            assert_eq(collapsed.get_unchecked(i), dep::std::unsafe::zeroed(), "Dirty collapsed vec storage");
+            assert_eq(collapsed.get_unchecked(i), std::unsafe::zeroed(), "Dirty collapsed vec storage");
         }
     }
     // We now know that:

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -3,18 +3,18 @@ mod dapp_payload;
 
 contract AppSubscription {
     use crate::{dapp_payload::DAppPayload, subscription_note::{SubscriptionNote, SUBSCRIPTION_NOTE_LEN}};
-    use dep::{
-        aztec::{
+
+    use aztec::{
         prelude::{
         AztecAddress, FunctionSelector, PrivateContext, NoteHeader, Map, PrivateMutable, PublicMutable,
         SharedImmutable
     },
         encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         protocol_types::{traits::is_empty, grumpkin_point::GrumpkinPoint}
-    },
-        authwit::{auth_witness::get_auth_witness, auth::assert_current_call_valid_authwit},
-        gas_token::GasToken, token::Token
     };
+    use authwit::{auth_witness::get_auth_witness, auth::assert_current_call_valid_authwit};
+    use gas_token::GasToken;
+    use token::Token;
 
     #[aztec(storage)]
     struct Storage {

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -24,7 +24,7 @@ contract AvmTest {
     global big_field_136_bits: Field = 0x991234567890abcdef1234567890abcdef;
 
     // Libs
-    use dep::std::embedded_curve_ops::{EmbeddedCurvePoint, EmbeddedCurveScalar, multi_scalar_mul};
+    use std::embedded_curve_ops::{EmbeddedCurvePoint, EmbeddedCurveScalar, multi_scalar_mul};
     use dep::aztec::protocol_types::constants::CONTRACT_INSTANCE_LENGTH;
     use dep::aztec::prelude::{Map, Deserialize};
     use dep::aztec::state_vars::PublicMutable;
@@ -76,7 +76,7 @@ contract AvmTest {
     fn set_storage_map(to: AztecAddress, amount: u32) -> Field {
         storage.map.at(to).write(amount);
         // returns storage slot for key
-        dep::std::hash::pedersen_hash([storage.map.storage_slot, to.to_field()])
+        std::hash::pedersen_hash([storage.map.storage_slot, to.to_field()])
     }
 
     #[aztec(public)]
@@ -84,7 +84,7 @@ contract AvmTest {
         let new_balance = storage.map.at(to).read().add(amount);
         storage.map.at(to).write(new_balance);
         // returns storage slot for key
-        dep::std::hash::pedersen_hash([storage.map.storage_slot, to.to_field()])
+        std::hash::pedersen_hash([storage.map.storage_slot, to.to_field()])
     }
 
     #[aztec(public)]
@@ -209,27 +209,27 @@ contract AvmTest {
      ************************************************************************/
     #[aztec(public)]
     fn keccak_hash(data: [u8; 10]) -> [u8; 32] {
-        dep::std::hash::keccak256(data, data.len() as u32)
+        std::hash::keccak256(data, data.len() as u32)
     }
 
     #[aztec(public)]
     fn poseidon2_hash(data: [Field; 10]) -> Field {
-        dep::std::hash::poseidon2::Poseidon2::hash(data, data.len())
+        std::hash::poseidon2::Poseidon2::hash(data, data.len())
     }
 
     #[aztec(public)]
     fn sha256_hash(data: [u8; 10]) -> [u8; 32] {
-        dep::std::hash::sha256(data)
+        std::hash::sha256(data)
     }
 
     #[aztec(public)]
     fn pedersen_hash(data: [Field; 10]) -> Field {
-        dep::std::hash::pedersen_hash(data)
+        std::hash::pedersen_hash(data)
     }
 
     #[aztec(public)]
     fn pedersen_hash_with_index(data: [Field; 10]) -> Field {
-        dep::std::hash::pedersen_hash_with_separator(data, /*index=*/ 20)
+        std::hash::pedersen_hash_with_separator(data, /*index=*/ 20)
     }
 
     /************************************************************************

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -9,8 +9,6 @@ use dep::aztec::{
     encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys,
     note::note_getter::view_notes, state_vars::PrivateSet, note::constants::MAX_NOTES_PER_PAGE
 };
-use dep::std;
-use dep::std::{option::Option};
 use dep::value_note::{value_note::{ValueNote, VALUE_NOTE_LEN}};
 
 struct Card {

--- a/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/main.nr
@@ -34,7 +34,7 @@ contract EasyPrivateVoting {
         let msg_sender_npk_m_hash = header_at_active_at_block.get_npk_m_hash(&mut context, context.msg_sender());
 
         let secret = context.request_nsk_app(msg_sender_npk_m_hash); // get secret key of caller of function
-        let nullifier = dep::std::hash::pedersen_hash([context.msg_sender().to_field(), secret]); // derive nullifier from sender and secret
+        let nullifier = std::hash::pedersen_hash([context.msg_sender().to_field(), secret]); // derive nullifier from sender and secret
         context.push_new_nullifier(nullifier, 0); // push nullifier
         EasyPrivateVoting::at(context.this_address()).add_to_tally_public(candidate).enqueue(&mut context);
     }

--- a/noir-projects/noir-contracts/contracts/schnorr_single_key_account_contract/src/util.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_single_key_account_contract/src/util.nr
@@ -1,4 +1,4 @@
-use dep::std::{schnorr::verify_signature_slice};
+use std::{schnorr::verify_signature_slice};
 use dep::aztec::prelude::AztecAddress;
 use crate::auth_oracle::AuthWitness;
 

--- a/noir-projects/noir-contracts/contracts/uniswap_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/uniswap_contract/src/main.nr
@@ -9,8 +9,8 @@ contract Uniswap {
     use dep::aztec::context::gas::GasOpts;
 
     use dep::authwit::auth::{
-        IS_VALID_SELECTOR, assert_current_call_valid_authwit_public, compute_authwit_message_hash_from_call,
-        compute_authwit_message_hash, set_authorized
+        IS_VALID_SELECTOR, assert_current_call_valid_authwit_public,
+        compute_authwit_message_hash_from_call, compute_authwit_message_hash, set_authorized
     };
 
     use dep::token::Token;

--- a/noir-projects/noir-protocol-circuits/crates/parity-lib/src/root/root_parity_input.nr
+++ b/noir-projects/noir-protocol-circuits/crates/parity-lib/src/root/root_parity_input.nr
@@ -23,7 +23,7 @@ impl Empty for RootParityInput {
 impl Verifiable for RootParityInput {
   fn verify(self) {
     let inputs = ParityPublicInputs::serialize(self.public_inputs);
-    dep::std::verify_proof(
+    std::verify_proof(
         self.verification_key.key.as_slice(),
         self.proof.fields.as_slice(),
         inputs.as_slice(),

--- a/noir-projects/noir-protocol-circuits/crates/parity-lib/src/root/root_rollup_parity_input.nr
+++ b/noir-projects/noir-protocol-circuits/crates/parity-lib/src/root/root_rollup_parity_input.nr
@@ -23,7 +23,7 @@ impl Empty for RootRollupParityInput {
 impl Verifiable for RootRollupParityInput {
   fn verify(self) {
     let inputs = ParityPublicInputs::serialize(self.public_inputs);
-    dep::std::verify_proof(
+    std::verify_proof(
         self.verification_key.key.as_slice(),
         self.proof.fields.as_slice(),
         inputs.as_slice(),

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator.nr
@@ -207,8 +207,8 @@ impl PrivateCallDataValidator {
         let private_call_vk_hash = stdlib_recursion_verification_key_compress_native_vk(self.data.vk);
 
         assert(!contract_address.is_zero(), "contract address cannot be zero");
-        // std::println(f"contract_address={contract_address}");
-        // std::println(f"private_call_vk_hash={private_call_vk_hash}");
+        // println(f"contract_address={contract_address}");
+        // println(f"private_call_vk_hash={private_call_vk_hash}");
 
         // Recompute the contract class id
         let computed_private_functions_root = private_functions_root_from_siblings(
@@ -217,24 +217,24 @@ impl PrivateCallDataValidator {
             self.data.function_leaf_membership_witness.leaf_index,
             self.data.function_leaf_membership_witness.sibling_path
         );
-        // std::println(f"computed_private_functions_root={computed_private_functions_root}");
+        // println(f"computed_private_functions_root={computed_private_functions_root}");
 
         let computed_contract_class_id = ContractClassId::compute(
             self.data.contract_class_artifact_hash,
             computed_private_functions_root,
             self.data.contract_class_public_bytecode_commitment
         );
-        // std::println(f"computed_contract_class_id={computed_contract_class_id}");
+        // println(f"computed_contract_class_id={computed_contract_class_id}");
 
         // Recompute contract address using the preimage which includes the class_id
         let computed_partial_address = PartialAddress::compute_from_salted_initialization_hash(
             computed_contract_class_id,
             self.data.salted_initialization_hash
         );
-        // std::println(f"computed_partial_address={computed_partial_address}");
+        // println(f"computed_partial_address={computed_partial_address}");
 
         let computed_address = AztecAddress::compute(self.data.public_keys_hash, computed_partial_address);
-        // std::println(f"computed_address={computed_address}");
+        // println(f"computed_address={computed_address}");
 
         assert(
             computed_address.eq(contract_address), "computed contract address does not match expected one"

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_empty.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_empty.nr
@@ -10,7 +10,7 @@ struct EmptyNestedCircuitPublicInputs {
 
 impl Verifiable for EmptyNestedCircuitPublicInputs {
   fn verify(self) {
-    dep::std::verify_proof(
+    std::verify_proof(
         self.vk.key.as_slice(),
         self.proof.fields.as_slice(),
         &[],

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_init.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_init.nr
@@ -47,13 +47,13 @@ impl PrivateKernelInitCircuitPrivateInputs {
         private_call_data_validator.validate_as_first_call(self.hints.first_revertible_private_call_request_index);
         private_call_data_validator.validate_against_tx_request(self.tx_request);
         private_call_data_validator.validate(output.end.new_note_hashes);
-        if !dep::std::runtime::is_unconstrained() {
+        if !std::runtime::is_unconstrained() {
             // verify/aggregate the private call proof
             self.private_call.verify();
         }
 
         // Validate output.
-        if !dep::std::runtime::is_unconstrained() {
+        if !std::runtime::is_unconstrained() {
             PrivateKernelCircuitOutputValidator::new(output).validate_as_first_call(
                 self.tx_request,
                 self.private_call.call_stack_item.public_inputs,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_inner.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_inner.nr
@@ -46,7 +46,7 @@ impl PrivateKernelInnerCircuitPrivateInputs {
         private_call_data_validator.validate_against_call_request(call_request);
         private_call_data_validator.validate_against_previous_kernel(self.previous_kernel.public_inputs);
         private_call_data_validator.validate(output.end.new_note_hashes);
-        if !dep::std::runtime::is_unconstrained() {
+        if !std::runtime::is_unconstrained() {
             // verify/aggregate the private call proof
             self.private_call.verify();
             // verify/aggregate the previous kernel
@@ -54,7 +54,7 @@ impl PrivateKernelInnerCircuitPrivateInputs {
         }
 
         // Validate output.
-        if !dep::std::runtime::is_unconstrained() {
+        if !std::runtime::is_unconstrained() {
             PrivateKernelCircuitOutputValidator::new(output).validate_as_inner_call(
                 self.previous_kernel.public_inputs,
                 previous_kernel_array_lengths,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
@@ -59,13 +59,13 @@ impl PrivateKernelTailCircuitPrivateInputs {
 
         // Validate inputs.
         PreviousKernelValidator::new(self.previous_kernel.public_inputs).validate_for_private_tail();
-        if !dep::std::runtime::is_unconstrained() {
+        if !std::runtime::is_unconstrained() {
             // verify/aggregate the previous kernel
             self.previous_kernel.verify();
         }
 
         // Validate output.
-        if !dep::std::runtime::is_unconstrained() {
+        if !std::runtime::is_unconstrained() {
             let hints = generate_hints(self.previous_kernel.public_inputs);
             KernelCircuitOutputValidator::new(output, self.previous_kernel.public_inputs).validate(hints);
         }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail_to_public.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail_to_public.nr
@@ -40,7 +40,7 @@ impl PrivateKernelTailToPublicCircuitPrivateInputs {
     pub fn execute(self) -> PublicKernelCircuitPublicInputs {
         // Validate inputs.
         PreviousKernelValidator::new(self.previous_kernel.public_inputs).validate_for_private_tail_to_public();
-        if !dep::std::runtime::is_unconstrained() {
+        if !std::runtime::is_unconstrained() {
             // verify/aggregate the previous kernel
             self.previous_kernel.verify();
         }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/constant_rollup_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/constant_rollup_data.nr
@@ -1,4 +1,3 @@
-use dep::std::cmp::Eq;
 use dep::types::{
     abis::{global_variables::GlobalVariables, append_only_tree_snapshot::AppendOnlyTreeSnapshot},
     traits::{Empty, Serialize, Deserialize}, constants::CONSTANT_ROLLUP_DATA_LENGTH,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/previous_rollup_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/previous_rollup_data.nr
@@ -16,7 +16,7 @@ struct PreviousRollupData{
 impl Verifiable for PreviousRollupData {
   fn verify(self) {
     let inputs = BaseOrMergeRollupPublicInputs::serialize(self.base_or_merge_rollup_public_inputs);
-    dep::std::verify_proof(
+    std::verify_proof(
         self.vk.key.as_slice(),
         self.proof.fields.as_slice(),
         inputs.as_slice(),

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/base_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/base_rollup_inputs.nr
@@ -1056,7 +1056,7 @@ mod tests {
         let outputs = BaseRollupInputsBuilder::new().execute();
 
         let hash_input_flattened = [0; TX_EFFECTS_HASH_INPUT_FIELDS * 32];
-        let sha_digest = dep::std::hash::sha256(hash_input_flattened);
+        let sha_digest = std::hash::sha256(hash_input_flattened);
         let expected_tx_effects_hash = field_from_bytes_32_trunc(sha_digest);
         assert_eq(outputs.txs_effects_hash, expected_tx_effects_hash);
     }
@@ -1067,7 +1067,7 @@ mod tests {
         // For now setting an empty out hash to be H(0,0) to keep consistent
         // with prev work.
         let hash_input_flattened = [0; 64];
-        let sha_digest = dep::std::hash::sha256(hash_input_flattened);
+        let sha_digest = std::hash::sha256(hash_input_flattened);
         let expected_out_hash = field_from_bytes_32_trunc(sha_digest);
         assert_eq(outputs.out_hash, expected_out_hash);
     }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_inputs.nr
@@ -2,9 +2,8 @@ use crate::{
     abis::{previous_rollup_data::PreviousRollupData, constant_rollup_data::ConstantRollupData},
     components, root::{root_rollup_public_inputs::RootRollupPublicInputs}
 };
-use dep::{
-    std, parity_lib::{root::root_rollup_parity_input::RootRollupParityInput, ParityPublicInputs},
-    types::{
+use parity_lib::{root::root_rollup_parity_input::RootRollupParityInput, ParityPublicInputs};
+use types::{
     abis::{append_only_tree_snapshot::AppendOnlyTreeSnapshot, nullifier_leaf_preimage::NullifierLeafPreimage},
     constants::{
     NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, L1_TO_L2_MSG_SUBTREE_HEIGHT,
@@ -13,7 +12,6 @@ use dep::{
     header::Header, content_commitment::ContentCommitment,
     merkle_tree::{append_only_tree, calculate_subtree_root, calculate_empty_tree_root},
     state_reference::StateReference, traits::Empty
-}
 };
 
 struct RootRollupInputs {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/append_only_tree_snapshot.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/append_only_tree_snapshot.nr
@@ -1,4 +1,3 @@
-use dep::std::cmp::Eq;
 
 struct AppendOnlyTreeSnapshot {
     root : Field,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/append_only_tree_snapshot.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/append_only_tree_snapshot.nr
@@ -1,4 +1,3 @@
-
 struct AppendOnlyTreeSnapshot {
     root : Field,
     // TODO(Alvaro) change this to a u64

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/call_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/call_request.nr
@@ -1,4 +1,3 @@
-use dep::std::cmp::Eq;
 use crate::{
     abis::{caller_context::CallerContext, side_effect::Ordered}, address::AztecAddress,
     constants::CALL_REQUEST_LENGTH, traits::{Empty, Serialize, Deserialize}, utils::reader::Reader

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/caller_context.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/caller_context.nr
@@ -1,5 +1,4 @@
 use crate::address::AztecAddress;
-use dep::std::cmp::Eq;
 use crate::traits::{Empty, Serialize, Deserialize};
 use crate::constants::CALLER_CONTEXT_LENGTH;
 use crate::utils::reader::Reader;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/contract_class_function_leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/contract_class_function_leaf_preimage.nr
@@ -9,7 +9,7 @@ struct ContractClassFunctionLeafPreimage {
 
 impl Hash for ContractClassFunctionLeafPreimage {
     fn hash(self) -> Field {
-        dep::std::hash::pedersen_hash_with_separator([
+        std::hash::pedersen_hash_with_separator([
             self.selector.to_field(),
             self.vk_hash,
         ], GENERATOR_INDEX__FUNCTION_LEAF)

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/event_selector.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/event_selector.nr
@@ -1,5 +1,4 @@
 use crate::utils::field::field_from_bytes;
-use dep::std::cmp::Eq;
 use crate::traits::{Serialize, Deserialize, FromField, ToField, Empty};
 
 global SELECTOR_SIZE = 4;
@@ -54,7 +53,7 @@ impl EventSelector {
 
     pub fn from_signature<N>(signature: str<N>) -> Self {
         let bytes = signature.as_bytes();
-        let hash = dep::std::hash::keccak256(bytes, bytes.len() as u32);
+        let hash = std::hash::keccak256(bytes, bytes.len() as u32);
 
         let mut selector_be_bytes = [0; SELECTOR_SIZE];
         for i in 0..SELECTOR_SIZE {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/function_selector.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/function_selector.nr
@@ -1,5 +1,4 @@
 use crate::utils::field::field_from_bytes;
-use dep::std::cmp::Eq;
 use crate::traits::{Serialize, Deserialize, FromField, ToField, Empty};
 
 global SELECTOR_SIZE = 4;
@@ -54,7 +53,7 @@ impl FunctionSelector {
 
     pub fn from_signature<N>(signature: str<N>) -> Self {
         let bytes = signature.as_bytes();
-        let hash = dep::std::hash::keccak256(bytes, bytes.len() as u32);
+        let hash = std::hash::keccak256(bytes, bytes.len() as u32);
 
         let mut selector_be_bytes = [0; SELECTOR_SIZE];
         for i in 0..SELECTOR_SIZE {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/gas.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/gas.nr
@@ -4,7 +4,7 @@ use crate::{
     traits::{Deserialize, Hash, Serialize, Empty}, abis::side_effect::Ordered, utils::reader::Reader,
     abis::gas_fees::GasFees
 };
-use dep::std::ops::{Add, Sub};
+use std::ops::{Add, Sub};
 
 struct Gas {
     da_gas: u32,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/global_variables.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/global_variables.nr
@@ -1,4 +1,3 @@
-use dep::std::cmp::Eq;
 use crate::{
     address::{AztecAddress, EthAddress}, abis::gas_fees::GasFees,
     constants::{GENERATOR_INDEX__GLOBAL_VARIABLES, GLOBAL_VARIABLES_LENGTH},

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/kernel_data.nr
@@ -13,7 +13,7 @@ struct KernelData {
 impl Verifiable for KernelData {
   fn verify(self) {
     let inputs = KernelCircuitPublicInputs::serialize(self.public_inputs);
-    dep::std::verify_proof(
+    std::verify_proof(
         self.vk.key.as_slice(),
         self.proof.fields.as_slice(),
         inputs.as_slice(),

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/note_hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/note_hash.nr
@@ -4,7 +4,6 @@ use crate::{
     constants::{NOTE_HASH_LENGTH, SCOPED_NOTE_HASH_LENGTH}, traits::{Empty, Serialize, Deserialize},
     utils::{arrays::array_concat, reader::Reader}
 };
-use dep::std::cmp::Eq;
 
 struct NoteHash {
     value: Field,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/nullifier_leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/nullifier_leaf_preimage.nr
@@ -26,7 +26,7 @@ impl Hash for NullifierLeafPreimage {
         if self.is_empty() {
             0
         } else {
-            dep::std::hash::pedersen_hash(self.serialize())
+            std::hash::pedersen_hash(self.serialize())
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_call_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_call_request.nr
@@ -1,4 +1,3 @@
-use dep::std::cmp::Eq;
 use crate::{
     abis::{caller_context::CallerContext, side_effect::{Ordered, RangeOrdered, Scoped}},
     address::AztecAddress, constants::{PRIVATE_CALL_REQUEST_LENGTH, SCOPED_PRIVATE_CALL_REQUEST_LENGTH},

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_kernel/private_call_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_kernel/private_call_data.nr
@@ -29,7 +29,7 @@ struct PrivateCallData {
 impl Verifiable for PrivateCallData {
   fn verify(self) {
     let inputs = PrivateCircuitPublicInputs::serialize(self.call_stack_item.public_inputs);
-    dep::std::verify_proof(
+    std::verify_proof(
         self.vk.key.as_slice(),
         self.proof.fields.as_slice(),
         inputs.as_slice(),

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_kernel_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_kernel_data.nr
@@ -26,7 +26,7 @@ struct PrivateKernelData {
 impl Verifiable for PrivateKernelData {
   fn verify(self) {
     let inputs = PrivateKernelCircuitPublicInputs::serialize(self.public_inputs);
-    dep::std::verify_proof(
+    std::verify_proof(
         self.vk.key.as_slice(),
         self.proof.fields.as_slice(),
         inputs.as_slice(),

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_call_stack_item.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_call_stack_item.nr
@@ -20,7 +20,7 @@ impl Hash for PublicCallStackItem {
             self
         };
 
-        dep::std::hash::pedersen_hash_with_separator([
+        std::hash::pedersen_hash_with_separator([
             item.contract_address.to_field(),
             item.function_data.hash(),
             item.public_inputs.hash(),

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_data_read.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_data_read.nr
@@ -1,5 +1,4 @@
 use crate::constants::{GENERATOR_INDEX__PUBLIC_DATA_READ, PUBLIC_DATA_READ_LENGTH};
-use dep::std::cmp::Eq;
 use crate::traits::{Empty, Hash, Serialize, Deserialize};
 use crate::contrakt::storage_read::StorageRead;
 use crate::data::hash::{compute_public_data_tree_value, compute_public_data_tree_index};
@@ -39,7 +38,7 @@ impl Empty for PublicDataRead {
 
 impl Hash for PublicDataRead {
     fn hash(self) -> Field {
-        dep::std::hash::pedersen_hash_with_separator([
+        std::hash::pedersen_hash_with_separator([
             self.leaf_slot,
             self.value,
         ], GENERATOR_INDEX__PUBLIC_DATA_READ)

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_data_update_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_data_update_request.nr
@@ -1,4 +1,3 @@
-use dep::std::cmp::Eq;
 use crate::constants::{PUBLIC_DATA_UPDATE_REQUEST_LENGTH, GENERATOR_INDEX__PUBLIC_DATA_UPDATE_REQUEST};
 use crate::traits::{Empty, Hash, Serialize, Deserialize};
 use crate::public_data_tree_leaf::PublicDataTreeLeaf;
@@ -57,7 +56,7 @@ impl Empty for PublicDataUpdateRequest {
 
 impl Hash for PublicDataUpdateRequest {
     fn hash(self) -> Field {
-        dep::std::hash::pedersen_hash_with_separator([
+        std::hash::pedersen_hash_with_separator([
             self.leaf_slot,
             self.new_value
         ], GENERATOR_INDEX__PUBLIC_DATA_UPDATE_REQUEST)

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_kernel_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_kernel_data.nr
@@ -13,7 +13,7 @@ struct PublicKernelData {
 impl Verifiable for PublicKernelData {
   fn verify(self) {
     let inputs = PublicKernelCircuitPublicInputs::serialize(self.public_inputs);
-    dep::std::verify_proof(
+    std::verify_proof(
         self.vk.key.as_slice(),
         self.proof.fields.as_slice(),
         inputs.as_slice(),

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/read_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/read_request.nr
@@ -3,7 +3,6 @@ use crate::{
     address::AztecAddress, constants::{READ_REQUEST_LENGTH, SCOPED_READ_REQUEST_LEN},
     utils::{arrays::array_concat, reader::Reader}
 };
-use dep::std::cmp::Eq;
 
 struct ReadRequest {
     value: Field,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/side_effect.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/side_effect.nr
@@ -1,5 +1,4 @@
 use crate::{abis::read_request::ScopedReadRequest, address::AztecAddress};
-use dep::std::cmp::Eq;
 
 trait Ordered {
     fn counter(self) -> u32;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/validation_requests/key_validation_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/validation_requests/key_validation_request.nr
@@ -1,4 +1,3 @@
-use dep::std::cmp::Eq;
 use crate::{
     constants::KEY_VALIDATION_REQUEST_LENGTH, traits::{Empty, Serialize, Deserialize},
     grumpkin_point::GrumpkinPoint

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/validation_requests/key_validation_request_and_generator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/validation_requests/key_validation_request_and_generator.nr
@@ -1,4 +1,3 @@
-use dep::std::cmp::Eq;
 use crate::{
     address::AztecAddress,
     abis::validation_requests::{

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/validation_requests/scoped_key_validation_request_and_generator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/validation_requests/scoped_key_validation_request_and_generator.nr
@@ -1,4 +1,3 @@
-use dep::std::cmp::Eq;
 use crate::{
     address::AztecAddress, constants::SCOPED_KEY_VALIDATION_REQUEST_AND_GENERATOR_LENGTH,
     traits::{Empty, Serialize, Deserialize}, utils::{arrays::array_concat, reader::Reader},

--- a/noir-projects/noir-protocol-circuits/crates/types/src/contract_class_id.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/contract_class_id.nr
@@ -41,7 +41,7 @@ impl ContractClassId {
         private_functions_root: Field,
         public_bytecode_commitment: Field
     ) -> Self {
-        let hash = dep::std::hash::pedersen_hash_with_separator(
+        let hash = std::hash::pedersen_hash_with_separator(
             [
             artifact_hash,
             private_functions_root,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/contrakt/storage_update_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/contrakt/storage_update_request.nr
@@ -2,7 +2,6 @@ use crate::{
     constants::{CONTRACT_STORAGE_UPDATE_REQUEST_LENGTH, GENERATOR_INDEX__PUBLIC_DATA_UPDATE_REQUEST},
     hash::pedersen_hash, traits::{Deserialize, Hash, Empty, Serialize}
 };
-use dep::std::cmp::Eq;
 
 struct StorageUpdateRequest {
     storage_slot : Field,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/data/hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/data/hash.nr
@@ -1,7 +1,7 @@
 use crate::{address::AztecAddress, constants::GENERATOR_INDEX__PUBLIC_LEAF_INDEX};
 
 pub fn compute_public_data_tree_index(contract_address: AztecAddress, storage_slot: Field) -> Field {
-    dep::std::hash::pedersen_hash_with_separator(
+    std::hash::pedersen_hash_with_separator(
         [
         contract_address.to_field(),
         storage_slot

--- a/noir-projects/noir-protocol-circuits/crates/types/src/grumpkin_point.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/grumpkin_point.nr
@@ -1,5 +1,4 @@
 use crate::{traits::{Serialize, Deserialize, Hash}, hash::poseidon2_hash};
-use dep::std::cmp::Eq;
 
 global GRUMPKIN_POINT_SERIALIZED_LEN: Field = 2;
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/grumpkin_private_key.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/grumpkin_private_key.nr
@@ -1,4 +1,4 @@
-use dep::std::{cmp::Eq, embedded_curve_ops::fixed_base_scalar_mul};
+use std::{cmp::Eq, embedded_curve_ops::fixed_base_scalar_mul};
 use crate::{grumpkin_point::GrumpkinPoint, traits::Empty};
 
 global GRUMPKIN_PRIVATE_KEY_SERIALIZED_LEN: Field = 2;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
@@ -14,7 +14,7 @@ use crate::{
     recursion::verification_key::VerificationKey, traits::is_empty,
     utils::field::field_from_bytes_32_trunc
 };
-use dep::std::hash::{pedersen_hash_with_separator, sha256};
+use std::hash::{pedersen_hash_with_separator, sha256};
 
 pub fn sha256_to_field<N>(bytes_to_hash: [u8; N]) -> Field {
     let sha256_hashed = sha256(bytes_to_hash);
@@ -249,11 +249,11 @@ pub fn compute_tx_note_logs_hash(logs: [LogHash; MAX_NOTE_ENCRYPTED_LOGS_PER_TX]
 }
 
 pub fn pedersen_hash<N>(inputs: [Field; N], hash_index: u32) -> Field {
-    dep::std::hash::pedersen_hash_with_separator(inputs, hash_index)
+    std::hash::pedersen_hash_with_separator(inputs, hash_index)
 }
 
 pub fn poseidon2_hash<N>(inputs: [Field; N]) -> Field {
-    dep::std::hash::poseidon2::Poseidon2::hash(inputs, N)
+    std::hash::poseidon2::Poseidon2::hash(inputs, N)
 }
 
 #[test]

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/membership.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/membership.nr
@@ -82,7 +82,7 @@ mod tests {
     },
         tests::merkle_tree_utils::NonEmptyMerkleTree
     };
-    use dep::std::hash::pedersen_hash;
+    use std::hash::pedersen_hash;
 
     struct TestLeafPreimage {
         value: Field,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/merkle_tree.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/merkle_tree.nr
@@ -24,12 +24,12 @@ impl<N> MerkleTree<N> {
 
         // hash base layer
         for i in 0..half_size {
-            nodes[i] = dep::std::hash::pedersen_hash([leaves[2*i], leaves[2*i+1]]);
+            nodes[i] = std::hash::pedersen_hash([leaves[2*i], leaves[2*i+1]]);
         }
 
         // hash the other layers
         for i in 0..(total_nodes - half_size) {
-            nodes[half_size+i] = dep::std::hash::pedersen_hash([nodes[2*i], nodes[2*i+1]]);
+            nodes[half_size+i] = std::hash::pedersen_hash([nodes[2*i], nodes[2*i+1]]);
         }
 
         MerkleTree { leaves, nodes }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/public_data_tree_leaf.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/public_data_tree_leaf.nr
@@ -1,5 +1,4 @@
 use crate::traits::Empty;
-use dep::std::cmp::Eq;
 
 struct PublicDataTreeLeaf {
     slot: Field,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/public_data_tree_leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/public_data_tree_leaf_preimage.nr
@@ -23,7 +23,7 @@ impl Hash for PublicDataTreeLeafPreimage {
         if self.is_empty() {
             0
         } else {
-            dep::std::hash::pedersen_hash([self.slot, self.value, (self.next_index as Field), self.next_slot])
+            std::hash::pedersen_hash([self.slot, self.value, (self.next_index as Field), self.next_slot])
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/merkle_tree_utils.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/merkle_tree_utils.nr
@@ -1,10 +1,10 @@
 use crate::{merkle_tree::{MerkleTree, calculate_empty_tree_root}, traits::Empty};
 
 pub fn compute_zero_hashes<N>(mut hashes: [Field; N]) -> [Field; N] {
-    hashes[0] = dep::std::hash::pedersen_hash([0, 0]);
+    hashes[0] = std::hash::pedersen_hash([0, 0]);
 
     for i in 1..N {
-        hashes[i] = dep::std::hash::pedersen_hash([hashes[i-1], hashes[i-1]]);
+        hashes[i] = std::hash::pedersen_hash([hashes[i-1], hashes[i-1]]);
     }
 
     hashes
@@ -25,7 +25,7 @@ impl<N> MerkleTree<N> {
         let mut layer_offset: u32 = 0;
         let mut node_index: u32 = index / 2 + layer_offset;
         for _ in 0..K {
-            self.nodes[node_index] = dep::std::hash::pedersen_hash([left_node, right_node]);
+            self.nodes[node_index] = std::hash::pedersen_hash([left_node, right_node]);
             sibling_index = MerkleTree::sibling_index(node_index);
             let nodes = if node_index % 2 == 0 {
                 (self.nodes[node_index], self.nodes[sibling_index])
@@ -51,11 +51,11 @@ impl<N> MerkleTree<N> {
 #[test]
 fn test_merkle_tree_update_leaf() {
     let mut tree = MerkleTree::new([1, 2]);
-    assert_eq(tree.get_root(), dep::std::hash::pedersen_hash([1, 2]));
+    assert_eq(tree.get_root(), std::hash::pedersen_hash([1, 2]));
     tree.update_leaf(1, 0, [0; 1]);
-    assert_eq(tree.get_root(), dep::std::hash::pedersen_hash([1, 0]));
+    assert_eq(tree.get_root(), std::hash::pedersen_hash([1, 0]));
     tree.update_leaf(0, 0, [0; 1]);
-    assert_eq(tree.get_root(), dep::std::hash::pedersen_hash([0, 0]));
+    assert_eq(tree.get_root(), std::hash::pedersen_hash([0, 0]));
 }
 
 #[test]
@@ -105,10 +105,10 @@ impl<SUBTREE_ITEMS, TREE_HEIGHT, SUPERTREE_HEIGHT, SUBTREE_HEIGHT> NonEmptyMerkl
         let zero_hashes = compute_zero_hashes(_tree_height);
 
         let mut left_supertree_branch = [0; SUPERTREE_HEIGHT];
-        left_supertree_branch[0] = dep::std::hash::pedersen_hash([subtree.get_root(), zero_hashes[SUBTREE_HEIGHT-1]]);
+        left_supertree_branch[0] = std::hash::pedersen_hash([subtree.get_root(), zero_hashes[SUBTREE_HEIGHT-1]]);
         for i in 1..left_supertree_branch.len() {
             // TODO(md): far right of this yuck
-            left_supertree_branch[i] = dep::std::hash::pedersen_hash([left_supertree_branch[i-1], zero_hashes[(SUBTREE_HEIGHT as u64 -1) + i as u64]]);
+            left_supertree_branch[i] = std::hash::pedersen_hash([left_supertree_branch[i-1], zero_hashes[(SUBTREE_HEIGHT as u64 -1) + i as u64]]);
         }
 
         NonEmptyMerkleTree { subtree, zero_hashes, left_supertree_branch, _phantom_subtree_height: _subtree_height }
@@ -154,9 +154,9 @@ impl<SUBTREE_ITEMS, TREE_HEIGHT, SUPERTREE_HEIGHT, SUBTREE_HEIGHT> NonEmptyMerkl
 
         self.subtree.update_leaf(index, value, [0; SUBTREE_HEIGHT]);
 
-        self.left_supertree_branch[0] = dep::std::hash::pedersen_hash([self.subtree.get_root(), self.zero_hashes[SUBTREE_HEIGHT-1]]);
+        self.left_supertree_branch[0] = std::hash::pedersen_hash([self.subtree.get_root(), self.zero_hashes[SUBTREE_HEIGHT-1]]);
         for i in 1..self.left_supertree_branch.len() {
-            self.left_supertree_branch[i] = dep::std::hash::pedersen_hash([self.left_supertree_branch[i-1], self.zero_hashes[SUBTREE_HEIGHT-1+i]]);
+            self.left_supertree_branch[i] = std::hash::pedersen_hash([self.left_supertree_branch[i-1], self.zero_hashes[SUBTREE_HEIGHT-1+i]]);
         }
     }
 
@@ -177,7 +177,7 @@ fn test_merkle_tree_empty_subtree() {
     assert_eq(tree.zero_hashes.len(), 2);
     let path = tree.get_sibling_path(3);
     assert_eq(path[0], 0);
-    assert_eq(path[1], dep::std::hash::pedersen_hash([0, 0]));
+    assert_eq(path[1], std::hash::pedersen_hash([0, 0]));
     assert_eq(tree.get_root(), calculate_empty_tree_root(2));
 }
 
@@ -200,7 +200,7 @@ fn test_merkle_tree_non_empty_subtree() {
     assert_eq(tree.zero_hashes.len(), 2);
     let path = tree.get_sibling_path(3);
     assert_eq(path[0], 0);
-    assert_eq(path[1], dep::std::hash::pedersen_hash([1, 1]));
+    assert_eq(path[1], std::hash::pedersen_hash([1, 1]));
 }
 
 #[test]

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/utils.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/utils.nr
@@ -1,4 +1,3 @@
-use dep::std::cmp::Eq;
 use crate::traits::{Empty, is_empty};
 
 fn count_non_empty_elements<T, N>(array: [T; N]) -> u64 where T: Empty + Eq {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
@@ -1,4 +1,3 @@
-use dep::std::cmp::Eq;
 use crate::utils::field::field_from_bytes;
 
 // Trait: is_empty

--- a/noir/noir-repo/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/noir/noir-repo/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -140,12 +140,32 @@ fn resolve_path_to_ns(
             // Resolve from the root of the crate
             resolve_path_from_crate_root(crate_id, importing_crate, import_path, def_maps)
         }
-        crate::ast::PathKind::Dep => {
-            resolve_external_dep(def_map, import_directive, def_maps, importing_crate)
-        }
         crate::ast::PathKind::Plain => {
-            // Plain paths are only used to import children modules. It's possible to allow import of external deps, but maybe this distinction is better?
-            // In Rust they can also point to external Dependencies, if no children can be found with the specified name
+            // There is a possibility that the import path is empty
+            // In that case, early return
+            if import_path.is_empty() {
+                return resolve_name_in_module(
+                    crate_id,
+                    importing_crate,
+                    import_path,
+                    import_directive.module_id,
+                    def_maps,
+                );
+            }
+
+            let current_mod_id = ModuleId { krate: crate_id, local_id: import_directive.module_id };
+            let current_mod = &def_map.modules[current_mod_id.local_id.0];
+            let first_segment = import_path.first().expect("ice: could not fetch first segment");
+            if current_mod.find_name(first_segment).is_none() {
+                // Resolve externally when first segment is unresolved
+                return resolve_external_dep(
+                    def_map,
+                    import_directive,
+                    def_maps,
+                    importing_crate,
+                );
+            }
+
             resolve_name_in_module(
                 crate_id,
                 importing_crate,
@@ -154,8 +174,15 @@ fn resolve_path_to_ns(
                 def_maps,
             )
         }
+
+        crate::ast::PathKind::Dep => resolve_external_dep(
+            def_map,
+            import_directive,
+            def_maps,
+            importing_crate,
+        ),
     }
-}
+}   
 
 fn resolve_path_from_crate_root(
     crate_id: CrateId,
@@ -270,8 +297,9 @@ fn resolve_external_dep(
         .get(&crate_name.0.contents)
         .ok_or_else(|| PathResolutionError::Unresolved(crate_name.to_owned()))?;
 
-    // Create an import directive for the dependency crate
-    let path_without_crate_name = &path[1..]; // XXX: This will panic if the path is of the form `use dep::std` Ideal algorithm will not distinguish between crate and module
+    // XXX: This will panic if the path is of the form `use std`. Ideal algorithm will not distinguish between crate and module
+    // See `singleton_import.nr` test case for a check that such cases are handled elsewhere.
+    let path_without_crate_name = &path[1..];
 
     let path = Path {
         segments: path_without_crate_name.to_vec(),

--- a/noir/noir-repo/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/noir/noir-repo/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -158,12 +158,7 @@ fn resolve_path_to_ns(
             let first_segment = import_path.first().expect("ice: could not fetch first segment");
             if current_mod.find_name(first_segment).is_none() {
                 // Resolve externally when first segment is unresolved
-                return resolve_external_dep(
-                    def_map,
-                    import_directive,
-                    def_maps,
-                    importing_crate,
-                );
+                return resolve_external_dep(def_map, import_directive, def_maps, importing_crate);
             }
 
             resolve_name_in_module(
@@ -175,14 +170,11 @@ fn resolve_path_to_ns(
             )
         }
 
-        crate::ast::PathKind::Dep => resolve_external_dep(
-            def_map,
-            import_directive,
-            def_maps,
-            importing_crate,
-        ),
+        crate::ast::PathKind::Dep => {
+            resolve_external_dep(def_map, import_directive, def_maps, importing_crate)
+        }
     }
-}   
+}
 
 fn resolve_path_from_crate_root(
     crate_id: CrateId,

--- a/noir/noir-repo/compiler/noirc_frontend/src/noir_parser.lalrpop
+++ b/noir/noir-repo/compiler/noirc_frontend/src/noir_parser.lalrpop
@@ -125,7 +125,7 @@ pub(crate) Path: Path = {
     },
 
     <lo:@L> "dep" "::" <segments:PathSegments> <hi:@R> => {
-        let kind = PathKind::Dep;
+        let kind = PathKind::Plain;
         let span = Span::from(lo as u32..hi as u32);
         Path { segments, kind, span }
     },

--- a/noir/noir-repo/compiler/noirc_frontend/src/parser/parser.rs
+++ b/noir/noir-repo/compiler/noirc_frontend/src/parser/parser.rs
@@ -1633,7 +1633,7 @@ mod test {
             "use foo::{bar, hello}",
             "use foo::{bar as bar2, hello}",
             "use foo::{bar as bar2, hello::{foo}, nested::{foo, bar}}",
-            "use dep::{std::println, bar::baz}",
+            "use std::{println, bar::baz}",
         ];
 
         let invalid_use_statements = [

--- a/noir/noir-repo/test_programs/benchmarks/bench_eddsa_poseidon/src/main.nr
+++ b/noir/noir-repo/test_programs/benchmarks/bench_eddsa_poseidon/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::eddsa::{eddsa_poseidon_verify};
+use std::eddsa::{eddsa_poseidon_verify};
 
 fn main(
     msg: pub Field,

--- a/noir/noir-repo/test_programs/benchmarks/bench_poseidon_hash/src/main.nr
+++ b/noir/noir-repo/test_programs/benchmarks/bench_poseidon_hash/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::hash::poseidon;
+use std::hash::poseidon;
 
 fn main(input: [Field; 2]) -> pub Field {
     poseidon::bn254::hash_2(input)

--- a/noir/noir-repo/test_programs/benchmarks/bench_poseidon_hash_100/src/main.nr
+++ b/noir/noir-repo/test_programs/benchmarks/bench_poseidon_hash_100/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::hash;
+use std::hash;
 
 global SIZE = 100;
 

--- a/noir/noir-repo/test_programs/benchmarks/bench_poseidon_hash_30/src/main.nr
+++ b/noir/noir-repo/test_programs/benchmarks/bench_poseidon_hash_30/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::hash;
+use std::hash;
 
 global SIZE = 30;
 

--- a/noir/noir-repo/test_programs/benchmarks/bench_sha256/src/main.nr
+++ b/noir/noir-repo/test_programs/benchmarks/bench_sha256/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(input: [u8; 2]) -> pub [u8; 32] {
     std::hash::sha256(input)

--- a/noir/noir-repo/test_programs/benchmarks/bench_sha256_100/src/main.nr
+++ b/noir/noir-repo/test_programs/benchmarks/bench_sha256_100/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 global SIZE = 100;
 

--- a/noir/noir-repo/test_programs/benchmarks/bench_sha256_30/src/main.nr
+++ b/noir/noir-repo/test_programs/benchmarks/bench_sha256_30/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 global SIZE = 30;
 

--- a/noir/noir-repo/test_programs/compile_failure/array_length_defaulting/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_failure/array_length_defaulting/src/main.nr
@@ -1,5 +1,5 @@
 fn main() {
-    let x = dep::std::unsafe::zeroed();
+    let x = std::unsafe::zeroed();
     foo(x);
 }
 

--- a/noir/noir-repo/test_programs/compile_failure/assert_constant_fail/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_failure/assert_constant_fail/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::assert_constant;
+use std::assert_constant;
 
 fn main(x: Field) {
     foo(5, x);

--- a/noir/noir-repo/test_programs/compile_failure/negate_unsigned/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_failure/negate_unsigned/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main() {
     let var = -1 as u8;

--- a/noir/noir-repo/test_programs/compile_failure/restricted_bit_sizes/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_failure/restricted_bit_sizes/src/main.nr
@@ -1,5 +1,3 @@
-use dep::std::assert_constant;
-
 fn main() -> pub u63 {
     5
 }

--- a/noir/noir-repo/test_programs/compile_failure/turbofish_generic_count/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_failure/turbofish_generic_count/src/main.nr
@@ -18,5 +18,5 @@ fn foo<T>(bar: Bar<T>) {
 fn main(x: Field, y: pub Field) {
     let bar1: Bar<Field> = Bar { one: x, two: y, other: 0 };
 
-    assert(bar1.zeroed::<Field>() == 0);
+    assert(bar1.zeroed::<u32, Field>() == 0);
 }

--- a/noir/noir-repo/test_programs/compile_failure/turbofish_generic_count/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_failure/turbofish_generic_count/src/main.nr
@@ -7,7 +7,7 @@ struct Bar<T> {
 
 impl<T> Bar<T> {
     fn zeroed<A>(_self: Self) -> A {
-        dep::std::unsafe::zeroed()
+        std::unsafe::zeroed()
     }
 }
 
@@ -18,5 +18,5 @@ fn foo<T>(bar: Bar<T>) {
 fn main(x: Field, y: pub Field) {
     let bar1: Bar<Field> = Bar { one: x, two: y, other: 0 };
 
-    assert(bar1.zeroed::<u32, Field>() == 0);
+    assert(bar1.zeroed::<Field>() == 0);
 }

--- a/noir/noir-repo/test_programs/compile_success_empty/conditional_regression_to_bits/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/conditional_regression_to_bits/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main() {
     //Regression for to_le_bits() constant evaluation 

--- a/noir/noir-repo/test_programs/compile_success_empty/conditional_regression_to_bits/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/conditional_regression_to_bits/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main() {
     //Regression for to_le_bits() constant evaluation 
     // binary array representation of u8 1

--- a/noir/noir-repo/test_programs/compile_success_empty/ec_baby_jubjub/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/ec_baby_jubjub/src/main.nr
@@ -1,14 +1,14 @@
 // Tests may be checked against https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve/tree/main/poc
-use dep::std::ec::tecurve::affine::Curve as AffineCurve;
-use dep::std::ec::tecurve::affine::Point as Gaffine;
-use dep::std::ec::tecurve::curvegroup::Curve;
-use dep::std::ec::tecurve::curvegroup::Point as G;
+use std::ec::tecurve::affine::Curve as AffineCurve;
+use std::ec::tecurve::affine::Point as Gaffine;
+use std::ec::tecurve::curvegroup::Curve;
+use std::ec::tecurve::curvegroup::Point as G;
 
-use dep::std::ec::swcurve::affine::Point as SWGaffine;
-use dep::std::ec::swcurve::curvegroup::Point as SWG;
+use std::ec::swcurve::affine::Point as SWGaffine;
+use std::ec::swcurve::curvegroup::Point as SWG;
 
-use dep::std::ec::montcurve::affine::Point as MGaffine;
-use dep::std::ec::montcurve::curvegroup::Point as MG;
+use std::ec::montcurve::affine::Point as MGaffine;
+use std::ec::montcurve::curvegroup::Point as MG;
 
 fn main() {
     // This test only makes sense if Field is the right prime field.

--- a/noir/noir-repo/test_programs/compile_success_empty/intrinsic_die/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/intrinsic_die/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 // This test checks that we perform dead-instruction-elimination on intrinsic functions.
 fn main(x: Field) {
     let hash = std::hash::pedersen_commitment([x]);

--- a/noir/noir-repo/test_programs/compile_success_empty/method_call_regression/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/method_call_regression/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main() {
     // s: Struct<?, ()>

--- a/noir/noir-repo/test_programs/compile_success_empty/method_call_regression/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/method_call_regression/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main() {
     // s: Struct<?, ()>
     let s = Struct { b: () };

--- a/noir/noir-repo/test_programs/compile_success_empty/regression_2099/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/regression_2099/src/main.nr
@@ -1,13 +1,13 @@
-use dep::std::ec::tecurve::affine::Curve as AffineCurve;
-use dep::std::ec::tecurve::affine::Point as Gaffine;
-use dep::std::ec::tecurve::curvegroup::Curve;
-use dep::std::ec::tecurve::curvegroup::Point as G;
+use std::ec::tecurve::affine::Curve as AffineCurve;
+use std::ec::tecurve::affine::Point as Gaffine;
+use std::ec::tecurve::curvegroup::Curve;
+use std::ec::tecurve::curvegroup::Point as G;
 
-use dep::std::ec::swcurve::affine::Point as SWGaffine;
-use dep::std::ec::swcurve::curvegroup::Point as SWG;
+use std::ec::swcurve::affine::Point as SWGaffine;
+use std::ec::swcurve::curvegroup::Point as SWG;
 
-use dep::std::ec::montcurve::affine::Point as MGaffine;
-use dep::std::ec::montcurve::curvegroup::Point as MG;
+use std::ec::montcurve::affine::Point as MGaffine;
+use std::ec::montcurve::curvegroup::Point as MG;
 
 fn main() {
     // Define Baby Jubjub (ERC-2494) parameters in affine representation

--- a/noir/noir-repo/test_programs/compile_success_empty/regression_3635/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/regression_3635/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main() {
     let x: u8 = 0x61;

--- a/noir/noir-repo/test_programs/compile_success_empty/regression_3635/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/regression_3635/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main() {
     let x: u8 = 0x61;
     let y: u8 = "a".as_bytes()[0];

--- a/noir/noir-repo/test_programs/compile_success_empty/str_as_bytes/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/str_as_bytes/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 fn main() {
     let a = "hello";
     let b = a.as_bytes();

--- a/noir/noir-repo/test_programs/compile_success_empty/trait_default_implementation/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/trait_default_implementation/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 trait MyDefault {
     fn my_default(x: Field, y: Field) -> Self;

--- a/noir/noir-repo/test_programs/compile_success_empty/trait_default_implementation/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/trait_default_implementation/src/main.nr
@@ -1,4 +1,3 @@
-
 trait MyDefault {
     fn my_default(x: Field, y: Field) -> Self;
 

--- a/noir/noir-repo/test_programs/compile_success_empty/trait_override_implementation/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/trait_override_implementation/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 trait MyDefault {
     fn my_default(x: Field, y: Field) -> Self;

--- a/noir/noir-repo/test_programs/compile_success_empty/trait_override_implementation/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/trait_override_implementation/src/main.nr
@@ -1,4 +1,3 @@
-
 trait MyDefault {
     fn my_default(x: Field, y: Field) -> Self;
 

--- a/noir/noir-repo/test_programs/compile_success_empty/traits/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/traits/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 trait MyDefault {
     fn my_default(x: Field, y: Field) -> Self;

--- a/noir/noir-repo/test_programs/compile_success_empty/traits/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/traits/src/main.nr
@@ -1,4 +1,3 @@
-
 trait MyDefault {
     fn my_default(x: Field, y: Field) -> Self;
 }

--- a/noir/noir-repo/test_programs/compile_success_empty/vectors/src/main.nr
+++ b/noir/noir-repo/test_programs/compile_success_empty/vectors/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::collections::vec::Vec;
+use std::collections::vec::Vec;
 
 fn main(x: Field, y: pub Field) {
     let mut vector = Vec::new();

--- a/noir/noir-repo/test_programs/execution_failure/div_by_zero_constants/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_failure/div_by_zero_constants/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main() {
     let a: Field = 3 / 0;

--- a/noir/noir-repo/test_programs/execution_failure/div_by_zero_numerator_witness/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_failure/div_by_zero_numerator_witness/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(x: Field) {
     let a: Field = x / 0;

--- a/noir/noir-repo/test_programs/execution_failure/div_by_zero_witness/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_failure/div_by_zero_witness/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 // It is expected that `y` must be equal to 0.
 fn main(x: Field, y: pub Field) {
     let a: Field = x / y;

--- a/noir/noir-repo/test_programs/execution_failure/hashmap_load_factor/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_failure/hashmap_load_factor/src/main.nr
@@ -1,6 +1,6 @@
-use dep::std::collections::map::HashMap;
-use dep::std::hash::BuildHasherDefault;
-use dep::std::hash::poseidon2::Poseidon2Hasher;
+use std::collections::map::HashMap;
+use std::hash::BuildHasherDefault;
+use std::hash::poseidon2::Poseidon2Hasher;
 
 struct Entry{
     key: Field,

--- a/noir/noir-repo/test_programs/execution_success/4_sub/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/4_sub/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 // Test unsafe integer subtraction with underflow: 12 - 2418266113 = 1876701195 modulo 2^32
 fn main(mut x: u32, y: u32, z: u32) {
     x = std::wrapping_sub(x,y);

--- a/noir/noir-repo/test_programs/execution_success/5_over/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/5_over/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 // Test unsafe integer arithmetic
 // Test odd bits integer
 fn main(mut x: u32, y: u32) {

--- a/noir/noir-repo/test_programs/execution_success/6/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/6/src/main.nr
@@ -5,7 +5,6 @@
 // If you do not cast, it will take all the bytes from the field element!
 // Mimc input is an array of field elements
 // The function is called mimc_bn254 to emphasize its parameters are chosen for bn254 curve, it should be used only with a proving system using the same curve (e.g Plonk from Aztec)
-use dep::std;
 
 fn main(x: [u8; 5], result: pub [u8; 32]) {
     let mut digest = std::hash::sha256(x);

--- a/noir/noir-repo/test_programs/execution_success/6_array/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/6_array/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 //Basic tests for arrays
 fn main(x: [u32; 5], y: [u32; 5], mut z: u32, t: u32) {
     let mut c = 2301;

--- a/noir/noir-repo/test_programs/execution_success/7/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/7/src/main.nr
@@ -2,7 +2,6 @@
 //
 // Pre-alpha dependencies must now be prefixed with the word "dep".
 // The line below indicates that we would like to pull in the standard library dependency.
-use dep::std;
 
 fn main(x: [u8; 5], result: [u8; 32]) {
     let digest = std::hash::blake2s(x);

--- a/noir/noir-repo/test_programs/execution_success/aes128_encrypt/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/aes128_encrypt/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 unconstrained fn decode_ascii(ascii: u8) -> u8 {
     if ascii < 58 {

--- a/noir/noir-repo/test_programs/execution_success/aes128_encrypt/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/aes128_encrypt/src/main.nr
@@ -1,4 +1,3 @@
-
 unconstrained fn decode_ascii(ascii: u8) -> u8 {
     if ascii < 58 {
         ascii - 48

--- a/noir/noir-repo/test_programs/execution_success/array_dynamic_blackbox_input/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/array_dynamic_blackbox_input/src/main.nr
@@ -18,7 +18,7 @@ fn compute_root(leaf: [u8; 32], path: [u8; 64], _index: u32, root: [u8; 32]) {
             hash_input[j + b] = path[offset + j];
         }
 
-        current = dep::std::hash::sha256(hash_input);
+        current = std::hash::sha256(hash_input);
         index = index >> 1;
     }
 

--- a/noir/noir-repo/test_programs/execution_success/array_dynamic_nested_blackbox_input/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/array_dynamic_nested_blackbox_input/src/main.nr
@@ -15,6 +15,6 @@ fn main(mut x: [Foo; 3], y: pub Field, hash_result: pub [u8; 32]) {
     // Make sure that we are passing a dynamic array to the black box function call
     // by setting the array using a dynamic index here
     hash_input[y - 1] = 0;
-    let hash = dep::std::hash::sha256(hash_input);
+    let hash = std::hash::sha256(hash_input);
     assert_eq(hash, hash_result);
 }

--- a/noir/noir-repo/test_programs/execution_success/bigint/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/bigint/src/main.nr
@@ -1,5 +1,5 @@
-use dep::std::bigint;
-use dep::std::{bigint::Secpk1Fq, println};
+use std::bigint;
+use std::{bigint::Secpk1Fq, println};
 
 fn main(mut x: [u8; 5], y: [u8; 5]) {
     let a = bigint::Secpk1Fq::from_le_bytes(&[x[0], x[1], x[2], x[3], x[4]]);
@@ -10,8 +10,8 @@ fn main(mut x: [u8; 5], y: [u8; 5]) {
         a_be_bytes[31-i] = x[i];
         b_be_bytes[31-i] = y[i];
     }
-    let a_field = dep::std::field::bytes32_to_field(a_be_bytes);
-    let b_field = dep::std::field::bytes32_to_field(b_be_bytes);
+    let a_field = std::field::bytes32_to_field(a_be_bytes);
+    let b_field = std::field::bytes32_to_field(b_be_bytes);
 
     // Regression for issue #4682
     let c = if x[0] != 0 {
@@ -19,7 +19,7 @@ fn main(mut x: [u8; 5], y: [u8; 5]) {
     } else {
         test_unconstrained2(a, b)
     };
-    assert(c.array[0] == dep::std::wrapping_mul(x[0], y[0]));
+    assert(c.array[0] == std::wrapping_mul(x[0], y[0]));
 
     let a_bytes = a.to_le_bytes();
     let b_bytes = b.to_le_bytes();

--- a/noir/noir-repo/test_programs/execution_success/blake3/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/blake3/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(x: [u8; 5], result: [u8; 32]) {
     let digest = std::hash::blake3(x);

--- a/noir/noir-repo/test_programs/execution_success/blake3/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/blake3/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main(x: [u8; 5], result: [u8; 32]) {
     let digest = std::hash::blake3(x);
     assert(digest == result);

--- a/noir/noir-repo/test_programs/execution_success/brillig_blake2s/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_blake2s/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 // Tests a very simple program.
 // 
 // The features being tested is blake2s in brillig

--- a/noir/noir-repo/test_programs/execution_success/brillig_blake3/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_blake3/src/main.nr
@@ -1,4 +1,3 @@
-
 unconstrained fn main(x: [u8; 5], result: [u8; 32]) {
     let digest = std::hash::blake3(x);
     assert(digest == result);

--- a/noir/noir-repo/test_programs/execution_success/brillig_blake3/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_blake3/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 unconstrained fn main(x: [u8; 5], result: [u8; 32]) {
     let digest = std::hash::blake3(x);

--- a/noir/noir-repo/test_programs/execution_success/brillig_block_parameter_liveness/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_block_parameter_liveness/src/main.nr
@@ -38,11 +38,11 @@ struct Outer {
 // If we don't take into account block parameter liveness, this function will need 5*500=2500 stack items
 unconstrained fn main(conditions: [bool; 5]) -> pub Outer {
     let out0 = if conditions[0] {
-        let mut outer: Outer = dep::std::unsafe::zeroed();
+        let mut outer: Outer = std::unsafe::zeroed();
         outer.middle_a.inner_a.a = 1;
         outer
     } else {
-        let mut outer: Outer= dep::std::unsafe::zeroed();
+        let mut outer: Outer= std::unsafe::zeroed();
         outer.middle_f.inner_c.d = 2;
         outer
     };

--- a/noir/noir-repo/test_programs/execution_success/brillig_cow_regression/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_cow_regression/src/main.nr
@@ -25,7 +25,7 @@ struct NewContractData {
 
 impl NewContractData {
     fn hash(self) -> Field {
-        dep::std::hash::pedersen_hash([self.contract_address, self.portal_contract_address])
+        std::hash::pedersen_hash([self.contract_address, self.portal_contract_address])
     }
 }
 
@@ -173,6 +173,6 @@ unconstrained fn main(kernel_data: DataToHash) -> pub [Field; NUM_FIELDS_PER_SHA
         }
     }
 
-    let sha_digest = dep::std::hash::sha256(hash_input_flattened);
+    let sha_digest = std::hash::sha256(hash_input_flattened);
     U256::from_bytes32(sha_digest).to_u128_limbs()
 }

--- a/noir/noir-repo/test_programs/execution_success/brillig_ecdsa_secp256k1/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_ecdsa_secp256k1/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 // Tests a very simple program.
 // 
 // The features being tested is ecdsa in brillig

--- a/noir/noir-repo/test_programs/execution_success/brillig_ecdsa_secp256r1/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_ecdsa_secp256r1/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 // Tests a very simple program.
 // 
 // The features being tested is ecdsa in brillig

--- a/noir/noir-repo/test_programs/execution_success/brillig_fns_as_values/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_fns_as_values/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 struct MyStruct {
     operation: fn (u32) -> u32,

--- a/noir/noir-repo/test_programs/execution_success/brillig_fns_as_values/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_fns_as_values/src/main.nr
@@ -1,4 +1,3 @@
-
 struct MyStruct {
     operation: fn (u32) -> u32,
 }

--- a/noir/noir-repo/test_programs/execution_success/brillig_hash_to_field/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_hash_to_field/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 // Tests a very simple program.
 // 
 // The features being tested is hash_to_field in brillig

--- a/noir/noir-repo/test_programs/execution_success/brillig_keccak/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_keccak/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 // Tests a very simple program.
 // 
 // The features being tested is keccak256 in brillig

--- a/noir/noir-repo/test_programs/execution_success/brillig_oracle/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_oracle/src/main.nr
@@ -1,5 +1,5 @@
-use dep::std::slice;
-use dep::std::test::OracleMock;
+use std::slice;
+use std::test::OracleMock;
 
 // Tests oracle usage in brillig/unconstrained functions
 fn main(_x: Field) {

--- a/noir/noir-repo/test_programs/execution_success/brillig_pedersen/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_pedersen/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 unconstrained fn main(x: Field, y: Field, salt: Field, out_x: Field, out_y: Field, out_hash: Field) {
     let res = std::hash::pedersen_commitment_with_separator([x, y], 0);

--- a/noir/noir-repo/test_programs/execution_success/brillig_pedersen/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_pedersen/src/main.nr
@@ -1,4 +1,3 @@
-
 unconstrained fn main(x: Field, y: Field, salt: Field, out_x: Field, out_y: Field, out_hash: Field) {
     let res = std::hash::pedersen_commitment_with_separator([x, y], 0);
     assert(res.x == out_x);

--- a/noir/noir-repo/test_programs/execution_success/brillig_sha256/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_sha256/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 // Tests a very simple program.
 // 
 // The features being tested is sha256 in brillig

--- a/noir/noir-repo/test_programs/execution_success/brillig_slices/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/brillig_slices/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::slice;
+use std::slice;
 unconstrained fn main(x: Field, y: Field) {
     let mut slice: [Field] = &[y, x];
     assert(slice.len() == 2);

--- a/noir/noir-repo/test_programs/execution_success/conditional_1/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/conditional_1/src/main.nr
@@ -1,4 +1,3 @@
-
 fn sort(mut a: [u32; 4]) -> [u32; 4] {
     for i in 1..4 {
         for j in 0..i {

--- a/noir/noir-repo/test_programs/execution_success/conditional_1/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/conditional_1/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn sort(mut a: [u32; 4]) -> [u32; 4] {
     for i in 1..4 {

--- a/noir/noir-repo/test_programs/execution_success/conditional_2/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/conditional_2/src/main.nr
@@ -1,4 +1,3 @@
-
 fn must_be_zero(x: u8) {
     assert(x == 0);
 }

--- a/noir/noir-repo/test_programs/execution_success/conditional_2/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/conditional_2/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn must_be_zero(x: u8) {
     assert(x == 0);

--- a/noir/noir-repo/test_programs/execution_success/conditional_regression_short_circuit/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/conditional_regression_short_circuit/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(a: u32, mut c: [u32; 4], x: [u8; 5], result: pub [u8; 32]) {
     //regression for short-circuit2

--- a/noir/noir-repo/test_programs/execution_success/conditional_regression_short_circuit/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/conditional_regression_short_circuit/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main(a: u32, mut c: [u32; 4], x: [u8; 5], result: pub [u8; 32]) {
     //regression for short-circuit2
     if 35 == a {

--- a/noir/noir-repo/test_programs/execution_success/databus/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/databus/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main(mut x: u32, y: call_data u32, z: call_data [u32; 4]) -> return_data u32 {
     let a = z[x];
     a + foo(y)

--- a/noir/noir-repo/test_programs/execution_success/databus/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/databus/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(mut x: u32, y: call_data u32, z: call_data [u32; 4]) -> return_data u32 {
     let a = z[x];

--- a/noir/noir-repo/test_programs/execution_success/double_verify_nested_proof/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/double_verify_nested_proof/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 // This circuit aggregates two recursive proofs from `double_verify_proof_recursive`.
 // Recursive aggregation is a backend-specific process and it is expected for backends 

--- a/noir/noir-repo/test_programs/execution_success/double_verify_proof/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/double_verify_proof/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 // This circuit aggregates two proofs from `assert_statement_recursive`.
 fn main(

--- a/noir/noir-repo/test_programs/execution_success/double_verify_proof_recursive/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/double_verify_proof_recursive/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 // This circuit aggregates two proofs from `assert_statement_recursive`.
 #[recursive]

--- a/noir/noir-repo/test_programs/execution_success/ecdsa_secp256k1/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/ecdsa_secp256k1/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main(
     message: [u8; 38],
     hashed_message: [u8; 32],

--- a/noir/noir-repo/test_programs/execution_success/ecdsa_secp256k1/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/ecdsa_secp256k1/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(
     message: [u8; 38],

--- a/noir/noir-repo/test_programs/execution_success/ecdsa_secp256r1/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/ecdsa_secp256r1/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main(hashed_message: [u8; 32], pub_key_x: [u8; 32], pub_key_y: [u8; 32], signature: [u8; 64]) {
     let valid_signature = std::ecdsa_secp256r1::verify_signature(pub_key_x, pub_key_y, signature, hashed_message);
     assert(valid_signature);

--- a/noir/noir-repo/test_programs/execution_success/ecdsa_secp256r1/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/ecdsa_secp256r1/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(hashed_message: [u8; 32], pub_key_x: [u8; 32], pub_key_y: [u8; 32], signature: [u8; 64]) {
     let valid_signature = std::ecdsa_secp256r1::verify_signature(pub_key_x, pub_key_y, signature, hashed_message);

--- a/noir/noir-repo/test_programs/execution_success/ecdsa_secp256r1_3x/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/ecdsa_secp256r1_3x/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main(
     hashed_message: [u8; 32],
     pub_key_x: [u8; 32],

--- a/noir/noir-repo/test_programs/execution_success/ecdsa_secp256r1_3x/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/ecdsa_secp256r1_3x/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(
     hashed_message: [u8; 32],

--- a/noir/noir-repo/test_programs/execution_success/eddsa/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/eddsa/src/main.nr
@@ -1,9 +1,9 @@
-use dep::std::compat;
-use dep::std::ec::consts::te::baby_jubjub;
-use dep::std::ec::tecurve::affine::Point as TEPoint;
-use dep::std::hash;
-use dep::std::eddsa::{eddsa_to_pub, eddsa_poseidon_verify, eddsa_verify};
-use dep::std::hash::poseidon2::Poseidon2Hasher;
+use std::compat;
+use std::ec::consts::te::baby_jubjub;
+use std::ec::tecurve::affine::Point as TEPoint;
+use std::hash;
+use std::eddsa::{eddsa_to_pub, eddsa_poseidon_verify, eddsa_verify};
+use std::hash::poseidon2::Poseidon2Hasher;
 
 fn main(msg: pub Field, _priv_key_a: Field, _priv_key_b: Field) {
     // Skip this test for non-bn254 backends

--- a/noir/noir-repo/test_programs/execution_success/embedded_curve_ops/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/embedded_curve_ops/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(priv_key: Field, pub_x: pub Field, pub_y: pub Field) {
     let g1_y = 17631683881184975370165255887551781615748388533673675138860;

--- a/noir/noir-repo/test_programs/execution_success/embedded_curve_ops/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/embedded_curve_ops/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main(priv_key: Field, pub_x: pub Field, pub_y: pub Field) {
     let g1_y = 17631683881184975370165255887551781615748388533673675138860;
     let g1 = std::embedded_curve_ops::EmbeddedCurvePoint { x: 1, y: g1_y, is_infinite: false };

--- a/noir/noir-repo/test_programs/execution_success/fold_numeric_generic_poseidon/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/fold_numeric_generic_poseidon/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::hash::{pedersen_hash_with_separator, poseidon2::Poseidon2};
+use std::hash::{pedersen_hash_with_separator, poseidon2::Poseidon2};
 
 global NUM_HASHES = 2;
 global HASH_LENGTH = 10;

--- a/noir/noir-repo/test_programs/execution_success/generics/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/generics/src/main.nr
@@ -34,7 +34,7 @@ impl Bar<Field> {
 impl<T> Bar<T> {
     // This is to test that we can use turbofish on methods as well
     fn zeroed<A>(_self: Self) -> A {
-        dep::std::unsafe::zeroed()
+        std::unsafe::zeroed()
     }
 }
 

--- a/noir/noir-repo/test_programs/execution_success/hash_to_field/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/hash_to_field/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(input: Field) -> pub Field {
     std::hash::hash_to_field(&[input])

--- a/noir/noir-repo/test_programs/execution_success/hash_to_field/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/hash_to_field/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main(input: Field) -> pub Field {
     std::hash::hash_to_field(&[input])
 }

--- a/noir/noir-repo/test_programs/execution_success/hashmap/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/hashmap/src/main.nr
@@ -3,7 +3,6 @@ mod utils;
 use std::collections::map::HashMap;
 use std::hash::BuildHasherDefault;
 use std::hash::poseidon2::Poseidon2Hasher;
-use std::cmp::Eq;
 
 use utils::cut;
 

--- a/noir/noir-repo/test_programs/execution_success/hashmap/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/hashmap/src/main.nr
@@ -1,9 +1,9 @@
 mod utils;
 
-use dep::std::collections::map::HashMap;
-use dep::std::hash::BuildHasherDefault;
-use dep::std::hash::poseidon2::Poseidon2Hasher;
-use dep::std::cmp::Eq;
+use std::collections::map::HashMap;
+use std::hash::BuildHasherDefault;
+use std::hash::poseidon2::Poseidon2Hasher;
+use std::cmp::Eq;
 
 use utils::cut;
 

--- a/noir/noir-repo/test_programs/execution_success/import/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/import/src/main.nr
@@ -2,7 +2,7 @@ mod import;
 use crate::import::hello;
 
 fn main(x: Field, y: Field) {
-    let _k = dep::std::hash::pedersen_commitment([x]);
+    let _k = std::hash::pedersen_commitment([x]);
     let _l = hello(x);
 
     assert(x != import::hello(y));

--- a/noir/noir-repo/test_programs/execution_success/is_unconstrained/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/is_unconstrained/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::runtime::is_unconstrained;
+use std::runtime::is_unconstrained;
 
 fn check(should_be_unconstrained: bool) {
     assert_eq(should_be_unconstrained, is_unconstrained());

--- a/noir/noir-repo/test_programs/execution_success/keccak256/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/keccak256/src/main.nr
@@ -1,5 +1,4 @@
 // docs:start:keccak256
-use dep::std;
 
 fn main(x: Field, result: [u8; 32]) {
     // We use the `as` keyword here to denote the fact that we want to take just the first byte from the x Field

--- a/noir/noir-repo/test_programs/execution_success/merkle_insert/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/merkle_insert/src/main.nr
@@ -1,5 +1,4 @@
-use dep::std;
-use dep::std::hash::mimc;
+use std::hash::mimc;
 
 fn main(
     old_root: Field,

--- a/noir/noir-repo/test_programs/execution_success/modulus/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/modulus/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main(bn254_modulus_be_bytes: [u8; 32], bn254_modulus_be_bits: [u1; 254]) {
     let modulus_size = std::field::modulus_num_bits();
     // NOTE: The constraints used in this circuit will only work when testing nargo with the plonk bn254 backend

--- a/noir/noir-repo/test_programs/execution_success/modulus/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/modulus/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(bn254_modulus_be_bytes: [u8; 32], bn254_modulus_be_bits: [u1; 254]) {
     let modulus_size = std::field::modulus_num_bits();

--- a/noir/noir-repo/test_programs/execution_success/no_predicates_numeric_generic_poseidon/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/no_predicates_numeric_generic_poseidon/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::hash::{pedersen_hash_with_separator, poseidon2::Poseidon2};
+use std::hash::{pedersen_hash_with_separator, poseidon2::Poseidon2};
 
 global NUM_HASHES = 2;
 global HASH_LENGTH = 10;

--- a/noir/noir-repo/test_programs/execution_success/operator_overloading/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/operator_overloading/src/main.nr
@@ -1,5 +1,5 @@
-use dep::std::ops::{Add, Sub, Mul, Div, Rem, BitAnd, BitOr, BitXor, Shl, Shr};
-use dep::std::cmp::Ordering;
+use std::ops::{Add, Sub, Mul, Div, Rem, BitAnd, BitOr, BitXor, Shl, Shr};
+use std::cmp::Ordering;
 
 // x = 3, y = 9
 fn main(x: u32, y: u32) {

--- a/noir/noir-repo/test_programs/execution_success/pedersen_check/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/pedersen_check/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(x: Field, y: Field, salt: Field, out_x: Field, out_y: Field, out_hash: Field) {
     let res = std::hash::pedersen_commitment([x, y]);

--- a/noir/noir-repo/test_programs/execution_success/pedersen_check/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/pedersen_check/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main(x: Field, y: Field, salt: Field, out_x: Field, out_y: Field, out_hash: Field) {
     let res = std::hash::pedersen_commitment([x, y]);
     assert(res.x == out_x);

--- a/noir/noir-repo/test_programs/execution_success/pedersen_commitment/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/pedersen_commitment/src/main.nr
@@ -1,5 +1,4 @@
 // docs:start:pedersen-commitment
-use dep::std;
 
 fn main(x: Field, y: Field, expected_commitment: std::embedded_curve_ops::EmbeddedCurvePoint) {
     let commitment = std::hash::pedersen_commitment([x, y]);

--- a/noir/noir-repo/test_programs/execution_success/pedersen_hash/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/pedersen_hash/src/main.nr
@@ -1,5 +1,4 @@
 // docs:start:pedersen-hash
-use dep::std;
 
 fn main(x: Field, y: Field, expected_hash: Field) {
     let hash = std::hash::pedersen_hash([x, y]);

--- a/noir/noir-repo/test_programs/execution_success/poseidon_bn254_hash/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/poseidon_bn254_hash/src/main.nr
@@ -1,6 +1,6 @@
 // docs:start:poseidon
-use dep::std::hash::poseidon;
-use dep::std::hash::poseidon2;
+use std::hash::poseidon;
+use std::hash::poseidon2;
 
 fn main(x1: [Field; 2], y1: pub Field, x2: [Field; 4], y2: pub Field, x3: [Field; 4], y3: Field) {
     let hash1 = poseidon::bn254::hash_2(x1);

--- a/noir/noir-repo/test_programs/execution_success/poseidonsponge_x5_254/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/poseidonsponge_x5_254/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::hash::poseidon;
+use std::hash::poseidon;
 
 fn main(x: [Field; 7]) {
     // Test optimized sponge

--- a/noir/noir-repo/test_programs/execution_success/prelude/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/prelude/src/main.nr
@@ -8,8 +8,8 @@ fn main() {
 
 mod a {
     // We don't want to give an error due to re-importing elements that are already in the prelude.
-    use dep::std::collections::vec::Vec;
-    use dep::std::option::Option;
+    use std::collections::vec::Vec;
+    use std::option::Option;
 
     fn main() {
         let _xs = Vec::new();

--- a/noir/noir-repo/test_programs/execution_success/regression_3051/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/regression_3051/src/main.nr
@@ -19,6 +19,6 @@ impl Bar for u64 {
 }
 
 fn main() {
-    dep::std::println(1.foo());
-    dep::std::println(1.bar());
+    std::println(1.foo());
+    std::println(1.bar());
 }

--- a/noir/noir-repo/test_programs/execution_success/regression_3394/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/regression_3394/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main() {
     let x : i8 = -128;
     std::println(x);

--- a/noir/noir-repo/test_programs/execution_success/regression_3394/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/regression_3394/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main() {
     let x : i8 = -128;

--- a/noir/noir-repo/test_programs/execution_success/regression_4124/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/regression_4124/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::option::Option;
+use std::option::Option;
 
 trait MyDeserialize<N> {
     fn deserialize(fields: [Field; N]) -> Self;
@@ -11,7 +11,7 @@ impl MyDeserialize<1> for Field {
 }
 
 pub fn storage_read<N>() -> [Field; N] {
-    dep::std::unsafe::zeroed()
+    std::unsafe::zeroed()
 }
 
 struct PublicMutable<T> {

--- a/noir/noir-repo/test_programs/execution_success/regression_4449/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/regression_4449/src/main.nr
@@ -1,5 +1,4 @@
 // Regression test for issue #4449
-use dep::std;
 
 fn main(x: u8, result: [u8; 32]) {
     let x = x % 31;

--- a/noir/noir-repo/test_programs/execution_success/regression_5045/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/regression_5045/src/main.nr
@@ -1,5 +1,5 @@
-use dep::std::embedded_curve_ops::EmbeddedCurvePoint;
-use dep::std::embedded_curve_ops::EmbeddedCurveScalar;
+use std::embedded_curve_ops::EmbeddedCurvePoint;
+use std::embedded_curve_ops::EmbeddedCurveScalar;
 
 fn main(is_active: bool) {
     let a = EmbeddedCurvePoint {
@@ -11,7 +11,7 @@ fn main(is_active: bool) {
     if is_active {
         let bad = EmbeddedCurvePoint { x: 0, y: 5, is_infinite: false };
         let d = bad.double();
-        let e = dep::std::embedded_curve_ops::multi_scalar_mul(
+        let e = std::embedded_curve_ops::multi_scalar_mul(
             [a, bad],
             [EmbeddedCurveScalar { lo: 1, hi: 0 }, EmbeddedCurveScalar { lo: 1, hi: 0 }]
         );

--- a/noir/noir-repo/test_programs/execution_success/regression_method_cannot_be_found/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/regression_method_cannot_be_found/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 struct Item {
     id: Field,
 }

--- a/noir/noir-repo/test_programs/execution_success/schnorr/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/schnorr/src/main.nr
@@ -1,5 +1,4 @@
-use dep::std;
-use dep::std::embedded_curve_ops;
+use std::embedded_curve_ops;
 
 // Note: If main has any unsized types, then the verifier will never be able
 // to figure out the circuit instance

--- a/noir/noir-repo/test_programs/execution_success/schnorr/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/schnorr/src/main.nr
@@ -36,11 +36,7 @@ fn main(
 // Meanwhile, you have to use a message with 32 additional bytes:
 // If you want to verify a signature on a message of 10 bytes, you need to pass a message of length 42,
 // where the first 10 bytes are the one from the original message (the other bytes are not used)
-pub fn verify_signature_noir<M>(
-    public_key: embedded_curve_ops::EmbeddedCurvePoint,
-    signature: [u8; 64],
-    message: [u8; M]
-) -> bool {
+pub fn verify_signature_noir<M>(public_key: embedded_curve_ops::EmbeddedCurvePoint, signature: [u8; 64], message: [u8; M]) -> bool {
     let N = message.len() - 32;
 
     //scalar lo/hi from bytes
@@ -89,11 +85,7 @@ pub fn bytes_to_scalar(bytes: [u8; 64], offset: u32) -> embedded_curve_ops::Embe
     sig_s
 }
 
-pub fn assert_valid_signature<M>(
-    public_key: embedded_curve_ops::EmbeddedCurvePoint,
-    signature: [u8; 64],
-    message: [u8; M]
-) {
+pub fn assert_valid_signature<M>(public_key: embedded_curve_ops::EmbeddedCurvePoint, signature: [u8; 64], message: [u8; M]) {
     let N = message.len() - 32;
     //scalar lo/hi from bytes
     let sig_s = bytes_to_scalar(signature, 0);

--- a/noir/noir-repo/test_programs/execution_success/sha256/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/sha256/src/main.nr
@@ -9,7 +9,6 @@
 //
 // Not yet here: For R1CS, it is more about manipulating arithmetic gates to get performance
 // This can be done in ACIR!
-use dep::std;
 
 fn main(x: Field, result: [u8; 32]) {
     // We use the `as` keyword here to denote the fact that we want to take just the first byte from the x Field

--- a/noir/noir-repo/test_programs/execution_success/sha2_byte/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/sha2_byte/src/main.nr
@@ -1,5 +1,4 @@
 // Test Noir implementations of SHA256 and SHA512 on a one-byte message.
-use dep::std;
 
 fn main(x: Field, result256: [u8; 32], result512: [u8; 64]) {
     let digest256 = std::sha256::digest([x as u8]);

--- a/noir/noir-repo/test_programs/execution_success/signed_comparison/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/signed_comparison/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main(mut x: i8, mut y: i8, z: i8) {
     let mut s1: i8 = 5;
     let mut s2: i8 = 8;

--- a/noir/noir-repo/test_programs/execution_success/signed_comparison/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/signed_comparison/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(mut x: i8, mut y: i8, z: i8) {
     let mut s1: i8 = 5;

--- a/noir/noir-repo/test_programs/execution_success/signed_division/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/signed_division/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 // Testing signed integer division: 
 //  7/3  = 2
 // -7/3  = -2

--- a/noir/noir-repo/test_programs/execution_success/simple_print/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/simple_print/src/main.nr
@@ -1,6 +1,5 @@
 // Simple program for testing the logging
 // of single witnesses and witness arrays.
-use dep::std;
 
 fn main(x: Field, y: pub Field) {
     std::println(x);

--- a/noir/noir-repo/test_programs/execution_success/simple_shield/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/simple_shield/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(
     // Public key of note

--- a/noir/noir-repo/test_programs/execution_success/simple_shield/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/simple_shield/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main(
     // Public key of note
   // all notes have the same denomination

--- a/noir/noir-repo/test_programs/execution_success/slice_coercion/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/slice_coercion/src/main.nr
@@ -23,5 +23,5 @@ fn main(expected: pub Field, first: Field) {
 fn regression_4967() {
     let var1: [(i32, u8)] = [(1, 2)];
     assert(var1.len() == 1);
-    dep::std::println(var1);
+    std::println(var1);
 }

--- a/noir/noir-repo/test_programs/execution_success/slices/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/slices/src/main.nr
@@ -1,5 +1,4 @@
-use dep::std::slice;
-use dep::std;
+use std::slice;
 
 fn main(x: Field, y: pub Field) {
     let mut slice = &[0; 2];

--- a/noir/noir-repo/test_programs/execution_success/strings/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/strings/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 // Test global string literals
 global HELLO_WORLD = "hello world";
 

--- a/noir/noir-repo/test_programs/execution_success/to_bits/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/to_bits/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main() {
     let field = 1000;

--- a/noir/noir-repo/test_programs/execution_success/to_bits/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/to_bits/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main() {
     let field = 1000;
     let be_bits = field.to_be_bits(16);

--- a/noir/noir-repo/test_programs/execution_success/to_bytes_integration/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/to_bytes_integration/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(x: Field, a: Field) {
     let y: Field = 2040124;

--- a/noir/noir-repo/test_programs/execution_success/to_bytes_integration/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/to_bytes_integration/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main(x: Field, a: Field) {
     let y: Field = 2040124;
     let be_byte_array = y.to_be_bytes(31);

--- a/noir/noir-repo/test_programs/execution_success/trait_method_mut_self/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/trait_method_mut_self/src/main.nr
@@ -1,5 +1,5 @@
-use dep::std::hash::Hasher;
-use dep::std::hash::poseidon2::Poseidon2Hasher;
+use std::hash::Hasher;
+use std::hash::poseidon2::Poseidon2Hasher;
 
 fn main(x: Field, y: pub Field) {
     let mut a_mut_ref = AType { x };

--- a/noir/noir-repo/test_programs/execution_success/turbofish_call_func_diff_types/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/turbofish_call_func_diff_types/src/main.nr
@@ -1,6 +1,6 @@
-use dep::std::hash::Hasher;
-use dep::std::hash::poseidon2::Poseidon2Hasher;
-use dep::std::hash::poseidon::PoseidonHasher;
+use std::hash::Hasher;
+use std::hash::poseidon2::Poseidon2Hasher;
+use std::hash::poseidon::PoseidonHasher;
 
 fn main(x: Field, y: pub Field) {
     let mut hasher = PoseidonHasher::default();

--- a/noir/noir-repo/test_programs/execution_success/u128/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/u128/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(mut x: u32, y: u32, z: u32, big_int: U128, hexa: str<7>) {
     let a = U128::from_u64s_le(x as u64, x as u64);

--- a/noir/noir-repo/test_programs/execution_success/u128/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/u128/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main(mut x: u32, y: u32, z: u32, big_int: U128, hexa: str<7>) {
     let a = U128::from_u64s_le(x as u64, x as u64);
     let b = U128::from_u64s_le(y as u64, x as u64);

--- a/noir/noir-repo/test_programs/execution_success/unit_value/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/unit_value/src/main.nr
@@ -1,5 +1,5 @@
 fn get_transaction() {
-    dep::std::unsafe::zeroed()
+    std::unsafe::zeroed()
 }
 
 fn main() {

--- a/noir/noir-repo/test_programs/execution_success/verify_honk_proof/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/verify_honk_proof/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 // This circuit aggregates a single Honk proof from `assert_statement_recursive`.
 fn main(

--- a/noir/noir-repo/test_programs/execution_success/wrapping_operations/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/wrapping_operations/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main(x: u8, y: u8) {
     assert(std::wrapping_sub(x, 1) == y);
     assert(std::wrapping_add(y, 1) == x);

--- a/noir/noir-repo/test_programs/execution_success/wrapping_operations/src/main.nr
+++ b/noir/noir-repo/test_programs/execution_success/wrapping_operations/src/main.nr
@@ -1,4 +1,3 @@
-use dep::std;
 
 fn main(x: u8, y: u8) {
     assert(std::wrapping_sub(x, 1) == y);

--- a/noir/noir-repo/test_programs/noir_test_failure/should_fail_mismatch/src/main.nr
+++ b/noir/noir-repo/test_programs/noir_test_failure/should_fail_mismatch/src/main.nr
@@ -11,5 +11,5 @@ fn test_with_extra_space() {
 #[test(should_fail_with = "Not equal")]
 fn test_runtime_mismatch() {
     // We use a pedersen commitment here so that the assertion failure is only known at runtime.
-    assert_eq(dep::std::hash::pedersen_commitment([27]).x, 0, "Not equal ");
+    assert_eq(std::hash::pedersen_commitment([27]).x, 0, "Not equal ");
 }

--- a/noir/noir-repo/test_programs/noir_test_success/brillig_overflow_checks/src/main.nr
+++ b/noir/noir-repo/test_programs/noir_test_success/brillig_overflow_checks/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::field::bn254::{TWO_POW_128, assert_gt};
+use std::field::bn254::{TWO_POW_128, assert_gt};
 
 #[test(should_fail_with = "attempt to add with overflow")]
 unconstrained fn test_overflow_add() {

--- a/noir/noir-repo/test_programs/noir_test_success/embedded_curve_ops/src/main.nr
+++ b/noir/noir-repo/test_programs/noir_test_success/embedded_curve_ops/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::embedded_curve_ops::{EmbeddedCurvePoint, EmbeddedCurveScalar, multi_scalar_mul};
+use std::embedded_curve_ops::{EmbeddedCurvePoint, EmbeddedCurveScalar, multi_scalar_mul};
 
 #[test]
     

--- a/noir/noir-repo/test_programs/noir_test_success/field_comparisons/src/main.nr
+++ b/noir/noir-repo/test_programs/noir_test_success/field_comparisons/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::field::bn254::{TWO_POW_128, assert_gt};
+use std::field::bn254::{TWO_POW_128, assert_gt};
 
 #[test(should_fail)]
 fn test_assert_gt_should_fail_eq() {

--- a/noir/noir-repo/test_programs/noir_test_success/mock_oracle/src/main.nr
+++ b/noir/noir-repo/test_programs/noir_test_success/mock_oracle/src/main.nr
@@ -1,4 +1,4 @@
-use dep::std::test::OracleMock;
+use std::test::OracleMock;
 
 struct Point {
     x: Field,

--- a/noir/noir-repo/test_programs/noir_test_success/should_fail_with_matches/src/main.nr
+++ b/noir/noir-repo/test_programs/noir_test_success/should_fail_with_matches/src/main.nr
@@ -10,21 +10,21 @@ fn test_should_fail_without_match() {
 
 #[test(should_fail_with = "Not equal")]
 fn test_should_fail_with_runtime_match() {
-    assert_eq(dep::std::hash::pedersen_commitment([27]).x, 0, "Not equal");
+    assert_eq(std::hash::pedersen_commitment([27]).x, 0, "Not equal");
 }
 
 #[test(should_fail)]
 fn test_should_fail_without_runtime_match() {
-    assert_eq(dep::std::hash::pedersen_commitment([27]).x, 0);
+    assert_eq(std::hash::pedersen_commitment([27]).x, 0);
 }
 
 struct InvalidPointError {
-    point: dep::std::embedded_curve_ops::EmbeddedCurvePoint,
+    point: std::embedded_curve_ops::EmbeddedCurvePoint,
 }
 
 #[test(should_fail_with = "InvalidPointError { point: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8, is_infinite: false } }")]
 fn test_should_fail_with_struct() {
-    let hash = dep::std::hash::pedersen_commitment([27]);
+    let hash = std::hash::pedersen_commitment([27]);
     assert_eq(hash.x, 0, InvalidPointError { point: hash });
 }
 
@@ -37,7 +37,7 @@ fn test_should_fail_with_basic_type_fmt_string() {
 
 #[test(should_fail_with = "Invalid hash: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8, is_infinite: false }")]
 fn test_should_fail_with_struct_fmt_string() {
-    let hash = dep::std::hash::pedersen_commitment([27]);
+    let hash = std::hash::pedersen_commitment([27]);
     assert_eq(hash.x, 0, f"Invalid hash: {hash}");
 }
 
@@ -55,17 +55,17 @@ unconstrained fn unconstrained_test_should_fail_without_match() {
 
 #[test(should_fail_with = "Not equal")]
 unconstrained fn unconstrained_test_should_fail_with_runtime_match() {
-    assert_eq(dep::std::hash::pedersen_commitment([27]).x, 0, "Not equal");
+    assert_eq(std::hash::pedersen_commitment([27]).x, 0, "Not equal");
 }
 
 #[test(should_fail)]
 unconstrained fn unconstrained_test_should_fail_without_runtime_match() {
-    assert_eq(dep::std::hash::pedersen_commitment([27]).x, 0);
+    assert_eq(std::hash::pedersen_commitment([27]).x, 0);
 }
 
 #[test(should_fail_with = "InvalidPointError { point: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8, is_infinite: false } }")]
 unconstrained fn unconstrained_test_should_fail_with_struct() {
-    let hash = dep::std::hash::pedersen_commitment([27]);
+    let hash = std::hash::pedersen_commitment([27]);
     assert_eq(hash.x, 0, InvalidPointError { point: hash });
 }
 
@@ -78,6 +78,6 @@ unconstrained fn unconstrained_test_should_fail_with_basic_type_fmt_string() {
 
 #[test(should_fail_with = "Invalid hash: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8, is_infinite: false }")]
 unconstrained fn unconstrained_test_should_fail_with_struct_fmt_string() {
-    let hash = dep::std::hash::pedersen_commitment([27]);
+    let hash = std::hash::pedersen_commitment([27]);
     assert_eq(hash.x, 0, f"Invalid hash: {hash}");
 }


### PR DESCRIPTION
This PR pulls out the `dep::` change from the sync PR so we can remove a lot of the diff.