### PR TITLE
chore: fix a bunch of generics issues in aztec-nr

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -222,7 +222,7 @@ impl PrivateContext {
         let cached_request = self.last_key_validation_requests[key_index].unwrap_or(KeyValidationRequest::empty());
 
         if cached_request.pk_m.hash() == pk_m_hash {
-            // We get a match so the cached request is the latest one 
+            // We get a match so the cached request is the latest one
             cached_request.sk_app
         } else {
             // We didn't get a match meaning the cached result is stale. We fetch new values from oracle and instruct
@@ -323,7 +323,7 @@ impl PrivateContext {
         self.call_private_function_with_packed_args(contract_address, function_selector, args_hash, false, true)
     }
 
-    pub fn call_private_function_no_args<RETURNS_COUNT>(
+    pub fn call_private_function_no_args(
         &mut self,
         contract_address: AztecAddress,
         function_selector: FunctionSelector
@@ -331,7 +331,7 @@ impl PrivateContext {
         self.call_private_function_with_packed_args(contract_address, function_selector, 0, false, false)
     }
 
-    pub fn static_call_private_function_no_args<RETURNS_COUNT>(
+    pub fn static_call_private_function_no_args(
         &mut self,
         contract_address: AztecAddress,
         function_selector: FunctionSelector
@@ -339,7 +339,7 @@ impl PrivateContext {
         self.call_private_function_with_packed_args(contract_address, function_selector, 0, true, false)
     }
 
-    pub fn delegate_call_private_function_no_args<let ARGS_COUNT: u32>(
+    pub fn delegate_call_private_function_no_args(
         &mut self,
         contract_address: AztecAddress,
         function_selector: FunctionSelector
@@ -347,7 +347,7 @@ impl PrivateContext {
         self.call_private_function_with_packed_args(contract_address, function_selector, 0, false, true)
     }
 
-    pub fn call_private_function_with_packed_args<RETURNS_COUNT>(
+    pub fn call_private_function_with_packed_args(
         &mut self,
         contract_address: AztecAddress,
         function_selector: FunctionSelector,
@@ -511,7 +511,7 @@ impl PrivateContext {
         self.set_public_teardown_function_with_packed_args(contract_address, function_selector, args_hash, false, false)
     }
 
-    pub fn set_public_teardown_function_with_packed_args<let ARGS_COUNT: u32>(
+    pub fn set_public_teardown_function_with_packed_args(
         &mut self,
         contract_address: AztecAddress,
         function_selector: FunctionSelector,

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -391,15 +391,17 @@ impl<let N: u32> FunctionReturns<N> {
         FunctionReturns { values }
     }
 
-    pub fn assert_empty(returns: FunctionReturns<0>) {
-        assert(returns.values.len() == 0);
-    }
-
     pub fn raw(self) -> [Field; N] {
         self.values
     }
 
     pub fn deserialize_into<T>(self) -> T where T: Deserialize<N> {
         Deserialize::deserialize(self.raw())
+    }
+}
+
+impl FunctionReturns<0> {
+    pub fn assert_empty(self) {
+        assert(self.values.len() == 0);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
@@ -14,7 +14,7 @@ fn extract_property_value_from_selector<let N: u32>(
     serialized_note: [Field; N],
     selector: PropertySelector
 ) -> Field {
-    // Selectors use PropertySelectors in order to locate note properties inside the serialized note. 
+    // Selectors use PropertySelectors in order to locate note properties inside the serialized note.
     // This allows easier packing and custom (de)serialization schemas. A note property is located
     // inside the serialized note using the index inside the array, a byte offset and a length.
     let value = serialized_note[selector.index].to_be_bytes(32);
@@ -113,7 +113,7 @@ pub fn get_notes<Note, let N: u32, let M: u32, PREPROCESSOR_ARGS, FILTER_ARGS>(
     constrain_get_notes_internal(context, storage_slot, opt_notes, options)
 }
 
-unconstrained fn apply_preprocessor<Note, let N: u32, let M: u32, PREPROCESSOR_ARGS>(
+unconstrained fn apply_preprocessor<Note, PREPROCESSOR_ARGS>(
     notes: [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
     preprocessor: fn([Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], PREPROCESSOR_ARGS) -> [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
     preprocessor_args: PREPROCESSOR_ARGS
@@ -264,7 +264,7 @@ unconstrained pub fn view_notes<Note, let N: u32, let M: u32>(
     notes
 }
 
-unconstrained fn flatten_options<Note, let N: u32>(
+unconstrained fn flatten_options<let N: u32>(
     selects: BoundedVec<Option<Select>, N>,
     sorts: BoundedVec<Option<Sort>, N>
 ) -> (u8, [u8; N], [u8; N], [u8; N], [Field; N], [u8; N], [u8; N], [u8; N], [u8; N], [u8; N]) {

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter_options.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter_options.nr
@@ -70,7 +70,7 @@ global NoteStatus = NoteStatusEnum {
     // TODO 4217: add 'NULLIFIED'
 };
 
-fn return_all_notes<Note, let N: u32>(
+fn return_all_notes<Note>(
     notes: [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
     _p: Field
 ) -> [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] {
@@ -100,64 +100,9 @@ struct NoteGetterOptions<Note, let N: u32, let M: u32, PREPROCESSOR_ARGS, FILTER
 // the result size.
 // And finally, a custom preprocessor and filter to refine the outcome further.
 impl<Note, let N: u32, let M: u32, PREPROCESSOR_ARGS, FILTER_ARGS> NoteGetterOptions<Note, N, M, PREPROCESSOR_ARGS, FILTER_ARGS> {
-    // This function initializes a NoteGetterOptions that simply returns the maximum number of notes allowed in a call.
-    pub fn new() -> NoteGetterOptions<Note, N, M, Field, Field> where Note: NoteInterface<N, M> {
-        NoteGetterOptions {
-            selects: BoundedVec::new(),
-            sorts: BoundedVec::new(),
-            limit: MAX_NOTE_HASH_READ_REQUESTS_PER_CALL as u32,
-            offset: 0,
-            preprocessor: return_all_notes,
-            preprocessor_args: 0,
-            filter: return_all_notes,
-            filter_args: 0,
-            status: NoteStatus.ACTIVE
-        }
-    }
-
-    // This function initializes a NoteGetterOptions with a preprocessor, which takes the notes returned from
-    // the database and preprocessor_args as its parameters.
-    // `preprocessor_args` allows you to provide additional data or context to the custom preprocessor.
-    pub fn with_preprocessor(
-        preprocessor: fn([Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], PREPROCESSOR_ARGS) -> [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-        preprocessor_args: PREPROCESSOR_ARGS
-    ) -> NoteGetterOptions<Note, N, M, PREPROCESSOR_ARGS, Field> where Note: NoteInterface<N, M> {
-        NoteGetterOptions {
-            selects: BoundedVec::new(),
-            sorts: BoundedVec::new(),
-            limit: MAX_NOTE_HASH_READ_REQUESTS_PER_CALL as u32,
-            offset: 0,
-            preprocessor,
-            preprocessor_args,
-            filter: return_all_notes,
-            filter_args: 0,
-            status: NoteStatus.ACTIVE
-        }
-    }
-
-    // This function initializes a NoteGetterOptions with a filter, which takes
-    // the notes returned from the database and filter_args as its parameters.
-    // `filter_args` allows you to provide additional data or context to the custom filter.
-    pub fn with_filter(
-        filter: fn([Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], FILTER_ARGS) -> [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-        filter_args: FILTER_ARGS
-    ) -> NoteGetterOptions<Note, N, M, Field, FILTER_ARGS> where Note: NoteInterface<N, M> {
-        NoteGetterOptions {
-            selects: BoundedVec::new(),
-            sorts: BoundedVec::new(),
-            limit: MAX_NOTE_HASH_READ_REQUESTS_PER_CALL as u32,
-            offset: 0,
-            preprocessor: return_all_notes,
-            preprocessor_args: 0,
-            filter,
-            filter_args,
-            status: NoteStatus.ACTIVE
-        }
-    }
-
     // This method adds a `Select` criterion to the options.
-    // It takes a property_selector indicating which field to select, 
-    // a value representing the specific value to match in that field, and 
+    // It takes a property_selector indicating which field to select,
+    // a value representing the specific value to match in that field, and
     // a comparator (For possible values of comparators, please see the Comparator enum above)
     pub fn select<T>(
         &mut self,
@@ -205,5 +150,66 @@ impl<Note, let N: u32, let M: u32, PREPROCESSOR_ARGS, FILTER_ARGS> NoteGetterOpt
     pub fn set_status(&mut self, status: u8) -> Self {
         self.status = status;
         *self
+    }
+}
+
+impl<Note, let N: u32, let M: u32> NoteGetterOptions<Note, N, M, Field, Field> where Note: NoteInterface<N, M> {
+    // This function initializes a NoteGetterOptions that simply returns the maximum number of notes allowed in a call.
+    pub fn new() -> Self {
+        Self {
+            selects: BoundedVec::new(),
+            sorts: BoundedVec::new(),
+            limit: MAX_NOTE_HASH_READ_REQUESTS_PER_CALL as u32,
+            offset: 0,
+            preprocessor: return_all_notes,
+            preprocessor_args: 0,
+            filter: return_all_notes,
+            filter_args: 0,
+            status: NoteStatus.ACTIVE
+        }
+    }
+}
+
+impl<Note, let N: u32, let M: u32, PREPROCESSOR_ARGS> NoteGetterOptions<Note, N, M, PREPROCESSOR_ARGS, Field> where Note: NoteInterface<N, M> {
+    // This function initializes a NoteGetterOptions with a preprocessor, which takes the notes returned from
+    // the database and preprocessor_args as its parameters.
+    // `preprocessor_args` allows you to provide additional data or context to the custom preprocessor.
+    pub fn with_preprocessor(
+        preprocessor: fn([Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], PREPROCESSOR_ARGS) -> [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+        preprocessor_args: PREPROCESSOR_ARGS
+    ) -> Self {
+        Self {
+            selects: BoundedVec::new(),
+            sorts: BoundedVec::new(),
+            limit: MAX_NOTE_HASH_READ_REQUESTS_PER_CALL as u32,
+            offset: 0,
+            preprocessor,
+            preprocessor_args,
+            filter: return_all_notes,
+            filter_args: 0,
+            status: NoteStatus.ACTIVE
+        }
+    }
+}
+
+impl<Note, let N: u32, let M: u32, FILTER_ARGS> NoteGetterOptions<Note, N, M, Field, FILTER_ARGS> where Note: NoteInterface<N, M> {
+    // This function initializes a NoteGetterOptions with a filter, which takes
+    // the notes returned from the database and filter_args as its parameters.
+    // `filter_args` allows you to provide additional data or context to the custom filter.
+    pub fn with_filter(
+        filter: fn([Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], FILTER_ARGS) -> [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+        filter_args: FILTER_ARGS
+    ) -> Self {
+        Self {
+            selects: BoundedVec::new(),
+            sorts: BoundedVec::new(),
+            limit: MAX_NOTE_HASH_READ_REQUESTS_PER_CALL as u32,
+            offset: 0,
+            preprocessor: return_all_notes,
+            preprocessor_args: 0,
+            filter,
+            filter_args,
+            status: NoteStatus.ACTIVE
+        }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/oracle/arguments.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/arguments.nr
@@ -5,18 +5,18 @@ unconstrained fn pack_arguments_array_oracle<let N: u32>(_args: [Field; N]) -> F
 unconstrained fn pack_arguments_oracle(_args: [Field]) -> Field {}
 
 /// - Pack arguments (array version) will notify the simulator that these arguments will be used later at
-///   some point in the call. 
+///   some point in the call.
 /// - When the external call is made later, the simulator will know what the values unpack to.
-/// - This oracle will not be required in public vm functions, as the vm will keep track of arguments 
+/// - This oracle will not be required in public vm functions, as the vm will keep track of arguments
 ///   itself.
 unconstrained pub fn pack_arguments_array<let N: u32>(args: [Field; N]) -> Field {
     pack_arguments_array_oracle(args)
 }
 
 /// - Pack arguments (slice version) will notify the simulator that these arguments will be used later at
-///   some point in the call. 
+///   some point in the call.
 /// - When the external call is made later, the simulator will know what the values unpack to.
-/// - This oracle will not be required in public vm functions, as the vm will keep track of arguments 
+/// - This oracle will not be required in public vm functions, as the vm will keep track of arguments
 ///   itself.
 unconstrained pub fn pack_arguments(args: [Field]) -> Field {
     pack_arguments_oracle(args)

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_membership_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_membership_witness.nr
@@ -33,7 +33,7 @@ unconstrained pub fn get_membership_witness<let N: u32, let M: u32>(
 
 // Note: get_nullifier_membership_witness function is implemented in get_nullifier_membership_witness.nr
 
-unconstrained pub fn get_note_hash_membership_witness<let N: u32, let M: u32>(
+unconstrained pub fn get_note_hash_membership_witness(
     block_number: u32,
     leaf_value: Field
 ) -> MembershipWitness<NOTE_HASH_TREE_HEIGHT, NOTE_HASH_TREE_HEIGHT + 1> {

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -22,13 +22,9 @@ unconstrained pub fn notify_created_note<let N: u32>(
 }
 
 #[oracle(notifyNullifiedNote)]
-unconstrained fn notify_nullified_note_oracle<let N: u32>(_nullifier: Field, _note_hash: Field, _counter: u32) -> Field {}
+unconstrained fn notify_nullified_note_oracle(_nullifier: Field, _note_hash: Field, _counter: u32) -> Field {}
 
-unconstrained pub fn notify_nullified_note<let N: u32>(
-    nullifier: Field,
-    note_hash: Field,
-    counter: u32
-) -> Field {
+unconstrained pub fn notify_nullified_note(nullifier: Field, note_hash: Field, counter: u32) -> Field {
     notify_nullified_note_oracle(nullifier, note_hash, counter)
 }
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/returns.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/returns.nr
@@ -1,5 +1,5 @@
 #[oracle(packReturns)]
-unconstrained fn pack_returns_oracle<let N: u32>(_returns: [Field]) -> Field {}
+unconstrained fn pack_returns_oracle(_returns: [Field]) -> Field {}
 
 unconstrained pub fn pack_returns(returns: [Field]) {
     let _unused = pack_returns_oracle(returns);

--- a/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
@@ -33,3 +33,4 @@ impl<K, V, Context> Map<K, V, Context> {
     }
     // docs:end:at
 }
+

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/shared_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/shared_mutable.nr
@@ -123,7 +123,6 @@ impl<T, let INITIAL_DELAY: u32, Context> SharedMutable<T, INITIAL_DELAY, Context
 }
 
 impl<T, let INITIAL_DELAY: u32> SharedMutable<T, INITIAL_DELAY, &mut PublicContext> where T: ToField + FromField + Eq {
-
     pub fn schedule_value_change(self, new_value: T) {
         let mut value_change = self.read_value_change();
         let delay_change = self.read_delay_change();

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/shared_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/shared_mutable.nr
@@ -62,16 +62,6 @@ impl<T, let INITIAL_DELAY: u32, Context> SharedMutable<T, INITIAL_DELAY, Context
         Self { context, storage_slot }
     }
 
-    fn hash_scheduled_data(
-        value_change: ScheduledValueChange<T>,
-        delay_change: ScheduledDelayChange<INITIAL_DELAY>
-    ) -> Field {
-        // TODO(#5491 and https://github.com/noir-lang/noir/issues/4784): update this so that we don't need to rely on
-        // ScheduledValueChange serializing to 3 and ScheduledDelayChange serializing to 1
-        let concatenated: [Field; 4] = concat_arrays(value_change.serialize(), delay_change.serialize());
-        poseidon2_hash(concatenated)
-    }
-
     // Since we can't rely on the native storage allocation scheme, we hash the storage slot to get a unique location in
     // which we can safely store as much data as we need.
     // See https://github.com/AztecProtocol/aztec-packages/issues/5492 and
@@ -133,6 +123,7 @@ impl<T, let INITIAL_DELAY: u32, Context> SharedMutable<T, INITIAL_DELAY, Context
 }
 
 impl<T, let INITIAL_DELAY: u32> SharedMutable<T, INITIAL_DELAY, &mut PublicContext> where T: ToField + FromField + Eq {
+
     pub fn schedule_value_change(self, new_value: T) {
         let mut value_change = self.read_value_change();
         let delay_change = self.read_delay_change();
@@ -227,6 +218,16 @@ impl<T, let INITIAL_DELAY: u32> SharedMutable<T, INITIAL_DELAY, &mut PrivateCont
         // historical public value matches the current one, since it can only change after the horizon.
         self.context.set_tx_max_block_number(block_horizon);
         value_change.get_current_at(historical_block_number)
+    }
+
+    fn hash_scheduled_data(
+        value_change: ScheduledValueChange<T>,
+        delay_change: ScheduledDelayChange<INITIAL_DELAY>
+    ) -> Field {
+        // TODO(#5491 and https://github.com/noir-lang/noir/issues/4784): update this so that we don't need to rely on
+        // ScheduledValueChange serializing to 3 and ScheduledDelayChange serializing to 1
+        let concatenated: [Field; 4] = concat_arrays(value_change.serialize(), delay_change.serialize());
+        poseidon2_hash(concatenated)
     }
 }
 

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -21,7 +21,7 @@ impl<Context> EasyPrivateUint<Context> {
     }
 }
 
-impl<Context> EasyPrivateUint<&mut PrivateContext> {
+impl EasyPrivateUint<&mut PrivateContext> {
     // Very similar to `value_note::utils::increment`.
     pub fn add(self, addend: u64, owner: AztecAddress, outgoing_viewer: AztecAddress) {
         let owner_keys = get_current_public_keys(self.context, owner);

--- a/noir-projects/noir-contracts/contracts/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/counter_contract/src/main.nr
@@ -55,7 +55,7 @@ contract Counter {
         let initial_value: Field = 5;
         env.impersonate(owner);
 
-        // Deploy contract and initialize 
+        // Deploy contract and initialize
         let initializer = Counter::interface().initialize(initial_value as u64, owner, outgoing_viewer);
         let counter_contract = env.deploy_self("Counter").with_private_initializer(initializer);
         let contract_address = counter_contract.to_address();

--- a/noir-projects/noir-contracts/contracts/easy_private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/easy_private_token_contract/src/main.nr
@@ -1,6 +1,6 @@
 // docs:start:easy_private_token_contract
 contract EasyPrivateToken {
-    use dep::aztec::prelude::{AztecAddress, NoteHeader, Map};
+    use dep::aztec::prelude::{AztecAddress, Map};
     use dep::value_note::balance_utils;
     use dep::easy_private_state::EasyPrivateUint;
 

--- a/noir-projects/noir-contracts/contracts/static_parent_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/static_parent_contract/src/main.nr
@@ -1,7 +1,7 @@
 
 // A contract used along with `StaticChild` contract to test static calls.
 contract StaticParent {
-    use dep::aztec::prelude::{AztecAddress, FunctionSelector, Deserialize};
+    use dep::aztec::prelude::{AztecAddress, FunctionSelector};
     use dep::aztec::context::gas::GasOpts;
     use dep::static_child_contract::StaticChild;
 


### PR DESCRIPTION
This PR removes a bunch of unnecessary generics from the aztec-nr codebase as this is becoming a hard error in new versions of nargo.