### PR TITLE
feat: Stronger typing in L1 contracts

### DIFF
--- a/l1-contracts/foundry.toml
+++ b/l1-contracts/foundry.toml
@@ -2,7 +2,7 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-solc = "0.8.23"
+solc = "0.8.27"
 
 remappings = [
   "@oz/=lib/openzeppelin-contracts/contracts/",

--- a/l1-contracts/src/core/FeeJuicePortal.sol
+++ b/l1-contracts/src/core/FeeJuicePortal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 import {IFeeJuicePortal} from "@aztec/core/interfaces/IFeeJuicePortal.sol";

--- a/l1-contracts/src/core/Leonidas.sol
+++ b/l1-contracts/src/core/Leonidas.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {ILeonidas} from "@aztec/core/interfaces/ILeonidas.sol";
 

--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {IProofCommitmentEscrow} from "@aztec/core/interfaces/IProofCommitmentEscrow.sol";
 import {IInbox} from "@aztec/core/interfaces/messagebridge/IInbox.sol";

--- a/l1-contracts/src/core/interfaces/IFeeJuicePortal.sol
+++ b/l1-contracts/src/core/interfaces/IFeeJuicePortal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 interface IFeeJuicePortal {
   function initialize(address _registry, address _underlying, bytes32 _l2TokenAddress) external;

--- a/l1-contracts/src/core/interfaces/ILeonidas.sol
+++ b/l1-contracts/src/core/interfaces/ILeonidas.sol
@@ -2,6 +2,8 @@
 // Copyright 2024 Aztec Labs.
 pragma solidity >=0.8.27;
 
+import {Timestamp, Slot, Epoch} from "@aztec/core/libraries/TimeMath.sol";
+
 interface ILeonidas {
   // Changing depending on sybil mechanism and slashing enforcement
   function addValidator(address _validator) external;
@@ -10,24 +12,24 @@ interface ILeonidas {
   // Likely changing to optimize in Pleistarchus
   function setupEpoch() external;
   function getCurrentProposer() external view returns (address);
-  function getProposerAt(uint256 _ts) external view returns (address);
+  function getProposerAt(Timestamp _ts) external view returns (address);
 
   // Stable
-  function getCurrentEpoch() external view returns (uint256);
-  function getCurrentSlot() external view returns (uint256);
+  function getCurrentEpoch() external view returns (Epoch);
+  function getCurrentSlot() external view returns (Slot);
   function isValidator(address _validator) external view returns (bool);
   function getValidatorCount() external view returns (uint256);
   function getValidatorAt(uint256 _index) external view returns (address);
 
   // Consider removing below this point
-  function getTimestampForSlot(uint256 _slotNumber) external view returns (uint256);
+  function getTimestampForSlot(Slot _slotNumber) external view returns (Timestamp);
 
   // Likely removal of these to replace with a size and indiviual getter
   // Get the current epoch committee
   function getCurrentEpochCommittee() external view returns (address[] memory);
-  function getEpochCommittee(uint256 _epoch) external view returns (address[] memory);
+  function getEpochCommittee(Epoch _epoch) external view returns (address[] memory);
   function getValidators() external view returns (address[] memory);
 
-  function getEpochAt(uint256 _ts) external view returns (uint256);
-  function getSlotAt(uint256 _ts) external view returns (uint256);
+  function getEpochAt(Timestamp _ts) external view returns (Epoch);
+  function getSlotAt(Timestamp _ts) external view returns (Slot);
 }

--- a/l1-contracts/src/core/interfaces/ILeonidas.sol
+++ b/l1-contracts/src/core/interfaces/ILeonidas.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 interface ILeonidas {
   // Changing depending on sybil mechanism and slashing enforcement

--- a/l1-contracts/src/core/interfaces/IProofCommitmentEscrow.sol
+++ b/l1-contracts/src/core/interfaces/IProofCommitmentEscrow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {SignatureLib} from "@aztec/core/libraries/crypto/SignatureLib.sol";
 

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {IInbox} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
 import {IOutbox} from "@aztec/core/interfaces/messagebridge/IOutbox.sol";

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -8,6 +8,8 @@ import {IOutbox} from "@aztec/core/interfaces/messagebridge/IOutbox.sol";
 import {SignatureLib} from "@aztec/core/libraries/crypto/SignatureLib.sol";
 import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
 
+import {Timestamp, Slot, Epoch} from "@aztec/core/libraries/TimeMath.sol";
+
 interface ITestRollup {
   function setVerifier(address _verifier) external;
   function setVkTreeRoot(bytes32 _vkTreeRoot) external;
@@ -19,11 +21,11 @@ interface IRollup {
   event L2ProofVerified(uint256 indexed blockNumber, bytes32 indexed proverId);
   event PrunedPending(uint256 provenBlockNumber, uint256 pendingBlockNumber);
   event ProofRightClaimed(
-    uint256 indexed epoch,
+    Epoch indexed epoch,
     address indexed bondProvider,
     address indexed proposer,
     uint256 bondAmount,
-    uint256 currentSlot
+    Slot currentSlot
   );
 
   function prune() external;
@@ -55,13 +57,13 @@ interface IRollup {
     bytes calldata _proof
   ) external;
 
-  function canProposeAtTime(uint256 _ts, bytes32 _archive) external view returns (uint256, uint256);
+  function canProposeAtTime(Timestamp _ts, bytes32 _archive) external view returns (Slot, uint256);
 
   function validateHeader(
     bytes calldata _header,
     SignatureLib.Signature[] memory _signatures,
     bytes32 _digest,
-    uint256 _currentTime,
+    Timestamp _currentTime,
     bytes32 _txsEffecstHash,
     DataStructures.ExecutionFlags memory _flags
   ) external view;
@@ -79,9 +81,9 @@ interface IRollup {
     external
     view
     returns (
-      uint256 provenBlockCount,
+      uint256 provenBlockNumber,
       bytes32 provenArchive,
-      uint256 pendingBlockCount,
+      uint256 pendingBlockNumber,
       bytes32 pendingArchive,
       bytes32 archiveOfMyBlock
     );
@@ -102,6 +104,6 @@ interface IRollup {
   function archiveAt(uint256 _blockNumber) external view returns (bytes32);
   function getProvenBlockNumber() external view returns (uint256);
   function getPendingBlockNumber() external view returns (uint256);
-  function getEpochToProve() external view returns (uint256);
+  function getEpochToProve() external view returns (Epoch);
   function computeTxsEffectsHash(bytes calldata _body) external pure returns (bytes32);
 }

--- a/l1-contracts/src/core/interfaces/IVerifier.sol
+++ b/l1-contracts/src/core/interfaces/IVerifier.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 interface IVerifier {
   function verify(bytes calldata _proof, bytes32[] calldata _publicInputs)

--- a/l1-contracts/src/core/interfaces/messagebridge/IInbox.sol
+++ b/l1-contracts/src/core/interfaces/messagebridge/IInbox.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {DataStructures} from "../../libraries/DataStructures.sol";
 

--- a/l1-contracts/src/core/interfaces/messagebridge/IOutbox.sol
+++ b/l1-contracts/src/core/interfaces/messagebridge/IOutbox.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {DataStructures} from "../../libraries/DataStructures.sol";
 

--- a/l1-contracts/src/core/interfaces/messagebridge/IRegistry.sol
+++ b/l1-contracts/src/core/interfaces/messagebridge/IRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {DataStructures} from "../../libraries/DataStructures.sol";
 import {IRollup} from "../IRollup.sol";

--- a/l1-contracts/src/core/libraries/ConstantsGen.sol
+++ b/l1-contracts/src/core/libraries/ConstantsGen.sol
@@ -1,7 +1,7 @@
 // GENERATED FILE - DO NOT EDIT, RUN yarn remake-constants in circuits.js
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 /**
  * @title Constants Library

--- a/l1-contracts/src/core/libraries/DataStructures.sol
+++ b/l1-contracts/src/core/libraries/DataStructures.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {SignatureLib} from "@aztec/core/libraries/crypto/SignatureLib.sol";
 

--- a/l1-contracts/src/core/libraries/DataStructures.sol
+++ b/l1-contracts/src/core/libraries/DataStructures.sol
@@ -4,6 +4,8 @@ pragma solidity >=0.8.27;
 
 import {SignatureLib} from "@aztec/core/libraries/crypto/SignatureLib.sol";
 
+import {Slot, Epoch} from "@aztec/core/libraries/TimeMath.sol";
+
 /**
  * @title Data Structures Library
  * @author Aztec Labs
@@ -96,8 +98,8 @@ library DataStructures {
    * @param basisPointFee - The fee measured in basis points
    */
   struct EpochProofQuote {
-    uint256 epochToProve;
-    uint256 validUntilSlot;
+    Epoch epochToProve;
+    Slot validUntilSlot;
     uint256 bondAmount;
     address prover;
     uint32 basisPointFee;
@@ -122,7 +124,7 @@ library DataStructures {
    * @param proposerClaimant - the address of the proposer that submitted the claim
    */
   struct EpochProofClaim {
-    uint256 epochToProve;
+    Epoch epochToProve;
     uint256 basisPointFee;
     uint256 bondAmount;
     address bondProvider;

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 /**
  * @title Errors Library

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -2,6 +2,8 @@
 // Copyright 2023 Aztec Labs.
 pragma solidity >=0.8.27;
 
+import {Timestamp, Slot, Epoch} from "@aztec/core/libraries/TimeMath.sol";
+
 /**
  * @title Errors Library
  * @author Aztec Labs
@@ -49,24 +51,23 @@ library Errors {
   error Rollup__InvalidBlockHash(bytes32 expected, bytes32 actual);
   error Rollup__InvalidBlockNumber(uint256 expected, uint256 actual); // 0xe5edf847
   error Rollup__InvalidChainId(uint256 expected, uint256 actual); // 0x37b5bc12
-  error Rollup__InvalidEpoch(uint256 expected, uint256 actual); // 0x3c6d65e6
+  error Rollup__InvalidEpoch(Epoch expected, Epoch actual); // 0x3c6d65e6
   error Rollup__InvalidInHash(bytes32 expected, bytes32 actual); // 0xcd6f4233
   error Rollup__InvalidPreviousArchive(bytes32 expected, bytes32 actual); // 0xb682a40e
   error Rollup__InvalidPreviousBlockHash(bytes32 expected, bytes32 actual);
   error Rollup__InvalidProof(); // 0xa5b2ba17
   error Rollup__InvalidProposedArchive(bytes32 expected, bytes32 actual); // 0x32532e73
-  error Rollup__InvalidTimestamp(uint256 expected, uint256 actual); // 0x3132e895
+  error Rollup__InvalidTimestamp(Timestamp expected, Timestamp actual); // 0x3132e895
   error Rollup__InvalidVersion(uint256 expected, uint256 actual); // 0x9ef30794
   error Rollup__NoEpochToProve(); // 0xcbaa3951
   error Rollup__NonSequentialProving(); // 0x1e5be132
-  error Rollup__NotClaimingCorrectEpoch(uint256 expected, uint256 actual); // 0xf0e0744d
+  error Rollup__NotClaimingCorrectEpoch(Epoch expected, Epoch actual); // 0xf0e0744d
   error Rollup__NothingToPrune(); // 0x850defd3
   error Rollup__NotInClaimPhase(uint256 currentSlotInEpoch, uint256 claimDuration); // 0xe6969f11
   error Rollup__ProofRightAlreadyClaimed(); // 0x2cac5f0a
-  error Rollup__QuoteExpired(uint256 currentSlot, uint256 quoteSlot); // 0x20a001eb
-  error Rollup__SlotAlreadyInChain(uint256 lastSlot, uint256 proposedSlot); // 0x83510bd0
-  error Rollup__SlotValueTooLarge(uint256 slot); // 0x7234f4fe
-  error Rollup__TimestampInFuture(uint256 max, uint256 actual); // 0x89f30690
+  error Rollup__QuoteExpired(Slot currentSlot, Slot quoteSlot); // 0x20a001eb
+  error Rollup__SlotAlreadyInChain(Slot lastSlot, Slot proposedSlot); // 0x83510bd0
+  error Rollup__TimestampInFuture(Timestamp max, Timestamp actual); // 0x89f30690
   error Rollup__TimestampTooOld(); // 0x72ed9c81
   error Rollup__TryingToProveNonExistingBlock(); // 0x34ef4954
   error Rollup__UnavailableTxs(bytes32 txsHash); // 0x414906c3
@@ -81,7 +82,7 @@ library Errors {
 
   // HeaderLib
   error HeaderLib__InvalidHeaderSize(uint256 expected, uint256 actual); // 0xf3ccb247
-  error HeaderLib__InvalidSlotNumber(uint256 expected, uint256 actual); // 0x09ba91ff
+  error HeaderLib__InvalidSlotNumber(Slot expected, Slot actual); // 0x09ba91ff
 
   // MerkleLib
   error MerkleLib__InvalidRoot(bytes32 expected, bytes32 actual, bytes32 leaf, uint256 leafIndex); // 0x5f216bf1

--- a/l1-contracts/src/core/libraries/HeaderLib.sol
+++ b/l1-contracts/src/core/libraries/HeaderLib.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";

--- a/l1-contracts/src/core/libraries/TimeMath.sol
+++ b/l1-contracts/src/core/libraries/TimeMath.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.19;
+
+import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
+
+type Timestamp is uint256;
+
+type Slot is uint256;
+
+type Epoch is uint256;
+
+library SlotLib {
+  function toTimestamp(Slot a) internal pure returns (Timestamp) {
+    return Timestamp.wrap(Slot.unwrap(a) * Constants.AZTEC_SLOT_DURATION);
+  }
+
+  function fromTimestamp(Timestamp a) internal pure returns (Slot) {
+    return Slot.wrap(Timestamp.unwrap(a) / Constants.AZTEC_SLOT_DURATION);
+  }
+
+  function positionInEpoch(Slot a) internal pure returns (uint256) {
+    return Slot.unwrap(a) % Constants.AZTEC_EPOCH_DURATION;
+  }
+
+  function unwrap(Slot a) internal pure returns (uint256) {
+    return Slot.unwrap(a);
+  }
+}
+
+library EpochLib {
+  function toSlots(Epoch a) internal pure returns (Slot) {
+    return Slot.wrap(Epoch.unwrap(a) * Constants.AZTEC_EPOCH_DURATION);
+  }
+
+  function toTimestamp(Epoch a) internal pure returns (Timestamp) {
+    return SlotLib.toTimestamp(toSlots(a));
+  }
+
+  function fromTimestamp(Timestamp a) internal pure returns (Epoch) {
+    return Epoch.wrap(
+      Timestamp.unwrap(a) / (Constants.AZTEC_EPOCH_DURATION * Constants.AZTEC_SLOT_DURATION)
+    );
+  }
+
+  function unwrap(Epoch a) internal pure returns (uint256) {
+    return Epoch.unwrap(a);
+  }
+}
+
+using SlotLib for Slot;
+using EpochLib for Epoch;
+
+function addTimestamp(Timestamp a, Timestamp b) pure returns (Timestamp) {
+  return Timestamp.wrap(Timestamp.unwrap(a) + Timestamp.unwrap(b));
+}
+
+function subTimestamp(Timestamp a, Timestamp b) pure returns (Timestamp) {
+  return Timestamp.wrap(Timestamp.unwrap(a) - Timestamp.unwrap(b));
+}
+
+function ltTimestamp(Timestamp a, Timestamp b) pure returns (bool) {
+  return Timestamp.unwrap(a) < Timestamp.unwrap(b);
+}
+
+function gtTimestamp(Timestamp a, Timestamp b) pure returns (bool) {
+  return Timestamp.unwrap(a) > Timestamp.unwrap(b);
+}
+
+function neqTimestamp(Timestamp a, Timestamp b) pure returns (bool) {
+  return Timestamp.unwrap(a) != Timestamp.unwrap(b);
+}
+
+// Slot
+
+function addSlot(Slot a, Slot b) pure returns (Slot) {
+  return Slot.wrap(Slot.unwrap(a) + Slot.unwrap(b));
+}
+
+function eqSlot(Slot a, Slot b) pure returns (bool) {
+  return Slot.unwrap(a) == Slot.unwrap(b);
+}
+
+function neqSlot(Slot a, Slot b) pure returns (bool) {
+  return Slot.unwrap(a) != Slot.unwrap(b);
+}
+
+function ltSlot(Slot a, Slot b) pure returns (bool) {
+  return Slot.unwrap(a) < Slot.unwrap(b);
+}
+
+function lteSlot(Slot a, Slot b) pure returns (bool) {
+  return Slot.unwrap(a) <= Slot.unwrap(b);
+}
+
+// Epoch
+
+function eqEpoch(Epoch a, Epoch b) pure returns (bool) {
+  return Epoch.unwrap(a) == Epoch.unwrap(b);
+}
+
+function neqEpoch(Epoch a, Epoch b) pure returns (bool) {
+  return Epoch.unwrap(a) != Epoch.unwrap(b);
+}
+
+function subEpoch(Epoch a, Epoch b) pure returns (Epoch) {
+  return Epoch.wrap(Epoch.unwrap(a) - Epoch.unwrap(b));
+}
+
+function addEpoch(Epoch a, Epoch b) pure returns (Epoch) {
+  return Epoch.wrap(Epoch.unwrap(a) + Epoch.unwrap(b));
+}
+
+using {
+  addTimestamp as +,
+  subTimestamp as -,
+  ltTimestamp as <,
+  gtTimestamp as >,
+  neqTimestamp as !=
+} for Timestamp global;
+
+using {addEpoch as +, subEpoch as -, eqEpoch as ==, neqEpoch as !=} for Epoch global;
+
+using {eqSlot as ==, neqSlot as !=, lteSlot as <=, ltSlot as <, addSlot as +} for Slot global;

--- a/l1-contracts/src/core/libraries/TxsDecoder.sol
+++ b/l1-contracts/src/core/libraries/TxsDecoder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";

--- a/l1-contracts/src/core/libraries/crypto/FrontierLib.sol
+++ b/l1-contracts/src/core/libraries/crypto/FrontierLib.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Hash} from "@aztec/core/libraries/crypto/Hash.sol";
 

--- a/l1-contracts/src/core/libraries/crypto/Hash.sol
+++ b/l1-contracts/src/core/libraries/crypto/Hash.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
 

--- a/l1-contracts/src/core/libraries/crypto/MerkleLib.sol
+++ b/l1-contracts/src/core/libraries/crypto/MerkleLib.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Errors} from "@aztec/core/libraries/Errors.sol";
 import {Hash} from "@aztec/core/libraries/crypto/Hash.sol";

--- a/l1-contracts/src/core/libraries/crypto/SampleLib.sol
+++ b/l1-contracts/src/core/libraries/crypto/SampleLib.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Errors} from "@aztec/core/libraries/Errors.sol";
 

--- a/l1-contracts/src/core/messagebridge/Inbox.sol
+++ b/l1-contracts/src/core/messagebridge/Inbox.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {IInbox} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
 

--- a/l1-contracts/src/core/messagebridge/Outbox.sol
+++ b/l1-contracts/src/core/messagebridge/Outbox.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {IOutbox} from "@aztec/core//interfaces/messagebridge/IOutbox.sol";
 

--- a/l1-contracts/src/core/messagebridge/Registry.sol
+++ b/l1-contracts/src/core/messagebridge/Registry.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {IRegistry} from "@aztec/core/interfaces/messagebridge/IRegistry.sol";
 import {IRollup} from "@aztec/core/interfaces/IRollup.sol";

--- a/l1-contracts/src/mock/MockProofCommitmentEscrow.sol
+++ b/l1-contracts/src/mock/MockProofCommitmentEscrow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {IProofCommitmentEscrow} from "@aztec/core/interfaces/IProofCommitmentEscrow.sol";
 

--- a/l1-contracts/src/mock/MockVerifier.sol
+++ b/l1-contracts/src/mock/MockVerifier.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 // Interfaces
 import {IVerifier} from "@aztec/core/interfaces/IVerifier.sol";

--- a/l1-contracts/test/Inbox.t.sol
+++ b/l1-contracts/test/Inbox.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/l1-contracts/test/Outbox.t.sol
+++ b/l1-contracts/test/Outbox.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";

--- a/l1-contracts/test/Parity.t.sol
+++ b/l1-contracts/test/Parity.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/l1-contracts/test/Registry.t.sol
+++ b/l1-contracts/test/Registry.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Ownable} from "@oz/access/Ownable.sol";

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -24,6 +24,8 @@ import {PortalERC20} from "./portals/PortalERC20.sol";
 import {TxsDecoderHelper} from "./decoders/helpers/TxsDecoderHelper.sol";
 import {IERC20Errors} from "@oz/interfaces/draft-IERC6093.sol";
 
+import {Timestamp, Slot, Epoch, SlotLib, EpochLib} from "@aztec/core/libraries/TimeMath.sol";
+
 // solhint-disable comprehensive-interface
 
 /**
@@ -31,6 +33,9 @@ import {IERC20Errors} from "@oz/interfaces/draft-IERC6093.sol";
  * Main use of these test is shorter cycles when updating the decoder contract.
  */
 contract RollupTest is DecoderBase {
+  using SlotLib for Slot;
+  using EpochLib for Epoch;
+
   Registry internal registry;
   Inbox internal inbox;
   Outbox internal outbox;
@@ -81,8 +86,8 @@ contract RollupTest is DecoderBase {
 
     quote = DataStructures.SignedEpochProofQuote({
       quote: DataStructures.EpochProofQuote({
-        epochToProve: 0,
-        validUntilSlot: 1,
+        epochToProve: Epoch.wrap(0),
+        validUntilSlot: Slot.wrap(1),
         bondAmount: rollup.PROOF_COMMITMENT_MIN_BOND_AMOUNT_IN_TST(),
         prover: address(0),
         basisPointFee: 0
@@ -93,7 +98,7 @@ contract RollupTest is DecoderBase {
   }
 
   function warpToL2Slot(uint256 _slot) public {
-    vm.warp(rollup.getTimestampForSlot(_slot));
+    vm.warp(Timestamp.unwrap(rollup.getTimestampForSlot(Slot.wrap(_slot))));
   }
 
   function testClaimWithNothingToProve() public setUpFor("mixed_block_1") {
@@ -115,7 +120,7 @@ contract RollupTest is DecoderBase {
   function testClaimWithWrongEpoch() public setUpFor("mixed_block_1") {
     _testBlock("mixed_block_1", false, 1);
 
-    quote.quote.epochToProve = 1;
+    quote.quote.epochToProve = Epoch.wrap(1);
 
     vm.expectRevert(
       abi.encodeWithSelector(
@@ -143,7 +148,7 @@ contract RollupTest is DecoderBase {
   function testClaimPastValidUntil() public setUpFor("mixed_block_1") {
     _testBlock("mixed_block_1", false, 1);
 
-    quote.quote.validUntilSlot = 0;
+    quote.quote.validUntilSlot = Slot.wrap(0);
 
     vm.expectRevert(
       abi.encodeWithSelector(Errors.Rollup__QuoteExpired.selector, 1, quote.quote.validUntilSlot)
@@ -156,12 +161,12 @@ contract RollupTest is DecoderBase {
 
     vm.expectEmit(true, true, true, true);
     emit IRollup.ProofRightClaimed(
-      quote.quote.epochToProve, address(0), address(this), quote.quote.bondAmount, 1
+      quote.quote.epochToProve, address(0), address(this), quote.quote.bondAmount, Slot.wrap(1)
     );
     rollup.claimEpochProofRight(quote);
 
     (
-      uint256 epochToProve,
+      Epoch epochToProve,
       uint256 basisPointFee,
       uint256 bondAmount,
       address bondProvider,
@@ -219,7 +224,7 @@ contract RollupTest is DecoderBase {
   function testNoPruneWhenClaimExists() public setUpFor("mixed_block_1") {
     _testBlock("mixed_block_1", false, 1);
 
-    quote.quote.validUntilSlot = 2 * Constants.AZTEC_EPOCH_DURATION;
+    quote.quote.validUntilSlot = Epoch.wrap(2).toSlots();
 
     warpToL2Slot(Constants.AZTEC_EPOCH_DURATION + rollup.CLAIM_DURATION_IN_L2_SLOTS() - 1);
 
@@ -234,7 +239,7 @@ contract RollupTest is DecoderBase {
   function testPruneWhenClaimExpires() public setUpFor("mixed_block_1") {
     _testBlock("mixed_block_1", false, 1);
 
-    quote.quote.validUntilSlot = 2 * Constants.AZTEC_EPOCH_DURATION;
+    quote.quote.validUntilSlot = Epoch.wrap(2).toSlots();
 
     warpToL2Slot(Constants.AZTEC_EPOCH_DURATION + rollup.CLAIM_DURATION_IN_L2_SLOTS() - 1);
 
@@ -255,7 +260,7 @@ contract RollupTest is DecoderBase {
   function testClaimAfterPrune() public setUpFor("mixed_block_1") {
     _testBlock("mixed_block_1", false, 1);
 
-    quote.quote.validUntilSlot = 3 * Constants.AZTEC_EPOCH_DURATION;
+    quote.quote.validUntilSlot = Epoch.wrap(3).toSlots();
     quote.quote.prover = address(this);
 
     warpToL2Slot(Constants.AZTEC_EPOCH_DURATION + rollup.CLAIM_DURATION_IN_L2_SLOTS() - 1);
@@ -266,9 +271,8 @@ contract RollupTest is DecoderBase {
 
     rollup.prune();
 
-    _testBlock("mixed_block_1", false, Constants.AZTEC_EPOCH_DURATION * 3);
-
-    quote.quote.epochToProve = 3;
+    _testBlock("mixed_block_1", false, Epoch.wrap(3).toSlots().unwrap());
+    quote.quote.epochToProve = Epoch.wrap(3);
 
     vm.expectEmit(true, true, true, true);
     emit IRollup.ProofRightClaimed(
@@ -276,7 +280,7 @@ contract RollupTest is DecoderBase {
       address(this),
       address(this),
       quote.quote.bondAmount,
-      Constants.AZTEC_EPOCH_DURATION * 3
+      Epoch.wrap(3).toSlots()
     );
     rollup.claimEpochProofRight(quote);
   }
@@ -317,8 +321,8 @@ contract RollupTest is DecoderBase {
   function testTimestamp() public setUpFor("mixed_block_1") {
     // Ensure that the timestamp of the current slot is never in the future.
     for (uint256 i = 0; i < 100; i++) {
-      uint256 slot = rollup.getCurrentSlot();
-      uint256 ts = rollup.getTimestampForSlot(slot);
+      Slot slot = rollup.getCurrentSlot();
+      Timestamp ts = rollup.getTimestampForSlot(slot);
 
       assertLe(ts, block.timestamp, "Invalid timestamp");
 
@@ -346,11 +350,11 @@ contract RollupTest is DecoderBase {
     //        Even if we end up reverting block 1, we should still see the same root in the inbox.
     bytes32 inboxRoot2 = inbox.getRoot(2);
 
-    (,, uint128 slot) = rollup.blocks(1);
-    uint256 prunableAt = uint256(slot) + Constants.AZTEC_EPOCH_DURATION * 2;
+    (,, Slot slot) = rollup.blocks(1);
+    Slot prunableAt = slot + Epoch.wrap(2).toSlots();
 
-    uint256 timeOfPrune = rollup.getTimestampForSlot(prunableAt);
-    vm.warp(timeOfPrune);
+    Timestamp timeOfPrune = rollup.getTimestampForSlot(prunableAt);
+    vm.warp(Timestamp.unwrap(timeOfPrune));
 
     assertEq(rollup.getPendingBlockNumber(), 1, "Invalid pending block number");
     assertEq(rollup.getProvenBlockNumber(), 0, "Invalid proven block number");
@@ -376,7 +380,7 @@ contract RollupTest is DecoderBase {
     //        and timestamp as if it was created at a different point in time. This allow us to insert it
     //        as if it was the first block, even after we had originally inserted the mixed block.
     //        An example where this could happen would be if no-one could prove the mixed block.
-    _testBlock("empty_block_1", false, prunableAt);
+    _testBlock("empty_block_1", false, prunableAt.unwrap());
 
     assertEq(inbox.inProgress(), 3, "Invalid in progress");
     assertEq(inbox.getRoot(2), inboxRoot2, "Invalid inbox root");
@@ -415,7 +419,7 @@ contract RollupTest is DecoderBase {
     _testBlock("mixed_block_1", false, 1);
     assertEq(rollup.getEpochToProve(), 0, "Invalid epoch to prove");
     warpToL2Slot(Constants.AZTEC_EPOCH_DURATION * 2);
-    _testBlock("mixed_block_1", false, Constants.AZTEC_EPOCH_DURATION * 2);
+    _testBlock("mixed_block_1", false, Epoch.wrap(2).toSlots().unwrap());
 
     assertEq(rollup.getPendingBlockNumber(), 1, "Invalid pending block number");
     assertEq(rollup.getProvenBlockNumber(), 0, "Invalid proven block number");
@@ -713,14 +717,16 @@ contract RollupTest is DecoderBase {
     uint32 numTxs = full.block.numTxs;
     bytes32[] memory txHashes = new bytes32[](0);
 
-    // Overwrite some timestamps if needed
-    if (_slotNumber != 0) {
-      uint256 ts = rollup.getTimestampForSlot(_slotNumber);
+    Slot slotNumber = Slot.wrap(_slotNumber);
 
-      full.block.decodedHeader.globalVariables.timestamp = ts;
-      full.block.decodedHeader.globalVariables.slotNumber = _slotNumber;
+    // Overwrite some timestamps if needed
+    if (slotNumber != Slot.wrap(0)) {
+      Timestamp ts = rollup.getTimestampForSlot(slotNumber);
+
+      full.block.decodedHeader.globalVariables.timestamp = Timestamp.unwrap(ts);
+      full.block.decodedHeader.globalVariables.slotNumber = Slot.unwrap(slotNumber);
       assembly {
-        mstore(add(header, add(0x20, 0x0194)), _slotNumber)
+        mstore(add(header, add(0x20, 0x0194)), slotNumber)
         mstore(add(header, add(0x20, 0x01b4)), ts)
       }
     }

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {DecoderBase} from "./decoders/Base.sol";
 

--- a/l1-contracts/test/decoders/Base.sol
+++ b/l1-contracts/test/decoders/Base.sol
@@ -4,11 +4,16 @@ pragma solidity >=0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 
+import {Timestamp, Slot, Epoch, SlotLib, EpochLib} from "@aztec/core/libraries/TimeMath.sol";
+
 // Many of the structs in here match what you see in `header` but with very important exceptions!
 // The order of variables is sorted alphabetically in the structs in here to work with the
 // JSON cheatcodes.
 
 contract DecoderBase is Test {
+  using SlotLib for Slot;
+  using EpochLib for Epoch;
+
   struct AppendOnlyTreeSnapshot {
     uint32 nextAvailableLeafIndex;
     bytes32 root;
@@ -97,5 +102,139 @@ contract DecoderBase is Test {
 
   function max(uint256 a, uint256 b) internal pure returns (uint256) {
     return a > b ? a : b;
+  }
+
+  // timestamps
+
+  function assertLe(Timestamp a, Timestamp b) internal {
+    if (a > b) {
+      emit log("Error: a <= b not satisfied [Timestamp]");
+      emit log_named_uint("      Left", Timestamp.unwrap(a));
+      emit log_named_uint("     Right", Timestamp.unwrap(b));
+      fail();
+    }
+  }
+
+  function assertLe(Timestamp a, uint256 b) internal {
+    if (a > Timestamp.wrap(b)) {
+      emit log("Error: a <= b not satisfied [Timestamp]");
+      emit log_named_uint("      Left", Timestamp.unwrap(a));
+      emit log_named_uint("     Right", b);
+      fail();
+    }
+  }
+
+  function assertLe(Timestamp a, Timestamp b, string memory err) internal {
+    if (a > b) {
+      emit log_named_string("Error", err);
+      assertEq(a, b);
+    }
+  }
+
+  function assertLe(Timestamp a, uint256 b, string memory err) internal {
+    if (a > Timestamp.wrap(b)) {
+      emit log_named_string("Error", err);
+      assertEq(a, b);
+    }
+  }
+
+  function assertEq(Timestamp a, Timestamp b) internal {
+    if (a != b) {
+      emit log("Error: a == b not satisfied [Timestamp]");
+      emit log_named_uint("      Left", Timestamp.unwrap(a));
+      emit log_named_uint("     Right", Timestamp.unwrap(b));
+      fail();
+    }
+  }
+
+  function assertEq(Timestamp a, uint256 b) internal {
+    if (a != Timestamp.wrap(b)) {
+      emit log("Error: a == b not satisfied [Timestamp]");
+      emit log_named_uint("      Left", Timestamp.unwrap(a));
+      emit log_named_uint("     Right", b);
+      fail();
+    }
+  }
+
+  function assertEq(Timestamp a, Timestamp b, string memory err) internal {
+    if (a != b) {
+      emit log_named_string("Error", err);
+      assertEq(a, b);
+    }
+  }
+
+  function assertEq(Timestamp a, uint256 b, string memory err) internal {
+    if (a != Timestamp.wrap(b)) {
+      emit log_named_string("Error", err);
+      assertEq(a, b);
+    }
+  }
+
+  // Slots
+
+  function assertEq(Slot a, Slot b) internal {
+    if (a != b) {
+      emit log("Error: a == b not satisfied [Slot]");
+      emit log_named_uint("      Left", a.unwrap());
+      emit log_named_uint("     Right", b.unwrap());
+      fail();
+    }
+  }
+
+  function assertEq(Slot a, uint256 b) internal {
+    if (a != Slot.wrap(b)) {
+      emit log("Error: a == b not satisfied [Slot]");
+      emit log_named_uint("      Left", a.unwrap());
+      emit log_named_uint("     Right", b);
+      fail();
+    }
+  }
+
+  function assertEq(Slot a, Slot b, string memory err) internal {
+    if (a != b) {
+      emit log_named_string("Error", err);
+      assertEq(a, b);
+    }
+  }
+
+  function assertEq(Slot a, uint256 b, string memory err) internal {
+    if (a != Slot.wrap(b)) {
+      emit log_named_string("Error", err);
+      assertEq(a, b);
+    }
+  }
+
+  // Epochs
+
+  function assertEq(Epoch a, Epoch b) internal {
+    if (a != b) {
+      emit log("Error: a == b not satisfied [Epoch]");
+      emit log_named_uint("      Left", a.unwrap());
+      emit log_named_uint("     Right", b.unwrap());
+      fail();
+    }
+  }
+
+  function assertEq(Epoch a, uint256 b) internal {
+    if (a != Epoch.wrap(b)) {
+      emit log("Error: a == b not satisfied [Epoch]");
+      emit log_named_uint("      Left", a.unwrap());
+      emit log_named_uint("     Right", b);
+      fail();
+    }
+  }
+
+  function assertEq(Epoch a, Epoch b, string memory err) internal {
+    if (a != b) {
+      emit log_named_string("Error", err);
+      assertEq(a, b);
+    }
+  }
+
+  function assertEq(Epoch a, uint256 b, string memory err) internal {
+    if (a != Epoch.wrap(b)) {
+      emit log_named_string("Error", err);
+      assertEq(a, b);
+    }
   }
 }

--- a/l1-contracts/test/decoders/Base.sol
+++ b/l1-contracts/test/decoders/Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/l1-contracts/test/decoders/Decoders.t.sol
+++ b/l1-contracts/test/decoders/Decoders.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {DecoderBase} from "./Base.sol";
 

--- a/l1-contracts/test/decoders/helpers/HeaderLibHelper.sol
+++ b/l1-contracts/test/decoders/helpers/HeaderLibHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {HeaderLib} from "@aztec/core/libraries/HeaderLib.sol";
 

--- a/l1-contracts/test/decoders/helpers/TxsDecoderHelper.sol
+++ b/l1-contracts/test/decoders/helpers/TxsDecoderHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {TxsDecoder} from "@aztec/core/libraries/TxsDecoder.sol";
 import {MerkleLib} from "@aztec/core/libraries/crypto/MerkleLib.sol";

--- a/l1-contracts/test/harnesses/Frontier.sol
+++ b/l1-contracts/test/harnesses/Frontier.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {FrontierLib} from "@aztec/core/libraries/crypto/FrontierLib.sol";
 

--- a/l1-contracts/test/harnesses/InboxHarness.sol
+++ b/l1-contracts/test/harnesses/InboxHarness.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
 

--- a/l1-contracts/test/merkle/Frontier.t.sol
+++ b/l1-contracts/test/merkle/Frontier.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/l1-contracts/test/merkle/MerkleLib.t.sol
+++ b/l1-contracts/test/merkle/MerkleLib.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/l1-contracts/test/merkle/Naive.sol
+++ b/l1-contracts/test/merkle/Naive.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Hash} from "@aztec/core/libraries/crypto/Hash.sol";
 

--- a/l1-contracts/test/merkle/Naive.t.sol
+++ b/l1-contracts/test/merkle/Naive.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/l1-contracts/test/merkle/TestUtil.sol
+++ b/l1-contracts/test/merkle/TestUtil.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/l1-contracts/test/merkle/UnbalancedMerkle.t.sol
+++ b/l1-contracts/test/merkle/UnbalancedMerkle.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Hash} from "@aztec/core/libraries/crypto/Hash.sol";

--- a/l1-contracts/test/merkle/helpers/MerkleLibHelper.sol
+++ b/l1-contracts/test/merkle/helpers/MerkleLibHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {MerkleLib} from "@aztec/core/libraries/crypto/MerkleLib.sol";
 

--- a/l1-contracts/test/portals/DataStructures.sol
+++ b/l1-contracts/test/portals/DataStructures.sol
@@ -1,7 +1,7 @@
 // docs:start:portals_data_structures
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 library DataStructures {
   struct OutboxMessageMetadata {

--- a/l1-contracts/test/portals/TokenPortal.sol
+++ b/l1-contracts/test/portals/TokenPortal.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";

--- a/l1-contracts/test/portals/TokenPortal.t.sol
+++ b/l1-contracts/test/portals/TokenPortal.t.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import "forge-std/Test.sol";
 

--- a/l1-contracts/test/portals/UniswapPortal.sol
+++ b/l1-contracts/test/portals/UniswapPortal.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 

--- a/l1-contracts/test/portals/UniswapPortal.t.sol
+++ b/l1-contracts/test/portals/UniswapPortal.t.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import "forge-std/Test.sol";
 

--- a/l1-contracts/test/sparta/Sampling.t.sol
+++ b/l1-contracts/test/sparta/Sampling.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/l1-contracts/test/sparta/Sparta.t.sol
+++ b/l1-contracts/test/sparta/Sparta.t.sol
@@ -21,6 +21,8 @@ import {TxsDecoderHelper} from "../decoders/helpers/TxsDecoderHelper.sol";
 import {IFeeJuicePortal} from "@aztec/core/interfaces/IFeeJuicePortal.sol";
 import {MessageHashUtils} from "@oz/utils/cryptography/MessageHashUtils.sol";
 
+import {Slot, Epoch, SlotLib, EpochLib} from "@aztec/core/libraries/TimeMath.sol";
+
 // solhint-disable comprehensive-interface
 
 /**
@@ -29,6 +31,8 @@ import {MessageHashUtils} from "@oz/utils/cryptography/MessageHashUtils.sol";
  */
 contract SpartaTest is DecoderBase {
   using MessageHashUtils for bytes32;
+  using SlotLib for Slot;
+  using EpochLib for Epoch;
 
   struct StructToAvoidDeepStacks {
     uint256 needed;
@@ -109,12 +113,12 @@ contract SpartaTest is DecoderBase {
   }
 
   function testProposerForNonSetupEpoch(uint8 _epochsToJump) public setup(4) {
-    uint256 pre = rollup.getCurrentEpoch();
+    Epoch pre = rollup.getCurrentEpoch();
     vm.warp(
       block.timestamp + uint256(_epochsToJump) * rollup.EPOCH_DURATION() * rollup.SLOT_DURATION()
     );
-    uint256 post = rollup.getCurrentEpoch();
-    assertEq(pre + _epochsToJump, post, "Invalid epoch");
+    Epoch post = rollup.getCurrentEpoch();
+    assertEq(pre + Epoch.wrap(_epochsToJump), post, "Invalid epoch");
 
     address expectedProposer = rollup.getCurrentProposer();
 

--- a/l1-contracts/test/sparta/Sparta.t.sol
+++ b/l1-contracts/test/sparta/Sparta.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 import {DecoderBase} from "../decoders/Base.sol";
 


### PR DESCRIPTION
Bumps the solidity version and makes use of the user defined types such that we have `Timestamp`, `Slot` and `Epoch` to make it less likely mixing up these `uint256` that have different "units".

Spurred from a timestamp issues, as a slotnumber was passed along and we should be able to make it scream earlier with this. 

Note that as the types are mostly syntactic sugar and won't make their way all the way down into the abis the errors and selectors should stay the same.