### PR TITLE
feat: proofClaim in Rollup

### DIFF
--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -18,8 +18,17 @@ interface IRollup {
   event L2BlockProposed(uint256 indexed blockNumber, bytes32 indexed archive);
   event L2ProofVerified(uint256 indexed blockNumber, bytes32 indexed proverId);
   event PrunedPending(uint256 provenBlockNumber, uint256 pendingBlockNumber);
+  event ProofRightClaimed(
+    uint256 indexed epoch,
+    address indexed bondProvider,
+    address indexed proposer,
+    uint256 bondAmount,
+    uint256 currentSlot
+  );
 
   function prune() external;
+
+  function claimEpochProofRight(DataStructures.EpochProofQuote calldata _quote) external;
 
   function propose(
     bytes calldata _header,
@@ -48,10 +57,13 @@ interface IRollup {
     DataStructures.ExecutionFlags memory _flags
   ) external view;
 
+  // solhint-disable-next-line func-name-mixedcase
   function INBOX() external view returns (IInbox);
 
+  // solhint-disable-next-line func-name-mixedcase
   function OUTBOX() external view returns (IOutbox);
 
+  // solhint-disable-next-line func-name-mixedcase
   function L1_BLOCK_AT_GENESIS() external view returns (uint256);
 
   // TODO(#7346): Integrate batch rollups
@@ -70,5 +82,6 @@ interface IRollup {
   function archiveAt(uint256 _blockNumber) external view returns (bytes32);
   function getProvenBlockNumber() external view returns (uint256);
   function getPendingBlockNumber() external view returns (uint256);
+  function getEpochToProve() external view returns (uint256);
   function computeTxsEffectsHash(bytes calldata _body) external pure returns (bytes32);
 }

--- a/l1-contracts/src/core/libraries/DataStructures.sol
+++ b/l1-contracts/src/core/libraries/DataStructures.sol
@@ -90,4 +90,12 @@ library DataStructures {
     address rollup;
     uint32 basisPointFee;
   }
+
+  struct EpochProofClaim {
+    uint256 epochToProve; // the epoch that the bond provider is claiming to prove
+    uint256 basisPointFee; // the fee that the bond provider will receive as a percentage of the block rewards
+    uint256 bondAmount; // the amount of escrowed funds that the bond provider will stake. Must be at least PROOF_COMMITMENT_BOND_AMOUNT
+    address bondProvider; // the address that has deposited funds in the escrow contract
+    address proposerClaimant; // the address of the proposer that submitted the claim
+  }
 }

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -44,23 +44,29 @@ library Errors {
   error Outbox__BlockNotProven(uint256 l2BlockNumber); // 0x0e194a6d
 
   // Rollup
+  error Rollup__InsufficientBondAmount(uint256 minimum, uint256 provided); // 0xa165f276
   error Rollup__InvalidArchive(bytes32 expected, bytes32 actual); // 0xb682a40e
-  error Rollup__InvalidProposedArchive(bytes32 expected, bytes32 actual); // 0x32532e73
   error Rollup__InvalidBlockNumber(uint256 expected, uint256 actual); // 0xe5edf847
-  error Rollup__SlotValueTooLarge(uint256 slot); // 0x7234f4fe
-  error Rollup__SlotAlreadyInChain(uint256 lastSlot, uint256 proposedSlot); // 0x83510bd0
+  error Rollup__InvalidChainId(uint256 expected, uint256 actual); // 0x37b5bc12
   error Rollup__InvalidEpoch(uint256 expected, uint256 actual); // 0x3c6d65e6
-  error Rollup__TryingToProveNonExistingBlock(); // 0x34ef4954
   error Rollup__InvalidInHash(bytes32 expected, bytes32 actual); // 0xcd6f4233
   error Rollup__InvalidProof(); // 0xa5b2ba17
-  error Rollup__InvalidChainId(uint256 expected, uint256 actual); // 0x37b5bc12
-  error Rollup__InvalidVersion(uint256 expected, uint256 actual); // 0x9ef30794
+  error Rollup__InvalidProposedArchive(bytes32 expected, bytes32 actual); // 0x32532e73
   error Rollup__InvalidTimestamp(uint256 expected, uint256 actual); // 0x3132e895
+  error Rollup__InvalidVersion(uint256 expected, uint256 actual); // 0x9ef30794
+  error Rollup__NoEpochToProve(); // 0xcbaa3951
+  error Rollup__NonSequentialProving(); // 0x1e5be132
+  error Rollup__NotClaimingCorrectEpoch(uint256 expected, uint256 actual); // 0xf0e0744d
+  error Rollup__NothingToPrune(); // 0x850defd3
+  error Rollup__NotInClaimPhase(uint256 currentSlot, uint256 currentSlotInEpoch); // 0xe6969f11
+  error Rollup__ProofRightAlreadyClaimed(); // 0x2cac5f0a
+  error Rollup__QuoteExpired(uint256 currentSlot, uint256 quoteSlot); // 0x20a001eb
+  error Rollup__SlotAlreadyInChain(uint256 lastSlot, uint256 proposedSlot); // 0x83510bd0
+  error Rollup__SlotValueTooLarge(uint256 slot); // 0x7234f4fe
   error Rollup__TimestampInFuture(uint256 max, uint256 actual); // 0x89f30690
   error Rollup__TimestampTooOld(); // 0x72ed9c81
+  error Rollup__TryingToProveNonExistingBlock(); // 0x34ef4954
   error Rollup__UnavailableTxs(bytes32 txsHash); // 0x414906c3
-  error Rollup__NothingToPrune(); // 0x850defd3
-  error Rollup__NonSequentialProving(); // 0x1e5be132
 
   // Registry
   error Registry__RollupNotRegistered(address rollup); // 0xa1fee4cf

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -58,7 +58,7 @@ library Errors {
   error Rollup__NonSequentialProving(); // 0x1e5be132
   error Rollup__NotClaimingCorrectEpoch(uint256 expected, uint256 actual); // 0xf0e0744d
   error Rollup__NothingToPrune(); // 0x850defd3
-  error Rollup__NotInClaimPhase(uint256 currentSlot, uint256 currentSlotInEpoch); // 0xe6969f11
+  error Rollup__NotInClaimPhase(uint256 currentSlotInEpoch, uint256 claimDuration); // 0xe6969f11
   error Rollup__ProofRightAlreadyClaimed(); // 0x2cac5f0a
   error Rollup__QuoteExpired(uint256 currentSlot, uint256 quoteSlot); // 0x20a001eb
   error Rollup__SlotAlreadyInChain(uint256 lastSlot, uint256 proposedSlot); // 0x83510bd0

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -257,7 +257,7 @@ contract RollupTest is DecoderBase {
     vm.expectRevert(
       abi.encodeWithSelector(
         Errors.Rollup__NotInClaimPhase.selector,
-        Constants.AZTEC_EPOCH_DURATION + rollup.CLAIM_DURATION_IN_L2_SLOTS(),
+        rollup.CLAIM_DURATION_IN_L2_SLOTS(),
         rollup.CLAIM_DURATION_IN_L2_SLOTS()
       )
     );

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -80,19 +80,17 @@ contract RollupTest is DecoderBase {
   }
 
   function warpToL2Slot(uint256 _slot) public {
-    uint256 initialTime = rollup.GENESIS_TIME();
-    vm.warp(initialTime + _slot * Constants.AZTEC_SLOT_DURATION);
+    vm.warp(rollup.getTimestampForSlot(_slot));
   }
 
-  function testClaimEpochProofRight() public setUpFor("mixed_block_1") {
+  function testClaimWithNothingToProve() public setUpFor("mixed_block_1") {
     assertEq(rollup.getCurrentSlot(), 0, "genesis slot should be zero");
 
-    // make a quote that we'll update as we go to hit various errors
     DataStructures.EpochProofQuote memory quote = DataStructures.EpochProofQuote({
       signature: SignatureLib.Signature({isEmpty: false, v: 27, r: bytes32(0), s: bytes32(0)}),
-      epochToProve: 42,
-      validUntilSlot: 0,
-      bondAmount: 1,
+      epochToProve: 0,
+      validUntilSlot: 1,
+      bondAmount: rollup.PROOF_COMMITMENT_MIN_BOND_AMOUNT_IN_TST(),
       rollup: address(0),
       basisPointFee: 0
     });
@@ -108,73 +106,123 @@ contract RollupTest is DecoderBase {
     // empty slots do not move pending chain
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__NoEpochToProve.selector));
     rollup.claimEpochProofRight(quote);
+  }
 
-    _testBlock("mixed_block_1", false, 1);
-    assertEq(rollup.getCurrentEpoch(), 0, "Invalid current epoch");
-    assertEq(rollup.getCurrentSlot(), 1, "propose block should not shift slot");
-    assertEq(rollup.getPendingBlockNumber(), 1, "Invalid pending block number");
-    assertEq(rollup.getProvenBlockNumber(), 0, "Invalid proven block number");
-    assertEq(rollup.getEpochToProve(), 0, "Invalid epoch to prove");
+  function testClaimWithWrongEpoch() public setUpFor("mixed_block_1") {
+    _testBlock("mixed_block_1", false, 0);
 
-    // the quote has the wrong epoch
+    DataStructures.EpochProofQuote memory quote = DataStructures.EpochProofQuote({
+      signature: SignatureLib.Signature({isEmpty: false, v: 27, r: bytes32(0), s: bytes32(0)}),
+      epochToProve: 1,
+      validUntilSlot: 1,
+      bondAmount: rollup.PROOF_COMMITMENT_MIN_BOND_AMOUNT_IN_TST(),
+      rollup: address(0),
+      basisPointFee: 0
+    });
+
     vm.expectRevert(
       abi.encodeWithSelector(Errors.Rollup__NotClaimingCorrectEpoch.selector, 0, quote.epochToProve)
     );
     rollup.claimEpochProofRight(quote);
-    quote.epochToProve = 0;
+  }
 
-    // the quote has too little bond
+  function testClaimWithInsufficientBond() public setUpFor("mixed_block_1") {
+    _testBlock("mixed_block_1", false, 0);
+
+    DataStructures.EpochProofQuote memory quote = DataStructures.EpochProofQuote({
+      signature: SignatureLib.Signature({isEmpty: false, v: 27, r: bytes32(0), s: bytes32(0)}),
+      epochToProve: 0,
+      validUntilSlot: 1,
+      bondAmount: 0,
+      rollup: address(0),
+      basisPointFee: 0
+    });
+
     vm.expectRevert(
       abi.encodeWithSelector(
         Errors.Rollup__InsufficientBondAmount.selector,
         rollup.PROOF_COMMITMENT_MIN_BOND_AMOUNT_IN_TST(),
-        1
+        quote.bondAmount
       )
     );
     rollup.claimEpochProofRight(quote);
-    quote.bondAmount = rollup.PROOF_COMMITMENT_MIN_BOND_AMOUNT_IN_TST();
+  }
 
-    // the quote has expired
+  function testClaimPastValidUntil() public setUpFor("mixed_block_1") {
+    _testBlock("mixed_block_1", false, 0);
+
+    DataStructures.EpochProofQuote memory quote = DataStructures.EpochProofQuote({
+      signature: SignatureLib.Signature({isEmpty: false, v: 27, r: bytes32(0), s: bytes32(0)}),
+      epochToProve: 0,
+      validUntilSlot: 0,
+      bondAmount: rollup.PROOF_COMMITMENT_MIN_BOND_AMOUNT_IN_TST(),
+      rollup: address(0),
+      basisPointFee: 0
+    });
+
+    warpToL2Slot(1);
+
     vm.expectRevert(
       abi.encodeWithSelector(Errors.Rollup__QuoteExpired.selector, 1, quote.validUntilSlot)
     );
     rollup.claimEpochProofRight(quote);
-    quote.validUntilSlot = 1;
+  }
 
-    // quick sanity that we still have nothing to prune
-    vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__NothingToPrune.selector));
-    rollup.prune();
+  function testClaimSimple() public setUpFor("mixed_block_1") {
+    _testBlock("mixed_block_1", false, 0);
 
-    // now the quote is good
+    DataStructures.EpochProofQuote memory quote = DataStructures.EpochProofQuote({
+      signature: SignatureLib.Signature({isEmpty: false, v: 27, r: bytes32(0), s: bytes32(0)}),
+      epochToProve: 0,
+      validUntilSlot: 1,
+      bondAmount: rollup.PROOF_COMMITMENT_MIN_BOND_AMOUNT_IN_TST(),
+      rollup: address(0),
+      basisPointFee: 0
+    });
+
+    warpToL2Slot(1);
+
     vm.expectEmit(true, true, true, true);
     emit IRollup.ProofRightClaimed(
       quote.epochToProve, address(0), address(this), quote.bondAmount, 1
     );
     rollup.claimEpochProofRight(quote);
 
-    // cannot claim again
+    (
+      uint256 epochToProve,
+      uint256 basisPointFee,
+      uint256 bondAmount,
+      address bondProvider,
+      address proposerClaimant
+    ) = rollup.proofClaim();
+    assertEq(epochToProve, quote.epochToProve, "Invalid epoch to prove");
+    assertEq(basisPointFee, quote.basisPointFee, "Invalid basis point fee");
+    assertEq(bondAmount, quote.bondAmount, "Invalid bond amount");
+    // TODO #8573
+    // This will be fixed with proper escrow
+    assertEq(bondProvider, address(0), "Invalid bond provider");
+    assertEq(proposerClaimant, address(this), "Invalid proposer claimant");
+  }
+
+  function testClaimTwice() public setUpFor("mixed_block_1") {
+    _testBlock("mixed_block_1", false, 0);
+
+    DataStructures.EpochProofQuote memory quote = DataStructures.EpochProofQuote({
+      signature: SignatureLib.Signature({isEmpty: false, v: 27, r: bytes32(0), s: bytes32(0)}),
+      epochToProve: 0,
+      validUntilSlot: 1,
+      bondAmount: rollup.PROOF_COMMITMENT_MIN_BOND_AMOUNT_IN_TST(),
+      rollup: address(0),
+      basisPointFee: 0
+    });
+
+    warpToL2Slot(1);
+
+    rollup.claimEpochProofRight(quote);
+
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__ProofRightAlreadyClaimed.selector));
     rollup.claimEpochProofRight(quote);
 
-    // the rollup properly stores the quote
-    {
-      (
-        uint256 epochToProve,
-        uint256 basisPointFee,
-        uint256 bondAmount,
-        address bondProvider,
-        address proposerClaimant
-      ) = rollup.proofClaim();
-      assertEq(epochToProve, quote.epochToProve, "Invalid epoch to prove");
-      assertEq(basisPointFee, quote.basisPointFee, "Invalid basis point fee");
-      assertEq(bondAmount, quote.bondAmount, "Invalid bond amount");
-      // TODO #8573
-      // This will be fixed with proper escrow
-      assertEq(bondProvider, address(0), "Invalid bond provider");
-      assertEq(proposerClaimant, address(this), "Invalid proposer claimant");
-    }
-
-    // still in the same epoch. shouldn't be able to claim
     warpToL2Slot(2);
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__ProofRightAlreadyClaimed.selector));
     rollup.claimEpochProofRight(quote);
@@ -190,10 +238,22 @@ contract RollupTest is DecoderBase {
     // still nothing to prune
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__NothingToPrune.selector));
     rollup.prune();
+  }
 
-    // different error demonstrated:
-    // cannot claim if we are not in the claim phase
+  function testClaimOutsideClaimPhase() public setUpFor("mixed_block_1") {
+    _testBlock("mixed_block_1", false, 0);
+
+    DataStructures.EpochProofQuote memory quote = DataStructures.EpochProofQuote({
+      signature: SignatureLib.Signature({isEmpty: false, v: 27, r: bytes32(0), s: bytes32(0)}),
+      epochToProve: 0,
+      validUntilSlot: 1,
+      bondAmount: rollup.PROOF_COMMITMENT_MIN_BOND_AMOUNT_IN_TST(),
+      rollup: address(0),
+      basisPointFee: 0
+    });
+
     warpToL2Slot(Constants.AZTEC_EPOCH_DURATION + rollup.CLAIM_DURATION_IN_L2_SLOTS());
+
     vm.expectRevert(
       abi.encodeWithSelector(
         Errors.Rollup__NotInClaimPhase.selector,
@@ -202,34 +262,80 @@ contract RollupTest is DecoderBase {
       )
     );
     rollup.claimEpochProofRight(quote);
+  }
 
-    // still cannot prune epoch 0 because a claim to prove it exists
+  function testNoPruneWhenClaimExists() public setUpFor("mixed_block_1") {
+    _testBlock("mixed_block_1", false, 0);
+
+    DataStructures.EpochProofQuote memory quote = DataStructures.EpochProofQuote({
+      signature: SignatureLib.Signature({isEmpty: false, v: 27, r: bytes32(0), s: bytes32(0)}),
+      epochToProve: 0,
+      validUntilSlot: 2 * Constants.AZTEC_EPOCH_DURATION,
+      bondAmount: rollup.PROOF_COMMITMENT_MIN_BOND_AMOUNT_IN_TST(),
+      rollup: address(0),
+      basisPointFee: 0
+    });
+
+    warpToL2Slot(Constants.AZTEC_EPOCH_DURATION + rollup.CLAIM_DURATION_IN_L2_SLOTS() - 1);
+
+    rollup.claimEpochProofRight(quote);
+
+    warpToL2Slot(Constants.AZTEC_EPOCH_DURATION + rollup.CLAIM_DURATION_IN_L2_SLOTS());
+
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__NothingToPrune.selector));
     rollup.prune();
+  }
 
-    // now we're in epoch 2
+  function testPruneWhenClaimExpires() public setUpFor("mixed_block_1") {
+    _testBlock("mixed_block_1", false, 0);
+
+    DataStructures.EpochProofQuote memory quote = DataStructures.EpochProofQuote({
+      signature: SignatureLib.Signature({isEmpty: false, v: 27, r: bytes32(0), s: bytes32(0)}),
+      epochToProve: 0,
+      validUntilSlot: 2 * Constants.AZTEC_EPOCH_DURATION,
+      bondAmount: rollup.PROOF_COMMITMENT_MIN_BOND_AMOUNT_IN_TST(),
+      rollup: address(0),
+      basisPointFee: 0
+    });
+
+    warpToL2Slot(Constants.AZTEC_EPOCH_DURATION + rollup.CLAIM_DURATION_IN_L2_SLOTS() - 1);
+
+    rollup.claimEpochProofRight(quote);
+
     warpToL2Slot(Constants.AZTEC_EPOCH_DURATION * 2);
 
     // We should still be trying to prove epoch 0 in epoch 2
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__ProofRightAlreadyClaimed.selector));
     rollup.claimEpochProofRight(quote);
 
-    // but at this point we can prune
     rollup.prune();
 
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__NoEpochToProve.selector));
     rollup.claimEpochProofRight(quote);
+  }
+
+  function testClaimAfterPrune() public setUpFor("mixed_block_1") {
+    _testBlock("mixed_block_1", false, 0);
+
+    DataStructures.EpochProofQuote memory quote = DataStructures.EpochProofQuote({
+      signature: SignatureLib.Signature({isEmpty: false, v: 27, r: bytes32(0), s: bytes32(0)}),
+      epochToProve: 0,
+      validUntilSlot: 2 * Constants.AZTEC_EPOCH_DURATION,
+      bondAmount: rollup.PROOF_COMMITMENT_MIN_BOND_AMOUNT_IN_TST(),
+      rollup: address(0),
+      basisPointFee: 0
+    });
+
+    warpToL2Slot(Constants.AZTEC_EPOCH_DURATION + rollup.CLAIM_DURATION_IN_L2_SLOTS() - 1);
+
+    rollup.claimEpochProofRight(quote);
+
+    warpToL2Slot(Constants.AZTEC_EPOCH_DURATION * 2);
+
+    rollup.prune();
 
     _testBlock("mixed_block_1", false, Constants.AZTEC_EPOCH_DURATION * 2);
 
-    vm.expectRevert(
-      abi.encodeWithSelector(
-        Errors.Rollup__QuoteExpired.selector, Constants.AZTEC_EPOCH_DURATION * 2, 1
-      )
-    );
-    rollup.claimEpochProofRight(quote);
-
-    quote.validUntilSlot = Constants.AZTEC_EPOCH_DURATION * 2;
     vm.expectEmit(true, true, true, true);
     emit IRollup.ProofRightClaimed(
       quote.epochToProve,


### PR DESCRIPTION
Fix #8608 

Add the proofClaim to the rollup.

Update the `canPrune` logic to account for it.