### PR TITLE
fix: dockerized vk build

### DIFF
--- a/noir-projects/Dockerfile
+++ b/noir-projects/Dockerfile
@@ -20,6 +20,7 @@ COPY . .
 RUN yarn
 # Override RAYON_NUM_THREADS default
 ENV RAYON_NUM_THREADS=32
+ENV PARALLEL_VK=false
 WORKDIR /usr/src/noir-projects/noir-contracts
 RUN ./bootstrap.sh
 WORKDIR /usr/src/noir-projects/noir-protocol-circuits

--- a/noir-projects/Earthfile
+++ b/noir-projects/Earthfile
@@ -39,7 +39,7 @@ build-protocol-circuits:
   RUN yarn
 
   ENV RAYON_NUM_THREADS=$RAYON_NUM_THREADS
-  RUN cd noir-protocol-circuits && BB_HASH=$bb_source_hash NARGO=nargo ./bootstrap.sh
+  RUN cd noir-protocol-circuits && BB_HASH=$bb_source_hash NARGO=nargo PARALLEL_VK=false ./bootstrap.sh
   SAVE ARTIFACT noir-protocol-circuits
 
 build-mock-protocol-circuits:

--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -18,8 +18,8 @@ fi
 yarn
 node ./scripts/generate_variants.js
 
-echo "Compiling protocol circuits..."
 NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
+echo "Compiling protocol circuits with ${RAYON_NUM_THREADS:-1} threads"
 RAYON_NUM_THREADS=${RAYON_NUM_THREADS:-1} $NARGO compile --silence-warnings
 
 BB_HASH=${BB_HASH:-$(cd ../../ && git ls-tree -r HEAD | grep 'barretenberg/cpp' | awk '{print $3}' | git hash-object --stdin)}
@@ -40,16 +40,9 @@ esac
 # This value may be too low.
 # If vk generation fail with an amount of free memory greater than this value then it should be increased.
 MIN_PARALLEL_VK_GENERATION_MEMORY=500000000
+PARALLEL_VK=${PARALLEL_VK:-true}
 
-if [[ AVAILABLE_MEMORY -lt MIN_PARALLEL_VK_GENERATION_MEMORY ]]; then
-  echo "System does not have enough memory for parallel vk generation, falling back to sequential"
-
-  for pathname in "./target"/*.json; do
-      BB_HASH=$BB_HASH node ../scripts/generate_vk_json.js "$pathname" "./target/keys"
-  done
-
-else
-
+if [[ AVAILABLE_MEMORY -gt MIN_PARALLEL_VK_GENERATION_MEMORY ]] && [[ $PARALLEL_VK == "true" ]]; then
   echo "Generating vks in parallel..."
   for pathname in "./target"/*.json; do
       BB_HASH=$BB_HASH node ../scripts/generate_vk_json.js "$pathname" "./target/keys" &
@@ -58,5 +51,13 @@ else
   for job in $(jobs -p); do
     wait $job || exit 1
   done
+
+else
+  echo "System does not have enough memory for parallel vk generation, falling back to sequential"
+
+  for pathname in "./target"/*.json; do
+      BB_HASH=$BB_HASH node ../scripts/generate_vk_json.js "$pathname" "./target/keys"
+  done
+
 
 fi


### PR DESCRIPTION
Dockerized generation of vks was failing with non-deterministic errors when being generated in parallel.