### PR TITLE
fix: Do not mount ssh agent on OSX

### DIFF
--- a/aztec-up/bin/.aztec-run
+++ b/aztec-up/bin/.aztec-run
@@ -120,7 +120,7 @@ if [[ -z "${SKIP_PORT_ASSIGNMENT:-}" ]]; then
 fi
 
 ssh_agent_forwarding=""
-if [ -n "${SSH_AUTH_SOCK:-}" ]; then
+if [ -n "${SSH_AUTH_SOCK:-}" ] && [ "$(uname)" != "Darwin" ]; then
   ssh_agent_forwarding="-v $(realpath $SSH_AUTH_SOCK):$SSH_AUTH_SOCK"
 fi
 


### PR DESCRIPTION
Fixes the error:
```
docker: Error response from daemon: error while creating mount source path '/host_mnt/private/tmp/com.apple.launchd.fgyb18bWUX/Listeners': mkdir /host_mnt/private/tmp/com.apple.launchd.fgyb18bWUX/Listeners: operation not supported.
```
