### PR TITLE
fix(ci): rerun.yml should not trigger if a commit has been pushed

### DIFF
--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -13,6 +13,9 @@ jobs:
       actions: write  # Needed for 'gh run rerun'
     steps:
       - name: Wait for run to finish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
         run: |
           gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
 

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -18,7 +18,8 @@ jobs:
 
       - name: Rerun failed jobs if the commit is the latest on the branch
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
         run: |
           RUN_ID="${{ inputs.run_id }}"
           # Get the run details

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - name: Wait for run to finish
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           GH_DEBUG: api
         run: |
@@ -21,6 +22,7 @@ jobs:
 
       - name: Rerun failed jobs if the commit is the latest on the branch
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           GH_DEBUG: api
         run: |

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,20 +1,47 @@
-# from https://github.com/orgs/community/discussions/67654
+# adapted from https://github.com/orgs/community/discussions/67654
+# altered to not rerun if we are not the newest commit in the run's branch
 on:
   workflow_dispatch:
     inputs:
       run_id:
         required: true
+
 jobs:
   rerun:
     runs-on: ubuntu-latest
     permissions:
-      actions: write
+      actions: write  # Needed for 'gh run rerun'
     steps:
-      - name: rerun ${{ inputs.run_id }}
+      - name: Check if the commit is the latest on the branch
         env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
-          GH_DEBUG: api
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RUN_ID="${{ inputs.run_id }}"
+          # Get the run details
+          RUN_INFO=$(gh run view $RUN_ID --json headSha,headBranch,event)
+          # Extract the commit SHA, branch name, and event type
+          COMMIT_SHA=$(echo "$RUN_INFO" | jq -r '.headSha')
+          BRANCH_NAME=$(echo "$RUN_INFO" | jq -r '.headBranch')
+          EVENT_TYPE=$(echo "$RUN_INFO" | jq -r '.event')
+
+          # Only proceed if the event is a pull_request
+          if [[ "$EVENT_TYPE" != "pull_request" ]]; then
+            echo "Event type is $EVENT_TYPE. Skipping rerun."
+            exit 0
+          fi
+
+          # Get the latest commit SHA on the branch
+          LATEST_COMMIT_SHA=$(gh api repos/${{ github.repository }}/commits/$BRANCH_NAME --jq .sha)
+
+          # Compare the SHAs
+          if [[ "$COMMIT_SHA" != "$LATEST_COMMIT_SHA" ]]; then
+            echo "Commit $COMMIT_SHA is not the latest commit on branch $BRANCH_NAME (latest is $LATEST_COMMIT_SHA). Skipping rerun."
+            exit 0
+          else
+            echo "Commit $COMMIT_SHA is the latest on branch $BRANCH_NAME. Proceeding with rerun."
+          fi
+
+      - name: Rerun failed jobs
         run: |
           gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
           gh run rerun ${{ inputs.run_id }} --failed

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -12,7 +12,11 @@ jobs:
     permissions:
       actions: write  # Needed for 'gh run rerun'
     steps:
-      - name: Check if the commit is the latest on the branch
+      - name: Wait for run to finish
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+
+      - name: Rerun failed jobs if the commit is the latest on the branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -36,12 +40,7 @@ jobs:
           # Compare the SHAs
           if [[ "$COMMIT_SHA" != "$LATEST_COMMIT_SHA" ]]; then
             echo "Commit $COMMIT_SHA is not the latest commit on branch $BRANCH_NAME (latest is $LATEST_COMMIT_SHA). Skipping rerun."
-            exit 0
           else
             echo "Commit $COMMIT_SHA is the latest on branch $BRANCH_NAME. Proceeding with rerun."
+            gh run rerun ${{ inputs.run_id }} --failed
           fi
-
-      - name: Rerun failed jobs
-        run: |
-          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
-          gh run rerun ${{ inputs.run_id }} --failed


### PR DESCRIPTION
I have tested this out with the actions run UI in github. Looks like all the cases are covered