### PR TITLE
refactor(avm): type aliasing for VmPublicInputs

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm_recursion_constraint.cpp
@@ -20,6 +20,7 @@ using namespace bb;
 using field_ct = stdlib::field_t<Builder>;
 using bn254 = stdlib::bn254<Builder>;
 using aggregation_state_ct = bb::stdlib::recursion::aggregation_state<bn254>;
+using VmPublicInputs = avm_trace::VmPublicInputs_<field_ct>;
 
 namespace {
 /**
@@ -184,7 +185,7 @@ AggregationObjectIndices create_avm_recursion_constraints(Builder& builder,
     const auto public_inputs_flattened = fields_from_witnesses(input.public_inputs);
 
     auto it = public_inputs_flattened.begin();
-    avm_trace::VmPublicInputs<field_ct> vm_public_inputs =
+    VmPublicInputs vm_public_inputs =
         avm_trace::convert_public_inputs(std::vector(it, it + PUBLIC_CIRCUIT_PUBLIC_INPUTS_LENGTH));
     it += PUBLIC_CIRCUIT_PUBLIC_INPUTS_LENGTH;
     std::vector<field_ct> calldata(it, it + AVM_PUBLIC_COLUMN_MAX_SIZE);

--- a/barretenberg/cpp/src/barretenberg/vm/avm/tests/helpers.test.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/tests/helpers.test.hpp
@@ -25,7 +25,7 @@ using FF = bb::AvmFlavorSettings::FF;
 using Row = bb::AvmFullRow<bb::fr>;
 using ThreeOpParam = std::array<FF, 3>;
 using ThreeOpParamRow = std::tuple<ThreeOpParam, bb::avm_trace::AvmMemoryTag>;
-using VmPublicInputsNT = bb::avm_trace::VmPublicInputs<FF>;
+using VmPublicInputsNT = bb::avm_trace::VmPublicInputs_<FF>;
 
 // If the test is expecting a relation to fail, then use validate_trace_check_circuit.
 // Otherwise, use validate_trace with a single argument. If the proving needs to be

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/common.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/common.hpp
@@ -15,10 +15,13 @@ using FF = AvmFlavorSettings::FF;
 
 // There are 4 public input columns, 1 for context inputs, and 3 for emitting side effects
 template <typename FF_>
-using VmPublicInputs = std::tuple<std::array<FF_, KERNEL_INPUTS_LENGTH>,   // Input: Kernel context inputs
-                                  std::array<FF_, KERNEL_OUTPUTS_LENGTH>,  // Output: Kernel outputs data
-                                  std::array<FF_, KERNEL_OUTPUTS_LENGTH>,  // Output: Kernel outputs side effects
-                                  std::array<FF_, KERNEL_OUTPUTS_LENGTH>>; // Output: Kernel outputs metadata
+using VmPublicInputs_ = std::tuple<std::array<FF_, KERNEL_INPUTS_LENGTH>,   // Input: Kernel context inputs
+                                   std::array<FF_, KERNEL_OUTPUTS_LENGTH>,  // Output: Kernel outputs data
+                                   std::array<FF_, KERNEL_OUTPUTS_LENGTH>,  // Output: Kernel outputs side effects
+                                   std::array<FF_, KERNEL_OUTPUTS_LENGTH>>; // Output: Kernel outputs metadata
+
+// This is the VmPublicInputs type for the current AVM flavor
+using VmPublicInputs = VmPublicInputs_<FF>;
 // Constants for indexing into the tuple above
 static const size_t KERNEL_INPUTS = 0;
 static const size_t KERNEL_OUTPUTS_VALUE = 1;

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/execution.cpp
@@ -146,7 +146,7 @@ void show_trace_info(const auto& trace)
 } // namespace
 
 // Needed for dependency injection in tests.
-Execution::TraceBuilderConstructor Execution::trace_builder_constructor = [](VmPublicInputs<FF> public_inputs,
+Execution::TraceBuilderConstructor Execution::trace_builder_constructor = [](VmPublicInputs public_inputs,
                                                                              ExecutionHints execution_hints,
                                                                              uint32_t side_effect_counter,
                                                                              std::vector<FF> calldata) {
@@ -252,7 +252,7 @@ bool Execution::verify(AvmFlavor::VerificationKey vk, HonkProof const& proof)
     std::copy(returndata_offset, raw_proof_offset, std::back_inserter(returndata));
     std::copy(raw_proof_offset, proof.end(), std::back_inserter(raw_proof));
 
-    VmPublicInputs<FF> public_inputs = convert_public_inputs(public_inputs_vec);
+    VmPublicInputs public_inputs = convert_public_inputs(public_inputs_vec);
     std::vector<std::vector<FF>> public_inputs_columns =
         copy_public_inputs_columns(public_inputs, calldata, returndata);
     return verifier.verify_proof(raw_proof, public_inputs_columns);
@@ -291,7 +291,7 @@ std::vector<Row> Execution::gen_trace(std::vector<Instruction> const& instructio
     vinfo("------- GENERATING TRACE -------");
     // TODO(https://github.com/AztecProtocol/aztec-packages/issues/6718): construction of the public input columns
     // should be done in the kernel - this is stubbed and underconstrained
-    VmPublicInputs<FF> public_inputs = convert_public_inputs(public_inputs_vec);
+    VmPublicInputs public_inputs = convert_public_inputs(public_inputs_vec);
     uint32_t start_side_effect_counter =
         !public_inputs_vec.empty() ? static_cast<uint32_t>(public_inputs_vec[START_SIDE_EFFECT_COUNTER_PCPI_OFFSET])
                                    : 0;

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/execution.hpp
@@ -15,7 +15,7 @@ namespace bb::avm_trace {
 class Execution {
   public:
     static constexpr size_t SRS_SIZE = 1 << 22;
-    using TraceBuilderConstructor = std::function<AvmTraceBuilder(VmPublicInputs<FF> public_inputs,
+    using TraceBuilderConstructor = std::function<AvmTraceBuilder(VmPublicInputs public_inputs,
                                                                   ExecutionHints execution_hints,
                                                                   uint32_t side_effect_counter,
                                                                   std::vector<FF> calldata)>;

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/helper.cpp
@@ -85,7 +85,7 @@ std::string to_hex(bb::avm_trace::AvmMemoryTag tag)
  * @param public_inputs Public inputs structure
  * @param trace The execution trace
  */
-void inject_end_gas_values(VmPublicInputs<FF>& public_inputs, std::vector<Row>& trace)
+void inject_end_gas_values(VmPublicInputs& public_inputs, std::vector<Row>& trace)
 {
     auto execution_end_row =
         std::ranges::find_if(trace.begin(), trace.end(), [](Row r) { return r.main_sel_execution_end == FF(1); });

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/helper.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/helper.hpp
@@ -22,9 +22,9 @@ bool is_operand_indirect(uint8_t ind_value, uint8_t operand_idx);
  * @param public_inputs_vec
  * @return VmPublicInputs
  */
-template <typename FF_> VmPublicInputs<FF_> convert_public_inputs(std::vector<FF_> const& public_inputs_vec)
+template <typename FF_> VmPublicInputs_<FF_> convert_public_inputs(std::vector<FF_> const& public_inputs_vec)
 {
-    VmPublicInputs<FF_> public_inputs;
+    VmPublicInputs_<FF_> public_inputs;
 
     // Case where we pass in empty public inputs - this will be used in tests where they are not required
     if (public_inputs_vec.empty()) {
@@ -173,7 +173,7 @@ template <typename FF_> VmPublicInputs<FF_> convert_public_inputs(std::vector<FF
 // rather than the fixed length arrays that are used during circuit building. This method copies each array
 // into a vector to be used by the verifier.
 template <typename FF_>
-std::vector<std::vector<FF_>> copy_public_inputs_columns(VmPublicInputs<FF_> const& public_inputs,
+std::vector<std::vector<FF_>> copy_public_inputs_columns(VmPublicInputs_<FF_> const& public_inputs,
                                                          std::vector<FF_> const& calldata,
                                                          std::vector<FF_> const& returndata)
 {
@@ -219,6 +219,6 @@ std::string to_hex(T value)
 std::string to_hex(bb::avm_trace::AvmMemoryTag tag);
 
 // Mutate the inputs
-void inject_end_gas_values(VmPublicInputs<FF>& public_inputs, std::vector<Row>& trace);
+void inject_end_gas_values(VmPublicInputs& public_inputs, std::vector<Row>& trace);
 
 } // namespace bb::avm_trace

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/kernel_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/kernel_trace.hpp
@@ -57,7 +57,7 @@ class AvmKernelTraceBuilder {
     // optimise this to just hardcode the counter to be the same as the lookup selector value!!!
     std::unordered_map<uint32_t, uint32_t> kernel_output_selector_counter;
 
-    AvmKernelTraceBuilder(uint32_t initial_side_effect_counter, VmPublicInputs<FF> public_inputs, ExecutionHints hints)
+    AvmKernelTraceBuilder(uint32_t initial_side_effect_counter, VmPublicInputs public_inputs, ExecutionHints hints)
         : public_inputs(std::move(public_inputs))
         , initial_side_effect_counter(initial_side_effect_counter)
         , hints(std::move(hints))
@@ -98,7 +98,7 @@ class AvmKernelTraceBuilder {
     void op_emit_l2_to_l1_msg(uint32_t clk, uint32_t side_effect_counter, const FF& l2_to_l1_msg, const FF& recipient);
 
     // This is temporarily made public so we can access PIs
-    VmPublicInputs<FF> public_inputs;
+    VmPublicInputs public_inputs;
 
   private:
     std::vector<KernelTraceEntry> kernel_trace;

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.cpp
@@ -276,7 +276,7 @@ void AvmTraceBuilder::finalise_mem_trace_lookup_counts()
  * @brief Constructor of a trace builder of AVM. Only serves to set the capacity of the
  *        underlying traces and initialize gas values.
  */
-AvmTraceBuilder::AvmTraceBuilder(VmPublicInputs<FF> public_inputs,
+AvmTraceBuilder::AvmTraceBuilder(VmPublicInputs public_inputs,
                                  ExecutionHints execution_hints_,
                                  uint32_t side_effect_counter,
                                  std::vector<FF> calldata)

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.hpp
@@ -52,7 +52,7 @@ struct AddressWithMode {
 class AvmTraceBuilder {
 
   public:
-    AvmTraceBuilder(VmPublicInputs<FF> public_inputs = {},
+    AvmTraceBuilder(VmPublicInputs public_inputs = {},
                     ExecutionHints execution_hints = {},
                     uint32_t side_effect_counter = 0,
                     std::vector<FF> calldata = {});


### PR DESCRIPTION
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
