### PR TITLE
feat: only download non-pruned blocks

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -225,7 +225,7 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
     uint256 l2ToL1TreeMinHeight = min + 1;
     OUTBOX.insert(blockNumber, header.contentCommitment.outHash, l2ToL1TreeMinHeight);
 
-    emit L2BlockProposed(blockNumber);
+    emit L2BlockProposed(blockNumber, _archive);
 
     // Automatically flag the block as proven if we have cheated and set assumeProvenThroughBlockNumber.
     if (blockNumber <= assumeProvenThroughBlockNumber) {
@@ -390,7 +390,10 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
    * @return bytes32 - The archive root of the block
    */
   function archiveAt(uint256 _blockNumber) external view override(IRollup) returns (bytes32) {
-    return blocks[_blockNumber].archive;
+    if (_blockNumber < pendingBlockCount) {
+      return blocks[_blockNumber].archive;
+    }
+    return bytes32(0);
   }
 
   /**

--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -390,7 +390,7 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
    * @return bytes32 - The archive root of the block
    */
   function archiveAt(uint256 _blockNumber) external view override(IRollup) returns (bytes32) {
-    if (_blockNumber < pendingBlockCount) {
+    if (_blockNumber <= tips.pendingBlockNumber) {
       return blocks[_blockNumber].archive;
     }
     return bytes32(0);

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -15,7 +15,7 @@ interface ITestRollup {
 }
 
 interface IRollup {
-  event L2BlockProposed(uint256 indexed blockNumber);
+  event L2BlockProposed(uint256 indexed blockNumber, bytes32 indexed archive);
   event L2ProofVerified(uint256 indexed blockNumber, bytes32 indexed proverId);
   event PrunedPending(uint256 provenBlockNumber, uint256 pendingBlockNumber);
 

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -268,6 +268,7 @@ export class Archiver implements ArchiveSource {
       blockUntilSynced,
       blocksSynchedTo + 1n,
       currentL1BlockNumber,
+      this.log,
     );
 
     // Add the body

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -43,7 +43,15 @@ import {
 } from '@aztec/types/contracts';
 
 import groupBy from 'lodash.groupby';
-import { type Chain, type HttpTransport, type PublicClient, createPublicClient, getContract, http } from 'viem';
+import {
+  type Chain,
+  type GetContractReturnType,
+  type HttpTransport,
+  type PublicClient,
+  createPublicClient,
+  getContract,
+  http,
+} from 'viem';
 
 import { type ArchiverDataStore } from './archiver_store.js';
 import { type ArchiverConfig } from './config.js';
@@ -68,6 +76,8 @@ export class Archiver implements ArchiveSource {
    */
   private runningPromise?: RunningPromise;
 
+  private rollup: GetContractReturnType<typeof RollupAbi, PublicClient<HttpTransport, Chain>>;
+
   /**
    * Creates a new instance of the Archiver.
    * @param publicClient - A client for interacting with the Ethereum node.
@@ -88,7 +98,13 @@ export class Archiver implements ArchiveSource {
     private readonly instrumentation: ArchiverInstrumentation,
     private readonly l1StartBlock: bigint = 0n,
     private readonly log: DebugLogger = createDebugLogger('aztec:archiver'),
-  ) {}
+  ) {
+    this.rollup = getContract({
+      address: rollupAddress.toString(),
+      abi: RollupAbi,
+      client: publicClient,
+    });
+  }
 
   /**
    * Creates a new instance of the Archiver and blocks until it syncs from chain.
@@ -245,17 +261,13 @@ export class Archiver implements ArchiveSource {
 
     await this.store.addL1ToL2Messages(retrievedL1ToL2Messages);
 
-    // Read all data from chain and then write to our stores at the end
-    const nextExpectedL2BlockNum = BigInt((await this.store.getSynchedL2BlockNumber()) + 1);
-
     this.log.debug(`Retrieving blocks from ${blocksSynchedTo + 1n} to ${currentL1BlockNumber}`);
     const retrievedBlocks = await retrieveBlockFromRollup(
+      this.rollup,
       this.publicClient,
-      this.rollupAddress,
       blockUntilSynced,
       blocksSynchedTo + 1n,
       currentL1BlockNumber,
-      nextExpectedL2BlockNum,
     );
 
     // Add the body

--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -62,7 +62,7 @@ export async function retrieveBlockFromRollup(
       `Got L2 block processed logs for ${l2BlockProposedLogs[0].blockNumber}-${lastLog.blockNumber} between ${searchStartBlock}-${searchEndBlock} L1 blocks`,
     );
 
-    const newBlocks = await processL2BlockProposedLogs(rollup, publicClient, l2BlockProposedLogs);
+    const newBlocks = await processL2BlockProposedLogs(rollup, publicClient, l2BlockProposedLogs, logger);
     retrievedBlocks.push(...newBlocks);
     searchStartBlock = lastLog.blockNumber! + 1n;
   } while (blockUntilSynced && searchStartBlock <= searchEndBlock);

--- a/yarn-project/archiver/src/archiver/eth_log_handlers.ts
+++ b/yarn-project/archiver/src/archiver/eth_log_handlers.ts
@@ -5,7 +5,18 @@ import { Fr } from '@aztec/foundation/fields';
 import { numToUInt32BE } from '@aztec/foundation/serialize';
 import { InboxAbi, RollupAbi } from '@aztec/l1-artifacts';
 
-import { type Hex, type Log, type PublicClient, decodeFunctionData, getAbiItem, getAddress, hexToBytes } from 'viem';
+import {
+  type Chain,
+  type GetContractReturnType,
+  type Hex,
+  type HttpTransport,
+  type Log,
+  type PublicClient,
+  decodeFunctionData,
+  getAbiItem,
+  getAddress,
+  hexToBytes,
+} from 'viem';
 
 import { type L1Published, type L1PublishedData } from './structs/published.js';
 
@@ -27,33 +38,35 @@ export function processMessageSentLogs(
 
 /**
  * Processes newly received L2BlockProposed logs.
+ * @param rollup - The rollup contract
  * @param publicClient - The viem public client to use for transaction retrieval.
- * @param expectedL2BlockNumber - The next expected L2 block number.
  * @param logs - L2BlockProposed logs.
  * @returns - An array blocks.
  */
 export async function processL2BlockProposedLogs(
+  rollup: GetContractReturnType<typeof RollupAbi, PublicClient<HttpTransport, Chain>>,
   publicClient: PublicClient,
-  expectedL2BlockNumber: bigint,
   logs: Log<bigint, number, false, undefined, true, typeof RollupAbi, 'L2BlockProposed'>[],
 ): Promise<L1Published<L2Block>[]> {
   const retrievedBlocks: L1Published<L2Block>[] = [];
   for (const log of logs) {
-    const blockNum = log.args.blockNumber;
-    if (blockNum !== expectedL2BlockNumber) {
-      throw new Error('Block number mismatch. Expected: ' + expectedL2BlockNumber + ' but got: ' + blockNum + '.');
+    const blockNum = log.args.blockNumber!;
+    const archive = log.args.archive!;
+    const archiveFromChain = await rollup.read.archiveAt([blockNum]);
+
+    // The value from the event and contract will match only if the block is in the chain.
+    if (archive === archiveFromChain) {
+      // TODO: Fetch blocks from calldata in parallel
+      const block = await getBlockFromRollupTx(publicClient, log.transactionHash!, blockNum);
+
+      const l1: L1PublishedData = {
+        blockNumber: log.blockNumber,
+        blockHash: log.blockHash,
+        timestamp: await getL1BlockTime(publicClient, log.blockNumber),
+      };
+
+      retrievedBlocks.push({ data: block, l1 });
     }
-    // TODO: Fetch blocks from calldata in parallel
-    const block = await getBlockFromRollupTx(publicClient, log.transactionHash!, log.args.blockNumber);
-
-    const l1: L1PublishedData = {
-      blockNumber: log.blockNumber,
-      blockHash: log.blockHash,
-      timestamp: await getL1BlockTime(publicClient, log.blockNumber),
-    };
-
-    retrievedBlocks.push({ data: block, l1 });
-    expectedL2BlockNumber++;
   }
 
   return retrievedBlocks;
@@ -101,7 +114,7 @@ async function getBlockFromRollupTx(
   const archive = AppendOnlyTreeSnapshot.fromBuffer(
     Buffer.concat([
       Buffer.from(hexToBytes(archiveRootHex)), // L2Block.archive.root
-      numToUInt32BE(Number(l2BlockNum)), // L2Block.archive.nextAvailableLeafIndex
+      numToUInt32BE(Number(l2BlockNum + 1n)), // L2Block.archive.nextAvailableLeafIndex
     ]),
   );
 

--- a/yarn-project/archiver/src/archiver/eth_log_handlers.ts
+++ b/yarn-project/archiver/src/archiver/eth_log_handlers.ts
@@ -2,6 +2,7 @@ import { Body, InboxLeaf, L2Block, type ViemSignature } from '@aztec/circuit-typ
 import { AppendOnlyTreeSnapshot, Header, Proof } from '@aztec/circuits.js';
 import { type EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
+import { type DebugLogger } from '@aztec/foundation/log';
 import { numToUInt32BE } from '@aztec/foundation/serialize';
 import { InboxAbi, RollupAbi } from '@aztec/l1-artifacts';
 
@@ -47,6 +48,7 @@ export async function processL2BlockProposedLogs(
   rollup: GetContractReturnType<typeof RollupAbi, PublicClient<HttpTransport, Chain>>,
   publicClient: PublicClient,
   logs: Log<bigint, number, false, undefined, true, typeof RollupAbi, 'L2BlockProposed'>[],
+  logger: DebugLogger,
 ): Promise<L1Published<L2Block>[]> {
   const retrievedBlocks: L1Published<L2Block>[] = [];
   for (const log of logs) {
@@ -66,6 +68,10 @@ export async function processL2BlockProposedLogs(
       };
 
       retrievedBlocks.push({ data: block, l1 });
+    } else {
+      logger.warn(
+        `Archive mismatch matching, ignoring block ${blockNum} with archive: ${archive}, expected ${archiveFromChain}`,
+      );
     }
   }
 

--- a/yarn-project/end-to-end/src/e2e_synching.test.ts
+++ b/yarn-project/end-to-end/src/e2e_synching.test.ts
@@ -26,18 +26,18 @@
  * Previous results. The `blockCount` is the number of blocks we will construct with `txCount`
  * transactions of the `complexity` provided.
  * The `numberOfBlocks` is the total number of blocks, including deployments of canonical contracts
- * and setup before we start the "actual" test. Similar, `numberOfTransactions` is the total number
- * of transactions across these blocks.
- * blockCount: 10, txCount: 36, complexity: Deployment:      {"numberOfBlocks":16, "syncTime":17.490706521987914, "numberOfTransactions":366}
- * blockCount: 10, txCount: 36, complexity: PrivateTransfer: {"numberOfBlocks":19, "syncTime":20.846745924949644, "numberOfTransactions":474}
- * blockCount: 10, txCount: 36, complexity: PublicTransfer:  {"numberOfBlocks":18, "syncTime":21.340179460525512, "numberOfTransactions":438}
- * blockCount: 10, txCount: 9,  complexity: Spam:            {"numberOfBlocks":17, "syncTime":49.40888188171387,  "numberOfTransactions":105}
+ * and setup before we start the "actual" test.
+ * blockCount: 10, txCount: 36, complexity: Deployment:      {"numberOfBlocks":16, "syncTime":17.490706521987914}
+ * blockCount: 10, txCount: 36, complexity: PrivateTransfer: {"numberOfBlocks":19, "syncTime":20.846745924949644}
+ * blockCount: 10, txCount: 36, complexity: PublicTransfer:  {"numberOfBlocks":18, "syncTime":21.340179460525512}
+ * blockCount: 10, txCount: 9,  complexity: Spam:            {"numberOfBlocks":17, "syncTime":49.40888188171387}
  */
 import { getSchnorrAccount } from '@aztec/accounts/schnorr';
 import { AztecNodeService } from '@aztec/aztec-node';
 import {
   type AccountWallet,
   type AccountWalletWithSecretKey,
+  AnvilTestWatcher,
   BatchCall,
   type DebugLogger,
   Fr,
@@ -49,15 +49,17 @@ import {
 import { ExtendedNote, L2Block, Note, type TxHash } from '@aztec/circuit-types';
 import { type AztecAddress, ETHEREUM_SLOT_DURATION } from '@aztec/circuits.js';
 import { Timer } from '@aztec/foundation/timer';
+import { RollupAbi } from '@aztec/l1-artifacts';
 import { SpamContract, TokenContract } from '@aztec/noir-contracts.js';
 import { type PXEService } from '@aztec/pxe';
 import { L1Publisher } from '@aztec/sequencer-client';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import * as fs from 'fs';
+import { getContract } from 'viem';
 
 import { addAccounts } from './fixtures/snapshot_manager.js';
-import { getPrivateKeyFromIndex, setup } from './fixtures/utils.js';
+import { type EndToEndContext, getPrivateKeyFromIndex, setup, setupPXEService } from './fixtures/utils.js';
 
 const SALT = 420;
 const AZTEC_GENERATE_TEST_DATA = !!process.env.AZTEC_GENERATE_TEST_DATA;
@@ -276,13 +278,6 @@ class TestVariant {
     return (json['blocks'] as string[]).map(b => L2Block.fromString(b));
   }
 
-  async writeStats(content: Record<string, string | number>) {
-    await this.writeJson(`stats`, {
-      description: this.description(),
-      ...content,
-    });
-  }
-
   numberOfBlocksStored() {
     const files = fs.readdirSync(this.dir());
     return files.filter(file => file.startsWith('block_')).length;
@@ -365,7 +360,11 @@ describe('e2e_l1_with_wall_time', () => {
     1_200_000,
   );
 
-  it.each(variants)('replay and then sync - %s', async (variant: TestVariant) => {
+  const testTheVariant = async (
+    variant: TestVariant,
+    beforeSync: (opts: Partial<EndToEndContext>) => Promise<void> = () => Promise.resolve(),
+    afterSync: (opts: Partial<EndToEndContext>) => Promise<void> = () => Promise.resolve(),
+  ) => {
     if (AZTEC_GENERATE_TEST_DATA) {
       return;
     }
@@ -407,6 +406,8 @@ describe('e2e_l1_with_wall_time', () => {
       await publisher.proposeL2Block(block);
     }
 
+    await beforeSync({ deployL1ContractsValues, cheatCodes, config, logger });
+
     // All the blocks have been "re-played" and we are now to simply get a new node up to speed
     const timer = new Timer();
     const freshNode = await AztecNodeService.createAndSync(
@@ -415,19 +416,79 @@ describe('e2e_l1_with_wall_time', () => {
     );
     const syncTime = timer.s();
 
-    const txCount = blocks.map(b => b.getStats().txCount).reduce((acc, curr) => acc + curr, 0);
     const blockNumber = await freshNode.getBlockNumber();
 
-    // @note  We should consider storing these stats to see changes over time etc.
-    // await variant.writeStats({ numberOfBlocks: blockNumber, syncTime, numberOfTransactions: txCount });
     logger.info(
       `Stats: ${variant.description()}: ${JSON.stringify({
         numberOfBlocks: blockNumber,
         syncTime,
-        numberOfTransactions: txCount,
       })}`,
     );
 
+    await afterSync({ deployL1ContractsValues, cheatCodes, config, logger });
+
     await teardown();
+  };
+
+  it.each(variants)('replay and then sync - %s', async (variant: TestVariant) => {
+    await testTheVariant(variant);
+  });
+
+  it('replay, then prune and only then perform an initial sync', async () => {
+    if (AZTEC_GENERATE_TEST_DATA) {
+      return;
+    }
+
+    const variant = variants[0];
+
+    const beforeSync = async (opts: Partial<EndToEndContext>) => {
+      const rollup = getContract({
+        address: opts.deployL1ContractsValues!.l1ContractAddresses.rollupAddress.toString(),
+        abi: RollupAbi,
+        client: opts.deployL1ContractsValues!.walletClient,
+      });
+
+      const pendingCount = await rollup.read.pendingBlockCount();
+      await rollup.write.setAssumeProvenUntilBlockNumber([pendingCount - BigInt(variant.blockCount) / 2n]);
+
+      const timeliness = await rollup.read.TIMELINESS_PROVING_IN_SLOTS();
+      const [, , slot] = await rollup.read.blocks([await rollup.read.provenBlockCount()]);
+      const timeJumpTo = await rollup.read.getTimestampForSlot([slot + timeliness]);
+
+      await opts.cheatCodes!.eth.warp(Number(timeJumpTo));
+
+      await rollup.write.prune();
+    };
+
+    // After we have synched the chain, we will publish a block. Here we are VERY interested in seeing the block number.
+    const afterSync = async (opts: Partial<EndToEndContext>) => {
+      const watcher = new AnvilTestWatcher(
+        opts.cheatCodes!.eth,
+        opts.deployL1ContractsValues!.l1ContractAddresses.rollupAddress,
+        opts.deployL1ContractsValues!.publicClient,
+      );
+      await watcher.start();
+
+      // The sync here could likely be avoided by using the node we just synched.
+      const aztecNode = await AztecNodeService.createAndSync(opts.config!, new NoopTelemetryClient());
+      const sequencer = aztecNode.getSequencer();
+
+      const { pxe } = await setupPXEService(aztecNode!);
+
+      variant.setPXE(pxe);
+
+      const blockBefore = await aztecNode.getBlock(await aztecNode.getBlockNumber());
+
+      sequencer?.updateSequencerConfig({ minTxsPerBlock: variant.txCount, maxTxsPerBlock: variant.txCount });
+      const txs = await variant.createAndSendTxs();
+      await Promise.all(txs.map(tx => tx.wait({ timeout: 1200 })));
+
+      const blockAfter = await aztecNode.getBlock(await aztecNode.getBlockNumber());
+
+      expect(blockAfter!.number).toEqual(blockBefore!.number + 1);
+      expect(blockAfter!.header.lastArchive).toEqual(blockBefore!.archive);
+    };
+
+    await testTheVariant(variant, beforeSync, afterSync);
   });
 });

--- a/yarn-project/end-to-end/src/e2e_synching.test.ts
+++ b/yarn-project/end-to-end/src/e2e_synching.test.ts
@@ -448,11 +448,11 @@ describe('e2e_l1_with_wall_time', () => {
         client: opts.deployL1ContractsValues!.walletClient,
       });
 
-      const pendingCount = await rollup.read.pendingBlockCount();
-      await rollup.write.setAssumeProvenUntilBlockNumber([pendingCount - BigInt(variant.blockCount) / 2n]);
+      const pendingBlockNumber = await rollup.read.getPendingBlockNumber();
+      await rollup.write.setAssumeProvenThroughBlockNumber([pendingBlockNumber - BigInt(variant.blockCount) / 2n]);
 
       const timeliness = await rollup.read.TIMELINESS_PROVING_IN_SLOTS();
-      const [, , slot] = await rollup.read.blocks([await rollup.read.provenBlockCount()]);
+      const [, , slot] = await rollup.read.blocks([(await rollup.read.getProvenBlockNumber()) + 1n]);
       const timeJumpTo = await rollup.read.getTimestampForSlot([slot + timeliness]);
 
       await opts.cheatCodes!.eth.warp(Number(timeJumpTo));


### PR DESCRIPTION
Fixes #8562.

- Extends the `L2BlockProposed` event to also include the archive
- Change `archiveAt` to only return archive if in pending, e.g., return `bytes32(0)` for pruned blocks
- Remove the expected l2 block num but check that it is in the `blocks` on contract
  - To support multiple blocks with same block number 
- Adds a test that will prune part of the chain, then sync a fresh and then build a new block.
- Fixes a bug in the `eth_log_handler::getBlockFromRollupTx` as it was loading an incorrect archive `nextAvailableLeafIndex` value, but since it seemed to not be used it did not cause any issues.