### PR TITLE
fix: Forking world state in prover-node

### DIFF
--- a/yarn-project/kv-store/src/lmdb/store.test.ts
+++ b/yarn-project/kv-store/src/lmdb/store.test.ts
@@ -20,7 +20,7 @@ describe('AztecLmdbStore', () => {
   };
 
   it('forks a persistent store', async () => {
-    const path = join(await mkdtemp(join(tmpdir(), 'aztec-store-test-')), 'main.mdb');
+    const path = await mkdtemp(join(tmpdir(), 'aztec-store-test-'));
     const store = AztecLmdbStore.open(path, false);
     await itForks(store);
   });

--- a/yarn-project/kv-store/src/lmdb/store.test.ts
+++ b/yarn-project/kv-store/src/lmdb/store.test.ts
@@ -25,6 +25,11 @@ describe('AztecLmdbStore', () => {
     await itForks(store);
   });
 
+  it('forks a persistent store with no path', async () => {
+    const store = AztecLmdbStore.open(undefined, false);
+    await itForks(store);
+  });
+
   it('forks an ephemeral store', async () => {
     const store = AztecLmdbStore.open(undefined, true);
     await itForks(store);

--- a/yarn-project/kv-store/src/lmdb/store.ts
+++ b/yarn-project/kv-store/src/lmdb/store.ts
@@ -72,7 +72,7 @@ export class AztecLmdbStore implements AztecKVStore {
   async fork() {
     const baseDir = this.path ? dirname(this.path) : tmpdir();
     this.#log.debug(`Forking store with basedir ${baseDir}`);
-    const forkPath = join(await mkdtemp(join(baseDir, 'aztec-store-fork-')), 'root.mdb');
+    const forkPath = (await mkdtemp(join(baseDir, 'aztec-store-fork-'))) + (this.isEphemeral ? '/data.mdb' : '');
     this.#log.verbose(`Forking store to ${forkPath}`);
     await this.#rootDb.backup(forkPath, false);
     const forkDb = open(forkPath, { noSync: this.isEphemeral });

--- a/yarn-project/kv-store/src/lmdb/store.ts
+++ b/yarn-project/kv-store/src/lmdb/store.ts
@@ -72,7 +72,8 @@ export class AztecLmdbStore implements AztecKVStore {
   async fork() {
     const baseDir = this.path ? dirname(this.path) : tmpdir();
     this.#log.debug(`Forking store with basedir ${baseDir}`);
-    const forkPath = (await mkdtemp(join(baseDir, 'aztec-store-fork-'))) + '/data.mdb';
+    const forkPath =
+      (await mkdtemp(join(baseDir, 'aztec-store-fork-'))) + (this.isEphemeral || !this.path ? '/data.mdb' : '');
     this.#log.verbose(`Forking store to ${forkPath}`);
     await this.#rootDb.backup(forkPath, false);
     const forkDb = open(forkPath, { noSync: this.isEphemeral });

--- a/yarn-project/kv-store/src/lmdb/store.ts
+++ b/yarn-project/kv-store/src/lmdb/store.ts
@@ -72,7 +72,7 @@ export class AztecLmdbStore implements AztecKVStore {
   async fork() {
     const baseDir = this.path ? dirname(this.path) : tmpdir();
     this.#log.debug(`Forking store with basedir ${baseDir}`);
-    const forkPath = (await mkdtemp(join(baseDir, 'aztec-store-fork-'))) + (this.isEphemeral ? '/data.mdb' : '');
+    const forkPath = (await mkdtemp(join(baseDir, 'aztec-store-fork-'))) + '/data.mdb';
     this.#log.verbose(`Forking store to ${forkPath}`);
     await this.#rootDb.backup(forkPath, false);
     const forkDb = open(forkPath, { noSync: this.isEphemeral });


### PR DESCRIPTION
Attempt to fix the `Error in prover node work: Error No such file or directory` error in prover-node when forking. Tested by connecting to the container, modifying the js, and running prover-node manually.
