### PR TITLE
feat: ts pedersen commit with offset

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind.cpp
@@ -5,11 +5,15 @@
 
 using namespace bb;
 
-WASM_EXPORT void pedersen_commit(fr::vec_in_buf inputs_buffer, grumpkin::g1::affine_element::out_buf output)
+WASM_EXPORT void pedersen_commit(fr::vec_in_buf inputs_buffer,
+                                 uint32_t const* ctx_index,
+                                 grumpkin::g1::affine_element::out_buf output)
 {
     std::vector<grumpkin::fq> to_commit;
     read(inputs_buffer, to_commit);
-    grumpkin::g1::affine_element pedersen_commitment = crypto::pedersen_commitment::commit_native(to_commit);
+    crypto::GeneratorContext<curve::Grumpkin> ctx;
+    ctx.offset = static_cast<size_t>(ntohl(*ctx_index));
+    grumpkin::g1::affine_element pedersen_commitment = crypto::pedersen_commitment::commit_native(to_commit, ctx);
 
     write(output, pedersen_commitment);
 }

--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_commitment/c_bind.hpp
@@ -8,5 +8,7 @@ extern "C" {
 using namespace bb;
 using affine_element = grumpkin::g1::affine_element;
 
-WASM_EXPORT void pedersen_commit(fr::vec_in_buf inputs_buffer, affine_element::out_buf output);
+WASM_EXPORT void pedersen_commit(fr::vec_in_buf inputs_buffer,
+                                 uint32_t const* ctx_index,
+                                 affine_element::out_buf output);
 }

--- a/barretenberg/exports.json
+++ b/barretenberg/exports.json
@@ -5,6 +5,10 @@
       {
         "name": "inputs_buffer",
         "type": "fr::vec_in_buf"
+      },
+      {
+        "name": "ctx_index",
+        "type": "const uint32_t *"
       }
     ],
     "outArgs": [
@@ -544,25 +548,6 @@
       {
         "name": "acir_composer_ptr",
         "type": "in_ptr"
-      }
-    ],
-    "outArgs": [],
-    "isAsync": false
-  },
-  {
-    "functionName": "acir_create_circuit",
-    "inArgs": [
-      {
-        "name": "acir_composer_ptr",
-        "type": "in_ptr"
-      },
-      {
-        "name": "constraint_system_buf",
-        "type": "const uint8_t *"
-      },
-      {
-        "name": "size_hint",
-        "type": "const uint32_t *"
       }
     ],
     "outArgs": [],

--- a/barretenberg/scripts/bindgen.sh
+++ b/barretenberg/scripts/bindgen.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Run from aztec-packages/barretenberg.
 set -eu
 
 if ! dpkg -l python3-clang-18 &> /dev/null; then
@@ -6,7 +7,7 @@ if ! dpkg -l python3-clang-18 &> /dev/null; then
   exit 1
 fi
 
-#find ./cpp/src -type f -name "c_bind*.hpp" | ./scripts/decls_json.py > exports.json
+#find ./cpp/src -type f -name "c_bind*.hpp" > ./scripts/c_bind_files.txt
 cat ./scripts/c_bind_files.txt | ./scripts/decls_json.py > exports.json
 (
   cd ./ts && \

--- a/barretenberg/ts/src/barretenberg/pedersen.test.ts
+++ b/barretenberg/ts/src/barretenberg/pedersen.test.ts
@@ -46,7 +46,7 @@ describe('pedersen sync', () => {
   });
 
   it('pedersenCommit', () => {
-    const result = api.pedersenCommit([new Fr(4n), new Fr(8n), new Fr(12n)]);
+    const result = api.pedersenCommit([new Fr(4n), new Fr(8n), new Fr(12n)], 0);
     expect(result).toMatchSnapshot();
   });
 
@@ -55,7 +55,7 @@ describe('pedersen sync', () => {
     const fields = Array.from({ length: loops * 2 }).map(() => Fr.random());
     const t = new Timer();
     for (let i = 0; i < loops; ++i) {
-      api.pedersenCommit([fields[i * 2], fields[i * 2 + 1]]);
+      api.pedersenCommit([fields[i * 2], fields[i * 2 + 1]], 0);
     }
     console.log(t.us() / loops);
   });

--- a/barretenberg/ts/src/barretenberg_api/index.ts
+++ b/barretenberg/ts/src/barretenberg_api/index.ts
@@ -15,8 +15,8 @@ import { Fr, Fq, Point, Buffer32, Buffer128, Ptr } from '../types/index.js';
 export class BarretenbergApi {
   constructor(protected wasm: BarretenbergWasmWorker) {}
 
-  async pedersenCommit(inputsBuffer: Fr[]): Promise<Point> {
-    const inArgs = [inputsBuffer].map(serializeBufferable);
+  async pedersenCommit(inputsBuffer: Fr[], ctxIndex: number): Promise<Point> {
+    const inArgs = [inputsBuffer, ctxIndex].map(serializeBufferable);
     const outTypes: OutputType[] = [Point];
     const result = await this.wasm.callWasmExport(
       'pedersen_commit',
@@ -367,18 +367,6 @@ export class BarretenbergApi {
     return;
   }
 
-  async acirCreateCircuit(acirComposerPtr: Ptr, constraintSystemBuf: Uint8Array, sizeHint: number): Promise<void> {
-    const inArgs = [acirComposerPtr, constraintSystemBuf, sizeHint].map(serializeBufferable);
-    const outTypes: OutputType[] = [];
-    const result = await this.wasm.callWasmExport(
-      'acir_create_circuit',
-      inArgs,
-      outTypes.map(t => t.SIZE_IN_BYTES),
-    );
-    const out = result.map((r, i) => outTypes[i].fromBuffer(r));
-    return;
-  }
-
   async acirInitProvingKey(acirComposerPtr: Ptr, constraintSystemBuf: Uint8Array): Promise<void> {
     const inArgs = [acirComposerPtr, constraintSystemBuf].map(serializeBufferable);
     const outTypes: OutputType[] = [];
@@ -606,8 +594,8 @@ export class BarretenbergApi {
 export class BarretenbergApiSync {
   constructor(protected wasm: BarretenbergWasm) {}
 
-  pedersenCommit(inputsBuffer: Fr[]): Point {
-    const inArgs = [inputsBuffer].map(serializeBufferable);
+  pedersenCommit(inputsBuffer: Fr[], ctxIndex: number): Point {
+    const inArgs = [inputsBuffer, ctxIndex].map(serializeBufferable);
     const outTypes: OutputType[] = [Point];
     const result = this.wasm.callWasmExport(
       'pedersen_commit',
@@ -948,18 +936,6 @@ export class BarretenbergApiSync {
     const outTypes: OutputType[] = [];
     const result = this.wasm.callWasmExport(
       'acir_delete_acir_composer',
-      inArgs,
-      outTypes.map(t => t.SIZE_IN_BYTES),
-    );
-    const out = result.map((r, i) => outTypes[i].fromBuffer(r));
-    return;
-  }
-
-  acirCreateCircuit(acirComposerPtr: Ptr, constraintSystemBuf: Uint8Array, sizeHint: number): void {
-    const inArgs = [acirComposerPtr, constraintSystemBuf, sizeHint].map(serializeBufferable);
-    const outTypes: OutputType[] = [];
-    const result = this.wasm.callWasmExport(
-      'acir_create_circuit',
       inArgs,
       outTypes.map(t => t.SIZE_IN_BYTES),
     );

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -155,7 +155,7 @@ contract AvmTest {
 
     #[aztec(public)]
     fn pedersen_commit(x: Field, y: Field) -> EmbeddedCurvePoint {
-        let commitment = dep::std::hash::pedersen_commitment([x, y]);
+        let commitment = dep::std::hash::pedersen_commitment_with_separator([x, y], 20);
         commitment
     }
 

--- a/yarn-project/foundation/src/crypto/pedersen/pedersen.wasm.ts
+++ b/yarn-project/foundation/src/crypto/pedersen/pedersen.wasm.ts
@@ -7,15 +7,18 @@ import { type Fieldable, serializeToFields } from '../../serialize/serialize.js'
  * Create a pedersen commitment (point) from an array of input fields.
  * Left pads any inputs less than 32 bytes.
  */
-export function pedersenCommit(input: Buffer[]) {
-  if (!input.every(i => i.length <= 32)) {
-    throw new Error('All Pedersen Commit input buffers must be <= 32 bytes.');
-  }
-  input = input.map(i => (i.length < 32 ? Buffer.concat([Buffer.alloc(32 - i.length, 0), i]) : i));
-  const point = BarretenbergSync.getSingleton().pedersenCommit(input.map(i => new FrBarretenberg(i)));
-  // toBuffer returns Uint8Arrays (browser/worker-boundary friendly).
-  // TODO: rename toTypedArray()?
-  return [Buffer.from(point.x.toBuffer()), Buffer.from(point.y.toBuffer())];
+export function pedersenCommit(input: Buffer[], offset = 0) {
+    if (!input.every(i => i.length <= 32)) {
+        throw new Error('All Pedersen Commit input buffers must be <= 32 bytes.');
+    }
+    input = input.map(i => (i.length < 32 ? Buffer.concat([Buffer.alloc(32 - i.length, 0), i]) : i));
+    const point = BarretenbergSync.getSingleton().pedersenCommit(
+        input.map(i => new FrBarretenberg(i)),
+        offset,
+    );
+    // toBuffer returns Uint8Arrays (browser/worker-boundary friendly).
+    // TODO: rename toTypedArray()?
+    return [Buffer.from(point.x.toBuffer()), Buffer.from(point.y.toBuffer())];
 }
 
 /**
@@ -25,22 +28,22 @@ export function pedersenCommit(input: Buffer[]) {
  * @returns The pedersen hash.
  */
 export function pedersenHash(input: Fieldable[], index = 0): Fr {
-  const inputFields = serializeToFields(input);
-  return Fr.fromBuffer(
-    Buffer.from(
-      BarretenbergSync.getSingleton()
-        .pedersenHash(
-          inputFields.map(i => new FrBarretenberg(i.toBuffer())), // TODO(#4189): remove this stupid conversion
-          index,
-        )
-        .toBuffer(),
-    ),
-  );
+    const inputFields = serializeToFields(input);
+    return Fr.fromBuffer(
+        Buffer.from(
+            BarretenbergSync.getSingleton()
+                .pedersenHash(
+                    inputFields.map(i => new FrBarretenberg(i.toBuffer())), // TODO(#4189): remove this stupid conversion
+                    index,
+                )
+                .toBuffer(),
+        ),
+    );
 }
 
 /**
  * Create a pedersen hash from an arbitrary length buffer.
  */
 export function pedersenHashBuffer(input: Buffer, index = 0) {
-  return Buffer.from(BarretenbergSync.getSingleton().pedersenHashBuffer(input, index).toBuffer());
+    return Buffer.from(BarretenbergSync.getSingleton().pedersenHashBuffer(input, index).toBuffer());
 }

--- a/yarn-project/foundation/src/crypto/pedersen/pedersen.wasm.ts
+++ b/yarn-project/foundation/src/crypto/pedersen/pedersen.wasm.ts
@@ -8,17 +8,17 @@ import { type Fieldable, serializeToFields } from '../../serialize/serialize.js'
  * Left pads any inputs less than 32 bytes.
  */
 export function pedersenCommit(input: Buffer[], offset = 0) {
-    if (!input.every(i => i.length <= 32)) {
-        throw new Error('All Pedersen Commit input buffers must be <= 32 bytes.');
-    }
-    input = input.map(i => (i.length < 32 ? Buffer.concat([Buffer.alloc(32 - i.length, 0), i]) : i));
-    const point = BarretenbergSync.getSingleton().pedersenCommit(
-        input.map(i => new FrBarretenberg(i)),
-        offset,
-    );
-    // toBuffer returns Uint8Arrays (browser/worker-boundary friendly).
-    // TODO: rename toTypedArray()?
-    return [Buffer.from(point.x.toBuffer()), Buffer.from(point.y.toBuffer())];
+  if (!input.every(i => i.length <= 32)) {
+    throw new Error('All Pedersen Commit input buffers must be <= 32 bytes.');
+  }
+  input = input.map(i => (i.length < 32 ? Buffer.concat([Buffer.alloc(32 - i.length, 0), i]) : i));
+  const point = BarretenbergSync.getSingleton().pedersenCommit(
+    input.map(i => new FrBarretenberg(i)),
+    offset,
+  );
+  // toBuffer returns Uint8Arrays (browser/worker-boundary friendly).
+  // TODO: rename toTypedArray()?
+  return [Buffer.from(point.x.toBuffer()), Buffer.from(point.y.toBuffer())];
 }
 
 /**
@@ -28,22 +28,22 @@ export function pedersenCommit(input: Buffer[], offset = 0) {
  * @returns The pedersen hash.
  */
 export function pedersenHash(input: Fieldable[], index = 0): Fr {
-    const inputFields = serializeToFields(input);
-    return Fr.fromBuffer(
-        Buffer.from(
-            BarretenbergSync.getSingleton()
-                .pedersenHash(
-                    inputFields.map(i => new FrBarretenberg(i.toBuffer())), // TODO(#4189): remove this stupid conversion
-                    index,
-                )
-                .toBuffer(),
-        ),
-    );
+  const inputFields = serializeToFields(input);
+  return Fr.fromBuffer(
+    Buffer.from(
+      BarretenbergSync.getSingleton()
+        .pedersenHash(
+          inputFields.map(i => new FrBarretenberg(i.toBuffer())), // TODO(#4189): remove this stupid conversion
+          index,
+        )
+        .toBuffer(),
+    ),
+  );
 }
 
 /**
  * Create a pedersen hash from an arbitrary length buffer.
  */
 export function pedersenHashBuffer(input: Buffer, index = 0) {
-    return Buffer.from(BarretenbergSync.getSingleton().pedersenHashBuffer(input, index).toBuffer());
+  return Buffer.from(BarretenbergSync.getSingleton().pedersenHashBuffer(input, index).toBuffer());
 }

--- a/yarn-project/simulator/src/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.test.ts
@@ -149,7 +149,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
     expect(results.reverted).toBe(false);
     // This doesnt include infinites
-    const expectedResult = pedersenCommit([Buffer.from([100]), Buffer.from([1])]).map(f => new Fr(f));
+    const expectedResult = pedersenCommit([Buffer.from([100]), Buffer.from([1])], 20).map(f => new Fr(f));
     // TODO: Come back to the handling of infinities when we confirm how they're handled in bb
     const isInf = expectedResult[0] === new Fr(0) && expectedResult[1] === new Fr(0);
     expectedResult.push(new Fr(isInf));

--- a/yarn-project/simulator/src/avm/opcodes/commitment.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/commitment.test.ts
@@ -7,87 +7,114 @@ import { Addressing, AddressingMode } from './addressing_mode.js';
 import { PedersenCommitment } from './commitment.js';
 
 describe('Commitment Opcode', () => {
-  let context: AvmContext;
+    let context: AvmContext;
 
-  beforeEach(async () => {
-    context = initContext();
-  });
+    beforeEach(async () => {
+        context = initContext();
+    });
 
-  describe('Pedersen Commitment', () => {
-    it('Should (de)serialize correctly', () => {
-      const buf = Buffer.from([
-        PedersenCommitment.opcode, // opcode
-        1, // indirect
-        ...Buffer.from('23456789', 'hex'), // inputOffset
-        ...Buffer.from('3456789a', 'hex'), // inputSizeOffset
-        ...Buffer.from('12345678', 'hex'), // outputOffset
-        ...Buffer.from('00000000', 'hex'), // genIndexOffset
-      ]);
-      const inst = new PedersenCommitment(
+    describe('Pedersen Commitment', () => {
+        it('Should (de)serialize correctly', () => {
+            const buf = Buffer.from([
+                PedersenCommitment.opcode, // opcode
+                1, // indirect
+                ...Buffer.from('23456789', 'hex'), // inputOffset
+                ...Buffer.from('3456789a', 'hex'), // inputSizeOffset
+                ...Buffer.from('12345678', 'hex'), // outputOffset
+                ...Buffer.from('00000000', 'hex'), // genIndexOffset
+            ]);
+            const inst = new PedersenCommitment(
         /*indirect=*/ 1,
         /*inputOffset=*/ 0x23456789,
         /*inputSizeOffset=*/ 0x3456789a,
         /*outputOffset=*/ 0x12345678,
         /*genIndexOffset=*/ 0,
-      );
+            );
 
-      expect(PedersenCommitment.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
-    });
+            expect(PedersenCommitment.deserialize(buf)).toEqual(inst);
+            expect(inst.serialize()).toEqual(buf);
+        });
 
-    it('Should commit correctly - direct', async () => {
-      const args = randomMemoryFields(10);
-      const inputOffset = 0;
-      const inputSizeOffset = 20;
-      const outputOffset = 50;
-      const indirect = 0;
-      const generatorIndexOffset = 10;
+        it('Should commit correctly - direct', async () => {
+            const args = randomMemoryFields(10);
+            const inputOffset = 0;
+            const inputSizeOffset = 20;
+            const outputOffset = 50;
+            const indirect = 0;
+            const generatorIndexOffset = 10;
 
-      context.machineState.memory.setSlice(inputOffset, args);
-      context.machineState.memory.set(inputSizeOffset, new Uint32(args.length));
-      context.machineState.memory.set(generatorIndexOffset, new Uint32(0));
+            context.machineState.memory.setSlice(inputOffset, args);
+            context.machineState.memory.set(inputSizeOffset, new Uint32(args.length));
+            context.machineState.memory.set(generatorIndexOffset, new Uint32(0));
 
-      const expectedCommitment = pedersenCommit(args.map(f => f.toBuffer())).map(f => new Field(f));
-      await new PedersenCommitment(indirect, inputOffset, outputOffset, inputSizeOffset, generatorIndexOffset).execute(
-        context,
-      );
+            const expectedCommitment = pedersenCommit(args.map(f => f.toBuffer())).map(f => new Field(f));
+            await new PedersenCommitment(indirect, inputOffset, outputOffset, inputSizeOffset, generatorIndexOffset).execute(
+                context,
+            );
 
-      const result = context.machineState.memory.getSlice(outputOffset, 2);
-      expect(result).toEqual(expectedCommitment);
-      // Check Inf
-      expect(0).toEqual(context.machineState.memory.get(outputOffset + 2).toNumber());
-    });
+            const result = context.machineState.memory.getSlice(outputOffset, 2);
+            expect(result).toEqual(expectedCommitment);
+            // Check Inf
+            expect(0).toEqual(context.machineState.memory.get(outputOffset + 2).toNumber());
+        });
 
-    it('Should commit correctly - indirect', async () => {
-      const args = randomMemoryFields(10);
-      const indirect = new Addressing([
+        it('Should commit correctly with a different gen - direct', async () => {
+            const args = randomMemoryFields(10);
+            const inputOffset = 0;
+            const inputSizeOffset = 20;
+            const outputOffset = 50;
+            const indirect = 0;
+            const generatorIndex = 40;
+            const generatorIndexOffset = 100;
+
+            context.machineState.memory.setSlice(inputOffset, args);
+            context.machineState.memory.set(inputSizeOffset, new Uint32(args.length));
+            context.machineState.memory.set(generatorIndexOffset, new Uint32(generatorIndex));
+
+            const expectedCommitment = pedersenCommit(
+                args.map(f => f.toBuffer()),
+                generatorIndex,
+            ).map(f => new Field(f));
+            await new PedersenCommitment(indirect, inputOffset, outputOffset, inputSizeOffset, generatorIndexOffset).execute(
+                context,
+            );
+
+            const result = context.machineState.memory.getSlice(outputOffset, 2);
+            expect(result).toEqual(expectedCommitment);
+            // Check Inf
+            expect(0).toEqual(context.machineState.memory.get(outputOffset + 2).toNumber());
+        });
+
+        it('Should commit correctly - indirect', async () => {
+            const args = randomMemoryFields(10);
+            const indirect = new Addressing([
         /*inputOffset=*/ AddressingMode.INDIRECT,
         /*outputOffset*/ AddressingMode.INDIRECT,
         /*inputSizeOffset=*/ AddressingMode.DIRECT,
         /*generatorIndexOffset=*/ AddressingMode.DIRECT,
-      ]).toWire();
-      const inputOffset = 0;
-      const inputSizeOffset = 20;
-      const outputOffset = 50;
-      const realOutputOffset = 100;
-      const realInputOffset = 200;
-      const generatorIndexOffset = 51;
+            ]).toWire();
+            const inputOffset = 0;
+            const inputSizeOffset = 20;
+            const outputOffset = 50;
+            const realOutputOffset = 100;
+            const realInputOffset = 200;
+            const generatorIndexOffset = 51;
 
-      context.machineState.memory.set(outputOffset, new Uint32(realOutputOffset));
-      context.machineState.memory.set(inputOffset, new Uint32(realInputOffset));
-      context.machineState.memory.setSlice(realInputOffset, args);
-      context.machineState.memory.set(inputSizeOffset, new Uint32(args.length));
-      context.machineState.memory.set(generatorIndexOffset, new Uint32(0));
+            context.machineState.memory.set(outputOffset, new Uint32(realOutputOffset));
+            context.machineState.memory.set(inputOffset, new Uint32(realInputOffset));
+            context.machineState.memory.setSlice(realInputOffset, args);
+            context.machineState.memory.set(inputSizeOffset, new Uint32(args.length));
+            context.machineState.memory.set(generatorIndexOffset, new Uint32(0));
 
-      const expectedCommitment = pedersenCommit(args.map(f => f.toBuffer())).map(f => new Field(f));
-      await new PedersenCommitment(indirect, inputOffset, outputOffset, inputSizeOffset, generatorIndexOffset).execute(
-        context,
-      );
+            const expectedCommitment = pedersenCommit(args.map(f => f.toBuffer())).map(f => new Field(f));
+            await new PedersenCommitment(indirect, inputOffset, outputOffset, inputSizeOffset, generatorIndexOffset).execute(
+                context,
+            );
 
-      const result = context.machineState.memory.getSlice(realOutputOffset, 2);
-      expect(result).toEqual(expectedCommitment);
-      // Check Inf
-      expect(0).toEqual(context.machineState.memory.get(realOutputOffset + 2).toNumber());
+            const result = context.machineState.memory.getSlice(realOutputOffset, 2);
+            expect(result).toEqual(expectedCommitment);
+            // Check Inf
+            expect(0).toEqual(context.machineState.memory.get(realOutputOffset + 2).toNumber());
+        });
     });
-  });
 });

--- a/yarn-project/simulator/src/avm/opcodes/commitment.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/commitment.test.ts
@@ -7,114 +7,114 @@ import { Addressing, AddressingMode } from './addressing_mode.js';
 import { PedersenCommitment } from './commitment.js';
 
 describe('Commitment Opcode', () => {
-    let context: AvmContext;
+  let context: AvmContext;
 
-    beforeEach(async () => {
-        context = initContext();
-    });
+  beforeEach(async () => {
+    context = initContext();
+  });
 
-    describe('Pedersen Commitment', () => {
-        it('Should (de)serialize correctly', () => {
-            const buf = Buffer.from([
-                PedersenCommitment.opcode, // opcode
-                1, // indirect
-                ...Buffer.from('23456789', 'hex'), // inputOffset
-                ...Buffer.from('3456789a', 'hex'), // inputSizeOffset
-                ...Buffer.from('12345678', 'hex'), // outputOffset
-                ...Buffer.from('00000000', 'hex'), // genIndexOffset
-            ]);
-            const inst = new PedersenCommitment(
+  describe('Pedersen Commitment', () => {
+    it('Should (de)serialize correctly', () => {
+      const buf = Buffer.from([
+        PedersenCommitment.opcode, // opcode
+        1, // indirect
+        ...Buffer.from('23456789', 'hex'), // inputOffset
+        ...Buffer.from('3456789a', 'hex'), // inputSizeOffset
+        ...Buffer.from('12345678', 'hex'), // outputOffset
+        ...Buffer.from('00000000', 'hex'), // genIndexOffset
+      ]);
+      const inst = new PedersenCommitment(
         /*indirect=*/ 1,
         /*inputOffset=*/ 0x23456789,
         /*inputSizeOffset=*/ 0x3456789a,
         /*outputOffset=*/ 0x12345678,
         /*genIndexOffset=*/ 0,
-            );
+      );
 
-            expect(PedersenCommitment.deserialize(buf)).toEqual(inst);
-            expect(inst.serialize()).toEqual(buf);
-        });
+      expect(PedersenCommitment.deserialize(buf)).toEqual(inst);
+      expect(inst.serialize()).toEqual(buf);
+    });
 
-        it('Should commit correctly - direct', async () => {
-            const args = randomMemoryFields(10);
-            const inputOffset = 0;
-            const inputSizeOffset = 20;
-            const outputOffset = 50;
-            const indirect = 0;
-            const generatorIndexOffset = 10;
+    it('Should commit correctly - direct', async () => {
+      const args = randomMemoryFields(10);
+      const inputOffset = 0;
+      const inputSizeOffset = 20;
+      const outputOffset = 50;
+      const indirect = 0;
+      const generatorIndexOffset = 10;
 
-            context.machineState.memory.setSlice(inputOffset, args);
-            context.machineState.memory.set(inputSizeOffset, new Uint32(args.length));
-            context.machineState.memory.set(generatorIndexOffset, new Uint32(0));
+      context.machineState.memory.setSlice(inputOffset, args);
+      context.machineState.memory.set(inputSizeOffset, new Uint32(args.length));
+      context.machineState.memory.set(generatorIndexOffset, new Uint32(0));
 
-            const expectedCommitment = pedersenCommit(args.map(f => f.toBuffer())).map(f => new Field(f));
-            await new PedersenCommitment(indirect, inputOffset, outputOffset, inputSizeOffset, generatorIndexOffset).execute(
-                context,
-            );
+      const expectedCommitment = pedersenCommit(args.map(f => f.toBuffer())).map(f => new Field(f));
+      await new PedersenCommitment(indirect, inputOffset, outputOffset, inputSizeOffset, generatorIndexOffset).execute(
+        context,
+      );
 
-            const result = context.machineState.memory.getSlice(outputOffset, 2);
-            expect(result).toEqual(expectedCommitment);
-            // Check Inf
-            expect(0).toEqual(context.machineState.memory.get(outputOffset + 2).toNumber());
-        });
+      const result = context.machineState.memory.getSlice(outputOffset, 2);
+      expect(result).toEqual(expectedCommitment);
+      // Check Inf
+      expect(0).toEqual(context.machineState.memory.get(outputOffset + 2).toNumber());
+    });
 
-        it('Should commit correctly with a different gen - direct', async () => {
-            const args = randomMemoryFields(10);
-            const inputOffset = 0;
-            const inputSizeOffset = 20;
-            const outputOffset = 50;
-            const indirect = 0;
-            const generatorIndex = 40;
-            const generatorIndexOffset = 100;
+    it('Should commit correctly with a different gen - direct', async () => {
+      const args = randomMemoryFields(10);
+      const inputOffset = 0;
+      const inputSizeOffset = 20;
+      const outputOffset = 50;
+      const indirect = 0;
+      const generatorIndex = 40;
+      const generatorIndexOffset = 100;
 
-            context.machineState.memory.setSlice(inputOffset, args);
-            context.machineState.memory.set(inputSizeOffset, new Uint32(args.length));
-            context.machineState.memory.set(generatorIndexOffset, new Uint32(generatorIndex));
+      context.machineState.memory.setSlice(inputOffset, args);
+      context.machineState.memory.set(inputSizeOffset, new Uint32(args.length));
+      context.machineState.memory.set(generatorIndexOffset, new Uint32(generatorIndex));
 
-            const expectedCommitment = pedersenCommit(
-                args.map(f => f.toBuffer()),
-                generatorIndex,
-            ).map(f => new Field(f));
-            await new PedersenCommitment(indirect, inputOffset, outputOffset, inputSizeOffset, generatorIndexOffset).execute(
-                context,
-            );
+      const expectedCommitment = pedersenCommit(
+        args.map(f => f.toBuffer()),
+        generatorIndex,
+      ).map(f => new Field(f));
+      await new PedersenCommitment(indirect, inputOffset, outputOffset, inputSizeOffset, generatorIndexOffset).execute(
+        context,
+      );
 
-            const result = context.machineState.memory.getSlice(outputOffset, 2);
-            expect(result).toEqual(expectedCommitment);
-            // Check Inf
-            expect(0).toEqual(context.machineState.memory.get(outputOffset + 2).toNumber());
-        });
+      const result = context.machineState.memory.getSlice(outputOffset, 2);
+      expect(result).toEqual(expectedCommitment);
+      // Check Inf
+      expect(0).toEqual(context.machineState.memory.get(outputOffset + 2).toNumber());
+    });
 
-        it('Should commit correctly - indirect', async () => {
-            const args = randomMemoryFields(10);
-            const indirect = new Addressing([
+    it('Should commit correctly - indirect', async () => {
+      const args = randomMemoryFields(10);
+      const indirect = new Addressing([
         /*inputOffset=*/ AddressingMode.INDIRECT,
         /*outputOffset*/ AddressingMode.INDIRECT,
         /*inputSizeOffset=*/ AddressingMode.DIRECT,
         /*generatorIndexOffset=*/ AddressingMode.DIRECT,
-            ]).toWire();
-            const inputOffset = 0;
-            const inputSizeOffset = 20;
-            const outputOffset = 50;
-            const realOutputOffset = 100;
-            const realInputOffset = 200;
-            const generatorIndexOffset = 51;
+      ]).toWire();
+      const inputOffset = 0;
+      const inputSizeOffset = 20;
+      const outputOffset = 50;
+      const realOutputOffset = 100;
+      const realInputOffset = 200;
+      const generatorIndexOffset = 51;
 
-            context.machineState.memory.set(outputOffset, new Uint32(realOutputOffset));
-            context.machineState.memory.set(inputOffset, new Uint32(realInputOffset));
-            context.machineState.memory.setSlice(realInputOffset, args);
-            context.machineState.memory.set(inputSizeOffset, new Uint32(args.length));
-            context.machineState.memory.set(generatorIndexOffset, new Uint32(0));
+      context.machineState.memory.set(outputOffset, new Uint32(realOutputOffset));
+      context.machineState.memory.set(inputOffset, new Uint32(realInputOffset));
+      context.machineState.memory.setSlice(realInputOffset, args);
+      context.machineState.memory.set(inputSizeOffset, new Uint32(args.length));
+      context.machineState.memory.set(generatorIndexOffset, new Uint32(0));
 
-            const expectedCommitment = pedersenCommit(args.map(f => f.toBuffer())).map(f => new Field(f));
-            await new PedersenCommitment(indirect, inputOffset, outputOffset, inputSizeOffset, generatorIndexOffset).execute(
-                context,
-            );
+      const expectedCommitment = pedersenCommit(args.map(f => f.toBuffer())).map(f => new Field(f));
+      await new PedersenCommitment(indirect, inputOffset, outputOffset, inputSizeOffset, generatorIndexOffset).execute(
+        context,
+      );
 
-            const result = context.machineState.memory.getSlice(realOutputOffset, 2);
-            expect(result).toEqual(expectedCommitment);
-            // Check Inf
-            expect(0).toEqual(context.machineState.memory.get(realOutputOffset + 2).toNumber());
-        });
+      const result = context.machineState.memory.getSlice(realOutputOffset, 2);
+      expect(result).toEqual(expectedCommitment);
+      // Check Inf
+      expect(0).toEqual(context.machineState.memory.get(realOutputOffset + 2).toNumber());
     });
+  });
 });

--- a/yarn-project/simulator/src/avm/opcodes/commitment.ts
+++ b/yarn-project/simulator/src/avm/opcodes/commitment.ts
@@ -43,15 +43,15 @@ export class PedersenCommitment extends Instruction {
     const inputs = memory.getSlice(inputOffset, inputSize);
     memory.checkTagsRange(TypeTag.FIELD, inputOffset, inputSize);
 
-    // Generator index not used for now since we dont utilise it in the pedersenCommit function
+    const generatorIndex = memory.get(genIndexOffset).toNumber();
     memory.checkTag(TypeTag.UINT32, genIndexOffset);
 
-    const memoryOperations = { reads: inputSize + 1, writes: 3, indirect: this.indirect };
+    const memoryOperations = { reads: inputSize + 2, writes: 3, indirect: this.indirect };
     context.machineState.consumeGas(this.gasCost(memoryOperations));
 
     const inputBuffer: Buffer[] = inputs.map(input => input.toBuffer());
     // TODO: Add the generate index to the pedersenCommit function
-    const commitment = pedersenCommit(inputBuffer).map(f => new Field(f));
+    const commitment = pedersenCommit(inputBuffer, generatorIndex).map(f => new Field(f));
     // The function doesnt include a flag if the output point is infinity, come back to this
     // for now we just check if theyre zero - until we know how bb encodes them
     const isInfinity = commitment[0].equals(new Field(0)) && commitment[1].equals(new Field(0));


### PR DESCRIPTION
Update the pedersen commit bindgen so it accepts a secondary parameter (the generator offset).

Updates the avm PedersenCommit opcode to utilise this secondary parameter