### PR TITLE
chore: Enables JSON logging in AWS

### DIFF
--- a/yarn-project/aztec/terraform/bot/main.tf
+++ b/yarn-project/aztec/terraform/bot/main.tf
@@ -172,7 +172,8 @@ resource "aws_ecs_task_definition" "aztec-bot" {
         { name = "PXE_PROVER_ENABLED", value = tostring(var.PROVING_ENABLED) },
         { name = "NETWORK", value = var.DEPLOY_TAG },
         { name = "BOT_FLUSH_SETUP_TRANSACTIONS", value = tostring(var.BOT_FLUSH_SETUP_TRANSACTIONS) },
-        { name = "BOT_MAX_PENDING_TXS", value = tostring(var.BOT_MAX_PENDING_TXS) }
+        { name = "BOT_MAX_PENDING_TXS", value = tostring(var.BOT_MAX_PENDING_TXS) },
+        { name = "LOG_JSON", value = "1" }
       ]
       logConfiguration = {
         logDriver = "awslogs"

--- a/yarn-project/aztec/terraform/node/main.tf
+++ b/yarn-project/aztec/terraform/node/main.tf
@@ -357,6 +357,10 @@ resource "aws_ecs_task_definition" "aztec-node" {
           value = "info"
         },
         {
+          name  = "LOG_JSON",
+          value = "1"
+        },
+        {
           name  = "NETWORK_NAME",
           value = "${var.DEPLOY_TAG}"
         }

--- a/yarn-project/aztec/terraform/prover-node/main.tf
+++ b/yarn-project/aztec/terraform/prover-node/main.tf
@@ -170,7 +170,8 @@ resource "aws_ecs_task_definition" "aztec-prover-node" {
       environment = [
         // General
         { name = "NODE_ENV", value = "production" },
-        { name = "LOG_LEVEL", value = "debug" },
+        { name = "LOG_LEVEL", value = "verbose" },
+        { name = "LOG_JSON", value = "1" },
         { name = "DEBUG", value = "aztec:*,-json-rpc:json_proxy:*,-aztec:avm_simulator:*" },
         { name = "DEPLOY_TAG", value = var.DEPLOY_TAG },
         { name = "NETWORK_NAME", value = "${var.DEPLOY_TAG}" },

--- a/yarn-project/aztec/terraform/prover/main.tf
+++ b/yarn-project/aztec/terraform/prover/main.tf
@@ -284,6 +284,10 @@ resource "aws_ecs_task_definition" "aztec-proving-agent" {
       {
         "name": "NETWORK_NAME",
         "value": "${var.DEPLOY_TAG}"
+      },
+      { 
+        "name": "LOG_JSON", 
+        "value": "1" 
       }
     ],
     "logConfiguration": {

--- a/yarn-project/aztec/terraform/pxe/main.tf
+++ b/yarn-project/aztec/terraform/pxe/main.tf
@@ -150,6 +150,10 @@ resource "aws_ecs_task_definition" "aztec-pxe" {
         {
           name  = "PXE_PROVER_ENABLED"
           value = tostring(var.PROVING_ENABLED)
+        },
+        {
+          name  = "LOG_JSON"
+          value = "1"
         }
       ]
       mountPoints = [


### PR DESCRIPTION
Cloudwatch is smart enough to parse JSON logs, and we can use the different fields extracted for querying in Insights.

**Builds on #8095**