### PR TITLE
chore: always run `build-check` step in `publish-bb.yml`

### DIFF
--- a/.github/workflows/publish-bb.yml
+++ b/.github/workflows/publish-bb.yml
@@ -204,6 +204,7 @@ jobs:
   build-check:
     name: Check builds are successful
     needs: [build-x86_64-linux-gnu, build-mac-intel, build-mac-m1,build-wasm-ts]
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Report overall success


### PR DESCRIPTION
I forgot to make sure that the `build-check` step always ran in #8223 so this PR fixes that.