### PR TITLE
fix: reenable CI reruns on master

### DIFF
--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,5 +1,5 @@
 # adapted from https://github.com/orgs/community/discussions/67654
-# altered to not rerun if we are not the newest commit in the run's branch
+# altered to not rerun if we are not the newest commit in the run's branch (exception for master/main)
 on:
   workflow_dispatch:
     inputs:
@@ -44,8 +44,8 @@ jobs:
           LATEST_COMMIT_SHA=$(gh api repos/${{ github.repository }}/commits/$BRANCH_NAME --jq .sha)
 
           # Compare the SHAs
-          if [[ "$COMMIT_SHA" != "$LATEST_COMMIT_SHA" ]]; then
-            echo "Commit $COMMIT_SHA is not the latest commit on branch $BRANCH_NAME (latest is $LATEST_COMMIT_SHA). Skipping rerun."
+          if [[ "$COMMIT_SHA" != "$LATEST_COMMIT_SHA" ]] && [[ "$BRANCH_NAME" != "master" && "$BRANCH_NAME" != "main" ]] ; then
+            echo "Commit $COMMIT_SHA is not the latest commit on branch $BRANCH_NAME (latest is $LATEST_COMMIT_SHA) and the branch is not master/main. Skipping rerun."
           else
             echo "Commit $COMMIT_SHA is the latest on branch $BRANCH_NAME. Proceeding with rerun."
             gh run rerun ${{ inputs.run_id }} --failed


### PR DESCRIPTION
Master typically has a commit already in by the time one finishes with fail status, so exempt it from the logic here that is meant to make PRs behave sanely. this also means the slack message will work again