### PR TITLE
chore(avm): more stats and codegen cleanup

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -902,7 +902,6 @@ void avm_prove(const std::filesystem::path& bytecode_path,
     // Prove execution and return vk
     auto const [verification_key, proof] =
         avm_trace::Execution::prove(bytecode, calldata, public_inputs_vec, avm_hints);
-    vinfo("------- PROVING DONE -------");
 
     // TODO(ilyas): <#4887>: Currently we only need these two parts of the vk, look into pcs_verification key reqs
     std::vector<uint64_t> vk_vector = { verification_key.circuit_size, verification_key.num_public_inputs };

--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.cpp
@@ -24,6 +24,7 @@
 #include "barretenberg/vm/avm_trace/fixed_gas.hpp"
 #include "barretenberg/vm/avm_trace/fixed_powers.hpp"
 #include "barretenberg/vm/avm_trace/gadgets/avm_slice_trace.hpp"
+#include "barretenberg/vm/avm_trace/stats.hpp"
 
 namespace bb::avm_trace {
 
@@ -3772,6 +3773,31 @@ std::vector<Row> AvmTraceBuilder::finalize(uint32_t min_trace_size, bool range_c
                                         gas_trace_size + 1, KERNEL_INPUTS_LENGTH,   KERNEL_OUTPUTS_LENGTH,
                                         min_trace_size,     fixed_gas_table.size(), slice_trace_size,
                                         calldata.size() };
+    vinfo("Trace sizes before padding:",
+          "\n\tmain_trace_size: ",
+          main_trace_size,
+          "\n\tmem_trace_size: ",
+          mem_trace_size,
+          "\n\talu_trace_size: ",
+          alu_trace_size,
+          "\n\trange_check_size: ",
+          range_check_size,
+          "\n\tconv_trace_size: ",
+          conv_trace_size,
+          "\n\tlookup_table_size: ",
+          lookup_table_size,
+          "\n\tsha256_trace_size: ",
+          sha256_trace_size,
+          "\n\tposeidon2_trace_size: ",
+          poseidon2_trace_size,
+          "\n\tpedersen_trace_size: ",
+          pedersen_trace_size,
+          "\n\tgas_trace_size: ",
+          gas_trace_size,
+          "\n\tfixed_gas_table_size: ",
+          fixed_gas_table.size(),
+          "\n\tslice_trace_size: ",
+          slice_trace_size);
     auto trace_size = std::max_element(trace_sizes.begin(), trace_sizes.end());
 
     // We only need to pad with zeroes to the size to the largest trace here, pow_2 padding is handled in the

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.cpp
@@ -2,6 +2,7 @@
 
 #include "barretenberg/commitment_schemes/claim.hpp"
 #include "barretenberg/commitment_schemes/commitment_key.hpp"
+#include "barretenberg/common/constexpr_utils.hpp"
 #include "barretenberg/honk/proof_system/logderivative_library.hpp"
 #include "barretenberg/honk/proof_system/permutation_library.hpp"
 #include "barretenberg/plonk_honk_shared/library/grand_product_library.hpp"
@@ -15,27 +16,6 @@ namespace bb {
 
 using Flavor = AvmFlavor;
 using FF = Flavor::FF;
-
-namespace {
-
-// Loops through LookupRelations and calculates the logderivatives.
-// Metaprogramming is used to loop through the relations, because they are types.
-template <size_t relation_idx = 0, typename PP>
-void compute_logderivative_rel(const RelationParameters<FF>& relation_parameters,
-                               PP& prover_polynomials,
-                               size_t circuit_size)
-{
-    using Relation = std::tuple_element_t<relation_idx, Flavor::LookupRelations>;
-    AVM_TRACK_TIME(
-        Relation::NAME + std::string("_ms"),
-        (compute_logderivative_inverse<Flavor, Relation>(prover_polynomials, relation_parameters, circuit_size)));
-
-    if constexpr (relation_idx + 1 < std::tuple_size_v<Flavor::LookupRelations>) {
-        compute_logderivative_rel<relation_idx + 1, PP>(relation_parameters, prover_polynomials, circuit_size);
-    }
-}
-
-} // namespace
 
 /**
  * Create AvmProver from proving key, witness and manifest.
@@ -93,8 +73,16 @@ void AvmProver::execute_log_derivative_inverse_round()
     relation_parameters.gamma = gamm;
 
     auto prover_polynomials = ProverPolynomials(*key);
-    compute_logderivative_rel(relation_parameters, prover_polynomials, key->circuit_size);
+    bb::constexpr_for<0, std::tuple_size_v<Flavor::LookupRelations>, 1>([&]<size_t relation_idx>() {
+        using Relation = std::tuple_element_t<relation_idx, Flavor::LookupRelations>;
+        AVM_TRACK_TIME(Relation::NAME + std::string("_ms"),
+                       (compute_logderivative_inverse<Flavor, Relation>(
+                           prover_polynomials, relation_parameters, key->circuit_size)));
+    });
+}
 
+void AvmProver::execute_log_derivative_inverse_commitments_round()
+{
     // Commit to all logderivative inverse polynomials
     for (auto [commitment, key_poly] : zip_view(witness_commitments.get_derived(), key->get_derived())) {
         commitment = commitment_key->commit(key_poly);
@@ -154,18 +142,22 @@ HonkProof AvmProver::construct_proof()
     execute_preamble_round();
 
     // Compute wire commitments
-    execute_wire_commitments_round();
+    AVM_TRACK_TIME("prove/execute_wire_commitments_round_ms", execute_wire_commitments_round());
 
-    // Compute sorted list accumulator and commitment
-    execute_log_derivative_inverse_round();
+    // Compute sorted list accumulator
+    AVM_TRACK_TIME("prove/execute_log_derivative_inverse_round_ms", execute_log_derivative_inverse_round());
+
+    // Compute commitments to logderivative inverse polynomials
+    AVM_TRACK_TIME("prove/execute_log_derivative_inverse_commitments_round_ms",
+                   execute_log_derivative_inverse_commitments_round());
 
     // Fiat-Shamir: alpha
     // Run sumcheck subprotocol.
-    execute_relation_check_rounds();
+    AVM_TRACK_TIME("prove/execute_relation_check_rounds_ms", execute_relation_check_rounds());
 
     // Fiat-Shamir: rho, y, x, z
     // Execute Zeromorph multilinear PCS
-    execute_pcs_rounds();
+    AVM_TRACK_TIME("prove/execute_pcs_rounds_ms", execute_pcs_rounds());
 
     return export_proof();
 }

--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.hpp
@@ -29,6 +29,7 @@ class AvmProver {
     void execute_preamble_round();
     void execute_wire_commitments_round();
     void execute_log_derivative_inverse_round();
+    void execute_log_derivative_inverse_commitments_round();
     void execute_relation_check_rounds();
     void execute_pcs_rounds();
 

--- a/bb-pilcom/bb-pil-backend/templates/circuit_builder.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/circuit_builder.hpp.hbs
@@ -161,7 +161,6 @@ class {{name}}CircuitBuilder {
             return true;
         }
     
-
         [[nodiscard]] size_t get_num_gates() const { return rows.size(); }
 
         [[nodiscard]] size_t get_circuit_subgroup_size() const

--- a/bb-pilcom/bb-pil-backend/templates/prover.cpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/prover.cpp.hbs
@@ -2,6 +2,7 @@
 
 #include "barretenberg/commitment_schemes/claim.hpp"
 #include "barretenberg/commitment_schemes/commitment_key.hpp"
+#include "barretenberg/common/constexpr_utils.hpp"
 #include "barretenberg/honk/proof_system/logderivative_library.hpp"
 #include "barretenberg/honk/proof_system/permutation_library.hpp"
 #include "barretenberg/plonk_honk_shared/library/grand_product_library.hpp"
@@ -15,27 +16,6 @@ namespace bb {
 
 using Flavor = {{name}}Flavor;
 using FF = Flavor::FF;
-
-namespace {
-
-// Loops through LookupRelations and calculates the logderivatives.
-// Metaprogramming is used to loop through the relations, because they are types.
-template <size_t relation_idx = 0, typename PP>
-void compute_logderivative_rel(const RelationParameters<FF>& relation_parameters,
-                               PP& prover_polynomials,
-                               size_t circuit_size)
-{
-    using Relation = std::tuple_element_t<relation_idx, Flavor::LookupRelations>;
-    AVM_TRACK_TIME(
-        Relation::NAME + std::string("_ms"),
-        (compute_logderivative_inverse<Flavor, Relation>(prover_polynomials, relation_parameters, circuit_size)));
-
-    if constexpr (relation_idx + 1 < std::tuple_size_v<Flavor::LookupRelations>) {
-        compute_logderivative_rel<relation_idx + 1, PP>(relation_parameters, prover_polynomials, circuit_size);
-    }
-}
-
-} // namespace
 
 /**
  * Create {{name}}Prover from proving key, witness and manifest.
@@ -94,8 +74,16 @@ void {{name}}Prover::execute_log_derivative_inverse_round()
     relation_parameters.gamma = gamm;
 
     auto prover_polynomials = ProverPolynomials(*key);
-    compute_logderivative_rel(relation_parameters, prover_polynomials, key->circuit_size);
+    bb::constexpr_for<0, std::tuple_size_v<Flavor::LookupRelations>, 1>([&]<size_t relation_idx>() {
+        using Relation = std::tuple_element_t<relation_idx, Flavor::LookupRelations>;
+        AVM_TRACK_TIME(Relation::NAME + std::string("_ms"),
+                       (compute_logderivative_inverse<Flavor, Relation>(
+                           prover_polynomials, relation_parameters, key->circuit_size)));
+    });
+}
 
+void {{name}}Prover::execute_log_derivative_inverse_commitments_round()
+{
     // Commit to all logderivative inverse polynomials
     for (auto [commitment, key_poly] : zip_view(witness_commitments.get_derived(), key->get_derived())) {
        commitment = commitment_key->commit(key_poly);
@@ -155,18 +143,21 @@ HonkProof {{name}}Prover::construct_proof()
     execute_preamble_round();
 
     // Compute wire commitments
-    execute_wire_commitments_round();
+    AVM_TRACK_TIME("prove/execute_wire_commitments_round_ms", execute_wire_commitments_round());
 
-    // Compute sorted list accumulator and commitment
-    execute_log_derivative_inverse_round();
+    // Compute sorted list accumulator
+    AVM_TRACK_TIME("prove/execute_log_derivative_inverse_round_ms", execute_log_derivative_inverse_round());
+
+    // Compute commitments to logderivative inverse polynomials
+    AVM_TRACK_TIME("prove/execute_log_derivative_inverse_commitments_round_ms", execute_log_derivative_inverse_commitments_round());
 
     // Fiat-Shamir: alpha
     // Run sumcheck subprotocol.
-    execute_relation_check_rounds();
+    AVM_TRACK_TIME("prove/execute_relation_check_rounds_ms", execute_relation_check_rounds());
 
     // Fiat-Shamir: rho, y, x, z
     // Execute Zeromorph multilinear PCS
-    execute_pcs_rounds();
+    AVM_TRACK_TIME("prove/execute_pcs_rounds_ms", execute_pcs_rounds());
 
     return export_proof();
 }

--- a/bb-pilcom/bb-pil-backend/templates/prover.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/prover.hpp.hbs
@@ -29,6 +29,7 @@ class {{name}}Prover {
     void execute_preamble_round();
     void execute_wire_commitments_round();
     void execute_log_derivative_inverse_round();
+    void execute_log_derivative_inverse_commitments_round();
     void execute_relation_check_rounds();
     void execute_pcs_rounds();
 


### PR DESCRIPTION
* Add trace size stats and proof sections time tracking
* Use `bb:constexpr_for` instead of custom template that did the same

Example public transfer
```
bytecode size: 31218
calldata size: 6
public_inputs size: 481
hints.storage_value_hints size: 2
hints.note_hash_exists_hints size: 0
hints.nullifier_exists_hints size: 1
hints.l1_to_l2_message_exists_hints size: 0
hints.externalcall_hints size: 0
hints.contract_instance_hints size: 0
using cached crs of size 8388609 at "/mnt/user-data/facundo/.bb-crs/bn254_g1.dat"
Deserialized 2524 instructions
------- GENERATING TRACE -------
Trace sizes before padding:
        main_trace_size: 1638
        mem_trace_size: 3880
        alu_trace_size: 811
        range_check_size: 65536
        conv_trace_size: 1
        lookup_table_size: 0
        sha256_trace_size: 0
        poseidon2_trace_size: 0
        pedersen_trace_size: 4
        gas_trace_size: 1620
        fixed_gas_table_size: 65
        slice_trace_size: 7
Final trace size: 65537
------- PROVING EXECUTION -------
proof written to: "/mnt/user-data/facundo/tmp-8Q3xgk/proof"
vk written to: "/mnt/user-data/facundo/tmp-8Q3xgk/vk"
vk as fields written to: "/mnt/user-data/facundo/tmp-8Q3xgk/vk_fields.json"
------- STATS -------
incl_main_tag_err_ms: 78
incl_mem_tag_err_ms: 79
kernel_output_lookup_ms: 79
lookup_byte_lengths_ms: 75
lookup_byte_operations_ms: 81
lookup_cd_value_ms: 77
lookup_div_u16_0_ms: 100
lookup_div_u16_1_ms: 98
lookup_div_u16_2_ms: 99
lookup_div_u16_3_ms: 97
lookup_div_u16_4_ms: 99
lookup_div_u16_5_ms: 103
lookup_div_u16_6_ms: 97
lookup_div_u16_7_ms: 97
lookup_into_kernel_ms: 83
lookup_mem_rng_chk_hi_ms: 79
lookup_mem_rng_chk_lo_ms: 95
lookup_mem_rng_chk_mid_ms: 108
lookup_opcode_gas_ms: 78
lookup_pow_2_0_ms: 84
lookup_pow_2_1_ms: 79
lookup_ret_value_ms: 82
lookup_u16_0_ms: 107
lookup_u16_10_ms: 107
lookup_u16_11_ms: 96
lookup_u16_12_ms: 96
lookup_u16_13_ms: 97
lookup_u16_14_ms: 103
lookup_u16_1_ms: 95
lookup_u16_2_ms: 96
lookup_u16_3_ms: 97
lookup_u16_4_ms: 98
lookup_u16_5_ms: 111
lookup_u16_6_ms: 99
lookup_u16_7_ms: 97
lookup_u16_8_ms: 97
lookup_u16_9_ms: 96
lookup_u8_0_ms: 79
lookup_u8_1_ms: 77
perm_main_alu_ms: 82
perm_main_bin_ms: 76
perm_main_conv_ms: 75
perm_main_mem_a_ms: 80
perm_main_mem_b_ms: 77
perm_main_mem_c_ms: 75
perm_main_mem_d_ms: 77
perm_main_mem_ind_addr_a_ms: 76
perm_main_mem_ind_addr_b_ms: 77
perm_main_mem_ind_addr_c_ms: 74
perm_main_mem_ind_addr_d_ms: 76
perm_main_pedersen_ms: 75
perm_main_pos2_perm_ms: 79
perm_main_slice_ms: 74
perm_slice_mem_ms: 80
prove/check_circuit: 5120
prove/execute_log_derivative_inverse_commitments_round_ms: 532
prove/execute_log_derivative_inverse_round_ms: 5199
prove/execute_pcs_rounds_ms: 413
prove/execute_relation_check_rounds_ms: 1328
prove/execute_wire_commitments_round_ms: 1742
prove/gen_trace: 850
range_check_da_gas_hi_ms: 98
range_check_da_gas_lo_ms: 103
range_check_l2_gas_hi_ms: 100
range_check_l2_gas_lo_ms: 98
```