### PR TITLE
fix: updated docs

### DIFF
--- a/docs/docs/guides/smart_contracts/testing_contracts/index.md
+++ b/docs/docs/guides/smart_contracts/testing_contracts/index.md
@@ -39,14 +39,14 @@ In order to use the TXE, it must be running on a known address.
 :::tip
 If you have [the sandbox](../../../getting_started.md) installed, you can quickly deploy a TXE by running:
 
-`docker run --workdir /usr/src/yarn-project/txe/dest/bin --entrypoint node --name txe -p 8080:8080 aztecprotocol/aztec index.js`
+`docker run --workdir /usr/src/yarn-project --entrypoint bash --name txe -p 8080:8080 --rm -it aztecprotocol/aztec -c "yarn workspaces focus @aztec/txe && cd txe && yarn build && yarn start"`
 
 This will be improved in the future with a dedicated command.
 :::
 
 By default, TXE runs at `http://localhost:8080`. Using `aztec-nargo`, contract tests can be run with:
 
-`aztec-nargo test --oracle-resolver http://host.docker.internal:8080`
+`aztec-nargo test --use-legacy --silence-warnings --oracle-resolver http://host.docker.internal:8080`
 
 :::warning
 Since TXE tests are written in Noir and executed with `aztec-nargo`, they all run in parallel. This also means every test creates their own isolated environment, so state modifications are local to each one of them.


### PR DESCRIPTION
Slightly uglier docker command working around the way our `aztecprotocol/aztec` image is built