### PR TITLE
fix: making sent tx's fail at validation, rather than waiting for the non inclusion of the tx at a block

### DIFF
--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -210,7 +210,9 @@ describe('e2e_block_building', () => {
       it('private -> private', async () => {
         const nullifier = Fr.random();
         await contract.methods.emit_nullifier(nullifier).send().wait();
-        await expect(contract.methods.emit_nullifier(nullifier).send().wait()).rejects.toThrow('dropped');
+        await expect(contract.methods.emit_nullifier(nullifier).send().wait()).rejects.toThrow(
+          'The simulated transaction is unable to be added to state and is invalid.',
+        );
       });
 
       it('public -> public', async () => {
@@ -232,7 +234,9 @@ describe('e2e_block_building', () => {
       it('public -> private', async () => {
         const nullifier = Fr.random();
         await contract.methods.emit_nullifier_public(nullifier).send().wait();
-        await expect(contract.methods.emit_nullifier(nullifier).send().wait()).rejects.toThrow('dropped');
+        await expect(contract.methods.emit_nullifier(nullifier).send().wait()).rejects.toThrow(
+          'The simulated transaction is unable to be added to state and is invalid.',
+        );
       });
     });
   });

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/legacy.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/legacy.test.ts
@@ -81,7 +81,9 @@ describe('e2e_deploy_contract legacy', () => {
     const deployer = new ContractDeployer(TestContractArtifact, wallet);
 
     await deployer.deploy().send({ contractAddressSalt }).wait({ wallet });
-    await expect(deployer.deploy().send({ contractAddressSalt }).wait()).rejects.toThrow(/dropped/);
+    await expect(deployer.deploy().send({ contractAddressSalt }).wait()).rejects.toThrow(
+      /The simulated transaction is unable to be added to state and is invalid./,
+    );
   });
 
   it('should not deploy a contract which failed the public part of the execution', async () => {

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/private_initialization.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/private_initialization.test.ts
@@ -93,7 +93,7 @@ describe('e2e_deploy_contract private initialization', () => {
         .constructor(...initArgs)
         .send()
         .wait(),
-    ).rejects.toThrow(/dropped/);
+    ).rejects.toThrow(/The simulated transaction is unable to be added to state and is invalid./);
   });
 
   it('refuses to call a private function that requires initialization', async () => {

--- a/yarn-project/end-to-end/src/e2e_max_block_number.test.ts
+++ b/yarn-project/end-to-end/src/e2e_max_block_number.test.ts
@@ -72,7 +72,7 @@ describe('e2e_max_block_number', () => {
       it('invalidates the transaction', async () => {
         await expect(
           contract.methods.set_tx_max_block_number(maxBlockNumber, enqueuePublicCall).send().wait(),
-        ).rejects.toThrow('dropped');
+        ).rejects.toThrow('The simulated transaction is unable to be added to state and is invalid.');
       });
     });
 
@@ -88,7 +88,7 @@ describe('e2e_max_block_number', () => {
       it('invalidates the transaction', async () => {
         await expect(
           contract.methods.set_tx_max_block_number(maxBlockNumber, enqueuePublicCall).send().wait(),
-        ).rejects.toThrow('dropped');
+        ).rejects.toThrow('The simulated transaction is unable to be added to state and is invalid.');
       });
     });
   });

--- a/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
@@ -50,7 +50,7 @@ describe('e2e_voting_contract', () => {
       // We try voting again, but our TX is dropped due to trying to emit duplicate nullifiers as the voting contract
       // ignored our previous key rotation.
       await expect(votingContract.methods.cast_vote(candidate).send().wait()).rejects.toThrow(
-        'Reason: Tx dropped by P2P node.',
+        'The simulated transaction is unable to be added to state and is invalid.',
       );
     });
   });

--- a/yarn-project/end-to-end/src/e2e_prover/full.test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/full.test.ts
@@ -106,7 +106,11 @@ describe('full_prover', () => {
       sentPublicTx.wait({ timeout: 10, interval: 0.1 }),
     ]);
 
-    expect(String((results[0] as PromiseRejectedResult).reason)).toMatch(/Tx dropped by P2P node/);
-    expect(String((results[1] as PromiseRejectedResult).reason)).toMatch(/Tx dropped by P2P node/);
+    expect(String((results[0] as PromiseRejectedResult).reason)).toMatch(
+      /Error: The simulated transaction is unable to be added to state and is invalid./,
+    );
+    expect(String((results[1] as PromiseRejectedResult).reason)).toMatch(
+      /Error: The simulated transaction is unable to be added to state and is invalid./,
+    );
   });
 });

--- a/yarn-project/end-to-end/src/fixtures/fixtures.ts
+++ b/yarn-project/end-to-end/src/fixtures/fixtures.ts
@@ -7,7 +7,8 @@ export const U128_UNDERFLOW_ERROR = "Assertion failed: attempt to subtract with 
 export const U128_OVERFLOW_ERROR = "Assertion failed: attempt to add with overflow 'hi == high'";
 export const BITSIZE_TOO_BIG_ERROR = "Assertion failed. 'self.__assert_max_bit_size'";
 // TODO(https://github.com/AztecProtocol/aztec-packages/issues/5818): Make these a fixed error after transition.
-export const DUPLICATE_NULLIFIER_ERROR = /dropped|duplicate nullifier|reverted/;
+export const DUPLICATE_NULLIFIER_ERROR =
+  /dropped|duplicate nullifier|reverted|The simulated transaction is unable to be added to state and is invalid./;
 export const NO_L1_TO_L2_MSG_ERROR =
   /No non-nullified L1 to L2 message found for message hash|Tried to consume nonexistent L1-to-L2 message/;
 export const STATIC_CALL_STATE_MODIFICATION_ERROR =

--- a/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
+++ b/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
@@ -214,7 +214,9 @@ describe('guides/dapp/testing', () => {
         await call2.prove();
 
         await call1.send().wait();
-        await expect(call2.send().wait()).rejects.toThrow(/dropped/);
+        await expect(call2.send().wait()).rejects.toThrow(
+          /The simulated transaction is unable to be added to state and is invalid./,
+        );
         // docs:end:tx-dropped
       });
 

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -564,9 +564,7 @@ export class PXEService implements PXE {
       throw new Error(`A settled tx with equal hash ${txHash.toString()} exists.`);
     }
 
-    const isValidTx = await this.node.validateTx(tx);
-
-    if (!isValidTx) {
+    if (!(await this.node.isValidTx(tx))) {
       throw new Error('The simulated transaction is unable to be added to state and is invalid.');
     }
 

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -563,6 +563,13 @@ export class PXEService implements PXE {
     if (await this.node.getTxEffect(txHash)) {
       throw new Error(`A settled tx with equal hash ${txHash.toString()} exists.`);
     }
+
+    const isValidTx = await this.node.validateTx(tx);
+
+    if (!isValidTx) {
+      throw new Error('The simulated transaction is unable to be added to state and is invalid.');
+    }
+
     this.log.info(`Sending transaction ${txHash}`);
     await this.node.sendTx(tx);
     this.log.info(`Sent transaction ${txHash}`);


### PR DESCRIPTION
Right now when we send a TX to the node, it gets "fake" validated; because if invalid, a no-op occurs, it doesn't give users feedback directly in any way. The transaction is not forwarded to the p2p client, and nothing is returned to the user. 

This change makes a sent transaction fail early if the transaction is invalid (that is, unable to be included in any block to advance state).

The mechanism by which this occurs is similar to what is implemented for a simulation, that is we use the previously introduced endpoint on the node to validate if the transaction is not invalid according to our above definition, and if it is invalid, we throw an error on the spot.

Addresses #8231.