### PR TITLE
fix: Better handle async timings in test

### DIFF
--- a/yarn-project/world-state/src/test/integration.test.ts
+++ b/yarn-project/world-state/src/test/integration.test.ts
@@ -33,7 +33,7 @@ describe('world-state integration', () => {
     log.info(`Generating ${MAX_BLOCK_COUNT} mock blocks`);
     ({ blocks, messages } = await mockBlocks(1, MAX_BLOCK_COUNT, 1, db));
     log.info(`Generated ${blocks.length} mock blocks`);
-  });
+  }, 30_000);
 
   beforeEach(async () => {
     config = {


### PR DESCRIPTION
This PR makes an improvement to the way a test handles waiting for syncs
