### PR TITLE
fix: bb mac build

### DIFF
--- a/barretenberg/cpp/src/CMakeLists.txt
+++ b/barretenberg/cpp/src/CMakeLists.txt
@@ -69,7 +69,6 @@ add_subdirectory(barretenberg/examples)
 add_subdirectory(barretenberg/flavor)
 add_subdirectory(barretenberg/goblin)
 add_subdirectory(barretenberg/grumpkin_srs_gen)
-add_subdirectory(barretenberg/honk)
 add_subdirectory(barretenberg/numeric)
 add_subdirectory(barretenberg/plonk)
 add_subdirectory(barretenberg/plonk_honk_shared)
@@ -127,7 +126,6 @@ set(BARRETENBERG_TARGET_OBJECTS
     $<TARGET_OBJECTS:simple_example_objects>
     $<TARGET_OBJECTS:flavor_objects>
     $<TARGET_OBJECTS:goblin_objects>
-    $<TARGET_OBJECTS:honk_objects>
     $<TARGET_OBJECTS:numeric_objects>
     $<TARGET_OBJECTS:plonk_objects>
     $<TARGET_OBJECTS:plonk_honk_shared_objects>

--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -572,7 +572,7 @@ void prove_tube(const std::string& output_path)
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1048): INSECURE - make this tube proof actually use
     // these public inputs by turning proof into witnesses and call
     // set_public on each witness
-    auto num_public_inputs = (size_t)proof.folding_proof[1];
+    auto num_public_inputs = static_cast<size_t>(static_cast<uint256_t>(proof.folding_proof[1]));
     for (size_t i = 0; i < num_public_inputs; i++) {
         // We offset 3
         builder->add_public_variable(proof.folding_proof[i + 3]);

--- a/barretenberg/cpp/src/barretenberg/eccvm/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/eccvm/CMakeLists.txt
@@ -1,1 +1,1 @@
-barretenberg_module(eccvm honk sumcheck)
+barretenberg_module(eccvm sumcheck)

--- a/barretenberg/cpp/src/barretenberg/translator_vm/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/CMakeLists.txt
@@ -1,1 +1,1 @@
-barretenberg_module(translator_vm honk sumcheck)
+barretenberg_module(translator_vm sumcheck)

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/CMakeLists.txt
@@ -1,1 +1,1 @@
-barretenberg_module(ultra_honk honk sumcheck)
+barretenberg_module(ultra_honk sumcheck)

--- a/barretenberg/cpp/src/barretenberg/vm/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/vm/CMakeLists.txt
@@ -1,3 +1,3 @@
 if(NOT DISABLE_AZTEC_VM)
-  barretenberg_module(vm honk sumcheck)
+  barretenberg_module(vm sumcheck)
 endif()


### PR DESCRIPTION
no forced c-style casting
honk no longer needed as an explicit cmake target object

RE the second point: inside barretenberg/honk, the only .cpp file is `testing.cpp`, with contents:
```
#include "testing.hpp"

// Adding this file so that an object file is created. Otherwise CMake configure complains
```

