### PR TITLE
feat: Run block-proving jobs in parallel by forking world-state

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -169,7 +169,7 @@ export class AztecNodeService implements AztecNode {
 
     const simulationProvider = await createSimulationProvider(config, log);
 
-    const prover = await createProverClient(config, worldStateSynchronizer, archiver, telemetry);
+    const prover = await createProverClient(config, telemetry);
 
     if (!prover && !config.disableSequencer) {
       throw new Error("Can't start a sequencer without a prover");

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -742,6 +742,7 @@ export class AztecNodeService implements AztecNode {
       this.telemetry,
     );
     const processor = publicProcessorFactory.create(prevHeader, newGlobalVariables);
+
     // REFACTOR: Consider merging ProcessReturnValues into ProcessedTx
     const [processedTxs, failedTxs, returns] = await processor.process([tx]);
     // REFACTOR: Consider returning the error/revert rather than throwing

--- a/yarn-project/circuit-types/src/interfaces/index.ts
+++ b/yarn-project/circuit-types/src/interfaces/index.ts
@@ -10,3 +10,4 @@ export * from './block-prover.js';
 export * from './server_circuit_prover.js';
 export * from './private_kernel_prover.js';
 export * from './tx-provider.js';
+export * from './merkle_tree_operations.js';

--- a/yarn-project/circuit-types/src/interfaces/prover-client.ts
+++ b/yarn-project/circuit-types/src/interfaces/prover-client.ts
@@ -2,6 +2,7 @@ import { type TxHash } from '@aztec/circuit-types';
 import { type Fr } from '@aztec/circuits.js';
 
 import { type BlockProver } from './block-prover.js';
+import { type MerkleTreeOperations } from './merkle_tree_operations.js';
 import { type ProvingJobSource } from './proving-job.js';
 
 /**
@@ -29,8 +30,11 @@ export type ProverConfig = {
 /**
  * The interface to the prover client.
  * Provides the ability to generate proofs and build rollups.
+ * TODO(palla/prover-node): Rename this interface
  */
-export interface ProverClient extends BlockProver {
+export interface ProverClient {
+  createBlockProver(db: MerkleTreeOperations): BlockProver;
+
   start(): Promise<void>;
 
   stop(): Promise<void>;

--- a/yarn-project/circuit-types/src/l2_block_downloader/l2_block_downloader.ts
+++ b/yarn-project/circuit-types/src/l2_block_downloader/l2_block_downloader.ts
@@ -73,9 +73,11 @@ export class L2BlockDownloader {
    */
   private async collectBlocks(targetBlockNumber?: number) {
     let totalBlocks = 0;
+    log.debug(`Starting block collection for target ${targetBlockNumber} from ${this.from}`);
     while (true) {
       // If we have a target and have reached it, return
-      if (targetBlockNumber !== undefined && this.from >= targetBlockNumber) {
+      if (targetBlockNumber !== undefined && this.from > targetBlockNumber) {
+        log.debug(`Reached target block number ${targetBlockNumber}`);
         return totalBlocks;
       }
 
@@ -85,6 +87,9 @@ export class L2BlockDownloader {
 
       // Hit the archiver for blocks
       const blocks = await this.l2BlockSource.getBlocks(this.from, limit, proven);
+      log.debug(
+        `Received ${blocks.length} blocks from archiver after querying from ${this.from} limit ${limit} (proven ${proven})`,
+      );
 
       // If there are no more blocks, return
       if (!blocks.length) {

--- a/yarn-project/circuit-types/src/l2_block_downloader/l2_block_downloader.ts
+++ b/yarn-project/circuit-types/src/l2_block_downloader/l2_block_downloader.ts
@@ -83,7 +83,7 @@ export class L2BlockDownloader {
 
       // If we have a target, then request at most the number of blocks to get to it, bypassing 'proven' restriction
       const [proven, limit] =
-        targetBlockNumber !== undefined ? [false, Math.max(targetBlockNumber - this.from, 10)] : [this.proven, 10];
+        targetBlockNumber !== undefined ? [false, Math.min(targetBlockNumber - this.from + 1, 10)] : [this.proven, 10];
 
       // Hit the archiver for blocks
       const blocks = await this.l2BlockSource.getBlocks(this.from, limit, proven);

--- a/yarn-project/circuit-types/src/l2_block_downloader/l2_block_downloader.ts
+++ b/yarn-project/circuit-types/src/l2_block_downloader/l2_block_downloader.ts
@@ -73,11 +73,10 @@ export class L2BlockDownloader {
    */
   private async collectBlocks(targetBlockNumber?: number) {
     let totalBlocks = 0;
-    log.debug(`Starting block collection for target ${targetBlockNumber} from ${this.from}`);
     while (true) {
       // If we have a target and have reached it, return
       if (targetBlockNumber !== undefined && this.from > targetBlockNumber) {
-        log.debug(`Reached target block number ${targetBlockNumber}`);
+        log.verbose(`Reached target block number ${targetBlockNumber}`);
         return totalBlocks;
       }
 
@@ -87,14 +86,15 @@ export class L2BlockDownloader {
 
       // Hit the archiver for blocks
       const blocks = await this.l2BlockSource.getBlocks(this.from, limit, proven);
-      log.debug(
-        `Received ${blocks.length} blocks from archiver after querying from ${this.from} limit ${limit} (proven ${proven})`,
-      );
 
       // If there are no more blocks, return
       if (!blocks.length) {
         return totalBlocks;
       }
+
+      log.verbose(
+        `Received ${blocks.length} blocks from archiver after querying from ${this.from} limit ${limit} (proven ${proven})`,
+      );
 
       // Push new blocks into the queue and loop
       await this.semaphore.acquire();

--- a/yarn-project/end-to-end/src/e2e_prover_node.test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover_node.test.ts
@@ -136,7 +136,6 @@ describe('e2e_prover_node', () => {
     // Prove the first two blocks simultaneously
     logger.info(`Starting proof for first block #${firstBlock}`);
     await proverNode.startProof(firstBlock, firstBlock);
-    await sleep(3000); // Well, _almost_ simultaneously!
     logger.info(`Starting proof for second block #${secondBlock}`);
     await proverNode.startProof(secondBlock, secondBlock);
 

--- a/yarn-project/end-to-end/src/e2e_prover_node.test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover_node.test.ts
@@ -15,7 +15,7 @@ import {
   sleep,
 } from '@aztec/aztec.js';
 import { StatefulTestContract, TestContract } from '@aztec/noir-contracts.js';
-import { type ProverNode, createProverNode } from '@aztec/prover-node';
+import { createProverNode } from '@aztec/prover-node';
 import { type SequencerClientConfig } from '@aztec/sequencer-client';
 
 import { sendL1ToL2Message } from './fixtures/l1_to_l2_messaging.js';
@@ -107,20 +107,12 @@ describe('e2e_prover_node', () => {
     ctx = await snapshotManager.setup();
   });
 
-  const prove = async (proverNode: ProverNode, blockNumber: number) => {
-    logger.info(`Proving block ${blockNumber}`);
-    await proverNode.prove(blockNumber, blockNumber);
-
-    logger.info(`Proof submitted. Awaiting aztec node to sync...`);
-    await retryUntil(async () => (await ctx.aztecNode.getProvenBlockNumber()) === blockNumber, 'block-1', 10, 1);
-    expect(await ctx.aztecNode.getProvenBlockNumber()).toEqual(blockNumber);
-  };
-
   it('submits three blocks, then prover proves the first two', async () => {
     // Check everything went well during setup and txs were mined in two different blocks
     const [txReceipt1, txReceipt2, txReceipt3] = txReceipts;
     const firstBlock = txReceipt1.blockNumber!;
-    expect(txReceipt2.blockNumber).toEqual(firstBlock + 1);
+    const secondBlock = firstBlock + 1;
+    expect(txReceipt2.blockNumber).toEqual(secondBlock);
     expect(txReceipt3.blockNumber).toEqual(firstBlock + 2);
     expect(await contract.methods.get_public_value(recipient).simulate()).toEqual(20n);
     expect(await contract.methods.summed_values(recipient).simulate()).toEqual(10n);
@@ -141,9 +133,19 @@ describe('e2e_prover_node', () => {
     const archiver = ctx.aztecNode.getBlockSource() as Archiver;
     const proverNode = await createProverNode(proverConfig, { aztecNodeTxProvider: ctx.aztecNode, archiver });
 
-    // Prove the first two blocks
-    await prove(proverNode, firstBlock);
-    await prove(proverNode, firstBlock + 1);
+    // Prove the first two blocks simultaneously
+    logger.info(`Starting proof for first block #${firstBlock}`);
+    await proverNode.startProof(firstBlock, firstBlock);
+    await sleep(3000); // Well, _almost_ simultaneously!
+    logger.info(`Starting proof for second block #${secondBlock}`);
+    await proverNode.startProof(secondBlock, secondBlock);
+
+    // Confirm that we cannot go back to prove an old one
+    await expect(proverNode.startProof(firstBlock, firstBlock)).rejects.toThrow(/behind the current world state/i);
+
+    // Await until proofs get submitted
+    await retryUntil(async () => (await ctx.aztecNode.getProvenBlockNumber()) === secondBlock, 'proven', 10, 1);
+    expect(await ctx.aztecNode.getProvenBlockNumber()).toEqual(secondBlock);
 
     // Check that the prover id made it to the emitted event
     const { publicClient, l1ContractAddresses } = ctx.deployL1ContractsValues;

--- a/yarn-project/kv-store/src/interfaces/store.ts
+++ b/yarn-project/kv-store/src/interfaces/store.ts
@@ -58,4 +58,9 @@ export interface AztecKVStore {
    * Clears the store
    */
   clear(): Promise<void>;
+
+  /**
+   * Forks the store.
+   */
+  fork(): Promise<AztecKVStore>;
 }

--- a/yarn-project/kv-store/src/lmdb/store.test.ts
+++ b/yarn-project/kv-store/src/lmdb/store.test.ts
@@ -1,0 +1,29 @@
+import { mkdtemp } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { AztecLmdbStore } from './store.js';
+
+describe('AztecLmdbStore', () => {
+  const itForks = async (store: AztecLmdbStore) => {
+    const singleton = store.openSingleton('singleton');
+    await singleton.set('foo');
+
+    const forkedStore = await store.fork();
+    const forkedSingleton = forkedStore.openSingleton('singleton');
+    expect(forkedSingleton.get()).toEqual('foo');
+    await forkedSingleton.set('bar');
+    expect(singleton.get()).toEqual('foo');
+  };
+
+  it('forks a persistent store', async () => {
+    const path = join(await mkdtemp(join(tmpdir(), 'aztec-store-test-')), 'main.mdb');
+    const store = AztecLmdbStore.open(path, false);
+    await itForks(store);
+  });
+
+  it('forks an ephemeral store', async () => {
+    const store = AztecLmdbStore.open(undefined, true);
+    await itForks(store);
+  });
+});

--- a/yarn-project/merkle-tree/src/interfaces/indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/interfaces/indexed_tree.ts
@@ -1,4 +1,4 @@
-import { type SiblingPath } from '@aztec/circuit-types';
+import { type BatchInsertionResult } from '@aztec/circuit-types';
 import { type IndexedTreeLeaf, type IndexedTreeLeafPreimage } from '@aztec/foundation/trees';
 
 import {
@@ -34,46 +34,6 @@ export interface PreimageFactory {
    * @param preimage - Preimage to be cloned.
    */
   clone(preimage: IndexedTreeLeafPreimage): IndexedTreeLeafPreimage;
-}
-
-/**
- * All of the data to be return during batch insertion.
- */
-export interface LowLeafWitnessData<N extends number> {
-  /**
-   * Preimage of the low nullifier that proves non membership.
-   */
-  leafPreimage: IndexedTreeLeafPreimage;
-  /**
-   * Sibling path to prove membership of low nullifier.
-   */
-  siblingPath: SiblingPath<N>;
-  /**
-   * The index of low nullifier.
-   */
-  index: bigint;
-}
-
-/**
- * The result of a batch insertion in an indexed merkle tree.
- */
-export interface BatchInsertionResult<TreeHeight extends number, SubtreeSiblingPathHeight extends number> {
-  /**
-   * Data for the leaves to be updated when inserting the new ones.
-   */
-  lowLeavesWitnessData?: LowLeafWitnessData<TreeHeight>[];
-  /**
-   * Sibling path "pointing to" where the new subtree should be inserted into the tree.
-   */
-  newSubtreeSiblingPath: SiblingPath<SubtreeSiblingPathHeight>;
-  /**
-   * The new leaves being inserted in high to low order. This order corresponds with the order of the low leaves witness.
-   */
-  sortedNewLeaves: Buffer[];
-  /**
-   * The indexes of the sorted new leaves to the original ones.
-   */
-  sortedNewLeavesIndexes: number[];
 }
 
 /**

--- a/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
@@ -1,4 +1,4 @@
-import { SiblingPath } from '@aztec/circuit-types';
+import { type BatchInsertionResult, type LowLeafWitnessData, SiblingPath } from '@aztec/circuit-types';
 import { type TreeInsertionStats } from '@aztec/circuit-types/stats';
 import { toBufferBE } from '@aztec/foundation/bigint-buffer';
 import { type FromBuffer } from '@aztec/foundation/serialize';
@@ -7,12 +7,7 @@ import { type IndexedTreeLeaf, type IndexedTreeLeafPreimage } from '@aztec/found
 import { type AztecKVStore, type AztecMap } from '@aztec/kv-store';
 import { type Hasher } from '@aztec/types/interfaces';
 
-import {
-  type BatchInsertionResult,
-  type IndexedTree,
-  type LowLeafWitnessData,
-  type PreimageFactory,
-} from '../interfaces/indexed_tree.js';
+import { type IndexedTree, type PreimageFactory } from '../interfaces/indexed_tree.js';
 import { IndexedTreeSnapshotBuilder } from '../snapshots/indexed_tree_snapshot.js';
 import { type IndexedTreeSnapshot } from '../snapshots/snapshot_builder.js';
 import { TreeBase } from '../tree_base.js';

--- a/yarn-project/prover-client/src/mocks/test_context.ts
+++ b/yarn-project/prover-client/src/mocks/test_context.ts
@@ -1,9 +1,7 @@
 import { type BBProverConfig } from '@aztec/bb-prover';
 import {
   type BlockProver,
-  type BlockResult,
   type ProcessedTx,
-  type ProvingTicket,
   type PublicExecutionRequest,
   type ServerCircuitProver,
   type Tx,
@@ -36,31 +34,7 @@ import { MemoryProvingQueue } from '../prover-agent/memory-proving-queue.js';
 import { ProverAgent } from '../prover-agent/prover-agent.js';
 import { getEnvironmentConfig, getSimulationProvider, makeGlobals } from './fixtures.js';
 
-// TODO(palla/prover-node): Delete this class?
-class DummyProverClient implements BlockProver {
-  constructor(private orchestrator: ProvingOrchestrator) {}
-  startNewBlock(numTxs: number, globalVariables: GlobalVariables, l1ToL2Messages: Fr[]): Promise<ProvingTicket> {
-    return this.orchestrator.startNewBlock(numTxs, globalVariables, l1ToL2Messages);
-  }
-  addNewTx(tx: ProcessedTx): Promise<void> {
-    return this.orchestrator.addNewTx(tx);
-  }
-  cancelBlock(): void {
-    return this.orchestrator.cancelBlock();
-  }
-  finaliseBlock(): Promise<BlockResult> {
-    return this.orchestrator.finaliseBlock();
-  }
-  setBlockCompleted(): Promise<void> {
-    return this.orchestrator.setBlockCompleted();
-  }
-  getProverId(): Fr {
-    return this.orchestrator.getProverId();
-  }
-}
-
 export class TestContext {
-  public blockProver: BlockProver;
   constructor(
     public publicExecutor: MockProxy<PublicExecutor>,
     public publicContractsDB: MockProxy<ContractsDataSourcePublicDB>,
@@ -75,8 +49,10 @@ export class TestContext {
     public blockNumber: number,
     public directoriesToCleanup: string[],
     public logger: DebugLogger,
-  ) {
-    this.blockProver = new DummyProverClient(this.orchestrator);
+  ) {}
+
+  public get blockProver() {
+    return this.orchestrator;
   }
 
   static async new(

--- a/yarn-project/prover-client/src/mocks/test_context.ts
+++ b/yarn-project/prover-client/src/mocks/test_context.ts
@@ -36,6 +36,7 @@ import { MemoryProvingQueue } from '../prover-agent/memory-proving-queue.js';
 import { ProverAgent } from '../prover-agent/prover-agent.js';
 import { getEnvironmentConfig, getSimulationProvider, makeGlobals } from './fixtures.js';
 
+// TODO(palla/prover-node): Delete this class?
 class DummyProverClient implements BlockProver {
   constructor(private orchestrator: ProvingOrchestrator) {}
   startNewBlock(numTxs: number, globalVariables: GlobalVariables, l1ToL2Messages: Fr[]): Promise<ProvingTicket> {
@@ -54,7 +55,7 @@ class DummyProverClient implements BlockProver {
     return this.orchestrator.setBlockCompleted();
   }
   getProverId(): Fr {
-    return this.orchestrator.proverId;
+    return this.orchestrator.getProverId();
   }
 }
 

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -145,8 +145,18 @@ export class ProvingOrchestrator implements BlockProver {
     if (!Number.isInteger(numTxs) || numTxs < 2) {
       throw new Error(`Length of txs for the block should be at least two (got ${numTxs})`);
     }
+
+    const { blockNumber } = globalVariables;
+    const dbBlockNumber = (await this.db.getTreeInfo(MerkleTreeId.ARCHIVE)).size - 1n;
+    if (dbBlockNumber !== blockNumber.toBigInt() - 1n) {
+      throw new Error(
+        `Database is at wrong block number (starting block ${blockNumber.toBigInt()} with db at ${dbBlockNumber})`,
+      );
+    }
+
     // Cancel any currently proving block before starting a new one
     this.cancelBlock();
+
     logger.info(`Starting new block with ${numTxs} transactions`);
     // we start the block by enqueueing all of the base parity circuits
     let baseParityInputs: BaseParityInputs[] = [];

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -15,6 +15,7 @@ import {
 } from '@aztec/circuit-types';
 import {
   BlockProofError,
+  type BlockProver,
   type BlockResult,
   PROVING_STATUS,
   type ProvingResult,
@@ -93,7 +94,7 @@ const logger = createDebugLogger('aztec:prover:proving-orchestrator');
 /**
  * The orchestrator, managing the flow of recursive proving operations required to build the rollup proof tree.
  */
-export class ProvingOrchestrator {
+export class ProvingOrchestrator implements BlockProver {
   private provingState: ProvingState | undefined = undefined;
   private pendingProvingJobs: AbortController[] = [];
   private paddingTx: PaddingProcessedTx | undefined = undefined;
@@ -104,13 +105,17 @@ export class ProvingOrchestrator {
     private db: MerkleTreeOperations,
     private prover: ServerCircuitProver,
     telemetryClient: TelemetryClient,
-    public readonly proverId: Fr = Fr.ZERO,
+    private readonly proverId: Fr = Fr.ZERO,
   ) {
     this.metrics = new ProvingOrchestratorMetrics(telemetryClient, 'ProvingOrchestrator');
   }
 
   get tracer(): Tracer {
     return this.metrics.tracer;
+  }
+
+  public getProverId(): Fr {
+    return this.proverId;
   }
 
   /**

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -146,10 +146,12 @@ export class ProvingOrchestrator implements BlockProver {
       throw new Error(`Length of txs for the block should be at least two (got ${numTxs})`);
     }
 
+    // TODO(palla/prover-node): Store block number in the db itself to make this check more reliable,
+    // and turn this warning into an exception that we throw.
     const { blockNumber } = globalVariables;
     const dbBlockNumber = (await this.db.getTreeInfo(MerkleTreeId.ARCHIVE)).size - 1n;
     if (dbBlockNumber !== blockNumber.toBigInt() - 1n) {
-      throw new Error(
+      logger.warn(
         `Database is at wrong block number (starting block ${blockNumber.toBigInt()} with db at ${dbBlockNumber})`,
       );
     }

--- a/yarn-project/prover-client/src/tx-prover/factory.ts
+++ b/yarn-project/prover-client/src/tx-prover/factory.ts
@@ -1,16 +1,9 @@
-import { type L2BlockSource } from '@aztec/circuit-types';
 import { type TelemetryClient } from '@aztec/telemetry-client';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
-import { type WorldStateSynchronizer } from '@aztec/world-state';
 
 import { type ProverClientConfig } from '../config.js';
 import { TxProver } from './tx-prover.js';
 
-export function createProverClient(
-  config: ProverClientConfig,
-  worldStateSynchronizer: WorldStateSynchronizer,
-  blockSource: L2BlockSource,
-  telemetry: TelemetryClient = new NoopTelemetryClient(),
-) {
-  return config.disableProver ? undefined : TxProver.new(config, worldStateSynchronizer, blockSource, telemetry);
+export function createProverClient(config: ProverClientConfig, telemetry: TelemetryClient = new NoopTelemetryClient()) {
+  return config.disableProver ? undefined : TxProver.new(config, telemetry);
 }

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -4,7 +4,7 @@ import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import { createStore } from '@aztec/kv-store/utils';
 import { createProverClient } from '@aztec/prover-client';
 import { getL1Publisher } from '@aztec/sequencer-client';
-import { PublicProcessorFactory, createSimulationProvider } from '@aztec/simulator';
+import { createSimulationProvider } from '@aztec/simulator';
 import { type TelemetryClient } from '@aztec/telemetry-client';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 import { createWorldStateSynchronizer } from '@aztec/world-state';
@@ -45,16 +45,19 @@ export async function createProverNode(
   // REFACTOR: Move publisher out of sequencer package and into an L1-related package
   const publisher = getL1Publisher(config, telemetry);
 
-  const publicProcessorFactory = new PublicProcessorFactory(
-    worldStateSynchronizer,
-    archiver,
-    simulationProvider,
-    telemetry,
-  );
-
   const txProvider = deps.aztecNodeTxProvider
     ? new AztecNodeTxProvider(deps.aztecNodeTxProvider)
     : createTxProvider(config);
 
-  return new ProverNode(prover!, publicProcessorFactory, publisher, archiver, archiver, txProvider);
+  return new ProverNode(
+    prover!,
+    publisher,
+    archiver,
+    archiver,
+    archiver,
+    worldStateSynchronizer,
+    txProvider,
+    simulationProvider,
+    telemetry,
+  );
 }

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -45,8 +45,12 @@ export async function createProverNode(
   // REFACTOR: Move publisher out of sequencer package and into an L1-related package
   const publisher = getL1Publisher(config, telemetry);
 
-  const latestWorldState = worldStateSynchronizer.getLatest();
-  const publicProcessorFactory = new PublicProcessorFactory(latestWorldState, archiver, simulationProvider, telemetry);
+  const publicProcessorFactory = new PublicProcessorFactory(
+    worldStateSynchronizer,
+    archiver,
+    simulationProvider,
+    telemetry,
+  );
 
   const txProvider = deps.aztecNodeTxProvider
     ? new AztecNodeTxProvider(deps.aztecNodeTxProvider)

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -40,7 +40,7 @@ export async function createProverNode(
 
   const simulationProvider = await createSimulationProvider(config, log);
 
-  const prover = await createProverClient(config, worldStateSynchronizer, archiver);
+  const prover = await createProverClient(config, telemetry);
 
   // REFACTOR: Move publisher out of sequencer package and into an L1-related package
   const publisher = getL1Publisher(config, telemetry);

--- a/yarn-project/prover-node/src/job/block-proving-job.ts
+++ b/yarn-project/prover-node/src/job/block-proving-job.ts
@@ -67,7 +67,11 @@ export class BlockProvingJob {
         ...globalVariables,
       });
       const provingTicket = await this.prover.startNewBlock(txCount, globalVariables, l1ToL2Messages);
-      const publicProcessor = this.publicProcessorFactory.create(historicalHeader, globalVariables);
+
+      // TODO: When we start proving multiple blocks per epoch, this will create a whole database copy for each block
+      // in the epoch, which we don't want. We should adapt the API so we can fork once and then spawn multiple processors
+      // from it, assuming we haven't moved to https://github.com/AztecProtocol/engineering-designs/pull/9 by then.
+      const publicProcessor = await this.publicProcessorFactory.createFromFork(historicalHeader, globalVariables);
 
       const txs = await this.getTxs(txHashes);
       await this.processTxs(publicProcessor, txs, txCount);

--- a/yarn-project/prover-node/src/job/block-proving-job.ts
+++ b/yarn-project/prover-node/src/job/block-proving-job.ts
@@ -42,70 +42,70 @@ export class BlockProvingJob {
     }
 
     this.log.info(`Starting block proving job`, { fromBlock, toBlock });
-    this.state = 'started';
-
-    // TODO: Fast-forward world state to fromBlock and/or await fromBlock to be published to the unproven chain
-
     this.state = 'processing';
+    try {
+      let historicalHeader = (await this.l2BlockSource.getBlock(fromBlock - 1))?.header;
+      for (let blockNumber = fromBlock; blockNumber <= toBlock; blockNumber++) {
+        const block = await this.getBlock(blockNumber);
+        const globalVariables = block.header.globalVariables;
+        const txHashes = block.body.txEffects.map(tx => tx.txHash);
+        const txCount = block.body.numberOfTxsIncludingPadded;
+        const l1ToL2Messages = await this.getL1ToL2Messages(block);
 
-    let historicalHeader = (await this.l2BlockSource.getBlock(fromBlock - 1))?.header;
-    for (let blockNumber = fromBlock; blockNumber <= toBlock; blockNumber++) {
-      const block = await this.getBlock(blockNumber);
-      const globalVariables = block.header.globalVariables;
-      const txHashes = block.body.txEffects.map(tx => tx.txHash);
-      const txCount = block.body.numberOfTxsIncludingPadded;
-      const l1ToL2Messages = await this.getL1ToL2Messages(block);
+        this.log.verbose(`Starting block processing`, {
+          number: block.number,
+          blockHash: block.hash().toString(),
+          lastArchive: block.header.lastArchive.root,
+          noteHashTreeRoot: block.header.state.partial.noteHashTree.root,
+          nullifierTreeRoot: block.header.state.partial.nullifierTree.root,
+          publicDataTreeRoot: block.header.state.partial.publicDataTree.root,
+          historicalHeader: historicalHeader?.hash(),
+          ...globalVariables,
+        });
 
-      this.log.verbose(`Starting block processing`, {
-        number: block.number,
-        blockHash: block.hash().toString(),
-        lastArchive: block.header.lastArchive.root,
-        noteHashTreeRoot: block.header.state.partial.noteHashTree.root,
-        nullifierTreeRoot: block.header.state.partial.nullifierTree.root,
-        publicDataTreeRoot: block.header.state.partial.publicDataTree.root,
-        historicalHeader: historicalHeader?.hash(),
-        ...globalVariables,
-      });
-      const provingTicket = await this.prover.startNewBlock(txCount, globalVariables, l1ToL2Messages);
+        // When we move to proving epochs, this should change into a startNewEpoch and be lifted outside the loop.
+        const provingTicket = await this.prover.startNewBlock(txCount, globalVariables, l1ToL2Messages);
 
-      // TODO: When we start proving multiple blocks per epoch, this will create a whole database copy for each block
-      // in the epoch, which we don't want. We should adapt the API so we can fork once and then spawn multiple processors
-      // from it, assuming we haven't moved to https://github.com/AztecProtocol/engineering-designs/pull/9 by then.
-      const publicProcessor = await this.publicProcessorFactory.createFromFork(historicalHeader, globalVariables);
+        const publicProcessor = this.publicProcessorFactory.create(historicalHeader, globalVariables);
 
-      const txs = await this.getTxs(txHashes);
-      await this.processTxs(publicProcessor, txs, txCount);
+        const txs = await this.getTxs(txHashes);
+        await this.processTxs(publicProcessor, txs, txCount);
 
-      this.log.verbose(`Processed all txs for block`, {
-        blockNumber: block.number,
-        blockHash: block.hash().toString(),
-      });
+        this.log.verbose(`Processed all txs for block`, {
+          blockNumber: block.number,
+          blockHash: block.hash().toString(),
+        });
 
-      await this.prover.setBlockCompleted();
+        await this.prover.setBlockCompleted();
 
-      const result = await provingTicket.provingPromise;
-      if (result.status === PROVING_STATUS.FAILURE) {
-        throw new Error(`Block proving failed: ${result.reason}`);
+        // This should be moved outside the loop to match the creation of the proving ticket when we move to epochs.
+        this.state = 'awaiting-prover';
+        const result = await provingTicket.provingPromise;
+        if (result.status === PROVING_STATUS.FAILURE) {
+          throw new Error(`Block proving failed: ${result.reason}`);
+        }
+
+        historicalHeader = block.header;
       }
 
-      historicalHeader = block.header;
+      const { block, aggregationObject, proof } = await this.prover.finaliseBlock();
+      this.log.info(`Finalised proof for block range`, { fromBlock, toBlock });
+
+      this.state = 'publishing-proof';
+      await this.publisher.submitProof(
+        block.header,
+        block.archive.root,
+        this.prover.getProverId(),
+        aggregationObject,
+        proof,
+      );
+      this.log.info(`Submitted proof for block range`, { fromBlock, toBlock });
+
+      this.state = 'completed';
+    } catch (err) {
+      this.log.error(`Error running block prover job: ${err}`);
+      this.state = 'failed';
     }
-
-    this.state = 'awaiting-prover';
-    const { block, aggregationObject, proof } = await this.prover.finaliseBlock();
-    this.log.info(`Finalised proof for block range`, { fromBlock, toBlock });
-
-    this.state = 'publishing-proof';
-    await this.publisher.submitProof(
-      block.header,
-      block.archive.root,
-      this.prover.getProverId(),
-      aggregationObject,
-      proof,
-    );
-    this.log.info(`Submitted proof for block range`, { fromBlock, toBlock });
-
-    this.state = 'completed';
   }
 
   private async getBlock(blockNumber: number): Promise<L2Block> {
@@ -155,8 +155,8 @@ export class BlockProvingJob {
 
 export type BlockProvingJobState =
   | 'initialized'
-  | 'started'
   | 'processing'
   | 'awaiting-prover'
   | 'publishing-proof'
-  | 'completed';
+  | 'completed'
+  | 'failed';

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -2,8 +2,11 @@ import { type L1ToL2MessageSource, type L2BlockSource, type ProverClient, type T
 import { createDebugLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { type L1Publisher } from '@aztec/sequencer-client';
-import { type PublicProcessorFactory } from '@aztec/simulator';
+import { PublicProcessorFactory, type SimulationProvider } from '@aztec/simulator';
+import { type TelemetryClient } from '@aztec/telemetry-client';
+import { type WorldStateSynchronizer } from '@aztec/world-state';
 
+import { type ContractDataSource } from '../../types/src/contracts/contract_data_source.js';
 import { BlockProvingJob } from './job/block-proving-job.js';
 
 /**
@@ -14,14 +17,18 @@ import { BlockProvingJob } from './job/block-proving-job.js';
 export class ProverNode {
   private log = createDebugLogger('aztec:prover-node');
   private runningPromise: RunningPromise | undefined;
+  private latestBlockWeAreProving: number | undefined;
 
   constructor(
     private prover: ProverClient,
-    private publicProcessorFactory: PublicProcessorFactory,
     private publisher: L1Publisher,
     private l2BlockSource: L2BlockSource,
     private l1ToL2MessageSource: L1ToL2MessageSource,
+    private contractDataSource: ContractDataSource,
+    private worldState: WorldStateSynchronizer,
     private txProvider: TxProvider,
+    private simulator: SimulationProvider,
+    private telemetryClient: TelemetryClient,
     private options: { pollingIntervalMs: number; disableAutomaticProving: boolean } = {
       pollingIntervalMs: 1_000,
       disableAutomaticProving: false,
@@ -53,7 +60,6 @@ export class ProverNode {
   /**
    * Single iteration of recurring work. This method is called periodically by the running promise.
    * Checks whether there are new blocks to prove, proves them, and submits them.
-   * Only proves one block per job and one job at a time (for now).
    */
   protected async work() {
     if (this.options.disableAutomaticProving) {
@@ -65,29 +71,35 @@ export class ProverNode {
       this.l2BlockSource.getProvenBlockNumber(),
     ]);
 
-    if (latestProvenBlockNumber >= latestBlockNumber) {
-      this.log.debug(`No new blocks to prove`, { latestBlockNumber, latestProvenBlockNumber });
+    // Consider both the latest block we are proving and the last block proven on the chain
+    const latestBlockBeingProven = this.latestBlockWeAreProving ?? 0;
+    const latestProven = Math.max(latestBlockBeingProven, latestProvenBlockNumber);
+    if (latestProven >= latestBlockNumber) {
+      this.log.debug(`No new blocks to prove`, { latestBlockNumber, latestProvenBlockNumber, latestBlockBeingProven });
       return;
     }
 
-    const fromBlock = latestProvenBlockNumber + 1;
+    const fromBlock = latestProven + 1;
     const toBlock = fromBlock; // We only prove one block at a time for now
-    await this.prove(fromBlock, toBlock);
+
+    await this.startProof(fromBlock, toBlock);
+    this.latestBlockWeAreProving = toBlock;
   }
 
   /**
    * Creates a proof for a block range. Returns once the proof has been submitted to L1.
    */
-  public prove(fromBlock: number, toBlock: number) {
-    return this.createProvingJob().run(fromBlock, toBlock);
+  public async prove(fromBlock: number, toBlock: number) {
+    const job = await this.createProvingJob(fromBlock);
+    return job.run(fromBlock, toBlock);
   }
 
   /**
    * Starts a proving process and returns immediately.
    */
-  public startProof(fromBlock: number, toBlock: number) {
-    void this.createProvingJob().run(fromBlock, toBlock);
-    return Promise.resolve();
+  public async startProof(fromBlock: number, toBlock: number) {
+    const job = await this.createProvingJob(fromBlock);
+    void job.run(fromBlock, toBlock);
   }
 
   /**
@@ -97,10 +109,27 @@ export class ProverNode {
     return this.prover;
   }
 
-  private createProvingJob() {
+  private async createProvingJob(fromBlock: number) {
+    if ((await this.worldState.status()).syncedToL2Block > fromBlock) {
+      throw new Error(`Cannot create proving job for block ${fromBlock} as it is behind the current world state`);
+    }
+
+    // Fast forward world state to the target block and get a fork
+    // TODO(palla/prover-node): We need to pause world state while we procure the fork
+    await this.worldState.syncImmediate(fromBlock);
+    const db = await this.worldState.getFork(true);
+
+    // Create a processor using the forked world state
+    const publicProcessorFactory = new PublicProcessorFactory(
+      db,
+      this.contractDataSource,
+      this.simulator,
+      this.telemetryClient,
+    );
+
     return new BlockProvingJob(
       this.prover,
-      this.publicProcessorFactory,
+      publicProcessorFactory,
       this.publisher,
       this.l2BlockSource,
       this.l1ToL2MessageSource,

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -116,9 +116,7 @@ export class ProverNode {
     }
 
     // Fast forward world state to right before the target block and get a fork
-    // TODO(palla/prover-node): We need to pause world state while we procure the fork
-    await this.worldState.syncImmediate(fromBlock - 1);
-    const db = await this.worldState.getFork(true);
+    const db = await this.worldState.syncImmediateAndFork(fromBlock - 1, true);
 
     // Create a processor using the forked world state
     const publicProcessorFactory = new PublicProcessorFactory(

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -46,7 +46,7 @@ export class SequencerClient {
     const merkleTreeDb = worldStateSynchronizer.getLatest();
 
     const publicProcessorFactory = new PublicProcessorFactory(
-      merkleTreeDb,
+      worldStateSynchronizer,
       contractDataSource,
       simulationProvider,
       telemetryClient,

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -46,7 +46,7 @@ export class SequencerClient {
     const merkleTreeDb = worldStateSynchronizer.getLatest();
 
     const publicProcessorFactory = new PublicProcessorFactory(
-      worldStateSynchronizer,
+      merkleTreeDb,
       contractDataSource,
       simulationProvider,
       telemetryClient,

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -1,5 +1,5 @@
 import { type L1ToL2MessageSource, type L2BlockSource } from '@aztec/circuit-types';
-import { type BlockProver } from '@aztec/circuit-types/interfaces';
+import { type ProverClient } from '@aztec/circuit-types/interfaces';
 import { type P2P } from '@aztec/p2p';
 import { PublicProcessorFactory, type SimulationProvider } from '@aztec/simulator';
 import { type TelemetryClient } from '@aztec/telemetry-client';
@@ -37,7 +37,7 @@ export class SequencerClient {
     contractDataSource: ContractDataSource,
     l2BlockSource: L2BlockSource,
     l1ToL2MessageSource: L1ToL2MessageSource,
-    prover: BlockProver,
+    prover: ProverClient,
     simulationProvider: SimulationProvider,
     telemetryClient: TelemetryClient,
   ) {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -1,4 +1,5 @@
 import {
+  type BlockProver,
   type L1ToL2MessageSource,
   L2Block,
   type L2BlockSource,
@@ -42,6 +43,7 @@ describe('sequencer', () => {
   let globalVariableBuilder: MockProxy<GlobalVariableBuilder>;
   let p2p: MockProxy<P2P>;
   let worldState: MockProxy<WorldStateSynchronizer>;
+  let blockProver: MockProxy<BlockProver>;
   let proverClient: MockProxy<ProverClient>;
   let merkleTreeOps: MockProxy<MerkleTreeOperations>;
   let publicProcessor: MockProxy<PublicProcessor>;
@@ -67,7 +69,11 @@ describe('sequencer', () => {
 
     globalVariableBuilder = mock<GlobalVariableBuilder>();
     merkleTreeOps = mock<MerkleTreeOperations>();
-    proverClient = mock<ProverClient>();
+    blockProver = mock<BlockProver>();
+
+    proverClient = mock<ProverClient>({
+      createBlockProver: () => blockProver,
+    });
 
     p2p = mock<P2P>({
       getStatus: () => Promise.resolve({ state: P2PClientState.IDLE, syncedToL2Block: lastBlockNumber }),
@@ -132,8 +138,8 @@ describe('sequencer', () => {
     };
 
     p2p.getTxs.mockReturnValueOnce([tx]);
-    proverClient.startNewBlock.mockResolvedValueOnce(ticket);
-    proverClient.finaliseBlock.mockResolvedValue({ block, aggregationObject: [], proof });
+    blockProver.startNewBlock.mockResolvedValueOnce(ticket);
+    blockProver.finaliseBlock.mockResolvedValue({ block, aggregationObject: [], proof });
     publisher.processL2Block.mockResolvedValueOnce(true);
     globalVariableBuilder.buildGlobalVariables.mockResolvedValueOnce(
       new GlobalVariables(
@@ -151,7 +157,7 @@ describe('sequencer', () => {
     await sequencer.initialSync();
     await sequencer.work();
 
-    expect(proverClient.startNewBlock).toHaveBeenCalledWith(
+    expect(blockProver.startNewBlock).toHaveBeenCalledWith(
       2,
       new GlobalVariables(
         chainId,
@@ -166,7 +172,7 @@ describe('sequencer', () => {
       Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n)),
     );
     expect(publisher.processL2Block).toHaveBeenCalledWith(block);
-    expect(proverClient.cancelBlock).toHaveBeenCalledTimes(0);
+    expect(blockProver.cancelBlock).toHaveBeenCalledTimes(0);
   });
 
   it('builds a block when it is their turn', async () => {
@@ -182,8 +188,8 @@ describe('sequencer', () => {
     };
 
     p2p.getTxs.mockReturnValueOnce([tx]);
-    proverClient.startNewBlock.mockResolvedValueOnce(ticket);
-    proverClient.finaliseBlock.mockResolvedValue({ block, aggregationObject: [], proof });
+    blockProver.startNewBlock.mockResolvedValueOnce(ticket);
+    blockProver.finaliseBlock.mockResolvedValue({ block, aggregationObject: [], proof });
     publisher.processL2Block.mockResolvedValueOnce(true);
     globalVariableBuilder.buildGlobalVariables.mockResolvedValueOnce(
       new GlobalVariables(
@@ -202,12 +208,12 @@ describe('sequencer', () => {
     publisher.isItMyTurnToSubmit.mockClear().mockResolvedValue(false);
     await sequencer.initialSync();
     await sequencer.work();
-    expect(proverClient.startNewBlock).not.toHaveBeenCalled();
+    expect(blockProver.startNewBlock).not.toHaveBeenCalled();
 
     // Now it is!
     publisher.isItMyTurnToSubmit.mockClear().mockResolvedValue(true);
     await sequencer.work();
-    expect(proverClient.startNewBlock).toHaveBeenCalledWith(
+    expect(blockProver.startNewBlock).toHaveBeenCalledWith(
       2,
       new GlobalVariables(
         chainId,
@@ -222,7 +228,7 @@ describe('sequencer', () => {
       Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n)),
     );
     expect(publisher.processL2Block).toHaveBeenCalledWith(block);
-    expect(proverClient.cancelBlock).toHaveBeenCalledTimes(0);
+    expect(blockProver.cancelBlock).toHaveBeenCalledTimes(0);
   });
 
   it('builds a block out of several txs rejecting double spends', async () => {
@@ -241,8 +247,8 @@ describe('sequencer', () => {
     };
 
     p2p.getTxs.mockReturnValueOnce(txs);
-    proverClient.startNewBlock.mockResolvedValueOnce(ticket);
-    proverClient.finaliseBlock.mockResolvedValue({ block, aggregationObject: [], proof });
+    blockProver.startNewBlock.mockResolvedValueOnce(ticket);
+    blockProver.finaliseBlock.mockResolvedValue({ block, aggregationObject: [], proof });
     publisher.processL2Block.mockResolvedValueOnce(true);
     globalVariableBuilder.buildGlobalVariables.mockResolvedValueOnce(
       new GlobalVariables(
@@ -268,7 +274,7 @@ describe('sequencer', () => {
     await sequencer.initialSync();
     await sequencer.work();
 
-    expect(proverClient.startNewBlock).toHaveBeenCalledWith(
+    expect(blockProver.startNewBlock).toHaveBeenCalledWith(
       2,
       new GlobalVariables(
         chainId,
@@ -284,7 +290,7 @@ describe('sequencer', () => {
     );
     expect(publisher.processL2Block).toHaveBeenCalledWith(block);
     expect(p2p.deleteTxs).toHaveBeenCalledWith([doubleSpendTx.getTxHash()]);
-    expect(proverClient.cancelBlock).toHaveBeenCalledTimes(0);
+    expect(blockProver.cancelBlock).toHaveBeenCalledTimes(0);
   });
 
   it('builds a block out of several txs rejecting incorrect chain ids', async () => {
@@ -303,8 +309,8 @@ describe('sequencer', () => {
     };
 
     p2p.getTxs.mockReturnValueOnce(txs);
-    proverClient.startNewBlock.mockResolvedValueOnce(ticket);
-    proverClient.finaliseBlock.mockResolvedValue({ block, aggregationObject: [], proof });
+    blockProver.startNewBlock.mockResolvedValueOnce(ticket);
+    blockProver.finaliseBlock.mockResolvedValue({ block, aggregationObject: [], proof });
     publisher.processL2Block.mockResolvedValueOnce(true);
     globalVariableBuilder.buildGlobalVariables.mockResolvedValueOnce(
       new GlobalVariables(
@@ -325,7 +331,7 @@ describe('sequencer', () => {
     await sequencer.initialSync();
     await sequencer.work();
 
-    expect(proverClient.startNewBlock).toHaveBeenCalledWith(
+    expect(blockProver.startNewBlock).toHaveBeenCalledWith(
       2,
       new GlobalVariables(
         chainId,
@@ -341,7 +347,7 @@ describe('sequencer', () => {
     );
     expect(publisher.processL2Block).toHaveBeenCalledWith(block);
     expect(p2p.deleteTxs).toHaveBeenCalledWith([invalidChainTx.getTxHash()]);
-    expect(proverClient.cancelBlock).toHaveBeenCalledTimes(0);
+    expect(blockProver.cancelBlock).toHaveBeenCalledTimes(0);
   });
 
   it('builds a block out of several txs dropping the ones that go over max size', async () => {
@@ -359,8 +365,8 @@ describe('sequencer', () => {
     };
 
     p2p.getTxs.mockReturnValueOnce(txs);
-    proverClient.startNewBlock.mockResolvedValueOnce(ticket);
-    proverClient.finaliseBlock.mockResolvedValue({ block, aggregationObject: [], proof });
+    blockProver.startNewBlock.mockResolvedValueOnce(ticket);
+    blockProver.finaliseBlock.mockResolvedValue({ block, aggregationObject: [], proof });
     publisher.processL2Block.mockResolvedValueOnce(true);
     globalVariableBuilder.buildGlobalVariables.mockResolvedValueOnce(
       new GlobalVariables(
@@ -382,7 +388,7 @@ describe('sequencer', () => {
     await sequencer.initialSync();
     await sequencer.work();
 
-    expect(proverClient.startNewBlock).toHaveBeenCalledWith(
+    expect(blockProver.startNewBlock).toHaveBeenCalledWith(
       2,
       new GlobalVariables(
         chainId,
@@ -397,7 +403,7 @@ describe('sequencer', () => {
       Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n)),
     );
     expect(publisher.processL2Block).toHaveBeenCalledWith(block);
-    expect(proverClient.cancelBlock).toHaveBeenCalledTimes(0);
+    expect(blockProver.cancelBlock).toHaveBeenCalledTimes(0);
   });
 
   it('aborts building a block if the chain moves underneath it', async () => {
@@ -413,8 +419,8 @@ describe('sequencer', () => {
     };
 
     p2p.getTxs.mockReturnValueOnce([tx]);
-    proverClient.startNewBlock.mockResolvedValueOnce(ticket);
-    proverClient.finaliseBlock.mockResolvedValue({ block, aggregationObject: [], proof });
+    blockProver.startNewBlock.mockResolvedValueOnce(ticket);
+    blockProver.finaliseBlock.mockResolvedValue({ block, aggregationObject: [], proof });
     publisher.processL2Block.mockResolvedValueOnce(true);
     globalVariableBuilder.buildGlobalVariables.mockResolvedValueOnce(
       new GlobalVariables(
@@ -442,7 +448,7 @@ describe('sequencer', () => {
     await sequencer.work();
 
     expect(publisher.processL2Block).not.toHaveBeenCalled();
-    expect(proverClient.cancelBlock).toHaveBeenCalledTimes(1);
+    expect(blockProver.cancelBlock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -87,7 +87,7 @@ describe('sequencer', () => {
     });
 
     publicProcessorFactory = mock<PublicProcessorFactory>({
-      create: (_a, _b_) => publicProcessor,
+      create: (_a, _b) => publicProcessor,
     });
 
     l2BlockSource = mock<L2BlockSource>({

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -448,7 +448,6 @@ describe('sequencer', () => {
     await sequencer.work();
 
     expect(publisher.processL2Block).not.toHaveBeenCalled();
-    expect(blockProver.cancelBlock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/yarn-project/simulator/src/public/hints_builder.ts
+++ b/yarn-project/simulator/src/public/hints_builder.ts
@@ -1,4 +1,4 @@
-import { MerkleTreeId } from '@aztec/circuit-types';
+import { type IndexedTreeId, MerkleTreeId } from '@aztec/circuit-types';
 import {
   type Fr,
   type MAX_NULLIFIERS_PER_TX,
@@ -23,7 +23,7 @@ import {
   buildSiloedNullifierReadRequestHints,
 } from '@aztec/circuits.js';
 import { type Tuple } from '@aztec/foundation/serialize';
-import { type IndexedTreeId, type MerkleTreeOperations } from '@aztec/world-state';
+import { type MerkleTreeOperations } from '@aztec/world-state';
 
 export class HintsBuilder {
   constructor(private db: MerkleTreeOperations) {}

--- a/yarn-project/simulator/src/public/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor.test.ts
@@ -4,6 +4,7 @@ import {
   PublicDataWrite,
   PublicKernelType,
   SimulationError,
+  type TreeInfo,
   type TxValidator,
   mockTx,
   toTxEffect,
@@ -43,7 +44,7 @@ import {
   computeFeePayerBalanceLeafSlot,
 } from '@aztec/simulator';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
-import { type MerkleTreeOperations, type TreeInfo } from '@aztec/world-state';
+import { type MerkleTreeOperations } from '@aztec/world-state';
 
 import { jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';

--- a/yarn-project/simulator/src/public/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor.ts
@@ -60,24 +60,24 @@ export class PublicProcessorFactory {
    * Creates a new instance of a PublicProcessor.
    * @param historicalHeader - The header of a block previous to the one in which the tx is included.
    * @param globalVariables - The global variables for the block being processed.
-   * @param newContracts - Provides access to contract bytecode for public executions.
    * @returns A new instance of a PublicProcessor.
    */
-  public create(historicalHeader: Header | undefined, globalVariables: GlobalVariables): PublicProcessor {
-    historicalHeader = historicalHeader ?? this.merkleTree.getInitialHeader();
-
+  public create(maybeHistoricalHeader: Header | undefined, globalVariables: GlobalVariables): PublicProcessor {
+    const { merkleTree, telemetryClient } = this;
+    const historicalHeader = maybeHistoricalHeader ?? merkleTree.getInitialHeader();
     const publicContractsDB = new ContractsDataSourcePublicDB(this.contractDataSource);
-    const worldStatePublicDB = new WorldStatePublicDB(this.merkleTree);
-    const worldStateDB = new WorldStateDB(this.merkleTree);
+
+    const worldStatePublicDB = new WorldStatePublicDB(merkleTree);
+    const worldStateDB = new WorldStateDB(merkleTree);
     const publicExecutor = new PublicExecutor(
       worldStatePublicDB,
       publicContractsDB,
       worldStateDB,
       historicalHeader,
-      this.telemetryClient,
+      telemetryClient,
     );
     return new PublicProcessor(
-      this.merkleTree,
+      merkleTree,
       publicExecutor,
       new RealPublicKernelCircuitSimulator(this.simulator),
       globalVariables,

--- a/yarn-project/simulator/src/public/setup_phase_manager.test.ts
+++ b/yarn-project/simulator/src/public/setup_phase_manager.test.ts
@@ -1,7 +1,7 @@
-import { mockTx } from '@aztec/circuit-types';
+import { type TreeInfo, mockTx } from '@aztec/circuit-types';
 import { GlobalVariables, Header } from '@aztec/circuits.js';
 import { type PublicExecutor } from '@aztec/simulator';
-import { type MerkleTreeOperations, type TreeInfo } from '@aztec/world-state';
+import { type MerkleTreeOperations } from '@aztec/world-state';
 
 import { it } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -1,4 +1,10 @@
-import { type L1ToL2MessageSource, type L2Block, L2BlockDownloader, type L2BlockSource } from '@aztec/circuit-types';
+import {
+  type HandleL2BlockAndMessagesResult,
+  type L1ToL2MessageSource,
+  type L2Block,
+  L2BlockDownloader,
+  type L2BlockSource,
+} from '@aztec/circuit-types';
 import { type L2BlockHandledStats } from '@aztec/circuit-types/stats';
 import { L1_TO_L2_MSG_SUBTREE_HEIGHT } from '@aztec/circuits.js/constants';
 import { Fr } from '@aztec/foundation/fields';
@@ -9,11 +15,7 @@ import { type AztecKVStore, type AztecSingleton } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/utils';
 import { SHA256Trunc, StandardTree } from '@aztec/merkle-tree';
 
-import {
-  type HandleL2BlockAndMessagesResult,
-  type MerkleTreeOperations,
-  type MerkleTrees,
-} from '../world-state-db/index.js';
+import { type MerkleTreeOperations, type MerkleTrees } from '../world-state-db/index.js';
 import { MerkleTreeOperationsFacade } from '../world-state-db/merkle_tree_operations_facade.js';
 import { MerkleTreeSnapshotOperationsFacade } from '../world-state-db/merkle_tree_snapshot_operations_facade.js';
 import { type WorldStateConfig } from './config.js';

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -4,7 +4,6 @@ import {
   type L2Block,
   L2BlockDownloader,
   type L2BlockSource,
-  MerkleTreeId,
 } from '@aztec/circuit-types';
 import { type L2BlockHandledStats } from '@aztec/circuit-types/stats';
 import { L1_TO_L2_MSG_SUBTREE_HEIGHT } from '@aztec/circuits.js/constants';

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -67,6 +67,10 @@ export class ServerWorldStateSynchronizer implements WorldStateSynchronizer {
     return new MerkleTreeSnapshotOperationsFacade(this.merkleTreeDb, blockNumber);
   }
 
+  public async getFork(includeUncommitted: boolean): Promise<MerkleTreeOperationsFacade> {
+    return new MerkleTreeOperationsFacade(await this.merkleTreeDb.fork(), includeUncommitted);
+  }
+
   public async start() {
     if (this.currentState === WorldStateRunningState.STOPPED) {
       throw new Error('Synchronizer already stopped');

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -75,7 +75,7 @@ export class ServerWorldStateSynchronizer implements WorldStateSynchronizer {
     return new MerkleTreeSnapshotOperationsFacade(this.merkleTreeDb, blockNumber);
   }
 
-  public async getFork(includeUncommitted: boolean): Promise<MerkleTreeOperationsFacade> {
+  private async getFork(includeUncommitted: boolean): Promise<MerkleTreeOperationsFacade> {
     this.log.verbose(`Forking world state at ${this.blockNumber.get()}`);
     return new MerkleTreeOperationsFacade(await this.merkleTreeDb.fork(), includeUncommitted);
   }

--- a/yarn-project/world-state/src/synchronizer/world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/world_state_synchronizer.ts
@@ -53,6 +53,14 @@ export interface WorldStateSynchronizer {
   syncImmediate(minBlockNumber?: number): Promise<number>;
 
   /**
+   * Pauses the synchronizer, syncs to the target block number, forks world state, and resumes.
+   * @param targetBlockNumber - The block number to sync to.
+   * @param forkIncludeUncommitted - Whether to include uncommitted data in the fork.
+   * @returns The db forked at the requested target block number.
+   */
+  syncImmediateAndFork(targetBlockNumber: number, forkIncludeUncommitted: boolean): Promise<MerkleTreeOperations>;
+
+  /**
    * Returns an instance of MerkleTreeOperations that will include uncommitted data.
    * @returns An instance of MerkleTreeOperations that will include uncommitted data.
    */

--- a/yarn-project/world-state/src/synchronizer/world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/world_state_synchronizer.ts
@@ -78,10 +78,4 @@ export interface WorldStateSynchronizer {
    * @returns An instance of MerkleTreeOperations
    */
   getSnapshot(block: number): MerkleTreeOperations;
-
-  /**
-   * Returns a writeable fork of the MerkleTreeOperations from the current state.
-   * @param includeUncommitted - Whether to include uncommitted data.
-   */
-  getFork(includeUncommitted: boolean): Promise<MerkleTreeOperations>;
 }

--- a/yarn-project/world-state/src/synchronizer/world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/world_state_synchronizer.ts
@@ -70,4 +70,10 @@ export interface WorldStateSynchronizer {
    * @returns An instance of MerkleTreeOperations
    */
   getSnapshot(block: number): MerkleTreeOperations;
+
+  /**
+   * Returns a writeable fork of the MerkleTreeOperations from the current state.
+   * @param includeUncommitted - Whether to include uncommitted data.
+   */
+  getFork(includeUncommitted: boolean): Promise<MerkleTreeOperations>;
 }

--- a/yarn-project/world-state/src/world-state-db/index.ts
+++ b/yarn-project/world-state/src/world-state-db/index.ts
@@ -1,5 +1,6 @@
 export * from './merkle_trees.js';
 export * from './merkle_tree_db.js';
-export * from './merkle_tree_operations.js';
 export * from './merkle_tree_operations_facade.js';
 export * from './merkle_tree_snapshot_operations_facade.js';
+
+export { MerkleTreeOperations } from '@aztec/circuit-types/interfaces';

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
@@ -1,8 +1,7 @@
 import { type MerkleTreeId } from '@aztec/circuit-types';
+import { type MerkleTreeOperations } from '@aztec/circuit-types/interfaces';
 import { type Fr, MAX_NULLIFIERS_PER_TX, MAX_TOTAL_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX } from '@aztec/circuits.js';
 import { type IndexedTreeSnapshot, type TreeSnapshot } from '@aztec/merkle-tree';
-
-import { type MerkleTreeOperations } from './merkle_tree_operations.js';
 
 /**
  *

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
@@ -62,4 +62,9 @@ export type MerkleTreeDb = {
      * @param block - The block number to take the snapshot at.
      */
     getSnapshot(block: number): Promise<TreeSnapshots>;
+
+    /**
+     * Forks the database at its current state.
+     */
+    fork(): Promise<MerkleTreeDb>;
   };

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_map.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_map.ts
@@ -1,0 +1,11 @@
+import { type MerkleTreeId } from '@aztec/circuit-types';
+import { type Fr } from '@aztec/circuits.js';
+import { type AppendOnlyTree, type IndexedTree } from '@aztec/merkle-tree';
+
+export type MerkleTreeMap = {
+  [MerkleTreeId.NULLIFIER_TREE]: IndexedTree;
+  [MerkleTreeId.NOTE_HASH_TREE]: AppendOnlyTree<Fr>;
+  [MerkleTreeId.PUBLIC_DATA_TREE]: IndexedTree;
+  [MerkleTreeId.L1_TO_L2_MESSAGE_TREE]: AppendOnlyTree<Fr>;
+  [MerkleTreeId.ARCHIVE]: AppendOnlyTree<Fr>;
+};

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_operations_facade.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_operations_facade.ts
@@ -1,16 +1,15 @@
-import { type L2Block, type MerkleTreeId, type SiblingPath } from '@aztec/circuit-types';
-import { type Fr, type Header, type NullifierLeafPreimage, type StateReference } from '@aztec/circuits.js';
-import { type IndexedTreeLeafPreimage } from '@aztec/foundation/trees';
-import { type BatchInsertionResult } from '@aztec/merkle-tree';
-
-import { type MerkleTreeDb } from './merkle_tree_db.js';
+import { type BatchInsertionResult, type L2Block, type MerkleTreeId, type SiblingPath } from '@aztec/circuit-types';
 import {
   type HandleL2BlockAndMessagesResult,
   type IndexedTreeId,
   type MerkleTreeLeafType,
   type MerkleTreeOperations,
   type TreeInfo,
-} from './merkle_tree_operations.js';
+} from '@aztec/circuit-types/interfaces';
+import { type Fr, type Header, type NullifierLeafPreimage, type StateReference } from '@aztec/circuits.js';
+import { type IndexedTreeLeafPreimage } from '@aztec/foundation/trees';
+
+import { type MerkleTreeDb } from './merkle_tree_db.js';
 
 /**
  * Wraps a MerkleTreeDbOperations to call all functions with a preset includeUncommitted flag.

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_snapshot_operations_facade.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_snapshot_operations_facade.ts
@@ -1,16 +1,17 @@
 import { MerkleTreeId, type SiblingPath } from '@aztec/circuit-types';
-import { AppendOnlyTreeSnapshot, Fr, type Header, PartialStateReference, StateReference } from '@aztec/circuits.js';
-import { type IndexedTreeLeafPreimage } from '@aztec/foundation/trees';
-import { type BatchInsertionResult, type IndexedTreeSnapshot } from '@aztec/merkle-tree';
-
-import { type MerkleTreeDb, type TreeSnapshots } from './merkle_tree_db.js';
 import {
+  type BatchInsertionResult,
   type HandleL2BlockAndMessagesResult,
   type IndexedTreeId,
   type MerkleTreeLeafType,
   type MerkleTreeOperations,
   type TreeInfo,
-} from './merkle_tree_operations.js';
+} from '@aztec/circuit-types/interfaces';
+import { AppendOnlyTreeSnapshot, Fr, type Header, PartialStateReference, StateReference } from '@aztec/circuits.js';
+import { type IndexedTreeLeafPreimage } from '@aztec/foundation/trees';
+import { type IndexedTreeSnapshot } from '@aztec/merkle-tree';
+
+import { type MerkleTreeDb, type TreeSnapshots } from './merkle_tree_db.js';
 
 /**
  * Merkle tree operations on readonly tree snapshots.

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -53,7 +53,7 @@ import {
   type MerkleTreeDb,
   type TreeSnapshots,
 } from './merkle_tree_db.js';
-import { MerkleTreeMap } from './merkle_tree_map.js';
+import { type MerkleTreeMap } from './merkle_tree_map.js';
 import { MerkleTreeOperationsFacade } from './merkle_tree_operations_facade.js';
 
 /**

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -1,5 +1,13 @@
 import { type L2Block, MerkleTreeId, PublicDataWrite, type SiblingPath, TxEffect } from '@aztec/circuit-types';
 import {
+  type BatchInsertionResult,
+  type HandleL2BlockAndMessagesResult,
+  type IndexedTreeId,
+  type MerkleTreeLeafType,
+  type MerkleTreeOperations,
+  type TreeInfo,
+} from '@aztec/circuit-types/interfaces';
+import {
   ARCHIVE_HEIGHT,
   AppendOnlyTreeSnapshot,
   Fr,
@@ -28,7 +36,6 @@ import { type IndexedTreeLeafPreimage } from '@aztec/foundation/trees';
 import { type AztecKVStore, type AztecSingleton } from '@aztec/kv-store';
 import {
   type AppendOnlyTree,
-  type BatchInsertionResult,
   type IndexedTree,
   Poseidon,
   StandardIndexedTree,
@@ -46,14 +53,7 @@ import {
   type MerkleTreeDb,
   type TreeSnapshots,
 } from './merkle_tree_db.js';
-import {
-  type HandleL2BlockAndMessagesResult,
-  type IndexedTreeId,
-  type MerkleTreeLeafType,
-  type MerkleTreeMap,
-  type MerkleTreeOperations,
-  type TreeInfo,
-} from './merkle_tree_operations.js';
+import { MerkleTreeMap } from './merkle_tree_map.js';
 import { MerkleTreeOperationsFacade } from './merkle_tree_operations_facade.js';
 
 /**

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -180,6 +180,15 @@ export class MerkleTrees implements MerkleTreeDb {
     await this.#commit();
   }
 
+  public async fork(): Promise<MerkleTrees> {
+    // TODO(palla/prover-node): If the underlying store is being shared with other components, we're unnecessarily
+    // copying a lot of data unrelated to merkle trees. This may be fine for now, and we may be able to ditch backup-based
+    // forking in favor of a more elegant proposal. But if we see this operation starts taking a lot of time, we may want
+    // to open separate stores for merkle trees and other components.
+    const forked = await this.store.fork();
+    return MerkleTrees.new(forked, this.log);
+  }
+
   public getInitialHeader(): Header {
     return Header.empty({ state: this.#loadInitialStateReference() });
   }


### PR DESCRIPTION
# Goal

We want to be able to kick off more than one `prove(blocknumber)` job in the prover-node at the same time.

We currently cannot do it because the prover-node has a single world-state, and building a proof modifies world-state. In particular, preparing the inputs for base rollups modifies state trees, and finalising the block modifies the archive tree.

# Why?

This'll be needed for the proving integration contest, in case we generate blocks faster than the time it takes to prove them.

It may still be useful once we move to epoch proving and sequencer-prover coordination, since the same prover could be picked for generating proofs for two consecutive epochs.

# How?

## The easy way

Easiest approach is to keep everything as-is today, and clone the world state before kicking off a job. Eventually, once we implement [Phil's world-state](https://github.com/AztecProtocol/engineering-designs/pull/9), we can use the writeable world-state snapshots for this.  **This is what we're doing on this PR.**

## The not-so-easy way

Another approach is to decouple input-generation from proving. Today the prover-orchestrator is responsible for computing all inputs, but this is not strictly needed. We can have one component that generates all inputs, modifies world-state, and outputs a graph of proving jobs (as Mitch commented [here](https://aztecprotocol.slack.com/archives/C04BTJAA694/p1722195399887399?thread_ts=1722195378.794149&cid=C04BTJAA694)). And then another component that orchestrates the execution of proving jobs exclusively based on their dependencies.

Note that this new component would be a good fit for generating a block in the sequencer, which today runs an orchestrator without proving enabled to get to a block header.

It's unclear whether this component should run everything serially (like [the old block builder](https://aztecprotocol.slack.com/archives/C04BTJAA694/p1722195399887399?thread_ts=1722195378.794149&cid=C04BTJAA694) did), or it makes more sense to fan out circuit simulation jobs to workers (like the proving orchestrator can do now).

