### PR TITLE
fix: only create d.ts files for contract artifacts

### DIFF
--- a/yarn-project/noir-protocol-circuits-types/src/scripts/generate_declaration_files.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/scripts/generate_declaration_files.ts
@@ -12,6 +12,10 @@ export = circuit;
 const target = fileURLToPath(new URL('../../artifacts', import.meta.url).href);
 const files = await readdir(target);
 for (const file of files) {
+  // guard against running this script twice without cleaning the artifacts/ dir first
+  if (!file.endsWith('.json')) {
+    continue;
+  }
   const name = file.replace('.json', '');
   await writeFile(join(target, `${name}.d.json.ts`), content);
 }


### PR DESCRIPTION
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
