### PR TITLE
refactor: optimise l1 to l2 message fetching

### DIFF
--- a/l1-contracts/src/core/messagebridge/Inbox.sol
+++ b/l1-contracts/src/core/messagebridge/Inbox.sol
@@ -37,6 +37,10 @@ contract Inbox is IInbox {
 
   mapping(uint256 blockNumber => FrontierLib.Tree tree) public trees;
 
+  // This value is not used much by the contract, but it is useful for synching the node faster
+  // as it can more easily figure out if it can just skip looking for events for a time period.
+  uint256 public totalMessagesInserted = 0;
+
   constructor(address _rollup, uint256 _height) {
     ROLLUP = _rollup;
 
@@ -89,6 +93,7 @@ contract Inbox is IInbox {
 
     bytes32 leaf = message.sha256ToField();
     uint256 index = currentTree.insertLeaf(leaf);
+    totalMessagesInserted++;
     emit MessageSent(inProgress, index, leaf);
 
     return leaf;

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -245,20 +245,23 @@ export class Archiver implements ArchiveSource {
       return;
     }
 
-    const retrievedL1ToL2Messages = await retrieveL1ToL2Messages(
-      this.inbox,
-      blockUntilSynced,
-      messagesSynchedTo + 1n,
-      currentL1BlockNumber,
-    );
+    const localTotalMessageCount = await this.store.getTotalL1ToL2MessageCount();
+    const destinationTotalMessageCount = await this.inbox.read.totalMessagesInserted();
 
-    if (retrievedL1ToL2Messages.retrievedData.length === 0) {
+    if (localTotalMessageCount === destinationTotalMessageCount) {
       await this.store.setMessageSynchedL1BlockNumber(currentL1BlockNumber);
       this.log.verbose(
         `Retrieved no new L1 -> L2 messages between L1 blocks ${messagesSynchedTo + 1n} and ${currentL1BlockNumber}.`,
       );
       return;
     }
+
+    const retrievedL1ToL2Messages = await retrieveL1ToL2Messages(
+      this.inbox,
+      blockUntilSynced,
+      messagesSynchedTo + 1n,
+      currentL1BlockNumber,
+    );
 
     await this.store.addL1ToL2Messages(retrievedL1ToL2Messages);
 

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -783,4 +783,7 @@ class ArchiverStoreHelper
   getContractArtifact(address: AztecAddress): Promise<ContractArtifact | undefined> {
     return this.store.getContractArtifact(address);
   }
+  getTotalL1ToL2MessageCount(): Promise<bigint> {
+    return this.store.getTotalL1ToL2MessageCount();
+  }
 }

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -109,6 +109,12 @@ export interface ArchiverDataStore {
   getL1ToL2MessageIndex(l1ToL2Message: Fr, startIndex: bigint): Promise<bigint | undefined>;
 
   /**
+   * Get the total number of L1 to L2 messages
+   * @returns The number of L1 to L2 messages in the store
+   */
+  getTotalL1ToL2MessageCount(): Promise<bigint>;
+
+  /**
    * Gets up to `limit` amount of logs starting from `from`.
    * @param from - Number of the L2 block to which corresponds the first logs to be returned.
    * @param limit - The number of logs to return.

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -167,6 +167,10 @@ export class KVArchiverDataStore implements ArchiverDataStore {
     return this.#logStore.deleteLogs(blocks);
   }
 
+  getTotalL1ToL2MessageCount(): Promise<bigint> {
+    return Promise.resolve(this.#messageStore.getTotalL1ToL2MessageCount());
+  }
+
   /**
    * Append L1 to L2 messages to the store.
    * @param messages - The L1 to L2 messages to be added to the store and the last processed L1 block.

--- a/yarn-project/archiver/src/archiver/memory_archiver_store/l1_to_l2_message_store.ts
+++ b/yarn-project/archiver/src/archiver/memory_archiver_store/l1_to_l2_message_store.ts
@@ -19,6 +19,10 @@ export class L1ToL2MessageStore {
 
   constructor() {}
 
+  getTotalL1ToL2MessageCount(): bigint {
+    return BigInt(this.store.size);
+  }
+
   addMessage(message: InboxLeaf) {
     if (message.index >= this.#l1ToL2MessagesSubtreeSize) {
       throw new Error(`Message index ${message.index} out of subtree range`);

--- a/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
@@ -219,6 +219,10 @@ export class MemoryArchiverStore implements ArchiverDataStore {
     return Promise.resolve(true);
   }
 
+  getTotalL1ToL2MessageCount(): Promise<bigint> {
+    return Promise.resolve(this.l1ToL2Messages.getTotalL1ToL2MessageCount());
+  }
+
   /**
    * Append L1 to L2 messages to the store.
    * @param messages - The L1 to L2 messages to be added to the store and the last processed L1 block.


### PR DESCRIPTION
Takes the same approach as done in other optimisations tasks related to #8457 and before it go looking at the events, it will check values in the contract to figure out if there is even anything to look for. If we figure that there is nothing to look for, we update the l1 block number of interest, and call it a day. This allow getting rid of a bunch of get logs call and replacing them with a single function call instead. Does not impact the tests in E2E significantly because they are running on anvil without anything but our rollup happening so there is not a lot of wasted effort there, but should see meaningful changes when pointed at larger systems.