### PR TITLE
feat: Add epochs to existing orchestrator

### DIFF
--- a/yarn-project/bb-prover/src/index.ts
+++ b/yarn-project/bb-prover/src/index.ts
@@ -3,3 +3,5 @@ export * from './test/index.js';
 export * from './verifier/index.js';
 export * from './config.js';
 export * from './bb/execute.js';
+
+export { type ClientProtocolCircuitVerifier } from '@aztec/circuit-types';

--- a/yarn-project/bb-prover/src/prover/bb_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_prover.ts
@@ -337,22 +337,19 @@ export class BBNativeRollupProver implements ServerCircuitProver {
   public async getBlockRootRollupProof(
     input: BlockRootRollupInputs,
   ): Promise<PublicInputsAndRecursiveProof<BlockRootOrBlockMergePublicInputs>> {
-    // TODO(#7346): When batch rollups are integrated, we probably want the below to be this.createRecursiveProof
-    // since we will no longer be verifying it directly on L1
-    const { circuitOutput, proof } = await this.createProof(
+    const { circuitOutput, proof } = await this.createRecursiveProof(
       input,
       'BlockRootRollupArtifact',
+      NESTED_RECURSIVE_PROOF_LENGTH,
       convertBlockRootRollupInputsToWitnessMap,
       convertBlockRootRollupOutputsFromWitnessMap,
     );
 
-    const recursiveProof = makeRecursiveProofFromBinary(proof, NESTED_RECURSIVE_PROOF_LENGTH);
-
     const verificationKey = await this.getVerificationKeyDataForCircuit('BlockRootRollupArtifact');
 
-    await this.verifyProof('BlockRootRollupArtifact', proof);
+    await this.verifyProof('BlockRootRollupArtifact', proof.binaryProof);
 
-    return makePublicInputsAndRecursiveProof(circuitOutput, recursiveProof, verificationKey);
+    return makePublicInputsAndRecursiveProof(circuitOutput, proof, verificationKey);
   }
 
   /**

--- a/yarn-project/circuit-types/src/interfaces/block-prover.ts
+++ b/yarn-project/circuit-types/src/interfaces/block-prover.ts
@@ -52,7 +52,7 @@ export interface BlockSimulator extends ProcessedTxHandler {
   startNewBlock(numTxs: number, globalVariables: GlobalVariables, l1ToL2Messages: Fr[]): Promise<ProvingTicket>;
 
   /** Cancels the block currently being processed. Processes already in progress built may continue but further proofs should not be started. */
-  cancelBlock(): void;
+  cancel(): void;
 
   /** Performs the final archive tree insertion for this block and returns the L2Block. */
   finaliseBlock(): Promise<SimulationBlockResult>;
@@ -71,4 +71,8 @@ export interface BlockProver extends BlockSimulator {
 
   /** Performs the final archive tree insertion for this block and returns the L2Block. */
   finaliseBlock(): Promise<ProvingBlockResult>;
+}
+
+export interface EpochProver extends BlockProver {
+  startNewEpoch(epochNumber: number, totalNumBlocks: number): ProvingTicket;
 }

--- a/yarn-project/circuits.js/src/structs/global_variables.ts
+++ b/yarn-project/circuits.js/src/structs/global_variables.ts
@@ -4,6 +4,8 @@ import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, FieldReader, serializeToBuffer, serializeToFields } from '@aztec/foundation/serialize';
 import { type FieldsOf } from '@aztec/foundation/types';
 
+import { inspect } from 'util';
+
 import { GLOBAL_VARIABLES_LENGTH } from '../constants.gen.js';
 import { GasFees } from './gas_fees.js';
 
@@ -149,5 +151,11 @@ export class GlobalVariables {
       this.feeRecipient.isZero() &&
       this.gasFees.isEmpty()
     );
+  }
+
+  [inspect.custom]() {
+    return `GlobalVariables { chainId: ${this.chainId.toString()}, version: ${this.version.toString()}, blockNumber: ${this.blockNumber.toString()}, slotNumber: ${this.slotNumber.toString()}, timestamp: ${this.timestamp.toString()}, coinbase: ${this.coinbase.toString()}, feeRecipient: ${this.feeRecipient.toString()}, gasFees: ${inspect(
+      this.gasFees,
+    )} }`;
   }
 }

--- a/yarn-project/circuits.js/src/structs/header.ts
+++ b/yarn-project/circuits.js/src/structs/header.ts
@@ -3,6 +3,8 @@ import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, FieldReader, serializeToBuffer, serializeToFields } from '@aztec/foundation/serialize';
 import { type FieldsOf } from '@aztec/foundation/types';
 
+import { inspect } from 'util';
+
 import { GeneratorIndex, HEADER_LENGTH } from '../constants.gen.js';
 import { ContentCommitment } from './content_commitment.js';
 import { GlobalVariables } from './global_variables.js';
@@ -124,5 +126,21 @@ export class Header {
 
   hash(): Fr {
     return poseidon2HashWithSeparator(this.toFields(), GeneratorIndex.BLOCK_HASH);
+  }
+
+  [inspect.custom]() {
+    return `Header {
+  lastArchive: ${inspect(this.lastArchive)},
+  contentCommitment.numTx: ${this.contentCommitment.numTxs.toNumber()},
+  contentCommitment.txsEffectsHash: ${this.contentCommitment.txsEffectsHash.toString('hex')},
+  contentCommitment.inHash: ${this.contentCommitment.inHash.toString('hex')},
+  contentCommitment.outHash: ${this.contentCommitment.outHash.toString('hex')},
+  state.l1ToL2MessageTree: ${inspect(this.state.l1ToL2MessageTree)},
+  state.noteHashTree: ${inspect(this.state.partial.noteHashTree)},
+  state.nullifierTree: ${inspect(this.state.partial.nullifierTree)},
+  state.publicDataTree: ${inspect(this.state.partial.publicDataTree)},
+  globalVariables: ${inspect(this.globalVariables)},
+  totalFees: ${this.totalFees},
+}`;
   }
 }

--- a/yarn-project/circuits.js/src/structs/rollup/append_only_tree_snapshot.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/append_only_tree_snapshot.ts
@@ -1,6 +1,8 @@
 import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, FieldReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
+import { inspect } from 'util';
+
 import { STRING_ENCODING, type UInt32 } from '../shared.js';
 
 /**
@@ -63,5 +65,11 @@ export class AppendOnlyTreeSnapshot {
 
   isZero(): boolean {
     return this.root.isZero() && this.nextAvailableLeafIndex === 0;
+  }
+
+  [inspect.custom]() {
+    return `AppendOnlyTreeSnapshot { root: ${this.root.toString()}, nextAvailableLeafIndex: ${
+      this.nextAvailableLeafIndex
+    } }`;
   }
 }

--- a/yarn-project/circuits.js/src/structs/rollup/block_root_or_block_merge_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/block_root_or_block_merge_public_inputs.ts
@@ -1,9 +1,9 @@
+import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, type Tuple, serializeToBuffer, serializeToFields } from '@aztec/foundation/serialize';
 import { type FieldsOf } from '@aztec/foundation/types';
 
 import { GlobalVariables } from '../global_variables.js';
-import { EthAddress } from '../index.js';
 import { AppendOnlyTreeSnapshot } from './append_only_tree_snapshot.js';
 
 /**
@@ -130,5 +130,16 @@ export class FeeRecipient {
 
   toFields() {
     return serializeToFields(...FeeRecipient.getFields(this));
+  }
+
+  isEmpty() {
+    return this.value.isZero() && this.recipient.isZero();
+  }
+
+  toFriendlyJSON() {
+    if (this.isEmpty()) {
+      return {};
+    }
+    return { recipient: this.recipient.toString(), value: this.value.toString() };
   }
 }

--- a/yarn-project/circuits.js/src/structs/rollup/block_root_rollup.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/block_root_rollup.ts
@@ -47,7 +47,6 @@ export class BlockRootRollupInputs {
     public newArchiveSiblingPath: Tuple<Fr, typeof ARCHIVE_HEIGHT>,
     /**
      * The hash of the block preceding this one.
-     * TODO(#7346): Integrate batch rollup circuits and inject below
      */
     public previousBlockHash: Fr,
     /**

--- a/yarn-project/circuits.js/src/structs/state_reference.ts
+++ b/yarn-project/circuits.js/src/structs/state_reference.ts
@@ -1,6 +1,8 @@
 import { type Fr } from '@aztec/foundation/fields';
 import { BufferReader, FieldReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
+import { inspect } from 'util';
+
 import { STATE_REFERENCE_LENGTH } from '../constants.gen.js';
 import { PartialStateReference } from './partial_state_reference.js';
 import { AppendOnlyTreeSnapshot } from './rollup/append_only_tree_snapshot.js';
@@ -55,5 +57,14 @@ export class StateReference {
 
   isEmpty(): boolean {
     return this.l1ToL2MessageTree.isZero() && this.partial.isEmpty();
+  }
+
+  [inspect.custom]() {
+    return `StateReference {
+  l1ToL2MessageTree: ${inspect(this.l1ToL2MessageTree)},
+  noteHashTree: ${inspect(this.partial.noteHashTree)},
+  nullifierTree: ${inspect(this.partial.nullifierTree)},
+  publicDataTree: ${inspect(this.partial.publicDataTree)},
+}`;
   }
 }

--- a/yarn-project/end-to-end/src/e2e_prover/e2e_prover_test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/e2e_prover_test.ts
@@ -16,7 +16,7 @@ import {
   createDebugLogger,
   deployL1Contract,
 } from '@aztec/aztec.js';
-import { BBCircuitVerifier } from '@aztec/bb-prover';
+import { BBCircuitVerifier, type ClientProtocolCircuitVerifier, TestCircuitVerifier } from '@aztec/bb-prover';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { TokenContract } from '@aztec/noir-contracts.js';
 import { type ProverNode, type ProverNodeConfig, createProverNode } from '@aztec/prover-node';
@@ -73,14 +73,14 @@ export class FullProverTest {
   private provenComponents: ProvenSetup[] = [];
   private bbConfigCleanup?: () => Promise<void>;
   private acvmConfigCleanup?: () => Promise<void>;
-  circuitProofVerifier?: BBCircuitVerifier;
+  circuitProofVerifier?: ClientProtocolCircuitVerifier;
   provenAssets: TokenContract[] = [];
   private context!: SubsystemsContext;
   private proverNode!: ProverNode;
   private simulatedProverNode!: ProverNode;
   private l1Contracts!: DeployL1Contracts;
 
-  constructor(testName: string, private minNumberOfTxsPerBlock: number) {
+  constructor(testName: string, private minNumberOfTxsPerBlock: number, private realProofs = true) {
     this.logger = createDebugLogger(`aztec:full_prover_test:${testName}`);
     this.snapshotManager = createSnapshotManager(`full_prover_integration/${testName}`, dataPath);
   }
@@ -149,25 +149,31 @@ export class FullProverTest {
 
     // Configure a full prover PXE
 
-    const [acvmConfig, bbConfig] = await Promise.all([getACVMConfig(this.logger), getBBConfig(this.logger)]);
-    if (!acvmConfig || !bbConfig) {
-      throw new Error('Missing ACVM or BB config');
+    let acvmConfig: Awaited<ReturnType<typeof getACVMConfig>> | undefined;
+    let bbConfig: Awaited<ReturnType<typeof getBBConfig>> | undefined;
+    if (this.realProofs) {
+      [acvmConfig, bbConfig] = await Promise.all([getACVMConfig(this.logger), getBBConfig(this.logger)]);
+      if (!acvmConfig || !bbConfig) {
+        throw new Error('Missing ACVM or BB config');
+      }
+
+      this.acvmConfigCleanup = acvmConfig.cleanup;
+      this.bbConfigCleanup = bbConfig.cleanup;
+
+      if (!bbConfig?.bbWorkingDirectory || !bbConfig?.bbBinaryPath) {
+        throw new Error(`Test must be run with BB native configuration`);
+      }
+
+      this.circuitProofVerifier = await BBCircuitVerifier.new(bbConfig);
+
+      this.logger.debug(`Configuring the node for real proofs...`);
+      await this.aztecNode.setConfig({
+        realProofs: true,
+        minTxsPerBlock: this.minNumberOfTxsPerBlock,
+      });
+    } else {
+      this.circuitProofVerifier = new TestCircuitVerifier();
     }
-
-    this.acvmConfigCleanup = acvmConfig.cleanup;
-    this.bbConfigCleanup = bbConfig.cleanup;
-
-    if (!bbConfig?.bbWorkingDirectory || !bbConfig?.bbBinaryPath) {
-      throw new Error(`Test must be run with BB native configuration`);
-    }
-
-    this.circuitProofVerifier = await BBCircuitVerifier.new(bbConfig);
-
-    this.logger.debug(`Configuring the node for real proofs...`);
-    await this.aztecNode.setConfig({
-      realProofs: true,
-      minTxsPerBlock: this.minNumberOfTxsPerBlock,
-    });
 
     this.logger.debug(`Main setup completed, initializing full prover PXE, Node, and Prover Node...`);
 
@@ -175,7 +181,7 @@ export class FullProverTest {
       const result = await setupPXEService(
         this.aztecNode,
         {
-          proverEnabled: true,
+          proverEnabled: this.realProofs,
           bbBinaryPath: bbConfig?.bbBinaryPath,
           bbWorkingDirectory: bbConfig?.bbWorkingDirectory,
         },
@@ -239,7 +245,7 @@ export class FullProverTest {
       txProviderNodeUrl: undefined,
       dataDirectory: undefined,
       proverId: new Fr(81),
-      realProofs: true,
+      realProofs: this.realProofs,
       proverAgentConcurrency: 2,
       publisherPrivateKey: `0x${proverNodePrivateKey!.toString('hex')}`,
       proverNodeMaxPendingJobs: 100,
@@ -341,13 +347,17 @@ export class FullProverTest {
   }
 
   async deployVerifier() {
+    if (!this.realProofs) {
+      return;
+    }
+
     if (!this.circuitProofVerifier) {
       throw new Error('No verifier');
     }
 
     const { walletClient, publicClient, l1ContractAddresses } = this.context.deployL1ContractsValues;
 
-    const contract = await this.circuitProofVerifier.generateSolidityContract(
+    const contract = await (this.circuitProofVerifier as BBCircuitVerifier).generateSolidityContract(
       'BlockRootRollupArtifact',
       'UltraHonkVerifier.sol',
     );

--- a/yarn-project/end-to-end/src/e2e_prover/full.test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/full.test.ts
@@ -8,7 +8,8 @@ const TIMEOUT = 1_800_000;
 process.env.AVM_PROVING_STRICT = '1';
 
 describe('full_prover', () => {
-  const t = new FullProverTest('full_prover', 2);
+  const realProofs = !['true', '1'].includes(process.env.FAKE_PROOFS ?? '');
+  const t = new FullProverTest('full_prover', 2, realProofs);
   let { provenAssets, accounts, tokenSim, logger } = t;
 
   beforeAll(async () => {
@@ -83,6 +84,11 @@ describe('full_prover', () => {
   );
 
   it('rejects txs with invalid proofs', async () => {
+    if (!realProofs) {
+      t.logger.warn(`Skipping test with fake proofs`);
+      return;
+    }
+
     const privateInteraction = t.fakeProofsAsset.methods.transfer(accounts[1].address, 1);
     const publicInteraction = t.fakeProofsAsset.methods.transfer_public(accounts[0].address, accounts[1].address, 1, 0);
 

--- a/yarn-project/prover-client/src/mocks/fixtures.ts
+++ b/yarn-project/prover-client/src/mocks/fixtures.ts
@@ -135,9 +135,9 @@ export const makeGlobals = (blockNumber: number) => {
   return new GlobalVariables(
     Fr.ZERO,
     Fr.ZERO,
-    new Fr(blockNumber),
+    new Fr(blockNumber) /** block number */,
     new Fr(blockNumber) /** slot number */,
-    Fr.ZERO,
+    new Fr(blockNumber) /** timestamp */,
     EthAddress.ZERO,
     AztecAddress.ZERO,
     GasFees.empty(),

--- a/yarn-project/prover-client/src/orchestrator/block-proving-state.ts
+++ b/yarn-project/prover-client/src/orchestrator/block-proving-state.ts
@@ -1,0 +1,240 @@
+import { type L2Block, type MerkleTreeId, type ProvingResult } from '@aztec/circuit-types';
+import {
+  type ARCHIVE_HEIGHT,
+  type AppendOnlyTreeSnapshot,
+  type BaseOrMergeRollupPublicInputs,
+  type BlockRootOrBlockMergePublicInputs,
+  type Fr,
+  type GlobalVariables,
+  type L1_TO_L2_MSG_SUBTREE_SIBLING_PATH_LENGTH,
+  type NESTED_RECURSIVE_PROOF_LENGTH,
+  type NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
+  NUM_BASE_PARITY_PER_ROOT_PARITY,
+  type Proof,
+  type RECURSIVE_PROOF_LENGTH,
+  type RecursiveProof,
+  type RootParityInput,
+  type VerificationKeyAsFields,
+} from '@aztec/circuits.js';
+import { type Tuple } from '@aztec/foundation/serialize';
+
+import { type TxProvingState } from './tx-proving-state.js';
+
+enum PROVING_STATE_LIFECYCLE {
+  PROVING_STATE_CREATED,
+  PROVING_STATE_RESOLVED,
+  PROVING_STATE_REJECTED,
+}
+
+export type MergeRollupInputData = {
+  inputs: [BaseOrMergeRollupPublicInputs | undefined, BaseOrMergeRollupPublicInputs | undefined];
+  proofs: [
+    RecursiveProof<typeof NESTED_RECURSIVE_PROOF_LENGTH> | undefined,
+    RecursiveProof<typeof NESTED_RECURSIVE_PROOF_LENGTH> | undefined,
+  ];
+  verificationKeys: [VerificationKeyAsFields | undefined, VerificationKeyAsFields | undefined];
+};
+
+export type TreeSnapshots = Map<MerkleTreeId, AppendOnlyTreeSnapshot>;
+
+/**
+ * The current state of the proving schedule for a given block. Managed by ProvingState.
+ * Contains the raw inputs and intermediate state to generate every constituent proof in the tree.
+ */
+export class BlockProvingState {
+  private mergeRollupInputs: MergeRollupInputData[] = [];
+  private rootParityInputs: Array<RootParityInput<typeof RECURSIVE_PROOF_LENGTH> | undefined> = [];
+  private finalRootParityInputs: RootParityInput<typeof NESTED_RECURSIVE_PROOF_LENGTH> | undefined;
+  public blockRootRollupPublicInputs: BlockRootOrBlockMergePublicInputs | undefined;
+  public finalProof: Proof | undefined;
+  public block: L2Block | undefined;
+  private txs: TxProvingState[] = [];
+
+  private provingStateLifecycle = PROVING_STATE_LIFECYCLE.PROVING_STATE_CREATED;
+
+  constructor(
+    public readonly index: number,
+    public readonly totalNumTxs: number,
+    public readonly globalVariables: GlobalVariables,
+    public readonly newL1ToL2Messages: Tuple<Fr, typeof NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP>,
+    public readonly messageTreeSnapshot: AppendOnlyTreeSnapshot,
+    public readonly messageTreeRootSiblingPath: Tuple<Fr, typeof L1_TO_L2_MSG_SUBTREE_SIBLING_PATH_LENGTH>,
+    public readonly messageTreeSnapshotAfterInsertion: AppendOnlyTreeSnapshot,
+    public readonly archiveTreeSnapshot: AppendOnlyTreeSnapshot,
+    public readonly archiveTreeRootSiblingPath: Tuple<Fr, typeof ARCHIVE_HEIGHT>,
+    public readonly previousBlockHash: Fr,
+    private completionCallback?: (result: ProvingResult) => void,
+    private rejectionCallback?: (reason: string) => void,
+  ) {
+    this.rootParityInputs = Array.from({ length: NUM_BASE_PARITY_PER_ROOT_PARITY }).map(_ => undefined);
+  }
+
+  public get blockNumber() {
+    return this.globalVariables.blockNumber.toNumber();
+  }
+
+  // Returns the number of levels of merge rollups
+  public get numMergeLevels() {
+    return BigInt(Math.ceil(Math.log2(this.totalNumTxs)) - 1);
+  }
+
+  // Calculates the index and level of the parent rollup circuit
+  // Based on tree implementation in unbalanced_tree.ts -> batchInsert()
+  public findMergeLevel(currentLevel: bigint, currentIndex: bigint) {
+    const moveUpMergeLevel = (levelSize: number, index: bigint, nodeToShift: boolean) => {
+      levelSize /= 2;
+      if (levelSize & 1) {
+        [levelSize, nodeToShift] = nodeToShift ? [levelSize + 1, false] : [levelSize - 1, true];
+      }
+      index >>= 1n;
+      return { thisLevelSize: levelSize, thisIndex: index, shiftUp: nodeToShift };
+    };
+    let [thisLevelSize, shiftUp] = this.totalNumTxs & 1 ? [this.totalNumTxs - 1, true] : [this.totalNumTxs, false];
+    const maxLevel = this.numMergeLevels + 1n;
+    let placeholder = currentIndex;
+    for (let i = 0; i < maxLevel - currentLevel; i++) {
+      ({ thisLevelSize, thisIndex: placeholder, shiftUp } = moveUpMergeLevel(thisLevelSize, placeholder, shiftUp));
+    }
+    let thisIndex = currentIndex;
+    let mergeLevel = currentLevel;
+    while (thisIndex >= thisLevelSize && mergeLevel != 0n) {
+      mergeLevel -= 1n;
+      ({ thisLevelSize, thisIndex, shiftUp } = moveUpMergeLevel(thisLevelSize, thisIndex, shiftUp));
+    }
+    return [mergeLevel - 1n, thisIndex >> 1n, thisIndex & 1n];
+  }
+
+  // Adds a transaction to the proving state, returns it's index
+  public addNewTx(tx: TxProvingState) {
+    this.txs.push(tx);
+    return this.txs.length - 1;
+  }
+
+  // Returns the number of received transactions
+  public get transactionsReceived() {
+    return this.txs.length;
+  }
+
+  // Returns the final set of root parity inputs
+  public get finalRootParityInput() {
+    return this.finalRootParityInputs;
+  }
+
+  // Sets the final set of root parity inputs
+  public set finalRootParityInput(input: RootParityInput<typeof NESTED_RECURSIVE_PROOF_LENGTH> | undefined) {
+    this.finalRootParityInputs = input;
+  }
+
+  // Returns the set of root parity inputs
+  public get rootParityInput() {
+    return this.rootParityInputs;
+  }
+
+  // Returns the complete set of transaction proving state objects
+  public get allTxs() {
+    return this.txs;
+  }
+
+  /** Returns the block number as an epoch number. Used for prioritizing proof requests. */
+  public get epochNumber(): number {
+    return this.globalVariables.blockNumber.toNumber();
+  }
+
+  /**
+   * Stores the inputs to a merge circuit and determines if the circuit is ready to be executed
+   * @param mergeInputs - The inputs to store
+   * @param indexWithinMerge - The index in the set of inputs to this merge circuit
+   * @param indexOfMerge - The global index of this merge circuit
+   * @returns True if the merge circuit is ready to be executed, false otherwise
+   */
+  public storeMergeInputs(
+    mergeInputs: [
+      BaseOrMergeRollupPublicInputs,
+      RecursiveProof<typeof NESTED_RECURSIVE_PROOF_LENGTH>,
+      VerificationKeyAsFields,
+    ],
+    indexWithinMerge: number,
+    indexOfMerge: number,
+  ) {
+    if (!this.mergeRollupInputs[indexOfMerge]) {
+      const mergeInputData: MergeRollupInputData = {
+        inputs: [undefined, undefined],
+        proofs: [undefined, undefined],
+        verificationKeys: [undefined, undefined],
+      };
+      mergeInputData.inputs[indexWithinMerge] = mergeInputs[0];
+      mergeInputData.proofs[indexWithinMerge] = mergeInputs[1];
+      mergeInputData.verificationKeys[indexWithinMerge] = mergeInputs[2];
+      this.mergeRollupInputs[indexOfMerge] = mergeInputData;
+      return false;
+    }
+    const mergeInputData = this.mergeRollupInputs[indexOfMerge];
+    mergeInputData.inputs[indexWithinMerge] = mergeInputs[0];
+    mergeInputData.proofs[indexWithinMerge] = mergeInputs[1];
+    mergeInputData.verificationKeys[indexWithinMerge] = mergeInputs[2];
+    return true;
+  }
+
+  // Returns a specific transaction proving state
+  public getTxProvingState(txIndex: number) {
+    return this.txs[txIndex];
+  }
+
+  // Returns a set of merge rollup inputs
+  public getMergeInputs(indexOfMerge: number) {
+    return this.mergeRollupInputs[indexOfMerge];
+  }
+
+  // Returns true if we have sufficient inputs to execute the block root rollup
+  public isReadyForBlockRootRollup() {
+    return !(
+      this.mergeRollupInputs[0] === undefined ||
+      this.finalRootParityInput === undefined ||
+      this.mergeRollupInputs[0].inputs.findIndex(p => !p) !== -1
+    );
+  }
+
+  // Stores a set of root parity inputs at the given index
+  public setRootParityInputs(inputs: RootParityInput<typeof RECURSIVE_PROOF_LENGTH>, index: number) {
+    this.rootParityInputs[index] = inputs;
+  }
+
+  // Returns true if we have sufficient root parity inputs to execute the root parity circuit
+  public areRootParityInputsReady() {
+    return this.rootParityInputs.findIndex(p => !p) === -1;
+  }
+
+  // Returns true if we are still able to accept transactions, false otherwise
+  public isAcceptingTransactions() {
+    return (
+      this.provingStateLifecycle === PROVING_STATE_LIFECYCLE.PROVING_STATE_CREATED && this.totalNumTxs > this.txs.length
+    );
+  }
+
+  // Returns true if this proving state is still valid, false otherwise
+  public verifyState() {
+    return this.provingStateLifecycle === PROVING_STATE_LIFECYCLE.PROVING_STATE_CREATED;
+  }
+
+  // Attempts to reject the proving state promise with the given reason
+  public reject(reason: string) {
+    if (!this.verifyState()) {
+      return;
+    }
+    this.provingStateLifecycle = PROVING_STATE_LIFECYCLE.PROVING_STATE_REJECTED;
+    if (this.rejectionCallback) {
+      this.rejectionCallback(reason);
+    }
+  }
+
+  // Attempts to resolve the proving state promise with the given result
+  public resolve(result: ProvingResult) {
+    if (!this.verifyState()) {
+      return;
+    }
+    this.provingStateLifecycle = PROVING_STATE_LIFECYCLE.PROVING_STATE_RESOLVED;
+    if (this.completionCallback) {
+      this.completionCallback(result);
+    }
+  }
+}

--- a/yarn-project/prover-client/src/orchestrator/epoch-proving-state.ts
+++ b/yarn-project/prover-client/src/orchestrator/epoch-proving-state.ts
@@ -1,31 +1,22 @@
-import { type L2Block, type MerkleTreeId, type ProvingResult } from '@aztec/circuit-types';
+import { type MerkleTreeId, type ProvingResult } from '@aztec/circuit-types';
 import {
+  type ARCHIVE_HEIGHT,
   type AppendOnlyTreeSnapshot,
-  type BaseOrMergeRollupPublicInputs,
   type BlockRootOrBlockMergePublicInputs,
-  type Fr,
+  Fr,
   type GlobalVariables,
   type L1_TO_L2_MSG_SUBTREE_SIBLING_PATH_LENGTH,
   type NESTED_RECURSIVE_PROOF_LENGTH,
-  type NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
+  NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
   type Proof,
-  type RECURSIVE_PROOF_LENGTH,
   type RecursiveProof,
-  type RootParityInput,
+  type RootRollupPublicInputs,
   type VerificationKeyAsFields,
 } from '@aztec/circuits.js';
+import { padArrayEnd } from '@aztec/foundation/collection';
 import { type Tuple } from '@aztec/foundation/serialize';
 
-import { type TxProvingState } from './tx-proving-state.js';
-
-export type MergeRollupInputData = {
-  inputs: [BaseOrMergeRollupPublicInputs | undefined, BaseOrMergeRollupPublicInputs | undefined];
-  proofs: [
-    RecursiveProof<typeof NESTED_RECURSIVE_PROOF_LENGTH> | undefined,
-    RecursiveProof<typeof NESTED_RECURSIVE_PROOF_LENGTH> | undefined,
-  ];
-  verificationKeys: [VerificationKeyAsFields | undefined, VerificationKeyAsFields | undefined];
-};
+import { BlockProvingState } from './block-proving-state.js';
 
 export type TreeSnapshots = Map<MerkleTreeId, AppendOnlyTreeSnapshot>;
 
@@ -36,40 +27,49 @@ enum PROVING_STATE_LIFECYCLE {
   PROVING_STATE_REJECTED,
 }
 
+export type BlockMergeRollupInputData = {
+  inputs: [BlockRootOrBlockMergePublicInputs | undefined, BlockRootOrBlockMergePublicInputs | undefined];
+  proofs: [
+    RecursiveProof<typeof NESTED_RECURSIVE_PROOF_LENGTH> | undefined,
+    RecursiveProof<typeof NESTED_RECURSIVE_PROOF_LENGTH> | undefined,
+  ];
+  verificationKeys: [VerificationKeyAsFields | undefined, VerificationKeyAsFields | undefined];
+};
+
 /**
- * The current state of the proving schedule. Contains the raw inputs (txs) and intermediate state to generate every constituent proof in the tree.
+ * The current state of the proving schedule for an epoch.
+ * Contains the raw inputs and intermediate state to generate every constituent proof in the tree.
  * Carries an identifier so we can identify if the proving state is discarded and a new one started.
  * Captures resolve and reject callbacks to provide a promise base interface to the consumer of our proving.
  */
-export class ProvingState {
+export class EpochProvingState {
   private provingStateLifecycle = PROVING_STATE_LIFECYCLE.PROVING_STATE_CREATED;
-  private mergeRollupInputs: MergeRollupInputData[] = [];
-  private rootParityInputs: Array<RootParityInput<typeof RECURSIVE_PROOF_LENGTH> | undefined> = [];
-  private finalRootParityInputs: RootParityInput<typeof NESTED_RECURSIVE_PROOF_LENGTH> | undefined;
-  public blockRootRollupPublicInputs: BlockRootOrBlockMergePublicInputs | undefined;
+
+  private mergeRollupInputs: BlockMergeRollupInputData[] = [];
+  public rootRollupPublicInputs: RootRollupPublicInputs | undefined;
   public finalProof: Proof | undefined;
-  public block: L2Block | undefined;
-  private txs: TxProvingState[] = [];
+  public blocks: BlockProvingState[] = [];
+
   constructor(
-    public readonly totalNumTxs: number,
+    public readonly epochNumber: number,
+    public readonly totalNumBlocks: number,
     private completionCallback: (result: ProvingResult) => void,
     private rejectionCallback: (reason: string) => void,
-    public readonly globalVariables: GlobalVariables,
-    public readonly newL1ToL2Messages: Tuple<Fr, typeof NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP>,
-    numRootParityInputs: number,
-    public readonly messageTreeSnapshot: AppendOnlyTreeSnapshot,
-    public readonly messageTreeRootSiblingPath: Tuple<Fr, typeof L1_TO_L2_MSG_SUBTREE_SIBLING_PATH_LENGTH>,
-  ) {
-    this.rootParityInputs = Array.from({ length: numRootParityInputs }).map(_ => undefined);
+  ) {}
+
+  /** Returns the current block proving state */
+  public get currentBlock(): BlockProvingState | undefined {
+    return this.blocks[this.blocks.length - 1];
   }
 
   // Returns the number of levels of merge rollups
   public get numMergeLevels() {
-    return BigInt(Math.ceil(Math.log2(this.totalNumTxs)) - 1);
+    return BigInt(Math.ceil(Math.log2(this.totalNumBlocks)) - 1);
   }
 
   // Calculates the index and level of the parent rollup circuit
   // Based on tree implementation in unbalanced_tree.ts -> batchInsert()
+  // REFACTOR: This is repeated from the block orchestrator
   public findMergeLevel(currentLevel: bigint, currentIndex: bigint) {
     const moveUpMergeLevel = (levelSize: number, index: bigint, nodeToShift: boolean) => {
       levelSize /= 2;
@@ -79,7 +79,8 @@ export class ProvingState {
       index >>= 1n;
       return { thisLevelSize: levelSize, thisIndex: index, shiftUp: nodeToShift };
     };
-    let [thisLevelSize, shiftUp] = this.totalNumTxs & 1 ? [this.totalNumTxs - 1, true] : [this.totalNumTxs, false];
+    let [thisLevelSize, shiftUp] =
+      this.totalNumBlocks & 1 ? [this.totalNumBlocks - 1, true] : [this.totalNumBlocks, false];
     const maxLevel = this.numMergeLevels + 1n;
     let placeholder = currentIndex;
     for (let i = 0; i < maxLevel - currentLevel; i++) {
@@ -94,34 +95,47 @@ export class ProvingState {
     return [mergeLevel - 1n, thisIndex >> 1n, thisIndex & 1n];
   }
 
-  // Adds a transaction to the proving state, returns it's index
-  // Will update the proving life cycle if this is the last transaction
-  public addNewTx(tx: TxProvingState) {
-    this.txs.push(tx);
-    if (this.txs.length === this.totalNumTxs) {
+  // Adds a block to the proving state, returns its index
+  // Will update the proving life cycle if this is the last block
+  public startNewBlock(
+    numTxs: number,
+    globalVariables: GlobalVariables,
+    l1ToL2Messages: Fr[],
+    messageTreeSnapshot: AppendOnlyTreeSnapshot,
+    messageTreeRootSiblingPath: Tuple<Fr, typeof L1_TO_L2_MSG_SUBTREE_SIBLING_PATH_LENGTH>,
+    messageTreeSnapshotAfterInsertion: AppendOnlyTreeSnapshot,
+    archiveTreeSnapshot: AppendOnlyTreeSnapshot,
+    archiveTreeRootSiblingPath: Tuple<Fr, typeof ARCHIVE_HEIGHT>,
+    previousBlockHash: Fr,
+    completionCallback?: (result: ProvingResult) => void,
+    rejectionCallback?: (reason: string) => void,
+  ) {
+    const block = new BlockProvingState(
+      this.blocks.length,
+      numTxs,
+      globalVariables,
+      padArrayEnd(l1ToL2Messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP),
+      messageTreeSnapshot,
+      messageTreeRootSiblingPath,
+      messageTreeSnapshotAfterInsertion,
+      archiveTreeSnapshot,
+      archiveTreeRootSiblingPath,
+      previousBlockHash,
+      completionCallback,
+      reason => {
+        // Reject the block
+        if (rejectionCallback) {
+          rejectionCallback(reason);
+        }
+        // An error on any block rejects this whole epoch
+        this.reject(reason);
+      },
+    );
+    this.blocks.push(block);
+    if (this.blocks.length === this.totalNumBlocks) {
       this.provingStateLifecycle = PROVING_STATE_LIFECYCLE.PROVING_STATE_FULL;
     }
-    return this.txs.length - 1;
-  }
-
-  // Returns the number of received transactions
-  public get transactionsReceived() {
-    return this.txs.length;
-  }
-
-  // Returns the final set of root parity inputs
-  public get finalRootParityInput() {
-    return this.finalRootParityInputs;
-  }
-
-  // Sets the final set of root parity inputs
-  public set finalRootParityInput(input: RootParityInput<typeof NESTED_RECURSIVE_PROOF_LENGTH> | undefined) {
-    this.finalRootParityInputs = input;
-  }
-
-  // Returns the set of root parity inputs
-  public get rootParityInput() {
-    return this.rootParityInputs;
+    return this.blocks.length - 1;
   }
 
   // Returns true if this proving state is still valid, false otherwise
@@ -132,19 +146,9 @@ export class ProvingState {
     );
   }
 
-  // Returns true if we are still able to accept transactions, false otherwise
-  public isAcceptingTransactions() {
+  // Returns true if we are still able to accept blocks, false otherwise
+  public isAcceptingBlocks() {
     return this.provingStateLifecycle === PROVING_STATE_LIFECYCLE.PROVING_STATE_CREATED;
-  }
-
-  // Returns the complete set of transaction proving state objects
-  public get allTxs() {
-    return this.txs;
-  }
-
-  /** Returns the block number as an epoch number. Used for prioritizing proof requests. */
-  public get epochNumber(): number {
-    return this.globalVariables.blockNumber.toNumber();
   }
 
   /**
@@ -156,7 +160,7 @@ export class ProvingState {
    */
   public storeMergeInputs(
     mergeInputs: [
-      BaseOrMergeRollupPublicInputs,
+      BlockRootOrBlockMergePublicInputs,
       RecursiveProof<typeof NESTED_RECURSIVE_PROOF_LENGTH>,
       VerificationKeyAsFields,
     ],
@@ -164,7 +168,7 @@ export class ProvingState {
     indexOfMerge: number,
   ) {
     if (!this.mergeRollupInputs[indexOfMerge]) {
-      const mergeInputData: MergeRollupInputData = {
+      const mergeInputData: BlockMergeRollupInputData = {
         inputs: [undefined, undefined],
         proofs: [undefined, undefined],
         verificationKeys: [undefined, undefined],
@@ -183,8 +187,8 @@ export class ProvingState {
   }
 
   // Returns a specific transaction proving state
-  public getTxProvingState(txIndex: number) {
-    return this.txs[txIndex];
+  public getBlockProvingState(index: number) {
+    return this.blocks[index];
   }
 
   // Returns a set of merge rollup inputs
@@ -193,22 +197,8 @@ export class ProvingState {
   }
 
   // Returns true if we have sufficient inputs to execute the block root rollup
-  public isReadyForBlockRootRollup() {
-    return !(
-      this.mergeRollupInputs[0] === undefined ||
-      this.finalRootParityInput === undefined ||
-      this.mergeRollupInputs[0].inputs.findIndex(p => !p) !== -1
-    );
-  }
-
-  // Stores a set of root parity inputs at the given index
-  public setRootParityInputs(inputs: RootParityInput<typeof RECURSIVE_PROOF_LENGTH>, index: number) {
-    this.rootParityInputs[index] = inputs;
-  }
-
-  // Returns true if we have sufficient root parity inputs to execute the root parity circuit
-  public areRootParityInputsReady() {
-    return this.rootParityInputs.findIndex(p => !p) === -1;
+  public isReadyForRootRollup() {
+    return !(this.mergeRollupInputs[0] === undefined || this.mergeRollupInputs[0].inputs.findIndex(p => !p) !== -1);
   }
 
   // Attempts to reject the proving state promise with a reason of 'cancelled'
@@ -224,6 +214,10 @@ export class ProvingState {
     }
     this.provingStateLifecycle = PROVING_STATE_LIFECYCLE.PROVING_STATE_REJECTED;
     this.rejectionCallback(reason);
+
+    for (const block of this.blocks) {
+      block.reject('Proving cancelled');
+    }
   }
 
   // Attempts to resolve the proving state promise with the given result

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -901,7 +901,14 @@ export class ProvingOrchestrator implements EpochProver {
         provingState.resolve({ status: PROVING_STATUS.SUCCESS });
 
         logger.debug(`Completed proof for block root rollup for ${provingState.block?.number}`);
-        // validatePartialState(result.inputs.end, tx.treeSnapshots); // TODO(palla)
+        // validatePartialState(result.inputs.end, tx.treeSnapshots); // TODO(palla/prover)
+
+        // TODO(palla/prover): Remove this once we've dropped the flow for proving single blocks
+        if (this.provingState?.totalNumBlocks === 1) {
+          logger.verbose(`Skipping epoch rollup, only one block in epoch`);
+          return;
+        }
+
         const currentLevel = this.provingState!.numMergeLevels + 1n;
         this.storeAndExecuteNextBlockMergeLevel(this.provingState!, currentLevel, BigInt(provingState.index), [
           result.inputs,

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -17,7 +17,7 @@ import {
 } from '@aztec/circuit-types';
 import {
   BlockProofError,
-  type BlockProver,
+  type EpochProver,
   PROVING_STATUS,
   type ProvingBlockResult,
   type ProvingResult,
@@ -31,6 +31,8 @@ import {
   type BaseOrMergeRollupPublicInputs,
   BaseParityInputs,
   type BaseRollupInputs,
+  type BlockRootOrBlockMergePublicInputs,
+  BlockRootRollupInputs,
   Fr,
   type GlobalVariables,
   type KernelCircuitPublicInputs,
@@ -70,16 +72,20 @@ import { inspect } from 'util';
 import {
   buildBaseRollupInput,
   buildHeaderFromCircuitOutputs,
+  buildHeaderFromTxEffects,
+  createBlockMergeRollupInputs,
   createMergeRollupInputs,
-  getBlockRootRollupInput,
+  getPreviousRollupDataFromPublicInputs,
+  getRootRollupInput,
+  getRootTreeSiblingPath,
   getSubtreeSiblingPath,
   getTreeSnapshot,
-  validateBlockRootOutput,
   validatePartialState,
   validateTx,
 } from './block-building-helpers.js';
+import { type BlockProvingState, type MergeRollupInputData } from './block-proving-state.js';
+import { type BlockMergeRollupInputData, EpochProvingState, type TreeSnapshots } from './epoch-proving-state.js';
 import { ProvingOrchestratorMetrics } from './orchestrator_metrics.js';
-import { type MergeRollupInputData, ProvingState, type TreeSnapshots } from './proving-state.js';
 import { TX_PROVING_CODE, type TxProvingInstruction, TxProvingState } from './tx-proving-state.js';
 
 const logger = createDebugLogger('aztec:prover:proving-orchestrator');
@@ -98,8 +104,8 @@ const logger = createDebugLogger('aztec:prover:proving-orchestrator');
 /**
  * The orchestrator, managing the flow of recursive proving operations required to build the rollup proof tree.
  */
-export class ProvingOrchestrator implements BlockProver {
-  private provingState: ProvingState | undefined = undefined;
+export class ProvingOrchestrator implements EpochProver {
+  private provingState: EpochProvingState | undefined = undefined;
   private pendingProvingJobs: AbortController[] = [];
   private paddingTx: PaddingProcessedTx | undefined = undefined;
 
@@ -129,6 +135,23 @@ export class ProvingOrchestrator implements BlockProver {
     this.paddingTx = undefined;
   }
 
+  @trackSpan('ProvingOrchestrator.startNewEpoch', (epochNumber, totalNumBlocks) => ({
+    [Attributes.EPOCH_SIZE]: totalNumBlocks,
+    [Attributes.EPOCH_NUMBER]: epochNumber,
+  }))
+  public startNewEpoch(epochNumber: number, totalNumBlocks: number): ProvingTicket {
+    const { promise: _promise, resolve, reject } = promiseWithResolvers<ProvingResult>();
+    const promise = _promise.catch(
+      (reason): ProvingResult => ({
+        status: PROVING_STATUS.FAILURE,
+        reason,
+      }),
+    );
+
+    this.provingState = new EpochProvingState(epochNumber, totalNumBlocks, resolve, reject);
+    return { provingPromise: promise };
+  }
+
   /**
    * Starts off a new block
    * @param numTxs - The total number of transactions in the block. Must be a power of 2
@@ -146,6 +169,15 @@ export class ProvingOrchestrator implements BlockProver {
     globalVariables: GlobalVariables,
     l1ToL2Messages: Fr[],
   ): Promise<ProvingTicket> {
+    // If no proving state, assume we only care about proving this block and initialize a 1-block epoch
+    if (!this.provingState) {
+      this.startNewEpoch(globalVariables.blockNumber.toNumber(), 1);
+    }
+
+    if (!this.provingState?.isAcceptingBlocks()) {
+      throw new Error(`Epoch not accepting further blocks`);
+    }
+
     if (!Number.isInteger(numTxs) || numTxs < 2) {
       throw new Error(`Length of txs for the block should be at least two (got ${numTxs})`);
     }
@@ -160,11 +192,10 @@ export class ProvingOrchestrator implements BlockProver {
       );
     }
 
-    // Cancel any currently proving block before starting a new one
-    this.cancelBlock();
     logger.info(
       `Starting block ${globalVariables.blockNumber} for slot ${globalVariables.slotNumber} with ${numTxs} transactions`,
     );
+
     // we start the block by enqueueing all of the base parity circuits
     let baseParityInputs: BaseParityInputs[] = [];
     let l1ToL2MessagesPadded: Tuple<Fr, typeof NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP>;
@@ -194,36 +225,39 @@ export class ProvingOrchestrator implements BlockProver {
 
     // Update the local trees to include the new l1 to l2 messages
     await this.db.appendLeaves(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, l1ToL2MessagesPadded);
+    const messageTreeSnapshotAfterInsertion = await getTreeSnapshot(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, this.db);
+
+    // Get archive snapshot before this block lands
+    const startArchiveSnapshot = await getTreeSnapshot(MerkleTreeId.ARCHIVE, this.db);
+    const newArchiveSiblingPath = await getRootTreeSiblingPath(MerkleTreeId.ARCHIVE, this.db);
+    const previousBlockHash = await this.db.getLeafValue(
+      MerkleTreeId.ARCHIVE,
+      BigInt(startArchiveSnapshot.nextAvailableLeafIndex - 1),
+    );
 
     const { promise: _promise, resolve, reject } = promiseWithResolvers<ProvingResult>();
-    const promise = _promise.catch(
-      (reason): ProvingResult => ({
-        status: PROVING_STATUS.FAILURE,
-        reason,
-      }),
-    );
+    const promise = _promise.catch((reason): ProvingResult => ({ status: PROVING_STATUS.FAILURE, reason }));
 
-    const provingState = new ProvingState(
+    this.provingState!.startNewBlock(
       numTxs,
-      resolve,
-      reject,
       globalVariables,
       l1ToL2MessagesPadded,
-      baseParityInputs.length,
       messageTreeSnapshot,
       newL1ToL2MessageTreeRootSiblingPath,
+      messageTreeSnapshotAfterInsertion,
+      startArchiveSnapshot,
+      newArchiveSiblingPath,
+      previousBlockHash!,
+      resolve,
+      reject,
     );
 
+    // Enqueue base parity circuits for the block
     for (let i = 0; i < baseParityInputs.length; i++) {
-      this.enqueueBaseParityCircuit(provingState, baseParityInputs[i], i);
+      this.enqueueBaseParityCircuit(this.provingState!.currentBlock!, baseParityInputs[i], i);
     }
 
-    this.provingState = provingState;
-
-    const ticket: ProvingTicket = {
-      provingPromise: promise,
-    };
-    return ticket;
+    return { provingPromise: promise };
   }
 
   /**
@@ -234,11 +268,12 @@ export class ProvingOrchestrator implements BlockProver {
     [Attributes.TX_HASH]: tx.hash.toString(),
   }))
   public async addNewTx(tx: ProcessedTx): Promise<void> {
-    if (!this.provingState) {
+    const provingState = this?.provingState?.currentBlock;
+    if (!provingState) {
       throw new Error(`Invalid proving state, call startNewBlock before adding transactions`);
     }
 
-    if (!this.provingState.isAcceptingTransactions()) {
+    if (!provingState.isAcceptingTransactions()) {
       throw new Error(`Rollup not accepting further transactions`);
     }
 
@@ -251,34 +286,43 @@ export class ProvingOrchestrator implements BlockProver {
       return;
     }
 
-    const [inputs, treeSnapshots] = await this.prepareTransaction(tx, this.provingState);
-    this.enqueueFirstProofs(inputs, treeSnapshots, tx, this.provingState);
+    const [inputs, treeSnapshots] = await this.prepareTransaction(tx, provingState);
+    this.enqueueFirstProofs(inputs, treeSnapshots, tx, provingState);
+
+    if (provingState.transactionsReceived === provingState.totalNumTxs) {
+      logger.verbose(
+        `All transactions received for block ${provingState.globalVariables.blockNumber}. Assembling header.`,
+      );
+      await this.buildBlockHeader(provingState);
+    }
   }
 
   /**
    * Marks the block as full and pads it if required, no more transactions will be accepted.
+   * Computes the block header and updates the archive tree.
    */
   @trackSpan('ProvingOrchestrator.setBlockCompleted', function () {
-    if (!this.provingState) {
+    const block = this.provingState?.currentBlock;
+    if (!block) {
       return {};
     }
-
     return {
-      [Attributes.BLOCK_NUMBER]: this.provingState!.globalVariables.blockNumber.toNumber(),
-      [Attributes.BLOCK_SIZE]: this.provingState!.totalNumTxs,
-      [Attributes.BLOCK_TXS_COUNT]: this.provingState!.transactionsReceived,
+      [Attributes.BLOCK_NUMBER]: block.globalVariables.blockNumber.toNumber(),
+      [Attributes.BLOCK_SIZE]: block.totalNumTxs,
+      [Attributes.BLOCK_TXS_COUNT]: block.transactionsReceived,
     };
   })
   public async setBlockCompleted() {
-    if (!this.provingState) {
+    const provingState = this.provingState?.currentBlock;
+    if (!provingState) {
       throw new Error(`Invalid proving state, call startNewBlock before adding transactions or completing the block`);
     }
 
     // we may need to pad the rollup with empty transactions
-    const paddingTxCount = this.provingState.totalNumTxs - this.provingState.transactionsReceived;
+    const paddingTxCount = provingState.totalNumTxs - provingState.transactionsReceived;
     if (paddingTxCount === 0) {
       return;
-    } else if (this.provingState.totalNumTxs > 2) {
+    } else if (provingState.totalNumTxs > 2) {
       throw new Error(`Block not ready for completion: expecting ${paddingTxCount} more transactions.`);
     }
 
@@ -292,13 +336,13 @@ export class ProvingOrchestrator implements BlockProver {
     // Then enqueue the proving of all the transactions
     const unprovenPaddingTx = makeEmptyProcessedTx(
       this.db.getInitialHeader(),
-      this.provingState.globalVariables.chainId,
-      this.provingState.globalVariables.version,
+      provingState.globalVariables.chainId,
+      provingState.globalVariables.version,
       getVKTreeRoot(),
     );
     const txInputs: Array<{ inputs: BaseRollupInputs; snapshot: TreeSnapshots }> = [];
     for (let i = 0; i < paddingTxCount; i++) {
-      const [inputs, snapshot] = await this.prepareTransaction(unprovenPaddingTx, this.provingState);
+      const [inputs, snapshot] = await this.prepareTransaction(unprovenPaddingTx, provingState);
       const txInput = {
         inputs,
         snapshot,
@@ -307,13 +351,53 @@ export class ProvingOrchestrator implements BlockProver {
     }
 
     // Now enqueue the proving
-    this.enqueuePaddingTxs(this.provingState, txInputs, unprovenPaddingTx);
+    this.enqueuePaddingTxs(provingState, txInputs, unprovenPaddingTx);
+
+    // And build the block header
+    logger.verbose(`Block ${provingState.globalVariables.blockNumber} padded with empty tx(s). Assembling header.`);
+    await this.buildBlockHeader(provingState);
+  }
+
+  private async buildBlockHeader(provingState: BlockProvingState) {
+    // Collect all new nullifiers, commitments, and contracts from all txs in this block to build body
+    const gasFees = provingState.globalVariables.gasFees;
+    const nonEmptyTxEffects: TxEffect[] = provingState!.allTxs
+      .map(txProvingState => toTxEffect(txProvingState.processedTx, gasFees))
+      .filter(txEffect => !txEffect.isEmpty());
+    const body = new Body(nonEmptyTxEffects);
+
+    // Given we've applied every change from this block, now assemble the block header
+    // and update the archive tree, so we're ready to start processing the next block
+    const header = await buildHeaderFromTxEffects(
+      body,
+      provingState.globalVariables,
+      provingState.newL1ToL2Messages,
+      this.db,
+    );
+
+    logger.verbose(`Updating archive tree with block ${provingState.blockNumber} header ${header.hash().toString()}`);
+    await this.db.updateArchive(header);
+
+    // Assemble the L2 block
+    const newArchive = await getTreeSnapshot(MerkleTreeId.ARCHIVE, this.db);
+    const l2Block = L2Block.fromFields({ archive: newArchive, header, body });
+
+    if (!l2Block.body.getTxsEffectsHash().equals(header.contentCommitment.txsEffectsHash)) {
+      throw new Error(
+        `Txs effects hash mismatch, ${l2Block.body
+          .getTxsEffectsHash()
+          .toString('hex')} == ${header.contentCommitment.txsEffectsHash.toString('hex')} `,
+      );
+    }
+
+    logger.verbose(`Orchestrator finalised block ${l2Block.number}`);
+    provingState.block = l2Block;
   }
 
   // Enqueues the proving of the required padding transactions
   // If the fully proven padding transaction is not available, this will first be proven
   private enqueuePaddingTxs(
-    provingState: ProvingState,
+    provingState: BlockProvingState,
     txInputs: Array<{ inputs: BaseRollupInputs; snapshot: TreeSnapshots }>,
     unprovenPaddingTx: ProcessedTx,
   ) {
@@ -331,7 +415,7 @@ export class ProvingOrchestrator implements BlockProver {
         'ProvingOrchestrator.prover.getEmptyPrivateKernelProof',
         {
           [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
-          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'private-kernel-empty' as CircuitName,
+          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'private-kernel-empty' satisfies CircuitName,
         },
         signal =>
           this.prover.getEmptyPrivateKernelProof(
@@ -365,7 +449,7 @@ export class ProvingOrchestrator implements BlockProver {
   private provePaddingTransactions(
     txInputs: Array<{ inputs: BaseRollupInputs; snapshot: TreeSnapshots }>,
     paddingTx: PaddingProcessedTx,
-    provingState: ProvingState,
+    provingState: BlockProvingState,
   ) {
     // The padding tx contains the proof and vk, generated separately from the base inputs
     // Copy these into the base rollup inputs and enqueue the base rollup proof
@@ -382,9 +466,9 @@ export class ProvingOrchestrator implements BlockProver {
   }
 
   /**
-   * Cancel any further proving of the block
+   * Cancel any further proving
    */
-  public cancelBlock() {
+  public cancel() {
     for (const controller of this.pendingProvingJobs) {
       controller.abort();
     }
@@ -394,110 +478,75 @@ export class ProvingOrchestrator implements BlockProver {
 
   /**
    * Extract the block header from public inputs.
-   * TODO(#7346): Refactor this once new batch rollup circuits are integrated
    * @returns The header of this proving state's block.
    */
-  private async extractBlockHeader() {
-    if (
-      !this.provingState ||
-      !this.provingState.blockRootRollupPublicInputs ||
-      !this.provingState.finalRootParityInput?.publicInputs.shaRoot
-    ) {
-      throw new Error(`Invalid proving state, a block must be proven before its header can be extracted.`);
-    }
-
-    const rootRollupOutputs = this.provingState.blockRootRollupPublicInputs;
-    const previousMergeData = this.provingState.getMergeInputs(0).inputs;
+  private extractBlockHeaderFromPublicInputs(
+    provingState: BlockProvingState,
+    rootRollupOutputs: BlockRootOrBlockMergePublicInputs,
+  ) {
+    const previousMergeData = provingState.getMergeInputs(0).inputs;
 
     if (!previousMergeData[0] || !previousMergeData[1]) {
       throw new Error(`Invalid proving state, final merge inputs before block root circuit missing.`);
     }
 
-    const l1ToL2TreeSnapshot = await getTreeSnapshot(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, this.db);
-
     return buildHeaderFromCircuitOutputs(
       [previousMergeData[0], previousMergeData[1]],
-      this.provingState.finalRootParityInput.publicInputs,
+      provingState.finalRootParityInput!.publicInputs,
       rootRollupOutputs,
-      l1ToL2TreeSnapshot,
+      provingState.messageTreeSnapshotAfterInsertion,
+      logger,
     );
   }
 
   /**
-   * Performs the final tree update for the block and returns the fully proven block.
+   * Returns the fully proven block. Requires proving to have been completed.
+   * @param index - The index of the block to finalise. Defaults to the last block.
    * @returns The fully proven block and proof.
    */
-  @trackSpan('ProvingOrchestrator.finaliseBlock', function () {
-    return {
-      [Attributes.BLOCK_NUMBER]: this.provingState!.globalVariables.blockNumber.toNumber(),
-      [Attributes.BLOCK_TXS_COUNT]: this.provingState!.transactionsReceived,
-      [Attributes.BLOCK_SIZE]: this.provingState!.totalNumTxs,
-    };
-  })
-  public async finaliseBlock() {
+  public finaliseBlock(index?: number) {
     try {
-      if (!this.provingState || !this.provingState.blockRootRollupPublicInputs || !this.provingState.finalProof) {
+      const block = this.provingState?.blocks[index ?? this.provingState?.blocks.length - 1];
+
+      if (!block || !block.blockRootRollupPublicInputs || !block.finalProof || !block.block) {
         throw new Error(`Invalid proving state, a block must be proven before it can be finalised`);
       }
-      if (this.provingState.block) {
-        throw new Error('Block already finalised');
-      }
-
-      const rootRollupOutputs = this.provingState.blockRootRollupPublicInputs;
-      const header = await this.extractBlockHeader();
-
-      logger?.debug(`Updating and validating root trees`);
-      await this.db.updateArchive(header);
-
-      await validateBlockRootOutput(rootRollupOutputs, header, this.db);
-
-      // Collect all new nullifiers, commitments, and contracts from all txs in this block
-      const gasFees = this.provingState.globalVariables.gasFees;
-      const nonEmptyTxEffects: TxEffect[] = this.provingState!.allTxs.map(txProvingState =>
-        toTxEffect(txProvingState.processedTx, gasFees),
-      ).filter(txEffect => !txEffect.isEmpty());
-      const blockBody = new Body(nonEmptyTxEffects);
-
-      const l2Block = L2Block.fromFields({
-        archive: rootRollupOutputs.newArchive,
-        header: header,
-        body: blockBody,
-      });
-
-      if (!l2Block.body.getTxsEffectsHash().equals(header.contentCommitment.txsEffectsHash)) {
-        logger.debug(inspect(blockBody));
-        throw new Error(
-          `Txs effects hash mismatch, ${l2Block.body
-            .getTxsEffectsHash()
-            .toString('hex')} == ${header.contentCommitment.txsEffectsHash.toString('hex')} `,
-        );
-      }
-
-      logger.info(`Orchestrator finalised block ${l2Block.number}`);
-
-      this.provingState.block = l2Block;
 
       const blockResult: ProvingBlockResult = {
-        proof: this.provingState.finalProof,
-        aggregationObject: this.provingState.finalProof.extractAggregationObject(),
-        block: l2Block,
+        proof: block.finalProof,
+        aggregationObject: block.finalProof.extractAggregationObject(),
+        block: block.block!,
       };
 
       pushTestData('blockResults', {
         proverId: this.proverId.toString(),
         vkTreeRoot: getVKTreeRoot().toString(),
-        block: l2Block.toString(),
-        proof: this.provingState.finalProof.toString(),
+        block: blockResult.block.toString(),
+        proof: blockResult.proof.toString(),
         aggregationObject: blockResult.aggregationObject.map(x => x.toString()),
       });
 
-      return blockResult;
+      return Promise.resolve(blockResult);
     } catch (err) {
       throw new BlockProofError(
         err && typeof err === 'object' && 'message' in err ? String(err.message) : String(err),
-        this.provingState?.allTxs.map(x => Tx.getHash(x.processedTx)) ?? [],
+        this.provingState?.blocks[index ?? this.provingState?.blocks.length - 1]?.allTxs.map(x =>
+          Tx.getHash(x.processedTx),
+        ) ?? [],
       );
     }
+  }
+
+  /**
+   * Returns the proof for the current epoch.
+   * Requires proving to have been completed.
+   */
+  public finaliseEpoch() {
+    if (!this.provingState || !this.provingState.rootRollupPublicInputs || !this.provingState.finalProof) {
+      throw new Error(`Invalid proving state, an epoch must be proven before it can be finalised`);
+    }
+
+    return { proof: this.provingState.finalProof, publicInputs: this.provingState.rootRollupPublicInputs };
   }
 
   /**
@@ -505,7 +554,7 @@ export class ProvingOrchestrator implements BlockProver {
    * @param tx - The transaction whose proving we wish to commence
    * @param provingState - The proving state being worked on
    */
-  private async prepareTransaction(tx: ProcessedTx, provingState: ProvingState) {
+  private async prepareTransaction(tx: ProcessedTx, provingState: BlockProvingState) {
     const txInputs = await this.prepareBaseRollupInputs(provingState, tx);
     if (!txInputs) {
       // This should not be possible
@@ -518,7 +567,7 @@ export class ProvingOrchestrator implements BlockProver {
     inputs: BaseRollupInputs,
     treeSnapshots: TreeSnapshots,
     tx: ProcessedTx,
-    provingState: ProvingState,
+    provingState: BlockProvingState,
   ) {
     const txProvingState = new TxProvingState(tx, inputs, treeSnapshots);
     const txIndex = provingState.addNewTx(txProvingState);
@@ -539,7 +588,7 @@ export class ProvingOrchestrator implements BlockProver {
    * @param job - The actual job, returns a promise notifying of the job's completion
    */
   private deferredProving<T>(
-    provingState: ProvingState | undefined,
+    provingState: EpochProvingState | BlockProvingState | undefined,
     request: (signal: AbortSignal) => Promise<T>,
     callback: (result: T) => void | Promise<void>,
   ) {
@@ -599,7 +648,7 @@ export class ProvingOrchestrator implements BlockProver {
     [Attributes.TX_HASH]: tx.hash.toString(),
   }))
   private async prepareBaseRollupInputs(
-    provingState: ProvingState | undefined,
+    provingState: BlockProvingState | undefined,
     tx: ProcessedTx,
   ): Promise<[BaseRollupInputs, TreeSnapshots] | undefined> {
     if (!provingState?.verifyState()) {
@@ -637,34 +686,9 @@ export class ProvingOrchestrator implements BlockProver {
     return [inputs, treeSnapshots];
   }
 
-  // Stores the intermediate inputs prepared for a merge proof
-  private storeMergeInputs(
-    provingState: ProvingState,
-    currentLevel: bigint,
-    currentIndex: bigint,
-    mergeInputs: [
-      BaseOrMergeRollupPublicInputs,
-      RecursiveProof<typeof NESTED_RECURSIVE_PROOF_LENGTH>,
-      VerificationKeyAsFields,
-    ],
-  ) {
-    const [mergeLevel, indexWithinMergeLevel, indexWithinMerge] = provingState.findMergeLevel(
-      currentLevel,
-      currentIndex,
-    );
-    const mergeIndex = 2n ** mergeLevel - 1n + indexWithinMergeLevel;
-    const ready = provingState.storeMergeInputs(mergeInputs, Number(indexWithinMerge), Number(mergeIndex));
-    return {
-      ready,
-      indexWithinMergeLevel,
-      mergeLevel,
-      mergeInputData: provingState.getMergeInputs(Number(mergeIndex)),
-    };
-  }
-
   // Executes the base rollup circuit and stored the output as intermediate state for the parent merge/root circuit
   // Executes the next level of merge if all inputs are available
-  private enqueueBaseRollup(provingState: ProvingState | undefined, index: bigint, tx: TxProvingState) {
+  private enqueueBaseRollup(provingState: BlockProvingState | undefined, index: bigint, tx: TxProvingState) {
     if (!provingState?.verifyState()) {
       logger.debug('Not running base rollup, state invalid');
       return;
@@ -725,7 +749,7 @@ export class ProvingOrchestrator implements BlockProver {
         {
           [Attributes.TX_HASH]: tx.processedTx.hash.toString(),
           [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
-          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'base-rollup' as CircuitName,
+          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'base-rollup' satisfies CircuitName,
         },
         signal => this.prover.getBaseRollupProof(tx.baseRollupInputs, signal, provingState.epochNumber),
       ),
@@ -744,7 +768,7 @@ export class ProvingOrchestrator implements BlockProver {
 
   // Enqueues the tub circuit for a given transaction index
   // Once completed, will enqueue the next circuit, either a public kernel or the base rollup
-  private enqueueTube(provingState: ProvingState, txIndex: number) {
+  private enqueueTube(provingState: BlockProvingState, txIndex: number) {
     if (!provingState?.verifyState()) {
       logger.debug('Not running tube circuit, state invalid');
       return;
@@ -761,7 +785,7 @@ export class ProvingOrchestrator implements BlockProver {
         {
           [Attributes.TX_HASH]: txProvingState.processedTx.hash.toString(),
           [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
-          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'tube-circuit' as CircuitName,
+          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'tube-circuit' satisfies CircuitName,
         },
         signal =>
           this.prover.getTubeProof(
@@ -788,7 +812,7 @@ export class ProvingOrchestrator implements BlockProver {
   // Executes the merge rollup circuit and stored the output as intermediate state for the parent merge/block root circuit
   // Enqueues the next level of merge if all inputs are available
   private enqueueMergeRollup(
-    provingState: ProvingState,
+    provingState: BlockProvingState,
     level: bigint,
     index: bigint,
     mergeInputData: MergeRollupInputData,
@@ -805,7 +829,7 @@ export class ProvingOrchestrator implements BlockProver {
         'ProvingOrchestrator.prover.getMergeRollupProof',
         {
           [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
-          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'merge-rollup' as CircuitName,
+          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'merge-rollup' satisfies CircuitName,
         },
         signal => this.prover.getMergeRollupProof(inputs, signal, provingState.epochNumber),
       ),
@@ -820,28 +844,37 @@ export class ProvingOrchestrator implements BlockProver {
   }
 
   // Executes the block root rollup circuit
-  private async enqueueBlockRootRollup(provingState: ProvingState | undefined) {
+  private enqueueBlockRootRollup(provingState: BlockProvingState | undefined) {
     if (!provingState?.verifyState()) {
-      logger.debug('Not running root rollup, state no longer valid');
+      logger.debug('Not running block root rollup, state no longer valid');
       return;
     }
     const mergeInputData = provingState.getMergeInputs(0);
     const rootParityInput = provingState.finalRootParityInput!;
 
-    const inputs = await getBlockRootRollupInput(
-      mergeInputData.inputs[0]!,
-      mergeInputData.proofs[0]!,
-      mergeInputData.verificationKeys[0]!,
-      mergeInputData.inputs[1]!,
-      mergeInputData.proofs[1]!,
-      mergeInputData.verificationKeys[1]!,
-      rootParityInput,
-      provingState.newL1ToL2Messages,
-      provingState.messageTreeSnapshot,
-      provingState.messageTreeRootSiblingPath,
-      this.db,
-      this.proverId,
+    logger.debug(
+      `Enqueuing block root rollup for block ${provingState.blockNumber} with ${provingState.newL1ToL2Messages.length} l1 to l2 msgs`,
     );
+
+    const previousRollupData: BlockRootRollupInputs['previousRollupData'] = makeTuple(2, i =>
+      getPreviousRollupDataFromPublicInputs(
+        mergeInputData.inputs[i]!,
+        mergeInputData.proofs[i]!,
+        mergeInputData.verificationKeys[i]!,
+      ),
+    );
+
+    const inputs = BlockRootRollupInputs.from({
+      previousRollupData,
+      l1ToL2Roots: rootParityInput,
+      newL1ToL2Messages: provingState.newL1ToL2Messages,
+      newL1ToL2MessageTreeRootSiblingPath: provingState.messageTreeRootSiblingPath,
+      startL1ToL2MessageTreeSnapshot: provingState.messageTreeSnapshot,
+      startArchiveSnapshot: provingState.archiveTreeSnapshot,
+      newArchiveSiblingPath: provingState.archiveTreeRootSiblingPath,
+      previousBlockHash: provingState.previousBlockHash,
+      proverId: this.proverId,
+    });
 
     this.deferredProving(
       provingState,
@@ -850,25 +883,38 @@ export class ProvingOrchestrator implements BlockProver {
         'ProvingOrchestrator.prover.getBlockRootRollupProof',
         {
           [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
-          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'block-root-rollup' as CircuitName,
+          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'block-root-rollup' satisfies CircuitName,
         },
         signal => this.prover.getBlockRootRollupProof(inputs, signal, provingState.epochNumber),
       ),
       result => {
+        const header = this.extractBlockHeaderFromPublicInputs(provingState, result.inputs);
+        if (!header.hash().equals(provingState.block!.header.hash())) {
+          logger.error(
+            `Block header mismatch\nCircuit:${inspect(header)}\nComputed:${inspect(provingState.block!.header)}`,
+          );
+          provingState.reject(`Block header hash mismatch`);
+        }
+
         provingState.blockRootRollupPublicInputs = result.inputs;
         provingState.finalProof = result.proof.binaryProof;
+        provingState.resolve({ status: PROVING_STATUS.SUCCESS });
 
-        const provingResult: ProvingResult = {
-          status: PROVING_STATUS.SUCCESS,
-        };
-        provingState.resolve(provingResult);
+        logger.debug(`Completed proof for block root rollup for ${provingState.block?.number}`);
+        // validatePartialState(result.inputs.end, tx.treeSnapshots); // TODO(palla)
+        const currentLevel = this.provingState!.numMergeLevels + 1n;
+        this.storeAndExecuteNextBlockMergeLevel(this.provingState!, currentLevel, BigInt(provingState.index), [
+          result.inputs,
+          result.proof,
+          result.verificationKey.keyAsFields,
+        ]);
       },
     );
   }
 
   // Executes the base parity circuit and stores the intermediate state for the root parity circuit
   // Enqueues the root parity circuit if all inputs are available
-  private enqueueBaseParityCircuit(provingState: ProvingState, inputs: BaseParityInputs, index: number) {
+  private enqueueBaseParityCircuit(provingState: BlockProvingState, inputs: BaseParityInputs, index: number) {
     this.deferredProving(
       provingState,
       wrapCallbackInSpan(
@@ -876,7 +922,7 @@ export class ProvingOrchestrator implements BlockProver {
         'ProvingOrchestrator.prover.getBaseParityProof',
         {
           [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
-          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'base-parity' as CircuitName,
+          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'base-parity' satisfies CircuitName,
         },
         signal => this.prover.getBaseParityProof(inputs, signal, provingState.epochNumber),
       ),
@@ -897,7 +943,7 @@ export class ProvingOrchestrator implements BlockProver {
 
   // Runs the root parity circuit ans stored the outputs
   // Enqueues the root rollup proof if all inputs are available
-  private enqueueRootParityCircuit(provingState: ProvingState, inputs: RootParityInputs) {
+  private enqueueRootParityCircuit(provingState: BlockProvingState, inputs: RootParityInputs) {
     this.deferredProving(
       provingState,
       wrapCallbackInSpan(
@@ -905,23 +951,104 @@ export class ProvingOrchestrator implements BlockProver {
         'ProvingOrchestrator.prover.getRootParityProof',
         {
           [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
-          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'root-parity' as CircuitName,
+          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'root-parity' satisfies CircuitName,
         },
         signal => this.prover.getRootParityProof(inputs, signal, provingState.epochNumber),
       ),
-      async rootInput => {
+      rootInput => {
         provingState!.finalRootParityInput = rootInput;
-        await this.checkAndEnqueueBlockRootRollup(provingState);
+        this.checkAndEnqueueBlockRootRollup(provingState);
       },
     );
   }
 
-  private async checkAndEnqueueBlockRootRollup(provingState: ProvingState | undefined) {
+  // Executes the block merge rollup circuit and stored the output as intermediate state for the parent merge/block root circuit
+  // Enqueues the next level of merge if all inputs are available
+  private enqueueBlockMergeRollup(
+    provingState: EpochProvingState,
+    level: bigint,
+    index: bigint,
+    mergeInputData: BlockMergeRollupInputData,
+  ) {
+    const inputs = createBlockMergeRollupInputs(
+      [mergeInputData.inputs[0]!, mergeInputData.proofs[0]!, mergeInputData.verificationKeys[0]!],
+      [mergeInputData.inputs[1]!, mergeInputData.proofs[1]!, mergeInputData.verificationKeys[1]!],
+    );
+
+    this.deferredProving(
+      provingState,
+      wrapCallbackInSpan(
+        this.tracer,
+        'ProvingOrchestrator.prover.getBlockMergeRollupProof',
+        {
+          [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
+          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'block-merge-rollup' satisfies CircuitName,
+        },
+        signal => this.prover.getBlockMergeRollupProof(inputs, signal, provingState.epochNumber),
+      ),
+      result => {
+        this.storeAndExecuteNextBlockMergeLevel(provingState, level, index, [
+          result.inputs,
+          result.proof,
+          result.verificationKey.keyAsFields,
+        ]);
+      },
+    );
+  }
+
+  // Executes the root rollup circuit
+  private enqueueRootRollup(provingState: EpochProvingState | undefined) {
+    if (!provingState?.verifyState()) {
+      logger.debug('Not running root rollup, state no longer valid');
+      return;
+    }
+
+    logger.debug(`Preparing root rollup`);
+    const mergeInputData = provingState.getMergeInputs(0);
+
+    const inputs = getRootRollupInput(
+      mergeInputData.inputs[0]!,
+      mergeInputData.proofs[0]!,
+      mergeInputData.verificationKeys[0]!,
+      mergeInputData.inputs[1]!,
+      mergeInputData.proofs[1]!,
+      mergeInputData.verificationKeys[1]!,
+      this.proverId,
+    );
+
+    this.deferredProving(
+      provingState,
+      wrapCallbackInSpan(
+        this.tracer,
+        'ProvingOrchestrator.prover.getRootRollupProof',
+        {
+          [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
+          [Attributes.PROTOCOL_CIRCUIT_NAME]: 'root-rollup' satisfies CircuitName,
+        },
+        signal => this.prover.getRootRollupProof(inputs, signal, provingState.epochNumber),
+      ),
+      result => {
+        provingState.rootRollupPublicInputs = result.inputs;
+        provingState.finalProof = result.proof.binaryProof;
+        provingState.resolve({ status: PROVING_STATUS.SUCCESS });
+      },
+    );
+  }
+
+  private checkAndEnqueueBlockRootRollup(provingState: BlockProvingState | undefined) {
     if (!provingState?.isReadyForBlockRootRollup()) {
       logger.debug('Not ready for root rollup');
       return;
     }
-    await this.enqueueBlockRootRollup(provingState);
+    this.enqueueBlockRootRollup(provingState);
+  }
+
+  private checkAndEnqueueRootRollup(provingState: EpochProvingState | undefined) {
+    if (!provingState?.isReadyForRootRollup()) {
+      logger.debug('Not ready for root rollup');
+      return;
+    }
+    this.enqueueRootRollup(provingState);
   }
 
   /**
@@ -932,7 +1059,7 @@ export class ProvingOrchestrator implements BlockProver {
    * @param mergeInputData - The inputs to be stored
    */
   private storeAndExecuteNextMergeLevel(
-    provingState: ProvingState,
+    provingState: BlockProvingState,
     currentLevel: bigint,
     currentIndex: bigint,
     mergeInputData: [
@@ -941,19 +1068,64 @@ export class ProvingOrchestrator implements BlockProver {
       VerificationKeyAsFields,
     ],
   ) {
-    const result = this.storeMergeInputs(provingState, currentLevel, currentIndex, mergeInputData);
+    const [mergeLevel, indexWithinMergeLevel, indexWithinMerge] = provingState.findMergeLevel(
+      currentLevel,
+      currentIndex,
+    );
+    const mergeIndex = 2n ** mergeLevel - 1n + indexWithinMergeLevel;
+    const ready = provingState.storeMergeInputs(mergeInputData, Number(indexWithinMerge), Number(mergeIndex));
+    const nextMergeInputData = provingState.getMergeInputs(Number(mergeIndex));
 
     // Are we ready to execute the next circuit?
-    if (!result.ready) {
+    if (!ready) {
       return;
     }
 
-    if (result.mergeLevel === 0n) {
-      // TODO (alexg) remove this `void`
-      void this.checkAndEnqueueBlockRootRollup(provingState);
+    if (mergeLevel === 0n) {
+      this.checkAndEnqueueBlockRootRollup(provingState);
     } else {
       // onto the next merge level
-      this.enqueueMergeRollup(provingState, result.mergeLevel, result.indexWithinMergeLevel, result.mergeInputData);
+      this.enqueueMergeRollup(provingState, mergeLevel, indexWithinMergeLevel, nextMergeInputData);
+    }
+  }
+
+  /**
+   * Stores the inputs to a block merge/root circuit and enqueues the circuit if ready
+   * @param provingState - The proving state being operated on
+   * @param currentLevel - The level of the merge/root circuit
+   * @param currentIndex - The index of the merge/root circuit
+   * @param mergeInputData - The inputs to be stored
+   */
+  private storeAndExecuteNextBlockMergeLevel(
+    provingState: EpochProvingState,
+    currentLevel: bigint,
+    currentIndex: bigint,
+    mergeInputData: [
+      BlockRootOrBlockMergePublicInputs,
+      RecursiveProof<typeof NESTED_RECURSIVE_PROOF_LENGTH>,
+      VerificationKeyAsFields,
+    ],
+  ) {
+    const [mergeLevel, indexWithinMergeLevel, indexWithinMerge] = provingState.findMergeLevel(
+      currentLevel,
+      currentIndex,
+    );
+    logger.debug(`Computed merge for ${currentLevel}.${currentIndex} as ${mergeLevel}.${indexWithinMergeLevel}`);
+    const mergeIndex = 2n ** mergeLevel - 1n + indexWithinMergeLevel;
+    const ready = provingState.storeMergeInputs(mergeInputData, Number(indexWithinMerge), Number(mergeIndex));
+    const nextMergeInputData = provingState.getMergeInputs(Number(mergeIndex));
+
+    // Are we ready to execute the next circuit?
+    if (!ready) {
+      logger.debug(`Not ready to execute next block merge for level ${mergeLevel} index ${indexWithinMergeLevel}`);
+      return;
+    }
+
+    if (mergeLevel === 0n) {
+      this.checkAndEnqueueRootRollup(provingState);
+    } else {
+      // onto the next merge level
+      this.enqueueBlockMergeRollup(provingState, mergeLevel, indexWithinMergeLevel, nextMergeInputData);
     }
   }
 
@@ -964,7 +1136,7 @@ export class ProvingOrchestrator implements BlockProver {
    * @param txIndex - The index of the transaction being proven
    * @param functionIndex - The index of the function/kernel being proven
    */
-  private enqueueVM(provingState: ProvingState | undefined, txIndex: number, functionIndex: number) {
+  private enqueueVM(provingState: BlockProvingState | undefined, txIndex: number, functionIndex: number) {
     if (!provingState?.verifyState()) {
       logger.debug(`Not running VM circuit as state is no longer valid`);
       return;
@@ -1016,7 +1188,7 @@ export class ProvingOrchestrator implements BlockProver {
   }
 
   private checkAndEnqueuePublicKernelFromVMProof(
-    provingState: ProvingState,
+    provingState: BlockProvingState,
     txIndex: number,
     functionIndex: number,
     vmProof: Proof,
@@ -1037,7 +1209,7 @@ export class ProvingOrchestrator implements BlockProver {
   // This could be either a public kernel or the base rollup
   // Alternatively, if we are still waiting on a public VM prof then it will continue waiting
   private checkAndEnqueueNextTxCircuit(
-    provingState: ProvingState,
+    provingState: BlockProvingState,
     txIndex: number,
     completedFunctionIndex: number,
     proof: RecursiveProof<typeof NESTED_RECURSIVE_PROOF_LENGTH> | RecursiveProof<typeof TUBE_PROOF_LENGTH>,
@@ -1081,7 +1253,7 @@ export class ProvingOrchestrator implements BlockProver {
    * @param txIndex - The index of the transaction being proven
    * @param functionIndex - The index of the function/kernel being proven
    */
-  private enqueuePublicKernel(provingState: ProvingState | undefined, txIndex: number, functionIndex: number) {
+  private enqueuePublicKernel(provingState: BlockProvingState | undefined, txIndex: number, functionIndex: number) {
     if (!provingState?.verifyState()) {
       logger.debug(`Not running public kernel circuit as state is no longer valid`);
       return;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -1111,6 +1111,10 @@ export class ProvingOrchestrator implements EpochProver {
       currentIndex,
     );
     logger.debug(`Computed merge for ${currentLevel}.${currentIndex} as ${mergeLevel}.${indexWithinMergeLevel}`);
+    if (mergeLevel < 0n) {
+      throw new Error(`Invalid merge level ${mergeLevel}`);
+    }
+
     const mergeIndex = 2n ** mergeLevel - 1n + indexWithinMergeLevel;
     const ready = provingState.storeMergeInputs(mergeInputData, Number(indexWithinMerge), Number(mergeIndex));
     const nextMergeInputData = provingState.getMergeInputs(Number(mergeIndex));

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_failures.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_failures.test.ts
@@ -1,4 +1,6 @@
 import { PROVING_STATUS, type ServerCircuitProver } from '@aztec/circuit-types';
+import { Fr } from '@aztec/circuits.js';
+import { times } from '@aztec/foundation/collection';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { WASMSimulator } from '@aztec/simulator';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
@@ -6,7 +8,7 @@ import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 import { jest } from '@jest/globals';
 
 import { TestCircuitProver } from '../../../bb-prover/src/test/test_circuit_prover.js';
-import { makeBloatedProcessedTx } from '../mocks/fixtures.js';
+import { makeBloatedProcessedTx, makeGlobals } from '../mocks/fixtures.js';
 import { TestContext } from '../mocks/test_context.js';
 import { ProvingOrchestrator } from './orchestrator.js';
 
@@ -51,19 +53,18 @@ describe('prover/orchestrator/failures', () => {
           jest.spyOn(mockProver, 'getBlockRootRollupProof').mockRejectedValue('Block Root Rollup Failed');
         },
       ],
-      // TODO(#7346): Integrate batch rollup circuits into orchestrator and test here
-      // [
-      //   'Block Merge Rollup Failed',
-      //   () => {
-      //     jest.spyOn(mockProver, 'getBlockMergeRollupProof').mockRejectedValue('Block Merge Rollup Failed');
-      //   },
-      // ],
-      // [
-      //   'Root Rollup Failed',
-      //   () => {
-      //     jest.spyOn(mockProver, 'getRootRollupProof').mockRejectedValue('Root Rollup Failed');
-      //   },
-      // ],
+      [
+        'Block Merge Rollup Failed',
+        () => {
+          jest.spyOn(mockProver, 'getBlockMergeRollupProof').mockRejectedValue('Block Merge Rollup Failed');
+        },
+      ],
+      [
+        'Root Rollup Failed',
+        () => {
+          jest.spyOn(mockProver, 'getRootRollupProof').mockRejectedValue('Root Rollup Failed');
+        },
+      ],
       [
         'Base Parity Failed',
         () => {
@@ -78,18 +79,20 @@ describe('prover/orchestrator/failures', () => {
       ],
     ] as const)('handles a %s error', async (message: string, fn: () => void) => {
       fn();
-      const txs = [
-        makeBloatedProcessedTx(context.actualDb, 1),
-        makeBloatedProcessedTx(context.actualDb, 2),
-        makeBloatedProcessedTx(context.actualDb, 3),
-      ];
 
-      const blockTicket = await orchestrator.startNewBlock(txs.length, context.globalVariables, []);
+      const epochTicket = orchestrator.startNewEpoch(1, 3);
 
-      for (const tx of txs) {
-        await orchestrator.addNewTx(tx);
+      // We need at least 3 blocks and 3 txs to ensure all circuits are used
+      for (let i = 0; i < 3; i++) {
+        const txs = times(3, j => makeBloatedProcessedTx(context.actualDb, i * 10 + j + 1));
+        const msgs = [new Fr(i + 100)];
+        await orchestrator.startNewBlock(txs.length, makeGlobals(i + 1), msgs);
+        for (const tx of txs) {
+          await orchestrator.addNewTx(tx);
+        }
       }
-      await expect(blockTicket.provingPromise).resolves.toEqual({ status: PROVING_STATUS.FAILURE, reason: message });
+
+      await expect(epochTicket.provingPromise).resolves.toEqual({ status: PROVING_STATUS.FAILURE, reason: message });
     });
   });
 });

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_lifecycle.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_lifecycle.test.ts
@@ -1,11 +1,6 @@
-import { PROVING_STATUS, type ProvingFailure, type ServerCircuitProver } from '@aztec/circuit-types';
-import {
-  type GlobalVariables,
-  NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
-  NUM_BASE_PARITY_PER_ROOT_PARITY,
-} from '@aztec/circuits.js';
-import { fr, makeGlobalVariables } from '@aztec/circuits.js/testing';
-import { range } from '@aztec/foundation/array';
+import { type ServerCircuitProver } from '@aztec/circuit-types';
+import { NUM_BASE_PARITY_PER_ROOT_PARITY } from '@aztec/circuits.js';
+import { makeGlobalVariables } from '@aztec/circuits.js/testing';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { type PromiseWithResolvers, promiseWithResolvers } from '@aztec/foundation/promise';
 import { sleep } from '@aztec/foundation/sleep';
@@ -14,7 +9,6 @@ import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 import { jest } from '@jest/globals';
 
 import { TestCircuitProver } from '../../../bb-prover/src/test/test_circuit_prover.js';
-import { makeBloatedProcessedTx, makeGlobals } from '../mocks/fixtures.js';
 import { TestContext } from '../mocks/test_context.js';
 import { ProvingOrchestrator } from './orchestrator.js';
 
@@ -32,77 +26,6 @@ describe('prover/orchestrator/lifecycle', () => {
   });
 
   describe('lifecycle', () => {
-    it('cancels current block and switches to new ones', async () => {
-      const txs1 = [makeBloatedProcessedTx(context.actualDb, 1), makeBloatedProcessedTx(context.actualDb, 2)];
-
-      const txs2 = [makeBloatedProcessedTx(context.actualDb, 3), makeBloatedProcessedTx(context.actualDb, 4)];
-
-      const globals1: GlobalVariables = makeGlobals(100);
-      const globals2: GlobalVariables = makeGlobals(101);
-
-      const l1ToL2Messages = range(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, 1 + 0x400).map(fr);
-
-      const blockTicket1 = await context.orchestrator.startNewBlock(2, globals1, l1ToL2Messages);
-
-      await context.orchestrator.addNewTx(txs1[0]);
-      await context.orchestrator.addNewTx(txs1[1]);
-
-      // Now we cancel the block. The first block will come to a stop as and when current proofs complete
-      context.orchestrator.cancelBlock();
-
-      const result1 = await blockTicket1.provingPromise;
-
-      // in all likelihood, the block will have a failure code as we cancelled it
-      // however it may have actually completed proving before we cancelled in which case it could be a success code
-      if (result1.status === PROVING_STATUS.FAILURE) {
-        expect((result1 as ProvingFailure).reason).toBe('Proving cancelled');
-      }
-
-      await context.actualDb.rollback();
-
-      const blockTicket2 = await context.orchestrator.startNewBlock(2, globals2, l1ToL2Messages);
-
-      await context.orchestrator.addNewTx(txs2[0]);
-      await context.orchestrator.addNewTx(txs2[1]);
-
-      const result2 = await blockTicket2.provingPromise;
-      expect(result2.status).toBe(PROVING_STATUS.SUCCESS);
-      const finalisedBlock = await context.orchestrator.finaliseBlock();
-
-      expect(finalisedBlock.block.number).toEqual(101);
-    });
-
-    it('automatically cancels an incomplete block when starting a new one', async () => {
-      const txs1 = [makeBloatedProcessedTx(context.actualDb, 1), makeBloatedProcessedTx(context.actualDb, 2)];
-      const txs2 = [makeBloatedProcessedTx(context.actualDb, 3), makeBloatedProcessedTx(context.actualDb, 4)];
-
-      const globals1: GlobalVariables = makeGlobals(100);
-      const globals2: GlobalVariables = makeGlobals(101);
-
-      const l1ToL2Messages = range(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, 1 + 0x400).map(fr);
-
-      const blockTicket1 = await context.orchestrator.startNewBlock(2, globals1, l1ToL2Messages);
-
-      await context.orchestrator.addNewTx(txs1[0]);
-
-      await context.actualDb.rollback();
-
-      const blockTicket2 = await context.orchestrator.startNewBlock(2, globals2, l1ToL2Messages);
-
-      await context.orchestrator.addNewTx(txs2[0]);
-      await context.orchestrator.addNewTx(txs2[1]);
-
-      const result1 = await blockTicket1.provingPromise;
-      expect(result1.status).toBe(PROVING_STATUS.FAILURE);
-      expect((result1 as ProvingFailure).reason).toBe('Proving cancelled');
-
-      const result2 = await blockTicket2.provingPromise;
-      expect(result2.status).toBe(PROVING_STATUS.SUCCESS);
-      const finalisedBlock = await context.orchestrator.finaliseBlock();
-
-      expect(finalisedBlock.block.number).toEqual(101);
-    }, 60000);
-
     it('cancels proving requests', async () => {
       const prover: ServerCircuitProver = new TestCircuitProver(new NoopTelemetryClient());
       const orchestrator = new ProvingOrchestrator(context.actualDb, prover, new NoopTelemetryClient());
@@ -121,7 +44,7 @@ describe('prover/orchestrator/lifecycle', () => {
       expect(spy).toHaveBeenCalledTimes(NUM_BASE_PARITY_PER_ROOT_PARITY);
       expect(spy.mock.calls.every(([_, signal]) => !signal?.aborted)).toBeTruthy();
 
-      orchestrator.cancelBlock();
+      orchestrator.cancel();
       expect(spy.mock.calls.every(([_, signal]) => signal?.aborted)).toBeTruthy();
     });
   });

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_multiple_blocks.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_multiple_blocks.test.ts
@@ -19,17 +19,17 @@ describe('prover/orchestrator/multi-block', () => {
   });
 
   describe('multiple blocks', () => {
-    it('builds multiple blocks in sequence', async () => {
-      const numBlocks = 5;
+    it.each([4, 5])('builds an epoch with %s blocks in sequence', async (numBlocks: number) => {
+      const provingTicket = context.orchestrator.startNewEpoch(1, numBlocks);
       let header = context.actualDb.getInitialHeader();
 
       for (let i = 0; i < numBlocks; i++) {
+        logger.info(`Creating block ${i + 1000}`);
         const tx = makeBloatedProcessedTx(context.actualDb, i + 1);
         tx.data.constants.historicalHeader = header;
         tx.data.constants.vkTreeRoot = getVKTreeRoot();
 
         const blockNum = i + 1000;
-
         const globals = makeGlobals(blockNum);
 
         // This will need to be a 2 tx block
@@ -46,9 +46,15 @@ describe('prover/orchestrator/multi-block', () => {
 
         expect(finalisedBlock.block.number).toEqual(blockNum);
         header = finalisedBlock.block.header;
-
-        await context.actualDb.commit();
       }
+
+      logger.info('Awaiting epoch ticket');
+      const result = await provingTicket.provingPromise;
+      expect(result).toEqual({ status: PROVING_STATUS.SUCCESS });
+
+      const epoch = context.orchestrator.finaliseEpoch();
+      expect(epoch.publicInputs.endBlockNumber.toNumber()).toEqual(1000 + numBlocks - 1);
+      expect(epoch.proof).toBeDefined();
     });
   });
 });

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_workflow.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_workflow.test.ts
@@ -64,7 +64,7 @@ describe('prover/orchestrator', () => {
       await sleep(10);
       expect(mockProver.getRootParityProof).toHaveBeenCalledTimes(1);
 
-      orchestrator.cancelBlock();
+      orchestrator.cancel();
     });
   });
 });

--- a/yarn-project/prover-node/src/job/block-proving-job.ts
+++ b/yarn-project/prover-node/src/job/block-proving-job.ts
@@ -129,7 +129,7 @@ export class BlockProvingJob {
   }
 
   public stop() {
-    this.prover.cancelBlock();
+    this.prover.cancel();
   }
 
   private async getBlock(blockNumber: number): Promise<L2Block> {

--- a/yarn-project/sequencer-client/src/block_builder/light.ts
+++ b/yarn-project/sequencer-client/src/block_builder/light.ts
@@ -9,30 +9,21 @@ import {
   type ProcessedTx,
   type ProvingTicket,
   type SimulationBlockResult,
-  TxEffect,
+  type TxEffect,
   makeEmptyProcessedTx,
   toTxEffect,
 } from '@aztec/circuit-types';
 import {
-  ContentCommitment,
   Fr,
   type GlobalVariables,
-  Header,
-  MerkleTreeCalculator,
   NESTED_RECURSIVE_PROOF_LENGTH,
   NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
-  NUM_BASE_PARITY_PER_ROOT_PARITY,
-  NUM_MSGS_PER_BASE_PARITY,
-  PartialStateReference,
-  StateReference,
   VerificationKeyData,
   makeEmptyRecursiveProof,
 } from '@aztec/circuits.js';
 import { padArrayEnd } from '@aztec/foundation/collection';
-import { sha256Trunc } from '@aztec/foundation/crypto';
-import { computeUnbalancedMerkleRoot } from '@aztec/foundation/trees';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
-import { buildBaseRollupInput, getTreeSnapshot } from '@aztec/prover-client/helpers';
+import { buildBaseRollupInput, buildHeaderFromTxEffects, getTreeSnapshot } from '@aztec/prover-client/helpers';
 import { type TelemetryClient } from '@aztec/telemetry-client';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
@@ -78,7 +69,7 @@ export class LightweightBlockBuilder implements BlockSimulator {
     );
   }
 
-  cancelBlock(): void {}
+  cancel(): void {}
 
   async setBlockCompleted(): Promise<void> {
     const paddingTxCount = this.numTxs! - this.txs.length;
@@ -101,57 +92,13 @@ export class LightweightBlockBuilder implements BlockSimulator {
       .map(tx => toTxEffect(tx, this.globalVariables!.gasFees))
       .filter(txEffect => !txEffect.isEmpty());
     const body = new Body(nonEmptyTxEffects);
-    const header = await this.makeHeader(body);
+    const header = await buildHeaderFromTxEffects(body, this.globalVariables!, this.l1ToL2Messages!, this.db);
 
     await this.db.updateArchive(header);
     const newArchive = await getTreeSnapshot(MerkleTreeId.ARCHIVE, this.db);
 
     const block = new L2Block(newArchive, header, body);
     return { block };
-  }
-
-  private async makeHeader(body: Body): Promise<Header> {
-    const { db } = this;
-
-    const stateReference = new StateReference(
-      await getTreeSnapshot(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, db),
-      new PartialStateReference(
-        await getTreeSnapshot(MerkleTreeId.NOTE_HASH_TREE, db),
-        await getTreeSnapshot(MerkleTreeId.NULLIFIER_TREE, db),
-        await getTreeSnapshot(MerkleTreeId.PUBLIC_DATA_TREE, db),
-      ),
-    );
-
-    const previousArchive = await getTreeSnapshot(MerkleTreeId.ARCHIVE, db);
-
-    const outHash = computeUnbalancedMerkleRoot(
-      body.txEffects.map(tx => tx.txOutHash()),
-      TxEffect.empty().txOutHash(),
-    );
-
-    const paritySize = NUM_BASE_PARITY_PER_ROOT_PARITY * NUM_MSGS_PER_BASE_PARITY;
-    const parityHeight = Math.ceil(Math.log2(paritySize));
-    const hasher = (left: Buffer, right: Buffer) => sha256Trunc(Buffer.concat([left, right]));
-    const parityShaRoot = new MerkleTreeCalculator(parityHeight, Fr.ZERO.toBuffer(), hasher).computeTreeRoot(
-      this.l1ToL2Messages!.map(msg => msg.toBuffer()),
-    );
-
-    const contentCommitment = new ContentCommitment(
-      new Fr(this.numTxs!),
-      body.getTxsEffectsHash(),
-      parityShaRoot,
-      outHash,
-    );
-
-    const fees = this.txs!.reduce(
-      (acc, tx) =>
-        acc
-          .add(tx.data.constants.txContext.gasSettings.inclusionFee)
-          .add(tx.data.end.gasUsed.computeFee(this.globalVariables!.gasFees)),
-      Fr.ZERO,
-    );
-
-    return new Header(previousArchive, contentCommitment, stateReference, this.globalVariables!, fees);
   }
 }
 

--- a/yarn-project/sequencer-client/src/block_builder/orchestrator.ts
+++ b/yarn-project/sequencer-client/src/block_builder/orchestrator.ts
@@ -28,8 +28,8 @@ export class OrchestratorBlockBuilder implements BlockSimulator {
   startNewBlock(numTxs: number, globalVariables: GlobalVariables, l1ToL2Messages: Fr[]): Promise<ProvingTicket> {
     return this.orchestrator.startNewBlock(numTxs, globalVariables, l1ToL2Messages);
   }
-  cancelBlock(): void {
-    this.orchestrator.cancelBlock();
+  cancel(): void {
+    this.orchestrator.cancel();
   }
   finaliseBlock(): Promise<SimulationBlockResult> {
     return this.orchestrator.finaliseBlock();

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -209,7 +209,7 @@ describe('sequencer', () => {
     // Ok, we have an issue that we never actually call the process L2 block
     expect(publisher.proposeL2Block).toHaveBeenCalledTimes(1);
     expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash]);
-    expect(blockSimulator.cancelBlock).toHaveBeenCalledTimes(0);
+    expect(blockSimulator.cancel).toHaveBeenCalledTimes(0);
   });
 
   it('builds a block when it is their turn', async () => {
@@ -258,7 +258,7 @@ describe('sequencer', () => {
       Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n)),
     );
     expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash]);
-    expect(blockSimulator.cancelBlock).toHaveBeenCalledTimes(0);
+    expect(blockSimulator.cancel).toHaveBeenCalledTimes(0);
   });
 
   it('builds a block out of several txs rejecting double spends', async () => {
@@ -302,7 +302,7 @@ describe('sequencer', () => {
     );
     expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), validTxHashes);
     expect(p2p.deleteTxs).toHaveBeenCalledWith([doubleSpendTx.getTxHash()]);
-    expect(blockSimulator.cancelBlock).toHaveBeenCalledTimes(0);
+    expect(blockSimulator.cancel).toHaveBeenCalledTimes(0);
   });
 
   it('builds a block out of several txs rejecting incorrect chain ids', async () => {
@@ -341,7 +341,7 @@ describe('sequencer', () => {
     );
     expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), validTxHashes);
     expect(p2p.deleteTxs).toHaveBeenCalledWith([invalidChainTx.getTxHash()]);
-    expect(blockSimulator.cancelBlock).toHaveBeenCalledTimes(0);
+    expect(blockSimulator.cancel).toHaveBeenCalledTimes(0);
   });
 
   it('builds a block out of several txs dropping the ones that go over max size', async () => {
@@ -381,7 +381,7 @@ describe('sequencer', () => {
       Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n)),
     );
     expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), validTxHashes);
-    expect(blockSimulator.cancelBlock).toHaveBeenCalledTimes(0);
+    expect(blockSimulator.cancel).toHaveBeenCalledTimes(0);
   });
 
   it('builds a block once it reaches the minimum number of transactions', async () => {
@@ -432,7 +432,7 @@ describe('sequencer', () => {
     );
     expect(publisher.proposeL2Block).toHaveBeenCalledTimes(1);
     expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), txHashes);
-    expect(blockSimulator.cancelBlock).toHaveBeenCalledTimes(0);
+    expect(blockSimulator.cancel).toHaveBeenCalledTimes(0);
   });
 
   it('builds a block that contains zero real transactions once flushed', async () => {
@@ -483,7 +483,7 @@ describe('sequencer', () => {
     );
     expect(publisher.proposeL2Block).toHaveBeenCalledTimes(1);
     expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), []);
-    expect(blockSimulator.cancelBlock).toHaveBeenCalledTimes(0);
+    expect(blockSimulator.cancel).toHaveBeenCalledTimes(0);
   });
 
   it('builds a block that contains less than the minimum number of transactions once flushed', async () => {
@@ -537,7 +537,7 @@ describe('sequencer', () => {
     expect(publisher.proposeL2Block).toHaveBeenCalledTimes(1);
 
     expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), postFlushTxHashes);
-    expect(blockSimulator.cancelBlock).toHaveBeenCalledTimes(0);
+    expect(blockSimulator.cancel).toHaveBeenCalledTimes(0);
   });
 
   it('aborts building a block if the chain moves underneath it', async () => {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -443,7 +443,7 @@ export class Sequencer {
         processedTxsCount: processedTxs.length,
       })
     ) {
-      blockBuilder.cancelBlock();
+      blockBuilder.cancel();
       throw new Error('Should not propose the block');
     }
 

--- a/yarn-project/telemetry-client/src/attributes.ts
+++ b/yarn-project/telemetry-client/src/attributes.ts
@@ -48,6 +48,10 @@ export const BLOCK_CANDIDATE_TXS_COUNT = 'aztec.block.candidate_txs_count';
 export const BLOCK_TXS_COUNT = 'aztec.block.txs_count';
 /** The block size (power of 2) */
 export const BLOCK_SIZE = 'aztec.block.size';
+/** How many blocks are included in this epoch */
+export const EPOCH_SIZE = 'aztec.epoch.size';
+/** The epoch number */
+export const EPOCH_NUMBER = 'aztec.epoch.number';
 /** The tx hash */
 export const TX_HASH = 'aztec.tx.hash';
 /** Generic attribute representing whether the action was successful or not */


### PR DESCRIPTION
Reverts the revert.

Original description
---

Adds epochs to the current Orchestrator. Splits the ProverState into epoch and block. Snapshots all inputs required for proving a block as early as possible, so we can keep updating trees without having to wait for older block proofs in the epoch.