### PR TITLE
fix: ts contracts codegen

### DIFF
--- a/yarn-project/builder/src/contract-interface-gen/typescript.ts
+++ b/yarn-project/builder/src/contract-interface-gen/typescript.ts
@@ -382,7 +382,7 @@ export class ${input.name}Contract extends ContractBase {
   ${notesGetter}
 
   /** Type-safe wrappers for the public methods exposed by the contract. */
-  declare public methods: {
+  public declare methods: {
     ${methods.join('\n')}
   };
 

--- a/yarn-project/builder/src/contract-interface-gen/typescript.ts
+++ b/yarn-project/builder/src/contract-interface-gen/typescript.ts
@@ -316,7 +316,10 @@ function generateEvents(events: any[] | undefined) {
  * @returns The corresponding ts code.
  */
 export function generateTypescriptContractInterface(input: ContractArtifact, artifactImportPath?: string) {
-  const methods = input.functions.filter(f => !f.isInternal).map(generateMethod);
+  const methods = input.functions
+    .filter(f => !f.isInternal)
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(generateMethod);
   const deploy = artifactImportPath && generateDeploy(input);
   const ctor = artifactImportPath && generateConstructor(input.name);
   const at = artifactImportPath && generateAt(input.name);
@@ -332,31 +335,31 @@ export function generateTypescriptContractInterface(input: ContractArtifact, art
 /* eslint-disable */
 import {
   AztecAddress,
-  AztecAddressLike,
+  type AztecAddressLike,
   CompleteAddress,
   Contract,
-  ContractArtifact,
+  type ContractArtifact,
   ContractBase,
   ContractFunctionInteraction,
-  ContractInstanceWithAddress,
-  ContractMethod,
-  ContractStorageLayout,
-  ContractNotes,
+  type ContractInstanceWithAddress,
+  type ContractMethod,
+  type ContractStorageLayout,
+  type ContractNotes,
   DeployMethod,
   EthAddress,
-  EthAddressLike,
+  type EthAddressLike,
   EventSelector,
-  FieldLike,
+  type FieldLike,
   Fr,
-  FunctionSelectorLike,
+  type FunctionSelectorLike,
   L1EventPayload,
   loadContractArtifact,
-  NoirCompiledContract,
+  type NoirCompiledContract,
   NoteSelector,
   Point,
-  PublicKey,
-  Wallet,
-  WrappedFieldLike,
+  type PublicKey,
+  type Wallet,
+  type WrappedFieldLike,
 } from '@aztec/aztec.js';
 ${artifactStatement}
 
@@ -379,7 +382,7 @@ export class ${input.name}Contract extends ContractBase {
   ${notesGetter}
 
   /** Type-safe wrappers for the public methods exposed by the contract. */
-  public override methods!: {
+  declare public methods: {
     ${methods.join('\n')}
   };
 

--- a/yarn-project/noir-contracts.js/tsconfig.json
+++ b/yarn-project/noir-contracts.js/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dest",
     "rootDir": "src",
-    "tsBuildInfoFile": ".tsbuildinfo"
+    "tsBuildInfoFile": ".tsbuildinfo",
+    "verbatimModuleSyntax": true
   },
   "references": [
     {

--- a/yarn-project/noir-contracts.js/tsconfig.json
+++ b/yarn-project/noir-contracts.js/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "outDir": "dest",
     "rootDir": "src",
-    "tsBuildInfoFile": ".tsbuildinfo",
-    "verbatimModuleSyntax": true
+    "tsBuildInfoFile": ".tsbuildinfo"
   },
   "references": [
     {


### PR DESCRIPTION
Fixes #4152. Related #4162 and #5792.

1. Prepends `type` keyword for type-only imports in generated contracts, so projects using `verbatimModuleSyntax: true` can typecheck successfully.
2. Fixes invalid `public override methods!` syntax.
3. Additionally, sorts generated methods by name to make it more deterministic.

I also added `verbatimModuleSyntax: true` to tsconfig to showcase that it fails to typecheck without `type` prefix.