### PR TITLE
chore!: Sequencer no longer proves

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/config.ts
+++ b/yarn-project/aztec-node/src/aztec-node/config.ts
@@ -18,12 +18,10 @@ export type AztecNodeConfig = ArchiverConfig &
   SequencerClientConfig &
   ProverClientConfig &
   WorldStateConfig &
+  Pick<ProverClientConfig, 'bbBinaryPath' | 'bbWorkingDirectory' | 'realProofs'> &
   P2PConfig & {
     /** Whether the sequencer is disabled for this node. */
     disableSequencer: boolean;
-
-    /** Whether the prover is disabled for this node. */
-    disableProver: boolean;
   };
 
 export const aztecNodeConfigMappings: ConfigMappingsType<AztecNodeConfig> = {
@@ -35,11 +33,6 @@ export const aztecNodeConfigMappings: ConfigMappingsType<AztecNodeConfig> = {
   disableSequencer: {
     env: 'SEQ_DISABLED',
     description: 'Whether the sequencer is disabled for this node.',
-    ...booleanConfigHelper(),
-  },
-  disableProver: {
-    env: 'PROVER_DISABLED',
-    description: 'Whether the prover is disabled for this node.',
     ...booleanConfigHelper(),
   },
 };

--- a/yarn-project/bb-prover/src/test/test_circuit_prover.ts
+++ b/yarn-project/bb-prover/src/test/test_circuit_prover.ts
@@ -65,8 +65,8 @@ import { SimulatedPublicKernelArtifactMapping } from '../mappings/mappings.js';
 import { mapPublicKernelToCircuitName } from '../stats.js';
 
 /**
- * A class for use in testing situations (e2e, unit test etc)
- * Simulates circuits using the most efficient method and performs no proving
+ * A class for use in testing situations (e2e, unit test, etc) and temporarily for assembling a block in the sequencer.
+ * Simulates circuits using the most efficient method and performs no proving.
  */
 export class TestCircuitProver implements ServerCircuitProver {
   private wasmSimulator = new WASMSimulator();

--- a/yarn-project/circuit-types/src/interfaces/block-prover.ts
+++ b/yarn-project/circuit-types/src/interfaces/block-prover.ts
@@ -23,48 +23,52 @@ export type ProvingTicket = {
   provingPromise: Promise<ProvingResult>;
 };
 
-export type BlockResult = {
+export type SimulationBlockResult = {
   block: L2Block;
+};
+
+export type ProvingBlockResult = SimulationBlockResult & {
   proof: Proof;
   aggregationObject: Fr[];
 };
 
-/**
- * The interface to the block prover.
- * Provides the ability to generate proofs and build rollups.
- */
-export interface BlockProver {
+/** Receives processed txs as part of block simulation or proving. */
+export interface ProcessedTxHandler {
   /**
-   * Cancels any block that is currently being built and prepares for a new one to be built
+   * Add a processed transaction to the current block.
+   * @param tx - The transaction to be added.
+   */
+  addNewTx(tx: ProcessedTx): Promise<void>;
+}
+
+/** The interface to a block simulator. Generates an L2 block out of a set of processed txs by calling into the Aztec circuits. */
+export interface BlockSimulator extends ProcessedTxHandler {
+  /**
+   * Prepares to build a new block.
    * @param numTxs - The complete size of the block, must be a power of 2
    * @param globalVariables - The global variables for this block
    * @param l1ToL2Messages - The set of L1 to L2 messages to be included in this block
-   * @param emptyTx - An instance of an empty transaction to be used in this block
    */
   startNewBlock(numTxs: number, globalVariables: GlobalVariables, l1ToL2Messages: Fr[]): Promise<ProvingTicket>;
 
-  /**
-   * Add a processed transaction to the current block
-   * @param tx - The transaction to be added
-   */
-  addNewTx(tx: ProcessedTx): Promise<void>;
-
-  /**
-   * Cancels the block currently being proven. Proofs already bring built may continue but further proofs should not be started.
-   */
+  /** Cancels the block currently being processed. Processes already in progress built may continue but further proofs should not be started. */
   cancelBlock(): void;
 
-  /**
-   * Performs the final archive tree insertion for this block and returns the L2Block and Proof instances
-   */
-  finaliseBlock(): Promise<BlockResult>;
+  /** Performs the final archive tree insertion for this block and returns the L2Block. */
+  finaliseBlock(): Promise<SimulationBlockResult>;
 
   /**
    * Mark the block as having all the transactions it is going to contain.
-   * Will pad the block to it's complete size with empty transactions and prove all the way to the root rollup.
+   * Will pad the block to its complete size with empty transactions and prove all the way to the root rollup.
    */
   setBlockCompleted(): Promise<void>;
+}
 
+/** The interface to a block prover. Generates a root rollup proof out of a set of processed txs by recursively proving Aztec circuits. */
+export interface BlockProver extends BlockSimulator {
   /** Returns an identifier for the prover or zero if not set. */
   getProverId(): Fr;
+
+  /** Performs the final archive tree insertion for this block and returns the L2Block. */
+  finaliseBlock(): Promise<ProvingBlockResult>;
 }

--- a/yarn-project/circuit-types/src/interfaces/configs.ts
+++ b/yarn-project/circuit-types/src/interfaces/configs.ts
@@ -37,6 +37,4 @@ export interface SequencerConfig {
   maxBlockSizeInBytes?: number;
   /** Whether to require every tx to have a fee payer */
   enforceFees?: boolean;
-  /** Temporary flag to skip submitting proofs, so a prover-node takes care of it. */
-  sequencerSkipSubmitProofs?: boolean;
 }

--- a/yarn-project/end-to-end/src/e2e_prover_node.test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover_node.test.ts
@@ -46,8 +46,7 @@ describe('e2e_prover_node', () => {
 
   beforeAll(async () => {
     logger = createDebugLogger('aztec:e2e_prover_node');
-    const config: Partial<SequencerClientConfig> = { sequencerSkipSubmitProofs: true };
-    snapshotManager = createSnapshotManager(`e2e_prover_node`, process.env.E2E_DATA_PATH, config);
+    snapshotManager = createSnapshotManager(`e2e_prover_node`, process.env.E2E_DATA_PATH);
 
     const testContractOpts = { contractAddressSalt: Fr.ONE, universalDeploy: true };
     await snapshotManager.snapshot(

--- a/yarn-project/end-to-end/src/e2e_prover_node.test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover_node.test.ts
@@ -16,7 +16,6 @@ import {
 } from '@aztec/aztec.js';
 import { StatefulTestContract, TestContract } from '@aztec/noir-contracts.js';
 import { createProverNode } from '@aztec/prover-node';
-import { type SequencerClientConfig } from '@aztec/sequencer-client';
 
 import { sendL1ToL2Message } from './fixtures/l1_to_l2_messaging.js';
 import {

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -61,7 +61,6 @@ import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
 import { getCanonicalAuthRegistry } from '@aztec/protocol-contracts/auth-registry';
 import { FeeJuiceAddress, getCanonicalFeeJuice } from '@aztec/protocol-contracts/fee-juice';
 import { getCanonicalKeyRegistry } from '@aztec/protocol-contracts/key-registry';
-import { type ProverClient } from '@aztec/prover-client';
 import { PXEService, type PXEServiceConfig, createPXEService, getPXEServiceConfig } from '@aztec/pxe';
 import { type SequencerClient } from '@aztec/sequencer-client';
 import { createAndStartTelemetryClient, getConfigEnvVars as getTelemetryConfig } from '@aztec/telemetry-client/start';

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -303,8 +303,6 @@ export type EndToEndContext = {
   logger: DebugLogger;
   /** The cheat codes. */
   cheatCodes: CheatCodes;
-  /** Proving jobs */
-  prover: ProverClient | undefined;
   /** Function to stop the started services. */
   teardown: () => Promise<void>;
 };
@@ -381,7 +379,6 @@ export async function setup(
   config.l1PublishRetryIntervalMS = 100;
   const aztecNode = await AztecNodeService.createAndSync(config, telemetry);
   const sequencer = aztecNode.getSequencer();
-  const prover = aztecNode.getProver();
 
   logger.verbose('Creating a pxe...');
 
@@ -434,7 +431,6 @@ export async function setup(
     logger,
     cheatCodes,
     sequencer,
-    prover,
     teardown,
   };
 }

--- a/yarn-project/prover-client/package.json
+++ b/yarn-project/prover-client/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "exports": {
     ".": "./dest/index.js",
-    "./prover-agent": "./dest/prover-agent/index.js"
+    "./prover-agent": "./dest/prover-agent/index.js",
+    "./orchestrator": "./dest/orchestrator/index.js"
   },
   "typedocOptions": {
     "entryPoints": [

--- a/yarn-project/prover-client/src/config.ts
+++ b/yarn-project/prover-client/src/config.ts
@@ -1,5 +1,5 @@
 import { type ProverConfig, proverConfigMappings } from '@aztec/circuit-types';
-import { type ConfigMappingsType, booleanConfigHelper, getConfigFromMappings } from '@aztec/foundation/config';
+import { type ConfigMappingsType, getConfigFromMappings } from '@aztec/foundation/config';
 
 /**
  * The prover configuration.
@@ -13,8 +13,6 @@ export type ProverClientConfig = ProverConfig & {
   bbWorkingDirectory: string;
   /** The path to the bb binary */
   bbBinaryPath: string;
-  /** True to disable proving altogether. */
-  disableProver: boolean;
 };
 
 export const proverClientConfigMappings: ConfigMappingsType<ProverClientConfig> = {
@@ -33,11 +31,6 @@ export const proverClientConfigMappings: ConfigMappingsType<ProverClientConfig> 
   bbBinaryPath: {
     env: 'BB_BINARY_PATH',
     description: 'The path to the bb binary',
-  },
-  disableProver: {
-    env: 'PROVER_DISABLED',
-    description: 'Whether to disable proving.',
-    ...booleanConfigHelper(),
   },
   ...proverConfigMappings,
 };

--- a/yarn-project/prover-client/src/orchestrator/index.ts
+++ b/yarn-project/prover-client/src/orchestrator/index.ts
@@ -1,0 +1,1 @@
+export { ProvingOrchestrator } from './orchestrator.js';

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -18,8 +18,8 @@ import {
 import {
   BlockProofError,
   type BlockProver,
-  type BlockResult,
   PROVING_STATUS,
+  type ProvingBlockResult,
   type ProvingResult,
   type ProvingTicket,
   type PublicInputsAndRecursiveProof,
@@ -450,7 +450,7 @@ export class ProvingOrchestrator implements BlockProver {
 
       this.provingState.block = l2Block;
 
-      const blockResult: BlockResult = {
+      const blockResult: ProvingBlockResult = {
         proof: this.provingState.finalProof,
         aggregationObject: this.provingState.finalAggregationObject,
         block: l2Block,

--- a/yarn-project/prover-client/src/tx-prover/factory.ts
+++ b/yarn-project/prover-client/src/tx-prover/factory.ts
@@ -5,5 +5,5 @@ import { type ProverClientConfig } from '../config.js';
 import { TxProver } from './tx-prover.js';
 
 export function createProverClient(config: ProverClientConfig, telemetry: TelemetryClient = new NoopTelemetryClient()) {
-  return config.disableProver ? undefined : TxProver.new(config, telemetry);
+  return TxProver.new(config, telemetry);
 }

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -24,6 +24,7 @@
     "test:integration:run": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --no-cache --config jest.integration.config.json"
   },
   "dependencies": {
+    "@aztec/bb-prover": "workspace:^",
     "@aztec/circuit-types": "workspace:^",
     "@aztec/circuits.js": "workspace:^",
     "@aztec/ethereum": "workspace:^",
@@ -34,6 +35,7 @@
     "@aztec/noir-protocol-circuits-types": "workspace:^",
     "@aztec/p2p": "workspace:^",
     "@aztec/protocol-contracts": "workspace:^",
+    "@aztec/prover-client": "workspace:^",
     "@aztec/simulator": "workspace:^",
     "@aztec/telemetry-client": "workspace:^",
     "@aztec/types": "workspace:^",

--- a/yarn-project/sequencer-client/src/block_builder/index.ts
+++ b/yarn-project/sequencer-client/src/block_builder/index.ts
@@ -1,0 +1,51 @@
+import { TestCircuitProver } from '@aztec/bb-prover';
+import {
+  type BlockSimulator,
+  type MerkleTreeOperations,
+  type ProcessedTx,
+  type ProvingTicket,
+  type SimulationBlockResult,
+} from '@aztec/circuit-types';
+import { type Fr, type GlobalVariables } from '@aztec/circuits.js';
+import { ProvingOrchestrator } from '@aztec/prover-client/orchestrator';
+import { type SimulationProvider } from '@aztec/simulator';
+import { type TelemetryClient } from '@aztec/telemetry-client';
+import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
+
+/**
+ * Implements a block simulator using a test circuit prover under the hood, which just simulates circuits and outputs empty proofs.
+ * This class is temporary and should die once we switch from tx effects to tx objects submissions, since sequencers won't have
+ * the need to create L2 block headers to submit to L1. When we do that, we should also remove the references to the
+ * prover-client and bb-prover packages from this package.
+ */
+export class BlockBuilder implements BlockSimulator {
+  private orchestrator: ProvingOrchestrator;
+  constructor(db: MerkleTreeOperations, simulationProvider: SimulationProvider, telemetry: TelemetryClient) {
+    const testProver = new TestCircuitProver(telemetry, simulationProvider);
+    this.orchestrator = new ProvingOrchestrator(db, testProver, telemetry);
+  }
+
+  startNewBlock(numTxs: number, globalVariables: GlobalVariables, l1ToL2Messages: Fr[]): Promise<ProvingTicket> {
+    return this.orchestrator.startNewBlock(numTxs, globalVariables, l1ToL2Messages);
+  }
+  cancelBlock(): void {
+    this.orchestrator.cancelBlock();
+  }
+  finaliseBlock(): Promise<SimulationBlockResult> {
+    return this.orchestrator.finaliseBlock();
+  }
+  setBlockCompleted(): Promise<void> {
+    return this.orchestrator.setBlockCompleted();
+  }
+  addNewTx(tx: ProcessedTx): Promise<void> {
+    return this.orchestrator.addNewTx(tx);
+  }
+}
+
+export class BlockBuilderFactory {
+  constructor(private simulationProvider: SimulationProvider, private telemetry?: TelemetryClient) {}
+
+  create(db: MerkleTreeOperations): BlockSimulator {
+    return new BlockBuilder(db, this.simulationProvider, this.telemetry ?? new NoopTelemetryClient());
+  }
+}

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -1,11 +1,11 @@
 import { type L1ToL2MessageSource, type L2BlockSource } from '@aztec/circuit-types';
-import { type ProverClient } from '@aztec/circuit-types/interfaces';
 import { type P2P } from '@aztec/p2p';
 import { PublicProcessorFactory, type SimulationProvider } from '@aztec/simulator';
 import { type TelemetryClient } from '@aztec/telemetry-client';
 import { type ContractDataSource } from '@aztec/types/contracts';
 import { type WorldStateSynchronizer } from '@aztec/world-state';
 
+import { BlockBuilderFactory } from '../block_builder/index.js';
 import { type SequencerClientConfig } from '../config.js';
 import { getGlobalVariableBuilder } from '../global_variable_builder/index.js';
 import { getL1Publisher } from '../publisher/index.js';
@@ -37,7 +37,6 @@ export class SequencerClient {
     contractDataSource: ContractDataSource,
     l2BlockSource: L2BlockSource,
     l1ToL2MessageSource: L1ToL2MessageSource,
-    prover: ProverClient,
     simulationProvider: SimulationProvider,
     telemetryClient: TelemetryClient,
   ) {
@@ -57,7 +56,7 @@ export class SequencerClient {
       globalsBuilder,
       p2pClient,
       worldStateSynchronizer,
-      prover,
+      new BlockBuilderFactory(simulationProvider, telemetryClient),
       l2BlockSource,
       l1ToL2MessageSource,
       publicProcessorFactory,

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -104,11 +104,6 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
     description: 'Whether to require every tx to have a fee payer',
     ...booleanConfigHelper(),
   },
-  sequencerSkipSubmitProofs: {
-    env: 'SEQ_SKIP_SUBMIT_PROOFS',
-    description: 'Temporary flag to skip submitting proofs, so a prover-node takes care of it.',
-    ...booleanConfigHelper(),
-  },
 };
 
 export const chainConfigMappings: ConfigMappingsType<ChainConfig> = {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -6,12 +6,7 @@ import {
   Tx,
   type TxValidator,
 } from '@aztec/circuit-types';
-import {
-  type AllowedElement,
-  BlockProofError,
-  PROVING_STATUS,
-  type ProverClient,
-} from '@aztec/circuit-types/interfaces';
+import { type AllowedElement, BlockProofError, PROVING_STATUS } from '@aztec/circuit-types/interfaces';
 import { type L2BlockBuiltStats } from '@aztec/circuit-types/stats';
 import { AztecAddress, EthAddress, type GlobalVariables, type Header, IS_DEV_NET } from '@aztec/circuits.js';
 import { Fr } from '@aztec/foundation/fields';
@@ -23,6 +18,7 @@ import { type PublicProcessorFactory } from '@aztec/simulator';
 import { Attributes, type TelemetryClient, type Tracer, trackSpan } from '@aztec/telemetry-client';
 import { type WorldStateStatus, type WorldStateSynchronizer } from '@aztec/world-state';
 
+import { BlockBuilderFactory } from '../block_builder/index.js';
 import { type GlobalVariableBuilder } from '../global_variable_builder/global_builder.js';
 import { type Attestation, type L1Publisher } from '../publisher/l1-publisher.js';
 import { type TxValidatorFactory } from '../tx_validator/tx_validator_factory.js';
@@ -53,7 +49,6 @@ export class Sequencer {
   private allowedInSetup: AllowedElement[] = [];
   private allowedInTeardown: AllowedElement[] = [];
   private maxBlockSizeInBytes: number = 1024 * 1024;
-  private skipSubmitProofs: boolean = false;
   private metrics: SequencerMetrics;
 
   constructor(
@@ -61,13 +56,13 @@ export class Sequencer {
     private globalsBuilder: GlobalVariableBuilder,
     private p2pClient: P2P,
     private worldState: WorldStateSynchronizer,
-    private prover: ProverClient,
+    private blockBuilderFactory: BlockBuilderFactory,
     private l2BlockSource: L2BlockSource,
     private l1ToL2MessageSource: L1ToL2MessageSource,
     private publicProcessorFactory: PublicProcessorFactory,
     private txValidatorFactory: TxValidatorFactory,
     telemetry: TelemetryClient,
-    config: SequencerConfig = {},
+    private config: SequencerConfig = {},
     private log = createDebugLogger('aztec:sequencer'),
   ) {
     this.updateConfig(config);
@@ -115,10 +110,8 @@ export class Sequencer {
     if (config.allowedInTeardown) {
       this.allowedInTeardown = config.allowedInTeardown;
     }
-    // TODO(palla/prover) This flag should not be needed: the sequencer should be initialized with a blockprover
-    // that does not return proofs at all (just simulates circuits), and use that to determine whether to submit
-    // proofs or not.
-    this.skipSubmitProofs = !!config.sequencerSkipSubmitProofs;
+    // TODO: Just read everything from the config object as needed instead of copying everything into local vars.
+    this.config = config;
   }
 
   /**
@@ -318,11 +311,11 @@ export class Sequencer {
     const blockSize = Math.max(2, numRealTxs);
 
     const blockBuildingTimer = new Timer();
-    const prover = this.prover.createBlockProver(this.worldState.getLatest());
-    const blockTicket = await prover.startNewBlock(blockSize, newGlobalVariables, l1ToL2Messages);
+    const blockBuilder = this.blockBuilderFactory.create(this.worldState.getLatest());
+    const blockTicket = await blockBuilder.startNewBlock(blockSize, newGlobalVariables, l1ToL2Messages);
 
     const [publicProcessorDuration, [processedTxs, failedTxs]] = await elapsed(() =>
-      processor.process(validTxs, blockSize, prover, this.txValidatorFactory.validatorForProcessedTxs()),
+      processor.process(validTxs, blockSize, blockBuilder, this.txValidatorFactory.validatorForProcessedTxs()),
     );
     if (failedTxs.length > 0) {
       const failedTxData = failedTxs.map(fail => fail.tx);
@@ -336,14 +329,14 @@ export class Sequencer {
     // we should bail.
     if (processedTxs.length === 0 && !this.skipMinTxsPerBlockCheck(elapsedSinceLastBlock)) {
       this.log.verbose('No txs processed correctly to build block. Exiting');
-      prover.cancelBlock();
+      blockBuilder.cancelBlock();
       return;
     }
 
     await assertBlockHeight();
 
     // All real transactions have been added, set the block as full and complete the proving.
-    await prover.setBlockCompleted();
+    await blockBuilder.setBlockCompleted();
 
     // Here we are now waiting for the block to be proven.
     // TODO(@PhilWindle) We should probably periodically check for things like another
@@ -355,8 +348,8 @@ export class Sequencer {
 
     await assertBlockHeight();
 
-    // Block is proven, now finalise and publish!
-    const { block, aggregationObject, proof } = await prover.finaliseBlock();
+    // Block is ready, now finalise and publish!
+    const { block } = await blockBuilder.finaliseBlock();
 
     await assertBlockHeight();
 
@@ -386,20 +379,6 @@ export class Sequencer {
     } catch (err) {
       this.metrics.recordFailedBlock();
       throw err;
-    }
-
-    // Submit the proof if we have configured this sequencer to run with an actual prover.
-    // This is temporary while we submit one proof per block, but will have to change once we
-    // move onto proving batches of multiple blocks at a time.
-    if (aggregationObject && proof && !this.skipSubmitProofs) {
-      await this.publisher.submitProof(
-        block.header,
-        block.archive.root,
-        prover.getProverId(),
-        aggregationObject,
-        proof,
-      );
-      this.log.info(`Submitted proof for block ${block.number}`);
     }
   }
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -18,7 +18,7 @@ import { type PublicProcessorFactory } from '@aztec/simulator';
 import { Attributes, type TelemetryClient, type Tracer, trackSpan } from '@aztec/telemetry-client';
 import { type WorldStateStatus, type WorldStateSynchronizer } from '@aztec/world-state';
 
-import { BlockBuilderFactory } from '../block_builder/index.js';
+import { type BlockBuilderFactory } from '../block_builder/index.js';
 import { type GlobalVariableBuilder } from '../global_variable_builder/global_builder.js';
 import { type Attestation, type L1Publisher } from '../publisher/l1-publisher.js';
 import { type TxValidatorFactory } from '../tx_validator/tx_validator_factory.js';

--- a/yarn-project/sequencer-client/tsconfig.json
+++ b/yarn-project/sequencer-client/tsconfig.json
@@ -7,6 +7,9 @@
   },
   "references": [
     {
+      "path": "../bb-prover"
+    },
+    {
       "path": "../circuit-types"
     },
     {
@@ -35,6 +38,9 @@
     },
     {
       "path": "../protocol-contracts"
+    },
+    {
+      "path": "../prover-client"
     },
     {
       "path": "../simulator"

--- a/yarn-project/simulator/src/public/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor.ts
@@ -1,8 +1,8 @@
 import {
-  type BlockProver,
   type FailedTx,
   NestedProcessReturnValues,
   type ProcessedTx,
+  type ProcessedTxHandler,
   PublicKernelType,
   type PublicProvingRequest,
   type SimulationError,
@@ -116,12 +116,13 @@ export class PublicProcessor {
   /**
    * Run each tx through the public circuit and the public kernel circuit if needed.
    * @param txs - Txs to process.
+   * @param processedTxHandler - Handler for processed txs in the context of block building or proving.
    * @returns The list of processed txs with their circuit simulation outputs.
    */
   public async process(
     txs: Tx[],
     maxTransactions = txs.length,
-    blockProver?: BlockProver,
+    processedTxHandler?: ProcessedTxHandler,
     txValidator?: TxValidator<ProcessedTx>,
   ): Promise<[ProcessedTx[], FailedTx[], NestedProcessReturnValues[]]> {
     // The processor modifies the tx objects in place, so we need to clone them.
@@ -164,9 +165,9 @@ export class PublicProcessor {
             throw new Error(`Transaction ${invalid[0].hash} invalid after processing public functions`);
           }
         }
-        // if we were given a prover then send the transaction to it for proving
-        if (blockProver) {
-          await blockProver.addNewTx(processedTx);
+        // if we were given a handler then send the transaction to it for block building or proving
+        if (processedTxHandler) {
+          await processedTxHandler.addNewTx(processedTx);
         }
         result.push(processedTx);
         returns = returns.concat(returnValues ?? []);

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -988,6 +988,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/sequencer-client@workspace:sequencer-client"
   dependencies:
+    "@aztec/bb-prover": "workspace:^"
     "@aztec/circuit-types": "workspace:^"
     "@aztec/circuits.js": "workspace:^"
     "@aztec/ethereum": "workspace:^"
@@ -999,6 +1000,7 @@ __metadata:
     "@aztec/noir-protocol-circuits-types": "workspace:^"
     "@aztec/p2p": "workspace:^"
     "@aztec/protocol-contracts": "workspace:^"
+    "@aztec/prover-client": "workspace:^"
     "@aztec/simulator": "workspace:^"
     "@aztec/telemetry-client": "workspace:^"
     "@aztec/types": "workspace:^"


### PR DESCRIPTION
Removes the code path where the sequencer would submit proofs for a given block, so this reponsibility is now exclusive of the prover-node. This allows us to remove the prover instance from the aztec node altogether, and drop the `PROVER_DISABLED` and `SEQ_SKIP_SUBMIT_PROOFS` env vars since are no longer needed.

Since the sequencer still needs to submit block roots as it is publishing tx effects instead of tx objects, we keep using the orchestrator as a means to assemble an L2Block using simulated circuits, relying on a block simulator backed by the `TestCircuitProver`. We should be able to remove this altogether once we migrate to tx objects.
