### PR TITLE
Remove quotes `$artifacts_to_transpile` in the for loop list of  `compile_then_transpile.sh`

### DIFF
--- a/avm-transpiler/scripts/compile_then_transpile.sh
+++ b/avm-transpiler/scripts/compile_then_transpile.sh
@@ -24,7 +24,8 @@ artifacts_to_transpile=$($NARGO compile --show-artifact-paths $@ | tee /dev/tty 
 # If the script is run via docker, however, the user will see this output on stdout and will be able to redirect.
 
 # Transpile each artifact
-for artifact in "$artifacts_to_transpile"; do
+# `$artifacts_to_transpile` needs to be unquoted here, otherwise it will break if there are multiple artifacts
+for artifact in $artifacts_to_transpile; do
   # transpiler input and output files are the same (modify in-place)
   $TRANSPILER "$artifact" "$artifact"
 done


### PR DESCRIPTION
This change remove quotes on `$artifacts_to_transpile` variable of the for loop list in `compile_then-transpile.sh` so it can be treated as a list instead of a single value.

When quotes are used here, transpilation of >1 artifact fails with an error like this:

```
thread 'main' panicked at src/main.rs:31:29:
Unable to read file: target/foo-Foo.json
target/bar-Bar.json
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This is because the transpiler tries to read a file named `target/foo-Foo.json\ntarget/bar-Bar.json` instead of handling `target/foo-Foo.json` and `target/bar-Bar.json` separately.