### PR TITLE
chore: minimize usage of get_row in inverse computation

### DIFF
--- a/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation.hpp
@@ -208,6 +208,7 @@ template <typename FF_> class DatabusLookupRelationImpl {
             }
             // We only compute the inverse if this row contains a read gate or data that has been read
             if (is_read || nonzero_read_count) {
+                // TODO(https://github.com/AztecProtocol/barretenberg/issues/940): avoid get_row if possible.
                 auto row = polynomials.get_row(i); // Note: this is a copy. use sparingly!
                 inverse_polynomial[i] = compute_read_term<FF>(row, relation_parameters) *
                                         compute_write_term<FF, bus_idx>(row, relation_parameters);

--- a/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
@@ -135,6 +135,33 @@ template <typename FF_> class LogDerivLookupRelationImpl {
     }
 
     /**
+     * @brief Construct the polynomial I whose components are the inverse of the product of the read and write terms
+     * @details If the denominators of log derivative lookup relation are read_term and write_term, then I_i =
+     * (read_term_i*write_term_i)^{-1}.
+     * @note Importantly, I_i = 0 for rows i at which there is no read or write, so the cost of this method is
+     * proportional to the actual number of lookups.
+     *
+     */
+    template <typename Polynomials>
+    static void compute_logderivative_inverse(Polynomials& polynomials,
+                                              auto& relation_parameters,
+                                              const size_t circuit_size)
+    {
+        auto& inverse_polynomial = get_inverse_polynomial(polynomials);
+
+        for (size_t i = 0; i < circuit_size; ++i) {
+            // We only compute the inverse if this row contains a lookup gate or data that has been looked up
+            if (polynomials.q_lookup[i] == 1 || polynomials.lookup_read_tags[i] == 1) {
+                auto row = polynomials.get_row(i); // Note: this is a copy. use sparingly!
+                inverse_polynomial[i] = compute_read_term<FF, 0>(row, relation_parameters) *
+                                        compute_write_term<FF, 0>(row, relation_parameters);
+            }
+        }
+        // Compute inverse polynomial I in place by inverting the product at each row
+        FF::batch_invert(inverse_polynomial);
+    };
+
+    /**
      * @brief Log-derivative style lookup argument for conventional lookups form tables with 3 or fewer columns
      * @details The identity to be checked is of the form
      *

--- a/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
@@ -152,6 +152,7 @@ template <typename FF_> class LogDerivLookupRelationImpl {
         for (size_t i = 0; i < circuit_size; ++i) {
             // We only compute the inverse if this row contains a lookup gate or data that has been looked up
             if (polynomials.q_lookup[i] == 1 || polynomials.lookup_read_tags[i] == 1) {
+                // TODO(https://github.com/AztecProtocol/barretenberg/issues/940): avoid get_row if possible.
                 auto row = polynomials.get_row(i); // Note: this is a copy. use sparingly!
                 inverse_polynomial[i] = compute_read_term<FF, 0>(row, relation_parameters) *
                                         compute_write_term<FF, 0>(row, relation_parameters);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -391,7 +391,7 @@ class MegaFlavor {
         void compute_logderivative_inverses(const RelationParameters<FF>& relation_parameters)
         {
             // Compute inverses for conventional lookups
-            compute_logderivative_inverse<MegaFlavor, LogDerivLookupRelation<FF>>(
+            LogDerivLookupRelation<FF>::compute_logderivative_inverse(
                 this->polynomials, relation_parameters, this->circuit_size);
 
             // Compute inverses for calldata reads


### PR DESCRIPTION
Using get_row in hot loops is known to be a bad plan since it amounts to a copy. When I implemented log derivative table lookups, I carelessly used the method in logderiv_library.hpp which computes the inverses needed in the log deriv relation. That method uses get_row in a loop over the entire execution trace which amounts to copying the entire set of prover polynomials one row at a time. 

A half-measure fix is to still use get_row, but only where we really need to use it (i.e. where the gate in question is active). this is what I did for the databus log-deriv lookup relation. This is still less efficient than it could be because we're copying an entire row when we only need a small subset of the data. This too could be avoided but at the cost of some icky duplication so for now I'm leaving it as is with reference to a bberg issue.

Results in a ~0.5s reduction in ClientIvc bench, essentially entirely in the PG prep round (where the lookup inverses are computed):

Before: 
`ClientIVCBench/Full/6      15131 ms        10319 ms`
`ProtoGalaxyProver_::preparation_round(t)           3569    52.15%`

After: 
`ClientIVCBench/Full/6      14582 ms         9853 ms`
`ProtoGalaxyProver_::preparation_round(t)           3055    48.72%`