### PR TITLE
chore: Fix benchmark summary credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,8 @@ jobs:
         working-directory: ./yarn-project/scripts
         run: |
           earthly-ci -P +bench-comment
+        env:
+          AZTEC_BOT_GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
 
   bb-gcc:
     needs: [build-images, changes]


### PR DESCRIPTION
In #7462 the aztec commenter github token was removed from the bench-comment job in favor of loading secrets in the earthly-ci wrapper script. However, the token was never injected into env, so the bench-summary was silently failing due to invalid credentials.
