### PR TITLE
fix: Log public vm errors as warn in prover-agent

### DIFF
--- a/yarn-project/prover-client/src/prover-agent/prover-agent.ts
+++ b/yarn-project/prover-client/src/prover-agent/prover-agent.ts
@@ -139,9 +139,9 @@ export class ProverAgent {
       const type = ProvingRequestType[job.request.type];
       if (this.isRunning()) {
         if (job.request.type === ProvingRequestType.PUBLIC_VM && !process.env.AVM_PROVING_STRICT) {
-          this.log.error(`Error processing proving job id=${job.id} type=${type}: ${err}`, err);
+          this.log.warn(`Expected error processing VM proving job id=${job.id} type=${type}: ${err}`);
         } else {
-          this.log.warn(`Ignoring error processing proving job id=${job.id} type=${type}: ${err}`);
+          this.log.error(`Error processing proving job id=${job.id} type=${type}: ${err}`, err);
         }
         await jobSource.rejectProvingJob(job.id, new ProvingError((err as any)?.message ?? String(err)));
       } else {


### PR DESCRIPTION
And not the other way around. I need to relearn how booleans work.