### PR TITLE
feat: Remove proof from L1 Rollup process

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -142,6 +142,49 @@ contract Rollup is IRollup {
     emit L2BlockProcessed(header.globalVariables.blockNumber);
   }
 
+  function submitProof(
+    bytes calldata _header,
+    bytes32 _archive,
+    bytes calldata _aggregationObject,
+    bytes calldata _proof
+  ) external override(IRollup) {
+    HeaderLib.Header memory header = HeaderLib.decode(_header);
+
+    bytes32[] memory publicInputs =
+      new bytes32[](3 + Constants.HEADER_LENGTH + Constants.AGGREGATION_OBJECT_LENGTH);
+    // the archive tree root
+    publicInputs[0] = _archive;
+    // this is the _next_ available leaf in the archive tree
+    // normally this should be equal to the block number (since leaves are 0-indexed and blocks 1-indexed)
+    // but in yarn-project/merkle-tree/src/new_tree.ts we prefill the tree so that block N is in leaf N
+    publicInputs[1] = bytes32(header.globalVariables.blockNumber + 1);
+
+    publicInputs[2] = vkTreeRoot;
+
+    bytes32[] memory headerFields = HeaderLib.toFields(header);
+    for (uint256 i = 0; i < headerFields.length; i++) {
+      publicInputs[i + 3] = headerFields[i];
+    }
+
+    // the block proof is recursive, which means it comes with an aggregation object
+    // this snippet copies it into the public inputs needed for verification
+    // it also guards against empty _aggregationObject used with mocked proofs
+    uint256 aggregationLength = _aggregationObject.length / 32;
+    for (uint256 i = 0; i < Constants.AGGREGATION_OBJECT_LENGTH && i < aggregationLength; i++) {
+      bytes32 part;
+      assembly {
+        part := calldataload(add(_aggregationObject.offset, mul(i, 32)))
+      }
+      publicInputs[i + 3 + Constants.HEADER_LENGTH] = part;
+    }
+
+    if (!verifier.verify(_proof, publicInputs)) {
+      revert Errors.Rollup__InvalidProof();
+    }
+
+    emit L2ProofVerified(header.globalVariables.blockNumber);
+  }
+
   function _computePublicInputHash(bytes calldata _header, bytes32 _archive)
     internal
     pure

--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -101,14 +101,8 @@ contract Rollup is IRollup {
    * @notice Process an incoming L2 block and progress the state
    * @param _header - The L2 block header
    * @param _archive - A root of the archive tree after the L2 block is applied
-   * @param _proof - The proof of correct execution
    */
-  function process(
-    bytes calldata _header,
-    bytes32 _archive,
-    bytes calldata _aggregationObject,
-    bytes calldata _proof
-  ) external override(IRollup) {
+  function process(bytes calldata _header, bytes32 _archive) external override(IRollup) {
     // Decode and validate header
     HeaderLib.Header memory header = HeaderLib.decode(_header);
     HeaderLib.validate(header, VERSION, lastBlockTs, archive);
@@ -122,38 +116,6 @@ contract Rollup is IRollup {
     address sequencer = whoseTurnIsIt(header.globalVariables.blockNumber);
     if (sequencer != address(0x0) && sequencer != msg.sender) {
       revert Errors.Rollup__InvalidSequencer(msg.sender);
-    }
-
-    bytes32[] memory publicInputs =
-      new bytes32[](3 + Constants.HEADER_LENGTH + Constants.AGGREGATION_OBJECT_LENGTH);
-    // the archive tree root
-    publicInputs[0] = _archive;
-    // this is the _next_ available leaf in the archive tree
-    // normally this should be equal to the block number (since leaves are 0-indexed and blocks 1-indexed)
-    // but in yarn-project/merkle-tree/src/new_tree.ts we prefill the tree so that block N is in leaf N
-    publicInputs[1] = bytes32(header.globalVariables.blockNumber + 1);
-
-    publicInputs[2] = vkTreeRoot;
-
-    bytes32[] memory headerFields = HeaderLib.toFields(header);
-    for (uint256 i = 0; i < headerFields.length; i++) {
-      publicInputs[i + 3] = headerFields[i];
-    }
-
-    // the block proof is recursive, which means it comes with an aggregation object
-    // this snippet copies it into the public inputs needed for verification
-    // it also guards against empty _aggregationObject used with mocked proofs
-    uint256 aggregationLength = _aggregationObject.length / 32;
-    for (uint256 i = 0; i < Constants.AGGREGATION_OBJECT_LENGTH && i < aggregationLength; i++) {
-      bytes32 part;
-      assembly {
-        part := calldataload(add(_aggregationObject.offset, mul(i, 32)))
-      }
-      publicInputs[i + 3 + Constants.HEADER_LENGTH] = part;
-    }
-
-    if (!verifier.verify(_proof, publicInputs)) {
-      revert Errors.Rollup__InvalidProof();
     }
 
     archive = _archive;

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -5,12 +5,7 @@ pragma solidity >=0.8.18;
 interface IRollup {
   event L2BlockProcessed(uint256 indexed blockNumber);
 
-  function process(
-    bytes calldata _header,
-    bytes32 _archive,
-    bytes calldata _aggregationObject,
-    bytes memory _proof
-  ) external;
+  function process(bytes calldata _header, bytes32 _archive) external;
 
   function setVerifier(address _verifier) external;
 }

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -4,8 +4,16 @@ pragma solidity >=0.8.18;
 
 interface IRollup {
   event L2BlockProcessed(uint256 indexed blockNumber);
+  event L2ProofVerified(uint256 indexed blockNumber);
 
   function process(bytes calldata _header, bytes32 _archive) external;
+
+  function submitProof(
+    bytes calldata _header,
+    bytes32 _archive,
+    bytes calldata _aggregationObject,
+    bytes calldata _proof
+  ) external;
 
   function setVerifier(address _verifier) external;
 }

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -85,7 +85,7 @@ contract RollupTest is DecoderBase {
     availabilityOracle.publish(body);
 
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidChainId.selector, 0x420, 31337));
-    rollup.process(header, archive, bytes(""), bytes(""));
+    rollup.process(header, archive);
   }
 
   function testRevertInvalidVersion() public {
@@ -101,7 +101,7 @@ contract RollupTest is DecoderBase {
     availabilityOracle.publish(body);
 
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidVersion.selector, 0x420, 1));
-    rollup.process(header, archive, bytes(""), bytes(""));
+    rollup.process(header, archive);
   }
 
   function testRevertTimestampInFuture() public {
@@ -118,7 +118,7 @@ contract RollupTest is DecoderBase {
     availabilityOracle.publish(body);
 
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__TimestampInFuture.selector));
-    rollup.process(header, archive, bytes(""), bytes(""));
+    rollup.process(header, archive);
   }
 
   function testRevertTimestampTooOld() public {
@@ -133,7 +133,7 @@ contract RollupTest is DecoderBase {
     availabilityOracle.publish(body);
 
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__TimestampTooOld.selector));
-    rollup.process(header, archive, bytes(""), bytes(""));
+    rollup.process(header, archive);
   }
 
   function _testBlock(string memory name) public {
@@ -153,7 +153,7 @@ contract RollupTest is DecoderBase {
     uint256 toConsume = inbox.toConsume();
 
     vm.record();
-    rollup.process(header, archive, bytes(""), bytes(""));
+    rollup.process(header, archive);
 
     assertEq(inbox.toConsume(), toConsume + 1, "Message subtree not consumed");
 

--- a/yarn-project/accounts/package.local.json
+++ b/yarn-project/accounts/package.local.json
@@ -7,10 +7,5 @@
     "build:ts": "tsc -b",
     "clean": "rm -rf ./dest .tsbuildinfo ./artifacts"
   },
-  "files": [
-    "dest",
-    "src",
-    "artifacts",
-    "!*.test.*"
-  ]
+  "files": ["dest", "src", "artifacts", "!*.test.*"]
 }

--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -248,12 +248,10 @@ function makeMessageSentEvent(l1BlockNum: bigint, l2BlockNumber: bigint, index: 
 function makeRollupTx(l2Block: L2Block) {
   const header = toHex(l2Block.header.toBuffer());
   const archive = toHex(l2Block.archive.root.toBuffer());
-  const aggregationObject = `0x`;
-  const proof = `0x`;
   const input = encodeFunctionData({
     abi: RollupAbi,
     functionName: 'process',
-    args: [header, archive, aggregationObject, proof],
+    args: [header, archive],
   });
   return { input } as Transaction<bigint, number>;
 }

--- a/yarn-project/archiver/src/archiver/eth_log_handlers.ts
+++ b/yarn-project/archiver/src/archiver/eth_log_handlers.ts
@@ -91,7 +91,7 @@ async function getBlockMetadataFromRollupTx(
   if (functionName !== 'process') {
     throw new Error(`Unexpected method called ${functionName}`);
   }
-  const [headerHex, archiveRootHex] = args! as readonly [Hex, Hex, Hex, Hex];
+  const [headerHex, archiveRootHex] = args! as readonly [Hex, Hex];
 
   const header = Header.fromBuffer(Buffer.from(hexToBytes(headerHex)));
 

--- a/yarn-project/circuit-types/src/stats/stats.ts
+++ b/yarn-project/circuit-types/src/stats/stats.ts
@@ -26,10 +26,8 @@ export type L2BlockStats = {
   unencryptedLogSize?: number;
 };
 
-/** Stats logged for each L1 rollup publish tx.*/
+/** Stats logged for each L1 publish tx.*/
 export type L1PublishStats = {
-  /** Name of the event for metrics purposes */
-  eventName: 'rollup-published-to-l1';
   /** Effective gas price of the tx. */
   gasPrice: bigint;
   /** Effective gas used in the tx. */
@@ -40,7 +38,20 @@ export type L1PublishStats = {
   calldataGas: number;
   /** Size in bytes of the calldata. */
   calldataSize: number;
-} & L2BlockStats;
+};
+
+/** Stats logged for each L1 rollup publish tx.*/
+export type L1PublishBlockStats = {
+  /** Name of the event for metrics purposes */
+  eventName: 'rollup-published-to-l1';
+} & L1PublishStats &
+  L2BlockStats;
+
+/** Stats logged for each L1 rollup publish tx.*/
+export type L1PublishProofStats = {
+  /** Name of the event for metrics purposes */
+  eventName: 'proof-published-to-l1';
+} & L1PublishStats;
 
 /** Stats logged for synching node chain history.  */
 export type NodeSyncedChainHistoryStats = {
@@ -271,7 +282,8 @@ export type Stats =
   | CircuitSimulationStats
   | CircuitWitnessGenerationStats
   | PublicDBAccessStats
-  | L1PublishStats
+  | L1PublishBlockStats
+  | L1PublishProofStats
   | L2BlockBuiltStats
   | L2BlockHandledStats
   | NodeSyncedChainHistoryStats

--- a/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
@@ -27,9 +27,7 @@ import {
   MAX_NULLIFIERS_PER_TX,
   MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
   NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
-  type Proof,
   PublicDataUpdateRequest,
-  makeEmptyProof,
 } from '@aztec/circuits.js';
 import { fr, makeProof } from '@aztec/circuits.js/testing';
 import { type L1ContractAddresses, createEthereumChain } from '@aztec/ethereum';
@@ -89,7 +87,6 @@ describe('L1Publisher integration', () => {
   let outbox: GetContractReturnType<typeof OutboxAbi, PublicClient<HttpTransport, Chain>>;
 
   let publisher: L1Publisher;
-  let l2Proof: Proof;
 
   let builder: TxProver;
   let builderDb: MerkleTrees;
@@ -147,7 +144,6 @@ describe('L1Publisher integration', () => {
     const worldStateSynchronizer = new ServerWorldStateSynchronizer(tmpStore, builderDb, blockSource, worldStateConfig);
     await worldStateSynchronizer.start();
     builder = await TxProver.new(config, worldStateSynchronizer, new NoopTelemetryClient());
-    l2Proof = makeEmptyProof();
 
     publisher = getL1Publisher({
       rpcUrl: config.rpcUrl,
@@ -411,7 +407,7 @@ describe('L1Publisher integration', () => {
 
       writeJson(`mixed_block_${i}`, block, l1ToL2Content, recipientAddress, deployerAccount.address);
 
-      await publisher.processL2Block(block, [], l2Proof);
+      await publisher.processL2Block(block);
 
       const logs = await publicClient.getLogs({
         address: rollupAddress,
@@ -431,12 +427,7 @@ describe('L1Publisher integration', () => {
       const expectedData = encodeFunctionData({
         abi: RollupAbi,
         functionName: 'process',
-        args: [
-          `0x${block.header.toBuffer().toString('hex')}`,
-          `0x${block.archive.root.toBuffer().toString('hex')}`,
-          `0x`, // empty aggregation object
-          `0x${l2Proof.withoutPublicInputs().toString('hex')}`,
-        ],
+        args: [`0x${block.header.toBuffer().toString('hex')}`, `0x${block.archive.root.toBuffer().toString('hex')}`],
       });
       expect(ethTx.input).toEqual(expectedData);
 
@@ -501,7 +492,7 @@ describe('L1Publisher integration', () => {
 
       writeJson(`empty_block_${i}`, block, [], AztecAddress.ZERO, deployerAccount.address);
 
-      await publisher.processL2Block(block, [], l2Proof);
+      await publisher.processL2Block(block);
 
       const logs = await publicClient.getLogs({
         address: rollupAddress,
@@ -521,12 +512,7 @@ describe('L1Publisher integration', () => {
       const expectedData = encodeFunctionData({
         abi: RollupAbi,
         functionName: 'process',
-        args: [
-          `0x${block.header.toBuffer().toString('hex')}`,
-          `0x${block.archive.root.toBuffer().toString('hex')}`,
-          `0x`, // empty aggregation object
-          `0x${l2Proof.withoutPublicInputs().toString('hex')}`,
-        ],
+        args: [`0x${block.header.toBuffer().toString('hex')}`, `0x${block.archive.root.toBuffer().toString('hex')}`],
       });
       expect(ethTx.input).toEqual(expectedData);
     }

--- a/yarn-project/end-to-end/src/composed/integration_proof_verification.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_proof_verification.test.ts
@@ -3,7 +3,7 @@ import { BBCircuitVerifier } from '@aztec/bb-prover';
 import { AGGREGATION_OBJECT_LENGTH, Fr, HEADER_LENGTH, Proof } from '@aztec/circuits.js';
 import { type L1ContractAddresses } from '@aztec/ethereum';
 import { type Logger } from '@aztec/foundation/log';
-import { BufferReader } from '@aztec/foundation/serialize';
+import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import { AvailabilityOracleAbi, RollupAbi } from '@aztec/l1-artifacts';
 
 import { type Anvil } from '@viem/anvil';
@@ -157,7 +157,7 @@ describe('proof_verification', () => {
     });
   });
 
-  describe.skip('Rollup', () => {
+  describe('Rollup', () => {
     let availabilityContract: GetContractReturnType<typeof AvailabilityOracleAbi, typeof walletClient>;
     let rollupContract: GetContractReturnType<typeof RollupAbi, typeof walletClient>;
 
@@ -183,9 +183,11 @@ describe('proof_verification', () => {
       const args = [
         `0x${block.header.toBuffer().toString('hex')}`,
         `0x${block.archive.root.toBuffer().toString('hex')}`,
+        `0x${serializeToBuffer(aggregationObject).toString('hex')}`,
+        `0x${proof.withoutPublicInputs().toString('hex')}`,
       ] as const;
 
-      await expect(rollupContract.write.process(args)).resolves.toBeDefined();
+      await expect(rollupContract.write.submitProof(args)).resolves.toBeDefined();
     });
   });
 });

--- a/yarn-project/end-to-end/src/composed/integration_proof_verification.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_proof_verification.test.ts
@@ -3,7 +3,7 @@ import { BBCircuitVerifier } from '@aztec/bb-prover';
 import { AGGREGATION_OBJECT_LENGTH, Fr, HEADER_LENGTH, Proof } from '@aztec/circuits.js';
 import { type L1ContractAddresses } from '@aztec/ethereum';
 import { type Logger } from '@aztec/foundation/log';
-import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
+import { BufferReader } from '@aztec/foundation/serialize';
 import { AvailabilityOracleAbi, RollupAbi } from '@aztec/l1-artifacts';
 
 import { type Anvil } from '@viem/anvil';
@@ -157,7 +157,7 @@ describe('proof_verification', () => {
     });
   });
 
-  describe('Rollup', () => {
+  describe.skip('Rollup', () => {
     let availabilityContract: GetContractReturnType<typeof AvailabilityOracleAbi, typeof walletClient>;
     let rollupContract: GetContractReturnType<typeof RollupAbi, typeof walletClient>;
 
@@ -183,8 +183,6 @@ describe('proof_verification', () => {
       const args = [
         `0x${block.header.toBuffer().toString('hex')}`,
         `0x${block.archive.root.toBuffer().toString('hex')}`,
-        `0x${serializeToBuffer(aggregationObject).toString('hex')}`,
-        `0x${proof.withoutPublicInputs().toString('hex')}`,
       ] as const;
 
       await expect(rollupContract.write.process(args)).resolves.toBeDefined();

--- a/yarn-project/noir-protocol-circuits-types/package.local.json
+++ b/yarn-project/noir-protocol-circuits-types/package.local.json
@@ -3,10 +3,5 @@
     "build": "yarn clean && yarn generate && tsc -b",
     "clean": "rm -rf ./dest .tsbuildinfo src/types artifacts"
   },
-  "files": [
-    "dest",
-    "src",
-    "artifacts",
-    "!*.test.*"
-  ]
+  "files": ["dest", "src", "artifacts", "!*.test.*"]
 }

--- a/yarn-project/protocol-contracts/package.local.json
+++ b/yarn-project/protocol-contracts/package.local.json
@@ -7,10 +7,5 @@
     "build:ts": "tsc -b",
     "clean": "rm -rf ./dest .tsbuildinfo ./artifacts"
   },
-  "files": [
-    "dest",
-    "src",
-    "artifacts",
-    "!*.test.*"
-  ]
+  "files": ["dest", "src", "artifacts", "!*.test.*"]
 }

--- a/yarn-project/scripts/src/benchmarks/aggregate.ts
+++ b/yarn-project/scripts/src/benchmarks/aggregate.ts
@@ -19,7 +19,7 @@ import {
   type CircuitProvingStats,
   type CircuitSimulationStats,
   type CircuitWitnessGenerationStats,
-  type L1PublishStats,
+  type L1PublishBlockStats,
   type L2BlockBuiltStats,
   type L2BlockHandledStats,
   type MetricName,
@@ -87,7 +87,7 @@ function processAcirProofGenerated(entry: ProofConstructed, results: BenchmarkCo
 }
 
 /** Processes an entry with event name 'rollup-published-to-l1' and updates results */
-function processRollupPublished(entry: L1PublishStats, results: BenchmarkCollectedResults) {
+function processRollupPublished(entry: L1PublishBlockStats, results: BenchmarkCollectedResults) {
   const bucket = entry.txCount;
   if (!BENCHMARK_BLOCK_SIZES.includes(bucket)) {
     return;

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.test.ts
@@ -56,7 +56,7 @@ describe('L1Publisher', () => {
   });
 
   it('publishes l2 block to l1', async () => {
-    const result = await publisher.processL2Block(l2Block, [], makeEmptyProof());
+    const result = await publisher.processL2Block(l2Block);
 
     expect(result).toEqual(true);
     expect(txSender.sendProcessTx).toHaveBeenCalledWith({
@@ -71,7 +71,7 @@ describe('L1Publisher', () => {
 
   it('does not publish if last archive root is different to expected', async () => {
     txSender.getCurrentArchive.mockResolvedValueOnce(L2Block.random(43).archive.root.toBuffer());
-    const result = await publisher.processL2Block(l2Block, [], makeEmptyProof());
+    const result = await publisher.processL2Block(l2Block);
     expect(result).toBe(false);
     expect(txSender.sendPublishTx).not.toHaveBeenCalled();
     expect(txSender.sendProcessTx).not.toHaveBeenCalled();
@@ -80,7 +80,7 @@ describe('L1Publisher', () => {
   it('does not retry if sending a publish tx fails', async () => {
     txSender.sendPublishTx.mockReset().mockRejectedValueOnce(new Error()).mockResolvedValueOnce(publishTxHash);
 
-    const result = await publisher.processL2Block(l2Block, [], makeEmptyProof());
+    const result = await publisher.processL2Block(l2Block);
 
     expect(result).toEqual(false);
     expect(txSender.sendPublishTx).toHaveBeenCalledTimes(1);
@@ -90,7 +90,7 @@ describe('L1Publisher', () => {
   it('does not retry if sending a process tx fails', async () => {
     txSender.sendProcessTx.mockReset().mockRejectedValueOnce(new Error()).mockResolvedValueOnce(processTxHash);
 
-    const result = await publisher.processL2Block(l2Block, [], makeEmptyProof());
+    const result = await publisher.processL2Block(l2Block);
 
     expect(result).toEqual(false);
     expect(txSender.sendPublishTx).toHaveBeenCalledTimes(1);
@@ -105,7 +105,7 @@ describe('L1Publisher', () => {
       .mockRejectedValueOnce(new Error())
       .mockResolvedValueOnce(processTxReceipt);
 
-    const result = await publisher.processL2Block(l2Block, [], makeEmptyProof());
+    const result = await publisher.processL2Block(l2Block);
 
     expect(result).toEqual(true);
     expect(txSender.getTransactionReceipt).toHaveBeenCalledTimes(4);
@@ -114,7 +114,7 @@ describe('L1Publisher', () => {
   it('returns false if publish tx reverts', async () => {
     txSender.getTransactionReceipt.mockReset().mockResolvedValueOnce({ ...publishTxReceipt, status: false });
 
-    const result = await publisher.processL2Block(l2Block, [], makeEmptyProof());
+    const result = await publisher.processL2Block(l2Block);
 
     expect(result).toEqual(false);
   });
@@ -125,7 +125,7 @@ describe('L1Publisher', () => {
       .mockResolvedValueOnce(publishTxReceipt)
       .mockResolvedValueOnce({ ...publishTxReceipt, status: false });
 
-    const result = await publisher.processL2Block(l2Block, [], makeEmptyProof());
+    const result = await publisher.processL2Block(l2Block);
 
     expect(result).toEqual(false);
   });
@@ -133,7 +133,7 @@ describe('L1Publisher', () => {
   it('returns false if sending publish tx is interrupted', async () => {
     txSender.sendPublishTx.mockReset().mockImplementationOnce(() => sleep(10, publishTxHash));
 
-    const resultPromise = publisher.processL2Block(l2Block, [], makeEmptyProof());
+    const resultPromise = publisher.processL2Block(l2Block);
     publisher.interrupt();
     const result = await resultPromise;
 
@@ -144,7 +144,7 @@ describe('L1Publisher', () => {
   it('returns false if sending process tx is interrupted', async () => {
     txSender.sendProcessTx.mockReset().mockImplementationOnce(() => sleep(10, processTxHash));
 
-    const resultPromise = publisher.processL2Block(l2Block, [], makeEmptyProof());
+    const resultPromise = publisher.processL2Block(l2Block);
     publisher.interrupt();
     const result = await resultPromise;
 

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.test.ts
@@ -1,5 +1,4 @@
 import { L2Block } from '@aztec/circuit-types';
-import { makeEmptyProof } from '@aztec/circuits.js';
 import { sleep } from '@aztec/foundation/sleep';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -28,8 +27,6 @@ describe('L1Publisher', () => {
     archive = l2Block.archive.root.toBuffer();
     txsEffectsHash = l2Block.body.getTxsEffectsHash();
     body = l2Block.body.toBuffer();
-    aggregationObject = Buffer.alloc(0);
-    proof = makeEmptyProof().withoutPublicInputs();
 
     txSender = mock<L1PublisherTxSender>();
 

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.test.ts
@@ -18,8 +18,6 @@ describe('L1Publisher', () => {
   let archive: Buffer;
   let txsEffectsHash: Buffer;
   let body: Buffer;
-  let proof: Buffer;
-  let aggregationObject: Buffer;
 
   let publisher: L1Publisher;
 
@@ -59,13 +57,7 @@ describe('L1Publisher', () => {
     const result = await publisher.processL2Block(l2Block);
 
     expect(result).toEqual(true);
-    expect(txSender.sendProcessTx).toHaveBeenCalledWith({
-      header,
-      archive,
-      body,
-      aggregationObject,
-      proof,
-    });
+    expect(txSender.sendProcessTx).toHaveBeenCalledWith({ header, archive, body });
     expect(txSender.getTransactionReceipt).toHaveBeenCalledWith(processTxHash);
   });
 

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -1,8 +1,7 @@
 import { type L2Block } from '@aztec/circuit-types';
 import { type L1PublishStats } from '@aztec/circuit-types/stats';
-import { type EthAddress, type Fr, type Proof } from '@aztec/circuits.js';
+import { type EthAddress } from '@aztec/circuits.js';
 import { createDebugLogger } from '@aztec/foundation/log';
-import { serializeToBuffer } from '@aztec/foundation/serialize';
 import { InterruptibleSleep } from '@aztec/foundation/sleep';
 
 import pick from 'lodash.pick';
@@ -97,10 +96,6 @@ export type L1ProcessArgs = {
   archive: Buffer;
   /** L2 block body. */
   body: Buffer;
-  /** Aggregation object needed to verify the proof */
-  aggregationObject: Buffer;
-  /** Root rollup proof of the L2 block. */
-  proof: Buffer;
 };
 
 /**
@@ -132,7 +127,7 @@ export class L1Publisher implements L2BlockReceiver {
    * @param block - L2 block to publish.
    * @returns True once the tx has been confirmed and is successful, false on revert or interrupt, blocks otherwise.
    */
-  public async processL2Block(block: L2Block, aggregationObject: Fr[], proof: Proof): Promise<boolean> {
+  public async processL2Block(block: L2Block): Promise<boolean> {
     // TODO(#4148) Remove this block number check, it's here because we don't currently have proper genesis state on the contract
     const lastArchive = block.header.lastArchive.root.toBuffer();
     if (block.number != 1 && !(await this.checkLastArchiveHash(lastArchive))) {
@@ -180,8 +175,6 @@ export class L1Publisher implements L2BlockReceiver {
       header: block.header.toBuffer(),
       archive: block.archive.root.toBuffer(),
       body: encodedBody,
-      aggregationObject: serializeToBuffer(aggregationObject),
-      proof: proof.withoutPublicInputs(),
     };
 
     // Process block

--- a/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
+++ b/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
@@ -23,6 +23,7 @@ import * as chains from 'viem/chains';
 import { type TxSenderConfig } from './config.js';
 import {
   type L1PublisherTxSender,
+  type L1SubmitProofArgs,
   type MinimalTransactionReceipt,
   type L1ProcessArgs as ProcessTxArgs,
   type TransactionStats,
@@ -166,6 +167,31 @@ export class ViemTxSender implements L1PublisherTxSender {
       gas,
       account: this.account,
     });
+    return hash;
+  }
+
+  /**
+   * Sends a tx to the L1 rollup contract with a proof. Returns once the tx has been mined.
+   * @param encodedData - Serialized data for the proof.
+   * @returns The hash of the mined tx.
+   */
+  async sendSubmitProofTx(submitProofArgs: L1SubmitProofArgs): Promise<string | undefined> {
+    const { header, archive, aggregationObject, proof } = submitProofArgs;
+    const args = [
+      `0x${header.toString('hex')}`,
+      `0x${archive.toString('hex')}`,
+      `0x${aggregationObject.toString('hex')}`,
+      `0x${proof.toString('hex')}`,
+    ] as const;
+
+    const gas = await this.rollupContract.estimateGas.submitProof(args, {
+      account: this.account,
+    });
+    const hash = await this.rollupContract.write.submitProof(args, {
+      gas,
+      account: this.account,
+    });
+
     return hash;
   }
 

--- a/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
+++ b/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
@@ -157,12 +157,7 @@ export class ViemTxSender implements L1PublisherTxSender {
    * @returns The hash of the mined tx.
    */
   async sendProcessTx(encodedData: ProcessTxArgs): Promise<string | undefined> {
-    const args = [
-      `0x${encodedData.header.toString('hex')}`,
-      `0x${encodedData.archive.toString('hex')}`,
-      `0x${encodedData.aggregationObject.toString('hex')}`,
-      `0x${encodedData.proof.toString('hex')}`,
-    ] as const;
+    const args = [`0x${encodedData.header.toString('hex')}`, `0x${encodedData.archive.toString('hex')}`] as const;
 
     const gas = await this.rollupContract.estimateGas.process(args, {
       account: this.account,

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -148,7 +148,7 @@ describe('sequencer', () => {
       new GlobalVariables(chainId, version, new Fr(lastBlockNumber + 1), Fr.ZERO, coinbase, feeRecipient, gasFees),
       Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n)),
     );
-    expect(publisher.processL2Block).toHaveBeenCalledWith(block, [], proof);
+    expect(publisher.processL2Block).toHaveBeenCalledWith(block);
     expect(proverClient.cancelBlock).toHaveBeenCalledTimes(0);
   });
 
@@ -186,7 +186,7 @@ describe('sequencer', () => {
       new GlobalVariables(chainId, version, new Fr(lastBlockNumber + 1), Fr.ZERO, coinbase, feeRecipient, gasFees),
       Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n)),
     );
-    expect(publisher.processL2Block).toHaveBeenCalledWith(block, [], proof);
+    expect(publisher.processL2Block).toHaveBeenCalledWith(block);
     expect(proverClient.cancelBlock).toHaveBeenCalledTimes(0);
   });
 
@@ -229,7 +229,7 @@ describe('sequencer', () => {
       new GlobalVariables(chainId, version, new Fr(lastBlockNumber + 1), Fr.ZERO, coinbase, feeRecipient, gasFees),
       Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n)),
     );
-    expect(publisher.processL2Block).toHaveBeenCalledWith(block, [], proof);
+    expect(publisher.processL2Block).toHaveBeenCalledWith(block);
     expect(p2p.deleteTxs).toHaveBeenCalledWith([doubleSpendTx.getTxHash()]);
     expect(proverClient.cancelBlock).toHaveBeenCalledTimes(0);
   });
@@ -268,7 +268,7 @@ describe('sequencer', () => {
       new GlobalVariables(chainId, version, new Fr(lastBlockNumber + 1), Fr.ZERO, coinbase, feeRecipient, gasFees),
       Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n)),
     );
-    expect(publisher.processL2Block).toHaveBeenCalledWith(block, [], proof);
+    expect(publisher.processL2Block).toHaveBeenCalledWith(block);
     expect(p2p.deleteTxs).toHaveBeenCalledWith([invalidChainTx.getTxHash()]);
     expect(proverClient.cancelBlock).toHaveBeenCalledTimes(0);
   });
@@ -307,7 +307,7 @@ describe('sequencer', () => {
       new GlobalVariables(chainId, version, new Fr(lastBlockNumber + 1), Fr.ZERO, coinbase, feeRecipient, gasFees),
       Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n)),
     );
-    expect(publisher.processL2Block).toHaveBeenCalledWith(block, [], proof);
+    expect(publisher.processL2Block).toHaveBeenCalledWith(block);
     expect(proverClient.cancelBlock).toHaveBeenCalledTimes(0);
   });
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -13,7 +13,7 @@ import {
   PROVING_STATUS,
 } from '@aztec/circuit-types/interfaces';
 import { type L2BlockBuiltStats } from '@aztec/circuit-types/stats';
-import { AztecAddress, EthAddress, type GlobalVariables, type Header, type Proof } from '@aztec/circuits.js';
+import { AztecAddress, EthAddress, type GlobalVariables, type Header } from '@aztec/circuits.js';
 import { Fr } from '@aztec/foundation/fields';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -294,7 +294,7 @@ export class Sequencer {
     await assertBlockHeight();
 
     // Block is proven, now finalise and publish!
-    const { block, aggregationObject, proof } = await this.prover.finaliseBlock();
+    const { block } = await this.prover.finaliseBlock();
 
     await assertBlockHeight();
 
@@ -306,7 +306,7 @@ export class Sequencer {
       ...block.getStats(),
     } satisfies L2BlockBuiltStats);
 
-    await this.publishL2Block(block, aggregationObject, proof);
+    await this.publishL2Block(block);
     this.log.info(`Submitted rollup block ${block.number} with ${processedTxs.length} transactions`);
   }
 
@@ -317,10 +317,10 @@ export class Sequencer {
   @trackSpan('Sequencer.publishL2Block', block => ({
     [Attributes.BLOCK_NUMBER]: block.number,
   }))
-  protected async publishL2Block(block: L2Block, aggregationObject: Fr[], proof: Proof) {
+  protected async publishL2Block(block: L2Block) {
     // Publishes new block to the network and awaits the tx to be mined
     this.state = SequencerState.PUBLISHING_BLOCK;
-    const publishedL2Block = await this.publisher.processL2Block(block, aggregationObject, proof);
+    const publishedL2Block = await this.publisher.processL2Block(block);
     if (publishedL2Block) {
       this.lastPublishedBlock = block.number;
     } else {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -294,7 +294,7 @@ export class Sequencer {
     await assertBlockHeight();
 
     // Block is proven, now finalise and publish!
-    const { block } = await this.prover.finaliseBlock();
+    const { block, aggregationObject, proof } = await this.prover.finaliseBlock();
 
     await assertBlockHeight();
 
@@ -308,6 +308,14 @@ export class Sequencer {
 
     await this.publishL2Block(block);
     this.log.info(`Submitted rollup block ${block.number} with ${processedTxs.length} transactions`);
+
+    // Submit the proof if we have configured this sequencer to run with a prover.
+    // This is temporary while we submit one proof per block, but will have to change once we
+    // move onto proving batches of multiple blocks at a time.
+    if (aggregationObject && proof) {
+      await this.publisher.submitProof(block.header, block.archive.root, aggregationObject, proof);
+      this.log.info(`Submitted proof for block ${block.number}`);
+    }
   }
 
   /**

--- a/yarn-project/types/src/abi/contract_artifact.ts
+++ b/yarn-project/types/src/abi/contract_artifact.ts
@@ -272,13 +272,17 @@ function getNoteTypes(input: NoirCompiledContract) {
  * @returns Aztec contract build artifact.
  */
 function generateContractArtifact(contract: NoirCompiledContract, aztecNrVersion?: string): ContractArtifact {
-  return {
-    name: contract.name,
-    functions: contract.functions.map(f => generateFunctionArtifact(f, contract)),
-    outputs: contract.outputs,
-    storageLayout: getStorageLayout(contract),
-    notes: getNoteTypes(contract),
-    fileMap: contract.file_map,
-    aztecNrVersion,
-  };
+  try {
+    return {
+      name: contract.name,
+      functions: contract.functions.map(f => generateFunctionArtifact(f, contract)),
+      outputs: contract.outputs,
+      storageLayout: getStorageLayout(contract),
+      notes: getNoteTypes(contract),
+      fileMap: contract.file_map,
+      aztecNrVersion,
+    };
+  } catch (err) {
+    throw new Error(`Could not generate contract artifact for ${contract.name}: ${err}`);
+  }
 }


### PR DESCRIPTION
Moves the proof verification from `Rollup.process` and into a new `submitProof` method, called separately from the sequencer. Eventually we'll want to move it out of the sequencer completely, but this way we don't break the current e2e flow.

See #7346
