### PR TITLE
fix: Add epoch proof quote to json rpc serialization

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/http_rpc_server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/http_rpc_server.ts
@@ -1,6 +1,7 @@
 import {
   type AztecNode,
   EncryptedNoteL2BlockL2Logs,
+  EpochProofQuote,
   ExtendedUnencryptedL2Log,
   L2Block,
   LogId,
@@ -53,6 +54,7 @@ export function createAztecNodeRpcServer(node: AztecNode) {
       Tx,
       TxReceipt,
       UnencryptedL2BlockL2Logs,
+      EpochProofQuote,
     },
     // disable methods not part of the AztecNode interface
     ['start', 'stop'],

--- a/yarn-project/circuit-types/src/aztec_node/rpc/aztec_node_client.ts
+++ b/yarn-project/circuit-types/src/aztec_node/rpc/aztec_node_client.ts
@@ -15,6 +15,7 @@ import {
   LogId,
   UnencryptedL2BlockL2Logs,
 } from '../../logs/index.js';
+import { EpochProofQuote } from '../../prover_coordination/epoch_proof_quote.js';
 import { PublicDataWitness } from '../../public_data_witness.js';
 import { SiblingPath } from '../../sibling_path/index.js';
 import { PublicSimulationOutput, Tx, TxHash, TxReceipt } from '../../tx/index.js';
@@ -53,6 +54,7 @@ export function createAztecNodeClient(url: string, fetch = defaultFetch): AztecN
       Tx,
       TxReceipt,
       UnencryptedL2BlockL2Logs,
+      EpochProofQuote,
     },
     false,
     'node',

--- a/yarn-project/circuit-types/src/prover_coordination/epoch_proof_quote.test.ts
+++ b/yarn-project/circuit-types/src/prover_coordination/epoch_proof_quote.test.ts
@@ -1,9 +1,13 @@
 import { EthAddress } from '@aztec/circuits.js';
+import { Signature } from '@aztec/foundation/eth-signature';
 
+import { EpochProofQuote } from './epoch_proof_quote.js';
 import { EpochProofQuotePayload } from './epoch_proof_quote_payload.js';
 
 describe('epoch proof quote', () => {
-  it('should serialize / deserialize', () => {
+  let quote: EpochProofQuote;
+
+  beforeEach(() => {
     const payload = EpochProofQuotePayload.from({
       basisPointFee: 5000,
       bondAmount: 1000000000000000000n,
@@ -12,6 +16,14 @@ describe('epoch proof quote', () => {
       validUntilSlot: 100n,
     });
 
-    expect(EpochProofQuotePayload.fromBuffer(payload.toBuffer())).toEqual(payload);
+    quote = new EpochProofQuote(payload, Signature.random());
+  });
+
+  it('should serialize and deserialize from buffer', () => {
+    expect(EpochProofQuote.fromBuffer(quote.toBuffer())).toEqual(quote);
+  });
+
+  it('should serialize and deserialize from JSON', () => {
+    expect(EpochProofQuote.fromJSON(quote.toJSON())).toEqual(quote);
   });
 });

--- a/yarn-project/circuit-types/src/prover_coordination/epoch_proof_quote.ts
+++ b/yarn-project/circuit-types/src/prover_coordination/epoch_proof_quote.ts
@@ -32,6 +32,17 @@ export class EpochProofQuote extends Gossipable {
     return new EpochProofQuote(reader.readObject(EpochProofQuotePayload), reader.readObject(Signature));
   }
 
+  toJSON() {
+    return {
+      payload: this.payload.toJSON(),
+      signature: this.signature.to0xString(),
+    };
+  }
+
+  static fromJSON(obj: any) {
+    return new EpochProofQuote(EpochProofQuotePayload.fromJSON(obj.payload), Signature.from0xString(obj.signature));
+  }
+
   // TODO: https://github.com/AztecProtocol/aztec-packages/issues/8911
   /**
    * Creates a new quote with a signature.

--- a/yarn-project/circuit-types/src/prover_coordination/epoch_proof_quote_payload.ts
+++ b/yarn-project/circuit-types/src/prover_coordination/epoch_proof_quote_payload.ts
@@ -48,6 +48,26 @@ export class EpochProofQuotePayload {
     );
   }
 
+  toJSON() {
+    return {
+      epochToProve: this.epochToProve.toString(),
+      validUntilSlot: this.validUntilSlot.toString(),
+      bondAmount: this.bondAmount.toString(),
+      prover: this.prover.toString(),
+      basisPointFee: this.basisPointFee,
+    };
+  }
+
+  static fromJSON(obj: any) {
+    return new EpochProofQuotePayload(
+      BigInt(obj.epochToProve),
+      BigInt(obj.validUntilSlot),
+      BigInt(obj.bondAmount),
+      EthAddress.fromString(obj.prover),
+      obj.basisPointFee,
+    );
+  }
+
   toViemArgs(): {
     epochToProve: bigint;
     validUntilSlot: bigint;

--- a/yarn-project/foundation/src/eth-signature/eth_signature.test.ts
+++ b/yarn-project/foundation/src/eth-signature/eth_signature.test.ts
@@ -9,22 +9,45 @@ const randomSigner = () => {
   return new Secp256k1Signer(pk);
 };
 
-describe('Signature serialization / deserialization', () => {
-  it('Should serialize / deserialize', () => {
-    const signer = randomSigner();
+describe('eth signature', () => {
+  let message: Buffer32;
+  let signer: Secp256k1Signer;
+  let signature: Signature;
 
-    const originalMessage = Fr.random();
-    const message = Buffer32.fromField(originalMessage);
+  beforeAll(() => {
+    signer = randomSigner();
+    message = Buffer32.fromField(Fr.random());
+    signature = signer.sign(message);
+  });
 
-    const signature = signer.sign(message);
-
-    // Serde
+  it('should serialize / deserialize to buffer', () => {
     const serialized = signature.toBuffer();
     const deserialized = Signature.fromBuffer(serialized);
     expect(deserialized).toEqual(signature);
+  });
 
-    // Recover signature
+  it('should serialize / deserialize real signature to hex string', () => {
+    const serialized = signature.to0xString();
+    const deserialized = Signature.from0xString(serialized);
+    expect(deserialized).toEqual(signature);
+  });
+
+  it('should recover signer from signature', () => {
     const sender = recoverAddress(message, signature);
     expect(sender).toEqual(signer.address);
+  });
+
+  it('should serialize / deserialize to hex string with 1-digit v', () => {
+    const signature = new Signature(Buffer32.random(), Buffer32.random(), 1, false);
+    const serialized = signature.to0xString();
+    const deserialized = Signature.from0xString(serialized);
+    expect(deserialized).toEqual(signature);
+  });
+
+  it('should serialize / deserialize to hex string with 2-digit v', () => {
+    const signature = new Signature(Buffer32.random(), Buffer32.random(), 26, false);
+    const serialized = signature.to0xString();
+    const deserialized = Signature.from0xString(serialized);
+    expect(deserialized).toEqual(signature);
   });
 });

--- a/yarn-project/foundation/src/eth-signature/eth_signature.ts
+++ b/yarn-project/foundation/src/eth-signature/eth_signature.ts
@@ -53,11 +53,15 @@ export class Signature {
 
     const r = reader.readObject(Buffer32);
     const s = reader.readObject(Buffer32);
-    const v = reader.readUInt8();
+    const v = parseInt(sig.slice(2 + 64 * 2), 16);
 
     const isEmpty = r.isZero() && s.isZero();
 
     return new Signature(r, s, v, isEmpty);
+  }
+
+  static random(): Signature {
+    return new Signature(Buffer32.random(), Buffer32.random(), Math.floor(Math.random() * 2), false);
   }
 
   static empty(): Signature {


### PR DESCRIPTION
Adds the epoch proof quote to the aztec node client and server serialization, otherwise the method for submitting the quote would fail. Also fixes string serialization of the eth-signature, which failed when v was 0 or 1.
