### PR TITLE
fix: Docker.dockerignore file can be huge.

### DIFF
--- a/avm-transpiler/Dockerfile.dockerignore
+++ b/avm-transpiler/Dockerfile.dockerignore
@@ -1,0 +1,4 @@
+*
+!noir
+!avm-transpiler
+noir/noir-repo/target

--- a/avm-transpiler/Dockerfile.dockerignore
+++ b/avm-transpiler/Dockerfile.dockerignore
@@ -1,4 +1,5 @@
 *
 !noir
 !avm-transpiler
-noir/noir-repo/target
+**/target
+**/node_modules

--- a/build-system/scripts/create_dockerignore
+++ b/build-system/scripts/create_dockerignore
@@ -11,6 +11,12 @@ DOCKERFILE=$(query_manifest dockerfile $REPOSITORY)
 
 cd $BUILD_DIR
 DOCKERIGNOREFILE=$DOCKERFILE.dockerignore
+
+# If there is a dockerignore file committed to git, use it.
+if git ls-files --error-unmatch $DOCKERIGNOREFILE > /dev/null 2>&1; then
+  exit 0
+fi
+
 echo '*' > $DOCKERIGNOREFILE
 (git ls-files; git ls-files --others --exclude-standard) | sort -u | sed 's/^/!/' >> $DOCKERIGNOREFILE
 echo '**/Dockerfile*' >> $DOCKERIGNOREFILE


### PR DESCRIPTION
We run into some nutty error when dockerignore files get large (circleci path):

```
#3 [internal] load metadata for docker.io/library/ubuntu:noble
#3 sha256:afb7fa05fafd7c9e9fe1ecefd45ae0531e51b736cd519c2fb8893340e4e08b59
#3 DONE 0.4s

#10 [internal] load build context
#10 sha256:8189bdeed2ad9e316ae51d8dddc8d96a01e5180ee99f9f37015f7c3dc8de7e41
#10 ERROR: rpc error: code = Internal desc = header list size to send violates the maximum size (1048896 bytes) set by server
```

This became the case with avm-transpiler as it's build context is the root of the monorepo so it can gain access to the noir source code. The autogenerated dockerignore file has to explicitly list every file in he monorepo as a reverse match which eventually got so big something broke internally to docker.

New script will not autogen the dockerignore file if its committed to git. This PR includes a manually crafted one for avm-transpiler.