### PR TITLE
chore: bump noir-bignum to 0.3.2

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
+++ b/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
@@ -5,4 +5,4 @@ authors = [""]
 compiler_version = ">=0.30.0"
 
 [dependencies]
-bigint = {tag = "v0.3.1", git = "https://github.com/noir-lang/noir-bignum" }
+bigint = {tag = "v0.3.2", git = "https://github.com/noir-lang/noir-bignum" }

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/main.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/main.nr
@@ -83,9 +83,7 @@ unconstrained fn __field_to_bytes(x: Field) -> [u8; 32] {
 unconstrained fn __field_to_bignum(x: Field) -> F {
     let x_bytes = __field_to_bytes(x);
 
-    BigNum::from_byte_be(x_bytes)
-    // TODO: use this once the name has been updated in the bignum lib:
-    // BigNum::from_be_bytes(x_bytes)
+    BigNum::from_be_bytes(x_bytes)
 }
 
 unconstrained fn __field_to_bignum_limbs(x: Field) -> [Field; 3] {

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/main.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/main.nr
@@ -516,24 +516,22 @@ fn barycentric_evaluate_blob_at_z(z: F, ys: [F; FIELDS_PER_BLOB]) -> F {
     y
 }
 
-// Need to wait for https://github.com/noir-lang/noir-bignum/pull/9 for this to work.
-// nargo test --show-output test_main
-// #[test]
-// fn test_main() {
-//     let mut blob: [F; FIELDS_PER_BLOB] = [BigNum::new(); FIELDS_PER_BLOB];
+#[test]
+fn test_main() {
+    let mut blob: [F; FIELDS_PER_BLOB] = [BigNum::new(); FIELDS_PER_BLOB];
 
-//     blob[0] = BigNum { limbs: [0x1234, 0, 0] };
-//     blob[1] = BigNum { limbs: [0xabcd, 0, 0] };
-//     blob[2] = BigNum { limbs: [0x69, 0, 0] };
+    blob[0] = BigNum { limbs: [0x1234, 0, 0] };
+    blob[1] = BigNum { limbs: [0xabcd, 0, 0] };
+    blob[2] = BigNum { limbs: [0x69, 0, 0] };
 
-//     let kzg_commitment_in = [1, 2]; // this is made-up nonsense.
+    let kzg_commitment_in = [1, 2]; // this is made-up nonsense.
 
-//     let (challenge_z, y, kzg_commitment) = main(blob, kzg_commitment_in);
+    let (challenge_z, y, kzg_commitment) = main(blob, kzg_commitment_in);
 
-//     println(challenge_z);
-//     println(y);
-//     println(kzg_commitment);
-// }
+    println(challenge_z);
+    println(y);
+    println(kzg_commitment);
+}
 
 #[test]
 fn test_print() {
@@ -541,13 +539,12 @@ fn test_print() {
     println(f"x: {x}");
 }
 
-// Need to wait for https://github.com/noir-lang/noir-bignum/pull/9 for this to work.
-// #[test]
-// fn test_bignum_conversions() {
-//     let x = 1000;
-//     let x_bignum = __field_to_bignum(x);
-//     println(f"x_bignum: {x_bignum}");
-// }
+#[test]
+fn test_bignum_conversions() {
+    let x = 1000;
+    let x_bignum = __field_to_bignum(x);
+    println(f"x_bignum: {x_bignum}");
+}
 
 // nargo test --show-output test_barycentric
 #[test]


### PR DESCRIPTION
This PR updates the version of `noir-bignum` to a version without a bug which is blocking the noir sync.