### PR TITLE
fix: Use curl instead of cast in mainnet fork script

### DIFF
--- a/iac/mainnet-fork/scripts/run_nginx_anvil.sh
+++ b/iac/mainnet-fork/scripts/run_nginx_anvil.sh
@@ -28,8 +28,8 @@ echo "Waiting for ethereum host at $ETHEREUM_HOST..."
 while ! curl -s $ETHEREUM_HOST >/dev/null; do sleep 1; done
 
 # Fix anvil's fork timestamp
-#.foundry/bin/cast rpc --rpc-url="$ETHEREUM_HOST" evm_setNextBlockTimestamp $(date +%s | xargs printf '0x%x') > /dev/null
-#.foundry/bin/cast rpc --rpc-url="$ETHEREUM_HOST" evm_mine > /dev/null
+curl -s -H "Content-Type: application/json" -XPOST -d"{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"evm_setNextBlockTimestamp\",\"params\":[\"$(date +%s | xargs printf '0x%x')\"]}" $ETHEREUM_HOST > /dev/null
+curl -s -H "Content-Type: application/json" -XPOST -d"{\"id\":2,\"jsonrpc\":\"2.0\",\"method\":\"evm_mine\",\"params\":[]}" $ETHEREUM_HOST > /dev/null
 
 echo "Starting nginx..."
 nginx &


### PR DESCRIPTION
Seems like we don't install cast as part of our foundry installation, so we just run good old curl instead.