### PR TITLE
feat: add outgoing keys support to getEvents

### DIFF
--- a/noir-projects/noir-contracts/contracts/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_log_contract/src/main.nr
@@ -1,6 +1,9 @@
 contract TestLog {
     use dep::aztec::prelude::PrivateSet;
-    use dep::aztec::protocol_types::{traits::Serialize, grumpkin_point::GrumpkinPoint, grumpkin_private_key::GrumpkinPrivateKey};
+    use dep::aztec::protocol_types::{
+        traits::Serialize, grumpkin_point::GrumpkinPoint, grumpkin_private_key::GrumpkinPrivateKey,
+        address::AztecAddress
+    };
     use dep::value_note::value_note::ValueNote;
     use dep::aztec::encrypted_logs::incoming_body::EncryptedLogIncomingBody;
     use dep::aztec::event::event_interface::EventInterface;
@@ -42,15 +45,27 @@ contract TestLog {
     }
 
     #[aztec(private)]
-    fn emit_encrypted_events(randomness: [Field; 2], preimages: [Field; 4]) {
+    fn emit_encrypted_events(other: AztecAddress, randomness: [Field; 2], preimages: [Field; 4]) {
         let event0 = ExampleEvent0 { value0: preimages[0], value1: preimages[1] };
 
         event0.emit(
             encode_and_encrypt_event(
                 &mut context,
                 randomness[0],
-                context.msg_sender(),
+                // outgoing is set to other, incoming is set to msg sender
+                other,
                 context.msg_sender()
+            )
+        );
+
+        // We duplicate the emission, but specifying different incoming and outgoing parties
+        event0.emit(
+            encode_and_encrypt_event(
+                &mut context,
+                randomness[0],
+                // outgoing is set to msg sender, incoming is set to other
+                context.msg_sender(),
+                other
             )
         );
 
@@ -60,7 +75,8 @@ contract TestLog {
             encode_and_encrypt_event(
                 &mut context,
                 randomness[1],
-                context.msg_sender(),
+                // outgoing is set to other, incoming is set to msg sender
+                other,
                 context.msg_sender()
             )
         );

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -187,8 +187,11 @@ export abstract class BaseWallet implements Wallet {
     eventMetadata: EventMetadata<T>,
     from: number,
     limit: number,
-    ivpk: Point = this.getCompleteAddress().publicKeys.masterIncomingViewingPublicKey,
+    vpks: Point[] = [
+      this.getCompleteAddress().publicKeys.masterIncomingViewingPublicKey,
+      this.getCompleteAddress().publicKeys.masterOutgoingViewingPublicKey,
+    ],
   ) {
-    return this.pxe.getEvents(type, eventMetadata, from, limit, ivpk);
+    return this.pxe.getEvents(type, eventMetadata, from, limit, vpks);
   }
 }

--- a/yarn-project/circuit-types/src/interfaces/pxe.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.ts
@@ -386,7 +386,7 @@ export interface PXE {
    * @param eventMetadata - Identifier of the event. This should be the class generated from the contract. e.g. Contract.events.Event
    * @param from - The block number to search from.
    * @param limit - The amount of blocks to search.
-   * @param ivpk - (Used for encrypted logs only) The incoming viewing public key that corresponds to the incoming viewing secret key that can decrypt the log.
+   * @param vpks - (Used for encrypted logs only) The viewing (incoming and outgoing) public keys that correspond to the viewing secret keys that can decrypt the log.
    * @returns - The deserialized events.
    */
   getEvents<T>(
@@ -394,7 +394,7 @@ export interface PXE {
     eventMetadata: EventMetadata<T>,
     from: number,
     limit: number,
-    ivpk: Point,
+    vpks: Point[],
   ): Promise<T[]>;
 }
 // docs:end:pxe-interface


### PR DESCRIPTION
Some considerations is the potential inefficiency with the current impl, but I think the UX is better passing in an array of heterogeneous keys.
