### PR TITLE
chore(avm): tweak check-circuit settings

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.cpp
@@ -3439,7 +3439,7 @@ void AvmTraceBuilder::op_keccakf1600(uint8_t indirect,
  *
  * @return The main trace
  */
-std::vector<Row> AvmTraceBuilder::finalize(uint32_t min_trace_size, bool range_check_required)
+std::vector<Row> AvmTraceBuilder::finalize(bool range_check_required)
 {
     auto mem_trace = mem_trace_builder.finalize();
     auto alu_trace = alu_trace_builder.finalize();
@@ -3476,12 +3476,11 @@ std::vector<Row> AvmTraceBuilder::finalize(uint32_t min_trace_size, bool range_c
     // Range check size is 1 less than it needs to be since we insert a "first row" at the top of the trace at the
     // end, with clk 0 (this doubles as our range check)
     size_t const range_check_size = range_check_required ? UINT16_MAX : 0;
-    std::vector<size_t> trace_sizes = { mem_trace_size,     main_trace_size,        alu_trace_size,
-                                        range_check_size,   conv_trace_size,        lookup_table_size,
-                                        sha256_trace_size,  poseidon2_trace_size,   pedersen_trace_size,
-                                        gas_trace_size + 1, KERNEL_INPUTS_LENGTH,   KERNEL_OUTPUTS_LENGTH,
-                                        min_trace_size,     fixed_gas_table.size(), slice_trace_size,
-                                        calldata.size() };
+    std::vector<size_t> trace_sizes = { mem_trace_size,         main_trace_size,      alu_trace_size,
+                                        range_check_size,       conv_trace_size,      lookup_table_size,
+                                        sha256_trace_size,      poseidon2_trace_size, pedersen_trace_size,
+                                        gas_trace_size + 1,     KERNEL_INPUTS_LENGTH, KERNEL_OUTPUTS_LENGTH,
+                                        fixed_gas_table.size(), slice_trace_size,     calldata.size() };
     vinfo("Trace sizes before padding:",
           "\n\tmain_trace_size: ",
           main_trace_size,

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.hpp
@@ -179,7 +179,7 @@ class AvmTraceBuilder {
     void op_sha256_compression(uint8_t indirect, uint32_t output_offset, uint32_t h_init_offset, uint32_t input_offset);
     void op_keccakf1600(uint8_t indirect, uint32_t output_offset, uint32_t input_offset, uint32_t input_size_offset);
 
-    std::vector<Row> finalize(uint32_t min_trace_size = 0, bool range_check_required = ENABLE_PROVING);
+    std::vector<Row> finalize(bool range_check_required = ENABLE_PROVING);
     void reset();
 
     // (not an opcode) Halt -> stop program execution.


### PR DESCRIPTION
Run check circuit if we are not proving or if `AVM_FORCE_CHECK_CIRCUIT` (env) is defined.