### PR TITLE
chore(ci): remove e2e-prover-full from default set

### DIFF
--- a/scripts/ci/get_e2e_jobs.sh
+++ b/scripts/ci/get_e2e_jobs.sh
@@ -21,7 +21,6 @@ allow_list=(
   "e2e-max-block-number"
   "e2e-nested-contract"
   "e2e-ordering"
-  "e2e-prover-full"
   "e2e-static-calls"
 )
 


### PR DESCRIPTION
This test is valuable however a little too long. This will reduce the merge/cycle time by about 15 minutes.