### PR TITLE
feat: flamegraph artifact cleanup

### DIFF
--- a/noir-projects/noir-contracts/scripts/flamegraph.sh
+++ b/noir-projects/noir-contracts/scripts/flamegraph.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -eu
 
+# Function to clean up and exit
+cleanup_and_exit() {
+    echo "Cleaning up..."
+    rm -f "$SCRIPT_DIR/../target/$FUNCTION_ARTIFACT"
+    exit 0
+}
+
+# Trap SIGINT (Ctrl+C) and call cleanup_and_exit
+trap cleanup_and_exit SIGINT
+
 # If first  arg is -h or --help, print usage
 if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
     echo "Usage: $0 <contract> <function>"
@@ -57,3 +67,6 @@ $PROFILER gates-flamegraph --artifact-path "$SCRIPT_DIR/../target/$FUNCTION_ARTI
 # serve the file over http
 echo "Serving flamegraph at http://0.0.0.0:8000/main_gates.svg"
 python3 -m http.server --directory "$SCRIPT_DIR/../dest" 8000
+
+# Clean up before exiting
+cleanup_and_exit


### PR DESCRIPTION
Rebuilding after using the flamegraph script causes re-build to fail because it tries to process the function artifact. This was annoying me so I modified the script such that it deltes the function artifact on exit.

![image](https://github.com/user-attachments/assets/0dd71d38-e81d-4a6b-bbfa-de1d78d5c8f3)