### PR TITLE
refactor: Protogalaxy verifier matches prover 2

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
@@ -593,7 +593,6 @@ template <typename Curve_> class IPA {
     static OpeningClaim<Curve> reduce_batch_opening_claim(
         const BatchOpeningClaim<Curve>&  batch_opening_claim)
     {
-        using Utils = CommitmentSchemesUtils<Curve>;
         // Extract batch_mul arguments from the accumulator
         const auto& commitments = batch_opening_claim.commitments;
         const auto& scalars = batch_opening_claim.scalars;
@@ -604,7 +603,7 @@ template <typename Curve_> class IPA {
             shplonk_output_commitment =
                 GroupElement::batch_mul(commitments, scalars, /*max_num_bits=*/0, /*with_edgecases=*/true);
         } else {
-            shplonk_output_commitment = Utils::batch_mul_native(commitments, scalars);
+            shplonk_output_commitment = batch_mul_native(commitments, scalars);
         }
         // Output an opening claim to be verified by the IPA opening protocol
         return { { shplonk_eval_challenge, Fr(0) }, shplonk_output_commitment };

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
@@ -108,7 +108,6 @@ template <typename Curve_> class KZG {
     static VerifierAccumulator reduce_verify_batch_opening_claim(BatchOpeningClaim<Curve> batch_opening_claim,
                                                                  const std::shared_ptr<Transcript>& transcript)
     {
-        using Utils = CommitmentSchemesUtils<Curve>;
         auto quotient_commitment = transcript->template receive_from_prover<Commitment>("KZG:W");
 
         // The pairing check can be expressed as
@@ -125,7 +124,7 @@ template <typename Curve_> class KZG {
                                           /*max_num_bits=*/0,
                                           /*with_edgecases=*/true);
         } else {
-            P_0 = Utils::batch_mul_native(batch_opening_claim.commitments, batch_opening_claim.scalars);
+            P_0 = batch_mul_native(batch_opening_claim.commitments, batch_opening_claim.scalars);
         }
         auto P_1 = -quotient_commitment;
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplemini_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplemini_verifier.hpp
@@ -3,7 +3,6 @@
 #include "barretenberg/commitment_schemes/commitment_key.hpp"
 #include "barretenberg/commitment_schemes/gemini/gemini.hpp"
 #include "barretenberg/commitment_schemes/shplonk/shplonk.hpp"
-#include "barretenberg/commitment_schemes/utils/batch_mul_native.hpp"
 #include "barretenberg/commitment_schemes/verification_key.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplemini_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplemini_verifier.test.cpp
@@ -33,7 +33,6 @@ TYPED_TEST(ShpleminiTest, CorrectnessOfMultivariateClaimBatching)
     using GroupElement = typename TypeParam::Element;
     using Commitment = typename TypeParam::AffineElement;
     using Polynomial = typename bb::Polynomial<Fr>;
-    using Utils = CommitmentSchemesUtils<TypeParam>;
 
     const size_t n = 16;
     const size_t log_n = 4;
@@ -111,7 +110,7 @@ TYPED_TEST(ShpleminiTest, CorrectnessOfMultivariateClaimBatching)
                                                          verifier_batched_evaluation);
 
     // Final pairing check
-    GroupElement shplemini_result = Utils::batch_mul_native(commitments, scalars);
+    GroupElement shplemini_result = batch_mul_native(commitments, scalars);
 
     EXPECT_EQ(commitments.size(), unshifted_commitments.size() + shifted_commitments.size());
     EXPECT_EQ(batched_evaluation, verifier_batched_evaluation);
@@ -127,7 +126,6 @@ TYPED_TEST(ShpleminiTest, CorrectnessOfGeminiClaimBatching)
     using GroupElement = typename TypeParam::Element;
     using Commitment = typename TypeParam::AffineElement;
     using Polynomial = typename bb::Polynomial<Fr>;
-    using Utils = CommitmentSchemesUtils<TypeParam>;
 
     const size_t n = 16;
     const size_t log_n = 4;
@@ -221,7 +219,7 @@ TYPED_TEST(ShpleminiTest, CorrectnessOfGeminiClaimBatching)
 
     EXPECT_EQ(commitments.size(), prover_commitments.size());
     // Compute the group element using the output of Shplemini method
-    GroupElement shplemini_result = Utils::batch_mul_native(commitments, scalars);
+    GroupElement shplemini_result = batch_mul_native(commitments, scalars);
 
     EXPECT_EQ(shplemini_result, expected_result);
 }

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/batch_mul_native.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/batch_mul_native.hpp
@@ -34,4 +34,18 @@ static Commitment batch_mul_native(const std::vector<Commitment>& _points, const
     }
     return result;
 }
+
+/**
+ * @brief Utility for native batch multiplication of group elements
+ * @note This is used only for native verification and is not optimized for efficiency
+ */
+template <typename FF> static FF linear_combination(const std::vector<FF>& as, const std::vector<FF>& bs)
+{
+    FF result = as[0] * bs[0];
+    for (size_t idx = 1; idx < as.size(); ++idx) {
+        result += as[idx] * bs[idx];
+    }
+    return result;
+}
+
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/batch_mul_native.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/batch_mul_native.hpp
@@ -4,40 +4,34 @@
 #include <vector>
 
 namespace bb {
-template <typename Curve> class CommitmentSchemesUtils {
+/**
+ * @brief Utility for native batch multiplication of group elements
+ * @note This is used only for native verification and is not optimized for efficiency
+ */
+template <typename Commitment, typename FF>
+static Commitment batch_mul_native(const std::vector<Commitment>& _points, const std::vector<FF>& _scalars)
+{
+    std::vector<Commitment> points;
+    std::vector<FF> scalars;
+    for (size_t i = 0; i < _points.size(); ++i) {
+        const auto& point = _points[i];
+        const auto& scalar = _scalars[i];
 
-  public:
-    using Commitment = typename Curve::AffineElement;
-    using FF = typename Curve::ScalarField;
-
-    /**
-     * @brief Utility for native batch multiplication of group elements
-     * @note This is used only for native verification and is not optimized for efficiency
-     */
-    static Commitment batch_mul_native(const std::vector<Commitment>& _points, const std::vector<FF>& _scalars)
-    {
-        std::vector<Commitment> points;
-        std::vector<FF> scalars;
-        for (size_t i = 0; i < _points.size(); ++i) {
-            const auto& point = _points[i];
-            const auto& scalar = _scalars[i];
-
-            // TODO: Special handling of point at infinity here due to incorrect serialization.
-            if (!scalar.is_zero() && !point.is_point_at_infinity() && !point.y.is_zero()) {
-                points.emplace_back(point);
-                scalars.emplace_back(scalar);
-            }
+        // TODO: Special handling of point at infinity here due to incorrect serialization.
+        if (!scalar.is_zero() && !point.is_point_at_infinity() && !point.y.is_zero()) {
+            points.emplace_back(point);
+            scalars.emplace_back(scalar);
         }
-
-        if (points.empty()) {
-            return Commitment::infinity();
-        }
-
-        auto result = points[0] * scalars[0];
-        for (size_t idx = 1; idx < scalars.size(); ++idx) {
-            result = result + points[idx] * scalars[idx];
-        }
-        return result;
     }
-};
+
+    if (points.empty()) {
+        return Commitment::infinity();
+    }
+
+    auto result = points[0] * scalars[0];
+    for (size_t idx = 1; idx < scalars.size(); ++idx) {
+        result = result + points[idx] * scalars[idx];
+    }
+    return result;
+}
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/zeromorph/zeromorph.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/zeromorph/zeromorph.hpp
@@ -469,7 +469,6 @@ template <typename Curve> class ZeroMorphProver_ {
 template <typename Curve> class ZeroMorphVerifier_ {
     using FF = typename Curve::ScalarField;
     using Commitment = typename Curve::AffineElement;
-    using Utils = CommitmentSchemesUtils<Curve>;
 
   public:
     /**
@@ -549,7 +548,7 @@ template <typename Curve> class ZeroMorphVerifier_ {
                 return Commitment::batch_mul(commitments, scalars);
             }
         } else {
-            return Utils::batch_mul_native(commitments, scalars);
+            return batch_mul_native(commitments, scalars);
         }
     }
 
@@ -705,7 +704,7 @@ template <typename Curve> class ZeroMorphVerifier_ {
                 return Commitment::batch_mul(commitments, scalars);
             }
         } else {
-            return Utils::batch_mul_native(commitments, scalars);
+            return batch_mul_native(commitments, scalars);
         }
     }
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -125,11 +125,9 @@ FoldingResult<typename DeciderProvingKeys::Flavor> ProtogalaxyProver_<DeciderPro
     const FF combiner_challenge = transcript->template get_challenge<FF>("combiner_quotient_challenge");
 
     FoldingResult<Flavor> result{ .accumulator = keys[0], .proof = std::move(transcript->proof_data) };
-
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/881): bad pattern
     result.accumulator->is_accumulator = true;
 
-    // Compute the next target sum
+    // Compute the next target sum (for its use; must be computed by the verifier)
     auto [vanishing_polynomial_at_challenge, lagranges] =
         Fun::compute_vanishing_polynomial_and_lagranges(combiner_challenge);
     result.accumulator->target_sum = perturbator_evaluation * lagranges[0] +

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -127,7 +127,7 @@ FoldingResult<typename DeciderProvingKeys::Flavor> ProtogalaxyProver_<DeciderPro
     FoldingResult<Flavor> result{ .accumulator = keys[0], .proof = std::move(transcript->proof_data) };
     result.accumulator->is_accumulator = true;
 
-    // Compute the next target sum (for its use; must be computed by the verifier)
+    // Compute the next target sum (for its own use; verifier must compute its own values)
     auto [vanishing_polynomial_at_challenge, lagranges] =
         Fun::compute_vanishing_polynomial_and_lagranges(combiner_challenge);
     result.accumulator->target_sum = perturbator_evaluation * lagranges[0] +

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -138,10 +138,9 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyVerifier
         alpha = linear_combination(keys_to_fold.get_alphas_at_index(idx), lagranges);
         idx++;
     }
-    idx = 0;
-    for (auto& param : next_accumulator->relation_parameters.get_to_fold()) {
-        param = linear_combination(keys_to_fold.get_relation_parameters_at_index(idx), lagranges);
-        idx++;
+    for (auto [combination, to_combine] :
+         zip_view(next_accumulator->relation_parameters.get_to_fold(), keys_to_fold.get_relation_parameters())) {
+        combination = linear_combination(to_combine, lagranges);
     }
 
     return next_accumulator;

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -98,7 +98,7 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyVerifier
     std::array<FF, BATCHED_EXTENDED_LENGTH - NUM_KEYS>
         combiner_quotient_evals; // The degree of the combiner quotient (K in the paper) is dk - k - 1 = k(d - 1) - 1.
                                  // Hence we need  k(d - 1) evaluations to represent it.
-    size_t idx = 0;
+    size_t idx = DeciderVerificationKeys::NUM;
     for (auto& val : combiner_quotient_evals) {
         val = transcript->template receive_from_prover<FF>("combiner_quotient_" + std::to_string(idx++));
     }

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -151,6 +151,10 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyVerifier
             key->relation_parameters.lookup_grand_product_delta * lagranges[vk_idx];
     }
 
+    for (auto& param : next_accumulator->relation_parameters.get_to_fold()) {
+        info(param);
+    };
+
     return next_accumulator;
 }
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -98,8 +98,7 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyVerifier
     std::array<FF, BATCHED_EXTENDED_LENGTH - NUM_KEYS>
         combiner_quotient_evals; // The degree of the combiner quotient (K in the paper) is dk - k - 1 = k(d - 1) - 1.
                                  // Hence we need  k(d - 1) evaluations to represent it.
-    size_t idx = DeciderVerificationKeys::NUM;
-    for (auto& val : combiner_quotient_evals) {
+    for (size_t idx = DeciderVerificationKeys::NUM; auto& val : combiner_quotient_evals) {
         val = transcript->template receive_from_prover<FF>("combiner_quotient_" + std::to_string(idx++));
     }
 
@@ -121,15 +120,13 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyVerifier
         update_gate_challenges(perturbator_challenge, accumulator->gate_challenges, deltas);
 
     // // Fold the commitments
-    idx = 0;
-    for (auto& folded_commitment : next_accumulator->verification_key->get_all()) {
-        folded_commitment = batch_mul_native(keys_to_fold.get_precomputed_commitments_at_index(idx), lagranges);
-        idx++;
+    for (auto [combination, to_combine] :
+         zip_view(next_accumulator->verification_key->get_all(), keys_to_fold.get_precomputed_commitments())) {
+        combination = batch_mul_native(to_combine, lagranges);
     }
-    idx = 0;
-    for (auto& folded_commitment : next_accumulator->witness_commitments.get_all()) {
-        folded_commitment = batch_mul_native(keys_to_fold.get_witness_commitments_at_index(idx), lagranges);
-        idx++;
+    for (auto [combination, to_combine] :
+         zip_view(next_accumulator->witness_commitments.get_all(), keys_to_fold.get_witness_commitments())) {
+        combination = batch_mul_native(to_combine, lagranges);
     }
 
     // Fold the relation parameters

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -114,7 +114,8 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyVerifier
 
     size_t commitment_idx = 0;
     for (auto& folded_commitment : next_accumulator->verification_key->get_all()) {
-        folded_commitment = batch_mul_native(keys_to_fold.get_commitments_at_index(commitment_idx), lagranges);
+        folded_commitment =
+            batch_mul_native(keys_to_fold.get_precomputed_commitments_at_index(commitment_idx), lagranges);
         commitment_idx++;
     }
 
@@ -125,15 +126,10 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyVerifier
         update_gate_challenges(perturbator_challenge, accumulator->gate_challenges, deltas);
 
     // Compute ϕ
-    auto& acc_witness_commitments = next_accumulator->witness_commitments;
+
     commitment_idx = 0;
-    for (auto& comm : acc_witness_commitments.get_all()) {
-        comm = Commitment::infinity();
-        size_t vk_idx = 0;
-        for (auto& key : keys_to_fold) {
-            comm = comm + key->witness_commitments.get_all()[commitment_idx] * lagranges[vk_idx];
-            vk_idx++;
-        }
+    for (auto& folded_commitment : next_accumulator->witness_commitments.get_all()) {
+        folded_commitment = batch_mul_native(keys_to_fold.get_witness_commitments_at_index(commitment_idx), lagranges);
         commitment_idx++;
     }
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -121,28 +121,22 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyVerifier
         update_gate_challenges(perturbator_challenge, accumulator->gate_challenges, deltas);
 
     // // Fold the commitments
-    size_t commitment_idx = 0;
+    idx = 0;
     for (auto& folded_commitment : next_accumulator->verification_key->get_all()) {
-        folded_commitment =
-            batch_mul_native(keys_to_fold.get_precomputed_commitments_at_index(commitment_idx), lagranges);
-        commitment_idx++;
+        folded_commitment = batch_mul_native(keys_to_fold.get_precomputed_commitments_at_index(idx), lagranges);
+        idx++;
     }
-    commitment_idx = 0;
+    idx = 0;
     for (auto& folded_commitment : next_accumulator->witness_commitments.get_all()) {
-        folded_commitment = batch_mul_native(keys_to_fold.get_witness_commitments_at_index(commitment_idx), lagranges);
-        commitment_idx++;
+        folded_commitment = batch_mul_native(keys_to_fold.get_witness_commitments_at_index(idx), lagranges);
+        idx++;
     }
 
     // Fold the relation parameters
-    size_t alpha_idx = 0;
+    idx = 0;
     for (auto& alpha : next_accumulator->alphas) {
-        alpha = FF(0);
-        size_t vk_idx = 0;
-        for (auto& key : keys_to_fold) {
-            alpha += key->alphas[alpha_idx] * lagranges[vk_idx];
-            vk_idx++;
-        }
-        alpha_idx++;
+        alpha = linear_combination(keys_to_fold.get_alphas_at_index(idx), lagranges);
+        idx++;
     }
     auto& expected_parameters = next_accumulator->relation_parameters;
     for (size_t vk_idx = 0; vk_idx < NUM_KEYS; vk_idx++) {

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -133,10 +133,8 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyVerifier
     }
 
     // Fold the relation parameters
-    idx = 0;
-    for (auto& alpha : next_accumulator->alphas) {
-        alpha = linear_combination(keys_to_fold.get_alphas_at_index(idx), lagranges);
-        idx++;
+    for (auto [combination, to_combine] : zip_view(next_accumulator->alphas, keys_to_fold.get_alphas())) {
+        combination = linear_combination(to_combine, lagranges);
     }
     for (auto [combination, to_combine] :
          zip_view(next_accumulator->relation_parameters.get_to_fold(), keys_to_fold.get_relation_parameters())) {

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -138,22 +138,11 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyVerifier
         alpha = linear_combination(keys_to_fold.get_alphas_at_index(idx), lagranges);
         idx++;
     }
-    auto& expected_parameters = next_accumulator->relation_parameters;
-    for (size_t vk_idx = 0; vk_idx < NUM_KEYS; vk_idx++) {
-        auto& key = keys_to_fold[vk_idx];
-        expected_parameters.eta += key->relation_parameters.eta * lagranges[vk_idx];
-        expected_parameters.eta_two += key->relation_parameters.eta_two * lagranges[vk_idx];
-        expected_parameters.eta_three += key->relation_parameters.eta_three * lagranges[vk_idx];
-        expected_parameters.beta += key->relation_parameters.beta * lagranges[vk_idx];
-        expected_parameters.gamma += key->relation_parameters.gamma * lagranges[vk_idx];
-        expected_parameters.public_input_delta += key->relation_parameters.public_input_delta * lagranges[vk_idx];
-        expected_parameters.lookup_grand_product_delta +=
-            key->relation_parameters.lookup_grand_product_delta * lagranges[vk_idx];
-    }
-
+    idx = 0;
     for (auto& param : next_accumulator->relation_parameters.get_to_fold()) {
-        info(param);
-    };
+        param = linear_combination(keys_to_fold.get_relation_parameters_at_index(idx), lagranges);
+        idx++;
+    }
 
     return next_accumulator;
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
@@ -14,6 +14,8 @@
 #include "barretenberg/ultra_honk/ultra_prover.hpp"
 #include "barretenberg/ultra_honk/ultra_verifier.hpp"
 
+auto& engine = bb::numeric::get_debug_randomness();
+
 namespace bb::stdlib::recursion::honk {
 template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public testing::Test {
   public:
@@ -72,11 +74,11 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         // Create 2^log_n many add gates based on input log num gates
         const size_t num_gates = 1 << log_num_gates;
         for (size_t i = 0; i < num_gates; ++i) {
-            fr a = fr::random_element();
+            fr a = fr::random_element(&engine);
             uint32_t a_idx = builder.add_variable(a);
 
-            fr b = fr::random_element();
-            fr c = fr::random_element();
+            fr b = fr::random_element(&engine);
+            fr c = fr::random_element(&engine);
             fr d = a + b + c;
             uint32_t b_idx = builder.add_variable(b);
             uint32_t c_idx = builder.add_variable(c);
@@ -86,9 +88,9 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         }
 
         // Define some additional non-trivial but arbitrary circuit logic
-        fr_ct a(public_witness_ct(&builder, fr::random_element()));
-        fr_ct b(public_witness_ct(&builder, fr::random_element()));
-        fr_ct c(public_witness_ct(&builder, fr::random_element()));
+        fr_ct a(public_witness_ct(&builder, fr::random_element(&engine)));
+        fr_ct b(public_witness_ct(&builder, fr::random_element(&engine)));
+        fr_ct c(public_witness_ct(&builder, fr::random_element(&engine)));
 
         for (size_t i = 0; i < 32; ++i) {
             a = (a * b) + b + a;
@@ -98,7 +100,7 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         byte_array_ct to_hash(&builder, "nonsense test data");
         blake3s(to_hash);
 
-        fr bigfield_data = fr::random_element();
+        fr bigfield_data = fr::random_element(&engine);
         fr bigfield_data_a{ bigfield_data.data[0], bigfield_data.data[1], 0, 0 };
         fr bigfield_data_b{ bigfield_data.data[2], bigfield_data.data[3], 0, 0 };
 
@@ -158,12 +160,12 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         std::vector<fr> coeffs;
         std::vector<fr_ct> coeffs_ct;
         for (size_t idx = 0; idx < 8; idx++) {
-            auto el = fr::random_element();
+            auto el = fr::random_element(&engine);
             coeffs.emplace_back(el);
             coeffs_ct.emplace_back(fr_ct(&builder, el));
         }
         Polynomial<fr> poly(coeffs);
-        fr point = fr::random_element();
+        fr point = fr::random_element(&engine);
         fr_ct point_ct(fr_ct(&builder, point));
         auto res1 = poly.evaluate(point);
 
@@ -333,7 +335,7 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         auto [prover_accumulator, verifier_accumulator] = fold_and_verify_native();
 
         // Tamper with the accumulator by changing the target sum
-        verifier_accumulator->target_sum = FF::random_element();
+        verifier_accumulator->target_sum = FF::random_element(&engine);
 
         // Create a decider proof for accumulator obtained through folding
         InnerDeciderProver decider_prover(prover_accumulator);
@@ -361,7 +363,7 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         auto verification_key = std::make_shared<InnerVerificationKey>(prover_inst->proving_key);
         auto verifier_inst = std::make_shared<InnerDeciderVerificationKey>(verification_key);
 
-        prover_accumulator->proving_key.polynomials.w_l.at(1) = FF::random_element();
+        prover_accumulator->proving_key.polynomials.w_l.at(1) = FF::random_element(&engine);
 
         // Generate a folding proof with the incorrect polynomials which would result in the prover having the wrong
         // target sum

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
@@ -156,5 +156,19 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderVerificationKeys_ {
 
         return result;
     }
+
+    /**
+     * @brief Get the witness commitments at a given index
+     * @details This is similar to get_precomputed_commitments_at_index, but for witness commitments.
+     */
+    std::vector<FF> get_relation_parameters_at_index(const size_t idx) const
+    {
+        std::vector<FF> result(NUM);
+        for (auto [elt, key] : zip_view(result, _data)) {
+            elt = key->relation_parameters.get_to_fold()[idx];
+        }
+
+        return result;
+    }
 };
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
@@ -43,9 +43,9 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderProvingKeys_ {
      *           PK 0             PK 1             PK 2             PK 3
      *           q_c q_l q_r ...  q_c q_l q_r ...  q_c q_l q_r ...  q_c q_l q_r ...
      *           *   *            *   *            *   *            *   *
-     *           *   *            *   *            *   *            *   *
      *           a_1 a_2 a_3 ...  b_1 b_2 b_3 ...  c_1 c_2 c_3 ...  d_1 d_2 d_3 ...
      *           *   *            *   *            *   *            *   *
+     *           ⋮    ⋮             ⋮   ⋮             ⋮   ⋮             ⋮   ⋮
      *
      * and the function returns the univariates [{a_1, b_1, c_1, d_1}, {a_2, b_2, c_2, d_2}, ...]
      *
@@ -108,6 +108,16 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderVerificationKeys_ {
         }
     };
 
+    /**
+     * @brief Get the precomputed commitments at a given index
+     * @example if the row idx is 2, and there are 4 decider verification keys
+     *           VK 0  VK 1  VK 2  VK 3
+     *           q_c   q_c   q_c   q_c
+     *           *     *     *     *
+     *           a_1   b_1   c_1   d_1
+     *           *     *     *     *
+     *  then the function outputs the vector of group elements {a_1, b_1, c_1, d_1}
+     */
     std::vector<Commitment> get_precomputed_commitments_at_index(const size_t idx) const
     {
         std::vector<Commitment> result(NUM);
@@ -118,6 +128,10 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderVerificationKeys_ {
         return result;
     }
 
+    /**
+     * @brief Get the witness commitments at a given index
+     * @details This is similar to get_precomputed_commitments_at_index, but for witness commitments.
+     */
     std::vector<Commitment> get_witness_commitments_at_index(const size_t idx) const
     {
         std::vector<Commitment> result(NUM);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
@@ -122,7 +122,7 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderVerificationKeys_ {
     {
         std::vector<Commitment> result(NUM);
         for (auto [elt, key] : zip_view(result, _data)) {
-            elt = key->witness_commitments->get_all()[idx];
+            elt = key->witness_commitments.get_all()[idx];
         }
 
         return result;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
@@ -86,6 +86,7 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderProvingKeys_ {
 template <typename Flavor_, size_t NUM_ = 2> struct DeciderVerificationKeys_ {
     static_assert(NUM_ > 1, "Must have at least two decider verification keys.");
     using Flavor = Flavor_;
+    using FF = typename Flavor_::FF;
     using Commitment = typename Flavor_::Commitment;
     using VerificationKey = typename Flavor::VerificationKey;
     using DeciderVK = DeciderVerificationKey_<Flavor>;
@@ -137,6 +138,20 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderVerificationKeys_ {
         std::vector<Commitment> result(NUM);
         for (auto [elt, key] : zip_view(result, _data)) {
             elt = key->witness_commitments.get_all()[idx];
+        }
+
+        return result;
+    }
+
+    /**
+     * @brief Get the witness commitments at a given index
+     * @details This is similar to get_precomputed_commitments_at_index, but for witness commitments.
+     */
+    std::vector<FF> get_alphas_at_index(const size_t idx) const
+    {
+        std::vector<FF> result(NUM);
+        for (auto [elt, key] : zip_view(result, _data)) {
+            elt = key->alphas[idx];
         }
 
         return result;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
@@ -158,16 +158,19 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderVerificationKeys_ {
     }
 
     /**
-     * @brief Get the witness commitments at a given index
-     * @details This is similar to get_precomputed_commitments_at_index, but for witness commitments.
+     * @brief Get the relation parameters at a given index
+     * @details This is similar to get_precomputed_commitments_at_index, but for relation parameters.
      */
-    std::vector<FF> get_relation_parameters_at_index(const size_t idx) const
+    std::vector<std::vector<FF>> get_relation_parameters() const
     {
-        std::vector<FF> result(NUM);
-        for (auto [elt, key] : zip_view(result, _data)) {
-            elt = key->relation_parameters.get_to_fold()[idx];
+        const size_t num_params_to_fold = _data[0]->relation_parameters.get_to_fold().size();
+        std::vector<std::vector<FF>> result(num_params_to_fold, std::vector<FF>(NUM));
+        for (size_t idx = 0; auto& params_at_idx : result) {
+            for (auto [elt, key] : zip_view(params_at_idx, _data)) {
+                elt = key->relation_parameters.get_to_fold()[idx];
+            }
+            idx++;
         }
-
         return result;
     }
 };

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
@@ -86,6 +86,7 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderProvingKeys_ {
 template <typename Flavor_, size_t NUM_ = 2> struct DeciderVerificationKeys_ {
     static_assert(NUM_ > 1, "Must have at least two decider verification keys.");
     using Flavor = Flavor_;
+    using Commitment = typename Flavor_::Commitment;
     using VerificationKey = typename Flavor::VerificationKey;
     using DeciderVK = DeciderVerificationKey_<Flavor>;
     using ArrayType = std::array<std::shared_ptr<DeciderVK>, NUM_>;
@@ -106,5 +107,15 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderVerificationKeys_ {
             _data[idx] = std::move(data[idx]);
         }
     };
+
+    std::vector<Commitment> get_commitments_at_index(const size_t idx) const
+    {
+        std::vector<Commitment> result(NUM);
+        for (auto [elt, key] : zip_view(result, _data)) {
+            elt = key->verification_key->get_all()[idx];
+        }
+
+        return result;
+    }
 };
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
@@ -143,24 +143,19 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderVerificationKeys_ {
         return result;
     }
 
-    /**
-     * @brief Get the witness commitments at a given index
-     * @details This is similar to get_precomputed_commitments_at_index, but for witness commitments.
-     */
-    std::vector<FF> get_alphas_at_index(const size_t idx) const
+    std::vector<std::vector<FF>> get_alphas() const
     {
-        std::vector<FF> result(NUM);
-        for (auto [elt, key] : zip_view(result, _data)) {
-            elt = key->alphas[idx];
+        const size_t num_alphas_to_fold = _data[0]->alphas.size();
+        std::vector<std::vector<FF>> result(num_alphas_to_fold, std::vector<FF>(NUM));
+        for (size_t idx = 0; auto& alpha_at_idx : result) {
+            for (auto [elt, key] : zip_view(alpha_at_idx, _data)) {
+                elt = key->alphas[idx];
+            }
+            idx++;
         }
-
         return result;
     }
 
-    /**
-     * @brief Get the relation parameters at a given index
-     * @details This is similar to get_precomputed_commitments_at_index, but for relation parameters.
-     */
     std::vector<std::vector<FF>> get_relation_parameters() const
     {
         const size_t num_params_to_fold = _data[0]->relation_parameters.get_to_fold().size();

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
@@ -98,8 +98,8 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderVerificationKeys_ {
     std::shared_ptr<DeciderVK> const& operator[](size_t idx) const { return _data[idx]; }
     typename ArrayType::iterator begin() { return _data.begin(); };
     typename ArrayType::iterator end() { return _data.end(); };
-    DeciderVerificationKeys_() = default;
 
+    DeciderVerificationKeys_() = default;
     DeciderVerificationKeys_(const std::vector<std::shared_ptr<DeciderVK>>& data)
     {
         ASSERT(data.size() == NUM);
@@ -108,11 +108,21 @@ template <typename Flavor_, size_t NUM_ = 2> struct DeciderVerificationKeys_ {
         }
     };
 
-    std::vector<Commitment> get_commitments_at_index(const size_t idx) const
+    std::vector<Commitment> get_precomputed_commitments_at_index(const size_t idx) const
     {
         std::vector<Commitment> result(NUM);
         for (auto [elt, key] : zip_view(result, _data)) {
             elt = key->verification_key->get_all()[idx];
+        }
+
+        return result;
+    }
+
+    std::vector<Commitment> get_witness_commitments_at_index(const size_t idx) const
+    {
+        std::vector<Commitment> result(NUM);
+        for (auto [elt, key] : zip_view(result, _data)) {
+            elt = key->witness_commitments->get_all()[idx];
         }
 
         return result;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verification_key.hpp
@@ -35,7 +35,7 @@ template <class Flavor, size_t NUM_ = 2> class DeciderVerificationKey_ {
 
     DeciderVerificationKey_() = default;
     DeciderVerificationKey_(std::shared_ptr<VerificationKey> vk)
-        : verification_key(std::move(vk))
+        : verification_key(vk)
     {}
 
     MSGPACK_FIELDS(verification_key,

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verification_key.hpp
@@ -35,7 +35,7 @@ template <class Flavor, size_t NUM_ = 2> class DeciderVerificationKey_ {
 
     DeciderVerificationKey_() = default;
     DeciderVerificationKey_(std::shared_ptr<VerificationKey> vk)
-        : verification_key(vk)
+        : verification_key(std::move(vk))
     {}
 
     MSGPACK_FIELDS(verification_key,


### PR DESCRIPTION
This PR reorganizes the native folding verifier to better match the folding prover. This amounts to encapsulating some logic in functions and a mild reshuffling. It's tempting to also implement the verifier as a series of pure-ish round functions, but I don't do that for lack of time.