### PR TITLE
chore: delete .gitattributes in aztec-nr

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
-*.nr linguist-language=Rust
-
 .yarn/releases/** binary
 .yarn/plugins/** binary
 yarn.lock -diff

--- a/noir-projects/aztec-nr/.gitattributes
+++ b/noir-projects/aztec-nr/.gitattributes
@@ -1,1 +1,0 @@
-*.nr linguist-language=Rust


### PR DESCRIPTION
This isn't necessary anymore so we can remove it.