### PR TITLE
feat: bus updates

### DIFF
--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
@@ -169,9 +169,9 @@ template <typename Builder> bool UltraCircuitChecker::check_databus_read(auto& v
 
         // Determine the type of read based on selector values
         bool is_calldata_read = (values.q_l == 1);
-        bool is_calldata_2_read = (values.q_r == 1);
+        bool is_secondary_calldata_read = (values.q_r == 1);
         bool is_return_data_read = (values.q_o == 1);
-        ASSERT(is_calldata_read || is_calldata_2_read || is_return_data_read);
+        ASSERT(is_calldata_read || is_secondary_calldata_read || is_return_data_read);
 
         // Check that the claimed value is present in the calldata/return data at the corresponding index
         FF bus_value;
@@ -179,9 +179,9 @@ template <typename Builder> bool UltraCircuitChecker::check_databus_read(auto& v
             auto calldata = builder.get_calldata();
             bus_value = builder.get_variable(calldata[raw_read_idx]);
         }
-        if (is_calldata_2_read) {
-            auto calldata_2 = builder.get_calldata_2();
-            bus_value = builder.get_variable(calldata_2[raw_read_idx]);
+        if (is_secondary_calldata_read) {
+            auto secondary_calldata = builder.get_secondary_calldata();
+            bus_value = builder.get_variable(secondary_calldata[raw_read_idx]);
         }
         if (is_return_data_read) {
             auto return_data = builder.get_return_data();

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
@@ -169,7 +169,8 @@ template <typename Builder> bool UltraCircuitChecker::check_databus_read(auto& v
 
         // Determine the type of read based on selector values
         bool is_calldata_read = (values.q_l == 1);
-        bool is_return_data_read = (values.q_r == 1);
+        bool is_calldata_2_read = (values.q_r == 1);
+        bool is_return_data_read = (values.q_o == 1);
         ASSERT(is_calldata_read || is_return_data_read);
 
         // Check that the claimed value is present in the calldata/return data at the corresponding index
@@ -177,6 +178,10 @@ template <typename Builder> bool UltraCircuitChecker::check_databus_read(auto& v
         if (is_calldata_read) {
             auto calldata = builder.get_calldata();
             bus_value = builder.get_variable(calldata[raw_read_idx]);
+        }
+        if (is_calldata_2_read) {
+            auto calldata_2 = builder.get_calldata_2();
+            bus_value = builder.get_variable(calldata_2[raw_read_idx]);
         }
         if (is_return_data_read) {
             auto return_data = builder.get_return_data();

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
@@ -171,7 +171,7 @@ template <typename Builder> bool UltraCircuitChecker::check_databus_read(auto& v
         bool is_calldata_read = (values.q_l == 1);
         bool is_calldata_2_read = (values.q_r == 1);
         bool is_return_data_read = (values.q_o == 1);
-        ASSERT(is_calldata_read || is_return_data_read);
+        ASSERT(is_calldata_read || is_calldata_2_read || is_return_data_read);
 
         // Check that the claimed value is present in the calldata/return data at the corresponding index
         FF bus_value;

--- a/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation.hpp
@@ -82,8 +82,8 @@ polynomials,
     template <typename AllEntities> inline static bool skip([[maybe_unused]] const AllEntities& in)
     {
         // Ensure the input does not contain a read gate or data that is being read
-        return in.q_busread.is_zero() && in.calldata_read_counts.is_zero() && in.return_data_read_counts.is_zero() &&
-               in.calldata_2_read_counts.is_zero();
+        return in.q_busread.is_zero() && in.calldata_read_counts.is_zero() && in.calldata_2_read_counts.is_zero() &&
+               in.return_data_read_counts.is_zero();
     }
 
     // Interface for easy access of databus components by column (bus_idx)

--- a/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation.hpp
@@ -102,7 +102,7 @@ polynomials,
     // Specialization for calldata_2 (bus_idx = 1)
     template <typename AllEntities> struct BusData</*bus_idx=*/1, AllEntities> {
         static auto& values(const AllEntities& in) { return in.calldata_2; }
-        static auto& selector(const AllEntities& in) { return in.q_l; }
+        static auto& selector(const AllEntities& in) { return in.q_r; }
         static auto& inverses(AllEntities& in) { return in.calldata_2_inverses; }
         static auto& inverses(const AllEntities& in) { return in.calldata_2_inverses; } // const version
         static auto& read_counts(const AllEntities& in) { return in.calldata_2_read_counts; }
@@ -112,7 +112,7 @@ polynomials,
     // Specialization for return data (bus_idx = 2)
     template <typename AllEntities> struct BusData</*bus_idx=*/2, AllEntities> {
         static auto& values(const AllEntities& in) { return in.return_data; }
-        static auto& selector(const AllEntities& in) { return in.q_r; }
+        static auto& selector(const AllEntities& in) { return in.q_o; }
         static auto& inverses(AllEntities& in) { return in.return_data_inverses; }
         static auto& inverses(const AllEntities& in) { return in.return_data_inverses; } // const version
         static auto& read_counts(const AllEntities& in) { return in.return_data_read_counts; }

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/protogalaxy_recursive_verifier.cpp
@@ -69,12 +69,10 @@ void ProtoGalaxyRecursiveVerifier_<VerifierInstances>::receive_and_finalise_inst
 
     // If Goblin (i.e. using DataBus) receive commitments to log-deriv inverses polynomial
     if constexpr (IsGoblinFlavor<Flavor>) {
-        witness_commitments.calldata_inverses = transcript->template receive_from_prover<Commitment>(
-            domain_separator + "_" + commitment_labels.calldata_inverses);
-        witness_commitments.calldata_2_inverses = transcript->template receive_from_prover<Commitment>(
-            domain_separator + "_" + commitment_labels.calldata_2_inverses);
-        witness_commitments.return_data_inverses = transcript->template receive_from_prover<Commitment>(
-            domain_separator + "_" + commitment_labels.return_data_inverses);
+        for (auto [commitment, label] :
+             zip_view(witness_commitments.get_databus_inverses(), commitment_labels.get_databus_inverses())) {
+            commitment = transcript->template receive_from_prover<Commitment>(domain_separator + "_" + label);
+        }
     }
 
     witness_commitments.z_perm =

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/protogalaxy_recursive_verifier.cpp
@@ -71,6 +71,8 @@ void ProtoGalaxyRecursiveVerifier_<VerifierInstances>::receive_and_finalise_inst
     if constexpr (IsGoblinFlavor<Flavor>) {
         witness_commitments.calldata_inverses = transcript->template receive_from_prover<Commitment>(
             domain_separator + "_" + commitment_labels.calldata_inverses);
+        witness_commitments.calldata_2_inverses = transcript->template receive_from_prover<Commitment>(
+            domain_separator + "_" + commitment_labels.calldata_2_inverses);
         witness_commitments.return_data_inverses = transcript->template receive_from_prover<Commitment>(
             domain_separator + "_" + commitment_labels.return_data_inverses);
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/ultra_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/ultra_recursive_verifier.cpp
@@ -107,15 +107,14 @@ std::array<typename Flavor::GroupElement, 2> UltraRecursiveVerifier_<Flavor>::ve
     commitments.lookup_inverses =
         transcript->template receive_from_prover<Commitment>(commitment_labels.lookup_inverses);
 
-    // If Goblin (i.e. using DataBus) receive commitments to log-deriv inverses polynomial
+    // If Goblin (i.e. using DataBus) receive commitments to log-deriv inverses polynomials
     if constexpr (IsGoblinFlavor<Flavor>) {
-        commitments.calldata_inverses =
-            transcript->template receive_from_prover<Commitment>(commitment_labels.calldata_inverses);
-        commitments.calldata_2_inverses =
-            transcript->template receive_from_prover<Commitment>(commitment_labels.calldata_2_inverses);
-        commitments.return_data_inverses =
-            transcript->template receive_from_prover<Commitment>(commitment_labels.return_data_inverses);
+        for (auto [commitment, label] :
+             zip_view(commitments.get_databus_inverses(), commitment_labels.get_databus_inverses())) {
+            commitment = transcript->template receive_from_prover<Commitment>(label);
+        }
     }
+
     const FF public_input_delta = compute_public_input_delta<Flavor>(
         public_inputs, beta, gamma, circuit_size, static_cast<uint32_t>(key->pub_inputs_offset));
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/ultra_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/ultra_recursive_verifier.cpp
@@ -111,6 +111,8 @@ std::array<typename Flavor::GroupElement, 2> UltraRecursiveVerifier_<Flavor>::ve
     if constexpr (IsGoblinFlavor<Flavor>) {
         commitments.calldata_inverses =
             transcript->template receive_from_prover<Commitment>(commitment_labels.calldata_inverses);
+        commitments.calldata_2_inverses =
+            transcript->template receive_from_prover<Commitment>(commitment_labels.calldata_2_inverses);
         commitments.return_data_inverses =
             transcript->template receive_from_prover<Commitment>(commitment_labels.return_data_inverses);
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
@@ -51,6 +51,7 @@ template <typename Builder> class databus {
   public:
     // The columns of the DataBus
     bus_vector calldata{ BusId::CALLDATA };
+    bus_vector calldata_2{ BusId::CALLDATA_2 };
     bus_vector return_data{ BusId::RETURNDATA };
 };
 } // namespace bb::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
@@ -51,7 +51,7 @@ template <typename Builder> class databus {
   public:
     // The columns of the DataBus
     bus_vector calldata{ BusId::CALLDATA };
-    bus_vector calldata_2{ BusId::CALLDATA_2 };
+    bus_vector secondary_calldata{ BusId::SECONDARY_CALLDATA };
     bus_vector return_data{ BusId::RETURNDATA };
 };
 } // namespace bb::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/databus.hpp
@@ -55,6 +55,6 @@ struct BusVector {
  *
  */
 using DataBus = std::array<BusVector, 3>;
-enum class BusId { CALLDATA, CALLDATA_2, RETURNDATA };
+enum class BusId { CALLDATA, SECONDARY_CALLDATA, RETURNDATA };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/databus.hpp
@@ -54,7 +54,7 @@ struct BusVector {
  * in-circuit as we would with public inputs).
  *
  */
-using DataBus = std::array<BusVector, 2>;
-enum class BusId { CALLDATA, RETURNDATA };
+using DataBus = std::array<BusVector, 3>;
+enum class BusId { CALLDATA, CALLDATA_2, RETURNDATA };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
@@ -40,11 +40,11 @@ template <typename FF> void MegaCircuitBuilder_<FF>::add_gates_to_ensure_all_pol
     auto read_idx = this->add_variable(raw_read_idx);
     read_calldata(read_idx);
 
-    // Create an arbitrary calldata_2 read gate
-    add_public_calldata_2(this->add_variable(25)); // ensure there is at least one entry in calldata_2
-    raw_read_idx = static_cast<uint32_t>(get_calldata_2().size()) - 1; // read data that was just added
+    // Create an arbitrary secondary_calldata read gate
+    add_public_secondary_calldata(this->add_variable(25)); // ensure there is at least one entry in secondary_calldata
+    raw_read_idx = static_cast<uint32_t>(get_secondary_calldata().size()) - 1; // read data that was just added
     read_idx = this->add_variable(raw_read_idx);
-    read_calldata_2(read_idx);
+    read_secondary_calldata(read_idx);
 
     // Create an arbitrary return data read gate
     add_public_return_data(this->add_variable(17)); // ensure there is at least one entry in return data
@@ -247,7 +247,7 @@ template <typename FF> void MegaCircuitBuilder_<FF>::apply_databus_selectors(con
         block.q_3().emplace_back(0);
         break;
     }
-    case BusId::CALLDATA_2: {
+    case BusId::SECONDARY_CALLDATA: {
         block.q_1().emplace_back(0);
         block.q_2().emplace_back(1);
         block.q_3().emplace_back(0);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
@@ -40,6 +40,12 @@ template <typename FF> void MegaCircuitBuilder_<FF>::add_gates_to_ensure_all_pol
     auto read_idx = this->add_variable(raw_read_idx);
     read_calldata(read_idx);
 
+    // Create an arbitrary calldata_2 read gate
+    add_public_calldata_2(this->add_variable(25)); // ensure there is at least one entry in calldata_2
+    raw_read_idx = static_cast<uint32_t>(get_calldata_2().size()) - 1; // read data that was just added
+    read_idx = this->add_variable(raw_read_idx);
+    read_calldata_2(read_idx);
+
     // Create an arbitrary return data read gate
     add_public_return_data(this->add_variable(17)); // ensure there is at least one entry in return data
     raw_read_idx = static_cast<uint32_t>(get_return_data().size()) - 1; // read data that was just added
@@ -238,17 +244,24 @@ template <typename FF> void MegaCircuitBuilder_<FF>::apply_databus_selectors(con
     case BusId::CALLDATA: {
         block.q_1().emplace_back(1);
         block.q_2().emplace_back(0);
+        block.q_3().emplace_back(0);
+        break;
+    }
+    case BusId::CALLDATA_2: {
+        block.q_1().emplace_back(0);
+        block.q_2().emplace_back(1);
+        block.q_3().emplace_back(0);
         break;
     }
     case BusId::RETURNDATA: {
         block.q_1().emplace_back(0);
-        block.q_2().emplace_back(1);
+        block.q_2().emplace_back(0);
+        block.q_3().emplace_back(1);
         break;
     }
     }
     block.q_busread().emplace_back(1);
     block.q_m().emplace_back(0);
-    block.q_3().emplace_back(0);
     block.q_c().emplace_back(0);
     block.q_delta_range().emplace_back(0);
     block.q_arith().emplace_back(0);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
@@ -172,6 +172,12 @@ template <typename FF> class MegaCircuitBuilder_ : public UltraCircuitBuilder_<M
     void add_public_calldata(const uint32_t& in) { return append_to_bus_vector(BusId::CALLDATA, in); }
 
     /**
+     * @brief Add a witness variable to the public calldata.
+     *
+     */
+    void add_public_calldata_2(const uint32_t& in) { return append_to_bus_vector(BusId::CALLDATA_2, in); }
+
+    /**
      * @brief Add a witness variable to the public return_data.
      *
      */
@@ -191,6 +197,17 @@ template <typename FF> class MegaCircuitBuilder_ : public UltraCircuitBuilder_<M
     };
 
     /**
+     * @brief Read from calldata_2 and create a corresponding databus read gate
+     *
+     * @param read_idx_witness_idx Witness index for the calldata_2 read index
+     * @return uint32_t Witness index for the result of the read
+     */
+    uint32_t read_calldata_2(const uint32_t& read_idx_witness_idx)
+    {
+        return read_bus_vector(BusId::CALLDATA_2, read_idx_witness_idx);
+    };
+
+    /**
      * @brief Read from return_data and create a corresponding databus read gate
      *
      * @param read_idx_witness_idx Witness index for the return_data read index
@@ -207,6 +224,7 @@ template <typename FF> class MegaCircuitBuilder_ : public UltraCircuitBuilder_<M
     }
 
     const BusVector& get_calldata() { return databus[static_cast<size_t>(BusId::CALLDATA)]; }
+    const BusVector& get_calldata_2() { return databus[static_cast<size_t>(BusId::CALLDATA_2)]; }
     const BusVector& get_return_data() { return databus[static_cast<size_t>(BusId::RETURNDATA)]; }
 
     void create_poseidon2_external_gate(const poseidon2_external_gate_<FF>& in);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
@@ -172,10 +172,14 @@ template <typename FF> class MegaCircuitBuilder_ : public UltraCircuitBuilder_<M
     void add_public_calldata(const uint32_t& in) { return append_to_bus_vector(BusId::CALLDATA, in); }
 
     /**
-     * @brief Add a witness variable to the public calldata.
+     * @brief Add a witness variable to secondary_calldata.
+     * @details In practice this is used in aztec by the kernel circuit to recieve output from a function circuit
      *
      */
-    void add_public_calldata_2(const uint32_t& in) { return append_to_bus_vector(BusId::CALLDATA_2, in); }
+    void add_public_secondary_calldata(const uint32_t& in)
+    {
+        return append_to_bus_vector(BusId::SECONDARY_CALLDATA, in);
+    }
 
     /**
      * @brief Add a witness variable to the public return_data.
@@ -197,14 +201,14 @@ template <typename FF> class MegaCircuitBuilder_ : public UltraCircuitBuilder_<M
     };
 
     /**
-     * @brief Read from calldata_2 and create a corresponding databus read gate
+     * @brief Read from secondary_calldata and create a corresponding databus read gate
      *
-     * @param read_idx_witness_idx Witness index for the calldata_2 read index
+     * @param read_idx_witness_idx Witness index for the secondary_calldata read index
      * @return uint32_t Witness index for the result of the read
      */
-    uint32_t read_calldata_2(const uint32_t& read_idx_witness_idx)
+    uint32_t read_secondary_calldata(const uint32_t& read_idx_witness_idx)
     {
-        return read_bus_vector(BusId::CALLDATA_2, read_idx_witness_idx);
+        return read_bus_vector(BusId::SECONDARY_CALLDATA, read_idx_witness_idx);
     };
 
     /**
@@ -224,7 +228,7 @@ template <typename FF> class MegaCircuitBuilder_ : public UltraCircuitBuilder_<M
     }
 
     const BusVector& get_calldata() { return databus[static_cast<size_t>(BusId::CALLDATA)]; }
-    const BusVector& get_calldata_2() { return databus[static_cast<size_t>(BusId::CALLDATA_2)]; }
+    const BusVector& get_secondary_calldata() { return databus[static_cast<size_t>(BusId::SECONDARY_CALLDATA)]; }
     const BusVector& get_return_data() { return databus[static_cast<size_t>(BusId::RETURNDATA)]; }
 
     void create_poseidon2_external_gate(const poseidon2_external_gate_<FF>& in);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -176,26 +176,26 @@ class MegaFlavor {
     template <typename DataType> class DerivedEntities {
       public:
         DEFINE_FLAVOR_MEMBERS(DataType,
-                              z_perm,                  // column 4
-                              lookup_inverses,         // column 5
-                              lookup_read_counts,      // column 6
-                              lookup_read_tags,        // column 7
-                              ecc_op_wire_1,           // column 8
-                              ecc_op_wire_2,           // column 9
-                              ecc_op_wire_3,           // column 10
-                              ecc_op_wire_4,           // column 11
-                              calldata,                // column 12
-                              calldata_read_counts,    // column 13
-                              calldata_read_tags,      // column 14
-                              calldata_inverses,       // column 15
-                              calldata_2,              // column 16
-                              calldata_2_read_counts,  // column 17
-                              calldata_2_read_tags,    // column 18
-                              calldata_2_inverses,     // column 19
-                              return_data,             // column 20
-                              return_data_read_counts, // column 21
-                              return_data_read_tags,   // column 22
-                              return_data_inverses);   // column 23
+                              z_perm,                         // column 4
+                              lookup_inverses,                // column 5
+                              lookup_read_counts,             // column 6
+                              lookup_read_tags,               // column 7
+                              ecc_op_wire_1,                  // column 8
+                              ecc_op_wire_2,                  // column 9
+                              ecc_op_wire_3,                  // column 10
+                              ecc_op_wire_4,                  // column 11
+                              calldata,                       // column 12
+                              calldata_read_counts,           // column 13
+                              calldata_read_tags,             // column 14
+                              calldata_inverses,              // column 15
+                              secondary_calldata,             // column 16
+                              secondary_calldata_read_counts, // column 17
+                              secondary_calldata_read_tags,   // column 18
+                              secondary_calldata_inverses,    // column 19
+                              return_data,                    // column 20
+                              return_data_read_counts,        // column 21
+                              return_data_read_tags,          // column 22
+                              return_data_inverses);          // column 23
     };
 
     /**
@@ -215,16 +215,18 @@ class MegaFlavor {
         }
         auto get_databus_entities() // Excludes the derived inverse polynomials
         {
-            return RefArray{ this->calldata,    this->calldata_read_counts,    this->calldata_read_tags,
-                             this->calldata_2,  this->calldata_2_read_counts,  this->calldata_2_read_tags,
-                             this->return_data, this->return_data_read_counts, this->return_data_read_tags };
+            return RefArray{
+                this->calldata,           this->calldata_read_counts,           this->calldata_read_tags,
+                this->secondary_calldata, this->secondary_calldata_read_counts, this->secondary_calldata_read_tags,
+                this->return_data,        this->return_data_read_counts,        this->return_data_read_tags
+            };
         }
 
         auto get_databus_inverses()
         {
             return RefArray{
                 this->calldata_inverses,
-                this->calldata_2_inverses,
+                this->secondary_calldata_inverses,
                 this->return_data_inverses,
             };
         }
@@ -245,10 +247,10 @@ class MegaFlavor {
                        this->calldata_read_counts,
                        this->calldata_read_tags,
                        this->calldata_inverses,
-                       this->calldata_2,
-                       this->calldata_2_read_counts,
-                       this->calldata_2_read_tags,
-                       this->calldata_2_inverses,
+                       this->secondary_calldata,
+                       this->secondary_calldata_read_counts,
+                       this->secondary_calldata_read_tags,
+                       this->secondary_calldata_inverses,
                        this->return_data,
                        this->return_data_read_counts,
                        this->return_data_read_tags,
@@ -421,7 +423,7 @@ class MegaFlavor {
             DatabusLookupRelation<FF>::compute_logderivative_inverse</*bus_idx=*/0>(
                 this->polynomials, relation_parameters, this->circuit_size);
 
-            // Compute inverses for calldata_2 reads
+            // Compute inverses for secondary_calldata reads
             DatabusLookupRelation<FF>::compute_logderivative_inverse</*bus_idx=*/1>(
                 this->polynomials, relation_parameters, this->circuit_size);
 
@@ -651,10 +653,10 @@ class MegaFlavor {
             calldata_read_counts = "CALLDATA_READ_COUNTS";
             calldata_read_tags = "CALLDATA_READ_TAGS";
             calldata_inverses = "CALLDATA_INVERSES";
-            calldata_2 = "CALLDATA_2";
-            calldata_2_read_counts = "CALLDATA_2_READ_COUNTS";
-            calldata_2_read_tags = "CALLDATA_2_READ_TAGS";
-            calldata_2_inverses = "CALLDATA_2_INVERSES";
+            secondary_calldata = "SECONDARY_CALLDATA";
+            secondary_calldata_read_counts = "SECONDARY_CALLDATA_READ_COUNTS";
+            secondary_calldata_read_tags = "SECONDARY_CALLDATA_READ_TAGS";
+            secondary_calldata_inverses = "SECONDARY_CALLDATA_INVERSES";
             return_data = "RETURN_DATA";
             return_data_read_counts = "RETURN_DATA_READ_COUNTS";
             return_data_read_tags = "RETURN_DATA_READ_TAGS";
@@ -750,10 +752,10 @@ class MegaFlavor {
                 this->calldata_read_counts = commitments.calldata_read_counts;
                 this->calldata_read_tags = commitments.calldata_read_tags;
                 this->calldata_inverses = commitments.calldata_inverses;
-                this->calldata_2 = commitments.calldata_2;
-                this->calldata_2_read_counts = commitments.calldata_2_read_counts;
-                this->calldata_2_read_tags = commitments.calldata_2_read_tags;
-                this->calldata_2_inverses = commitments.calldata_2_inverses;
+                this->secondary_calldata = commitments.secondary_calldata;
+                this->secondary_calldata_read_counts = commitments.secondary_calldata_read_counts;
+                this->secondary_calldata_read_tags = commitments.secondary_calldata_read_tags;
+                this->secondary_calldata_inverses = commitments.secondary_calldata_inverses;
                 this->return_data = commitments.return_data;
                 this->return_data_read_counts = commitments.return_data_read_counts;
                 this->return_data_read_tags = commitments.return_data_read_tags;
@@ -786,10 +788,10 @@ class MegaFlavor {
         Commitment calldata_read_counts_comm;
         Commitment calldata_read_tags_comm;
         Commitment calldata_inverses_comm;
-        Commitment calldata_2_comm;
-        Commitment calldata_2_read_counts_comm;
-        Commitment calldata_2_read_tags_comm;
-        Commitment calldata_2_inverses_comm;
+        Commitment secondary_calldata_comm;
+        Commitment secondary_calldata_read_counts_comm;
+        Commitment secondary_calldata_read_tags_comm;
+        Commitment secondary_calldata_inverses_comm;
         Commitment return_data_comm;
         Commitment return_data_read_counts_comm;
         Commitment return_data_read_tags_comm;
@@ -848,10 +850,10 @@ class MegaFlavor {
             calldata_read_counts_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
             calldata_read_tags_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
             calldata_inverses_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
-            calldata_2_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
-            calldata_2_read_counts_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
-            calldata_2_read_tags_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
-            calldata_2_inverses_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
+            secondary_calldata_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
+            secondary_calldata_read_counts_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
+            secondary_calldata_read_tags_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
+            secondary_calldata_inverses_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
             return_data_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
             return_data_read_counts_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
             return_data_read_tags_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
@@ -895,10 +897,10 @@ class MegaFlavor {
             serialize_to_buffer(calldata_read_counts_comm, proof_data);
             serialize_to_buffer(calldata_read_tags_comm, proof_data);
             serialize_to_buffer(calldata_inverses_comm, proof_data);
-            serialize_to_buffer(calldata_2_comm, proof_data);
-            serialize_to_buffer(calldata_2_read_counts_comm, proof_data);
-            serialize_to_buffer(calldata_2_read_tags_comm, proof_data);
-            serialize_to_buffer(calldata_2_inverses_comm, proof_data);
+            serialize_to_buffer(secondary_calldata_comm, proof_data);
+            serialize_to_buffer(secondary_calldata_read_counts_comm, proof_data);
+            serialize_to_buffer(secondary_calldata_read_tags_comm, proof_data);
+            serialize_to_buffer(secondary_calldata_inverses_comm, proof_data);
             serialize_to_buffer(return_data_comm, proof_data);
             serialize_to_buffer(return_data_read_counts_comm, proof_data);
             serialize_to_buffer(return_data_read_tags_comm, proof_data);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -39,12 +39,12 @@ class MegaFlavor {
     static constexpr size_t NUM_WIRES = CircuitBuilder::NUM_WIRES;
     // The number of multivariate polynomials on which a sumcheck prover sumcheck operates (including shifts). We often
     // need containers of this size to hold related data, so we choose a name more agnostic than `NUM_POLYNOMIALS`.
-    static constexpr size_t NUM_ALL_ENTITIES = 59;
+    static constexpr size_t NUM_ALL_ENTITIES = 63;
     // The number of polynomials precomputed to describe a circuit and to aid a prover in constructing a satisfying
     // assignment of witnesses. We again choose a neutral name.
     static constexpr size_t NUM_PRECOMPUTED_ENTITIES = 30;
     // The total number of witness entities not including shifts.
-    static constexpr size_t NUM_WITNESS_ENTITIES = 20;
+    static constexpr size_t NUM_WITNESS_ENTITIES = 24;
     // Total number of folded polynomials, which is just all polynomials except the shifts
     static constexpr size_t NUM_FOLDED_ENTITIES = NUM_PRECOMPUTED_ENTITIES + NUM_WITNESS_ENTITIES;
 
@@ -188,10 +188,14 @@ class MegaFlavor {
                               calldata_read_counts,    // column 13
                               calldata_read_tags,      // column 14
                               calldata_inverses,       // column 15
-                              return_data,             // column 16
-                              return_data_read_counts, // column 17
-                              return_data_read_tags,   // column 18
-                              return_data_inverses);   // column 19
+                              calldata_2,              // column 16
+                              calldata_2_read_counts,  // column 17
+                              calldata_2_read_tags,    // column 18
+                              calldata_2_inverses,     // column 19
+                              return_data,             // column 20
+                              return_data_read_counts, // column 21
+                              return_data_read_tags,   // column 22
+                              return_data_inverses);   // column 23
     };
 
     /**
@@ -212,6 +216,7 @@ class MegaFlavor {
         auto get_databus_entities() // Excludes the derived inverse polynomials
         {
             return RefArray{ this->calldata,    this->calldata_read_counts,    this->calldata_read_tags,
+                             this->calldata_2,  this->calldata_2_read_counts,  this->calldata_2_read_tags,
                              this->return_data, this->return_data_read_counts, this->return_data_read_tags };
         }
 
@@ -231,6 +236,10 @@ class MegaFlavor {
                        this->calldata_read_counts,
                        this->calldata_read_tags,
                        this->calldata_inverses,
+                       this->calldata_2,
+                       this->calldata_2_read_counts,
+                       this->calldata_2_read_tags,
+                       this->calldata_2_inverses,
                        this->return_data,
                        this->return_data_read_counts,
                        this->return_data_read_tags,
@@ -403,8 +412,12 @@ class MegaFlavor {
             DatabusLookupRelation<FF>::compute_logderivative_inverse</*bus_idx=*/0>(
                 this->polynomials, relation_parameters, this->circuit_size);
 
-            // Compute inverses for return data reads
+            // Compute inverses for calldata_2 reads
             DatabusLookupRelation<FF>::compute_logderivative_inverse</*bus_idx=*/1>(
+                this->polynomials, relation_parameters, this->circuit_size);
+
+            // Compute inverses for return data reads
+            DatabusLookupRelation<FF>::compute_logderivative_inverse</*bus_idx=*/2>(
                 this->polynomials, relation_parameters, this->circuit_size);
         }
 
@@ -629,6 +642,10 @@ class MegaFlavor {
             calldata_read_counts = "CALLDATA_READ_COUNTS";
             calldata_read_tags = "CALLDATA_READ_TAGS";
             calldata_inverses = "CALLDATA_INVERSES";
+            calldata = "CALLDATA_2";
+            calldata_read_counts = "CALLDATA_2_READ_COUNTS";
+            calldata_read_tags = "CALLDATA_2_READ_TAGS";
+            calldata_inverses = "CALLDATA_2_INVERSES";
             return_data = "RETURN_DATA";
             return_data_read_counts = "RETURN_DATA_READ_COUNTS";
             return_data_read_tags = "RETURN_DATA_READ_TAGS";
@@ -724,6 +741,10 @@ class MegaFlavor {
                 this->calldata_read_counts = commitments.calldata_read_counts;
                 this->calldata_read_tags = commitments.calldata_read_tags;
                 this->calldata_inverses = commitments.calldata_inverses;
+                this->calldata_2 = commitments.calldata_2;
+                this->calldata_2_read_counts = commitments.calldata_2_read_counts;
+                this->calldata_2_read_tags = commitments.calldata_2_read_tags;
+                this->calldata_2_inverses = commitments.calldata_2_inverses;
                 this->return_data = commitments.return_data;
                 this->return_data_read_counts = commitments.return_data_read_counts;
                 this->return_data_read_tags = commitments.return_data_read_tags;
@@ -756,6 +777,10 @@ class MegaFlavor {
         Commitment calldata_read_counts_comm;
         Commitment calldata_read_tags_comm;
         Commitment calldata_inverses_comm;
+        Commitment calldata_2_comm;
+        Commitment calldata_2_read_counts_comm;
+        Commitment calldata_2_read_tags_comm;
+        Commitment calldata_2_inverses_comm;
         Commitment return_data_comm;
         Commitment return_data_read_counts_comm;
         Commitment return_data_read_tags_comm;
@@ -814,6 +839,10 @@ class MegaFlavor {
             calldata_read_counts_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
             calldata_read_tags_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
             calldata_inverses_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
+            calldata_2_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
+            calldata_2_read_counts_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
+            calldata_2_read_tags_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
+            calldata_2_inverses_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
             return_data_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
             return_data_read_counts_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
             return_data_read_tags_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
@@ -857,6 +886,10 @@ class MegaFlavor {
             serialize_to_buffer(calldata_read_counts_comm, proof_data);
             serialize_to_buffer(calldata_read_tags_comm, proof_data);
             serialize_to_buffer(calldata_inverses_comm, proof_data);
+            serialize_to_buffer(calldata_2_comm, proof_data);
+            serialize_to_buffer(calldata_2_read_counts_comm, proof_data);
+            serialize_to_buffer(calldata_2_read_tags_comm, proof_data);
+            serialize_to_buffer(calldata_2_inverses_comm, proof_data);
             serialize_to_buffer(return_data_comm, proof_data);
             serialize_to_buffer(return_data_read_counts_comm, proof_data);
             serialize_to_buffer(return_data_read_tags_comm, proof_data);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -642,10 +642,10 @@ class MegaFlavor {
             calldata_read_counts = "CALLDATA_READ_COUNTS";
             calldata_read_tags = "CALLDATA_READ_TAGS";
             calldata_inverses = "CALLDATA_INVERSES";
-            calldata = "CALLDATA_2";
-            calldata_read_counts = "CALLDATA_2_READ_COUNTS";
-            calldata_read_tags = "CALLDATA_2_READ_TAGS";
-            calldata_inverses = "CALLDATA_2_INVERSES";
+            calldata_2 = "CALLDATA_2";
+            calldata_2_read_counts = "CALLDATA_2_READ_COUNTS";
+            calldata_2_read_tags = "CALLDATA_2_READ_TAGS";
+            calldata_2_inverses = "CALLDATA_2_INVERSES";
             return_data = "RETURN_DATA";
             return_data_read_counts = "RETURN_DATA_READ_COUNTS";
             return_data_read_tags = "RETURN_DATA_READ_TAGS";

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -220,6 +220,15 @@ class MegaFlavor {
                              this->return_data, this->return_data_read_counts, this->return_data_read_tags };
         }
 
+        auto get_databus_inverses()
+        {
+            return RefArray{
+                this->calldata_inverses,
+                this->calldata_2_inverses,
+                this->return_data_inverses,
+            };
+        }
+
         MSGPACK_FIELDS(this->w_l,
                        this->w_r,
                        this->w_o,

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -331,7 +331,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization_
      * @param varnum number of known witness
      *
      * @note The size of witness_values may be less than varnum. The former is the set of actual witness values known at
-     * the time of acir generation. The former may be larger and essentially acounts for placeholders for witnesses that
+     * the time of acir generation. The latter may be larger and essentially acounts for placeholders for witnesses that
      * we know will exist but whose values are not known during acir generation. Both are in general less than the total
      * number of variables/witnesses that might be present for a circuit generated from acir, since many gates will
      * depend on the details of the bberg implementation (or more generally on the backend used to process acir).

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.cpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.cpp
@@ -44,15 +44,15 @@ void ProverInstance_<Flavor>::construct_databus_polynomials(Circuit& circuit)
     auto& public_calldata = proving_key.polynomials.calldata;
     auto& calldata_read_counts = proving_key.polynomials.calldata_read_counts;
     auto& calldata_read_tags = proving_key.polynomials.calldata_read_tags;
-    auto& public_calldata_2 = proving_key.polynomials.calldata_2;
-    auto& calldata_2_read_counts = proving_key.polynomials.calldata_2_read_counts;
-    auto& calldata_2_read_tags = proving_key.polynomials.calldata_2_read_tags;
+    auto& public_secondary_calldata = proving_key.polynomials.secondary_calldata;
+    auto& secondary_calldata_read_counts = proving_key.polynomials.secondary_calldata_read_counts;
+    auto& secondary_calldata_read_tags = proving_key.polynomials.secondary_calldata_read_tags;
     auto& public_return_data = proving_key.polynomials.return_data;
     auto& return_data_read_counts = proving_key.polynomials.return_data_read_counts;
     auto& return_data_read_tags = proving_key.polynomials.return_data_read_tags;
 
     auto calldata = circuit.get_calldata();
-    auto calldata_2 = circuit.get_calldata_2();
+    auto secondary_calldata = circuit.get_secondary_calldata();
     auto return_data = circuit.get_return_data();
 
     // Note: We do not utilize a zero row for databus columns
@@ -61,10 +61,10 @@ void ProverInstance_<Flavor>::construct_databus_polynomials(Circuit& circuit)
         calldata_read_counts[idx] = calldata.get_read_count(idx);        // read counts
         calldata_read_tags[idx] = calldata_read_counts[idx] > 0 ? 1 : 0; // has row been read or not
     }
-    for (size_t idx = 0; idx < calldata_2.size(); ++idx) {
-        public_calldata_2[idx] = circuit.get_variable(calldata_2[idx]);      // calldata_2 values
-        calldata_2_read_counts[idx] = calldata_2.get_read_count(idx);        // read counts
-        calldata_2_read_tags[idx] = calldata_2_read_counts[idx] > 0 ? 1 : 0; // has row been read or not
+    for (size_t idx = 0; idx < secondary_calldata.size(); ++idx) {
+        public_secondary_calldata[idx] = circuit.get_variable(secondary_calldata[idx]); // secondary_calldata values
+        secondary_calldata_read_counts[idx] = secondary_calldata.get_read_count(idx);   // read counts
+        secondary_calldata_read_tags[idx] = secondary_calldata_read_counts[idx] > 0 ? 1 : 0; // has row been read or not
     }
     for (size_t idx = 0; idx < return_data.size(); ++idx) {
         public_return_data[idx] = circuit.get_variable(return_data[idx]);      // return data values

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.cpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.cpp
@@ -44,11 +44,15 @@ void ProverInstance_<Flavor>::construct_databus_polynomials(Circuit& circuit)
     auto& public_calldata = proving_key.polynomials.calldata;
     auto& calldata_read_counts = proving_key.polynomials.calldata_read_counts;
     auto& calldata_read_tags = proving_key.polynomials.calldata_read_tags;
+    auto& public_calldata_2 = proving_key.polynomials.calldata_2;
+    auto& calldata_2_read_counts = proving_key.polynomials.calldata_2_read_counts;
+    auto& calldata_2_read_tags = proving_key.polynomials.calldata_2_read_tags;
     auto& public_return_data = proving_key.polynomials.return_data;
     auto& return_data_read_counts = proving_key.polynomials.return_data_read_counts;
     auto& return_data_read_tags = proving_key.polynomials.return_data_read_tags;
 
     auto calldata = circuit.get_calldata();
+    auto calldata_2 = circuit.get_calldata_2();
     auto return_data = circuit.get_return_data();
 
     // Note: We do not utilize a zero row for databus columns
@@ -56,6 +60,11 @@ void ProverInstance_<Flavor>::construct_databus_polynomials(Circuit& circuit)
         public_calldata[idx] = circuit.get_variable(calldata[idx]);      // calldata values
         calldata_read_counts[idx] = calldata.get_read_count(idx);        // read counts
         calldata_read_tags[idx] = calldata_read_counts[idx] > 0 ? 1 : 0; // has row been read or not
+    }
+    for (size_t idx = 0; idx < calldata_2.size(); ++idx) {
+        public_calldata_2[idx] = circuit.get_variable(calldata_2[idx]);      // calldata_2 values
+        calldata_2_read_counts[idx] = calldata_2.get_read_count(idx);        // read counts
+        calldata_2_read_tags[idx] = calldata_2_read_counts[idx] > 0 ? 1 : 0; // has row been read or not
     }
     for (size_t idx = 0; idx < return_data.size(); ++idx) {
         public_return_data[idx] = circuit.get_variable(return_data[idx]);      // return data values

--- a/barretenberg/cpp/src/barretenberg/transcript/transcript.hpp
+++ b/barretenberg/cpp/src/barretenberg/transcript/transcript.hpp
@@ -23,6 +23,16 @@ class TranscriptManifest {
         std::vector<std::string> challenge_label;
         std::vector<std::pair<std::string, size_t>> entries;
 
+        void print()
+        {
+            for (auto& label : challenge_label) {
+                info("\tchallenge: ", label);
+            }
+            for (auto& entry : entries) {
+                info("\telement (", entry.second, "): ", entry.first);
+            }
+        }
+
         bool operator==(const RoundData& other) const = default;
     };
 
@@ -33,12 +43,7 @@ class TranscriptManifest {
     {
         for (auto& round : manifest) {
             info("Round: ", round.first);
-            for (auto& label : round.second.challenge_label) {
-                info("\tchallenge: ", label);
-            }
-            for (auto& entry : round.second.entries) {
-                info("\telement (", entry.second, "): ", entry.first);
-            }
+            round.second.print();
         }
     }
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/databus.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/databus.test.cpp
@@ -88,11 +88,15 @@ class DataBusTests : public ::testing::Test {
         return construct_circuit_with_databus_reads(builder, add_method, read_method);
     }
 
-    static Builder construct_circuit_with_calldata_2_reads(Builder& builder)
+    static Builder construct_circuit_with_secondary_calldata_reads(Builder& builder)
     {
-        // Define interfaces for the add and read methods for databus calldata_2
-        auto add_method = [](Builder& builder, uint32_t witness_idx) { builder.add_public_calldata_2(witness_idx); };
-        auto read_method = [](Builder& builder, uint32_t witness_idx) { return builder.read_calldata_2(witness_idx); };
+        // Define interfaces for the add and read methods for databus secondary_calldata
+        auto add_method = [](Builder& builder, uint32_t witness_idx) {
+            builder.add_public_secondary_calldata(witness_idx);
+        };
+        auto read_method = [](Builder& builder, uint32_t witness_idx) {
+            return builder.read_secondary_calldata(witness_idx);
+        };
 
         return construct_circuit_with_databus_reads(builder, add_method, read_method);
     }
@@ -120,13 +124,13 @@ TEST_F(DataBusTests, CallDataRead)
 }
 
 /**
- * @brief Test proof construction/verification for a circuit with calldata_2 lookup gates
+ * @brief Test proof construction/verification for a circuit with secondary_calldata lookup gates
  *
  */
 TEST_F(DataBusTests, CallData2Read)
 {
     Builder builder = construct_test_builder();
-    construct_circuit_with_calldata_2_reads(builder);
+    construct_circuit_with_secondary_calldata_reads(builder);
 
     EXPECT_TRUE(construct_and_verify_proof(builder));
 }
@@ -151,7 +155,7 @@ TEST_F(DataBusTests, ReadAll)
 {
     Builder builder = construct_test_builder();
     construct_circuit_with_calldata_reads(builder);
-    construct_circuit_with_calldata_2_reads(builder);
+    construct_circuit_with_secondary_calldata_reads(builder);
     construct_circuit_with_return_data_reads(builder);
 
     EXPECT_TRUE(construct_and_verify_proof(builder));

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_transcript.test.cpp
@@ -167,7 +167,12 @@ TEST_F(MegaTranscriptTests, ProverManifestConsistency)
     auto prover_manifest = prover.transcript->get_manifest();
     // Note: a manifest can be printed using manifest.print()
     for (size_t round = 0; round < manifest_expected.size(); ++round) {
-        ASSERT_EQ(prover_manifest[round], manifest_expected[round]) << "Prover manifest discrepency in round " << round;
+        if (prover_manifest[round] != manifest_expected[round]) {
+            info("Prover manifest discrepency in round ", round);
+            prover_manifest[round].print();
+            manifest_expected[round].print();
+            ASSERT(false);
+        }
     }
 }
 
@@ -199,8 +204,12 @@ TEST_F(MegaTranscriptTests, VerifierManifestConsistency)
 
     // Note: a manifest can be printed using manifest.print()
     for (size_t round = 0; round < prover_manifest.size(); ++round) {
-        ASSERT_EQ(prover_manifest[round], verifier_manifest[round])
-            << "Prover/Verifier manifest discrepency in round " << round;
+        if (prover_manifest[round] != verifier_manifest[round]) {
+            info("Prover/Verifier manifest discrepency in round ", round);
+            prover_manifest[round].print();
+            verifier_manifest[round].print();
+            ASSERT(false);
+        }
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_transcript.test.cpp
@@ -61,6 +61,9 @@ class MegaTranscriptTests : public ::testing::Test {
         manifest_expected.add_entry(round, "CALLDATA", frs_per_G);
         manifest_expected.add_entry(round, "CALLDATA_READ_COUNTS", frs_per_G);
         manifest_expected.add_entry(round, "CALLDATA_READ_TAGS", frs_per_G);
+        manifest_expected.add_entry(round, "CALLDATA_2", frs_per_G);
+        manifest_expected.add_entry(round, "CALLDATA_2_READ_COUNTS", frs_per_G);
+        manifest_expected.add_entry(round, "CALLDATA_2_READ_TAGS", frs_per_G);
         manifest_expected.add_entry(round, "RETURN_DATA", frs_per_G);
         manifest_expected.add_entry(round, "RETURN_DATA_READ_COUNTS", frs_per_G);
         manifest_expected.add_entry(round, "RETURN_DATA_READ_TAGS", frs_per_G);
@@ -75,6 +78,7 @@ class MegaTranscriptTests : public ::testing::Test {
         round++;
         manifest_expected.add_entry(round, "LOOKUP_INVERSES", frs_per_G);
         manifest_expected.add_entry(round, "CALLDATA_INVERSES", frs_per_G);
+        manifest_expected.add_entry(round, "CALLDATA_2_INVERSES", frs_per_G);
         manifest_expected.add_entry(round, "RETURN_DATA_INVERSES", frs_per_G);
         manifest_expected.add_entry(round, "Z_PERM", frs_per_G);
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_transcript.test.cpp
@@ -61,9 +61,9 @@ class MegaTranscriptTests : public ::testing::Test {
         manifest_expected.add_entry(round, "CALLDATA", frs_per_G);
         manifest_expected.add_entry(round, "CALLDATA_READ_COUNTS", frs_per_G);
         manifest_expected.add_entry(round, "CALLDATA_READ_TAGS", frs_per_G);
-        manifest_expected.add_entry(round, "CALLDATA_2", frs_per_G);
-        manifest_expected.add_entry(round, "CALLDATA_2_READ_COUNTS", frs_per_G);
-        manifest_expected.add_entry(round, "CALLDATA_2_READ_TAGS", frs_per_G);
+        manifest_expected.add_entry(round, "SECONDARY_CALLDATA", frs_per_G);
+        manifest_expected.add_entry(round, "SECONDARY_CALLDATA_READ_COUNTS", frs_per_G);
+        manifest_expected.add_entry(round, "SECONDARY_CALLDATA_READ_TAGS", frs_per_G);
         manifest_expected.add_entry(round, "RETURN_DATA", frs_per_G);
         manifest_expected.add_entry(round, "RETURN_DATA_READ_COUNTS", frs_per_G);
         manifest_expected.add_entry(round, "RETURN_DATA_READ_TAGS", frs_per_G);
@@ -78,7 +78,7 @@ class MegaTranscriptTests : public ::testing::Test {
         round++;
         manifest_expected.add_entry(round, "LOOKUP_INVERSES", frs_per_G);
         manifest_expected.add_entry(round, "CALLDATA_INVERSES", frs_per_G);
-        manifest_expected.add_entry(round, "CALLDATA_2_INVERSES", frs_per_G);
+        manifest_expected.add_entry(round, "SECONDARY_CALLDATA_INVERSES", frs_per_G);
         manifest_expected.add_entry(round, "RETURN_DATA_INVERSES", frs_per_G);
         manifest_expected.add_entry(round, "Z_PERM", frs_per_G);
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
@@ -144,9 +144,12 @@ template <IsUltraFlavor Flavor> void OinkProver<Flavor>::execute_log_derivative_
     // If Mega, commit to the databus inverse polynomials and send
     if constexpr (IsGoblinFlavor<Flavor>) {
         witness_commitments.calldata_inverses = commitment_key->commit(proving_key.polynomials.calldata_inverses);
+        witness_commitments.calldata_2_inverses = commitment_key->commit(proving_key.polynomials.calldata_2_inverses);
         witness_commitments.return_data_inverses = commitment_key->commit(proving_key.polynomials.return_data_inverses);
         transcript->send_to_verifier(domain_separator + commitment_labels.calldata_inverses,
                                      witness_commitments.calldata_inverses);
+        transcript->send_to_verifier(domain_separator + commitment_labels.calldata_2_inverses,
+                                     witness_commitments.calldata_2_inverses);
         transcript->send_to_verifier(domain_separator + commitment_labels.return_data_inverses,
                                      witness_commitments.return_data_inverses);
     }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
@@ -143,15 +143,12 @@ template <IsUltraFlavor Flavor> void OinkProver<Flavor>::execute_log_derivative_
 
     // If Mega, commit to the databus inverse polynomials and send
     if constexpr (IsGoblinFlavor<Flavor>) {
-        witness_commitments.calldata_inverses = commitment_key->commit(proving_key.polynomials.calldata_inverses);
-        witness_commitments.calldata_2_inverses = commitment_key->commit(proving_key.polynomials.calldata_2_inverses);
-        witness_commitments.return_data_inverses = commitment_key->commit(proving_key.polynomials.return_data_inverses);
-        transcript->send_to_verifier(domain_separator + commitment_labels.calldata_inverses,
-                                     witness_commitments.calldata_inverses);
-        transcript->send_to_verifier(domain_separator + commitment_labels.calldata_2_inverses,
-                                     witness_commitments.calldata_2_inverses);
-        transcript->send_to_verifier(domain_separator + commitment_labels.return_data_inverses,
-                                     witness_commitments.return_data_inverses);
+        for (auto [commitment, polynomial, label] : zip_view(witness_commitments.get_databus_inverses(),
+                                                             proving_key.polynomials.get_databus_inverses(),
+                                                             commitment_labels.get_databus_inverses())) {
+            commitment = commitment_key->commit(polynomial);
+            transcript->send_to_verifier(domain_separator + label, commitment);
+        }
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
@@ -114,6 +114,8 @@ template <IsUltraFlavor Flavor> void OinkVerifier<Flavor>::execute_log_derivativ
     if constexpr (IsGoblinFlavor<Flavor>) {
         witness_comms.calldata_inverses =
             transcript->template receive_from_prover<Commitment>(domain_separator + comm_labels.calldata_inverses);
+        witness_comms.calldata_2_inverses =
+            transcript->template receive_from_prover<Commitment>(domain_separator + comm_labels.calldata_2_inverses);
         witness_comms.return_data_inverses =
             transcript->template receive_from_prover<Commitment>(domain_separator + comm_labels.return_data_inverses);
     }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
@@ -112,12 +112,10 @@ template <IsUltraFlavor Flavor> void OinkVerifier<Flavor>::execute_log_derivativ
 
     // If Goblin (i.e. using DataBus) receive commitments to log-deriv inverses polynomials
     if constexpr (IsGoblinFlavor<Flavor>) {
-        witness_comms.calldata_inverses =
-            transcript->template receive_from_prover<Commitment>(domain_separator + comm_labels.calldata_inverses);
-        witness_comms.calldata_2_inverses =
-            transcript->template receive_from_prover<Commitment>(domain_separator + comm_labels.calldata_2_inverses);
-        witness_comms.return_data_inverses =
-            transcript->template receive_from_prover<Commitment>(domain_separator + comm_labels.return_data_inverses);
+        for (auto [commitment, label] :
+             zip_view(witness_comms.get_databus_inverses(), comm_labels.get_databus_inverses())) {
+            commitment = transcript->template receive_from_prover<Commitment>(domain_separator + label);
+        }
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/relation_correctness.test.cpp
@@ -344,9 +344,9 @@ TEST_F(UltraRelationCorrectnessTests, Mega)
     ensure_non_zero(proving_key.polynomials.calldata);
     ensure_non_zero(proving_key.polynomials.calldata_read_counts);
     ensure_non_zero(proving_key.polynomials.calldata_inverses);
-    ensure_non_zero(proving_key.polynomials.calldata_2);
-    ensure_non_zero(proving_key.polynomials.calldata_2_read_counts);
-    ensure_non_zero(proving_key.polynomials.calldata_2_inverses);
+    ensure_non_zero(proving_key.polynomials.secondary_calldata);
+    ensure_non_zero(proving_key.polynomials.secondary_calldata_read_counts);
+    ensure_non_zero(proving_key.polynomials.secondary_calldata_inverses);
     ensure_non_zero(proving_key.polynomials.return_data);
     ensure_non_zero(proving_key.polynomials.return_data_read_counts);
     ensure_non_zero(proving_key.polynomials.return_data_inverses);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/relation_correctness.test.cpp
@@ -344,6 +344,9 @@ TEST_F(UltraRelationCorrectnessTests, Mega)
     ensure_non_zero(proving_key.polynomials.calldata);
     ensure_non_zero(proving_key.polynomials.calldata_read_counts);
     ensure_non_zero(proving_key.polynomials.calldata_inverses);
+    ensure_non_zero(proving_key.polynomials.calldata_2);
+    ensure_non_zero(proving_key.polynomials.calldata_2_read_counts);
+    ensure_non_zero(proving_key.polynomials.calldata_2_inverses);
     ensure_non_zero(proving_key.polynomials.return_data);
     ensure_non_zero(proving_key.polynomials.return_data_read_counts);
     ensure_non_zero(proving_key.polynomials.return_data_inverses);


### PR DESCRIPTION
Adds a second calldata column to the databus (which now has 3 columns). This is needed to support kernel circuits which will have two calldata inputs (one from previous kernel, one from a function circuit).

Note: I'm using the admittedly uninspired naming `calldata_2`. Originally thought of this as just a placeholder but a better name never came to mind. Open to suggestions.