### PR TITLE
feat(avm-transpiler): optionally count opcode types

### DIFF
--- a/avm-transpiler/src/opcodes.rs
+++ b/avm-transpiler/src/opcodes.rs
@@ -1,7 +1,7 @@
 /// All AVM opcodes
 /// Keep updated with TS, cpp, and docs protocol specs!
 #[allow(clippy::upper_case_acronyms, dead_code)]
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Copy, Clone, Debug, Eq, Hash)]
 pub enum AvmOpcode {
     // Compute
     ADD,

--- a/avm-transpiler/src/transpile_contract.rs
+++ b/avm-transpiler/src/transpile_contract.rs
@@ -100,6 +100,7 @@ impl From<CompiledAcirContractArtifact> for TranspiledContractArtifact {
                 let acir_program = function.bytecode;
                 let brillig_bytecode = extract_brillig_from_acir_program(&acir_program);
                 let assert_messages = extract_static_assert_messages(&acir_program);
+                info!("Extracted Brillig program has {} instructions", brillig_bytecode.len());
 
                 // Map Brillig pcs to AVM pcs (index is Brillig PC, value is AVM PC)
                 let brillig_pcs_to_avm_pcs = map_brillig_pcs_to_avm_pcs(brillig_bytecode);
@@ -118,7 +119,7 @@ impl From<CompiledAcirContractArtifact> for TranspiledContractArtifact {
                 let _ = encoder.read_to_end(&mut compressed_avm_bytecode);
 
                 log::info!(
-                    "{}::{}: compressed {} to {} bytes ({}% reduction)",
+                    "{}::{}: bytecode size of {} was compressed to {} ({}% reduction)",
                     contract.name,
                     function.name,
                     avm_bytecode.len(),


### PR DESCRIPTION
```
[2024-09-07T13:52:42Z INFO  avm_transpiler::transpile_contract] Transpiling AVM function transfer_public on contract Token
[2024-09-07T13:52:42Z INFO  avm_transpiler::transpile_contract] Extracted Brillig program has 746 instructions
[2024-09-07T13:52:42Z INFO  avm_transpiler::utils] Transpiled AVM program has 765 instructions
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils] AVM opcode counts:
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      MOV_8: 234
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      ADD: 136
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      SET: 97
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      JUMPI: 48
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      CAST: 43
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      JUMP: 36
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      REVERT: 35
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      EQ: 29
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      MOV_16: 22
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      LT: 18
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      SUB: 17
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      LTE: 11
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      INTERNALCALL: 7
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      MUL: 6
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      PEDERSEN: 4
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      FDIV: 4
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      ADDRESS: 2
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      SENDER: 2
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      INTERNALRETURN: 2
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      POSEIDON2: 2
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      SSTORE: 2
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      SLOAD: 2
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      TORADIXLE: 1
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      FUNCTIONSELECTOR: 1
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      NULLIFIEREXISTS: 1
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      CALLDATACOPY: 1
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      RETURN: 1
[2024-09-07T13:52:42Z DEBUG avm_transpiler::utils]      CALL: 1
[2024-09-07T13:52:42Z INFO  avm_transpiler::transpile_contract] Token::transfer_public: bytecode size of 7401 was compressed to 2342 (69% reduction)
```