### PR TITLE
feat(avm/public): user space PublicContext::get_args_hash

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/inputs/public_context_inputs.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/inputs/public_context_inputs.nr
@@ -2,14 +2,15 @@ use dep::protocol_types::traits::Empty;
 
 // These inputs will likely go away once the AVM processes 1 public kernel per enqueued call.
 struct PublicContextInputs {
-    args_hash: Field,
+    // TODO: Remove this structure and get calldata size at compile time.
+    calldata_length: Field,
     is_static_call: bool
 }
 
 impl Empty for PublicContextInputs {
     fn empty() -> Self {
         PublicContextInputs {
-            args_hash: 0,
+            calldata_length: 0,
             is_static_call: false
         }
     }

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -5,14 +5,16 @@ use dep::protocol_types::traits::{Serialize, Deserialize, Empty};
 use dep::protocol_types::abis::function_selector::FunctionSelector;
 use crate::context::inputs::public_context_inputs::PublicContextInputs;
 use crate::context::gas::GasOpts;
+use crate::hash::ArgsHasher;
 
 struct PublicContext {
     inputs: PublicContextInputs,
+    args_hash: Option<Field>
 }
 
 impl PublicContext {
     pub fn new(inputs: PublicContextInputs) -> Self {
-        PublicContext { inputs }
+        PublicContext { inputs, args_hash: Option::none() }
     }
 
     pub fn emit_unencrypted_log<T, let N: u32>(_self: &mut Self, log: T) where T: Serialize<N> {
@@ -130,8 +132,20 @@ impl PublicContext {
     fn selector(_self: Self) -> FunctionSelector {
         FunctionSelector::from_u32(function_selector())
     }
-    fn get_args_hash(self) -> Field {
-        self.inputs.args_hash
+    fn get_args_hash(mut self) -> Field {
+        if !self.args_hash.is_some() {
+            let mut hasher = ArgsHasher::new();
+
+            // TODO: this should be replaced with the compile-time calldata size.
+            for i in 0..self.inputs.calldata_length as u32 {
+                let argn: [Field; 1] = calldata_copy((2 + i) as u32, 1);
+                hasher.add(argn[0]);
+            }
+
+            self.args_hash = Option::some(hasher.hash());
+        }
+
+        self.args_hash.unwrap()
     }
     fn transaction_fee(_self: Self) -> Field {
         transaction_fee()
@@ -278,6 +292,10 @@ unconstrained fn call_static<let RET_SIZE: u32>(
     call_static_opcode(gas, address, args, function_selector)
 }
 
+unconstrained fn calldata_copy<let N: u32>(cdoffset: u32, copy_size: u32) -> [Field; N] {
+    calldata_copy_opcode(cdoffset, copy_size)
+}
+
 unconstrained fn storage_read(storage_slot: Field) -> Field {
     storage_read_opcode(storage_slot)
 }
@@ -355,6 +373,9 @@ unconstrained fn l1_to_l2_msg_exists_opcode(msg_hash: Field, msg_leaf_index: Fie
 
 #[oracle(avmOpcodeSendL2ToL1Msg)]
 unconstrained fn send_l2_to_l1_msg_opcode(recipient: EthAddress, content: Field) {}
+
+#[oracle(avmOpcodeCalldataCopy)]
+unconstrained fn calldata_copy_opcode<let N: u32>(cdoffset: u32, copy_size: u32) -> [Field; N] {}
 
 #[oracle(avmOpcodeCall)]
 unconstrained fn call_opcode<let RET_SIZE: u32>(

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
@@ -57,6 +57,10 @@ unconstrained pub fn set_msg_sender(msg_sender: AztecAddress) {
     oracle_set_msg_sender(msg_sender)
 }
 
+unconstrained pub fn set_calldata(calldata: [Field]) {
+    oracle_set_calldata(calldata)
+}
+
 unconstrained pub fn get_msg_sender() -> AztecAddress {
     oracle_get_msg_sender()
 }
@@ -187,3 +191,6 @@ unconstrained fn oracle_get_function_selector() -> FunctionSelector {}
 
 #[oracle(setFunctionSelector)]
 unconstrained fn oracle_set_function_selector(selector: FunctionSelector) {}
+
+#[oracle(setCalldata)]
+unconstrained fn oracle_set_calldata(calldata: [Field]) {}

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -164,18 +164,22 @@ impl TestEnvironment {
         let original_fn_selector = cheatcodes::get_function_selector();
         let target_address = call_interface.get_contract_address();
         let fn_selector = call_interface.get_selector();
+        let calldata = call_interface.get_args();
 
         cheatcodes::set_fn_selector(fn_selector);
         cheatcodes::set_contract_address(target_address);
         cheatcodes::set_msg_sender(original_contract_address);
         let mut inputs = cheatcodes::get_public_context_inputs();
-        inputs.args_hash = hash_args(call_interface.get_args());
+        inputs.calldata_length = call_interface.get_args().len() as Field;
         inputs.is_static_call = call_interface.get_is_static();
+        cheatcodes::set_calldata(calldata);
+
         let result = original_fn(inputs);
 
         cheatcodes::set_fn_selector(original_fn_selector);
         cheatcodes::set_contract_address(original_contract_address);
         cheatcodes::set_msg_sender(original_msg_sender);
+        cheatcodes::set_calldata(calldata);
         result
     }
 

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
@@ -82,17 +82,22 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
         let original_msg_sender = cheatcodes::get_msg_sender();
         let original_contract_address = get_contract_address();
         let original_fn_selector = cheatcodes::get_function_selector();
+        let calldata = call_interface.get_args();
 
         cheatcodes::set_fn_selector(call_interface.get_selector());
         cheatcodes::set_contract_address(instance.to_address());
         cheatcodes::set_msg_sender(original_contract_address);
         let mut inputs = cheatcodes::get_public_context_inputs();
-        inputs.args_hash = hash_args(call_interface.get_args());
+        inputs.calldata_length = call_interface.get_args().len() as Field;
+        inputs.is_static_call = call_interface.get_is_static();
+        cheatcodes::set_calldata(calldata);
+
         let _result: T = original_fn(inputs);
 
         cheatcodes::set_fn_selector(original_fn_selector);
         cheatcodes::set_contract_address(original_contract_address);
         cheatcodes::set_msg_sender(original_msg_sender);
+        cheatcodes::set_calldata(calldata);
         instance
     }
 

--- a/yarn-project/simulator/src/avm/avm_execution_environment.ts
+++ b/yarn-project/simulator/src/avm/avm_execution_environment.ts
@@ -1,15 +1,14 @@
 import { FunctionSelector, type GlobalVariables, type Header } from '@aztec/circuits.js';
-import { computeVarArgsHash } from '@aztec/circuits.js/hash';
 import { type AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
 
 export class AvmContextInputs {
   static readonly SIZE = 2;
 
-  constructor(private argsHash: Fr, private isStaticCall: boolean) {}
+  constructor(private calldataSize: Fr, private isStaticCall: boolean) {}
 
   public toFields(): Fr[] {
-    return [this.argsHash, new Fr(this.isStaticCall)];
+    return [this.calldataSize, new Fr(this.isStaticCall)];
   }
 }
 
@@ -33,7 +32,7 @@ export class AvmExecutionEnvironment {
   ) {
     // We encode some extra inputs (AvmContextInputs) in calldata.
     // This will have to go once we move away from one proof per call.
-    const inputs = new AvmContextInputs(computeVarArgsHash(calldata), isStaticCall).toFields();
+    const inputs = new AvmContextInputs(new Fr(calldata.length), isStaticCall).toFields();
     this.calldata = [...inputs, ...calldata];
   }
 

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -82,6 +82,9 @@ export class TXE implements TypedOracle {
   private contractAddress: AztecAddress;
   private msgSender: AztecAddress;
   private functionSelector = FunctionSelector.fromField(new Fr(0));
+  // This will hold the _real_ calldata. That is, the one without the PublicContextInputs.
+  // TODO: Remove this comment once PublicContextInputs are removed.
+  private calldata: Fr[] = [];
 
   private contractDataOracle: ContractDataOracle;
 
@@ -128,8 +131,18 @@ export class TXE implements TypedOracle {
     return this.functionSelector;
   }
 
+  getCalldata() {
+    // TODO: Remove this once PublicContextInputs are removed.
+    const inputs = this.getPublicContextInputs();
+    return [...inputs.toFields(), ...this.calldata];
+  }
+
   setMsgSender(msgSender: Fr) {
     this.msgSender = msgSender;
+  }
+
+  setCalldata(calldata: Fr[]) {
+    this.calldata = calldata;
   }
 
   setFunctionSelector(functionSelector: FunctionSelector) {
@@ -204,10 +217,10 @@ export class TXE implements TypedOracle {
 
   getPublicContextInputs() {
     const inputs = {
-      argsHash: new Fr(0),
+      calldataLength: new Fr(this.calldata.length),
       isStaticCall: false,
       toFields: function () {
-        return [this.argsHash, new Fr(this.isStaticCall)];
+        return [this.calldataLength, new Fr(this.isStaticCall)];
       },
     };
     return inputs;
@@ -738,6 +751,7 @@ export class TXE implements TypedOracle {
     this.setMsgSender(this.contractAddress);
     this.setContractAddress(targetContractAddress);
     this.setFunctionSelector(functionSelector);
+    this.setCalldata(args);
 
     const callContext = CallContext.empty();
     callContext.msgSender = this.msgSender;

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -272,6 +272,11 @@ export class TXEService {
     return toForeignCallResult([]);
   }
 
+  setCalldata(_length: ForeignCallSingle, calldata: ForeignCallArray) {
+    (this.typedOracle as TXE).setCalldata(fromArray(calldata));
+    return toForeignCallResult([]);
+  }
+
   getFunctionSelector() {
     const functionSelector = (this.typedOracle as TXE).getFunctionSelector();
     return toForeignCallResult([toSingle(functionSelector.toField())]);
@@ -580,6 +585,17 @@ export class TXEService {
   async avmOpcodeStorageWrite(slot: ForeignCallSingle, value: ForeignCallSingle) {
     await this.typedOracle.storageWrite(fromSingle(slot), [fromSingle(value)]);
     return toForeignCallResult([]);
+  }
+
+  //unconstrained fn calldata_copy_opcode<let N: u32>(cdoffset: u32, copy_size: u32) -> [Field; N] {}
+  avmOpcodeCalldataCopy(cdOffsetInput: ForeignCallSingle, copySizeInput: ForeignCallSingle) {
+    const cdOffset = fromSingle(cdOffsetInput).toNumber();
+    const copySize = fromSingle(copySizeInput).toNumber();
+
+    const calldata = (this.typedOracle as TXE).getCalldata();
+    const calldataSlice = calldata.slice(cdOffset, cdOffset + copySize);
+
+    return toForeignCallResult([toArray(calldataSlice)]);
   }
 
   async getPublicKeysAndPartialAddress(address: ForeignCallSingle) {


### PR DESCRIPTION
This PR implements `PublicContext::get_args_hash` in user space. We are still passing the calldata length as a runtime variable until we can get it at compile time. This requires @Thunkar 's work on `aztec(public)` as a macro.

Once that is done, we'll pass the hasher as a closure when creating the PublicContext, i.e.:
```
struct PublicContext {
    hash_getter: fn[(Field,)]() -> Field,
    // ...
}

impl PublicContext {
    pub fn new(..., hash_getter) -> Self {
        // ...
    }

    fn get_args_hash(self) -> Field {
        (self.hash_getter)()
    }
}

// In the aztec(public) macro
comptime let N = get_calldata_length();
let hash_getter = || {
    let mut hasher = ArgsHasher::new();
    let mut fields = std::meta::unquote!(quote { [0; $N] });
    fields = calldata_copy(2 /*or 1*/, N);
    hasher.add_many(fields);
    hasher.hash()
};
let context = PublicContext::new(..., hash_getter);
```