### PR TITLE
refactor: Renaming `Instance`'s

### DIFF
--- a/barretenberg/CHANGELOG.md
+++ b/barretenberg/CHANGELOG.md
@@ -1210,7 +1210,7 @@
 - Master borked arithmetic tests ([#4606](https://github.com/AztecProtocol/aztec-packages/issues/4606)) ([472c54a](https://github.com/AztecProtocol/aztec-packages/commit/472c54a7e89001f5f752da670cc25ec1a537da87))
 - Msan build ([#4646](https://github.com/AztecProtocol/aztec-packages/issues/4646)) ([886cc75](https://github.com/AztecProtocol/aztec-packages/commit/886cc7585f935f4f12257444af7862b51dc91584))
 - MSAN msgpack noise ([#4677](https://github.com/AztecProtocol/aztec-packages/issues/4677)) ([1abae28](https://github.com/AztecProtocol/aztec-packages/commit/1abae28580354f5ccc620dbd717bf079f39fb445))
-- Remove the `VerificationKey` from `ProverInstance` ([#4908](https://github.com/AztecProtocol/aztec-packages/issues/4908)) ([8619c08](https://github.com/AztecProtocol/aztec-packages/commit/8619c084cdfd061f284058b00a96f16fbbca65bf))
+- Remove the `VerificationKey` from `DeciderProvingKey` ([#4908](https://github.com/AztecProtocol/aztec-packages/issues/4908)) ([8619c08](https://github.com/AztecProtocol/aztec-packages/commit/8619c084cdfd061f284058b00a96f16fbbca65bf))
 - Use size hint for ivc circuits ([#4802](https://github.com/AztecProtocol/aztec-packages/issues/4802)) ([035cff4](https://github.com/AztecProtocol/aztec-packages/commit/035cff451ca2171e08279b9d36b23f38b840efea))
 
 ### Miscellaneous

--- a/barretenberg/CHANGELOG.md
+++ b/barretenberg/CHANGELOG.md
@@ -1210,7 +1210,7 @@
 - Master borked arithmetic tests ([#4606](https://github.com/AztecProtocol/aztec-packages/issues/4606)) ([472c54a](https://github.com/AztecProtocol/aztec-packages/commit/472c54a7e89001f5f752da670cc25ec1a537da87))
 - Msan build ([#4646](https://github.com/AztecProtocol/aztec-packages/issues/4646)) ([886cc75](https://github.com/AztecProtocol/aztec-packages/commit/886cc7585f935f4f12257444af7862b51dc91584))
 - MSAN msgpack noise ([#4677](https://github.com/AztecProtocol/aztec-packages/issues/4677)) ([1abae28](https://github.com/AztecProtocol/aztec-packages/commit/1abae28580354f5ccc620dbd717bf079f39fb445))
-- Remove the `VerificationKey` from `DeciderProvingKey` ([#4908](https://github.com/AztecProtocol/aztec-packages/issues/4908)) ([8619c08](https://github.com/AztecProtocol/aztec-packages/commit/8619c084cdfd061f284058b00a96f16fbbca65bf))
+- Remove the `VerificationKey` from `ProverInstance` ([#4908](https://github.com/AztecProtocol/aztec-packages/issues/4908)) ([8619c08](https://github.com/AztecProtocol/aztec-packages/commit/8619c084cdfd061f284058b00a96f16fbbca65bf))
 - Use size hint for ivc circuits ([#4802](https://github.com/AztecProtocol/aztec-packages/issues/4802)) ([035cff4](https://github.com/AztecProtocol/aztec-packages/commit/035cff451ca2171e08279b9d36b23f38b840efea))
 
 ### Miscellaneous

--- a/barretenberg/cpp/scripts/analyze_client_ivc_bench.py
+++ b/barretenberg/cpp/scripts/analyze_client_ivc_bench.py
@@ -16,7 +16,7 @@ PREFIX = args.prefix
 # Single out an independent set of functions accounting for most of BENCHMARK's real_time
 to_keep = [
     "construct_circuits(t)",
-    "ProverInstance(Circuit&)(t)",
+    "DeciderProvingKey(Circuit&)(t)",
     "ProtogalaxyProver::prove(t)",
     "Decider::construct_proof(t)",
     "ECCVMProver(CircuitBuilder&)(t)",

--- a/barretenberg/cpp/src/barretenberg/aztec_ivc/aztec_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/aztec_ivc/aztec_ivc.cpp
@@ -46,7 +46,7 @@ void AztecIVC::complete_kernel_circuit_logic(ClientCircuit& circuit)
             // Perform oink recursive verification to complete the initial verifier accumulator
             OinkRecursiveVerifier oink{ &circuit, verifier_accum };
             oink.verify_proof(stdlib_proof);
-            verifier_accum->is_accumulator = true; // indicate to PG that it should not run oink on this instance
+            verifier_accum->is_accumulator = true; // indicate to PG that it should not run oink on this key
 
             // Extract native verifier accumulator from the stdlib accum for use on the next round
             verifier_accumulator = std::make_shared<DeciderVerificationKey>(verifier_accum->get_value());
@@ -73,9 +73,9 @@ void AztecIVC::complete_kernel_circuit_logic(ClientCircuit& circuit)
 }
 
 /**
- * @brief Execute prover work for instance accumulation
- * @details Construct an instance for the provided circuit. If this is the first instance in the IVC, simply initialize
- * the folding accumulator. Otherwise, execute the PG prover to fold the instance into the accumulator and produce a
+ * @brief Execute prover work for accumulation
+ * @details Construct an proving key for the provided circuit. If this is the first step in the IVC, simply initialize
+ * the folding accumulator. Otherwise, execute the PG prover to fold the proving key into the accumulator and produce a
  * folding proof. Also execute the merge protocol to produce a merge proof.
  *
  * @param circuit
@@ -91,40 +91,40 @@ void AztecIVC::accumulate(ClientCircuit& circuit, const std::shared_ptr<Verifica
     // verifier.
     circuit.add_recursive_proof(stdlib::recursion::init_default_agg_obj_indices<ClientCircuit>(circuit));
 
-    // Construct the prover instance for circuit
-    std::shared_ptr<DeciderProvingKey> prover_instance;
+    // Construct the proving key for circuit
+    std::shared_ptr<DeciderProvingKey> proving_key;
     if (!initialized) {
-        prover_instance = std::make_shared<DeciderProvingKey>(circuit, trace_structure);
+        proving_key = std::make_shared<DeciderProvingKey>(circuit, trace_structure);
     } else {
-        prover_instance = std::make_shared<DeciderProvingKey>(
+        proving_key = std::make_shared<DeciderProvingKey>(
             circuit, trace_structure, fold_output.accumulator->proving_key.commitment_key);
     }
 
-    // Set the instance verification key from precomputed if available, else compute it
-    decider_vk = precomputed_vk ? precomputed_vk : std::make_shared<VerificationKey>(prover_instance->proving_key);
+    // Set the verification key from precomputed if available, else compute it
+    honk_vk = precomputed_vk ? precomputed_vk : std::make_shared<VerificationKey>(proving_key->proving_key);
 
-    // If this is the first circuit in the IVC, use oink to compute the completed instance and generate an oink proof
+    // If this is the first circuit in the IVC, use oink to complete the decider proving key and generate an oink proof
     if (!initialized) {
-        OinkProver<Flavor> oink_prover{ prover_instance };
+        OinkProver<Flavor> oink_prover{ proving_key };
         oink_prover.prove();
-        prover_instance->is_accumulator = true; // indicate to PG that it should not run oink on this instance
+        proving_key->is_accumulator = true; // indicate to PG that it should not run oink on this key
         // Initialize the gate challenges to zero for use in first round of folding
-        prover_instance->gate_challenges = std::vector<FF>(prover_instance->proving_key.log_circuit_size, 0);
+        proving_key->gate_challenges = std::vector<FF>(proving_key->proving_key.log_circuit_size, 0);
 
-        fold_output.accumulator = prover_instance; // initialize the prover accum with the completed instance
+        fold_output.accumulator = proving_key; // initialize the prover accum with the completed key
 
         // Add oink proof and corresponding verification key to the verification queue
         verification_queue.push_back(
-            bb::AztecIVC::RecursiveVerifierInputs{ oink_prover.transcript->proof_data, decider_vk, QUEUE_TYPE::OINK });
+            bb::AztecIVC::RecursiveVerifierInputs{ oink_prover.transcript->proof_data, honk_vk, QUEUE_TYPE::OINK });
 
         initialized = true;
-    } else { // Otherwise, fold the new instance into the accumulator
-        FoldingProver folding_prover({ fold_output.accumulator, prover_instance });
+    } else { // Otherwise, fold the new key into the accumulator
+        FoldingProver folding_prover({ fold_output.accumulator, proving_key });
         fold_output = folding_prover.prove();
 
         // Add fold proof and corresponding verification key to the verification queue
         verification_queue.push_back(
-            bb::AztecIVC::RecursiveVerifierInputs{ fold_output.proof, decider_vk, QUEUE_TYPE::PG });
+            bb::AztecIVC::RecursiveVerifierInputs{ fold_output.proof, honk_vk, QUEUE_TYPE::PG });
     }
 
     // Track the maximum size of each block for all circuits porcessed (for debugging purposes only)
@@ -148,7 +148,7 @@ AztecIVC::Proof AztecIVC::prove()
 
 bool AztecIVC::verify(const Proof& proof,
                       const std::shared_ptr<DeciderVerificationKey>& accumulator,
-                      const std::shared_ptr<DeciderVerificationKey>& final_verifier_instance,
+                      const std::shared_ptr<DeciderVerificationKey>& final_stack_vk,
                       const std::shared_ptr<AztecIVC::ECCVMVerificationKey>& eccvm_vk,
                       const std::shared_ptr<AztecIVC::TranslatorVerificationKey>& translator_vk)
 {
@@ -157,7 +157,7 @@ bool AztecIVC::verify(const Proof& proof,
     bool goblin_verified = goblin_verifier.verify(proof.goblin_proof);
 
     // Decider verification
-    AztecIVC::FoldingVerifier folding_verifier({ accumulator, final_verifier_instance });
+    AztecIVC::FoldingVerifier folding_verifier({ accumulator, final_stack_vk });
     auto verifier_accumulator = folding_verifier.verify_folding_proof(proof.folding_proof);
 
     AztecIVC::DeciderVerifier decider_verifier(verifier_accumulator);
@@ -171,11 +171,11 @@ bool AztecIVC::verify(const Proof& proof,
  * @param proof
  * @return bool
  */
-bool AztecIVC::verify(Proof& proof, const std::vector<std::shared_ptr<DeciderVerificationKey>>& verifier_instances)
+bool AztecIVC::verify(Proof& proof, const std::vector<std::shared_ptr<DeciderVerificationKey>>& vk_stack)
 {
     auto eccvm_vk = std::make_shared<ECCVMVerificationKey>(goblin.get_eccvm_proving_key());
     auto translator_vk = std::make_shared<TranslatorVerificationKey>(goblin.get_translator_proving_key());
-    return verify(proof, verifier_instances[0], verifier_instances[1], eccvm_vk, translator_vk);
+    return verify(proof, vk_stack[0], vk_stack[1], eccvm_vk, translator_vk);
 }
 
 /**
@@ -200,7 +200,7 @@ bool AztecIVC::prove_and_verify()
     auto proof = prove();
 
     ASSERT(verification_queue.size() == 1); // ensure only a single fold proof remains in the queue
-    auto verifier_inst = std::make_shared<DeciderVerificationKey>(this->verification_queue[0].decider_vk);
+    auto verifier_inst = std::make_shared<DeciderVerificationKey>(this->verification_queue[0].honk_verification_key);
     return verify(proof, { this->verifier_accumulator, verifier_inst });
 }
 

--- a/barretenberg/cpp/src/barretenberg/aztec_ivc/aztec_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/aztec_ivc/aztec_ivc.hpp
@@ -45,7 +45,7 @@ class AztecIVC {
     using RecursiveFlavor = MegaRecursiveFlavor_<bb::MegaCircuitBuilder>;
     using RecursiveDeciderVerificationKeys =
         bb::stdlib::recursion::honk::RecursiveDeciderVerificationKeys_<RecursiveFlavor, 2>;
-    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::Instance;
+    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::RecursiveDeciderVK;
     using RecursiveVerificationKey = RecursiveFlavor::VerificationKey;
     using FoldingRecursiveVerifier =
         bb::stdlib::recursion::honk::ProtogalaxyRecursiveVerifier_<RecursiveDeciderVerificationKeys>;
@@ -67,7 +67,7 @@ class AztecIVC {
     enum class QUEUE_TYPE { OINK, PG };
     struct RecursiveVerifierInputs {
         std::vector<FF> proof; // oink or PG
-        std::shared_ptr<VerificationKey> instance_vk;
+        std::shared_ptr<VerificationKey> decider_vk;
         QUEUE_TYPE type;
     };
 
@@ -83,7 +83,7 @@ class AztecIVC {
     ProverFoldOutput fold_output; // prover accumulator instance and fold proof
 
     std::shared_ptr<DeciderVerificationKey> verifier_accumulator; // verifier accumulator instance
-    std::shared_ptr<VerificationKey> instance_vk;                 // verification key for instance to be folded
+    std::shared_ptr<VerificationKey> decider_vk;                  // verification key for instance to be folded
 
     // Set of pairs of {fold_proof, verification_key} to be recursively verified
     std::vector<RecursiveVerifierInputs> verification_queue;

--- a/barretenberg/cpp/src/barretenberg/aztec_ivc/aztec_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/aztec_ivc/aztec_ivc.hpp
@@ -30,24 +30,25 @@ class AztecIVC {
     using FF = Flavor::FF;
     using FoldProof = std::vector<FF>;
     using MergeProof = std::vector<FF>;
-    using ProverInstance = ProverInstance_<Flavor>;
-    using VerifierInstance = VerifierInstance_<Flavor>;
+    using DeciderProvingKey = DeciderProvingKey_<Flavor>;
+    using DeciderVerificationKey = DeciderVerificationKey_<Flavor>;
     using ClientCircuit = MegaCircuitBuilder; // can only be Mega
     using DeciderProver = DeciderProver_<Flavor>;
     using DeciderVerifier = DeciderVerifier_<Flavor>;
-    using ProverInstances = ProverInstances_<Flavor>;
-    using FoldingProver = ProtogalaxyProver_<ProverInstances>;
-    using VerifierInstances = VerifierInstances_<Flavor>;
-    using FoldingVerifier = ProtogalaxyVerifier_<VerifierInstances>;
+    using DeciderProvingKeys = DeciderProvingKeys_<Flavor>;
+    using FoldingProver = ProtogalaxyProver_<DeciderProvingKeys>;
+    using DeciderVerificationKeys = DeciderVerificationKeys_<Flavor>;
+    using FoldingVerifier = ProtogalaxyVerifier_<DeciderVerificationKeys>;
     using ECCVMVerificationKey = bb::ECCVMFlavor::VerificationKey;
     using TranslatorVerificationKey = bb::TranslatorFlavor::VerificationKey;
 
     using RecursiveFlavor = MegaRecursiveFlavor_<bb::MegaCircuitBuilder>;
-    using RecursiveVerifierInstances = bb::stdlib::recursion::honk::RecursiveVerifierInstances_<RecursiveFlavor, 2>;
-    using RecursiveVerifierInstance = RecursiveVerifierInstances::Instance;
+    using RecursiveDeciderVerificationKeys =
+        bb::stdlib::recursion::honk::RecursiveDeciderVerificationKeys_<RecursiveFlavor, 2>;
+    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::Instance;
     using RecursiveVerificationKey = RecursiveFlavor::VerificationKey;
     using FoldingRecursiveVerifier =
-        bb::stdlib::recursion::honk::ProtogalaxyRecursiveVerifier_<RecursiveVerifierInstances>;
+        bb::stdlib::recursion::honk::ProtogalaxyRecursiveVerifier_<RecursiveDeciderVerificationKeys>;
     using OinkRecursiveVerifier = stdlib::recursion::honk::OinkRecursiveVerifier_<RecursiveFlavor>;
 
     using DataBusDepot = stdlib::DataBusDepot<ClientCircuit>;
@@ -81,8 +82,8 @@ class AztecIVC {
 
     ProverFoldOutput fold_output; // prover accumulator instance and fold proof
 
-    std::shared_ptr<VerifierInstance> verifier_accumulator; // verifier accumulator instance
-    std::shared_ptr<VerificationKey> instance_vk;           // verification key for instance to be folded
+    std::shared_ptr<DeciderVerificationKey> verifier_accumulator; // verifier accumulator instance
+    std::shared_ptr<VerificationKey> instance_vk;                 // verification key for instance to be folded
 
     // Set of pairs of {fold_proof, verification_key} to be recursively verified
     std::vector<RecursiveVerifierInputs> verification_queue;
@@ -92,7 +93,7 @@ class AztecIVC {
     // Management of linking databus commitments between circuits in the IVC
     DataBusDepot bus_depot;
 
-    // A flag indicating whether or not to construct a structured trace in the ProverInstance
+    // A flag indicating whether or not to construct a structured trace in the DeciderProvingKey
     TraceStructure trace_structure = TraceStructure::NONE;
 
     bool initialized = false; // Is the IVC accumulator initialized
@@ -106,12 +107,12 @@ class AztecIVC {
     Proof prove();
 
     static bool verify(const Proof& proof,
-                       const std::shared_ptr<VerifierInstance>& accumulator,
-                       const std::shared_ptr<VerifierInstance>& final_verifier_instance,
+                       const std::shared_ptr<DeciderVerificationKey>& accumulator,
+                       const std::shared_ptr<DeciderVerificationKey>& final_verifier_instance,
                        const std::shared_ptr<AztecIVC::ECCVMVerificationKey>& eccvm_vk,
                        const std::shared_ptr<AztecIVC::TranslatorVerificationKey>& translator_vk);
 
-    bool verify(Proof& proof, const std::vector<std::shared_ptr<VerifierInstance>>& verifier_instances);
+    bool verify(Proof& proof, const std::vector<std::shared_ptr<DeciderVerificationKey>>& verifier_instances);
 
     bool prove_and_verify();
 

--- a/barretenberg/cpp/src/barretenberg/aztec_ivc/aztec_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/aztec_ivc/aztec_ivc.test.cpp
@@ -86,7 +86,7 @@ class AztecIVCTests : public ::testing::Test {
             for (size_t idx = 0; idx < num_circuits; ++idx) {
                 ClientCircuit circuit = create_next_circuit(ivc, log2_num_gates); // create the next circuit
                 ivc.accumulate(circuit);                                          // accumulate the circuit
-                vkeys.emplace_back(ivc.decider_vk);                               // save the VK for the circuit
+                vkeys.emplace_back(ivc.honk_vk);                                  // save the VK for the circuit
             }
             is_kernel = false;
 

--- a/barretenberg/cpp/src/barretenberg/aztec_ivc/aztec_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/aztec_ivc/aztec_ivc.test.cpp
@@ -86,7 +86,7 @@ class AztecIVCTests : public ::testing::Test {
             for (size_t idx = 0; idx < num_circuits; ++idx) {
                 ClientCircuit circuit = create_next_circuit(ivc, log2_num_gates); // create the next circuit
                 ivc.accumulate(circuit);                                          // accumulate the circuit
-                vkeys.emplace_back(ivc.instance_vk);                              // save the VK for the circuit
+                vkeys.emplace_back(ivc.decider_vk);                               // save the VK for the circuit
             }
             is_kernel = false;
 

--- a/barretenberg/cpp/src/barretenberg/aztec_ivc/aztec_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/aztec_ivc/aztec_ivc.test.cpp
@@ -20,15 +20,15 @@ class AztecIVCTests : public ::testing::Test {
     using FF = typename Flavor::FF;
     using VerificationKey = Flavor::VerificationKey;
     using Builder = AztecIVC::ClientCircuit;
-    using ProverInstance = AztecIVC::ProverInstance;
-    using VerifierInstance = AztecIVC::VerifierInstance;
+    using DeciderProvingKey = AztecIVC::DeciderProvingKey;
+    using DeciderVerificationKey = AztecIVC::DeciderVerificationKey;
     using FoldProof = AztecIVC::FoldProof;
     using DeciderProver = AztecIVC::DeciderProver;
     using DeciderVerifier = AztecIVC::DeciderVerifier;
-    using ProverInstances = ProverInstances_<Flavor>;
-    using FoldingProver = ProtogalaxyProver_<ProverInstances>;
-    using VerifierInstances = VerifierInstances_<Flavor>;
-    using FoldingVerifier = ProtogalaxyVerifier_<VerifierInstances>;
+    using DeciderProvingKeys = DeciderProvingKeys_<Flavor>;
+    using FoldingProver = ProtogalaxyProver_<DeciderProvingKeys>;
+    using DeciderVerificationKeys = DeciderVerificationKeys_<Flavor>;
+    using FoldingVerifier = ProtogalaxyVerifier_<DeciderVerificationKeys>;
 
     /**
      * @brief Construct mock circuit with arithmetic gates and goblin ops

--- a/barretenberg/cpp/src/barretenberg/aztec_ivc/mock_circuit_producer.hpp
+++ b/barretenberg/cpp/src/barretenberg/aztec_ivc/mock_circuit_producer.hpp
@@ -139,7 +139,7 @@ class PrivateFunctionExecutionMockCircuitProducer {
         for (size_t idx = 0; idx < num_circuits; ++idx) {
             ClientCircuit circuit = create_next_circuit(ivc); // create the next circuit
             ivc.accumulate(circuit);                          // accumulate the circuit
-            vkeys.emplace_back(ivc.instance_vk);              // save the VK for the circuit
+            vkeys.emplace_back(ivc.decider_vk);               // save the VK for the circuit
         }
         circuit_counter = 0; // reset the internal circuit counter back to 0
 

--- a/barretenberg/cpp/src/barretenberg/aztec_ivc/mock_circuit_producer.hpp
+++ b/barretenberg/cpp/src/barretenberg/aztec_ivc/mock_circuit_producer.hpp
@@ -139,7 +139,7 @@ class PrivateFunctionExecutionMockCircuitProducer {
         for (size_t idx = 0; idx < num_circuits; ++idx) {
             ClientCircuit circuit = create_next_circuit(ivc); // create the next circuit
             ivc.accumulate(circuit);                          // accumulate the circuit
-            vkeys.emplace_back(ivc.decider_vk);               // save the VK for the circuit
+            vkeys.emplace_back(ivc.honk_vk);                  // save the VK for the circuit
         }
         circuit_counter = 0; // reset the internal circuit counter back to 0
 

--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -368,7 +368,7 @@ void client_ivc_prove_output_all_msgpack(const std::string& bytecodePath,
 
     // Write the proof and verification keys into the working directory in  'binary' format (in practice it seems this
     // directory is passed by bb.js)
-    std::string vkPath = outputDir + "/final_decider_vk"; // the vk of the last instance
+    std::string vkPath = outputDir + "/final_decider_vk"; // the vk of the last circuit in the stack
     std::string accPath = outputDir + "/pg_acc";
     std::string proofPath = outputDir + "/client_ivc_proof";
     std::string translatorVkPath = outputDir + "/translator_vk";
@@ -378,8 +378,8 @@ void client_ivc_prove_output_all_msgpack(const std::string& bytecodePath,
     auto eccvm_vk = std::make_shared<ECCVMVK>(ivc.goblin.get_eccvm_proving_key());
     auto translator_vk = std::make_shared<TranslatorVK>(ivc.goblin.get_translator_proving_key());
 
-    auto last_instance = std::make_shared<ClientIVC::DeciderVerificationKey>(ivc.decider_vk);
-    vinfo("ensure valid proof: ", ivc.verify(proof, { ivc.verifier_accumulator, last_instance }));
+    auto last_vk = std::make_shared<ClientIVC::DeciderVerificationKey>(ivc.decider_vk);
+    vinfo("ensure valid proof: ", ivc.verify(proof, { ivc.verifier_accumulator, last_vk }));
 
     vinfo("write proof and vk data to files..");
     write_file(proofPath, to_buffer(proof));
@@ -402,7 +402,7 @@ template <typename T> std::shared_ptr<T> read_to_shared_ptr(const std::filesyste
  *   an exit code of 0 will be returned for success and 1 for failure.
  *
  * @param proof_path Path to the file containing the serialized proof
- * @param vk_path Path to the file containing the serialized verification key of the final mega honk instance
+ * @param vk_path Path to the serialized verification key of the final (MegaHonk) circuit in the stack
  * @param accumualtor_path Path to the file containing the serialized protogalaxy accumulator
  * @return true (resp., false) if the proof is valid (resp., invalid).
  */
@@ -503,7 +503,7 @@ void client_ivc_prove_output_all(const std::string& bytecodePath,
 
     // Write the proof and verification keys into the working directory in  'binary' format (in practice it seems this
     // directory is passed by bb.js)
-    std::string vkPath = outputPath + "/final_decider_vk"; // the vk of the last instance
+    std::string vkPath = outputPath + "/final_decider_vk"; // the vk of the last circuit in the stack
     std::string accPath = outputPath + "/pg_acc";
     std::string proofPath = outputPath + "/client_ivc_proof";
     std::string translatorVkPath = outputPath + "/translator_vk";
@@ -513,8 +513,8 @@ void client_ivc_prove_output_all(const std::string& bytecodePath,
     auto eccvm_vk = std::make_shared<ECCVMVK>(ivc.goblin.get_eccvm_proving_key());
     auto translator_vk = std::make_shared<TranslatorVK>(ivc.goblin.get_translator_proving_key());
 
-    auto last_instance = std::make_shared<ClientIVC::DeciderVerificationKey>(ivc.decider_vk);
-    vinfo("ensure valid proof: ", ivc.verify(proof, { ivc.verifier_accumulator, last_instance }));
+    auto last_vk = std::make_shared<ClientIVC::DeciderVerificationKey>(ivc.decider_vk);
+    vinfo("ensure valid proof: ", ivc.verify(proof, { ivc.verifier_accumulator, last_vk }));
 
     vinfo("write proof and vk data to files..");
     write_file(proofPath, to_buffer(proof));
@@ -543,7 +543,7 @@ void prove_tube(const std::string& output_path)
     using Builder = UltraCircuitBuilder;
     using GrumpkinVk = bb::VerifierCommitmentKey<curve::Grumpkin>;
 
-    std::string vkPath = output_path + "/final_decider_vk"; // the vk of the last instance
+    std::string vkPath = output_path + "/final_decider_vk"; // the vk of the last circuit in the stack
     std::string accPath = output_path + "/pg_acc";
     std::string proofPath = output_path + "/client_ivc_proof";
     std::string translatorVkPath = output_path + "/translator_vk";

--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -197,7 +197,7 @@ bool proveAndVerifyHonkAcirFormat(acir_format::AcirFormat constraint_system, aci
     auto proof = prover.construct_proof();
 
     // Verify Honk proof
-    auto verification_key = std::make_shared<VerificationKey>(prover.instance->proving_key);
+    auto verification_key = std::make_shared<VerificationKey>(prover.proving_key->proving_key);
 
     Verifier verifier{ verification_key };
 
@@ -378,12 +378,12 @@ void client_ivc_prove_output_all_msgpack(const std::string& bytecodePath,
     auto eccvm_vk = std::make_shared<ECCVMVK>(ivc.goblin.get_eccvm_proving_key());
     auto translator_vk = std::make_shared<TranslatorVK>(ivc.goblin.get_translator_proving_key());
 
-    auto last_instance = std::make_shared<ClientIVC::DeciderVerificationKey>(ivc.instance_vk);
+    auto last_instance = std::make_shared<ClientIVC::DeciderVerificationKey>(ivc.decider_vk);
     vinfo("ensure valid proof: ", ivc.verify(proof, { ivc.verifier_accumulator, last_instance }));
 
     vinfo("write proof and vk data to files..");
     write_file(proofPath, to_buffer(proof));
-    write_file(vkPath, to_buffer(ivc.instance_vk));
+    write_file(vkPath, to_buffer(ivc.decider_vk));
     write_file(accPath, to_buffer(ivc.verifier_accumulator));
     write_file(translatorVkPath, to_buffer(translator_vk));
     write_file(eccVkPath, to_buffer(eccvm_vk));
@@ -513,12 +513,12 @@ void client_ivc_prove_output_all(const std::string& bytecodePath,
     auto eccvm_vk = std::make_shared<ECCVMVK>(ivc.goblin.get_eccvm_proving_key());
     auto translator_vk = std::make_shared<TranslatorVK>(ivc.goblin.get_translator_proving_key());
 
-    auto last_instance = std::make_shared<ClientIVC::DeciderVerificationKey>(ivc.instance_vk);
+    auto last_instance = std::make_shared<ClientIVC::DeciderVerificationKey>(ivc.decider_vk);
     vinfo("ensure valid proof: ", ivc.verify(proof, { ivc.verifier_accumulator, last_instance }));
 
     vinfo("write proof and vk data to files..");
     write_file(proofPath, to_buffer(proof));
-    write_file(vkPath, to_buffer(ivc.instance_vk)); // maybe dereference
+    write_file(vkPath, to_buffer(ivc.decider_vk)); // maybe dereference
     write_file(accPath, to_buffer(ivc.verifier_accumulator));
     write_file(translatorVkPath, to_buffer(translator_vk));
     write_file(eccVkPath, to_buffer(eccvm_vk));
@@ -533,7 +533,7 @@ void client_ivc_prove_output_all(const std::string& bytecodePath,
 void prove_tube(const std::string& output_path)
 {
     using ClientIVC = stdlib::recursion::honk::ClientIVCRecursiveVerifier;
-    using StackDeciderVK = ClientIVC::FoldVerifierInput::Instance;
+    using StackDeciderVK = ClientIVC::FoldVerifierInput::DeciderVK;
     using StackHonkVK = typename MegaFlavor::VerificationKey;
     using ECCVMVk = ECCVMFlavor::VerificationKey;
     using TranslatorVk = TranslatorFlavor::VerificationKey;
@@ -604,7 +604,7 @@ void prove_tube(const std::string& output_path)
 
     std::string tubeVkPath = output_path + "/vk";
     auto tube_verification_key =
-        std::make_shared<typename UltraFlavor::VerificationKey>(tube_prover.instance->proving_key);
+        std::make_shared<typename UltraFlavor::VerificationKey>(tube_prover.proving_key->proving_key);
     write_file(tubeVkPath, to_buffer(tube_verification_key));
 
     std::string tubeAsFieldsVkPath = output_path + "/vk_fields.json";
@@ -1146,7 +1146,7 @@ template <IsUltraFlavor Flavor> void write_vk_honk(const std::string& bytecodePa
     using VerificationKey = Flavor::VerificationKey;
 
     Prover prover = compute_valid_prover<Flavor>(bytecodePath, "");
-    DeciderProvingKey& prover_inst = *prover.instance;
+    DeciderProvingKey& prover_inst = *prover.proving_key;
     VerificationKey vk(
         prover_inst.proving_key); // uses a partial form of the proving key which only has precomputed entities
 
@@ -1311,7 +1311,7 @@ void prove_honk_output_all(const std::string& bytecodePath,
     std::string proofFieldsPath = outputPath + "/proof_fields.json";
 
     VerificationKey vk(
-        prover.instance->proving_key); // uses a partial form of the proving key which only has precomputed entities
+        prover.proving_key->proving_key); // uses a partial form of the proving key which only has precomputed entities
 
     // Write the 'binary' proof
     write_file(proofPath, to_buffer</*include_size=*/true>(proof));

--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -378,7 +378,7 @@ void client_ivc_prove_output_all_msgpack(const std::string& bytecodePath,
     auto eccvm_vk = std::make_shared<ECCVMVK>(ivc.goblin.get_eccvm_proving_key());
     auto translator_vk = std::make_shared<TranslatorVK>(ivc.goblin.get_translator_proving_key());
 
-    auto last_instance = std::make_shared<ClientIVC::VerifierInstance>(ivc.instance_vk);
+    auto last_instance = std::make_shared<ClientIVC::DeciderVerificationKey>(ivc.instance_vk);
     vinfo("ensure valid proof: ", ivc.verify(proof, { ivc.verifier_accumulator, last_instance }));
 
     vinfo("write proof and vk data to files..");
@@ -416,7 +416,7 @@ bool verify_client_ivc(const std::filesystem::path& proof_path,
     init_grumpkin_crs(1 << 15);
 
     const auto proof = from_buffer<ClientIVC::Proof>(read_file(proof_path));
-    const auto accumulator = read_to_shared_ptr<ClientIVC::VerifierInstance>(accumulator_path);
+    const auto accumulator = read_to_shared_ptr<ClientIVC::DeciderVerificationKey>(accumulator_path);
     accumulator->verification_key->pcs_verification_key = std::make_shared<VerifierCommitmentKey<curve::BN254>>();
     const auto final_vk = read_to_shared_ptr<ClientIVC::VerificationKey>(final_vk_path);
     const auto eccvm_vk = read_to_shared_ptr<ECCVMFlavor::VerificationKey>(eccvm_vk_path);
@@ -426,7 +426,7 @@ bool verify_client_ivc(const std::filesystem::path& proof_path,
     translator_vk->pcs_verification_key = std::make_shared<VerifierCommitmentKey<curve::BN254>>();
 
     const bool verified = ClientIVC::verify(
-        proof, accumulator, std::make_shared<ClientIVC::VerifierInstance>(final_vk), eccvm_vk, translator_vk);
+        proof, accumulator, std::make_shared<ClientIVC::DeciderVerificationKey>(final_vk), eccvm_vk, translator_vk);
     vinfo("verified: ", verified);
     return verified;
 }
@@ -513,7 +513,7 @@ void client_ivc_prove_output_all(const std::string& bytecodePath,
     auto eccvm_vk = std::make_shared<ECCVMVK>(ivc.goblin.get_eccvm_proving_key());
     auto translator_vk = std::make_shared<TranslatorVK>(ivc.goblin.get_translator_proving_key());
 
-    auto last_instance = std::make_shared<ClientIVC::VerifierInstance>(ivc.instance_vk);
+    auto last_instance = std::make_shared<ClientIVC::DeciderVerificationKey>(ivc.instance_vk);
     vinfo("ensure valid proof: ", ivc.verify(proof, { ivc.verifier_accumulator, last_instance }));
 
     vinfo("write proof and vk data to files..");
@@ -1142,11 +1142,11 @@ template <IsUltraFlavor Flavor> bool verify_honk(const std::string& proof_path, 
 template <IsUltraFlavor Flavor> void write_vk_honk(const std::string& bytecodePath, const std::string& outputPath)
 {
     using Prover = UltraProver_<Flavor>;
-    using ProverInstance = ProverInstance_<Flavor>;
+    using DeciderProvingKey = DeciderProvingKey_<Flavor>;
     using VerificationKey = Flavor::VerificationKey;
 
     Prover prover = compute_valid_prover<Flavor>(bytecodePath, "");
-    ProverInstance& prover_inst = *prover.instance;
+    DeciderProvingKey& prover_inst = *prover.instance;
     VerificationKey vk(
         prover_inst.proving_key); // uses a partial form of the proving key which only has precomputed entities
 

--- a/barretenberg/cpp/src/barretenberg/benchmark/aztec_ivc_bench/aztec_ivc.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/aztec_ivc_bench/aztec_ivc.bench.cpp
@@ -40,7 +40,7 @@ class AztecIVCBench : public benchmark::Fixture {
      */
     static bool verify_ivc(Proof& proof, AztecIVC& ivc)
     {
-        auto verifier_inst = std::make_shared<DeciderVerificationKey>(ivc.verification_queue[0].verification_key);
+        auto verifier_inst = std::make_shared<DeciderVerificationKey>(ivc.verification_queue[0].honk_verification_key);
         bool verified = ivc.verify(proof, { ivc.verifier_accumulator, verifier_inst });
 
         // This is a benchmark, not a test, so just print success or failure to the log

--- a/barretenberg/cpp/src/barretenberg/benchmark/aztec_ivc_bench/aztec_ivc.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/aztec_ivc_bench/aztec_ivc.bench.cpp
@@ -21,7 +21,7 @@ namespace {
 class AztecIVCBench : public benchmark::Fixture {
   public:
     using Builder = MegaCircuitBuilder;
-    using VerifierInstance = VerifierInstance_<MegaFlavor>;
+    using DeciderVerificationKey = DeciderVerificationKey_<MegaFlavor>;
     using Proof = AztecIVC::Proof;
     using MockCircuitProducer = PrivateFunctionExecutionMockCircuitProducer;
 
@@ -40,7 +40,7 @@ class AztecIVCBench : public benchmark::Fixture {
      */
     static bool verify_ivc(Proof& proof, AztecIVC& ivc)
     {
-        auto verifier_inst = std::make_shared<VerifierInstance>(ivc.verification_queue[0].instance_vk);
+        auto verifier_inst = std::make_shared<DeciderVerificationKey>(ivc.verification_queue[0].instance_vk);
         bool verified = ivc.verify(proof, { ivc.verifier_accumulator, verifier_inst });
 
         // This is a benchmark, not a test, so just print success or failure to the log

--- a/barretenberg/cpp/src/barretenberg/benchmark/aztec_ivc_bench/aztec_ivc.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/aztec_ivc_bench/aztec_ivc.bench.cpp
@@ -40,7 +40,7 @@ class AztecIVCBench : public benchmark::Fixture {
      */
     static bool verify_ivc(Proof& proof, AztecIVC& ivc)
     {
-        auto verifier_inst = std::make_shared<DeciderVerificationKey>(ivc.verification_queue[0].instance_vk);
+        auto verifier_inst = std::make_shared<DeciderVerificationKey>(ivc.verification_queue[0].verification_key);
         bool verified = ivc.verify(proof, { ivc.verifier_accumulator, verifier_inst });
 
         // This is a benchmark, not a test, so just print success or failure to the log

--- a/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_bench/protogalaxy.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_bench/protogalaxy.bench.cpp
@@ -14,9 +14,9 @@ namespace bb {
 // Fold one instance into an accumulator.
 template <typename Flavor, size_t k> void fold_k(State& state) noexcept
 {
-    using ProverInstance = ProverInstance_<Flavor>;
-    using Instance = ProverInstance;
-    using Instances = ProverInstances_<Flavor, k + 1>;
+    using DeciderProvingKey = DeciderProvingKey_<Flavor>;
+    using Instance = DeciderProvingKey;
+    using Instances = DeciderProvingKeys_<Flavor, k + 1>;
     using ProtogalaxyProver = ProtogalaxyProver_<Instances>;
     using Builder = typename Flavor::CircuitBuilder;
 
@@ -27,7 +27,7 @@ template <typename Flavor, size_t k> void fold_k(State& state) noexcept
     const auto construct_instance = [&]() {
         Builder builder;
         MockCircuits::construct_arithmetic_circuit(builder, log2_num_gates);
-        return std::make_shared<ProverInstance>(builder);
+        return std::make_shared<DeciderProvingKey>(builder);
     };
     std::vector<std::shared_ptr<Instance>> instances;
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/938): Parallelize this loop

--- a/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_bench/protogalaxy.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_bench/protogalaxy.bench.cpp
@@ -15,9 +15,7 @@ namespace bb {
 template <typename Flavor, size_t k> void fold_k(State& state) noexcept
 {
     using DeciderProvingKey = DeciderProvingKey_<Flavor>;
-    using Instance = DeciderProvingKey;
-    using Instances = DeciderProvingKeys_<Flavor, k + 1>;
-    using ProtogalaxyProver = ProtogalaxyProver_<Instances>;
+    using ProtogalaxyProver = ProtogalaxyProver_<DeciderProvingKeys_<Flavor, k + 1>>;
     using Builder = typename Flavor::CircuitBuilder;
 
     bb::srs::init_crs_factory("../srs_db/ignition");
@@ -29,13 +27,13 @@ template <typename Flavor, size_t k> void fold_k(State& state) noexcept
         MockCircuits::construct_arithmetic_circuit(builder, log2_num_gates);
         return std::make_shared<DeciderProvingKey>(builder);
     };
-    std::vector<std::shared_ptr<Instance>> instances;
+    std::vector<std::shared_ptr<DeciderProvingKey>> decider_pks;
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/938): Parallelize this loop
     for (size_t i = 0; i < k + 1; ++i) {
-        instances.emplace_back(construct_instance());
+        decider_pks.emplace_back(construct_instance());
     }
 
-    ProtogalaxyProver folding_prover(instances);
+    ProtogalaxyProver folding_prover(decider_pks);
 
     for (auto _ : state) {
         BB_REPORT_OP_COUNT_IN_BENCH(state);

--- a/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_bench/protogalaxy.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_bench/protogalaxy.bench.cpp
@@ -11,7 +11,7 @@ using namespace benchmark;
 
 namespace bb {
 
-// Fold one instance into an accumulator.
+// Fold one proving key into an accumulator.
 template <typename Flavor, size_t k> void fold_k(State& state) noexcept
 {
     using DeciderProvingKey = DeciderProvingKey_<Flavor>;
@@ -22,7 +22,7 @@ template <typename Flavor, size_t k> void fold_k(State& state) noexcept
 
     auto log2_num_gates = static_cast<size_t>(state.range(0));
 
-    const auto construct_instance = [&]() {
+    const auto construct_key = [&]() {
         Builder builder;
         MockCircuits::construct_arithmetic_circuit(builder, log2_num_gates);
         return std::make_shared<DeciderProvingKey>(builder);
@@ -30,7 +30,7 @@ template <typename Flavor, size_t k> void fold_k(State& state) noexcept
     std::vector<std::shared_ptr<DeciderProvingKey>> decider_pks;
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/938): Parallelize this loop
     for (size_t i = 0; i < k + 1; ++i) {
-        decider_pks.emplace_back(construct_instance());
+        decider_pks.emplace_back(construct_key());
     }
 
     ProtogalaxyProver folding_prover(decider_pks);

--- a/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_rounds_bench/protogalaxy_rounds.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_rounds_bench/protogalaxy_rounds.bench.cpp
@@ -10,11 +10,11 @@ using namespace benchmark;
 namespace bb {
 
 template <typename Flavor>
-void _bench_round(::benchmark::State& state, void (*F)(ProtogalaxyProver_<ProverInstances_<Flavor, 2>>&))
+void _bench_round(::benchmark::State& state, void (*F)(ProtogalaxyProver_<DeciderProvingKeys_<Flavor, 2>>&))
 {
     using Builder = typename Flavor::CircuitBuilder;
-    using ProverInstance = ProverInstance_<Flavor>;
-    using Instances = ProverInstances_<Flavor, 2>;
+    using DeciderProvingKey = DeciderProvingKey_<Flavor>;
+    using Instances = DeciderProvingKeys_<Flavor, 2>;
     using ProtogalaxyProver = ProtogalaxyProver_<Instances>;
 
     bb::srs::init_crs_factory("../srs_db/ignition");
@@ -23,13 +23,13 @@ void _bench_round(::benchmark::State& state, void (*F)(ProtogalaxyProver_<Prover
     const auto construct_instance = [&]() {
         Builder builder;
         MockCircuits::construct_arithmetic_circuit(builder, log2_num_gates);
-        return std::make_shared<ProverInstance>(builder);
+        return std::make_shared<DeciderProvingKey>(builder);
     };
 
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/938): Parallelize this loop, also extend to more than
     // k=1
-    std::shared_ptr<ProverInstance> prover_instance_1 = construct_instance();
-    std::shared_ptr<ProverInstance> prover_instance_2 = construct_instance();
+    std::shared_ptr<DeciderProvingKey> prover_instance_1 = construct_instance();
+    std::shared_ptr<DeciderProvingKey> prover_instance_2 = construct_instance();
 
     ProtogalaxyProver folding_prover({ prover_instance_1, prover_instance_2 });
 
@@ -46,7 +46,7 @@ void _bench_round(::benchmark::State& state, void (*F)(ProtogalaxyProver_<Prover
     }
 }
 
-void bench_round_mega(::benchmark::State& state, void (*F)(ProtogalaxyProver_<ProverInstances_<MegaFlavor, 2>>&))
+void bench_round_mega(::benchmark::State& state, void (*F)(ProtogalaxyProver_<DeciderProvingKeys_<MegaFlavor, 2>>&))
 {
     _bench_round<MegaFlavor>(state, F);
 }

--- a/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_rounds_bench/protogalaxy_rounds.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_rounds_bench/protogalaxy_rounds.bench.cpp
@@ -39,7 +39,7 @@ void _bench_round(::benchmark::State& state, void (*F)(ProtogalaxyProver_<Decide
     std::fill_n(folding_prover.deltas.begin(), log2_num_gates, 0);
     folding_prover.perturbator = Flavor::Polynomial::random(1 << log2_num_gates);
     folding_prover.transcript = Flavor::Transcript::prover_init_empty();
-    folding_prover.run_oink_prover_on_each_instance();
+    folding_prover.run_oink_prover_on_each_incomplete_key();
 
     for (auto _ : state) {
         F(folding_prover);

--- a/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_rounds_bench/protogalaxy_rounds.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_rounds_bench/protogalaxy_rounds.bench.cpp
@@ -34,10 +34,10 @@ void _bench_round(::benchmark::State& state, void (*F)(ProtogalaxyProver_<Prover
     ProtogalaxyProver folding_prover({ prover_instance_1, prover_instance_2 });
 
     // prepare the prover state
-    folding_prover.state.accumulator = prover_instance_1;
-    folding_prover.state.deltas.resize(log2_num_gates);
-    std::fill_n(folding_prover.state.deltas.begin(), log2_num_gates, 0);
-    folding_prover.state.perturbator = Flavor::Polynomial::random(1 << log2_num_gates);
+    folding_prover.accumulator = prover_instance_1;
+    folding_prover.deltas.resize(log2_num_gates);
+    std::fill_n(folding_prover.deltas.begin(), log2_num_gates, 0);
+    folding_prover.perturbator = Flavor::Polynomial::random(1 << log2_num_gates);
     folding_prover.transcript = Flavor::Transcript::prover_init_empty();
     folding_prover.run_oink_prover_on_each_instance();
 
@@ -53,18 +53,17 @@ void bench_round_mega(::benchmark::State& state, void (*F)(ProtogalaxyProver_<Pr
 
 BENCHMARK_CAPTURE(bench_round_mega, oink, [](auto& prover) { prover.run_oink_prover_on_each_instance(); })
     -> DenseRange(14, 20) -> Unit(kMillisecond);
-BENCHMARK_CAPTURE(bench_round_mega, perturbator, [](auto& prover) {
-    prover.perturbator_round(prover.state.accumulator);
-}) -> DenseRange(14, 20) -> Unit(kMillisecond);
+BENCHMARK_CAPTURE(bench_round_mega, perturbator, [](auto& prover) { prover.perturbator_round(prover.accumulator); })
+    -> DenseRange(14, 20) -> Unit(kMillisecond);
 BENCHMARK_CAPTURE(bench_round_mega, combiner_quotient, [](auto& prover) {
-    prover.combiner_quotient_round(prover.state.accumulator->gate_challenges, prover.state.deltas, prover.instances);
+    prover.combiner_quotient_round(prover.accumulator->gate_challenges, prover.deltas, prover.instances);
 }) -> DenseRange(14, 20) -> Unit(kMillisecond);
 BENCHMARK_CAPTURE(bench_round_mega, fold, [](auto& prover) {
     prover.update_target_sum_and_fold(prover.instances,
-                                      prover.state.combiner_quotient,
-                                      prover.state.alphas,
-                                      prover.state.relation_parameters,
-                                      prover.state.perturbator_evaluation);
+                                      prover.combiner_quotient,
+                                      prover.alphas,
+                                      prover.relation_parameters,
+                                      prover.perturbator_evaluation);
 }) -> DenseRange(14, 20) -> Unit(kMillisecond);
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_rounds_bench/protogalaxy_rounds.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_rounds_bench/protogalaxy_rounds.bench.cpp
@@ -51,15 +51,15 @@ void bench_round_mega(::benchmark::State& state, void (*F)(ProtogalaxyProver_<De
     _bench_round<MegaFlavor>(state, F);
 }
 
-BENCHMARK_CAPTURE(bench_round_mega, oink, [](auto& prover) { prover.run_oink_prover_on_each_instance(); })
+BENCHMARK_CAPTURE(bench_round_mega, oink, [](auto& prover) { prover.run_oink_prover_on_each_incomplete_key(); })
     -> DenseRange(14, 20) -> Unit(kMillisecond);
 BENCHMARK_CAPTURE(bench_round_mega, perturbator, [](auto& prover) { prover.perturbator_round(prover.accumulator); })
     -> DenseRange(14, 20) -> Unit(kMillisecond);
 BENCHMARK_CAPTURE(bench_round_mega, combiner_quotient, [](auto& prover) {
-    prover.combiner_quotient_round(prover.accumulator->gate_challenges, prover.deltas, prover.instances);
+    prover.combiner_quotient_round(prover.accumulator->gate_challenges, prover.deltas, prover.keys_to_fold);
 }) -> DenseRange(14, 20) -> Unit(kMillisecond);
 BENCHMARK_CAPTURE(bench_round_mega, fold, [](auto& prover) {
-    prover.update_target_sum_and_fold(prover.instances,
+    prover.update_target_sum_and_fold(prover.keys_to_fold,
                                       prover.combiner_quotient,
                                       prover.alphas,
                                       prover.relation_parameters,

--- a/barretenberg/cpp/src/barretenberg/benchmark/relations_bench/relations.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/relations_bench/relations.bench.cpp
@@ -53,10 +53,10 @@ template <typename Flavor, typename Relation> void execute_relation_for_univaria
 // Single execution of relation on PG univariates, i.e. PG combiner work
 template <typename Flavor, typename Relation> void execute_relation_for_pg_univariates(::benchmark::State& state)
 {
-    using ProverInstances = ProverInstances_<Flavor>;
-    using Input = ProtogalaxyProverInternal<ProverInstances>::ExtendedUnivariatesNoOptimisticSkipping;
+    using DeciderProvingKeys = DeciderProvingKeys_<Flavor>;
+    using Input = ProtogalaxyProverInternal<DeciderProvingKeys>::ExtendedUnivariatesNoOptimisticSkipping;
     using Accumulator = typename Relation::template ProtogalaxyTupleOfUnivariatesOverSubrelationsNoOptimisticSkipping<
-        ProverInstances::NUM>;
+        DeciderProvingKeys::NUM>;
 
     execute_relation<Flavor, Relation, Input, Accumulator>(state);
 }

--- a/barretenberg/cpp/src/barretenberg/benchmark/simulator_bench/simulator.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/simulator_bench/simulator.bench.cpp
@@ -11,7 +11,7 @@ template <typename RecursiveFlavor> class SimulatorFixture : public benchmark::F
 
   public:
     using Flavor = typename RecursiveFlavor::NativeFlavor;
-    using ProverInstance = ProverInstance_<Flavor>;
+    using DeciderProvingKey = DeciderProvingKey_<Flavor>;
     using Builder = typename Flavor::CircuitBuilder;
     using VerificationKey = typename Flavor::VerificationKey;
     using CircuitSimulator = typename RecursiveFlavor::CircuitBuilder;
@@ -36,7 +36,7 @@ template <typename RecursiveFlavor> class SimulatorFixture : public benchmark::F
     {
 
         auto builder = construct_mock_function_circuit(large);
-        auto instance = std::make_shared<ProverInstance>(builder);
+        auto instance = std::make_shared<DeciderProvingKey>(builder);
         UltraProver_<Flavor> prover(instance);
         auto ultra_proof = prover.construct_proof();
         auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);

--- a/barretenberg/cpp/src/barretenberg/benchmark/simulator_bench/simulator.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/simulator_bench/simulator.bench.cpp
@@ -36,10 +36,10 @@ template <typename RecursiveFlavor> class SimulatorFixture : public benchmark::F
     {
 
         auto builder = construct_mock_function_circuit(large);
-        auto instance = std::make_shared<DeciderProvingKey>(builder);
-        UltraProver_<Flavor> prover(instance);
+        auto proving_key = std::make_shared<DeciderProvingKey>(builder);
+        UltraProver_<Flavor> prover(proving_key);
         auto ultra_proof = prover.construct_proof();
-        auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
+        auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
         return { ultra_proof, verification_key };
     }
 

--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk_rounds.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk_rounds.bench.cpp
@@ -46,17 +46,17 @@ BB_PROFILE static void test_round_inner(State& state, MegaProver& prover, size_t
             BB_REPORT_OP_COUNT_BENCH_CANCEL();
         }
     };
-    OinkProver<MegaFlavor> oink_prover(prover.instance, prover.transcript);
+    OinkProver<MegaFlavor> oink_prover(prover.proving_key, prover.transcript);
     time_if_index(PREAMBLE, [&] { oink_prover.execute_preamble_round(); });
     time_if_index(WIRE_COMMITMENTS, [&] { oink_prover.execute_wire_commitments_round(); });
     time_if_index(SORTED_LIST_ACCUMULATOR, [&] { oink_prover.execute_sorted_list_accumulator_round(); });
     time_if_index(LOG_DERIVATIVE_INVERSE, [&] { oink_prover.execute_log_derivative_inverse_round(); });
     time_if_index(GRAND_PRODUCT_COMPUTATION, [&] { oink_prover.execute_grand_product_computation_round(); });
-    time_if_index(GENERATE_ALPHAS, [&] { prover.instance->alphas = oink_prover.generate_alphas_round(); });
+    time_if_index(GENERATE_ALPHAS, [&] { prover.proving_key->alphas = oink_prover.generate_alphas_round(); });
 
     prover.generate_gate_challenges();
 
-    DeciderProver_<MegaFlavor> decider_prover(prover.instance, prover.transcript);
+    DeciderProver_<MegaFlavor> decider_prover(prover.proving_key, prover.transcript);
     time_if_index(RELATION_CHECK, [&] { decider_prover.execute_relation_check_rounds(); });
     time_if_index(ZEROMORPH, [&] { decider_prover.execute_pcs_rounds(); });
 }

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -40,7 +40,7 @@ class ClientIVC {
     using GURecursiveFlavor = MegaRecursiveFlavor_<bb::MegaCircuitBuilder>;
     using RecursiveDeciderVerificationKeys =
         bb::stdlib::recursion::honk::RecursiveDeciderVerificationKeys_<GURecursiveFlavor, 2>;
-    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::Instance;
+    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::RecursiveDeciderVK;
     using RecursiveVerificationKey = RecursiveDeciderVerificationKeys::VerificationKey;
     using FoldingRecursiveVerifier =
         bb::stdlib::recursion::honk::ProtogalaxyRecursiveVerifier_<RecursiveDeciderVerificationKeys>;
@@ -68,7 +68,7 @@ class ClientIVC {
     GoblinProver goblin;
     ProverFoldOutput fold_output;
     std::shared_ptr<DeciderVerificationKey> verifier_accumulator;
-    std::shared_ptr<VerificationKey> instance_vk;
+    std::shared_ptr<VerificationKey> decider_vk;
 
     // A flag indicating whether or not to construct a structured trace in the DeciderProvingKey
     TraceStructure trace_structure = TraceStructure::NONE;

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -25,24 +25,25 @@ class ClientIVC {
     using VerificationKey = Flavor::VerificationKey;
     using FF = Flavor::FF;
     using FoldProof = std::vector<FF>;
-    using ProverInstance = ProverInstance_<Flavor>;
-    using VerifierInstance = VerifierInstance_<Flavor>;
+    using DeciderProvingKey = DeciderProvingKey_<Flavor>;
+    using DeciderVerificationKey = DeciderVerificationKey_<Flavor>;
     using ClientCircuit = MegaCircuitBuilder; // can only be Mega
     using DeciderProver = DeciderProver_<Flavor>;
     using DeciderVerifier = DeciderVerifier_<Flavor>;
-    using ProverInstances = ProverInstances_<Flavor>;
-    using FoldingProver = ProtogalaxyProver_<ProverInstances>;
-    using VerifierInstances = VerifierInstances_<Flavor>;
-    using FoldingVerifier = ProtogalaxyVerifier_<VerifierInstances>;
+    using DeciderProvingKeys = DeciderProvingKeys_<Flavor>;
+    using FoldingProver = ProtogalaxyProver_<DeciderProvingKeys>;
+    using DeciderVerificationKeys = DeciderVerificationKeys_<Flavor>;
+    using FoldingVerifier = ProtogalaxyVerifier_<DeciderVerificationKeys>;
     using ECCVMVerificationKey = bb::ECCVMFlavor::VerificationKey;
     using TranslatorVerificationKey = bb::TranslatorFlavor::VerificationKey;
 
     using GURecursiveFlavor = MegaRecursiveFlavor_<bb::MegaCircuitBuilder>;
-    using RecursiveVerifierInstances = bb::stdlib::recursion::honk::RecursiveVerifierInstances_<GURecursiveFlavor, 2>;
-    using RecursiveVerifierInstance = RecursiveVerifierInstances::Instance;
-    using RecursiveVerificationKey = RecursiveVerifierInstances::VerificationKey;
+    using RecursiveDeciderVerificationKeys =
+        bb::stdlib::recursion::honk::RecursiveDeciderVerificationKeys_<GURecursiveFlavor, 2>;
+    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::Instance;
+    using RecursiveVerificationKey = RecursiveDeciderVerificationKeys::VerificationKey;
     using FoldingRecursiveVerifier =
-        bb::stdlib::recursion::honk::ProtogalaxyRecursiveVerifier_<RecursiveVerifierInstances>;
+        bb::stdlib::recursion::honk::ProtogalaxyRecursiveVerifier_<RecursiveDeciderVerificationKeys>;
 
     // A full proof for the IVC scheme
     struct Proof {
@@ -66,10 +67,10 @@ class ClientIVC {
   public:
     GoblinProver goblin;
     ProverFoldOutput fold_output;
-    std::shared_ptr<VerifierInstance> verifier_accumulator;
+    std::shared_ptr<DeciderVerificationKey> verifier_accumulator;
     std::shared_ptr<VerificationKey> instance_vk;
 
-    // A flag indicating whether or not to construct a structured trace in the ProverInstance
+    // A flag indicating whether or not to construct a structured trace in the DeciderProvingKey
     TraceStructure trace_structure = TraceStructure::NONE;
 
     // A flag indicating whether the IVC has been initialized with an initial instance
@@ -80,12 +81,12 @@ class ClientIVC {
     Proof prove();
 
     static bool verify(const Proof& proof,
-                       const std::shared_ptr<VerifierInstance>& accumulator,
-                       const std::shared_ptr<VerifierInstance>& final_verifier_instance,
+                       const std::shared_ptr<DeciderVerificationKey>& accumulator,
+                       const std::shared_ptr<DeciderVerificationKey>& final_verifier_instance,
                        const std::shared_ptr<ClientIVC::ECCVMVerificationKey>& eccvm_vk,
                        const std::shared_ptr<ClientIVC::TranslatorVerificationKey>& translator_vk);
 
-    bool verify(Proof& proof, const std::vector<std::shared_ptr<VerifierInstance>>& verifier_instances) const;
+    bool verify(Proof& proof, const std::vector<std::shared_ptr<DeciderVerificationKey>>& verifier_instances) const;
 
     bool prove_and_verify();
 

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -14,9 +14,7 @@ namespace bb {
 
 /**
  * @brief The IVC interface to be used by the aztec client for private function execution
- * @details Combines Protogalaxy with Goblin to accumulate one circuit instance at a time with efficient EC group
- * operations
- *
+ * @details Combines Protogalaxy with Goblin to accumulate one circuit at a time with efficient EC group operations
  */
 class ClientIVC {
 
@@ -40,7 +38,7 @@ class ClientIVC {
     using GURecursiveFlavor = MegaRecursiveFlavor_<bb::MegaCircuitBuilder>;
     using RecursiveDeciderVerificationKeys =
         bb::stdlib::recursion::honk::RecursiveDeciderVerificationKeys_<GURecursiveFlavor, 2>;
-    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::RecursiveDeciderVK;
+    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::DeciderVK;
     using RecursiveVerificationKey = RecursiveDeciderVerificationKeys::VerificationKey;
     using FoldingRecursiveVerifier =
         bb::stdlib::recursion::honk::ProtogalaxyRecursiveVerifier_<RecursiveDeciderVerificationKeys>;
@@ -61,8 +59,8 @@ class ClientIVC {
 
   private:
     using ProverFoldOutput = FoldingResult<Flavor>;
-    // Note: We need to save the last instance that was folded in order to compute its verification key, this will not
-    // be needed in the real IVC as they are provided as inputs
+    // Note: We need to save the last proving key that was folded in order to compute its verification key, this will
+    // not be needed in the real IVC as they are provided as inputs
 
   public:
     GoblinProver goblin;
@@ -73,7 +71,7 @@ class ClientIVC {
     // A flag indicating whether or not to construct a structured trace in the DeciderProvingKey
     TraceStructure trace_structure = TraceStructure::NONE;
 
-    // A flag indicating whether the IVC has been initialized with an initial instance
+    // A flag indicating whether the IVC has been initialized with an initial decider proving key
     bool initialized = false;
 
     void accumulate(ClientCircuit& circuit, const std::shared_ptr<VerificationKey>& precomputed_vk = nullptr);
@@ -82,11 +80,11 @@ class ClientIVC {
 
     static bool verify(const Proof& proof,
                        const std::shared_ptr<DeciderVerificationKey>& accumulator,
-                       const std::shared_ptr<DeciderVerificationKey>& final_verifier_instance,
+                       const std::shared_ptr<DeciderVerificationKey>& final_stack_vk,
                        const std::shared_ptr<ClientIVC::ECCVMVerificationKey>& eccvm_vk,
                        const std::shared_ptr<ClientIVC::TranslatorVerificationKey>& translator_vk);
 
-    bool verify(Proof& proof, const std::vector<std::shared_ptr<DeciderVerificationKey>>& verifier_instances) const;
+    bool verify(Proof& proof, const std::vector<std::shared_ptr<DeciderVerificationKey>>& vk_stack) const;
 
     bool prove_and_verify();
 

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -20,15 +20,15 @@ class ClientIVCTests : public ::testing::Test {
     using FF = typename Flavor::FF;
     using VerificationKey = Flavor::VerificationKey;
     using Builder = ClientIVC::ClientCircuit;
-    using ProverInstance = ClientIVC::ProverInstance;
-    using VerifierInstance = ClientIVC::VerifierInstance;
+    using DeciderProvingKey = ClientIVC::DeciderProvingKey;
+    using DeciderVerificationKey = ClientIVC::DeciderVerificationKey;
     using FoldProof = ClientIVC::FoldProof;
     using DeciderProver = ClientIVC::DeciderProver;
     using DeciderVerifier = ClientIVC::DeciderVerifier;
-    using ProverInstances = ProverInstances_<Flavor>;
-    using FoldingProver = ProtogalaxyProver_<ProverInstances>;
-    using VerifierInstances = VerifierInstances_<Flavor>;
-    using FoldingVerifier = ProtogalaxyVerifier_<VerifierInstances>;
+    using DeciderProvingKeys = DeciderProvingKeys_<Flavor>;
+    using FoldingProver = ProtogalaxyProver_<DeciderProvingKeys>;
+    using DeciderVerificationKeys = DeciderVerificationKeys_<Flavor>;
+    using FoldingVerifier = ProtogalaxyVerifier_<DeciderVerificationKeys>;
 
     /**
      * @brief Prove and verify the IVC scheme
@@ -41,7 +41,7 @@ class ClientIVCTests : public ::testing::Test {
         ZoneScopedN("ClientIVC::prove_and_verify");
         auto proof = ivc.prove();
 
-        auto verifier_inst = std::make_shared<VerifierInstance>(ivc.instance_vk);
+        auto verifier_inst = std::make_shared<DeciderVerificationKey>(ivc.instance_vk);
         return ivc.verify(proof, { ivc.verifier_accumulator, verifier_inst });
     }
 

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -41,7 +41,7 @@ class ClientIVCTests : public ::testing::Test {
         ZoneScopedN("ClientIVC::prove_and_verify");
         auto proof = ivc.prove();
 
-        auto verifier_inst = std::make_shared<DeciderVerificationKey>(ivc.instance_vk);
+        auto verifier_inst = std::make_shared<DeciderVerificationKey>(ivc.decider_vk);
         return ivc.verify(proof, { ivc.verifier_accumulator, verifier_inst });
     }
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
@@ -65,8 +65,8 @@ class AcirIntegrationTest : public ::testing::Test {
         builder.blocks.summarize();
         info("num gates          = ", builder.get_num_gates());
         info("total circuit size = ", builder.get_total_circuit_size());
-        info("circuit size       = ", prover.instance->proving_key.circuit_size);
-        info("log circuit size   = ", prover.instance->proving_key.log_circuit_size);
+        info("circuit size       = ", prover.proving_key->proving_key.circuit_size);
+        info("log circuit size   = ", prover.proving_key->proving_key.log_circuit_size);
 #endif
         auto proof = prover.construct_proof();
 
@@ -418,7 +418,7 @@ TEST_P(AcirIntegrationFoldingTest, DISABLED_FoldAndVerifyProgramStack)
         ivc.accumulate(circuit);
 
         CircuitChecker::check(circuit);
-        // EXPECT_TRUE(prove_and_verify_honk<Flavor>(ivc.prover_instance));
+        // EXPECT_TRUE(prove_and_verify_honk<Flavor>(circuit));
 
         program_stack.pop_back();
     }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
@@ -71,7 +71,7 @@ class AcirIntegrationTest : public ::testing::Test {
         auto proof = prover.construct_proof();
 
         // Verify Honk proof
-        auto verification_key = std::make_shared<VerificationKey>(prover.instance->proving_key);
+        auto verification_key = std::make_shared<VerificationKey>(prover.proving_key->proving_key);
         Verifier verifier{ verification_key };
         return verifier.verify_proof(proof);
     }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
@@ -33,7 +33,7 @@ class MegaHonk : public ::testing::Test {
         Prover prover{ circuit };
         auto proof = prover.construct_proof();
 
-        auto verification_key = std::make_shared<VerificationKey>(prover.instance->proving_key);
+        auto verification_key = std::make_shared<VerificationKey>(prover.proving_key->proving_key);
         Verifier verifier{ verification_key };
 
         return verifier.verify_proof(proof);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
@@ -15,7 +15,7 @@ using namespace bb;
 class AcirHonkRecursionConstraint : public ::testing::Test {
 
   public:
-    using ProverInstance = ProverInstance_<UltraFlavor>;
+    using DeciderProvingKey = DeciderProvingKey_<UltraFlavor>;
     using Prover = bb::UltraProver;
     using VerificationKey = UltraFlavor::VerificationKey;
     using Verifier = bb::UltraVerifier;
@@ -145,7 +145,7 @@ class AcirHonkRecursionConstraint : public ::testing::Test {
 
         for (auto& inner_circuit : inner_circuits) {
 
-            auto instance = std::make_shared<ProverInstance>(inner_circuit);
+            auto instance = std::make_shared<DeciderProvingKey>(inner_circuit);
             Prover prover(instance);
             auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
             Verifier verifier(verification_key);
@@ -222,7 +222,7 @@ TEST_F(AcirHonkRecursionConstraint, TestBasicSingleHonkRecursionConstraint)
 
     info("circuit gates = ", layer_2_circuit.get_num_gates());
 
-    auto instance = std::make_shared<ProverInstance>(layer_2_circuit);
+    auto instance = std::make_shared<DeciderProvingKey>(layer_2_circuit);
     Prover prover(instance);
     info("prover gates = ", instance->proving_key.circuit_size);
     auto proof = prover.construct_proof();
@@ -242,7 +242,7 @@ TEST_F(AcirHonkRecursionConstraint, TestBasicDoubleHonkRecursionConstraints)
 
     info("circuit gates = ", layer_2_circuit.get_num_gates());
 
-    auto instance = std::make_shared<ProverInstance>(layer_2_circuit);
+    auto instance = std::make_shared<DeciderProvingKey>(layer_2_circuit);
     Prover prover(instance);
     info("prover gates = ", instance->proving_key.circuit_size);
     auto proof = prover.construct_proof();
@@ -300,7 +300,7 @@ TEST_F(AcirHonkRecursionConstraint, TestOneOuterRecursiveCircuit)
     info("created second outer circuit");
     info("number of gates in layer 3 = ", layer_3_circuit.get_num_gates());
 
-    auto instance = std::make_shared<ProverInstance>(layer_3_circuit);
+    auto instance = std::make_shared<DeciderProvingKey>(layer_3_circuit);
     Prover prover(instance);
     info("prover gates = ", instance->proving_key.circuit_size);
     auto proof = prover.construct_proof();
@@ -330,7 +330,7 @@ TEST_F(AcirHonkRecursionConstraint, TestFullRecursiveComposition)
     info("created third outer circuit");
     info("number of gates in layer 3 circuit = ", layer_3_circuit.get_num_gates());
 
-    auto instance = std::make_shared<ProverInstance>(layer_3_circuit);
+    auto instance = std::make_shared<DeciderProvingKey>(layer_3_circuit);
     Prover prover(instance);
     info("prover gates = ", instance->proving_key.circuit_size);
     auto proof = prover.construct_proof();

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
@@ -145,9 +145,9 @@ class AcirHonkRecursionConstraint : public ::testing::Test {
 
         for (auto& inner_circuit : inner_circuits) {
 
-            auto instance = std::make_shared<DeciderProvingKey>(inner_circuit);
-            Prover prover(instance);
-            auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
+            auto proving_key = std::make_shared<DeciderProvingKey>(inner_circuit);
+            Prover prover(proving_key);
+            auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
             Verifier verifier(verification_key);
             auto inner_proof = prover.construct_proof();
 
@@ -222,11 +222,11 @@ TEST_F(AcirHonkRecursionConstraint, TestBasicSingleHonkRecursionConstraint)
 
     info("circuit gates = ", layer_2_circuit.get_num_gates());
 
-    auto instance = std::make_shared<DeciderProvingKey>(layer_2_circuit);
-    Prover prover(instance);
-    info("prover gates = ", instance->proving_key.circuit_size);
+    auto proving_key = std::make_shared<DeciderProvingKey>(layer_2_circuit);
+    Prover prover(proving_key);
+    info("prover gates = ", proving_key->proving_key.circuit_size);
     auto proof = prover.construct_proof();
-    auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
+    auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
     Verifier verifier(verification_key);
     EXPECT_EQ(verifier.verify_proof(proof), true);
 }
@@ -242,11 +242,11 @@ TEST_F(AcirHonkRecursionConstraint, TestBasicDoubleHonkRecursionConstraints)
 
     info("circuit gates = ", layer_2_circuit.get_num_gates());
 
-    auto instance = std::make_shared<DeciderProvingKey>(layer_2_circuit);
-    Prover prover(instance);
-    info("prover gates = ", instance->proving_key.circuit_size);
+    auto proving_key = std::make_shared<DeciderProvingKey>(layer_2_circuit);
+    Prover prover(proving_key);
+    info("prover gates = ", proving_key->proving_key.circuit_size);
     auto proof = prover.construct_proof();
-    auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
+    auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
     Verifier verifier(verification_key);
     EXPECT_EQ(verifier.verify_proof(proof), true);
 }
@@ -300,11 +300,11 @@ TEST_F(AcirHonkRecursionConstraint, TestOneOuterRecursiveCircuit)
     info("created second outer circuit");
     info("number of gates in layer 3 = ", layer_3_circuit.get_num_gates());
 
-    auto instance = std::make_shared<DeciderProvingKey>(layer_3_circuit);
-    Prover prover(instance);
-    info("prover gates = ", instance->proving_key.circuit_size);
+    auto proving_key = std::make_shared<DeciderProvingKey>(layer_3_circuit);
+    Prover prover(proving_key);
+    info("prover gates = ", proving_key->proving_key.circuit_size);
     auto proof = prover.construct_proof();
-    auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
+    auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
     Verifier verifier(verification_key);
     EXPECT_EQ(verifier.verify_proof(proof), true);
 }
@@ -330,11 +330,11 @@ TEST_F(AcirHonkRecursionConstraint, TestFullRecursiveComposition)
     info("created third outer circuit");
     info("number of gates in layer 3 circuit = ", layer_3_circuit.get_num_gates());
 
-    auto instance = std::make_shared<DeciderProvingKey>(layer_3_circuit);
-    Prover prover(instance);
-    info("prover gates = ", instance->proving_key.circuit_size);
+    auto proving_key = std::make_shared<DeciderProvingKey>(layer_3_circuit);
+    Prover prover(proving_key);
+    info("prover gates = ", proving_key->proving_key.circuit_size);
     auto proof = prover.construct_proof();
-    auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
+    auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
     Verifier verifier(verification_key);
     EXPECT_EQ(verifier.verify_proof(proof), true);
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
@@ -230,14 +230,14 @@ WASM_EXPORT void acir_verify_ultra_honk(uint8_t const* proof_buf, uint8_t const*
 
 WASM_EXPORT void acir_write_vk_ultra_honk(uint8_t const* acir_vec, uint8_t** out)
 {
-    using ProverInstance = ProverInstance_<UltraFlavor>;
+    using DeciderProvingKey = DeciderProvingKey_<UltraFlavor>;
     using VerificationKey = UltraFlavor::VerificationKey;
 
     auto constraint_system =
         acir_format::circuit_buf_to_acir_format(from_buffer<std::vector<uint8_t>>(acir_vec), /*honk_recursion=*/true);
     auto builder = acir_format::create_circuit<UltraCircuitBuilder>(constraint_system, 0, {}, /*honk_recursion=*/true);
 
-    ProverInstance prover_inst(builder);
+    DeciderProvingKey prover_inst(builder);
     VerificationKey vk(prover_inst.proving_key);
     *out = to_heap_buffer(to_buffer(vk));
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
@@ -75,7 +75,7 @@ WASM_EXPORT void acir_prove_and_verify_ultra_honk(uint8_t const* acir_vec, uint8
     UltraProver prover{ builder };
     auto proof = prover.construct_proof();
 
-    auto verification_key = std::make_shared<UltraFlavor::VerificationKey>(prover.instance->proving_key);
+    auto verification_key = std::make_shared<UltraFlavor::VerificationKey>(prover.proving_key->proving_key);
     UltraVerifier verifier{ verification_key };
 
     *result = verifier.verify_proof(proof);
@@ -121,7 +121,7 @@ WASM_EXPORT void acir_prove_and_verify_mega_honk(uint8_t const* acir_vec, uint8_
     MegaProver prover{ builder };
     auto proof = prover.construct_proof();
 
-    auto verification_key = std::make_shared<MegaFlavor::VerificationKey>(prover.instance->proving_key);
+    auto verification_key = std::make_shared<MegaFlavor::VerificationKey>(prover.proving_key->proving_key);
     MegaVerifier verifier{ verification_key };
 
     *result = verifier.verify_proof(proof);

--- a/barretenberg/cpp/src/barretenberg/execution_trace/execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/execution_trace/execution_trace.hpp
@@ -67,7 +67,7 @@ template <class Flavor> class ExecutionTrace_ {
      * constructs a trace that is both sorted and "structured" in the sense that each block/gate-type has a fixed amount
      * of space within the wire polynomials, regardless of how many actual constraints of each type exist. This is
      * useful primarily for folding since it guarantees that the set of relations that must be executed at each row is
-     * consistent across all instances.
+     * consistent across all folding steps.
      *
      * @param builder
      * @param is_structured whether or not the trace is to be structured with a fixed block size

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -273,10 +273,10 @@ template <typename Tuple> constexpr size_t compute_number_of_subrelations()
  * @brief Utility function to construct a container for the subrelation accumulators of Protogalaxy folding.
  * @details The size of the outer tuple is equal to the number of relations. Each relation contributes an inner tuple of
  * univariates whose size is equal to the number of subrelations of the relation. The length of a univariate in an inner
- * tuple is determined by the corresponding subrelation length and the number of instances to be folded.
+ * tuple is determined by the corresponding subrelation length and the number of keys to be folded.
  * @tparam optimised Enable optimised version with skipping some of the computation
  */
-template <typename Tuple, size_t NUM_INSTANCES, bool optimised = false>
+template <typename Tuple, size_t NUM_KEYS, bool optimised = false>
 constexpr auto create_protogalaxy_tuple_of_tuples_of_univariates()
 {
     constexpr auto seq = std::make_index_sequence<std::tuple_size_v<Tuple>>();
@@ -284,11 +284,11 @@ constexpr auto create_protogalaxy_tuple_of_tuples_of_univariates()
         if constexpr (optimised) {
             return std::make_tuple(
                 typename std::tuple_element_t<I, Tuple>::template ProtogalaxyTupleOfUnivariatesOverSubrelations<
-                    NUM_INSTANCES>{}...);
+                    NUM_KEYS>{}...);
         } else {
             return std::make_tuple(
                 typename std::tuple_element_t<I, Tuple>::
-                    template ProtogalaxyTupleOfUnivariatesOverSubrelationsNoOptimisticSkipping<NUM_INSTANCES>{}...);
+                    template ProtogalaxyTupleOfUnivariatesOverSubrelationsNoOptimisticSkipping<NUM_KEYS>{}...);
         }
     }(seq);
 }

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
@@ -92,10 +92,10 @@ class GoblinProver {
         }
 
         // Construct a Honk proof for the main circuit
-        auto instance = std::make_shared<MegaDeciderProvingKey>(circuit_builder);
-        MegaProver prover(instance);
+        auto proving_key = std::make_shared<MegaDeciderProvingKey>(circuit_builder);
+        MegaProver prover(proving_key);
         auto ultra_proof = prover.construct_proof();
-        auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
+        auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
 
         // Construct and store the merge proof to be recursively verified on the next call to accumulate
         MergeProver merge_prover{ circuit_builder.op_queue };
@@ -151,8 +151,8 @@ class GoblinProver {
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/993): Some circuits (particularly on the first call
         // to accumulate) may not have any goblin ecc ops prior to the call to merge(), so the commitment to the new
         // contribution (C_t_shift) in the merge prover will be the point at infinity. (Note: Some dummy ops are added
-        // in 'add_gates_to_ensure...' but not until instance construction which comes later). See issue for ideas about
-        // how to resolve.
+        // in 'add_gates_to_ensure...' but not until proving_key construction which comes later). See issue for ideas
+        // about how to resolve.
         if (circuit_builder.blocks.ecc_op.size() == 0) {
             MockCircuits::construct_goblin_ecc_op_circuit(circuit_builder); // Add some arbitrary goblin ECC ops
         }

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
@@ -30,7 +30,7 @@ class GoblinProver {
     using Builder = MegaCircuitBuilder;
     using Fr = bb::fr;
     using Transcript = NativeTranscript;
-    using MegaProverInstance = ProverInstance_<MegaFlavor>;
+    using MegaDeciderProvingKey = DeciderProvingKey_<MegaFlavor>;
     using OpQueue = bb::ECCOpQueue;
     using ECCVMFlavor = bb::ECCVMFlavor;
     using ECCVMBuilder = bb::ECCVMCircuitBuilder;
@@ -92,7 +92,7 @@ class GoblinProver {
         }
 
         // Construct a Honk proof for the main circuit
-        auto instance = std::make_shared<MegaProverInstance>(circuit_builder);
+        auto instance = std::make_shared<MegaDeciderProvingKey>(circuit_builder);
         MegaProver prover(instance);
         auto ultra_proof = prover.construct_proof();
         auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);

--- a/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
@@ -30,10 +30,11 @@ class GoblinMockCircuits {
     using Flavor = bb::MegaFlavor;
     using RecursiveFlavor = bb::MegaRecursiveFlavor_<MegaBuilder>;
     using RecursiveVerifier = bb::stdlib::recursion::honk::UltraRecursiveVerifier_<RecursiveFlavor>;
-    using VerifierInstance = bb::VerifierInstance_<Flavor>;
-    using RecursiveVerifierInstance = ::bb::stdlib::recursion::honk::RecursiveVerifierInstance_<RecursiveFlavor>;
-    using RecursiveVerificationKey = RecursiveVerifierInstance::VerificationKey;
-    using RecursiveVerifierAccumulator = std::shared_ptr<RecursiveVerifierInstance>;
+    using DeciderVerificationKey = bb::DeciderVerificationKey_<Flavor>;
+    using RecursiveDeciderVerificationKey =
+        ::bb::stdlib::recursion::honk::RecursiveDeciderVerificationKey_<RecursiveFlavor>;
+    using RecursiveVerificationKey = RecursiveDeciderVerificationKey::VerificationKey;
+    using RecursiveVerifierAccumulator = std::shared_ptr<RecursiveDeciderVerificationKey>;
     using VerificationKey = Flavor::VerificationKey;
     static constexpr size_t NUM_OP_QUEUE_COLUMNS = Flavor::NUM_WIRES;
 
@@ -65,9 +66,9 @@ class GoblinMockCircuits {
 
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/911): We require goblin ops to be added to the
         // function circuit because we cannot support zero commtiments. While the builder handles this at
-        // ProverInstance creation stage via the add_gates_to_ensure_all_polys_are_non_zero function for other MegaHonk
-        // circuits (where we don't explicitly need to add goblin ops), in IVC merge proving happens prior to folding
-        // where the absense of goblin ecc ops will result in zero commitments.
+        // DeciderProvingKey creation stage via the add_gates_to_ensure_all_polys_are_non_zero function for other
+        // MegaHonk circuits (where we don't explicitly need to add goblin ops), in IVC merge proving happens prior to
+        // folding where the absense of goblin ecc ops will result in zero commitments.
         MockCircuits::construct_goblin_ecc_op_circuit(builder);
     }
 
@@ -98,9 +99,9 @@ class GoblinMockCircuits {
 
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/911): We require goblin ops to be added to the
         // function circuit because we cannot support zero commtiments. While the builder handles this at
-        // ProverInstance creation stage via the add_gates_to_ensure_all_polys_are_non_zero function for other MegaHonk
-        // circuits (where we don't explicitly need to add goblin ops), in ClientIVC merge proving happens prior to
-        // folding where the absense of goblin ecc ops will result in zero commitments.
+        // DeciderProvingKey creation stage via the add_gates_to_ensure_all_polys_are_non_zero function for other
+        // MegaHonk circuits (where we don't explicitly need to add goblin ops), in ClientIVC merge proving happens
+        // prior to folding where the absense of goblin ecc ops will result in zero commitments.
         MockCircuits::construct_goblin_ecc_op_circuit(builder);
     }
 

--- a/barretenberg/cpp/src/barretenberg/goblin/mock_circuits_pinning.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/mock_circuits_pinning.test.cpp
@@ -13,7 +13,7 @@ using namespace bb;
  */
 class MegaMockCircuitsPinning : public ::testing::Test {
   protected:
-    using ProverInstance = ProverInstance_<MegaFlavor>;
+    using DeciderProvingKey = DeciderProvingKey_<MegaFlavor>;
     static void SetUpTestSuite() { srs::init_crs_factory("../srs_db/ignition"); }
 };
 
@@ -23,7 +23,7 @@ TEST_F(MegaMockCircuitsPinning, FunctionSizes)
         GoblinProver goblin;
         MegaCircuitBuilder app_circuit{ goblin.op_queue };
         GoblinMockCircuits::construct_mock_function_circuit(app_circuit, large);
-        auto instance = std::make_shared<ProverInstance>(app_circuit);
+        auto instance = std::make_shared<DeciderProvingKey>(app_circuit);
         if (large) {
             EXPECT_EQ(instance->proving_key.log_circuit_size, 19);
         } else {
@@ -40,7 +40,7 @@ TEST_F(MegaMockCircuitsPinning, AppCircuitSizes)
         GoblinProver goblin;
         MegaCircuitBuilder app_circuit{ goblin.op_queue };
         GoblinMockCircuits::construct_mock_app_circuit(app_circuit, large);
-        auto instance = std::make_shared<ProverInstance>(app_circuit);
+        auto instance = std::make_shared<DeciderProvingKey>(app_circuit);
         if (large) {
             EXPECT_EQ(instance->proving_key.log_circuit_size, 19);
         } else {

--- a/barretenberg/cpp/src/barretenberg/goblin/mock_circuits_pinning.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/mock_circuits_pinning.test.cpp
@@ -23,11 +23,11 @@ TEST_F(MegaMockCircuitsPinning, FunctionSizes)
         GoblinProver goblin;
         MegaCircuitBuilder app_circuit{ goblin.op_queue };
         GoblinMockCircuits::construct_mock_function_circuit(app_circuit, large);
-        auto instance = std::make_shared<DeciderProvingKey>(app_circuit);
+        auto proving_key = std::make_shared<DeciderProvingKey>(app_circuit);
         if (large) {
-            EXPECT_EQ(instance->proving_key.log_circuit_size, 19);
+            EXPECT_EQ(proving_key->proving_key.log_circuit_size, 19);
         } else {
-            EXPECT_EQ(instance->proving_key.log_circuit_size, 17);
+            EXPECT_EQ(proving_key->proving_key.log_circuit_size, 17);
         };
     };
     run_test(true);
@@ -40,11 +40,11 @@ TEST_F(MegaMockCircuitsPinning, AppCircuitSizes)
         GoblinProver goblin;
         MegaCircuitBuilder app_circuit{ goblin.op_queue };
         GoblinMockCircuits::construct_mock_app_circuit(app_circuit, large);
-        auto instance = std::make_shared<DeciderProvingKey>(app_circuit);
+        auto proving_key = std::make_shared<DeciderProvingKey>(app_circuit);
         if (large) {
-            EXPECT_EQ(instance->proving_key.log_circuit_size, 19);
+            EXPECT_EQ(proving_key->proving_key.log_circuit_size, 19);
         } else {
-            EXPECT_EQ(instance->proving_key.log_circuit_size, 17);
+            EXPECT_EQ(proving_key->proving_key.log_circuit_size, 17);
         };
     };
     run_test(true);

--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/instance_inspector.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/instance_inspector.hpp
@@ -2,7 +2,7 @@
 
 #include "barretenberg/common/log.hpp"
 
-namespace bb::instance_inspector {
+namespace bb::proving_key_inspector {
 
 // Determine whether a polynomial has at least one non-zero coefficient
 bool is_non_zero(auto& polynomial)
@@ -16,13 +16,13 @@ bool is_non_zero(auto& polynomial)
 }
 
 /**
- * @brief Utility for indicating which polynomials in a prover instance are identically zero
+ * @brief Utility for indicating which polynomials in a decider proving key are identically zero
  *
- * @param prover_instance
+ * @param decider_proving_key
  */
-void inspect_instance(auto& prover_instance)
+void inspect_proving_key(auto& decider_proving_key)
 {
-    auto& prover_polys = prover_instance->prover_polynomials;
+    auto& prover_polys = decider_proving_key->prover_polynomials;
     std::vector<std::string> zero_polys;
     for (auto [label, poly] : zip_view(prover_polys.get_labels(), prover_polys.get_all())) {
         if (!is_non_zero(poly)) {
@@ -30,9 +30,9 @@ void inspect_instance(auto& prover_instance)
         }
     }
     if (zero_polys.empty()) {
-        info("\nInstance Inspector: All prover polynomials are non-zero.");
+        info("\nProving Key Inspector: All prover polynomials are non-zero.");
     } else {
-        info("\nInstance Inspector: The following prover polynomials are identically zero: ");
+        info("\nProving Key Inspector: The following prover polynomials are identically zero: ");
         for (const std::string& label : zero_polys) {
             info("\t", label);
         }
@@ -43,13 +43,13 @@ void inspect_instance(auto& prover_instance)
 /**
  * @brief Print some useful info about polys related to the databus lookup relation
  *
- * @param prover_instance
+ * @param decider_proving_key
  */
-void print_databus_info(auto& prover_instance)
+void print_databus_info(auto& decider_proving_key)
 {
-    info("\nInstance Inspector: Printing databus gate info.");
-    auto& key = prover_instance->proving_key;
-    for (size_t idx = 0; idx < prover_instance->proving_key.circuit_size; ++idx) {
+    info("\nProving Key Inspector: Printing databus gate info.");
+    auto& key = decider_proving_key->proving_key;
+    for (size_t idx = 0; idx < decider_proving_key->proving_key.circuit_size; ++idx) {
         if (key->q_busread[idx] == 1) {
             info("idx = ", idx);
             info("q_busread = ", key->q_busread[idx]);
@@ -66,4 +66,4 @@ void print_databus_info(auto& prover_instance)
     info();
 }
 
-} // namespace bb::instance_inspector
+} // namespace bb::proving_key_inspector

--- a/barretenberg/cpp/src/barretenberg/polynomials/univariate.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/univariate.hpp
@@ -21,9 +21,9 @@ template <class Fr, size_t view_domain_end, size_t view_domain_start, size_t ski
  * domain under the hood.
  *
  * @tparam skip_count Skip computing the values of elements [domain_start+1,..,domain_start+skip_count]. Used for
- * optimising computation in protogalaxy. The value at [domain_start] is the value from the accumulator instance, while
- * the values in [domain_start+1, ... domain_start + skip_count] in the accumulator should be zero if the original
- * instances are correct.
+ * optimising computation in protogalaxy. The value at [domain_start] is the value from the accumulator, while the
+ * values in [domain_start+1, ... domain_start + skip_count] in the accumulator should be zero if the original if the
+ * skip_count-many keys to be folded are all valid
  */
 template <class Fr, size_t domain_end, size_t domain_start = 0, size_t skip_count = 0> class Univariate {
   public:

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/combiner.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/combiner.test.cpp
@@ -13,11 +13,11 @@ using FF = typename Flavor::FF;
 
 // TODO(https://github.com/AztecProtocol/barretenberg/issues/780): Improve combiner tests to check more than the
 // arithmetic relation so we more than unit test folding relation parameters and alpha as well.
-TEST(Protogalaxy, CombinerOn2Instances)
+TEST(Protogalaxy, CombinerOn2Keys)
 {
-    constexpr size_t NUM_INSTANCES = 2;
+    constexpr size_t NUM_KEYS = 2;
     using DeciderProvingKey = DeciderProvingKey_<Flavor>;
-    using DeciderProvingKeys = DeciderProvingKeys_<Flavor, NUM_INSTANCES>;
+    using DeciderProvingKeys = DeciderProvingKeys_<Flavor, NUM_KEYS>;
     using Fun = ProtogalaxyProverInternal<DeciderProvingKeys>;
 
     const auto restrict_to_standard_arithmetic_relation = [](auto& polys) {
@@ -37,26 +37,26 @@ TEST(Protogalaxy, CombinerOn2Instances)
         // Combiner test on prover polynomisls containing random values, restricted to only the standard arithmetic
         // relation.
         if (is_random_input) {
-            std::vector<std::shared_ptr<DeciderProvingKey>> instance_data(NUM_INSTANCES);
+            std::vector<std::shared_ptr<DeciderProvingKey>> keys_data(NUM_KEYS);
 
-            for (size_t idx = 0; idx < NUM_INSTANCES; idx++) {
-                auto instance = std::make_shared<DeciderProvingKey>();
+            for (size_t idx = 0; idx < NUM_KEYS; idx++) {
+                auto key = std::make_shared<DeciderProvingKey>();
                 auto prover_polynomials = get_sequential_prover_polynomials<Flavor>(
                     /*log_circuit_size=*/1, idx * 128);
                 restrict_to_standard_arithmetic_relation(prover_polynomials);
-                instance->proving_key.polynomials = std::move(prover_polynomials);
-                instance->proving_key.circuit_size = 2;
-                instance->proving_key.log_circuit_size = 1;
-                instance_data[idx] = instance;
+                key->proving_key.polynomials = std::move(prover_polynomials);
+                key->proving_key.circuit_size = 2;
+                key->proving_key.log_circuit_size = 1;
+                keys_data[idx] = key;
             }
 
-            DeciderProvingKeys instances{ instance_data };
+            DeciderProvingKeys keys{ keys_data };
             Fun::UnivariateRelationSeparator alphas;
             alphas.fill(bb::Univariate<FF, 12>(FF(0))); // focus on the arithmetic relation only
             GateSeparatorPolynomial<FF> gate_separators({ 2 }, /*log_num_monomials=*/1);
             Fun::UnivariateRelationParametersNoOptimisticSkipping univariate_relation_parameters_no_skpping;
             auto result_no_skipping = Fun::compute_combiner_no_optimistic_skipping(
-                instances, gate_separators, univariate_relation_parameters_no_skpping, alphas);
+                keys, gate_separators, univariate_relation_parameters_no_skpping, alphas);
             // The expected_result values are computed by running the python script combiner_example_gen.py
             auto expected_result = Univariate<FF, 12>(std::array<FF, 12>{ 9704UL,
                                                                           13245288UL,
@@ -72,20 +72,20 @@ TEST(Protogalaxy, CombinerOn2Instances)
                                                                           9072095848UL });
             EXPECT_EQ(result_no_skipping, expected_result);
         } else {
-            std::vector<std::shared_ptr<DeciderProvingKey>> instance_data(NUM_INSTANCES);
+            std::vector<std::shared_ptr<DeciderProvingKey>> keys_data(NUM_KEYS);
 
-            for (size_t idx = 0; idx < NUM_INSTANCES; idx++) {
-                auto instance = std::make_shared<DeciderProvingKey>();
+            for (size_t idx = 0; idx < NUM_KEYS; idx++) {
+                auto key = std::make_shared<DeciderProvingKey>();
                 auto prover_polynomials = get_zero_prover_polynomials<Flavor>(
                     /*log_circuit_size=*/1);
                 restrict_to_standard_arithmetic_relation(prover_polynomials);
-                instance->proving_key.polynomials = std::move(prover_polynomials);
-                instance->proving_key.circuit_size = 2;
-                instance->proving_key.log_circuit_size = 1;
-                instance_data[idx] = instance;
+                key->proving_key.polynomials = std::move(prover_polynomials);
+                key->proving_key.circuit_size = 2;
+                key->proving_key.log_circuit_size = 1;
+                keys_data[idx] = key;
             }
 
-            DeciderProvingKeys instances{ instance_data };
+            DeciderProvingKeys keys{ keys_data };
             Fun::UnivariateRelationSeparator alphas;
             alphas.fill(bb::Univariate<FF, 12>(FF(0))); // focus on the arithmetic relation only
 
@@ -106,15 +106,15 @@ TEST(Protogalaxy, CombinerOn2Instances)
                 polys.q_o[idx] = -1;
             };
 
-            create_add_gate(instances[0]->proving_key.polynomials, 0, 1, 2);
-            create_add_gate(instances[0]->proving_key.polynomials, 1, 0, 4);
-            create_add_gate(instances[1]->proving_key.polynomials, 0, 3, 4);
-            create_mul_gate(instances[1]->proving_key.polynomials, 1, 1, 4);
+            create_add_gate(keys[0]->proving_key.polynomials, 0, 1, 2);
+            create_add_gate(keys[0]->proving_key.polynomials, 1, 0, 4);
+            create_add_gate(keys[1]->proving_key.polynomials, 0, 3, 4);
+            create_mul_gate(keys[1]->proving_key.polynomials, 1, 1, 4);
 
-            restrict_to_standard_arithmetic_relation(instances[0]->proving_key.polynomials);
-            restrict_to_standard_arithmetic_relation(instances[1]->proving_key.polynomials);
+            restrict_to_standard_arithmetic_relation(keys[0]->proving_key.polynomials);
+            restrict_to_standard_arithmetic_relation(keys[1]->proving_key.polynomials);
 
-            /* Instance 0                                    Instance 1
+            /* DeciderProvingKey 0                            DeciderProvingKey 1
                 w_l w_r w_o q_m q_l q_r q_o q_c               w_l w_r w_o q_m q_l q_r q_o q_c
                 1   2   3   0   1   1   -1  0                 3   4   7   0   1   1   -1  0
                 0   4   4   0   1   1   -1  0                 1   4   4   1   0   0   -1  0             */
@@ -137,9 +137,9 @@ TEST(Protogalaxy, CombinerOn2Instances)
             Fun::UnivariateRelationParametersNoOptimisticSkipping univariate_relation_parameters_no_skpping;
             Fun::UnivariateRelationParameters univariate_relation_parameters;
             auto result_no_skipping = Fun::compute_combiner_no_optimistic_skipping(
-                instances, gate_separators, univariate_relation_parameters_no_skpping, alphas);
+                keys, gate_separators, univariate_relation_parameters_no_skpping, alphas);
             auto result_with_skipping =
-                Fun::compute_combiner(instances, gate_separators, univariate_relation_parameters, alphas);
+                Fun::compute_combiner(keys, gate_separators, univariate_relation_parameters, alphas);
             auto expected_result =
                 Univariate<FF, 12>(std::array<FF, 12>{ 0, 0, 12, 36, 72, 120, 180, 252, 336, 432, 540, 660 });
 
@@ -154,9 +154,9 @@ TEST(Protogalaxy, CombinerOn2Instances)
 // Check that the optimized combiner computation yields a result consistent with the unoptimized version
 TEST(Protogalaxy, CombinerOptimizationConsistency)
 {
-    constexpr size_t NUM_INSTANCES = 2;
+    constexpr size_t NUM_KEYS = 2;
     using DeciderProvingKey = DeciderProvingKey_<Flavor>;
-    using DeciderProvingKeys = DeciderProvingKeys_<Flavor, NUM_INSTANCES>;
+    using DeciderProvingKeys = DeciderProvingKeys_<Flavor, NUM_KEYS>;
     using Fun = ProtogalaxyProverInternal<DeciderProvingKeys>;
     using UltraArithmeticRelation = UltraArithmeticRelation<FF>;
 
@@ -176,77 +176,75 @@ TEST(Protogalaxy, CombinerOptimizationConsistency)
         // Combiner test on prover polynomisls containing random values, restricted to only the standard arithmetic
         // relation.
         if (is_random_input) {
-            std::vector<std::shared_ptr<DeciderProvingKey>> instance_data(NUM_INSTANCES);
-            ASSERT(NUM_INSTANCES == 2); // Don't want to handle more here
+            std::vector<std::shared_ptr<DeciderProvingKey>> keys_data(NUM_KEYS);
+            ASSERT(NUM_KEYS == 2); // Don't want to handle more here
 
-            for (size_t idx = 0; idx < NUM_INSTANCES; idx++) {
-                auto instance = std::make_shared<DeciderProvingKey>();
+            for (size_t idx = 0; idx < NUM_KEYS; idx++) {
+                auto key = std::make_shared<DeciderProvingKey>();
                 auto prover_polynomials = get_sequential_prover_polynomials<Flavor>(
                     /*log_circuit_size=*/1, idx * 128);
                 restrict_to_standard_arithmetic_relation(prover_polynomials);
-                instance->proving_key.polynomials = std::move(prover_polynomials);
-                instance->proving_key.circuit_size = 2;
-                instance->proving_key.log_circuit_size = 1;
-                instance_data[idx] = instance;
+                key->proving_key.polynomials = std::move(prover_polynomials);
+                key->proving_key.circuit_size = 2;
+                key->proving_key.log_circuit_size = 1;
+                keys_data[idx] = key;
             }
 
-            DeciderProvingKeys instances{ instance_data };
+            DeciderProvingKeys keys{ keys_data };
             Fun::UnivariateRelationSeparator alphas;
             alphas.fill(bb::Univariate<FF, UNIVARIATE_LENGTH>(FF(0))); // focus on the arithmetic relation only
             GateSeparatorPolynomial<FF> gate_separators({ 2 }, /*log_num_monomials=*/1);
 
             // Relation parameters are all zeroes
             RelationParameters<FF> relation_parameters;
-            // Temporary accumulator to compute the sumcheck on the second instance
+            // Temporary accumulator to compute the sumcheck on the second key
             typename Flavor::TupleOfArraysOfValues temporary_accumulator;
 
-            // Accumulate arithmetic relation over 2 rows on the second instance
+            // Accumulate arithmetic relation over 2 rows on the second key
             for (size_t i = 0; i < 2; i++) {
-                UltraArithmeticRelation::accumulate(
-                    std::get<0>(temporary_accumulator),
-                    instance_data[NUM_INSTANCES - 1]->proving_key.polynomials.get_row(i),
-                    relation_parameters,
-                    gate_separators[i]);
+                UltraArithmeticRelation::accumulate(std::get<0>(temporary_accumulator),
+                                                    keys_data[NUM_KEYS - 1]->proving_key.polynomials.get_row(i),
+                                                    relation_parameters,
+                                                    gate_separators[i]);
             }
             // Get the result of the 0th subrelation of the arithmetic relation
-            FF instance_offset = std::get<0>(temporary_accumulator)[0];
+            FF key_offset = std::get<0>(temporary_accumulator)[0];
             // Subtract it from q_c[0] (it directly affect the target sum, making it zero and enabling the optimisation)
-            instance_data[1]->proving_key.polynomials.q_c[0] -= instance_offset;
+            keys_data[1]->proving_key.polynomials.q_c[0] -= key_offset;
             std::vector<typename Flavor::ProverPolynomials>
                 extended_polynomials; // These hold the extensions of prover polynomials
 
             // Manually extend all polynomials. Create new ProverPolynomials from extended values
-            for (size_t idx = NUM_INSTANCES; idx < UNIVARIATE_LENGTH; idx++) {
+            for (size_t idx = NUM_KEYS; idx < UNIVARIATE_LENGTH; idx++) {
 
-                auto instance = std::make_shared<DeciderProvingKey>();
+                auto key = std::make_shared<DeciderProvingKey>();
                 auto prover_polynomials = get_zero_prover_polynomials<Flavor>(1);
-                for (auto [instance_0_polynomial, instance_1_polynomial, new_polynomial] :
-                     zip_view(instance_data[0]->proving_key.polynomials.get_all(),
-                              instance_data[1]->proving_key.polynomials.get_all(),
+                for (auto [key_0_polynomial, key_1_polynomial, new_polynomial] :
+                     zip_view(keys_data[0]->proving_key.polynomials.get_all(),
+                              keys_data[1]->proving_key.polynomials.get_all(),
                               prover_polynomials.get_all())) {
                     for (size_t i = 0; i < /*circuit_size*/ 2; i++) {
-                        new_polynomial[i] =
-                            instance_0_polynomial[i] + ((instance_1_polynomial[i] - instance_0_polynomial[i]) * idx);
+                        new_polynomial[i] = key_0_polynomial[i] + ((key_1_polynomial[i] - key_0_polynomial[i]) * idx);
                     }
                 }
                 extended_polynomials.push_back(std::move(prover_polynomials));
             }
             std::array<FF, UNIVARIATE_LENGTH> precomputed_result{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-            // Compute the sum for each index separately, treating each extended instance independently
+            // Compute the sum for each index separately, treating each extended key independently
             for (size_t idx = 0; idx < UNIVARIATE_LENGTH; idx++) {
 
                 typename Flavor::TupleOfArraysOfValues accumulator;
-                if (idx < NUM_INSTANCES) {
+                if (idx < NUM_KEYS) {
                     for (size_t i = 0; i < 2; i++) {
                         UltraArithmeticRelation::accumulate(std::get<0>(accumulator),
-                                                            instance_data[idx]->proving_key.polynomials.get_row(i),
+                                                            keys_data[idx]->proving_key.polynomials.get_row(i),
                                                             relation_parameters,
                                                             gate_separators[i]);
                     }
                 } else {
                     for (size_t i = 0; i < 2; i++) {
                         UltraArithmeticRelation::accumulate(std::get<0>(accumulator),
-                                                            extended_polynomials[idx - NUM_INSTANCES].get_row(i),
+                                                            extended_polynomials[idx - NUM_KEYS].get_row(i),
                                                             relation_parameters,
                                                             gate_separators[i]);
                     }
@@ -257,27 +255,27 @@ TEST(Protogalaxy, CombinerOptimizationConsistency)
             Fun::UnivariateRelationParametersNoOptimisticSkipping univariate_relation_parameters_no_skpping;
             Fun::UnivariateRelationParameters univariate_relation_parameters;
             auto result_no_skipping = Fun::compute_combiner_no_optimistic_skipping(
-                instances, gate_separators, univariate_relation_parameters_no_skpping, alphas);
+                keys, gate_separators, univariate_relation_parameters_no_skpping, alphas);
             auto result_with_skipping =
-                Fun::compute_combiner(instances, gate_separators, univariate_relation_parameters, alphas);
+                Fun::compute_combiner(keys, gate_separators, univariate_relation_parameters, alphas);
 
             EXPECT_EQ(result_no_skipping, expected_result);
             EXPECT_EQ(result_with_skipping, expected_result);
         } else {
-            std::vector<std::shared_ptr<DeciderProvingKey>> instance_data(NUM_INSTANCES);
+            std::vector<std::shared_ptr<DeciderProvingKey>> keys_data(NUM_KEYS);
 
-            for (size_t idx = 0; idx < NUM_INSTANCES; idx++) {
-                auto instance = std::make_shared<DeciderProvingKey>();
+            for (size_t idx = 0; idx < NUM_KEYS; idx++) {
+                auto key = std::make_shared<DeciderProvingKey>();
                 auto prover_polynomials = get_zero_prover_polynomials<Flavor>(
                     /*log_circuit_size=*/1);
                 restrict_to_standard_arithmetic_relation(prover_polynomials);
-                instance->proving_key.polynomials = std::move(prover_polynomials);
-                instance->proving_key.circuit_size = 2;
-                instance->proving_key.log_circuit_size = 1;
-                instance_data[idx] = instance;
+                key->proving_key.polynomials = std::move(prover_polynomials);
+                key->proving_key.circuit_size = 2;
+                key->proving_key.log_circuit_size = 1;
+                keys_data[idx] = key;
             }
 
-            DeciderProvingKeys instances{ instance_data };
+            DeciderProvingKeys keys{ keys_data };
             Fun::UnivariateRelationSeparator alphas;
             alphas.fill(bb::Univariate<FF, 12>(FF(0))); // focus on the arithmetic relation only
 
@@ -298,15 +296,15 @@ TEST(Protogalaxy, CombinerOptimizationConsistency)
                 polys.q_o[idx] = -1;
             };
 
-            create_add_gate(instances[0]->proving_key.polynomials, 0, 1, 2);
-            create_add_gate(instances[0]->proving_key.polynomials, 1, 0, 4);
-            create_add_gate(instances[1]->proving_key.polynomials, 0, 3, 4);
-            create_mul_gate(instances[1]->proving_key.polynomials, 1, 1, 4);
+            create_add_gate(keys[0]->proving_key.polynomials, 0, 1, 2);
+            create_add_gate(keys[0]->proving_key.polynomials, 1, 0, 4);
+            create_add_gate(keys[1]->proving_key.polynomials, 0, 3, 4);
+            create_mul_gate(keys[1]->proving_key.polynomials, 1, 1, 4);
 
-            restrict_to_standard_arithmetic_relation(instances[0]->proving_key.polynomials);
-            restrict_to_standard_arithmetic_relation(instances[1]->proving_key.polynomials);
+            restrict_to_standard_arithmetic_relation(keys[0]->proving_key.polynomials);
+            restrict_to_standard_arithmetic_relation(keys[1]->proving_key.polynomials);
 
-            /* Instance 0                                    Instance 1
+            /* DeciderProvingKey 0                            DeciderProvingKey 1
                 w_l w_r w_o q_m q_l q_r q_o q_c               w_l w_r w_o q_m q_l q_r q_o q_c
                 1   2   3   0   1   1   -1  0                 3   4   7   0   1   1   -1  0
                 0   4   4   0   1   1   -1  0                 1   4   4   1   0   0   -1  0             */
@@ -329,9 +327,9 @@ TEST(Protogalaxy, CombinerOptimizationConsistency)
             Fun::UnivariateRelationParametersNoOptimisticSkipping univariate_relation_parameters_no_skpping;
             Fun::UnivariateRelationParameters univariate_relation_parameters;
             auto result_no_skipping = Fun::compute_combiner_no_optimistic_skipping(
-                instances, gate_separators, univariate_relation_parameters_no_skpping, alphas);
+                keys, gate_separators, univariate_relation_parameters_no_skpping, alphas);
             auto result_with_skipping =
-                Fun::compute_combiner(instances, gate_separators, univariate_relation_parameters, alphas);
+                Fun::compute_combiner(keys, gate_separators, univariate_relation_parameters, alphas);
             auto expected_result =
                 Univariate<FF, 12>(std::array<FF, 12>{ 0, 0, 12, 36, 72, 120, 180, 252, 336, 432, 540, 660 });
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/combiner.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/combiner.test.cpp
@@ -16,9 +16,9 @@ using FF = typename Flavor::FF;
 TEST(Protogalaxy, CombinerOn2Instances)
 {
     constexpr size_t NUM_INSTANCES = 2;
-    using ProverInstance = ProverInstance_<Flavor>;
-    using ProverInstances = ProverInstances_<Flavor, NUM_INSTANCES>;
-    using Fun = ProtogalaxyProverInternal<ProverInstances>;
+    using DeciderProvingKey = DeciderProvingKey_<Flavor>;
+    using DeciderProvingKeys = DeciderProvingKeys_<Flavor, NUM_INSTANCES>;
+    using Fun = ProtogalaxyProverInternal<DeciderProvingKeys>;
 
     const auto restrict_to_standard_arithmetic_relation = [](auto& polys) {
         std::fill(polys.q_arith.begin(), polys.q_arith.end(), 1);
@@ -37,10 +37,10 @@ TEST(Protogalaxy, CombinerOn2Instances)
         // Combiner test on prover polynomisls containing random values, restricted to only the standard arithmetic
         // relation.
         if (is_random_input) {
-            std::vector<std::shared_ptr<ProverInstance>> instance_data(NUM_INSTANCES);
+            std::vector<std::shared_ptr<DeciderProvingKey>> instance_data(NUM_INSTANCES);
 
             for (size_t idx = 0; idx < NUM_INSTANCES; idx++) {
-                auto instance = std::make_shared<ProverInstance>();
+                auto instance = std::make_shared<DeciderProvingKey>();
                 auto prover_polynomials = get_sequential_prover_polynomials<Flavor>(
                     /*log_circuit_size=*/1, idx * 128);
                 restrict_to_standard_arithmetic_relation(prover_polynomials);
@@ -50,7 +50,7 @@ TEST(Protogalaxy, CombinerOn2Instances)
                 instance_data[idx] = instance;
             }
 
-            ProverInstances instances{ instance_data };
+            DeciderProvingKeys instances{ instance_data };
             Fun::UnivariateRelationSeparator alphas;
             alphas.fill(bb::Univariate<FF, 12>(FF(0))); // focus on the arithmetic relation only
             GateSeparatorPolynomial<FF> gate_separators({ 2 }, /*log_num_monomials=*/1);
@@ -72,10 +72,10 @@ TEST(Protogalaxy, CombinerOn2Instances)
                                                                           9072095848UL });
             EXPECT_EQ(result_no_skipping, expected_result);
         } else {
-            std::vector<std::shared_ptr<ProverInstance>> instance_data(NUM_INSTANCES);
+            std::vector<std::shared_ptr<DeciderProvingKey>> instance_data(NUM_INSTANCES);
 
             for (size_t idx = 0; idx < NUM_INSTANCES; idx++) {
-                auto instance = std::make_shared<ProverInstance>();
+                auto instance = std::make_shared<DeciderProvingKey>();
                 auto prover_polynomials = get_zero_prover_polynomials<Flavor>(
                     /*log_circuit_size=*/1);
                 restrict_to_standard_arithmetic_relation(prover_polynomials);
@@ -85,7 +85,7 @@ TEST(Protogalaxy, CombinerOn2Instances)
                 instance_data[idx] = instance;
             }
 
-            ProverInstances instances{ instance_data };
+            DeciderProvingKeys instances{ instance_data };
             Fun::UnivariateRelationSeparator alphas;
             alphas.fill(bb::Univariate<FF, 12>(FF(0))); // focus on the arithmetic relation only
 
@@ -155,9 +155,9 @@ TEST(Protogalaxy, CombinerOn2Instances)
 TEST(Protogalaxy, CombinerOptimizationConsistency)
 {
     constexpr size_t NUM_INSTANCES = 2;
-    using ProverInstance = ProverInstance_<Flavor>;
-    using ProverInstances = ProverInstances_<Flavor, NUM_INSTANCES>;
-    using Fun = ProtogalaxyProverInternal<ProverInstances>;
+    using DeciderProvingKey = DeciderProvingKey_<Flavor>;
+    using DeciderProvingKeys = DeciderProvingKeys_<Flavor, NUM_INSTANCES>;
+    using Fun = ProtogalaxyProverInternal<DeciderProvingKeys>;
     using UltraArithmeticRelation = UltraArithmeticRelation<FF>;
 
     constexpr size_t UNIVARIATE_LENGTH = 12;
@@ -176,11 +176,11 @@ TEST(Protogalaxy, CombinerOptimizationConsistency)
         // Combiner test on prover polynomisls containing random values, restricted to only the standard arithmetic
         // relation.
         if (is_random_input) {
-            std::vector<std::shared_ptr<ProverInstance>> instance_data(NUM_INSTANCES);
+            std::vector<std::shared_ptr<DeciderProvingKey>> instance_data(NUM_INSTANCES);
             ASSERT(NUM_INSTANCES == 2); // Don't want to handle more here
 
             for (size_t idx = 0; idx < NUM_INSTANCES; idx++) {
-                auto instance = std::make_shared<ProverInstance>();
+                auto instance = std::make_shared<DeciderProvingKey>();
                 auto prover_polynomials = get_sequential_prover_polynomials<Flavor>(
                     /*log_circuit_size=*/1, idx * 128);
                 restrict_to_standard_arithmetic_relation(prover_polynomials);
@@ -190,7 +190,7 @@ TEST(Protogalaxy, CombinerOptimizationConsistency)
                 instance_data[idx] = instance;
             }
 
-            ProverInstances instances{ instance_data };
+            DeciderProvingKeys instances{ instance_data };
             Fun::UnivariateRelationSeparator alphas;
             alphas.fill(bb::Univariate<FF, UNIVARIATE_LENGTH>(FF(0))); // focus on the arithmetic relation only
             GateSeparatorPolynomial<FF> gate_separators({ 2 }, /*log_num_monomials=*/1);
@@ -218,7 +218,7 @@ TEST(Protogalaxy, CombinerOptimizationConsistency)
             // Manually extend all polynomials. Create new ProverPolynomials from extended values
             for (size_t idx = NUM_INSTANCES; idx < UNIVARIATE_LENGTH; idx++) {
 
-                auto instance = std::make_shared<ProverInstance>();
+                auto instance = std::make_shared<DeciderProvingKey>();
                 auto prover_polynomials = get_zero_prover_polynomials<Flavor>(1);
                 for (auto [instance_0_polynomial, instance_1_polynomial, new_polynomial] :
                      zip_view(instance_data[0]->proving_key.polynomials.get_all(),
@@ -264,10 +264,10 @@ TEST(Protogalaxy, CombinerOptimizationConsistency)
             EXPECT_EQ(result_no_skipping, expected_result);
             EXPECT_EQ(result_with_skipping, expected_result);
         } else {
-            std::vector<std::shared_ptr<ProverInstance>> instance_data(NUM_INSTANCES);
+            std::vector<std::shared_ptr<DeciderProvingKey>> instance_data(NUM_INSTANCES);
 
             for (size_t idx = 0; idx < NUM_INSTANCES; idx++) {
-                auto instance = std::make_shared<ProverInstance>();
+                auto instance = std::make_shared<DeciderProvingKey>();
                 auto prover_polynomials = get_zero_prover_polynomials<Flavor>(
                     /*log_circuit_size=*/1);
                 restrict_to_standard_arithmetic_relation(prover_polynomials);
@@ -277,7 +277,7 @@ TEST(Protogalaxy, CombinerOptimizationConsistency)
                 instance_data[idx] = instance;
             }
 
-            ProverInstances instances{ instance_data };
+            DeciderProvingKeys instances{ instance_data };
             Fun::UnivariateRelationSeparator alphas;
             alphas.fill(bb::Univariate<FF, 12>(FF(0))); // focus on the arithmetic relation only
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/folding_result.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/folding_result.hpp
@@ -4,10 +4,8 @@
 #include "barretenberg/sumcheck/instance/prover_instance.hpp"
 namespace bb {
 /**
- * @brief The result of running the Protogalaxy prover containing a new accumulator (relaxed instance) as well as the
- * proof data to instantiate the verifier transcript.
- *
- * @tparam Flavor
+ * @brief The result of running the Protogalaxy prover containing a new accumulator as well as the proof data to
+ * instantiate the verifier transcript.
  */
 template <class Flavor> struct FoldingResult {
   public:

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/folding_result.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/folding_result.hpp
@@ -11,7 +11,7 @@ namespace bb {
  */
 template <class Flavor> struct FoldingResult {
   public:
-    std::shared_ptr<ProverInstance_<Flavor>> accumulator;
+    std::shared_ptr<DeciderProvingKey_<Flavor>> accumulator;
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/656): turn folding data into a struct
     std::vector<typename Flavor::FF> proof;
 };

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy.test.cpp
@@ -40,8 +40,8 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
     using FoldingVerifier = ProtogalaxyVerifier_<DeciderVerificationKeys>;
     using Fun = ProtogalaxyProverInternal<DeciderProvingKeys>;
 
-    using TupleOfInstances = std::tuple<std::vector<std::shared_ptr<DeciderProvingKey>>,
-                                        std::vector<std::shared_ptr<DeciderVerificationKey>>>;
+    using TupleOfKeys = std::tuple<std::vector<std::shared_ptr<DeciderProvingKey>>,
+                                   std::vector<std::shared_ptr<DeciderVerificationKey>>>;
 
     static void SetUpTestSuite() { bb::srs::init_crs_factory("../srs_db/ignition"); }
 
@@ -53,39 +53,37 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
         }
     }
 
-    // Construct prover and verifier instance for a provided circuit and add to tuple
-    static void construct_prover_and_verifier_instance(TupleOfInstances& instances,
-                                                       Builder& builder,
-                                                       TraceStructure structure = TraceStructure::NONE)
+    // Construct decider keys for a provided circuit and add to tuple
+    static void construct_keys(TupleOfKeys& keys, Builder& builder, TraceStructure structure = TraceStructure::NONE)
     {
 
-        auto prover_instance = std::make_shared<DeciderProvingKey>(builder, structure);
-        auto verification_key = std::make_shared<VerificationKey>(prover_instance->proving_key);
-        auto verifier_instance = std::make_shared<DeciderVerificationKey>(verification_key);
-        get<0>(instances).emplace_back(prover_instance);
-        get<1>(instances).emplace_back(verifier_instance);
+        auto decider_proving_key = std::make_shared<DeciderProvingKey>(builder, structure);
+        auto verification_key = std::make_shared<VerificationKey>(decider_proving_key->proving_key);
+        auto decider_verification_keys = std::make_shared<DeciderVerificationKey>(verification_key);
+        get<0>(keys).emplace_back(decider_proving_key);
+        get<1>(keys).emplace_back(decider_verification_keys);
     }
 
-    // constructs num_insts number of prover and verifier instances
-    static TupleOfInstances construct_instances(size_t num_insts, TraceStructure structure = TraceStructure::NONE)
+    // Construct a given numer of decider key pairs
+    static TupleOfKeys construct_keys(size_t num_keys, TraceStructure structure = TraceStructure::NONE)
     {
-        TupleOfInstances instances;
+        TupleOfKeys keys;
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/938): Parallelize this loop
-        for (size_t idx = 0; idx < num_insts; idx++) {
+        for (size_t idx = 0; idx < num_keys; idx++) {
             auto builder = typename Flavor::CircuitBuilder();
             construct_circuit(builder);
 
-            construct_prover_and_verifier_instance(instances, builder, structure);
+            construct_keys(keys, builder, structure);
         }
-        return instances;
+        return keys;
     }
 
     static std::tuple<std::shared_ptr<DeciderProvingKey>, std::shared_ptr<DeciderVerificationKey>> fold_and_verify(
-        const std::vector<std::shared_ptr<DeciderProvingKey>>& prover_instances,
-        const std::vector<std::shared_ptr<DeciderVerificationKey>>& verifier_instances)
+        const std::vector<std::shared_ptr<DeciderProvingKey>>& proving_keys,
+        const std::vector<std::shared_ptr<DeciderVerificationKey>>& verification_keys)
     {
-        FoldingProver folding_prover(prover_instances);
-        FoldingVerifier folding_verifier(verifier_instances);
+        FoldingProver folding_prover(proving_keys);
+        FoldingVerifier folding_verifier(verification_keys);
 
         auto [prover_accumulator, folding_proof] = folding_prover.prove();
         auto verifier_accumulator = folding_verifier.verify_folding_proof(folding_proof);
@@ -95,7 +93,7 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
     static void check_accumulator_target_sum_manual(std::shared_ptr<DeciderProvingKey>& accumulator,
                                                     bool expected_result)
     {
-        auto instance_size = accumulator->proving_key.circuit_size;
+        size_t accumulator_size = accumulator->proving_key.circuit_size;
         auto expected_honk_evals = Fun::compute_row_evaluations(
             accumulator->proving_key.polynomials, accumulator->alphas, accumulator->relation_parameters);
         // Construct pow(\vec{betas*}) as in the paper
@@ -103,9 +101,9 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
                                                          accumulator->gate_challenges.size());
 
         // Compute the corresponding target sum and create a dummy accumulator
-        auto expected_target_sum = FF(0);
-        for (size_t i = 0; i < instance_size; i++) {
-            expected_target_sum += expected_honk_evals[i] * expected_gate_separators[i];
+        FF expected_target_sum{ 0 };
+        for (size_t idx = 0; idx < accumulator_size; idx++) {
+            expected_target_sum += expected_honk_evals[idx] * expected_gate_separators[idx];
         }
         EXPECT_EQ(accumulator->target_sum == expected_target_sum, expected_result);
     }
@@ -132,25 +130,25 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
         auto builder = typename Flavor::CircuitBuilder();
         construct_circuit(builder);
 
-        auto instance = std::make_shared<DeciderProvingKey>(builder);
+        auto decider_pk = std::make_shared<DeciderProvingKey>(builder);
 
-        instance->relation_parameters.eta = FF::random_element();
-        instance->relation_parameters.eta_two = FF::random_element();
-        instance->relation_parameters.eta_three = FF::random_element();
-        instance->relation_parameters.beta = FF::random_element();
-        instance->relation_parameters.gamma = FF::random_element();
+        decider_pk->relation_parameters.eta = FF::random_element();
+        decider_pk->relation_parameters.eta_two = FF::random_element();
+        decider_pk->relation_parameters.eta_three = FF::random_element();
+        decider_pk->relation_parameters.beta = FF::random_element();
+        decider_pk->relation_parameters.gamma = FF::random_element();
 
-        instance->proving_key.add_ram_rom_memory_records_to_wire_4(instance->relation_parameters.eta,
-                                                                   instance->relation_parameters.eta_two,
-                                                                   instance->relation_parameters.eta_three);
-        instance->proving_key.compute_logderivative_inverses(instance->relation_parameters);
-        instance->proving_key.compute_grand_product_polynomials(instance->relation_parameters);
+        decider_pk->proving_key.add_ram_rom_memory_records_to_wire_4(decider_pk->relation_parameters.eta,
+                                                                     decider_pk->relation_parameters.eta_two,
+                                                                     decider_pk->relation_parameters.eta_three);
+        decider_pk->proving_key.compute_logderivative_inverses(decider_pk->relation_parameters);
+        decider_pk->proving_key.compute_grand_product_polynomials(decider_pk->relation_parameters);
 
-        for (auto& alpha : instance->alphas) {
+        for (auto& alpha : decider_pk->alphas) {
             alpha = FF::random_element();
         }
         auto full_honk_evals = Fun::compute_row_evaluations(
-            instance->proving_key.polynomials, instance->alphas, instance->relation_parameters);
+            decider_pk->proving_key.polynomials, decider_pk->alphas, decider_pk->relation_parameters);
 
         // Evaluations should be 0 for valid circuit
         for (const auto& eval : full_honk_evals) {
@@ -170,7 +168,7 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
         std::vector<FF> full_honk_evaluations = { FF(1), FF(1), FF(1), FF(1), FF(1), FF(1), FF(1), FF(1) };
         auto perturbator = Fun::construct_perturbator_coefficients(betas, deltas, full_honk_evaluations);
         std::vector<FF> expected_values = { FF(648), FF(936), FF(432), FF(64) };
-        EXPECT_EQ(perturbator.size(), 4); // log(instance_size) + 1
+        EXPECT_EQ(perturbator.size(), 4); // log(size) + 1
         for (size_t i = 0; i < perturbator.size(); i++) {
             EXPECT_EQ(perturbator[i], expected_values[i]);
         }
@@ -184,12 +182,12 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
     static void test_pertubator_polynomial()
     {
         using RelationSeparator = typename Flavor::RelationSeparator;
-        const size_t log_instance_size(3);
-        const size_t instance_size(1 << log_instance_size);
+        const size_t log_size(3);
+        const size_t size(1 << log_size);
         // Construct fully random prover polynomials
         ProverPolynomials full_polynomials;
         for (auto& poly : full_polynomials.get_all()) {
-            poly = bb::Polynomial<FF>::random(instance_size);
+            poly = bb::Polynomial<FF>::random(size);
         }
 
         auto relation_parameters = bb::RelationParameters<FF>::get_random();
@@ -199,17 +197,17 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
         }
 
         auto full_honk_evals = Fun::compute_row_evaluations(full_polynomials, alphas, relation_parameters);
-        std::vector<FF> betas(log_instance_size);
-        for (size_t idx = 0; idx < log_instance_size; idx++) {
+        std::vector<FF> betas(log_size);
+        for (size_t idx = 0; idx < log_size; idx++) {
             betas[idx] = FF::random_element();
         }
 
         // Construct pow(\vec{betas}) as in the paper
-        bb::GateSeparatorPolynomial gate_separators(betas, log_instance_size);
+        bb::GateSeparatorPolynomial gate_separators(betas, log_size);
 
         // Compute the corresponding target sum and create a dummy accumulator
         auto target_sum = FF(0);
-        for (size_t i = 0; i < instance_size; i++) {
+        for (size_t i = 0; i < size; i++) {
             target_sum += full_honk_evals[i] * gate_separators[i];
         }
 
@@ -220,7 +218,7 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
         accumulator->relation_parameters = relation_parameters;
         accumulator->alphas = alphas;
 
-        auto deltas = compute_round_challenge_pows(log_instance_size, FF::random_element());
+        auto deltas = compute_round_challenge_pows(log_size, FF::random_element());
         auto perturbator = Fun::compute_perturbator(accumulator, deltas);
 
         // Ensure the constant coefficient of the perturbator is equal to the target sum as indicated by the paper
@@ -259,27 +257,27 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
     }
 
     /**
-     * @brief For two dummy instances with their relation parameter η set, check that combining them in a
+     * @brief For two dummy decider proving keys with their relation parameter η set, check that combining them in a
      * univariate, barycentrially extended to the desired number of evaluations, is performed correctly.
      *
      */
     static void test_compute_extended_relation_parameters()
     {
         Builder builder1;
-        auto instance1 = std::make_shared<DeciderProvingKey>(builder1);
-        instance1->relation_parameters.eta = 1;
+        auto pk_1 = std::make_shared<DeciderProvingKey>(builder1);
+        pk_1->relation_parameters.eta = 1;
 
         Builder builder2;
         builder2.add_variable(3);
-        auto instance2 = std::make_shared<DeciderProvingKey>(builder2);
-        instance2->relation_parameters.eta = 3;
+        auto pk_2 = std::make_shared<DeciderProvingKey>(builder2);
+        pk_2->relation_parameters.eta = 3;
 
-        DeciderProvingKeys instances{ { instance1, instance2 } };
+        DeciderProvingKeys pks{ { pk_1, pk_2 } };
         auto relation_parameters_no_optimistic_skipping = Fun::template compute_extended_relation_parameters<
-            typename Fun::UnivariateRelationParametersNoOptimisticSkipping>(instances);
+            typename Fun::UnivariateRelationParametersNoOptimisticSkipping>(pks);
         auto relation_parameters =
             Fun::template compute_extended_relation_parameters<typename FoldingProver::UnivariateRelationParameters>(
-                instances);
+                pks);
 
         bb::Univariate<FF, 11> expected_eta{ { 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21 } };
         EXPECT_EQ(relation_parameters_no_optimistic_skipping.eta, expected_eta);
@@ -291,22 +289,22 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
     }
 
     /**
-     * @brief Given two dummy instances with the batching challenges alphas set (one for each subrelation) ensure
-     * combining them in a univariate of desired length works as expected.
+     * @brief Given two dummy decider proving_keys with the batching challenges alphas set (one for each subrelation)
+     * ensure combining them in a univariate of desired length works as expected.
      */
     static void test_compute_and_extend_alphas()
     {
         Builder builder1;
-        auto instance1 = std::make_shared<DeciderProvingKey>(builder1);
-        instance1->alphas.fill(2);
+        auto pk_1 = std::make_shared<DeciderProvingKey>(builder1);
+        pk_1->alphas.fill(2);
 
         Builder builder2;
         builder2.add_variable(3);
-        auto instance2 = std::make_shared<DeciderProvingKey>(builder2);
-        instance2->alphas.fill(4);
+        auto pk_2 = std::make_shared<DeciderProvingKey>(builder2);
+        pk_2->alphas.fill(4);
 
-        DeciderProvingKeys instances{ { instance1, instance2 } };
-        auto alphas = Fun::compute_and_extend_alphas(instances);
+        DeciderProvingKeys pks{ { pk_1, pk_2 } };
+        auto alphas = Fun::compute_and_extend_alphas(pks);
 
         bb::Univariate<FF, 12> expected_alphas{ { 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24 } };
         for (const auto& alpha : alphas) {
@@ -322,13 +320,13 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
     static void test_protogalaxy_inhomogeneous()
     {
         auto check_fold_and_decide = [](Builder& circuit_1, Builder& circuit_2) {
-            // Construct the prover/verifier instances for each
-            TupleOfInstances instances;
-            construct_prover_and_verifier_instance(instances, circuit_1);
-            construct_prover_and_verifier_instance(instances, circuit_2);
+            // Construct decider key pairs for each
+            TupleOfKeys keys;
+            construct_keys(keys, circuit_1);
+            construct_keys(keys, circuit_2);
 
             // Perform prover and verifier folding
-            auto [prover_accumulator, verifier_accumulator] = fold_and_verify(get<0>(instances), get<1>(instances));
+            auto [prover_accumulator, verifier_accumulator] = fold_and_verify(get<0>(keys), get<1>(keys));
             check_accumulator_target_sum_manual(prover_accumulator, true);
 
             // Run decider
@@ -403,13 +401,13 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
             }
         }
 
-        // Construct the prover/verifier instances for each
-        TupleOfInstances instances;
-        construct_prover_and_verifier_instance(instances, builder1);
-        construct_prover_and_verifier_instance(instances, builder2);
+        // Construct the key pairs for each
+        TupleOfKeys keys;
+        construct_keys(keys, builder1);
+        construct_keys(keys, builder2);
 
         // Perform prover and verifier folding
-        auto [prover_accumulator, verifier_accumulator] = fold_and_verify(get<0>(instances), get<1>(instances));
+        auto [prover_accumulator, verifier_accumulator] = fold_and_verify(get<0>(keys), get<1>(keys));
 
         // Expect failure in manual target sum check and decider
         bool expected_result = false;
@@ -423,11 +421,11 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
      */
     static void test_full_protogalaxy()
     {
-        TupleOfInstances insts = construct_instances(2);
+        TupleOfKeys insts = construct_keys(2);
         auto [prover_accumulator, verifier_accumulator] = fold_and_verify(get<0>(insts), get<1>(insts));
         check_accumulator_target_sum_manual(prover_accumulator, true);
 
-        TupleOfInstances insts_2 = construct_instances(1); // just one set of prover/verifier instances
+        TupleOfKeys insts_2 = construct_keys(1); // just one key pair
         auto [prover_accumulator_2, verifier_accumulator_2] =
             fold_and_verify({ prover_accumulator, get<0>(insts_2)[0] }, { verifier_accumulator, get<1>(insts_2)[0] });
         check_accumulator_target_sum_manual(prover_accumulator_2, true);
@@ -442,16 +440,15 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
     static void test_full_protogalaxy_structured_trace()
     {
         TraceStructure trace_structure = TraceStructure::SMALL_TEST;
-        TupleOfInstances instances = construct_instances(2, trace_structure);
+        TupleOfKeys keys_1 = construct_keys(2, trace_structure);
 
-        auto [prover_accumulator, verifier_accumulator] = fold_and_verify(get<0>(instances), get<1>(instances));
+        auto [prover_accumulator, verifier_accumulator] = fold_and_verify(get<0>(keys_1), get<1>(keys_1));
         check_accumulator_target_sum_manual(prover_accumulator, true);
 
-        TupleOfInstances instances_2 =
-            construct_instances(1, trace_structure); // just one set of prover/verifier instances
+        TupleOfKeys keys_2 = construct_keys(1, trace_structure); // just one key pair
 
-        auto [prover_accumulator_2, verifier_accumulator_2] = fold_and_verify(
-            { prover_accumulator, get<0>(instances_2)[0] }, { verifier_accumulator, get<1>(instances_2)[0] });
+        auto [prover_accumulator_2, verifier_accumulator_2] =
+            fold_and_verify({ prover_accumulator, get<0>(keys_2)[0] }, { verifier_accumulator, get<1>(keys_2)[0] });
         check_accumulator_target_sum_manual(prover_accumulator_2, true);
         info(prover_accumulator_2->proving_key.circuit_size);
         decide_and_verify(prover_accumulator_2, verifier_accumulator_2, true);
@@ -480,22 +477,22 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
         MockCircuits::add_arithmetic_gates(builder2, 100);
         MockCircuits::add_arithmetic_gates(builder3, 1000);
 
-        // Construct the Prover/Verifier instances for the first two circuits
-        TupleOfInstances instances;
-        construct_prover_and_verifier_instance(instances, builder1, trace_structure);
-        construct_prover_and_verifier_instance(instances, builder2, trace_structure);
+        // Construct the decider key pairs for the first two circuits
+        TupleOfKeys keys_1;
+        construct_keys(keys_1, builder1, trace_structure);
+        construct_keys(keys_1, builder2, trace_structure);
 
-        // Fold the first two instances
-        auto [prover_accumulator, verifier_accumulator] = fold_and_verify(get<0>(instances), get<1>(instances));
+        // Fold the first two pairs
+        auto [prover_accumulator, verifier_accumulator] = fold_and_verify(get<0>(keys_1), get<1>(keys_1));
         check_accumulator_target_sum_manual(prover_accumulator, true);
 
-        // Construct the Prover/Verifier instance for the third circuit
-        TupleOfInstances instances_2;
-        construct_prover_and_verifier_instance(instances_2, builder3, trace_structure);
+        // Construct the decider key pair for the third circuit
+        TupleOfKeys keys_2;
+        construct_keys(keys_2, builder3, trace_structure);
 
-        // Fold 3rd instance into accumulator
-        auto [prover_accumulator_2, verifier_accumulator_2] = fold_and_verify(
-            { prover_accumulator, get<0>(instances_2)[0] }, { verifier_accumulator, get<1>(instances_2)[0] });
+        // Fold 3rd pair of keys into their respective accumulators
+        auto [prover_accumulator_2, verifier_accumulator_2] =
+            fold_and_verify({ prover_accumulator, get<0>(keys_2)[0] }, { verifier_accumulator, get<1>(keys_2)[0] });
         check_accumulator_target_sum_manual(prover_accumulator_2, true);
         info(prover_accumulator_2->proving_key.circuit_size);
 
@@ -509,14 +506,14 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
      */
     static void test_tampered_commitment()
     {
-        TupleOfInstances insts = construct_instances(2);
+        TupleOfKeys insts = construct_keys(2);
         auto [prover_accumulator, verifier_accumulator] = fold_and_verify(get<0>(insts), get<1>(insts));
         check_accumulator_target_sum_manual(prover_accumulator, true);
 
         // Tamper with a commitment
         verifier_accumulator->witness_commitments.w_l = Projective(Affine::random_element());
 
-        TupleOfInstances insts_2 = construct_instances(1); // just one set of prover/verifier instances
+        TupleOfKeys insts_2 = construct_keys(1); // just one decider key pair
         auto [prover_accumulator_2, verifier_accumulator_2] =
             fold_and_verify({ prover_accumulator, get<0>(insts_2)[0] }, { verifier_accumulator, get<1>(insts_2)[0] });
         check_accumulator_target_sum_manual(prover_accumulator_2, true);
@@ -531,7 +528,7 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
      */
     static void test_tampered_accumulator_polynomial()
     {
-        TupleOfInstances insts = construct_instances(2);
+        TupleOfKeys insts = construct_keys(2);
         auto [prover_accumulator, verifier_accumulator] = fold_and_verify(get<0>(insts), get<1>(insts));
         check_accumulator_target_sum_manual(prover_accumulator, true);
 
@@ -539,7 +536,7 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
         prover_accumulator->proving_key.polynomials.w_l[1] = FF::random_element();
         check_accumulator_target_sum_manual(prover_accumulator, false);
 
-        TupleOfInstances insts_2 = construct_instances(1); // just one set of prover/verifier instances
+        TupleOfKeys insts_2 = construct_keys(1); // just one decider key pair
         auto [prover_accumulator_2, verifier_accumulator_2] =
             fold_and_verify({ prover_accumulator, get<0>(insts_2)[0] }, { verifier_accumulator, get<1>(insts_2)[0] });
 
@@ -547,10 +544,10 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
         decide_and_verify(prover_accumulator_2, verifier_accumulator_2, false);
     }
 
-    template <size_t k> static void test_fold_k_instances()
+    template <size_t k> static void test_fold_k_key_pairs()
     {
         constexpr size_t total_insts = k + 1;
-        TupleOfInstances insts = construct_instances(total_insts);
+        TupleOfKeys insts = construct_keys(total_insts);
 
         ProtogalaxyProver_<DeciderProvingKeys_<Flavor, total_insts>> folding_prover(get<0>(insts));
         ProtogalaxyVerifier_<DeciderVerificationKeys_<Flavor, total_insts>> folding_verifier(get<1>(insts));
@@ -631,8 +628,9 @@ TYPED_TEST(ProtogalaxyTests, BadLookupFailure)
     TestFixture::test_protogalaxy_bad_lookup_failure();
 }
 
-// We only fold one instance currently due to significant compile time added by multiple instances
-TYPED_TEST(ProtogalaxyTests, Fold1Instance)
+// We only fold one incoming decider key pair since this is all we plan to use, and compiling for higher values of k is
+// a significant compilation time cost.
+TYPED_TEST(ProtogalaxyTests, Fold1)
 {
-    TestFixture::template test_fold_k_instances<1>();
+    TestFixture::template test_fold_k_key_pairs<1>();
 }

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
@@ -19,15 +19,6 @@ template <class ProverInstances_> class ProtogalaxyProver_ {
     using UnivariateRelationSeparator =
         std::array<Univariate<FF, ProverInstances_::BATCHED_EXTENDED_LENGTH>, Flavor::NUM_SUBRELATIONS - 1>;
 
-    struct State {
-        std::shared_ptr<ProverInstance> accumulator;
-        Polynomial<FF> perturbator;
-        std::vector<FF> deltas;
-        CombinerQuotient combiner_quotient;
-        FF perturbator_evaluation;
-        UnivariateRelationParameters relation_parameters;
-        UnivariateRelationSeparator alphas;
-    };
     using Transcript = typename Flavor::Transcript;
     using Instance = typename ProverInstances_::Instance;
     using CommitmentKey = typename Flavor::CommitmentKey;
@@ -36,9 +27,17 @@ template <class ProverInstances_> class ProtogalaxyProver_ {
     static constexpr size_t NUM_SUBRELATIONS = ProverInstances_::NUM_SUBRELATIONS;
 
     ProverInstances_ instances;
-    std::shared_ptr<Transcript> transcript = std::make_shared<Transcript>();
     std::shared_ptr<CommitmentKey> commitment_key;
-    State state;
+
+    // the updated and state carried forward beween rounds
+    std::shared_ptr<Transcript> transcript = std::make_shared<Transcript>();
+    std::shared_ptr<ProverInstance> accumulator;
+    Polynomial<FF> perturbator;
+    std::vector<FF> deltas;
+    CombinerQuotient combiner_quotient;
+    FF perturbator_evaluation;
+    UnivariateRelationParameters relation_parameters;
+    UnivariateRelationSeparator alphas;
 
     ProtogalaxyProver_() = default;
     ProtogalaxyProver_(const std::vector<std::shared_ptr<Instance>>& insts)

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
@@ -29,7 +29,7 @@ template <class ProverInstances_> class ProtogalaxyProver_ {
     ProverInstances_ instances;
     std::shared_ptr<CommitmentKey> commitment_key;
 
-    // the updated and state carried forward beween rounds
+    // the state updated and carried forward beween rounds
     std::shared_ptr<Transcript> transcript = std::make_shared<Transcript>();
     std::shared_ptr<ProverInstance> accumulator;
     Polynomial<FF> perturbator;

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
@@ -4,34 +4,34 @@
 
 namespace bb {
 
-template <class ProverInstances_> class ProtogalaxyProver_ {
+template <class DeciderProvingKeys_> class ProtogalaxyProver_ {
   public:
-    using ProverInstance = typename ProverInstances_::Instance;
-    using Flavor = typename ProverInstances_::Flavor;
-    using FF = typename ProverInstances_::Flavor::FF;
-    static constexpr size_t NUM_INSTANCES = ProverInstances_::NUM;
-    using CombinerQuotient = Univariate<FF, ProverInstances_::BATCHED_EXTENDED_LENGTH, NUM_INSTANCES>;
+    using DeciderProvingKey = typename DeciderProvingKeys_::Instance;
+    using Flavor = typename DeciderProvingKeys_::Flavor;
+    using FF = typename DeciderProvingKeys_::Flavor::FF;
+    static constexpr size_t NUM_INSTANCES = DeciderProvingKeys_::NUM;
+    using CombinerQuotient = Univariate<FF, DeciderProvingKeys_::BATCHED_EXTENDED_LENGTH, NUM_INSTANCES>;
     using TupleOfTuplesOfUnivariatesNoOptimisticSkipping =
         typename Flavor::template ProtogalaxyTupleOfTuplesOfUnivariatesNoOptimisticSkipping<NUM_INSTANCES>;
     using TupleOfTuplesOfUnivariates = typename Flavor::template ProtogalaxyTupleOfTuplesOfUnivariates<NUM_INSTANCES>;
-    using UnivariateRelationParameters =
-        bb::RelationParameters<Univariate<FF, ProverInstances_::EXTENDED_LENGTH, 0, /*skip_count=*/NUM_INSTANCES - 1>>;
+    using UnivariateRelationParameters = bb::RelationParameters<
+        Univariate<FF, DeciderProvingKeys_::EXTENDED_LENGTH, 0, /*skip_count=*/NUM_INSTANCES - 1>>;
     using UnivariateRelationSeparator =
-        std::array<Univariate<FF, ProverInstances_::BATCHED_EXTENDED_LENGTH>, Flavor::NUM_SUBRELATIONS - 1>;
+        std::array<Univariate<FF, DeciderProvingKeys_::BATCHED_EXTENDED_LENGTH>, Flavor::NUM_SUBRELATIONS - 1>;
 
     using Transcript = typename Flavor::Transcript;
-    using Instance = typename ProverInstances_::Instance;
+    using Instance = typename DeciderProvingKeys_::Instance;
     using CommitmentKey = typename Flavor::CommitmentKey;
-    using ProverInstances = ProverInstances_;
+    using DeciderProvingKeys = DeciderProvingKeys_;
 
-    static constexpr size_t NUM_SUBRELATIONS = ProverInstances_::NUM_SUBRELATIONS;
+    static constexpr size_t NUM_SUBRELATIONS = DeciderProvingKeys_::NUM_SUBRELATIONS;
 
-    ProverInstances_ instances;
+    DeciderProvingKeys_ instances;
     std::shared_ptr<CommitmentKey> commitment_key;
 
     // the state updated and carried forward beween rounds
     std::shared_ptr<Transcript> transcript = std::make_shared<Transcript>();
-    std::shared_ptr<ProverInstance> accumulator;
+    std::shared_ptr<DeciderProvingKey> accumulator;
     Polynomial<FF> perturbator;
     std::vector<FF> deltas;
     CombinerQuotient combiner_quotient;
@@ -41,11 +41,11 @@ template <class ProverInstances_> class ProtogalaxyProver_ {
 
     ProtogalaxyProver_() = default;
     ProtogalaxyProver_(const std::vector<std::shared_ptr<Instance>>& insts)
-        : instances(ProverInstances_(insts))
+        : instances(DeciderProvingKeys_(insts))
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/878)
         , commitment_key(instances[1]->proving_key.commitment_key){};
 
-    // Returns the accumulator, which is the first element in ProverInstances. The accumulator is assumed to have the
+    // Returns the accumulator, which is the first element in DeciderProvingKeys. The accumulator is assumed to have the
     // FoldingParameters set and be the result of a previous round of folding.
     std::shared_ptr<Instance> get_accumulator() { return instances[0]; }
 
@@ -83,7 +83,7 @@ template <class ProverInstances_> class ProtogalaxyProver_ {
     std::tuple<std::vector<FF>, UnivariateRelationSeparator, UnivariateRelationParameters, FF, CombinerQuotient>
     combiner_quotient_round(const std::vector<FF>& gate_challenges,
                             const std::vector<FF>& deltas,
-                            const ProverInstances_& instances);
+                            const DeciderProvingKeys_& instances);
 
     /**
      * @brief Steps 12 - 13 of the paper plus the prover folding work.
@@ -92,7 +92,7 @@ template <class ProverInstances_> class ProtogalaxyProver_ {
      * of matrices whose columns are polynomials, as well as taking similar linear combinations of the relation
      * parameters.
      */
-    FoldingResult<Flavor> update_target_sum_and_fold(const ProverInstances_& instances,
+    FoldingResult<Flavor> update_target_sum_and_fold(const DeciderProvingKeys_& instances,
                                                      const CombinerQuotient& combiner_quotient,
                                                      const UnivariateRelationSeparator& alphas,
                                                      const UnivariateRelationParameters& univariate_relation_parameters,

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
@@ -6,27 +6,27 @@ namespace bb {
 
 template <class DeciderProvingKeys_> class ProtogalaxyProver_ {
   public:
-    using DeciderProvingKey = typename DeciderProvingKeys_::Instance;
+    using DeciderProvingKey = typename DeciderProvingKeys_::DeciderPK;
     using Flavor = typename DeciderProvingKeys_::Flavor;
     using FF = typename DeciderProvingKeys_::Flavor::FF;
-    static constexpr size_t NUM_INSTANCES = DeciderProvingKeys_::NUM;
-    using CombinerQuotient = Univariate<FF, DeciderProvingKeys_::BATCHED_EXTENDED_LENGTH, NUM_INSTANCES>;
+    static constexpr size_t NUM_KEYS = DeciderProvingKeys_::NUM;
+    using CombinerQuotient = Univariate<FF, DeciderProvingKeys_::BATCHED_EXTENDED_LENGTH, NUM_KEYS>;
     using TupleOfTuplesOfUnivariatesNoOptimisticSkipping =
-        typename Flavor::template ProtogalaxyTupleOfTuplesOfUnivariatesNoOptimisticSkipping<NUM_INSTANCES>;
-    using TupleOfTuplesOfUnivariates = typename Flavor::template ProtogalaxyTupleOfTuplesOfUnivariates<NUM_INSTANCES>;
-    using UnivariateRelationParameters = bb::RelationParameters<
-        Univariate<FF, DeciderProvingKeys_::EXTENDED_LENGTH, 0, /*skip_count=*/NUM_INSTANCES - 1>>;
+        typename Flavor::template ProtogalaxyTupleOfTuplesOfUnivariatesNoOptimisticSkipping<NUM_KEYS>;
+    using TupleOfTuplesOfUnivariates = typename Flavor::template ProtogalaxyTupleOfTuplesOfUnivariates<NUM_KEYS>;
+    using UnivariateRelationParameters =
+        bb::RelationParameters<Univariate<FF, DeciderProvingKeys_::EXTENDED_LENGTH, 0, /*skip_count=*/NUM_KEYS - 1>>;
     using UnivariateRelationSeparator =
         std::array<Univariate<FF, DeciderProvingKeys_::BATCHED_EXTENDED_LENGTH>, Flavor::NUM_SUBRELATIONS - 1>;
 
     using Transcript = typename Flavor::Transcript;
-    using Instance = typename DeciderProvingKeys_::Instance;
+    using DeciderPK = typename DeciderProvingKeys_::DeciderPK;
     using CommitmentKey = typename Flavor::CommitmentKey;
     using DeciderProvingKeys = DeciderProvingKeys_;
 
     static constexpr size_t NUM_SUBRELATIONS = DeciderProvingKeys_::NUM_SUBRELATIONS;
 
-    DeciderProvingKeys_ instances;
+    DeciderProvingKeys_ keys_to_fold;
     std::shared_ptr<CommitmentKey> commitment_key;
 
     // the state updated and carried forward beween rounds
@@ -40,31 +40,30 @@ template <class DeciderProvingKeys_> class ProtogalaxyProver_ {
     UnivariateRelationSeparator alphas;
 
     ProtogalaxyProver_() = default;
-    ProtogalaxyProver_(const std::vector<std::shared_ptr<Instance>>& insts)
-        : instances(DeciderProvingKeys_(insts))
+    ProtogalaxyProver_(const std::vector<std::shared_ptr<DeciderPK>>& keys)
+        : keys_to_fold(DeciderProvingKeys_(keys))
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/878)
-        , commitment_key(instances[1]->proving_key.commitment_key){};
+        , commitment_key(keys_to_fold[1]->proving_key.commitment_key){};
 
     // Returns the accumulator, which is the first element in DeciderProvingKeys. The accumulator is assumed to have the
     // FoldingParameters set and be the result of a previous round of folding.
-    std::shared_ptr<Instance> get_accumulator() { return instances[0]; }
+    std::shared_ptr<DeciderPK> get_accumulator() { return keys_to_fold[0]; }
 
     /**
-     * @brief For each instance produced by a circuit, prior to folding, we need to complete the computation of its
-     * prover polynomials, commit to witnesses and generate the relation parameters as well as send the public data ϕ of
-     * an instance to the verifier.
+     * @brief For each key produced by a circuit, prior to folding, we need to complete the computation of its
+     * prover polynomials; commit to witnesses and generate the relation parameters; and send the public data ϕ of
+     * the key to the verifier.
      *
-     * @param domain_separator  separates the same type of data coming from difference instances by instance
-     * index
+     * @param domain_separator a label used for tracking data in the transcript
      */
-    void run_oink_prover_on_instance(std::shared_ptr<Instance>, const std::string& domain_separator);
+    void run_oink_prover_on_one_incomplete_key(std::shared_ptr<DeciderPK>, const std::string& domain_separator);
 
     /**
      * @brief Create inputs to folding protocol (an Oink interaction).
-     * @details Finalise the prover instances that will be folded: complete computation of all the witness polynomials
+     * @details Complete the decider pks that will be folded: complete computation of all the witness polynomials
      * and compute commitments. Send commitments to the verifier and retrieve challenges.
      */
-    void run_oink_prover_on_each_instance();
+    void run_oink_prover_on_each_incomplete_key();
 
     /**
      * @brief Steps 2 - 5 of the paper.
@@ -73,7 +72,7 @@ template <class DeciderProvingKeys_> class ProtogalaxyProver_ {
      * @param accumulator
      * @return std::tuple<std::vector<FF>, Polynomial<FF>> deltas, perturbator
      */
-    std::tuple<std::vector<FF>, Polynomial<FF>> perturbator_round(const std::shared_ptr<const Instance>& accumulator);
+    std::tuple<std::vector<FF>, Polynomial<FF>> perturbator_round(const std::shared_ptr<const DeciderPK>& accumulator);
 
     /**
      * @brief Steps 6 - 11 of the paper.
@@ -83,16 +82,16 @@ template <class DeciderProvingKeys_> class ProtogalaxyProver_ {
     std::tuple<std::vector<FF>, UnivariateRelationSeparator, UnivariateRelationParameters, FF, CombinerQuotient>
     combiner_quotient_round(const std::vector<FF>& gate_challenges,
                             const std::vector<FF>& deltas,
-                            const DeciderProvingKeys_& instances);
+                            const DeciderProvingKeys_& keys);
 
     /**
      * @brief Steps 12 - 13 of the paper plus the prover folding work.
      * @details Compute \f$ e^* \f$ plus, then update the prover accumulator by taking a Lagrange-linear combination of
-     * the current accumulator and the instances to be folded. In our mental model, we are doing a scalar multipliation
-     * of matrices whose columns are polynomials, as well as taking similar linear combinations of the relation
-     * parameters.
+     * the current accumulator and the decider keys to be folded. In our mental model, we are doing a scalar
+     * multiplication of matrices whose columns are polynomials, as well as taking similar linear combinations of the
+     * relation parameters.
      */
-    FoldingResult<Flavor> update_target_sum_and_fold(const DeciderProvingKeys_& instances,
+    FoldingResult<Flavor> update_target_sum_and_fold(const DeciderProvingKeys_& keys,
                                                      const CombinerQuotient& combiner_quotient,
                                                      const UnivariateRelationSeparator& alphas,
                                                      const UnivariateRelationParameters& univariate_relation_parameters,

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -37,7 +37,7 @@ template <class ProverInstances> void ProtogalaxyProver_<ProverInstances>::run_o
         run_oink_prover_on_instance(instance, domain_separator);
     }
 
-    state.accumulator = instances[0];
+    accumulator = instances[0];
 };
 
 template <class ProverInstances>
@@ -95,7 +95,7 @@ ProtogalaxyProver_<ProverInstances>::combiner_quotient_round(const std::vector<F
     TupleOfTuplesOfUnivariates accumulators;
     auto combiner = Fun::compute_combiner(instances, gate_separators, relation_parameters, alphas, accumulators);
 
-    const FF perturbator_evaluation = state.perturbator.evaluate(perturbator_challenge);
+    const FF perturbator_evaluation = perturbator.evaluate(perturbator_challenge);
     const CombinerQuotient combiner_quotient = Fun::compute_combiner_quotient(perturbator_evaluation, combiner);
 
     for (size_t idx = ProverInstances::NUM; idx < ProverInstances::BATCHED_EXTENDED_LENGTH; idx++) {
@@ -177,17 +177,13 @@ FoldingResult<typename ProverInstances::Flavor> ProtogalaxyProver_<ProverInstanc
     }
     run_oink_prover_on_each_instance();
 
-    std::tie(state.deltas, state.perturbator) = perturbator_round(state.accumulator);
+    std::tie(deltas, perturbator) = perturbator_round(accumulator);
 
-    std::tie(state.accumulator->gate_challenges,
-             state.alphas,
-             state.relation_parameters,
-             state.perturbator_evaluation,
-             state.combiner_quotient) =
-        combiner_quotient_round(state.accumulator->gate_challenges, state.deltas, instances);
+    std::tie(accumulator->gate_challenges, alphas, relation_parameters, perturbator_evaluation, combiner_quotient) =
+        combiner_quotient_round(accumulator->gate_challenges, deltas, instances);
 
-    const FoldingResult<Flavor> result = update_target_sum_and_fold(
-        instances, state.combiner_quotient, state.alphas, state.relation_parameters, state.perturbator_evaluation);
+    const FoldingResult<Flavor> result =
+        update_target_sum_and_fold(instances, combiner_quotient, alphas, relation_parameters, perturbator_evaluation);
 
     return result;
 }

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -8,42 +8,43 @@
 
 namespace bb {
 template <class DeciderProvingKeys>
-void ProtogalaxyProver_<DeciderProvingKeys>::run_oink_prover_on_instance(std::shared_ptr<Instance> instance,
-                                                                         const std::string& domain_separator)
+void ProtogalaxyProver_<DeciderProvingKeys>::run_oink_prover_on_one_incomplete_key(std::shared_ptr<DeciderPK> keys,
+                                                                                   const std::string& domain_separator)
 {
-    ZoneScopedN("ProtogalaxyProver::run_oink_prover_on_instance");
-    OinkProver<Flavor> oink_prover(instance, transcript, domain_separator + '_');
+    ZoneScopedN("ProtogalaxyProver::run_oink_prover_on_one_incomplete_key");
+    OinkProver<Flavor> oink_prover(keys, transcript, domain_separator + '_');
     oink_prover.prove();
 }
 
-template <class DeciderProvingKeys> void ProtogalaxyProver_<DeciderProvingKeys>::run_oink_prover_on_each_instance()
+template <class DeciderProvingKeys>
+void ProtogalaxyProver_<DeciderProvingKeys>::run_oink_prover_on_each_incomplete_key()
 {
-    BB_OP_COUNT_TIME_NAME("ProtogalaxyProver_::run_oink_prover_on_each_instance");
-    auto idx = 0;
-    auto& instance = instances[0];
+    BB_OP_COUNT_TIME_NAME("ProtogalaxyProver_::run_oink_prover_on_each_incomplete_key");
+    size_t idx = 0;
+    auto& key = keys_to_fold[0];
     auto domain_separator = std::to_string(idx);
 
-    if (!instance->is_accumulator) {
-        run_oink_prover_on_instance(instance, domain_separator);
-        instance->target_sum = 0;
-        instance->gate_challenges = std::vector<FF>(instance->proving_key.log_circuit_size, 0);
+    if (!key->is_accumulator) {
+        run_oink_prover_on_one_incomplete_key(key, domain_separator);
+        key->target_sum = 0;
+        key->gate_challenges = std::vector<FF>(key->proving_key.log_circuit_size, 0);
     }
 
     idx++;
 
-    for (auto it = instances.begin() + 1; it != instances.end(); it++, idx++) {
-        auto instance = *it;
+    for (auto it = keys_to_fold.begin() + 1; it != keys_to_fold.end(); it++, idx++) {
+        auto key = *it;
         auto domain_separator = std::to_string(idx);
-        run_oink_prover_on_instance(instance, domain_separator);
+        run_oink_prover_on_one_incomplete_key(key, domain_separator);
     }
 
-    accumulator = instances[0];
+    accumulator = keys_to_fold[0];
 };
 
 template <class DeciderProvingKeys>
 std::tuple<std::vector<typename DeciderProvingKeys::Flavor::FF>, Polynomial<typename DeciderProvingKeys::Flavor::FF>>
 ProtogalaxyProver_<DeciderProvingKeys>::perturbator_round(
-    const std::shared_ptr<const typename DeciderProvingKeys::Instance>& accumulator)
+    const std::shared_ptr<const typename DeciderProvingKeys::DeciderPK>& accumulator)
 {
     BB_OP_COUNT_TIME_NAME("ProtogalaxyProver_::perturbator_round");
 
@@ -51,7 +52,7 @@ ProtogalaxyProver_<DeciderProvingKeys>::perturbator_round(
 
     const FF delta = transcript->template get_challenge<FF>("delta");
     const std::vector<FF> deltas = compute_round_challenge_pows(accumulator->proving_key.log_circuit_size, delta);
-    // An honest prover with valid initial instances computes that the perturbator is 0 in the first round
+    // An honest prover with valid initial key computes that the perturbator is 0 in the first round
     const Polynomial<FF> perturbator = accumulator->is_accumulator
                                            ? Fun::compute_perturbator(accumulator, deltas)
                                            : Polynomial<FF>(accumulator->proving_key.log_circuit_size + 1);
@@ -76,7 +77,7 @@ std::tuple<std::vector<typename DeciderProvingKeys::Flavor::FF>,
            typename ProtogalaxyProver_<DeciderProvingKeys>::CombinerQuotient>
 ProtogalaxyProver_<DeciderProvingKeys>::combiner_quotient_round(const std::vector<FF>& gate_challenges,
                                                                 const std::vector<FF>& deltas,
-                                                                const DeciderProvingKeys& instances)
+                                                                const DeciderProvingKeys& keys)
 {
     BB_OP_COUNT_TIME_NAME("ProtogalaxyProver_::combiner_quotient_round");
 
@@ -86,14 +87,13 @@ ProtogalaxyProver_<DeciderProvingKeys>::combiner_quotient_round(const std::vecto
 
     const std::vector<FF> updated_gate_challenges =
         update_gate_challenges(perturbator_challenge, gate_challenges, deltas);
-    const UnivariateRelationSeparator alphas = Fun::compute_and_extend_alphas(instances);
-    const GateSeparatorPolynomial<FF> gate_separators{ updated_gate_challenges,
-                                                       instances[0]->proving_key.log_circuit_size };
+    const UnivariateRelationSeparator alphas = Fun::compute_and_extend_alphas(keys);
+    const GateSeparatorPolynomial<FF> gate_separators{ updated_gate_challenges, keys[0]->proving_key.log_circuit_size };
     const UnivariateRelationParameters relation_parameters =
-        Fun::template compute_extended_relation_parameters<UnivariateRelationParameters>(instances);
+        Fun::template compute_extended_relation_parameters<UnivariateRelationParameters>(keys);
 
     TupleOfTuplesOfUnivariates accumulators;
-    auto combiner = Fun::compute_combiner(instances, gate_separators, relation_parameters, alphas, accumulators);
+    auto combiner = Fun::compute_combiner(keys, gate_separators, relation_parameters, alphas, accumulators);
 
     const FF perturbator_evaluation = perturbator.evaluate(perturbator_challenge);
     const CombinerQuotient combiner_quotient = Fun::compute_combiner_quotient(perturbator_evaluation, combiner);
@@ -109,11 +109,11 @@ ProtogalaxyProver_<DeciderProvingKeys>::combiner_quotient_round(const std::vecto
 /**
  * @brief Given the challenge \gamma, compute Z(\gamma) and {L_0(\gamma),L_1(\gamma)}
  * TODO(https://github.com/AztecProtocol/barretenberg/issues/764): Generalize the vanishing polynomial formula
- * and the computation of Lagrange basis for k instances
+ * and the computation of Lagrange basis for k decider proving keys.
  */
 template <class DeciderProvingKeys>
 FoldingResult<typename DeciderProvingKeys::Flavor> ProtogalaxyProver_<DeciderProvingKeys>::update_target_sum_and_fold(
-    const DeciderProvingKeys& instances,
+    const DeciderProvingKeys& keys,
     const CombinerQuotient& combiner_quotient,
     const UnivariateRelationSeparator& alphas,
     const UnivariateRelationParameters& univariate_relation_parameters,
@@ -124,7 +124,7 @@ FoldingResult<typename DeciderProvingKeys::Flavor> ProtogalaxyProver_<DeciderPro
 
     const FF combiner_challenge = transcript->template get_challenge<FF>("combiner_quotient_challenge");
 
-    FoldingResult<Flavor> result{ .accumulator = instances[0], .proof = std::move(transcript->proof_data) };
+    FoldingResult<Flavor> result{ .accumulator = keys[0], .proof = std::move(transcript->proof_data) };
 
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/881): bad pattern
     result.accumulator->is_accumulator = true;
@@ -139,17 +139,17 @@ FoldingResult<typename DeciderProvingKeys::Flavor> ProtogalaxyProver_<DeciderPro
     for (auto& poly : result.accumulator->proving_key.polynomials.get_unshifted()) {
         poly *= lagranges[0];
     }
-    for (size_t inst_idx = 1; inst_idx < DeciderProvingKeys::NUM; inst_idx++) {
-        for (auto [acc_poly, inst_poly] : zip_view(result.accumulator->proving_key.polynomials.get_unshifted(),
-                                                   instances[inst_idx]->proving_key.polynomials.get_unshifted())) {
-            acc_poly.add_scaled(inst_poly, lagranges[inst_idx]);
+    for (size_t key_idx = 1; key_idx < DeciderProvingKeys::NUM; key_idx++) {
+        for (auto [acc_poly, key_poly] : zip_view(result.accumulator->proving_key.polynomials.get_unshifted(),
+                                                  keys[key_idx]->proving_key.polynomials.get_unshifted())) {
+            acc_poly.add_scaled(key_poly, lagranges[key_idx]);
         }
     }
 
     // Evaluate the combined batching  α_i univariate at challenge to obtain next α_i and send it to the
     // verifier, where i ∈ {0,...,NUM_SUBRELATIONS - 1}
-    for (auto [folded_alpha, inst_alpha] : zip_view(result.accumulator->alphas, alphas)) {
-        folded_alpha = inst_alpha.evaluate(combiner_challenge);
+    for (auto [folded_alpha, key_alpha] : zip_view(result.accumulator->alphas, alphas)) {
+        folded_alpha = key_alpha.evaluate(combiner_challenge);
     }
 
     // Evaluate each relation parameter univariate at challenge to obtain the folded relation parameters.
@@ -166,24 +166,24 @@ FoldingResult<typename DeciderProvingKeys::Flavor> ProtogalaxyProver_<DeciderPro
 {
     ZoneScopedN("ProtogalaxyProver::prove");
     BB_OP_COUNT_TIME_NAME("ProtogalaxyProver::prove");
-    // Ensure instances are all of the same size
+    // Ensure keys are all of the same size
     for (size_t idx = 0; idx < DeciderProvingKeys::NUM - 1; ++idx) {
-        if (instances[idx]->proving_key.circuit_size != instances[idx + 1]->proving_key.circuit_size) {
+        if (keys_to_fold[idx]->proving_key.circuit_size != keys_to_fold[idx + 1]->proving_key.circuit_size) {
             info("ProtogalaxyProver: circuit size mismatch!");
-            info("Instance ", idx, " size = ", instances[idx]->proving_key.circuit_size);
-            info("Instance ", idx + 1, " size = ", instances[idx + 1]->proving_key.circuit_size);
+            info("DeciderPK ", idx, " size = ", keys_to_fold[idx]->proving_key.circuit_size);
+            info("DeciderPK ", idx + 1, " size = ", keys_to_fold[idx + 1]->proving_key.circuit_size);
             ASSERT(false);
         }
     }
-    run_oink_prover_on_each_instance();
+    run_oink_prover_on_each_incomplete_key();
 
     std::tie(deltas, perturbator) = perturbator_round(accumulator);
 
     std::tie(accumulator->gate_challenges, alphas, relation_parameters, perturbator_evaluation, combiner_quotient) =
-        combiner_quotient_round(accumulator->gate_challenges, deltas, instances);
+        combiner_quotient_round(accumulator->gate_challenges, deltas, keys_to_fold);
 
-    const FoldingResult<Flavor> result =
-        update_target_sum_and_fold(instances, combiner_quotient, alphas, relation_parameters, perturbator_evaluation);
+    const FoldingResult<Flavor> result = update_target_sum_and_fold(
+        keys_to_fold, combiner_quotient, alphas, relation_parameters, perturbator_evaluation);
 
     return result;
 }

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
@@ -17,45 +17,42 @@ namespace bb {
  */
 template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
   public:
-    using DeciderProvingKeys = DeciderProvingKeys_;
-    using Flavor = typename DeciderProvingKeys::Flavor;
+    using DeciderPKs = DeciderProvingKeys_;
+    using Flavor = typename DeciderPKs::Flavor;
     using FF = typename Flavor::FF;
-    using Instance = typename DeciderProvingKeys::Instance;
+    using DeciderPK = typename DeciderPKs::DeciderPK;
     using RelationUtils = bb::RelationUtils<Flavor>;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     using Relations = typename Flavor::Relations;
     using RelationSeparator = typename Flavor::RelationSeparator;
-    static constexpr size_t NUM_INSTANCES = DeciderProvingKeys_::NUM;
+    static constexpr size_t NUM_KEYS = DeciderProvingKeys_::NUM;
     using UnivariateRelationParametersNoOptimisticSkipping =
         bb::RelationParameters<Univariate<FF, DeciderProvingKeys_::EXTENDED_LENGTH>>;
-    using UnivariateRelationParameters = bb::RelationParameters<
-        Univariate<FF, DeciderProvingKeys_::EXTENDED_LENGTH, 0, /*skip_count=*/NUM_INSTANCES - 1>>;
+    using UnivariateRelationParameters =
+        bb::RelationParameters<Univariate<FF, DeciderProvingKeys_::EXTENDED_LENGTH, 0, /*skip_count=*/NUM_KEYS - 1>>;
     using UnivariateRelationSeparator =
-        std::array<Univariate<FF, DeciderProvingKeys::BATCHED_EXTENDED_LENGTH>, Flavor::NUM_SUBRELATIONS - 1>;
+        std::array<Univariate<FF, DeciderPKs::BATCHED_EXTENDED_LENGTH>, Flavor::NUM_SUBRELATIONS - 1>;
 
     // The length of ExtendedUnivariate is the largest length (==max_relation_degree + 1) of a univariate polynomial
-    // obtained by composing a relation with folded instance + relation parameters .
-    using ExtendedUnivariate =
-        Univariate<FF, (Flavor::MAX_TOTAL_RELATION_LENGTH - 1) * (DeciderProvingKeys::NUM - 1) + 1>;
+    // obtained by composing a relation with Lagrange polynomial-linear combination of NUM-many decider pks, with
+    // relation parameters regarded as variables.
+    using ExtendedUnivariate = Univariate<FF, (Flavor::MAX_TOTAL_RELATION_LENGTH - 1) * (DeciderPKs::NUM - 1) + 1>;
     // Represents the total length of the combiner univariate, obtained by combining the already folded relations with
     // the folded relation batching challenge.
-    using ExtendedUnivariateWithRandomization = Univariate<
-        FF,
-        (Flavor::MAX_TOTAL_RELATION_LENGTH - 1 + DeciderProvingKeys::NUM - 1) * (DeciderProvingKeys::NUM - 1) + 1>;
+    using ExtendedUnivariateWithRandomization =
+        Univariate<FF, (Flavor::MAX_TOTAL_RELATION_LENGTH - 1 + DeciderPKs::NUM - 1) * (DeciderPKs::NUM - 1) + 1>;
     using ExtendedUnivariatesNoOptimisticSkipping =
         typename Flavor::template ProverUnivariates<ExtendedUnivariate::LENGTH>;
     using ExtendedUnivariates =
         typename Flavor::template ProverUnivariatesWithOptimisticSkipping<ExtendedUnivariate::LENGTH,
-                                                                          /* SKIP_COUNT= */ DeciderProvingKeys::NUM -
-                                                                              1>;
+                                                                          /* SKIP_COUNT= */ DeciderPKs::NUM - 1>;
 
     using TupleOfTuplesOfUnivariatesNoOptimisticSkipping =
-        typename Flavor::template ProtogalaxyTupleOfTuplesOfUnivariatesNoOptimisticSkipping<DeciderProvingKeys::NUM>;
-    using TupleOfTuplesOfUnivariates =
-        typename Flavor::template ProtogalaxyTupleOfTuplesOfUnivariates<DeciderProvingKeys::NUM>;
+        typename Flavor::template ProtogalaxyTupleOfTuplesOfUnivariatesNoOptimisticSkipping<DeciderPKs::NUM>;
+    using TupleOfTuplesOfUnivariates = typename Flavor::template ProtogalaxyTupleOfTuplesOfUnivariates<DeciderPKs::NUM>;
     using RelationEvaluations = typename Flavor::TupleOfArraysOfValues;
 
-    static constexpr size_t NUM_SUBRELATIONS = DeciderProvingKeys::NUM_SUBRELATIONS;
+    static constexpr size_t NUM_SUBRELATIONS = DeciderPKs::NUM_SUBRELATIONS;
 
     /**
      * @brief Compute the values of the aggregated relation evaluations at each row in the execution trace, representing
@@ -63,25 +60,25 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
      * challenges that help establishing each subrelation is independently valid in Honk - from the Plonk paper, DO NOT
      * confuse with α in Protogalaxy).
      *
-     * @details When folding Mega instances, one of the relations is linearly dependent. We define such relations
-     * as acting on the entire execution trace and hence requiring to be accumulated separately as we iterate over each
-     * row. At the end of the function, the linearly dependent contribution is accumulated at index 0 representing the
-     * sum f_0(ω) + α_j*g(ω) where f_0 represents the full honk evaluation at row 0, g(ω) is the linearly dependent
-     * subrelation and α_j is its corresponding batching challenge.
+     * @details When folding Mega decider proving keys, one of the relations is linearly dependent. We define such
+     * relations as acting on the entire execution trace and hence requiring to be accumulated separately as we iterate
+     * over each row. At the end of the function, the linearly dependent contribution is accumulated at index 0
+     * representing the sum f_0(ω) + α_j*g(ω) where f_0 represents the full honk evaluation at row 0, g(ω) is the
+     * linearly dependent subrelation and α_j is its corresponding batching challenge.
      */
-    static std::vector<FF> compute_row_evaluations(const ProverPolynomials& instance_polynomials,
+    static std::vector<FF> compute_row_evaluations(const ProverPolynomials& polynomials,
                                                    const RelationSeparator& alpha,
                                                    const RelationParameters<FF>& relation_parameters)
 
     {
         BB_OP_COUNT_TIME_NAME("ProtogalaxyProver_::compute_row_evaluations");
-        auto instance_size = instance_polynomials.get_polynomial_size();
-        std::vector<FF> full_honk_evaluations(instance_size);
+        const size_t polynomial_size = polynomials.get_polynomial_size();
+        std::vector<FF> full_honk_evaluations(polynomial_size);
         const std::vector<FF> linearly_dependent_contribution_accumulators = parallel_for_heuristic(
-            instance_size,
+            polynomial_size,
             /*accumulator default*/ FF(0),
             [&](size_t row, FF& linearly_dependent_contribution_accumulator) {
-                auto row_evaluations = instance_polynomials.get_row(row);
+                auto row_evaluations = polynomials.get_row(row);
                 RelationEvaluations relation_evaluations;
                 RelationUtils::zero_elements(relation_evaluations);
 
@@ -163,12 +160,9 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
     }
 
     /**
-     * @brief Construct the power perturbator polynomial F(X) in coefficient form from the accumulator, representing the
-     * relaxed instance.
-     *
-     *
+     * @brief Construct the power perturbator polynomial F(X) in coefficient form from the accumulator
      */
-    static Polynomial<FF> compute_perturbator(const std::shared_ptr<const Instance>& accumulator,
+    static Polynomial<FF> compute_perturbator(const std::shared_ptr<const DeciderPK>& accumulator,
                                               const std::vector<FF>& deltas)
     {
         BB_OP_COUNT_TIME();
@@ -180,11 +174,10 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
     }
 
     /**
-     * @brief Prepare a univariate polynomial for relation execution in one step of the main loop in folded instance
-     * construction.
-     * @details For a fixed prover polynomial index, extract that polynomial from each instance in Instances. From
-     *each polynomial, extract the value at row_idx. Use these values to create a univariate polynomial, and then
-     *extend (i.e., compute additional evaluations at adjacent domain values) as needed.
+     * @brief Prepare a univariate polynomial for relation execution in one step of the combiner construction.
+     * @details For a fixed prover polynomial index, extract that polynomial from each key in DeciderProvingKeys. From
+     * each polynomial, extract the value at row_idx. Use these values to create a univariate polynomial, and then
+     * extend (i.e., compute additional evaluations at adjacent domain values) as needed.
      * @todo TODO(https://github.com/AztecProtocol/barretenberg/issues/751) Optimize memory
      */
 
@@ -192,10 +185,10 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
     static void extend_univariates(
         std::conditional_t<skip_count != 0, ExtendedUnivariates, ExtendedUnivariatesNoOptimisticSkipping>&
             extended_univariates,
-        const DeciderProvingKeys& instances,
+        const DeciderPKs& keys,
         const size_t row_idx)
     {
-        const auto base_univariates = instances.template row_to_univariates<skip_count>(row_idx);
+        const auto base_univariates = keys.template row_to_univariates<skip_count>(row_idx);
         for (auto [extended_univariate, base_univariate] : zip_view(extended_univariates.get_all(), base_univariates)) {
             extended_univariate = base_univariate.template extend_to<ExtendedUnivariate::LENGTH, skip_count>();
         }
@@ -259,12 +252,12 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
      * @todo (https://github.com/AztecProtocol/barretenberg/issues/968) Make combiner tests better
      *
      * @tparam skip_zero_computations whether to use the the optimization that skips computing zero.
-     * @param instances
+     * @param
      * @param gate_separators
      * @return ExtendedUnivariateWithRandomization
      */
     template <typename Parameters, typename TupleOfTuples>
-    static ExtendedUnivariateWithRandomization compute_combiner(const DeciderProvingKeys& instances,
+    static ExtendedUnivariateWithRandomization compute_combiner(const DeciderPKs& keys,
                                                                 const GateSeparatorPolynomial<FF>& gate_separators,
                                                                 const Parameters& relation_parameters,
                                                                 const UnivariateRelationSeparator& alphas,
@@ -275,7 +268,7 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
         // Whether to use univariates whose operators ignore some values which an honest prover would compute to be zero
         constexpr bool skip_zero_computations = std::same_as<TupleOfTuples, TupleOfTuplesOfUnivariates>;
 
-        const size_t common_instance_size = instances[0]->proving_key.circuit_size;
+        const size_t common_polynomial_size = keys[0]->proving_key.circuit_size;
         // Determine number of threads for multithreading.
         // Note: Multithreading is "on" for every round but we reduce the number of threads from the max available based
         // on a specified minimum number of iterations per thread. This eventually leads to the use of a
@@ -284,10 +277,10 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
         const size_t max_num_threads = get_num_cpus_pow2(); // number of available threads (power of 2)
         const size_t min_iterations_per_thread =
             1 << 6; // min number of iterations for which we'll spin up a unique thread
-        const size_t desired_num_threads = common_instance_size / min_iterations_per_thread;
-        size_t num_threads = std::min(desired_num_threads, max_num_threads);     // fewer than max if justified
-        num_threads = num_threads > 0 ? num_threads : 1;                         // ensure num threads is >= 1
-        const size_t iterations_per_thread = common_instance_size / num_threads; // actual iterations per thread
+        const size_t desired_num_threads = common_polynomial_size / min_iterations_per_thread;
+        size_t num_threads = std::min(desired_num_threads, max_num_threads);       // fewer than max if justified
+        num_threads = num_threads > 0 ? num_threads : 1;                           // ensure num threads is >= 1
+        const size_t iterations_per_thread = common_polynomial_size / num_threads; // actual iterations per thread
 
         // Univariates are optimised for usual PG, but we need the unoptimised version for tests (it's a version that
         // doesn't skip computation), so we need to define types depending on the template instantiation
@@ -315,8 +308,8 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
                 // Instantiate univariates, possibly with skipping toto ignore computation in those indices (they are
                 // still available for skipping relations, but all derived univariate will ignore those evaluations)
                 // No need to initialise extended_univariates to 0, as it's assigned to.
-                constexpr size_t skip_count = skip_zero_computations ? DeciderProvingKeys::NUM - 1 : 0;
-                extend_univariates<skip_count>(extended_univariates[thread_idx], instances, idx);
+                constexpr size_t skip_count = skip_zero_computations ? DeciderPKs::NUM - 1 : 0;
+                extend_univariates<skip_count>(extended_univariates[thread_idx], keys, idx);
 
                 const FF pow_challenge = gate_separators[idx];
 
@@ -347,22 +340,22 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
      * @details This is only used for testing the combiner calculation.
      */
     static ExtendedUnivariateWithRandomization compute_combiner_no_optimistic_skipping(
-        const DeciderProvingKeys& instances,
+        const DeciderPKs& keys,
         const GateSeparatorPolynomial<FF>& gate_separators,
         const UnivariateRelationParametersNoOptimisticSkipping& relation_parameters,
         const UnivariateRelationSeparator& alphas)
     {
         TupleOfTuplesOfUnivariatesNoOptimisticSkipping accumulators;
-        return compute_combiner(instances, gate_separators, relation_parameters, alphas, accumulators);
+        return compute_combiner(keys, gate_separators, relation_parameters, alphas, accumulators);
     }
 
-    static ExtendedUnivariateWithRandomization compute_combiner(const DeciderProvingKeys& instances,
+    static ExtendedUnivariateWithRandomization compute_combiner(const DeciderPKs& keys,
                                                                 const GateSeparatorPolynomial<FF>& gate_separators,
                                                                 const UnivariateRelationParameters& relation_parameters,
                                                                 const UnivariateRelationSeparator& alphas)
     {
         TupleOfTuplesOfUnivariates accumulators;
-        return compute_combiner(instances, gate_separators, relation_parameters, alphas, accumulators);
+        return compute_combiner(keys, gate_separators, relation_parameters, alphas, accumulators);
     }
 
     /**
@@ -394,11 +387,11 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
         TupleOfTuplesOfUnivariatesNoOptimisticSkipping& univariate_accumulators,
         const UnivariateRelationSeparator& alpha)
     {
-        auto result = std::get<0>(std::get<0>(univariate_accumulators))
-                          .template extend_to<DeciderProvingKeys::BATCHED_EXTENDED_LENGTH>();
+        auto result =
+            std::get<0>(std::get<0>(univariate_accumulators)).template extend_to<DeciderPKs::BATCHED_EXTENDED_LENGTH>();
         size_t idx = 0;
         const auto scale_and_sum = [&]<size_t outer_idx, size_t inner_idx>(auto& element) {
-            auto extended = element.template extend_to<DeciderProvingKeys::BATCHED_EXTENDED_LENGTH>();
+            auto extended = element.template extend_to<DeciderPKs::BATCHED_EXTENDED_LENGTH>();
             extended *= alpha[idx];
             result += extended;
             idx++;
@@ -410,23 +403,22 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
         return result;
     }
 
-    static std::pair<typename DeciderProvingKeys::FF,
-                     std::array<typename DeciderProvingKeys::FF, DeciderProvingKeys::NUM>>
+    static std::pair<typename DeciderPKs::FF, std::array<typename DeciderPKs::FF, DeciderPKs::NUM>>
     compute_vanishing_polynomial_and_lagranges(const FF& challenge)
     {
         FF vanishing_polynomial_at_challenge;
-        std::array<FF, DeciderProvingKeys::NUM> lagranges;
+        std::array<FF, DeciderPKs::NUM> lagranges;
         constexpr FF inverse_two = FF(2).invert();
 
-        if constexpr (DeciderProvingKeys::NUM == 2) {
+        if constexpr (DeciderPKs::NUM == 2) {
             vanishing_polynomial_at_challenge = challenge * (challenge - FF(1));
             lagranges = { FF(1) - challenge, challenge };
-        } else if constexpr (DeciderProvingKeys::NUM == 3) {
+        } else if constexpr (DeciderPKs::NUM == 3) {
             vanishing_polynomial_at_challenge = challenge * (challenge - FF(1)) * (challenge - FF(2));
             lagranges = { (FF(1) - challenge) * (FF(2) - challenge) * inverse_two,
                           challenge * (FF(2) - challenge),
                           challenge * (challenge - FF(1)) / FF(2) };
-        } else if constexpr (DeciderProvingKeys::NUM == 4) {
+        } else if constexpr (DeciderPKs::NUM == 4) {
             constexpr FF inverse_six = FF(6).invert();
             vanishing_polynomial_at_challenge =
                 challenge * (challenge - FF(1)) * (challenge - FF(2)) * (challenge - FF(3));
@@ -435,7 +427,7 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
                           challenge * (challenge - FF(1)) * (FF(3) - challenge) * inverse_two,
                           challenge * (challenge - FF(1)) * (challenge - FF(2)) * inverse_six };
         }
-        static_assert(DeciderProvingKeys::NUM < 5);
+        static_assert(DeciderPKs::NUM < 5);
 
         return { vanishing_polynomial_at_challenge, lagranges };
     }
@@ -447,54 +439,52 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
      * polynomials and Lagrange basis and use batch_invert.
      *
      */
-    static Univariate<FF, DeciderProvingKeys::BATCHED_EXTENDED_LENGTH, DeciderProvingKeys::NUM>
-    compute_combiner_quotient(FF perturbator_evaluation, ExtendedUnivariateWithRandomization combiner)
+    static Univariate<FF, DeciderPKs::BATCHED_EXTENDED_LENGTH, DeciderPKs::NUM> compute_combiner_quotient(
+        FF perturbator_evaluation, ExtendedUnivariateWithRandomization combiner)
     {
-        std::array<FF, DeciderProvingKeys::BATCHED_EXTENDED_LENGTH - DeciderProvingKeys::NUM>
-            combiner_quotient_evals = {};
+        std::array<FF, DeciderPKs::BATCHED_EXTENDED_LENGTH - DeciderPKs::NUM> combiner_quotient_evals = {};
 
         constexpr FF inverse_two = FF(2).invert();
         constexpr FF inverse_six = FF(6).invert();
-        for (size_t point = DeciderProvingKeys::NUM; point < combiner.size(); point++) {
-            auto idx = point - DeciderProvingKeys::NUM;
+        for (size_t point = DeciderPKs::NUM; point < combiner.size(); point++) {
+            auto idx = point - DeciderPKs::NUM;
             FF lagrange_0;
             FF vanishing_polynomial;
-            if constexpr (DeciderProvingKeys::NUM == 2) {
+            if constexpr (DeciderPKs::NUM == 2) {
                 lagrange_0 = FF(1) - FF(point);
                 vanishing_polynomial = FF(point) * (FF(point) - 1);
-            } else if constexpr (DeciderProvingKeys::NUM == 3) {
+            } else if constexpr (DeciderPKs::NUM == 3) {
                 lagrange_0 = (FF(1) - FF(point)) * (FF(2) - FF(point)) * inverse_two;
                 vanishing_polynomial = FF(point) * (FF(point) - 1) * (FF(point) - 2);
-            } else if constexpr (DeciderProvingKeys::NUM == 4) {
+            } else if constexpr (DeciderPKs::NUM == 4) {
                 lagrange_0 = (FF(1) - FF(point)) * (FF(2) - FF(point)) * (FF(3) - FF(point)) * inverse_six;
                 vanishing_polynomial = FF(point) * (FF(point) - 1) * (FF(point) - 2) * (FF(point) - 3);
             }
-            static_assert(DeciderProvingKeys::NUM < 5);
+            static_assert(DeciderPKs::NUM < 5);
 
             combiner_quotient_evals[idx] =
                 (combiner.value_at(point) - perturbator_evaluation * lagrange_0) * vanishing_polynomial.invert();
         }
 
-        return Univariate<FF, DeciderProvingKeys::BATCHED_EXTENDED_LENGTH, DeciderProvingKeys::NUM>(
-            combiner_quotient_evals);
+        return Univariate<FF, DeciderPKs::BATCHED_EXTENDED_LENGTH, DeciderPKs::NUM>(combiner_quotient_evals);
     }
 
     /**
-     * @brief For each parameter, collect the value in each instance in a univariate and extend for use in the combiner
-     * compute.
+     * @brief For each parameter, collect the value in each decider pvogin key in a univariate and extend for use in the
+     * combiner compute.
      */
     template <typename ExtendedRelationParameters>
-    static ExtendedRelationParameters compute_extended_relation_parameters(const DeciderProvingKeys& instances)
+    static ExtendedRelationParameters compute_extended_relation_parameters(const DeciderPKs& keys)
     {
         using UnivariateParameter = typename ExtendedRelationParameters::DataType;
         ExtendedRelationParameters result;
         size_t param_idx = 0;
         for (auto& param : result.get_to_fold()) {
-            Univariate<FF, DeciderProvingKeys::NUM> tmp(0);
-            size_t instance_idx = 0;
-            for (auto& instance : instances) {
-                tmp.value_at(instance_idx) = instance->relation_parameters.get_to_fold()[param_idx];
-                instance_idx++;
+            Univariate<FF, DeciderPKs::NUM> tmp(0);
+            size_t key_idx = 0;
+            for (auto& key : keys) {
+                tmp.value_at(key_idx) = key->relation_parameters.get_to_fold()[param_idx];
+                key_idx++;
             }
             param = tmp.template extend_to<UnivariateParameter::LENGTH, UnivariateParameter::SKIP_COUNT>();
             param_idx++;
@@ -503,21 +493,21 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
     }
 
     /**
-     * @brief Combine the relation batching parameters (alphas) from each instance into a univariate, used in the
-     * computation of combiner.
+     * @brief Combine the relation batching parameters (alphas) from each decider proving key into a univariate for
+     * using in the combiner computation.
      */
-    static UnivariateRelationSeparator compute_and_extend_alphas(const DeciderProvingKeys& instances)
+    static UnivariateRelationSeparator compute_and_extend_alphas(const DeciderPKs& keys)
     {
         UnivariateRelationSeparator result;
         size_t alpha_idx = 0;
         for (auto& alpha : result) {
-            Univariate<FF, DeciderProvingKeys::NUM> tmp;
-            size_t instance_idx = 0;
-            for (auto& instance : instances) {
-                tmp.value_at(instance_idx) = instance->alphas[alpha_idx];
-                instance_idx++;
+            Univariate<FF, DeciderPKs::NUM> tmp;
+            size_t key_idx = 0;
+            for (auto& key : keys) {
+                tmp.value_at(key_idx) = key->alphas[alpha_idx];
+                key_idx++;
             }
-            alpha = tmp.template extend_to<DeciderProvingKeys::BATCHED_EXTENDED_LENGTH>();
+            alpha = tmp.template extend_to<DeciderPKs::BATCHED_EXTENDED_LENGTH>();
             alpha_idx++;
         }
         return result;

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_mega.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_mega.cpp
@@ -5,5 +5,5 @@
 #include "protogalaxy_prover_impl.hpp"
 namespace bb {
 
-template class ProtogalaxyProver_<ProverInstances_<MegaFlavor, 2>>;
+template class ProtogalaxyProver_<DeciderProvingKeys_<MegaFlavor, 2>>;
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_ultra.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_ultra.cpp
@@ -4,5 +4,5 @@
 
 // TODO(https://github.com/AztecProtocol/barretenberg/issues/1076) Remove this instantiation.
 namespace bb {
-template class ProtogalaxyProver_<ProverInstances_<UltraFlavor, 2>>;
+template class ProtogalaxyProver_<DeciderProvingKeys_<UltraFlavor, 2>>;
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.hpp
@@ -13,7 +13,7 @@ template <class DeciderVerificationKeys> class ProtogalaxyVerifier_ {
     using Transcript = typename Flavor::Transcript;
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
-    using Instance = typename DeciderVerificationKeys::Instance;
+    using DeciderVK = typename DeciderVerificationKeys::DeciderVK;
     using VerificationKey = typename Flavor::VerificationKey;
     using WitnessCommitments = typename Flavor::WitnessCommitments;
     using CommitmentLabels = typename Flavor::CommitmentLabels;
@@ -21,37 +21,37 @@ template <class DeciderVerificationKeys> class ProtogalaxyVerifier_ {
 
     static constexpr size_t NUM_SUBRELATIONS = Flavor::NUM_SUBRELATIONS;
 
-    DeciderVerificationKeys instances;
+    DeciderVerificationKeys keys_to_fold;
 
     std::shared_ptr<Transcript> transcript = std::make_shared<Transcript>();
 
     CommitmentLabels commitment_labels;
 
-    ProtogalaxyVerifier_(const std::vector<std::shared_ptr<Instance>>& insts)
-        : instances(DeciderVerificationKeys(insts)){};
+    ProtogalaxyVerifier_(const std::vector<std::shared_ptr<DeciderVK>>& keys)
+        : keys_to_fold(DeciderVerificationKeys(keys)){};
     ~ProtogalaxyVerifier_() = default;
 
-    std::shared_ptr<Instance> get_accumulator() { return instances[0]; }
+    std::shared_ptr<DeciderVK> get_accumulator() { return keys_to_fold[0]; }
 
     /**
-     * @brief Instatiate the instances and the transcript.
+     * @brief Instatiate the vks and the transcript.
      *
      * @param fold_data The data transmitted via the transcript by the prover.
      */
     void prepare_for_folding(const std::vector<FF>&);
 
     /**
-     * @brief Process the public data ϕ for the Instances to be folded.
+     * @brief Process the public data ϕ for the decider verification keys to be folded.
      *
      */
-    void receive_and_finalise_instance(const std::shared_ptr<Instance>&, const std::string&);
+    void receive_and_finalise_key(const std::shared_ptr<DeciderVK>&, const std::string&);
 
     /**
      * @brief Run the folding protocol on the verifier side to establish whether the public data ϕ of the new
      * accumulator, received from the prover is the same as that produced by the verifier.
      *
      */
-    std::shared_ptr<Instance> verify_folding_proof(const std::vector<FF>&);
+    std::shared_ptr<DeciderVK> verify_folding_proof(const std::vector<FF>&);
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.hpp
@@ -7,13 +7,13 @@
 #include "barretenberg/transcript/transcript.hpp"
 
 namespace bb {
-template <class VerifierInstances> class ProtogalaxyVerifier_ {
+template <class DeciderVerificationKeys> class ProtogalaxyVerifier_ {
   public:
-    using Flavor = typename VerifierInstances::Flavor;
+    using Flavor = typename DeciderVerificationKeys::Flavor;
     using Transcript = typename Flavor::Transcript;
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
-    using Instance = typename VerifierInstances::Instance;
+    using Instance = typename DeciderVerificationKeys::Instance;
     using VerificationKey = typename Flavor::VerificationKey;
     using WitnessCommitments = typename Flavor::WitnessCommitments;
     using CommitmentLabels = typename Flavor::CommitmentLabels;
@@ -21,14 +21,14 @@ template <class VerifierInstances> class ProtogalaxyVerifier_ {
 
     static constexpr size_t NUM_SUBRELATIONS = Flavor::NUM_SUBRELATIONS;
 
-    VerifierInstances instances;
+    DeciderVerificationKeys instances;
 
     std::shared_ptr<Transcript> transcript = std::make_shared<Transcript>();
 
     CommitmentLabels commitment_labels;
 
     ProtogalaxyVerifier_(const std::vector<std::shared_ptr<Instance>>& insts)
-        : instances(VerifierInstances(insts)){};
+        : instances(DeciderVerificationKeys(insts)){};
     ~ProtogalaxyVerifier_() = default;
 
     std::shared_ptr<Instance> get_accumulator() { return instances[0]; }

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.hpp
@@ -42,14 +42,12 @@ template <class DeciderVerificationKeys> class ProtogalaxyVerifier_ {
 
     /**
      * @brief Process the public data ϕ for the decider verification keys to be folded.
-     *
      */
     void receive_and_finalise_key(const std::shared_ptr<DeciderVK>&, const std::string&);
 
     /**
      * @brief Run the folding protocol on the verifier side to establish whether the public data ϕ of the new
      * accumulator, received from the prover is the same as that produced by the verifier.
-     *
      */
     std::shared_ptr<DeciderVK> verify_folding_proof(const std::vector<FF>&);
 };

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/prover_verifier_shared.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/prover_verifier_shared.cpp
@@ -5,24 +5,20 @@ std::vector<fr> update_gate_challenges(const fr& perturbator_challenge,
                                        const std::vector<fr>& gate_challenges,
                                        const std::vector<fr>& init_challenges)
 {
-    auto log_instance_size = gate_challenges.size();
-    std::vector<fr> next_gate_challenges(log_instance_size);
+    const size_t num_challenges = gate_challenges.size();
+    std::vector<fr> next_gate_challenges(num_challenges);
 
-    for (size_t idx = 0; idx < log_instance_size; idx++) {
+    for (size_t idx = 0; idx < num_challenges; idx++) {
         next_gate_challenges[idx] = gate_challenges[idx] + perturbator_challenge * init_challenges[idx];
     }
     return next_gate_challenges;
 }
 
-/**
- * @brief For a new round challenge δ at each iteration of the Protogalaxy protocol, compute the vector
- * [δ, δ^2,..., δ^t] where t = logn and n is the size of the instance.
- */
-std::vector<fr> compute_round_challenge_pows(const size_t log_instance_size, const fr& round_challenge)
+std::vector<fr> compute_round_challenge_pows(const size_t num_powers, const fr& round_challenge)
 {
-    std::vector<fr> pows(log_instance_size);
+    std::vector<fr> pows(num_powers);
     pows[0] = round_challenge;
-    for (size_t i = 1; i < log_instance_size; i++) {
+    for (size_t i = 1; i < num_powers; i++) {
         pows[i] = pows[i - 1].sqr();
     }
     return pows;

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/prover_verifier_shared.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/prover_verifier_shared.hpp
@@ -12,9 +12,9 @@ std::vector<fr> update_gate_challenges(const fr& perturbator_challenge,
                                        const std::vector<fr>& init_challenges);
 
 /**
- * @brief For a new round challenge δ at each iteration of the Protogalaxy protocol, compute the vector
- * [δ, δ^2,..., δ^t] where t = logn and n is the size of the instance.
+ * @brief Given δ, compute the vector [δ, δ^2,..., δ^num_powers].
+ * @details This is Step 2 of the protocol as written in the paper.
  */
-std::vector<fr> compute_round_challenge_pows(const size_t log_instance_size, const fr& round_challenge);
+std::vector<fr> compute_round_challenge_pows(const size_t num_powers, const fr& round_challenge);
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/relation_types.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/relation_types.hpp
@@ -95,22 +95,22 @@ consteval std::array<size_t, RelationImpl::SUBRELATION_PARTIAL_LENGTHS.size()> c
 /**
  * @brief Get the subrelation accumulators for the Protogalaxy combiner calculation.
  * @details A subrelation of degree D, when evaluated on polynomials of degree N, gives a polynomial of degree D
- * * N. In the context of Protogalaxy, N = NUM_INSTANCES-1. Hence, given a subrelation of length x, its
- * evaluation on such polynomials will have degree (x-1) * (NUM_INSTANCES-1), and the length of this evaluation
+ * * N. In the context of Protogalaxy, N = NUM_KEYS-1. Hence, given a subrelation of length x, its
+ * evaluation on such polynomials will have degree (x-1) * (NUM_KEYS-1), and the length of this evaluation
  * will be one greater than this.
- * @tparam NUM_INSTANCES
+ * @tparam NUM_KEYS
  * @tparam NUM_SUBRELATIONS
  * @param SUBRELATION_PARTIAL_LENGTHS The array of subrelation lengths supplied by a relation.
  * @return The transformed subrelation lenths
  */
-template <size_t NUM_INSTANCES, size_t NUM_SUBRELATIONS>
+template <size_t NUM_KEYS, size_t NUM_SUBRELATIONS>
 consteval std::array<size_t, NUM_SUBRELATIONS> compute_composed_subrelation_partial_lengths(
     std::array<size_t, NUM_SUBRELATIONS> SUBRELATION_PARTIAL_LENGTHS)
 {
     std::transform(SUBRELATION_PARTIAL_LENGTHS.begin(),
                    SUBRELATION_PARTIAL_LENGTHS.end(),
                    SUBRELATION_PARTIAL_LENGTHS.begin(),
-                   [](const size_t x) { return (x - 1) * (NUM_INSTANCES - 1) + 1; });
+                   [](const size_t x) { return (x - 1) * (NUM_KEYS - 1) + 1; });
     return SUBRELATION_PARTIAL_LENGTHS;
 };
 
@@ -177,15 +177,15 @@ template <typename RelationImpl> class Relation : public RelationImpl {
     static constexpr size_t ZK_TOTAL_RELATION_LENGTH =
         *std::max_element(ZK_PARTIAL_LENGTHS.begin(), ZK_PARTIAL_LENGTHS.end());
 
-    template <size_t NUM_INSTANCES>
+    template <size_t NUM_KEYS>
     using ProtogalaxyTupleOfUnivariatesOverSubrelationsNoOptimisticSkipping =
-        TupleOfUnivariates<FF, compute_composed_subrelation_partial_lengths<NUM_INSTANCES>(SUBRELATION_TOTAL_LENGTHS)>;
-    template <size_t NUM_INSTANCES>
+        TupleOfUnivariates<FF, compute_composed_subrelation_partial_lengths<NUM_KEYS>(SUBRELATION_TOTAL_LENGTHS)>;
+    template <size_t NUM_KEYS>
     using ProtogalaxyTupleOfUnivariatesOverSubrelations =
         TupleOfUnivariatesWithOptimisticSkipping<FF,
-                                                 compute_composed_subrelation_partial_lengths<NUM_INSTANCES>(
+                                                 compute_composed_subrelation_partial_lengths<NUM_KEYS>(
                                                      SUBRELATION_TOTAL_LENGTHS),
-                                                 NUM_INSTANCES - 1>;
+                                                 NUM_KEYS - 1>;
     using SumcheckTupleOfUnivariatesOverSubrelations =
         TupleOfUnivariates<FF, RelationImpl::SUBRELATION_PARTIAL_LENGTHS>;
     // The containter constructor for sumcheck univariates corresponding to each subrelation in ZK Flavor's relations

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/honk_key_gen.cpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/honk_key_gen.cpp
@@ -13,7 +13,7 @@
 
 using namespace bb;
 
-using ProverInstance = ProverInstance_<UltraKeccakFlavor>;
+using DeciderProvingKey = DeciderProvingKey_<UltraKeccakFlavor>;
 using VerificationKey = UltraKeccakFlavor::VerificationKey;
 
 template <template <typename> typename Circuit>
@@ -22,7 +22,7 @@ void generate_keys_honk(std::string output_path, std::string flavour_prefix, std
     uint256_t public_inputs[4] = { 0, 0, 0, 0 };
     UltraCircuitBuilder builder = Circuit<UltraCircuitBuilder>::generate(public_inputs);
 
-    auto instance = std::make_shared<ProverInstance>(builder);
+    auto instance = std::make_shared<DeciderProvingKey>(builder);
     UltraKeccakProver prover(instance);
     auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
 

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/honk_key_gen.cpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/honk_key_gen.cpp
@@ -22,9 +22,9 @@ void generate_keys_honk(std::string output_path, std::string flavour_prefix, std
     uint256_t public_inputs[4] = { 0, 0, 0, 0 };
     UltraCircuitBuilder builder = Circuit<UltraCircuitBuilder>::generate(public_inputs);
 
-    auto instance = std::make_shared<DeciderProvingKey>(builder);
-    UltraKeccakProver prover(instance);
-    auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
+    auto proving_key = std::make_shared<DeciderProvingKey>(builder);
+    UltraKeccakProver prover(proving_key);
+    auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
 
     // Make verification key file upper case
     circuit_name.at(0) = static_cast<char>(std::toupper(static_cast<unsigned char>(circuit_name.at(0))));

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/honk_proof_gen.cpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/honk_proof_gen.cpp
@@ -15,7 +15,7 @@
 using namespace bb;
 using numeric::uint256_t;
 
-using ProverInstance = ProverInstance_<UltraKeccakFlavor>;
+using DeciderProvingKey = DeciderProvingKey_<UltraKeccakFlavor>;
 using VerificationKey = UltraKeccakFlavor::VerificationKey;
 using Prover = UltraKeccakProver;
 using Verifier = UltraKeccakVerifier;
@@ -25,7 +25,7 @@ template <template <typename> typename Circuit> void generate_proof(uint256_t in
 
     UltraCircuitBuilder builder = Circuit<UltraCircuitBuilder>::generate(inputs);
 
-    auto instance = std::make_shared<ProverInstance>(builder);
+    auto instance = std::make_shared<DeciderProvingKey>(builder);
     Prover prover(instance);
     auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
     Verifier verifier(verification_key);

--- a/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.cpp
@@ -13,15 +13,15 @@ void ClientIVCRecursiveVerifier::verify(const ClientIVC::Proof& proof)
     // Construct stdlib accumulator, vkey and proof
     auto stdlib_verifier_accum =
         std::make_shared<RecursiveDeciderVerificationKey>(builder.get(), verifier_input.fold_input.accumulator);
-    auto stdlib_instance_vk =
-        std::make_shared<RecursiveVerificationKey>(builder.get(), verifier_input.fold_input.instance_vks[0]);
+    auto stdlib_decider_vk =
+        std::make_shared<RecursiveVerificationKey>(builder.get(), verifier_input.fold_input.decider_vks[0]);
     auto stdlib_proof = bb::convert_proof_to_witness(builder.get(), proof.folding_proof);
 
     // Perform recursive folding verification
-    FoldingVerifier folding_verifier{ builder.get(), stdlib_verifier_accum, { stdlib_instance_vk } };
+    FoldingVerifier folding_verifier{ builder.get(), stdlib_verifier_accum, { stdlib_decider_vk } };
     auto recursive_verifier_accumulator = folding_verifier.verify_folding_proof(stdlib_proof);
     auto native_verifier_acc =
-        std::make_shared<FoldVerifierInput::Instance>(recursive_verifier_accumulator->get_value());
+        std::make_shared<FoldVerifierInput::DeciderVK>(recursive_verifier_accumulator->get_value());
 
     // Perform recursive decider verification
     DeciderVerifier decider{ builder.get(), native_verifier_acc };

--- a/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.cpp
@@ -12,7 +12,7 @@ void ClientIVCRecursiveVerifier::verify(const ClientIVC::Proof& proof)
 {
     // Construct stdlib accumulator, vkey and proof
     auto stdlib_verifier_accum =
-        std::make_shared<RecursiveVerifierInstance>(builder.get(), verifier_input.fold_input.accumulator);
+        std::make_shared<RecursiveDeciderVerificationKey>(builder.get(), verifier_input.fold_input.accumulator);
     auto stdlib_instance_vk =
         std::make_shared<RecursiveVerificationKey>(builder.get(), verifier_input.fold_input.instance_vks[0]);
     auto stdlib_proof = bb::convert_proof_to_witness(builder.get(), proof.folding_proof);

--- a/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.hpp
@@ -8,7 +8,7 @@ class ClientIVCRecursiveVerifier {
     using Builder = UltraCircuitBuilder;                   // The circuit will be an Ultra circuit
     using RecursiveFlavor = MegaRecursiveFlavor_<Builder>; // The verifier algorithms are Mega
     using RecursiveDeciderVerificationKeys = RecursiveDeciderVerificationKeys_<RecursiveFlavor, 2>;
-    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::RecursiveDeciderVK;
+    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::DeciderVK;
     using RecursiveVerificationKey = RecursiveDeciderVerificationKeys::VerificationKey;
     using DeciderVerifier = DeciderRecursiveVerifier_<RecursiveFlavor>;
     using FoldingVerifier = ProtogalaxyRecursiveVerifier_<RecursiveDeciderVerificationKeys>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.hpp
@@ -8,7 +8,7 @@ class ClientIVCRecursiveVerifier {
     using Builder = UltraCircuitBuilder;                   // The circuit will be an Ultra circuit
     using RecursiveFlavor = MegaRecursiveFlavor_<Builder>; // The verifier algorithms are Mega
     using RecursiveDeciderVerificationKeys = RecursiveDeciderVerificationKeys_<RecursiveFlavor, 2>;
-    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::Instance;
+    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::RecursiveDeciderVK;
     using RecursiveVerificationKey = RecursiveDeciderVerificationKeys::VerificationKey;
     using DeciderVerifier = DeciderRecursiveVerifier_<RecursiveFlavor>;
     using FoldingVerifier = ProtogalaxyRecursiveVerifier_<RecursiveDeciderVerificationKeys>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.hpp
@@ -7,11 +7,11 @@ namespace bb::stdlib::recursion::honk {
 class ClientIVCRecursiveVerifier {
     using Builder = UltraCircuitBuilder;                   // The circuit will be an Ultra circuit
     using RecursiveFlavor = MegaRecursiveFlavor_<Builder>; // The verifier algorithms are Mega
-    using RecursiveVerifierInstances = RecursiveVerifierInstances_<RecursiveFlavor, 2>;
-    using RecursiveVerifierInstance = RecursiveVerifierInstances::Instance;
-    using RecursiveVerificationKey = RecursiveVerifierInstances::VerificationKey;
+    using RecursiveDeciderVerificationKeys = RecursiveDeciderVerificationKeys_<RecursiveFlavor, 2>;
+    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::Instance;
+    using RecursiveVerificationKey = RecursiveDeciderVerificationKeys::VerificationKey;
     using DeciderVerifier = DeciderRecursiveVerifier_<RecursiveFlavor>;
-    using FoldingVerifier = ProtogalaxyRecursiveVerifier_<RecursiveVerifierInstances>;
+    using FoldingVerifier = ProtogalaxyRecursiveVerifier_<RecursiveDeciderVerificationKeys>;
     using GoblinVerifier = GoblinRecursiveVerifier;
 
   public:

--- a/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.test.cpp
@@ -11,7 +11,7 @@ class ClientIVCRecursionTests : public testing::Test {
     using VerifierInput = ClientIVCVerifier::VerifierInput;
     using FoldVerifierInput = ClientIVCVerifier::FoldVerifierInput;
     using GoblinVerifierInput = ClientIVCVerifier::GoblinVerifierInput;
-    using DeciderVerificationKey = FoldVerifierInput::Instance;
+    using DeciderVerificationKey = FoldVerifierInput::DeciderVK;
     using ECCVMVK = GoblinVerifier::ECCVMVerificationKey;
     using TranslatorVK = GoblinVerifier::TranslatorVerificationKey;
     using Proof = ClientIVC::Proof;
@@ -47,7 +47,7 @@ class ClientIVCRecursionTests : public testing::Test {
         }
 
         Proof proof = ivc.prove();
-        FoldVerifierInput fold_verifier_input{ ivc.verifier_accumulator, { ivc.instance_vk } };
+        FoldVerifierInput fold_verifier_input{ ivc.verifier_accumulator, { ivc.decider_vk } };
         GoblinVerifierInput goblin_verifier_input{ std::make_shared<ECCVMVK>(ivc.goblin.get_eccvm_proving_key()),
                                                    std::make_shared<TranslatorVK>(
                                                        ivc.goblin.get_translator_proving_key()) };
@@ -67,7 +67,7 @@ TEST_F(ClientIVCRecursionTests, NativeVerification)
 
     // Construct the set of native verifier instances to be processed by the folding verifier
     std::vector<std::shared_ptr<DeciderVerificationKey>> instances{ verifier_input.fold_input.accumulator };
-    for (auto vk : verifier_input.fold_input.instance_vks) {
+    for (auto vk : verifier_input.fold_input.decider_vks) {
         instances.emplace_back(std::make_shared<DeciderVerificationKey>(vk));
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.test.cpp
@@ -11,7 +11,7 @@ class ClientIVCRecursionTests : public testing::Test {
     using VerifierInput = ClientIVCVerifier::VerifierInput;
     using FoldVerifierInput = ClientIVCVerifier::FoldVerifierInput;
     using GoblinVerifierInput = ClientIVCVerifier::GoblinVerifierInput;
-    using VerifierInstance = FoldVerifierInput::Instance;
+    using DeciderVerificationKey = FoldVerifierInput::Instance;
     using ECCVMVK = GoblinVerifier::ECCVMVerificationKey;
     using TranslatorVK = GoblinVerifier::TranslatorVerificationKey;
     using Proof = ClientIVC::Proof;
@@ -66,9 +66,9 @@ TEST_F(ClientIVCRecursionTests, NativeVerification)
     auto [proof, verifier_input] = construct_client_ivc_prover_output(ivc);
 
     // Construct the set of native verifier instances to be processed by the folding verifier
-    std::vector<std::shared_ptr<VerifierInstance>> instances{ verifier_input.fold_input.accumulator };
+    std::vector<std::shared_ptr<DeciderVerificationKey>> instances{ verifier_input.fold_input.accumulator };
     for (auto vk : verifier_input.fold_input.instance_vks) {
-        instances.emplace_back(std::make_shared<VerifierInstance>(vk));
+        instances.emplace_back(std::make_shared<DeciderVerificationKey>(vk));
     }
 
     // Confirm that the IVC proof can be natively verified
@@ -122,7 +122,7 @@ TEST_F(ClientIVCRecursionTests, ClientTubeBase)
     // EXPECT_TRUE(CircuitChecker::check(*tube_builder));
 
     // Construct and verify a proof for the ClientIVC Recursive Verifier circuit
-    auto inner_instance = std::make_shared<ProverInstance_<UltraFlavor>>(*tube_builder);
+    auto inner_instance = std::make_shared<DeciderProvingKey_<UltraFlavor>>(*tube_builder);
     UltraProver tube_prover{ inner_instance };
     auto native_tube_proof = tube_prover.construct_proof();
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.test.cpp
@@ -65,14 +65,14 @@ TEST_F(ClientIVCRecursionTests, NativeVerification)
     ClientIVC ivc;
     auto [proof, verifier_input] = construct_client_ivc_prover_output(ivc);
 
-    // Construct the set of native verifier instances to be processed by the folding verifier
-    std::vector<std::shared_ptr<DeciderVerificationKey>> instances{ verifier_input.fold_input.accumulator };
+    // Construct the set of native decider vks to be processed by the folding verifier
+    std::vector<std::shared_ptr<DeciderVerificationKey>> keys{ verifier_input.fold_input.accumulator };
     for (auto vk : verifier_input.fold_input.decider_vks) {
-        instances.emplace_back(std::make_shared<DeciderVerificationKey>(vk));
+        keys.emplace_back(std::make_shared<DeciderVerificationKey>(vk));
     }
 
     // Confirm that the IVC proof can be natively verified
-    EXPECT_TRUE(ivc.verify(proof, instances));
+    EXPECT_TRUE(ivc.verify(proof, keys));
 }
 
 /**
@@ -122,12 +122,12 @@ TEST_F(ClientIVCRecursionTests, ClientTubeBase)
     // EXPECT_TRUE(CircuitChecker::check(*tube_builder));
 
     // Construct and verify a proof for the ClientIVC Recursive Verifier circuit
-    auto inner_instance = std::make_shared<DeciderProvingKey_<UltraFlavor>>(*tube_builder);
-    UltraProver tube_prover{ inner_instance };
+    auto proving_key = std::make_shared<DeciderProvingKey_<UltraFlavor>>(*tube_builder);
+    UltraProver tube_prover{ proving_key };
     auto native_tube_proof = tube_prover.construct_proof();
 
     Builder base_builder;
-    auto native_vk = std::make_shared<NativeFlavor::VerificationKey>(inner_instance->proving_key);
+    auto native_vk = std::make_shared<NativeFlavor::VerificationKey>(proving_key->proving_key);
     auto vk = std::make_shared<Flavor::VerificationKey>(&base_builder, native_vk);
     auto tube_proof = bb::convert_proof_to_witness(&base_builder, native_tube_proof);
     UltraRecursiveVerifier base_verifier{ &base_builder, vk };

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
@@ -29,7 +29,7 @@ template <typename RecursiveFlavor> class ECCVMRecursiveTests : public ::testing
     using OuterFlavor = std::conditional_t<IsMegaBuilder<OuterBuilder>, MegaFlavor, UltraFlavor>;
     using OuterProver = UltraProver_<OuterFlavor>;
     using OuterVerifier = UltraVerifier_<OuterFlavor>;
-    using OuterProverInstance = ProverInstance_<OuterFlavor>;
+    using OuterDeciderProvingKey = DeciderProvingKey_<OuterFlavor>;
     static void SetUpTestSuite()
     {
         srs::init_grumpkin_crs_factory("../srs_db/grumpkin");
@@ -113,7 +113,7 @@ template <typename RecursiveFlavor> class ECCVMRecursiveTests : public ::testing
 
         // Construct a full proof from the recursive verifier circuit
         {
-            auto instance = std::make_shared<OuterProverInstance>(outer_circuit);
+            auto instance = std::make_shared<OuterDeciderProvingKey>(outer_circuit);
             OuterProver prover(instance);
             auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(instance->proving_key);
             OuterVerifier verifier(verification_key);

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
@@ -113,9 +113,9 @@ template <typename RecursiveFlavor> class ECCVMRecursiveTests : public ::testing
 
         // Construct a full proof from the recursive verifier circuit
         {
-            auto instance = std::make_shared<OuterDeciderProvingKey>(outer_circuit);
-            OuterProver prover(instance);
-            auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(instance->proving_key);
+            auto proving_key = std::make_shared<OuterDeciderProvingKey>(outer_circuit);
+            OuterProver prover(proving_key);
+            auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(proving_key->proving_key);
             OuterVerifier verifier(verification_key);
             auto proof = prover.construct_proof();
             bool verified = verifier.verify_proof(proof);

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursion.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursion.test.cpp
@@ -18,16 +18,16 @@ class GoblinRecursionTests : public ::testing::Test {
     using Curve = curve::BN254;
     using FF = Curve::ScalarField;
     using KernelInput = GoblinAccumulationOutput;
-    using ProverInstance = ProverInstance_<MegaFlavor>;
-    using VerifierInstance = VerifierInstance_<MegaFlavor>;
+    using DeciderProvingKey = DeciderProvingKey_<MegaFlavor>;
+    using DeciderVerificationKey = DeciderVerificationKey_<MegaFlavor>;
     using ECCVMVerificationKey = bb::ECCVMFlavor::VerificationKey;
     using TranslatorVerificationKey = bb::TranslatorFlavor::VerificationKey;
 
     static GoblinAccumulationOutput construct_accumulator(MegaCircuitBuilder& builder)
     {
-        auto prover_instance = std::make_shared<ProverInstance>(builder);
+        auto prover_instance = std::make_shared<DeciderProvingKey>(builder);
         auto verification_key = std::make_shared<MegaFlavor::VerificationKey>(prover_instance->proving_key);
-        auto verifier_instance = std::make_shared<VerifierInstance>(verification_key);
+        auto verifier_instance = std::make_shared<DeciderVerificationKey>(verification_key);
         MegaProver prover(prover_instance);
         auto ultra_proof = prover.construct_proof();
         return { ultra_proof, verifier_instance->verification_key };

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursion.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursion.test.cpp
@@ -25,12 +25,12 @@ class GoblinRecursionTests : public ::testing::Test {
 
     static GoblinAccumulationOutput construct_accumulator(MegaCircuitBuilder& builder)
     {
-        auto prover_instance = std::make_shared<DeciderProvingKey>(builder);
-        auto verification_key = std::make_shared<MegaFlavor::VerificationKey>(prover_instance->proving_key);
-        auto verifier_instance = std::make_shared<DeciderVerificationKey>(verification_key);
-        MegaProver prover(prover_instance);
+        auto proving_key = std::make_shared<DeciderProvingKey>(builder);
+        auto honk_verification_key = std::make_shared<MegaFlavor::VerificationKey>(proving_key->proving_key);
+        auto decider_verification_key = std::make_shared<DeciderVerificationKey>(honk_verification_key);
+        MegaProver prover(proving_key);
         auto ultra_proof = prover.construct_proof();
-        return { ultra_proof, verifier_instance->verification_key };
+        return { ultra_proof, decider_verification_key->verification_key };
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
@@ -15,7 +15,7 @@ class GoblinRecursiveVerifierTests : public testing::Test {
     using OuterFlavor = UltraFlavor;
     using OuterProver = UltraProver_<OuterFlavor>;
     using OuterVerifier = UltraVerifier_<OuterFlavor>;
-    using OuterProverInstance = ProverInstance_<OuterFlavor>;
+    using OuterDeciderProvingKey = DeciderProvingKey_<OuterFlavor>;
 
     static void SetUpTestSuite()
     {
@@ -92,7 +92,7 @@ TEST_F(GoblinRecursiveVerifierTests, Basic)
 
     // Construct and verify a proof for the Goblin Recursive Verifier circuit
     {
-        auto instance = std::make_shared<OuterProverInstance>(builder);
+        auto instance = std::make_shared<OuterDeciderProvingKey>(builder);
         OuterProver prover(instance);
         auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(instance->proving_key);
         OuterVerifier verifier(verification_key);

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
@@ -92,9 +92,9 @@ TEST_F(GoblinRecursiveVerifierTests, Basic)
 
     // Construct and verify a proof for the Goblin Recursive Verifier circuit
     {
-        auto instance = std::make_shared<OuterDeciderProvingKey>(builder);
-        OuterProver prover(instance);
-        auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(instance->proving_key);
+        auto proving_key = std::make_shared<OuterDeciderProvingKey>(builder);
+        OuterProver prover(proving_key);
+        auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(proving_key->proving_key);
         OuterVerifier verifier(verification_key);
         auto proof = prover.construct_proof();
         bool verified = verifier.verify_proof(proof);

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/merge_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/merge_verifier.test.cpp
@@ -24,7 +24,7 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
 
     // Define types relevant for inner circuit
     using InnerFlavor = MegaFlavor;
-    using InnerProverInstance = ProverInstance_<InnerFlavor>;
+    using InnerDeciderProvingKey = DeciderProvingKey_<InnerFlavor>;
     using InnerBuilder = typename InnerFlavor::CircuitBuilder;
 
     // Define additional types for testing purposes

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.cpp
@@ -6,8 +6,7 @@
 namespace bb::stdlib::recursion::honk {
 
 /**
- * @brief This function verifies an Ultra Honk proof for a given Flavor, produced for a relaxed instance (ϕ, \vec{β*},
- * e*).
+ * @brief Create a circuit used to prove that a Protogalaxy folding verification was executed.
  *
  */
 template <typename Flavor>

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.hpp
@@ -17,20 +17,20 @@ template <typename Flavor> class DeciderRecursiveVerifier_ {
     using Builder = typename Flavor::CircuitBuilder;
     using RelationSeparator = typename Flavor::RelationSeparator;
     using PairingPoints = std::array<GroupElement, 2>;
-    using Instance = RecursiveDeciderVerificationKey_<Flavor>;
+    using RecursiveDeciderVK = RecursiveDeciderVerificationKey_<Flavor>;
     using NativeInstance = bb::DeciderVerificationKey_<NativeFlavor>;
     using Transcript = bb::BaseTranscript<bb::stdlib::recursion::honk::StdlibTranscriptParams<Builder>>;
 
   public:
     explicit DeciderRecursiveVerifier_(Builder* builder, std::shared_ptr<NativeInstance> accumulator)
         : builder(builder)
-        , accumulator(std::make_shared<Instance>(builder, accumulator)){};
+        , accumulator(std::make_shared<RecursiveDeciderVK>(builder, accumulator)){};
 
     PairingPoints verify_proof(const HonkProof& proof);
 
     std::shared_ptr<VerifierCommitmentKey> pcs_verification_key;
     Builder* builder;
-    std::shared_ptr<Instance> accumulator;
+    std::shared_ptr<RecursiveDeciderVK> accumulator;
     std::shared_ptr<Transcript> transcript;
 };
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.hpp
@@ -18,11 +18,11 @@ template <typename Flavor> class DeciderRecursiveVerifier_ {
     using RelationSeparator = typename Flavor::RelationSeparator;
     using PairingPoints = std::array<GroupElement, 2>;
     using RecursiveDeciderVK = RecursiveDeciderVerificationKey_<Flavor>;
-    using NativeInstance = bb::DeciderVerificationKey_<NativeFlavor>;
+    using NativeDeciderVK = bb::DeciderVerificationKey_<NativeFlavor>;
     using Transcript = bb::BaseTranscript<bb::stdlib::recursion::honk::StdlibTranscriptParams<Builder>>;
 
   public:
-    explicit DeciderRecursiveVerifier_(Builder* builder, std::shared_ptr<NativeInstance> accumulator)
+    explicit DeciderRecursiveVerifier_(Builder* builder, std::shared_ptr<NativeDeciderVK> accumulator)
         : builder(builder)
         , accumulator(std::make_shared<RecursiveDeciderVK>(builder, accumulator)){};
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.hpp
@@ -17,8 +17,8 @@ template <typename Flavor> class DeciderRecursiveVerifier_ {
     using Builder = typename Flavor::CircuitBuilder;
     using RelationSeparator = typename Flavor::RelationSeparator;
     using PairingPoints = std::array<GroupElement, 2>;
-    using Instance = RecursiveVerifierInstance_<Flavor>;
-    using NativeInstance = bb::VerifierInstance_<NativeFlavor>;
+    using Instance = RecursiveDeciderVerificationKey_<Flavor>;
+    using NativeInstance = bb::DeciderVerificationKey_<NativeFlavor>;
     using Transcript = bb::BaseTranscript<bb::stdlib::recursion::honk::StdlibTranscriptParams<Builder>>;
 
   public:

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
@@ -9,7 +9,7 @@ namespace bb::stdlib::recursion::honk {
 
 template <typename Flavor>
 OinkRecursiveVerifier_<Flavor>::OinkRecursiveVerifier_(Builder* builder,
-                                                       const std::shared_ptr<Instance>& instance,
+                                                       const std::shared_ptr<RecursiveDeciderVK>& instance,
                                                        std::shared_ptr<Transcript> transcript,
                                                        std::string domain_separator)
     : instance(instance)
@@ -20,7 +20,7 @@ OinkRecursiveVerifier_<Flavor>::OinkRecursiveVerifier_(Builder* builder,
 
 template <typename Flavor>
 OinkRecursiveVerifier_<Flavor>::OinkRecursiveVerifier_(Builder* builder,
-                                                       const std::shared_ptr<Instance>& instance,
+                                                       const std::shared_ptr<RecursiveDeciderVK>& instance,
                                                        std::string domain_separator)
     : instance(instance)
     , builder(builder)

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
@@ -9,10 +9,10 @@ namespace bb::stdlib::recursion::honk {
 
 template <typename Flavor>
 OinkRecursiveVerifier_<Flavor>::OinkRecursiveVerifier_(Builder* builder,
-                                                       const std::shared_ptr<RecursiveDeciderVK>& instance,
+                                                       const std::shared_ptr<RecursiveDeciderVK>& verification_key,
                                                        std::shared_ptr<Transcript> transcript,
                                                        std::string domain_separator)
-    : instance(instance)
+    : verification_key(verification_key)
     , builder(builder)
     , transcript(transcript)
     , domain_separator(std::move(domain_separator))
@@ -20,9 +20,9 @@ OinkRecursiveVerifier_<Flavor>::OinkRecursiveVerifier_(Builder* builder,
 
 template <typename Flavor>
 OinkRecursiveVerifier_<Flavor>::OinkRecursiveVerifier_(Builder* builder,
-                                                       const std::shared_ptr<RecursiveDeciderVK>& instance,
+                                                       const std::shared_ptr<RecursiveDeciderVK>& verification_key,
                                                        std::string domain_separator)
-    : instance(instance)
+    : verification_key(verification_key)
     , builder(builder)
     , domain_separator(std::move(domain_separator))
 {}
@@ -51,7 +51,7 @@ template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
     // ASSERT(static_cast<uint32_t>(pub_inputs_offset.get_value()) == key->pub_inputs_offset);
 
     std::vector<FF> public_inputs;
-    for (size_t i = 0; i < instance->verification_key->num_public_inputs; ++i) {
+    for (size_t i = 0; i < verification_key->verification_key->num_public_inputs; ++i) {
         public_inputs.emplace_back(
             transcript->template receive_from_prover<FF>(domain_separator + "public_input_" + std::to_string(i)));
     }
@@ -99,7 +99,11 @@ template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
     }
 
     const FF public_input_delta = compute_public_input_delta<Flavor>(
-        public_inputs, beta, gamma, circuit_size, static_cast<uint32_t>(instance->verification_key->pub_inputs_offset));
+        public_inputs,
+        beta,
+        gamma,
+        circuit_size,
+        static_cast<uint32_t>(verification_key->verification_key->pub_inputs_offset));
 
     // Get commitment to permutation and lookup grand products
     commitments.z_perm = transcript->template receive_from_prover<Commitment>(domain_separator + labels.z_perm);
@@ -109,10 +113,11 @@ template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
         alphas[idx] = transcript->template get_challenge<FF>(domain_separator + "alpha_" + std::to_string(idx));
     }
 
-    instance->relation_parameters = RelationParameters<FF>{ eta, eta_two, eta_three, beta, gamma, public_input_delta };
-    instance->witness_commitments = std::move(commitments);
-    instance->public_inputs = std::move(public_inputs);
-    instance->alphas = std::move(alphas);
+    verification_key->relation_parameters =
+        RelationParameters<FF>{ eta, eta_two, eta_three, beta, gamma, public_input_delta };
+    verification_key->witness_commitments = std::move(commitments);
+    verification_key->public_inputs = std::move(public_inputs);
+    verification_key->alphas = std::move(alphas);
 }
 
 template class OinkRecursiveVerifier_<bb::UltraRecursiveFlavor_<UltraCircuitBuilder>>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.hpp
@@ -11,7 +11,7 @@ template <typename Flavor> class OinkRecursiveVerifier_ {
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
     using GroupElement = typename Flavor::GroupElement;
-    using Instance = RecursiveVerifierInstance_<Flavor>;
+    using Instance = RecursiveDeciderVerificationKey_<Flavor>;
     using VerificationKey = typename Flavor::VerificationKey;
     using Builder = typename Flavor::CircuitBuilder;
     using RelationSeparator = typename Flavor::RelationSeparator;

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.hpp
@@ -25,12 +25,12 @@ template <typename Flavor> class OinkRecursiveVerifier_ {
      * exists, e.g. Honk recursive verification.
      *
      * @param builder
-     * @param instance Incomplete verifier instance to be completed during verification
+     * @param verification_key Incomplete verifier verification_key to be completed during verification
      * @param transcript Transcript instantiated with an Oink proof (or a proof that contains an Oink proof).
-     * @param domain_separator string used for differentiating instances in the transcript (PG only)
+     * @param domain_separator string used for differentiating verification_keys in the transcript (PG only)
      */
     explicit OinkRecursiveVerifier_(Builder* builder,
-                                    const std::shared_ptr<RecursiveDeciderVK>& instance,
+                                    const std::shared_ptr<RecursiveDeciderVK>& verification_key,
                                     std::shared_ptr<Transcript> transcript,
                                     std::string domain_separator = "");
 
@@ -38,11 +38,11 @@ template <typename Flavor> class OinkRecursiveVerifier_ {
      * @brief Constructs an Oink Recursive Verifier
      *
      * @param builder
-     * @param instance Incomplete verifier instance to be completed during verification
-     * @param domain_separator string used for differentiating instances in the transcript (PG only)
+     * @param verification_key Incomplete verifier verification_key to be completed during verification
+     * @param domain_separator string used for differentiating verification_keys in the transcript (PG only)
      */
     explicit OinkRecursiveVerifier_(Builder* builder,
-                                    const std::shared_ptr<RecursiveDeciderVK>& instance,
+                                    const std::shared_ptr<RecursiveDeciderVK>& verification_key,
                                     std::string domain_separator = "");
 
     /**
@@ -57,10 +57,10 @@ template <typename Flavor> class OinkRecursiveVerifier_ {
      */
     void verify_proof(OinkProof& proof);
 
-    std::shared_ptr<RecursiveDeciderVK> instance;
+    std::shared_ptr<RecursiveDeciderVK> verification_key;
     Builder* builder;
     std::shared_ptr<Transcript> transcript;
-    std::string domain_separator; // used in PG to distinguish between instances in transcript
+    std::string domain_separator; // used in PG to distinguish between verification_keys in transcript
 };
 
 } // namespace bb::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.hpp
@@ -11,7 +11,7 @@ template <typename Flavor> class OinkRecursiveVerifier_ {
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
     using GroupElement = typename Flavor::GroupElement;
-    using Instance = RecursiveDeciderVerificationKey_<Flavor>;
+    using RecursiveDeciderVK = RecursiveDeciderVerificationKey_<Flavor>;
     using VerificationKey = typename Flavor::VerificationKey;
     using Builder = typename Flavor::CircuitBuilder;
     using RelationSeparator = typename Flavor::RelationSeparator;
@@ -30,7 +30,7 @@ template <typename Flavor> class OinkRecursiveVerifier_ {
      * @param domain_separator string used for differentiating instances in the transcript (PG only)
      */
     explicit OinkRecursiveVerifier_(Builder* builder,
-                                    const std::shared_ptr<Instance>& instance,
+                                    const std::shared_ptr<RecursiveDeciderVK>& instance,
                                     std::shared_ptr<Transcript> transcript,
                                     std::string domain_separator = "");
 
@@ -42,7 +42,7 @@ template <typename Flavor> class OinkRecursiveVerifier_ {
      * @param domain_separator string used for differentiating instances in the transcript (PG only)
      */
     explicit OinkRecursiveVerifier_(Builder* builder,
-                                    const std::shared_ptr<Instance>& instance,
+                                    const std::shared_ptr<RecursiveDeciderVK>& instance,
                                     std::string domain_separator = "");
 
     /**
@@ -57,7 +57,7 @@ template <typename Flavor> class OinkRecursiveVerifier_ {
      */
     void verify_proof(OinkProof& proof);
 
-    std::shared_ptr<Instance> instance;
+    std::shared_ptr<RecursiveDeciderVK> instance;
     Builder* builder;
     std::shared_ptr<Transcript> transcript;
     std::string domain_separator; // used in PG to distinguish between instances in transcript

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.cpp
@@ -47,11 +47,11 @@ UltraRecursiveVerifier_<Flavor>::AggregationObject UltraRecursiveVerifier_<Flavo
     using Transcript = typename Flavor::Transcript;
 
     transcript = std::make_shared<Transcript>(proof);
-    auto instance = std::make_shared<RecursiveDeciderVK>(builder, key);
-    OinkVerifier oink_verifier{ builder, instance, transcript };
+    auto verification_key = std::make_shared<RecursiveDeciderVK>(builder, key);
+    OinkVerifier oink_verifier{ builder, verification_key, transcript };
     oink_verifier.verify();
 
-    VerifierCommitments commitments{ key, instance->witness_commitments };
+    VerifierCommitments commitments{ key, verification_key->witness_commitments };
 
     auto gate_challenges = std::vector<FF>(CONST_PROOF_SIZE_LOG_N);
     for (size_t idx = 0; idx < CONST_PROOF_SIZE_LOG_N; idx++) {
@@ -67,7 +67,7 @@ UltraRecursiveVerifier_<Flavor>::AggregationObject UltraRecursiveVerifier_<Flavo
         for (size_t j = 0; j < 2; j++) {
             std::array<FF, 4> bigfield_limbs;
             for (size_t k = 0; k < 4; k++) {
-                bigfield_limbs[k] = instance->public_inputs[key->recursive_proof_public_input_indices[idx]];
+                bigfield_limbs[k] = verification_key->public_inputs[key->recursive_proof_public_input_indices[idx]];
                 idx++;
             }
             base_field_vals[j] =
@@ -89,7 +89,7 @@ UltraRecursiveVerifier_<Flavor>::AggregationObject UltraRecursiveVerifier_<Flavo
     auto sumcheck = Sumcheck(log_circuit_size, transcript);
 
     auto [multivariate_challenge, claimed_evaluations, sumcheck_verified] =
-        sumcheck.verify(instance->relation_parameters, instance->alphas, gate_challenges);
+        sumcheck.verify(verification_key->relation_parameters, verification_key->alphas, gate_challenges);
 
     // Execute ZeroMorph to produce an opening claim subsequently verified by a univariate PCS
     auto opening_claim = ZeroMorph::verify(key->circuit_size,

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.cpp
@@ -47,7 +47,7 @@ UltraRecursiveVerifier_<Flavor>::AggregationObject UltraRecursiveVerifier_<Flavo
     using Transcript = typename Flavor::Transcript;
 
     transcript = std::make_shared<Transcript>(proof);
-    auto instance = std::make_shared<Instance>(builder, key);
+    auto instance = std::make_shared<RecursiveDeciderVK>(builder, key);
     OinkVerifier oink_verifier{ builder, instance, transcript };
     oink_verifier.verify();
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.hpp
@@ -13,7 +13,7 @@ template <typename Flavor> class UltraRecursiveVerifier_ {
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
     using GroupElement = typename Flavor::GroupElement;
-    using Instance = RecursiveVerifierInstance_<Flavor>;
+    using Instance = RecursiveDeciderVerificationKey_<Flavor>;
     using VerificationKey = typename Flavor::VerificationKey;
     using NativeVerificationKey = typename Flavor::NativeVerificationKey;
     using VerifierCommitmentKey = typename Flavor::VerifierCommitmentKey;

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.hpp
@@ -13,7 +13,7 @@ template <typename Flavor> class UltraRecursiveVerifier_ {
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
     using GroupElement = typename Flavor::GroupElement;
-    using Instance = RecursiveDeciderVerificationKey_<Flavor>;
+    using RecursiveDeciderVK = RecursiveDeciderVerificationKey_<Flavor>;
     using VerificationKey = typename Flavor::VerificationKey;
     using NativeVerificationKey = typename Flavor::NativeVerificationKey;
     using VerifierCommitmentKey = typename Flavor::VerifierCommitmentKey;

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -234,7 +234,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         auto pcs_verification_key = std::make_shared<VerifierCommitmentKey>();
         bool result = pcs_verification_key->pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
         info("input pairing points result: ", result);
-        auto recursive_result = native_verifier.instance->verification_key->pcs_verification_key->pairing_check(
+        auto recursive_result = native_verifier.verification_key->verification_key->pcs_verification_key->pairing_check(
             pairing_points.P0.get_value(), pairing_points.P1.get_value());
         EXPECT_EQ(recursive_result, native_result);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -26,7 +26,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
     using InnerProver = UltraProver_<InnerFlavor>;
     using InnerVerifier = UltraVerifier_<InnerFlavor>;
     using InnerBuilder = typename InnerFlavor::CircuitBuilder;
-    using InnerProverInstance = ProverInstance_<InnerFlavor>;
+    using InnerDeciderProvingKey = DeciderProvingKey_<InnerFlavor>;
     using InnerCurve = bn254<InnerBuilder>;
     using InnerCommitment = InnerFlavor::Commitment;
     using InnerFF = InnerFlavor::FF;
@@ -36,7 +36,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
     using OuterFlavor = std::conditional_t<IsMegaBuilder<OuterBuilder>, MegaFlavor, UltraFlavor>;
     using OuterProver = UltraProver_<OuterFlavor>;
     using OuterVerifier = UltraVerifier_<OuterFlavor>;
-    using OuterProverInstance = ProverInstance_<OuterFlavor>;
+    using OuterDeciderProvingKey = DeciderProvingKey_<OuterFlavor>;
 
     using RecursiveVerifier = UltraRecursiveVerifier_<RecursiveFlavor>;
     using VerificationKey = typename RecursiveVerifier::VerificationKey;
@@ -102,7 +102,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         OuterBuilder outer_circuit;
 
         // Compute native verification key
-        auto instance = std::make_shared<InnerProverInstance>(inner_circuit);
+        auto instance = std::make_shared<InnerDeciderProvingKey>(inner_circuit);
         InnerProver prover(instance); // A prerequisite for computing VK
         auto verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(instance->proving_key);
         // Instantiate the recursive verifier using the native verification key
@@ -132,7 +132,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
             auto inner_circuit = create_inner_circuit(inner_size);
 
             // Generate a proof over the inner circuit
-            auto instance = std::make_shared<InnerProverInstance>(inner_circuit);
+            auto instance = std::make_shared<InnerDeciderProvingKey>(inner_circuit);
             InnerProver inner_prover(instance);
             info("test circuit size: ", instance->proving_key.circuit_size);
             auto verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(instance->proving_key);
@@ -145,7 +145,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
                 inner_proof,
                 init_default_aggregation_state<OuterBuilder, typename RecursiveFlavor::Curve>(outer_circuit));
 
-            auto outer_instance = std::make_shared<OuterProverInstance>(outer_circuit);
+            auto outer_instance = std::make_shared<OuterDeciderProvingKey>(outer_circuit);
             auto outer_verification_key =
                 std::make_shared<typename OuterFlavor::VerificationKey>(outer_instance->proving_key);
 
@@ -206,7 +206,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         auto inner_circuit = create_inner_circuit();
 
         // Generate a proof over the inner circuit
-        auto instance = std::make_shared<InnerProverInstance>(inner_circuit);
+        auto instance = std::make_shared<InnerDeciderProvingKey>(inner_circuit);
         InnerProver inner_prover(instance);
         auto verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(instance->proving_key);
         auto inner_proof = inner_prover.construct_proof();
@@ -248,7 +248,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
 
         // Check 3: Construct and verify a proof of the recursive verifier circuit
         if constexpr (!IsSimulator<OuterBuilder>) {
-            auto instance = std::make_shared<OuterProverInstance>(outer_circuit);
+            auto instance = std::make_shared<OuterDeciderProvingKey>(outer_circuit);
             OuterProver prover(instance);
             auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(instance->proving_key);
             OuterVerifier verifier(verification_key);
@@ -271,7 +271,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         auto inner_circuit = create_inner_circuit();
 
         // Generate a proof over the inner circuit
-        auto instance = std::make_shared<InnerProverInstance>(inner_circuit);
+        auto instance = std::make_shared<InnerDeciderProvingKey>(inner_circuit);
         InnerProver inner_prover(instance);
         auto inner_proof = inner_prover.construct_proof();
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -102,17 +102,17 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         OuterBuilder outer_circuit;
 
         // Compute native verification key
-        auto instance = std::make_shared<InnerDeciderProvingKey>(inner_circuit);
-        InnerProver prover(instance); // A prerequisite for computing VK
-        auto verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(instance->proving_key);
+        auto proving_key = std::make_shared<InnerDeciderProvingKey>(inner_circuit);
+        InnerProver prover(proving_key); // A prerequisite for computing VK
+        auto honk_vk = std::make_shared<typename InnerFlavor::VerificationKey>(proving_key->proving_key);
         // Instantiate the recursive verifier using the native verification key
-        RecursiveVerifier verifier{ &outer_circuit, verification_key };
+        RecursiveVerifier verifier{ &outer_circuit, honk_vk };
 
         // Spot check some values in the recursive VK to ensure it was constructed correctly
-        EXPECT_EQ(verifier.key->circuit_size, verification_key->circuit_size);
-        EXPECT_EQ(verifier.key->log_circuit_size, verification_key->log_circuit_size);
-        EXPECT_EQ(verifier.key->num_public_inputs, verification_key->num_public_inputs);
-        for (auto [vk_poly, native_vk_poly] : zip_view(verifier.key->get_all(), verification_key->get_all())) {
+        EXPECT_EQ(verifier.key->circuit_size, honk_vk->circuit_size);
+        EXPECT_EQ(verifier.key->log_circuit_size, honk_vk->log_circuit_size);
+        EXPECT_EQ(verifier.key->num_public_inputs, honk_vk->num_public_inputs);
+        for (auto [vk_poly, native_vk_poly] : zip_view(verifier.key->get_all(), honk_vk->get_all())) {
             EXPECT_EQ(vk_poly.get_value(), native_vk_poly);
         }
     }
@@ -132,10 +132,11 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
             auto inner_circuit = create_inner_circuit(inner_size);
 
             // Generate a proof over the inner circuit
-            auto instance = std::make_shared<InnerDeciderProvingKey>(inner_circuit);
-            InnerProver inner_prover(instance);
-            info("test circuit size: ", instance->proving_key.circuit_size);
-            auto verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(instance->proving_key);
+            auto inner_proving_key = std::make_shared<InnerDeciderProvingKey>(inner_circuit);
+            InnerProver inner_prover(inner_proving_key);
+            info("test circuit size: ", inner_proving_key->proving_key.circuit_size);
+            auto verification_key =
+                std::make_shared<typename InnerFlavor::VerificationKey>(inner_proving_key->proving_key);
             auto inner_proof = inner_prover.construct_proof();
 
             // Create a recursive verification circuit for the proof of the inner circuit
@@ -145,9 +146,9 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
                 inner_proof,
                 init_default_aggregation_state<OuterBuilder, typename RecursiveFlavor::Curve>(outer_circuit));
 
-            auto outer_instance = std::make_shared<OuterDeciderProvingKey>(outer_circuit);
+            auto outer_proving_key = std::make_shared<OuterDeciderProvingKey>(outer_circuit);
             auto outer_verification_key =
-                std::make_shared<typename OuterFlavor::VerificationKey>(outer_instance->proving_key);
+                std::make_shared<typename OuterFlavor::VerificationKey>(outer_proving_key->proving_key);
 
             return { outer_circuit.blocks, outer_verification_key };
         };
@@ -206,9 +207,9 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         auto inner_circuit = create_inner_circuit();
 
         // Generate a proof over the inner circuit
-        auto instance = std::make_shared<InnerDeciderProvingKey>(inner_circuit);
-        InnerProver inner_prover(instance);
-        auto verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(instance->proving_key);
+        auto proving_key = std::make_shared<InnerDeciderProvingKey>(inner_circuit);
+        InnerProver inner_prover(proving_key);
+        auto verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(proving_key->proving_key);
         auto inner_proof = inner_prover.construct_proof();
 
         // Create a recursive verification circuit for the proof of the inner circuit
@@ -248,9 +249,9 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
 
         // Check 3: Construct and verify a proof of the recursive verifier circuit
         if constexpr (!IsSimulator<OuterBuilder>) {
-            auto instance = std::make_shared<OuterDeciderProvingKey>(outer_circuit);
-            OuterProver prover(instance);
-            auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(instance->proving_key);
+            auto proving_key = std::make_shared<OuterDeciderProvingKey>(outer_circuit);
+            OuterProver prover(proving_key);
+            auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(proving_key->proving_key);
             OuterVerifier verifier(verification_key);
             auto proof = prover.construct_proof();
             bool verified = verifier.verify_proof(proof);
@@ -271,8 +272,8 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         auto inner_circuit = create_inner_circuit();
 
         // Generate a proof over the inner circuit
-        auto instance = std::make_shared<InnerDeciderProvingKey>(inner_circuit);
-        InnerProver inner_prover(instance);
+        auto proving_key = std::make_shared<InnerDeciderProvingKey>(inner_circuit);
+        InnerProver inner_prover(proving_key);
         auto inner_proof = inner_prover.construct_proof();
 
         // Arbitrarily tamper with the proof to be verified
@@ -282,7 +283,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         inner_proof = inner_prover.export_proof();
 
         // Generate the corresponding inner verification key
-        auto inner_verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(instance->proving_key);
+        auto inner_verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(proving_key->proving_key);
 
         // Create a recursive verification circuit for the proof of the inner circuit
         OuterBuilder outer_circuit;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
@@ -91,17 +91,17 @@ template <class Builder> class DataBusDepot {
      * perform two databus consistency checks: (1) that the return_data of app circuit A_{i} was secondary calldata to
      * K_{i}, and (2) that the return_data of K_{i-1} was calldata to K_{i}.
      *
-     * @param commitments Witness polynomial commitments for an instance that has been accumulated
-     * @param public_inputs The public inputs of that instance
-     * @param propagation_data Data about the presence of databus commitments on the public inputs of the instance
+     * @param commitments Witness polynomial commitments for an key that has been accumulated
+     * @param public_inputs The public inputs of that key
+     * @param propagation_data Data about the presence of databus commitments on the public inputs of the key.
      */
     void execute(const WitnessCommitments& commitments,
                  const std::vector<Fr>& public_inputs,
                  const DatabusPropagationData& propagation_data)
     {
-        // Flag indicating whether the input data corresponds to a kernel instance (else, an app instance). This is
-        // used to indicate whether the return data commitment being propagated belongs to a kernel or an app so that it
-        // can be checked against the appropriate calldata commitment in a subsequent round.
+        // Flag indicating whether the input data corresponds to a kernel decider proving key (else, an app decider
+        // proving key). This is used to indicate whether the return data commitment being propagated belongs to a
+        // kernel or an app so that it can be checked against the appropriate calldata commitment in a subsequent round.
         bool is_kernel_data = propagation_data.is_kernel;
 
         // Assert equality between return data commitments propagated via the public inputs and the corresponding

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
@@ -70,7 +70,8 @@ template <class Builder> class DataBusDepot {
     using Fq = typename Curve::BaseField;
 
     using RecursiveFlavor = MegaRecursiveFlavor_<Builder>;
-    using RecursiveVerifierInstances = bb::stdlib::recursion::honk::RecursiveVerifierInstances_<RecursiveFlavor, 2>;
+    using RecursiveDeciderVerificationKeys =
+        bb::stdlib::recursion::honk::RecursiveDeciderVerificationKeys_<RecursiveFlavor, 2>;
     using WitnessCommitments = RecursiveFlavor::WitnessCommitments;
 
     static constexpr size_t NUM_FR_LIMBS_PER_FQ = Fq::NUM_LIMBS;

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.hpp
@@ -9,15 +9,15 @@
 #include "barretenberg/stdlib_circuit_builders/ultra_recursive_flavor.hpp"
 
 namespace bb::stdlib::recursion::honk {
-template <class VerifierInstances> class ProtogalaxyRecursiveVerifier_ {
+template <class DeciderVerificationKeys> class ProtogalaxyRecursiveVerifier_ {
   public:
-    using Flavor = typename VerifierInstances::Flavor;
+    using Flavor = typename DeciderVerificationKeys::Flavor;
     using NativeFlavor = typename Flavor::NativeFlavor;
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
     using GroupElement = typename Flavor::GroupElement;
-    using Instance = typename VerifierInstances::Instance;
-    using NativeInstance = bb::VerifierInstance_<NativeFlavor>;
+    using Instance = typename DeciderVerificationKeys::Instance;
+    using NativeInstance = bb::DeciderVerificationKey_<NativeFlavor>;
     using VerificationKey = typename Flavor::VerificationKey;
     using NativeVerificationKey = typename Flavor::NativeVerificationKey;
     using WitnessCommitments = typename Flavor::WitnessCommitments;
@@ -25,7 +25,7 @@ template <class VerifierInstances> class ProtogalaxyRecursiveVerifier_ {
     using Builder = typename Flavor::CircuitBuilder;
     using RelationSeparator = typename Flavor::RelationSeparator;
     using PairingPoints = std::array<GroupElement, 2>;
-    static constexpr size_t NUM = VerifierInstances::NUM;
+    static constexpr size_t NUM = DeciderVerificationKeys::NUM;
     using Transcript = bb::BaseTranscript<bb::stdlib::recursion::honk::StdlibTranscriptParams<Builder>>;
     using OinkVerifier = OinkRecursiveVerifier_<Flavor>;
     struct VerifierInput {
@@ -41,13 +41,13 @@ template <class VerifierInstances> class ProtogalaxyRecursiveVerifier_ {
 
     Builder* builder;
     std::shared_ptr<Transcript> transcript;
-    VerifierInstances instances;
+    DeciderVerificationKeys instances;
 
     ProtogalaxyRecursiveVerifier_(Builder* builder,
                                   const std::shared_ptr<Instance>& accumulator,
                                   const std::vector<std::shared_ptr<VerificationKey>>& instance_vks)
         : builder(builder)
-        , instances(VerifierInstances(builder, accumulator, instance_vks)){};
+        , instances(DeciderVerificationKeys(builder, accumulator, instance_vks)){};
 
     /**
      * @brief Given a new round challenge δ for each iteration of the full Protogalaxy protocol, compute the vector
@@ -136,7 +136,7 @@ template <class VerifierInstances> class ProtogalaxyRecursiveVerifier_ {
      */
 
     void fold_commitments(std::vector<FF> lagranges,
-                          VerifierInstances& instances,
+                          DeciderVerificationKeys& instances,
                           std::shared_ptr<Instance>& accumulator)
     {
         size_t vk_idx = 0;

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
@@ -38,7 +38,7 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
 
     using RecursiveDeciderVerificationKeys =
         ::bb::stdlib::recursion::honk::RecursiveDeciderVerificationKeys_<RecursiveFlavor, 2>;
-    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::RecursiveDeciderVK;
+    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::DeciderVK;
     using RecursiveVerificationKey = RecursiveDeciderVerificationKeys::VerificationKey;
     using FoldingRecursiveVerifier = ProtogalaxyRecursiveVerifier_<RecursiveDeciderVerificationKeys>;
     using DeciderRecursiveVerifier = DeciderRecursiveVerifier_<RecursiveFlavor>;
@@ -117,14 +117,14 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         builder2.add_public_variable(FF(1));
         create_function_circuit(builder2);
 
-        auto prover_instance_1 = std::make_shared<InnerDeciderProvingKey>(builder1);
-        auto verification_key_1 = std::make_shared<InnerVerificationKey>(prover_instance_1->proving_key);
-        auto verifier_instance_1 = std::make_shared<InnerDeciderVerificationKey>(verification_key_1);
-        auto prover_instance_2 = std::make_shared<InnerDeciderProvingKey>(builder2);
-        auto verification_key_2 = std::make_shared<InnerVerificationKey>(prover_instance_2->proving_key);
-        auto verifier_instance_2 = std::make_shared<InnerDeciderVerificationKey>(verification_key_2);
-        InnerFoldingProver folding_prover({ prover_instance_1, prover_instance_2 });
-        InnerFoldingVerifier folding_verifier({ verifier_instance_1, verifier_instance_2 });
+        auto decider_pk_1 = std::make_shared<InnerDeciderProvingKey>(builder1);
+        auto honk_vk_1 = std::make_shared<InnerVerificationKey>(decider_pk_1->proving_key);
+        auto decider_vk_1 = std::make_shared<InnerDeciderVerificationKey>(honk_vk_1);
+        auto decider_pk_2 = std::make_shared<InnerDeciderProvingKey>(builder2);
+        auto honk_vk2 = std::make_shared<InnerVerificationKey>(decider_pk_2->proving_key);
+        auto decider_vk_2 = std::make_shared<InnerDeciderVerificationKey>(honk_vk2);
+        InnerFoldingProver folding_prover({ decider_pk_1, decider_pk_2 });
+        InnerFoldingVerifier folding_verifier({ decider_vk_1, decider_vk_2 });
 
         auto [prover_accumulator, folding_proof] = folding_prover.prove();
         auto verifier_accumulator = folding_verifier.verify_folding_proof(folding_proof);
@@ -184,35 +184,33 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         builder2.add_public_variable(FF(1));
         create_function_circuit(builder2);
 
-        auto prover_instance_1 = std::make_shared<InnerDeciderProvingKey>(builder1);
-        auto verification_key_1 = std::make_shared<InnerVerificationKey>(prover_instance_1->proving_key);
-        auto verifier_instance_1 = std::make_shared<InnerDeciderVerificationKey>(verification_key_1);
-        auto prover_instance_2 = std::make_shared<InnerDeciderProvingKey>(builder2);
-        auto verification_key_2 = std::make_shared<InnerVerificationKey>(prover_instance_2->proving_key);
-        auto verifier_instance_2 = std::make_shared<InnerDeciderVerificationKey>(verification_key_2);
+        auto decider_pk_1 = std::make_shared<InnerDeciderProvingKey>(builder1);
+        auto honk_vk_1 = std::make_shared<InnerVerificationKey>(decider_pk_1->proving_key);
+        auto decider_vk_1 = std::make_shared<InnerDeciderVerificationKey>(honk_vk_1);
+        auto decider_pk_2 = std::make_shared<InnerDeciderProvingKey>(builder2);
+        auto honk_vk_2 = std::make_shared<InnerVerificationKey>(decider_pk_2->proving_key);
+        auto decider_vk_2 = std::make_shared<InnerDeciderVerificationKey>(honk_vk_2);
         // Generate a folding proof
-        InnerFoldingProver folding_prover({ prover_instance_1, prover_instance_2 });
+        InnerFoldingProver folding_prover({ decider_pk_1, decider_pk_2 });
         auto folding_proof = folding_prover.prove();
 
-        // Create a recursive folding verifier circuit for the folding proof of the two instances
+        // Create a folding verifier circuit
         OuterBuilder folding_circuit;
 
-        auto recursive_verifier_instance_1 =
-            std::make_shared<RecursiveDeciderVerificationKey>(&folding_circuit, verifier_instance_1);
-        auto recursive_verification_key_2 =
-            std::make_shared<RecursiveVerificationKey>(&folding_circuit, verifier_instance_2->verification_key);
+        auto recursive_decider_vk_1 = std::make_shared<RecursiveDeciderVerificationKey>(&folding_circuit, decider_vk_1);
+        auto recursive_decider_vk_2 =
+            std::make_shared<RecursiveVerificationKey>(&folding_circuit, decider_vk_2->verification_key);
         StdlibProof<OuterBuilder> stdlib_proof = bb::convert_proof_to_witness(&folding_circuit, folding_proof.proof);
 
-        auto verifier = FoldingRecursiveVerifier{ &folding_circuit,
-                                                  recursive_verifier_instance_1,
-                                                  { recursive_verification_key_2 } };
+        auto verifier =
+            FoldingRecursiveVerifier{ &folding_circuit, recursive_decider_vk_1, { recursive_decider_vk_2 } };
         verifier.verify_folding_proof(stdlib_proof);
         info("Folding Recursive Verifier: num gates = ", folding_circuit.num_gates);
         EXPECT_EQ(folding_circuit.failed(), false) << folding_circuit.err();
 
         // Perform native folding verification and ensure it returns the same result (either true or false) as
         // calling check_circuit on the recursive folding verifier
-        InnerFoldingVerifier native_folding_verifier({ verifier_instance_1, verifier_instance_2 });
+        InnerFoldingVerifier native_folding_verifier({ decider_vk_1, decider_vk_2 });
         native_folding_verifier.verify_folding_proof(folding_proof.proof);
 
         // Ensure that the underlying native and recursive folding verification algorithms agree by ensuring the
@@ -228,10 +226,10 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         // Check for a failure flag in the recursive verifier circuit
 
         if constexpr (!IsSimulator<OuterBuilder>) {
-            auto instance = std::make_shared<OuterDeciderProvingKey>(folding_circuit);
-            OuterProver prover(instance);
-            auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(instance->proving_key);
-            OuterVerifier verifier(verification_key);
+            auto decider_pk = std::make_shared<OuterDeciderProvingKey>(folding_circuit);
+            OuterProver prover(decider_pk);
+            auto honk_vk = std::make_shared<typename OuterFlavor::VerificationKey>(decider_pk->proving_key);
+            OuterVerifier verifier(honk_vk);
             auto proof = prover.construct_proof();
             bool verified = verifier.verify_proof(proof);
 
@@ -245,7 +243,7 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
      * verifiers are identical by checking the manifests
      */
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/844): Fold the recursive folding verifier in
-    // tests once we can fold instances of different sizes.
+    // tests once we can fold keys of different sizes.
     static void test_full_protogalaxy_recursive()
     {
         // Create two arbitrary circuits for the first round of folding
@@ -256,27 +254,25 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
 
         create_function_circuit(builder2);
 
-        auto prover_instance_1 = std::make_shared<InnerDeciderProvingKey>(builder1);
-        auto verification_key_1 = std::make_shared<InnerVerificationKey>(prover_instance_1->proving_key);
-        auto verifier_instance_1 = std::make_shared<InnerDeciderVerificationKey>(verification_key_1);
-        auto prover_instance_2 = std::make_shared<InnerDeciderProvingKey>(builder2);
-        auto verification_key_2 = std::make_shared<InnerVerificationKey>(prover_instance_2->proving_key);
-        auto verifier_instance_2 = std::make_shared<InnerDeciderVerificationKey>(verification_key_2);
+        auto decider_pk_1 = std::make_shared<InnerDeciderProvingKey>(builder1);
+        auto honk_vk_1 = std::make_shared<InnerVerificationKey>(decider_pk_1->proving_key);
+        auto decider_vk_1 = std::make_shared<InnerDeciderVerificationKey>(honk_vk_1);
+        auto decider_pk_2 = std::make_shared<InnerDeciderProvingKey>(builder2);
+        auto honk_vk_2 = std::make_shared<InnerVerificationKey>(decider_pk_2->proving_key);
+        auto decider_vk_2 = std::make_shared<InnerDeciderVerificationKey>(honk_vk_2);
         // Generate a folding proof
-        InnerFoldingProver folding_prover({ prover_instance_1, prover_instance_2 });
+        InnerFoldingProver folding_prover({ decider_pk_1, decider_pk_2 });
         auto folding_proof = folding_prover.prove();
 
-        // Create a recursive folding verifier circuit for the folding proof of the two instances
+        // Create a folding verifier circuit
         OuterBuilder folding_circuit;
-        auto recursive_verifier_instance_1 =
-            std::make_shared<RecursiveDeciderVerificationKey>(&folding_circuit, verifier_instance_1);
-        auto recursive_verification_key_2 =
-            std::make_shared<RecursiveVerificationKey>(&folding_circuit, verifier_instance_2->verification_key);
+        auto recursive_decider_vk_1 = std::make_shared<RecursiveDeciderVerificationKey>(&folding_circuit, decider_vk_1);
+        auto recursive_decider_vk_2 =
+            std::make_shared<RecursiveVerificationKey>(&folding_circuit, decider_vk_2->verification_key);
         StdlibProof<OuterBuilder> stdlib_proof = bb::convert_proof_to_witness(&folding_circuit, folding_proof.proof);
 
-        auto verifier = FoldingRecursiveVerifier{ &folding_circuit,
-                                                  recursive_verifier_instance_1,
-                                                  { recursive_verification_key_2 } };
+        auto verifier =
+            FoldingRecursiveVerifier{ &folding_circuit, recursive_decider_vk_1, { recursive_decider_vk_2 } };
         auto recursive_verifier_accumulator = verifier.verify_folding_proof(stdlib_proof);
         auto native_verifier_acc =
             std::make_shared<InnerDeciderVerificationKey>(recursive_verifier_accumulator->get_value());
@@ -287,7 +283,7 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
 
         // Perform native folding verification and ensure it returns the same result (either true or false) as
         // calling check_circuit on the recursive folding verifier
-        InnerFoldingVerifier native_folding_verifier({ verifier_instance_1, verifier_instance_2 });
+        InnerFoldingVerifier native_folding_verifier({ decider_vk_1, decider_vk_2 });
         auto verifier_accumulator = native_folding_verifier.verify_folding_proof(folding_proof.proof);
 
         // Ensure that the underlying native and recursive folding verification algorithms agree by ensuring the
@@ -320,10 +316,10 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         EXPECT_EQ(native_result, recursive_result);
 
         if constexpr (!IsSimulator<OuterBuilder>) {
-            auto instance = std::make_shared<OuterDeciderProvingKey>(decider_circuit);
-            OuterProver prover(instance);
-            auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(instance->proving_key);
-            OuterVerifier verifier(verification_key);
+            auto decider_pk = std::make_shared<OuterDeciderProvingKey>(decider_circuit);
+            OuterProver prover(decider_pk);
+            auto honk_vk = std::make_shared<typename OuterFlavor::VerificationKey>(decider_pk->proving_key);
+            OuterVerifier verifier(honk_vk);
             auto proof = prover.construct_proof();
             bool verified = verifier.verify_proof(proof);
 
@@ -339,7 +335,7 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         // Tamper with the accumulator by changing the target sum
         verifier_accumulator->target_sum = FF::random_element();
 
-        // Create a decider proof for the relaxed instance obtained through folding
+        // Create a decider proof for accumulator obtained through folding
         InnerDeciderProver decider_prover(prover_accumulator);
         auto decider_proof = decider_prover.construct_proof();
 
@@ -372,18 +368,17 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         InnerFoldingProver folding_prover({ prover_accumulator, prover_inst });
         auto folding_proof = folding_prover.prove();
 
-        // Create a recursive folding verifier circuit for the folding proof of the two instances with the untampered
+        // Create a folding verifier circuit
         // commitments
         OuterBuilder folding_circuit;
-        auto recursive_verifier_instance_1 =
+        auto recursive_decider_vk_1 =
             std::make_shared<RecursiveDeciderVerificationKey>(&folding_circuit, verifier_accumulator);
-        auto recursive_verification_key_2 =
+        auto recursive_decider_vk_2 =
             std::make_shared<RecursiveVerificationKey>(&folding_circuit, verifier_inst->verification_key);
         StdlibProof<OuterBuilder> stdlib_proof = bb::convert_proof_to_witness(&folding_circuit, folding_proof.proof);
 
-        auto verifier = FoldingRecursiveVerifier{ &folding_circuit,
-                                                  recursive_verifier_instance_1,
-                                                  { recursive_verification_key_2 } };
+        auto verifier =
+            FoldingRecursiveVerifier{ &folding_circuit, recursive_decider_vk_1, { recursive_decider_vk_2 } };
         auto recursive_verifier_acc = verifier.verify_folding_proof(stdlib_proof);
 
         // Validate that the target sum between prover and verifier is now different

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
@@ -38,7 +38,7 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
 
     using RecursiveDeciderVerificationKeys =
         ::bb::stdlib::recursion::honk::RecursiveDeciderVerificationKeys_<RecursiveFlavor, 2>;
-    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::Instance;
+    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::RecursiveDeciderVK;
     using RecursiveVerificationKey = RecursiveDeciderVerificationKeys::VerificationKey;
     using FoldingRecursiveVerifier = ProtogalaxyRecursiveVerifier_<RecursiveDeciderVerificationKeys>;
     using DeciderRecursiveVerifier = DeciderRecursiveVerifier_<RecursiveFlavor>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_instances.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_instances.hpp
@@ -8,20 +8,20 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveDeciderVerific
     using Flavor = Flavor_;
     using Builder = typename Flavor::CircuitBuilder;
     using VerificationKey = typename Flavor::VerificationKey;
-    using RecursiveDeciderVK = RecursiveDeciderVerificationKey_<Flavor>;
-    using ArrayType = std::array<std::shared_ptr<RecursiveDeciderVK>, NUM_>;
+    using DeciderVK = RecursiveDeciderVerificationKey_<Flavor>;
+    using ArrayType = std::array<std::shared_ptr<DeciderVK>, NUM_>;
 
   public:
     static constexpr size_t NUM = NUM_;
     static constexpr size_t BATCHED_EXTENDED_LENGTH = (Flavor::MAX_TOTAL_RELATION_LENGTH - 1 + NUM - 1) * (NUM - 1) + 1;
     ArrayType _data;
-    std::shared_ptr<RecursiveDeciderVK> const& operator[](size_t idx) const { return _data[idx]; }
+    std::shared_ptr<DeciderVK> const& operator[](size_t idx) const { return _data[idx]; }
     typename ArrayType::iterator begin() { return _data.begin(); };
     typename ArrayType::iterator end() { return _data.end(); };
     Builder* builder;
 
     RecursiveDeciderVerificationKeys_(Builder* builder,
-                                      const std::shared_ptr<RecursiveDeciderVK>& accumulator,
+                                      const std::shared_ptr<DeciderVK>& accumulator,
                                       const std::vector<std::shared_ptr<VerificationKey>>& vks)
         : builder(builder)
     {
@@ -31,7 +31,7 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveDeciderVerific
 
         size_t idx = 1;
         for (auto& vk : vks) {
-            _data[idx] = std::make_shared<RecursiveDeciderVK>(builder, vk);
+            _data[idx] = std::make_shared<DeciderVK>(builder, vk);
             idx++;
         }
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_instances.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_instances.hpp
@@ -8,20 +8,20 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveDeciderVerific
     using Flavor = Flavor_;
     using Builder = typename Flavor::CircuitBuilder;
     using VerificationKey = typename Flavor::VerificationKey;
-    using Instance = RecursiveDeciderVerificationKey_<Flavor>;
-    using ArrayType = std::array<std::shared_ptr<Instance>, NUM_>;
+    using RecursiveDeciderVK = RecursiveDeciderVerificationKey_<Flavor>;
+    using ArrayType = std::array<std::shared_ptr<RecursiveDeciderVK>, NUM_>;
 
   public:
     static constexpr size_t NUM = NUM_;
     static constexpr size_t BATCHED_EXTENDED_LENGTH = (Flavor::MAX_TOTAL_RELATION_LENGTH - 1 + NUM - 1) * (NUM - 1) + 1;
     ArrayType _data;
-    std::shared_ptr<Instance> const& operator[](size_t idx) const { return _data[idx]; }
+    std::shared_ptr<RecursiveDeciderVK> const& operator[](size_t idx) const { return _data[idx]; }
     typename ArrayType::iterator begin() { return _data.begin(); };
     typename ArrayType::iterator end() { return _data.end(); };
     Builder* builder;
 
     RecursiveDeciderVerificationKeys_(Builder* builder,
-                                      const std::shared_ptr<Instance>& accumulator,
+                                      const std::shared_ptr<RecursiveDeciderVK>& accumulator,
                                       const std::vector<std::shared_ptr<VerificationKey>>& vks)
         : builder(builder)
     {
@@ -31,7 +31,7 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveDeciderVerific
 
         size_t idx = 1;
         for (auto& vk : vks) {
-            _data[idx] = std::make_shared<Instance>(builder, vk);
+            _data[idx] = std::make_shared<RecursiveDeciderVK>(builder, vk);
             idx++;
         }
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_instances.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_instances.hpp
@@ -4,11 +4,11 @@
 #include "barretenberg/stdlib/protogalaxy_verifier/recursive_verifier_instance.hpp"
 
 namespace bb::stdlib::recursion::honk {
-template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveVerifierInstances_ {
+template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveDeciderVerificationKeys_ {
     using Flavor = Flavor_;
     using Builder = typename Flavor::CircuitBuilder;
     using VerificationKey = typename Flavor::VerificationKey;
-    using Instance = RecursiveVerifierInstance_<Flavor>;
+    using Instance = RecursiveDeciderVerificationKey_<Flavor>;
     using ArrayType = std::array<std::shared_ptr<Instance>, NUM_>;
 
   public:
@@ -20,9 +20,9 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveVerifierInstan
     typename ArrayType::iterator end() { return _data.end(); };
     Builder* builder;
 
-    RecursiveVerifierInstances_(Builder* builder,
-                                const std::shared_ptr<Instance>& accumulator,
-                                const std::vector<std::shared_ptr<VerificationKey>>& vks)
+    RecursiveDeciderVerificationKeys_(Builder* builder,
+                                      const std::shared_ptr<Instance>& accumulator,
+                                      const std::vector<std::shared_ptr<VerificationKey>>& vks)
         : builder(builder)
     {
         ASSERT(vks.size() == NUM - 1);

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_verifier_instance.hpp
@@ -26,13 +26,13 @@ template <IsRecursiveFlavor Flavor> class RecursiveDeciderVerificationKey_ {
     Builder* builder;
 
     std::shared_ptr<VerificationKey> verification_key;
-    RelationParameters<FF> relation_parameters;
-    RelationSeparator alphas;
+
     bool is_accumulator = false;
     std::vector<FF> public_inputs;
-
-    // The folding parameters (\vec{β}, e) which are set for accumulators (i.e. relaxed instances).
+    RelationSeparator alphas; // a challenge for each subrelation
+    RelationParameters<FF> relation_parameters;
     std::vector<FF> gate_challenges;
+    // The target sum, which is typically nonzero for a ProtogalaxyProver's accmumulator
     FF target_sum;
 
     WitnessCommitments witness_commitments;
@@ -51,42 +51,42 @@ template <IsRecursiveFlavor Flavor> class RecursiveDeciderVerificationKey_ {
         , verification_key(vk)
     {}
 
-    RecursiveDeciderVerificationKey_(Builder* builder, const std::shared_ptr<DeciderVerificationKey>& instance)
-        : RecursiveDeciderVerificationKey_(builder, instance->verification_key)
+    RecursiveDeciderVerificationKey_(Builder* builder, const std::shared_ptr<DeciderVerificationKey>& verification_key)
+        : RecursiveDeciderVerificationKey_(builder, verification_key->verification_key)
     {
-        is_accumulator = instance->is_accumulator;
+        is_accumulator = verification_key->is_accumulator;
         if (is_accumulator) {
 
-            for (auto [native_public_input] : zip_view(instance->public_inputs)) {
+            for (auto [native_public_input] : zip_view(verification_key->public_inputs)) {
                 public_inputs.emplace_back(FF::from_witness(builder, native_public_input));
             }
             for (size_t alpha_idx = 0; alpha_idx < alphas.size(); alpha_idx++) {
-                alphas[alpha_idx] = FF::from_witness(builder, instance->alphas[alpha_idx]);
+                alphas[alpha_idx] = FF::from_witness(builder, verification_key->alphas[alpha_idx]);
             }
 
-            auto other_comms = instance->witness_commitments.get_all();
+            auto other_comms = verification_key->witness_commitments.get_all();
             size_t comm_idx = 0;
             for (auto& comm : witness_commitments.get_all()) {
                 comm = Commitment::from_witness(builder, other_comms[comm_idx]);
                 comm_idx++;
             }
-            target_sum = FF::from_witness(builder, instance->target_sum);
+            target_sum = FF::from_witness(builder, verification_key->target_sum);
 
             size_t challenge_idx = 0;
-            gate_challenges = std::vector<FF>(instance->gate_challenges.size());
+            gate_challenges = std::vector<FF>(verification_key->gate_challenges.size());
             for (auto& challenge : gate_challenges) {
-                challenge = FF::from_witness(builder, instance->gate_challenges[challenge_idx]);
+                challenge = FF::from_witness(builder, verification_key->gate_challenges[challenge_idx]);
                 challenge_idx++;
             }
-            relation_parameters.eta = FF::from_witness(builder, instance->relation_parameters.eta);
-            relation_parameters.eta_two = FF::from_witness(builder, instance->relation_parameters.eta_two);
-            relation_parameters.eta_three = FF::from_witness(builder, instance->relation_parameters.eta_three);
-            relation_parameters.beta = FF::from_witness(builder, instance->relation_parameters.beta);
-            relation_parameters.gamma = FF::from_witness(builder, instance->relation_parameters.gamma);
+            relation_parameters.eta = FF::from_witness(builder, verification_key->relation_parameters.eta);
+            relation_parameters.eta_two = FF::from_witness(builder, verification_key->relation_parameters.eta_two);
+            relation_parameters.eta_three = FF::from_witness(builder, verification_key->relation_parameters.eta_three);
+            relation_parameters.beta = FF::from_witness(builder, verification_key->relation_parameters.beta);
+            relation_parameters.gamma = FF::from_witness(builder, verification_key->relation_parameters.gamma);
             relation_parameters.public_input_delta =
-                FF::from_witness(builder, instance->relation_parameters.public_input_delta);
+                FF::from_witness(builder, verification_key->relation_parameters.public_input_delta);
             relation_parameters.lookup_grand_product_delta =
-                FF::from_witness(builder, instance->relation_parameters.lookup_grand_product_delta);
+                FF::from_witness(builder, verification_key->relation_parameters.lookup_grand_product_delta);
         }
     }
 
@@ -99,52 +99,52 @@ template <IsRecursiveFlavor Flavor> class RecursiveDeciderVerificationKey_ {
      */
     DeciderVerificationKey get_value()
     {
-        auto inst_verification_key = std::make_shared<NativeVerificationKey>(verification_key->circuit_size,
-                                                                             verification_key->num_public_inputs);
-        inst_verification_key->pcs_verification_key = verification_key->pcs_verification_key;
-        inst_verification_key->pub_inputs_offset = verification_key->pub_inputs_offset;
-        inst_verification_key->contains_recursive_proof = verification_key->contains_recursive_proof;
-        inst_verification_key->recursive_proof_public_input_indices =
-            verification_key->recursive_proof_public_input_indices;
+        auto native_honk_vk = std::make_shared<NativeVerificationKey>(verification_key->circuit_size,
+                                                                      verification_key->num_public_inputs);
+        native_honk_vk->pcs_verification_key = verification_key->pcs_verification_key;
+        native_honk_vk->pub_inputs_offset = verification_key->pub_inputs_offset;
+        native_honk_vk->contains_recursive_proof = verification_key->contains_recursive_proof;
+        native_honk_vk->recursive_proof_public_input_indices = verification_key->recursive_proof_public_input_indices;
         if constexpr (IsGoblinFlavor<Flavor>) {
-            inst_verification_key->databus_propagation_data = verification_key->databus_propagation_data;
+            native_honk_vk->databus_propagation_data = verification_key->databus_propagation_data;
         }
 
-        for (auto [vk, final_decider_vk] : zip_view(verification_key->get_all(), inst_verification_key->get_all())) {
+        for (auto [vk, final_decider_vk] : zip_view(verification_key->get_all(), native_honk_vk->get_all())) {
             final_decider_vk = vk.get_value();
         }
 
-        DeciderVerificationKey inst(inst_verification_key);
-        inst.is_accumulator = is_accumulator;
+        DeciderVerificationKey decider_vk(native_honk_vk);
+        decider_vk.is_accumulator = is_accumulator;
 
-        inst.public_inputs = std::vector<NativeFF>(static_cast<size_t>(verification_key->num_public_inputs));
-        for (auto [public_input, inst_public_input] : zip_view(public_inputs, inst.public_inputs)) {
+        decider_vk.public_inputs = std::vector<NativeFF>(static_cast<size_t>(verification_key->num_public_inputs));
+        for (auto [public_input, inst_public_input] : zip_view(public_inputs, decider_vk.public_inputs)) {
             inst_public_input = public_input.get_value();
         }
 
-        for (auto [alpha, inst_alpha] : zip_view(alphas, inst.alphas)) {
+        for (auto [alpha, inst_alpha] : zip_view(alphas, decider_vk.alphas)) {
             inst_alpha = alpha.get_value();
         }
 
-        for (auto [comm, inst_comm] : zip_view(witness_commitments.get_all(), inst.witness_commitments.get_all())) {
+        for (auto [comm, inst_comm] :
+             zip_view(witness_commitments.get_all(), decider_vk.witness_commitments.get_all())) {
             inst_comm = comm.get_value();
         }
-        inst.target_sum = target_sum.get_value();
+        decider_vk.target_sum = target_sum.get_value();
 
-        inst.gate_challenges = std::vector<NativeFF>(gate_challenges.size());
-        for (auto [challenge, inst_challenge] : zip_view(gate_challenges, inst.gate_challenges)) {
+        decider_vk.gate_challenges = std::vector<NativeFF>(gate_challenges.size());
+        for (auto [challenge, inst_challenge] : zip_view(gate_challenges, decider_vk.gate_challenges)) {
             inst_challenge = challenge.get_value();
         }
 
-        inst.relation_parameters.eta = relation_parameters.eta.get_value();
-        inst.relation_parameters.eta_two = relation_parameters.eta_two.get_value();
-        inst.relation_parameters.eta_three = relation_parameters.eta_three.get_value();
-        inst.relation_parameters.beta = relation_parameters.beta.get_value();
-        inst.relation_parameters.gamma = relation_parameters.gamma.get_value();
-        inst.relation_parameters.public_input_delta = relation_parameters.public_input_delta.get_value();
-        inst.relation_parameters.lookup_grand_product_delta =
+        decider_vk.relation_parameters.eta = relation_parameters.eta.get_value();
+        decider_vk.relation_parameters.eta_two = relation_parameters.eta_two.get_value();
+        decider_vk.relation_parameters.eta_three = relation_parameters.eta_three.get_value();
+        decider_vk.relation_parameters.beta = relation_parameters.beta.get_value();
+        decider_vk.relation_parameters.gamma = relation_parameters.gamma.get_value();
+        decider_vk.relation_parameters.public_input_delta = relation_parameters.public_input_delta.get_value();
+        decider_vk.relation_parameters.lookup_grand_product_delta =
             relation_parameters.lookup_grand_product_delta.get_value();
-        return inst;
+        return decider_vk;
     }
 };
 } // namespace bb::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_verifier_instance.hpp
@@ -110,8 +110,8 @@ template <IsRecursiveFlavor Flavor> class RecursiveDeciderVerificationKey_ {
             inst_verification_key->databus_propagation_data = verification_key->databus_propagation_data;
         }
 
-        for (auto [vk, inst_vk] : zip_view(verification_key->get_all(), inst_verification_key->get_all())) {
-            inst_vk = vk.get_value();
+        for (auto [vk, final_decider_vk] : zip_view(verification_key->get_all(), inst_verification_key->get_all())) {
+            final_decider_vk = vk.get_value();
         }
 
         DeciderVerificationKey inst(inst_verification_key);

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_verifier_instance.hpp
@@ -7,9 +7,9 @@
 namespace bb::stdlib::recursion::honk {
 
 /**
- * @brief The stdlib counterpart of VerifierInstance, used in recursive folding verification.
+ * @brief The stdlib counterpart of DeciderVerificationKey, used in recursive folding verification.
  */
-template <IsRecursiveFlavor Flavor> class RecursiveVerifierInstance_ {
+template <IsRecursiveFlavor Flavor> class RecursiveDeciderVerificationKey_ {
   public:
     using FF = typename Flavor::FF;
     using NativeFF = typename Flavor::Curve::ScalarFieldNative;
@@ -21,7 +21,7 @@ template <IsRecursiveFlavor Flavor> class RecursiveVerifierInstance_ {
     using RelationSeparator = typename Flavor::RelationSeparator;
     using Builder = typename Flavor::CircuitBuilder;
     using NativeFlavor = typename Flavor::NativeFlavor;
-    using VerifierInstance = bb::VerifierInstance_<NativeFlavor>;
+    using DeciderVerificationKey = bb::DeciderVerificationKey_<NativeFlavor>;
 
     Builder* builder;
 
@@ -38,21 +38,21 @@ template <IsRecursiveFlavor Flavor> class RecursiveVerifierInstance_ {
     WitnessCommitments witness_commitments;
     CommitmentLabels commitment_labels;
 
-    RecursiveVerifierInstance_(Builder* builder)
+    RecursiveDeciderVerificationKey_(Builder* builder)
         : builder(builder){};
 
-    RecursiveVerifierInstance_(Builder* builder, std::shared_ptr<NativeVerificationKey> vk)
+    RecursiveDeciderVerificationKey_(Builder* builder, std::shared_ptr<NativeVerificationKey> vk)
         : builder(builder)
         , verification_key(std::make_shared<VerificationKey>(builder, vk)){};
 
     // Constructor from stdlib vkey
-    RecursiveVerifierInstance_(Builder* builder, std::shared_ptr<VerificationKey> vk)
+    RecursiveDeciderVerificationKey_(Builder* builder, std::shared_ptr<VerificationKey> vk)
         : builder(builder)
         , verification_key(vk)
     {}
 
-    RecursiveVerifierInstance_(Builder* builder, const std::shared_ptr<VerifierInstance>& instance)
-        : RecursiveVerifierInstance_(builder, instance->verification_key)
+    RecursiveDeciderVerificationKey_(Builder* builder, const std::shared_ptr<DeciderVerificationKey>& instance)
+        : RecursiveDeciderVerificationKey_(builder, instance->verification_key)
     {
         is_accumulator = instance->is_accumulator;
         if (is_accumulator) {
@@ -91,13 +91,13 @@ template <IsRecursiveFlavor Flavor> class RecursiveVerifierInstance_ {
     }
 
     /**
-     * @brief Return the underlying native VerifierInstance.
+     * @brief Return the underlying native DeciderVerificationKey.
      *
      * @details In the context of client IVC, we will have several iterations of recursive folding verification. The
-     * RecursiveVerifierInstance is tied to the builder in whose context it was created so in order to preserve the
-     * accumulator values between several iterations we need to retrieve the native VerifierInstance values.
+     * RecursiveDeciderVerificationKey is tied to the builder in whose context it was created so in order to preserve
+     * the accumulator values between several iterations we need to retrieve the native DeciderVerificationKey values.
      */
-    VerifierInstance get_value()
+    DeciderVerificationKey get_value()
     {
         auto inst_verification_key = std::make_shared<NativeVerificationKey>(verification_key->circuit_size,
                                                                              verification_key->num_public_inputs);
@@ -114,7 +114,7 @@ template <IsRecursiveFlavor Flavor> class RecursiveVerifierInstance_ {
             inst_vk = vk.get_value();
         }
 
-        VerifierInstance inst(inst_verification_key);
+        DeciderVerificationKey inst(inst_verification_key);
         inst.is_accumulator = is_accumulator;
 
         inst.public_inputs = std::vector<NativeFF>(static_cast<size_t>(verification_key->num_public_inputs));

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
@@ -37,7 +37,7 @@ template <typename RecursiveFlavor> class TranslatorRecursiveTests : public ::te
     using OuterFlavor = std::conditional_t<IsMegaBuilder<OuterBuilder>, MegaFlavor, UltraFlavor>;
     using OuterProver = UltraProver_<OuterFlavor>;
     using OuterVerifier = UltraVerifier_<OuterFlavor>;
-    using OuterProverInstance = ProverInstance_<OuterFlavor>;
+    using OuterDeciderProvingKey = DeciderProvingKey_<OuterFlavor>;
 
     using Transcript = InnerFlavor::Transcript;
 
@@ -110,7 +110,7 @@ template <typename RecursiveFlavor> class TranslatorRecursiveTests : public ::te
         }
 
         if constexpr (!IsSimulator<OuterBuilder>) {
-            auto instance = std::make_shared<OuterProverInstance>(outer_circuit);
+            auto instance = std::make_shared<OuterDeciderProvingKey>(outer_circuit);
             OuterProver prover(instance);
             auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(instance->proving_key);
             OuterVerifier verifier(verification_key);

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
@@ -110,9 +110,9 @@ template <typename RecursiveFlavor> class TranslatorRecursiveTests : public ::te
         }
 
         if constexpr (!IsSimulator<OuterBuilder>) {
-            auto instance = std::make_shared<OuterDeciderProvingKey>(outer_circuit);
-            OuterProver prover(instance);
-            auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(instance->proving_key);
+            auto proving_key = std::make_shared<OuterDeciderProvingKey>(outer_circuit);
+            OuterProver prover(proving_key);
+            auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(proving_key->proving_key);
             OuterVerifier verifier(verification_key);
             auto proof = prover.construct_proof();
             bool verified = verifier.verify_proof(proof);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -84,14 +84,14 @@ class MegaFlavor {
     static constexpr size_t NUM_SUBRELATIONS = compute_number_of_subrelations<Relations>();
     using RelationSeparator = std::array<FF, NUM_SUBRELATIONS - 1>;
 
-    template <size_t NUM_INSTANCES>
+    template <size_t NUM_KEYS>
     using ProtogalaxyTupleOfTuplesOfUnivariatesNoOptimisticSkipping =
-        decltype(create_protogalaxy_tuple_of_tuples_of_univariates<Relations, NUM_INSTANCES>());
+        decltype(create_protogalaxy_tuple_of_tuples_of_univariates<Relations, NUM_KEYS>());
 
-    template <size_t NUM_INSTANCES>
+    template <size_t NUM_KEYS>
     using ProtogalaxyTupleOfTuplesOfUnivariates =
         decltype(create_protogalaxy_tuple_of_tuples_of_univariates<Relations,
-                                                                   NUM_INSTANCES,
+                                                                   NUM_KEYS,
                                                                    /*optimised=*/true>());
     using SumcheckTupleOfTuplesOfUnivariates = decltype(create_sumcheck_tuple_of_tuples_of_univariates<Relations>());
     using TupleOfArraysOfValues = decltype(create_tuple_of_arrays_of_values<Relations>());

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
@@ -83,13 +83,13 @@ class UltraFlavor {
     static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = MAX_PARTIAL_RELATION_LENGTH + 1;
     static constexpr size_t NUM_RELATIONS = std::tuple_size_v<Relations>;
 
-    template <size_t NUM_INSTANCES>
+    template <size_t NUM_KEYS>
     using ProtogalaxyTupleOfTuplesOfUnivariatesNoOptimisticSkipping =
-        decltype(create_protogalaxy_tuple_of_tuples_of_univariates<Relations, NUM_INSTANCES>());
-    template <size_t NUM_INSTANCES>
+        decltype(create_protogalaxy_tuple_of_tuples_of_univariates<Relations, NUM_KEYS>());
+    template <size_t NUM_KEYS>
     using ProtogalaxyTupleOfTuplesOfUnivariates =
         decltype(create_protogalaxy_tuple_of_tuples_of_univariates<Relations,
-                                                                   NUM_INSTANCES,
+                                                                   NUM_KEYS,
                                                                    /*optimised=*/true>());
     using SumcheckTupleOfTuplesOfUnivariates = decltype(create_sumcheck_tuple_of_tuples_of_univariates<Relations>());
     using TupleOfArraysOfValues = decltype(create_tuple_of_arrays_of_values<Relations>());

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_keccak.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_keccak.hpp
@@ -78,13 +78,13 @@ class UltraKeccakFlavor {
     static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = MAX_PARTIAL_RELATION_LENGTH + 1;
     static constexpr size_t NUM_RELATIONS = std::tuple_size_v<Relations>;
 
-    template <size_t NUM_INSTANCES>
+    template <size_t NUM_KEYS>
     using ProtogalaxyTupleOfTuplesOfUnivariatesNoOptimisticSkipping =
-        decltype(create_protogalaxy_tuple_of_tuples_of_univariates<Relations, NUM_INSTANCES>());
-    template <size_t NUM_INSTANCES>
+        decltype(create_protogalaxy_tuple_of_tuples_of_univariates<Relations, NUM_KEYS>());
+    template <size_t NUM_KEYS>
     using ProtogalaxyTupleOfTuplesOfUnivariates =
         decltype(create_protogalaxy_tuple_of_tuples_of_univariates<Relations,
-                                                                   NUM_INSTANCES,
+                                                                   NUM_KEYS,
                                                                    /*optimised=*/true>());
     using SumcheckTupleOfTuplesOfUnivariates = decltype(create_sumcheck_tuple_of_tuples_of_univariates<Relations>());
     using TupleOfArraysOfValues = decltype(create_tuple_of_arrays_of_values<Relations>());

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/instances.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/instances.hpp
@@ -4,14 +4,14 @@
 
 namespace bb {
 
-template <typename Flavor_, size_t NUM_ = 2> struct ProverInstances_ {
+template <typename Flavor_, size_t NUM_ = 2> struct DeciderProvingKeys_ {
   public:
     static_assert(NUM_ > 1, "Must have at least two prover instances");
     using Flavor = Flavor_;
     using FF = typename Flavor::FF;
     static constexpr size_t NUM = NUM_;
     static constexpr size_t NUM_SUBRELATIONS = Flavor::NUM_SUBRELATIONS;
-    using Instance = ProverInstance_<Flavor>;
+    using Instance = DeciderProvingKey_<Flavor>;
 
     using ArrayType = std::array<std::shared_ptr<Instance>, NUM_>;
     // The extended length here is the length of a composition of polynomials.
@@ -25,8 +25,8 @@ template <typename Flavor_, size_t NUM_ = 2> struct ProverInstances_ {
     typename ArrayType::iterator begin() { return _data.begin(); };
     typename ArrayType::const_iterator end() const { return _data.end(); };
     typename ArrayType::iterator end() { return _data.end(); };
-    ProverInstances_() = default;
-    ProverInstances_(std::vector<std::shared_ptr<Instance>> data)
+    DeciderProvingKeys_() = default;
+    DeciderProvingKeys_(std::vector<std::shared_ptr<Instance>> data)
     {
         ASSERT(data.size() == NUM);
         for (size_t idx = 0; idx < data.size(); idx++) {
@@ -83,11 +83,11 @@ template <typename Flavor_, size_t NUM_ = 2> struct ProverInstances_ {
     }
 };
 
-template <typename Flavor_, size_t NUM_ = 2> struct VerifierInstances_ {
+template <typename Flavor_, size_t NUM_ = 2> struct DeciderVerificationKeys_ {
     static_assert(NUM_ > 1, "Must have at least two prover instances");
     using Flavor = Flavor_;
     using VerificationKey = typename Flavor::VerificationKey;
-    using Instance = VerifierInstance_<Flavor>;
+    using Instance = DeciderVerificationKey_<Flavor>;
     using ArrayType = std::array<std::shared_ptr<Instance>, NUM_>;
 
   public:
@@ -97,9 +97,9 @@ template <typename Flavor_, size_t NUM_ = 2> struct VerifierInstances_ {
     std::shared_ptr<Instance> const& operator[](size_t idx) const { return _data[idx]; }
     typename ArrayType::iterator begin() { return _data.begin(); };
     typename ArrayType::iterator end() { return _data.end(); };
-    VerifierInstances_() = default;
+    DeciderVerificationKeys_() = default;
 
-    VerifierInstances_(const std::vector<std::shared_ptr<Instance>>& data)
+    DeciderVerificationKeys_(const std::vector<std::shared_ptr<Instance>>& data)
     {
         ASSERT(data.size() == NUM);
         for (size_t idx = 0; idx < data.size(); idx++) {

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/instances.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/instances.hpp
@@ -6,27 +6,27 @@ namespace bb {
 
 template <typename Flavor_, size_t NUM_ = 2> struct DeciderProvingKeys_ {
   public:
-    static_assert(NUM_ > 1, "Must have at least two prover instances");
+    static_assert(NUM_ > 1, "Must have at least two deicder proving keys.");
     using Flavor = Flavor_;
     using FF = typename Flavor::FF;
     static constexpr size_t NUM = NUM_;
     static constexpr size_t NUM_SUBRELATIONS = Flavor::NUM_SUBRELATIONS;
-    using Instance = DeciderProvingKey_<Flavor>;
+    using DeciderPK = DeciderProvingKey_<Flavor>;
 
-    using ArrayType = std::array<std::shared_ptr<Instance>, NUM_>;
+    using ArrayType = std::array<std::shared_ptr<DeciderPK>, NUM_>;
     // The extended length here is the length of a composition of polynomials.
     static constexpr size_t EXTENDED_LENGTH = (Flavor::MAX_TOTAL_RELATION_LENGTH - 1) * (NUM - 1) + 1;
     static constexpr size_t BATCHED_EXTENDED_LENGTH = (Flavor::MAX_TOTAL_RELATION_LENGTH - 1 + NUM - 1) * (NUM - 1) + 1;
 
     ArrayType _data; // we should not add any other data to this class
 
-    std::shared_ptr<Instance> const& operator[](size_t idx) const { return _data[idx]; }
+    std::shared_ptr<DeciderPK> const& operator[](size_t idx) const { return _data[idx]; }
     typename ArrayType::const_iterator begin() const { return _data.begin(); };
     typename ArrayType::iterator begin() { return _data.begin(); };
     typename ArrayType::const_iterator end() const { return _data.end(); };
     typename ArrayType::iterator end() { return _data.end(); };
     DeciderProvingKeys_() = default;
-    DeciderProvingKeys_(std::vector<std::shared_ptr<Instance>> data)
+    DeciderProvingKeys_(std::vector<std::shared_ptr<DeciderPK>> data)
     {
         ASSERT(data.size() == NUM);
         for (size_t idx = 0; idx < data.size(); idx++) {
@@ -36,11 +36,11 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderProvingKeys_ {
 
     /**
      * @brief For a fixed row index and each polynomial, construct univariates from the corresponding value
-     * from each instance.
+     * from each decider proving key.
      *
-     * @example if the row index is 2, and there are 4 instances visually we have
+     * @example if the row index is 2, and there are 4 decider proving keys, visually we have
      *
-     *           Instance 0       Instance 1       Instance 2       Instance 3
+     *           PK 0             PK 1             PK 2             PK 3
      *           q_c q_l q_r ...  q_c q_l q_r ...  q_c q_l q_r ...  q_c q_l q_r ...
      *           *   *            *   *            *   *            *   *
      *           *   *            *   *            *   *            *   *
@@ -55,26 +55,26 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderProvingKeys_ {
      */
     template <size_t skip_count = 0> auto row_to_univariates(size_t row_idx) const
     {
-        auto insts_prover_polynomials_views = get_polynomials_views();
-        std::array<Univariate<FF, NUM, 0, skip_count>, insts_prover_polynomials_views[0].size()> results;
+        auto prover_polynomials_views = get_polynomials_views();
+        std::array<Univariate<FF, NUM, 0, skip_count>, prover_polynomials_views[0].size()> results;
         // Set the size corresponding to the number of rows in the execution trace
-        size_t instance_idx = 0;
-        // Iterate over the prover polynomials' views corresponding to each instance
-        for (auto& get_all : insts_prover_polynomials_views) {
-            // Iterate over all columns in the trace execution of an instance and extract their value at row_idx.
+        size_t pk_idx = 0;
+        // Iterate over the prover polynomials' views corresponding to each proving key
+        for (auto& get_all : prover_polynomials_views) {
+            // Iterate over all columns in the trace execution of an proving key and extract their value at row_idx.
             for (auto [result, poly_ptr] : zip_view(results, get_all)) {
-                result.evaluations[instance_idx] = poly_ptr[row_idx];
+                result.evaluations[pk_idx] = poly_ptr[row_idx];
             }
-            instance_idx++;
+            pk_idx++;
         }
         return results;
     }
 
   private:
-    // Returns a vector containing pointer views to the prover polynomials corresponding to each instance.
+    // Returns a vector containing pointer views to the prover polynomials corresponding to each proving key.
     auto get_polynomials_views() const
     {
-        // As a practical measure, get the first instance's view to deduce the array type
+        // As a practical measure, get the first proving key's view to deduce the array type
         std::array<decltype(_data[0]->proving_key.polynomials.get_all()), NUM> views;
         for (size_t i = 0; i < NUM; i++) {
             views[i] = _data[i]->proving_key.polynomials.get_all();
@@ -84,22 +84,22 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderProvingKeys_ {
 };
 
 template <typename Flavor_, size_t NUM_ = 2> struct DeciderVerificationKeys_ {
-    static_assert(NUM_ > 1, "Must have at least two prover instances");
+    static_assert(NUM_ > 1, "Must have at least two decider verification keys.");
     using Flavor = Flavor_;
     using VerificationKey = typename Flavor::VerificationKey;
-    using Instance = DeciderVerificationKey_<Flavor>;
-    using ArrayType = std::array<std::shared_ptr<Instance>, NUM_>;
+    using DeciderVK = DeciderVerificationKey_<Flavor>;
+    using ArrayType = std::array<std::shared_ptr<DeciderVK>, NUM_>;
 
   public:
     static constexpr size_t NUM = NUM_;
     static constexpr size_t BATCHED_EXTENDED_LENGTH = (Flavor::MAX_TOTAL_RELATION_LENGTH - 1 + NUM - 1) * (NUM - 1) + 1;
     ArrayType _data;
-    std::shared_ptr<Instance> const& operator[](size_t idx) const { return _data[idx]; }
+    std::shared_ptr<DeciderVK> const& operator[](size_t idx) const { return _data[idx]; }
     typename ArrayType::iterator begin() { return _data.begin(); };
     typename ArrayType::iterator end() { return _data.end(); };
     DeciderVerificationKeys_() = default;
 
-    DeciderVerificationKeys_(const std::vector<std::shared_ptr<Instance>>& data)
+    DeciderVerificationKeys_(const std::vector<std::shared_ptr<DeciderVK>>& data)
     {
         ASSERT(data.size() == NUM);
         for (size_t idx = 0; idx < data.size(); idx++) {

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.cpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.cpp
@@ -10,7 +10,7 @@ namespace bb {
  * @tparam Flavor
  * @param circuit
  */
-template <class Flavor> size_t ProverInstance_<Flavor>::compute_dyadic_size(Circuit& circuit)
+template <class Flavor> size_t DeciderProvingKey_<Flavor>::compute_dyadic_size(Circuit& circuit)
 {
     // for the lookup argument the circuit size must be at least as large as the sum of all tables used
     const size_t min_size_due_to_lookups = circuit.get_tables_size();
@@ -38,7 +38,7 @@ template <class Flavor> size_t ProverInstance_<Flavor>::compute_dyadic_size(Circ
  * @param circuit
  */
 template <class Flavor>
-void ProverInstance_<Flavor>::construct_databus_polynomials(Circuit& circuit)
+void DeciderProvingKey_<Flavor>::construct_databus_polynomials(Circuit& circuit)
     requires IsGoblinFlavor<Flavor>
 {
     auto& public_calldata = proving_key.polynomials.calldata;
@@ -79,8 +79,8 @@ void ProverInstance_<Flavor>::construct_databus_polynomials(Circuit& circuit)
     }
 }
 
-template class ProverInstance_<UltraFlavor>;
-template class ProverInstance_<UltraKeccakFlavor>;
-template class ProverInstance_<MegaFlavor>;
+template class DeciderProvingKey_<UltraFlavor>;
+template class DeciderProvingKey_<UltraKeccakFlavor>;
+template class DeciderProvingKey_<MegaFlavor>;
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
@@ -12,15 +12,15 @@
 
 namespace bb {
 /**
- * @brief  A ProverInstance is normally constructed from a finalized circuit and it contains all the information
- * required by an Ultra Goblin Honk prover to create a proof. A ProverInstance is also the result of running the
+ * @brief  A DeciderProvingKey is normally constructed from a finalized circuit and it contains all the information
+ * required by an Ultra Goblin Honk prover to create a proof. A DeciderProvingKey is also the result of running the
  * Protogalaxy prover, in which case it becomes a relaxed counterpart with the folding parameters (target sum and gate
  * challenges set to non-zero values).
  *
  * @details This is the equivalent of ω in the paper.
  */
 
-template <class Flavor> class ProverInstance_ {
+template <class Flavor> class DeciderProvingKey_ {
     using Circuit = typename Flavor::CircuitBuilder;
     using ProvingKey = typename Flavor::ProvingKey;
     using VerificationKey = typename Flavor::VerificationKey;
@@ -43,11 +43,11 @@ template <class Flavor> class ProverInstance_ {
     std::vector<FF> gate_challenges;
     FF target_sum;
 
-    ProverInstance_(Circuit& circuit,
-                    TraceStructure trace_structure = TraceStructure::NONE,
-                    std::shared_ptr<typename Flavor::CommitmentKey> commitment_key = nullptr)
+    DeciderProvingKey_(Circuit& circuit,
+                       TraceStructure trace_structure = TraceStructure::NONE,
+                       std::shared_ptr<typename Flavor::CommitmentKey> commitment_key = nullptr)
     {
-        BB_OP_COUNT_TIME_NAME("ProverInstance(Circuit&)");
+        BB_OP_COUNT_TIME_NAME("DeciderProvingKey(Circuit&)");
         circuit.add_gates_to_ensure_all_polys_are_non_zero();
         circuit.finalize_circuit();
         info("finalized gate count: ", circuit.num_gates);
@@ -112,8 +112,8 @@ template <class Flavor> class ProverInstance_ {
         }
     }
 
-    ProverInstance_() = default;
-    ~ProverInstance_() = default;
+    DeciderProvingKey_() = default;
+    ~DeciderProvingKey_() = default;
 
   private:
     static constexpr size_t num_zero_rows = Flavor::has_zero_row ? 1 : 0;

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/prover_instance.hpp
@@ -34,13 +34,12 @@ template <class Flavor> class DeciderProvingKey_ {
 
   public:
     ProvingKey proving_key;
-    RelationSeparator alphas; // a challenge for each subrelation
-    bb::RelationParameters<FF> relation_parameters;
 
     bool is_accumulator = false;
-
-    // The folding parameters (\vec{β}, e) which are set for accumulators (i.e. relaxed instances).
+    RelationSeparator alphas; // a challenge for each subrelation
+    bb::RelationParameters<FF> relation_parameters;
     std::vector<FF> gate_challenges;
+    // The target sum, which is typically nonzero for a ProtogalaxyProver's accmumulator
     FF target_sum;
 
     DeciderProvingKey_(Circuit& circuit,

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/verifier_instance.hpp
@@ -5,13 +5,13 @@
 
 namespace bb {
 /**
- * @brief The VerifierInstance encapsulates all the necessary information for a Mega Honk Verifier to verify a
+ * @brief The DeciderVerificationKey encapsulates all the necessary information for a Mega Honk Verifier to verify a
  * proof (sumcheck + Zeromorph). In the context of folding, this is returned by the Protogalaxy verifier with non-zero
  * target sum and gate challenges.
  *
  * @details This is ϕ in the paper.
  */
-template <class Flavor, size_t NUM_ = 2> class VerifierInstance_ {
+template <class Flavor, size_t NUM_ = 2> class DeciderVerificationKey_ {
   public:
     using FF = typename Flavor::FF;
     using VerificationKey = typename Flavor::VerificationKey;
@@ -33,8 +33,8 @@ template <class Flavor, size_t NUM_ = 2> class VerifierInstance_ {
     WitnessCommitments witness_commitments;
     CommitmentLabels commitment_labels;
 
-    VerifierInstance_() = default;
-    VerifierInstance_(std::shared_ptr<VerificationKey> vk)
+    DeciderVerificationKey_() = default;
+    DeciderVerificationKey_(std::shared_ptr<VerificationKey> vk)
         : verification_key(std::move(vk))
     {}
 

--- a/barretenberg/cpp/src/barretenberg/sumcheck/instance/verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/instance/verifier_instance.hpp
@@ -21,13 +21,13 @@ template <class Flavor, size_t NUM_ = 2> class DeciderVerificationKey_ {
     using RelationSeparator = typename Flavor::RelationSeparator;
 
     std::shared_ptr<VerificationKey> verification_key;
-    RelationParameters<FF> relation_parameters;
-    RelationSeparator alphas;
+
     bool is_accumulator = false;
     std::vector<FF> public_inputs;
-
-    // The folding parameters (\vec{β}, e) which are set for accumulators (i.e. relaxed instances).
+    RelationSeparator alphas; // a challenge for each subrelation
+    RelationParameters<FF> relation_parameters;
     std::vector<FF> gate_challenges;
+    // The target sum, which is typically nonzero for a ProtogalaxyProver's accmumulator
     FF target_sum{ 0 };
 
     WitnessCommitments witness_commitments;

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -123,7 +123,7 @@ template <typename Flavor> class SumcheckProver {
     using ClaimedEvaluations = typename Flavor::AllValues;
 
     using Transcript = typename Flavor::Transcript;
-    using Instance = ProverInstance_<Flavor>;
+    using Instance = DeciderProvingKey_<Flavor>;
     using RelationSeparator = typename Flavor::RelationSeparator;
     /**
      * @brief The total algebraic degree of the Sumcheck relation \f$ F \f$ as a polynomial in Prover Polynomials

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -123,7 +123,7 @@ template <typename Flavor> class SumcheckProver {
     using ClaimedEvaluations = typename Flavor::AllValues;
 
     using Transcript = typename Flavor::Transcript;
-    using Instance = DeciderProvingKey_<Flavor>;
+    using DeciderPK = DeciderProvingKey_<Flavor>;
     using RelationSeparator = typename Flavor::RelationSeparator;
     /**
      * @brief The total algebraic degree of the Sumcheck relation \f$ F \f$ as a polynomial in Prover Polynomials
@@ -182,12 +182,9 @@ template <typename Flavor> class SumcheckProver {
      * @brief Compute round univariate, place it in transcript, compute challenge, partially evaluate. Repeat
      * until final round, then get full evaluations of prover polynomials, and place them in transcript.
      */
-    SumcheckOutput<Flavor> prove(std::shared_ptr<Instance> instance)
+    SumcheckOutput<Flavor> prove(std::shared_ptr<DeciderPK> key)
     {
-        return prove(instance->proving_key.polynomials,
-                     instance->relation_parameters,
-                     instance->alphas,
-                     instance->gate_challenges);
+        return prove(key->proving_key.polynomials, key->relation_parameters, key->alphas, key->gate_challenges);
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/databus.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/databus.test.cpp
@@ -28,7 +28,7 @@ class DataBusTests : public ::testing::Test {
     static bool construct_and_verify_proof(MegaCircuitBuilder& builder)
     {
         MegaProver prover{ builder };
-        auto verification_key = std::make_shared<MegaFlavor::VerificationKey>(prover.instance->proving_key);
+        auto verification_key = std::make_shared<MegaFlavor::VerificationKey>(prover.proving_key->proving_key);
         MegaVerifier verifier{ verification_key };
         auto proof = prover.construct_proof();
         return verifier.verify_proof(proof);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_prover.hpp
@@ -15,12 +15,11 @@ template <IsUltraFlavor Flavor> class DeciderProver_ {
     using Curve = typename Flavor::Curve;
     using Commitment = typename Flavor::Commitment;
     using CommitmentKey = typename Flavor::CommitmentKey;
-    using ProvingKey = typename Flavor::ProvingKey;
     using Polynomial = typename Flavor::Polynomial;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     using CommitmentLabels = typename Flavor::CommitmentLabels;
     using PCS = typename Flavor::PCS;
-    using Instance = ProverInstance_<Flavor>;
+    using Instance = DeciderProvingKey_<Flavor>;
     using Transcript = typename Flavor::Transcript;
     using RelationSeparator = typename Flavor::RelationSeparator;
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_prover.hpp
@@ -19,12 +19,12 @@ template <IsUltraFlavor Flavor> class DeciderProver_ {
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     using CommitmentLabels = typename Flavor::CommitmentLabels;
     using PCS = typename Flavor::PCS;
-    using Instance = DeciderProvingKey_<Flavor>;
+    using DeciderPK = DeciderProvingKey_<Flavor>;
     using Transcript = typename Flavor::Transcript;
     using RelationSeparator = typename Flavor::RelationSeparator;
 
   public:
-    explicit DeciderProver_(const std::shared_ptr<Instance>&,
+    explicit DeciderProver_(const std::shared_ptr<DeciderPK>&,
                             const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());
 
     BB_PROFILE void execute_relation_check_rounds();
@@ -33,7 +33,7 @@ template <IsUltraFlavor Flavor> class DeciderProver_ {
     HonkProof export_proof();
     HonkProof construct_proof();
 
-    std::shared_ptr<Instance> accumulator;
+    std::shared_ptr<DeciderPK> proving_key;
 
     std::shared_ptr<Transcript> transcript;
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.cpp
@@ -21,9 +21,7 @@ DeciderVerifier_<Flavor>::DeciderVerifier_(const std::shared_ptr<DeciderVerifica
 {}
 
 /**
- * @brief This function verifies a decider proof for a given Flavor, produced for a relaxed instance (ϕ, \vec{β*},
- * e*).
- *
+ * @brief Verify a decider proof relative to a decider verification key (ϕ, \vec{β*}, e*).
  */
 template <typename Flavor> bool DeciderVerifier_<Flavor>::verify_proof(const DeciderProof& proof)
 {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.cpp
@@ -7,7 +7,7 @@
 namespace bb {
 
 template <typename Flavor>
-DeciderVerifier_<Flavor>::DeciderVerifier_(const std::shared_ptr<VerifierInstance>& accumulator,
+DeciderVerifier_<Flavor>::DeciderVerifier_(const std::shared_ptr<DeciderVerificationKey>& accumulator,
                                            const std::shared_ptr<Transcript>& transcript)
     : accumulator(accumulator)
     , pcs_verification_key(accumulator->verification_key->pcs_verification_key)
@@ -15,7 +15,7 @@ DeciderVerifier_<Flavor>::DeciderVerifier_(const std::shared_ptr<VerifierInstanc
 {}
 
 template <typename Flavor>
-DeciderVerifier_<Flavor>::DeciderVerifier_(const std::shared_ptr<VerifierInstance>& accumulator)
+DeciderVerifier_<Flavor>::DeciderVerifier_(const std::shared_ptr<DeciderVerificationKey>& accumulator)
     : accumulator(accumulator)
     , pcs_verification_key(accumulator->verification_key->pcs_verification_key)
 {}

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.hpp
@@ -13,7 +13,7 @@ template <typename Flavor> class DeciderVerifier_ {
     using VerificationKey = typename Flavor::VerificationKey;
     using VerifierCommitmentKey = typename Flavor::VerifierCommitmentKey;
     using Transcript = typename Flavor::Transcript;
-    using VerifierInstance = VerifierInstance_<Flavor>;
+    using DeciderVerificationKey = DeciderVerificationKey_<Flavor>;
     using DeciderProof = std::vector<FF>;
 
   public:
@@ -24,19 +24,19 @@ template <typename Flavor> class DeciderVerifier_ {
      * when the decider is being used in the context of the larger honk protocol.
      *
      */
-    explicit DeciderVerifier_(const std::shared_ptr<VerifierInstance>& accumulator,
+    explicit DeciderVerifier_(const std::shared_ptr<DeciderVerificationKey>& accumulator,
                               const std::shared_ptr<Transcript>& transcript);
     /**
      * @brief Constructor from prover instance
      *
      */
-    explicit DeciderVerifier_(const std::shared_ptr<VerifierInstance>& accumulator);
+    explicit DeciderVerifier_(const std::shared_ptr<DeciderVerificationKey>& accumulator);
 
     bool verify_proof(const DeciderProof&); // used when a decider proof is known explicitly
     bool verify();                          // used when transcript that has been initialized with a proof
     std::shared_ptr<VerificationKey> key;
     std::map<std::string, Commitment> commitments;
-    std::shared_ptr<VerifierInstance> accumulator;
+    std::shared_ptr<DeciderVerificationKey> accumulator;
     std::shared_ptr<VerifierCommitmentKey> pcs_verification_key;
     std::shared_ptr<Transcript> transcript;
 };

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.hpp
@@ -19,18 +19,15 @@ template <typename Flavor> class DeciderVerifier_ {
   public:
     explicit DeciderVerifier_();
     /**
-     * @brief Constructor from prover instance and a transcript assumed to be initialized with a full honk proof
+     * @brief Constructor from a verification key and a transcript assumed to be initialized with a full Honk proof
      * @details Used in the case where an external transcript already exists and has been initialized with a proof, e.g.
-     * when the decider is being used in the context of the larger honk protocol.
+     * when the decider is being used in the context of the larger Honk protocol.
      *
      */
-    explicit DeciderVerifier_(const std::shared_ptr<DeciderVerificationKey>& accumulator,
+    explicit DeciderVerifier_(const std::shared_ptr<DeciderVerificationKey>& verification_key,
                               const std::shared_ptr<Transcript>& transcript);
-    /**
-     * @brief Constructor from prover instance
-     *
-     */
-    explicit DeciderVerifier_(const std::shared_ptr<DeciderVerificationKey>& accumulator);
+
+    explicit DeciderVerifier_(const std::shared_ptr<DeciderVerificationKey>& verification_key);
 
     bool verify_proof(const DeciderProof&); // used when a decider proof is known explicitly
     bool verify();                          // used when transcript that has been initialized with a proof

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_composer.test.cpp
@@ -33,9 +33,9 @@ class MegaHonkTests : public ::testing::Test {
      */
     bool construct_and_verify_honk_proof(auto& builder)
     {
-        auto instance = std::make_shared<DeciderProvingKey_<MegaFlavor>>(builder);
-        MegaProver prover(instance);
-        auto verification_key = std::make_shared<MegaFlavor::VerificationKey>(instance->proving_key);
+        auto proving_key = std::make_shared<DeciderProvingKey_<MegaFlavor>>(builder);
+        MegaProver prover(proving_key);
+        auto verification_key = std::make_shared<MegaFlavor::VerificationKey>(proving_key->proving_key);
         MegaVerifier verifier(verification_key);
         auto proof = prover.construct_proof();
         bool verified = verifier.verify_proof(proof);
@@ -87,9 +87,9 @@ TEST_F(MegaHonkTests, BasicStructured)
 
     // Construct and verify Honk proof using a structured trace
     TraceStructure trace_structure = TraceStructure::SMALL_TEST;
-    auto instance = std::make_shared<DeciderProvingKey_<MegaFlavor>>(builder, trace_structure);
-    MegaProver prover(instance);
-    auto verification_key = std::make_shared<MegaFlavor::VerificationKey>(instance->proving_key);
+    auto proving_key = std::make_shared<DeciderProvingKey_<MegaFlavor>>(builder, trace_structure);
+    MegaProver prover(proving_key);
+    auto verification_key = std::make_shared<MegaFlavor::VerificationKey>(proving_key->proving_key);
     MegaVerifier verifier(verification_key);
     auto proof = prover.construct_proof();
     EXPECT_TRUE(verifier.verify_proof(proof));

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_composer.test.cpp
@@ -33,7 +33,7 @@ class MegaHonkTests : public ::testing::Test {
      */
     bool construct_and_verify_honk_proof(auto& builder)
     {
-        auto instance = std::make_shared<ProverInstance_<MegaFlavor>>(builder);
+        auto instance = std::make_shared<DeciderProvingKey_<MegaFlavor>>(builder);
         MegaProver prover(instance);
         auto verification_key = std::make_shared<MegaFlavor::VerificationKey>(instance->proving_key);
         MegaVerifier verifier(verification_key);
@@ -87,7 +87,7 @@ TEST_F(MegaHonkTests, BasicStructured)
 
     // Construct and verify Honk proof using a structured trace
     TraceStructure trace_structure = TraceStructure::SMALL_TEST;
-    auto instance = std::make_shared<ProverInstance_<MegaFlavor>>(builder, trace_structure);
+    auto instance = std::make_shared<DeciderProvingKey_<MegaFlavor>>(builder, trace_structure);
     MegaProver prover(instance);
     auto verification_key = std::make_shared<MegaFlavor::VerificationKey>(instance->proving_key);
     MegaVerifier verifier(verification_key);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_transcript.test.cpp
@@ -156,8 +156,8 @@ TEST_F(MegaTranscriptTests, ProverManifestConsistency)
     generate_test_circuit(builder);
 
     // Automatically generate a transcript manifest by constructing a proof
-    auto instance = std::make_shared<DeciderProvingKey>(builder);
-    MegaProver prover(instance);
+    auto proving_key = std::make_shared<DeciderProvingKey>(builder);
+    MegaProver prover(proving_key);
     auto proof = prover.construct_proof();
 
     // Check that the prover generated manifest agrees with the manifest hard coded in this suite
@@ -187,12 +187,12 @@ TEST_F(MegaTranscriptTests, VerifierManifestConsistency)
     generate_test_circuit(builder);
 
     // Automatically generate a transcript manifest in the prover by constructing a proof
-    auto instance = std::make_shared<DeciderProvingKey>(builder);
-    MegaProver prover(instance);
+    auto proving_key = std::make_shared<DeciderProvingKey>(builder);
+    MegaProver prover(proving_key);
     auto proof = prover.construct_proof();
 
     // Automatically generate a transcript manifest in the verifier by verifying a proof
-    auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
+    auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
     MegaVerifier verifier(verification_key);
     verifier.verify_proof(proof);
 
@@ -242,10 +242,10 @@ TEST_F(MegaTranscriptTests, StructureTest)
     generate_test_circuit(builder);
 
     // Automatically generate a transcript manifest by constructing a proof
-    auto instance = std::make_shared<DeciderProvingKey>(builder);
-    MegaProver prover(instance);
+    auto proving_key = std::make_shared<DeciderProvingKey>(builder);
+    MegaProver prover(proving_key);
     auto proof = prover.construct_proof();
-    auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
+    auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
     MegaVerifier verifier(verification_key);
     EXPECT_TRUE(verifier.verify_proof(proof));
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_transcript.test.cpp
@@ -16,7 +16,7 @@ class MegaTranscriptTests : public ::testing::Test {
     static void SetUpTestSuite() { bb::srs::init_crs_factory("../srs_db/ignition"); }
 
     using Flavor = MegaFlavor;
-    using ProverInstance = ProverInstance_<Flavor>;
+    using DeciderProvingKey = DeciderProvingKey_<Flavor>;
     using FF = Flavor::FF;
     using VerificationKey = Flavor::VerificationKey;
 
@@ -156,7 +156,7 @@ TEST_F(MegaTranscriptTests, ProverManifestConsistency)
     generate_test_circuit(builder);
 
     // Automatically generate a transcript manifest by constructing a proof
-    auto instance = std::make_shared<ProverInstance>(builder);
+    auto instance = std::make_shared<DeciderProvingKey>(builder);
     MegaProver prover(instance);
     auto proof = prover.construct_proof();
 
@@ -187,7 +187,7 @@ TEST_F(MegaTranscriptTests, VerifierManifestConsistency)
     generate_test_circuit(builder);
 
     // Automatically generate a transcript manifest in the prover by constructing a proof
-    auto instance = std::make_shared<ProverInstance>(builder);
+    auto instance = std::make_shared<DeciderProvingKey>(builder);
     MegaProver prover(instance);
     auto proof = prover.construct_proof();
 
@@ -242,7 +242,7 @@ TEST_F(MegaTranscriptTests, StructureTest)
     generate_test_circuit(builder);
 
     // Automatically generate a transcript manifest by constructing a proof
-    auto instance = std::make_shared<ProverInstance>(builder);
+    auto instance = std::make_shared<DeciderProvingKey>(builder);
     MegaProver prover(instance);
     auto proof = prover.construct_proof();
     auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
@@ -36,12 +36,12 @@ namespace bb {
  */
 template <IsUltraFlavor Flavor> class OinkProver {
     using CommitmentKey = typename Flavor::CommitmentKey;
-    using Instance = DeciderProvingKey_<Flavor>;
+    using DeciderPK = DeciderProvingKey_<Flavor>;
     using Transcript = typename Flavor::Transcript;
     using FF = typename Flavor::FF;
 
   public:
-    std::shared_ptr<Instance> instance;
+    std::shared_ptr<DeciderPK> proving_key;
     std::shared_ptr<Transcript> transcript;
     std::shared_ptr<CommitmentKey> commitment_key;
     std::string domain_separator;
@@ -49,12 +49,12 @@ template <IsUltraFlavor Flavor> class OinkProver {
     typename Flavor::CommitmentLabels commitment_labels;
     using RelationSeparator = typename Flavor::RelationSeparator;
 
-    OinkProver(std::shared_ptr<Instance> instance,
+    OinkProver(std::shared_ptr<DeciderPK> proving_key,
                const std::shared_ptr<typename Flavor::Transcript>& transcript = std::make_shared<Transcript>(),
                std::string domain_separator = "")
-        : instance(instance)
+        : proving_key(proving_key)
         , transcript(transcript)
-        , commitment_key(this->instance->proving_key.commitment_key)
+        , commitment_key(this->proving_key->proving_key.commitment_key)
         , domain_separator(std::move(domain_separator))
     {}
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
@@ -36,7 +36,7 @@ namespace bb {
  */
 template <IsUltraFlavor Flavor> class OinkProver {
     using CommitmentKey = typename Flavor::CommitmentKey;
-    using Instance = ProverInstance_<Flavor>;
+    using Instance = DeciderProvingKey_<Flavor>;
     using Transcript = typename Flavor::Transcript;
     using FF = typename Flavor::FF;
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
@@ -18,10 +18,10 @@ template <IsUltraFlavor Flavor> void OinkVerifier<Flavor>::verify()
     execute_log_derivative_inverse_round();
     execute_grand_product_computation_round();
 
-    instance->witness_commitments = witness_comms;
-    instance->relation_parameters = relation_parameters;
-    instance->public_inputs = public_inputs;
-    instance->alphas = generate_alphas_round();
+    verification_key->witness_commitments = witness_comms;
+    verification_key->relation_parameters = relation_parameters;
+    verification_key->public_inputs = public_inputs;
+    verification_key->alphas = generate_alphas_round();
 }
 
 /**
@@ -37,13 +37,13 @@ template <IsUltraFlavor Flavor> void OinkVerifier<Flavor>::execute_preamble_roun
     const auto pub_inputs_offset =
         transcript->template receive_from_prover<uint32_t>(domain_separator + "pub_inputs_offset");
 
-    if (circuit_size != instance->verification_key->circuit_size) {
+    if (circuit_size != verification_key->verification_key->circuit_size) {
         throw_or_abort("OinkVerifier::execute_preamble_round: proof circuit size does not match verification key!");
     }
-    if (public_input_size != instance->verification_key->num_public_inputs) {
+    if (public_input_size != verification_key->verification_key->num_public_inputs) {
         throw_or_abort("OinkVerifier::execute_preamble_round: public inputs size does not match verification key!");
     }
-    if (pub_inputs_offset != instance->verification_key->pub_inputs_offset) {
+    if (pub_inputs_offset != verification_key->verification_key->pub_inputs_offset) {
         throw_or_abort("OinkVerifier::execute_preamble_round: public inputs offset does not match verification key!");
     }
 
@@ -135,8 +135,8 @@ template <IsUltraFlavor Flavor> void OinkVerifier<Flavor>::execute_grand_product
         compute_public_input_delta<Flavor>(public_inputs,
                                            relation_parameters.beta,
                                            relation_parameters.gamma,
-                                           instance->verification_key->circuit_size,
-                                           static_cast<size_t>(instance->verification_key->pub_inputs_offset));
+                                           verification_key->verification_key->circuit_size,
+                                           static_cast<size_t>(verification_key->verification_key->pub_inputs_offset));
 
     relation_parameters.public_input_delta = public_input_delta;
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.hpp
@@ -20,7 +20,7 @@ namespace bb {
  * @tparam Flavor
  */
 template <IsUltraFlavor Flavor> class OinkVerifier {
-    using Instance = VerifierInstance_<Flavor>;
+    using Instance = DeciderVerificationKey_<Flavor>;
     using WitnessCommitments = typename Flavor::WitnessCommitments;
     using Transcript = typename Flavor::Transcript;
     using FF = typename Flavor::FF;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.hpp
@@ -20,7 +20,7 @@ namespace bb {
  * @tparam Flavor
  */
 template <IsUltraFlavor Flavor> class OinkVerifier {
-    using Instance = DeciderVerificationKey_<Flavor>;
+    using DeciderVK = DeciderVerificationKey_<Flavor>;
     using WitnessCommitments = typename Flavor::WitnessCommitments;
     using Transcript = typename Flavor::Transcript;
     using FF = typename Flavor::FF;
@@ -29,18 +29,18 @@ template <IsUltraFlavor Flavor> class OinkVerifier {
 
   public:
     std::shared_ptr<Transcript> transcript;
-    std::shared_ptr<Instance> instance;
+    std::shared_ptr<DeciderVK> verification_key;
     std::string domain_separator;
     typename Flavor::CommitmentLabels comm_labels;
     bb::RelationParameters<FF> relation_parameters;
     WitnessCommitments witness_comms;
     std::vector<FF> public_inputs;
 
-    OinkVerifier(const std::shared_ptr<Instance>& instance,
+    OinkVerifier(const std::shared_ptr<DeciderVK>& verification_key,
                  const std::shared_ptr<Transcript>& transcript,
                  std::string domain_separator = "")
         : transcript(transcript)
-        , instance(instance)
+        , verification_key(verification_key)
         , domain_separator(std::move(domain_separator))
     {}
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/relation_correctness.test.cpp
@@ -261,22 +261,22 @@ TEST_F(UltraRelationCorrectnessTests, Ultra)
     create_some_RAM_gates<Flavor>(builder);
 
     // Create a prover (it will compute proving key and witness)
-    auto instance = std::make_shared<DeciderProvingKey_<Flavor>>(builder);
-    auto& proving_key = instance->proving_key;
+    auto decider_pk = std::make_shared<DeciderProvingKey_<Flavor>>(builder);
+    auto& proving_key = decider_pk->proving_key;
     auto circuit_size = proving_key.circuit_size;
 
     // Generate eta, beta and gamma
-    instance->relation_parameters.eta = FF::random_element();
-    instance->relation_parameters.eta_two = FF::random_element();
-    instance->relation_parameters.eta_three = FF::random_element();
-    instance->relation_parameters.beta = FF::random_element();
-    instance->relation_parameters.gamma = FF::random_element();
+    decider_pk->relation_parameters.eta = FF::random_element();
+    decider_pk->relation_parameters.eta_two = FF::random_element();
+    decider_pk->relation_parameters.eta_three = FF::random_element();
+    decider_pk->relation_parameters.beta = FF::random_element();
+    decider_pk->relation_parameters.gamma = FF::random_element();
 
-    instance->proving_key.add_ram_rom_memory_records_to_wire_4(instance->relation_parameters.eta,
-                                                               instance->relation_parameters.eta_two,
-                                                               instance->relation_parameters.eta_three);
-    instance->proving_key.compute_logderivative_inverses(instance->relation_parameters);
-    instance->proving_key.compute_grand_product_polynomials(instance->relation_parameters);
+    decider_pk->proving_key.add_ram_rom_memory_records_to_wire_4(decider_pk->relation_parameters.eta,
+                                                                 decider_pk->relation_parameters.eta_two,
+                                                                 decider_pk->relation_parameters.eta_three);
+    decider_pk->proving_key.compute_logderivative_inverses(decider_pk->relation_parameters);
+    decider_pk->proving_key.compute_grand_product_polynomials(decider_pk->relation_parameters);
 
     // Check that selectors are nonzero to ensure corresponding relation has nontrivial contribution
     ensure_non_zero(proving_key.polynomials.q_arith);
@@ -285,8 +285,8 @@ TEST_F(UltraRelationCorrectnessTests, Ultra)
     ensure_non_zero(proving_key.polynomials.q_elliptic);
     ensure_non_zero(proving_key.polynomials.q_aux);
 
-    auto& prover_polynomials = instance->proving_key.polynomials;
-    auto params = instance->relation_parameters;
+    auto& prover_polynomials = decider_pk->proving_key.polynomials;
+    auto params = decider_pk->relation_parameters;
     // Check that each relation is satisfied across each row of the prover polynomials
     check_relation<UltraArithmeticRelation<FF>>(circuit_size, prover_polynomials, params);
     check_relation<UltraPermutationRelation<FF>>(circuit_size, prover_polynomials, params);
@@ -314,22 +314,22 @@ TEST_F(UltraRelationCorrectnessTests, Mega)
     create_some_ecc_op_queue_gates<Flavor>(builder); // Goblin!
 
     // Create a prover (it will compute proving key and witness)
-    auto instance = std::make_shared<DeciderProvingKey_<Flavor>>(builder);
-    auto& proving_key = instance->proving_key;
+    auto decider_pk = std::make_shared<DeciderProvingKey_<Flavor>>(builder);
+    auto& proving_key = decider_pk->proving_key;
     auto circuit_size = proving_key.circuit_size;
 
     // Generate eta, beta and gamma
-    instance->relation_parameters.eta = FF::random_element();
-    instance->relation_parameters.eta_two = FF::random_element();
-    instance->relation_parameters.eta_three = FF::random_element();
-    instance->relation_parameters.beta = FF::random_element();
-    instance->relation_parameters.gamma = FF::random_element();
+    decider_pk->relation_parameters.eta = FF::random_element();
+    decider_pk->relation_parameters.eta_two = FF::random_element();
+    decider_pk->relation_parameters.eta_three = FF::random_element();
+    decider_pk->relation_parameters.beta = FF::random_element();
+    decider_pk->relation_parameters.gamma = FF::random_element();
 
-    instance->proving_key.add_ram_rom_memory_records_to_wire_4(instance->relation_parameters.eta,
-                                                               instance->relation_parameters.eta_two,
-                                                               instance->relation_parameters.eta_three);
-    instance->proving_key.compute_logderivative_inverses(instance->relation_parameters);
-    instance->proving_key.compute_grand_product_polynomials(instance->relation_parameters);
+    decider_pk->proving_key.add_ram_rom_memory_records_to_wire_4(decider_pk->relation_parameters.eta,
+                                                                 decider_pk->relation_parameters.eta_two,
+                                                                 decider_pk->relation_parameters.eta_three);
+    decider_pk->proving_key.compute_logderivative_inverses(decider_pk->relation_parameters);
+    decider_pk->proving_key.compute_grand_product_polynomials(decider_pk->relation_parameters);
 
     // Check that selectors are nonzero to ensure corresponding relation has nontrivial contribution
     ensure_non_zero(proving_key.polynomials.q_arith);
@@ -351,8 +351,8 @@ TEST_F(UltraRelationCorrectnessTests, Mega)
     ensure_non_zero(proving_key.polynomials.return_data_read_counts);
     ensure_non_zero(proving_key.polynomials.return_data_inverses);
 
-    auto& prover_polynomials = instance->proving_key.polynomials;
-    auto params = instance->relation_parameters;
+    auto& prover_polynomials = decider_pk->proving_key.polynomials;
+    auto params = decider_pk->relation_parameters;
 
     // Check that each relation is satisfied across each row of the prover polynomials
     check_relation<UltraArithmeticRelation<FF>>(circuit_size, prover_polynomials, params);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/relation_correctness.test.cpp
@@ -261,7 +261,7 @@ TEST_F(UltraRelationCorrectnessTests, Ultra)
     create_some_RAM_gates<Flavor>(builder);
 
     // Create a prover (it will compute proving key and witness)
-    auto instance = std::make_shared<ProverInstance_<Flavor>>(builder);
+    auto instance = std::make_shared<DeciderProvingKey_<Flavor>>(builder);
     auto& proving_key = instance->proving_key;
     auto circuit_size = proving_key.circuit_size;
 
@@ -314,7 +314,7 @@ TEST_F(UltraRelationCorrectnessTests, Mega)
     create_some_ecc_op_queue_gates<Flavor>(builder); // Goblin!
 
     // Create a prover (it will compute proving key and witness)
-    auto instance = std::make_shared<ProverInstance_<Flavor>>(builder);
+    auto instance = std::make_shared<DeciderProvingKey_<Flavor>>(builder);
     auto& proving_key = instance->proving_key;
     auto circuit_size = proving_key.circuit_size;
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/sumcheck.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/sumcheck.test.cpp
@@ -146,7 +146,7 @@ TEST_F(SumcheckTestsRealCircuit, Ultra)
         false);
 
     // Create a prover (it will compute proving key and witness)
-    auto instance = std::make_shared<ProverInstance_<Flavor>>(builder);
+    auto instance = std::make_shared<DeciderProvingKey_<Flavor>>(builder);
 
     // Generate eta, beta and gamma
     instance->relation_parameters.eta = FF::random_element();

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/sumcheck.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/sumcheck.test.cpp
@@ -146,24 +146,24 @@ TEST_F(SumcheckTestsRealCircuit, Ultra)
         false);
 
     // Create a prover (it will compute proving key and witness)
-    auto instance = std::make_shared<DeciderProvingKey_<Flavor>>(builder);
+    auto decider_pk = std::make_shared<DeciderProvingKey_<Flavor>>(builder);
 
     // Generate eta, beta and gamma
-    instance->relation_parameters.eta = FF::random_element();
-    instance->relation_parameters.eta = FF::random_element();
-    instance->relation_parameters.eta_two = FF::random_element();
-    instance->relation_parameters.eta_three = FF::random_element();
-    instance->relation_parameters.beta = FF::random_element();
-    instance->relation_parameters.gamma = FF::random_element();
+    decider_pk->relation_parameters.eta = FF::random_element();
+    decider_pk->relation_parameters.eta = FF::random_element();
+    decider_pk->relation_parameters.eta_two = FF::random_element();
+    decider_pk->relation_parameters.eta_three = FF::random_element();
+    decider_pk->relation_parameters.beta = FF::random_element();
+    decider_pk->relation_parameters.gamma = FF::random_element();
 
-    instance->proving_key.add_ram_rom_memory_records_to_wire_4(instance->relation_parameters.eta,
-                                                               instance->relation_parameters.eta_two,
-                                                               instance->relation_parameters.eta_three);
-    instance->proving_key.compute_logderivative_inverses(instance->relation_parameters);
-    instance->proving_key.compute_grand_product_polynomials(instance->relation_parameters);
+    decider_pk->proving_key.add_ram_rom_memory_records_to_wire_4(decider_pk->relation_parameters.eta,
+                                                                 decider_pk->relation_parameters.eta_two,
+                                                                 decider_pk->relation_parameters.eta_three);
+    decider_pk->proving_key.compute_logderivative_inverses(decider_pk->relation_parameters);
+    decider_pk->proving_key.compute_grand_product_polynomials(decider_pk->relation_parameters);
 
     auto prover_transcript = Transcript::prover_init_empty();
-    auto circuit_size = instance->proving_key.circuit_size;
+    auto circuit_size = decider_pk->proving_key.circuit_size;
     auto log_circuit_size = numeric::get_msb(circuit_size);
 
     RelationSeparator prover_alphas;
@@ -171,15 +171,15 @@ TEST_F(SumcheckTestsRealCircuit, Ultra)
         prover_alphas[idx] = prover_transcript->template get_challenge<FF>("Sumcheck:alpha_" + std::to_string(idx));
     }
 
-    instance->alphas = prover_alphas;
+    decider_pk->alphas = prover_alphas;
     auto sumcheck_prover = SumcheckProver<Flavor>(circuit_size, prover_transcript);
     std::vector<FF> prover_gate_challenges(log_circuit_size);
     for (size_t idx = 0; idx < log_circuit_size; idx++) {
         prover_gate_challenges[idx] =
             prover_transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
     }
-    instance->gate_challenges = prover_gate_challenges;
-    auto prover_output = sumcheck_prover.prove(instance);
+    decider_pk->gate_challenges = prover_gate_challenges;
+    auto prover_output = sumcheck_prover.prove(decider_pk);
 
     auto verifier_transcript = Transcript::verifier_init_empty(prover_transcript);
 
@@ -195,7 +195,7 @@ TEST_F(SumcheckTestsRealCircuit, Ultra)
             verifier_transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
     }
     auto verifier_output =
-        sumcheck_verifier.verify(instance->relation_parameters, verifier_alphas, verifier_gate_challenges);
+        sumcheck_verifier.verify(decider_pk->relation_parameters, verifier_alphas, verifier_gate_challenges);
 
     auto verified = verifier_output.verified.value();
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_honk.test.cpp
@@ -30,9 +30,9 @@ std::vector<uint32_t> add_variables(auto& circuit_builder, std::vector<bb::fr> v
 
 void prove_and_verify(auto& circuit_builder, bool expected_result)
 {
-    auto instance = std::make_shared<DeciderProvingKey>(circuit_builder);
-    UltraProver prover(instance);
-    auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
+    auto proving_key = std::make_shared<DeciderProvingKey>(circuit_builder);
+    UltraProver prover(proving_key);
+    auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
     UltraVerifier verifier(verification_key);
     auto proof = prover.construct_proof();
     bool verified = verifier.verify_proof(proof);
@@ -66,10 +66,10 @@ TEST_F(UltraHonkTests, ANonZeroPolynomialIsAGoodPolynomial)
 {
     auto circuit_builder = UltraCircuitBuilder();
 
-    auto instance = std::make_shared<DeciderProvingKey>(circuit_builder);
-    UltraProver prover(instance);
+    auto proving_key = std::make_shared<DeciderProvingKey>(circuit_builder);
+    UltraProver prover(proving_key);
     auto proof = prover.construct_proof();
-    auto& polynomials = instance->proving_key.polynomials;
+    auto& polynomials = proving_key->proving_key.polynomials;
 
     for (auto& poly : polynomials.get_selectors()) {
         ensure_non_zero(poly);
@@ -96,11 +96,11 @@ TEST_F(UltraHonkTests, StructuredTrace)
     // Add some arbitrary arithmetic gates that utilize public inputs
     MockCircuits::add_arithmetic_gates_with_public_inputs(builder, num_gates);
 
-    // Construct an instance with a structured execution trace
+    // Construct an proving_key with a structured execution trace
     TraceStructure trace_structure = TraceStructure::SMALL_TEST;
-    auto instance = std::make_shared<DeciderProvingKey>(builder, trace_structure);
-    UltraProver prover(instance);
-    auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
+    auto proving_key = std::make_shared<DeciderProvingKey>(builder, trace_structure);
+    UltraProver prover(proving_key);
+    auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
     UltraVerifier verifier(verification_key);
     auto proof = prover.construct_proof();
     EXPECT_TRUE(verifier.verify_proof(proof));
@@ -224,9 +224,9 @@ TEST_F(UltraHonkTests, LookupFailure)
         return builder;
     };
 
-    auto prove_and_verify = [](auto& instance) {
-        UltraProver prover(instance);
-        auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
+    auto prove_and_verify = [](auto& proving_key) {
+        UltraProver prover(proving_key);
+        auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
         UltraVerifier verifier(verification_key);
         auto proof = prover.construct_proof();
         return verifier.verify_proof(proof);
@@ -236,17 +236,17 @@ TEST_F(UltraHonkTests, LookupFailure)
     {
         auto builder = construct_circuit_with_lookups();
 
-        auto instance = std::make_shared<DeciderProvingKey>(builder);
+        auto proving_key = std::make_shared<DeciderProvingKey>(builder);
 
-        EXPECT_TRUE(prove_and_verify(instance));
+        EXPECT_TRUE(prove_and_verify(proving_key));
     }
 
     // Failure mode 1: bad read counts/tags
     {
         auto builder = construct_circuit_with_lookups();
 
-        auto instance = std::make_shared<DeciderProvingKey>(builder);
-        auto& polynomials = instance->proving_key.polynomials;
+        auto proving_key = std::make_shared<DeciderProvingKey>(builder);
+        auto& polynomials = proving_key->proving_key.polynomials;
 
         // Erroneously update the read counts/tags at an arbitrary index
         // Note: updating only one or the other may not cause failure due to the design of the relation algebra. For
@@ -256,15 +256,15 @@ TEST_F(UltraHonkTests, LookupFailure)
         polynomials.lookup_read_counts[25] = 1;
         polynomials.lookup_read_tags[25] = 1;
 
-        EXPECT_FALSE(prove_and_verify(instance));
+        EXPECT_FALSE(prove_and_verify(proving_key));
     }
 
     // Failure mode 2: bad lookup gate wire value
     {
         auto builder = construct_circuit_with_lookups();
 
-        auto instance = std::make_shared<DeciderProvingKey>(builder);
-        auto& polynomials = instance->proving_key.polynomials;
+        auto proving_key = std::make_shared<DeciderProvingKey>(builder);
+        auto& polynomials = proving_key->proving_key.polynomials;
 
         // Find a lookup gate and alter one of the wire values
         for (auto [q_lookup, wire_3] : zip_view(polynomials.q_lookup, polynomials.w_o)) {
@@ -274,21 +274,21 @@ TEST_F(UltraHonkTests, LookupFailure)
             }
         }
 
-        EXPECT_FALSE(prove_and_verify(instance));
+        EXPECT_FALSE(prove_and_verify(proving_key));
     }
 
     // Failure mode 3: erroneous lookup gate
     {
         auto builder = construct_circuit_with_lookups();
 
-        auto instance = std::make_shared<DeciderProvingKey>(builder);
-        auto& polynomials = instance->proving_key.polynomials;
+        auto proving_key = std::make_shared<DeciderProvingKey>(builder);
+        auto& polynomials = proving_key->proving_key.polynomials;
 
         // Turn the lookup selector on for an arbitrary row where it is not already active
         EXPECT_TRUE(polynomials.q_lookup[25] != 1);
         polynomials.q_lookup[25] = 1;
 
-        EXPECT_FALSE(prove_and_verify(instance));
+        EXPECT_FALSE(prove_and_verify(proving_key));
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_honk.test.cpp
@@ -16,7 +16,7 @@
 
 using namespace bb;
 
-using ProverInstance = ProverInstance_<UltraFlavor>;
+using DeciderProvingKey = DeciderProvingKey_<UltraFlavor>;
 using VerificationKey = UltraFlavor::VerificationKey;
 
 std::vector<uint32_t> add_variables(auto& circuit_builder, std::vector<bb::fr> variables)
@@ -30,7 +30,7 @@ std::vector<uint32_t> add_variables(auto& circuit_builder, std::vector<bb::fr> v
 
 void prove_and_verify(auto& circuit_builder, bool expected_result)
 {
-    auto instance = std::make_shared<ProverInstance>(circuit_builder);
+    auto instance = std::make_shared<DeciderProvingKey>(circuit_builder);
     UltraProver prover(instance);
     auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
     UltraVerifier verifier(verification_key);
@@ -66,7 +66,7 @@ TEST_F(UltraHonkTests, ANonZeroPolynomialIsAGoodPolynomial)
 {
     auto circuit_builder = UltraCircuitBuilder();
 
-    auto instance = std::make_shared<ProverInstance>(circuit_builder);
+    auto instance = std::make_shared<DeciderProvingKey>(circuit_builder);
     UltraProver prover(instance);
     auto proof = prover.construct_proof();
     auto& polynomials = instance->proving_key.polynomials;
@@ -98,7 +98,7 @@ TEST_F(UltraHonkTests, StructuredTrace)
 
     // Construct an instance with a structured execution trace
     TraceStructure trace_structure = TraceStructure::SMALL_TEST;
-    auto instance = std::make_shared<ProverInstance>(builder, trace_structure);
+    auto instance = std::make_shared<DeciderProvingKey>(builder, trace_structure);
     UltraProver prover(instance);
     auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
     UltraVerifier verifier(verification_key);
@@ -236,7 +236,7 @@ TEST_F(UltraHonkTests, LookupFailure)
     {
         auto builder = construct_circuit_with_lookups();
 
-        auto instance = std::make_shared<ProverInstance>(builder);
+        auto instance = std::make_shared<DeciderProvingKey>(builder);
 
         EXPECT_TRUE(prove_and_verify(instance));
     }
@@ -245,7 +245,7 @@ TEST_F(UltraHonkTests, LookupFailure)
     {
         auto builder = construct_circuit_with_lookups();
 
-        auto instance = std::make_shared<ProverInstance>(builder);
+        auto instance = std::make_shared<DeciderProvingKey>(builder);
         auto& polynomials = instance->proving_key.polynomials;
 
         // Erroneously update the read counts/tags at an arbitrary index
@@ -263,7 +263,7 @@ TEST_F(UltraHonkTests, LookupFailure)
     {
         auto builder = construct_circuit_with_lookups();
 
-        auto instance = std::make_shared<ProverInstance>(builder);
+        auto instance = std::make_shared<DeciderProvingKey>(builder);
         auto& polynomials = instance->proving_key.polynomials;
 
         // Find a lookup gate and alter one of the wire values
@@ -281,7 +281,7 @@ TEST_F(UltraHonkTests, LookupFailure)
     {
         auto builder = construct_circuit_with_lookups();
 
-        auto instance = std::make_shared<ProverInstance>(builder);
+        auto instance = std::make_shared<DeciderProvingKey>(builder);
         auto& polynomials = instance->proving_key.polynomials;
 
         // Turn the lookup selector on for an arbitrary row where it is not already active

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
@@ -27,7 +27,7 @@ UltraProver_<Flavor>::UltraProver_(const std::shared_ptr<Instance>& inst, const 
  * */
 template <IsUltraFlavor Flavor>
 UltraProver_<Flavor>::UltraProver_(Builder& circuit)
-    : instance(std::make_shared<ProverInstance>(circuit))
+    : instance(std::make_shared<DeciderProvingKey>(circuit))
     , transcript(std::make_shared<Transcript>())
     , commitment_key(instance->proving_key.commitment_key)
 {}

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
@@ -5,31 +5,32 @@
 namespace bb {
 
 /**
- * Create UltraProver_ from an instance.
+ * @brief Create UltraProver_ from a decider proving key.
  *
- * @param instance Instance whose proof we want to generate.
+ * @param proving_key key whose proof we want to generate.
  *
  * @tparam a type of UltraFlavor
  * */
 template <IsUltraFlavor Flavor>
-UltraProver_<Flavor>::UltraProver_(const std::shared_ptr<Instance>& inst, const std::shared_ptr<Transcript>& transcript)
-    : instance(std::move(inst))
+UltraProver_<Flavor>::UltraProver_(const std::shared_ptr<DeciderPK>& proving_key,
+                                   const std::shared_ptr<Transcript>& transcript)
+    : proving_key(std::move(proving_key))
     , transcript(transcript)
-    , commitment_key(instance->proving_key.commitment_key)
+    , commitment_key(proving_key->proving_key.commitment_key)
 {}
 
 /**
- * Create UltraProver_ from a circuit.
+ * @brief Create UltraProver_ from a circuit.
  *
- * @param instance Circuit with witnesses whose validity we'd like to prove.
+ * @param circuit Circuit with witnesses whose validity we'd like to prove.
  *
  * @tparam a type of UltraFlavor
  * */
 template <IsUltraFlavor Flavor>
 UltraProver_<Flavor>::UltraProver_(Builder& circuit)
-    : instance(std::make_shared<DeciderProvingKey>(circuit))
+    : proving_key(std::make_shared<DeciderProvingKey>(circuit))
     , transcript(std::make_shared<Transcript>())
-    , commitment_key(instance->proving_key.commitment_key)
+    , commitment_key(proving_key->proving_key.commitment_key)
 {}
 
 template <IsUltraFlavor Flavor> HonkProof UltraProver_<Flavor>::export_proof()
@@ -43,17 +44,17 @@ template <IsUltraFlavor Flavor> void UltraProver_<Flavor>::generate_gate_challen
     for (size_t idx = 0; idx < gate_challenges.size(); idx++) {
         gate_challenges[idx] = transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
     }
-    instance->gate_challenges = gate_challenges;
+    proving_key->gate_challenges = gate_challenges;
 }
 
 template <IsUltraFlavor Flavor> HonkProof UltraProver_<Flavor>::construct_proof()
 {
-    OinkProver<Flavor> oink_prover(instance, transcript);
+    OinkProver<Flavor> oink_prover(proving_key, transcript);
     oink_prover.prove();
 
     generate_gate_challenges();
 
-    DeciderProver_<Flavor> decider_prover(instance, transcript);
+    DeciderProver_<Flavor> decider_prover(proving_key, transcript);
     return decider_prover.construct_proof();
 }
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.hpp
@@ -22,11 +22,11 @@ template <IsUltraFlavor Flavor_> class UltraProver_ {
     using CommitmentLabels = typename Flavor::CommitmentLabels;
     using PCS = typename Flavor::PCS;
     using DeciderProvingKey = DeciderProvingKey_<Flavor>;
-    using Instance = DeciderProvingKey;
+    using DeciderPK = DeciderProvingKey;
     using Transcript = typename Flavor::Transcript;
     using ZeroMorph = ZeroMorphProver_<PCS>;
 
-    std::shared_ptr<Instance> instance;
+    std::shared_ptr<DeciderPK> proving_key;
 
     std::shared_ptr<Transcript> transcript;
 
@@ -38,7 +38,7 @@ template <IsUltraFlavor Flavor_> class UltraProver_ {
 
     std::shared_ptr<CommitmentKey> commitment_key;
 
-    explicit UltraProver_(const std::shared_ptr<Instance>&,
+    explicit UltraProver_(const std::shared_ptr<DeciderPK>&,
                           const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());
 
     explicit UltraProver_(Builder&);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.hpp
@@ -21,8 +21,8 @@ template <IsUltraFlavor Flavor_> class UltraProver_ {
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     using CommitmentLabels = typename Flavor::CommitmentLabels;
     using PCS = typename Flavor::PCS;
-    using ProverInstance = ProverInstance_<Flavor>;
-    using Instance = ProverInstance;
+    using DeciderProvingKey = DeciderProvingKey_<Flavor>;
+    using Instance = DeciderProvingKey;
     using Transcript = typename Flavor::Transcript;
     using ZeroMorph = ZeroMorphProver_<PCS>;
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_transcript.test.cpp
@@ -19,7 +19,7 @@ class UltraTranscriptTests : public ::testing::Test {
     using Flavor = UltraFlavor;
     using VerificationKey = Flavor::VerificationKey;
     using FF = Flavor::FF;
-    using ProverInstance = ProverInstance_<Flavor>;
+    using DeciderProvingKey = DeciderProvingKey_<Flavor>;
 
     /**
      * @brief Construct a manifest for a Ultra Honk proof
@@ -134,7 +134,7 @@ TEST_F(UltraTranscriptTests, ProverManifestConsistency)
     generate_test_circuit(builder);
 
     // Automatically generate a transcript manifest by constructing a proof
-    auto instance = std::make_shared<ProverInstance>(builder);
+    auto instance = std::make_shared<DeciderProvingKey>(builder);
     UltraProver prover(instance);
     auto proof = prover.construct_proof();
 
@@ -160,7 +160,7 @@ TEST_F(UltraTranscriptTests, VerifierManifestConsistency)
     generate_test_circuit(builder);
 
     // Automatically generate a transcript manifest in the prover by constructing a proof
-    auto instance = std::make_shared<ProverInstance>(builder);
+    auto instance = std::make_shared<DeciderProvingKey>(builder);
     UltraProver prover(instance);
     auto proof = prover.construct_proof();
 
@@ -211,7 +211,7 @@ TEST_F(UltraTranscriptTests, StructureTest)
     generate_test_circuit(builder);
 
     // Automatically generate a transcript manifest by constructing a proof
-    auto instance = std::make_shared<ProverInstance>(builder);
+    auto instance = std::make_shared<DeciderProvingKey>(builder);
     UltraProver prover(instance);
     auto proof = prover.construct_proof();
     auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_transcript.test.cpp
@@ -134,8 +134,8 @@ TEST_F(UltraTranscriptTests, ProverManifestConsistency)
     generate_test_circuit(builder);
 
     // Automatically generate a transcript manifest by constructing a proof
-    auto instance = std::make_shared<DeciderProvingKey>(builder);
-    UltraProver prover(instance);
+    auto proving_key = std::make_shared<DeciderProvingKey>(builder);
+    UltraProver prover(proving_key);
     auto proof = prover.construct_proof();
 
     // Check that the prover generated manifest agrees with the manifest hard coded in this suite
@@ -160,12 +160,12 @@ TEST_F(UltraTranscriptTests, VerifierManifestConsistency)
     generate_test_circuit(builder);
 
     // Automatically generate a transcript manifest in the prover by constructing a proof
-    auto instance = std::make_shared<DeciderProvingKey>(builder);
-    UltraProver prover(instance);
+    auto proving_key = std::make_shared<DeciderProvingKey>(builder);
+    UltraProver prover(proving_key);
     auto proof = prover.construct_proof();
 
     // Automatically generate a transcript manifest in the verifier by verifying a proof
-    auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
+    auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
     UltraVerifier verifier(verification_key);
     verifier.verify_proof(proof);
 
@@ -211,10 +211,10 @@ TEST_F(UltraTranscriptTests, StructureTest)
     generate_test_circuit(builder);
 
     // Automatically generate a transcript manifest by constructing a proof
-    auto instance = std::make_shared<DeciderProvingKey>(builder);
-    UltraProver prover(instance);
+    auto proving_key = std::make_shared<DeciderProvingKey>(builder);
+    UltraProver prover(proving_key);
     auto proof = prover.construct_proof();
-    auto verification_key = std::make_shared<VerificationKey>(instance->proving_key);
+    auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
     UltraVerifier verifier(verification_key);
     EXPECT_TRUE(verifier.verify_proof(proof));
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
@@ -15,15 +15,15 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const HonkP
     using FF = typename Flavor::FF;
 
     transcript = std::make_shared<Transcript>(proof);
-    OinkVerifier<Flavor> oink_verifier{ instance, transcript };
+    OinkVerifier<Flavor> oink_verifier{ verification_key, transcript };
     oink_verifier.verify();
 
     for (size_t idx = 0; idx < CONST_PROOF_SIZE_LOG_N; idx++) {
-        instance->gate_challenges.emplace_back(
+        verification_key->gate_challenges.emplace_back(
             transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx)));
     }
 
-    DeciderVerifier decider_verifier{ instance, transcript };
+    DeciderVerifier decider_verifier{ verification_key, transcript };
 
     return decider_verifier.verify();
 }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.hpp
@@ -14,7 +14,7 @@ template <typename Flavor> class UltraVerifier_ {
     using VerificationKey = typename Flavor::VerificationKey;
     using VerifierCommitmentKey = typename Flavor::VerifierCommitmentKey;
     using Transcript = typename Flavor::Transcript;
-    using Instance = VerifierInstance_<Flavor>;
+    using Instance = DeciderVerificationKey_<Flavor>;
     using DeciderVerifier = DeciderVerifier_<Flavor>;
 
   public:

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.hpp
@@ -14,18 +14,18 @@ template <typename Flavor> class UltraVerifier_ {
     using VerificationKey = typename Flavor::VerificationKey;
     using VerifierCommitmentKey = typename Flavor::VerifierCommitmentKey;
     using Transcript = typename Flavor::Transcript;
-    using Instance = DeciderVerificationKey_<Flavor>;
+    using DeciderVK = DeciderVerificationKey_<Flavor>;
     using DeciderVerifier = DeciderVerifier_<Flavor>;
 
   public:
     explicit UltraVerifier_(const std::shared_ptr<VerificationKey>& verifier_key)
-        : instance(std::make_shared<Instance>(verifier_key))
+        : verification_key(std::make_shared<DeciderVK>(verifier_key))
     {}
 
     bool verify_proof(const HonkProof& proof);
 
     std::shared_ptr<Transcript> transcript{ nullptr };
-    std::shared_ptr<Instance> instance;
+    std::shared_ptr<DeciderVK> verification_key;
 };
 
 using UltraVerifier = UltraVerifier_<UltraFlavor>;

--- a/barretenberg/cpp/src/barretenberg/vm/avm/recursion/avm_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/recursion/avm_recursive_verifier.test.cpp
@@ -38,7 +38,7 @@ class AvmRecursiveTests : public ::testing::Test {
     using OuterBuilder = typename RecursiveFlavor::CircuitBuilder;
     using OuterProver = UltraProver_<UltraFlavor>;
     using OuterVerifier = UltraVerifier_<UltraFlavor>;
-    using OuterProverInstance = ProverInstance_<UltraFlavor>;
+    using OuterDeciderProvingKey = DeciderProvingKey_<UltraFlavor>;
 
     static void SetUpTestSuite() { bb::srs::init_crs_factory("../srs_db/ignition"); }
 
@@ -113,7 +113,7 @@ TEST_F(AvmRecursiveTests, recursion)
 
     // Make a proof of the verification of an AVM proof
     const size_t srs_size = 1 << 23;
-    auto ultra_instance = std::make_shared<OuterProverInstance>(
+    auto ultra_instance = std::make_shared<OuterDeciderProvingKey>(
         outer_circuit, TraceStructure::NONE, std::make_shared<bb::CommitmentKey<curve::BN254>>(srs_size));
     OuterProver ultra_prover(ultra_instance);
     auto ultra_verification_key = std::make_shared<UltraFlavor::VerificationKey>(ultra_instance->proving_key);

--- a/yarn-project/bb-prover/src/bb/execute.ts
+++ b/yarn-project/bb-prover/src/bb/execute.ts
@@ -420,7 +420,7 @@ export async function generateTubeProof(
   }
 
   // // Paths for the inputs
-  const vkPath = join(workingDirectory, 'inst_vk.bin'); // the vk of the last instance
+  const vkPath = join(workingDirectory, 'final_decider_vk.bin'); // the vk of the last instance
   const accPath = join(workingDirectory, 'pg_acc.bin');
   const proofPath = join(workingDirectory, 'client_ivc_proof.bin');
   const translatorVkPath = join(workingDirectory, 'translator_vk.bin');

--- a/yarn-project/circuits.js/src/structs/client_ivc_proof.ts
+++ b/yarn-project/circuits.js/src/structs/client_ivc_proof.ts
@@ -35,7 +35,7 @@ export class ClientIvcProof {
    */
   static async readFromOutputDirectory(directory: string) {
     const [instVkBuffer, pgAccBuffer, clientIvcProofBuffer, translatorVkBuffer, eccVkBuffer] = await Promise.all(
-      ['inst_vk', 'pg_acc', 'client_ivc_proof', 'translator_vk', 'ecc_vk'].map(fileName =>
+      ['final_decider_vk', 'pg_acc', 'client_ivc_proof', 'translator_vk', 'ecc_vk'].map(fileName =>
         fs.readFile(path.join(directory, fileName)),
       ),
     );
@@ -58,7 +58,7 @@ export class ClientIvcProof {
   async writeToOutputDirectory(directory: string) {
     const { instVkBuffer, pgAccBuffer, clientIvcProofBuffer, translatorVkBuffer, eccVkBuffer } = this;
     const fileData = [
-      ['inst_vk', instVkBuffer],
+      ['final_decider_vk', instVkBuffer],
       ['pg_acc', pgAccBuffer],
       ['client_ivc_proof', clientIvcProofBuffer],
       ['translator_vk', translatorVkBuffer],


### PR DESCRIPTION
The main objective of this PR is to do some renaming to stop using the term "instance" as we currently do in the Honk flavors that can be used to construct proofs from stdlib circuits (Mega, UItra, relative). This is bad terminology for several reasons:
 - the term "instace-witness pair" is widely in use in ZK, and our existing use of "instance" directly clashes with this.
 - `ProverInstance` is really just a key for Decider proving; similarly for `VerifierInstance`
 - `ProvingKey` as it currently exists is de facto deprecated in the contexts where we use "instance"'s since we have have rewritten those provers and verifiers using Oink prover and verifier.
 - "Prover instance" sounds a lot like an instance of the Prover class--can be confusing in conversation.
 - I take it as a sign that "instance" is a bad term that we variously use that term and the term "accumulator" for the same thing, depending on the context, whether or not any accumulation is or could even happen.

I simply rename things to Decider[Proving/Verification]Key and variants of this depending on context. A sign that this is a good choice is the fact that we now have the absurd-looking `proving_key->proving_key`, which will become non-absurb when the inner proving key type is actually deprecated. At that point the DeciderProvingKey class could move into the flavor, time permitting.

I also have a small change to remove the `State` struct I recently added to Protogalaxy Prover. This is where the work started before I undertook the big renaming job, and it's small and localized enough that it feels unnecessary to split it out.

Note: renaming of files is done in a follow-on https://github.com/AztecProtocol/aztec-packages/pull/8383