### PR TITLE
chore(deployments): native/kind network test in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,7 @@ jobs:
 
   build:
     needs: [build-images, changes]
-    # NOTE: we don't skip this job here instead using if's below so that dependencies are not broken
-    # we still want build to be at the bottom of the dependency chain
+    if: (needs.changes.outputs.non-docs == 'true' && needs.changes.outputs.non-misc-ci == 'true' && needs.changes.outputs.non-barretenberg-cpp == 'true') || github.ref_name == 'master'
     runs-on: ${{ github.event.pull_request.user.login || github.actor }}-x86
     outputs:
       e2e_list: ${{ steps.e2e_list.outputs.list }}
@@ -133,7 +132,6 @@ jobs:
       # prepare images locally, tagged by commit hash
       - name: "Build E2E Image"
         timeout-minutes: 40
-        if: (needs.changes.outputs.non-docs == 'true' && needs.changes.outputs.non-misc-ci == 'true' && needs.changes.outputs.non-barretenberg-cpp == 'true') || github.ref_name == 'master'
         run: |
           earthly-ci ./yarn-project+export-e2e-test-images
       # We base our e2e list used in e2e-x86 off the targets in ./yarn-project/end-to-end
@@ -414,7 +412,7 @@ jobs:
         run: earthly-ci --no-output ./+barretenberg-acir-tests-bb.js
 
   noir-format:
-    needs: [build, changes]
+    needs: [build-images, changes]
     runs-on: ${{ github.event.pull_request.user.login || github.actor }}-x86
     if: needs.changes.outputs.noir == 'true' || needs.changes.outputs.noir-projects == 'true'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,8 @@ jobs:
 
   build:
     needs: [build-images, changes]
-    if: (needs.changes.outputs.non-docs == 'true' && needs.changes.outputs.non-misc-ci == 'true' && needs.changes.outputs.non-barretenberg-cpp == 'true') || github.ref_name == 'master'
+    # NOTE: we don't skip this job here instead using if's below so that dependencies are not broken
+    # we still want build to be at the bottom of the dependency chain
     runs-on: ${{ github.event.pull_request.user.login || github.actor }}-x86
     outputs:
       e2e_list: ${{ steps.e2e_list.outputs.list }}
@@ -132,6 +133,7 @@ jobs:
       # prepare images locally, tagged by commit hash
       - name: "Build E2E Image"
         timeout-minutes: 40
+        if: (needs.changes.outputs.non-docs == 'true' && needs.changes.outputs.non-misc-ci == 'true' && needs.changes.outputs.non-barretenberg-cpp == 'true') || github.ref_name == 'master'
         run: |
           earthly-ci ./yarn-project+export-e2e-test-images
       # We base our e2e list used in e2e-x86 off the targets in ./yarn-project/end-to-end
@@ -412,7 +414,7 @@ jobs:
         run: earthly-ci --no-output ./+barretenberg-acir-tests-bb.js
 
   noir-format:
-    needs: [build-images, changes]
+    needs: [build, changes]
     runs-on: ${{ github.event.pull_request.user.login || github.actor }}-x86
     if: needs.changes.outputs.noir == 'true' || needs.changes.outputs.noir-projects == 'true'
     steps:
@@ -539,6 +541,19 @@ jobs:
       - name: "Prover Client Tests"
         timeout-minutes: 40
         run: earthly-ci --no-output ./yarn-project/+prover-client-test
+
+  network-test-fake-proofs:
+    needs: build
+    runs-on: ${{ github.event.pull_request.user.login || github.actor }}-x86
+    steps:
+      - uses: actions/checkout@v4
+        with: { ref: "${{ env.GIT_COMMIT }}" }
+      - uses: ./.github/ci-setup-action
+        with:
+          concurrency_key: network-test-fake-proofs-x86
+      - name: "Prover Client Tests"
+        timeout-minutes: 40
+        run: earthly-ci --no-output ./yarn-project/+network-test-fake-proofs
 
   l1-contracts-test:
     needs: [build, changes]
@@ -764,6 +779,7 @@ jobs:
       - yarn-project-formatting
       - yarn-project-test
       - prover-client-test
+      - network-test-fake-proofs
       - l1-contracts-test
       - docs-preview
       # - bb-bench # non-blocking
@@ -819,6 +835,7 @@ jobs:
       - yarn-project-formatting
       - yarn-project-test
       - prover-client-test
+      - network-test-fake-proofs
       - l1-contracts-test
       - docs-preview
       # - bb-bench # non-blocking

--- a/.github/workflows/network-deploy.yml
+++ b/.github/workflows/network-deploy.yml
@@ -54,4 +54,4 @@ jobs:
       - name: Deploy Helm chart
         run: |
           helm dependency update ${{ env.CHART_PATH }}
-          helm upgrade --install ${{ env.NAMESPACE }} ${{ env.CHART_PATH }} --namespace ${{ env.NAMESPACE }} --set network.public=true --atomic
+          helm upgrade --install ${{ env.NAMESPACE }} ${{ env.CHART_PATH }} --namespace ${{ env.NAMESPACE }} --set network.public=true --atomic --create-namespace --timeout 20m

--- a/.github/workflows/nightly-kind-test.yml
+++ b/.github/workflows/nightly-kind-test.yml
@@ -75,7 +75,7 @@ jobs:
             ./spartan/scripts/setup_local_k8s.sh
             export FORCE_COLOR=1
             export EARTHLY_BUILD_ARGS="${{ env.EARTHLY_BUILD_ARGS }}"
-            ./scripts/earthly-ci --exec-stats -P --no-output ./yarn-project/end-to-end/+network-transfer --values-file=${{ matrix.values_file }}
+            ./scripts/earthly-ci --exec-stats -P --no-output ./yarn-project/end-to-end/+kind-network-transfer --values-file=${{ matrix.values_file }}
 
   success-check:
     runs-on: ubuntu-20.04

--- a/scripts/Earthfile
+++ b/scripts/Earthfile
@@ -1,0 +1,6 @@
+VERSION 0.8
+
+scripts:
+  FROM scratch
+  COPY *.sh .
+  SAVE ARTIFACT *.sh

--- a/scripts/run_interleaved.sh
+++ b/scripts/run_interleaved.sh
@@ -2,35 +2,57 @@
 set -eu
 
 # Usage: run_bg_args.sh <main command> <background commands>...
-# Runs the main command with output logging and background commands without logging.
+# Runs the main command with output logging and background commands with logging.
 # Finishes when the main command exits.
 
-# Check if at least two commands are provided (otherwise what is the point)
+# Check if at least two commands are provided
 if [ "$#" -lt 2 ]; then
     echo "Usage: $0 <main-command> <background commands>..."
     exit 1
 fi
 
+# Define colors
+colors=(
+    "\e[31m" # Red
+    "\e[32m" # Green
+    "\e[33m" # Yellow
+    "\e[34m" # Blue
+    "\e[35m" # Magenta
+    "\e[36m" # Cyan
+    "\e[37m" # White
+    "\e[91m" # Bright Red
+    "\e[92m" # Bright Green
+    "\e[93m" # Bright Yellow
+    "\e[94m" # Bright Blue
+    "\e[95m" # Bright Magenta
+    "\e[96m" # Bright Cyan
+)
+
 main_cmd="$1"
 shift
 
-# Function to run a command and prefix the output
+# Function to run a command and prefix the output with color
 function run_command() {
     local cmd="$1"
+    local color="$2"
     while IFS= read -r line; do
-        echo "[$cmd] $line"
+        echo -e "${color}[$cmd] $line\e[0m"
     done < <($cmd 2>&1)
 }
 
-# Run the main command, piping output through the run_command function
-run_command "$main_cmd" &
-main_pid=$!
+i=0
 
-# Run background commands without logging output
+# Run the main command with its assigned color
+run_command "$main_cmd" "${colors[$((i % ${#colors[@]}))]}" &
+main_pid=$!
+((i++))
+
+# Run background commands with their assigned colors
 declare -a bg_pids
 for cmd in "$@"; do
-    run_command "$cmd" &
+    run_command "$cmd" "${colors[$((i % ${#colors[@]}))]}" &
     bg_pids+=($!)
+    ((i++))
 done
 
 # Wait for the main command to finish and capture its exit code

--- a/scripts/run_interleaved.sh
+++ b/scripts/run_interleaved.sh
@@ -9,60 +9,50 @@ set -o pipefail
 
 # Check if at least two commands are provided (otherwise what is the point)
 if [ "$#" -lt 2 ]; then
-    echo "Usage: $0 <main-command> <background commands>..."
-    exit 1
+  echo "Usage: $0 <main-command> <background commands>..."
+  exit 1
 fi
 
 # Define colors
 colors=(
-    "\e[33m" # Yellow
-    "\e[34m" # Blue
-    "\e[35m" # Magenta
-    "\e[36m" # Cyan
-    "\e[92m" # Bright Green
-    "\e[93m" # Bright Yellow
-    "\e[94m" # Bright Blue
-    "\e[95m" # Bright Magenta
-    "\e[96m" # Bright Cyan
-    "\e[91m" # Bright Red
+  "\e[33m" # Yellow
+  "\e[34m" # Blue
+  "\e[35m" # Magenta
+  "\e[36m" # Cyan
+  "\e[92m" # Bright Green
+  "\e[93m" # Bright Yellow
+  "\e[94m" # Bright Blue
+  "\e[95m" # Bright Magenta
+  "\e[96m" # Bright Cyan
+  "\e[91m" # Bright Red
 )
 
 main_cmd="$1"
 shift
 
+# pattern from https://stackoverflow.com/questions/28238952/how-to-kill-a-running-bash-function-from-terminal
+function cleanup_function() {
+  kill $(jobs -p) 2>/dev/null || true
+  return
+}
+
 # Function to run a command and prefix the output with color
 function run_command() {
-    local cmd="$1"
-    local color="$2"
-    $cmd 2>&1 | while IFS= read -r line; do
-        echo -e "${color}[$cmd]\e[0m $line"
-    done
+  # pattern from https://stackoverflow.com/questions/28238952/how-to-kill-a-running-bash-function-from-terminal
+  trap cleanup_function INT EXIT
+  local cmd="$1"
+  local color="$2"
+  $cmd 2>&1 | while IFS= read -r line; do
+    echo -e "${color}[$cmd]\e[0m $line"
+  done
 }
-
-# Run the main command, piping output through the run_command function with green color
-run_command "$main_cmd" "\e[32m" &
-main_pid=$!
 
 # Run background commands without logging output
-declare -a bg_pids
-function cleanup() {
-# Kill any remaining background jobs
-for pid in "${bg_pids[@]}"; do
-    kill "$pid" 2>/dev/null || true
-done
-}
-trap EXIT cleanup
-
 i=0
 for cmd in "$@"; do
-    run_command "$cmd" "${colors[$((i % ${#colors[@]}))]}" &
-    bg_pids+=($!)
-    ((i++)) || true # annoyingly considered a failure based on result
+  run_command "$cmd" "${colors[$((i % ${#colors[@]}))]}" &
+  ((i++)) || true # annoyingly considered a failure based on result
 done
 
-# Wait for the main command to finish and capture its exit code
-wait $main_pid
-main_exit_code=$?
-
-# Exit with the same code as the main command
-exit $main_exit_code
+# Run the main command synchronously, piping output through the run_command function with green color
+run_command "$main_cmd" "\e[32m"

--- a/scripts/run_interleaved.sh
+++ b/scripts/run_interleaved.sh
@@ -2,10 +2,10 @@
 set -eu
 
 # Usage: run_bg_args.sh <main command> <background commands>...
-# Runs the main command with output logging and background commands with logging.
+# Runs the main command with output logging and background commands without logging.
 # Finishes when the main command exits.
 
-# Check if at least two commands are provided
+# Check if at least two commands are provided (otherwise what is the point)
 if [ "$#" -lt 2 ]; then
     echo "Usage: $0 <main-command> <background commands>..."
     exit 1
@@ -13,19 +13,16 @@ fi
 
 # Define colors
 colors=(
-    "\e[31m" # Red
-    "\e[32m" # Green
     "\e[33m" # Yellow
     "\e[34m" # Blue
     "\e[35m" # Magenta
     "\e[36m" # Cyan
-    "\e[37m" # White
-    "\e[91m" # Bright Red
     "\e[92m" # Bright Green
     "\e[93m" # Bright Yellow
     "\e[94m" # Bright Blue
     "\e[95m" # Bright Magenta
     "\e[96m" # Bright Cyan
+    "\e[91m" # Bright Red
 )
 
 main_cmd="$1"
@@ -36,23 +33,21 @@ function run_command() {
     local cmd="$1"
     local color="$2"
     while IFS= read -r line; do
-        echo -e "${color}[$cmd] $line\e[0m"
+        echo -e "${color}[$cmd]\e[0m $line"
     done < <($cmd 2>&1)
 }
 
-i=0
-
-# Run the main command with its assigned color
-run_command "$main_cmd" "${colors[$((i % ${#colors[@]}))]}" &
+# Run the main command, piping output through the run_command function with green color
+run_command "$main_cmd" "\e[32m" &
 main_pid=$!
-((i++))
 
-# Run background commands with their assigned colors
+# Run background commands without logging output
 declare -a bg_pids
+i=0
 for cmd in "$@"; do
     run_command "$cmd" "${colors[$((i % ${#colors[@]}))]}" &
     bg_pids+=($!)
-    ((i++))
+    ((i++)) || true # annoyingly considered a failure based on result
 done
 
 # Wait for the main command to finish and capture its exit code

--- a/spartan/aztec-network/templates/l2-contracts.yaml
+++ b/spartan/aztec-network/templates/l2-contracts.yaml
@@ -27,7 +27,7 @@ spec:
               done
               echo "PXE service is ready!"
               set -e
-              node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js setup-protocol-contracts
+              node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js setup-protocol-contracts --skipProofWait
               echo "L2 contracts initialized"
           env:
             - name: PXE_URL

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -283,8 +283,11 @@ prover-client-test:
 # Running this inside the main builder as the point is not to run this through dockerization.
 network-test-fake-proofs:
     FROM +build
+    WORKDIR /usr/src/
     # Bare minimum git setup to run 'git rev-parse --show-toplevel'
-    RUN (cd .. && git init)
+    RUN git init -b master
+    COPY ../scripts/+scripts/run_interleaved.sh scripts/run_interleaved.sh
+    WORKDIR /usr/src/yarn-project
     # All script arguments are in the end-to-end/scripts/native-network folder
     RUN INTERLEAVED=true end-to-end/scripts/native_network_test.sh \
         ./test-transfer.sh \

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -279,6 +279,22 @@ prover-client-test:
     ARG debug=""
     RUN cd prover-client && DEBUG=$debug yarn test $test
 
+# NOTE: This is not in the end-to-end Earthfile as that is entirely LOCALLY commands that will go away sometime.
+# Running this inside the main builder as the point is not to run this through dockerization.
+network-test-fake-proofs:
+    FROM +build
+    # All script arguments are in the end-to-end/scripts/native-network folder
+    RUN INTERLEAVED=true end-to-end/scripts/native_network_test.sh \
+        ./test-transfer.sh \
+        ./deploy-l1-contracts.sh \
+        ./deploy-l2-contracts.sh \
+        ./boot-node.sh \
+        ./ethereum.sh \
+        "./prover-node.sh false" \
+        ./pxe.sh \
+        ./transaction-bot.sh \
+        "./validator.sh 8081"
+
 publish-npm:
     FROM +build
     ARG DIST_TAG="latest"

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -283,6 +283,8 @@ prover-client-test:
 # Running this inside the main builder as the point is not to run this through dockerization.
 network-test-fake-proofs:
     FROM +build
+    # Bare minimum git setup to run 'git rev-parse --show-toplevel'
+    RUN (cd .. && git init)
     # All script arguments are in the end-to-end/scripts/native-network folder
     RUN INTERLEAVED=true end-to-end/scripts/native_network_test.sh \
         ./test-transfer.sh \

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -296,9 +296,7 @@ network-test-fake-proofs:
         ./boot-node.sh \
         ./ethereum.sh \
         "./prover-node.sh false" \
-        ./pxe.sh \
-        ./transaction-bot.sh \
-        "./validator.sh 8081"
+        ./pxe.sh
 
 publish-npm:
     FROM +build

--- a/yarn-project/cli/src/cmds/misc/setup_contracts.ts
+++ b/yarn-project/cli/src/cmds/misc/setup_contracts.ts
@@ -19,7 +19,7 @@ export async function setupCanonicalL2FeeJuice(
   const feeJuiceContract = await FeeJuiceContract.at(ProtocolContractAddress.FeeJuice, deployer);
   log('setupCanonicalL2FeeJuice: Calling initialize on fee juice contract...');
   await feeJuiceContract.methods
-    .initialize(feeJuicePortalAddress)
+    .set_portal(feeJuicePortalAddress)
     .send({ fee: { paymentMethod: new NoFeePaymentMethod(), gasSettings: GasSettings.teardownless() } })
     .wait(waitOpts);
 }

--- a/yarn-project/cli/src/cmds/misc/setup_contracts.ts
+++ b/yarn-project/cli/src/cmds/misc/setup_contracts.ts
@@ -19,7 +19,7 @@ export async function setupCanonicalL2FeeJuice(
   const feeJuiceContract = await FeeJuiceContract.at(ProtocolContractAddress.FeeJuice, deployer);
   log('setupCanonicalL2FeeJuice: Calling initialize on fee juice contract...');
   await feeJuiceContract.methods
-    .set_portal(feeJuicePortalAddress)
+    .initialize(feeJuicePortalAddress)
     .send({ fee: { paymentMethod: new NoFeePaymentMethod(), gasSettings: GasSettings.teardownless() } })
     .wait(waitOpts);
 }

--- a/yarn-project/end-to-end/Earthfile
+++ b/yarn-project/end-to-end/Earthfile
@@ -297,7 +297,7 @@ network-smoke:
   LOCALLY
   RUN NAMESPACE=smoke FRESH_INSTALL=true VALUES_FILE=${values_file:-default.yaml} ./scripts/network_test.sh ./src/spartan/smoke.test.ts
 
-network-transfer:
+kind-network-transfer:
   ARG values_file
   LOCALLY
   RUN NAMESPACE=transfer FRESH_INSTALL=true VALUES_FILE=${values_file:-default.yaml} ./scripts/network_test.sh ./src/spartan/transfer.test.ts

--- a/yarn-project/end-to-end/scripts/native-network/deploy-l1-contracts.sh
+++ b/yarn-project/end-to-end/scripts/native-network/deploy-l1-contracts.sh
@@ -44,4 +44,7 @@ EOCONFIG
 
 echo "Contract addresses saved to l1-contracts.env"
 sleep 5
-tmux kill-pane -t $(tmux display -p '#{pane_id}')
+function close_tmux_pane() {
+  tmux kill-pane -t $(tmux display -p '#{pane_id}')
+}
+close_tmux_pane 2>/dev/null || true

--- a/yarn-project/end-to-end/scripts/native-network/deploy-l2-contracts.sh
+++ b/yarn-project/end-to-end/scripts/native-network/deploy-l2-contracts.sh
@@ -25,7 +25,7 @@ ARGS="--skipProofWait"
 # Deploy L2 contracts
 export AZTEC_NODE_URL="http://127.0.0.1:8080"
 export PXE_URL="http://127.0.0.1:8079"
-node --no-warnings $(git rev-parse --show-toplevel)/yarn-project/aztec/dest/bin/index.js deploy-protocol-contracts $ARGS
+node --no-warnings $(git rev-parse --show-toplevel)/yarn-project/aztec/dest/bin/index.js setup-protocol-contracts $ARGS
 echo "Deployed L2 contracts"
 # Use file just as done signal
 echo "" > l2-contracts.env

--- a/yarn-project/end-to-end/scripts/native-network/deploy-l2-contracts.sh
+++ b/yarn-project/end-to-end/scripts/native-network/deploy-l2-contracts.sh
@@ -31,4 +31,7 @@ echo "Deployed L2 contracts"
 echo "" > l2-contracts.env
 echo "Wrote to l2-contracts.env to signal completion"
 sleep 5
-tmux kill-pane -t $(tmux display -p '#{pane_id}')
+function close_tmux_pane() {
+  tmux kill-pane -t $(tmux display -p '#{pane_id}')
+}
+close_tmux_pane 2>/dev/null || true

--- a/yarn-project/end-to-end/scripts/native-network/prover-node.sh
+++ b/yarn-project/end-to-end/scripts/native-network/prover-node.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -eu
 
+export PROVER_REAL_PROOFS="$1"
 # Get the name of the script without the path and extension
 SCRIPT_NAME=$(basename "$0" .sh)
 
@@ -28,7 +29,6 @@ export BOOTSTRAP_NODES=$(echo "$output" | grep -oP 'Node ENR: \K.*')
 export LOG_LEVEL="debug"
 export DEBUG="aztec:*"
 export ETHEREUM_HOST="http://127.0.0.1:8545"
-export PROVER_REAL_PROOFS="false"
 export PROVER_AGENT_ENABLED="true"
 export PROVER_PUBLISHER_PRIVATE_KEY="0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97"
 export PROVER_COORDINATION_NODE_URL="http://127.0.0.1:8080"

--- a/yarn-project/end-to-end/scripts/native_network_test.sh
+++ b/yarn-project/end-to-end/scripts/native_network_test.sh
@@ -8,6 +8,8 @@
 # The will run in parallel either in tmux or just interleaved
 # They will log to native-network/logs, where it is easier to debug errors further up the logs, while watching tmux helps catch issues live,
 # or where things crash and need to be tweaked and restarted.
+# Arguments:
+#   Expects a list of scripts from the native-network folder.
 # Optional environment variables:
 #   INTERLEAVED (default: "false") should we just start all programs in the background?
 
@@ -45,12 +47,4 @@ function run_parallel() {
 
 # We exit with the return code of the first command
 # While the others are ran in the background, either in tmux or just interleaved
-run_parallel ./test-transfer.sh \
-  ./deploy-l1-contracts.sh \
-  ./deploy-l2-contracts.sh \
-  ./boot-node.sh \
-  ./ethereum.sh \
-  ./prover-node.sh \
-  ./pxe.sh \
-  ./transaction-bot.sh
-  # "./validator.sh 8081"
+run_parallel "$@"

--- a/yarn-project/end-to-end/scripts/native_network_test.sh
+++ b/yarn-project/end-to-end/scripts/native_network_test.sh
@@ -17,7 +17,6 @@ set -eu
 
 # Ensure dependencies are installed
 command -v anvil >/dev/null || (echo "We need 'anvil' installed to be able to simulate ethereum" && exit 1)
-command -v tmux >/dev/null || (echo "We need 'tmux' installed to be able to manage terminal sessions" && exit 1)
 
 REPO=$(git rev-parse --show-toplevel)
 
@@ -37,6 +36,7 @@ rm -f l1-contracts.env l2-contracts.env logs/*.log
 
 function run_parallel() {
   if [ "${INTERLEAVED:-false}" = "false" ] ; then
+    command -v tmux >/dev/null || (echo "We need 'tmux' installed to be able to manage terminal sessions" && exit 1)
     # Run in tmux for local debugging
     "$REPO"/scripts/tmux_split_args.sh native_network_test_session "$@"
   else

--- a/yarn-project/end-to-end/scripts/network_test.sh
+++ b/yarn-project/end-to-end/scripts/network_test.sh
@@ -35,7 +35,6 @@ if ! docker image ls --format '{{.Repository}}:{{.Tag}}' | grep -q "aztecprotoco
 fi
 
 # Load the Docker images into kind
-kind load docker-image aztecprotocol/end-to-end:$AZTEC_DOCKER_TAG
 kind load docker-image aztecprotocol/aztec:$AZTEC_DOCKER_TAG
 
 # If FRESH_INSTALL is true, delete the namespace

--- a/yarn-project/end-to-end/src/benchmarks/bench_prover.test.ts
+++ b/yarn-project/end-to-end/src/benchmarks/bench_prover.test.ts
@@ -60,7 +60,6 @@ describe('benchmarks/proving', () => {
         minTxsPerBlock: 1,
       },
       {},
-      true,
     );
 
     schnorrWalletSalt = Fr.random();

--- a/yarn-project/end-to-end/src/benchmarks/bench_tx_size_fees.test.ts
+++ b/yarn-project/end-to-end/src/benchmarks/bench_tx_size_fees.test.ts
@@ -30,7 +30,7 @@ describe('benchmarks/tx_size_fees', () => {
 
   // setup the environment
   beforeAll(async () => {
-    ctx = await setup(3, {}, {}, true);
+    ctx = await setup(3, {}, {});
 
     aliceWallet = ctx.wallets[0];
     bobAddress = ctx.wallets[1].getAddress();

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -327,7 +327,6 @@ export async function setup(
   numberOfAccounts = 1,
   opts: SetupOptions = {},
   pxeOpts: Partial<PXEServiceConfig> = {},
-  enableGas = false,
   chain: Chain = foundry,
 ): Promise<EndToEndContext> {
   const config = { ...getConfigEnvVars(), ...opts };

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -695,7 +695,7 @@ export async function setupCanonicalFeeJuice(pxe: PXE) {
 
   try {
     await feeJuice.methods
-      .initialize(feeJuicePortalAddress)
+      .set_portal(feeJuicePortalAddress)
       .send({ fee: { paymentMethod: new NoFeePaymentMethod(), gasSettings: GasSettings.teardownless() } })
       .wait();
     getLogger().info(`Fee Juice successfully setup. Portal address: ${feeJuicePortalAddress}`);

--- a/yarn-project/end-to-end/src/public-testnet/e2e_public_testnet_transfer.test.ts
+++ b/yarn-project/end-to-end/src/public-testnet/e2e_public_testnet_transfer.test.ts
@@ -22,13 +22,7 @@ describe(`deploys and transfers a private only token`, () => {
   beforeEach(async () => {
     const chainId = !process.env.L1_CHAIN_ID ? foundry.id : +process.env.L1_CHAIN_ID;
     const chain = chainId == sepolia.id ? sepolia : foundry; // Not the best way of doing this.
-    ({ logger, pxe, teardown } = await setup(
-      0,
-      { skipProtocolContracts: true, stateLoad: undefined },
-      {},
-      false,
-      chain,
-    ));
+    ({ logger, pxe, teardown } = await setup(0, { skipProtocolContracts: true, stateLoad: undefined }, {}, chain));
   }, 600_000);
 
   afterEach(async () => {

--- a/yarn-project/end-to-end/src/spartan/transfer.test.ts
+++ b/yarn-project/end-to-end/src/spartan/transfer.test.ts
@@ -39,7 +39,7 @@ describe('token transfer test', () => {
   const TOKEN_DECIMALS = 18n;
   const MINT_AMOUNT = 20n;
 
-  const WALLET_COUNT = 16;
+  const WALLET_COUNT = 1; // TODO fix this to allow for 16 wallets again
   const ROUNDS = 5n;
 
   let pxe: PXE;

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -263,8 +263,9 @@ export class L1Publisher {
     try {
       await this.rollupContract.read.validateEpochProofRightClaim(args, { account: this.account });
     } catch (err) {
+      this.log.verbose(JSON.stringify(err));
       const errorName = tryGetCustomErrorName(err);
-      this.log.verbose(`Proof quote validation failed: ${errorName}`);
+      this.log.warn(`Proof quote validation failed: ${errorName}`);
       return undefined;
     }
     return quote;


### PR DESCRIPTION
- enables 'native' tests, called network-fake-proofs-test here. This runs a version of the tmux-outputting test that is normally runnable with:
```
./bootstrap.sh fast
yarn-project/end-to-end/scripts/native_network_test.sh \
        ./test-transfer.sh \
        ./deploy-l1-contracts.sh \
        ./deploy-l2-contracts.sh \
        ./boot-node.sh \
        ./ethereum.sh \
        "./prover-node.sh false" \
        ./pxe.sh \
        ./transaction-bot.sh \
        "./validator.sh 8081"
```
it uses the RUN_INTERLEAVED=1 env var to make it suitable output for CI. This catches application issues, isolating them from k8s-specific issues. It is meant to continue to be maintained alongside the k8s deploy as this is by far the most productive dev workflow, being able to simply restart network components after tweaks (especially with yarn build:dev)
- enables kind tests (also with fake proofs)