### PR TITLE
chore: added healthcheck and startup check

### DIFF
--- a/aztec-up/bin/docker-compose.test.yml
+++ b/aztec-up/bin/docker-compose.test.yml
@@ -9,6 +9,12 @@ services:
       - ./log:/usr/src/yarn-project/aztec/log:rw
       - ${HOME}:${HOME}
     command: start --txe --port 8081
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8081/status"]
+      interval: 1s
+      timeout: 1s
+      retries: 10
+
 
   aztec-nargo:
     image: "aztecprotocol/aztec-nargo"
@@ -20,4 +26,5 @@ services:
     volumes:
       - ${HOME}:${HOME}
     depends_on:
-      - txe
+      txe:
+        condition: service_healthy

--- a/yarn-project/aztec/src/cli/cmds/start_txe.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_txe.ts
@@ -1,3 +1,4 @@
+import { createStatusRouter } from '@aztec/foundation/json-rpc/server';
 import { type DebugLogger } from '@aztec/foundation/log';
 import { createTXERpcServer } from '@aztec/txe';
 
@@ -7,8 +8,13 @@ export const startTXE = (options: any, debugLogger: DebugLogger) => {
   debugLogger.info(`Setting up TXE...`);
   const txeServer = createTXERpcServer(debugLogger);
   const app = txeServer.getApp();
+  // add status route
+  const statusRouter = createStatusRouter();
+  app.use(statusRouter.routes()).use(statusRouter.allowedMethods());
+
   const httpServer = http.createServer(app.callback());
   httpServer.timeout = 1e3 * 60 * 5; // 5 minutes
   httpServer.listen(options.port);
+
   debugLogger.info(`TXE listening on port ${options.port}`);
 };

--- a/yarn-project/txe/src/bin/index.ts
+++ b/yarn-project/txe/src/bin/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S node --no-warnings
 import { createDebugLogger } from '@aztec/aztec.js';
+import { createStatusRouter } from '@aztec/foundation/json-rpc/server';
 
 import http from 'http';
 
@@ -16,6 +17,10 @@ function main() {
 
   const txeServer = createTXERpcServer(logger);
   const app = txeServer.getApp();
+  // add status route
+  const statusRouter = createStatusRouter();
+  app.use(statusRouter.routes()).use(statusRouter.allowedMethods());
+
   const httpServer = http.createServer(app.callback());
   httpServer.timeout = 1e3 * 60 * 5; // 5 minutes
   httpServer.listen(TXE_PORT);


### PR DESCRIPTION
Now that noir parses way faster, `nargo test` was running before TXE could start on the container, so `aztec test` would error out since the RPC oracle resolver wasn't available.

This PR adds a healthcheck to the container via the `/status` endpoint so that we can properly check whether TXE is up and running or not, delaying the startup of the `aztec-nargo` container.