### PR TITLE
feat: Do not evict tx objects from p2p tx pool immediately

### DIFF
--- a/yarn-project/aztec/terraform/node/main.tf
+++ b/yarn-project/aztec/terraform/node/main.tf
@@ -325,6 +325,10 @@ resource "aws_ecs_task_definition" "aztec-node" {
           value = "2000"
         },
         {
+          name  = "P2P_TX_POOL_KEEP_PROVEN_FOR",
+          value = tostring(var.P2P_TX_POOL_KEEP_PROVEN_FOR)
+        },
+        {
           name  = "PROVER_AGENTS"
           value = "0"
         },

--- a/yarn-project/aztec/terraform/node/variables.tf
+++ b/yarn-project/aztec/terraform/node/variables.tf
@@ -72,6 +72,11 @@ variable "P2P_ENABLED" {
   default = true
 }
 
+variable "P2P_TX_POOL_KEEP_PROVEN_FOR" {
+  type    = number
+  default = 64
+}
+
 variable "PROVING_ENABLED" {
   type    = bool
   default = false

--- a/yarn-project/p2p/src/client/index.ts
+++ b/yarn-project/p2p/src/client/index.ts
@@ -63,5 +63,5 @@ export const createP2PClient = async (
   } else {
     p2pService = new DummyP2PService();
   }
-  return new P2PClient(store, l2BlockSource, txPool, p2pService);
+  return new P2PClient(store, l2BlockSource, txPool, p2pService, config.keepProvenTxsInPoolFor);
 };

--- a/yarn-project/p2p/src/config.ts
+++ b/yarn-project/p2p/src/config.ts
@@ -88,6 +88,9 @@ export interface P2PConfig {
    * If announceUdpAddress or announceTcpAddress are not provided, query for the IP address of the machine. Default is false.
    */
   queryForIp: boolean;
+
+  /** How many blocks have to pass after a block is proven before its txs are deleted (zero to delete immediately once proven) */
+  keepProvenTxsInPoolFor: number;
 }
 
 /**
@@ -113,6 +116,7 @@ export function getP2PConfigEnvVars(): P2PConfig {
     TX_GOSSIP_VERSION,
     P2P_TX_PROTOCOL,
     P2P_QUERY_FOR_IP,
+    P2P_TX_POOL_KEEP_PROVEN_FOR,
   } = process.env;
   // P2P listen & announce addresses passed in format: <IP_ADDRESS>:<PORT>
   // P2P announce multiaddrs passed in format: /ip4/<IP_ADDRESS>/<protocol>/<PORT>
@@ -134,6 +138,7 @@ export function getP2PConfigEnvVars(): P2PConfig {
     dataDirectory: DATA_DIRECTORY,
     txGossipVersion: TX_GOSSIP_VERSION ? new SemVer(TX_GOSSIP_VERSION) : new SemVer('0.1.0'),
     queryForIp: P2P_QUERY_FOR_IP === 'true',
+    keepProvenTxsInPoolFor: P2P_TX_POOL_KEEP_PROVEN_FOR ? +P2P_TX_POOL_KEEP_PROVEN_FOR : 0,
   };
   return envVars;
 }

--- a/yarn-project/p2p/src/service/discv5_service.test.ts
+++ b/yarn-project/p2p/src/service/discv5_service.test.ts
@@ -5,6 +5,7 @@ import type { PeerId } from '@libp2p/interface';
 import { SemVer } from 'semver';
 
 import { BootstrapNode } from '../bootstrap/bootstrap.js';
+import { type P2PConfig } from '../config.js';
 import { DiscV5Service } from './discV5_service.js';
 import { createLibP2PPeerId } from './libp2p_service.js';
 import { PeerDiscoveryState } from './service.js';
@@ -122,7 +123,7 @@ describe('Discv5Service', () => {
   const createNode = async (port: number) => {
     const bootnodeAddr = bootNode.getENR().encodeTxt();
     const peerId = await createLibP2PPeerId();
-    const config = {
+    const config: P2PConfig = {
       ...baseConfig,
       tcpListenAddress: `0.0.0.0:${port}`,
       udpListenAddress: `0.0.0.0:${port}`,
@@ -135,6 +136,7 @@ describe('Discv5Service', () => {
       p2pEnabled: true,
       p2pL2QueueSize: 100,
       txGossipVersion: new SemVer('0.1.0'),
+      keepProvenTxsInPoolFor: 0,
     };
     return new DiscV5Service(peerId, config);
   };


### PR DESCRIPTION
Tweaks the p2p client so it waits a configurable number of blocks before deleting proven txs from its pool. This can help with reorgs or troubleshooting, and it also allows slow provers to get the tx objects they need in a scenario where multiple provers can submit a proof for the same block.

Tweaks the node default variables in terraform to set this new value to 64.