### PR TITLE
refactor: add log_hash as input in log emission in private context

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -13,7 +13,6 @@ use crate::{
 }
 };
 use dep::protocol_types::{
-    hash::sha256_to_field,
     abis::{
     caller_context::CallerContext, function_selector::FunctionSelector,
     max_block_number::MaxBlockNumber,
@@ -263,25 +262,23 @@ impl PrivateContext {
 
     // NB: A randomness value of 0 signals that the kernels should not mask the contract address
     // used in siloing later on e.g. 'handshaking' contract w/ known address.
-    pub fn emit_raw_event_log_with_masked_address<M>(&mut self, randomness: Field, encrypted_log: [u8; M]) {
+    pub fn emit_raw_event_log_with_masked_address<M>(&mut self, randomness: Field, log: [u8; M], log_hash: Field) {
         let counter = self.next_counter();
         let contract_address = self.this_address();
-        let len = encrypted_log.len() as Field + 4;
-        let log_hash = sha256_to_field(encrypted_log);
+        let len = log.len() as Field + 4;
         let side_effect = EncryptedLogHash { value: log_hash, counter, length: len, randomness };
         self.encrypted_logs_hashes.push(side_effect);
 
-        emit_encrypted_event_log(contract_address, randomness, encrypted_log, counter);
+        emit_encrypted_event_log(contract_address, randomness, log, counter);
     }
 
-    pub fn emit_raw_note_log<M>(&mut self, note_hash_counter: u32, encrypted_log: [u8; M]) {
+    pub fn emit_raw_note_log<M>(&mut self, note_hash_counter: u32, log: [u8; M], log_hash: Field) {
         let counter = self.next_counter();
-        let len = encrypted_log.len() as Field + 4;
-        let log_hash = sha256_to_field(encrypted_log);
+        let len = log.len() as Field + 4;
         let side_effect = NoteLogHash { value: log_hash, counter, length: len, note_hash_counter };
         self.note_encrypted_logs_hashes.push(side_effect);
 
-        emit_encrypted_note_log(note_hash_counter, encrypted_log, counter);
+        emit_encrypted_note_log(note_hash_counter, log, counter);
     }
 
     pub fn call_private_function<ARGS_COUNT>(

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
@@ -3,7 +3,7 @@ use crate::{
     encrypted_logs::payload::compute_encrypted_event_log, oracle::logs_traits::LensForEncryptedEvent,
     oracle::unsafe_rand::unsafe_rand
 };
-use dep::protocol_types::{address::AztecAddress, grumpkin_point::GrumpkinPoint};
+use dep::protocol_types::{address::AztecAddress, grumpkin_point::GrumpkinPoint, hash::sha256_to_field};
 
 fn emit_with_keys<Event, NB, MB, OB>(
     context: &mut PrivateContext,
@@ -17,7 +17,9 @@ fn emit_with_keys<Event, NB, MB, OB>(
 
     let encrypted_log: [u8; OB] = compute_encrypted_event_log(contract_address, randomness, ovsk_app, ovpk, ivpk, event);
 
-    context.emit_raw_event_log_with_masked_address(randomness, encrypted_log);
+    let log_hash = sha256_to_field(encrypted_log);
+
+    context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
 }
 
 pub fn encode_and_encrypt_event<Event, NB, MB, OB>(

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -3,8 +3,8 @@ use crate::{
     encrypted_logs::payload::compute_encrypted_note_log, oracle::logs_traits::LensForEncryptedLog
 };
 use dep::protocol_types::{
-    address::AztecAddress, grumpkin_point::GrumpkinPoint, abis::note_hash::NoteHash,
-    constants::MAX_NEW_NOTE_HASHES_PER_CALL, utils::arrays::find_index
+    hash::sha256_to_field, address::AztecAddress, grumpkin_point::GrumpkinPoint,
+    abis::note_hash::NoteHash, constants::MAX_NEW_NOTE_HASHES_PER_CALL, utils::arrays::find_index
 };
 
 fn emit_with_keys<Note, N, NB, M>(
@@ -30,7 +30,9 @@ fn emit_with_keys<Note, N, NB, M>(
 
     let encrypted_log: [u8; M] = compute_encrypted_note_log(contract_address, storage_slot, ovsk_app, ovpk, ivpk, note);
 
-    context.emit_raw_note_log(note_hash_counter, encrypted_log);
+    let log_hash = sha256_to_field(encrypted_log);
+
+    context.emit_raw_note_log(note_hash_counter, encrypted_log, log_hash);
 }
 
 pub fn encode_and_encrypt_note<Note, N, NB, M>(


### PR DESCRIPTION
Updates the `PrivateContext` such that the `emit_raw_note_log` and `emit_ raw_event_log_with_masked_address` now both are taking the `log_hash` as a parameter instead of computing it. 

This allow us more flexibility when designing note emission wrappers, meaning that we can have the one we have currently, where the full encryption and log hash computation is constrained, but it is also possible to more easily support it being the case that these are instead unconstrained, but still keeping the same interface.