### PR TITLE
chore: Revert "fix: assign one_idx in the same place as zero_idx in `UltraCircuitBuilder`"

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
@@ -674,7 +674,7 @@ TEST_F(AcirFormatTests, TestCollectsGateCounts)
     auto builder =
         create_circuit(constraint_system, /*size_hint*/ 0, witness, false, std::make_shared<bb::ECCOpQueue>(), true);
 
-    EXPECT_EQ(constraint_system.gates_per_opcode, std::vector<size_t>({ 3, 1 }));
+    EXPECT_EQ(constraint_system.gates_per_opcode, std::vector<size_t>({ 2, 1 }));
 }
 
 TEST_F(AcirFormatTests, TestBigAdd)

--- a/barretenberg/cpp/src/barretenberg/examples/join_split/join_split.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/examples/join_split/join_split.test.cpp
@@ -701,7 +701,7 @@ TEST_F(join_split_tests, test_0_input_notes_and_detect_circuit_change)
     // The below part detects any changes in the join-split circuit
     constexpr size_t DYADIC_CIRCUIT_SIZE = 1 << 16;
 
-    constexpr uint256_t CIRCUIT_HASH("0x7dc795fff69e5f49469e514198cc9f6d8db2338049510cdfdb303da4ab8d8cea");
+    constexpr uint256_t CIRCUIT_HASH("0x2b30566e4d921ea9b0c76802d86ea5b8381ffa78ef143af1b0d0e3045862cb6b");
 
     const uint256_t circuit_hash = circuit.hash_circuit();
     // circuit is finalized now

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -156,6 +156,7 @@ void UltraCircuitBuilder_<Arithmetization>::add_gates_to_ensure_all_polys_are_no
     create_dummy_gate(blocks.aux, this->zero_idx, this->zero_idx, this->zero_idx, this->zero_idx);
 
     // Add nonzero values in w_4 and q_c (q_4*w_4 + q_c --> 1*1 - 1 = 0)
+    this->one_idx = put_constant_variable(FF::one());
     create_big_add_gate({ this->zero_idx, this->zero_idx, this->zero_idx, this->one_idx, 0, 0, 0, 1, -1 });
 
     // Take care of all polys related to lookups (q_lookup, tables, sorted, etc)

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -319,10 +319,9 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization_
     UltraCircuitBuilder_(const size_t size_hint = 0)
         : CircuitBuilderBase<FF>(size_hint)
     {
+        // TODO(https://github.com/AztecProtocol/barretenberg/issues/870): reserve space in blocks here somehow?
         this->zero_idx = put_constant_variable(FF::zero());
-        this->one_idx = put_constant_variable(FF::one());
-
-        this->tau.insert({ DUMMY_TAG, DUMMY_TAG }); // TODO(https://github.com/AztecProtocol/barretenberg/issues/1123)
+        this->tau.insert({ DUMMY_TAG, DUMMY_TAG }); // TODO(luke): explain this
     };
     /**
      * @brief Constructor from data generated from ACIR
@@ -360,8 +359,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename Arithmetization_
         // Add the const zero variable after the acir witness has been
         // incorporated into variables.
         this->zero_idx = put_constant_variable(FF::zero());
-        this->one_idx = put_constant_variable(FF::one());
-        this->tau.insert({ DUMMY_TAG, DUMMY_TAG }); // TODO(https://github.com/AztecProtocol/barretenberg/issues/1123)
+        this->tau.insert({ DUMMY_TAG, DUMMY_TAG }); // TODO(luke): explain this
 
         this->is_recursive_circuit = recursive;
     };


### PR DESCRIPTION
Reverts AztecProtocol/aztec-packages#9029