### PR TITLE
fix: Use correct PG degree adjustment in log deriv lookup relation

### DIFF
--- a/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
@@ -32,6 +32,8 @@ template <typename FF_> class LogDerivLookupRelationImpl {
         3, // log derivative lookup argument sub-relation
     };
 
+    // Note: the required correction for the second sub-relation is technically +1 but the two corrections must agree
+    // due to the way the relation algebra is written so both are set to +2.
     static constexpr std::array<size_t, 2> TOTAL_LENGTH_ADJUSTMENTS{
         2, // inverse construction sub-relation
         2  // log derivative lookup argument sub-relation

--- a/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
@@ -32,11 +32,9 @@ template <typename FF_> class LogDerivLookupRelationImpl {
         3, // log derivative lookup argument sub-relation
     };
 
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1036): Scrutinize these adjustment factors. Counting
-    // degrees suggests the first subrelation should require an adjustment of 2.
     static constexpr std::array<size_t, 2> TOTAL_LENGTH_ADJUSTMENTS{
-        1, // inverse construction sub-relation
-        1  // log derivative lookup argument sub-relation
+        2, // inverse construction sub-relation
+        2  // log derivative lookup argument sub-relation
     };
 
     static constexpr std::array<bool, 2> SUBRELATION_LINEARLY_INDEPENDENT = { true, false };

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.cpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.cpp
@@ -12,8 +12,8 @@ namespace bb {
  */
 template <class Flavor> size_t ProverInstance_<Flavor>::compute_dyadic_size(Circuit& circuit)
 {
-    // minimum circuit size due to lookup argument
-    const size_t min_size_due_to_lookups = circuit.get_tables_size() + circuit.get_lookups_size();
+    // for the lookup argument the circuit size must be at least as large as the sum of all tables used
+    const size_t min_size_due_to_lookups = circuit.get_tables_size();
 
     // minimum size of execution trace due to everything else
     size_t min_size_of_execution_trace = circuit.public_inputs.size() + circuit.num_gates;


### PR DESCRIPTION
In issue https://github.com/AztecProtocol/barretenberg/issues/1036 I noted that it seemed like all of the lookup tests passed with a seemingly lower than necessary relation degree adjustment for PG (where challenges become univariates and thus contribute to the degree). It turns out that achieving the maximum theoretical degree for this relation is somewhat of an edge case and was simply never triggered by any of our tests. I finally triggered it in another PR but I'm putting this fix in separately so they're not connected.

Also made an unrelated fix to the way the circuit size is determined based on lookups in Honk.

Closes https://github.com/AztecProtocol/barretenberg/issues/1036