### PR TITLE
chore: CLI command to set latest block as proven

### DIFF
--- a/.github/workflows/devnet-deploys.yml
+++ b/.github/workflows/devnet-deploys.yml
@@ -584,6 +584,16 @@ jobs:
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
 
+      - name: Set latest block as proven
+        working-directory: ./yarn-project/aztec/terraform/pxe
+        run: |
+          set -eo pipefail
+          docker run aztecprotocol/aztec:${{ env.DEPLOY_TAG }} set-proven-until \
+            --rpc-url https://api.aztec.network/${{ env.DEPLOY_TAG }}/aztec-pxe/${{ env.API_KEY }} \
+            --l1-rpc-url https://${{ env.DEPLOY_TAG }}-mainnet-fork.aztec.network:8545/${{ env.API_KEY }} \
+            --l1-chain-id ${{ env.L1_CHAIN_ID }} \
+            --l1-private-key ${{ env.CONTRACT_PUBLISHER_PRIVATE_KEY }}
+
       - name: Deploy PXE
         working-directory: ./yarn-project/aztec/terraform/pxe
         run: |

--- a/.github/workflows/devnet-deploys.yml
+++ b/.github/workflows/devnet-deploys.yml
@@ -584,15 +584,16 @@ jobs:
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
 
-      - name: Set latest block as proven
-        working-directory: ./yarn-project/aztec/terraform/pxe
-        run: |
-          set -eo pipefail
-          docker run aztecprotocol/aztec:${{ env.DEPLOY_TAG }} set-proven-until \
-            --rpc-url https://api.aztec.network/${{ env.DEPLOY_TAG }}/aztec-pxe/${{ env.API_KEY }} \
-            --l1-rpc-url https://${{ env.DEPLOY_TAG }}-mainnet-fork.aztec.network:8545/${{ env.API_KEY }} \
-            --l1-chain-id ${{ env.L1_CHAIN_ID }} \
-            --l1-private-key ${{ env.CONTRACT_PUBLISHER_PRIVATE_KEY }}
+      # Unneded for now, since the prover-node runs with simulated proofs and submits them to L1, which does not verify them yet.
+      # - name: Set latest block as proven
+      #   working-directory: ./yarn-project/aztec/terraform/pxe
+      #   run: |
+      #     set -eo pipefail
+      #     docker run aztecprotocol/aztec:${{ env.DEPLOY_TAG }} set-proven-until \
+      #       --rpc-url https://api.aztec.network/${{ env.DEPLOY_TAG }}/aztec-pxe/${{ env.API_KEY }} \
+      #       --l1-rpc-url https://${{ env.DEPLOY_TAG }}-mainnet-fork.aztec.network:8545/${{ env.API_KEY }} \
+      #       --l1-chain-id ${{ env.L1_CHAIN_ID }} \
+      #       --l1-private-key ${{ env.CONTRACT_PUBLISHER_PRIVATE_KEY }}
 
       - name: Deploy PXE
         working-directory: ./yarn-project/aztec/terraform/pxe

--- a/yarn-project/cli/src/cmds/l1/assume_proven_until.ts
+++ b/yarn-project/cli/src/cmds/l1/assume_proven_until.ts
@@ -20,6 +20,6 @@ export async function assumeProvenUntil(
   const rollupAddress = await pxe.getNodeInfo().then(i => i.l1ContractAddresses.rollupAddress);
   const blockNumber = blockNumberOrLatest ?? (await pxe.getBlockNumber());
 
-  await setAssumeProvenUntil(blockNumber, rollupAddress, walletClient);
+  await setAssumeProvenUntil(blockNumber + 1, rollupAddress, walletClient);
   log(`Assumed proven until block ${blockNumber}`);
 }

--- a/yarn-project/cli/src/cmds/l1/assume_proven_until.ts
+++ b/yarn-project/cli/src/cmds/l1/assume_proven_until.ts
@@ -1,0 +1,25 @@
+import { createPXEClient, makeFetch } from '@aztec/aztec.js';
+import { createEthereumChain, createL1Clients } from '@aztec/ethereum';
+import { type LogFn } from '@aztec/foundation/log';
+
+import { setAssumeProvenUntil } from '../../utils/aztec.js';
+
+export async function assumeProvenUntil(
+  blockNumberOrLatest: number | undefined,
+  l1RpcUrl: string,
+  rpcUrl: string,
+  chainId: number,
+  privateKey: string | undefined,
+  mnemonic: string,
+  log: LogFn,
+) {
+  const chain = createEthereumChain(l1RpcUrl, chainId);
+  const { walletClient } = createL1Clients(chain.rpcUrl, privateKey ?? mnemonic, chain.chainInfo);
+
+  const pxe = createPXEClient(rpcUrl, makeFetch([], true));
+  const rollupAddress = await pxe.getNodeInfo().then(i => i.l1ContractAddresses.rollupAddress);
+  const blockNumber = blockNumberOrLatest ?? (await pxe.getBlockNumber());
+
+  await setAssumeProvenUntil(blockNumber, rollupAddress, walletClient);
+  log(`Assumed proven until block ${blockNumber}`);
+}

--- a/yarn-project/cli/src/cmds/l1/index.ts
+++ b/yarn-project/cli/src/cmds/l1/index.ts
@@ -154,5 +154,37 @@ export function injectCommands(program: Command, log: LogFn, debugLogger: DebugL
       await getL1Balance(who, options.token, options.l1RpcUrl, options.l1ChainId, options.json, log);
     });
 
+  program
+    .command('set-proven-until')
+    .description(
+      'Instructs the L1 rollup contract to assume all blocks until the given number are automatically proven.',
+    )
+    .argument('[blockNumber]', 'The target block number, defaults to the latest pending block number.', parseBigint)
+    .requiredOption(
+      '--l1-rpc-url <string>',
+      'Url of the ethereum host. Chain identifiers localhost and testnet can be used',
+      ETHEREUM_HOST,
+    )
+    .addOption(pxeOption)
+    .option(
+      '-m, --mnemonic <string>',
+      'The mnemonic to use for deriving the Ethereum address that will mint and bridge',
+      'test test test test test test test test test test test junk',
+    )
+    .addOption(l1ChainIdOption)
+    .option('--l1-private-key <string>', 'The private key to use for deployment', PRIVATE_KEY)
+    .action(async (blockNumber, options) => {
+      const { assumeProvenUntil } = await import('./assume_proven_until.js');
+      await assumeProvenUntil(
+        blockNumber,
+        options.l1RpcUrl,
+        options.rpcUrl,
+        options.l1ChainId,
+        options.l1PrivateKey,
+        options.mnemonic,
+        log,
+      );
+    });
+
   return program;
 }

--- a/yarn-project/cli/src/utils/aztec.ts
+++ b/yarn-project/cli/src/utils/aztec.ts
@@ -2,7 +2,7 @@ import { type ContractArtifact, type FunctionArtifact, loadContractArtifact } fr
 import { type L1ContractArtifactsForDeployment } from '@aztec/aztec.js/ethereum';
 import { type PXE } from '@aztec/circuit-types';
 import { type DeployL1Contracts } from '@aztec/ethereum';
-import { EthAddress } from '@aztec/foundation/eth-address';
+import { type EthAddress } from '@aztec/foundation/eth-address';
 import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
 import { type NoirPackageConfig } from '@aztec/foundation/noir';
 import { RollupAbi } from '@aztec/l1-artifacts';
@@ -12,11 +12,10 @@ import TOML from '@iarna/toml';
 import { readFile } from 'fs/promises';
 import { gtr, ltr, satisfies, valid } from 'semver';
 import {
-  Account,
-  Chain,
-  HttpTransport,
-  PublicClient,
-  WalletClient,
+  type Account,
+  type Chain,
+  type HttpTransport,
+  type WalletClient,
   getAddress,
   getContract,
   publicActions,

--- a/yarn-project/cli/src/utils/aztec.ts
+++ b/yarn-project/cli/src/utils/aztec.ts
@@ -2,13 +2,25 @@ import { type ContractArtifact, type FunctionArtifact, loadContractArtifact } fr
 import { type L1ContractArtifactsForDeployment } from '@aztec/aztec.js/ethereum';
 import { type PXE } from '@aztec/circuit-types';
 import { type DeployL1Contracts } from '@aztec/ethereum';
+import { EthAddress } from '@aztec/foundation/eth-address';
 import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
 import { type NoirPackageConfig } from '@aztec/foundation/noir';
+import { RollupAbi } from '@aztec/l1-artifacts';
 import { FeeJuiceAddress } from '@aztec/protocol-contracts/fee-juice';
 
 import TOML from '@iarna/toml';
 import { readFile } from 'fs/promises';
 import { gtr, ltr, satisfies, valid } from 'semver';
+import {
+  Account,
+  Chain,
+  HttpTransport,
+  PublicClient,
+  WalletClient,
+  getAddress,
+  getContract,
+  publicActions,
+} from 'viem';
 
 import { encodeArgs } from './encoding.js';
 
@@ -106,6 +118,21 @@ export async function deployAztecContracts(
     l2FeeJuiceAddress: FeeJuiceAddress,
     vkTreeRoot: getVKTreeRoot(),
   });
+}
+
+/** Sets the assumed proven block number on the rollup contract on L1 */
+export async function setAssumeProvenUntil(
+  blockNumber: number,
+  rollupAddress: EthAddress,
+  walletClient: WalletClient<HttpTransport, Chain, Account>,
+) {
+  const rollup = getContract({
+    address: getAddress(rollupAddress.toString()),
+    abi: RollupAbi,
+    client: walletClient,
+  });
+  const hash = await rollup.write.setAssumeProvenUntilBlockNumber([BigInt(blockNumber)]);
+  await walletClient.extend(publicActions).waitForTransactionReceipt({ hash });
 }
 
 /**

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -446,7 +446,7 @@ export class ProvingOrchestrator implements BlockProver {
         );
       }
 
-      logger.info(`Successfully proven block ${l2Block.number}!`);
+      logger.info(`Orchestrator finalised block ${l2Block.number}`);
 
       this.provingState.block = l2Block;
 


### PR DESCRIPTION
Adds a new `set-proven-until` cli command that sends a tx to the rollup contract on L1 to assume all blocks until the given one as proven.