### PR TITLE
chore: pin yarn versions in noir-projects and bb/ts

### DIFF
--- a/barretenberg/ts/package.json
+++ b/barretenberg/ts/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@aztec/bb.js",
+  "packageManager": "yarn@1.22.22",
   "version": "0.48.0",
   "homepage": "https://github.com/AztecProtocol/aztec-packages/tree/master/barretenberg/ts",
   "license": "MIT",

--- a/noir-projects/package.json
+++ b/noir-projects/package.json
@@ -1,5 +1,6 @@
 {
   "name": "noir-projects",
+  "packageManager": "yarn@1.22.22",
   "version": "0.0.0",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.609.0",


### PR DESCRIPTION
This was being overridden when unspecified.

