### PR TITLE
fix: txe ts fixes

### DIFF
--- a/yarn-project/simulator/src/client/execution_note_cache.ts
+++ b/yarn-project/simulator/src/client/execution_note_cache.ts
@@ -146,4 +146,27 @@ export class ExecutionNoteCache {
     notes.push(note);
     this.noteMap.set(note.note.contractAddress.toBigInt(), notes);
   }
+
+  public getAllNotes() {
+    return this.notes;
+  }
+
+  public removeNotesFromCache(amount: number) {
+    if (amount > this.notes.length) {
+      throw new Error(`Cannot remove more notes than existing in cache. Tried to remove ${amount} notes. Total note length: ${this.notes.length}`);
+    }
+
+    for (let i = 0; i < amount; i++) {
+      const noteToRemove = this.notes.pop();
+
+      const { contractAddress } = noteToRemove!.note;
+
+      const contractNotes = this.noteMap.get(contractAddress.toBigInt());
+      if (contractNotes === undefined) {
+        throw new Error(`Notes for contract ${contractAddress} not found`);
+      }
+
+      contractNotes.pop();
+    }
+  }
 }


### PR DESCRIPTION
This PR fixes and adds some functionality that enables us to port the vast majority of e2e tests—that are able to be ported to TXE tests—to TXE tests.

A quick inventory of the additional features:

ts:

execution_note_cache
1. get all notes
2. pop notes from

txe_oracle
1. adding temp_note_cache
2. get_timestamp (avm)
3. get_low_nullifier_membership_witness
4. get_notes takes into account the status filter (nullified / non_nullified)
5. we now roll back created notes from `assertPrivateCallFails` correctly

txe_service
1. allows us to deploy contracts with public keys
2. correctly deserializes arrays that come from slices in nr