### PR TITLE
chore: rename process to propose for clarity

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -188,7 +188,7 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
   }
 
   /**
-   * @notice  Published the body and processes the block
+   * @notice  Published the body and propose the block
    * @dev     This should likely be purged in the future as it is a convenience method
    * @dev     `eth_log_handlers` rely on this function
    *
@@ -198,7 +198,7 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
    * @param _signatures - Signatures from the validators
    * @param _body - The body of the L2 block
    */
-  function publishAndProcess(
+  function propose(
     bytes calldata _header,
     bytes32 _archive,
     bytes32 _blockHash,
@@ -206,11 +206,11 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
     bytes calldata _body
   ) external override(IRollup) {
     AVAILABILITY_ORACLE.publish(_body);
-    process(_header, _archive, _blockHash, _signatures);
+    propose(_header, _archive, _blockHash, _signatures);
   }
 
   /**
-   * @notice  Published the body and processes the block
+   * @notice  Published the body and propose the block
    * @dev     This should likely be purged in the future as it is a convenience method
    * @dev     `eth_log_handlers` rely on this function
    * @param _header - The L2 block header
@@ -218,14 +218,14 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
    * @param _blockHash - The poseidon2 hash of the header added to the archive tree in the rollup circuit
    * @param _body - The body of the L2 block
    */
-  function publishAndProcess(
+  function propose(
     bytes calldata _header,
     bytes32 _archive,
     bytes32 _blockHash,
     bytes calldata _body
   ) external override(IRollup) {
     AVAILABILITY_ORACLE.publish(_body);
-    process(_header, _archive, _blockHash);
+    propose(_header, _archive, _blockHash);
   }
 
   /**
@@ -447,14 +447,14 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
   }
 
   /**
-   * @notice Processes an incoming L2 block with signatures
+   * @notice propose an incoming L2 block with signatures
    *
    * @param _header - The L2 block header
    * @param _archive - A root of the archive tree after the L2 block is applied
    * @param _blockHash - The poseidon2 hash of the header added to the archive tree in the rollup circuit
    * @param _signatures - Signatures from the validators
    */
-  function process(
+  function propose(
     bytes calldata _header,
     bytes32 _archive,
     bytes32 _blockHash,
@@ -491,7 +491,7 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
       header.globalVariables.blockNumber, header.contentCommitment.outHash, l2ToL1TreeMinHeight
     );
 
-    emit L2BlockProcessed(header.globalVariables.blockNumber);
+    emit L2BlockProposed(header.globalVariables.blockNumber);
 
     // Automatically flag the block as proven if we have cheated and set assumeProvenUntilBlockNumber.
     if (header.globalVariables.blockNumber < assumeProvenUntilBlockNumber) {
@@ -509,18 +509,18 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
   }
 
   /**
-   * @notice Processes an incoming L2 block without signatures
+   * @notice Propose a L2 block without signatures
    *
    * @param _header - The L2 block header
    * @param _archive - A root of the archive tree after the L2 block is applied
    * @param _blockHash - The poseidon2 hash of the header added to the archive tree in the rollup circuit
    */
-  function process(bytes calldata _header, bytes32 _archive, bytes32 _blockHash)
+  function propose(bytes calldata _header, bytes32 _archive, bytes32 _blockHash)
     public
     override(IRollup)
   {
     SignatureLib.Signature[] memory emptySignatures = new SignatureLib.Signature[](0);
-    process(_header, _archive, _blockHash, emptySignatures);
+    propose(_header, _archive, _blockHash, emptySignatures);
   }
 
   /**
@@ -610,7 +610,7 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
       revert Errors.Rollup__InvalidEpoch(currentEpoch, epochNumber);
     }
 
-    _processPendingBlock(_slot, _signatures, _digest, _flags);
+    _proposePendingBlock(_slot, _signatures, _digest, _flags);
   }
 
   /**

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -16,7 +16,7 @@ interface ITestRollup {
 }
 
 interface IRollup {
-  event L2BlockProcessed(uint256 indexed blockNumber);
+  event L2BlockProposed(uint256 indexed blockNumber);
   event L2ProofVerified(uint256 indexed blockNumber, bytes32 indexed proverId);
   event PrunedPending(uint256 provenBlockCount, uint256 pendingBlockCount);
 
@@ -38,21 +38,21 @@ interface IRollup {
 
   function OUTBOX() external view returns (IOutbox);
 
-  function publishAndProcess(
+  function propose(
     bytes calldata _header,
     bytes32 _archive,
     bytes32 _blockHash,
     SignatureLib.Signature[] memory _signatures,
     bytes calldata _body
   ) external;
-  function publishAndProcess(
+  function propose(
     bytes calldata _header,
     bytes32 _archive,
     bytes32 _blockHash,
     bytes calldata _body
   ) external;
-  function process(bytes calldata _header, bytes32 _archive, bytes32 _blockHash) external;
-  function process(
+  function propose(bytes calldata _header, bytes32 _archive, bytes32 _blockHash) external;
+  function propose(
     bytes calldata _header,
     bytes32 _archive,
     bytes32 _blockHash,

--- a/l1-contracts/src/core/sequencer_selection/Leonidas.sol
+++ b/l1-contracts/src/core/sequencer_selection/Leonidas.sol
@@ -339,7 +339,7 @@ contract Leonidas is Ownable, ILeonidas {
   }
 
   /**
-   * @notice  Process a pending block from the point-of-view of sequencer selection. Will:
+   * @notice  Propose a pending block from the point-of-view of sequencer selection. Will:
    *          - Setup the epoch if needed (if epoch committee is empty skips the rest)
    *          - Validate that the proposer is the proposer of the slot
    *          - Validate that the signatures for attestations are indeed from the validatorset
@@ -354,7 +354,7 @@ contract Leonidas is Ownable, ILeonidas {
    * @param _signatures - The signatures of the committee members
    * @param _digest - The digest of the block
    */
-  function _processPendingBlock(
+  function _proposePendingBlock(
     uint256 _slot,
     SignatureLib.Signature[] memory _signatures,
     bytes32 _digest,

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -91,7 +91,7 @@ contract RollupTest is DecoderBase {
     // We jump to the time of the block. (unless it is in the past)
     vm.warp(max(block.timestamp, data.decodedHeader.globalVariables.timestamp));
 
-    rollup.process(header, archive, bytes32(0));
+    rollup.propose(header, archive, bytes32(0));
 
     rollup.submitBlockRootProof(header, archive, bytes32(0), "", "");
 
@@ -224,7 +224,7 @@ contract RollupTest is DecoderBase {
     assertEq(coinbaseBalance, 0, "invalid initial coinbase balance");
 
     // Assert that balance have NOT been increased by proposing the block
-    rollup.process(header, archive, bytes32(0));
+    rollup.propose(header, archive, bytes32(0));
     assertEq(portalERC20.balanceOf(coinbase), 0, "invalid coinbase balance");
 
     vm.expectRevert(
@@ -272,7 +272,7 @@ contract RollupTest is DecoderBase {
 
     vm.warp(max(block.timestamp, data.decodedHeader.globalVariables.timestamp));
     availabilityOracle.publish(body);
-    rollup.process(header, archive, bytes32(0));
+    rollup.propose(header, archive, bytes32(0));
 
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__NonSequentialProving.selector));
     rollup.submitBlockRootProof(header, archive, bytes32(0), "", "");
@@ -310,7 +310,7 @@ contract RollupTest is DecoderBase {
     availabilityOracle.publish(body);
 
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidBlockNumber.selector, 1, 0x420));
-    rollup.process(header, archive, bytes32(0));
+    rollup.propose(header, archive, bytes32(0));
   }
 
   function testRevertInvalidChainId() public setUpFor("empty_block_1") {
@@ -327,7 +327,7 @@ contract RollupTest is DecoderBase {
     availabilityOracle.publish(body);
 
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidChainId.selector, 31337, 0x420));
-    rollup.process(header, archive, bytes32(0));
+    rollup.propose(header, archive, bytes32(0));
   }
 
   function testRevertInvalidVersion() public setUpFor("empty_block_1") {
@@ -343,7 +343,7 @@ contract RollupTest is DecoderBase {
     availabilityOracle.publish(body);
 
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidVersion.selector, 1, 0x420));
-    rollup.process(header, archive, bytes32(0));
+    rollup.propose(header, archive, bytes32(0));
   }
 
   function testRevertInvalidTimestamp() public setUpFor("empty_block_1") {
@@ -364,7 +364,7 @@ contract RollupTest is DecoderBase {
     availabilityOracle.publish(body);
 
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidTimestamp.selector, realTs, badTs));
-    rollup.process(header, archive, bytes32(0));
+    rollup.propose(header, archive, bytes32(0));
   }
 
   function testBlocksWithAssumeProven() public setUpFor("mixed_block_1") {
@@ -465,7 +465,7 @@ contract RollupTest is DecoderBase {
 
     availabilityOracle.publish(body);
 
-    rollup.process(header, archive, bytes32(0));
+    rollup.propose(header, archive, bytes32(0));
 
     if (_submitProof) {
       uint256 pre = rollup.provenBlockCount();

--- a/l1-contracts/test/sparta/DevNet.t.sol
+++ b/l1-contracts/test/sparta/DevNet.t.sol
@@ -173,7 +173,7 @@ contract DevNetTest is DecoderBase {
     }
 
     vm.prank(ree.proposer);
-    rollup.process(header, archive, bytes32(0));
+    rollup.propose(header, archive, bytes32(0));
 
     assertEq(_expectRevert, ree.shouldRevert, "Invalid revert expectation");
 

--- a/l1-contracts/test/sparta/Sparta.t.sol
+++ b/l1-contracts/test/sparta/Sparta.t.sol
@@ -218,13 +218,13 @@ contract SpartaTest is DecoderBase {
       }
 
       vm.prank(ree.proposer);
-      rollup.process(header, archive, bytes32(0), signatures);
+      rollup.propose(header, archive, bytes32(0), signatures);
 
       if (ree.shouldRevert) {
         return;
       }
     } else {
-      rollup.process(header, archive, bytes32(0));
+      rollup.propose(header, archive, bytes32(0));
     }
 
     assertEq(_expectRevert, ree.shouldRevert, "Does not match revert expectation");

--- a/yarn-project/archiver/README.md
+++ b/yarn-project/archiver/README.md
@@ -3,7 +3,7 @@
 Archiver is a service which is used to fetch data on-chain data and present them in a nice-to-consume form.
 The on-chain data specifically are the following events:
 
-1. `L2BlockProcessed` event emitted on Rollup contract,
+1. `L2BlockProposed` event emitted on Rollup contract,
 2. `MessageAdded` event emitted on Inbox contract,
 
 The interfaces defining how the data can be consumed from the archiver are `L2BlockSource`, `L2LogsSource` and `ContractDataSource`.

--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -83,7 +83,7 @@ describe('Archiver', () => {
     mockGetLogs({
       messageSent: [makeMessageSentEvent(98n, 1n, 0n), makeMessageSentEvent(99n, 1n, 1n)],
       txPublished: [makeTxsPublishedEvent(101n, blocks[0].body.getTxsEffectsHash())],
-      l2BlockProcessed: [makeL2BlockProcessedEvent(101n, 1n)],
+      L2BlockProposed: [makeL2BlockProposedEvent(101n, 1n)],
       proofVerified: [makeProofVerifiedEvent(102n, 1n, proverId)],
     });
 
@@ -98,7 +98,7 @@ describe('Archiver', () => {
         makeTxsPublishedEvent(2510n, blocks[1].body.getTxsEffectsHash()),
         makeTxsPublishedEvent(2520n, blocks[2].body.getTxsEffectsHash()),
       ],
-      l2BlockProcessed: [makeL2BlockProcessedEvent(2510n, 2n), makeL2BlockProcessedEvent(2520n, 3n)],
+      L2BlockProposed: [makeL2BlockProposedEvent(2510n, 2n), makeL2BlockProposedEvent(2520n, 3n)],
     });
 
     publicClient.getTransaction.mockResolvedValueOnce(publishTxs[0]);
@@ -208,7 +208,7 @@ describe('Archiver', () => {
         makeTxsPublishedEvent(70n, blocks[0].body.getTxsEffectsHash()),
         makeTxsPublishedEvent(80n, blocks[1].body.getTxsEffectsHash()),
       ],
-      l2BlockProcessed: [makeL2BlockProcessedEvent(70n, 1n), makeL2BlockProcessedEvent(80n, 2n)],
+      L2BlockProposed: [makeL2BlockProposedEvent(70n, 1n), makeL2BlockProposedEvent(80n, 2n)],
     });
 
     mockGetLogs({});
@@ -231,29 +231,29 @@ describe('Archiver', () => {
   const mockGetLogs = (logs: {
     messageSent?: ReturnType<typeof makeMessageSentEvent>[];
     txPublished?: ReturnType<typeof makeTxsPublishedEvent>[];
-    l2BlockProcessed?: ReturnType<typeof makeL2BlockProcessedEvent>[];
+    L2BlockProposed?: ReturnType<typeof makeL2BlockProposedEvent>[];
     proofVerified?: ReturnType<typeof makeProofVerifiedEvent>[];
   }) => {
     publicClient.getLogs
       .mockResolvedValueOnce(logs.messageSent ?? [])
       .mockResolvedValueOnce(logs.txPublished ?? [])
-      .mockResolvedValueOnce(logs.l2BlockProcessed ?? [])
+      .mockResolvedValueOnce(logs.L2BlockProposed ?? [])
       .mockResolvedValueOnce(logs.proofVerified ?? []);
   };
 });
 
 /**
- * Makes a fake L2BlockProcessed event for testing purposes.
+ * Makes a fake L2BlockProposed event for testing purposes.
  * @param l1BlockNum - L1 block number.
  * @param l2BlockNum - L2 Block number.
- * @returns An L2BlockProcessed event log.
+ * @returns An L2BlockProposed event log.
  */
-function makeL2BlockProcessedEvent(l1BlockNum: bigint, l2BlockNum: bigint) {
+function makeL2BlockProposedEvent(l1BlockNum: bigint, l2BlockNum: bigint) {
   return {
     blockNumber: l1BlockNum,
     args: { blockNumber: l2BlockNum },
     transactionHash: `0x${l2BlockNum}`,
-  } as Log<bigint, number, false, undefined, true, typeof RollupAbi, 'L2BlockProcessed'>;
+  } as Log<bigint, number, false, undefined, true, typeof RollupAbi, 'L2BlockProposed'>;
 }
 
 /**
@@ -310,7 +310,7 @@ function makeRollupTx(l2Block: L2Block) {
   const blockHash = toHex(l2Block.header.hash().toBuffer());
   const input = encodeFunctionData({
     abi: RollupAbi,
-    functionName: 'process',
+    functionName: 'propose',
     args: [header, archive, blockHash],
   });
   return { input } as Transaction<bigint, number>;

--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -7,10 +7,10 @@ import { RollupAbi } from '@aztec/l1-artifacts';
 import { type PublicClient, getAbiItem } from 'viem';
 
 import {
-  getL2BlockProcessedLogs,
+  getL2BlockProposedLogs,
   getMessageSentLogs,
   getTxsPublishedLogs,
-  processL2BlockProcessedLogs,
+  processL2BlockProposedLogs,
   processMessageSentLogs,
   processTxsPublishedLogs,
 } from './eth_log_handlers.js';
@@ -41,25 +41,25 @@ export async function retrieveBlockMetadataFromRollup(
     if (searchStartBlock > searchEndBlock) {
       break;
     }
-    const l2BlockProcessedLogs = await getL2BlockProcessedLogs(
+    const L2BlockProposedLogs = await getL2BlockProposedLogs(
       publicClient,
       rollupAddress,
       searchStartBlock,
       searchEndBlock,
     );
-    if (l2BlockProcessedLogs.length === 0) {
+    if (L2BlockProposedLogs.length === 0) {
       break;
     }
 
-    const lastLog = l2BlockProcessedLogs[l2BlockProcessedLogs.length - 1];
+    const lastLog = L2BlockProposedLogs[L2BlockProposedLogs.length - 1];
     logger.debug(
-      `Got L2 block processed logs for ${l2BlockProcessedLogs[0].blockNumber}-${lastLog.blockNumber} between ${searchStartBlock}-${searchEndBlock} L1 blocks`,
+      `Got L2 block processed logs for ${L2BlockProposedLogs[0].blockNumber}-${lastLog.blockNumber} between ${searchStartBlock}-${searchEndBlock} L1 blocks`,
     );
 
-    const newBlockMetadata = await processL2BlockProcessedLogs(
+    const newBlockMetadata = await processL2BlockProposedLogs(
       publicClient,
       expectedNextL2BlockNum,
-      l2BlockProcessedLogs,
+      L2BlockProposedLogs,
     );
     retrievedBlockMetadata.push(...newBlockMetadata);
     searchStartBlock = lastLog.blockNumber! + 1n;

--- a/yarn-project/archiver/src/archiver/eth_log_handlers.ts
+++ b/yarn-project/archiver/src/archiver/eth_log_handlers.ts
@@ -35,16 +35,16 @@ export function processMessageSentLogs(
 }
 
 /**
- * Processes newly received L2BlockProcessed logs.
+ * Processes newly received L2BlockProposed logs.
  * @param publicClient - The viem public client to use for transaction retrieval.
  * @param expectedL2BlockNumber - The next expected L2 block number.
- * @param logs - L2BlockProcessed logs.
+ * @param logs - L2BlockProposed logs.
  * @returns - An array of tuples representing block metadata including the header, archive tree snapshot.
  */
-export async function processL2BlockProcessedLogs(
+export async function processL2BlockProposedLogs(
   publicClient: PublicClient,
   expectedL2BlockNumber: bigint,
-  logs: Log<bigint, number, false, undefined, true, typeof RollupAbi, 'L2BlockProcessed'>[],
+  logs: Log<bigint, number, false, undefined, true, typeof RollupAbi, 'L2BlockProposed'>[],
 ): Promise<[Header, AppendOnlyTreeSnapshot, L1PublishedData][]> {
   const retrievedBlockMetadata: [Header, AppendOnlyTreeSnapshot, L1PublishedData][] = [];
   for (const log of logs) {
@@ -110,7 +110,7 @@ async function getBlockMetadataFromRollupTx(
     data,
   });
 
-  if (!(functionName === 'process' || functionName === 'publishAndProcess')) {
+  if (!(functionName === 'propose')) {
     throw new Error(`Unexpected method called ${functionName}`);
   }
   const [headerHex, archiveRootHex, _] = args! as readonly [Hex, Hex, Hex];
@@ -135,7 +135,7 @@ async function getBlockMetadataFromRollupTx(
 
 /**
  * Gets block bodies from calldata of an L1 transaction, and deserializes them into Body objects.
- * @note Assumes that the block was published using `publishAndProcess` or `publish`.
+ * @note Assumes that the block was published using `propose` or `publish`.
  * TODO: Add retries and error management.
  * @param publicClient - The viem public client to use for transaction retrieval.
  * @param txHash - Hash of the tx that published it.
@@ -146,16 +146,16 @@ async function getBlockBodiesFromAvailabilityOracleTx(
   txHash: `0x${string}`,
 ): Promise<Body> {
   const { input: data } = await publicClient.getTransaction({ hash: txHash });
-  const DATA_INDEX = [4, 3, 0];
 
   // @note  Use `forge inspect Rollup methodIdentifiers to get this,
   //        If using `forge sig` you will get an INVALID value for the case with a struct.
   // [
-  //   "publishAndProcess(bytes calldata _header,bytes32 _archive,bytes32 _blockHash,SignatureLib.Signature[] memory _signatures,bytes calldata _body)",
-  //   "publishAndProcess(bytes calldata _header,bytes32 _archive,bytes32 _blockHash,bytes calldata _body)",
+  //   "propose(bytes,bytes32,bytes32,(bool,uint8,bytes32,bytes32)[],bytes)": "08978fe9",
+  //   "propose(bytes,bytes32,bytes32,bytes)": "81e6f472",
   //   "publish(bytes calldata _body)"
   // ]
-  const SUPPORTED_SIGS = ['0x64450c6c', '0xde36c478', '0x7fd28346'];
+  const DATA_INDEX = [4, 3, 0];
+  const SUPPORTED_SIGS = ['0x08978fe9', '0x81e6f472', '0x7fd28346'];
 
   const signature = slice(data, 0, 4);
 
@@ -163,7 +163,7 @@ async function getBlockBodiesFromAvailabilityOracleTx(
     throw new Error(`Unexpected method called ${signature}`);
   }
 
-  if (signature === SUPPORTED_SIGS[2]) {
+  if (signature === SUPPORTED_SIGS[SUPPORTED_SIGS.length - 1]) {
     const { args } = decodeFunctionData({
       abi: AvailabilityOracleAbi,
       data,
@@ -184,24 +184,24 @@ async function getBlockBodiesFromAvailabilityOracleTx(
 }
 
 /**
- * Gets relevant `L2BlockProcessed` logs from chain.
+ * Gets relevant `L2BlockProposed` logs from chain.
  * @param publicClient - The viem public client to use for transaction retrieval.
  * @param rollupAddress - The address of the rollup contract.
  * @param fromBlock - First block to get logs from (inclusive).
  * @param toBlock - Last block to get logs from (inclusive).
- * @returns An array of `L2BlockProcessed` logs.
+ * @returns An array of `L2BlockProposed` logs.
  */
-export function getL2BlockProcessedLogs(
+export function getL2BlockProposedLogs(
   publicClient: PublicClient,
   rollupAddress: EthAddress,
   fromBlock: bigint,
   toBlock: bigint,
-): Promise<Log<bigint, number, false, undefined, true, typeof RollupAbi, 'L2BlockProcessed'>[]> {
+): Promise<Log<bigint, number, false, undefined, true, typeof RollupAbi, 'L2BlockProposed'>[]> {
   return publicClient.getLogs({
     address: getAddress(rollupAddress.toString()),
     event: getAbiItem({
       abi: RollupAbi,
-      name: 'L2BlockProcessed',
+      name: 'L2BlockProposed',
     }),
     fromBlock,
     toBlock: toBlock + 1n, // the toBlock argument in getLogs is exclusive

--- a/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
@@ -414,7 +414,7 @@ describe('L1Publisher integration', () => {
         address: rollupAddress,
         event: getAbiItem({
           abi: RollupAbi,
-          name: 'L2BlockProcessed',
+          name: 'L2BlockProposed',
         }),
         fromBlock: blockNumber + 1n,
       });
@@ -427,7 +427,7 @@ describe('L1Publisher integration', () => {
 
       const expectedData = encodeFunctionData({
         abi: RollupAbi,
-        functionName: 'publishAndProcess',
+        functionName: 'propose',
         args: [
           `0x${block.header.toBuffer().toString('hex')}`,
           `0x${block.archive.root.toBuffer().toString('hex')}`,
@@ -514,7 +514,7 @@ describe('L1Publisher integration', () => {
         address: rollupAddress,
         event: getAbiItem({
           abi: RollupAbi,
-          name: 'L2BlockProcessed',
+          name: 'L2BlockProposed',
         }),
         fromBlock: blockNumber + 1n,
       });
@@ -529,7 +529,7 @@ describe('L1Publisher integration', () => {
         i == 0
           ? encodeFunctionData({
               abi: RollupAbi,
-              functionName: 'publishAndProcess',
+              functionName: 'propose',
               args: [
                 `0x${block.header.toBuffer().toString('hex')}`,
                 `0x${block.archive.root.toBuffer().toString('hex')}`,
@@ -539,7 +539,7 @@ describe('L1Publisher integration', () => {
             })
           : encodeFunctionData({
               abi: RollupAbi,
-              functionName: 'process',
+              functionName: 'propose',
               args: [
                 `0x${block.header.toBuffer().toString('hex')}`,
                 `0x${block.archive.root.toBuffer().toString('hex')}`,

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -287,16 +287,16 @@ export class L1Publisher {
       attestations,
     };
 
-    // Process block and publish the body if needed (if not already published)
+    // Publish body and propose block (if not already published)
     if (!this.interrupted) {
       let txHash;
       const timer = new Timer();
 
       if (await this.checkIfTxsAreAvailable(block)) {
         this.log.verbose(`Transaction effects of block ${block.number} already published.`, ctx);
-        txHash = await this.sendProcessTx(processTxArgs);
+        txHash = await this.sendProposeWithoutBodyTx(processTxArgs);
       } else {
-        txHash = await this.sendPublishAndProcessTx(processTxArgs);
+        txHash = await this.sendProposeTx(processTxArgs);
       }
 
       if (!txHash) {
@@ -453,7 +453,7 @@ export class L1Publisher {
     }
   }
 
-  private async sendProcessTx(encodedData: L1ProcessArgs): Promise<string | undefined> {
+  private async sendProposeWithoutBodyTx(encodedData: L1ProcessArgs): Promise<string | undefined> {
     if (!this.interrupted) {
       try {
         if (encodedData.attestations) {
@@ -466,10 +466,10 @@ export class L1Publisher {
           ] as const;
 
           if (!L1Publisher.SKIP_SIMULATION) {
-            await this.rollupContract.simulate.process(args, { account: this.account });
+            await this.rollupContract.simulate.propose(args, { account: this.account });
           }
 
-          return await this.rollupContract.write.process(args, {
+          return await this.rollupContract.write.propose(args, {
             account: this.account,
           });
         } else {
@@ -480,9 +480,9 @@ export class L1Publisher {
           ] as const;
 
           if (!L1Publisher.SKIP_SIMULATION) {
-            await this.rollupContract.simulate.process(args, { account: this.account });
+            await this.rollupContract.simulate.propose(args, { account: this.account });
           }
-          return await this.rollupContract.write.process(args, {
+          return await this.rollupContract.write.propose(args, {
             account: this.account,
           });
         }
@@ -493,7 +493,7 @@ export class L1Publisher {
     }
   }
 
-  private async sendPublishAndProcessTx(encodedData: L1ProcessArgs): Promise<string | undefined> {
+  private async sendProposeTx(encodedData: L1ProcessArgs): Promise<string | undefined> {
     if (!this.interrupted) {
       try {
         if (encodedData.attestations) {
@@ -507,12 +507,12 @@ export class L1Publisher {
           ] as const;
 
           if (!L1Publisher.SKIP_SIMULATION) {
-            await this.rollupContract.simulate.publishAndProcess(args, {
+            await this.rollupContract.simulate.propose(args, {
               account: this.account,
             });
           }
 
-          return await this.rollupContract.write.publishAndProcess(args, {
+          return await this.rollupContract.write.propose(args, {
             account: this.account,
           });
         } else {
@@ -524,12 +524,12 @@ export class L1Publisher {
           ] as const;
 
           if (!L1Publisher.SKIP_SIMULATION) {
-            await this.rollupContract.simulate.publishAndProcess(args, {
+            await this.rollupContract.simulate.propose(args, {
               account: this.account,
             });
           }
 
-          return await this.rollupContract.write.publishAndProcess(args, {
+          return await this.rollupContract.write.propose(args, {
             account: this.account,
           });
         }


### PR DESCRIPTION
Changes the naming of the `process` function on the rollup to become `propose` since it is a proposal for a block. 