### PR TITLE
chore: misc unsafe improvements

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
@@ -53,10 +53,7 @@ pub struct PrivateCallInterface<let N: u32, T, Env> {
 
 impl<let N: u32, T, Env> PrivateCallInterface<N, T, Env> {
     pub fn call<let M: u32>(self, context: &mut PrivateContext) -> T where T: Deserialize<M> {
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(self.args_hash == packed_args_hash);
+        pack_arguments(self.args);
         let returns = context.call_private_function_with_packed_args(
             self.target_contract,
             self.selector,
@@ -69,19 +66,13 @@ impl<let N: u32, T, Env> PrivateCallInterface<N, T, Env> {
     }
 
     pub fn view<let M: u32>(self, context: &mut PrivateContext) -> T where T: Deserialize<M> {
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(self.args_hash == packed_args_hash);
+        pack_arguments(self.args);
         let returns = context.call_private_function_with_packed_args(self.target_contract, self.selector, self.args_hash, true, false);
         returns.unpack_into()
     }
 
     pub fn delegate_call<let M: u32>(self, context: &mut PrivateContext) -> T where T: Deserialize<M> {
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(self.args_hash == packed_args_hash);
+        pack_arguments(self.args);
         let returns = context.call_private_function_with_packed_args(self.target_contract, self.selector, self.args_hash, false, true);
         returns.unpack_into()
     }
@@ -105,10 +96,7 @@ pub struct PrivateVoidCallInterface<let N: u32, Env> {
 
 impl<let N: u32, Env> PrivateVoidCallInterface<N, Env> {
     pub fn call(self, context: &mut PrivateContext) {
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(self.args_hash == packed_args_hash);
+        pack_arguments(self.args);
         context.call_private_function_with_packed_args(
             self.target_contract,
             self.selector,
@@ -119,18 +107,12 @@ impl<let N: u32, Env> PrivateVoidCallInterface<N, Env> {
     }
 
     pub fn view(self, context: &mut PrivateContext) {
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(self.args_hash == packed_args_hash);
+        pack_arguments(self.args);
         context.call_private_function_with_packed_args(self.target_contract, self.selector, self.args_hash, true, false).assert_empty();
     }
 
     pub fn delegate_call(self, context: &mut PrivateContext) {
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(self.args_hash == packed_args_hash);
+        pack_arguments(self.args);
         context.call_private_function_with_packed_args(self.target_contract, self.selector, self.args_hash, false, true).assert_empty();
     }
 }
@@ -153,10 +135,7 @@ pub struct PrivateStaticCallInterface<let N: u32, T, Env> {
 
 impl<let N: u32, T, Env> PrivateStaticCallInterface<N, T, Env> {
     pub fn view<let M: u32>(self, context: &mut PrivateContext) -> T where T: Deserialize<M> {
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(self.args_hash == packed_args_hash);
+        pack_arguments(self.args);
         let returns = context.call_private_function_with_packed_args(self.target_contract, self.selector, self.args_hash, true, false);
         returns.unpack_into()
     }
@@ -180,10 +159,7 @@ pub struct PrivateStaticVoidCallInterface<let N: u32, Env> {
 
 impl<let N: u32, Env> PrivateStaticVoidCallInterface<N, Env> {
     pub fn view(self, context: &mut PrivateContext) {
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(self.args_hash == packed_args_hash);
+        pack_arguments(self.args);
         context.call_private_function_with_packed_args(self.target_contract, self.selector, self.args_hash, true, false).assert_empty();
     }
 }
@@ -227,10 +203,7 @@ impl<let N: u32, T, Env> PublicCallInterface<N, T, Env> {
 
     pub fn enqueue(self, context: &mut PrivateContext) {
         let args_hash = hash_args(self.args);
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(args_hash == packed_args_hash);
+        pack_arguments(self.args);
         context.call_public_function_with_packed_args(
             self.target_contract,
             self.selector,
@@ -242,10 +215,7 @@ impl<let N: u32, T, Env> PublicCallInterface<N, T, Env> {
 
     pub fn enqueue_view(self, context: &mut PrivateContext) {
         let args_hash = hash_args(self.args);
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(args_hash == packed_args_hash);
+        pack_arguments(self.args);
         context.call_public_function_with_packed_args(
             self.target_contract,
             self.selector,
@@ -257,10 +227,7 @@ impl<let N: u32, T, Env> PublicCallInterface<N, T, Env> {
 
     pub fn delegate_enqueue(self, context: &mut PrivateContext) {
         let args_hash = hash_args(self.args);
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(args_hash == packed_args_hash);
+        pack_arguments(self.args);
         context.call_public_function_with_packed_args(
             self.target_contract,
             self.selector,
@@ -310,10 +277,7 @@ impl<let N: u32, Env> PublicVoidCallInterface<N, Env> {
 
     pub fn enqueue(self, context: &mut PrivateContext) {
         let args_hash = hash_args(self.args);
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(args_hash == packed_args_hash);
+        pack_arguments(self.args);
         context.call_public_function_with_packed_args(
             self.target_contract,
             self.selector,
@@ -325,10 +289,7 @@ impl<let N: u32, Env> PublicVoidCallInterface<N, Env> {
 
     pub fn enqueue_view(self, context: &mut PrivateContext) {
         let args_hash = hash_args(self.args);
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(args_hash == packed_args_hash);
+        pack_arguments(self.args);
         context.call_public_function_with_packed_args(
             self.target_contract,
             self.selector,
@@ -340,10 +301,7 @@ impl<let N: u32, Env> PublicVoidCallInterface<N, Env> {
 
     pub fn delegate_enqueue(self, context: &mut PrivateContext) {
         let args_hash = hash_args(self.args);
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(args_hash == packed_args_hash);
+        pack_arguments(self.args);
         context.call_public_function_with_packed_args(
             self.target_contract,
             self.selector,
@@ -384,10 +342,7 @@ impl<let N: u32, T, Env> PublicStaticCallInterface<N, T, Env> {
 
     pub fn enqueue_view(self, context: &mut PrivateContext) {
         let args_hash = hash_args(self.args);
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(args_hash == packed_args_hash);
+        pack_arguments(self.args);
         context.call_public_function_with_packed_args(
             self.target_contract,
             self.selector,
@@ -427,10 +382,7 @@ impl<let N: u32, Env> PublicStaticVoidCallInterface<N, Env> {
 
     pub fn enqueue_view(self, context: &mut PrivateContext) {
         let args_hash = hash_args(self.args);
-        let packed_args_hash = unsafe {
-            pack_arguments(self.args)
-        };
-        assert(args_hash == packed_args_hash);
+        pack_arguments(self.args);
         context.call_public_function_with_packed_args(
             self.target_contract,
             self.selector,

--- a/noir-projects/aztec-nr/aztec/src/context/packed_returns.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/packed_returns.nr
@@ -19,7 +19,11 @@ impl PackedReturns {
     }
 
     pub fn unpack<let N: u32>(self) -> [Field; N] {
-        let unpacked: [Field; N] = unpack_returns(self.packed_returns);
+        // We verify that the value returned by `unpack_returns` is the preimage of `packed_returns`, fully constraining
+        // it.
+        let unpacked: [Field; N] = unsafe {
+            unpack_returns(self.packed_returns)
+        };
         assert_eq(self.packed_returns, hash_args_array(unpacked));
         unpacked
     }

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -295,7 +295,7 @@ impl PrivateContext {
         args: [Field; ARGS_COUNT]
     ) -> PackedReturns {
         let args_hash = hash_args_array(args);
-        assert(args_hash == arguments::pack_arguments_array(args));
+        arguments::pack_arguments_array(args);
         self.call_private_function_with_packed_args(contract_address, function_selector, args_hash, false, false)
     }
 
@@ -306,7 +306,7 @@ impl PrivateContext {
         args: [Field; ARGS_COUNT]
     ) -> PackedReturns {
         let args_hash = hash_args_array(args);
-        assert(args_hash == arguments::pack_arguments_array(args));
+        arguments::pack_arguments_array(args);
         self.call_private_function_with_packed_args(contract_address, function_selector, args_hash, true, false)
     }
 
@@ -317,7 +317,7 @@ impl PrivateContext {
         args: [Field; ARGS_COUNT]
     ) -> PackedReturns {
         let args_hash = hash_args_array(args);
-        assert(args_hash == arguments::pack_arguments_array(args));
+        arguments::pack_arguments_array(args);
         self.call_private_function_with_packed_args(contract_address, function_selector, args_hash, false, true)
     }
 
@@ -407,7 +407,7 @@ impl PrivateContext {
         args: [Field; ARGS_COUNT]
     ) {
         let args_hash = hash_args_array(args);
-        assert(args_hash == arguments::pack_arguments_array(args));
+        arguments::pack_arguments_array(args);
         self.call_public_function_with_packed_args(contract_address, function_selector, args_hash, false, false)
     }
 
@@ -418,7 +418,7 @@ impl PrivateContext {
         args: [Field; ARGS_COUNT]
     ) {
         let args_hash = hash_args_array(args);
-        assert(args_hash == arguments::pack_arguments_array(args));
+        arguments::pack_arguments_array(args);
         self.call_public_function_with_packed_args(contract_address, function_selector, args_hash, true, false)
     }
 
@@ -429,7 +429,7 @@ impl PrivateContext {
         args: [Field; ARGS_COUNT]
     ) {
         let args_hash = hash_args_array(args);
-        assert(args_hash == arguments::pack_arguments_array(args));
+        arguments::pack_arguments_array(args);
         self.call_public_function_with_packed_args(contract_address, function_selector, args_hash, false, true)
     }
 
@@ -495,7 +495,7 @@ impl PrivateContext {
         args: [Field; ARGS_COUNT]
     ) {
         let args_hash = hash_args_array(args);
-        assert(args_hash == arguments::pack_arguments_array(args));
+        arguments::pack_arguments_array(args);
         self.set_public_teardown_function_with_packed_args(contract_address, function_selector, args_hash, false, false)
     }
 

--- a/noir-projects/aztec-nr/aztec/src/messaging.nr
+++ b/noir-projects/aztec-nr/aztec/src/messaging.nr
@@ -3,8 +3,7 @@ use crate::{
     oracle::get_l1_to_l2_membership_witness::get_l1_to_l2_membership_witness
 };
 
-use dep::protocol_types::merkle_tree::root::root_from_sibling_path;
-use dep::protocol_types::{constants::L1_TO_L2_MSG_TREE_HEIGHT, address::{AztecAddress, EthAddress}, utils::arr_copy_slice};
+use dep::protocol_types::{address::{AztecAddress, EthAddress}, merkle_tree::root::root_from_sibling_path};
 
 pub fn process_l1_to_l2_message(
     l1_to_l2_root: Field,
@@ -25,12 +24,12 @@ pub fn process_l1_to_l2_message(
         secret_hash
     );
 
-    let returned_message = get_l1_to_l2_membership_witness(storage_contract_address, message_hash, secret);
-    let leaf_index = returned_message[0];
-    let sibling_path = arr_copy_slice(returned_message, [0; L1_TO_L2_MSG_TREE_HEIGHT], 1);
+    // We prove that `message_hash` is in the tree by showing the derivation of the tree root, using a merkle path we
+    // get from an oracle.
+    let (leaf_index, sibling_path) = unsafe {
+        get_l1_to_l2_membership_witness(storage_contract_address, message_hash, secret)
+    };
 
-    // Check that the message is in the tree
-    // This is implicitly checking that the values of the message are correct
     let root = root_from_sibling_path(message_hash, leaf_index, sibling_path);
     assert(root == l1_to_l2_root, "Message not in state");
 

--- a/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
@@ -19,15 +19,12 @@ pub fn create_note<Note, let N: u32>(
     let note_hash = note.compute_note_hash();
 
     let serialized_note = Note::serialize_content(*note);
-    assert(
-        notify_created_note(
+    notify_created_note(
         storage_slot,
         Note::get_note_type_id(),
         serialized_note,
         note_hash,
         note_hash_counter
-    )
-        == 0
     );
 
     context.push_note_hash(note_hash);
@@ -81,8 +78,7 @@ pub fn destroy_note_unsafe<Note, let N: u32>(
     };
 
     let nullifier_counter = context.side_effect_counter;
-    assert(notify_nullified_note(nullifier, notification_note_hash, nullifier_counter) == 0);
+    notify_nullified_note(nullifier, notification_note_hash, nullifier_counter);
 
     context.push_nullifier_for_note_hash(nullifier, notification_note_hash)
 }
-

--- a/noir-projects/aztec-nr/aztec/src/note/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/utils.nr
@@ -105,7 +105,7 @@ pub fn compute_note_hash_for_nullify<Note, let N: u32>(note: Note) -> Field wher
     compute_note_hash_for_nullify_internal(note, note_hash_for_read_request)
 }
 
-pub fn compute_note_hash_and_optionally_a_nullifier<T, let N: u32, let S: u32>(
+unconstrained pub fn compute_note_hash_and_optionally_a_nullifier<T, let N: u32, let S: u32>(
     deserialize_content: fn([Field; N]) -> T,
     note_header: NoteHeader,
     compute_nullifier: bool,

--- a/noir-projects/aztec-nr/aztec/src/oracle/arguments.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/arguments.nr
@@ -1,24 +1,32 @@
-#[oracle(packArgumentsArray)]
-unconstrained fn pack_arguments_array_oracle<let N: u32>(_args: [Field; N]) -> Field {}
+/// Notifies the simulator that `args` will later be used at some point during execution, referenced by their hash. This
+/// allows the simulator to know how to respond to this future request.
+///
+/// This is only used during private execution, since in public it is the VM itself that keeps track of arguments.
+pub fn pack_arguments(args: [Field]) {
+    // This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to call.
+    unsafe {
+        pack_arguments_oracle_wrapper(args)
+    };
+}
+
+/// Same as `pack_arguments`, but using arrays instead of slices.
+pub fn pack_arguments_array<let N: u32>(args: [Field; N]) {
+    // This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to call.
+    unsafe {
+        pack_arguments_array_oracle_wrapper(args)
+    };
+}
+
+unconstrained fn pack_arguments_oracle_wrapper(args: [Field]) {
+    let _ = pack_arguments_oracle(args);
+}
+
+unconstrained fn pack_arguments_array_oracle_wrapper<let N: u32>(args: [Field; N]) {
+    let _ = pack_arguments_array_oracle(args);
+}
 
 #[oracle(packArguments)]
 unconstrained fn pack_arguments_oracle(_args: [Field]) -> Field {}
 
-/// - Pack arguments (array version) will notify the simulator that these arguments will be used later at
-///   some point in the call.
-/// - When the external call is made later, the simulator will know what the values unpack to.
-/// - This oracle will not be required in public vm functions, as the vm will keep track of arguments
-///   itself.
-unconstrained pub fn pack_arguments_array<let N: u32>(args: [Field; N]) -> Field {
-    pack_arguments_array_oracle(args)
-}
-
-/// - Pack arguments (slice version) will notify the simulator that these arguments will be used later at
-///   some point in the call.
-/// - When the external call is made later, the simulator will know what the values unpack to.
-/// - This oracle will not be required in public vm functions, as the vm will keep track of arguments
-///   itself.
-unconstrained pub fn pack_arguments(args: [Field]) -> Field {
-    pack_arguments_oracle(args)
-}
-
+#[oracle(packArgumentsArray)]
+unconstrained fn pack_arguments_array_oracle<let N: u32>(_args: [Field; N]) -> Field {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/arguments.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/arguments.nr
@@ -3,7 +3,8 @@
 ///
 /// This is only used during private execution, since in public it is the VM itself that keeps track of arguments.
 pub fn pack_arguments(args: [Field]) {
-    // This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to call.
+    // This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to call. When
+    // unpacking however the caller must check that the returned value is indeed the preimage.
     unsafe {
         pack_arguments_oracle_wrapper(args)
     };
@@ -11,7 +12,8 @@ pub fn pack_arguments(args: [Field]) {
 
 /// Same as `pack_arguments`, but using arrays instead of slices.
 pub fn pack_arguments_array<let N: u32>(args: [Field; N]) {
-    // This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to call.
+    // This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to call. When
+    // unpacking however the caller must check that the returned value is indeed the preimage.
     unsafe {
         pack_arguments_array_oracle_wrapper(args)
     };

--- a/noir-projects/aztec-nr/aztec/src/oracle/enqueue_public_function_call.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/enqueue_public_function_call.nr
@@ -56,9 +56,15 @@ unconstrained pub fn set_public_teardown_function_call_internal(
     );
 }
 
-#[oracle(notifySetMinRevertibleSideEffectCounter)]
-unconstrained fn notify_set_min_revertible_side_effect_counter_oracle(_counter: u32) {}
+pub fn notify_set_min_revertible_side_effect_counter(counter: u32) {
+    unsafe {
+        notify_set_min_revertible_side_effect_counter_oracle_wrapper(counter)
+    };
+}
 
-unconstrained pub fn notify_set_min_revertible_side_effect_counter(counter: u32) {
+unconstrained pub fn notify_set_min_revertible_side_effect_counter_oracle_wrapper(counter: u32) {
     notify_set_min_revertible_side_effect_counter_oracle(counter);
 }
+
+#[oracle(notifySetMinRevertibleSideEffectCounter)]
+unconstrained fn notify_set_min_revertible_side_effect_counter_oracle(_counter: u32) {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_l1_to_l2_membership_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_l1_to_l2_membership_witness.nr
@@ -1,6 +1,18 @@
-use dep::protocol_types::address::AztecAddress;
+use dep::protocol_types::{address::AztecAddress, constants::L1_TO_L2_MSG_TREE_HEIGHT, utils::arr_copy_slice};
 
-global L1_TO_L2_MESSAGE_ORACLE_CALL_LENGTH: u32 = 17;
+/// Returns the leaf index and sibling path of an entry in the L1 to L2 messaging tree, which can then be used to prove
+/// its existence.
+unconstrained pub fn get_l1_to_l2_membership_witness(
+    contract_address: AztecAddress,
+    message_hash: Field,
+    secret: Field
+) -> (Field, [Field; L1_TO_L2_MSG_TREE_HEIGHT]) {
+    let returned_message = get_l1_to_l2_membership_witness_oracle(contract_address, message_hash, secret);
+    let leaf_index = returned_message[0];
+    let sibling_path = arr_copy_slice(returned_message, [0; L1_TO_L2_MSG_TREE_HEIGHT], 1);
+
+    (leaf_index, sibling_path)
+}
 
 // Obtains membership witness (index and sibling path) for a message in the L1 to L2 message tree.
 #[oracle(getL1ToL2MembershipWitness)]
@@ -8,12 +20,4 @@ unconstrained fn get_l1_to_l2_membership_witness_oracle(
     _contract_address: AztecAddress,
     _message_hash: Field,
     _secret: Field
-) -> [Field; L1_TO_L2_MESSAGE_ORACLE_CALL_LENGTH] {}
-
-unconstrained pub fn get_l1_to_l2_membership_witness(
-    contract_address: AztecAddress,
-    message_hash: Field,
-    secret: Field
-) -> [Field; L1_TO_L2_MESSAGE_ORACLE_CALL_LENGTH] {
-    get_l1_to_l2_membership_witness_oracle(contract_address, message_hash, secret)
-}
+) -> [Field; L1_TO_L2_MSG_TREE_HEIGHT + 1] {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -171,11 +171,13 @@ unconstrained pub fn get_notes<Note, let N: u32, let M: u32, let S: u32, let NS:
     placeholder_opt_notes
 }
 
-// Only ever use this in private!
-#[oracle(checkNullifierExists)]
-unconstrained fn check_nullifier_exists_oracle(_inner_nullifier: Field) -> Field {}
-
-// Only ever use this in private!
+/// Returns true if the nullifier exists. Note that a `true` value can be constrained by proving existence of the
+/// nullifier, but a `false` value should not be relied upon since other transactions may emit this nullifier before the
+/// current transaction is included in a block. While this might seem of little use at first, certain design patterns
+/// benefit from this abstraction (see e.g. `PrivateMutable`).
 unconstrained pub fn check_nullifier_exists(inner_nullifier: Field) -> bool {
     check_nullifier_exists_oracle(inner_nullifier) == 1
 }
+
+#[oracle(checkNullifierExists)]
+unconstrained fn check_nullifier_exists_oracle(_inner_nullifier: Field) -> Field {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -2,6 +2,41 @@ use crate::note::{note_header::NoteHeader, note_interface::NoteInterface};
 
 use dep::protocol_types::{address::AztecAddress, utils::arr_copy_slice};
 
+/// Notifies the simulator that a note has been created, so that it can be returned in future read requests in the same
+/// transaction. This note should only be added to the non-volatile database if found in an actual block.
+pub fn notify_created_note<let N: u32>(
+    storage_slot: Field,
+    note_type_id: Field,
+    serialized_note: [Field; N],
+    note_hash: Field,
+    counter: u32
+) {
+    // This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to call.
+    unsafe {
+        notify_created_note_oracle_wrapper(storage_slot, note_type_id, serialized_note, note_hash, counter)
+    };
+}
+
+/// Notifies the simulator that a note has been nullified, so that it is no longer returned in future read requests in
+/// the same transaction. This note should only be removed to the non-volatile database if its nullifier is found in an
+/// actual block.
+pub fn notify_nullified_note(nullifier: Field, note_hash: Field, counter: u32) {
+    // This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to call.
+    unsafe {
+        notify_nullified_note_oracle_wrapper(nullifier, note_hash, counter)
+    };
+}
+
+unconstrained fn notify_created_note_oracle_wrapper<let N: u32>(
+    storage_slot: Field,
+    note_type_id: Field,
+    serialized_note: [Field; N],
+    note_hash: Field,
+    counter: u32
+) {
+    let _ = notify_created_note_oracle(storage_slot, note_type_id, serialized_note, note_hash, counter);
+}
+
 #[oracle(notifyCreatedNote)]
 unconstrained fn notify_created_note_oracle<let N: u32>(
     _storage_slot: Field,
@@ -11,22 +46,16 @@ unconstrained fn notify_created_note_oracle<let N: u32>(
     _counter: u32
 ) -> Field {}
 
-unconstrained pub fn notify_created_note<let N: u32>(
-    storage_slot: Field,
-    note_type_id: Field,
-    serialized_note: [Field; N],
+unconstrained fn notify_nullified_note_oracle_wrapper(
+    nullifier: Field,
     note_hash: Field,
     counter: u32
-) -> Field {
-    notify_created_note_oracle(storage_slot, note_type_id, serialized_note, note_hash, counter)
+) {
+    let _ = notify_nullified_note_oracle(nullifier, note_hash, counter);
 }
 
 #[oracle(notifyNullifiedNote)]
 unconstrained fn notify_nullified_note_oracle(_nullifier: Field, _note_hash: Field, _counter: u32) -> Field {}
-
-unconstrained pub fn notify_nullified_note(nullifier: Field, note_hash: Field, counter: u32) -> Field {
-    notify_nullified_note_oracle(nullifier, note_hash, counter)
-}
 
 #[oracle(getNotes)]
 unconstrained fn get_notes_oracle<let N: u32, let S: u32>(

--- a/noir-projects/aztec-nr/aztec/src/oracle/returns.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/returns.nr
@@ -6,11 +6,11 @@ pub fn pack_returns(returns: [Field]) {
     // This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to call. When
     // unpacking however the caller must check that the returned value is indeed the preimage.
     unsafe {
-        pack_returns_wrapper(returns)
+        pack_returns_oracle_wrapper(returns)
     };
 }
 
-unconstrained pub fn pack_returns_wrapper(returns: [Field]) {
+unconstrained pub fn pack_returns_oracle_wrapper(returns: [Field]) {
     let _ = pack_returns_oracle(returns);
 }
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/returns.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/returns.nr
@@ -1,13 +1,25 @@
-#[oracle(packReturns)]
-unconstrained fn pack_returns_oracle(_returns: [Field]) -> Field {}
-
-unconstrained pub fn pack_returns(returns: [Field]) {
-    let _unused = pack_returns_oracle(returns);
+/// Notifies the simulator that `returns` will be later fetched once the function return is processed, referenced by
+/// their hash. This allows the simulator to know how to respond to this future request.
+///
+/// This is only used during private execution, since in public it is the VM itself that keeps track of return values.
+pub fn pack_returns(returns: [Field]) {
+    // This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to call. When
+    // unpacking however the caller must check that the returned value is indeed the preimage.
+    unsafe {
+        pack_returns_wrapper(returns)
+    };
 }
 
-#[oracle(unpackReturns)]
-unconstrained fn unpack_returns_oracle<let N: u32>(_return_hash: Field) -> [Field; N] {}
+unconstrained pub fn pack_returns_wrapper(returns: [Field]) {
+    let _ = pack_returns_oracle(returns);
+}
 
 unconstrained pub fn unpack_returns<let N: u32>(return_hash: Field) -> [Field; N] {
     unpack_returns_oracle(return_hash)
 }
+
+#[oracle(packReturns)]
+unconstrained fn pack_returns_oracle(_returns: [Field]) -> Field {}
+
+#[oracle(unpackReturns)]
+unconstrained fn unpack_returns_oracle<let N: u32>(_return_hash: Field) -> [Field; N] {}

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
@@ -68,11 +68,7 @@ impl<Note, let N: u32> PrivateMutable<Note, &mut PrivateContext> where Note: Not
     // docs:end:replace
 
     pub fn initialize_or_replace(self, note: &mut Note) -> NoteEmission<Note> {
-        let is_initialized = unsafe {
-            check_nullifier_exists(self.compute_initialization_nullifier())
-        };
-
-        // check_nullifier_exists() is an unconstrained function - we can constrain a true value by providing an
+        // `check_nullifier_exists` is an unconstrained function - we can constrain a true value by providing an
         // inclusion proof of the nullifier, but cannot constrain a false value since a non-inclusion proof would only
         // be valid if done in public.
         // Ultimately, this is not an issue ginen that we'll either:
@@ -82,6 +78,10 @@ impl<Note, let N: u32> PrivateMutable<Note, &mut PrivateContext> where Note: Not
         //    an inclusion proof for the current note
         // This means that an honest oracle will assist the prover to produce a valid proof, while a malicious oracle
         // (i.e. one that returns an incorrect value for is_initialized) will simply fail to produce a proof.
+        let is_initialized = unsafe {
+            check_nullifier_exists(self.compute_initialization_nullifier())
+        };
+
         if (!is_initialized) {
             self.initialize(note)
         } else {

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -202,15 +202,12 @@ impl TestEnvironment {
         note.set_header(header);
         let note_hash = note.compute_note_hash();
         let serialized_note = Note::serialize_content(*note);
-        assert(
-            notify_created_note(
+        notify_created_note(
             storage_slot,
             Note::get_note_type_id(),
             serialized_note,
             note_hash,
             note_hash_counter
-        )
-            == 0
         );
         cheatcodes::set_contract_address(original_contract_address);
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/debug_log.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/debug_log.nr
@@ -1,23 +1,26 @@
-// Utility function to console.log data in the acir simulator
-// WARNING: sometimes when using debug logs the ACVM errors with: `thrown: "solver opcode resolution error: cannot solve opcode: expression has too many unknowns x155"`
-
-#[oracle(debugLog)]
-unconstrained fn debug_log_oracle<let M: u32>(_msg: str<M>, args: [Field]) {}
-
-/// NOTE: call this with a str<N> msg of form
-/// "some string with {0} and {1} ... {N}"
-/// and an array of N field which will be formatted
-/// into the string in the simulator.
+/// Utility function to console.log data in the acir simulator.
 /// Example:
-/// debug_log_format("get_2(slot:{0}) =>\n\t0:{1}\n\t1:{2}", [storage_slot, note0_hash, note1_hash]);
-/// debug_log_format("whole array: {}", [e1, e2, e3, e4]);
-unconstrained pub fn debug_log_format<let M: u32, let N: u32>(msg: str<M>, args: [Field; N]) {
+///   debug_log("blah blah this is a debug string");
+pub fn debug_log<let N: u32>(msg: str<N>) {
+    debug_log_format(msg, []);
+}
+
+/// Utility function to console.log data in the acir simulator. This variant receives a format string in which the
+/// `${k}` tokens will be replaced with the k-eth value in the `args` array.
+/// Examples:
+///   debug_log_format("get_2(slot:{0}) =>\n\t0:{1}\n\t1:{2}", [storage_slot, note0_hash, note1_hash]);
+///   debug_log_format("whole array: {}", [e1, e2, e3, e4]);
+pub fn debug_log_format<let M: u32, let N: u32>(msg: str<M>, args: [Field; N]) {
+    // This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to call.
+    unsafe {
+        debug_log_oracle_wrapper(msg, args)
+    };
+}
+
+unconstrained pub fn debug_log_oracle_wrapper<let M: u32, let N: u32>(msg: str<M>, args: [Field; N]) {
     debug_log_oracle(msg, args.as_slice());
 }
 
-/// NOTE: call this with a str<N> msg of length > 1
-/// Example:
-/// `debug_log("blah blah this is a debug string");`
-unconstrained pub fn debug_log<let N: u32>(msg: str<N>) {
-    debug_log_format(msg, []);
-}
+// WARNING: sometimes when using debug logs the ACVM errors with: `thrown: "solver opcode resolution error: cannot solve opcode: expression has too many unknowns x155"`
+#[oracle(debugLog)]
+unconstrained fn debug_log_oracle<let M: u32>(_msg: str<M>, args: [Field]) {}


### PR DESCRIPTION
Continuation of the safety efforts: I removed the `unconstrained` property from some functions that are actually always safe to call (e.g. logs), improved documentation a bit, and expanded on some `unsafe` callsites explaining why what we're doing is correct.

This was originally much larger, covering `unsafe_rand` and `get_key_validation_request`, but I left those out as things got a bit out of hand.