### PR TITLE
fix: Uniswap e2e test "nonce too low"

### DIFF
--- a/yarn-project/end-to-end/src/composed/uniswap_trade_on_l1_from_l2.test.ts
+++ b/yarn-project/end-to-end/src/composed/uniswap_trade_on_l1_from_l2.test.ts
@@ -1,4 +1,4 @@
-import { setup as e2eSetup } from '../fixtures/utils.js';
+import { setup as e2eSetup, getL1WalletClient } from '../fixtures/utils.js';
 import { type UniswapSetupContext, uniswapL1L2TestSuite } from '../shared/uniswap_l1_l2.js';
 
 // This tests works on forked mainnet. There is a dump of the data in `dumpedState` such that we
@@ -18,9 +18,10 @@ const testSetup = async (): Promise<UniswapSetupContext> => {
     deployL1ContractsValues,
     wallets,
     logger,
+    config,
   } = await e2eSetup(2, { stateLoad: dumpedState });
 
-  const walletClient = deployL1ContractsValues.walletClient;
+  const walletClient = getL1WalletClient(config.rpcUrl, 1);
   const publicClient = deployL1ContractsValues.publicClient;
 
   const ownerWallet = wallets[0];

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -439,6 +439,16 @@ export async function setup(
   };
 }
 
+/** Returns an L1 wallet client for anvil using a well-known private key based on the index. */
+export function getL1WalletClient(rpcUrl: string, index: number) {
+  const hdAccount = mnemonicToAccount(MNEMONIC, { addressIndex: index });
+  return createWalletClient({
+    account: hdAccount,
+    chain: foundry,
+    transport: http(rpcUrl),
+  });
+}
+
 /**
  * Ensures there's a running Anvil instance and returns the RPC URL.
  * @returns


### PR DESCRIPTION
The uniswap e2e test was intermittently failing with "nonce too low" error when deploying the L1 contracts needed for testing. See [here](https://github.com/AztecProtocol/aztec-packages/actions/runs/10113107392/job/27969400151?pr=7630#step:4:1187) for an example run.

This seems to happen because the same L1 account is used for pushing blocks from the sequencer and for deploying the contracts in the test. If both components try to send a tx at the same time, it fails with nonce too low since they clash on the nonce used.

This PR changes it so the deployment of contracts for the test happens using a different anvil account.