### PR TITLE
feat: Adding support for siloing notes in pxe database

### DIFF
--- a/yarn-project/circuit-types/src/interfaces/pxe.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.ts
@@ -250,8 +250,9 @@ export interface PXE {
    * Adds a note to the database.
    * @throws If the note hash of the note doesn't exist in the tree.
    * @param note - The note to add.
+   * @param scope - The scope to add the note under. Currently optional.
    */
-  addNote(note: ExtendedNote): Promise<void>;
+  addNote(note: ExtendedNote, scope?: AztecAddress): Promise<void>;
 
   /**
    * Adds a nullified note to the database.

--- a/yarn-project/circuit-types/src/notes/incoming_notes_filter.ts
+++ b/yarn-project/circuit-types/src/notes/incoming_notes_filter.ts
@@ -20,4 +20,6 @@ export type IncomingNotesFilter = {
   status?: NoteStatus;
   /** The siloed nullifier for the note. */
   siloedNullifier?: Fr;
+  /** The scopes in which to get incoming notes from. This defaults to all scopes. */
+  scopes?: AztecAddress[];
 };

--- a/yarn-project/pxe/src/database/pxe_database.ts
+++ b/yarn-project/pxe/src/database/pxe_database.ts
@@ -62,8 +62,10 @@ export interface PxeDatabase extends ContractArtifactDatabase, ContractInstanceD
   /**
    * Adds a note to DB.
    * @param note - The note to add.
+   * @param scope - The scope to add the note under. Currently optional.
+   * @remark - Will create a database for the scope if it does not already exist.
    */
-  addNote(note: IncomingNoteDao): Promise<void>;
+  addNote(note: IncomingNoteDao, scope?: AztecAddress): Promise<void>;
 
   /**
    * Adds a nullified note to DB.
@@ -78,8 +80,10 @@ export interface PxeDatabase extends ContractArtifactDatabase, ContractInstanceD
    *
    * @param incomingNotes - An array of notes which were decrypted as incoming.
    * @param outgoingNotes - An array of notes which were decrypted as outgoing.
+   * @param scope - The scope to add the notes under. Currently optional.
+   * @remark - Will create a database for the scope if it does not already exist.
    */
-  addNotes(incomingNotes: IncomingNoteDao[], outgoingNotes: OutgoingNoteDao[]): Promise<void>;
+  addNotes(incomingNotes: IncomingNoteDao[], outgoingNotes: OutgoingNoteDao[], scope?: AztecAddress): Promise<void>;
 
   /**
    * Add notes to the database that are intended for us, but we don't yet have the contract.

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -338,7 +338,7 @@ export class PXEService implements PXE {
     return Promise.all(extendedNotes);
   }
 
-  public async addNote(note: ExtendedNote) {
+  public async addNote(note: ExtendedNote, scope?: AztecAddress) {
     const owner = await this.db.getCompleteAddress(note.owner);
     if (!owner) {
       throw new Error(`Unknown account: ${note.owner.toString()}`);
@@ -384,6 +384,7 @@ export class PXEService implements PXE {
           index,
           owner.publicKeys.masterIncomingViewingPublicKey,
         ),
+        scope,
       );
     }
   }

--- a/yarn-project/tsconfig.json
+++ b/yarn-project/tsconfig.json
@@ -51,7 +51,7 @@
     { "path": "scripts/tsconfig.json" },
     { "path": "entrypoints/tsconfig.json" },
     { "path": "cli/tsconfig.json" },
-    { "path": "cli-wallet/tsconfig.json"}
+    { "path": "cli-wallet/tsconfig.json" }
   ],
   "files": ["./@types/jest/index.d.ts"],
   "exclude": ["node_modules", "**/node_modules", "**/.*/"]


### PR DESCRIPTION
The goal of this stack is to start the implementation to be able to control what notes from which accounts returned in an any arbitrary oracle call.

This PR starts the implementation by giving the option to silo notes in the PXE database.
