### PR TITLE
fix: remove extra `crate::`

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/types/src/address/aztec_address.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/address/aztec_address.nr
@@ -1,5 +1,5 @@
 use crate::{
-    crate::address::{partial_address::PartialAddress, public_keys_hash::PublicKeysHash},
+    address::{partial_address::PartialAddress, public_keys_hash::PublicKeysHash},
     constants::{AZTEC_ADDRESS_LENGTH, GENERATOR_INDEX__CONTRACT_ADDRESS_V1},
     hash::poseidon2_hash_with_separator, traits::{Empty, FromField, ToField, Serialize, Deserialize},
     utils


### PR DESCRIPTION
The handwritten parser errors on it (like Rust errors on it) so this is blocking the handwritten parser.