### PR TITLE
chore: Enable execute command on aws ecs services

### DIFF
--- a/yarn-project/aztec-faucet/terraform/main.tf
+++ b/yarn-project/aztec-faucet/terraform/main.tf
@@ -171,6 +171,7 @@ resource "aws_ecs_service" "aztec-faucet" {
   deployment_maximum_percent         = 100
   deployment_minimum_healthy_percent = 0
   platform_version                   = "1.4.0"
+  enable_execute_command             = true
 
   network_configuration {
     subnets = [

--- a/yarn-project/aztec/terraform/bot/main.tf
+++ b/yarn-project/aztec/terraform/bot/main.tf
@@ -192,6 +192,7 @@ resource "aws_ecs_service" "aztec-bot" {
   deployment_maximum_percent         = 100
   deployment_minimum_healthy_percent = 0
   force_new_deployment               = true
+  enable_execute_command             = true
 
   network_configuration {
     subnets = [

--- a/yarn-project/aztec/terraform/node/main.tf
+++ b/yarn-project/aztec/terraform/node/main.tf
@@ -402,6 +402,7 @@ resource "aws_ecs_service" "aztec-node" {
   deployment_minimum_healthy_percent = 0
   platform_version                   = "1.4.0"
   force_new_deployment               = true
+  enable_execute_command             = true
 
 
   network_configuration {

--- a/yarn-project/aztec/terraform/prover-node/main.tf
+++ b/yarn-project/aztec/terraform/prover-node/main.tf
@@ -272,7 +272,7 @@ resource "aws_ecs_service" "aztec-prover-node" {
   deployment_minimum_healthy_percent = 0
   platform_version                   = "1.4.0"
   force_new_deployment               = true
-
+  enable_execute_command             = true
 
   network_configuration {
     assign_public_ip = true

--- a/yarn-project/aztec/terraform/prover/main.tf
+++ b/yarn-project/aztec/terraform/prover/main.tf
@@ -307,6 +307,7 @@ resource "aws_ecs_service" "aztec-proving-agent" {
   desired_count                      = local.agents_per_prover
   deployment_maximum_percent         = 100
   deployment_minimum_healthy_percent = 0
+  enable_execute_command             = true
   #platform_version                   = "1.4.0"
 
   # Associate the EC2 capacity provider

--- a/yarn-project/aztec/terraform/pxe/main.tf
+++ b/yarn-project/aztec/terraform/pxe/main.tf
@@ -179,6 +179,7 @@ resource "aws_ecs_service" "aztec-pxe" {
   deployment_minimum_healthy_percent = 0
   platform_version                   = "1.4.0"
   force_new_deployment               = true
+  enable_execute_command             = true
 
   network_configuration {
     subnets = [


### PR DESCRIPTION
This allows executing commands from the AWS CLI directly on the containers for troubleshooting.

See https://aws.amazon.com/about-aws/whats-new/2021/03/amazon-ecs-now-allows-you-to-run-commands-in-a-container-running-on-amazon-ec2-or-aws-fargate/ for more info.