### PR TITLE
chore: fix some more imports

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -4,7 +4,6 @@ use dep::protocol_types::constants::MAX_FIELD_VALUE;
 use dep::protocol_types::traits::{Serialize, Deserialize, Empty};
 use dep::protocol_types::abis::function_selector::FunctionSelector;
 use crate::context::gas::GasOpts;
-use crate::hash::ArgsHasher;
 
 pub struct PublicContext {
     args_hash: Option<Field>,
@@ -204,7 +203,6 @@ fn gas_for_call(user_gas: GasOpts) -> [Field; 2] {
 }
 
 // Unconstrained opcode wrappers (do not use directly).
-// TODO(https://github.com/AztecProtocol/aztec-packages/issues/6420): reconsider.
 unconstrained fn address() -> AztecAddress {
     address_opcode()
 }

--- a/noir-projects/aztec-nr/aztec/src/test/mocks/mock_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/mocks/mock_note.nr
@@ -1,9 +1,9 @@
 use crate::{
-    context::PrivateContext, generators::Ga1 as G_val, hash::poseidon2_hash_with_separator,
+    context::PrivateContext, generators::Ga1 as G_val,
     note::{note_header::NoteHeader, note_interface::NoteInterface, utils::compute_note_hash_for_nullify}
 };
 
-use dep::protocol_types::{address::AztecAddress, constants::GENERATOR_INDEX__NOTE_NULLIFIER, traits::Eq};
+use dep::protocol_types::{address::AztecAddress, constants::GENERATOR_INDEX__NOTE_NULLIFIER, hash::poseidon2_hash_with_separator};
 use dep::std::{embedded_curve_ops::multi_scalar_mul, hash::from_field_unsafe};
 use crate::note::note_interface::NullifiableNote;
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_sorted_transformed_value_array/get_combined_order_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_sorted_transformed_value_array/get_combined_order_hints.nr
@@ -3,7 +3,7 @@ use crate::{
     utils::arrays::{array_length, sort_by_counter::compare_by_counter_empty_padded_asc, get_sorted_tuple::get_sorted_tuple}
 };
 
-pub(crate) struct CombinedOrderHint {
+pub struct CombinedOrderHint {
     counter: u32,
     original_index: u32,
 }


### PR DESCRIPTION
Continuation of https://github.com/AztecProtocol/aztec-packages/pull/8760 and #8748. We still get some private exports due to https://github.com/noir-lang/noir/pull/6154, but hopefully those will be fixed soon.