### PR TITLE
fix: Do not assume blocks as proven in e2e-prover tests

### DIFF
--- a/yarn-project/end-to-end/src/e2e_prover/e2e_prover_test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/e2e_prover_test.ts
@@ -88,7 +88,12 @@ export class FullProverTest {
 
   constructor(testName: string, private minNumberOfTxsPerBlock: number, private realProofs = true) {
     this.logger = createDebugLogger(`aztec:full_prover_test:${testName}`);
-    this.snapshotManager = createSnapshotManager(`full_prover_integration/${testName}`, dataPath);
+    this.snapshotManager = createSnapshotManager(
+      `full_prover_integration/${testName}`,
+      dataPath,
+      {},
+      { assumeProvenThrough: undefined },
+    );
   }
 
   /**


### PR DESCRIPTION
Fixes issue introduced in #8830 