### PR TITLE
chore: use random ports in p2p_client tests

### DIFF
--- a/yarn-project/foundation/src/testing/index.ts
+++ b/yarn-project/foundation/src/testing/index.ts
@@ -1,2 +1,3 @@
 export * from './test_data.js';
 export * from './snapshot_serializer.js';
+export * from './port_allocator.js';

--- a/yarn-project/foundation/src/testing/port_allocator.ts
+++ b/yarn-project/foundation/src/testing/port_allocator.ts
@@ -8,8 +8,8 @@ import net from 'net';
  *
  * @returns a random port that is free to use.
  */
-export async function getRandomPort(): Promise<number | undefined> {
-  return new Promise((resolve) => {
+export function getRandomPort(): Promise<number | undefined> {
+  return new Promise(resolve => {
     const server = net.createServer();
     server.listen(0, () => {
       const address = server.address();

--- a/yarn-project/foundation/src/testing/port_allocator.ts
+++ b/yarn-project/foundation/src/testing/port_allocator.ts
@@ -1,0 +1,31 @@
+import net from 'net';
+
+/**
+ * Get a random port that is free to use.
+ * Returns undefined if it fails to get a port.
+ *
+ * @attribution: adapted from https://stackoverflow.com/a/71178451
+ *
+ * @returns a random port that is free to use.
+ */
+export async function getRandomPort(): Promise<number | undefined> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.listen(0, () => {
+      const address = server.address();
+      if (address && typeof address === 'object' && 'port' in address) {
+        const port = address.port;
+        server.close(() => {
+          resolve(port);
+        });
+      } else {
+        server.close(() => {
+          resolve(undefined);
+        });
+      }
+    });
+    server.on('error', () => {
+      resolve(undefined);
+    });
+  });
+}

--- a/yarn-project/p2p/src/service/reqresp/p2p_client.integration.test.ts
+++ b/yarn-project/p2p/src/service/reqresp/p2p_client.integration.test.ts
@@ -3,9 +3,9 @@ import { type ClientProtocolCircuitVerifier, type WorldStateSynchronizer, mockTx
 import { EthAddress } from '@aztec/circuits.js';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
+import { getRandomPort } from '@aztec/foundation/testing';
 import { type AztecKVStore } from '@aztec/kv-store';
 import { type DataStoreConfig, openTmpStore } from '@aztec/kv-store/utils';
-import { getRandomPort } from '@aztec/foundation/testing';
 
 import { describe, expect, it, jest } from '@jest/globals';
 import { generatePrivateKey } from 'viem/accounts';
@@ -77,7 +77,7 @@ describe('Req Resp p2p client integration', () => {
     const peerIdPrivateKeys = generatePeerIdPrivateKeys(numberOfPeers);
     for (let i = 0; i < numberOfPeers; i++) {
       // Note these bindings are important
-      const port = (await getRandomPort()) || (bootNodePort + i + 1);
+      const port = (await getRandomPort()) || bootNodePort + i + 1;
       const addr = `127.0.0.1:${port}`;
       const listenAddr = `0.0.0.0:${port}`;
       const config: P2PConfig & DataStoreConfig = {

--- a/yarn-project/p2p/src/service/reqresp/p2p_client.integration.test.ts
+++ b/yarn-project/p2p/src/service/reqresp/p2p_client.integration.test.ts
@@ -5,6 +5,7 @@ import { createDebugLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { type AztecKVStore } from '@aztec/kv-store';
 import { type DataStoreConfig, openTmpStore } from '@aztec/kv-store/utils';
+import { getRandomPort } from '@aztec/foundation/testing';
 
 import { describe, expect, it, jest } from '@jest/globals';
 import { generatePrivateKey } from 'viem/accounts';
@@ -27,7 +28,7 @@ type Mockify<T> = {
 
 const TEST_TIMEOUT = 80000;
 
-const BOOT_NODE_UDP_PORT = 40400;
+const DEFAULT_BOOT_NODE_UDP_PORT = 40400;
 async function createBootstrapNode(port: number) {
   const peerId = await createLibP2PPeerId();
   const bootstrapNode = new BootstrapNode();
@@ -61,10 +62,12 @@ describe('Req Resp p2p client integration', () => {
   let kvStore: AztecKVStore;
   let worldStateSynchronizer: WorldStateSynchronizer;
   let proofVerifier: ClientProtocolCircuitVerifier;
+  let bootNodePort: number;
   const logger = createDebugLogger('p2p-client-integration-test');
 
   const makeBootstrapNode = async (): Promise<[BootstrapNode, string]> => {
-    const bootstrapNode = await createBootstrapNode(BOOT_NODE_UDP_PORT);
+    bootNodePort = (await getRandomPort()) || DEFAULT_BOOT_NODE_UDP_PORT;
+    const bootstrapNode = await createBootstrapNode(bootNodePort);
     const enr = bootstrapNode.getENR().encodeTxt();
     return [bootstrapNode, enr];
   };
@@ -74,8 +77,9 @@ describe('Req Resp p2p client integration', () => {
     const peerIdPrivateKeys = generatePeerIdPrivateKeys(numberOfPeers);
     for (let i = 0; i < numberOfPeers; i++) {
       // Note these bindings are important
-      const addr = `127.0.0.1:${i + 1 + BOOT_NODE_UDP_PORT}`;
-      const listenAddr = `0.0.0.0:${i + 1 + BOOT_NODE_UDP_PORT}`;
+      const port = (await getRandomPort()) || (bootNodePort + i + 1);
+      const addr = `127.0.0.1:${port}`;
+      const listenAddr = `0.0.0.0:${port}`;
       const config: P2PConfig & DataStoreConfig = {
         ...getP2PDefaultConfig(),
         p2pEnabled: true,


### PR DESCRIPTION
Other reqresp tests bind nodes to port 0 so we have random ports there already, this test does not, so it may be interfered with from other tests

Prompted by https://github.com/AztecProtocol/aztec-packages/issues/8616, but I have not reproduced that yet