### PR TITLE
fix: use different rust toolchain for foundry builds

### DIFF
--- a/build-images/Earthfile
+++ b/build-images/Earthfile
@@ -96,7 +96,7 @@ foundry-build:
   RUN ulimit -n 65535 \
       && git clone --depth 1 --branch nightly-$FOUNDRY_TAG https://github.com/foundry-rs/foundry.git \
       && cd foundry \
-      && touch rust-toolchain.toml && echo '[toolchain]\nchannel = "1.80.0"\n' > rust-toolchain.toml \
+      && echo '[toolchain]\nchannel = "1.80.0"\n' > rust-toolchain.toml \
       && cargo build --release \
       && mkdir -p /opt/foundry/bin \
       && for t in forge cast anvil chisel; do \

--- a/build-images/Earthfile
+++ b/build-images/Earthfile
@@ -100,7 +100,7 @@ foundry-build:
       && cargo build --release \
       && mkdir -p /opt/foundry/bin \
       && for t in forge cast anvil chisel; do \
-          mv ./target/local/$t /opt/foundry/bin/$t; \
+          mv ./target/release/$t /opt/foundry/bin/$t; \
           strip /opt/foundry/bin/$t; \
       done \
       && rm -rf /foundry

--- a/build-images/Earthfile
+++ b/build-images/Earthfile
@@ -88,7 +88,7 @@ osxcross:
 foundry-build:
   LET FOUNDRY_TAG = 25f24e677a6a32a62512ad4f561995589ac2c7dc
   FROM +base-build
-  # This will not be run often, so we use rustup to manage the cargo version via a tool-chain file
+  # We use rustup rather than cargo to manage the cargo version via a tool-chain file
   # It is done this way to avoid conflicting with noir builds
   # This image should only be rebuilt when our foundry tag changes, so it should be extremely infrequent
   RUN apt remove -y cargo

--- a/build-images/Earthfile
+++ b/build-images/Earthfile
@@ -88,10 +88,16 @@ osxcross:
 foundry-build:
   LET FOUNDRY_TAG = 25f24e677a6a32a62512ad4f561995589ac2c7dc
   FROM +base-build
+  # This will not be run often, so we use rustup to manage the cargo version via a tool-chain file
+  # It is done this way to avoid conflicting with noir builds
+  # This image should only be rebuilt when our foundry tag changes, so it should be extremely infrequent
+  RUN apt remove -y cargo
+  RUN apt update && apt install -y rustup
   RUN ulimit -n 65535 \
       && git clone --depth 1 --branch nightly-$FOUNDRY_TAG https://github.com/foundry-rs/foundry.git \
       && cd foundry \
-      && cargo build --profile local \
+      && touch rust-toolchain.toml && echo '[toolchain]\nchannel = "1.80.0"\n' > rust-toolchain.toml \
+      && cargo build --release \
       && mkdir -p /opt/foundry/bin \
       && for t in forge cast anvil chisel; do \
           mv ./target/local/$t /opt/foundry/bin/$t; \

--- a/l1-contracts/test/merkle/Frontier.t.sol
+++ b/l1-contracts/test/merkle/Frontier.t.sol
@@ -8,7 +8,10 @@ import {NaiveMerkle} from "./Naive.sol";
 import {FrontierMerkle} from "../harnesses/Frontier.sol";
 
 contract FrontierTest is Test {
-  function setUp() public {}
+  function setUp() public {
+    // Pause gas metering as calculating the root on each insert is expensive
+    vm.pauseGasMetering();
+  }
 
   function testFrontier() public {
     uint256 depth = 10;

--- a/l1-contracts/test/portals/TokenPortal.sol
+++ b/l1-contracts/test/portals/TokenPortal.sol
@@ -118,7 +118,7 @@ contract TokenPortal {
           _amount,
           _withCaller ? msg.sender : address(0)
         )
-        )
+      )
     });
 
     IOutbox outbox = IRollup(registry.getRollup()).OUTBOX();

--- a/l1-contracts/test/portals/TokenPortal.t.sol
+++ b/l1-contracts/test/portals/TokenPortal.t.sol
@@ -88,7 +88,7 @@ contract TokenPortalTest is Test {
         abi.encodeWithSignature(
           "mint_private(bytes32,uint256)", secretHashForRedeemingMintedNotes, amount
         )
-        ),
+      ),
       secretHash: secretHashForL2MessageConsumption
     });
   }
@@ -166,7 +166,7 @@ contract TokenPortalTest is Test {
           abi.encodeWithSignature(
             "withdraw(address,uint256,address)", recipient, withdrawAmount, _designatedCaller
           )
-          )
+        )
       })
     );
 

--- a/l1-contracts/test/portals/UniswapPortal.t.sol
+++ b/l1-contracts/test/portals/UniswapPortal.t.sol
@@ -90,7 +90,7 @@ contract UniswapPortalTest is Test {
       recipient: DataStructures.L1Actor(address(daiTokenPortal), block.chainid),
       content: Hash.sha256ToField(
         abi.encodeWithSignature("withdraw(address,uint256,address)", _recipient, amount, _caller)
-        )
+      )
     });
 
     return message.sha256ToField();
@@ -122,7 +122,7 @@ contract UniswapPortalTest is Test {
           secretHash,
           _caller
         )
-        )
+      )
     });
 
     return message.sha256ToField();
@@ -153,7 +153,7 @@ contract UniswapPortalTest is Test {
           secretHash,
           _caller
         )
-        )
+      )
     });
 
     return message.sha256ToField();

--- a/yarn-project/end-to-end/scripts/docker-compose-no-sandbox.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose-no-sandbox.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: aztecprotocol/foundry:25f24e677a6a32a62512ad4f561995589ac2c7dc
+    image: aztecprotocol/foundry:25f24e677a6a32a62512ad4f561995589ac2c7dc-amd64
     pull_policy: always
     entrypoint: >
       sh -c '

--- a/yarn-project/end-to-end/scripts/docker-compose-p2p.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose-p2p.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: aztecprotocol/foundry:25f24e677a6a32a62512ad4f561995589ac2c7dc
+    image: aztecprotocol/foundry:25f24e677a6a32a62512ad4f561995589ac2c7dc-amd64
     pull_policy: always
     entrypoint: 'anvil --silent -p 8545 --host 0.0.0.0 --chain-id 31337'
     expose:

--- a/yarn-project/end-to-end/scripts/docker-compose-wallet.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose-wallet.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: aztecprotocol/foundry:25f24e677a6a32a62512ad4f561995589ac2c7dc
+    image: aztecprotocol/foundry:25f24e677a6a32a62512ad4f561995589ac2c7dc-amd64
     pull_policy: always
     entrypoint: >
       sh -c '

--- a/yarn-project/end-to-end/scripts/docker-compose.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fork:
-    image: aztecprotocol/foundry:25f24e677a6a32a62512ad4f561995589ac2c7dc
+    image: aztecprotocol/foundry:25f24e677a6a32a62512ad4f561995589ac2c7dc-amd64
     pull_policy: always
     entrypoint: >
       sh -c '


### PR DESCRIPTION
## Overview

Cargo version installed by default in `build-images` was not the minimum required for the newer release of foundry that was pinned in https://github.com/AztecProtocol/aztec-packages/pull/8868, this alters the `foundry-build` earthly script to use `1.80` rustc version. This is set through adding a toolchain file so the correct binary will be installed automatically. 

In the future if we need to bump the version for builds, we can just alter this toolchain version.

This also runs forge fmt for this updated version