### PR TITLE
chore: remove unused imports

### DIFF
--- a/noir-projects/aztec-nr/authwit/src/auth.nr
+++ b/noir-projects/aztec-nr/authwit/src/auth.nr
@@ -6,7 +6,7 @@ use dep::aztec::protocol_types::{
 },
     hash::poseidon2_hash_with_separator
 };
-use dep::aztec::{prelude::Deserialize, context::{PrivateContext, PublicContext, gas::GasOpts}, hash::hash_args_array};
+use dep::aztec::{context::{PrivateContext, PublicContext, gas::GasOpts}, hash::hash_args_array};
 
 /**
  * Authenticaion witness helper library

--- a/noir-projects/aztec-nr/authwit/src/auth.nr
+++ b/noir-projects/aztec-nr/authwit/src/auth.nr
@@ -215,11 +215,7 @@ pub fn assert_current_call_valid_authwit(context: &mut PrivateContext, on_behalf
  * @param on_behalf_of The address that have authorized the current call
  * @param inner_hash The hash of the message to authorize
  */
-pub fn assert_inner_hash_valid_authwit(
-    context: &mut PrivateContext,
-    on_behalf_of: AztecAddress,
-    inner_hash: Field
-) {
+pub fn assert_inner_hash_valid_authwit(context: &mut PrivateContext, on_behalf_of: AztecAddress, inner_hash: Field) {
     // We perform a static call here and not a standard one to ensure that the account contract cannot re-enter.
     let result: Field = context.static_call_private_function(
         on_behalf_of,
@@ -247,7 +243,10 @@ pub fn assert_inner_hash_valid_authwit(
  * @param on_behalf_of The address that have authorized the current call
  */
 // docs:start:assert_current_call_valid_authwit_public
-pub fn assert_current_call_valid_authwit_public(context: &mut PublicContext, on_behalf_of: AztecAddress) {
+pub fn assert_current_call_valid_authwit_public(
+    context: &mut PublicContext,
+    on_behalf_of: AztecAddress
+) {
     let inner_hash = compute_inner_authwit_hash(
         [(*context).msg_sender().to_field(), (*context).selector().to_field(), (*context).get_args_hash()]
     );
@@ -266,11 +265,7 @@ pub fn assert_current_call_valid_authwit_public(context: &mut PublicContext, on_
  *
  * @param on_behalf_of The address that have authorized the `inner_hash`
  */
-pub fn assert_inner_hash_valid_authwit_public(
-    context: &mut PublicContext,
-    on_behalf_of: AztecAddress,
-    inner_hash: Field
-) {
+pub fn assert_inner_hash_valid_authwit_public(context: &mut PublicContext, on_behalf_of: AztecAddress, inner_hash: Field) {
     let result: Field = context.call_public_function(
         CANONICAL_AUTH_REGISTRY_ADDRESS,
         comptime {
@@ -346,12 +341,7 @@ pub fn compute_authwit_nullifier(on_behalf_of: AztecAddress, inner_hash: Field) 
  * @param version The version of the chain that the message is being consumed on
  * @param inner_hash The hash of the "inner" message that is being consumed
  */
-pub fn compute_authwit_message_hash(
-    consumer: AztecAddress,
-    chain_id: Field,
-    version: Field,
-    inner_hash: Field
-) -> Field {
+pub fn compute_authwit_message_hash(consumer: AztecAddress, chain_id: Field, version: Field, inner_hash: Field) -> Field {
     poseidon2_hash_with_separator(
         [
         consumer.to_field(),

--- a/noir-projects/aztec-nr/authwit/src/entrypoint/app.nr
+++ b/noir-projects/aztec-nr/authwit/src/entrypoint/app.nr
@@ -4,7 +4,7 @@ use dep::aztec::protocol_types::{
     traits::{Hash, Serialize}
 };
 
-use crate::entrypoint::function_call::{FunctionCall, FUNCTION_CALL_SIZE_IN_BYTES};
+use crate::entrypoint::function_call::FunctionCall;
 
 // FUNCTION_CALL_SIZE * ACCOUNT_MAX_CALLS + 1
 global APP_PAYLOAD_SIZE: u32 = 21;

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/incoming_body.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/incoming_body.nr
@@ -40,7 +40,7 @@ mod test {
     };
 
     use crate::{
-        note::{note_header::NoteHeader, note_interface::{NoteInterface, PartialNote, NullifiableNote}},
+        note::{note_header::NoteHeader, note_interface::{NoteInterface, NullifiableNote}},
         encrypted_logs::incoming_body::EncryptedLogIncomingBody, event::event_interface::EventInterface,
         context::PrivateContext, keys::public_keys::IvpkM
     };

--- a/noir-projects/aztec-nr/aztec/src/macros/notes/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes/mod.nr
@@ -374,7 +374,7 @@ pub comptime fn note(s: StructDefinition) -> Quoted {
 pub comptime fn note_custom_interface(s: StructDefinition) -> Quoted {
     let (common, note_type_id) = common_note_annotation(s);
     let serialized_len_type = fresh_type_variable();
-    let note_interface_impl = s.as_type().get_trait_impl(quote { NoteInterface<$serialized_len_type> }.as_trait_constraint());
+    let note_interface_impl = s.as_type().get_trait_impl(quote { crate::note::note_interface::NoteInterface<$serialized_len_type> }.as_trait_constraint());
     let name = s.name();
 
     let note_serialized_len = note_interface_impl.expect(f"Note {name} must implement NoteInterface trait").trait_generic_args()[0].as_constant().unwrap();

--- a/noir-projects/aztec-nr/aztec/src/macros/notes/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes/mod.nr
@@ -3,7 +3,7 @@ use std::{
     hash::{BuildHasherDefault, poseidon2::Poseidon2Hasher}
 };
 use protocol_types::meta::{flatten_to_fields, pack_from_fields};
-use crate::note::{note_header::NoteHeader, note_getter_options::PropertySelector, note_interface::NoteInterface};
+use crate::note::{note_header::NoteHeader, note_getter_options::PropertySelector};
 
 comptime global NOTE_HEADER_TYPE = type_of(NoteHeader::empty());
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
@@ -33,4 +33,3 @@ impl<K, V, Context> Map<K, V, Context> {
     }
     // docs:end:at
 }
-

--- a/noir-projects/aztec-nr/aztec/src/state_vars/storage.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/storage.nr
@@ -12,4 +12,3 @@ pub trait Storage<T> where T: Serialize<N> + Deserialize<N> {
 pub struct Storable {
     slot: Field,
 }
-

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -8,7 +8,6 @@ use crate::context::{packed_returns::PackedReturns, call_interfaces::CallInterfa
 
 use crate::context::{PrivateContext, PublicContext, UnconstrainedContext};
 use crate::test::helpers::{cheatcodes, utils::{apply_side_effects_private, Deployer}};
-use crate::keys::constants::{NULLIFIER_INDEX, INCOMING_INDEX, OUTGOING_INDEX, TAGGING_INDEX};
 use crate::hash::hash_args;
 
 use crate::note::{note_header::NoteHeader, note_interface::{NoteInterface, NullifiableNote}};

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/main.nr
@@ -14,8 +14,6 @@ contract CardGame {
     use crate::game::{PLAYABLE_CARDS, PlayerEntry, Game};
     use dep::aztec::macros::{storage::storage, functions::{private, public, internal}};
 
-    use value_note::value_note::ValueNote;
-
     #[storage]
     struct Storage<Context> {
         collections: Map<AztecAddress, Deck<Context>, Context>,

--- a/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/events/private_function_broadcasted.nr
+++ b/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/events/private_function_broadcasted.nr
@@ -1,5 +1,4 @@
 use dep::aztec::prelude::FunctionSelector;
-use dep::aztec::protocol_types;
 use dep::aztec::protocol_types::{
     contract_class_id::ContractClassId,
     constants::{

--- a/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/events/unconstrained_function_broadcasted.nr
+++ b/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/events/unconstrained_function_broadcasted.nr
@@ -1,5 +1,4 @@
 use dep::aztec::prelude::FunctionSelector;
-use dep::aztec::protocol_types;
 use dep::aztec::protocol_types::{
     contract_class_id::ContractClassId,
     constants::{


### PR DESCRIPTION
Some may remain, but we're getting a lot of false positives until https://github.com/AztecProtocol/aztec-packages/pull/8760 is merged, since a re-exported private struct is considered an error, and therefore the import of said struct is considered unused.