### PR TITLE
refactor: showcase recursion case for transfer

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
@@ -161,8 +161,6 @@ fn constrain_get_notes_internal<Note, N, M, FILTER_ARGS>(
         assert(filtered_notes[i].is_none(), "Got more notes than limit.");
     }
 
-    assert(returned_notes.len() != 0, "Cannot return zero notes");
-
     returned_notes
 }
 

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
@@ -92,17 +92,6 @@ fn collapses_notes_at_the_beginning_of_the_array() {
     assert_equivalent_vec_and_array(returned, expected);
 }
 
-#[test(should_fail_with="Cannot return zero notes")]
-fn rejects_zero_notes() {
-    let mut env = setup();
-    let mut context = env.private();
-
-    let opt_notes: [Option<MockNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-
-    let options = NoteGetterOptions::new();
-    let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
-}
-
 #[test(should_fail_with="Got more notes than limit.")]
 fn rejects_mote_notes_than_limit() {
     let mut env = setup();

--- a/noir-projects/noir-contracts/contracts/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/benchmarking_contract/src/main.nr
@@ -31,7 +31,7 @@ contract Benchmarking {
         let owner_notes = storage.notes.at(owner);
         let mut getter_options = NoteGetterOptions::new();
         let notes = owner_notes.get_notes(getter_options.set_limit(1).set_offset(index));
-        let note = notes.get_unchecked(0);
+        let note = notes.get(0);
         owner_notes.remove(note);
         increment(owner_notes, note.value, owner, outgoing_viewer);
     }

--- a/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
@@ -65,7 +65,7 @@ contract Child {
         let mut options = NoteGetterOptions::new();
         options = options.select(ValueNote::properties().value, amount, Option::none()).set_limit(1);
         let notes = storage.a_map_with_private_values.at(owner).get_notes(options);
-        notes.get_unchecked(0).value
+        notes.get(0).value
     }
 
     // Increments `current_value` by `new_value`

--- a/noir-projects/noir-contracts/contracts/delegated_on_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/delegated_on_contract/src/main.nr
@@ -35,7 +35,7 @@ contract DelegatedOn {
         let mut options = NoteGetterOptions::new();
         options = options.select(ValueNote::properties().value, amount, Option::none()).set_limit(1);
         let notes = storage.a_map_with_private_values.at(owner).get_notes(options);
-        notes.get_unchecked(0).value
+        notes.get(0).value
     }
 
     unconstrained fn view_public_value() -> pub Field {

--- a/noir-projects/noir-contracts/contracts/delegator_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/delegator_contract/src/main.nr
@@ -35,7 +35,7 @@ contract Delegator {
         let mut options = NoteGetterOptions::new();
         options = options.select(ValueNote::properties().value, amount, Option::none()).set_limit(1);
         let notes = storage.a_map_with_private_values.at(owner).get_notes(options);
-        notes.get_unchecked(0).value
+        notes.get(0).value
     }
 
     unconstrained fn view_public_value() -> pub Field {

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
@@ -55,7 +55,7 @@ contract InclusionProofs {
         if (nullified) {
             options = options.set_status(NoteStatus.ACTIVE_OR_NULLIFIED);
         }
-        let note = private_values.get_notes(options).get_unchecked(0);
+        let note = private_values.get_notes(options).get(0);
         // docs:end:get_note_from_pxe
 
         // 2) Prove the note inclusion
@@ -106,7 +106,7 @@ contract InclusionProofs {
         if (fail_case) {
             options = options.set_status(NoteStatus.ACTIVE_OR_NULLIFIED);
         }
-        let note = private_values.get_notes(options).get_unchecked(0);
+        let note = private_values.get_notes(options).get(0);
 
         let header = if (use_block_number) {
             context.get_header_at(block_number)

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
@@ -154,8 +154,6 @@ contract PendingNoteHashes {
         let options = NoteGetterOptions::new();
         let notes = owner_balance.get_notes(options);
 
-        // TODO https://github.com/AztecProtocol/aztec-packages/issues/7059: review what this test aimed to test, as 
-        // it's now superfluous: get_notes never returns 0 notes.
         assert(notes.len() == 0);
     }
 

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
@@ -59,11 +59,6 @@ contract PendingNoteHashes {
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, amount);
         // get note (note inserted at bottom of function shouldn't exist yet)
         let notes = owner_balance.get_notes(options);
-
-        // TODO https://github.com/AztecProtocol/aztec-packages/issues/7059: clean this test up - we won't actually hit 
-        // this assert because the same one exists in get_notes (we always return at least one note), so all lines after 
-        // this one are effectively dead code. We should find a different way to test what this function attempts to 
-        // test.
         assert(notes.len() == 0);
 
         let header = context.get_header();
@@ -71,7 +66,7 @@ contract PendingNoteHashes {
 
         // Insert note
         let mut note = ValueNote::new(amount, owner_npk_m_hash);
-        owner_balance.insert(&mut note).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), owner));
+        owner_balance.insert(&mut note).discard();
 
         0
     }

--- a/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
@@ -73,7 +73,7 @@ contract StaticChild {
             Option::none()
         ).set_limit(1);
         let notes = storage.a_private_value.get_notes(options);
-        notes.get_unchecked(0).value
+        notes.get(0).value
     }
 
     // Increments `current_value` by `new_value`

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -472,7 +472,7 @@ contract Test {
         let mut options = NoteGetterOptions::new();
         options = options.select(TestNote::properties().value, secret_hash, Option::none()).set_limit(1);
         let notes = notes_set.get_notes(options);
-        let note = notes.get_unchecked(0);
+        let note = notes.get(0);
         notes_set.remove(note);
     }
 

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
@@ -173,7 +173,7 @@ contract TokenBlacklist {
             Option::none()
         ).set_limit(1);
         let notes = pending_shields.get_notes(options);
-        let note = notes.get_unchecked(0);
+        let note = notes.get(0);
         // Remove the note from the pending shields set
         pending_shields.remove(note);
 

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -295,7 +295,8 @@ contract Token {
             Option::none()
         ).set_limit(1);
         let notes = pending_shields.get_notes(options);
-        let note = notes.get_unchecked(0);
+        assert(notes.len() == 1, "No pending shield found");
+        let note = notes.get(0);
         // Remove the note from the pending shields set
         pending_shields.remove(note);
 
@@ -354,7 +355,6 @@ contract Token {
      * Accumulate value by spending notes until we hit the missing amount
      * If not enough notes are available, recurse to do it again.
      * Will use MORE notes than the transfer directly since there are much smaller usual overhead on this function.
-     * Will fail with `Cannot return zero notes` if there are not enough notes to cover the amount.
      */
     #[aztec(private)]
     #[aztec(internal)]

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -338,8 +338,9 @@ contract Token {
         let mut (change, missing) = storage.balances.odd_sub(from, amount, 2);
 
         // If we are still missing some balance to cover the amount, call accumulate to spend more notes.
+        let call = Token::at(context.this_address())._accumulate(from, missing.to_field());
         if !missing.eq(U128::zero()) {
-            change = Token::at(context.this_address())._accumulate(from, missing.to_field()).call(&mut context);
+            change = call.call(&mut context);
         }
 
         storage.balances.add(from, change).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_ovpk, from_ivpk));
@@ -360,8 +361,9 @@ contract Token {
     fn _accumulate(owner: AztecAddress, missing_: Field) -> U128 {
         // Since we are already spending a lot of doing the call, and we don't do anything else in here, we might as well go over more notes.
         let mut (change, missing) = storage.balances.odd_sub(owner, U128::from_integer(missing_), 8);
+        let call = Token::at(context.this_address())._accumulate(owner, missing.to_field());
         if !missing.eq(U128::zero()) {
-            change = Token::at(context.this_address())._accumulate(owner, missing.to_field()).call(&mut context);
+            change = call.call(&mut context);
         }
         change
     }

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -335,12 +335,36 @@ contract Token {
         let to_ivpk = header.get_ivpk_m(&mut context, to);
 
         let amount = U128::from_integer(amount);
-        storage.balances.sub(from, amount).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_ovpk, from_ivpk));
+        let mut (change, missing) = storage.balances.odd_sub(from, amount, 2);
+
+        // If we are still missing some balance to cover the amount, call accumulate to spend more notes.
+        if !missing.eq(U128::zero()) {
+            change = Token::at(context.this_address())._accumulate(from, missing.to_field()).call(&mut context);
+        }
+
+        storage.balances.add(from, change).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_ovpk, from_ivpk));
         storage.balances.add(to, amount).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_ovpk, to_ivpk));
 
         Transfer { from, to, amount: amount.to_field() }.emit(encode_and_encrypt_event_with_keys_unconstrained(&mut context, from_ovpk, to_ivpk));
     }
     // docs:end:transfer
+
+    /**
+     * Accumulate value by spending notes until we hit the missing amount
+     * If not enough notes are available, recurse to do it again.
+     * Will use MORE notes than the transfer directly since there are much smaller usual overhead on this function.
+     * Will fail with `Cannot return zero notes` if there are not enough notes to cover the amount.
+     */
+    #[aztec(private)]
+    #[aztec(internal)]
+    fn _accumulate(owner: AztecAddress, missing_: Field) -> U128 {
+        // Since we are already spending a lot of doing the call, and we don't do anything else in here, we might as well go over more notes.
+        let mut (change, missing) = storage.balances.odd_sub(owner, U128::from_integer(missing_), 8);
+        if !missing.eq(U128::zero()) {
+            change = Token::at(context.this_address())._accumulate(owner, missing.to_field()).call(&mut context);
+        }
+        change
+    }
 
     /**
      * Cancel a private authentication witness.

--- a/noir-projects/noir-contracts/contracts/token_contract/src/test/minting.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/test/minting.nr
@@ -88,7 +88,7 @@ unconstrained fn mint_private_success() {
     utils::check_private_balance(token_contract_address, owner, mint_amount);
 }
 
-#[test(should_fail_with="Cannot return zero notes")]
+#[test(should_fail_with="No pending shield found")]
 unconstrained fn mint_private_failure_double_spend() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, recipient) = utils::setup(/* with_account_contracts */ false);

--- a/noir-projects/noir-contracts/contracts/token_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/types/balances_map.nr
@@ -123,7 +123,7 @@ impl<T> BalancesMap<T, &mut PrivateContext> {
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, subtrahend).set_limit(limit);
         let notes = self.map.at(owner).get_notes(options);
 
-        assert(notes.len() > 0, "No notes found");
+        assert(notes.len() > 0, "Balance too low");
 
         let mut minuend: U128 = U128::from_integer(0);
         for i in 0..options.limit {

--- a/noir-projects/noir-contracts/contracts/token_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/types/balances_map.nr
@@ -120,10 +120,8 @@ impl<T> BalancesMap<T, &mut PrivateContext> {
         subtrahend: U128,
         limit: u32
     ) -> (U128, U128) where T: NoteInterface<T_SERIALIZED_LEN, T_SERIALIZED_BYTES_LEN> + OwnedNote {
-        // docs:start:get_notes
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, subtrahend).set_limit(limit);
         let notes = self.map.at(owner).get_notes(options);
-        // docs:end:get_notes
 
         assert(notes.len() > 0, "No notes found");
 
@@ -136,9 +134,7 @@ impl<T> BalancesMap<T, &mut PrivateContext> {
                 // This will call the the `compute_nullifer` function of the `token_note`
                 // which require knowledge of the secret key (currently the users encryption key).
                 // The contract logic must ensure that the spending key is used as well.
-                // docs:start:remove
                 self.map.at(owner).remove(note);
-                // docs:end:remove
 
                 minuend = minuend + note.get_amount();
             }

--- a/noir-projects/noir-contracts/contracts/token_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/types/balances_map.nr
@@ -113,6 +113,43 @@ impl<T> BalancesMap<T, &mut PrivateContext> {
 
         self.add(owner, minuend - subtrahend)
     }
+
+    pub fn odd_sub<T_SERIALIZED_LEN, T_SERIALIZED_BYTES_LEN>(
+        self: Self,
+        owner: AztecAddress,
+        subtrahend: U128,
+        limit: u32
+    ) -> (U128, U128) where T: NoteInterface<T_SERIALIZED_LEN, T_SERIALIZED_BYTES_LEN> + OwnedNote {
+        // docs:start:get_notes
+        let options = NoteGetterOptions::with_filter(filter_notes_min_sum, subtrahend).set_limit(limit);
+        let notes = self.map.at(owner).get_notes(options);
+        // docs:end:get_notes
+
+        assert(notes.len() > 0, "No notes found");
+
+        let mut minuend: U128 = U128::from_integer(0);
+        for i in 0..options.limit {
+            if i < notes.len() {
+                let note = notes.get_unchecked(i);
+
+                // Removes the note from the owner's set of notes.
+                // This will call the the `compute_nullifer` function of the `token_note`
+                // which require knowledge of the secret key (currently the users encryption key).
+                // The contract logic must ensure that the spending key is used as well.
+                // docs:start:remove
+                self.map.at(owner).remove(note);
+                // docs:end:remove
+
+                minuend = minuend + note.get_amount();
+            }
+        }
+
+        if minuend >= subtrahend {
+            (minuend - subtrahend, U128::zero())
+        } else {
+            (U128::zero(), subtrahend - minuend)
+        }
+    }
 }
 
 pub fn filter_notes_min_sum<T, T_SERIALIZED_LEN, T_SERIALIZED_BYTES_LEN>(

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/minting.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/minting.test.ts
@@ -111,7 +111,7 @@ describe('e2e_blacklist_token_contract mint', () => {
           'The note has been destroyed.',
         );
         await expect(asset.methods.redeem_shield(wallets[0].getAddress(), amount, secret).prove()).rejects.toThrow(
-          `Assertion failed: Cannot return zero notes`,
+          "Cannot satisfy constraint 'index < self.len'",
         );
       });
 

--- a/yarn-project/end-to-end/src/e2e_card_game.test.ts
+++ b/yarn-project/end-to-end/src/e2e_card_game.test.ts
@@ -183,7 +183,7 @@ describe('e2e_card_game', () => {
           .join_game(GAME_ID, [cardToField(firstPlayerCollection[0]), cardToField(firstPlayerCollection[1])])
           .send()
           .wait(),
-      ).rejects.toThrow("Cannot satisfy constraint 'index < self.len'");
+      ).rejects.toThrow("Assertion failed: Card not found 'card_note.is_some()'");
 
       const collection = await contract.methods.view_collection_cards(firstPlayer, 0).simulate({ from: firstPlayer });
       expect(boundedVecToArray(collection)).toHaveLength(1);

--- a/yarn-project/end-to-end/src/e2e_card_game.test.ts
+++ b/yarn-project/end-to-end/src/e2e_card_game.test.ts
@@ -183,7 +183,7 @@ describe('e2e_card_game', () => {
           .join_game(GAME_ID, [cardToField(firstPlayerCollection[0]), cardToField(firstPlayerCollection[1])])
           .send()
           .wait(),
-      ).rejects.toThrow(`Assertion failed: Cannot return zero notes`);
+      ).rejects.toThrow("Cannot satisfy constraint 'index < self.len'");
 
       const collection = await contract.methods.view_collection_cards(firstPlayer, 0).simulate({ from: firstPlayer });
       expect(boundedVecToArray(collection)).toHaveLength(1);

--- a/yarn-project/end-to-end/src/e2e_note_getter.test.ts
+++ b/yarn-project/end-to-end/src/e2e_note_getter.test.ts
@@ -182,7 +182,7 @@ describe('e2e_note_getter', () => {
         'index < self.len', // from BoundedVec::get
       );
       await expect(contract.methods.call_get_notes(storageSlot, activeOrNullified).prove()).rejects.toThrow(
-        `Assertion failed: Cannot return zero notes`,
+        "Cannot satisfy constraint 'index < self.len'",
       );
     }
 

--- a/yarn-project/end-to-end/src/e2e_pending_note_hashes_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_pending_note_hashes_contract.test.ts
@@ -108,9 +108,7 @@ describe('e2e_pending_note_hashes_contract', () => {
       )
       .send()
       .wait();
-    await expect(deployedContract.methods.get_note_zero_balance(owner).prove()).rejects.toThrow(
-      "Cannot satisfy constraint 'index < self.len'",
-    );
+    await deployedContract.methods.get_note_zero_balance(owner).prove();
 
     await expectNoteHashesSquashedExcept(0);
     await expectNullifiersSquashedExcept(0);
@@ -244,9 +242,7 @@ describe('e2e_pending_note_hashes_contract', () => {
       )
       .send()
       .wait();
-    await expect(deployedContract.methods.get_note_zero_balance(owner).prove()).rejects.toThrow(
-      "Cannot satisfy constraint 'index < self.len'",
-    );
+    await deployedContract.methods.get_note_zero_balance(owner).prove();
 
     // second TX creates 1 note, but it is squashed!
     await expectNoteHashesSquashedExcept(0);

--- a/yarn-project/end-to-end/src/e2e_pending_note_hashes_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_pending_note_hashes_contract.test.ts
@@ -109,7 +109,7 @@ describe('e2e_pending_note_hashes_contract', () => {
       .send()
       .wait();
     await expect(deployedContract.methods.get_note_zero_balance(owner).prove()).rejects.toThrow(
-      `Assertion failed: Cannot return zero notes`,
+      "Cannot satisfy constraint 'index < self.len'",
     );
 
     await expectNoteHashesSquashedExcept(0);
@@ -245,7 +245,7 @@ describe('e2e_pending_note_hashes_contract', () => {
       .send()
       .wait();
     await expect(deployedContract.methods.get_note_zero_balance(owner).prove()).rejects.toThrow(
-      `Assertion failed: Cannot return zero notes`,
+      "Cannot satisfy constraint 'index < self.len'",
     );
 
     // second TX creates 1 note, but it is squashed!

--- a/yarn-project/end-to-end/src/e2e_token_contract/minting.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/minting.test.ts
@@ -101,7 +101,7 @@ describe('e2e_token_contract minting', () => {
           'The note has been destroyed.',
         );
         await expect(asset.methods.redeem_shield(accounts[0].address, amount, secret).simulate()).rejects.toThrow(
-          `Assertion failed: Cannot return zero notes`,
+          "Cannot satisfy constraint 'index < self.len'",
         );
       });
 

--- a/yarn-project/end-to-end/src/e2e_token_contract/minting.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/minting.test.ts
@@ -101,7 +101,7 @@ describe('e2e_token_contract minting', () => {
           'The note has been destroyed.',
         );
         await expect(asset.methods.redeem_shield(accounts[0].address, amount, secret).simulate()).rejects.toThrow(
-          "Cannot satisfy constraint 'index < self.len'",
+          "Assertion failed: No pending shield found 'notes.len() == 1'",
         );
       });
 

--- a/yarn-project/end-to-end/src/e2e_token_contract/odd_transfer_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/odd_transfer_private.test.ts
@@ -72,7 +72,7 @@ describe('e2e_token_contract transfer private', () => {
       const amount = balance0 + 1n;
       expect(amount).toBeGreaterThan(0n);
       await expect(asset.methods.transfer(accounts[1].address, amount).simulate()).rejects.toThrow(
-        "Assertion failed: Cannot return zero notes 'returned_notes.len() != 0'",
+        'Assertion failed: Balance too low',
       );
     });
   });

--- a/yarn-project/end-to-end/src/e2e_token_contract/odd_transfer_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/odd_transfer_private.test.ts
@@ -1,0 +1,79 @@
+import { BatchCall, EventType, Fr } from '@aztec/aztec.js';
+import { TokenContract } from '@aztec/noir-contracts.js';
+
+import { TokenContractTest } from './token_contract_test.js';
+
+describe('e2e_token_contract transfer private', () => {
+  const t = new TokenContractTest('odd_transfer_private');
+  let { asset, accounts, tokenSim, wallets } = t;
+
+  beforeAll(async () => {
+    await t.applyBaseSnapshots();
+    await t.applyMintSnapshot();
+    await t.setup();
+    ({ asset, accounts, tokenSim, wallets } = t);
+  });
+
+  afterAll(async () => {
+    await t.teardown();
+  });
+
+  afterEach(async () => {
+    await t.tokenSim.check();
+  });
+
+  it('transfer full balance', async () => {
+    const N = 5;
+    // Mint 4 * N notes
+    // Then calls `transfer` to send all the notes to another account
+    // The transfer will only spend 2 notes itself, and then call `_accumulate` which will recurse
+    // until it have spent all the notes
+
+    let expectedNullifiers = 2; // 1 from the tx_hash and 1 from the original note in the senders possesion
+
+    for (let i = 0; i < N; i++) {
+      const actions = [
+        asset.methods.privately_mint_private_note(1n).request(),
+        asset.methods.privately_mint_private_note(1n).request(),
+        asset.methods.privately_mint_private_note(1n).request(),
+        asset.methods.privately_mint_private_note(1n).request(),
+      ];
+      await new BatchCall(wallets[0], actions).send().wait();
+
+      expectedNullifiers += actions.length;
+
+      tokenSim.mintPrivate(BigInt(actions.length));
+      tokenSim.redeemShield(accounts[0].address, BigInt(actions.length));
+    }
+
+    const amount = await asset.methods.balance_of_private(accounts[0].address).simulate();
+
+    expect(amount).toBeGreaterThan(0n);
+    const tx = await asset.methods.transfer(accounts[1].address, amount).send().wait({ debug: true });
+    tokenSim.transferPrivate(accounts[0].address, accounts[1].address, amount);
+
+    expect(tx.debugInfo?.nullifiers.length).toBe(expectedNullifiers);
+
+    // We expect there to have been inserted a single new note.
+    expect(tx.debugInfo?.noteHashes.length).toBe(1);
+
+    const events = await wallets[1].getEvents(EventType.Encrypted, TokenContract.events.Transfer, tx.blockNumber!, 1);
+
+    expect(events[0]).toEqual({
+      from: accounts[0].address,
+      to: accounts[1].address,
+      amount: new Fr(amount),
+    });
+  });
+
+  describe('failure cases', () => {
+    it('transfer more than balance', async () => {
+      const balance0 = await asset.methods.balance_of_private(accounts[0].address).simulate();
+      const amount = balance0 + 1n;
+      expect(amount).toBeGreaterThan(0n);
+      await expect(asset.methods.transfer(accounts[1].address, amount).simulate()).rejects.toThrow(
+        "Assertion failed: Cannot return zero notes 'returned_notes.len() != 0'",
+      );
+    });
+  });
+});

--- a/yarn-project/end-to-end/src/e2e_token_contract/transfer_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/transfer_private.test.ts
@@ -108,7 +108,7 @@ describe('e2e_token_contract transfer private', () => {
       const amount = balance0 + 1n;
       expect(amount).toBeGreaterThan(0n);
       await expect(asset.methods.transfer(accounts[1].address, amount).simulate()).rejects.toThrow(
-        'Assertion failed: Balance too low',
+        "Assertion failed: Cannot return zero notes 'returned_notes.len() != 0'",
       );
     });
 

--- a/yarn-project/end-to-end/src/e2e_token_contract/transfer_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/transfer_private.test.ts
@@ -108,7 +108,7 @@ describe('e2e_token_contract transfer private', () => {
       const amount = balance0 + 1n;
       expect(amount).toBeGreaterThan(0n);
       await expect(asset.methods.transfer(accounts[1].address, amount).simulate()).rejects.toThrow(
-        "Assertion failed: Cannot return zero notes 'returned_notes.len() != 0'",
+        'Assertion failed: Balance too low',
       );
     });
 

--- a/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
+++ b/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
@@ -215,18 +215,14 @@ describe('guides/dapp/testing', () => {
       it('asserts a local transaction simulation fails by calling simulate', async () => {
         // docs:start:local-tx-fails
         const call = token.methods.transfer(recipient.getAddress(), 200n);
-        await expect(call.prove()).rejects.toThrow(
-          "Assertion failed: Cannot return zero notes 'returned_notes.len() != 0'",
-        );
+        await expect(call.prove()).rejects.toThrow('Assertion failed: Balance too low');
         // docs:end:local-tx-fails
       });
 
       it('asserts a local transaction simulation fails by calling send', async () => {
         // docs:start:local-tx-fails-send
         const call = token.methods.transfer(recipient.getAddress(), 200n);
-        await expect(call.send().wait()).rejects.toThrow(
-          "Assertion failed: Cannot return zero notes 'returned_notes.len() != 0'",
-        );
+        await expect(call.send().wait()).rejects.toThrow('Assertion failed: Balance too low');
         // docs:end:local-tx-fails-send
       });
 

--- a/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
+++ b/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
@@ -215,14 +215,18 @@ describe('guides/dapp/testing', () => {
       it('asserts a local transaction simulation fails by calling simulate', async () => {
         // docs:start:local-tx-fails
         const call = token.methods.transfer(recipient.getAddress(), 200n);
-        await expect(call.prove()).rejects.toThrow(/Balance too low/);
+        await expect(call.prove()).rejects.toThrow(
+          "Assertion failed: Cannot return zero notes 'returned_notes.len() != 0'",
+        );
         // docs:end:local-tx-fails
       });
 
       it('asserts a local transaction simulation fails by calling send', async () => {
         // docs:start:local-tx-fails-send
         const call = token.methods.transfer(recipient.getAddress(), 200n);
-        await expect(call.send().wait()).rejects.toThrow(/Balance too low/);
+        await expect(call.send().wait()).rejects.toThrow(
+          "Assertion failed: Cannot return zero notes 'returned_notes.len() != 0'",
+        );
         // docs:end:local-tx-fails-send
       });
 

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -1109,13 +1109,13 @@ describe('Private Execution test suite', () => {
       const artifact = getFunctionArtifact(PendingNoteHashesContractArtifact, 'test_bad_get_then_insert_flat');
 
       const args = [amountToTransfer, owner];
-      await expect(() =>
-        runSimulator({
-          args: args,
-          artifact: artifact,
-          contractAddress,
-        }),
-      ).rejects.toThrow(`Assertion failed: Cannot return zero notes`);
+
+      // This will throw if we can read the note before it was inserted.
+      await runSimulator({
+        args: args,
+        artifact: artifact,
+        contractAddress,
+      });
     });
   });
 
@@ -1143,7 +1143,7 @@ describe('Private Execution test suite', () => {
       oracle.getNotes.mockResolvedValue([]);
 
       await expect(() => runSimulator({ artifact, args })).rejects.toThrow(
-        `Assertion failed: Cannot return zero notes`,
+        "Cannot satisfy constraint 'index < self.len'",
       );
     });
   });


### PR DESCRIPTION
Fixes #7142 and #7362.

Instead of doing direct recursion on the `transfer` I have altered the `balances_map` slightly to include a new `sub` function that allow a reduction of notes WITHOUT inserting the change note. We can then recurse over this new sub function to spend notes until we get what we need and then insert a change note after that. 

Notice that the transfer is consuming at most 2 notes, but that the `_accumulate` might consume up to 8!

The reason for this is fairly simple, the `transfer` would be inserting notes that are instantly consumed but spend plenty of juice on constraining the encryption first. Instead we can just spend a lot of notes with `_accumulate` without creating any new notes, and then return a final change value for the transfer to add for the `from`.

Since there are less "overhead" and we are just consuming notes in `_accumulate` we can spend the same number of constraints just consuming notes as we usually spend on consuming, encrypting and updating state. 

---

During the testing figured something interesting, that might be an issue with compiler optimisation. 

```rust
// Doing this 
let call = Token::at(context.this_address())._accumulate(from, missing.to_field());
if !missing.eq(U128::zero()) {
    change = call.call(&mut context);
}

// Is usually MUCH (many thousand constraints) cheaper than doing this
if !missing.eq(U128::zero()) {
    change = Token::at(context.this_address())._accumulate(from, missing.to_field()).call(&mut context);
}

```

---

- Also removes the check in the `note_getter` that asserts the length of the bounded vec is non-zero. Since that allow us for more meaningful error messages.
- Adds support for foreign call errors such that we catch nested calls failing.