### PR TITLE
refactor: use options.limit as upper limit for note-getter loop

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
@@ -127,7 +127,7 @@ fn constrain_get_notes_internal<Note, N, M, FILTER_ARGS>(
     let filtered_notes = filter_fn(opt_notes, filter_args);
 
     let mut prev_fields = [0; N];
-    for i in 0..filtered_notes.len() {
+    for i in 0..options.limit {
         let opt_note = filtered_notes[i];
         if opt_note.is_some() {
             let note = opt_note.unwrap_unchecked();
@@ -154,7 +154,13 @@ fn constrain_get_notes_internal<Note, N, M, FILTER_ARGS>(
         };
     }
 
+    // As long as we only loop till `options.limit` the array will be guaranteed to be at most of length `options.limit`.
     assert(returned_notes.len() <= options.limit, "Got more notes than limit.");
+    // We will however check that nothing else was returned after the limit.
+    for i in options.limit..filtered_notes.len() {
+        assert(filtered_notes[i].is_none(), "Got more notes than limit.");
+    }
+
     assert(returned_notes.len() != 0, "Cannot return zero notes");
 
     returned_notes


### PR DESCRIPTION
Using the `options.limit` as the upper limit for the loop in `constrain_get_notes_internal` in the `note_getter` to ensure that we don't waste constraints going over the full potential 32 notes for cases where we don't even accept this many.

When limiting number of notes with the option, it is now heavily reducing the number of hashes etc. 

Adds a smaller loop over `limit..N` to ensure that nothing have been added after the limit.

For a function like `redeem_shield` this cuts down 40K constraints instantly which is fairly neat, it already had a limit of 1, so now that is used. Unclear how the cost is still as high for it as it is though.

For a `transfer` function it is more apparent though, with a limit of 8, we save around 400K 🤷 vs no limit. So fairly easy to straight forward to do a big change which is neat.