### PR TITLE
fix: fixing private voting by correctly throwing an error if simulation fails

### DIFF
--- a/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
@@ -23,6 +23,8 @@ export type SimulateMethodOptions = {
   from?: AztecAddress;
   /** Gas settings for the simulation. */
   gasSettings?: GasSettings;
+  /** Simulate without validating tx against current state. */
+  offline?: boolean;
 };
 
 /**
@@ -93,7 +95,7 @@ export class ContractFunctionInteraction extends BaseContractInteraction {
     }
 
     const txRequest = await this.create();
-    const simulatedTx = await this.wallet.simulateTx(txRequest, true, options?.from);
+    const simulatedTx = await this.wallet.simulateTx(txRequest, true, options?.from, options?.offline);
 
     // As account entrypoints are private, for private functions we retrieve the return values from the first nested call
     // since we're interested in the first set of values AFTER the account entrypoint

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -108,8 +108,13 @@ export abstract class BaseWallet implements Wallet {
   proveTx(txRequest: TxExecutionRequest, simulatePublic: boolean): Promise<Tx> {
     return this.pxe.proveTx(txRequest, simulatePublic, this.scopes);
   }
-  simulateTx(txRequest: TxExecutionRequest, simulatePublic: boolean, msgSender?: AztecAddress): Promise<SimulatedTx> {
-    return this.pxe.simulateTx(txRequest, simulatePublic, msgSender, this.scopes);
+  simulateTx(
+    txRequest: TxExecutionRequest,
+    simulatePublic: boolean,
+    msgSender?: AztecAddress,
+    offline?: boolean,
+  ): Promise<SimulatedTx> {
+    return this.pxe.simulateTx(txRequest, simulatePublic, msgSender, offline, this.scopes);
   }
   sendTx(tx: Tx): Promise<TxHash> {
     return this.pxe.sendTx(tx);

--- a/yarn-project/circuit-types/src/interfaces/aztec-node.ts
+++ b/yarn-project/circuit-types/src/interfaces/aztec-node.ts
@@ -317,6 +317,13 @@ export interface AztecNode {
   simulatePublicCalls(tx: Tx): Promise<PublicSimulationOutput>;
 
   /**
+   * Validates the correctness of the execution, namely that a transaction is valid if and
+   * only if the transaction can be added to a valid block at the current state.
+   * @param tx - The transaction to validate for correctness.
+   */
+  validateTx(tx: Tx): Promise<boolean>;
+
+  /**
    * Updates the configuration of this node.
    * @param config - Updated configuration to be merged with the current one.
    */

--- a/yarn-project/circuit-types/src/interfaces/pxe.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.ts
@@ -180,6 +180,7 @@ export interface PXE {
    * @param txRequest - An authenticated tx request ready for simulation
    * @param simulatePublic - Whether to simulate the public part of the transaction.
    * @param msgSender - (Optional) The message sender to use for the simulation.
+   * @param offline - (Optional) Whether to simulate without validating tx against current state.
    * @param scopes - (Optional) The accounts whose notes we can access in this call. Currently optional and will default to all.
    * @returns A simulated transaction object that includes a transaction that is potentially ready
    * to be sent to the network for execution, along with public and private return values.
@@ -190,6 +191,7 @@ export interface PXE {
     txRequest: TxExecutionRequest,
     simulatePublic: boolean,
     msgSender?: AztecAddress,
+    offline?: boolean,
     scopes?: AztecAddress[],
   ): Promise<SimulatedTx>;
 

--- a/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
@@ -47,9 +47,11 @@ describe('e2e_voting_contract', () => {
       await crossDelay();
 
       // We try simulating voting again, but our TX is invalid because it will emit duplicate nullifiers
-      await expect(votingContract.methods.cast_vote(candidate).simulate()).rejects.toThrow(
-        'The simulated transaction is unable to be added to state and is invalid.',
-      );
+      await expect(
+        votingContract.methods.cast_vote(candidate).simulate({
+          offline: false,
+        }),
+      ).rejects.toThrow('The simulated transaction is unable to be added to state and is invalid.');
 
       // We try voting again, but our TX is dropped due to trying to emit duplicate nullifiers
       await expect(votingContract.methods.cast_vote(candidate).send().wait()).rejects.toThrow(

--- a/yarn-project/sequencer-client/src/index.ts
+++ b/yarn-project/sequencer-client/src/index.ts
@@ -4,6 +4,7 @@ export * from './publisher/index.js';
 export * from './sequencer/index.js';
 export * from './tx_validator/aggregate_tx_validator.js';
 export * from './tx_validator/data_validator.js';
+export * from './tx_validator/double_spend_validator.js';
 
 // Used by the node to simulate public parts of transactions. Should these be moved to a shared library?
 export * from './global_variable_builder/index.js';


### PR DESCRIPTION
This PR makes a simulation of a tx fail, if the tx cannot be included in a block and added to the state.

e.g. If a simulation produces duplicate nullifiers, or nullifiers that already exist in a state tree, the results of this simulation should not be returned, but should warn users that the transaction simulated is impossible to actually be added to a block due to being an invalid transaction.

The method for achieving the above is that a new API on the node was created, used for validating the correctness of the metadata and side-effects produced by a transaction. A transaction is deemed valid if and only if the transaction can be added to a block that can be used to advance state.

Note: this update does not make this validation necessary, and defaults to offline simulation. Offline simulation is previous non-validated behavior, and is potentially useful if we ever move to a model where a node is optional to a pxe.

Another note just for reference: there is weirdness in e2e_prover, that fails the proof validation. 

Resolves #4781.