### PR TITLE
fix: Create proving job queue when prover node started with no agents

### DIFF
--- a/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
@@ -70,7 +70,7 @@ export const startProverNode = async (
 
   services.push({ node: createProverNodeRpcServer(proverNode) });
 
-  if (options.prover) {
+  if (!options.prover) {
     const provingJobSource = createProvingJobSourceServer(proverNode.getProver().getProvingJobSource());
     services.push({ provingJobSource });
   }

--- a/yarn-project/prover-client/src/prover-agent/prover-agent.ts
+++ b/yarn-project/prover-client/src/prover-agent/prover-agent.ts
@@ -71,7 +71,7 @@ export class ProverAgent {
             );
           }
         } catch (err) {
-          // no-op
+          this.log.error(`Error fetching job`, err);
         }
       }
     }, this.pollIntervalMs);
@@ -96,7 +96,7 @@ export class ProverAgent {
       this.log.debug(`Picked up proving job id=${job.id} type=${ProvingRequestType[job.request.type]}`);
       const [time, result] = await elapsed(this.getProof(job.request));
       if (this.isRunning()) {
-        this.log.debug(
+        this.log.verbose(
           `Processed proving job id=${job.id} type=${ProvingRequestType[job.request.type]} duration=${time}ms`,
         );
         await jobSource.resolveProvingJob(job.id, result);


### PR DESCRIPTION
If the prover node is started with no in-proc agents, then we should create a proving job source so agents can attach to it.

Unrelated, also tweaks some logging statements on the agent.