### PR TITLE
feat: Benchmark compute_row_evaluations and update analysis script

### DIFF
--- a/barretenberg/cpp/scripts/analyze_client_ivc_bench.py
+++ b/barretenberg/cpp/scripts/analyze_client_ivc_bench.py
@@ -66,7 +66,7 @@ for key in ['commit(t)', 'compute_combiner(t)', 'compute_perturbator(t)', 'compu
 
 print('\nBreakdown of ProtogalaxyProver::prove:')
 protogalaxy_round_labels = [
-    "ProtogalaxyProver_::preparation_round(t)",
+    "ProtogalaxyProver_::run_oink_prover_on_each_incomplete_key(t)",
     "ProtogalaxyProver_::perturbator_round(t)",
     "ProtogalaxyProver_::combiner_quotient_round(t)",
     "ProtogalaxyProver_::update_target_sum_and_fold(t)"

--- a/barretenberg/cpp/scripts/analyze_protogalaxy_bench.py
+++ b/barretenberg/cpp/scripts/analyze_protogalaxy_bench.py
@@ -47,7 +47,7 @@ for key in ['commit(t)', 'compute_combiner(t)', 'compute_perturbator(t)', 'compu
 
 print('\nBreakdown of ProtogalaxyProver::prove:')
 protogalaxy_round_labels = [
-    "ProtogalaxyProver_::preparation_round(t)",
+    "ProtogalaxyProver_::run_oink_prover_on_each_incomplete_key(t)",
     "ProtogalaxyProver_::perturbator_round(t)",
     "ProtogalaxyProver_::combiner_quotient_round(t)",
     "ProtogalaxyProver_::update_target_sum_and_fold(t)"

--- a/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_bench/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_bench/CMakeLists.txt
@@ -1,4 +1,4 @@
 barretenberg_module(
     protogalaxy_bench
-    stdlib_protogalaxy_verifier
+    protogalaxy
 )

--- a/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_bench/protogalaxy.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_bench/protogalaxy.bench.cpp
@@ -15,11 +15,6 @@ namespace bb {
 using Flavor = MegaFlavor;
 using FF = typename Flavor::FF;
 
-/**
- * @brief As expected, this is about NUM_SUBRELAITONSS (40ish) * cost of FF alloc (33ms at size 2^21)
- *
- * @param state
- */
 void vector_of_evaluations(State& state) noexcept
 {
     using RelationEvaluations = typename Flavor::TupleOfArraysOfValues;
@@ -30,11 +25,6 @@ void vector_of_evaluations(State& state) noexcept
     }
 }
 
-/**
- * @brief As expected, this is about NUM_SUBRELAITONSS (40ish) * cost of FF alloc (33ms at size 2^21)
- *
- * @param state
- */
 void compute_row_evaluations(State& state) noexcept
 {
     using Fun = ProtogalaxyProverInternal<DeciderProvingKeys_<Flavor, 2>>;

--- a/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_bench/protogalaxy.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/protogalaxy_bench/protogalaxy.bench.cpp
@@ -2,6 +2,7 @@
 
 #include "barretenberg/common/op_count_google_bench.hpp"
 #include "barretenberg/protogalaxy/protogalaxy_prover.hpp"
+#include "barretenberg/protogalaxy/protogalaxy_prover_internal.hpp"
 #include "barretenberg/stdlib_circuit_builders/mock_circuits.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 #include "barretenberg/ultra_honk/decider_keys.hpp"
@@ -53,9 +54,9 @@ void compute_row_evaluations(State& state) noexcept
 }
 
 // Fold one proving key into an accumulator.
-template <typename Flavor, size_t k> void fold_k(State& state) noexcept
+void fold_k(State& state) noexcept
 {
-    static constexpr size_t k(1);
+    static constexpr size_t k{ 1 };
 
     using DeciderProvingKey = DeciderProvingKey_<Flavor>;
     using ProtogalaxyProver = ProtogalaxyProver_<DeciderProvingKeys_<Flavor, k + 1>>;
@@ -87,7 +88,7 @@ template <typename Flavor, size_t k> void fold_k(State& state) noexcept
 BENCHMARK(vector_of_evaluations)->DenseRange(15, 21)->Unit(kMillisecond);
 BENCHMARK(compute_row_evaluations)->DenseRange(15, 21)->Unit(kMillisecond);
 // We stick to just k=1 for compile-time reasons.
-BENCHMARK(fold_k<MegaFlavor, 1>)->/* vary the circuit size */ DenseRange(14, 20)->Unit(kMillisecond);
+BENCHMARK(fold_k)->/* vary the circuit size */ DenseRange(14, 20)->Unit(kMillisecond);
 
 } // namespace bb
 


### PR DESCRIPTION
Adds a bench and updates the CIVC benchmark analysis script to use the new name for Oink part of the Pg prover.

Benchmark results:
```
Benchmarking lock created at ~/BENCHMARK_IN_PROGRESS.
protogalaxy_bench                                                            100% 5225KB  24.6MB/s   00:00    
2024-09-20T20:16:15+00:00
Running ./protogalaxy_bench
Run on (16 X 3000 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 36608 KiB (x1)
Load Average: 0.08, 0.06, 0.34
---------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations
---------------------------------------------------------------------
compute_row_evaluations/15       6.59 ms         6.51 ms          107
compute_row_evaluations/16       13.4 ms         13.4 ms           52
compute_row_evaluations/17       27.0 ms         26.9 ms           26
compute_row_evaluations/18       54.8 ms         54.6 ms           12
compute_row_evaluations/19        112 ms          112 ms            6
compute_row_evaluations/20        233 ms          232 ms            3
compute_row_evaluations/21        462 ms          461 ms            2
```