### PR TITLE
fix: Handle proofs for blocks submitted out of range

### DIFF
--- a/yarn-project/foundation/src/collection/object.ts
+++ b/yarn-project/foundation/src/collection/object.ts
@@ -1,19 +1,19 @@
 /** Returns a new object with the same keys and where each value has been passed through the mapping function. */
 export function mapValues<K extends string | number | symbol, T, U>(
   obj: Record<K, T>,
-  fn: (value: T) => U,
+  fn: (value: T, key: K) => U,
 ): Record<K, U>;
 export function mapValues<K extends string | number | symbol, T, U>(
   obj: Partial<Record<K, T>>,
-  fn: (value: T) => U,
+  fn: (value: T, key: K) => U,
 ): Partial<Record<K, U>>;
 export function mapValues<K extends string | number | symbol, T, U>(
   obj: Record<K, T>,
-  fn: (value: T) => U,
+  fn: (value: T, key: K) => U,
 ): Record<K, U> {
   const result: Record<K, U> = {} as Record<K, U>;
   for (const key in obj) {
-    result[key] = fn(obj[key]);
+    result[key] = fn(obj[key], key);
   }
   return result;
 }


### PR DESCRIPTION
`prover-stats` was throwing an error when querying with a start-block that was not the start of the chain, since it'd look up for the submission time of the L2 block for a proof, but would not find it because it was out of range.