### PR TITLE
fix: Archiver getBlocksForEpoch and EpochProvingJob on block 1

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -479,7 +479,7 @@ export class Archiver implements ArchiveSource {
       block = await this.getBlock(block.number - 1);
     }
 
-    return blocks;
+    return blocks.reverse();
   }
 
   public async isEpochComplete(epochNumber: bigint): Promise<boolean> {

--- a/yarn-project/prover-node/src/bond/bond-manager.ts
+++ b/yarn-project/prover-node/src/bond/bond-manager.ts
@@ -25,7 +25,7 @@ export class BondManager {
 
     try {
       const current = await this.escrowContract.getProverDeposit();
-      if (current > minimum) {
+      if (current >= minimum) {
         this.logger.debug(`Current prover bond ${current} is above minimum ${minimum}`);
         return;
       }

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -63,7 +63,12 @@ export class EpochProvingJob {
 
     try {
       this.prover.startNewEpoch(epochNumber, epochSize);
-      let previousHeader = await this.l2BlockSource.getBlockHeader(this.blocks[0].number - 1);
+
+      // Get the genesis header if the first block of the epoch is the first block of the chain
+      let previousHeader =
+        this.blocks[0].number === 1
+          ? this.publicProcessorFactory.getInitialHeader()
+          : await this.l2BlockSource.getBlockHeader(this.blocks[0].number - 1);
 
       for (const block of this.blocks) {
         // Gather all data to prove this block

--- a/yarn-project/simulator/src/public/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor.ts
@@ -70,6 +70,10 @@ export class PublicProcessorFactory {
       this.telemetryClient,
     );
   }
+
+  public getInitialHeader() {
+    return this.merkleTree.getInitialHeader();
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes a few issues around proving:

- Archiver was returning block headers in reverse order when filtering by epoch. This hadn't popped up in e2e tests before because we were testing with single-block epochs. We now changed the e2e_prover test to have two blocks in the epoch.

- Epoch proving job would fail to prove an epoch that started in block one because it requested the header of the previous block to begin, which was undefined. That edge case is now handled.

- Bond manager would trigger a top up when the amount to top up was exactly zero.

