### PR TITLE
chore(avm): nuke declare_views

### DIFF
--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/alu.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/alu.hpp
@@ -244,805 +244,798 @@ template <typename FF_> class aluImpl {
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        // Contribution 0
         {
-            Avm_DECLARE_VIEWS(0);
-            auto tmp = (alu_sel_alu -
-                        ((((((((((alu_op_add + alu_op_sub) + alu_op_mul) + alu_op_not) + alu_op_eq) + alu_op_cast) +
-                             alu_op_lt) +
-                            alu_op_lte) +
-                           alu_op_shr) +
-                          alu_op_shl) +
-                         alu_op_div));
-            tmp *= scaling_factor;
-            std::get<0>(evals) += tmp;
-        }
-        // Contribution 1
-        {
-            Avm_DECLARE_VIEWS(1);
-            auto tmp = (alu_sel_cmp - (alu_op_lt + alu_op_lte));
-            tmp *= scaling_factor;
-            std::get<1>(evals) += tmp;
-        }
-        // Contribution 2
-        {
-            Avm_DECLARE_VIEWS(2);
-            auto tmp = (alu_sel_shift_which - (alu_op_shl + alu_op_shr));
-            tmp *= scaling_factor;
-            std::get<2>(evals) += tmp;
-        }
-        // Contribution 3
-        {
-            Avm_DECLARE_VIEWS(3);
-            auto tmp = (alu_cf * (-alu_cf + FF(1)));
-            tmp *= scaling_factor;
-            std::get<3>(evals) += tmp;
-        }
-        // Contribution 4
-        {
-            Avm_DECLARE_VIEWS(4);
-            auto tmp = (alu_ff_tag * (-alu_ff_tag + FF(1)));
-            tmp *= scaling_factor;
-            std::get<4>(evals) += tmp;
-        }
-        // Contribution 5
-        {
-            Avm_DECLARE_VIEWS(5);
-            auto tmp = (alu_u8_tag * (-alu_u8_tag + FF(1)));
-            tmp *= scaling_factor;
-            std::get<5>(evals) += tmp;
-        }
-        // Contribution 6
-        {
-            Avm_DECLARE_VIEWS(6);
-            auto tmp = (alu_u16_tag * (-alu_u16_tag + FF(1)));
-            tmp *= scaling_factor;
-            std::get<6>(evals) += tmp;
-        }
-        // Contribution 7
-        {
-            Avm_DECLARE_VIEWS(7);
-            auto tmp = (alu_u32_tag * (-alu_u32_tag + FF(1)));
-            tmp *= scaling_factor;
-            std::get<7>(evals) += tmp;
-        }
-        // Contribution 8
-        {
-            Avm_DECLARE_VIEWS(8);
-            auto tmp = (alu_u64_tag * (-alu_u64_tag + FF(1)));
-            tmp *= scaling_factor;
-            std::get<8>(evals) += tmp;
-        }
-        // Contribution 9
-        {
-            Avm_DECLARE_VIEWS(9);
-            auto tmp = (alu_u128_tag * (-alu_u128_tag + FF(1)));
-            tmp *= scaling_factor;
-            std::get<9>(evals) += tmp;
-        }
-        // Contribution 10
-        {
-            Avm_DECLARE_VIEWS(10);
+            using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
             auto tmp =
-                (alu_sel_alu *
-                 ((((((alu_ff_tag + alu_u8_tag) + alu_u16_tag) + alu_u32_tag) + alu_u64_tag) + alu_u128_tag) - FF(1)));
+                (new_term.alu_sel_alu -
+                 ((((((((((new_term.alu_op_add + new_term.alu_op_sub) + new_term.alu_op_mul) + new_term.alu_op_not) +
+                        new_term.alu_op_eq) +
+                       new_term.alu_op_cast) +
+                      new_term.alu_op_lt) +
+                     new_term.alu_op_lte) +
+                    new_term.alu_op_shr) +
+                   new_term.alu_op_shl) +
+                  new_term.alu_op_div));
             tmp *= scaling_factor;
-            std::get<10>(evals) += tmp;
+            std::get<0>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 11
         {
-            Avm_DECLARE_VIEWS(11);
-            auto tmp = (alu_in_tag -
-                        (((((alu_u8_tag + (alu_u16_tag * FF(2))) + (alu_u32_tag * FF(3))) + (alu_u64_tag * FF(4))) +
-                          (alu_u128_tag * FF(5))) +
-                         (alu_ff_tag * FF(6))));
+            using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_sel_cmp - (new_term.alu_op_lt + new_term.alu_op_lte));
             tmp *= scaling_factor;
-            std::get<11>(evals) += tmp;
+            std::get<1>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 12
         {
-            Avm_DECLARE_VIEWS(12);
+            using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_sel_shift_which - (new_term.alu_op_shl + new_term.alu_op_shr));
+            tmp *= scaling_factor;
+            std::get<2>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_cf * (-new_term.alu_cf + FF(1)));
+            tmp *= scaling_factor;
+            std::get<3>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_ff_tag * (-new_term.alu_ff_tag + FF(1)));
+            tmp *= scaling_factor;
+            std::get<4>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_u8_tag * (-new_term.alu_u8_tag + FF(1)));
+            tmp *= scaling_factor;
+            std::get<5>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_u16_tag * (-new_term.alu_u16_tag + FF(1)));
+            tmp *= scaling_factor;
+            std::get<6>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_u32_tag * (-new_term.alu_u32_tag + FF(1)));
+            tmp *= scaling_factor;
+            std::get<7>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_u64_tag * (-new_term.alu_u64_tag + FF(1)));
+            tmp *= scaling_factor;
+            std::get<8>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_u128_tag * (-new_term.alu_u128_tag + FF(1)));
+            tmp *= scaling_factor;
+            std::get<9>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
             auto tmp =
-                (((alu_op_add + alu_op_sub) * ((((((((((alu_u8_r0 + (alu_u8_r1 * FF(256))) + (alu_u16_r0 * FF(65536))) +
-                                                      (alu_u16_r1 * FF(4294967296UL))) +
-                                                     (alu_u16_r2 * FF(281474976710656UL))) +
-                                                    (alu_u16_r3 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
-                                                   (alu_u16_r4 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
-                                                  (alu_u16_r5 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
-                                                 (alu_u16_r6 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))) -
-                                                alu_ia) +
-                                               (alu_ff_tag * alu_ic))) +
-                 ((alu_op_add - alu_op_sub) * ((alu_cf * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL })) - alu_ib)));
+                (new_term.alu_sel_alu *
+                 ((((((new_term.alu_ff_tag + new_term.alu_u8_tag) + new_term.alu_u16_tag) + new_term.alu_u32_tag) +
+                    new_term.alu_u64_tag) +
+                   new_term.alu_u128_tag) -
+                  FF(1)));
             tmp *= scaling_factor;
-            std::get<12>(evals) += tmp;
+            std::get<10>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 13
         {
-            Avm_DECLARE_VIEWS(13);
-            auto tmp = (((alu_op_add + alu_op_sub) *
-                         (((((((alu_u8_tag * alu_u8_r0) + (alu_u16_tag * (alu_u8_r0 + (alu_u8_r1 * FF(256))))) +
-                              (alu_u32_tag * ((alu_u8_r0 + (alu_u8_r1 * FF(256))) + (alu_u16_r0 * FF(65536))))) +
-                             (alu_u64_tag * ((((alu_u8_r0 + (alu_u8_r1 * FF(256))) + (alu_u16_r0 * FF(65536))) +
-                                              (alu_u16_r1 * FF(4294967296UL))) +
-                                             (alu_u16_r2 * FF(281474976710656UL))))) +
-                            (alu_u128_tag * ((((((((alu_u8_r0 + (alu_u8_r1 * FF(256))) + (alu_u16_r0 * FF(65536))) +
-                                                  (alu_u16_r1 * FF(4294967296UL))) +
-                                                 (alu_u16_r2 * FF(281474976710656UL))) +
-                                                (alu_u16_r3 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
-                                               (alu_u16_r4 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
-                                              (alu_u16_r5 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
-                                             (alu_u16_r6 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))))) +
-                           (alu_ff_tag * alu_ia)) -
-                          alu_ic)) +
-                        ((alu_ff_tag * (alu_op_add - alu_op_sub)) * alu_ib));
+            using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_in_tag -
+                        (((((new_term.alu_u8_tag + (new_term.alu_u16_tag * FF(2))) + (new_term.alu_u32_tag * FF(3))) +
+                           (new_term.alu_u64_tag * FF(4))) +
+                          (new_term.alu_u128_tag * FF(5))) +
+                         (new_term.alu_ff_tag * FF(6))));
             tmp *= scaling_factor;
-            std::get<13>(evals) += tmp;
+            std::get<11>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 14
         {
-            Avm_DECLARE_VIEWS(14);
-            auto tmp = ((alu_ff_tag * alu_op_mul) * ((alu_ia * alu_ib) - alu_ic));
-            tmp *= scaling_factor;
-            std::get<14>(evals) += tmp;
-        }
-        // Contribution 15
-        {
-            Avm_DECLARE_VIEWS(15);
-            auto tmp = ((((-alu_ff_tag + FF(1)) - alu_u128_tag) * alu_op_mul) *
-                        (((((((((alu_u8_r0 + (alu_u8_r1 * FF(256))) + (alu_u16_r0 * FF(65536))) +
-                               (alu_u16_r1 * FF(4294967296UL))) +
-                              (alu_u16_r2 * FF(281474976710656UL))) +
-                             (alu_u16_r3 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
-                            (alu_u16_r4 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
-                           (alu_u16_r5 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
-                          (alu_u16_r6 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))) -
-                         (alu_ia * alu_ib)));
-            tmp *= scaling_factor;
-            std::get<15>(evals) += tmp;
-        }
-        // Contribution 16
-        {
-            Avm_DECLARE_VIEWS(16);
+            using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
             auto tmp =
-                (alu_op_mul * (((((alu_u8_tag * alu_u8_r0) + (alu_u16_tag * (alu_u8_r0 + (alu_u8_r1 * FF(256))))) +
-                                 (alu_u32_tag * ((alu_u8_r0 + (alu_u8_r1 * FF(256))) + (alu_u16_r0 * FF(65536))))) +
-                                (alu_u64_tag * ((((alu_u8_r0 + (alu_u8_r1 * FF(256))) + (alu_u16_r0 * FF(65536))) +
-                                                 (alu_u16_r1 * FF(4294967296UL))) +
-                                                (alu_u16_r2 * FF(281474976710656UL))))) -
-                               (((-alu_ff_tag + FF(1)) - alu_u128_tag) * alu_ic)));
+                (((new_term.alu_op_add + new_term.alu_op_sub) *
+                  ((((((((((new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))) + (new_term.alu_u16_r0 * FF(65536))) +
+                          (new_term.alu_u16_r1 * FF(4294967296UL))) +
+                         (new_term.alu_u16_r2 * FF(281474976710656UL))) +
+                        (new_term.alu_u16_r3 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
+                       (new_term.alu_u16_r4 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
+                      (new_term.alu_u16_r5 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
+                     (new_term.alu_u16_r6 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))) -
+                    new_term.alu_ia) +
+                   (new_term.alu_ff_tag * new_term.alu_ic))) +
+                 ((new_term.alu_op_add - new_term.alu_op_sub) *
+                  ((new_term.alu_cf * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL })) - new_term.alu_ib)));
             tmp *= scaling_factor;
-            std::get<16>(evals) += tmp;
+            std::get<12>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 17
         {
-            Avm_DECLARE_VIEWS(17);
-            auto tmp = ((alu_u128_tag * alu_op_mul) *
-                        ((((((alu_u8_r0 + (alu_u8_r1 * FF(256))) + (alu_u16_r0 * FF(65536))) +
-                            (alu_u16_r1 * FF(4294967296UL))) +
-                           (alu_u16_r2 * FF(281474976710656UL))) +
-                          ((((alu_u16_r3 + (alu_u16_r4 * FF(65536))) + (alu_u16_r5 * FF(4294967296UL))) +
-                            (alu_u16_r6 * FF(281474976710656UL))) *
-                           FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) -
-                         alu_ia));
-            tmp *= scaling_factor;
-            std::get<17>(evals) += tmp;
-        }
-        // Contribution 18
-        {
-            Avm_DECLARE_VIEWS(18);
+            using Accumulator = typename std::tuple_element_t<13, ContainerOverSubrelations>;
             auto tmp =
-                ((alu_u128_tag * alu_op_mul) *
-                 ((((((alu_u8_r0_shift + (alu_u8_r1_shift * FF(256))) + (alu_u16_r0_shift * FF(65536))) +
-                     (alu_u16_r1_shift * FF(4294967296UL))) +
-                    (alu_u16_r2_shift * FF(281474976710656UL))) +
-                   ((((alu_u16_r3_shift + (alu_u16_r4_shift * FF(65536))) + (alu_u16_r5_shift * FF(4294967296UL))) +
-                     (alu_u16_r6_shift * FF(281474976710656UL))) *
+                (((new_term.alu_op_add + new_term.alu_op_sub) *
+                  (((((((new_term.alu_u8_tag * new_term.alu_u8_r0) +
+                        (new_term.alu_u16_tag * (new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))))) +
+                       (new_term.alu_u32_tag *
+                        ((new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))) + (new_term.alu_u16_r0 * FF(65536))))) +
+                      (new_term.alu_u64_tag *
+                       ((((new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))) + (new_term.alu_u16_r0 * FF(65536))) +
+                         (new_term.alu_u16_r1 * FF(4294967296UL))) +
+                        (new_term.alu_u16_r2 * FF(281474976710656UL))))) +
+                     (new_term.alu_u128_tag *
+                      ((((((((new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))) +
+                             (new_term.alu_u16_r0 * FF(65536))) +
+                            (new_term.alu_u16_r1 * FF(4294967296UL))) +
+                           (new_term.alu_u16_r2 * FF(281474976710656UL))) +
+                          (new_term.alu_u16_r3 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
+                         (new_term.alu_u16_r4 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
+                        (new_term.alu_u16_r5 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
+                       (new_term.alu_u16_r6 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))))) +
+                    (new_term.alu_ff_tag * new_term.alu_ia)) -
+                   new_term.alu_ic)) +
+                 ((new_term.alu_ff_tag * (new_term.alu_op_add - new_term.alu_op_sub)) * new_term.alu_ib));
+            tmp *= scaling_factor;
+            std::get<13>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<14, ContainerOverSubrelations>;
+            auto tmp =
+                ((new_term.alu_ff_tag * new_term.alu_op_mul) * ((new_term.alu_ia * new_term.alu_ib) - new_term.alu_ic));
+            tmp *= scaling_factor;
+            std::get<14>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<15, ContainerOverSubrelations>;
+            auto tmp =
+                ((((-new_term.alu_ff_tag + FF(1)) - new_term.alu_u128_tag) * new_term.alu_op_mul) *
+                 (((((((((new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))) + (new_term.alu_u16_r0 * FF(65536))) +
+                        (new_term.alu_u16_r1 * FF(4294967296UL))) +
+                       (new_term.alu_u16_r2 * FF(281474976710656UL))) +
+                      (new_term.alu_u16_r3 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
+                     (new_term.alu_u16_r4 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
+                    (new_term.alu_u16_r5 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
+                   (new_term.alu_u16_r6 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))) -
+                  (new_term.alu_ia * new_term.alu_ib)));
+            tmp *= scaling_factor;
+            std::get<15>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<16, ContainerOverSubrelations>;
+            auto tmp =
+                (new_term.alu_op_mul *
+                 (((((new_term.alu_u8_tag * new_term.alu_u8_r0) +
+                     (new_term.alu_u16_tag * (new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))))) +
+                    (new_term.alu_u32_tag *
+                     ((new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))) + (new_term.alu_u16_r0 * FF(65536))))) +
+                   (new_term.alu_u64_tag *
+                    ((((new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))) + (new_term.alu_u16_r0 * FF(65536))) +
+                      (new_term.alu_u16_r1 * FF(4294967296UL))) +
+                     (new_term.alu_u16_r2 * FF(281474976710656UL))))) -
+                  (((-new_term.alu_ff_tag + FF(1)) - new_term.alu_u128_tag) * new_term.alu_ic)));
+            tmp *= scaling_factor;
+            std::get<16>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<17, ContainerOverSubrelations>;
+            auto tmp =
+                ((new_term.alu_u128_tag * new_term.alu_op_mul) *
+                 ((((((new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))) + (new_term.alu_u16_r0 * FF(65536))) +
+                     (new_term.alu_u16_r1 * FF(4294967296UL))) +
+                    (new_term.alu_u16_r2 * FF(281474976710656UL))) +
+                   ((((new_term.alu_u16_r3 + (new_term.alu_u16_r4 * FF(65536))) +
+                      (new_term.alu_u16_r5 * FF(4294967296UL))) +
+                     (new_term.alu_u16_r6 * FF(281474976710656UL))) *
                     FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) -
-                  alu_ib));
+                  new_term.alu_ia));
             tmp *= scaling_factor;
-            std::get<18>(evals) += tmp;
+            std::get<17>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 19
         {
-            Avm_DECLARE_VIEWS(19);
+            using Accumulator = typename std::tuple_element_t<18, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_u128_tag * new_term.alu_op_mul) *
+                        ((((((new_term.alu_u8_r0_shift + (new_term.alu_u8_r1_shift * FF(256))) +
+                             (new_term.alu_u16_r0_shift * FF(65536))) +
+                            (new_term.alu_u16_r1_shift * FF(4294967296UL))) +
+                           (new_term.alu_u16_r2_shift * FF(281474976710656UL))) +
+                          ((((new_term.alu_u16_r3_shift + (new_term.alu_u16_r4_shift * FF(65536))) +
+                             (new_term.alu_u16_r5_shift * FF(4294967296UL))) +
+                            (new_term.alu_u16_r6_shift * FF(281474976710656UL))) *
+                           FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) -
+                         new_term.alu_ib));
+            tmp *= scaling_factor;
+            std::get<18>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<19, ContainerOverSubrelations>;
             auto tmp =
-                ((alu_u128_tag * alu_op_mul) *
-                 ((((alu_ia * ((((alu_u8_r0_shift + (alu_u8_r1_shift * FF(256))) + (alu_u16_r0_shift * FF(65536))) +
-                                (alu_u16_r1_shift * FF(4294967296UL))) +
-                               (alu_u16_r2_shift * FF(281474976710656UL)))) +
-                    ((((((alu_u8_r0 + (alu_u8_r1 * FF(256))) + (alu_u16_r0 * FF(65536))) +
-                        (alu_u16_r1 * FF(4294967296UL))) +
-                       (alu_u16_r2 * FF(281474976710656UL))) *
-                      (((alu_u16_r3_shift + (alu_u16_r4_shift * FF(65536))) + (alu_u16_r5_shift * FF(4294967296UL))) +
-                       (alu_u16_r6_shift * FF(281474976710656UL)))) *
+                ((new_term.alu_u128_tag * new_term.alu_op_mul) *
+                 ((((new_term.alu_ia * ((((new_term.alu_u8_r0_shift + (new_term.alu_u8_r1_shift * FF(256))) +
+                                          (new_term.alu_u16_r0_shift * FF(65536))) +
+                                         (new_term.alu_u16_r1_shift * FF(4294967296UL))) +
+                                        (new_term.alu_u16_r2_shift * FF(281474976710656UL)))) +
+                    ((((((new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))) + (new_term.alu_u16_r0 * FF(65536))) +
+                        (new_term.alu_u16_r1 * FF(4294967296UL))) +
+                       (new_term.alu_u16_r2 * FF(281474976710656UL))) *
+                      (((new_term.alu_u16_r3_shift + (new_term.alu_u16_r4_shift * FF(65536))) +
+                        (new_term.alu_u16_r5_shift * FF(4294967296UL))) +
+                       (new_term.alu_u16_r6_shift * FF(281474976710656UL)))) *
                      FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) -
-                   (((alu_cf * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL })) +
-                     (((alu_u16_r7 + (alu_u16_r8 * FF(65536))) + (alu_u16_r9 * FF(4294967296UL))) +
-                      (alu_u16_r10 * FF(281474976710656UL)))) *
+                   (((new_term.alu_cf * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL })) +
+                     (((new_term.alu_u16_r7 + (new_term.alu_u16_r8 * FF(65536))) +
+                       (new_term.alu_u16_r9 * FF(4294967296UL))) +
+                      (new_term.alu_u16_r10 * FF(281474976710656UL)))) *
                     FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) -
-                  alu_ic));
+                  new_term.alu_ic));
             tmp *= scaling_factor;
-            std::get<19>(evals) += tmp;
+            std::get<19>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 20
         {
-            Avm_DECLARE_VIEWS(20);
-            auto tmp = (alu_op_not * alu_ff_tag);
+            using Accumulator = typename std::tuple_element_t<20, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_op_not * new_term.alu_ff_tag);
             tmp *= scaling_factor;
-            std::get<20>(evals) += tmp;
+            std::get<20>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 21
         {
-            Avm_DECLARE_VIEWS(21);
-            auto tmp = (alu_op_not *
-                        ((alu_ia + alu_ic) -
-                         ((((((alu_u8_tag * FF(256)) + (alu_u16_tag * FF(65536))) + (alu_u32_tag * FF(4294967296UL))) +
-                            (alu_u64_tag * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
-                           (alu_u128_tag * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) -
-                          FF(1))));
-            tmp *= scaling_factor;
-            std::get<21>(evals) += tmp;
-        }
-        // Contribution 22
-        {
-            Avm_DECLARE_VIEWS(22);
-            auto tmp = ((alu_sel_cmp + alu_op_eq) * (alu_ic * (-alu_ic + FF(1))));
-            tmp *= scaling_factor;
-            std::get<22>(evals) += tmp;
-        }
-        // Contribution 23
-        {
-            Avm_DECLARE_VIEWS(23);
+            using Accumulator = typename std::tuple_element_t<21, ContainerOverSubrelations>;
             auto tmp =
-                (alu_op_eq *
-                 ((((alu_ia - alu_ib) * ((alu_ic * (-alu_op_eq_diff_inv + FF(1))) + alu_op_eq_diff_inv)) - FF(1)) +
-                  alu_ic));
+                (new_term.alu_op_not * ((new_term.alu_ia + new_term.alu_ic) -
+                                        ((((((new_term.alu_u8_tag * FF(256)) + (new_term.alu_u16_tag * FF(65536))) +
+                                            (new_term.alu_u32_tag * FF(4294967296UL))) +
+                                           (new_term.alu_u64_tag * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
+                                          (new_term.alu_u128_tag * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) -
+                                         FF(1))));
             tmp *= scaling_factor;
-            std::get<23>(evals) += tmp;
+            std::get<21>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 24
         {
-            Avm_DECLARE_VIEWS(24);
-            auto tmp = (((alu_op_lt * alu_ib) + ((alu_op_lte + alu_op_cast) * alu_ia)) -
-                        ((alu_a_lo + (alu_a_hi * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) * (alu_sel_cmp + alu_op_cast)));
+            using Accumulator = typename std::tuple_element_t<22, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_sel_cmp + new_term.alu_op_eq) * (new_term.alu_ic * (-new_term.alu_ic + FF(1))));
             tmp *= scaling_factor;
-            std::get<24>(evals) += tmp;
+            std::get<22>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 25
         {
-            Avm_DECLARE_VIEWS(25);
-            auto tmp = (((alu_op_lt * alu_ia) + (alu_op_lte * alu_ib)) -
-                        ((alu_b_lo + (alu_b_hi * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) * alu_sel_cmp));
+            using Accumulator = typename std::tuple_element_t<23, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_op_eq *
+                        ((((new_term.alu_ia - new_term.alu_ib) *
+                           ((new_term.alu_ic * (-new_term.alu_op_eq_diff_inv + FF(1))) + new_term.alu_op_eq_diff_inv)) -
+                          FF(1)) +
+                         new_term.alu_ic));
             tmp *= scaling_factor;
-            std::get<25>(evals) += tmp;
+            std::get<23>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 26
         {
-            Avm_DECLARE_VIEWS(26);
-            auto tmp = (alu_p_a_borrow * (-alu_p_a_borrow + FF(1)));
+            using Accumulator = typename std::tuple_element_t<24, ContainerOverSubrelations>;
+            auto tmp = (((new_term.alu_op_lt * new_term.alu_ib) +
+                         ((new_term.alu_op_lte + new_term.alu_op_cast) * new_term.alu_ia)) -
+                        ((new_term.alu_a_lo + (new_term.alu_a_hi * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) *
+                         (new_term.alu_sel_cmp + new_term.alu_op_cast)));
             tmp *= scaling_factor;
-            std::get<26>(evals) += tmp;
+            std::get<24>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 27
         {
-            Avm_DECLARE_VIEWS(27);
-            auto tmp = ((alu_p_sub_a_lo -
-                         ((-alu_a_lo + FF(uint256_t{ 4891460686036598784UL, 2896914383306846353UL, 0UL, 0UL })) +
-                          (alu_p_a_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL })))) *
-                        ((alu_sel_cmp + alu_op_cast) + alu_op_div_std));
+            using Accumulator = typename std::tuple_element_t<25, ContainerOverSubrelations>;
+            auto tmp = (((new_term.alu_op_lt * new_term.alu_ia) + (new_term.alu_op_lte * new_term.alu_ib)) -
+                        ((new_term.alu_b_lo + (new_term.alu_b_hi * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) *
+                         new_term.alu_sel_cmp));
             tmp *= scaling_factor;
-            std::get<27>(evals) += tmp;
+            std::get<25>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 28
         {
-            Avm_DECLARE_VIEWS(28);
-            auto tmp = ((alu_p_sub_a_hi -
-                         ((-alu_a_hi + FF(uint256_t{ 13281191951274694749UL, 3486998266802970665UL, 0UL, 0UL })) -
-                          alu_p_a_borrow)) *
-                        ((alu_sel_cmp + alu_op_cast) + alu_op_div_std));
+            using Accumulator = typename std::tuple_element_t<26, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_p_a_borrow * (-new_term.alu_p_a_borrow + FF(1)));
             tmp *= scaling_factor;
-            std::get<28>(evals) += tmp;
+            std::get<26>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 29
         {
-            Avm_DECLARE_VIEWS(29);
-            auto tmp = (alu_p_b_borrow * (-alu_p_b_borrow + FF(1)));
-            tmp *= scaling_factor;
-            std::get<29>(evals) += tmp;
-        }
-        // Contribution 30
-        {
-            Avm_DECLARE_VIEWS(30);
-            auto tmp = ((alu_p_sub_b_lo -
-                         ((-alu_b_lo + FF(uint256_t{ 4891460686036598784UL, 2896914383306846353UL, 0UL, 0UL })) +
-                          (alu_p_b_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL })))) *
-                        alu_sel_cmp);
-            tmp *= scaling_factor;
-            std::get<30>(evals) += tmp;
-        }
-        // Contribution 31
-        {
-            Avm_DECLARE_VIEWS(31);
-            auto tmp = ((alu_p_sub_b_hi -
-                         ((-alu_b_hi + FF(uint256_t{ 13281191951274694749UL, 3486998266802970665UL, 0UL, 0UL })) -
-                          alu_p_b_borrow)) *
-                        alu_sel_cmp);
-            tmp *= scaling_factor;
-            std::get<31>(evals) += tmp;
-        }
-        // Contribution 32
-        {
-            Avm_DECLARE_VIEWS(32);
-            auto tmp = ((alu_res_lo -
-                         (((((alu_a_lo - alu_b_lo) - FF(1)) + (alu_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) *
-                           ((alu_op_lt * alu_ic) + ((-alu_ic + FF(1)) * alu_op_lte))) +
-                          (((alu_b_lo - alu_a_lo) + (alu_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) *
-                           (-((alu_op_lt * alu_ic) + ((-alu_ic + FF(1)) * alu_op_lte)) + FF(1))))) *
-                        alu_sel_cmp);
-            tmp *= scaling_factor;
-            std::get<32>(evals) += tmp;
-        }
-        // Contribution 33
-        {
-            Avm_DECLARE_VIEWS(33);
+            using Accumulator = typename std::tuple_element_t<27, ContainerOverSubrelations>;
             auto tmp =
-                ((alu_res_hi -
-                  ((((alu_a_hi - alu_b_hi) - alu_borrow) * ((alu_op_lt * alu_ic) + ((-alu_ic + FF(1)) * alu_op_lte))) +
-                   (((alu_b_hi - alu_a_hi) - alu_borrow) *
-                    (-((alu_op_lt * alu_ic) + ((-alu_ic + FF(1)) * alu_op_lte)) + FF(1))))) *
-                 alu_sel_cmp);
+                ((new_term.alu_p_sub_a_lo -
+                  ((-new_term.alu_a_lo + FF(uint256_t{ 4891460686036598784UL, 2896914383306846353UL, 0UL, 0UL })) +
+                   (new_term.alu_p_a_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL })))) *
+                 ((new_term.alu_sel_cmp + new_term.alu_op_cast) + new_term.alu_op_div_std));
             tmp *= scaling_factor;
-            std::get<33>(evals) += tmp;
+            std::get<27>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 34
         {
-            Avm_DECLARE_VIEWS(34);
-            auto tmp = (((alu_cmp_rng_ctr_shift - alu_cmp_rng_ctr) + FF(1)) * alu_cmp_rng_ctr);
-            tmp *= scaling_factor;
-            std::get<34>(evals) += tmp;
-        }
-        // Contribution 35
-        {
-            Avm_DECLARE_VIEWS(35);
-            auto tmp = ((alu_cmp_rng_ctr_shift - FF(4)) * alu_sel_cmp);
-            tmp *= scaling_factor;
-            std::get<35>(evals) += tmp;
-        }
-        // Contribution 36
-        {
-            Avm_DECLARE_VIEWS(36);
-            auto tmp = (alu_sel_rng_chk * (-alu_sel_rng_chk + FF(1)));
-            tmp *= scaling_factor;
-            std::get<36>(evals) += tmp;
-        }
-        // Contribution 37
-        {
-            Avm_DECLARE_VIEWS(37);
-            auto tmp = (alu_sel_rng_chk * alu_sel_cmp);
-            tmp *= scaling_factor;
-            std::get<37>(evals) += tmp;
-        }
-        // Contribution 38
-        {
-            Avm_DECLARE_VIEWS(38);
-            auto tmp = ((alu_cmp_rng_ctr *
-                         (((-alu_sel_rng_chk + FF(1)) * (-alu_op_eq_diff_inv + FF(1))) + alu_op_eq_diff_inv)) -
-                        alu_sel_rng_chk);
-            tmp *= scaling_factor;
-            std::get<38>(evals) += tmp;
-        }
-        // Contribution 39
-        {
-            Avm_DECLARE_VIEWS(39);
-            auto tmp = (alu_sel_rng_chk_lookup_shift -
-                        ((((((((((alu_sel_cmp_shift + alu_sel_rng_chk_shift) + alu_op_add_shift) + alu_op_sub_shift) +
-                               alu_op_mul_shift) +
-                              (alu_op_mul * alu_u128_tag)) +
-                             alu_op_cast_shift) +
-                            alu_op_cast_prev_shift) +
-                           alu_op_shl_shift) +
-                          alu_op_shr_shift) +
-                         alu_op_div_shift));
-            tmp *= scaling_factor;
-            std::get<39>(evals) += tmp;
-        }
-        // Contribution 40
-        {
-            Avm_DECLARE_VIEWS(40);
+            using Accumulator = typename std::tuple_element_t<28, ContainerOverSubrelations>;
             auto tmp =
-                (alu_a_lo -
-                 (((((((((alu_u8_r0 + (alu_u8_r1 * FF(256))) + (alu_u16_r0 * FF(65536))) +
-                        (alu_u16_r1 * FF(4294967296UL))) +
-                       (alu_u16_r2 * FF(281474976710656UL))) +
-                      (alu_u16_r3 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
-                     (alu_u16_r4 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
-                    (alu_u16_r5 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
-                   (alu_u16_r6 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))) *
-                  (((((alu_sel_rng_chk + alu_sel_cmp) + alu_op_cast) + alu_op_cast_prev) + alu_shift_lt_bit_len) +
-                   alu_op_div)));
+                ((new_term.alu_p_sub_a_hi -
+                  ((-new_term.alu_a_hi + FF(uint256_t{ 13281191951274694749UL, 3486998266802970665UL, 0UL, 0UL })) -
+                   new_term.alu_p_a_borrow)) *
+                 ((new_term.alu_sel_cmp + new_term.alu_op_cast) + new_term.alu_op_div_std));
             tmp *= scaling_factor;
-            std::get<40>(evals) += tmp;
+            std::get<28>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 41
         {
-            Avm_DECLARE_VIEWS(41);
+            using Accumulator = typename std::tuple_element_t<29, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_p_b_borrow * (-new_term.alu_p_b_borrow + FF(1)));
+            tmp *= scaling_factor;
+            std::get<29>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<30, ContainerOverSubrelations>;
             auto tmp =
-                (alu_a_hi -
-                 ((((((((alu_u16_r7 + (alu_u16_r8 * FF(65536))) + (alu_u16_r9 * FF(4294967296UL))) +
-                       (alu_u16_r10 * FF(281474976710656UL))) +
-                      (alu_u16_r11 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
-                     (alu_u16_r12 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
-                    (alu_u16_r13 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
-                   (alu_u16_r14 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))) *
-                  (((((alu_sel_rng_chk + alu_sel_cmp) + alu_op_cast) + alu_op_cast_prev) + alu_shift_lt_bit_len) +
-                   alu_op_div)));
+                ((new_term.alu_p_sub_b_lo -
+                  ((-new_term.alu_b_lo + FF(uint256_t{ 4891460686036598784UL, 2896914383306846353UL, 0UL, 0UL })) +
+                   (new_term.alu_p_b_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL })))) *
+                 new_term.alu_sel_cmp);
             tmp *= scaling_factor;
-            std::get<41>(evals) += tmp;
+            std::get<30>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 42
         {
-            Avm_DECLARE_VIEWS(42);
-            auto tmp = ((alu_a_lo_shift - alu_b_lo) * alu_sel_rng_chk_shift);
-            tmp *= scaling_factor;
-            std::get<42>(evals) += tmp;
-        }
-        // Contribution 43
-        {
-            Avm_DECLARE_VIEWS(43);
-            auto tmp = ((alu_a_hi_shift - alu_b_hi) * alu_sel_rng_chk_shift);
-            tmp *= scaling_factor;
-            std::get<43>(evals) += tmp;
-        }
-        // Contribution 44
-        {
-            Avm_DECLARE_VIEWS(44);
-            auto tmp = ((alu_b_lo_shift - alu_p_sub_a_lo) * alu_sel_rng_chk_shift);
-            tmp *= scaling_factor;
-            std::get<44>(evals) += tmp;
-        }
-        // Contribution 45
-        {
-            Avm_DECLARE_VIEWS(45);
-            auto tmp = ((alu_b_hi_shift - alu_p_sub_a_hi) * alu_sel_rng_chk_shift);
-            tmp *= scaling_factor;
-            std::get<45>(evals) += tmp;
-        }
-        // Contribution 46
-        {
-            Avm_DECLARE_VIEWS(46);
-            auto tmp = ((alu_p_sub_a_lo_shift - alu_p_sub_b_lo) * alu_sel_rng_chk_shift);
-            tmp *= scaling_factor;
-            std::get<46>(evals) += tmp;
-        }
-        // Contribution 47
-        {
-            Avm_DECLARE_VIEWS(47);
-            auto tmp = ((alu_p_sub_a_hi_shift - alu_p_sub_b_hi) * alu_sel_rng_chk_shift);
-            tmp *= scaling_factor;
-            std::get<47>(evals) += tmp;
-        }
-        // Contribution 48
-        {
-            Avm_DECLARE_VIEWS(48);
-            auto tmp = ((alu_p_sub_b_lo_shift - alu_res_lo) * alu_sel_rng_chk_shift);
-            tmp *= scaling_factor;
-            std::get<48>(evals) += tmp;
-        }
-        // Contribution 49
-        {
-            Avm_DECLARE_VIEWS(49);
-            auto tmp = ((alu_p_sub_b_hi_shift - alu_res_hi) * alu_sel_rng_chk_shift);
-            tmp *= scaling_factor;
-            std::get<49>(evals) += tmp;
-        }
-        // Contribution 50
-        {
-            Avm_DECLARE_VIEWS(50);
-            auto tmp = (alu_op_cast_prev_shift - alu_op_cast);
-            tmp *= scaling_factor;
-            std::get<50>(evals) += tmp;
-        }
-        // Contribution 51
-        {
-            Avm_DECLARE_VIEWS(51);
-            auto tmp = (alu_op_cast *
-                        (((((((alu_u8_tag * alu_u8_r0) + (alu_u16_tag * (alu_u8_r0 + (alu_u8_r1 * FF(256))))) +
-                             (alu_u32_tag * ((alu_u8_r0 + (alu_u8_r1 * FF(256))) + (alu_u16_r0 * FF(65536))))) +
-                            (alu_u64_tag * ((((alu_u8_r0 + (alu_u8_r1 * FF(256))) + (alu_u16_r0 * FF(65536))) +
-                                             (alu_u16_r1 * FF(4294967296UL))) +
-                                            (alu_u16_r2 * FF(281474976710656UL))))) +
-                           (alu_u128_tag * ((((((((alu_u8_r0 + (alu_u8_r1 * FF(256))) + (alu_u16_r0 * FF(65536))) +
-                                                 (alu_u16_r1 * FF(4294967296UL))) +
-                                                (alu_u16_r2 * FF(281474976710656UL))) +
-                                               (alu_u16_r3 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
-                                              (alu_u16_r4 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
-                                             (alu_u16_r5 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
-                                            (alu_u16_r6 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))))) +
-                          (alu_ff_tag * alu_ia)) -
-                         alu_ic));
-            tmp *= scaling_factor;
-            std::get<51>(evals) += tmp;
-        }
-        // Contribution 52
-        {
-            Avm_DECLARE_VIEWS(52);
-            auto tmp = (alu_op_cast * (alu_a_lo_shift - alu_p_sub_a_lo));
-            tmp *= scaling_factor;
-            std::get<52>(evals) += tmp;
-        }
-        // Contribution 53
-        {
-            Avm_DECLARE_VIEWS(53);
-            auto tmp = (alu_op_cast * (alu_a_hi_shift - alu_p_sub_a_hi));
-            tmp *= scaling_factor;
-            std::get<53>(evals) += tmp;
-        }
-        // Contribution 54
-        {
-            Avm_DECLARE_VIEWS(54);
-            auto tmp = (((alu_op_mul * alu_u128_tag) + alu_op_cast) * alu_sel_alu_shift);
-            tmp *= scaling_factor;
-            std::get<54>(evals) += tmp;
-        }
-        // Contribution 55
-        {
-            Avm_DECLARE_VIEWS(55);
-            auto tmp = ((alu_shift_lt_bit_len * alu_op_shr) * (alu_a_lo - ((alu_two_pow_s - alu_b_lo) - FF(1))));
-            tmp *= scaling_factor;
-            std::get<55>(evals) += tmp;
-        }
-        // Contribution 56
-        {
-            Avm_DECLARE_VIEWS(56);
-            auto tmp = ((alu_shift_lt_bit_len * alu_op_shr) * (alu_a_hi - ((alu_two_pow_t_sub_s - alu_b_hi) - FF(1))));
-            tmp *= scaling_factor;
-            std::get<56>(evals) += tmp;
-        }
-        // Contribution 57
-        {
-            Avm_DECLARE_VIEWS(57);
-            auto tmp = ((alu_shift_lt_bit_len * alu_op_shl) * (alu_a_lo - ((alu_two_pow_t_sub_s - alu_b_lo) - FF(1))));
-            tmp *= scaling_factor;
-            std::get<57>(evals) += tmp;
-        }
-        // Contribution 58
-        {
-            Avm_DECLARE_VIEWS(58);
-            auto tmp = ((alu_shift_lt_bit_len * alu_op_shl) * (alu_a_hi - ((alu_two_pow_s - alu_b_hi) - FF(1))));
-            tmp *= scaling_factor;
-            std::get<58>(evals) += tmp;
-        }
-        // Contribution 59
-        {
-            Avm_DECLARE_VIEWS(59);
-            auto tmp = (alu_shift_lt_bit_len * (-alu_shift_lt_bit_len + FF(1)));
-            tmp *= scaling_factor;
-            std::get<59>(evals) += tmp;
-        }
-        // Contribution 60
-        {
-            Avm_DECLARE_VIEWS(60);
-            auto tmp = (alu_t_sub_s_bits -
-                        (alu_sel_shift_which *
-                         ((alu_shift_lt_bit_len *
-                           ((((((alu_u8_tag * FF(8)) + (alu_u16_tag * FF(16))) + (alu_u32_tag * FF(32))) +
-                              (alu_u64_tag * FF(64))) +
-                             (alu_u128_tag * FF(128))) -
-                            alu_ib)) +
-                          ((-alu_shift_lt_bit_len + FF(1)) *
-                           (alu_ib - (((((alu_u8_tag * FF(8)) + (alu_u16_tag * FF(16))) + (alu_u32_tag * FF(32))) +
-                                       (alu_u64_tag * FF(64))) +
-                                      (alu_u128_tag * FF(128))))))));
-            tmp *= scaling_factor;
-            std::get<60>(evals) += tmp;
-        }
-        // Contribution 61
-        {
-            Avm_DECLARE_VIEWS(61);
-            auto tmp = ((alu_shift_lt_bit_len * alu_op_shr) * (((alu_b_hi * alu_two_pow_s) + alu_b_lo) - alu_ia));
-            tmp *= scaling_factor;
-            std::get<61>(evals) += tmp;
-        }
-        // Contribution 62
-        {
-            Avm_DECLARE_VIEWS(62);
-            auto tmp = (alu_op_shr * (alu_ic - (alu_b_hi * alu_shift_lt_bit_len)));
-            tmp *= scaling_factor;
-            std::get<62>(evals) += tmp;
-        }
-        // Contribution 63
-        {
-            Avm_DECLARE_VIEWS(63);
-            auto tmp = ((alu_shift_lt_bit_len * alu_op_shl) * (((alu_b_hi * alu_two_pow_t_sub_s) + alu_b_lo) - alu_ia));
-            tmp *= scaling_factor;
-            std::get<63>(evals) += tmp;
-        }
-        // Contribution 64
-        {
-            Avm_DECLARE_VIEWS(64);
-            auto tmp = (alu_op_shl * (alu_ic - ((alu_b_lo * alu_two_pow_s) * alu_shift_lt_bit_len)));
-            tmp *= scaling_factor;
-            std::get<64>(evals) += tmp;
-        }
-        // Contribution 65
-        {
-            Avm_DECLARE_VIEWS(65);
-            auto tmp = (alu_op_div - (alu_op_div_std + alu_op_div_a_lt_b));
-            tmp *= scaling_factor;
-            std::get<65>(evals) += tmp;
-        }
-        // Contribution 66
-        {
-            Avm_DECLARE_VIEWS(66);
-            auto tmp = (alu_op_div_a_lt_b * (-alu_op_div_a_lt_b + FF(1)));
-            tmp *= scaling_factor;
-            std::get<66>(evals) += tmp;
-        }
-        // Contribution 67
-        {
-            Avm_DECLARE_VIEWS(67);
-            auto tmp = (alu_op_div_a_lt_b * (alu_a_lo - ((alu_ib - alu_ia) - FF(1))));
-            tmp *= scaling_factor;
-            std::get<67>(evals) += tmp;
-        }
-        // Contribution 68
-        {
-            Avm_DECLARE_VIEWS(68);
-            auto tmp = (alu_op_div_a_lt_b * alu_ic);
-            tmp *= scaling_factor;
-            std::get<68>(evals) += tmp;
-        }
-        // Contribution 69
-        {
-            Avm_DECLARE_VIEWS(69);
-            auto tmp = (alu_op_div_a_lt_b * (alu_ia - alu_remainder));
-            tmp *= scaling_factor;
-            std::get<69>(evals) += tmp;
-        }
-        // Contribution 70
-        {
-            Avm_DECLARE_VIEWS(70);
-            auto tmp = (alu_op_div_std * (-alu_op_div_std + FF(1)));
-            tmp *= scaling_factor;
-            std::get<70>(evals) += tmp;
-        }
-        // Contribution 71
-        {
-            Avm_DECLARE_VIEWS(71);
+            using Accumulator = typename std::tuple_element_t<31, ContainerOverSubrelations>;
             auto tmp =
-                (alu_op_div_std * ((alu_ib - alu_divisor_lo) - (alu_divisor_hi * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))));
+                ((new_term.alu_p_sub_b_hi -
+                  ((-new_term.alu_b_hi + FF(uint256_t{ 13281191951274694749UL, 3486998266802970665UL, 0UL, 0UL })) -
+                   new_term.alu_p_b_borrow)) *
+                 new_term.alu_sel_cmp);
             tmp *= scaling_factor;
-            std::get<71>(evals) += tmp;
+            std::get<31>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 72
         {
-            Avm_DECLARE_VIEWS(72);
-            auto tmp = (alu_op_div_std *
-                        ((alu_ic - alu_quotient_lo) - (alu_quotient_hi * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))));
-            tmp *= scaling_factor;
-            std::get<72>(evals) += tmp;
-        }
-        // Contribution 73
-        {
-            Avm_DECLARE_VIEWS(73);
-            auto tmp = (((alu_divisor_hi * alu_quotient_lo) + (alu_divisor_lo * alu_quotient_hi)) -
-                        (alu_partial_prod_lo + (alu_partial_prod_hi * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))));
-            tmp *= scaling_factor;
-            std::get<73>(evals) += tmp;
-        }
-        // Contribution 74
-        {
-            Avm_DECLARE_VIEWS(74);
+            using Accumulator = typename std::tuple_element_t<32, ContainerOverSubrelations>;
             auto tmp =
-                (alu_op_div_std *
-                 ((((alu_divisor_lo * alu_quotient_lo) + (alu_partial_prod_lo * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
-                   ((alu_partial_prod_hi + (alu_divisor_hi * alu_quotient_hi)) * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) -
-                  (alu_a_lo + (alu_a_hi * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL })))));
+                ((new_term.alu_res_lo -
+                  (((((new_term.alu_a_lo - new_term.alu_b_lo) - FF(1)) +
+                     (new_term.alu_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) *
+                    ((new_term.alu_op_lt * new_term.alu_ic) + ((-new_term.alu_ic + FF(1)) * new_term.alu_op_lte))) +
+                   (((new_term.alu_b_lo - new_term.alu_a_lo) +
+                     (new_term.alu_borrow * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) *
+                    (-((new_term.alu_op_lt * new_term.alu_ic) + ((-new_term.alu_ic + FF(1)) * new_term.alu_op_lte)) +
+                     FF(1))))) *
+                 new_term.alu_sel_cmp);
             tmp *= scaling_factor;
-            std::get<74>(evals) += tmp;
+            std::get<32>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 75
         {
-            Avm_DECLARE_VIEWS(75);
-            auto tmp = (alu_op_div_std * (alu_b_hi - ((alu_ib - alu_remainder) - FF(1))));
-            tmp *= scaling_factor;
-            std::get<75>(evals) += tmp;
-        }
-        // Contribution 76
-        {
-            Avm_DECLARE_VIEWS(76);
-            auto tmp = ((alu_cmp_rng_ctr_shift - FF(2)) * alu_op_div_std);
-            tmp *= scaling_factor;
-            std::get<76>(evals) += tmp;
-        }
-        // Contribution 77
-        {
-            Avm_DECLARE_VIEWS(77);
-            auto tmp = (alu_sel_rng_chk * alu_op_div_std);
-            tmp *= scaling_factor;
-            std::get<77>(evals) += tmp;
-        }
-        // Contribution 78
-        {
-            Avm_DECLARE_VIEWS(78);
+            using Accumulator = typename std::tuple_element_t<33, ContainerOverSubrelations>;
             auto tmp =
-                (alu_op_div_std *
-                 ((((alu_divisor_lo * alu_quotient_lo) + (alu_partial_prod_lo * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
-                   ((alu_partial_prod_hi + (alu_divisor_hi * alu_quotient_hi)) * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) -
-                  (alu_ia - alu_remainder)));
+                ((new_term.alu_res_hi -
+                  ((((new_term.alu_a_hi - new_term.alu_b_hi) - new_term.alu_borrow) *
+                    ((new_term.alu_op_lt * new_term.alu_ic) + ((-new_term.alu_ic + FF(1)) * new_term.alu_op_lte))) +
+                   (((new_term.alu_b_hi - new_term.alu_a_hi) - new_term.alu_borrow) *
+                    (-((new_term.alu_op_lt * new_term.alu_ic) + ((-new_term.alu_ic + FF(1)) * new_term.alu_op_lte)) +
+                     FF(1))))) *
+                 new_term.alu_sel_cmp);
             tmp *= scaling_factor;
-            std::get<78>(evals) += tmp;
+            std::get<33>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 79
         {
-            Avm_DECLARE_VIEWS(79);
-            auto tmp = (alu_sel_div_rng_chk * (-alu_sel_div_rng_chk + FF(1)));
-            tmp *= scaling_factor;
-            std::get<79>(evals) += tmp;
-        }
-        // Contribution 80
-        {
-            Avm_DECLARE_VIEWS(80);
-            auto tmp = ((alu_sel_div_rng_chk * alu_sel_div_rng_chk_shift) - alu_op_div_std);
-            tmp *= scaling_factor;
-            std::get<80>(evals) += tmp;
-        }
-        // Contribution 81
-        {
-            Avm_DECLARE_VIEWS(81);
-            auto tmp = (alu_divisor_lo - (alu_op_div_std * (((alu_div_u16_r0 + (alu_div_u16_r1 * FF(65536))) +
-                                                             (alu_div_u16_r2 * FF(4294967296UL))) +
-                                                            (alu_div_u16_r3 * FF(281474976710656UL)))));
-            tmp *= scaling_factor;
-            std::get<81>(evals) += tmp;
-        }
-        // Contribution 82
-        {
-            Avm_DECLARE_VIEWS(82);
-            auto tmp = (alu_divisor_hi - (alu_op_div_std * (((alu_div_u16_r4 + (alu_div_u16_r5 * FF(65536))) +
-                                                             (alu_div_u16_r6 * FF(4294967296UL))) +
-                                                            (alu_div_u16_r7 * FF(281474976710656UL)))));
-            tmp *= scaling_factor;
-            std::get<82>(evals) += tmp;
-        }
-        // Contribution 83
-        {
-            Avm_DECLARE_VIEWS(83);
+            using Accumulator = typename std::tuple_element_t<34, ContainerOverSubrelations>;
             auto tmp =
-                (alu_quotient_lo - (alu_op_div_std * (((alu_div_u16_r0_shift + (alu_div_u16_r1_shift * FF(65536))) +
-                                                       (alu_div_u16_r2_shift * FF(4294967296UL))) +
-                                                      (alu_div_u16_r3_shift * FF(281474976710656UL)))));
+                (((new_term.alu_cmp_rng_ctr_shift - new_term.alu_cmp_rng_ctr) + FF(1)) * new_term.alu_cmp_rng_ctr);
             tmp *= scaling_factor;
-            std::get<83>(evals) += tmp;
+            std::get<34>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 84
         {
-            Avm_DECLARE_VIEWS(84);
+            using Accumulator = typename std::tuple_element_t<35, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_cmp_rng_ctr_shift - FF(4)) * new_term.alu_sel_cmp);
+            tmp *= scaling_factor;
+            std::get<35>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<36, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_sel_rng_chk * (-new_term.alu_sel_rng_chk + FF(1)));
+            tmp *= scaling_factor;
+            std::get<36>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<37, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_sel_rng_chk * new_term.alu_sel_cmp);
+            tmp *= scaling_factor;
+            std::get<37>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<38, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_cmp_rng_ctr *
+                         (((-new_term.alu_sel_rng_chk + FF(1)) * (-new_term.alu_op_eq_diff_inv + FF(1))) +
+                          new_term.alu_op_eq_diff_inv)) -
+                        new_term.alu_sel_rng_chk);
+            tmp *= scaling_factor;
+            std::get<38>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<39, ContainerOverSubrelations>;
             auto tmp =
-                (alu_quotient_hi - (alu_op_div_std * (((alu_div_u16_r4_shift + (alu_div_u16_r5_shift * FF(65536))) +
-                                                       (alu_div_u16_r6_shift * FF(4294967296UL))) +
-                                                      (alu_div_u16_r7_shift * FF(281474976710656UL)))));
+                (new_term.alu_sel_rng_chk_lookup_shift -
+                 ((((((((((new_term.alu_sel_cmp_shift + new_term.alu_sel_rng_chk_shift) + new_term.alu_op_add_shift) +
+                         new_term.alu_op_sub_shift) +
+                        new_term.alu_op_mul_shift) +
+                       (new_term.alu_op_mul * new_term.alu_u128_tag)) +
+                      new_term.alu_op_cast_shift) +
+                     new_term.alu_op_cast_prev_shift) +
+                    new_term.alu_op_shl_shift) +
+                   new_term.alu_op_shr_shift) +
+                  new_term.alu_op_div_shift));
             tmp *= scaling_factor;
-            std::get<84>(evals) += tmp;
+            std::get<39>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 85
         {
-            Avm_DECLARE_VIEWS(85);
-            auto tmp = (alu_partial_prod_lo - (alu_op_div_std * ((((alu_u8_r0_shift + (alu_u8_r1_shift * FF(256))) +
-                                                                   (alu_u16_r0_shift * FF(65536))) +
-                                                                  (alu_u16_r1_shift * FF(4294967296UL))) +
-                                                                 (alu_u16_r2_shift * FF(281474976710656UL)))));
+            using Accumulator = typename std::tuple_element_t<40, ContainerOverSubrelations>;
+            auto tmp =
+                (new_term.alu_a_lo -
+                 (((((((((new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))) + (new_term.alu_u16_r0 * FF(65536))) +
+                        (new_term.alu_u16_r1 * FF(4294967296UL))) +
+                       (new_term.alu_u16_r2 * FF(281474976710656UL))) +
+                      (new_term.alu_u16_r3 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
+                     (new_term.alu_u16_r4 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
+                    (new_term.alu_u16_r5 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
+                   (new_term.alu_u16_r6 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))) *
+                  (((((new_term.alu_sel_rng_chk + new_term.alu_sel_cmp) + new_term.alu_op_cast) +
+                     new_term.alu_op_cast_prev) +
+                    new_term.alu_shift_lt_bit_len) +
+                   new_term.alu_op_div)));
             tmp *= scaling_factor;
-            std::get<85>(evals) += tmp;
+            std::get<40>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 86
         {
-            Avm_DECLARE_VIEWS(86);
-            auto tmp = (alu_partial_prod_hi - (alu_op_div_std * (((alu_u16_r3_shift + (alu_u16_r4_shift * FF(65536))) +
-                                                                  (alu_u16_r5_shift * FF(4294967296UL))) +
-                                                                 (alu_u16_r6_shift * FF(281474976710656UL)))));
+            using Accumulator = typename std::tuple_element_t<41, ContainerOverSubrelations>;
+            auto tmp =
+                (new_term.alu_a_hi - ((((((((new_term.alu_u16_r7 + (new_term.alu_u16_r8 * FF(65536))) +
+                                            (new_term.alu_u16_r9 * FF(4294967296UL))) +
+                                           (new_term.alu_u16_r10 * FF(281474976710656UL))) +
+                                          (new_term.alu_u16_r11 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
+                                         (new_term.alu_u16_r12 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
+                                        (new_term.alu_u16_r13 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
+                                       (new_term.alu_u16_r14 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))) *
+                                      (((((new_term.alu_sel_rng_chk + new_term.alu_sel_cmp) + new_term.alu_op_cast) +
+                                         new_term.alu_op_cast_prev) +
+                                        new_term.alu_shift_lt_bit_len) +
+                                       new_term.alu_op_div)));
             tmp *= scaling_factor;
-            std::get<86>(evals) += tmp;
+            std::get<41>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<42, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_a_lo_shift - new_term.alu_b_lo) * new_term.alu_sel_rng_chk_shift);
+            tmp *= scaling_factor;
+            std::get<42>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<43, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_a_hi_shift - new_term.alu_b_hi) * new_term.alu_sel_rng_chk_shift);
+            tmp *= scaling_factor;
+            std::get<43>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<44, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_b_lo_shift - new_term.alu_p_sub_a_lo) * new_term.alu_sel_rng_chk_shift);
+            tmp *= scaling_factor;
+            std::get<44>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<45, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_b_hi_shift - new_term.alu_p_sub_a_hi) * new_term.alu_sel_rng_chk_shift);
+            tmp *= scaling_factor;
+            std::get<45>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<46, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_p_sub_a_lo_shift - new_term.alu_p_sub_b_lo) * new_term.alu_sel_rng_chk_shift);
+            tmp *= scaling_factor;
+            std::get<46>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<47, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_p_sub_a_hi_shift - new_term.alu_p_sub_b_hi) * new_term.alu_sel_rng_chk_shift);
+            tmp *= scaling_factor;
+            std::get<47>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<48, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_p_sub_b_lo_shift - new_term.alu_res_lo) * new_term.alu_sel_rng_chk_shift);
+            tmp *= scaling_factor;
+            std::get<48>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<49, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_p_sub_b_hi_shift - new_term.alu_res_hi) * new_term.alu_sel_rng_chk_shift);
+            tmp *= scaling_factor;
+            std::get<49>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<50, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_op_cast_prev_shift - new_term.alu_op_cast);
+            tmp *= scaling_factor;
+            std::get<50>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<51, ContainerOverSubrelations>;
+            auto tmp =
+                (new_term.alu_op_cast *
+                 (((((((new_term.alu_u8_tag * new_term.alu_u8_r0) +
+                       (new_term.alu_u16_tag * (new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))))) +
+                      (new_term.alu_u32_tag *
+                       ((new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))) + (new_term.alu_u16_r0 * FF(65536))))) +
+                     (new_term.alu_u64_tag *
+                      ((((new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))) + (new_term.alu_u16_r0 * FF(65536))) +
+                        (new_term.alu_u16_r1 * FF(4294967296UL))) +
+                       (new_term.alu_u16_r2 * FF(281474976710656UL))))) +
+                    (new_term.alu_u128_tag *
+                     ((((((((new_term.alu_u8_r0 + (new_term.alu_u8_r1 * FF(256))) + (new_term.alu_u16_r0 * FF(65536))) +
+                           (new_term.alu_u16_r1 * FF(4294967296UL))) +
+                          (new_term.alu_u16_r2 * FF(281474976710656UL))) +
+                         (new_term.alu_u16_r3 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
+                        (new_term.alu_u16_r4 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }))) +
+                       (new_term.alu_u16_r5 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }))) +
+                      (new_term.alu_u16_r6 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }))))) +
+                   (new_term.alu_ff_tag * new_term.alu_ia)) -
+                  new_term.alu_ic));
+            tmp *= scaling_factor;
+            std::get<51>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<52, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_op_cast * (new_term.alu_a_lo_shift - new_term.alu_p_sub_a_lo));
+            tmp *= scaling_factor;
+            std::get<52>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<53, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_op_cast * (new_term.alu_a_hi_shift - new_term.alu_p_sub_a_hi));
+            tmp *= scaling_factor;
+            std::get<53>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<54, ContainerOverSubrelations>;
+            auto tmp =
+                (((new_term.alu_op_mul * new_term.alu_u128_tag) + new_term.alu_op_cast) * new_term.alu_sel_alu_shift);
+            tmp *= scaling_factor;
+            std::get<54>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<55, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_shift_lt_bit_len * new_term.alu_op_shr) *
+                        (new_term.alu_a_lo - ((new_term.alu_two_pow_s - new_term.alu_b_lo) - FF(1))));
+            tmp *= scaling_factor;
+            std::get<55>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<56, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_shift_lt_bit_len * new_term.alu_op_shr) *
+                        (new_term.alu_a_hi - ((new_term.alu_two_pow_t_sub_s - new_term.alu_b_hi) - FF(1))));
+            tmp *= scaling_factor;
+            std::get<56>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<57, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_shift_lt_bit_len * new_term.alu_op_shl) *
+                        (new_term.alu_a_lo - ((new_term.alu_two_pow_t_sub_s - new_term.alu_b_lo) - FF(1))));
+            tmp *= scaling_factor;
+            std::get<57>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<58, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_shift_lt_bit_len * new_term.alu_op_shl) *
+                        (new_term.alu_a_hi - ((new_term.alu_two_pow_s - new_term.alu_b_hi) - FF(1))));
+            tmp *= scaling_factor;
+            std::get<58>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<59, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_shift_lt_bit_len * (-new_term.alu_shift_lt_bit_len + FF(1)));
+            tmp *= scaling_factor;
+            std::get<59>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<60, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_t_sub_s_bits -
+                        (new_term.alu_sel_shift_which *
+                         ((new_term.alu_shift_lt_bit_len *
+                           ((((((new_term.alu_u8_tag * FF(8)) + (new_term.alu_u16_tag * FF(16))) +
+                               (new_term.alu_u32_tag * FF(32))) +
+                              (new_term.alu_u64_tag * FF(64))) +
+                             (new_term.alu_u128_tag * FF(128))) -
+                            new_term.alu_ib)) +
+                          ((-new_term.alu_shift_lt_bit_len + FF(1)) *
+                           (new_term.alu_ib - (((((new_term.alu_u8_tag * FF(8)) + (new_term.alu_u16_tag * FF(16))) +
+                                                 (new_term.alu_u32_tag * FF(32))) +
+                                                (new_term.alu_u64_tag * FF(64))) +
+                                               (new_term.alu_u128_tag * FF(128))))))));
+            tmp *= scaling_factor;
+            std::get<60>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<61, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_shift_lt_bit_len * new_term.alu_op_shr) *
+                        (((new_term.alu_b_hi * new_term.alu_two_pow_s) + new_term.alu_b_lo) - new_term.alu_ia));
+            tmp *= scaling_factor;
+            std::get<61>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<62, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_op_shr * (new_term.alu_ic - (new_term.alu_b_hi * new_term.alu_shift_lt_bit_len)));
+            tmp *= scaling_factor;
+            std::get<62>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<63, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_shift_lt_bit_len * new_term.alu_op_shl) *
+                        (((new_term.alu_b_hi * new_term.alu_two_pow_t_sub_s) + new_term.alu_b_lo) - new_term.alu_ia));
+            tmp *= scaling_factor;
+            std::get<63>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<64, ContainerOverSubrelations>;
+            auto tmp =
+                (new_term.alu_op_shl *
+                 (new_term.alu_ic - ((new_term.alu_b_lo * new_term.alu_two_pow_s) * new_term.alu_shift_lt_bit_len)));
+            tmp *= scaling_factor;
+            std::get<64>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<65, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_op_div - (new_term.alu_op_div_std + new_term.alu_op_div_a_lt_b));
+            tmp *= scaling_factor;
+            std::get<65>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<66, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_op_div_a_lt_b * (-new_term.alu_op_div_a_lt_b + FF(1)));
+            tmp *= scaling_factor;
+            std::get<66>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<67, ContainerOverSubrelations>;
+            auto tmp =
+                (new_term.alu_op_div_a_lt_b * (new_term.alu_a_lo - ((new_term.alu_ib - new_term.alu_ia) - FF(1))));
+            tmp *= scaling_factor;
+            std::get<67>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<68, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_op_div_a_lt_b * new_term.alu_ic);
+            tmp *= scaling_factor;
+            std::get<68>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<69, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_op_div_a_lt_b * (new_term.alu_ia - new_term.alu_remainder));
+            tmp *= scaling_factor;
+            std::get<69>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<70, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_op_div_std * (-new_term.alu_op_div_std + FF(1)));
+            tmp *= scaling_factor;
+            std::get<70>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<71, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_op_div_std * ((new_term.alu_ib - new_term.alu_divisor_lo) -
+                                                   (new_term.alu_divisor_hi * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))));
+            tmp *= scaling_factor;
+            std::get<71>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<72, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_op_div_std * ((new_term.alu_ic - new_term.alu_quotient_lo) -
+                                                   (new_term.alu_quotient_hi * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))));
+            tmp *= scaling_factor;
+            std::get<72>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<73, ContainerOverSubrelations>;
+            auto tmp =
+                (((new_term.alu_divisor_hi * new_term.alu_quotient_lo) +
+                  (new_term.alu_divisor_lo * new_term.alu_quotient_hi)) -
+                 (new_term.alu_partial_prod_lo + (new_term.alu_partial_prod_hi * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))));
+            tmp *= scaling_factor;
+            std::get<73>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<74, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_op_div_std *
+                        ((((new_term.alu_divisor_lo * new_term.alu_quotient_lo) +
+                           (new_term.alu_partial_prod_lo * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
+                          ((new_term.alu_partial_prod_hi + (new_term.alu_divisor_hi * new_term.alu_quotient_hi)) *
+                           FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) -
+                         (new_term.alu_a_lo + (new_term.alu_a_hi * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL })))));
+            tmp *= scaling_factor;
+            std::get<74>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<75, ContainerOverSubrelations>;
+            auto tmp =
+                (new_term.alu_op_div_std * (new_term.alu_b_hi - ((new_term.alu_ib - new_term.alu_remainder) - FF(1))));
+            tmp *= scaling_factor;
+            std::get<75>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<76, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_cmp_rng_ctr_shift - FF(2)) * new_term.alu_op_div_std);
+            tmp *= scaling_factor;
+            std::get<76>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<77, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_sel_rng_chk * new_term.alu_op_div_std);
+            tmp *= scaling_factor;
+            std::get<77>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<78, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_op_div_std *
+                        ((((new_term.alu_divisor_lo * new_term.alu_quotient_lo) +
+                           (new_term.alu_partial_prod_lo * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }))) +
+                          ((new_term.alu_partial_prod_hi + (new_term.alu_divisor_hi * new_term.alu_quotient_hi)) *
+                           FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }))) -
+                         (new_term.alu_ia - new_term.alu_remainder)));
+            tmp *= scaling_factor;
+            std::get<78>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<79, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_sel_div_rng_chk * (-new_term.alu_sel_div_rng_chk + FF(1)));
+            tmp *= scaling_factor;
+            std::get<79>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<80, ContainerOverSubrelations>;
+            auto tmp = ((new_term.alu_sel_div_rng_chk * new_term.alu_sel_div_rng_chk_shift) - new_term.alu_op_div_std);
+            tmp *= scaling_factor;
+            std::get<80>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<81, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_divisor_lo -
+                        (new_term.alu_op_div_std * (((new_term.alu_div_u16_r0 + (new_term.alu_div_u16_r1 * FF(65536))) +
+                                                     (new_term.alu_div_u16_r2 * FF(4294967296UL))) +
+                                                    (new_term.alu_div_u16_r3 * FF(281474976710656UL)))));
+            tmp *= scaling_factor;
+            std::get<81>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<82, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_divisor_hi -
+                        (new_term.alu_op_div_std * (((new_term.alu_div_u16_r4 + (new_term.alu_div_u16_r5 * FF(65536))) +
+                                                     (new_term.alu_div_u16_r6 * FF(4294967296UL))) +
+                                                    (new_term.alu_div_u16_r7 * FF(281474976710656UL)))));
+            tmp *= scaling_factor;
+            std::get<82>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<83, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_quotient_lo -
+                        (new_term.alu_op_div_std *
+                         (((new_term.alu_div_u16_r0_shift + (new_term.alu_div_u16_r1_shift * FF(65536))) +
+                           (new_term.alu_div_u16_r2_shift * FF(4294967296UL))) +
+                          (new_term.alu_div_u16_r3_shift * FF(281474976710656UL)))));
+            tmp *= scaling_factor;
+            std::get<83>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<84, ContainerOverSubrelations>;
+            auto tmp = (new_term.alu_quotient_hi -
+                        (new_term.alu_op_div_std *
+                         (((new_term.alu_div_u16_r4_shift + (new_term.alu_div_u16_r5_shift * FF(65536))) +
+                           (new_term.alu_div_u16_r6_shift * FF(4294967296UL))) +
+                          (new_term.alu_div_u16_r7_shift * FF(281474976710656UL)))));
+            tmp *= scaling_factor;
+            std::get<84>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<85, ContainerOverSubrelations>;
+            auto tmp =
+                (new_term.alu_partial_prod_lo -
+                 (new_term.alu_op_div_std * ((((new_term.alu_u8_r0_shift + (new_term.alu_u8_r1_shift * FF(256))) +
+                                               (new_term.alu_u16_r0_shift * FF(65536))) +
+                                              (new_term.alu_u16_r1_shift * FF(4294967296UL))) +
+                                             (new_term.alu_u16_r2_shift * FF(281474976710656UL)))));
+            tmp *= scaling_factor;
+            std::get<85>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<86, ContainerOverSubrelations>;
+            auto tmp =
+                (new_term.alu_partial_prod_hi -
+                 (new_term.alu_op_div_std * (((new_term.alu_u16_r3_shift + (new_term.alu_u16_r4_shift * FF(65536))) +
+                                              (new_term.alu_u16_r5_shift * FF(4294967296UL))) +
+                                             (new_term.alu_u16_r6_shift * FF(281474976710656UL)))));
+            tmp *= scaling_factor;
+            std::get<86>(evals) += typename Accumulator::View(tmp);
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/binary.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/binary.hpp
@@ -55,77 +55,75 @@ template <typename FF_> class binaryImpl {
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        // Contribution 0
         {
-            Avm_DECLARE_VIEWS(0);
-            auto tmp = (binary_sel_bin * (-binary_sel_bin + FF(1)));
+            using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
+            auto tmp = (new_term.binary_sel_bin * (-new_term.binary_sel_bin + FF(1)));
             tmp *= scaling_factor;
-            std::get<0>(evals) += tmp;
+            std::get<0>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 1
         {
-            Avm_DECLARE_VIEWS(1);
-            auto tmp = ((binary_op_id_shift - binary_op_id) * binary_mem_tag_ctr);
+            using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
+            auto tmp = ((new_term.binary_op_id_shift - new_term.binary_op_id) * new_term.binary_mem_tag_ctr);
             tmp *= scaling_factor;
-            std::get<1>(evals) += tmp;
+            std::get<1>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 2
         {
-            Avm_DECLARE_VIEWS(2);
-            auto tmp = (((binary_mem_tag_ctr_shift - binary_mem_tag_ctr) + FF(1)) * binary_mem_tag_ctr);
+            using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
+            auto tmp = (((new_term.binary_mem_tag_ctr_shift - new_term.binary_mem_tag_ctr) + FF(1)) *
+                        new_term.binary_mem_tag_ctr);
             tmp *= scaling_factor;
-            std::get<2>(evals) += tmp;
+            std::get<2>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 3
         {
-            Avm_DECLARE_VIEWS(3);
-            auto tmp = ((binary_mem_tag_ctr *
-                         (((-binary_sel_bin + FF(1)) * (-binary_mem_tag_ctr_inv + FF(1))) + binary_mem_tag_ctr_inv)) -
-                        binary_sel_bin);
+            using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
+            auto tmp = ((new_term.binary_mem_tag_ctr *
+                         (((-new_term.binary_sel_bin + FF(1)) * (-new_term.binary_mem_tag_ctr_inv + FF(1))) +
+                          new_term.binary_mem_tag_ctr_inv)) -
+                        new_term.binary_sel_bin);
             tmp *= scaling_factor;
-            std::get<3>(evals) += tmp;
+            std::get<3>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 4
         {
-            Avm_DECLARE_VIEWS(4);
-            auto tmp = ((-binary_sel_bin + FF(1)) * binary_acc_ia);
+            using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
+            auto tmp = ((-new_term.binary_sel_bin + FF(1)) * new_term.binary_acc_ia);
             tmp *= scaling_factor;
-            std::get<4>(evals) += tmp;
+            std::get<4>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 5
         {
-            Avm_DECLARE_VIEWS(5);
-            auto tmp = ((-binary_sel_bin + FF(1)) * binary_acc_ib);
+            using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
+            auto tmp = ((-new_term.binary_sel_bin + FF(1)) * new_term.binary_acc_ib);
             tmp *= scaling_factor;
-            std::get<5>(evals) += tmp;
+            std::get<5>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 6
         {
-            Avm_DECLARE_VIEWS(6);
-            auto tmp = ((-binary_sel_bin + FF(1)) * binary_acc_ic);
+            using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
+            auto tmp = ((-new_term.binary_sel_bin + FF(1)) * new_term.binary_acc_ic);
             tmp *= scaling_factor;
-            std::get<6>(evals) += tmp;
+            std::get<6>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 7
         {
-            Avm_DECLARE_VIEWS(7);
-            auto tmp = (((binary_acc_ia - binary_ia_bytes) - (binary_acc_ia_shift * FF(256))) * binary_mem_tag_ctr);
+            using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
+            auto tmp =
+                (((new_term.binary_acc_ia - new_term.binary_ia_bytes) - (new_term.binary_acc_ia_shift * FF(256))) *
+                 new_term.binary_mem_tag_ctr);
             tmp *= scaling_factor;
-            std::get<7>(evals) += tmp;
+            std::get<7>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 8
         {
-            Avm_DECLARE_VIEWS(8);
-            auto tmp = (((binary_acc_ib - binary_ib_bytes) - (binary_acc_ib_shift * FF(256))) * binary_mem_tag_ctr);
+            using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
+            auto tmp =
+                (((new_term.binary_acc_ib - new_term.binary_ib_bytes) - (new_term.binary_acc_ib_shift * FF(256))) *
+                 new_term.binary_mem_tag_ctr);
             tmp *= scaling_factor;
-            std::get<8>(evals) += tmp;
+            std::get<8>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 9
         {
-            Avm_DECLARE_VIEWS(9);
-            auto tmp = (((binary_acc_ic - binary_ic_bytes) - (binary_acc_ic_shift * FF(256))) * binary_mem_tag_ctr);
+            using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
+            auto tmp =
+                (((new_term.binary_acc_ic - new_term.binary_ic_bytes) - (new_term.binary_acc_ic_shift * FF(256))) *
+                 new_term.binary_mem_tag_ctr);
             tmp *= scaling_factor;
-            std::get<9>(evals) += tmp;
+            std::get<9>(evals) += typename Accumulator::View(tmp);
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/conversion.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/conversion.hpp
@@ -28,12 +28,11 @@ template <typename FF_> class conversionImpl {
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        // Contribution 0
         {
-            Avm_DECLARE_VIEWS(0);
-            auto tmp = (conversion_sel_to_radix_le * (-conversion_sel_to_radix_le + FF(1)));
+            using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
+            auto tmp = (new_term.conversion_sel_to_radix_le * (-new_term.conversion_sel_to_radix_le + FF(1)));
             tmp *= scaling_factor;
-            std::get<0>(evals) += tmp;
+            std::get<0>(evals) += typename Accumulator::View(tmp);
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/gas.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/gas.hpp
@@ -30,26 +30,23 @@ template <typename FF_> class gasImpl {
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        // Contribution 0
         {
-            Avm_DECLARE_VIEWS(0);
-            auto tmp = (gas_sel_gas_cost - gas_sel_gas_cost);
+            using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
+            auto tmp = (new_term.gas_sel_gas_cost - new_term.gas_sel_gas_cost);
             tmp *= scaling_factor;
-            std::get<0>(evals) += tmp;
+            std::get<0>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 1
         {
-            Avm_DECLARE_VIEWS(1);
-            auto tmp = (gas_l2_gas_fixed_table - gas_l2_gas_fixed_table);
+            using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
+            auto tmp = (new_term.gas_l2_gas_fixed_table - new_term.gas_l2_gas_fixed_table);
             tmp *= scaling_factor;
-            std::get<1>(evals) += tmp;
+            std::get<1>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 2
         {
-            Avm_DECLARE_VIEWS(2);
-            auto tmp = (gas_da_gas_fixed_table - gas_da_gas_fixed_table);
+            using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
+            auto tmp = (new_term.gas_da_gas_fixed_table - new_term.gas_da_gas_fixed_table);
             tmp *= scaling_factor;
-            std::get<2>(evals) += tmp;
+            std::get<2>(evals) += typename Accumulator::View(tmp);
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/keccakf1600.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/keccakf1600.hpp
@@ -28,12 +28,11 @@ template <typename FF_> class keccakf1600Impl {
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        // Contribution 0
         {
-            Avm_DECLARE_VIEWS(0);
-            auto tmp = (keccakf1600_sel_keccakf1600 * (-keccakf1600_sel_keccakf1600 + FF(1)));
+            using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
+            auto tmp = (new_term.keccakf1600_sel_keccakf1600 * (-new_term.keccakf1600_sel_keccakf1600 + FF(1)));
             tmp *= scaling_factor;
-            std::get<0>(evals) += tmp;
+            std::get<0>(evals) += typename Accumulator::View(tmp);
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/kernel.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/kernel.hpp
@@ -79,92 +79,89 @@ template <typename FF_> class kernelImpl {
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        // Contribution 0
         {
-            Avm_DECLARE_VIEWS(0);
+            using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
+            auto tmp = ((-new_term.main_sel_last + FF(1)) *
+                        (new_term.kernel_note_hash_exist_write_offset_shift -
+                         (new_term.kernel_note_hash_exist_write_offset + new_term.main_sel_op_note_hash_exists)));
+            tmp *= scaling_factor;
+            std::get<0>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
+            auto tmp = ((-new_term.main_sel_last + FF(1)) *
+                        (new_term.kernel_emit_note_hash_write_offset_shift -
+                         (new_term.kernel_emit_note_hash_write_offset + new_term.main_sel_op_emit_note_hash)));
+            tmp *= scaling_factor;
+            std::get<1>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
             auto tmp =
-                ((-main_sel_last + FF(1)) * (kernel_note_hash_exist_write_offset_shift -
-                                             (kernel_note_hash_exist_write_offset + main_sel_op_note_hash_exists)));
+                ((-new_term.main_sel_last + FF(1)) * (new_term.kernel_nullifier_exists_write_offset_shift -
+                                                      (new_term.kernel_nullifier_exists_write_offset +
+                                                       (new_term.main_sel_op_nullifier_exists * new_term.main_ib))));
             tmp *= scaling_factor;
-            std::get<0>(evals) += tmp;
+            std::get<2>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 1
         {
-            Avm_DECLARE_VIEWS(1);
-            auto tmp = ((-main_sel_last + FF(1)) * (kernel_emit_note_hash_write_offset_shift -
-                                                    (kernel_emit_note_hash_write_offset + main_sel_op_emit_note_hash)));
+            using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
+            auto tmp = ((-new_term.main_sel_last + FF(1)) *
+                        (new_term.kernel_nullifier_non_exists_write_offset_shift -
+                         (new_term.kernel_nullifier_non_exists_write_offset +
+                          (new_term.main_sel_op_nullifier_exists * (-new_term.main_ib + FF(1))))));
             tmp *= scaling_factor;
-            std::get<1>(evals) += tmp;
+            std::get<3>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 2
         {
-            Avm_DECLARE_VIEWS(2);
-            auto tmp = ((-main_sel_last + FF(1)) *
-                        (kernel_nullifier_exists_write_offset_shift -
-                         (kernel_nullifier_exists_write_offset + (main_sel_op_nullifier_exists * main_ib))));
+            using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
+            auto tmp = ((-new_term.main_sel_last + FF(1)) *
+                        (new_term.kernel_emit_nullifier_write_offset_shift -
+                         (new_term.kernel_emit_nullifier_write_offset + new_term.main_sel_op_emit_nullifier)));
             tmp *= scaling_factor;
-            std::get<2>(evals) += tmp;
+            std::get<4>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 3
         {
-            Avm_DECLARE_VIEWS(3);
+            using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
             auto tmp =
-                ((-main_sel_last + FF(1)) *
-                 (kernel_nullifier_non_exists_write_offset_shift -
-                  (kernel_nullifier_non_exists_write_offset + (main_sel_op_nullifier_exists * (-main_ib + FF(1))))));
+                ((-new_term.main_sel_last + FF(1)) *
+                 (new_term.kernel_l1_to_l2_msg_exists_write_offset_shift -
+                  (new_term.kernel_l1_to_l2_msg_exists_write_offset + new_term.main_sel_op_l1_to_l2_msg_exists)));
             tmp *= scaling_factor;
-            std::get<3>(evals) += tmp;
+            std::get<5>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 4
         {
-            Avm_DECLARE_VIEWS(4);
-            auto tmp = ((-main_sel_last + FF(1)) * (kernel_emit_nullifier_write_offset_shift -
-                                                    (kernel_emit_nullifier_write_offset + main_sel_op_emit_nullifier)));
-            tmp *= scaling_factor;
-            std::get<4>(evals) += tmp;
-        }
-        // Contribution 5
-        {
-            Avm_DECLARE_VIEWS(5);
-            auto tmp = ((-main_sel_last + FF(1)) *
-                        (kernel_l1_to_l2_msg_exists_write_offset_shift -
-                         (kernel_l1_to_l2_msg_exists_write_offset + main_sel_op_l1_to_l2_msg_exists)));
-            tmp *= scaling_factor;
-            std::get<5>(evals) += tmp;
-        }
-        // Contribution 6
-        {
-            Avm_DECLARE_VIEWS(6);
-            auto tmp = ((-main_sel_last + FF(1)) *
-                        (kernel_emit_unencrypted_log_write_offset_shift -
-                         (kernel_emit_unencrypted_log_write_offset + main_sel_op_emit_unencrypted_log)));
-            tmp *= scaling_factor;
-            std::get<6>(evals) += tmp;
-        }
-        // Contribution 7
-        {
-            Avm_DECLARE_VIEWS(7);
+            using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
             auto tmp =
-                ((-main_sel_last + FF(1)) * (kernel_emit_l2_to_l1_msg_write_offset_shift -
-                                             (kernel_emit_l2_to_l1_msg_write_offset + main_sel_op_emit_l2_to_l1_msg)));
+                ((-new_term.main_sel_last + FF(1)) *
+                 (new_term.kernel_emit_unencrypted_log_write_offset_shift -
+                  (new_term.kernel_emit_unencrypted_log_write_offset + new_term.main_sel_op_emit_unencrypted_log)));
             tmp *= scaling_factor;
-            std::get<7>(evals) += tmp;
+            std::get<6>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 8
         {
-            Avm_DECLARE_VIEWS(8);
-            auto tmp = ((-main_sel_last + FF(1)) *
-                        (kernel_sload_write_offset_shift - (kernel_sload_write_offset + main_sel_op_sload)));
+            using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
+            auto tmp = ((-new_term.main_sel_last + FF(1)) *
+                        (new_term.kernel_emit_l2_to_l1_msg_write_offset_shift -
+                         (new_term.kernel_emit_l2_to_l1_msg_write_offset + new_term.main_sel_op_emit_l2_to_l1_msg)));
             tmp *= scaling_factor;
-            std::get<8>(evals) += tmp;
+            std::get<7>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 9
         {
-            Avm_DECLARE_VIEWS(9);
-            auto tmp = ((-main_sel_last + FF(1)) *
-                        (kernel_sstore_write_offset_shift - (kernel_sstore_write_offset + main_sel_op_sstore)));
+            using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
+            auto tmp = ((-new_term.main_sel_last + FF(1)) *
+                        (new_term.kernel_sload_write_offset_shift -
+                         (new_term.kernel_sload_write_offset + new_term.main_sel_op_sload)));
             tmp *= scaling_factor;
-            std::get<9>(evals) += tmp;
+            std::get<8>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
+            auto tmp = ((-new_term.main_sel_last + FF(1)) *
+                        (new_term.kernel_sstore_write_offset_shift -
+                         (new_term.kernel_sstore_write_offset + new_term.main_sel_op_sstore)));
+            tmp *= scaling_factor;
+            std::get<9>(evals) += typename Accumulator::View(tmp);
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/main.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/main.hpp
@@ -258,1225 +258,1117 @@ template <typename FF_> class mainImpl {
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        // Contribution 0
         {
-            Avm_DECLARE_VIEWS(0);
-            auto tmp = (main_l2_out_of_gas * (-main_l2_out_of_gas + FF(1)));
+            using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_l2_out_of_gas * (-new_term.main_l2_out_of_gas + FF(1)));
             tmp *= scaling_factor;
-            std::get<0>(evals) += tmp;
+            std::get<0>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 1
         {
-            Avm_DECLARE_VIEWS(1);
-            auto tmp = (main_da_out_of_gas * (-main_da_out_of_gas + FF(1)));
+            using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_da_out_of_gas * (-new_term.main_da_out_of_gas + FF(1)));
             tmp *= scaling_factor;
-            std::get<1>(evals) += tmp;
+            std::get<1>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 2
         {
-            Avm_DECLARE_VIEWS(2);
-            auto tmp = (main_sel_gas_accounting_active *
-                        ((main_l2_gas_remaining_shift - main_l2_gas_remaining) + main_l2_gas_op_cost));
+            using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_gas_accounting_active *
+                        ((new_term.main_l2_gas_remaining_shift - new_term.main_l2_gas_remaining) +
+                         new_term.main_l2_gas_op_cost));
             tmp *= scaling_factor;
-            std::get<2>(evals) += tmp;
+            std::get<2>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 3
         {
-            Avm_DECLARE_VIEWS(3);
-            auto tmp = (main_sel_gas_accounting_active *
-                        ((main_da_gas_remaining_shift - main_da_gas_remaining) + main_da_gas_op_cost));
+            using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_gas_accounting_active *
+                        ((new_term.main_da_gas_remaining_shift - new_term.main_da_gas_remaining) +
+                         new_term.main_da_gas_op_cost));
             tmp *= scaling_factor;
-            std::get<3>(evals) += tmp;
+            std::get<3>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 4
         {
-            Avm_DECLARE_VIEWS(4);
-            auto tmp = ((-main_sel_gas_accounting_active + FF(1)) * main_l2_gas_op_cost);
+            using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
+            auto tmp = ((-new_term.main_sel_gas_accounting_active + FF(1)) * new_term.main_l2_gas_op_cost);
             tmp *= scaling_factor;
-            std::get<4>(evals) += tmp;
+            std::get<4>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 5
         {
-            Avm_DECLARE_VIEWS(5);
-            auto tmp = ((-main_sel_gas_accounting_active + FF(1)) * main_da_gas_op_cost);
+            using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
+            auto tmp = ((-new_term.main_sel_gas_accounting_active + FF(1)) * new_term.main_da_gas_op_cost);
             tmp *= scaling_factor;
-            std::get<5>(evals) += tmp;
+            std::get<5>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 6
         {
-            Avm_DECLARE_VIEWS(6);
-            auto tmp = (main_sel_gas_accounting_active *
-                        ((((-(main_l2_out_of_gas * FF(2)) + FF(1)) * main_l2_gas_remaining_shift) -
-                          (main_abs_l2_rem_gas_hi * FF(65536))) -
-                         main_abs_l2_rem_gas_lo));
+            using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_gas_accounting_active *
+                        ((((-(new_term.main_l2_out_of_gas * FF(2)) + FF(1)) * new_term.main_l2_gas_remaining_shift) -
+                          (new_term.main_abs_l2_rem_gas_hi * FF(65536))) -
+                         new_term.main_abs_l2_rem_gas_lo));
             tmp *= scaling_factor;
-            std::get<6>(evals) += tmp;
+            std::get<6>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 7
         {
-            Avm_DECLARE_VIEWS(7);
-            auto tmp = (main_sel_gas_accounting_active *
-                        ((((-(main_da_out_of_gas * FF(2)) + FF(1)) * main_da_gas_remaining_shift) -
-                          (main_abs_da_rem_gas_hi * FF(65536))) -
-                         main_abs_da_rem_gas_lo));
+            using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_gas_accounting_active *
+                        ((((-(new_term.main_da_out_of_gas * FF(2)) + FF(1)) * new_term.main_da_gas_remaining_shift) -
+                          (new_term.main_abs_da_rem_gas_hi * FF(65536))) -
+                         new_term.main_abs_da_rem_gas_lo));
             tmp *= scaling_factor;
-            std::get<7>(evals) += tmp;
+            std::get<7>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 8
         {
-            Avm_DECLARE_VIEWS(8);
-            auto tmp = (main_sel_op_address * (-main_sel_op_address + FF(1)));
+            using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_address * (-new_term.main_sel_op_address + FF(1)));
             tmp *= scaling_factor;
-            std::get<8>(evals) += tmp;
+            std::get<8>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 9
         {
-            Avm_DECLARE_VIEWS(9);
-            auto tmp = (main_sel_op_storage_address * (-main_sel_op_storage_address + FF(1)));
+            using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_storage_address * (-new_term.main_sel_op_storage_address + FF(1)));
             tmp *= scaling_factor;
-            std::get<9>(evals) += tmp;
+            std::get<9>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 10
         {
-            Avm_DECLARE_VIEWS(10);
-            auto tmp = (main_sel_op_sender * (-main_sel_op_sender + FF(1)));
+            using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_sender * (-new_term.main_sel_op_sender + FF(1)));
             tmp *= scaling_factor;
-            std::get<10>(evals) += tmp;
+            std::get<10>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 11
         {
-            Avm_DECLARE_VIEWS(11);
-            auto tmp = (main_sel_op_function_selector * (-main_sel_op_function_selector + FF(1)));
+            using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_function_selector * (-new_term.main_sel_op_function_selector + FF(1)));
             tmp *= scaling_factor;
-            std::get<11>(evals) += tmp;
+            std::get<11>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 12
         {
-            Avm_DECLARE_VIEWS(12);
-            auto tmp = (main_sel_op_transaction_fee * (-main_sel_op_transaction_fee + FF(1)));
+            using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_transaction_fee * (-new_term.main_sel_op_transaction_fee + FF(1)));
             tmp *= scaling_factor;
-            std::get<12>(evals) += tmp;
+            std::get<12>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 13
         {
-            Avm_DECLARE_VIEWS(13);
-            auto tmp = (main_sel_op_chain_id * (-main_sel_op_chain_id + FF(1)));
+            using Accumulator = typename std::tuple_element_t<13, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_chain_id * (-new_term.main_sel_op_chain_id + FF(1)));
             tmp *= scaling_factor;
-            std::get<13>(evals) += tmp;
+            std::get<13>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 14
         {
-            Avm_DECLARE_VIEWS(14);
-            auto tmp = (main_sel_op_version * (-main_sel_op_version + FF(1)));
+            using Accumulator = typename std::tuple_element_t<14, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_version * (-new_term.main_sel_op_version + FF(1)));
             tmp *= scaling_factor;
-            std::get<14>(evals) += tmp;
+            std::get<14>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 15
         {
-            Avm_DECLARE_VIEWS(15);
-            auto tmp = (main_sel_op_block_number * (-main_sel_op_block_number + FF(1)));
+            using Accumulator = typename std::tuple_element_t<15, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_block_number * (-new_term.main_sel_op_block_number + FF(1)));
             tmp *= scaling_factor;
-            std::get<15>(evals) += tmp;
+            std::get<15>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 16
         {
-            Avm_DECLARE_VIEWS(16);
-            auto tmp = (main_sel_op_coinbase * (-main_sel_op_coinbase + FF(1)));
+            using Accumulator = typename std::tuple_element_t<16, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_coinbase * (-new_term.main_sel_op_coinbase + FF(1)));
             tmp *= scaling_factor;
-            std::get<16>(evals) += tmp;
+            std::get<16>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 17
         {
-            Avm_DECLARE_VIEWS(17);
-            auto tmp = (main_sel_op_timestamp * (-main_sel_op_timestamp + FF(1)));
+            using Accumulator = typename std::tuple_element_t<17, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_timestamp * (-new_term.main_sel_op_timestamp + FF(1)));
             tmp *= scaling_factor;
-            std::get<17>(evals) += tmp;
+            std::get<17>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 18
         {
-            Avm_DECLARE_VIEWS(18);
-            auto tmp = (main_sel_op_fee_per_l2_gas * (-main_sel_op_fee_per_l2_gas + FF(1)));
+            using Accumulator = typename std::tuple_element_t<18, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_fee_per_l2_gas * (-new_term.main_sel_op_fee_per_l2_gas + FF(1)));
             tmp *= scaling_factor;
-            std::get<18>(evals) += tmp;
+            std::get<18>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 19
         {
-            Avm_DECLARE_VIEWS(19);
-            auto tmp = (main_sel_op_fee_per_da_gas * (-main_sel_op_fee_per_da_gas + FF(1)));
+            using Accumulator = typename std::tuple_element_t<19, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_fee_per_da_gas * (-new_term.main_sel_op_fee_per_da_gas + FF(1)));
             tmp *= scaling_factor;
-            std::get<19>(evals) += tmp;
+            std::get<19>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 20
         {
-            Avm_DECLARE_VIEWS(20);
-            auto tmp = (main_sel_op_l2gasleft * (-main_sel_op_l2gasleft + FF(1)));
+            using Accumulator = typename std::tuple_element_t<20, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_l2gasleft * (-new_term.main_sel_op_l2gasleft + FF(1)));
             tmp *= scaling_factor;
-            std::get<20>(evals) += tmp;
+            std::get<20>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 21
         {
-            Avm_DECLARE_VIEWS(21);
-            auto tmp = (main_sel_op_dagasleft * (-main_sel_op_dagasleft + FF(1)));
+            using Accumulator = typename std::tuple_element_t<21, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_dagasleft * (-new_term.main_sel_op_dagasleft + FF(1)));
             tmp *= scaling_factor;
-            std::get<21>(evals) += tmp;
+            std::get<21>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 22
         {
-            Avm_DECLARE_VIEWS(22);
-            auto tmp = (main_sel_op_note_hash_exists * (-main_sel_op_note_hash_exists + FF(1)));
+            using Accumulator = typename std::tuple_element_t<22, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_note_hash_exists * (-new_term.main_sel_op_note_hash_exists + FF(1)));
             tmp *= scaling_factor;
-            std::get<22>(evals) += tmp;
+            std::get<22>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 23
         {
-            Avm_DECLARE_VIEWS(23);
-            auto tmp = (main_sel_op_emit_note_hash * (-main_sel_op_emit_note_hash + FF(1)));
+            using Accumulator = typename std::tuple_element_t<23, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_emit_note_hash * (-new_term.main_sel_op_emit_note_hash + FF(1)));
             tmp *= scaling_factor;
-            std::get<23>(evals) += tmp;
+            std::get<23>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 24
         {
-            Avm_DECLARE_VIEWS(24);
-            auto tmp = (main_sel_op_nullifier_exists * (-main_sel_op_nullifier_exists + FF(1)));
+            using Accumulator = typename std::tuple_element_t<24, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_nullifier_exists * (-new_term.main_sel_op_nullifier_exists + FF(1)));
             tmp *= scaling_factor;
-            std::get<24>(evals) += tmp;
+            std::get<24>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 25
         {
-            Avm_DECLARE_VIEWS(25);
-            auto tmp = (main_sel_op_emit_nullifier * (-main_sel_op_emit_nullifier + FF(1)));
+            using Accumulator = typename std::tuple_element_t<25, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_emit_nullifier * (-new_term.main_sel_op_emit_nullifier + FF(1)));
             tmp *= scaling_factor;
-            std::get<25>(evals) += tmp;
+            std::get<25>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 26
         {
-            Avm_DECLARE_VIEWS(26);
-            auto tmp = (main_sel_op_l1_to_l2_msg_exists * (-main_sel_op_l1_to_l2_msg_exists + FF(1)));
+            using Accumulator = typename std::tuple_element_t<26, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_l1_to_l2_msg_exists * (-new_term.main_sel_op_l1_to_l2_msg_exists + FF(1)));
             tmp *= scaling_factor;
-            std::get<26>(evals) += tmp;
+            std::get<26>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 27
         {
-            Avm_DECLARE_VIEWS(27);
-            auto tmp = (main_sel_op_emit_unencrypted_log * (-main_sel_op_emit_unencrypted_log + FF(1)));
-            tmp *= scaling_factor;
-            std::get<27>(evals) += tmp;
-        }
-        // Contribution 28
-        {
-            Avm_DECLARE_VIEWS(28);
-            auto tmp = (main_sel_op_emit_l2_to_l1_msg * (-main_sel_op_emit_l2_to_l1_msg + FF(1)));
-            tmp *= scaling_factor;
-            std::get<28>(evals) += tmp;
-        }
-        // Contribution 29
-        {
-            Avm_DECLARE_VIEWS(29);
-            auto tmp = (main_sel_op_get_contract_instance * (-main_sel_op_get_contract_instance + FF(1)));
-            tmp *= scaling_factor;
-            std::get<29>(evals) += tmp;
-        }
-        // Contribution 30
-        {
-            Avm_DECLARE_VIEWS(30);
-            auto tmp = (main_sel_op_sload * (-main_sel_op_sload + FF(1)));
-            tmp *= scaling_factor;
-            std::get<30>(evals) += tmp;
-        }
-        // Contribution 31
-        {
-            Avm_DECLARE_VIEWS(31);
-            auto tmp = (main_sel_op_sstore * (-main_sel_op_sstore + FF(1)));
-            tmp *= scaling_factor;
-            std::get<31>(evals) += tmp;
-        }
-        // Contribution 32
-        {
-            Avm_DECLARE_VIEWS(32);
-            auto tmp = (main_sel_op_radix_le * (-main_sel_op_radix_le + FF(1)));
-            tmp *= scaling_factor;
-            std::get<32>(evals) += tmp;
-        }
-        // Contribution 33
-        {
-            Avm_DECLARE_VIEWS(33);
-            auto tmp = (main_sel_op_sha256 * (-main_sel_op_sha256 + FF(1)));
-            tmp *= scaling_factor;
-            std::get<33>(evals) += tmp;
-        }
-        // Contribution 34
-        {
-            Avm_DECLARE_VIEWS(34);
-            auto tmp = (main_sel_op_poseidon2 * (-main_sel_op_poseidon2 + FF(1)));
-            tmp *= scaling_factor;
-            std::get<34>(evals) += tmp;
-        }
-        // Contribution 35
-        {
-            Avm_DECLARE_VIEWS(35);
-            auto tmp = (main_sel_op_keccak * (-main_sel_op_keccak + FF(1)));
-            tmp *= scaling_factor;
-            std::get<35>(evals) += tmp;
-        }
-        // Contribution 36
-        {
-            Avm_DECLARE_VIEWS(36);
-            auto tmp = (main_sel_op_pedersen * (-main_sel_op_pedersen + FF(1)));
-            tmp *= scaling_factor;
-            std::get<36>(evals) += tmp;
-        }
-        // Contribution 37
-        {
-            Avm_DECLARE_VIEWS(37);
-            auto tmp = (main_sel_op_add * (-main_sel_op_add + FF(1)));
-            tmp *= scaling_factor;
-            std::get<37>(evals) += tmp;
-        }
-        // Contribution 38
-        {
-            Avm_DECLARE_VIEWS(38);
-            auto tmp = (main_sel_op_sub * (-main_sel_op_sub + FF(1)));
-            tmp *= scaling_factor;
-            std::get<38>(evals) += tmp;
-        }
-        // Contribution 39
-        {
-            Avm_DECLARE_VIEWS(39);
-            auto tmp = (main_sel_op_mul * (-main_sel_op_mul + FF(1)));
-            tmp *= scaling_factor;
-            std::get<39>(evals) += tmp;
-        }
-        // Contribution 40
-        {
-            Avm_DECLARE_VIEWS(40);
-            auto tmp = (main_sel_op_div * (-main_sel_op_div + FF(1)));
-            tmp *= scaling_factor;
-            std::get<40>(evals) += tmp;
-        }
-        // Contribution 41
-        {
-            Avm_DECLARE_VIEWS(41);
-            auto tmp = (main_sel_op_fdiv * (-main_sel_op_fdiv + FF(1)));
-            tmp *= scaling_factor;
-            std::get<41>(evals) += tmp;
-        }
-        // Contribution 42
-        {
-            Avm_DECLARE_VIEWS(42);
-            auto tmp = (main_sel_op_not * (-main_sel_op_not + FF(1)));
-            tmp *= scaling_factor;
-            std::get<42>(evals) += tmp;
-        }
-        // Contribution 43
-        {
-            Avm_DECLARE_VIEWS(43);
-            auto tmp = (main_sel_op_eq * (-main_sel_op_eq + FF(1)));
-            tmp *= scaling_factor;
-            std::get<43>(evals) += tmp;
-        }
-        // Contribution 44
-        {
-            Avm_DECLARE_VIEWS(44);
-            auto tmp = (main_sel_op_and * (-main_sel_op_and + FF(1)));
-            tmp *= scaling_factor;
-            std::get<44>(evals) += tmp;
-        }
-        // Contribution 45
-        {
-            Avm_DECLARE_VIEWS(45);
-            auto tmp = (main_sel_op_or * (-main_sel_op_or + FF(1)));
-            tmp *= scaling_factor;
-            std::get<45>(evals) += tmp;
-        }
-        // Contribution 46
-        {
-            Avm_DECLARE_VIEWS(46);
-            auto tmp = (main_sel_op_xor * (-main_sel_op_xor + FF(1)));
-            tmp *= scaling_factor;
-            std::get<46>(evals) += tmp;
-        }
-        // Contribution 47
-        {
-            Avm_DECLARE_VIEWS(47);
-            auto tmp = (main_sel_op_cast * (-main_sel_op_cast + FF(1)));
-            tmp *= scaling_factor;
-            std::get<47>(evals) += tmp;
-        }
-        // Contribution 48
-        {
-            Avm_DECLARE_VIEWS(48);
-            auto tmp = (main_sel_op_lt * (-main_sel_op_lt + FF(1)));
-            tmp *= scaling_factor;
-            std::get<48>(evals) += tmp;
-        }
-        // Contribution 49
-        {
-            Avm_DECLARE_VIEWS(49);
-            auto tmp = (main_sel_op_lte * (-main_sel_op_lte + FF(1)));
-            tmp *= scaling_factor;
-            std::get<49>(evals) += tmp;
-        }
-        // Contribution 50
-        {
-            Avm_DECLARE_VIEWS(50);
-            auto tmp = (main_sel_op_shl * (-main_sel_op_shl + FF(1)));
-            tmp *= scaling_factor;
-            std::get<50>(evals) += tmp;
-        }
-        // Contribution 51
-        {
-            Avm_DECLARE_VIEWS(51);
-            auto tmp = (main_sel_op_shr * (-main_sel_op_shr + FF(1)));
-            tmp *= scaling_factor;
-            std::get<51>(evals) += tmp;
-        }
-        // Contribution 52
-        {
-            Avm_DECLARE_VIEWS(52);
-            auto tmp = (main_sel_op_internal_call * (-main_sel_op_internal_call + FF(1)));
-            tmp *= scaling_factor;
-            std::get<52>(evals) += tmp;
-        }
-        // Contribution 53
-        {
-            Avm_DECLARE_VIEWS(53);
-            auto tmp = (main_sel_op_internal_return * (-main_sel_op_internal_return + FF(1)));
-            tmp *= scaling_factor;
-            std::get<53>(evals) += tmp;
-        }
-        // Contribution 54
-        {
-            Avm_DECLARE_VIEWS(54);
-            auto tmp = (main_sel_op_jump * (-main_sel_op_jump + FF(1)));
-            tmp *= scaling_factor;
-            std::get<54>(evals) += tmp;
-        }
-        // Contribution 55
-        {
-            Avm_DECLARE_VIEWS(55);
-            auto tmp = (main_sel_op_jumpi * (-main_sel_op_jumpi + FF(1)));
-            tmp *= scaling_factor;
-            std::get<55>(evals) += tmp;
-        }
-        // Contribution 56
-        {
-            Avm_DECLARE_VIEWS(56);
-            auto tmp = (main_sel_op_halt * (-main_sel_op_halt + FF(1)));
-            tmp *= scaling_factor;
-            std::get<56>(evals) += tmp;
-        }
-        // Contribution 57
-        {
-            Avm_DECLARE_VIEWS(57);
-            auto tmp = (main_sel_op_external_call * (-main_sel_op_external_call + FF(1)));
-            tmp *= scaling_factor;
-            std::get<57>(evals) += tmp;
-        }
-        // Contribution 58
-        {
-            Avm_DECLARE_VIEWS(58);
-            auto tmp = (main_sel_op_calldata_copy * (-main_sel_op_calldata_copy + FF(1)));
-            tmp *= scaling_factor;
-            std::get<58>(evals) += tmp;
-        }
-        // Contribution 59
-        {
-            Avm_DECLARE_VIEWS(59);
-            auto tmp = (main_sel_op_external_return * (-main_sel_op_external_return + FF(1)));
-            tmp *= scaling_factor;
-            std::get<59>(evals) += tmp;
-        }
-        // Contribution 60
-        {
-            Avm_DECLARE_VIEWS(60);
-            auto tmp = (main_sel_op_mov * (-main_sel_op_mov + FF(1)));
-            tmp *= scaling_factor;
-            std::get<60>(evals) += tmp;
-        }
-        // Contribution 61
-        {
-            Avm_DECLARE_VIEWS(61);
-            auto tmp = (main_sel_op_cmov * (-main_sel_op_cmov + FF(1)));
-            tmp *= scaling_factor;
-            std::get<61>(evals) += tmp;
-        }
-        // Contribution 62
-        {
-            Avm_DECLARE_VIEWS(62);
-            auto tmp = (main_op_err * (-main_op_err + FF(1)));
-            tmp *= scaling_factor;
-            std::get<62>(evals) += tmp;
-        }
-        // Contribution 63
-        {
-            Avm_DECLARE_VIEWS(63);
-            auto tmp = (main_tag_err * (-main_tag_err + FF(1)));
-            tmp *= scaling_factor;
-            std::get<63>(evals) += tmp;
-        }
-        // Contribution 64
-        {
-            Avm_DECLARE_VIEWS(64);
-            auto tmp = (main_id_zero * (-main_id_zero + FF(1)));
-            tmp *= scaling_factor;
-            std::get<64>(evals) += tmp;
-        }
-        // Contribution 65
-        {
-            Avm_DECLARE_VIEWS(65);
-            auto tmp = (main_sel_mem_op_a * (-main_sel_mem_op_a + FF(1)));
-            tmp *= scaling_factor;
-            std::get<65>(evals) += tmp;
-        }
-        // Contribution 66
-        {
-            Avm_DECLARE_VIEWS(66);
-            auto tmp = (main_sel_mem_op_b * (-main_sel_mem_op_b + FF(1)));
-            tmp *= scaling_factor;
-            std::get<66>(evals) += tmp;
-        }
-        // Contribution 67
-        {
-            Avm_DECLARE_VIEWS(67);
-            auto tmp = (main_sel_mem_op_c * (-main_sel_mem_op_c + FF(1)));
-            tmp *= scaling_factor;
-            std::get<67>(evals) += tmp;
-        }
-        // Contribution 68
-        {
-            Avm_DECLARE_VIEWS(68);
-            auto tmp = (main_sel_mem_op_d * (-main_sel_mem_op_d + FF(1)));
-            tmp *= scaling_factor;
-            std::get<68>(evals) += tmp;
-        }
-        // Contribution 69
-        {
-            Avm_DECLARE_VIEWS(69);
-            auto tmp = (main_rwa * (-main_rwa + FF(1)));
-            tmp *= scaling_factor;
-            std::get<69>(evals) += tmp;
-        }
-        // Contribution 70
-        {
-            Avm_DECLARE_VIEWS(70);
-            auto tmp = (main_rwb * (-main_rwb + FF(1)));
-            tmp *= scaling_factor;
-            std::get<70>(evals) += tmp;
-        }
-        // Contribution 71
-        {
-            Avm_DECLARE_VIEWS(71);
-            auto tmp = (main_rwc * (-main_rwc + FF(1)));
-            tmp *= scaling_factor;
-            std::get<71>(evals) += tmp;
-        }
-        // Contribution 72
-        {
-            Avm_DECLARE_VIEWS(72);
-            auto tmp = (main_rwd * (-main_rwd + FF(1)));
-            tmp *= scaling_factor;
-            std::get<72>(evals) += tmp;
-        }
-        // Contribution 73
-        {
-            Avm_DECLARE_VIEWS(73);
-            auto tmp = (main_sel_resolve_ind_addr_a * (-main_sel_resolve_ind_addr_a + FF(1)));
-            tmp *= scaling_factor;
-            std::get<73>(evals) += tmp;
-        }
-        // Contribution 74
-        {
-            Avm_DECLARE_VIEWS(74);
-            auto tmp = (main_sel_resolve_ind_addr_b * (-main_sel_resolve_ind_addr_b + FF(1)));
-            tmp *= scaling_factor;
-            std::get<74>(evals) += tmp;
-        }
-        // Contribution 75
-        {
-            Avm_DECLARE_VIEWS(75);
-            auto tmp = (main_sel_resolve_ind_addr_c * (-main_sel_resolve_ind_addr_c + FF(1)));
-            tmp *= scaling_factor;
-            std::get<75>(evals) += tmp;
-        }
-        // Contribution 76
-        {
-            Avm_DECLARE_VIEWS(76);
-            auto tmp = (main_sel_resolve_ind_addr_d * (-main_sel_resolve_ind_addr_d + FF(1)));
-            tmp *= scaling_factor;
-            std::get<76>(evals) += tmp;
-        }
-        // Contribution 77
-        {
-            Avm_DECLARE_VIEWS(77);
-            auto tmp = (((main_sel_op_eq + main_sel_op_lte) + main_sel_op_lt) * (main_w_in_tag - FF(1)));
-            tmp *= scaling_factor;
-            std::get<77>(evals) += tmp;
-        }
-        // Contribution 78
-        {
-            Avm_DECLARE_VIEWS(78);
-            auto tmp = ((main_sel_op_fdiv * (-main_op_err + FF(1))) * ((main_ic * main_ib) - main_ia));
-            tmp *= scaling_factor;
-            std::get<78>(evals) += tmp;
-        }
-        // Contribution 79
-        {
-            Avm_DECLARE_VIEWS(79);
-            auto tmp = ((main_sel_op_fdiv + main_sel_op_div) * (((main_ib * main_inv) - FF(1)) + main_op_err));
-            tmp *= scaling_factor;
-            std::get<79>(evals) += tmp;
-        }
-        // Contribution 80
-        {
-            Avm_DECLARE_VIEWS(80);
-            auto tmp = (((main_sel_op_fdiv + main_sel_op_div) * main_op_err) * (-main_inv + FF(1)));
-            tmp *= scaling_factor;
-            std::get<80>(evals) += tmp;
-        }
-        // Contribution 81
-        {
-            Avm_DECLARE_VIEWS(81);
-            auto tmp = (main_sel_op_fdiv * (main_r_in_tag - FF(6)));
-            tmp *= scaling_factor;
-            std::get<81>(evals) += tmp;
-        }
-        // Contribution 82
-        {
-            Avm_DECLARE_VIEWS(82);
-            auto tmp = (main_sel_op_fdiv * (main_w_in_tag - FF(6)));
-            tmp *= scaling_factor;
-            std::get<82>(evals) += tmp;
-        }
-        // Contribution 83
-        {
-            Avm_DECLARE_VIEWS(83);
-            auto tmp = (main_op_err * ((main_sel_op_fdiv + main_sel_op_div) - FF(1)));
-            tmp *= scaling_factor;
-            std::get<83>(evals) += tmp;
-        }
-        // Contribution 84
-        {
-            Avm_DECLARE_VIEWS(84);
-            auto tmp = ((((((((((((main_sel_op_address + main_sel_op_storage_address) + main_sel_op_sender) +
-                                 main_sel_op_function_selector) +
-                                main_sel_op_transaction_fee) +
-                               main_sel_op_chain_id) +
-                              main_sel_op_version) +
-                             main_sel_op_block_number) +
-                            main_sel_op_coinbase) +
-                           main_sel_op_timestamp) +
-                          main_sel_op_fee_per_l2_gas) +
-                         main_sel_op_fee_per_da_gas) *
-                        (-main_sel_q_kernel_lookup + FF(1)));
-            tmp *= scaling_factor;
-            std::get<84>(evals) += tmp;
-        }
-        // Contribution 85
-        {
-            Avm_DECLARE_VIEWS(85);
+            using Accumulator = typename std::tuple_element_t<27, ContainerOverSubrelations>;
             auto tmp =
-                (((((((main_sel_op_note_hash_exists + main_sel_op_emit_note_hash) + main_sel_op_nullifier_exists) +
-                     main_sel_op_emit_nullifier) +
-                    main_sel_op_l1_to_l2_msg_exists) +
-                   main_sel_op_emit_unencrypted_log) +
-                  main_sel_op_emit_l2_to_l1_msg) *
-                 (-main_sel_q_kernel_output_lookup + FF(1)));
+                (new_term.main_sel_op_emit_unencrypted_log * (-new_term.main_sel_op_emit_unencrypted_log + FF(1)));
             tmp *= scaling_factor;
-            std::get<85>(evals) += tmp;
+            std::get<27>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 86
         {
-            Avm_DECLARE_VIEWS(86);
-            auto tmp = (main_sel_op_jump * (main_pc_shift - main_ia));
+            using Accumulator = typename std::tuple_element_t<28, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_emit_l2_to_l1_msg * (-new_term.main_sel_op_emit_l2_to_l1_msg + FF(1)));
             tmp *= scaling_factor;
-            std::get<86>(evals) += tmp;
+            std::get<28>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 87
         {
-            Avm_DECLARE_VIEWS(87);
-            auto tmp = (main_sel_op_jumpi * (((-main_id_zero + FF(1)) * (main_pc_shift - main_ia)) +
-                                             (main_id_zero * ((main_pc_shift - main_pc) - FF(1)))));
-            tmp *= scaling_factor;
-            std::get<87>(evals) += tmp;
-        }
-        // Contribution 88
-        {
-            Avm_DECLARE_VIEWS(88);
+            using Accumulator = typename std::tuple_element_t<29, ContainerOverSubrelations>;
             auto tmp =
-                (main_sel_op_internal_call * (main_internal_return_ptr_shift - (main_internal_return_ptr + FF(1))));
+                (new_term.main_sel_op_get_contract_instance * (-new_term.main_sel_op_get_contract_instance + FF(1)));
             tmp *= scaling_factor;
-            std::get<88>(evals) += tmp;
+            std::get<29>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 89
         {
-            Avm_DECLARE_VIEWS(89);
-            auto tmp = (main_sel_op_internal_call * (main_internal_return_ptr - main_mem_addr_b));
+            using Accumulator = typename std::tuple_element_t<30, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_sload * (-new_term.main_sel_op_sload + FF(1)));
             tmp *= scaling_factor;
-            std::get<89>(evals) += tmp;
+            std::get<30>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 90
         {
-            Avm_DECLARE_VIEWS(90);
-            auto tmp = (main_sel_op_internal_call * (main_pc_shift - main_ia));
+            using Accumulator = typename std::tuple_element_t<31, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_sstore * (-new_term.main_sel_op_sstore + FF(1)));
             tmp *= scaling_factor;
-            std::get<90>(evals) += tmp;
+            std::get<31>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 91
         {
-            Avm_DECLARE_VIEWS(91);
-            auto tmp = (main_sel_op_internal_call * ((main_pc + FF(1)) - main_ib));
+            using Accumulator = typename std::tuple_element_t<32, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_radix_le * (-new_term.main_sel_op_radix_le + FF(1)));
             tmp *= scaling_factor;
-            std::get<91>(evals) += tmp;
+            std::get<32>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 92
         {
-            Avm_DECLARE_VIEWS(92);
-            auto tmp = (main_sel_op_internal_call * (main_rwb - FF(1)));
+            using Accumulator = typename std::tuple_element_t<33, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_sha256 * (-new_term.main_sel_op_sha256 + FF(1)));
             tmp *= scaling_factor;
-            std::get<92>(evals) += tmp;
+            std::get<33>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 93
         {
-            Avm_DECLARE_VIEWS(93);
-            auto tmp = (main_sel_op_internal_call * (main_sel_mem_op_b - FF(1)));
+            using Accumulator = typename std::tuple_element_t<34, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_poseidon2 * (-new_term.main_sel_op_poseidon2 + FF(1)));
             tmp *= scaling_factor;
-            std::get<93>(evals) += tmp;
+            std::get<34>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 94
         {
-            Avm_DECLARE_VIEWS(94);
+            using Accumulator = typename std::tuple_element_t<35, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_keccak * (-new_term.main_sel_op_keccak + FF(1)));
+            tmp *= scaling_factor;
+            std::get<35>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<36, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_pedersen * (-new_term.main_sel_op_pedersen + FF(1)));
+            tmp *= scaling_factor;
+            std::get<36>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<37, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_add * (-new_term.main_sel_op_add + FF(1)));
+            tmp *= scaling_factor;
+            std::get<37>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<38, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_sub * (-new_term.main_sel_op_sub + FF(1)));
+            tmp *= scaling_factor;
+            std::get<38>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<39, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_mul * (-new_term.main_sel_op_mul + FF(1)));
+            tmp *= scaling_factor;
+            std::get<39>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<40, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_div * (-new_term.main_sel_op_div + FF(1)));
+            tmp *= scaling_factor;
+            std::get<40>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<41, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_fdiv * (-new_term.main_sel_op_fdiv + FF(1)));
+            tmp *= scaling_factor;
+            std::get<41>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<42, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_not * (-new_term.main_sel_op_not + FF(1)));
+            tmp *= scaling_factor;
+            std::get<42>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<43, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_eq * (-new_term.main_sel_op_eq + FF(1)));
+            tmp *= scaling_factor;
+            std::get<43>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<44, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_and * (-new_term.main_sel_op_and + FF(1)));
+            tmp *= scaling_factor;
+            std::get<44>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<45, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_or * (-new_term.main_sel_op_or + FF(1)));
+            tmp *= scaling_factor;
+            std::get<45>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<46, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_xor * (-new_term.main_sel_op_xor + FF(1)));
+            tmp *= scaling_factor;
+            std::get<46>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<47, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_cast * (-new_term.main_sel_op_cast + FF(1)));
+            tmp *= scaling_factor;
+            std::get<47>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<48, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_lt * (-new_term.main_sel_op_lt + FF(1)));
+            tmp *= scaling_factor;
+            std::get<48>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<49, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_lte * (-new_term.main_sel_op_lte + FF(1)));
+            tmp *= scaling_factor;
+            std::get<49>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<50, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_shl * (-new_term.main_sel_op_shl + FF(1)));
+            tmp *= scaling_factor;
+            std::get<50>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<51, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_shr * (-new_term.main_sel_op_shr + FF(1)));
+            tmp *= scaling_factor;
+            std::get<51>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<52, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_internal_call * (-new_term.main_sel_op_internal_call + FF(1)));
+            tmp *= scaling_factor;
+            std::get<52>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<53, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_internal_return * (-new_term.main_sel_op_internal_return + FF(1)));
+            tmp *= scaling_factor;
+            std::get<53>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<54, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_jump * (-new_term.main_sel_op_jump + FF(1)));
+            tmp *= scaling_factor;
+            std::get<54>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<55, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_jumpi * (-new_term.main_sel_op_jumpi + FF(1)));
+            tmp *= scaling_factor;
+            std::get<55>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<56, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_halt * (-new_term.main_sel_op_halt + FF(1)));
+            tmp *= scaling_factor;
+            std::get<56>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<57, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_external_call * (-new_term.main_sel_op_external_call + FF(1)));
+            tmp *= scaling_factor;
+            std::get<57>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<58, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_calldata_copy * (-new_term.main_sel_op_calldata_copy + FF(1)));
+            tmp *= scaling_factor;
+            std::get<58>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<59, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_external_return * (-new_term.main_sel_op_external_return + FF(1)));
+            tmp *= scaling_factor;
+            std::get<59>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<60, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_mov * (-new_term.main_sel_op_mov + FF(1)));
+            tmp *= scaling_factor;
+            std::get<60>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<61, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_cmov * (-new_term.main_sel_op_cmov + FF(1)));
+            tmp *= scaling_factor;
+            std::get<61>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<62, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_op_err * (-new_term.main_op_err + FF(1)));
+            tmp *= scaling_factor;
+            std::get<62>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<63, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_tag_err * (-new_term.main_tag_err + FF(1)));
+            tmp *= scaling_factor;
+            std::get<63>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<64, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_id_zero * (-new_term.main_id_zero + FF(1)));
+            tmp *= scaling_factor;
+            std::get<64>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<65, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_mem_op_a * (-new_term.main_sel_mem_op_a + FF(1)));
+            tmp *= scaling_factor;
+            std::get<65>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<66, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_mem_op_b * (-new_term.main_sel_mem_op_b + FF(1)));
+            tmp *= scaling_factor;
+            std::get<66>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<67, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_mem_op_c * (-new_term.main_sel_mem_op_c + FF(1)));
+            tmp *= scaling_factor;
+            std::get<67>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<68, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_mem_op_d * (-new_term.main_sel_mem_op_d + FF(1)));
+            tmp *= scaling_factor;
+            std::get<68>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<69, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_rwa * (-new_term.main_rwa + FF(1)));
+            tmp *= scaling_factor;
+            std::get<69>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<70, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_rwb * (-new_term.main_rwb + FF(1)));
+            tmp *= scaling_factor;
+            std::get<70>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<71, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_rwc * (-new_term.main_rwc + FF(1)));
+            tmp *= scaling_factor;
+            std::get<71>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<72, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_rwd * (-new_term.main_rwd + FF(1)));
+            tmp *= scaling_factor;
+            std::get<72>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<73, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_resolve_ind_addr_a * (-new_term.main_sel_resolve_ind_addr_a + FF(1)));
+            tmp *= scaling_factor;
+            std::get<73>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<74, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_resolve_ind_addr_b * (-new_term.main_sel_resolve_ind_addr_b + FF(1)));
+            tmp *= scaling_factor;
+            std::get<74>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<75, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_resolve_ind_addr_c * (-new_term.main_sel_resolve_ind_addr_c + FF(1)));
+            tmp *= scaling_factor;
+            std::get<75>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<76, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_resolve_ind_addr_d * (-new_term.main_sel_resolve_ind_addr_d + FF(1)));
+            tmp *= scaling_factor;
+            std::get<76>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<77, ContainerOverSubrelations>;
+            auto tmp = (((new_term.main_sel_op_eq + new_term.main_sel_op_lte) + new_term.main_sel_op_lt) *
+                        (new_term.main_w_in_tag - FF(1)));
+            tmp *= scaling_factor;
+            std::get<77>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<78, ContainerOverSubrelations>;
+            auto tmp = ((new_term.main_sel_op_fdiv * (-new_term.main_op_err + FF(1))) *
+                        ((new_term.main_ic * new_term.main_ib) - new_term.main_ia));
+            tmp *= scaling_factor;
+            std::get<78>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<79, ContainerOverSubrelations>;
+            auto tmp = ((new_term.main_sel_op_fdiv + new_term.main_sel_op_div) *
+                        (((new_term.main_ib * new_term.main_inv) - FF(1)) + new_term.main_op_err));
+            tmp *= scaling_factor;
+            std::get<79>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<80, ContainerOverSubrelations>;
+            auto tmp = (((new_term.main_sel_op_fdiv + new_term.main_sel_op_div) * new_term.main_op_err) *
+                        (-new_term.main_inv + FF(1)));
+            tmp *= scaling_factor;
+            std::get<80>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<81, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_fdiv * (new_term.main_r_in_tag - FF(6)));
+            tmp *= scaling_factor;
+            std::get<81>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<82, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_fdiv * (new_term.main_w_in_tag - FF(6)));
+            tmp *= scaling_factor;
+            std::get<82>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<83, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_op_err * ((new_term.main_sel_op_fdiv + new_term.main_sel_op_div) - FF(1)));
+            tmp *= scaling_factor;
+            std::get<83>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<84, ContainerOverSubrelations>;
+            auto tmp = ((((((((((((new_term.main_sel_op_address + new_term.main_sel_op_storage_address) +
+                                  new_term.main_sel_op_sender) +
+                                 new_term.main_sel_op_function_selector) +
+                                new_term.main_sel_op_transaction_fee) +
+                               new_term.main_sel_op_chain_id) +
+                              new_term.main_sel_op_version) +
+                             new_term.main_sel_op_block_number) +
+                            new_term.main_sel_op_coinbase) +
+                           new_term.main_sel_op_timestamp) +
+                          new_term.main_sel_op_fee_per_l2_gas) +
+                         new_term.main_sel_op_fee_per_da_gas) *
+                        (-new_term.main_sel_q_kernel_lookup + FF(1)));
+            tmp *= scaling_factor;
+            std::get<84>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<85, ContainerOverSubrelations>;
+            auto tmp = (((((((new_term.main_sel_op_note_hash_exists + new_term.main_sel_op_emit_note_hash) +
+                             new_term.main_sel_op_nullifier_exists) +
+                            new_term.main_sel_op_emit_nullifier) +
+                           new_term.main_sel_op_l1_to_l2_msg_exists) +
+                          new_term.main_sel_op_emit_unencrypted_log) +
+                         new_term.main_sel_op_emit_l2_to_l1_msg) *
+                        (-new_term.main_sel_q_kernel_output_lookup + FF(1)));
+            tmp *= scaling_factor;
+            std::get<85>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<86, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_jump * (new_term.main_pc_shift - new_term.main_ia));
+            tmp *= scaling_factor;
+            std::get<86>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<87, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_jumpi *
+                        (((-new_term.main_id_zero + FF(1)) * (new_term.main_pc_shift - new_term.main_ia)) +
+                         (new_term.main_id_zero * ((new_term.main_pc_shift - new_term.main_pc) - FF(1)))));
+            tmp *= scaling_factor;
+            std::get<87>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<88, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_internal_call *
+                        (new_term.main_internal_return_ptr_shift - (new_term.main_internal_return_ptr + FF(1))));
+            tmp *= scaling_factor;
+            std::get<88>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<89, ContainerOverSubrelations>;
             auto tmp =
-                (main_sel_op_internal_return * (main_internal_return_ptr_shift - (main_internal_return_ptr - FF(1))));
+                (new_term.main_sel_op_internal_call * (new_term.main_internal_return_ptr - new_term.main_mem_addr_b));
             tmp *= scaling_factor;
-            std::get<94>(evals) += tmp;
+            std::get<89>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 95
         {
-            Avm_DECLARE_VIEWS(95);
-            auto tmp = (main_sel_op_internal_return * ((main_internal_return_ptr - FF(1)) - main_mem_addr_a));
+            using Accumulator = typename std::tuple_element_t<90, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_internal_call * (new_term.main_pc_shift - new_term.main_ia));
             tmp *= scaling_factor;
-            std::get<95>(evals) += tmp;
+            std::get<90>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 96
         {
-            Avm_DECLARE_VIEWS(96);
-            auto tmp = (main_sel_op_internal_return * (main_pc_shift - main_ia));
+            using Accumulator = typename std::tuple_element_t<91, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_internal_call * ((new_term.main_pc + FF(1)) - new_term.main_ib));
             tmp *= scaling_factor;
-            std::get<96>(evals) += tmp;
+            std::get<91>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 97
         {
-            Avm_DECLARE_VIEWS(97);
-            auto tmp = (main_sel_op_internal_return * main_rwa);
+            using Accumulator = typename std::tuple_element_t<92, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_internal_call * (new_term.main_rwb - FF(1)));
             tmp *= scaling_factor;
-            std::get<97>(evals) += tmp;
+            std::get<92>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 98
         {
-            Avm_DECLARE_VIEWS(98);
-            auto tmp = (main_sel_op_internal_return * (main_sel_mem_op_a - FF(1)));
+            using Accumulator = typename std::tuple_element_t<93, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_internal_call * (new_term.main_sel_mem_op_b - FF(1)));
             tmp *= scaling_factor;
-            std::get<98>(evals) += tmp;
+            std::get<93>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 99
         {
-            Avm_DECLARE_VIEWS(99);
-            auto tmp = (((((main_sel_gas_accounting_active -
-                            ((((((((main_sel_op_fdiv +
-                                    ((((((((((main_sel_op_add + main_sel_op_sub) + main_sel_op_mul) + main_sel_op_div) +
-                                           main_sel_op_not) +
-                                          main_sel_op_eq) +
-                                         main_sel_op_lt) +
-                                        main_sel_op_lte) +
-                                       main_sel_op_shr) +
-                                      main_sel_op_shl) +
-                                     main_sel_op_cast)) +
-                                   ((main_sel_op_and + main_sel_op_or) + main_sel_op_xor)) +
-                                  (main_sel_op_cmov + main_sel_op_mov)) +
-                                 ((((main_sel_op_radix_le + main_sel_op_sha256) + main_sel_op_poseidon2) +
-                                   main_sel_op_keccak) +
-                                  main_sel_op_pedersen)) +
-                                (((((((((((main_sel_op_address + main_sel_op_storage_address) + main_sel_op_sender) +
-                                         main_sel_op_function_selector) +
-                                        main_sel_op_transaction_fee) +
-                                       main_sel_op_chain_id) +
-                                      main_sel_op_version) +
-                                     main_sel_op_block_number) +
-                                    main_sel_op_coinbase) +
-                                   main_sel_op_timestamp) +
-                                  main_sel_op_fee_per_l2_gas) +
-                                 main_sel_op_fee_per_da_gas)) +
-                               ((((((main_sel_op_note_hash_exists + main_sel_op_emit_note_hash) +
-                                    main_sel_op_nullifier_exists) +
-                                   main_sel_op_emit_nullifier) +
-                                  main_sel_op_l1_to_l2_msg_exists) +
-                                 main_sel_op_emit_unencrypted_log) +
-                                main_sel_op_emit_l2_to_l1_msg)) +
-                              (main_sel_op_dagasleft + main_sel_op_l2gasleft)) +
-                             (main_sel_op_calldata_copy + main_sel_op_external_return))) -
-                           (((main_sel_op_jump + main_sel_op_jumpi) + main_sel_op_internal_call) +
-                            main_sel_op_internal_return)) -
-                          main_sel_op_sload) -
-                         main_sel_op_sstore) -
-                        main_sel_mem_op_activate_gas);
+            using Accumulator = typename std::tuple_element_t<94, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_internal_return *
+                        (new_term.main_internal_return_ptr_shift - (new_term.main_internal_return_ptr - FF(1))));
             tmp *= scaling_factor;
-            std::get<99>(evals) += tmp;
+            std::get<94>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 100
         {
-            Avm_DECLARE_VIEWS(100);
+            using Accumulator = typename std::tuple_element_t<95, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_internal_return *
+                        ((new_term.main_internal_return_ptr - FF(1)) - new_term.main_mem_addr_a));
+            tmp *= scaling_factor;
+            std::get<95>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<96, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_internal_return * (new_term.main_pc_shift - new_term.main_ia));
+            tmp *= scaling_factor;
+            std::get<96>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<97, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_internal_return * new_term.main_rwa);
+            tmp *= scaling_factor;
+            std::get<97>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<98, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_internal_return * (new_term.main_sel_mem_op_a - FF(1)));
+            tmp *= scaling_factor;
+            std::get<98>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<99, ContainerOverSubrelations>;
             auto tmp =
-                ((((-main_sel_first + FF(1)) * (-main_sel_op_halt + FF(1))) *
-                  ((((((((main_sel_op_fdiv +
-                          ((((((((((main_sel_op_add + main_sel_op_sub) + main_sel_op_mul) + main_sel_op_div) +
-                                 main_sel_op_not) +
-                                main_sel_op_eq) +
-                               main_sel_op_lt) +
-                              main_sel_op_lte) +
-                             main_sel_op_shr) +
-                            main_sel_op_shl) +
-                           main_sel_op_cast)) +
-                         ((main_sel_op_and + main_sel_op_or) + main_sel_op_xor)) +
-                        (main_sel_op_cmov + main_sel_op_mov)) +
-                       ((((main_sel_op_radix_le + main_sel_op_sha256) + main_sel_op_poseidon2) + main_sel_op_keccak) +
-                        main_sel_op_pedersen)) +
-                      (((((((((((main_sel_op_address + main_sel_op_storage_address) + main_sel_op_sender) +
-                               main_sel_op_function_selector) +
-                              main_sel_op_transaction_fee) +
-                             main_sel_op_chain_id) +
-                            main_sel_op_version) +
-                           main_sel_op_block_number) +
-                          main_sel_op_coinbase) +
-                         main_sel_op_timestamp) +
-                        main_sel_op_fee_per_l2_gas) +
-                       main_sel_op_fee_per_da_gas)) +
-                     ((((((main_sel_op_note_hash_exists + main_sel_op_emit_note_hash) + main_sel_op_nullifier_exists) +
-                         main_sel_op_emit_nullifier) +
-                        main_sel_op_l1_to_l2_msg_exists) +
-                       main_sel_op_emit_unencrypted_log) +
-                      main_sel_op_emit_l2_to_l1_msg)) +
-                    (main_sel_op_dagasleft + main_sel_op_l2gasleft)) +
-                   (main_sel_op_calldata_copy + main_sel_op_external_return))) *
-                 (main_pc_shift - (main_pc + FF(1))));
+                (((((new_term.main_sel_gas_accounting_active -
+                     ((((((((new_term.main_sel_op_fdiv +
+                             ((((((((((new_term.main_sel_op_add + new_term.main_sel_op_sub) +
+                                      new_term.main_sel_op_mul) +
+                                     new_term.main_sel_op_div) +
+                                    new_term.main_sel_op_not) +
+                                   new_term.main_sel_op_eq) +
+                                  new_term.main_sel_op_lt) +
+                                 new_term.main_sel_op_lte) +
+                                new_term.main_sel_op_shr) +
+                               new_term.main_sel_op_shl) +
+                              new_term.main_sel_op_cast)) +
+                            ((new_term.main_sel_op_and + new_term.main_sel_op_or) + new_term.main_sel_op_xor)) +
+                           (new_term.main_sel_op_cmov + new_term.main_sel_op_mov)) +
+                          ((((new_term.main_sel_op_radix_le + new_term.main_sel_op_sha256) +
+                             new_term.main_sel_op_poseidon2) +
+                            new_term.main_sel_op_keccak) +
+                           new_term.main_sel_op_pedersen)) +
+                         (((((((((((new_term.main_sel_op_address + new_term.main_sel_op_storage_address) +
+                                   new_term.main_sel_op_sender) +
+                                  new_term.main_sel_op_function_selector) +
+                                 new_term.main_sel_op_transaction_fee) +
+                                new_term.main_sel_op_chain_id) +
+                               new_term.main_sel_op_version) +
+                              new_term.main_sel_op_block_number) +
+                             new_term.main_sel_op_coinbase) +
+                            new_term.main_sel_op_timestamp) +
+                           new_term.main_sel_op_fee_per_l2_gas) +
+                          new_term.main_sel_op_fee_per_da_gas)) +
+                        ((((((new_term.main_sel_op_note_hash_exists + new_term.main_sel_op_emit_note_hash) +
+                             new_term.main_sel_op_nullifier_exists) +
+                            new_term.main_sel_op_emit_nullifier) +
+                           new_term.main_sel_op_l1_to_l2_msg_exists) +
+                          new_term.main_sel_op_emit_unencrypted_log) +
+                         new_term.main_sel_op_emit_l2_to_l1_msg)) +
+                       (new_term.main_sel_op_dagasleft + new_term.main_sel_op_l2gasleft)) +
+                      (new_term.main_sel_op_calldata_copy + new_term.main_sel_op_external_return))) -
+                    (((new_term.main_sel_op_jump + new_term.main_sel_op_jumpi) + new_term.main_sel_op_internal_call) +
+                     new_term.main_sel_op_internal_return)) -
+                   new_term.main_sel_op_sload) -
+                  new_term.main_sel_op_sstore) -
+                 new_term.main_sel_mem_op_activate_gas);
             tmp *= scaling_factor;
-            std::get<100>(evals) += tmp;
+            std::get<99>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 101
         {
-            Avm_DECLARE_VIEWS(101);
+            using Accumulator = typename std::tuple_element_t<100, ContainerOverSubrelations>;
             auto tmp =
-                ((-(((main_sel_first + main_sel_op_internal_call) + main_sel_op_internal_return) + main_sel_op_halt) +
-                  FF(1)) *
-                 (main_internal_return_ptr_shift - main_internal_return_ptr));
+                ((((-new_term.main_sel_first + FF(1)) * (-new_term.main_sel_op_halt + FF(1))) *
+                  ((((((((new_term.main_sel_op_fdiv +
+                          ((((((((((new_term.main_sel_op_add + new_term.main_sel_op_sub) + new_term.main_sel_op_mul) +
+                                  new_term.main_sel_op_div) +
+                                 new_term.main_sel_op_not) +
+                                new_term.main_sel_op_eq) +
+                               new_term.main_sel_op_lt) +
+                              new_term.main_sel_op_lte) +
+                             new_term.main_sel_op_shr) +
+                            new_term.main_sel_op_shl) +
+                           new_term.main_sel_op_cast)) +
+                         ((new_term.main_sel_op_and + new_term.main_sel_op_or) + new_term.main_sel_op_xor)) +
+                        (new_term.main_sel_op_cmov + new_term.main_sel_op_mov)) +
+                       ((((new_term.main_sel_op_radix_le + new_term.main_sel_op_sha256) +
+                          new_term.main_sel_op_poseidon2) +
+                         new_term.main_sel_op_keccak) +
+                        new_term.main_sel_op_pedersen)) +
+                      (((((((((((new_term.main_sel_op_address + new_term.main_sel_op_storage_address) +
+                                new_term.main_sel_op_sender) +
+                               new_term.main_sel_op_function_selector) +
+                              new_term.main_sel_op_transaction_fee) +
+                             new_term.main_sel_op_chain_id) +
+                            new_term.main_sel_op_version) +
+                           new_term.main_sel_op_block_number) +
+                          new_term.main_sel_op_coinbase) +
+                         new_term.main_sel_op_timestamp) +
+                        new_term.main_sel_op_fee_per_l2_gas) +
+                       new_term.main_sel_op_fee_per_da_gas)) +
+                     ((((((new_term.main_sel_op_note_hash_exists + new_term.main_sel_op_emit_note_hash) +
+                          new_term.main_sel_op_nullifier_exists) +
+                         new_term.main_sel_op_emit_nullifier) +
+                        new_term.main_sel_op_l1_to_l2_msg_exists) +
+                       new_term.main_sel_op_emit_unencrypted_log) +
+                      new_term.main_sel_op_emit_l2_to_l1_msg)) +
+                    (new_term.main_sel_op_dagasleft + new_term.main_sel_op_l2gasleft)) +
+                   (new_term.main_sel_op_calldata_copy + new_term.main_sel_op_external_return))) *
+                 (new_term.main_pc_shift - (new_term.main_pc + FF(1))));
             tmp *= scaling_factor;
-            std::get<101>(evals) += tmp;
+            std::get<100>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 102
         {
-            Avm_DECLARE_VIEWS(102);
-            auto tmp = ((main_sel_op_internal_call + main_sel_op_internal_return) * (main_space_id - FF(255)));
+            using Accumulator = typename std::tuple_element_t<101, ContainerOverSubrelations>;
+            auto tmp = ((-(((new_term.main_sel_first + new_term.main_sel_op_internal_call) +
+                            new_term.main_sel_op_internal_return) +
+                           new_term.main_sel_op_halt) +
+                         FF(1)) *
+                        (new_term.main_internal_return_ptr_shift - new_term.main_internal_return_ptr));
             tmp *= scaling_factor;
-            std::get<102>(evals) += tmp;
+            std::get<101>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 103
         {
-            Avm_DECLARE_VIEWS(103);
+            using Accumulator = typename std::tuple_element_t<102, ContainerOverSubrelations>;
+            auto tmp = ((new_term.main_sel_op_internal_call + new_term.main_sel_op_internal_return) *
+                        (new_term.main_space_id - FF(255)));
+            tmp *= scaling_factor;
+            std::get<102>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<103, ContainerOverSubrelations>;
             auto tmp =
-                (((((((((main_sel_op_fdiv +
-                         ((((((((((main_sel_op_add + main_sel_op_sub) + main_sel_op_mul) + main_sel_op_div) +
-                                main_sel_op_not) +
-                               main_sel_op_eq) +
-                              main_sel_op_lt) +
-                             main_sel_op_lte) +
-                            main_sel_op_shr) +
-                           main_sel_op_shl) +
-                          main_sel_op_cast)) +
-                        ((main_sel_op_and + main_sel_op_or) + main_sel_op_xor)) +
-                       (main_sel_op_cmov + main_sel_op_mov)) +
-                      ((((main_sel_op_radix_le + main_sel_op_sha256) + main_sel_op_poseidon2) + main_sel_op_keccak) +
-                       main_sel_op_pedersen)) +
-                     (((((((((((main_sel_op_address + main_sel_op_storage_address) + main_sel_op_sender) +
-                              main_sel_op_function_selector) +
-                             main_sel_op_transaction_fee) +
-                            main_sel_op_chain_id) +
-                           main_sel_op_version) +
-                          main_sel_op_block_number) +
-                         main_sel_op_coinbase) +
-                        main_sel_op_timestamp) +
-                       main_sel_op_fee_per_l2_gas) +
-                      main_sel_op_fee_per_da_gas)) +
-                    ((((((main_sel_op_note_hash_exists + main_sel_op_emit_note_hash) + main_sel_op_nullifier_exists) +
-                        main_sel_op_emit_nullifier) +
-                       main_sel_op_l1_to_l2_msg_exists) +
-                      main_sel_op_emit_unencrypted_log) +
-                     main_sel_op_emit_l2_to_l1_msg)) +
-                   (main_sel_op_dagasleft + main_sel_op_l2gasleft)) +
-                  (main_sel_op_calldata_copy + main_sel_op_external_return)) *
-                 (main_call_ptr - main_space_id));
+                (((((((((new_term.main_sel_op_fdiv +
+                         ((((((((((new_term.main_sel_op_add + new_term.main_sel_op_sub) + new_term.main_sel_op_mul) +
+                                 new_term.main_sel_op_div) +
+                                new_term.main_sel_op_not) +
+                               new_term.main_sel_op_eq) +
+                              new_term.main_sel_op_lt) +
+                             new_term.main_sel_op_lte) +
+                            new_term.main_sel_op_shr) +
+                           new_term.main_sel_op_shl) +
+                          new_term.main_sel_op_cast)) +
+                        ((new_term.main_sel_op_and + new_term.main_sel_op_or) + new_term.main_sel_op_xor)) +
+                       (new_term.main_sel_op_cmov + new_term.main_sel_op_mov)) +
+                      ((((new_term.main_sel_op_radix_le + new_term.main_sel_op_sha256) +
+                         new_term.main_sel_op_poseidon2) +
+                        new_term.main_sel_op_keccak) +
+                       new_term.main_sel_op_pedersen)) +
+                     (((((((((((new_term.main_sel_op_address + new_term.main_sel_op_storage_address) +
+                               new_term.main_sel_op_sender) +
+                              new_term.main_sel_op_function_selector) +
+                             new_term.main_sel_op_transaction_fee) +
+                            new_term.main_sel_op_chain_id) +
+                           new_term.main_sel_op_version) +
+                          new_term.main_sel_op_block_number) +
+                         new_term.main_sel_op_coinbase) +
+                        new_term.main_sel_op_timestamp) +
+                       new_term.main_sel_op_fee_per_l2_gas) +
+                      new_term.main_sel_op_fee_per_da_gas)) +
+                    ((((((new_term.main_sel_op_note_hash_exists + new_term.main_sel_op_emit_note_hash) +
+                         new_term.main_sel_op_nullifier_exists) +
+                        new_term.main_sel_op_emit_nullifier) +
+                       new_term.main_sel_op_l1_to_l2_msg_exists) +
+                      new_term.main_sel_op_emit_unencrypted_log) +
+                     new_term.main_sel_op_emit_l2_to_l1_msg)) +
+                   (new_term.main_sel_op_dagasleft + new_term.main_sel_op_l2gasleft)) +
+                  (new_term.main_sel_op_calldata_copy + new_term.main_sel_op_external_return)) *
+                 (new_term.main_call_ptr - new_term.main_space_id));
             tmp *= scaling_factor;
-            std::get<103>(evals) += tmp;
+            std::get<103>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 104
         {
-            Avm_DECLARE_VIEWS(104);
-            auto tmp = ((main_sel_op_cmov + main_sel_op_jumpi) * (((main_id * main_inv) - FF(1)) + main_id_zero));
+            using Accumulator = typename std::tuple_element_t<104, ContainerOverSubrelations>;
+            auto tmp = ((new_term.main_sel_op_cmov + new_term.main_sel_op_jumpi) *
+                        (((new_term.main_id * new_term.main_inv) - FF(1)) + new_term.main_id_zero));
             tmp *= scaling_factor;
-            std::get<104>(evals) += tmp;
+            std::get<104>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 105
         {
-            Avm_DECLARE_VIEWS(105);
-            auto tmp = (((main_sel_op_cmov + main_sel_op_jumpi) * main_id_zero) * (-main_inv + FF(1)));
+            using Accumulator = typename std::tuple_element_t<105, ContainerOverSubrelations>;
+            auto tmp = (((new_term.main_sel_op_cmov + new_term.main_sel_op_jumpi) * new_term.main_id_zero) *
+                        (-new_term.main_inv + FF(1)));
             tmp *= scaling_factor;
-            std::get<105>(evals) += tmp;
+            std::get<105>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 106
         {
-            Avm_DECLARE_VIEWS(106);
-            auto tmp = (main_sel_mov_ia_to_ic - (main_sel_op_mov + (main_sel_op_cmov * (-main_id_zero + FF(1)))));
+            using Accumulator = typename std::tuple_element_t<106, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_mov_ia_to_ic -
+                        (new_term.main_sel_op_mov + (new_term.main_sel_op_cmov * (-new_term.main_id_zero + FF(1)))));
             tmp *= scaling_factor;
-            std::get<106>(evals) += tmp;
+            std::get<106>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 107
         {
-            Avm_DECLARE_VIEWS(107);
-            auto tmp = (main_sel_mov_ib_to_ic - (main_sel_op_cmov * main_id_zero));
+            using Accumulator = typename std::tuple_element_t<107, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_mov_ib_to_ic - (new_term.main_sel_op_cmov * new_term.main_id_zero));
             tmp *= scaling_factor;
-            std::get<107>(evals) += tmp;
+            std::get<107>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 108
         {
-            Avm_DECLARE_VIEWS(108);
-            auto tmp = (main_sel_mov_ia_to_ic * (main_ia - main_ic));
+            using Accumulator = typename std::tuple_element_t<108, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_mov_ia_to_ic * (new_term.main_ia - new_term.main_ic));
             tmp *= scaling_factor;
-            std::get<108>(evals) += tmp;
+            std::get<108>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 109
         {
-            Avm_DECLARE_VIEWS(109);
-            auto tmp = (main_sel_mov_ib_to_ic * (main_ib - main_ic));
+            using Accumulator = typename std::tuple_element_t<109, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_mov_ib_to_ic * (new_term.main_ib - new_term.main_ic));
             tmp *= scaling_factor;
-            std::get<109>(evals) += tmp;
+            std::get<109>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 110
         {
-            Avm_DECLARE_VIEWS(110);
-            auto tmp = ((main_sel_op_mov + main_sel_op_cmov) * (main_r_in_tag - main_w_in_tag));
+            using Accumulator = typename std::tuple_element_t<110, ContainerOverSubrelations>;
+            auto tmp = ((new_term.main_sel_op_mov + new_term.main_sel_op_cmov) *
+                        (new_term.main_r_in_tag - new_term.main_w_in_tag));
             tmp *= scaling_factor;
-            std::get<110>(evals) += tmp;
+            std::get<110>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 111
         {
-            Avm_DECLARE_VIEWS(111);
+            using Accumulator = typename std::tuple_element_t<111, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_alu -
+                        ((((((((((((new_term.main_sel_op_add + new_term.main_sel_op_sub) + new_term.main_sel_op_mul) +
+                                  new_term.main_sel_op_div) +
+                                 new_term.main_sel_op_not) +
+                                new_term.main_sel_op_eq) +
+                               new_term.main_sel_op_lt) +
+                              new_term.main_sel_op_lte) +
+                             new_term.main_sel_op_shr) +
+                            new_term.main_sel_op_shl) +
+                           new_term.main_sel_op_cast) *
+                          (-new_term.main_tag_err + FF(1))) *
+                         (-new_term.main_op_err + FF(1))));
+            tmp *= scaling_factor;
+            std::get<111>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<112, ContainerOverSubrelations>;
+            auto tmp = ((((((((((new_term.main_sel_op_add + new_term.main_sel_op_sub) + new_term.main_sel_op_mul) +
+                               new_term.main_sel_op_div) +
+                              new_term.main_sel_op_not) +
+                             new_term.main_sel_op_eq) +
+                            new_term.main_sel_op_lt) +
+                           new_term.main_sel_op_lte) +
+                          new_term.main_sel_op_shr) +
+                         new_term.main_sel_op_shl) *
+                        (new_term.main_alu_in_tag - new_term.main_r_in_tag));
+            tmp *= scaling_factor;
+            std::get<112>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<113, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_cast * (new_term.main_alu_in_tag - new_term.main_w_in_tag));
+            tmp *= scaling_factor;
+            std::get<113>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<114, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_l2gasleft * (new_term.main_ia - new_term.main_l2_gas_remaining_shift));
+            tmp *= scaling_factor;
+            std::get<114>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<115, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_dagasleft * (new_term.main_ia - new_term.main_da_gas_remaining_shift));
+            tmp *= scaling_factor;
+            std::get<115>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<116, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_address * (new_term.kernel_kernel_in_offset - FF(1)));
+            tmp *= scaling_factor;
+            std::get<116>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<117, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_storage_address * (new_term.kernel_kernel_in_offset - FF(1)));
+            tmp *= scaling_factor;
+            std::get<117>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<118, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_sender * new_term.kernel_kernel_in_offset);
+            tmp *= scaling_factor;
+            std::get<118>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<119, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_function_selector * (new_term.kernel_kernel_in_offset - FF(2)));
+            tmp *= scaling_factor;
+            std::get<119>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<120, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_transaction_fee * (new_term.kernel_kernel_in_offset - FF(39)));
+            tmp *= scaling_factor;
+            std::get<120>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<121, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_chain_id * (new_term.kernel_kernel_in_offset - FF(28)));
+            tmp *= scaling_factor;
+            std::get<121>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<122, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_version * (new_term.kernel_kernel_in_offset - FF(29)));
+            tmp *= scaling_factor;
+            std::get<122>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<123, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_block_number * (new_term.kernel_kernel_in_offset - FF(30)));
+            tmp *= scaling_factor;
+            std::get<123>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<124, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_timestamp * (new_term.kernel_kernel_in_offset - FF(31)));
+            tmp *= scaling_factor;
+            std::get<124>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<125, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_coinbase * (new_term.kernel_kernel_in_offset - FF(32)));
+            tmp *= scaling_factor;
+            std::get<125>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<126, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_fee_per_da_gas * (new_term.kernel_kernel_in_offset - FF(34)));
+            tmp *= scaling_factor;
+            std::get<126>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<127, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_fee_per_l2_gas * (new_term.kernel_kernel_in_offset - FF(35)));
+            tmp *= scaling_factor;
+            std::get<127>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<128, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_note_hash_exists *
+                        (new_term.kernel_kernel_out_offset - (new_term.kernel_note_hash_exist_write_offset + FF(0))));
+            tmp *= scaling_factor;
+            std::get<128>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<129, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_first * new_term.kernel_note_hash_exist_write_offset);
+            tmp *= scaling_factor;
+            std::get<129>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<130, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_emit_note_hash *
+                        (new_term.kernel_kernel_out_offset - (new_term.kernel_emit_note_hash_write_offset + FF(128))));
+            tmp *= scaling_factor;
+            std::get<130>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<131, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_first * new_term.kernel_emit_note_hash_write_offset);
+            tmp *= scaling_factor;
+            std::get<131>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<132, ContainerOverSubrelations>;
             auto tmp =
-                (main_sel_alu - ((((((((((((main_sel_op_add + main_sel_op_sub) + main_sel_op_mul) + main_sel_op_div) +
-                                         main_sel_op_not) +
-                                        main_sel_op_eq) +
-                                       main_sel_op_lt) +
-                                      main_sel_op_lte) +
-                                     main_sel_op_shr) +
-                                    main_sel_op_shl) +
-                                   main_sel_op_cast) *
-                                  (-main_tag_err + FF(1))) *
-                                 (-main_op_err + FF(1))));
+                (new_term.main_sel_op_nullifier_exists *
+                 (new_term.kernel_kernel_out_offset -
+                  ((new_term.main_ib * (new_term.kernel_nullifier_exists_write_offset + FF(16))) +
+                   ((-new_term.main_ib + FF(1)) * (new_term.kernel_nullifier_non_exists_write_offset + FF(32))))));
             tmp *= scaling_factor;
-            std::get<111>(evals) += tmp;
+            std::get<132>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 112
         {
-            Avm_DECLARE_VIEWS(112);
+            using Accumulator = typename std::tuple_element_t<133, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_first * new_term.kernel_nullifier_exists_write_offset);
+            tmp *= scaling_factor;
+            std::get<133>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<134, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_first * new_term.kernel_nullifier_non_exists_write_offset);
+            tmp *= scaling_factor;
+            std::get<134>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<135, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_emit_nullifier *
+                        (new_term.kernel_kernel_out_offset - (new_term.kernel_emit_nullifier_write_offset + FF(144))));
+            tmp *= scaling_factor;
+            std::get<135>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<136, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_first * new_term.kernel_emit_nullifier_write_offset);
+            tmp *= scaling_factor;
+            std::get<136>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<137, ContainerOverSubrelations>;
             auto tmp =
-                ((((((((((main_sel_op_add + main_sel_op_sub) + main_sel_op_mul) + main_sel_op_div) + main_sel_op_not) +
-                      main_sel_op_eq) +
-                     main_sel_op_lt) +
-                    main_sel_op_lte) +
-                   main_sel_op_shr) +
-                  main_sel_op_shl) *
-                 (main_alu_in_tag - main_r_in_tag));
+                (new_term.main_sel_op_l1_to_l2_msg_exists *
+                 (new_term.kernel_kernel_out_offset - (new_term.kernel_l1_to_l2_msg_exists_write_offset + FF(48))));
             tmp *= scaling_factor;
-            std::get<112>(evals) += tmp;
+            std::get<137>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 113
         {
-            Avm_DECLARE_VIEWS(113);
-            auto tmp = (main_sel_op_cast * (main_alu_in_tag - main_w_in_tag));
+            using Accumulator = typename std::tuple_element_t<138, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_first * new_term.kernel_l1_to_l2_msg_exists_write_offset);
             tmp *= scaling_factor;
-            std::get<113>(evals) += tmp;
+            std::get<138>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 114
         {
-            Avm_DECLARE_VIEWS(114);
-            auto tmp = (main_sel_op_l2gasleft * (main_ia - main_l2_gas_remaining_shift));
-            tmp *= scaling_factor;
-            std::get<114>(evals) += tmp;
-        }
-        // Contribution 115
-        {
-            Avm_DECLARE_VIEWS(115);
-            auto tmp = (main_sel_op_dagasleft * (main_ia - main_da_gas_remaining_shift));
-            tmp *= scaling_factor;
-            std::get<115>(evals) += tmp;
-        }
-        // Contribution 116
-        {
-            Avm_DECLARE_VIEWS(116);
-            auto tmp = (main_sel_op_address * (kernel_kernel_in_offset - FF(1)));
-            tmp *= scaling_factor;
-            std::get<116>(evals) += tmp;
-        }
-        // Contribution 117
-        {
-            Avm_DECLARE_VIEWS(117);
-            auto tmp = (main_sel_op_storage_address * (kernel_kernel_in_offset - FF(1)));
-            tmp *= scaling_factor;
-            std::get<117>(evals) += tmp;
-        }
-        // Contribution 118
-        {
-            Avm_DECLARE_VIEWS(118);
-            auto tmp = (main_sel_op_sender * kernel_kernel_in_offset);
-            tmp *= scaling_factor;
-            std::get<118>(evals) += tmp;
-        }
-        // Contribution 119
-        {
-            Avm_DECLARE_VIEWS(119);
-            auto tmp = (main_sel_op_function_selector * (kernel_kernel_in_offset - FF(2)));
-            tmp *= scaling_factor;
-            std::get<119>(evals) += tmp;
-        }
-        // Contribution 120
-        {
-            Avm_DECLARE_VIEWS(120);
-            auto tmp = (main_sel_op_transaction_fee * (kernel_kernel_in_offset - FF(39)));
-            tmp *= scaling_factor;
-            std::get<120>(evals) += tmp;
-        }
-        // Contribution 121
-        {
-            Avm_DECLARE_VIEWS(121);
-            auto tmp = (main_sel_op_chain_id * (kernel_kernel_in_offset - FF(28)));
-            tmp *= scaling_factor;
-            std::get<121>(evals) += tmp;
-        }
-        // Contribution 122
-        {
-            Avm_DECLARE_VIEWS(122);
-            auto tmp = (main_sel_op_version * (kernel_kernel_in_offset - FF(29)));
-            tmp *= scaling_factor;
-            std::get<122>(evals) += tmp;
-        }
-        // Contribution 123
-        {
-            Avm_DECLARE_VIEWS(123);
-            auto tmp = (main_sel_op_block_number * (kernel_kernel_in_offset - FF(30)));
-            tmp *= scaling_factor;
-            std::get<123>(evals) += tmp;
-        }
-        // Contribution 124
-        {
-            Avm_DECLARE_VIEWS(124);
-            auto tmp = (main_sel_op_timestamp * (kernel_kernel_in_offset - FF(31)));
-            tmp *= scaling_factor;
-            std::get<124>(evals) += tmp;
-        }
-        // Contribution 125
-        {
-            Avm_DECLARE_VIEWS(125);
-            auto tmp = (main_sel_op_coinbase * (kernel_kernel_in_offset - FF(32)));
-            tmp *= scaling_factor;
-            std::get<125>(evals) += tmp;
-        }
-        // Contribution 126
-        {
-            Avm_DECLARE_VIEWS(126);
-            auto tmp = (main_sel_op_fee_per_da_gas * (kernel_kernel_in_offset - FF(34)));
-            tmp *= scaling_factor;
-            std::get<126>(evals) += tmp;
-        }
-        // Contribution 127
-        {
-            Avm_DECLARE_VIEWS(127);
-            auto tmp = (main_sel_op_fee_per_l2_gas * (kernel_kernel_in_offset - FF(35)));
-            tmp *= scaling_factor;
-            std::get<127>(evals) += tmp;
-        }
-        // Contribution 128
-        {
-            Avm_DECLARE_VIEWS(128);
-            auto tmp = (main_sel_op_note_hash_exists *
-                        (kernel_kernel_out_offset - (kernel_note_hash_exist_write_offset + FF(0))));
-            tmp *= scaling_factor;
-            std::get<128>(evals) += tmp;
-        }
-        // Contribution 129
-        {
-            Avm_DECLARE_VIEWS(129);
-            auto tmp = (main_sel_first * kernel_note_hash_exist_write_offset);
-            tmp *= scaling_factor;
-            std::get<129>(evals) += tmp;
-        }
-        // Contribution 130
-        {
-            Avm_DECLARE_VIEWS(130);
-            auto tmp = (main_sel_op_emit_note_hash *
-                        (kernel_kernel_out_offset - (kernel_emit_note_hash_write_offset + FF(128))));
-            tmp *= scaling_factor;
-            std::get<130>(evals) += tmp;
-        }
-        // Contribution 131
-        {
-            Avm_DECLARE_VIEWS(131);
-            auto tmp = (main_sel_first * kernel_emit_note_hash_write_offset);
-            tmp *= scaling_factor;
-            std::get<131>(evals) += tmp;
-        }
-        // Contribution 132
-        {
-            Avm_DECLARE_VIEWS(132);
-            auto tmp = (main_sel_op_nullifier_exists *
-                        (kernel_kernel_out_offset -
-                         ((main_ib * (kernel_nullifier_exists_write_offset + FF(16))) +
-                          ((-main_ib + FF(1)) * (kernel_nullifier_non_exists_write_offset + FF(32))))));
-            tmp *= scaling_factor;
-            std::get<132>(evals) += tmp;
-        }
-        // Contribution 133
-        {
-            Avm_DECLARE_VIEWS(133);
-            auto tmp = (main_sel_first * kernel_nullifier_exists_write_offset);
-            tmp *= scaling_factor;
-            std::get<133>(evals) += tmp;
-        }
-        // Contribution 134
-        {
-            Avm_DECLARE_VIEWS(134);
-            auto tmp = (main_sel_first * kernel_nullifier_non_exists_write_offset);
-            tmp *= scaling_factor;
-            std::get<134>(evals) += tmp;
-        }
-        // Contribution 135
-        {
-            Avm_DECLARE_VIEWS(135);
-            auto tmp = (main_sel_op_emit_nullifier *
-                        (kernel_kernel_out_offset - (kernel_emit_nullifier_write_offset + FF(144))));
-            tmp *= scaling_factor;
-            std::get<135>(evals) += tmp;
-        }
-        // Contribution 136
-        {
-            Avm_DECLARE_VIEWS(136);
-            auto tmp = (main_sel_first * kernel_emit_nullifier_write_offset);
-            tmp *= scaling_factor;
-            std::get<136>(evals) += tmp;
-        }
-        // Contribution 137
-        {
-            Avm_DECLARE_VIEWS(137);
-            auto tmp = (main_sel_op_l1_to_l2_msg_exists *
-                        (kernel_kernel_out_offset - (kernel_l1_to_l2_msg_exists_write_offset + FF(48))));
-            tmp *= scaling_factor;
-            std::get<137>(evals) += tmp;
-        }
-        // Contribution 138
-        {
-            Avm_DECLARE_VIEWS(138);
-            auto tmp = (main_sel_first * kernel_l1_to_l2_msg_exists_write_offset);
-            tmp *= scaling_factor;
-            std::get<138>(evals) += tmp;
-        }
-        // Contribution 139
-        {
-            Avm_DECLARE_VIEWS(139);
-            auto tmp = (main_sel_op_emit_unencrypted_log *
-                        (kernel_kernel_out_offset - (kernel_emit_unencrypted_log_write_offset + FF(162))));
-            tmp *= scaling_factor;
-            std::get<139>(evals) += tmp;
-        }
-        // Contribution 140
-        {
-            Avm_DECLARE_VIEWS(140);
-            auto tmp = (main_sel_first * kernel_emit_unencrypted_log_write_offset);
-            tmp *= scaling_factor;
-            std::get<140>(evals) += tmp;
-        }
-        // Contribution 141
-        {
-            Avm_DECLARE_VIEWS(141);
-            auto tmp = (main_sel_op_emit_l2_to_l1_msg *
-                        (kernel_kernel_out_offset - (kernel_emit_l2_to_l1_msg_write_offset + FF(160))));
-            tmp *= scaling_factor;
-            std::get<141>(evals) += tmp;
-        }
-        // Contribution 142
-        {
-            Avm_DECLARE_VIEWS(142);
-            auto tmp = (main_sel_first * kernel_emit_l2_to_l1_msg_write_offset);
-            tmp *= scaling_factor;
-            std::get<142>(evals) += tmp;
-        }
-        // Contribution 143
-        {
-            Avm_DECLARE_VIEWS(143);
-            auto tmp = (main_sel_op_sload * (kernel_kernel_out_offset - (kernel_sload_write_offset + FF(96))));
-            tmp *= scaling_factor;
-            std::get<143>(evals) += tmp;
-        }
-        // Contribution 144
-        {
-            Avm_DECLARE_VIEWS(144);
-            auto tmp = (main_sel_first * kernel_sload_write_offset);
-            tmp *= scaling_factor;
-            std::get<144>(evals) += tmp;
-        }
-        // Contribution 145
-        {
-            Avm_DECLARE_VIEWS(145);
-            auto tmp = (main_sel_op_sstore * (kernel_kernel_out_offset - (kernel_sstore_write_offset + FF(64))));
-            tmp *= scaling_factor;
-            std::get<145>(evals) += tmp;
-        }
-        // Contribution 146
-        {
-            Avm_DECLARE_VIEWS(146);
-            auto tmp = (main_sel_first * kernel_sstore_write_offset);
-            tmp *= scaling_factor;
-            std::get<146>(evals) += tmp;
-        }
-        // Contribution 147
-        {
-            Avm_DECLARE_VIEWS(147);
+            using Accumulator = typename std::tuple_element_t<139, ContainerOverSubrelations>;
             auto tmp =
-                (((((((main_sel_op_note_hash_exists + main_sel_op_emit_note_hash) + main_sel_op_nullifier_exists) +
-                     main_sel_op_emit_nullifier) +
-                    main_sel_op_l1_to_l2_msg_exists) +
-                   main_sel_op_emit_unencrypted_log) +
-                  main_sel_op_emit_l2_to_l1_msg) *
-                 (kernel_side_effect_counter_shift - (kernel_side_effect_counter + FF(1))));
+                (new_term.main_sel_op_emit_unencrypted_log *
+                 (new_term.kernel_kernel_out_offset - (new_term.kernel_emit_unencrypted_log_write_offset + FF(162))));
             tmp *= scaling_factor;
-            std::get<147>(evals) += tmp;
+            std::get<139>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 148
         {
-            Avm_DECLARE_VIEWS(148);
-            auto tmp = (main_sel_slice_gadget -
-                        ((main_sel_op_calldata_copy + main_sel_op_external_return) * (-main_tag_err + FF(1))));
+            using Accumulator = typename std::tuple_element_t<140, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_first * new_term.kernel_emit_unencrypted_log_write_offset);
             tmp *= scaling_factor;
-            std::get<148>(evals) += tmp;
+            std::get<140>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 149
         {
-            Avm_DECLARE_VIEWS(149);
-            auto tmp = (main_bin_op_id - (main_sel_op_or + (main_sel_op_xor * FF(2))));
+            using Accumulator = typename std::tuple_element_t<141, ContainerOverSubrelations>;
+            auto tmp =
+                (new_term.main_sel_op_emit_l2_to_l1_msg *
+                 (new_term.kernel_kernel_out_offset - (new_term.kernel_emit_l2_to_l1_msg_write_offset + FF(160))));
             tmp *= scaling_factor;
-            std::get<149>(evals) += tmp;
+            std::get<141>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 150
         {
-            Avm_DECLARE_VIEWS(150);
-            auto tmp = (main_sel_bin - ((main_sel_op_and + main_sel_op_or) + main_sel_op_xor));
+            using Accumulator = typename std::tuple_element_t<142, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_first * new_term.kernel_emit_l2_to_l1_msg_write_offset);
             tmp *= scaling_factor;
-            std::get<150>(evals) += tmp;
+            std::get<142>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<143, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_sload *
+                        (new_term.kernel_kernel_out_offset - (new_term.kernel_sload_write_offset + FF(96))));
+            tmp *= scaling_factor;
+            std::get<143>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<144, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_first * new_term.kernel_sload_write_offset);
+            tmp *= scaling_factor;
+            std::get<144>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<145, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_op_sstore *
+                        (new_term.kernel_kernel_out_offset - (new_term.kernel_sstore_write_offset + FF(64))));
+            tmp *= scaling_factor;
+            std::get<145>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<146, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_first * new_term.kernel_sstore_write_offset);
+            tmp *= scaling_factor;
+            std::get<146>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<147, ContainerOverSubrelations>;
+            auto tmp = (((((((new_term.main_sel_op_note_hash_exists + new_term.main_sel_op_emit_note_hash) +
+                             new_term.main_sel_op_nullifier_exists) +
+                            new_term.main_sel_op_emit_nullifier) +
+                           new_term.main_sel_op_l1_to_l2_msg_exists) +
+                          new_term.main_sel_op_emit_unencrypted_log) +
+                         new_term.main_sel_op_emit_l2_to_l1_msg) *
+                        (new_term.kernel_side_effect_counter_shift - (new_term.kernel_side_effect_counter + FF(1))));
+            tmp *= scaling_factor;
+            std::get<147>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<148, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_slice_gadget -
+                        ((new_term.main_sel_op_calldata_copy + new_term.main_sel_op_external_return) *
+                         (-new_term.main_tag_err + FF(1))));
+            tmp *= scaling_factor;
+            std::get<148>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<149, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_bin_op_id - (new_term.main_sel_op_or + (new_term.main_sel_op_xor * FF(2))));
+            tmp *= scaling_factor;
+            std::get<149>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<150, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_bin -
+                        ((new_term.main_sel_op_and + new_term.main_sel_op_or) + new_term.main_sel_op_xor));
+            tmp *= scaling_factor;
+            std::get<150>(evals) += typename Accumulator::View(tmp);
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/mem.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/mem.hpp
@@ -103,338 +103,302 @@ template <typename FF_> class memImpl {
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        // Contribution 0
         {
-            Avm_DECLARE_VIEWS(0);
-            auto tmp = (mem_lastAccess * (-mem_lastAccess + FF(1)));
+            using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_lastAccess * (-new_term.mem_lastAccess + FF(1)));
             tmp *= scaling_factor;
-            std::get<0>(evals) += tmp;
+            std::get<0>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 1
         {
-            Avm_DECLARE_VIEWS(1);
-            auto tmp = (mem_last * (-mem_last + FF(1)));
+            using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_last * (-new_term.mem_last + FF(1)));
             tmp *= scaling_factor;
-            std::get<1>(evals) += tmp;
+            std::get<1>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 2
         {
-            Avm_DECLARE_VIEWS(2);
-            auto tmp = (mem_rw * (-mem_rw + FF(1)));
+            using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_rw * (-new_term.mem_rw + FF(1)));
             tmp *= scaling_factor;
-            std::get<2>(evals) += tmp;
+            std::get<2>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 3
         {
-            Avm_DECLARE_VIEWS(3);
-            auto tmp = (mem_tag_err * (-mem_tag_err + FF(1)));
+            using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_tag_err * (-new_term.mem_tag_err + FF(1)));
             tmp *= scaling_factor;
-            std::get<3>(evals) += tmp;
+            std::get<3>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 4
         {
-            Avm_DECLARE_VIEWS(4);
-            auto tmp = (mem_sel_op_a * (-mem_sel_op_a + FF(1)));
+            using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_op_a * (-new_term.mem_sel_op_a + FF(1)));
             tmp *= scaling_factor;
-            std::get<4>(evals) += tmp;
+            std::get<4>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 5
         {
-            Avm_DECLARE_VIEWS(5);
-            auto tmp = (mem_sel_op_b * (-mem_sel_op_b + FF(1)));
+            using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_op_b * (-new_term.mem_sel_op_b + FF(1)));
             tmp *= scaling_factor;
-            std::get<5>(evals) += tmp;
+            std::get<5>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 6
         {
-            Avm_DECLARE_VIEWS(6);
-            auto tmp = (mem_sel_op_c * (-mem_sel_op_c + FF(1)));
+            using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_op_c * (-new_term.mem_sel_op_c + FF(1)));
             tmp *= scaling_factor;
-            std::get<6>(evals) += tmp;
+            std::get<6>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 7
         {
-            Avm_DECLARE_VIEWS(7);
-            auto tmp = (mem_sel_op_d * (-mem_sel_op_d + FF(1)));
+            using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_op_d * (-new_term.mem_sel_op_d + FF(1)));
             tmp *= scaling_factor;
-            std::get<7>(evals) += tmp;
+            std::get<7>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 8
         {
-            Avm_DECLARE_VIEWS(8);
-            auto tmp = (mem_sel_op_slice * (-mem_sel_op_slice + FF(1)));
+            using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_op_slice * (-new_term.mem_sel_op_slice + FF(1)));
             tmp *= scaling_factor;
-            std::get<8>(evals) += tmp;
+            std::get<8>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 9
         {
-            Avm_DECLARE_VIEWS(9);
-            auto tmp = (mem_sel_resolve_ind_addr_a * (-mem_sel_resolve_ind_addr_a + FF(1)));
+            using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_resolve_ind_addr_a * (-new_term.mem_sel_resolve_ind_addr_a + FF(1)));
             tmp *= scaling_factor;
-            std::get<9>(evals) += tmp;
+            std::get<9>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 10
         {
-            Avm_DECLARE_VIEWS(10);
-            auto tmp = (mem_sel_resolve_ind_addr_b * (-mem_sel_resolve_ind_addr_b + FF(1)));
+            using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_resolve_ind_addr_b * (-new_term.mem_sel_resolve_ind_addr_b + FF(1)));
             tmp *= scaling_factor;
-            std::get<10>(evals) += tmp;
+            std::get<10>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 11
         {
-            Avm_DECLARE_VIEWS(11);
-            auto tmp = (mem_sel_resolve_ind_addr_c * (-mem_sel_resolve_ind_addr_c + FF(1)));
+            using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_resolve_ind_addr_c * (-new_term.mem_sel_resolve_ind_addr_c + FF(1)));
             tmp *= scaling_factor;
-            std::get<11>(evals) += tmp;
+            std::get<11>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 12
         {
-            Avm_DECLARE_VIEWS(12);
-            auto tmp = (mem_sel_resolve_ind_addr_d * (-mem_sel_resolve_ind_addr_d + FF(1)));
+            using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_resolve_ind_addr_d * (-new_term.mem_sel_resolve_ind_addr_d + FF(1)));
             tmp *= scaling_factor;
-            std::get<12>(evals) += tmp;
+            std::get<12>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 13
         {
-            Avm_DECLARE_VIEWS(13);
+            using Accumulator = typename std::tuple_element_t<13, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_mem -
+                        ((((((((new_term.mem_sel_op_a + new_term.mem_sel_op_b) + new_term.mem_sel_op_c) +
+                              new_term.mem_sel_op_d) +
+                             new_term.mem_sel_resolve_ind_addr_a) +
+                            new_term.mem_sel_resolve_ind_addr_b) +
+                           new_term.mem_sel_resolve_ind_addr_c) +
+                          new_term.mem_sel_resolve_ind_addr_d) +
+                         new_term.mem_sel_op_slice));
+            tmp *= scaling_factor;
+            std::get<13>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<14, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_mem * (new_term.mem_sel_mem - FF(1)));
+            tmp *= scaling_factor;
+            std::get<14>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<15, ContainerOverSubrelations>;
             auto tmp =
-                (mem_sel_mem -
-                 ((((((((mem_sel_op_a + mem_sel_op_b) + mem_sel_op_c) + mem_sel_op_d) + mem_sel_resolve_ind_addr_a) +
-                     mem_sel_resolve_ind_addr_b) +
-                    mem_sel_resolve_ind_addr_c) +
-                   mem_sel_resolve_ind_addr_d) +
-                  mem_sel_op_slice));
+                (((-new_term.main_sel_first + FF(1)) * new_term.mem_sel_mem_shift) * (-new_term.mem_sel_mem + FF(1)));
             tmp *= scaling_factor;
-            std::get<13>(evals) += tmp;
+            std::get<15>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 14
         {
-            Avm_DECLARE_VIEWS(14);
-            auto tmp = (mem_sel_mem * (mem_sel_mem - FF(1)));
+            using Accumulator = typename std::tuple_element_t<16, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_first * new_term.mem_sel_mem);
             tmp *= scaling_factor;
-            std::get<14>(evals) += tmp;
+            std::get<16>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 15
         {
-            Avm_DECLARE_VIEWS(15);
-            auto tmp = (((-main_sel_first + FF(1)) * mem_sel_mem_shift) * (-mem_sel_mem + FF(1)));
+            using Accumulator = typename std::tuple_element_t<17, ContainerOverSubrelations>;
+            auto tmp = (((-new_term.mem_last + FF(1)) * new_term.mem_sel_mem) * (-new_term.mem_sel_mem_shift + FF(1)));
             tmp *= scaling_factor;
-            std::get<15>(evals) += tmp;
+            std::get<17>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 16
         {
-            Avm_DECLARE_VIEWS(16);
-            auto tmp = (main_sel_first * mem_sel_mem);
+            using Accumulator = typename std::tuple_element_t<18, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_rng_chk - (new_term.mem_sel_mem * (-new_term.mem_last + FF(1))));
             tmp *= scaling_factor;
-            std::get<16>(evals) += tmp;
+            std::get<18>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 17
         {
-            Avm_DECLARE_VIEWS(17);
-            auto tmp = (((-mem_last + FF(1)) * mem_sel_mem) * (-mem_sel_mem_shift + FF(1)));
+            using Accumulator = typename std::tuple_element_t<19, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_tsp -
+                        ((new_term.mem_clk * FF(12)) +
+                         (new_term.mem_sel_mem *
+                          ((((new_term.mem_sel_resolve_ind_addr_b + new_term.mem_sel_op_b) +
+                             ((new_term.mem_sel_resolve_ind_addr_c + new_term.mem_sel_op_c) * FF(2))) +
+                            ((new_term.mem_sel_resolve_ind_addr_d + new_term.mem_sel_op_d) * FF(3))) +
+                           (((-(((new_term.mem_sel_resolve_ind_addr_a + new_term.mem_sel_resolve_ind_addr_b) +
+                                 new_term.mem_sel_resolve_ind_addr_c) +
+                                new_term.mem_sel_resolve_ind_addr_d) +
+                              FF(1)) +
+                             new_term.mem_rw) *
+                            FF(4))))));
             tmp *= scaling_factor;
-            std::get<17>(evals) += tmp;
+            std::get<19>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 18
         {
-            Avm_DECLARE_VIEWS(18);
-            auto tmp = (mem_sel_rng_chk - (mem_sel_mem * (-mem_last + FF(1))));
+            using Accumulator = typename std::tuple_element_t<20, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_glob_addr - ((new_term.mem_space_id * FF(4294967296UL)) + new_term.mem_addr));
             tmp *= scaling_factor;
-            std::get<18>(evals) += tmp;
+            std::get<20>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 19
         {
-            Avm_DECLARE_VIEWS(19);
+            using Accumulator = typename std::tuple_element_t<21, ContainerOverSubrelations>;
+            auto tmp = (new_term.main_sel_first * (-new_term.mem_lastAccess + FF(1)));
+            tmp *= scaling_factor;
+            std::get<21>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<22, ContainerOverSubrelations>;
+            auto tmp = ((-new_term.mem_lastAccess + FF(1)) * (new_term.mem_glob_addr_shift - new_term.mem_glob_addr));
+            tmp *= scaling_factor;
+            std::get<22>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<23, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_rng_chk *
+                        (((((new_term.mem_lastAccess * (new_term.mem_glob_addr_shift - new_term.mem_glob_addr)) +
+                            ((-new_term.mem_lastAccess + FF(1)) * (new_term.mem_tsp_shift - new_term.mem_tsp))) -
+                           (new_term.mem_diff_hi * FF(4294967296UL))) -
+                          (new_term.mem_diff_mid * FF(65536))) -
+                         new_term.mem_diff_lo));
+            tmp *= scaling_factor;
+            std::get<23>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<24, ContainerOverSubrelations>;
+            auto tmp = (((-new_term.mem_lastAccess + FF(1)) * (-new_term.mem_rw_shift + FF(1))) *
+                        (new_term.mem_val_shift - new_term.mem_val));
+            tmp *= scaling_factor;
+            std::get<24>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<25, ContainerOverSubrelations>;
+            auto tmp = (((-new_term.mem_lastAccess + FF(1)) * (-new_term.mem_rw_shift + FF(1))) *
+                        (new_term.mem_tag_shift - new_term.mem_tag));
+            tmp *= scaling_factor;
+            std::get<25>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<26, ContainerOverSubrelations>;
+            auto tmp = ((new_term.mem_lastAccess * (-new_term.mem_rw_shift + FF(1))) * new_term.mem_val_shift);
+            tmp *= scaling_factor;
+            std::get<26>(evals) += typename Accumulator::View(tmp);
+        }
+        {
+            using Accumulator = typename std::tuple_element_t<27, ContainerOverSubrelations>;
             auto tmp =
-                (mem_tsp -
-                 ((mem_clk * FF(12)) +
-                  (mem_sel_mem *
-                   ((((mem_sel_resolve_ind_addr_b + mem_sel_op_b) +
-                      ((mem_sel_resolve_ind_addr_c + mem_sel_op_c) * FF(2))) +
-                     ((mem_sel_resolve_ind_addr_d + mem_sel_op_d) * FF(3))) +
-                    (((-(((mem_sel_resolve_ind_addr_a + mem_sel_resolve_ind_addr_b) + mem_sel_resolve_ind_addr_c) +
-                         mem_sel_resolve_ind_addr_d) +
-                       FF(1)) +
-                      mem_rw) *
-                     FF(4))))));
+                (new_term.mem_skip_check_tag -
+                 ((new_term.mem_sel_op_cmov *
+                   ((new_term.mem_sel_op_d + (new_term.mem_sel_op_a * (-new_term.mem_sel_mov_ia_to_ic + FF(1)))) +
+                    (new_term.mem_sel_op_b * (-new_term.mem_sel_mov_ib_to_ic + FF(1))))) +
+                  new_term.mem_sel_op_slice));
             tmp *= scaling_factor;
-            std::get<19>(evals) += tmp;
+            std::get<27>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 20
         {
-            Avm_DECLARE_VIEWS(20);
-            auto tmp = (mem_glob_addr - ((mem_space_id * FF(4294967296UL)) + mem_addr));
+            using Accumulator = typename std::tuple_element_t<28, ContainerOverSubrelations>;
+            auto tmp = (((new_term.mem_tag * (-new_term.mem_skip_check_tag + FF(1))) * (-new_term.mem_rw + FF(1))) *
+                        (((new_term.mem_r_in_tag - new_term.mem_tag) * (-new_term.mem_one_min_inv + FF(1))) -
+                         new_term.mem_tag_err));
             tmp *= scaling_factor;
-            std::get<20>(evals) += tmp;
+            std::get<28>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 21
         {
-            Avm_DECLARE_VIEWS(21);
-            auto tmp = (main_sel_first * (-mem_lastAccess + FF(1)));
+            using Accumulator = typename std::tuple_element_t<29, ContainerOverSubrelations>;
+            auto tmp = ((new_term.mem_tag * (-new_term.mem_tag_err + FF(1))) * new_term.mem_one_min_inv);
             tmp *= scaling_factor;
-            std::get<21>(evals) += tmp;
+            std::get<29>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 22
         {
-            Avm_DECLARE_VIEWS(22);
-            auto tmp = ((-mem_lastAccess + FF(1)) * (mem_glob_addr_shift - mem_glob_addr));
+            using Accumulator = typename std::tuple_element_t<30, ContainerOverSubrelations>;
+            auto tmp = ((new_term.mem_skip_check_tag + new_term.mem_rw) * new_term.mem_tag_err);
             tmp *= scaling_factor;
-            std::get<22>(evals) += tmp;
+            std::get<30>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 23
         {
-            Avm_DECLARE_VIEWS(23);
-            auto tmp = (mem_sel_rng_chk * (((((mem_lastAccess * (mem_glob_addr_shift - mem_glob_addr)) +
-                                              ((-mem_lastAccess + FF(1)) * (mem_tsp_shift - mem_tsp))) -
-                                             (mem_diff_hi * FF(4294967296UL))) -
-                                            (mem_diff_mid * FF(65536))) -
-                                           mem_diff_lo));
+            using Accumulator = typename std::tuple_element_t<31, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_rw * (new_term.mem_w_in_tag - new_term.mem_tag));
             tmp *= scaling_factor;
-            std::get<23>(evals) += tmp;
+            std::get<31>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 24
         {
-            Avm_DECLARE_VIEWS(24);
-            auto tmp = (((-mem_lastAccess + FF(1)) * (-mem_rw_shift + FF(1))) * (mem_val_shift - mem_val));
+            using Accumulator = typename std::tuple_element_t<32, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_rw * new_term.mem_tag_err);
             tmp *= scaling_factor;
-            std::get<24>(evals) += tmp;
+            std::get<32>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 25
         {
-            Avm_DECLARE_VIEWS(25);
-            auto tmp = (((-mem_lastAccess + FF(1)) * (-mem_rw_shift + FF(1))) * (mem_tag_shift - mem_tag));
+            using Accumulator = typename std::tuple_element_t<33, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_resolve_ind_addr_a * (new_term.mem_r_in_tag - FF(3)));
             tmp *= scaling_factor;
-            std::get<25>(evals) += tmp;
+            std::get<33>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 26
         {
-            Avm_DECLARE_VIEWS(26);
-            auto tmp = ((mem_lastAccess * (-mem_rw_shift + FF(1))) * mem_val_shift);
+            using Accumulator = typename std::tuple_element_t<34, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_resolve_ind_addr_b * (new_term.mem_r_in_tag - FF(3)));
             tmp *= scaling_factor;
-            std::get<26>(evals) += tmp;
+            std::get<34>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 27
         {
-            Avm_DECLARE_VIEWS(27);
-            auto tmp = (mem_skip_check_tag -
-                        ((mem_sel_op_cmov * ((mem_sel_op_d + (mem_sel_op_a * (-mem_sel_mov_ia_to_ic + FF(1)))) +
-                                             (mem_sel_op_b * (-mem_sel_mov_ib_to_ic + FF(1))))) +
-                         mem_sel_op_slice));
+            using Accumulator = typename std::tuple_element_t<35, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_resolve_ind_addr_c * (new_term.mem_r_in_tag - FF(3)));
             tmp *= scaling_factor;
-            std::get<27>(evals) += tmp;
+            std::get<35>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 28
         {
-            Avm_DECLARE_VIEWS(28);
-            auto tmp = (((mem_tag * (-mem_skip_check_tag + FF(1))) * (-mem_rw + FF(1))) *
-                        (((mem_r_in_tag - mem_tag) * (-mem_one_min_inv + FF(1))) - mem_tag_err));
+            using Accumulator = typename std::tuple_element_t<36, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_resolve_ind_addr_d * (new_term.mem_r_in_tag - FF(3)));
             tmp *= scaling_factor;
-            std::get<28>(evals) += tmp;
+            std::get<36>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 29
         {
-            Avm_DECLARE_VIEWS(29);
-            auto tmp = ((mem_tag * (-mem_tag_err + FF(1))) * mem_one_min_inv);
+            using Accumulator = typename std::tuple_element_t<37, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_resolve_ind_addr_a * new_term.mem_rw);
             tmp *= scaling_factor;
-            std::get<29>(evals) += tmp;
+            std::get<37>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 30
         {
-            Avm_DECLARE_VIEWS(30);
-            auto tmp = ((mem_skip_check_tag + mem_rw) * mem_tag_err);
+            using Accumulator = typename std::tuple_element_t<38, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_resolve_ind_addr_b * new_term.mem_rw);
             tmp *= scaling_factor;
-            std::get<30>(evals) += tmp;
+            std::get<38>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 31
         {
-            Avm_DECLARE_VIEWS(31);
-            auto tmp = (mem_rw * (mem_w_in_tag - mem_tag));
+            using Accumulator = typename std::tuple_element_t<39, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_resolve_ind_addr_c * new_term.mem_rw);
             tmp *= scaling_factor;
-            std::get<31>(evals) += tmp;
+            std::get<39>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 32
         {
-            Avm_DECLARE_VIEWS(32);
-            auto tmp = (mem_rw * mem_tag_err);
+            using Accumulator = typename std::tuple_element_t<40, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_resolve_ind_addr_d * new_term.mem_rw);
             tmp *= scaling_factor;
-            std::get<32>(evals) += tmp;
+            std::get<40>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 33
         {
-            Avm_DECLARE_VIEWS(33);
-            auto tmp = (mem_sel_resolve_ind_addr_a * (mem_r_in_tag - FF(3)));
+            using Accumulator = typename std::tuple_element_t<41, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_op_slice * (new_term.mem_w_in_tag - FF(6)));
             tmp *= scaling_factor;
-            std::get<33>(evals) += tmp;
+            std::get<41>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 34
         {
-            Avm_DECLARE_VIEWS(34);
-            auto tmp = (mem_sel_resolve_ind_addr_b * (mem_r_in_tag - FF(3)));
+            using Accumulator = typename std::tuple_element_t<42, ContainerOverSubrelations>;
+            auto tmp = (new_term.mem_sel_op_slice * (new_term.mem_r_in_tag - FF(6)));
             tmp *= scaling_factor;
-            std::get<34>(evals) += tmp;
+            std::get<42>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 35
         {
-            Avm_DECLARE_VIEWS(35);
-            auto tmp = (mem_sel_resolve_ind_addr_c * (mem_r_in_tag - FF(3)));
+            using Accumulator = typename std::tuple_element_t<43, ContainerOverSubrelations>;
+            auto tmp = ((new_term.mem_sel_mov_ia_to_ic + new_term.mem_sel_mov_ib_to_ic) * new_term.mem_tag_err);
             tmp *= scaling_factor;
-            std::get<35>(evals) += tmp;
-        }
-        // Contribution 36
-        {
-            Avm_DECLARE_VIEWS(36);
-            auto tmp = (mem_sel_resolve_ind_addr_d * (mem_r_in_tag - FF(3)));
-            tmp *= scaling_factor;
-            std::get<36>(evals) += tmp;
-        }
-        // Contribution 37
-        {
-            Avm_DECLARE_VIEWS(37);
-            auto tmp = (mem_sel_resolve_ind_addr_a * mem_rw);
-            tmp *= scaling_factor;
-            std::get<37>(evals) += tmp;
-        }
-        // Contribution 38
-        {
-            Avm_DECLARE_VIEWS(38);
-            auto tmp = (mem_sel_resolve_ind_addr_b * mem_rw);
-            tmp *= scaling_factor;
-            std::get<38>(evals) += tmp;
-        }
-        // Contribution 39
-        {
-            Avm_DECLARE_VIEWS(39);
-            auto tmp = (mem_sel_resolve_ind_addr_c * mem_rw);
-            tmp *= scaling_factor;
-            std::get<39>(evals) += tmp;
-        }
-        // Contribution 40
-        {
-            Avm_DECLARE_VIEWS(40);
-            auto tmp = (mem_sel_resolve_ind_addr_d * mem_rw);
-            tmp *= scaling_factor;
-            std::get<40>(evals) += tmp;
-        }
-        // Contribution 41
-        {
-            Avm_DECLARE_VIEWS(41);
-            auto tmp = (mem_sel_op_slice * (mem_w_in_tag - FF(6)));
-            tmp *= scaling_factor;
-            std::get<41>(evals) += tmp;
-        }
-        // Contribution 42
-        {
-            Avm_DECLARE_VIEWS(42);
-            auto tmp = (mem_sel_op_slice * (mem_r_in_tag - FF(6)));
-            tmp *= scaling_factor;
-            std::get<42>(evals) += tmp;
-        }
-        // Contribution 43
-        {
-            Avm_DECLARE_VIEWS(43);
-            auto tmp = ((mem_sel_mov_ia_to_ic + mem_sel_mov_ib_to_ic) * mem_tag_err);
-            tmp *= scaling_factor;
-            std::get<43>(evals) += tmp;
+            std::get<43>(evals) += typename Accumulator::View(tmp);
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/mem_slice.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/mem_slice.hpp
@@ -66,85 +66,75 @@ template <typename FF_> class mem_sliceImpl {
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        // Contribution 0
         {
-            Avm_DECLARE_VIEWS(0);
-            auto tmp = (slice_sel_mem_active - (slice_sel_cd_cpy + slice_sel_return));
+            using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
+            auto tmp = (new_term.slice_sel_mem_active - (new_term.slice_sel_cd_cpy + new_term.slice_sel_return));
             tmp *= scaling_factor;
-            std::get<0>(evals) += tmp;
+            std::get<0>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 1
         {
-            Avm_DECLARE_VIEWS(1);
-            auto tmp = ((slice_cnt * (-slice_one_min_inv + FF(1))) - slice_sel_mem_active);
+            using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
+            auto tmp = ((new_term.slice_cnt * (-new_term.slice_one_min_inv + FF(1))) - new_term.slice_sel_mem_active);
             tmp *= scaling_factor;
-            std::get<1>(evals) += tmp;
+            std::get<1>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 2
         {
-            Avm_DECLARE_VIEWS(2);
-            auto tmp = ((-slice_sel_mem_active + FF(1)) * slice_one_min_inv);
+            using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
+            auto tmp = ((-new_term.slice_sel_mem_active + FF(1)) * new_term.slice_one_min_inv);
             tmp *= scaling_factor;
-            std::get<2>(evals) += tmp;
+            std::get<2>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 3
         {
-            Avm_DECLARE_VIEWS(3);
-            auto tmp = (slice_sel_mem_active * ((slice_cnt - FF(1)) - slice_cnt_shift));
+            using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
+            auto tmp = (new_term.slice_sel_mem_active * ((new_term.slice_cnt - FF(1)) - new_term.slice_cnt_shift));
             tmp *= scaling_factor;
-            std::get<3>(evals) += tmp;
+            std::get<3>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 4
         {
-            Avm_DECLARE_VIEWS(4);
-            auto tmp = (slice_sel_mem_active * ((slice_addr + FF(1)) - slice_addr_shift));
+            using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
+            auto tmp = (new_term.slice_sel_mem_active * ((new_term.slice_addr + FF(1)) - new_term.slice_addr_shift));
             tmp *= scaling_factor;
-            std::get<4>(evals) += tmp;
+            std::get<4>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 5
         {
-            Avm_DECLARE_VIEWS(5);
-            auto tmp = (slice_sel_mem_active * ((slice_col_offset + FF(1)) - slice_col_offset_shift));
+            using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
+            auto tmp = (new_term.slice_sel_mem_active *
+                        ((new_term.slice_col_offset + FF(1)) - new_term.slice_col_offset_shift));
             tmp *= scaling_factor;
-            std::get<5>(evals) += tmp;
+            std::get<5>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 6
         {
-            Avm_DECLARE_VIEWS(6);
-            auto tmp = (slice_sel_mem_active * (slice_clk - slice_clk_shift));
+            using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
+            auto tmp = (new_term.slice_sel_mem_active * (new_term.slice_clk - new_term.slice_clk_shift));
             tmp *= scaling_factor;
-            std::get<6>(evals) += tmp;
+            std::get<6>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 7
         {
-            Avm_DECLARE_VIEWS(7);
-            auto tmp = (slice_sel_mem_active * (slice_space_id - slice_space_id_shift));
+            using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
+            auto tmp = (new_term.slice_sel_mem_active * (new_term.slice_space_id - new_term.slice_space_id_shift));
             tmp *= scaling_factor;
-            std::get<7>(evals) += tmp;
+            std::get<7>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 8
         {
-            Avm_DECLARE_VIEWS(8);
-            auto tmp =
-                ((slice_sel_mem_active * slice_sel_mem_active_shift) * (slice_sel_return - slice_sel_return_shift));
+            using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
+            auto tmp = ((new_term.slice_sel_mem_active * new_term.slice_sel_mem_active_shift) *
+                        (new_term.slice_sel_return - new_term.slice_sel_return_shift));
             tmp *= scaling_factor;
-            std::get<8>(evals) += tmp;
+            std::get<8>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 9
         {
-            Avm_DECLARE_VIEWS(9);
-            auto tmp =
-                ((slice_sel_mem_active * slice_sel_mem_active_shift) * (slice_sel_cd_cpy - slice_sel_cd_cpy_shift));
+            using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
+            auto tmp = ((new_term.slice_sel_mem_active * new_term.slice_sel_mem_active_shift) *
+                        (new_term.slice_sel_cd_cpy - new_term.slice_sel_cd_cpy_shift));
             tmp *= scaling_factor;
-            std::get<9>(evals) += tmp;
+            std::get<9>(evals) += typename Accumulator::View(tmp);
         }
-        // Contribution 10
         {
-            Avm_DECLARE_VIEWS(10);
-            auto tmp =
-                (((-slice_sel_mem_active + FF(1)) * slice_sel_mem_active_shift) * (-slice_sel_start_shift + FF(1)));
+            using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
+            auto tmp = (((-new_term.slice_sel_mem_active + FF(1)) * new_term.slice_sel_mem_active_shift) *
+                        (-new_term.slice_sel_start_shift + FF(1)));
             tmp *= scaling_factor;
-            std::get<10>(evals) += tmp;
+            std::get<10>(evals) += typename Accumulator::View(tmp);
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/pedersen.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/pedersen.hpp
@@ -28,12 +28,11 @@ template <typename FF_> class pedersenImpl {
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        // Contribution 0
         {
-            Avm_DECLARE_VIEWS(0);
-            auto tmp = (pedersen_sel_pedersen * (-pedersen_sel_pedersen + FF(1)));
+            using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
+            auto tmp = (new_term.pedersen_sel_pedersen * (-new_term.pedersen_sel_pedersen + FF(1)));
             tmp *= scaling_factor;
-            std::get<0>(evals) += tmp;
+            std::get<0>(evals) += typename Accumulator::View(tmp);
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/poseidon2.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/poseidon2.hpp
@@ -28,12 +28,11 @@ template <typename FF_> class poseidon2Impl {
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        // Contribution 0
         {
-            Avm_DECLARE_VIEWS(0);
-            auto tmp = (poseidon2_sel_poseidon_perm * (-poseidon2_sel_poseidon_perm + FF(1)));
+            using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
+            auto tmp = (new_term.poseidon2_sel_poseidon_perm * (-new_term.poseidon2_sel_poseidon_perm + FF(1)));
             tmp *= scaling_factor;
-            std::get<0>(evals) += tmp;
+            std::get<0>(evals) += typename Accumulator::View(tmp);
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/powers.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/powers.hpp
@@ -28,12 +28,11 @@ template <typename FF_> class powersImpl {
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        // Contribution 0
         {
-            Avm_DECLARE_VIEWS(0);
-            auto tmp = (powers_power_of_2 - powers_power_of_2);
+            using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
+            auto tmp = (new_term.powers_power_of_2 - new_term.powers_power_of_2);
             tmp *= scaling_factor;
-            std::get<0>(evals) += tmp;
+            std::get<0>(evals) += typename Accumulator::View(tmp);
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/relations/generated/avm/sha256.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generated/avm/sha256.hpp
@@ -28,12 +28,11 @@ template <typename FF_> class sha256Impl {
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        // Contribution 0
         {
-            Avm_DECLARE_VIEWS(0);
-            auto tmp = (sha256_sel_sha256_compression * (-sha256_sel_sha256_compression + FF(1)));
+            using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
+            auto tmp = (new_term.sha256_sel_sha256_compression * (-new_term.sha256_sel_sha256_compression + FF(1)));
             tmp *= scaling_factor;
-            std::get<0>(evals) += tmp;
+            std::get<0>(evals) += typename Accumulator::View(tmp);
         }
     }
 };

--- a/bb-pilcom/bb-pil-backend/src/vm_builder.rs
+++ b/bb-pilcom/bb-pil-backend/src/vm_builder.rs
@@ -114,8 +114,6 @@ pub fn analyzed_to_cpp<F: FieldElement>(
         &lookups,
     );
 
-    bb_files.create_declare_views(file_name, &all_cols_with_shifts);
-
     // ----------------------- Create the full row files -----------------------
     bb_files.create_full_row_hpp(file_name, &all_cols);
     bb_files.create_full_row_cpp(file_name, &all_cols);

--- a/bb-pilcom/bb-pil-backend/templates/declare_views.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/declare_views.hpp.hbs
@@ -1,8 +1,0 @@
-#pragma once
-
-#define {{root_name}}_DECLARE_VIEWS(index)                                                                                       \
-    using Accumulator = typename std::tuple_element<index, ContainerOverSubrelations>::type;                           \
-    using View = typename Accumulator::View;                                                                           \
-    {{#each all_cols_and_shifts as |col| ~}}
-    [[maybe_unused]] auto {{col}} = View(new_term.{{col}});{{#unless @last}} \\{{/unless}}
-    {{/each}}

--- a/bb-pilcom/bb-pil-backend/templates/relation.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/relation.hpp.hbs
@@ -38,12 +38,11 @@ template <typename FF_> class {{name}}Impl {
             [[maybe_unused]] const FF& scaling_factor
         ){
             {{#each identities}}
-            // Contribution {{@index}}
             {
-                {{../root_name}}_DECLARE_VIEWS({{@index}});
+                using Accumulator = typename std::tuple_element_t<{{@index}}, ContainerOverSubrelations>;
                 auto tmp = {{identity}};
                 tmp *= scaling_factor;
-                std::get<{{@index}}>(evals) += tmp;
+                std::get<{{@index}}>(evals) += typename Accumulator::View(tmp);
             }
             {{/each}}
         }


### PR DESCRIPTION
Should improve compilation time.

Token transfer proving time still takes ~17s.