### PR TITLE
fix: faucet correctly derives its account

### DIFF
--- a/.github/workflows/devnet-deploys.yml
+++ b/.github/workflows/devnet-deploys.yml
@@ -26,7 +26,7 @@ env:
   TF_VAR_API_KEY: ${{ secrets.FORK_API_KEY }}
   TF_VAR_FORK_MNEMONIC: ${{ secrets.FORK_MNEMONIC }}
   TF_VAR_INFURA_API_KEY: ${{ secrets.INFURA_API_KEY }}
-  TF_VAR_FAUCET_ACCOUNT_INDEX: 5
+  TF_VAR_FAUCET_ACCOUNT_INDEX: 9
   TF_VAR_BOT_API_KEY: ${{ secrets.BOT_API_KEY }}
   TF_VAR_BOT_PRIVATE_KEY: ${{ secrets.BOT_PRIVATE_KEY }}
   CONTRACT_S3_BUCKET: s3://aztec-devnet-deployments

--- a/yarn-project/aztec-faucet/src/bin/index.ts
+++ b/yarn-project/aztec-faucet/src/bin/index.ts
@@ -115,9 +115,9 @@ function updateThrottle(asset: 'eth' | AssetName, address: Hex) {
 function getFaucetAccount(): LocalAccount {
   let account: LocalAccount;
   if (FORK_MNEMONIC) {
-    const accountIndex = Number.isNaN(+FAUCET_ACCOUNT_INDEX) ? 0 : +FAUCET_ACCOUNT_INDEX;
+    const index = Number.isNaN(+FAUCET_ACCOUNT_INDEX) ? 0 : +FAUCET_ACCOUNT_INDEX;
     account = mnemonicToAccount(FORK_MNEMONIC, {
-      accountIndex,
+      addressIndex: index,
     });
   } else if (PRIVATE_KEY) {
     account = privateKeyToAccount(PRIVATE_KEY as `0x${string}`);


### PR DESCRIPTION
Fix faucet not being able to send funds because its account didn't have any tokens.
