### PR TITLE
chore: disable new world state on ARM

### DIFF
--- a/yarn-project/aztec/Dockerfile
+++ b/yarn-project/aztec/Dockerfile
@@ -5,7 +5,7 @@ ENV BB_WORKING_DIRECTORY=/usr/src/yarn-project/bb
 ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
 ENV ACVM_WORKING_DIRECTORY=/usr/src/yarn-project/acvm
 RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY
-ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec/dest/bin/index.js"]
+ENTRYPOINT ["/bin/sh", "-c", "if [[ $(arch) == arm* ]]; then export USE_LEGACY_WORLD_STATE=1; fi; exec node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js"]
 EXPOSE 8080
 
 # The version has been updated in yarn-project.


### PR DESCRIPTION
This PR configures the sandbox to use the old WorldState implementation when running on ARM.

(Untested)
