### PR TITLE
fix: native world state test issues

### DIFF
--- a/yarn-project/world-state/scripts/build.sh
+++ b/yarn-project/world-state/scripts/build.sh
@@ -5,15 +5,16 @@ set -e
 cd "$(dirname "$0")/.."
 
 # relatiev path from the directory containing package.json
-WORLD_STATE_LIB_PATH=../../barretenberg/cpp/build/bin/world_state_napi.node
+WORLD_STATE_LIB_PATH=../../barretenberg/cpp/build-pic/lib/world_state_napi.node
+PRESET=${PRESET:-clang16-pic}
 
 build_addon() {
-  (cd ../../barretenberg/cpp; cmake --preset clang16-pic -DCMAKE_BUILD_TYPE=RelWithAssert; cmake --build --preset clang16-pic --target world_state_napi; echo $PWD; mkdir -p build/bin;  cp ./build-pic/lib/world_state_napi.node ./build/bin/world_state_napi.node)
+  (cd ../../barretenberg/cpp; cmake --preset $PRESET -DCMAKE_BUILD_TYPE=RelWithAssert; cmake --build --preset $PRESET --target world_state_napi; echo $PWD; mkdir -p build/bin;  cp ./build-pic/lib/world_state_napi.node ./build/bin/world_state_napi.node)
 }
 
 cp_addon_lib() {
   if [ -f $WORLD_STATE_LIB_PATH ]; then
-    echo "Copying world_state_napi.node to build directory"
+    echo "Copying $(realpath $WORLD_STATE_LIB_PATH) to build directory"
     rm -rf build
     mkdir build
     cp $WORLD_STATE_LIB_PATH build/world_state_napi.node


### PR DESCRIPTION
This PR fixes the flaky Jest tests that were comparing the C++ WorldState against the JS implementation.

The issue stemmed from the `WorldState::get_state_reference` function reading state reference for all five trees in parallel and saving that information in a `std::unordered_map`. Concurrent writes to a `std::unordered_map` [are invalid](https://devblogs.microsoft.com/oldnewthing/20231103-00/?p=108966) so I've added a lock to ensure that only one thread writes at a time. Simultaneous reads are fine though.

