### PR TITLE
feat: help commands for bb

### DIFF
--- a/barretenberg/acir_tests/flows/honk_sol.sh
+++ b/barretenberg/acir_tests/flows/honk_sol.sh
@@ -9,7 +9,7 @@ export PROOF="$(pwd)/proof"
 export PROOF_AS_FIELDS="$(pwd)/proof_fields.json"
 
 # Create a proof, write the solidity contract, write the proof as fields in order to extract the public inputs
-$BIN prove_keccak_ultra_honk -o proof $FLAGS $BFLAG
+$BIN prove_ultra_keccak_honk -o proof $FLAGS $BFLAG
 $BIN write_vk_ultra_keccak_honk -o vk $FLAGS $BFLAG
 $BIN proof_as_fields_honk -k vk -c $CRS_PATH -p $PROOF
 $BIN contract_ultra_honk -k vk -c $CRS_PATH -o Verifier.sol

--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -1536,7 +1536,7 @@ int main(int argc, char* argv[])
         } else if (command == "prove_ultra_honk") {
             std::string output_path = get_option(args, "-o", "./proofs/proof");
             prove_honk<UltraFlavor>(bytecode_path, witness_path, output_path);
-        } else if (command == "prove_keccak_ultra_honk") {
+        } else if (command == "prove_ultra_keccak_honk") {
             std::string output_path = get_option(args, "-o", "./proofs/proof");
             prove_honk<UltraKeccakFlavor>(bytecode_path, witness_path, output_path);
         } else if (command == "prove_ultra_keccak_honk_output_all") {

--- a/barretenberg/cpp/src/barretenberg/bb/readme.md
+++ b/barretenberg/cpp/src/barretenberg/bb/readme.md
@@ -107,10 +107,10 @@ Barretenberg UltraHonk comes with the capability to verify proofs in Solidity, i
 2. Prove the valid execution of your Noir program running:
 
     ```bash
-    bb prove_keccak_ultra_honk -b ./target/hello_world.json -w ./target/witness-name.gz -o ./target/proof
+    bb prove_ultra_keccak_honk -b ./target/hello_world.json -w ./target/witness-name.gz -o ./target/proof
     ```
 
-    > **Note:** `prove_keccak_ultra_honk` is used to generate UltraHonk proofs with Keccak hashes, as it is what the Solidity verifier is designed to be compatible with given the better gas efficiency when verifying on-chain; `prove_ultra_honk` in comparison generates proofs with Poseidon hashes, more efficient in recursions but not on-chain verifications.
+    > **Note:** `prove_ultra_keccak_honk` is used to generate UltraHonk proofs with Keccak hashes, as it is what the Solidity verifier is designed to be compatible with given the better gas efficiency when verifying on-chain; `prove_ultra_honk` in comparison generates proofs with Poseidon hashes, more efficient in recursions but not on-chain verifications.
 
 3. Compute the verification key for your Noir program running:
 


### PR DESCRIPTION
## Overview

fixes: https://github.com/AztecProtocol/aztec-packages/issues/8464

Alter the main dispatch function from bb such that it supports commands

This pr is more of a showcase and is expected to be iterative as it does change a good bit here

```
t % ../cpp/build/bin/bb --help
Available commands:
  vk_as_fields_ultra_keccak_honk: Convert Ultra Keccak Honk verification key to fields
  vk_as_fields_ultra_honk: Convert Ultra Honk verification key to fields
  write_vk_mega_honk: Write Mega Honk verification key
  vk_as_fields_mega_honk: Convert Mega Honk verification key to fields
  verify_mega_honk: Verify Mega Honk proof
  write_vk_ultra_keccak_honk: Write Ultra Keccak Honk verification key
  write_vk_ultra_honk: Write Ultra Honk verification key
  prove_ultra_keccak_honk_output_all: Generate Ultra Keccak Honk proof and output all related data
  prove_ultra_keccak_honk: Generate Ultra Keccak Honk proof
  prove_mega_honk_output_all: Generate a Mega Honk proof and output all related data
  prove_output_all: Generate a proof and output all related data
  fold_and_verify_program: Fold and verify program
  vk_as_fields: Convert verification key to fields
  verify_ultra_honk: Verify Ultra Honk proof
  prove_and_verify_mega_honk_program: Prove and verify Mega Honk program
  prove_and_verify_ultra_honk_program: Prove and verify Ultra Honk program
  prove_and_verify_mega_honk: Prove and verify using Mega Honk
  client_ivc_prove_output_all_msgpack: Client IVC prove output all msgpack
  prove_ultra_honk: Generate Ultra Honk proof
  prove_and_verify_ultra_honk: Prove and verify using Ultra Honk
  prove_and_verify: Prove and verify
  avm_verify: Verify AVM proof
  --version: Display version information
  proof_as_fields_honk: Convert Honk proof to fields
  proof_as_fields: Convert proof to fields
  verify_ultra_keccak_honk: Verify Ultra Keccak Honk proof
  prove_tube: Generate a tube proof
  write_recursion_inputs_honk: Write recursion inputs for Honk
  verify_tube: Verify a tube proof
  client_ivc_prove_output_all: Generate a client IVC proof and output all related data
  gates: Count gates for Ultra circuit
  verify_client_ivc: Verify client IVC
  prove: Generate a proof
  gates_mega_honk: Count gates for Mega Honk circuit
  prove_ultra_honk_output_all: Generate an Ultra Honk proof and output all related data
  verify: Verify a proof
  write_vk: Write verification key
  avm_prove: Generate AVM proof
  contract: Generate a contract
  contract_ultra_honk: Generate an Ultra Honk contract
  prove_mega_honk: Generate Mega Honk proof
  write_pk: Write proving key
Use --help with any command for more information.
```

For an individual command:

```
t % ../cpp/build/bin/bb vk_as_fields_ultra_keccak_honk --help
vk_as_fields_ultra_keccak_honk: Convert Ultra Keccak Honk verification key to fields
Usage: vk_as_fields_ultra_keccak_honk -k <vk_path> -o <output_path>

```

