### PR TITLE
chore(avm): use commit_sparse

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/generated/avm_prover.cpp
@@ -63,7 +63,7 @@ void AvmProver::execute_wire_commitments_round()
     auto wire_polys = prover_polynomials.get_wires();
     auto labels = commitment_labels.get_wires();
     for (size_t idx = 0; idx < wire_polys.size(); ++idx) {
-        transcript->send_to_verifier(labels[idx], commitment_key->commit(wire_polys[idx]));
+        transcript->send_to_verifier(labels[idx], commitment_key->commit_sparse(wire_polys[idx]));
     }
 }
 
@@ -92,6 +92,7 @@ void AvmProver::execute_log_derivative_inverse_commitments_round()
 {
     // Commit to all logderivative inverse polynomials
     for (auto [commitment, key_poly] : zip_view(witness_commitments.get_derived(), key->get_derived())) {
+        // We don't use commit_sparse here because the logderivative inverse polynomials are dense
         commitment = commitment_key->commit(key_poly);
     }
 

--- a/bb-pilcom/bb-pil-backend/templates/prover.cpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/prover.cpp.hbs
@@ -64,7 +64,7 @@ void {{name}}Prover::execute_wire_commitments_round()
     auto wire_polys = prover_polynomials.get_wires();
     auto labels = commitment_labels.get_wires();
     for (size_t idx = 0; idx < wire_polys.size(); ++idx) {
-        transcript->send_to_verifier(labels[idx], commitment_key->commit(wire_polys[idx]));
+        transcript->send_to_verifier(labels[idx], commitment_key->commit_sparse(wire_polys[idx]));
     }
 }
 
@@ -93,12 +93,13 @@ void {{name}}Prover::execute_log_derivative_inverse_commitments_round()
 {
     // Commit to all logderivative inverse polynomials
     for (auto [commitment, key_poly] : zip_view(witness_commitments.get_derived(), key->get_derived())) {
-       commitment = commitment_key->commit(key_poly);
+        // We don't use commit_sparse here because the logderivative inverse polynomials are dense
+        commitment = commitment_key->commit(key_poly);
     }
 
     // Send all commitments to the verifier
     for (auto [label, commitment] : zip_view(commitment_labels.get_derived(), witness_commitments.get_derived())) {
-       transcript->send_to_verifier(label, commitment);
+        transcript->send_to_verifier(label, commitment);
     }
 }
 


### PR DESCRIPTION
Ran on a ~2^19 trace with 7% non-zero elems (the long keccak).

BEFORE
```
prove/execute_log_derivative_inverse_commitments_round_ms: 1598
prove/execute_wire_commitments_round_ms: 4992
```

AFTER
```
prove/execute_log_derivative_inverse_commitments_round_ms: 1826
prove/execute_wire_commitments_round_ms: 2092
```