### PR TITLE
chore: Run CI after merges to provernet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master, alphanet, provernet, devnet]
+    branches: [master, provernet]
   pull_request:
     branches-ignore: [devnet]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [master, alphanet, provernet, devnet]
   pull_request:
     branches-ignore: [devnet]
   workflow_dispatch:


### PR DESCRIPTION
Given provernet is diverging from master, it'd be nice to have the CI catch any bad cherry picks.