### PR TITLE
chore: Less noisy AVM failures in proving

### DIFF
--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -1024,8 +1024,9 @@ export class ProvingOrchestrator implements BlockProver {
             if (process.env.AVM_PROVING_STRICT) {
               throw err;
             } else {
-              logger.warn(`Error thrown when proving AVM circuit: ${err}`);
-              logger.warn(`AVM_PROVING_STRICT is off, faking AVM proof and carrying on...`);
+              logger.warn(
+                `Error thrown when proving AVM circuit, but AVM_PROVING_STRICT is off, so faking AVM proof and carrying on. Error: ${err}.`,
+              );
               return { proof: makeEmptyProof(), verificationKey: VerificationKeyData.makeFake() };
             }
           }

--- a/yarn-project/prover-client/src/prover-agent/memory-proving-queue.ts
+++ b/yarn-project/prover-client/src/prover-agent/memory-proving-queue.ts
@@ -178,7 +178,11 @@ export class MemoryProvingQueue implements ServerCircuitProver, ProvingJobSource
       );
       this.queue.put(job);
     } else {
-      this.log.error(`Job id=${job.id} type=${ProvingRequestType[job.request.type]} failed with error: ${err}`);
+      const logFn =
+        job.request.type === ProvingRequestType.PUBLIC_VM && !process.env.AVM_PROVING_STRICT
+          ? this.log.warn
+          : this.log.error;
+      logFn(`Job id=${job.id} type=${ProvingRequestType[job.request.type]} failed with error: ${err}`);
       job.reject(err);
     }
     return Promise.resolve();

--- a/yarn-project/prover-client/src/prover-agent/prover-agent.ts
+++ b/yarn-project/prover-client/src/prover-agent/prover-agent.ts
@@ -136,20 +136,16 @@ export class ProverAgent {
         );
       }
     } catch (err) {
+      const type = ProvingRequestType[job.request.type];
       if (this.isRunning()) {
-        this.log.error(
-          `Error processing proving job id=${job.id} type=${ProvingRequestType[job.request.type]}: ${
-            (err as any).stack || err
-          }`,
-          err,
-        );
+        if (job.request.type === ProvingRequestType.PUBLIC_VM && !process.env.AVM_PROVING_STRICT) {
+          this.log.error(`Error processing proving job id=${job.id} type=${type}: ${err}`, err);
+        } else {
+          this.log.warn(`Ignoring error processing proving job id=${job.id} type=${type}: ${err}`);
+        }
         await jobSource.rejectProvingJob(job.id, new ProvingError((err as any)?.message ?? String(err)));
       } else {
-        this.log.verbose(
-          `Dropping proving job id=${job.id} type=${ProvingRequestType[job.request.type]}: agent stopped: ${
-            (err as any).stack || err
-          }`,
-        );
+        this.log.verbose(`Dropping proving job id=${job.id} type=${type}: agent stopped: ${(err as any).stack || err}`);
       }
     }
   }


### PR DESCRIPTION
If AVM fails to prove and AVM_PROVING_STRICT is not set, do not log an error.
