### PR TITLE
feat!: replace public key fetching API

### DIFF
--- a/docs/docs/aztec/concepts/accounts/keys.md
+++ b/docs/docs/aztec/concepts/accounts/keys.md
@@ -33,7 +33,10 @@ There is 1 key registry and its address is hardcoded in the protocol code.
 
 To retrieve them a developer can use one of the getters in Aztec.nr:
 
-#include_code key-getters /noir-projects/aztec-nr/aztec/src/keys/getters/mod.nr rust
+```
+fn get_current_public_keys(context: &mut PrivateContext, account: AztecAddress) -> PublicKeys;
+fn get_historical_public_keys(historical_header: Header, account: AztecAddress) -> PublicKeys;
+```
 
 If the keys are registered in the key registry these methods can be called without any setup.
 If they are not there, it is necessary to first register the user as a recipient in our PXE.

--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -6,6 +6,38 @@ keywords: [sandbox, aztec, notes, migration, updating, upgrading]
 
 Aztec is in full-speed development. Literally every version breaks compatibility with the previous ones. This page attempts to target errors and difficulties you might encounter when upgrading, and how to resolve them.
 
+## TBD
+
+### Key Rotation API overhaul
+
+Public keys (ivpk, ovpk, npk, tpk) should no longer be fetched using the old `get_[x]pk_m` methods on the `Header` struct, but rather by calling `get_current_public_keys`, which returns a `PublicKeys` struct with all four keys at once:
+
+```diff
++use dep::aztec::keys::getters::get_current_public_keys;
+
+-let header = context.header();
+-let owner_ivpk_m = header.get_ivpk_m(&mut context, owner);
+-let owner_ovpk_m = header.get_ovpk_m(&mut context, owner);
++let owner_keys = get_current_public_keys(&mut context, owner);
++let owner_ivpk_m = owner_keys.ivpk_m;
++let owner_ovpk_m = owner_keys.ovpk_m;
+```
+
+If using more than one key per account, this will result in very large circuit gate count reductions.
+
+Additionally, `get_historical_public_keys` was added to support reading historical keys using a historical header:
+
+```diff
++use dep::aztec::keys::getters::get_historical_public_keys;
+
+let historical_header = context.header_at(some_block_number);
+-let owner_ivpk_m = header.get_ivpk_m(&mut context, owner);
+-let owner_ovpk_m = header.get_ovpk_m(&mut context, owner);
++let owner_keys = get_historical_public_keys(historical_header, owner);
++let owner_ivpk_m = owner_keys.ivpk_m;
++let owner_ovpk_m = owner_keys.ovpk_m;
+```
+
 ## 0.48.0
 
 ### NoteInterface changes

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
@@ -1,6 +1,7 @@
 use crate::{
     context::PrivateContext, event::event_interface::EventInterface,
-    encrypted_logs::payload::compute_encrypted_event_log, oracle::logs_traits::LensForEncryptedEvent,
+    encrypted_logs::payload::compute_encrypted_event_log, keys::getters::get_current_public_keys,
+    oracle::logs_traits::LensForEncryptedEvent,
     oracle::unsafe_rand::unsafe_rand
 };
 use dep::protocol_types::{address::AztecAddress, point::Point, hash::sha256_to_field};
@@ -68,9 +69,8 @@ pub fn encode_and_encrypt_event<Event, let NB: u32, let MB: u32, let OB: u32>(
     iv: AztecAddress
 ) -> fn[(&mut PrivateContext, AztecAddress, AztecAddress)](Event) -> () where Event: EventInterface<NB, MB>, [u8; NB]: LensForEncryptedEvent<NB, OB> {
     | e: Event | {
-        let header = context.get_header();
-        let ovpk = header.get_ovpk_m(context, ov);
-        let ivpk = header.get_ivpk_m(context, iv);
+        let ovpk = get_current_public_keys(context, ov).ovpk_m;
+        let ivpk = get_current_public_keys(context, iv).ivpk_m;
         let randomness = unsafe_rand();
         emit_with_keys(context, randomness, e, ovpk, ivpk, iv, compute);
     }
@@ -82,9 +82,8 @@ pub fn encode_and_encrypt_event_unconstrained<Event, let NB: u32, let MB: u32, l
     iv: AztecAddress
 ) -> fn[(&mut PrivateContext, AztecAddress, AztecAddress)](Event) -> () where Event: EventInterface<NB, MB>, [u8; NB]: LensForEncryptedEvent<NB, OB> {
     | e: Event | {
-        let header = context.get_header();
-        let ovpk = header.get_ovpk_m(context, ov);
-        let ivpk = header.get_ivpk_m(context, iv);
+        let ovpk = get_current_public_keys(context, ov).ovpk_m;
+        let ivpk = get_current_public_keys(context, iv).ivpk_m;
         let randomness = unsafe_rand();
         emit_with_keys(context, randomness, e, ovpk, ivpk, iv, compute_unconstrained);
     }
@@ -97,9 +96,8 @@ pub fn encode_and_encrypt_event_with_randomness<Event, let NB: u32, let MB: u32,
     iv: AztecAddress
 ) -> fn[(&mut PrivateContext, AztecAddress, AztecAddress, Field)](Event) -> () where Event: EventInterface<NB, MB>, [u8; NB]: LensForEncryptedEvent<NB, OB> {
     | e: Event | {
-        let header = context.get_header();
-        let ovpk = header.get_ovpk_m(context, ov);
-        let ivpk = header.get_ivpk_m(context, iv);
+        let ovpk = get_current_public_keys(context, ov).ovpk_m;
+        let ivpk = get_current_public_keys(context, iv).ivpk_m;
         emit_with_keys(context, randomness, e, ovpk, ivpk, iv, compute);
     }
 }
@@ -111,9 +109,8 @@ pub fn encode_and_encrypt_event_with_randomness_unconstrained<Event, let NB: u32
     iv: AztecAddress
 ) -> fn[(&mut PrivateContext, AztecAddress, AztecAddress, Field)](Event) -> () where Event: EventInterface<NB, MB>, [u8; NB]: LensForEncryptedEvent<NB, OB> {
     | e: Event | {
-        let header = context.get_header();
-        let ovpk = header.get_ovpk_m(context, ov);
-        let ivpk = header.get_ivpk_m(context, iv);
+        let ovpk = get_current_public_keys(context, ov).ovpk_m;
+        let ivpk = get_current_public_keys(context, iv).ivpk_m;
         emit_with_keys(context, randomness, e, ovpk, ivpk, iv, compute_unconstrained);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
@@ -1,8 +1,7 @@
 use crate::{
     context::PrivateContext, event::event_interface::EventInterface,
     encrypted_logs::payload::compute_encrypted_event_log, keys::getters::get_current_public_keys,
-    oracle::logs_traits::LensForEncryptedEvent,
-    oracle::unsafe_rand::unsafe_rand
+    oracle::logs_traits::LensForEncryptedEvent, oracle::unsafe_rand::unsafe_rand
 };
 use dep::protocol_types::{address::AztecAddress, point::Point, hash::sha256_to_field};
 

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -1,7 +1,7 @@
 use crate::{
     context::PrivateContext, note::{note_emission::NoteEmission, note_interface::NoteInterface},
-    keys::getters::get_current_public_keys,
-    encrypted_logs::payload::compute_encrypted_note_log, oracle::logs_traits::LensForEncryptedLog
+    keys::getters::get_current_public_keys, encrypted_logs::payload::compute_encrypted_note_log,
+    oracle::logs_traits::LensForEncryptedLog
 };
 use dep::protocol_types::{
     hash::sha256_to_field, address::AztecAddress, point::Point, abis::note_hash::NoteHash,

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -1,5 +1,6 @@
 use crate::{
     context::PrivateContext, note::{note_emission::NoteEmission, note_interface::NoteInterface},
+    keys::getters::get_current_public_keys,
     encrypted_logs::payload::compute_encrypted_note_log, oracle::logs_traits::LensForEncryptedLog
 };
 use dep::protocol_types::{
@@ -86,9 +87,8 @@ pub fn encode_and_encrypt_note<Note, let N: u32, let NB: u32, let M: u32>(
     iv: AztecAddress
 ) -> fn[(&mut PrivateContext, AztecAddress, AztecAddress)](NoteEmission<Note>) -> () where Note: NoteInterface<N, NB>, [Field; N]: LensForEncryptedLog<N, M> {
     | e: NoteEmission<Note> | {
-        let header = context.get_header();
-        let ovpk = header.get_ovpk_m(context, ov);
-        let ivpk = header.get_ivpk_m(context, iv);
+        let ovpk = get_current_public_keys(context, ov).ovpk_m;
+        let ivpk = get_current_public_keys(context, iv).ivpk_m;
         emit_with_keys(context, e.note, ovpk, ivpk, iv, compute);
     }
 }
@@ -99,9 +99,8 @@ pub fn encode_and_encrypt_note_unconstrained<Note, let N: u32, let NB: u32, let 
     iv: AztecAddress
 ) -> fn[(&mut PrivateContext, AztecAddress, AztecAddress)](NoteEmission<Note>) -> () where Note: NoteInterface<N, NB>, [Field; N]: LensForEncryptedLog<N, M> {
     | e: NoteEmission<Note> | {
-        let header = context.get_header();
-        let ovpk = header.get_ovpk_m(context, ov);
-        let ivpk = header.get_ivpk_m(context, iv);
+        let ovpk = get_current_public_keys(context, ov).ovpk_m;
+        let ivpk = get_current_public_keys(context, iv).ivpk_m;
         emit_with_keys(context, e.note, ovpk, ivpk, iv, compute_unconstrained);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/keys/getters/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/keys/getters/mod.nr
@@ -21,35 +21,7 @@ global DELAY = 5;
 mod test;
 
 // docs:start:key-getters
-trait KeyGetters {
-  fn get_npk_m(header: Header, context: &mut PrivateContext, address: AztecAddress) -> Point;
-  fn get_ivpk_m(header: Header, context: &mut PrivateContext, address: AztecAddress) -> Point;
-  fn get_ovpk_m(header: Header, context: &mut PrivateContext, address: AztecAddress) -> Point;
-  fn get_tpk_m(header: Header, context: &mut PrivateContext, address: AztecAddress) -> Point;
-  fn get_npk_m_hash(header: Header, context: &mut PrivateContext, address: AztecAddress) -> Field;
-}
 
-impl KeyGetters for Header {
-    fn get_npk_m(self, _context: &mut PrivateContext, address: AztecAddress) -> Point {
-        get_historical_public_keys(self, address).npk_m
-    }
-
-    fn get_ivpk_m(self, _context: &mut PrivateContext, address: AztecAddress) -> Point {
-        get_historical_public_keys(self, address).ivpk_m
-    }
-
-    fn get_ovpk_m(self, _context: &mut PrivateContext, address: AztecAddress) -> Point {
-        get_historical_public_keys(self, address).ovpk_m
-    }
-
-    fn get_tpk_m(self, _context: &mut PrivateContext, address: AztecAddress) -> Point {
-        get_historical_public_keys(self, address).tpk_m
-    }
-
-    fn get_npk_m_hash(self, context: &mut PrivateContext, address: AztecAddress) -> Field {
-        self.get_npk_m(context, address).hash()
-    }
-}
 // docs:end:key-getters
 
 // A helper function since requesting nsk_app is very common

--- a/noir-projects/aztec-nr/aztec/src/keys/getters/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/keys/getters/mod.nr
@@ -16,25 +16,19 @@ use crate::{
 }
 };
 
-global DELAY = 5;
-
 mod test;
-
-// docs:start:key-getters
-
-// docs:end:key-getters
-
-// A helper function since requesting nsk_app is very common
-// TODO(#6543)
-pub fn get_nsk_app(npk_m_hash: Field) -> Field {
-    get_key_validation_request(npk_m_hash, NULLIFIER_INDEX).sk_app
-}
 
 // This is the number of blocks that must pass after a key rotation event until the old keys are fully phased out and
 // become invalid.
 global KEY_REGISTRY_UPDATE_BLOCKS = 5;
 
 global KEY_REGISTRY_STORAGE_SLOT = 1;
+
+// A helper function since requesting nsk_app is very common
+// TODO(#6543)
+pub fn get_nsk_app(npk_m_hash: Field) -> Field {
+    get_key_validation_request(npk_m_hash, NULLIFIER_INDEX).sk_app
+}
 
 // Returns all current public keys for a given account, applying proper constraints to the context. We read all
 // keys at once since the constraints for reading them all are actually fewer than if we read them one at a time - any

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -2,7 +2,7 @@ use dep::aztec::{
     context::PrivateContext, protocol_types::{address::AztecAddress},
     note::note_getter_options::NoteGetterOptions, state_vars::PrivateSet,
     encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
-    keys::getters::get_current_public_keys,
+    keys::getters::get_current_public_keys
 };
 use dep::value_note::{filter::filter_notes_min_sum, value_note::ValueNote};
 

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -1,7 +1,8 @@
 use dep::aztec::{
     context::PrivateContext, protocol_types::{address::AztecAddress},
     note::note_getter_options::NoteGetterOptions, state_vars::PrivateSet,
-    encrypted_logs::encrypted_note_emission::encode_and_encrypt_note
+    encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
+    keys::getters::get_current_public_keys,
 };
 use dep::value_note::{filter::filter_notes_min_sum, value_note::ValueNote};
 
@@ -23,8 +24,7 @@ impl<Context> EasyPrivateUint<Context> {
 impl<Context> EasyPrivateUint<&mut PrivateContext> {
     // Very similar to `value_note::utils::increment`.
     pub fn add(self, addend: u64, owner: AztecAddress, outgoing_viewer: AztecAddress) {
-        let header = self.context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(self.context, owner);
+        let owner_npk_m_hash = get_current_public_keys(self.context, owner).npk_m.hash();
         // Creates new note for the owner.
         let mut addend_note = ValueNote::new(addend as Field, owner_npk_m_hash);
 
@@ -36,8 +36,7 @@ impl<Context> EasyPrivateUint<&mut PrivateContext> {
 
     // Very similar to `value_note::utils::decrement`.
     pub fn sub(self, subtrahend: u64, owner: AztecAddress, outgoing_viewer: AztecAddress) {
-        let header = self.context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(self.context, owner);
+        let owner_npk_m_hash = get_current_public_keys(self.context, owner).npk_m.hash();
 
         // docs:start:pop_notes
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, subtrahend as Field);

--- a/noir-projects/aztec-nr/value-note/src/utils.nr
+++ b/noir-projects/aztec-nr/value-note/src/utils.nr
@@ -1,6 +1,7 @@
 use dep::aztec::prelude::{AztecAddress, PrivateContext, PrivateSet, NoteGetterOptions};
 use dep::aztec::note::note_getter_options::SortOrder;
 use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note;
+use dep::aztec::keys::getters::get_current_public_keys;
 use crate::{filter::filter_notes_min_sum, value_note::{ValueNote, VALUE_NOTE_LEN, VALUE_NOTE_BYTES_LEN}};
 
 // Sort the note values (0th field) in descending order.
@@ -18,8 +19,7 @@ pub fn increment(
     recipient: AztecAddress,
     outgoing_viewer: AztecAddress // docs:end:increment_args
 ) {
-    let header = balance.context.get_header();
-    let recipient_npk_m_hash = header.get_npk_m_hash(balance.context, recipient);
+    let recipient_npk_m_hash = get_current_public_keys(balance.context, recipient).npk_m.hash();
 
     let mut note = ValueNote::new(amount, recipient_npk_m_hash);
     // Insert the new note to the owner's set of notes and emit the log if value is non-zero.

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -10,8 +10,7 @@ contract AppSubscription {
         SharedImmutable
     },
         encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
-        keys::getters::get_current_public_keys,
-        protocol_types::constants::MAX_FIELD_VALUE
+        keys::getters::get_current_public_keys, protocol_types::constants::MAX_FIELD_VALUE
     };
     use authwit::{auth_witness::get_auth_witness, auth::assert_current_call_valid_authwit};
     use token::Token;

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -10,6 +10,7 @@ contract AppSubscription {
         SharedImmutable
     },
         encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
+        keys::getters::get_current_public_keys,
         protocol_types::constants::MAX_FIELD_VALUE
     };
     use authwit::{auth_witness::get_auth_witness, auth::assert_current_call_valid_authwit};
@@ -109,8 +110,7 @@ contract AppSubscription {
 
         // Assert that the given expiry_block_number < current_block_number + SUBSCRIPTION_DURATION_IN_BLOCKS.
         AppSubscription::at(context.this_address()).assert_block_number(expiry_block_number).enqueue_view(&mut context);
-        let header = context.get_header();
-        let subscriber_npk_m_hash = header.get_npk_m_hash(&mut context, subscriber_address);
+        let subscriber_npk_m_hash = get_current_public_keys(&mut context, subscriber_address).npk_m.hash();
 
         let mut subscription_note = SubscriptionNote::new(subscriber_npk_m_hash, expiry_block_number, tx_count);
         storage.subscriptions.at(subscriber_address).initialize_or_replace(&mut subscription_note).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), subscriber_address));

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -150,8 +150,7 @@ pub fn get_pack_cards(
     owner: AztecAddress,
     context: &mut PrivateContext
 ) -> [Card; PACK_CARDS] {
-    let header = context.get_header();
-    let owner_npk_m_hash = header.get_npk_m_hash(context, owner);
+    let owner_npk_m_hash = get_current_public_keys(context, owner).npk_m.hash();
 
     // generate pseudo randomness deterministically from 'seed' and user secret
     let secret = context.request_nsk_app(owner_npk_m_hash);

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -3,8 +3,9 @@ use dep::aztec::prelude::{AztecAddress, FunctionSelector, PrivateContext, NoteHe
 use dep::aztec::{
     context::UnconstrainedContext,
     protocol_types::{traits::{ToField, Serialize, FromField}, constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL},
-    encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys, keys::getters::get_current_public_keys,
-    note::note_getter::view_notes, state_vars::PrivateSet, note::constants::MAX_NOTES_PER_PAGE
+    encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys,
+    keys::getters::get_current_public_keys, note::note_getter::view_notes, state_vars::PrivateSet,
+    note::constants::MAX_NOTES_PER_PAGE
 };
 use dep::value_note::{value_note::{ValueNote, VALUE_NOTE_LEN}};
 

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -103,9 +103,10 @@ impl<Context> Deck<Context> {
 
 impl Deck<&mut PrivateContext> {
     pub fn add_cards<N>(&mut self, cards: [Card; N], owner: AztecAddress) -> [CardNote] {
-        let owner_npk_m_hash = get_current_public_keys(self.set.context, owner).npk_m.hash();
+        let owner_keys = get_current_public_keys(self.set.context, owner);
+        let owner_ivpk_m = owner_keys.ivpk_m;
+        let owner_npk_m_hash = owner_keys.npk_m.hash();
         let msg_sender_ovpk_m = get_current_public_keys(self.set.context, self.set.context.msg_sender()).ovpk_m;
-        let owner_ivpk_m = get_current_public_keys(self.set.context, owner).ivpk_m;
 
         let mut inserted_cards = &[];
         for card in cards {

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -3,7 +3,7 @@ use dep::aztec::prelude::{AztecAddress, FunctionSelector, PrivateContext, NoteHe
 use dep::aztec::{
     context::UnconstrainedContext,
     protocol_types::{traits::{ToField, Serialize, FromField}, constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL},
-    encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys,
+    encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys, keys::getters::get_current_public_keys,
     note::note_getter::view_notes, state_vars::PrivateSet, note::constants::MAX_NOTES_PER_PAGE
 };
 use dep::value_note::{value_note::{ValueNote, VALUE_NOTE_LEN}};
@@ -103,10 +103,9 @@ impl<Context> Deck<Context> {
 
 impl Deck<&mut PrivateContext> {
     pub fn add_cards<N>(&mut self, cards: [Card; N], owner: AztecAddress) -> [CardNote] {
-        let header = self.set.context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(self.set.context, owner);
-        let msg_sender_ovpk_m = header.get_ovpk_m(self.set.context, self.set.context.msg_sender());
-        let owner_ivpk_m = header.get_ivpk_m(self.set.context, owner);
+        let owner_npk_m_hash = get_current_public_keys(self.set.context, owner).npk_m.hash();
+        let msg_sender_ovpk_m = get_current_public_keys(self.set.context, self.set.context.msg_sender()).ovpk_m;
+        let owner_ivpk_m = get_current_public_keys(self.set.context, owner).ivpk_m;
 
         let mut inserted_cards = &[];
         for card in cards {

--- a/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
@@ -5,7 +5,8 @@ contract Child {
     use dep::aztec::{
         context::gas::GasOpts, protocol_types::{abis::call_context::CallContext},
         note::{note_getter_options::NoteGetterOptions, note_header::NoteHeader},
-        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
+        keys::getters::get_current_public_keys
     };
     use dep::value_note::value_note::ValueNote;
 
@@ -51,8 +52,7 @@ contract Child {
 
     #[aztec(private)]
     fn private_set_value(new_value: Field, owner: AztecAddress) -> Field {
-        let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(&mut context, owner);
+        let owner_npk_m_hash = get_current_public_keys(&mut context, owner).npk_m.hash();
 
         let mut note = ValueNote::new(new_value, owner_npk_m_hash);
         storage.a_map_with_private_values.at(owner).insert(&mut note).emit(encode_and_encrypt_note(&mut context, owner, owner));

--- a/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
@@ -6,6 +6,7 @@ contract Crowdfunding {
     use dep::aztec::{
         protocol_types::address::AztecAddress,
         encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
+        keys::getters::get_current_public_keys,
         state_vars::{PrivateSet, PublicImmutable, SharedImmutable}
     };
     use dep::aztec::unencrypted_logs::unencrypted_event_emission::encode_event;
@@ -76,10 +77,9 @@ contract Crowdfunding {
         Token::at(storage.donation_token.read_private()).transfer_from(donor, context.this_address(), amount as Field, 0).call(&mut context);
         // docs:end:do-transfer
 
-        let header = context.get_header();
         // 3) Create a value note for the donor so that he can later on claim a rewards token in the Claim
         // contract by proving that the hash of this note exists in the note hash tree.
-        let donor_npk_m_hash = header.get_npk_m_hash(&mut context, donor);
+        let donor_npk_m_hash = get_current_public_keys(&mut context, donor).npk_m.hash();
         // docs:start:valuenote_new
         let mut note = ValueNote::new(amount as Field, donor_npk_m_hash);
         // docs:end:valuenote_new

--- a/noir-projects/noir-contracts/contracts/delegated_on_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/delegated_on_contract/src/main.nr
@@ -4,7 +4,10 @@ contract DelegatedOn {
         AztecAddress, FunctionSelector, NoteHeader, NoteGetterOptions, NoteViewerOptions, PublicMutable,
         PrivateSet, PrivateContext, Map
     };
-    use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note;
+    use dep::aztec::{
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
+        keys::getters::get_current_public_keys
+    };
     use dep::value_note::value_note::ValueNote;
 
     #[aztec(storage)]
@@ -15,8 +18,7 @@ contract DelegatedOn {
 
     #[aztec(private)]
     fn private_set_value(new_value: Field, owner: AztecAddress) -> Field {
-        let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(&mut context, owner);
+        let owner_npk_m_hash = get_current_public_keys(&mut context, owner).npk_m.hash();
 
         let mut note = ValueNote::new(new_value, owner_npk_m_hash);
         storage.a_map_with_private_values.at(owner).insert(&mut note).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), owner));

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -20,6 +20,7 @@ contract DocsExample {
     };
     use dep::aztec::encrypted_logs::encrypted_note_emission::{encode_and_encrypt_note, encode_and_encrypt_note_with_keys};
     use dep::aztec::note::note_getter_options::Comparator;
+    use dep::aztec::keys::getters::get_current_public_keys;
     // how to import methods from other files/folders within your workspace
     use crate::types::{card_note::{CardNote, CARD_NOTE_LEN}, leader::Leader};
 
@@ -189,18 +190,16 @@ contract DocsExample {
 
     #[aztec(private)]
     fn insert_notes(amounts: [u8; 3]) {
-        let header = context.get_header();
-        let msg_sender_npk_m_hash = header.get_npk_m_hash(&mut context, context.msg_sender());
-        let msg_sender_ovpk_m = header.get_ovpk_m(&mut context, context.msg_sender());
-        let msg_sender_ivpk_m = header.get_ivpk_m(&mut context, context.msg_sender());
+        let sender_keys = get_current_public_keys(&mut context, context.msg_sender());
+        let sender_npk_m_hash = sender_keys.npk_m.hash();
 
         for i in 0..amounts.len() {
-            let mut note = CardNote::new(amounts[i], 1, msg_sender_npk_m_hash);
+            let mut note = CardNote::new(amounts[i], 1, sender_npk_m_hash);
             storage.set.insert(&mut note).emit(
                 encode_and_encrypt_note_with_keys(
                     &mut context,
-                    msg_sender_ovpk_m,
-                    msg_sender_ivpk_m,
+                    sender_keys.ovpk_m,
+                    sender_keys.ivpk_m,
                     context.msg_sender()
                 )
             );
@@ -209,10 +208,9 @@ contract DocsExample {
 
     #[aztec(private)]
     fn insert_note(amount: u8, randomness: Field) {
-        let header = context.get_header();
-        let msg_sender_npk_m_hash = header.get_npk_m_hash(&mut context, context.msg_sender());
-
-        let mut note = CardNote::new(amount, randomness, msg_sender_npk_m_hash);
+        let sender_npk_m_hash = get_current_public_keys(&mut context, context.msg_sender()).npk_m.hash();
+        
+        let mut note = CardNote::new(amount, randomness, sender_npk_m_hash);
         storage.set.insert(&mut note).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), context.msg_sender()));
     }
 
@@ -231,10 +229,9 @@ contract DocsExample {
 
     #[aztec(private)]
     fn update_legendary_card(randomness: Field, points: u8) {
-        let header = context.get_header();
-        let msg_sender_npk_m_hash = header.get_npk_m_hash(&mut context, context.msg_sender());
+        let sender_npk_m_hash = get_current_public_keys(&mut context, context.msg_sender()).npk_m.hash();
 
-        let mut new_card = CardNote::new(points, randomness, msg_sender_npk_m_hash);
+        let mut new_card = CardNote::new(points, randomness, sender_npk_m_hash);
         storage.legendary_card.replace(&mut new_card).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), context.msg_sender()));
         DocsExample::at(context.this_address()).update_leader(context.msg_sender(), points).enqueue(&mut context);
     }
@@ -244,8 +241,7 @@ contract DocsExample {
         // Ensure `points` > current value
         // Also serves as a e2e test that you can `get_note()` and then `replace()`
 
-        let header = context.get_header();
-        let msg_sender_npk_m_hash = header.get_npk_m_hash(&mut context, context.msg_sender());
+        let sender_npk_m_hash = get_current_public_keys(&mut context, context.msg_sender()).npk_m.hash();
 
         // docs:start:state_vars-PrivateMutableGet
         let card = storage.legendary_card.get_note().note;
@@ -254,7 +250,7 @@ contract DocsExample {
 
         let points = card.points + 1;
 
-        let mut new_card = CardNote::new(points, card.randomness, msg_sender_npk_m_hash);
+        let mut new_card = CardNote::new(points, card.randomness, sender_npk_m_hash);
         // docs:start:state_vars-PrivateMutableReplace
         storage.legendary_card.replace(&mut new_card).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), context.msg_sender()));
         // docs:end:state_vars-PrivateMutableReplace

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -207,7 +207,7 @@ contract DocsExample {
     #[aztec(private)]
     fn insert_note(amount: u8, randomness: Field) {
         let sender_npk_m_hash = get_current_public_keys(&mut context, context.msg_sender()).npk_m.hash();
-        
+
         let mut note = CardNote::new(amount, randomness, sender_npk_m_hash);
         storage.set.insert(&mut note).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), context.msg_sender()));
     }

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -169,8 +169,7 @@ contract DocsExample {
     // docs:start:initialize-private-mutable
     #[aztec(private)]
     fn initialize_private_immutable(randomness: Field, points: u8) {
-        let header = context.get_header();
-        let msg_sender_npk_m_hash = header.get_npk_m_hash(&mut context, context.msg_sender());
+        let msg_sender_npk_m_hash = get_current_public_keys(&mut context, context.msg_sender()).npk_m.hash();
 
         let mut new_card = CardNote::new(points, randomness, msg_sender_npk_m_hash);
         storage.private_immutable.initialize(&mut new_card).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), context.msg_sender()));
@@ -180,8 +179,7 @@ contract DocsExample {
     #[aztec(private)]
     // msg_sender() is 0 at deploy time. So created another function
     fn initialize_private(randomness: Field, points: u8) {
-        let header = context.get_header();
-        let msg_sender_npk_m_hash = header.get_npk_m_hash(&mut context, context.msg_sender());
+        let msg_sender_npk_m_hash = get_current_public_keys(&mut context, context.msg_sender()).npk_m.hash();
 
         let mut legendary_card = CardNote::new(points, randomness, msg_sender_npk_m_hash);
         // create and broadcast note

--- a/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/main.nr
@@ -1,6 +1,7 @@
 contract EasyPrivateVoting {
     // docs:start:imports
     use dep::aztec::prelude::{AztecAddress, FunctionSelector, PrivateContext, Map, PublicMutable, SharedImmutable};
+    use dep::aztec::keys::getters::get_historical_public_keys;
     // docs:end:imports
     // docs:start:storage_struct
     #[aztec(storage)]
@@ -28,7 +29,7 @@ contract EasyPrivateVoting {
         // Below, we make sure to get our nullifier public key at a specific block. By pinning the nullifier public key at a specific block,
         // rotating keys will have no effect on the nullifier being produced, and voting again after will fail because the same nullifier is computed each time the user votes.
         let header_at_active_at_block = context.get_header_at(storage.active_at_block.read_private());
-        let msg_sender_npk_m_hash = header_at_active_at_block.get_npk_m_hash(&mut context, context.msg_sender());
+        let msg_sender_npk_m_hash = get_historical_public_keys(header_at_active_at_block, context.msg_sender()).npk_m.hash();
 
         let secret = context.request_nsk_app(msg_sender_npk_m_hash); // get secret key of caller of function
         let nullifier = std::hash::pedersen_hash([context.msg_sender().to_field(), secret]); // derive nullifier from sender and secret

--- a/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/src/main.nr
@@ -2,7 +2,10 @@
 // The signing key is stored in an immutable private note and should be different from the signing key.
 contract EcdsaKAccount {
     use dep::aztec::prelude::{AztecAddress, FunctionSelector, NoteHeader, NoteGetterOptions, PrivateContext, PrivateImmutable};
-    use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note;
+    use dep::aztec::{
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
+        keys::getters::get_current_public_keys
+    };
 
     use dep::aztec::protocol_types::abis::call_context::CallContext;
     use dep::std;
@@ -24,8 +27,7 @@ contract EcdsaKAccount {
     #[aztec(initializer)]
     fn constructor(signing_pub_key_x: [u8; 32], signing_pub_key_y: [u8; 32]) {
         let this = context.this_address();
-        let header = context.get_header();
-        let this_npk_m_hash = header.get_npk_m_hash(&mut context, this);
+        let this_npk_m_hash = get_current_public_keys(&mut context, this).npk_m.hash();
         // Not emitting outgoing for msg_sender here to not have to register keys for the contract through which we
         // deploy this (typically MultiCallEntrypoint). I think it's ok here as I feel the outgoing here is not that
         // important.

--- a/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/src/main.nr
@@ -1,7 +1,10 @@
 // Account contract that uses ECDSA signatures for authentication on random version of the p256 curve (to use with touchID).
 contract EcdsaRAccount {
     use dep::aztec::prelude::{AztecAddress, FunctionSelector, NoteHeader, NoteGetterOptions, PrivateContext, PrivateImmutable};
-    use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note;
+    use dep::aztec::{
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
+        keys::getters::get_current_public_keys
+    };
 
     use dep::aztec::protocol_types::abis::call_context::CallContext;
     use dep::std;
@@ -23,8 +26,7 @@ contract EcdsaRAccount {
     #[aztec(initializer)]
     fn constructor(signing_pub_key_x: [u8; 32], signing_pub_key_y: [u8; 32]) {
         let this = context.this_address();
-        let header = context.get_header();
-        let this_npk_m_hash = header.get_npk_m_hash(&mut context, this);
+        let this_npk_m_hash = get_current_public_keys(&mut context, this).npk_m.hash();
         // Not emitting outgoing for msg_sender here to not have to register keys for the contract through which we
         // deploy this (typically MultiCallEntrypoint). I think it's ok here as I feel the outgoing here is not that
         // important.

--- a/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
@@ -1,7 +1,10 @@
 // Sample escrow contract that stores a balance of a private token on behalf of an owner.
 contract Escrow {
     use dep::aztec::prelude::{AztecAddress, EthAddress, FunctionSelector, NoteHeader, PrivateContext, PrivateImmutable};
-    use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note;
+    use dep::aztec::{
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
+        keys::getters::get_current_public_keys
+    };
 
     // docs:start:addressnote_import
     use dep::address_note::address_note::AddressNote;
@@ -17,8 +20,7 @@ contract Escrow {
     #[aztec(private)]
     #[aztec(initializer)]
     fn constructor(owner: AztecAddress) {
-        let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(&mut context, owner);
+        let owner_npk_m_hash = get_current_public_keys(&mut context, owner).npk_m.hash();
         // docs:start:addressnote_new
         let mut note = AddressNote::new(owner, owner_npk_m_hash);
         // docs:end:addressnote_new

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
@@ -4,7 +4,10 @@ contract InclusionProofs {
         AztecAddress, EthAddress, FunctionSelector, NoteHeader, NoteGetterOptions, PrivateContext, Map,
         PrivateSet, PublicMutable
     };
-    use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note;
+    use dep::aztec::{
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
+        keys::getters::get_current_public_keys
+    };
 
     use dep::aztec::protocol_types::{contract_class_id::ContractClassId, header::Header};
     use dep::aztec::{note::note_getter_options::NoteStatus};
@@ -29,8 +32,7 @@ contract InclusionProofs {
     #[aztec(private)]
     fn create_note(owner: AztecAddress, value: Field) {
         let owner_private_values = storage.private_values.at(owner);
-        let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(&mut context, owner);
+        let owner_npk_m_hash = get_current_public_keys(&mut context, owner).npk_m.hash();
 
         let mut note = ValueNote::new(value, owner_npk_m_hash);
         owner_private_values.insert(&mut note).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), owner));
@@ -74,7 +76,7 @@ contract InclusionProofs {
         block_number: u32 // The block at which we'll prove that the note exists
     ) {
         let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(&mut context, owner);
+        let owner_npk_m_hash = get_current_public_keys(&mut context, owner).npk_m.hash();
         let mut note = ValueNote::new(1, owner_npk_m_hash);
 
         let header = if (use_block_number) {

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
@@ -334,7 +334,7 @@ contract PendingNoteHashes {
         let owner_npk_m_hash = owner_keys.npk_m.hash();
         let owner_ivpk_m = owner_keys.ivpk_m;
         let outgoing_viewer_ovpk_m = get_current_public_keys(&mut context, outgoing_viewer).ovpk_m;
-        
+
         let mut good_note = ValueNote::new(10, owner_npk_m_hash);
         // Insert good note with real log
         owner_balance.insert(&mut good_note).emit(encode_and_encrypt_note(&mut context, outgoing_viewer, owner));

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
@@ -9,6 +9,7 @@ contract PendingNoteHashes {
     use dep::aztec::protocol_types::constants::{MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, MAX_NOTE_HASHES_PER_CALL};
     use dep::aztec::encrypted_logs::encrypted_note_emission::{encode_and_encrypt_note, encode_and_encrypt_note_with_keys};
     use dep::aztec::note::note_emission::NoteEmission;
+    use dep::aztec::keys::getters::get_current_public_keys;
 
     #[aztec(storage)]
     struct Storage {
@@ -333,10 +334,11 @@ contract PendingNoteHashes {
     fn test_emit_bad_note_log(owner: AztecAddress, outgoing_viewer: AztecAddress) {
         let owner_balance = storage.balances.at(owner);
 
-        let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(&mut context, owner);
-        let outgoing_viewer_ovpk_m = header.get_ovpk_m(&mut context, outgoing_viewer);
-        let owner_ivpk_m = header.get_ivpk_m(&mut context, owner);
+        let owner_keys = get_current_public_keys(&mut context, owner);
+        let owner_npk_m_hash = owner_keys.npk_m.hash();
+        let owner_ivpk_m = owner_keys.ivpk_m;
+        let outgoing_viewer_ovpk_m = get_current_public_keys(&mut context, outgoing_viewer).ovpk_m;
+        
         let mut good_note = ValueNote::new(10, owner_npk_m_hash);
         // Insert good note with real log
         owner_balance.insert(&mut good_note).emit(encode_and_encrypt_note(&mut context, outgoing_viewer, owner));
@@ -359,10 +361,11 @@ contract PendingNoteHashes {
         context: &mut PrivateContext
     ) {
         let owner_balance = storage.balances.at(owner);
-        let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(context, owner);
-        let outgoing_viewer_ovpk_m = header.get_ovpk_m(context, outgoing_viewer);
-        let owner_ivpk_m = header.get_ivpk_m(context, owner);
+
+        let owner_keys = get_current_public_keys(context, owner);
+        let owner_npk_m_hash = owner_keys.npk_m.hash();
+        let owner_ivpk_m = owner_keys.ivpk_m;
+        let outgoing_viewer_ovpk_m = get_current_public_keys(context, outgoing_viewer).ovpk_m;
 
         for i in 0..max_notes_per_call() {
             let mut note = ValueNote::new(i as Field, owner_npk_m_hash);

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
@@ -30,8 +30,7 @@ contract PendingNoteHashes {
     ) -> Field {
         let owner_balance = storage.balances.at(owner);
 
-        let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(&mut context, owner);
+        let owner_npk_m_hash = get_current_public_keys(&mut context, owner).npk_m.hash();
 
         let mut note = ValueNote::new(amount, owner_npk_m_hash);
 
@@ -61,7 +60,7 @@ contract PendingNoteHashes {
         assert(notes.len() == 0);
 
         let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(&mut context, owner);
+        let owner_npk_m_hash = get_current_public_keys(&mut context, owner).npk_m.hash();
 
         // Insert note
         let mut note = ValueNote::new(amount, owner_npk_m_hash);
@@ -79,8 +78,7 @@ contract PendingNoteHashes {
     fn insert_note(amount: Field, owner: AztecAddress, outgoing_viewer: AztecAddress) {
         let owner_balance = storage.balances.at(owner);
 
-        let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(&mut context, owner);
+        let owner_npk_m_hash = get_current_public_keys(&mut context, owner).npk_m.hash();
 
         let mut note = ValueNote::new(amount, owner_npk_m_hash);
 
@@ -99,8 +97,7 @@ contract PendingNoteHashes {
     ) {
         let mut owner_balance = storage.balances.at(owner);
 
-        let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(&mut context, owner);
+        let owner_npk_m_hash = get_current_public_keys(&mut context, owner).npk_m.hash();
 
         let mut note = ValueNote::new(amount, owner_npk_m_hash);
         note.randomness = 2;
@@ -115,8 +112,7 @@ contract PendingNoteHashes {
     fn insert_note_extra_emit(amount: Field, owner: AztecAddress, outgoing_viewer: AztecAddress) {
         let mut owner_balance = storage.balances.at(owner);
 
-        let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(&mut context, owner);
+        let owner_npk_m_hash = get_current_public_keys(&mut context, owner).npk_m.hash();
 
         let mut note = ValueNote::new(amount, owner_npk_m_hash);
 

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -11,10 +11,7 @@ contract SchnorrAccount {
         entrypoint::{app::AppPayload, fee::FeePayload}, account::AccountActions,
         auth_witness::get_auth_witness, auth::{compute_authwit_nullifier, compute_authwit_message_hash}
     };
-    use dep::aztec::{
-        hash::compute_siloed_nullifier,
-        keys::getters::get_current_public_keys
-    };
+    use dep::aztec::{hash::compute_siloed_nullifier, keys::getters::get_current_public_keys};
     use dep::aztec::oracle::get_nullifier_membership_witness::get_low_nullifier_membership_witness;
 
     use crate::public_key_note::{PublicKeyNote, PUBLIC_KEY_NOTE_LEN};

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -11,7 +11,10 @@ contract SchnorrAccount {
         entrypoint::{app::AppPayload, fee::FeePayload}, account::AccountActions,
         auth_witness::get_auth_witness, auth::{compute_authwit_nullifier, compute_authwit_message_hash}
     };
-    use dep::aztec::hash::compute_siloed_nullifier;
+    use dep::aztec::{
+        hash::compute_siloed_nullifier,
+        keys::getters::get_current_public_keys
+    };
     use dep::aztec::oracle::get_nullifier_membership_witness::get_low_nullifier_membership_witness;
 
     use crate::public_key_note::{PublicKeyNote, PUBLIC_KEY_NOTE_LEN};
@@ -28,8 +31,7 @@ contract SchnorrAccount {
     #[aztec(initializer)]
     fn constructor(signing_pub_key_x: Field, signing_pub_key_y: Field) {
         let this = context.this_address();
-        let header = context.get_header();
-        let this_npk_m_hash = header.get_npk_m_hash(&mut context, this);
+        let this_npk_m_hash = get_current_public_keys(&mut context, this).npk_m.hash();
         // Not emitting outgoing for msg_sender here to not have to register keys for the contract through which we
         // deploy this (typically MultiCallEntrypoint). I think it's ok here as I feel the outgoing here is not that
         // important.

--- a/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
@@ -5,7 +5,8 @@ contract StaticChild {
     use dep::aztec::{
         context::{PublicContext, gas::GasOpts}, protocol_types::{abis::{call_context::CallContext}},
         note::{note_getter_options::NoteGetterOptions, note_header::NoteHeader},
-        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
+        keys::getters::get_current_public_keys
     };
     use dep::value_note::value_note::ValueNote;
 
@@ -40,8 +41,7 @@ contract StaticChild {
     #[aztec(private)]
     #[aztec(view)]
     fn private_illegal_set_value(new_value: Field, owner: AztecAddress) -> Field {
-        let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(&mut context, owner);
+        let owner_npk_m_hash = get_current_public_keys(&mut context, owner).npk_m.hash();
         let mut note = ValueNote::new(new_value, owner_npk_m_hash);
         storage.a_private_value.insert(&mut note).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), owner));
         new_value
@@ -54,8 +54,7 @@ contract StaticChild {
         owner: AztecAddress,
         outgoing_viewer: AztecAddress
     ) -> Field {
-        let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(&mut context, owner);
+        let owner_npk_m_hash = get_current_public_keys(&mut context, owner).npk_m.hash();
         let mut note = ValueNote::new(new_value, owner_npk_m_hash);
         storage.a_private_value.insert(&mut note).emit(encode_and_encrypt_note(&mut context, outgoing_viewer, owner));
         new_value
@@ -65,7 +64,7 @@ contract StaticChild {
     #[aztec(private)]
     #[aztec(view)]
     fn private_get_value(amount: Field, owner: AztecAddress) -> Field {
-        let owner_npk_m_hash = context.get_header().get_npk_m_hash(&mut context, owner);
+        let owner_npk_m_hash = get_current_public_keys(&mut context, owner).npk_m.hash();
         let mut options = NoteGetterOptions::new();
         options = options.select(ValueNote::properties().value, amount, Option::none()).select(
             ValueNote::properties().npk_m_hash,

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -22,6 +22,7 @@ contract Test {
     use dep::aztec::encrypted_logs::outgoing_body::EncryptedLogOutgoingBody;
 
     use dep::aztec::note::constants::MAX_NOTES_PER_PAGE;
+    use dep::aztec::keys::getters::get_current_public_keys;
 
     use dep::aztec::state_vars::{shared_mutable::SharedMutablePrivateGetter};
 
@@ -63,10 +64,9 @@ contract Test {
 
     #[aztec(private)]
     fn get_master_incoming_viewing_public_key(address: AztecAddress) -> [Field; 2] {
-        let header = context.get_header();
-        let pub_key = header.get_ivpk_m(&mut context, address);
-
-        [pub_key.x, pub_key.y]
+        let ivpk_m = get_current_public_keys(&mut context, address).ivpk_m;
+        
+        [ivpk_m.x, ivpk_m.y]
     }
 
     // Get the address of this contract (taken from the input context)
@@ -266,9 +266,8 @@ contract Test {
         outgoing_viewer: AztecAddress,
         nest: bool
     ) {
-        let header = context.get_header();
-        let outgoing_viewer_ovpk_m = header.get_ovpk_m(&mut context, outgoing_viewer);
-        let owner_ivpk_m = header.get_ivpk_m(&mut context, owner);
+        let owner_ivpk_m = get_current_public_keys(&mut context, owner).ivpk_m;
+        let outgoing_viewer_ovpk_m = get_current_public_keys(&mut context, outgoing_viewer).ovpk_m;
 
         let event = ExampleEvent { value0: fields[0], value1: fields[1], value2: fields[2], value3: fields[3], value4: fields[4] };
 
@@ -504,7 +503,7 @@ contract Test {
 
     #[aztec(private)]
     fn test_nullifier_key_freshness(address: AztecAddress, public_nullifying_key: Point) {
-        assert_eq(context.get_header().get_npk_m(&mut context, address), public_nullifying_key);
+        assert_eq(get_current_keys(&mut context, address).npk_m, public_nullifying_key);
     }
 
     // Purely exists for testing

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -65,7 +65,7 @@ contract Test {
     #[aztec(private)]
     fn get_master_incoming_viewing_public_key(address: AztecAddress) -> [Field; 2] {
         let ivpk_m = get_current_public_keys(&mut context, address).ivpk_m;
-        
+
         [ivpk_m.x, ivpk_m.y]
     }
 

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -99,8 +99,7 @@ contract Test {
             storage_slot != storage.example_constant.get_storage_slot(), "this storage slot is reserved for example_constant"
         );
 
-        let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(&mut context, owner);
+        let owner_npk_m_hash = get_current_public_keys(&mut context, owner).npk_m.hash();
 
         let mut note = ValueNote::new(value, owner_npk_m_hash);
         create_note(&mut context, storage_slot, &mut note).emit(encode_and_encrypt_note(&mut context, outgoing_viewer, owner));
@@ -308,8 +307,7 @@ contract Test {
         Test::at(context.this_address()).call_create_note(value, owner, outgoing_viewer, storage_slot).call(&mut context);
         storage_slot += 1;
 
-        let header = context.get_header();
-        let owner_npk_m_hash = header.get_npk_m_hash(&mut context, owner);
+        let owner_npk_m_hash = get_current_public_keys(&mut context, owner).npk_m.hash();
 
         let mut note = ValueNote::new(value + 1, owner_npk_m_hash);
         create_note(&mut context, storage_slot, &mut note).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), owner));
@@ -503,7 +501,7 @@ contract Test {
 
     #[aztec(private)]
     fn test_nullifier_key_freshness(address: AztecAddress, public_nullifying_key: Point) {
-        assert_eq(get_current_keys(&mut context, address).npk_m, public_nullifying_key);
+        assert_eq(get_current_public_keys(&mut context, address).npk_m, public_nullifying_key);
     }
 
     // Purely exists for testing

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/balances_map.nr
@@ -2,7 +2,8 @@ use dep::aztec::prelude::{AztecAddress, NoteGetterOptions, NoteViewerOptions, No
 use dep::aztec::{
     context::{PrivateContext, UnconstrainedContext},
     protocol_types::constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
-    note::{note_getter::view_notes, note_getter_options::SortOrder, note_emission::OuterNoteEmission}
+    note::{note_getter::view_notes, note_getter_options::SortOrder, note_emission::OuterNoteEmission},
+    keys::getters::get_current_public_keys
 };
 use crate::types::{token_note::{TokenNote, OwnedNote}};
 
@@ -64,10 +65,9 @@ impl<T> BalancesMap<T, &mut PrivateContext> {
             OuterNoteEmission::new(Option::none())
         } else {
             let context = self.map.context;
-            let header = context.get_header();
 
             // We fetch the nullifier public key hash from the registry / from our PXE
-            let owner_npk_m_hash = header.get_npk_m_hash(context, owner);
+            let owner_npk_m_hash = get_current_public_keys(context, owner).npk_m.hash();
             let mut addend_note = T::new(addend, owner_npk_m_hash);
 
             // docs:start:insert

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -356,11 +356,11 @@ contract Token {
         );
 
         storage.balances.add(from, change).emit(
-            encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ivpk_m, from_keys.ovpk_m, from)
+            encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from)
         );
 
         storage.balances.add(to, amount).emit(
-            encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ivpk_m, to_keys.ivpk_m, to)
+            encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to)
         );
 
         // We don't constrain encryption of the note log in `transfer` (unlike in `transfer_from`) because the transfer
@@ -368,7 +368,7 @@ contract Token {
         // another person where the payment is considered to be successful when the other party successfully decrypts a
         // note).
         Transfer { from, to, amount: amount.to_field() }.emit(
-            encode_and_encrypt_event_with_keys_unconstrained(&mut context, from_keys.ivpk_m, to_keys.ivpk_m, to)
+            encode_and_encrypt_event_with_keys_unconstrained(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to)
         );
     }
     // docs:end:transfer

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -25,7 +25,7 @@ contract Token {
     },
         encrypted_event_emission::{encode_and_encrypt_event, encode_and_encrypt_event_with_keys_unconstrained}
     },
-        keys::getters::get_current_public_keys,
+        keys::getters::get_current_public_keys
     };
 
     // docs:start:import_authwit
@@ -335,7 +335,7 @@ contract Token {
     #[aztec(private)]
     fn transfer(to: AztecAddress, amount: Field) {
         let from = context.msg_sender();
-        
+
         let from_keys = get_current_public_keys(&mut context, from);
         let to_keys = get_current_public_keys(&mut context, to);
 
@@ -355,15 +355,21 @@ contract Token {
             INITIAL_TRANSFER_CALL_MAX_NOTES
         );
 
-        storage.balances.add(from, change).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ivpk_m, from_keys.ovpk_m, from));
+        storage.balances.add(from, change).emit(
+            encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ivpk_m, from_keys.ovpk_m, from)
+        );
 
-        storage.balances.add(to, amount).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ivpk_m, to_keys.ivpk_m, to));
+        storage.balances.add(to, amount).emit(
+            encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ivpk_m, to_keys.ivpk_m, to)
+        );
 
         // We don't constrain encryption of the note log in `transfer` (unlike in `transfer_from`) because the transfer
         // function is only designed to be used in situations where the event is not strictly necessary (e.g. payment to
         // another person where the payment is considered to be successful when the other party successfully decrypts a
         // note).
-        Transfer { from, to, amount: amount.to_field() }.emit(encode_and_encrypt_event_with_keys_unconstrained(&mut context, from_keys.ivpk_m, to_keys.ivpk_m, to));
+        Transfer { from, to, amount: amount.to_field() }.emit(
+            encode_and_encrypt_event_with_keys_unconstrained(&mut context, from_keys.ivpk_m, to_keys.ivpk_m, to)
+        );
     }
     // docs:end:transfer
 
@@ -443,7 +449,7 @@ contract Token {
             assert(nonce == 0, "invalid nonce");
         }
         // docs:end:assert_current_call_valid_authwit
-        
+
         let from_keys = get_current_public_keys(&mut context, from);
         let to_keys = get_current_public_keys(&mut context, to);
 

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -24,7 +24,8 @@ contract Token {
         encode_and_encrypt_note_with_keys_unconstrained
     },
         encrypted_event_emission::{encode_and_encrypt_event, encode_and_encrypt_event_with_keys_unconstrained}
-    }
+    },
+        keys::getters::get_current_public_keys,
     };
 
     // docs:start:import_authwit
@@ -334,13 +335,9 @@ contract Token {
     #[aztec(private)]
     fn transfer(to: AztecAddress, amount: Field) {
         let from = context.msg_sender();
-
-        // By fetching the keys here, we can avoid doing an extra read from the storage, since from_ovpk would
-        // be needed twice.
-        let header = context.get_header();
-        let from_ovpk = header.get_ovpk_m(&mut context, from);
-        let from_ivpk = header.get_ivpk_m(&mut context, from);
-        let to_ivpk = header.get_ivpk_m(&mut context, to);
+        
+        let from_keys = get_current_public_keys(&mut context, from);
+        let to_keys = get_current_public_keys(&mut context, to);
 
         let amount = U128::from_integer(amount);
 
@@ -358,15 +355,15 @@ contract Token {
             INITIAL_TRANSFER_CALL_MAX_NOTES
         );
 
-        storage.balances.add(from, change).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_ovpk, from_ivpk, from));
+        storage.balances.add(from, change).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ivpk_m, from_keys.ovpk_m, from));
 
-        storage.balances.add(to, amount).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_ovpk, to_ivpk, to));
+        storage.balances.add(to, amount).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ivpk_m, to_keys.ivpk_m, to));
 
         // We don't constrain encryption of the note log in `transfer` (unlike in `transfer_from`) because the transfer
         // function is only designed to be used in situations where the event is not strictly necessary (e.g. payment to
         // another person where the payment is considered to be successful when the other party successfully decrypts a
         // note).
-        Transfer { from, to, amount: amount.to_field() }.emit(encode_and_encrypt_event_with_keys_unconstrained(&mut context, from_ovpk, to_ivpk, to));
+        Transfer { from, to, amount: amount.to_field() }.emit(encode_and_encrypt_event_with_keys_unconstrained(&mut context, from_keys.ivpk_m, to_keys.ivpk_m, to));
     }
     // docs:end:transfer
 
@@ -446,21 +443,17 @@ contract Token {
             assert(nonce == 0, "invalid nonce");
         }
         // docs:end:assert_current_call_valid_authwit
-
-        // By fetching the keys here, we can avoid doing an extra read from the storage, since from_ovpk would
-        // be needed twice.
-        let header = context.get_header();
-        let from_ovpk = header.get_ovpk_m(&mut context, from);
-        let from_ivpk = header.get_ivpk_m(&mut context, from);
-        let to_ivpk = header.get_ivpk_m(&mut context, to);
+        
+        let from_keys = get_current_public_keys(&mut context, from);
+        let to_keys = get_current_public_keys(&mut context, to);
 
         let amount = U128::from_integer(amount);
         // docs:start:increase_private_balance
         // docs:start:encrypted
-        storage.balances.sub(from, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, from_ivpk, from));
+        storage.balances.sub(from, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from));
         // docs:end:encrypted
         // docs:end:increase_private_balance
-        storage.balances.add(to, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, to_ivpk, to));
+        storage.balances.add(to, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to));
     }
     // docs:end:transfer_from
 

--- a/noir-projects/noir-contracts/contracts/token_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/types/balances_map.nr
@@ -4,8 +4,9 @@ use dep::aztec::{
     protocol_types::constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
     note::{
     note_getter::view_notes, note_getter_options::SortOrder,
-    note_emission::{NoteEmission, OuterNoteEmission}
-}
+    note_emission::{NoteEmission, OuterNoteEmission},
+},
+    keys::getters::get_current_public_keys
 };
 use crate::types::{token_note::{TokenNote, OwnedNote}};
 
@@ -67,10 +68,9 @@ impl<T> BalancesMap<T, &mut PrivateContext> {
             OuterNoteEmission::new(Option::none())
         } else {
             let context = self.map.context;
-            let header = context.get_header();
 
             // We fetch the nullifier public key hash from the registry / from our PXE
-            let owner_npk_m_hash = header.get_npk_m_hash(context, owner);
+            let owner_npk_m_hash = get_current_public_keys(context, owner).npk_m.hash();
             let mut addend_note = T::new(addend, owner_npk_m_hash);
 
             // docs:start:insert

--- a/noir-projects/noir-contracts/contracts/token_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/types/balances_map.nr
@@ -4,7 +4,7 @@ use dep::aztec::{
     protocol_types::constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
     note::{
     note_getter::view_notes, note_getter_options::SortOrder,
-    note_emission::{NoteEmission, OuterNoteEmission},
+    note_emission::{NoteEmission, OuterNoteEmission}
 },
     keys::getters::get_current_public_keys
 };

--- a/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/main.nr
@@ -331,7 +331,7 @@ contract TokenWithRefunds {
     #[aztec(private)]
     fn transfer(to: AztecAddress, amount: Field) {
         let from = context.msg_sender();
-        
+
         let from_keys = get_current_public_keys(&mut context, from);
         let to_keys = get_current_public_keys(&mut context, to);
 
@@ -351,15 +351,21 @@ contract TokenWithRefunds {
             INITIAL_TRANSFER_CALL_MAX_NOTES
         );
 
-        storage.balances.add(from, change).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from));
+        storage.balances.add(from, change).emit(
+            encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from)
+        );
 
-        storage.balances.add(to, amount).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to));
+        storage.balances.add(to, amount).emit(
+            encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to)
+        );
 
         // We don't constrain encryption of the note log in `transfer` (unlike in `transfer_from`) because the transfer
         // function is only designed to be used in situations where the event is not strictly necessary (e.g. payment to
         // another person where the payment is considered to be successful when the other party successfully decrypts a
         // note).
-        Transfer2 { from, to, amount: amount.to_field() }.emit(encode_and_encrypt_event_with_keys_unconstrained(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to));
+        Transfer2 { from, to, amount: amount.to_field() }.emit(
+            encode_and_encrypt_event_with_keys_unconstrained(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to)
+        );
     }
     // docs:end:transfer
 
@@ -439,7 +445,7 @@ contract TokenWithRefunds {
             assert(nonce == 0, "invalid nonce");
         }
         // docs:end:assert_current_call_valid_authwit
-        
+
         let from_keys = get_current_public_keys(&mut context, from);
         let to_keys = get_current_public_keys(&mut context, to);
 
@@ -545,7 +551,9 @@ contract TokenWithRefunds {
             U128::from_integer(funded_amount),
             INITIAL_TRANSFER_CALL_MAX_NOTES
         );
-        storage.balances.add(user, change).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, user_keys.ovpk_m, user_keys.ivpk_m, user));
+        storage.balances.add(user, change).emit(
+            encode_and_encrypt_note_with_keys_unconstrained(&mut context, user_keys.ovpk_m, user_keys.ivpk_m, user)
+        );
 
         // 4. We create the partial notes for the fee payer and the user.
         // --> Called "partial" because they don't have the amount set yet (that will be done in `complete_refund(...)`).

--- a/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/main.nr
@@ -19,7 +19,8 @@ contract TokenWithRefunds {
         encode_and_encrypt_note_with_keys_unconstrained
     },
         encrypted_event_emission::{encode_and_encrypt_event, encode_and_encrypt_event_with_keys_unconstrained}
-    }
+    },
+        keys::getters::get_current_public_keys,
     };
 
     // docs:start:import_authwit
@@ -330,13 +331,9 @@ contract TokenWithRefunds {
     #[aztec(private)]
     fn transfer(to: AztecAddress, amount: Field) {
         let from = context.msg_sender();
-
-        // By fetching the keys here, we can avoid doing an extra read from the storage, since from_ovpk would
-        // be needed twice.
-        let header = context.get_header();
-        let from_ovpk = header.get_ovpk_m(&mut context, from);
-        let from_ivpk = header.get_ivpk_m(&mut context, from);
-        let to_ivpk = header.get_ivpk_m(&mut context, to);
+        
+        let from_keys = get_current_public_keys(&mut context, from);
+        let to_keys = get_current_public_keys(&mut context, to);
 
         let amount = U128::from_integer(amount);
 
@@ -354,15 +351,15 @@ contract TokenWithRefunds {
             INITIAL_TRANSFER_CALL_MAX_NOTES
         );
 
-        storage.balances.add(from, change).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_ovpk, from_ivpk, from));
+        storage.balances.add(from, change).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from));
 
-        storage.balances.add(to, amount).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_ovpk, to_ivpk, to));
+        storage.balances.add(to, amount).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to));
 
         // We don't constrain encryption of the note log in `transfer` (unlike in `transfer_from`) because the transfer
         // function is only designed to be used in situations where the event is not strictly necessary (e.g. payment to
         // another person where the payment is considered to be successful when the other party successfully decrypts a
         // note).
-        Transfer2 { from, to, amount: amount.to_field() }.emit(encode_and_encrypt_event_with_keys_unconstrained(&mut context, from_ovpk, to_ivpk, to));
+        Transfer2 { from, to, amount: amount.to_field() }.emit(encode_and_encrypt_event_with_keys_unconstrained(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to));
     }
     // docs:end:transfer
 
@@ -442,21 +439,17 @@ contract TokenWithRefunds {
             assert(nonce == 0, "invalid nonce");
         }
         // docs:end:assert_current_call_valid_authwit
-
-        // By fetching the keys here, we can avoid doing an extra read from the storage, since from_ovpk would
-        // be needed twice.
-        let header = context.get_header();
-        let from_ovpk = header.get_ovpk_m(&mut context, from);
-        let from_ivpk = header.get_ivpk_m(&mut context, from);
-        let to_ivpk = header.get_ivpk_m(&mut context, to);
+        
+        let from_keys = get_current_public_keys(&mut context, from);
+        let to_keys = get_current_public_keys(&mut context, to);
 
         let amount = U128::from_integer(amount);
         // docs:start:increase_private_balance
         // docs:start:encrypted
-        storage.balances.sub(from, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, from_ivpk, from));
+        storage.balances.sub(from, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from));
         // docs:end:encrypted
         // docs:end:increase_private_balance
-        storage.balances.add(to, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk, to_ivpk, to));
+        storage.balances.add(to, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to));
     }
     // docs:end:transfer_from
 
@@ -537,10 +530,10 @@ contract TokenWithRefunds {
 
         // 2. Get all the relevant keys
         let header = context.get_header();
-        let fee_payer_npk_m_hash = header.get_npk_m_hash(&mut context, fee_payer);
-        let user_npk_m_hash = header.get_npk_m_hash(&mut context, user);
-        let user_ovpk = header.get_ovpk_m(&mut context, user);
-        let user_ivpk = header.get_ivpk_m(&mut context, user);
+
+        let fee_payer_npk_m_hash = get_current_public_keys(&mut context, fee_payer).npk_m.hash();
+        let user_keys = get_current_public_keys(&mut context, user);
+        let user_npk_m_hash = user_keys.npk_m.hash();
 
         // 3. Deduct the funded amount from the user's balance - this is a maximum fee a user is willing to pay
         // (called fee limit in aztec spec). The difference between fee limit and the actual tx fee will be refunded 
@@ -552,7 +545,7 @@ contract TokenWithRefunds {
             U128::from_integer(funded_amount),
             INITIAL_TRANSFER_CALL_MAX_NOTES
         );
-        storage.balances.add(user, change).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, user_ovpk, user_ivpk, user));
+        storage.balances.add(user, change).emit(encode_and_encrypt_note_with_keys_unconstrained(&mut context, user_keys.ovpk_m, user_keys.ivpk_m, user));
 
         // 4. We create the partial notes for the fee payer and the user.
         // --> Called "partial" because they don't have the amount set yet (that will be done in `complete_refund(...)`).

--- a/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/main.nr
@@ -20,7 +20,7 @@ contract TokenWithRefunds {
     },
         encrypted_event_emission::{encode_and_encrypt_event, encode_and_encrypt_event_with_keys_unconstrained}
     },
-        keys::getters::get_current_public_keys,
+        keys::getters::get_current_public_keys
     };
 
     // docs:start:import_authwit

--- a/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/test/basic.nr
+++ b/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/test/basic.nr
@@ -2,7 +2,8 @@ use crate::{test::utils, TokenWithRefunds, types::token_note::TokenNote};
 
 use dep::aztec::{
     test::helpers::cheatcodes, oracle::unsafe_rand::unsafe_rand, hash::compute_secret_hash,
-    prelude::NoteHeader, protocol_types::storage::map::derive_storage_slot_in_map
+    prelude::NoteHeader, protocol_types::storage::map::derive_storage_slot_in_map,
+    keys::getters::get_current_public_keys
 };
 use dep::authwit::cheatcodes as authwit_cheatcodes;
 
@@ -33,8 +34,8 @@ unconstrained fn setup_refund_success() {
 
     env.call_private_void(setup_refund_from_call_interface);
     let mut context = env.private();
-    let user_npk_m_hash = context.get_header().get_npk_m_hash(&mut context, user);
-    let fee_payer_npk_m_hash = context.get_header().get_npk_m_hash(&mut context, fee_payer);
+    let user_npk_m_hash = get_current_public_keys(&mut context, user).npk_m.hash();
+    let fee_payer_npk_m_hash = get_current_public_keys(&mut context, fee_payer).npk_m.hash();
 
     let fee_payer_balances_slot = derive_storage_slot_in_map(TokenWithRefunds::storage().balances.slot, fee_payer);
     let user_balances_slot = derive_storage_slot_in_map(TokenWithRefunds::storage().balances.slot, user);

--- a/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_with_refunds_contract/src/types/balances_map.nr
@@ -5,7 +5,8 @@ use dep::aztec::{
     note::{
     note_getter::view_notes, note_getter_options::SortOrder,
     note_emission::{NoteEmission, OuterNoteEmission}
-}
+},
+    keys::getters::get_current_public_keys
 };
 use crate::types::{token_note::{TokenNote, OwnedNote}};
 
@@ -67,10 +68,9 @@ impl<T> BalancesMap<T, &mut PrivateContext> {
             OuterNoteEmission::new(Option::none())
         } else {
             let context = self.map.context;
-            let header = context.get_header();
 
             // We fetch the nullifier public key hash from the registry / from our PXE
-            let owner_npk_m_hash = header.get_npk_m_hash(context, owner);
+            let owner_npk_m_hash = get_current_public_keys(context, owner).npk_m.hash();
             let mut addend_note = T::new(addend, owner_npk_m_hash);
 
             // docs:start:insert


### PR DESCRIPTION
Closes #7953.

This was fairly straightforward since it turns out almost all key fetching locations requested the current keys and not historical ones. The only historical callsite is `easy_private_voting`, as expected.

Most of the callsites were simple replacements of the old API for the new one - in some of them it was clear that we were fetching multiple keys for the same account, and in those I added small edits so that'd we'd reuse the previously fetched keys.

With this, the token transfer gate count sits at 49k. Once we do #7954 we'll be able to reuse the npks we're computing in note creation, dropping ~10k further gates.