### PR TITLE
fix: Do not load the BN254 CRS for verifying client ivc proofs

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -405,7 +405,7 @@ bool verify_client_ivc(const std::filesystem::path& proof_path,
                        const std::filesystem::path& eccvm_vk_path,
                        const std::filesystem::path& translator_vk_path)
 {
-    init_bn254_crs(1 << 24);
+    init_bn254_crs(1);
     init_grumpkin_crs(1 << 14);
 
     const auto proof = from_buffer<ClientIVC::Proof>(read_file(proof_path));


### PR DESCRIPTION
> since we are verifying we only need the g2_data part of the bn254 CRS
> (so you can pass size 0 or 1 or whatever small value doesn't error)

Thanks @codygunton for the tip!
