### PR TITLE
fix: flaky e2e_prover_node test

### DIFF
--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -38,7 +38,7 @@ import {
   getContractClassFromArtifact,
 } from '@aztec/circuits.js';
 import { bufferAsFields } from '@aztec/foundation/abi';
-import { makeBackoff, retry } from '@aztec/foundation/retry';
+import { makeBackoff, retry, retryUntil } from '@aztec/foundation/retry';
 import {
   AvailabilityOracleAbi,
   AvailabilityOracleBytecode,
@@ -742,4 +742,15 @@ export async function deployCanonicalAuthRegistry(deployer: Wallet) {
   expect(getContractClassFromArtifact(authRegistry.artifact).id).toEqual(authRegistry.instance.contractClassId);
   await expect(deployer.isContractClassPubliclyRegistered(canonicalAuthRegistry.contractClass.id)).resolves.toBe(true);
   await expect(deployer.getContractInstance(canonicalAuthRegistry.instance.address)).resolves.toBeDefined();
+}
+
+export async function waitForProvenChain(node: AztecNode, targetBlock?: number, timeoutSec = 60, intervalSec = 1) {
+  targetBlock ??= await node.getBlockNumber();
+
+  await retryUntil(
+    async () => (await node.getProvenBlockNumber()) === targetBlock,
+    'proven chain status',
+    timeoutSec,
+    intervalSec,
+  );
 }

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -748,7 +748,7 @@ export async function waitForProvenChain(node: AztecNode, targetBlock?: number, 
   targetBlock ??= await node.getBlockNumber();
 
   await retryUntil(
-    async () => (await node.getProvenBlockNumber()) === targetBlock,
+    async () => (await node.getProvenBlockNumber()) >= targetBlock,
     'proven chain status',
     timeoutSec,
     intervalSec,


### PR DESCRIPTION
Fix for the flakiness in e2e_prover_node caused by halting the default prover node while it was building a proof.

Later edit: alternatively we could refactor the test to start proving from the first unproven block instead of from the block the first tx landed in.