### PR TITLE
fix: Export brillig names in contract functions

### DIFF
--- a/noir-projects/noir-contracts/extractFunctionAsNoirArtifact.js
+++ b/noir-projects/noir-contracts/extractFunctionAsNoirArtifact.js
@@ -32,6 +32,7 @@ async function main() {
     debug_symbols: func.debug_symbols,
     file_map: contractArtifact.file_map,
     names: ["main"],
+    brillig_names: func.brillig_names,
   };
 
   const outputDir = path.dirname(contractArtifactPath);

--- a/noir/noir-repo/compiler/noirc_driver/src/contract.rs
+++ b/noir/noir-repo/compiler/noirc_driver/src/contract.rs
@@ -57,4 +57,7 @@ pub struct ContractFunction {
 
     /// Names of the functions in the program. These are used for more informative debugging and benchmarking.
     pub names: Vec<String>,
+
+    /// Names of the unconstrained functions in the program.
+    pub brillig_names: Vec<String>,
 }

--- a/noir/noir-repo/compiler/noirc_driver/src/lib.rs
+++ b/noir/noir-repo/compiler/noirc_driver/src/lib.rs
@@ -469,6 +469,7 @@ fn compile_contract_inner(
             debug: function.debug,
             is_unconstrained: modifiers.is_unconstrained,
             names: function.names,
+            brillig_names: function.brillig_names,
         });
     }
 

--- a/noir/noir-repo/tooling/noirc_artifacts/src/contract.rs
+++ b/noir/noir-repo/tooling/noirc_artifacts/src/contract.rs
@@ -72,6 +72,8 @@ pub struct ContractFunctionArtifact {
         deserialize_with = "ProgramDebugInfo::deserialize_compressed_base64_json"
     )]
     pub debug_symbols: ProgramDebugInfo,
+
+    pub brillig_names: Vec<String>,
 }
 
 impl From<ContractFunction> for ContractFunctionArtifact {
@@ -82,6 +84,7 @@ impl From<ContractFunction> for ContractFunctionArtifact {
             custom_attributes: func.custom_attributes,
             abi: func.abi,
             bytecode: func.bytecode,
+            brillig_names: func.brillig_names,
             debug_symbols: ProgramDebugInfo { debug_infos: func.debug },
         }
     }


### PR DESCRIPTION
We need to export brillig_names in contract functions (same as regular artifacts) so they are convertible back to a regular noir artifact for profiling purposes.