### PR TITLE
chore: Reenable warp test in guides e2e

### DIFF
--- a/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
+++ b/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
@@ -126,7 +126,8 @@ describe('guides/dapp/testing', () => {
 
       it('warps time to 1h into the future', async () => {
         // docs:start:warp
-        const newTimestamp = Math.floor(Date.now() / 1000) + 60 * 60 * 24;
+        const timestamp = await cheats.eth.timestamp();
+        const newTimestamp = timestamp + 60 * 60 * 24;
         await cheats.aztec.warp(newTimestamp);
         await testContract.methods.is_time_equal(newTimestamp).send().wait();
         // docs:end:warp

--- a/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
+++ b/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
@@ -124,8 +124,7 @@ describe('guides/dapp/testing', () => {
         cheats = CheatCodes.create(ETHEREUM_HOST, pxe);
       });
 
-      // TODO(@spalladino) Disabled due to flakiness after #7347. Note that warp is already tested in e2e_cheat_codes.
-      it.skip('warps time to 1h into the future', async () => {
+      it('warps time to 1h into the future', async () => {
         // docs:start:warp
         const newTimestamp = Math.floor(Date.now() / 1000) + 60 * 60 * 24;
         await cheats.aztec.warp(newTimestamp);


### PR DESCRIPTION
Had been disabled due to flakiness, let's see how it's doing now...