### PR TITLE
fix: load prover node config from env

### DIFF
--- a/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
@@ -7,6 +7,7 @@ import {
   type ProverNodeConfig,
   createProverNode,
   createProverNodeRpcServer,
+  getProverNodeConfigFromEnv,
   proverNodeConfigMappings,
 } from '@aztec/prover-node';
 import { createAndStartTelemetryClient, telemetryClientConfigMappings } from '@aztec/telemetry-client/start';
@@ -29,7 +30,8 @@ export const startProverNode = async (
   }
 
   const proverConfig = {
-    ...extractRelevantOptions<ProverNodeConfig>(options, proverNodeConfigMappings, 'proverNode'),
+    ...getProverNodeConfigFromEnv(), // get default config from env
+    ...extractRelevantOptions<ProverNodeConfig>(options, proverNodeConfigMappings, 'proverNode'), // override with command line options
     l1Contracts: extractL1ContractAddresses(options),
   };
 


### PR DESCRIPTION
Fixes spartan deployments.

`BigInt(config.archiverL1StartBlock)` was failing because `config.archiverL1StartBlock` was not defined in the environment, nor on the command line, and the existing code did not actually use the `parseEnv` command, which is how this default value seems to be loaded.