### PR TITLE
chore: Have prover-node self-mint L1 fee juice

### DIFF
--- a/yarn-project/prover-node/src/bond/bond-manager.ts
+++ b/yarn-project/prover-node/src/bond/bond-manager.ts
@@ -7,8 +7,8 @@ export class BondManager {
   private logger = createDebugLogger('aztec:prover-node:bond-manager');
 
   constructor(
-    private readonly tokenContract: TokenContract,
-    private readonly escrowContract: EscrowContract,
+    public readonly tokenContract: TokenContract,
+    public readonly escrowContract: EscrowContract,
     /** Minimum escrowed bond. A top-up will be issued once this threshold is hit. */
     public minimumAmount: bigint,
     /** Target escrowed bond. Top-up will target this value. */

--- a/yarn-project/prover-node/src/bond/factory.ts
+++ b/yarn-project/prover-node/src/bond/factory.ts
@@ -40,5 +40,8 @@ export async function createBondManager(
   const tokenContractAddress = await escrow.getTokenAddress();
   const token = new TokenContract(client, tokenContractAddress);
 
+  // Ensure the prover has enough balance to cover escrow and try to mint otherwise if on a dev environment
+  await token.ensureBalance((targetStake ?? minimumStake) * 3n);
+
   return new BondManager(token, escrow, minimumStake, targetStake ?? minimumStake);
 }


### PR DESCRIPTION
So it can escrow funds for prover quotes. This should be handled in a prior setup step, but this should be an easy fix for any process that kicks off a prover node.