### PR TITLE
feat: Optimize constant array handling in brillig_gen

### DIFF
--- a/noir/noir-repo/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/noir/noir-repo/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -938,7 +938,7 @@ impl<'block> BrilligBlock<'block> {
 
         if let Some((index_register, value_variable)) = opt_index_and_value {
             // Then set the value in the newly created array
-            self.store_variable_in_array(
+            self.brillig_context.codegen_store_variable_in_array(
                 destination_pointer,
                 SingleAddrVariable::new_usize(index_register),
                 value_variable,
@@ -947,47 +947,6 @@ impl<'block> BrilligBlock<'block> {
 
         self.brillig_context.deallocate_register(condition);
         source_size_as_register
-    }
-
-    pub(crate) fn store_variable_in_array_with_ctx(
-        ctx: &mut BrilligContext<FieldElement>,
-        destination_pointer: MemoryAddress,
-        index_register: SingleAddrVariable,
-        value_variable: BrilligVariable,
-    ) {
-        match value_variable {
-            BrilligVariable::SingleAddr(value_variable) => {
-                ctx.codegen_array_set(destination_pointer, index_register, value_variable.address);
-            }
-            BrilligVariable::BrilligArray(_) => {
-                let reference: MemoryAddress = ctx.allocate_register();
-                ctx.codegen_allocate_array_reference(reference);
-                ctx.codegen_store_variable(reference, value_variable);
-                ctx.codegen_array_set(destination_pointer, index_register, reference);
-                ctx.deallocate_register(reference);
-            }
-            BrilligVariable::BrilligVector(_) => {
-                let reference = ctx.allocate_register();
-                ctx.codegen_allocate_vector_reference(reference);
-                ctx.codegen_store_variable(reference, value_variable);
-                ctx.codegen_array_set(destination_pointer, index_register, reference);
-                ctx.deallocate_register(reference);
-            }
-        }
-    }
-
-    pub(crate) fn store_variable_in_array(
-        &mut self,
-        destination_pointer: MemoryAddress,
-        index_variable: SingleAddrVariable,
-        value_variable: BrilligVariable,
-    ) {
-        Self::store_variable_in_array_with_ctx(
-            self.brillig_context,
-            destination_pointer,
-            index_variable,
-            value_variable,
-        );
     }
 
     /// Convert the SSA slice operations to brillig slice operations
@@ -1748,9 +1707,18 @@ impl<'block> BrilligBlock<'block> {
             subitem_to_repeat_variables.push(self.convert_ssa_value(subitem_id, dfg));
         }
 
-        let data_length_variable = self
+        // Initialize loop bound with the array length
+        let end_pointer_variable = self
             .brillig_context
             .make_usize_constant_instruction((item_count * item_types.len()).into());
+
+        // Add the pointer to the array length
+        self.brillig_context.memory_op_instruction(
+            end_pointer_variable.address,
+            pointer,
+            end_pointer_variable.address,
+            BrilligBinaryOp::Add,
+        );
 
         // If this is an array with complex subitems, we need a custom step in the loop to write all the subitems while iterating.
         if item_types.len() > 1 {
@@ -1760,33 +1728,50 @@ impl<'block> BrilligBlock<'block> {
             let subitem_pointer =
                 SingleAddrVariable::new_usize(self.brillig_context.allocate_register());
 
-            let initializer_fn = |ctx: &mut BrilligContext<_>, iterator: SingleAddrVariable| {
-                ctx.mov_instruction(subitem_pointer.address, iterator.address);
-                for subitem in subitem_to_repeat_variables.into_iter() {
-                    Self::store_variable_in_array_with_ctx(ctx, pointer, subitem_pointer, subitem);
-                    ctx.codegen_usize_op_in_place(subitem_pointer.address, BrilligBinaryOp::Add, 1);
-                }
-            };
+            let one = self.brillig_context.make_usize_constant_instruction(1_usize.into());
 
-            self.brillig_context.codegen_loop_with_bound_and_step(
-                data_length_variable.address,
-                step_variable.address,
+            // Initializes a single subitem
+            let initializer_fn =
+                |ctx: &mut BrilligContext<_>, subitem_start_pointer: SingleAddrVariable| {
+                    ctx.mov_instruction(subitem_pointer.address, subitem_start_pointer.address);
+                    for subitem in subitem_to_repeat_variables.into_iter() {
+                        ctx.codegen_store_variable_in_pointer(subitem_pointer.address, subitem);
+                        ctx.memory_op_instruction(
+                            subitem_pointer.address,
+                            one.address,
+                            subitem_pointer.address,
+                            BrilligBinaryOp::Add,
+                        );
+                    }
+                };
+
+            // for (let subitem_start_pointer = pointer; subitem_start_pointer < pointer + data_length; subitem_start_pointer += step) { initializer_fn(iterator) }
+            self.brillig_context.codegen_for_loop(
+                Some(pointer),
+                end_pointer_variable.address,
+                Some(step_variable.address),
                 initializer_fn,
             );
 
             self.brillig_context.deallocate_single_addr(step_variable);
             self.brillig_context.deallocate_single_addr(subitem_pointer);
+            self.brillig_context.deallocate_single_addr(one);
         } else {
             let subitem = subitem_to_repeat_variables.into_iter().next().unwrap();
 
-            let initializer_fn = |ctx: &mut _, iterator_register| {
-                Self::store_variable_in_array_with_ctx(ctx, pointer, iterator_register, subitem);
+            let initializer_fn = |ctx: &mut BrilligContext<_>, item_pointer: SingleAddrVariable| {
+                ctx.codegen_store_variable_in_pointer(item_pointer.address, subitem);
             };
 
-            self.brillig_context.codegen_loop(data_length_variable.address, initializer_fn);
+            // for (let item_pointer = pointer; item_pointer < pointer + data_length; item_pointer += 1) { initializer_fn(iterator) }
+            self.brillig_context.codegen_for_loop(
+                Some(pointer),
+                end_pointer_variable.address,
+                None,
+                initializer_fn,
+            );
         }
-
-        self.brillig_context.deallocate_single_addr(data_length_variable);
+        self.brillig_context.deallocate_single_addr(end_pointer_variable);
     }
 
     fn initialize_constant_array_comptime(
@@ -1796,22 +1781,27 @@ impl<'block> BrilligBlock<'block> {
         pointer: MemoryAddress,
     ) {
         // Allocate a register for the iterator
-        let iterator_register =
-            self.brillig_context.make_usize_constant_instruction(0_usize.into());
+        let write_pointer_register = self.brillig_context.allocate_register();
+        let one = self.brillig_context.make_usize_constant_instruction(1_usize.into());
+
+        self.brillig_context.mov_instruction(write_pointer_register, pointer);
 
         for element_id in data.iter() {
             let element_variable = self.convert_ssa_value(*element_id, dfg);
             // Store the item in memory
-            self.store_variable_in_array(pointer, iterator_register, element_variable);
-            // Increment the iterator
-            self.brillig_context.codegen_usize_op_in_place(
-                iterator_register.address,
+            self.brillig_context
+                .codegen_store_variable_in_pointer(write_pointer_register, element_variable);
+            // Increment the write_pointer_register
+            self.brillig_context.memory_op_instruction(
+                write_pointer_register,
+                one.address,
+                write_pointer_register,
                 BrilligBinaryOp::Add,
-                1,
             );
         }
 
-        self.brillig_context.deallocate_single_addr(iterator_register);
+        self.brillig_context.deallocate_register(write_pointer_register);
+        self.brillig_context.deallocate_single_addr(one);
     }
 
     /// Converts an SSA `ValueId` into a `MemoryAddress`. Initializes if necessary.
@@ -1896,7 +1886,7 @@ impl<'block> BrilligBlock<'block> {
                                 let inner_array = self.allocate_nested_array(element_type, None);
                                 let idx =
                                     self.brillig_context.make_usize_constant_instruction(index.into());
-                                self.store_variable_in_array(array.pointer, idx, inner_array);
+                                self.brillig_context.codegen_store_variable_in_array(array.pointer, idx, inner_array);
                             }
                             Type::Slice(_) => unreachable!("ICE: unsupported slice type in allocate_nested_array(), expects an array or a numeric type"),
                             _ => (),

--- a/noir/noir-repo/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_slice_ops.rs
+++ b/noir/noir-repo/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_slice_ops.rs
@@ -38,7 +38,11 @@ impl<'block> BrilligBlock<'block> {
                 target_index.address,
                 BrilligBinaryOp::Add,
             );
-            self.store_variable_in_array(target_vector.pointer, target_index, *variable);
+            self.brillig_context.codegen_store_variable_in_array(
+                target_vector.pointer,
+                target_index,
+                *variable,
+            );
             self.brillig_context.deallocate_single_addr(target_index);
         }
     }
@@ -79,7 +83,11 @@ impl<'block> BrilligBlock<'block> {
         // Then we write the items to insert at the start
         for (index, variable) in variables_to_insert.iter().enumerate() {
             let target_index = self.brillig_context.make_usize_constant_instruction(index.into());
-            self.store_variable_in_array(target_vector.pointer, target_index, *variable);
+            self.brillig_context.codegen_store_variable_in_array(
+                target_vector.pointer,
+                target_index,
+                *variable,
+            );
             self.brillig_context.deallocate_single_addr(target_index);
         }
 
@@ -239,7 +247,11 @@ impl<'block> BrilligBlock<'block> {
                 target_index.address,
                 BrilligBinaryOp::Add,
             );
-            self.store_variable_in_array(target_vector.pointer, target_index, *variable);
+            self.brillig_context.codegen_store_variable_in_array(
+                target_vector.pointer,
+                target_index,
+                *variable,
+            );
             self.brillig_context.deallocate_single_addr(target_index);
         }
 

--- a/noir/noir-repo/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_memory.rs
+++ b/noir/noir-repo/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_memory.rs
@@ -112,6 +112,50 @@ impl<F: AcirField + DebugToString> BrilligContext<F> {
         self.deallocate_register(index_of_element_in_memory);
     }
 
+    pub(crate) fn codegen_store_variable_in_array(
+        &mut self,
+        array_pointer: MemoryAddress,
+        index: SingleAddrVariable,
+        value_variable: BrilligVariable,
+    ) {
+        assert!(index.bit_size == BRILLIG_MEMORY_ADDRESSING_BIT_SIZE);
+        let final_pointer_register = self.allocate_register();
+        self.memory_op_instruction(
+            array_pointer,
+            index.address,
+            final_pointer_register,
+            BrilligBinaryOp::Add,
+        );
+        self.codegen_store_variable_in_pointer(final_pointer_register, value_variable);
+        self.deallocate_register(final_pointer_register);
+    }
+
+    pub(crate) fn codegen_store_variable_in_pointer(
+        &mut self,
+        destination_pointer: MemoryAddress,
+        value_variable: BrilligVariable,
+    ) {
+        match value_variable {
+            BrilligVariable::SingleAddr(value_variable) => {
+                self.store_instruction(destination_pointer, value_variable.address);
+            }
+            BrilligVariable::BrilligArray(_) => {
+                let reference: MemoryAddress = self.allocate_register();
+                self.codegen_allocate_array_reference(reference);
+                self.codegen_store_variable(reference, value_variable);
+                self.store_instruction(destination_pointer, reference);
+                self.deallocate_register(reference);
+            }
+            BrilligVariable::BrilligVector(_) => {
+                let reference = self.allocate_register();
+                self.codegen_allocate_vector_reference(reference);
+                self.codegen_store_variable(reference, value_variable);
+                self.store_instruction(destination_pointer, reference);
+                self.deallocate_register(reference);
+            }
+        }
+    }
+
     /// Copies the values of an array pointed by source with length stored in `num_elements_register`
     /// Into the array pointed by destination
     pub(crate) fn codegen_copy_array(


### PR DESCRIPTION
Optimize array initialization to avoid repeatedly computing pointers. Instead of tracking indices and recomputing pointers at every step, track the pointers and increase them at every step.

<details>
<summary>Improvements in public function opcode count</summary>

```
Transpiling  AppSubscription::assert_block_number with size 668 => 409
Transpiling  AppSubscription::assert_not_expired with size 657 => 402
Transpiling  AppSubscription::constructor with size 1918 => 1318
Transpiling  Auth::constructor with size 979 => 709
Transpiling  Auth::get_authorized with size 437 => 300
Transpiling  Auth::get_authorized_delay with size 511 => 362
Transpiling  Auth::get_scheduled_authorized with size 442 => 285
Transpiling  Auth::set_authorized with size 2022 => 1899
Transpiling  Auth::set_authorized_delay with size 1903 => 1817
Transpiling  AuthRegistry::_set_authorized with size 877 => 525
Transpiling  AuthRegistry::consume with size 1706 => 1040
Transpiling  AuthRegistry::is_consumable with size 871 => 524
Transpiling  AuthRegistry::is_reject_all with size 583 => 358
Transpiling  AuthRegistry::set_authorized with size 620 => 375
Transpiling  AuthRegistry::set_reject_all with size 332 => 209
Transpiling  AuthWitTest::consume_public with size 1818 => 1645
Transpiling  AvmInitializerTest::constructor with size 893 => 648
Transpiling  AvmInitializerTest::read_storage_immutable with size 130 => 101
Transpiling  AvmTest::add_args_return with size 14 => 14
Transpiling  AvmTest::add_storage_map with size 656 => 408
Transpiling  AvmTest::add_u128 with size 186 => 131
Transpiling  AvmTest::assert_nullifier_exists with size 155 => 108
Transpiling  AvmTest::assert_same with size 137 => 98
Transpiling  AvmTest::assert_timestamp with size 151 => 104
Transpiling  AvmTest::assertion_failure with size 165 => 112
Transpiling  AvmTest::check_selector with size 1560 => 1468
Transpiling  AvmTest::create_different_nullifier_in_nested_call with size 288 => 248
Transpiling  AvmTest::create_same_nullifier_in_nested_call with size 286 => 246
Transpiling  AvmTest::debug_logging with size 399 => 247
Transpiling  AvmTest::elliptic_curve_add_and_double with size 81 => 81
Transpiling  AvmTest::emit_nullifier_and_check with size 313 => 190
Transpiling  AvmTest::emit_unencrypted_log with size 766 => 645
Transpiling  AvmTest::get_address with size 12 => 12
Transpiling  AvmTest::get_args_hash with size 17 => 17
Transpiling  AvmTest::get_block_number with size 12 => 12
Transpiling  AvmTest::get_chain_id with size 12 => 12
Transpiling  AvmTest::get_da_gas_left with size 12 => 12
Transpiling  AvmTest::get_fee_per_da_gas with size 12 => 12
Transpiling  AvmTest::get_fee_per_l2_gas with size 12 => 12
Transpiling  AvmTest::get_function_selector with size 12 => 12
Transpiling  AvmTest::get_l2_gas_left with size 12 => 12
Transpiling  AvmTest::get_sender with size 12 => 12
Transpiling  AvmTest::get_storage_address with size 12 => 12
Transpiling  AvmTest::get_timestamp with size 12 => 12
Transpiling  AvmTest::get_transaction_fee with size 12 => 12
Transpiling  AvmTest::get_version with size 12 => 12
Transpiling  AvmTest::keccak_f1600 with size 61 => 61
Transpiling  AvmTest::keccak_hash with size 1236 => 1221
Transpiling  AvmTest::l1_to_l2_msg_exists with size 16 => 16
Transpiling  AvmTest::modulo2 with size 15 => 15
Transpiling  AvmTest::nested_call_to_add with size 405 => 365
Transpiling  AvmTest::nested_call_to_add_with_gas with size 549 => 480
Transpiling  AvmTest::nested_static_call_to_add with size 433 => 379
Transpiling  AvmTest::nested_static_call_to_set_storage with size 313 => 259
Transpiling  AvmTest::new_note_hash with size 10 => 10
Transpiling  AvmTest::new_nullifier with size 10 => 10
Transpiling  AvmTest::note_hash_exists with size 16 => 16
Transpiling  AvmTest::nullifier_collision with size 11 => 11
Transpiling  AvmTest::nullifier_exists with size 16 => 16
Transpiling  AvmTest::pedersen_hash with size 18 => 18
Transpiling  AvmTest::pedersen_hash_with_index with size 18 => 18
Transpiling  AvmTest::poseidon2_hash with size 1315 => 1293
Transpiling  AvmTest::read_storage_list with size 59 => 56
Transpiling  AvmTest::read_storage_map with size 337 => 215
Transpiling  AvmTest::read_storage_single with size 24 => 24
Transpiling  AvmTest::send_l2_to_l1_msg with size 11 => 11
Transpiling  AvmTest::set_opcode_big_field with size 18 => 18
Transpiling  AvmTest::set_opcode_small_field with size 12 => 12
Transpiling  AvmTest::set_opcode_u32 with size 12 => 12
Transpiling  AvmTest::set_opcode_u64 with size 12 => 12
Transpiling  AvmTest::set_opcode_u8 with size 12 => 12
Transpiling  AvmTest::set_read_storage_single with size 35 => 34
Transpiling  AvmTest::set_storage_list with size 25 => 22
Transpiling  AvmTest::set_storage_map with size 350 => 224
Transpiling  AvmTest::set_storage_single with size 20 => 19
Transpiling  AvmTest::sha256_hash with size 46 => 46
Transpiling  AvmTest::test_get_contract_instance with size 405 => 341
Transpiling  AvmTest::test_get_contract_instance_raw with size 82 => 82
Transpiling  AvmTest::to_radix_le with size 182 => 163
Transpiling  AvmTest::u128_addition_overflow with size 661 => 472
Transpiling  AvmTest::u128_from_integer_overflow with size 213 => 150
Transpiling  AvmTest::variable_base_msm with size 112 => 94
Transpiling  Benchmarking::broadcast with size 342 => 219
Transpiling  Benchmarking::increment_balance with size 905 => 620
Transpiling  CardGame::on_card_played with size 2119 => 1745
Transpiling  CardGame::on_cards_claimed with size 1879 => 1482
Transpiling  CardGame::on_game_joined with size 1724 => 1382
Transpiling  CardGame::start_game with size 2165 => 1921
Transpiling  Child::pub_get_value with size 21 => 21
Transpiling  Child::pub_inc_value with size 47 => 45
Transpiling  Child::pub_inc_value_internal with size 342 => 219
Transpiling  Child::pub_set_value with size 34 => 32
Transpiling  Child::set_value_twice_with_nested_first with size 308 => 266
Transpiling  Child::set_value_twice_with_nested_last with size 308 => 266
Transpiling  Child::set_value_with_two_nested_calls with size 314 => 232
Transpiling  Claim::constructor with size 1098 => 782
Transpiling  Crowdfunding::_check_deadline with size 749 => 469
Transpiling  Crowdfunding::_publish_donation_receipts with size 2079 => 1828
Transpiling  Crowdfunding::init with size 1306 => 919
Transpiling  DelegatedOn::public_set_value with size 23 => 22
Transpiling  Delegator::public_delegate_set_value with size 387 => 292
Transpiling  DocsExample::get_shared_immutable_constrained_public with size 403 => 248
Transpiling  DocsExample::get_shared_immutable_constrained_public_indirect with size 226 => 172
Transpiling  DocsExample::get_shared_immutable_constrained_public_multiple with size 95 => 76
Transpiling  DocsExample::initialize_public_immutable with size 241 => 168
Transpiling  DocsExample::initialize_shared_immutable with size 241 => 168
Transpiling  DocsExample::spend_public_authwit with size 13 => 13
Transpiling  DocsExample::update_leader with size 285 => 179
Transpiling  EasyPrivateVoting::add_to_tally_public with size 1102 => 686
Transpiling  EasyPrivateVoting::constructor with size 918 => 671
Transpiling  EasyPrivateVoting::end_vote with size 272 => 195
Transpiling  FPC::constructor with size 1098 => 782
Transpiling  FPC::pay_refund with size 1331 => 1042
Transpiling  FPC::pay_refund_with_shielded_rebate with size 1418 => 1087
Transpiling  FPC::prepare_fee with size 927 => 759
Transpiling  GasToken::_increase_public_balance with size 1095 => 670
Transpiling  GasToken::balance_of_public with size 608 => 375
Transpiling  GasToken::check_balance with size 760 => 506
Transpiling  GasToken::claim_public with size 2382 => 1914
Transpiling  GasToken::mint_public with size 805 => 505
Transpiling  GasToken::set_portal with size 259 => 188
Transpiling  ImportTest::pub_call_public_fn with size 285 => 245
Transpiling  InclusionProofs::constructor with size 695 => 520
Transpiling  InclusionProofs::push_nullifier_public with size 116 => 87
Transpiling  InclusionProofs::test_nullifier_inclusion_from_public with size 120 => 91
Transpiling  KeyRegistry::register_npk_and_ivpk with size 11223 => 10338
Transpiling  KeyRegistry::register_ovpk_and_tpk with size 11225 => 10340
Transpiling  KeyRegistry::rotate_npk_m with size 6090 => 5529
Transpiling  Lending::_borrow with size 9086 => 6477
Transpiling  Lending::_deposit with size 822 => 537
Transpiling  Lending::_repay with size 5912 => 4143
Transpiling  Lending::_withdraw with size 8785 => 6359
Transpiling  Lending::borrow_public with size 587 => 518
Transpiling  Lending::deposit_public with size 1148 => 1039
Transpiling  Lending::get_asset with size 714 => 468
Transpiling  Lending::get_assets with size 406 => 277
Transpiling  Lending::get_position with size 3611 => 2493
Transpiling  Lending::init with size 579 => 415
Transpiling  Lending::repay_public with size 1050 => 941
Transpiling  Lending::update_accumulator with size 8347 => 6083
Transpiling  Lending::withdraw_public with size 587 => 518
Transpiling  Parent::pub_entry_point with size 188 => 147
Transpiling  Parent::pub_entry_point_twice with size 338 => 256
Transpiling  Parent::public_nested_static_call with size 1746 => 1594
Transpiling  Parent::public_static_call with size 235 => 181
Transpiling  PriceFeed::get_price with size 575 => 358
Transpiling  PriceFeed::set_price with size 344 => 219
Transpiling  PrivateFPC::constructor with size 1098 => 782
Transpiling  PrivateToken::_reduce_total_supply with size 619 => 405
Transpiling  PrivateToken::assert_minter_and_mint with size 744 => 498
Transpiling  PrivateToken::complete_refund with size 632 => 482
Transpiling  PrivateToken::constructor with size 1917 => 1381
Transpiling  PrivateToken::public_get_decimals with size 134 => 105
Transpiling  PrivateToken::public_get_name with size 131 => 102
Transpiling  PrivateToken::public_get_symbol with size 131 => 102
Transpiling  PrivateToken::set_admin with size 250 => 183
Transpiling  PrivateToken::set_minter with size 551 => 362
Transpiling  StatefulTest::get_public_value with size 594 => 363
Transpiling  StatefulTest::increment_public_value with size 441 => 289
Transpiling  StatefulTest::increment_public_value_no_init_check with size 343 => 220
Transpiling  StatefulTest::public_constructor with size 1051 => 837
Transpiling  StaticChild::pub_get_value with size 280 => 177
Transpiling  StaticChild::pub_illegal_inc_value with size 338 => 217
Transpiling  StaticChild::pub_inc_value with size 47 => 45
Transpiling  StaticChild::pub_set_value with size 34 => 32
Transpiling  StaticParent::public_call with size 188 => 147
Transpiling  StaticParent::public_get_value_from_child with size 335 => 281
Transpiling  StaticParent::public_nested_static_call with size 542 => 488
Transpiling  StaticParent::public_static_call with size 235 => 181
Transpiling  Test::assert_public_global_vars with size 678 => 460
Transpiling  Test::consume_message_from_arbitrary_sender_public with size 1130 => 962
Transpiling  Test::consume_mint_public_message with size 1575 => 1407
Transpiling  Test::create_l2_to_l1_message_arbitrary_recipient_public with size 11 => 11
Transpiling  Test::create_l2_to_l1_message_public with size 28 => 25
Transpiling  Test::dummy_public_call with size 283 => 172
Transpiling  Test::emit_nullifier_public with size 10 => 10
Transpiling  Test::emit_unencrypted with size 294 => 262
Transpiling  Test::is_time_equal with size 17 => 17
Transpiling  TestLog::emit_unencrypted_events with size 3321 => 3159
Transpiling  Token::_increase_public_balance with size 1193 => 739
Transpiling  Token::_reduce_total_supply with size 619 => 405
Transpiling  Token::admin with size 345 => 229
Transpiling  Token::assert_minter_and_mint with size 1025 => 658
Transpiling  Token::balance_of_public with size 706 => 444
Transpiling  Token::burn_public with size 3082 => 2470
Transpiling  Token::constructor with size 1917 => 1381
Transpiling  Token::is_minter with size 664 => 418
Transpiling  Token::mint_private with size 780 => 528
Transpiling  Token::mint_public with size 1504 => 958
Transpiling  Token::public_get_decimals with size 408 => 264
Transpiling  Token::public_get_name with size 389 => 253
Transpiling  Token::public_get_symbol with size 397 => 257
Transpiling  Token::set_admin with size 250 => 183
Transpiling  Token::set_minter with size 551 => 362
Transpiling  Token::shield with size 2935 => 2385
Transpiling  Token::total_supply with size 387 => 257
Transpiling  Token::transfer_public with size 3632 => 2788
Transpiling  TokenBlacklist::_increase_public_balance with size 1193 => 739
Transpiling  TokenBlacklist::_reduce_total_supply with size 619 => 405
Transpiling  TokenBlacklist::balance_of_public with size 706 => 444
Transpiling  TokenBlacklist::burn_public with size 3589 => 2815
Transpiling  TokenBlacklist::constructor with size 2908 => 2555
Transpiling  TokenBlacklist::get_roles with size 745 => 496
Transpiling  TokenBlacklist::mint_private with size 897 => 642
Transpiling  TokenBlacklist::mint_public with size 2121 => 1404
Transpiling  TokenBlacklist::shield with size 3442 => 2730
Transpiling  TokenBlacklist::total_supply with size 387 => 257
Transpiling  TokenBlacklist::transfer_public with size 4655 => 3481
Transpiling  TokenBlacklist::update_roles with size 2895 => 2525
Transpiling  TokenBridge::_assert_token_is_same with size 637 => 394
Transpiling  TokenBridge::_call_mint_on_token with size 774 => 590
Transpiling  TokenBridge::claim_public with size 2080 => 1843
Transpiling  TokenBridge::constructor with size 905 => 659
Transpiling  TokenBridge::exit_to_l1_public with size 1419 => 1151
Transpiling  TokenBridge::get_portal_address_public with size 142 => 113
Transpiling  TokenBridge::get_token with size 363 => 239
Transpiling  Uniswap::_approve_bridge_and_exit_input_asset_to_L1 with size 4510 => 4062
Transpiling  Uniswap::_assert_token_is_same with size 1155 => 703
Transpiling  Uniswap::constructor with size 893 => 648
Transpiling  Uniswap::swap_public with size 5942 => 4790
```

</details>