### PR TITLE
fix: enable verifier when deploying the networks

### DIFF
--- a/.github/workflows/devnet-deploys.yml
+++ b/.github/workflows/devnet-deploys.yml
@@ -771,7 +771,6 @@ jobs:
           ./.github/scripts/wait_for_infra.sh pxe ${{ env.DEPLOY_TAG }} ${{ env.API_KEY }}
 
       - name: Deploy verifier (allow failure)
-        continue-on-error: true
         working-directory: ./yarn-project/aztec/terraform/pxe
         run: |
           set -eo pipefail

--- a/yarn-project/cli/src/cmds/l1/deploy_l1_verifier.ts
+++ b/yarn-project/cli/src/cmds/l1/deploy_l1_verifier.ts
@@ -57,7 +57,7 @@ export async function deployUltraHonkVerifier(
   const output = JSON.parse(solc.compile(JSON.stringify(input)));
   log('Compiled UltraHonkVerifier');
 
-  const abi = output.contracts['UltraHonkVerifier.sol']['UltraHonkVerifier'].abi;
+  const abi = output.contracts['UltraHonkVerifier.sol']['HonkVerifier'].abi;
   const bytecode: string = output.contracts['UltraHonkVerifier.sol']['HonkVerifier'].evm.bytecode.object;
 
   const { publicClient, walletClient } = createL1Clients(


### PR DESCRIPTION
Fixes an `can't access X on undefined` error and fails a network deploy if deploying the verifier fails.
