### PR TITLE
fix(bb.js): Account for extra gates in the c bind circuit size estimate

### DIFF
--- a/barretenberg/Earthfile
+++ b/barretenberg/Earthfile
@@ -110,7 +110,9 @@ barretenberg-acir-tests-bb.js:
     # Run ecdsa_secp256r1_3x through bb.js on node to check 256k support.
     RUN BIN=../ts/dest/node/main.js FLOW=prove_then_verify ./run_acir_tests.sh ecdsa_secp256r1_3x
     # Run a single arbitrary test not involving recursion through bb.js for UltraHonk
-    RUN BIN=../ts/dest/node/main.js FLOW=prove_and_verify_ultra_honk ./run_acir_tests.sh 6_array
+    RUN BIN=../ts/dest/node/main.js FLOW=prove_and_verify_ultra_honk ./run_acir_tests.sh 6_array assert_statement
+    # Run the prove then verify flow for UltraHonk. This makes sure we have the same circuit for different witness inputs.
+    RUN BIN=../ts/dest/node/main.js FLOW=prove_then_verify_ultra_honk ./run_acir_tests.sh 6_array assert_statement
     # Run a single arbitrary test not involving recursion through bb.js for MegaHonk
     RUN BIN=../ts/dest/node/main.js FLOW=prove_and_verify_mega_honk ./run_acir_tests.sh 6_array
     # Run 1_mul through bb.js build, all_cmds flow, to test all cli args.

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
@@ -21,7 +21,8 @@ WASM_EXPORT void acir_get_circuit_sizes(
     auto builder = acir_format::create_circuit(constraint_system, 1 << 19, {}, *honk_recursion);
     *exact = htonl((uint32_t)builder.get_num_gates());
     auto num_extra_gates = builder.get_num_gates_added_to_ensure_nonzero_polynomials();
-    *total = htonl((uint32_t)builder.get_total_circuit_size() + num_extra_gates);
+    auto total_with_extra_gates = builder.get_total_circuit_size() + num_extra_gates;
+    *total = htonl((uint32_t)total_with_extra_gates);
     *subgroup = htonl((uint32_t)builder.get_circuit_subgroup_size(builder.get_total_circuit_size()));
 }
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
@@ -20,7 +20,8 @@ WASM_EXPORT void acir_get_circuit_sizes(
         acir_format::circuit_buf_to_acir_format(from_buffer<std::vector<uint8_t>>(acir_vec), *honk_recursion);
     auto builder = acir_format::create_circuit(constraint_system, 1 << 19, {}, *honk_recursion);
     *exact = htonl((uint32_t)builder.get_num_gates());
-    *total = htonl((uint32_t)builder.get_total_circuit_size());
+    auto num_extra_gates = builder.get_num_gates_added_to_ensure_nonzero_polynomials();
+    *total = htonl((uint32_t)builder.get_total_circuit_size() + num_extra_gates);
     *subgroup = htonl((uint32_t)builder.get_circuit_subgroup_size(builder.get_total_circuit_size()));
 }
 


### PR DESCRIPTION
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.

We account for extra gates in `compute_valid_prover` for the normal cpp binary, but we do not account for them in the c binds which are used by bb.js

e.g. this command will fail on master:
```
BIN=../ts/dest/node/main.js FLOW=prove_then_verify_ultra_honk ./run_acir_tests.sh assert_statement
```
This now passes on this PR.