### PR TITLE
feat(avm)!: remove tags from wire format

### DIFF
--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -88,7 +88,7 @@ pub fn brillig_to_avm(
                             .direct_operand(destination)
                             .build(),
                     ),
-                    tag: Some(AvmTypeTag::FIELD),
+                    tag: None,
                     operands: vec![
                         make_operand(bits_needed, &lhs.to_usize()),
                         make_operand(bits_needed, &rhs.to_usize()),
@@ -181,7 +181,7 @@ pub fn brillig_to_avm(
                             .direct_operand(destination)
                             .build(),
                     ),
-                    tag: Some(tag_from_bit_size(BitSize::Integer(*bit_size))),
+                    tag: None,
                     operands: vec![
                         make_operand(bits_needed, &lhs.to_usize()),
                         make_operand(bits_needed, &rhs.to_usize()),

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm_recursion_constraint.test.cpp
@@ -51,9 +51,9 @@ class AcirAvmRecursionConstraint : public ::testing::Test {
 
         trace_builder.op_set(0, 15, 1, AvmMemoryTag::U8);
         trace_builder.op_set(0, 12, 2, AvmMemoryTag::U8);
-        trace_builder.op_add(0, 1, 2, 3, AvmMemoryTag::U8);
-        trace_builder.op_sub(0, 3, 2, 3, AvmMemoryTag::U8);
-        trace_builder.op_mul(0, 1, 1, 3, AvmMemoryTag::U8);
+        trace_builder.op_add(0, 1, 2, 3);
+        trace_builder.op_sub(0, 3, 2, 3);
+        trace_builder.op_mul(0, 1, 1, 3);
         trace_builder.op_return(0, 0, 0);
         auto trace = trace_builder.finalize(); // Passing true enables a longer trace with lookups
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm/recursion/avm_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/recursion/avm_recursive_verifier.test.cpp
@@ -68,7 +68,6 @@ class AvmRecursiveTests : public ::testing::Test {
 
 TEST_F(AvmRecursiveTests, recursion)
 {
-    GTEST_SKIP();
     AvmCircuitBuilder circuit_builder = generate_avm_circuit();
     AvmComposer composer = AvmComposer();
     InnerProver prover = composer.create_prover(circuit_builder);

--- a/barretenberg/cpp/src/barretenberg/vm/avm/recursion/avm_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/recursion/avm_recursive_verifier.test.cpp
@@ -52,7 +52,7 @@ class AvmRecursiveTests : public ::testing::Test {
 
         trace_builder.op_set(0, 1, 1, AvmMemoryTag::U8);
         trace_builder.op_set(0, 1, 2, AvmMemoryTag::U8);
-        trace_builder.op_add(0, 1, 2, 3, AvmMemoryTag::U8);
+        trace_builder.op_add(0, 1, 2, 3);
         trace_builder.op_return(0, 0, 0);
         auto trace = trace_builder.finalize(); // Passing true enables a longer trace with lookups
 
@@ -68,6 +68,7 @@ class AvmRecursiveTests : public ::testing::Test {
 
 TEST_F(AvmRecursiveTests, recursion)
 {
+    GTEST_SKIP();
     AvmCircuitBuilder circuit_builder = generate_avm_circuit();
     AvmComposer composer = AvmComposer();
     InnerProver prover = composer.create_prover(circuit_builder);

--- a/barretenberg/cpp/src/barretenberg/vm/avm/tests/arithmetic.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/tests/arithmetic.test.cpp
@@ -231,7 +231,7 @@ class AvmArithmeticTests : public ::testing::Test {
     {
         trace_builder.op_set(0, a, addr_a, tag);
         trace_builder.op_set(0, b, addr_b, tag);
-        trace_builder.op_eq(0, addr_a, addr_b, addr_c, tag);
+        trace_builder.op_eq(0, addr_a, addr_b, addr_c);
         trace_builder.op_return(0, 0, 0);
         return trace_builder.finalize();
     }
@@ -243,7 +243,7 @@ class AvmArithmeticTests : public ::testing::Test {
     {
         trace_builder.op_set(0, a, 0, tag);
         trace_builder.op_set(0, b, 1, tag);
-        trace_builder.op_add(0, 0, 1, 2, tag);
+        trace_builder.op_add(0, 0, 1, 2);
         trace_builder.op_return(0, 0, 0);
         auto trace = trace_builder.finalize();
 
@@ -260,7 +260,7 @@ class AvmArithmeticTests : public ::testing::Test {
     {
         trace_builder.op_set(0, a, 0, tag);
         trace_builder.op_set(0, b, 1, tag);
-        trace_builder.op_sub(0, 0, 1, 2, tag);
+        trace_builder.op_sub(0, 0, 1, 2);
         trace_builder.op_return(0, 0, 0);
         auto trace = trace_builder.finalize();
 
@@ -277,7 +277,7 @@ class AvmArithmeticTests : public ::testing::Test {
     {
         trace_builder.op_set(0, a, 0, tag);
         trace_builder.op_set(0, b, 1, tag);
-        trace_builder.op_mul(0, 0, 1, 2, tag);
+        trace_builder.op_mul(0, 0, 1, 2);
         trace_builder.op_return(0, 0, 0);
         auto trace = trace_builder.finalize();
 
@@ -297,7 +297,7 @@ class AvmArithmeticTests : public ::testing::Test {
     {
         trace_builder.op_set(0, a, 0, tag);
         trace_builder.op_set(0, b, 1, tag);
-        trace_builder.op_eq(0, 0, 1, 2, tag);
+        trace_builder.op_eq(0, 0, 1, 2);
         trace_builder.op_return(0, 0, 0);
         auto trace = trace_builder.finalize();
 
@@ -405,7 +405,7 @@ TEST_F(AvmArithmeticTestsFF, addition)
     trace_builder.op_calldata_copy(0, 0, 1, 0);
 
     //                                   Memory layout:    [37,4,11,0,0,0,....]
-    trace_builder.op_add(0, 0, 1, 4, AvmMemoryTag::FF); // [37,4,11,0,41,0,....]
+    trace_builder.op_add(0, 0, 1, 4); // [37,4,11,0,41,0,....]
     trace_builder.op_return(0, 0, 5);
     auto trace = trace_builder.finalize();
 
@@ -429,7 +429,7 @@ TEST_F(AvmArithmeticTestsFF, subtraction)
     trace_builder.op_calldata_copy(0, 0, 1, 0);
 
     //                             Memory layout:    [8,4,17,0,0,0,....]
-    trace_builder.op_sub(0, 2, 0, 1, AvmMemoryTag::FF); // [8,9,17,0,0,0....]
+    trace_builder.op_sub(0, 2, 0, 1); // [8,9,17,0,0,0....]
     trace_builder.op_return(0, 0, 3);
     auto trace = trace_builder.finalize();
 
@@ -452,7 +452,7 @@ TEST_F(AvmArithmeticTestsFF, multiplication)
     trace_builder.op_calldata_copy(0, 0, 1, 0);
 
     //                             Memory layout:    [5,0,20,0,0,0,....]
-    trace_builder.op_mul(0, 2, 0, 1, AvmMemoryTag::FF); // [5,100,20,0,0,0....]
+    trace_builder.op_mul(0, 2, 0, 1); // [5,100,20,0,0,0....]
     trace_builder.op_return(0, 0, 3);
     auto trace = trace_builder.finalize();
 
@@ -476,7 +476,7 @@ TEST_F(AvmArithmeticTestsFF, multiplicationByZero)
     trace_builder.op_calldata_copy(0, 0, 1, 0);
 
     //                             Memory layout:    [127,0,0,0,0,0,....]
-    trace_builder.op_mul(0, 0, 1, 2, AvmMemoryTag::FF); // [127,0,0,0,0,0....]
+    trace_builder.op_mul(0, 0, 1, 2); // [127,0,0,0,0,0....]
     trace_builder.op_return(0, 0, 3);
     auto trace = trace_builder.finalize();
 
@@ -500,7 +500,7 @@ TEST_F(AvmArithmeticTestsFF, fDivision)
     trace_builder.op_calldata_copy(0, 0, 1, 0);
 
     //                  Memory layout:    [15,315,0,0,0,0,....]
-    trace_builder.op_fdiv(0, 1, 0, 2, AvmMemoryTag::FF); // [15,315,21,0,0,0....]
+    trace_builder.op_fdiv(0, 1, 0, 2); // [15,315,21,0,0,0....]
     trace_builder.op_return(0, 0, 3);
     auto trace = trace_builder.finalize();
 
@@ -528,7 +528,7 @@ TEST_F(AvmArithmeticTestsFF, fDivisionNumeratorZero)
     trace_builder.op_calldata_copy(0, 0, 1, 0);
 
     //                  Memory layout:    [15,0,0,0,0,0,....]
-    trace_builder.op_fdiv(0, 1, 0, 0, AvmMemoryTag::FF); // [0,0,0,0,0,0....]
+    trace_builder.op_fdiv(0, 1, 0, 0); // [0,0,0,0,0,0....]
     trace_builder.op_return(0, 0, 3);
     auto trace = trace_builder.finalize();
 
@@ -557,7 +557,7 @@ TEST_F(AvmArithmeticTestsFF, fDivisionByZeroError)
     trace_builder.op_calldata_copy(0, 0, 1, 0);
 
     //                  Memory layout:    [15,0,0,0,0,0,....]
-    trace_builder.op_fdiv(0, 0, 1, 2, AvmMemoryTag::FF); // [15,0,0,0,0,0....]
+    trace_builder.op_fdiv(0, 0, 1, 2); // [15,0,0,0,0,0....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -580,7 +580,7 @@ TEST_F(AvmArithmeticTestsFF, fDivisionByZeroError)
 TEST_F(AvmArithmeticTestsFF, fDivisionZeroByZeroError)
 {
     //                  Memory layout:    [0,0,0,0,0,0,....]
-    trace_builder.op_fdiv(0, 0, 1, 2, AvmMemoryTag::FF); // [0,0,0,0,0,0....]
+    trace_builder.op_fdiv(0, 0, 1, 2); // [0,0,0,0,0,0....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -611,16 +611,15 @@ TEST_F(AvmArithmeticTestsFF, mixedOperationsWithError)
     trace_builder.op_calldata_copy(0, 0, 1, 0);
 
     //                             Memory layout:    [0,0,45,23,12,0,0,0,....]
-    trace_builder.op_add(0, 2, 3, 4, AvmMemoryTag::FF);  // [0,0,45,23,68,0,0,0,....]
-    trace_builder.op_add(0, 4, 5, 5, AvmMemoryTag::FF);  // [0,0,45,23,68,68,0,0,....]
-    trace_builder.op_add(0, 5, 5, 5, AvmMemoryTag::FF);  // [0,0,45,23,68,136,0,0,....]
-    trace_builder.op_add(0, 5, 6, 7, AvmMemoryTag::FF);  // [0,0,45,23,68,136,0,136,0....]
-    trace_builder.op_sub(0, 7, 6, 8, AvmMemoryTag::FF);  // [0,0,45,23,68,136,0,136,136,0....]
-    trace_builder.op_mul(0, 8, 8, 8, AvmMemoryTag::FF);  // [0,0,45,23,68,136,0,136,136^2,0....]
-    trace_builder.op_fdiv(0, 3, 5, 1, AvmMemoryTag::FF); // [0,23*136^(-1),45,23,68,136,0,136,136^2,0....]
-    trace_builder.op_fdiv(0, 1, 1, 9, AvmMemoryTag::FF); // [0,23*136^(-1),45,23,68,136,0,136,136^2,1,0....]
-    trace_builder.op_fdiv(
-        0, 9, 0, 4, AvmMemoryTag::FF); // [0,23*136^(-1),45,23,1/0,136,0,136,136^2,1,0....] Error: division by 0
+    trace_builder.op_add(0, 2, 3, 4);  // [0,0,45,23,68,0,0,0,....]
+    trace_builder.op_add(0, 4, 5, 5);  // [0,0,45,23,68,68,0,0,....]
+    trace_builder.op_add(0, 5, 5, 5);  // [0,0,45,23,68,136,0,0,....]
+    trace_builder.op_add(0, 5, 6, 7);  // [0,0,45,23,68,136,0,136,0....]
+    trace_builder.op_sub(0, 7, 6, 8);  // [0,0,45,23,68,136,0,136,136,0....]
+    trace_builder.op_mul(0, 8, 8, 8);  // [0,0,45,23,68,136,0,136,136^2,0....]
+    trace_builder.op_fdiv(0, 3, 5, 1); // [0,23*136^(-1),45,23,68,136,0,136,136^2,0....]
+    trace_builder.op_fdiv(0, 1, 1, 9); // [0,23*136^(-1),45,23,68,136,0,136,136^2,1,0....]
+    trace_builder.op_fdiv(0, 9, 0, 4); // [0,23*136^(-1),45,23,1/0,136,0,136,136^2,1,0....] Error: division by 0
     trace_builder.op_return(0, 0, 0);
 
     auto trace = trace_builder.finalize();
@@ -637,7 +636,7 @@ TEST_F(AvmArithmeticTestsFF, equality)
     trace_builder.op_set(0, 0, 0, AvmMemoryTag::U32);
     trace_builder.op_set(0, 2, 1, AvmMemoryTag::U32);
     trace_builder.op_calldata_copy(0, 0, 1, 0);
-    trace_builder.op_eq(0, 0, 1, 2, AvmMemoryTag::FF); // Memory Layout [q - 1, q - 1, 1, 0..]
+    trace_builder.op_eq(0, 0, 1, 2); // Memory Layout [q - 1, q - 1, 1, 0..]
     trace_builder.op_return(0, 0, 3);
     auto trace = trace_builder.finalize();
 
@@ -661,7 +660,7 @@ TEST_F(AvmArithmeticTestsFF, nonEquality)
     trace_builder.op_set(0, 2, 1, AvmMemoryTag::U32);
     trace_builder.op_calldata_copy(0, 0, 1, 0);
 
-    trace_builder.op_eq(0, 0, 1, 2, AvmMemoryTag::FF); // Memory Layout [q - 1, q, 0, 0..]
+    trace_builder.op_eq(0, 0, 1, 2); // Memory Layout [q - 1, q, 0, 0..]
     trace_builder.op_return(0, 0, 3);
     auto trace = trace_builder.finalize();
 
@@ -681,7 +680,7 @@ TEST_P(AvmArithmeticTestsDiv, division)
     const auto [a, b, output] = operands;
     trace_builder.op_set(0, a, 0, mem_tag);
     trace_builder.op_set(0, b, 1, mem_tag);
-    trace_builder.op_div(0, 0, 1, 2, mem_tag);
+    trace_builder.op_div(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -699,7 +698,7 @@ TEST_F(AvmArithmeticTests, DivisionByZeroError)
 {
     trace_builder.op_set(0, 100, 0, AvmMemoryTag::U128);
     trace_builder.op_set(0, 0, 1, AvmMemoryTag::U128);
-    trace_builder.op_div(0, 0, 1, 2, AvmMemoryTag::U128);
+    trace_builder.op_div(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -729,7 +728,7 @@ TEST_F(AvmArithmeticTestsU1, addition)
     trace_builder.op_set(0, 0, 1, AvmMemoryTag::U1);
 
     //                             Memory layout:    [1,0,0,0,0,....]
-    trace_builder.op_add(0, 0, 1, 2, AvmMemoryTag::U1); // [1,0,1,0,0,....]
+    trace_builder.op_add(0, 0, 1, 2); // [1,0,1,0,0,....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -749,7 +748,7 @@ TEST_F(AvmArithmeticTestsU1, additionCarry)
     trace_builder.op_set(0, 1, 1, AvmMemoryTag::U1);
 
     //                             Memory layout:    [1,1,0,0,0,....]
-    trace_builder.op_add(0, 0, 1, 2, AvmMemoryTag::U1); // [1,1,0,0,0,....]
+    trace_builder.op_add(0, 0, 1, 2); // [1,1,0,0,0,....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -769,7 +768,7 @@ TEST_F(AvmArithmeticTestsU1, subtraction)
     trace_builder.op_set(0, 1, 1, AvmMemoryTag::U1);
 
     //                             Memory layout:    [1,1,0,0,0,....]
-    trace_builder.op_sub(0, 0, 1, 2, AvmMemoryTag::U1); // [1,1,0,0,0,....]
+    trace_builder.op_sub(0, 0, 1, 2); // [1,1,0,0,0,....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -790,7 +789,7 @@ TEST_F(AvmArithmeticTestsU1, subtractionCarry)
     trace_builder.op_set(0, 1, 1, AvmMemoryTag::U1);
 
     //                             Memory layout:    [0,1,0,0,0,....]
-    trace_builder.op_sub(0, 0, 1, 2, AvmMemoryTag::U1); // [0,1,1,0,0,....]
+    trace_builder.op_sub(0, 0, 1, 2); // [0,1,1,0,0,....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -809,7 +808,7 @@ TEST_F(AvmArithmeticTestsU1, multiplication)
     trace_builder.op_set(0, 1, 0, AvmMemoryTag::U1);
     trace_builder.op_set(0, 1, 1, AvmMemoryTag::U1);
 
-    trace_builder.op_mul(0, 0, 1, 2, AvmMemoryTag::U1);
+    trace_builder.op_mul(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -828,7 +827,7 @@ TEST_F(AvmArithmeticTestsU1, multiplicationByzero)
     trace_builder.op_set(0, 1, 0, AvmMemoryTag::U1);
     trace_builder.op_set(0, 0, 1, AvmMemoryTag::U1);
 
-    trace_builder.op_mul(0, 0, 1, 2, AvmMemoryTag::U1);
+    trace_builder.op_mul(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -878,7 +877,7 @@ TEST_F(AvmArithmeticTestsU8, addition)
     trace_builder.op_set(0, 29, 1, AvmMemoryTag::U8);
 
     //                             Memory layout:    [62,29,0,0,0,....]
-    trace_builder.op_add(0, 0, 1, 2, AvmMemoryTag::U8); // [62,29,91,0,0,....]
+    trace_builder.op_add(0, 0, 1, 2); // [62,29,91,0,0,....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -898,7 +897,7 @@ TEST_F(AvmArithmeticTestsU8, additionCarry)
     trace_builder.op_set(0, 100, 1, AvmMemoryTag::U8);
 
     //                             Memory layout:    [159,100,0,0,0,....]
-    trace_builder.op_add(0, 0, 1, 2, AvmMemoryTag::U8); // [159,100,3,0,0,....]
+    trace_builder.op_add(0, 0, 1, 2); // [159,100,3,0,0,....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -918,7 +917,7 @@ TEST_F(AvmArithmeticTestsU8, subtraction)
     trace_builder.op_set(0, 29, 1, AvmMemoryTag::U8);
 
     //                             Memory layout:    [162,29,0,0,0,....]
-    trace_builder.op_sub(0, 0, 1, 2, AvmMemoryTag::U8); // [162,29,133,0,0,....]
+    trace_builder.op_sub(0, 0, 1, 2); // [162,29,133,0,0,....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -939,7 +938,7 @@ TEST_F(AvmArithmeticTestsU8, subtractionCarry)
     trace_builder.op_set(0, 29, 1, AvmMemoryTag::U8);
 
     //                             Memory layout:    [5,29,0,0,0,....]
-    trace_builder.op_sub(0, 0, 1, 2, AvmMemoryTag::U8); // [5,29,232,0,0,....]
+    trace_builder.op_sub(0, 0, 1, 2); // [5,29,232,0,0,....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -958,7 +957,7 @@ TEST_F(AvmArithmeticTestsU8, multiplication)
     trace_builder.op_set(0, 13, 0, AvmMemoryTag::U8);
     trace_builder.op_set(0, 15, 1, AvmMemoryTag::U8);
 
-    trace_builder.op_mul(0, 0, 1, 2, AvmMemoryTag::U8);
+    trace_builder.op_mul(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -977,7 +976,7 @@ TEST_F(AvmArithmeticTestsU8, multiplicationOverflow)
     trace_builder.op_set(0, 200, 0, AvmMemoryTag::U8);
     trace_builder.op_set(0, 170, 1, AvmMemoryTag::U8);
 
-    trace_builder.op_mul(0, 0, 1, 2, AvmMemoryTag::U8);
+    trace_builder.op_mul(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1026,7 +1025,7 @@ TEST_F(AvmArithmeticTestsU16, addition)
     trace_builder.op_set(0, 1775, 119, AvmMemoryTag::U16);
     trace_builder.op_set(0, 33005, 546, AvmMemoryTag::U16);
 
-    trace_builder.op_add(0, 546, 119, 5, AvmMemoryTag::U16);
+    trace_builder.op_add(0, 546, 119, 5);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1046,7 +1045,7 @@ TEST_F(AvmArithmeticTestsU16, additionCarry)
     trace_builder.op_set(0, UINT16_MAX - 982, 0, AvmMemoryTag::U16);
     trace_builder.op_set(0, 1000, 1, AvmMemoryTag::U16);
 
-    trace_builder.op_add(0, 1, 0, 0, AvmMemoryTag::U16);
+    trace_builder.op_add(0, 1, 0, 0);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1066,7 +1065,7 @@ TEST_F(AvmArithmeticTestsU16, subtraction)
     trace_builder.op_set(0, 1775, 119, AvmMemoryTag::U16);
     trace_builder.op_set(0, 33005, 546, AvmMemoryTag::U16);
 
-    trace_builder.op_sub(0, 546, 119, 5, AvmMemoryTag::U16);
+    trace_builder.op_sub(0, 546, 119, 5);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1087,7 +1086,7 @@ TEST_F(AvmArithmeticTestsU16, subtractionCarry)
     trace_builder.op_set(0, UINT16_MAX - 982, 0, AvmMemoryTag::U16);
     trace_builder.op_set(0, 1000, 1, AvmMemoryTag::U16);
 
-    trace_builder.op_sub(0, 1, 0, 0, AvmMemoryTag::U16);
+    trace_builder.op_sub(0, 1, 0, 0);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1107,7 +1106,7 @@ TEST_F(AvmArithmeticTestsU16, multiplication)
     trace_builder.op_set(0, 200, 0, AvmMemoryTag::U16);
     trace_builder.op_set(0, 245, 1, AvmMemoryTag::U16);
 
-    trace_builder.op_mul(0, 0, 1, 2, AvmMemoryTag::U16);
+    trace_builder.op_mul(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1126,7 +1125,7 @@ TEST_F(AvmArithmeticTestsU16, multiplicationOverflow)
     trace_builder.op_set(0, 512, 0, AvmMemoryTag::U16);
     trace_builder.op_set(0, 1024, 1, AvmMemoryTag::U16);
 
-    trace_builder.op_mul(0, 0, 1, 2, AvmMemoryTag::U16);
+    trace_builder.op_mul(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1175,7 +1174,7 @@ TEST_F(AvmArithmeticTestsU32, addition)
     trace_builder.op_set(0, 1000000000, 8, AvmMemoryTag::U32);
     trace_builder.op_set(0, 1234567891, 9, AvmMemoryTag::U32);
 
-    trace_builder.op_add(0, 8, 9, 0, AvmMemoryTag::U32);
+    trace_builder.op_add(0, 8, 9, 0);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1195,7 +1194,7 @@ TEST_F(AvmArithmeticTestsU32, additionCarry)
     trace_builder.op_set(0, UINT32_MAX - 1293, 8, AvmMemoryTag::U32);
     trace_builder.op_set(0, 2293, 9, AvmMemoryTag::U32);
 
-    trace_builder.op_add(0, 8, 9, 0, AvmMemoryTag::U32);
+    trace_builder.op_add(0, 8, 9, 0);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1215,7 +1214,7 @@ TEST_F(AvmArithmeticTestsU32, subtraction)
     trace_builder.op_set(0, 1345678991, 8, AvmMemoryTag::U32);
     trace_builder.op_set(0, 1234567891, 9, AvmMemoryTag::U32);
 
-    trace_builder.op_sub(0, 8, 9, 0, AvmMemoryTag::U32);
+    trace_builder.op_sub(0, 8, 9, 0);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1236,7 +1235,7 @@ TEST_F(AvmArithmeticTestsU32, subtractionCarry)
     trace_builder.op_set(0, UINT32_MAX - 99, 8, AvmMemoryTag::U32);
     trace_builder.op_set(0, uint256_t(3210987654), 9, AvmMemoryTag::U32);
 
-    trace_builder.op_sub(0, 9, 8, 0, AvmMemoryTag::U32);
+    trace_builder.op_sub(0, 9, 8, 0);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1256,7 +1255,7 @@ TEST_F(AvmArithmeticTestsU32, multiplication)
     trace_builder.op_set(0, 11111, 0, AvmMemoryTag::U32);
     trace_builder.op_set(0, 11111, 1, AvmMemoryTag::U32);
 
-    trace_builder.op_mul(0, 0, 1, 2, AvmMemoryTag::U32);
+    trace_builder.op_mul(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1276,7 +1275,7 @@ TEST_F(AvmArithmeticTestsU32, multiplicationOverflow)
     trace_builder.op_set(0, 11 << 25, 0, AvmMemoryTag::U32);
     trace_builder.op_set(0, 13 << 22, 1, AvmMemoryTag::U32);
 
-    trace_builder.op_mul(0, 0, 1, 2, AvmMemoryTag::U32);
+    trace_builder.op_mul(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1333,7 +1332,7 @@ TEST_F(AvmArithmeticTestsU64, addition)
     trace_builder.op_set(0, a, 8, AvmMemoryTag::U64);
     trace_builder.op_set(0, b, 9, AvmMemoryTag::U64);
 
-    trace_builder.op_add(0, 8, 9, 9, AvmMemoryTag::U64);
+    trace_builder.op_add(0, 8, 9, 9);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1356,7 +1355,7 @@ TEST_F(AvmArithmeticTestsU64, additionCarry)
     trace_builder.op_set(0, a, 0, AvmMemoryTag::U64);
     trace_builder.op_set(0, b, 1, AvmMemoryTag::U64);
 
-    trace_builder.op_add(0, 0, 1, 0, AvmMemoryTag::U64);
+    trace_builder.op_add(0, 0, 1, 0);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1379,7 +1378,7 @@ TEST_F(AvmArithmeticTestsU64, subtraction)
     trace_builder.op_set(0, a, 8, AvmMemoryTag::U64);
     trace_builder.op_set(0, b, 9, AvmMemoryTag::U64);
 
-    trace_builder.op_sub(0, 8, 9, 9, AvmMemoryTag::U64);
+    trace_builder.op_sub(0, 8, 9, 9);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1403,7 +1402,7 @@ TEST_F(AvmArithmeticTestsU64, subtractionCarry)
     trace_builder.op_set(0, a, 0, AvmMemoryTag::U64);
     trace_builder.op_set(0, b, 1, AvmMemoryTag::U64);
 
-    trace_builder.op_sub(0, 0, 1, 0, AvmMemoryTag::U64);
+    trace_builder.op_sub(0, 0, 1, 0);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1422,7 +1421,7 @@ TEST_F(AvmArithmeticTestsU64, multiplication)
     trace_builder.op_set(0, 999888777, 0, AvmMemoryTag::U64);
     trace_builder.op_set(0, 555444333, 1, AvmMemoryTag::U64);
 
-    trace_builder.op_mul(0, 0, 1, 2, AvmMemoryTag::U64);
+    trace_builder.op_mul(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1446,7 +1445,7 @@ TEST_F(AvmArithmeticTestsU64, multiplicationOverflow)
     trace_builder.op_set(0, a, 0, AvmMemoryTag::U64);
     trace_builder.op_set(0, b, 1, AvmMemoryTag::U64);
 
-    trace_builder.op_mul(0, 0, 1, 2, AvmMemoryTag::U64);
+    trace_builder.op_mul(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1500,7 +1499,7 @@ TEST_F(AvmArithmeticTestsU128, addition)
     trace_builder.op_set(0, a, 8, AvmMemoryTag::U128);
     trace_builder.op_set(0, b, 9, AvmMemoryTag::U128);
 
-    trace_builder.op_add(0, 8, 9, 9, AvmMemoryTag::U128);
+    trace_builder.op_add(0, 8, 9, 9);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1524,7 +1523,7 @@ TEST_F(AvmArithmeticTestsU128, additionCarry)
     trace_builder.op_set(0, a, 8, AvmMemoryTag::U128);
     trace_builder.op_set(0, b, 9, AvmMemoryTag::U128);
 
-    trace_builder.op_add(0, 8, 9, 9, AvmMemoryTag::U128);
+    trace_builder.op_add(0, 8, 9, 9);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1547,7 +1546,7 @@ TEST_F(AvmArithmeticTestsU128, subtraction)
     trace_builder.op_set(0, a, 8, AvmMemoryTag::U128);
     trace_builder.op_set(0, b, 9, AvmMemoryTag::U128);
 
-    trace_builder.op_sub(0, 8, 9, 9, AvmMemoryTag::U128);
+    trace_builder.op_sub(0, 8, 9, 9);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1570,7 +1569,7 @@ TEST_F(AvmArithmeticTestsU128, subtractionCarry)
     trace_builder.op_set(0, a, 8, AvmMemoryTag::U128);
     trace_builder.op_set(0, b, 9, AvmMemoryTag::U128);
 
-    trace_builder.op_sub(0, 8, 9, 9, AvmMemoryTag::U128);
+    trace_builder.op_sub(0, 8, 9, 9);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1591,7 +1590,7 @@ TEST_F(AvmArithmeticTestsU128, multiplication)
     // Integer multiplication output in HEX: 70289AEB0A7DDA0BAE60CA3A5
     FF c{ uint256_t{ 0xA7DDA0BAE60CA3A5, 0x70289AEB0, 0, 0 } };
 
-    trace_builder.op_mul(0, 0, 1, 2, AvmMemoryTag::U128);
+    trace_builder.op_mul(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1616,7 +1615,7 @@ TEST_F(AvmArithmeticTestsU128, multiplicationOverflow)
     trace_builder.op_set(0, a, 0, AvmMemoryTag::U128);
     trace_builder.op_set(0, b, 1, AvmMemoryTag::U128);
 
-    trace_builder.op_mul(0, 0, 1, 2, AvmMemoryTag::U128);
+    trace_builder.op_mul(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1710,7 +1709,7 @@ TEST_F(AvmArithmeticNegativeTestsFF, fDivision)
     trace_builder.op_calldata_copy(0, 0, 2, 0);
 
     //                  Memory layout:    [15,315,0,0,0,0,....]
-    trace_builder.op_fdiv(0, 1, 0, 2, AvmMemoryTag::FF); // [15,315,21,0,0,0....]
+    trace_builder.op_fdiv(0, 1, 0, 2); // [15,315,21,0,0,0....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1729,7 +1728,7 @@ TEST_F(AvmArithmeticNegativeTestsFF, fDivisionNoZeroButError)
     trace_builder.op_calldata_copy(0, 0, 2, 0);
 
     //                  Memory layout:    [15,315,0,0,0,0,....]
-    trace_builder.op_fdiv(0, 1, 0, 2, AvmMemoryTag::FF); // [15,315,21,0,0,0....]
+    trace_builder.op_fdiv(0, 1, 0, 2); // [15,315,21,0,0,0....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1757,7 +1756,7 @@ TEST_F(AvmArithmeticNegativeTestsFF, fDivisionByZeroNoError)
     trace_builder.op_calldata_copy(0, 0, 1, 0);
 
     //                  Memory layout:    [15,0,0,0,0,0,....]
-    trace_builder.op_fdiv(0, 0, 1, 2, AvmMemoryTag::FF); // [15,0,0,0,0,0....]
+    trace_builder.op_fdiv(0, 0, 1, 2); // [15,0,0,0,0,0....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1774,7 +1773,7 @@ TEST_F(AvmArithmeticNegativeTestsFF, fDivisionByZeroNoError)
 TEST_F(AvmArithmeticNegativeTestsFF, fDivisionZeroByZeroNoError)
 {
     //                  Memory layout:    [0,0,0,0,0,0,....]
-    trace_builder.op_fdiv(0, 0, 1, 2, AvmMemoryTag::FF); // [0,0,0,0,0,0....]
+    trace_builder.op_fdiv(0, 0, 1, 2); // [0,0,0,0,0,0....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1794,7 +1793,7 @@ TEST_F(AvmArithmeticNegativeTestsFF, fDivisionWrongRInTag)
     gen_trace_builder(calldata);
     trace_builder.op_calldata_copy(0, 0, 1, 0);
     //                  Memory layout:    [18,6,0,0,0,0,....]
-    trace_builder.op_fdiv(0, 0, 1, 2, AvmMemoryTag::FF); // [18,6,3,0,0,0....]
+    trace_builder.op_fdiv(0, 0, 1, 2); // [18,6,3,0,0,0....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1814,7 +1813,7 @@ TEST_F(AvmArithmeticNegativeTestsFF, fDivisionWrongWInTag)
     gen_trace_builder(calldata);
     trace_builder.op_calldata_copy(0, 0, 1, 0);
     //                  Memory layout:    [18,6,0,0,0,0,....]
-    trace_builder.op_fdiv(0, 0, 1, 2, AvmMemoryTag::FF); // [18,6,3,0,0,0....]
+    trace_builder.op_fdiv(0, 0, 1, 2); // [18,6,3,0,0,0....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -1836,7 +1835,7 @@ TEST_F(AvmArithmeticNegativeTestsFF, operationWithErrorFlag1)
     trace_builder.op_calldata_copy(0, 0, 3, 0);
 
     //                             Memory layout:    [37,4,11,0,0,0,....]
-    trace_builder.op_add(0, 0, 1, 4, AvmMemoryTag::FF); // [37,4,11,0,41,0,....]
+    trace_builder.op_add(0, 0, 1, 4); // [37,4,11,0,41,0,....]
     trace_builder.op_return(0, 0, 5);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
@@ -1857,7 +1856,7 @@ TEST_F(AvmArithmeticNegativeTestsFF, operationWithErrorFlag2)
     trace_builder.op_calldata_copy(0, 0, 3, 0);
 
     //                             Memory layout:    [8,4,17,0,0,0,....]
-    trace_builder.op_sub(0, 2, 0, 1, AvmMemoryTag::FF); // [8,9,17,0,0,0....]
+    trace_builder.op_sub(0, 2, 0, 1); // [8,9,17,0,0,0....]
     trace_builder.op_return(0, 0, 3);
     auto trace = trace_builder.finalize();
 
@@ -1877,7 +1876,7 @@ TEST_F(AvmArithmeticNegativeTestsFF, operationWithErrorFlag3)
     trace_builder.op_calldata_copy(0, 0, 3, 0);
 
     //                             Memory layout:    [5,0,20,0,0,0,....]
-    trace_builder.op_mul(0, 2, 0, 1, AvmMemoryTag::FF); // [5,100,20,0,0,0....]
+    trace_builder.op_mul(0, 2, 0, 1); // [5,100,20,0,0,0....]
     trace_builder.op_return(0, 0, 3);
     auto trace = trace_builder.finalize();
 
@@ -1920,7 +1919,7 @@ TEST_F(AvmArithmeticNegativeTestsFF, eqOutputWrongTag)
     std::vector<FF> const calldata = { elem, elem };
     gen_trace_builder(calldata);
     trace_builder.op_calldata_copy(0, 0, 2, 0);
-    trace_builder.op_eq(0, 0, 1, 2, AvmMemoryTag::FF); // Memory Layout [elem, elem, 1, 0..]
+    trace_builder.op_eq(0, 0, 1, 2); // Memory Layout [elem, elem, 1, 0..]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -2270,7 +2269,7 @@ TEST_F(AvmArithmeticNegativeTestsU128, multiplicationSecondRowNoOp)
     trace_builder.op_set(0, 3, 0, AvmMemoryTag::U128);
     trace_builder.op_set(0, 4, 1, AvmMemoryTag::U128);
 
-    trace_builder.op_mul(0, 0, 1, 2, AvmMemoryTag::U128);
+    trace_builder.op_mul(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm/tests/bitwise.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/tests/bitwise.test.cpp
@@ -494,7 +494,7 @@ TEST_P(AvmBitwiseTestsAnd, AllAndTest)
     const auto [a, b, output] = operands;
     trace_builder.op_set(0, a, 0, mem_tag);
     trace_builder.op_set(0, b, 1, mem_tag);
-    trace_builder.op_and(0, 0, 1, 2, mem_tag);
+    trace_builder.op_and(0, 0, 1, 2);
     trace_builder.op_return(0, 2, 1);
 
     auto trace = trace_builder.finalize();
@@ -511,7 +511,7 @@ TEST_P(AvmBitwiseTestsOr, AllOrTest)
     const auto [a, b, output] = operands;
     trace_builder.op_set(0, a, 0, mem_tag);
     trace_builder.op_set(0, b, 1, mem_tag);
-    trace_builder.op_or(0, 0, 1, 2, mem_tag);
+    trace_builder.op_or(0, 0, 1, 2);
     trace_builder.op_return(0, 2, 1);
     auto trace = trace_builder.finalize();
 
@@ -528,7 +528,7 @@ TEST_P(AvmBitwiseTestsXor, AllXorTest)
     const auto [a, b, output] = operands;
     trace_builder.op_set(0, a, 0, mem_tag);
     trace_builder.op_set(0, b, 1, mem_tag);
-    trace_builder.op_xor(0, 0, 1, 2, mem_tag);
+    trace_builder.op_xor(0, 0, 1, 2);
     trace_builder.op_return(0, 2, 1);
     auto trace = trace_builder.finalize();
 
@@ -546,7 +546,7 @@ TEST_P(AvmBitwiseTestsShr, AllShrTest)
     const auto [a, b, output] = operands;
     trace_builder.op_set(0, a, 0, mem_tag);
     trace_builder.op_set(0, b, 1, mem_tag);
-    trace_builder.op_shr(0, 0, 1, 2, mem_tag);
+    trace_builder.op_shr(0, 0, 1, 2);
     trace_builder.op_return(0, 2, 1);
     auto trace = trace_builder.finalize();
     common_validate_shift_op(trace, a, b, output, FF(0), FF(1), FF(2), mem_tag, true);
@@ -563,7 +563,7 @@ TEST_P(AvmBitwiseTestsShl, AllShlTest)
     const auto [a, b, output] = operands;
     trace_builder.op_set(0, a, 0, mem_tag);
     trace_builder.op_set(0, b, 1, mem_tag);
-    trace_builder.op_shl(0, 0, 1, 2, mem_tag);
+    trace_builder.op_shl(0, 0, 1, 2);
     trace_builder.op_return(0, 2, 1);
     auto trace = trace_builder.finalize();
 
@@ -667,7 +667,7 @@ TEST_P(AvmBitwiseNegativeTestsAnd, AllNegativeTests)
     const auto [a, b, output] = operands;
     trace_builder.op_set(0, a, 0, mem_tag);
     trace_builder.op_set(0, b, 1, mem_tag);
-    trace_builder.op_and(0, 0, 1, 2, mem_tag);
+    trace_builder.op_and(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
     std::function<bool(Row)>&& select_row = [](Row r) { return r.main_sel_op_and == FF(1); };
@@ -686,7 +686,7 @@ TEST_P(AvmBitwiseNegativeTestsOr, AllNegativeTests)
     const auto [a, b, output] = operands;
     trace_builder.op_set(0, a, 0, mem_tag);
     trace_builder.op_set(0, b, 1, mem_tag);
-    trace_builder.op_or(0, 0, 1, 2, mem_tag);
+    trace_builder.op_or(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
     std::function<bool(Row)>&& select_row = [](Row r) { return r.main_sel_op_or == FF(1); };
@@ -704,7 +704,7 @@ TEST_P(AvmBitwiseNegativeTestsXor, AllNegativeTests)
     const auto [a, b, output] = operands;
     trace_builder.op_set(0, a, 0, mem_tag);
     trace_builder.op_set(0, b, 1, mem_tag);
-    trace_builder.op_xor(0, 0, 1, 2, mem_tag);
+    trace_builder.op_xor(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
     std::function<bool(Row)>&& select_row = [](Row r) { return r.main_sel_op_xor == FF(1); };
@@ -722,7 +722,7 @@ TEST_P(AvmBitwiseNegativeTestsShr, AllNegativeTests)
     const auto [a, b, output] = operands;
     trace_builder.op_set(0, a, 0, mem_tag);
     trace_builder.op_set(0, b, 1, mem_tag);
-    trace_builder.op_shr(0, 0, 1, 2, mem_tag);
+    trace_builder.op_shr(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
     std::function<bool(Row)>&& select_row = [](Row r) { return r.main_sel_op_shr == FF(1); };
@@ -741,7 +741,7 @@ TEST_P(AvmBitwiseNegativeTestsShl, AllNegativeTests)
     const auto [a, b, output] = operands;
     trace_builder.op_set(0, a, 0, mem_tag);
     trace_builder.op_set(0, b, 1, mem_tag);
-    trace_builder.op_shl(0, 0, 1, 2, mem_tag);
+    trace_builder.op_shl(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
     std::function<bool(Row)>&& select_row = [](Row r) { return r.main_sel_op_shl == FF(1); };

--- a/barretenberg/cpp/src/barretenberg/vm/avm/tests/comparison.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/tests/comparison.test.cpp
@@ -121,7 +121,7 @@ TEST_P(AvmCmpTestsLT, ParamTest)
         trace_builder.op_set(0, a, 0, mem_tag);
         trace_builder.op_set(0, b, 1, mem_tag);
     }
-    trace_builder.op_lt(0, 0, 1, 2, mem_tag);
+    trace_builder.op_lt(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -159,7 +159,7 @@ TEST_P(AvmCmpTestsLTE, ParamTest)
         trace_builder.op_set(0, a, 0, mem_tag);
         trace_builder.op_set(0, b, 1, mem_tag);
     }
-    trace_builder.op_lte(0, 0, 1, 2, mem_tag);
+    trace_builder.op_lte(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
     auto row = std::ranges::find_if(trace.begin(), trace.end(), [](Row r) { return r.main_sel_op_lte == FF(1); });
@@ -335,7 +335,7 @@ TEST_P(AvmCmpNegativeTestsLT, ParamTest)
                         .set_full_precomputed_tables(false)
                         .set_range_check_required(false);
     trace_builder.op_calldata_copy(0, 0, 3, 0);
-    trace_builder.op_lt(0, 0, 1, 2, AvmMemoryTag::FF);
+    trace_builder.op_lt(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
     std::function<bool(Row)> select_row = [](Row r) { return r.main_sel_op_lt == FF(1); };
@@ -356,7 +356,7 @@ TEST_P(AvmCmpNegativeTestsLTE, ParamTest)
                         .set_full_precomputed_tables(false)
                         .set_range_check_required(false);
     trace_builder.op_calldata_copy(0, 0, 3, 0);
-    trace_builder.op_lte(0, 0, 1, 2, AvmMemoryTag::FF);
+    trace_builder.op_lte(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
     std::function<bool(Row)> select_row = [](Row r) { return r.main_sel_op_lte == FF(1); };

--- a/barretenberg/cpp/src/barretenberg/vm/avm/tests/gas.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/tests/gas.test.cpp
@@ -54,19 +54,18 @@ void test_gas(StartGas startGas, OpcodesFunc apply_opcodes, CheckFunc check_trac
     validate_trace(std::move(trace), public_inputs);
 }
 
-TEST_F(AvmGasPositiveTests, gasAdd)
+TEST_F(AvmGasPositiveTests, gasMov)
 {
     StartGas start_gas = {
         .l2_gas = 3000,
         .da_gas = 10,
     };
 
-    // We test that the sender opcode is included at index 0 in the public inputs
-    auto apply_opcodes = [=](AvmTraceBuilder& trace_builder) { trace_builder.op_add(0, 1, 2, 3); };
+    auto apply_opcodes = [=](AvmTraceBuilder& trace_builder) { trace_builder.op_mov(0, 1, 2); };
 
     auto checks = [=](const std::vector<Row>& trace) {
         auto sender_row =
-            std::ranges::find_if(trace.begin(), trace.end(), [](Row r) { return r.main_sel_op_add == FF(1); });
+            std::ranges::find_if(trace.begin(), trace.end(), [](Row r) { return r.main_sel_op_mov == FF(1); });
         EXPECT_TRUE(sender_row != trace.end());
     };
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm/tests/gas.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/tests/gas.test.cpp
@@ -62,7 +62,7 @@ TEST_F(AvmGasPositiveTests, gasAdd)
     };
 
     // We test that the sender opcode is included at index 0 in the public inputs
-    auto apply_opcodes = [=](AvmTraceBuilder& trace_builder) { trace_builder.op_add(0, 1, 2, 3, AvmMemoryTag::FF); };
+    auto apply_opcodes = [=](AvmTraceBuilder& trace_builder) { trace_builder.op_add(0, 1, 2, 3); };
 
     auto checks = [=](const std::vector<Row>& trace) {
         auto sender_row =

--- a/barretenberg/cpp/src/barretenberg/vm/avm/tests/indirect_mem.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/tests/indirect_mem.test.cpp
@@ -41,7 +41,7 @@ TEST_F(AvmIndirectMemTests, allIndirectAdd)
     trace_builder.op_set(0, 101, 11, AvmMemoryTag::U16);
 
     // All indirect flags are encoded as 7 = 1 + 2 + 4
-    trace_builder.op_add(7, 0, 1, 2, AvmMemoryTag::U16);
+    trace_builder.op_add(7, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -90,7 +90,7 @@ TEST_F(AvmIndirectMemTests, indirectOutputSub)
     trace_builder.op_set(0, 500, 51, AvmMemoryTag::U128);
 
     // The indirect flag is encoded as 4
-    trace_builder.op_sub(4, 50, 51, 5, AvmMemoryTag::U128);
+    trace_builder.op_sub(4, 50, 51, 5);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -138,7 +138,7 @@ TEST_F(AvmIndirectMemTests, indirectInputAMul)
     trace_builder.op_set(0, 7, 101, AvmMemoryTag::U64);
 
     // The indirect flag is encoded as 1
-    trace_builder.op_mul(1, 1000, 101, 102, AvmMemoryTag::U64);
+    trace_builder.op_mul(1, 1000, 101, 102);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm/tests/inter_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/tests/inter_table.test.cpp
@@ -55,9 +55,9 @@ class AvmPermMainAluNegativeTests : public AvmInterTableTests {
 
         trace_builder.op_set(0, 19, 0, AvmMemoryTag::U64);
         trace_builder.op_set(0, 15, 1, AvmMemoryTag::U64);
-        trace_builder.op_add(0, 0, 1, 1, AvmMemoryTag::U64); // 19 + 15 = 34
-        trace_builder.op_add(0, 0, 1, 1, AvmMemoryTag::U64); // 19 + 34 = 53
-        trace_builder.op_mul(0, 0, 1, 2, AvmMemoryTag::U64); // 19 * 53 = 1007
+        trace_builder.op_add(0, 0, 1, 1); // 19 + 15 = 34
+        trace_builder.op_add(0, 0, 1, 1); // 19 + 34 = 53
+        trace_builder.op_mul(0, 0, 1, 2); // 19 * 53 = 1007
         trace_builder.op_return(0, 0, 0);
 
         trace = trace_builder.finalize();
@@ -152,7 +152,7 @@ class AvmRangeCheckNegativeTests : public AvmInterTableTests {
     {
         trace_builder.op_set(0, a, 0, tag);
         trace_builder.op_set(0, b, 1, tag);
-        trace_builder.op_add(0, 0, 1, 2, tag); // 7 + 8 = 15
+        trace_builder.op_add(0, 0, 1, 2); // 7 + 8 = 15
         trace_builder.op_return(0, 0, 0);
         trace = trace_builder.finalize();
 
@@ -403,7 +403,7 @@ class AvmPermMainMemNegativeTests : public AvmInterTableTests {
     {
         trace_builder.op_set(0, a, 52, AvmMemoryTag::U8);
         trace_builder.op_set(0, b, 11, AvmMemoryTag::U8);
-        trace_builder.op_sub(0, 52, 11, 55, AvmMemoryTag::U8);
+        trace_builder.op_sub(0, 52, 11, 55);
         trace_builder.op_return(0, 0, 0);
 
         trace = trace_builder.finalize();
@@ -449,7 +449,7 @@ TEST_F(AvmPermMainMemNegativeTests, tagErrNotCopiedInMain)
     // Equality operation on U128 and second operand is of type U16.
     trace_builder.op_set(0, 32, 18, AvmMemoryTag::U128);
     trace_builder.op_set(0, 32, 76, AvmMemoryTag::U16);
-    trace_builder.op_eq(0, 18, 76, 65, AvmMemoryTag::U128);
+    trace_builder.op_eq(0, 18, 76, 65);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm/tests/memory.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/tests/memory.test.cpp
@@ -44,7 +44,7 @@ TEST_F(AvmMemoryTests, mismatchedTagAddOperation)
     trace_builder.op_set(0, 2, 1, AvmMemoryTag::U32);
     trace_builder.op_calldata_copy(0, 0, 1, 0);
 
-    trace_builder.op_add(0, 0, 1, 4, AvmMemoryTag::U8);
+    trace_builder.op_add(0, 0, 1, 4);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -91,7 +91,7 @@ TEST_F(AvmMemoryTests, mismatchedTagEqOperation)
     trace_builder.op_set(0, 3, 0, AvmMemoryTag::U32);
     trace_builder.op_set(0, 5, 1, AvmMemoryTag::U16);
 
-    trace_builder.op_eq(0, 0, 1, 2, AvmMemoryTag::U32);
+    trace_builder.op_eq(0, 0, 1, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -135,7 +135,7 @@ TEST_F(AvmMemoryTests, mLastAccessViolation)
     trace_builder.op_set(0, 9, 1, AvmMemoryTag::U8);
 
     //                           Memory layout:     [4,9,0,0,0,0,....]
-    trace_builder.op_sub(0, 1, 0, 2, AvmMemoryTag::U8); // [4,9,5,0,0,0.....]
+    trace_builder.op_sub(0, 1, 0, 2); // [4,9,5,0,0,0.....]
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -166,8 +166,8 @@ TEST_F(AvmMemoryTests, readWriteConsistencyValViolation)
     trace_builder.op_set(0, 9, 1, AvmMemoryTag::U8);
 
     //                           Memory layout:      [4,9,0,0,0,0,....]
-    trace_builder.op_mul(0, 1, 0, 2, AvmMemoryTag::U8); // [4,9,36,0,0,0.....]
-    trace_builder.op_return(0, 2, 1);                   // Return single memory word at position 2 (36)
+    trace_builder.op_mul(0, 1, 0, 2); // [4,9,36,0,0,0.....]
+    trace_builder.op_return(0, 2, 1); // Return single memory word at position 2 (36)
     auto trace = trace_builder.finalize();
 
     // Find the row with multiplication operation
@@ -196,8 +196,8 @@ TEST_F(AvmMemoryTests, readWriteConsistencyTagViolation)
     trace_builder.op_set(0, 9, 1, AvmMemoryTag::U8);
 
     //                           Memory layout:      [4,9,0,0,0,0,....]
-    trace_builder.op_mul(0, 1, 0, 2, AvmMemoryTag::U8); // [4,9,36,0,0,0.....]
-    trace_builder.op_return(0, 2, 1);                   // Return single memory word at position 2 (36)
+    trace_builder.op_mul(0, 1, 0, 2); // [4,9,36,0,0,0.....]
+    trace_builder.op_return(0, 2, 1); // Return single memory word at position 2 (36)
     auto trace = trace_builder.finalize();
 
     // Find the row with multiplication operation
@@ -240,7 +240,7 @@ TEST_F(AvmMemoryTests, mismatchedTagErrorViolation)
     trace_builder.op_set(0, 2, 1, AvmMemoryTag::U32);
     trace_builder.op_calldata_copy(0, 0, 1, 0);
 
-    trace_builder.op_sub(0, 0, 1, 4, AvmMemoryTag::U8);
+    trace_builder.op_sub(0, 0, 1, 4);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -277,7 +277,7 @@ TEST_F(AvmMemoryTests, consistentTagNoErrorViolation)
                         .set_range_check_required(false);
     trace_builder.op_set(0, 2, 1, AvmMemoryTag::U32);
     trace_builder.op_calldata_copy(0, 0, 1, 0);
-    trace_builder.op_fdiv(0, 0, 1, 4, AvmMemoryTag::FF);
+    trace_builder.op_fdiv(0, 0, 1, 4);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -306,7 +306,7 @@ TEST_F(AvmMemoryTests, noErrorTagWriteViolation)
                         .set_range_check_required(false);
     trace_builder.op_set(0, 2, 1, AvmMemoryTag::U32);
     trace_builder.op_calldata_copy(0, 0, 1, 0);
-    trace_builder.op_fdiv(0, 0, 1, 4, AvmMemoryTag::FF);
+    trace_builder.op_fdiv(0, 0, 1, 4);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -338,7 +338,7 @@ TEST_F(AvmMemoryTests, directRelativeMemory)
 
     // Addition with direct relative addressing on the 2 input operands and direct addressing on the output
     // indirect byte: 00011000 = 24
-    trace_builder.op_add(24, 10, 100, 10, AvmMemoryTag::U16);
+    trace_builder.op_add(24, 10, 100, 10);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 
@@ -369,7 +369,7 @@ TEST_F(AvmMemoryTests, indirectRelativeMemory)
 
     // Output c = a + b = 8 is stored at direct relative offset 2, i.e., address 102.
     // indirect byte: 00111011 = 1 + 2 + 8 + 16 + 32 = 59
-    trace_builder.op_add(59, 23, 47, 2, AvmMemoryTag::U8);
+    trace_builder.op_add(59, 23, 47, 2);
     trace_builder.op_return(0, 0, 0);
     auto trace = trace_builder.finalize();
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/deserialization.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/deserialization.cpp
@@ -16,10 +16,16 @@ namespace bb::avm_trace {
 namespace {
 
 const std::vector<OperandType> three_operand_format8 = {
-    OperandType::INDIRECT8, OperandType::TAG, OperandType::UINT8, OperandType::UINT8, OperandType::UINT8,
+    OperandType::INDIRECT8,
+    OperandType::UINT8,
+    OperandType::UINT8,
+    OperandType::UINT8,
 };
 const std::vector<OperandType> three_operand_format16 = {
-    OperandType::INDIRECT8, OperandType::TAG, OperandType::UINT16, OperandType::UINT16, OperandType::UINT16,
+    OperandType::INDIRECT8,
+    OperandType::UINT16,
+    OperandType::UINT16,
+    OperandType::UINT16,
 };
 const std::vector<OperandType> kernel_input_operand_format = { OperandType::INDIRECT8, OperandType::UINT16 };
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/execution.cpp
@@ -314,157 +314,135 @@ std::vector<Row> Execution::gen_trace(std::vector<Instruction> const& instructio
             // Compute - Arithmetic
         case OpCode::ADD_8:
             trace_builder.op_add(std::get<uint8_t>(inst.operands.at(0)),
+                                 std::get<uint8_t>(inst.operands.at(1)),
                                  std::get<uint8_t>(inst.operands.at(2)),
-                                 std::get<uint8_t>(inst.operands.at(3)),
-                                 std::get<uint8_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint8_t>(inst.operands.at(3)));
             break;
         case OpCode::ADD_16:
             trace_builder.op_add(std::get<uint8_t>(inst.operands.at(0)),
+                                 std::get<uint16_t>(inst.operands.at(1)),
                                  std::get<uint16_t>(inst.operands.at(2)),
-                                 std::get<uint16_t>(inst.operands.at(3)),
-                                 std::get<uint16_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint16_t>(inst.operands.at(3)));
             break;
         case OpCode::SUB_8:
             trace_builder.op_sub(std::get<uint8_t>(inst.operands.at(0)),
+                                 std::get<uint8_t>(inst.operands.at(1)),
                                  std::get<uint8_t>(inst.operands.at(2)),
-                                 std::get<uint8_t>(inst.operands.at(3)),
-                                 std::get<uint8_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint8_t>(inst.operands.at(3)));
             break;
         case OpCode::SUB_16:
             trace_builder.op_sub(std::get<uint8_t>(inst.operands.at(0)),
+                                 std::get<uint16_t>(inst.operands.at(1)),
                                  std::get<uint16_t>(inst.operands.at(2)),
-                                 std::get<uint16_t>(inst.operands.at(3)),
-                                 std::get<uint16_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint16_t>(inst.operands.at(3)));
             break;
         case OpCode::MUL_8:
             trace_builder.op_mul(std::get<uint8_t>(inst.operands.at(0)),
+                                 std::get<uint8_t>(inst.operands.at(1)),
                                  std::get<uint8_t>(inst.operands.at(2)),
-                                 std::get<uint8_t>(inst.operands.at(3)),
-                                 std::get<uint8_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint8_t>(inst.operands.at(3)));
             break;
         case OpCode::MUL_16:
             trace_builder.op_mul(std::get<uint8_t>(inst.operands.at(0)),
+                                 std::get<uint16_t>(inst.operands.at(1)),
                                  std::get<uint16_t>(inst.operands.at(2)),
-                                 std::get<uint16_t>(inst.operands.at(3)),
-                                 std::get<uint16_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint16_t>(inst.operands.at(3)));
             break;
         case OpCode::DIV_8:
             trace_builder.op_div(std::get<uint8_t>(inst.operands.at(0)),
+                                 std::get<uint8_t>(inst.operands.at(1)),
                                  std::get<uint8_t>(inst.operands.at(2)),
-                                 std::get<uint8_t>(inst.operands.at(3)),
-                                 std::get<uint8_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint8_t>(inst.operands.at(3)));
             break;
         case OpCode::DIV_16:
             trace_builder.op_div(std::get<uint8_t>(inst.operands.at(0)),
+                                 std::get<uint16_t>(inst.operands.at(1)),
                                  std::get<uint16_t>(inst.operands.at(2)),
-                                 std::get<uint16_t>(inst.operands.at(3)),
-                                 std::get<uint16_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint16_t>(inst.operands.at(3)));
             break;
         case OpCode::FDIV_8:
             trace_builder.op_fdiv(std::get<uint8_t>(inst.operands.at(0)),
+                                  std::get<uint8_t>(inst.operands.at(1)),
                                   std::get<uint8_t>(inst.operands.at(2)),
-                                  std::get<uint8_t>(inst.operands.at(3)),
-                                  std::get<uint8_t>(inst.operands.at(4)),
-                                  std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                  std::get<uint8_t>(inst.operands.at(3)));
             break;
         case OpCode::FDIV_16:
             trace_builder.op_fdiv(std::get<uint8_t>(inst.operands.at(0)),
+                                  std::get<uint16_t>(inst.operands.at(1)),
                                   std::get<uint16_t>(inst.operands.at(2)),
-                                  std::get<uint16_t>(inst.operands.at(3)),
-                                  std::get<uint16_t>(inst.operands.at(4)),
-                                  std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                  std::get<uint16_t>(inst.operands.at(3)));
             break;
         case OpCode::EQ_8:
             trace_builder.op_eq(std::get<uint8_t>(inst.operands.at(0)),
+                                std::get<uint8_t>(inst.operands.at(1)),
                                 std::get<uint8_t>(inst.operands.at(2)),
-                                std::get<uint8_t>(inst.operands.at(3)),
-                                std::get<uint8_t>(inst.operands.at(4)),
-                                std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                std::get<uint8_t>(inst.operands.at(3)));
             break;
         case OpCode::EQ_16:
             trace_builder.op_eq(std::get<uint8_t>(inst.operands.at(0)),
+                                std::get<uint16_t>(inst.operands.at(1)),
                                 std::get<uint16_t>(inst.operands.at(2)),
-                                std::get<uint16_t>(inst.operands.at(3)),
-                                std::get<uint16_t>(inst.operands.at(4)),
-                                std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                std::get<uint16_t>(inst.operands.at(3)));
             break;
         case OpCode::LT_8:
             trace_builder.op_lt(std::get<uint8_t>(inst.operands.at(0)),
+                                std::get<uint8_t>(inst.operands.at(1)),
                                 std::get<uint8_t>(inst.operands.at(2)),
-                                std::get<uint8_t>(inst.operands.at(3)),
-                                std::get<uint8_t>(inst.operands.at(4)),
-                                std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                std::get<uint8_t>(inst.operands.at(3)));
             break;
         case OpCode::LT_16:
             trace_builder.op_lt(std::get<uint8_t>(inst.operands.at(0)),
+                                std::get<uint16_t>(inst.operands.at(1)),
                                 std::get<uint16_t>(inst.operands.at(2)),
-                                std::get<uint16_t>(inst.operands.at(3)),
-                                std::get<uint16_t>(inst.operands.at(4)),
-                                std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                std::get<uint16_t>(inst.operands.at(3)));
             break;
         case OpCode::LTE_8:
             trace_builder.op_lte(std::get<uint8_t>(inst.operands.at(0)),
                                  std::get<uint8_t>(inst.operands.at(2)),
-                                 std::get<uint8_t>(inst.operands.at(3)),
-                                 std::get<uint8_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint8_t>(inst.operands.at(2)),
+                                 std::get<uint8_t>(inst.operands.at(3)));
             break;
         case OpCode::LTE_16:
             trace_builder.op_lte(std::get<uint8_t>(inst.operands.at(0)),
+                                 std::get<uint16_t>(inst.operands.at(1)),
                                  std::get<uint16_t>(inst.operands.at(2)),
-                                 std::get<uint16_t>(inst.operands.at(3)),
-                                 std::get<uint16_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint16_t>(inst.operands.at(3)));
             break;
         case OpCode::AND_8:
             trace_builder.op_and(std::get<uint8_t>(inst.operands.at(0)),
                                  std::get<uint8_t>(inst.operands.at(2)),
-                                 std::get<uint8_t>(inst.operands.at(3)),
-                                 std::get<uint8_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint8_t>(inst.operands.at(2)),
+                                 std::get<uint8_t>(inst.operands.at(3)));
             break;
         case OpCode::AND_16:
             trace_builder.op_and(std::get<uint8_t>(inst.operands.at(0)),
+                                 std::get<uint16_t>(inst.operands.at(1)),
                                  std::get<uint16_t>(inst.operands.at(2)),
-                                 std::get<uint16_t>(inst.operands.at(3)),
-                                 std::get<uint16_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint16_t>(inst.operands.at(3)));
             break;
         case OpCode::OR_8:
             trace_builder.op_or(std::get<uint8_t>(inst.operands.at(0)),
+                                std::get<uint8_t>(inst.operands.at(1)),
                                 std::get<uint8_t>(inst.operands.at(2)),
-                                std::get<uint8_t>(inst.operands.at(3)),
-                                std::get<uint8_t>(inst.operands.at(4)),
-                                std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                std::get<uint8_t>(inst.operands.at(3)));
             break;
         case OpCode::OR_16:
             trace_builder.op_or(std::get<uint8_t>(inst.operands.at(0)),
+                                std::get<uint16_t>(inst.operands.at(1)),
                                 std::get<uint16_t>(inst.operands.at(2)),
-                                std::get<uint16_t>(inst.operands.at(3)),
-                                std::get<uint16_t>(inst.operands.at(4)),
-                                std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                std::get<uint16_t>(inst.operands.at(3)));
             break;
         case OpCode::XOR_8:
             trace_builder.op_xor(std::get<uint8_t>(inst.operands.at(0)),
                                  std::get<uint8_t>(inst.operands.at(2)),
-                                 std::get<uint8_t>(inst.operands.at(3)),
-                                 std::get<uint8_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint8_t>(inst.operands.at(2)),
+                                 std::get<uint8_t>(inst.operands.at(3)));
             break;
         case OpCode::XOR_16:
             trace_builder.op_xor(std::get<uint8_t>(inst.operands.at(0)),
+                                 std::get<uint16_t>(inst.operands.at(1)),
                                  std::get<uint16_t>(inst.operands.at(2)),
-                                 std::get<uint16_t>(inst.operands.at(3)),
-                                 std::get<uint16_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint16_t>(inst.operands.at(3)));
             break;
         case OpCode::NOT_8:
             trace_builder.op_not(std::get<uint8_t>(inst.operands.at(0)),
@@ -479,30 +457,26 @@ std::vector<Row> Execution::gen_trace(std::vector<Instruction> const& instructio
         case OpCode::SHL_8:
             trace_builder.op_shl(std::get<uint8_t>(inst.operands.at(0)),
                                  std::get<uint8_t>(inst.operands.at(2)),
-                                 std::get<uint8_t>(inst.operands.at(3)),
-                                 std::get<uint8_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint8_t>(inst.operands.at(2)),
+                                 std::get<uint8_t>(inst.operands.at(3)));
             break;
         case OpCode::SHL_16:
             trace_builder.op_shl(std::get<uint8_t>(inst.operands.at(0)),
+                                 std::get<uint16_t>(inst.operands.at(1)),
                                  std::get<uint16_t>(inst.operands.at(2)),
-                                 std::get<uint16_t>(inst.operands.at(3)),
-                                 std::get<uint16_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint16_t>(inst.operands.at(3)));
             break;
         case OpCode::SHR_8:
             trace_builder.op_shr(std::get<uint8_t>(inst.operands.at(0)),
                                  std::get<uint8_t>(inst.operands.at(2)),
-                                 std::get<uint8_t>(inst.operands.at(3)),
-                                 std::get<uint8_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint8_t>(inst.operands.at(2)),
+                                 std::get<uint8_t>(inst.operands.at(3)));
             break;
         case OpCode::SHR_16:
             trace_builder.op_shr(std::get<uint8_t>(inst.operands.at(0)),
+                                 std::get<uint16_t>(inst.operands.at(1)),
                                  std::get<uint16_t>(inst.operands.at(2)),
-                                 std::get<uint16_t>(inst.operands.at(3)),
-                                 std::get<uint16_t>(inst.operands.at(4)),
-                                 std::get<AvmMemoryTag>(inst.operands.at(1)));
+                                 std::get<uint16_t>(inst.operands.at(3)));
             break;
 
             // Compute - Type Conversions

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/execution.cpp
@@ -398,7 +398,7 @@ std::vector<Row> Execution::gen_trace(std::vector<Instruction> const& instructio
             break;
         case OpCode::LTE_8:
             trace_builder.op_lte(std::get<uint8_t>(inst.operands.at(0)),
-                                 std::get<uint8_t>(inst.operands.at(2)),
+                                 std::get<uint8_t>(inst.operands.at(1)),
                                  std::get<uint8_t>(inst.operands.at(2)),
                                  std::get<uint8_t>(inst.operands.at(3)));
             break;
@@ -410,7 +410,7 @@ std::vector<Row> Execution::gen_trace(std::vector<Instruction> const& instructio
             break;
         case OpCode::AND_8:
             trace_builder.op_and(std::get<uint8_t>(inst.operands.at(0)),
-                                 std::get<uint8_t>(inst.operands.at(2)),
+                                 std::get<uint8_t>(inst.operands.at(1)),
                                  std::get<uint8_t>(inst.operands.at(2)),
                                  std::get<uint8_t>(inst.operands.at(3)));
             break;
@@ -434,7 +434,7 @@ std::vector<Row> Execution::gen_trace(std::vector<Instruction> const& instructio
             break;
         case OpCode::XOR_8:
             trace_builder.op_xor(std::get<uint8_t>(inst.operands.at(0)),
-                                 std::get<uint8_t>(inst.operands.at(2)),
+                                 std::get<uint8_t>(inst.operands.at(1)),
                                  std::get<uint8_t>(inst.operands.at(2)),
                                  std::get<uint8_t>(inst.operands.at(3)));
             break;
@@ -456,7 +456,7 @@ std::vector<Row> Execution::gen_trace(std::vector<Instruction> const& instructio
             break;
         case OpCode::SHL_8:
             trace_builder.op_shl(std::get<uint8_t>(inst.operands.at(0)),
-                                 std::get<uint8_t>(inst.operands.at(2)),
+                                 std::get<uint8_t>(inst.operands.at(1)),
                                  std::get<uint8_t>(inst.operands.at(2)),
                                  std::get<uint8_t>(inst.operands.at(3)));
             break;
@@ -468,7 +468,7 @@ std::vector<Row> Execution::gen_trace(std::vector<Instruction> const& instructio
             break;
         case OpCode::SHR_8:
             trace_builder.op_shr(std::get<uint8_t>(inst.operands.at(0)),
-                                 std::get<uint8_t>(inst.operands.at(2)),
+                                 std::get<uint8_t>(inst.operands.at(1)),
                                  std::get<uint8_t>(inst.operands.at(2)),
                                  std::get<uint8_t>(inst.operands.at(3)));
             break;

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.cpp
@@ -286,8 +286,7 @@ AvmTraceBuilder::AvmTraceBuilder(VmPublicInputs public_inputs,
  * @param dst_offset An index in memory pointing to the output of the addition.
  * @param in_tag The instruction memory tag of the operands.
  */
-void AvmTraceBuilder::op_add(
-    uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag)
+void AvmTraceBuilder::op_add(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset)
 {
     auto clk = static_cast<uint32_t>(main_trace.size()) + 1;
 
@@ -295,6 +294,8 @@ void AvmTraceBuilder::op_add(
     auto [resolved_a, resolved_b, resolved_c] =
         Addressing<3>::fromWire(indirect, call_ptr).resolve({ a_offset, b_offset, dst_offset }, mem_trace_builder);
 
+    // We get our representative memory tag from the resolved_a memory address.
+    AvmMemoryTag in_tag = unconstrained_get_memory_tag(resolved_a);
     // Reading from memory and loading into ia resp. ib.
     auto read_a = constrained_read_from_memory(call_ptr, clk, resolved_a, in_tag, in_tag, IntermRegister::IA);
     auto read_b = constrained_read_from_memory(call_ptr, clk, resolved_b, in_tag, in_tag, IntermRegister::IB);
@@ -354,8 +355,7 @@ void AvmTraceBuilder::op_add(
  * @param dst_offset An index in memory pointing to the output of the subtraction.
  * @param in_tag The instruction memory tag of the operands.
  */
-void AvmTraceBuilder::op_sub(
-    uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag)
+void AvmTraceBuilder::op_sub(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset)
 {
     auto clk = static_cast<uint32_t>(main_trace.size()) + 1;
 
@@ -363,6 +363,8 @@ void AvmTraceBuilder::op_sub(
     auto [resolved_a, resolved_b, resolved_c] =
         Addressing<3>::fromWire(indirect, call_ptr).resolve({ a_offset, b_offset, dst_offset }, mem_trace_builder);
 
+    // We get our representative memory tag from the resolved_a memory address.
+    AvmMemoryTag in_tag = unconstrained_get_memory_tag(resolved_a);
     // Reading from memory and loading into ia resp. ib.
     auto read_a = constrained_read_from_memory(call_ptr, clk, resolved_a, in_tag, in_tag, IntermRegister::IA);
     auto read_b = constrained_read_from_memory(call_ptr, clk, resolved_b, in_tag, in_tag, IntermRegister::IB);
@@ -422,8 +424,7 @@ void AvmTraceBuilder::op_sub(
  * @param dst_offset An index in memory pointing to the output of the multiplication.
  * @param in_tag The instruction memory tag of the operands.
  */
-void AvmTraceBuilder::op_mul(
-    uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag)
+void AvmTraceBuilder::op_mul(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset)
 {
     auto clk = static_cast<uint32_t>(main_trace.size()) + 1;
 
@@ -431,6 +432,8 @@ void AvmTraceBuilder::op_mul(
     auto [resolved_a, resolved_b, resolved_c] =
         Addressing<3>::fromWire(indirect, call_ptr).resolve({ a_offset, b_offset, dst_offset }, mem_trace_builder);
 
+    // We get our representative memory tag from the resolved_a memory address.
+    AvmMemoryTag in_tag = unconstrained_get_memory_tag(resolved_a);
     // Reading from memory and loading into ia resp. ib.
     auto read_a = constrained_read_from_memory(call_ptr, clk, resolved_a, in_tag, in_tag, IntermRegister::IA);
     auto read_b = constrained_read_from_memory(call_ptr, clk, resolved_b, in_tag, in_tag, IntermRegister::IB);
@@ -490,14 +493,15 @@ void AvmTraceBuilder::op_mul(
  * @param dst_offset An index in memory pointing to the output of the division.
  * @param in_tag The instruction memory tag of the operands.
  */
-void AvmTraceBuilder::op_div(
-    uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag)
+void AvmTraceBuilder::op_div(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset)
 {
     auto clk = static_cast<uint32_t>(main_trace.size()) + 1;
 
     auto [resolved_a, resolved_b, resolved_dst] =
         Addressing<3>::fromWire(indirect, call_ptr).resolve({ a_offset, b_offset, dst_offset }, mem_trace_builder);
 
+    // We get our representative memory tag from the resolved_a memory address.
+    AvmMemoryTag in_tag = unconstrained_get_memory_tag(resolved_a);
     // Reading from memory and loading into ia resp. ib.
     auto read_a = constrained_read_from_memory(call_ptr, clk, resolved_a, in_tag, in_tag, IntermRegister::IA);
     auto read_b = constrained_read_from_memory(call_ptr, clk, resolved_b, in_tag, in_tag, IntermRegister::IB);
@@ -571,8 +575,7 @@ void AvmTraceBuilder::op_div(
  * @param dst_offset An index in memory pointing to the output of the division.
  * @param in_tag The instruction memory tag of the operands.
  */
-void AvmTraceBuilder::op_fdiv(
-    uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, [[maybe_unused]] AvmMemoryTag in_tag)
+void AvmTraceBuilder::op_fdiv(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset)
 {
     auto clk = static_cast<uint32_t>(main_trace.size()) + 1;
 
@@ -596,7 +599,6 @@ void AvmTraceBuilder::op_fdiv(
     FF error;
 
     if (!b.is_zero()) {
-
         inv = b.invert();
         c = a * inv;
         error = 0;
@@ -656,14 +658,15 @@ void AvmTraceBuilder::op_fdiv(
  * @param dst_offset An index in memory pointing to the output of the equality.
  * @param in_tag The instruction memory tag of the operands.
  */
-void AvmTraceBuilder::op_eq(
-    uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag)
+void AvmTraceBuilder::op_eq(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset)
 {
     auto clk = static_cast<uint32_t>(main_trace.size()) + 1;
 
     auto [resolved_a, resolved_b, resolved_c] =
         Addressing<3>::fromWire(indirect, call_ptr).resolve({ a_offset, b_offset, dst_offset }, mem_trace_builder);
 
+    // We get our representative memory tag from the resolved_a memory address.
+    AvmMemoryTag in_tag = unconstrained_get_memory_tag(resolved_a);
     // Reading from memory and loading into ia resp. ib.
     auto read_a = constrained_read_from_memory(call_ptr, clk, resolved_a, in_tag, AvmMemoryTag::U1, IntermRegister::IA);
     auto read_b = constrained_read_from_memory(call_ptr, clk, resolved_b, in_tag, AvmMemoryTag::U1, IntermRegister::IB);
@@ -713,14 +716,15 @@ void AvmTraceBuilder::op_eq(
     });
 }
 
-void AvmTraceBuilder::op_lt(
-    uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag)
+void AvmTraceBuilder::op_lt(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset)
 {
     auto clk = static_cast<uint32_t>(main_trace.size()) + 1;
 
     auto [resolved_a, resolved_b, resolved_c] =
         Addressing<3>::fromWire(indirect, call_ptr).resolve({ a_offset, b_offset, dst_offset }, mem_trace_builder);
 
+    // We get our representative memory tag from the resolved_a memory address.
+    AvmMemoryTag in_tag = unconstrained_get_memory_tag(resolved_a);
     auto read_a = constrained_read_from_memory(call_ptr, clk, resolved_a, in_tag, AvmMemoryTag::U1, IntermRegister::IA);
     auto read_b = constrained_read_from_memory(call_ptr, clk, resolved_b, in_tag, AvmMemoryTag::U1, IntermRegister::IB);
     bool tag_match = read_a.tag_match && read_b.tag_match;
@@ -766,14 +770,15 @@ void AvmTraceBuilder::op_lt(
     });
 }
 
-void AvmTraceBuilder::op_lte(
-    uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag)
+void AvmTraceBuilder::op_lte(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset)
 {
     auto clk = static_cast<uint32_t>(main_trace.size()) + 1;
 
     auto [resolved_a, resolved_b, resolved_c] =
         Addressing<3>::fromWire(indirect, call_ptr).resolve({ a_offset, b_offset, dst_offset }, mem_trace_builder);
 
+    // We get our representative memory tag from the resolved_a memory address.
+    AvmMemoryTag in_tag = unconstrained_get_memory_tag(resolved_a);
     // Reading from memory and loading into ia resp. ib.
     auto read_a = constrained_read_from_memory(call_ptr, clk, resolved_a, in_tag, AvmMemoryTag::U1, IntermRegister::IA);
     auto read_b = constrained_read_from_memory(call_ptr, clk, resolved_b, in_tag, AvmMemoryTag::U1, IntermRegister::IB);
@@ -824,14 +829,15 @@ void AvmTraceBuilder::op_lte(
  *                            COMPUTE - BITWISE
  **************************************************************************************************/
 
-void AvmTraceBuilder::op_and(
-    uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag)
+void AvmTraceBuilder::op_and(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset)
 {
     auto clk = static_cast<uint32_t>(main_trace.size()) + 1;
 
     auto [resolved_a, resolved_b, resolved_c] =
         Addressing<3>::fromWire(indirect, call_ptr).resolve({ a_offset, b_offset, dst_offset }, mem_trace_builder);
 
+    // We get our representative memory tag from the resolved_a memory address.
+    AvmMemoryTag in_tag = unconstrained_get_memory_tag(resolved_a);
     // Reading from memory and loading into ia resp. ib.
     auto read_a = constrained_read_from_memory(call_ptr, clk, resolved_a, in_tag, in_tag, IntermRegister::IA);
     auto read_b = constrained_read_from_memory(call_ptr, clk, resolved_b, in_tag, in_tag, IntermRegister::IB);
@@ -878,13 +884,14 @@ void AvmTraceBuilder::op_and(
     });
 }
 
-void AvmTraceBuilder::op_or(
-    uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag)
+void AvmTraceBuilder::op_or(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset)
 {
     auto clk = static_cast<uint32_t>(main_trace.size()) + 1;
     auto [resolved_a, resolved_b, resolved_c] =
         Addressing<3>::fromWire(indirect, call_ptr).resolve({ a_offset, b_offset, dst_offset }, mem_trace_builder);
 
+    // We get our representative memory tag from the resolved_a memory address.
+    AvmMemoryTag in_tag = unconstrained_get_memory_tag(resolved_a);
     // Reading from memory and loading into ia resp. ib.
     auto read_a = constrained_read_from_memory(call_ptr, clk, resolved_a, in_tag, in_tag, IntermRegister::IA);
     auto read_b = constrained_read_from_memory(call_ptr, clk, resolved_b, in_tag, in_tag, IntermRegister::IB);
@@ -931,14 +938,15 @@ void AvmTraceBuilder::op_or(
     });
 }
 
-void AvmTraceBuilder::op_xor(
-    uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag)
+void AvmTraceBuilder::op_xor(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset)
 {
     auto clk = static_cast<uint32_t>(main_trace.size()) + 1;
 
     auto [resolved_a, resolved_b, resolved_c] =
         Addressing<3>::fromWire(indirect, call_ptr).resolve({ a_offset, b_offset, dst_offset }, mem_trace_builder);
 
+    // We get our representative memory tag from the resolved_a memory address.
+    AvmMemoryTag in_tag = unconstrained_get_memory_tag(resolved_a);
     // Reading from memory and loading into ia resp. ib.
     auto read_a = constrained_read_from_memory(call_ptr, clk, resolved_a, in_tag, in_tag, IntermRegister::IA);
     auto read_b = constrained_read_from_memory(call_ptr, clk, resolved_b, in_tag, in_tag, IntermRegister::IB);
@@ -1044,14 +1052,15 @@ void AvmTraceBuilder::op_not(uint8_t indirect, uint32_t a_offset, uint32_t dst_o
     });
 }
 
-void AvmTraceBuilder::op_shl(
-    uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag)
+void AvmTraceBuilder::op_shl(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset)
 {
     auto clk = static_cast<uint32_t>(main_trace.size()) + 1;
 
     auto [resolved_a, resolved_b, resolved_c] =
         Addressing<3>::fromWire(indirect, call_ptr).resolve({ a_offset, b_offset, dst_offset }, mem_trace_builder);
 
+    // We get our representative memory tag from the resolved_a memory address.
+    AvmMemoryTag in_tag = unconstrained_get_memory_tag(resolved_a);
     // Reading from memory and loading into ia resp. ib.
     auto read_a = constrained_read_from_memory(call_ptr, clk, resolved_a, in_tag, in_tag, IntermRegister::IA);
     auto read_b = constrained_read_from_memory(call_ptr, clk, resolved_b, in_tag, in_tag, IntermRegister::IB);
@@ -1096,14 +1105,15 @@ void AvmTraceBuilder::op_shl(
     });
 }
 
-void AvmTraceBuilder::op_shr(
-    uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag)
+void AvmTraceBuilder::op_shr(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset)
 {
     auto clk = static_cast<uint32_t>(main_trace.size()) + 1;
 
     auto [resolved_a, resolved_b, resolved_c] =
         Addressing<3>::fromWire(indirect, call_ptr).resolve({ a_offset, b_offset, dst_offset }, mem_trace_builder);
 
+    // We get our representative memory tag from the resolved_a memory address.
+    AvmMemoryTag in_tag = unconstrained_get_memory_tag(resolved_a);
     // Reading from memory and loading into ia resp. ib.
     auto read_a = constrained_read_from_memory(call_ptr, clk, resolved_a, in_tag, in_tag, IntermRegister::IA);
     auto read_b = constrained_read_from_memory(call_ptr, clk, resolved_b, in_tag, in_tag, IntermRegister::IB);

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.hpp
@@ -38,24 +38,24 @@ class AvmTraceBuilder {
     uint32_t getPc() const { return pc; }
 
     // Compute - Arithmetic
-    void op_add(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag);
-    void op_sub(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag);
-    void op_mul(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag);
-    void op_div(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag);
-    void op_fdiv(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag);
+    void op_add(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset);
+    void op_sub(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset);
+    void op_mul(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset);
+    void op_div(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset);
+    void op_fdiv(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset);
 
     // Compute - Comparators
-    void op_eq(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag);
-    void op_lt(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag);
-    void op_lte(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag);
+    void op_eq(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset);
+    void op_lt(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset);
+    void op_lte(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset);
 
     // Compute - Bitwise
-    void op_and(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag);
-    void op_or(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag);
-    void op_xor(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag);
+    void op_and(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset);
+    void op_or(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset);
+    void op_xor(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset);
     void op_not(uint8_t indirect, uint32_t a_offset, uint32_t dst_offset);
-    void op_shl(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag);
-    void op_shr(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset, AvmMemoryTag in_tag);
+    void op_shl(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset);
+    void op_shr(uint8_t indirect, uint32_t a_offset, uint32_t b_offset, uint32_t dst_offset);
 
     // Compute - Type Conversions
     void op_cast(uint8_t indirect, uint32_t a_offset, uint32_t dst_offset, AvmMemoryTag dst_tag);

--- a/yarn-project/simulator/src/avm/avm_gas.test.ts
+++ b/yarn-project/simulator/src/avm/avm_gas.test.ts
@@ -15,14 +15,14 @@ describe.skip('AVM simulator: dynamic gas costs per instruction', () => {
     // BASE_GAS(10) * 5 + MEMORY_WRITE(100) * 5 = 550
     [new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ TypeTag.UINT8, /*copySize=*/ 5, /*dstOffset=*/ 0), [510]],
     // BASE_GAS(10) * 1 + MEMORY_READ(10) * 2 + MEMORY_WRITE(100) = 130
-    [new Add(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [130]],
+    [new Add(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [130]],
     // BASE_GAS(10) * 4 + MEMORY_READ(10) * 2 + MEMORY_WRITE(100) = 160
-    [new Add(/*indirect=*/ 0, /*inTag=*/ TypeTag.UINT32, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [160]],
+    [new Add(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [160]],
     // BASE_GAS(10) * 1 + MEMORY_READ(10) * 2 + MEMORY_INDIRECT_READ_PENALTY(10) * 2 + MEMORY_WRITE(100) = 150
-    [new Add(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
-    [new Sub(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
-    [new Mul(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
-    [new Div(/*indirect=*/ 3, /*inTag=*/ TypeTag.UINT8, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
+    [new Add(/*indirect=*/ 3, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
+    [new Sub(/*indirect=*/ 3, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
+    [new Mul(/*indirect=*/ 3, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
+    [new Div(/*indirect=*/ 3, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
   ] as const)('computes gas cost for %s', async (instruction, [l2GasCost, daGasCost]) => {
     const bytecode = encodeToBytecode([instruction]);
     const context = initContext();

--- a/yarn-project/simulator/src/avm/avm_memory_types.ts
+++ b/yarn-project/simulator/src/avm/avm_memory_types.ts
@@ -333,6 +333,16 @@ export class TaggedMemory implements TaggedMemoryInterface {
   }
 
   /**
+   * Check that all tags at the given offsets are the same.
+   */
+  public checkTagsAreSame(...offsets: number[]) {
+    const tag = this.getTag(offsets[0]);
+    for (let i = 1; i < offsets.length; i++) {
+      this.checkTag(tag, offsets[i]);
+    }
+  }
+
+  /**
    * Check tags for all memory in the specified range.
    */
   public checkTagsRange(tag: TypeTag, startOffset: number, size: number) {
@@ -509,6 +519,10 @@ export class MeteredTaggedMemory implements TaggedMemoryInterface {
 
   public checkTags(tag: TypeTag, ...offsets: number[]): void {
     this.wrapped.checkTags(tag, ...offsets);
+  }
+
+  public checkTagsAreSame(...offsets: number[]): void {
+    this.wrapped.checkTagsAreSame(...offsets);
   }
 
   public checkTagsRange(tag: TypeTag, startOffset: number, size: number): void {

--- a/yarn-project/simulator/src/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.test.ts
@@ -71,10 +71,7 @@ describe('AVM simulator: injected bytecode', () => {
       new Set(/*indirect*/ 0, TypeTag.UINT32, /*value*/ 0, /*dstOffset*/ 0).as(Opcode.SET_8, Set.wireFormat8),
       new Set(/*indirect*/ 0, TypeTag.UINT32, /*value*/ 2, /*dstOffset*/ 1).as(Opcode.SET_8, Set.wireFormat8),
       new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ 0, /*copySize=*/ 1, /*dstOffset=*/ 0),
-      new Add(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(
-        Opcode.ADD_8,
-        Add.wireFormat8,
-      ),
+      new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.ADD_8, Add.wireFormat8),
       new Return(/*indirect=*/ 0, /*returnOffset=*/ 2, /*copySize=*/ 1),
     ]);
   });
@@ -1012,7 +1009,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
           new Set(/*indirect*/ 0, TypeTag.UINT32, /*value*/ 1, /*dstOffset*/ 1).as(Opcode.SET_8, Set.wireFormat8),
           createInstr(),
           // change value at memory offset 0 so each instr operates on a different value (important for nullifier emission)
-          new Add(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 100, /*dstOffset=*/ 0).as(
+          new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 100, /*dstOffset=*/ 0).as(
             Opcode.ADD_8,
             Add.wireFormat8,
           ),

--- a/yarn-project/simulator/src/avm/opcodes/arithmetic.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/arithmetic.test.ts
@@ -255,7 +255,6 @@ describe('Arithmetic Instructions', () => {
       const buf = Buffer.from([
         Opcode.FDIV_16, // opcode
         0x01, // indirect
-        TypeTag.FIELD, // tag
         ...Buffer.from('1234', 'hex'), // aOffset
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset

--- a/yarn-project/simulator/src/avm/opcodes/arithmetic.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/arithmetic.test.ts
@@ -17,18 +17,14 @@ describe('Arithmetic Instructions', () => {
       const buf = Buffer.from([
         Opcode.ADD_16, // opcode
         0x01, // indirect
-        TypeTag.FIELD, // inTag
         ...Buffer.from('1234', 'hex'), // aOffset
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Add(
-        /*indirect=*/ 0x01,
-        /*inTag=*/ TypeTag.FIELD,
-        /*aOffset=*/ 0x1234,
-        /*bOffset=*/ 0x2345,
-        /*dstOffset=*/ 0x3456,
-      ).as(Opcode.ADD_16, Add.wireFormat16);
+      const inst = new Add(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
+        Opcode.ADD_16,
+        Add.wireFormat16,
+      );
 
       expect(Add.as(Add.wireFormat16).deserialize(buf)).toEqual(inst);
       expect(inst.serialize()).toEqual(buf);
@@ -46,9 +42,7 @@ describe('Arithmetic Instructions', () => {
         context.machineState.memory.set(0, a);
         context.machineState.memory.set(1, b);
 
-        await new Add(/*indirect=*/ 0, /*inTag=*/ tag, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(
-          context,
-        );
+        await new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
         const actual = context.machineState.memory.get(2);
         expect(actual).toEqual(expected);
@@ -71,7 +65,6 @@ describe('Arithmetic Instructions', () => {
           /*bOffset*/ AddressingMode.DIRECT,
           /*dstOffset*/ AddressingMode.INDIRECT | AddressingMode.RELATIVE,
         ]).toWire(),
-        /*inTag=*/ TypeTag.FIELD,
         /*aOffset=*/ 10,
         /*bOffset=*/ 11,
         /*dstOffset=*/ 2, // We expect the result to be stored at MEM[30 + 2] = 5
@@ -92,9 +85,7 @@ describe('Arithmetic Instructions', () => {
       it(`${TypeTag[tag]}`, async () => {
         context.machineState.memory.set(0, a);
 
-        await new Add(/*indirect=*/ 0, /*inTag=*/ tag, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 2).execute(
-          context,
-        );
+        await new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 2).execute(context);
 
         const actual = context.machineState.memory.get(2);
         expect(actual).toEqual(expected);
@@ -107,18 +98,14 @@ describe('Arithmetic Instructions', () => {
       const buf = Buffer.from([
         Opcode.SUB_16, // opcode
         0x01, // indirect
-        TypeTag.FIELD, // inTag
         ...Buffer.from('1234', 'hex'), // aOffset
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Sub(
-        /*indirect=*/ 0x01,
-        /*inTag=*/ TypeTag.FIELD,
-        /*aOffset=*/ 0x1234,
-        /*bOffset=*/ 0x2345,
-        /*dstOffset=*/ 0x3456,
-      ).as(Opcode.SUB_16, Sub.wireFormat16);
+      const inst = new Sub(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
+        Opcode.SUB_16,
+        Sub.wireFormat16,
+      );
 
       expect(Sub.as(Sub.wireFormat16).deserialize(buf)).toEqual(inst);
       expect(inst.serialize()).toEqual(buf);
@@ -136,9 +123,7 @@ describe('Arithmetic Instructions', () => {
         context.machineState.memory.set(0, a);
         context.machineState.memory.set(1, b);
 
-        await new Sub(/*indirect=*/ 0, /*inTag=*/ tag, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(
-          context,
-        );
+        await new Sub(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
         const actual = context.machineState.memory.get(2);
         expect(actual).toEqual(expected);
@@ -162,9 +147,7 @@ describe('Arithmetic Instructions', () => {
         context.machineState.memory.set(0, a);
         context.machineState.memory.set(1, b);
 
-        await new Sub(/*indirect=*/ 0, /*inTag=*/ tag, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(
-          context,
-        );
+        await new Sub(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
         const actual = context.machineState.memory.get(2);
         expect(actual).toEqual(expected);
@@ -177,18 +160,14 @@ describe('Arithmetic Instructions', () => {
       const buf = Buffer.from([
         Opcode.MUL_16, // opcode
         0x01, // indirect
-        TypeTag.FIELD, // inTag
         ...Buffer.from('1234', 'hex'), // aOffset
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Mul(
-        /*indirect=*/ 0x01,
-        /*inTag=*/ TypeTag.FIELD,
-        /*aOffset=*/ 0x1234,
-        /*bOffset=*/ 0x2345,
-        /*dstOffset=*/ 0x3456,
-      ).as(Opcode.MUL_16, Mul.wireFormat16);
+      const inst = new Mul(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
+        Opcode.MUL_16,
+        Mul.wireFormat16,
+      );
 
       expect(Mul.as(Mul.wireFormat16).deserialize(buf)).toEqual(inst);
       expect(inst.serialize()).toEqual(buf);
@@ -206,9 +185,7 @@ describe('Arithmetic Instructions', () => {
         context.machineState.memory.set(0, a);
         context.machineState.memory.set(1, b);
 
-        await new Mul(/*indirect=*/ 0, /*inTag=*/ tag, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(
-          context,
-        );
+        await new Mul(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
         const actual = context.machineState.memory.get(2);
         expect(actual).toEqual(expected);
@@ -227,9 +204,7 @@ describe('Arithmetic Instructions', () => {
         context.machineState.memory.set(0, a);
         context.machineState.memory.set(1, b);
 
-        await new Mul(/*indirect=*/ 0, /*inTag=*/ tag, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(
-          context,
-        );
+        await new Mul(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
         const actual = context.machineState.memory.get(2);
         expect(actual).toEqual(expected);
@@ -242,18 +217,14 @@ describe('Arithmetic Instructions', () => {
       const buf = Buffer.from([
         Opcode.DIV_16, // opcode
         0x01, // indirect
-        TypeTag.FIELD, // inTag
         ...Buffer.from('1234', 'hex'), // aOffset
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Div(
-        /*indirect=*/ 0x01,
-        /*inTag=*/ TypeTag.FIELD,
-        /*aOffset=*/ 0x1234,
-        /*bOffset=*/ 0x2345,
-        /*dstOffset=*/ 0x3456,
-      ).as(Opcode.DIV_16, Div.wireFormat16);
+      const inst = new Div(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
+        Opcode.DIV_16,
+        Div.wireFormat16,
+      );
 
       expect(Div.as(Div.wireFormat16).deserialize(buf)).toEqual(inst);
       expect(inst.serialize()).toEqual(buf);
@@ -271,9 +242,7 @@ describe('Arithmetic Instructions', () => {
         context.machineState.memory.set(0, a);
         context.machineState.memory.set(1, b);
 
-        await new Div(/*indirect=*/ 0, /*inTag=*/ tag, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(
-          context,
-        );
+        await new Div(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
         const actual = context.machineState.memory.get(2);
         expect(actual).toEqual(expected);
@@ -291,13 +260,10 @@ describe('Arithmetic Instructions', () => {
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new FieldDiv(
-        /*indirect=*/ 0x01,
-        /*tag=*/ TypeTag.FIELD,
-        /*aOffset=*/ 0x1234,
-        /*bOffset=*/ 0x2345,
-        /*dstOffset=*/ 0x3456,
-      ).as(Opcode.FDIV_16, FieldDiv.wireFormat16);
+      const inst = new FieldDiv(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
+        Opcode.FDIV_16,
+        FieldDiv.wireFormat16,
+      );
 
       expect(FieldDiv.as(FieldDiv.wireFormat16).deserialize(buf)).toEqual(inst);
       expect(inst.serialize()).toEqual(buf);
@@ -310,13 +276,7 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new FieldDiv(
-        /*indirect=*/ 0,
-        /*inTag=*/ TypeTag.FIELD,
-        /*aOffset=*/ 0,
-        /*bOffset=*/ 1,
-        /*dstOffset=*/ 2,
-      ).execute(context);
+      await new FieldDiv(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const actual = context.machineState.memory.get(2);
       expect(actual).toEqual(new Field(2));

--- a/yarn-project/simulator/src/avm/opcodes/arithmetic.ts
+++ b/yarn-project/simulator/src/avm/opcodes/arithmetic.ts
@@ -12,7 +12,7 @@ export abstract class ThreeOperandArithmeticInstruction extends ThreeOperandInst
     const operands = [this.aOffset, this.bOffset, this.dstOffset];
     const addressing = Addressing.fromWire(this.indirect, operands.length);
     const [aOffset, bOffset, dstOffset] = addressing.resolve(operands, memory);
-    memory.checkTags(this.inTag, aOffset, bOffset);
+    memory.checkTagsAreSame(aOffset, bOffset);
 
     const a = memory.get(aOffset);
     const b = memory.get(bOffset);

--- a/yarn-project/simulator/src/avm/opcodes/bitwise.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/bitwise.test.ts
@@ -1,5 +1,5 @@
 import { type AvmContext } from '../avm_context.js';
-import { TypeTag, Uint8, Uint16, Uint32 } from '../avm_memory_types.js';
+import { Uint8, Uint16, Uint32 } from '../avm_memory_types.js';
 import { initContext } from '../fixtures/index.js';
 import { Opcode } from '../serialization/instruction_serialization.js';
 import { And, Not, Or, Shl, Shr, Xor } from './bitwise.js';

--- a/yarn-project/simulator/src/avm/opcodes/bitwise.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/bitwise.test.ts
@@ -16,18 +16,14 @@ describe('Bitwise instructions', () => {
       const buf = Buffer.from([
         Opcode.AND_16, // opcode
         0x01, // indirect
-        TypeTag.UINT64, // inTag
         ...Buffer.from('1234', 'hex'), // aOffset
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new And(
-        /*indirect=*/ 0x01,
-        /*inTag=*/ TypeTag.UINT64,
-        /*aOffset=*/ 0x1234,
-        /*bOffset=*/ 0x2345,
-        /*dstOffset=*/ 0x3456,
-      ).as(Opcode.AND_16, And.wireFormat16);
+      const inst = new And(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
+        Opcode.AND_16,
+        And.wireFormat16,
+      );
 
       expect(And.as(And.wireFormat16).deserialize(buf)).toEqual(inst);
       expect(inst.serialize()).toEqual(buf);
@@ -37,13 +33,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(0, new Uint32(0b11111110010011100100n));
       context.machineState.memory.set(1, new Uint32(0b11100100111001001111n));
 
-      await new And(
-        /*indirect=*/ 0,
-        /*inTag=*/ TypeTag.UINT32,
-        /*aOffset=*/ 0,
-        /*bOffset=*/ 1,
-        /*dstOffset=*/ 2,
-      ).execute(context);
+      await new And(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const actual = context.machineState.memory.get(2);
       expect(actual).toEqual(new Uint32(0b11100100010001000100n));
@@ -55,18 +45,14 @@ describe('Bitwise instructions', () => {
       const buf = Buffer.from([
         Opcode.OR_16, // opcode
         0x01, // indirect
-        TypeTag.UINT64, // inTag
         ...Buffer.from('1234', 'hex'), // aOffset
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Or(
-        /*indirect=*/ 0x01,
-        /*inTag=*/ TypeTag.UINT64,
-        /*aOffset=*/ 0x1234,
-        /*bOffset=*/ 0x2345,
-        /*dstOffset=*/ 0x3456,
-      ).as(Opcode.OR_16, Or.wireFormat16);
+      const inst = new Or(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
+        Opcode.OR_16,
+        Or.wireFormat16,
+      );
 
       expect(Or.as(Or.wireFormat16).deserialize(buf)).toEqual(inst);
       expect(inst.serialize()).toEqual(buf);
@@ -79,13 +65,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Or(
-        /*indirect=*/ 0,
-        /*inTag=*/ TypeTag.UINT32,
-        /*aOffset=*/ 0,
-        /*bOffset=*/ 1,
-        /*dstOffset=*/ 2,
-      ).execute(context);
+      await new Or(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint32(0b11111110111011101111n);
       const actual = context.machineState.memory.get(2);
@@ -98,18 +78,14 @@ describe('Bitwise instructions', () => {
       const buf = Buffer.from([
         Opcode.XOR_16, // opcode
         0x01, // indirect
-        TypeTag.UINT64, // inTag
         ...Buffer.from('1234', 'hex'), // aOffset
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Xor(
-        /*indirect=*/ 0x01,
-        /*inTag=*/ TypeTag.UINT64,
-        /*aOffset=*/ 0x1234,
-        /*bOffset=*/ 0x2345,
-        /*dstOffset=*/ 0x3456,
-      ).as(Opcode.XOR_16, Xor.wireFormat16);
+      const inst = new Xor(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
+        Opcode.XOR_16,
+        Xor.wireFormat16,
+      );
 
       expect(Xor.as(Xor.wireFormat16).deserialize(buf)).toEqual(inst);
       expect(inst.serialize()).toEqual(buf);
@@ -122,13 +98,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Xor(
-        /*indirect=*/ 0,
-        /*inTag=*/ TypeTag.UINT32,
-        /*aOffset=*/ 0,
-        /*bOffset=*/ 1,
-        /*dstOffset=*/ 2,
-      ).execute(context);
+      await new Xor(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint32(0b00011010101010101011n);
       const actual = context.machineState.memory.get(2);
@@ -141,18 +111,14 @@ describe('Bitwise instructions', () => {
       const buf = Buffer.from([
         Opcode.SHR_16, // opcode
         0x01, // indirect
-        TypeTag.UINT64, // inTag
         ...Buffer.from('1234', 'hex'), // aOffset
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Shr(
-        /*indirect=*/ 0x01,
-        /*inTag=*/ TypeTag.UINT64,
-        /*aOffset=*/ 0x1234,
-        /*bOffset=*/ 0x2345,
-        /*dstOffset=*/ 0x3456,
-      ).as(Opcode.SHR_16, Shr.wireFormat16);
+      const inst = new Shr(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
+        Opcode.SHR_16,
+        Shr.wireFormat16,
+      );
 
       expect(Shr.as(Shr.wireFormat16).deserialize(buf)).toEqual(inst);
       expect(inst.serialize()).toEqual(buf);
@@ -166,14 +132,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(1, b);
 
       await expect(
-        async () =>
-          await new Shr(
-            /*indirect=*/ 0,
-            /*inTag=*/ TypeTag.UINT32,
-            /*aOffset=*/ 0,
-            /*bOffset=*/ 1,
-            /*dstOffset=*/ 2,
-          ).execute(context),
+        async () => await new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context),
       ).rejects.toThrow(/got UINT32, expected UINT8/);
     });
 
@@ -184,13 +143,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Shr(
-        /*indirect=*/ 0,
-        /*inTag=*/ TypeTag.UINT32,
-        /*aOffset=*/ 0,
-        /*bOffset=*/ 1,
-        /*dstOffset=*/ 2,
-      ).execute(context);
+      await new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = a;
       const actual = context.machineState.memory.get(2);
@@ -204,13 +157,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Shr(
-        /*indirect=*/ 0,
-        /*inTag=*/ TypeTag.UINT32,
-        /*aOffset=*/ 0,
-        /*bOffset=*/ 1,
-        /*dstOffset=*/ 2,
-      ).execute(context);
+      await new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint32(0b00111111100100111001n);
       const actual = context.machineState.memory.get(2);
@@ -224,13 +171,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Shr(
-        /*indirect=*/ 0,
-        /*inTag=*/ TypeTag.UINT32,
-        /*aOffset=*/ 0,
-        /*bOffset=*/ 1,
-        /*dstOffset=*/ 2,
-      ).execute(context);
+      await new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint32(0b01n);
       const actual = context.machineState.memory.get(2);
@@ -243,18 +184,14 @@ describe('Bitwise instructions', () => {
       const buf = Buffer.from([
         Opcode.SHL_16, // opcode
         0x01, // indirect
-        TypeTag.UINT64, // inTag
         ...Buffer.from('1234', 'hex'), // aOffset
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Shl(
-        /*indirect=*/ 0x01,
-        /*inTag=*/ TypeTag.UINT64,
-        /*aOffset=*/ 0x1234,
-        /*bOffset=*/ 0x2345,
-        /*dstOffset=*/ 0x3456,
-      ).as(Opcode.SHL_16, Shl.wireFormat16);
+      const inst = new Shl(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
+        Opcode.SHL_16,
+        Shl.wireFormat16,
+      );
 
       expect(Shl.as(Shl.wireFormat16).deserialize(buf)).toEqual(inst);
       expect(inst.serialize()).toEqual(buf);
@@ -268,14 +205,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(1, b);
 
       await expect(
-        async () =>
-          await new Shl(
-            /*indirect=*/ 0,
-            /*inTag=*/ TypeTag.UINT32,
-            /*aOffset=*/ 0,
-            /*bOffset=*/ 1,
-            /*dstOffset=*/ 2,
-          ).execute(context),
+        async () => await new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context),
       ).rejects.toThrow(/got UINT32, expected UINT8/);
     });
 
@@ -286,13 +216,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Shl(
-        /*indirect=*/ 0,
-        /*inTag=*/ TypeTag.UINT32,
-        /*aOffset=*/ 0,
-        /*bOffset=*/ 1,
-        /*dstOffset=*/ 2,
-      ).execute(context);
+      await new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = a;
       const actual = context.machineState.memory.get(2);
@@ -306,13 +230,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Shl(
-        /*indirect=*/ 0,
-        /*inTag=*/ TypeTag.UINT32,
-        /*aOffset=*/ 0,
-        /*bOffset=*/ 1,
-        /*dstOffset=*/ 2,
-      ).execute(context);
+      await new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint32(0b1111111001001110010000n);
       const actual = context.machineState.memory.get(2);
@@ -326,13 +244,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Shl(
-        /*indirect=*/ 0,
-        /*inTag=*/ TypeTag.UINT16,
-        /*aOffset=*/ 0,
-        /*bOffset=*/ 1,
-        /*dstOffset=*/ 2,
-      ).execute(context);
+      await new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint16(0n);
       const actual = context.machineState.memory.get(2);
@@ -346,13 +258,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Shl(
-        /*indirect=*/ 0,
-        /*inTag=*/ TypeTag.UINT16,
-        /*aOffset=*/ 0,
-        /*bOffset=*/ 1,
-        /*dstOffset=*/ 2,
-      ).execute(context);
+      await new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint16(0b1001001110011100n);
       const actual = context.machineState.memory.get(2);

--- a/yarn-project/simulator/src/avm/opcodes/bitwise.ts
+++ b/yarn-project/simulator/src/avm/opcodes/bitwise.ts
@@ -13,7 +13,8 @@ abstract class ThreeOperandBitwiseInstruction extends ThreeOperandInstruction {
     const operands = [this.aOffset, this.bOffset, this.dstOffset];
     const addressing = Addressing.fromWire(this.indirect, operands.length);
     const [aOffset, bOffset, dstOffset] = addressing.resolve(operands, memory);
-    this.checkTags(memory, this.inTag, aOffset, bOffset);
+    TaggedMemory.checkIsIntegralTag(memory.getTag(aOffset));
+    memory.checkTagsAreSame(aOffset, bOffset);
 
     const a = memory.getAs<IntegralValue>(aOffset);
     const b = memory.getAs<IntegralValue>(bOffset);

--- a/yarn-project/simulator/src/avm/opcodes/bitwise.ts
+++ b/yarn-project/simulator/src/avm/opcodes/bitwise.ts
@@ -13,8 +13,7 @@ abstract class ThreeOperandBitwiseInstruction extends ThreeOperandInstruction {
     const operands = [this.aOffset, this.bOffset, this.dstOffset];
     const addressing = Addressing.fromWire(this.indirect, operands.length);
     const [aOffset, bOffset, dstOffset] = addressing.resolve(operands, memory);
-    TaggedMemory.checkIsIntegralTag(memory.getTag(aOffset));
-    memory.checkTagsAreSame(aOffset, bOffset);
+    this.checkTags(memory, aOffset, bOffset);
 
     const a = memory.getAs<IntegralValue>(aOffset);
     const b = memory.getAs<IntegralValue>(bOffset);
@@ -27,8 +26,9 @@ abstract class ThreeOperandBitwiseInstruction extends ThreeOperandInstruction {
   }
 
   protected abstract compute(a: IntegralValue, b: IntegralValue): IntegralValue;
-  protected checkTags(memory: TaggedMemoryInterface, inTag: number, aOffset: number, bOffset: number) {
-    memory.checkTags(inTag, aOffset, bOffset);
+  protected checkTags(memory: TaggedMemoryInterface, aOffset: number, bOffset: number) {
+    TaggedMemory.checkIsIntegralTag(memory.getTag(aOffset));
+    memory.checkTagsAreSame(aOffset, bOffset);
   }
 }
 
@@ -66,8 +66,8 @@ export class Shl extends ThreeOperandBitwiseInstruction {
   protected override compute(a: IntegralValue, b: IntegralValue): IntegralValue {
     return a.shl(b);
   }
-  protected override checkTags(memory: TaggedMemoryInterface, inTag: number, aOffset: number, bOffset: number) {
-    memory.checkTag(inTag, aOffset);
+  protected override checkTags(memory: TaggedMemoryInterface, aOffset: number, bOffset: number) {
+    TaggedMemory.checkIsIntegralTag(memory.getTag(aOffset));
     memory.checkTag(TypeTag.UINT8, bOffset);
   }
 }
@@ -79,8 +79,8 @@ export class Shr extends ThreeOperandBitwiseInstruction {
   protected override compute(a: IntegralValue, b: IntegralValue): IntegralValue {
     return a.shr(b);
   }
-  protected override checkTags(memory: TaggedMemoryInterface, inTag: number, aOffset: number, bOffset: number) {
-    memory.checkTag(inTag, aOffset);
+  protected override checkTags(memory: TaggedMemoryInterface, aOffset: number, bOffset: number) {
+    TaggedMemory.checkIsIntegralTag(memory.getTag(aOffset));
     memory.checkTag(TypeTag.UINT8, bOffset);
   }
 }

--- a/yarn-project/simulator/src/avm/opcodes/comparators.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/comparators.test.ts
@@ -17,18 +17,14 @@ describe('Comparators', () => {
       const buf = Buffer.from([
         Opcode.EQ_16, // opcode
         0x01, // indirect
-        TypeTag.UINT64, // inTag
         ...Buffer.from('1234', 'hex'), // aOffset
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Eq(
-        /*indirect=*/ 0x01,
-        /*inTag=*/ TypeTag.UINT64,
-        /*aOffset=*/ 0x1234,
-        /*bOffset=*/ 0x2345,
-        /*dstOffset=*/ 0x3456,
-      ).as(Opcode.EQ_16, Eq.wireFormat16);
+      const inst = new Eq(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
+        Opcode.EQ_16,
+        Eq.wireFormat16,
+      );
 
       expect(Eq.as(Eq.wireFormat16).deserialize(buf)).toEqual(inst);
       expect(inst.serialize()).toEqual(buf);
@@ -38,9 +34,9 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Uint32(1), new Uint32(2), new Uint32(3), new Uint32(1)]);
 
       const ops = [
-        new Eq(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
-        new Eq(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 11),
-        new Eq(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 3, /*dstOffset=*/ 12),
+        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
+        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 11),
+        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 3, /*dstOffset=*/ 12),
       ];
 
       for (const op of ops) {
@@ -55,9 +51,9 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Field(2), new Field(3), new Field(1)]);
 
       const ops = [
-        new Eq(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
-        new Eq(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 11),
-        new Eq(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 3, /*dstOffset=*/ 12),
+        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
+        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 11),
+        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 3, /*dstOffset=*/ 12),
       ];
 
       for (const op of ops) {
@@ -72,10 +68,10 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Uint32(2), new Uint16(3)]);
 
       const ops = [
-        new Eq(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
-        new Eq(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 10),
-        new Eq(/*indirect=*/ 0, TypeTag.UINT16, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 10),
-        new Eq(/*indirect=*/ 0, TypeTag.UINT16, /*aOffset=*/ 1, /*bOffset=*/ 1, /*dstOffset=*/ 10),
+        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
+        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 10),
+        new Eq(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 10),
+        new Eq(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 1, /*dstOffset=*/ 10),
       ];
 
       for (const o of ops) {
@@ -89,18 +85,14 @@ describe('Comparators', () => {
       const buf = Buffer.from([
         Opcode.LT_16, // opcode
         0x01, // indirect
-        TypeTag.UINT64, // inTag
         ...Buffer.from('1234', 'hex'), // aOffset
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Lt(
-        /*indirect=*/ 0x01,
-        /*inTag=*/ TypeTag.UINT64,
-        /*aOffset=*/ 0x1234,
-        /*bOffset=*/ 0x2345,
-        /*dstOffset=*/ 0x3456,
-      ).as(Opcode.LT_16, Lt.wireFormat16);
+      const inst = new Lt(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
+        Opcode.LT_16,
+        Lt.wireFormat16,
+      );
 
       expect(Lt.as(Lt.wireFormat16).deserialize(buf)).toEqual(inst);
       expect(inst.serialize()).toEqual(buf);
@@ -110,9 +102,9 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Uint32(1), new Uint32(2), new Uint32(0)]);
 
       const ops = [
-        new Lt(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
-        new Lt(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
-        new Lt(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
+        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
+        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
+        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
       ];
 
       for (const op of ops) {
@@ -127,9 +119,9 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Field(2), new Field(0)]);
 
       const ops = [
-        new Lt(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
-        new Lt(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
-        new Lt(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
+        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
+        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
+        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
       ];
 
       for (const op of ops) {
@@ -144,10 +136,10 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Uint32(2), new Uint16(3)]);
 
       const ops = [
-        new Lt(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
-        new Lt(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 10),
-        new Lt(/*indirect=*/ 0, TypeTag.UINT16, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 10),
-        new Lt(/*indirect=*/ 0, TypeTag.UINT16, /*aOffset=*/ 1, /*bOffset=*/ 1, /*dstOffset=*/ 10),
+        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
+        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 10),
+        new Lt(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 10),
+        new Lt(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 1, /*dstOffset=*/ 10),
       ];
 
       for (const o of ops) {
@@ -161,18 +153,14 @@ describe('Comparators', () => {
       const buf = Buffer.from([
         Opcode.LTE_16, // opcode
         0x01, // indirect
-        TypeTag.UINT64, // inTag
         ...Buffer.from('1234', 'hex'), // aOffset
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Lte(
-        /*indirect=*/ 0x01,
-        /*inTag=*/ TypeTag.UINT64,
-        /*aOffset=*/ 0x1234,
-        /*bOffset=*/ 0x2345,
-        /*dstOffset=*/ 0x3456,
-      ).as(Opcode.LTE_16, Lte.wireFormat16);
+      const inst = new Lte(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
+        Opcode.LTE_16,
+        Lte.wireFormat16,
+      );
 
       expect(Lte.as(Lte.wireFormat16).deserialize(buf)).toEqual(inst);
       expect(inst.serialize()).toEqual(buf);
@@ -182,9 +170,9 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Uint32(1), new Uint32(2), new Uint32(0)]);
 
       const ops = [
-        new Lte(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
-        new Lte(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
-        new Lte(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
+        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
+        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
+        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
       ];
 
       for (const op of ops) {
@@ -199,9 +187,9 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Field(2), new Field(0)]);
 
       const ops = [
-        new Lte(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
-        new Lte(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
-        new Lte(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
+        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
+        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
+        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
       ];
 
       for (const op of ops) {
@@ -216,10 +204,10 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Uint32(2), new Uint16(3)]);
 
       const ops = [
-        new Lte(/*indirect=*/ 0, TypeTag.FIELD, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
-        new Lte(/*indirect=*/ 0, TypeTag.UINT32, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 10),
-        new Lte(/*indirect=*/ 0, TypeTag.UINT16, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 10),
-        new Lte(/*indirect=*/ 0, TypeTag.UINT16, /*aOffset=*/ 1, /*bOffset=*/ 1, /*dstOffset=*/ 10),
+        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
+        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 10),
+        new Lte(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 10),
+        new Lte(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 1, /*dstOffset=*/ 10),
       ];
 
       for (const o of ops) {

--- a/yarn-project/simulator/src/avm/opcodes/comparators.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/comparators.test.ts
@@ -1,5 +1,5 @@
 import { type AvmContext } from '../avm_context.js';
-import { Field, TypeTag, Uint8, Uint16, Uint32 } from '../avm_memory_types.js';
+import { Field, Uint8, Uint16, Uint32 } from '../avm_memory_types.js';
 import { TagCheckError } from '../errors.js';
 import { initContext } from '../fixtures/index.js';
 import { Opcode } from '../serialization/instruction_serialization.js';

--- a/yarn-project/simulator/src/avm/opcodes/comparators.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/comparators.test.ts
@@ -71,7 +71,6 @@ describe('Comparators', () => {
         new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
         new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 10),
         new Eq(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 10),
-        new Eq(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 1, /*dstOffset=*/ 10),
       ];
 
       for (const o of ops) {
@@ -139,7 +138,6 @@ describe('Comparators', () => {
         new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
         new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 10),
         new Lt(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 10),
-        new Lt(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 1, /*dstOffset=*/ 10),
       ];
 
       for (const o of ops) {
@@ -207,7 +205,6 @@ describe('Comparators', () => {
         new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
         new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 10),
         new Lte(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 10),
-        new Lte(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 1, /*dstOffset=*/ 10),
       ];
 
       for (const o of ops) {

--- a/yarn-project/simulator/src/avm/opcodes/comparators.ts
+++ b/yarn-project/simulator/src/avm/opcodes/comparators.ts
@@ -12,7 +12,7 @@ abstract class ComparatorInstruction extends ThreeOperandInstruction {
     const operands = [this.aOffset, this.bOffset, this.dstOffset];
     const addressing = Addressing.fromWire(this.indirect, operands.length);
     const [aOffset, bOffset, dstOffset] = addressing.resolve(operands, memory);
-    memory.checkTags(this.inTag, aOffset, bOffset);
+    memory.checkTagsAreSame(aOffset, bOffset);
 
     const a = memory.get(aOffset);
     const b = memory.get(bOffset);

--- a/yarn-project/simulator/src/avm/opcodes/instruction_impl.ts
+++ b/yarn-project/simulator/src/avm/opcodes/instruction_impl.ts
@@ -8,10 +8,8 @@ export const ThreeOperandWireFormat8 = [
   OperandType.UINT8,
   OperandType.UINT8,
   OperandType.UINT8,
-  OperandType.UINT8,
 ];
 export const ThreeOperandWireFormat16 = [
-  OperandType.UINT8,
   OperandType.UINT8,
   OperandType.UINT8,
   OperandType.UINT16,
@@ -29,7 +27,6 @@ export abstract class ThreeOperandInstruction extends Instruction {
 
   constructor(
     protected indirect: number,
-    protected inTag: number,
     protected aOffset: number,
     protected bOffset: number,
     protected dstOffset: number,

--- a/yarn-project/simulator/src/avm/serialization/bytecode_serialization.test.ts
+++ b/yarn-project/simulator/src/avm/serialization/bytecode_serialization.test.ts
@@ -72,14 +72,8 @@ describe('Bytecode Serialization', () => {
 
   it('Should deserialize real instructions', () => {
     const instructions = [
-      new Add(/*indirect=*/ 0, /*inTag=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(
-        Opcode.ADD_8,
-        Add.wireFormat8,
-      ),
-      new Sub(/*indirect=*/ 0, /*inTag=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(
-        Opcode.SUB_8,
-        Sub.wireFormat8,
-      ),
+      new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.ADD_8, Add.wireFormat8),
+      new Sub(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.SUB_8, Sub.wireFormat8),
       new GetEnvVar(/*indirect=*/ 0, EnvironmentVariable.ADDRESS, /*dstOffset=*/ 1).as(
         Opcode.GETENVVAR_16,
         GetEnvVar.wireFormat16,
@@ -116,14 +110,8 @@ describe('Bytecode Serialization', () => {
 
   it('Should serialize real instructions', () => {
     const instructions = [
-      new Add(/*indirect=*/ 0, /*inTag=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(
-        Opcode.ADD_8,
-        Add.wireFormat8,
-      ),
-      new Sub(/*indirect=*/ 0, /*inTag=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(
-        Opcode.SUB_8,
-        Sub.wireFormat8,
-      ),
+      new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.ADD_8, Add.wireFormat8),
+      new Sub(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.SUB_8, Sub.wireFormat8),
       new GetEnvVar(/*indirect=*/ 0, EnvironmentVariable.ADDRESS, /*dstOffset=*/ 1).as(
         Opcode.GETENVVAR_16,
         GetEnvVar.wireFormat16,


### PR DESCRIPTION
Yields ~5% reduction in bytecode size (public_dispatch).

Part of #9059.