### PR TITLE
[DO_NOT_MERGE] feat: optimizing `private_set.nr`

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/note/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/mod.nr
@@ -7,3 +7,4 @@ mod note_interface;
 mod note_viewer_options;
 mod utils;
 mod note_emission;
+mod note_and_hash;

--- a/noir-projects/aztec-nr/aztec/src/note/note_and_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_and_hash.nr
@@ -1,6 +1,9 @@
-use crate::note::note_interface::NoteInterface;
-
+/// When obtaining notes via `get_notes(...)` a note hash is computed for each note when constraining it (and a read
+/// request is created and passed to kernels). This same note hash (called note_hash_for_read_request) is needed when
+/// removing notes. Since computing this hash is expensive and since it is needed when removing a note we return it
+/// from the `get_notes(...)` function. The purpose of this struct is to couple the note and the note hash and make it
+/// easier to pass these values around.
 struct NoteAndHash<Note> {
    note: Note,
-   hash: Field,
+   hash: Field, // (note_hash_for_read_request)
 }

--- a/noir-projects/aztec-nr/aztec/src/note/note_and_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_and_hash.nr
@@ -1,0 +1,6 @@
+use crate::note::note_interface::NoteInterface;
+
+struct NoteAndHash<Note> {
+   note: Note,
+   hash: Field,
+}

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
@@ -108,6 +108,14 @@ pub fn get_notes<Note, let N: u32, let M: u32, FILTER_ARGS>(
     storage_slot: Field,
     options: NoteGetterOptions<Note, N, M, FILTER_ARGS>
 ) -> BoundedVec<Note, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> where Note: NoteInterface<N, M> + Eq {
+    get_notes_and_note_hashes(context, storage_slot, options).0
+}
+
+pub fn get_notes_and_note_hashes<Note, let N: u32, let M: u32, FILTER_ARGS>(
+    context: &mut PrivateContext,
+    storage_slot: Field,
+    options: NoteGetterOptions<Note, N, M, FILTER_ARGS>
+) -> (BoundedVec<Note, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>, BoundedVec<Field, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>) where Note: NoteInterface<N, M> + Eq {
     let opt_notes = get_notes_internal(storage_slot, options);
 
     constrain_get_notes_internal(context, storage_slot, opt_notes, options)
@@ -118,7 +126,7 @@ fn constrain_get_notes_internal<Note, let N: u32, let M: u32, FILTER_ARGS>(
     storage_slot: Field,
     opt_notes: [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
     options: NoteGetterOptions<Note, N, M, FILTER_ARGS>
-) -> BoundedVec<Note, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> where Note: NoteInterface<N, M> + Eq {
+) -> (BoundedVec<Note, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>, BoundedVec<Field, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>) where Note: NoteInterface<N, M> + Eq {
     // The filter is applied first to avoid pushing note read requests for notes we're not interested in. Note that
     // while the filter function can technically mutate the contents of the notes (as opposed to simply removing some),
     // the private kernel will later validate that these note actually exist, so transformations would cause for that
@@ -128,6 +136,7 @@ fn constrain_get_notes_internal<Note, let N: u32, let M: u32, FILTER_ARGS>(
     let filtered_notes = filter_fn(opt_notes, filter_args);
 
     let notes = crate::utils::collapse(filtered_notes);
+    let mut note_hashes = BoundedVec::new();
 
     // We have now collapsed the sparse array of Options into a BoundedVec. This is a more ergonomic type and also
     // results in reduced gate counts when setting a limit value, since we guarantee that the limit is an upper bound
@@ -150,10 +159,11 @@ fn constrain_get_notes_internal<Note, let N: u32, let M: u32, FILTER_ARGS>(
             // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1410): test to ensure
             // failure if malicious oracle injects 0 nonce here for a "pre-existing" note.
             context.push_note_hash_read_request(note_hash_for_read_request);
+            note_hashes.push(note_hash_for_read_request);
         };
     }
 
-    notes
+    (notes, note_hashes)
 }
 
 unconstrained fn get_note_internal<Note, let N: u32, let M: u32>(storage_slot: Field) -> Note where Note: NoteInterface<N, M> {

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
@@ -107,14 +107,6 @@ pub fn get_notes<Note, let N: u32, let M: u32, FILTER_ARGS>(
     context: &mut PrivateContext,
     storage_slot: Field,
     options: NoteGetterOptions<Note, N, M, FILTER_ARGS>
-) -> BoundedVec<Note, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> where Note: NoteInterface<N, M> + Eq {
-    get_notes_and_hashes(context, storage_slot, options).map(|note_and_hash: NoteAndHash<Note>| note_and_hash.note)
-}
-
-pub fn get_notes_and_hashes<Note, let N: u32, let M: u32, FILTER_ARGS>(
-    context: &mut PrivateContext,
-    storage_slot: Field,
-    options: NoteGetterOptions<Note, N, M, FILTER_ARGS>
 ) -> BoundedVec<NoteAndHash<Note>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> where Note: NoteInterface<N, M> + Eq {
     let opt_notes = get_notes_internal(storage_slot, options);
 

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
@@ -3,7 +3,7 @@ use crate::context::PrivateContext;
 use crate::note::{
     constants::{GET_NOTE_ORACLE_RETURN_LENGTH, MAX_NOTES_PER_PAGE, VIEW_NOTE_ORACLE_RETURN_LENGTH},
     note_getter_options::{NoteGetterOptions, Select, Sort, SortOrder, Comparator, NoteStatus, PropertySelector},
-    note_interface::NoteInterface, note_viewer_options::NoteViewerOptions,
+    note_interface::NoteInterface, note_and_hash::NoteAndHash, note_viewer_options::NoteViewerOptions,
     utils::compute_note_hash_for_read_request
 };
 use crate::oracle;
@@ -108,14 +108,14 @@ pub fn get_notes<Note, let N: u32, let M: u32, FILTER_ARGS>(
     storage_slot: Field,
     options: NoteGetterOptions<Note, N, M, FILTER_ARGS>
 ) -> BoundedVec<Note, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> where Note: NoteInterface<N, M> + Eq {
-    get_notes_and_note_hashes(context, storage_slot, options).0
+    get_notes_and_hashes(context, storage_slot, options).map(|note_and_hash: NoteAndHash<Note>| note_and_hash.note)
 }
 
-pub fn get_notes_and_note_hashes<Note, let N: u32, let M: u32, FILTER_ARGS>(
+pub fn get_notes_and_hashes<Note, let N: u32, let M: u32, FILTER_ARGS>(
     context: &mut PrivateContext,
     storage_slot: Field,
     options: NoteGetterOptions<Note, N, M, FILTER_ARGS>
-) -> (BoundedVec<Note, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>, BoundedVec<Field, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>) where Note: NoteInterface<N, M> + Eq {
+) -> BoundedVec<NoteAndHash<Note>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> where Note: NoteInterface<N, M> + Eq {
     let opt_notes = get_notes_internal(storage_slot, options);
 
     constrain_get_notes_internal(context, storage_slot, opt_notes, options)
@@ -126,7 +126,7 @@ fn constrain_get_notes_internal<Note, let N: u32, let M: u32, FILTER_ARGS>(
     storage_slot: Field,
     opt_notes: [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
     options: NoteGetterOptions<Note, N, M, FILTER_ARGS>
-) -> (BoundedVec<Note, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>, BoundedVec<Field, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>) where Note: NoteInterface<N, M> + Eq {
+) -> BoundedVec<NoteAndHash<Note>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> where Note: NoteInterface<N, M> + Eq {
     // The filter is applied first to avoid pushing note read requests for notes we're not interested in. Note that
     // while the filter function can technically mutate the contents of the notes (as opposed to simply removing some),
     // the private kernel will later validate that these note actually exist, so transformations would cause for that
@@ -136,7 +136,7 @@ fn constrain_get_notes_internal<Note, let N: u32, let M: u32, FILTER_ARGS>(
     let filtered_notes = filter_fn(opt_notes, filter_args);
 
     let notes = crate::utils::collapse(filtered_notes);
-    let mut note_hashes = BoundedVec::new();
+    let mut note_and_hashes = BoundedVec::new();
 
     // We have now collapsed the sparse array of Options into a BoundedVec. This is a more ergonomic type and also
     // results in reduced gate counts when setting a limit value, since we guarantee that the limit is an upper bound
@@ -159,11 +159,11 @@ fn constrain_get_notes_internal<Note, let N: u32, let M: u32, FILTER_ARGS>(
             // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1410): test to ensure
             // failure if malicious oracle injects 0 nonce here for a "pre-existing" note.
             context.push_note_hash_read_request(note_hash_for_read_request);
-            note_hashes.push(note_hash_for_read_request);
+            note_and_hashes.push(NoteAndHash { note, hash: note_hash_for_read_request });
         };
     }
 
-    (notes, note_hashes)
+    note_and_hashes
 }
 
 unconstrained fn get_note_internal<Note, let N: u32, let M: u32>(storage_slot: Field) -> Note where Note: NoteInterface<N, M> {

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
@@ -136,7 +136,7 @@ fn constrain_get_notes_internal<Note, let N: u32, let M: u32, FILTER_ARGS>(
     let filtered_notes = filter_fn(opt_notes, filter_args);
 
     let notes = crate::utils::collapse(filtered_notes);
-    let mut note_and_hashes = BoundedVec::new();
+    let mut notes_and_hashes = BoundedVec::new();
 
     // We have now collapsed the sparse array of Options into a BoundedVec. This is a more ergonomic type and also
     // results in reduced gate counts when setting a limit value, since we guarantee that the limit is an upper bound
@@ -159,11 +159,11 @@ fn constrain_get_notes_internal<Note, let N: u32, let M: u32, FILTER_ARGS>(
             // TODO(https://github.com/AztecProtocol/aztec-packages/issues/1410): test to ensure
             // failure if malicious oracle injects 0 nonce here for a "pre-existing" note.
             context.push_note_hash_read_request(note_hash_for_read_request);
-            note_and_hashes.push(NoteAndHash { note, hash: note_hash_for_read_request });
+            notes_and_hashes.push(NoteAndHash { note, hash: note_hash_for_read_request });
         };
     }
 
-    note_and_hashes
+    notes_and_hashes
 }
 
 unconstrained fn get_note_internal<Note, let N: u32, let M: u32>(storage_slot: Field) -> Note where Note: NoteInterface<N, M> {

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
@@ -1,246 +1,247 @@
-// use dep::protocol_types::constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL;
-// use crate::{
-//     context::PrivateContext,
-//     note::{
-//     note_header::NoteHeader,
-//     note_getter_options::{NoteGetterOptions, Sort, SortOrder, Comparator, PropertySelector},
-//     note_getter::constrain_get_notes_internal
-// },
-//     oracle::execution::get_contract_address
-// };
-// use dep::protocol_types::address::AztecAddress;
+use dep::protocol_types::constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL;
+use crate::{
+    context::PrivateContext,
+    note::{
+    note_header::NoteHeader,
+    note_getter_options::{NoteGetterOptions, Sort, SortOrder, Comparator, PropertySelector},
+    note_getter::constrain_get_notes_internal, note_and_hash::NoteAndHash
+},
+    oracle::execution::get_contract_address
+};
+use dep::protocol_types::address::AztecAddress;
 
-// use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_note::MockNote};
+use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_note::MockNote};
 
-// global storage_slot: Field = 42;
+global storage_slot: Field = 42;
 
-// fn setup() -> TestEnvironment {
-//     TestEnvironment::new()
-// }
+fn setup() -> TestEnvironment {
+    TestEnvironment::new()
+}
 
-// fn build_valid_note(value: Field) -> MockNote {
-//     MockNote::new(value).contract_address(get_contract_address()).storage_slot(storage_slot).build()
-// }
+fn build_valid_note(value: Field) -> MockNote {
+    MockNote::new(value).contract_address(get_contract_address()).storage_slot(storage_slot).build()
+}
 
-// fn assert_equivalent_vec_and_array<T, let N: u32>(
-//     vec: BoundedVec<T, N>,
-//     arr: [Option<T>; N]
-// ) where T: Eq {
-//     let mut count = 0;
+fn assert_equivalent_vec_and_array<T, let N: u32>(
+    vec: BoundedVec<T, N>,
+    arr: [Option<T>; N]
+) where T: Eq {
+    let mut count = 0;
 
-//     for i in 0..N {
-//         if arr[i].is_some() {
-//             assert_eq(arr[i].unwrap(), vec.get(count));
-//             count += 1;
-//         }
-//     }
+    for i in 0..N {
+        if arr[i].is_some() {
+            assert_eq(arr[i].unwrap(), vec.get(count));
+            count += 1;
+        }
+    }
 
-//     assert_eq(count, vec.len());
-// }
+    assert_eq(count, vec.len());
+}
 
-// #[test]
-// fn processes_single_note() {
-//     let mut env = setup();
-//     let mut context = env.private();
+#[test]
+fn processes_single_note() {
+    let mut env = setup();
+    let mut context = env.private();
 
-//     let mut notes_to_constrain = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-//     notes_to_constrain[0] = Option::some(build_valid_note(13));
+    let mut notes_to_constrain = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+    notes_to_constrain[0] = Option::some(build_valid_note(13));
 
-//     let options = NoteGetterOptions::new();
-//     let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
-//     let notes = returned_notes_and_hashes.map(|note_and_hash| note_and_hash.note);
+    let options = NoteGetterOptions::new();
+    let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
+    let returned_notes = returned_notes_and_hashes.map(|note_and_hash: NoteAndHash<MockNote>| note_and_hash.note);
 
-//     assert_equivalent_vec_and_array(notes, notes_to_constrain);
-//     assert_eq(context.note_hash_read_requests.len(), 1);
-// }
+    assert_equivalent_vec_and_array(returned_notes, notes_to_constrain);
+    assert_eq(context.note_hash_read_requests.len(), 1);
+}
 
-// #[test]
-// fn processes_many_notes() {
-//     let mut env = setup();
-//     let mut context = env.private();
+#[test]
+fn processes_many_notes() {
+    let mut env = setup();
+    let mut context = env.private();
 
-//     let mut notes_to_constrain = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-//     notes_to_constrain[0] = Option::some(build_valid_note(13));
-//     notes_to_constrain[1] = Option::some(build_valid_note(19));
+    let mut notes_to_constrain = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+    notes_to_constrain[0] = Option::some(build_valid_note(13));
+    notes_to_constrain[1] = Option::some(build_valid_note(19));
 
-//     let options: NoteGetterOptions<MockNote, 1, 96, Field> = NoteGetterOptions::new();
-//     let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
-//     let notes = returned_notes_and_hashes.map(|note_and_hash| note_and_hash.note);
+    let options: NoteGetterOptions<MockNote, 1, 96, Field> = NoteGetterOptions::new();
+    let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
+    let returned_notes = returned_notes_and_hashes.map(|note_and_hash: NoteAndHash<MockNote>| note_and_hash.note);
 
-//     assert_equivalent_vec_and_array(notes, notes_to_constrain);
-//     assert_eq(context.note_hash_read_requests.len(), 2);
-// }
+    assert_equivalent_vec_and_array(returned_notes, notes_to_constrain);
+    assert_eq(context.note_hash_read_requests.len(), 2);
+}
 
-// #[test]
-// fn collapses_notes_at_the_beginning_of_the_array() {
-//     let mut env = setup();
-//     let mut context = env.private();
+#[test]
+fn collapses_notes_at_the_beginning_of_the_array() {
+    let mut env = setup();
+    let mut context = env.private();
 
-//     let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-//     opt_notes[1] = Option::some(build_valid_note(0));
-//     opt_notes[2] = Option::some(build_valid_note(1));
-//     opt_notes[3] = Option::some(build_valid_note(2));
-//     opt_notes[5] = Option::some(build_valid_note(3));
-//     opt_notes[8] = Option::some(build_valid_note(4));
-//     opt_notes[13] = Option::some(build_valid_note(5));
+    let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+    opt_notes[1] = Option::some(build_valid_note(0));
+    opt_notes[2] = Option::some(build_valid_note(1));
+    opt_notes[3] = Option::some(build_valid_note(2));
+    opt_notes[5] = Option::some(build_valid_note(3));
+    opt_notes[8] = Option::some(build_valid_note(4));
+    opt_notes[13] = Option::some(build_valid_note(5));
 
-//     let options = NoteGetterOptions::new();
-//     let (returned_notes, _) = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+    let options = NoteGetterOptions::new();
+    let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+    let returned_notes = returned_notes_and_hashes.map(|note_and_hash: NoteAndHash<MockNote>| note_and_hash.note);
 
-//     let mut expected = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-//     expected[0] = Option::some(build_valid_note(0));
-//     expected[1] = Option::some(build_valid_note(1));
-//     expected[2] = Option::some(build_valid_note(2));
-//     expected[3] = Option::some(build_valid_note(3));
-//     expected[4] = Option::some(build_valid_note(4));
-//     expected[5] = Option::some(build_valid_note(5));
+    let mut expected = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+    expected[0] = Option::some(build_valid_note(0));
+    expected[1] = Option::some(build_valid_note(1));
+    expected[2] = Option::some(build_valid_note(2));
+    expected[3] = Option::some(build_valid_note(3));
+    expected[4] = Option::some(build_valid_note(4));
+    expected[5] = Option::some(build_valid_note(5));
 
-//     assert_equivalent_vec_and_array(returned_notes, expected);
-// }
+    assert_equivalent_vec_and_array(returned_notes, expected);
+}
 
-// fn can_return_zero_notes() {
-//     let mut env = setup();
-//     let mut context = env.private();
+fn can_return_zero_notes() {
+    let mut env = setup();
+    let mut context = env.private();
 
-//     let opt_notes: [Option<MockNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+    let opt_notes: [Option<MockNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
 
-//     let options = NoteGetterOptions::new();
-//     let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+    let options = NoteGetterOptions::new();
+    let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
 
-//     assert_eq(returned_notes_and_hashes.len(), 0);
-// }
+    assert_eq(returned_notes_and_hashes.len(), 0);
+}
 
-// #[test(should_fail_with="Got more notes than limit.")]
-// fn rejects_mote_notes_than_limit() {
-//     let mut env = setup();
-//     let mut context = env.private();
+#[test(should_fail_with="Got more notes than limit.")]
+fn rejects_mote_notes_than_limit() {
+    let mut env = setup();
+    let mut context = env.private();
 
-//     let mut opt_notes: [Option<MockNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-//     opt_notes[1] = Option::some(build_valid_note(0));
-//     opt_notes[2] = Option::some(build_valid_note(1));
-//     opt_notes[3] = Option::some(build_valid_note(2));
+    let mut opt_notes: [Option<MockNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+    opt_notes[1] = Option::some(build_valid_note(0));
+    opt_notes[2] = Option::some(build_valid_note(1));
+    opt_notes[3] = Option::some(build_valid_note(2));
 
-//     let mut options = NoteGetterOptions::new();
-//     options = options.set_limit(2);
-//     let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
-// }
+    let mut options = NoteGetterOptions::new();
+    options = options.set_limit(2);
+    let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+}
 
-// #[test]
-// fn applies_filter_before_constraining() {
-//     let mut env = setup();
-//     let mut context = env.private();
+#[test]
+fn applies_filter_before_constraining() {
+    let mut env = setup();
+    let mut context = env.private();
 
-//     let mut notes_to_constrain = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-//     let invalid_note = MockNote::new(13).build(); // This note does not have the correct address or storage slot
-//     notes_to_constrain[0] = Option::some(invalid_note);
-//     notes_to_constrain[1] = Option::some(build_valid_note(42));
+    let mut notes_to_constrain = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+    let invalid_note = MockNote::new(13).build(); // This note does not have the correct address or storage slot
+    notes_to_constrain[0] = Option::some(invalid_note);
+    notes_to_constrain[1] = Option::some(build_valid_note(42));
 
-//     let filter_fn = |opt_notes: [Option<MockNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], _| {
-//         let mut selected = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+    let filter_fn = |opt_notes: [Option<MockNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], _| {
+        let mut selected = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
 
-//         for i in 0..opt_notes.len() {
-//             // This will filter the notes so that only the valid one remains
-//             if opt_notes[i].is_some() & (opt_notes[i].unwrap_unchecked().value == 42) {
-//                 selected[i] = opt_notes[i];
-//             }
-//         }
-//         selected
-//     };
+        for i in 0..opt_notes.len() {
+            // This will filter the notes so that only the valid one remains
+            if opt_notes[i].is_some() & (opt_notes[i].unwrap_unchecked().value == 42) {
+                selected[i] = opt_notes[i];
+            }
+        }
+        selected
+    };
 
-//     let options = NoteGetterOptions::with_filter(filter_fn, ());
-//     let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
-//     let returned_notes = returned_notes_and_hashes.map(|note_and_hash| note_and_hash.note);
+    let options = NoteGetterOptions::with_filter(filter_fn, ());
+    let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
+    let returned_notes = returned_notes_and_hashes.map(|note_and_hash: NoteAndHash<MockNote>| note_and_hash.note);
 
-//     // Only the note with value 42 should be returned, and moved to the beginning of the array. The other notes were not
-//     // constrained, and hence validation did not fail.
-//     let mut expected = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-//     expected[0] = Option::some(build_valid_note(42));
+    // Only the note with value 42 should be returned, and moved to the beginning of the array. The other notes were not
+    // constrained, and hence validation did not fail.
+    let mut expected = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+    expected[0] = Option::some(build_valid_note(42));
 
-//     assert_equivalent_vec_and_array(returned_notes, expected);
-//     assert_eq(context.note_hash_read_requests.len(), 1);
-// }
+    assert_equivalent_vec_and_array(returned_notes, expected);
+    assert_eq(context.note_hash_read_requests.len(), 1);
+}
 
-// #[test(should_fail_with="Mismatch note header contract address.")]
-// fn rejects_mismatched_address() {
-//     let mut env = setup();
-//     let mut context = env.private();
+#[test(should_fail_with="Mismatch note header contract address.")]
+fn rejects_mismatched_address() {
+    let mut env = setup();
+    let mut context = env.private();
 
-//     let note = MockNote::new(1).storage_slot(storage_slot).build(); // We're not setting the right contract address
+    let note = MockNote::new(1).storage_slot(storage_slot).build(); // We're not setting the right contract address
 
-//     let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-//     opt_notes[0] = Option::some(note);
+    let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+    opt_notes[0] = Option::some(note);
 
-//     let mut options = NoteGetterOptions::new();
-//     let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
-// }
+    let mut options = NoteGetterOptions::new();
+    let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+}
 
-// #[test(should_fail_with="Mismatch note header storage slot.")]
-// fn rejects_mismatched_storage_slot() {
-//     let mut env = setup();
-//     let mut context = env.private();
+#[test(should_fail_with="Mismatch note header storage slot.")]
+fn rejects_mismatched_storage_slot() {
+    let mut env = setup();
+    let mut context = env.private();
 
-//     let note = MockNote::new(1).contract_address(get_contract_address()).build(); // We're not setting the right storage slot
+    let note = MockNote::new(1).contract_address(get_contract_address()).build(); // We're not setting the right storage slot
 
-//     let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-//     opt_notes[0] = Option::some(note);
+    let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+    opt_notes[0] = Option::some(note);
 
-//     let mut options = NoteGetterOptions::new();
-//     let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
-// }
+    let mut options = NoteGetterOptions::new();
+    let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+}
 
-// #[test(should_fail_with="Mismatch return note field.")]
-// fn rejects_mismatched_selector() {
-//     let mut env = setup();
-//     let mut context = env.private();
+#[test(should_fail_with="Mismatch return note field.")]
+fn rejects_mismatched_selector() {
+    let mut env = setup();
+    let mut context = env.private();
 
-//     let value = 10;
-//     let note = build_valid_note(value);
+    let value = 10;
+    let note = build_valid_note(value);
 
-//     let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-//     opt_notes[0] = Option::some(note);
+    let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+    opt_notes[0] = Option::some(note);
 
-//     let mut options = NoteGetterOptions::new();
-//     options = options.select(
-//             PropertySelector { index: 0, offset: 0, length: 32 },
-//             value + 1,
-//             Option::some(Comparator.EQ)
-//         );
+    let mut options = NoteGetterOptions::new();
+    options = options.select(
+            PropertySelector { index: 0, offset: 0, length: 32 },
+            value + 1,
+            Option::some(Comparator.EQ)
+        );
 
-//     let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
-// }
+    let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+}
 
-// #[test(should_fail_with="Return notes not sorted in descending order.")]
-// fn rejects_mismatched_desc_sort_order() {
-//     let mut env = setup();
-//     let mut context = env.private();
+#[test(should_fail_with="Return notes not sorted in descending order.")]
+fn rejects_mismatched_desc_sort_order() {
+    let mut env = setup();
+    let mut context = env.private();
 
-//     let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-//     // Notes in ascending order
-//     opt_notes[0] = Option::some(build_valid_note(1));
-//     opt_notes[1] = Option::some(build_valid_note(2));
+    let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+    // Notes in ascending order
+    opt_notes[0] = Option::some(build_valid_note(1));
+    opt_notes[1] = Option::some(build_valid_note(2));
 
-//     let mut options = NoteGetterOptions::new();
-//     options = options.sort(
-//             PropertySelector { index: 0, offset: 0, length: 32 },
-//             SortOrder.DESC
-//         );
-//     let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
-// }
+    let mut options = NoteGetterOptions::new();
+    options = options.sort(
+            PropertySelector { index: 0, offset: 0, length: 32 },
+            SortOrder.DESC
+        );
+    let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+}
 
-// #[test(should_fail_with="Return notes not sorted in ascending order.")]
-// fn rejects_mismatched_asc_sort_order() {
-//     let mut env = setup();
-//     let mut context = env.private();
+#[test(should_fail_with="Return notes not sorted in ascending order.")]
+fn rejects_mismatched_asc_sort_order() {
+    let mut env = setup();
+    let mut context = env.private();
 
-//     let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-//     // Notes in descending order
-//     opt_notes[0] = Option::some(build_valid_note(2));
-//     opt_notes[1] = Option::some(build_valid_note(1));
+    let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+    // Notes in descending order
+    opt_notes[0] = Option::some(build_valid_note(2));
+    opt_notes[1] = Option::some(build_valid_note(1));
 
-//     let mut options = NoteGetterOptions::new();
-//     options = options.sort(
-//             PropertySelector { index: 0, offset: 0, length: 32 },
-//             SortOrder.ASC
-//         );
-//     let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
-// }
+    let mut options = NoteGetterOptions::new();
+    options = options.sort(
+            PropertySelector { index: 0, offset: 0, length: 32 },
+            SortOrder.ASC
+        );
+    let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+}

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
@@ -47,9 +47,9 @@ fn processes_single_note() {
     notes_to_constrain[0] = Option::some(build_valid_note(13));
 
     let options = NoteGetterOptions::new();
-    let returned = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
+    let (returned_notes, _) = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
 
-    assert_equivalent_vec_and_array(returned, notes_to_constrain);
+    assert_equivalent_vec_and_array(returned_notes, notes_to_constrain);
     assert_eq(context.note_hash_read_requests.len(), 1);
 }
 
@@ -63,9 +63,9 @@ fn processes_many_notes() {
     notes_to_constrain[1] = Option::some(build_valid_note(19));
 
     let options = NoteGetterOptions::new();
-    let returned = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
+    let (returned_notes, _) = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
 
-    assert_equivalent_vec_and_array(returned, notes_to_constrain);
+    assert_equivalent_vec_and_array(returned_notes, notes_to_constrain);
     assert_eq(context.note_hash_read_requests.len(), 2);
 }
 
@@ -83,7 +83,7 @@ fn collapses_notes_at_the_beginning_of_the_array() {
     opt_notes[13] = Option::some(build_valid_note(5));
 
     let options = NoteGetterOptions::new();
-    let returned = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+    let (returned_notes, _) = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
 
     let mut expected = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
     expected[0] = Option::some(build_valid_note(0));
@@ -93,7 +93,7 @@ fn collapses_notes_at_the_beginning_of_the_array() {
     expected[4] = Option::some(build_valid_note(4));
     expected[5] = Option::some(build_valid_note(5));
 
-    assert_equivalent_vec_and_array(returned, expected);
+    assert_equivalent_vec_and_array(returned_notes, expected);
 }
 
 fn can_return_zero_notes() {
@@ -103,8 +103,9 @@ fn can_return_zero_notes() {
     let opt_notes: [Option<MockNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
 
     let options = NoteGetterOptions::new();
-    let returned = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
-    assert_eq(returned.len(), 0);
+    let (notes, note_hashes) = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+    assert_eq(notes.len(), 0);
+    assert_eq(note_hashes.len(), 0);
 }
 
 #[test(should_fail_with="Got more notes than limit.")]
@@ -145,14 +146,14 @@ fn applies_filter_before_constraining() {
     };
 
     let options = NoteGetterOptions::with_filter(filter_fn, ());
-    let returned = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
+    let (returned_notes, _) = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
 
     // Only the note with value 42 should be returned, and moved to the beginning of the array. The other notes were not
     // constrained, and hence validation did not fail.
     let mut expected = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
     expected[0] = Option::some(build_valid_note(42));
 
-    assert_equivalent_vec_and_array(returned, expected);
+    assert_equivalent_vec_and_array(returned_notes, expected);
     assert_eq(context.note_hash_read_requests.len(), 1);
 }
 

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
@@ -47,9 +47,10 @@ fn processes_single_note() {
     notes_to_constrain[0] = Option::some(build_valid_note(13));
 
     let options = NoteGetterOptions::new();
-    let (returned_notes, _) = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
+    let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
+    let notes = returned_notes_and_hashes.map(|note_and_hash| note_and_hash.note);
 
-    assert_equivalent_vec_and_array(returned_notes, notes_to_constrain);
+    assert_equivalent_vec_and_array(notes, notes_to_constrain);
     assert_eq(context.note_hash_read_requests.len(), 1);
 }
 
@@ -62,10 +63,11 @@ fn processes_many_notes() {
     notes_to_constrain[0] = Option::some(build_valid_note(13));
     notes_to_constrain[1] = Option::some(build_valid_note(19));
 
-    let options = NoteGetterOptions::new();
-    let (returned_notes, _) = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
+    let options: NoteGetterOptions<MockNote, 1, 96, Field> = NoteGetterOptions::new();
+    let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
+    let notes = returned_notes_and_hashes.map(|note_and_hash| note_and_hash.note);
 
-    assert_equivalent_vec_and_array(returned_notes, notes_to_constrain);
+    assert_equivalent_vec_and_array(notes, notes_to_constrain);
     assert_eq(context.note_hash_read_requests.len(), 2);
 }
 
@@ -103,9 +105,9 @@ fn can_return_zero_notes() {
     let opt_notes: [Option<MockNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
 
     let options = NoteGetterOptions::new();
-    let (notes, note_hashes) = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
-    assert_eq(notes.len(), 0);
-    assert_eq(note_hashes.len(), 0);
+    let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+
+    assert_eq(returned_notes_and_hashes.len(), 0);
 }
 
 #[test(should_fail_with="Got more notes than limit.")]
@@ -146,7 +148,8 @@ fn applies_filter_before_constraining() {
     };
 
     let options = NoteGetterOptions::with_filter(filter_fn, ());
-    let (returned_notes, _) = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
+    let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
+    let returned_notes = returned_notes_and_hashes.map(|note_and_hash| note_and_hash.note);
 
     // Only the note with value 42 should be returned, and moved to the beginning of the array. The other notes were not
     // constrained, and hence validation did not fail.

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
@@ -1,246 +1,246 @@
-use dep::protocol_types::constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL;
-use crate::{
-    context::PrivateContext,
-    note::{
-    note_header::NoteHeader,
-    note_getter_options::{NoteGetterOptions, Sort, SortOrder, Comparator, PropertySelector},
-    note_getter::constrain_get_notes_internal
-},
-    oracle::execution::get_contract_address
-};
-use dep::protocol_types::address::AztecAddress;
+// use dep::protocol_types::constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL;
+// use crate::{
+//     context::PrivateContext,
+//     note::{
+//     note_header::NoteHeader,
+//     note_getter_options::{NoteGetterOptions, Sort, SortOrder, Comparator, PropertySelector},
+//     note_getter::constrain_get_notes_internal
+// },
+//     oracle::execution::get_contract_address
+// };
+// use dep::protocol_types::address::AztecAddress;
 
-use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_note::MockNote};
+// use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_note::MockNote};
 
-global storage_slot: Field = 42;
+// global storage_slot: Field = 42;
 
-fn setup() -> TestEnvironment {
-    TestEnvironment::new()
-}
+// fn setup() -> TestEnvironment {
+//     TestEnvironment::new()
+// }
 
-fn build_valid_note(value: Field) -> MockNote {
-    MockNote::new(value).contract_address(get_contract_address()).storage_slot(storage_slot).build()
-}
+// fn build_valid_note(value: Field) -> MockNote {
+//     MockNote::new(value).contract_address(get_contract_address()).storage_slot(storage_slot).build()
+// }
 
-fn assert_equivalent_vec_and_array<T, let N: u32>(
-    vec: BoundedVec<T, N>,
-    arr: [Option<T>; N]
-) where T: Eq {
-    let mut count = 0;
+// fn assert_equivalent_vec_and_array<T, let N: u32>(
+//     vec: BoundedVec<T, N>,
+//     arr: [Option<T>; N]
+// ) where T: Eq {
+//     let mut count = 0;
 
-    for i in 0..N {
-        if arr[i].is_some() {
-            assert_eq(arr[i].unwrap(), vec.get(count));
-            count += 1;
-        }
-    }
+//     for i in 0..N {
+//         if arr[i].is_some() {
+//             assert_eq(arr[i].unwrap(), vec.get(count));
+//             count += 1;
+//         }
+//     }
 
-    assert_eq(count, vec.len());
-}
+//     assert_eq(count, vec.len());
+// }
 
-#[test]
-fn processes_single_note() {
-    let mut env = setup();
-    let mut context = env.private();
+// #[test]
+// fn processes_single_note() {
+//     let mut env = setup();
+//     let mut context = env.private();
 
-    let mut notes_to_constrain = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-    notes_to_constrain[0] = Option::some(build_valid_note(13));
+//     let mut notes_to_constrain = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+//     notes_to_constrain[0] = Option::some(build_valid_note(13));
 
-    let options = NoteGetterOptions::new();
-    let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
-    let notes = returned_notes_and_hashes.map(|note_and_hash| note_and_hash.note);
+//     let options = NoteGetterOptions::new();
+//     let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
+//     let notes = returned_notes_and_hashes.map(|note_and_hash| note_and_hash.note);
 
-    assert_equivalent_vec_and_array(notes, notes_to_constrain);
-    assert_eq(context.note_hash_read_requests.len(), 1);
-}
+//     assert_equivalent_vec_and_array(notes, notes_to_constrain);
+//     assert_eq(context.note_hash_read_requests.len(), 1);
+// }
 
-#[test]
-fn processes_many_notes() {
-    let mut env = setup();
-    let mut context = env.private();
+// #[test]
+// fn processes_many_notes() {
+//     let mut env = setup();
+//     let mut context = env.private();
 
-    let mut notes_to_constrain = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-    notes_to_constrain[0] = Option::some(build_valid_note(13));
-    notes_to_constrain[1] = Option::some(build_valid_note(19));
+//     let mut notes_to_constrain = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+//     notes_to_constrain[0] = Option::some(build_valid_note(13));
+//     notes_to_constrain[1] = Option::some(build_valid_note(19));
 
-    let options: NoteGetterOptions<MockNote, 1, 96, Field> = NoteGetterOptions::new();
-    let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
-    let notes = returned_notes_and_hashes.map(|note_and_hash| note_and_hash.note);
+//     let options: NoteGetterOptions<MockNote, 1, 96, Field> = NoteGetterOptions::new();
+//     let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
+//     let notes = returned_notes_and_hashes.map(|note_and_hash| note_and_hash.note);
 
-    assert_equivalent_vec_and_array(notes, notes_to_constrain);
-    assert_eq(context.note_hash_read_requests.len(), 2);
-}
+//     assert_equivalent_vec_and_array(notes, notes_to_constrain);
+//     assert_eq(context.note_hash_read_requests.len(), 2);
+// }
 
-#[test]
-fn collapses_notes_at_the_beginning_of_the_array() {
-    let mut env = setup();
-    let mut context = env.private();
+// #[test]
+// fn collapses_notes_at_the_beginning_of_the_array() {
+//     let mut env = setup();
+//     let mut context = env.private();
 
-    let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-    opt_notes[1] = Option::some(build_valid_note(0));
-    opt_notes[2] = Option::some(build_valid_note(1));
-    opt_notes[3] = Option::some(build_valid_note(2));
-    opt_notes[5] = Option::some(build_valid_note(3));
-    opt_notes[8] = Option::some(build_valid_note(4));
-    opt_notes[13] = Option::some(build_valid_note(5));
+//     let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+//     opt_notes[1] = Option::some(build_valid_note(0));
+//     opt_notes[2] = Option::some(build_valid_note(1));
+//     opt_notes[3] = Option::some(build_valid_note(2));
+//     opt_notes[5] = Option::some(build_valid_note(3));
+//     opt_notes[8] = Option::some(build_valid_note(4));
+//     opt_notes[13] = Option::some(build_valid_note(5));
 
-    let options = NoteGetterOptions::new();
-    let (returned_notes, _) = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+//     let options = NoteGetterOptions::new();
+//     let (returned_notes, _) = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
 
-    let mut expected = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-    expected[0] = Option::some(build_valid_note(0));
-    expected[1] = Option::some(build_valid_note(1));
-    expected[2] = Option::some(build_valid_note(2));
-    expected[3] = Option::some(build_valid_note(3));
-    expected[4] = Option::some(build_valid_note(4));
-    expected[5] = Option::some(build_valid_note(5));
+//     let mut expected = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+//     expected[0] = Option::some(build_valid_note(0));
+//     expected[1] = Option::some(build_valid_note(1));
+//     expected[2] = Option::some(build_valid_note(2));
+//     expected[3] = Option::some(build_valid_note(3));
+//     expected[4] = Option::some(build_valid_note(4));
+//     expected[5] = Option::some(build_valid_note(5));
 
-    assert_equivalent_vec_and_array(returned_notes, expected);
-}
+//     assert_equivalent_vec_and_array(returned_notes, expected);
+// }
 
-fn can_return_zero_notes() {
-    let mut env = setup();
-    let mut context = env.private();
+// fn can_return_zero_notes() {
+//     let mut env = setup();
+//     let mut context = env.private();
 
-    let opt_notes: [Option<MockNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+//     let opt_notes: [Option<MockNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
 
-    let options = NoteGetterOptions::new();
-    let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+//     let options = NoteGetterOptions::new();
+//     let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
 
-    assert_eq(returned_notes_and_hashes.len(), 0);
-}
+//     assert_eq(returned_notes_and_hashes.len(), 0);
+// }
 
-#[test(should_fail_with="Got more notes than limit.")]
-fn rejects_mote_notes_than_limit() {
-    let mut env = setup();
-    let mut context = env.private();
+// #[test(should_fail_with="Got more notes than limit.")]
+// fn rejects_mote_notes_than_limit() {
+//     let mut env = setup();
+//     let mut context = env.private();
 
-    let mut opt_notes: [Option<MockNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-    opt_notes[1] = Option::some(build_valid_note(0));
-    opt_notes[2] = Option::some(build_valid_note(1));
-    opt_notes[3] = Option::some(build_valid_note(2));
+//     let mut opt_notes: [Option<MockNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+//     opt_notes[1] = Option::some(build_valid_note(0));
+//     opt_notes[2] = Option::some(build_valid_note(1));
+//     opt_notes[3] = Option::some(build_valid_note(2));
 
-    let mut options = NoteGetterOptions::new();
-    options = options.set_limit(2);
-    let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
-}
+//     let mut options = NoteGetterOptions::new();
+//     options = options.set_limit(2);
+//     let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+// }
 
-#[test]
-fn applies_filter_before_constraining() {
-    let mut env = setup();
-    let mut context = env.private();
+// #[test]
+// fn applies_filter_before_constraining() {
+//     let mut env = setup();
+//     let mut context = env.private();
 
-    let mut notes_to_constrain = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-    let invalid_note = MockNote::new(13).build(); // This note does not have the correct address or storage slot
-    notes_to_constrain[0] = Option::some(invalid_note);
-    notes_to_constrain[1] = Option::some(build_valid_note(42));
+//     let mut notes_to_constrain = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+//     let invalid_note = MockNote::new(13).build(); // This note does not have the correct address or storage slot
+//     notes_to_constrain[0] = Option::some(invalid_note);
+//     notes_to_constrain[1] = Option::some(build_valid_note(42));
 
-    let filter_fn = |opt_notes: [Option<MockNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], _| {
-        let mut selected = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+//     let filter_fn = |opt_notes: [Option<MockNote>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], _| {
+//         let mut selected = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
 
-        for i in 0..opt_notes.len() {
-            // This will filter the notes so that only the valid one remains
-            if opt_notes[i].is_some() & (opt_notes[i].unwrap_unchecked().value == 42) {
-                selected[i] = opt_notes[i];
-            }
-        }
-        selected
-    };
+//         for i in 0..opt_notes.len() {
+//             // This will filter the notes so that only the valid one remains
+//             if opt_notes[i].is_some() & (opt_notes[i].unwrap_unchecked().value == 42) {
+//                 selected[i] = opt_notes[i];
+//             }
+//         }
+//         selected
+//     };
 
-    let options = NoteGetterOptions::with_filter(filter_fn, ());
-    let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
-    let returned_notes = returned_notes_and_hashes.map(|note_and_hash| note_and_hash.note);
+//     let options = NoteGetterOptions::with_filter(filter_fn, ());
+//     let returned_notes_and_hashes = constrain_get_notes_internal(&mut context, storage_slot, notes_to_constrain, options);
+//     let returned_notes = returned_notes_and_hashes.map(|note_and_hash| note_and_hash.note);
 
-    // Only the note with value 42 should be returned, and moved to the beginning of the array. The other notes were not
-    // constrained, and hence validation did not fail.
-    let mut expected = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-    expected[0] = Option::some(build_valid_note(42));
+//     // Only the note with value 42 should be returned, and moved to the beginning of the array. The other notes were not
+//     // constrained, and hence validation did not fail.
+//     let mut expected = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+//     expected[0] = Option::some(build_valid_note(42));
 
-    assert_equivalent_vec_and_array(returned_notes, expected);
-    assert_eq(context.note_hash_read_requests.len(), 1);
-}
+//     assert_equivalent_vec_and_array(returned_notes, expected);
+//     assert_eq(context.note_hash_read_requests.len(), 1);
+// }
 
-#[test(should_fail_with="Mismatch note header contract address.")]
-fn rejects_mismatched_address() {
-    let mut env = setup();
-    let mut context = env.private();
+// #[test(should_fail_with="Mismatch note header contract address.")]
+// fn rejects_mismatched_address() {
+//     let mut env = setup();
+//     let mut context = env.private();
 
-    let note = MockNote::new(1).storage_slot(storage_slot).build(); // We're not setting the right contract address
+//     let note = MockNote::new(1).storage_slot(storage_slot).build(); // We're not setting the right contract address
 
-    let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-    opt_notes[0] = Option::some(note);
+//     let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+//     opt_notes[0] = Option::some(note);
 
-    let mut options = NoteGetterOptions::new();
-    let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
-}
+//     let mut options = NoteGetterOptions::new();
+//     let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+// }
 
-#[test(should_fail_with="Mismatch note header storage slot.")]
-fn rejects_mismatched_storage_slot() {
-    let mut env = setup();
-    let mut context = env.private();
+// #[test(should_fail_with="Mismatch note header storage slot.")]
+// fn rejects_mismatched_storage_slot() {
+//     let mut env = setup();
+//     let mut context = env.private();
 
-    let note = MockNote::new(1).contract_address(get_contract_address()).build(); // We're not setting the right storage slot
+//     let note = MockNote::new(1).contract_address(get_contract_address()).build(); // We're not setting the right storage slot
 
-    let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-    opt_notes[0] = Option::some(note);
+//     let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+//     opt_notes[0] = Option::some(note);
 
-    let mut options = NoteGetterOptions::new();
-    let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
-}
+//     let mut options = NoteGetterOptions::new();
+//     let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+// }
 
-#[test(should_fail_with="Mismatch return note field.")]
-fn rejects_mismatched_selector() {
-    let mut env = setup();
-    let mut context = env.private();
+// #[test(should_fail_with="Mismatch return note field.")]
+// fn rejects_mismatched_selector() {
+//     let mut env = setup();
+//     let mut context = env.private();
 
-    let value = 10;
-    let note = build_valid_note(value);
+//     let value = 10;
+//     let note = build_valid_note(value);
 
-    let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-    opt_notes[0] = Option::some(note);
+//     let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+//     opt_notes[0] = Option::some(note);
 
-    let mut options = NoteGetterOptions::new();
-    options = options.select(
-            PropertySelector { index: 0, offset: 0, length: 32 },
-            value + 1,
-            Option::some(Comparator.EQ)
-        );
+//     let mut options = NoteGetterOptions::new();
+//     options = options.select(
+//             PropertySelector { index: 0, offset: 0, length: 32 },
+//             value + 1,
+//             Option::some(Comparator.EQ)
+//         );
 
-    let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
-}
+//     let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+// }
 
-#[test(should_fail_with="Return notes not sorted in descending order.")]
-fn rejects_mismatched_desc_sort_order() {
-    let mut env = setup();
-    let mut context = env.private();
+// #[test(should_fail_with="Return notes not sorted in descending order.")]
+// fn rejects_mismatched_desc_sort_order() {
+//     let mut env = setup();
+//     let mut context = env.private();
 
-    let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-    // Notes in ascending order
-    opt_notes[0] = Option::some(build_valid_note(1));
-    opt_notes[1] = Option::some(build_valid_note(2));
+//     let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+//     // Notes in ascending order
+//     opt_notes[0] = Option::some(build_valid_note(1));
+//     opt_notes[1] = Option::some(build_valid_note(2));
 
-    let mut options = NoteGetterOptions::new();
-    options = options.sort(
-            PropertySelector { index: 0, offset: 0, length: 32 },
-            SortOrder.DESC
-        );
-    let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
-}
+//     let mut options = NoteGetterOptions::new();
+//     options = options.sort(
+//             PropertySelector { index: 0, offset: 0, length: 32 },
+//             SortOrder.DESC
+//         );
+//     let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+// }
 
-#[test(should_fail_with="Return notes not sorted in ascending order.")]
-fn rejects_mismatched_asc_sort_order() {
-    let mut env = setup();
-    let mut context = env.private();
+// #[test(should_fail_with="Return notes not sorted in ascending order.")]
+// fn rejects_mismatched_asc_sort_order() {
+//     let mut env = setup();
+//     let mut context = env.private();
 
-    let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
-    // Notes in descending order
-    opt_notes[0] = Option::some(build_valid_note(2));
-    opt_notes[1] = Option::some(build_valid_note(1));
+//     let mut opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
+//     // Notes in descending order
+//     opt_notes[0] = Option::some(build_valid_note(2));
+//     opt_notes[1] = Option::some(build_valid_note(1));
 
-    let mut options = NoteGetterOptions::new();
-    options = options.sort(
-            PropertySelector { index: 0, offset: 0, length: 32 },
-            SortOrder.ASC
-        );
-    let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
-}
+//     let mut options = NoteGetterOptions::new();
+//     options = options.sort(
+//             PropertySelector { index: 0, offset: 0, length: 32 },
+//             SortOrder.ASC
+//         );
+//     let _ = constrain_get_notes_internal(&mut context, storage_slot, opt_notes, options);
+// }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
@@ -2,7 +2,7 @@ use dep::protocol_types::{constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, abis:
 use crate::context::{PrivateContext, PublicContext, UnconstrainedContext};
 use crate::note::{
     constants::MAX_NOTES_PER_PAGE, lifecycle::{create_note, create_note_hash_from_public, destroy_note},
-    note_getter::{get_notes_and_hashes, get_notes, view_notes}, note_getter_options::NoteGetterOptions,
+    note_getter::{get_notes, view_notes}, note_getter_options::NoteGetterOptions,
     note_header::NoteHeader, note_interface::NoteInterface, note_viewer_options::NoteViewerOptions,
     utils::compute_note_hash_for_read_request, note_emission::NoteEmission, note_and_hash::NoteAndHash
 };
@@ -54,17 +54,10 @@ impl<Note, let N: u32, let M: u32> PrivateSet<Note, &mut PrivateContext> where N
     pub fn get_notes<FILTER_ARGS>(
         self,
         options: NoteGetterOptions<Note, N, M, FILTER_ARGS>
-    ) -> BoundedVec<Note, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> {
+    ) -> BoundedVec<NoteAndHash<Note>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> {
         get_notes(self.context, self.storage_slot, options)
     }
     // docs:end:get_notes
-
-    pub fn get_notes_and_hashes<FILTER_ARGS>(
-        self,
-        options: NoteGetterOptions<Note, N, M, FILTER_ARGS>
-    ) -> BoundedVec<NoteAndHash<Note>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> {
-        get_notes_and_hashes(self.context, self.storage_slot, options)
-    }
 }
 
 impl<Note, let N: u32, let M: u32> PrivateSet<Note, UnconstrainedContext> where Note: NoteInterface<N, M> {

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
@@ -2,9 +2,9 @@ use dep::protocol_types::{constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, abis:
 use crate::context::{PrivateContext, PublicContext, UnconstrainedContext};
 use crate::note::{
     constants::MAX_NOTES_PER_PAGE, lifecycle::{create_note, create_note_hash_from_public, destroy_note},
-    note_getter::{get_notes, view_notes}, note_getter_options::NoteGetterOptions,
+    note_getter::{get_notes_and_hashes, view_notes}, note_getter_options::NoteGetterOptions,
     note_header::NoteHeader, note_interface::NoteInterface, note_viewer_options::NoteViewerOptions,
-    utils::compute_note_hash_for_read_request, note_emission::NoteEmission
+    utils::compute_note_hash_for_read_request, note_emission::NoteEmission, note_and_hash::NoteAndHash
 };
 use crate::state_vars::storage::Storage;
 
@@ -42,21 +42,20 @@ impl<Note, let N: u32, let M: u32> PrivateSet<Note, &mut PrivateContext> where N
     // docs:end:insert
 
     // docs:start:remove
-    pub fn remove(self, note: Note) {
-        let note_hash = compute_note_hash_for_read_request(note);
-        let has_been_read = self.context.note_hash_read_requests.any(|r: ReadRequest| r.value == note_hash);
+    pub fn remove(self, note_and_hash: NoteAndHash<Note>) {
+        let has_been_read = self.context.note_hash_read_requests.any(|r: ReadRequest| r.value == note_and_hash.hash);
         assert(has_been_read, "Can only remove a note that has been read from the set.");
 
-        destroy_note(self.context, note);
+        destroy_note(self.context, note_and_hash.note);
     }
     // docs:end:remove
 
     // docs:start:get_notes
-    pub fn get_notes<FILTER_ARGS>(
+    pub fn get_notes_and_hashes<FILTER_ARGS>(
         self,
         options: NoteGetterOptions<Note, N, M, FILTER_ARGS>
-    ) -> BoundedVec<Note, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> {
-        get_notes(self.context, self.storage_slot, options)
+    ) -> BoundedVec<NoteAndHash<Note>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> {
+        get_notes_and_hashes(self.context, self.storage_slot, options)
     }
     // docs:end:get_notes
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
@@ -4,7 +4,7 @@ use crate::note::{
     constants::MAX_NOTES_PER_PAGE, lifecycle::{create_note, create_note_hash_from_public, destroy_note},
     note_getter::{get_notes, view_notes}, note_getter_options::NoteGetterOptions,
     note_header::NoteHeader, note_interface::NoteInterface, note_viewer_options::NoteViewerOptions,
-    utils::compute_note_hash_for_read_request, note_emission::NoteEmission, note_and_hash::NoteAndHash
+    note_emission::NoteEmission, note_and_hash::NoteAndHash
 };
 use crate::state_vars::storage::Storage;
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
@@ -2,7 +2,7 @@ use dep::protocol_types::{constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, abis:
 use crate::context::{PrivateContext, PublicContext, UnconstrainedContext};
 use crate::note::{
     constants::MAX_NOTES_PER_PAGE, lifecycle::{create_note, create_note_hash_from_public, destroy_note},
-    note_getter::{get_notes_and_hashes, view_notes}, note_getter_options::NoteGetterOptions,
+    note_getter::{get_notes_and_hashes, get_notes, view_notes}, note_getter_options::NoteGetterOptions,
     note_header::NoteHeader, note_interface::NoteInterface, note_viewer_options::NoteViewerOptions,
     utils::compute_note_hash_for_read_request, note_emission::NoteEmission, note_and_hash::NoteAndHash
 };
@@ -51,13 +51,20 @@ impl<Note, let N: u32, let M: u32> PrivateSet<Note, &mut PrivateContext> where N
     // docs:end:remove
 
     // docs:start:get_notes
+    pub fn get_notes<FILTER_ARGS>(
+        self,
+        options: NoteGetterOptions<Note, N, M, FILTER_ARGS>
+    ) -> BoundedVec<Note, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> {
+        get_notes(self.context, self.storage_slot, options)
+    }
+    // docs:end:get_notes
+
     pub fn get_notes_and_hashes<FILTER_ARGS>(
         self,
         options: NoteGetterOptions<Note, N, M, FILTER_ARGS>
     ) -> BoundedVec<NoteAndHash<Note>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> {
         get_notes_and_hashes(self.context, self.storage_slot, options)
     }
-    // docs:end:get_notes
 }
 
 impl<Note, let N: u32, let M: u32> PrivateSet<Note, UnconstrainedContext> where Note: NoteInterface<N, M> {

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -41,20 +41,20 @@ impl<Context> EasyPrivateUint<&mut PrivateContext> {
 
         // docs:start:get_notes
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, subtrahend as Field);
-        let notes = self.set.get_notes(options);
+        let notes_and_hashes = self.set.get_notes_and_hashes(options);
         // docs:end:get_notes
 
         let mut minuend: u64 = 0;
         for i in 0..options.limit {
-            if i < notes.len() {
-                let note = notes.get_unchecked(i);
+            if i < notes_and_hashes.len() {
+                let note_and_hash = notes_and_hashes.get_unchecked(i);
 
                 // Removes the note from the owner's set of notes.
                 // docs:start:remove
-                self.set.remove(note);
+                self.set.remove(note_and_hash);
                 // docs:end:remove
 
-                minuend += note.value as u64;
+                minuend += note_and_hash.note.value as u64;
             }
         }
 

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -41,7 +41,7 @@ impl<Context> EasyPrivateUint<&mut PrivateContext> {
 
         // docs:start:get_notes
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, subtrahend as Field);
-        let notes_and_hashes = self.set.get_notes_and_hashes(options);
+        let notes_and_hashes = self.set.get_notes(options);
         // docs:end:get_notes
 
         let mut minuend: u64 = 0;

--- a/noir-projects/aztec-nr/value-note/src/utils.nr
+++ b/noir-projects/aztec-nr/value-note/src/utils.nr
@@ -55,14 +55,15 @@ pub fn decrement_by_at_most(
     outgoing_viewer: AztecAddress
 ) -> Field {
     let options = create_note_getter_options_for_decreasing_balance(max_amount);
-    let notes_and_hashes = balance.get_notes_and_hashes(options);
+    let notes_and_hashes = balance.get_notes(options);
 
     let mut decremented = 0;
     for i in 0..options.limit {
         if i < notes_and_hashes.len() {
             let note_and_hash = notes_and_hashes.get_unchecked(i);
 
-            decremented += destroy_note(balance, note_and_hash);
+            balance.remove(note_and_hash);
+            decremented += note_and_hash.note.value;
         }
     }
 
@@ -75,15 +76,4 @@ pub fn decrement_by_at_most(
     increment(balance, change_value, owner, outgoing_viewer);
 
     decremented
-}
-
-// Removes the note from the owner's set of notes.
-// Returns the value of the destroyed note.
-pub fn destroy_note(
-    balance: PrivateSet<ValueNote, &mut PrivateContext>,
-    note_and_hash: NoteAndHash<ValueNote>
-) -> Field {
-    balance.remove(note_and_hash);
-
-    note_and_hash.note.value
 }

--- a/noir-projects/aztec-nr/value-note/src/utils.nr
+++ b/noir-projects/aztec-nr/value-note/src/utils.nr
@@ -1,5 +1,5 @@
 use dep::aztec::prelude::{AztecAddress, PrivateContext, PrivateSet, NoteGetterOptions};
-use dep::aztec::note::note_getter_options::SortOrder;
+use dep::aztec::note::{note_getter_options::SortOrder, note_and_hash::NoteAndHash};
 use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note;
 use crate::{filter::filter_notes_min_sum, value_note::{ValueNote, VALUE_NOTE_LEN, VALUE_NOTE_BYTES_LEN}};
 
@@ -55,14 +55,14 @@ pub fn decrement_by_at_most(
     outgoing_viewer: AztecAddress
 ) -> Field {
     let options = create_note_getter_options_for_decreasing_balance(max_amount);
-    let notes = balance.get_notes(options);
+    let notes_and_hashes = balance.get_notes_and_hashes(options);
 
     let mut decremented = 0;
     for i in 0..options.limit {
-        if i < notes.len() {
-            let note = notes.get_unchecked(i);
+        if i < notes_and_hashes.len() {
+            let note_and_hash = notes_and_hashes.get_unchecked(i);
 
-            decremented += destroy_note(balance, note);
+            decremented += destroy_note(balance, note_and_hash);
         }
     }
 
@@ -79,8 +79,11 @@ pub fn decrement_by_at_most(
 
 // Removes the note from the owner's set of notes.
 // Returns the value of the destroyed note.
-pub fn destroy_note(balance: PrivateSet<ValueNote, &mut PrivateContext>, note: ValueNote) -> Field {
-    balance.remove(note);
+pub fn destroy_note(
+    balance: PrivateSet<ValueNote, &mut PrivateContext>,
+    note_and_hash: NoteAndHash<ValueNote>
+) -> Field {
+    balance.remove(note_and_hash);
 
-    note.value
+    note_and_hash.note.value
 }

--- a/noir-projects/noir-contracts/contracts/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/benchmarking_contract/src/main.nr
@@ -31,7 +31,7 @@ contract Benchmarking {
     fn recreate_note(owner: AztecAddress, outgoing_viewer: AztecAddress, index: u32) {
         let owner_notes = storage.notes.at(owner);
         let mut getter_options = NoteGetterOptions::new();
-        let notes_and_hashes = owner_notes.get_notes_and_hashes(getter_options.set_limit(1).set_offset(index));
+        let notes_and_hashes = owner_notes.get_notes(getter_options.set_limit(1).set_offset(index));
         let note_and_hash = notes_and_hashes.get(0);
         owner_notes.remove(note_and_hash);
         increment(owner_notes, note_and_hash.note.value, owner, outgoing_viewer);

--- a/noir-projects/noir-contracts/contracts/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/benchmarking_contract/src/main.nr
@@ -31,10 +31,10 @@ contract Benchmarking {
     fn recreate_note(owner: AztecAddress, outgoing_viewer: AztecAddress, index: u32) {
         let owner_notes = storage.notes.at(owner);
         let mut getter_options = NoteGetterOptions::new();
-        let notes = owner_notes.get_notes(getter_options.set_limit(1).set_offset(index));
-        let note = notes.get(0);
-        owner_notes.remove(note);
-        increment(owner_notes, note.value, owner, outgoing_viewer);
+        let notes_and_hashes = owner_notes.get_notes_and_hashes(getter_options.set_limit(1).set_offset(index));
+        let note_and_hash = notes_and_hashes.get(0);
+        owner_notes.remove(note_and_hash);
+        increment(owner_notes, note_and_hash.note.value, owner, outgoing_viewer);
     }
 
     // Reads and writes to public storage and enqueues a call to another public function.

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -4,7 +4,8 @@ use dep::aztec::{
     context::UnconstrainedContext,
     protocol_types::{traits::{ToField, Serialize, FromField}, constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL},
     encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys,
-    note::note_getter::view_notes, state_vars::PrivateSet, note::constants::MAX_NOTES_PER_PAGE
+    note::{note_getter::view_notes, note_and_hash::NoteAndHash}, state_vars::PrivateSet,
+    note::constants::MAX_NOTES_PER_PAGE
 };
 use dep::value_note::{value_note::{ValueNote, VALUE_NOTE_LEN}};
 
@@ -120,17 +121,19 @@ impl Deck<&mut PrivateContext> {
         inserted_cards
     }
 
-    pub fn get_cards<N>(&mut self, cards: [Card; N]) -> [CardNote; N] {
+    pub fn get_cards_and_note_hashes<N>(&mut self, cards: [Card; N]) -> ([CardNote; N], [Field; N]) {
         let options = NoteGetterOptions::with_filter(filter_cards, cards);
-        let notes = self.set.get_notes(options);
+        let notes_and_hashes = self.set.get_notes_and_hashes(options);
 
         // This array will hold the notes that correspond to each of the requested cards. It begins empty (with all the
         // options being none) and we gradually fill it up as we find the matching notes.
         let mut found_cards = [Option::none(); N];
+        let mut found_cards_note_hashes = [0; N];
 
         for i in 0..options.limit {
-            if i < notes.len() {
-                let card_note = CardNote::from_note(notes.get_unchecked(i));
+            if i < notes_and_hashes.len() {
+                let note_and_hash = notes_and_hashes.get_unchecked(i);
+                let card_note = CardNote::from_note(note_and_hash.note);
 
                 // For each note that we read, we search for a matching card that we have not already marked as found.
                 for j in 0..cards.len() {
@@ -138,24 +141,26 @@ impl Deck<&mut PrivateContext> {
                         & (cards[j].strength == card_note.card.strength)
                         & (cards[j].points == card_note.card.points) {
                         found_cards[j] = Option::some(card_note);
+                        found_cards_note_hashes[j] = note_and_hash.hash;
                     }
                 }
             }
         }
 
         // And then we assert that we did indeed find all cards, since found_cards and cards have the same length.
-        found_cards.map(
-            |card_note: Option<CardNote>| {
+        (found_cards.map(
+                |card_note: Option<CardNote>| {
             assert(card_note.is_some(), "Card not found");
             card_note.unwrap_unchecked()
         }
-        )
+            ), found_cards_note_hashes)
     }
 
     pub fn remove_cards<N>(&mut self, cards: [Card; N]) {
-        let card_notes = self.get_cards(cards);
-        for card_note in card_notes {
-            self.set.remove(card_note.note);
+        let (card_notes, note_hashes) = self.get_cards_and_note_hashes(cards);
+        for i in 0..N {
+            let note_and_hash = NoteAndHash { note: card_notes[i].note, hash: note_hashes[i] };
+            self.set.remove(note_and_hash);
         }
     }
 }

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -123,7 +123,7 @@ impl Deck<&mut PrivateContext> {
 
     pub fn get_cards_and_note_hashes<N>(&mut self, cards: [Card; N]) -> ([CardNote; N], [Field; N]) {
         let options = NoteGetterOptions::with_filter(filter_cards, cards);
-        let notes_and_hashes = self.set.get_notes_and_hashes(options);
+        let notes_and_hashes = self.set.get_notes(options);
 
         // This array will hold the notes that correspond to each of the requested cards. It begins empty (with all the
         // options being none) and we gradually fill it up as we find the matching notes.

--- a/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
@@ -64,7 +64,7 @@ contract Child {
         let mut options = NoteGetterOptions::new();
         options = options.select(ValueNote::properties().value, amount, Option::none()).set_limit(1);
         let notes = storage.a_map_with_private_values.at(owner).get_notes(options);
-        notes.get(0).value
+        notes.get(0).note.value
     }
 
     // Increments `current_value` by `new_value`

--- a/noir-projects/noir-contracts/contracts/delegated_on_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/delegated_on_contract/src/main.nr
@@ -34,7 +34,7 @@ contract DelegatedOn {
         let mut options = NoteGetterOptions::new();
         options = options.select(ValueNote::properties().value, amount, Option::none()).set_limit(1);
         let notes = storage.a_map_with_private_values.at(owner).get_notes(options);
-        notes.get(0).value
+        notes.get(0).note.value
     }
 
     unconstrained fn view_public_value() -> pub Field {

--- a/noir-projects/noir-contracts/contracts/delegator_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/delegator_contract/src/main.nr
@@ -35,7 +35,7 @@ contract Delegator {
         let mut options = NoteGetterOptions::new();
         options = options.select(ValueNote::properties().value, amount, Option::none()).set_limit(1);
         let notes = storage.a_map_with_private_values.at(owner).get_notes(options);
-        notes.get_unchecked(0).value
+        notes.get_unchecked(0).note.value
     }
 
     unconstrained fn view_public_value() -> pub Field {

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
@@ -52,7 +52,7 @@ contract InclusionProofs {
         if (nullified) {
             options = options.set_status(NoteStatus.ACTIVE_OR_NULLIFIED);
         }
-        let note = private_values.get_notes(options).get(0);
+        let note = private_values.get_notes(options).get(0).note;
         // docs:end:get_note_from_pxe
 
         // docs:start:prove_note_inclusion
@@ -104,7 +104,7 @@ contract InclusionProofs {
         if (fail_case) {
             options = options.set_status(NoteStatus.ACTIVE_OR_NULLIFIED);
         }
-        let note = private_values.get_notes(options).get(0);
+        let note = private_values.get_notes(options).get(0).note;
 
         let header = if (use_block_number) {
             context.get_header_at(block_number)
@@ -130,7 +130,7 @@ contract InclusionProofs {
         if (nullified) {
             options = options.set_status(NoteStatus.ACTIVE_OR_NULLIFIED);
         }
-        let note = private_values.get_notes(options).get(0);
+        let note = private_values.get_notes(options).get(0).note;
 
         // 2) Prove the note validity
         let header = if (use_block_number) {
@@ -149,7 +149,7 @@ contract InclusionProofs {
         let private_values = storage.private_values.at(owner);
         let mut options = NoteGetterOptions::new();
         options = options.set_limit(1);
-        let notes_and_hashes = private_values.get_notes_and_hashes(options);
+        let notes_and_hashes = private_values.get_notes(options);
         let note_and_hash = notes_and_hashes.get(0);
 
         private_values.remove(note_and_hash);

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
@@ -149,10 +149,10 @@ contract InclusionProofs {
         let private_values = storage.private_values.at(owner);
         let mut options = NoteGetterOptions::new();
         options = options.set_limit(1);
-        let notes = private_values.get_notes(options);
-        let note = notes.get(0);
+        let notes_and_hashes = private_values.get_notes_and_hashes(options);
+        let note_and_hash = notes_and_hashes.get(0);
 
-        private_values.remove(note);
+        private_values.remove(note_and_hash);
     }
     // docs:end:nullify_note
 

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
@@ -39,15 +39,15 @@ contract PendingNoteHashes {
 
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, amount);
         // get note inserted above
-        let notes = owner_balance.get_notes(options);
+        let notes_and_hashes = owner_balance.get_notes_and_hashes(options);
 
-        let note0 = notes.get(0);
-        assert(note.value == note0.value);
-        assert(notes.len() == 1);
+        let note_and_hash0 = notes_and_hashes.get(0);
+        assert(note.value == note_and_hash0.note.value);
+        assert(notes_and_hashes.len() == 1);
 
-        owner_balance.remove(note0);
+        owner_balance.remove(note_and_hash0);
 
-        note0.value
+        note_and_hash0.note.value
     }
 
     // Confirm cannot access note hashes inserted later in same function
@@ -137,11 +137,11 @@ contract PendingNoteHashes {
 
         let mut options = NoteGetterOptions::new();
         options = options.set_limit(1);
-        let note = owner_balance.get_notes(options).get(0);
+        let note_and_hash = owner_balance.get_notes_and_hashes(options).get(0);
 
-        assert(expected_value == note.value);
+        assert(expected_value == note_and_hash.note.value);
 
-        owner_balance.remove(note);
+        owner_balance.remove(note_and_hash);
 
         expected_value
     }
@@ -378,11 +378,11 @@ contract PendingNoteHashes {
     #[contract_library_method]
     fn destroy_max_notes(owner: AztecAddress, storage: Storage<&mut PrivateContext>) {
         let owner_balance = storage.balances.at(owner);
-        let notes = owner_balance.get_notes(NoteGetterOptions::new());
+        let notes_and_hashes = owner_balance.get_notes_and_hashes(NoteGetterOptions::new());
 
         for i in 0..max_notes_per_call() {
-            let note = notes.get(i);
-            owner_balance.remove(note);
+            let note_and_hash = notes_and_hashes.get(i);
+            owner_balance.remove(note_and_hash);
         }
     }
 

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
@@ -39,7 +39,7 @@ contract PendingNoteHashes {
 
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, amount);
         // get note inserted above
-        let notes_and_hashes = owner_balance.get_notes_and_hashes(options);
+        let notes_and_hashes = owner_balance.get_notes(options);
 
         let note_and_hash0 = notes_and_hashes.get(0);
         assert(note.value == note_and_hash0.note.value);
@@ -137,7 +137,7 @@ contract PendingNoteHashes {
 
         let mut options = NoteGetterOptions::new();
         options = options.set_limit(1);
-        let note_and_hash = owner_balance.get_notes_and_hashes(options).get(0);
+        let note_and_hash = owner_balance.get_notes(options).get(0);
 
         assert(expected_value == note_and_hash.note.value);
 
@@ -378,7 +378,7 @@ contract PendingNoteHashes {
     #[contract_library_method]
     fn destroy_max_notes(owner: AztecAddress, storage: Storage<&mut PrivateContext>) {
         let owner_balance = storage.balances.at(owner);
-        let notes_and_hashes = owner_balance.get_notes_and_hashes(NoteGetterOptions::new());
+        let notes_and_hashes = owner_balance.get_notes(NoteGetterOptions::new());
 
         for i in 0..max_notes_per_call() {
             let note_and_hash = notes_and_hashes.get(i);

--- a/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
@@ -73,7 +73,7 @@ contract StaticChild {
             Option::none()
         ).set_limit(1);
         let notes = storage.a_private_value.get_notes(options);
-        notes.get(0).value
+        notes.get(0).note.value
     }
 
     // Increments `current_value` by `new_value`

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -474,9 +474,9 @@ contract Test {
         let secret_hash = compute_secret_hash(secret);
         let mut options = NoteGetterOptions::new();
         options = options.select(TestNote::properties().value, secret_hash, Option::none()).set_limit(1);
-        let notes = notes_set.get_notes(options);
-        let note = notes.get(0);
-        notes_set.remove(note);
+        let notes_and_hashes = notes_set.get_notes_and_hashes(options);
+        let note_and_hash = notes_and_hashes.get(0);
+        notes_set.remove(note_and_hash);
     }
 
     unconstrained fn get_constant() -> pub Field {

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -30,7 +30,7 @@ contract Test {
         hash::{pedersen_hash, compute_secret_hash, ArgsHasher},
         note::{
         lifecycle::{create_note, destroy_note}, note_getter::{get_notes, view_notes},
-        note_getter_options::NoteStatus
+        note_getter_options::NoteStatus, note_and_hash::NoteAndHash
     },
         deploy::deploy_contract as aztec_deploy_contract,
         oracle::{encryption::aes128_encrypt, unsafe_rand::unsafe_rand}
@@ -117,9 +117,9 @@ contract Test {
             options = options.set_status(NoteStatus.ACTIVE_OR_NULLIFIED);
         }
 
-        let notes: BoundedVec<ValueNote, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> = get_notes(&mut context, storage_slot, options);
+        let notes: BoundedVec<NoteAndHash<ValueNote>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> = get_notes(&mut context, storage_slot, options);
 
-        notes.get(0).value
+        notes.get(0).note.value
     }
 
     #[aztec(private)]
@@ -133,9 +133,9 @@ contract Test {
             options = options.set_status(NoteStatus.ACTIVE_OR_NULLIFIED);
         }
 
-        let notes: BoundedVec<ValueNote, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> = get_notes(&mut context, storage_slot, options);
+        let notes: BoundedVec<NoteAndHash<ValueNote>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> = get_notes(&mut context, storage_slot, options);
 
-        [notes.get(0).value, notes.get(1).value]
+        [notes.get(0).note.value, notes.get(1).note.value]
     }
 
     unconstrained fn call_view_notes(storage_slot: Field, active_or_nullified: bool) -> pub Field {
@@ -175,9 +175,9 @@ contract Test {
         );
 
         let options = NoteGetterOptions::new();
-        let notes: BoundedVec<ValueNote, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> = get_notes(&mut context, storage_slot, options);
+        let notes: BoundedVec<NoteAndHash<ValueNote>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> = get_notes(&mut context, storage_slot, options);
 
-        let note = notes.get(0);
+        let note = notes.get(0).note;
 
         destroy_note(&mut context, note);
     }
@@ -474,7 +474,7 @@ contract Test {
         let secret_hash = compute_secret_hash(secret);
         let mut options = NoteGetterOptions::new();
         options = options.select(TestNote::properties().value, secret_hash, Option::none()).set_limit(1);
-        let notes_and_hashes = notes_set.get_notes_and_hashes(options);
+        let notes_and_hashes = notes_set.get_notes(options);
         let note_and_hash = notes_and_hashes.get(0);
         notes_set.remove(note_and_hash);
     }

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
@@ -172,7 +172,7 @@ contract TokenBlacklist {
             secret_hash,
             Option::none()
         ).set_limit(1);
-        let notes_and_hashes = pending_shields.get_notes_and_hashes(options);
+        let notes_and_hashes = pending_shields.get_notes(options);
         let note_and_hash = notes_and_hashes.get(0);
         // Remove the note from the pending shields set
         pending_shields.remove(note_and_hash);

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
@@ -172,10 +172,10 @@ contract TokenBlacklist {
             secret_hash,
             Option::none()
         ).set_limit(1);
-        let notes = pending_shields.get_notes(options);
-        let note = notes.get(0);
+        let notes_and_hashes = pending_shields.get_notes_and_hashes(options);
+        let note_and_hash = notes_and_hashes.get(0);
         // Remove the note from the pending shields set
-        pending_shields.remove(note);
+        pending_shields.remove(note_and_hash);
 
         // Add the token note to user's balances set
         let caller = context.msg_sender();

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/balances_map.nr
@@ -83,23 +83,23 @@ impl<T> BalancesMap<T, &mut PrivateContext> {
     ) -> OuterNoteEmission<T> where T: NoteInterface<T_SERIALIZED_LEN, T_SERIALIZED_BYTES_LEN> + OwnedNote + Eq {
         // docs:start:get_notes
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, subtrahend);
-        let notes = self.map.at(owner).get_notes(options);
+        let notes_and_hashes = self.map.at(owner).get_notes_and_hashes(options);
         // docs:end:get_notes
 
         let mut minuend: U128 = U128::from_integer(0);
         for i in 0..options.limit {
-            if i < notes.len() {
-                let note = notes.get_unchecked(i);
+            if i < notes_and_hashes.len() {
+                let note_and_hash = notes_and_hashes.get_unchecked(i);
 
                 // Removes the note from the owner's set of notes.
                 // This will call the `compute_nullifer` function of the `token_note`
                 // which require knowledge of the secret key (currently the users encryption key).
                 // The contract logic must ensure that the spending key is used as well.
                 // docs:start:remove
-                self.map.at(owner).remove(note);
+                self.map.at(owner).remove(note_and_hash);
                 // docs:end:remove
 
-                minuend = minuend + note.get_amount();
+                minuend = minuend + note_and_hash.note.get_amount();
             }
         }
 

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/balances_map.nr
@@ -83,7 +83,7 @@ impl<T> BalancesMap<T, &mut PrivateContext> {
     ) -> OuterNoteEmission<T> where T: NoteInterface<T_SERIALIZED_LEN, T_SERIALIZED_BYTES_LEN> + OwnedNote + Eq {
         // docs:start:get_notes
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, subtrahend);
-        let notes_and_hashes = self.map.at(owner).get_notes_and_hashes(options);
+        let notes_and_hashes = self.map.at(owner).get_notes(options);
         // docs:end:get_notes
 
         let mut minuend: U128 = U128::from_integer(0);

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -303,10 +303,10 @@ contract Token {
             secret_hash,
             Option::none()
         ).set_limit(1);
-        let notes = pending_shields.get_notes(options);
-        let note = notes.get(0);
+        let notes_and_hashes = pending_shields.get_notes_and_hashes(options);
+        let note_and_hash = notes_and_hashes.get(0);
         // Remove the note from the pending shields set
-        pending_shields.remove(note);
+        pending_shields.remove(note_and_hash);
 
         // Add the token note to user's balances set
         // Note: Using context.msg_sender() as a sender below makes this incompatible with escrows because we send

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -303,7 +303,7 @@ contract Token {
             secret_hash,
             Option::none()
         ).set_limit(1);
-        let notes_and_hashes = pending_shields.get_notes_and_hashes(options);
+        let notes_and_hashes = pending_shields.get_notes(options);
         let note_and_hash = notes_and_hashes.get(0);
         // Remove the note from the pending shields set
         pending_shields.remove(note_and_hash);

--- a/noir-projects/noir-contracts/contracts/token_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/types/balances_map.nr
@@ -109,23 +109,23 @@ impl<T> BalancesMap<T, &mut PrivateContext> {
     ) -> U128 where T: NoteInterface<T_SERIALIZED_LEN, T_SERIALIZED_BYTES_LEN> + OwnedNote + Eq {
         // docs:start:get_notes
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, target_amount).set_limit(max_notes);
-        let notes = self.map.at(owner).get_notes(options);
+        let notes_and_hashes = self.map.at(owner).get_notes_and_hashes(options);
         // docs:end:get_notes
 
         let mut subtracted = U128::from_integer(0);
         for i in 0..options.limit {
-            if i < notes.len() {
-                let note = notes.get_unchecked(i);
+            if i < notes_and_hashes.len() {
+                let note_and_hash = notes_and_hashes.get_unchecked(i);
 
                 // Removes the note from the owner's set of notes.
                 // This will call the `compute_nullifer` function of the `token_note`
                 // which require knowledge of the secret key (currently the users encryption key).
                 // The contract logic must ensure that the spending key is used as well.
                 // docs:start:remove
-                self.map.at(owner).remove(note);
+                self.map.at(owner).remove(note_and_hash);
                 // docs:end:remove
 
-                subtracted = subtracted + note.get_amount();
+                subtracted = subtracted + note_and_hash.note.get_amount();
             }
         }
 

--- a/noir-projects/noir-contracts/contracts/token_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/types/balances_map.nr
@@ -109,7 +109,7 @@ impl<T> BalancesMap<T, &mut PrivateContext> {
     ) -> U128 where T: NoteInterface<T_SERIALIZED_LEN, T_SERIALIZED_BYTES_LEN> + OwnedNote + Eq {
         // docs:start:get_notes
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, target_amount).set_limit(max_notes);
-        let notes_and_hashes = self.map.at(owner).get_notes_and_hashes(options);
+        let notes_and_hashes = self.map.at(owner).get_notes(options);
         // docs:end:get_notes
 
         let mut subtracted = U128::from_integer(0);

--- a/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/main.nr
@@ -290,10 +290,10 @@ contract TokenWithRefunds {
             secret_hash,
             Option::none()
         ).set_limit(1);
-        let notes = pending_shields.get_notes(options);
-        let note = notes.get_unchecked(0);
+        let notes_and_hashes = pending_shields.get_notes_and_hashes(options);
+        let note_and_hash = notes_and_hashes.get_unchecked(0);
         // Remove the note from the pending shields set
-        pending_shields.remove(note);
+        pending_shields.remove(note_and_hash);
 
         // Add the token note to user's balances set
         // Note: Using context.msg_sender() as a sender below makes this incompatible with escrows because we send

--- a/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/main.nr
@@ -290,7 +290,7 @@ contract TokenWithRefunds {
             secret_hash,
             Option::none()
         ).set_limit(1);
-        let notes_and_hashes = pending_shields.get_notes_and_hashes(options);
+        let notes_and_hashes = pending_shields.get_notes(options);
         let note_and_hash = notes_and_hashes.get_unchecked(0);
         // Remove the note from the pending shields set
         pending_shields.remove(note_and_hash);

--- a/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/types/balances_map.nr
@@ -86,7 +86,7 @@ impl<T> BalancesMap<T, &mut PrivateContext> {
     ) -> OuterNoteEmission<T> where T: NoteInterface<T_SERIALIZED_LEN, T_SERIALIZED_BYTES_LEN> + OwnedNote + Eq {
         // docs:start:get_notes
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, subtrahend);
-        let notes_and_hashes = self.map.at(owner).get_notes_and_hashes(options);
+        let notes_and_hashes = self.map.at(owner).get_notes(options);
         // docs:end:get_notes
 
         let mut minuend: U128 = U128::from_integer(0);

--- a/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/types/balances_map.nr
@@ -86,23 +86,23 @@ impl<T> BalancesMap<T, &mut PrivateContext> {
     ) -> OuterNoteEmission<T> where T: NoteInterface<T_SERIALIZED_LEN, T_SERIALIZED_BYTES_LEN> + OwnedNote + Eq {
         // docs:start:get_notes
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, subtrahend);
-        let notes = self.map.at(owner).get_notes(options);
+        let notes_and_hashes = self.map.at(owner).get_notes_and_hashes(options);
         // docs:end:get_notes
 
         let mut minuend: U128 = U128::from_integer(0);
         for i in 0..options.limit {
-            if i < notes.len() {
-                let note = notes.get_unchecked(i);
+            if i < notes_and_hashes.len() {
+                let note_and_hash = notes_and_hashes.get_unchecked(i);
 
                 // Removes the note from the owner's set of notes.
                 // This will call the `compute_nullifer` function of the `token_note`
                 // which require knowledge of the secret key (currently the users encryption key).
                 // The contract logic must ensure that the spending key is used as well.
                 // docs:start:remove
-                self.map.at(owner).remove(note);
+                self.map.at(owner).remove(note_and_hash);
                 // docs:end:remove
 
-                minuend = minuend + note.get_amount();
+                minuend = minuend + note_and_hash.note.get_amount();
             }
         }
 


### PR DESCRIPTION
We unnecessarily compute note_hash_for_read_request twice when removing a note: once when getting it via get_notes and the second time in PrivateSet::remove. This is expensive. This PRs removes the redundant hash computation by passing the hashes from get_notes.

Gate count change of Token transfer:
Before 93k gates.

After:

<img width="296" alt="image" src="https://github.com/user-attachments/assets/21ab061a-220c-45e3-a0b4-5b158fc7bcbf">

Gate count change: 93k-89k=4k gates savings.


## Note for reviewer
I initially had 2 get notes functions: get_notes and get_notes_and_hashes. As the name implies get_notes returned "pure notes" and get_notes_and_hashes returned both the note and the hash. When I checked usage of the get_notes method it was only used in test contracts and hence would not consider them a real use case. So it generally seems that whenever we obtain a note we will most likely also want to destroy it. Hence I merged the 2 functions and now there is only 1 get_notes func.