### PR TITLE
chore!: keccak_ultra -> ultra_keccak

### DIFF
--- a/barretenberg/acir_tests/flows/honk_sol.sh
+++ b/barretenberg/acir_tests/flows/honk_sol.sh
@@ -9,7 +9,7 @@ export PROOF="$(pwd)/proof"
 export PROOF_AS_FIELDS="$(pwd)/proof_fields.json"
 
 # Create a proof, write the solidity contract, write the proof as fields in order to extract the public inputs
-$BIN prove_keccak_ultra_honk -o proof $FLAGS $BFLAG
+$BIN prove_ultra_keccak_honk -o proof $FLAGS $BFLAG
 $BIN write_vk_ultra_keccak_honk -o vk $FLAGS $BFLAG
 $BIN proof_as_fields_honk -k vk -c $CRS_PATH -p $PROOF
 $BIN contract_ultra_honk -k vk -c $CRS_PATH -o Verifier.sol

--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -1536,7 +1536,7 @@ int main(int argc, char* argv[])
         } else if (command == "prove_ultra_honk") {
             std::string output_path = get_option(args, "-o", "./proofs/proof");
             prove_honk<UltraFlavor>(bytecode_path, witness_path, output_path);
-        } else if (command == "prove_keccak_ultra_honk") {
+        } else if (command == "prove_ultra_keccak_honk") {
             std::string output_path = get_option(args, "-o", "./proofs/proof");
             prove_honk<UltraKeccakFlavor>(bytecode_path, witness_path, output_path);
         } else if (command == "prove_ultra_keccak_honk_output_all") {

--- a/barretenberg/cpp/src/barretenberg/bb/readme.md
+++ b/barretenberg/cpp/src/barretenberg/bb/readme.md
@@ -107,10 +107,10 @@ Barretenberg UltraHonk comes with the capability to verify proofs in Solidity, i
 2. Prove the valid execution of your Noir program running:
 
     ```bash
-    bb prove_keccak_ultra_honk -b ./target/hello_world.json -w ./target/witness-name.gz -o ./target/proof
+    bb prove_ultra_keccak_honk -b ./target/hello_world.json -w ./target/witness-name.gz -o ./target/proof
     ```
 
-    > **Note:** `prove_keccak_ultra_honk` is used to generate UltraHonk proofs with Keccak hashes, as it is what the Solidity verifier is designed to be compatible with given the better gas efficiency when verifying on-chain; `prove_ultra_honk` in comparison generates proofs with Poseidon hashes, more efficient in recursions but not on-chain verifications.
+    > **Note:** `prove_ultra_keccak_honk` is used to generate UltraHonk proofs with Keccak hashes, as it is what the Solidity verifier is designed to be compatible with given the better gas efficiency when verifying on-chain; `prove_ultra_honk` in comparison generates proofs with Poseidon hashes, more efficient in recursions but not on-chain verifications.
 
 3. Compute the verification key for your Noir program running:
 


### PR DESCRIPTION
In main.cpp there are instances that list ultra_keccak and some that list keccak_ultra, for the sake of consistency
this pr replaces keccak_ultra with the more frequently occuring ultra_keccak
