### PR TITLE
feat: Client ivc proof verification in sequencer

### DIFF
--- a/yarn-project/circuit-types/src/stats/stats.ts
+++ b/yarn-project/circuit-types/src/stats/stats.ts
@@ -164,6 +164,18 @@ export type CircuitProvingStats = {
   numPublicInputs: number;
 };
 
+/** Stats for verifying a circuit */
+export type CircuitVerificationStats = {
+  /** Name of the event. */
+  eventName: 'circuit-verification';
+  /** Name of the circuit. */
+  circuitName: CircuitName;
+  /** Type of proof (client-ivc, honk, etc) */
+  proofType: 'client-ivc' | 'ultra-honk';
+  /** Duration in ms. */
+  duration: number;
+};
+
 /** Stats for an L2 block built by a sequencer. */
 export type L2BlockBuiltStats = {
   /** Name of the event. */

--- a/yarn-project/end-to-end/src/benchmarks/bench_prover.test.ts
+++ b/yarn-project/end-to-end/src/benchmarks/bench_prover.test.ts
@@ -208,15 +208,13 @@ describe('benchmarks/proving', () => {
     const verifier = await BBCircuitVerifier.new((await getBBConfig(ctx.logger))!);
     for (let i = 0; i < txVerifyIterations; i++) {
       for (const tx of provenTxs) {
-        await verifier.verifyProof(tx);
+        expect(await verifier.verifyProof(tx)).toBe(true);
       }
     }
 
     ctx.logger.info('Sending transactions');
     const txs = [
-      fnCalls[0].send({
-        fee: feeFnCall0,
-      }),
+      fnCalls[0].send({ fee: feeFnCall0 }),
       fnCalls[1].send(),
       // fnCalls[2].send(),
       // fnCalls[3].send(),

--- a/yarn-project/end-to-end/src/benchmarks/bench_prover.test.ts
+++ b/yarn-project/end-to-end/src/benchmarks/bench_prover.test.ts
@@ -1,6 +1,7 @@
 import { getSchnorrAccount, getSchnorrWallet } from '@aztec/accounts/schnorr';
 import { PublicFeePaymentMethod, TxStatus, sleep } from '@aztec/aztec.js';
 import { type AccountWallet } from '@aztec/aztec.js/wallet';
+import { BBCircuitVerifier } from '@aztec/bb-prover';
 import { CompleteAddress, Fq, Fr, GasSettings } from '@aztec/circuits.js';
 import { FPCContract, GasTokenContract, TestContract, TokenContract } from '@aztec/noir-contracts.js';
 import { GasTokenAddress } from '@aztec/protocol-contracts/gas-token';
@@ -17,6 +18,11 @@ import { type EndToEndContext, setup } from '../fixtures/utils.js';
 jest.setTimeout(1_800_000);
 
 const txTimeoutSec = 3600;
+
+// How many times we'll run bb verify on each tx for benchmarking purposes
+const txVerifyIterations = process.env.BENCH_TX_VERIFY_ITERATIONS
+  ? parseInt(process.env.BENCH_TX_VERIFY_ITERATIONS)
+  : 10;
 
 // This makes AVM proving throw if there's a failure.
 process.env.AVM_PROVING_STRICT = '1';
@@ -191,16 +197,20 @@ describe('benchmarks/proving', () => {
     // };
 
     ctx.logger.info('Proving transactions');
-    await Promise.all([
-      fnCalls[0].prove({
-        fee: feeFnCall0,
-      }),
+    const provenTxs = await Promise.all([
+      fnCalls[0].prove({ fee: feeFnCall0 }),
       fnCalls[1].prove(),
       // fnCalls[2].prove(),
       // fnCalls[3].prove(),
     ]);
 
-    ctx.logger.info('Finished proving');
+    ctx.logger.info('Verifying transactions client proofs');
+    const verifier = await BBCircuitVerifier.new((await getBBConfig(ctx.logger))!);
+    for (let i = 0; i < txVerifyIterations; i++) {
+      for (const tx of provenTxs) {
+        await verifier.verifyProof(tx);
+      }
+    }
 
     ctx.logger.info('Sending transactions');
     const txs = [


### PR DESCRIPTION
Wires the `verify_client_ivc` bb call to the BBVerifier in ts (which still needs love so we don't read the vk from the tx object), and runs it multiple times as part of the full prover e2e to benchmark how much it takes to verify a client ivc proof. Outputs event logs like the following, though they are not yet loaded by bench-aggregate:

```
{"circuitName":"private-kernel-tail-to-public","duration":3640.18761600001,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:37:19.785Z"}
{"circuitName":"private-kernel-tail","duration":3630.627105999971,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:37:23.419Z"}
{"circuitName":"private-kernel-tail-to-public","duration":3636.371545000002,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:37:27.057Z"}
{"circuitName":"private-kernel-tail","duration":3561.3480010000058,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:37:30.620Z"}
{"circuitName":"private-kernel-tail-to-public","duration":3588.0015310000163,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:37:34.211Z"}
{"circuitName":"private-kernel-tail","duration":3610.198040999996,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:37:37.824Z"}
{"circuitName":"private-kernel-tail-to-public","duration":3569.164287999971,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:37:41.396Z"}
{"circuitName":"private-kernel-tail","duration":3557.741927999945,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:37:44.955Z"}
{"circuitName":"private-kernel-tail-to-public","duration":3568.2085040000384,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:37:48.526Z"}
{"circuitName":"private-kernel-tail","duration":3557.740408999962,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:37:52.088Z"}
{"circuitName":"private-kernel-tail-to-public","duration":3568.786586000002,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:37:55.659Z"}
{"circuitName":"private-kernel-tail","duration":3559.4025660000043,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:37:59.221Z"}
{"circuitName":"private-kernel-tail-to-public","duration":3567.728372999991,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:38:02.792Z"}
{"circuitName":"private-kernel-tail","duration":3566.036272999947,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:38:06.362Z"}
{"circuitName":"private-kernel-tail-to-public","duration":3569.9772229999653,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:38:09.935Z"}
{"circuitName":"private-kernel-tail","duration":3561.0968479999574,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:38:13.499Z"}
{"circuitName":"private-kernel-tail-to-public","duration":3569.0639850000152,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:38:17.071Z"}
{"circuitName":"private-kernel-tail","duration":3562.8168169999844,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:38:20.639Z"}
{"circuitName":"private-kernel-tail-to-public","duration":3568.064185999974,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:38:24.209Z"}
{"circuitName":"private-kernel-tail","duration":3558.7975469999947,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:38:27.771Z"}
{"circuitName":"private-kernel-tail","duration":3616.5346459999564,"eventName":"circuit-verification","level":"debug","message":"ClientIVC verification successful","namespace":"aztec:bb-verifier","proofType":"client-ivc","timestamp":"2024-07-22T19:38:31.404Z"}
```

