### PR TITLE
fix: Track L1 block for last L2 block body retrieved

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -30,8 +30,10 @@ import { type DataRetrieval } from './data_retrieval.js';
  * Represents the latest L1 block processed by the archiver for various objects in L2.
  */
 export type ArchiverL1SynchPoint = {
-  /** Number of the last L1 block that added a new L2 block.  */
+  /** Number of the last L1 block that added a new L2 block metadata.  */
   blocksSynchedTo: bigint;
+  /** Number of the last L1 block that added a new L2 block body.  */
+  blockBodiesSynchedTo: bigint;
   /** Number of the last L1 block that added L1 -> L2 messages from the Inbox. */
   messagesSynchedTo: bigint;
 };
@@ -53,7 +55,7 @@ export interface ArchiverDataStore {
    * @param blockBodies - The L2 block bodies to be added to the store.
    * @returns True if the operation is successful.
    */
-  addBlockBodies(blockBodies: Body[]): Promise<boolean>;
+  addBlockBodies(blockBodies: DataRetrieval<Body>): Promise<boolean>;
 
   /**
    * Gets block bodies that have the same txsEffectsHashes as we supply.

--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -97,7 +97,6 @@ export async function retrieveBlockBodiesFromAvailabilityOracle(
   searchEndBlock: bigint,
 ): Promise<DataRetrieval<Body>> {
   const retrievedBlockBodies: Body[] = [];
-  let lastProcessedL1BlockNumber = searchStartBlock;
 
   do {
     if (searchStartBlock > searchEndBlock) {
@@ -115,11 +114,10 @@ export async function retrieveBlockBodiesFromAvailabilityOracle(
 
     const newBlockBodies = await processTxsPublishedLogs(publicClient, l2TxsPublishedLogs);
     retrievedBlockBodies.push(...newBlockBodies.map(([body]) => body));
-    lastProcessedL1BlockNumber = l2TxsPublishedLogs[l2TxsPublishedLogs.length - 1].blockNumber!;
-    searchStartBlock = lastProcessedL1BlockNumber + 1n;
+    searchStartBlock = l2TxsPublishedLogs[l2TxsPublishedLogs.length - 1].blockNumber + 1n;
   } while (blockUntilSynced && searchStartBlock <= searchEndBlock);
 
-  return { lastProcessedL1BlockNumber, retrievedData: retrievedBlockBodies };
+  return { lastProcessedL1BlockNumber: searchStartBlock - 1n, retrievedData: retrievedBlockBodies };
 }
 
 /**

--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -1,6 +1,7 @@
 import { type Body, type InboxLeaf } from '@aztec/circuit-types';
 import { type AppendOnlyTreeSnapshot, Fr, type Header } from '@aztec/circuits.js';
 import { type EthAddress } from '@aztec/foundation/eth-address';
+import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import { RollupAbi } from '@aztec/l1-artifacts';
 
 import { type PublicClient, getAbiItem } from 'viem';
@@ -45,6 +46,7 @@ export async function retrieveBlockMetadataFromRollup(
   searchStartBlock: bigint,
   searchEndBlock: bigint,
   expectedNextL2BlockNum: bigint,
+  logger: DebugLogger = createDebugLogger('aztec:archiver'),
 ): Promise<DataRetrieval<[Header, AppendOnlyTreeSnapshot]>> {
   const retrievedBlockMetadata: [Header, AppendOnlyTreeSnapshot][] = [];
   do {
@@ -61,13 +63,18 @@ export async function retrieveBlockMetadataFromRollup(
       break;
     }
 
+    const lastLog = l2BlockProcessedLogs[l2BlockProcessedLogs.length - 1];
+    logger.debug(
+      `Got L2 block processed logs for ${l2BlockProcessedLogs[0].blockNumber}-${lastLog.blockNumber} between ${searchStartBlock}-${searchEndBlock} L1 blocks`,
+    );
+
     const newBlockMetadata = await processL2BlockProcessedLogs(
       publicClient,
       expectedNextL2BlockNum,
       l2BlockProcessedLogs,
     );
     retrievedBlockMetadata.push(...newBlockMetadata);
-    searchStartBlock = l2BlockProcessedLogs[l2BlockProcessedLogs.length - 1].blockNumber! + 1n;
+    searchStartBlock = lastLog.blockNumber! + 1n;
     expectedNextL2BlockNum += BigInt(newBlockMetadata.length);
   } while (blockUntilSynced && searchStartBlock <= searchEndBlock);
   return { lastProcessedL1BlockNumber: searchStartBlock - 1n, retrievedData: retrievedBlockMetadata };
@@ -80,7 +87,7 @@ export async function retrieveBlockMetadataFromRollup(
  * @param blockUntilSynced - If true, blocks until the archiver has fully synced.
  * @param searchStartBlock - The block number to use for starting the search.
  * @param searchEndBlock - The highest block number that we should search up to.
- * @returns A array of tuples of L2 block bodies and their associated hash as well as the next eth block to search from
+ * @returns A array of L2 block bodies as well as the next eth block to search from
  */
 export async function retrieveBlockBodiesFromAvailabilityOracle(
   publicClient: PublicClient,
@@ -88,8 +95,9 @@ export async function retrieveBlockBodiesFromAvailabilityOracle(
   blockUntilSynced: boolean,
   searchStartBlock: bigint,
   searchEndBlock: bigint,
-): Promise<DataRetrieval<[Body, Buffer]>> {
-  const retrievedBlockBodies: [Body, Buffer][] = [];
+): Promise<DataRetrieval<Body>> {
+  const retrievedBlockBodies: Body[] = [];
+  let lastProcessedL1BlockNumber = searchStartBlock;
 
   do {
     if (searchStartBlock > searchEndBlock) {
@@ -106,10 +114,12 @@ export async function retrieveBlockBodiesFromAvailabilityOracle(
     }
 
     const newBlockBodies = await processTxsPublishedLogs(publicClient, l2TxsPublishedLogs);
-    retrievedBlockBodies.push(...newBlockBodies);
-    searchStartBlock = l2TxsPublishedLogs[l2TxsPublishedLogs.length - 1].blockNumber! + 1n;
+    retrievedBlockBodies.push(...newBlockBodies.map(([body]) => body));
+    lastProcessedL1BlockNumber = l2TxsPublishedLogs[l2TxsPublishedLogs.length - 1].blockNumber!;
+    searchStartBlock = lastProcessedL1BlockNumber + 1n;
   } while (blockUntilSynced && searchStartBlock <= searchEndBlock);
-  return { lastProcessedL1BlockNumber: searchStartBlock - 1n, retrievedData: retrievedBlockBodies };
+
+  return { lastProcessedL1BlockNumber, retrievedData: retrievedBlockBodies };
 }
 
 /**

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/block_body_store.test.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/block_body_store.test.ts
@@ -13,12 +13,14 @@ describe('Block Body Store', () => {
   it('Should add and return block bodies', async () => {
     const body = Body.random(1);
 
-    await archiverStore.addBlockBodies([body]);
+    await archiverStore.addBlockBodies({ retrievedData: [body], lastProcessedL1BlockNumber: 5n });
 
     const txsEffectsHash = body.getTxsEffectsHash();
 
     const [returnedBody] = await archiverStore.getBlockBodies([txsEffectsHash]);
-
     expect(body).toStrictEqual(returnedBody);
+
+    const { blockBodiesSynchedTo } = await archiverStore.getSynchPoint();
+    expect(blockBodiesSynchedTo).toEqual(5n);
   });
 });

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -101,7 +101,7 @@ export class KVArchiverDataStore implements ArchiverDataStore {
    * @param blockBodies - The L2 block bodies to be added to the store.
    * @returns True if the operation is successful.
    */
-  addBlockBodies(blockBodies: Body[]): Promise<boolean> {
+  addBlockBodies(blockBodies: DataRetrieval<Body>): Promise<boolean> {
     return this.#blockBodyStore.addBlockBodies(blockBodies);
   }
 
@@ -260,6 +260,7 @@ export class KVArchiverDataStore implements ArchiverDataStore {
   getSynchPoint(): Promise<ArchiverL1SynchPoint> {
     return Promise.resolve({
       blocksSynchedTo: this.#blockStore.getSynchedL1BlockNumber(),
+      blockBodiesSynchedTo: this.#blockBodyStore.getSynchedL1BlockNumber(),
       messagesSynchedTo: this.#messageStore.getSynchedL1BlockNumber(),
     });
   }

--- a/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
@@ -83,6 +83,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
   private contractInstances: Map<string, ContractInstanceWithAddress> = new Map();
 
   private lastL1BlockNewBlocks: bigint = 0n;
+  private lastL1BlockNewBlockBodies: bigint = 0n;
   private lastL1BlockNewMessages: bigint = 0n;
   private lastProvenL2BlockNumber: number = 0;
 
@@ -163,11 +164,11 @@ export class MemoryArchiverStore implements ArchiverDataStore {
    * @param blockBodies - The L2 block bodies to be added to the store.
    * @returns True if the operation is successful.
    */
-  addBlockBodies(blockBodies: Body[]): Promise<boolean> {
-    for (const body of blockBodies) {
+  addBlockBodies(blockBodies: DataRetrieval<Body>): Promise<boolean> {
+    for (const body of blockBodies.retrievedData) {
       void this.l2BlockBodies.set(body.getTxsEffectsHash().toString('hex'), body);
     }
-
+    this.lastL1BlockNewBlockBodies = blockBodies.lastProcessedL1BlockNumber;
     return Promise.resolve(true);
   }
 
@@ -443,6 +444,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
     return Promise.resolve({
       blocksSynchedTo: this.lastL1BlockNewBlocks,
       messagesSynchedTo: this.lastL1BlockNewMessages,
+      blockBodiesSynchedTo: this.lastL1BlockNewBlockBodies,
     });
   }
 

--- a/yarn-project/circuit-types/src/l2_block.ts
+++ b/yarn-project/circuit-types/src/l2_block.ts
@@ -233,6 +233,7 @@ export class L2Block {
     return {
       txCount: this.body.txEffects.length,
       blockNumber: this.number,
+      blockTimestamp: this.header.globalVariables.timestamp.toNumber(),
       ...logsStats,
     };
   }

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -11,6 +11,7 @@ import {
   type PXE,
   type Wallet,
   deriveKeys,
+  retryUntil,
 } from '@aztec/aztec.js';
 import { times } from '@aztec/foundation/collection';
 import { poseidon2HashWithSeparator } from '@aztec/foundation/crypto';
@@ -314,6 +315,17 @@ describe('e2e_block_building', () => {
       if (teardown) {
         await teardown();
       }
+    });
+
+    // Regression for https://github.com/AztecProtocol/aztec-packages/issues/7918
+    it('publishes two blocks with only padding txs', async () => {
+      ({ teardown, pxe, logger, aztecNode } = await setup(0, {
+        minTxsPerBlock: 0,
+        sequencerSkipSubmitProofs: true,
+        skipProtocolContracts: true,
+      }));
+
+      await retryUntil(async () => (await aztecNode.getBlockNumber()) >= 3, 'wait-block', 10, 1);
     });
 
     // Regression for https://github.com/AztecProtocol/aztec-packages/issues/7537

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -201,11 +201,14 @@ export class Sequencer {
       const lastBlockTime = historicalHeader?.globalVariables.timestamp.toNumber() || 0;
       const currentTime = Math.floor(Date.now() / 1000);
       const elapsedSinceLastBlock = currentTime - lastBlockTime;
+      this.log.debug(
+        `Last block mined at ${lastBlockTime} current time is ${currentTime} (elapsed ${elapsedSinceLastBlock})`,
+      );
 
       // Do not go forward with new block if not enough time has passed since last block
       if (this.minSecondsBetweenBlocks > 0 && elapsedSinceLastBlock < this.minSecondsBetweenBlocks) {
         this.log.debug(
-          `Not creating block because not enough time has passed since last block (last block at ${lastBlockTime} current time ${currentTime})`,
+          `Not creating block because not enough time ${this.minSecondsBetweenBlocks} has passed since last block`,
         );
         return;
       }
@@ -334,7 +337,7 @@ export class Sequencer {
     // less txs than the minimum. But that'd cause the entire block to be aborted and retried. Instead, we should
     // go back to the p2p pool and load more txs until we hit our minTxsPerBLock target. Only if there are no txs
     // we should bail.
-    if (processedTxs.length === 0 && !this.skipMinTxsPerBlockCheck(elapsedSinceLastBlock)) {
+    if (processedTxs.length === 0 && !this.skipMinTxsPerBlockCheck(elapsedSinceLastBlock) && this.minTxsPerBLock > 0) {
       this.log.verbose('No txs processed correctly to build block. Exiting');
       prover.cancelBlock();
       return;


### PR DESCRIPTION
The archiver was keeping a single L1 pointer for L2 blocks, shared by block metadata and block bodies, using the min of the two. However, if a block metadata had no corresponding block body, then the L1 pointer would not be advanced, leading to the same block metadata to being downloaded again, which triggered an error of expected L2 block mismatch.

Having no corresponding block body happens when the tx effects hash is not submitted by the sequencer, which happens when it is detected to have been uploaded already, which happens when the tx effects hash is repeated across two blocks, which happens when two blocks are empty (ie have only padding txs).

By adding separate tracking pointers, we ensure that we don't accidentally process the same block header twice from the archiver. This PR also adds a try/catch to the archiver loop so it doesn't bring down the entire node if it runs into an error.

Fixes #7918 