### PR TITLE
chore: Oink takes directly populates an instance

### DIFF
--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk_rounds.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk_rounds.bench.cpp
@@ -46,15 +46,13 @@ BB_PROFILE static void test_round_inner(State& state, MegaProver& prover, size_t
             BB_REPORT_OP_COUNT_BENCH_CANCEL();
         }
     };
-    OinkProver<MegaFlavor> oink_prover(prover.instance->proving_key, prover.transcript);
+    OinkProver<MegaFlavor> oink_prover(prover.instance, prover.transcript);
     time_if_index(PREAMBLE, [&] { oink_prover.execute_preamble_round(); });
     time_if_index(WIRE_COMMITMENTS, [&] { oink_prover.execute_wire_commitments_round(); });
     time_if_index(SORTED_LIST_ACCUMULATOR, [&] { oink_prover.execute_sorted_list_accumulator_round(); });
     time_if_index(LOG_DERIVATIVE_INVERSE, [&] { oink_prover.execute_log_derivative_inverse_round(); });
     time_if_index(GRAND_PRODUCT_COMPUTATION, [&] { oink_prover.execute_grand_product_computation_round(); });
     time_if_index(GENERATE_ALPHAS, [&] { prover.instance->alphas = oink_prover.generate_alphas_round(); });
-    // we need to get the relation_parameters and prover_polynomials from the oink_prover
-    prover.instance->relation_parameters = oink_prover.relation_parameters;
 
     prover.generate_gate_challenges();
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -218,12 +218,9 @@ void ProtoGalaxyProver_<ProverInstances>::finalise_and_send_instance(std::shared
                                                                      const std::string& domain_separator)
 {
     ZoneScopedN("ProtoGalaxyProver::finalise_and_send_instance");
-    OinkProver<Flavor> oink_prover(instance->proving_key, transcript, domain_separator + '_');
+    OinkProver<Flavor> oink_prover(instance, transcript, domain_separator + '_');
 
-    auto [proving_key, relation_params, alphas] = oink_prover.prove();
-    instance->proving_key = std::move(proving_key);
-    instance->relation_parameters = std::move(relation_params);
-    instance->alphas = std::move(alphas);
+    oink_prover.prove();
 }
 
 template <class ProverInstances> void ProtoGalaxyProver_<ProverInstances>::prepare_for_folding()

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -9,13 +9,8 @@ template <class VerifierInstances>
 void ProtoGalaxyVerifier_<VerifierInstances>::receive_and_finalise_instance(const std::shared_ptr<Instance>& inst,
                                                                             const std::string& domain_separator)
 {
-    auto& key = inst->verification_key;
-    OinkVerifier<Flavor> oink_verifier{ key, transcript, domain_separator + '_' };
-    auto [relation_parameters, witness_commitments, public_inputs, alphas] = oink_verifier.verify();
-    inst->relation_parameters = std::move(relation_parameters);
-    inst->witness_commitments = std::move(witness_commitments);
-    inst->public_inputs = std::move(public_inputs);
-    inst->alphas = std::move(alphas);
+    OinkVerifier<Flavor> oink_verifier{ inst, transcript, domain_separator + '_' };
+    oink_verifier.verify();
 }
 
 template <class VerifierInstances>

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
@@ -9,10 +9,10 @@ namespace bb::stdlib::recursion::honk {
 
 template <typename Flavor>
 OinkRecursiveVerifier_<Flavor>::OinkRecursiveVerifier_(Builder* builder,
-                                                       const std::shared_ptr<VerificationKey>& vkey,
+                                                       const std::shared_ptr<Instance>& instance,
                                                        std::shared_ptr<Transcript> transcript,
                                                        std::string domain_separator)
-    : key(vkey)
+    : instance(instance)
     , builder(builder)
     , transcript(transcript)
     , domain_separator(std::move(domain_separator))
@@ -22,7 +22,7 @@ OinkRecursiveVerifier_<Flavor>::OinkRecursiveVerifier_(Builder* builder,
  * @brief This function constructs a recursive verifier circuit for a native Ultra Honk proof of a given flavor.
  * @return Output aggregation object
  */
-template <typename Flavor> OinkRecursiveVerifier_<Flavor>::Output OinkRecursiveVerifier_<Flavor>::verify()
+template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
 {
     using CommitmentLabels = typename Flavor::CommitmentLabels;
     using RelationParams = ::bb::RelationParameters<FF>;
@@ -42,7 +42,7 @@ template <typename Flavor> OinkRecursiveVerifier_<Flavor>::Output OinkRecursiveV
     // ASSERT(static_cast<uint32_t>(pub_inputs_offset.get_value()) == key->pub_inputs_offset);
 
     std::vector<FF> public_inputs;
-    for (size_t i = 0; i < key->num_public_inputs; ++i) {
+    for (size_t i = 0; i < instance->verification_key->num_public_inputs; ++i) {
         public_inputs.emplace_back(
             transcript->template receive_from_prover<FF>(domain_separator + "public_input_" + std::to_string(i)));
     }
@@ -90,7 +90,7 @@ template <typename Flavor> OinkRecursiveVerifier_<Flavor>::Output OinkRecursiveV
     }
 
     const FF public_input_delta = compute_public_input_delta<Flavor>(
-        public_inputs, beta, gamma, circuit_size, static_cast<uint32_t>(key->pub_inputs_offset));
+        public_inputs, beta, gamma, circuit_size, static_cast<uint32_t>(instance->verification_key->pub_inputs_offset));
 
     relation_parameters = RelationParameters<FF>{ eta, eta_two, eta_three, beta, gamma, public_input_delta };
 
@@ -101,11 +101,6 @@ template <typename Flavor> OinkRecursiveVerifier_<Flavor>::Output OinkRecursiveV
     for (size_t idx = 0; idx < alphas.size(); idx++) {
         alphas[idx] = transcript->template get_challenge<FF>(domain_separator + "alpha_" + std::to_string(idx));
     }
-
-    return { .relation_parameters = relation_parameters,
-             .commitments = std::move(commitments),
-             .public_inputs = public_inputs,
-             .alphas = alphas };
 }
 
 template class OinkRecursiveVerifier_<bb::UltraRecursiveFlavor_<UltraCircuitBuilder>>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
@@ -25,9 +25,7 @@ OinkRecursiveVerifier_<Flavor>::OinkRecursiveVerifier_(Builder* builder,
 template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
 {
     using CommitmentLabels = typename Flavor::CommitmentLabels;
-    using RelationParams = ::bb::RelationParameters<FF>;
 
-    RelationParams relation_parameters;
     WitnessCommitments commitments;
     CommitmentLabels labels;
 
@@ -92,8 +90,6 @@ template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
     const FF public_input_delta = compute_public_input_delta<Flavor>(
         public_inputs, beta, gamma, circuit_size, static_cast<uint32_t>(instance->verification_key->pub_inputs_offset));
 
-    relation_parameters = RelationParameters<FF>{ eta, eta_two, eta_three, beta, gamma, public_input_delta };
-
     // Get commitment to permutation and lookup grand products
     commitments.z_perm = transcript->template receive_from_prover<Commitment>(domain_separator + labels.z_perm);
 
@@ -101,6 +97,11 @@ template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
     for (size_t idx = 0; idx < alphas.size(); idx++) {
         alphas[idx] = transcript->template get_challenge<FF>(domain_separator + "alpha_" + std::to_string(idx));
     }
+
+    instance->relation_parameters = RelationParameters<FF>{ eta, eta_two, eta_three, beta, gamma, public_input_delta };
+    instance->witness_commitments = std::move(commitments);
+    instance->public_inputs = std::move(public_inputs);
+    instance->alphas = std::move(alphas);
 }
 
 template class OinkRecursiveVerifier_<bb::UltraRecursiveFlavor_<UltraCircuitBuilder>>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "barretenberg/stdlib/protogalaxy_verifier/recursive_verifier_instance.hpp"
 #include "barretenberg/stdlib/transcript/transcript.hpp"
 #include "barretenberg/stdlib_circuit_builders/mega_recursive_flavor.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_recursive_flavor.hpp"
@@ -10,27 +11,21 @@ template <typename Flavor> class OinkRecursiveVerifier_ {
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
     using GroupElement = typename Flavor::GroupElement;
+    using Instance = RecursiveVerifierInstance_<Flavor>;
     using VerificationKey = typename Flavor::VerificationKey;
     using Builder = typename Flavor::CircuitBuilder;
     using RelationSeparator = typename Flavor::RelationSeparator;
     using Transcript = bb::BaseTranscript<bb::stdlib::recursion::honk::StdlibTranscriptParams<Builder>>;
     using WitnessCommitments = typename Flavor::WitnessCommitments;
 
-    struct Output {
-        bb::RelationParameters<typename Flavor::FF> relation_parameters;
-        WitnessCommitments commitments;
-        std::vector<typename Flavor::FF> public_inputs;
-        typename Flavor::RelationSeparator alphas;
-    };
-
     explicit OinkRecursiveVerifier_(Builder* builder,
-                                    const std::shared_ptr<VerificationKey>& vkey,
+                                    const std::shared_ptr<Instance>& instance,
                                     std::shared_ptr<Transcript> transcript,
                                     std::string domain_separator = "");
 
-    Output verify();
+    void verify();
 
-    std::shared_ptr<VerificationKey> key;
+    std::shared_ptr<Instance> instance;
     Builder* builder;
     std::shared_ptr<Transcript> transcript;
     std::string domain_separator; // used in PG to distinguish between instances in transcript

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.hpp
@@ -13,6 +13,7 @@ template <typename Flavor> class UltraRecursiveVerifier_ {
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
     using GroupElement = typename Flavor::GroupElement;
+    using Instance = RecursiveVerifierInstance_<Flavor>;
     using VerificationKey = typename Flavor::VerificationKey;
     using NativeVerificationKey = typename Flavor::NativeVerificationKey;
     using VerifierCommitmentKey = typename Flavor::VerifierCommitmentKey;

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -9,12 +9,8 @@ void ProtoGalaxyRecursiveVerifier_<VerifierInstances>::receive_and_finalise_inst
     const std::shared_ptr<Instance>& inst, std::string& domain_separator)
 {
     domain_separator = domain_separator + "_";
-    OinkVerifier oink_verifier{ builder, inst->verification_key, transcript, domain_separator };
-    auto [relation_parameters, witness_commitments, public_inputs, alphas] = oink_verifier.verify();
-    inst->relation_parameters = std::move(relation_parameters);
-    inst->witness_commitments = std::move(witness_commitments);
-    inst->public_inputs = std::move(public_inputs);
-    inst->alphas = std::move(alphas);
+    OinkVerifier oink_verifier{ builder, inst, transcript, domain_separator };
+    oink_verifier.verify();
 }
 
 // TODO(https://github.com/AztecProtocol/barretenberg/issues/795): The rounds prior to actual verifying are common

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
@@ -2,12 +2,12 @@
 // clang-format off
 /*                                            )\   /|
 *                                          .-/'-|_/ |
-*                       __            __,-' (   / \/          
-*                   .-'"  "'-..__,-'""          -o.`-._   
+*                       __            __,-' (   / \/
+*                   .-'"  "'-..__,-'""          -o.`-._
 *                  /                                   '/
-*          *--._ ./                                 _.-- 
-*                |                              _.-' 
-*                :                           .-/   
+*          *--._ ./                                 _.--
+*                |                              _.-'
+*                :                           .-/
 *                 \                       )_ /
 *                  \                _)   / \(
 *                    `.   /-.___.---'(  /   \\
@@ -22,15 +22,10 @@
 #include "barretenberg/stdlib_circuit_builders/mega_flavor.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_flavor.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_keccak.hpp"
+#include "barretenberg/sumcheck/instance/prover_instance.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 
 namespace bb {
-template <IsUltraFlavor Flavor> struct OinkProverOutput {
-    typename Flavor::ProvingKey proving_key;
-    bb::RelationParameters<typename Flavor::FF> relation_parameters;
-    typename Flavor::RelationSeparator alphas;
-};
-
 /**
  * @brief Class for all the oink rounds, which are shared between the folding prover and ultra prover.
  * @details This class contains execute_preamble_round(), execute_wire_commitments_round(),
@@ -41,12 +36,12 @@ template <IsUltraFlavor Flavor> struct OinkProverOutput {
  */
 template <IsUltraFlavor Flavor> class OinkProver {
     using CommitmentKey = typename Flavor::CommitmentKey;
-    using ProvingKey = typename Flavor::ProvingKey;
+    using Instance = ProverInstance_<Flavor>;
     using Transcript = typename Flavor::Transcript;
     using FF = typename Flavor::FF;
 
   public:
-    ProvingKey proving_key;
+    std::shared_ptr<Instance> instance;
     std::shared_ptr<Transcript> transcript;
     std::shared_ptr<CommitmentKey> commitment_key;
     std::string domain_separator;
@@ -54,18 +49,16 @@ template <IsUltraFlavor Flavor> class OinkProver {
     typename Flavor::CommitmentLabels commitment_labels;
     using RelationSeparator = typename Flavor::RelationSeparator;
 
-    bb::RelationParameters<typename Flavor::FF> relation_parameters;
-
-    OinkProver(ProvingKey& proving_key,
+    OinkProver(std::shared_ptr<Instance> instance,
                const std::shared_ptr<typename Flavor::Transcript>& transcript,
                std::string domain_separator = "")
-        : proving_key(std::move(proving_key))
+        : instance(instance)
         , transcript(transcript)
-        , commitment_key(this->proving_key.commitment_key)
+        , commitment_key(this->instance->proving_key.commitment_key)
         , domain_separator(std::move(domain_separator))
     {}
 
-    OinkProverOutput<Flavor> prove();
+    void prove();
     void execute_preamble_round();
     void execute_wire_commitments_round();
     void execute_sorted_list_accumulator_round();

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
@@ -9,7 +9,7 @@ namespace bb {
  * @tparam Flavor
  * @return OinkOutput<Flavor>
  */
-template <IsUltraFlavor Flavor> OinkOutput<Flavor> OinkVerifier<Flavor>::verify()
+template <IsUltraFlavor Flavor> void OinkVerifier<Flavor>::verify()
 {
     // Execute the Verifier rounds
     execute_preamble_round();
@@ -17,12 +17,11 @@ template <IsUltraFlavor Flavor> OinkOutput<Flavor> OinkVerifier<Flavor>::verify(
     execute_sorted_list_accumulator_round();
     execute_log_derivative_inverse_round();
     execute_grand_product_computation_round();
-    RelationSeparator alphas = generate_alphas_round();
 
-    return OinkOutput<Flavor>{ .relation_parameters = relation_parameters,
-                               .commitments = std::move(witness_comms),
-                               .public_inputs = public_inputs,
-                               .alphas = alphas };
+    instance->witness_commitments = witness_comms;
+    instance->relation_parameters = relation_parameters;
+    instance->public_inputs = public_inputs;
+    instance->alphas = generate_alphas_round();
 }
 
 /**
@@ -38,13 +37,13 @@ template <IsUltraFlavor Flavor> void OinkVerifier<Flavor>::execute_preamble_roun
     const auto pub_inputs_offset =
         transcript->template receive_from_prover<uint32_t>(domain_separator + "pub_inputs_offset");
 
-    if (circuit_size != key->circuit_size) {
+    if (circuit_size != instance->verification_key->circuit_size) {
         throw_or_abort("OinkVerifier::execute_preamble_round: proof circuit size does not match verification key!");
     }
-    if (public_input_size != key->num_public_inputs) {
+    if (public_input_size != instance->verification_key->num_public_inputs) {
         throw_or_abort("OinkVerifier::execute_preamble_round: public inputs size does not match verification key!");
     }
-    if (pub_inputs_offset != key->pub_inputs_offset) {
+    if (pub_inputs_offset != instance->verification_key->pub_inputs_offset) {
         throw_or_abort("OinkVerifier::execute_preamble_round: public inputs offset does not match verification key!");
     }
 
@@ -132,11 +131,12 @@ template <IsUltraFlavor Flavor> void OinkVerifier<Flavor>::execute_log_derivativ
  */
 template <IsUltraFlavor Flavor> void OinkVerifier<Flavor>::execute_grand_product_computation_round()
 {
-    const FF public_input_delta = compute_public_input_delta<Flavor>(public_inputs,
-                                                                     relation_parameters.beta,
-                                                                     relation_parameters.gamma,
-                                                                     key->circuit_size,
-                                                                     static_cast<size_t>(key->pub_inputs_offset));
+    const FF public_input_delta =
+        compute_public_input_delta<Flavor>(public_inputs,
+                                           relation_parameters.beta,
+                                           relation_parameters.gamma,
+                                           instance->verification_key->circuit_size,
+                                           static_cast<size_t>(instance->verification_key->pub_inputs_offset));
 
     relation_parameters.public_input_delta = public_input_delta;
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.hpp
@@ -6,15 +6,9 @@
 #include "barretenberg/stdlib_circuit_builders/mega_flavor.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_flavor.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_keccak.hpp"
+#include "barretenberg/sumcheck/instance/verifier_instance.hpp"
 
 namespace bb {
-
-template <IsUltraFlavor Flavor> struct OinkOutput {
-    bb::RelationParameters<typename Flavor::FF> relation_parameters;
-    typename Flavor::WitnessCommitments commitments;
-    std::vector<typename Flavor::FF> public_inputs;
-    typename Flavor::RelationSeparator alphas;
-};
 
 /**
  * @brief Verifier class for all the presumcheck rounds, which are shared between the folding verifier and ultra
@@ -26,7 +20,7 @@ template <IsUltraFlavor Flavor> struct OinkOutput {
  * @tparam Flavor
  */
 template <IsUltraFlavor Flavor> class OinkVerifier {
-    using VerificationKey = typename Flavor::VerificationKey;
+    using Instance = VerifierInstance_<Flavor>;
     using WitnessCommitments = typename Flavor::WitnessCommitments;
     using Transcript = typename Flavor::Transcript;
     using FF = typename Flavor::FF;
@@ -35,22 +29,22 @@ template <IsUltraFlavor Flavor> class OinkVerifier {
 
   public:
     std::shared_ptr<Transcript> transcript;
-    std::shared_ptr<VerificationKey> key;
+    std::shared_ptr<Instance> instance;
     std::string domain_separator;
     typename Flavor::CommitmentLabels comm_labels;
     bb::RelationParameters<FF> relation_parameters;
     WitnessCommitments witness_comms;
     std::vector<FF> public_inputs;
 
-    OinkVerifier(const std::shared_ptr<VerificationKey>& verifier_key,
+    OinkVerifier(const std::shared_ptr<Instance>& instance,
                  const std::shared_ptr<Transcript>& transcript,
                  std::string domain_separator = "")
         : transcript(transcript)
-        , key(verifier_key)
+        , instance(instance)
         , domain_separator(std::move(domain_separator))
     {}
 
-    OinkOutput<Flavor> verify();
+    void verify();
 
     void execute_preamble_round();
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
@@ -48,11 +48,8 @@ template <IsUltraFlavor Flavor> void UltraProver_<Flavor>::generate_gate_challen
 
 template <IsUltraFlavor Flavor> HonkProof UltraProver_<Flavor>::construct_proof()
 {
-    OinkProver<Flavor> oink_prover(instance->proving_key, transcript);
-    auto [proving_key, relation_params, alphas] = oink_prover.prove();
-    instance->proving_key = std::move(proving_key);
-    instance->relation_parameters = std::move(relation_params);
-    instance->alphas = alphas;
+    OinkProver<Flavor> oink_prover(instance, transcript);
+    oink_prover.prove();
 
     generate_gate_challenges();
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
@@ -15,11 +15,8 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const HonkP
     using FF = typename Flavor::FF;
 
     transcript = std::make_shared<Transcript>(proof);
-    OinkVerifier<Flavor> oink_verifier{ instance->verification_key, transcript };
-    auto [relation_parameters, witness_commitments, public_inputs, alphas] = oink_verifier.verify();
-    instance->relation_parameters = std::move(relation_parameters);
-    instance->witness_commitments = std::move(witness_commitments);
-    instance->alphas = std::move(alphas);
+    OinkVerifier<Flavor> oink_verifier{ instance, transcript };
+    oink_verifier.verify();
 
     for (size_t idx = 0; idx < CONST_PROOF_SIZE_LOG_N; idx++) {
         instance->gate_challenges.emplace_back(


### PR DESCRIPTION
Oink can be thought of as an "instance completer", i.e. when it is done running all of the data that comprises an instance has been created. Up until now the model was to pass oink a reference to a proving key. It would "complete" the proving key in place by populating some witness polynomials then explicitly return the rest of the data comprising an instance (relation_parameters etc.) in a custom struct like `OinkOutput`. The data from this output would then be std::move'd into an instance existing in the external scope.

This PR simplifies this model by simply passing oink an instance (ProverInstance or VerifierInstance) which is "completed" in place throughout oink. IMO this is cleaner and clearer than the half-and-half approach of completing the proving key in place and explicitly returning other data. It also removes a ton of boilerplate for moving data in and out of an instance. I don't love the "input parameter treated as output parameter approach" but unless we refactor Honk/PG to construct proving_key instead of an instance, I think this is preferred. (In that case oink could take a proving_key and return a completed instance).