### PR TITLE
refactor: event encryption funcs working as note ones

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
@@ -40,7 +40,9 @@ pub fn encode_and_encrypt_event<Event, let N: u32>(
     recipient: AztecAddress
 ) -> fn[(&mut PrivateContext, OvpkM, IvpkM, AztecAddress)](Event) -> () where Event: EventInterface<N> {
     | e: Event | {
-        let randomness = unsafe_rand();
+        let randomness =  unsafe {
+            unsafe_rand()
+        };
         let ovsk_app: Field = context.request_ovsk_app(ovpk.hash());
         let (encrypted_log, log_hash) = compute_raw_event_log(*context, e, randomness, ovsk_app, ovpk, ivpk, recipient);
         context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
@@ -54,8 +56,12 @@ pub fn encode_and_encrypt_event_unconstrained<Event, let N: u32>(
     recipient: AztecAddress
 ) -> fn[(&mut PrivateContext, OvpkM, IvpkM, AztecAddress)](Event) -> () where Event: EventInterface<N> {
     | e: Event | {
-        let randomness = unsafe_rand();
-        let (encrypted_log, log_hash) = compute_raw_event_log_unconstrained(*context, e, randomness, ovpk, ivpk, recipient);
+        let randomness =  unsafe {
+            unsafe_rand()
+        };
+        let (encrypted_log, log_hash) =  unsafe {
+            compute_raw_event_log_unconstrained(*context, e, randomness, ovpk, ivpk, recipient)
+        };
         context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
     }
 }
@@ -82,7 +88,23 @@ pub fn encode_and_encrypt_event_with_randomness_unconstrained<Event, let N: u32>
     recipient: AztecAddress
 ) -> fn[(&mut PrivateContext, Field, OvpkM, IvpkM, AztecAddress)](Event) -> () where Event: EventInterface<N> {
     | e: Event | {
-        let (encrypted_log, log_hash) = compute_raw_event_log_unconstrained(*context, e, randomness, ovpk, ivpk, recipient);
+        //   Having the log hash be unconstrained here is fine because the way this works is we send the log hash
+        // to the kernel, and it gets included as part of its public inputs. Then we send the tx to the sequencer,
+        // which includes the kernel proof and the log preimages. The sequencer computes the hashes of the logs
+        // and checks that they are the ones in the public inputs of the kernel, and drops the tx otherwise (proposing
+        // the block on L1 would later fail if it didn't because of txs effects hash mismatch).
+        //   So if we don't constrain the log hash, then a malicious sender can compute the correct log, submit a bad
+        // log hash to the kernel, and then submit the bad log preimage to the sequencer. All checks will pass, but
+        // the submitted log will not be the one that was computed by the app.
+        //   In the unconstrained case, we don't care about the log at all because we don't do anything with it,
+        // and because it's unconstrained: it could be anything. So if a sender chooses to broadcast the tx with a log
+        // that is different from the one that was used in the circuit, then they'll be able to, but they were already
+        // able to change the log before anyway, so the end result is the same. It's important here that we do not
+        // return the log from this function to the app, otherwise it could try to do stuff with it and then that might
+        // be wrong.
+        let (encrypted_log, log_hash) = unsafe {
+            compute_raw_event_log_unconstrained(*context, e, randomness, ovpk, ivpk, recipient)
+        };
         context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
@@ -1,156 +1,88 @@
 use crate::{
     context::PrivateContext, event::event_interface::EventInterface,
     encrypted_logs::payload::compute_encrypted_log,
-    keys::{getters::get_public_keys, public_keys::{OvpkM, IvpkM}}, oracle::unsafe_rand::unsafe_rand
+    keys::{getters::get_ovsk_app, public_keys::{OvpkM, IvpkM}}, oracle::unsafe_rand::unsafe_rand
 };
 use dep::protocol_types::{address::AztecAddress, hash::sha256_to_field};
 
-unconstrained fn compute_unconstrained<Event, let N: u32>(
-    contract_address: AztecAddress,
+fn compute_raw_event_log<Event, let N: u32>(
+    context: PrivateContext,
+    event: Event,
     randomness: Field,
     ovsk_app: Field,
     ovpk: OvpkM,
     ivpk: IvpkM,
-    recipient: AztecAddress,
-    event: Event
+    recipient: AztecAddress
 ) -> ([u8; 416 + N * 32], Field) where Event: EventInterface<N> {
-    compute(
-        contract_address,
-        randomness,
-        ovsk_app,
-        ovpk,
-        ivpk,
-        recipient,
-        event
-    )
-}
-
-fn compute<Event, let N: u32>(
-    contract_address: AztecAddress,
-    randomness: Field,
-    ovsk_app: Field,
-    ovpk: OvpkM,
-    ivpk: IvpkM,
-    recipient: AztecAddress,
-    event: Event
-) -> ([u8; 416 + N * 32], Field) where Event: EventInterface<N> {
+    let contract_address: AztecAddress = context.this_address();
     let plaintext = event.private_to_be_bytes(randomness);
     let encrypted_log: [u8; 416 + N * 32] = compute_encrypted_log(contract_address, ovsk_app, ovpk, ivpk, recipient, plaintext);
     let log_hash = sha256_to_field(encrypted_log);
     (encrypted_log, log_hash)
 }
 
-fn emit_with_keys<Event, let N: u32>(
-    context: &mut PrivateContext,
-    randomness: Field,
+unconstrained fn compute_raw_event_log_unconstrained<Event, let N: u32>(
+    context: PrivateContext,
     event: Event,
+    randomness: Field,
     ovpk: OvpkM,
     ivpk: IvpkM,
-    iv: AztecAddress,
-    inner_compute: fn(AztecAddress, Field, Field, OvpkM, IvpkM, AztecAddress, Event) -> ([u8; 416 + N * 32], Field)
-) where Event: EventInterface<N> {
-    let contract_address: AztecAddress = context.this_address();
-    let ovsk_app: Field  = context.request_ovsk_app(ovpk.hash());
-    let (encrypted_log, log_hash) = inner_compute(contract_address, randomness, ovsk_app, ovpk, ivpk, iv, event);
-    context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
+    recipient: AztecAddress
+) -> ([u8; 416 + N * 32], Field) where Event: EventInterface<N> {
+    let ovsk_app = get_ovsk_app(ovpk.hash());
+    compute_raw_event_log(context, event, randomness, ovsk_app, ovpk, ivpk, recipient)
 }
 
 pub fn encode_and_encrypt_event<Event, let N: u32>(
     context: &mut PrivateContext,
-    ov: AztecAddress,
-    iv: AztecAddress
-) -> fn[(AztecAddress, AztecAddress, &mut PrivateContext)](Event) -> () where Event: EventInterface<N> {
+    ovpk: OvpkM,
+    ivpk: IvpkM,
+    recipient: AztecAddress
+) -> fn[(&mut PrivateContext, OvpkM, IvpkM, AztecAddress)](Event) -> () where Event: EventInterface<N> {
     | e: Event | {
-        let ovpk = get_public_keys(ov).ovpk_m;
-        let ivpk = get_public_keys(iv).ivpk_m;
         let randomness = unsafe_rand();
-        emit_with_keys(context, randomness, e, ovpk, ivpk, iv, compute);
+        let ovsk_app: Field = context.request_ovsk_app(ovpk.hash());
+        let (encrypted_log, log_hash) = compute_raw_event_log(*context, e, randomness, ovsk_app, ovpk, ivpk, recipient);
+        context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
     }
 }
 
 pub fn encode_and_encrypt_event_unconstrained<Event, let N: u32>(
     context: &mut PrivateContext,
-    ov: AztecAddress,
-    iv: AztecAddress
-) -> fn[(AztecAddress, AztecAddress, &mut PrivateContext)](Event) -> () where Event: EventInterface<N> {
+    ovpk: OvpkM,
+    ivpk: IvpkM,
+    recipient: AztecAddress
+) -> fn[(&mut PrivateContext, OvpkM, IvpkM, AztecAddress)](Event) -> () where Event: EventInterface<N> {
     | e: Event | {
-        let ovpk = get_public_keys(ov).ovpk_m;
-        let ivpk = get_public_keys(iv).ivpk_m;
         let randomness = unsafe_rand();
-        emit_with_keys(context, randomness, e, ovpk, ivpk, iv, compute_unconstrained);
+        let (encrypted_log, log_hash) = compute_raw_event_log_unconstrained(*context, e, randomness, ovpk, ivpk, recipient);
+        context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
     }
 }
 
 pub fn encode_and_encrypt_event_with_randomness<Event, let N: u32>(
     context: &mut PrivateContext,
     randomness: Field,
-    ov: AztecAddress,
-    iv: AztecAddress
-) -> fn[(AztecAddress, AztecAddress, &mut PrivateContext, Field)](Event) -> () where Event: EventInterface<N> {
+    ovpk: OvpkM,
+    ivpk: IvpkM,
+    recipient: AztecAddress
+) -> fn[(&mut PrivateContext, OvpkM, Field, IvpkM, AztecAddress)](Event) -> () where Event: EventInterface<N> {
     | e: Event | {
-        let ovpk = get_public_keys(ov).ovpk_m;
-        let ivpk = get_public_keys(iv).ivpk_m;
-        emit_with_keys(context, randomness, e, ovpk, ivpk, iv, compute);
+        let ovsk_app: Field = context.request_ovsk_app(ovpk.hash());
+        let (encrypted_log, log_hash) = compute_raw_event_log(*context, e, randomness, ovsk_app, ovpk, ivpk, recipient);
+        context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
     }
 }
 
 pub fn encode_and_encrypt_event_with_randomness_unconstrained<Event, let N: u32>(
     context: &mut PrivateContext,
     randomness: Field,
-    ov: AztecAddress,
-    iv: AztecAddress
-) -> fn[(AztecAddress, AztecAddress, &mut PrivateContext, Field)](Event) -> () where Event: EventInterface<N> {
-    | e: Event | {
-        let ovpk = get_public_keys(ov).ovpk_m;
-        let ivpk = get_public_keys(iv).ivpk_m;
-        emit_with_keys(context, randomness, e, ovpk, ivpk, iv, compute_unconstrained);
-    }
-}
-
-pub fn encode_and_encrypt_event_with_keys<Event, let N: u32>(
-    context: &mut PrivateContext,
-    ovpk: OvpkM,
-    ivpk: IvpkM,
-    recipient: AztecAddress
-) -> fn[(&mut PrivateContext, OvpkM, IvpkM, AztecAddress)](Event) -> () where Event: EventInterface<N> {
-    | e: Event | {
-        let randomness = unsafe_rand();
-        emit_with_keys(context, randomness, e, ovpk, ivpk, recipient, compute);
-    }
-}
-
-pub fn encode_and_encrypt_event_with_keys_unconstrained<Event, let N: u32>(
-    context: &mut PrivateContext,
-    ovpk: OvpkM,
-    ivpk: IvpkM,
-    recipient: AztecAddress
-) -> fn[(&mut PrivateContext, OvpkM, IvpkM, AztecAddress)](Event) -> () where Event: EventInterface<N> {
-    | e: Event | {
-        let randomness = unsafe_rand();
-        emit_with_keys(context, randomness, e, ovpk, ivpk, recipient, compute_unconstrained);
-    }
-}
-
-pub fn encode_and_encrypt_event_with_keys_with_randomness<Event, let N: u32>(
-    context: &mut PrivateContext,
-    randomness: Field,
     ovpk: OvpkM,
     ivpk: IvpkM,
     recipient: AztecAddress
 ) -> fn[(&mut PrivateContext, Field, OvpkM, IvpkM, AztecAddress)](Event) -> () where Event: EventInterface<N> {
     | e: Event | {
-        emit_with_keys(context, randomness, e, ovpk, ivpk, recipient, compute);
-    }
-}
-
-pub fn encode_and_encrypt_event_with_keys_with_randomness_unconstrained<Event, let N: u32>(
-    context: &mut PrivateContext,
-    randomness: Field,
-    ovpk: OvpkM,
-    ivpk: IvpkM,
-    recipient: AztecAddress
-) -> fn[(&mut PrivateContext, Field, OvpkM, IvpkM, AztecAddress)](Event) -> () where Event: EventInterface<N> {
-    | e: Event | {
-        emit_with_keys(context, randomness, e, ovpk, ivpk, recipient, compute_unconstrained);
+        let (encrypted_log, log_hash) = compute_raw_event_log_unconstrained(*context, e, randomness, ovpk, ivpk, recipient);
+        context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
@@ -66,6 +66,9 @@ pub fn encode_and_encrypt_event_unconstrained<Event, let N: u32>(
     }
 }
 
+// This function seems to be affected by the following Noir bug:
+// https://github.com/noir-lang/noir/issues/5771
+// If you get weird behavior it might be because of it.
 pub fn encode_and_encrypt_event_with_randomness<Event, let N: u32>(
     context: &mut PrivateContext,
     randomness: Field,

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -41,6 +41,9 @@ unconstrained fn compute_raw_note_log_unconstrained<Note, let N: u32>(
     compute_raw_note_log(context, note, ovsk_app, ovpk, ivpk, recipient)
 }
 
+// This function seems to be affected by the following Noir bug:
+// https://github.com/noir-lang/noir/issues/5771
+// If you get weird behavior it might be because of it.
 pub fn encode_and_encrypt_note<Note, let N: u32>(
     context: &mut PrivateContext,
     ovpk: OvpkM,

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -11,7 +11,7 @@ contract Test {
         PrivateImmutable, PrivateSet
     };
     use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note;
-    use dep::aztec::encrypted_logs::encrypted_event_emission::encode_and_encrypt_event_with_keys_with_randomness;
+    use dep::aztec::encrypted_logs::encrypted_event_emission::encode_and_encrypt_event_with_randomness;
 
     use dep::aztec::protocol_types::{constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, traits::Serialize, point::Point, scalar::Scalar};
 
@@ -280,7 +280,7 @@ contract Test {
         let event = ExampleEvent { value0: fields[0], value1: fields[1], value2: fields[2], value3: fields[3], value4: fields[4] };
 
         event.emit(
-            encode_and_encrypt_event_with_keys_with_randomness(
+            encode_and_encrypt_event_with_randomness(
                 &mut context,
                 // testing only - a secret random value is passed in here to salt / mask the address
                 5,
@@ -298,9 +298,9 @@ contract Test {
             let otherEvent = ExampleEvent { value0: 1, value1: 2, value2: 3, value3: 4, value4: 5 };
 
             otherEvent.emit(
-                encode_and_encrypt_event_with_keys_with_randomness(
+                encode_and_encrypt_event_with_randomness(
                     &mut context,
-                    // testing only - a randomness of 0 signals the kerels to not mask the address
+                    // testing only - a randomness of 0 signals the kernels to not mask the address
                     0,
                     outgoing_viewer_ovpk_m,
                     owner_ivpk_m,

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -11,7 +11,7 @@ contract Test {
         PrivateImmutable, PrivateSet
     };
     use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note;
-    use dep::aztec::encrypted_logs::encrypted_event_emission::encode_and_encrypt_event_with_randomness;
+    use dep::aztec::encrypted_logs::encrypted_event_emission::encode_and_encrypt_event_with_randomness_unconstrained;
 
     use dep::aztec::protocol_types::{constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, traits::Serialize, point::Point, scalar::Scalar};
 
@@ -280,7 +280,7 @@ contract Test {
         let event = ExampleEvent { value0: fields[0], value1: fields[1], value2: fields[2], value3: fields[3], value4: fields[4] };
 
         event.emit(
-            encode_and_encrypt_event_with_randomness(
+            encode_and_encrypt_event_with_randomness_unconstrained(
                 &mut context,
                 // testing only - a secret random value is passed in here to salt / mask the address
                 5,
@@ -298,7 +298,7 @@ contract Test {
             let otherEvent = ExampleEvent { value0: 1, value1: 2, value2: 3, value3: 4, value4: 5 };
 
             otherEvent.emit(
-                encode_and_encrypt_event_with_randomness(
+                encode_and_encrypt_event_with_randomness_unconstrained(
                     &mut context,
                     // testing only - a randomness of 0 signals the kernels to not mask the address
                     0,

--- a/noir-projects/noir-contracts/contracts/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_log_contract/src/main.nr
@@ -5,7 +5,7 @@ contract TestLog {
     use std::meta::derive;
     use dep::aztec::prelude::PrivateSet;
     use dep::aztec::protocol_types::{scalar::Scalar, address::AztecAddress, traits::Serialize};
-    use dep::aztec::keys::public_keys::IvpkM;
+    use dep::aztec::keys::{getters::get_public_keys, public_keys::IvpkM};
     use dep::value_note::value_note::ValueNote;
     use dep::aztec::encrypted_logs::payload::compute_incoming_body_ciphertext;
     use dep::aztec::encrypted_logs::encrypted_event_emission::encode_and_encrypt_event_with_randomness;
@@ -53,12 +53,16 @@ contract TestLog {
     fn emit_encrypted_events(other: AztecAddress, randomness: [Field; 2], preimages: [Field; 4]) {
         let event0 = ExampleEvent0 { value0: preimages[0], value1: preimages[1] };
 
+        let other_keys = get_public_keys(other);
+        let msg_sender_keys = get_public_keys(context.msg_sender());
+
         event0.emit(
             encode_and_encrypt_event_with_randomness(
                 &mut context,
                 randomness[0],
                 // outgoing is set to other, incoming is set to msg sender
-                other,
+                other_keys.ovpk_m,
+                msg_sender_keys.ivpk_m,
                 context.msg_sender()
             )
         );
@@ -69,7 +73,8 @@ contract TestLog {
                 &mut context,
                 randomness[0],
                 // outgoing is set to msg sender, incoming is set to other
-                context.msg_sender(),
+                msg_sender_keys.ovpk_m,
+                other_keys.ivpk_m,
                 other
             )
         );
@@ -81,7 +86,8 @@ contract TestLog {
                 &mut context,
                 randomness[1],
                 // outgoing is set to other, incoming is set to msg sender
-                other,
+                other_keys.ovpk_m,
+                msg_sender_keys.ivpk_m,
                 context.msg_sender()
             )
         );

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -23,7 +23,7 @@ contract Token {
         prelude::{NoteGetterOptions, Map, PublicMutable, SharedImmutable, PrivateSet, AztecAddress, FunctionSelector},
         encrypted_logs::{
         encrypted_note_emission::{encode_and_encrypt_note, encode_and_encrypt_note_unconstrained},
-        encrypted_event_emission::encode_and_encrypt_event_with_keys_unconstrained
+        encrypted_event_emission::encode_and_encrypt_event_unconstrained
     },
         keys::getters::get_public_keys,
         macros::{storage::storage, events::event, functions::{initializer, private, view, public}},
@@ -334,9 +334,7 @@ contract Token {
         // function is only designed to be used in situations where the event is not strictly necessary (e.g. payment to
         // another person where the payment is considered to be successful when the other party successfully decrypts a
         // note).
-        Transfer { from, to, amount: amount.to_field() }.emit(
-            encode_and_encrypt_event_with_keys_unconstrained(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to)
-        );
+        Transfer { from, to, amount: amount.to_field() }.emit(encode_and_encrypt_event_unconstrained(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to));
     }
     // docs:end:transfer
     #[contract_library_method]


### PR DESCRIPTION
Refactored event emission code so that it works the same way as the note ones. This makes it more efficient and cleaner.
