### PR TITLE
fix: devnet CI issues

### DIFF
--- a/.github/workflows/devnet-deploys.yml
+++ b/.github/workflows/devnet-deploys.yml
@@ -123,11 +123,17 @@ jobs:
         run: |
           docker pull aztecprotocol/aztec:${{ env.DEPLOY_TAG }}
           docker run aztecprotocol/aztec:${{ env.DEPLOY_TAG }} deploy-l1-contracts \
-            --private-key ${{ secrets.SEQ_1_PUBLISHER_PRIVATE_KEY }} \
+            --private-key ${{ secrets.CONTRACT_PUBLISHER_PRIVATE_KEY }} \
             --rpc-url https://${{ env.DEPLOY_TAG }}-mainnet-fork.aztec.network:8545/${{ secrets.FORK_API_KEY }} \
             --l1-chain-id ${{ env.L1_CHAIN_ID }} \
             --json \
             | tee  ./l1_contracts.json
+
+
+          if [ $? -ne 0 ]; then
+            echo "deploy-l1-contracts command failed"
+            exit 1
+          fi
 
           # upload contract addresses to S3
           aws s3 cp ./l1_contracts.json ${{ env.CONTRACT_S3_BUCKET }}/${{ env.DEPLOY_TAG }}/l1_contracts.json
@@ -211,6 +217,11 @@ jobs:
             --json \
             | tee  ./protocol_contracts.json
 
+          if [ $? -ne 0 ]; then
+            echo "deploy-protocol-contracts command failed"
+            exit 1
+          fi
+
           aws s3 cp ./protocol_contracts.json ${{ env.CONTRACT_S3_BUCKET }}/${{ env.DEPLOY_TAG }}/protocol_contracts.json
 
       - name: Bootstrap network
@@ -220,9 +231,14 @@ jobs:
             --rpc-url https://api.aztec.network/${{ env.DEPLOY_TAG }}/aztec-pxe/${{ secrets.FORK_API_KEY }} \
             --l1-rpc-url https://${{ env.DEPLOY_TAG }}-mainnet-fork.aztec.network:8545/${{ secrets.FORK_API_KEY }} \
             --l1-chain-id ${{ env.L1_CHAIN_ID }} \
-            --l1-private-key ${{ secrets.SEQ_1_PUBLISHER_PRIVATE_KEY }} \
+            --l1-private-key ${{ secrets.CONTRACT_PUBLISHER_PRIVATE_KEY }} \
             --json \
             | tee ./basic_contracts.json
+
+            if [ $? -ne 0 ]; then
+              echo "bootstrap-network command failed"
+              exit 1
+            fi
 
           aws s3 cp ./basic_contracts.json ${{ env.CONTRACT_S3_BUCKET }}/${{ env.DEPLOY_TAG }}/basic_contracts.json
 


### PR DESCRIPTION
- Exit 0 CI if aztec CLI commands fail
- Use different private key for publishing contracts to avoid nonce problems with publisher PK