### PR TITLE
feat: tuple return value typescript decoding

### DIFF
--- a/yarn-project/foundation/src/abi/abi.ts
+++ b/yarn-project/foundation/src/abi/abi.ts
@@ -84,7 +84,14 @@ export interface BasicType<T extends string> {
 /**
  * A variable type.
  */
-export type AbiType = BasicType<'field'> | BasicType<'boolean'> | IntegerType | ArrayType | StringType | StructType;
+export type AbiType =
+  | BasicType<'field'>
+  | BasicType<'boolean'>
+  | IntegerType
+  | ArrayType
+  | StringType
+  | StructType
+  | TupleType;
 
 type Sign = 'unsigned' | 'signed';
 
@@ -114,6 +121,16 @@ export interface ArrayType extends BasicType<'array'> {
    * The type of the array elements.
    */
   type: AbiType;
+}
+
+/**
+ * A tuple type.
+ */
+export interface TupleType extends BasicType<'tuple'> {
+  /**
+   * The types of the tuple elements.
+   */
+  fields: AbiType[];
 }
 
 /**

--- a/yarn-project/foundation/src/abi/decoder.ts
+++ b/yarn-project/foundation/src/abi/decoder.ts
@@ -56,6 +56,13 @@ class ReturnValuesDecoder {
         }
         return array;
       }
+      case 'tuple': {
+        const array = [];
+        for (const tupleAbiType of abiType.fields) {
+          array.push(this.decodeReturn(tupleAbiType));
+        }
+        return array;
+      }
       default:
         throw new Error(`Unsupported type: ${abiType}`);
     }

--- a/yarn-project/foundation/src/abi/encoder.ts
+++ b/yarn-project/foundation/src/abi/encoder.ts
@@ -23,6 +23,8 @@ class ArgumentEncoder {
         return abiType.length * ArgumentEncoder.typeSize(abiType.type);
       case 'struct':
         return abiType.fields.reduce((acc, field) => acc + ArgumentEncoder.typeSize(field.type), 0);
+      case 'tuple':
+        return abiType.fields.reduce((acc, field) => acc + ArgumentEncoder.typeSize(field), 0);
       default: {
         const exhaustiveCheck: never = abiType;
         throw new Error(`Unhandled abi type: ${exhaustiveCheck}`);


### PR DESCRIPTION
In a PR up the stack I needed to return a tuple return value and decoder did not support it. This PR adds it. Note that the new functionality is untested in this PR but the PR up the stack uses it and the tests there passed so I think it can be merged.
