### PR TITLE
refactor: remove AvmVerificationKeyData and tube specific types

### DIFF
--- a/yarn-project/bb-prover/src/avm_proving.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving.test.ts
@@ -1,10 +1,10 @@
 import {
   AvmCircuitInputs,
-  AvmVerificationKeyData,
   FunctionSelector,
   Gas,
   GlobalVariables,
   SerializableContractInstance,
+  VerificationKeyData,
 } from '@aztec/circuits.js';
 import { Fr } from '@aztec/foundation/fields';
 import { createDebugLogger } from '@aztec/foundation/log';
@@ -131,7 +131,7 @@ const proveAndVerifyAvmTestContract = async (
   // Then we test VK extraction and serialization.
   const succeededRes = proofRes as BBSuccess;
   const vkData = await extractAvmVkData(succeededRes.vkPath!);
-  AvmVerificationKeyData.fromBuffer(vkData.toBuffer());
+  VerificationKeyData.fromBuffer(vkData.toBuffer());
 
   // Then we verify.
   const rawVkPath = path.join(succeededRes.vkPath!, 'vk');

--- a/yarn-project/bb-prover/src/prover/bb_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_prover.ts
@@ -1,8 +1,9 @@
 /* eslint-disable require-await */
 import {
-  type AvmProofAndVerificationKey,
+  ProofAndVerificationKey,
   type PublicInputsAndRecursiveProof,
   type ServerCircuitProver,
+  makeProofAndVerificationKey,
   makePublicInputsAndRecursiveProof,
 } from '@aztec/circuit-types';
 import { type CircuitProvingStats, type CircuitWitnessGenerationStats } from '@aztec/circuit-types/stats';
@@ -207,7 +208,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
   @trackSpan('BBNativeRollupProver.getAvmProof', inputs => ({
     [Attributes.APP_CIRCUIT_NAME]: inputs.functionName,
   }))
-  public async getAvmProof(inputs: AvmCircuitInputs): Promise<AvmProofAndVerificationKey> {
+  public async getAvmProof(inputs: AvmCircuitInputs): Promise<ProofAndVerificationKey<Proof>> {
     const proofAndVk = await this.createAvmProof(inputs);
     await this.verifyAvmProof(proofAndVk.proof, proofAndVk.verificationKey);
     return proofAndVk;
@@ -676,8 +677,8 @@ export class BBNativeRollupProver implements ServerCircuitProver {
     return provingResult;
   }
 
-  private async createAvmProof(input: AvmCircuitInputs): Promise<AvmProofAndVerificationKey> {
-    const operation = async (bbWorkingDirectory: string): Promise<AvmProofAndVerificationKey> => {
+  private async createAvmProof(input: AvmCircuitInputs): Promise<ProofAndVerificationKey<Proof>> {
+    const operation = async (bbWorkingDirectory: string): Promise<ProofAndVerificationKey<Proof>> => {
       const provingResult = await this.generateAvmProofWithBB(input, bbWorkingDirectory);
 
       const rawProof = await fs.readFile(provingResult.proofPath!);
@@ -708,14 +709,14 @@ export class BBNativeRollupProver implements ServerCircuitProver {
         } satisfies CircuitProvingStats,
       );
 
-      return { proof, verificationKey };
+      return makeProofAndVerificationKey(proof, verificationKey);
     };
     return await this.runInDirectory(operation);
   }
 
   public async getTubeProof(
     input: TubeInputs,
-  ): Promise<{ tubeVK: VerificationKeyData; tubeProof: RecursiveProof<typeof TUBE_PROOF_LENGTH> }> {
+  ): Promise<ProofAndVerificationKey<RecursiveProof<typeof TUBE_PROOF_LENGTH>>> {
     // this probably is gonna need to call client ivc
     const operation = async (bbWorkingDirectory: string) => {
       logger.debug(`createTubeProof: ${bbWorkingDirectory}`);
@@ -739,7 +740,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
         } fields`,
       );
 
-      return { tubeVK, tubeProof };
+      return makeProofAndVerificationKey(tubeProof, tubeVK);
     };
     return await this.runInDirectory(operation);
   }

--- a/yarn-project/bb-prover/src/prover/bb_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_prover.ts
@@ -1,6 +1,6 @@
 /* eslint-disable require-await */
 import {
-  ProofAndVerificationKey,
+  type ProofAndVerificationKey,
   type PublicInputsAndRecursiveProof,
   type ServerCircuitProver,
   makeProofAndVerificationKey,

--- a/yarn-project/bb-prover/src/prover/bb_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_prover.ts
@@ -9,7 +9,6 @@ import { type CircuitProvingStats, type CircuitWitnessGenerationStats } from '@a
 import {
   AGGREGATION_OBJECT_LENGTH,
   type AvmCircuitInputs,
-  type AvmVerificationKeyData,
   type BaseOrMergeRollupPublicInputs,
   type BaseParityInputs,
   type BaseRollupInputs,
@@ -814,7 +813,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
     return await this.verifyWithKey(getUltraHonkFlavorForCircuit(circuitType), verificationKey, proof);
   }
 
-  public async verifyAvmProof(proof: Proof, verificationKey: AvmVerificationKeyData) {
+  public async verifyAvmProof(proof: Proof, verificationKey: VerificationKeyData) {
     return await this.verifyWithKeyInternal(proof, verificationKey, (proofPath, vkPath) =>
       verifyAvmProof(this.config.bbBinaryPath, proofPath, vkPath, logger.debug),
     );

--- a/yarn-project/bb-prover/src/test/test_circuit_prover.ts
+++ b/yarn-project/bb-prover/src/test/test_circuit_prover.ts
@@ -5,8 +5,8 @@ import {
   makePublicInputsAndRecursiveProof,
 } from '@aztec/circuit-types';
 import {
+  AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS,
   type AvmCircuitInputs,
-  AvmVerificationKeyData,
   type BaseOrMergeRollupPublicInputs,
   type BaseParityInputs,
   type BaseRollupInputs,
@@ -551,7 +551,10 @@ export class TestCircuitProver implements ServerCircuitProver {
     // We just return an empty proof and VK data.
     this.logger.debug('Skipping AVM simulation in TestCircuitProver.');
     await this.delay();
-    return { proof: makeEmptyProof(), verificationKey: AvmVerificationKeyData.makeFake() };
+    return {
+      proof: makeEmptyProof(),
+      verificationKey: VerificationKeyData.makeFake(AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS),
+    };
   }
 
   private async delay(): Promise<void> {

--- a/yarn-project/bb-prover/src/test/test_circuit_prover.ts
+++ b/yarn-project/bb-prover/src/test/test_circuit_prover.ts
@@ -1,7 +1,8 @@
 import {
-  type AvmProofAndVerificationKey,
+  type ProofAndVerificationKey,
   type PublicInputsAndRecursiveProof,
   type ServerCircuitProver,
+  makeProofAndVerificationKey,
   makePublicInputsAndRecursiveProof,
 } from '@aztec/circuit-types';
 import {
@@ -273,12 +274,9 @@ export class TestCircuitProver implements ServerCircuitProver {
 
   public async getTubeProof(
     _tubeInput: TubeInputs,
-  ): Promise<{ tubeVK: VerificationKeyData; tubeProof: RecursiveProof<typeof TUBE_PROOF_LENGTH> }> {
+  ): Promise<ProofAndVerificationKey<RecursiveProof<typeof TUBE_PROOF_LENGTH>>> {
     await this.delay();
-    return {
-      tubeVK: VerificationKeyData.makeFakeHonk(),
-      tubeProof: makeEmptyRecursiveProof(TUBE_PROOF_LENGTH),
-    };
+    return makeProofAndVerificationKey(makeEmptyRecursiveProof(TUBE_PROOF_LENGTH), VerificationKeyData.makeFakeHonk());
   }
 
   /**
@@ -546,15 +544,15 @@ export class TestCircuitProver implements ServerCircuitProver {
     );
   }
 
-  public async getAvmProof(_inputs: AvmCircuitInputs): Promise<AvmProofAndVerificationKey> {
+  public async getAvmProof(_inputs: AvmCircuitInputs): Promise<ProofAndVerificationKey<Proof>> {
     // We can't simulate the AVM because we don't have enough context to do so (e.g., DBs).
     // We just return an empty proof and VK data.
     this.logger.debug('Skipping AVM simulation in TestCircuitProver.');
     await this.delay();
-    return {
-      proof: makeEmptyProof(),
-      verificationKey: VerificationKeyData.makeFake(AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS),
-    };
+    return makeProofAndVerificationKey(
+      makeEmptyProof(),
+      VerificationKeyData.makeFake(AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS),
+    );
   }
 
   private async delay(): Promise<void> {

--- a/yarn-project/bb-prover/src/verification_key/verification_key_data.ts
+++ b/yarn-project/bb-prover/src/verification_key/verification_key_data.ts
@@ -1,7 +1,5 @@
 import {
   AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS,
-  AvmVerificationKeyAsFields,
-  AvmVerificationKeyData,
   Fr,
   VerificationKeyAsFields,
   VerificationKeyData,
@@ -33,7 +31,7 @@ export async function extractVkData(vkDirectoryPath: string): Promise<Verificati
 }
 
 // TODO: This was adapted from the above function. A refactor might be needed.
-export async function extractAvmVkData(vkDirectoryPath: string): Promise<AvmVerificationKeyData> {
+export async function extractAvmVkData(vkDirectoryPath: string): Promise<VerificationKeyData> {
   const [rawFields, rawBinary] = await Promise.all([
     fs.readFile(path.join(vkDirectoryPath, VK_FIELDS_FILENAME), { encoding: 'utf-8' }),
     fs.readFile(path.join(vkDirectoryPath, VK_FILENAME)),
@@ -44,7 +42,7 @@ export async function extractAvmVkData(vkDirectoryPath: string): Promise<AvmVeri
   // TODO: is the above actually the case?
   const vkHash = fields[0];
   assert(fields.length === AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS, 'Invalid AVM verification key length');
-  const vkAsFields = new AvmVerificationKeyAsFields(fields, vkHash);
-  const vk = new AvmVerificationKeyData(vkAsFields, rawBinary);
+  const vkAsFields = new VerificationKeyAsFields(fields, vkHash);
+  const vk = new VerificationKeyData(vkAsFields, rawBinary);
   return vk;
 }

--- a/yarn-project/circuit-types/src/interfaces/proving-job.ts
+++ b/yarn-project/circuit-types/src/interfaces/proving-job.ts
@@ -30,29 +30,30 @@ import {
 
 import { type CircuitName } from '../stats/index.js';
 
-export type AvmProofAndVerificationKey = {
-  proof: Proof;
+export type ProofAndVerificationKey<P> = {
+  proof: P;
   verificationKey: VerificationKeyData;
 };
 
-export type PublicInputsAndRecursiveProof<T> = {
+export function makeProofAndVerificationKey<P>(
+  proof: P,
+  verificationKey: VerificationKeyData,
+): ProofAndVerificationKey<P> {
+  return { proof, verificationKey };
+}
+
+export type PublicInputsAndRecursiveProof<T, N extends number = typeof NESTED_RECURSIVE_PROOF_LENGTH> = {
   inputs: T;
-  proof: RecursiveProof<typeof NESTED_RECURSIVE_PROOF_LENGTH>;
+  proof: RecursiveProof<N>;
   verificationKey: VerificationKeyData;
 };
 
-export type PublicInputsAndTubeProof<T> = {
-  inputs: T;
-  proof: RecursiveProof<typeof TUBE_PROOF_LENGTH>;
-  verificationKey: VerificationKeyData;
-};
-
-export function makePublicInputsAndRecursiveProof<T>(
+export function makePublicInputsAndRecursiveProof<T, N extends number = typeof NESTED_RECURSIVE_PROOF_LENGTH>(
   inputs: T,
-  proof: RecursiveProof<typeof NESTED_RECURSIVE_PROOF_LENGTH>,
+  proof: RecursiveProof<N>,
   verificationKey: VerificationKeyData,
 ) {
-  const result: PublicInputsAndRecursiveProof<T> = {
+  const result: PublicInputsAndRecursiveProof<T, N> = {
     inputs,
     proof,
     verificationKey,
@@ -187,7 +188,7 @@ export type ProvingRequest =
 
 export type ProvingRequestPublicInputs = {
   [ProvingRequestType.PRIVATE_KERNEL_EMPTY]: PublicInputsAndRecursiveProof<KernelCircuitPublicInputs>;
-  [ProvingRequestType.PUBLIC_VM]: AvmProofAndVerificationKey;
+  [ProvingRequestType.PUBLIC_VM]: ProofAndVerificationKey<Proof>;
 
   [ProvingRequestType.PUBLIC_KERNEL_INNER]: PublicInputsAndRecursiveProof<VMCircuitPublicInputs>;
   [ProvingRequestType.PUBLIC_KERNEL_MERGE]: PublicInputsAndRecursiveProof<PublicKernelCircuitPublicInputs>;
@@ -202,8 +203,7 @@ export type ProvingRequestPublicInputs = {
 
   [ProvingRequestType.BASE_PARITY]: RootParityInput<typeof RECURSIVE_PROOF_LENGTH>;
   [ProvingRequestType.ROOT_PARITY]: RootParityInput<typeof NESTED_RECURSIVE_PROOF_LENGTH>;
-  // TODO(#7369) properly structure tube proof flow
-  [ProvingRequestType.TUBE_PROOF]: { tubeVK: VerificationKeyData; tubeProof: RecursiveProof<typeof TUBE_PROOF_LENGTH> };
+  [ProvingRequestType.TUBE_PROOF]: ProofAndVerificationKey<RecursiveProof<typeof TUBE_PROOF_LENGTH>>;
 };
 
 export type ProvingRequestResult<T extends ProvingRequestType> = ProvingRequestPublicInputs[T];

--- a/yarn-project/circuit-types/src/interfaces/proving-job.ts
+++ b/yarn-project/circuit-types/src/interfaces/proving-job.ts
@@ -1,6 +1,5 @@
 import {
   type AvmCircuitInputs,
-  type AvmVerificationKeyData,
   type BaseOrMergeRollupPublicInputs,
   type BaseParityInputs,
   type BaseRollupInputs,
@@ -33,7 +32,7 @@ import { type CircuitName } from '../stats/index.js';
 
 export type AvmProofAndVerificationKey = {
   proof: Proof;
-  verificationKey: AvmVerificationKeyData;
+  verificationKey: VerificationKeyData;
 };
 
 export type PublicInputsAndRecursiveProof<T> = {

--- a/yarn-project/circuit-types/src/interfaces/server_circuit_prover.ts
+++ b/yarn-project/circuit-types/src/interfaces/server_circuit_prover.ts
@@ -1,10 +1,4 @@
 import {
-  type AvmProofAndVerificationKey,
-  type PublicInputsAndRecursiveProof,
-  type PublicInputsAndTubeProof,
-  type Tx,
-} from '@aztec/circuit-types';
-import {
   type AvmCircuitInputs,
   type BaseOrMergeRollupPublicInputs,
   type BaseParityInputs,
@@ -17,6 +11,7 @@ import {
   type MergeRollupInputs,
   type NESTED_RECURSIVE_PROOF_LENGTH,
   type PrivateKernelEmptyInputData,
+  type Proof,
   type PublicKernelCircuitPrivateInputs,
   type PublicKernelCircuitPublicInputs,
   type PublicKernelInnerCircuitPrivateInputs,
@@ -27,10 +22,13 @@ import {
   type RootParityInputs,
   type RootRollupInputs,
   type RootRollupPublicInputs,
+  type TUBE_PROOF_LENGTH,
   type TubeInputs,
   type VMCircuitPublicInputs,
-  type VerificationKeyData,
 } from '@aztec/circuits.js';
+
+import type { Tx } from '../tx/tx.js';
+import { type ProofAndVerificationKey, type PublicInputsAndRecursiveProof } from './proving-job.js';
 
 /**
  * Generates proofs for parity and rollup circuits.
@@ -64,7 +62,7 @@ export interface ServerCircuitProver {
     baseRollupInput: BaseRollupInputs,
     signal?: AbortSignal,
     epochNumber?: number,
-  ): Promise<PublicInputsAndRecursiveProof<BaseOrMergeRollupPublicInputs>>;
+  ): Promise<PublicInputsAndRecursiveProof<BaseOrMergeRollupPublicInputs, typeof RECURSIVE_PROOF_LENGTH>>;
 
   /**
    * Get a recursively verified client IVC proof (making it a compatible honk proof for the rest of the rollup).
@@ -74,7 +72,7 @@ export interface ServerCircuitProver {
     tubeInput: TubeInputs,
     signal?: AbortSignal,
     epochNumber?: number,
-  ): Promise<{ tubeVK: VerificationKeyData; tubeProof: RecursiveProof<typeof RECURSIVE_PROOF_LENGTH> }>;
+  ): Promise<ProofAndVerificationKey<RecursiveProof<typeof RECURSIVE_PROOF_LENGTH>>>;
 
   /**
    * Creates a proof for the given input.
@@ -84,7 +82,7 @@ export interface ServerCircuitProver {
     input: MergeRollupInputs,
     signal?: AbortSignal,
     epochNumber?: number,
-  ): Promise<PublicInputsAndRecursiveProof<BaseOrMergeRollupPublicInputs>>;
+  ): Promise<PublicInputsAndRecursiveProof<BaseOrMergeRollupPublicInputs, typeof RECURSIVE_PROOF_LENGTH>>;
 
   /**
    * Creates a proof for the given input.
@@ -94,7 +92,7 @@ export interface ServerCircuitProver {
     input: BlockRootRollupInputs,
     signal?: AbortSignal,
     epochNumber?: number,
-  ): Promise<PublicInputsAndRecursiveProof<BlockRootOrBlockMergePublicInputs>>;
+  ): Promise<PublicInputsAndRecursiveProof<BlockRootOrBlockMergePublicInputs, typeof RECURSIVE_PROOF_LENGTH>>;
 
   /**
    * Creates a proof for the given input.
@@ -114,7 +112,7 @@ export interface ServerCircuitProver {
     input: BlockMergeRollupInputs,
     signal?: AbortSignal,
     epochNumber?: number,
-  ): Promise<PublicInputsAndRecursiveProof<BlockRootOrBlockMergePublicInputs>>;
+  ): Promise<PublicInputsAndRecursiveProof<BlockRootOrBlockMergePublicInputs, typeof RECURSIVE_PROOF_LENGTH>>;
 
   /**
    * Creates a proof for the given input.
@@ -124,7 +122,7 @@ export interface ServerCircuitProver {
     input: RootRollupInputs,
     signal?: AbortSignal,
     epochNumber?: number,
-  ): Promise<PublicInputsAndRecursiveProof<RootRollupPublicInputs>>;
+  ): Promise<PublicInputsAndRecursiveProof<RootRollupPublicInputs, typeof RECURSIVE_PROOF_LENGTH>>;
 
   /**
    * Create a public kernel inner proof.
@@ -140,25 +138,25 @@ export interface ServerCircuitProver {
     inputs: PublicKernelCircuitPrivateInputs,
     signal?: AbortSignal,
     epochNumber?: number,
-  ): Promise<PublicInputsAndRecursiveProof<PublicKernelCircuitPublicInputs>>;
+  ): Promise<PublicInputsAndRecursiveProof<PublicKernelCircuitPublicInputs, typeof RECURSIVE_PROOF_LENGTH>>;
 
   getPublicTailProof(
     inputs: PublicKernelTailCircuitPrivateInputs,
     signal?: AbortSignal,
     epochNumber?: number,
-  ): Promise<PublicInputsAndRecursiveProof<KernelCircuitPublicInputs>>;
+  ): Promise<PublicInputsAndRecursiveProof<KernelCircuitPublicInputs, typeof RECURSIVE_PROOF_LENGTH>>;
 
   getEmptyPrivateKernelProof(
     inputs: PrivateKernelEmptyInputData,
     signal?: AbortSignal,
     epochNumber?: number,
-  ): Promise<PublicInputsAndRecursiveProof<KernelCircuitPublicInputs>>;
+  ): Promise<PublicInputsAndRecursiveProof<KernelCircuitPublicInputs, typeof RECURSIVE_PROOF_LENGTH>>;
 
   getEmptyTubeProof(
     inputs: PrivateKernelEmptyInputData,
     signal?: AbortSignal,
     epochNumber?: number,
-  ): Promise<PublicInputsAndTubeProof<KernelCircuitPublicInputs>>;
+  ): Promise<PublicInputsAndRecursiveProof<KernelCircuitPublicInputs, typeof TUBE_PROOF_LENGTH>>;
 
   /**
    * Create a proof for the AVM circuit.
@@ -168,7 +166,7 @@ export interface ServerCircuitProver {
     inputs: AvmCircuitInputs,
     signal?: AbortSignal,
     epochNumber?: number,
-  ): Promise<AvmProofAndVerificationKey>;
+  ): Promise<ProofAndVerificationKey<Proof>>;
 }
 
 /**

--- a/yarn-project/circuit-types/src/tx/processed_tx.ts
+++ b/yarn-project/circuit-types/src/tx/processed_tx.ts
@@ -3,7 +3,6 @@ import {
   EncryptedTxL2Logs,
   PublicDataWrite,
   type PublicInputsAndRecursiveProof,
-  type PublicInputsAndTubeProof,
   type PublicKernelInnerRequest,
   type PublicKernelMergeRequest,
   type PublicKernelTailRequest,
@@ -198,7 +197,7 @@ export function makePaddingProcessedTx(
  * @returns A valid padding processed tx.
  */
 export function makePaddingProcessedTxFromTubeProof(
-  kernelOutput: PublicInputsAndTubeProof<KernelCircuitPublicInputs>,
+  kernelOutput: PublicInputsAndRecursiveProof<KernelCircuitPublicInputs, typeof TUBE_PROOF_LENGTH>,
 ): PaddingProcessedTxFromTube {
   const hash = new TxHash(Fr.ZERO.toBuffer());
   return {

--- a/yarn-project/circuits.js/src/hash/hash.ts
+++ b/yarn-project/circuits.js/src/hash/hash.ts
@@ -4,7 +4,8 @@ import { Fr } from '@aztec/foundation/fields';
 import { numToUInt8, numToUInt16BE, numToUInt32BE } from '@aztec/foundation/serialize';
 
 import { GeneratorIndex } from '../constants.gen.js';
-import { type ScopedL2ToL1Message, VerificationKey } from '../structs/index.js';
+import { type ScopedL2ToL1Message } from '../structs/l2_to_l1_message.js';
+import { VerificationKey } from '../structs/verification_key.js';
 
 /**
  * Computes a hash of a given verification key.

--- a/yarn-project/circuits.js/src/structs/verification_key.ts
+++ b/yarn-project/circuits.js/src/structs/verification_key.ts
@@ -3,9 +3,7 @@ import { times } from '@aztec/foundation/collection';
 import { Fq, Fr } from '@aztec/foundation/fields';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
-import { strict as assert } from 'assert';
-
-import { AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS, HONK_VERIFICATION_KEY_LENGTH_IN_FIELDS } from '../constants.gen.js';
+import { HONK_VERIFICATION_KEY_LENGTH_IN_FIELDS } from '../constants.gen.js';
 import { CircuitType } from './shared.js';
 
 /**
@@ -141,71 +139,6 @@ export class VerificationKeyAsFields {
   }
 }
 
-/**
- * Provides a 'fields' representation of the AVM's verification key
- */
-// TODO: This is a copy of the above, a refactor might be needed.
-export class AvmVerificationKeyAsFields {
-  constructor(public key: Fr[], public hash: Fr) {
-    assert(this.key.length === AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS, 'Invalid AVM key length');
-  }
-
-  public get numPublicInputs() {
-    return Number(this.key[CIRCUIT_PUBLIC_INPUTS_INDEX]);
-  }
-
-  public get circuitSize() {
-    return Number(this.key[CIRCUIT_SIZE_INDEX]);
-  }
-
-  public get isRecursive() {
-    return this.key[CIRCUIT_RECURSIVE_INDEX].equals(Fr.ONE);
-  }
-
-  /**
-   * Serialize as a buffer.
-   * @returns The buffer.
-   */
-  toBuffer() {
-    return serializeToBuffer(this.key, this.hash);
-  }
-  toFields() {
-    return [...this.key, this.hash];
-  }
-
-  /**
-   * Deserializes from a buffer or reader, corresponding to a write in cpp.
-   * @param buffer - Buffer to read from.
-   * @returns The AvmVerificationKeyAsFields.
-   */
-  static fromBuffer(buffer: Buffer | BufferReader): AvmVerificationKeyAsFields {
-    const reader = BufferReader.asReader(buffer);
-    return new AvmVerificationKeyAsFields(
-      reader.readArray(AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS, Fr),
-      reader.readObject(Fr),
-    );
-  }
-
-  /**
-   * Builds a fake verification key that should be accepted by circuits.
-   * @returns A fake verification key.
-   */
-  static makeFake(seed = 1): AvmVerificationKeyAsFields {
-    return new AvmVerificationKeyAsFields(
-      makeTuple(AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS, Fr.random, seed),
-      Fr.random(),
-    );
-  }
-
-  /**
-   * Builds an 'empty' verification key
-   * @returns An 'empty' verification key
-   */
-  static makeEmpty(): AvmVerificationKeyAsFields {
-    return new AvmVerificationKeyAsFields(makeTuple(AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS, Fr.zero), Fr.zero());
-  }
-}
-
 export class VerificationKey {
   constructor(
     /**
@@ -300,6 +233,10 @@ export class VerificationKeyData {
     return new VerificationKeyData(VerificationKeyAsFields.makeFakeHonk(), VerificationKey.makeFake().toBuffer());
   }
 
+  static makeFake(len = HONK_VERIFICATION_KEY_LENGTH_IN_FIELDS): VerificationKeyData {
+    return new VerificationKeyData(VerificationKeyAsFields.makeFake(len), VerificationKey.makeFake().toBuffer());
+  }
+
   /**
    * Serialize as a buffer.
    * @returns The buffer.
@@ -326,53 +263,5 @@ export class VerificationKeyData {
 
   public clone() {
     return VerificationKeyData.fromBuffer(this.toBuffer());
-  }
-}
-
-export class AvmVerificationKeyData {
-  constructor(public readonly keyAsFields: AvmVerificationKeyAsFields, public readonly keyAsBytes: Buffer) {}
-
-  public get numPublicInputs() {
-    return this.keyAsFields.numPublicInputs;
-  }
-
-  public get circuitSize() {
-    return this.keyAsFields.circuitSize;
-  }
-
-  public get isRecursive() {
-    return this.keyAsFields.isRecursive;
-  }
-
-  static makeFake(): AvmVerificationKeyData {
-    return new AvmVerificationKeyData(AvmVerificationKeyAsFields.makeFake(), VerificationKey.makeFake().toBuffer());
-  }
-
-  /**
-   * Serialize as a buffer.
-   * @returns The buffer.
-   */
-  toBuffer() {
-    return serializeToBuffer(this.keyAsFields, this.keyAsBytes.length, this.keyAsBytes);
-  }
-
-  toString() {
-    return this.toBuffer().toString('hex');
-  }
-
-  static fromBuffer(buffer: Buffer | BufferReader): AvmVerificationKeyData {
-    const reader = BufferReader.asReader(buffer);
-    const verificationKeyAsFields = reader.readObject(AvmVerificationKeyAsFields);
-    const length = reader.readNumber();
-    const bytes = reader.readBytes(length);
-    return new AvmVerificationKeyData(verificationKeyAsFields, bytes);
-  }
-
-  static fromString(str: string): AvmVerificationKeyData {
-    return AvmVerificationKeyData.fromBuffer(Buffer.from(str, 'hex'));
-  }
-
-  public clone() {
-    return AvmVerificationKeyData.fromBuffer(this.toBuffer());
   }
 }

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -848,8 +848,14 @@ export class ProvingOrchestrator implements EpochProver {
       ),
       result => {
         logger.debug(`Completed tube proof for tx index: ${txIndex}`);
-        const nextKernelRequest = txProvingState.getNextPublicKernelFromTubeProof(result.tubeProof, result.tubeVK);
-        this.checkAndEnqueueNextTxCircuit(provingState, txIndex, result.tubeProof, result.tubeVK, nextKernelRequest);
+        const nextKernelRequest = txProvingState.getNextPublicKernelFromTubeProof(result.proof, result.verificationKey);
+        this.checkAndEnqueueNextTxCircuit(
+          provingState,
+          txIndex,
+          result.proof,
+          result.verificationKey,
+          nextKernelRequest,
+        );
       },
     );
   }

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -4,52 +4,52 @@ import {
   EncryptedTxL2Logs,
   L2Block,
   MerkleTreeId,
+  type PaddingProcessedTx,
+  type ProcessedTx,
   ProvingRequestType,
+  type PublicInputsAndRecursiveProof,
+  type ServerCircuitProver,
+  type TxEffect,
   UnencryptedTxL2Logs,
   makeEmptyProcessedTx,
   makePaddingProcessedTx,
   mapProvingRequestTypeToCircuitName,
   toTxEffect,
-  type PaddingProcessedTx,
-  type ProcessedTx,
-  type PublicInputsAndRecursiveProof,
-  type ServerCircuitProver,
-  type TxEffect,
 } from '@aztec/circuit-types';
 import { type EpochProver, type MerkleTreeWriteOperations } from '@aztec/circuit-types/interfaces';
 import { type CircuitName } from '@aztec/circuit-types/stats';
 import {
   AvmCircuitInputs,
+  type BaseOrMergeRollupPublicInputs,
   BaseParityInputs,
+  type BaseRollupInputs,
+  type BlockRootOrBlockMergePublicInputs,
   BlockRootRollupInputs,
   EmptyBlockRootRollupInputs,
   Fr,
+  type GlobalVariables,
+  type Header,
+  type KernelCircuitPublicInputs,
   L1_TO_L2_MSG_SUBTREE_HEIGHT,
   L1_TO_L2_MSG_SUBTREE_SIBLING_PATH_LENGTH,
   NESTED_RECURSIVE_PROOF_LENGTH,
   NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
   NUM_BASE_PARITY_PER_ROOT_PARITY,
   PrivateKernelEmptyInputData,
-  RootParityInputs,
-  TUBE_INDEX,
-  TubeInputs,
-  VerificationKeyData,
-  makeEmptyProof,
-  makeEmptyRecursiveProof,
-  type BaseOrMergeRollupPublicInputs,
-  type BaseRollupInputs,
-  type BlockRootOrBlockMergePublicInputs,
-  type GlobalVariables,
-  type Header,
-  type KernelCircuitPublicInputs,
   type Proof,
   type PublicKernelCircuitPublicInputs,
   type RECURSIVE_PROOF_LENGTH,
   type RecursiveProof,
   type RootParityInput,
+  RootParityInputs,
+  TUBE_INDEX,
   type TUBE_PROOF_LENGTH,
+  TubeInputs,
   type VMCircuitPublicInputs,
-  type VerificationKeyAsFields
+  type VerificationKeyAsFields,
+  VerificationKeyData,
+  makeEmptyProof,
+  makeEmptyRecursiveProof,
 } from '@aztec/circuits.js';
 import { makeTuple } from '@aztec/foundation/array';
 import { padArrayEnd } from '@aztec/foundation/collection';
@@ -61,7 +61,7 @@ import { pushTestData } from '@aztec/foundation/testing';
 import { elapsed } from '@aztec/foundation/timer';
 import { TubeVk, getVKIndex, getVKSiblingPath, getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
 import { protocolContractTreeRoot } from '@aztec/protocol-contracts';
-import { Attributes, trackSpan, wrapCallbackInSpan, type TelemetryClient, type Tracer } from '@aztec/telemetry-client';
+import { Attributes, type TelemetryClient, type Tracer, trackSpan, wrapCallbackInSpan } from '@aztec/telemetry-client';
 
 import { inspect } from 'util';
 
@@ -81,13 +81,13 @@ import {
 } from './block-building-helpers.js';
 import { type BlockProvingState, type MergeRollupInputData } from './block-proving-state.js';
 import {
-  EpochProvingState,
   type BlockMergeRollupInputData,
+  EpochProvingState,
   type ProvingResult,
   type TreeSnapshots,
 } from './epoch-proving-state.js';
 import { ProvingOrchestratorMetrics } from './orchestrator_metrics.js';
-import { TX_PROVING_CODE, TxProvingState, type TxProvingInstruction } from './tx-proving-state.js';
+import { TX_PROVING_CODE, type TxProvingInstruction, TxProvingState } from './tx-proving-state.js';
 
 const logger = createDebugLogger('aztec:prover:proving-orchestrator');
 

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -4,53 +4,52 @@ import {
   EncryptedTxL2Logs,
   L2Block,
   MerkleTreeId,
-  type PaddingProcessedTx,
-  type ProcessedTx,
   ProvingRequestType,
-  type PublicInputsAndRecursiveProof,
-  type ServerCircuitProver,
-  type TxEffect,
   UnencryptedTxL2Logs,
   makeEmptyProcessedTx,
   makePaddingProcessedTx,
   mapProvingRequestTypeToCircuitName,
   toTxEffect,
+  type PaddingProcessedTx,
+  type ProcessedTx,
+  type PublicInputsAndRecursiveProof,
+  type ServerCircuitProver,
+  type TxEffect,
 } from '@aztec/circuit-types';
 import { type EpochProver, type MerkleTreeWriteOperations } from '@aztec/circuit-types/interfaces';
 import { type CircuitName } from '@aztec/circuit-types/stats';
 import {
-  AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS,
   AvmCircuitInputs,
-  type BaseOrMergeRollupPublicInputs,
   BaseParityInputs,
-  type BaseRollupInputs,
-  type BlockRootOrBlockMergePublicInputs,
   BlockRootRollupInputs,
   EmptyBlockRootRollupInputs,
   Fr,
-  type GlobalVariables,
-  type Header,
-  type KernelCircuitPublicInputs,
   L1_TO_L2_MSG_SUBTREE_HEIGHT,
   L1_TO_L2_MSG_SUBTREE_SIBLING_PATH_LENGTH,
   NESTED_RECURSIVE_PROOF_LENGTH,
   NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
   NUM_BASE_PARITY_PER_ROOT_PARITY,
   PrivateKernelEmptyInputData,
+  RootParityInputs,
+  TUBE_INDEX,
+  TubeInputs,
+  VerificationKeyData,
+  makeEmptyProof,
+  makeEmptyRecursiveProof,
+  type BaseOrMergeRollupPublicInputs,
+  type BaseRollupInputs,
+  type BlockRootOrBlockMergePublicInputs,
+  type GlobalVariables,
+  type Header,
+  type KernelCircuitPublicInputs,
   type Proof,
   type PublicKernelCircuitPublicInputs,
   type RECURSIVE_PROOF_LENGTH,
   type RecursiveProof,
   type RootParityInput,
-  RootParityInputs,
-  TUBE_INDEX,
   type TUBE_PROOF_LENGTH,
-  TubeInputs,
   type VMCircuitPublicInputs,
-  type VerificationKeyAsFields,
-  VerificationKeyData,
-  makeEmptyProof,
-  makeEmptyRecursiveProof,
+  type VerificationKeyAsFields
 } from '@aztec/circuits.js';
 import { makeTuple } from '@aztec/foundation/array';
 import { padArrayEnd } from '@aztec/foundation/collection';
@@ -62,7 +61,7 @@ import { pushTestData } from '@aztec/foundation/testing';
 import { elapsed } from '@aztec/foundation/timer';
 import { TubeVk, getVKIndex, getVKSiblingPath, getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
 import { protocolContractTreeRoot } from '@aztec/protocol-contracts';
-import { Attributes, type TelemetryClient, type Tracer, trackSpan, wrapCallbackInSpan } from '@aztec/telemetry-client';
+import { Attributes, trackSpan, wrapCallbackInSpan, type TelemetryClient, type Tracer } from '@aztec/telemetry-client';
 
 import { inspect } from 'util';
 
@@ -82,13 +81,13 @@ import {
 } from './block-building-helpers.js';
 import { type BlockProvingState, type MergeRollupInputData } from './block-proving-state.js';
 import {
-  type BlockMergeRollupInputData,
   EpochProvingState,
+  type BlockMergeRollupInputData,
   type ProvingResult,
   type TreeSnapshots,
 } from './epoch-proving-state.js';
 import { ProvingOrchestratorMetrics } from './orchestrator_metrics.js';
-import { TX_PROVING_CODE, type TxProvingInstruction, TxProvingState } from './tx-proving-state.js';
+import { TX_PROVING_CODE, TxProvingState, type TxProvingInstruction } from './tx-proving-state.js';
 
 const logger = createDebugLogger('aztec:prover:proving-orchestrator');
 

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -19,6 +19,7 @@ import {
 import { type EpochProver, type MerkleTreeWriteOperations } from '@aztec/circuit-types/interfaces';
 import { type CircuitName } from '@aztec/circuit-types/stats';
 import {
+  AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS,
   AvmCircuitInputs,
   type BaseOrMergeRollupPublicInputs,
   BaseParityInputs,

--- a/yarn-project/prover-client/src/prover-agent/memory-proving-queue.ts
+++ b/yarn-project/prover-client/src/prover-agent/memory-proving-queue.ts
@@ -1,5 +1,5 @@
 import {
-  type AvmProofAndVerificationKey,
+  type ProofAndVerificationKey,
   type ProvingJob,
   type ProvingJobSource,
   type ProvingRequest,
@@ -21,6 +21,7 @@ import type {
   MergeRollupInputs,
   NESTED_RECURSIVE_PROOF_LENGTH,
   PrivateKernelEmptyInputData,
+  Proof,
   PublicKernelCircuitPrivateInputs,
   PublicKernelCircuitPublicInputs,
   PublicKernelInnerCircuitPrivateInputs,
@@ -33,7 +34,6 @@ import type {
   RootRollupPublicInputs,
   TubeInputs,
   VMCircuitPublicInputs,
-  VerificationKeyData,
 } from '@aztec/circuits.js';
 import { randomBytes } from '@aztec/foundation/crypto';
 import { AbortError, TimeoutError } from '@aztec/foundation/error';
@@ -280,7 +280,7 @@ export class MemoryProvingQueue implements ServerCircuitProver, ProvingJobSource
     inputs: TubeInputs,
     signal?: AbortSignal,
     epochNumber?: number,
-  ): Promise<{ tubeVK: VerificationKeyData; tubeProof: RecursiveProof<typeof RECURSIVE_PROOF_LENGTH> }> {
+  ): Promise<ProofAndVerificationKey<RecursiveProof<typeof RECURSIVE_PROOF_LENGTH>>> {
     return this.enqueue({ type: ProvingRequestType.TUBE_PROOF, inputs }, signal, epochNumber);
   }
 
@@ -427,7 +427,7 @@ export class MemoryProvingQueue implements ServerCircuitProver, ProvingJobSource
     inputs: AvmCircuitInputs,
     signal?: AbortSignal,
     epochNumber?: number,
-  ): Promise<AvmProofAndVerificationKey> {
+  ): Promise<ProofAndVerificationKey<Proof>> {
     return this.enqueue({ type: ProvingRequestType.PUBLIC_VM, inputs }, signal, epochNumber);
   }
 

--- a/yarn-project/prover-client/src/prover-agent/rpc.ts
+++ b/yarn-project/prover-client/src/prover-agent/rpc.ts
@@ -1,7 +1,6 @@
 import { type ProvingJobSource } from '@aztec/circuit-types';
 import {
   AvmCircuitInputs,
-  AvmVerificationKeyData,
   AztecAddress,
   BaseOrMergeRollupPublicInputs,
   BaseParityInputs,
@@ -41,7 +40,6 @@ export function createProvingJobSourceServer(queue: ProvingJobSource): JsonRpcSe
   return new JsonRpcServer(
     queue,
     {
-      AvmVerificationKeyData,
       AvmCircuitInputs,
       BaseOrMergeRollupPublicInputs,
       BaseParityInputs,
@@ -83,7 +81,6 @@ export function createProvingJobSourceClient(
   return createJsonRpcClient(
     url,
     {
-      AvmVerificationKeyData,
       AvmCircuitInputs,
       BaseOrMergeRollupPublicInputs,
       BaseParityInputs,

--- a/yarn-project/prover-client/src/test/mock_prover.ts
+++ b/yarn-project/prover-client/src/test/mock_prover.ts
@@ -1,7 +1,8 @@
 import {
+  type ProofAndVerificationKey,
   type PublicInputsAndRecursiveProof,
-  type PublicInputsAndTubeProof,
   type ServerCircuitProver,
+  makeProofAndVerificationKey,
   makePublicInputsAndRecursiveProof,
 } from '@aztec/circuit-types';
 import {
@@ -13,6 +14,7 @@ import {
   RECURSIVE_PROOF_LENGTH,
   type RecursiveProof,
   type RootRollupPublicInputs,
+  TUBE_PROOF_LENGTH,
   type VMCircuitPublicInputs,
   VerificationKeyData,
   makeEmptyProof,
@@ -33,10 +35,10 @@ export class MockProver implements ServerCircuitProver {
 
   getAvmProof() {
     return Promise.resolve(
-      Promise.resolve({
-        proof: makeEmptyProof(),
-        verificationKey: VerificationKeyData.makeFake(AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS),
-      }),
+      makeProofAndVerificationKey(
+        makeEmptyProof(),
+        VerificationKeyData.makeFake(AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS),
+      ),
     );
   }
 
@@ -108,7 +110,7 @@ export class MockProver implements ServerCircuitProver {
     );
   }
 
-  getEmptyTubeProof(): Promise<PublicInputsAndTubeProof<KernelCircuitPublicInputs>> {
+  getEmptyTubeProof(): Promise<PublicInputsAndRecursiveProof<KernelCircuitPublicInputs>> {
     return Promise.resolve(
       makePublicInputsAndRecursiveProof(
         makeKernelCircuitPublicInputs(),
@@ -158,13 +160,9 @@ export class MockProver implements ServerCircuitProver {
     );
   }
 
-  getTubeProof(): Promise<{
-    tubeVK: VerificationKeyData;
-    tubeProof: RecursiveProof<typeof RECURSIVE_PROOF_LENGTH>;
-  }> {
-    return Promise.resolve({
-      tubeVK: VerificationKeyData.makeFakeHonk(),
-      tubeProof: makeRecursiveProof(RECURSIVE_PROOF_LENGTH),
-    });
+  getTubeProof(): Promise<ProofAndVerificationKey<RecursiveProof<typeof TUBE_PROOF_LENGTH>>> {
+    return Promise.resolve(
+      makeProofAndVerificationKey(makeRecursiveProof(TUBE_PROOF_LENGTH), VerificationKeyData.makeFake()),
+    );
   }
 }

--- a/yarn-project/prover-client/src/test/mock_prover.ts
+++ b/yarn-project/prover-client/src/test/mock_prover.ts
@@ -5,7 +5,7 @@ import {
   makePublicInputsAndRecursiveProof,
 } from '@aztec/circuit-types';
 import {
-  AvmVerificationKeyData,
+  AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS,
   type BaseOrMergeRollupPublicInputs,
   type BlockRootOrBlockMergePublicInputs,
   type KernelCircuitPublicInputs,
@@ -35,7 +35,7 @@ export class MockProver implements ServerCircuitProver {
     return Promise.resolve(
       Promise.resolve({
         proof: makeEmptyProof(),
-        verificationKey: AvmVerificationKeyData.makeFake(),
+        verificationKey: VerificationKeyData.makeFake(AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS),
       }),
     );
   }


### PR DESCRIPTION
Removes the `AvmVerificationKey*` classes in favour of using the vanilla classes with custom length.
