### PR TITLE
fix: prefer release world_state_napi

### DIFF
--- a/yarn-project/world-state/package.json
+++ b/yarn-project/world-state/package.json
@@ -14,7 +14,7 @@
     "tsconfig": "./tsconfig.json"
   },
   "scripts": {
-    "build": "yarn clean && mkdir -p build && (([ -f ../../barretenberg/cpp/build-pic/lib/world_state_napi.node ] && cp -v ../../barretenberg/cpp/build-pic/lib/world_state_napi.node build) || ([ -f ../../barretenberg/cpp/build/bin/world_state_napi.node ] && cp -v ../../barretenberg/cpp/build/bin/world_state_napi.node build) || true) && tsc -b",
+    "build": "yarn clean && mkdir -p build && (([ -f ../../barretenberg/cpp/build/bin/world_state_napi.node ] && cp -v ../../barretenberg/cpp/build/bin/world_state_napi.node build) || ([ -f ../../barretenberg/cpp/build-pic/lib/world_state_napi.node ] && cp -v ../../barretenberg/cpp/build-pic/lib/world_state_napi.node build) || true) && tsc -b",
     "build:cpp": "./scripts/build.sh cpp",
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest ./build .tsbuildinfo",

--- a/yarn-project/world-state/package.local.json
+++ b/yarn-project/world-state/package.local.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "yarn clean && mkdir -p build && (([ -f ../../barretenberg/cpp/build-pic/lib/world_state_napi.node ] && cp -v ../../barretenberg/cpp/build-pic/lib/world_state_napi.node build) || ([ -f ../../barretenberg/cpp/build/bin/world_state_napi.node ] && cp -v ../../barretenberg/cpp/build/bin/world_state_napi.node build) || true) && tsc -b",
+    "build": "yarn clean && mkdir -p build && (([ -f ../../barretenberg/cpp/build/bin/world_state_napi.node ] && cp -v ../../barretenberg/cpp/build/bin/world_state_napi.node build) || ([ -f ../../barretenberg/cpp/build-pic/lib/world_state_napi.node ] && cp -v ../../barretenberg/cpp/build-pic/lib/world_state_napi.node build) || true) && tsc -b",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
     "clean": "rm -rf ./dest ./build .tsbuildinfo"
   }


### PR DESCRIPTION
This PR makes the world-state's `yarn build` prefer the "release" version of the world state library over some potentially out-of-date version built in build-pic.

`yarn build:cpp` will build world-state locally and copy it to the right location as before.

