### PR TITLE
feat: use scopes in wallet calls

### DIFF
--- a/yarn-project/aztec.js/src/wallet/account_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/account_wallet.ts
@@ -19,7 +19,7 @@ import { BaseWallet } from './base_wallet.js';
  */
 export class AccountWallet extends BaseWallet {
   constructor(pxe: PXE, protected account: AccountInterface) {
-    super(pxe);
+    super(pxe, [account.getAddress()]);
   }
 
   createTxExecutionRequest(exec: ExecutionRequestInit): Promise<TxExecutionRequest> {

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -39,7 +39,7 @@ import { type IntentAction, type IntentInnerHash } from '../utils/authwit.js';
  * A base class for Wallet implementations
  */
 export abstract class BaseWallet implements Wallet {
-  constructor(protected readonly pxe: PXE) {}
+  constructor(protected readonly pxe: PXE, private scopes?: AztecAddress[]) {}
 
   abstract getCompleteAddress(): CompleteAddress;
 
@@ -52,6 +52,10 @@ export abstract class BaseWallet implements Wallet {
   abstract createAuthWit(intent: Fr | Buffer | IntentInnerHash | IntentAction): Promise<AuthWitness>;
 
   abstract rotateNullifierKeys(newNskM: Fq): Promise<void>;
+
+  setScopes(scopes: AztecAddress[]) {
+    this.scopes = scopes;
+  }
 
   getAddress() {
     return this.getCompleteAddress().address;
@@ -102,10 +106,10 @@ export abstract class BaseWallet implements Wallet {
     return this.pxe.getContracts();
   }
   proveTx(txRequest: TxExecutionRequest, simulatePublic: boolean): Promise<Tx> {
-    return this.pxe.proveTx(txRequest, simulatePublic);
+    return this.pxe.proveTx(txRequest, simulatePublic, this.scopes);
   }
   simulateTx(txRequest: TxExecutionRequest, simulatePublic: boolean, msgSender?: AztecAddress): Promise<SimulatedTx> {
-    return this.pxe.simulateTx(txRequest, simulatePublic, msgSender);
+    return this.pxe.simulateTx(txRequest, simulatePublic, msgSender, this.scopes);
   }
   sendTx(tx: Tx): Promise<TxHash> {
     return this.pxe.sendTx(tx);
@@ -130,7 +134,7 @@ export abstract class BaseWallet implements Wallet {
     return this.pxe.getPublicStorageAt(contract, storageSlot);
   }
   addNote(note: ExtendedNote): Promise<void> {
-    return this.pxe.addNote(note);
+    return this.pxe.addNote(note, this.getAddress());
   }
   addNullifiedNote(note: ExtendedNote): Promise<void> {
     return this.pxe.addNullifiedNote(note);

--- a/yarn-project/end-to-end/src/composed/e2e_sandbox_example.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_sandbox_example.test.ts
@@ -77,7 +77,7 @@ describe('e2e_sandbox_example', () => {
 
     // Add the newly created "pending shield" note to PXE
     const note = new Note([new Fr(initialSupply), aliceSecretHash]);
-    await pxe.addNote(
+    await aliceWallet.addNote(
       new ExtendedNote(
         note,
         alice,
@@ -152,7 +152,7 @@ describe('e2e_sandbox_example', () => {
     const mintPrivateReceipt = await tokenContractBob.methods.mint_private(mintQuantity, bobSecretHash).send().wait();
 
     const bobPendingShield = new Note([new Fr(mintQuantity), bobSecretHash]);
-    await pxe.addNote(
+    await bobWallet.addNote(
       new ExtendedNote(
         bobPendingShield,
         bob,

--- a/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
@@ -116,7 +116,7 @@ describe('e2e_2_pxes', () => {
       TokenContract.notes.TransparentNote.id,
       receipt.txHash,
     );
-    await recipientPxe.addNote(extendedNote);
+    await recipientPxe.addNote(extendedNote, recipient);
 
     await contractAsRecipient.methods.redeem_shield(recipient, balance, secret).send().wait();
   };

--- a/yarn-project/end-to-end/src/e2e_authwit.test.ts
+++ b/yarn-project/end-to-end/src/e2e_authwit.test.ts
@@ -60,11 +60,17 @@ describe('e2e_authwit_tests', () => {
           isValidInPublic: false,
         });
 
+        // We give wallets[0] access to wallets[1]'s notes.
+        wallets[0].setScopes([wallets[0].getAddress(), wallets[1].getAddress()]);
+
         // Check that the authwit is NOT valid in private for wallets[1]
         expect(await wallets[0].lookupValidity(wallets[1].getAddress(), intent)).toEqual({
           isValidInPrivate: false,
           isValidInPublic: false,
         });
+
+        // We give wallets[1] access to wallets[0]'s notes.
+        wallets[1].setScopes([wallets[0].getAddress(), wallets[1].getAddress()]);
 
         // Consume the inner hash using the wallets[0] as the "on behalf of".
         await auth.withWallet(wallets[1]).methods.consume(wallets[0].getAddress(), innerHash).send().wait();

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/burn.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/burn.test.ts
@@ -141,6 +141,9 @@ describe('e2e_blacklist_token_contract burn', () => {
       const witness = await wallets[0].createAuthWit({ caller: wallets[1].getAddress(), action });
       await wallets[1].addAuthWitness(witness);
 
+      // We give wallets[1] access to wallets[0]'s notes to be able to burn the notes.
+      wallets[1].setScopes([wallets[1].getAddress(), wallets[0].getAddress()]);
+
       await asset.withWallet(wallets[1]).methods.burn(wallets[0].getAddress(), amount, nonce).send().wait();
       tokenSim.burnPrivate(wallets[0].getAddress(), amount);
 
@@ -198,6 +201,9 @@ describe('e2e_blacklist_token_contract burn', () => {
           { chainId: wallets[0].getChainId(), version: wallets[0].getVersion() },
         );
 
+        // We give wallets[1] access to wallets[0]'s notes to test the authwit.
+        wallets[1].setScopes([wallets[1].getAddress(), wallets[0].getAddress()]);
+
         await expect(action.prove()).rejects.toThrow(`Unknown auth witness for message hash ${messageHash.toString()}`);
       });
 
@@ -216,6 +222,9 @@ describe('e2e_blacklist_token_contract burn', () => {
 
         const witness = await wallets[0].createAuthWit({ caller: wallets[1].getAddress(), action });
         await wallets[2].addAuthWitness(witness);
+
+        // We give wallets[2] access to wallets[0]'s notes to test the authwit.
+        wallets[2].setScopes([wallets[2].getAddress(), wallets[0].getAddress()]);
 
         await expect(action.prove()).rejects.toThrow(
           `Unknown auth witness for message hash ${expectedMessageHash.toString()}`,

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/transfer_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/transfer_private.test.ts
@@ -30,6 +30,9 @@ describe('e2e_blacklist_token_contract transfer private', () => {
     expect(amount).toBeGreaterThan(0n);
     await asset.methods.transfer(wallets[0].getAddress(), wallets[1].getAddress(), amount, 0).send().wait();
     tokenSim.transferPrivate(wallets[0].getAddress(), wallets[1].getAddress(), amount);
+
+    // We give wallets[0] access to wallets[1]'s notes to be able to check balances after the test.
+    wallets[0].setScopes([wallets[0].getAddress(), wallets[1].getAddress()]);
   });
 
   it('transfer to self', async () => {
@@ -62,6 +65,9 @@ describe('e2e_blacklist_token_contract transfer private', () => {
     // docs:end:add_authwit
     // docs:end:authwit_transfer_example
 
+    // We give wallets[1] access to wallets[0]'s notes to be able to transfer the notes.
+    wallets[1].setScopes([wallets[1].getAddress(), wallets[0].getAddress()]);
+
     // Perform the transfer
     await action.send().wait();
     tokenSim.transferPrivate(wallets[0].getAddress(), wallets[1].getAddress(), amount);
@@ -72,6 +78,9 @@ describe('e2e_blacklist_token_contract transfer private', () => {
       .methods.transfer(wallets[0].getAddress(), wallets[1].getAddress(), amount, nonce)
       .send();
     await expect(txReplay.wait()).rejects.toThrow(DUPLICATE_NULLIFIER_ERROR);
+
+    // We give wallets[0] access to wallets[1]'s notes to be able to check balances after the test.
+    wallets[0].setScopes([wallets[0].getAddress(), wallets[1].getAddress()]);
   });
 
   describe('failure cases', () => {
@@ -160,6 +169,9 @@ describe('e2e_blacklist_token_contract transfer private', () => {
 
       const witness = await wallets[0].createAuthWit({ caller: wallets[1].getAddress(), action });
       await wallets[2].addAuthWitness(witness);
+
+      // We give wallets[2] access to wallets[0]'s notes to test the authwit.
+      wallets[2].setScopes([wallets[2].getAddress(), wallets[0].getAddress()]);
 
       await expect(action.prove()).rejects.toThrow(
         `Unknown auth witness for message hash ${expectedMessageHash.toString()}`,

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/unshielding.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/unshielding.test.ts
@@ -50,6 +50,9 @@ describe('e2e_blacklist_token_contract unshielding', () => {
     const witness = await wallets[0].createAuthWit({ caller: wallets[1].getAddress(), action });
     await wallets[1].addAuthWitness(witness);
 
+    // We give wallets[1] access to wallets[0]'s notes to unshield the note.
+    wallets[1].setScopes([wallets[1].getAddress(), wallets[0].getAddress()]);
+
     await action.send().wait();
     tokenSim.unshield(wallets[0].getAddress(), wallets[1].getAddress(), amount);
 
@@ -121,6 +124,9 @@ describe('e2e_blacklist_token_contract unshielding', () => {
       // But doing it in two actions to show the flow.
       const witness = await wallets[0].createAuthWit({ caller: wallets[1].getAddress(), action });
       await wallets[2].addAuthWitness(witness);
+
+      // We give wallets[2] access to wallets[0]'s notes to test the authwit.
+      wallets[2].setScopes([wallets[2].getAddress(), wallets[0].getAddress()]);
 
       await expect(action.prove()).rejects.toThrow(
         `Unknown auth witness for message hash ${expectedMessageHash.toString()}`,

--- a/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
+++ b/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
@@ -238,6 +238,9 @@ describe('e2e_crowdfunding_and_claim', () => {
 
     // 3) We claim the reward token via the Claim contract
     {
+      // We allow the donor wallet to use the crowdfunding contract's notes
+      donorWallets[0].setScopes([donorWallets[0].getAddress(), crowdfundingContract.address]);
+
       await claimContract
         .withWallet(donorWallets[0])
         .methods.claim(valueNote, donorWallets[0].getAddress())
@@ -254,6 +257,8 @@ describe('e2e_crowdfunding_and_claim', () => {
       .simulate();
     expect(balanceDNTBeforeWithdrawal).toEqual(0n);
 
+    // We allow the operator wallet to use the crowdfunding contract's notes
+    operatorWallet.setScopes([operatorWallet.getAddress(), crowdfundingContract.address]);
     // 4) At last, we withdraw the raised funds from the crowdfunding contract to the operator's address
     await crowdfundingContract.methods.withdraw(donationAmount).send().wait();
 
@@ -399,6 +404,10 @@ describe('e2e_crowdfunding_and_claim', () => {
     // a non-entrypoint function (withdraw never calls context.end_setup()), meaning the min revertible counter will remain 0.
     // This does not protect fully against impersonation as the contract could just call context.end_setup() and the below would pass.
     // => the private_init msg_sender assertion is required (#7190, #7404)
+
+    // We allow the donor wallet to use the crowdfunding contract's notes
+    donorWallets[1].setScopes([donorWallets[1].getAddress(), crowdfundingContract.address]);
+
     await expect(donorWallets[1].simulateTx(request, true, operatorWallet.getAddress())).rejects.toThrow(
       'Assertion failed: Users cannot set msg_sender in first call',
     );

--- a/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
@@ -72,9 +72,12 @@ describe('e2e_escrow_contract', () => {
       TokenContract.notes.TransparentNote.id,
       receipt.txHash,
     );
-    await pxe.addNote(extendedNote);
+    await wallet.addNote(extendedNote);
 
     await token.methods.redeem_shield(escrowContract.address, mintAmount, secret).send().wait();
+
+    // We allow our wallet to see the escrow contract's notes.
+    wallet.setScopes([wallet.getAddress(), escrowContract.address]);
 
     logger.info(`Token contract deployed at ${token.address}`);
   });
@@ -123,7 +126,7 @@ describe('e2e_escrow_contract', () => {
       TokenContract.notes.TransparentNote.id,
       receipt.txHash,
     );
-    await pxe.addNote(extendedNote);
+    await wallet.addNote(extendedNote);
 
     await token.methods.redeem_shield(owner, mintAmount, secret).send().wait();
 

--- a/yarn-project/end-to-end/src/e2e_fees/account_init.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/account_init.test.ts
@@ -139,7 +139,7 @@ describe('e2e_fees account_init', () => {
       await expect(t.getGasBalanceFn(bananaFPC.address)).resolves.toEqual([fpcsInitialGas - actualFee]);
 
       // the new account should have received a refund
-      await t.addPendingShieldNoteToPXE(bobsAddress, maxFee - actualFee, computeSecretHash(rebateSecret), tx.txHash);
+      await t.addPendingShieldNoteToPXE(aliceAddress, maxFee - actualFee, computeSecretHash(rebateSecret), tx.txHash);
 
       // and it can redeem the refund
       await bananaCoin.methods

--- a/yarn-project/end-to-end/src/e2e_fees/dapp_subscription.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/dapp_subscription.test.ts
@@ -112,6 +112,9 @@ describe('e2e_fees dapp_subscription', () => {
       new PrivateFeePaymentMethod(bananaCoin.address, bananaFPC.address, aliceWallet),
     );
 
+    // We let Alice see Bob's notes because the expect uses Alice's wallet to interact with the contracts to "get" state.
+    aliceWallet.setScopes([aliceAddress, bobAddress]);
+
     await expectMapping(
       t.getGasBalanceFn,
       [sequencerAddress, bananaFPC.address],

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -145,7 +145,7 @@ export class FeesTest {
       BananaCoin.notes.TransparentNote.id,
       txHash,
     );
-    await this.pxe.addNote(extendedNote);
+    await this.pxe.addNote(extendedNote, ownerAddress);
   }
 
   public async applyBaseSnapshots() {

--- a/yarn-project/end-to-end/src/e2e_fees/gas_estimation.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/gas_estimation.test.ts
@@ -33,6 +33,9 @@ describe('e2e_fees gas_estimation', () => {
     ({ aliceWallet, aliceAddress, bobAddress, bananaCoin, bananaFPC, gasSettings, logger } = await t.setup());
 
     teardownFixedFee = gasSettings.teardownGasLimits.computeFee(GasFees.default()).toBigInt();
+
+    // We let Alice see Bob's notes because the expect uses Alice's wallet to interact with the contracts to "get" state.
+    aliceWallet.setScopes([aliceAddress, bobAddress]);
   });
 
   afterAll(async () => {

--- a/yarn-project/end-to-end/src/e2e_fees/native_payments.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/native_payments.test.ts
@@ -1,4 +1,9 @@
-import { type AztecAddress, NativeFeePaymentMethod, NativeFeePaymentMethodWithClaim } from '@aztec/aztec.js';
+import {
+  type AccountWallet,
+  type AztecAddress,
+  NativeFeePaymentMethod,
+  NativeFeePaymentMethodWithClaim,
+} from '@aztec/aztec.js';
 import { type GasSettings } from '@aztec/circuits.js';
 import { type TokenContract as BananaCoin, type GasTokenContract } from '@aztec/noir-contracts.js';
 
@@ -6,6 +11,7 @@ import { FeesTest } from './fees_test.js';
 
 describe('e2e_fees native_payments', () => {
   let aliceAddress: AztecAddress;
+  let aliceWallet: AccountWallet;
   let bobAddress: AztecAddress;
   let bananaCoin: BananaCoin;
   let gasSettings: GasSettings;
@@ -17,9 +23,12 @@ describe('e2e_fees native_payments', () => {
   beforeAll(async () => {
     await t.applyBaseSnapshots();
     await t.applyFundAliceWithBananas();
-    ({ gasTokenContract, aliceAddress, bobAddress, bananaCoin, gasSettings } = await t.setup());
+    ({ gasTokenContract, aliceAddress, aliceWallet, bobAddress, bananaCoin, gasSettings } = await t.setup());
 
     paymentMethod = new NativeFeePaymentMethod(aliceAddress);
+
+    // We let Alice see Bob's notes because the expect uses Alice's wallet to interact with the contracts to "get" state.
+    aliceWallet.setScopes([aliceAddress, bobAddress]);
   });
 
   afterAll(async () => {

--- a/yarn-project/end-to-end/src/e2e_fees/private_payments.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/private_payments.test.ts
@@ -1,10 +1,10 @@
 import {
+  type AccountWallet,
   type AztecAddress,
   BatchCall,
   Fr,
   PrivateFeePaymentMethod,
   type TxReceipt,
-  type Wallet,
   computeSecretHash,
 } from '@aztec/aztec.js';
 import { type GasSettings } from '@aztec/circuits.js';
@@ -14,7 +14,7 @@ import { expectMapping } from '../fixtures/utils.js';
 import { FeesTest } from './fees_test.js';
 
 describe('e2e_fees private_payment', () => {
-  let aliceWallet: Wallet;
+  let aliceWallet: AccountWallet;
   let aliceAddress: AztecAddress;
   let bobAddress: AztecAddress;
   let sequencerAddress: AztecAddress;
@@ -73,6 +73,9 @@ describe('e2e_fees private_payment', () => {
       t.getBananaPublicBalanceFn(aliceAddress, bobAddress, bananaFPC.address),
       t.getGasBalanceFn(aliceAddress, bananaFPC.address, sequencerAddress),
     ]);
+
+    // We let Alice see Bob's notes because the expect uses Alice's wallet to interact with the contracts to "get" state.
+    aliceWallet.setScopes([aliceAddress, bobAddress]);
   });
 
   const getFeeAndRefund = (tx: Pick<TxReceipt, 'transactionFee'>) => [tx.transactionFee!, maxFee - tx.transactionFee!];

--- a/yarn-project/end-to-end/src/e2e_fees/private_refunds.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/private_refunds.test.ts
@@ -1,4 +1,5 @@
 import {
+  type AccountWallet,
   type AztecAddress,
   ExtendedNote,
   type FeePaymentMethod,
@@ -16,8 +17,9 @@ import { expectMapping } from '../fixtures/utils.js';
 import { FeesTest } from './fees_test.js';
 
 describe('e2e_fees/private_refunds', () => {
-  let aliceWallet: Wallet;
+  let aliceWallet: AccountWallet;
   let aliceAddress: AztecAddress;
+  let bobAddress: AztecAddress;
   let tokenWithRefunds: TokenWithRefundsContract;
   let privateFPC: PrivateFPCContract;
 
@@ -34,8 +36,11 @@ describe('e2e_fees/private_refunds', () => {
     await t.applyDeployGasTokenSnapshot();
     await t.applyTokenWithRefundsAndFPC();
     await t.applyFundAliceWithTokens();
-    ({ aliceWallet, aliceAddress, privateFPC, tokenWithRefunds } = await t.setup());
+    ({ aliceWallet, aliceAddress, bobAddress, privateFPC, tokenWithRefunds } = await t.setup());
     t.logger.debug(`Alice address: ${aliceAddress}`);
+
+    // We give Alice access to Bob's notes because Alice is used to check if balances are correct.
+    aliceWallet.setScopes([aliceAddress, bobAddress]);
   });
 
   afterAll(async () => {

--- a/yarn-project/end-to-end/src/e2e_keys.test.ts
+++ b/yarn-project/end-to-end/src/e2e_keys.test.ts
@@ -79,7 +79,7 @@ describe('Key Registry', () => {
 
       expect(await getNumNullifiedNotes(nskApp, testContract.address)).toEqual(0);
 
-      await testContract.methods.call_destroy_note(noteStorageSlot).send().wait();
+      await testContract.withWallet(account).methods.call_destroy_note(noteStorageSlot).send().wait();
 
       expect(await getNumNullifiedNotes(nskApp, testContract.address)).toEqual(1);
     });

--- a/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
@@ -72,7 +72,7 @@ describe('e2e_multiple_accounts_1_enc_key', () => {
       TokenContract.notes.TransparentNote.id,
       receipt.txHash,
     );
-    await pxe.addNote(extendedNote);
+    await wallets[0].addNote(extendedNote);
 
     await token.methods.redeem_shield(accounts[0], initialBalance, secret).send().wait();
   });

--- a/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging/public_cross_chain_messaging_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_cross_chain_messaging/public_cross_chain_messaging_contract_test.ts
@@ -167,6 +167,7 @@ export class PublicCrossChainMessagingContractTest {
           walletClient,
           this.ownerAddress,
           this.aztecNodeConfig.l1Contracts,
+          this.user1Wallet,
         );
 
         this.publicClient = publicClient;

--- a/yarn-project/end-to-end/src/e2e_token_contract/burn.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/burn.test.ts
@@ -134,6 +134,9 @@ describe('e2e_token_contract burn', () => {
       const witness = await wallets[0].createAuthWit({ caller: accounts[1].address, action });
       await wallets[1].addAuthWitness(witness);
 
+      // We give wallets[1] access to wallets[0]'s notes to burn the note.
+      wallets[1].setScopes([wallets[1].getAddress(), wallets[0].getAddress()]);
+
       await asset.withWallet(wallets[1]).methods.burn(accounts[0].address, amount, nonce).send().wait();
       tokenSim.burnPrivate(accounts[0].address, amount);
 
@@ -191,6 +194,9 @@ describe('e2e_token_contract burn', () => {
           { chainId: wallets[0].getChainId(), version: wallets[0].getVersion() },
         );
 
+        // We give wallets[1] access to wallets[0]'s notes to test the authwit.
+        wallets[1].setScopes([wallets[1].getAddress(), wallets[0].getAddress()]);
+
         await expect(action.simulate()).rejects.toThrow(
           `Unknown auth witness for message hash ${messageHash.toString()}`,
         );
@@ -211,6 +217,9 @@ describe('e2e_token_contract burn', () => {
 
         const witness = await wallets[0].createAuthWit({ caller: accounts[1].address, action });
         await wallets[2].addAuthWitness(witness);
+
+        // We give wallets[2] access to wallets[0]'s notes to test the authwit.
+        wallets[2].setScopes([wallets[2].getAddress(), wallets[0].getAddress()]);
 
         await expect(action.simulate()).rejects.toThrow(
           `Unknown auth witness for message hash ${expectedMessageHash.toString()}`,

--- a/yarn-project/end-to-end/src/e2e_token_contract/unshielding.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/unshielding.test.ts
@@ -49,6 +49,9 @@ describe('e2e_token_contract unshielding', () => {
     const witness = await wallets[0].createAuthWit({ caller: accounts[1].address, action });
     await wallets[1].addAuthWitness(witness);
 
+    // We give wallets[1] access to wallets[0]'s notes to unshield the note.
+    wallets[1].setScopes([wallets[1].getAddress(), wallets[0].getAddress()]);
+
     await action.send().wait();
     tokenSim.unshield(accounts[0].address, accounts[1].address, amount);
 
@@ -119,6 +122,9 @@ describe('e2e_token_contract unshielding', () => {
       // But doing it in two actions to show the flow.
       const witness = await wallets[0].createAuthWit({ caller: accounts[1].address, action });
       await wallets[2].addAuthWitness(witness);
+
+      // We give wallets[2] access to wallets[0]'s notes to test the authwit.
+      wallets[2].setScopes([wallets[2].getAddress(), wallets[0].getAddress()]);
 
       await expect(action.simulate()).rejects.toThrow(
         `Unknown auth witness for message hash ${expectedMessageHash.toString()}`,

--- a/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
+++ b/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
@@ -64,10 +64,10 @@ describe('guides/dapp/testing', () => {
           TokenContract.notes.TransparentNote.id,
           receipt.txHash,
         );
-        await pxe.addNote(extendedNote);
+        await owner.addNote(extendedNote);
 
         await token.methods.redeem_shield(recipientAddress, mintAmount, secret).send().wait();
-        expect(await token.methods.balance_of_private(recipientAddress).simulate()).toEqual(20n);
+        expect(await token.withWallet(recipient).methods.balance_of_private(recipientAddress).simulate()).toEqual(20n);
       });
     });
 
@@ -104,10 +104,10 @@ describe('guides/dapp/testing', () => {
           TokenContract.notes.TransparentNote.id,
           receipt.txHash,
         );
-        await pxe.addNote(extendedNote);
+        await owner.addNote(extendedNote);
 
         await token.methods.redeem_shield(recipientAddress, mintAmount, secret).send().wait();
-        expect(await token.methods.balance_of_private(recipientAddress).simulate()).toEqual(20n);
+        expect(await token.withWallet(recipient).methods.balance_of_private(recipientAddress).simulate()).toEqual(20n);
       });
     });
 
@@ -167,7 +167,7 @@ describe('guides/dapp/testing', () => {
           TokenContract.notes.TransparentNote.id,
           receipt.txHash,
         );
-        await pxe.addNote(extendedNote);
+        await owner.addNote(extendedNote);
 
         await token.methods.redeem_shield(ownerAddress, 100n, secret).send().wait();
 
@@ -184,6 +184,7 @@ describe('guides/dapp/testing', () => {
           owner: owner.getAddress(),
           contractAddress: token.address,
           storageSlot: ownerSlot,
+          scopes: [owner.getAddress()],
         });
         const values = notes.map(note => note.note.items[0]);
         const balance = values.reduce((sum, current) => sum + current.toBigInt(), 0n);

--- a/yarn-project/end-to-end/src/guides/writing_an_account_contract.test.ts
+++ b/yarn-project/end-to-end/src/guides/writing_an_account_contract.test.ts
@@ -81,7 +81,7 @@ describe('guides/writing_an_account_contract', () => {
       TokenContract.notes.TransparentNote.id,
       receipt.txHash,
     );
-    await pxe.addNote(extendedNote);
+    await wallet.addNote(extendedNote);
 
     await token.methods.redeem_shield(address, mintAmount, secret).send().wait();
 

--- a/yarn-project/end-to-end/src/shared/browser.ts
+++ b/yarn-project/end-to-end/src/shared/browser.ts
@@ -271,7 +271,7 @@ export const browserTestSuite = (
             noteTypeId,
             mintPrivateReceipt.txHash,
           );
-          await pxe.addNote(extendedNote);
+          await owner.addNote(extendedNote);
 
           await token.methods.redeem_shield(ownerAddress, initialBalance, secret).send().wait();
 

--- a/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
@@ -187,6 +187,7 @@ export class CrossChainTestHarness {
       walletClient,
       owner.address,
       l1ContractAddresses,
+      wallet,
     );
   }
 
@@ -226,6 +227,9 @@ export class CrossChainTestHarness {
 
     /** Deployment addresses for all L1 contracts */
     public readonly l1ContractAddresses: L1ContractAddresses,
+
+    /** Wallet of the owner. */
+    public readonly ownerWallet: Wallet,
   ) {}
 
   /**
@@ -440,7 +444,7 @@ export class CrossChainTestHarness {
       TokenContract.notes.TransparentNote.id,
       txHash,
     );
-    await this.pxeService.addNote(extendedNote);
+    await this.ownerWallet.addNote(extendedNote);
   }
 
   async redeemShieldPrivatelyOnL2(shieldAmount: bigint, secret: Fr) {


### PR DESCRIPTION
This PR introduces an initial implementation for adding scopes to calls via a wallet. Note that this only affects wallets that are associated with an "account", and does not yet affect signerless wallets. Signerless wallets that are not associated with any account still has access to all notes.
