### PR TITLE
chore: remove key rotation from the key store

### DIFF
--- a/yarn-project/key-store/src/key_store.ts
+++ b/yarn-project/key-store/src/key_store.ts
@@ -107,30 +107,28 @@ export class KeyStore {
     const [keyPrefix, account] = this.#getKeyPrefixAndAccount(pkMHash);
 
     // Now we find the master public key for the account
-    // Since each public keys buffer contains multiple public keys, we need to find the one that matches the hash.
-    // Then we store the index of the key in the buffer to be able to quickly obtain the corresponding secret key.
-    const pkMsBuffer = this.#keys.get(`${account.toString()}-${keyPrefix}pk_m`);
-    if (!pkMsBuffer) {
+    const pkMBuffer = this.#keys.get(`${account.toString()}-${keyPrefix}pk_m`);
+    if (!pkMBuffer) {
       throw new Error(
         `Could not find ${keyPrefix}pk_m for account ${account.toString()} whose address was successfully obtained with ${keyPrefix}pk_m_hash ${pkMHash.toString()}.`,
       );
     }
 
-    const pkM = Point.fromBuffer(pkMsBuffer);
+    const pkM = Point.fromBuffer(pkMBuffer);
 
     if (!pkM.hash().equals(pkMHash)) {
       throw new Error(`Could not find ${keyPrefix}pkM for ${keyPrefix}pk_m_hash ${pkMHash.toString()}.`);
     }
 
     // Now we find the secret key for the public key
-    const skMsBuffer = this.#keys.get(`${account.toString()}-${keyPrefix}sk_m`);
-    if (!skMsBuffer) {
+    const skMBuffer = this.#keys.get(`${account.toString()}-${keyPrefix}sk_m`);
+    if (!skMBuffer) {
       throw new Error(
         `Could not find ${keyPrefix}sk_m for account ${account.toString()} whose address was successfully obtained with ${keyPrefix}pk_m_hash ${pkMHash.toString()}.`,
       );
     }
 
-    const skM = GrumpkinScalar.fromBuffer(skMsBuffer);
+    const skM = GrumpkinScalar.fromBuffer(skMBuffer);
 
     // We sanity check that it's possible to derive the public key from the secret key
     if (!derivePublicKeyFromSecretKey(skM).equals(pkM)) {
@@ -249,15 +247,14 @@ export class KeyStore {
   public getMasterSecretKey(pkM: PublicKey): Promise<GrumpkinScalar> {
     const [keyPrefix, account] = this.#getKeyPrefixAndAccount(pkM);
 
-    // We get the secret keys buffer and iterate over the values in the buffer to find the one that matches pkM
-    const secretKeysBuffer = this.#keys.get(`${account.toString()}-${keyPrefix}sk_m`);
-    if (!secretKeysBuffer) {
+    const secretKeyBuffer = this.#keys.get(`${account.toString()}-${keyPrefix}sk_m`);
+    if (!secretKeyBuffer) {
       throw new Error(
         `Could not find ${keyPrefix}sk_m for ${keyPrefix}pk_m ${pkM.toString()}. This should not happen.`,
       );
     }
 
-    const skM = GrumpkinScalar.fromBuffer(secretKeysBuffer);
+    const skM = GrumpkinScalar.fromBuffer(secretKeyBuffer);
     if (!derivePublicKeyFromSecretKey(skM).equals(pkM)) {
       throw new Error(`Could not find ${keyPrefix}skM for ${keyPrefix}pkM ${pkM.toString()} in secret keys buffer.`);
     }

--- a/yarn-project/key-store/src/key_store.ts
+++ b/yarn-project/key-store/src/key_store.ts
@@ -21,7 +21,7 @@ import { type Bufferable, serializeToBuffer } from '@aztec/foundation/serialize'
 import { type AztecKVStore, type AztecMap } from '@aztec/kv-store';
 
 /**
- * Used for managing keys. Can hold keys of multiple accounts and allows for key rotation.
+ * Used for managing keys. Can hold keys of multiple accounts.
  */
 export class KeyStore {
   #keys: AztecMap<string, Buffer>;
@@ -310,9 +310,7 @@ export class KeyStore {
   #getKeyPrefixAndAccount(value: Bufferable): [KeyPrefix, AztecAddress] {
     const valueBuffer = serializeToBuffer(value);
     for (const [key, val] of this.#keys.entries()) {
-      // `val` can contain multiple values due to key rotation so we check if the value is in the buffer instead
-      // of just calling `.equals(...)`
-      if (val.includes(valueBuffer)) {
+      if (val.equals(valueBuffer)) {
         for (const prefix of KEY_PREFIXES) {
           if (key.includes(`-${prefix}`)) {
             const account = AztecAddress.fromString(key.split('-')[0]);


### PR DESCRIPTION
Follow up to #8613 - the key store still had some lingering code from back when it supported key rotation - each entry could hold multiple keys. We no longer do this (i.e. we never append anything to an entry, we only set it with a single key), so instead of checking if the entry includes the hash we're looking for, we can simply check if it's the correct (only) one.

Similarly when looking for the public key and secret key we no longer need to iterate over the multiple entries since there's a single one.