### PR TITLE
chore(avm): remove mem accounting from gas

### DIFF
--- a/yarn-project/simulator/src/avm/opcodes/accrued_substate.ts
+++ b/yarn-project/simulator/src/avm/opcodes/accrued_substate.ts
@@ -30,7 +30,7 @@ export class NoteHashExists extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: 2, writes: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
     const [noteHashOffset, leafIndexOffset, existsOffset] = Addressing.fromWire(this.indirect).resolve(
       [this.noteHashOffset, this.leafIndexOffset, this.existsOffset],
       memory,
@@ -66,7 +66,7 @@ export class EmitNoteHash extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [noteHashOffset] = Addressing.fromWire(this.indirect).resolve([this.noteHashOffset], memory);
     memory.checkTag(TypeTag.FIELD, noteHashOffset);
@@ -107,7 +107,7 @@ export class NullifierExists extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: 2, writes: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [nullifierOffset, addressOffset, existsOffset] = Addressing.fromWire(this.indirect).resolve(
       [this.nullifierOffset, this.addressOffset, this.existsOffset],
@@ -143,7 +143,7 @@ export class EmitNullifier extends Instruction {
 
     const memoryOperations = { reads: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [nullifierOffset] = Addressing.fromWire(this.indirect).resolve([this.nullifierOffset], memory);
     memory.checkTag(TypeTag.FIELD, nullifierOffset);
@@ -191,7 +191,7 @@ export class L1ToL2MessageExists extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: 2, writes: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [msgHashOffset, msgLeafIndexOffset, existsOffset] = Addressing.fromWire(this.indirect).resolve(
       [this.msgHashOffset, this.msgLeafIndexOffset, this.existsOffset],
@@ -241,7 +241,7 @@ export class EmitUnencryptedLog extends Instruction {
     const contractAddress = context.environment.address;
 
     const memoryOperations = { reads: 1 + logSize, indirect: this.indirect };
-    context.machineState.consumeGas(this.gasCost({ ...memoryOperations, dynMultiplier: logSize }));
+    context.machineState.consumeGas(this.gasCost(logSize));
     const log = memory.getSlice(logOffset, logSize).map(f => f.toFr());
     context.persistableState.writeUnencryptedLog(contractAddress, log);
 
@@ -267,7 +267,7 @@ export class SendL2ToL1Message extends Instruction {
 
     const memoryOperations = { reads: 2, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [recipientOffset, contentOffset] = Addressing.fromWire(this.indirect).resolve(
       [this.recipientOffset, this.contentOffset],

--- a/yarn-project/simulator/src/avm/opcodes/arithmetic.ts
+++ b/yarn-project/simulator/src/avm/opcodes/arithmetic.ts
@@ -8,7 +8,7 @@ export abstract class ThreeOperandArithmeticInstruction extends ThreeOperandInst
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: 2, writes: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [aOffset, bOffset, dstOffset] = Addressing.fromWire(this.indirect).resolve(
       [this.aOffset, this.bOffset, this.dstOffset],

--- a/yarn-project/simulator/src/avm/opcodes/bitwise.ts
+++ b/yarn-project/simulator/src/avm/opcodes/bitwise.ts
@@ -9,7 +9,7 @@ abstract class ThreeOperandBitwiseInstruction extends ThreeOperandInstruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: 2, writes: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [aOffset, bOffset, dstOffset] = Addressing.fromWire(this.indirect).resolve(
       [this.aOffset, this.bOffset, this.dstOffset],
@@ -100,7 +100,7 @@ export class Not extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: 1, writes: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [srcOffset, dstOffset] = Addressing.fromWire(this.indirect).resolve([this.srcOffset, this.dstOffset], memory);
     TaggedMemory.checkIsIntegralTag(memory.getTag(srcOffset));

--- a/yarn-project/simulator/src/avm/opcodes/commitment.ts
+++ b/yarn-project/simulator/src/avm/opcodes/commitment.ts
@@ -47,7 +47,7 @@ export class PedersenCommitment extends Instruction {
     memory.checkTag(TypeTag.UINT32, genIndexOffset);
 
     const memoryOperations = { reads: inputSize + 2, writes: 3, indirect: this.indirect };
-    context.machineState.consumeGas(this.gasCost({ ...memoryOperations, dynMultiplier: inputSize }));
+    context.machineState.consumeGas(this.gasCost(inputSize));
 
     const inputBuffer: Buffer[] = inputs.map(input => input.toBuffer());
     // TODO: Add the generate index to the pedersenCommit function

--- a/yarn-project/simulator/src/avm/opcodes/comparators.ts
+++ b/yarn-project/simulator/src/avm/opcodes/comparators.ts
@@ -8,7 +8,7 @@ abstract class ComparatorInstruction extends ThreeOperandInstruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: 2, writes: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [aOffset, bOffset, dstOffset] = Addressing.fromWire(this.indirect).resolve(
       [this.aOffset, this.bOffset, this.dstOffset],

--- a/yarn-project/simulator/src/avm/opcodes/contract.ts
+++ b/yarn-project/simulator/src/avm/opcodes/contract.ts
@@ -24,7 +24,7 @@ export class GetContractInstance extends Instruction {
   async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: 1, writes: 6, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [addressOffset, dstOffset] = Addressing.fromWire(this.indirect).resolve(
       [this.addressOffset, this.dstOffset],

--- a/yarn-project/simulator/src/avm/opcodes/control_flow.ts
+++ b/yarn-project/simulator/src/avm/opcodes/control_flow.ts
@@ -43,7 +43,7 @@ export class JumpI extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [condOffset] = Addressing.fromWire(this.indirect).resolve([this.condOffset], memory);
     const condition = memory.getAs<IntegralValue>(condOffset);

--- a/yarn-project/simulator/src/avm/opcodes/conversion.ts
+++ b/yarn-project/simulator/src/avm/opcodes/conversion.ts
@@ -38,7 +38,7 @@ export class ToRadixLE extends Instruction {
       memory,
     );
     const memoryOperations = { reads: 2, writes: this.numLimbs, indirect: this.indirect };
-    context.machineState.consumeGas(this.gasCost({ ...memoryOperations, dynMultiplier: this.numLimbs }));
+    context.machineState.consumeGas(this.gasCost(this.numLimbs));
 
     // The radix gadget only takes in a Field
     memory.checkTag(TypeTag.FIELD, srcOffset);

--- a/yarn-project/simulator/src/avm/opcodes/ec_add.ts
+++ b/yarn-project/simulator/src/avm/opcodes/ec_add.ts
@@ -40,7 +40,7 @@ export class EcAdd extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: 6, writes: 3, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [p1XOffset, p1YOffset, p1IsInfiniteOffset, p2XOffset, p2YOffset, p2IsInfiniteOffset, dstOffset] =
       Addressing.fromWire(this.indirect).resolve(

--- a/yarn-project/simulator/src/avm/opcodes/environment_getters.ts
+++ b/yarn-project/simulator/src/avm/opcodes/environment_getters.ts
@@ -73,7 +73,7 @@ export class GetEnvVar extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { writes: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [dstOffset] = Addressing.fromWire(this.indirect).resolve([this.dstOffset], memory);
 

--- a/yarn-project/simulator/src/avm/opcodes/external_calls.ts
+++ b/yarn-project/simulator/src/avm/opcodes/external_calls.ts
@@ -67,7 +67,7 @@ abstract class ExternalCall extends Instruction {
 
     // First we consume the gas for this operation.
     const memoryOperations = { reads: calldataSize + 5, writes: 1 + this.retSize, indirect: this.indirect };
-    context.machineState.consumeGas(this.gasCost({ ...memoryOperations, dynMultiplier: calldataSize + this.retSize }));
+    context.machineState.consumeGas(this.gasCost(calldataSize + this.retSize));
     // Then we consume the gas allocated for the nested call. The excess will be refunded later.
     // Gas allocation is capped by the amount of gas left in the current context.
     // We have to do some dancing here because the gas allocation is a field,
@@ -170,7 +170,7 @@ export class Return extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: this.copySize, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost({ ...memoryOperations, dynMultiplier: this.copySize }));
+    context.machineState.consumeGas(this.gasCost(this.copySize));
 
     const [returnOffset] = Addressing.fromWire(this.indirect).resolve([this.returnOffset], memory);
 
@@ -205,7 +205,7 @@ export class Revert extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: this.retSize, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost({ ...memoryOperations, dynMultiplier: this.retSize }));
+    context.machineState.consumeGas(this.gasCost(this.retSize));
 
     const [returnOffset] = Addressing.fromWire(this.indirect).resolve([this.returnOffset], memory);
 

--- a/yarn-project/simulator/src/avm/opcodes/hashing.ts
+++ b/yarn-project/simulator/src/avm/opcodes/hashing.ts
@@ -35,7 +35,7 @@ export class Poseidon2 extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: Poseidon2.stateSize, writes: Poseidon2.stateSize, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [inputOffset, outputOffset] = Addressing.fromWire(this.indirect).resolve(
       [this.inputStateOffset, this.outputStateOffset],
@@ -87,7 +87,7 @@ export class Keccak extends Instruction {
     memory.checkTag(TypeTag.UINT32, messageSizeOffset);
     const messageSize = memory.get(messageSizeOffset).toNumber();
     const memoryOperations = { reads: messageSize + 1, writes: 32, indirect: this.indirect };
-    context.machineState.consumeGas(this.gasCost({ ...memoryOperations, dynMultiplier: messageSize }));
+    context.machineState.consumeGas(this.gasCost(messageSize));
 
     memory.checkTagsRange(TypeTag.UINT8, messageOffset, messageSize);
 
@@ -137,7 +137,7 @@ export class KeccakF1600 extends Instruction {
     const stateSize = memory.get(stateSizeOffset).toNumber();
     assert(stateSize === 25, 'Invalid state size for keccakf1600');
     const memoryOperations = { reads: stateSize + 1, writes: 25, indirect: this.indirect };
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     memory.checkTagsRange(TypeTag.UINT64, stateOffset, stateSize);
 
@@ -200,7 +200,7 @@ export class Sha256Compression extends Instruction {
     // +2 to account for both size offsets (stateSizeOffset and inputsSizeOffset)
     // Note: size of output is same as size of state
     const memoryOperations = { reads: stateSize + inputsSize + 2, writes: stateSize, indirect: this.indirect };
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
     memory.checkTagsRange(TypeTag.UINT32, inputsOffset, inputsSize);
     memory.checkTagsRange(TypeTag.UINT32, stateOffset, stateSize);
 
@@ -256,7 +256,7 @@ export class Pedersen extends Instruction {
     const hashData = memory.getSlice(messageOffset, messageSize);
 
     const memoryOperations = { reads: messageSize + 2, writes: 1, indirect: this.indirect };
-    context.machineState.consumeGas(this.gasCost({ ...memoryOperations, dynMultiplier: messageSize }));
+    context.machineState.consumeGas(this.gasCost(messageSize));
 
     memory.checkTagsRange(TypeTag.FIELD, messageOffset, messageSize);
 

--- a/yarn-project/simulator/src/avm/opcodes/instruction.ts
+++ b/yarn-project/simulator/src/avm/opcodes/instruction.ts
@@ -2,7 +2,6 @@ import { strict as assert } from 'assert';
 
 import type { AvmContext } from '../avm_context.js';
 import { getBaseGasCost, getDynamicGasCost, mulGas, sumGas } from '../avm_gas.js';
-import { type MemoryOperations } from '../avm_memory_types.js';
 import { type BufferCursor } from '../serialization/buffer_cursor.js';
 import { type Serializable } from '../serialization/bytecode_serialization.js';
 import { Opcode, type OperandType, deserialize, serializeAs } from '../serialization/instruction_serialization.js';
@@ -86,17 +85,11 @@ export abstract class Instruction {
 
   /**
    * Computes gas cost for the instruction based on its base cost and memory operations.
-   * @param memoryOps Memory operations performed by the instruction.
    * @returns Gas cost.
    */
-  protected gasCost(ops: Partial<MemoryOperations & { indirect: number; dynMultiplier: number }> = {}) {
+  protected gasCost(dynMultiplier: number = 0) {
     const baseGasCost = getBaseGasCost(this.opcode);
-    // TODO: We are using a simplified gas model to reduce complexity in the circuit.
-    // Memory accounting will probably be removed.
-    // TODO(https://github.com/AztecProtocol/aztec-packages/issues/6861): reconsider.
-    // const memoryGasCost = getMemoryGasCost(memoryOps);
-    // const memoryGasCost = { l2Gas: 0, daGas: 0 };
-    const dynGasCost = mulGas(getDynamicGasCost(this.opcode), ops.dynMultiplier ?? 0);
+    const dynGasCost = mulGas(getDynamicGasCost(this.opcode), dynMultiplier);
     return sumGas(baseGasCost, dynGasCost);
   }
 

--- a/yarn-project/simulator/src/avm/opcodes/memory.ts
+++ b/yarn-project/simulator/src/avm/opcodes/memory.ts
@@ -64,7 +64,7 @@ export class Set extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { writes: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [dstOffset] = Addressing.fromWire(this.indirect).resolve([this.dstOffset], memory);
     const res = TaggedMemory.buildFromTagTruncating(this.value, this.inTag);
@@ -101,7 +101,7 @@ export class CMov extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: 3, writes: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [aOffset, bOffset, condOffset, dstOffset] = Addressing.fromWire(this.indirect).resolve(
       [this.aOffset, this.bOffset, this.condOffset, this.dstOffset],
@@ -146,7 +146,7 @@ export class Cast extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: 1, writes: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [srcOffset, dstOffset] = Addressing.fromWire(this.indirect).resolve([this.srcOffset, this.dstOffset], memory);
 
@@ -185,7 +185,7 @@ export class Mov extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { reads: 1, writes: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const [srcOffset, dstOffset] = Addressing.fromWire(this.indirect).resolve([this.srcOffset, this.dstOffset], memory);
 
@@ -230,7 +230,7 @@ export class CalldataCopy extends Instruction {
     const cdStart = memory.get(cdStartOffset).toNumber();
     const copySize = memory.get(copySizeOffset).toNumber();
     const memoryOperations = { reads: 2, writes: copySize, indirect: this.indirect };
-    context.machineState.consumeGas(this.gasCost({ ...memoryOperations, dynMultiplier: copySize }));
+    context.machineState.consumeGas(this.gasCost(copySize));
 
     const transformedData = context.environment.calldata.slice(cdStart, cdStart + copySize).map(f => new Field(f));
 

--- a/yarn-project/simulator/src/avm/opcodes/misc.ts
+++ b/yarn-project/simulator/src/avm/opcodes/misc.ts
@@ -43,7 +43,7 @@ export class DebugLog extends Instruction {
     memory.checkTagsRange(TypeTag.FIELD, fieldsOffset, fieldsSize);
 
     const memoryOperations = { reads: 1 + fieldsSize + this.messageSize, writes: 0, indirect: this.indirect };
-    context.machineState.consumeGas(this.gasCost(memoryOperations));
+    context.machineState.consumeGas(this.gasCost());
 
     const rawMessage = memory.getSlice(messageOffset, this.messageSize);
     const fields = memory.getSlice(fieldsOffset, fieldsSize);

--- a/yarn-project/simulator/src/avm/opcodes/multi_scalar_mul.ts
+++ b/yarn-project/simulator/src/avm/opcodes/multi_scalar_mul.ts
@@ -68,7 +68,7 @@ export class MultiScalarMul extends Instruction {
       writes: 3 /* output triplet */,
       indirect: this.indirect,
     };
-    context.machineState.consumeGas(this.gasCost({ ...memoryOperations, dynMultiplier: pointsReadLength }));
+    context.machineState.consumeGas(this.gasCost(pointsReadLength));
     // Get the unrolled scalar (lo & hi) representing the scalars
     const scalarsVector = memory.getSlice(scalarsOffset, scalarReadLength);
     memory.checkTagsRange(TypeTag.FIELD, scalarsOffset, scalarReadLength);

--- a/yarn-project/simulator/src/avm/opcodes/storage.ts
+++ b/yarn-project/simulator/src/avm/opcodes/storage.ts
@@ -34,7 +34,7 @@ export class SStore extends BaseStorageInstruction {
 
     const memoryOperations = { reads: 2, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost({ ...memoryOperations }));
+    context.machineState.consumeGas(this.gasCost());
 
     const [srcOffset, slotOffset] = Addressing.fromWire(this.indirect).resolve([this.aOffset, this.bOffset], memory);
     memory.checkTag(TypeTag.FIELD, slotOffset);
@@ -60,7 +60,7 @@ export class SLoad extends BaseStorageInstruction {
   public async execute(context: AvmContext): Promise<void> {
     const memoryOperations = { writes: 1, reads: 1, indirect: this.indirect };
     const memory = context.machineState.memory.track(this.type);
-    context.machineState.consumeGas(this.gasCost({ ...memoryOperations }));
+    context.machineState.consumeGas(this.gasCost());
 
     const [slotOffset, dstOffset] = Addressing.fromWire(this.indirect).resolve([this.aOffset, this.bOffset], memory);
     memory.checkTag(TypeTag.FIELD, slotOffset);


### PR DESCRIPTION
We are not using it, and it's a required simplification to make relative addressing easier.
