### PR TITLE
feat: static.aztec.network

### DIFF
--- a/.github/workflows/devnet-deploys.yml
+++ b/.github/workflows/devnet-deploys.yml
@@ -14,6 +14,7 @@ env:
   L1_CHAIN_ID: 677692
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  CONTRACT_S3_BUCKET: s3://static.aztec.network
   # TF Vars
   TF_VAR_DOCKERHUB_ACCOUNT: aztecprotocol
   TF_VAR_L1_CHAIN_ID: 677692
@@ -29,7 +30,6 @@ env:
   TF_VAR_FAUCET_ACCOUNT_INDEX: 5
   TF_VAR_BOT_API_KEY: ${{ secrets.BOT_API_KEY }}
   TF_VAR_BOT_PRIVATE_KEY: ${{ secrets.BOT_PRIVATE_KEY }}
-  CONTRACT_S3_BUCKET: s3://aztec-devnet-deployments
 
 jobs:
   setup:
@@ -127,14 +127,14 @@ jobs:
             --rpc-url https://${{ env.DEPLOY_TAG }}-mainnet-fork.aztec.network:8545/${{ secrets.FORK_API_KEY }} \
             --l1-chain-id ${{ env.L1_CHAIN_ID }} \
             --json \
-            | tee  ./l1-contract_addresses.json
+            | tee  ./l1_contracts.json
 
           # upload contract addresses to S3
-          aws s3 cp ./l1-contract_addresses.json ${{ env.CONTRACT_S3_BUCKET }}/l1_contract_addresses.json
+          aws s3 cp ./l1_contracts.json ${{ env.CONTRACT_S3_BUCKET }}/${{ env.DEPLOY_TAG }}/l1_contracts.json
 
           # export contract addresses so they can be used by subsequent terraform deployments
           function extract() {
-            jq -r ".$1" ./l1-contract_addresses.json
+            jq -r ".$1" ./l1_contracts.json
           }
 
           echo "TF_VAR_ROLLUP_CONTRACT_ADDRESS=$(extract rollupAddress)" >>$GITHUB_ENV
@@ -209,22 +209,22 @@ jobs:
             --rpc-url https://api.aztec.network/${{ env.DEPLOY_TAG }}/aztec-pxe/${{ secrets.FORK_API_KEY }} \
             --l1-chain-id ${{ env.L1_CHAIN_ID }} \
             --json \
-            | tee  ./protocol-contracts.json
+            | tee  ./protocol_contracts.json
 
-          aws s3 cp ./protocol-contracts.json ${{ env.CONTRACT_S3_BUCKET }}/protocol-contracts.json
+          aws s3 cp ./protocol_contracts.json ${{ env.CONTRACT_S3_BUCKET }}/${{ env.DEPLOY_TAG }}/protocol_contracts.json
 
-      - name: Bootstrap devnet
+      - name: Bootstrap network
         run: |
           set -e
-          docker run aztecprotocol/aztec:${{ env.DEPLOY_TAG }} bootstrap-devnet \
+          docker run aztecprotocol/aztec:${{ env.DEPLOY_TAG }} bootstrap-network \
             --rpc-url https://api.aztec.network/${{ env.DEPLOY_TAG }}/aztec-pxe/${{ secrets.FORK_API_KEY }} \
             --l1-rpc-url https://${{ env.DEPLOY_TAG }}-mainnet-fork.aztec.network:8545/${{ secrets.FORK_API_KEY }} \
             --l1-chain-id ${{ env.L1_CHAIN_ID }} \
             --l1-private-key ${{ secrets.SEQ_1_PUBLISHER_PRIVATE_KEY }} \
             --json \
-            | tee ./devnet-contracts.json
+            | tee ./basic_contracts.json
 
-          aws s3 cp ./devnet-contracts.json ${{ env.CONTRACT_S3_BUCKET }}/devnet-contracts.json
+          aws s3 cp ./basic_contracts.json ${{ env.CONTRACT_S3_BUCKET }}/${{ env.DEPLOY_TAG }}/basic_contracts.json
 
   deploy-faucet:
     runs-on: ubuntu-latest
@@ -249,11 +249,11 @@ jobs:
       - name: Retrieve contract addresses
         run: |
           set -e
-          aws s3 cp ${{ env.CONTRACT_S3_BUCKET }}/l1_contract_addresses.json ./l1-contract_addresses.json
-          aws s3 cp ${{ env.CONTRACT_S3_BUCKET }}/devnet-contracts.json ./devnet-contracts.json
+          aws s3 cp ${{ env.CONTRACT_S3_BUCKET }}/${{ env.DEPLOY_TAG }}/l1_contracts.json ./l1_contracts.json
+          aws s3 cp ${{ env.CONTRACT_S3_BUCKET }}/${{ env.DEPLOY_TAG }}/basic_contracts.json ./basic_contracts.json
 
-          echo "TF_VAR_GAS_TOKEN_CONTRACT_ADDRESS=$(jq -r '.gasTokenAddress' ./l1-contract_addresses.json)" >>$GITHUB_ENV
-          echo "TF_VAR_DEV_COIN_CONTRACT_ADDRESS=$(jq -r '.devCoinL1' ./devnet-contracts.json)" >>$GITHUB_ENV
+          echo "TF_VAR_GAS_TOKEN_CONTRACT_ADDRESS=$(jq -r '.gasTokenAddress' ./l1_contracts.json)" >>$GITHUB_ENV
+          echo "TF_VAR_DEV_COIN_CONTRACT_ADDRESS=$(jq -r '.devCoinL1' ./basic_contracts.json)" >>$GITHUB_ENV
 
       - name: Deploy Faucet
         working-directory: ./yarn-project/aztec-faucet

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.29.0"
+      version = "3.74.2"
     }
   }
 }
@@ -83,13 +83,9 @@ resource "aws_security_group" "security-group-p2p" {
 # static.aztec.network resources
 resource "aws_s3_bucket" "contract_addresses" {
   bucket = "static.aztec.network"
-}
 
-resource "aws_s3_bucket_website_configuration" "addresses_website_bucket" {
-  bucket = aws_s3_bucket.contract_addresses.id
-
-  index_document {
-    suffix = "aztec-static"
+  website {
+    index_document = "index.html"
   }
 }
 
@@ -124,7 +120,7 @@ resource "aws_route53_record" "static" {
   type    = "A"
 
   alias {
-    name                   = aws_s3_bucket_website_configuration.addresses_website_bucket.website_domain
+    name                   = aws_s3_bucket.contract_addresses.website_domain
     zone_id                = aws_s3_bucket.contract_addresses.hosted_zone_id
     evaluate_target_health = true
   }

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -7,9 +7,14 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.74.2"
+      version = "5.29.0"
     }
   }
+}
+
+provider "aws" {
+  profile = "default"
+  region  = "eu-west-2"
 }
 
 data "terraform_remote_state" "setup_iac" {
@@ -21,9 +26,13 @@ data "terraform_remote_state" "setup_iac" {
   }
 }
 
-provider "aws" {
-  profile = "default"
-  region  = "eu-west-2"
+data "terraform_remote_state" "aztec2_iac" {
+  backend = "s3"
+  config = {
+    bucket = "aztec-terraform"
+    key    = "aztec2/iac"
+    region = "eu-west-2"
+  }
 }
 
 # Allocate Elastic IPs for each subnet
@@ -68,5 +77,55 @@ resource "aws_security_group" "security-group-p2p" {
 
   tags = {
     Name = "allow-p2p"
+  }
+}
+
+# static.aztec.network resources
+resource "aws_s3_bucket" "contract_addresses" {
+  bucket = "static.aztec.network"
+}
+
+resource "aws_s3_bucket_website_configuration" "addresses_website_bucket" {
+  bucket = aws_s3_bucket.contract_addresses.id
+
+  index_document {
+    suffix = "aztec-static"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "addresses_public_access" {
+  bucket = aws_s3_bucket.contract_addresses.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "addresses_bucket_policy" {
+  bucket = aws_s3_bucket.contract_addresses.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource  = "arn:aws:s3:::${aws_s3_bucket.contract_addresses.id}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_route53_record" "static" {
+  zone_id = data.terraform_remote_state.aztec2_iac.outputs.aws_route53_zone_id
+  name    = "static.aztec.network"
+  type    = "A"
+
+  alias {
+    name                   = aws_s3_bucket_website_configuration.addresses_website_bucket.website_domain
+    zone_id                = aws_s3_bucket.contract_addresses.hosted_zone_id
+    evaluate_target_health = true
   }
 }

--- a/l1-contracts/terraform/main.tf
+++ b/l1-contracts/terraform/main.tf
@@ -6,71 +6,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.29.0"
+      version = "3.74.2"
     }
-  }
-}
-
-data "terraform_remote_state" "aztec2_iac" {
-  backend = "s3"
-  config = {
-    bucket = "aztec-terraform"
-    key    = "aztec2/iac"
-    region = "eu-west-2"
-  }
-}
-
-variable "DEPLOY_TAG" {
-  type = string
-}
-
-# S3 Bucket to store contract addresses
-resource "aws_s3_bucket" "contract_addresses" {
-  bucket = "static.aztec.network"
-}
-
-resource "aws_s3_bucket_website_configuration" "addresses_website_bucket" {
-  bucket = aws_s3_bucket.contract_addresses.id
-
-  index_document {
-    suffix = "aztec-static"
-  }
-}
-
-resource "aws_s3_bucket_public_access_block" "addresses_public_access" {
-  bucket = aws_s3_bucket.contract_addresses.id
-
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = false
-  restrict_public_buckets = false
-}
-
-resource "aws_s3_bucket_policy" "addresses_bucket_policy" {
-  bucket = aws_s3_bucket.contract_addresses.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect    = "Allow"
-        Principal = "*"
-        Action    = "s3:GetObject"
-        Resource  = "arn:aws:s3:::${aws_s3_bucket.contract_addresses.id}/*"
-      }
-    ]
-  })
-}
-
-resource "aws_route53_record" "static" {
-  zone_id = data.terraform_remote_state.aztec2_iac.outputs.aws_route53_zone_id
-  name    = "static.aztec.network"
-  type    = "A"
-
-  alias {
-    name                   = aws_s3_bucket_website_configuration.addresses_website_bucket.website_domain
-    zone_id                = aws_s3_bucket.contract_addresses.hosted_zone_id
-    evaluate_target_health = true
   }
 }
 

--- a/l1-contracts/terraform/main.tf
+++ b/l1-contracts/terraform/main.tf
@@ -6,8 +6,17 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.74.2"
+      version = "5.29.0"
     }
+  }
+}
+
+data "terraform_remote_state" "aztec2_iac" {
+  backend = "s3"
+  config = {
+    bucket = "aztec-terraform"
+    key    = "aztec2/iac"
+    region = "eu-west-2"
   }
 }
 
@@ -17,7 +26,52 @@ variable "DEPLOY_TAG" {
 
 # S3 Bucket to store contract addresses
 resource "aws_s3_bucket" "contract_addresses" {
-  bucket = "aztec-${var.DEPLOY_TAG}-deployments"
+  bucket = "static.aztec.network"
+}
+
+resource "aws_s3_bucket_website_configuration" "addresses_website_bucket" {
+  bucket = aws_s3_bucket.contract_addresses.id
+
+  index_document {
+    suffix = "aztec-static"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "addresses_public_access" {
+  bucket = aws_s3_bucket.contract_addresses.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "addresses_bucket_policy" {
+  bucket = aws_s3_bucket.contract_addresses.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource  = "arn:aws:s3:::${aws_s3_bucket.contract_addresses.id}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_route53_record" "static" {
+  zone_id = data.terraform_remote_state.aztec2_iac.outputs.aws_route53_zone_id
+  name    = "static.aztec.network"
+  type    = "A"
+
+  alias {
+    name                   = aws_s3_bucket_website_configuration.addresses_website_bucket.website_domain
+    zone_id                = aws_s3_bucket.contract_addresses.hosted_zone_id
+    evaluate_target_health = true
+  }
 }
 
 variable "ROLLUP_CONTRACT_ADDRESS" {

--- a/yarn-project/cli/src/cmds/devnet/index.ts
+++ b/yarn-project/cli/src/cmds/devnet/index.ts
@@ -6,8 +6,8 @@ import { ETHEREUM_HOST, l1ChainIdOption, parseEthereumAddress, pxeOption } from 
 
 export function injectCommands(program: Command, log: LogFn, debugLogger: DebugLogger) {
   program
-    .command('bootstrap-devnet')
-    .description('Bootstrap the devnet')
+    .command('bootstrap-network')
+    .description('Bootstrap a new network')
     .addOption(pxeOption)
     .addOption(l1ChainIdOption)
     .requiredOption(


### PR DESCRIPTION
- Fixes #7641 
- Fixes #7642 (but without using cloudfront)
Also:
- normalize json file names
- remove references to `devnet` since we'll be supporting more networks soon

Once deployed, JSON files with contract addresses will be posted to static.aztec.network/<network_name>/<file_name>.json