### PR TITLE
fix: Include artifacts in noir-contracts package.json

### DIFF
--- a/yarn-project/noir-contracts.js/package.json
+++ b/yarn-project/noir-contracts.js/package.json
@@ -67,6 +67,7 @@
   "files": [
     "dest",
     "src",
+    "artifacts",
     "!*.test.*"
   ],
   "types": "./dest/types/index.d.ts",

--- a/yarn-project/noir-contracts.js/package.local.json
+++ b/yarn-project/noir-contracts.js/package.local.json
@@ -4,5 +4,11 @@
     "generate": "yarn generate:noir-contracts",
     "generate:noir-contracts": "./scripts/generate-types.sh && run -T prettier -w ./src --loglevel warn",
     "clean": "rm -rf ./dest .tsbuildinfo ./artifacts ./src ./codegenCache.json"
-  }
+  },
+  "files": [
+    "dest",
+    "src",
+    "artifacts",
+    "!*.test.*"
+  ]
 }


### PR DESCRIPTION
Ensures artifacts are included in the package when publishing.
