### PR TITLE
chore(docs): Cleanup voting tutorial and deployment guide

### DIFF
--- a/docs/docs/guides/smart_contracts/how_to_deploy_contract.md
+++ b/docs/docs/guides/smart_contracts/how_to_deploy_contract.md
@@ -26,72 +26,35 @@ aztec-nargo compile
 Generate the typescript class:
 
 ```bash
-aztec-builder ./aztec-nargo/output/target/path -o src/artifacts
+aztec-builder codegen ./aztec-nargo/output/target/path -o src/artifacts
 ```
 
 This would create a typescript file like `Example.ts` in `./src/artifacts`. Read more on the [compiling page](how_to_compile_contract.md).
 
-Now you can import it to easily deploy and interact with the contract.
+You can use the `Contract` class to deploy the contract:
 
-```ts
-import { ExampleContract } from "./target/Example.js";
+#include_code dapp_deploy yarn-project/end-to-end/src/sample-dapp/deploy.mjs typescript
 
-const tx = ExampleContract.deploy(pxe).send();
-await tx.wait({ interval: 0.5 });
-const receipt = await tx.getReceipt();
-const exampleContract = await ExampleContract.at(
-  receipt.contractAddress!,
-  myWallet
-);
-```
+Or you can use the generated contract class. See [below](#deploying-token-contract) for more details.
 
 ### Deploy Arguments
 
 There are several optional arguments that can be passed:
 
 The `deploy(...)` method is generated automatically with the typescript class representing your contract.
-Its arguments are `PXE` client and contract constructor arguments.
 
 Additionally the `.send()` method can have a few optional arguments too, which are specified in an optional object:
 
-- `contractAddressSalt?: Fr`: A salt which is one of the inputs when computing a contract address of the contract to be deployed.
-  By default is set to a random value.
-  Set it, if you need a deterministic contract address (same functionality as Ethereum's `CREATE2` opcode).
-
-```ts
-const tx = ExampleContract.deploy(pxe).send({
-  contractAddressSalt: new Fr(3n),
-});
-```
+#include_code deploy_options yarn-project/aztec.js/src/contract/deploy_method.ts typescript
 
 ### Deploying token contract
 
 To give you a more complete example we will deploy a `Token` contract whose artifacts are included in the `@aztec/noir-contracts.js` package.
 
-The contract has `admin` as a constructor argument.
-We will deploy the contract and pass the `admin` address as an argument.
-
-```ts
-const admin = AztecAddress.from(
-  "0x147392a39e593189902458f4303bc6e0a39128c5a1c1612f76527a162d36d529"
-);
-// TokenContract is the TS interface that is automatically generated when compiling the contract with the `-ts` flag.
-const contract = await TokenContract.deploy(wallet, admin).send().deployed();
-logger(`Contract deployed at ${contract.address}`);
-```
+#include_code full_deploy yarn-project/end-to-end/src/composed/docs_examples.test.ts typescript
 
 If everything went as expected you should see the following output (with a different address):
 
-> Contract deployed at `0x151de6120ae6628129ee852c5fc7bcbc8531055f76d4347cdc86003bbea96906`
-
-If we pass the salt as an argument:
-
-```ts
-const contract = await TokenContract.deploy(wallet, admin)
-  .send({ contractAddressSalt: Fr.fromString("0x123") })
-  .deployed();
-```
-
-the resulting address will be deterministic.
-
-> **NOTE**: You can try running the deployment with the same salt the second time in which case the transaction will fail because the address has been already deployed to.
+:::note
+You can try running the deployment with the same salt the second time in which case the transaction will fail because the address has been already deployed to.
+:::

--- a/docs/docs/guides/smart_contracts/how_to_deploy_contract.md
+++ b/docs/docs/guides/smart_contracts/how_to_deploy_contract.md
@@ -33,7 +33,7 @@ This would create a typescript file like `Example.ts` in `./src/artifacts`. Read
 
 You can use the `Contract` class to deploy the contract:
 
-#include_code dapp_deploy yarn-project/end-to-end/src/sample-dapp/deploy.mjs typescript
+#include_code dapp-deploy yarn-project/end-to-end/src/sample-dapp/deploy.mjs typescript
 
 Or you can use the generated contract class. See [below](#deploying-token-contract) for more details.
 

--- a/docs/docs/guides/smart_contracts/how_to_deploy_contract.md
+++ b/docs/docs/guides/smart_contracts/how_to_deploy_contract.md
@@ -31,7 +31,7 @@ aztec-builder codegen ./aztec-nargo/output/target/path -o src/artifacts
 
 This would create a typescript file like `Example.ts` in `./src/artifacts`. Read more on the [compiling page](how_to_compile_contract.md).
 
-You can use the `Contract` class to deploy the contract:
+You can use the `Contract` class to deploy a contract:
 
 #include_code dapp-deploy yarn-project/end-to-end/src/sample-dapp/deploy.mjs typescript
 
@@ -51,9 +51,17 @@ Additionally the `.send()` method can have a few optional arguments too, which a
 
 To give you a more complete example we will deploy a `Token` contract whose artifacts are included in the `@aztec/noir-contracts.js` package.
 
-#include_code full_deploy yarn-project/end-to-end/src/composed/docs_examples.test.ts typescript
+```ts
+#include_code create_account_imports yarn-project/end-to-end/src/composed/docs_examples.test.ts raw
+#include_code import_contract yarn-project/end-to-end/src/composed/docs_examples.test.ts raw
+#include_code import_token_contract yarn-project/end-to-end/src/composed/docs_examples.test.ts raw
 
-If everything went as expected you should see the following output (with a different address):
+async function main(){
+
+    #include_code full_deploy yarn-project/end-to-end/src/composed/docs_examples.test.ts raw
+
+}
+```
 
 :::note
 You can try running the deployment with the same salt the second time in which case the transaction will fail because the address has been already deployed to.

--- a/docs/docs/tutorials/contract_tutorials/token_contract.md
+++ b/docs/docs/tutorials/contract_tutorials/token_contract.md
@@ -487,9 +487,7 @@ aztec-builder target -o src/artifacts
 
 ### Testing
 
-Review the end to end tests for reference:
-
-https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/yarn-project/end-to-end/src/e2e_token_contract/
+Review [the end to end tests](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/yarn-project/end-to-end/src/e2e_token_contract/) for reference.
 
 ### Token Bridge Contract
 

--- a/docs/docs/tutorials/contract_tutorials/token_contract.md
+++ b/docs/docs/tutorials/contract_tutorials/token_contract.md
@@ -489,7 +489,7 @@ aztec-builder target -o src/artifacts
 
 Review the end to end tests for reference:
 
-https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/yarn-project/end-to-end/src/e2e_token_contract/*.test.ts
+https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/yarn-project/end-to-end/src/e2e_token_contract/
 
 ### Token Bridge Contract
 

--- a/docs/docs/tutorials/simple_dapp/2_contract_deployment.md
+++ b/docs/docs/tutorials/simple_dapp/2_contract_deployment.md
@@ -69,12 +69,7 @@ We import the contract artifacts we have generated plus the dependencies we'll n
 Note that the token's `_initialize()` method expects an `owner` address to mint an initial set of tokens to. We are using the first account from the Sandbox for this.
 
 :::info
-If you are using the generated typescript classes, you can drop the generic `ContractDeployer` in favor of using the `deploy` method of the generated class, which will automatically load the artifact for you and type-check the constructor arguments:
-
-```typescript
-await Token.deploy(client).send().wait();
-```
-
+If you are using the generated typescript classes, you can drop the generic `ContractDeployer` in favor of using the `deploy` method of the generated class, which will automatically load the artifact for you and type-check the constructor arguments. SEe the [How to deploy a contract](../../guides/smart_contracts/how_to_deploy_contract.md) page for more info.
 :::
 
 Run the snippet above as `node src/deploy.mjs`, and you should see the following output, along with a new `addresses.json` file in your project root:

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -23,6 +23,7 @@ import { DeploySentTx } from './deploy_sent_tx.js';
  * Options for deploying a contract on the Aztec network.
  * Allows specifying a contract address salt, and additional send method options.
  */
+// docs:start:deploy_options
 export type DeployOptions = {
   /** An optional salt value used to deterministically calculate the contract address. */
   contractAddressSalt?: Fr;
@@ -35,7 +36,7 @@ export type DeployOptions = {
   /** Skip contract initialization. */
   skipInitialization?: boolean;
 } & SendMethodOptions;
-
+// docs:end:deploy_options
 // TODO(@spalladino): Add unit tests for this class!
 
 /**

--- a/yarn-project/end-to-end/src/composed/docs_examples.test.ts
+++ b/yarn-project/end-to-end/src/composed/docs_examples.test.ts
@@ -11,8 +11,8 @@ import { TokenContract, TokenContractArtifact } from '@aztec/noir-contracts.js/T
 // docs:end:import_token_contract
 
 describe('docs_examples', () => {
-  // docs:start:full_deploy
   it('deploys and interacts with a token contract', async () => {
+    // docs:start:full_deploy
     // docs:start:define_account_vars
     const PXE_URL = process.env.PXE_URL || 'http://localhost:8080';
     const secretKey = Fr.random();

--- a/yarn-project/end-to-end/src/composed/docs_examples.test.ts
+++ b/yarn-project/end-to-end/src/composed/docs_examples.test.ts
@@ -11,6 +11,7 @@ import { TokenContract, TokenContractArtifact } from '@aztec/noir-contracts.js/T
 // docs:end:import_token_contract
 
 describe('docs_examples', () => {
+  // docs:start:full_deploy
   it('deploys and interacts with a token contract', async () => {
     // docs:start:define_account_vars
     const PXE_URL = process.env.PXE_URL || 'http://localhost:8080';
@@ -30,7 +31,7 @@ describe('docs_examples', () => {
       'TokenName', // constructor arg1
       'TokenSymbol', // constructor arg2
       18,
-    ) // constructor arg3
+    )
       .send()
       .deployed();
     // docs:end:deploy_contract
@@ -38,6 +39,7 @@ describe('docs_examples', () => {
     // docs:start:get_contract
     const contract = await Contract.at(deployedContract.address, TokenContractArtifact, wallet);
     // docs:end:get_contract
+    // docs:end:full_deploy
 
     // docs:start:send_transaction
     const _tx = await contract.methods.mint_public(wallet.getAddress(), 1).send().wait();


### PR DESCRIPTION
The voting tutorial code was recently updated, this PR updates the text. It also updates some of the deployment docs to reference source code instead of using hardcoded blocks.