### PR TITLE
chore: use panic instead of assert

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -109,8 +109,7 @@ impl PublicContext {
         _function_selector: FunctionSelector,
         _args: [Field]
     ) -> FunctionReturns<RETURNS_COUNT> {
-        assert(false, "'delegate_call_public_function' not implemented!");
-        FunctionReturns::new([0; RETURNS_COUNT])
+        panic(f"'delegate_call_public_function' not implemented!")
     }
 
     fn push_note_hash(_self: &mut Self, note_hash: Field) {

--- a/noir-projects/aztec-nr/aztec/src/utils/comparison.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/comparison.nr
@@ -34,8 +34,7 @@ pub fn compare(lhs: Field, operation: u8, rhs: Field) -> bool {
     } else if (operation == Comparator.GTE) {
         !is_lt
     } else {
-        assert(false, "Invalid operation");
-        false // Noir would complain without boolean value here
+        panic(f"Invalid operation")
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/components/public_call_data_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/components/public_call_data_validator.nr
@@ -125,8 +125,7 @@ impl PublicCallDataValidator {
         } else if self.phase == PublicKernelPhase.TEARDOWN {
             previous_kernel.public_teardown_call_stack
         } else {
-            assert(false, "Unknown phase");
-            [PublicCallRequest::empty(); MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX]
+            panic(f"Unknown phase")
         };
 
         let call_request = call_stack[array_length(call_stack) - 1];

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/root.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/root.nr
@@ -62,8 +62,7 @@ pub fn calculate_empty_tree_root(depth: u32) -> Field {
     } else if depth == 10 {
         0x2a775ea761d20435b31fa2c33ff07663e24542ffb9e7b293dfce3042eb104686
     } else {
-        assert(false, "depth should be between 0 and 10");
-        0
+        panic(f"depth should be between 0 and 10")
     }
 }
 


### PR DESCRIPTION
These constructs are equivalent (though we do need to pass a format string to `panic`), but this nicely avoids the weirdness of having to return some default value after the assertion fails (`panic` returns `std::zeroed`).