### PR TITLE
fix: stop WorldStrateSynchronizer in prover node

### DIFF
--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -67,6 +67,7 @@ export class ProverNode {
     await this.l2BlockSource.stop();
     this.publisher.interrupt();
     this.jobs.forEach(job => job.stop());
+    await this.worldState.stop();
     this.log.info('Stopped ProverNode');
   }
 


### PR DESCRIPTION
Stop world state instance used by prover-node when node is shutdown
