### PR TITLE
fix: Split stores per component and split merkle tree operations

### DIFF
--- a/yarn-project/archiver/src/factory.ts
+++ b/yarn-project/archiver/src/factory.ts
@@ -1,4 +1,5 @@
-import { type AztecKVStore } from '@aztec/kv-store';
+import { createDebugLogger } from '@aztec/foundation/log';
+import { createStore } from '@aztec/kv-store/utils';
 import { type TelemetryClient } from '@aztec/telemetry-client';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
@@ -7,14 +8,13 @@ import { type ArchiverConfig } from './archiver/config.js';
 import { KVArchiverDataStore } from './archiver/index.js';
 import { createArchiverClient } from './rpc/archiver_client.js';
 
-export function createArchiver(
+export async function createArchiver(
   config: ArchiverConfig,
-  store: AztecKVStore,
   telemetry: TelemetryClient = new NoopTelemetryClient(),
   opts: { blockUntilSync: boolean } = { blockUntilSync: true },
 ) {
   if (!config.archiverUrl) {
-    // first create and sync the archiver
+    const store = await createStore('archiver', config, createDebugLogger('aztec:archiver:lmdb'));
     const archiverStore = new KVArchiverDataStore(store, config.maxLogs);
     return Archiver.createAndSync(config, archiverStore, telemetry, opts.blockUntilSync);
   } else {

--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -4,12 +4,11 @@ import {
   type L1ToL2MessageSource,
   type L2BlockSource,
   type L2LogsSource,
+  type MerkleTreeAdminOperations,
   MerkleTreeId,
-  type MerkleTreeOperations,
   mockTxForRollup,
 } from '@aztec/circuit-types';
 import { AztecAddress, EthAddress, Fr, GasFees, GlobalVariables, MaxBlockNumber } from '@aztec/circuits.js';
-import { type AztecLmdbStore } from '@aztec/kv-store/lmdb';
 import { type P2P } from '@aztec/p2p';
 import { type GlobalVariableBuilder } from '@aztec/sequencer-client';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
@@ -24,7 +23,7 @@ import { AztecNodeService } from './server.js';
 describe('aztec node', () => {
   let p2p: MockProxy<P2P>;
   let globalVariablesBuilder: MockProxy<GlobalVariableBuilder>;
-  let merkleTreeOps: MockProxy<MerkleTreeOperations>;
+  let merkleTreeOps: MockProxy<MerkleTreeAdminOperations>;
 
   let lastBlockNumber: number;
 
@@ -42,7 +41,7 @@ describe('aztec node', () => {
     p2p = mock<P2P>();
 
     globalVariablesBuilder = mock<GlobalVariableBuilder>();
-    merkleTreeOps = mock<MerkleTreeOperations>();
+    merkleTreeOps = mock<MerkleTreeAdminOperations>();
 
     const worldState = mock<WorldStateSynchronizer>({
       getLatest: () => merkleTreeOps,
@@ -58,8 +57,6 @@ describe('aztec node', () => {
 
     // all txs use the same allowed FPC class
     const contractSource = mock<ContractDataSource>();
-
-    const store = mock<AztecLmdbStore>();
 
     const aztecNodeConfig: AztecNodeConfig = getConfigEnvVars();
 
@@ -86,7 +83,6 @@ describe('aztec node', () => {
       31337,
       1,
       globalVariablesBuilder,
-      store,
       new TestCircuitVerifier(),
       new NoopTelemetryClient(),
     );

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -726,13 +726,8 @@ export class AztecNodeService implements AztecNode {
     );
     const prevHeader = (await this.blockSource.getBlock(-1))?.header;
 
-    // Instantiate merkle trees so uncommitted updates by this simulation are local to it.
-    // TODO we should be able to remove this after https://github.com/AztecProtocol/aztec-packages/issues/1869
-    // So simulation of public functions doesn't affect the merkle trees.
-    const merkleTrees = await MerkleTrees.new(this.merkleTreesDb, new NoopTelemetryClient(), this.log);
-
     const publicProcessorFactory = new PublicProcessorFactory(
-      merkleTrees.asLatest(),
+      await this.worldStateSynchronizer.ephemeralFork(),
       this.contractDataSource,
       new WASMSimulator(),
       this.telemetry,

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -50,10 +50,9 @@ import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
-import { type AztecKVStore } from '@aztec/kv-store';
-import { createStore, openTmpStore } from '@aztec/kv-store/utils';
+import { openTmpStore } from '@aztec/kv-store/utils';
 import { SHA256Trunc, StandardTree, UnbalancedTree } from '@aztec/merkle-tree';
-import { AztecKVTxPool, InMemoryAttestationPool, type P2P, createP2PClient } from '@aztec/p2p';
+import { InMemoryAttestationPool, type P2P, createP2PClient } from '@aztec/p2p';
 import { getCanonicalClassRegisterer } from '@aztec/protocol-contracts/class-registerer';
 import { getCanonicalFeeJuice } from '@aztec/protocol-contracts/fee-juice';
 import { getCanonicalInstanceDeployer } from '@aztec/protocol-contracts/instance-deployer';
@@ -77,7 +76,7 @@ import {
   type ProtocolContractAddresses,
 } from '@aztec/types/contracts';
 import { createValidatorClient } from '@aztec/validator-client';
-import { MerkleTrees, type WorldStateSynchronizer, createWorldStateSynchronizer } from '@aztec/world-state';
+import { type WorldStateSynchronizer, createWorldStateSynchronizer } from '@aztec/world-state';
 
 import { type AztecNodeConfig, getPackageInfo } from './config.js';
 import { NodeMetrics } from './node_metrics.js';
@@ -104,7 +103,6 @@ export class AztecNodeService implements AztecNode {
     protected readonly l1ChainId: number,
     protected readonly version: number,
     protected readonly globalVariableBuilder: GlobalVariableBuilder,
-    protected readonly merkleTreesDb: AztecKVStore,
     private proofVerifier: ClientProtocolCircuitVerifier,
     private telemetry: TelemetryClient,
     private log = createDebugLogger('aztec:node'),
@@ -131,7 +129,6 @@ export class AztecNodeService implements AztecNode {
     config: AztecNodeConfig,
     telemetry?: TelemetryClient,
     log = createDebugLogger('aztec:node'),
-    storeLog = createDebugLogger('aztec:node:lmdb'),
   ): Promise<AztecNodeService> {
     telemetry ??= new NoopTelemetryClient();
     const ethereumChain = createEthereumChain(config.l1RpcUrl, config.l1ChainId);
@@ -142,25 +139,17 @@ export class AztecNodeService implements AztecNode {
       );
     }
 
-    const store = await createStore(config, config.l1Contracts.rollupAddress, storeLog);
-
-    const archiver = await createArchiver(config, store, telemetry, { blockUntilSync: true });
+    const archiver = await createArchiver(config, telemetry, { blockUntilSync: true });
 
     // we identify the P2P transaction protocol by using the rollup contract address.
     // this may well change in future
     config.transactionProtocol = `/aztec/tx/${config.l1Contracts.rollupAddress.toString()}`;
 
     // create the tx pool and the p2p client, which will need the l2 block source
-    const p2pClient = await createP2PClient(
-      config,
-      store,
-      new AztecKVTxPool(store, telemetry),
-      new InMemoryAttestationPool(),
-      archiver,
-    );
+    const p2pClient = await createP2PClient(config, new InMemoryAttestationPool(), archiver, telemetry);
 
     // now create the merkle trees and the world state synchronizer
-    const worldStateSynchronizer = await createWorldStateSynchronizer(config, store, archiver, telemetry);
+    const worldStateSynchronizer = await createWorldStateSynchronizer(config, archiver, telemetry);
 
     // start both and wait for them to sync from the block source
     await Promise.all([p2pClient.start(), worldStateSynchronizer.start()]);
@@ -199,7 +188,6 @@ export class AztecNodeService implements AztecNode {
       ethereumChain.chainInfo.id,
       config.version,
       new GlobalVariableBuilder(config),
-      store,
       proofVerifier,
       telemetry,
       log,

--- a/yarn-project/aztec/src/cli/cmds/start_archiver.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_archiver.ts
@@ -21,8 +21,7 @@ export const startArchiver = async (options: any, signalHandlers: (() => Promise
   const archiverConfig = extractRelevantOptions<ArchiverConfig>(options, archiverConfigMappings, 'archiver');
 
   const storeLog = createDebugLogger('aztec:archiver:lmdb');
-  const rollupAddress = archiverConfig.l1Contracts.rollupAddress;
-  const store = await createStore(archiverConfig, rollupAddress, storeLog);
+  const store = await createStore('archiver', archiverConfig, storeLog);
   const archiverStore = new KVArchiverDataStore(store, archiverConfig.maxLogs);
 
   const telemetry = await createAndStartTelemetryClient(getTelemetryClientConfig());

--- a/yarn-project/circuit-types/src/interfaces/merkle_tree_operations.ts
+++ b/yarn-project/circuit-types/src/interfaces/merkle_tree_operations.ts
@@ -84,9 +84,7 @@ type LeafTypes = {
 
 export type MerkleTreeLeafType<ID extends MerkleTreeId> = LeafTypes[ID];
 
-/**
- * Defines the interface for operations on a set of Merkle Trees.
- */
+/** Defines the interface for operations on a set of Merkle Trees. */
 export interface MerkleTreeOperations {
   /**
    * Appends leaves to a given tree.
@@ -203,7 +201,10 @@ export interface MerkleTreeOperations {
     leaves: Buffer[],
     subtreeHeight: number,
   ): Promise<BatchInsertionResult<TreeHeight, SubtreeSiblingPathHeight>>;
+}
 
+/** Operations on merkle trees world state that can modify the underlying store. */
+export interface MerkleTreeAdminOperations extends MerkleTreeOperations {
   /**
    * Handles a single L2 block (i.e. Inserts the new note hashes into the merkle tree).
    * @param block - The L2 block to handle.

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -339,7 +339,7 @@ describe('e2e_block_building', () => {
     });
 
     // Regression for https://github.com/AztecProtocol/aztec-packages/issues/8306
-    it.skip('can simulate public txs while building a block', async () => {
+    it('can simulate public txs while building a block', async () => {
       ({
         teardown,
         pxe,
@@ -368,7 +368,7 @@ describe('e2e_block_building', () => {
       }
 
       logger.info('Waiting for txs to be mined');
-      await Promise.all(txs.map(tx => tx.wait()));
+      await Promise.all(txs.map(tx => tx.wait({ proven: false, timeout: 600 })));
     });
   });
 });

--- a/yarn-project/end-to-end/src/e2e_prover/e2e_prover_test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/e2e_prover_test.ts
@@ -17,7 +17,6 @@ import {
   deployL1Contract,
 } from '@aztec/aztec.js';
 import { BBCircuitVerifier } from '@aztec/bb-prover';
-import { createStore } from '@aztec/kv-store/utils';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { TokenContract } from '@aztec/noir-contracts.js';
 import { type ProverNode, type ProverNodeConfig, createProverNode } from '@aztec/prover-node';

--- a/yarn-project/end-to-end/src/e2e_prover/e2e_prover_test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/e2e_prover_test.ts
@@ -225,11 +225,8 @@ export class FullProverTest {
     // Creating temp store and archiver for fully proven prover node
 
     this.logger.verbose('Starting archiver for new prover node');
-    const store = await createStore({ dataDirectory: undefined }, this.l1Contracts.l1ContractAddresses.rollupAddress);
-
     const archiver = await createArchiver(
       { ...this.context.aztecNodeConfig, dataDirectory: undefined },
-      store,
       new NoopTelemetryClient(),
       { blockUntilSync: true },
     );

--- a/yarn-project/end-to-end/src/public-testnet/e2e_public_testnet_transfer.test.ts
+++ b/yarn-project/end-to-end/src/public-testnet/e2e_public_testnet_transfer.test.ts
@@ -45,12 +45,7 @@ describe(`deploys and transfers a private only token`, () => {
         ? `0x${proverNodePrivateKey?.toString('hex')}`
         : proverConfig.publisherPrivateKey;
 
-    proverNode = await createAndSyncProverNode(
-      config.l1Contracts.rollupAddress,
-      proverConfig.publisherPrivateKey,
-      config,
-      aztecNode,
-    );
+    proverNode = await createAndSyncProverNode(proverConfig.publisherPrivateKey, config, aztecNode);
   }, 600_000);
 
   afterEach(async () => {

--- a/yarn-project/prover-client/src/mocks/test_context.ts
+++ b/yarn-project/prover-client/src/mocks/test_context.ts
@@ -1,6 +1,7 @@
 import { type BBProverConfig } from '@aztec/bb-prover';
 import {
   type BlockProver,
+  type MerkleTreeAdminOperations,
   type ProcessedTx,
   type PublicExecutionRequest,
   type ServerCircuitProver,
@@ -23,7 +24,7 @@ import {
   type WorldStatePublicDB,
 } from '@aztec/simulator';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
-import { type MerkleTreeOperations, MerkleTrees } from '@aztec/world-state';
+import { MerkleTrees } from '@aztec/world-state';
 
 import * as fs from 'fs/promises';
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -42,7 +43,7 @@ export class TestContext {
     public publicProcessor: PublicProcessor,
     public simulationProvider: SimulationProvider,
     public globalVariables: GlobalVariables,
-    public actualDb: MerkleTreeOperations,
+    public actualDb: MerkleTreeAdminOperations,
     public prover: ServerCircuitProver,
     public proverAgent: ProverAgent,
     public orchestrator: ProvingOrchestrator,

--- a/yarn-project/prover-node/src/prover-node.test.ts
+++ b/yarn-project/prover-node/src/prover-node.test.ts
@@ -1,7 +1,7 @@
 import {
   type L1ToL2MessageSource,
   type L2BlockSource,
-  type MerkleTreeOperations,
+  type MerkleTreeAdminOperations,
   type ProverClient,
   type TxProvider,
 } from '@aztec/circuit-types';
@@ -32,7 +32,7 @@ describe('prover-node', () => {
   let jobs: {
     job: MockProxy<BlockProvingJob>;
     cleanUp: (job: BlockProvingJob) => Promise<void>;
-    db: MerkleTreeOperations;
+    db: MerkleTreeAdminOperations;
   }[];
 
   beforeEach(() => {
@@ -47,7 +47,7 @@ describe('prover-node', () => {
     const telemetryClient = new NoopTelemetryClient();
 
     // World state returns a new mock db every time it is asked to fork
-    worldState.syncImmediateAndFork.mockImplementation(() => Promise.resolve(mock<MerkleTreeOperations>()));
+    worldState.syncImmediateAndFork.mockImplementation(() => Promise.resolve(mock<MerkleTreeAdminOperations>()));
 
     jobs = [];
     proverNode = new TestProverNode(
@@ -161,7 +161,7 @@ describe('prover-node', () => {
 
   class TestProverNode extends ProverNode {
     protected override doCreateBlockProvingJob(
-      db: MerkleTreeOperations,
+      db: MerkleTreeAdminOperations,
       _publicProcessorFactory: PublicProcessorFactory,
       cleanUp: (job: BlockProvingJob) => Promise<void>,
     ): BlockProvingJob {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -5,6 +5,7 @@ import {
   type L1ToL2MessageSource,
   L2Block,
   type L2BlockSource,
+  type MerkleTreeAdminOperations,
   MerkleTreeId,
   PROVING_STATUS,
   type ProvingSuccess,
@@ -35,7 +36,7 @@ import { type PublicProcessor, type PublicProcessorFactory } from '@aztec/simula
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 import { type ContractDataSource } from '@aztec/types/contracts';
 import { type ValidatorClient } from '@aztec/validator-client';
-import { type MerkleTreeOperations, WorldStateRunningState, type WorldStateSynchronizer } from '@aztec/world-state';
+import { WorldStateRunningState, type WorldStateSynchronizer } from '@aztec/world-state';
 
 import { type MockProxy, mock, mockFn } from 'jest-mock-extended';
 
@@ -52,7 +53,7 @@ describe('sequencer', () => {
   let p2p: MockProxy<P2P>;
   let worldState: MockProxy<WorldStateSynchronizer>;
   let blockSimulator: MockProxy<BlockSimulator>;
-  let merkleTreeOps: MockProxy<MerkleTreeOperations>;
+  let merkleTreeOps: MockProxy<MerkleTreeAdminOperations>;
   let publicProcessor: MockProxy<PublicProcessor>;
   let l2BlockSource: MockProxy<L2BlockSource>;
   let l1ToL2MessageSource: MockProxy<L1ToL2MessageSource>;
@@ -104,7 +105,7 @@ describe('sequencer', () => {
     publisher.validateBlockForSubmission.mockResolvedValue(true);
 
     globalVariableBuilder = mock<GlobalVariableBuilder>();
-    merkleTreeOps = mock<MerkleTreeOperations>();
+    merkleTreeOps = mock<MerkleTreeAdminOperations>();
     blockSimulator = mock<BlockSimulator>();
 
     p2p = mock<P2P>({

--- a/yarn-project/world-state/src/synchronizer/factory.ts
+++ b/yarn-project/world-state/src/synchronizer/factory.ts
@@ -1,5 +1,6 @@
 import { type L1ToL2MessageSource, type L2BlockSource } from '@aztec/circuit-types';
-import { type AztecKVStore } from '@aztec/kv-store';
+import { createDebugLogger } from '@aztec/foundation/log';
+import { type DataStoreConfig, createStore } from '@aztec/kv-store/utils';
 import { type TelemetryClient } from '@aztec/telemetry-client';
 
 import { MerkleTrees } from '../world-state-db/merkle_trees.js';
@@ -7,11 +8,11 @@ import { type WorldStateConfig } from './config.js';
 import { ServerWorldStateSynchronizer } from './server_world_state_synchronizer.js';
 
 export async function createWorldStateSynchronizer(
-  config: WorldStateConfig,
-  store: AztecKVStore,
+  config: WorldStateConfig & DataStoreConfig,
   l2BlockSource: L2BlockSource & L1ToL2MessageSource,
   client: TelemetryClient,
 ) {
+  const store = await createStore('world-state', config, createDebugLogger('aztec:world-state:lmdb'));
   const merkleTrees = await MerkleTrees.new(store, client);
   return new ServerWorldStateSynchronizer(store, merkleTrees, l2BlockSource, config);
 }

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
@@ -11,7 +11,7 @@ import { INITIAL_LEAF, Pedersen, SHA256Trunc, StandardTree } from '@aztec/merkle
 import { jest } from '@jest/globals';
 import { mock } from 'jest-mock-extended';
 
-import { type MerkleTreeDb, type MerkleTrees, type WorldStateConfig } from '../index.js';
+import { type MerkleTreeAdminDb, type MerkleTrees, type WorldStateConfig } from '../index.js';
 import { ServerWorldStateSynchronizer } from './server_world_state_synchronizer.js';
 import { WorldStateRunningState } from './world_state_synchronizer.js';
 
@@ -39,7 +39,7 @@ describe('server_world_state_synchronizer', () => {
     getL1ToL2Messages: jest.fn(() => Promise.resolve(l1ToL2Messages)),
   });
 
-  const merkleTreeDb = mock<MerkleTreeDb>({
+  const merkleTreeDb = mock<MerkleTreeAdminDb>({
     getTreeInfo: jest.fn(() =>
       Promise.resolve({ depth: 8, treeId: MerkleTreeId.NOTE_HASH_TREE, root: Buffer.alloc(32, 0), size: 0n }),
     ),

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -4,6 +4,7 @@ import {
   type L2Block,
   L2BlockDownloader,
   type L2BlockSource,
+  type MerkleTreeAdminOperations,
 } from '@aztec/circuit-types';
 import { type L2BlockHandledStats } from '@aztec/circuit-types/stats';
 import { L1_TO_L2_MSG_SUBTREE_HEIGHT } from '@aztec/circuits.js/constants';
@@ -16,8 +17,11 @@ import { type AztecKVStore, type AztecSingleton } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/utils';
 import { SHA256Trunc, StandardTree } from '@aztec/merkle-tree';
 
-import { type MerkleTreeOperations, type MerkleTrees } from '../world-state-db/index.js';
-import { MerkleTreeOperationsFacade } from '../world-state-db/merkle_tree_operations_facade.js';
+import { type MerkleTrees } from '../world-state-db/index.js';
+import {
+  MerkleTreeAdminOperationsFacade,
+  MerkleTreeOperationsFacade,
+} from '../world-state-db/merkle_tree_operations_facade.js';
 import { MerkleTreeSnapshotOperationsFacade } from '../world-state-db/merkle_tree_snapshot_operations_facade.js';
 import { type WorldStateConfig } from './config.js';
 import {
@@ -62,21 +66,25 @@ export class ServerWorldStateSynchronizer implements WorldStateSynchronizer {
     });
   }
 
-  public getLatest(): MerkleTreeOperations {
-    return new MerkleTreeOperationsFacade(this.merkleTreeDb, true);
+  public getLatest(): MerkleTreeAdminOperations {
+    return new MerkleTreeAdminOperationsFacade(this.merkleTreeDb, true);
   }
 
-  public getCommitted(): MerkleTreeOperations {
-    return new MerkleTreeOperationsFacade(this.merkleTreeDb, false);
+  public getCommitted(): MerkleTreeAdminOperations {
+    return new MerkleTreeAdminOperationsFacade(this.merkleTreeDb, false);
   }
 
-  public getSnapshot(blockNumber: number): MerkleTreeOperations {
+  public getSnapshot(blockNumber: number): MerkleTreeAdminOperations {
     return new MerkleTreeSnapshotOperationsFacade(this.merkleTreeDb, blockNumber);
   }
 
-  private async getFork(includeUncommitted: boolean): Promise<MerkleTreeOperationsFacade> {
+  public async ephemeralFork(): Promise<MerkleTreeOperationsFacade> {
+    return new MerkleTreeOperationsFacade(await this.merkleTreeDb.ephemeralFork(), true);
+  }
+
+  private async getFork(includeUncommitted: boolean): Promise<MerkleTreeAdminOperationsFacade> {
     this.log.verbose(`Forking world state at ${this.blockNumber.get()}`);
-    return new MerkleTreeOperationsFacade(await this.merkleTreeDb.fork(), includeUncommitted);
+    return new MerkleTreeAdminOperationsFacade(await this.merkleTreeDb.fork(), includeUncommitted);
   }
 
   public async start() {
@@ -212,7 +220,7 @@ export class ServerWorldStateSynchronizer implements WorldStateSynchronizer {
   public async syncImmediateAndFork(
     targetBlockNumber: number,
     forkIncludeUncommitted: boolean,
-  ): Promise<MerkleTreeOperationsFacade> {
+  ): Promise<MerkleTreeAdminOperationsFacade> {
     try {
       await this.pause();
       await this.syncImmediate(targetBlockNumber);

--- a/yarn-project/world-state/src/synchronizer/world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/world_state_synchronizer.ts
@@ -1,4 +1,4 @@
-import { type MerkleTreeOperations } from '../world-state-db/index.js';
+import { type MerkleTreeAdminOperations, type MerkleTreeOperations } from '../world-state-db/index.js';
 
 /**
  * Defines the possible states of the world state synchronizer.
@@ -58,24 +58,26 @@ export interface WorldStateSynchronizer {
    * @param forkIncludeUncommitted - Whether to include uncommitted data in the fork.
    * @returns The db forked at the requested target block number.
    */
-  syncImmediateAndFork(targetBlockNumber: number, forkIncludeUncommitted: boolean): Promise<MerkleTreeOperations>;
+  syncImmediateAndFork(targetBlockNumber: number, forkIncludeUncommitted: boolean): Promise<MerkleTreeAdminOperations>;
 
   /**
-   * Returns an instance of MerkleTreeOperations that will include uncommitted data.
-   * @returns An instance of MerkleTreeOperations that will include uncommitted data.
+   * Forks the current in-memory state based off the current committed state, and returns an instance that cannot modify the underlying data store.
    */
-  getLatest(): MerkleTreeOperations;
+  ephemeralFork(): Promise<MerkleTreeOperations>;
 
   /**
-   * Returns an instance of MerkleTreeOperations that will not include uncommitted data.
-   * @returns An instance of MerkleTreeOperations that will not include uncommitted data.
+   * Returns an instance of MerkleTreeAdminOperations that will include uncommitted data.
    */
-  getCommitted(): MerkleTreeOperations;
+  getLatest(): MerkleTreeAdminOperations;
 
   /**
-   * Returns a readonly instance of MerkleTreeOperations where the state is as it was at the given block number
+   * Returns an instance of MerkleTreeAdminOperations that will not include uncommitted data.
+   */
+  getCommitted(): MerkleTreeAdminOperations;
+
+  /**
+   * Returns a readonly instance of MerkleTreeAdminOperations where the state is as it was at the given block number
    * @param block - The block number to look at
-   * @returns An instance of MerkleTreeOperations
    */
   getSnapshot(block: number): MerkleTreeOperations;
 }

--- a/yarn-project/world-state/src/world-state-db/index.ts
+++ b/yarn-project/world-state/src/world-state-db/index.ts
@@ -3,4 +3,4 @@ export * from './merkle_tree_db.js';
 export * from './merkle_tree_operations_facade.js';
 export * from './merkle_tree_snapshot_operations_facade.js';
 
-export { MerkleTreeOperations } from '@aztec/circuit-types/interfaces';
+export { MerkleTreeOperations, MerkleTreeAdminOperations } from '@aztec/circuit-types/interfaces';

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
@@ -1,5 +1,5 @@
 import { type MerkleTreeId } from '@aztec/circuit-types';
-import { type MerkleTreeOperations } from '@aztec/circuit-types/interfaces';
+import { type MerkleTreeAdminOperations, type MerkleTreeOperations } from '@aztec/circuit-types/interfaces';
 import { type Fr, MAX_NULLIFIERS_PER_TX, MAX_TOTAL_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX } from '@aztec/circuits.js';
 import { type IndexedTreeSnapshot, type TreeSnapshot } from '@aztec/merkle-tree';
 
@@ -32,13 +32,9 @@ type WithIncludeUncommitted<F> = F extends (...args: [...infer Rest]) => infer R
 /**
  * Defines the names of the setters on Merkle Trees.
  */
-type MerkleTreeSetters =
-  | 'appendLeaves'
-  | 'updateLeaf'
-  | 'commit'
-  | 'rollback'
-  | 'handleL2BlockAndMessages'
-  | 'batchInsert';
+type MerkleTreeSetters = 'appendLeaves' | 'updateLeaf' | 'batchInsert';
+
+type MerkleTreeAdmin = 'commit' | 'rollback' | 'handleL2BlockAndMessages';
 
 export type TreeSnapshots = {
   [MerkleTreeId.NULLIFIER_TREE]: IndexedTreeSnapshot;
@@ -48,14 +44,26 @@ export type TreeSnapshots = {
   [MerkleTreeId.ARCHIVE]: TreeSnapshot<Fr>;
 };
 
-/**
- * Defines the interface for operations on a set of Merkle Trees configuring whether to return committed or uncommitted data.
- */
+/** Defines the interface for operations on a set of Merkle Trees configuring whether to return committed or uncommitted data. */
 export type MerkleTreeDb = {
   [Property in keyof MerkleTreeOperations as Exclude<Property, MerkleTreeSetters>]: WithIncludeUncommitted<
     MerkleTreeOperations[Property]
   >;
 } & Pick<MerkleTreeOperations, MerkleTreeSetters> & {
+    /**
+     * Returns a snapshot of the current state of the trees.
+     * @param block - The block number to take the snapshot at.
+     */
+    getSnapshot(block: number): Promise<TreeSnapshots>;
+  };
+
+/** Extends operations on MerkleTreeDb to include modifying the underlying store */
+export type MerkleTreeAdminDb = {
+  [Property in keyof MerkleTreeAdminOperations as Exclude<
+    Property,
+    MerkleTreeSetters | MerkleTreeAdmin
+  >]: WithIncludeUncommitted<MerkleTreeAdminOperations[Property]>;
+} & Pick<MerkleTreeAdminOperations, MerkleTreeSetters | MerkleTreeAdmin> & {
     /**
      * Returns a snapshot of the current state of the trees.
      * @param block - The block number to take the snapshot at.

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_operations_facade.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_operations_facade.ts
@@ -2,6 +2,7 @@ import { type BatchInsertionResult, type L2Block, type MerkleTreeId, type Siblin
 import {
   type HandleL2BlockAndMessagesResult,
   type IndexedTreeId,
+  type MerkleTreeAdminOperations,
   type MerkleTreeLeafType,
   type MerkleTreeOperations,
   type TreeInfo,
@@ -9,13 +10,13 @@ import {
 import { type Fr, type Header, type NullifierLeafPreimage, type StateReference } from '@aztec/circuits.js';
 import { type IndexedTreeLeafPreimage } from '@aztec/foundation/trees';
 
-import { type MerkleTreeDb } from './merkle_tree_db.js';
+import { type MerkleTreeAdminDb, type MerkleTreeDb } from './merkle_tree_db.js';
 
 /**
  * Wraps a MerkleTreeDbOperations to call all functions with a preset includeUncommitted flag.
  */
 export class MerkleTreeOperationsFacade implements MerkleTreeOperations {
-  constructor(private trees: MerkleTreeDb, private includeUncommitted: boolean) {}
+  constructor(protected trees: MerkleTreeDb, protected includeUncommitted: boolean) {}
 
   /**
    * Returns the tree info for the specified tree id.
@@ -165,6 +166,27 @@ export class MerkleTreeOperationsFacade implements MerkleTreeOperations {
   }
 
   /**
+   * Batch insert multiple leaves into the tree.
+   * @param treeId - The ID of the tree.
+   * @param leaves - Leaves to insert into the tree.
+   * @param subtreeHeight - Height of the subtree.
+   * @returns The data for the leaves to be updated when inserting the new ones.
+   */
+  public batchInsert<TreeHeight extends number, SubtreeSiblingPathHeight extends number>(
+    treeId: IndexedTreeId,
+    leaves: Buffer[],
+    subtreeHeight: number,
+  ): Promise<BatchInsertionResult<TreeHeight, SubtreeSiblingPathHeight>> {
+    return this.trees.batchInsert(treeId, leaves, subtreeHeight);
+  }
+}
+
+export class MerkleTreeAdminOperationsFacade extends MerkleTreeOperationsFacade implements MerkleTreeAdminOperations {
+  constructor(protected override trees: MerkleTreeAdminDb, includeUncommitted: boolean) {
+    super(trees, includeUncommitted);
+  }
+
+  /**
    * Handles a single L2 block (i.e. Inserts the new note hashes into the merkle tree).
    * @param block - The L2 block to handle.
    * @param l1ToL2Messages - The L1 to L2 messages for the block.
@@ -188,21 +210,6 @@ export class MerkleTreeOperationsFacade implements MerkleTreeOperations {
    */
   public async rollback(): Promise<void> {
     return await this.trees.rollback();
-  }
-
-  /**
-   * Batch insert multiple leaves into the tree.
-   * @param treeId - The ID of the tree.
-   * @param leaves - Leaves to insert into the tree.
-   * @param subtreeHeight - Height of the subtree.
-   * @returns The data for the leaves to be updated when inserting the new ones.
-   */
-  public batchInsert<TreeHeight extends number, SubtreeSiblingPathHeight extends number>(
-    treeId: IndexedTreeId,
-    leaves: Buffer[],
-    subtreeHeight: number,
-  ): Promise<BatchInsertionResult<TreeHeight, SubtreeSiblingPathHeight>> {
-    return this.trees.batchInsert(treeId, leaves, subtreeHeight);
   }
 
   public delete(): Promise<void> {


### PR DESCRIPTION
This PR packs two changesets:

1. Spins off a `MerkleTreeAdminOperations` from `MerkleTreeOperations`, to have an interface that does not expose methods that commit changes to the underlying store. World state now exposes a method to get an `ephemeralFork` without these operations, that can be used for answering public simulation requests. Note that we do not yet enforce that no changes go into the store, that requires more changes to have "readonly" versions of the trees and store all the way down.
2. Moves creation of the underlying data store to the factory of each component, so each creates a new db as needed, instead of sharing a single one. This allows to keep separate db files for p2p, archive, and world state. As a bonus, it makes forking world state cheaper.