### PR TITLE
fix: Anvil block timestamp

### DIFF
--- a/iac/mainnet-fork/scripts/run_nginx_anvil.sh
+++ b/iac/mainnet-fork/scripts/run_nginx_anvil.sh
@@ -27,6 +27,10 @@ mkdir -p /data
 echo "Waiting for ethereum host at $ETHEREUM_HOST..."
 while ! curl -s $ETHEREUM_HOST >/dev/null; do sleep 1; done
 
+# Fix anvil's fork timestamp
+./foundry/bin/cast rpc --rpc-url="$ETHEREUM_HOST" evm_setNextBlockTimestamp $(date +%s | xargs printf '0x%x') > /dev/null
+./foundry/bin/cast rpc --rpc-url="$ETHEREUM_HOST" evm_mine > /dev/null
+
 echo "Starting nginx..."
 nginx &
 wait


### PR DESCRIPTION
Anvil uses the time of the forked block as its timestamp as its baseline. Subsequent blocks have a timestamp equal to that baseline plus the time that passed since the fork was created.

To fix it, we set the next block timestamp manually to the current date and immediately trigger a block mine.
