### PR TITLE
feat: WIP - balanced outbox tree

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -150,13 +150,12 @@ contract Rollup is IRollup {
       revert Errors.Rollup__InvalidInHash(inHash, header.contentCommitment.inHash);
     }
 
-    // TODO(#7218): Revert to fixed height tree for outbox, currently just providing min as interim
-    // Min size = smallest path of the rollup tree + 1
-    (uint256 min,) = MerkleLib.computeMinMaxPathLength(header.contentCommitment.numTxs);
-    uint256 l2ToL1TreeMinHeight = min + 1;
-    OUTBOX.insert(
-      header.globalVariables.blockNumber, header.contentCommitment.outHash, l2ToL1TreeMinHeight
-    );
+    bytes32 outHash = AVAILABILITY_ORACLE.outHash(header.contentCommitment.txsEffectsHash);
+    uint256 height = MerkleLib.calculateTreeHeightFromSize(header.contentCommitment.numTxs);
+    // Currently we have 8 msgs per tx => height of 3
+    // TODO: calc this value
+    uint256 l2ToL1TreeHeight = height + 3;
+    OUTBOX.insert(header.globalVariables.blockNumber, outHash, l2ToL1TreeHeight);
 
     // pay the coinbase 1 gas token if it is not empty and header.totalFees is not zero
     if (header.globalVariables.coinbase != address(0) && header.totalFees > 0) {

--- a/l1-contracts/src/core/availability_oracle/AvailabilityOracle.sol
+++ b/l1-contracts/src/core/availability_oracle/AvailabilityOracle.sol
@@ -15,6 +15,7 @@ import {TxsDecoder} from "./../libraries/decoders/TxsDecoder.sol";
  */
 contract AvailabilityOracle is IAvailabilityOracle {
   mapping(bytes32 txsHash => bool available) public override(IAvailabilityOracle) isAvailable;
+  mapping(bytes32 txsHash => bytes32 blockOutHash) public override(IAvailabilityOracle) outHash;
 
   /**
    * @notice Publishes transactions and marks its commitment, the TxsEffectsHash, as available
@@ -22,8 +23,9 @@ contract AvailabilityOracle is IAvailabilityOracle {
    * @return txsEffectsHash - The TxsEffectsHash
    */
   function publish(bytes calldata _body) external override(IAvailabilityOracle) returns (bytes32) {
-    bytes32 txsEffectsHash = TxsDecoder.decode(_body);
+    (bytes32 txsEffectsHash, bytes32 blockOutHash) = TxsDecoder.decode(_body);
     isAvailable[txsEffectsHash] = true;
+    outHash[txsEffectsHash] = blockOutHash;
 
     emit TxsPublished(txsEffectsHash);
 

--- a/l1-contracts/src/core/interfaces/IAvailabilityOracle.sol
+++ b/l1-contracts/src/core/interfaces/IAvailabilityOracle.sol
@@ -8,4 +8,6 @@ interface IAvailabilityOracle {
   function publish(bytes calldata _body) external returns (bytes32);
 
   function isAvailable(bytes32 _txsEffectsHash) external view returns (bool);
+
+  function outHash(bytes32 _txsEffectsHash) external view returns (bytes32);
 }

--- a/l1-contracts/src/core/interfaces/messagebridge/IOutbox.sol
+++ b/l1-contracts/src/core/interfaces/messagebridge/IOutbox.sol
@@ -11,7 +11,7 @@ import {DataStructures} from "../../libraries/DataStructures.sol";
  * and will be consumed by the portal contracts.
  */
 interface IOutbox {
-  event RootAdded(uint256 indexed l2BlockNumber, bytes32 indexed root, uint256 minHeight);
+  event RootAdded(uint256 indexed l2BlockNumber, bytes32 indexed root, uint256 height);
   event MessageConsumed(
     uint256 indexed l2BlockNumber,
     bytes32 indexed root,
@@ -27,9 +27,9 @@ interface IOutbox {
    * @dev Emits `RootAdded` upon inserting the root successfully
    * @param _l2BlockNumber - The L2 Block Number in which the L2 to L1 messages reside
    * @param _root - The merkle root of the tree where all the L2 to L1 messages are leaves
-   * @param _minHeight - The min height of the merkle tree that the root corresponds to
+   * @param _height - The height of the merkle tree that the root corresponds to
    */
-  function insert(uint256 _l2BlockNumber, bytes32 _root, uint256 _minHeight) external;
+  function insert(uint256 _l2BlockNumber, bytes32 _root, uint256 _height) external;
   // docs:end:outbox_insert
 
   // docs:start:outbox_consume

--- a/l1-contracts/src/core/libraries/HeaderLib.sol
+++ b/l1-contracts/src/core/libraries/HeaderLib.sol
@@ -166,6 +166,7 @@ library HeaderLib {
     header.contentCommitment.numTxs = uint256(bytes32(_header[0x0024:0x0044]));
     header.contentCommitment.txsEffectsHash = bytes32(_header[0x0044:0x0064]);
     header.contentCommitment.inHash = bytes32(_header[0x0064:0x0084]);
+    // TODO remove
     header.contentCommitment.outHash = bytes32(_header[0x0084:0x00a4]);
 
     // Reading StateReference

--- a/l1-contracts/src/core/libraries/MerkleLib.sol
+++ b/l1-contracts/src/core/libraries/MerkleLib.sol
@@ -92,23 +92,28 @@ library MerkleLib {
 
   /**
    * @notice Calculates a tree height from the amount of elements in the tree
-   * @dev - This mirrors the function in TestUtil, but assumes _size is an exact power of 2 or = 1
+   * @dev - This mirrors the function in TestUtil
    * @param _size - The number of elements in the tree
    */
   function calculateTreeHeightFromSize(uint256 _size) internal pure returns (uint256) {
     /// We need the height of the tree that will contain all of our leaves,
     /// hence the next highest power of two from the amount of leaves - Math.ceil(Math.log2(x))
     uint256 height = 0;
+    uint256 size = _size;
 
-    if (_size == 1) {
+    // A single leaf needs no tree - the value itself is the root
+    if (size <= 1) {
       return 0;
     }
 
     /// While size > 1, we divide by two, and count how many times we do this; producing a rudimentary way of calculating Math.Floor(Math.log2(x))
-    while (_size > 1) {
-      _size >>= 1;
+    while (size > 1) {
+      size >>= 1;
       height++;
     }
-    return height;
+    /// @notice - We check if 2 ** height does not equal our original number. If so, this means that our size is not a power of two,
+    /// and hence we've rounded down (Math.floor) and have obtained the next lowest power of two instead of rounding up (Math.ceil) to obtain the next highest power of two and therefore we need to increment height before returning it.
+    /// If 2 ** height equals our original number, it means that we have a perfect power of two and Math.floor(Math.log2(x)) = Math.ceil(Math.log2(x)) and we can return height as-is
+    return (2 ** height) != _size ? ++height : height;
   }
 }

--- a/l1-contracts/src/core/libraries/decoders/TxsDecoder.sol
+++ b/l1-contracts/src/core/libraries/decoders/TxsDecoder.sol
@@ -265,6 +265,18 @@ library TxsDecoder {
         // Value taken from tx_effect.test.ts "hash of empty tx effect matches snapshot" test case
         vars.baseLeaves[i] = hex"00e8b31e302d11fbf7da124b537ba2d44f88e165da03c6557e2b0f6dc486e025";
       }
+      // We pad tx out hashes with hashes of empty tx node at that level.
+      // TODO calc subtree height based on num msgs per tx (currently 8 => height = 3)
+      // TODO handle case of 0 msgs better
+      if (numTxEffects != 0) {
+        bytes32 zeroHash = 0;
+        for (uint256 i = 0; i < 3; i++) {
+          zeroHash = Hash.sha256ToField(bytes.concat(zeroHash, zeroHash));
+        }
+        for (uint256 i = numTxEffects; i < vars.l2ToL1MsgsSubtreeRoots.length; i++) {
+          vars.l2ToL1MsgsSubtreeRoots[i] = zeroHash;
+        }
+      }
     }
 
     return (computeUnbalancedRoot(vars.baseLeaves), computeRoot(vars.l2ToL1MsgsSubtreeRoots));

--- a/l1-contracts/src/core/messagebridge/Outbox.sol
+++ b/l1-contracts/src/core/messagebridge/Outbox.sol
@@ -22,7 +22,7 @@ contract Outbox is IOutbox {
   struct RootData {
     // This is the outhash specified by header.globalvariables.outHash of any given block.
     bytes32 root;
-    uint256 minHeight;
+    uint256 height;
     mapping(uint256 => bool) nullified;
   }
 
@@ -40,9 +40,9 @@ contract Outbox is IOutbox {
    * @dev Emits `RootAdded` upon inserting the root successfully
    * @param _l2BlockNumber - The L2 Block Number in which the L2 to L1 messages reside
    * @param _root - The merkle root of the tree where all the L2 to L1 messages are leaves
-   * @param _minHeight - The min height of the merkle tree that the root corresponds to
+   * @param _height - The height of the merkle tree that the root corresponds to
    */
-  function insert(uint256 _l2BlockNumber, bytes32 _root, uint256 _minHeight)
+  function insert(uint256 _l2BlockNumber, bytes32 _root, uint256 _height)
     external
     override(IOutbox)
   {
@@ -59,9 +59,9 @@ contract Outbox is IOutbox {
     }
 
     roots[_l2BlockNumber].root = _root;
-    roots[_l2BlockNumber].minHeight = _minHeight;
+    roots[_l2BlockNumber].height = _height;
 
-    emit RootAdded(_l2BlockNumber, _root, _minHeight);
+    emit RootAdded(_l2BlockNumber, _root, _height);
   }
 
   /**
@@ -100,14 +100,9 @@ contract Outbox is IOutbox {
     if (rootData.nullified[_leafIndex]) {
       revert Errors.Outbox__AlreadyNullified(_l2BlockNumber, _leafIndex);
     }
-    // TODO(#7218): We will eventually move back to a balanced tree and constrain the path length
-    // to be equal to height - for now we just check the min
 
-    // Min height = height of rollup layers
-    // The smallest num of messages will require a subtree of height 1
-    uint256 minHeight = rootData.minHeight;
-    if (minHeight > _path.length) {
-      revert Errors.Outbox__InvalidPathLength(minHeight, _path.length);
+    if (rootData.height != _path.length) {
+      revert Errors.Outbox__InvalidPathLength(rootData.height, _path.length);
     }
 
     bytes32 messageHash = _message.sha256ToField();

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -166,9 +166,9 @@ contract RollupTest is DecoderBase {
       // The below is a little janky - we know that this test deals with full txs with equal numbers
       // of msgs or txs with no messages, so the division works
       // TODO edit full.messages to include information about msgs per tx?
-      uint256 subTreeHeight = merkleTestUtil.calculateTreeHeightFromSize(
-        full.messages.l2ToL1Messages.length == 0 ? 0 : full.messages.l2ToL1Messages.length / numTxs
-      );
+      uint256 subTreeHeight = full.messages.l2ToL1Messages.length == 0
+        ? 0
+        : merkleTestUtil.calculateTreeHeightFromSize(full.messages.l2ToL1Messages.length / numTxs);
       uint256 outHashTreeHeight = merkleTestUtil.calculateTreeHeightFromSize(numTxs);
       uint256 numMessagesWithPadding = numTxs * Constants.MAX_NEW_L2_TO_L1_MSGS_PER_TX;
 

--- a/l1-contracts/test/decoders/Decoders.t.sol
+++ b/l1-contracts/test/decoders/Decoders.t.sol
@@ -79,7 +79,8 @@ contract DecodersTest is DecoderBase {
           "Invalid txsEffectsHash"
         );
         assertEq(header.contentCommitment.inHash, contentCommitment.inHash, "Invalid inHash");
-        assertEq(header.contentCommitment.outHash, contentCommitment.outHash, "Invalid outHash");
+        // TODO: remove
+        // assertEq(header.contentCommitment.outHash, contentCommitment.outHash, "Invalid outHash");
       }
 
       // StateReference

--- a/l1-contracts/test/decoders/helpers/TxsDecoderHelper.sol
+++ b/l1-contracts/test/decoders/helpers/TxsDecoderHelper.sol
@@ -7,8 +7,9 @@ import {MerkleLib} from "../../../src/core/libraries/MerkleLib.sol";
 
 contract TxsDecoderHelper {
   // A wrapper used such that we get "calldata" and not memory
-  function decode(bytes calldata _body) public pure returns (bytes32 txsHash) {
-    return TxsDecoder.decode(_body);
+  function decode(bytes calldata _body) public pure returns (bytes32) {
+    (bytes32 txsHash,) = TxsDecoder.decode(_body);
+    return txsHash;
   }
 
   function computeKernelLogsHash(bytes calldata _kernelLogs)

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/base_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/base_rollup_inputs.nr
@@ -121,7 +121,8 @@ impl BaseRollupInputs {
             transaction_fee,
             all_public_data_update_requests
         );
-        let out_hash = compute_kernel_out_hash(self.kernel_data.public_inputs.end);
+        // TODO remove
+        let out_hash = 0; // compute_kernel_out_hash(self.kernel_data.public_inputs.end);
 
         // Perform membership checks that the notes provided exist within the historical trees data
         self.perform_archive_membership_checks();
@@ -1061,16 +1062,16 @@ mod tests {
         assert_eq(outputs.txs_effects_hash, expected_tx_effects_hash);
     }
 
-    #[test]
-    unconstrained fn empty_block_out_hash() {
-        let outputs = BaseRollupInputsBuilder::new().execute();
-        // For now setting an empty out hash to be H(0,0) to keep consistent
-        // with prev work.
-        let hash_input_flattened = [0; 64];
-        let sha_digest = std::hash::sha256(hash_input_flattened);
-        let expected_out_hash = field_from_bytes_32_trunc(sha_digest);
-        assert_eq(outputs.out_hash, expected_out_hash);
-    }
+    // #[test]
+    // unconstrained fn empty_block_out_hash() {
+    //     let outputs = BaseRollupInputsBuilder::new().execute();
+    //     // For now setting an empty out hash to be H(0,0) to keep consistent
+    //     // with prev work.
+    //     let hash_input_flattened = [0; 64];
+    //     let sha_digest = std::hash::sha256(hash_input_flattened);
+    //     let expected_out_hash = field_from_bytes_32_trunc(sha_digest);
+    //     assert_eq(outputs.out_hash, expected_out_hash);
+    // }
 
     #[test]
     unconstrained fn nonempty_block_out_hash() {

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/merge/merge_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/merge/merge_rollup_inputs.nr
@@ -34,7 +34,8 @@ impl MergeRollupInputs {
 
         // compute calldata hash:
         let txs_effects_hash = components::compute_txs_effects_hash(self.previous_rollup_data);
-        let out_hash = components::compute_out_hash(self.previous_rollup_data);
+        //TODO remove
+        let out_hash = 0; //components::compute_out_hash(self.previous_rollup_data);
 
         let accumulated_fees = components::accumulate_fees(left, right);
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_inputs.nr
@@ -65,7 +65,8 @@ impl RootRollupInputs {
             num_txs: (left.num_txs + right.num_txs) as Field,
             txs_effects_hash: components::compute_txs_effects_hash(self.previous_rollup_data),
             in_hash: self.l1_to_l2_roots.public_inputs.sha_root,
-            out_hash: components::compute_out_hash(self.previous_rollup_data)
+            // TODO remove
+            out_hash: 0// components::compute_out_hash(self.previous_rollup_data)
         };
 
         let total_fees = components::accumulate_fees(left, right);


### PR DESCRIPTION
Quick POC for removing out hash from the circuits. Instead we:

- Use the L2 to L1 msgs we already gather in the availability oracle to calc `txsEffectsHash` and fill a tree, then return the root of that tree alongside the effects hash
- The rollup contract adds this tree only if the usual checks pass, and calc tree height based on numTxs and num msgs per tx (currently 8 => some hardcoded 8s around for now)

The rollup circuits no longer need to deal with the out hash and we can remove it from the content commitment.
EDIT: Gas cost increase - unsure if acceptable. Note that we could use regular sha (not `shaToField`) here, which would bring down the costs as well.

| Sol Test | Gas Before | Gas After | Change |
| -------- | ------------ | --------- | -------- |
| Decode Blocks | 2,715,860 | 2,912,727 | +196,867 |
| C. Empty Blocks | 2,325,504 | 2,337,322 | +11,818 |
| C. Mixed Blocks | 6,986,350 | 7,223,404 | +237,054 |
| Empty Block | 1,191,048 | 1,207,958 | +16,910 |
| Mixed Block | 3,385,143 | 3,503,670 | +118,527 |