### PR TITLE
feat: Leotychidas

### DIFF
--- a/yarn-project/aztec-node/package.json
+++ b/yarn-project/aztec-node/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@aztec/archiver": "workspace:^",
+    "@aztec/aztec-validator": "workspace:^",
     "@aztec/bb-prover": "workspace:^",
     "@aztec/circuit-types": "workspace:^",
     "@aztec/circuits.js": "workspace:^",

--- a/yarn-project/aztec-validator/README.md
+++ b/yarn-project/aztec-validator/README.md
@@ -1,0 +1,1 @@
+idea is that this validator client just handles signing things

--- a/yarn-project/aztec-validator/package.json
+++ b/yarn-project/aztec-validator/package.json
@@ -1,24 +1,25 @@
 {
-  "name": "@aztec/p2p",
-  "version": "0.0.0",
+  "name": "@aztec/aztec-validator",
+  "version": "0.1.0",
+  "main": "dest/index.js",
   "type": "module",
   "exports": "./dest/index.js",
+  "bin": "./dest/bin/index.js",
   "typedocOptions": {
     "entryPoints": [
       "./src/index.ts"
     ],
-    "name": "P2P",
+    "name": "Aztec Node",
     "tsconfig": "./tsconfig.json"
   },
   "scripts": {
+    "start": "node --no-warnings ./dest/bin",
     "build": "yarn clean && tsc -b",
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
-    "start": "node ./dest",
-    "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests"
   },
   "inherits": [
     "../package.common.json"
@@ -52,51 +53,32 @@
           "summaryThreshold": 9999
         }
       ]
-    ],
-    "testTimeout": 15000
+    ]
   },
   "dependencies": {
-    "@aztec/aztec-validator": "workspace:^",
-    "@aztec/circuit-types": "workspace:^",
-    "@aztec/circuits.js": "workspace:^",
+    "@aztec/ethereum": "workspace:^",
     "@aztec/foundation": "workspace:^",
     "@aztec/kv-store": "workspace:^",
+    "@aztec/l1-artifacts": "workspace:^",
+    "@aztec/merkle-tree": "workspace:^",
+    "@aztec/p2p": "workspace:^",
+    "@aztec/protocol-contracts": "workspace:^",
+    "@aztec/prover-client": "workspace:^",
+    "@aztec/sequencer-client": "workspace:^",
+    "@aztec/simulator": "workspace:^",
     "@aztec/telemetry-client": "workspace:^",
-    "@chainsafe/discv5": "9.0.0",
-    "@chainsafe/enr": "3.0.0",
-    "@chainsafe/libp2p-gossipsub": "13.0.0",
-    "@chainsafe/libp2p-noise": "^15.0.0",
-    "@chainsafe/libp2p-yamux": "^6.0.2",
-    "@libp2p/bootstrap": "10.0.0",
-    "@libp2p/crypto": "4.0.3",
-    "@libp2p/identify": "1.0.18",
-    "@libp2p/interface": "1.3.1",
-    "@libp2p/kad-dht": "10.0.4",
-    "@libp2p/mplex": "10.0.16",
-    "@libp2p/peer-id": "4.0.7",
-    "@libp2p/peer-id-factory": "4.1.1",
-    "@libp2p/peer-store": "10.0.16",
-    "@libp2p/tcp": "9.0.24",
-    "@multiformats/multiaddr": "12.1.14",
-    "interface-datastore": "^8.2.11",
-    "interface-store": "^5.1.8",
-    "it-pipe": "^3.0.1",
-    "libp2p": "1.5.0",
-    "semver": "^7.6.0",
-    "sha3": "^2.1.4",
+    "@aztec/types": "workspace:^",
+    "@aztec/world-state": "workspace:^",
     "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.14.6",
-    "it-drain": "^3.0.5",
-    "it-length": "^3.0.6",
+    "@types/node": "^18.7.23",
     "jest": "^29.5.0",
-    "jest-mock-extended": "^3.0.4",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4",
-    "uint8arrays": "^5.0.3"
+    "viem": "^2.7.15"
   },
   "files": [
     "dest",

--- a/yarn-project/aztec-validator/src/index.ts
+++ b/yarn-project/aztec-validator/src/index.ts
@@ -1,0 +1,9 @@
+export * from "./validator.js";
+
+// Create a validator client based on the node config
+import { AztecValidator } from "./validator.js";
+
+// A validator is really just a glorified signer at this point
+export function createValidator(signingKey: string): AztecValidator {
+   return new AztecValidator(signingKey) ;
+}

--- a/yarn-project/aztec-validator/src/validator.ts
+++ b/yarn-project/aztec-validator/src/validator.ts
@@ -1,0 +1,25 @@
+import {BlockAttestation, BlockProposal, Signature} from "@aztec/foundation/sequencer";
+import {privateKeyToAccount} from "viem/accounts";
+
+
+export class AztecValidator {
+    private signer;
+
+    constructor(private signingKey: string) {
+        this.signer = privateKeyToAccount(signingKey as `0x${string})`);
+    }
+
+    async attestToProposal(proposal: BlockProposal) : Promise<BlockAttestation> {
+        // Sign the proposal as a buffer
+        const message = `0x${proposal.toBuffer().toString("hex")}`;
+        const signature = await this.signer.signMessage({message})
+
+        // TODO(md): add conversion types
+        const sigBuffer = new Signature(Buffer.from(signature.slice(2), "hex"));
+
+        return new BlockAttestation(
+            proposal,
+            sigBuffer
+        );
+    }
+}

--- a/yarn-project/aztec-validator/tsconfig.json
+++ b/yarn-project/aztec-validator/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "..",
+  "compilerOptions": {
+    "outDir": "dest",
+    "rootDir": "src",
+    "tsBuildInfoFile": ".tsbuildinfo"
+  },
+  "references": [
+    {
+      "path": "../foundation"
+    },
+  ],
+  "include": ["src"]
+}

--- a/yarn-project/end-to-end/src/e2e_p2p_committee.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p_committee.ts
@@ -1,0 +1,139 @@
+/**
+ * An example e2e test where every node has validator responsibilities
+ *
+ * Spin up a p2p network where all of the nodes are connected to each other
+ *
+ * One of the nodes will send a small block of data (proposal) to all of the other nodes
+ * - Each of the nodes will sign the data with an ecdsa signature
+ * - The nodes will propagate the signatures
+ * - The leader, who will be hardcoded in configuration will receive the signatures and validate that they came from the other nodes.
+ */
+import { AztecNodeConfig } from '@aztec/aztec-node';
+import { AztecNodeService } from '@aztec/aztec-node';
+import { AztecAddress, DebugLogger, SentTx, createAztecNodeClient, sleep } from '@aztec/aztec.js';
+import { BootstrapNode } from '@aztec/p2p';
+import { createLibP2PPeerId } from '@aztec/p2p';
+import { BootNodeConfig } from '@aztec/p2p';
+import { PXEService } from '@aztec/pxe';
+
+import fs from 'fs';
+
+import { setup } from './fixtures/utils.js';
+
+const NUM_NODES = 4;
+const NUM_TXS_PER_BLOCK = 2;
+const NUM_TXS_PER_NODE = 1;
+const BOOT_NODE_UDP_PORT = 40400;
+
+interface NodeContext {
+  node: AztecNodeService;
+  pxeService: PXEService;
+  txs: SentTx[];
+  account: AztecAddress;
+}
+
+// TODO(md): copied and pasted from the other p2p test
+const PEER_ID_PRIVATE_KEYS = [
+  '0802122002f651fd8653925529e3baccb8489b3af4d7d9db440cbf5df4a63ff04ea69683',
+  '08021220c3bd886df5fe5b33376096ad0dab3d2dc86ed2a361d5fde70f24d979dc73da41',
+  '080212206b6567ac759db5434e79495ec7458e5e93fe479a5b80713446e0bce5439a5655',
+  '08021220366453668099bdacdf08fab476ee1fced6bf00ddc1223d6c2ee626e7236fb526',
+];
+
+describe('e2e_p2p_committee', () => {
+  let config: AztecNodeConfig;
+  let logger: DebugLogger;
+  let teardown: () => Promise<void>;
+  let bootstrapNode: BootstrapNode;
+  let bootstrapNodeEnr: string;
+
+  beforeEach(async () => {
+    ({ teardown, config, logger } = await setup(0));
+    bootstrapNode = await createBootstrapNode();
+    bootstrapNodeEnr = bootstrapNode.getENR().encodeTxt();
+  });
+
+  afterEach(() => teardown());
+
+  afterAll(() => {
+    for (let i = 0; i < NUM_NODES; i++) {
+      fs.rmSync(`./data-${i}`, { recursive: true, force: true });
+    }
+  });
+
+  it('should sign proposal from peers', async () => {
+    // TODO(md): turn reused logic into a suite
+    if (!bootstrapNodeEnr) {
+      throw new Error('Bootstrap node ENR is not available');
+    }
+
+    let contexts: NodeContext[] = [];
+    const nodes: AztecNodeService[] = [];
+    for (let i = 0; i < NUM_NODES; i++) {
+      // Place on consecutive ports
+      //
+      const node = await createAztecNodeClient(i + 1 + BOOT_NODE_UDP_PORT, bootstrapNodeEnr, i, `./data-${i}`);
+      nodes.push(node);
+    }
+
+    // wait to let the peers discover each other
+    await sleep(2000);
+
+    // Create a proposal on one of the nodes
+    // Get signatures from all of the other nodes
+  });
+
+  // TODO(md): copied from p2p e2e
+  const createBootstrapNode = async () => {
+    const peerId = await createLibP2PPeerId();
+    const bootstrapNode = new BootstrapNode();
+    const config: BootNodeConfig = {
+      udpListenAddress: `0.0.0.0:${BOOT_NODE_UDP_PORT}`,
+      udpAnnounceAddress: `127.0.0.1:${BOOT_NODE_UDP_PORT}`,
+      peerIdPrivateKey: Buffer.from(peerId.privateKey!).toString('hex'),
+      minPeerCount: 10,
+      maxPeerCount: 100,
+      p2pPeerCheckIntervalMS: 100,
+    };
+    await bootstrapNode.start(config);
+
+    return bootstrapNode;
+  };
+
+  // TODO(md): copied from the p2p e2e
+  // creates a P2P enabled instance of Aztec Node Service
+  const createNode = async (
+    tcpListenPort: number,
+    bootstrapNode: string | undefined,
+    publisherAddressIndex: number,
+    dataDirectory?: string,
+  ) => {
+    // We use different L1 publisher accounts in order to avoid duplicate tx nonces. We start from
+    // publisherAddressIndex + 1 because index 0 was already used during test environment setup.
+    const hdAccount = mnemonicToAccount(MNEMONIC, { addressIndex: publisherAddressIndex + 1 });
+    const publisherPrivKey = Buffer.from(hdAccount.getHdKey().privateKey!);
+    config.publisherPrivateKey = `0x${publisherPrivKey!.toString('hex')}`;
+
+    const newConfig: AztecNodeConfig = {
+      ...config,
+      peerIdPrivateKey: PEER_ID_PRIVATE_KEYS[publisherAddressIndex],
+      udpListenAddress: `0.0.0.0:${tcpListenPort}`,
+      tcpListenAddress: `0.0.0.0:${tcpListenPort}`,
+      tcpAnnounceAddress: `127.0.0.1:${tcpListenPort}`,
+      udpAnnounceAddress: `127.0.0.1:${tcpListenPort}`,
+      minTxsPerBlock: NUM_TXS_PER_BLOCK,
+      maxTxsPerBlock: NUM_TXS_PER_BLOCK,
+      p2pEnabled: true,
+      p2pBlockCheckIntervalMS: 1000,
+      p2pL2QueueSize: 1,
+      transactionProtocol: '',
+      dataDirectory,
+      bootstrapNodes: bootstrapNode ? [bootstrapNode] : [],
+    };
+    return await AztecNodeService.createAndSync(
+      newConfig,
+      new NoopTelemetryClient(),
+      createDebugLogger(`aztec:node-${tcpListenPort}`),
+    );
+  };
+});

--- a/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p_network.test.ts
@@ -152,7 +152,6 @@ describe('e2e_p2p_network', () => {
     );
 
     // shutdown all nodes.
-    // for (const context of contexts) {
     for (const context of contexts) {
       await context.node.stop();
       await context.pxeService.stop();

--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -42,7 +42,8 @@
     "./testing": "./dest/testing/index.js",
     "./array": "./dest/array/index.js",
     "./validation": "./dest/validation/index.js",
-    "./promise": "./dest/promise/index.js"
+    "./promise": "./dest/promise/index.js",
+    "./sequencer": "./dest/sequencer/index.js"
   },
   "scripts": {
     "build": "yarn clean && tsc -b",

--- a/yarn-project/foundation/src/index.ts
+++ b/yarn-project/foundation/src/index.ts
@@ -28,3 +28,4 @@ export * as url from './url/index.js';
 export * as wasm from './wasm/index.js';
 export * as worker from './worker/index.js';
 export * as testing from './testing/index.js';
+export * as sequencer from './sequencer/index.js';

--- a/yarn-project/foundation/src/sequencer/block_attestation.ts
+++ b/yarn-project/foundation/src/sequencer/block_attestation.ts
@@ -1,0 +1,16 @@
+import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
+
+import { BlockProposal } from './block_proposal.js';
+
+export class BlockAttestation {
+  constructor(public readonly blockProposal: BlockProposal, public readonly signature: Buffer) {}
+
+  toBuffer() {
+    return serializeToBuffer([this.blockProposal, this.signature]);
+  }
+
+  static fromBuffer(buffer: Buffer | BufferReader): BlockAttestation {
+    const reader = BufferReader.asReader(buffer);
+    return new BlockAttestation(reader.readObject(BlockProposal), reader.readBuffer());
+  }
+}

--- a/yarn-project/foundation/src/sequencer/block_attestation.ts
+++ b/yarn-project/foundation/src/sequencer/block_attestation.ts
@@ -1,9 +1,10 @@
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
 import { BlockProposal } from './block_proposal.js';
+import { Signature } from './signature.js';
 
 export class BlockAttestation {
-  constructor(public readonly blockProposal: BlockProposal, public readonly signature: Buffer) {}
+  constructor(public readonly blockProposal: BlockProposal, public readonly signature: Signature) {}
 
   toBuffer() {
     return serializeToBuffer([this.blockProposal, this.signature]);
@@ -11,6 +12,6 @@ export class BlockAttestation {
 
   static fromBuffer(buffer: Buffer | BufferReader): BlockAttestation {
     const reader = BufferReader.asReader(buffer);
-    return new BlockAttestation(reader.readObject(BlockProposal), reader.readBuffer());
+    return new BlockAttestation(reader.readObject(BlockProposal), reader.readObject(Signature));
   }
 }

--- a/yarn-project/foundation/src/sequencer/block_proposal.ts
+++ b/yarn-project/foundation/src/sequencer/block_proposal.ts
@@ -1,0 +1,16 @@
+import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
+
+// For the sake of this example, the proposals are just a message that is signed by the proposer
+// In reality it should be an array of Txs?
+export class BlockProposal {
+  constructor(public readonly message: Buffer, public readonly signature: Buffer) {}
+
+  toBuffer() {
+    return serializeToBuffer([this.message, this.signature]);
+  }
+
+  static fromBuffer(buffer: Buffer | BufferReader): BlockProposal {
+    const reader = BufferReader.asReader(buffer);
+    return new BlockProposal(reader.readBuffer(), reader.readBuffer());
+  }
+}

--- a/yarn-project/foundation/src/sequencer/block_proposal.ts
+++ b/yarn-project/foundation/src/sequencer/block_proposal.ts
@@ -1,16 +1,34 @@
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
+import { Signature } from './signature.js';
+
+
+export class ProposalMessage {
+  constructor(public readonly message: Buffer) {}
+
+  toBuffer() {
+    return serializeToBuffer([this.message.length, this.message]);
+  }
+
+  static fromBuffer(buffer: Buffer | BufferReader): ProposalMessage {
+    const reader = BufferReader.asReader(buffer);
+    return new ProposalMessage(reader.readBuffer());
+  }
+}
+
 
 // For the sake of this example, the proposals are just a message that is signed by the proposer
 // In reality it should be an array of Txs?
 export class BlockProposal {
-  constructor(public readonly message: Buffer, public readonly signature: Buffer) {}
+  constructor(public readonly message: ProposalMessage, public readonly signature: Signature) {}
 
   toBuffer() {
     return serializeToBuffer([this.message, this.signature]);
   }
 
   static fromBuffer(buffer: Buffer | BufferReader): BlockProposal {
+    console.log("the buffer: ", buffer);
     const reader = BufferReader.asReader(buffer);
-    return new BlockProposal(reader.readBuffer(), reader.readBuffer());
+    return new BlockProposal(reader.readObject(ProposalMessage), reader.readObject(Signature));
   }
+
 }

--- a/yarn-project/foundation/src/sequencer/index.ts
+++ b/yarn-project/foundation/src/sequencer/index.ts
@@ -1,0 +1,2 @@
+export * from './block_proposal.js';
+export * from './block_attestation.js';

--- a/yarn-project/foundation/src/sequencer/index.ts
+++ b/yarn-project/foundation/src/sequencer/index.ts
@@ -1,2 +1,3 @@
 export * from './block_proposal.js';
 export * from './block_attestation.js';
+export * from "./signature.js";

--- a/yarn-project/foundation/src/sequencer/signature.ts
+++ b/yarn-project/foundation/src/sequencer/signature.ts
@@ -1,0 +1,17 @@
+import { BufferReader, serializeToBuffer } from "../serialize/index.js";
+
+// Temp wrapper for p2p serde
+export class Signature {
+    constructor(public readonly signature: Buffer) {}
+
+
+  toBuffer() {
+    return serializeToBuffer([this.signature.length, this.signature]);
+  }
+
+  static fromBuffer(buffer: Buffer | BufferReader): Signature {
+    const reader = BufferReader.asReader(buffer);
+    return new Signature(reader.readBuffer());
+  }
+
+}

--- a/yarn-project/p2p/src/client/index.ts
+++ b/yarn-project/p2p/src/client/index.ts
@@ -8,6 +8,7 @@ import { DummyP2PService } from '../service/dummy_service.js';
 import { LibP2PService, createLibP2PPeerId } from '../service/index.js';
 import { type TxPool } from '../tx_pool/index.js';
 import { getPublicIp, splitAddressPort } from '../util.js';
+import {AztecValidator} from "@aztec/aztec-validator";
 
 export * from './p2p_client.js';
 
@@ -15,6 +16,7 @@ export const createP2PClient = async (
   config: P2PConfig,
   store: AztecKVStore,
   txPool: TxPool,
+  validatorClient: AztecValidator,
   l2BlockSource: L2BlockSource,
 ) => {
   let p2pService;
@@ -59,7 +61,7 @@ export const createP2PClient = async (
     // Create peer discovery service
     const peerId = await createLibP2PPeerId(config.peerIdPrivateKey);
     const discoveryService = new DiscV5Service(peerId, config);
-    p2pService = await LibP2PService.new(config, discoveryService, peerId, txPool, store);
+    p2pService = await LibP2PService.new(config, discoveryService, peerId, txPool, validatorClient, store);
   } else {
     p2pService = new DummyP2PService();
   }

--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -40,6 +40,8 @@ describe('In-Memory P2P Client', () => {
       start: jest.fn(),
       stop: jest.fn(),
       propagateTx: jest.fn(),
+      propagateProposal: jest.fn(),
+      propagateAttestation: jest.fn(),
     };
 
     blockSource = new MockBlockSource();

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -7,6 +7,7 @@ import { type AztecKVStore, type AztecSingleton } from '@aztec/kv-store';
 import { getP2PConfigEnvVars } from '../config.js';
 import type { P2PService } from '../service/service.js';
 import { type TxPool } from '../tx_pool/index.js';
+import {AztecValidator} from "@aztec/aztec-validator";
 
 /**
  * Enum defining the possible states of the p2p client.
@@ -121,6 +122,10 @@ export class P2PClient implements P2P {
 
   private synchedLatestBlockNumber: AztecSingleton<number>;
   private synchedProvenBlockNumber: AztecSingleton<number>;
+
+
+  // Temporary
+  private proposalAttestations = [];
 
   /**
    * In-memory P2P client constructor.
@@ -269,11 +274,16 @@ export class P2PClient implements P2P {
     this.p2pService.propagateTx(tx);
   }
 
+
   public async sendProposal(proposal: BlockProposal): Promise<void> {
     const ready = await this.isReady();
     if (!ready) {
       throw new Error('P2P client not ready');
     }
+    // Mock logic to keep track of proposal responses
+    // clean proposal signatures when we sent em
+    this.proposalAttestations = [];
+
     // TODO(md): we are only propogating proposals for now
     this.p2pService.propagateProposal(proposal);
   }

--- a/yarn-project/p2p/src/service/commitment_message.test.ts
+++ b/yarn-project/p2p/src/service/commitment_message.test.ts
@@ -1,0 +1,21 @@
+import { BlockAttestation, BlockProposal, ProposalMessage, Signature } from '@aztec/foundation/sequencer';
+import { deepStrictEqual } from 'assert';
+
+const mockAttestationMessage = (): BlockAttestation => {
+    const message = new ProposalMessage(Buffer.from("test message"));
+    const proposalSignature = new Signature(Buffer.from("test proposal sig"));
+    const attestationSignature = new Signature(Buffer.from("test attestation sig"));
+
+    const proposal = new BlockProposal(message, proposalSignature);
+    return new BlockAttestation(proposal, attestationSignature);
+}
+
+describe("Serde attestation messages", () => {
+    it("Should serde a attestation message", () => {
+        const attestationMessage = mockAttestationMessage();
+        const message = attestationMessage.toBuffer();
+        const decodedMessage = BlockAttestation.fromBuffer(message);
+
+        deepStrictEqual(attestationMessage, decodedMessage);
+    })
+})

--- a/yarn-project/p2p/src/service/commitment_message.ts
+++ b/yarn-project/p2p/src/service/commitment_message.ts
@@ -7,7 +7,7 @@ import { BlockAttestation } from '@aztec/foundation/sequencer';
 import { SemVer } from 'semver';
 
 // TODO(md): can be combined with the other message creators
-export class AztecCommitmentMessageCreator {
+export class AztecAttestationMessageCreator {
   private readonly topic: string;
   constructor(version: SemVer) {
     this.topic = `/aztec/commitment/${version.toString()}`;

--- a/yarn-project/p2p/src/service/dummy_service.ts
+++ b/yarn-project/p2p/src/service/dummy_service.ts
@@ -1,4 +1,5 @@
 import type { Tx, TxHash } from '@aztec/circuit-types';
+import { BlockAttestation, BlockProposal } from '@aztec/foundation/sequencer';
 
 import type { PeerId } from '@libp2p/interface';
 import EventEmitter from 'events';
@@ -30,6 +31,9 @@ export class DummyP2PService implements P2PService {
    * @param _ - The transaction to be propagated.
    */
   public propagateTx(_: Tx) {}
+
+  public propagateProposal(_: BlockProposal) {}
+  public propagateAttestation(_: BlockAttestation) {}
 
   /**
    * Called upon receipt of settled transactions.

--- a/yarn-project/p2p/src/service/message/index.ts
+++ b/yarn-project/p2p/src/service/message/index.ts
@@ -1,0 +1,5 @@
+interface Message<Type> {
+  encode(): Buffer;
+  decode(buffer: Buffer): Type;
+  handleGossipMessage(message: Type): void;
+}

--- a/yarn-project/p2p/src/service/p2p_serde.ts
+++ b/yarn-project/p2p/src/service/p2p_serde.ts
@@ -1,0 +1,52 @@
+import { numToUInt32BE } from "@aztec/foundation/serialize";
+
+    // Serialize
+
+  export function createMessageComponent(obj?: { toBuffer: () => Buffer }) {
+    if (!obj) {
+      // specify a length of 0 bytes
+      return numToUInt32BE(0);
+    }
+    const buffer = obj.toBuffer();
+    return Buffer.concat([numToUInt32BE(buffer.length), buffer]);
+  };
+
+  // eslint-disable-next-line jsdoc/require-jsdoc
+  export function createMessageComponents(obj?: { toBuffer: () => Buffer }[]) {
+    if (!obj || !obj.length) {
+      // specify a length of 0 bytes
+      return numToUInt32BE(0);
+    }
+    const allComponents = Buffer.concat(obj.map(createMessageComponent));
+    return Buffer.concat([numToUInt32BE(obj.length), allComponents]);
+  };
+
+  // Deserialize
+
+  // eslint-disable-next-line jsdoc/require-jsdoc
+  export function toObject<T>(objectBuffer: Buffer, factory: { fromBuffer: (b: Buffer) => T }) {
+    const objectSize = objectBuffer.readUint32BE(0);
+
+    return {
+      remainingData: objectBuffer.subarray(objectSize + 4),
+      obj: objectSize === 0 ? undefined : factory.fromBuffer(objectBuffer.subarray(4, objectSize + 4)),
+    };
+  };
+
+  // eslint-disable-next-line jsdoc/require-jsdoc
+  export function toObjectArray<T>(objectBuffer: Buffer, factory: { fromBuffer: (b: Buffer) => T }) {
+    const output: T[] = [];
+    const numItems = objectBuffer.readUint32BE(0);
+    let workingBuffer = objectBuffer.subarray(4);
+    for (let i = 0; i < numItems; i++) {
+      const obj = toObject<T>(workingBuffer, factory);
+      workingBuffer = obj.remainingData;
+      if (obj !== undefined) {
+        output.push(obj.obj!);
+      }
+    }
+    return {
+      remainingData: workingBuffer,
+      objects: output,
+    };
+  };

--- a/yarn-project/p2p/src/service/proposal_messages.test.ts
+++ b/yarn-project/p2p/src/service/proposal_messages.test.ts
@@ -1,0 +1,21 @@
+import { BlockProposal, ProposalMessage, Signature } from '@aztec/foundation/sequencer';
+import { deepStrictEqual } from 'assert';
+
+const mockProposal = (): BlockProposal => {
+    const message = new ProposalMessage(Buffer.from("test message"));
+    const signature = new Signature(Buffer.from("test signature"));
+    return new BlockProposal(
+        message,
+        signature
+    )
+}
+
+describe("Serde attestation messages", () => {
+    it("Should serde a attestation message", () => {
+        const proposal = mockProposal();
+        const message = proposal.toBuffer();
+        const decodedMessage = BlockProposal.fromBuffer(message);
+
+        deepStrictEqual(proposal, decodedMessage);
+    })
+})

--- a/yarn-project/p2p/src/service/proposal_messages.ts
+++ b/yarn-project/p2p/src/service/proposal_messages.ts
@@ -2,9 +2,11 @@
  * Follows the design of the tx_messages class
  * The idea is that we have a message type for a proposal that will be sent around by the block proposer to collect signatures
  */
-import { BlockProposal } from '@aztec/foundation/sequencer';
+import { BlockProposal, ProposalMessage, Signature } from '@aztec/foundation/sequencer';
 
 import { SemVer } from 'semver';
+import { createMessageComponent, toObject } from './p2p_serde.js';
+import { BufferReader, numToInt32BE } from '@aztec/foundation/serialize';
 
 // TODO(md): do a similar thing to how we have setup opcodes in the vm such that
 // they have a base class + interfaces that they deal with

--- a/yarn-project/p2p/src/service/service.ts
+++ b/yarn-project/p2p/src/service/service.ts
@@ -1,4 +1,5 @@
 import type { Tx } from '@aztec/circuit-types';
+import { BlockAttestation, BlockProposal } from '@aztec/foundation/sequencer';
 
 import type { ENR } from '@chainsafe/enr';
 import type { PeerId } from '@libp2p/interface';
@@ -30,6 +31,11 @@ export interface P2PService {
    * @param tx - The transaction to be propagated.
    */
   propagateTx(tx: Tx): void;
+
+  // DO we want to be able to propagate more than just transactions, in which case this interface is not enough to suit our needs?
+  // We could make a sum type of Tx | Proposal | Attestation that could just be forwarded without much thought
+  propagateProposal(proposal: BlockProposal): void;
+  propagateAttestation(attestation: BlockAttestation): void;
 }
 
 /**

--- a/yarn-project/p2p/src/service/tx_messages.ts
+++ b/yarn-project/p2p/src/service/tx_messages.ts
@@ -6,6 +6,8 @@ import { type SemVer } from 'semver';
 
 export const TX_MESSAGE_TOPIC = '';
 
+// NOTE(Md): I think that all of this code could be wrapped in a serialize / deserialize interface that can be implemented for all messages
+// With a message type index that tells the general implementation how to encode / decode messages - wait, this is what the topic really does
 export class AztecTxMessageCreator {
   private readonly topic: string;
   constructor(version: SemVer) {
@@ -65,6 +67,7 @@ export function toTxMessage(tx: Tx): Buffer {
     const allComponents = Buffer.concat(obj.map(createMessageComponent));
     return Buffer.concat([numToUInt32BE(obj.length), allComponents]);
   };
+  // TODO(md): Why is this different than the classic serde for sending over the wire through the cbinds??
   const messageBuffer = Buffer.concat([
     createMessageComponent(tx.data),
     createMessageComponent(tx.clientIvcProof),

--- a/yarn-project/p2p/src/service/z_commitment_message.ts
+++ b/yarn-project/p2p/src/service/z_commitment_message.ts
@@ -1,0 +1,24 @@
+/**
+ * Follows the design of the tx_messages class
+ * The idea is that we have a message type for a commitment that will be sent by validators who have received the proposal messages
+ */
+import { BlockAttestation } from '@aztec/foundation/sequencer';
+
+import { SemVer } from 'semver';
+
+// TODO(md): can be combined with the other message creators
+export class AztecCommitmentMessageCreator {
+  private readonly topic: string;
+  constructor(version: SemVer) {
+    this.topic = `/aztec/commitment/${version.toString()}`;
+  }
+
+  createAttestationMessage(commitment: BlockAttestation) {
+    const data = commitment.toBuffer();
+    return { topic: this.topic, data };
+  }
+
+  getTopic() {
+    return this.topic;
+  }
+}

--- a/yarn-project/p2p/src/service/z_proposal_messages.ts
+++ b/yarn-project/p2p/src/service/z_proposal_messages.ts
@@ -1,0 +1,25 @@
+/**
+ * Follows the design of the tx_messages class
+ * The idea is that we have a message type for a proposal that will be sent around by the block proposer to collect signatures
+ */
+import { BlockProposal } from '@aztec/foundation/sequencer';
+
+import { SemVer } from 'semver';
+
+// TODO(md): do a similar thing to how we have setup opcodes in the vm such that
+// they have a base class + interfaces that they deal with
+export class AztecProposalMessageCreator {
+  private readonly topic: string;
+  constructor(version: SemVer) {
+    this.topic = `/aztec/proposal/${version.toString()}`;
+  }
+
+  createProposalMessage(proposal: BlockProposal) {
+    const data = proposal.toBuffer();
+    return { topic: this.topic, data };
+  }
+
+  getTopic() {
+    return this.topic;
+  }
+}

--- a/yarn-project/package.json
+++ b/yarn-project/package.json
@@ -24,6 +24,7 @@
     "archiver",
     "aztec-faucet",
     "aztec-node",
+    "aztec-validator",
     "bb-prover",
     "builder",
     "pxe",

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -108,6 +108,7 @@ __metadata:
   resolution: "@aztec/aztec-node@workspace:aztec-node"
   dependencies:
     "@aztec/archiver": "workspace:^"
+    "@aztec/aztec-validator": "workspace:^"
     "@aztec/bb-prover": "workspace:^"
     "@aztec/circuit-types": "workspace:^"
     "@aztec/circuits.js": "workspace:^"
@@ -135,6 +136,36 @@ __metadata:
     typescript: ^5.0.4
   bin:
     aztec-node: ./dest/bin/index.js
+  languageName: unknown
+  linkType: soft
+
+"@aztec/aztec-validator@workspace:^, @aztec/aztec-validator@workspace:aztec-validator":
+  version: 0.0.0-use.local
+  resolution: "@aztec/aztec-validator@workspace:aztec-validator"
+  dependencies:
+    "@aztec/ethereum": "workspace:^"
+    "@aztec/foundation": "workspace:^"
+    "@aztec/kv-store": "workspace:^"
+    "@aztec/l1-artifacts": "workspace:^"
+    "@aztec/merkle-tree": "workspace:^"
+    "@aztec/p2p": "workspace:^"
+    "@aztec/protocol-contracts": "workspace:^"
+    "@aztec/prover-client": "workspace:^"
+    "@aztec/sequencer-client": "workspace:^"
+    "@aztec/simulator": "workspace:^"
+    "@aztec/telemetry-client": "workspace:^"
+    "@aztec/types": "workspace:^"
+    "@aztec/world-state": "workspace:^"
+    "@jest/globals": ^29.5.0
+    "@types/jest": ^29.5.0
+    "@types/node": ^18.7.23
+    jest: ^29.5.0
+    ts-node: ^10.9.1
+    tslib: ^2.4.0
+    typescript: ^5.0.4
+    viem: ^2.7.15
+  bin:
+    aztec-validator: ./dest/bin/index.js
   languageName: unknown
   linkType: soft
 
@@ -698,6 +729,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/p2p@workspace:p2p"
   dependencies:
+    "@aztec/aztec-validator": "workspace:^"
     "@aztec/circuit-types": "workspace:^"
     "@aztec/circuits.js": "workspace:^"
     "@aztec/foundation": "workspace:^"


### PR DESCRIPTION
Do not merge this puppy.- ever - it is a prototype to inform a spec

## Leotychidas Exploration

The leotychidas PR explored what was required to gossiping block proposals / attestations through the existing p2p layer. 

The following functionality is demonstrated:
- Creating a proposal (which is just arbitrary bytes)
- Introduction of an aztec-validator (a dumb signer for now)
- Attesting to a proposal
    - A validator client signs over the proposal that they have received, then forwards it onwards.


## Comments on Current Code organisation
- Creation of a generic P2P message sub class similar to how opcodes are defined in the avm. 

```ts!
abstract class P2PMessage {
    
    constructor(version: string);
    
    public abstract handle(): Promise<void>;
    
    public serialize(this: any): Buffer;
    public deserialize(this, buf);
    
    // Static method
    public get topic(): string;
}
```

Handle can handle propogation of a message, or not if we are not the sequencer. 

## Validator Client
The node will need to have an optional validator-key provided within the config. 
In essence the validator client is sufficient enough to be a dumbish signer. I.e. for our use case, it signs when it sees something that it is happy with. 
A naive implementation of this can be completely stateless, where we sign and forward all valid proposals that come our way. 
But we likely want to add some logic to maintain proposals that we have already signed, such that we do not waste work. I would stress that we do not want to implement this sort of logic from the get go however tempting it may be, lets keep it simple (this is very much a note to self).

## In process / out of process
For the sake of moving quickly we can provide options to allow the validator node to run in process, in which it will run as part of the entire full node. 

However; the validator client can be separated from the full node without any loss of generality.

i.e. a signer subscribed to just the /attestation/ /proposal/ p2p topics, and when it is their turn to build the block, they can ping a full node / another party to build it for them. The pattern where the validator client receives the block they propose out of process is colloquially referred to as Proposer Builder Separation. 

Note this is not a protocol change, but entirely an implementation detail. 

> aside: Before we ship mainnet, I would like that we support out of process remote signers such as https://docs.web3signer.consensys.io/. The majority of large scale operators will use these services to store their signing keys. It has an integrations with industry standard 'secure' databases such as hashicop's vault. 

For the sake of a prototype, we will implement the validator in process, with it's activation triggered by the existence of a validator key in the config. However, we will need to design the interfaces such that the signing / removal is hotswappable. 


## Storing Attestations
The current implementation does not store any of the attestations that it collects over the p2p network. To do so the validator client will need to maintain an `attestation_pool` (as described in disco dingo). Storing and forwarding the observed attestations for the given epoch. 


## New Issues
- Add validator-key to the config
- Alter the P2P message types
- Add a validator set object where the validator client can keep track of the validator set and who is the current validator.
    - i.e. who they should accept signed proposal messages from



