### PR TITLE
Fix typo in token bridge tutorial

### DIFF
--- a/docs/docs/tutorials/codealong/contract_tutorials/advanced/token_bridge/2_minting_on_aztec.md
+++ b/docs/docs/tutorials/codealong/contract_tutorials/advanced/token_bridge/2_minting_on_aztec.md
@@ -6,7 +6,7 @@ In this step we will start writing our Aztec.nr bridge smart contract and write 
 
 ## Initial contract setup
 
-In our `token-bridge` Aztec project in `aztec-contracts`, under `src` there is an example `main.nr` file. Paste this to define imports:
+In our `token_bridge` Aztec project in `aztec-contracts`, under `src` there is an example `main.nr` file. Paste this to define imports:
 
 ```rust
 #include_code token_bridge_imports /noir-projects/noir-contracts/contracts/token_bridge_contract/src/main.nr raw

--- a/docs/docs/tutorials/codealong/contract_tutorials/advanced/token_bridge/4_typescript_glue_code.md
+++ b/docs/docs/tutorials/codealong/contract_tutorials/advanced/token_bridge/4_typescript_glue_code.md
@@ -9,8 +9,7 @@ In this step we will write a Typescript test to interact with the sandbox and ca
 We need some helper files that can keep our code clean. Inside your `src/test` directory:
 
 ```bash
-cd fixtures
-cd .. && mkdir shared && cd shared
+mkdir shared && cd shared
 touch cross_chain_test_harness.ts
 ```
 


### PR DESCRIPTION
Changes `token-bridge` to `token_bridge`.

Resolves: #8199 
