### PR TITLE
feat: Free instances and circuits earlier to reduce max memory usage

### DIFF
--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/mock_circuits.hpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/mock_circuits.hpp
@@ -35,8 +35,6 @@ template <typename Builder> void generate_basic_arithmetic_circuit(Builder& buil
         a = b * b;
         b = c * c;
     }
-    info("number of gates at the end of mock circuit generation: ", builder.num_gates);
-    info("number of variables at the end of mock circuit generation: ", builder.variables.size());
 }
 
 template <typename Prover>

--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/mock_circuits.hpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/mock_circuits.hpp
@@ -35,6 +35,8 @@ template <typename Builder> void generate_basic_arithmetic_circuit(Builder& buil
         a = b * b;
         b = c * c;
     }
+    info("number of gates at the end of mock circuit generation: ", builder.num_gates);
+    info("number of variables at the end of mock circuit generation: ", builder.variables.size());
 }
 
 template <typename Prover>

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -68,8 +68,14 @@ void ClientIVC::accumulate(std::unique_ptr<ClientCircuit> circuit,
     // If a previous fold proof exists, add a recursive folding verification to the circuit
     if (!fold_output.proof.empty()) {
         BB_OP_COUNT_TIME_NAME("construct_circuits");
-        FoldingRecursiveVerifier verifier{ &(*circuit), { verifier_accumulator, { instance_vk } } };
-        auto verifier_accum = verifier.verify_folding_proof(fold_output.proof);
+
+        // Construct stdlib accumulator, vkey and proof
+        auto stdlib_verifier_accum = std::make_shared<RecursiveVerifierInstance>(&*circuit, verifier_accumulator);
+        auto stdlib_instance_vk = std::make_shared<RecursiveVerificationKey>(&*circuit, instance_vk);
+        auto stdlib_proof = bb::convert_proof_to_witness(&*circuit, fold_output.proof);
+
+        FoldingRecursiveVerifier verifier{ &*circuit, stdlib_verifier_accum, { stdlib_instance_vk } };
+        auto verifier_accum = verifier.verify_folding_proof(stdlib_proof);
         verifier_accumulator = std::make_shared<VerifierInstance>(verifier_accum->get_value());
     }
 
@@ -100,7 +106,7 @@ void ClientIVC::accumulate(std::unique_ptr<ClientCircuit> circuit,
         initialized = true;
     } else { // Otherwise, fold the new instance into the accumulator
         FoldingProver folding_prover({ fold_output.accumulator, prover_instance });
-        fold_output = folding_prover.fold_instances();
+        fold_output = folding_prover.prove();
     }
     // forget the prover_instance now?
     prover_instance = nullptr;

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -80,6 +80,8 @@ class ClientIVC {
     bool initialized = false;
 
     void accumulate(ClientCircuit& circuit, const std::shared_ptr<VerificationKey>& precomputed_vk = nullptr);
+    void accumulate(std::unique_ptr<ClientCircuit> circuit,
+                    const std::shared_ptr<VerificationKey>& precomputed_vk = nullptr);
 
     Proof prove();
 

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -68,9 +68,6 @@ class ClientIVC {
     ProverFoldOutput fold_output;
     std::shared_ptr<ProverInstance> prover_accumulator;
     std::shared_ptr<VerifierInstance> verifier_accumulator;
-    // Note: We need to save the last instance that was folded in order to compute its verification key, this will not
-    // be needed in the real IVC as they are provided as inputs
-    std::shared_ptr<ProverInstance> prover_instance;
     std::shared_ptr<VerificationKey> instance_vk;
 
     // A flag indicating whether or not to construct a structured trace in the ProverInstance
@@ -80,8 +77,6 @@ class ClientIVC {
     bool initialized = false;
 
     void accumulate(ClientCircuit& circuit, const std::shared_ptr<VerificationKey>& precomputed_vk = nullptr);
-    void accumulate(std::unique_ptr<ClientCircuit> circuit,
-                    const std::shared_ptr<VerificationKey>& precomputed_vk = nullptr);
 
     Proof prove();
 

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -74,17 +74,33 @@ TEST_F(ClientIVCTests, Basic)
 {
     ClientIVC ivc;
 
-    // Initialize the IVC with an arbitrary circuit
-    auto circuit_0 = std::make_unique<Builder>(create_mock_circuit(ivc));
-    ivc.accumulate(std::move(circuit_0));
+    {
+        // Initialize the IVC with an arbitrary circuit
+        Builder circuit_0 = create_mock_circuit(ivc);
+        ivc.accumulate(circuit_0);
+    }
 
-    // Create another circuit and accumulate
-    auto circuit_1 = std::make_unique<Builder>(create_mock_circuit(ivc));
-    ivc.accumulate(std::move(circuit_1));
+    {
+        // Create another circuit and accumulate
+        Builder circuit_1 = create_mock_circuit(ivc);
+        ivc.accumulate(circuit_1);
+    }
 
-    // Create another circuit and accumulate
-    auto circuit_2 = std::make_unique<Builder>(create_mock_circuit(ivc));
-    ivc.accumulate(std::move(circuit_2));
+    EXPECT_TRUE(prove_and_verify(ivc));
+};
+
+/**
+ * @brief A simple-as-possible test demonstrating IVC for three mock circuits
+ *
+ */
+TEST_F(ClientIVCTests, BasicThree)
+{
+    ClientIVC ivc;
+
+    for (size_t idx = 0; idx < 3; ++idx) {
+        Builder circuit = create_mock_circuit(ivc);
+        ivc.accumulate(circuit);
+    }
 
     EXPECT_TRUE(prove_and_verify(ivc));
 };
@@ -98,12 +114,12 @@ TEST_F(ClientIVCTests, BasicFailure)
     ClientIVC ivc;
 
     // Initialize the IVC with an arbitrary circuit
-    auto circuit_0 = std::make_unique<Builder>(create_mock_circuit(ivc));
-    ivc.accumulate(std::move(circuit_0));
+    Builder circuit_0 = create_mock_circuit(ivc);
+    ivc.accumulate(circuit_0);
 
     // Create another circuit and accumulate
-    auto circuit_1 = std::make_unique<Builder>(create_mock_circuit(ivc));
-    ivc.accumulate(std::move(circuit_1));
+    Builder circuit_1 = create_mock_circuit(ivc);
+    ivc.accumulate(circuit_1);
 
     // Tamper with the fold proof just created in the last accumulation step
     for (auto& val : ivc.fold_output.proof) {
@@ -114,8 +130,8 @@ TEST_F(ClientIVCTests, BasicFailure)
     }
 
     // Accumulate another circuit; this involves recursive folding verification of the bad proof
-    auto circuit_2 = std::make_unique<Builder>(create_mock_circuit(ivc));
-    ivc.accumulate(std::move(circuit_2));
+    Builder circuit_2 = create_mock_circuit(ivc);
+    ivc.accumulate(circuit_2);
 
     // The bad fold proof should result in an invalid witness in the final circuit and the IVC should fail to verify
     EXPECT_FALSE(prove_and_verify(ivc));

--- a/barretenberg/cpp/src/barretenberg/client_ivc/mock_kernel_pinning.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/mock_kernel_pinning.test.cpp
@@ -37,5 +37,5 @@ TEST_F(MockKernelTest, PinFoldingKernelSizes)
     ivc.accumulate(circuit_2);
     ivc.accumulate(kernel_circuit);
 
-    EXPECT_EQ(ivc.prover_instance->proving_key.log_circuit_size, 17);
+    EXPECT_EQ(ivc.prover_accumulator->proving_key.log_circuit_size, 17);
 }

--- a/barretenberg/cpp/src/barretenberg/client_ivc/mock_kernel_pinning.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/mock_kernel_pinning.test.cpp
@@ -37,5 +37,5 @@ TEST_F(MockKernelTest, PinFoldingKernelSizes)
     ivc.accumulate(circuit_2);
     ivc.accumulate(kernel_circuit);
 
-    EXPECT_EQ(ivc.prover_accumulator->proving_key.log_circuit_size, 17);
+    EXPECT_EQ(ivc.fold_output.accumulator->proving_key.log_circuit_size, 17);
 }

--- a/barretenberg/cpp/src/barretenberg/execution_trace/execution_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/execution_trace/execution_trace.cpp
@@ -121,42 +121,6 @@ typename ExecutionTrace_<Flavor>::TraceData ExecutionTrace_<Flavor>::construct_t
             offset += block_size;
         }
     }
-    size_t biggest_copy_cycle = 0;
-    int count0 = 0;
-    int count1 = 0;
-    int count2 = 0;
-    int count3 = 0;
-    int count4 = 0;
-    int count1048600 = 0;
-    int countelse = 0;
-    for (size_t i = 0; i < builder.variables.size(); ++i) {
-        size_t len = trace_data.copy_cycles[i].size();
-        biggest_copy_cycle = std::max(biggest_copy_cycle, len);
-        if (len == 0)
-            count0++;
-        else if (len == 1)
-            count1++;
-        else if (len == 2)
-            count2++;
-        else if (len == 3)
-            count3++;
-        else if (len == 4)
-            count4++;
-        else if (len == 1048600)
-            count1048600++;
-        else {
-            info("other len: ", len);
-            countelse++;
-        }
-    }
-    info("biggest copy cycle: ", biggest_copy_cycle);
-    info("count0: ", count0);
-    info("count1: ", count1);
-    info("count2: ", count2);
-    info("count3: ", count3);
-    info("count4: ", count4);
-    info("count1048600: ", count1048600);
-    info("countelse: ", countelse);
     return trace_data;
 }
 

--- a/barretenberg/cpp/src/barretenberg/execution_trace/execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/execution_trace/execution_trace.hpp
@@ -31,43 +31,33 @@ template <class Flavor> class ExecutionTrace_ {
 
         TraceData(Builder& builder, ProvingKey& proving_key)
         {
-            ZoneScopedN("TraceData construction");
+            ZoneScopedN("TraceData constructor");
             if constexpr (IsHonkFlavor<Flavor>) {
-                {
-                    ZoneScopedN("wires initialization");
-                    // Initialize and share the wire and selector polynomials
-                    for (auto [wire, other_wire] : zip_view(wires, proving_key.polynomials.get_wires())) {
-                        wire = other_wire.share();
-                    }
+                // Initialize and share the wire and selector polynomials
+                for (auto [wire, other_wire] : zip_view(wires, proving_key.polynomials.get_wires())) {
+                    wire = other_wire.share();
                 }
-                {
-                    ZoneScopedN("selector initialization");
-                    for (auto [selector, other_selector] :
-                         zip_view(selectors, proving_key.polynomials.get_selectors())) {
-                        selector = other_selector.share();
-                    }
+                for (auto [selector, other_selector] : zip_view(selectors, proving_key.polynomials.get_selectors())) {
+                    selector = other_selector.share();
                 }
                 proving_key.polynomials.set_shifted(); // Ensure shifted wires are set correctly
             } else {
-                {
-                    ZoneScopedN("wires initialization");
-                    // Initialize and share the wire and selector polynomials
-                    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
-                        wires[idx] = Polynomial(proving_key.circuit_size);
-                        std::string wire_tag = "w_" + std::to_string(idx + 1) + "_lagrange";
-                        proving_key.polynomial_store.put(wire_tag, wires[idx].share());
-                    }
+                // Initialize and share the wire and selector polynomials
+                for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
+                    wires[idx] = Polynomial(proving_key.circuit_size);
+                    std::string wire_tag = "w_" + std::to_string(idx + 1) + "_lagrange";
+                    proving_key.polynomial_store.put(wire_tag, wires[idx].share());
                 }
-                {
-                    ZoneScopedN("selector initialization");
-                    for (size_t idx = 0; idx < NUM_USED_SELECTORS; ++idx) {
-                        selectors[idx] = Polynomial(proving_key.circuit_size);
-                        std::string selector_tag = builder.selector_names[idx] + "_lagrange";
-                        proving_key.polynomial_store.put(selector_tag, selectors[idx].share());
-                    }
+                for (size_t idx = 0; idx < Builder::Arithmetization::NUM_SELECTORS; ++idx) {
+                    selectors[idx] = Polynomial(proving_key.circuit_size);
+                    std::string selector_tag = builder.selector_names[idx] + "_lagrange";
+                    proving_key.polynomial_store.put(selector_tag, selectors[idx].share());
                 }
             }
-            copy_cycles.resize(builder.variables.size());
+            {
+                ZoneScopedN("copy cycle initialization");
+                copy_cycles.resize(builder.variables.size());
+            }
         }
     };
 

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -126,7 +126,10 @@ template <typename FF, typename CommitmentKey_> class ProvingKey_ {
     ProvingKey_() = default;
     ProvingKey_(const size_t circuit_size, const size_t num_public_inputs)
     {
-        this->commitment_key = std::make_shared<CommitmentKey_>(circuit_size + 1);
+        {
+            ZoneScopedN("init commitment key");
+            this->commitment_key = std::make_shared<CommitmentKey_>(circuit_size + 1);
+        }
         this->evaluation_domain = bb::EvaluationDomain<FF>(circuit_size, circuit_size);
         this->circuit_size = circuit_size;
         this->log_circuit_size = numeric::get_msb(circuit_size);

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
@@ -198,9 +198,16 @@ class GoblinProver {
      */
     GoblinProof prove(MergeProof merge_proof_in = {})
     {
+        ZoneScopedN("Goblin::prove");
         goblin_proof.merge_proof = merge_proof_in.empty() ? std::move(merge_proof) : std::move(merge_proof_in);
-        prove_eccvm();
-        prove_translator();
+        {
+            ZoneScopedN("prove_eccvm");
+            prove_eccvm();
+        }
+        {
+            ZoneScopedN("prove_translator");
+            prove_translator();
+        }
         return goblin_proof;
     };
 };

--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/composer/permutation_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/composer/permutation_lib.hpp
@@ -62,6 +62,7 @@ template <size_t NUM_WIRES, bool generalized> struct PermutationMapping {
      */
     PermutationMapping(size_t circuit_size)
     {
+        ZoneScopedN("PermutationMapping constructor");
         for (uint8_t col_idx = 0; col_idx < NUM_WIRES; ++col_idx) {
             sigmas[col_idx].reserve(circuit_size);
             if constexpr (generalized) {
@@ -109,13 +110,13 @@ PermutationMapping<Flavor::NUM_WIRES, generalized> compute_permutation_mapping(
 
     // Go through each cycle
     size_t cycle_index = 0;
-    for (auto& copy_cycle : wire_copy_cycles) {
+    for (const auto& copy_cycle : wire_copy_cycles) {
         for (size_t node_idx = 0; node_idx < copy_cycle.size(); ++node_idx) {
             // Get the indices of the current node and next node in the cycle
-            cycle_node current_cycle_node = copy_cycle[node_idx];
+            const cycle_node& current_cycle_node = copy_cycle[node_idx];
             // If current node is the last one in the cycle, then the next one is the first one
             size_t next_cycle_node_index = (node_idx == copy_cycle.size() - 1 ? 0 : node_idx + 1);
-            cycle_node next_cycle_node = copy_cycle[next_cycle_node_index];
+            const cycle_node& next_cycle_node = copy_cycle[next_cycle_node_index];
             const auto current_row = current_cycle_node.gate_index;
             const auto next_row = next_cycle_node.gate_index;
 
@@ -383,10 +384,16 @@ void compute_permutation_argument_polynomials(const typename Flavor::CircuitBuil
         }
     } else if constexpr (IsUltraFlavor<Flavor>) { // any UltraHonk flavor
         // Compute Honk-style sigma and ID polynomials from the corresponding mappings
-        compute_honk_style_permutation_lagrange_polynomials_from_mapping<Flavor>(
-            key->polynomials.get_sigmas(), mapping.sigmas, key);
-        compute_honk_style_permutation_lagrange_polynomials_from_mapping<Flavor>(
-            key->polynomials.get_ids(), mapping.ids, key);
+        {
+            ZoneScopedN("compute_honk_style_permutation_lagrange_polynomials_from_mapping");
+            compute_honk_style_permutation_lagrange_polynomials_from_mapping<Flavor>(
+                key->polynomials.get_sigmas(), mapping.sigmas, key);
+        }
+        {
+            ZoneScopedN("compute_honk_style_permutation_lagrange_polynomials_from_mapping");
+            compute_honk_style_permutation_lagrange_polynomials_from_mapping<Flavor>(
+                key->polynomials.get_ids(), mapping.ids, key);
+        }
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -215,6 +215,7 @@ template <class ProverInstances>
 void ProtoGalaxyProver_<ProverInstances>::finalise_and_send_instance(std::shared_ptr<Instance> instance,
                                                                      const std::string& domain_separator)
 {
+    ZoneScopedN("ProtoGalaxyProver::finalise_and_send_instance");
     OinkProver<Flavor> oink_prover(instance->proving_key, transcript, domain_separator + '_');
 
     auto [proving_key, relation_params, alphas] = oink_prover.prove();
@@ -408,7 +409,12 @@ template <class ProverInstances> void ProtoGalaxyProver_<ProverInstances>::accum
 template <class ProverInstances>
 FoldingResult<typename ProverInstances::Flavor> ProtoGalaxyProver_<ProverInstances>::prove()
 {
+<<<<<<< Updated upstream
     BB_OP_COUNT_TIME_NAME("ProtogalaxyProver::prove");
+=======
+    ZoneScopedN("ProtogalaxyProver::prove");
+    BB_OP_COUNT_TIME_NAME("ProtogalaxyProver::prove");
+>>>>>>> Stashed changes
     // Ensure instances are all of the same size
     for (size_t idx = 0; idx < ProverInstances::NUM - 1; ++idx) {
         if (instances[idx]->proving_key.circuit_size != instances[idx + 1]->proving_key.circuit_size) {

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -409,12 +409,8 @@ template <class ProverInstances> void ProtoGalaxyProver_<ProverInstances>::accum
 template <class ProverInstances>
 FoldingResult<typename ProverInstances::Flavor> ProtoGalaxyProver_<ProverInstances>::prove()
 {
-<<<<<<< Updated upstream
-    BB_OP_COUNT_TIME_NAME("ProtogalaxyProver::prove");
-=======
     ZoneScopedN("ProtogalaxyProver::prove");
     BB_OP_COUNT_TIME_NAME("ProtogalaxyProver::prove");
->>>>>>> Stashed changes
     // Ensure instances are all of the same size
     for (size_t idx = 0; idx < ProverInstances::NUM - 1; ++idx) {
         if (instances[idx]->proving_key.circuit_size != instances[idx + 1]->proving_key.circuit_size) {

--- a/barretenberg/cpp/src/barretenberg/srs/factories/file_crs_factory.cpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/file_crs_factory.cpp
@@ -56,6 +56,7 @@ template <typename Curve>
 std::shared_ptr<bb::srs::factories::ProverCrs<Curve>> FileCrsFactory<Curve>::get_prover_crs(size_t degree)
 {
     if (degree != degree_ || !prover_crs_) {
+        ZoneScopedN("get_prover_crs");
         prover_crs_ = std::make_shared<FileProverCrs<Curve>>(degree, path_);
         degree_ = degree;
     }

--- a/barretenberg/cpp/src/barretenberg/srs/factories/file_crs_factory.hpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/file_crs_factory.hpp
@@ -43,6 +43,7 @@ template <typename Curve> class FileProverCrs : public ProverCrs<Curve> {
     FileProverCrs(const size_t num_points, std::string const& path)
         : num_points(num_points)
     {
+        ZoneScopedN("FileProverCrs constructor");
         monomials_ = scalar_multiplication::point_table_alloc<typename Curve::AffineElement>(num_points);
 
         srs::IO<Curve>::read_transcript_g1(monomials_.get(), num_points, path);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
@@ -551,6 +551,7 @@ class UltraFlavor {
         PartiallyEvaluatedMultivariates() = default;
         PartiallyEvaluatedMultivariates(const size_t circuit_size)
         {
+            ZoneScopedN("PartiallyEvaluatedMultivariates constructor");
             // Storage is only needed after the first partial evaluation, hence polynomials of
             // size (n / 2)
             for (auto& poly : this->get_all()) {

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
@@ -66,6 +66,7 @@ template <typename Flavor> class SumcheckProverRound {
     SumcheckProverRound(size_t initial_round_size)
         : round_size(initial_round_size)
     {
+        ZoneScopedN("SumcheckProverRound constructor");
         // Initialize univariate accumulators to 0
         Utils::zero_univariates(univariate_accumulators);
     }
@@ -160,6 +161,7 @@ template <typename Flavor> class SumcheckProverRound {
         const RelationSeparator alpha,
         std::optional<ZKSumcheckData<Flavor>> zk_sumcheck_data = std::nullopt) // only submitted when Flavor HasZK
     {
+        ZoneScopedN("compute_univariate");
         BB_OP_COUNT_TIME();
 
         // Determine number of threads for multithreading.

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_prover.cpp
@@ -30,7 +30,10 @@ template <IsUltraFlavor Flavor> void DeciderProver_<Flavor>::execute_relation_ch
     using Sumcheck = SumcheckProver<Flavor>;
     auto instance_size = accumulator->proving_key.circuit_size;
     auto sumcheck = Sumcheck(instance_size, transcript);
-    sumcheck_output = sumcheck.prove(accumulator);
+    {
+        ZoneScopedN("sumcheck.prove");
+        sumcheck_output = sumcheck.prove(accumulator);
+    }
 }
 
 /**


### PR DESCRIPTION
This PR reduces max memory by roughly a third by deleting a prover_instance member variable in client_ivc. Before, we were storing this prover_instance, which meant that when we accumulate a third circuit, we were storing three instances at the same time - the accumulator, the old instance, and the new instance. It also adjusts the test (ClientIVCTests.BasicThree) to only store the builder for when it's needed.

This is the original memory graph when running ClientIVCTests.BasicThree, which accumulates three circuits of size 2^17 (?).
<img width="735" alt="Before" src="https://github.com/user-attachments/assets/66bed03b-3692-4bb2-b176-b6772bdcb27e">

After freeing the Builder after constructing the instance from it, and after freeing the instance after folding it into the accumulator, our memory graph looks like.
<img width="700" alt="After" src="https://github.com/user-attachments/assets/13f4432c-cfc3-4095-aa6d-908a244aa6b5">

You can see that the peak memory goes from 1216MB to 774MB, and that we're no longer storing 3 instances worth of data at one time.
