### PR TITLE
feat: populate recipient in outgoing

### DIFF
--- a/boxes/boxes/react/src/contracts/src/main.nr
+++ b/boxes/boxes/react/src/contracts/src/main.nr
@@ -20,7 +20,7 @@ contract BoxReact {
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner_npk_m_hash);
-        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note_with_keys(&mut context, owner_ovpk_m, owner_ivpk_m));
+        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note_with_keys(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
     }
 
     #[aztec(private)]
@@ -33,7 +33,7 @@ contract BoxReact {
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner_npk_m_hash);
-        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note_with_keys(&mut context, owner_ovpk_m, owner_ivpk_m));
+        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note_with_keys(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
     }
 
     unconstrained fn getNumber(owner: AztecAddress) -> pub ValueNote {

--- a/boxes/boxes/vanilla/src/contracts/src/main.nr
+++ b/boxes/boxes/vanilla/src/contracts/src/main.nr
@@ -20,7 +20,7 @@ contract Vanilla {
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner_npk_m_hash);
-        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note_with_keys(&mut context, owner_ovpk_m, owner_ivpk_m));
+        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note_with_keys(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
     }
 
     #[aztec(private)]
@@ -33,7 +33,7 @@ contract Vanilla {
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner_npk_m_hash);
-        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note_with_keys(&mut context, owner_ovpk_m, owner_ivpk_m));
+        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note_with_keys(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
     }
 
     unconstrained fn getNumber(owner: AztecAddress) -> pub ValueNote {

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
@@ -11,9 +11,18 @@ unconstrained fn compute_unconstrained<Event, NB, MB, OB>(
     ovsk_app: Field,
     ovpk: Point,
     ivpk: Point,
+    recipient: AztecAddress,
     event: Event
 ) -> ([u8; OB], Field) where Event: EventInterface<NB, MB>, [u8; NB]: LensForEncryptedEvent<NB, OB> {
-    compute(contract_address, randomness, ovsk_app, ovpk, ivpk, event)
+    compute(
+        contract_address,
+        randomness,
+        ovsk_app,
+        ovpk,
+        ivpk,
+        recipient,
+        event
+    )
 }
 
 fn compute<Event, NB, MB, OB>(
@@ -22,9 +31,18 @@ fn compute<Event, NB, MB, OB>(
     ovsk_app: Field,
     ovpk: Point,
     ivpk: Point,
+    recipient: AztecAddress,
     event: Event
 ) -> ([u8; OB], Field) where Event: EventInterface<NB, MB>, [u8; NB]: LensForEncryptedEvent<NB, OB> {
-    let encrypted_log: [u8; OB] = compute_encrypted_event_log(contract_address, randomness, ovsk_app, ovpk, ivpk, event);
+    let encrypted_log: [u8; OB] = compute_encrypted_event_log(
+        contract_address,
+        randomness,
+        ovsk_app,
+        ovpk,
+        ivpk,
+        recipient,
+        event
+    );
     let log_hash = sha256_to_field(encrypted_log);
     (encrypted_log, log_hash)
 }
@@ -35,11 +53,12 @@ fn emit_with_keys<Event, NB, MB, OB>(
     event: Event,
     ovpk: Point,
     ivpk: Point,
-    inner_compute: fn(AztecAddress, Field, Field, Point, Point, Event) -> ([u8; OB], Field)
+    iv: AztecAddress,
+    inner_compute: fn(AztecAddress, Field, Field, Point, Point, AztecAddress, Event) -> ([u8; OB], Field)
 ) where Event: EventInterface<NB, MB>, [u8; NB]: LensForEncryptedEvent<NB, OB> {
     let contract_address: AztecAddress = context.this_address();
     let ovsk_app: Field  = context.request_ovsk_app(ovpk.hash());
-    let (encrypted_log, log_hash) = inner_compute(contract_address, randomness, ovsk_app, ovpk, ivpk, event);
+    let (encrypted_log, log_hash) = inner_compute(contract_address, randomness, ovsk_app, ovpk, ivpk, iv, event);
     context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
 }
 
@@ -53,7 +72,7 @@ pub fn encode_and_encrypt_event<Event, NB, MB, OB>(
         let ovpk = header.get_ovpk_m(context, ov);
         let ivpk = header.get_ivpk_m(context, iv);
         let randomness = unsafe_rand();
-        emit_with_keys(context, randomness, e, ovpk, ivpk, compute);
+        emit_with_keys(context, randomness, e, ovpk, ivpk, iv, compute);
     }
 }
 
@@ -67,7 +86,7 @@ pub fn encode_and_encrypt_event_unconstrained<Event, NB, MB, OB>(
         let ovpk = header.get_ovpk_m(context, ov);
         let ivpk = header.get_ivpk_m(context, iv);
         let randomness = unsafe_rand();
-        emit_with_keys(context, randomness, e, ovpk, ivpk, compute_unconstrained);
+        emit_with_keys(context, randomness, e, ovpk, ivpk, iv, compute_unconstrained);
     }
 }
 
@@ -81,7 +100,7 @@ pub fn encode_and_encrypt_event_with_randomness<Event, NB, MB, OB>(
         let header = context.get_header();
         let ovpk = header.get_ovpk_m(context, ov);
         let ivpk = header.get_ivpk_m(context, iv);
-        emit_with_keys(context, randomness, e, ovpk, ivpk, compute);
+        emit_with_keys(context, randomness, e, ovpk, ivpk, iv, compute);
     }
 }
 
@@ -95,29 +114,31 @@ pub fn encode_and_encrypt_event_with_randomness_unconstrained<Event, NB, MB, OB>
         let header = context.get_header();
         let ovpk = header.get_ovpk_m(context, ov);
         let ivpk = header.get_ivpk_m(context, iv);
-        emit_with_keys(context, randomness, e, ovpk, ivpk, compute_unconstrained);
+        emit_with_keys(context, randomness, e, ovpk, ivpk, iv, compute_unconstrained);
     }
 }
 
 pub fn encode_and_encrypt_event_with_keys<Event, NB, MB, OB>(
     context: &mut PrivateContext,
     ovpk: Point,
-    ivpk: Point
-) -> fn[(&mut PrivateContext, Point, Point)](Event) -> () where Event: EventInterface<NB, MB>, [u8; NB]: LensForEncryptedEvent<NB, OB> {
+    ivpk: Point,
+    recipient: AztecAddress
+) -> fn[(&mut PrivateContext, Point, Point, AztecAddress)](Event) -> () where Event: EventInterface<NB, MB>, [u8; NB]: LensForEncryptedEvent<NB, OB> {
     | e: Event | {
         let randomness = unsafe_rand();
-        emit_with_keys(context, randomness, e, ovpk, ivpk, compute);
+        emit_with_keys(context, randomness, e, ovpk, ivpk, recipient, compute);
     }
 }
 
 pub fn encode_and_encrypt_event_with_keys_unconstrained<Event, NB, MB, OB>(
     context: &mut PrivateContext,
     ovpk: Point,
-    ivpk: Point
-) -> fn[(&mut PrivateContext, Point, Point)](Event) -> () where Event: EventInterface<NB, MB>, [u8; NB]: LensForEncryptedEvent<NB, OB> {
+    ivpk: Point,
+    recipient: AztecAddress
+) -> fn[(&mut PrivateContext, Point, Point, AztecAddress)](Event) -> () where Event: EventInterface<NB, MB>, [u8; NB]: LensForEncryptedEvent<NB, OB> {
     | e: Event | {
         let randomness = unsafe_rand();
-        emit_with_keys(context, randomness, e, ovpk, ivpk, compute_unconstrained);
+        emit_with_keys(context, randomness, e, ovpk, ivpk, recipient, compute_unconstrained);
     }
 }
 
@@ -125,10 +146,11 @@ pub fn encode_and_encrypt_event_with_keys_with_randomness<Event, NB, MB, OB>(
     context: &mut PrivateContext,
     randomness: Field,
     ovpk: Point,
-    ivpk: Point
-) -> fn[(&mut PrivateContext, Field, Point, Point)](Event) -> () where Event: EventInterface<NB, MB>, [u8; NB]: LensForEncryptedEvent<NB, OB> {
+    ivpk: Point,
+    recipient: AztecAddress
+) -> fn[(&mut PrivateContext, Field, Point, Point, AztecAddress)](Event) -> () where Event: EventInterface<NB, MB>, [u8; NB]: LensForEncryptedEvent<NB, OB> {
     | e: Event | {
-        emit_with_keys(context, randomness, e, ovpk, ivpk, compute);
+        emit_with_keys(context, randomness, e, ovpk, ivpk, recipient, compute);
     }
 }
 
@@ -136,9 +158,10 @@ pub fn encode_and_encrypt_event_with_keys_with_randomness_unconstrained<Event, N
     context: &mut PrivateContext,
     randomness: Field,
     ovpk: Point,
-    ivpk: Point
-) -> fn[(&mut PrivateContext, Field, Point, Point)](Event) -> () where Event: EventInterface<NB, MB>, [u8; NB]: LensForEncryptedEvent<NB, OB> {
+    ivpk: Point,
+    recipient: AztecAddress
+) -> fn[(&mut PrivateContext, Field, Point, Point, AztecAddress)](Event) -> () where Event: EventInterface<NB, MB>, [u8; NB]: LensForEncryptedEvent<NB, OB> {
     | e: Event | {
-        emit_with_keys(context, randomness, e, ovpk, ivpk, compute_unconstrained);
+        emit_with_keys(context, randomness, e, ovpk, ivpk, recipient, compute_unconstrained);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -13,9 +13,18 @@ unconstrained fn compute_unconstrained<Note, N, NB, M>(
     ovsk_app: Field,
     ovpk: Point,
     ivpk: Point,
+    recipient: AztecAddress,
     note: Note
 ) -> ([u8; M], Field) where Note: NoteInterface<N, NB>, [Field; N]: LensForEncryptedLog<N, M> {
-    compute(contract_address, storage_slot, ovsk_app, ovpk, ivpk, note)
+    compute(
+        contract_address,
+        storage_slot,
+        ovsk_app,
+        ovpk,
+        ivpk,
+        recipient,
+        note
+    )
 }
 
 fn compute<Note, N, NB, M>(
@@ -24,9 +33,18 @@ fn compute<Note, N, NB, M>(
     ovsk_app: Field,
     ovpk: Point,
     ivpk: Point,
+    recipient: AztecAddress,
     note: Note
 ) -> ([u8; M], Field) where Note: NoteInterface<N, NB>, [Field; N]: LensForEncryptedLog<N, M> {
-    let encrypted_log: [u8; M] = compute_encrypted_note_log(contract_address, storage_slot, ovsk_app, ovpk, ivpk, note);
+    let encrypted_log: [u8; M] = compute_encrypted_note_log(
+        contract_address,
+        storage_slot,
+        ovsk_app,
+        ovpk,
+        ivpk,
+        recipient,
+        note
+    );
     let log_hash = sha256_to_field(encrypted_log);
     (encrypted_log, log_hash)
 }
@@ -36,7 +54,8 @@ fn emit_with_keys<Note, N, NB, M>(
     note: Note,
     ovpk: Point,
     ivpk: Point,
-    inner_compute: fn(AztecAddress, Field, Field, Point, Point, Note) -> ([u8; M], Field)
+    recipient: AztecAddress,
+    inner_compute: fn(AztecAddress, Field, Field, Point, Point, AztecAddress, Note) -> ([u8; M], Field)
 ) where Note: NoteInterface<N, NB>, [Field; N]: LensForEncryptedLog<N, M> {
     let note_header = note.get_header();
     let note_hash_counter = note_header.note_hash_counter;
@@ -53,7 +72,15 @@ fn emit_with_keys<Note, N, NB, M>(
     let contract_address: AztecAddress = context.this_address();
     let ovsk_app: Field  = context.request_ovsk_app(ovpk.hash());
 
-    let (encrypted_log, log_hash) = inner_compute(contract_address, storage_slot, ovsk_app, ovpk, ivpk, note);
+    let (encrypted_log, log_hash) = inner_compute(
+        contract_address,
+        storage_slot,
+        ovsk_app,
+        ovpk,
+        ivpk,
+        recipient,
+        note
+    );
 
     context.emit_raw_note_log(note_hash_counter, encrypted_log, log_hash);
 }
@@ -67,7 +94,7 @@ pub fn encode_and_encrypt_note<Note, N, NB, M>(
         let header = context.get_header();
         let ovpk = header.get_ovpk_m(context, ov);
         let ivpk = header.get_ivpk_m(context, iv);
-        emit_with_keys(context, e.note, ovpk, ivpk, compute);
+        emit_with_keys(context, e.note, ovpk, ivpk, iv, compute);
     }
 }
 
@@ -80,26 +107,28 @@ pub fn encode_and_encrypt_note_unconstrained<Note, N, NB, M>(
         let header = context.get_header();
         let ovpk = header.get_ovpk_m(context, ov);
         let ivpk = header.get_ivpk_m(context, iv);
-        emit_with_keys(context, e.note, ovpk, ivpk, compute_unconstrained);
+        emit_with_keys(context, e.note, ovpk, ivpk, iv, compute_unconstrained);
     }
 }
 
 pub fn encode_and_encrypt_note_with_keys<Note, N, NB, M>(
     context: &mut PrivateContext,
     ovpk: Point,
-    ivpk: Point
-) -> fn[(&mut PrivateContext, Point, Point)](NoteEmission<Note>) -> () where Note: NoteInterface<N, NB>, [Field; N]: LensForEncryptedLog<N, M> {
+    ivpk: Point,
+    recipient: AztecAddress
+) -> fn[(&mut PrivateContext, Point, Point, AztecAddress)](NoteEmission<Note>) -> () where Note: NoteInterface<N, NB>, [Field; N]: LensForEncryptedLog<N, M> {
     | e: NoteEmission<Note> | {
-        emit_with_keys(context, e.note, ovpk, ivpk, compute);
+        emit_with_keys(context, e.note, ovpk, ivpk, recipient, compute);
     }
 }
 
 pub fn encode_and_encrypt_note_with_keys_unconstrained<Note, N, NB, M>(
     context: &mut PrivateContext,
     ovpk: Point,
-    ivpk: Point
-) -> fn[(&mut PrivateContext, Point, Point)](NoteEmission<Note>) -> () where Note: NoteInterface<N, NB>, [Field; N]: LensForEncryptedLog<N, M> {
+    ivpk: Point,
+    recipient: AztecAddress
+) -> fn[(&mut PrivateContext, Point, Point, AztecAddress)](NoteEmission<Note>) -> () where Note: NoteInterface<N, NB>, [Field; N]: LensForEncryptedLog<N, M> {
     | e: NoteEmission<Note> | {
-        emit_with_keys(context, e.note, ovpk, ivpk, compute_unconstrained);
+        emit_with_keys(context, e.note, ovpk, ivpk, recipient, compute_unconstrained);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
@@ -21,14 +21,12 @@ pub fn compute_encrypted_event_log<Event, NB, MB, OB>(
     ovsk_app: Field,
     ovpk: Point,
     ivpk: Point,
+    recipient: AztecAddress,
     event: Event
 ) -> [u8; OB] where Event: EventInterface<NB, MB> {
     // @todo Need to draw randomness from the full domain of Fq not only Fr
     let eph_sk: Scalar = fr_to_fq(unsafe_rand());
     let eph_pk = derive_public_key(eph_sk);
-
-    // TODO: (#7177) This value needs to be populated!
-    let recipient = AztecAddress::from_field(0);
 
     let ivpk_app = compute_ivpk_app(ivpk, contract_address);
 
@@ -78,14 +76,12 @@ pub fn compute_encrypted_note_log<Note, N, NB, M>(
     ovsk_app: Field,
     ovpk: Point,
     ivpk: Point,
+    recipient: AztecAddress,
     note: Note
 ) -> [u8; M] where Note: NoteInterface<N, NB> {
     // @todo Need to draw randomness from the full domain of Fq not only Fr
     let eph_sk: Scalar = fr_to_fq(unsafe_rand());
     let eph_pk = derive_public_key(eph_sk);
-
-    // TODO: (#7177) This value needs to be populated!
-    let recipient = AztecAddress::from_field(0);
 
     let ivpk_app = compute_ivpk_app(ivpk, contract_address);
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/logs.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/logs.nr
@@ -38,6 +38,7 @@ unconstrained fn compute_encrypted_note_log_oracle<N, M>(
     _ovsk_app: Field,
     _ovpk_m: Point,
     _ivpk_m: Point,
+    _recipient: AztecAddress,
     _preimage: [Field; N]
 ) -> [u8; M] {}
 
@@ -48,6 +49,7 @@ unconstrained pub fn compute_encrypted_note_log<N, M>(
     ovsk_app: Field,
     ovpk_m: Point,
     ivpk_m: Point,
+    recipient: AztecAddress,
     preimage: [Field; N]
 ) -> [u8; M] {
     compute_encrypted_note_log_oracle(
@@ -57,6 +59,7 @@ unconstrained pub fn compute_encrypted_note_log<N, M>(
         ovsk_app,
         ovpk_m,
         ivpk_m,
+        recipient,
         preimage
     )
 }
@@ -70,6 +73,7 @@ unconstrained fn compute_encrypted_event_log_oracle<N, M>(
     _ovsk_app: Field,
     _ovpk_m: Point,
     _ivpk_m: Point,
+    _recipient: AztecAddress,
     _preimage: [Field; N]
 ) -> [u8; M] {}
 
@@ -80,6 +84,7 @@ unconstrained pub fn compute_encrypted_event_log<N, M>(
     ovsk_app: Field,
     ovpk_m: Point,
     ivpk_m: Point,
+    recipient: AztecAddress,
     preimage: [Field; N]
 ) -> [u8; M] {
     compute_encrypted_event_log_oracle(
@@ -89,6 +94,7 @@ unconstrained pub fn compute_encrypted_event_log<N, M>(
         ovsk_app,
         ovpk_m,
         ivpk_m,
+        recipient,
         preimage
     )
 }

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -111,7 +111,9 @@ impl Deck<&mut PrivateContext> {
         let mut inserted_cards = &[];
         for card in cards {
             let mut card_note = CardNote::from_card(card, owner_npk_m_hash);
-            self.set.insert(&mut card_note.note).emit(encode_and_encrypt_note_with_keys(self.set.context, msg_sender_ovpk_m, owner_ivpk_m));
+            self.set.insert(&mut card_note.note).emit(
+                encode_and_encrypt_note_with_keys(self.set.context, msg_sender_ovpk_m, owner_ivpk_m, owner)
+            );
             inserted_cards = inserted_cards.push_back(card_note);
         }
 

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -196,7 +196,14 @@ contract DocsExample {
 
         for i in 0..amounts.len() {
             let mut note = CardNote::new(amounts[i], 1, msg_sender_npk_m_hash);
-            storage.set.insert(&mut note).emit(encode_and_encrypt_note_with_keys(&mut context, msg_sender_ovpk_m, msg_sender_ivpk_m));
+            storage.set.insert(&mut note).emit(
+                encode_and_encrypt_note_with_keys(
+                    &mut context,
+                    msg_sender_ovpk_m,
+                    msg_sender_ivpk_m,
+                    context.msg_sender()
+                )
+            );
         }
     }
 

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
@@ -359,7 +359,7 @@ contract PendingNoteHashes {
         let existing_note_header = good_note.get_header();
         bad_note.set_header(existing_note_header);
 
-        NoteEmission::new(bad_note).emit(encode_and_encrypt_note_with_keys(&mut context, outgoing_viewer_ovpk_m, owner_ivpk_m));
+        NoteEmission::new(bad_note).emit(encode_and_encrypt_note_with_keys(&mut context, outgoing_viewer_ovpk_m, owner_ivpk_m, owner));
     }
 
     #[contract_library_method]
@@ -377,7 +377,7 @@ contract PendingNoteHashes {
 
         for i in 0..max_notes_per_call() {
             let mut note = ValueNote::new(i as Field, owner_npk_m_hash);
-            owner_balance.insert(&mut note).emit(encode_and_encrypt_note_with_keys(context, outgoing_viewer_ovpk_m, owner_ivpk_m));
+            owner_balance.insert(&mut note).emit(encode_and_encrypt_note_with_keys(context, outgoing_viewer_ovpk_m, owner_ivpk_m, owner));
         }
     }
 

--- a/noir-projects/noir-contracts/contracts/private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/private_token_contract/src/main.nr
@@ -123,8 +123,8 @@ contract PrivateToken {
         let to_npk_m_hash = header.get_npk_m_hash(&mut context, to);
 
         let amount = U128::from_integer(amount);
-        storage.balances.sub(from_npk_m_hash, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, from_ivpk));
-        storage.balances.add(to_npk_m_hash, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, to_ivpk));
+        storage.balances.sub(from_npk_m_hash, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, from_ivpk, from));
+        storage.balances.add(to_npk_m_hash, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, to_ivpk, to));
     }
 
     #[aztec(private)]
@@ -138,8 +138,8 @@ contract PrivateToken {
         let to_npk_m_hash = header.get_npk_m_hash(&mut context, to);
 
         let amount = U128::from_integer(amount);
-        storage.balances.sub(from_npk_m_hash, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, from_ivpk));
-        storage.balances.add(to_npk_m_hash, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, to_ivpk));
+        storage.balances.sub(from_npk_m_hash, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, from_ivpk, from));
+        storage.balances.add(to_npk_m_hash, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, to_ivpk, to));
     }
 
     #[aztec(private)]
@@ -175,7 +175,7 @@ contract PrivateToken {
         // (called fee limit in aztec spec). The difference between fee limit and the actual tx fee will be refunded 
         // to the user in the `complete_refund(...)` function.
         // TODO(#7324), TODO(#7323): using npk_m_hash here is vulnerable in 2 ways described in the linked issues.
-        storage.balances.sub(user_npk_m_hash, U128::from_integer(funded_amount)).emit(encode_and_encrypt_note_with_keys(&mut context, user_ovpk, user_ivpk));
+        storage.balances.sub(user_npk_m_hash, U128::from_integer(funded_amount)).emit(encode_and_encrypt_note_with_keys(&mut context, user_ovpk, user_ivpk, user));
 
         // 4. We generate the refund points.
         let (fee_payer_point, user_point) = TokenNote::generate_refund_points(

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -277,7 +277,8 @@ contract Test {
                 // testing only - a secret random value is passed in here to salt / mask the address
                 5,
                 outgoing_viewer_ovpk_m,
-                owner_ivpk_m
+                owner_ivpk_m,
+                owner
             )
         );
 
@@ -294,7 +295,8 @@ contract Test {
                     // testing only - a randomness of 0 signals the kerels to not mask the address
                     0,
                     outgoing_viewer_ovpk_m,
-                    owner_ivpk_m
+                    owner_ivpk_m,
+                    owner
                 )
             );
         }

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -335,10 +335,10 @@ contract Token {
         let to_ivpk = header.get_ivpk_m(&mut context, to);
 
         let amount = U128::from_integer(amount);
-        storage.balances.sub(from, amount).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_ovpk, from_ivpk));
-        storage.balances.add(to, amount).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_ovpk, to_ivpk));
+        storage.balances.sub(from, amount).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_ovpk, from_ivpk, from));
+        storage.balances.add(to, amount).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_ovpk, to_ivpk, to));
 
-        Transfer { from, to, amount: amount.to_field() }.emit(encode_and_encrypt_event_with_keys_unconstrained(&mut context, from_ovpk, to_ivpk));
+        Transfer { from, to, amount: amount.to_field() }.emit(encode_and_encrypt_event_with_keys_unconstrained(&mut context, from_ovpk, to_ivpk, to));
     }
     // docs:end:transfer
 
@@ -376,10 +376,10 @@ contract Token {
         let amount = U128::from_integer(amount);
         // docs:start:increase_private_balance
         // docs:start:encrypted
-        storage.balances.sub(from, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, from_ivpk));
+        storage.balances.sub(from, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, from_ivpk, from));
         // docs:end:encrypted
         // docs:end:increase_private_balance
-        storage.balances.add(to, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, to_ivpk));
+        storage.balances.add(to, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, to_ivpk, to));
     }
     // docs:end:transfer_from
 

--- a/yarn-project/simulator/src/acvm/oracle/oracle.ts
+++ b/yarn-project/simulator/src/acvm/oracle/oracle.ts
@@ -340,6 +340,7 @@ export class Oracle {
     [ivpkMX]: ACVMField[],
     [ivpkMY]: ACVMField[],
     [ivpkMIsInfinite]: ACVMField[],
+    [recipient]: ACVMField[],
     preimage: ACVMField[],
   ): ACVMField[] {
     const ovpkM = new Point(fromACVMField(ovpkMX), fromACVMField(ovpkMY), !fromACVMField(ovpkMIsInfinite).isZero());
@@ -351,6 +352,7 @@ export class Oracle {
       Fr.fromString(eventTypeId),
       ovKeys,
       ivpkM,
+      AztecAddress.fromString(recipient),
       preimage.map(fromACVMField),
     );
     const bytes: ACVMField[] = [];
@@ -371,6 +373,7 @@ export class Oracle {
     [ivpkMX]: ACVMField[],
     [ivpkMY]: ACVMField[],
     [ivpkMIsInfinite]: ACVMField[],
+    [recipient]: ACVMField[],
     preimage: ACVMField[],
   ): ACVMField[] {
     const ovpkM = new Point(fromACVMField(ovpkMX), fromACVMField(ovpkMY), !fromACVMField(ovpkMIsInfinite).isZero());
@@ -382,6 +385,7 @@ export class Oracle {
       NoteSelector.fromField(Fr.fromString(noteTypeId)),
       ovKeys,
       ivpkM,
+      AztecAddress.fromString(recipient),
       preimage.map(fromACVMField),
     );
     const bytes: ACVMField[] = [];

--- a/yarn-project/simulator/src/acvm/oracle/typed_oracle.ts
+++ b/yarn-project/simulator/src/acvm/oracle/typed_oracle.ts
@@ -222,6 +222,7 @@ export abstract class TypedOracle {
     _eventTypeId: Fr,
     _ovKeys: KeyValidationRequest,
     _ivpkM: PublicKey,
+    _recipient: AztecAddress,
     _preimage: Fr[],
   ): Buffer {
     throw new OracleMethodNotAvailableError('computeEncryptedEventLog');
@@ -233,6 +234,7 @@ export abstract class TypedOracle {
     _noteTypeId: NoteSelector,
     _ovKeys: KeyValidationRequest,
     _ivpkM: PublicKey,
+    _recipient: AztecAddress,
     _preimage: Fr[],
   ): Buffer {
     throw new OracleMethodNotAvailableError('computeEncryptedNoteLog');

--- a/yarn-project/simulator/src/client/client_execution_context.ts
+++ b/yarn-project/simulator/src/client/client_execution_context.ts
@@ -29,7 +29,7 @@ import {
   type NoteSelector,
   countArgumentsSize,
 } from '@aztec/foundation/abi';
-import { AztecAddress } from '@aztec/foundation/aztec-address';
+import { type AztecAddress } from '@aztec/foundation/aztec-address';
 import { pedersenHash } from '@aztec/foundation/crypto';
 import { Fr, GrumpkinScalar, type Point } from '@aztec/foundation/fields';
 import { applyStringFormatting, createDebugLogger } from '@aztec/foundation/log';
@@ -377,6 +377,7 @@ export class ClientExecutionContext extends ViewDataOracle {
    * @param eventTypeId - The type ID of the event (function selector).
    * @param ovKeys - The outgoing viewing keys to use to encrypt.
    * @param ivpkM - The master incoming viewing public key.
+   * @param recipient - The recipient of the encrypted event log.
    * @param preimage - The event preimage.
    */
   public override computeEncryptedEventLog(
@@ -385,6 +386,7 @@ export class ClientExecutionContext extends ViewDataOracle {
     eventTypeId: Fr,
     ovKeys: KeyValidationRequest,
     ivpkM: Point,
+    recipient: AztecAddress,
     preimage: Fr[],
   ) {
     const event = new Event(preimage);
@@ -392,8 +394,6 @@ export class ClientExecutionContext extends ViewDataOracle {
     const taggedEvent = new TaggedLog(l1EventPayload);
 
     const ephSk = GrumpkinScalar.random();
-
-    const recipient = AztecAddress.random();
 
     return taggedEvent.encrypt(ephSk, recipient, ivpkM, ovKeys);
   }
@@ -405,6 +405,7 @@ export class ClientExecutionContext extends ViewDataOracle {
    * @param noteTypeId - The type ID of the note.
    * @param ovKeys - The outgoing viewing keys to use to encrypt.
    * @param ivpkM - The master incoming viewing public key.
+   * @param recipient - The recipient of the encrypted note log.
    * @param preimage - The note preimage.
    */
   public override computeEncryptedNoteLog(
@@ -413,6 +414,7 @@ export class ClientExecutionContext extends ViewDataOracle {
     noteTypeId: NoteSelector,
     ovKeys: KeyValidationRequest,
     ivpkM: Point,
+    recipient: AztecAddress,
     preimage: Fr[],
   ) {
     const note = new Note(preimage);
@@ -420,11 +422,6 @@ export class ClientExecutionContext extends ViewDataOracle {
     const taggedNote = new TaggedLog(l1NotePayload);
 
     const ephSk = GrumpkinScalar.random();
-
-    // @todo This should be populated properly.
-    // Note that this encryption function SHOULD not be used, but is currently used
-    // as oracle for encrypted event logs.
-    const recipient = AztecAddress.random();
 
     return taggedNote.encrypt(ephSk, recipient, ivpkM, ovKeys);
   }

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -1,5 +1,7 @@
 import {
   AuthWitness,
+  Event,
+  L1EventPayload,
   L1NotePayload,
   MerkleTreeId,
   Note,
@@ -38,6 +40,7 @@ import { Aes128, Schnorr } from '@aztec/circuits.js/barretenberg';
 import { computePublicDataTreeLeafSlot, siloNoteHash, siloNullifier } from '@aztec/circuits.js/hash';
 import {
   type ContractArtifact,
+  EventSelector,
   type FunctionAbi,
   FunctionSelector,
   type NoteSelector,
@@ -522,6 +525,7 @@ export class TXE implements TypedOracle {
     noteTypeId: NoteSelector,
     ovKeys: KeyValidationRequest,
     ivpkM: Point,
+    recipient: AztecAddress,
     preimage: Fr[],
   ): Buffer {
     const note = new Note(preimage);
@@ -529,8 +533,6 @@ export class TXE implements TypedOracle {
     const taggedNote = new TaggedLog(l1NotePayload);
 
     const ephSk = GrumpkinScalar.random();
-
-    const recipient = AztecAddress.random();
 
     return taggedNote.encrypt(ephSk, recipient, ivpkM, ovKeys);
   }
@@ -898,13 +900,20 @@ export class TXE implements TypedOracle {
   }
 
   computeEncryptedEventLog(
-    _contractAddress: AztecAddress,
-    _randomness: Fr,
-    _eventTypeId: Fr,
-    _ovKeys: KeyValidationRequest,
-    _ivpkM: Point,
-    _preimage: Fr[],
+    contractAddress: AztecAddress,
+    randomness: Fr,
+    eventTypeId: Fr,
+    ovKeys: KeyValidationRequest,
+    ivpkM: Point,
+    recipient: AztecAddress,
+    preimage: Fr[],
   ): Buffer {
-    throw new Error('Method not implemented.');
+    const event = new Event(preimage);
+    const l1EventPayload = new L1EventPayload(event, contractAddress, randomness, EventSelector.fromField(eventTypeId));
+    const taggedEvent = new TaggedLog(l1EventPayload);
+
+    const ephSk = GrumpkinScalar.random();
+
+    return taggedEvent.encrypt(ephSk, recipient, ivpkM, ovKeys);
   }
 }

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -578,6 +578,7 @@ export class TXEService {
     ivpkMX: ForeignCallSingle,
     ivpkMY: ForeignCallSingle,
     ivpkMIsInfinite: ForeignCallSingle,
+    recipient: ForeignCallSingle,
     preimage: ForeignCallArray,
   ) {
     const ovpkM = new Point(fromSingle(ovpkMX), fromSingle(ovpkMY), !fromSingle(ovpkMIsInfinite).isZero());
@@ -589,6 +590,7 @@ export class TXEService {
       NoteSelector.fromField(Fr.fromString(fromSingle(noteTypeId).toString())),
       ovKeys,
       ivpkM,
+      AztecAddress.fromString(fromSingle(recipient).toString()),
       fromArray(preimage),
     );
     const bytes: Fr[] = [];


### PR DESCRIPTION
Resolves #7177.

With this, we are adding recipient to the outgoing log. I'm adding it as another parameter to the emission, when we pass it in the normal circumstance (without keys), it is using the same value as the incoming viewer.