### PR TITLE
fix: Increase timeout for Sepolia mining

### DIFF
--- a/yarn-project/end-to-end/src/public-testnet/e2e_public_testnet_transfer.test.ts
+++ b/yarn-project/end-to-end/src/public-testnet/e2e_public_testnet_transfer.test.ts
@@ -64,6 +64,7 @@ describe(`deploys and transfers a private only token`, () => {
       interval: 0.1,
       proven: true,
       provenTimeout: 600,
+      timeout: 300,
     });
 
     logger.info(`Accounts deployed, deploying token.`);
@@ -86,6 +87,7 @@ describe(`deploys and transfers a private only token`, () => {
       .deployed({
         proven: true,
         provenTimeout: 600,
+        timeout: 300,
       });
 
     logger.info(`Performing transfer.`);
@@ -93,7 +95,7 @@ describe(`deploys and transfers a private only token`, () => {
     await token.methods
       .transfer(transferValue, deployerWallet.getAddress(), recipientWallet.getAddress(), deployerWallet.getAddress())
       .send()
-      .wait({ proven: true, provenTimeout: 600 });
+      .wait({ proven: true, provenTimeout: 600, timeout: 300 });
 
     logger.info(`Transfer completed`);
 


### PR DESCRIPTION
This Pr simply increases the wait timeout on Sepolia transactions to give them a chance to settle.
