### PR TITLE
fix: earthly-script output

### DIFF
--- a/scripts/setup-earthly-local.sh
+++ b/scripts/setup-earthly-local.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-echo 'alias earthly="$(git rev-parse --show-toplevel)/scripts/earthly-local"' >> ~/.zshrc
+EARTHLY_SCRIPT_LOCATION="$(git rev-parse --show-toplevel)/scripts/earthly-local"
+echo "alias earthly=\"$EARTHLY_SCRIPT_LOCATION\"" >> ~/.zshrc


### PR DESCRIPTION
Current install script will add an alias that runs git rev-parse on every run, so if youre not in a git repo you will get the output below

<img width="555" alt="image" src="https://github.com/user-attachments/assets/1f5c6cc4-96b0-46b3-9512-a83f79e373ee">
