### PR TITLE
refactor: move public keys to protocol circuits

### DIFF
--- a/boxes/boxes/react/src/contracts/src/main.nr
+++ b/boxes/boxes/react/src/contracts/src/main.nr
@@ -3,7 +3,7 @@ use dep::aztec::macros::aztec;
 #[aztec]
 contract BoxReact {
     use dep::aztec::{
-        keys::public_keys::{IvpkM, OvpkM},
+        protocol_types::public_keys::{IvpkM, OvpkM},
         prelude::{AztecAddress, PrivateMutable, Map, NoteInterface, NoteHeader, Point},
         encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         macros::{storage::storage, functions::{private, public, initializer}}

--- a/boxes/boxes/vanilla/src/contracts/src/main.nr
+++ b/boxes/boxes/vanilla/src/contracts/src/main.nr
@@ -3,7 +3,7 @@ use dep::aztec::macros::aztec;
 #[aztec]
 contract Vanilla {
     use dep::aztec::{
-        keys::public_keys::{IvpkM, OvpkM},
+        protocol_types::public_keys::{IvpkM, OvpkM},
         prelude::{AztecAddress, PrivateMutable, Map, NoteInterface, NoteHeader, Point},
         encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         macros::{storage::storage, functions::{private, public, initializer}}

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
@@ -1,9 +1,8 @@
 use crate::{
     context::PrivateContext, event::event_interface::EventInterface,
-    encrypted_logs::payload::compute_encrypted_log,
-    keys::{getters::get_ovsk_app, public_keys::{OvpkM, IvpkM}}, oracle::random::random
+    encrypted_logs::payload::compute_encrypted_log, keys::getters::get_ovsk_app, oracle::random::random
 };
-use dep::protocol_types::{address::AztecAddress, hash::sha256_to_field};
+use dep::protocol_types::{address::AztecAddress, public_keys::{OvpkM, IvpkM}, hash::sha256_to_field};
 
 fn compute_raw_event_log<Event, let N: u32>(
     context: PrivateContext,

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -1,9 +1,11 @@
 use crate::{
     context::PrivateContext, note::{note_emission::NoteEmission, note_interface::NoteInterface},
-    keys::{getters::get_ovsk_app, public_keys::{PublicKeys, OvpkM, IvpkM}},
-    encrypted_logs::payload::compute_encrypted_log
+    keys::getters::get_ovsk_app, encrypted_logs::payload::compute_encrypted_log
 };
-use dep::protocol_types::{hash::sha256_to_field, address::AztecAddress, abis::note_hash::NoteHash};
+use dep::protocol_types::{
+    address::AztecAddress, public_keys::{PublicKeys, OvpkM, IvpkM}, hash::sha256_to_field,
+    abis::note_hash::NoteHash
+};
 
 fn compute_raw_note_log<Note, let N: u32>(
     context: PrivateContext,

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/header.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/header.nr
@@ -1,6 +1,6 @@
-use dep::protocol_types::{address::AztecAddress, scalar::Scalar, point::Point};
+use dep::protocol_types::{address::AztecAddress, public_keys::{PublicKeys, IvpkM, ToPoint}, scalar::Scalar, point::Point};
 
-use crate::keys::{point_to_symmetric_key::point_to_symmetric_key, public_keys::ToPoint};
+use crate::keys::point_to_symmetric_key::point_to_symmetric_key;
 
 use std::aes128::aes128_encrypt;
 
@@ -36,7 +36,7 @@ unconstrained fn test_encrypted_log_header_matches_noir() {
         lo: 0x00000000000000000000000000000000649e7ca01d9de27b21624098b897babd,
         hi: 0x0000000000000000000000000000000023b3127c127b1f29a7adff5cccf8fb06
     };
-    let point = crate::keys::public_keys::IvpkM {
+    let point = IvpkM {
         inner: Point {
             x: 0x2688431c705a5ff3e6c6f2573c9e3ba1c1026d2251d0dbbf2d810aa53fd1d186,
             y: 0x1e96887b117afca01c00468264f4f80b5bb16d94c1808a448595f115556e5c8e,

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
@@ -1,6 +1,6 @@
 use dep::protocol_types::{
-    address::AztecAddress, scalar::Scalar, point::Point, constants::GENERATOR_INDEX__SYMMETRIC_KEY,
-    hash::poseidon2_hash_with_separator
+    address::AztecAddress, scalar::Scalar, point::Point, public_keys::{OvpkM, IvpkM},
+    constants::GENERATOR_INDEX__SYMMETRIC_KEY, hash::poseidon2_hash_with_separator
 };
 use std::{
     aes128::aes128_encrypt, embedded_curve_ops::fixed_base_scalar_mul as derive_public_key,
@@ -9,7 +9,7 @@ use std::{
 
 use crate::{
     oracle::random::random, utils::point::point_to_bytes, encrypted_logs::{header::EncryptedLogHeader},
-    keys::{point_to_symmetric_key::point_to_symmetric_key, public_keys::{OvpkM, IvpkM}}
+    keys::{point_to_symmetric_key::point_to_symmetric_key}
 };
 
 pub fn compute_encrypted_log<let P: u32, let M: u32>(
@@ -147,12 +147,9 @@ pub fn compute_outgoing_body_ciphertext(
 }
 
 mod test {
-    use crate::{
-        encrypted_logs::payload::{compute_encrypted_log, compute_incoming_body_ciphertext, compute_outgoing_body_ciphertext},
-        keys::public_keys::{OvpkM, IvpkM}
-    };
+    use crate::{encrypted_logs::payload::{compute_encrypted_log, compute_incoming_body_ciphertext, compute_outgoing_body_ciphertext}};
     use std::embedded_curve_ops::fixed_base_scalar_mul as derive_public_key;
-    use dep::protocol_types::{address::AztecAddress, point::Point, scalar::Scalar};
+    use dep::protocol_types::{address::AztecAddress, public_keys::{OvpkM, IvpkM}, point::Point, scalar::Scalar};
     use std::test::OracleMock;
 
     #[test]

--- a/noir-projects/aztec-nr/aztec/src/keys/getters/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/keys/getters/mod.nr
@@ -1,7 +1,7 @@
-use dep::protocol_types::address::AztecAddress;
+use dep::protocol_types::{address::AztecAddress, public_keys::PublicKeys};
 use crate::{
     oracle::{keys::get_public_keys_and_partial_address, key_validation_request::get_key_validation_request},
-    keys::{public_keys::PublicKeys, constants::{NULLIFIER_INDEX, OUTGOING_INDEX}}
+    keys::{constants::{NULLIFIER_INDEX, OUTGOING_INDEX}}
 };
 
 mod test;

--- a/noir-projects/aztec-nr/aztec/src/keys/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/keys/mod.nr
@@ -1,6 +1,3 @@
 mod constants;
 mod getters;
 mod point_to_symmetric_key;
-mod public_keys;
-
-pub use crate::keys::public_keys::{PublicKeys, PUBLIC_KEYS_LENGTH};

--- a/noir-projects/aztec-nr/aztec/src/oracle/keys.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/keys.nr
@@ -1,5 +1,7 @@
-use crate::keys::{PublicKeys, public_keys::{NpkM, IvpkM, OvpkM, TpkM}};
-use dep::protocol_types::{address::{AztecAddress, PartialAddress}, point::Point};
+use dep::protocol_types::{
+    address::{AztecAddress, PartialAddress}, public_keys::{PublicKeys, NpkM, IvpkM, OvpkM, TpkM},
+    point::Point
+};
 
 #[oracle(getPublicKeysAndPartialAddress)]
 unconstrained fn get_public_keys_and_partial_address_oracle(_address: AztecAddress) -> [Field; 13] {}

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
@@ -1,10 +1,9 @@
 use dep::protocol_types::{
-    abis::function_selector::FunctionSelector, address::AztecAddress,
+    abis::function_selector::FunctionSelector, address::AztecAddress, public_keys::PublicKeys,
     constants::CONTRACT_INSTANCE_LENGTH, contract_instance::ContractInstance
 };
 use crate::context::inputs::PrivateContextInputs;
 use crate::test::helpers::utils::TestAccount;
-use crate::keys::public_keys::PublicKeys;
 
 unconstrained pub fn reset() {
     oracle_reset();

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
@@ -1,5 +1,6 @@
 use dep::protocol_types::{
     traits::{Deserialize, Serialize}, address::AztecAddress,
+    public_keys::{PublicKeys, PUBLIC_KEYS_LENGTH},
     abis::{function_selector::FunctionSelector, private_circuit_public_inputs::PrivateCircuitPublicInputs},
     contract_instance::ContractInstance
 };
@@ -7,7 +8,6 @@ use dep::protocol_types::{
 use crate::context::inputs::PrivateContextInputs;
 use crate::context::call_interfaces::CallInterface;
 use crate::test::helpers::cheatcodes;
-use crate::keys::public_keys::{PUBLIC_KEYS_LENGTH, PublicKeys};
 
 use crate::oracle::{execution::{get_block_number, get_contract_address}};
 use protocol_types::constants::PUBLIC_DISPATCH_SELECTOR;

--- a/noir-projects/noir-contracts/contracts/schnorr_single_key_account_contract/src/auth_oracle.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_single_key_account_contract/src/auth_oracle.nr
@@ -1,8 +1,5 @@
 use dep::authwit::auth_witness;
-use dep::aztec::{
-    protocol_types::{address::PartialAddress, utils::arr_copy_slice},
-    keys::{PublicKeys, PUBLIC_KEYS_LENGTH}
-};
+use dep::aztec::protocol_types::{address::PartialAddress, utils::arr_copy_slice, public_keys::{PublicKeys, PUBLIC_KEYS_LENGTH}};
 
 pub struct AuthWitness {
     keys: PublicKeys,

--- a/noir-projects/noir-contracts/contracts/spam_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/spam_contract/src/types/balance_set.nr
@@ -2,8 +2,8 @@
 use dep::aztec::prelude::{NoteGetterOptions, NoteViewerOptions, NoteInterface, NullifiableNote, PrivateSet};
 use dep::aztec::{
     context::{PrivateContext, UnconstrainedContext},
-    protocol_types::constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
-    note::note_emission::OuterNoteEmission, keys::public_keys::NpkM
+    protocol_types::{constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, public_keys::NpkM},
+    note::note_emission::OuterNoteEmission
 };
 use crate::types::token_note::OwnedNote;
 

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -13,13 +13,13 @@ contract Test {
     use dep::aztec::encrypted_logs::encrypted_note_emission::encode_and_encrypt_note;
     use dep::aztec::encrypted_logs::encrypted_event_emission::encode_and_encrypt_event_with_randomness_unconstrained;
 
-    use dep::aztec::protocol_types::{constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, traits::Serialize, point::Point};
+    use dep::aztec::protocol_types::{constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, traits::Serialize, point::Point, public_keys::IvpkM};
 
     use dep::aztec::note::constants::MAX_NOTES_PER_PAGE;
     use dep::aztec::keys::getters::get_public_keys;
 
     use dep::aztec::{
-        hash::{pedersen_hash, compute_secret_hash, ArgsHasher}, keys::public_keys::IvpkM,
+        hash::{pedersen_hash, compute_secret_hash, ArgsHasher},
         note::{
         lifecycle::{create_note, destroy_note_unsafe}, note_getter::{get_notes, view_notes},
         note_getter_options::NoteStatus

--- a/noir-projects/noir-contracts/contracts/token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/types/balance_set.nr
@@ -1,9 +1,9 @@
 use dep::aztec::prelude::{NoteGetterOptions, NoteViewerOptions, NoteInterface, PrivateSet};
 use dep::aztec::{
     context::{PrivateContext, UnconstrainedContext},
-    protocol_types::constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
+    protocol_types::{constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, public_keys::NpkM},
     note::{note_interface::NullifiableNote, note_getter::view_notes, note_emission::OuterNoteEmission},
-    keys::{getters::get_public_keys, public_keys::NpkM}
+    keys::getters::get_public_keys
 };
 use crate::types::token_note::OwnedNote;
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/lib.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/lib.nr
@@ -1,6 +1,7 @@
 mod utils;
 mod address;
 mod debug_log;
+pub mod public_keys;
 mod point;
 mod scalar;
 // This is intentionally spelled like this since contract is a reserved keyword, so it cannot be used as an ident.

--- a/noir-projects/noir-protocol-circuits/crates/types/src/public_keys.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/public_keys.nr
@@ -1,10 +1,12 @@
-use dep::protocol_types::{
-    address::PublicKeysHash, constants::GENERATOR_INDEX__PUBLIC_KEYS_HASH,
-    hash::poseidon2_hash_with_separator, point::{Point, POINT_LENGTH},
+use crate::{
+    address::public_keys_hash::PublicKeysHash, constants::GENERATOR_INDEX__PUBLIC_KEYS_HASH,
+    hash::poseidon2_hash_with_separator, point::POINT_LENGTH,
     traits::{Deserialize, Serialize, Empty, is_empty, Hash}
 };
 
-global PUBLIC_KEYS_LENGTH: u32 = 12;
+use dep::std::embedded_curve_ops::EmbeddedCurvePoint as Point;
+
+pub global PUBLIC_KEYS_LENGTH: u32 = 12;
 
 pub struct PublicKeys {
     npk_m: NpkM,


### PR DESCRIPTION
In the new address scheme, we will need to calculate the address with the IvpkM. The address type resides in the protocol circuits, therefore this is just a simple move / plumbing and I'm moving the public keys type to the protocol circuits so it can be used in calculating the address.
