### PR TITLE
feat: some fixes and cleanup in PG recursive verifier

### DIFF
--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -102,6 +102,16 @@ std::shared_ptr<typename VerifierInstances::Instance> ProtoGalaxyVerifier_<Verif
         accumulator->verification_key->circuit_size, accumulator->verification_key->num_public_inputs);
     next_accumulator->verification_key->pcs_verification_key = accumulator->verification_key->pcs_verification_key;
     next_accumulator->verification_key->pub_inputs_offset = accumulator->verification_key->pub_inputs_offset;
+    next_accumulator->verification_key->contains_recursive_proof =
+        accumulator->verification_key->contains_recursive_proof;
+    next_accumulator->verification_key->recursive_proof_public_input_indices =
+        accumulator->verification_key->recursive_proof_public_input_indices;
+
+    if constexpr (IsGoblinFlavor<Flavor>) { // Databus commitment propagation data
+        next_accumulator->verification_key->databus_propagation_data =
+            accumulator->verification_key->databus_propagation_data;
+    }
+
     size_t vk_idx = 0;
     for (auto& expected_vk : next_accumulator->verification_key->get_all()) {
         size_t inst = 0;

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/protogalaxy_recursive_verifier.cpp
@@ -157,10 +157,20 @@ std::shared_ptr<typename VerifierInstances::Instance> ProtoGalaxyRecursiveVerifi
     auto lagranges = std::vector<FF>{ FF(1) - combiner_challenge, combiner_challenge };
 
     auto next_accumulator = std::make_shared<Instance>(builder);
+
     next_accumulator->verification_key = std::make_shared<VerificationKey>(
         accumulator->verification_key->circuit_size, accumulator->verification_key->num_public_inputs);
     next_accumulator->verification_key->pcs_verification_key = accumulator->verification_key->pcs_verification_key;
     next_accumulator->verification_key->pub_inputs_offset = accumulator->verification_key->pub_inputs_offset;
+    next_accumulator->verification_key->contains_recursive_proof =
+        accumulator->verification_key->contains_recursive_proof;
+    next_accumulator->verification_key->recursive_proof_public_input_indices =
+        accumulator->verification_key->recursive_proof_public_input_indices;
+    if constexpr (IsGoblinFlavor<Flavor>) { // Databus commitment propagation data
+        next_accumulator->verification_key->databus_propagation_data =
+            accumulator->verification_key->databus_propagation_data;
+    }
+
     next_accumulator->public_inputs = accumulator->public_inputs;
 
     next_accumulator->is_accumulator = true;

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/recursive_instances.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/recursive_instances.hpp
@@ -28,11 +28,9 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveVerifierInstan
         : builder(builder)
     {
         ASSERT(vks.size() == NUM - 1);
-        if (accumulator->is_accumulator) {
-            _data[0] = std::make_shared<Instance>(builder, accumulator);
-        } else {
-            _data[0] = std::make_shared<Instance>(builder, accumulator->verification_key);
-        }
+
+        _data[0] = std::make_shared<Instance>(builder, accumulator);
+
         size_t idx = 1;
         for (auto& vk : vks) {
             _data[idx] = std::make_shared<Instance>(builder, vk);

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/recursive_verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_recursion/verifier/recursive_verifier_instance.hpp
@@ -46,52 +46,42 @@ template <IsRecursiveFlavor Flavor> class RecursiveVerifierInstance_ {
     {}
 
     RecursiveVerifierInstance_(Builder* builder, const std::shared_ptr<VerifierInstance>& instance)
-        : verification_key(std::make_shared<VerificationKey>(instance->verification_key->circuit_size,
-                                                             instance->verification_key->num_public_inputs))
-        , is_accumulator(bool(instance->is_accumulator))
-        , public_inputs(std::vector<FF>(static_cast<size_t>(instance->verification_key->num_public_inputs)))
+        : RecursiveVerifierInstance_(builder, instance->verification_key)
     {
+        is_accumulator = instance->is_accumulator;
+        if (is_accumulator) {
 
-        verification_key->pub_inputs_offset = instance->verification_key->pub_inputs_offset;
-        verification_key->pcs_verification_key = instance->verification_key->pcs_verification_key;
+            for (auto [native_public_input] : zip_view(instance->public_inputs)) {
+                public_inputs.emplace_back(FF::from_witness(builder, native_public_input));
+            }
+            for (size_t alpha_idx = 0; alpha_idx < alphas.size(); alpha_idx++) {
+                alphas[alpha_idx] = FF::from_witness(builder, instance->alphas[alpha_idx]);
+            }
 
-        for (auto [public_input, native_public_input] : zip_view(public_inputs, instance->public_inputs)) {
-            public_input = FF::from_witness(builder, native_public_input);
-        }
+            auto other_comms = instance->witness_commitments.get_all();
+            size_t comm_idx = 0;
+            for (auto& comm : witness_commitments.get_all()) {
+                comm = Commitment::from_witness(builder, other_comms[comm_idx]);
+                comm_idx++;
+            }
+            target_sum = FF::from_witness(builder, instance->target_sum);
 
-        auto other_vks = instance->verification_key->get_all();
-        size_t vk_idx = 0;
-        for (auto& vk : verification_key->get_all()) {
-            vk = Commitment::from_witness(builder, other_vks[vk_idx]);
-            vk_idx++;
+            size_t challenge_idx = 0;
+            gate_challenges = std::vector<FF>(instance->gate_challenges.size());
+            for (auto& challenge : gate_challenges) {
+                challenge = FF::from_witness(builder, instance->gate_challenges[challenge_idx]);
+                challenge_idx++;
+            }
+            relation_parameters.eta = FF::from_witness(builder, instance->relation_parameters.eta);
+            relation_parameters.eta_two = FF::from_witness(builder, instance->relation_parameters.eta_two);
+            relation_parameters.eta_three = FF::from_witness(builder, instance->relation_parameters.eta_three);
+            relation_parameters.beta = FF::from_witness(builder, instance->relation_parameters.beta);
+            relation_parameters.gamma = FF::from_witness(builder, instance->relation_parameters.gamma);
+            relation_parameters.public_input_delta =
+                FF::from_witness(builder, instance->relation_parameters.public_input_delta);
+            relation_parameters.lookup_grand_product_delta =
+                FF::from_witness(builder, instance->relation_parameters.lookup_grand_product_delta);
         }
-        for (size_t alpha_idx = 0; alpha_idx < alphas.size(); alpha_idx++) {
-            alphas[alpha_idx] = FF::from_witness(builder, instance->alphas[alpha_idx]);
-        }
-
-        auto other_comms = instance->witness_commitments.get_all();
-        size_t comm_idx = 0;
-        for (auto& comm : witness_commitments.get_all()) {
-            comm = Commitment::from_witness(builder, other_comms[comm_idx]);
-            comm_idx++;
-        }
-        target_sum = FF::from_witness(builder, instance->target_sum);
-
-        size_t challenge_idx = 0;
-        gate_challenges = std::vector<FF>(instance->gate_challenges.size());
-        for (auto& challenge : gate_challenges) {
-            challenge = FF::from_witness(builder, instance->gate_challenges[challenge_idx]);
-            challenge_idx++;
-        }
-        relation_parameters.eta = FF::from_witness(builder, instance->relation_parameters.eta);
-        relation_parameters.eta_two = FF::from_witness(builder, instance->relation_parameters.eta_two);
-        relation_parameters.eta_three = FF::from_witness(builder, instance->relation_parameters.eta_three);
-        relation_parameters.beta = FF::from_witness(builder, instance->relation_parameters.beta);
-        relation_parameters.gamma = FF::from_witness(builder, instance->relation_parameters.gamma);
-        relation_parameters.public_input_delta =
-            FF::from_witness(builder, instance->relation_parameters.public_input_delta);
-        relation_parameters.lookup_grand_product_delta =
-            FF::from_witness(builder, instance->relation_parameters.lookup_grand_product_delta);
     }
 
     /**
@@ -106,6 +96,14 @@ template <IsRecursiveFlavor Flavor> class RecursiveVerifierInstance_ {
         auto inst_verification_key = std::make_shared<NativeVerificationKey>(verification_key->circuit_size,
                                                                              verification_key->num_public_inputs);
         inst_verification_key->pcs_verification_key = verification_key->pcs_verification_key;
+        inst_verification_key->pub_inputs_offset = verification_key->pub_inputs_offset;
+        inst_verification_key->contains_recursive_proof = verification_key->contains_recursive_proof;
+        inst_verification_key->recursive_proof_public_input_indices =
+            verification_key->recursive_proof_public_input_indices;
+        if constexpr (IsGoblinFlavor<Flavor>) {
+            inst_verification_key->databus_propagation_data = verification_key->databus_propagation_data;
+        }
+
         for (auto [vk, inst_vk] : zip_view(verification_key->get_all(), inst_verification_key->get_all())) {
             inst_vk = vk.get_value();
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_recursive_flavor.hpp
@@ -118,7 +118,6 @@ template <typename BuilderType> class MegaRecursiveFlavor_ {
          */
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {
-
             this->pcs_verification_key = native_key->pcs_verification_key;
             this->circuit_size = native_key->circuit_size;
             this->log_circuit_size = numeric::get_msb(this->circuit_size);
@@ -127,36 +126,11 @@ template <typename BuilderType> class MegaRecursiveFlavor_ {
             this->contains_recursive_proof = native_key->contains_recursive_proof;
             this->recursive_proof_public_input_indices = native_key->recursive_proof_public_input_indices;
             this->databus_propagation_data = native_key->databus_propagation_data;
-            this->q_m = Commitment::from_witness(builder, native_key->q_m);
-            this->q_l = Commitment::from_witness(builder, native_key->q_l);
-            this->q_r = Commitment::from_witness(builder, native_key->q_r);
-            this->q_o = Commitment::from_witness(builder, native_key->q_o);
-            this->q_4 = Commitment::from_witness(builder, native_key->q_4);
-            this->q_c = Commitment::from_witness(builder, native_key->q_c);
-            this->q_arith = Commitment::from_witness(builder, native_key->q_arith);
-            this->q_delta_range = Commitment::from_witness(builder, native_key->q_delta_range);
-            this->q_elliptic = Commitment::from_witness(builder, native_key->q_elliptic);
-            this->q_aux = Commitment::from_witness(builder, native_key->q_aux);
-            this->q_lookup = Commitment::from_witness(builder, native_key->q_lookup);
-            this->q_busread = Commitment::from_witness(builder, native_key->q_busread);
-            this->q_poseidon2_external = Commitment::from_witness(builder, native_key->q_poseidon2_external);
-            this->q_poseidon2_internal = Commitment::from_witness(builder, native_key->q_poseidon2_internal);
-            this->sigma_1 = Commitment::from_witness(builder, native_key->sigma_1);
-            this->sigma_2 = Commitment::from_witness(builder, native_key->sigma_2);
-            this->sigma_3 = Commitment::from_witness(builder, native_key->sigma_3);
-            this->sigma_4 = Commitment::from_witness(builder, native_key->sigma_4);
-            this->id_1 = Commitment::from_witness(builder, native_key->id_1);
-            this->id_2 = Commitment::from_witness(builder, native_key->id_2);
-            this->id_3 = Commitment::from_witness(builder, native_key->id_3);
-            this->id_4 = Commitment::from_witness(builder, native_key->id_4);
-            this->table_1 = Commitment::from_witness(builder, native_key->table_1);
-            this->table_2 = Commitment::from_witness(builder, native_key->table_2);
-            this->table_3 = Commitment::from_witness(builder, native_key->table_3);
-            this->table_4 = Commitment::from_witness(builder, native_key->table_4);
-            this->lagrange_first = Commitment::from_witness(builder, native_key->lagrange_first);
-            this->lagrange_last = Commitment::from_witness(builder, native_key->lagrange_last);
-            this->lagrange_ecc_op = Commitment::from_witness(builder, native_key->lagrange_ecc_op);
-            this->databus_id = Commitment::from_witness(builder, native_key->databus_id);
+
+            // Generate stdlib commitments (biggroup) from the native counterparts
+            for (auto [commitment, native_commitment] : zip_view(this->get_all(), native_key->get_all())) {
+                commitment = Commitment::from_witness(builder, native_commitment);
+            }
         };
 
         /**


### PR DESCRIPTION
Some minor reorganization/fixes for VerifierInstance/VerificationKey constructors. There are lots of places where we are manually reproducing something resembling the VerificationKey constructor. This PR tries to simplify some of that logic where possible and adds in handling of components of the vkey that were missed in a few of these locations. (Done in prep for introducing PG verifier logic based on stdlib types).