### PR TITLE
feat: Cheat rollup contract into assuming first blocks as proven

### DIFF
--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -180,6 +180,24 @@ contract RollupTest is DecoderBase {
     rollup.process(header, archive);
   }
 
+  function testBlocksWithAssumeProven() public setUpFor("mixed_block_1") {
+    rollup.setAssumeProvenUntilBlockNumber(2);
+    _testBlock("mixed_block_1", false);
+    _testBlock("mixed_block_2", false);
+
+    assertEq(rollup.pendingBlockCount(), 3, "Invalid pending block count");
+    assertEq(rollup.provenBlockCount(), 2, "Invalid proven block count");
+  }
+
+  function testSetAssumeProvenAfterBlocksProcessed() public setUpFor("mixed_block_1") {
+    _testBlock("mixed_block_1", false);
+    _testBlock("mixed_block_2", false);
+    rollup.setAssumeProvenUntilBlockNumber(2);
+
+    assertEq(rollup.pendingBlockCount(), 3, "Invalid pending block count");
+    assertEq(rollup.provenBlockCount(), 2, "Invalid proven block count");
+  }
+
   function testSubmitProofNonExistantBlock() public setUpFor("empty_block_1") {
     DecoderBase.Data memory data = load("empty_block_1").block;
     bytes memory header = data.header;

--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -174,6 +174,14 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
       parseVal: val => ['1', true].includes(val),
     },
     {
+      flag: '--node.assumeProvenUntilBlockNumber',
+      description:
+        'Cheats the rollup contract into assuming every block until this one is proven. Useful for speeding up bootstraps.',
+      envVar: 'ASSUME_PROVEN_UNTIL_BLOCK_NUMBER',
+      parseVal: (val: string) => parseInt(val, 10),
+      defaultValue: 0,
+    },
+    {
       flag: '--node.publisherPrivateKey <value>',
       description: 'Private key of account for publishing L1 contracts',
       defaultValue: undefined,

--- a/yarn-project/aztec/src/cli/cmds/start_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_node.ts
@@ -50,7 +50,9 @@ export const startNode = async (
     } else {
       throw new Error('--node.publisherPrivateKey or --l1-mnemonic is required to deploy L1 contracts');
     }
-    await deployContractsToL1(nodeConfig, account!);
+    await deployContractsToL1(nodeConfig, account!, undefined, {
+      assumeProvenUntilBlockNumber: nodeSpecificOptions.assumeProvenUntilBlockNumber,
+    });
   }
 
   // if no publisher private key, then use l1Mnemonic

--- a/yarn-project/aztec/src/sandbox.ts
+++ b/yarn-project/aztec/src/sandbox.ts
@@ -90,6 +90,7 @@ export async function deployContractsToL1(
   aztecNodeConfig: AztecNodeConfig,
   hdAccount: HDAccount | PrivateKeyAccount,
   contractDeployLogger = logger,
+  opts: { assumeProvenUntilBlockNumber?: number } = {},
 ) {
   const l1Artifacts: L1ContractArtifactsForDeployment = {
     registry: {
@@ -130,6 +131,7 @@ export async function deployContractsToL1(
     deployL1Contracts(aztecNodeConfig.l1RpcUrl, hdAccount, chain.chainInfo, contractDeployLogger, l1Artifacts, {
       l2FeeJuiceAddress: FeeJuiceAddress,
       vkTreeRoot: getVKTreeRoot(),
+      assumeProvenUntil: opts.assumeProvenUntilBlockNumber,
     }),
   );
 


### PR DESCRIPTION
Adds a temp state variable in the rollup contract `assumeProvenUntilBlockNumber`, which makes every block submitted with a block number up to that one to be automatically flagged as proven.

This helps in expensive chain setups where we want to skip proving.
