### PR TITLE
chore: fix a load of warnings in aztec-nr

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/mod.nr
@@ -9,13 +9,13 @@ mod unconstrained_context;
 mod call_interfaces;
 mod gas;
 
-use call_interfaces::{
+pub use call_interfaces::{
     PrivateCallInterface, PrivateStaticCallInterface, PublicCallInterface, PublicStaticCallInterface,
     PrivateVoidCallInterface, PrivateStaticVoidCallInterface, PublicVoidCallInterface,
     PublicStaticVoidCallInterface
 };
-use private_context::PrivateContext;
-use packed_returns::PackedReturns;
-use public_context::PublicContext;
-use public_context::FunctionReturns;
-use unconstrained_context::UnconstrainedContext;
+pub use private_context::PrivateContext;
+pub use packed_returns::PackedReturns;
+pub use public_context::PublicContext;
+pub use public_context::FunctionReturns;
+pub use unconstrained_context::UnconstrainedContext;

--- a/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
@@ -25,4 +25,4 @@ mod returns;
 
 // debug_log oracle is used by both noir-protocol-circuits and this crate and for this reason we just re-export it
 // here from protocol circuits.
-use dep::protocol_types::debug_log;
+pub use dep::protocol_types::debug_log;

--- a/noir-projects/aztec-nr/aztec/src/prelude.nr
+++ b/noir-projects/aztec-nr/aztec/src/prelude.nr
@@ -1,9 +1,9 @@
 // docs:start:prelude
-use dep::protocol_types::{
+pub use dep::protocol_types::{
     address::{AztecAddress, EthAddress}, abis::function_selector::FunctionSelector, point::Point,
     traits::{Serialize, Deserialize}
 };
-use crate::{
+pub use crate::{
     state_vars::{
     map::Map, private_immutable::PrivateImmutable, private_mutable::PrivateMutable,
     public_immutable::PublicImmutable, public_mutable::PublicMutable, private_set::PrivateSet,

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
@@ -1,5 +1,5 @@
 use dep::protocol_types::{
-    address::AztecAddress, constants::GENERATOR_INDEX__INITIALIZATION_NULLIFIER,
+    constants::GENERATOR_INDEX__INITIALIZATION_NULLIFIER,
     hash::poseidon2_hash_with_separator
 };
 
@@ -32,7 +32,7 @@ impl<Note, Context> PrivateImmutable<Note, Context> {
     // When this initialization nullifier is emitted, an observer could do a dictionary or rainbow attack to learn the preimage of this nullifier to deduce the storage slot and contract address.
     // For some applications, leaking the details that a particular state variable of a particular contract has been initialized will be unacceptable.
     // Under such circumstances, such application developers might wish to _not_ use this state variable type.
-    // This is especially dangerous for initial assignment to elements of a `Map<AztecAddress, PrivateImmutable>` type (for example), because the storage slot often also identifies an actor. 
+    // This is especially dangerous for initial assignment to elements of a `Map<AztecAddress, PrivateImmutable>` type (for example), because the storage slot often also identifies an actor.
     // e.g. the initial assignment to `my_map.at(msg.sender)` will leak: `msg.sender`, the fact that an element of `my_map` was assigned-to for the first time, and the contract_address.
     pub fn compute_initialization_nullifier(self) -> Field {
         poseidon2_hash_with_separator(

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
@@ -1,7 +1,4 @@
-use dep::protocol_types::{
-    constants::GENERATOR_INDEX__INITIALIZATION_NULLIFIER,
-    hash::poseidon2_hash_with_separator
-};
+use dep::protocol_types::{constants::GENERATOR_INDEX__INITIALIZATION_NULLIFIER, hash::poseidon2_hash_with_separator};
 
 use crate::context::{PrivateContext, UnconstrainedContext};
 use crate::note::{

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
@@ -4,7 +4,7 @@ use crate::note::{
     constants::MAX_NOTES_PER_PAGE,
     lifecycle::{create_note, create_note_hash_from_public, destroy_note_unsafe},
     note_getter::{get_notes, view_notes}, note_getter_options::NoteGetterOptions,
-    note_header::NoteHeader, note_interface::NoteInterface, note_viewer_options::NoteViewerOptions,
+    note_interface::NoteInterface, note_viewer_options::NoteViewerOptions,
     utils::compute_note_hash_for_read_request, note_emission::NoteEmission
 };
 use crate::state_vars::storage::Storage;

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -1,7 +1,4 @@
-use crate::{
-    context::{PublicContext, UnconstrainedContext}, oracle::storage::storage_read,
-    state_vars::storage::Storage
-};
+use crate::{context::{PublicContext, UnconstrainedContext}, state_vars::storage::Storage};
 use dep::protocol_types::{constants::INITIALIZATION_SLOT_SEPARATOR, traits::{Deserialize, Serialize}};
 
 // Just like SharedImmutable but without the ability to read from private functions.

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_immutable.nr
@@ -1,5 +1,5 @@
 use crate::{
-    context::{PrivateContext, PublicContext, UnconstrainedContext}, oracle::storage::storage_read,
+    context::{PrivateContext, PublicContext, UnconstrainedContext},
     state_vars::storage::Storage
 };
 use dep::protocol_types::{constants::INITIALIZATION_SLOT_SEPARATOR, traits::{Deserialize, Serialize}};
@@ -24,7 +24,7 @@ impl<T, Context> SharedImmutable<T, Context> {
 }
 
 impl<T, T_SERIALIZED_LEN> SharedImmutable<T, &mut PublicContext> where T: Serialize<T_SERIALIZED_LEN> + Deserialize<T_SERIALIZED_LEN> {
-    // Intended to be only called once. 
+    // Intended to be only called once.
     pub fn initialize(self, value: T) {
         // We check that the struct is not yet initialized by checking if the initialization slot is 0
         let initialization_slot = INITIALIZATION_SLOT_SEPARATOR + self.storage_slot;

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_immutable.nr
@@ -1,7 +1,4 @@
-use crate::{
-    context::{PrivateContext, PublicContext, UnconstrainedContext},
-    state_vars::storage::Storage
-};
+use crate::{context::{PrivateContext, PublicContext, UnconstrainedContext}, state_vars::storage::Storage};
 use dep::protocol_types::{constants::INITIALIZATION_SLOT_SEPARATOR, traits::{Deserialize, Serialize}};
 
 // Just like PublicImmutable but with the ability to read from private functions.

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/scheduled_delay_change.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/scheduled_delay_change.nr
@@ -1,16 +1,16 @@
-use dep::protocol_types::traits::{Serialize, Deserialize, FromField, ToField};
+use dep::protocol_types::traits::{Serialize, Deserialize};
 use std::cmp::min;
 
 mod test;
 
 // This data structure is used by SharedMutable to store the minimum delay with which a ScheduledValueChange object can
 // schedule a change.
-// This delay is initally equal to INITIAL_DELAY, and can be safely mutated to any other value over time. This mutation 
-// is performed via `schedule_change` in order to satisfy ScheduleValueChange constraints: if e.g. we allowed for the 
-// delay to be decreased immediately then it'd be possible for the state variable to schedule a value change with a 
+// This delay is initally equal to INITIAL_DELAY, and can be safely mutated to any other value over time. This mutation
+// is performed via `schedule_change` in order to satisfy ScheduleValueChange constraints: if e.g. we allowed for the
+// delay to be decreased immediately then it'd be possible for the state variable to schedule a value change with a
 // reduced delay, invalidating prior private reads.
 struct ScheduledDelayChange<let INITIAL_DELAY: u32> {
-    // Both pre and post are stored in public storage, so by default they are zeroed. By wrapping them in an Option, 
+    // Both pre and post are stored in public storage, so by default they are zeroed. By wrapping them in an Option,
     // they default to Option::none(), which we detect and replace with INITIAL_DELAY. The end result is that a
     // ScheduledDelayChange that has not been initialized has a delay equal to INITIAL_DELAY, which is the desired
     // effect. Once initialized, the Option will never be none again.
@@ -83,11 +83,11 @@ impl<let INITIAL_DELAY: u32> ScheduledDelayChange<INITIAL_DELAY> {
     }
 
     /// Returns the minimum delay before a value might mutate due to a scheduled change, from the perspective of some
-    /// historical block number. It only returns a meaningful value when called in private with historical blocks. This 
+    /// historical block number. It only returns a meaningful value when called in private with historical blocks. This
     /// function can be used alongside `ScheduledValueChange.get_block_horizon` to properly constrain the
     /// `max_block_number` transaction property when reading mutable shared state.
     /// This value typically equals the current delay at the block following the historical one (the earliest one in
-    /// which a value change could be scheduled), but it also considers scenarios in which a delay reduction is 
+    /// which a value change could be scheduled), but it also considers scenarios in which a delay reduction is
     /// scheduled to happen in the near future, resulting in a way to schedule a change with an overall delay lower than
     /// the current one.
     pub fn get_effective_minimum_delay_at(self, historical_block_number: u32) -> u32 {
@@ -114,7 +114,7 @@ impl<let INITIAL_DELAY: u32> ScheduledDelayChange<INITIAL_DELAY> {
             //           |      until change                                              |
             //           |                                                                |
             //           |----------------------------------------------------------------|
-            //                        current delay at the earliest block in 
+            //                        current delay at the earliest block in
             //                             which to scheduled value change
 
             let blocks_until_change = self.block_of_change - (historical_block_number + 1);
@@ -136,8 +136,8 @@ impl<INITIAL_DELAY> Serialize<1> for ScheduledDelayChange<INITIAL_DELAY> {
         let lo = ((self.pre.unwrap_unchecked() as u64) * (1 << 32))
             + (self.post.unwrap_unchecked() as u64);
 
-        let hi = (self.pre.is_some() as u64) * (1 << 33) 
-            + (self.post.is_some() as u64 * (1 << 32)) 
+        let hi = (self.pre.is_some() as u64) * (1 << 33)
+            + (self.post.is_some() as u64 * (1 << 32))
             + self.block_of_change as u64;
 
         let packed = U128::from_u64s_le(lo, hi);

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -1,8 +1,8 @@
 use dep::aztec::{
     generators::{Ga1 as G_amt, Ga2 as G_npk, Ga3 as G_rnd, G_slot},
-    prelude::{NoteHeader, NoteInterface, PrivateContext},
+    prelude::{NoteInterface, PrivateContext},
     protocol_types::{
-    constants::GENERATOR_INDEX__NOTE_NULLIFIER, point::{Point, POINT_LENGTH}, scalar::Scalar,
+    constants::GENERATOR_INDEX__NOTE_NULLIFIER, point::{Point, POINT_LENGTH},
     hash::poseidon2_hash_with_separator, traits::Serialize
 },
     note::utils::compute_note_hash_for_nullify, oracle::unsafe_rand::unsafe_rand,


### PR DESCRIPTION
aztec-nr isn't properly specifying the visibility of its re-exports so there's a ton of warnings. This PR addresses some of them along with some unused imports.