### PR TITLE
fix: Load l1 addresses in prover node

### DIFF
--- a/yarn-project/prover-node/src/tx-provider/config.ts
+++ b/yarn-project/prover-node/src/tx-provider/config.ts
@@ -8,7 +8,7 @@ export const txProviderConfigMappings: ConfigMappingsType<TxProviderConfig> = {
   txProviderNodeUrl: {
     env: 'TX_PROVIDER_NODE_URL',
     description: 'The URL of the tx provider node',
-    parseEnv: (val: string) => val || process.env.AZTEC_NODE_URL,
+    parseEnv: (val: string) => val,
   },
 };
 


### PR DESCRIPTION
`aztec start --prover-node` was failing due to not being able to load l1 contract addresses