### PR TITLE
refactor: use require(predicate, custom_error)

### DIFF
--- a/l1-contracts/.solhint.json
+++ b/l1-contracts/.solhint.json
@@ -1,23 +1,67 @@
 {
   "extends": "solhint:recommended",
   "rules": {
-    "compiler-version": ["error", ">=0.8.4"],
+    "compiler-version": [
+      "error",
+      ">=0.8.27"
+    ],
     "no-inline-assembly": "off",
-    "func-visibility": ["error", { "ignoreConstructors": true }],
+    "gas-custom-errors": "off",
+    "func-visibility": [
+      "error",
+      {
+        "ignoreConstructors": true
+      }
+    ],
     "no-empty-blocks": "off",
-    "no-unused-vars": ["error"],
-    "state-visibility": ["error"],
+    "no-unused-vars": [
+      "error"
+    ],
+    "state-visibility": [
+      "error"
+    ],
     "not-rely-on-time": "off",
-    "const-name-snakecase": ["error", { "treatImmutableVarAsConstant": true }],
-    "var-name-mixedcase": ["error", { "treatImmutableVarAsConstant": true }],
-    "custom-error-name-camelcase": ["error", { "allowPrefix": true }],
-    "private-func-leading-underscore": ["error"],
-    "private-vars-no-leading-underscore": ["error"],
-    "func-param-name-leading-underscore": ["error"],
-    "func-param-name-mixedcase": ["error"],
-    "strict-override": ["error"],
-    "strict-import": ["error"],
-    "ordering": ["error"],
-    "comprehensive-interface": ["error"]
+    "const-name-snakecase": [
+      "error",
+      {
+        "treatImmutableVarAsConstant": true
+      }
+    ],
+    "var-name-mixedcase": [
+      "error",
+      {
+        "treatImmutableVarAsConstant": true
+      }
+    ],
+    "custom-error-name-camelcase": [
+      "error",
+      {
+        "allowPrefix": true
+      }
+    ],
+    "private-func-leading-underscore": [
+      "error"
+    ],
+    "private-vars-no-leading-underscore": [
+      "error"
+    ],
+    "func-param-name-leading-underscore": [
+      "error"
+    ],
+    "func-param-name-mixedcase": [
+      "error"
+    ],
+    "strict-override": [
+      "error"
+    ],
+    "strict-import": [
+      "error"
+    ],
+    "ordering": [
+      "error"
+    ],
+    "comprehensive-interface": [
+      "error"
+    ]
   }
 }

--- a/l1-contracts/.solhint.json
+++ b/l1-contracts/.solhint.json
@@ -15,7 +15,6 @@
     "private-vars-no-leading-underscore": ["error"],
     "func-param-name-leading-underscore": ["error"],
     "func-param-name-mixedcase": ["error"],
-    "custom-error-over-require": ["error"],
     "strict-override": ["error"],
     "strict-import": ["error"],
     "ordering": ["error"],

--- a/l1-contracts/src/core/FeeJuicePortal.sol
+++ b/l1-contracts/src/core/FeeJuicePortal.sol
@@ -42,13 +42,14 @@ contract FeeJuicePortal is IFeeJuicePortal, Ownable {
     override(IFeeJuicePortal)
     onlyOwner
   {
-    if (address(registry) != address(0) || address(underlying) != address(0) || l2TokenAddress != 0)
-    {
-      revert Errors.FeeJuicePortal__AlreadyInitialized();
-    }
-    if (_registry == address(0) || _underlying == address(0) || _l2TokenAddress == 0) {
-      revert Errors.FeeJuicePortal__InvalidInitialization();
-    }
+    require(
+      address(registry) == address(0) && address(underlying) == address(0) && l2TokenAddress == 0,
+      Errors.FeeJuicePortal__AlreadyInitialized()
+    );
+    require(
+      _registry != address(0) && _underlying != address(0) && _l2TokenAddress != 0,
+      Errors.FeeJuicePortal__InvalidInitialization()
+    );
 
     registry = IRegistry(_registry);
     underlying = IERC20(_underlying);
@@ -100,9 +101,7 @@ contract FeeJuicePortal is IFeeJuicePortal, Ownable {
    * @param _amount - The amount to pay them
    */
   function distributeFees(address _to, uint256 _amount) external override(IFeeJuicePortal) {
-    if (msg.sender != address(registry.getRollup())) {
-      revert Errors.FeeJuicePortal__Unauthorized();
-    }
+    require(msg.sender == registry.getRollup(), Errors.FeeJuicePortal__Unauthorized());
     underlying.safeTransfer(_to, _amount);
   }
 }

--- a/l1-contracts/src/core/Leonidas.sol
+++ b/l1-contracts/src/core/Leonidas.sol
@@ -392,9 +392,7 @@ contract Leonidas is Ownable, ILeonidas {
     }
 
     // @todo We should allow to provide a signature instead of needing the proposer to broadcast.
-    if (proposer != msg.sender) {
-      revert Errors.Leonidas__InvalidProposer(proposer, msg.sender);
-    }
+    require(proposer == msg.sender, Errors.Leonidas__InvalidProposer(proposer, msg.sender));
 
     // @note  This is NOT the efficient way to do it, but it is a very convenient way for us to do it
     //        that allows us to reduce the number of code paths. Also when changed with optimistic for
@@ -407,9 +405,10 @@ contract Leonidas is Ownable, ILeonidas {
     address[] memory committee = getCommitteeAt(ts);
 
     uint256 needed = committee.length * 2 / 3 + 1;
-    if (_signatures.length < needed) {
-      revert Errors.Leonidas__InsufficientAttestationsProvided(needed, _signatures.length);
-    }
+    require(
+      _signatures.length >= needed,
+      Errors.Leonidas__InsufficientAttestationsProvided(needed, _signatures.length)
+    );
 
     // Validate the attestations
     uint256 validAttestations = 0;
@@ -426,9 +425,10 @@ contract Leonidas is Ownable, ILeonidas {
       validAttestations++;
     }
 
-    if (validAttestations < needed) {
-      revert Errors.Leonidas__InsufficientAttestations(needed, validAttestations);
-    }
+    require(
+      validAttestations >= needed,
+      Errors.Leonidas__InsufficientAttestations(needed, validAttestations)
+    );
   }
 
   /**

--- a/l1-contracts/src/core/interfaces/IProofCommitmentEscrow.sol
+++ b/l1-contracts/src/core/interfaces/IProofCommitmentEscrow.sol
@@ -2,8 +2,6 @@
 // Copyright 2024 Aztec Labs.
 pragma solidity >=0.8.27;
 
-import {SignatureLib} from "@aztec/core/libraries/crypto/SignatureLib.sol";
-
 interface IProofCommitmentEscrow {
   function deposit(uint256 _amount) external;
   function withdraw(uint256 _amount) external;

--- a/l1-contracts/src/core/libraries/HeaderLib.sol
+++ b/l1-contracts/src/core/libraries/HeaderLib.sol
@@ -112,9 +112,10 @@ library HeaderLib {
    * @return The decoded header
    */
   function decode(bytes calldata _header) internal pure returns (Header memory) {
-    if (_header.length != HEADER_LENGTH) {
-      revert Errors.HeaderLib__InvalidHeaderSize(HEADER_LENGTH, _header.length);
-    }
+    require(
+      _header.length == HEADER_LENGTH,
+      Errors.HeaderLib__InvalidHeaderSize(HEADER_LENGTH, _header.length)
+    );
 
     Header memory header;
 
@@ -196,9 +197,10 @@ library HeaderLib {
     fields[23] = bytes32(_header.totalFees);
 
     // fail if the header structure has changed without updating this function
-    if (fields.length != Constants.HEADER_LENGTH) {
-      revert Errors.HeaderLib__InvalidHeaderSize(Constants.HEADER_LENGTH, fields.length);
-    }
+    require(
+      fields.length == Constants.HEADER_LENGTH,
+      Errors.HeaderLib__InvalidHeaderSize(Constants.HEADER_LENGTH, fields.length)
+    );
 
     return fields;
   }
@@ -223,11 +225,12 @@ library HeaderLib {
     fields[8] = bytes32(_globalVariables.gasFees.feePerL2Gas);
 
     // fail if the header structure has changed without updating this function
-    if (fields.length != Constants.GLOBAL_VARIABLES_LENGTH) {
-      // TODO(Miranda): Temporarily using this method and below error while block-root proofs are verified
-      // When we verify root proofs, this method can be removed => no need for separate named error
-      revert Errors.HeaderLib__InvalidHeaderSize(Constants.HEADER_LENGTH, fields.length);
-    }
+    // TODO(Miranda): Temporarily using this method and below error while block-root proofs are verified
+    // When we verify root proofs, this method can be removed => no need for separate named error
+    require(
+      fields.length == Constants.GLOBAL_VARIABLES_LENGTH,
+      Errors.HeaderLib__InvalidHeaderSize(Constants.HEADER_LENGTH, fields.length)
+    );
 
     return fields;
   }

--- a/l1-contracts/src/core/libraries/SignatureLib.sol
+++ b/l1-contracts/src/core/libraries/SignatureLib.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity ^0.8.13;
+pragma solidity >=0.8.27;
 
 import {Errors} from "@aztec/core/libraries/Errors.sol";
 

--- a/l1-contracts/src/core/libraries/SignatureLib.sol
+++ b/l1-contracts/src/core/libraries/SignatureLib.sol
@@ -20,12 +20,8 @@ library SignatureLib {
    * @param _digest - The digest that was signed
    */
   function verify(Signature memory _signature, address _signer, bytes32 _digest) internal pure {
-    if (_signature.isEmpty) {
-      revert Errors.SignatureLib__CannotVerifyEmpty();
-    }
+    require(!_signature.isEmpty, Errors.SignatureLib__CannotVerifyEmpty());
     address recovered = ecrecover(_digest, _signature.v, _signature.r, _signature.s);
-    if (_signer != recovered) {
-      revert Errors.SignatureLib__InvalidSignature(_signer, recovered);
-    }
+    require(_signer == recovered, Errors.SignatureLib__InvalidSignature(_signer, recovered));
   }
 }

--- a/l1-contracts/src/core/libraries/TimeMath.sol
+++ b/l1-contracts/src/core/libraries/TimeMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity >=0.8.19;
+pragma solidity >=0.8.27;
 
 import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
 

--- a/l1-contracts/src/core/libraries/TimeMath.sol
+++ b/l1-contracts/src/core/libraries/TimeMath.sol
@@ -63,12 +63,24 @@ function ltTimestamp(Timestamp a, Timestamp b) pure returns (bool) {
   return Timestamp.unwrap(a) < Timestamp.unwrap(b);
 }
 
+function lteTimestamp(Timestamp a, Timestamp b) pure returns (bool) {
+  return Timestamp.unwrap(a) <= Timestamp.unwrap(b);
+}
+
 function gtTimestamp(Timestamp a, Timestamp b) pure returns (bool) {
   return Timestamp.unwrap(a) > Timestamp.unwrap(b);
 }
 
+function gteTimestamp(Timestamp a, Timestamp b) pure returns (bool) {
+  return Timestamp.unwrap(a) >= Timestamp.unwrap(b);
+}
+
 function neqTimestamp(Timestamp a, Timestamp b) pure returns (bool) {
   return Timestamp.unwrap(a) != Timestamp.unwrap(b);
+}
+
+function eqTimestamp(Timestamp a, Timestamp b) pure returns (bool) {
+  return Timestamp.unwrap(a) == Timestamp.unwrap(b);
 }
 
 // Slot
@@ -91,6 +103,14 @@ function ltSlot(Slot a, Slot b) pure returns (bool) {
 
 function lteSlot(Slot a, Slot b) pure returns (bool) {
   return Slot.unwrap(a) <= Slot.unwrap(b);
+}
+
+function gtSlot(Slot a, Slot b) pure returns (bool) {
+  return Slot.unwrap(a) > Slot.unwrap(b);
+}
+
+function gteSlot(Slot a, Slot b) pure returns (bool) {
+  return Slot.unwrap(a) >= Slot.unwrap(b);
 }
 
 // Epoch
@@ -116,9 +136,20 @@ using {
   subTimestamp as -,
   ltTimestamp as <,
   gtTimestamp as >,
-  neqTimestamp as !=
+  lteTimestamp as <=,
+  gteTimestamp as >=,
+  neqTimestamp as !=,
+  eqTimestamp as ==
 } for Timestamp global;
 
 using {addEpoch as +, subEpoch as -, eqEpoch as ==, neqEpoch as !=} for Epoch global;
 
-using {eqSlot as ==, neqSlot as !=, lteSlot as <=, ltSlot as <, addSlot as +} for Slot global;
+using {
+  eqSlot as ==,
+  neqSlot as !=,
+  gteSlot as >=,
+  gtSlot as >,
+  lteSlot as <=,
+  ltSlot as <,
+  addSlot as +
+} for Slot global;

--- a/l1-contracts/src/core/libraries/TxsDecoder.sol
+++ b/l1-contracts/src/core/libraries/TxsDecoder.sol
@@ -184,33 +184,30 @@ library TxsDecoder {
 
         // We throw to ensure that the byte len we charge for DA gas in the kernels matches the actual chargable log byte len
         // Without this check, the user may provide the kernels with a lower log len than reality
-        if (
+        require(
           uint256(bytes32(slice(_body, offsets.noteEncryptedLogsLength, 0x20)))
-            != vars.kernelNoteEncryptedLogsLength
-        ) {
-          revert Errors.TxsDecoder__InvalidLogsLength(
+            == vars.kernelNoteEncryptedLogsLength,
+          Errors.TxsDecoder__InvalidLogsLength(
             uint256(bytes32(slice(_body, offsets.noteEncryptedLogsLength, 0x20))),
             vars.kernelNoteEncryptedLogsLength
-          );
-        }
-        if (
+          )
+        );
+        require(
           uint256(bytes32(slice(_body, offsets.encryptedLogsLength, 0x20)))
-            != vars.kernelEncryptedLogsLength
-        ) {
-          revert Errors.TxsDecoder__InvalidLogsLength(
+            == vars.kernelEncryptedLogsLength,
+          Errors.TxsDecoder__InvalidLogsLength(
             uint256(bytes32(slice(_body, offsets.encryptedLogsLength, 0x20))),
             vars.kernelEncryptedLogsLength
-          );
-        }
-        if (
+          )
+        );
+        require(
           uint256(bytes32(slice(_body, offsets.unencryptedLogsLength, 0x20)))
-            != vars.kernelUnencryptedLogsLength
-        ) {
-          revert Errors.TxsDecoder__InvalidLogsLength(
+            == vars.kernelUnencryptedLogsLength,
+          Errors.TxsDecoder__InvalidLogsLength(
             uint256(bytes32(slice(_body, offsets.unencryptedLogsLength, 0x20))),
             vars.kernelUnencryptedLogsLength
-          );
-        }
+          )
+        );
 
         // Insertions are split into multiple `bytes.concat` to work around stack too deep.
         vars.baseLeaf = bytes.concat(

--- a/l1-contracts/src/core/libraries/crypto/MerkleLib.sol
+++ b/l1-contracts/src/core/libraries/crypto/MerkleLib.sol
@@ -47,9 +47,10 @@ library MerkleLib {
       indexAtHeight >>= 1;
     }
 
-    if (subtreeRoot != _expectedRoot) {
-      revert Errors.MerkleLib__InvalidRoot(_expectedRoot, subtreeRoot, _leaf, _index);
-    }
+    require(
+      subtreeRoot == _expectedRoot,
+      Errors.MerkleLib__InvalidRoot(_expectedRoot, subtreeRoot, _leaf, _index)
+    );
   }
 
   /**

--- a/l1-contracts/src/core/libraries/crypto/SampleLib.sol
+++ b/l1-contracts/src/core/libraries/crypto/SampleLib.sol
@@ -33,9 +33,7 @@ library SampleLib {
     pure
     returns (uint256)
   {
-    if (_index >= _indexCount) {
-      revert Errors.SampleLib__IndexOutOfBounds(_index, _indexCount);
-    }
+    require(_index < _indexCount, Errors.SampleLib__IndexOutOfBounds(_index, _indexCount));
     uint256 rounds = computeShuffleRounds(_indexCount);
 
     uint256 index = _index;
@@ -64,9 +62,9 @@ library SampleLib {
     pure
     returns (uint256)
   {
-    if (_shuffledIndex >= _indexCount) {
-      revert Errors.SampleLib__IndexOutOfBounds(_shuffledIndex, _indexCount);
-    }
+    require(
+      _shuffledIndex < _indexCount, Errors.SampleLib__IndexOutOfBounds(_shuffledIndex, _indexCount)
+    );
 
     uint256 rounds = computeShuffleRounds(_indexCount);
 

--- a/l1-contracts/src/core/libraries/crypto/SignatureLib.sol
+++ b/l1-contracts/src/core/libraries/crypto/SignatureLib.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.27;
 
 import {Errors} from "@aztec/core/libraries/Errors.sol";
 

--- a/l1-contracts/src/core/libraries/crypto/SignatureLib.sol
+++ b/l1-contracts/src/core/libraries/crypto/SignatureLib.sol
@@ -20,12 +20,8 @@ library SignatureLib {
    * @param _digest - The digest that was signed
    */
   function verify(Signature memory _signature, address _signer, bytes32 _digest) internal pure {
-    if (_signature.isEmpty) {
-      revert Errors.SignatureLib__CannotVerifyEmpty();
-    }
+    require(!_signature.isEmpty, Errors.SignatureLib__CannotVerifyEmpty());
     address recovered = ecrecover(_digest, _signature.v, _signature.r, _signature.s);
-    if (_signer != recovered) {
-      revert Errors.SignatureLib__InvalidSignature(_signer, recovered);
-    }
+    require(_signer == recovered, Errors.SignatureLib__InvalidSignature(_signer, recovered));
   }
 }

--- a/l1-contracts/src/core/messagebridge/Inbox.sol
+++ b/l1-contracts/src/core/messagebridge/Inbox.sol
@@ -64,15 +64,15 @@ contract Inbox is IInbox {
     bytes32 _content,
     bytes32 _secretHash
   ) external override(IInbox) returns (bytes32) {
-    if (uint256(_recipient.actor) > Constants.MAX_FIELD_VALUE) {
-      revert Errors.Inbox__ActorTooLarge(_recipient.actor);
-    }
-    if (uint256(_content) > Constants.MAX_FIELD_VALUE) {
-      revert Errors.Inbox__ContentTooLarge(_content);
-    }
-    if (uint256(_secretHash) > Constants.MAX_FIELD_VALUE) {
-      revert Errors.Inbox__SecretHashTooLarge(_secretHash);
-    }
+    require(
+      uint256(_recipient.actor) <= Constants.MAX_FIELD_VALUE,
+      Errors.Inbox__ActorTooLarge(_recipient.actor)
+    );
+    require(uint256(_content) <= Constants.MAX_FIELD_VALUE, Errors.Inbox__ContentTooLarge(_content));
+    require(
+      uint256(_secretHash) <= Constants.MAX_FIELD_VALUE,
+      Errors.Inbox__SecretHashTooLarge(_secretHash)
+    );
 
     FrontierLib.Tree storage currentTree = trees[inProgress];
 
@@ -108,13 +108,8 @@ contract Inbox is IInbox {
    * @return The root of the consumed tree
    */
   function consume(uint256 _toConsume) external override(IInbox) returns (bytes32) {
-    if (msg.sender != ROLLUP) {
-      revert Errors.Inbox__Unauthorized();
-    }
-
-    if (_toConsume >= inProgress) {
-      revert Errors.Inbox__MustBuildBeforeConsume();
-    }
+    require(msg.sender == ROLLUP, Errors.Inbox__Unauthorized());
+    require(_toConsume < inProgress, Errors.Inbox__MustBuildBeforeConsume());
 
     bytes32 root = EMPTY_ROOT;
     if (_toConsume > Constants.INITIAL_L2_BLOCK_NUM) {

--- a/l1-contracts/src/core/messagebridge/Outbox.sol
+++ b/l1-contracts/src/core/messagebridge/Outbox.sol
@@ -48,13 +48,8 @@ contract Outbox is IOutbox {
     external
     override(IOutbox)
   {
-    if (msg.sender != address(ROLLUP)) {
-      revert Errors.Outbox__Unauthorized();
-    }
-
-    if (_root == bytes32(0)) {
-      revert Errors.Outbox__InsertingInvalidRoot();
-    }
+    require(msg.sender == address(ROLLUP), Errors.Outbox__Unauthorized());
+    require(_root != bytes32(0), Errors.Outbox__InsertingInvalidRoot());
 
     roots[_l2BlockNumber].root = _root;
     roots[_l2BlockNumber].minHeight = _minHeight;
@@ -81,38 +76,33 @@ contract Outbox is IOutbox {
     uint256 _leafIndex,
     bytes32[] calldata _path
   ) external override(IOutbox) {
-    if (_l2BlockNumber > ROLLUP.getProvenBlockNumber()) {
-      revert Errors.Outbox__BlockNotProven(_l2BlockNumber);
-    }
+    require(
+      _l2BlockNumber <= ROLLUP.getProvenBlockNumber(), Errors.Outbox__BlockNotProven(_l2BlockNumber)
+    );
 
-    if (msg.sender != _message.recipient.actor) {
-      revert Errors.Outbox__InvalidRecipient(_message.recipient.actor, msg.sender);
-    }
+    require(
+      msg.sender == _message.recipient.actor,
+      Errors.Outbox__InvalidRecipient(_message.recipient.actor, msg.sender)
+    );
 
-    if (block.chainid != _message.recipient.chainId) {
-      revert Errors.Outbox__InvalidChainId();
-    }
+    require(block.chainid == _message.recipient.chainId, Errors.Outbox__InvalidChainId());
 
     RootData storage rootData = roots[_l2BlockNumber];
 
     bytes32 blockRoot = rootData.root;
 
-    if (blockRoot == 0) {
-      revert Errors.Outbox__NothingToConsumeAtBlock(_l2BlockNumber);
-    }
+    require(blockRoot != bytes32(0), Errors.Outbox__NothingToConsumeAtBlock(_l2BlockNumber));
 
-    if (rootData.nullified[_leafIndex]) {
-      revert Errors.Outbox__AlreadyNullified(_l2BlockNumber, _leafIndex);
-    }
+    require(
+      !rootData.nullified[_leafIndex], Errors.Outbox__AlreadyNullified(_l2BlockNumber, _leafIndex)
+    );
     // TODO(#7218): We will eventually move back to a balanced tree and constrain the path length
     // to be equal to height - for now we just check the min
 
     // Min height = height of rollup layers
     // The smallest num of messages will require a subtree of height 1
     uint256 minHeight = rootData.minHeight;
-    if (minHeight > _path.length) {
-      revert Errors.Outbox__InvalidPathLength(minHeight, _path.length);
-    }
+    require(minHeight <= _path.length, Errors.Outbox__InvalidPathLength(minHeight, _path.length));
 
     bytes32 messageHash = _message.sha256ToField();
 

--- a/l1-contracts/src/governance/Registry.sol
+++ b/l1-contracts/src/governance/Registry.sol
@@ -42,7 +42,7 @@ contract Registry is IRegistry, Ownable {
    */
   function getVersionFor(address _rollup) external view override(IRegistry) returns (uint256) {
     (uint256 version, bool exists) = _getVersionFor(_rollup);
-    if (!exists) revert Errors.Registry__RollupNotRegistered(_rollup);
+    require(exists, Errors.Registry__RollupNotRegistered(_rollup));
     return version;
   }
 
@@ -99,7 +99,7 @@ contract Registry is IRegistry, Ownable {
 
   function _upgrade(address _rollup) internal returns (uint256) {
     (, bool exists) = _getVersionFor(_rollup);
-    if (exists) revert Errors.Registry__RollupAlreadyRegistered(_rollup);
+    require(!exists, Errors.Registry__RollupAlreadyRegistered(_rollup));
 
     DataStructures.RegistrySnapshot memory newSnapshot =
       DataStructures.RegistrySnapshot(_rollup, block.number);

--- a/l1-contracts/src/governance/libraries/DataStructures.sol
+++ b/l1-contracts/src/governance/libraries/DataStructures.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 /**
  * @title Data Structures Library

--- a/l1-contracts/src/governance/libraries/Errors.sol
+++ b/l1-contracts/src/governance/libraries/Errors.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Aztec Labs.
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.27;
 
 /**
  * @title Errors Library


### PR DESCRIPTION
With solidity `0.8.27` we can use `require(predicate,custom_error)`, this pr is modifying the codebase use this notation as it will often be easier to read.