### PR TITLE
feat: Add status check to prover agent

### DIFF
--- a/docker-compose.provernet.yml
+++ b/docker-compose.provernet.yml
@@ -145,6 +145,11 @@ services:
         condition: service_healthy
     command: [ "start", "--prover" ]
     restart: on-failure:5
+    healthcheck:
+      test: [ "CMD", "curl", "-fSs", "http://127.0.0.1:$AZTEC_PORT/status" ]
+      interval: 3s
+      timeout: 30s
+      start_period: 20s
 
   # Simple watcher that logs the latest block numbers every few seconds using the CLI and the bot's PXE
   aztec-block-watcher:

--- a/yarn-project/aztec/src/cli/cmds/start_prover_agent.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_agent.ts
@@ -1,7 +1,11 @@
 import { BBNativeRollupProver, TestCircuitProver } from '@aztec/bb-prover';
 import { type ServerCircuitProver } from '@aztec/circuit-types';
 import { type ProverClientConfig, proverClientConfigMappings } from '@aztec/prover-client';
-import { ProverAgent, createProvingJobSourceClient } from '@aztec/prover-client/prover-agent';
+import {
+  ProverAgent,
+  createProverAgentRpcServer,
+  createProvingJobSourceClient,
+} from '@aztec/prover-client/prover-agent';
 import {
   type TelemetryClientConfig,
   createAndStartTelemetryClient,
@@ -43,5 +47,5 @@ export const startProverAgent: ServiceStarter = async (options, signalHandlers, 
 
   signalHandlers.push(() => agent.stop());
 
-  return Promise.resolve([]);
+  return [{ prover: createProverAgentRpcServer(agent) }];
 };

--- a/yarn-project/prover-client/src/prover-agent/prover-agent.ts
+++ b/yarn-project/prover-client/src/prover-agent/prover-agent.ts
@@ -53,6 +53,10 @@ export class ProverAgent {
     return this.runningPromise?.isRunning() ?? false;
   }
 
+  getCurrentJobs(): { id: string; type: string }[] {
+    return Array.from(this.inFlightPromises.values()).map(({ id, type }) => ({ id, type: ProvingRequestType[type] }));
+  }
+
   start(jobSource: ProvingJobSource): void {
     if (this.runningPromise) {
       throw new Error('Agent is already running');

--- a/yarn-project/prover-client/src/prover-agent/rpc.ts
+++ b/yarn-project/prover-client/src/prover-agent/rpc.ts
@@ -1,12 +1,14 @@
 import { type ProvingJobSource } from '@aztec/circuit-types';
 import {
   AvmCircuitInputs,
+  AztecAddress,
   BaseOrMergeRollupPublicInputs,
   BaseParityInputs,
   BaseRollupInputs,
   BlockMergeRollupInputs,
   BlockRootOrBlockMergePublicInputs,
   BlockRootRollupInputs,
+  EthAddress,
   Fr,
   Header,
   KernelCircuitPublicInputs,
@@ -28,6 +30,7 @@ import {
 import { createJsonRpcClient, makeFetch } from '@aztec/foundation/json-rpc/client';
 import { JsonRpcServer } from '@aztec/foundation/json-rpc/server';
 
+import { type ProverAgent } from './prover-agent.js';
 import { ProvingError } from './proving-error.js';
 
 export function createProvingJobSourceServer(queue: ProvingJobSource): JsonRpcServer {
@@ -103,4 +106,25 @@ export function createProvingJobSourceClient(
     namespace,
     fetch,
   ) as ProvingJobSource;
+}
+
+/**
+ * Wrap a ProverAgent instance with a JSON RPC HTTP server.
+ * @param node - The ProverNode
+ * @returns An JSON-RPC HTTP server
+ */
+export function createProverAgentRpcServer(agent: ProverAgent) {
+  const rpc = new JsonRpcServer(
+    agent,
+    {
+      AztecAddress,
+      EthAddress,
+      Fr,
+      Header,
+    },
+    {},
+    // disable methods
+    ['start', 'stop', 'setCircuitProver', 'work', 'getProof'],
+  );
+  return rpc;
 }


### PR DESCRIPTION
Adds a status check and an endpoint for querying current jobs to the prover agent:

```
$ curl -XPOST -d'{"method": "prover_getCurrentJobs"}' http://localhost:8085/
{"result":[{"id":"ab3f1629","type":"ROOT_PARITY"}]}
```
