### PR TITLE
fix(avm): one too many range check rows

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm_trace/avm_trace.cpp
@@ -3766,7 +3766,9 @@ std::vector<Row> AvmTraceBuilder::finalize(uint32_t min_trace_size, bool range_c
     // If the bin_trace_size has entries, we need the main_trace to be as big as our byte lookup table (3 *
     // 2**16 long)
     size_t const lookup_table_size = (bin_trace_size > 0 && range_check_required) ? 3 * (1 << 16) : 0;
-    size_t const range_check_size = range_check_required ? UINT16_MAX + 1 : 0;
+    // Range check size is 1 less than it needs to be since we insert a "first row" at the top of the trace at the end,
+    // with clk 0 (this doubles as our range check)
+    size_t const range_check_size = range_check_required ? UINT16_MAX : 0;
     std::vector<size_t> trace_sizes = { mem_trace_size,     main_trace_size,        alu_trace_size,
                                         range_check_size,   conv_trace_size,        lookup_table_size,
                                         sha256_trace_size,  poseidon2_trace_size,   pedersen_trace_size,
@@ -3781,7 +3783,7 @@ std::vector<Row> AvmTraceBuilder::finalize(uint32_t min_trace_size, bool range_c
           "\n\talu_trace_size: ",
           alu_trace_size,
           "\n\trange_check_size: ",
-          range_check_size,
+          range_check_size + 1, // The manually inserted first row is part of the range check
           "\n\tconv_trace_size: ",
           conv_trace_size,
           "\n\tlookup_table_size: ",


### PR DESCRIPTION
```
time AVM_ENABLE_FULL_PROVING=1 build/bin/bb avm_prove --avm-bytecode ~/tmp-8Q3xgk/avm_bytecode.bin --avm-calldata ~/tmp-8Q3xgk/avm_calldata.bin --avm-public-inputs ~/tmp-8Q3xgk/avm_public_inputs.bin --avm-hints ~/tmp-8Q3xgk/avm_hints.bin -o
~/tmp-8Q3xgk -v
bytecode size: 31218
calldata size: 6
public_inputs size: 481
hints.storage_value_hints size: 2
hints.note_hash_exists_hints size: 0
hints.nullifier_exists_hints size: 1
hints.l1_to_l2_message_exists_hints size: 0
hints.externalcall_hints size: 0
hints.contract_instance_hints size: 0
using cached crs of size 8388609 at "/mnt/user-data/ilyas/.bb-crs/bn254_g1.dat"
Deserialized 2524 instructions
------- GENERATING TRACE -------
Trace sizes before padding:
        main_trace_size: 1638
        mem_trace_size: 3880
        alu_trace_size: 811
        range_check_size: 65535
        conv_trace_size: 1
        lookup_table_size: 0
        sha256_trace_size: 0
        poseidon2_trace_size: 0
        pedersen_trace_size: 4
        gas_trace_size: 1620
        fixed_gas_table_size: 65
        slice_trace_size: 7
Final trace size: 65536
------- PROVING EXECUTION -------
proof written to: "/mnt/user-data/ilyas/tmp-8Q3xgk/proof"
vk written to: "/mnt/user-data/ilyas/tmp-8Q3xgk/vk"
vk as fields written to: "/mnt/user-data/ilyas/tmp-8Q3xgk/vk_fields.json"
------- STATS -------
incl_main_tag_err_ms: 42
incl_mem_tag_err_ms: 40
kernel_output_lookup_ms: 41
lookup_byte_lengths_ms: 37
lookup_byte_operations_ms: 37
lookup_cd_value_ms: 38
lookup_div_u16_0_ms: 58
lookup_div_u16_1_ms: 58
lookup_div_u16_2_ms: 57
lookup_div_u16_3_ms: 58
lookup_div_u16_4_ms: 58
lookup_div_u16_5_ms: 61
lookup_div_u16_6_ms: 57
lookup_div_u16_7_ms: 59
lookup_into_kernel_ms: 46
lookup_mem_rng_chk_hi_ms: 45
lookup_mem_rng_chk_lo_ms: 62
lookup_mem_rng_chk_mid_ms: 59
lookup_opcode_gas_ms: 38
lookup_pow_2_0_ms: 43
lookup_pow_2_1_ms: 42
lookup_ret_value_ms: 38
lookup_u16_0_ms: 58
lookup_u16_10_ms: 57
lookup_u16_11_ms: 58
lookup_u16_12_ms: 58
lookup_u16_13_ms: 58
lookup_u16_14_ms: 67
lookup_u16_1_ms: 58
lookup_u16_2_ms: 62
lookup_u16_3_ms: 58
lookup_u16_4_ms: 58
lookup_u16_5_ms: 58
lookup_u16_6_ms: 57
lookup_u16_7_ms: 66
lookup_u16_8_ms: 58
lookup_u16_9_ms: 58
lookup_u8_0_ms: 53
lookup_u8_1_ms: 39
perm_main_alu_ms: 39
perm_main_bin_ms: 38
perm_main_conv_ms: 37
perm_main_mem_a_ms: 39
perm_main_mem_b_ms: 38
perm_main_mem_c_ms: 47
perm_main_mem_d_ms: 38
perm_main_mem_ind_addr_a_ms: 39
perm_main_mem_ind_addr_b_ms: 39
perm_main_mem_ind_addr_c_ms: 39
perm_main_mem_ind_addr_d_ms: 38
perm_main_pedersen_ms: 38
perm_main_pos2_perm_ms: 38
perm_main_slice_ms: 38
perm_slice_mem_ms: 38
prove/check_circuit: 2593
prove/execute_log_derivative_inverse_commitments_round_ms: 417
prove/execute_log_derivative_inverse_round_ms: 2927
prove/execute_pcs_rounds_ms: 502
prove/execute_relation_check_rounds_ms: 751
prove/execute_wire_commitments_round_ms: 1231
prove/gen_trace: 822
range_check_da_gas_hi_ms: 62
range_check_da_gas_lo_ms: 60
range_check_l2_gas_hi_ms: 58
range_check_l2_gas_lo_ms: 56

AVM_ENABLE_FULL_PROVING=1 build/bin/bb avm_prove --avm-bytecode        -o  -v  88.25s user 39.63s system 1050% cpu 12.171 total
```