### PR TITLE
chore: Remove unused methods and small state cleanup

### DIFF
--- a/barretenberg/cpp/src/barretenberg/honk/proof_system/permutation_library.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/proof_system/permutation_library.hpp
@@ -26,10 +26,10 @@ namespace bb {
 template <typename Flavor> void compute_concatenated_polynomials(typename Flavor::ProverPolynomials& polynomials)
 {
     // Concatenation groups are vectors of polynomials that are concatenated together
-    auto concatenation_groups = polynomials.get_concatenation_groups();
+    auto concatenation_groups = polynomials.get_groups_to_be_concatenated();
 
     // Resulting concatenated polynomials
-    auto targets = polynomials.get_concatenated_constraints();
+    auto targets = polynomials.get_concatenated();
 
     // Targets have to be full-sized polynomials. We can compute the mini circuit size from them by dividing by
     // concatenation index
@@ -116,7 +116,7 @@ void compute_translator_range_constraint_ordered_polynomials(typename Flavor::Pr
     std::vector<size_t> extra_denominator_uint(full_circuit_size);
 
     // Get information which polynomials need to be concatenated
-    auto concatenation_groups = polynomials.get_concatenation_groups();
+    auto concatenation_groups = polynomials.get_groups_to_be_concatenated();
 
     // A function that transfers elements from each of the polynomials in the chosen concatenation group in the uint
     // ordered polynomials

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
@@ -125,8 +125,8 @@ std::array<typename Flavor::GroupElement, 2> TranslatorRecursiveVerifier_<Flavor
                                            multivariate_challenge,
                                            Commitment::one(builder),
                                            transcript,
-                                           commitments.get_concatenation_groups(),
-                                           claimed_evaluations.get_concatenated_constraints());
+                                           commitments.get_groups_to_be_concatenated(),
+                                           claimed_evaluations.get_concatenated());
     auto pairing_points = PCS::reduce_verify(opening_claim, transcript);
 
     return pairing_points;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
@@ -224,8 +224,8 @@ TEST_F(TranslatorRelationCorrectnessTests, DeltaRangeConstraint)
                    prover_polynomials.ordered_range_constraints_0.coeffs().begin(),
                    [](uint64_t in) { return FF(in); });
 
-    // Copy the same polynomial into the 4 other ordered polynomials (they are not the same in an actual proof, but we
-    // only need to check the correctness of the relation and it acts independently on each polynomial)
+    // Copy the same polynomial into the 4 other ordered polynomials (they are not the same in an actual proof, but
+    // we only need to check the correctness of the relation and it acts independently on each polynomial)
     parallel_for(4, [&](size_t i) {
         std::copy(prover_polynomials.ordered_range_constraints_0.coeffs().begin(),
                   prover_polynomials.ordered_range_constraints_0.coeffs().end(),

--- a/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
@@ -43,6 +43,7 @@ TEST_F(TranslatorRelationCorrectnessTests, Permutation)
     using Flavor = TranslatorFlavor;
     using FF = typename Flavor::FF;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
+    using ProvingKey = typename Flavor::ProvingKey;
     using Polynomial = bb::Polynomial<FF>;
     auto& engine = numeric::get_debug_randomness();
     const size_t mini_circuit_size = 2048;
@@ -56,7 +57,9 @@ TEST_F(TranslatorRelationCorrectnessTests, Permutation)
     params.gamma = gamma;
 
     // Create storage for polynomials
-    ProverPolynomials prover_polynomials;
+    auto proving_key = std::make_shared<ProvingKey>();
+
+    ProverPolynomials& prover_polynomials = proving_key->polynomials;
     // ensure we can shift these
     for (Polynomial& prover_poly : prover_polynomials.get_to_be_shifted()) {
         prover_poly = Polynomial::shiftable(full_circuit_size);
@@ -147,7 +150,7 @@ TEST_F(TranslatorRelationCorrectnessTests, Permutation)
     compute_translator_range_constraint_ordered_polynomials<Flavor>(prover_polynomials, mini_circuit_size);
 
     // Compute the fixed numerator (part of verification key)
-    prover_polynomials.compute_extra_range_constraint_numerator();
+    proving_key->compute_extra_range_constraint_numerator();
 
     // Compute concatenated polynomials (4 polynomials produced from other constraint polynomials by concatenation)
     compute_concatenated_polynomials<Flavor>(prover_polynomials);

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -128,65 +128,6 @@ class TranslatorFlavor {
                               lagrange_even_in_minicircuit,            // column 4
                               lagrange_second,                         // column 5
                               lagrange_second_to_last_in_minicircuit); // column 6
-        auto get_selectors() { return RefArray<DataType, 0>{}; };
-        auto get_sigma_polynomials() { return RefArray<DataType, 0>{}; };
-        auto get_id_polynomials() { return RefArray<DataType, 0>{}; };
-
-        inline void compute_lagrange_polynomials(const CircuitBuilder& builder)
-        {
-            const size_t mini_circuit_dyadic_size = compute_mini_circuit_dyadic_size(builder);
-
-            for (size_t i = 1; i < mini_circuit_dyadic_size - 1; i += 2) {
-                this->lagrange_odd_in_minicircuit.at(i) = 1;
-                this->lagrange_even_in_minicircuit.at(i + 1) = 1;
-            }
-            this->lagrange_second.at(1) = 1;
-            this->lagrange_second_to_last_in_minicircuit.at(mini_circuit_dyadic_size - 2) = 1;
-        }
-
-        /**
-         * @brief Compute the extra numerator for Goblin range constraint argument
-         *
-         * @details Goblin proves that several polynomials contain only values in a certain range through 2 relations:
-         * 1) A grand product which ignores positions of elements (TranslatorPermutationRelation)
-         * 2) A relation enforcing a certain ordering on the elements of the given polynomial
-         * (TranslatorDeltaRangeConstraintRelation)
-         *
-         * We take the values from 4 polynomials, and spread them into 5 polynomials + add all the steps from MAX_VALUE
-         * to 0. We order these polynomials and use them in the denominator of the grand product, at the same time
-         * checking that they go from MAX_VALUE to 0. To counteract the added steps we also generate an extra range
-         * constraint numerator, which contains 5 MAX_VALUE, 5 (MAX_VALUE-STEP),... values
-         *
-         */
-        inline void compute_extra_range_constraint_numerator()
-        {
-            auto& extra_range_constraint_numerator = this->ordered_extra_range_constraints_numerator;
-
-            static constexpr uint32_t MAX_VALUE = (1 << MICRO_LIMB_BITS) - 1;
-
-            // Calculate how many elements there are in the sequence MAX_VALUE, MAX_VALUE - 3,...,0
-            size_t sorted_elements_count = (MAX_VALUE / SORT_STEP) + 1 + (MAX_VALUE % SORT_STEP == 0 ? 0 : 1);
-
-            // Check that we can fit every element in the polynomial
-            ASSERT((NUM_CONCATENATED_WIRES + 1) * sorted_elements_count < extra_range_constraint_numerator.size());
-
-            std::vector<size_t> sorted_elements(sorted_elements_count);
-
-            // Calculate the sequence in integers
-            sorted_elements[0] = MAX_VALUE;
-            for (size_t i = 1; i < sorted_elements_count; i++) {
-                sorted_elements[i] = (sorted_elements_count - 1 - i) * SORT_STEP;
-            }
-
-            // TODO(#756): can be parallelized further. This will use at most 5 threads
-            auto fill_with_shift = [&](size_t shift) {
-                for (size_t i = 0; i < sorted_elements_count; i++) {
-                    extra_range_constraint_numerator.at(shift + i * (NUM_CONCATENATED_WIRES + 1)) = sorted_elements[i];
-                }
-            };
-            // Fill polynomials with a sequence, where each element is repeated NUM_CONCATENATED_WIRES+1 times
-            parallel_for(NUM_CONCATENATED_WIRES + 1, fill_with_shift);
-        }
     };
 
     template <typename DataType> class ConcatenatedRangeConstraints {
@@ -356,14 +297,6 @@ class TranslatorFlavor {
                                DerivedWitnessEntities<DataType>::get_all(),
                                ConcatenatedRangeConstraints<DataType>::get_all());
         }
-        std::vector<std::string> get_unshifted_labels()
-        {
-            return concatenate(WireNonshiftedEntities<DataType>::get_labels(),
-                               WireToBeShiftedEntities<DataType>::get_labels(),
-                               OrderedRangeConstraints<DataType>::get_labels(),
-                               DerivedWitnessEntities<DataType>::get_labels(),
-                               ConcatenatedRangeConstraints<DataType>::get_labels());
-        }
         auto get_to_be_shifted()
         {
             return concatenate(WireToBeShiftedEntities<DataType>::get_all(),
@@ -372,18 +305,16 @@ class TranslatorFlavor {
         };
 
         /**
-         * @brief Get the polynomials that need to be constructed from other polynomials by concatenation
+         * @brief Getter for entities constructed by concatenation
          *
-         * @return auto
          */
-        auto get_concatenated_constraints() { return ConcatenatedRangeConstraints<DataType>::get_all(); }
+        auto get_concatenated() { return ConcatenatedRangeConstraints<DataType>::get_all(); }
 
         /**
          * @brief Get the polynomials that are concatenated for the permutation relation
          *
-         * @return std::vector<auto>
          */
-        std::vector<RefVector<DataType>> get_concatenation_groups()
+        std::vector<RefVector<DataType>> get_groups_to_be_concatenated()
         {
             return {
                 {
@@ -582,112 +513,21 @@ class TranslatorFlavor {
         auto get_precomputed() { return PrecomputedEntities<DataType>::get_all(); };
 
         /**
-         * @brief Get the polynomials that are concatenated for the permutation relation
+         * @brief Get the polynomials concatenated for the permutation relation
          *
-         * @return std::vector<auto>
+         * @details Each group is concatenated into a single polynomial
          */
-        std::vector<RefVector<DataType>> get_concatenation_groups()
+        std::vector<RefVector<DataType>> get_groups_to_be_concatenated()
         {
-            return {
-                {
-                    this->p_x_low_limbs_range_constraint_0,
-                    this->p_x_low_limbs_range_constraint_1,
-                    this->p_x_low_limbs_range_constraint_2,
-                    this->p_x_low_limbs_range_constraint_3,
-                    this->p_x_low_limbs_range_constraint_4,
-                    this->p_x_low_limbs_range_constraint_tail,
-                    this->p_x_high_limbs_range_constraint_0,
-                    this->p_x_high_limbs_range_constraint_1,
-                    this->p_x_high_limbs_range_constraint_2,
-                    this->p_x_high_limbs_range_constraint_3,
-                    this->p_x_high_limbs_range_constraint_4,
-                    this->p_x_high_limbs_range_constraint_tail,
-                    this->p_y_low_limbs_range_constraint_0,
-                    this->p_y_low_limbs_range_constraint_1,
-                    this->p_y_low_limbs_range_constraint_2,
-                    this->p_y_low_limbs_range_constraint_3,
-                },
-                {
-                    this->p_y_low_limbs_range_constraint_4,
-                    this->p_y_low_limbs_range_constraint_tail,
-                    this->p_y_high_limbs_range_constraint_0,
-                    this->p_y_high_limbs_range_constraint_1,
-                    this->p_y_high_limbs_range_constraint_2,
-                    this->p_y_high_limbs_range_constraint_3,
-                    this->p_y_high_limbs_range_constraint_4,
-                    this->p_y_high_limbs_range_constraint_tail,
-                    this->z_low_limbs_range_constraint_0,
-                    this->z_low_limbs_range_constraint_1,
-                    this->z_low_limbs_range_constraint_2,
-                    this->z_low_limbs_range_constraint_3,
-                    this->z_low_limbs_range_constraint_4,
-                    this->z_low_limbs_range_constraint_tail,
-                    this->z_high_limbs_range_constraint_0,
-                    this->z_high_limbs_range_constraint_1,
-                },
-                {
-                    this->z_high_limbs_range_constraint_2,
-                    this->z_high_limbs_range_constraint_3,
-                    this->z_high_limbs_range_constraint_4,
-                    this->z_high_limbs_range_constraint_tail,
-                    this->accumulator_low_limbs_range_constraint_0,
-                    this->accumulator_low_limbs_range_constraint_1,
-                    this->accumulator_low_limbs_range_constraint_2,
-                    this->accumulator_low_limbs_range_constraint_3,
-                    this->accumulator_low_limbs_range_constraint_4,
-                    this->accumulator_low_limbs_range_constraint_tail,
-                    this->accumulator_high_limbs_range_constraint_0,
-                    this->accumulator_high_limbs_range_constraint_1,
-                    this->accumulator_high_limbs_range_constraint_2,
-                    this->accumulator_high_limbs_range_constraint_3,
-                    this->accumulator_high_limbs_range_constraint_4,
-                    this->accumulator_high_limbs_range_constraint_tail,
-                },
-                {
-                    this->quotient_low_limbs_range_constraint_0,
-                    this->quotient_low_limbs_range_constraint_1,
-                    this->quotient_low_limbs_range_constraint_2,
-                    this->quotient_low_limbs_range_constraint_3,
-                    this->quotient_low_limbs_range_constraint_4,
-                    this->quotient_low_limbs_range_constraint_tail,
-                    this->quotient_high_limbs_range_constraint_0,
-                    this->quotient_high_limbs_range_constraint_1,
-                    this->quotient_high_limbs_range_constraint_2,
-                    this->quotient_high_limbs_range_constraint_3,
-                    this->quotient_high_limbs_range_constraint_4,
-                    this->quotient_high_limbs_range_constraint_tail,
-                    this->relation_wide_limbs_range_constraint_0,
-                    this->relation_wide_limbs_range_constraint_1,
-                    this->relation_wide_limbs_range_constraint_2,
-                    this->relation_wide_limbs_range_constraint_3,
-                },
-            };
+            return WitnessEntities<DataType>::get_groups_to_be_concatenated();
         }
         /**
          * @brief Get the polynomials that need to be constructed from other polynomials by concatenation
          *
          * @return auto
          */
-        auto get_concatenated_constraints() { return ConcatenatedRangeConstraints<DataType>::get_all(); };
-        /**
-         * @brief Get the polynomials from the grand product denominator
-         *
-         * @return auto
-         */
-        auto get_ordered_constraints()
-        {
-            return RefArray{ this->ordered_range_constraints_0,
-                             this->ordered_range_constraints_1,
-                             this->ordered_range_constraints_2,
-                             this->ordered_range_constraints_3,
-                             this->ordered_range_constraints_4 };
-        };
+        auto get_concatenated() { return ConcatenatedRangeConstraints<DataType>::get_all(); };
 
-        // Gemini-specific getters.
-        auto get_unshifted()
-        {
-            return concatenate(PrecomputedEntities<DataType>::get_all(), WitnessEntities<DataType>::get_unshifted());
-        }
         // everything but ConcatenatedRangeConstraints (used for ZeroMorph input since concatenated handled separately)
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/810)
         auto get_unshifted_without_concatenated()
@@ -698,29 +538,12 @@ class TranslatorFlavor {
         // get_to_be_shifted is inherited
         auto get_shifted() { return ShiftedEntities<DataType>::get_all(); };
         // this getter is necessary for more uniform zk verifiers
-        auto get_shifted_witnesses() { return ShiftedEntities<DataType>::get_all(); };
+        auto get_shifted_witnesses() { return get_shifted(); };
         auto get_wires_and_ordered_range_constraints()
         {
             return WitnessEntities<DataType>::get_wires_and_ordered_range_constraints();
         };
 
-        /**
-         * @brief Polynomials/commitments, that can be constructed only after the r challenge has been received from
-         * gemini
-         *
-         * @return auto
-         */
-        auto get_special() { return get_concatenated_constraints(); }
-
-        auto get_unshifted_then_shifted_then_special()
-        {
-            auto result{ this->get_unshifted() };
-            auto shifted{ get_shifted() };
-            auto special{ get_special() };
-            result.insert(result.end(), shifted.begin(), shifted.end());
-            result.insert(result.end(), special.begin(), special.end());
-            return result;
-        }
         // Get witness polynomials including shifts. This getter is required by ZK-Sumcheck.
         auto get_all_witnesses()
         {
@@ -854,11 +677,67 @@ class TranslatorFlavor {
 
             // Compute polynomials with odd and even indices set to 1 up to the minicircuit margin + lagrange
             // polynomials at second and second to last indices in the minicircuit
-            polynomials.compute_lagrange_polynomials(builder);
+            compute_lagrange_polynomials(builder);
 
             // Compute the numerator for the permutation argument with several repetitions of steps bridging 0 and
             // maximum range constraint compute_extra_range_constraint_numerator();
-            polynomials.compute_extra_range_constraint_numerator();
+            compute_extra_range_constraint_numerator();
+        }
+
+        inline void compute_lagrange_polynomials(const CircuitBuilder& builder)
+        {
+            const size_t mini_circuit_dyadic_size = compute_mini_circuit_dyadic_size(builder);
+
+            for (size_t i = 1; i < mini_circuit_dyadic_size - 1; i += 2) {
+                polynomials.lagrange_odd_in_minicircuit.at(i) = 1;
+                polynomials.lagrange_even_in_minicircuit.at(i + 1) = 1;
+            }
+            polynomials.lagrange_second.at(1) = 1;
+            polynomials.lagrange_second_to_last_in_minicircuit.at(mini_circuit_dyadic_size - 2) = 1;
+        }
+
+        /**
+         * @brief Compute the extra numerator for Goblin range constraint argument
+         *
+         * @details Goblin proves that several polynomials contain only values in a certain range through 2 relations:
+         * 1) A grand product which ignores positions of elements (TranslatorPermutationRelation)
+         * 2) A relation enforcing a certain ordering on the elements of the given polynomial
+         * (TranslatorDeltaRangeConstraintRelation)
+         *
+         * We take the values from 4 polynomials, and spread them into 5 polynomials + add all the steps from MAX_VALUE
+         * to 0. We order these polynomials and use them in the denominator of the grand product, at the same time
+         * checking that they go from MAX_VALUE to 0. To counteract the added steps we also generate an extra range
+         * constraint numerator, which contains 5 MAX_VALUE, 5 (MAX_VALUE-STEP),... values
+         *
+         */
+        inline void compute_extra_range_constraint_numerator()
+        {
+            auto& extra_range_constraint_numerator = polynomials.ordered_extra_range_constraints_numerator;
+
+            static constexpr uint32_t MAX_VALUE = (1 << MICRO_LIMB_BITS) - 1;
+
+            // Calculate how many elements there are in the sequence MAX_VALUE, MAX_VALUE - 3,...,0
+            size_t sorted_elements_count = (MAX_VALUE / SORT_STEP) + 1 + (MAX_VALUE % SORT_STEP == 0 ? 0 : 1);
+
+            // Check that we can fit every element in the polynomial
+            ASSERT((NUM_CONCATENATED_WIRES + 1) * sorted_elements_count < extra_range_constraint_numerator.size());
+
+            std::vector<size_t> sorted_elements(sorted_elements_count);
+
+            // Calculate the sequence in integers
+            sorted_elements[0] = MAX_VALUE;
+            for (size_t i = 1; i < sorted_elements_count; i++) {
+                sorted_elements[i] = (sorted_elements_count - 1 - i) * SORT_STEP;
+            }
+
+            // TODO(#756): can be parallelized further. This will use at most 5 threads
+            auto fill_with_shift = [&](size_t shift) {
+                for (size_t i = 0; i < sorted_elements_count; i++) {
+                    extra_range_constraint_numerator.at(shift + i * (NUM_CONCATENATED_WIRES + 1)) = sorted_elements[i];
+                }
+            };
+            // Fill polynomials with a sequence, where each element is repeated NUM_CONCATENATED_WIRES+1 times
+            parallel_for(NUM_CONCATENATED_WIRES + 1, fill_with_shift);
         }
     };
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -538,8 +538,6 @@ class TranslatorFlavor {
         {
             return concatenate(PrecomputedEntities<DataType>::get_all(), WitnessEntities<DataType>::get_unshifted());
         }
-        // everything but ConcatenatedRangeConstraints (used for ZeroMorph input since concatenated handled
-        // separately)
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/810)
         auto get_unshifted_without_concatenated()
         {
@@ -591,8 +589,8 @@ class TranslatorFlavor {
         // Next power of 2
         const size_t mini_circuit_dyadic_size = builder.get_circuit_subgroup_size(total_num_gates);
 
-        // The actual circuit size is several times bigger than the trace in the builder, because we use
-        // concatenation to bring the degree of relations down, while extending the length.
+        // The actual circuit size is several times bigger than the trace in the builder, because we use concatenation
+        // to bring the degree of relations down, while extending the length.
         return mini_circuit_dyadic_size * CONCATENATION_GROUP_SIZE;
     }
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
@@ -185,9 +185,9 @@ void TranslatorProver::execute_pcs_rounds()
                          sumcheck_output.challenge,
                          commitment_key,
                          transcript,
-                         key->polynomials.get_concatenated_constraints(),
-                         sumcheck_output.claimed_evaluations.get_concatenated_constraints(),
-                         key->polynomials.get_concatenation_groups());
+                         key->polynomials.get_concatenated(),
+                         sumcheck_output.claimed_evaluations.get_concatenated(),
+                         key->polynomials.get_groups_to_be_concatenated());
     PCS::compute_opening_proof(commitment_key, prover_opening_claim, transcript);
 }
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.cpp
@@ -121,8 +121,8 @@ bool TranslatorVerifier::verify_proof(const HonkProof& proof)
                                            multivariate_challenge,
                                            Commitment::one(),
                                            transcript,
-                                           commitments.get_concatenation_groups(),
-                                           claimed_evaluations.get_concatenated_constraints());
+                                           commitments.get_groups_to_be_concatenated(),
+                                           claimed_evaluations.get_concatenated());
     auto pairing_points = PCS::reduce_verify(opening_claim, transcript);
 
     auto verified = key->pcs_verification_key->pairing_check(pairing_points[0], pairing_points[1]);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.hpp
@@ -13,7 +13,7 @@
 namespace bb {
 /**
  * @brief  A DeciderProvingKey is normally constructed from a finalized circuit and it contains all the information
- * required by an Ultra Goblin Honk prover to create a proof. A DeciderProvingKey is also the result of running the
+ * required by an Mega Honk prover to create a proof. A DeciderProvingKey is also the result of running the
  * Protogalaxy prover, in which case it becomes a relaxed counterpart with the folding parameters (target sum and gate
  * challenges set to non-zero values).
  *


### PR DESCRIPTION
Translator flavor had several unused getters that have been removed. Additionally, the PrecomputedEntities included methods operating on polynomials and modifying state which should be done as part of the ProvingKey. 