### PR TITLE
chore: fix flakey e2e fees failures test

### DIFF
--- a/yarn-project/end-to-end/Earthfile
+++ b/yarn-project/end-to-end/Earthfile
@@ -140,9 +140,9 @@ e2e-fees-dapp-subscription:
   LOCALLY
   RUN ./scripts/e2e_test.sh ./src/e2e_fees/dapp_subscription.test.ts
 
-# e2e-fees-failures:
-#   LOCALLY
-#   RUN ./scripts/e2e_test.sh ./src/e2e_fees/failures.test.ts
+e2e-fees-failures:
+  LOCALLY
+  RUN ./scripts/e2e_test.sh ./src/e2e_fees/failures.test.ts
 
 e2e-fees-fee-juice-payments:
   LOCALLY

--- a/yarn-project/end-to-end/scripts/deflaker.sh
+++ b/yarn-project/end-to-end/scripts/deflaker.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+testname=$1
+script_dir=$(dirname "$0")
+
+for i in {1..100}
+do
+  echo "Run #$i"
+  if ! yarn test $1 > $script_dir/deflaker.log 2>&1; then
+    echo "failed"
+    exit 1
+  fi
+done
+echo "success"

--- a/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
@@ -8,7 +8,6 @@ import {
   PublicFeePaymentMethod,
   TxStatus,
   computeSecretHash,
-  sleep,
 } from '@aztec/aztec.js';
 import { Gas, GasSettings } from '@aztec/circuits.js';
 import { FunctionType } from '@aztec/foundation/abi';
@@ -31,7 +30,6 @@ describe('e2e_fees failures', () => {
     await t.applyBaseSnapshots();
     await t.applyFPCSetupSnapshot();
     ({ aliceWallet, aliceAddress, sequencerAddress, bananaCoin, bananaFPC, gasSettings } = await t.setup());
-    await t.aztecNode.setConfig({ minTxsPerBlock: 1, maxTxsPerBlock: 1 });
   });
 
   afterAll(async () => {
@@ -84,6 +82,10 @@ describe('e2e_fees failures', () => {
     // if we skip simulation, it includes the failed TX
     const rebateSecret = Fr.random();
     const currentSequencerL1Gas = await t.getCoinbaseBalance();
+
+    // We wait until the proven chain is caught up so all previous fees are paid out.
+    await t.catchUpProvenChain();
+
     const txReceipt = await bananaCoin.methods
       .transfer_public(aliceAddress, sequencerAddress, OutrageousPublicAmountAliceDoesNotHave, 0)
       .send({
@@ -98,10 +100,7 @@ describe('e2e_fees failures', () => {
     expect(txReceipt.status).toBe(TxStatus.APP_LOGIC_REVERTED);
 
     // We wait until the block is proven since that is when the payout happens.
-    const bn = await t.aztecNode.getBlockNumber();
-    while ((await t.aztecNode.getProvenBlockNumber()) < bn) {
-      await sleep(1000);
-    }
+    await t.catchUpProvenChain();
 
     const feeAmount = txReceipt.transactionFee!;
     const newSequencerL1FeeAssetBalance = await t.getCoinbaseBalance();

--- a/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
@@ -81,10 +81,10 @@ describe('e2e_fees failures', () => {
 
     // if we skip simulation, it includes the failed TX
     const rebateSecret = Fr.random();
-    const currentSequencerL1Gas = await t.getCoinbaseBalance();
 
     // We wait until the proven chain is caught up so all previous fees are paid out.
     await t.catchUpProvenChain();
+    const currentSequencerL1Gas = await t.getCoinbaseBalance();
 
     const txReceipt = await bananaCoin.methods
       .transfer_public(aliceAddress, sequencerAddress, OutrageousPublicAmountAliceDoesNotHave, 0)

--- a/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
@@ -31,6 +31,7 @@ describe('e2e_fees failures', () => {
     await t.applyBaseSnapshots();
     await t.applyFPCSetupSnapshot();
     ({ aliceWallet, aliceAddress, sequencerAddress, bananaCoin, bananaFPC, gasSettings } = await t.setup());
+    await t.aztecNode.setConfig({ minTxsPerBlock: 1, maxTxsPerBlock: 1 });
   });
 
   afterAll(async () => {

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -12,6 +12,7 @@ import {
   type TxHash,
   computeSecretHash,
   createDebugLogger,
+  sleep,
 } from '@aztec/aztec.js';
 import { DefaultMultiCallEntrypoint } from '@aztec/aztec.js/entrypoint';
 import { EthAddress, GasSettings, computePartialAddress } from '@aztec/circuits.js';
@@ -99,6 +100,13 @@ export class FeesTest {
 
   async teardown() {
     await this.snapshotManager.teardown();
+  }
+
+  async catchUpProvenChain() {
+    const bn = await this.aztecNode.getBlockNumber();
+    while ((await this.aztecNode.getProvenBlockNumber()) < bn) {
+      await sleep(1000);
+    }
   }
 
   /** Alice mints Token  */


### PR DESCRIPTION
If the proven chain weren't caught up before we took the measurement for coinbase's L1 balance, it could look as though the wrong amount of fees were paid out.