### PR TITLE
fix(avm): correctly build spike vm

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.cpp
@@ -3,7 +3,8 @@
 
 namespace bb {
 
-AvmFlavor::AllConstRefValues::AllConstRefValues(const RefArray<FF const, AvmFlavor::NUM_ALL_ENTITIES>& il)
+AvmFlavor::AllConstRefValues::AllConstRefValues(
+    const RefArray<AvmFlavor::AllConstRefValues::BaseDataType, AvmFlavor::NUM_ALL_ENTITIES>& il)
     : main_clk(il[0])
     , main_sel_first(il[1])
     , kernel_kernel_inputs(il[2])

--- a/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.hpp
@@ -252,9 +252,11 @@ class AvmFlavor {
     };
 
     template <typename DataType, typename PrecomputedAndWitnessEntitiesSuperset>
-    static auto get_to_be_shifted(PrecomputedAndWitnessEntitiesSuperset& entities)
+    static auto get_to_be_shifted([[maybe_unused]] PrecomputedAndWitnessEntitiesSuperset& entities)
     {
-        return RefArray{ TO_BE_SHIFTED(entities) };
+        return RefArray<DataType, std::tuple_size<decltype(std::make_tuple(TO_BE_SHIFTED(entities)))>::value>{
+            TO_BE_SHIFTED(entities)
+        };
     }
 
     template <typename DataType>
@@ -302,11 +304,12 @@ class AvmFlavor {
 
     class AllConstRefValues {
       public:
-        using DataType = const FF&;
+        using BaseDataType = const FF;
+        using DataType = BaseDataType&;
 
         DEFINE_FLAVOR_MEMBERS(DataType, ALL_ENTITIES)
 
-        AllConstRefValues(const RefArray<FF const, NUM_ALL_ENTITIES>& il);
+        AllConstRefValues(const RefArray<BaseDataType, NUM_ALL_ENTITIES>& il);
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/vm/avm/generated/verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/generated/verifier.cpp
@@ -48,7 +48,8 @@ using FF = AvmFlavor::FF;
  * @brief This function verifies an Avm Honk proof for given program settings.
  *
  */
-bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::vector<FF>>& public_inputs)
+bool AvmVerifier::verify_proof(const HonkProof& proof,
+                               [[maybe_unused]] const std::vector<std::vector<FF>>& public_inputs)
 {
     using Flavor = AvmFlavor;
     using FF = Flavor::FF;

--- a/bb-pilcom/bb-pil-backend/templates/flavor.cpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/flavor.cpp.hbs
@@ -3,7 +3,7 @@
 
 namespace bb {
 
-{{name}}Flavor::AllConstRefValues::AllConstRefValues(const RefArray<FF const, AvmFlavor::NUM_ALL_ENTITIES>& il) :
+{{name}}Flavor::AllConstRefValues::AllConstRefValues(const RefArray<{{name}}Flavor::AllConstRefValues::BaseDataType, {{name}}Flavor::NUM_ALL_ENTITIES>& il) :
     {{#each (join fixed witness_without_inverses lookups shifted) as |item|}}
     {{item}}(il[{{@index}}]){{#unless @last}},{{/unless}}
     {{/each}}

--- a/bb-pilcom/bb-pil-backend/templates/flavor.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/flavor.hpp.hbs
@@ -35,7 +35,7 @@ template <typename... input_t> using tuple_cat_t = decltype(std::tuple_cat(std::
 #define DERIVED_WITNESS_ENTITIES {{#each lookups as |item|}}{{#if @index}}, {{/if}}{{item}}{{/each}}
 #define SHIFTED_ENTITIES {{#each shifted as |item|}}{{#if @index}}, {{/if}}{{item}}{{/each}}
 #define TO_BE_SHIFTED(e) {{#each to_be_shifted as |item|}}{{#if @index}}, {{/if}}e.{{item}}{{/each}}
-#define ALL_ENTITIES PRECOMPUTED_ENTITIES, WIRE_ENTITIES, DERIVED_WITNESS_ENTITIES, SHIFTED_ENTITIES
+#define ALL_ENTITIES {{#if (len fixed)}}PRECOMPUTED_ENTITIES{{/if}}{{#if (len witness_without_inverses)}}, WIRE_ENTITIES{{/if}}{{#if (len lookups)}}, DERIVED_WITNESS_ENTITIES{{/if}}{{#if (len shifted)}}, SHIFTED_ENTITIES{{/if}}
 // clang-format on
 
 namespace bb {
@@ -123,8 +123,8 @@ class {{name}}Flavor {
       };
 
       template <typename DataType, typename PrecomputedAndWitnessEntitiesSuperset>
-      static auto get_to_be_shifted(PrecomputedAndWitnessEntitiesSuperset& entities) {
-          return RefArray{ TO_BE_SHIFTED(entities) };
+      static auto get_to_be_shifted([[maybe_unused]] PrecomputedAndWitnessEntitiesSuperset& entities) {
+          return RefArray<DataType, std::tuple_size<decltype(std::make_tuple(TO_BE_SHIFTED(entities)))>::value>{ TO_BE_SHIFTED(entities) };
       }
 
       template <typename DataType>
@@ -154,7 +154,7 @@ class {{name}}Flavor {
       class ProvingKey : public ProvingKeyAvm_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey> {
         public:
           // Expose constructors on the base class
-          using Base = ProvingKey{{name}}_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey>;
+          using Base = ProvingKeyAvm_<PrecomputedEntities<Polynomial>, WitnessEntities<Polynomial>, CommitmentKey>;
           using Base::Base;
 
           auto get_to_be_shifted() { 
@@ -174,7 +174,8 @@ class {{name}}Flavor {
       {{!-- Used by get_row, logderivs, etc --}}
       class AllConstRefValues {
         public:
-          using DataType = const FF&;
+          using BaseDataType = const FF;
+          using DataType = BaseDataType&;
 
           {{!-- 
           We define the flavor members here again to avoid having to make this class inherit from AllEntities.
@@ -183,7 +184,7 @@ class {{name}}Flavor {
           --}}
           DEFINE_FLAVOR_MEMBERS(DataType, ALL_ENTITIES)
 
-          AllConstRefValues(const RefArray<FF const, NUM_ALL_ENTITIES>& il);
+          AllConstRefValues(const RefArray<BaseDataType, NUM_ALL_ENTITIES>& il);
       };
 
       /**

--- a/bb-pilcom/bb-pil-backend/templates/prover.cpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/prover.cpp.hbs
@@ -69,7 +69,7 @@ void {{name}}Prover::execute_wire_commitments_round()
     }
 }
 
-void AvmProver::execute_log_derivative_inverse_round()
+void {{name}}Prover::execute_log_derivative_inverse_round()
 {
     auto [beta, gamm] = transcript->template get_challenges<FF>("beta", "gamma");
     relation_parameters.beta = beta;

--- a/bb-pilcom/bb-pil-backend/templates/verifier.cpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/verifier.cpp.hbs
@@ -48,7 +48,7 @@ using FF = {{name}}Flavor::FF;
  * @brief This function verifies an {{name}} Honk proof for given program settings.
  *
  */
-bool {{name}}Verifier::verify_proof(const HonkProof& proof, const std::vector<std::vector<FF>>& public_inputs)
+bool {{name}}Verifier::verify_proof(const HonkProof& proof, [[maybe_unused]] const std::vector<std::vector<FF>>& public_inputs)
 {
     using Flavor = {{name}}Flavor;
     using FF = Flavor::FF;


### PR DESCRIPTION
After this PR you can now generate an alternative (spike) vm and it will build correctly. Most of the changes are to account for empty entity subsets.

I had to add some typing information to `flavor_macros.hpp` to work when the flavor is empty. This is annoying but shouldn't have any runtime implications.
