### PR TITLE
refactor: nuking `encode_and_encrypt_note(...)`

### DIFF
--- a/boxes/boxes/react/src/contracts/src/main.nr
+++ b/boxes/boxes/react/src/contracts/src/main.nr
@@ -5,7 +5,7 @@ contract BoxReact {
     use dep::aztec::{
         keys::public_keys::{IvpkM, OvpkM},
         prelude::{AztecAddress, PrivateMutable, Map, NoteInterface, NoteHeader, Point},
-        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys,
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         macros::{storage::storage, functions::{private, public, initializer}}
     };
     use dep::value_note::value_note::ValueNote;
@@ -26,7 +26,7 @@ contract BoxReact {
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner_npk_m_hash);
-        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note_with_keys(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
+        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
     }
 
     #[private]
@@ -39,7 +39,7 @@ contract BoxReact {
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner_npk_m_hash);
-        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note_with_keys(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
+        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
     }
 
     unconstrained fn getNumber(owner: AztecAddress) -> pub ValueNote {

--- a/boxes/boxes/vanilla/src/contracts/src/main.nr
+++ b/boxes/boxes/vanilla/src/contracts/src/main.nr
@@ -5,7 +5,7 @@ contract Vanilla {
     use dep::aztec::{
         keys::public_keys::{IvpkM, OvpkM},
         prelude::{AztecAddress, PrivateMutable, Map, NoteInterface, NoteHeader, Point},
-        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys,
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         macros::{storage::storage, functions::{private, public, initializer}}
     };
     use dep::value_note::value_note::{ValueNote, VALUE_NOTE_LEN};
@@ -26,7 +26,7 @@ contract Vanilla {
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner_npk_m_hash);
-        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note_with_keys(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
+        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
     }
 
     #[private]
@@ -39,7 +39,7 @@ contract Vanilla {
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner_npk_m_hash);
-        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note_with_keys(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
+        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
     }
 
     unconstrained fn getNumber(owner: AztecAddress) -> pub ValueNote {

--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -33,6 +33,19 @@ All of `TestEnvironment`'s functions are now `unconstrained`, preventing acciden
     let env = TestEnvironment::new();
 ```
 
+### [Aztec.nr] removed `encode_and_encrypt_note` and renamed `encode_and_encrypt_note_with_keys` to `encode_and_encrypt_note`
+
+````diff
+contract XYZ {
+-   use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys;
++   use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note;
+....
+
+-    numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note_with_keys(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
++    numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
+
+}
+
 ## 0.56.0
 
 ### [Aztec.nr] Changes to contract definition

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -1,6 +1,6 @@
 use crate::{
     context::PrivateContext, note::{note_emission::NoteEmission, note_interface::NoteInterface},
-    keys::{getters::{get_public_keys, get_ovsk_app}, public_keys::{OvpkM, IvpkM}},
+    keys::{getters::get_ovsk_app, public_keys::{OvpkM, IvpkM}},
     encrypted_logs::payload::compute_encrypted_log
 };
 use dep::protocol_types::{hash::sha256_to_field, address::AztecAddress, abis::note_hash::NoteHash};
@@ -43,41 +43,6 @@ unconstrained fn compute_raw_note_log_unconstrained<Note, let N: u32>(
 
 pub fn encode_and_encrypt_note<Note, let N: u32>(
     context: &mut PrivateContext,
-    ov: AztecAddress,
-    iv: AztecAddress
-) -> fn[(AztecAddress, AztecAddress, &mut PrivateContext)](NoteEmission<Note>) -> () where Note: NoteInterface<N> {
-    | e: NoteEmission<Note> | {
-        let ovpk = get_public_keys(ov).ovpk_m;
-        let ivpk = get_public_keys(iv).ivpk_m;
-        let ovsk_app: Field  = context.request_ovsk_app(ovpk.hash());
-
-        let (note_hash_counter, encrypted_log, log_hash) = compute_raw_note_log(*context, e.note, ovsk_app, ovpk, ivpk, iv);
-        context.emit_raw_note_log(note_hash_counter, encrypted_log, log_hash);
-    }
-}
-
-pub fn encode_and_encrypt_note_unconstrained<Note, let N: u32>(
-    context: &mut PrivateContext,
-    ov: AztecAddress,
-    iv: AztecAddress
-) -> fn[(AztecAddress, AztecAddress, &mut PrivateContext)](NoteEmission<Note>) -> () where Note: NoteInterface<N> {
-    | e: NoteEmission<Note> | {
-        // Note: We could save a lot of gates by obtaining the following keys in an unconstrained context but this
-        // function is currently not used anywhere so we are not optimizing it.
-        let ovpk = get_public_keys(ov).ovpk_m;
-        let ivpk = get_public_keys(iv).ivpk_m;
-
-        // See the comment in `encode_and_encrypt_note_with_keys_unconstrained` for why having note hash counter
-        // and log hash unconstrained here is fine.
-        let (note_hash_counter, encrypted_log, log_hash) = unsafe {
-            compute_raw_note_log_unconstrained(*context, e.note, ovpk, ivpk, iv)
-        };
-        context.emit_raw_note_log(note_hash_counter, encrypted_log, log_hash);
-    }
-}
-
-pub fn encode_and_encrypt_note_with_keys<Note, let N: u32>(
-    context: &mut PrivateContext,
     ovpk: OvpkM,
     ivpk: IvpkM,
     recipient: AztecAddress
@@ -90,7 +55,7 @@ pub fn encode_and_encrypt_note_with_keys<Note, let N: u32>(
     }
 }
 
-pub fn encode_and_encrypt_note_with_keys_unconstrained<Note, let N: u32>(
+pub fn encode_and_encrypt_note_unconstrained<Note, let N: u32>(
     context: &mut PrivateContext,
     ovpk: OvpkM,
     ivpk: IvpkM,

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -1,8 +1,7 @@
 use dep::aztec::{
     context::PrivateContext, protocol_types::{address::AztecAddress},
     note::note_getter_options::NoteGetterOptions, state_vars::PrivateSet,
-    encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys,
-    keys::getters::get_public_keys
+    encrypted_logs::encrypted_note_emission::encode_and_encrypt_note, keys::getters::get_public_keys
 };
 use dep::value_note::{filter::filter_notes_min_sum, value_note::ValueNote};
 
@@ -32,7 +31,7 @@ impl EasyPrivateUint<&mut PrivateContext> {
         // Insert the new note to the owner's set of notes.
         // docs:start:insert
         self.set.insert(&mut addend_note).emit(
-            encode_and_encrypt_note_with_keys(
+            encode_and_encrypt_note(
                 self.context,
                 outgoing_viewer_keys.ovpk_m,
                 owner_keys.ivpk_m,
@@ -67,7 +66,7 @@ impl EasyPrivateUint<&mut PrivateContext> {
         let result_value = minuend - subtrahend;
         let mut result_note = ValueNote::new(result_value as Field, owner_keys.npk_m.hash());
         self.set.insert(&mut result_note).emit(
-            encode_and_encrypt_note_with_keys(
+            encode_and_encrypt_note(
                 self.context,
                 outgoing_viewer_keys.ovpk_m,
                 owner_keys.ivpk_m,

--- a/noir-projects/aztec-nr/value-note/src/utils.nr
+++ b/noir-projects/aztec-nr/value-note/src/utils.nr
@@ -1,6 +1,6 @@
 use dep::aztec::prelude::{AztecAddress, PrivateContext, PrivateSet, NoteGetterOptions};
 use dep::aztec::note::note_getter_options::SortOrder;
-use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys;
+use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note;
 use dep::aztec::keys::getters::get_public_keys;
 use crate::{filter::filter_notes_min_sum, value_note::{ValueNote, VALUE_NOTE_LEN}};
 
@@ -25,7 +25,7 @@ pub fn increment(
     let mut note = ValueNote::new(amount, recipient_keys.npk_m.hash());
     // Insert the new note to the owner's set of notes and emit the log if value is non-zero.
     balance.insert(&mut note).emit(
-        encode_and_encrypt_note_with_keys(
+        encode_and_encrypt_note(
             balance.context,
             outgoing_viewer_ovpk_m,
             recipient_keys.ivpk_m,

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -10,7 +10,7 @@ contract AppSubscription {
     use aztec::{
         prelude::{AztecAddress, Map, PrivateMutable, SharedImmutable}, keys::getters::get_public_keys,
         protocol_types::constants::MAX_FIELD_VALUE, utils::comparison::Comparator,
-        encrypted_logs::encrypted_note_emission::{encode_and_encrypt_note, encode_and_encrypt_note_with_keys},
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         macros::{storage::storage, functions::{public, initializer, private}}
     };
     use authwit::auth::assert_current_call_valid_authwit;
@@ -46,7 +46,8 @@ contract AppSubscription {
 
         // We are emitting both the outgoing and the incoming logs to the subscriber here because passing a separate
         // outgoing_viewer arg to entrypoint function is impractical and the outgoing are not so valuable here.
-        storage.subscriptions.at(user_address).replace(&mut note).emit(encode_and_encrypt_note(&mut context, user_address, user_address));
+        let keys = get_public_keys(user_address);
+        storage.subscriptions.at(user_address).replace(&mut note).emit(encode_and_encrypt_note(&mut context, keys.ovpk_m, keys.ivpk_m, user_address));
 
         context.set_as_fee_payer();
 
@@ -102,7 +103,7 @@ contract AppSubscription {
 
         let mut subscription_note = SubscriptionNote::new(subscriber_keys.npk_m.hash(), expiry_block_number, tx_count);
         storage.subscriptions.at(subscriber).initialize_or_replace(&mut subscription_note).emit(
-            encode_and_encrypt_note_with_keys(
+            encode_and_encrypt_note(
                 &mut context,
                 msg_sender_ovpk_m,
                 subscriber_keys.ivpk_m,

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -3,8 +3,8 @@ use dep::aztec::prelude::{AztecAddress, PrivateContext, NoteGetterOptions, NoteV
 use dep::aztec::{
     context::UnconstrainedContext,
     protocol_types::{traits::{ToField, Serialize, FromField}, constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL},
-    encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys,
-    keys::getters::get_public_keys, state_vars::PrivateSet, note::constants::MAX_NOTES_PER_PAGE
+    encrypted_logs::encrypted_note_emission::encode_and_encrypt_note, keys::getters::get_public_keys,
+    state_vars::PrivateSet, note::constants::MAX_NOTES_PER_PAGE
 };
 use dep::value_note::value_note::ValueNote;
 
@@ -112,9 +112,7 @@ impl Deck<&mut PrivateContext> {
         let mut inserted_cards = &[];
         for card in cards {
             let mut card_note = CardNote::from_card(card, owner_npk_m_hash);
-            self.set.insert(&mut card_note.note).emit(
-                encode_and_encrypt_note_with_keys(self.set.context, msg_sender_ovpk_m, owner_ivpk_m, owner)
-            );
+            self.set.insert(&mut card_note.note).emit(encode_and_encrypt_note(self.set.context, msg_sender_ovpk_m, owner_ivpk_m, owner));
             inserted_cards = inserted_cards.push_back(card_note);
         }
 

--- a/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
@@ -7,7 +7,7 @@ contract Child {
 
     use dep::aztec::{
         note::{note_getter_options::NoteGetterOptions},
-        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys,
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         keys::getters::get_public_keys, utils::comparison::Comparator,
         macros::{storage::storage, functions::{private, public, internal}}
     };
@@ -58,7 +58,7 @@ contract Child {
         let owner_keys = get_public_keys(owner);
 
         let mut note = ValueNote::new(new_value, owner_keys.npk_m.hash());
-        storage.a_map_with_private_values.at(owner).insert(&mut note).emit(encode_and_encrypt_note_with_keys(&mut context, owner_keys.ovpk_m, owner_keys.ivpk_m, owner));
+        storage.a_map_with_private_values.at(owner).insert(&mut note).emit(encode_and_encrypt_note(&mut context, owner_keys.ovpk_m, owner_keys.ivpk_m, owner));
         new_value
     }
 

--- a/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
@@ -7,7 +7,7 @@ contract Crowdfunding {
 
     // docs:start:all-deps
     use dep::aztec::{
-        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys,
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         keys::getters::get_public_keys, prelude::{AztecAddress, PrivateSet, SharedImmutable},
         utils::comparison::Comparator, unencrypted_logs::unencrypted_event_emission::encode_event,
         macros::{storage::storage, events::event, functions::{public, initializer, private, internal}},
@@ -80,7 +80,7 @@ contract Crowdfunding {
         // docs:start:valuenote_new
         let mut note = ValueNote::new(amount as Field, donor_keys.npk_m.hash());
         // docs:end:valuenote_new
-        storage.donation_receipts.insert(&mut note).emit(encode_and_encrypt_note_with_keys(&mut context, donor_keys.ovpk_m, donor_keys.ivpk_m, donor));
+        storage.donation_receipts.insert(&mut note).emit(encode_and_encrypt_note(&mut context, donor_keys.ovpk_m, donor_keys.ivpk_m, donor));
     }
     // docs:end:donate
 

--- a/noir-projects/noir-contracts/contracts/delegated_on_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/delegated_on_contract/src/main.nr
@@ -19,10 +19,11 @@ contract DelegatedOn {
 
     #[private]
     fn private_set_value(new_value: Field, owner: AztecAddress) -> Field {
-        let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
+        let msg_sender_keys = get_public_keys(context.msg_sender());
+        let owner_keys = get_public_keys(owner);
 
-        let mut note = ValueNote::new(new_value, owner_npk_m_hash);
-        storage.a_map_with_private_values.at(owner).insert(&mut note).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), owner));
+        let mut note = ValueNote::new(new_value, owner_keys.npk_m.hash());
+        storage.a_map_with_private_values.at(owner).insert(&mut note).emit(encode_and_encrypt_note(&mut context, msg_sender_keys.ovpk_m, owner_keys.ivpk_m, owner));
         new_value
     }
 

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -21,7 +21,7 @@ contract DocsExample {
         PrivateMutable, PrivateImmutable, PrivateSet, SharedImmutable
     };
     use dep::aztec::{
-        encrypted_logs::encrypted_note_emission::{encode_and_encrypt_note, encode_and_encrypt_note_with_keys},
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         keys::getters::get_public_keys,
         macros::{storage::storage, functions::{public, private, internal, view}}
     };
@@ -174,35 +174,48 @@ contract DocsExample {
     // docs:start:initialize-private-mutable
     #[private]
     fn initialize_private_immutable(randomness: Field, points: u8) {
-        let msg_sender_npk_m_hash = get_public_keys(context.msg_sender()).npk_m.hash();
+        let msg_sender_keys = get_public_keys(context.msg_sender());
 
-        let mut new_card = CardNote::new(points, randomness, msg_sender_npk_m_hash);
-        storage.private_immutable.initialize(&mut new_card).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), context.msg_sender()));
+        let mut new_card = CardNote::new(points, randomness, msg_sender_keys.npk_m.hash());
+        storage.private_immutable.initialize(&mut new_card).emit(
+            encode_and_encrypt_note(
+                &mut context,
+                msg_sender_keys.ovpk_m,
+                msg_sender_keys.ivpk_m,
+                context.msg_sender()
+            )
+        );
     }
     // docs:end:initialize-private-mutable
 
     #[private]
     // msg_sender() is 0 at deploy time. So created another function
     fn initialize_private(randomness: Field, points: u8) {
-        let msg_sender_npk_m_hash = get_public_keys(context.msg_sender()).npk_m.hash();
+        let msg_sender_keys = get_public_keys(context.msg_sender());
 
-        let mut legendary_card = CardNote::new(points, randomness, msg_sender_npk_m_hash);
+        let mut legendary_card = CardNote::new(points, randomness, msg_sender_keys.npk_m.hash());
         // create and broadcast note
-        storage.legendary_card.initialize(&mut legendary_card).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), context.msg_sender()));
+        storage.legendary_card.initialize(&mut legendary_card).emit(
+            encode_and_encrypt_note(
+                &mut context,
+                msg_sender_keys.ovpk_m,
+                msg_sender_keys.ivpk_m,
+                context.msg_sender()
+            )
+        );
     }
 
     #[private]
     fn insert_notes(amounts: [u8; 3]) {
-        let sender_keys = get_public_keys(context.msg_sender());
-        let sender_npk_m_hash = sender_keys.npk_m.hash();
+        let msg_sender_keys = get_public_keys(context.msg_sender());
 
         for i in 0..amounts.len() {
-            let mut note = CardNote::new(amounts[i], 1, sender_npk_m_hash);
+            let mut note = CardNote::new(amounts[i], 1, msg_sender_keys.npk_m.hash());
             storage.set.insert(&mut note).emit(
-                encode_and_encrypt_note_with_keys(
+                encode_and_encrypt_note(
                     &mut context,
-                    sender_keys.ovpk_m,
-                    sender_keys.ivpk_m,
+                    msg_sender_keys.ovpk_m,
+                    msg_sender_keys.ivpk_m,
                     context.msg_sender()
                 )
             );
@@ -210,10 +223,17 @@ contract DocsExample {
     }
     #[private]
     fn insert_note(amount: u8, randomness: Field) {
-        let sender_npk_m_hash = get_public_keys(context.msg_sender()).npk_m.hash();
+        let msg_sender_keys = get_public_keys(context.msg_sender());
 
-        let mut note = CardNote::new(amount, randomness, sender_npk_m_hash);
-        storage.set.insert(&mut note).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), context.msg_sender()));
+        let mut note = CardNote::new(amount, randomness, msg_sender_keys.npk_m.hash());
+        storage.set.insert(&mut note).emit(
+            encode_and_encrypt_note(
+                &mut context,
+                msg_sender_keys.ovpk_m,
+                msg_sender_keys.ivpk_m,
+                context.msg_sender()
+            )
+        );
     }
     // docs:start:state_vars-NoteGetterOptionsComparatorExampleNoir
     unconstrained fn read_note(comparator: u8, amount: Field) -> BoundedVec<CardNote, 10> {
@@ -223,10 +243,17 @@ contract DocsExample {
     // docs:end:state_vars-NoteGetterOptionsComparatorExampleNoir
     #[private]
     fn update_legendary_card(randomness: Field, points: u8) {
-        let sender_npk_m_hash = get_public_keys(context.msg_sender()).npk_m.hash();
+        let msg_sender_keys = get_public_keys(context.msg_sender());
 
-        let mut new_card = CardNote::new(points, randomness, sender_npk_m_hash);
-        storage.legendary_card.replace(&mut new_card).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), context.msg_sender()));
+        let mut new_card = CardNote::new(points, randomness, msg_sender_keys.npk_m.hash());
+        storage.legendary_card.replace(&mut new_card).emit(
+            encode_and_encrypt_note(
+                &mut context,
+                msg_sender_keys.ovpk_m,
+                msg_sender_keys.ivpk_m,
+                context.msg_sender()
+            )
+        );
         DocsExample::at(context.this_address()).update_leader(context.msg_sender(), points).enqueue(&mut context);
     }
     #[private]
@@ -234,15 +261,22 @@ contract DocsExample {
         // Ensure `points` > current value
         // Also serves as a e2e test that you can `get_note()` and then `replace()`
 
-        let sender_npk_m_hash = get_public_keys(context.msg_sender()).npk_m.hash();
+        let msg_sender_keys = get_public_keys(context.msg_sender());
 
         // docs:start:state_vars-PrivateMutableGet
         let card = storage.legendary_card.get_note().note;
         // docs:end:state_vars-PrivateMutableGet
         let points = card.points + 1;
-        let mut new_card = CardNote::new(points, card.randomness, sender_npk_m_hash);
+        let mut new_card = CardNote::new(points, card.randomness, msg_sender_keys.npk_m.hash());
         // docs:start:state_vars-PrivateMutableReplace
-        storage.legendary_card.replace(&mut new_card).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), context.msg_sender()));
+        storage.legendary_card.replace(&mut new_card).emit(
+            encode_and_encrypt_note(
+                &mut context,
+                msg_sender_keys.ovpk_m,
+                msg_sender_keys.ivpk_m,
+                context.msg_sender()
+            )
+        );
         // docs:end:state_vars-PrivateMutableReplace
         DocsExample::at(context.this_address()).update_leader(context.msg_sender(), points).enqueue(&mut context);
     }

--- a/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/src/main.nr
@@ -6,7 +6,7 @@ use dep::aztec::macros::aztec;
 contract EcdsaKAccount {
     use dep::aztec::prelude::{PrivateContext, PrivateImmutable};
     use dep::aztec::{
-        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys,
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         keys::getters::get_public_keys,
         macros::{storage::storage, functions::{private, initializer, view, noinitcheck}}
     };
@@ -34,7 +34,7 @@ contract EcdsaKAccount {
         // important.
 
         let mut pub_key_note = EcdsaPublicKeyNote::new(signing_pub_key_x, signing_pub_key_y, this_keys.npk_m.hash());
-        storage.public_key.initialize(&mut pub_key_note).emit(encode_and_encrypt_note_with_keys(&mut context, this_keys.ovpk_m, this_keys.ivpk_m, this));
+        storage.public_key.initialize(&mut pub_key_note).emit(encode_and_encrypt_note(&mut context, this_keys.ovpk_m, this_keys.ivpk_m, this));
     }
 
     // Note: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts

--- a/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/src/main.nr
@@ -5,7 +5,7 @@ use dep::aztec::macros::aztec;
 contract EcdsaRAccount {
     use dep::aztec::prelude::{PrivateContext, PrivateImmutable};
     use dep::aztec::{
-        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys,
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         keys::getters::get_public_keys,
         macros::{storage::storage, functions::{private, initializer, view, noinitcheck}}
     };
@@ -33,7 +33,7 @@ contract EcdsaRAccount {
         // important.
 
         let mut pub_key_note = EcdsaPublicKeyNote::new(signing_pub_key_x, signing_pub_key_y, this_keys.npk_m.hash());
-        storage.public_key.initialize(&mut pub_key_note).emit(encode_and_encrypt_note_with_keys(&mut context, this_keys.ovpk_m, this_keys.ivpk_m, this));
+        storage.public_key.initialize(&mut pub_key_note).emit(encode_and_encrypt_note(&mut context, this_keys.ovpk_m, this_keys.ivpk_m, this));
     }
 
     // Note: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts

--- a/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
@@ -5,7 +5,7 @@ use dep::aztec::macros::aztec;
 contract Escrow {
     use dep::aztec::prelude::{AztecAddress, PrivateImmutable};
     use dep::aztec::{
-        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys,
+        encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         keys::getters::get_public_keys, macros::{storage::storage, functions::{private, initializer}}
     };
 
@@ -28,9 +28,7 @@ contract Escrow {
         // docs:start:addressnote_new
         let mut note = AddressNote::new(owner, owner_keys.npk_m.hash());
         // docs:end:addressnote_new
-        storage.owner.initialize(&mut note).emit(
-            encode_and_encrypt_note_with_keys(&mut context, msg_sender_keys.ovpk_m, owner_keys.ivpk_m, owner)
-        );
+        storage.owner.initialize(&mut note).emit(encode_and_encrypt_note(&mut context, msg_sender_keys.ovpk_m, owner_keys.ivpk_m, owner));
     }
 
     // Withdraws balance. Requires that msg.sender is the owner.

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
@@ -30,11 +30,11 @@ contract InclusionProofs {
     // Creates a value note owned by `owner`.
     #[private]
     fn create_note(owner: AztecAddress, value: Field) {
-        let owner_private_values = storage.private_values.at(owner);
-        let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
+        let msg_sender_keys = get_public_keys(context.msg_sender());
+        let owner_keys = get_public_keys(owner);
 
-        let mut note = ValueNote::new(value, owner_npk_m_hash);
-        owner_private_values.insert(&mut note).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), owner));
+        let mut note = ValueNote::new(value, owner_keys.npk_m.hash());
+        storage.private_values.at(owner).insert(&mut note).emit(encode_and_encrypt_note(&mut context, msg_sender_keys.ovpk_m, owner_keys.ivpk_m, owner));
     }
     // docs:end:create_note
 

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
@@ -10,8 +10,8 @@ contract NFT {
     use dep::compressed_string::FieldCompressedString;
     use dep::aztec::{
         prelude::{NoteGetterOptions, NoteViewerOptions, Map, PublicMutable, SharedImmutable, PrivateSet, AztecAddress},
-        encrypted_logs::{encrypted_note_emission::encode_and_encrypt_note_with_keys},
-        hash::pedersen_hash, keys::getters::get_public_keys, note::constants::MAX_NOTES_PER_PAGE,
+        encrypted_logs::{encrypted_note_emission::encode_and_encrypt_note}, hash::pedersen_hash,
+        keys::getters::get_public_keys, note::constants::MAX_NOTES_PER_PAGE,
         protocol_types::traits::is_empty, utils::comparison::Comparator,
         protocol_types::{point::Point, traits::Serialize},
         macros::{storage::storage, events::event, functions::{private, public, view, internal, initializer}}
@@ -246,7 +246,7 @@ contract NFT {
         let to_keys = get_public_keys(to);
 
         let mut new_note = NFTNote::new(token_id, to_keys.npk_m.hash());
-        nfts.at(to).insert(&mut new_note).emit(encode_and_encrypt_note_with_keys(&mut context, from_ovpk_m, to_keys.ivpk_m, to));
+        nfts.at(to).insert(&mut new_note).emit(encode_and_encrypt_note(&mut context, from_ovpk_m, to_keys.ivpk_m, to));
     }
 
     #[private]

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
@@ -10,7 +10,7 @@ contract PendingNoteHashes {
     use dep::aztec::prelude::{AztecAddress, FunctionSelector, NoteGetterOptions, PrivateContext, Map, PrivateSet};
     use dep::value_note::{filter::filter_notes_min_sum, value_note::ValueNote};
     use dep::aztec::protocol_types::constants::{MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, MAX_NOTE_HASHES_PER_CALL};
-    use dep::aztec::encrypted_logs::encrypted_note_emission::{encode_and_encrypt_note, encode_and_encrypt_note_with_keys};
+    use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note;
     use dep::aztec::note::note_emission::NoteEmission;
     use dep::aztec::keys::getters::get_public_keys;
     use dep::aztec::macros::{storage::storage, functions::private};
@@ -34,12 +34,20 @@ contract PendingNoteHashes {
     ) -> Field {
         let owner_balance = storage.balances.at(owner);
 
-        let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
+        let owner_keys = get_public_keys(owner);
+        let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
 
-        let mut note = ValueNote::new(amount, owner_npk_m_hash);
+        let mut note = ValueNote::new(amount, owner_keys.npk_m.hash());
 
         // Insert note
-        owner_balance.insert(&mut note).emit(encode_and_encrypt_note(&mut context, outgoing_viewer, owner));
+        owner_balance.insert(&mut note).emit(
+            encode_and_encrypt_note(
+                &mut context,
+                outgoing_viewer_keys.ovpk_m,
+                owner_keys.ivpk_m,
+                owner
+            )
+        );
 
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, amount);
         // get note inserted above
@@ -81,12 +89,20 @@ contract PendingNoteHashes {
     fn insert_note(amount: Field, owner: AztecAddress, outgoing_viewer: AztecAddress) {
         let owner_balance = storage.balances.at(owner);
 
-        let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
+        let owner_keys = get_public_keys(owner);
+        let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
 
-        let mut note = ValueNote::new(amount, owner_npk_m_hash);
+        let mut note = ValueNote::new(amount, owner_keys.npk_m.hash());
 
         // Insert note
-        owner_balance.insert(&mut note).emit(encode_and_encrypt_note(&mut context, outgoing_viewer, owner));
+        owner_balance.insert(&mut note).emit(
+            encode_and_encrypt_note(
+                &mut context,
+                outgoing_viewer_keys.ovpk_m,
+                owner_keys.ivpk_m,
+                owner
+            )
+        );
     }
 
     // Nested/inner function to create and insert a note
@@ -100,13 +116,21 @@ contract PendingNoteHashes {
     ) {
         let mut owner_balance = storage.balances.at(owner);
 
-        let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
+        let owner_keys = get_public_keys(owner);
+        let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
 
-        let mut note = ValueNote::new(amount, owner_npk_m_hash);
+        let mut note = ValueNote::new(amount, owner_keys.npk_m.hash());
         note.randomness = 2;
 
         // Insert note
-        owner_balance.insert(&mut note).emit(encode_and_encrypt_note(&mut context, outgoing_viewer, owner));
+        owner_balance.insert(&mut note).emit(
+            encode_and_encrypt_note(
+                &mut context,
+                outgoing_viewer_keys.ovpk_m,
+                owner_keys.ivpk_m,
+                owner
+            )
+        );
     }
 
     // Nested/inner function to create and insert a note
@@ -115,17 +139,32 @@ contract PendingNoteHashes {
     fn insert_note_extra_emit(amount: Field, owner: AztecAddress, outgoing_viewer: AztecAddress) {
         let mut owner_balance = storage.balances.at(owner);
 
-        let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
+        let owner_keys = get_public_keys(owner);
+        let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
 
-        let mut note = ValueNote::new(amount, owner_npk_m_hash);
+        let mut note = ValueNote::new(amount, owner_keys.npk_m.hash());
 
         // Insert note
         let emission = owner_balance.insert(&mut note);
 
-        emission.emit(encode_and_encrypt_note(&mut context, outgoing_viewer, owner));
+        emission.emit(
+            encode_and_encrypt_note(
+                &mut context,
+                outgoing_viewer_keys.ovpk_m,
+                owner_keys.ivpk_m,
+                owner
+            )
+        );
 
         // Emit note again
-        emission.emit(encode_and_encrypt_note(&mut context, outgoing_viewer, owner));
+        emission.emit(
+            encode_and_encrypt_note(
+                &mut context,
+                outgoing_viewer_keys.ovpk_m,
+                owner_keys.ivpk_m,
+                owner
+            )
+        );
     }
 
     // Nested/inner function to get a note and confirm it matches the expected value
@@ -335,12 +374,18 @@ contract PendingNoteHashes {
 
         let owner_keys = get_public_keys(owner);
         let owner_npk_m_hash = owner_keys.npk_m.hash();
-        let owner_ivpk_m = owner_keys.ivpk_m;
-        let outgoing_viewer_ovpk_m = get_public_keys(outgoing_viewer).ovpk_m;
+        let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
 
         let mut good_note = ValueNote::new(10, owner_npk_m_hash);
         // Insert good note with real log
-        owner_balance.insert(&mut good_note).emit(encode_and_encrypt_note(&mut context, outgoing_viewer, owner));
+        owner_balance.insert(&mut good_note).emit(
+            encode_and_encrypt_note(
+                &mut context,
+                outgoing_viewer_keys.ovpk_m,
+                owner_keys.ivpk_m,
+                owner
+            )
+        );
 
         // We will emit a note log with an incorrect preimage to ensure the pxe throws
         // This note has not been inserted...
@@ -349,7 +394,14 @@ contract PendingNoteHashes {
         let existing_note_header = good_note.get_header();
         bad_note.set_header(existing_note_header);
 
-        NoteEmission::new(bad_note).emit(encode_and_encrypt_note_with_keys(&mut context, outgoing_viewer_ovpk_m, owner_ivpk_m, owner));
+        NoteEmission::new(bad_note).emit(
+            encode_and_encrypt_note(
+                &mut context,
+                outgoing_viewer_keys.ovpk_m,
+                owner_keys.ivpk_m,
+                owner
+            )
+        );
     }
 
     #[contract_library_method]
@@ -368,7 +420,7 @@ contract PendingNoteHashes {
 
         for i in 0..max_notes_per_call() {
             let mut note = ValueNote::new(i as Field, owner_npk_m_hash);
-            owner_balance.insert(&mut note).emit(encode_and_encrypt_note_with_keys(context, outgoing_viewer_ovpk_m, owner_ivpk_m, owner));
+            owner_balance.insert(&mut note).emit(encode_and_encrypt_note(context, outgoing_viewer_ovpk_m, owner_ivpk_m, owner));
         }
     }
 

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -9,7 +9,7 @@ contract SchnorrAccount {
     use dep::std;
 
     use dep::aztec::prelude::{AztecAddress, PrivateContext, PrivateImmutable};
-    use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note_with_keys;
+    use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note;
     use dep::authwit::{
         entrypoint::{app::AppPayload, fee::FeePayload}, account::AccountActions,
         auth_witness::get_auth_witness, auth::{compute_authwit_nullifier, compute_authwit_message_hash}
@@ -36,7 +36,7 @@ contract SchnorrAccount {
         // important.
 
         let mut pub_key_note = PublicKeyNote::new(signing_pub_key_x, signing_pub_key_y, this_keys.npk_m.hash());
-        storage.signing_public_key.initialize(&mut pub_key_note).emit(encode_and_encrypt_note_with_keys(&mut context, this_keys.ovpk_m, this_keys.ivpk_m, this));
+        storage.signing_public_key.initialize(&mut pub_key_note).emit(encode_and_encrypt_note(&mut context, this_keys.ovpk_m, this_keys.ivpk_m, this));
     }
 
     // Note: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts file

--- a/noir-projects/noir-contracts/contracts/spam_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/spam_contract/src/main.nr
@@ -8,7 +8,7 @@ contract Spam {
 
     use dep::aztec::{
         prelude::{Map, AztecAddress, PublicMutable},
-        encrypted_logs::{encrypted_note_emission::encode_and_encrypt_note_with_keys_unconstrained},
+        encrypted_logs::{encrypted_note_emission::encode_and_encrypt_note_unconstrained},
         keys::getters::get_public_keys,
         protocol_types::{
         hash::poseidon2_hash_with_separator,
@@ -36,7 +36,7 @@ contract Spam {
 
         for _ in 0..MAX_NOTE_HASHES_PER_CALL {
             storage.balances.at(caller).add(caller_keys.npk_m, U128::from_integer(amount)).emit(
-                encode_and_encrypt_note_with_keys_unconstrained(&mut context, caller_keys.ovpk_m, caller_keys.ivpk_m, caller)
+                encode_and_encrypt_note_unconstrained(&mut context, caller_keys.ovpk_m, caller_keys.ivpk_m, caller)
             );
         }
 

--- a/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
@@ -44,9 +44,12 @@ contract StaticChild {
     #[private]
     #[view]
     fn private_illegal_set_value(new_value: Field, owner: AztecAddress) -> Field {
-        let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
-        let mut note = ValueNote::new(new_value, owner_npk_m_hash);
-        storage.a_private_value.insert(&mut note).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), owner));
+        let msg_sender_keys = get_public_keys(context.msg_sender());
+        let owner_keys = get_public_keys(owner);
+
+        let mut note = ValueNote::new(new_value, owner_keys.npk_m.hash());
+
+        storage.a_private_value.insert(&mut note).emit(encode_and_encrypt_note(&mut context, msg_sender_keys.ovpk_m, owner_keys.ivpk_m, owner));
         new_value
     }
 
@@ -57,9 +60,18 @@ contract StaticChild {
         owner: AztecAddress,
         outgoing_viewer: AztecAddress
     ) -> Field {
-        let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
-        let mut note = ValueNote::new(new_value, owner_npk_m_hash);
-        storage.a_private_value.insert(&mut note).emit(encode_and_encrypt_note(&mut context, outgoing_viewer, owner));
+        let owner_keys = get_public_keys(owner);
+        let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
+
+        let mut note = ValueNote::new(new_value, owner_keys.npk_m.hash());
+        storage.a_private_value.insert(&mut note).emit(
+            encode_and_encrypt_note(
+                &mut context,
+                outgoing_viewer_keys.ovpk_m,
+                owner_keys.ivpk_m,
+                owner
+            )
+        );
         new_value
     }
 

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -102,10 +102,18 @@ contract Test {
             storage_slot != storage.example_constant.get_storage_slot(), "this storage slot is reserved for example_constant"
         );
 
-        let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
+        let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
+        let owner_keys = get_public_keys(owner);
 
-        let mut note = ValueNote::new(value, owner_npk_m_hash);
-        create_note(&mut context, storage_slot, &mut note).emit(encode_and_encrypt_note(&mut context, outgoing_viewer, owner));
+        let mut note = ValueNote::new(value, owner_keys.npk_m.hash());
+        create_note(&mut context, storage_slot, &mut note).emit(
+            encode_and_encrypt_note(
+                &mut context,
+                outgoing_viewer_keys.ovpk_m,
+                owner_keys.ivpk_m,
+                owner
+            )
+        );
     }
 
     #[private]
@@ -312,10 +320,11 @@ contract Test {
         Test::at(context.this_address()).call_create_note(value, owner, outgoing_viewer, storage_slot).call(&mut context);
         storage_slot += 1;
 
-        let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
+        let msg_sender_keys = get_public_keys(context.msg_sender());
+        let owner_keys = get_public_keys(owner);
 
-        let mut note = ValueNote::new(value + 1, owner_npk_m_hash);
-        create_note(&mut context, storage_slot, &mut note).emit(encode_and_encrypt_note(&mut context, context.msg_sender(), owner));
+        let mut note = ValueNote::new(value + 1, owner_keys.npk_m.hash());
+        create_note(&mut context, storage_slot, &mut note).emit(encode_and_encrypt_note(&mut context, msg_sender_keys.ovpk_m, owner_keys.ivpk_m, owner));
         storage_slot += 1;
         Test::at(context.this_address()).call_create_note(value + 2, owner, outgoing_viewer, storage_slot).call(&mut context);
     }

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
@@ -18,7 +18,8 @@ contract TokenBlacklist {
         prelude::{AztecAddress, Map, NoteGetterOptions, PrivateSet, PublicMutable, SharedMutable},
         encrypted_logs::encrypted_note_emission::{encode_and_encrypt_note_unconstrained, encode_and_encrypt_note},
         utils::comparison::Comparator,
-        macros::{storage::storage, functions::{private, public, initializer, view, internal}}
+        macros::{storage::storage, functions::{private, public, initializer, view, internal}},
+        keys::getters::get_public_keys
     };
 
     use dep::authwit::{auth::{assert_current_call_valid_authwit, assert_current_call_valid_authwit_public}};
@@ -182,8 +183,9 @@ contract TokenBlacklist {
         assert(notes.len() == 1, "note not popped");
 
         // Add the token note to user's balances set
-        let caller = context.msg_sender();
-        storage.balances.add(to, U128::from_integer(amount)).emit(encode_and_encrypt_note(&mut context, caller, to));
+        let msg_sender_keys = get_public_keys(context.msg_sender());
+        let to_keys = get_public_keys(to);
+        storage.balances.add(to, U128::from_integer(amount)).emit(encode_and_encrypt_note(&mut context, msg_sender_keys.ovpk_m, to_keys.ivpk_m, to));
     }
 
     #[private]
@@ -199,7 +201,8 @@ contract TokenBlacklist {
             assert(nonce == 0, "invalid nonce");
         }
 
-        storage.balances.sub(from, U128::from_integer(amount)).emit(encode_and_encrypt_note(&mut context, from, from));
+        let from_keys = get_public_keys(from);
+        storage.balances.sub(from, U128::from_integer(amount)).emit(encode_and_encrypt_note(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from));
 
         TokenBlacklist::at(context.this_address())._increase_public_balance(to, amount).enqueue(&mut context);
     }
@@ -218,9 +221,14 @@ contract TokenBlacklist {
             assert(nonce == 0, "invalid nonce");
         }
 
+        let from_keys = get_public_keys(from);
+        let to_keys = get_public_keys(to);
+
         let amount = U128::from_integer(amount);
-        storage.balances.sub(from, amount).emit(encode_and_encrypt_note_unconstrained(&mut context, from, from));
-        storage.balances.add(to, amount).emit(encode_and_encrypt_note_unconstrained(&mut context, from, to));
+        storage.balances.sub(from, amount).emit(
+            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from)
+        );
+        storage.balances.add(to, amount).emit(encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to));
     }
 
     #[private]
@@ -234,7 +242,8 @@ contract TokenBlacklist {
             assert(nonce == 0, "invalid nonce");
         }
 
-        storage.balances.sub(from, U128::from_integer(amount)).emit(encode_and_encrypt_note(&mut context, from, from));
+        let from_keys = get_public_keys(from);
+        storage.balances.sub(from, U128::from_integer(amount)).emit(encode_and_encrypt_note(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from));
 
         TokenBlacklist::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);
     }

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -22,7 +22,7 @@ contract Token {
         context::{PrivateContext, PrivateCallInterface}, hash::compute_secret_hash,
         prelude::{NoteGetterOptions, Map, PublicMutable, SharedImmutable, PrivateSet, AztecAddress, FunctionSelector},
         encrypted_logs::{
-        encrypted_note_emission::{encode_and_encrypt_note_with_keys, encode_and_encrypt_note_with_keys_unconstrained},
+        encrypted_note_emission::{encode_and_encrypt_note, encode_and_encrypt_note_unconstrained},
         encrypted_event_emission::encode_and_encrypt_event_with_keys_unconstrained
     },
         keys::getters::get_public_keys,
@@ -208,9 +208,7 @@ contract Token {
     fn privately_mint_private_note(amount: Field) {
         let caller = context.msg_sender();
         let caller_keys = get_public_keys(caller);
-        storage.balances.at(caller).add(caller_keys.npk_m, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_with_keys(&mut context, caller_keys.ovpk_m, caller_keys.ivpk_m, caller)
-        );
+        storage.balances.at(caller).add(caller_keys.npk_m, U128::from_integer(amount)).emit(encode_and_encrypt_note(&mut context, caller_keys.ovpk_m, caller_keys.ivpk_m, caller));
         Token::at(context.this_address()).assert_minter_and_mint(context.msg_sender(), amount).enqueue(&mut context);
     }
     #[public]
@@ -289,7 +287,7 @@ contract Token {
         let from = context.msg_sender();
         let from_keys = get_public_keys(from);
         let to_keys = get_public_keys(to);
-        storage.balances.at(to).add(to_keys.npk_m, U128::from_integer(amount)).emit(encode_and_encrypt_note_with_keys(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to));
+        storage.balances.at(to).add(to_keys.npk_m, U128::from_integer(amount)).emit(encode_and_encrypt_note(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to));
     }
     // docs:end:redeem_shield
     // docs:start:unshield
@@ -302,7 +300,7 @@ contract Token {
         }
 
         let from_keys = get_public_keys(from);
-        storage.balances.at(from).sub(from_keys.npk_m, U128::from_integer(amount)).emit(encode_and_encrypt_note_with_keys(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from));
+        storage.balances.at(from).sub(from_keys.npk_m, U128::from_integer(amount)).emit(encode_and_encrypt_note(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from));
         Token::at(context.this_address())._increase_public_balance(to, amount).enqueue(&mut context);
     }
     // docs:end:unshield
@@ -329,11 +327,9 @@ contract Token {
             INITIAL_TRANSFER_CALL_MAX_NOTES
         );
         storage.balances.at(from).add(from_keys.npk_m, change).emit(
-            encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from)
+            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from)
         );
-        storage.balances.at(to).add(to_keys.npk_m, amount).emit(
-            encode_and_encrypt_note_with_keys_unconstrained(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to)
-        );
+        storage.balances.at(to).add(to_keys.npk_m, amount).emit(encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to));
         // We don't constrain encryption of the note log in `transfer` (unlike in `transfer_from`) because the transfer
         // function is only designed to be used in situations where the event is not strictly necessary (e.g. payment to
         // another person where the payment is considered to be successful when the other party successfully decrypts a
@@ -420,10 +416,10 @@ contract Token {
         let amount = U128::from_integer(amount);
         // docs:start:increase_private_balance
         // docs:start:encrypted
-        storage.balances.at(from).sub(from_keys.npk_m, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from));
+        storage.balances.at(from).sub(from_keys.npk_m, amount).emit(encode_and_encrypt_note(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from));
         // docs:end:encrypted
         // docs:end:increase_private_balance
-        storage.balances.at(to).add(to_keys.npk_m, amount).emit(encode_and_encrypt_note_with_keys(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to));
+        storage.balances.at(to).add(to_keys.npk_m, amount).emit(encode_and_encrypt_note(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to));
     }
     // docs:end:transfer_from
     // docs:start:burn
@@ -435,7 +431,7 @@ contract Token {
             assert(nonce == 0, "invalid nonce");
         }
         let from_keys = get_public_keys(from);
-        storage.balances.at(from).sub(from_keys.npk_m, U128::from_integer(amount)).emit(encode_and_encrypt_note_with_keys(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from));
+        storage.balances.at(from).sub(from_keys.npk_m, U128::from_integer(amount)).emit(encode_and_encrypt_note(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from));
         Token::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);
     }
     // docs:end:burn
@@ -485,7 +481,7 @@ contract Token {
             INITIAL_TRANSFER_CALL_MAX_NOTES
         );
         storage.balances.at(user).add(user_keys.npk_m, change).emit(
-            encode_and_encrypt_note_with_keys_unconstrained(&mut context, user_keys.ovpk_m, user_keys.ivpk_m, user)
+            encode_and_encrypt_note_unconstrained(&mut context, user_keys.ovpk_m, user_keys.ivpk_m, user)
         );
         // 4. Now we get the note hiding points.
         let mut fee_payer_point = TokenNote::hiding_point().new(


### PR DESCRIPTION
`encode_and_encrypt_note(...)` was not was not used very much as it was impractical for use when you want to produce efficient circuits (it commonly led to devs fetching the same keys twice: once for note, once inside the func). This PR nukes it and renames `encode_and_encrypt_note_with_keys` as `encode_and_encrypt_note`.
