### PR TITLE
chore: Skip some tests in CI

### DIFF
--- a/barretenberg/cpp/cmake/module.cmake
+++ b/barretenberg/cpp/cmake/module.cmake
@@ -156,7 +156,7 @@ function(barretenberg_module MODULE_NAME)
         # enable msgpack downloading via dependency (solves race condition)
         add_dependencies(${MODULE_NAME}_test_objects msgpack-c)
         add_dependencies(${MODULE_NAME}_tests msgpack-c)
-        if(NOT WASM AND NOT CI)
+        if(NOT WASM)
             # If collecting coverage data, set profile
             # For some reason processor affinity doesn't work, so the developer has to set it manually anyway
             if(COVERAGE)
@@ -168,7 +168,7 @@ function(barretenberg_module MODULE_NAME)
                 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
             else()
                 # Currently haven't found a way to easily wrap the calls in wasmtime when run from ctest.
-                gtest_discover_tests(${MODULE_NAME}_tests WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+                gtest_discover_tests(${MODULE_NAME}_tests WORKING_DIRECTORY ${CMAKE_BINARY_DIR} TEST_FILTER -*_SKIP_CI*)
             endif()
         endif()
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/plonk_recursion/verifier/verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/plonk_recursion/verifier/verifier.test.cpp
@@ -16,7 +16,7 @@
 
 namespace bb::stdlib {
 
-template <typename OuterComposer> class stdlib_verifier : public testing::Test {
+template <typename OuterComposer> class stdlib_verifier_SKIP_CI : public testing::Test {
 
     using InnerComposer = plonk::UltraComposer;
     using InnerBuilder = typename InnerComposer::CircuitBuilder;
@@ -564,17 +564,17 @@ typedef testing::Types<plonk::StandardComposer, plonk::UltraComposer> OuterCompo
 
 TYPED_TEST_SUITE(stdlib_verifier, OuterComposerTypes);
 
-HEAVY_TYPED_TEST(stdlib_verifier, test_inner_circuit)
+HEAVY_TYPED_TEST(stdlib_verifier_SKIP_CI, test_inner_circuit)
 {
     TestFixture::test_inner_circuit();
 }
 
-HEAVY_TYPED_TEST(stdlib_verifier, recursive_proof_composition)
+HEAVY_TYPED_TEST(stdlib_verifier_SKIP_CI, recursive_proof_composition)
 {
     TestFixture::test_recursive_proof_composition();
 };
 
-HEAVY_TYPED_TEST(stdlib_verifier, recursive_proof_composition_ultra_no_tables)
+HEAVY_TYPED_TEST(stdlib_verifier_SKIP_CI, recursive_proof_composition_ultra_no_tables)
 {
     if constexpr (std::same_as<TypeParam, plonk::UltraComposer>) {
         TestFixture::test_recursive_proof_composition_ultra_no_tables();
@@ -583,7 +583,7 @@ HEAVY_TYPED_TEST(stdlib_verifier, recursive_proof_composition_ultra_no_tables)
     }
 };
 
-HEAVY_TYPED_TEST(stdlib_verifier, double_verification)
+HEAVY_TYPED_TEST(stdlib_verifier_SKIP_CI, double_verification)
 {
     if constexpr (std::same_as<TypeParam, plonk::UltraComposer>) {
         TestFixture::test_double_verification();
@@ -593,22 +593,22 @@ HEAVY_TYPED_TEST(stdlib_verifier, double_verification)
     }
 };
 
-HEAVY_TYPED_TEST(stdlib_verifier, recursive_proof_composition_with_variable_verification_key_a)
+HEAVY_TYPED_TEST(stdlib_verifier_SKIP_CI, recursive_proof_composition_with_variable_verification_key_a)
 {
     TestFixture::test_recursive_proof_composition_with_variable_verification_key_a();
 }
 
-HEAVY_TYPED_TEST(stdlib_verifier, recursive_proof_composition_with_variable_verification_key_b)
+HEAVY_TYPED_TEST(stdlib_verifier_SKIP_CI, recursive_proof_composition_with_variable_verification_key_b)
 {
     TestFixture::test_recursive_proof_composition_with_variable_verification_key_b();
 }
 
-HEAVY_TYPED_TEST(stdlib_verifier, recursive_proof_composition_var_verif_key_fail)
+HEAVY_TYPED_TEST(stdlib_verifier_SKIP_CI, recursive_proof_composition_var_verif_key_fail)
 {
     TestFixture::test_recursive_proof_composition_with_variable_verification_key_failure_case();
 }
 
-HEAVY_TYPED_TEST(stdlib_verifier, recursive_proof_composition_const_verif_key)
+HEAVY_TYPED_TEST(stdlib_verifier_SKIP_CI, recursive_proof_composition_const_verif_key)
 {
     TestFixture::test_recursive_proof_composition_with_constant_verification_key();
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/plonk_recursion/verifier/verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/plonk_recursion/verifier/verifier.test.cpp
@@ -562,7 +562,7 @@ template <typename OuterComposer> class stdlib_verifier_SKIP_CI : public testing
 
 typedef testing::Types<plonk::StandardComposer, plonk::UltraComposer> OuterComposerTypes;
 
-TYPED_TEST_SUITE(stdlib_verifier, OuterComposerTypes);
+TYPED_TEST_SUITE(stdlib_verifier_SKIP_CI, OuterComposerTypes);
 
 HEAVY_TYPED_TEST(stdlib_verifier_SKIP_CI, test_inner_circuit)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -918,7 +918,7 @@ template <typename Builder> class stdlib_bigfield_SKIP_CI : public testing::Test
 // Define types for which the above tests will be constructed.
 using CircuitTypes = testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder, bb::CircuitSimulatorBN254>;
 // Define the suite of tests.
-TYPED_TEST_SUITE(stdlib_bigfield, CircuitTypes);
+TYPED_TEST_SUITE(stdlib_bigfield_SKIP_CI, CircuitTypes);
 TYPED_TEST(stdlib_bigfield_SKIP_CI, badmul)
 {
     TestFixture::test_division_formula_bug();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -29,7 +29,7 @@ namespace {
 auto& engine = numeric::get_debug_randomness();
 }
 
-template <typename Builder> class stdlib_bigfield : public testing::Test {
+template <typename Builder> class stdlib_bigfield_SKIP_CI : public testing::Test {
 
     typedef stdlib::bn254<Builder> bn254;
 
@@ -919,100 +919,100 @@ template <typename Builder> class stdlib_bigfield : public testing::Test {
 using CircuitTypes = testing::Types<bb::StandardCircuitBuilder, bb::UltraCircuitBuilder, bb::CircuitSimulatorBN254>;
 // Define the suite of tests.
 TYPED_TEST_SUITE(stdlib_bigfield, CircuitTypes);
-TYPED_TEST(stdlib_bigfield, badmul)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, badmul)
 {
     TestFixture::test_division_formula_bug();
 }
-TYPED_TEST(stdlib_bigfield, mul)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, mul)
 {
     TestFixture::test_mul();
 }
-TYPED_TEST(stdlib_bigfield, sqr)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, sqr)
 {
     TestFixture::test_sqr();
 }
-TYPED_TEST(stdlib_bigfield, mult_madd)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, mult_madd)
 {
     TestFixture::test_mult_madd();
 }
-TYPED_TEST(stdlib_bigfield, dual_madd)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, dual_madd)
 {
     TestFixture::test_dual_madd();
 }
-TYPED_TEST(stdlib_bigfield, div_without_denominator_check)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, div_without_denominator_check)
 {
     TestFixture::test_div();
 }
-TYPED_TEST(stdlib_bigfield, add_and_div)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, add_and_div)
 {
     TestFixture::test_add_and_div();
 }
-TYPED_TEST(stdlib_bigfield, add_and_mul)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, add_and_mul)
 {
     TestFixture::test_add_and_mul();
 }
-TYPED_TEST(stdlib_bigfield, add_and_mul_with_constants)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, add_and_mul_with_constants)
 {
     TestFixture::test_add_and_mul_with_constants();
 }
-TYPED_TEST(stdlib_bigfield, sub_and_mul)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, sub_and_mul)
 {
     TestFixture::test_sub_and_mul();
 }
-TYPED_TEST(stdlib_bigfield, msub_div)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, msub_div)
 {
     TestFixture::test_msub_div();
 }
-TYPED_TEST(stdlib_bigfield, conditional_negate)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, conditional_negate)
 {
     TestFixture::test_conditional_negate();
 }
-TYPED_TEST(stdlib_bigfield, group_operations)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, group_operations)
 {
     TestFixture::test_group_operations();
 }
-TYPED_TEST(stdlib_bigfield, reduce)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, reduce)
 {
     TestFixture::test_reduce();
 }
-TYPED_TEST(stdlib_bigfield, assert_is_in_field_succes)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, assert_is_in_field_succes)
 {
     TestFixture::test_assert_is_in_field_success();
 }
-TYPED_TEST(stdlib_bigfield, assert_less_than_success)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, assert_less_than_success)
 {
     TestFixture::test_assert_less_than_success();
 }
-TYPED_TEST(stdlib_bigfield, byte_array_constructors)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, byte_array_constructors)
 {
     TestFixture::test_byte_array_constructors();
 }
-TYPED_TEST(stdlib_bigfield, quotient_completeness_regression)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, quotient_completeness_regression)
 {
     TestFixture::test_quotient_completeness();
 }
 
-TYPED_TEST(stdlib_bigfield, conditional_select_regression)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, conditional_select_regression)
 {
     TestFixture::test_conditional_select_regression();
 }
 
-TYPED_TEST(stdlib_bigfield, division_context)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, division_context)
 {
     TestFixture::test_division_context();
 }
 
-TYPED_TEST(stdlib_bigfield, inverse)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, inverse)
 {
     TestFixture::test_inversion();
 }
 
-TYPED_TEST(stdlib_bigfield, assert_equal_not_equal)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, assert_equal_not_equal)
 {
     TestFixture::test_assert_equal_not_equal();
 }
 
-TYPED_TEST(stdlib_bigfield, pow)
+TYPED_TEST(stdlib_bigfield_SKIP_CI, pow)
 {
     TestFixture::test_pow();
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -32,7 +32,7 @@ template <typename _Curve, bool _use_bigfield = false> struct TestType {
         typename std::conditional<_use_bigfield, typename Curve::bigfr_ct, typename Curve::ScalarField>::type;
 };
 
-template <typename TestType> class stdlib_biggroup : public testing::Test {
+template <typename TestType> class stdlib_biggroup_SKIP_CI : public testing::Test {
     using Curve = typename TestType::Curve;
     using element_ct = typename TestType::element_ct;
     using scalar_ct = typename TestType::scalar_ct;
@@ -1194,33 +1194,33 @@ using TestTypes = testing::Types<TestType<stdlib::bn254<bb::StandardCircuitBuild
 
 TYPED_TEST_SUITE(stdlib_biggroup, TestTypes);
 
-TYPED_TEST(stdlib_biggroup, add)
+TYPED_TEST(stdlib_biggroup_SKIP_CI, add)
 {
 
     TestFixture::test_add();
 }
-TYPED_TEST(stdlib_biggroup, add_points_at_infinity)
+TYPED_TEST(stdlib_biggroup_SKIP_CI, add_points_at_infinity)
 {
     TestFixture::test_add_points_at_infinity();
 }
-TYPED_TEST(stdlib_biggroup, standard_form_of_point_at_infinity)
+TYPED_TEST(stdlib_biggroup_SKIP_CI, standard_form_of_point_at_infinity)
 {
     TestFixture::test_standard_form_of_point_at_infinity();
 }
-TYPED_TEST(stdlib_biggroup, sub)
+TYPED_TEST(stdlib_biggroup_SKIP_CI, sub)
 {
     TestFixture::test_sub();
 }
-TYPED_TEST(stdlib_biggroup, sub_points_at_infinity)
+TYPED_TEST(stdlib_biggroup_SKIP_CI, sub_points_at_infinity)
 {
 
     TestFixture::test_sub_points_at_infinity();
 }
-TYPED_TEST(stdlib_biggroup, dbl)
+TYPED_TEST(stdlib_biggroup_SKIP_CI, dbl)
 {
     TestFixture::test_dbl();
 }
-TYPED_TEST(stdlib_biggroup, montgomery_ladder)
+TYPED_TEST(stdlib_biggroup_SKIP_CI, montgomery_ladder)
 {
     if constexpr (HasGoblinBuilder<TypeParam>) {
         GTEST_SKIP() << "https://github.com/AztecProtocol/barretenberg/issues/707";
@@ -1228,11 +1228,11 @@ TYPED_TEST(stdlib_biggroup, montgomery_ladder)
         TestFixture::test_montgomery_ladder();
     };
 }
-HEAVY_TYPED_TEST(stdlib_biggroup, mul)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, mul)
 {
     TestFixture::test_mul();
 }
-HEAVY_TYPED_TEST(stdlib_biggroup, twin_mul)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, twin_mul)
 {
     if constexpr (HasGoblinBuilder<TypeParam>) {
         GTEST_SKIP() << "https://github.com/AztecProtocol/barretenberg/issues/707";
@@ -1240,7 +1240,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, twin_mul)
         TestFixture::test_twin_mul();
     };
 }
-HEAVY_TYPED_TEST(stdlib_biggroup, triple_mul)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, triple_mul)
 {
     if constexpr (HasGoblinBuilder<TypeParam>) {
         GTEST_SKIP() << "https://github.com/AztecProtocol/barretenberg/issues/707";
@@ -1248,7 +1248,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, triple_mul)
         TestFixture::test_triple_mul();
     };
 }
-HEAVY_TYPED_TEST(stdlib_biggroup, quad_mul)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, quad_mul)
 {
     if constexpr (HasGoblinBuilder<TypeParam>) {
         GTEST_SKIP() << "https://github.com/AztecProtocol/barretenberg/issues/707";
@@ -1256,16 +1256,16 @@ HEAVY_TYPED_TEST(stdlib_biggroup, quad_mul)
         TestFixture::test_quad_mul();
     };
 }
-HEAVY_TYPED_TEST(stdlib_biggroup, one)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, one)
 {
     TestFixture::test_one();
 }
-HEAVY_TYPED_TEST(stdlib_biggroup, batch_mul)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, batch_mul)
 {
     TestFixture::test_batch_mul();
 }
 
-HEAVY_TYPED_TEST(stdlib_biggroup, batch_mul_edgecase_equivalence)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, batch_mul_edgecase_equivalence)
 {
     if constexpr (HasGoblinBuilder<TypeParam>) {
         GTEST_SKIP();
@@ -1273,16 +1273,16 @@ HEAVY_TYPED_TEST(stdlib_biggroup, batch_mul_edgecase_equivalence)
         TestFixture::test_batch_mul_edgecase_equivalence();
     }
 }
-HEAVY_TYPED_TEST(stdlib_biggroup, batch_mul_edge_case_set1)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, batch_mul_edge_case_set1)
 {
     TestFixture::test_batch_mul_edge_case_set1();
 }
 
-HEAVY_TYPED_TEST(stdlib_biggroup, batch_mul_edge_case_set2)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, batch_mul_edge_case_set2)
 {
     TestFixture::test_batch_mul_edge_case_set2();
 }
-HEAVY_TYPED_TEST(stdlib_biggroup, chain_add)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, chain_add)
 {
 
     if constexpr (HasGoblinBuilder<TypeParam>) {
@@ -1291,7 +1291,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, chain_add)
         TestFixture::test_chain_add();
     };
 }
-HEAVY_TYPED_TEST(stdlib_biggroup, multiple_montgomery_ladder)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, multiple_montgomery_ladder)
 {
 
     if constexpr (HasGoblinBuilder<TypeParam>) {
@@ -1301,7 +1301,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, multiple_montgomery_ladder)
     };
 }
 
-HEAVY_TYPED_TEST(stdlib_biggroup, compute_naf)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, compute_naf)
 {
     // ULTRATODO: make this work for secp curves
     if constexpr ((TypeParam::Curve::type == CurveType::BN254) && !HasGoblinBuilder<TypeParam>) {
@@ -1315,7 +1315,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, compute_naf)
 }
 
 /* These tests only work for Ultra Circuit Constructor */
-HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_batch_mul)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, wnaf_batch_mul)
 {
     if constexpr (HasPlookup<typename TypeParam::Curve::Builder>) {
         if constexpr (TypeParam::Curve::type == CurveType::BN254 && HasGoblinBuilder<TypeParam>) {
@@ -1329,7 +1329,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_batch_mul)
 }
 
 /* These tests only work for Ultra Circuit Constructor */
-HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_batch_mul_edge_cases)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, wnaf_batch_mul_edge_cases)
 {
     if constexpr (HasPlookup<typename TypeParam::Curve::Builder>) {
         if constexpr (TypeParam::Curve::type == CurveType::BN254 && HasGoblinBuilder<TypeParam>) {
@@ -1344,7 +1344,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_batch_mul_edge_cases)
 
 /* the following test was only developed as a test of Ultra Circuit Constructor. It fails for Standard in the
    case where Fr is a bigfield. */
-HEAVY_TYPED_TEST(stdlib_biggroup, compute_wnaf)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, compute_wnaf)
 {
     if constexpr ((!HasPlookup<typename TypeParam::Curve::Builder> && TypeParam::use_bigfield) ||
                   (TypeParam::Curve::type == CurveType::BN254 && HasGoblinBuilder<TypeParam>)) {
@@ -1356,7 +1356,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, compute_wnaf)
 
 /* batch_mul with specified value of max_num_bits does not work for a biggroup formed over a big scalar field.
    We skip such cases in the next group of tests. */
-HEAVY_TYPED_TEST(stdlib_biggroup, batch_mul_short_scalars)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, batch_mul_short_scalars)
 {
     if constexpr (TypeParam::use_bigfield) {
         GTEST_SKIP();
@@ -1368,7 +1368,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, batch_mul_short_scalars)
         };
     }
 }
-HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_batch_mul_128_bit)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, wnaf_batch_mul_128_bit)
 {
     if constexpr (TypeParam::use_bigfield) {
         GTEST_SKIP();
@@ -1380,7 +1380,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_batch_mul_128_bit)
         };
     }
 }
-HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_batch_4)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, wnaf_batch_4)
 {
     if constexpr (TypeParam::use_bigfield) {
         GTEST_SKIP();
@@ -1390,7 +1390,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_batch_4)
 }
 
 /* The following tests are specific to BN254 and don't work when Fr is a bigfield */
-HEAVY_TYPED_TEST(stdlib_biggroup, bn254_endo_batch_mul)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, bn254_endo_batch_mul)
 {
     if constexpr (TypeParam::Curve::type == CurveType::BN254 && !TypeParam::use_bigfield) {
         if constexpr (HasGoblinBuilder<TypeParam>) {
@@ -1402,7 +1402,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, bn254_endo_batch_mul)
         GTEST_SKIP();
     }
 }
-HEAVY_TYPED_TEST(stdlib_biggroup, mixed_mul_bn254_endo)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, mixed_mul_bn254_endo)
 {
     if constexpr (TypeParam::Curve::type == CurveType::BN254 && !TypeParam::use_bigfield) {
         if constexpr (HasGoblinBuilder<TypeParam>) {
@@ -1416,7 +1416,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, mixed_mul_bn254_endo)
 }
 
 /* The following tests are specific to SECP256k1 */
-HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_secp256k1)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, wnaf_secp256k1)
 {
     if constexpr (TypeParam::Curve::type == CurveType::SECP256K1) {
         TestFixture::test_wnaf_secp256k1();
@@ -1424,7 +1424,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_secp256k1)
         GTEST_SKIP();
     }
 }
-HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_8bit_secp256k1)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, wnaf_8bit_secp256k1)
 {
     if constexpr (TypeParam::Curve::type == CurveType::SECP256K1) {
         TestFixture::test_wnaf_8bit_secp256k1();
@@ -1432,7 +1432,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_8bit_secp256k1)
         GTEST_SKIP();
     }
 }
-HEAVY_TYPED_TEST(stdlib_biggroup, ecdsa_mul_secp256k1)
+HEAVY_TYPED_TEST(stdlib_biggroup_SKIP_CI, ecdsa_mul_secp256k1)
 {
     if constexpr (TypeParam::Curve::type == CurveType::SECP256K1) {
         TestFixture::test_ecdsa_mul_secp256k1();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -1192,7 +1192,7 @@ using TestTypes = testing::Types<TestType<stdlib::bn254<bb::StandardCircuitBuild
                                  TestType<stdlib::bn254<bb::MegaCircuitBuilder>, UseBigfield::No>,
                                  TestType<stdlib::bn254<bb::CircuitSimulatorBN254>, UseBigfield::No>>;
 
-TYPED_TEST_SUITE(stdlib_biggroup, TestTypes);
+TYPED_TEST_SUITE(stdlib_biggroup_SKIP_CI, TestTypes);
 
 TYPED_TEST(stdlib_biggroup_SKIP_CI, add)
 {


### PR DESCRIPTION
Introduce a string for filtering Barretenberg tests run by ctest and apply it to biggroup, bigfield, and stdlib Plonk verifier tests. These no longer run in CI!
