### PR TITLE
feat: private refunds optimizations

### DIFF
--- a/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/main.nr
@@ -545,7 +545,14 @@ contract TokenWithRefunds {
         // 3. Deduct the funded amount from the user's balance - this is a maximum fee a user is willing to pay
         // (called fee limit in aztec spec). The difference between fee limit and the actual tx fee will be refunded 
         // to the user in the `complete_refund(...)` function.
-        storage.balances.sub(user, U128::from_integer(funded_amount)).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, user_ovpk, user_ivpk, user));
+        let change = subtract_balance(
+            &mut context,
+            storage,
+            user,
+            U128::from_integer(funded_amount),
+            INITIAL_TRANSFER_CALL_MAX_NOTES
+        );
+        storage.balances.add(user, change).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, user_ovpk, user_ivpk, user));
 
         // 4. We create the partial notes for the fee payer and the user.
         // --> Called "partial" because they don't have the amount set yet (that will be done in `complete_refund(...)`).

--- a/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/main.nr
@@ -545,7 +545,7 @@ contract TokenWithRefunds {
         // 3. Deduct the funded amount from the user's balance - this is a maximum fee a user is willing to pay
         // (called fee limit in aztec spec). The difference between fee limit and the actual tx fee will be refunded 
         // to the user in the `complete_refund(...)` function.
-        storage.balances.sub(user, U128::from_integer(funded_amount)).emit(encode_and_encrypt_note_with_keys(&mut context, user_ovpk, user_ivpk, user));
+        storage.balances.sub(user, U128::from_integer(funded_amount)).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, user_ovpk, user_ivpk, user));
 
         // 4. We create the partial notes for the fee payer and the user.
         // --> Called "partial" because they don't have the amount set yet (that will be done in `complete_refund(...)`).

--- a/yarn-project/end-to-end/src/e2e_fees/private_refunds.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/private_refunds.test.ts
@@ -153,7 +153,7 @@ describe('e2e_fees/private_refunds', () => {
             aliceRandomness,
             bobRandomness,
             t.bobWallet.getAddress(), // Bob is the recipient of the fee notes.
-            true, // We set max fee/funded amount to zero to trigger the error.
+            true, // We set max fee/funded amount to 1 to trigger the error.
           ),
         },
       }),
@@ -195,10 +195,10 @@ class PrivateRefundPaymentMethod implements FeePaymentMethod {
     private feeRecipient: AztecAddress,
 
     /**
-     * If true, the max fee will be set to 0.
+     * If true, the max fee will be set to 1.
      * TODO(#7694): Remove this param once the lacking feature in TXE is implemented.
      */
-    private setMaxFeeToZero = false,
+    private setMaxFeeToOne = false,
   ) {}
 
   /**
@@ -221,7 +221,7 @@ class PrivateRefundPaymentMethod implements FeePaymentMethod {
   async getFunctionCalls(gasSettings: GasSettings): Promise<FunctionCall[]> {
     // We assume 1:1 exchange rate between fee juice and token. But in reality you would need to convert feeLimit
     // (maxFee) to be in token denomination.
-    const maxFee = this.setMaxFeeToZero ? Fr.ZERO : gasSettings.getFeeLimit();
+    const maxFee = this.setMaxFeeToOne ? Fr.ONE : gasSettings.getFeeLimit();
 
     await this.wallet.createAuthWit({
       caller: this.paymentContract,


### PR DESCRIPTION
Optimizing gate counts of private refunds.

Optimizations performed:
1. Using unconstrained encryption when submitting a change note to the user in setup_refunds --> user is sending the note to himself from his own pxe so constraining here is not necessary.
2. Using the optimized subtract_balance functionality which performs recursive calls.

Before: 265418 gates
After opt. 1: 181864 gates,
After opt. 2: 80319 gates