### PR TITLE
refactor: tree leaf type

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -228,6 +228,7 @@
     "siloes",
     "sload",
     "snakecase",
+    "Snapshotted",
     "solhint",
     "SSTORE",
     "staticcall",

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -42,6 +42,7 @@ import {
   type NullifierLeafPreimage,
   type PUBLIC_DATA_TREE_HEIGHT,
   type PublicDataTreeLeafPreimage,
+  NullifierLeaf,
 } from '@aztec/circuits.js';
 import { computePublicDataTreeLeafSlot } from '@aztec/circuits.js/hash';
 import { type L1ContractAddresses, createEthereumChain } from '@aztec/ethereum';
@@ -181,13 +182,13 @@ export class AztecNodeService implements AztecNode {
     const prover = config.disableProver
       ? undefined
       : await TxProver.new(
-          config,
-          worldStateSynchronizer,
-          telemetry,
-          await archiver
-            .getBlock(-1)
-            .then(b => b?.header ?? worldStateSynchronizer.getCommitted().buildInitialHeader()),
-        );
+        config,
+        worldStateSynchronizer,
+        telemetry,
+        await archiver
+          .getBlock(-1)
+          .then(b => b?.header ?? worldStateSynchronizer.getCommitted().buildInitialHeader()),
+      );
 
     if (!prover && !config.disableSequencer) {
       throw new Error("Can't start a sequencer without a prover");
@@ -197,16 +198,16 @@ export class AztecNodeService implements AztecNode {
     const sequencer = config.disableSequencer
       ? undefined
       : await SequencerClient.new(
-          config,
-          p2pClient,
-          worldStateSynchronizer,
-          archiver,
-          archiver,
-          archiver,
-          prover!,
-          simulationProvider,
-          telemetry,
-        );
+        config,
+        p2pClient,
+        worldStateSynchronizer,
+        archiver,
+        archiver,
+        archiver,
+        prover!,
+        simulationProvider,
+        telemetry,
+      );
 
     return new AztecNodeService(
       config,
@@ -423,7 +424,7 @@ export class AztecNodeService implements AztecNode {
     leafValue: Fr,
   ): Promise<bigint | undefined> {
     const committedDb = await this.#getWorldState(blockNumber);
-    return committedDb.findLeafIndex(treeId, leafValue.toBuffer());
+    return committedDb.findLeafIndex(treeId, leafValue);
   }
 
   /**
@@ -611,7 +612,7 @@ export class AztecNodeService implements AztecNode {
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined> {
     const db = await this.#getWorldState(blockNumber);
-    const index = await db.findLeafIndex(MerkleTreeId.NULLIFIER_TREE, nullifier.toBuffer());
+    const index = await db.findLeafIndex(MerkleTreeId.NULLIFIER_TREE, new NullifierLeaf(nullifier));
     if (!index) {
       return undefined;
     }

--- a/yarn-project/foundation/src/fifo/serial_queue.ts
+++ b/yarn-project/foundation/src/fifo/serial_queue.ts
@@ -1,3 +1,4 @@
+import { isPromise } from '../promise/utils.js';
 import { MemoryFifo } from './memory_fifo.js';
 
 /**
@@ -56,11 +57,14 @@ export class SerialQueue {
    * @param fn - The function to enqueue.
    * @returns A resolution promise. Rejects if the function does, or if the function could not be enqueued.
    */
-  public put<T>(fn: () => Promise<T>): Promise<T> {
+  public put<T>(fn: () => T | Promise<T>): Promise<T> {
     return new Promise((resolve, reject) => {
       const accepted = this.queue.put(async () => {
         try {
-          const res = await fn();
+          let res = fn();
+          if (isPromise(res)) {
+            res = await res;
+          }
           resolve(res);
         } catch (e) {
           reject(e);
@@ -76,6 +80,6 @@ export class SerialQueue {
    * Awaiting this ensures the queue is empty before resuming.
    */
   public async syncPoint() {
-    await this.put(async () => {});
+    await this.put(async () => { });
   }
 }

--- a/yarn-project/foundation/src/promise/utils.ts
+++ b/yarn-project/foundation/src/promise/utils.ts
@@ -27,3 +27,11 @@ export function promiseWithResolvers<T>(): PromiseWithResolvers<T> {
     reject,
   };
 }
+
+/**
+ * Checks if the given object is a Promise.
+ * A weaker version of Node's util.types.isPromise that works in the browser.
+ */
+export function isPromise(obj: any): obj is PromiseLike<any> {
+  return obj && typeof obj.then === 'function';
+}

--- a/yarn-project/merkle-tree/src/interfaces/indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/interfaces/indexed_tree.ts
@@ -81,8 +81,8 @@ export interface BatchInsertionResult<TreeHeight extends number, SubtreeSiblingP
  */
 export interface IndexedTree
   extends MerkleTree<Buffer>,
-    TreeSnapshotBuilder<IndexedTreeSnapshot>,
-    Omit<AppendOnlyTree<Buffer>, keyof TreeSnapshotBuilder<TreeSnapshot<Buffer>>> {
+  TreeSnapshotBuilder<IndexedTreeSnapshot>,
+  Omit<AppendOnlyTree<Buffer>, keyof TreeSnapshotBuilder<TreeSnapshot<Buffer>>> {
   /**
    * Finds the index of the largest leaf whose value is less than or equal to the provided value.
    * @param newValue - The new value to be inserted into the tree.
@@ -94,15 +94,15 @@ export interface IndexedTree
     includeUncommitted: boolean,
   ):
     | {
-        /**
-         * The index of the found leaf.
-         */
-        index: bigint;
-        /**
-         * A flag indicating if the corresponding leaf's value is equal to `newValue`.
-         */
-        alreadyPresent: boolean;
-      }
+      /**
+       * The index of the found leaf.
+       */
+      index: bigint;
+      /**
+       * A flag indicating if the corresponding leaf's value is equal to `newValue`.
+       */
+      alreadyPresent: boolean;
+    }
     | undefined;
 
   /**
@@ -122,6 +122,5 @@ export interface IndexedTree
   batchInsert<TreeHeight extends number, SubtreeHeight extends number, SubtreeSiblingPathHeight extends number>(
     leaves: Buffer[],
     subtreeHeight: SubtreeHeight,
-    includeUncommitted: boolean,
   ): Promise<BatchInsertionResult<TreeHeight, SubtreeSiblingPathHeight>>;
 }

--- a/yarn-project/merkle-tree/src/interfaces/merkle_tree.ts
+++ b/yarn-project/merkle-tree/src/interfaces/merkle_tree.ts
@@ -57,7 +57,7 @@ export interface MerkleTree<T extends Bufferable = Buffer> extends SiblingPathSo
    * @param includeUncommitted - Indicates whether to include uncommitted data.
    * @returns The index of the first leaf found with a given value (undefined if not found).
    */
-  findLeafIndex(leaf: T, includeUncommitted: boolean): bigint | undefined;
+  findLeafIndex(leaf: Buffer, includeUncommitted: boolean): bigint | undefined;
 
   /**
    * Returns the first index containing a leaf value after `startIndex`.
@@ -66,5 +66,5 @@ export interface MerkleTree<T extends Bufferable = Buffer> extends SiblingPathSo
    * @param includeUncommitted - Indicates whether to include uncommitted data.
    * @returns The index of the first leaf found with a given value (undefined if not found).
    */
-  findLeafIndexAfter(leaf: T, startIndex: bigint, includeUncommitted: boolean): bigint | undefined;
+  findLeafIndexAfter(leaf: Buffer, startIndex: bigint, includeUncommitted: boolean): bigint | undefined;
 }

--- a/yarn-project/merkle-tree/src/sparse_tree/sparse_tree.ts
+++ b/yarn-project/merkle-tree/src/sparse_tree/sparse_tree.ts
@@ -46,11 +46,11 @@ export class SparseTree<T extends Bufferable> extends TreeBase<T> implements Upd
     return this.#snapshotBuilder.getSnapshot(block);
   }
 
-  public findLeafIndex(_value: T, _includeUncommitted: boolean): bigint | undefined {
+  public findLeafIndex(_value: Buffer, _includeUncommitted: boolean): bigint | undefined {
     throw new Error('Finding leaf index is not supported for sparse trees');
   }
 
-  public findLeafIndexAfter(_value: T, _startIndex: bigint, _includeUncommitted: boolean): bigint | undefined {
+  public findLeafIndexAfter(_value: Buffer, _startIndex: bigint, _includeUncommitted: boolean): bigint | undefined {
     throw new Error('Finding leaf index is not supported for sparse trees');
   }
 }

--- a/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
@@ -136,15 +136,15 @@ export class StandardIndexedTree extends TreeBase<Buffer> implements IndexedTree
     includeUncommitted: boolean,
   ):
     | {
-        /**
-         * The index of the found leaf.
-         */
-        index: bigint;
-        /**
-         * A flag indicating if the corresponding leaf's value is equal to `newValue`.
-         */
-        alreadyPresent: boolean;
-      }
+      /**
+       * The index of the found leaf.
+       */
+      index: bigint;
+      /**
+       * A flag indicating if the corresponding leaf's value is equal to `newValue`.
+       */
+      alreadyPresent: boolean;
+    }
     | undefined {
     let lowLeafIndex = this.getDbLowLeafIndex(newKey);
     let lowLeafPreimage = lowLeafIndex !== undefined ? this.getDbPreimage(lowLeafIndex) : undefined;

--- a/yarn-project/merkle-tree/src/standard_tree/standard_tree.ts
+++ b/yarn-project/merkle-tree/src/standard_tree/standard_tree.ts
@@ -43,15 +43,14 @@ export class StandardTree<T extends Bufferable = Buffer> extends TreeBase<T> imp
     return this.#snapshotBuilder.getSnapshot(blockNumber);
   }
 
-  public findLeafIndex(value: T, includeUncommitted: boolean): bigint | undefined {
+  public findLeafIndex(value: Buffer, includeUncommitted: boolean): bigint | undefined {
     return this.findLeafIndexAfter(value, 0n, includeUncommitted);
   }
 
-  public findLeafIndexAfter(value: T, startIndex: bigint, includeUncommitted: boolean): bigint | undefined {
-    const buffer = serializeToBuffer(value);
+  public findLeafIndexAfter(value: Buffer, startIndex: bigint, includeUncommitted: boolean): bigint | undefined {
     for (let i = startIndex; i < this.getNumLeaves(includeUncommitted); i++) {
-      const currentValue = this.getLeafValue(i, includeUncommitted);
-      if (currentValue && serializeToBuffer(currentValue).equals(buffer)) {
+      const leaf = this.getLeafBuffer(i, includeUncommitted);
+      if (leaf && leaf.equals(value)) {
         return i;
       }
     }

--- a/yarn-project/merkle-tree/src/tree_base.ts
+++ b/yarn-project/merkle-tree/src/tree_base.ts
@@ -347,7 +347,7 @@ export abstract class TreeBase<T extends Bufferable> implements MerkleTree<T> {
    * @param includeUncommitted - Indicates whether to include uncommitted data.
    * @returns The index of the first leaf found with a given value (undefined if not found).
    */
-  abstract findLeafIndex(value: T, includeUncommitted: boolean): bigint | undefined;
+  abstract findLeafIndex(value: Buffer, includeUncommitted: boolean): bigint | undefined;
 
   /**
    * Returns the first index containing a leaf value after `startIndex`.
@@ -356,5 +356,5 @@ export abstract class TreeBase<T extends Bufferable> implements MerkleTree<T> {
    * @param includeUncommitted - Indicates whether to include uncommitted data.
    * @returns The index of the first leaf found with a given value (undefined if not found).
    */
-  abstract findLeafIndexAfter(leaf: T, startIndex: bigint, includeUncommitted: boolean): bigint | undefined;
+  abstract findLeafIndexAfter(leaf: Buffer, startIndex: bigint, includeUncommitted: boolean): bigint | undefined;
 }

--- a/yarn-project/merkle-tree/src/unbalanced_tree.ts
+++ b/yarn-project/merkle-tree/src/unbalanced_tree.ts
@@ -99,8 +99,8 @@ export class UnbalancedTree<T extends Bufferable = Buffer> implements MerkleTree
    * @returns The index of the first leaf found with a given value (undefined if not found).
    * @remark This is NOT the index as inserted, but the index which will be used to calculate path structure.
    */
-  public findLeafIndex(value: T): bigint | undefined {
-    const key = this.valueCache[serializeToBuffer(value).toString('hex')];
+  public findLeafIndex(value: Buffer): bigint | undefined {
+    const key = this.valueCache[value.toString('hex')];
     const [, , index] = key.split(':');
     return BigInt(index);
   }
@@ -112,7 +112,7 @@ export class UnbalancedTree<T extends Bufferable = Buffer> implements MerkleTree
    * @returns The index of the first leaf found with a given value (undefined if not found).
    * @remark This is not really used for a wonky tree, but required to implement MerkleTree.
    */
-  public findLeafIndexAfter(value: T, startIndex: bigint): bigint | undefined {
+  public findLeafIndexAfter(value: Buffer, startIndex: bigint): bigint | undefined {
     const index = this.findLeafIndex(value);
     if (!index || index < startIndex) {
       return undefined;

--- a/yarn-project/simulator/src/public/hints_builder.ts
+++ b/yarn-project/simulator/src/public/hints_builder.ts
@@ -21,12 +21,13 @@ import {
   buildPublicDataHints,
   buildPublicDataReadRequestHints,
   buildSiloedNullifierReadRequestHints,
+  NullifierLeaf,
 } from '@aztec/circuits.js';
 import { type Tuple } from '@aztec/foundation/serialize';
 import { type IndexedTreeId, type MerkleTreeOperations } from '@aztec/world-state';
 
 export class HintsBuilder {
-  constructor(private db: MerkleTreeOperations) {}
+  constructor(private db: MerkleTreeOperations) { }
 
   async getNullifierReadRequestHints(
     nullifierReadRequests: Tuple<ScopedReadRequest, typeof MAX_NULLIFIER_READ_REQUESTS_PER_TX>,
@@ -71,7 +72,7 @@ export class HintsBuilder {
   }
 
   async getNullifierMembershipWitness(nullifier: Fr) {
-    const index = await this.db.findLeafIndex(MerkleTreeId.NULLIFIER_TREE, nullifier.toBuffer());
+    const index = await this.db.findLeafIndex(MerkleTreeId.NULLIFIER_TREE, new NullifierLeaf(nullifier));
     if (index === undefined) {
       throw new Error(`Cannot find the leaf for nullifier ${nullifier.toBigInt()}.`);
     }

--- a/yarn-project/simulator/src/public/public_db_sources.ts
+++ b/yarn-project/simulator/src/public/public_db_sources.ts
@@ -10,6 +10,7 @@ import {
   type NULLIFIER_TREE_HEIGHT,
   type NullifierLeafPreimage,
   type PublicDataTreeLeafPreimage,
+  NullifierLeaf,
 } from '@aztec/circuits.js';
 import { computeL1ToL2MessageNullifier, computePublicDataTreeLeafSlot } from '@aztec/circuits.js/hash';
 import { createDebugLogger } from '@aztec/foundation/log';
@@ -38,7 +39,7 @@ export class ContractsDataSourcePublicDB implements PublicContractsDB {
 
   private log = createDebugLogger('aztec:sequencer:contracts-data-source');
 
-  constructor(private db: ContractDataSource) {}
+  constructor(private db: ContractDataSource) { }
 
   /**
    * Add new contracts from a transaction
@@ -122,7 +123,7 @@ export class WorldStatePublicDB implements PublicStateDB {
   private checkpointedWriteCache: Map<bigint, Fr> = new Map();
   private uncommittedWriteCache: Map<bigint, Fr> = new Map();
 
-  constructor(private db: MerkleTreeOperations) {}
+  constructor(private db: MerkleTreeOperations) { }
 
   /**
    * Reads a value from public storage, returning zero if none.
@@ -216,13 +217,13 @@ export class WorldStatePublicDB implements PublicStateDB {
 export class WorldStateDB implements CommitmentsDB {
   private log = createDebugLogger('aztec:sequencer:world-state-db');
 
-  constructor(private db: MerkleTreeOperations) {}
+  constructor(private db: MerkleTreeOperations) { }
 
   public async getNullifierMembershipWitnessAtLatestBlock(
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined> {
     const timer = new Timer();
-    const index = await this.db.findLeafIndex(MerkleTreeId.NULLIFIER_TREE, nullifier.toBuffer());
+    const index = await this.db.findLeafIndex(MerkleTreeId.NULLIFIER_TREE, new NullifierLeaf(nullifier));
     if (!index) {
       return undefined;
     }
@@ -310,7 +311,7 @@ export class WorldStateDB implements CommitmentsDB {
 
   public async getNullifierIndex(nullifier: Fr): Promise<bigint | undefined> {
     const timer = new Timer();
-    const index = await this.db.findLeafIndex(MerkleTreeId.NULLIFIER_TREE, nullifier.toBuffer());
+    const index = await this.db.findLeafIndex(MerkleTreeId.NULLIFIER_TREE, new NullifierLeaf(nullifier));
     this.log.debug(`[DB] Fetched nullifier index`, {
       eventName: 'public-db-access',
       duration: timer.ms(),

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
@@ -35,7 +35,6 @@ type WithIncludeUncommitted<F> = F extends (...args: [...infer Rest]) => infer R
  */
 type MerkleTreeSetters =
   | 'appendLeaves'
-  | 'updateLeaf'
   | 'commit'
   | 'rollback'
   | 'handleL2BlockAndMessages'
@@ -57,9 +56,9 @@ export type MerkleTreeDb = {
     MerkleTreeOperations[Property]
   >;
 } & Pick<MerkleTreeOperations, MerkleTreeSetters> & {
-    /**
-     * Returns a snapshot of the current state of the trees.
-     * @param block - The block number to take the snapshot at.
-     */
-    getSnapshot(block: number): Promise<TreeSnapshots>;
-  };
+  /**
+   * Returns a snapshot of the current state of the trees.
+   * @param block - The block number to take the snapshot at.
+   */
+  getSnapshot(block: number): Promise<TreeSnapshots>;
+};

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_operations.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_operations.ts
@@ -94,15 +94,15 @@ export interface MerkleTreeOperations {
     value: bigint,
   ): Promise<
     | {
-        /**
-         * The index of the found leaf.
-         */
-        index: bigint;
-        /**
-         * A flag indicating if the corresponding leaf's value is equal to `newValue`.
-         */
-        alreadyPresent: boolean;
-      }
+      /**
+       * The index of the found leaf.
+       */
+      index: bigint;
+      /**
+       * A flag indicating if the corresponding leaf's value is equal to `newValue`.
+       */
+      alreadyPresent: boolean;
+    }
     | undefined
   >;
 
@@ -112,14 +112,6 @@ export interface MerkleTreeOperations {
    * @param index - The index of the leaf required.
    */
   getLeafPreimage<ID extends IndexedTreeId>(treeId: ID, index: bigint): Promise<IndexedTreeLeafPreimage | undefined>;
-
-  /**
-   * Update the leaf data at the given index.
-   * @param treeId - The tree for which leaf data should be edited.
-   * @param leaf - The updated leaf value.
-   * @param index - The index of the leaf to be updated.
-   */
-  updateLeaf<ID extends IndexedTreeId>(treeId: ID, leaf: NullifierLeafPreimage | Buffer, index: bigint): Promise<void>;
 
   /**
    * Returns the index containing a leaf value.

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_operations_facade.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_operations_facade.ts
@@ -5,6 +5,7 @@ import { type BatchInsertionResult } from '@aztec/merkle-tree';
 
 import { type MerkleTreeDb } from './merkle_tree_db.js';
 import {
+  AppendOnlyTreeId,
   type HandleL2BlockAndMessagesResult,
   type IndexedTreeId,
   type MerkleTreeLeafType,
@@ -50,7 +51,7 @@ export class MerkleTreeOperationsFacade implements MerkleTreeOperations {
    * @param leaves - The set of leaves to be appended.
    * @returns The tree info of the specified tree.
    */
-  appendLeaves<ID extends MerkleTreeId>(treeId: ID, leaves: MerkleTreeLeafType<ID>[]): Promise<void> {
+  appendLeaves<ID extends AppendOnlyTreeId>(treeId: ID, leaves: MerkleTreeLeafType<ID>[]): Promise<void> {
     return this.trees.appendLeaves(treeId, leaves);
   }
 

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_operations_facade.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_operations_facade.ts
@@ -16,7 +16,7 @@ import {
  * Wraps a MerkleTreeDbOperations to call all functions with a preset includeUncommitted flag.
  */
 export class MerkleTreeOperationsFacade implements MerkleTreeOperations {
-  constructor(private trees: MerkleTreeDb, private includeUncommitted: boolean) {}
+  constructor(private trees: MerkleTreeDb, private includeUncommitted: boolean) { }
 
   /**
    * Returns the tree info for the specified tree id.
@@ -77,29 +77,18 @@ export class MerkleTreeOperationsFacade implements MerkleTreeOperations {
     value: bigint,
   ): Promise<
     | {
-        /**
-         * The index of the found leaf.
-         */
-        index: bigint;
-        /**
-         * A flag indicating if the corresponding leaf's value is equal to `newValue`.
-         */
-        alreadyPresent: boolean;
-      }
+      /**
+       * The index of the found leaf.
+       */
+      index: bigint;
+      /**
+       * A flag indicating if the corresponding leaf's value is equal to `newValue`.
+       */
+      alreadyPresent: boolean;
+    }
     | undefined
   > {
     return this.trees.getPreviousValueIndex(treeId, value, this.includeUncommitted);
-  }
-
-  /**
-   * Updates a leaf in a tree at a given index.
-   * @param treeId - The ID of the tree.
-   * @param leaf - The new leaf value.
-   * @param index - The index to insert into.
-   * @returns Empty promise.
-   */
-  updateLeaf<ID extends IndexedTreeId>(treeId: ID, leaf: NullifierLeafPreimage, index: bigint): Promise<void> {
-    return this.trees.updateLeaf(treeId, leaf, index);
   }
 
   /**

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -35,7 +35,6 @@ import {
   Pedersen,
   StandardIndexedTree,
   StandardTree,
-  type UpdateOnlyTree,
   getTreeMeta,
   loadTree,
   newTree,
@@ -100,7 +99,7 @@ export class MerkleTrees implements MerkleTreeDb {
   private trees: MerkleTreeMap = null as any;
   private jobQueue = new SerialQueue();
 
-  private constructor(private store: AztecKVStore, private log: DebugLogger) {}
+  private constructor(private store: AztecKVStore, private log: DebugLogger) { }
 
   /**
    * Method to asynchronously create and initialize a MerkleTrees instance.
@@ -326,15 +325,15 @@ export class MerkleTrees implements MerkleTreeDb {
     includeUncommitted: boolean,
   ): Promise<
     | {
-        /**
-         * The index of the found leaf.
-         */
-        index: bigint;
-        /**
-         * A flag indicating if the corresponding leaf's value is equal to `newValue`.
-         */
-        alreadyPresent: boolean;
-      }
+      /**
+       * The index of the found leaf.
+       */
+      index: bigint;
+      /**
+       * A flag indicating if the corresponding leaf's value is equal to `newValue`.
+       */
+      alreadyPresent: boolean;
+    }
     | undefined
   > {
     return await this.synchronize(() =>
@@ -396,17 +395,6 @@ export class MerkleTrees implements MerkleTreeDb {
       // TODO #5448 fix "as any"
       return Promise.resolve(tree.findLeafIndexAfter(value as any, startIndex, includeUncommitted));
     });
-  }
-
-  /**
-   * Updates a leaf in a tree at a given index.
-   * @param treeId - The ID of the tree.
-   * @param leaf - The new leaf value.
-   * @param index - The index to insert into.
-   * @returns Empty promise.
-   */
-  public async updateLeaf(treeId: IndexedTreeId, leaf: Buffer, index: bigint): Promise<void> {
-    return await this.synchronize(() => this.#updateLeaf(treeId, leaf, index));
   }
 
   /**
@@ -502,14 +490,6 @@ export class MerkleTrees implements MerkleTreeDb {
     }
     // TODO #5448 fix "as any"
     return await tree.appendLeaves(leaves as any[]);
-  }
-
-  async #updateLeaf(treeId: IndexedTreeId, leaf: MerkleTreeLeafType<typeof treeId>, index: bigint): Promise<void> {
-    const tree = this.trees[treeId];
-    if (!('updateLeaf' in tree)) {
-      throw new Error('Tree does not support `updateLeaf` method');
-    }
-    return await (tree as UpdateOnlyTree<typeof leaf>).updateLeaf(leaf, index);
   }
 
   /**


### PR DESCRIPTION
This PR changes the world state functions to read/write indexed leaf types rather than buffers. This only applies at the world state level. MerkleTrees still only work on buffers (this will get replaced soon as part of #7037, but we need a clean interface for it)