### PR TITLE
chore(avm): basic stat collection

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -712,6 +712,12 @@ void avm_prove(const std::filesystem::path& bytecode_path,
     vinfo("vk written to: ", vk_path);
     write_file(vk_fields_path, { vk_json.begin(), vk_json.end() });
     vinfo("vk as fields written to: ", vk_fields_path);
+
+#ifdef AVM_TRACK_STATS
+    info("------- STATS -------");
+    const auto& stats = avm_trace::Stats::get();
+    info(stats.to_string());
+#endif
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_common.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_common.hpp
@@ -3,6 +3,7 @@
 #include "barretenberg/common/throw_or_abort.hpp"
 #include "barretenberg/serialize/msgpack.hpp"
 #include "barretenberg/vm/avm_trace/constants.hpp"
+#include "barretenberg/vm/avm_trace/stats.hpp"
 #include "barretenberg/vm/generated/avm_flavor.hpp"
 
 #include <array>

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/stats.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/stats.cpp
@@ -1,0 +1,60 @@
+#include "barretenberg/vm/avm_trace/stats.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace bb::avm_trace {
+
+Stats& Stats::get()
+{
+    static Stats stats;
+    return stats;
+}
+
+void Stats::reset()
+{
+    stats.clear();
+}
+
+void Stats::increment(const std::string& key, uint64_t value)
+{
+    stats[key] += value;
+}
+
+void Stats::time(const std::string& key, std::function<void()> f)
+{
+    auto start = std::chrono::system_clock::now();
+    f();
+    auto elapsed = std::chrono::system_clock::now() - start;
+    increment(key, static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count()));
+}
+
+std::string Stats::to_string() const
+{
+    std::vector<std::string> result;
+    result.reserve(stats.size());
+    for (const auto& [key, value] : stats) {
+        result.push_back(key + ": " + std::to_string(value));
+    }
+    std::sort(result.begin(), result.end());
+    std::string joined;
+    for (auto& s : result) {
+        joined += std::move(s) + "\n";
+    }
+    return joined;
+}
+
+std::string Stats::aggregate_to_string(const std::string& key_prefix) const
+{
+    uint64_t result = 0;
+    for (const auto& [key, value] : stats) {
+        if (key.starts_with(key_prefix)) {
+            result += value;
+        }
+    }
+    return key_prefix + ": " + std::to_string(result);
+}
+
+} // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/stats.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/stats.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+// To enable stats tracking, compile in RelWithAssert mode.
+// cmake --preset $PRESET -DCMAKE_BUILD_TYPE=RelWithAssert
+#ifndef NDEBUG
+#define AVM_TRACK_STATS
+#endif
+
+#ifdef AVM_TRACK_STATS
+#define AVM_TRACK_TIME(key, body) ::bb::avm_trace::Stats::get().time(key, [&]() { body; });
+#else
+#define AVM_TRACK_TIME(key, body) body
+#endif
+
+namespace bb::avm_trace {
+
+class Stats {
+  public:
+    static Stats& get();
+    void reset();
+    void increment(const std::string& key, uint64_t value);
+    void time(const std::string& key, std::function<void()> f);
+    std::string to_string() const;
+    std::string aggregate_to_string(const std::string& key_prefix) const;
+
+  private:
+    Stats() = default;
+
+    std::unordered_map<std::string, uint64_t> stats;
+};
+
+} // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_flavor.hpp
@@ -80,6 +80,7 @@
 #include "barretenberg/relations/generated/avm/range_check_l2_gas_lo.hpp"
 #include "barretenberg/relations/generated/avm/sha256.hpp"
 #include "barretenberg/transcript/transcript.hpp"
+#include "barretenberg/vm/avm_trace/stats.hpp"
 
 namespace bb {
 
@@ -849,114 +850,168 @@ class AvmFlavor {
         {
             ProverPolynomials prover_polynomials = ProverPolynomials(*this);
 
-            bb::compute_logderivative_inverse<AvmFlavor, perm_main_alu_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, perm_main_bin_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, perm_main_conv_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, perm_main_pos2_perm_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, perm_main_pedersen_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_a_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_b_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_c_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_d_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_ind_addr_a_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_ind_addr_b_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_ind_addr_c_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_ind_addr_d_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_byte_lengths_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_byte_operations_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_opcode_gas_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, range_check_l2_gas_hi_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, range_check_l2_gas_lo_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, range_check_da_gas_hi_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, range_check_da_gas_lo_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, kernel_output_lookup_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_into_kernel_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, incl_main_tag_err_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, incl_mem_tag_err_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_mem_rng_chk_lo_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_mem_rng_chk_mid_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_mem_rng_chk_hi_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_pow_2_0_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_pow_2_1_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u8_0_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u8_1_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_0_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_1_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_2_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_3_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_4_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_5_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_6_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_7_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_8_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_9_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_10_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_11_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_12_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_13_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_14_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_0_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_1_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_2_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_3_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_4_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_5_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_6_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
-            bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_7_relation<FF>>(
-                prover_polynomials, relation_parameters, this->circuit_size);
+            AVM_TRACK_TIME("compute_logderivative_inverse/perm_main_alu_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, perm_main_alu_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/perm_main_bin_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, perm_main_bin_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/perm_main_conv_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, perm_main_conv_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/perm_main_pos2_perm_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, perm_main_pos2_perm_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/perm_main_pedersen_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, perm_main_pedersen_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/perm_main_mem_a_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_a_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/perm_main_mem_b_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_b_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/perm_main_mem_c_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_c_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/perm_main_mem_d_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_d_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/perm_main_mem_ind_addr_a_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_ind_addr_a_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/perm_main_mem_ind_addr_b_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_ind_addr_b_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/perm_main_mem_ind_addr_c_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_ind_addr_c_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/perm_main_mem_ind_addr_d_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, perm_main_mem_ind_addr_d_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_byte_lengths_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_byte_lengths_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_byte_operations_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_byte_operations_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_opcode_gas_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_opcode_gas_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/range_check_l2_gas_hi_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, range_check_l2_gas_hi_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/range_check_l2_gas_lo_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, range_check_l2_gas_lo_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/range_check_da_gas_hi_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, range_check_da_gas_hi_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/range_check_da_gas_lo_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, range_check_da_gas_lo_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/kernel_output_lookup_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, kernel_output_lookup_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_into_kernel_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_into_kernel_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/incl_main_tag_err_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, incl_main_tag_err_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/incl_mem_tag_err_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, incl_mem_tag_err_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_mem_rng_chk_lo_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_mem_rng_chk_lo_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_mem_rng_chk_mid_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_mem_rng_chk_mid_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_mem_rng_chk_hi_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_mem_rng_chk_hi_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_pow_2_0_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_pow_2_0_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_pow_2_1_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_pow_2_1_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u8_0_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u8_0_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u8_1_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u8_1_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u16_0_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_0_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u16_1_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_1_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u16_2_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_2_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u16_3_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_3_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u16_4_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_4_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u16_5_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_5_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u16_6_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_6_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u16_7_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_7_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u16_8_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_8_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u16_9_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_9_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u16_10_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_10_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u16_11_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_11_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u16_12_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_12_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u16_13_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_13_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_u16_14_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_u16_14_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_div_u16_0_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_0_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_div_u16_1_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_1_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_div_u16_2_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_2_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_div_u16_3_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_3_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_div_u16_4_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_4_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_div_u16_5_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_5_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_div_u16_6_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_6_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
+            AVM_TRACK_TIME("compute_logderivative_inverse/lookup_div_u16_7_ms",
+                           (bb::compute_logderivative_inverse<AvmFlavor, lookup_div_u16_7_relation<FF>>(
+                               prover_polynomials, relation_parameters, this->circuit_size)));
         }
     };
 

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.cpp
@@ -9,6 +9,7 @@
 #include "barretenberg/polynomials/polynomial.hpp"
 #include "barretenberg/relations/permutation_relation.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
+#include "barretenberg/vm/avm_trace/stats.hpp"
 
 namespace bb {
 
@@ -240,18 +241,18 @@ HonkProof AvmProver::construct_proof()
     execute_preamble_round();
 
     // Compute wire commitments
-    execute_wire_commitments_round();
+    AVM_TRACK_TIME("proving/wire_commitments_round_ms", execute_wire_commitments_round());
 
     // Compute sorted list accumulator and commitment
-    execute_log_derivative_inverse_round();
+    AVM_TRACK_TIME("proving/log_derivative_inverse_round_ms", execute_log_derivative_inverse_round());
 
     // Fiat-Shamir: alpha
     // Run sumcheck subprotocol.
-    execute_relation_check_rounds();
+    AVM_TRACK_TIME("proving/relation_check_rounds_ms", execute_relation_check_rounds());
 
     // Fiat-Shamir: rho, y, x, z
     // Execute Zeromorph multilinear PCS
-    execute_pcs_rounds();
+    AVM_TRACK_TIME("proving/pcs_rounds_ms", execute_pcs_rounds());
 
     return export_proof();
 }

--- a/bb-pilcom/bb-pil-backend/src/flavor_builder.rs
+++ b/bb-pilcom/bb-pil-backend/src/flavor_builder.rs
@@ -128,6 +128,7 @@ fn flavor_includes(name: &str, relation_file_names: &[String], lookups: &[String
 
 #include \"barretenberg/relations/generic_permutation/generic_permutation_relation.hpp\"
 
+#include \"barretenberg/vm/avm_trace/stats.hpp\"
 #include \"barretenberg/flavor/flavor_macros.hpp\"
 #include \"barretenberg/transcript/transcript.hpp\"
 #include \"barretenberg/polynomials/evaluation_domain.hpp\"
@@ -568,7 +569,7 @@ fn create_compute_logderivative_inverses(flavor_name: &str, lookups: &[String]) 
     }
 
     let compute_inverse_transformation = |lookup_name: &String| {
-        format!("bb::compute_logderivative_inverse<{flavor_name}Flavor, {lookup_name}_relation<FF>>(prover_polynomials, relation_parameters, this->circuit_size);")
+        format!("AVM_TRACK_TIME(\"compute_logderivative_inverse/{lookup_name}_ms\", (bb::compute_logderivative_inverse<{flavor_name}Flavor, {lookup_name}_relation<FF>>(prover_polynomials, relation_parameters, this->circuit_size)));")
     };
 
     let compute_inverses = map_with_newline(lookups, compute_inverse_transformation);


### PR DESCRIPTION
Colelcts and prints stats for `avm_prove` when BB is compiled with in `RelWithAssert` mode or `AVM_TRACK_STATS` is defined.

Has no impact otherwise.

```
------- STATS -------
compute_logderivative_inverse/incl_main_tag_err_ms: 0
compute_logderivative_inverse/incl_mem_tag_err_ms: 0
compute_logderivative_inverse/kernel_output_lookup_ms: 0
compute_logderivative_inverse/lookup_byte_lengths_ms: 0
compute_logderivative_inverse/lookup_byte_operations_ms: 0
compute_logderivative_inverse/lookup_div_u16_0_ms: 0
compute_logderivative_inverse/lookup_div_u16_1_ms: 0
compute_logderivative_inverse/lookup_div_u16_2_ms: 0
compute_logderivative_inverse/lookup_div_u16_3_ms: 0
compute_logderivative_inverse/lookup_div_u16_4_ms: 0
compute_logderivative_inverse/lookup_div_u16_5_ms: 0
compute_logderivative_inverse/lookup_div_u16_6_ms: 0
compute_logderivative_inverse/lookup_div_u16_7_ms: 0
compute_logderivative_inverse/lookup_into_kernel_ms: 0
compute_logderivative_inverse/lookup_mem_rng_chk_hi_ms: 0
compute_logderivative_inverse/lookup_mem_rng_chk_lo_ms: 0
compute_logderivative_inverse/lookup_mem_rng_chk_mid_ms: 0
compute_logderivative_inverse/lookup_opcode_gas_ms: 0
compute_logderivative_inverse/lookup_pow_2_0_ms: 0
compute_logderivative_inverse/lookup_pow_2_1_ms: 0
compute_logderivative_inverse/lookup_u16_0_ms: 0
compute_logderivative_inverse/lookup_u16_10_ms: 0
compute_logderivative_inverse/lookup_u16_11_ms: 0
compute_logderivative_inverse/lookup_u16_12_ms: 0
compute_logderivative_inverse/lookup_u16_13_ms: 0
compute_logderivative_inverse/lookup_u16_14_ms: 0
compute_logderivative_inverse/lookup_u16_1_ms: 0
compute_logderivative_inverse/lookup_u16_2_ms: 0
compute_logderivative_inverse/lookup_u16_3_ms: 0
compute_logderivative_inverse/lookup_u16_4_ms: 0
compute_logderivative_inverse/lookup_u16_5_ms: 0
compute_logderivative_inverse/lookup_u16_6_ms: 0
compute_logderivative_inverse/lookup_u16_7_ms: 0
compute_logderivative_inverse/lookup_u16_8_ms: 0
compute_logderivative_inverse/lookup_u16_9_ms: 0
compute_logderivative_inverse/lookup_u8_0_ms: 0
compute_logderivative_inverse/lookup_u8_1_ms: 0
compute_logderivative_inverse/perm_main_alu_ms: 1
compute_logderivative_inverse/perm_main_bin_ms: 0
compute_logderivative_inverse/perm_main_conv_ms: 0
compute_logderivative_inverse/perm_main_mem_a_ms: 0
compute_logderivative_inverse/perm_main_mem_b_ms: 0
compute_logderivative_inverse/perm_main_mem_c_ms: 0
compute_logderivative_inverse/perm_main_mem_d_ms: 0
compute_logderivative_inverse/perm_main_mem_ind_addr_a_ms: 0
compute_logderivative_inverse/perm_main_mem_ind_addr_b_ms: 0
compute_logderivative_inverse/perm_main_mem_ind_addr_c_ms: 0
compute_logderivative_inverse/perm_main_mem_ind_addr_d_ms: 0
compute_logderivative_inverse/perm_main_pedersen_ms: 0
compute_logderivative_inverse/perm_main_pos2_perm_ms: 0
compute_logderivative_inverse/range_check_da_gas_hi_ms: 0
compute_logderivative_inverse/range_check_da_gas_lo_ms: 0
compute_logderivative_inverse/range_check_l2_gas_hi_ms: 0
compute_logderivative_inverse/range_check_l2_gas_lo_ms: 0
proving/log_derivative_inverse_round_ms: 82
proving/pcs_rounds_ms: 158
proving/relation_check_rounds_ms: 66
proving/wire_commitments_round_ms: 193
```
