### PR TITLE
fix: Deploy L1 rollup contract using salt if provided

### DIFF
--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -20,7 +20,8 @@
     "serve:flames": "python3 -m http.server --directory \"flame_graph\" 8000",
     "test:debug": "LOG_LEVEL=${LOG_LEVEL:-verbose} DEBUG_COLORS=1 NODE_NO_WARNINGS=1 node --inspect --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=300000 --forceExit",
     "test:integration": "concurrently -k -s first -c reset,dim -n test,anvil \"yarn test:integration:run\" \"anvil\"",
-    "test:integration:run": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --no-cache --runInBand --config jest.integration.config.json"
+    "test:integration:run": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --no-cache --runInBand --config jest.integration.config.json",
+    "test:unit": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest src/fixtures"
   },
   "dependencies": {
     "@aztec/accounts": "workspace:^",

--- a/yarn-project/end-to-end/package.local.json
+++ b/yarn-project/end-to-end/package.local.json
@@ -2,6 +2,7 @@
   "scripts": {
     "build": "yarn clean && tsc -b && webpack",
     "formatting": "run -T prettier --check ./src \"!src/web/main.js\" && run -T eslint ./src",
-    "test": "LOG_LEVEL=${LOG_LEVEL:-verbose} DEBUG_COLORS=1 NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=300000 --forceExit"
+    "test": "LOG_LEVEL=${LOG_LEVEL:-verbose} DEBUG_COLORS=1 NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=300000 --forceExit",
+    "test:unit": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest src/fixtures"
   }
 }

--- a/yarn-project/end-to-end/src/fixtures/setup_l1_contracts.test.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup_l1_contracts.test.ts
@@ -1,0 +1,45 @@
+import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+
+import { type Anvil } from '@viem/anvil';
+import { type PrivateKeyAccount } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { setupL1Contracts, startAnvil } from './utils.js';
+
+describe('deploy_l1_contracts', () => {
+  let anvil: Anvil;
+  let rpcUrl: string;
+  let privateKey: PrivateKeyAccount;
+  let logger: DebugLogger;
+
+  beforeAll(async () => {
+    logger = createDebugLogger('aztec:setup_l1_contracts');
+    privateKey = privateKeyToAccount('0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba');
+
+    ({ anvil, rpcUrl } = await startAnvil());
+  });
+
+  afterAll(async () => {
+    await anvil.stop();
+  });
+
+  const deploy = (salt: number | undefined) => setupL1Contracts(rpcUrl, privateKey, logger, { salt });
+
+  it('deploys without salt', async () => {
+    await deploy(undefined);
+  });
+
+  it('deploys with salt on different addresses', async () => {
+    const first = await deploy(42);
+    const second = await deploy(43);
+
+    expect(first.l1ContractAddresses).not.toEqual(second.l1ContractAddresses);
+  });
+
+  it('deploys twice with salt on same addresses', async () => {
+    const first = await deploy(44);
+    const second = await deploy(44);
+
+    expect(first.l1ContractAddresses).toEqual(second.l1ContractAddresses);
+  });
+});

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -111,6 +111,7 @@ export const setupL1Contracts = async (
   l1RpcUrl: string,
   account: HDAccount | PrivateKeyAccount,
   logger: DebugLogger,
+  args: { salt?: number } = {},
 ) => {
   const l1Artifacts: L1ContractArtifactsForDeployment = {
     registry: {
@@ -146,7 +147,7 @@ export const setupL1Contracts = async (
   const l1Data = await deployL1Contracts(l1RpcUrl, account, foundry, logger, l1Artifacts, {
     l2FeeJuiceAddress: FeeJuiceAddress,
     vkTreeRoot: getVKTreeRoot(),
-    salt: undefined,
+    salt: args.salt,
   });
 
   return l1Data;

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -21,6 +21,7 @@ import {
   http,
   numberToHex,
   padHex,
+  zeroAddress,
 } from 'viem';
 import { type HDAccount, type PrivateKeyAccount, mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
@@ -207,13 +208,18 @@ export const deployL1Contracts = async (
   await publicClient.waitForTransactionReceipt({ hash: receipt });
   logger.info(`Funded fee juice portal contract with Fee Juice`);
 
-  await publicClient.waitForTransactionReceipt({
-    hash: await feeJuicePortal.write.initialize([
-      registryAddress.toString(),
-      feeJuiceAddress.toString(),
-      args.l2FeeJuiceAddress.toString(),
-    ]),
-  });
+  if ((await feeJuicePortal.read.registry([])) === zeroAddress) {
+    await publicClient.waitForTransactionReceipt({
+      hash: await feeJuicePortal.write.initialize([
+        registryAddress.toString(),
+        feeJuiceAddress.toString(),
+        args.l2FeeJuiceAddress.toString(),
+      ]),
+    });
+    logger.verbose(`Fee juice portal initialized with registry ${registryAddress.toString()}`);
+  } else {
+    logger.verbose(`Fee juice portal is already initialized`);
+  }
 
   logger.info(
     `Initialized Gas Portal at ${feeJuicePortalAddress} to bridge between L1 ${feeJuiceAddress} to L2 ${args.l2FeeJuiceAddress}`,

--- a/yarn-project/package.json
+++ b/yarn-project/package.json
@@ -10,7 +10,7 @@
     "formatting:fix": "FORCE_COLOR=true yarn workspaces foreach -p -v run formatting:fix",
     "lint": "yarn eslint --cache --ignore-pattern l1-artifacts .",
     "format": "yarn prettier --cache -w .",
-    "test": "FORCE_COLOR=true yarn workspaces foreach --exclude @aztec/aztec3-packages --exclude @aztec/end-to-end --exclude @aztec/prover-client -p -v run test",
+    "test": "FORCE_COLOR=true yarn workspaces foreach --exclude @aztec/aztec3-packages --exclude @aztec/end-to-end --exclude @aztec/prover-client -p -v run test && yarn workspaces foreach --include @aztec/end-to-end -p -v run test:unit",
     "build": "FORCE_COLOR=true yarn workspaces foreach --parallel --topological-dev --verbose --exclude @aztec/aztec3-packages --exclude @aztec/docs run build",
     "build:fast": "yarn generate && tsc -b",
     "build:dev": "./watch.sh",


### PR DESCRIPTION
Fixes a bad merge that disabled the usage of deployment salt for rollup contract.
