### PR TITLE
chore: fix warnings in `avm-transpiler`

### DIFF
--- a/avm-transpiler/src/main.rs
+++ b/avm-transpiler/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
 
     // Parse original (pre-transpile) contract.
     let contract_json = fs::read_to_string(Path::new(in_contract_artifact_path))
-        .expect(&format!("Unable to read file: {in_contract_artifact_path}"));
+        .unwrap_or_else(|_| panic!("Unable to read file: {in_contract_artifact_path}"));
     let raw_json_obj: serde_json::Value =
         serde_json::from_str(&contract_json).expect(&json_parse_error);
 
@@ -44,7 +44,7 @@ fn main() {
             Path::new(out_transpiled_artifact_path),
             Path::new(&(out_transpiled_artifact_path.clone() + ".bak")),
         )
-        .expect(&format!("Unable to backup file: {out_transpiled_artifact_path}"));
+        .unwrap_or_else(|_| panic!("Unable to backup file: {out_transpiled_artifact_path}"));
     }
 
     // Parse json into contract object

--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -982,7 +982,7 @@ fn handle_storage_write(
     inputs: &Vec<ValueOrArray>,
 ) {
     assert!(inputs.len() == 2);
-    assert!(destinations.len() == 0);
+    assert!(destinations.is_empty());
 
     let slot_offset_maybe = inputs[0];
     let slot_offset = match slot_offset_maybe {


### PR DESCRIPTION
This PR fixes clippy issues from the avm-transpiler crate.