### PR TITLE
feat!: introduce `WithHash<T>` + use it in `PublicImmutable`

### DIFF
--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -9,9 +9,9 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 ### TBD
 
 ### [Aztec.nr] Introduction of `WithHash<T>
-`WithHash<T>` is a struct that allows for efficient reading of value `T` from public storage in private.
+`WithHash<T>` is a struct that allows for efficient reading of value T from public storage in private.
 This is achieved by storing the value with its hash, then obtaining the values via an oracle and verifying them against the hash.
-This results in in a fewer tree inclusion proofs for values `T` that are packed into more than a single field.
+This results in in a fewer tree inclusion proofs for values T that are packed into more than a single field.
 
 `WithHash<T>` is leveraged by state variables like `PublicImmutable`.
 This is a breaking change because now we require values stored in `PublicImmutable` and `SharedMutable` to implement the `Eq` trait.

--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -8,7 +8,7 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 
 ### TBD
 
-### [Aztec.nr] Introduction of `WithHash<T>
+### [Aztec.nr] Introduction of `WithHash<T>`
 `WithHash<T>` is a struct that allows for efficient reading of value `T` from public storage in private.
 This is achieved by storing the value with its hash, then obtaining the values via an oracle and verifying them against the hash.
 This results in in a fewer tree inclusion proofs for values `T` that are packed into more than a single field.

--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -6,6 +6,27 @@ keywords: [sandbox, aztec, notes, migration, updating, upgrading]
 
 Aztec is in full-speed development. Literally every version breaks compatibility with the previous ones. This page attempts to target errors and difficulties you might encounter when upgrading, and how to resolve them.
 
+### TBD
+
+### [Aztec.nr] Introduction of `WithHash<T>
+`WithHash<T>` is a struct that allows for efficient reading of value `T` from public storage in private.
+This is achieved by storing the value with its hash, then obtaining the values via an oracle and verifying them against the hash.
+This results in in a fewer tree inclusion proofs for values `T` that are packed into more than a single field.
+
+`WithHash<T>` is leveraged by state variables like `PublicImmutable`.
+This is a breaking change because now we require values stored in `PublicImmutable` and `SharedMutable` to implement the `Eq` trait.
+
+To implement the `Eq` trait you can use the `#[derive(Eq)]` macro:
+
+```diff
++ use std::meta::derive;
+
++ #[derive(Eq)]
+pub struct YourType {
+    ...
+}
+```
+
 ## 0.73.0
 
 ### [Token, FPC] Moving fee-related complexity from the Token to the FPC

--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -9,9 +9,9 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 ### TBD
 
 ### [Aztec.nr] Introduction of `WithHash<T>
-`WithHash<T>` is a struct that allows for efficient reading of value T from public storage in private.
+`WithHash<T>` is a struct that allows for efficient reading of value `T` from public storage in private.
 This is achieved by storing the value with its hash, then obtaining the values via an oracle and verifying them against the hash.
-This results in in a fewer tree inclusion proofs for values T that are packed into more than a single field.
+This results in in a fewer tree inclusion proofs for values `T` that are packed into more than a single field.
 
 `WithHash<T>` is leveraged by state variables like `PublicImmutable`.
 This is a breaking change because now we require values stored in `PublicImmutable` and `SharedMutable` to implement the `Eq` trait.

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -1,7 +1,7 @@
 use crate::{
     context::{PrivateContext, PublicContext, UnconstrainedContext},
-    history::public_storage::PublicStorageHistoricalRead,
     state_vars::storage::Storage,
+    utils::with_hash::WithHash,
 };
 use dep::protocol_types::{constants::INITIALIZATION_SLOT_SEPARATOR, traits::Packable};
 
@@ -14,9 +14,9 @@ pub struct PublicImmutable<T, Context> {
 }
 // docs:end:public_immutable_struct
 
-impl<T, Context, let N: u32> Storage<N> for PublicImmutable<T, Context>
+impl<T, Context, let M: u32, let N: u32> Storage<N> for PublicImmutable<T, Context>
 where
-    T: Packable<N>,
+    WithHash<T, M>: Packable<N>,
 {
     fn get_storage_slot(self) -> Field {
         self.storage_slot
@@ -38,7 +38,7 @@ impl<T, Context> PublicImmutable<T, Context> {
 
 impl<T, let T_PACKED_LEN: u32> PublicImmutable<T, &mut PublicContext>
 where
-    T: Packable<T_PACKED_LEN>,
+    T: Packable<T_PACKED_LEN> + Eq,
 {
     // docs:start:public_immutable_struct_write
     pub fn initialize(self, value: T) {
@@ -49,41 +49,36 @@ where
 
         // We populate the initialization slot with a non-zero value to indicate that the struct is initialized
         self.context.storage_write(initialization_slot, 0xdead);
-        self.context.storage_write(self.storage_slot, value);
+        self.context.storage_write(self.storage_slot, WithHash::new(value));
     }
     // docs:end:public_immutable_struct_write
 
     // Note that we don't access the context, but we do call oracles that are only available in public
     // docs:start:public_immutable_struct_read
     pub fn read(self) -> T {
-        self.context.storage_read(self.storage_slot)
+        WithHash::public_storage_read(*self.context, self.storage_slot)
     }
     // docs:end:public_immutable_struct_read
 }
 
 impl<T, let T_PACKED_LEN: u32> PublicImmutable<T, UnconstrainedContext>
 where
-    T: Packable<T_PACKED_LEN>,
+    T: Packable<T_PACKED_LEN> + Eq,
 {
     pub unconstrained fn read(self) -> T {
-        self.context.storage_read(self.storage_slot)
+        WithHash::unconstrained_public_storage_read(self.context, self.storage_slot)
     }
 }
 
 impl<T, let T_PACKED_LEN: u32> PublicImmutable<T, &mut PrivateContext>
 where
-    T: Packable<T_PACKED_LEN>,
+    T: Packable<T_PACKED_LEN> + Eq,
 {
     pub fn read(self) -> T {
-        let header = self.context.get_block_header();
-        let mut fields = [0; T_PACKED_LEN];
-
-        for i in 0..fields.len() {
-            fields[i] = header.public_storage_historical_read(
-                self.storage_slot + i as Field,
-                (*self.context).this_address(),
-            );
-        }
-        T::unpack(fields)
+        WithHash::historical_public_storage_read(
+            self.context.get_block_header(),
+            self.context.this_address(),
+            self.storage_slot,
+        )
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -7,6 +7,13 @@ use dep::protocol_types::{constants::INITIALIZATION_SLOT_SEPARATOR, traits::Pack
 
 /// Stores an immutable value in public state which can be read from public, private and unconstrained execution
 /// contexts.
+///
+/// Leverages `WithHash<T>` to enable efficient private reads of public storage. `WithHash` wrapper allows for
+/// efficient reads by verifying large values through a single hash check and then proving inclusion only of the hash
+/// in the public storage. This reduces the number of required tree inclusion proofs from O(M) to O(1).
+///
+/// This is valuable when T packs to multiple fields, as it maintains "almost constant" verification overhead
+/// regardless of the original data size.
 // docs:start:public_immutable_struct
 pub struct PublicImmutable<T, Context> {
     context: Context,
@@ -14,16 +21,8 @@ pub struct PublicImmutable<T, Context> {
 }
 // docs:end:public_immutable_struct
 
-/// Implements Storage<N> for PublicImmutable by leveraging WithHash<T> to enable efficient
-/// private reads of public storage. This approach stores both the packed value (using N fields)
-/// and its hash (1 field), requiring M = N + 1 total fields.
-///
-/// The WithHash wrapper allows for efficient reads by verifying large values through a single
-/// hash check and then proving inclusion only of the hash in the public storage. This reduces
-/// the number of required tree inclusion proofs from O(M) to O(1).
-///
-/// This is valuable when T packs to multiple fields, as it maintains "almost constant"
-/// verification overhead regardless of the original data size.
+/// `WithHash<T>` stores both the packed value (using N fields) and its hash (1 field), requiring N = M + 1 total
+/// fields.
 impl<T, Context, let M: u32, let N: u32> Storage<N> for PublicImmutable<T, Context>
 where
     WithHash<T, M>: Packable<N>,

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -14,6 +14,16 @@ pub struct PublicImmutable<T, Context> {
 }
 // docs:end:public_immutable_struct
 
+/// Implements Storage<N> for PublicImmutable by leveraging WithHash<T> to enable efficient
+/// private reads of public storage. This approach stores both the packed value (using N fields)
+/// and its hash (1 field), requiring M = N + 1 total fields.
+///
+/// The WithHash wrapper allows for efficient reads by verifying large values through a single
+/// hash check and then proving inclusion only of the hash in the public storage. This reduces
+/// the number of required tree inclusion proofs from O(M) to O(1).
+///
+/// This is valuable when T packs to multiple fields, as it maintains "almost constant"
+/// verification overhead regardless of the original data size.
 impl<T, Context, let M: u32, let N: u32> Storage<N> for PublicImmutable<T, Context>
 where
     WithHash<T, M>: Packable<N>,

--- a/noir-projects/aztec-nr/aztec/src/utils/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/mod.nr
@@ -5,3 +5,4 @@ pub mod field;
 pub mod point;
 pub mod to_bytes;
 pub mod secrets;
+pub mod with_hash;

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -7,15 +7,15 @@ use dep::protocol_types::{
     address::AztecAddress, block_header::BlockHeader, hash::poseidon2_hash, traits::Packable,
 };
 
-/// A struct that allows for efficient reading of value T from public storage in private.
+/// A struct that allows for efficient reading of value `T` from public storage in private.
 ///
 /// The efficient reads are achieved by verifying large values through a single hash check
 /// and then proving inclusion only of the hash in public storage. This reduces the number
-/// of required tree inclusion proofs from O(M) to O(1)
+/// of required tree inclusion proofs from `N` to 1.
 ///
 /// # Type Parameters
 /// - `T`: The underlying type being wrapped, must implement `Packable<N>`
-/// - `N`: The number of field elements required to pack values of type T
+/// - `N`: The number of field elements required to pack values of type `T`
 pub struct WithHash<T, let N: u32> {
     value: T,
     packed: [Field; N],

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -7,6 +7,14 @@ use dep::protocol_types::{
     address::AztecAddress, block_header::BlockHeader, hash::poseidon2_hash, traits::Packable,
 };
 
+/// A struct that allows for efficient reading of value T from public storage in private. This is
+/// achieved by storing the value with its hash, then obtaining the values via an oracle and
+/// verifying them against the hash. This results in in a fewer tree inclusion proofs for values T
+/// that are packed into more than a single field.
+///
+/// # Type Parameters
+/// - `T`: The underlying type being wrapped, must implement `Packable<N>`
+/// - `N`: The number of field elements required to pack values of type T
 pub struct WithHash<T, let N: u32> {
     value: T,
     packed: [Field; N],

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -51,7 +51,7 @@ where
         // We could simply produce historical inclusion proofs for each field in `packed`, but that would require one
         // full sibling path per storage slot (since due to kernel siloing the storage is not contiguous). Instead, we
         // get an oracle to provide us the values, and instead we prove inclusion of their hash, which is both a much
-        // smaller proof (a single slot), and also independent of the size of T.
+        // smaller proof (a single slot), and also independent of the size of T (except in that we need to pack and hash T).
         let hint = WithHash::new(
             /// Safety: We verify that a hash of the hint/packed data matches the stored hash.
             unsafe {

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -156,7 +156,7 @@ mod test {
     }
 
     #[test]
-    unconstrained fn test_reading_initialized_value() {
+    unconstrained fn read_initialized_value() {
         let mut env = TestEnvironment::new();
 
         let value = MockStruct { a: 5, b: 3 };
@@ -230,7 +230,7 @@ mod test {
         // We advance block by 1 because env.private() currently returns context at latest_block - 1
         env.advance_block_by(1);
 
-        let result = WithHash::<MockStruct, 2>::historical_public_storage_read(
+        let _ = WithHash::<MockStruct, 2>::historical_public_storage_read(
             env.private().historical_header,
             env.contract_address(),
             storage_slot,

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -78,7 +78,7 @@ where
             assert_eq(
                 hint.get_value(),
                 T::unpack(std::mem::zeroed()),
-                "Non-zero value change for zero hash",
+                "Non-zero hint for zero hash",
             );
         };
 
@@ -112,9 +112,15 @@ where
 }
 
 mod test {
-    use crate::test::mocks::mock_struct::MockStruct;
-    use crate::utils::with_hash::WithHash;
+    use crate::{
+        oracle::random::random,
+        test::{helpers::test_environment::TestEnvironment, mocks::mock_struct::MockStruct},
+        utils::with_hash::WithHash,
+    };
     use dep::protocol_types::hash::poseidon2_hash;
+    use dep::std::{mem, test::OracleMock};
+
+    global storage_slot: Field = 47;
 
     #[test]
     unconstrained fn create_and_recover() {
@@ -125,5 +131,90 @@ mod test {
         assert_eq(recovered.value, value);
         assert_eq(recovered.packed, value.pack());
         assert_eq(recovered.hash, poseidon2_hash(value.pack()));
+    }
+
+    // Test reading an uninitialized value
+    #[test]
+    unconstrained fn test_reading_uninitialized_value() {
+        let mut env = TestEnvironment::new();
+
+        let block_header = env.private_at(6).historical_header;
+        let address = env.contract_address();
+
+        let result = WithHash::<MockStruct, 2>::historical_public_storage_read(
+            block_header,
+            address,
+            storage_slot,
+        );
+
+        let expected: MockStruct = mem::zeroed();
+        assert_eq(result, expected);
+    }
+
+    // Test getting a bad hint for an uninitialized value
+    #[test(should_fail_with = "Non-zero hint for zero hash")]
+    unconstrained fn test_bad_hint_uninitialized_value() {
+        let mut env = TestEnvironment::new();
+
+        env.advance_block_to(6);
+
+        let value_packed = MockStruct { a: 1, b: 1 }.pack();
+
+        let block_header = env.private().historical_header;
+        let address = env.contract_address();
+
+        // Mock the oracle to return a non-zero hint/packed value
+        let _ = OracleMock::mock("storageRead")
+            .with_params((
+                address.to_field(), storage_slot, block_header.global_variables.block_number as u32,
+                value_packed.len(),
+            ))
+            .returns(value_packed)
+            .times(1);
+
+        let _ = WithHash::<MockStruct, 2>::historical_public_storage_read(
+            block_header,
+            address,
+            storage_slot,
+        );
+    }
+
+    // Test getting a bad hint for an initialized value
+    #[test(should_fail_with = "Non-zero hint for zero hash")]
+    unconstrained fn test_bad_hint_initialized_value() {
+        let mut env = TestEnvironment::new();
+
+        env.advance_block_to(6);
+
+        let value_packed = MockStruct { a: 5, b: 3 }.pack();
+
+        let block_header = env.private().historical_header;
+        let address = env.contract_address();
+
+        // Mock the oracle to return a non-zero hint/packed value
+        let _ = OracleMock::mock("storageRead")
+            .with_params((
+                address.to_field(), storage_slot, block_header.global_variables.block_number as u32,
+                value_packed.len(),
+            ))
+            .returns(value_packed)
+            .times(1);
+
+        // Now we mock the oracle to return an incorrect hash
+        let hash_len = 1;
+        let random_hash = random();
+        let _ = OracleMock::mock("storageRead")
+            .with_params((
+                address.to_field(), storage_slot + 2,
+                block_header.global_variables.block_number as u32, hash_len,
+            ))
+            .returns(random_hash)
+            .times(1);
+
+        let _ = WithHash::<MockStruct, 2>::historical_public_storage_read(
+            block_header,
+            address,
+            storage_slot,
+        );
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -140,7 +140,7 @@ mod test {
     unconstrained fn read_uninitialized_value() {
         let mut env = TestEnvironment::new();
 
-        let block_header = env.private_at(6).historical_header;
+        let block_header = env.private().historical_header;
         let address = env.contract_address();
 
         let result = WithHash::<MockStruct, 2>::historical_public_storage_read(

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -143,7 +143,7 @@ mod test {
         let block_header = env.private().historical_header;
         let address = env.contract_address();
 
-        let result = WithHash::<MockStruct, 2>::historical_public_storage_read(
+        let result = WithHash::<MockStruct, _>::historical_public_storage_read(
             block_header,
             address,
             storage_slot,
@@ -171,7 +171,7 @@ mod test {
         // We advance block by 1 because env.private() currently returns context at latest_block - 1
         env.advance_block_by(1);
 
-        let result = WithHash::<MockStruct, 2>::historical_public_storage_read(
+        let result = WithHash::<MockStruct, _>::historical_public_storage_read(
             env.private().historical_header,
             env.contract_address(),
             storage_slot,
@@ -201,7 +201,7 @@ mod test {
             .times(1);
 
         // This should revert because the hint value is non-zero and the hash is zero (default value of storage)
-        let _ = WithHash::<MockStruct, 2>::historical_public_storage_read(
+        let _ = WithHash::<MockStruct, _>::historical_public_storage_read(
             block_header,
             address,
             storage_slot,
@@ -229,7 +229,7 @@ mod test {
         // We advance block by 1 because env.private() currently returns context at latest_block - 1
         env.advance_block_by(1);
 
-        let _ = WithHash::<MockStruct, 2>::historical_public_storage_read(
+        let _ = WithHash::<MockStruct, _>::historical_public_storage_read(
             env.private().historical_header,
             env.contract_address(),
             storage_slot,

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -136,9 +136,8 @@ mod test {
         assert_eq(recovered.hash, poseidon2_hash(value.pack()));
     }
 
-    // Test reading an uninitialized value
     #[test]
-    unconstrained fn test_reading_uninitialized_value() {
+    unconstrained fn read_uninitialized_value() {
         let mut env = TestEnvironment::new();
 
         let block_header = env.private_at(6).historical_header;

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -114,7 +114,10 @@ where
 mod test {
     use crate::{
         oracle::random::random,
-        test::{helpers::test_environment::TestEnvironment, mocks::mock_struct::MockStruct},
+        test::{
+            helpers::{cheatcodes, test_environment::TestEnvironment},
+            mocks::mock_struct::MockStruct,
+        },
         utils::with_hash::WithHash,
     };
     use dep::protocol_types::hash::poseidon2_hash;
@@ -147,6 +150,7 @@ mod test {
             storage_slot,
         );
 
+        // We should get zeroed value
         let expected: MockStruct = mem::zeroed();
         assert_eq(result, expected);
     }
@@ -155,36 +159,22 @@ mod test {
     unconstrained fn test_reading_initialized_value() {
         let mut env = TestEnvironment::new();
 
-        env.advance_block_to(6);
-
         let value = MockStruct { a: 5, b: 3 };
-        let value_packed = value.pack();
+        let value_with_hash = WithHash::new(value);
 
-        let block_header = env.private().historical_header;
-        let address = env.contract_address();
+        // We write the value with hash to storage
+        cheatcodes::direct_storage_write(
+            env.contract_address(),
+            storage_slot,
+            value_with_hash.pack(),
+        );
 
-        // Mock the oracle to return a non-zero hint/packed value
-        let _ = OracleMock::mock("storageRead")
-            .with_params((
-                address.to_field(), storage_slot, block_header.global_variables.block_number as u32,
-                value_packed.len(),
-            ))
-            .returns(value_packed)
-            .times(1);
-
-        // Now we mock the oracle to return an incorrect hash
-        let hash_len = 1;
-        let _ = OracleMock::mock("storageRead")
-            .with_params((
-                address.to_field(), storage_slot + (value_packed.len() as Field),
-                block_header.global_variables.block_number as u32, hash_len,
-            ))
-            .returns(poseidon2_hash(value_packed))
-            .times(1);
+        // We advance block by 1 because env.private() currently returns context at latest_block - 1
+        env.advance_block_by(1);
 
         let result = WithHash::<MockStruct, 2>::historical_public_storage_read(
-            block_header,
-            address,
+            env.private().historical_header,
+            env.contract_address(),
             storage_slot,
         );
 
@@ -211,6 +201,7 @@ mod test {
             .returns(value_packed)
             .times(1);
 
+        // This should revert because the hint value is non-zero and the hash is zero (default value of storage)
         let _ = WithHash::<MockStruct, 2>::historical_public_storage_read(
             block_header,
             address,
@@ -222,36 +213,26 @@ mod test {
     unconstrained fn test_bad_hint_initialized_value() {
         let mut env = TestEnvironment::new();
 
-        env.advance_block_to(6);
-
         let value_packed = MockStruct { a: 5, b: 3 }.pack();
 
-        let block_header = env.private().historical_header;
-        let address = env.contract_address();
+        // We write the value to storage
+        cheatcodes::direct_storage_write(env.contract_address(), storage_slot, value_packed);
 
-        // Mock the oracle to return a non-zero hint/packed value
-        let _ = OracleMock::mock("storageRead")
-            .with_params((
-                address.to_field(), storage_slot, block_header.global_variables.block_number as u32,
-                value_packed.len(),
-            ))
-            .returns(value_packed)
-            .times(1);
+        // Now we write incorrect hash to the hash storage slot
+        let incorrect_hash = random();
+        let hash_storage_slot = storage_slot + (value_packed.len() as Field);
+        cheatcodes::direct_storage_write(
+            env.contract_address(),
+            hash_storage_slot,
+            [incorrect_hash],
+        );
 
-        // Now we mock the oracle to return an incorrect hash
-        let hash_len = 1;
-        let random_hash = random();
-        let _ = OracleMock::mock("storageRead")
-            .with_params((
-                address.to_field(), storage_slot + (value_packed.len() as Field),
-                block_header.global_variables.block_number as u32, hash_len,
-            ))
-            .returns(random_hash)
-            .times(1);
+        // We advance block by 1 because env.private() currently returns context at latest_block - 1
+        env.advance_block_by(1);
 
-        let _ = WithHash::<MockStruct, 2>::historical_public_storage_read(
-            block_header,
-            address,
+        let result = WithHash::<MockStruct, 2>::historical_public_storage_read(
+            env.private().historical_header,
+            env.contract_address(),
             storage_slot,
         );
     }

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -7,10 +7,11 @@ use dep::protocol_types::{
     address::AztecAddress, block_header::BlockHeader, hash::poseidon2_hash, traits::Packable,
 };
 
-/// A struct that allows for efficient reading of value T from public storage in private. This is
-/// achieved by storing the value with its hash, then obtaining the values via an oracle and
-/// verifying them against the hash. This results in in a fewer tree inclusion proofs for values T
-/// that are packed into more than a single field.
+/// A struct that allows for efficient reading of value T from public storage in private.
+///
+/// The efficient reads are achieved by verifying large values through a single hash check
+/// and then proving inclusion only of the hash in public storage. This reduces the number
+/// of required tree inclusion proofs from O(M) to O(1)
 ///
 /// # Type Parameters
 /// - `T`: The underlying type being wrapped, must implement `Packable<N>`

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -66,7 +66,7 @@ where
             assert_eq(hash, hint.get_hash(), "Hint values do not match hash");
         } else {
             // The hash slot can only hold a zero if it is uninitialized. Therefore, the hints must then be zero
-            // as well.
+            // (i.e. the default value for public storage) as well.
             assert_eq(
                 hint.get_value(),
                 T::unpack(std::mem::zeroed()),

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -1,0 +1,121 @@
+use crate::{
+    context::{PublicContext, UnconstrainedContext},
+    history::public_storage::PublicStorageHistoricalRead,
+    oracle,
+};
+use dep::protocol_types::{
+    address::AztecAddress, block_header::BlockHeader, hash::poseidon2_hash, traits::Packable,
+};
+
+pub struct WithHash<T, let N: u32> {
+    value: T,
+    packed: [Field; N],
+    hash: Field,
+}
+
+impl<T, let N: u32> WithHash<T, N>
+where
+    T: Packable<N> + Eq,
+{
+    pub fn new(value: T) -> Self {
+        let packed = value.pack();
+        Self { value, packed, hash: poseidon2_hash(packed) }
+    }
+
+    pub fn get_value(self) -> T {
+        self.value
+    }
+
+    pub fn get_hash(self) -> Field {
+        self.hash
+    }
+
+    pub fn public_storage_read(context: PublicContext, storage_slot: Field) -> T {
+        context.storage_read(storage_slot)
+    }
+
+    pub unconstrained fn unconstrained_public_storage_read(
+        context: UnconstrainedContext,
+        storage_slot: Field,
+    ) -> T {
+        context.storage_read(storage_slot)
+    }
+
+    pub fn historical_public_storage_read(
+        header: BlockHeader,
+        address: AztecAddress,
+        storage_slot: Field,
+    ) -> T {
+        let historical_block_number = header.global_variables.block_number as u32;
+
+        // We could simply produce historical inclusion proofs for each field in `packed`, but that would require one
+        // full sibling path per storage slot (since due to kernel siloing the storage is not contiguous). Instead, we
+        // get an oracle to provide us the values, and instead we prove inclusion of their hash, which is both a much
+        // smaller proof (a single slot), and also independent of the size of T.
+        let hint = WithHash::new(
+            /// Safety: We verify that a hash of the hint/packed data matches the stored hash.
+            unsafe {
+                oracle::storage::storage_read(address, storage_slot, historical_block_number)
+            },
+        );
+
+        // Ideally the following would be simply public_storage::read_historical, but we can't implement that yet.
+        let hash = header.public_storage_historical_read(storage_slot + N as Field, address);
+
+        if hash != 0 {
+            assert_eq(hash, hint.get_hash(), "Hint values do not match hash");
+        } else {
+            // The hash slot can only hold a zero if it is uninitialized. Therefore, the hints must then be zero
+            // as well.
+            assert_eq(
+                hint.get_value(),
+                T::unpack(std::mem::zeroed()),
+                "Non-zero value change for zero hash",
+            );
+        };
+
+        hint.get_value()
+    }
+}
+
+impl<T, let N: u32> Packable<N + 1> for WithHash<T, N>
+where
+    T: Packable<N>,
+{
+    fn pack(self) -> [Field; N + 1] {
+        let mut result: [Field; N + 1] = std::mem::zeroed();
+        for i in 0..N {
+            result[i] = self.packed[i];
+        }
+        result[N] = self.hash;
+
+        result
+    }
+
+    fn unpack(packed: [Field; N + 1]) -> Self {
+        let mut value_packed: [Field; N] = std::mem::zeroed();
+        for i in 0..N {
+            value_packed[i] = packed[i];
+        }
+        let hash = packed[N];
+
+        Self { value: T::unpack(value_packed), packed: value_packed, hash }
+    }
+}
+
+mod test {
+    use crate::test::mocks::mock_struct::MockStruct;
+    use crate::utils::with_hash::WithHash;
+    use dep::protocol_types::hash::poseidon2_hash;
+
+    #[test]
+    unconstrained fn create_and_recover() {
+        let value = MockStruct { a: 5, b: 3 };
+        let value_with_hash = WithHash::new(value);
+        let recovered = WithHash::unpack(value_with_hash.pack());
+
+        assert_eq(recovered.value, value);
+        assert_eq(recovered.packed, value.pack());
+        assert_eq(recovered.hash, poseidon2_hash(value.pack()));
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -151,7 +151,46 @@ mod test {
         assert_eq(result, expected);
     }
 
-    // Test getting a bad hint for an uninitialized value
+    #[test]
+    unconstrained fn test_reading_initialized_value() {
+        let mut env = TestEnvironment::new();
+
+        env.advance_block_to(6);
+
+        let value = MockStruct { a: 5, b: 3 };
+        let value_packed = value.pack();
+
+        let block_header = env.private().historical_header;
+        let address = env.contract_address();
+
+        // Mock the oracle to return a non-zero hint/packed value
+        let _ = OracleMock::mock("storageRead")
+            .with_params((
+                address.to_field(), storage_slot, block_header.global_variables.block_number as u32,
+                value_packed.len(),
+            ))
+            .returns(value_packed)
+            .times(1);
+
+        // Now we mock the oracle to return an incorrect hash
+        let hash_len = 1;
+        let _ = OracleMock::mock("storageRead")
+            .with_params((
+                address.to_field(), storage_slot + (value_packed.len() as Field),
+                block_header.global_variables.block_number as u32, hash_len,
+            ))
+            .returns(poseidon2_hash(value_packed))
+            .times(1);
+
+        let result = WithHash::<MockStruct, 2>::historical_public_storage_read(
+            block_header,
+            address,
+            storage_slot,
+        );
+
+        assert_eq(result, value);
+    }
+
     #[test(should_fail_with = "Non-zero hint for zero hash")]
     unconstrained fn test_bad_hint_uninitialized_value() {
         let mut env = TestEnvironment::new();
@@ -179,8 +218,7 @@ mod test {
         );
     }
 
-    // Test getting a bad hint for an initialized value
-    #[test(should_fail_with = "Non-zero hint for zero hash")]
+    #[test(should_fail_with = "Hint values do not match hash")]
     unconstrained fn test_bad_hint_initialized_value() {
         let mut env = TestEnvironment::new();
 
@@ -205,7 +243,7 @@ mod test {
         let random_hash = random();
         let _ = OracleMock::mock("storageRead")
             .with_params((
-                address.to_field(), storage_slot + 2,
+                address.to_field(), storage_slot + (value_packed.len() as Field),
                 block_header.global_variables.block_number as u32, hash_len,
             ))
             .returns(random_hash)

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -59,7 +59,6 @@ where
             },
         );
 
-        // Ideally the following would be simply public_storage::read_historical, but we can't implement that yet.
         let hash = header.public_storage_historical_read(storage_slot + N as Field, address);
 
         if hash != 0 {

--- a/noir-projects/aztec-nr/compressed-string/src/field_compressed_string.nr
+++ b/noir-projects/aztec-nr/compressed-string/src/field_compressed_string.nr
@@ -6,7 +6,7 @@ use std::meta::derive;
 
 // A Fixedsize Compressed String.
 // Essentially a special version of Compressed String for practical use.
-#[derive(Deserialize, Packable, Serialize)]
+#[derive(Deserialize, Eq, Packable, Serialize)]
 pub struct FieldCompressedString {
     value: Field,
 }

--- a/noir-projects/noir-contracts/contracts/amm_contract/src/config.nr
+++ b/noir-projects/noir-contracts/contracts/amm_contract/src/config.nr
@@ -4,7 +4,7 @@ use std::meta::derive;
 /// We store the tokens of the pool in a struct such that to load it from SharedImmutable asserts only a single
 /// merkle proof.
 /// (Once we actually do the optimization. WIP in https://github.com/AztecProtocol/aztec-packages/pull/8022).
-#[derive(Deserialize, Packable, Serialize)]
+#[derive(Deserialize, Eq, Packable, Serialize)]
 pub struct Config {
     pub token0: AztecAddress,
     pub token1: AztecAddress,

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -18,6 +18,7 @@ pub contract AppSubscription {
     use router::utils::privately_check_block_number;
     use token::Token;
 
+    // TODO: This can be optimized by storing the values in Config struct in 1 PublicImmutable (less merkle proofs).
     #[storage]
     struct Storage<Context> {
         target_address: PublicImmutable<AztecAddress, Context>,

--- a/noir-projects/noir-contracts/contracts/claim_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/claim_contract/src/main.nr
@@ -11,6 +11,7 @@ pub contract Claim {
     use dep::uint_note::uint_note::UintNote;
     use token::Token;
 
+    // TODO: This can be optimized by storing the addresses in Config struct in 1 PublicImmutable (less merkle proofs).
     #[storage]
     struct Storage<Context> {
         // Address of a contract based on whose notes we distribute the rewards

--- a/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
@@ -31,6 +31,7 @@ pub contract Crowdfunding {
         amount: U128,
     }
 
+    // TODO: This can be optimized by storing the values in Config struct in 1 PublicImmutable (less merkle proofs).
     // docs:start:storage
     #[storage]
     struct Storage<Context> {

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/types/leader.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/types/leader.nr
@@ -2,7 +2,7 @@ use dep::aztec::protocol_types::{address::AztecAddress, traits::{Deserialize, Pa
 use std::meta::derive;
 
 // Shows how to create a custom struct in Public
-#[derive(Deserialize, Packable, Serialize)]
+#[derive(Deserialize, Eq, Packable, Serialize)]
 pub struct Leader {
     account: AztecAddress,
     points: u8,

--- a/noir-projects/noir-contracts/contracts/fpc_contract/src/config.nr
+++ b/noir-projects/noir-contracts/contracts/fpc_contract/src/config.nr
@@ -1,7 +1,7 @@
 use dep::aztec::protocol_types::{address::AztecAddress, traits::{Deserialize, Packable, Serialize}};
 use std::meta::derive;
 
-#[derive(Deserialize, Packable, Serialize)]
+#[derive(Deserialize, Eq, Packable, Serialize)]
 pub struct Config {
     pub accepted_asset: AztecAddress, // Asset the FPC accepts (denoted as AA below)
     pub admin: AztecAddress, // Address to which AA is sent during the private fee payment flow

--- a/noir-projects/noir-contracts/contracts/fpc_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/fpc_contract/src/main.nr
@@ -76,7 +76,6 @@ pub contract FPC {
     // docs:start:fee_entrypoint_private
     #[private]
     fn fee_entrypoint_private(max_fee: U128, nonce: Field) {
-        // TODO(PR #8022): Once PublicImmutable performs only 1 merkle proof here, we'll save ~4k gates
         let accepted_asset = storage.config.read().accepted_asset;
 
         let user = context.msg_sender();
@@ -150,7 +149,6 @@ pub contract FPC {
     /// 4. The protocol deducts the actual fee denominated in fee juice from the FPC's balance.
     #[private]
     fn fee_entrypoint_public(max_fee: U128, nonce: Field) {
-        // TODO(PR #8022): Once PublicImmutable performs only 1 merkle proof here, we'll save ~4k gates
         let config = storage.config.read();
 
         // We pull the max fee from the user's balance of the accepted asset to this contract.
@@ -198,7 +196,6 @@ pub contract FPC {
     /// this function.
     #[public]
     fn pull_funds(to: AztecAddress) {
-        // TODO(PR #8022): Once PublicImmutable performs only 1 merkle proof here, we'll save ~4k gates
         let config = storage.config.read();
 
         assert(context.msg_sender() == config.admin, "Only admin can pull funds");

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -14,7 +14,7 @@ pub contract Test {
     };
     use dep::aztec::prelude::{
         AztecAddress, EthAddress, FunctionSelector, Map, NoteGetterOptions, NoteViewerOptions,
-        PrivateImmutable, PrivateSet,
+        PrivateImmutable, PrivateSet, PublicImmutable,
     };
 
     use dep::aztec::protocol_types::{
@@ -77,6 +77,7 @@ pub contract Test {
         example_constant: PrivateImmutable<TestNote, Context>,
         example_set: PrivateSet<TestNote, Context>,
         example_struct: PrivateImmutable<ExampleStruct, Context>,
+        example_struct_in_public_immutable: PublicImmutable<ExampleStruct, Context>,
         example_struct_in_map: Map<AztecAddress, PrivateImmutable<ExampleStruct, Context>, Context>,
         another_example_struct: PrivateImmutable<ExampleStruct, Context>,
     }

--- a/noir-projects/noir-contracts/contracts/test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/test.nr
@@ -25,6 +25,7 @@ unconstrained fn test_storage_slot_allocation() {
     //     example_constant: PrivateImmutable<TestNote, Context>,
     //     example_set: PrivateSet<TestNote, Context>,
     //     example_struct: PrivateImmutable<ExampleStruct, Context>,
+    //     example_struct_in_public_immutable: PublicImmutable<ExampleStruct, Context>,
     //     example_struct_in_map: Map<AztecAddress, PrivateImmutable<ExampleStruct, Context>, Context>,
     //     another_example_struct: PrivateImmutable<ExampleStruct, Context>,
     // }
@@ -36,22 +37,27 @@ unconstrained fn test_storage_slot_allocation() {
     // The first slot is always 1.
     let mut expected_slot = 1;
     assert_eq(Test::storage_layout().example_constant.slot, expected_slot);
-
     // Even though example_constant holds TestNote, which packs to a length larger than 1, notes always reserve a
     // single slot.
     expected_slot += 1;
-    assert_eq(Test::storage_layout().example_set.slot, expected_slot);
 
+    assert_eq(Test::storage_layout().example_set.slot, expected_slot);
     // example_set also held a note, so it should have only allocated a single slot.
     expected_slot += 1;
-    assert_eq(Test::storage_layout().example_struct.slot, expected_slot);
 
+    assert_eq(Test::storage_layout().example_struct.slot, expected_slot);
     // example_struct allocates 5 slots because it is not a note and it's packed length is 5.
     expected_slot += 5;
-    assert_eq(Test::storage_layout().example_struct_in_map.slot, expected_slot);
 
-    // example_struct_in_map should allocate a single note because it's a map, regardless of whatever it holds. The Map
+    assert_eq(Test::storage_layout().example_struct_in_public_immutable.slot, expected_slot);
+    // example_struct_in_public_immutable should allocate 6 slots because ExampleStruct occupies 5 slots
+    // and `PublicImmutable` wraps the struct in a `WithHash<T>` that adds an additional slot.
+    expected_slot += 6;
+
+    assert_eq(Test::storage_layout().example_struct_in_map.slot, expected_slot);
+    // example_struct_in_map should allocate a single slot because it's a map, regardless of whatever it holds. The Map
     // type is going to deal with its own dynamic allocation based on keys
     expected_slot += 1;
+
     assert_eq(Test::storage_layout().another_example_struct.slot, expected_slot);
 }

--- a/noir-projects/noir-contracts/contracts/token_bridge_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_bridge_contract/src/main.nr
@@ -24,6 +24,7 @@ pub contract TokenBridge {
     };
     // docs:end:token_bridge_imports
 
+    // TODO: This can be optimized by storing the values in Config struct in 1 PublicImmutable (less merkle proofs).
     // docs:start:token_bridge_storage_and_constructor
     // Storage structure, containing all storage, and specifying what slots they use.
     #[storage]

--- a/yarn-project/foundation/src/fields/fields.ts
+++ b/yarn-project/foundation/src/fields/fields.ts
@@ -261,7 +261,7 @@ export class Fr extends BaseField {
       return fromHexString(buf, Fr);
     }
 
-    throw new Error('Tried to create a Fr from an invalid string');
+    throw new Error(`Tried to create a Fr from an invalid string: ${buf}`);
   }
 
   /**
@@ -412,7 +412,7 @@ export class Fq extends BaseField {
       return fromHexString(buf, Fq);
     }
 
-    throw new Error('Tried to create a Fq from an invalid string');
+    throw new Error(`Tried to create a Fq from an invalid string: ${buf}`);
   }
 
   /**

--- a/yarn-project/types/src/abi/contract_artifact.ts
+++ b/yarn-project/types/src/abi/contract_artifact.ts
@@ -220,7 +220,7 @@ function getStorageLayout(input: NoirCompiledContract) {
     const name = field.name;
     const slot = field.value.fields[0].value as IntegerValue;
     acc[name] = {
-      slot: slot.value,
+      slot: `0x${slot.value}`,
     };
     return acc;
   }, {});


### PR DESCRIPTION
Fixes #8399

Introducing `WithHash<T>` which Nico originally implemented in https://github.com/AztecProtocol/aztec-packages/pull/11684 and using that in `PublicImmutable`.

\+ Fixes a bug with generating TS artifacts of contracts containing storage slots larger than 9 (see comments below for explanation).

Optimizes `PublicImmutable` by storing packed values along with their hash in storage, then fetching the packed values in unconstrained, fetching hash in constrained and checking the hash.

Note: It's not worthwhile to optimize the case where we store only 1 field in storage by not going with the loading-in-unconstrained flow because hashing 2 fields costs 80 gates and here we would hash just 1 extra field (to get the value hash). The gain is not worth the complexity here.

### 1 field gate diff:
TokenBridge::get_portal_address
Before: 9787
After: 9869

**diff: +82 gates**

As expected for 1 field we get a gate count rise as we do 1 more pedersen hash.

### 2 fields gate diff:
FPC::fee_entrypoint_private(...) gates
Before: 14219
After: 10464

**diff: -3755 gates**


### 3 fields gate diff:
AMM:add_liquidity
Before: 19113
After: 12039

**diff: -7074 gates**