### PR TITLE
chore: notify Noir team on changes to the stdlib

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,8 @@
 
 # Notify the Noir team of any changes to ACIR serialization
 /noir/noir-repo/acvm-repo/acir/codegen/* @TomAFrench @vezenovm @guipublic
+# on changes to stdlib
+/noir/noir-repo/noir_stdlib/* @TomAFrench
 
 #####################################################
 # Notify the AVM team


### PR DESCRIPTION
This PR notifies Noir team on changes to the stdlib to avoid these slipping under the radar.