### PR TITLE
chore(ci): only show last 50 master cpp benches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,6 +577,7 @@ jobs:
       # https://aztecprotocol.github.io/aztec-packages/dev/bench/ with new benchmark data.
       # This also creates an alert if benchmarks exceed the threshold specified below.
       - name: Store benchmark result
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: benchmark-action/github-action-benchmark@4de1bed97a47495fc4c5404952da0499e31f5c29
         with:
           name: C++ Benchmark
@@ -591,6 +592,7 @@ jobs:
           comment-on-alert: true
           fail-on-alert: false
           alert-comment-cc-users: "@ludamad @codygunton"
+          max-items-in-chart: 50
 
   boxes:
     needs: build


### PR DESCRIPTION
Make https://aztecprotocol.github.io/aztec-packages/dev/bench/ more readable


Unrelated image, master of benches 
![image](https://github.com/user-attachments/assets/210c73c2-e3a1-492a-b65c-599671c16012)
