### PR TITLE
feat: key validation request key type runtime check

### DIFF
--- a/yarn-project/key-store/src/key_store.ts
+++ b/yarn-project/key-store/src/key_store.ts
@@ -267,9 +267,20 @@ export class KeyStore {
    * @throws If the provided public key is not associated with any of the registered accounts.
    * @param pkM - The master public key to get secret key for.
    * @returns A Promise that resolves to sk_m.
-   * @dev Used when feeding the sk_m to the kernel circuit for keys verification.
    */
   public getMasterSecretKey(pkM: PublicKey): Promise<GrumpkinScalar> {
+    return this.getMasterSecretKeyAndPrefix(pkM).then(([skM]) => skM);
+  }
+
+  /**
+   * Retrieves the sk_m corresponding to the pk_m and the key prefix.
+   * @throws If the provided public key is not associated with any of the registered accounts.
+   * @param pkM - The master public key to get secret key for.
+   * @returns A Promise that resolves to sk_m and the key prefix.
+   * @dev Used when feeding the sk_m to the kernel circuit for keys verification. We are returning the key prefix here
+   * to be able to check what keys were returned.
+   */
+  public getMasterSecretKeyAndPrefix(pkM: PublicKey): Promise<[GrumpkinScalar, KeyPrefix]> {
     const [keyPrefix, account] = this.#getKeyPrefixAndAccount(pkM);
 
     // We get the secret keys buffer and iterate over the values in the buffer to find the one that matches pkM
@@ -298,7 +309,7 @@ export class KeyStore {
       }
     }
 
-    return Promise.resolve(skM);
+    return Promise.resolve([skM, keyPrefix]);
   }
 
   /**

--- a/yarn-project/pxe/src/kernel_oracle/index.ts
+++ b/yarn-project/pxe/src/kernel_oracle/index.ts
@@ -4,9 +4,10 @@ import {
   type Fr,
   type FunctionSelector,
   type GrumpkinScalar,
+  type KeyPrefix,
   MembershipWitness,
   type NOTE_HASH_TREE_HEIGHT,
-  type Point,
+  type PublicKey,
   VK_TREE_HEIGHT,
   type VerificationKeyAsFields,
   computeContractClassIdPreimage,
@@ -73,8 +74,8 @@ export class KernelOracle implements ProvingDataOracle {
     return header.state.partial.noteHashTree.root;
   }
 
-  public getMasterSecretKey(masterPublicKey: Point): Promise<GrumpkinScalar> {
-    return this.keyStore.getMasterSecretKey(masterPublicKey);
+  public getMasterSecretKeyAndPrefix(pkM: PublicKey): Promise<[GrumpkinScalar, KeyPrefix]> {
+    return this.keyStore.getMasterSecretKeyAndPrefix(pkM);
   }
 
   public getDebugFunctionName(contractAddress: AztecAddress, selector: FunctionSelector): Promise<string> {

--- a/yarn-project/pxe/src/kernel_prover/hints/build_private_kernel_reset_hints.ts
+++ b/yarn-project/pxe/src/kernel_prover/hints/build_private_kernel_reset_hints.ts
@@ -79,8 +79,15 @@ async function getMasterSecretKeysAndAppKeyGenerators(
     if (request.isEmpty()) {
       break;
     }
-    const secretKeys = await oracle.getMasterSecretKey(request.request.pkM);
-    keysHints[keyIndex] = new KeyValidationHint(secretKeys, i);
+    const [secretKey, prefix] = await oracle.getMasterSecretKeyAndPrefix(request.request.pkM);
+    if (prefix === 'iv' || prefix !== 't') {
+      const keyTypeName = prefix === 'iv' ? 'incoming viewing' : 'tagging';
+      throw new Error(
+        `Requesting key validation request for ${keyTypeName} keys is currently not supported. You have probably made a mistake in your contract.`,
+      );
+    }
+
+    keysHints[keyIndex] = new KeyValidationHint(secretKey, i);
     keyIndex++;
   }
   return {

--- a/yarn-project/pxe/src/kernel_prover/proving_data_oracle.ts
+++ b/yarn-project/pxe/src/kernel_prover/proving_data_oracle.ts
@@ -4,9 +4,10 @@ import {
   type Fr,
   type FunctionSelector,
   type GrumpkinScalar,
+  type KeyPrefix,
   type MembershipWitness,
   type NOTE_HASH_TREE_HEIGHT,
-  type Point,
+  type PublicKey,
   type VK_TREE_HEIGHT,
   type VerificationKeyAsFields,
 } from '@aztec/circuits.js';
@@ -76,7 +77,7 @@ export interface ProvingDataOracle {
    * @returns A Promise that resolves to sk_m.
    * @dev Used when feeding the sk_m to the kernel circuit for keys verification.
    */
-  getMasterSecretKey(masterPublicKey: Point): Promise<GrumpkinScalar>;
+  getMasterSecretKeyAndPrefix(pkM: PublicKey): Promise<[GrumpkinScalar, KeyPrefix]>;
 
   getDebugFunctionName(contractAddress: AztecAddress, selector: FunctionSelector): Promise<string | undefined>;
 }


### PR DESCRIPTION
When passing around keys in aztec-nr it's very easy to make a mistake and pass e.g. ivpk to a function instead of ovpk. This has recently happened in [Nico's PR](https://github.com/AztecProtocol/aztec-packages/pull/7996) and it was quite a pain to debug. For this reason I added a check that verifies that either nsk_app or ovsk_app is requested.

When I was coding this it came to my mind that insted of having this runtime check we could use type system to have a compile time check. This would require creating a type for each of the key types we currently have. I think this is the way to go so I would probably not merge this and do the compile time check instead.
