### PR TITLE
chore(ci): slightly safer default e2e jobs

### DIFF
--- a/scripts/ci/get_e2e_jobs.sh
+++ b/scripts/ci/get_e2e_jobs.sh
@@ -22,6 +22,7 @@ allow_list=(
   "e2e-nested-contract"
   "e2e-ordering"
   "e2e-static-calls"
+  "integration-l1-publisher"
 )
 
 # Add labels from input to the allow_list


### PR DESCRIPTION
For now, turning on anything that breaks that isn't proving tests