### PR TITLE
chore(ci): report memory usage in bb-native-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
         working-directory: ./barretenberg/cpp/
         timeout-minutes: 40
         # limit our parallelism to half our cores
-        run: earthly-ci --no-output +test --hardware_concurrency=64
+        run: earthly-ci --exec-stats --no-output +test --hardware_concurrency=64
 
   bb-js-test:
     needs: [build-images, changes]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
   bb-native-tests:
     needs: [build-images, changes]
     runs-on: ${{ github.event.pull_request.user.login || github.actor }}-x86
-    if: ${{ needs.changes.outputs.barretenberg-cpp == 'true' }}
+    if: ${{ 'true' == 'true' }}
     steps:
       - uses: actions/checkout@v4
         with: { ref: "${{ env.GIT_COMMIT }}" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
   bb-native-tests:
     needs: [build-images, changes]
     runs-on: ${{ github.event.pull_request.user.login || github.actor }}-x86
-    if: ${{ 'true' == 'true' }}
+    if: ${{ needs.changes.outputs.barretenberg-cpp == 'true' }}
     steps:
       - uses: actions/checkout@v4
         with: { ref: "${{ env.GIT_COMMIT }}" }


### PR DESCRIPTION
It was hard to see why Mara's PR took down memory, should make it more clear.