### PR TITLE
chore: Configure interval mining for anvil

### DIFF
--- a/docker-compose.provernet.yml
+++ b/docker-compose.provernet.yml
@@ -3,12 +3,12 @@
 # Logs latest block numbers every 10 seconds.
 name: aztec-provernet
 services:
-  
+
   # Anvil instance that serves as L1
   ethereum:
     image: ghcr.io/foundry-rs/foundry@sha256:29ba6e34379e79c342ec02d437beb7929c9e254261e8032b17e187be71a2609f
     command: >
-      'anvil --host 0.0.0.0 --chain-id 31337 --port 8545 --silent'
+      'anvil --block-time 12 --host 0.0.0.0 --chain-id 31337 --port 8545 --silent'
     ports:
       - 8545:8545
 

--- a/helm-charts/aztec-network/templates/anvil.deployment.yaml
+++ b/helm-charts/aztec-network/templates/anvil.deployment.yaml
@@ -25,8 +25,8 @@ spec:
             - |
               [ -n "$FORK_URL" ] && ARGS="$ARGS --fork-url $FORK_URL";
               [ -n "$FORK_BLOCK_NUMBER" ] && ARGS="$ARGS --fork-block-number $FORK_BLOCK_NUMBER";
-              echo anvil -p $ANVIL_PORT --host 0.0.0.0 --chain-id {{ .Values.ethereum.chainId }} $ARGS;
-              anvil -p $ANVIL_PORT --host 0.0.0.0 --chain-id {{ .Values.ethereum.chainId }} $ARGS;
+              echo anvil --block-time 12 -p $ANVIL_PORT --host 0.0.0.0 --chain-id {{ .Values.ethereum.chainId }} $ARGS;
+              anvil --block-time 12 -p $ANVIL_PORT --host 0.0.0.0 --chain-id {{ .Values.ethereum.chainId }} $ARGS;
           ports:
             - containerPort: {{ .Values.ethereum.service.port }}
               name: anvil

--- a/iac/mainnet-fork/scripts/run_nginx_anvil.sh
+++ b/iac/mainnet-fork/scripts/run_nginx_anvil.sh
@@ -22,7 +22,7 @@ echo "result: ${MNEMONIC_STRIPPED:0:10}..."
 mkdir -p /data
 
 # Run anvil silently
-.foundry/bin/anvil --silent --host $HOST -p $PORT -m "$MNEMONIC_STRIPPED" -f=https://mainnet.infura.io/v3/$INFURA_API_KEY --chain-id=$L1_CHAIN_ID --fork-block-number=15918000 --block-base-fee-per-gas=10 -s=$SNAPSHOT_FREQUENCY --state=./data/state --balance=1000000000000000000 >/dev/null &
+.foundry/bin/anvil --silent --block-time 12 --host $HOST -p $PORT -m "$MNEMONIC_STRIPPED" -f=https://mainnet.infura.io/v3/$INFURA_API_KEY --chain-id=$L1_CHAIN_ID --fork-block-number=15918000 --block-base-fee-per-gas=10 -s=$SNAPSHOT_FREQUENCY --state=./data/state --balance=1000000000000000000 >/dev/null &
 
 echo "Waiting for ethereum host at $ETHEREUM_HOST..."
 while ! curl -s $ETHEREUM_HOST >/dev/null; do sleep 1; done


### PR DESCRIPTION
For all setups that are not e2e tests, sets up anvil to use 12-second block times interval mining, as opposed to automine. This will make setup a bit slower unfortunately, but will reduce divergence with the work on block building.
