### PR TITLE
chore: reduce number of gates in stdlib/sha256 hash function

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.cpp
@@ -213,6 +213,10 @@ field_t<Builder> majority(sparse_value<Builder>& a, const sparse_value<Builder>&
 
     field_pt rotation_result =
         lookup[ColumnIdx::C3][0]; // last index of first row gives accumulating sum of "non-trival" wraps
+<<<<<<< HEAD
+=======
+
+>>>>>>> 4df65a2a27 (optimization for stdlib sha256 function)
     a.sparse = lookup[ColumnIdx::C2][0];
     // use these values to compute trivial wraps somehow
     field_pt sparse_accumulator_2 = lookup[ColumnIdx::C2][1];
@@ -271,11 +275,26 @@ std::array<field_t<Builder>, 8> sha256_block(const std::array<field_t<Builder>, 
     /**
      * Initialize round variables with previous block output
      **/
+<<<<<<< HEAD
     auto a = map_into_maj_sparse_form(h_init[0]);
     auto b = map_into_maj_sparse_form(h_init[1]);
     auto c = map_into_maj_sparse_form(h_init[2]);
     auto d = map_into_maj_sparse_form(h_init[3]);
     auto e = map_into_choose_sparse_form(h_init[4]);
+=======
+    /**
+     * We can initialize round variables a and c and put value h_init[0] and
+     * h_init[4] in .normal, and don't do lookup for maj_output, because majority and choose
+     * functions will do that next step
+     **/
+    sparse_value<Builder> a = sparse_value<Builder>();
+    a.normal = h_init[0];
+    auto b = map_into_maj_sparse_form(h_init[1]);
+    auto c = map_into_maj_sparse_form(h_init[2]);
+    auto d = map_into_maj_sparse_form(h_init[3]);
+    sparse_value<Builder> e = sparse_value<Builder>();
+    e.normal = h_init[4];
+>>>>>>> 4df65a2a27 (optimization for stdlib sha256 function)
     auto f = map_into_choose_sparse_form(h_init[5]);
     auto g = map_into_choose_sparse_form(h_init[6]);
     auto h = map_into_choose_sparse_form(h_init[7]);

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.cpp
@@ -213,10 +213,6 @@ field_t<Builder> majority(sparse_value<Builder>& a, const sparse_value<Builder>&
 
     field_pt rotation_result =
         lookup[ColumnIdx::C3][0]; // last index of first row gives accumulating sum of "non-trival" wraps
-<<<<<<< HEAD
-=======
-
->>>>>>> 4df65a2a27 (optimization for stdlib sha256 function)
     a.sparse = lookup[ColumnIdx::C2][0];
     // use these values to compute trivial wraps somehow
     field_pt sparse_accumulator_2 = lookup[ColumnIdx::C2][1];
@@ -278,15 +274,13 @@ std::array<field_t<Builder>, 8> sha256_block(const std::array<field_t<Builder>, 
     /**
      * We can initialize round variables a and c and put value h_init[0] and
      * h_init[4] in .normal, and don't do lookup for maj_output, because majority and choose
-     * functions will do that next step
+     * functions will do that in the next step
      **/
-    sparse_value<Builder> a = sparse_value<Builder>();
-    a.normal = h_init[0];
+    sparse_value<Builder> a = sparse_value<Builder>(h_init[0]);
     auto b = map_into_maj_sparse_form(h_init[1]);
     auto c = map_into_maj_sparse_form(h_init[2]);
     auto d = map_into_maj_sparse_form(h_init[3]);
-    sparse_value<Builder> e = sparse_value<Builder>();
-    e.normal = h_init[4];
+    sparse_value<Builder> e = sparse_value<Builder>(h_init[4]);
     auto f = map_into_choose_sparse_form(h_init[5]);
     auto g = map_into_choose_sparse_form(h_init[6]);
     auto h = map_into_choose_sparse_form(h_init[7]);

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.cpp
@@ -275,13 +275,6 @@ std::array<field_t<Builder>, 8> sha256_block(const std::array<field_t<Builder>, 
     /**
      * Initialize round variables with previous block output
      **/
-<<<<<<< HEAD
-    auto a = map_into_maj_sparse_form(h_init[0]);
-    auto b = map_into_maj_sparse_form(h_init[1]);
-    auto c = map_into_maj_sparse_form(h_init[2]);
-    auto d = map_into_maj_sparse_form(h_init[3]);
-    auto e = map_into_choose_sparse_form(h_init[4]);
-=======
     /**
      * We can initialize round variables a and c and put value h_init[0] and
      * h_init[4] in .normal, and don't do lookup for maj_output, because majority and choose
@@ -294,7 +287,6 @@ std::array<field_t<Builder>, 8> sha256_block(const std::array<field_t<Builder>, 
     auto d = map_into_maj_sparse_form(h_init[3]);
     sparse_value<Builder> e = sparse_value<Builder>();
     e.normal = h_init[4];
->>>>>>> 4df65a2a27 (optimization for stdlib sha256 function)
     auto f = map_into_choose_sparse_form(h_init[5]);
     auto g = map_into_choose_sparse_form(h_init[6]);
     auto h = map_into_choose_sparse_form(h_init[7]);

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.hpp
@@ -77,10 +77,6 @@ template <typename Builder>
 field_t<Builder> choose(sparse_value<Builder>& e, const sparse_value<Builder>& f, const sparse_value<Builder>& g);
 template <typename Builder>
 field_t<Builder> majority(sparse_value<Builder>& a, const sparse_value<Builder>& b, const sparse_value<Builder>& c);
-<<<<<<< HEAD
-
-=======
->>>>>>> 4df65a2a27 (optimization for stdlib sha256 function)
 template <typename Builder>
 std::array<field_t<Builder>, 8> sha256_block(const std::array<field_t<Builder>, 8>& h_init,
                                              const std::array<field_t<Builder>, 16>& input);

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.hpp
@@ -77,6 +77,7 @@ template <typename Builder>
 field_t<Builder> choose(sparse_value<Builder>& e, const sparse_value<Builder>& f, const sparse_value<Builder>& g);
 template <typename Builder>
 field_t<Builder> majority(sparse_value<Builder>& a, const sparse_value<Builder>& b, const sparse_value<Builder>& c);
+
 template <typename Builder>
 std::array<field_t<Builder>, 8> sha256_block(const std::array<field_t<Builder>, 8>& h_init,
                                              const std::array<field_t<Builder>, 16>& input);

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256_plookup.hpp
@@ -77,7 +77,10 @@ template <typename Builder>
 field_t<Builder> choose(sparse_value<Builder>& e, const sparse_value<Builder>& f, const sparse_value<Builder>& g);
 template <typename Builder>
 field_t<Builder> majority(sparse_value<Builder>& a, const sparse_value<Builder>& b, const sparse_value<Builder>& c);
+<<<<<<< HEAD
 
+=======
+>>>>>>> 4df65a2a27 (optimization for stdlib sha256 function)
 template <typename Builder>
 std::array<field_t<Builder>, 8> sha256_block(const std::array<field_t<Builder>, 8>& h_init,
                                              const std::array<field_t<Builder>, 16>& input);


### PR DESCRIPTION
We can reduce number of gates for round variables a and e in sha256.

At the start of the round variables a and e were converted in maj and ch form respectively. But after that their .sparse form was replaced in functions majority and choose with the same values, and this procedure added some unnecessary gates.

We can fix this by just initializing a and e using default constructors and put in .normal part values of h_init[0] and h_init[4]. After that functions majority and choose will add in .sparse values of lookup automatically

All tests for stdlib/sha256 have passed after this patch. As a result, number of gates from sha256_nist_vector_five were reduced from 65194 to 65104.
