### PR TITLE
fix: Delete forks after proving job has finished

### DIFF
--- a/yarn-project/circuit-types/src/interfaces/merkle_tree_operations.ts
+++ b/yarn-project/circuit-types/src/interfaces/merkle_tree_operations.ts
@@ -220,6 +220,9 @@ export interface MerkleTreeOperations {
    * Rolls back pending changes.
    */
   rollback(): Promise<void>;
+
+  /** Deletes this database. Useful for cleaning up forks. */
+  delete(): Promise<void>;
 }
 
 /** Return type for handleL2BlockAndMessages */

--- a/yarn-project/kv-store/src/interfaces/store.ts
+++ b/yarn-project/kv-store/src/interfaces/store.ts
@@ -55,7 +55,7 @@ export interface AztecKVStore {
   transaction<T extends Exclude<any, Promise<any>>>(callback: () => T): Promise<T>;
 
   /**
-   * Clears the store
+   * Clears all entries in the store
    */
   clear(): Promise<void>;
 
@@ -63,4 +63,9 @@ export interface AztecKVStore {
    * Forks the store.
    */
   fork(): Promise<AztecKVStore>;
+
+  /**
+   * Deletes the store
+   */
+  delete(): Promise<void>;
 }

--- a/yarn-project/kv-store/src/lmdb/store.test.ts
+++ b/yarn-project/kv-store/src/lmdb/store.test.ts
@@ -14,6 +14,9 @@ describe('AztecLmdbStore', () => {
     expect(forkedSingleton.get()).toEqual('foo');
     await forkedSingleton.set('bar');
     expect(singleton.get()).toEqual('foo');
+    expect(forkedSingleton.get()).toEqual('bar');
+    await forkedSingleton.delete();
+    expect(singleton.get()).toEqual('foo');
   };
 
   it('forks a persistent store', async () => {

--- a/yarn-project/kv-store/src/lmdb/store.ts
+++ b/yarn-project/kv-store/src/lmdb/store.ts
@@ -134,9 +134,14 @@ export class AztecLmdbStore implements AztecKVStore {
   }
 
   /**
-   * Clears the store
+   * Clears all entries in the store
    */
   async clear() {
     await this.#rootDb.clearAsync();
+  }
+
+  /** Deletes this store */
+  async delete() {
+    await this.#rootDb.drop();
   }
 }

--- a/yarn-project/prover-node/src/job/block-proving-job.ts
+++ b/yarn-project/prover-node/src/job/block-proving-job.ts
@@ -30,6 +30,7 @@ export class BlockProvingJob {
     private l2BlockSource: L2BlockSource,
     private l1ToL2MessageSource: L1ToL2MessageSource,
     private txProvider: TxProvider,
+    private cleanUp: () => Promise<void> = () => Promise.resolve(),
   ) {}
 
   public getState(): BlockProvingJobState {
@@ -105,6 +106,8 @@ export class BlockProvingJob {
     } catch (err) {
       this.log.error(`Error running block prover job: ${err}`);
       this.state = 'failed';
+    } finally {
+      await this.cleanUp();
     }
   }
 

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -133,6 +133,7 @@ export class ProverNode {
       this.l2BlockSource,
       this.l1ToL2MessageSource,
       this.txProvider,
+      () => db.delete(),
     );
   }
 }

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
@@ -66,4 +66,7 @@ export type MerkleTreeDb = {
      * Forks the database at its current state.
      */
     fork(): Promise<MerkleTreeDb>;
+
+    /** Deletes this database. */
+    delete(): Promise<void>;
   };

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_operations_facade.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_operations_facade.ts
@@ -204,4 +204,8 @@ export class MerkleTreeOperationsFacade implements MerkleTreeOperations {
   ): Promise<BatchInsertionResult<TreeHeight, SubtreeSiblingPathHeight>> {
     return this.trees.batchInsert(treeId, leaves, subtreeHeight);
   }
+
+  public delete(): Promise<void> {
+    return this.trees.delete();
+  }
 }

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_snapshot_operations_facade.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_snapshot_operations_facade.ts
@@ -159,6 +159,10 @@ export class MerkleTreeSnapshotOperationsFacade implements MerkleTreeOperations 
     return Promise.reject(new Error('Tree snapshot operations are read-only'));
   }
 
+  delete(): Promise<void> {
+    return Promise.reject(new Error('Tree snapshot operations are read-only'));
+  }
+
   updateHistoricArchive(): Promise<void> {
     return Promise.reject(new Error('Tree snapshot operations are read-only'));
   }

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -189,6 +189,10 @@ export class MerkleTrees implements MerkleTreeDb {
     return MerkleTrees.new(forked, this.log);
   }
 
+  public async delete() {
+    await this.store.delete();
+  }
+
   public getInitialHeader(): Header {
     return Header.empty({ state: this.#loadInitialStateReference() });
   }


### PR DESCRIPTION
Adds a delete method to the db, which is called in a cleanup handler of the proving job once it finishes. This is needed so we don't pile up forks of the db as we keep proving blocks.
