### PR TITLE
fix: don't prune while proposing or proving.

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -229,9 +229,6 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
     SignatureLib.Signature[] memory _signatures,
     bytes calldata _body
   ) external override(IRollup) {
-    if (_canPrune()) {
-      _prune();
-    }
     bytes32 txsEffectsHash = TxsDecoder.decode(_body);
 
     // Decode and validate header
@@ -316,9 +313,6 @@ contract Rollup is Leonidas, IRollup, ITestRollup {
     bytes calldata _aggregationObject,
     bytes calldata _proof
   ) external override(IRollup) {
-    if (_canPrune()) {
-      _prune();
-    }
     HeaderLib.Header memory header = HeaderLib.decode(_header);
 
     if (header.globalVariables.blockNumber > tips.pendingBlockNumber) {

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -455,15 +455,6 @@ contract RollupTest is DecoderBase {
     assertNotEq(minHeightEmpty, minHeightMixed, "Invalid min height");
   }
 
-  function testPruneDuringPropose() public setUpFor("mixed_block_1") {
-    _testBlock("mixed_block_1", false);
-    warpToL2Slot(Constants.AZTEC_EPOCH_DURATION * 2);
-    _testBlock("mixed_block_1", false, Constants.AZTEC_EPOCH_DURATION * 2);
-
-    assertEq(rollup.getPendingBlockNumber(), 1, "Invalid pending block number");
-    assertEq(rollup.getProvenBlockNumber(), 0, "Invalid proven block number");
-  }
-
   function testBlockFee() public setUpFor("mixed_block_1") {
     uint256 feeAmount = 2e18;
 


### PR DESCRIPTION
Apparently this broke the lending test and cheatcodes test.

Disabling auto-prune to investigate.