### PR TITLE
fix: specify correct env var in prover node helm

### DIFF
--- a/spartan/aztec-network/templates/prover-node.yaml
+++ b/spartan/aztec-network/templates/prover-node.yaml
@@ -72,7 +72,7 @@ spec:
             - name: PROVER_PUBLISHER_PRIVATE_KEY
               value: "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97"
             # get private proofs from the boot node
-            - name: TX_PROVIDER_NODE_URL
+            - name: PROVER_COORDINATION_NODE_URL
               value: {{ include "aztec-network.bootNodeUrl" . | quote }}
             # prover agent gets jobs from itself
             - name: AZTEC_NODE_URL


### PR DESCRIPTION
I changed the name of this config the other day. 