### PR TITLE
chore(avm): make stats thread safe

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/stats.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/stats.cpp
@@ -20,6 +20,7 @@ void Stats::reset()
 
 void Stats::increment(const std::string& key, uint64_t value)
 {
+    std::lock_guard lock(stats_mutex);
     stats[key] += value;
 }
 
@@ -33,6 +34,8 @@ void Stats::time(const std::string& key, std::function<void()> f)
 
 std::string Stats::to_string() const
 {
+    std::lock_guard lock(stats_mutex);
+
     std::vector<std::string> result;
     result.reserve(stats.size());
     for (const auto& [key, value] : stats) {
@@ -48,6 +51,8 @@ std::string Stats::to_string() const
 
 std::string Stats::aggregate_to_string(const std::string& key_prefix) const
 {
+    std::lock_guard lock(stats_mutex);
+
     uint64_t result = 0;
     for (const auto& [key, value] : stats) {
         if (key.starts_with(key_prefix)) {

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/stats.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/stats.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -32,6 +33,7 @@ class Stats {
     Stats() = default;
 
     std::unordered_map<std::string, uint64_t> stats;
+    mutable std::mutex stats_mutex;
 };
 
 } // namespace bb::avm_trace


### PR DESCRIPTION
Needed because some things are calculated in parallel.
