### PR TITLE
fix: Call generate-variants on noir-projects bootstrap fast

### DIFF
--- a/noir-projects/bootstrap_cache.sh
+++ b/noir-projects/bootstrap_cache.sh
@@ -14,3 +14,4 @@ remove_old_images noir-projects
 yarn
 
 ./mock-protocol-circuits/bootstrap.sh
+(cd ./noir-protocol-circuits && yarn && node ./scripts/generate_variants.js)


### PR DESCRIPTION
Running bootstrap fast on a clean repo would fail to generate the `private-kernel-reset-dimensions.json` file which was required during the generate step of `yarn-project`.
