### PR TITLE
feat: Add proverId to root rollup public inputs

### DIFF
--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -4,13 +4,14 @@ pragma solidity >=0.8.18;
 
 interface IRollup {
   event L2BlockProcessed(uint256 indexed blockNumber);
-  event L2ProofVerified(uint256 indexed blockNumber);
+  event L2ProofVerified(uint256 indexed blockNumber, bytes32 indexed proverId);
 
   function process(bytes calldata _header, bytes32 _archive) external;
 
   function submitProof(
     bytes calldata _header,
     bytes32 _archive,
+    bytes32 _proverId,
     bytes calldata _aggregationObject,
     bytes calldata _proof
   ) external;

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_inputs.nr
@@ -93,7 +93,7 @@ impl RootRollupInputs {
             content_commitment,
             state,
             global_variables: left.constants.global_variables,
-            total_fees,
+            total_fees
         };
 
         // Build the block hash for this by hashing the header and then insert the new leaf to archive tree.

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_inputs.nr
@@ -34,6 +34,8 @@ struct RootRollupInputs {
     // inputs required to add the block hash
     start_archive_snapshot : AppendOnlyTreeSnapshot,
     new_archive_sibling_path : [Field; ARCHIVE_HEIGHT],
+
+    prover_id: Field,
 }
 
 impl RootRollupInputs {
@@ -91,7 +93,7 @@ impl RootRollupInputs {
             content_commitment,
             state,
             global_variables: left.constants.global_variables,
-            total_fees
+            total_fees,
         };
 
         // Build the block hash for this by hashing the header and then insert the new leaf to archive tree.
@@ -106,7 +108,7 @@ impl RootRollupInputs {
             0
         );
 
-        RootRollupPublicInputs { archive, header, vk_tree_root }
+        RootRollupPublicInputs { archive, header, vk_tree_root, prover_id: self.prover_id }
     }
 }
 
@@ -120,6 +122,7 @@ impl Empty for RootRollupInputs {
             start_l1_to_l2_message_tree_snapshot : AppendOnlyTreeSnapshot::zero(),
             start_archive_snapshot : AppendOnlyTreeSnapshot::zero(),
             new_archive_sibling_path : [0; ARCHIVE_HEIGHT],
+            prover_id: 0
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_public_inputs.nr
@@ -9,4 +9,7 @@ struct RootRollupPublicInputs {
 
     // New block header
     header: Header,
+
+    // Identifier of the prover
+    prover_id: Field,
 }

--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -36,10 +36,12 @@ describe('Archiver', () => {
 
   let publicClient: MockProxy<PublicClient<HttpTransport, Chain>>;
   let archiverStore: ArchiverDataStore;
+  let proverId: Fr;
 
   beforeEach(() => {
     publicClient = mock<PublicClient<HttpTransport, Chain>>();
     archiverStore = new MemoryArchiverStore(1000);
+    proverId = Fr.random();
   });
 
   it('can start, sync and stop and handle l1 to l2 messages and logs', async () => {
@@ -67,7 +69,7 @@ describe('Archiver', () => {
       messageSent: [makeMessageSentEvent(98n, 1n, 0n), makeMessageSentEvent(99n, 1n, 1n)],
       txPublished: [makeTxsPublishedEvent(101n, blocks[0].body.getTxsEffectsHash())],
       l2BlockProcessed: [makeL2BlockProcessedEvent(101n, 1n)],
-      proofVerified: [makeProofVerifiedEvent(102n, 1n)],
+      proofVerified: [makeProofVerifiedEvent(102n, 1n, proverId)],
     });
 
     mockGetLogs({
@@ -271,11 +273,12 @@ function makeMessageSentEvent(l1BlockNum: bigint, l2BlockNumber: bigint, index: 
   } as Log<bigint, number, false, undefined, true, typeof InboxAbi, 'MessageSent'>;
 }
 
-function makeProofVerifiedEvent(l1BlockNum: bigint, l2BlockNumber: bigint) {
+function makeProofVerifiedEvent(l1BlockNum: bigint, l2BlockNumber: bigint, proverId: Fr) {
   return {
     blockNumber: l1BlockNum,
     args: {
       blockNumber: l2BlockNumber,
+      proverId: proverId.toString(),
     },
   } as Log<bigint, number, false, undefined, true, typeof RollupAbi, 'L2ProofVerified'>;
 }

--- a/yarn-project/archiver/src/index.ts
+++ b/yarn-project/archiver/src/index.ts
@@ -12,6 +12,9 @@ export * from './archiver/index.js';
 export * from './rpc/index.js';
 export * from './factory.js';
 
+// We are not storing the info from these events in the archiver for now (and we don't really need to), so we expose this query directly
+export { retrieveL2ProofVerifiedEvents } from './archiver/data_retrieval.js';
+
 const log = createDebugLogger('aztec:archiver');
 
 /**

--- a/yarn-project/circuit-types/src/interfaces/block-prover.ts
+++ b/yarn-project/circuit-types/src/interfaces/block-prover.ts
@@ -64,4 +64,7 @@ export interface BlockProver {
    * Will pad the block to it's complete size with empty transactions and prove all the way to the root rollup.
    */
   setBlockCompleted(): Promise<void>;
+
+  /** Returns an identifier for the prover or zero if not set. */
+  getProverId(): Fr;
 }

--- a/yarn-project/circuit-types/src/interfaces/prover-client.ts
+++ b/yarn-project/circuit-types/src/interfaces/prover-client.ts
@@ -1,4 +1,5 @@
 import { type TxHash } from '@aztec/circuit-types';
+import { type Fr } from '@aztec/circuits.js';
 
 import { type BlockProver } from './block-prover.js';
 import { type ProvingJobSource } from './proving-job.js';
@@ -21,6 +22,8 @@ export type ProverConfig = {
   proverJobTimeoutMs: number;
   /** The interval to check job health status */
   proverJobPollIntervalMs: number;
+  /** Identifier of the prover */
+  proverId?: Fr;
 };
 
 /**

--- a/yarn-project/circuits.js/src/structs/rollup/root_rollup.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/root_rollup.ts
@@ -48,6 +48,8 @@ export class RootRollupInputs {
      * Sibling path of the new block tree root.
      */
     public newArchiveSiblingPath: Tuple<Fr, typeof ARCHIVE_HEIGHT>,
+    /** Identifier of the prover for this root rollup. */
+    public proverId: Fr,
   ) {}
 
   /**
@@ -89,6 +91,7 @@ export class RootRollupInputs {
       fields.startL1ToL2MessageTreeSnapshot,
       fields.startArchiveSnapshot,
       fields.newArchiveSiblingPath,
+      fields.proverId,
     ] as const;
   }
 
@@ -107,6 +110,7 @@ export class RootRollupInputs {
       reader.readObject(AppendOnlyTreeSnapshot),
       reader.readObject(AppendOnlyTreeSnapshot),
       reader.readArray(ARCHIVE_HEIGHT, Fr),
+      reader.readObject(Fr),
     );
   }
 
@@ -133,10 +137,12 @@ export class RootRollupPublicInputs {
     public vkTreeRoot: Fr,
     /** A header of an L2 block. */
     public header: Header,
+    /** Identifier of the prover who generated this proof. */
+    public proverId: Fr,
   ) {}
 
   static getFields(fields: FieldsOf<RootRollupPublicInputs>) {
-    return [fields.archive, fields.vkTreeRoot, fields.header] as const;
+    return [fields.archive, fields.vkTreeRoot, fields.header, fields.proverId] as const;
   }
 
   toBuffer() {
@@ -160,8 +166,9 @@ export class RootRollupPublicInputs {
     const reader = BufferReader.asReader(buffer);
     return new RootRollupPublicInputs(
       reader.readObject(AppendOnlyTreeSnapshot),
-      Fr.fromBuffer(reader),
+      reader.readObject(Fr),
       reader.readObject(Header),
+      reader.readObject(Fr),
     );
   }
 

--- a/yarn-project/circuits.js/src/tests/factories.ts
+++ b/yarn-project/circuits.js/src/tests/factories.ts
@@ -932,6 +932,7 @@ export function makeRootRollupInputs(seed = 0, globalVariables?: GlobalVariables
     makeAppendOnlyTreeSnapshot(seed + 0x2200),
     makeAppendOnlyTreeSnapshot(seed + 0x2200),
     makeTuple(ARCHIVE_HEIGHT, fr, 0x2400),
+    fr(0x2500),
   );
 }
 
@@ -983,6 +984,7 @@ export function makeRootRollupPublicInputs(
     archive: makeAppendOnlyTreeSnapshot(seed + 0x100),
     header: makeHeader(seed + 0x200, blockNumber),
     vkTreeRoot: fr(seed + 0x300),
+    proverId: fr(seed + 0x400),
   });
 }
 

--- a/yarn-project/end-to-end/src/composed/integration_proof_verification.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_proof_verification.test.ts
@@ -33,6 +33,7 @@ import { getLogger, setupL1Contracts, startAnvil } from '../fixtures/utils.js';
  */
 describe('proof_verification', () => {
   let proof: Proof;
+  let proverId: Fr;
   let block: L2Block;
   let aggregationObject: Fr[];
   let anvil: Anvil | undefined;
@@ -121,6 +122,7 @@ describe('proof_verification', () => {
 
     block = L2Block.fromString(blockResult.block);
     proof = Proof.fromString(blockResult.proof);
+    proverId = Fr.ZERO;
     aggregationObject = blockResult.aggregationObject.map((x: string) => Fr.fromString(x));
   });
 
@@ -183,6 +185,7 @@ describe('proof_verification', () => {
       const args = [
         `0x${block.header.toBuffer().toString('hex')}`,
         `0x${block.archive.root.toBuffer().toString('hex')}`,
+        `0x${proverId.toBuffer().toString('hex')}`,
         `0x${serializeToBuffer(aggregationObject).toString('hex')}`,
         `0x${proof.withoutPublicInputs().toString('hex')}`,
       ] as const;

--- a/yarn-project/noir-protocol-circuits-types/src/type_conversion.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/type_conversion.ts
@@ -2005,6 +2005,7 @@ export function mapRootRollupInputsToNoir(rootRollupInputs: RootRollupInputs): R
     ),
     start_archive_snapshot: mapAppendOnlyTreeSnapshotToNoir(rootRollupInputs.startArchiveSnapshot),
     new_archive_sibling_path: mapTuple(rootRollupInputs.newArchiveSiblingPath, mapFieldToNoir),
+    prover_id: mapFieldToNoir(rootRollupInputs.proverId),
   };
 }
 
@@ -2045,6 +2046,7 @@ export function mapRootRollupPublicInputsFromNoir(
     mapAppendOnlyTreeSnapshotFromNoir(rootRollupPublicInputs.archive),
     mapFieldFromNoir(rootRollupPublicInputs.vk_tree_root),
     mapHeaderFromNoir(rootRollupPublicInputs.header),
+    mapFieldFromNoir(rootRollupPublicInputs.prover_id),
   );
 }
 

--- a/yarn-project/prover-client/src/config.ts
+++ b/yarn-project/prover-client/src/config.ts
@@ -1,4 +1,5 @@
 import { type ProverConfig } from '@aztec/circuit-types';
+import { Fr } from '@aztec/circuits.js';
 
 import { tmpdir } from 'os';
 
@@ -39,6 +40,7 @@ export function getProverEnvVars(): ProverClientConfig {
     PROVER_REAL_PROOFS = '',
     PROVER_JOB_TIMEOUT_MS = '60000',
     PROVER_JOB_POLL_INTERVAL_MS = '1000',
+    PROVER_ID,
   } = process.env;
 
   const realProofs = ['1', 'true'].includes(PROVER_REAL_PROOFS);
@@ -48,6 +50,7 @@ export function getProverEnvVars(): ProverClientConfig {
   const proverJobTimeoutMs = safeParseNumber(PROVER_JOB_TIMEOUT_MS, 60000);
   const proverJobPollIntervalMs = safeParseNumber(PROVER_JOB_POLL_INTERVAL_MS, 1000);
   const disableProver = ['1', 'true'].includes(PROVER_DISABLED);
+  const proverId = PROVER_ID ? parseProverId(PROVER_ID) : undefined;
 
   return {
     acvmWorkingDirectory: ACVM_WORKING_DIRECTORY,
@@ -62,7 +65,12 @@ export function getProverEnvVars(): ProverClientConfig {
     nodeUrl: AZTEC_NODE_URL,
     proverJobPollIntervalMs,
     proverJobTimeoutMs,
+    proverId,
   };
+}
+
+function parseProverId(str: string) {
+  return Fr.fromString(str.startsWith('0x') ? str : Buffer.from(str, 'utf8').toString('hex'));
 }
 
 function safeParseNumber(value: string, defaultValue: number): number {

--- a/yarn-project/prover-client/src/mocks/test_context.ts
+++ b/yarn-project/prover-client/src/mocks/test_context.ts
@@ -53,6 +53,9 @@ class DummyProverClient implements BlockProver {
   setBlockCompleted(): Promise<void> {
     return this.orchestrator.setBlockCompleted();
   }
+  getProverId(): Fr {
+    return this.orchestrator.proverId;
+  }
 }
 
 export class TestContext {

--- a/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
+++ b/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
@@ -224,6 +224,7 @@ export async function getRootRollupInput(
   messageTreeSnapshot: AppendOnlyTreeSnapshot,
   messageTreeRootSiblingPath: Tuple<Fr, typeof L1_TO_L2_MSG_SUBTREE_SIBLING_PATH_LENGTH>,
   db: MerkleTreeOperations,
+  proverId: Fr,
 ) {
   const previousRollupData: RootRollupInputs['previousRollupData'] = [
     getPreviousRollupDataFromPublicInputs(rollupOutputLeft, rollupProofLeft, verificationKeyLeft),
@@ -254,6 +255,7 @@ export async function getRootRollupInput(
     startL1ToL2MessageTreeSnapshot: messageTreeSnapshot,
     startArchiveSnapshot,
     newArchiveSiblingPath,
+    proverId,
   });
 }
 

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -97,7 +97,12 @@ export class ProvingOrchestrator {
 
   public readonly tracer: Tracer;
 
-  constructor(private db: MerkleTreeOperations, private prover: ServerCircuitProver, telemetryClient: TelemetryClient) {
+  constructor(
+    private db: MerkleTreeOperations,
+    private prover: ServerCircuitProver,
+    telemetryClient: TelemetryClient,
+    public readonly proverId: Fr = Fr.ZERO,
+  ) {
     this.tracer = telemetryClient.getTracer('ProvingOrchestrator');
   }
 
@@ -739,6 +744,7 @@ export class ProvingOrchestrator {
       provingState.messageTreeSnapshot,
       provingState.messageTreeRootSiblingPath,
       this.db,
+      this.proverId,
     );
 
     this.deferredProving(

--- a/yarn-project/prover-client/src/tx-prover/tx-prover.ts
+++ b/yarn-project/prover-client/src/tx-prover/tx-prover.ts
@@ -7,7 +7,7 @@ import {
   type ProvingTicket,
   type ServerCircuitProver,
 } from '@aztec/circuit-types/interfaces';
-import { type Fr, type GlobalVariables } from '@aztec/circuits.js';
+import { Fr, type GlobalVariables } from '@aztec/circuits.js';
 import { NativeACVMSimulator } from '@aztec/simulator';
 import { type TelemetryClient } from '@aztec/telemetry-client';
 import { type WorldStateSynchronizer } from '@aztec/world-state';
@@ -32,7 +32,16 @@ export class TxProver implements ProverClient {
     private agent?: ProverAgent,
   ) {
     this.queue = new MemoryProvingQueue(config.proverJobTimeoutMs, config.proverJobPollIntervalMs);
-    this.orchestrator = new ProvingOrchestrator(worldStateSynchronizer.getLatest(), this.queue, telemetry);
+    this.orchestrator = new ProvingOrchestrator(
+      worldStateSynchronizer.getLatest(),
+      this.queue,
+      telemetry,
+      config.proverId,
+    );
+  }
+
+  public getProverId(): Fr {
+    return this.config.proverId ?? Fr.ZERO;
   }
 
   async updateProverConfig(config: Partial<ProverClientConfig>): Promise<void> {

--- a/yarn-project/prover-node/src/job/block-proving-job.ts
+++ b/yarn-project/prover-node/src/job/block-proving-job.ts
@@ -92,7 +92,13 @@ export class BlockProvingJob {
     this.log.info(`Finalised proof for block range`, { fromBlock, toBlock });
 
     this.state = 'publishing-proof';
-    await this.publisher.submitProof(block.header, block.archive.root, aggregationObject, proof);
+    await this.publisher.submitProof(
+      block.header,
+      block.archive.root,
+      this.prover.getProverId(),
+      aggregationObject,
+      proof,
+    );
     this.log.info(`Submitted proof for block range`, { fromBlock, toBlock });
 
     this.state = 'completed';

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -113,6 +113,8 @@ export type L1SubmitProofArgs = {
   header: Buffer;
   /** A root of the archive tree after the L2 block is applied. */
   archive: Buffer;
+  /** Identifier of the prover. */
+  proverId: Buffer;
   /** The proof for the block. */
   proof: Buffer;
   /** The aggregation object for the block's proof. */
@@ -238,12 +240,19 @@ export class L1Publisher implements L2BlockReceiver {
     return false;
   }
 
-  public async submitProof(header: Header, archiveRoot: Fr, aggregationObject: Fr[], proof: Proof): Promise<boolean> {
+  public async submitProof(
+    header: Header,
+    archiveRoot: Fr,
+    proverId: Fr,
+    aggregationObject: Fr[],
+    proof: Proof,
+  ): Promise<boolean> {
     const ctx = { blockNumber: header.globalVariables.blockNumber };
 
     const txArgs: L1SubmitProofArgs = {
       header: header.toBuffer(),
       archive: archiveRoot.toBuffer(),
+      proverId: proverId.toBuffer(),
       aggregationObject: serializeToBuffer(aggregationObject),
       proof: proof.withoutPublicInputs(),
     };

--- a/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
+++ b/yarn-project/sequencer-client/src/publisher/viem-tx-sender.ts
@@ -176,10 +176,11 @@ export class ViemTxSender implements L1PublisherTxSender {
    * @returns The hash of the mined tx.
    */
   async sendSubmitProofTx(submitProofArgs: L1SubmitProofArgs): Promise<string | undefined> {
-    const { header, archive, aggregationObject, proof } = submitProofArgs;
+    const { header, archive, proverId, aggregationObject, proof } = submitProofArgs;
     const args = [
       `0x${header.toString('hex')}`,
       `0x${archive.toString('hex')}`,
+      `0x${proverId.toString('hex')}`,
       `0x${aggregationObject.toString('hex')}`,
       `0x${proof.toString('hex')}`,
     ] as const;

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -365,7 +365,13 @@ export class Sequencer {
     // This is temporary while we submit one proof per block, but will have to change once we
     // move onto proving batches of multiple blocks at a time.
     if (aggregationObject && proof && !this.skipSubmitProofs) {
-      await this.publisher.submitProof(block.header, block.archive.root, aggregationObject, proof);
+      await this.publisher.submitProof(
+        block.header,
+        block.archive.root,
+        this.prover.getProverId(),
+        aggregationObject,
+        proof,
+      );
       this.log.info(`Submitted proof for block ${block.number}`);
     }
   }


### PR DESCRIPTION
Adds a field element as a prover identifier to the public inputs of the root rollup. This is passed directly from the root rollup inputs, and set via a PROVER_ID env var. The prover id gets emitted as part of the L2ProofVerified event on L1.

Eventually we may want to change the prover id into an L1 or L2 address, but for now it's an arbitrary value.

Fixes #7670 