### PR TITLE
feat: fix encoding of public keys

### DIFF
--- a/yarn-project/circuits.js/src/types/public_keys.ts
+++ b/yarn-project/circuits.js/src/types/public_keys.ts
@@ -125,6 +125,12 @@ export class PublicKeys {
     ];
   }
 
+  // TOOD: This is used in foundation/src/abi/encoder. This is probably non-optimal but I did not want
+  // to spend too much time on the encoder now. It probably needs a refactor.
+  encodeToNoir(): Fr[] {
+    return this.toFields();
+  }
+
   static fromFields(fields: Fr[] | FieldReader): PublicKeys {
     const reader = FieldReader.asReader(fields);
     return new PublicKeys(

--- a/yarn-project/foundation/src/abi/encoder.ts
+++ b/yarn-project/foundation/src/abi/encoder.ts
@@ -80,6 +80,12 @@ class ArgumentEncoder {
         }
         break;
       case 'struct': {
+        // If the type defines the encoding to noir, we use it
+        if (arg.encodeToNoir !== undefined) {
+          this.flattened.push(...arg.encodeToNoir());
+          break;
+        }
+
         // If the abi expects a struct like { address: Field } and the supplied arg does not have
         // an address field in it, we try to encode it as if it were a field directly.
         const isAddress = isAddressStruct(abiType);


### PR DESCRIPTION
This PR enables us to implement arbitrary serialization from a ts type to a noir type when used with the encoder. This was needed because previously the public keys could not be passed as a parameter (we need to pass it as a parameter when sending it to the contract deployer)