### PR TITLE
fix: Docker containers healthchecks

### DIFF
--- a/docker-compose.provernet.yml
+++ b/docker-compose.provernet.yml
@@ -38,10 +38,10 @@ services:
     volumes:
       - ./log/aztec-node/:/usr/src/yarn-project/aztec/log:rw
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost/status" ]
+      test: [ "CMD", "curl", "-fSs", "http://127.0.0.1:$AZTEC_PORT/status" ]
       interval: 3s
       timeout: 30s
-      start_period: 10s
+      start_period: 120s
     depends_on:
       - ethereum
     command:
@@ -63,7 +63,7 @@ services:
       L1_CHAIN_ID: 31337
       AZTEC_PORT: 80
       BOT_PRIVATE_KEY: 0xcafe
-      BOT_TX_INTERVAL_SECONDS: 300
+      BOT_TX_INTERVAL_SECONDS: 5
       BOT_PRIVATE_TRANSFERS_PER_TX: 1
       BOT_PUBLIC_TRANSFERS_PER_TX: 0
       BOT_NO_WAIT_FOR_TRANSFERS: true
@@ -80,7 +80,7 @@ services:
       aztec-node:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost/status" ]
+      test: [ "CMD", "curl", "-fSs", "http://127.0.0.1:$AZTEC_PORT/status" ]
       interval: 3s
       timeout: 30s
       start_period: 10s
@@ -112,7 +112,7 @@ services:
       aztec-node:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost/status" ]
+      test: [ "CMD", "curl", "-fSs", "http://127.0.0.1:$AZTEC_PORT/status" ]
       interval: 3s
       timeout: 30s
       start_period: 10s

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -160,8 +160,8 @@ aztec:
     ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec/dest/bin/index.js"]
     LET port=8080
     ENV PORT=$port
-    HEALTHCHECK --interval=10s --timeout=10s --retries=6 \
-        CMD curl -fsSd '{\"jsonrpc\":\"2.0\",\"method\":\"pxe_getNodeInfo\",\"id\":1}' http://127.0.0.1:$port
+    HEALTHCHECK --interval=10s --timeout=10s --retries=6 --start-period=120s \
+        CMD curl -fsS http://127.0.0.1:$port/status
     EXPOSE $port
 
 aztec-faucet-build:


### PR DESCRIPTION
Fixes `start_period` for aztec node in provernet healtcheck, as since #8211 the startup takes much longer.

Fixes the healthcheck defined in the image itself, so it works with the common `status` route and does not require the pxe to be exposed.