### PR TITLE
refactor: nuking L2Block.fromFields

### DIFF
--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -8,6 +8,14 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 
 ## TBD
 
+### [Aztec.js] Removed `L2Block.fromFields`
+`L2Block.fromFields` was a syntactic sugar which is causing [issues](https://github.com/AztecProtocol/aztec-packages/issues/8340) so we've removed it.
+
+```diff
+-const l2Block = L2Block.fromFields({ header, archive, body });
++const l2Block = new L2Block(archive, header, body);
+```
+
 ### [Aztec.nr] Removed `SharedMutablePrivateGetter`
 
 This state variable was deleted due to it being difficult to use safely.

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
@@ -149,7 +149,7 @@ export class BlockStore {
     }
     const body = Body.fromBuffer(blockBodyBuffer);
 
-    const l2Block = L2Block.fromFields({ header, archive, body });
+    const l2Block = new L2Block(archive, header, body);
     return { data: l2Block, l1: blockStorage.l1 };
   }
 

--- a/yarn-project/circuit-types/src/l2_block.ts
+++ b/yarn-project/circuit-types/src/l2_block.ts
@@ -20,21 +20,6 @@ export class L2Block {
   ) {}
 
   /**
-   * Constructs a new instance from named fields.
-   * @param fields - Fields to pass to the constructor.
-   * @returns A new instance.
-   */
-  static fromFields(fields: {
-    /** Snapshot of archive tree after the block is applied. */
-    archive: AppendOnlyTreeSnapshot;
-    /** L2 block header. */
-    header: Header;
-    body: Body;
-  }) {
-    return new this(fields.archive, fields.header, fields.body);
-  }
-
-  /**
    * Deserializes a block from a buffer
    * @returns A deserialized L2 block.
    */
@@ -44,11 +29,11 @@ export class L2Block {
     const archive = reader.readObject(AppendOnlyTreeSnapshot);
     const body = reader.readObject(Body);
 
-    return L2Block.fromFields({
+    return new L2Block(
       archive,
       header,
       body,
-    });
+    );
   }
 
   /**
@@ -107,11 +92,11 @@ export class L2Block {
 
     const txsEffectsHash = body.getTxsEffectsHash();
 
-    return L2Block.fromFields({
-      archive: makeAppendOnlyTreeSnapshot(l2BlockNum + 1),
-      header: makeHeader(0, l2BlockNum, slotNumber ?? l2BlockNum, txsEffectsHash, inHash),
+    return new L2Block(
+       makeAppendOnlyTreeSnapshot(l2BlockNum + 1),
+      makeHeader(0, l2BlockNum, slotNumber ?? l2BlockNum, txsEffectsHash, inHash),
       body,
-    });
+    );
   }
 
   /**
@@ -119,11 +104,11 @@ export class L2Block {
    * @returns The L2 block.
    */
   static empty(): L2Block {
-    return L2Block.fromFields({
-      archive: AppendOnlyTreeSnapshot.zero(),
-      header: Header.empty(),
-      body: Body.empty(),
-    });
+    return new L2Block(
+      AppendOnlyTreeSnapshot.zero(),
+      Header.empty(),
+      Body.empty(),
+    );
   }
 
   get number(): number {

--- a/yarn-project/circuit-types/src/l2_block.ts
+++ b/yarn-project/circuit-types/src/l2_block.ts
@@ -29,11 +29,7 @@ export class L2Block {
     const archive = reader.readObject(AppendOnlyTreeSnapshot);
     const body = reader.readObject(Body);
 
-    return new L2Block(
-      archive,
-      header,
-      body,
-    );
+    return new L2Block(archive, header, body);
   }
 
   /**
@@ -93,7 +89,7 @@ export class L2Block {
     const txsEffectsHash = body.getTxsEffectsHash();
 
     return new L2Block(
-       makeAppendOnlyTreeSnapshot(l2BlockNum + 1),
+      makeAppendOnlyTreeSnapshot(l2BlockNum + 1),
       makeHeader(0, l2BlockNum, slotNumber ?? l2BlockNum, txsEffectsHash, inHash),
       body,
     );
@@ -104,11 +100,7 @@ export class L2Block {
    * @returns The L2 block.
    */
   static empty(): L2Block {
-    return new L2Block(
-      AppendOnlyTreeSnapshot.zero(),
-      Header.empty(),
-      Body.empty(),
-    );
+    return new L2Block(AppendOnlyTreeSnapshot.zero(), Header.empty(), Body.empty());
   }
 
   get number(): number {

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -437,7 +437,7 @@ export class ProvingOrchestrator implements EpochProver {
 
     // Assemble the L2 block
     const newArchive = await getTreeSnapshot(MerkleTreeId.ARCHIVE, this.db);
-    const l2Block = L2Block.fromFields({ archive: newArchive, header, body });
+    const l2Block = new L2Block(newArchive, header, body);
 
     if (!l2Block.body.getTxsEffectsHash().equals(header.contentCommitment.txsEffectsHash)) {
       throw new Error(

--- a/yarn-project/pxe/src/synchronizer/synchronizer.test.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.test.ts
@@ -97,20 +97,12 @@ describe('Synchronizer', () => {
       .mockResolvedValueOnce([blocks[1].body.encryptedLogs]);
 
     aztecNode.getBlocks
-      // called by synchronizer.work, we are testing fromFields in this first call
+      // called by synchronizer.work,
       .mockResolvedValueOnce([
-        L2Block.fromFields({
-          archive: blocks[0].archive,
-          header: blocks[0].header,
-          body: blocks[0].body,
-        }),
+          blocks[0],
       ])
       .mockResolvedValueOnce([
-        L2Block.fromFields({
-          archive: blocks[1].archive,
-          header: blocks[1].header,
-          body: blocks[1].body,
-        }),
+          blocks[1]
       ])
       // called by synchronizer.workNoteProcessorCatchUp
       .mockResolvedValueOnce([blocks[0]])

--- a/yarn-project/pxe/src/synchronizer/synchronizer.test.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.test.ts
@@ -98,12 +98,8 @@ describe('Synchronizer', () => {
 
     aztecNode.getBlocks
       // called by synchronizer.work,
-      .mockResolvedValueOnce([
-          blocks[0],
-      ])
-      .mockResolvedValueOnce([
-          blocks[1]
-      ])
+      .mockResolvedValueOnce([blocks[0]])
+      .mockResolvedValueOnce([blocks[1]])
       // called by synchronizer.workNoteProcessorCatchUp
       .mockResolvedValueOnce([blocks[0]])
       .mockResolvedValueOnce([blocks[1]]);


### PR DESCRIPTION
Fixes https://github.com/AztecProtocol/aztec-packages/issues/8340

It's an unnecessary syntactic sugar which is causing [issues](https://github.com/AztecProtocol/aztec-packages/issues/8340). `fromFields` name is also used to deserialize from an array of `Fr`s in [other parts of codebase](https://github.com/AztecProtocol/aztec-packages/blob/1257a2a9936b2a45391f17ca014954dcde24a2d3/yarn-project/circuits.js/src/structs/call_context.ts#L104) so it's quite confusing.