### PR TITLE
chore: add jq to aztec image

### DIFF
--- a/yarn-project/Dockerfile
+++ b/yarn-project/Dockerfile
@@ -62,5 +62,5 @@ ENV COMMIT_TAG=$COMMIT_TAG
 COPY --from=builder /usr/src /usr/src
 WORKDIR /usr/src/yarn-project
 # add curl to be able to download CRS file
-RUN apt update && apt install -y curl
+RUN apt update && apt install -y curl jq
 ENTRYPOINT ["yarn"]


### PR DESCRIPTION
It is useful for parsing output from CLI. E.g. in `spartan/aztec-network/files/config/config-validator-env.sh`

```
# Generate a private key for the validator
json_account=$(aztec generate-l1-account)

echo "$json_account"
address=$(echo $json_account | jq -r '.address')
private_key=$(echo $json_account | jq -r '.privateKey')
```