### PR TITLE
fix: Add trailing extra arguments for backend in gates_flamegraph

### DIFF
--- a/noir-projects/noir-protocol-circuits/scripts/flamegraph.sh
+++ b/noir-projects/noir-protocol-circuits/scripts/flamegraph.sh
@@ -72,7 +72,7 @@ DEST="$SCRIPT_DIR/../dest"
 mkdir -p $DEST
 
 # At last, generate the flamegraph.
-$PROFILER gates-flamegraph --artifact-path "${ARTIFACT}" --backend-path "$SCRIPT_DIR/../../../barretenberg/cpp/build/bin/bb"  --output "$DEST"
+$PROFILER gates-flamegraph --artifact-path "${ARTIFACT}" --backend-path "$SCRIPT_DIR/../../../barretenberg/cpp/build/bin/bb"  --output "$DEST" -- -h
 
 # Serve the file over http if -s is set.
 if $SERVE; then

--- a/noir/noir-repo/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
+++ b/noir/noir-repo/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
@@ -19,15 +19,22 @@ pub(crate) struct GatesFlamegraphCommand {
     #[clap(long, short)]
     backend_path: String,
 
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    backend_extra_args: Vec<String>,
+
     /// The output folder for the flamegraph svg files
     #[clap(long, short)]
     output: String,
 }
 
 pub(crate) fn run(args: GatesFlamegraphCommand) -> eyre::Result<()> {
+    dbg!(&args.backend_extra_args);
     run_with_provider(
         &PathBuf::from(args.artifact_path),
-        &BackendGatesProvider { backend_path: PathBuf::from(args.backend_path) },
+        &BackendGatesProvider {
+            backend_path: PathBuf::from(args.backend_path),
+            extra_args: args.backend_extra_args,
+        },
         &InfernoFlamegraphGenerator { count_name: "gates".to_string() },
         &PathBuf::from(args.output),
     )

--- a/noir/noir-repo/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
+++ b/noir/noir-repo/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
@@ -28,7 +28,6 @@ pub(crate) struct GatesFlamegraphCommand {
 }
 
 pub(crate) fn run(args: GatesFlamegraphCommand) -> eyre::Result<()> {
-    dbg!(&args.backend_extra_args);
     run_with_provider(
         &PathBuf::from(args.artifact_path),
         &BackendGatesProvider {

--- a/noir/noir-repo/tooling/profiler/src/gates_provider.rs
+++ b/noir/noir-repo/tooling/profiler/src/gates_provider.rs
@@ -10,12 +10,20 @@ pub(crate) trait GatesProvider {
 
 pub(crate) struct BackendGatesProvider {
     pub(crate) backend_path: PathBuf,
+    pub(crate) extra_args: Vec<String>,
 }
 
 impl GatesProvider for BackendGatesProvider {
     fn get_gates(&self, artifact_path: &Path) -> eyre::Result<BackendGatesResponse> {
-        let backend_gates_response =
-            Command::new(&self.backend_path).arg("gates").arg("-b").arg(artifact_path).output()?;
+        let mut backend_gates_cmd = Command::new(&self.backend_path);
+
+        backend_gates_cmd.arg("gates").arg("-b").arg(artifact_path);
+
+        for arg in &self.extra_args {
+            backend_gates_cmd.arg(arg);
+        }
+
+        let backend_gates_response = backend_gates_cmd.output()?;
 
         // Parse the backend gates command stdout as json
         let backend_gates_response: BackendGatesResponse =


### PR DESCRIPTION
Allows adding extra arguments for the backend for profiling, for example:
`noir-profiler gates-flamegraph -a $ARTIFACT_PATH -b $BB_PATH -o $OUT_PATH -- -h` 
to use honk recursion