### PR TITLE
feat: removing nullifier from private FPC

### DIFF
--- a/noir-projects/noir-contracts/contracts/private_fpc_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/private_fpc_contract/src/main.nr
@@ -21,8 +21,6 @@ contract PrivateFPC {
     #[aztec(private)]
     fn fund_transaction_privately(amount: Field, asset: AztecAddress, user_randomness: Field) {
         assert(asset == storage.other_asset.read_private());
-        // convince the FPC we are not cheating
-        context.push_nullifier(user_randomness);
 
         // We use different randomness for fee payer to prevent a potential privacy leak (see description
         // of `setup_refund(...)` function in TokenWithRefunds for details.


### PR DESCRIPTION
Leila recently implemented injection of nonces to public note hashes ([relevant PR](https://github.com/AztecProtocol/aztec-packages/pull/7715)) and with that it's no longer necessary to prevent collisions of notes in the private refunds. These collisions were prevented until now by emitting randomness as a nullifier.

**Context**: Given that note hashes used to not be noncified it could happen that a user would emit the same note hash twice and effectively losing one of the notes (since it could not be nullified). To prevent this we used to emit user randomness (which is part of the note hash preimage).

[Here](https://github.com/AztecProtocol/aztec-packages/pull/7226#discussion_r1660999326) is the original discussion.