### PR TITLE
fix: add missing parameter to context.push_nullifier

### DIFF
--- a/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/main.nr
@@ -35,7 +35,7 @@ contract EasyPrivateVoting {
 
         let secret = context.request_nsk_app(msg_sender_npk_m_hash); // get secret key of caller of function
         let nullifier = std::hash::pedersen_hash([context.msg_sender().to_field(), secret]); // derive nullifier from sender and secret
-        context.push_nullifier(nullifier);
+        context.push_nullifier(nullifier, 0);
         EasyPrivateVoting::at(context.this_address()).add_to_tally_public(candidate).enqueue(&mut context);
     }
     // docs:end:cast_vote


### PR DESCRIPTION
Added the missing third parameter to `context.push_nullifier` in the `cast_vote` function to resolve a function signature error