### PR TITLE
fix: porting e2e tests to txe

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/note/note_header.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_header.nr
@@ -1,4 +1,4 @@
-use dep::protocol_types::{address::AztecAddress, traits::{Empty, Serialize}};
+use dep::protocol_types::{address::AztecAddress, traits::{Empty, Serialize, Deserialize}};
 
 global NOTE_HEADER_LENGTH: u32 = 4;
 
@@ -41,5 +41,19 @@ impl Serialize<NOTE_HEADER_LENGTH> for NoteHeader {
         [
             self.contract_address.to_field(), self.nonce, self.storage_slot, self.note_hash_counter as Field
         ]
+    }
+}
+
+impl Deserialize<NOTE_HEADER_LENGTH> for NoteHeader {
+    /// The following method is used by implementations of the Deserialize trait for notes
+    fn deserialize(fields: [Field; NOTE_HEADER_LENGTH]) -> NoteHeader {
+        // Note: If you change this function don't forget to update implementations of Deserialize trait for notes.
+        // (Deserialize trait needs to be implemented for a note when it's returned from a contract function (e.g. in the case of TXe tests)
+        NoteHeader {
+            contract_address: AztecAddress::from_field(fields[0]),
+            nonce: fields[1],
+            storage_slot: fields[2],
+            note_hash_counter: fields[3] as u32,
+        }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
@@ -6,7 +6,7 @@ use dep::protocol_types::{
 
 use crate::context::inputs::PrivateContextInputs;
 use crate::context::call_interfaces::CallInterface;
-use crate::test::helpers::cheatcodes;
+use crate::test::helpers::{cheatcodes, test_environment::TestEnvironment};
 use crate::keys::public_keys::{PUBLIC_KEYS_LENGTH, PublicKeys};
 
 use crate::oracle::execution::{get_block_number, get_contract_address};
@@ -141,4 +141,52 @@ impl Deserialize<TEST_ACCOUNT_LENGTH> for TestAccount {
 
         Self { address, keys }
     }
+}
+
+unconstrained pub fn setup(
+    with_account_contracts: bool,
+    with_canonical_contracts: bool,
+) -> (
+  &mut TestEnvironment,
+  (AztecAddress, AztecAddress, AztecAddress, AztecAddress, AztecAddress)
+) {
+    let mut env = TestEnvironment::new();
+
+    let (account_1, account_2, account_3, account_4, account_5) = if (
+        with_account_contracts
+    ) {
+        (
+            env.create_account_contract(1),
+            env.create_account_contract(2),
+            env.create_account_contract(3),
+            env.create_account_contract(4),
+            env.create_account_contract(5)
+        )
+    } else {
+        (
+            env.create_account(),
+            env.create_account(),
+            env.create_account(),
+            env.create_account(),
+            env.create_account()
+        )
+    };
+
+    env.impersonate(account_1);
+
+    if (with_canonical_contracts) {
+        // Deploy canonical auth registry
+        let _auth_registry = env.deploy("./@auth_registry_contract", "AuthRegistry").without_initializer();
+        env.advance_block_by(1);
+
+        // Deploy canonical router
+        let _router_contract = env.deploy("./@router_contract", "Router").without_initializer();
+    }
+
+    env.advance_block_by(1);
+
+    (
+      &mut env,
+      (account_1, account_2, account_3, account_4, account_5)
+    )
 }

--- a/noir-projects/aztec-nr/value-note/src/value_note.nr
+++ b/noir-projects/aztec-nr/value-note/src/value_note.nr
@@ -1,5 +1,5 @@
 use dep::aztec::{
-    protocol_types::{traits::Serialize, constants::GENERATOR_INDEX__NOTE_NULLIFIER, hash::poseidon2_hash_with_separator},
+    protocol_types::{traits::{Serialize, Deserialize}, constants::GENERATOR_INDEX__NOTE_NULLIFIER, hash::poseidon2_hash_with_separator},
     macros::notes::note,
     note::{note_header::NoteHeader, note_interface::NullifiableNote, utils::compute_note_hash_for_nullify},
     oracle::unsafe_rand::unsafe_rand, keys::getters::get_nsk_app, context::PrivateContext
@@ -54,6 +54,20 @@ impl ValueNote {
         let randomness = unsafe_rand();
         let header = NoteHeader::empty();
         ValueNote { value, npk_m_hash, randomness, header }
+    }
+}
+
+impl Deserialize<7> for ValueNote {
+    /// The following method needed to be implemented because the note is returned from a contract function in noir (e.g. in a TXe test)
+    fn deserialize(fields: [Field; 7]) -> Self {
+        let header = NoteHeader::deserialize([fields[3], fields[4], fields[5], fields[6]]);
+
+        ValueNote {
+            value: fields[0],
+            npk_m_hash: fields[1],
+            randomness: fields[2],
+            header,
+        }
     }
 }
 

--- a/noir-projects/noir-contracts/contracts/auth_wit_test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/auth_wit_test_contract/Nargo.toml
@@ -7,3 +7,6 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../aztec-nr/aztec" }
 authwit = { path = "../../../aztec-nr/authwit" }
+protocol_types = { path = "../../../noir-protocol-circuits/crates/types" }
+schnorr_account_contract = { path = "../schnorr_account_contract" }
+auth_registry_contract = { path = "../auth_registry_contract" }

--- a/noir-projects/noir-contracts/contracts/auth_wit_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/auth_wit_test_contract/src/main.nr
@@ -1,5 +1,7 @@
 use dep::aztec::macros::aztec;
 
+mod test;
+
 #[aztec]
 contract AuthWitTest {
     use dep::aztec::{protocol_types::address::AztecAddress, macros::{functions::{private, public}}};

--- a/noir-projects/noir-contracts/contracts/auth_wit_test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/auth_wit_test_contract/src/test.nr
@@ -1,0 +1,2 @@
+mod main;
+mod utils;

--- a/noir-projects/noir-contracts/contracts/auth_wit_test_contract/src/test/main.nr
+++ b/noir-projects/noir-contracts/contracts/auth_wit_test_contract/src/test/main.nr
@@ -1,0 +1,152 @@
+use crate::test::utils;
+use crate::AuthWitTest;
+
+use dep::schnorr_account_contract::SchnorrAccount;
+use dep::auth_registry_contract::AuthRegistry;
+
+use dep::aztec::{oracle::{unsafe_rand::unsafe_rand, execution::{get_chain_id, get_version}}, test::helpers::cheatcodes};
+use dep::authwit::{auth::{compute_inner_authwit_hash, compute_authwit_message_hash, IS_VALID_SELECTOR}, cheatcodes::set_public_authwit_from_inner_hash};
+use protocol_types::constants::CANONICAL_AUTH_REGISTRY_ADDRESS;
+
+#[test]
+fn private_authwit_flow() {
+    let (env, authwit_test_contract_address, account_1, account_2) = utils::setup();
+
+    let inner_hash = compute_inner_authwit_hash([0xdead]);
+    let message_hash = compute_authwit_message_hash(authwit_test_contract_address, get_chain_id(), get_version(), inner_hash);
+    cheatcodes::add_authwit(account_1, message_hash);
+
+    let authwit_valid_for_account_1 = env.call_unconstrained(account_1, || { SchnorrAccount::lookup_validity(authwit_test_contract_address, inner_hash) });
+    assert_eq(authwit_valid_for_account_1, true);
+
+    let authwit_valid_for_account_2 =  env.call_unconstrained(account_2, || { SchnorrAccount::lookup_validity(authwit_test_contract_address, inner_hash) });
+    assert_eq(authwit_valid_for_account_2, false);
+
+    env.impersonate(account_2);
+    env.call_private_void(AuthWitTest::at(authwit_test_contract_address).consume(account_1, inner_hash));
+
+    // Calls the function again
+    env.assert_private_call_fails(AuthWitTest::at(authwit_test_contract_address).consume(account_1, inner_hash));
+}
+
+#[test(should_fail_with="Auth witness not found for message hash")]
+fn private_wrong_chain_id_lookup_validity_fails() {
+    let (env, authwit_test_contract_address, account_1, account_2) = utils::setup();
+
+    let inner_hash = compute_inner_authwit_hash([0xdead, 0xbeef]);
+    let message_hash = compute_authwit_message_hash(authwit_test_contract_address, unsafe_rand(), get_version(), inner_hash);
+
+    cheatcodes::add_authwit(account_1, message_hash);
+
+    env.call_unconstrained(account_1, || { SchnorrAccount::lookup_validity(authwit_test_contract_address, inner_hash) });
+}
+
+#[test(should_fail_with="Authorization not found for message hash")]
+fn private_wrong_chain_id_consume_fails() {
+    let (env, authwit_test_contract_address, account_1, account_2) = utils::setup();
+
+    let inner_hash = compute_inner_authwit_hash([0xdead, 0xbeef]);
+    let message_hash = compute_authwit_message_hash(authwit_test_contract_address, unsafe_rand(), get_version(), inner_hash);
+
+    cheatcodes::add_authwit(account_1, message_hash);
+
+    env.impersonate(account_2);
+    env.call_private_void(AuthWitTest::at(authwit_test_contract_address).consume(account_1, inner_hash));
+}
+
+#[test(should_fail_with="Auth witness not found for message hash")]
+fn private_wrong_version_lookup_validity_fails() {
+    let (env, authwit_test_contract_address, account_1, account_2) = utils::setup();
+
+    let inner_hash = compute_inner_authwit_hash([0xdead, 0xbeef]);
+    let message_hash = compute_authwit_message_hash(authwit_test_contract_address, get_chain_id(), unsafe_rand(), inner_hash);
+
+    cheatcodes::add_authwit(account_1, message_hash);
+
+    env.call_unconstrained(account_1, || { SchnorrAccount::lookup_validity(authwit_test_contract_address, inner_hash) });
+}
+
+#[test(should_fail_with="Authorization not found for message hash")]
+fn private_wrong_version_consume_fails() {
+    let (env, authwit_test_contract_address, account_1, account_2) = utils::setup();
+
+    let inner_hash = compute_inner_authwit_hash([0xdead, 0xbeef]);
+    let message_hash = compute_authwit_message_hash(authwit_test_contract_address, get_chain_id(), unsafe_rand(), inner_hash);
+
+    cheatcodes::add_authwit(account_1, message_hash);
+
+    env.impersonate(account_2);
+    env.call_private_void(AuthWitTest::at(authwit_test_contract_address).consume(account_1, inner_hash));
+}
+
+#[test]
+unconstrained fn public_flow() {
+    let (env, _, account_1, account_2) = utils::setup();
+
+    let inner_hash = compute_inner_authwit_hash([0xdead, 0x01]);
+    let message_hash = compute_authwit_message_hash(account_2, get_chain_id(), get_version(), inner_hash);
+
+    let authwit_valid_for_account_1_before = env.call_unconstrained(CANONICAL_AUTH_REGISTRY_ADDRESS, || { AuthRegistry::unconstrained_is_consumable(account_1, message_hash) });
+    assert_eq(authwit_valid_for_account_1_before, false);
+
+    set_public_authwit_from_inner_hash(account_2, account_1, inner_hash, true);
+
+    let authwit_valid_for_account_1 = env.call_unconstrained(CANONICAL_AUTH_REGISTRY_ADDRESS, || { AuthRegistry::unconstrained_is_consumable(account_1, message_hash) });
+    assert_eq(authwit_valid_for_account_1, true);
+
+    env.impersonate(account_2);
+    let valid = env.call_public(AuthRegistry::at(CANONICAL_AUTH_REGISTRY_ADDRESS).consume(account_1, inner_hash));
+
+    assert_eq(valid, IS_VALID_SELECTOR);
+
+    let authwit_valid_for_account_1_after_consume = env.call_unconstrained(CANONICAL_AUTH_REGISTRY_ADDRESS, || { AuthRegistry::unconstrained_is_consumable(account_1, message_hash) });
+    assert_eq(authwit_valid_for_account_1_after_consume, false);
+}
+
+#[test]
+unconstrained fn public_flow_with_authwit_test_contract() {
+    let (env, authwit_test_contract_address, account_1, account_2) = utils::setup();
+
+    let inner_hash = compute_inner_authwit_hash([0xdead, 0x01]);
+    let message_hash = compute_authwit_message_hash(authwit_test_contract_address, get_chain_id(), get_version(), inner_hash);
+
+    let authwit_valid_for_account_1_before = env.call_unconstrained(CANONICAL_AUTH_REGISTRY_ADDRESS, || { AuthRegistry::unconstrained_is_consumable(account_1, message_hash) });
+    assert_eq(authwit_valid_for_account_1_before, false);
+
+    set_public_authwit_from_inner_hash(authwit_test_contract_address, account_1, inner_hash, true);
+
+    let authwit_valid_for_account_1 = env.call_unconstrained(CANONICAL_AUTH_REGISTRY_ADDRESS, || { AuthRegistry::unconstrained_is_consumable(account_1, message_hash) });
+    assert_eq(authwit_valid_for_account_1, true);
+
+    env.impersonate(account_2);
+
+    // TODO: Figure out why this fails with brillig panic
+    // env.call_public(AuthWitTest::at(authwit_test_contract_address).consume_public(account_1, inner_hash));
+
+    // let authwit_valid_for_account_1_after_consume = env.call_unconstrained(CANONICAL_AUTH_REGISTRY_ADDRESS, || { AuthRegistry::unconstrained_is_consumable(account_1, message_hash) });
+    // assert_eq(authwit_valid_for_account_1_after_consume, false);
+}
+
+#[test(should_fail_with="unauthorized")]
+unconstrained fn public_flow_with_unset() {
+    let (env, _, account_1, account_2) = utils::setup();
+
+    let inner_hash = compute_inner_authwit_hash([0xdead, 0x02]);
+    let message_hash = compute_authwit_message_hash(account_2, get_chain_id(), get_version(), inner_hash);
+
+    let authwit_valid_for_account_1_before = env.call_unconstrained(CANONICAL_AUTH_REGISTRY_ADDRESS, || { AuthRegistry::unconstrained_is_consumable(account_1, message_hash) });
+    assert_eq(authwit_valid_for_account_1_before, false);
+
+    set_public_authwit_from_inner_hash(account_2, account_1, inner_hash, true);
+
+    let authwit_valid_for_account_1 = env.call_unconstrained(CANONICAL_AUTH_REGISTRY_ADDRESS, || { AuthRegistry::unconstrained_is_consumable(account_1, message_hash) });
+    assert_eq(authwit_valid_for_account_1, true);
+
+    set_public_authwit_from_inner_hash(account_2, account_1, inner_hash, false);
+
+    let authwit_valid_for_account_1_before = env.call_unconstrained(CANONICAL_AUTH_REGISTRY_ADDRESS, || { AuthRegistry::unconstrained_is_consumable(account_1, message_hash) });
+    assert_eq(authwit_valid_for_account_1_before, false);
+
+    env.impersonate(account_2);
+    env.call_public(AuthRegistry::at(CANONICAL_AUTH_REGISTRY_ADDRESS).consume(account_1, inner_hash)) as Field;
+}

--- a/noir-projects/noir-contracts/contracts/auth_wit_test_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/auth_wit_test_contract/src/test/utils.nr
@@ -1,0 +1,17 @@
+use dep::aztec::{
+    prelude::AztecAddress, test::helpers::test_environment::TestEnvironment,
+};
+
+pub fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress) {
+    let mut env = TestEnvironment::new();
+
+    let account_1 = env.create_account_contract(1);
+    let account_2 = env.create_account_contract(2);
+    // Deploy canonical auth registry
+    let _auth_registry = env.deploy("./@auth_registry_contract", "AuthRegistry").without_initializer();
+
+    let auth_test_contract = env.deploy("./@auth_wit_test_contract", "AuthWitTest").without_initializer();
+
+    env.advance_block_by(1);
+    (&mut env, auth_test_contract.to_address(), account_1, account_2)
+}

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -14,6 +14,12 @@ pub struct Card {
     points: u32,
 }
 
+impl Eq for Card {
+    fn eq(self, other: Card) -> bool {
+        (self.strength == other.strength) & (self.points == other.points)
+    }
+}
+
 impl FromField for Card {
     fn from_field(field: Field) -> Card {
         let value_bytes: [u8; 32] = field.to_le_bytes();

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/main.nr
@@ -1,5 +1,6 @@
 mod cards;
 mod game;
+mod test;
 
 use dep::aztec::macros::aztec;
 

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/test.nr
@@ -1,0 +1,2 @@
+mod main;
+mod utils;

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/test/main.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/test/main.nr
@@ -1,0 +1,209 @@
+use crate::test::utils;
+use crate::CardGame;
+
+use dep::aztec::{prelude::AztecAddress, oracle::{unsafe_rand::unsafe_rand, execution::{get_chain_id, get_version, get_contract_address}}, test::helpers::cheatcodes};
+use crate::cards::get_pack_cards;
+use crate::cards::Card;
+use crate::game::PlayerEntry;
+
+#[test]
+fn main() {
+    let (env, card_game_contract_address, account_1, account_2) = utils::setup();
+
+    let deck_seed = 27;
+
+    env.impersonate(account_1);
+    env.call_private_void(CardGame::at(card_game_contract_address).buy_pack(deck_seed));
+    env.advance_block_by(1);
+
+    let actual_cards = env.call_unconstrained(card_game_contract_address, || { CardGame::view_collection_cards(account_1, 0) });
+    assert(actual_cards.len() == 3);
+    assert(actual_cards.max_len() == 10);
+
+    let mut private_context = env.private();
+
+    let current_contract_address = get_contract_address();
+
+    cheatcodes::set_contract_address(card_game_contract_address);
+    let expected_cards: BoundedVec<Card, 10> = BoundedVec::from(get_pack_cards(deck_seed, account_1, &mut private_context));
+    cheatcodes::set_contract_address(current_contract_address);
+
+    assert(expected_cards.len() == 3);
+    assert(expected_cards.max_len() == 10);
+
+    for i in 0..3 {
+      assert(expected_cards.any(|expected| {
+        actual_cards.get(i).eq(expected)
+      }));
+    }
+}
+
+
+#[test]
+unconstrained fn play_game() {
+    let (env, card_game_contract_address, account_1, account_2) = utils::setup();
+
+    let deck_seed = 27;
+    let game_id = 42;
+
+    env.impersonate(account_1);
+    env.call_private_void(CardGame::at(card_game_contract_address).buy_pack(deck_seed));
+    env.advance_block_by(1);
+
+    env.impersonate(account_2);
+    env.call_private_void(CardGame::at(card_game_contract_address).buy_pack(deck_seed));
+    env.advance_block_by(1);
+
+    env.impersonate(account_1);
+    let actual_cards: BoundedVec<Card, 10> = env.call_unconstrained(card_game_contract_address, || { CardGame::view_collection_cards(account_1, 0) });
+    env.call_private_void(CardGame::at(card_game_contract_address).join_game(game_id, [actual_cards.get(0).to_field(), actual_cards.get(1).to_field()]));
+    env.advance_block_by(1);
+
+    env.impersonate(account_2);
+    env.assert_private_call_fails(CardGame::at(card_game_contract_address).join_game(game_id, [actual_cards.get(0).to_field(), actual_cards.get(1).to_field()]));
+    env.advance_block_by(1);
+
+    let actual_cards_after_joining_game = env.call_unconstrained(card_game_contract_address, || { CardGame::view_collection_cards(account_1, 0) });
+    assert(actual_cards_after_joining_game.len() == 1);
+
+    let one_player_game = env.call_unconstrained(card_game_contract_address, || { CardGame::view_game(game_id) });
+
+    assert(
+        (one_player_game.started == false) &
+        (one_player_game.finished == false) &
+        (one_player_game.claimed == false) &
+        (one_player_game.current_player == 0)
+    );
+
+    assert(
+        (one_player_game.players[0].address.eq(account_1)) &
+        (one_player_game.players[0].deck_strength > 0) &
+        (one_player_game.players[0].points == 0)
+    );
+
+    assert(
+        (one_player_game.players[1].address.eq(AztecAddress::zero())) &
+        (one_player_game.players[1].deck_strength == 0) &
+        (one_player_game.players[1].points == 0)
+    );
+
+
+    env.impersonate(account_2);
+    let actual_cards_account_2: BoundedVec<Card, 10> = env.call_unconstrained(card_game_contract_address, || { CardGame::view_collection_cards(account_2, 0) });
+    env.call_private_void(CardGame::at(card_game_contract_address).join_game(game_id, [actual_cards_account_2.get(0).to_field(), actual_cards_account_2.get(1).to_field()]));
+    env.advance_block_by(1);
+
+    let actual_game_cards = [actual_cards, actual_cards_account_2];
+
+    env.impersonate(account_1);
+    env.call_public(CardGame::at(card_game_contract_address).start_game(game_id));
+    env.advance_block_by(1);
+
+    let started_game = env.call_unconstrained(card_game_contract_address, || { CardGame::view_game(game_id) });
+
+    assert(
+        (started_game.started == true) &
+        (started_game.finished == false) &
+        (started_game.claimed == false) &
+        (started_game.current_player == 0)
+    );
+
+    assert(started_game.players.len() == 2);
+
+    assert(started_game.players.any(|player: PlayerEntry| {
+        (player.address.eq(account_1)) &
+        (player.deck_strength > 0) &
+        (player.points == 0)
+    }));
+
+    assert(started_game.players.any(|player: PlayerEntry| {
+        (player.address.eq(account_2)) &
+        (player.deck_strength > 0) &
+        (player.points == 0)
+    }));
+
+    let first_to_move = if (started_game.players[0].address.eq(account_1)) {0} else {1};
+    let second_to_move = (!(first_to_move as bool)) as Field;
+
+    for i in 0..2 {
+        env.impersonate(started_game.players[0].address);
+        env.call_private_void(CardGame::at(card_game_contract_address).play_card(game_id, actual_game_cards[first_to_move].get(i)));
+        env.advance_block_by(1);
+
+        env.impersonate(started_game.players[1].address);
+        env.call_private_void(CardGame::at(card_game_contract_address).play_card(game_id, actual_game_cards[second_to_move].get(i)));
+        env.advance_block_by(1);
+    }
+
+    let finished_game = env.call_unconstrained(card_game_contract_address, || { CardGame::view_game(game_id) });
+
+    assert(
+        (finished_game.started == true) &
+        (finished_game.finished == true) &
+        (finished_game.claimed == false) &
+        (finished_game.current_player == 0)
+    );
+
+    let (winner, loser) = if (finished_game.players[0].points > finished_game.players[1].points) {
+        (finished_game.players[0].address, finished_game.players[1].address)
+    } else {
+        (finished_game.players[1].address, finished_game.players[0].address)
+    };
+
+    env.impersonate(loser);
+    env.assert_private_call_fails(CardGame::at(card_game_contract_address).claim_cards(game_id, finished_game.rounds_cards.map(|card: Card| card.to_field())));
+    env.advance_block_by(1);
+
+    env.impersonate(winner);
+    env.call_private_void(CardGame::at(card_game_contract_address).claim_cards(game_id, finished_game.rounds_cards.map(|card: Card| card.to_field())));
+    env.advance_block_by(1);
+
+    let actual_cards_after_winning_game = env.call_unconstrained(card_game_contract_address, || { CardGame::view_collection_cards(winner, 0) });
+    assert(actual_cards_after_winning_game.len() == 5);
+
+    env.impersonate(loser);
+    env.call_private_void(CardGame::at(card_game_contract_address).buy_pack(deck_seed + 1));
+    env.advance_block_by(1);
+
+    let actual_cards_after_buying_back_in = env.call_unconstrained(card_game_contract_address, || { CardGame::view_collection_cards(loser, 0) });
+
+    assert(actual_cards_after_buying_back_in.len() == 4);
+
+    let actual_second_game_cards = [actual_cards_after_winning_game, actual_cards_after_buying_back_in];
+
+    env.call_private_void(CardGame::at(card_game_contract_address).join_game(game_id + 1, [actual_cards_after_buying_back_in.get(0).to_field(), actual_cards_after_buying_back_in.get(1).to_field()]));
+    env.advance_block_by(1);
+
+    env.impersonate(winner);
+    env.call_private_void(CardGame::at(card_game_contract_address).join_game(game_id + 1, [actual_cards_after_winning_game.get(3).to_field(), actual_cards_after_winning_game.get(4).to_field()]));
+    env.advance_block_by(1);
+
+    env.call_public(CardGame::at(card_game_contract_address).start_game(game_id + 1));
+    env.advance_block_by(1);
+
+    let second_started_game = env.call_unconstrained(card_game_contract_address, || { CardGame::view_game(game_id + 1) });
+
+    for i in 0..2 {
+        if (second_started_game.players[0].address.eq(winner)) {
+            env.impersonate(winner);
+            env.call_private_void(CardGame::at(card_game_contract_address).play_card(game_id + 1, actual_cards_after_winning_game.get(3 + i)));
+            env.advance_block_by(1);
+
+            env.impersonate(loser);
+            env.call_private_void(CardGame::at(card_game_contract_address).play_card(game_id + 1, actual_cards_after_buying_back_in.get(i)));
+            env.advance_block_by(1);
+        } else {
+            env.impersonate(loser);
+            env.call_private_void(CardGame::at(card_game_contract_address).play_card(game_id + 1, actual_cards_after_buying_back_in.get(i)));
+            env.advance_block_by(1);
+
+            env.impersonate(winner);
+            env.call_private_void(CardGame::at(card_game_contract_address).play_card(game_id + 1, actual_cards_after_winning_game.get(3 + i)));
+            env.advance_block_by(1);
+        }
+    }
+
+
+    let second_finished_game = env.call_unconstrained(card_game_contract_address, || { CardGame::view_game(game_id + 1) });
+    assert(second_finished_game.finished);
+}

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/test/utils.nr
@@ -1,0 +1,15 @@
+use dep::aztec::{
+    prelude::AztecAddress, test::helpers::test_environment::TestEnvironment,
+};
+
+pub fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress) {
+    let mut env = TestEnvironment::new();
+
+    let account_1 = env.create_account();
+    let account_2 = env.create_account();
+
+    let card_game_contract = env.deploy("./@card_game_contract", "CardGame").without_initializer();
+
+    env.advance_block_by(1);
+    (&mut env, card_game_contract.to_address(), account_1, account_2)
+}

--- a/noir-projects/noir-contracts/contracts/crowdfunding_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/crowdfunding_contract/Nargo.toml
@@ -6,6 +6,8 @@ type = "contract"
 
 [dependencies]
 aztec = { path = "../../../aztec-nr/aztec" }
+authwit = { path = "../../../aztec-nr/authwit" }
 value_note = { path = "../../../aztec-nr/value-note" }
 token = { path = "../token_contract" }
 router = { path = "../router_contract" }
+claim = { path = "../claim_contract" }

--- a/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
@@ -1,3 +1,5 @@
+mod test;
+
 // docs:start:empty-contract
 use dep::aztec::macros::aztec;
 
@@ -60,7 +62,7 @@ contract Crowdfunding {
 
     // docs:start:donate
     #[private]
-    fn donate(amount: u64) {
+    fn donate(amount: u64) -> ValueNote {
         // 1) Check that the deadline has not passed --> we do that via the router contract to conceal which contract
         // is performing the check.
         // docs:start:call-check-deadline
@@ -81,6 +83,7 @@ contract Crowdfunding {
         let mut note = ValueNote::new(amount as Field, donor_keys.npk_m.hash());
         // docs:end:valuenote_new
         storage.donation_receipts.insert(&mut note).emit(encode_and_encrypt_note_with_keys(&mut context, donor_keys.ovpk_m, donor_keys.ivpk_m, donor));
+        note
     }
     // docs:end:donate
 

--- a/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/test.nr
@@ -1,0 +1,2 @@
+mod main;
+mod utils;

--- a/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/test/main.nr
+++ b/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/test/main.nr
@@ -1,0 +1,45 @@
+use crate::test::utils;
+use crate::Crowdfunding;
+use dep::claim::Claim;
+use dep::token::Token;
+use dep::authwit::cheatcodes as authwit_cheatcodes;
+
+use dep::aztec::{prelude::AztecAddress, oracle::{unsafe_rand::unsafe_rand, execution::{get_chain_id, get_version, get_contract_address}}, test::helpers::cheatcodes};
+use dep::value_note::value_note::ValueNote;
+
+#[test]
+fn main() {
+    let (
+        env,
+        donation_token_contract_address,
+        reward_token_contract_address,
+        crowdfunding_contract_address,
+        claim_contract_address,
+        account_1,
+        account_2
+    ) = utils::setup();
+    env.impersonate(account_1);
+
+    env.call_private_void(Token::at(donation_token_contract_address).privately_mint_private_note(2000000));
+    env.advance_block_by(1);
+
+    let bal = env.call_unconstrained(donation_token_contract_address, || { Token::balance_of_private(account_1) });
+    assert_eq(bal, 2000000);
+
+    let transfer_private_from_call_interface = Token::at(donation_token_contract_address).transfer_from(account_1, crowdfunding_contract_address, 999999, 0);
+    authwit_cheatcodes::add_private_authwit_from_call_interface(account_1, crowdfunding_contract_address, transfer_private_from_call_interface);
+
+    assert(crowdfunding_contract_address.eq(AztecAddress::from_field(0x2f931814ecca22bc73bc91827315eab2d08f6c907e3dbbbfeb9fc670612ba31a)));
+
+    let claim_note: ValueNote= env.call_private(Crowdfunding::at(crowdfunding_contract_address).donate(999999));
+    env.advance_block_by(1);
+
+    let mut bal = env.call_unconstrained(donation_token_contract_address, || { Token::balance_of_private(account_1) });
+    assert_eq(bal, 2000000 - 999999);
+
+    bal = env.call_unconstrained(donation_token_contract_address, || { Token::balance_of_private(crowdfunding_contract_address) });
+    assert_eq(bal, 999999);
+
+    // This doesn't work because proving historical proofs don't work
+    // env.call_private_void(Claim::at(claim_contract_address).claim(claim_note, account_1));
+}

--- a/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/test/utils.nr
@@ -1,0 +1,89 @@
+use dep::aztec::{
+    prelude::AztecAddress, test::helpers::test_environment::TestEnvironment,
+};
+use crate::Crowdfunding;
+
+use dep::token::Token;
+use dep::claim::Claim;
+
+pub fn setup() -> (
+  &mut TestEnvironment,
+  AztecAddress,
+  AztecAddress,
+  AztecAddress,
+  AztecAddress,
+  AztecAddress,
+  AztecAddress
+) {
+    let mut env = TestEnvironment::new();
+    let account_1 = env.create_account_contract(1);
+    let account_2 = env.create_account_contract(2);
+    env.impersonate(account_1);
+
+    // Deploy canonical auth registry
+    let _auth_registry = env.deploy("./@auth_registry_contract", "AuthRegistry").without_initializer();
+    env.advance_block_by(1);
+
+      // Deploy canonical auth registry
+    let _router_contract = env.deploy("./@router_contract", "Router").without_initializer();
+    env.advance_block_by(1);
+
+    // Start the test in the account contract address
+    env.impersonate(account_1);
+
+    // Deploy token contract
+    let donation_token_initializer_call_interface = Token::interface().constructor(
+        account_1,
+        "DonationToken000000000000000000",
+        "DNT0000000000000000000000000000",
+        18
+    );
+    let donation_token_contract = env.deploy("./@token_contract", "Token").with_public_initializer(donation_token_initializer_call_interface);
+    let donation_token_contract_address = donation_token_contract.to_address();
+    env.advance_block_by(1);
+
+    // Deploy reward token
+    let reward_token_initializer_call_interface = Token::interface().constructor(
+        account_1,
+        "RewardToken00000000000000000000",
+        "RWD0000000000000000000000000000",
+        18
+    );
+    let reward_token_contract = env.deploy("./@token_contract", "Token").with_public_initializer(reward_token_initializer_call_interface);
+    let reward_token_contract_address = reward_token_contract.to_address();
+    env.advance_block_by(1);
+
+    // Deploy Crowdfunding contract with public keys
+    let crowdfunding_initializer_call_interface = Crowdfunding::interface().init(
+      donation_token_contract_address,
+      account_1,
+      3137976546,
+    );
+    let crowdfunding_contract = env.deploy_with_public_keys("./@crowdfunding_contract", "Crowdfunding", 6969).with_public_initializer(crowdfunding_initializer_call_interface);
+    let crowdfunding_contract_address = crowdfunding_contract.to_address();
+
+    assert(crowdfunding_contract_address.eq(AztecAddress::from_field(0x2f931814ecca22bc73bc91827315eab2d08f6c907e3dbbbfeb9fc670612ba31a)));
+    env.advance_block_by(1);
+
+    // Deploy Claim contract
+    let claim_initializer_call_interface = Claim::interface().constructor(
+      crowdfunding_contract_address,
+      reward_token_contract_address,
+    );
+    let claim_contract = env.deploy("./@claim_contract", "Claim").with_public_initializer(claim_initializer_call_interface);
+    let claim_contract_address = claim_contract.to_address();
+    env.advance_block_by(1);
+
+    env.call_public(Token::at(reward_token_contract_address).set_minter(claim_contract_address, true));
+    env.advance_block_by(1);
+
+    (
+      &mut env,
+      donation_token_contract_address,
+      reward_token_contract_address,
+      crowdfunding_contract_address,
+      claim_contract_address,
+      account_1,
+      account_2
+    )
+}

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -1,5 +1,6 @@
 mod options;
 mod types;
+mod test;
 
 // Following is a very simple game to show case use of PrivateMutable in as minimalistic way as possible
 // It also serves as an e2e test that you can read and then replace the PrivateMutable in the same call

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/test.nr
@@ -1,0 +1,2 @@
+mod note_getter;
+mod state_vars;

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/test/note_getter.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/test/note_getter.nr
@@ -1,0 +1,209 @@
+use aztec::utils::comparison::Comparator;
+use crate::DocsExample;
+use crate::types::card_note::CardNote;
+use dep::aztec::test::helpers::utils;
+
+#[test]
+unconstrained fn comparators() {
+  let (env) = utils::setup(false, false);
+    // The docs_example_contract has the functions we need to test note retrieval.
+    let docs_example_contract = env.deploy("./@docs_example_contract", "DocsExample").without_initializer();
+    let docs_example_contract_address = docs_example_contract.to_address();
+    env.advance_block_by(1);
+
+    // We insert notes with various values to fetch them later
+    env.call_private_void(DocsExample::at(docs_example_contract_address).initialize_private(1337, 1));
+    env.call_private_void(DocsExample::at(docs_example_contract_address).insert_notes([0, 1, 2]));
+    env.call_private_void(DocsExample::at(docs_example_contract_address).insert_notes([3, 4, 5]));
+    env.call_private_void(DocsExample::at(docs_example_contract_address).insert_notes([6, 7, 8]));
+    env.call_private_void(DocsExample::at(docs_example_contract_address).insert_note(9, 1));
+    env.call_private_void(DocsExample::at(docs_example_contract_address).insert_note(5, 0));
+
+    env.advance_block_by(1);
+
+    // We query for the notes with the correct comparator
+    let return_eq = env.call_unconstrained(docs_example_contract_address, || {DocsExample::read_note(Comparator.EQ, 5)});
+    let return_neq = env.call_unconstrained(docs_example_contract_address, || {DocsExample::read_note(Comparator.NEQ, 5)});
+    let return_lt = env.call_unconstrained(docs_example_contract_address, || {DocsExample::read_note(Comparator.LT, 5)});
+    let return_gt = env.call_unconstrained(docs_example_contract_address, || {DocsExample::read_note(Comparator.GT, 5)});
+    let return_lte = env.call_unconstrained(docs_example_contract_address, || {DocsExample::read_note(Comparator.LTE, 5)});
+    let return_gte = env.call_unconstrained(docs_example_contract_address, || {DocsExample::read_note(Comparator.GTE, 5)});
+
+    // TODO: Make some test utils
+    // EQ values
+    assert(return_eq.len() == 2);
+    assert(return_eq.any(|card: CardNote| {
+        (card.points == 5) &
+        (card.randomness ==  0)
+    }));
+
+    assert(return_eq.any(|card: CardNote| {
+        (card.points == 5) &
+        (card.randomness ==  1)
+    }));
+
+    // NEQ values
+    assert(return_neq.len() == 9);
+    assert(return_neq.any(|card: CardNote| {
+        (card.points == 0) &
+        (card.randomness == 1)
+    }));
+
+    assert(return_neq.any(|card: CardNote| {
+        (card.points == 1) &
+        (card.randomness == 1)
+    }));
+
+    assert(return_neq.any(|card: CardNote| {
+        (card.points == 2) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_neq.any(|card: CardNote| {
+        (card.points == 3) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_neq.any(|card: CardNote| {
+        (card.points == 4) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_neq.any(|card: CardNote| {
+        (card.points == 6) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_neq.any(|card: CardNote| {
+        (card.points == 7) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_neq.any(|card: CardNote| {
+        (card.points == 8) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_neq.any(|card: CardNote| {
+        (card.points == 9) &
+        (card.randomness ==  1)
+    }));
+
+    // LT values
+    assert(return_lt.len() == 5);
+    assert(return_neq.any(|card: CardNote| {
+        (card.points == 0) &
+        (card.randomness == 1)
+    }));
+
+    assert(return_lt.any(|card: CardNote| {
+        (card.points == 1) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_lt.any(|card: CardNote| {
+        (card.points == 2) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_lt.any(|card: CardNote| {
+        (card.points == 3) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_lt.any(|card: CardNote| {
+        (card.points == 4) &
+        (card.randomness ==  1)
+    }));
+
+    // GT values
+    assert(return_gt.len() == 4);
+    assert(return_gt.any(|card: CardNote| {
+        (card.points == 6) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_gt.any(|card: CardNote| {
+        (card.points == 7) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_gt.any(|card: CardNote| {
+        (card.points == 8) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_gt.any(|card: CardNote| {
+        (card.points == 9) &
+        (card.randomness ==  1)
+    }));
+
+    // LTE values
+    assert(return_lte.len() == 7);
+    assert(return_lte.any(|card: CardNote| {
+        (card.points == 0) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_lte.any(|card: CardNote| {
+        (card.points == 1) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_lte.any(|card: CardNote| {
+        (card.points == 2) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_lte.any(|card: CardNote| {
+        (card.points == 3) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_lte.any(|card: CardNote| {
+        (card.points == 4) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_lte.any(|card: CardNote| {
+        (card.points == 5) &
+        (card.randomness == 0)
+    }));
+
+    assert(return_lte.any(|card: CardNote| {
+        (card.points == 5) &
+        (card.randomness == 1)
+    }));
+
+    // GTE values
+    assert(return_gte.len() == 6);
+    assert(return_gte.any(|card: CardNote| {
+        (card.points == 5) &
+        (card.randomness ==  0)
+    }));
+
+    assert(return_gte.any(|card: CardNote| {
+        (card.points == 5) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_gte.any(|card: CardNote| {
+        (card.points == 6) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_gte.any(|card: CardNote| {
+        (card.points == 7) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_gte.any(|card: CardNote| {
+        (card.points == 8) &
+        (card.randomness ==  1)
+    }));
+
+    assert(return_gte.any(|card: CardNote| {
+        (card.points == 9) &
+        (card.randomness ==  1)
+    }));
+}

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/test/state_vars.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/test/state_vars.nr
@@ -1,0 +1,205 @@
+use crate::DocsExample;
+use crate::types::leader::Leader;
+use dep::aztec::test::helpers::utils;
+
+#[test]
+unconstrained fn shared_immutable() {
+    let (env, (account_1)) = utils::setup(false, false);
+    // The docs_example_contract has the functions we need to test note retrieval.
+    let docs_example_contract = env.deploy("./@docs_example_contract", "DocsExample").without_initializer();
+    let docs_example_contract_address = docs_example_contract.to_address();
+    env.advance_block_by(1);
+
+    // Private read of uninitialized SharedImmutable
+    let leader = env.call_unconstrained(docs_example_contract_address, || {DocsExample::get_shared_immutable()});
+    env.call_private_void(DocsExample::at(docs_example_contract_address).match_shared_immutable(leader.account, leader.points));
+
+    // Initialize and read SharedImmutable
+    let leader_points = 69;
+    env.call_public(DocsExample::at(docs_example_contract_address).initialize_shared_immutable(leader_points));
+    env.advance_block_by(1);
+    let mut leader_after_init = env.call_unconstrained(docs_example_contract_address, || {DocsExample::get_shared_immutable()});
+
+    assert_eq(leader_after_init, Leader {
+      account: account_1,
+      points: leader_points
+    });
+
+    // Private read of SharedImmutable
+    // Reads the value using an unconstrained function checking the return values with:
+    // 1. A constrained private function that reads it directly
+    // 2. A constrained private function that calls another private function that reads.
+    //    The indirect, adds 1 to the point to ensure that we are returning the correct value.
+    let leader_constrained_private = env.call_private(DocsExample::at(docs_example_contract_address).get_shared_immutable_constrained_private());
+    let leader_constrained_indirect_private = env.call_private(DocsExample::at(docs_example_contract_address).get_shared_immutable_constrained_private_indirect());
+    leader_after_init = env.call_unconstrained(docs_example_contract_address, || {DocsExample::get_shared_immutable()});
+
+    assert_eq(leader_constrained_private, leader_after_init);
+    assert_eq(leader_constrained_indirect_private, Leader {
+      account: leader_after_init.account,
+      points: leader_after_init.points + 1,
+    });
+
+    env.call_private_void(DocsExample::at(docs_example_contract_address).match_shared_immutable(leader_after_init.account, leader_after_init.points));
+
+    // Public read of SharedImmutable
+    // Reads the value using an unconstrained function checking the return values with:
+    // 1. A constrained public function that reads it directly
+    // 2. A constrained public function that calls another public function that reads.
+    //    The indirect, adds 1 to the point to ensure that we are returning the correct value.
+    let leader_constrained_public = env.call_public(DocsExample::at(docs_example_contract_address).get_shared_immutable_constrained_public());
+    let leader_constrained_indirect_public = env.call_public(DocsExample::at(docs_example_contract_address).get_shared_immutable_constrained_public_indirect());
+    leader_after_init = env.call_unconstrained(docs_example_contract_address, || {DocsExample::get_shared_immutable()});
+
+    assert_eq(leader_constrained_public, leader_after_init);
+    assert_eq(leader_constrained_indirect_public, Leader {
+      account: leader_after_init.account,
+      points: leader_after_init.points + 1,
+    });
+
+    env.call_private_void(DocsExample::at(docs_example_contract_address).match_shared_immutable(leader_after_init.account, leader_after_init.points));
+
+    // Public multiread of SharedImmutable
+    // Reads the value using an unconstrained function checking the return values with:
+    // 1. A constrained public function that reads 5 times directly (going beyond the previous 4 Field return value)
+    let leader_constrained_public_multiple = env.call_public(DocsExample::at(docs_example_contract_address).get_shared_immutable_constrained_public_multiple());
+    leader_after_init = env.call_unconstrained(docs_example_contract_address, || {DocsExample::get_shared_immutable()});
+
+    assert_eq([leader_after_init, leader_after_init, leader_after_init, leader_after_init, leader_after_init], leader_constrained_public_multiple);
+
+    // Initializing PublicImmutable the second time should fail
+    env.assert_public_call_fails(DocsExample::at(docs_example_contract_address).initialize_shared_immutable(leader_points));
+}
+
+#[test]
+unconstrained fn public_immutable() {
+    let (env, (account_1)) = utils::setup(false, false);
+    // The docs_example_contract has the functions we need to test note retrieval.
+    let docs_example_contract = env.deploy("./@docs_example_contract", "DocsExample").without_initializer();
+    let docs_example_contract_address = docs_example_contract.to_address();
+    env.advance_block_by(1);
+
+    // Initialize and read public immutable
+    let num_points = 1;
+    env.call_public(DocsExample::at(docs_example_contract_address).initialize_public_immutable(num_points));
+    let leader = env.call_unconstrained(docs_example_contract_address, || { DocsExample::get_public_immutable() });
+
+    assert_eq(leader, Leader {
+      account: account_1,
+      points: num_points,
+    });
+
+    // Initializing PublicImmutable the second time should fail
+    env.assert_public_call_fails(DocsExample::at(docs_example_contract_address).initialize_public_immutable(num_points));
+}
+
+#[test]
+unconstrained fn private_mutable() {
+    let (env, (account_1)) = utils::setup(false, false);
+    // The docs_example_contract has the functions we need to test note retrieval.
+    let docs_example_contract = env.deploy("./@docs_example_contract", "DocsExample").without_initializer();
+    let docs_example_contract_address = docs_example_contract.to_address();
+    env.advance_block_by(1);
+
+    let POINTS = 1;
+    let RANDOMNESS = 2;
+
+    // Fail to read uninitialized PrivateMutable
+    assert(!env.call_unconstrained(docs_example_contract_address, || {DocsExample::is_legendary_initialized()}));
+    // Should add assert_unconstrained_fails
+    // env.call_unconstrained(docs_example_contract_address, || {DocsExample::get_legendary_card()});
+
+    // Initialize PrivateMutable (TODO: for parity with e2e, we probably want to check what nullifiers / note hashes / side effects are available from the TXE)
+    env.call_private_void(DocsExample::at(docs_example_contract_address).initialize_private(RANDOMNESS, POINTS));
+    env.advance_block_by(1);
+    assert(env.call_unconstrained(docs_example_contract_address, || {DocsExample::is_legendary_initialized()}));
+
+    // Fail to reinitialize
+    env.assert_private_call_fails(DocsExample::at(docs_example_contract_address).initialize_private(RANDOMNESS, POINTS));
+    assert(env.call_unconstrained(docs_example_contract_address, || {DocsExample::is_legendary_initialized()}));
+
+    // Read initialized PrivateMutable
+    let card_note_before_update = env.call_unconstrained(docs_example_contract_address, || {DocsExample::get_legendary_card()});
+    assert((card_note_before_update.points == POINTS) & (card_note_before_update.randomness == RANDOMNESS));
+
+    // Replace with same value
+    // This cannot be tested here as nonces are not unique
+    // env.call_private_void(DocsExample::at(docs_example_contract_address).update_legendary_card(RANDOMNESS, POINTS));
+    // env.advance_block_by(1);
+    // let card_note_after_update = env.call_unconstrained(docs_example_contract_address, || {DocsExample::get_legendary_card()});
+
+    // assert(
+    //   (card_note_after_update.npk_m_hash == card_note_before_update.npk_m_hash) &
+    //   (card_note_after_update.points == card_note_before_update.points) &
+    //   (card_note_after_update.randomness == card_note_before_update.randomness) &
+    //   (card_note_after_update.header.contract_address == card_note_before_update.header.contract_address) &
+    //   (card_note_after_update.header.storage_slot == card_note_before_update.header.storage_slot) &
+    //   (card_note_after_update.header.note_hash_counter == card_note_before_update.header.note_hash_counter) &
+    //   // This is not true in e2e tests, as note nonce cannot be known in private
+    //   (card_note_after_update.header.nonce != card_note_before_update.header.nonce)
+    // );
+
+    // Replace PrivateMutable with other values
+    let NEW_POINTS = 69;
+    let NEW_RANDOMNESS = 42;
+    env.call_private_void(DocsExample::at(docs_example_contract_address).update_legendary_card(NEW_RANDOMNESS, NEW_POINTS));
+    env.advance_block_by(1);
+
+    let card_note_after_update = env.call_unconstrained(docs_example_contract_address, || {DocsExample::get_legendary_card()});
+    assert(
+      (card_note_after_update.npk_m_hash == card_note_before_update.npk_m_hash) &
+      (card_note_after_update.points == NEW_POINTS) &
+      (card_note_after_update.randomness == NEW_RANDOMNESS) &
+      (card_note_after_update.header.contract_address == card_note_before_update.header.contract_address) &
+      (card_note_after_update.header.storage_slot == card_note_before_update.header.storage_slot) &
+      (card_note_after_update.header.note_hash_counter == card_note_before_update.header.note_hash_counter) &
+      // This is not equal in e2e tests, as note nonce cannot be known in private
+      (card_note_after_update.header.nonce == card_note_before_update.header.nonce)
+    );
+
+    // Replace PrivateMutable dependent on prior value
+    // This function also does not work due to not being able to set a note nonce.
+    // The note is fetched, with the original note is initially nullified and replaced.
+    // The note is then replaced, with the replacement being nullified. The issue is that because note nonces are set at 0, this second nullification
+    // produces a duplicate nullifier. Not sure if there is a way around it. Maybe if we can tell if a note was only replaced with the same "values", we could ignore this first nullifier ?
+    // env.call_private_void(DocsExample::at(docs_example_contract_address).increase_legendary_points());
+    // env.advance_block_by(1);
+
+    // let card_note_after_increase = env.call_unconstrained(docs_example_contract_address, || {DocsExample::get_legendary_card()});
+    // assert(
+    //   (card_note_after_increase.npk_m_hash == card_note_before_update.npk_m_hash) &
+    //   (card_note_after_increase.points == card_note_after_update.points + 1) &
+    //   (card_note_after_increase.randomness == card_note_after_update.randomness)
+    // );
+}
+
+#[test]
+unconstrained fn private_immutable() {
+    let (env, (account_1)) = utils::setup(false, false);
+    // The docs_example_contract has the functions we need to test note retrieval.
+    let docs_example_contract = env.deploy("./@docs_example_contract", "DocsExample").without_initializer();
+    let docs_example_contract_address = docs_example_contract.to_address();
+    env.advance_block_by(1);
+
+    let POINTS = 1;
+    let RANDOMNESS = 2;
+
+    // Fail to read uninitialized PrivateImmutable
+    assert(!env.call_unconstrained(docs_example_contract_address, || { DocsExample::is_priv_imm_initialized() }));
+    // Cannot yet assert unconstrained call fails
+    // let imm_card = env.call_unconstrained(docs_example_contract_address, || { DocsExample::view_imm_card() });
+
+    // Initialize PrivateImmutable
+    env.call_private_void(DocsExample::at(docs_example_contract_address).initialize_private_immutable(RANDOMNESS, POINTS));
+    env.advance_block_by(1);
+
+    assert(env.call_unconstrained(docs_example_contract_address, || { DocsExample::is_priv_imm_initialized() }));
+
+    // Fails to reinitialize
+    env.assert_private_call_fails(DocsExample::at(docs_example_contract_address).initialize_private_immutable(RANDOMNESS, POINTS));
+    assert(env.call_unconstrained(docs_example_contract_address, || { DocsExample::is_priv_imm_initialized() }));
+
+    // Read initialized PrivateImmutable
+    let imm_card = env.call_unconstrained(docs_example_contract_address, || { DocsExample::view_imm_card() });
+    assert((imm_card.points == POINTS) & (imm_card.randomness == RANDOMNESS));
+}

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/types/leader.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/types/leader.nr
@@ -8,6 +8,13 @@ pub struct Leader {
 
 global LEADER_SERIALIZED_LEN: u32 = 2;
 
+impl Eq for Leader {
+    fn eq(self, other: Leader) -> bool {
+        (self.account == other.account) &
+        (self.points == other.points)
+    }
+}
+
 impl Deserialize<LEADER_SERIALIZED_LEN> for Leader {
     fn deserialize(fields: [Field; LEADER_SERIALIZED_LEN]) -> Self {
         Leader { account: AztecAddress::from_field(fields[0]), points: fields[1] as u8 }

--- a/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/main.nr
@@ -1,4 +1,5 @@
 use dep::aztec::macros::aztec;
+mod test;
 
 #[aztec]
 contract EasyPrivateVoting {

--- a/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/test.nr
@@ -1,0 +1,25 @@
+use crate::EasyPrivateVoting;
+use dep::aztec::test::helpers::utils;
+
+#[test]
+unconstrained fn votes() {
+  let (
+    env,
+    (account_1)
+  ) = utils::setup(false, false);
+    let initializer_call_interface = EasyPrivateVoting::interface().constructor(
+        account_1,
+    );
+    let easy_private_voting_contract = env.deploy("./@easy_private_voting_contract", "EasyPrivateVoting").with_public_initializer(initializer_call_interface);
+    let easy_private_voting_contract_address = easy_private_voting_contract.to_address();
+    env.advance_block_by(1);
+
+    // We cast our vote for candidate 1
+    env.call_private_void(EasyPrivateVoting::at(easy_private_voting_contract_address).cast_vote(1));
+
+    let votes = env.call_unconstrained(easy_private_voting_contract_address, || { EasyPrivateVoting::get_vote(1) });
+    assert_eq(votes, 1);
+
+    // We try voting again, but our TX is invalid due to trying to emit duplicate nullifiers
+    env.assert_private_call_fails(EasyPrivateVoting::at(easy_private_voting_contract_address).cast_vote(1));
+}

--- a/noir-projects/noir-contracts/contracts/escrow_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/escrow_contract/Nargo.toml
@@ -6,5 +6,7 @@ type = "contract"
 
 [dependencies]
 aztec = { path = "../../../aztec-nr/aztec" }
+authwit = { path = "../../../aztec-nr/authwit" }
 address_note = { path = "../../../aztec-nr/address-note" }
 token = { path = "../token_contract" }
+value_note = { path = "../../../aztec-nr/value-note" }

--- a/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
@@ -1,3 +1,5 @@
+mod test;
+
 // Sample escrow contract that stores a balance of a private token on behalf of an owner.
 use dep::aztec::macros::aztec;
 

--- a/noir-projects/noir-contracts/contracts/escrow_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/escrow_contract/src/test.nr
@@ -1,0 +1,129 @@
+use crate::Escrow;
+use dep::token::Token;
+
+use dep::aztec::{
+    prelude::AztecAddress, test::helpers::{test_environment::TestEnvironment, utils},
+};
+
+global MINT_AMOUNT = 200000;
+
+unconstrained fn deploy_contracts(
+    env: &mut TestEnvironment,
+    admin_and_owner: AztecAddress,
+) -> (AztecAddress, AztecAddress) {
+    env.impersonate(admin_and_owner);
+
+    // Deploy token contract
+    let donation_token_initializer_call_interface = Token::interface().constructor(
+        admin_and_owner,
+        "Token00000000000000000000000000",
+        "TKN0000000000000000000000000000",
+        18
+    );
+    let donation_token_contract = env.deploy("./@token_contract", "Token").with_public_initializer(donation_token_initializer_call_interface);
+    let token_contract_address = donation_token_contract.to_address();
+    env.advance_block_by(1);
+
+    // Deploy Escrow contract with public keys
+    let escrow_contract_initializer_call_interface = Escrow::interface().constructor(
+      admin_and_owner,
+    );
+    let escrow_contract = env.deploy_with_keys("./@escrow_contract", "Escrow", 6969).with_private_initializer(escrow_contract_initializer_call_interface);
+    let escrow_contract_address = escrow_contract.to_address();
+
+    env.advance_block_by(1);
+
+    env.call_private_void(Token::at(token_contract_address).privately_mint_private_note(MINT_AMOUNT));
+    env.advance_block_by(1);
+
+    let private_balance_after_mint = env.call_unconstrained(token_contract_address, || { Token::balance_of_private(admin_and_owner) });
+    assert_eq(private_balance_after_mint, MINT_AMOUNT);
+
+    (token_contract_address, escrow_contract_address)
+}
+
+#[test]
+unconstrained fn main() {
+    let (
+      env,
+      (account_1, account_2)
+    ) = utils::setup(true, true);
+
+    let (token_contract_address, escrow_contract_address) = deploy_contracts(env, account_1);
+
+    // We transfer tokens to the escrow contract
+    let TRANSFER_AMOUNT = 20000;
+    env.call_private_void(Token::at(token_contract_address).transfer(escrow_contract_address, TRANSFER_AMOUNT));
+    env.advance_block_by(1);
+
+    let balance_of_account_after_transfer = env.call_unconstrained(token_contract_address, || { Token::balance_of_private(account_1) });
+    assert_eq(balance_of_account_after_transfer, MINT_AMOUNT - TRANSFER_AMOUNT);
+
+    let balance_of_escrow_after_transfer = env.call_unconstrained(token_contract_address, || { Token::balance_of_private(escrow_contract_address) });
+    assert_eq(balance_of_escrow_after_transfer, TRANSFER_AMOUNT);
+
+    // We then withdraw some escrowed funds to account_2
+    let balance_of_account_2_before_withdrawal = env.call_unconstrained(token_contract_address, || { Token::balance_of_private(account_2) });
+    assert_eq(balance_of_account_2_before_withdrawal, 0);
+
+    let WITHDRAWAL_AMOUNT = 69;
+
+    env.call_private_void(Escrow::at(escrow_contract_address).withdraw(token_contract_address, WITHDRAWAL_AMOUNT, account_2));
+    env.advance_block_by(1);
+
+    let balance_of_account_2_after_withdrawal = env.call_unconstrained(token_contract_address, || { Token::balance_of_private(account_2) });
+    assert_eq(balance_of_account_2_after_withdrawal, WITHDRAWAL_AMOUNT);
+
+    let balance_of_escrow_after_withdrawal = env.call_unconstrained(token_contract_address, || { Token::balance_of_private(escrow_contract_address) });
+    assert_eq(balance_of_escrow_after_withdrawal, TRANSFER_AMOUNT - WITHDRAWAL_AMOUNT);
+
+    // We test that withdrawal with an unauthorized user fails.
+    env.impersonate(account_2);
+    env.assert_private_call_fails(Escrow::at(escrow_contract_address).withdraw(token_contract_address, 69, account_2));
+}
+
+#[test]
+unconstrained fn multi_1011() {
+    let (
+      env,
+      (account_1, account_2)
+    ) = utils::setup(true, true);
+
+    let (token_contract_address, escrow_contract_address) = deploy_contracts(env, account_1);
+
+    // We transfer tokens to the escrow contract
+    let TRANSFER_AMOUNT = 20000;
+    env.call_private_void(Token::at(token_contract_address).transfer(escrow_contract_address, TRANSFER_AMOUNT));
+    env.advance_block_by(1);
+
+    let balance_of_account_after_transfer = env.call_unconstrained(token_contract_address, || { Token::balance_of_private(account_1) });
+    assert_eq(balance_of_account_after_transfer, MINT_AMOUNT - TRANSFER_AMOUNT);
+
+    let balance_of_escrow_after_transfer = env.call_unconstrained(token_contract_address, || { Token::balance_of_private(escrow_contract_address) });
+    assert_eq(balance_of_escrow_after_transfer, TRANSFER_AMOUNT);
+
+    // We then withdraw some escrowed funds to account_2
+    let balance_of_account_2_before_withdrawal = env.call_unconstrained(token_contract_address, || { Token::balance_of_private(account_2) });
+    assert_eq(balance_of_account_2_before_withdrawal, 0);
+
+    let WITHDRAWAL_AMOUNT = 69;
+    let SECOND_TRANSFER_AMOUNT = 690;
+
+    // This may not be a good approximation of a batch call.
+    env.call_private_void(Token::at(token_contract_address).transfer(account_2, SECOND_TRANSFER_AMOUNT));
+    env.call_private_void(Escrow::at(escrow_contract_address).withdraw(token_contract_address, WITHDRAWAL_AMOUNT, account_2));
+    env.advance_block_by(1);
+
+    let balance_of_account_1 = env.call_unconstrained(token_contract_address, || { Token::balance_of_private(account_1) });
+    assert_eq(balance_of_account_1, MINT_AMOUNT - TRANSFER_AMOUNT - SECOND_TRANSFER_AMOUNT);
+
+    let balance_of_account_2 = env.call_unconstrained(token_contract_address, || { Token::balance_of_private(account_2) });
+    assert_eq(balance_of_account_2, WITHDRAWAL_AMOUNT + SECOND_TRANSFER_AMOUNT);
+
+    let balance_of_escrow = env.call_unconstrained(token_contract_address, || { Token::balance_of_private(escrow_contract_address) });
+    assert_eq(balance_of_escrow, TRANSFER_AMOUNT - WITHDRAWAL_AMOUNT);
+
+    // We test that withdrawal with an unauthorized user fails.
+    env.impersonate(account_2);
+    env.assert_private_call_fails(Escrow::at(escrow_contract_address).withdraw(token_contract_address, 69, account_2));
+}

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
@@ -1,3 +1,5 @@
+mod test;
+
 // A demonstration of inclusion and non-inclusion proofs.
 use dep::aztec::macros::aztec;
 

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/test.nr
@@ -1,0 +1,2 @@
+mod utils;
+mod main;

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/test/main.nr
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/test/main.nr
@@ -1,0 +1,25 @@
+use crate::test::utils;
+use crate::InclusionProofs;
+
+#[test]
+unconstrained fn shared_immutable() {
+  let (env,
+    inclusion_proofs_contract_address,
+    account_1
+  ) = utils::setup();
+  env.impersonate(account_1);
+
+  let note_creation_block_number = 10;
+
+  env.advance_block_to(note_creation_block_number - 1);
+  env.call_private_void(InclusionProofs::at(inclusion_proofs_contract_address).create_note(account_1, 100));
+  env.advance_block_by(5);
+
+  // owner: AztecAddress,
+  // use_block_number: bool,
+  // block_number: u32, // The block at which we'll prove that the note exists
+  // nullified: bool
+  env.call_private_void(InclusionProofs::at(inclusion_proofs_contract_address).test_note_inclusion(account_1, true, note_creation_block_number, false));
+  // env.call_private_void(InclusionProofs::at(inclusion_proofs_contract_address).test_note_inclusion(account_1, false, 0, false));
+
+}

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/test/utils.nr
@@ -1,0 +1,27 @@
+use dep::aztec::{
+    prelude::AztecAddress, test::helpers::test_environment::TestEnvironment,
+};
+use crate::InclusionProofs;
+
+pub fn setup() -> (
+  &mut TestEnvironment,
+  AztecAddress,
+  AztecAddress
+) {
+    let mut env = TestEnvironment::new();
+    let account_1 = env.create_account();
+
+    env.impersonate(account_1);
+    // Deploy token contract
+    let initializer_call_interface = InclusionProofs::interface().constructor(236);
+
+    let inclusion_proofs_contract = env.deploy("./@inclusion_proofs_contract", "InclusionProofs").with_public_initializer(initializer_call_interface);
+    let inclusion_proofs_contract_address = inclusion_proofs_contract.to_address();
+    env.advance_block_by(1);
+
+    (
+      &mut env,
+      inclusion_proofs_contract_address,
+      account_1
+    )
+}

--- a/noir-projects/noir-contracts/contracts/lending_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/lending_contract/Nargo.toml
@@ -6,5 +6,6 @@ type = "contract"
 
 [dependencies]
 aztec = { path = "../../../aztec-nr/aztec" }
+authwit = { path = "../../../aztec-nr/authwit" }
 token = { path = "../token_contract" }
 price_feed = { path = "../price_feed_contract" }

--- a/noir-projects/noir-contracts/contracts/lending_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/lending_contract/src/main.nr
@@ -2,6 +2,7 @@ mod asset;
 mod position;
 mod interest_math;
 mod helpers;
+mod test;
 
 // Single asset CDP contract.
 // Shoving re-entries up the ass.

--- a/noir-projects/noir-contracts/contracts/lending_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/lending_contract/src/test.nr
@@ -1,0 +1,2 @@
+mod main;
+mod utils;

--- a/noir-projects/noir-contracts/contracts/lending_contract/src/test/main.nr
+++ b/noir-projects/noir-contracts/contracts/lending_contract/src/test/main.nr
@@ -1,0 +1,60 @@
+use crate::test::utils;
+use dep::token::Token;
+use crate::Lending;
+use dep::authwit::cheatcodes as authwit_cheatcodes;
+
+use dep::aztec::{prelude::AztecAddress, oracle::{unsafe_rand::unsafe_rand, execution::{get_chain_id, get_version, get_contract_address}}, test::helpers::cheatcodes};
+
+#[test]
+fn main() {
+    let (
+      env,
+      price_feed_contract_address,
+      asset_token_contract_address,
+      stable_token_contract_address,
+      lending_contract_address,
+      account_1,
+      account_2
+    ) = utils::setup();
+    env.impersonate(account_1);
+
+    env.call_private_void(Token::at(asset_token_contract_address).privately_mint_private_note(10000));
+    env.advance_block_by(1);
+
+    env.call_private_void(Token::at(stable_token_contract_address).privately_mint_private_note(10000));
+    env.advance_block_by(1);
+
+    env.call_public(Token::at(asset_token_contract_address).mint_public(account_1, 10000));
+    env.advance_block_by(1);
+
+    env.call_public(Token::at(stable_token_contract_address).mint_public(account_1, 10000));
+    env.advance_block_by(1);
+
+    let mut bal = env.call_unconstrained(asset_token_contract_address, || { Token::balance_of_private(account_1) });
+    assert_eq(bal, 10000);
+
+    bal = env.call_unconstrained(stable_token_contract_address, || { Token::balance_of_private(account_1) });
+    assert_eq(bal, 10000);
+
+    bal = env.call_public(Token::at(asset_token_contract_address).balance_of_public(account_1));
+    assert_eq(bal, 10000);
+
+    bal = env.call_public(Token::at(stable_token_contract_address).balance_of_public(account_1));
+    assert_eq(bal, 10000);
+
+    env.call_public(Lending::at(lending_contract_address).init(price_feed_contract_address, 8000, asset_token_contract_address, stable_token_contract_address));
+    env.advance_block_by(1);
+
+    let unshield_call_interface = Token::at(asset_token_contract_address).unshield(account_1, lending_contract_address, 420, 2348924);
+    authwit_cheatcodes::add_private_authwit_from_call_interface(account_1, lending_contract_address, unshield_call_interface);
+    // This fails when enqueueing the public call, removing the enqueue works, but commenting out all the lines in the enqueue function does not.
+    // env.call_private_void(Lending::at(lending_contract_address).deposit_private(
+    //   account_1,
+    //   420,
+    //   2348924,
+    //   1234, //     lendingAccount.secret,
+    //   0,
+    //   asset_token_contract_address
+    // ));
+    // env.advance_block_by(1);
+}

--- a/noir-projects/noir-contracts/contracts/lending_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/lending_contract/src/test/utils.nr
@@ -1,0 +1,79 @@
+use dep::aztec::{
+    prelude::AztecAddress, test::helpers::test_environment::TestEnvironment,
+};
+use crate::Lending;
+use dep::token::Token;
+use dep::price_feed::PriceFeed;
+
+pub fn setup() -> (
+  &mut TestEnvironment,
+  AztecAddress,
+  AztecAddress,
+  AztecAddress,
+  AztecAddress,
+  AztecAddress,
+  AztecAddress
+) {
+    let mut env = TestEnvironment::new();
+    let account_1 = env.create_account_contract(1);
+    let account_2 = env.create_account_contract(2);
+    env.impersonate(account_1);
+
+    // Deploy canonical auth registry
+    let _auth_registry = env.deploy("./@auth_registry_contract", "AuthRegistry").without_initializer();
+    env.advance_block_by(1);
+
+    // Deploy canonical auth registry
+    let _router_contract = env.deploy("./@router_contract", "Router").without_initializer();
+    env.advance_block_by(1);
+
+    let price_feed_contract = env.deploy("./@price_feed_contract", "PriceFeed").without_initializer();
+    let price_feed_contract_address = price_feed_contract.to_address();
+    env.advance_block_by(1);
+
+    env.call_public(PriceFeed::at(price_feed_contract_address).set_price(0, 2000000000));
+    env.advance_block_by(1);
+
+    // Deploy asset token contract
+    let asset_token_initializer_call_interface = Token::interface().constructor(
+        account_1,
+        "DonationToken000000000000000000",
+        "DNT0000000000000000000000000000",
+        18
+    );
+    let asset_token_contract = env.deploy("./@token_contract", "Token").with_public_initializer(asset_token_initializer_call_interface);
+    let asset_token_contract_address = asset_token_contract.to_address();
+    env.advance_block_by(1);
+
+    // Deploy stable token contract
+    let stable_token_initializer_call_interface = Token::interface().constructor(
+        account_1,
+        "StableToken00000000000000000000",
+        "STAB000000000000000000000000000",
+        18
+    );
+    let stable_token_contract = env.deploy("./@token_contract", "Token").with_public_initializer(stable_token_initializer_call_interface);
+    let stable_token_contract_address = stable_token_contract.to_address();
+    env.advance_block_by(1);
+
+    let lending_initializer_call_interface = Lending::interface().constructor();
+    let lending_contract = env.deploy("./@lending_contract", "Lending").with_private_initializer(lending_initializer_call_interface);
+    let lending_contract_address = lending_contract.to_address();
+    env.advance_block_by(1);
+
+    env.call_public(Token::at(asset_token_contract_address).set_minter(lending_contract_address, true));
+    env.advance_block_by(1);
+
+    env.call_public(Token::at(stable_token_contract_address).set_minter(lending_contract_address, true));
+    env.advance_block_by(1);
+
+    (
+      &mut env,
+      price_feed_contract_address,
+      asset_token_contract_address,
+      stable_token_contract_address,
+      lending_contract_address,
+      account_1,
+      account_2
+    )
+}

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -1,4 +1,5 @@
 mod test_note;
+mod test;
 
 // A contract used for testing a random hodgepodge of small features from simulator and end-to-end tests.
 use dep::aztec::macros::aztec;

--- a/noir-projects/noir-contracts/contracts/test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/test.nr
@@ -1,0 +1,1 @@
+mod note_getter;

--- a/noir-projects/noir-contracts/contracts/test_contract/src/test/note_getter.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/test/note_getter.nr
@@ -1,0 +1,85 @@
+use crate::Test;
+use dep::aztec::test::helpers::utils;
+
+global VALUE = 5;
+
+#[test]
+unconstrained fn status_filters() {
+  let (
+    env,
+    (account_1)
+  ) = utils::setup(false, false);
+    // The test_contract has the functions we need to test note retrieval.
+    let test_contract = env.deploy("./@test_contract", "Test").without_initializer();
+    let test_contract_address = test_contract.to_address();
+    env.advance_block_by(1);
+
+    // To prevent tests from interacting with one another, we'll have each use a different storage slot.
+    let mut storage_slot = Test::storage_layout().example_set.slot + 1;
+
+    // We create a note, then fetch it
+    let mut active_or_nullified = false;
+    env.call_private_void(Test::at(test_contract_address).call_create_note(VALUE, account_1, account_1, storage_slot));
+    env.advance_block_by(1);
+
+    assert_eq(env.call_unconstrained(test_contract_address, || { Test::call_view_notes(storage_slot, active_or_nullified) }), VALUE);
+    assert_eq(env.call_private(Test::at(test_contract_address).call_get_notes(storage_slot, active_or_nullified)), VALUE);
+
+    storage_slot = storage_slot + 1;
+
+    // We create, then destroy the note, when we get the note we should expect failure as we are only fetching active notes
+    env.call_private_void(Test::at(test_contract_address).call_create_note(VALUE, account_1, account_1, storage_slot));
+    env.advance_block_by(1);
+
+    env.call_private_void(Test::at(test_contract_address).call_destroy_note(storage_slot));
+    env.advance_block_by(1);
+
+    // TODO: Add assert unconstrained call fails
+    // assert_eq(env.call_unconstrained(test_contract_address, || { Test::call_view_notes(storage_slot, active_or_nullified) }), VALUE);
+    env.assert_private_call_fails(Test::at(test_contract_address).call_get_notes(storage_slot, active_or_nullified));
+
+    storage_slot = storage_slot + 1;
+
+    // We create, then destroy the note, when we get the note we should not expect failure as we are fetching active and nullified notes
+    env.call_private_void(Test::at(test_contract_address).call_create_note(VALUE, account_1, account_1, storage_slot));
+    env.advance_block_by(1);
+
+    env.call_private_void(Test::at(test_contract_address).call_destroy_note(storage_slot));
+    env.advance_block_by(1);
+
+    active_or_nullified = true;
+    assert_eq(env.call_unconstrained(test_contract_address, || { Test::call_view_notes(storage_slot, active_or_nullified) }), VALUE);
+    assert_eq(env.call_private(Test::at(test_contract_address).call_get_notes(storage_slot, active_or_nullified)), VALUE);
+
+    storage_slot = storage_slot + 1;
+
+    // We create two notes, then destroy one note, when we get the note we should not expect failure as we are fetching active and nullified notes and we expect two notes to be returned.
+    env.call_private_void(Test::at(test_contract_address).call_create_note(VALUE, account_1, account_1, storage_slot));
+    env.call_private_void(Test::at(test_contract_address).call_create_note(VALUE + 1, account_1, account_1, storage_slot));
+    env.advance_block_by(1);
+
+    env.call_private_void(Test::at(test_contract_address).call_destroy_note(storage_slot));
+    env.advance_block_by(1);
+
+    let view_notes_many = env.call_unconstrained(test_contract_address, || { Test::call_view_notes_many(storage_slot, active_or_nullified) });
+    let get_notes_many: [Field; 2] = env.call_private(Test::at(test_contract_address).call_get_notes_many(storage_slot, active_or_nullified));
+
+    assert_eq(view_notes_many.len(), 2);
+    assert_eq(get_notes_many.len(), 2);
+
+    assert(view_notes_many.any(|field| {
+        field == 5
+    }));
+
+    assert(view_notes_many.any(|field| {
+        field == 6
+    }));
+
+    assert(get_notes_many.any(|field| {
+        field == 5
+    }));
+
+    assert(get_notes_many.any(|field| {
+        field == 6
+    }));
+}


### PR DESCRIPTION
ported:
~~escrow~~
~~note_getter~~
~~private_voting~~
~~state_vars~~

can delete (covered by other tests):
~~encryption~~

blocked:
crowdfunding and claim (inclusion proof fails due to txe workings)
lending (enqueuing public call fails—todo to investigate)