### PR TITLE
fix: correct use of finalize_circuit in bb gates

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -701,7 +701,7 @@ template <typename Builder = UltraCircuitBuilder> void gateCount(const std::stri
     for (auto constraint_system : constraint_systems) {
         auto builder = acir_format::create_circuit<Builder>(
             constraint_system, 0, {}, honk_recursion, std::make_shared<bb::ECCOpQueue>(), true);
-        builder.finalize_circuit();
+        builder.finalize_circuit(/* ensure_nonzero= */ true);
         size_t circuit_size = builder.num_gates;
 
         // Build individual circuit report


### PR DESCRIPTION
In previous[ PR](https://github.com/AztecProtocol/aztec-packages/pull/9042), I modified `bb gates` to return the number of gates after the circuit is finalised, not using an estimation with `get_num_gates`, but without setting `ensure_nonzero` to true, which means that the dummy gates added to ensure nonzero polynomials were not taken into account. This PR fixes it.