### PR TITLE
fix: remove special case for epoch 0

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -170,7 +170,7 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
 
   function computeTxsEffectsHash(bytes calldata _body)
     external
-    view
+    pure
     override(IRollup)
     returns (bytes32)
   {

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -66,5 +66,5 @@ interface IRollup {
 
   function archive() external view returns (bytes32);
   function archiveAt(uint256 _blockNumber) external view returns (bytes32);
-  function computeTxsEffectsHash(bytes calldata _body) external view returns (bytes32);
+  function computeTxsEffectsHash(bytes calldata _body) external pure returns (bytes32);
 }

--- a/l1-contracts/src/core/sequencer_selection/Leonidas.sol
+++ b/l1-contracts/src/core/sequencer_selection/Leonidas.sol
@@ -289,9 +289,6 @@ contract Leonidas is Ownable, ILeonidas {
   function getProposerAt(uint256 _ts) public view override(ILeonidas) returns (address) {
     uint256 epochNumber = getEpochAt(_ts);
     uint256 slot = getSlotAt(_ts);
-    if (epochNumber == 0) {
-      return address(0);
-    }
 
     Epoch storage epoch = epochs[epochNumber];
 

--- a/l1-contracts/test/sparta/Sparta.t.sol
+++ b/l1-contracts/test/sparta/Sparta.t.sol
@@ -97,6 +97,9 @@ contract SpartaTest is DecoderBase {
       assertFalse(_seenCommittee[committee[i]]);
       _seenCommittee[committee[i]] = true;
     }
+
+    address proposer = rollup.getCurrentProposer();
+    assertTrue(_seenCommittee[proposer]);
   }
 
   function testProposerForNonSetupEpoch(uint8 _epochsToJump) public setup(4) {

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -383,6 +383,9 @@ export async function setup(
     config.publisherPrivateKey = `0x${publisherPrivKey!.toString('hex')}`;
   }
 
+  // Made as separate values such that keys can change, but for test they will be the same.
+  config.validatorPrivateKey = config.publisherPrivateKey;
+
   if (PXE_URL) {
     // we are setting up against a remote environment, l1 contracts are assumed to already be deployed
     return await setupWithRemoteEnvironment(publisherHdAccount!, config, logger, numberOfAccounts, enableGas);
@@ -407,10 +410,6 @@ export async function setup(
   );
 
   await watcher.start();
-
-  // Run the test with validators enabled
-  const validatorPrivKey = getPrivateKeyFromIndex(1);
-  config.validatorPrivateKey = `0x${validatorPrivKey!.toString('hex')}`;
 
   logger.verbose('Creating and synching an aztec node...');
 

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -405,14 +405,12 @@ export class L1Publisher {
           }),
         });
 
-        const min = (a: bigint, b: bigint) => (a > b ? b : a);
-
         // @note  We perform this guesstimate instead of the usual `gasEstimate` since
         //        viem will use the current state to simulate against, which means that
         //        we will fail estimation in the case where we are simulating for the
         //        first ethereum block within our slot (as current time is not in the
         //        slot yet).
-        const gasGuesstimate = min(computeTxsEffectsHashGas + L1Publisher.PROPOSE_GAS_GUESS, 15_000_000n);
+        const gasGuesstimate = computeTxsEffectsHashGas + L1Publisher.PROPOSE_GAS_GUESS;
 
         const attestations = encodedData.attestations
           ? encodedData.attestations.map(attest => attest.toViemSignature())


### PR DESCRIPTION
Getting rid of the edge case for epoch 0 with regards to the proposer. Also removes the `min` in the publisher, as this should be accounted for by the kb that we can push in blob data, and would only be a hinderance currently for large blocks as we are doing calldata 🤷 

Changes the `validate` keys of the fixture setup to match the first account such that the sequencer is the validator as well.