### PR TITLE
chore: remove unused generic parameters

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_sorted_transformed_value_array/get_combined_order_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_sorted_transformed_value_array/get_combined_order_hints.nr
@@ -30,7 +30,7 @@ unconstrained fn count_private_items<T, let N: u32>(array: [T; N]) -> u32 where 
     length
 }
 
-pub fn get_combined_order_hints_asc<T, S, let N: u32>(
+pub fn get_combined_order_hints_asc<T, let N: u32>(
     array_lt: [T; N],
     array_gte: [T; N]
 ) -> [CombinedOrderHint; N] where T: Ordered + Eq + Empty {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_exposed_sorted_transformed_value_array/get_order_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_exposed_sorted_transformed_value_array/get_order_hints.nr
@@ -44,11 +44,11 @@ pub fn get_order_hints<T, let N: u32>(
     hints
 }
 
-pub fn get_order_hints_asc<T, S, let N: u32>(array: [T; N]) -> [OrderHint; N] where T: Ordered + Eq + Empty {
+pub fn get_order_hints_asc<T, let N: u32>(array: [T; N]) -> [OrderHint; N] where T: Ordered + Eq + Empty {
     get_order_hints(array, compare_by_counter_empty_padded_asc)
 }
 
-pub fn get_order_hints_desc<T, S, let N: u32>(array: [T; N]) -> [OrderHint; N] where T: Ordered + Eq + Empty {
+pub fn get_order_hints_desc<T, let N: u32>(array: [T; N]) -> [OrderHint; N] where T: Ordered + Eq + Empty {
     get_order_hints(array, compare_by_counter_empty_padded_desc)
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_sorted_transformed_value_arrays/get_split_order_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_sorted_transformed_value_arrays/get_split_order_hints.nr
@@ -67,14 +67,14 @@ fn get_split_order_hints<T, let N: u32>(
     SplitOrderHints { sorted_counters_lt, sorted_counters_gte, sorted_indexes }
 }
 
-pub fn get_split_order_hints_asc<T, S, let N: u32>(
+pub fn get_split_order_hints_asc<T, let N: u32>(
     array: [T; N],
     split_counter: u32
 ) -> SplitOrderHints<N> where T: Ordered + Eq + Empty {
     get_split_order_hints(array, split_counter, true)
 }
 
-pub fn get_split_order_hints_desc<T, S, let N: u32>(
+pub fn get_split_order_hints_desc<T, let N: u32>(
     array: [T; N],
     split_counter: u32
 ) -> SplitOrderHints<N> where T: Ordered + Eq + Empty {


### PR DESCRIPTION
These generic parameters are not used by these functions so we can just remove them.