### PR TITLE
feat: Deterministic deployments for L1

### DIFF
--- a/.github/workflows/devnet-deploys.yml
+++ b/.github/workflows/devnet-deploys.yml
@@ -401,6 +401,7 @@ jobs:
             --private-key ${{ env.CONTRACT_PUBLISHER_PRIVATE_KEY }} \
             --rpc-url https://${{ env.DEPLOY_TAG }}-mainnet-fork.aztec.network:8545/${{ env.API_KEY }} \
             --l1-chain-id ${{ env.L1_CHAIN_ID }} \
+            --salt ${{ github.run_id }} \
             --json | tee ./l1_contracts.json
 
           # upload contract addresses to S3
@@ -436,7 +437,7 @@ jobs:
         working-directory: ./yarn-project/aztec/terraform/node
         run: |
           terraform init -input=false -backend-config="key=${{ env.DEPLOY_TAG }}/aztec-node"
-          terraform apply -input=false -auto-approve -replace="aws_efs_file_system.node_data_store" -var="NODE_P2P_TCP_PORT=${{ needs.set-network.outputs.node_tcp_range_start }}" -var="NODE_P2P_UDP_PORT=${{ needs.set-network.outputs.node_udp_range_start }}"
+          terraform apply -input=false -auto-approve -var="NODE_P2P_TCP_PORT=${{ needs.set-network.outputs.node_tcp_range_start }}" -var="NODE_P2P_UDP_PORT=${{ needs.set-network.outputs.node_udp_range_start }}"
 
       - name: Deploy Aztec Prover Nodes
         working-directory: ./yarn-project/aztec/terraform/prover-node
@@ -454,7 +455,7 @@ jobs:
         working-directory: ./yarn-project/aztec/terraform/pxe
         run: |
           terraform init -input=false -backend-config="key=${{ env.DEPLOY_TAG }}/pxe"
-          terraform apply -input=false -auto-approve -replace="aws_efs_file_system.pxe_data_store"
+          terraform apply -input=false -auto-approve
 
   bootstrap:
     runs-on: ubuntu-latest

--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -75,8 +75,9 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
     IRegistry _registry,
     IAvailabilityOracle _availabilityOracle,
     IERC20 _fpcJuice,
-    bytes32 _vkTreeRoot
-  ) Leonidas(msg.sender) {
+    bytes32 _vkTreeRoot,
+    address _ares
+  ) Leonidas(_ares) {
     verifier = new MockVerifier();
     REGISTRY = _registry;
     AVAILABILITY_ORACLE = _availabilityOracle;

--- a/l1-contracts/src/core/interfaces/messagebridge/IRegistry.sol
+++ b/l1-contracts/src/core/interfaces/messagebridge/IRegistry.sol
@@ -31,4 +31,6 @@ interface IRegistry {
   // docs:start:registry_number_of_versions
   function numberOfVersions() external view returns (uint256);
   // docs:end:registry_number_of_versions
+
+  function isRollupRegistered(address _rollup) external view returns (bool);
 }

--- a/l1-contracts/src/core/messagebridge/Registry.sol
+++ b/l1-contracts/src/core/messagebridge/Registry.sol
@@ -24,10 +24,10 @@ contract Registry is IRegistry, Ownable {
   mapping(uint256 version => DataStructures.RegistrySnapshot snapshot) internal snapshots;
   mapping(address rollup => uint256 version) internal rollupToVersion;
 
-  constructor() Ownable(msg.sender) {
+  constructor(address _owner) Ownable(_owner) {
     // Inserts a "dead" rollup at version 0
     // This is simply done to make first version 1, which fits better with the rest of the system
-    upgrade(address(0xdead));
+    _upgrade(address(0xdead));
   }
 
   /**
@@ -47,6 +47,16 @@ contract Registry is IRegistry, Ownable {
     (uint256 version, bool exists) = _getVersionFor(_rollup);
     if (!exists) revert Errors.Registry__RollupNotRegistered(_rollup);
     return version;
+  }
+
+  /**
+   * @notice Returns whther the rollup is registered
+   * @param _rollup - The address of the rollup contract
+   * @return Whether the rollup is registered
+   */
+  function isRollupRegistered(address _rollup) external view override(IRegistry) returns (bool) {
+    (, bool exists) = _getVersionFor(_rollup);
+    return exists;
   }
 
   /**
@@ -87,6 +97,10 @@ contract Registry is IRegistry, Ownable {
    * @return The version of the new snapshot
    */
   function upgrade(address _rollup) public override(IRegistry) onlyOwner returns (uint256) {
+    return _upgrade(_rollup);
+  }
+
+  function _upgrade(address _rollup) internal returns (uint256) {
     (, bool exists) = _getVersionFor(_rollup);
     if (exists) revert Errors.Registry__RollupAlreadyRegistered(_rollup);
 

--- a/l1-contracts/test/Registry.t.sol
+++ b/l1-contracts/test/Registry.t.sol
@@ -15,7 +15,7 @@ contract RegistryTest is Test {
   Registry internal registry;
 
   function setUp() public {
-    registry = new Registry();
+    registry = new Registry(address(this));
   }
 
   function testConstructorSetup() public {

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -51,10 +51,12 @@ contract RollupTest is DecoderBase {
       vm.warp(initialTime);
     }
 
-    registry = new Registry();
+    registry = new Registry(address(this));
     availabilityOracle = new AvailabilityOracle();
     portalERC20 = new PortalERC20();
-    rollup = new Rollup(registry, availabilityOracle, IERC20(address(portalERC20)), bytes32(0));
+    rollup = new Rollup(
+      registry, availabilityOracle, IERC20(address(portalERC20)), bytes32(0), address(this)
+    );
     inbox = Inbox(address(rollup.INBOX()));
     outbox = Outbox(address(rollup.OUTBOX()));
 

--- a/l1-contracts/test/portals/TokenPortal.t.sol
+++ b/l1-contracts/test/portals/TokenPortal.t.sol
@@ -59,10 +59,11 @@ contract TokenPortalTest is Test {
   uint256 internal l2BlockNumber = 69;
 
   function setUp() public {
-    registry = new Registry();
+    registry = new Registry(address(this));
     portalERC20 = new PortalERC20();
-    rollup =
-      new Rollup(registry, new AvailabilityOracle(), IERC20(address(portalERC20)), bytes32(0));
+    rollup = new Rollup(
+      registry, new AvailabilityOracle(), IERC20(address(portalERC20)), bytes32(0), address(this)
+    );
     inbox = rollup.INBOX();
     outbox = rollup.OUTBOX();
 

--- a/l1-contracts/test/portals/UniswapPortal.t.sol
+++ b/l1-contracts/test/portals/UniswapPortal.t.sol
@@ -54,10 +54,11 @@ contract UniswapPortalTest is Test {
     uint256 forkId = vm.createFork(vm.rpcUrl("mainnet_fork"));
     vm.selectFork(forkId);
 
-    registry = new Registry();
+    registry = new Registry(address(this));
     PortalERC20 portalERC20 = new PortalERC20();
-    rollup =
-      new Rollup(registry, new AvailabilityOracle(), IERC20(address(portalERC20)), bytes32(0));
+    rollup = new Rollup(
+      registry, new AvailabilityOracle(), IERC20(address(portalERC20)), bytes32(0), address(this)
+    );
     registry.upgrade(address(rollup));
     portalERC20.mint(address(rollup), 1000000);
 

--- a/l1-contracts/test/sparta/DevNet.t.sol
+++ b/l1-contracts/test/sparta/DevNet.t.sol
@@ -57,10 +57,12 @@ contract DevNetTest is DecoderBase {
       vm.warp(initialTime);
     }
 
-    registry = new Registry();
+    registry = new Registry(address(this));
     availabilityOracle = new AvailabilityOracle();
     portalERC20 = new PortalERC20();
-    rollup = new Rollup(registry, availabilityOracle, IERC20(address(portalERC20)), bytes32(0));
+    rollup = new Rollup(
+      registry, availabilityOracle, IERC20(address(portalERC20)), bytes32(0), address(this)
+    );
     inbox = Inbox(address(rollup.INBOX()));
     outbox = Outbox(address(rollup.OUTBOX()));
 

--- a/l1-contracts/test/sparta/Sparta.t.sol
+++ b/l1-contracts/test/sparta/Sparta.t.sol
@@ -60,10 +60,12 @@ contract SpartaTest is DecoderBase {
       vm.warp(initialTime);
     }
 
-    registry = new Registry();
+    registry = new Registry(address(this));
     availabilityOracle = new AvailabilityOracle();
     portalERC20 = new PortalERC20();
-    rollup = new Rollup(registry, availabilityOracle, IERC20(address(portalERC20)), bytes32(0));
+    rollup = new Rollup(
+      registry, availabilityOracle, IERC20(address(portalERC20)), bytes32(0), address(this)
+    );
     inbox = Inbox(address(rollup.INBOX()));
     outbox = Outbox(address(rollup.OUTBOX()));
 

--- a/yarn-project/aztec/src/cli/cli.ts
+++ b/yarn-project/aztec/src/cli/cli.ts
@@ -99,6 +99,7 @@ export function injectAztecCommands(program: Command, userLog: LogFn, debugLogge
         process.exit(1);
       }
     }
+
     installSignalHandlers(debugLogger.info, signalHandlers);
 
     if (services.length) {

--- a/yarn-project/aztec/src/cli/cmds/start_archiver.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_archiver.ts
@@ -7,8 +7,7 @@ import {
 } from '@aztec/archiver';
 import { createDebugLogger } from '@aztec/aztec.js';
 import { type ServerList } from '@aztec/foundation/json-rpc/server';
-import { AztecLmdbStore } from '@aztec/kv-store/lmdb';
-import { initStoreForRollup } from '@aztec/kv-store/utils';
+import { createStore } from '@aztec/kv-store/utils';
 import {
   createAndStartTelemetryClient,
   getConfigEnvVars as getTelemetryClientConfig,
@@ -22,11 +21,8 @@ export const startArchiver = async (options: any, signalHandlers: (() => Promise
   const archiverConfig = extractRelevantOptions<ArchiverConfig>(options, archiverConfigMappings);
 
   const storeLog = createDebugLogger('aztec:archiver:lmdb');
-  const store = await initStoreForRollup(
-    AztecLmdbStore.open(archiverConfig.dataDirectory, false),
-    archiverConfig.l1Contracts.rollupAddress,
-    storeLog,
-  );
+  const rollupAddress = archiverConfig.l1Contracts.rollupAddress;
+  const store = await createStore(archiverConfig, rollupAddress, storeLog);
   const archiverStore = new KVArchiverDataStore(store, archiverConfig.maxLogs);
 
   const telemetry = createAndStartTelemetryClient(getTelemetryClientConfig());

--- a/yarn-project/aztec/src/sandbox.ts
+++ b/yarn-project/aztec/src/sandbox.ts
@@ -132,6 +132,7 @@ export async function deployContractsToL1(
       l2FeeJuiceAddress: FeeJuiceAddress,
       vkTreeRoot: getVKTreeRoot(),
       assumeProvenUntil: opts.assumeProvenUntilBlockNumber,
+      salt: undefined,
     }),
   );
 

--- a/yarn-project/aztec/terraform/node/main.tf
+++ b/yarn-project/aztec/terraform/node/main.tf
@@ -149,18 +149,6 @@ resource "aws_ecs_task_definition" "aztec-node" {
 
   container_definitions = jsonencode([
     {
-      name      = "init-container"
-      image     = "amazonlinux:latest"
-      essential = false
-      command   = ["sh", "-c", "mkdir -p ${local.data_dir}/node_${count.index + 1}/data ${local.data_dir}/node_${count.index + 1}/temp"]
-      mountPoints = [
-        {
-          containerPath = local.data_dir
-          sourceVolume  = "efs-data-store"
-        }
-      ]
-    },
-    {
       name              = "${var.DEPLOY_TAG}-aztec-node-${count.index + 1}"
       image             = "${var.DOCKERHUB_ACCOUNT}/aztec:${var.IMAGE_TAG}"
       command           = ["start", "--node", "--archiver", "--sequencer"]
@@ -376,10 +364,6 @@ resource "aws_ecs_task_definition" "aztec-node" {
         }
       ]
       dependsOn = [
-        {
-          containerName = "init-container"
-          condition     = "COMPLETE"
-        }
       ]
       logConfiguration = {
         logDriver = "awslogs"

--- a/yarn-project/aztec/terraform/prover-node/main.tf
+++ b/yarn-project/aztec/terraform/prover-node/main.tf
@@ -149,18 +149,6 @@ resource "aws_ecs_task_definition" "aztec-prover-node" {
 
   container_definitions = jsonencode([
     {
-      name      = "init-container"
-      image     = "amazonlinux:latest"
-      essential = false
-      command   = ["sh", "-c", "mkdir -p ${local.data_dir}/prover_node_${count.index + 1}/data ${local.data_dir}/prover_node_${count.index + 1}/temp"]
-      mountPoints = [
-        {
-          containerPath = local.data_dir
-          sourceVolume  = "efs-data-store"
-        }
-      ]
-    },
-    {
       name              = "${var.DEPLOY_TAG}-aztec-prover-node-${count.index + 1}"
       image             = "${var.DOCKERHUB_ACCOUNT}/aztec:${var.IMAGE_TAG}"
       command           = ["start", "--prover-node", "--archiver"]
@@ -246,10 +234,6 @@ resource "aws_ecs_task_definition" "aztec-prover-node" {
         }
       ]
       dependsOn = [
-        {
-          containerName = "init-container"
-          condition     = "COMPLETE"
-        }
       ]
       logConfiguration = {
         logDriver = "awslogs"

--- a/yarn-project/bb-prover/src/prover/bb_private_kernel_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_private_kernel_prover.ts
@@ -22,7 +22,7 @@ import {
 } from '@aztec/circuits.js';
 import { siloNoteHash } from '@aztec/circuits.js/hash';
 import { runInDirectory } from '@aztec/foundation/fs';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import {
   ClientCircuitArtifacts,
@@ -57,6 +57,7 @@ import {
   executeBbClientIvcProof,
   verifyProof,
 } from '../bb/execute.js';
+import { type BBConfig } from '../config.js';
 import { mapProtocolArtifactNameToCircuitName } from '../stats.js';
 import { extractVkData } from '../verification_key/verification_key_data.js';
 
@@ -73,12 +74,17 @@ export class BBNativePrivateKernelProver implements PrivateKernelProver {
     Promise<VerificationKeyData>
   >();
 
-  constructor(
+  private constructor(
     private bbBinaryPath: string,
     private bbWorkingDirectory: string,
     private skipCleanup: boolean,
     private log = createDebugLogger('aztec:bb-native-prover'),
   ) {}
+
+  public static async new(config: BBConfig, log?: DebugLogger) {
+    await fs.mkdir(config.bbWorkingDirectory, { recursive: true });
+    return new BBNativePrivateKernelProver(config.bbBinaryPath, config.bbWorkingDirectory, !!config.bbSkipCleanup, log);
+  }
 
   private async _createClientIvcProof(
     directory: string,

--- a/yarn-project/bb-prover/src/verifier/bb_verifier.ts
+++ b/yarn-project/bb-prover/src/verifier/bb_verifier.ts
@@ -37,6 +37,7 @@ export class BBCircuitVerifier implements ClientProtocolCircuitVerifier {
     initialCircuits: ProtocolArtifact[] = [],
     logger = createDebugLogger('aztec:bb-verifier'),
   ) {
+    await fs.mkdir(config.bbWorkingDirectory, { recursive: true });
     const keys = new Map<ProtocolArtifact, Promise<VerificationKeyData>>();
     for (const circuit of initialCircuits) {
       const vkData = await this.generateVerificationKey(

--- a/yarn-project/cli/src/cmds/devnet/bootstrap_network.ts
+++ b/yarn-project/cli/src/cmds/devnet/bootstrap_network.ts
@@ -112,20 +112,8 @@ async function deployERC20({ walletClient, publicClient }: L1Clients) {
     contractBytecode: TokenPortalBytecode,
   };
 
-  const erc20Address = await deployL1Contract(
-    walletClient,
-    publicClient,
-    erc20.contractAbi,
-    erc20.contractBytecode,
-    [],
-  );
-  const portalAddress = await deployL1Contract(
-    walletClient,
-    publicClient,
-    portal.contractAbi,
-    portal.contractBytecode,
-    [],
-  );
+  const erc20Address = await deployL1Contract(walletClient, publicClient, erc20.contractAbi, erc20.contractBytecode);
+  const portalAddress = await deployL1Contract(walletClient, publicClient, portal.contractAbi, portal.contractBytecode);
 
   return {
     erc20Address,

--- a/yarn-project/cli/src/cmds/l1/deploy_l1_contracts.ts
+++ b/yarn-project/cli/src/cmds/l1/deploy_l1_contracts.ts
@@ -7,11 +7,12 @@ export async function deployL1Contracts(
   chainId: number,
   privateKey: string | undefined,
   mnemonic: string,
+  salt: number | undefined,
   json: boolean,
   log: LogFn,
   debugLogger: DebugLogger,
 ) {
-  const { l1ContractAddresses } = await deployAztecContracts(rpcUrl, chainId, privateKey, mnemonic, debugLogger);
+  const { l1ContractAddresses } = await deployAztecContracts(rpcUrl, chainId, privateKey, mnemonic, salt, debugLogger);
 
   if (json) {
     log(

--- a/yarn-project/cli/src/cmds/l1/index.ts
+++ b/yarn-project/cli/src/cmds/l1/index.ts
@@ -30,6 +30,7 @@ export function injectCommands(program: Command, log: LogFn, debugLogger: DebugL
       'test test test test test test test test test test test junk',
     )
     .addOption(l1ChainIdOption)
+    .option('--salt <number>', 'The optional salt to use in deployment', arg => parseInt(arg))
     .option('--json', 'Output the contract addresses in JSON format')
     .action(async options => {
       const { deployL1Contracts } = await import('./deploy_l1_contracts.js');
@@ -38,6 +39,7 @@ export function injectCommands(program: Command, log: LogFn, debugLogger: DebugL
         options.l1ChainId,
         options.privateKey,
         options.mnemonic,
+        options.salt,
         options.json,
         log,
         debugLogger,

--- a/yarn-project/cli/src/utils/aztec.ts
+++ b/yarn-project/cli/src/utils/aztec.ts
@@ -45,6 +45,7 @@ export async function deployAztecContracts(
   chainId: number,
   privateKey: string | undefined,
   mnemonic: string,
+  salt: number | undefined,
   debugLogger: DebugLogger,
 ): Promise<DeployL1Contracts> {
   const {
@@ -105,6 +106,7 @@ export async function deployAztecContracts(
   return await deployL1Contracts(chain.rpcUrl, account, chain.chainInfo, debugLogger, l1Artifacts, {
     l2FeeJuiceAddress: FeeJuiceAddress,
     vkTreeRoot: getVKTreeRoot(),
+    salt,
   });
 }
 

--- a/yarn-project/end-to-end/src/fixtures/setup_l1_contracts.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup_l1_contracts.ts
@@ -62,6 +62,7 @@ export const setupL1Contracts = async (
   const l1Data = await deployL1Contracts(l1RpcUrl, account, foundry, logger, l1Artifacts, {
     l2FeeJuiceAddress: FeeJuiceAddress,
     vkTreeRoot: getVKTreeRoot(),
+    salt: undefined,
   });
 
   return l1Data;

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -140,6 +140,7 @@ export const setupL1Contracts = async (
   const l1Data = await deployL1Contracts(l1RpcUrl, account, foundry, logger, l1Artifacts, {
     l2FeeJuiceAddress: FeeJuiceAddress,
     vkTreeRoot: getVKTreeRoot(),
+    salt: undefined,
   });
 
   return l1Data;

--- a/yarn-project/kv-store/src/lmdb/store.ts
+++ b/yarn-project/kv-store/src/lmdb/store.ts
@@ -1,5 +1,6 @@
 import { createDebugLogger } from '@aztec/foundation/log';
 
+import { mkdirSync } from 'fs';
 import { mkdtemp } from 'fs/promises';
 import { type Database, type Key, type RootDatabase, open } from 'lmdb';
 import { tmpdir } from 'os';
@@ -60,7 +61,10 @@ export class AztecLmdbStore implements AztecKVStore {
     ephemeral: boolean = false,
     log = createDebugLogger('aztec:kv-store:lmdb'),
   ): AztecLmdbStore {
-    log.verbose(`Opening LMDB database at ${path || 'temporary location'}`);
+    log.debug(`Opening LMDB database at ${path || 'temporary location'}`);
+    if (path) {
+      mkdirSync(path, { recursive: true });
+    }
     const rootDb = open({ path, noSync: ephemeral });
     return new AztecLmdbStore(rootDb, ephemeral, path);
   }

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -124,6 +124,7 @@ export class ProverNode {
     }
 
     // Fast forward world state to right before the target block and get a fork
+    this.log.verbose(`Creating proving job for block ${fromBlock}`);
     const db = await this.worldState.syncImmediateAndFork(fromBlock - 1, true);
 
     // Create a processor using the forked world state

--- a/yarn-project/pxe/src/pxe_service/create_pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/create_pxe_service.ts
@@ -3,8 +3,7 @@ import { type AztecNode, type PrivateKernelProver } from '@aztec/circuit-types';
 import { randomBytes } from '@aztec/foundation/crypto';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { KeyStore } from '@aztec/key-store';
-import { AztecLmdbStore } from '@aztec/kv-store/lmdb';
-import { initStoreForRollup } from '@aztec/kv-store/utils';
+import { createStore } from '@aztec/kv-store/utils';
 import { getCanonicalAuthRegistry } from '@aztec/protocol-contracts/auth-registry';
 import { getCanonicalClassRegisterer } from '@aztec/protocol-contracts/class-registerer';
 import { getCanonicalFeeJuice } from '@aztec/protocol-contracts/fee-juice';
@@ -43,25 +42,10 @@ export async function createPXEService(
   const keyStorePath = config.dataDirectory ? join(config.dataDirectory, 'pxe_key_store') : undefined;
   const l1Contracts = await aztecNode.getL1ContractAddresses();
 
-  const keyStore = new KeyStore(await initStoreForRollup(AztecLmdbStore.open(keyStorePath), l1Contracts.rollupAddress));
-  const db = new KVPxeDatabase(await initStoreForRollup(AztecLmdbStore.open(pxeDbPath), l1Contracts.rollupAddress));
+  const keyStore = new KeyStore(await createStore(keyStorePath, l1Contracts.rollupAddress));
+  const db = new KVPxeDatabase(await createStore(pxeDbPath, l1Contracts.rollupAddress));
 
-  // (@PhilWindle) Temporary validation until WASM is implemented
-  let prover: PrivateKernelProver | undefined = proofCreator;
-  if (!prover) {
-    if (config.proverEnabled && (!config.bbBinaryPath || !config.bbWorkingDirectory)) {
-      throw new Error(`Prover must be configured with binary path and working directory`);
-    }
-    prover = !config.proverEnabled
-      ? new TestPrivateKernelProver()
-      : new BBNativePrivateKernelProver(
-          config.bbBinaryPath!,
-          config.bbWorkingDirectory!,
-          !!config.bbSkipCleanup,
-          createDebugLogger('aztec:pxe:bb-native-prover' + (logSuffix ? `:${logSuffix}` : '')),
-        );
-  }
-
+  const prover = proofCreator ?? (await createProver(config, logSuffix));
   const server = new PXEService(keyStore, aztecNode, db, prover, config, logSuffix);
   for (const contract of [
     getCanonicalClassRegisterer(),
@@ -76,4 +60,18 @@ export async function createPXEService(
 
   await server.start();
   return server;
+}
+
+function createProver(config: PXEServiceConfig, logSuffix?: string) {
+  if (!config.proverEnabled) {
+    return new TestPrivateKernelProver();
+  }
+
+  // (@PhilWindle) Temporary validation until WASM is implemented
+  if (!config.bbBinaryPath || !config.bbWorkingDirectory) {
+    throw new Error(`Prover must be configured with binary path and working directory`);
+  }
+  const bbConfig = config as Required<Pick<PXEServiceConfig, 'bbBinaryPath' | 'bbWorkingDirectory'>> & PXEServiceConfig;
+  const log = createDebugLogger('aztec:pxe:bb-native-prover' + (logSuffix ? `:${logSuffix}` : ''));
+  return BBNativePrivateKernelProver.new(bbConfig, log);
 }


### PR DESCRIPTION
This PR does multiple things. In retrospective, should've broken it into multiple ones, but here we are.

## L1 contracts

This PR updates L1 contracts that depended on `msg.sender` during deployment to instead accept the owner as an argument. 

This allows us to use the [deterministic deployment proxy](https://github.com/Arachnid/deterministic-deployment-proxy) (already deployed to mainnet and to anvil by default) for deploying our contracts using a salt (otherwise the factory contract would be appointed as owner), so we can get different deployment addresses based on the salt we use.

With the current setup we'd always get the same deployment addresses on a fresh anvil instance, since contract addresses on ethereum are derived from the sender address and an incremental nonce, and we are consistently using the same deployer address.

## Creating data stores

Refactors calls to creating new stores to ensure they always go through `initStoreForRollup`, which means that the lmdb store is cleared if we detect that it was created for a different rollup address contract (we should be using an Aztec Chain ID, though maybe we should make the rollup contract address **be** the chain id? anyway, that's another discussion).

This, combined with a rollup contract address that can be different on each deployment, means that our components should automatically clean their db if connected to a different L1 rollup.

## Creating dirs

Adds mkdir (recursive) calls wherever they were missing, so we no longer need to manually create data or working dirs in an init container in our ECS tasks.

## Deployments

Removes the forced EFS replacement for each task, so they can reuse the same filesystem, which should greatly improve deployment times (from 2 min to 10 seconds). Given the above tasks, we can now rely on the changing rollup contract address for our components to init a new db as needed.

To ensure we get a fresh rollup address on each deployment, we bind the deployment salt to the github run id, which should be unique.