### PR TITLE
chore: Change efs volumes to use bursting throughput

### DIFF
--- a/yarn-project/aztec/terraform/node/main.tf
+++ b/yarn-project/aztec/terraform/node/main.tf
@@ -103,9 +103,7 @@ resource "aws_service_discovery_service" "aztec-node" {
 
 # Configure an EFS filesystem.
 resource "aws_efs_file_system" "node_data_store" {
-  creation_token                  = "${var.DEPLOY_TAG}-node-data"
-  throughput_mode                 = "provisioned"
-  provisioned_throughput_in_mibps = 20
+  creation_token = "${var.DEPLOY_TAG}-node-data"
 
   tags = {
     Name = "${var.DEPLOY_TAG}-node-data"

--- a/yarn-project/aztec/terraform/prover-node/main.tf
+++ b/yarn-project/aztec/terraform/prover-node/main.tf
@@ -104,8 +104,6 @@ resource "aws_service_discovery_service" "aztec-prover-node" {
 # Configure an EFS filesystem.
 resource "aws_efs_file_system" "prover_node_data_store" {
   creation_token                  = "${var.DEPLOY_TAG}-prover-node-data"
-  throughput_mode                 = "provisioned"
-  provisioned_throughput_in_mibps = 20
 
   tags = {
     Name = "${var.DEPLOY_TAG}-prover-node-data"

--- a/yarn-project/aztec/terraform/pxe/main.tf
+++ b/yarn-project/aztec/terraform/pxe/main.tf
@@ -70,9 +70,7 @@ resource "aws_service_discovery_service" "aztec-pxe" {
 }
 
 resource "aws_efs_file_system" "pxe_data_store" {
-  creation_token                  = "${var.DEPLOY_TAG}-pxe-data"
-  throughput_mode                 = "provisioned"
-  provisioned_throughput_in_mibps = 20
+  creation_token = "${var.DEPLOY_TAG}-pxe-data"
 
   tags = {
     Name = "${var.DEPLOY_TAG}-pxe-data"


### PR DESCRIPTION
This PR changes our EFS volumes to use the default (burst) throughput mode
