### PR TITLE
refactor: moving pub_key_to_bytes to aztec-nr

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
@@ -1,11 +1,12 @@
 use dep::protocol_types::{
-    address::AztecAddress, scalar::Scalar, point::{Point, pub_key_to_bytes},
+    address::AztecAddress, scalar::Scalar, point::Point,
     constants::{GENERATOR_INDEX__IVSK_M, GENERATOR_INDEX__OVSK_M}, hash::poseidon2_hash
 };
 use std::embedded_curve_ops::fixed_base_scalar_mul as derive_public_key;
 use std::field::bytes32_to_field;
 
 use crate::oracle::unsafe_rand::unsafe_rand;
+use crate::utils::point::pub_key_to_bytes;
 
 use crate::event::event_interface::EventInterface;
 use crate::note::note_interface::NoteInterface;

--- a/noir-projects/aztec-nr/aztec/src/keys/point_to_symmetric_key.nr
+++ b/noir-projects/aztec-nr/aztec/src/keys/point_to_symmetric_key.nr
@@ -1,7 +1,5 @@
-use dep::protocol_types::{
-    constants::GENERATOR_INDEX__SYMMETRIC_KEY, scalar::Scalar, point::{Point, pub_key_to_bytes},
-    utils::arr_copy_slice
-};
+use dep::protocol_types::{constants::GENERATOR_INDEX__SYMMETRIC_KEY, scalar::Scalar, point::Point, utils::arr_copy_slice};
+use crate::utils::point::pub_key_to_bytes;
 use std::{hash::sha256, embedded_curve_ops::multi_scalar_mul};
 
 // TODO(#5726): This function is called deriveAESSecret in TS. I don't like point_to_symmetric_key name much since

--- a/noir-projects/aztec-nr/aztec/src/utils/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/mod.nr
@@ -1,6 +1,7 @@
 use dep::protocol_types::traits::Eq;
 
 mod test;
+mod point;
 
 // Collapses an array of Options with sparse Some values into a BoundedVec, essentially unwrapping the Options and
 // removing the None values. For example, given:

--- a/noir-projects/aztec-nr/aztec/src/utils/point.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/point.nr
@@ -1,0 +1,17 @@
+use dep::protocol_types::point::Point;
+
+/// Converts a public key to a byte array.
+///
+/// We don't serialize the point at infinity flag because this function is used in situations where we do not want
+/// to waste the extra byte (encrypted log).
+pub fn pub_key_to_bytes(pk: Point) -> [u8; 64] {
+    assert(!pk.is_infinite, "Point at infinity is not a valid public key.");
+    let mut result = [0 as u8; 64];
+    let x_bytes = pk.x.to_be_bytes(32);
+    let y_bytes = pk.y.to_be_bytes(32);
+    for i in 0..32 {
+        result[i] = x_bytes[i];
+        result[i + 32] = y_bytes[i];
+    }
+    result
+}

--- a/noir-projects/noir-protocol-circuits/crates/types/src/point.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/point.nr
@@ -27,18 +27,3 @@ impl Empty for Point {
     }
 }
 
-/// Converts a public key to a byte array.
-///
-/// We don't serialize the point at infinity flag because this function is used in situations where we do not want
-/// to waste the extra byte (encrypted log).
-pub fn pub_key_to_bytes(pk: Point) -> [u8; 64] {
-    assert(!pk.is_infinite, "Point at infinity is not a valid public key.");
-    let mut result = [0 as u8; 64];
-    let x_bytes = pk.x.to_be_bytes(32);
-    let y_bytes = pk.y.to_be_bytes(32);
-    for i in 0..32 {
-        result[i] = x_bytes[i];
-        result[i + 32] = y_bytes[i];
-    }
-    result
-}


### PR DESCRIPTION
It's a utility func used only by aztec-nr so it didn't make sense to have it in protocol circuits.
