### PR TITLE
fix(ci): Do not post public functions report when empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -719,7 +719,7 @@ jobs:
 
       - name: Compare public functions bytecode size reports
         id: public_functions_sizes_diff
-        uses: noir-lang/noir-gates-diff@ef8aaf48fb833f3b6e3f91665bb23afb7e68c6e3
+        uses: noir-lang/noir-gates-diff@ca7ea349b9ff46cb6212c60f8d49b11a38a9543c
         with:
           report: public_functions_report.json
           header: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -719,7 +719,7 @@ jobs:
 
       - name: Compare public functions bytecode size reports
         id: public_functions_sizes_diff
-        uses: noir-lang/noir-gates-diff@ca7ea349b9ff46cb6212c60f8d49b11a38a9543c
+        uses: noir-lang/noir-gates-diff@d88f7523b013b9edd3f31c5cfddaef87a3fe1b48
         with:
           report: public_functions_report.json
           header: |


### PR DESCRIPTION
This updates the commit to the noir-gates-diff which does not post a markdown file when there are no changes to the public function sizes.

Right now, every PR will post the following snippet:
<img width="917" alt="Screenshot 2024-09-25 at 12 25 14 PM" src="https://github.com/user-attachments/assets/83bfb6cc-fece-4ffe-98e4-4bb2bd272155">

Now when there are no changes in public function sizes the snippet will not post. Commit referenced comes from the commit that merges https://github.com/noir-lang/noir-gates-diff/pull/6 into the noir-gates-diff `main` branch. Exact commit is here https://github.com/noir-lang/noir-gates-diff/commit/d88f7523b013b9edd3f31c5cfddaef87a3fe1b48
