### PR TITLE
chore: remove 4738 ref

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -30,11 +30,6 @@ impl<T, Context> PublicImmutable<T, Context> {
 impl <T> PublicImmutable<T, &mut PublicContext> {
     // docs:start:public_immutable_struct_write
     pub fn initialize<T_SERIALIZED_LEN>(self, value: T) where T: Serialize<T_SERIALIZED_LEN> {
-        // TODO(#4738): Uncomment the following assert
-        // assert(
-        //     self.context.public.unwrap_unchecked().is_deployment(), "PublicImmutable can only be initialized during contract deployment"
-        // );
-
         // We check that the struct is not yet initialized by checking if the initialization slot is 0
         let initialization_slot = INITIALIZATION_SLOT_SEPARATOR + self.storage_slot;
         let init_field: Field = self.context.storage_read(initialization_slot);

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_immutable.nr
@@ -26,11 +26,6 @@ impl<T, Context> SharedImmutable<T, Context> {
 impl<T> SharedImmutable<T, &mut PublicContext> {
     // Intended to be only called once. 
     pub fn initialize<T_SERIALIZED_LEN>(self, value: T) where T: Serialize<T_SERIALIZED_LEN> {
-        // TODO(#4738): Uncomment the following assert
-        // assert(
-        //     self.context.public.unwrap_unchecked().is_deployment(), "SharedImmutable can only be initialized during contract deployment"
-        // );
-
         // We check that the struct is not yet initialized by checking if the initialization slot is 0
         let initialization_slot = INITIALIZATION_SLOT_SEPARATOR + self.storage_slot;
         let init_field: Field = self.context.storage_read(initialization_slot);


### PR DESCRIPTION
Gets rid of references to #4738 as it is dropped.