### PR TITLE
chore: Revert to current date as timestamp for devnet

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -585,19 +585,21 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
       revert Errors.Rollup__InvalidArchive(tipArchive, _header.lastArchive.root);
     }
 
-    uint256 slot = _header.globalVariables.slotNumber;
-    if (slot > type(uint128).max) {
-      revert Errors.Rollup__SlotValueTooLarge(slot);
-    }
+    if (!isDevNet) {
+      uint256 slot = _header.globalVariables.slotNumber;
+      if (slot > type(uint128).max) {
+        revert Errors.Rollup__SlotValueTooLarge(slot);
+      }
 
-    uint256 lastSlot = uint256(blocks[pendingBlockCount - 1].slotNumber);
-    if (slot <= lastSlot) {
-      revert Errors.Rollup__SlotAlreadyInChain(lastSlot, slot);
-    }
+      uint256 lastSlot = uint256(blocks[pendingBlockCount - 1].slotNumber);
+      if (slot <= lastSlot) {
+        revert Errors.Rollup__SlotAlreadyInChain(lastSlot, slot);
+      }
 
-    uint256 timestamp = getTimestampForSlot(slot);
-    if (_header.globalVariables.timestamp != timestamp) {
-      revert Errors.Rollup__InvalidTimestamp(timestamp, _header.globalVariables.timestamp);
+      uint256 timestamp = getTimestampForSlot(slot);
+      if (_header.globalVariables.timestamp != timestamp) {
+        revert Errors.Rollup__InvalidTimestamp(timestamp, _header.globalVariables.timestamp);
+      }
     }
 
     // Check if the data is available using availability oracle (change availability oracle if you want a different DA layer)

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -296,7 +296,11 @@ contract RollupTest is DecoderBase {
 
     availabilityOracle.publish(body);
 
-    vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidTimestamp.selector, realTs, badTs));
+    if (Constants.IS_DEV_NET != 1) {
+      vm.expectRevert(
+        abi.encodeWithSelector(Errors.Rollup__InvalidTimestamp.selector, realTs, badTs)
+      );
+    }
     rollup.process(header, archive, bytes32(0));
   }
 

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -57,7 +57,13 @@ import { getCanonicalFeeJuice } from '@aztec/protocol-contracts/fee-juice';
 import { getCanonicalInstanceDeployer } from '@aztec/protocol-contracts/instance-deployer';
 import { getCanonicalKeyRegistryAddress } from '@aztec/protocol-contracts/key-registry';
 import { getCanonicalMultiCallEntrypointAddress } from '@aztec/protocol-contracts/multi-call-entrypoint';
-import { AggregateTxValidator, DataTxValidator, GlobalVariableBuilder, SequencerClient } from '@aztec/sequencer-client';
+import {
+  AggregateTxValidator,
+  DataTxValidator,
+  type GlobalVariableBuilder,
+  SequencerClient,
+  createGlobalVariableBuilder,
+} from '@aztec/sequencer-client';
 import { PublicProcessorFactory, WASMSimulator, createSimulationProvider } from '@aztec/simulator';
 import { type TelemetryClient } from '@aztec/telemetry-client';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
@@ -195,7 +201,7 @@ export class AztecNodeService implements AztecNode {
       sequencer,
       ethereumChain.chainInfo.id,
       config.version,
-      new GlobalVariableBuilder(config),
+      createGlobalVariableBuilder(config),
       store,
       txValidator,
       telemetry,

--- a/yarn-project/aztec/src/sandbox.ts
+++ b/yarn-project/aztec/src/sandbox.ts
@@ -3,6 +3,7 @@ import { type AztecNodeConfig, AztecNodeService, getConfigEnvVars } from '@aztec
 import { SignerlessWallet } from '@aztec/aztec.js';
 import { DefaultMultiCallEntrypoint } from '@aztec/aztec.js/entrypoint';
 import { type AztecNode } from '@aztec/circuit-types';
+import { IS_DEV_NET } from '@aztec/circuits.js';
 import { deployCanonicalAuthRegistry, deployCanonicalKeyRegistry, deployCanonicalL2FeeJuice } from '@aztec/cli/misc';
 import {
   type DeployL1Contracts,
@@ -133,6 +134,7 @@ export async function deployContractsToL1(
       vkTreeRoot: getVKTreeRoot(),
       assumeProvenUntil: opts.assumeProvenUntilBlockNumber,
       salt: undefined,
+      blockInterval: IS_DEV_NET ? undefined : 12,
     }),
   );
 

--- a/yarn-project/cli/src/utils/aztec.ts
+++ b/yarn-project/cli/src/utils/aztec.ts
@@ -1,6 +1,7 @@
 import { type ContractArtifact, type FunctionArtifact, loadContractArtifact } from '@aztec/aztec.js/abi';
 import { type L1ContractArtifactsForDeployment } from '@aztec/aztec.js/ethereum';
 import { type PXE } from '@aztec/circuit-types';
+import { IS_DEV_NET } from '@aztec/circuits.js';
 import { type DeployL1Contracts } from '@aztec/ethereum';
 import { type EthAddress } from '@aztec/foundation/eth-address';
 import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
@@ -118,6 +119,7 @@ export async function deployAztecContracts(
     l2FeeJuiceAddress: FeeJuiceAddress,
     vkTreeRoot: getVKTreeRoot(),
     salt,
+    blockInterval: IS_DEV_NET ? undefined : 12,
   });
 }
 

--- a/yarn-project/end-to-end/src/fixtures/setup_l1_contracts.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup_l1_contracts.ts
@@ -1,4 +1,5 @@
 import { type DebugLogger, type L1ContractArtifactsForDeployment, deployL1Contracts } from '@aztec/aztec.js';
+import { IS_DEV_NET } from '@aztec/circuits.js';
 import {
   AvailabilityOracleAbi,
   AvailabilityOracleBytecode,
@@ -63,6 +64,7 @@ export const setupL1Contracts = async (
     l2FeeJuiceAddress: FeeJuiceAddress,
     vkTreeRoot: getVKTreeRoot(),
     salt: undefined,
+    blockInterval: IS_DEV_NET ? undefined : 12,
   });
 
   return l1Data;

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -33,6 +33,7 @@ import {
   CANONICAL_AUTH_REGISTRY_ADDRESS,
   CANONICAL_KEY_REGISTRY_ADDRESS,
   GasSettings,
+  IS_DEV_NET,
   MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS,
   computeContractAddressFromInstance,
   getContractClassFromArtifact,
@@ -151,6 +152,7 @@ export const setupL1Contracts = async (
     l2FeeJuiceAddress: FeeJuiceAddress,
     vkTreeRoot: getVKTreeRoot(),
     salt: args.salt,
+    blockInterval: IS_DEV_NET ? undefined : 12,
   });
 
   return l1Data;

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -147,7 +147,13 @@ export const deployL1Contracts = async (
   chain: Chain,
   logger: DebugLogger,
   contractsToDeploy: L1ContractArtifactsForDeployment,
-  args: { l2FeeJuiceAddress: AztecAddress; vkTreeRoot: Fr; assumeProvenUntil?: number; salt: number | undefined },
+  args: {
+    blockInterval: number | undefined;
+    l2FeeJuiceAddress: AztecAddress;
+    vkTreeRoot: Fr;
+    assumeProvenUntil?: number;
+    salt: number | undefined;
+  },
 ): Promise<DeployL1Contracts> => {
   // We are assuming that you are running this on a local anvil node which have 1s block times
   // To align better with actual deployment, we update the block interval to 12s
@@ -161,13 +167,13 @@ export const deployL1Contracts = async (
     };
     return await (await fetch(rpcUrl, content)).json();
   };
-  if (chain.id == foundry.id) {
-    const interval = 12;
-    const res = await rpcCall(rpcUrl, 'anvil_setBlockTimestampInterval', [interval]);
+
+  if (chain.id == foundry.id && args.blockInterval !== undefined) {
+    const res = await rpcCall(rpcUrl, 'anvil_setBlockTimestampInterval', [args.blockInterval]);
     if (res.error) {
       throw new Error(`Error setting block interval: ${res.error.message}`);
     }
-    logger.info(`Set block interval to ${interval}`);
+    logger.info(`Set block interval to ${args.blockInterval}`);
   }
 
   logger.info(`Deploying contracts from ${account.address.toString()}...`);

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -8,7 +8,7 @@ import { type WorldStateSynchronizer } from '@aztec/world-state';
 
 import { BlockBuilderFactory } from '../block_builder/index.js';
 import { type SequencerClientConfig } from '../config.js';
-import { GlobalVariableBuilder } from '../global_variable_builder/index.js';
+import { createGlobalVariableBuilder } from '../global_variable_builder/index.js';
 import { L1Publisher } from '../publisher/index.js';
 import { Sequencer, type SequencerConfig } from '../sequencer/index.js';
 import { TxValidatorFactory } from '../tx_validator/tx_validator_factory.js';
@@ -44,7 +44,7 @@ export class SequencerClient {
     telemetryClient: TelemetryClient,
   ) {
     const publisher = new L1Publisher(config, telemetryClient);
-    const globalsBuilder = new GlobalVariableBuilder(config);
+    const globalsBuilder = createGlobalVariableBuilder(config);
     const merkleTreeDb = worldStateSynchronizer.getLatest();
 
     const publicProcessorFactory = new PublicProcessorFactory(

--- a/yarn-project/sequencer-client/src/global_variable_builder/index.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/index.ts
@@ -1,1 +1,19 @@
-export { GlobalVariableBuilder } from './global_builder.js';
+import { type AztecAddress, type EthAddress, type GlobalVariables } from '@aztec/circuits.js';
+import { IS_DEV_NET } from '@aztec/circuits.js';
+import { type L1ReaderConfig } from '@aztec/ethereum';
+import { type Fr } from '@aztec/foundation/fields';
+
+import { DevnetGlobalVariableBuilder } from './devnet_global_builder.js';
+import { SimpleGlobalVariableBuilder } from './simple_global_builder.js';
+
+export { DevnetGlobalVariableBuilder } from './devnet_global_builder.js';
+export { SimpleGlobalVariableBuilder } from './simple_global_builder.js';
+
+export function createGlobalVariableBuilder(config: L1ReaderConfig): GlobalVariableBuilder {
+  return IS_DEV_NET ? new DevnetGlobalVariableBuilder(config) : new SimpleGlobalVariableBuilder(config);
+}
+
+/** Builds global variables for a block. */
+export interface GlobalVariableBuilder {
+  buildGlobalVariables(blockNumber: Fr, coinbase: EthAddress, feeRecipient: AztecAddress): Promise<GlobalVariables>;
+}

--- a/yarn-project/sequencer-client/src/global_variable_builder/simple_global_builder.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/simple_global_builder.ts
@@ -1,0 +1,88 @@
+import {
+  type AztecAddress,
+  ETHEREUM_SLOT_DURATION,
+  type EthAddress,
+  GasFees,
+  GlobalVariables,
+} from '@aztec/circuits.js';
+import { type L1ReaderConfig, createEthereumChain } from '@aztec/ethereum';
+import { Fr } from '@aztec/foundation/fields';
+import { createDebugLogger } from '@aztec/foundation/log';
+import { RollupAbi } from '@aztec/l1-artifacts';
+
+import {
+  type GetContractReturnType,
+  type HttpTransport,
+  type PublicClient,
+  createPublicClient,
+  getAddress,
+  getContract,
+  http,
+} from 'viem';
+import type * as chains from 'viem/chains';
+
+/**
+ * Simple global variables builder.
+ */
+export class SimpleGlobalVariableBuilder {
+  private log = createDebugLogger('aztec:sequencer:global_variable_builder');
+
+  private rollupContract: GetContractReturnType<typeof RollupAbi, PublicClient<HttpTransport, chains.Chain>>;
+  private publicClient: PublicClient<HttpTransport, chains.Chain>;
+
+  constructor(config: L1ReaderConfig) {
+    const { l1RpcUrl, l1ChainId: chainId, l1Contracts } = config;
+
+    const chain = createEthereumChain(l1RpcUrl, chainId);
+
+    this.publicClient = createPublicClient({
+      chain: chain.chainInfo,
+      transport: http(chain.rpcUrl),
+    });
+
+    this.rollupContract = getContract({
+      address: getAddress(l1Contracts.rollupAddress.toString()),
+      abi: RollupAbi,
+      client: this.publicClient,
+    });
+  }
+
+  /**
+   * Simple builder of global variables that use the minimum time possible.
+   * @param blockNumber - The block number to build global variables for.
+   * @param coinbase - The address to receive block reward.
+   * @param feeRecipient - The address to receive fees.
+   * @returns The global variables for the given block number.
+   */
+  public async buildGlobalVariables(
+    blockNumber: Fr,
+    coinbase: EthAddress,
+    feeRecipient: AztecAddress,
+  ): Promise<GlobalVariables> {
+    const version = new Fr(await this.rollupContract.read.VERSION());
+    const chainId = new Fr(this.publicClient.chain.id);
+
+    const ts = (await this.publicClient.getBlock()).timestamp;
+
+    // Not just the current slot, the slot of the next block.
+    const slot = await this.rollupContract.read.getSlotAt([ts + BigInt(ETHEREUM_SLOT_DURATION)]);
+    const timestamp = await this.rollupContract.read.getTimestampForSlot([slot]);
+
+    const slotFr = new Fr(slot);
+    const timestampFr = new Fr(timestamp);
+
+    const gasFees = GasFees.default();
+    const globalVariables = new GlobalVariables(
+      chainId,
+      version,
+      blockNumber,
+      slotFr,
+      timestampFr,
+      coinbase,
+      feeRecipient,
+      gasFees,
+    );
+    this.log.debug(`Built global variables for block ${blockNumber}`, globalVariables.toJSON());
+    return globalVariables;
+  }
+}

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -35,7 +35,7 @@ import { type MerkleTreeOperations, WorldStateRunningState, type WorldStateSynch
 import { type MockProxy, mock, mockFn } from 'jest-mock-extended';
 
 import { type BlockBuilderFactory } from '../block_builder/index.js';
-import { type GlobalVariableBuilder } from '../global_variable_builder/global_builder.js';
+import { type GlobalVariableBuilder } from '../global_variable_builder/index.js';
 import { type L1Publisher } from '../publisher/l1-publisher.js';
 import { TxValidatorFactory } from '../tx_validator/tx_validator_factory.js';
 import { Sequencer } from './sequencer.js';

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -22,7 +22,7 @@ import { type ValidatorClient } from '@aztec/validator-client';
 import { type WorldStateStatus, type WorldStateSynchronizer } from '@aztec/world-state';
 
 import { type BlockBuilderFactory } from '../block_builder/index.js';
-import { type GlobalVariableBuilder } from '../global_variable_builder/global_builder.js';
+import { type GlobalVariableBuilder } from '../global_variable_builder/index.js';
 import { type L1Publisher } from '../publisher/l1-publisher.js';
 import { type TxValidatorFactory } from '../tx_validator/tx_validator_factory.js';
 import { type SequencerConfig } from './config.js';


### PR DESCRIPTION
When running devnet, using the slot timestamps instead of current timestmap meant that blocks were often generated with a timestamp much into the future. This screwed up settings such as the min and max time between blocks for a sequencer configuration, which relied on L2 timestamps. In addition, the custom block timestamp interval in anvil meant that we could no longer rely on L1 timestamps for measuring time, which was needed for tracking the time between a block being submitted and its proof.

This PR changes timestamps if devnet is set so that we use the current timestamp for building blocks, do not alter anvil's block timestamp, and drop time validations.
