### PR TITLE
fix: Add boolean config helper

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/config.ts
+++ b/yarn-project/aztec-node/src/aztec-node/config.ts
@@ -1,5 +1,5 @@
 import { type ArchiverConfig, archiverConfigMappings } from '@aztec/archiver';
-import { type ConfigMappingsType, getConfigFromMappings } from '@aztec/foundation/config';
+import { type ConfigMappingsType, booleanConfigHelper, getConfigFromMappings } from '@aztec/foundation/config';
 import { type P2PConfig, p2pConfigMappings } from '@aztec/p2p';
 import { type ProverClientConfig, proverClientConfigMappings } from '@aztec/prover-client';
 import { type SequencerClientConfig, sequencerClientConfigMappings } from '@aztec/sequencer-client';
@@ -34,15 +34,13 @@ export const aztecNodeConfigMappings: ConfigMappingsType<AztecNodeConfig> = {
   ...p2pConfigMappings,
   disableSequencer: {
     env: 'SEQ_DISABLED',
-    parseEnv: (val: string) => ['1', 'true'].includes(val),
-    default: false,
     description: 'Whether the sequencer is disabled for this node.',
+    ...booleanConfigHelper(),
   },
   disableProver: {
     env: 'PROVER_DISABLED',
-    parseEnv: (val: string) => ['1', 'true'].includes(val),
-    default: false,
     description: 'Whether the prover is disabled for this node.',
+    ...booleanConfigHelper(),
   },
 };
 

--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -27,7 +27,7 @@ export interface AztecStartOption {
 
 export const getOptions = (namespace: string, configMappings: Record<string, ConfigMapping>) => {
   const options: AztecStartOption[] = [];
-  for (const [key, { env, default: def, parseEnv, description, printDefault }] of Object.entries(configMappings)) {
+  for (const [key, { env, defaultValue: def, parseEnv, description, printDefault }] of Object.entries(configMappings)) {
     if (universalOptions.includes(key)) {
       continue;
     }

--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -1,7 +1,12 @@
 import { type ArchiverConfig, archiverConfigMappings } from '@aztec/archiver';
 import { sequencerClientConfigMappings } from '@aztec/aztec-node';
 import { botConfigMappings } from '@aztec/bot';
-import { type ConfigMapping, filterConfigMappings, isBooleanConfigValue } from '@aztec/foundation/config';
+import {
+  type ConfigMapping,
+  booleanConfigHelper,
+  filterConfigMappings,
+  isBooleanConfigValue,
+} from '@aztec/foundation/config';
 import { bootnodeConfigMappings, p2pConfigMappings } from '@aztec/p2p';
 import { proverClientConfigMappings } from '@aztec/prover-client';
 import { proverNodeConfigMappings } from '@aztec/prover-node';
@@ -54,16 +59,14 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
     {
       flag: '--sandbox.testAccounts',
       description: 'Deploy test accounts on sandbox start',
-      defaultValue: true,
       envVar: 'TEST_ACCOUNTS',
-      parseVal: val => ['1', true].includes(val),
+      ...booleanConfigHelper(true),
     },
     {
       flag: '--sandbox.enableGas',
       description: 'Enable gas on sandbox start',
-      defaultValue: false,
       envVar: 'ENABLE_GAS',
-      parseVal: val => ['1', true].includes(val),
+      ...booleanConfigHelper(),
     },
   ],
   API: [
@@ -169,9 +172,8 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
     {
       flag: '--node.deployAztecContracts',
       description: 'Deploys L1 Aztec contracts before starting the node. Needs mnemonic or private key to be set',
-      defaultValue: false,
       envVar: 'DEPLOY_AZTEC_CONTRACTS',
-      parseVal: val => ['1', true].includes(val),
+      ...booleanConfigHelper(),
     },
     {
       flag: '--node.assumeProvenUntilBlockNumber',
@@ -206,9 +208,8 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
     {
       flag: '--p2p-enabled',
       description: 'Enable P2P subsystem',
-      defaultValue: false,
       envVar: 'P2P_ENABLED',
-      parseVal: val => ['1', true].includes(val),
+      ...booleanConfigHelper(),
     },
     ...getOptions('p2p', p2pConfigMappings),
   ],

--- a/yarn-project/bot/src/config.ts
+++ b/yarn-project/bot/src/config.ts
@@ -1,6 +1,7 @@
 import { Fr } from '@aztec/circuits.js';
 import {
   type ConfigMappingsType,
+  booleanConfigHelper,
   getConfigFromMappings,
   getDefaultConfig,
   numberConfigHelper,
@@ -78,8 +79,7 @@ export const botConfigMappings: ConfigMappingsType<BotConfig> = {
   noStart: {
     env: 'BOT_NO_START',
     description: 'True to not automatically setup or start the bot on initialization.',
-    parseEnv: val => ['1', 'true'].includes(val),
-    default: false,
+    ...booleanConfigHelper(),
   },
   txMinedWaitSeconds: {
     env: 'BOT_TX_MINED_WAIT_SECONDS',
@@ -89,8 +89,7 @@ export const botConfigMappings: ConfigMappingsType<BotConfig> = {
   noWaitForTransfers: {
     env: 'BOT_NO_WAIT_FOR_TRANSFERS',
     description: "Don't wait for transfer transactions.",
-    parseEnv: val => ['1', 'true'].includes(val),
-    default: false,
+    ...booleanConfigHelper(),
   },
 };
 

--- a/yarn-project/bot/src/config.ts
+++ b/yarn-project/bot/src/config.ts
@@ -41,19 +41,19 @@ export const botConfigMappings: ConfigMappingsType<BotConfig> = {
     env: 'BOT_PRIVATE_KEY',
     description: 'Signing private key for the sender account.',
     parseEnv: (val: string) => Fr.fromString(val),
-    default: Fr.random(),
+    defaultValue: Fr.random(),
   },
   recipientEncryptionSecret: {
     env: 'BOT_RECIPIENT_ENCRYPTION_SECRET',
     description: 'Encryption secret for a recipient account.',
     parseEnv: (val: string) => Fr.fromString(val),
-    default: Fr.fromString('0xcafecafe'),
+    defaultValue: Fr.fromString('0xcafecafe'),
   },
   tokenSalt: {
     env: 'BOT_TOKEN_SALT',
     description: 'Salt for the token contract deployment.',
     parseEnv: (val: string) => Fr.fromString(val),
-    default: Fr.fromString('1'),
+    defaultValue: Fr.fromString('1'),
   },
   txIntervalSeconds: {
     env: 'BOT_TX_INTERVAL_SECONDS',
@@ -74,7 +74,7 @@ export const botConfigMappings: ConfigMappingsType<BotConfig> = {
     env: 'BOT_FEE_PAYMENT_METHOD',
     description: 'How to handle fee payments. (Options: fee_juice, none)',
     parseEnv: val => (val as 'fee_juice' | 'none') || undefined,
-    default: 'none',
+    defaultValue: 'none',
   },
   noStart: {
     env: 'BOT_NO_START',

--- a/yarn-project/circuit-types/src/interfaces/prover-client.ts
+++ b/yarn-project/circuit-types/src/interfaces/prover-client.ts
@@ -1,6 +1,6 @@
 import { type TxHash } from '@aztec/circuit-types';
 import { Fr } from '@aztec/circuits.js';
-import { type ConfigMappingsType, numberConfigHelper } from '@aztec/foundation/config';
+import { type ConfigMappingsType, booleanConfigHelper, numberConfigHelper } from '@aztec/foundation/config';
 
 import { type BlockProver } from './block-prover.js';
 import { type MerkleTreeOperations } from './merkle_tree_operations.js';
@@ -37,15 +37,13 @@ export const proverConfigMappings: ConfigMappingsType<ProverConfig> = {
   },
   realProofs: {
     env: 'PROVER_REAL_PROOFS',
-    parseEnv: (val: string) => ['1', 'true'].includes(val),
-    default: false,
     description: 'Whether to construct real proofs',
+    ...booleanConfigHelper(),
   },
   proverAgentEnabled: {
     env: 'PROVER_AGENT_ENABLED',
-    parseEnv: (val: string) => ['1', 'true'].includes(val),
-    default: true,
     description: 'Whether this prover has a local prover agent',
+    ...booleanConfigHelper(true),
   },
   proverAgentPollInterval: {
     env: 'PROVER_AGENT_POLL_INTERVAL_MS',

--- a/yarn-project/ethereum/src/l1_reader.ts
+++ b/yarn-project/ethereum/src/l1_reader.ts
@@ -29,12 +29,12 @@ export const l1ReaderConfigMappings: ConfigMappingsType<L1ReaderConfig> = {
   l1ChainId: {
     env: 'L1_CHAIN_ID',
     parseEnv: (val: string) => +val,
-    default: 31337,
+    defaultValue: 31337,
     description: 'The chain ID of the ethereum host.',
   },
   // NOTE: Special case for l1Contracts
   l1Contracts: {
     description: 'The deployed L1 contract addresses',
-    default: l1ContractAddressesMapping,
+    defaultValue: l1ContractAddressesMapping,
   },
 };

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -60,10 +60,23 @@ export function filterConfigMappings<T, K extends keyof T>(
  * @param defaultVal - The default numerical value to use if the environment variable is not set or is invalid
  * @returns Object with parseEnv and default values for a numerical config value
  */
-export function numberConfigHelper(defaultVal: number): Partial<ConfigMapping> {
+export function numberConfigHelper(defaultVal: number): Pick<ConfigMapping, 'parseEnv' | 'default'> {
   return {
     parseEnv: (val: string) => safeParseNumber(val, defaultVal),
     default: defaultVal,
+  };
+}
+
+/**
+ * Generates parseEnv and default values for a boolean config value.
+ * @param defaultVal - The default value to use if the environment variable is not set or is invalid
+ * @returns Object with parseEnv and default values for a boolean config value
+ */
+export function booleanConfigHelper(defaultVal = false): Pick<ConfigMapping, 'parseEnv' | 'default' | 'isBoolean'> {
+  return {
+    parseEnv: (val: string) => ['1', 'true', 'TRUE'].includes(val),
+    default: defaultVal,
+    isBoolean: true,
   };
 }
 

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -5,7 +5,7 @@ export { EnvVar } from './env_var.js';
 export interface ConfigMapping {
   env?: EnvVar;
   parseEnv?: (val: string) => any;
-  default?: any;
+  defaultValue?: any;
   printDefault?: (val: any) => string;
   description: string;
   isBoolean?: boolean;
@@ -22,7 +22,7 @@ export function getConfigFromMappings<T>(configMappings: ConfigMappingsType<T>):
 
   for (const key in configMappings) {
     if (configMappings[key]) {
-      const { env, parseEnv, default: def } = configMappings[key];
+      const { env, parseEnv, defaultValue: def } = configMappings[key];
       // Special case for L1 contract addresses which is an object of config values
       if (key === 'l1Contracts' && def) {
         (config as any)[key] = getConfigFromMappings(def);
@@ -60,10 +60,10 @@ export function filterConfigMappings<T, K extends keyof T>(
  * @param defaultVal - The default numerical value to use if the environment variable is not set or is invalid
  * @returns Object with parseEnv and default values for a numerical config value
  */
-export function numberConfigHelper(defaultVal: number): Pick<ConfigMapping, 'parseEnv' | 'default'> {
+export function numberConfigHelper(defaultVal: number): Pick<ConfigMapping, 'parseEnv' | 'defaultValue'> {
   return {
     parseEnv: (val: string) => safeParseNumber(val, defaultVal),
-    default: defaultVal,
+    defaultValue: defaultVal,
   };
 }
 
@@ -72,10 +72,12 @@ export function numberConfigHelper(defaultVal: number): Pick<ConfigMapping, 'par
  * @param defaultVal - The default value to use if the environment variable is not set or is invalid
  * @returns Object with parseEnv and default values for a boolean config value
  */
-export function booleanConfigHelper(defaultVal = false): Pick<ConfigMapping, 'parseEnv' | 'default' | 'isBoolean'> {
+export function booleanConfigHelper(
+  defaultVal = false,
+): Required<Pick<ConfigMapping, 'parseEnv' | 'defaultValue' | 'isBoolean'>> {
   return {
     parseEnv: (val: string) => ['1', 'true', 'TRUE'].includes(val),
-    default: defaultVal,
+    defaultValue: defaultVal,
     isBoolean: true,
   };
 }
@@ -119,8 +121,8 @@ export function getDefaultConfig<T>(configMappings: ConfigMappingsType<T>): T {
   const defaultConfig = {} as T;
 
   for (const key in configMappings) {
-    if (configMappings[key] && configMappings[key].default !== undefined) {
-      (defaultConfig as any)[key] = configMappings[key].default;
+    if (configMappings[key] && configMappings[key].defaultValue !== undefined) {
+      (defaultConfig as any)[key] = configMappings[key].defaultValue;
     }
   }
 

--- a/yarn-project/p2p/src/config.ts
+++ b/yarn-project/p2p/src/config.ts
@@ -112,12 +112,12 @@ export const p2pConfigMappings: ConfigMappingsType<P2PConfig> = {
   },
   tcpListenAddress: {
     env: 'TCP_LISTEN_ADDR',
-    default: '0.0.0.0:40400',
+    defaultValue: '0.0.0.0:40400',
     description: 'The listen address for TCP. Format: <IP_ADDRESS>:<PORT>.',
   },
   udpListenAddress: {
     env: 'UDP_LISTEN_ADDR',
-    default: '0.0.0.0:40400',
+    defaultValue: '0.0.0.0:40400',
     description: 'The listen address for UDP. Format: <IP_ADDRESS>:<PORT>.',
   },
   tcpAnnounceAddress: {
@@ -142,7 +142,7 @@ export const p2pConfigMappings: ConfigMappingsType<P2PConfig> = {
   transactionProtocol: {
     env: 'P2P_TX_PROTOCOL',
     description: 'Protocol identifier for transaction gossiping.',
-    default: '/aztec/0.1.0',
+    defaultValue: '/aztec/0.1.0',
   },
   minPeerCount: {
     env: 'P2P_MIN_PEERS',

--- a/yarn-project/p2p/src/config.ts
+++ b/yarn-project/p2p/src/config.ts
@@ -1,5 +1,6 @@
 import {
   type ConfigMappingsType,
+  booleanConfigHelper,
   getConfigFromMappings,
   numberConfigHelper,
   pickConfigMappings,
@@ -91,8 +92,8 @@ export interface P2PConfig {
 export const p2pConfigMappings: ConfigMappingsType<P2PConfig> = {
   p2pEnabled: {
     env: 'P2P_ENABLED',
-    parseEnv: (val: string) => ['1', 'true'].includes(val),
     description: 'A flag dictating whether the P2P subsystem should be enabled.',
+    ...booleanConfigHelper(),
   },
   blockCheckIntervalMS: {
     env: 'P2P_BLOCK_CHECK_INTERVAL_MS',
@@ -161,7 +162,7 @@ export const p2pConfigMappings: ConfigMappingsType<P2PConfig> = {
     env: 'P2P_QUERY_FOR_IP',
     description:
       'If announceUdpAddress or announceTcpAddress are not provided, query for the IP address of the machine. Default is false.',
-    parseEnv: (val: string) => ['1', 'true'].includes(val),
+    ...booleanConfigHelper(),
   },
   keepProvenTxsInPoolFor: {
     env: 'P2P_TX_POOL_KEEP_PROVEN_FOR',

--- a/yarn-project/prover-client/src/config.ts
+++ b/yarn-project/prover-client/src/config.ts
@@ -1,5 +1,5 @@
 import { type ProverConfig, proverConfigMappings } from '@aztec/circuit-types';
-import { type ConfigMappingsType, getConfigFromMappings } from '@aztec/foundation/config';
+import { type ConfigMappingsType, booleanConfigHelper, getConfigFromMappings } from '@aztec/foundation/config';
 
 /**
  * The prover configuration.
@@ -36,9 +36,8 @@ export const proverClientConfigMappings: ConfigMappingsType<ProverClientConfig> 
   },
   disableProver: {
     env: 'PROVER_DISABLED',
-    parseEnv: (val: string) => ['1', 'true'].includes(val),
-    default: false,
     description: 'Whether to disable proving.',
+    ...booleanConfigHelper(),
   },
   ...proverConfigMappings,
 };

--- a/yarn-project/pxe/src/config/index.ts
+++ b/yarn-project/pxe/src/config/index.ts
@@ -1,5 +1,10 @@
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/circuits.js/constants';
-import { type ConfigMappingsType, getConfigFromMappings, numberConfigHelper } from '@aztec/foundation/config';
+import {
+  type ConfigMappingsType,
+  booleanConfigHelper,
+  getConfigFromMappings,
+  numberConfigHelper,
+} from '@aztec/foundation/config';
 import { type Network } from '@aztec/types/network';
 
 import { readFileSync } from 'fs';
@@ -69,9 +74,8 @@ export const pxeConfigMappings: ConfigMappingsType<PXEServiceConfig> = {
   },
   proverEnabled: {
     env: 'PXE_PROVER_ENABLED',
-    parseEnv: (val: string) => ['1', 'true'].includes(val),
     description: 'Enable real proofs',
-    isBoolean: true,
+    ...booleanConfigHelper(),
   },
 };
 
@@ -103,7 +107,7 @@ export const allPxeConfigMappings: ConfigMappingsType<CliPXEOptions & PXEService
   ...pxeCliConfigMappings,
   proverEnabled: {
     env: 'PXE_PROVER_ENABLED',
-    parseEnv: (val: string) => ['1', 'true'].includes(val) || !!process.env.NETWORK,
+    parseEnv: (val: string) => ['1', 'true', 'TRUE'].includes(val) || !!process.env.NETWORK,
     description: 'Enable real proofs',
     isBoolean: true,
   },

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -82,7 +82,7 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
   allowedInSetup: {
     env: 'SEQ_ALLOWED_SETUP_FN',
     parseEnv: (val: string) => parseSequencerAllowList(val),
-    default: getDefaultAllowedSetupFunctions(),
+    defaultValue: getDefaultAllowedSetupFunctions(),
     description: 'The list of functions calls allowed to run in setup',
     printDefault: () =>
       'AuthRegistry, FeeJuice.increase_public_balance, Token.increase_public_balance, FPC.prepare_fee',
@@ -90,7 +90,7 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
   allowedInTeardown: {
     env: 'SEQ_ALLOWED_TEARDOWN_FN',
     parseEnv: (val: string) => parseSequencerAllowList(val),
-    default: getDefaultAllowedTeardownFunctions(),
+    defaultValue: getDefaultAllowedTeardownFunctions(),
     description: 'The list of functions calls allowed to run teardown',
     printDefault: () => 'FPC.pay_refund, FPC.pay_refund_with_shielded_rebate',
   },

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -1,7 +1,12 @@
 import { type AllowedElement } from '@aztec/circuit-types';
 import { AztecAddress, Fr, FunctionSelector, getContractClassFromArtifact } from '@aztec/circuits.js';
 import { type L1ReaderConfig, l1ReaderConfigMappings } from '@aztec/ethereum';
-import { type ConfigMappingsType, getConfigFromMappings, numberConfigHelper } from '@aztec/foundation/config';
+import {
+  type ConfigMappingsType,
+  booleanConfigHelper,
+  getConfigFromMappings,
+  numberConfigHelper,
+} from '@aztec/foundation/config';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { FPCContract } from '@aztec/noir-contracts.js/FPC';
 import { TokenContractArtifact } from '@aztec/noir-contracts.js/Token';
@@ -96,13 +101,13 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
   },
   enforceFees: {
     env: 'ENFORCE_FEES',
-    parseEnv: (val: string) => ['1', 'true'].includes(val),
     description: 'Whether to require every tx to have a fee payer',
+    ...booleanConfigHelper(),
   },
   sequencerSkipSubmitProofs: {
     env: 'SEQ_SKIP_SUBMIT_PROOFS',
-    parseEnv: (val: string) => ['1', 'true'].includes(val),
     description: 'Temporary flag to skip submitting proofs, so a prover-node takes care of it.',
+    ...booleanConfigHelper(),
   },
 };
 

--- a/yarn-project/sequencer-client/src/publisher/config.ts
+++ b/yarn-project/sequencer-client/src/publisher/config.ts
@@ -36,19 +36,19 @@ export const getTxSenderConfigMappings: (
   l1ChainId: {
     env: 'L1_CHAIN_ID',
     parseEnv: (val: string) => +val,
-    default: 31337,
+    defaultValue: 31337,
     description: 'The chain ID of the ethereum host.',
   },
   publisherPrivateKey: {
     env: `${scope}_PUBLISHER_PRIVATE_KEY`,
     description: 'The private key to be used by the publisher.',
     parseEnv: (val: string) => (val ? `0x${val.replace('0x', '')}` : NULL_KEY),
-    default: NULL_KEY,
+    defaultValue: NULL_KEY,
   },
   requiredConfirmations: {
     env: `${scope}_REQUIRED_CONFIRMATIONS`,
     parseEnv: (val: string) => +val,
-    default: 1,
+    defaultValue: 1,
     description: 'The number of confirmations required.',
   },
 });
@@ -61,7 +61,7 @@ export const getPublisherConfigMappings: (scope: 'PROVER' | 'SEQ') => ConfigMapp
   l1PublishRetryIntervalMS: {
     env: `${scope}_PUBLISH_RETRY_INTERVAL_MS`,
     parseEnv: (val: string) => +val,
-    default: 1000,
+    defaultValue: 1000,
     description: 'The interval to wait between publish retries.',
   },
 });

--- a/yarn-project/telemetry-client/src/config.ts
+++ b/yarn-project/telemetry-client/src/config.ts
@@ -15,12 +15,12 @@ export const telemetryClientConfigMappings: ConfigMappingsType<TelemetryClientCo
   serviceName: {
     env: 'OTEL_SERVICE_NAME',
     description: 'The URL of the telemetry collector',
-    default: 'aztec',
+    defaultValue: 'aztec',
   },
   networkName: {
     env: 'NETWORK_NAME',
     description: 'The network ID of the telemetry service',
-    default: 'local',
+    defaultValue: 'local',
   },
 };
 

--- a/yarn-project/world-state/src/synchronizer/config.ts
+++ b/yarn-project/world-state/src/synchronizer/config.ts
@@ -16,13 +16,13 @@ export const worldStateConfigMappings: ConfigMappingsType<WorldStateConfig> = {
   worldStateBlockCheckIntervalMS: {
     env: 'WS_BLOCK_CHECK_INTERVAL_MS',
     parseEnv: (val: string) => +val,
-    default: 100,
+    defaultValue: 100,
     description: 'The frequency in which to check.',
   },
   l2QueueSize: {
     env: 'WS_L2_BLOCK_QUEUE_SIZE',
     parseEnv: (val: string) => +val,
-    default: 1000,
+    defaultValue: 1000,
     description: 'Size of queue of L2 blocks to store.',
   },
   worldStateProvenBlocksOnly: {

--- a/yarn-project/world-state/src/synchronizer/config.ts
+++ b/yarn-project/world-state/src/synchronizer/config.ts
@@ -1,4 +1,4 @@
-import { type ConfigMappingsType, getConfigFromMappings } from '@aztec/foundation/config';
+import { type ConfigMappingsType, booleanConfigHelper, getConfigFromMappings } from '@aztec/foundation/config';
 
 /** World State synchronizer configuration values. */
 export interface WorldStateConfig {
@@ -27,9 +27,8 @@ export const worldStateConfigMappings: ConfigMappingsType<WorldStateConfig> = {
   },
   worldStateProvenBlocksOnly: {
     env: 'WS_PROVEN_BLOCKS_ONLY',
-    parseEnv: (val: string) => ['1', 'true'].includes(val),
-    default: false,
     description: 'Whether to follow only the proven chain.',
+    ...booleanConfigHelper(),
   },
 };
 


### PR DESCRIPTION
Adds a helper method for parsing boolean env vars, and fixes instances where we were looking for true (boolean) instead of 'true' (string) when parsing env.