### PR TITLE
chore: Do not clean up bb files on err

### DIFF
--- a/yarn-project/bb-prover/src/prover/bb_private_kernel_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_private_kernel_prover.ts
@@ -366,6 +366,15 @@ export class BBNativePrivateKernelProver implements PrivateKernelProver {
   }
 
   private runInDirectory<T>(fn: (dir: string) => Promise<T>) {
-    return runInDirectory(this.bbWorkingDirectory, fn, this.skipCleanup);
+    const log = this.log;
+    return runInDirectory(
+      this.bbWorkingDirectory,
+      (dir: string) =>
+        fn(dir).catch(err => {
+          log.error(`Error running operation at ${dir}: ${err}`);
+          throw err;
+        }),
+      this.skipCleanup,
+    );
   }
 }

--- a/yarn-project/bb-prover/src/prover/bb_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_prover.ts
@@ -956,6 +956,14 @@ export class BBNativeRollupProver implements ServerCircuitProver {
   }
 
   private runInDirectory<T>(fn: (dir: string) => Promise<T>) {
-    return runInDirectory(this.config.bbWorkingDirectory, fn, this.config.bbSkipCleanup);
+    return runInDirectory(
+      this.config.bbWorkingDirectory,
+      (dir: string) =>
+        fn(dir).catch(err => {
+          logger.error(`Error running operation at ${dir}: ${err}`);
+          throw err;
+        }),
+      this.config.bbSkipCleanup,
+    );
   }
 }

--- a/yarn-project/foundation/src/fs/run_in_dir.ts
+++ b/yarn-project/foundation/src/fs/run_in_dir.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 
 // Create a random directory underneath a 'base' directory
-// Calls a provided method, ensures the random directory is cleaned up afterwards
+// Calls a provided method, ensures the random directory is cleaned up afterwards unless the operation fails
 export async function runInDirectory<T>(
   workingDirBase: string,
   fn: (dir: string) => Promise<T>,
@@ -15,6 +15,9 @@ export async function runInDirectory<T>(
 
   try {
     return await fn(workingDirectory);
+  } catch (err) {
+    skipCleanup = true;
+    throw err;
   } finally {
     if (!skipCleanup) {
       await fs.rm(workingDirectory, { recursive: true, force: true });


### PR DESCRIPTION
Even if BB_SKIP_CLEANUP is not set, avoid deleting the tmp dir for bb if the operation fails, so we can retrieve those files later.
