### PR TITLE
docs: making private refunds smooth-brain friendly

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/note/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/utils.nr
@@ -9,14 +9,18 @@ use dep::protocol_types::{
     utils::arr_copy_slice
 };
 
+pub fn compute_inner_note_hash_from_preimage(storage_slot: Field, note_content_hash: Field) -> Field {
+    pedersen_hash(
+        [storage_slot, note_content_hash],
+        GENERATOR_INDEX__INNER_NOTE_HASH
+    )
+}
+
 fn compute_inner_note_hash<Note, N, M>(note: Note) -> Field where Note: NoteInterface<N, M> {
     let header = note.get_header();
     let note_hash = note.compute_note_content_hash();
 
-    pedersen_hash(
-        [header.storage_slot, note_hash],
-        GENERATOR_INDEX__INNER_NOTE_HASH
-    )
+    compute_inner_note_hash_from_preimage(header.storage_slot, note_hash)
 }
 
 pub fn compute_siloed_nullifier<Note, N, M>(

--- a/noir-projects/noir-contracts/contracts/private_fpc_contract/src/lib.nr
+++ b/noir-projects/noir-contracts/contracts/private_fpc_contract/src/lib.nr
@@ -3,13 +3,13 @@ use dep::aztec::oracle::logs::emit_unencrypted_log_private_internal;
 use dep::aztec::hash::compute_unencrypted_log_hash;
 use dep::aztec::context::PrivateContext;
 
-fn emit_nonce_as_unencrypted_log(context: &mut PrivateContext, nonce: Field) {
+fn emit_randomness_as_unencrypted_log(context: &mut PrivateContext, randomness: Field) {
     let counter = context.next_counter();
-    let log_slice = nonce.to_be_bytes_arr();
-    let log_hash = compute_unencrypted_log_hash(context.this_address(), nonce);
+    let log_slice = randomness.to_be_bytes_arr();
+    let log_hash = compute_unencrypted_log_hash(context.this_address(), randomness);
     // 40 = addr (32) + raw log len (4) + processed log len (4)
     let len = 40 + log_slice.len().to_field();
     let side_effect = LogHash { value: log_hash, counter, length: len };
     context.unencrypted_logs_hashes.push(side_effect);
-    let _void = emit_unencrypted_log_private_internal(context.this_address(), nonce, counter);
+    let _void = emit_unencrypted_log_private_internal(context.this_address(), randomness, counter);
 }

--- a/noir-projects/noir-contracts/contracts/private_fpc_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/private_fpc_contract/src/main.nr
@@ -4,7 +4,7 @@ contract PrivateFPC {
     use dep::aztec::protocol_types::{abis::log_hash::LogHash, address::AztecAddress};
     use dep::aztec::state_vars::SharedImmutable;
     use dep::private_token::PrivateToken;
-    use crate::lib::emit_nonce_as_unencrypted_log;
+    use crate::lib::emit_randomness_as_unencrypted_log;
 
     #[aztec(storage)]
     struct Storage {
@@ -20,19 +20,19 @@ contract PrivateFPC {
     }
 
     #[aztec(private)]
-    fn fund_transaction_privately(amount: Field, asset: AztecAddress, nonce: Field) {
+    fn fund_transaction_privately(amount: Field, asset: AztecAddress, randomness: Field) {
         assert(asset == storage.other_asset.read_private());
         // convince the FPC we are not cheating
-        context.push_nullifier(nonce, 0);
+        context.push_nullifier(randomness, 0);
 
         // allow the FPC to reconstruct their fee note
-        emit_nonce_as_unencrypted_log(&mut context, nonce);
+        emit_randomness_as_unencrypted_log(&mut context, randomness);
 
         PrivateToken::at(asset).setup_refund(
             storage.admin_npk_m_hash.read_private(),
             context.msg_sender(),
             amount,
-            nonce
+            randomness
         ).call(&mut context);
         context.set_as_fee_payer();
     }

--- a/noir-projects/noir-contracts/contracts/private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/private_token_contract/src/main.nr
@@ -160,7 +160,7 @@ contract PrivateToken {
         fee_payer_npk_m_hash: Field,
         sponsored_user: AztecAddress,
         funded_amount: Field,
-        refund_nonce: Field
+        randomness: Field // A randomness to mix in with the generated notes.
     ) {
         // 1. This function is called by fee paying contract (FPC) when setting up a refund so we need to support
         // the authwit flow here and check that the user really permitted FPC to set up a refund on their behalf.
@@ -183,7 +183,7 @@ contract PrivateToken {
             fee_payer_npk_m_hash,
             sponsored_user_npk_m_hash,
             funded_amount,
-            refund_nonce
+            randomness
         );
 
         // 5. Set the public teardown function to `complete_refund(...)`. Public teardown is the only time when a public

--- a/noir-projects/noir-contracts/contracts/private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/private_token_contract/src/main.nr
@@ -157,31 +157,31 @@ contract PrivateToken {
 
     #[aztec(private)]
     fn setup_refund(
-        fee_payer_npk_m_hash: Field,
-        sponsored_user: AztecAddress,
-        funded_amount: Field,
+        fee_payer_npk_m_hash: Field, // NpkMHash of the entity which will receive the fee note.
+        user: AztecAddress, // A user for which we are setting up the fee refund.
+        funded_amount: Field, // The amount the user funded the fee payer with (represents fee limit).
         randomness: Field // A randomness to mix in with the generated notes.
     ) {
         // 1. This function is called by fee paying contract (fee_payer) when setting up a refund so we need to support
         // the authwit flow here and check that the user really permitted fee_payer to set up a refund on their behalf.
-        assert_current_call_valid_authwit(&mut context, sponsored_user);
+        assert_current_call_valid_authwit(&mut context, user);
 
         // 2. Get all the relevant user keys
         let header = context.get_header();
-        let sponsored_user_npk_m_hash = header.get_npk_m_hash(&mut context, sponsored_user);
-        let sponsored_user_ovpk = header.get_ovpk_m(&mut context, sponsored_user);
-        let sponsored_user_ivpk = header.get_ivpk_m(&mut context, sponsored_user);
+        let user_npk_m_hash = header.get_npk_m_hash(&mut context, user);
+        let user_ovpk = header.get_ovpk_m(&mut context, user);
+        let user_ivpk = header.get_ivpk_m(&mut context, user);
 
         // 3. Deduct the funded amount from the user's balance - this is a maximum fee a user is willing to pay
         // (called fee limit in aztec spec). The difference between fee limit and the actual tx fee will be refunded 
         // to the user in the `complete_refund(...)` function.
         // TODO(#7324): using npk_m_hash here does not work with key rotation
-        storage.balances.sub(sponsored_user_npk_m_hash, U128::from_integer(funded_amount)).emit(encode_and_encrypt_note_with_keys(&mut context, sponsored_user_ovpk, sponsored_user_ivpk));
+        storage.balances.sub(user_npk_m_hash, U128::from_integer(funded_amount)).emit(encode_and_encrypt_note_with_keys(&mut context, user_ovpk, user_ivpk));
 
         // 4. We generate the refund points.
         let (fee_payer_point, user_point) = TokenNote::generate_refund_points(
             fee_payer_npk_m_hash,
-            sponsored_user_npk_m_hash,
+            user_npk_m_hash,
             funded_amount,
             randomness
         );

--- a/noir-projects/noir-contracts/contracts/private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/private_token_contract/src/main.nr
@@ -162,8 +162,8 @@ contract PrivateToken {
         funded_amount: Field,
         randomness: Field // A randomness to mix in with the generated notes.
     ) {
-        // 1. This function is called by fee paying contract (FPC) when setting up a refund so we need to support
-        // the authwit flow here and check that the user really permitted FPC to set up a refund on their behalf.
+        // 1. This function is called by fee paying contract (fee_payer) when setting up a refund so we need to support
+        // the authwit flow here and check that the user really permitted fee_payer to set up a refund on their behalf.
         assert_current_call_valid_authwit(&mut context, sponsored_user);
 
         // 2. Get all the relevant user keys
@@ -179,7 +179,7 @@ contract PrivateToken {
         storage.balances.sub(sponsored_user_npk_m_hash, U128::from_integer(funded_amount)).emit(encode_and_encrypt_note_with_keys(&mut context, sponsored_user_ovpk, sponsored_user_ivpk));
 
         // 4. We generate the refund points.
-        let (fpc_point, user_point) = TokenNote::generate_refund_points(
+        let (fee_payer_point, user_point) = TokenNote::generate_refund_points(
             fee_payer_npk_m_hash,
             sponsored_user_npk_m_hash,
             funded_amount,
@@ -191,30 +191,33 @@ contract PrivateToken {
         context.set_public_teardown_function(
             context.this_address(),
             FunctionSelector::from_signature("complete_refund(Field,Field,Field,Field)"),
-            [fpc_point.x, fpc_point.y, user_point.x, user_point.y]
+            [fee_payer_point.x, fee_payer_point.y, user_point.x, user_point.y]
         );
     }
 
     #[aztec(public)]
     #[aztec(internal)]
     fn complete_refund(
-        fpc_point_x: Field,
-        fpc_point_y: Field,
+        fee_payer_point_x: Field,
+        fee_payer_point_y: Field,
         user_point_x: Field,
         user_point_y: Field
     ) {
         // 1. We get the final note content hashes by calling the `complete_refund` on the note.
-        let fpc_point = EmbeddedCurvePoint { x: fpc_point_x, y: fpc_point_y, is_infinite: false };
+        let fee_payer_point = EmbeddedCurvePoint { x: fee_payer_point_x, y: fee_payer_point_y, is_infinite: false };
         let user_point = EmbeddedCurvePoint { x: user_point_x, y: user_point_y, is_infinite: false };
         let tx_fee = context.transaction_fee();
-        let (fpc_note_content_hash, user_note_content_hash) = TokenNote::complete_refund(fpc_point, user_point, tx_fee);
+        let (fee_payer_note_content_hash, user_note_content_hash) = TokenNote::complete_refund(fee_payer_point, user_point, tx_fee);
 
         // 2. Now we "manually" compute the inner note hashes.
-        let fpc_inner_note_hash = compute_inner_note_hash_from_preimage(PrivateToken::storage().balances.slot, fpc_note_content_hash);
+        let fee_payer_inner_note_hash = compute_inner_note_hash_from_preimage(
+            PrivateToken::storage().balances.slot,
+            fee_payer_note_content_hash
+        );
         let user_inner_note_hash = compute_inner_note_hash_from_preimage(PrivateToken::storage().balances.slot, user_note_content_hash);
 
         // 3. At last we emit the note hashes.
-        context.push_note_hash(fpc_inner_note_hash);
+        context.push_note_hash(fee_payer_inner_note_hash);
         context.push_note_hash(user_inner_note_hash);
         // --> Once the tx is settled user and fee recipient can add the notes to their pixies.
     }

--- a/noir-projects/noir-contracts/contracts/private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/private_token_contract/src/main.nr
@@ -6,12 +6,9 @@ mod test;
 contract PrivateToken {
     use dep::compressed_string::FieldCompressedString;
     use dep::aztec::{
-        hash::compute_secret_hash,
+        note::utils::compute_inner_note_hash_from_preimage, hash::compute_secret_hash,
         prelude::{NoteGetterOptions, Map, PublicMutable, SharedImmutable, PrivateSet, AztecAddress},
-        protocol_types::{
-        abis::function_selector::FunctionSelector, hash::pedersen_hash,
-        constants::GENERATOR_INDEX__INNER_NOTE_HASH
-    },
+        protocol_types::{abis::function_selector::FunctionSelector, hash::pedersen_hash},
         oracle::unsafe_rand::unsafe_rand,
         encrypted_logs::encrypted_note_emission::{encode_and_encrypt_note, encode_and_encrypt_note_with_keys}
     };
@@ -182,7 +179,7 @@ contract PrivateToken {
         storage.balances.sub(sponsored_user_npk_m_hash, U128::from_integer(funded_amount)).emit(encode_and_encrypt_note_with_keys(&mut context, sponsored_user_ovpk, sponsored_user_ivpk));
 
         // 4. We generate the refund points.
-        let points = TokenNote::generate_refund_points(
+        let (fpc_point, user_point) = TokenNote::generate_refund_points(
             fee_payer_npk_m_hash,
             sponsored_user_npk_m_hash,
             funded_amount,
@@ -194,7 +191,7 @@ contract PrivateToken {
         context.set_public_teardown_function(
             context.this_address(),
             FunctionSelector::from_signature("complete_refund(Field,Field,Field,Field)"),
-            [points[0].x, points[0].y, points[1].x, points[1].y]
+            [fpc_point.x, fpc_point.y, user_point.x, user_point.y]
         );
     }
 
@@ -206,25 +203,20 @@ contract PrivateToken {
         user_point_x: Field,
         user_point_y: Field
     ) {
+        // 1. We get the final note content hashes by calling the `complete_refund` on the note.
         let fpc_point = EmbeddedCurvePoint { x: fpc_point_x, y: fpc_point_y, is_infinite: false };
         let user_point = EmbeddedCurvePoint { x: user_point_x, y: user_point_y, is_infinite: false };
         let tx_fee = context.transaction_fee();
-        let note_hashes = TokenNote::complete_refund(fpc_point, user_point, tx_fee);
+        let (fpc_note_content_hash, user_note_content_hash) = TokenNote::complete_refund(fpc_point, user_point, tx_fee);
 
-        // `compute_inner_note_hash` manually, without constructing the note
-        // `3` is the storage slot of the balances
-        context.push_note_hash(
-            pedersen_hash(
-                [PrivateToken::storage().balances.slot, note_hashes[0]],
-                GENERATOR_INDEX__INNER_NOTE_HASH
-            )
-        );
-        context.push_note_hash(
-            pedersen_hash(
-                [PrivateToken::storage().balances.slot, note_hashes[1]],
-                GENERATOR_INDEX__INNER_NOTE_HASH
-            )
-        );
+        // 2. Now we "manually" compute the inner note hashes.
+        let fpc_inner_note_hash = compute_inner_note_hash_from_preimage(PrivateToken::storage().balances.slot, fpc_note_content_hash);
+        let user_inner_note_hash = compute_inner_note_hash_from_preimage(PrivateToken::storage().balances.slot, user_note_content_hash);
+
+        // 3. At last we emit the note hashes.
+        context.push_note_hash(fpc_inner_note_hash);
+        context.push_note_hash(user_inner_note_hash);
+        // --> Once the tx is settled user and fee recipient can add the notes to their pixies.
     }
 
     /// Internal ///

--- a/noir-projects/noir-contracts/contracts/private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/private_token_contract/src/main.nr
@@ -165,18 +165,32 @@ contract PrivateToken {
         funded_amount: Field,
         refund_nonce: Field
     ) {
+        // 1. This function is called by fee paying contract (FPC) when setting up a refund so we need to support
+        // the authwit flow here and check that the user really permitted FPC to set up a refund on their behalf.
         assert_current_call_valid_authwit(&mut context, sponsored_user);
+
+        // 2. Get all the relevant user keys
         let header = context.get_header();
         let sponsored_user_npk_m_hash = header.get_npk_m_hash(&mut context, sponsored_user);
         let sponsored_user_ovpk = header.get_ovpk_m(&mut context, sponsored_user);
         let sponsored_user_ivpk = header.get_ivpk_m(&mut context, sponsored_user);
+
+        // 3. Deduct the funded amount from the user's balance - this is a maximum fee a user is willing to pay
+        // (called fee limit in aztec spec). The difference between fee limit and the actual tx fee will be refunded 
+        // to the user in the `complete_refund(...)` function.
+        // TODO(#7324): using npk_m_hash here does not work with key rotation
         storage.balances.sub(sponsored_user_npk_m_hash, U128::from_integer(funded_amount)).emit(encode_and_encrypt_note_with_keys(&mut context, sponsored_user_ovpk, sponsored_user_ivpk));
+
+        // 4. We generate the refund points.
         let points = TokenNote::generate_refund_points(
             fee_payer_npk_m_hash,
             sponsored_user_npk_m_hash,
             funded_amount,
             refund_nonce
         );
+
+        // 5. Set the public teardown function to `complete_refund(...)`. Public teardown is the only time when a public
+        // function has access to the final transaction fee, which is needed to compute the actual refund amount.
         context.set_public_teardown_function(
             context.this_address(),
             FunctionSelector::from_signature("complete_refund(Field,Field,Field,Field)"),

--- a/noir-projects/noir-contracts/contracts/private_token_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/private_token_contract/src/types/token_note.nr
@@ -19,7 +19,7 @@ trait PrivatelyRefundable {
         fee_payer_npk_m_hash: Field,
         sponsored_user_npk_m_hash: Field,
         funded_amount: Field,
-        refund_nonce: Field
+        randomness: Field
     ) -> (EmbeddedCurvePoint, EmbeddedCurvePoint);
 
     fn complete_refund(
@@ -116,22 +116,22 @@ impl OwnedNote for TokenNote {
 }
 
 impl PrivatelyRefundable for TokenNote {
-    fn generate_refund_points(fee_payer_npk_m_hash: Field, sponsored_user_npk_m_hash: Field, funded_amount: Field, refund_nonce: Field) -> (EmbeddedCurvePoint, EmbeddedCurvePoint) {
-        // 1. To be able to multiply generators with nonce and npk_m_hash using barretneberg's (BB) blackbox function we
+    fn generate_refund_points(fee_payer_npk_m_hash: Field, sponsored_user_npk_m_hash: Field, funded_amount: Field, randomness: Field) -> (EmbeddedCurvePoint, EmbeddedCurvePoint) {
+        // 1. To be able to multiply generators with randomness and npk_m_hash using barretneberg's (BB) blackbox function we
         // first need to convert the fields to high and low limbs.
-        let (refund_nonce_lo, refund_nonce_hi) = decompose(refund_nonce);
-        let (fee_payer_lo, fee_payer_hi) = decompose(fee_payer_npk_m_hash);
+        let (randomness_lo, randomness_hi) = decompose(randomness);
+        let (fee_payer_npk_m_hash_lo, fee_payer_npk_m_hash_hi) = decompose(fee_payer_npk_m_hash);
 
-        // 2. Now that we have correct representationsn of fee payer and refund nonce we can compute `G ^ (fee_payer_npk + refund_nonce)`
+        // 2. Now that we have correct representationsn of fee payer and randomness we can compute `G ^ (fee_payer_npk + randomness)`
         let fee_payer_point = multi_scalar_mul(
             [G1, G1],
             [EmbeddedCurveScalar {
-                lo: fee_payer_lo,
-                hi: fee_payer_hi
+                lo: fee_payer_npk_m_hash_lo,
+                hi: fee_payer_npk_m_hash_hi
             },
             EmbeddedCurveScalar {
-                lo: refund_nonce_lo,
-                hi: refund_nonce_hi
+                lo: randomness_lo,
+                hi: randomness_hi
             }]
         );
 
@@ -140,7 +140,7 @@ impl PrivatelyRefundable for TokenNote {
         let (sponsored_user_lo, sponsored_user_hi) = decompose(sponsored_user_npk_m_hash);
         let (funded_amount_lo, funded_amount_hi) = decompose(funded_amount);
 
-        // 4. We compute `G ^ (sponsored_user_npk_m_hash + funded_amount + refund_nonce)`
+        // 4. We compute `G ^ (sponsored_user_npk_m_hash + funded_amount + randomness)`
         let sponsored_user_point = multi_scalar_mul(
             [G1, G1, G1],
             [EmbeddedCurveScalar {
@@ -152,8 +152,8 @@ impl PrivatelyRefundable for TokenNote {
                 hi: funded_amount_hi
             },
             EmbeddedCurveScalar {
-                lo: refund_nonce_lo,
-                hi: refund_nonce_hi
+                lo: randomness_lo,
+                hi: randomness_hi
             }]
         );
 
@@ -224,8 +224,8 @@ impl PrivatelyRefundable for TokenNote {
         deduce what n is. This is the discrete log problem.
 
         However we can still perform addition/subtraction on points! That is why we generate those two points, which are:
-        fee_payer_point := (fee_payer_npk + nonce) * G
-        sponsored_user_point := (sponsored_user_npk + funded_amount + nonce) * G
+        fee_payer_point := (fee_payer_npk + randomness) * G
+        sponsored_user_point := (sponsored_user_npk + funded_amount + randomness) * G
 
         where `funded_amount` is the total amount in tokens that the sponsored user initially supplied, from which the transaction fee will be subtracted.
 
@@ -236,18 +236,18 @@ impl PrivatelyRefundable for TokenNote {
         Then we arrive at the final points via addition/subtraction of that transaction fee point:
 
         completed_fpc_point := fee_payer_point + fee_point
-                             = (fee_payer_npk + nonce) * G + transaction_fee * G
-                             = (fee_payer_npk + nonce + transaction_fee) * G
+                             = (fee_payer_npk + randomness) * G + transaction_fee * G
+                             = (fee_payer_npk + randomness + transaction_fee) * G
 
         completed_user_point := sponsored_user_point - fee_point
-                              = (sponsored_user_npk + funded_amount + nonce) * G - transaction_fee * G
-                              = (sponsored_user_npk + nonce + (funded_amount - transaction_fee)) * G
+                              = (sponsored_user_npk + funded_amount + randomness) * G - transaction_fee * G
+                              = (sponsored_user_npk + randomness + (funded_amount - transaction_fee)) * G
         
         When we return the x-coordinate of those points, it identically matches the note_content_hash of (and therefore *is*) notes like:
         {
             amount: (funded_amount - transaction_fee),
             npk_m_hash: sponsored_user_npk,
-            randomness: nonce
+            randomness: randomness
         }
         */
 

--- a/noir-projects/noir-contracts/contracts/private_token_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/private_token_contract/src/types/token_note.nr
@@ -117,9 +117,12 @@ impl OwnedNote for TokenNote {
 
 impl PrivatelyRefundable for TokenNote {
     fn generate_refund_points(fee_payer_npk_m_hash: Field, sponsored_user_npk_m_hash: Field, funded_amount: Field, refund_nonce: Field) -> [EmbeddedCurvePoint; 2] {
+        // 1. To be able to multiply generators with nonce and npk_m_hash using barretneberg's blackbox function we
+        // first need to convert the fields to high and low limbs.
         let (refund_nonce_lo, refund_nonce_hi) = decompose(refund_nonce);
         let (fee_payer_lo, fee_payer_hi) = decompose(fee_payer_npk_m_hash);
 
+        // 2. Now that we have correct representationsn of fee payer and refund nonce we can compute `G ^ (fee_payer_npk + refund_nonce)`
         let fee_payer_point = multi_scalar_mul(
             [G1, G1],
             [EmbeddedCurveScalar {
@@ -132,8 +135,12 @@ impl PrivatelyRefundable for TokenNote {
             }]
         );
 
+        // 3. We do the necessary conversion for values relevant for the sponsored user point.
+        // TODO(#7324): representing user with their npk_m_hash here does not work with key rotation
         let (sponsored_user_lo, sponsored_user_hi) = decompose(sponsored_user_npk_m_hash);
         let (funded_amount_lo, funded_amount_hi) = decompose(funded_amount);
+
+        // 4. We compute `G ^ (sponsored_user_npk_m_hash + funded_amount + refund_nonce)`
         let sponsored_user_point = multi_scalar_mul(
             [G1, G1, G1],
             [EmbeddedCurveScalar {
@@ -150,15 +157,16 @@ impl PrivatelyRefundable for TokenNote {
             }]
         );
 
+        // 5. At last we represent the points as EmbeddedCurvePoints and return them.
         [EmbeddedCurvePoint {
             x: fee_payer_point[0],
             y: fee_payer_point[1],
             is_infinite: fee_payer_point[2] == 1
-        },EmbeddedCurvePoint {
+        }, EmbeddedCurvePoint {
             x: sponsored_user_point[0],
             y: sponsored_user_point[1],
             is_infinite: sponsored_user_point[2] == 1
-        } ]
+        }]
     }
 
     fn complete_refund(fee_payer_point: EmbeddedCurvePoint, sponsored_user_point: EmbeddedCurvePoint, transaction_fee: Field) -> [Field; 2] {
@@ -174,7 +182,7 @@ impl PrivatelyRefundable for TokenNote {
         let fee_point = EmbeddedCurvePoint {
             x: fee_point_raw[0],
             y: fee_point_raw[1],
-            is_infinite: fee_point_raw[2] ==1
+            is_infinite: fee_point_raw[2] == 1
         };
 
         /**
@@ -186,7 +194,7 @@ impl PrivatelyRefundable for TokenNote {
 
         So you can think of these (x,y) points as "partial notes": they encode part of the internals of the notes.
 
-        This is because the compute_note_content_hash function above defines the the content hash to be
+        This is because the compute_note_content_hash function above defines the content hash to be
         the x-coordinate of a point defined as:
 
         amount * G + npk * G + randomness * G

--- a/noir-projects/noir-contracts/contracts/private_token_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/private_token_contract/src/types/token_note.nr
@@ -17,14 +17,14 @@ trait OwnedNote {
 trait PrivatelyRefundable {
     fn generate_refund_points(
         fee_payer_npk_m_hash: Field,
-        sponsored_user_npk_m_hash: Field,
+        user_npk_m_hash: Field,
         funded_amount: Field,
         randomness: Field
     ) -> (EmbeddedCurvePoint, EmbeddedCurvePoint);
 
     fn complete_refund(
         incomplete_fee_payer_point: EmbeddedCurvePoint,
-        incomplete_sponsored_user_point: EmbeddedCurvePoint,
+        incomplete_user_point: EmbeddedCurvePoint,
         transaction_fee: Field
     ) -> (Field, Field);
 }
@@ -156,7 +156,7 @@ impl OwnedNote for TokenNote {
  *
  * However we can still perform addition/subtraction on points! That is why we generate those two points, which are:
  * incomplete_fee_payer_point := (fee_payer_npk + randomness) * G
- * incomplete_sponsored_user_point := (sponsored_user_npk + funded_amount + randomness) * G
+ * incomplete_user_point := (user_npk + funded_amount + randomness) * G
  *
  * where `funded_amount` is the total amount in tokens that the sponsored user initially supplied, from which the transaction fee will be subtracted.
  *
@@ -170,19 +170,19 @@ impl OwnedNote for TokenNote {
  *                      = (fee_payer_npk + randomness) * G + transaction_fee * G
  *                      = (fee_payer_npk + randomness + transaction_fee) * G
  *
- * sponsored_user_point := incomplete_sponsored_user_point - fee_point
- *                       = (sponsored_user_npk + funded_amount + randomness) * G - transaction_fee * G
- *                       = (sponsored_user_npk + randomness + (funded_amount - transaction_fee)) * G
+ * user_point := incomplete_user_point - fee_point
+ *                       = (user_npk + funded_amount + randomness) * G - transaction_fee * G
+ *                       = (user_npk + randomness + (funded_amount - transaction_fee)) * G
  * 
  * When we return the x-coordinate of those points, it identically matches the note_content_hash of (and therefore *is*) notes like:
  * {
  *     amount: (funded_amount - transaction_fee),
- *     npk_m_hash: sponsored_user_npk,
+ *     npk_m_hash: user_npk,
  *     randomness: randomness
  * }
  */
 impl PrivatelyRefundable for TokenNote {
-    fn generate_refund_points(fee_payer_npk_m_hash: Field, sponsored_user_npk_m_hash: Field, funded_amount: Field, randomness: Field) -> (EmbeddedCurvePoint, EmbeddedCurvePoint) {
+    fn generate_refund_points(fee_payer_npk_m_hash: Field, user_npk_m_hash: Field, funded_amount: Field, randomness: Field) -> (EmbeddedCurvePoint, EmbeddedCurvePoint) {
         // 1. To be able to multiply generators with randomness and npk_m_hash using barretneberg's (BB) blackbox function we
         // first need to convert the fields to high and low limbs.
         let (randomness_lo, randomness_hi) = decompose(randomness);
@@ -203,15 +203,15 @@ impl PrivatelyRefundable for TokenNote {
 
         // 3. We do the necessary conversion for values relevant for the sponsored user point.
         // TODO(#7324): representing user with their npk_m_hash here does not work with key rotation
-        let (sponsored_user_lo, sponsored_user_hi) = decompose(sponsored_user_npk_m_hash);
+        let (user_lo, user_hi) = decompose(user_npk_m_hash);
         let (funded_amount_lo, funded_amount_hi) = decompose(funded_amount);
 
-        // 4. We compute `G ^ (sponsored_user_npk_m_hash + funded_amount + randomness)`
-        let incomplete_sponsored_user_point = multi_scalar_mul(
+        // 4. We compute `G ^ (user_npk_m_hash + funded_amount + randomness)`
+        let incomplete_user_point = multi_scalar_mul(
             [G1, G1, G1],
             [EmbeddedCurveScalar {
-                lo: sponsored_user_lo,
-                hi: sponsored_user_hi
+                lo: user_lo,
+                hi: user_hi
             },
             EmbeddedCurveScalar {
                 lo: funded_amount_lo,
@@ -229,13 +229,13 @@ impl PrivatelyRefundable for TokenNote {
             y: incomplete_fee_payer_point[1],
             is_infinite: incomplete_fee_payer_point[2] == 1
         }, EmbeddedCurvePoint {
-            x: incomplete_sponsored_user_point[0],
-            y: incomplete_sponsored_user_point[1],
-            is_infinite: incomplete_sponsored_user_point[2] == 1
+            x: incomplete_user_point[0],
+            y: incomplete_user_point[1],
+            is_infinite: incomplete_user_point[2] == 1
         })
     }
 
-    fn complete_refund(incomplete_fee_payer_point: EmbeddedCurvePoint, incomplete_sponsored_user_point: EmbeddedCurvePoint, transaction_fee: Field) -> (Field, Field) {
+    fn complete_refund(incomplete_fee_payer_point: EmbeddedCurvePoint, incomplete_user_point: EmbeddedCurvePoint, transaction_fee: Field) -> (Field, Field) {
         // 1. We convert the transaction fee to high and low limbs to be able to use BB API.
         let (transaction_fee_lo, transaction_fee_hi) = decompose(transaction_fee);
 
@@ -256,11 +256,11 @@ impl PrivatelyRefundable for TokenNote {
         // 3. Now we leverage homomorphism to privately add the fee to fee payer point and subtract it from
         // the sponsored user point in public.
         let fee_payer_point = incomplete_fee_payer_point + fee_point;
-        let sponsored_user_point = incomplete_sponsored_user_point - fee_point;
+        let user_point = incomplete_user_point - fee_point;
 
-        assert_eq(sponsored_user_point.is_infinite, false);
+        assert_eq(user_point.is_infinite, false);
 
         // Finally we return the x-coordinates of the points which are the note content hashes.
-        (fee_payer_point.x, sponsored_user_point.x)
+        (fee_payer_point.x, user_point.x)
     }
 }

--- a/noir-projects/noir-contracts/contracts/private_token_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/private_token_contract/src/types/token_note.nr
@@ -74,9 +74,9 @@ impl NoteInterface<TOKEN_NOTE_LEN, TOKEN_NOTE_BYTES_LEN> for TokenNote {
     fn compute_note_content_hash(self) -> Field {
         let (npk_lo, npk_hi) = decompose(self.npk_m_hash);
         let (random_lo, random_hi) = decompose(self.randomness);
-        // We compute the note content hash as `G ^ (amount + npk_m_hash + randomness)` instead of using pedersen
-        // or poseidon2 because it allows us to privately add and subtract from amount in public by leveraging
-        // homomorphism.
+        // We compute the note content hash as an x-coordinate of `G ^ (amount + npk_m_hash + randomness)` instead
+        // of using pedersen or poseidon2 because it allows us to privately add and subtract from amount in public
+        // by leveraging homomorphism.
         multi_scalar_mul(
             [G1, G1, G1],
             [EmbeddedCurveScalar {
@@ -118,6 +118,69 @@ impl OwnedNote for TokenNote {
     }
 }
 
+/**
+ * What is happening below?
+ *
+ * First in generate_refund_points, we create two points on the grumpkin curve;
+ * these are going to be eventually turned into notes:
+ * one for the user, and one for the fee payer.
+ *
+ * So you can think of these (x,y) points as "partial notes": they encode part of the internals of the notes.
+ *
+ * This is because the compute_note_content_hash function above defines the content hash to be
+ * the x-coordinate of a point defined as:
+ *
+ * amount * G + npk * G + randomness * G
+ *   = (amount + npk + randomness) * G
+ * 
+ * where G is a generator point. Interesting point here is that we actually need to convert
+ * - amount
+ * - npk
+ * - randomness
+ * from grumpkin Field elements
+ * (which have a modulus of 21888242871839275222246405745257275088548364400416034343698204186575808495617)
+ * into a grumpkin scalar
+ * (which have a modulus of 21888242871839275222246405745257275088696311157297823662689037894645226208583)
+ *
+ * The intuition for this is that the Field elements define the domain of the x,y coordinates for points on the curves,
+ * but the number of points on the curve is actually greater than the size of that domain.
+ *
+ * (Consider, e.g. if the curve were defined over a field of 10 elements, and each x coord had two corresponding y for +/-)
+ *
+ * For a bit more info, see
+ * https://hackmd.io/@aztec-network/ByzgNxBfd#2-Grumpkin---A-curve-on-top-of-BN-254-for-SNARK-efficient-group-operations
+ *
+ *
+ * Anyway, if we have a secret scalar n := amount + npk + randomness, and then we reveal a point n * G, there is no efficient way to
+ * deduce what n is. This is the discrete log problem.
+ *
+ * However we can still perform addition/subtraction on points! That is why we generate those two points, which are:
+ * incomplete_fee_payer_point := (fee_payer_npk + randomness) * G
+ * incomplete_sponsored_user_point := (sponsored_user_npk + funded_amount + randomness) * G
+ *
+ * where `funded_amount` is the total amount in tokens that the sponsored user initially supplied, from which the transaction fee will be subtracted.
+ *
+ * So we pass those points into the teardown function (here) and compute a third point corresponding to the transaction fee as just
+ *
+ * fee_point := transaction_fee * G
+ *
+ * Then we arrive at the final points via addition/subtraction of that transaction fee point:
+ *
+ * fee_payer_point := incomplete_fee_payer_point + fee_point
+ *                      = (fee_payer_npk + randomness) * G + transaction_fee * G
+ *                      = (fee_payer_npk + randomness + transaction_fee) * G
+ *
+ * sponsored_user_point := incomplete_sponsored_user_point - fee_point
+ *                       = (sponsored_user_npk + funded_amount + randomness) * G - transaction_fee * G
+ *                       = (sponsored_user_npk + randomness + (funded_amount - transaction_fee)) * G
+ * 
+ * When we return the x-coordinate of those points, it identically matches the note_content_hash of (and therefore *is*) notes like:
+ * {
+ *     amount: (funded_amount - transaction_fee),
+ *     npk_m_hash: sponsored_user_npk,
+ *     randomness: randomness
+ * }
+ */
 impl PrivatelyRefundable for TokenNote {
     fn generate_refund_points(fee_payer_npk_m_hash: Field, sponsored_user_npk_m_hash: Field, funded_amount: Field, randomness: Field) -> (EmbeddedCurvePoint, EmbeddedCurvePoint) {
         // 1. To be able to multiply generators with randomness and npk_m_hash using barretneberg's (BB) blackbox function we
@@ -189,70 +252,6 @@ impl PrivatelyRefundable for TokenNote {
             y: fee_point_raw[1],
             is_infinite: fee_point_raw[2] == 1
         };
-
-        /**
-        What is happening here?
-
-        Back up in generate_refund_points, we created two points on the grumpkin curve;
-        these are going to be eventually turned into notes:
-        one for the user, and one for the FPC.
-
-        So you can think of these (x,y) points as "partial notes": they encode part of the internals of the notes.
-
-        This is because the compute_note_content_hash function above defines the content hash to be
-        the x-coordinate of a point defined as:
-
-        amount * G + npk * G + randomness * G
-          = (amount + npk + randomness) * G
-        
-        where G is a generator point. Interesting point here is that we actually need to convert
-        - amount
-        - npk
-        - randomness
-        from grumpkin Field elements
-        (which have a modulus of 21888242871839275222246405745257275088548364400416034343698204186575808495617)
-        into a grumpkin scalar
-        (which have a modulus of 21888242871839275222246405745257275088696311157297823662689037894645226208583)
-
-        The intuition for this is that the Field elements define the domain of the x,y coordinates for points on the curves,
-        but the number of points on the curve is actually greater than the size of that domain.
-
-        (Consider, e.g. if the curve were defined over a field of 10 elements, and each x coord had two corresponding y for +/-)
-
-        For a bit more info, see
-        https://hackmd.io/@aztec-network/ByzgNxBfd#2-Grumpkin---A-curve-on-top-of-BN-254-for-SNARK-efficient-group-operations
-
-
-        Anyway, if we have a secret scalar n := amount + npk + randomness, and then we reveal a point n * G, there is no efficient way to
-        deduce what n is. This is the discrete log problem.
-
-        However we can still perform addition/subtraction on points! That is why we generate those two points, which are:
-        incomplete_fee_payer_point := (fee_payer_npk + randomness) * G
-        incomplete_sponsored_user_point := (sponsored_user_npk + funded_amount + randomness) * G
-
-        where `funded_amount` is the total amount in tokens that the sponsored user initially supplied, from which the transaction fee will be subtracted.
-
-        So we pass those points into the teardown function (here) and compute a third point corresponding to the transaction fee as just
-
-        fee_point := transaction_fee * G
-
-        Then we arrive at the final points via addition/subtraction of that transaction fee point:
-
-        fee_payer_point := incomplete_fee_payer_point + fee_point
-                             = (fee_payer_npk + randomness) * G + transaction_fee * G
-                             = (fee_payer_npk + randomness + transaction_fee) * G
-
-        sponsored_user_point := incomplete_sponsored_user_point - fee_point
-                              = (sponsored_user_npk + funded_amount + randomness) * G - transaction_fee * G
-                              = (sponsored_user_npk + randomness + (funded_amount - transaction_fee)) * G
-        
-        When we return the x-coordinate of those points, it identically matches the note_content_hash of (and therefore *is*) notes like:
-        {
-            amount: (funded_amount - transaction_fee),
-            npk_m_hash: sponsored_user_npk,
-            randomness: randomness
-        }
-        */
 
         // 3. Now we leverage homomorphism to privately add the fee to fee payer point and subtract it from
         // the sponsored user point in public.

--- a/noir-projects/noir-contracts/contracts/private_token_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/private_token_contract/src/types/token_note.nr
@@ -23,7 +23,7 @@ trait PrivatelyRefundable {
     ) -> (EmbeddedCurvePoint, EmbeddedCurvePoint);
 
     fn complete_refund(
-        Incomplete_fee_payer_point: EmbeddedCurvePoint,
+        incomplete_fee_payer_point: EmbeddedCurvePoint,
         incomplete_sponsored_user_point: EmbeddedCurvePoint,
         transaction_fee: Field
     ) -> (Field, Field);
@@ -74,6 +74,9 @@ impl NoteInterface<TOKEN_NOTE_LEN, TOKEN_NOTE_BYTES_LEN> for TokenNote {
     fn compute_note_content_hash(self) -> Field {
         let (npk_lo, npk_hi) = decompose(self.npk_m_hash);
         let (random_lo, random_hi) = decompose(self.randomness);
+        // We compute the note content hash as `G ^ (amount + npk_m_hash + randomness)` instead of using pedersen
+        // or poseidon2 because it allows us to privately add and subtract from amount in public by leveraging
+        // homomorphism.
         multi_scalar_mul(
             [G1, G1, G1],
             [EmbeddedCurveScalar {
@@ -123,7 +126,7 @@ impl PrivatelyRefundable for TokenNote {
         let (fee_payer_npk_m_hash_lo, fee_payer_npk_m_hash_hi) = decompose(fee_payer_npk_m_hash);
 
         // 2. Now that we have correct representationsn of fee payer and randomness we can compute `G ^ (fee_payer_npk + randomness)`
-        let Incomplete_fee_payer_point = multi_scalar_mul(
+        let incomplete_fee_payer_point = multi_scalar_mul(
             [G1, G1],
             [EmbeddedCurveScalar {
                 lo: fee_payer_npk_m_hash_lo,
@@ -159,9 +162,9 @@ impl PrivatelyRefundable for TokenNote {
 
         // 5. At last we represent the points as EmbeddedCurvePoints and return them.
         (EmbeddedCurvePoint {
-            x: Incomplete_fee_payer_point[0],
-            y: Incomplete_fee_payer_point[1],
-            is_infinite: Incomplete_fee_payer_point[2] == 1
+            x: incomplete_fee_payer_point[0],
+            y: incomplete_fee_payer_point[1],
+            is_infinite: incomplete_fee_payer_point[2] == 1
         }, EmbeddedCurvePoint {
             x: incomplete_sponsored_user_point[0],
             y: incomplete_sponsored_user_point[1],
@@ -169,7 +172,7 @@ impl PrivatelyRefundable for TokenNote {
         })
     }
 
-    fn complete_refund(Incomplete_fee_payer_point: EmbeddedCurvePoint, incomplete_sponsored_user_point: EmbeddedCurvePoint, transaction_fee: Field) -> (Field, Field) {
+    fn complete_refund(incomplete_fee_payer_point: EmbeddedCurvePoint, incomplete_sponsored_user_point: EmbeddedCurvePoint, transaction_fee: Field) -> (Field, Field) {
         // 1. We convert the transaction fee to high and low limbs to be able to use BB API.
         let (transaction_fee_lo, transaction_fee_hi) = decompose(transaction_fee);
 
@@ -224,7 +227,7 @@ impl PrivatelyRefundable for TokenNote {
         deduce what n is. This is the discrete log problem.
 
         However we can still perform addition/subtraction on points! That is why we generate those two points, which are:
-        Incomplete_fee_payer_point := (fee_payer_npk + randomness) * G
+        incomplete_fee_payer_point := (fee_payer_npk + randomness) * G
         incomplete_sponsored_user_point := (sponsored_user_npk + funded_amount + randomness) * G
 
         where `funded_amount` is the total amount in tokens that the sponsored user initially supplied, from which the transaction fee will be subtracted.
@@ -235,7 +238,7 @@ impl PrivatelyRefundable for TokenNote {
 
         Then we arrive at the final points via addition/subtraction of that transaction fee point:
 
-        fee_payer_point := Incomplete_fee_payer_point + fee_point
+        fee_payer_point := incomplete_fee_payer_point + fee_point
                              = (fee_payer_npk + randomness) * G + transaction_fee * G
                              = (fee_payer_npk + randomness + transaction_fee) * G
 
@@ -253,7 +256,7 @@ impl PrivatelyRefundable for TokenNote {
 
         // 3. Now we leverage homomorphism to privately add the fee to fee payer point and subtract it from
         // the sponsored user point in public.
-        let fee_payer_point = Incomplete_fee_payer_point + fee_point;
+        let fee_payer_point = incomplete_fee_payer_point + fee_point;
         let sponsored_user_point = incomplete_sponsored_user_point - fee_point;
 
         assert_eq(sponsored_user_point.is_infinite, false);

--- a/noir-projects/noir-contracts/contracts/private_token_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/private_token_contract/src/types/token_note.nr
@@ -23,8 +23,8 @@ trait PrivatelyRefundable {
     ) -> (EmbeddedCurvePoint, EmbeddedCurvePoint);
 
     fn complete_refund(
-        fee_payer_point: EmbeddedCurvePoint,
-        sponsored_user_point: EmbeddedCurvePoint,
+        Incomplete_fee_payer_point: EmbeddedCurvePoint,
+        incomplete_sponsored_user_point: EmbeddedCurvePoint,
         transaction_fee: Field
     ) -> (Field, Field);
 }
@@ -123,7 +123,7 @@ impl PrivatelyRefundable for TokenNote {
         let (fee_payer_npk_m_hash_lo, fee_payer_npk_m_hash_hi) = decompose(fee_payer_npk_m_hash);
 
         // 2. Now that we have correct representationsn of fee payer and randomness we can compute `G ^ (fee_payer_npk + randomness)`
-        let fee_payer_point = multi_scalar_mul(
+        let Incomplete_fee_payer_point = multi_scalar_mul(
             [G1, G1],
             [EmbeddedCurveScalar {
                 lo: fee_payer_npk_m_hash_lo,
@@ -141,7 +141,7 @@ impl PrivatelyRefundable for TokenNote {
         let (funded_amount_lo, funded_amount_hi) = decompose(funded_amount);
 
         // 4. We compute `G ^ (sponsored_user_npk_m_hash + funded_amount + randomness)`
-        let sponsored_user_point = multi_scalar_mul(
+        let incomplete_sponsored_user_point = multi_scalar_mul(
             [G1, G1, G1],
             [EmbeddedCurveScalar {
                 lo: sponsored_user_lo,
@@ -159,17 +159,17 @@ impl PrivatelyRefundable for TokenNote {
 
         // 5. At last we represent the points as EmbeddedCurvePoints and return them.
         (EmbeddedCurvePoint {
-            x: fee_payer_point[0],
-            y: fee_payer_point[1],
-            is_infinite: fee_payer_point[2] == 1
+            x: Incomplete_fee_payer_point[0],
+            y: Incomplete_fee_payer_point[1],
+            is_infinite: Incomplete_fee_payer_point[2] == 1
         }, EmbeddedCurvePoint {
-            x: sponsored_user_point[0],
-            y: sponsored_user_point[1],
-            is_infinite: sponsored_user_point[2] == 1
+            x: incomplete_sponsored_user_point[0],
+            y: incomplete_sponsored_user_point[1],
+            is_infinite: incomplete_sponsored_user_point[2] == 1
         })
     }
 
-    fn complete_refund(fee_payer_point: EmbeddedCurvePoint, sponsored_user_point: EmbeddedCurvePoint, transaction_fee: Field) -> (Field, Field) {
+    fn complete_refund(Incomplete_fee_payer_point: EmbeddedCurvePoint, incomplete_sponsored_user_point: EmbeddedCurvePoint, transaction_fee: Field) -> (Field, Field) {
         // 1. We convert the transaction fee to high and low limbs to be able to use BB API.
         let (transaction_fee_lo, transaction_fee_hi) = decompose(transaction_fee);
 
@@ -224,8 +224,8 @@ impl PrivatelyRefundable for TokenNote {
         deduce what n is. This is the discrete log problem.
 
         However we can still perform addition/subtraction on points! That is why we generate those two points, which are:
-        fee_payer_point := (fee_payer_npk + randomness) * G
-        sponsored_user_point := (sponsored_user_npk + funded_amount + randomness) * G
+        Incomplete_fee_payer_point := (fee_payer_npk + randomness) * G
+        incomplete_sponsored_user_point := (sponsored_user_npk + funded_amount + randomness) * G
 
         where `funded_amount` is the total amount in tokens that the sponsored user initially supplied, from which the transaction fee will be subtracted.
 
@@ -235,11 +235,11 @@ impl PrivatelyRefundable for TokenNote {
 
         Then we arrive at the final points via addition/subtraction of that transaction fee point:
 
-        completed_fpc_point := fee_payer_point + fee_point
+        fee_payer_point := Incomplete_fee_payer_point + fee_point
                              = (fee_payer_npk + randomness) * G + transaction_fee * G
                              = (fee_payer_npk + randomness + transaction_fee) * G
 
-        completed_user_point := sponsored_user_point - fee_point
+        sponsored_user_point := incomplete_sponsored_user_point - fee_point
                               = (sponsored_user_npk + funded_amount + randomness) * G - transaction_fee * G
                               = (sponsored_user_npk + randomness + (funded_amount - transaction_fee)) * G
         
@@ -251,11 +251,14 @@ impl PrivatelyRefundable for TokenNote {
         }
         */
 
-        let completed_fpc_point = fee_payer_point + fee_point;
+        // 3. Now we leverage homomorphism to privately add the fee to fee payer point and subtract it from
+        // the sponsored user point in public.
+        let fee_payer_point = Incomplete_fee_payer_point + fee_point;
+        let sponsored_user_point = incomplete_sponsored_user_point - fee_point;
 
-        let completed_user_point = sponsored_user_point - fee_point;
-        assert_eq(completed_user_point.is_infinite, false);
+        assert_eq(sponsored_user_point.is_infinite, false);
 
-        (completed_fpc_point.x, completed_user_point.x)
+        // Finally we return the x-coordinates of the points which are the note content hashes.
+        (fee_payer_point.x, sponsored_user_point.x)
     }
 }

--- a/noir-projects/noir-contracts/contracts/private_token_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/private_token_contract/src/types/token_note.nr
@@ -20,13 +20,13 @@ trait PrivatelyRefundable {
         sponsored_user_npk_m_hash: Field,
         funded_amount: Field,
         refund_nonce: Field
-    ) -> [EmbeddedCurvePoint; 2];
+    ) -> (EmbeddedCurvePoint, EmbeddedCurvePoint);
 
     fn complete_refund(
         fee_payer_point: EmbeddedCurvePoint,
         sponsored_user_point: EmbeddedCurvePoint,
         transaction_fee: Field
-    ) -> [Field; 2];
+    ) -> (Field, Field);
 }
 
 global TOKEN_NOTE_LEN: Field = 3; // 3 plus a header.
@@ -116,8 +116,8 @@ impl OwnedNote for TokenNote {
 }
 
 impl PrivatelyRefundable for TokenNote {
-    fn generate_refund_points(fee_payer_npk_m_hash: Field, sponsored_user_npk_m_hash: Field, funded_amount: Field, refund_nonce: Field) -> [EmbeddedCurvePoint; 2] {
-        // 1. To be able to multiply generators with nonce and npk_m_hash using barretneberg's blackbox function we
+    fn generate_refund_points(fee_payer_npk_m_hash: Field, sponsored_user_npk_m_hash: Field, funded_amount: Field, refund_nonce: Field) -> (EmbeddedCurvePoint, EmbeddedCurvePoint) {
+        // 1. To be able to multiply generators with nonce and npk_m_hash using barretneberg's (BB) blackbox function we
         // first need to convert the fields to high and low limbs.
         let (refund_nonce_lo, refund_nonce_hi) = decompose(refund_nonce);
         let (fee_payer_lo, fee_payer_hi) = decompose(fee_payer_npk_m_hash);
@@ -158,7 +158,7 @@ impl PrivatelyRefundable for TokenNote {
         );
 
         // 5. At last we represent the points as EmbeddedCurvePoints and return them.
-        [EmbeddedCurvePoint {
+        (EmbeddedCurvePoint {
             x: fee_payer_point[0],
             y: fee_payer_point[1],
             is_infinite: fee_payer_point[2] == 1
@@ -166,12 +166,14 @@ impl PrivatelyRefundable for TokenNote {
             x: sponsored_user_point[0],
             y: sponsored_user_point[1],
             is_infinite: sponsored_user_point[2] == 1
-        }]
+        })
     }
 
-    fn complete_refund(fee_payer_point: EmbeddedCurvePoint, sponsored_user_point: EmbeddedCurvePoint, transaction_fee: Field) -> [Field; 2] {
-
+    fn complete_refund(fee_payer_point: EmbeddedCurvePoint, sponsored_user_point: EmbeddedCurvePoint, transaction_fee: Field) -> (Field, Field) {
+        // 1. We convert the transaction fee to high and low limbs to be able to use BB API.
         let (transaction_fee_lo, transaction_fee_hi) = decompose(transaction_fee);
+
+        // 2. We compute the fee point as `G ^ transaction_fee`
         let fee_point_raw = multi_scalar_mul(
             [G1],
             [EmbeddedCurveScalar {
@@ -254,6 +256,6 @@ impl PrivatelyRefundable for TokenNote {
         let completed_user_point = sponsored_user_point - fee_point;
         assert_eq(completed_user_point.is_infinite, false);
 
-        [completed_fpc_point.x, completed_user_point.x]
+        (completed_fpc_point.x, completed_user_point.x)
     }
 }

--- a/yarn-project/end-to-end/src/e2e_fees/dapp_subscription.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/dapp_subscription.test.ts
@@ -67,32 +67,33 @@ describe('e2e_fees dapp_subscription', () => {
 
   beforeAll(async () => {
     await expectMapping(
-      t.gasBalances,
+      t.getGasBalanceFn,
       [aliceAddress, sequencerAddress, subscriptionContract.address, bananaFPC.address],
       [0n, 0n, t.INITIAL_GAS_BALANCE, t.INITIAL_GAS_BALANCE],
     );
 
     await expectMapping(
-      t.bananaPrivateBalances,
+      t.getBananaPrivateBalanceFn,
       [aliceAddress, bobAddress, bananaFPC.address],
       [t.ALICE_INITIAL_BANANAS, 0n, 0n],
     );
 
     await expectMapping(
-      t.bananaPublicBalances,
+      t.getBananaPublicBalanceFn,
       [aliceAddress, bobAddress, bananaFPC.address],
       [t.ALICE_INITIAL_BANANAS, 0n, 0n],
     );
   });
 
   beforeEach(async () => {
-    [initialSubscriptionContractGasBalance, initialSequencerGasBalance, initialFPCGasBalance] = (await t.gasBalances(
-      subscriptionContract,
-      sequencerAddress,
+    [initialSubscriptionContractGasBalance, initialSequencerGasBalance, initialFPCGasBalance] =
+      (await t.getGasBalanceFn(subscriptionContract, sequencerAddress, bananaFPC)) as Balances;
+    initialBananasPublicBalances = (await t.getBananaPublicBalanceFn(aliceAddress, bobAddress, bananaFPC)) as Balances;
+    initialBananasPrivateBalances = (await t.getBananaPrivateBalanceFn(
+      aliceAddress,
+      bobAddress,
       bananaFPC,
     )) as Balances;
-    initialBananasPublicBalances = (await t.bananaPublicBalances(aliceAddress, bobAddress, bananaFPC)) as Balances;
-    initialBananasPrivateBalances = (await t.bananaPrivateBalances(aliceAddress, bobAddress, bananaFPC)) as Balances;
   });
 
   it('should allow Alice to subscribe by paying privately with bananas', async () => {
@@ -112,7 +113,7 @@ describe('e2e_fees dapp_subscription', () => {
     );
 
     await expectMapping(
-      t.gasBalances,
+      t.getGasBalanceFn,
       [sequencerAddress, bananaFPC.address],
       [initialSequencerGasBalance, initialFPCGasBalance - transactionFee!],
     );
@@ -140,7 +141,7 @@ describe('e2e_fees dapp_subscription', () => {
     );
 
     await expectMapping(
-      t.gasBalances,
+      t.getGasBalanceFn,
       [sequencerAddress, bananaFPC.address],
       [initialSequencerGasBalance, initialFPCGasBalance - transactionFee!],
     );
@@ -170,7 +171,7 @@ describe('e2e_fees dapp_subscription', () => {
     expect(await counterContract.methods.get_counter(bobAddress).simulate()).toBe(1n);
 
     await expectMapping(
-      t.gasBalances,
+      t.getGasBalanceFn,
       [sequencerAddress, subscriptionContract.address],
       [initialSequencerGasBalance, initialSubscriptionContractGasBalance - transactionFee!],
     );
@@ -216,7 +217,7 @@ describe('e2e_fees dapp_subscription', () => {
   const expectBananasPrivateDelta = (aliceAmount: bigint, bobAmount: bigint, fpcAmount: bigint) =>
     expectMappingDelta(
       initialBananasPrivateBalances,
-      t.bananaPrivateBalances,
+      t.getBananaPrivateBalanceFn,
       [aliceAddress, bobAddress, bananaFPC.address],
       [aliceAmount, bobAmount, fpcAmount],
     );
@@ -224,7 +225,7 @@ describe('e2e_fees dapp_subscription', () => {
   const expectBananasPublicDelta = (aliceAmount: bigint, bobAmount: bigint, fpcAmount: bigint) =>
     expectMappingDelta(
       initialBananasPublicBalances,
-      t.bananaPublicBalances,
+      t.getBananaPublicBalanceFn,
       [aliceAddress, bobAddress, bananaFPC.address],
       [aliceAmount, bobAmount, fpcAmount],
     );

--- a/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
@@ -40,15 +40,15 @@ describe('e2e_fees failures', () => {
     const OutrageousPublicAmountAliceDoesNotHave = BigInt(1e8);
     const PrivateMintedAlicePrivateBananas = BigInt(1e15);
 
-    const [initialAlicePrivateBananas, initialFPCPrivateBananas] = await t.bananaPrivateBalances(
+    const [initialAlicePrivateBananas, initialFPCPrivateBananas] = await t.getBananaPrivateBalanceFn(
       aliceAddress,
       bananaFPC.address,
     );
-    const [initialAlicePublicBananas, initialFPCPublicBananas] = await t.bananaPublicBalances(
+    const [initialAlicePublicBananas, initialFPCPublicBananas] = await t.getBananaPublicBalanceFn(
       aliceAddress,
       bananaFPC.address,
     );
-    const [initialAliceGas, initialFPCGas] = await t.gasBalances(aliceAddress, bananaFPC.address);
+    const [initialAliceGas, initialFPCGas] = await t.getGasBalanceFn(aliceAddress, bananaFPC.address);
 
     await t.mintPrivateBananas(PrivateMintedAlicePrivateBananas, aliceAddress);
 
@@ -68,16 +68,16 @@ describe('e2e_fees failures', () => {
 
     // we did not pay the fee, because we did not submit the TX
     await expectMapping(
-      t.bananaPrivateBalances,
+      t.getBananaPrivateBalanceFn,
       [aliceAddress, bananaFPC.address],
       [initialAlicePrivateBananas + PrivateMintedAlicePrivateBananas, initialFPCPrivateBananas],
     );
     await expectMapping(
-      t.bananaPublicBalances,
+      t.getBananaPublicBalanceFn,
       [aliceAddress, bananaFPC.address],
       [initialAlicePublicBananas, initialFPCPublicBananas],
     );
-    await expectMapping(t.gasBalances, [aliceAddress, bananaFPC.address], [initialAliceGas, initialFPCGas]);
+    await expectMapping(t.getGasBalanceFn, [aliceAddress, bananaFPC.address], [initialAliceGas, initialFPCGas]);
 
     // if we skip simulation, it includes the failed TX
     const rebateSecret = Fr.random();
@@ -100,7 +100,7 @@ describe('e2e_fees failures', () => {
 
     // and thus we paid the fee
     await expectMapping(
-      t.bananaPrivateBalances,
+      t.getBananaPrivateBalanceFn,
       [aliceAddress, bananaFPC.address],
       [
         // alice paid the maximum amount in private bananas
@@ -109,11 +109,15 @@ describe('e2e_fees failures', () => {
       ],
     );
     await expectMapping(
-      t.bananaPublicBalances,
+      t.getBananaPublicBalanceFn,
       [aliceAddress, bananaFPC.address],
       [initialAlicePublicBananas, initialFPCPublicBananas + feeAmount],
     );
-    await expectMapping(t.gasBalances, [aliceAddress, bananaFPC.address], [initialAliceGas, initialFPCGas - feeAmount]);
+    await expectMapping(
+      t.getGasBalanceFn,
+      [aliceAddress, bananaFPC.address],
+      [initialAliceGas, initialFPCGas - feeAmount],
+    );
 
     // Alice can redeem her shield to get the rebate
     const refund = gasSettings.getFeeLimit().toBigInt() - feeAmount;
@@ -123,7 +127,7 @@ describe('e2e_fees failures', () => {
     await bananaCoin.methods.redeem_shield(aliceAddress, refund, rebateSecret).send().wait();
 
     await expectMapping(
-      t.bananaPrivateBalances,
+      t.getBananaPrivateBalanceFn,
       [aliceAddress, bananaFPC.address],
       [initialAlicePrivateBananas + PrivateMintedAlicePrivateBananas - feeAmount, initialFPCPrivateBananas],
     );
@@ -133,15 +137,15 @@ describe('e2e_fees failures', () => {
     const OutrageousPublicAmountAliceDoesNotHave = BigInt(1e15);
     const PublicMintedAlicePublicBananas = BigInt(1e12);
 
-    const [initialAlicePrivateBananas, initialFPCPrivateBananas] = await t.bananaPrivateBalances(
+    const [initialAlicePrivateBananas, initialFPCPrivateBananas] = await t.getBananaPrivateBalanceFn(
       aliceAddress,
       bananaFPC.address,
     );
-    const [initialAlicePublicBananas, initialFPCPublicBananas] = await t.bananaPublicBalances(
+    const [initialAlicePublicBananas, initialFPCPublicBananas] = await t.getBananaPublicBalanceFn(
       aliceAddress,
       bananaFPC.address,
     );
-    const [initialAliceGas, initialFPCGas, initialSequencerGas] = await t.gasBalances(
+    const [initialAliceGas, initialFPCGas, initialSequencerGas] = await t.getGasBalanceFn(
       aliceAddress,
       bananaFPC.address,
       sequencerAddress,
@@ -163,17 +167,17 @@ describe('e2e_fees failures', () => {
 
     // we did not pay the fee, because we did not submit the TX
     await expectMapping(
-      t.bananaPrivateBalances,
+      t.getBananaPrivateBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [initialAlicePrivateBananas, initialFPCPrivateBananas, 0n],
     );
     await expectMapping(
-      t.bananaPublicBalances,
+      t.getBananaPublicBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [initialAlicePublicBananas + PublicMintedAlicePublicBananas, initialFPCPublicBananas, 0n],
     );
     await expectMapping(
-      t.gasBalances,
+      t.getGasBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [initialAliceGas, initialFPCGas, initialSequencerGas],
     );
@@ -195,17 +199,17 @@ describe('e2e_fees failures', () => {
 
     // and thus we paid the fee
     await expectMapping(
-      t.bananaPrivateBalances,
+      t.getBananaPrivateBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [initialAlicePrivateBananas, initialFPCPrivateBananas, 0n],
     );
     await expectMapping(
-      t.bananaPublicBalances,
+      t.getBananaPublicBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [initialAlicePublicBananas + PublicMintedAlicePublicBananas - feeAmount, initialFPCPublicBananas + feeAmount, 0n],
     );
     await expectMapping(
-      t.gasBalances,
+      t.getGasBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [initialAliceGas, initialFPCGas - feeAmount, initialSequencerGas],
     );
@@ -248,15 +252,15 @@ describe('e2e_fees failures', () => {
      */
     const PublicMintedAlicePublicBananas = 100_000_000_000n;
 
-    const [initialAlicePrivateBananas, initialFPCPrivateBananas] = await t.bananaPrivateBalances(
+    const [initialAlicePrivateBananas, initialFPCPrivateBananas] = await t.getBananaPrivateBalanceFn(
       aliceAddress,
       bananaFPC.address,
     );
-    const [initialAlicePublicBananas, initialFPCPublicBananas] = await t.bananaPublicBalances(
+    const [initialAlicePublicBananas, initialFPCPublicBananas] = await t.getBananaPublicBalanceFn(
       aliceAddress,
       bananaFPC.address,
     );
-    const [initialAliceGas, initialFPCGas, initialSequencerGas] = await t.gasBalances(
+    const [initialAliceGas, initialFPCGas, initialSequencerGas] = await t.getGasBalanceFn(
       aliceAddress,
       bananaFPC.address,
       sequencerAddress,
@@ -299,13 +303,13 @@ describe('e2e_fees failures', () => {
     expect(receipt.transactionFee).toBeGreaterThan(0n);
 
     await expectMapping(
-      t.bananaPrivateBalances,
+      t.getBananaPrivateBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [initialAlicePrivateBananas, initialFPCPrivateBananas, 0n],
     );
     // Since setup went through, Alice transferred to the FPC
     await expectMapping(
-      t.bananaPublicBalances,
+      t.getBananaPublicBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [
         initialAlicePublicBananas + PublicMintedAlicePublicBananas - badGas.getFeeLimit().toBigInt(),
@@ -314,7 +318,7 @@ describe('e2e_fees failures', () => {
       ],
     );
     await expectMapping(
-      t.gasBalances,
+      t.getGasBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [initialAliceGas, initialFPCGas - receipt.transactionFee!, initialSequencerGas],
     );

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -74,10 +74,10 @@ export class FeesTest {
   public gasBridgeTestHarness!: IGasBridgingTestHarness;
 
   public getCoinbaseBalance!: () => Promise<bigint>;
-  public gasBalances!: BalancesFn;
-  public bananaPublicBalances!: BalancesFn;
-  public bananaPrivateBalances!: BalancesFn;
-  public privateTokenBalances!: BalancesFn;
+  public getGasBalanceFn!: BalancesFn;
+  public getBananaPublicBalanceFn!: BalancesFn;
+  public getBananaPrivateBalanceFn!: BalancesFn;
+  public getPrivateTokenBalanceFn!: BalancesFn;
 
   public readonly INITIAL_GAS_BALANCE = BigInt(1e15);
   public readonly ALICE_INITIAL_BANANAS = BigInt(1e12);
@@ -210,7 +210,7 @@ export class FeesTest {
       async (_data, context) => {
         this.gasTokenContract = await GasTokenContract.at(getCanonicalGasToken().address, this.aliceWallet);
 
-        this.gasBalances = getBalancesFn('⛽', this.gasTokenContract.methods.balance_of_public, this.logger);
+        this.getGasBalanceFn = getBalancesFn('⛽', this.gasTokenContract.methods.balance_of_public, this.logger);
 
         const { publicClient, walletClient } = createL1Clients(context.aztecNodeConfig.rpcUrl, MNEMONIC);
         this.gasBridgeTestHarness = await GasPortalTestingHarnessFactory.create({
@@ -277,7 +277,11 @@ export class FeesTest {
         this.privateToken = await PrivateTokenContract.at(data.privateTokenAddress, this.aliceWallet);
 
         const logger = this.logger;
-        this.privateTokenBalances = getBalancesFn('🕵️.private', this.privateToken.methods.balance_of_private, logger);
+        this.getPrivateTokenBalanceFn = getBalancesFn(
+          '🕵️.private',
+          this.privateToken.methods.balance_of_private,
+          logger,
+        );
       },
     );
   }
@@ -313,8 +317,12 @@ export class FeesTest {
         this.bananaFPC = bananaFPC;
 
         const logger = this.logger;
-        this.bananaPublicBalances = getBalancesFn('🍌.public', this.bananaCoin.methods.balance_of_public, logger);
-        this.bananaPrivateBalances = getBalancesFn('🍌.private', this.bananaCoin.methods.balance_of_private, logger);
+        this.getBananaPublicBalanceFn = getBalancesFn('🍌.public', this.bananaCoin.methods.balance_of_public, logger);
+        this.getBananaPrivateBalanceFn = getBalancesFn(
+          '🍌.private',
+          this.bananaCoin.methods.balance_of_private,
+          logger,
+        );
 
         this.getCoinbaseBalance = async () => {
           const { walletClient } = createL1Clients(context.aztecNodeConfig.rpcUrl, MNEMONIC);

--- a/yarn-project/end-to-end/src/e2e_fees/private_payments.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/private_payments.test.ts
@@ -69,9 +69,9 @@ describe('e2e_fees private_payment', () => {
       [InitialAlicePublicBananas, InitialBobPublicBananas, InitialFPCPublicBananas],
       [InitialAliceGas, InitialFPCGas, InitialSequencerGas],
     ] = await Promise.all([
-      t.bananaPrivateBalances(aliceAddress, bobAddress, bananaFPC.address),
-      t.bananaPublicBalances(aliceAddress, bobAddress, bananaFPC.address),
-      t.gasBalances(aliceAddress, bananaFPC.address, sequencerAddress),
+      t.getBananaPrivateBalanceFn(aliceAddress, bobAddress, bananaFPC.address),
+      t.getBananaPublicBalanceFn(aliceAddress, bobAddress, bananaFPC.address),
+      t.getGasBalanceFn(aliceAddress, bananaFPC.address, sequencerAddress),
     ]);
   });
 
@@ -142,17 +142,17 @@ describe('e2e_fees private_payment', () => {
     const [feeAmount, refundAmount] = getFeeAndRefund(tx);
 
     await expectMapping(
-      t.bananaPrivateBalances,
+      t.getBananaPrivateBalanceFn,
       [aliceAddress, bobAddress, bananaFPC.address, sequencerAddress],
       [InitialAlicePrivateBananas - maxFee - transferAmount, transferAmount, InitialFPCPrivateBananas, 0n],
     );
     await expectMapping(
-      t.bananaPublicBalances,
+      t.getBananaPublicBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [InitialAlicePublicBananas, InitialFPCPublicBananas + maxFee - refundAmount, 0n],
     );
     await expectMapping(
-      t.gasBalances,
+      t.getGasBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [InitialAliceGas, InitialFPCGas - feeAmount, InitialSequencerGas],
     );
@@ -199,17 +199,17 @@ describe('e2e_fees private_payment', () => {
     const [feeAmount, refundAmount] = getFeeAndRefund(tx);
 
     await expectMapping(
-      t.bananaPrivateBalances,
+      t.getBananaPrivateBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [InitialAlicePrivateBananas - maxFee + newlyMintedBananas, InitialFPCPrivateBananas, 0n],
     );
     await expectMapping(
-      t.bananaPublicBalances,
+      t.getBananaPublicBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [InitialAlicePublicBananas, InitialFPCPublicBananas + maxFee - refundAmount, 0n],
     );
     await expectMapping(
-      t.gasBalances,
+      t.getGasBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [InitialAliceGas, InitialFPCGas - feeAmount, InitialSequencerGas],
     );
@@ -259,17 +259,17 @@ describe('e2e_fees private_payment', () => {
     const [feeAmount, refundAmount] = getFeeAndRefund(tx);
 
     await expectMapping(
-      t.bananaPrivateBalances,
+      t.getBananaPrivateBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [InitialAlicePrivateBananas - maxFee, InitialFPCPrivateBananas, 0n],
     );
     await expectMapping(
-      t.bananaPublicBalances,
+      t.getBananaPublicBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [InitialAlicePublicBananas - shieldedBananas, InitialFPCPublicBananas + maxFee - refundAmount, 0n],
     );
     await expectMapping(
-      t.gasBalances,
+      t.getGasBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [InitialAliceGas, InitialFPCGas - feeAmount, InitialSequencerGas],
     );
@@ -327,7 +327,7 @@ describe('e2e_fees private_payment', () => {
     const [feeAmount, refundAmount] = getFeeAndRefund(tx);
 
     await expectMapping(
-      t.bananaPrivateBalances,
+      t.getBananaPrivateBalanceFn,
       [aliceAddress, bobAddress, bananaFPC.address, sequencerAddress],
       [
         InitialAlicePrivateBananas - maxFee - privateTransfer,
@@ -337,12 +337,12 @@ describe('e2e_fees private_payment', () => {
       ],
     );
     await expectMapping(
-      t.bananaPublicBalances,
+      t.getBananaPublicBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [InitialAlicePublicBananas - shieldedBananas, InitialFPCPublicBananas + maxFee - refundAmount, 0n],
     );
     await expectMapping(
-      t.gasBalances,
+      t.getGasBalanceFn,
       [aliceAddress, bananaFPC.address, sequencerAddress],
       [InitialAliceGas, InitialFPCGas - feeAmount, InitialSequencerGas],
     );
@@ -362,7 +362,7 @@ describe('e2e_fees private_payment', () => {
       .send()
       .deployed();
 
-    await expectMapping(t.gasBalances, [bankruptFPC.address], [0n]);
+    await expectMapping(t.getGasBalanceFn, [bankruptFPC.address], [0n]);
 
     await expect(
       bananaCoin.methods

--- a/yarn-project/end-to-end/src/e2e_fees/private_refunds.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/private_refunds.test.ts
@@ -141,10 +141,10 @@ class PrivateRefundPaymentMethod implements FeePaymentMethod {
     private wallet: Wallet,
 
     /**
-     * A nonce to mix in with the generated notes.
+     * A randomness to mix in with the generated notes.
      * Use this to reconstruct note preimages for the PXE.
      */
-    private rebateNonce: Fr,
+    private randomness: Fr,
 
     /**
      * The hash of the master nullifier public key that the FPC sends notes it receives to.
@@ -176,7 +176,7 @@ class PrivateRefundPaymentMethod implements FeePaymentMethod {
       caller: this.paymentContract,
       action: {
         name: 'setup_refund',
-        args: [this.feeRecipientNpkMHash, this.wallet.getCompleteAddress().address, maxFee, this.rebateNonce],
+        args: [this.feeRecipientNpkMHash, this.wallet.getCompleteAddress().address, maxFee, this.randomness],
         selector: FunctionSelector.fromSignature('setup_refund(Field,(Field),Field,Field)'),
         type: FunctionType.PRIVATE,
         isStatic: false,
@@ -192,7 +192,7 @@ class PrivateRefundPaymentMethod implements FeePaymentMethod {
         selector: FunctionSelector.fromSignature('fund_transaction_privately(Field,(Field),Field)'),
         type: FunctionType.PRIVATE,
         isStatic: false,
-        args: [maxFee, this.asset, this.rebateNonce],
+        args: [maxFee, this.asset, this.randomness],
         returnTypes: [],
       },
     ];

--- a/yarn-project/end-to-end/src/e2e_fees/private_refunds.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/private_refunds.test.ts
@@ -20,6 +20,7 @@ describe('e2e_fees/private_refunds', () => {
   let privateFPC: PrivateFPCContract;
 
   let initialAliceBalance: bigint;
+  // Bob is the admin of the fee paying contract
   let initialBobBalance: bigint;
   let initialFPCGasBalance: bigint;
 

--- a/yarn-project/end-to-end/src/e2e_fees/private_refunds.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/private_refunds.test.ts
@@ -41,8 +41,8 @@ describe('e2e_fees/private_refunds', () => {
 
   beforeEach(async () => {
     [[initialAliceBalance, initialBobBalance], [initialFPCGasBalance]] = await Promise.all([
-      t.privateTokenBalances(aliceAddress, t.bobAddress),
-      t.gasBalances(privateFPC.address),
+      t.getPrivateTokenBalanceFn(aliceAddress, t.bobAddress),
+      t.getGasBalanceFn(privateFPC.address),
     ]);
   });
 
@@ -114,10 +114,10 @@ describe('e2e_fees/private_refunds', () => {
     );
 
     // 7. At last we check that the gas balance of FPC has decreased exactly by the transaction fee ...
-    await expectMapping(t.gasBalances, [privateFPC.address], [initialFPCGasBalance - tx.transactionFee!]);
+    await expectMapping(t.getGasBalanceFn, [privateFPC.address], [initialFPCGasBalance - tx.transactionFee!]);
     // ... and that the transaction fee was correctly transferred from Alice to Bob.
     await expectMapping(
-      t.privateTokenBalances,
+      t.getPrivateTokenBalanceFn,
       [aliceAddress, t.bobAddress],
       [initialAliceBalance - tx.transactionFee!, initialBobBalance + tx.transactionFee!],
     );

--- a/yarn-project/end-to-end/src/e2e_fees/private_refunds.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/private_refunds.test.ts
@@ -100,6 +100,8 @@ describe('e2e_fees/private_refunds', () => {
 
     // 5. Now we reconstruct the note for the final fee payment. It should contain the transaction fee, Bob's
     // npk_m_hash (set in the paymentMethod above) and the randomness.
+    // Note that FPC emits randomness as unencrypted log and the tx fee is publicly know so Bob is able to reconstruct
+    // his note just from on-chain data.
     const bobFeeNote = new Note([new Fr(tx.transactionFee!), bobNpkMHash, randomness]);
 
     // 6. Once again we add the note to PXE which computes the note hash and checks that it is in the note hash tree.


### PR DESCRIPTION
I've been going through the private refunds today and since it's all quite complex I decided to add more comments and clean that up 
