### PR TITLE
test: basic network matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,11 +161,13 @@ jobs:
             export FORCE_COLOR=1
             ../../scripts/earthly-ci -P --no-output +${{ matrix.test }}
 
-  # all the network end-to-end tests for aztec (not required to merge)
   network-e2e:
     needs: [build, changes]
     if: ${{ needs.changes.outputs.non-barretenberg-cpp == 'true' }}
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        values_file: ["default.yaml", "3-validators.yaml"]
     steps:
       - uses: actions/checkout@v4
         with: { ref: "${{ env.GIT_COMMIT }}" }
@@ -188,7 +190,7 @@ jobs:
             ./scripts/setup_local_k8s.sh
             export FORCE_COLOR=1
             export EARTHLY_BUILD_ARGS="${{ env.EARTHLY_BUILD_ARGS }}"
-            ../../scripts/earthly-ci --exec-stats -P --no-output ./+network-transfer
+            ../../scripts/earthly-ci --exec-stats -P --no-output ./+network-transfer --values-file=${{ matrix.values_file }}
 
   # all the benchmarking end-to-end integration tests for aztec (not required to merge)
   bench-e2e:

--- a/helm-charts/aztec-network/templates/boot-node.stateful-set.yaml
+++ b/helm-charts/aztec-network/templates/boot-node.stateful-set.yaml
@@ -85,6 +85,12 @@ spec:
               value: {{ include "aztec-network.ethereumHost" . | quote }}
             - name: P2P_ENABLED
               value: "{{ .Values.bootNode.p2p.enabled }}"
+            - name: VALIDATOR_DISABLED
+              value: "{{ .Values.bootNode.validator.disabled }}"
+            - name: SEQ_MAX_SECONDS_BETWEEN_BLOCKS
+              value: "{{ .Values.bootNode.sequencer.maxSecondsBetweenBlocks }}"
+            - name: SEQ_MIN_TX_PER_BLOCK
+              value: "{{ .Values.bootNode.sequencer.minTxsPerBlock }}"
             - name: P2P_TCP_ANNOUNCE_ADDR
               value: "$(POD_DNS_NAME):{{ .Values.bootNode.service.p2pPort }}"
             - name: P2P_UDP_ANNOUNCE_ADDR

--- a/helm-charts/aztec-network/templates/validator.stateful-set.yaml
+++ b/helm-charts/aztec-network/templates/validator.stateful-set.yaml
@@ -65,6 +65,12 @@ spec:
               value: {{ include "aztec-network.ethereumHost" . | quote }}
             - name: P2P_ENABLED
               value: "{{ .Values.validator.p2p.enabled }}"
+            - name: VALIDATOR_DISABLED
+              value: "{{ .Values.validator.validator.disabled }}"
+            - name: SEQ_MAX_SECONDS_BETWEEN_BLOCKS
+              value: "{{ .Values.bootNode.sequencer.maxSecondsBetweenBlocks }}"
+            - name: SEQ_MIN_TX_PER_BLOCK
+              value: "{{ .Values.bootNode.sequencer.minTxsPerBlock }}"
             - name: P2P_TCP_ANNOUNCE_ADDR
               value: "$(POD_DNS_NAME):{{ .Values.validator.service.p2pPort }}"
             - name: P2P_UDP_ANNOUNCE_ADDR
@@ -73,6 +79,10 @@ spec:
               value: "0.0.0.0:{{ .Values.validator.service.p2pPort }}"
             - name: P2P_UDP_LISTEN_ADDR
               value: "0.0.0.0:{{ .Values.validator.service.p2pPort }}"
+            - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+              value: {{ include "aztec-network.otelCollectorMetricsEndpoint" . | quote }}
+            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+              value: {{ include "aztec-network.otelCollectorTracesEndpoint" . | quote }}
           ports:
             - containerPort: {{ .Values.validator.service.nodePort }}
             - containerPort: {{ .Values.validator.service.p2pPort }}

--- a/helm-charts/aztec-network/values.yaml
+++ b/helm-charts/aztec-network/values.yaml
@@ -30,7 +30,12 @@ bootNode:
     p2pPort: 40400
     nodePort: 8080
   logLevel: "debug"
-  debug: "aztec:*"
+  debug: "aztec:*,-aztec:avm_simulator:*"
+  sequencer:
+    maxSecondsBetweenBlocks: 0
+    minTxsPerBlock: 1
+  validator:
+    disabled: true
   p2p:
     enabled: "true"
   resources: {}
@@ -41,7 +46,12 @@ validator:
     p2pPort: 40400
     nodePort: 8080
   logLevel: "debug"
-  debug: "aztec:*"
+  debug: "aztec:*,-aztec:avm_simulator:*"
+  sequencer:
+    maxSecondsBetweenBlocks: 0
+    minTxsPerBlock: 1
+  validator:
+    disabled: false
   p2p:
     enabled: "true"
   resources: {}

--- a/helm-charts/aztec-network/values/3-validators.yaml
+++ b/helm-charts/aztec-network/values/3-validators.yaml
@@ -1,0 +1,8 @@
+validator:
+  replicas: 3
+  validator:
+    disabled: false
+
+bootNode:
+  validator:
+    disabled: false

--- a/helm-charts/aztec-network/values/default.yaml
+++ b/helm-charts/aztec-network/values/default.yaml
@@ -1,0 +1,1 @@
+# Left intentionally blank- this file is used to override the default values in the values.yaml file

--- a/yarn-project/end-to-end/Earthfile
+++ b/yarn-project/end-to-end/Earthfile
@@ -67,7 +67,7 @@ E2E_TEST_PUBLIC_TESTNET:
 
 NETWORK_TEST:
   FUNCTION
-  ARG hardware_concurrency=""
+  ARG values_file="default.yaml"
   ARG namespace
   ARG test
   ARG chaos_values
@@ -93,7 +93,9 @@ NETWORK_TEST:
   END
 
   RUN helm install spartan ../../helm-charts/aztec-network \
-        --namespace $namespace --create-namespace \
+        --namespace $namespace \
+        --create-namespace \
+        --values ../../helm-charts/aztec-network/values/$values_file \
         --set images.test.image="aztecprotocol/end-to-end:$AZTEC_DOCKER_TAG" \
         --set images.aztec.image="aztecprotocol/aztec:$AZTEC_DOCKER_TAG" \
         --set test="$test" \
@@ -325,8 +327,10 @@ e2e-cli-wallet:
 
 network-smoke:
   ARG force_build
-  DO +NETWORK_TEST --force_build=$force_build --fresh_install=true --namespace=smoke --test=./src/spartan/smoke.test.ts
+  ARG values_file="default.yaml"
+  DO +NETWORK_TEST --test=./src/spartan/smoke.test.ts --namespace=smoke --fresh_install=true --force_build=$force_build --values_file=$values_file
 
 network-transfer:
   ARG force_build
-  DO +NETWORK_TEST --force_build=$force_build --fresh_install=true --namespace=transfer --test=./src/spartan/transfer.test.ts
+  ARG values_file="default.yaml"
+  DO +NETWORK_TEST --test=./src/spartan/transfer.test.ts --namespace=transfer --fresh_install=true --force_build=$force_build --values_file=$values_file

--- a/yarn-project/end-to-end/src/spartan/transfer.test.ts
+++ b/yarn-project/end-to-end/src/spartan/transfer.test.ts
@@ -15,6 +15,8 @@ import {
 import { createDebugLogger } from '@aztec/foundation/log';
 import { TokenContract } from '@aztec/noir-contracts.js';
 
+import { jest } from '@jest/globals';
+
 import { addAccounts, publicDeployAccounts } from '../fixtures/snapshot_manager.js';
 
 const { PXE_URL } = process.env;
@@ -56,11 +58,13 @@ const addPendingShieldNoteToPXE = async (args: {
 };
 
 describe('token transfer test', () => {
+  jest.setTimeout(10 * 60 * 1000); // 10 minutes
+
   const logger = createDebugLogger(`aztec:spartan-test:transfer`);
   const TOKEN_NAME = 'USDC';
   const TOKEN_SYMBOL = 'USD';
   const TOKEN_DECIMALS = 18n;
-  const MINT_AMOUNT = 1000000n;
+  const MINT_AMOUNT = 20n;
   let pxe: PXE;
   let wallets: AccountWalletWithSecretKey[];
   let completeAddresses: CompleteAddress[];
@@ -117,26 +121,35 @@ describe('token transfer test', () => {
 
   it('can transfer 1 publicly', async () => {
     const transferAmount = 1n;
-    const balance0 = await tokenAtWallet0.methods.balance_of_public(completeAddresses[0].address).simulate();
-    expect(balance0).toBeGreaterThanOrEqual(transferAmount);
-    await tokenAtWallet0.methods
-      .transfer_public(completeAddresses[0].address, completeAddresses[1].address, transferAmount, 0)
-      .send()
-      .wait();
-    const balance0After = await tokenAtWallet0.methods.balance_of_public(completeAddresses[0].address).simulate();
-    const balance1After = await tokenAtWallet0.methods.balance_of_public(completeAddresses[1].address).simulate();
-    expect(balance0After).toBe(balance0 - transferAmount);
-    expect(balance1After).toBe(transferAmount);
+    const initialBalance = await tokenAtWallet0.methods.balance_of_public(completeAddresses[0].address).simulate();
+    expect(initialBalance).toBeGreaterThanOrEqual(transferAmount);
+    const sentTxs = [];
+    for (let i = 1n; i <= MINT_AMOUNT / transferAmount; i++) {
+      sentTxs.push(
+        tokenAtWallet0.methods
+          .transfer_public(completeAddresses[0].address, completeAddresses[1].address, transferAmount, 0)
+          .send(),
+      );
+    }
+    await Promise.all(sentTxs.map(tx => tx.wait()));
+    const finalBalance0 = await tokenAtWallet0.methods.balance_of_public(completeAddresses[0].address).simulate();
+    expect(finalBalance0).toBe(0n);
+    const finalBalance1 = await tokenAtWallet0.methods.balance_of_public(completeAddresses[1].address).simulate();
+    expect(finalBalance1).toBe(MINT_AMOUNT);
   });
 
   it('can transfer 1 privately', async () => {
     const transferAmount = 1n;
-    const balance0 = await tokenAtWallet0.methods.balance_of_private(completeAddresses[0].address).simulate();
-    expect(balance0).toBeGreaterThanOrEqual(transferAmount);
-    await tokenAtWallet0.methods.transfer(completeAddresses[1].address, transferAmount).send().wait();
-    const balance0After = await tokenAtWallet0.methods.balance_of_private(completeAddresses[0].address).simulate();
-    const balance1After = await tokenAtWallet0.methods.balance_of_private(completeAddresses[1].address).simulate();
-    expect(balance0After).toBe(balance0 - transferAmount);
-    expect(balance1After).toBe(transferAmount);
+    const initialBalance = await tokenAtWallet0.methods.balance_of_private(completeAddresses[0].address).simulate();
+    expect(initialBalance).toBeGreaterThanOrEqual(transferAmount);
+    const sentTxs = [];
+    for (let i = 1n; i <= MINT_AMOUNT / transferAmount; i++) {
+      sentTxs.push(tokenAtWallet0.methods.transfer(completeAddresses[1].address, transferAmount).send());
+    }
+    await Promise.all(sentTxs.map(tx => tx.wait()));
+    const finalBalance0 = await tokenAtWallet0.methods.balance_of_private(completeAddresses[0].address).simulate();
+    expect(finalBalance0).toBe(0n);
+    const finalBalance1 = await tokenAtWallet0.methods.balance_of_private(completeAddresses[1].address).simulate();
+    expect(finalBalance1).toBe(MINT_AMOUNT);
   });
 });

--- a/yarn-project/end-to-end/src/spartan/transfer.test.ts
+++ b/yarn-project/end-to-end/src/spartan/transfer.test.ts
@@ -121,17 +121,15 @@ describe('token transfer test', () => {
 
   it('can transfer 1 publicly', async () => {
     const transferAmount = 1n;
+    const numTransfers = MINT_AMOUNT / transferAmount;
     const initialBalance = await tokenAtWallet0.methods.balance_of_public(completeAddresses[0].address).simulate();
     expect(initialBalance).toBeGreaterThanOrEqual(transferAmount);
-    const sentTxs = [];
-    for (let i = 1n; i <= MINT_AMOUNT / transferAmount; i++) {
-      sentTxs.push(
-        tokenAtWallet0.methods
-          .transfer_public(completeAddresses[0].address, completeAddresses[1].address, transferAmount, 0)
-          .send(),
-      );
+    for (let i = 1n; i <= numTransfers; i++) {
+      await tokenAtWallet0.methods
+        .transfer_public(completeAddresses[0].address, completeAddresses[1].address, transferAmount, 0)
+        .send()
+        .wait();
     }
-    await Promise.all(sentTxs.map(tx => tx.wait()));
     const finalBalance0 = await tokenAtWallet0.methods.balance_of_public(completeAddresses[0].address).simulate();
     expect(finalBalance0).toBe(0n);
     const finalBalance1 = await tokenAtWallet0.methods.balance_of_public(completeAddresses[1].address).simulate();
@@ -140,13 +138,12 @@ describe('token transfer test', () => {
 
   it('can transfer 1 privately', async () => {
     const transferAmount = 1n;
+    const numTransfers = MINT_AMOUNT / transferAmount;
     const initialBalance = await tokenAtWallet0.methods.balance_of_private(completeAddresses[0].address).simulate();
     expect(initialBalance).toBeGreaterThanOrEqual(transferAmount);
-    const sentTxs = [];
-    for (let i = 1n; i <= MINT_AMOUNT / transferAmount; i++) {
-      sentTxs.push(tokenAtWallet0.methods.transfer(completeAddresses[1].address, transferAmount).send());
+    for (let i = 1n; i <= numTransfers; i++) {
+      await tokenAtWallet0.methods.transfer(completeAddresses[1].address, transferAmount).send().wait();
     }
-    await Promise.all(sentTxs.map(tx => tx.wait()));
     const finalBalance0 = await tokenAtWallet0.methods.balance_of_private(completeAddresses[0].address).simulate();
     expect(finalBalance0).toBe(0n);
     const finalBalance1 = await tokenAtWallet0.methods.balance_of_private(completeAddresses[1].address).simulate();


### PR DESCRIPTION
Adds new values files to the aztec-network helm chart, and creates a matrix over them for CI. 

Presently we test a single ("boot") node with validator off, and a boot + 3 validators with validators on. 

The test was also update to perform several transfers serially.

Fix #8001 