### PR TITLE
chore: misc cleanup

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/notes/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes/mod.nr
@@ -376,9 +376,8 @@ pub comptime fn note_custom_interface(s: StructDefinition) -> Quoted {
     let serialized_len_type = fresh_type_variable();
     let note_interface_impl = s.as_type().get_trait_impl(quote { NoteInterface<$serialized_len_type> }.as_trait_constraint());
     let name = s.name();
-    assert(note_interface_impl.is_some(), f"Note {name} must implement NoteInterface trait");
 
-    let note_serialized_len = note_interface_impl.unwrap().trait_generic_args()[0].as_constant().unwrap();
+    let note_serialized_len = note_interface_impl.expect(f"Note {name} must implement NoteInterface trait").trait_generic_args()[0].as_constant().unwrap();
 
     register_note(s, note_serialized_len, note_type_id);
 

--- a/noir-projects/aztec-nr/aztec/src/macros/storage/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/storage/mod.nr
@@ -142,21 +142,16 @@ comptime fn is_storage_map(typ: Type) -> bool {
 }
 
 comptime fn add_context_generic(typ: Type, context_generic: Type) -> Type {
-    assert(
-        typ.as_struct().is_some(), "Storage containers must be generic structs of the form `Container<..., Context>`"
-    );
+    let (def, mut generics) = typ.as_struct().expect(f"Storage containers must be generic structs of the form `Container<..., Context>`");
+    let name = def.name();
+
     if is_storage_map(typ) {
-        let (def, mut generics) = typ.as_struct().unwrap();
-        let name = def.name();
         generics[generics.len() - 2] = add_context_generic(generics[1], context_generic);
         generics[generics.len() - 1] = context_generic;
-        let generics = generics.map(|typ: Type| quote{$typ}).join(quote{,});
-        quote { $name<$generics> }.as_type()
     } else {
-        let (def, mut generics) = typ.as_struct().unwrap();
-        let name = def.name();
         generics[generics.len() - 1] = context_generic;
-        let generics = generics.map(|typ: Type| quote{$typ}).join(quote{,});
-        quote { $name<$generics> }.as_type()
     }
+
+    let generics = generics.map(|typ: Type| quote{$typ}).join(quote{,});
+    quote { $name<$generics> }.as_type()
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/utils.nr
@@ -55,8 +55,7 @@ pub(crate) comptime fn modify_fn_body(body: [Expr], prepend: Quoted, append: Quo
         }
     };
     let body_expr = body_quote.as_expr();
-    assert(body_expr.is_some(), f"Body is not an expression: {body_quote}");
-    body_expr.unwrap()
+    body_expr.expect(f"Body is not an expression: {body_quote}")
 }
 
 pub(crate) comptime fn add_to_field_slice(slice_name: Quoted, name: Quoted, typ: Type) -> Quoted {
@@ -229,11 +228,8 @@ pub(crate) comptime fn compute_event_selector(s: StructDefinition) -> Field {
 pub(crate) comptime fn get_serialized_size(typ: Type) -> u32 {
     let any = fresh_type_variable();
     let maybe_serialize_impl = typ.get_trait_impl(quote { protocol_types::traits::Serialize<$any> }.as_trait_constraint());
-    assert(
-        maybe_serialize_impl.is_some(), f"Attempted to fetch serialization length, but {typ} does not implement the Serialize trait"
-    );
-    let serialize_impl = maybe_serialize_impl.unwrap();
-    serialize_impl.trait_generic_args()[0].as_constant().unwrap()
+
+    maybe_serialize_impl.expect(f"Attempted to fetch serialization length, but {typ} does not implement the Serialize trait").trait_generic_args()[0].as_constant().unwrap()
 }
 
 pub(crate) comptime fn module_has_storage(m: Module) -> bool {

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
@@ -185,7 +185,7 @@ unconstrained fn get_note_internal<Note, let N: u32>(storage_slot: Field) -> Not
         placeholder_note,
         placeholder_fields,
         placeholder_note_length
-    )[0].unwrap() // Notice: we don't allow dummies to be returned from get_note (singular).
+    )[0].expect(f"Failed to get a note") // Notice: we don't allow dummies to be returned from get_note (singular).
 }
 
 unconstrained fn get_notes_internal<Note, let N: u32, PREPROCESSOR_ARGS, FILTER_ARGS>(

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
@@ -94,6 +94,7 @@ fn collapses_notes_at_the_beginning_of_the_array() {
     assert_equivalent_vec_and_array(returned, expected);
 }
 
+#[test]
 fn can_return_zero_notes() {
     let mut env = setup();
     let mut context = env.private();

--- a/noir-projects/aztec-nr/aztec/src/utils/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/test.nr
@@ -75,8 +75,7 @@ fn verify_collapse_hints_hint_length_mismatch() {
     verify_collapse_hints(original, collapsed, collapsed_to_input_index_mapping);
 }
 
-// https://github.com/noir-lang/noir/issues/5464
-#[test(should_fail)]
+#[test(should_fail_with="Out of bounds index hint")]
 fn verify_collapse_hints_out_of_bounds_index_hint() {
     let original = [Option::some(7), Option::none(), Option::some(3)];
     let collapsed = BoundedVec::from_array([7, 3]);


### PR DESCRIPTION
This restores a test that was missing the `#[test]` attribute, another one that was disabled by https://github.com/noir-lang/noir/issues/5464 (or rather the failure reason was removed), and replaces usage of `assert(f.is_some()); f.unwrap()` with the `expect` function.