### PR TITLE
fix: add validation of address when registering a contract

### DIFF
--- a/yarn-project/circuit-types/src/mocks.ts
+++ b/yarn-project/circuit-types/src/mocks.ts
@@ -14,6 +14,7 @@ import {
   PrivateKernelTailCircuitPublicInputs,
   PublicAccumulatedDataBuilder,
   ScopedLogHash,
+  computeContractAddressFromInstance,
   computeContractClassId,
   getContractClassFromArtifact,
 } from '@aztec/circuits.js';
@@ -236,8 +237,11 @@ export const randomContractArtifact = (): ContractArtifact => ({
 
 export const randomContractInstanceWithAddress = (
   opts: { contractClassId?: Fr } = {},
-  address: AztecAddress = AztecAddress.random(),
-): ContractInstanceWithAddress => SerializableContractInstance.random(opts).withAddress(address);
+  address?: AztecAddress,
+): ContractInstanceWithAddress => {
+  const instance = SerializableContractInstance.random(opts);
+  return instance.withAddress(address ?? computeContractAddressFromInstance(instance));
+};
 
 export const randomDeployedContract = () => {
   const artifact = randomContractArtifact();

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -36,6 +36,7 @@ import {
   type CompleteAddress,
   type L1_TO_L2_MSG_TREE_HEIGHT,
   type PartialAddress,
+  computeContractAddressFromInstance,
   computeContractClassId,
   getContractClassFromArtifact,
 } from '@aztec/circuits.js';
@@ -272,6 +273,13 @@ export class PXEService implements PXE {
           `Artifact does not match expected class id (computed ${contractClassId} but instance refers to ${instance.contractClassId})`,
         );
       }
+      if (
+        // Computed address from the instance does not match address inside instance
+        !computeContractAddressFromInstance(instance).equals(instance.address)
+      ) {
+        throw new Error('Added a contract in which the address does not match the contract instance.');
+      }
+
       await this.db.addContractArtifact(contractClassId, artifact);
       await this.node.addContractArtifact(instance.address, artifact);
     } else {

--- a/yarn-project/pxe/src/pxe_service/test/pxe_test_suite.ts
+++ b/yarn-project/pxe/src/pxe_service/test/pxe_test_suite.ts
@@ -112,6 +112,22 @@ export const pxeTestSuite = (testName: string, pxeSetup: () => Promise<PXE>) => 
       expect(await pxe.getContractInstance(instance.address)).toEqual(instance);
     });
 
+    it('refuses to register a class with a mismatched address', async () => {
+      const artifact = randomContractArtifact();
+      const contractClass = getContractClassFromArtifact(artifact);
+      const contractClassId = contractClass.id;
+      const instance = randomContractInstanceWithAddress({ contractClassId });
+      await expect(
+        pxe.registerContract({
+          instance: {
+            ...instance,
+            address: Fr.random(),
+          },
+          artifact,
+        }),
+      ).rejects.toThrow(/Added a contract in which the address does not match the contract instance./);
+    });
+
     it('refuses to register a contract with a class that has not been registered', async () => {
       const instance = randomContractInstanceWithAddress();
       await expect(pxe.registerContract({ instance })).rejects.toThrow(/Missing contract artifact/i);


### PR DESCRIPTION
This PR adds validation upon adding a new contract. We had issues with devnet where the contract being added to the PXE was incorrect, as the contract class id matched the one passed in with the artifact, but the actual computed address was incorrect due to the artifacts being different. 