### PR TITLE
fix: limit number of bb.js threads to 32

### DIFF
--- a/barretenberg/acir_tests/browser-test-app/src/index.ts
+++ b/barretenberg/acir_tests/browser-test-app/src/index.ts
@@ -2,7 +2,7 @@ import createDebug from "debug";
 import { inflate } from "pako";
 
 createDebug.enable("*");
-const debug = createDebug("simple_test");
+const debug = createDebug("browser-test-app");
 
 async function runTest(
   bytecode: Uint8Array,

--- a/barretenberg/ts/src/barretenberg/backend.ts
+++ b/barretenberg/ts/src/barretenberg/backend.ts
@@ -16,16 +16,6 @@ export class UltraPlonkBackend {
   /** @ignore */
   async instantiate(): Promise<void> {
     if (!this.api) {
-      if (typeof navigator !== 'undefined' && navigator.hardwareConcurrency) {
-        this.options.threads = navigator.hardwareConcurrency;
-      } else {
-        try {
-          const os = await import('os');
-          this.options.threads = os.cpus().length;
-        } catch (e) {
-          console.log('Could not detect environment. Falling back to one thread.', e);
-        }
-      }
       const api = await Barretenberg.new(this.options);
 
       const honkRecursion = false;
@@ -125,16 +115,6 @@ export class UltraHonkBackend {
   /** @ignore */
   async instantiate(): Promise<void> {
     if (!this.api) {
-      if (typeof navigator !== 'undefined' && navigator.hardwareConcurrency) {
-        this.options.threads = navigator.hardwareConcurrency;
-      } else {
-        try {
-          const os = await import('os');
-          this.options.threads = os.cpus().length;
-        } catch (e) {
-          console.log('Could not detect environment. Falling back to one thread.', e);
-        }
-      }
       const api = await Barretenberg.new(this.options);
       const honkRecursion = true;
       await api.acirInitSRS(this.acirUncompressedBytecode, honkRecursion);

--- a/barretenberg/ts/src/barretenberg/verifier.ts
+++ b/barretenberg/ts/src/barretenberg/verifier.ts
@@ -18,17 +18,6 @@ export class BarretenbergVerifier {
   /** @ignore */
   async instantiate(): Promise<void> {
     if (!this.api) {
-      if (typeof navigator !== 'undefined' && navigator.hardwareConcurrency) {
-        this.options.threads = navigator.hardwareConcurrency;
-      } else {
-        try {
-          const os = await import('os');
-          this.options.threads = os.cpus().length;
-        } catch (e) {
-          console.log('Could not detect environment. Falling back to one thread.', e);
-        }
-      }
-
       const api = await Barretenberg.new(this.options);
       await api.initSRSForCircuitSize(0);
 

--- a/noir/noir-repo/compiler/integration-tests/test/node/prove_and_verify.test.ts
+++ b/noir/noir-repo/compiler/integration-tests/test/node/prove_and_verify.test.ts
@@ -215,7 +215,6 @@ it('UltraHonk end-to-end proof creation and verification (inner)', async () => {
   // bb.js part
   //
   // Proof creation
-  const honkBackend = await UltraHonkBackend.new(assert_lt_program);
   const proof = await honkBackend.generateProof(witness);
 
   // Proof verification

--- a/noir/noir-repo/compiler/integration-tests/test/node/prove_and_verify.test.ts
+++ b/noir/noir-repo/compiler/integration-tests/test/node/prove_and_verify.test.ts
@@ -215,6 +215,7 @@ it('UltraHonk end-to-end proof creation and verification (inner)', async () => {
   // bb.js part
   //
   // Proof creation
+  const honkBackend = await UltraHonkBackend.new(assert_lt_program);
   const proof = await honkBackend.generateProof(witness);
 
   // Proof verification


### PR DESCRIPTION
This PR pulls out the limiting of the number of threads from #8861 without the other changes which are failing CI.