### PR TITLE
feat: changing note processor / synchronizer to add siloed notes

### DIFF
--- a/yarn-project/pxe/src/note_processor/note_processor.test.ts
+++ b/yarn-project/pxe/src/note_processor/note_processor.test.ts
@@ -200,6 +200,7 @@ describe('Note Processor', () => {
         }),
       ],
       [],
+      account.address,
     );
   }, 25_000);
 
@@ -211,7 +212,7 @@ describe('Note Processor', () => {
 
     expect(addNotesSpy).toHaveBeenCalledTimes(1);
     // For outgoing notes, the resulting DAO does not contain index.
-    expect(addNotesSpy).toHaveBeenCalledWith([], [expect.objectContaining(request.note.payload)]);
+    expect(addNotesSpy).toHaveBeenCalledWith([], [expect.objectContaining(request.note.payload)], account.address);
   }, 25_000);
 
   it('should store multiple notes that belong to us', async () => {
@@ -249,6 +250,7 @@ describe('Note Processor', () => {
         expect.objectContaining(requests[1].note.payload),
         expect.objectContaining(requests[4].note.payload),
       ],
+      account.address,
     );
   }, 30_000);
 

--- a/yarn-project/pxe/src/note_processor/note_processor.ts
+++ b/yarn-project/pxe/src/note_processor/note_processor.ts
@@ -227,7 +227,7 @@ export class NoteProcessor {
     const incomingNotes = blocksAndNotes.flatMap(b => b.incomingNotes);
     const outgoingNotes = blocksAndNotes.flatMap(b => b.outgoingNotes);
     if (incomingNotes.length || outgoingNotes.length) {
-      await this.db.addNotes(incomingNotes, outgoingNotes);
+      await this.db.addNotes(incomingNotes, outgoingNotes, this.account);
       incomingNotes.forEach(noteDao => {
         this.log.verbose(
           `Added incoming note for contract ${noteDao.contractAddress} at slot ${

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -9,7 +9,6 @@ import { type KeyStore } from '@aztec/key-store';
 import { type DeferredNoteDao } from '../database/deferred_note_dao.js';
 import { type IncomingNoteDao } from '../database/incoming_note_dao.js';
 import { type PxeDatabase } from '../database/index.js';
-import { type OutgoingNoteDao } from '../database/outgoing_note_dao.js';
 import { NoteProcessor } from '../note_processor/index.js';
 
 /**
@@ -334,7 +333,6 @@ export class Synchronizer {
 
     // keep track of decoded notes
     const incomingNotes: IncomingNoteDao[] = [];
-    const outgoingNotes: OutgoingNoteDao[] = [];
 
     // now process each txHash
     for (const deferredNotes of txHashToDeferredNotes.values()) {
@@ -342,27 +340,29 @@ export class Synchronizer {
       for (const processor of this.noteProcessors) {
         const { incomingNotes: inNotes, outgoingNotes: outNotes } = await processor.decodeDeferredNotes(deferredNotes);
         incomingNotes.push(...inNotes);
-        outgoingNotes.push(...outNotes);
+
+        await this.db.addNotes(inNotes, outNotes, processor.account);
+
+        inNotes.forEach(noteDao => {
+          this.log.debug(
+            `Decoded deferred incoming note under account ${processor.account.toString()} for contract ${
+              noteDao.contractAddress
+            } at slot ${noteDao.storageSlot} with nullifier ${noteDao.siloedNullifier.toString()}`,
+          );
+        });
+
+        outNotes.forEach(noteDao => {
+          this.log.debug(
+            `Decoded deferred outgoing note under account ${processor.account.toString()} for contract ${
+              noteDao.contractAddress
+            } at slot ${noteDao.storageSlot}`,
+          );
+        });
       }
     }
 
     // now drop the deferred notes, and add the decoded notes
     await this.db.removeDeferredNotesByContract(contractAddress);
-    await this.db.addNotes(incomingNotes, outgoingNotes);
-
-    incomingNotes.forEach(noteDao => {
-      this.log.debug(
-        `Decoded deferred incoming note for contract ${noteDao.contractAddress} at slot ${
-          noteDao.storageSlot
-        } with nullifier ${noteDao.siloedNullifier.toString()}`,
-      );
-    });
-
-    outgoingNotes.forEach(noteDao => {
-      this.log.debug(
-        `Decoded deferred outgoing note for contract ${noteDao.contractAddress} at slot ${noteDao.storageSlot}`,
-      );
-    });
 
     await this.#removeNullifiedNotes(incomingNotes);
   }


### PR DESCRIPTION
This PR changes how we add notes from the note processor / synchronizer, by adding them siloed to accounts. Note that this does not break anything because currently when we get notes, we only get them without taking siloed accounts into account. The method of fetching without specifying a scope uses all the scopes currently in the pxe.
