### PR TITLE
feat: add `onlyOwner` to `Registry::upgrade`

### DIFF
--- a/l1-contracts/src/core/messagebridge/Registry.sol
+++ b/l1-contracts/src/core/messagebridge/Registry.sol
@@ -99,8 +99,10 @@ contract Registry is IRegistry, Ownable {
 
   /**
    * @notice Creates a new snapshot of the registry
+   *
+   * @dev Only callable by the owner
    * @dev Reverts if the rollup is already registered
-   * todo: this function must be permissioned with some kind of governance/voting/authority
+   *
    * @param _rollup - The address of the rollup contract
    * @param _inbox - The address of the inbox contract
    * @param _outbox - The address of the outbox contract
@@ -109,6 +111,7 @@ contract Registry is IRegistry, Ownable {
   function upgrade(address _rollup, address _inbox, address _outbox)
     public
     override(IRegistry)
+    onlyOwner
     returns (uint256)
   {
     (, bool exists) = _getVersionFor(_rollup);

--- a/l1-contracts/test/Registry.t.sol
+++ b/l1-contracts/test/Registry.t.sol
@@ -3,8 +3,7 @@
 pragma solidity >=0.8.18;
 
 import {Test} from "forge-std/Test.sol";
-import {IInbox} from "../src/core/interfaces/messagebridge/IInbox.sol";
-import {Inbox} from "../src/core/messagebridge/Inbox.sol";
+import {Ownable} from "@oz/access/Ownable.sol";
 import {Registry} from "../src/core/messagebridge/Registry.sol";
 import {Errors} from "../src/core/libraries/Errors.sol";
 
@@ -63,5 +62,12 @@ contract RegistryTest is Test {
     address rollup = address(0xbeef1);
     vm.expectRevert(abi.encodeWithSelector(Errors.Registry__RollupNotRegistered.selector, rollup));
     registry.getVersionFor(rollup);
+  }
+
+  function testRevertUpgradeAsNonOwner(address _owner) public {
+    vm.assume(_owner != registry.owner());
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, _owner));
+    vm.prank(_owner);
+    registry.upgrade(DEAD, DEAD, DEAD);
   }
 }


### PR DESCRIPTION
Fixes #7896 by actually using `onlyOwner` at the `upgrade` function of the registry and adding an extra test for it.