### PR TITLE
refactor: disallow prune in devnet + add onlyOwners

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -110,6 +110,10 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
    * @dev     Will revert if there is nothing to prune or if the chain is not ready to be pruned
    */
   function prune() external override(IRollup) {
+    if (isDevNet) {
+      revert Errors.DevNet__NoPruningAllowed();
+    }
+
     if (pendingBlockCount == provenBlockCount) {
       revert Errors.Rollup__NothingToPrune();
     }
@@ -159,7 +163,7 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
    *
    * @param _devNet - Whether or not the contract is in devnet mode
    */
-  function setDevNet(bool _devNet) external override(ITestRollup) {
+  function setDevNet(bool _devNet) external override(ITestRollup) onlyOwner {
     isDevNet = _devNet;
   }
 
@@ -170,7 +174,7 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
    *
    * @param _verifier - The new verifier contract
    */
-  function setVerifier(address _verifier) external override(ITestRollup) {
+  function setVerifier(address _verifier) external override(ITestRollup) onlyOwner {
     verifier = IVerifier(_verifier);
   }
 
@@ -181,7 +185,7 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
    *
    * @param _vkTreeRoot - The new vkTreeRoot to be used by proofs
    */
-  function setVkTreeRoot(bytes32 _vkTreeRoot) external override(ITestRollup) {
+  function setVkTreeRoot(bytes32 _vkTreeRoot) external override(ITestRollup) onlyOwner {
     vkTreeRoot = _vkTreeRoot;
   }
 

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -10,6 +10,9 @@ pragma solidity >=0.8.18;
  * when there are multiple contracts that could have thrown the error.
  */
 library Errors {
+  // DEVNET related
+  error DevNet__NoPruningAllowed(); // 0x6984c590
+
   // Inbox
   error Inbox__Unauthorized(); // 0xe5336a6b
   error Inbox__ActorTooLarge(bytes32 actor); // 0xa776a06e

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -79,6 +79,13 @@ contract RollupTest is DecoderBase {
   }
 
   function testRevertPrune() public setUpFor("mixed_block_1") {
+    if (rollup.isDevNet()) {
+      vm.expectRevert(abi.encodeWithSelector(Errors.DevNet__NoPruningAllowed.selector));
+      rollup.prune();
+
+      return;
+    }
+
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__NothingToPrune.selector));
     rollup.prune();
 
@@ -95,6 +102,10 @@ contract RollupTest is DecoderBase {
   }
 
   function testPrune() public setUpFor("mixed_block_1") {
+    if (rollup.isDevNet()) {
+      return;
+    }
+
     _testBlock("mixed_block_1", false);
 
     assertEq(inbox.inProgress(), 3, "Invalid in progress");


### PR DESCRIPTION
Fixes #8103. 

Disallow pruning when in devnet, and adds `onlyOwner` modifier to `setDevNet`, `setVerifier` and `setVkTreeRoot`.