### PR TITLE
chore: Do not start prover node in e2e tests if not needed

### DIFF
--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -28,7 +28,6 @@ import {
   TokenContract,
 } from '@aztec/noir-contracts.js';
 import { getCanonicalFeeJuice } from '@aztec/protocol-contracts/fee-juice';
-import { type ProverNode } from '@aztec/prover-node';
 
 import { getContract } from 'viem';
 
@@ -55,7 +54,6 @@ export class FeesTest {
   public logger: DebugLogger;
   public pxe!: PXE;
   public aztecNode!: AztecNode;
-  public proverNode!: ProverNode;
 
   public aliceWallet!: AccountWallet;
   public aliceAddress!: AztecAddress;
@@ -175,10 +173,9 @@ export class FeesTest {
     await this.snapshotManager.snapshot(
       'initial_accounts',
       addAccounts(3, this.logger),
-      async ({ accountKeys }, { pxe, aztecNode, aztecNodeConfig, proverNode }) => {
+      async ({ accountKeys }, { pxe, aztecNode, aztecNodeConfig }) => {
         this.pxe = pxe;
         this.aztecNode = aztecNode;
-        this.proverNode = proverNode;
         const accountManagers = accountKeys.map(ak => getSchnorrAccount(pxe, ak[0], ak[1], 1));
         await Promise.all(accountManagers.map(a => a.register()));
         this.wallets = await Promise.all(accountManagers.map(a => a.getWallet()));

--- a/yarn-project/end-to-end/src/e2e_prover/e2e_prover_test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/e2e_prover_test.ts
@@ -95,7 +95,7 @@ export class FullProverTest {
     this.snapshotManager = createSnapshotManager(
       `full_prover_integration/${testName}`,
       dataPath,
-      {},
+      { startProverNode: true },
       { assumeProvenThrough: undefined, useRealProofCommitmentEscrow: true },
     );
   }
@@ -155,10 +155,10 @@ export class FullProverTest {
 
   async setup() {
     this.context = await this.snapshotManager.setup();
+    this.simulatedProverNode = this.context.proverNode!;
     ({
       pxe: this.pxe,
       aztecNode: this.aztecNode,
-      proverNode: this.simulatedProverNode,
       deployL1ContractsValues: this.l1Contracts,
       cheatCodes: this.cheatCodes,
     } = this.context);

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -318,6 +318,8 @@ export type SetupOptions = {
   l2StartTime?: number;
   /** How far we should assume proven */
   assumeProvenThrough?: number;
+  /** Whether to start a prover node */
+  startProverNode?: boolean;
 } & Partial<AztecNodeConfig>;
 
 /** Context for an end-to-end test as returned by the `setup` function */

--- a/yarn-project/end-to-end/src/prover-coordination/e2e_prover_coordination.test.ts
+++ b/yarn-project/end-to-end/src/prover-coordination/e2e_prover_coordination.test.ts
@@ -51,10 +51,8 @@ describe('e2e_prover_coordination', () => {
     snapshotManager = createSnapshotManager(
       `prover_coordination/e2e_json_coordination`,
       process.env.E2E_DATA_PATH,
-      {},
-      {
-        assumeProvenThrough: undefined,
-      },
+      { startProverNode: true },
+      { assumeProvenThrough: undefined },
     );
 
     await snapshotManager.snapshot('setup', addAccounts(2, logger), async ({ accountKeys }, ctx) => {
@@ -80,7 +78,7 @@ describe('e2e_prover_coordination', () => {
 
     ctx = await snapshotManager.setup();
 
-    await ctx.proverNode.stop();
+    await ctx.proverNode!.stop();
 
     cc = new EthCheatCodes(ctx.aztecNodeConfig.l1RpcUrl);
 
@@ -195,7 +193,7 @@ describe('e2e_prover_coordination', () => {
     });
 
     // Send in the quote
-    await ctx.proverNode.sendEpochProofQuote(quoteForEpoch0);
+    await ctx.proverNode!.sendEpochProofQuote(quoteForEpoch0);
 
     // Build a block, this should NOT use the above quote as it is for the current epoch (0)
     await contract.methods.create_note(recipient, recipient, 10).send().wait();
@@ -272,7 +270,7 @@ describe('e2e_prover_coordination', () => {
 
     const allQuotes = [proofQuoteInvalidSlot, proofQuoteInvalidEpoch, ...validQuotes, proofQuoteInsufficientBond];
 
-    await Promise.all(allQuotes.map(x => ctx.proverNode.sendEpochProofQuote(x)));
+    await Promise.all(allQuotes.map(x => ctx.proverNode!.sendEpochProofQuote(x)));
 
     // now build another block and we should see the best valid quote being published
     await contract.methods.create_note(recipient, recipient, 10).send().wait();

--- a/yarn-project/end-to-end/src/public-testnet/e2e_public_testnet_transfer.test.ts
+++ b/yarn-project/end-to-end/src/public-testnet/e2e_public_testnet_transfer.test.ts
@@ -1,14 +1,10 @@
 import { createAccounts } from '@aztec/accounts/testing';
-import { type AztecNodeConfig } from '@aztec/aztec-node';
-import { type AztecNode, type DebugLogger, Fr, type PXE } from '@aztec/aztec.js';
-import { NULL_KEY } from '@aztec/ethereum';
+import { type DebugLogger, Fr, type PXE } from '@aztec/aztec.js';
 import { EasyPrivateTokenContract } from '@aztec/noir-contracts.js';
-import { type ProverNode, type ProverNodeConfig, getProverNodeConfigFromEnv } from '@aztec/prover-node';
 
 import { foundry, sepolia } from 'viem/chains';
 
-import { createAndSyncProverNode } from '../fixtures/snapshot_manager.js';
-import { getPrivateKeyFromIndex, setup } from '../fixtures/utils.js';
+import { setup } from '../fixtures/utils.js';
 
 // process.env.SEQ_PUBLISHER_PRIVATE_KEY = '<PRIVATE_KEY_WITH_SEPOLIA_ETH>';
 // process.env.PROVER_PUBLISHER_PRIVATE_KEY = '<PRIVATE_KEY_WITH_SEPOLIA_ETH>';
@@ -18,10 +14,6 @@ import { getPrivateKeyFromIndex, setup } from '../fixtures/utils.js';
 describe(`deploys and transfers a private only token`, () => {
   let secretKey1: Fr;
   let secretKey2: Fr;
-  let proverConfig: ProverNodeConfig;
-  let config: AztecNodeConfig;
-  let aztecNode: AztecNode;
-  let proverNode: ProverNode;
 
   let pxe: PXE;
   let logger: DebugLogger;
@@ -30,25 +22,16 @@ describe(`deploys and transfers a private only token`, () => {
   beforeEach(async () => {
     const chainId = !process.env.L1_CHAIN_ID ? foundry.id : +process.env.L1_CHAIN_ID;
     const chain = chainId == sepolia.id ? sepolia : foundry; // Not the best way of doing this.
-    ({ logger, pxe, teardown, config, aztecNode } = await setup(
+    ({ logger, pxe, teardown } = await setup(
       0,
       { skipProtocolContracts: true, stateLoad: undefined },
       {},
       false,
       chain,
     ));
-    proverConfig = getProverNodeConfigFromEnv();
-    const proverNodePrivateKey = getPrivateKeyFromIndex(2);
-    proverConfig.publisherPrivateKey =
-      proverConfig.publisherPrivateKey === NULL_KEY
-        ? `0x${proverNodePrivateKey?.toString('hex')}`
-        : proverConfig.publisherPrivateKey;
-
-    proverNode = await createAndSyncProverNode(proverConfig.publisherPrivateKey, config, aztecNode);
   }, 600_000);
 
   afterEach(async () => {
-    await proverNode.stop();
     await teardown();
   });
 


### PR DESCRIPTION
Removes prover node from the snapshot manager and from the public testnet transfer e2e.
