### PR TITLE
feat: removed socat, fixed aztec-run

### DIFF
--- a/aztec-up/bin/.aztec-run
+++ b/aztec-up/bin/.aztec-run
@@ -120,12 +120,23 @@ if [[ -z "${SKIP_PORT_ASSIGNMENT:-}" ]]; then
   port_assignment="-p $AZTEC_PORT:$AZTEC_PORT"
 fi
 
-if [[ "$ENV_VARS_TO_INJECT" == *"SSH_AUTH_SOCK"* && -n "${SSH_AUTH_SOCK:-}" ]]; then
-  warn "SSH_AUTH_SOCK is set to ${SSH_AUTH_SOCK:-}. Enabling SSH agent forwarding via socat"
-  socat TCP-LISTEN:${SSH_AUTH_SOCK_SOCAT_PORT:-12345},reuseaddr,fork UNIX-CLIENT:$SSH_AUTH_SOCK &
-  SOCAT_PID=$!
-  trap "kill -9 $SOCAT_PID" SIGINT SIGTERM EXIT
-  DOCKER_ENV+=" -e SSH_AUTH_SOCK_SOCAT_PORT=${SSH_AUTH_SOCK_SOCAT_PORT:-12345}"
+ssh_agent_socket_mount=""
+if [[ "${ENV_VARS_TO_INJECT:-}" == *"SSH_AUTH_SOCK"* && -n "${SSH_AUTH_SOCK:-}" ]]; then
+  warn "SSH_AUTH_SOCK is set to ${SSH_AUTH_SOCK:-}. Attempting to enable SSH agent forwarding"
+
+  if [[ "$UNAME" == "Darwin" ]]; then
+    if ! command -v socat &> /dev/null; then
+      warn "Socat is not installed. To make SSH agent forwarding work in MacOS, please run:\n\nbrew install socat\n"
+    else
+      socat TCP-LISTEN:${SSH_AUTH_SOCK_SOCAT_PORT:-12345},reuseaddr,fork UNIX-CLIENT:$SSH_AUTH_SOCK &
+      SOCAT_PID=$!
+      trap "kill -9 $SOCAT_PID" SIGINT SIGTERM EXIT
+      DOCKER_ENV+=" -e SSH_AUTH_SOCK_SOCAT_PORT=${SSH_AUTH_SOCK_SOCAT_PORT:-12345}"
+    fi
+  else
+    DOCKER_ENV+=" -e SSH_AUTH_SOCK=${SSH_AUTH_SOCK}"
+    ssh_agent_socket_mount="-v $SSH_AUTH_SOCK:$SSH_AUTH_SOCK"
+  fi
 fi
 
 docker run \
@@ -134,6 +145,7 @@ docker run \
   --workdir "$PWD" \
   -v $HOME:$HOME -v cache:/cache \
   $port_assignment \
+  $ssh_agent_socket_mount \
   ${DOCKER_ENV:-} \
   ${DOCKER_HOST_BINDS:-} \
   ${DOCKER_USER:-} \

--- a/aztec-up/bin/aztec-install
+++ b/aztec-up/bin/aztec-install
@@ -75,11 +75,6 @@ if ! command -v docker &>/dev/null; then
   exit 1
 fi
 
-if ! command -v socat &> /dev/null; then
-  echo "Socat is not installed. Please install socat and try again."
-  exit 1
-fi
-
 # Check if Docker is running.
 if ! docker info &>/dev/null; then
   warn "Docker is not running. Please start Docker and try again."

--- a/yarn-project/cli-wallet/wallet-entrypoint.sh
+++ b/yarn-project/cli-wallet/wallet-entrypoint.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-
-cleanup() {
-    kill -9 $SOCAT_PID
-    rm -rf $SOCKET
-}
-
 if [[ -n "${SSH_AUTH_SOCK_SOCAT_PORT:-}" ]]; then
+    cleanup() {
+        kill -9 $SOCAT_PID
+        rm -rf $SOCKET
+    }
+
     SOCKET="$HOME/.aztec/aztec-wallet-$RANDOM.sock"
     socat UNIX-LISTEN:$SOCKET,fork TCP:host.docker.internal:${SSH_AUTH_SOCK_SOCAT_PORT} &
     SOCAT_PID=$!
     trap cleanup EXIT SIGKILL SIGTERM
+    export SSH_AUTH_SOCK="${SOCKET:-}"
 fi
 
-SSH_AUTH_SOCK="${SOCKET:-}" node --no-warnings /usr/src/yarn-project/cli-wallet/dest/bin/index.js $@
+node --no-warnings /usr/src/yarn-project/cli-wallet/dest/bin/index.js $@


### PR DESCRIPTION
Removes socat as dependency for aztec bins, only complaining in case the user is using a mac and wants to access the SSH functionality of the wallet.