### PR TITLE
chore: remove unused header in public executor

### DIFF
--- a/yarn-project/simulator/src/avm/avm_execution_environment.ts
+++ b/yarn-project/simulator/src/avm/avm_execution_environment.ts
@@ -1,4 +1,4 @@
-import { FunctionSelector, type GlobalVariables, type Header } from '@aztec/circuits.js';
+import { FunctionSelector, type GlobalVariables } from '@aztec/circuits.js';
 import { type AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
 
@@ -14,7 +14,6 @@ export class AvmExecutionEnvironment {
     public readonly functionSelector: FunctionSelector, // may be temporary (#7224)
     public readonly contractCallDepth: Fr,
     public readonly transactionFee: Fr,
-    public readonly header: Header,
     public readonly globals: GlobalVariables,
     public readonly isStaticCall: boolean,
     public readonly isDelegateCall: boolean,
@@ -35,7 +34,6 @@ export class AvmExecutionEnvironment {
       functionSelector,
       this.contractCallDepth.add(Fr.ONE),
       this.transactionFee,
-      this.header,
       this.globals,
       isStaticCall,
       isDelegateCall,

--- a/yarn-project/simulator/src/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.test.ts
@@ -819,7 +819,6 @@ describe('AVM simulator: transpiled Noir contracts', () => {
           /*nestedEnvironment=*/ expect.objectContaining({
             sender: environment.address, // sender is top-level call
             contractCallDepth: new Fr(1), // top call is depth 0, nested is depth 1
-            header: environment.header, // just confirming that nested env looks roughly right
             globals: environment.globals, // just confirming that nested env looks roughly right
             isStaticCall: isStaticCall,
             // TODO(7121): can't check calldata like this since it is modified on environment construction

--- a/yarn-project/simulator/src/avm/fixtures/index.ts
+++ b/yarn-project/simulator/src/avm/fixtures/index.ts
@@ -1,5 +1,5 @@
 import { isNoirCallStackUnresolved } from '@aztec/circuit-types';
-import { GasFees, GlobalVariables, Header } from '@aztec/circuits.js';
+import { GasFees, GlobalVariables } from '@aztec/circuits.js';
 import { FunctionSelector, getFunctionDebugMetadata } from '@aztec/foundation/abi';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -63,7 +63,6 @@ export function initExecutionEnvironment(overrides?: Partial<AvmExecutionEnviron
     overrides?.functionSelector ?? FunctionSelector.empty(),
     overrides?.contractCallDepth ?? Fr.zero(),
     overrides?.transactionFee ?? Fr.zero(),
-    overrides?.header ?? Header.empty(),
     overrides?.globals ?? GlobalVariables.empty(),
     overrides?.isStaticCall ?? false,
     overrides?.isDelegateCall ?? false,

--- a/yarn-project/simulator/src/public/executor.ts
+++ b/yarn-project/simulator/src/public/executor.ts
@@ -1,6 +1,6 @@
 import { type PublicExecutionRequest } from '@aztec/circuit-types';
 import { type AvmSimulationStats } from '@aztec/circuit-types/stats';
-import { Fr, Gas, type GlobalVariables, type Header, type Nullifier, type TxContext } from '@aztec/circuits.js';
+import { Fr, Gas, type GlobalVariables, type Nullifier, type TxContext } from '@aztec/circuits.js';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import { type TelemetryClient } from '@aztec/telemetry-client';
@@ -61,11 +61,7 @@ export class PublicExecutor {
       pendingSiloedNullifiers.map(n => n.value),
     );
 
-    const avmExecutionEnv = createAvmExecutionEnvironment(
-      executionRequest,
-      globalVariables,
-      transactionFee,
-    );
+    const avmExecutionEnv = createAvmExecutionEnvironment(executionRequest, globalVariables, transactionFee);
 
     const avmMachineState = new AvmMachineState(availableGas);
     const avmContext = new AvmContext(avmPersistableState, avmExecutionEnv, avmMachineState);

--- a/yarn-project/simulator/src/public/executor.ts
+++ b/yarn-project/simulator/src/public/executor.ts
@@ -21,7 +21,7 @@ import { PublicSideEffectTrace } from './side_effect_trace.js';
 export class PublicExecutor {
   metrics: ExecutorMetrics;
 
-  constructor(private readonly worldStateDB: WorldStateDB, private readonly header: Header, client: TelemetryClient) {
+  constructor(private readonly worldStateDB: WorldStateDB, client: TelemetryClient) {
     this.metrics = new ExecutorMetrics(client, 'PublicExecutor');
   }
 
@@ -63,7 +63,6 @@ export class PublicExecutor {
 
     const avmExecutionEnv = createAvmExecutionEnvironment(
       executionRequest,
-      this.header,
       globalVariables,
       transactionFee,
     );
@@ -120,7 +119,6 @@ export class PublicExecutor {
  */
 function createAvmExecutionEnvironment(
   executionRequest: PublicExecutionRequest,
-  header: Header,
   globalVariables: GlobalVariables,
   transactionFee: Fr,
 ): AvmExecutionEnvironment {
@@ -131,7 +129,6 @@ function createAvmExecutionEnvironment(
     executionRequest.callContext.functionSelector,
     /*contractCallDepth=*/ Fr.zero(),
     transactionFee,
-    header,
     globalVariables,
     executionRequest.callContext.isStaticCall,
     executionRequest.callContext.isDelegateCall,

--- a/yarn-project/simulator/src/public/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor.ts
@@ -57,7 +57,7 @@ export class PublicProcessorFactory {
     const historicalHeader = maybeHistoricalHeader ?? merkleTree.getInitialHeader();
 
     const worldStateDB = new WorldStateDB(merkleTree, this.contractDataSource);
-    const publicExecutor = new PublicExecutor(worldStateDB, historicalHeader, telemetryClient);
+    const publicExecutor = new PublicExecutor(worldStateDB, telemetryClient);
     const publicKernelSimulator = new RealPublicKernelCircuitSimulator(this.simulator);
 
     return PublicProcessor.create(

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -679,24 +679,14 @@ export class TXE implements TypedOracle {
     return `${artifact.name}:${f.name}`;
   }
 
-  async executePublicFunction(
-    targetContractAddress: AztecAddress,
-    args: Fr[],
-    callContext: CallContext,
-    counter: number,
-  ) {
-    const header = Header.empty();
-    header.state = await this.trees.getStateReference(true);
-    header.globalVariables.blockNumber = new Fr(await this.getBlockNumber());
-
+  executePublicFunction(targetContractAddress: AztecAddress, args: Fr[], callContext: CallContext, counter: number) {
     const executor = new PublicExecutor(
       new TXEWorldStateDB(this.trees.asLatest(), new TXEPublicContractDataSource(this)),
-      header,
       new NoopTelemetryClient(),
     );
     const execution = new PublicExecutionRequest(targetContractAddress, callContext, args);
 
-    return executor.simulate(
+    const executionResult = executor.simulate(
       execution,
       GlobalVariables.empty(),
       Gas.test(),
@@ -705,6 +695,7 @@ export class TXE implements TypedOracle {
       /* transactionFee */ Fr.ONE,
       counter,
     );
+    return Promise.resolve(executionResult);
   }
 
   async avmOpcodeCall(


### PR DESCRIPTION
upon discussion with facundo, it can be nuked for the time being
