### PR TITLE
chore: Log name of current e2e test

### DIFF
--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -113,7 +113,8 @@
   "jest": {
     "slowTestThreshold": 300,
     "setupFilesAfterEnv": [
-      "jest-extended/all"
+      "jest-extended/all",
+      "./shared/jest_setup.ts"
     ],
     "extensionsToTreatAsEsm": [
       ".ts"

--- a/yarn-project/end-to-end/src/shared/jest_setup.ts
+++ b/yarn-project/end-to-end/src/shared/jest_setup.ts
@@ -1,0 +1,13 @@
+import { createDebugLogger } from '@aztec/aztec.js';
+
+import { beforeEach, expect } from '@jest/globals';
+import { basename } from 'path';
+
+beforeEach(() => {
+  const { testPath, currentTestName } = expect.getState();
+  if (!testPath || !currentTestName) {
+    return;
+  }
+  const logger = createDebugLogger(`aztec:${basename(testPath).replace('.test.ts', '')}`);
+  logger.info(`Running test: ${currentTestName}`);
+});


### PR DESCRIPTION
Logs as INFO the name of the current e2e test. Otherwise the logs give no indication of when one test has finished and the next one starts.