### PR TITLE
chore: Send anvil logs to stdout

### DIFF
--- a/iac/mainnet-fork/Earthfile
+++ b/iac/mainnet-fork/Earthfile
@@ -16,7 +16,6 @@ build:
     COPY ./scripts ./scripts
     COPY ./redeploy ./redeploy
     COPY ./nginx/ /etc/nginx/
-    COPY --chmod 640 ./etc/anvil.logrotate.conf /etc/logrotate.d/anvil
 
     # Expose port 80
     EXPOSE 80

--- a/iac/mainnet-fork/etc/anvil.logrotate.conf
+++ b/iac/mainnet-fork/etc/anvil.logrotate.conf
@@ -1,9 +1,0 @@
-/var/log/anvil/*.log {
-  daily
-  missingok
-  rotate 14
-  size 50M
-  compress
-  notifempty
-  copytruncate
-}

--- a/iac/mainnet-fork/scripts/run_nginx_anvil.sh
+++ b/iac/mainnet-fork/scripts/run_nginx_anvil.sh
@@ -25,8 +25,8 @@ mkdir -p /data
 # Log directory for anvil
 mkdir -p /var/log/anvil/
 
-# Run anvil logging to /var/log/anvil
-.foundry/bin/anvil --block-time 12 --host $HOST -p $PORT -m "$MNEMONIC_STRIPPED" -f=https://mainnet.infura.io/v3/$INFURA_API_KEY --chain-id=$L1_CHAIN_ID --fork-block-number=15918000 --block-base-fee-per-gas=10 -s=$SNAPSHOT_FREQUENCY --state=./data/state --balance=1000000000000000000 >>/var/log/anvil/anvil.log &
+# Run anvil logging to stdout
+.foundry/bin/anvil --block-time 12 --host $HOST -p $PORT -m "$MNEMONIC_STRIPPED" -f=https://mainnet.infura.io/v3/$INFURA_API_KEY --chain-id=$L1_CHAIN_ID --fork-block-number=15918000 --block-base-fee-per-gas=10 -s=$SNAPSHOT_FREQUENCY --state=./data/state --balance=1000000000000000000 &
 
 echo "Waiting for ethereum host at $ETHEREUM_HOST..."
 while ! curl -s $ETHEREUM_HOST >/dev/null; do sleep 1; done


### PR DESCRIPTION
Instead of a local file, so we can read them from cloudwatch when deployed in aws.

Also, it's possible that logrotate wasn't running, since the container runs the process required and not cron and logrotate. Logging inside the container is an antipattern that I walked straight into.