### PR TITLE
fix: Fixes mapTuple typing

### DIFF
--- a/yarn-project/circuits.js/src/hints/build_nullifier_non_existent_read_request_hints.ts
+++ b/yarn-project/circuits.js/src/hints/build_nullifier_non_existent_read_request_hints.ts
@@ -1,7 +1,6 @@
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { type Fr } from '@aztec/foundation/fields';
 import { type Tuple } from '@aztec/foundation/serialize';
-import { type IndexedTreeLeafPreimage } from '@aztec/foundation/trees';
 
 import {
   MAX_NULLIFIERS_PER_TX,
@@ -9,7 +8,7 @@ import {
   type NULLIFIER_TREE_HEIGHT,
 } from '../constants.gen.js';
 import { siloNullifier } from '../hash/index.js';
-import { Nullifier } from '../structs/index.js';
+import { Nullifier, type NullifierLeafPreimage } from '../structs/index.js';
 import { type MembershipWitness } from '../structs/membership_witness.js';
 import { NullifierNonExistentReadRequestHintsBuilder } from '../structs/non_existent_read_request_hints.js';
 import { type ScopedReadRequest } from '../structs/read_request.js';
@@ -17,7 +16,7 @@ import { countAccumulatedItems } from '../utils/index.js';
 
 interface NullifierMembershipWitnessWithPreimage {
   membershipWitness: MembershipWitness<typeof NULLIFIER_TREE_HEIGHT>;
-  leafPreimage: IndexedTreeLeafPreimage;
+  leafPreimage: NullifierLeafPreimage;
 }
 
 interface SortedResult<T, N extends number> {

--- a/yarn-project/circuits.js/src/structs/non_existent_read_request_hints.ts
+++ b/yarn-project/circuits.js/src/structs/non_existent_read_request_hints.ts
@@ -100,7 +100,7 @@ export class NonExistentReadRequestHints<
 export type NullifierNonExistentReadRequestHints = NonExistentReadRequestHints<
   typeof MAX_NULLIFIER_NON_EXISTENT_READ_REQUESTS_PER_TX,
   typeof NULLIFIER_TREE_HEIGHT,
-  IndexedTreeLeafPreimage,
+  NullifierLeafPreimage,
   typeof MAX_NULLIFIERS_PER_TX,
   Nullifier
 >;
@@ -147,7 +147,7 @@ export class NullifierNonExistentReadRequestHintsBuilder {
 
   addHint(
     membershipWitness: MembershipWitness<typeof NULLIFIER_TREE_HEIGHT>,
-    lowLeafPreimage: IndexedTreeLeafPreimage,
+    lowLeafPreimage: NullifierLeafPreimage,
     nextPendingValueIndex: number,
   ) {
     this.hints.nonMembershipHints[this.readRequestIndex] = new NonMembershipHint(membershipWitness, lowLeafPreimage);

--- a/yarn-project/foundation/src/serialize/types.test.ts
+++ b/yarn-project/foundation/src/serialize/types.test.ts
@@ -1,0 +1,13 @@
+import { makeTuple } from '../array/array.js';
+import { type Tuple, mapTuple } from './types.js';
+
+describe('tuple', () => {
+  it('types mapTuple correctly', () => {
+    const tuple: Tuple<number, 3> = makeTuple(3, i => i);
+    // @ts-expect-error should not allow an argument of a different type
+    mapTuple(tuple, (i: string) => i);
+
+    const mapped: Tuple<string, 3> = mapTuple(tuple, (i: number) => `${i}`);
+    expect(mapped).toEqual(['0', '1', '2']);
+  });
+});

--- a/yarn-project/foundation/src/serialize/types.ts
+++ b/yarn-project/foundation/src/serialize/types.ts
@@ -35,6 +35,6 @@ type MapTuple<T extends any[], F extends (item: any) => any> = {
  * @see https://github.com/microsoft/TypeScript/issues/29841.
  * @param array - A tuple array.
  */
-export function mapTuple<T extends any[], F extends (item: any) => any>(tuple: T, fn: F): MapTuple<T, F> {
+export function mapTuple<T extends any[], F extends (item: T[number]) => any>(tuple: T, fn: F): MapTuple<T, F> {
   return tuple.map(fn) as MapTuple<T, F>;
 }

--- a/yarn-project/noir-protocol-circuits-types/src/type_conversion.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/type_conversion.ts
@@ -2185,7 +2185,7 @@ export function mapBlockRootRollupInputsToNoir(rootRollupInputs: BlockRootRollup
  */
 export function mapRootRollupInputsToNoir(rootRollupInputs: RootRollupInputs): RootRollupInputsNoir {
   return {
-    previous_rollup_data: mapTuple(rootRollupInputs.previousRollupData, mapPreviousRollupDataToNoir),
+    previous_rollup_data: mapTuple(rootRollupInputs.previousRollupData, mapPreviousRollupBlockDataToNoir),
     prover_id: mapFieldToNoir(rootRollupInputs.proverId),
   };
 }

--- a/yarn-project/simulator/src/public/hints_builder.ts
+++ b/yarn-project/simulator/src/public/hints_builder.ts
@@ -13,6 +13,7 @@ import {
   NOTE_HASH_TREE_HEIGHT,
   NULLIFIER_TREE_HEIGHT,
   type Nullifier,
+  type NullifierLeafPreimage,
   PUBLIC_DATA_TREE_HEIGHT,
   type PublicDataRead,
   type PublicDataTreeLeafPreimage,
@@ -27,6 +28,7 @@ import {
 } from '@aztec/circuits.js';
 import { makeTuple } from '@aztec/foundation/array';
 import { type Tuple } from '@aztec/foundation/serialize';
+import { type IndexedTreeLeafPreimage } from '@aztec/foundation/trees';
 import { type MerkleTreeOperations } from '@aztec/world-state';
 
 export class HintsBuilder {
@@ -112,7 +114,8 @@ export class HintsBuilder {
       throw new Error(`Nullifier ${nullifier.toBigInt()} already exists in the tree.`);
     }
 
-    return this.getMembershipWitnessWithPreimage<typeof NULLIFIER_TREE_HEIGHT>(
+    // Should find a way to stop casting IndexedTreeLeafPreimage as NullifierLeafPreimage
+    return this.getMembershipWitnessWithPreimage<typeof NULLIFIER_TREE_HEIGHT, NullifierLeafPreimage>(
       MerkleTreeId.NULLIFIER_TREE,
       NULLIFIER_TREE_HEIGHT,
       index,
@@ -125,23 +128,22 @@ export class HintsBuilder {
       throw new Error(`Cannot find the previous value index for public data ${leafSlot}.`);
     }
 
-    const { membershipWitness, leafPreimage } = await this.getMembershipWitnessWithPreimage<
-      typeof PUBLIC_DATA_TREE_HEIGHT
-    >(MerkleTreeId.PUBLIC_DATA_TREE, PUBLIC_DATA_TREE_HEIGHT, res.index);
-
     // Should find a way to stop casting IndexedTreeLeafPreimage as PublicDataTreeLeafPreimage everywhere.
-    return { membershipWitness, leafPreimage: leafPreimage as PublicDataTreeLeafPreimage };
+    return this.getMembershipWitnessWithPreimage<typeof PUBLIC_DATA_TREE_HEIGHT, PublicDataTreeLeafPreimage>(
+      MerkleTreeId.PUBLIC_DATA_TREE,
+      PUBLIC_DATA_TREE_HEIGHT,
+      res.index,
+    );
   }
 
-  private async getMembershipWitnessWithPreimage<TREE_HEIGHT extends number>(
-    treeId: IndexedTreeId,
-    treeHeight: TREE_HEIGHT,
-    index: bigint,
-  ) {
+  private async getMembershipWitnessWithPreimage<
+    TREE_HEIGHT extends number,
+    LEAF_PREIMAGE extends IndexedTreeLeafPreimage = IndexedTreeLeafPreimage,
+  >(treeId: IndexedTreeId, treeHeight: TREE_HEIGHT, index: bigint) {
     const siblingPath = await this.db.getSiblingPath<TREE_HEIGHT>(treeId, index);
     const membershipWitness = new MembershipWitness(treeHeight, index, siblingPath.toTuple());
 
-    const leafPreimage = await this.db.getLeafPreimage(treeId, index);
+    const leafPreimage = (await this.db.getLeafPreimage(treeId, index)) as LEAF_PREIMAGE;
     if (!leafPreimage) {
       throw new Error(`Cannot find the leaf preimage for tree ${treeId} at index ${index}.`);
     }


### PR DESCRIPTION
mapTuple allowed any argument type in the mapping function, and was hiding some typing errors (such as mixing up previous rollup data and previous rollup block data in noir mappings).

Now mapTuple requires that the argument of the callback matches the type of the tuple. This required some additional fixes around leafs typings.
