### PR TITLE
chore(bb): define missing univ-fr operators

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "barretenberg/common/serialize.hpp"
 #include "barretenberg/ecc/curves/bn254/fq2.hpp"
 #include "barretenberg/numeric/uint256/uint256.hpp"
@@ -62,6 +63,8 @@ template <typename Fq_, typename Fr_, typename Params> class alignas(64) affine_
     constexpr affine_element& operator=(affine_element&& other) noexcept = default;
 
     constexpr affine_element operator+(const affine_element& other) const noexcept;
+
+    constexpr affine_element operator*(const Fr& exponent) const noexcept;
 
     template <typename BaseField = Fq,
               typename CompileTimeEnabled = std::enable_if_t<(BaseField::modulus >> 255) == uint256_t(0), void>>

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element_impl.hpp
@@ -69,6 +69,12 @@ constexpr affine_element<Fq, Fr, T> affine_element<Fq, Fr, T>::operator+(
 }
 
 template <class Fq, class Fr, class T>
+constexpr affine_element<Fq, Fr, T> affine_element<Fq, Fr, T>::operator*(const Fr& exponent) const noexcept
+{
+    return bb::group_elements::element(*this) * exponent;
+}
+
+template <class Fq, class Fr, class T>
 template <typename BaseField, typename CompileTimeEnabled>
 
 constexpr uint256_t affine_element<Fq, Fr, T>::compress() const noexcept

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element.hpp
@@ -153,17 +153,3 @@ template <class Fq, class Fr, class Params> std::ostream& operator<<(std::ostrea
 } // namespace bb::group_elements
 
 #include "./element_impl.hpp"
-
-template <class Fq, class Fr, class Params>
-bb::group_elements::affine_element<Fq, Fr, Params> operator*(
-    const bb::group_elements::affine_element<Fq, Fr, Params>& base, const Fr& exponent) noexcept
-{
-    return bb::group_elements::affine_element<Fq, Fr, Params>(bb::group_elements::element(base) * exponent);
-}
-
-template <class Fq, class Fr, class Params>
-bb::group_elements::affine_element<Fq, Fr, Params> operator*(const bb::group_elements::element<Fq, Fr, Params>& base,
-                                                             const Fr& exponent) noexcept
-{
-    return (bb::group_elements::element(base) * exponent);
-}

--- a/barretenberg/cpp/src/barretenberg/polynomials/univariate.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/univariate.hpp
@@ -524,6 +524,27 @@ inline void write(B& it, Univariate<Fr, domain_end, domain_start> const& univari
     write(it, univariate.evaluations);
 }
 
+template <class Fr, size_t domain_end, size_t domain_start = 0, size_t skip_count = 0>
+Univariate<Fr, domain_end, domain_start, skip_count> operator+(
+    const Fr& ff, const Univariate<Fr, domain_end, domain_start, skip_count>& uv)
+{
+    return uv + ff;
+}
+
+template <class Fr, size_t domain_end, size_t domain_start = 0, size_t skip_count = 0>
+Univariate<Fr, domain_end, domain_start, skip_count> operator-(
+    const Fr& ff, const Univariate<Fr, domain_end, domain_start, skip_count>& uv)
+{
+    return uv - ff;
+}
+
+template <class Fr, size_t domain_end, size_t domain_start = 0, size_t skip_count = 0>
+Univariate<Fr, domain_end, domain_start, skip_count> operator*(
+    const Fr& ff, const Univariate<Fr, domain_end, domain_start, skip_count>& uv)
+{
+    return uv * ff;
+}
+
 template <class Fr, size_t domain_end, size_t domain_start = 0, size_t skip_count = 0> class UnivariateView {
   public:
     static constexpr size_t LENGTH = domain_end - domain_start;


### PR DESCRIPTION
The defined operators could only take a field on the right hand side.

(On the AVM side, this simplifies codegen)