### PR TITLE
feat: new proving broker implementation

### DIFF
--- a/yarn-project/circuits.js/src/structs/kernel/private_kernel_empty_inputs.test.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/private_kernel_empty_inputs.test.ts
@@ -1,11 +1,43 @@
 import { Fr } from '@aztec/foundation/fields';
 
+import { NESTED_RECURSIVE_PROOF_LENGTH } from '../../constants.gen.js';
 import { makeHeader } from '../../tests/factories.js';
-import { PrivateKernelEmptyInputData } from './private_kernel_empty_inputs.js';
+import { makeRecursiveProof } from '../recursive_proof.js';
+import { VerificationKeyAsFields } from '../verification_key.js';
+import {
+  EmptyNestedData,
+  PrivateKernelEmptyInputData,
+  PrivateKernelEmptyInputs,
+} from './private_kernel_empty_inputs.js';
 
 describe('PrivateKernelEmptyInputData', () => {
   it('serializes and deserializes', () => {
     const obj = new PrivateKernelEmptyInputData(makeHeader(), Fr.random(), Fr.random(), Fr.random(), Fr.random());
     expect(PrivateKernelEmptyInputData.fromString(obj.toString())).toEqual(obj);
+  });
+});
+
+describe('PrivateKernelEmptyInputs', () => {
+  it('serializes and deserializes', () => {
+    const obj = new PrivateKernelEmptyInputs(
+      new EmptyNestedData(makeRecursiveProof(NESTED_RECURSIVE_PROOF_LENGTH), VerificationKeyAsFields.makeFakeHonk()),
+      makeHeader(),
+      Fr.random(),
+      Fr.random(),
+      Fr.random(),
+      Fr.random(),
+    );
+
+    expect(PrivateKernelEmptyInputs.fromBuffer(obj.toBuffer())).toEqual(obj);
+  });
+});
+
+describe('EmptyNestedData', () => {
+  it('serializes and deserializes', () => {
+    const obj = new EmptyNestedData(
+      makeRecursiveProof(NESTED_RECURSIVE_PROOF_LENGTH),
+      VerificationKeyAsFields.makeFakeHonk(),
+    );
+    expect(EmptyNestedData.fromBuffer(obj.toBuffer())).toEqual(obj);
   });
 });

--- a/yarn-project/circuits.js/src/structs/kernel/private_kernel_empty_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/private_kernel_empty_inputs.ts
@@ -2,10 +2,10 @@ import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import { type FieldsOf } from '@aztec/foundation/types';
 
-import { type RECURSIVE_PROOF_LENGTH } from '../../constants.gen.js';
+import { RECURSIVE_PROOF_LENGTH } from '../../constants.gen.js';
 import { Header } from '../header.js';
-import { type RecursiveProof } from '../recursive_proof.js';
-import { type VerificationKeyAsFields } from '../verification_key.js';
+import { RecursiveProof } from '../recursive_proof.js';
+import { VerificationKeyAsFields } from '../verification_key.js';
 
 export class PrivateKernelEmptyInputData {
   constructor(
@@ -81,6 +81,18 @@ export class PrivateKernelEmptyInputs {
       fields.protocolContractTreeRoot,
     );
   }
+
+  static fromBuffer(buf: Buffer | BufferReader): PrivateKernelEmptyInputs {
+    const reader = BufferReader.asReader(buf);
+    return new PrivateKernelEmptyInputs(
+      reader.readObject(EmptyNestedData),
+      reader.readObject(Header),
+      reader.readObject(Fr),
+      reader.readObject(Fr),
+      reader.readObject(Fr),
+      reader.readObject(Fr),
+    );
+  }
 }
 
 export class EmptyNestedCircuitInputs {
@@ -97,5 +109,21 @@ export class EmptyNestedData {
 
   toBuffer(): Buffer {
     return serializeToBuffer(this.proof, this.vk);
+  }
+
+  static fromBuffer(buf: Buffer | BufferReader): EmptyNestedData {
+    const reader = BufferReader.asReader(buf);
+    const recursiveProof = reader.readObject(RecursiveProof);
+
+    if (recursiveProof.proof.length !== RECURSIVE_PROOF_LENGTH) {
+      throw new TypeError(
+        `Invalid proof length. Expected: ${RECURSIVE_PROOF_LENGTH} got: ${recursiveProof.proof.length}`,
+      );
+    }
+
+    return new EmptyNestedData(
+      recursiveProof as RecursiveProof<typeof RECURSIVE_PROOF_LENGTH>,
+      reader.readObject(VerificationKeyAsFields),
+    );
   }
 }

--- a/yarn-project/prover-client/src/proving_broker/proving_broker.test.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker.test.ts
@@ -1,0 +1,648 @@
+import { makePublicInputsAndRecursiveProof } from '@aztec/circuit-types';
+import { RECURSIVE_PROOF_LENGTH, VerificationKeyData, makeRecursiveProof } from '@aztec/circuits.js';
+import {
+  makeBaseOrMergeRollupPublicInputs,
+  makeBaseParityInputs,
+  makeBaseRollupInputs,
+  makeRootParityInput,
+  makeRootParityInputs,
+} from '@aztec/circuits.js/testing';
+
+import { jest } from '@jest/globals';
+
+import { ProvingBroker } from './proving_broker.js';
+import { InMemoryDatabase } from './proving_broker_database.js';
+import { ProofType, type ProvingJob, type ProvingJobId, makeProvingJobId } from './proving_job.js';
+
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+describe('ProvingBroker', () => {
+  let database: InMemoryDatabase;
+  let broker: ProvingBroker;
+  let timeoutMs: number;
+  let maxRetries: number;
+
+  beforeEach(() => {
+    timeoutMs = 300;
+    maxRetries = 2;
+    database = new InMemoryDatabase();
+    broker = new ProvingBroker(database, {
+      jobTimeoutMs: timeoutMs,
+      timeoutIntervalMs: timeoutMs / 3,
+      maxRetries,
+    });
+  });
+
+  describe('Producer API', () => {
+    beforeEach(async () => {
+      await broker.start();
+    });
+
+    afterEach(async () => {
+      await broker.stop();
+    });
+
+    it('enqueues jobs', async () => {
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs() });
+      expect(await broker.getProvingJobStatus(id)).toEqual({ status: 'in-queue' });
+
+      const id2 = makeProvingJobId(ProofType.BaseRollupProof);
+      await broker.enqueueProvingJob({ id: id2, blockNumber: 1, inputs: makeBaseRollupInputs() });
+      expect(await broker.getProvingJobStatus(id2)).toEqual({ status: 'in-queue' });
+    });
+
+    it('ignores duplicate jobs', async () => {
+      const provingJob: ProvingJob<ProofType.BaseParityProof> = {
+        id: makeProvingJobId(ProofType.BaseParityProof),
+        blockNumber: 1,
+        inputs: makeBaseParityInputs(),
+      };
+
+      await broker.enqueueProvingJob(provingJob);
+      await expect(broker.enqueueProvingJob(provingJob)).resolves.toBeUndefined();
+      await expect(broker.getProvingJobStatus(provingJob.id)).resolves.toEqual({ status: 'in-queue' });
+    });
+
+    it('throws an error in case of duplicate job IDs', async () => {
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs(1) });
+      await expect(broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs(2) })).rejects.toThrow(
+        'Duplicate proving job ID',
+      );
+    });
+
+    it('returns not-found status for non-existing jobs', async () => {
+      const status = await broker.getProvingJobStatus(makeProvingJobId(ProofType.BaseParityProof));
+      expect(status).toEqual({ status: 'not-found' });
+    });
+
+    it('cancels jobs in queue', async () => {
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs() });
+      await expect(broker.getProvingJobStatus(id)).resolves.toEqual({ status: 'in-queue' });
+
+      await broker.removeAndCancelProvingJob(id);
+
+      await expect(broker.getProvingJobStatus(id)).resolves.toEqual({ status: 'not-found' });
+    });
+
+    it('cancels jobs in-progress', async () => {
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs() });
+      await expect(broker.getProvingJobStatus(id)).resolves.toEqual({ status: 'in-queue' });
+      await broker.getProvingJob();
+      await expect(broker.getProvingJobStatus(id)).resolves.toEqual({ status: 'in-progress' });
+      await broker.removeAndCancelProvingJob(id);
+      await expect(broker.getProvingJobStatus(id)).resolves.toEqual({ status: 'not-found' });
+    });
+
+    it('returns job result if successful', async () => {
+      const provingJob: ProvingJob<ProofType.BaseParityProof> = {
+        id: makeProvingJobId(ProofType.BaseParityProof),
+        blockNumber: 1,
+        inputs: makeBaseParityInputs(),
+      };
+
+      await broker.enqueueProvingJob(provingJob);
+      const value = makeRootParityInput(RECURSIVE_PROOF_LENGTH);
+      await broker.reportProvingJobSuccess(provingJob.id, value);
+
+      const status = await broker.getProvingJobStatus(provingJob.id);
+      expect(status).toEqual({ status: 'resolved', value });
+    });
+
+    it('returns job error if failed', async () => {
+      const provingJob: ProvingJob<ProofType.BaseParityProof> = {
+        id: makeProvingJobId(ProofType.BaseParityProof),
+        blockNumber: 1,
+        inputs: makeBaseParityInputs(),
+      };
+
+      await broker.enqueueProvingJob(provingJob);
+      const error = new Error('test error');
+      await broker.reportProvingJobError(provingJob.id, error);
+
+      const status = await broker.getProvingJobStatus(provingJob.id);
+      expect(status).toEqual({ status: 'rejected', error });
+    });
+  });
+
+  describe('Consumer API', () => {
+    beforeEach(async () => {
+      await broker.start();
+    });
+
+    afterEach(async () => {
+      await broker.stop();
+    });
+
+    it('returns undefined if no jobs are available', async () => {
+      const provingJob = await broker.getProvingJob({ allowList: [ProofType.BaseParityProof] });
+      expect(provingJob).toBeUndefined();
+    });
+
+    it('returns jobs in priority order', async () => {
+      const provingJob1: ProvingJob<ProofType.BaseParityProof> = {
+        id: makeProvingJobId(ProofType.BaseParityProof),
+        blockNumber: 1,
+        inputs: makeBaseParityInputs(),
+      };
+
+      const provingJob2: ProvingJob<ProofType.BaseParityProof> = {
+        id: makeProvingJobId(ProofType.BaseParityProof),
+        blockNumber: 2,
+        inputs: makeBaseParityInputs(),
+      };
+
+      const provingJob3: ProvingJob<ProofType.BaseParityProof> = {
+        id: makeProvingJobId(ProofType.BaseParityProof),
+        blockNumber: 3,
+        inputs: makeBaseParityInputs(),
+      };
+
+      await broker.enqueueProvingJob(provingJob2);
+      await broker.enqueueProvingJob(provingJob3);
+      await broker.enqueueProvingJob(provingJob1);
+
+      await getAndAssertNextJobId(provingJob1.id, ProofType.BaseParityProof);
+    });
+
+    it('returns undefined if no jobs are available for the given allowList', async () => {
+      await broker.enqueueProvingJob({
+        id: makeProvingJobId(ProofType.BaseParityProof),
+        blockNumber: 1,
+        inputs: makeBaseParityInputs(),
+      });
+
+      await expect(broker.getProvingJob({ allowList: [ProofType.BaseRollupProof] })).resolves.toBeUndefined();
+    });
+
+    it('returns a job if it is in the allowList', async () => {
+      const baseParity1 = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id: baseParity1, blockNumber: 1, inputs: makeBaseParityInputs() });
+
+      const baseRollup1 = makeProvingJobId(ProofType.BaseRollupProof);
+      await broker.enqueueProvingJob({ id: baseRollup1, blockNumber: 1, inputs: makeBaseRollupInputs() });
+
+      const baseRollup2 = makeProvingJobId(ProofType.BaseRollupProof);
+      await broker.enqueueProvingJob({ id: baseRollup2, blockNumber: 2, inputs: makeBaseRollupInputs() });
+
+      const rootParity1 = makeProvingJobId(ProofType.RootParityProof);
+      await broker.enqueueProvingJob({ id: rootParity1, blockNumber: 1, inputs: makeRootParityInputs() });
+
+      await getAndAssertNextJobId(baseParity1, ProofType.BaseParityProof);
+    });
+
+    it('returns the most important job if it is in the allowList', async () => {
+      const baseParity1 = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id: baseParity1, blockNumber: 1, inputs: makeBaseParityInputs() });
+
+      const baseRollup1 = makeProvingJobId(ProofType.BaseRollupProof);
+      await broker.enqueueProvingJob({ id: baseRollup1, blockNumber: 1, inputs: makeBaseRollupInputs() });
+
+      const baseRollup2 = makeProvingJobId(ProofType.BaseRollupProof);
+      await broker.enqueueProvingJob({ id: baseRollup2, blockNumber: 2, inputs: makeBaseRollupInputs() });
+
+      const rootParity1 = makeProvingJobId(ProofType.RootParityProof);
+      await broker.enqueueProvingJob({ id: rootParity1, blockNumber: 1, inputs: makeRootParityInputs() });
+
+      await getAndAssertNextJobId(
+        baseRollup1,
+        ProofType.BaseParityProof,
+        ProofType.BaseRollupProof,
+        ProofType.RootParityProof,
+      );
+    });
+
+    it('returns a new job when reporting progress if current one is cancelled', async () => {
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs() });
+      await broker.getProvingJob();
+      await assertJobStatus(id, 'in-progress');
+      await broker.removeAndCancelProvingJob(id);
+      await assertJobStatus(id, 'not-found');
+
+      const id2 = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id: id2, blockNumber: 1, inputs: makeBaseParityInputs() });
+      await expect(broker.reportProvingJobProgress(id2, { allowList: [ProofType.BaseParityProof] })).resolves.toEqual(
+        expect.objectContaining({ id: id2 }),
+      );
+    });
+
+    it('tracks job result if in progress', async () => {
+      const id1 = makeProvingJobId(ProofType.BaseParityProof);
+      const id2 = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id: id1, blockNumber: 1, inputs: makeBaseParityInputs() });
+      await broker.enqueueProvingJob({ id: id2, blockNumber: 2, inputs: makeBaseParityInputs() });
+
+      await expect(broker.getProvingJob()).resolves.toEqual(expect.objectContaining({ id: id1 }));
+      await assertJobStatus(id1, 'in-progress');
+      await broker.reportProvingJobSuccess(id1, makeRootParityInput(RECURSIVE_PROOF_LENGTH));
+      await assertJobStatus(id1, 'resolved');
+
+      await expect(broker.getProvingJob()).resolves.toEqual(expect.objectContaining({ id: id2 }));
+      await assertJobStatus(id2, 'in-progress');
+      await broker.reportProvingJobError(id2, new Error('test error'));
+      await assertJobStatus(id2, 'rejected');
+    });
+
+    it('tracks job result even if job is in queue', async () => {
+      const id1 = makeProvingJobId(ProofType.BaseParityProof);
+      const id2 = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id: id1, blockNumber: 1, inputs: makeBaseParityInputs() });
+      await broker.enqueueProvingJob({ id: id2, blockNumber: 2, inputs: makeBaseParityInputs() });
+
+      await broker.reportProvingJobSuccess(id1, makeRootParityInput(RECURSIVE_PROOF_LENGTH));
+      await assertJobStatus(id1, 'resolved');
+
+      await broker.reportProvingJobError(id2, new Error('test error'));
+      await assertJobStatus(id2, 'rejected');
+    });
+
+    it('ignores reported job error if unknown job', async () => {
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await assertJobStatus(id, 'not-found');
+      await broker.reportProvingJobError(id, new Error('test error'));
+      await assertJobStatus(id, 'not-found');
+    });
+
+    it('ignores job result if unknown job', async () => {
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await assertJobStatus(id, 'not-found');
+      await broker.reportProvingJobSuccess(id, makeRootParityInput(RECURSIVE_PROOF_LENGTH));
+      await assertJobStatus(id, 'not-found');
+    });
+  });
+
+  describe('Timeouts', () => {
+    beforeEach(async () => {
+      await broker.start();
+    });
+
+    afterEach(async () => {
+      await broker.stop();
+    });
+
+    it('tracks in progress jobs', async () => {
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs() });
+
+      await assertJobStatus(id, 'in-queue');
+      await getAndAssertNextJobId(id);
+      await assertJobStatus(id, 'in-progress');
+    });
+
+    it('re-enqueues jobs that time out', async () => {
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs() });
+
+      await assertJobStatus(id, 'in-queue');
+      await getAndAssertNextJobId(id);
+      await assertJobStatus(id, 'in-progress');
+
+      // advance time so job times out because of no heartbeats
+      await jest.advanceTimersByTimeAsync(timeoutMs);
+
+      // should be back in the queue now
+      await assertJobStatus(id, 'in-queue');
+    });
+
+    it('keeps the jobs in progress while it is alive', async () => {
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs() });
+
+      await assertJobStatus(id, 'in-queue');
+      await getAndAssertNextJobId(id);
+      await assertJobStatus(id, 'in-progress');
+
+      // advance the time slightly, not enough for the request to timeout
+      await jest.advanceTimersByTimeAsync(timeoutMs / 2);
+
+      await assertJobStatus(id, 'in-progress');
+
+      // send a heartbeat
+      await broker.reportProvingJobProgress(id);
+
+      // advance the time again
+      await jest.advanceTimersByTimeAsync(timeoutMs);
+
+      // should still be our request to process
+      await assertJobStatus(id, 'in-progress');
+
+      // advance the time again and lose the request
+      await jest.advanceTimersByTimeAsync(timeoutMs);
+      await assertJobStatus(id, 'in-queue');
+    });
+  });
+
+  describe('Retries', () => {
+    it('retries jobs', async () => {
+      const provingJob: ProvingJob<ProofType.BaseParityProof> = {
+        id: makeProvingJobId(ProofType.BaseParityProof),
+        blockNumber: 1,
+        inputs: makeBaseParityInputs(),
+      };
+
+      await broker.enqueueProvingJob(provingJob);
+
+      await expect(broker.getProvingJobStatus(provingJob.id)).resolves.toEqual({
+        status: 'in-queue',
+      });
+
+      await expect(broker.getProvingJob()).resolves.toEqual(provingJob);
+
+      await expect(broker.getProvingJobStatus(provingJob.id)).resolves.toEqual({
+        status: 'in-progress',
+      });
+
+      await broker.reportProvingJobError(provingJob.id, new Error('test error'), true);
+
+      await expect(broker.getProvingJobStatus(provingJob.id)).resolves.toEqual({
+        status: 'in-queue',
+      });
+    });
+
+    it('retries up to a maximum number of times', async () => {
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs() });
+
+      for (let i = 0; i < maxRetries; i++) {
+        await assertJobStatus(id, 'in-queue');
+        await getAndAssertNextJobId(id);
+        await assertJobStatus(id, 'in-progress');
+        await broker.reportProvingJobError(id, new Error('test error'), true);
+      }
+
+      await expect(broker.getProvingJobStatus(id)).resolves.toEqual({
+        status: 'rejected',
+        error: new Error('test error'),
+      });
+    });
+
+    it('passing retry=false does not retry', async () => {
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs() });
+
+      await getAndAssertNextJobId(id);
+      await assertJobStatus(id, 'in-progress');
+      await broker.reportProvingJobError(id, new Error('test error'), false);
+      await expect(broker.getProvingJobStatus(id)).resolves.toEqual({
+        status: 'rejected',
+        error: new Error('test error'),
+      });
+    });
+  });
+
+  describe('Database management', () => {
+    afterEach(async () => {
+      await broker.stop();
+    });
+
+    it('re-enqueues proof requests on start', async () => {
+      const id1 = makeProvingJobId(ProofType.BaseParityProof);
+
+      await database.addProvingJob({
+        id: id1,
+        blockNumber: 1,
+        inputs: makeBaseParityInputs(),
+      });
+
+      const id2 = makeProvingJobId(ProofType.BaseRollupProof);
+      await database.addProvingJob({
+        id: id2,
+        blockNumber: 2,
+        inputs: makeBaseRollupInputs(),
+      });
+
+      await broker.start();
+
+      await expect(broker.getProvingJobStatus(id1)).resolves.toEqual({ status: 'in-queue' });
+      await expect(broker.getProvingJobStatus(id2)).resolves.toEqual({ status: 'in-queue' });
+
+      await expect(broker.getProvingJob({ allowList: [ProofType.BaseParityProof] })).resolves.toEqual({
+        id: id1,
+        blockNumber: 1,
+        inputs: expect.any(Object),
+      });
+
+      await expect(broker.getProvingJob()).resolves.toEqual({
+        id: id2,
+        blockNumber: 2,
+        inputs: expect.any(Object),
+      });
+
+      await expect(broker.getProvingJobStatus(id1)).resolves.toEqual({
+        status: 'in-progress',
+      });
+      await expect(broker.getProvingJobStatus(id2)).resolves.toEqual({
+        status: 'in-progress',
+      });
+    });
+
+    it('restores proof results on start', async () => {
+      const id1 = makeProvingJobId(ProofType.BaseParityProof);
+
+      await database.addProvingJob({
+        id: id1,
+        blockNumber: 1,
+        inputs: makeBaseParityInputs(),
+      });
+
+      const id2 = makeProvingJobId(ProofType.BaseRollupProof);
+      await database.addProvingJob({
+        id: id2,
+        blockNumber: 2,
+        inputs: makeBaseRollupInputs(),
+      });
+
+      await database.setProvingJobResult(id1, makeRootParityInput(RECURSIVE_PROOF_LENGTH));
+
+      await database.setProvingJobResult(
+        id2,
+        makePublicInputsAndRecursiveProof(
+          makeBaseOrMergeRollupPublicInputs(),
+          makeRecursiveProof(RECURSIVE_PROOF_LENGTH),
+          VerificationKeyData.makeFake(),
+        ),
+      );
+
+      await broker.start();
+
+      await expect(broker.getProvingJobStatus(id1)).resolves.toEqual({
+        status: 'resolved',
+        value: expect.any(Object),
+      });
+
+      await expect(broker.getProvingJobStatus(id2)).resolves.toEqual({
+        status: 'resolved',
+        value: expect.any(Object),
+      });
+    });
+
+    it('only re-enqueues unfinished jobs', async () => {
+      const id1 = makeProvingJobId(ProofType.BaseParityProof);
+
+      await database.addProvingJob({
+        id: id1,
+        blockNumber: 1,
+        inputs: makeBaseParityInputs(),
+      });
+      await database.setProvingJobResult(id1, makeRootParityInput(RECURSIVE_PROOF_LENGTH));
+
+      const id2 = makeProvingJobId(ProofType.BaseRollupProof);
+      await database.addProvingJob({
+        id: id2,
+        blockNumber: 2,
+        inputs: makeBaseRollupInputs(),
+      });
+
+      await broker.start();
+
+      await expect(broker.getProvingJobStatus(id1)).resolves.toEqual({
+        status: 'resolved',
+        value: expect.any(Object),
+      });
+
+      await expect(broker.getProvingJobStatus(id2)).resolves.toEqual({ status: 'in-queue' });
+      await expect(broker.getProvingJob()).resolves.toEqual(expect.objectContaining({ id: id2 }));
+    });
+
+    it('clears job state when job is removed', async () => {
+      const id1 = makeProvingJobId(ProofType.BaseParityProof);
+
+      await database.addProvingJob({
+        id: id1,
+        blockNumber: 1,
+        inputs: makeBaseParityInputs(),
+      });
+      await database.setProvingJobResult(id1, makeRootParityInput(RECURSIVE_PROOF_LENGTH));
+
+      const id2 = makeProvingJobId(ProofType.BaseRollupProof);
+      await database.addProvingJob({
+        id: id2,
+        blockNumber: 2,
+        inputs: makeBaseRollupInputs(),
+      });
+
+      expect(database.getProvingJob(id1)).not.toBeUndefined();
+      expect(database.getProvingJobResult(id1)).not.toBeUndefined();
+      expect(database.getProvingJob(id2)).not.toBeUndefined();
+
+      await broker.start();
+
+      await expect(broker.getProvingJobStatus(id1)).resolves.toEqual({
+        status: 'resolved',
+        value: expect.any(Object),
+      });
+
+      await expect(broker.getProvingJobStatus(id2)).resolves.toEqual({ status: 'in-queue' });
+
+      await broker.removeAndCancelProvingJob(id1);
+      await broker.removeAndCancelProvingJob(id2);
+
+      await expect(broker.getProvingJobStatus(id1)).resolves.toEqual({ status: 'not-found' });
+      await expect(broker.getProvingJobStatus(id2)).resolves.toEqual({ status: 'not-found' });
+
+      expect(database.getProvingJob(id1)).toBeUndefined();
+      expect(database.getProvingJobResult(id1)).toBeUndefined();
+      expect(database.getProvingJob(id2)).toBeUndefined();
+    });
+
+    it('saves job when enqueued', async () => {
+      await broker.start();
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs() });
+      expect(database.getProvingJob(id)).not.toBeUndefined();
+    });
+
+    it('does not retain job if database fails to save', async () => {
+      await broker.start();
+
+      jest.spyOn(database, 'addProvingJob').mockRejectedValue(new Error('db error'));
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await expect(broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs() })).rejects.toThrow(
+        new Error('db error'),
+      );
+      await assertJobStatus(id, 'not-found');
+    });
+
+    it('saves job result', async () => {
+      await broker.start();
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs() });
+      await broker.reportProvingJobSuccess(id, makeRootParityInput(RECURSIVE_PROOF_LENGTH));
+      await assertJobStatus(id, 'resolved');
+      expect(database.getProvingJobResult(id)).toEqual({ value: expect.any(Object) });
+    });
+
+    it('does not retain job result if database fails to save', async () => {
+      await broker.start();
+      jest.spyOn(database, 'setProvingJobResult').mockRejectedValue(new Error('db error'));
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs() });
+      await expect(broker.reportProvingJobSuccess(id, makeRootParityInput(RECURSIVE_PROOF_LENGTH))).rejects.toThrow(
+        new Error('db error'),
+      );
+      await assertJobStatus(id, 'in-queue');
+      expect(database.getProvingJobResult(id)).toBeUndefined();
+    });
+
+    it('saves job error', async () => {
+      await broker.start();
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs() });
+      await broker.reportProvingJobError(id, new Error('test error'));
+      await assertJobStatus(id, 'rejected');
+      expect(database.getProvingJobResult(id)).toEqual({ error: new Error('test error') });
+    });
+
+    it('does not retain job error if database fails to save', async () => {
+      await broker.start();
+      jest.spyOn(database, 'setProvingJobError').mockRejectedValue(new Error('db error'));
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+      await broker.enqueueProvingJob({ id, blockNumber: 1, inputs: makeBaseParityInputs() });
+      await expect(broker.reportProvingJobError(id, new Error())).rejects.toThrow(new Error('db error'));
+      await assertJobStatus(id, 'in-queue');
+      expect(database.getProvingJobResult(id)).toBeUndefined();
+    });
+
+    it('does not save job result if job is unknown', async () => {
+      await broker.start();
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+
+      expect(database.getProvingJob(id)).toBeUndefined();
+      expect(database.getProvingJobResult(id)).toBeUndefined();
+
+      await broker.reportProvingJobSuccess(id, makeRootParityInput(RECURSIVE_PROOF_LENGTH));
+
+      expect(database.getProvingJob(id)).toBeUndefined();
+      expect(database.getProvingJobResult(id)).toBeUndefined();
+    });
+
+    it('does not save job error if job is unknown', async () => {
+      await broker.start();
+      const id = makeProvingJobId(ProofType.BaseParityProof);
+
+      expect(database.getProvingJob(id)).toBeUndefined();
+      expect(database.getProvingJobResult(id)).toBeUndefined();
+
+      await broker.reportProvingJobError(id, new Error('test error'));
+
+      expect(database.getProvingJob(id)).toBeUndefined();
+      expect(database.getProvingJobResult(id)).toBeUndefined();
+    });
+  });
+
+  async function assertJobStatus(id: ProvingJobId, status: string) {
+    await expect(broker.getProvingJobStatus(id)).resolves.toEqual(expect.objectContaining({ status }));
+  }
+
+  async function getAndAssertNextJobId(id: ProvingJobId, ...allowList: ProofType[]) {
+    await expect(broker.getProvingJob(allowList.length > 0 ? { allowList } : undefined)).resolves.toEqual(
+      expect.objectContaining({ id }),
+    );
+  }
+});

--- a/yarn-project/prover-client/src/proving_broker/proving_broker.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker.ts
@@ -1,0 +1,351 @@
+import { createDebugLogger } from '@aztec/foundation/log';
+import { RunningPromise } from '@aztec/foundation/promise';
+import { PriorityMemoryQueue } from '@aztec/foundation/queue';
+
+import assert from 'assert';
+
+import { type ProvingBrokerDatabase } from './proving_broker_database.js';
+import type { ProvingJobConsumer, ProvingJobFilter, ProvingJobProducer } from './proving_broker_interface.js';
+import {
+  type ProofOutputs,
+  ProofType,
+  type ProvingJob,
+  type ProvingJobId,
+  type ProvingJobStatus,
+  getProofTypeFromId,
+} from './proving_job.js';
+
+type InProgressMetadata<T extends ProofType = ProofType> = {
+  id: ProvingJobId<T>;
+  startedAt: number;
+  lastUpdatedAt: number;
+};
+
+type ProofRequestBrokerConfig = {
+  timeoutIntervalMs?: number;
+  jobTimeoutMs?: number;
+  maxRetries?: number;
+};
+
+/**
+ * A broker that manages proof requests and distributes them to workers based on their priority.
+ * It takes a backend that is responsible for storing and retrieving proof requests and results.
+ */
+export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer {
+  // Each proof type gets its own queue so that agents can request specific types of proofs
+  // Manually create the queues to get type checking
+  private queues: ProvingQueues = {
+    [ProofType.AvmProof]: new PriorityMemoryQueue<ProvingJob<ProofType.AvmProof>>(provingJobComparator),
+
+    [ProofType.TubeProof]: new PriorityMemoryQueue<ProvingJob<ProofType.TubeProof>>(provingJobComparator),
+    [ProofType.EmptyTubeProof]: new PriorityMemoryQueue<ProvingJob<ProofType.EmptyTubeProof>>(provingJobComparator),
+
+    [ProofType.PublicKernelSetupProof]: new PriorityMemoryQueue<ProvingJob<ProofType.PublicKernelSetupProof>>(
+      provingJobComparator,
+    ),
+    [ProofType.PublicKernelAppLogicProof]: new PriorityMemoryQueue<ProvingJob<ProofType.PublicKernelAppLogicProof>>(
+      provingJobComparator,
+    ),
+    [ProofType.PublicKernelTeardownProof]: new PriorityMemoryQueue<ProvingJob<ProofType.PublicKernelTeardownProof>>(
+      provingJobComparator,
+    ),
+    [ProofType.PublicKernelTailProof]: new PriorityMemoryQueue<ProvingJob<ProofType.PublicKernelTailProof>>(
+      provingJobComparator,
+    ),
+
+    [ProofType.BaseRollupProof]: new PriorityMemoryQueue<ProvingJob<ProofType.BaseRollupProof>>(provingJobComparator),
+    [ProofType.MergeRollupProof]: new PriorityMemoryQueue<ProvingJob<ProofType.MergeRollupProof>>(provingJobComparator),
+    [ProofType.RootRollupProof]: new PriorityMemoryQueue<ProvingJob<ProofType.RootRollupProof>>(provingJobComparator),
+
+    [ProofType.BlockMergeRollupProof]: new PriorityMemoryQueue<ProvingJob<ProofType.BlockMergeRollupProof>>(
+      provingJobComparator,
+    ),
+    [ProofType.BlockRootRollupProof]: new PriorityMemoryQueue<ProvingJob<ProofType.BlockRootRollupProof>>(
+      provingJobComparator,
+    ),
+
+    [ProofType.BaseParityProof]: new PriorityMemoryQueue<ProvingJob<ProofType.BaseParityProof>>(provingJobComparator),
+    [ProofType.RootParityProof]: new PriorityMemoryQueue<ProvingJob<ProofType.RootParityProof>>(provingJobComparator),
+  };
+
+  // holds a copy of the database in memory in order to quickly fulfill requests
+  // this is fine because this broker is the only one that can modify the database
+  private jobsCache = new Map<ProvingJobId, ProvingJob>();
+  // as above, but for results
+  private resultsCache = new Map<ProvingJobId, { value: ProofOutputs[ProofType] } | { error: Error }>();
+
+  // keeps track of which jobs are currently being processed
+  // in the event of a crash this information is lost, but that's ok
+  // the next time the broker starts it will recreate jobsCache and still
+  // accept results from the workers
+  private inProgress = new Map<ProvingJobId, InProgressMetadata>();
+
+  // keep track of which proving job has been retried
+  private retries = new Map<ProvingJobId, number>();
+
+  private timeoutPromise: RunningPromise;
+  private timeSource = Date.now;
+  private proofRequestTimeoutMs: number;
+  private maxRetries: number;
+
+  public constructor(
+    private database: ProvingBrokerDatabase,
+    {
+      jobTimeoutMs: proofRequestTimeoutMs = 30_000,
+      timeoutIntervalMs = 10_000,
+      maxRetries = 3,
+    }: ProofRequestBrokerConfig = {},
+    private logger = createDebugLogger('aztec:prover-client:proof-request-broker'),
+  ) {
+    this.timeoutPromise = new RunningPromise(this.timeoutCheck, timeoutIntervalMs);
+    this.proofRequestTimeoutMs = proofRequestTimeoutMs;
+    this.maxRetries = maxRetries;
+  }
+
+  // eslint-disable-next-line require-await
+  public async start(): Promise<void> {
+    for (const [item, result] of this.database.allProvingJobs()) {
+      this.logger.info(`Restoring proving job id=${item.id} settled=${!!result}`);
+
+      this.jobsCache.set(item.id, item);
+      if (result) {
+        this.resultsCache.set(item.id, result);
+      } else {
+        this.logger.debug(`Re-enqueuing proving job id=${item.id}`);
+        this.enqueueJobInternal(item);
+      }
+    }
+
+    this.timeoutPromise.start();
+  }
+
+  public stop(): Promise<void> {
+    return this.timeoutPromise.stop();
+  }
+
+  public async enqueueProvingJob<T extends ProofType>(job: ProvingJob<T>): Promise<void> {
+    if (this.jobsCache.has(job.id)) {
+      const existing = this.jobsCache.get(job.id);
+      assert.deepStrictEqual(job, existing, 'Duplicate proving job ID');
+      return;
+    }
+
+    await this.database.addProvingJob(job);
+    this.jobsCache.set(job.id, job);
+    this.enqueueJobInternal(job);
+  }
+
+  public async removeAndCancelProvingJob<T extends ProofType>(id: ProvingJobId<T>): Promise<void> {
+    this.logger.info(`Cancelling job id=${id}`);
+    await this.database.deleteProvingJobAndResult(id);
+
+    this.jobsCache.delete(id);
+    this.resultsCache.delete(id);
+    this.inProgress.delete(id);
+    this.retries.delete(id);
+  }
+
+  // eslint-disable-next-line require-await
+  public async getProvingJobStatus<T extends ProofType>(id: ProvingJobId<T>): Promise<ProvingJobStatus<T>> {
+    const result = this.resultsCache.get(id);
+    if (!result) {
+      // no result yet, check if we know the item
+      const item = this.jobsCache.get(id);
+
+      if (!item) {
+        this.logger.warn(`Proving job id=${id} not found`);
+        return Promise.resolve({ status: 'not-found' });
+      }
+
+      return Promise.resolve({ status: this.inProgress.has(id) ? 'in-progress' : 'in-queue' });
+    } else if ('value' in result) {
+      return Promise.resolve({ status: 'resolved', value: result.value as ProofOutputs[T] });
+    } else {
+      return Promise.resolve({ status: 'rejected', error: result.error });
+    }
+  }
+
+  // eslint-disable-next-line require-await
+  async getProvingJob<T extends ProofType[]>(
+    filter: ProvingJobFilter<T> = {},
+  ): Promise<ProvingJob<T[number]> | undefined> {
+    const allowedProofs = filter.allowList ? [...filter.allowList] : Object.values(ProofType);
+    allowedProofs.sort(proofTypeComparator);
+
+    for (const proofType of allowedProofs) {
+      const queue = this.queues[proofType];
+      const item = queue.getImmediate();
+      if (item) {
+        this.inProgress.set(item.id, {
+          id: item.id,
+          startedAt: this.timeSource(),
+          lastUpdatedAt: this.timeSource(),
+        });
+
+        return item;
+      }
+    }
+
+    return undefined;
+  }
+
+  async reportProvingJobError<T extends ProofType>(id: ProvingJobId<T>, err: Error, retry = false): Promise<void> {
+    const info = this.inProgress.get(id);
+    const item = this.jobsCache.get(id);
+    const retries = this.retries.get(id) ?? 0;
+
+    if (!item) {
+      this.logger.warn(`Proving job id=${id} not found`);
+      return;
+    }
+
+    if (!info) {
+      this.logger.warn(`Proving job id=${id} not in the in-progress set`);
+    } else {
+      this.inProgress.delete(id);
+    }
+
+    if (retry && retries + 1 < this.maxRetries) {
+      this.logger.info(`Retrying proving job id=${id} retry=${retries + 1}`);
+      this.retries.set(id, retries + 1);
+      this.enqueueJobInternal(item);
+      return;
+    }
+
+    this.logger.debug(`Marking proving job id=${id} totalAttempts=${retries + 1} as failed`);
+    await this.database.setProvingJobError(id, err);
+    this.resultsCache.set(id, { error: err });
+  }
+
+  reportProvingJobProgress<T extends ProofType, F extends ProofType[]>(
+    id: ProvingJobId<T>,
+    filter?: ProvingJobFilter<F>,
+  ): Promise<ProvingJob<F[number]> | undefined> {
+    const metadata = this.inProgress.get(id);
+    if (metadata) {
+      metadata.lastUpdatedAt = this.timeSource();
+      return Promise.resolve(undefined);
+    } else if (filter) {
+      this.logger.warn(`Proving job id=${id} not found in the in-progress set. Sending new one`);
+      return this.getProvingJob(filter);
+    } else {
+      this.logger.warn(`Proving job id=${id} not found in the in-progress set`);
+      return Promise.resolve(undefined);
+    }
+  }
+
+  async reportProvingJobSuccess<T extends ProofType>(id: ProvingJobId<T>, value: ProofOutputs[T]): Promise<void> {
+    const info = this.inProgress.get(id);
+    const item = this.jobsCache.get(id);
+    const retries = this.retries.get(id) ?? 0;
+    if (!item) {
+      this.logger.warn(`Proving job id=${id} not found`);
+      return;
+    }
+
+    if (!info) {
+      this.logger.warn(`Proving job id=${id} not in the in-progress set`);
+    } else {
+      this.inProgress.delete(id);
+    }
+
+    this.logger.debug(`Proving job complete id=${id} totalAttempts=${retries + 1}`);
+    await this.database.setProvingJobResult(id, value);
+    this.resultsCache.set(id, { value });
+  }
+
+  private timeoutCheck = () => {
+    for (const [id, metadata] of this.inProgress.entries()) {
+      const item = this.jobsCache.get(id);
+      if (!item) {
+        this.logger.warn(`Proving job id=${id} not found. Removing it from the queue.`);
+        this.inProgress.delete(id);
+        continue;
+      }
+
+      const elapsedSinceLastUpdate = this.timeSource() - metadata.lastUpdatedAt;
+      if (elapsedSinceLastUpdate >= this.proofRequestTimeoutMs) {
+        this.logger.warn(`Proving job id=${id} timed out. Adding it back to the queue.`);
+        this.inProgress.delete(id);
+        this.enqueueJobInternal(item);
+      }
+    }
+  };
+
+  private enqueueJobInternal<T extends ProofType>(job: ProvingJob<T>): void {
+    const proofType = getProofTypeFromId(job.id);
+    this.queues[proofType].put(job);
+    this.logger.debug(`Enqueued new proving job id=${job.id}`);
+  }
+}
+
+type ProvingQueues = {
+  [K in ProofType]: PriorityMemoryQueue<ProvingJob<K>>;
+};
+
+/**
+ * Compares two proving jobs and selects which one's more important
+ * @param a - A proving job
+ * @param b - Another proving job
+ * @returns A number indicating the relative priority of the two proving jobs
+ */
+function provingJobComparator<T extends ProofType>(a: ProvingJob<T>, b: ProvingJob<T>): -1 | 0 | 1 {
+  if (a.blockNumber < b.blockNumber) {
+    return -1;
+  } else if (a.blockNumber > b.blockNumber) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+/**
+ * Compares two proofs and selects which one's more important.
+ * If some proofs does not exist in the priority array then it's considered the least important.
+ *
+ * @param a - A proof type
+ * @param b - Another proof type
+ * @returns A number indicating the relative priority of the two proof types
+ */
+function proofTypeComparator(a: ProofType, b: ProofType): -1 | 0 | 1 {
+  const indexOfA = PROOF_TYPES_IN_PRIORITY_ORDER.indexOf(a);
+  const indexOfB = PROOF_TYPES_IN_PRIORITY_ORDER.indexOf(b);
+  if (indexOfA === indexOfB) {
+    return 0;
+  } else if (indexOfA === -1) {
+    // a is some new proof that didn't get added to the array
+    // b is more important because we know about it
+    return 1;
+  } else if (indexOfB === -1) {
+    // the opposite of the previous if branch
+    return -1;
+  } else if (indexOfA < indexOfB) {
+    return -1;
+  } else {
+    return 1;
+  }
+}
+
+/**
+ * Relative priority of each proof type. Proofs higher up on the list are more important and should be prioritized
+ * over proofs lower on the list.
+ *
+ * The aim is that this will speed up block proving as the closer we get to a block's root proof the more likely it
+ * is to get picked up by agents
+ */
+const PROOF_TYPES_IN_PRIORITY_ORDER: ProofType[] = [
+  ProofType.BlockRootRollupProof,
+  ProofType.BlockMergeRollupProof,
+  ProofType.RootRollupProof,
+  ProofType.MergeRollupProof,
+  ProofType.BaseRollupProof,
+  ProofType.PublicKernelSetupProof,
+  ProofType.PublicKernelAppLogicProof,
+  ProofType.PublicKernelTeardownProof,
+  ProofType.PublicKernelTailProof,
+  ProofType.AvmProof,
+  ProofType.TubeProof,
+  ProofType.EmptyTubeProof,
+  ProofType.RootParityProof,
+  ProofType.BaseParityProof,
+];

--- a/yarn-project/prover-client/src/proving_broker/proving_broker_database.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker_database.ts
@@ -1,0 +1,78 @@
+import type { ProofOutputs, ProofType, ProvingJob, ProvingJobId } from './proving_job.js';
+
+export type ProvingJobResult<T extends ProofType> = { value: ProofOutputs[T] } | { error: Error };
+
+export interface ProvingBrokerDatabase {
+  /**
+   * Saves a proof request so it can be retrieved later
+   * @param request - The proof request to save
+   */
+  addProvingJob<T extends ProofType>(request: ProvingJob<T>): Promise<void>;
+
+  /**
+   * Removes a proof request from the backend
+   * @param id - The ID of the proof request to remove
+   */
+  deleteProvingJobAndResult<T extends ProofType>(id: ProvingJobId<T>): Promise<void>;
+
+  /**
+   * Returns an iterator over all saved proving jobs
+   */
+  allProvingJobs(): Iterable<[ProvingJob<ProofType>, ProvingJobResult<ProofType> | undefined]>;
+
+  /**
+   * Saves the result of a proof request
+   * @param id - The ID of the proof request to save the result for
+   * @param proofType - The type of proof that was requested
+   * @param value - The result of the proof request
+   */
+  setProvingJobResult<T extends ProofType>(id: ProvingJobId<T>, value: ProofOutputs[T]): Promise<void>;
+
+  /**
+   * Saves an error that occurred while processing a proof request
+   * @param id - The ID of the proof request to save the error for
+   * @param proofType - The type of proof that was requested
+   * @param err - The error that occurred while processing the proof request
+   */
+  setProvingJobError<T extends ProofType>(id: ProvingJobId<T>, err: Error): Promise<void>;
+}
+
+export class InMemoryDatabase implements ProvingBrokerDatabase {
+  private jobs = new Map<ProvingJobId, ProvingJob<ProofType>>();
+  private results = new Map<ProvingJobId, ProvingJobResult<ProofType>>();
+
+  getProvingJob<T extends ProofType>(id: ProvingJobId<T>): ProvingJob<T> | undefined {
+    return this.jobs.get(id) as ProvingJob<T> | undefined;
+  }
+
+  getProvingJobResult<T extends ProofType>(id: ProvingJobId<T>): ProvingJobResult<T> | undefined {
+    return this.results.get(id) as ProvingJobResult<T> | undefined;
+  }
+
+  addProvingJob<T extends ProofType>(request: ProvingJob<T>): Promise<void> {
+    this.jobs.set(request.id, request);
+    return Promise.resolve();
+  }
+
+  setProvingJobResult<T extends ProofType>(id: ProvingJobId<T>, value: ProofOutputs[T]): Promise<void> {
+    this.results.set(id, { value });
+    return Promise.resolve();
+  }
+
+  setProvingJobError<T extends ProofType>(id: ProvingJobId<T>, error: Error): Promise<void> {
+    this.results.set(id, { error });
+    return Promise.resolve();
+  }
+
+  deleteProvingJobAndResult<T extends ProofType>(id: ProvingJobId<T>): Promise<void> {
+    this.jobs.delete(id);
+    this.results.delete(id);
+    return Promise.resolve();
+  }
+
+  *allProvingJobs(): Iterable<[ProvingJob<ProofType>, ProvingJobResult<ProofType> | undefined]> {
+    for (const item of this.jobs.values()) {
+      yield [item, this.results.get(item.id)] as const;
+    }
+  }
+}

--- a/yarn-project/prover-client/src/proving_broker/proving_broker_interface.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker_interface.ts
@@ -1,0 +1,64 @@
+import type { ProofOutputs, ProofType, ProvingJob, ProvingJobId, ProvingJobStatus } from './proving_job.js';
+
+/**
+ * An interface for the proving orchestrator. The producer uses this to enqueue jobs for agents
+ */
+export interface ProvingJobProducer {
+  /**
+   * Enqueues a proving job
+   * @param job - The job to enqueue
+   */
+  enqueueProvingJob<T extends ProofType>(job: ProvingJob<T>): Promise<void>;
+
+  /**
+   * Cancels a proving job and clears all of its
+   * @param id - The ID of the job to cancel
+   */
+  removeAndCancelProvingJob<T extends ProofType>(id: ProvingJobId<T>): Promise<void>;
+
+  /**
+   * Returns the current status fof the proving job
+   * @param id - The ID of the job to get the status of
+   */
+  getProvingJobStatus<T extends ProofType>(id: ProvingJobId<T>): Promise<ProvingJobStatus<T>>;
+}
+
+export interface ProvingJobFilter<T extends ProofType[]> {
+  allowList?: T;
+}
+
+/**
+ * An interface for proving agents to request jobs and report results
+ */
+export interface ProvingJobConsumer {
+  /**
+   * Gets a proving job to work on
+   * @param filter - Optional filter for the type of job to get
+   */
+  getProvingJob<T extends ProofType[]>(filter?: ProvingJobFilter<T>): Promise<ProvingJob<T[number]> | undefined>;
+
+  /**
+   * Marks a proving job as successful
+   * @param id - The ID of the job to report success for
+   * @param result - The result of the job
+   */
+  reportProvingJobSuccess<T extends ProofType>(id: ProvingJobId<T>, result: ProofOutputs[T]): Promise<void>;
+
+  /**
+   * Marks a proving job as errored
+   * @param id - The ID of the job to report an error for
+   * @param err - The error that occurred while processing the job
+   * @param retry - Whether to retry the job
+   */
+  reportProvingJobError<T extends ProofType>(id: ProvingJobId<T>, err: Error, retry?: boolean): Promise<void>;
+
+  /**
+   * Sends a heartbeat to the broker to indicate that the agent is still working on the given proving job
+   * @param id - The ID of the job to report progress for
+   * @param filter - Optional filter for the type of job to get
+   */
+  reportProvingJobProgress<T extends ProofType, F extends ProofType[]>(
+    id: ProvingJobId<T>,
+    filter?: ProvingJobFilter<F>,
+  ): Promise<ProvingJob<F[number]> | undefined>;
+}

--- a/yarn-project/prover-client/src/proving_broker/proving_job.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_job.ts
@@ -1,0 +1,147 @@
+import { type ProofAndVerificationKey, type PublicInputsAndRecursiveProof } from '@aztec/circuit-types';
+import {
+  AvmCircuitInputs,
+  type BaseOrMergeRollupPublicInputs,
+  BaseParityInputs,
+  BaseRollupInputs,
+  BlockMergeRollupInputs,
+  type BlockRootOrBlockMergePublicInputs,
+  BlockRootRollupInputs,
+  type KernelCircuitPublicInputs,
+  MergeRollupInputs,
+  type NESTED_RECURSIVE_PROOF_LENGTH,
+  PrivateKernelEmptyInputs,
+  type Proof,
+  PublicKernelCircuitPrivateInputs,
+  type PublicKernelCircuitPublicInputs,
+  PublicKernelTailCircuitPrivateInputs,
+  type RECURSIVE_PROOF_LENGTH,
+  type RecursiveProof,
+  type RootParityInput,
+  RootParityInputs,
+  RootRollupInputs,
+  type RootRollupPublicInputs,
+  type TUBE_PROOF_LENGTH,
+  TubeInputs,
+} from '@aztec/circuits.js';
+
+import { randomBytes } from 'crypto';
+
+export enum ProofType {
+  AvmProof = 'AvmProof',
+
+  TubeProof = 'TubeProof',
+  EmptyTubeProof = 'EmptyTubeProof',
+
+  PublicKernelSetupProof = 'PublicKernelSetupProof',
+  PublicKernelAppLogicProof = 'PublicKernelAppLogicProof',
+  PublicKernelTeardownProof = 'PublicKernelTeardownProof',
+  PublicKernelTailProof = 'PublicKernelTailProof',
+
+  BaseRollupProof = 'BaseRollupProof',
+  MergeRollupProof = 'MergeRollupProof',
+  RootRollupProof = 'RootRollupProof',
+
+  BlockMergeRollupProof = 'BlockMergeRollupProof',
+  BlockRootRollupProof = 'BlockRootRollupProof',
+
+  BaseParityProof = 'BaseParityProof',
+  RootParityProof = 'RootParityProof',
+}
+
+/**
+ * A mapping from proof type to the inputs needed to produce the proof.
+ * This object is useful for serializing/deserializing
+ */
+export const ProofInputs = {
+  [ProofType.AvmProof]: AvmCircuitInputs,
+
+  [ProofType.TubeProof]: TubeInputs,
+  [ProofType.EmptyTubeProof]: PrivateKernelEmptyInputs,
+
+  [ProofType.PublicKernelSetupProof]: PublicKernelCircuitPrivateInputs,
+  [ProofType.PublicKernelAppLogicProof]: PublicKernelCircuitPrivateInputs,
+  [ProofType.PublicKernelTeardownProof]: PublicKernelCircuitPrivateInputs,
+  [ProofType.PublicKernelTailProof]: PublicKernelTailCircuitPrivateInputs,
+
+  [ProofType.BaseRollupProof]: BaseRollupInputs,
+  [ProofType.MergeRollupProof]: MergeRollupInputs,
+  [ProofType.RootRollupProof]: RootRollupInputs,
+
+  [ProofType.BlockMergeRollupProof]: BlockMergeRollupInputs,
+  [ProofType.BlockRootRollupProof]: BlockRootRollupInputs,
+
+  [ProofType.BaseParityProof]: BaseParityInputs,
+  [ProofType.RootParityProof]: RootParityInputs,
+};
+
+export type ProofInputs = {
+  [K in keyof typeof ProofInputs]: InstanceType<(typeof ProofInputs)[K]>;
+};
+
+export type ProofOutputs = {
+  AvmProof: ProofAndVerificationKey<Proof>;
+
+  TubeProof: ProofAndVerificationKey<RecursiveProof<typeof TUBE_PROOF_LENGTH>>;
+  EmptyTubeProof: PublicInputsAndRecursiveProof<KernelCircuitPublicInputs>;
+
+  PublicKernelSetupProof: PublicInputsAndRecursiveProof<PublicKernelCircuitPublicInputs>;
+  PublicKernelAppLogicProof: PublicInputsAndRecursiveProof<PublicKernelCircuitPublicInputs>;
+  PublicKernelTeardownProof: PublicInputsAndRecursiveProof<PublicKernelCircuitPublicInputs>;
+  PublicKernelTailProof: PublicInputsAndRecursiveProof<KernelCircuitPublicInputs>;
+
+  BaseRollupProof: PublicInputsAndRecursiveProof<BaseOrMergeRollupPublicInputs>;
+  MergeRollupProof: PublicInputsAndRecursiveProof<BaseOrMergeRollupPublicInputs>;
+  RootRollupProof: PublicInputsAndRecursiveProof<RootRollupPublicInputs>;
+
+  BlockMergeRollupProof: PublicInputsAndRecursiveProof<BlockRootOrBlockMergePublicInputs>;
+  BlockRootRollupProof: PublicInputsAndRecursiveProof<BlockRootOrBlockMergePublicInputs>;
+
+  BaseParityProof: RootParityInput<typeof RECURSIVE_PROOF_LENGTH>;
+  RootParityProof: RootParityInput<typeof NESTED_RECURSIVE_PROOF_LENGTH>;
+};
+
+export type ProvingJobId<T extends ProofType = ProofType> = `${T}:${string}` & {
+  readonly __brand: unique symbol;
+};
+
+export function makeProvingJobId<T extends ProofType>(proofType: T): ProvingJobId<T> {
+  const id = randomBytes(8).toString('hex');
+  return `${proofType}:${id}` as ProvingJobId<T>;
+}
+
+export function getProofTypeFromId<T extends ProofType>(id: ProvingJobId<T>): T {
+  const proofType = id.split(':')[0];
+
+  // TS enums also contain a reverse mapping from value to key
+  if (proofType in ProofType) {
+    return proofType as T;
+  }
+
+  throw new Error(`Invalid proof type: ${proofType}`);
+}
+
+export interface ProvingJob<T extends ProofType = ProofType> {
+  readonly id: ProvingJobId<T>;
+  readonly blockNumber: number;
+  readonly inputs: ProofInputs[T];
+}
+
+export type ProvingJobStatus<T extends ProofType> =
+  | {
+      status: 'in-queue';
+    }
+  | {
+      status: 'in-progress';
+    }
+  | {
+      status: 'not-found';
+    }
+  | {
+      status: 'resolved';
+      value: ProofOutputs[T];
+    }
+  | {
+      status: 'rejected';
+      error: Error;
+    };


### PR DESCRIPTION
This PR adds `ProvingBroker` which implements a new interface for distributing proving jobs to workers as specified in #8495