### PR TITLE
chore: remove unused imports

### DIFF
--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -5,8 +5,7 @@ use dep::aztec::{
     constants::GENERATOR_INDEX__NOTE_NULLIFIER, point::{Point, POINT_LENGTH},
     hash::poseidon2_hash_with_separator, traits::Serialize
 },
-    note::utils::compute_note_hash_for_nullify, oracle::unsafe_rand::unsafe_rand,
-    keys::getters::get_nsk_app
+    note::utils::compute_note_hash_for_nullify, keys::getters::get_nsk_app
 };
 use dep::std::{embedded_curve_ops::multi_scalar_mul, hash::from_field_unsafe};
 

--- a/noir-projects/noir-protocol-circuits/crates/parity-lib/src/base/base_parity_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/parity-lib/src/base/base_parity_inputs.nr
@@ -1,5 +1,5 @@
 use crate::{parity_public_inputs::ParityPublicInputs, utils::sha256_merkle_tree::Sha256MerkleTree};
-use dep::types::{constants::NUM_MSGS_PER_BASE_PARITY, merkle_tree::MerkleTree, utils::uint256::U256};
+use dep::types::{constants::NUM_MSGS_PER_BASE_PARITY, merkle_tree::MerkleTree};
 
 struct BaseParityInputs {
     msgs: [Field; NUM_MSGS_PER_BASE_PARITY],

--- a/noir-projects/noir-protocol-circuits/crates/parity-lib/src/lib.nr
+++ b/noir-projects/noir-protocol-circuits/crates/parity-lib/src/lib.nr
@@ -3,8 +3,8 @@ mod root;
 mod parity_public_inputs;
 mod utils;
 
-use crate::base::base_parity_inputs::BaseParityInputs;
-use crate::root::root_parity_input::RootParityInput;
-use crate::root::root_parity_inputs::RootParityInputs;
-use crate::root::root_rollup_parity_input::RootRollupParityInput;
-use crate::parity_public_inputs::ParityPublicInputs;
+pub use crate::base::base_parity_inputs::BaseParityInputs;
+pub use crate::root::root_parity_input::RootParityInput;
+pub use crate::root::root_parity_inputs::RootParityInputs;
+pub use crate::root::root_rollup_parity_input::RootRollupParityInput;
+pub use crate::parity_public_inputs::ParityPublicInputs;

--- a/noir-projects/noir-protocol-circuits/crates/parity-lib/src/root/root_parity_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/parity-lib/src/root/root_parity_inputs.nr
@@ -1,12 +1,8 @@
-use dep::types::{
-    merkle_tree::MerkleTree, recursion::{verification_key::VerificationKey, proof::RecursiveProof},
-    traits::Serialize
-};
+use dep::types::merkle_tree::MerkleTree;
 use crate::{
     parity_public_inputs::ParityPublicInputs, root::root_parity_input::RootParityInput,
     utils::sha256_merkle_tree::Sha256MerkleTree
 };
-use dep::std;
 
 global NUM_BASE_PARITY_PER_ROOT_PARITY: u64 = 4;
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/base_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/base_rollup_inputs.nr
@@ -482,10 +482,7 @@ mod tests {
     },
         partial_state_reference::PartialStateReference,
         data::{PublicDataTreeLeaf, PublicDataTreeLeafPreimage},
-        tests::{
-        fixtures, fixture_builder::FixtureBuilder,
-        merkle_tree_utils::{NonEmptyMerkleTree, compute_zero_hashes}
-    },
+        tests::{fixtures, fixture_builder::FixtureBuilder, merkle_tree_utils::NonEmptyMerkleTree},
         utils::{arrays::get_sorted_tuple::get_sorted_tuple, field::{full_field_less_than, field_from_bytes_32_trunc}},
         traits::Empty
     };
@@ -607,10 +604,6 @@ mod tests {
         // Index of the item in the pre_existing_public_data array that contains the fee payer's Fee Juice balance.
         // Used for building the public data hint read for the payment update request. If set to none, no hint is built.
         fee_payer_fee_juice_balance_pre_existing_public_data_index: Option<u32>
-    }
-
-    fn test_compute_empty_root<let N: u32>(size: [Field; N]) -> Field {
-        compute_zero_hashes(size)[N - 1]
     }
 
     impl BaseRollupInputsBuilder {


### PR DESCRIPTION
This PR removes a bunch of unused imports and makes private items public if they are reexports.