### PR TITLE
chore: use uint32_t instead of size_t for databus data

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.hpp
@@ -93,7 +93,7 @@ std::vector<bb::fr> convert_grumpkin_fr_to_bn254_frs(const grumpkin::fr& val);
  */
 template <typename T> std::vector<bb::fr> convert_to_bn254_frs(const T& val)
 {
-    if constexpr (IsAnyOf<T, bool, uint32_t, uint64_t, size_t, bb::fr>) {
+    if constexpr (IsAnyOf<T, bool, uint32_t, uint64_t, bb::fr>) {
         std::vector<bb::fr> fr_vec{ val };
         return fr_vec;
     } else if constexpr (IsAnyOf<T, grumpkin::fr>) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
@@ -140,7 +140,7 @@ template <class Builder> class DataBusDepot {
         auto context = commitment.get_context();
 
         // Set flag indicating propagation of return data; save the index at which it will be stored in public inputs
-        size_t start_idx = context->public_inputs.size();
+        auto start_idx = static_cast<uint32_t>(context->public_inputs.size());
         if (is_kernel) {
             context->databus_propagation_data.contains_kernel_return_data_commitment = true;
             context->databus_propagation_data.kernel_return_data_public_input_idx = start_idx;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/databus.hpp
@@ -77,8 +77,8 @@ struct DatabusPropagationData {
     // The start index of the return data commitments (if present) in the public inputs. Note: a start index is all
     // that's needed here since the commitents are represented by a fixed number of witnesses and are contiguous in the
     // public inputs by construction.
-    size_t app_return_data_public_input_idx = 0;
-    size_t kernel_return_data_public_input_idx = 0;
+    uint32_t app_return_data_public_input_idx = 0;
+    uint32_t kernel_return_data_public_input_idx = 0;
 
     // Is this a kernel circuit (used to determine when databus consistency checks can be appended to a circuit in IVC)
     bool is_kernel = false;


### PR DESCRIPTION
Change type from `size_t` to `uint32_t` for `databus_propagation_data` to avoid potential issues serializing `size_t`.