### PR TITLE
feat(bb): optimize tuple creation

### DIFF
--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -76,9 +76,13 @@
 #include "barretenberg/polynomials/barycentric.hpp"
 #include "barretenberg/polynomials/evaluation_domain.hpp"
 #include "barretenberg/polynomials/univariate.hpp"
+#include "barretenberg/srs/global_crs.hpp"
+
 #include <array>
-#include <barretenberg/srs/global_crs.hpp>
 #include <concepts>
+#include <cstddef>
+#include <numeric>
+#include <utility>
 #include <vector>
 
 namespace bb {
@@ -252,115 +256,125 @@ class VerificationKey_ : public PrecomputedCommitments {
     }
 };
 
-// Because of how Gemini is written, is importat to put the polynomials out in this order.
+// Because of how Gemini is written, it is important to put the polynomials out in this order.
 auto get_unshifted_then_shifted(const auto& all_entities)
 {
     return concatenate(all_entities.get_unshifted(), all_entities.get_shifted());
 };
 
+template <typename Tuple, size_t... I>
+static constexpr auto _compute_max_partial_relation_length_internal([[maybe_unused]] std::index_sequence<I...>)
+{
+    constexpr std::array<size_t, sizeof...(I)> lengths = { std::tuple_element_t<I, Tuple>::RELATION_LENGTH... };
+    return *std::max_element(lengths.begin(), lengths.end());
+}
+
 /**
- * @brief Recursive utility function to find max PARTIAL_RELATION_LENGTH tuples of Relations.
+ * @brief Utility function to find max PARTIAL_RELATION_LENGTH tuples of Relations.
  * @details The "partial length" of a relation is 1 + the degree of the relation, where any challenges used in the
  * relation are as constants, not as variables..
- *
  */
 template <typename Tuple, std::size_t Index = 0> static constexpr size_t compute_max_partial_relation_length()
 {
-    if constexpr (Index >= std::tuple_size<Tuple>::value) {
-        return 0; // Return 0 when reach end of the tuple
-    } else {
-        constexpr size_t current_length = std::tuple_element<Index, Tuple>::type::RELATION_LENGTH;
-        constexpr size_t next_length = compute_max_partial_relation_length<Tuple, Index + 1>();
-        return (current_length > next_length) ? current_length : next_length;
-    }
+    return _compute_max_partial_relation_length_internal<Tuple>(std::make_index_sequence<std::tuple_size_v<Tuple>>());
+}
+
+template <typename Tuple, size_t... I>
+static constexpr auto _compute_max_total_relation_length_internal([[maybe_unused]] std::index_sequence<I...>)
+{
+    constexpr std::array<size_t, sizeof...(I)> lengths = { std::tuple_element_t<I, Tuple>::TOTAL_RELATION_LENGTH... };
+    return *std::max_element(lengths.begin(), lengths.end());
 }
 
 /**
- * @brief Recursive utility function to find max TOTAL_RELATION_LENGTH among tuples of Relations.
+ * @brief Utility function to find max TOTAL_RELATION_LENGTH among tuples of Relations.
  * @details The "total length" of a relation is 1 + the degree of the relation, where any challenges used in the
  * relation are regarded as variables.
- *
  */
-template <typename Tuple, std::size_t Index = 0> static constexpr size_t compute_max_total_relation_length()
+template <typename Tuple> static constexpr size_t compute_max_total_relation_length()
 {
-    if constexpr (Index >= std::tuple_size<Tuple>::value) {
-        return 0; // Return 0 when reach end of the tuple
+    return _compute_max_total_relation_length_internal<Tuple>(std::make_index_sequence<std::tuple_size_v<Tuple>>());
+}
+
+template <typename Tuple, size_t... I>
+static constexpr auto _compute_number_of_subrelations_internal([[maybe_unused]] std::index_sequence<I...>)
+{
+    constexpr std::array<size_t, sizeof...(I)> lengths = {
+        std::tuple_element_t<I, Tuple>::SUBRELATION_PARTIAL_LENGTHS.size()...
+    };
+    return std::accumulate(lengths.begin(), lengths.end(), 0);
+}
+
+/**
+ * @brief Utility function to find the number of subrelations.
+ */
+template <typename Tuple> static constexpr size_t compute_number_of_subrelations()
+{
+    return _compute_number_of_subrelations_internal<Tuple>(std::make_index_sequence<std::tuple_size_v<Tuple>>());
+}
+
+template <typename Tuple, size_t NUM_INSTANCES, bool optimised = false, size_t... I>
+static constexpr auto _create_protogalaxy_tuple_of_tuples_of_univariates_internal(
+    [[maybe_unused]] std::index_sequence<I...>)
+{
+    if constexpr (optimised) {
+        return std::make_tuple(
+            typename std::tuple_element_t<I, Tuple>::template OptimisedProtogalaxyTupleOfUnivariatesOverSubrelations<
+                NUM_INSTANCES>{}...);
     } else {
-        constexpr size_t current_length = std::tuple_element<Index, Tuple>::type::TOTAL_RELATION_LENGTH;
-        constexpr size_t next_length = compute_max_total_relation_length<Tuple, Index + 1>();
-        return (current_length > next_length) ? current_length : next_length;
+        return std::make_tuple(
+            typename std::tuple_element_t<I, Tuple>::template ProtogalaxyTupleOfUnivariatesOverSubrelations<
+                NUM_INSTANCES>{}...);
     }
 }
 
 /**
- * @brief Recursive utility function to find the number of subrelations.
- *
- */
-template <typename Tuple, std::size_t Index = 0> static constexpr size_t compute_number_of_subrelations()
-{
-    if constexpr (Index >= std::tuple_size<Tuple>::value) {
-        return 0;
-    } else {
-        constexpr size_t subrelations_in_relation =
-            std::tuple_element_t<Index, Tuple>::SUBRELATION_PARTIAL_LENGTHS.size();
-        return subrelations_in_relation + compute_number_of_subrelations<Tuple, Index + 1>();
-    }
-}
-/**
- * @brief Recursive utility function to construct a container for the subrelation accumulators of Protogalaxy folding.
+ * @brief Utility function to construct a container for the subrelation accumulators of Protogalaxy folding.
  * @details The size of the outer tuple is equal to the number of relations. Each relation contributes an inner tuple of
  * univariates whose size is equal to the number of subrelations of the relation. The length of a univariate in an inner
  * tuple is determined by the corresponding subrelation length and the number of instances to be folded.
  * @tparam optimised Enable optimised version with skipping some of the computation
  */
-template <typename Tuple, size_t NUM_INSTANCES, bool optimised = false, size_t Index = 0>
+template <typename Tuple, size_t NUM_INSTANCES, bool optimised = false>
 static constexpr auto create_protogalaxy_tuple_of_tuples_of_univariates()
 {
-    if constexpr (Index >= std::tuple_size<Tuple>::value) {
-        return std::tuple<>{}; // Return empty when reach end of the tuple
-    } else {
-        using UnivariateTuple =
-            std::conditional_t<optimised,
-                               typename std::tuple_element_t<Index, Tuple>::
-                                   template OptimisedProtogalaxyTupleOfUnivariatesOverSubrelations<NUM_INSTANCES>,
-                               typename std::tuple_element_t<Index, Tuple>::
-                                   template ProtogalaxyTupleOfUnivariatesOverSubrelations<NUM_INSTANCES>>;
-        return std::tuple_cat(
-            std::tuple<UnivariateTuple>{},
-            create_protogalaxy_tuple_of_tuples_of_univariates<Tuple, NUM_INSTANCES, optimised, Index + 1>());
-    }
+    return _create_protogalaxy_tuple_of_tuples_of_univariates_internal<Tuple, NUM_INSTANCES, optimised>(
+        std::make_index_sequence<std::tuple_size_v<Tuple>>());
+}
+
+template <typename Tuple, size_t... I>
+static constexpr auto _create_sumcheck_tuple_of_tuples_of_univariates_internal(
+    [[maybe_unused]] std::index_sequence<I...>)
+{
+    return std::make_tuple(typename std::tuple_element_t<I, Tuple>::SumcheckTupleOfUnivariatesOverSubrelations{}...);
 }
 
 /**
- * @brief Recursive utility function to construct a container for the subrelation accumulators of sumcheck proving.
+ * @brief Utility function to construct a container for the subrelation accumulators of sumcheck proving.
  * @details The size of the outer tuple is equal to the number of relations. Each relation contributes an inner tuple of
  * univariates whose size is equal to the number of subrelations of the relation. The length of a univariate in an inner
  * tuple is determined by the corresponding subrelation length.
  */
-template <typename Tuple, std::size_t Index = 0> static constexpr auto create_sumcheck_tuple_of_tuples_of_univariates()
+template <typename Tuple> static constexpr auto create_sumcheck_tuple_of_tuples_of_univariates()
 {
-    if constexpr (Index >= std::tuple_size<Tuple>::value) {
-        return std::tuple<>{}; // Return empty when reach end of the tuple
-    } else {
-        using UnivariateTuple = typename std::tuple_element_t<Index, Tuple>::SumcheckTupleOfUnivariatesOverSubrelations;
-        return std::tuple_cat(std::tuple<UnivariateTuple>{},
-                              create_sumcheck_tuple_of_tuples_of_univariates<Tuple, Index + 1>());
-    }
+    return _create_sumcheck_tuple_of_tuples_of_univariates_internal<Tuple>(
+        std::make_index_sequence<std::tuple_size_v<Tuple>>());
+}
+
+template <typename Tuple, size_t... I>
+static constexpr auto _create_tuple_of_arrays_of_values_internal([[maybe_unused]] std::index_sequence<I...>)
+{
+    return std::make_tuple(typename std::tuple_element_t<I, Tuple>::SumcheckArrayOfValuesOverSubrelations{}...);
 }
 
 /**
- * @brief Recursive utility function to construct tuple of arrays
+ * @brief Construct tuple of arrays
  * @details Container for storing value of each identity in each relation. Each Relation contributes an array of
  * length num-identities.
  */
-template <typename Tuple, std::size_t Index = 0> static constexpr auto create_tuple_of_arrays_of_values()
+template <typename Tuple> static constexpr auto create_tuple_of_arrays_of_values()
 {
-    if constexpr (Index >= std::tuple_size<Tuple>::value) {
-        return std::tuple<>{}; // Return empty when reach end of the tuple
-    } else {
-        using Values = typename std::tuple_element_t<Index, Tuple>::SumcheckArrayOfValuesOverSubrelations;
-        return std::tuple_cat(std::tuple<Values>{}, create_tuple_of_arrays_of_values<Tuple, Index + 1>());
-    }
+    return _create_tuple_of_arrays_of_values_internal<Tuple>(std::make_index_sequence<std::tuple_size_v<Tuple>>());
 }
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.hpp
@@ -227,9 +227,6 @@ class AvmFlavor {
     static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = MAX_PARTIAL_RELATION_LENGTH + 1;
     static constexpr size_t NUM_RELATIONS = std::tuple_size_v<Relations>;
 
-    template <size_t NUM_INSTANCES>
-    using ProtogalaxyTupleOfTuplesOfUnivariates =
-        decltype(create_protogalaxy_tuple_of_tuples_of_univariates<Relations, NUM_INSTANCES>());
     using SumcheckTupleOfTuplesOfUnivariates = decltype(create_sumcheck_tuple_of_tuples_of_univariates<Relations>());
     using TupleOfArraysOfValues = decltype(create_tuple_of_arrays_of_values<Relations>());
 

--- a/bb-pilcom/bb-pil-backend/templates/flavor.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/flavor.hpp.hbs
@@ -82,9 +82,6 @@ class {{name}}Flavor {
     static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = MAX_PARTIAL_RELATION_LENGTH + 1;
     static constexpr size_t NUM_RELATIONS = std::tuple_size_v<Relations>;
 
-    template <size_t NUM_INSTANCES>
-    using ProtogalaxyTupleOfTuplesOfUnivariates =
-      decltype(create_protogalaxy_tuple_of_tuples_of_univariates<Relations, NUM_INSTANCES>());
     using SumcheckTupleOfTuplesOfUnivariates = decltype(create_sumcheck_tuple_of_tuples_of_univariates<Relations>());
     using TupleOfArraysOfValues = decltype(create_tuple_of_arrays_of_values<Relations>());
 


### PR DESCRIPTION
35% improvement in VM compilation time, and I'm sure it will improve BB's compilation time in general. Using this same trick, avoiding tuple concat and recursive usage, we can make other functions faster to compile as well.

BEFORE
```
VM Total Compilation time(ms): 684615
255329 ms: std::tuple_cat<$> (3092 times, avg 82 ms)
243861 ms: bb::create_sumcheck_tuple_of_tuples_of_univariates<$> (99 times, avg 2463 ms)
188579 ms: std::__tuple_concater<$>::_S_do<$> (3092 times, avg 60 ms)
118890 ms: bb::create_tuple_of_arrays_of_values<$> (177 times, avg 671 ms)
112903 ms: std::tuple<$> (6588 times, avg 17 ms)
```

AFTER
```
VM Total Compilation time(ms): 451748
41011 ms: bb::create_sumcheck_tuple_of_tuples_of_univariates<$> (99 times, avg 414 ms)
40975 ms: bb::create_sumcheck_tuple_of_tuples_of_univariates_internal<$> (99 times, avg 413 ms)
```
