### PR TITLE
refactor: minor archiver refactor

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -1,6 +1,7 @@
 import {
   type FromLogType,
   type GetUnencryptedLogsResponse,
+  type InboxLeaf,
   type L1ToL2MessageSource,
   type L2Block,
   type L2BlockL2Logs,
@@ -13,14 +14,15 @@ import {
   type TxReceipt,
   type UnencryptedL2Log,
 } from '@aztec/circuit-types';
-import { ContractClassRegisteredEvent, type FunctionSelector } from '@aztec/circuits.js';
 import {
+  ContractClassRegisteredEvent,
   ContractInstanceDeployedEvent,
+  type FunctionSelector,
   PrivateFunctionBroadcastedEvent,
   UnconstrainedFunctionBroadcastedEvent,
   isValidPrivateFunctionMembershipProof,
   isValidUnconstrainedFunctionMembershipProof,
-} from '@aztec/circuits.js/contract';
+} from '@aztec/circuits.js';
 import { createEthereumChain } from '@aztec/ethereum';
 import { type ContractArtifact } from '@aztec/foundation/abi';
 import { type AztecAddress } from '@aztec/foundation/aztec-address';
@@ -52,11 +54,12 @@ import {
   http,
 } from 'viem';
 
-import { type ArchiverDataStore } from './archiver_store.js';
+import { type ArchiverDataStore, type ArchiverL1SynchPoint } from './archiver_store.js';
 import { type ArchiverConfig } from './config.js';
 import { retrieveBlockFromRollup, retrieveL1ToL2Messages } from './data_retrieval.js';
 import { ArchiverInstrumentation } from './instrumentation.js';
-import { type SingletonDataRetrieval } from './structs/data_retrieval.js';
+import { type DataRetrieval, type SingletonDataRetrieval } from './structs/data_retrieval.js';
+import { type L1Published } from './structs/published.js';
 
 /**
  * Helper interface to combine all sources this archiver implementation provides.
@@ -77,6 +80,8 @@ export class Archiver implements ArchiveSource {
   private rollup: GetContractReturnType<typeof RollupAbi, PublicClient<HttpTransport, Chain>>;
   private inbox: GetContractReturnType<typeof InboxAbi, PublicClient<HttpTransport, Chain>>;
 
+  private store: ArchiverStoreHelper;
+
   /**
    * Creates a new instance of the Archiver.
    * @param publicClient - A client for interacting with the Ethereum node.
@@ -90,14 +95,16 @@ export class Archiver implements ArchiveSource {
   constructor(
     private readonly publicClient: PublicClient<HttpTransport, Chain>,
     private readonly rollupAddress: EthAddress,
-    private readonly inboxAddress: EthAddress,
+    readonly inboxAddress: EthAddress,
     private readonly registryAddress: EthAddress,
-    private readonly store: ArchiverDataStore,
+    readonly dataStore: ArchiverDataStore,
     private readonly pollingIntervalMs = 10_000,
     private readonly instrumentation: ArchiverInstrumentation,
     private readonly l1StartBlock: bigint = 0n,
     private readonly log: DebugLogger = createDebugLogger('aztec:archiver'),
   ) {
+    this.store = new ArchiverStoreHelper(dataStore);
+
     this.rollup = getContract({
       address: rollupAddress.toString(),
       abi: RollupAbi,
@@ -340,29 +347,6 @@ export class Archiver implements ArchiveSource {
         .join(',')} with last processed L1 block ${lastProcessedL1BlockNumber}`,
     );
 
-    await Promise.all(
-      retrievedBlocks.map(block => {
-        return this.store.addLogs(
-          block.data.body.noteEncryptedLogs,
-          block.data.body.encryptedLogs,
-          block.data.body.unencryptedLogs,
-          block.data.number,
-        );
-      }),
-    );
-
-    // Unroll all logs emitted during the retrieved blocks and extract any contract classes and instances from them
-    await Promise.all(
-      retrievedBlocks.map(async block => {
-        const blockLogs = block.data.body.txEffects
-          .flatMap(txEffect => (txEffect ? [txEffect.unencryptedLogs] : []))
-          .flatMap(txLog => txLog.unrollLogs());
-        await this.storeRegisteredContractClasses(blockLogs, block.data.number);
-        await this.storeDeployedContractInstances(blockLogs, block.data.number);
-        await this.storeBroadcastedIndividualFunctions(blockLogs, block.data.number);
-      }),
-    );
-
     const timer = new Timer();
     await this.store.addBlocks(retrievedBlocks);
     this.instrumentation.processNewBlocks(
@@ -371,73 +355,6 @@ export class Archiver implements ArchiveSource {
     );
     const lastL2BlockNumber = retrievedBlocks[retrievedBlocks.length - 1].data.number;
     this.log.verbose(`Processed ${retrievedBlocks.length} new L2 blocks up to ${lastL2BlockNumber}`);
-  }
-
-  /**
-   * Extracts and stores contract classes out of ContractClassRegistered events emitted by the class registerer contract.
-   * @param allLogs - All logs emitted in a bunch of blocks.
-   */
-  private async storeRegisteredContractClasses(allLogs: UnencryptedL2Log[], blockNum: number) {
-    const contractClasses = ContractClassRegisteredEvent.fromLogs(allLogs, ClassRegistererAddress).map(e =>
-      e.toContractClassPublic(),
-    );
-    if (contractClasses.length > 0) {
-      contractClasses.forEach(c => this.log.verbose(`Registering contract class ${c.id.toString()}`));
-      await this.store.addContractClasses(contractClasses, blockNum);
-    }
-  }
-
-  /**
-   * Extracts and stores contract instances out of ContractInstanceDeployed events emitted by the canonical deployer contract.
-   * @param allLogs - All logs emitted in a bunch of blocks.
-   */
-  private async storeDeployedContractInstances(allLogs: UnencryptedL2Log[], blockNum: number) {
-    const contractInstances = ContractInstanceDeployedEvent.fromLogs(allLogs).map(e => e.toContractInstance());
-    if (contractInstances.length > 0) {
-      contractInstances.forEach(c => this.log.verbose(`Storing contract instance at ${c.address.toString()}`));
-      await this.store.addContractInstances(contractInstances, blockNum);
-    }
-  }
-
-  private async storeBroadcastedIndividualFunctions(allLogs: UnencryptedL2Log[], _blockNum: number) {
-    // Filter out private and unconstrained function broadcast events
-    const privateFnEvents = PrivateFunctionBroadcastedEvent.fromLogs(allLogs, ClassRegistererAddress);
-    const unconstrainedFnEvents = UnconstrainedFunctionBroadcastedEvent.fromLogs(allLogs, ClassRegistererAddress);
-
-    // Group all events by contract class id
-    for (const [classIdString, classEvents] of Object.entries(
-      groupBy([...privateFnEvents, ...unconstrainedFnEvents], e => e.contractClassId.toString()),
-    )) {
-      const contractClassId = Fr.fromString(classIdString);
-      const contractClass = await this.store.getContractClass(contractClassId);
-      if (!contractClass) {
-        this.log.warn(`Skipping broadcasted functions as contract class ${contractClassId.toString()} was not found`);
-        continue;
-      }
-
-      // Split private and unconstrained functions, and filter out invalid ones
-      const allFns = classEvents.map(e => e.toFunctionWithMembershipProof());
-      const privateFns = allFns.filter(
-        (fn): fn is ExecutablePrivateFunctionWithMembershipProof => 'unconstrainedFunctionsArtifactTreeRoot' in fn,
-      );
-      const unconstrainedFns = allFns.filter(
-        (fn): fn is UnconstrainedFunctionWithMembershipProof => 'privateFunctionsArtifactTreeRoot' in fn,
-      );
-      const validPrivateFns = privateFns.filter(fn => isValidPrivateFunctionMembershipProof(fn, contractClass));
-      const validUnconstrainedFns = unconstrainedFns.filter(fn =>
-        isValidUnconstrainedFunctionMembershipProof(fn, contractClass),
-      );
-      const validFnCount = validPrivateFns.length + validUnconstrainedFns.length;
-      if (validFnCount !== allFns.length) {
-        this.log.warn(`Skipping ${allFns.length - validFnCount} invalid functions`);
-      }
-
-      // Store the functions in the contract class in a single operation
-      if (validFnCount > 0) {
-        this.log.verbose(`Storing ${validFnCount} functions for contract class ${contractClassId.toString()}`);
-      }
-      await this.store.addFunctions(contractClassId, validPrivateFns, validUnconstrainedFns);
-    }
   }
 
   /**
@@ -593,6 +510,177 @@ export class Archiver implements ArchiveSource {
     return this.store.addContractArtifact(address, artifact);
   }
 
+  getContractArtifact(address: AztecAddress): Promise<ContractArtifact | undefined> {
+    return this.store.getContractArtifact(address);
+  }
+}
+
+/**
+ * A helper class that we use to deal with some of the logic needed when adding blocks.
+ *
+ * I would have preferred to not have this type. But it is useful for handling the logic that any
+ * store would need to include otherwise while exposing fewer functions and logic directly to the archiver.
+ */
+class ArchiverStoreHelper
+  implements Omit<ArchiverDataStore, 'addLogs' | 'addContractClasses' | 'addContractInstances' | 'addFunctions'>
+{
+  #log = createDebugLogger('aztec:archiver:block-helper');
+
+  constructor(private readonly store: ArchiverDataStore) {}
+
+  /**
+   * Extracts and stores contract classes out of ContractClassRegistered events emitted by the class registerer contract.
+   * @param allLogs - All logs emitted in a bunch of blocks.
+   */
+  async #storeRegisteredContractClasses(allLogs: UnencryptedL2Log[], blockNum: number) {
+    const contractClasses = ContractClassRegisteredEvent.fromLogs(allLogs, ClassRegistererAddress).map(e =>
+      e.toContractClassPublic(),
+    );
+    if (contractClasses.length > 0) {
+      contractClasses.forEach(c => this.#log.verbose(`Registering contract class ${c.id.toString()}`));
+      return await this.store.addContractClasses(contractClasses, blockNum);
+    }
+    return true;
+  }
+
+  /**
+   * Extracts and stores contract instances out of ContractInstanceDeployed events emitted by the canonical deployer contract.
+   * @param allLogs - All logs emitted in a bunch of blocks.
+   */
+  async #storeDeployedContractInstances(allLogs: UnencryptedL2Log[], blockNum: number) {
+    const contractInstances = ContractInstanceDeployedEvent.fromLogs(allLogs).map(e => e.toContractInstance());
+    if (contractInstances.length > 0) {
+      contractInstances.forEach(c => this.#log.verbose(`Storing contract instance at ${c.address.toString()}`));
+      return await this.store.addContractInstances(contractInstances, blockNum);
+    }
+    return true;
+  }
+
+  async #storeBroadcastedIndividualFunctions(allLogs: UnencryptedL2Log[], _blockNum: number) {
+    // Filter out private and unconstrained function broadcast events
+    const privateFnEvents = PrivateFunctionBroadcastedEvent.fromLogs(allLogs, ClassRegistererAddress);
+    const unconstrainedFnEvents = UnconstrainedFunctionBroadcastedEvent.fromLogs(allLogs, ClassRegistererAddress);
+
+    // Group all events by contract class id
+    for (const [classIdString, classEvents] of Object.entries(
+      groupBy([...privateFnEvents, ...unconstrainedFnEvents], e => e.contractClassId.toString()),
+    )) {
+      const contractClassId = Fr.fromString(classIdString);
+      const contractClass = await this.getContractClass(contractClassId);
+      if (!contractClass) {
+        this.#log.warn(`Skipping broadcasted functions as contract class ${contractClassId.toString()} was not found`);
+        continue;
+      }
+
+      // Split private and unconstrained functions, and filter out invalid ones
+      const allFns = classEvents.map(e => e.toFunctionWithMembershipProof());
+      const privateFns = allFns.filter(
+        (fn): fn is ExecutablePrivateFunctionWithMembershipProof => 'unconstrainedFunctionsArtifactTreeRoot' in fn,
+      );
+      const unconstrainedFns = allFns.filter(
+        (fn): fn is UnconstrainedFunctionWithMembershipProof => 'privateFunctionsArtifactTreeRoot' in fn,
+      );
+      const validPrivateFns = privateFns.filter(fn => isValidPrivateFunctionMembershipProof(fn, contractClass));
+      const validUnconstrainedFns = unconstrainedFns.filter(fn =>
+        isValidUnconstrainedFunctionMembershipProof(fn, contractClass),
+      );
+      const validFnCount = validPrivateFns.length + validUnconstrainedFns.length;
+      if (validFnCount !== allFns.length) {
+        this.#log.warn(`Skipping ${allFns.length - validFnCount} invalid functions`);
+      }
+
+      // Store the functions in the contract class in a single operation
+      if (validFnCount > 0) {
+        this.#log.verbose(`Storing ${validFnCount} functions for contract class ${contractClassId.toString()}`);
+      }
+      return await this.store.addFunctions(contractClassId, validPrivateFns, validUnconstrainedFns);
+    }
+    return true;
+  }
+
+  async addBlocks(blocks: L1Published<L2Block>[]): Promise<boolean> {
+    return [
+      this.store.addLogs(blocks.map(block => block.data)),
+      // Unroll all logs emitted during the retrieved blocks and extract any contract classes and instances from them
+      ...(await Promise.all(
+        blocks.map(async block => {
+          const blockLogs = block.data.body.txEffects
+            .flatMap(txEffect => (txEffect ? [txEffect.unencryptedLogs] : []))
+            .flatMap(txLog => txLog.unrollLogs());
+
+          return (
+            await Promise.all([
+              this.#storeRegisteredContractClasses(blockLogs, block.data.number),
+              this.#storeDeployedContractInstances(blockLogs, block.data.number),
+              this.#storeBroadcastedIndividualFunctions(blockLogs, block.data.number),
+            ])
+          ).every(Boolean);
+        }),
+      )),
+      this.store.addBlocks(blocks),
+    ].every(Boolean);
+  }
+
+  getBlocks(from: number, limit: number): Promise<L1Published<L2Block>[]> {
+    return this.store.getBlocks(from, limit);
+  }
+
+  getTxEffect(txHash: TxHash): Promise<TxEffect | undefined> {
+    return this.store.getTxEffect(txHash);
+  }
+
+  getSettledTxReceipt(txHash: TxHash): Promise<TxReceipt | undefined> {
+    return this.store.getSettledTxReceipt(txHash);
+  }
+  addL1ToL2Messages(messages: DataRetrieval<InboxLeaf>): Promise<boolean> {
+    return this.store.addL1ToL2Messages(messages);
+  }
+  getL1ToL2Messages(blockNumber: bigint): Promise<Fr[]> {
+    return this.store.getL1ToL2Messages(blockNumber);
+  }
+  getL1ToL2MessageIndex(l1ToL2Message: Fr, startIndex: bigint): Promise<bigint | undefined> {
+    return this.store.getL1ToL2MessageIndex(l1ToL2Message, startIndex);
+  }
+  getLogs<TLogType extends LogType>(
+    from: number,
+    limit: number,
+    logType: TLogType,
+  ): Promise<L2BlockL2Logs<FromLogType<TLogType>>[]> {
+    return this.store.getLogs(from, limit, logType);
+  }
+  getUnencryptedLogs(filter: LogFilter): Promise<GetUnencryptedLogsResponse> {
+    return this.store.getUnencryptedLogs(filter);
+  }
+  getSynchedL2BlockNumber(): Promise<number> {
+    return this.store.getSynchedL2BlockNumber();
+  }
+  getProvenL2BlockNumber(): Promise<number> {
+    return this.store.getProvenL2BlockNumber();
+  }
+  setProvenL2BlockNumber(l2BlockNumber: SingletonDataRetrieval<number>): Promise<void> {
+    return this.store.setProvenL2BlockNumber(l2BlockNumber);
+  }
+  setBlockSynchedL1BlockNumber(l1BlockNumber: bigint): Promise<void> {
+    return this.store.setBlockSynchedL1BlockNumber(l1BlockNumber);
+  }
+  setMessageSynchedL1BlockNumber(l1BlockNumber: bigint): Promise<void> {
+    return this.store.setMessageSynchedL1BlockNumber(l1BlockNumber);
+  }
+  getSynchPoint(): Promise<ArchiverL1SynchPoint> {
+    return this.store.getSynchPoint();
+  }
+  getContractClass(id: Fr): Promise<ContractClassPublic | undefined> {
+    return this.store.getContractClass(id);
+  }
+  getContractInstance(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
+    return this.store.getContractInstance(address);
+  }
+  getContractClassIds(): Promise<Fr[]> {
+    return this.store.getContractClassIds();
+  }
+  addContractArtifact(address: AztecAddress, contract: ContractArtifact): Promise<void> {
+    return this.store.addContractArtifact(address, contract);
+  }
   getContractArtifact(address: AztecAddress): Promise<ContractArtifact | undefined> {
     return this.store.getContractArtifact(address);
   }

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -1,6 +1,4 @@
 import {
-  type EncryptedL2BlockL2Logs,
-  type EncryptedNoteL2BlockL2Logs,
   type FromLogType,
   type GetUnencryptedLogsResponse,
   type InboxLeaf,
@@ -11,7 +9,6 @@ import {
   type TxEffect,
   type TxHash,
   type TxReceipt,
-  type UnencryptedL2BlockL2Logs,
 } from '@aztec/circuit-types';
 import { type Fr } from '@aztec/circuits.js';
 import { type ContractArtifact } from '@aztec/foundation/abi';
@@ -74,18 +71,10 @@ export interface ArchiverDataStore {
 
   /**
    * Append new logs to the store's list.
-   * @param noteEncryptedLogs - The note encrypted logs to be added to the store.
-   * @param encryptedLogs - The encrypted logs to be added to the store.
-   * @param unencryptedLogs - The unencrypted logs to be added to the store.
-   * @param blockNumber - The block for which to add the logs.
+   * @param blocks - The blocks for which to add the logs.
    * @returns True if the operation is successful.
    */
-  addLogs(
-    noteEncryptedLogs: EncryptedNoteL2BlockL2Logs | undefined,
-    encryptedLogs: EncryptedL2BlockL2Logs | undefined,
-    unencryptedLogs: UnencryptedL2BlockL2Logs | undefined,
-    blockNumber: number,
-  ): Promise<boolean>;
+  addLogs(blocks: L2Block[]): Promise<boolean>;
 
   /**
    * Append L1 to L2 messages to the store.

--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -128,14 +128,7 @@ export function describeArchiverDataStore(testName: string, getStore: () => Arch
     describe('addLogs', () => {
       it('adds encrypted & unencrypted logs', async () => {
         const block = blocks[0].data;
-        await expect(
-          store.addLogs(
-            block.body.noteEncryptedLogs,
-            block.body.encryptedLogs,
-            block.body.unencryptedLogs,
-            block.number,
-          ),
-        ).resolves.toEqual(true);
+        await expect(store.addLogs([block])).resolves.toEqual(true);
       });
     });
 
@@ -145,16 +138,7 @@ export function describeArchiverDataStore(testName: string, getStore: () => Arch
       ['unencrypted', LogType.UNENCRYPTED],
     ])('getLogs (%s)', (_, logType) => {
       beforeEach(async () => {
-        await Promise.all(
-          blocks.map(block =>
-            store.addLogs(
-              block.data.body.noteEncryptedLogs,
-              block.data.body.encryptedLogs,
-              block.data.body.unencryptedLogs,
-              block.data.number,
-            ),
-          ),
-        );
+        await store.addLogs(blocks.map(b => b.data));
       });
 
       it.each(blockTests)('retrieves previously stored logs', async (from, limit, getExpectedBlocks) => {
@@ -176,16 +160,7 @@ export function describeArchiverDataStore(testName: string, getStore: () => Arch
 
     describe('getTxEffect', () => {
       beforeEach(async () => {
-        await Promise.all(
-          blocks.map(block =>
-            store.addLogs(
-              block.data.body.noteEncryptedLogs,
-              block.data.body.encryptedLogs,
-              block.data.body.unencryptedLogs,
-              block.data.number,
-            ),
-          ),
-        );
+        await store.addLogs(blocks.map(b => b.data));
         await store.addBlocks(blocks);
       });
 
@@ -338,17 +313,7 @@ export function describeArchiverDataStore(testName: string, getStore: () => Arch
         }));
 
         await store.addBlocks(blocks);
-
-        await Promise.all(
-          blocks.map(block =>
-            store.addLogs(
-              block.data.body.noteEncryptedLogs,
-              block.data.body.encryptedLogs,
-              block.data.body.unencryptedLogs,
-              block.data.number,
-            ),
-          ),
-        );
+        await store.addLogs(blocks.map(b => b.data));
       });
 
       it('"txHash" filter param is respected', async () => {

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -1,6 +1,4 @@
 import {
-  type EncryptedL2BlockL2Logs,
-  type EncryptedNoteL2BlockL2Logs,
   type FromLogType,
   type GetUnencryptedLogsResponse,
   type InboxLeaf,
@@ -11,7 +9,6 @@ import {
   type TxEffect,
   type TxHash,
   type TxReceipt,
-  type UnencryptedL2BlockL2Logs,
 } from '@aztec/circuit-types';
 import { type Fr } from '@aztec/circuits.js';
 import { type ContractArtifact } from '@aztec/foundation/abi';
@@ -141,18 +138,11 @@ export class KVArchiverDataStore implements ArchiverDataStore {
 
   /**
    * Append new logs to the store's list.
-   * @param encryptedLogs - The logs to be added to the store.
-   * @param unencryptedLogs - The type of the logs to be added to the store.
-   * @param blockNumber - The block for which to add the logs.
+   * @param blocks - The blocks for which to add the logs.
    * @returns True if the operation is successful.
    */
-  addLogs(
-    noteEncryptedLogs: EncryptedNoteL2BlockL2Logs | undefined,
-    encryptedLogs: EncryptedL2BlockL2Logs | undefined,
-    unencryptedLogs: UnencryptedL2BlockL2Logs | undefined,
-    blockNumber: number,
-  ): Promise<boolean> {
-    return this.#logStore.addLogs(noteEncryptedLogs, encryptedLogs, unencryptedLogs, blockNumber);
+  addLogs(blocks: L2Block[]): Promise<boolean> {
+    return this.#logStore.addLogs(blocks);
   }
 
   /**

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/log_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/log_store.ts
@@ -4,6 +4,7 @@ import {
   ExtendedUnencryptedL2Log,
   type FromLogType,
   type GetUnencryptedLogsResponse,
+  type L2Block,
   type L2BlockL2Logs,
   type LogFilter,
   LogId,
@@ -37,29 +38,24 @@ export class LogStore {
 
   /**
    * Append new logs to the store's list.
-   * @param encryptedLogs - The logs to be added to the store.
-   * @param unencryptedLogs - The type of the logs to be added to the store.
-   * @param blockNumber - The block for which to add the logs.
+   * @param blocks - The blocks for which to add the logs.
    * @returns True if the operation is successful.
    */
-  addLogs(
-    noteEncryptedLogs: EncryptedNoteL2BlockL2Logs | undefined,
-    encryptedLogs: EncryptedL2BlockL2Logs | undefined,
-    unencryptedLogs: UnencryptedL2BlockL2Logs | undefined,
-    blockNumber: number,
-  ): Promise<boolean> {
+  addLogs(blocks: L2Block[]): Promise<boolean> {
     return this.db.transaction(() => {
-      if (noteEncryptedLogs) {
-        void this.#noteEncryptedLogs.set(blockNumber, noteEncryptedLogs.toBuffer());
-      }
+      blocks.forEach(block => {
+        if (block.body.noteEncryptedLogs) {
+          void this.#noteEncryptedLogs.set(block.number, block.body.noteEncryptedLogs.toBuffer());
+        }
 
-      if (encryptedLogs) {
-        void this.#encryptedLogs.set(blockNumber, encryptedLogs.toBuffer());
-      }
+        if (block.body.encryptedLogs) {
+          void this.#encryptedLogs.set(block.number, block.body.encryptedLogs.toBuffer());
+        }
 
-      if (unencryptedLogs) {
-        void this.#unencryptedLogs.set(blockNumber, unencryptedLogs.toBuffer());
-      }
+        if (block.body.unencryptedLogs) {
+          void this.#unencryptedLogs.set(block.number, block.body.unencryptedLogs.toBuffer());
+        }
+      });
 
       return true;
     });

--- a/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.test.ts
+++ b/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.test.ts
@@ -24,16 +24,7 @@ describe('MemoryArchiverStore', () => {
       }));
 
       await archiverStore.addBlocks(blocks);
-      await Promise.all(
-        blocks.map(block =>
-          archiverStore.addLogs(
-            block.data.body.noteEncryptedLogs,
-            block.data.body.encryptedLogs,
-            block.data.body.unencryptedLogs,
-            block.data.number,
-          ),
-        ),
-      );
+      await archiverStore.addLogs(blocks.map(b => b.data));
 
       const response = await archiverStore.getUnencryptedLogs({});
 

--- a/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
@@ -162,28 +162,23 @@ export class MemoryArchiverStore implements ArchiverDataStore {
 
   /**
    * Append new logs to the store's list.
-   * @param encryptedLogs - The encrypted logs to be added to the store.
-   * @param unencryptedLogs - The unencrypted logs to be added to the store.
-   * @param blockNumber - The block for which to add the logs.
+   * @param block - The block for which to add the logs.
    * @returns True if the operation is successful.
    */
-  addLogs(
-    noteEncryptedLogs: EncryptedNoteL2BlockL2Logs,
-    encryptedLogs: EncryptedL2BlockL2Logs,
-    unencryptedLogs: UnencryptedL2BlockL2Logs,
-    blockNumber: number,
-  ): Promise<boolean> {
-    if (noteEncryptedLogs) {
-      this.noteEncryptedLogsPerBlock[blockNumber - INITIAL_L2_BLOCK_NUM] = noteEncryptedLogs;
-    }
+  addLogs(blocks: L2Block[]): Promise<boolean> {
+    blocks.forEach(block => {
+      if (block.body.noteEncryptedLogs) {
+        this.noteEncryptedLogsPerBlock[block.number - INITIAL_L2_BLOCK_NUM] = block.body.noteEncryptedLogs;
+      }
 
-    if (encryptedLogs) {
-      this.encryptedLogsPerBlock[blockNumber - INITIAL_L2_BLOCK_NUM] = encryptedLogs;
-    }
+      if (block.body.encryptedLogs) {
+        this.encryptedLogsPerBlock[block.number - INITIAL_L2_BLOCK_NUM] = block.body.encryptedLogs;
+      }
 
-    if (unencryptedLogs) {
-      this.unencryptedLogsPerBlock[blockNumber - INITIAL_L2_BLOCK_NUM] = unencryptedLogs;
-    }
+      if (block.body.unencryptedLogs) {
+        this.unencryptedLogsPerBlock[block.number - INITIAL_L2_BLOCK_NUM] = block.body.unencryptedLogs;
+      }
+    });
 
     return Promise.resolve(true);
   }


### PR DESCRIPTION
Minor modifications to the archiver to make it simpler for my tiny mind to follow along.

- Create an `ArchiverStoreHelper` that lives in the archiver and just wraps the `store` and have additional logic for handling the addition of blocks and unwinding them (in later pr)
- Updates the `addLogs` to take blocks as input as all of the values were already in there and it was just painful to pick them apart first.