### PR TITLE
chore(p2p): store received epoch quotes

### DIFF
--- a/yarn-project/p2p/src/client/index.ts
+++ b/yarn-project/p2p/src/client/index.ts
@@ -53,6 +53,7 @@ export const createP2PClient = async (
       peerId,
       txPool,
       attestationsPool,
+      epochProofQuotePool,
       l2BlockSource,
       proofVerifier,
       worldStateSynchronizer,

--- a/yarn-project/p2p/src/service/libp2p_service.ts
+++ b/yarn-project/p2p/src/service/libp2p_service.ts
@@ -34,6 +34,7 @@ import { createLibp2p } from 'libp2p';
 
 import { type AttestationPool } from '../attestation_pool/attestation_pool.js';
 import { type P2PConfig } from '../config.js';
+import { type EpochProofQuotePool } from '../epoch_proof_quote_pool/epoch_proof_quote_pool.js';
 import { type TxPool } from '../tx_pool/index.js';
 import {
   DataTxValidator,
@@ -58,7 +59,6 @@ import {
 } from './reqresp/interface.js';
 import { ReqResp } from './reqresp/reqresp.js';
 import type { P2PService, PeerDiscoveryService } from './service.js';
-import { EpochProofQuotePool } from '../epoch_proof_quote_pool/epoch_proof_quote_pool.js';
 
 /**
  * Create a libp2p peer ID from the private key if provided, otherwise creates a new random ID.


### PR DESCRIPTION
## Overview

Receive epoch quotes through the p2p client and add them to the store. Testing this to see if it fixes a halt with x validators when progression halts past the first epoch