### PR TITLE
feat: Handle reorgs on sequencer

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -127,7 +127,7 @@ contract Rollup is EIP712("Aztec Rollup", "1"), Leonidas, IRollup, ITestRollup {
    * @dev     Will revert if there is nothing to prune or if the chain is not ready to be pruned
    */
   function prune() external override(IRollup) {
-    require(_canPrune(), Errors.Rollup__NothingToPrune());
+    require(canPrune(), Errors.Rollup__NothingToPrune());
     _prune();
   }
 
@@ -417,7 +417,7 @@ contract Rollup is EIP712("Aztec Rollup", "1"), Leonidas, IRollup, ITestRollup {
     SignatureLib.Signature[] memory _signatures,
     bytes calldata _body
   ) public override(IRollup) {
-    if (_canPrune()) {
+    if (canPrune()) {
       _prune();
     }
     bytes32 txsEffectsHash = TxsDecoder.decode(_body);
@@ -733,7 +733,7 @@ contract Rollup is EIP712("Aztec Rollup", "1"), Leonidas, IRollup, ITestRollup {
     emit PrunedPending(tips.provenBlockNumber, pending);
   }
 
-  function _canPrune() internal view returns (bool) {
+  function canPrune() public view returns (bool) {
     if (
       tips.pendingBlockNumber == tips.provenBlockNumber
         || tips.pendingBlockNumber <= assumeProvenThroughBlockNumber

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -32,6 +32,8 @@ interface IRollup {
 
   function prune() external;
 
+  function canPrune() external view returns (bool);
+
   function claimEpochProofRight(EpochProofQuoteLib.SignedEpochProofQuote calldata _quote) external;
 
   function propose(

--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -379,7 +379,7 @@ describe('Archiver', () => {
   }, 10_000);
 
   // TODO(palla/reorg): Add a unit test for the archiver handleEpochPrune
-  it('handles an upcoming L2 prune');
+  xit('handles an upcoming L2 prune', () => {});
 
   // logs should be created in order of how archiver syncs.
   const mockGetLogs = (logs: {

--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -298,7 +298,7 @@ describe('Archiver', () => {
     expect(loggerSpy).toHaveBeenNthCalledWith(2, `No blocks to retrieve from ${1n} to ${50n}`);
   }, 10_000);
 
-  it('Handle L2 reorg', async () => {
+  it('handles L2 reorg', async () => {
     const loggerSpy = jest.spyOn((archiver as any).log, 'verbose');
 
     let latestBlockNum = await archiver.getBlockNumber();
@@ -377,6 +377,9 @@ describe('Archiver', () => {
 
     // The random blocks don't include contract instances nor classes we we cannot look for those here.
   }, 10_000);
+
+  // TODO(palla/reorg): Add a unit test for the archiver handleEpochPrune
+  it('handles an upcoming L2 prune');
 
   // logs should be created in order of how archiver syncs.
   const mockGetLogs = (logs: {

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -246,12 +246,42 @@ export class Archiver implements ArchiveSource {
     await this.handleL1ToL2Messages(blockUntilSynced, messagesSynchedTo, currentL1BlockNumber);
 
     // ********** Events that are processed per L2 block **********
-    await this.handleL2blocks(blockUntilSynced, blocksSynchedTo, currentL1BlockNumber);
+    if (currentL1BlockNumber > blocksSynchedTo) {
+      // First we retrieve new L2 blocks
+      const { provenBlockNumber } = await this.handleL2blocks(blockUntilSynced, blocksSynchedTo, currentL1BlockNumber);
+      // And then we prune the current epoch if it'd reorg on next submission.
+      // Note that we don't do this before retrieving L2 blocks because we may need to retrieve
+      // blocks from more than 2 epochs ago, so we want to make sure we have the latest view of
+      // the chain locally before we start unwinding stuff. This can be optimized by figuring out
+      // up to which point we're pruning, and then requesting L2 blocks up to that point only.
+      await this.handleEpochPrune(provenBlockNumber, currentL1BlockNumber);
+    }
 
     // Store latest l1 block number and timestamp seen. Used for epoch and slots calculations.
     if (!this.l1BlockNumber || this.l1BlockNumber < currentL1BlockNumber) {
       this.l1Timestamp = await this.publicClient.getBlock({ blockNumber: currentL1BlockNumber }).then(b => b.timestamp);
       this.l1BlockNumber = currentL1BlockNumber;
+    }
+  }
+
+  /** Checks if there'd be a reorg for the next block submission and start pruning now. */
+  private async handleEpochPrune(provenBlockNumber: bigint, currentL1BlockNumber: bigint) {
+    const localPendingBlockNumber = BigInt(await this.getBlockNumber());
+
+    const canPrune =
+      localPendingBlockNumber > provenBlockNumber &&
+      (await this.rollup.read.canPrune({ blockNumber: currentL1BlockNumber }));
+
+    if (canPrune) {
+      this.log.verbose(`L2 prune will occur on next submission. Rolling back to last proven block.`);
+      const blocksToUnwind = localPendingBlockNumber - provenBlockNumber;
+      this.log.verbose(
+        `Unwinding ${blocksToUnwind} block${blocksToUnwind > 1n ? 's' : ''} from block ${localPendingBlockNumber}`,
+      );
+      await this.store.unwindBlocks(Number(localPendingBlockNumber), Number(blocksToUnwind));
+      // TODO(palla/reorg): Do we need to set the block synched L1 block number here?
+      // Seems like the next iteration should handle this.
+      // await this.store.setBlockSynchedL1BlockNumber(currentL1BlockNumber);
     }
   }
 
@@ -291,11 +321,11 @@ export class Archiver implements ArchiveSource {
     );
   }
 
-  private async handleL2blocks(blockUntilSynced: boolean, blocksSynchedTo: bigint, currentL1BlockNumber: bigint) {
-    if (currentL1BlockNumber <= blocksSynchedTo) {
-      return;
-    }
-
+  private async handleL2blocks(
+    blockUntilSynced: boolean,
+    blocksSynchedTo: bigint,
+    currentL1BlockNumber: bigint,
+  ): Promise<{ provenBlockNumber: bigint }> {
     const localPendingBlockNumber = BigInt(await this.getBlockNumber());
     const [
       provenBlockNumber,
@@ -304,7 +334,7 @@ export class Archiver implements ArchiveSource {
       pendingArchive,
       archiveForLocalPendingBlockNumber,
       provenEpochNumber,
-    ] = await this.rollup.read.status([localPendingBlockNumber]);
+    ] = await this.rollup.read.status([localPendingBlockNumber], { blockNumber: currentL1BlockNumber });
 
     const updateProvenBlock = async () => {
       const localBlockForDestinationProvenBlockNumber = await this.getBlock(Number(provenBlockNumber));
@@ -326,7 +356,7 @@ export class Archiver implements ArchiveSource {
     if (noBlocks) {
       await this.store.setBlockSynchedL1BlockNumber(currentL1BlockNumber);
       this.log.verbose(`No blocks to retrieve from ${blocksSynchedTo + 1n} to ${currentL1BlockNumber}`);
-      return;
+      return { provenBlockNumber };
     }
 
     await updateProvenBlock();
@@ -343,7 +373,7 @@ export class Archiver implements ArchiveSource {
       if (noBlockSinceLast) {
         await this.store.setBlockSynchedL1BlockNumber(currentL1BlockNumber);
         this.log.verbose(`No blocks to retrieve from ${blocksSynchedTo + 1n} to ${currentL1BlockNumber}`);
-        return;
+        return { provenBlockNumber };
       }
 
       const localPendingBlockInChain = archiveForLocalPendingBlockNumber === localPendingBlock.archive.root.toString();
@@ -383,7 +413,7 @@ export class Archiver implements ArchiveSource {
       this.rollup,
       this.publicClient,
       blockUntilSynced,
-      blocksSynchedTo + 1n,
+      blocksSynchedTo + 1n, // TODO(palla/reorg): If the L2 reorg was due to an L1 reorg, we need to start search earlier
       currentL1BlockNumber,
       this.log,
     );
@@ -391,8 +421,8 @@ export class Archiver implements ArchiveSource {
     if (retrievedBlocks.length === 0) {
       // We are not calling `setBlockSynchedL1BlockNumber` because it may cause sync issues if based off infura.
       // See further details in earlier comments.
-      this.log.verbose(`Retrieved no new blocks from ${blocksSynchedTo + 1n} to ${currentL1BlockNumber}`);
-      return;
+      this.log.verbose(`Retrieved no new L2 blocks from ${blocksSynchedTo + 1n} to ${currentL1BlockNumber}`);
+      return { provenBlockNumber };
     }
 
     this.log.debug(
@@ -410,6 +440,7 @@ export class Archiver implements ArchiveSource {
 
     const timer = new Timer();
     await this.store.addBlocks(retrievedBlocks);
+
     // Important that we update AFTER inserting the blocks.
     await updateProvenBlock();
     this.instrumentation.processNewBlocks(
@@ -418,6 +449,8 @@ export class Archiver implements ArchiveSource {
     );
     const lastL2BlockNumber = retrievedBlocks[retrievedBlocks.length - 1].data.number;
     this.log.verbose(`Processed ${retrievedBlocks.length} new L2 blocks up to ${lastL2BlockNumber}`);
+
+    return { provenBlockNumber };
   }
 
   /**
@@ -497,7 +530,10 @@ export class Archiver implements ArchiveSource {
     const [_startTimestamp, endTimestamp] = getTimestampRangeForEpoch(epochNumber, this.l1constants);
 
     // For this computation, we throw in a few extra seconds just for good measure,
-    // since we know the next L1 block won't be mined within this range
+    // since we know the next L1 block won't be mined within this range. Remember that
+    // l1timestamp is the timestamp of the last l1 block we've seen, so this 3s rely on
+    // the fact that L1 won't mine two blocks within 3s of each other.
+    // TODO(palla/reorg): Is the above a safe assumption?
     const leeway = 3n;
     return l1Timestamp + leeway >= endTimestamp;
   }

--- a/yarn-project/aztec.js/src/utils/cheat_codes.ts
+++ b/yarn-project/aztec.js/src/utils/cheat_codes.ts
@@ -329,6 +329,18 @@ export class RollupCheatCodes {
     this.logger.verbose(`Advanced to next epoch`);
   }
 
+  /**
+   * Warps time in L1 equivalent to however many slots.
+   * @param howMany - The number of slots to advance.
+   */
+  public async advanceSlots(howMany: number) {
+    const l1Timestamp = Number((await this.client.getBlock()).timestamp);
+    const timeToWarp = howMany * AZTEC_SLOT_DURATION;
+    await this.ethCheatCodes.warp(l1Timestamp + timeToWarp);
+    const [slot, epoch] = await Promise.all([this.getSlot(), this.getEpoch()]);
+    this.logger.verbose(`Advanced ${howMany} slots up to slot ${slot} in epoch ${epoch}`);
+  }
+
   /** Returns the current proof claim (if any) */
   public async getProofClaim(): Promise<EpochProofClaim | undefined> {
     // REFACTOR: This code is duplicated from l1-publisher

--- a/yarn-project/aztec.js/src/utils/cheat_codes.ts
+++ b/yarn-project/aztec.js/src/utils/cheat_codes.ts
@@ -125,7 +125,7 @@ export class EthCheatCodes {
     if (res.error) {
       throw new Error(`Error mining: ${res.error.message}`);
     }
-    this.logger.verbose(`Mined ${numberOfBlocks} blocks`);
+    this.logger.verbose(`Mined ${numberOfBlocks} L1 blocks`);
   }
 
   /**
@@ -150,7 +150,7 @@ export class EthCheatCodes {
     if (res.error) {
       throw new Error(`Error setting block interval: ${res.error.message}`);
     }
-    this.logger.verbose(`Set block interval to ${interval}`);
+    this.logger.verbose(`Set L1 block interval to ${interval}`);
   }
 
   /**
@@ -162,7 +162,7 @@ export class EthCheatCodes {
     if (res.error) {
       throw new Error(`Error setting next block timestamp: ${res.error.message}`);
     }
-    this.logger.verbose(`Set next block timestamp to ${timestamp}`);
+    this.logger.verbose(`Set L1 next block timestamp to ${timestamp}`);
   }
 
   /**
@@ -175,7 +175,7 @@ export class EthCheatCodes {
       throw new Error(`Error warping: ${res.error.message}`);
     }
     await this.mine();
-    this.logger.verbose(`Warped to ${timestamp}`);
+    this.logger.verbose(`Warped L1 timestamp to ${timestamp}`);
   }
 
   /**
@@ -228,7 +228,7 @@ export class EthCheatCodes {
     if (res.error) {
       throw new Error(`Error setting storage for contract ${contract} at ${slot}: ${res.error.message}`);
     }
-    this.logger.verbose(`Set storage for contract ${contract} at ${slot} to ${value}`);
+    this.logger.verbose(`Set L1 storage for contract ${contract} at ${slot} to ${value}`);
   }
 
   /**

--- a/yarn-project/circuit-types/src/interfaces/world_state.ts
+++ b/yarn-project/circuit-types/src/interfaces/world_state.ts
@@ -1,3 +1,4 @@
+import { type L2BlockId } from '../l2_block_source.js';
 import type { MerkleTreeReadOperations, MerkleTreeWriteOperations } from './merkle_tree_operations.js';
 
 /**
@@ -21,7 +22,7 @@ export interface WorldStateSynchronizerStatus {
   /**
    * The block number that the world state synchronizer is synced to.
    */
-  syncedToL2Block: number;
+  syncedToL2Block: L2BlockId;
 }
 
 /**

--- a/yarn-project/circuit-types/src/l2_block_downloader/l2_block_stream.test.ts
+++ b/yarn-project/circuit-types/src/l2_block_downloader/l2_block_stream.test.ts
@@ -125,14 +125,6 @@ describe('L2BlockStream', () => {
         { type: 'chain-finalized', blockNumber: 35 },
       ]);
     });
-
-    it('does not emit events for chain proven or finalized if local data ignores them', async () => {
-      setRemoteTips(45, 40, 35);
-      localData.latest.number = 40;
-
-      await blockStream.work();
-      expect(handler.events).toEqual([{ type: 'blocks-added', blocks: times(5, i => makeBlock(i + 41)) }]);
-    });
   });
 });
 

--- a/yarn-project/circuit-types/src/l2_block_downloader/l2_block_stream.ts
+++ b/yarn-project/circuit-types/src/l2_block_downloader/l2_block_stream.ts
@@ -63,7 +63,7 @@ export class L2BlockStream {
         latestBlockNumber--;
       }
       if (latestBlockNumber < localTips.latest.number) {
-        this.log.verbose(`Reorg detected. Pruning blocks from ${latestBlockNumber + 1} to ${localTips.latest}.`);
+        this.log.verbose(`Reorg detected. Pruning blocks from ${latestBlockNumber + 1} to ${localTips.latest.number}.`);
         await this.emitEvent({ type: 'chain-pruned', blockNumber: latestBlockNumber });
       }
 

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -448,7 +448,7 @@ describe('e2e_block_building', () => {
       await cheatCodes.rollup.advanceSlots(AZTEC_EPOCH_PROOF_CLAIM_WINDOW_IN_L2_SLOTS + 1); // off-by-one?
 
       // Wait a bit before spawning a new pxe
-      await sleep(1000);
+      await sleep(2000);
 
       // Send another tx which should be mined a block that is built on the reorg'd chain
       // We need to send it from a new pxe since pxe doesn't detect reorgs (yet)

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -412,7 +412,7 @@ describe('e2e_block_building', () => {
     let teardown: () => Promise<void>;
 
     beforeEach(async () => {
-      ({ teardown, pxe, logger, wallet: owner, cheatCodes } = await setup(1));
+      ({ teardown, pxe, logger, wallet: owner, cheatCodes } = await setup(1, { assumeProvenThrough: undefined }));
       ownerAddress = owner.getCompleteAddress().address;
       contract = await StatefulTestContract.deploy(owner, ownerAddress, ownerAddress, 1).send().deployed();
       initialBlockNumber = await pxe.getBlockNumber();
@@ -429,7 +429,7 @@ describe('e2e_block_building', () => {
       logger.info('Sending initial tx');
       const tx1 = await contract.methods.increment_public_value(ownerAddress, 20).send().wait();
       expect(tx1.blockNumber).toEqual(initialBlockNumber + 1);
-      expect(await contract.methods.get_public_value(ownerAddress).simulate()).toEqual(21n);
+      expect(await contract.methods.get_public_value(ownerAddress).simulate()).toEqual(20n);
 
       // Now move past the proof claim window
       logger.info('Advancing past the proof claim window');
@@ -441,7 +441,7 @@ describe('e2e_block_building', () => {
       // Send another tx which should be mined a block that is built on the reorg'd chain
       logger.info('Sending new tx on reorgd chain');
       const tx2 = await contract.methods.increment_public_value(ownerAddress, 10).send().wait();
-      expect(await contract.methods.get_public_value(ownerAddress).simulate()).toEqual(11n);
+      expect(await contract.methods.get_public_value(ownerAddress).simulate()).toEqual(10n);
       expect(tx2.blockNumber).toEqual(initialBlockNumber + 1);
     });
   });

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -456,15 +456,17 @@ describe('e2e_block_building', () => {
       const pxeServiceConfig = { ...getPXEServiceConfig() };
       const newPxe = await createPXEService(aztecNode, pxeServiceConfig);
       const newWallet = await createAccount(newPxe);
-      const contractFromNewPxe = await StatefulTestContract.at(contract.address, newWallet);
+      expect(await pxe.getBlockNumber()).toEqual(initialBlockNumber + 1);
+
       // TODO: Contract.at should automatically register the instance in the pxe
-      logger.info(`Registering contract at ${contractFromNewPxe.address} in new pxe`);
-      await newPxe.registerContract({ instance: contractFromNewPxe.instance, artifact: StatefulTestContractArtifact });
+      logger.info(`Registering contract at ${contract.address} in new pxe`);
+      await newPxe.registerContract({ instance: contract.instance, artifact: StatefulTestContractArtifact });
+      const contractFromNewPxe = await StatefulTestContract.at(contract.address, newWallet);
 
       logger.info('Sending new tx on reorgd chain');
       const tx2 = await contractFromNewPxe.methods.increment_public_value(ownerAddress, 10).send().wait();
       expect(await contractFromNewPxe.methods.get_public_value(ownerAddress).simulate()).toEqual(10n);
-      expect(tx2.blockNumber).toEqual(initialBlockNumber + 1);
+      expect(tx2.blockNumber).toEqual(initialBlockNumber + 2);
     });
   });
 });

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -447,8 +447,8 @@ describe('e2e_block_building', () => {
       await cheatCodes.rollup.advanceToNextEpoch();
       await cheatCodes.rollup.advanceSlots(AZTEC_EPOCH_PROOF_CLAIM_WINDOW_IN_L2_SLOTS + 1); // off-by-one?
 
-      // Await (sequencer should wait here, not us)
-      await sleep(5000);
+      // Wait a bit before spawning a new pxe
+      await sleep(1000);
 
       // Send another tx which should be mined a block that is built on the reorg'd chain
       // We need to send it from a new pxe since pxe doesn't detect reorgs (yet)

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -445,7 +445,7 @@ describe('e2e_block_building', () => {
       // Now move to a new epoch and past the proof claim window
       logger.info('Advancing past the proof claim window');
       await cheatCodes.rollup.advanceToNextEpoch();
-      await cheatCodes.rollup.advanceSlots(AZTEC_EPOCH_PROOF_CLAIM_WINDOW_IN_L2_SLOTS + 5); // off-by-one?
+      await cheatCodes.rollup.advanceSlots(AZTEC_EPOCH_PROOF_CLAIM_WINDOW_IN_L2_SLOTS + 1); // off-by-one?
 
       // Await (sequencer should wait here, not us)
       await sleep(5000);

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -4,6 +4,7 @@ import {
   type EpochProofQuote,
   type L2Block,
   L2BlockDownloader,
+  type L2BlockId,
   type L2BlockSource,
   type Tx,
   type TxHash,
@@ -44,7 +45,7 @@ export interface P2PSyncState {
   /**
    * The block number that the p2p client is synced to.
    */
-  syncedToL2Block: number;
+  syncedToL2Block: L2BlockId;
 }
 
 /**
@@ -472,10 +473,15 @@ export class P2PClient extends WithTracer implements P2P {
    * Method to check the status the p2p client.
    * @returns Information about p2p client status: state & syncedToBlockNum.
    */
-  public getStatus(): Promise<P2PSyncState> {
+  public async getStatus(): Promise<P2PSyncState> {
+    const blockNumber = this.getSyncedLatestBlockNum();
+    const blockHash =
+      blockNumber == 0
+        ? ''
+        : await this.l2BlockSource.getBlockHeader(blockNumber).then(header => header?.hash().toString());
     return Promise.resolve({
       state: this.currentState,
-      syncedToL2Block: this.getSyncedLatestBlockNum(),
+      syncedToL2Block: { number: blockNumber, hash: blockHash },
     } as P2PSyncState);
   }
 

--- a/yarn-project/prover-node/src/prover-node.test.ts
+++ b/yarn-project/prover-node/src/prover-node.test.ts
@@ -115,7 +115,10 @@ describe('prover-node', () => {
 
     // World state returns a new mock db every time it is asked to fork
     worldState.fork.mockImplementation(() => Promise.resolve(mock<MerkleTreeWriteOperations>()));
-    worldState.status.mockResolvedValue({ syncedToL2Block: 1, state: WorldStateRunningState.RUNNING });
+    worldState.status.mockResolvedValue({
+      syncedToL2Block: { number: 1, hash: '' },
+      state: WorldStateRunningState.RUNNING,
+    });
 
     // Publisher returns its sender address
     address = EthAddress.random();

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -213,6 +213,9 @@ export class L1Publisher {
    * @return blockNumber - The L2 block number of the next L2 block
    */
   public async canProposeAtNextEthBlock(archive: Buffer): Promise<[bigint, bigint]> {
+    // FIXME: This should not throw if unable to propose but return a falsey value, so
+    // we can differentiate between errors when hitting the L1 rollup contract (eg RPC error)
+    // which may require a retry, vs actually not being the turn for proposing.
     const ts = BigInt((await this.publicClient.getBlock()).timestamp + BigInt(ETHEREUM_SLOT_DURATION));
     const [slot, blockNumber] = await this.rollupContract.read.canProposeAtTime([ts, `0x${archive.toString('hex')}`]);
     return [slot, blockNumber];

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -191,7 +191,6 @@ describe('sequencer', () => {
 
     globalVariableBuilder.buildGlobalVariables.mockResolvedValueOnce(mockedGlobalVariables);
 
-    await sequencer.initialSync();
     await sequencer.work();
 
     expect(blockBuilder.startNewBlock).toHaveBeenCalledWith(
@@ -219,7 +218,6 @@ describe('sequencer', () => {
     publisher.canProposeAtNextEthBlock.mockRejectedValue(new Error());
     publisher.validateBlockForSubmission.mockRejectedValue(new Error());
 
-    await sequencer.initialSync();
     await sequencer.work();
     expect(blockBuilder.startNewBlock).not.toHaveBeenCalled();
 
@@ -269,7 +267,6 @@ describe('sequencer', () => {
       );
     });
 
-    await sequencer.initialSync();
     await sequencer.work();
 
     expect(blockBuilder.startNewBlock).toHaveBeenCalledWith(
@@ -299,7 +296,6 @@ describe('sequencer', () => {
     // We make the chain id on the invalid tx not equal to the configured chain id
     invalidChainTx.data.constants.txContext.chainId = new Fr(1n + chainId.value);
 
-    await sequencer.initialSync();
     await sequencer.work();
 
     expect(blockBuilder.startNewBlock).toHaveBeenCalledWith(
@@ -331,7 +327,6 @@ describe('sequencer', () => {
     (txs[invalidTransactionIndex].unencryptedLogs.functionLogs[0].logs[0] as Writeable<UnencryptedL2Log>).data =
       randomBytes(1024 * 1022);
 
-    await sequencer.initialSync();
     await sequencer.work();
 
     expect(blockBuilder.startNewBlock).toHaveBeenCalledWith(
@@ -354,8 +349,6 @@ describe('sequencer', () => {
     publisher.proposeL2Block.mockResolvedValueOnce(true);
 
     globalVariableBuilder.buildGlobalVariables.mockResolvedValueOnce(mockedGlobalVariables);
-
-    await sequencer.initialSync();
 
     sequencer.updateConfig({ minTxsPerBlock: 4 });
 
@@ -398,8 +391,6 @@ describe('sequencer', () => {
 
     globalVariableBuilder.buildGlobalVariables.mockResolvedValueOnce(mockedGlobalVariables);
 
-    await sequencer.initialSync();
-
     sequencer.updateConfig({ minTxsPerBlock: 4 });
 
     // block is not built with 0 txs
@@ -440,8 +431,6 @@ describe('sequencer', () => {
     publisher.proposeL2Block.mockResolvedValueOnce(true);
 
     globalVariableBuilder.buildGlobalVariables.mockResolvedValueOnce(mockedGlobalVariables);
-
-    await sequencer.initialSync();
 
     sequencer.updateConfig({ minTxsPerBlock: 4 });
 
@@ -494,8 +483,6 @@ describe('sequencer', () => {
     );
 
     globalVariableBuilder.buildGlobalVariables.mockResolvedValueOnce(mockedGlobalVariables);
-
-    await sequencer.initialSync();
 
     // This could practically be for any reason, e.g., could also be that we have entered a new slot.
     publisher.validateBlockForSubmission
@@ -579,7 +566,6 @@ describe('sequencer', () => {
       // The previous epoch can be claimed
       publisher.nextEpochToClaim.mockImplementation(() => Promise.resolve(currentEpoch - 1n));
 
-      await sequencer.initialSync();
       await sequencer.work();
       expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash], proofQuote);
     });
@@ -603,7 +589,6 @@ describe('sequencer', () => {
       // The previous epoch can be claimed
       publisher.nextEpochToClaim.mockImplementation(() => Promise.resolve(0n));
 
-      await sequencer.initialSync();
       await sequencer.work();
       expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash], undefined);
     });
@@ -628,7 +613,6 @@ describe('sequencer', () => {
       // The previous epoch can be claimed
       publisher.nextEpochToClaim.mockImplementation(() => Promise.resolve(currentEpoch - 1n));
 
-      await sequencer.initialSync();
       await sequencer.work();
       expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash], undefined);
     });
@@ -652,7 +636,6 @@ describe('sequencer', () => {
       // The previous epoch can be claimed
       publisher.nextEpochToClaim.mockResolvedValue(currentEpoch);
 
-      await sequencer.initialSync();
       await sequencer.work();
       expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash], undefined);
     });
@@ -678,7 +661,6 @@ describe('sequencer', () => {
       // The previous epoch can be claimed
       publisher.nextEpochToClaim.mockImplementation(() => Promise.resolve(currentEpoch - 1n));
 
-      await sequencer.initialSync();
       await sequencer.work();
       expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash], undefined);
     });
@@ -734,7 +716,6 @@ describe('sequencer', () => {
       // The previous epoch can be claimed
       publisher.nextEpochToClaim.mockImplementation(() => Promise.resolve(currentEpoch - 1n));
 
-      await sequencer.initialSync();
       await sequencer.work();
       expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash], validProofQuote);
     });
@@ -794,7 +775,6 @@ describe('sequencer', () => {
       // The previous epoch can be claimed
       publisher.nextEpochToClaim.mockImplementation(() => Promise.resolve(currentEpoch - 1n));
 
-      await sequencer.initialSync();
       await sequencer.work();
       expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash], validQuotes[0]);
     });
@@ -804,9 +784,5 @@ describe('sequencer', () => {
 class TestSubject extends Sequencer {
   public override work() {
     return super.work();
-  }
-
-  public override initialSync(): Promise<void> {
-    return super.initialSync();
   }
 }

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -529,11 +529,11 @@ describe('sequencer', () => {
 
       worldState.status.mockResolvedValue({
         state: WorldStateRunningState.IDLE,
-        syncedToL2Block: block.header.globalVariables.blockNumber.toNumber() - 1,
+        syncedToL2Block: { number: block.header.globalVariables.blockNumber.toNumber() - 1, hash: '' },
       });
 
       p2p.getStatus.mockResolvedValue({
-        syncedToL2Block: block.header.globalVariables.blockNumber.toNumber() - 1,
+        syncedToL2Block: { number: block.header.globalVariables.blockNumber.toNumber() - 1, hash: '' },
         state: P2PClientState.IDLE,
       });
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -9,6 +9,7 @@ import {
   type L2BlockSource,
   MerkleTreeId,
   type MerkleTreeReadOperations,
+  type MerkleTreeWriteOperations,
   type Tx,
   TxHash,
   type UnencryptedL2Log,
@@ -53,6 +54,7 @@ describe('sequencer', () => {
   let globalVariableBuilder: MockProxy<GlobalVariableBuilder>;
   let p2p: MockProxy<P2P>;
   let worldState: MockProxy<WorldStateSynchronizer>;
+  let fork: MockProxy<MerkleTreeWriteOperations>;
   let blockBuilder: MockProxy<BlockBuilder>;
   let merkleTreeOps: MockProxy<MerkleTreeReadOperations>;
   let publicProcessor: MockProxy<PublicProcessor>;
@@ -61,6 +63,7 @@ describe('sequencer', () => {
   let publicProcessorFactory: MockProxy<PublicProcessorFactory>;
 
   let lastBlockNumber: number;
+  let hash: string;
 
   let sequencer: TestSubject;
 
@@ -92,6 +95,7 @@ describe('sequencer', () => {
 
   beforeEach(() => {
     lastBlockNumber = 0;
+    hash = Fr.ZERO.toString();
 
     block = L2Block.random(lastBlockNumber + 1);
 
@@ -120,12 +124,20 @@ describe('sequencer', () => {
     blockBuilder = mock<BlockBuilder>();
 
     p2p = mock<P2P>({
-      getStatus: mockFn().mockResolvedValue({ state: P2PClientState.IDLE, syncedToL2Block: lastBlockNumber }),
+      getStatus: mockFn().mockResolvedValue({
+        state: P2PClientState.IDLE,
+        syncedToL2Block: { number: lastBlockNumber, hash },
+      }),
     });
 
+    fork = mock<MerkleTreeWriteOperations>();
     worldState = mock<WorldStateSynchronizer>({
+      fork: () => Promise.resolve(fork),
       getCommitted: () => merkleTreeOps,
-      status: mockFn().mockResolvedValue({ state: WorldStateRunningState.IDLE, syncedToL2Block: lastBlockNumber }),
+      status: mockFn().mockResolvedValue({
+        state: WorldStateRunningState.IDLE,
+        syncedToL2Block: { number: lastBlockNumber, hash },
+      }),
     });
 
     publicProcessor = mock<PublicProcessor>({
@@ -142,6 +154,7 @@ describe('sequencer', () => {
 
     l2BlockSource = mock<L2BlockSource>({
       getBlockNumber: mockFn().mockResolvedValue(lastBlockNumber),
+      getL2Tips: mockFn().mockResolvedValue({ latest: { number: lastBlockNumber, hash } }),
     });
 
     l1ToL2MessageSource = mock<L1ToL2MessageSource>({
@@ -516,11 +529,11 @@ describe('sequencer', () => {
 
       worldState.status.mockResolvedValue({
         state: WorldStateRunningState.IDLE,
-        syncedToL2Block: { number: block.header.globalVariables.blockNumber.toNumber() - 1, hash: '' },
+        syncedToL2Block: { number: block.header.globalVariables.blockNumber.toNumber() - 1, hash },
       });
 
       p2p.getStatus.mockResolvedValue({
-        syncedToL2Block: { number: block.header.globalVariables.blockNumber.toNumber() - 1, hash: '' },
+        syncedToL2Block: { number: block.header.globalVariables.blockNumber.toNumber() - 1, hash },
         state: P2PClientState.IDLE,
       });
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -661,7 +661,7 @@ export class Sequencer {
       (l2BlockSource.hash === undefined || worldState.hash === l2BlockSource.hash) &&
       // and p2p client and message source are at least at the same block
       // this should change to hashes once p2p client handles reorgs
-      // and once we stop pretending that hte l1tol2message source is not
+      // and once we stop pretending that the l1tol2message source is not
       // just the archiver under a different name
       p2p >= l2BlockSource.number &&
       l1ToL2MessageSource >= l2BlockSource.number;

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -3,7 +3,6 @@ import {
   type EpochProofQuote,
   type L1ToL2MessageSource,
   type L2Block,
-  type L2BlockId,
   type L2BlockSource,
   type ProcessedTx,
   Tx,

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -71,7 +71,6 @@ export class Sequencer {
   // TODO: zero values should not be allowed for the following 2 values in PROD
   private _coinbase = EthAddress.ZERO;
   private _feeRecipient = AztecAddress.ZERO;
-  private lastPublishedBlock: L2BlockId = { number: 0, hash: undefined };
   private state = SequencerState.STOPPED;
   private allowedInSetup: AllowedElement[] = [];
   private allowedInTeardown: AllowedElement[] = [];
@@ -146,13 +145,12 @@ export class Sequencer {
   /**
    * Starts the sequencer and moves to IDLE state. Blocks until the initial sync is complete.
    */
-  public async start() {
-    await this.initialSync();
-
+  public start() {
     this.runningPromise = new RunningPromise(this.work.bind(this), this.pollingIntervalMs);
     this.runningPromise.start();
     this.state = SequencerState.IDLE;
     this.log.info('Sequencer started');
+    return Promise.resolve();
   }
 
   /**
@@ -182,13 +180,6 @@ export class Sequencer {
    */
   public status() {
     return { state: this.state };
-  }
-
-  protected async initialSync() {
-    // TODO: Should we wait for world state to be ready, or is the caller expected to run await start?
-    this.lastPublishedBlock = await this.worldState
-      .status()
-      .then((s: WorldStateSynchronizerStatus) => s.syncedToL2Block);
   }
 
   /**
@@ -319,6 +310,7 @@ export class Sequencer {
       this.log.debug(`Can propose block ${proposalBlockNumber} at slot ${slot}`);
       return slot;
     } catch (err) {
+      this.log.verbose(`Rejected from being able to propose at next block with ${tipArchive}`);
       prettyLogViemError(err, this.log);
       throw err;
     }
@@ -615,9 +607,7 @@ export class Sequencer {
     this.state = SequencerState.PUBLISHING_BLOCK;
 
     const publishedL2Block = await this.publisher.proposeL2Block(block, attestations, txHashes, proofQuote);
-    if (publishedL2Block) {
-      this.lastPublishedBlock = { number: block.number, hash: block.hash().toString() };
-    } else {
+    if (!publishedL2Block) {
       throw new Error(`Failed to publish block ${block.number}`);
     }
   }
@@ -653,28 +643,38 @@ export class Sequencer {
   }
 
   /**
-   * Returns whether the previous block sent has been mined, and all dependencies have caught up with it.
+   * Returns whether all dependencies have caught up.
+   * We don't check against the previous block submitted since it may have been reorg'd out.
    * @returns Boolean indicating if our dependencies are synced to the latest block.
    */
   protected async isBlockSynced() {
     const syncedBlocks = await Promise.all([
-      this.worldState.status().then((s: WorldStateSynchronizerStatus) => s.syncedToL2Block.number),
+      this.worldState.status().then((s: WorldStateSynchronizerStatus) => s.syncedToL2Block),
+      this.l2BlockSource.getL2Tips().then(t => t.latest),
       this.p2pClient.getStatus().then(s => s.syncedToL2Block.number),
-      this.l2BlockSource.getBlockNumber(),
       this.l1ToL2MessageSource.getBlockNumber(),
-    ]);
-    const min = Math.min(...syncedBlocks);
-    const [worldState, p2p, l2BlockSource, l1ToL2MessageSource] = syncedBlocks;
-    const result = min >= this.lastPublishedBlock.number;
-    this.log.debug(
-      `Sync check to last published block ${this.lastPublishedBlock.number} ${result ? 'succeeded' : 'failed'}`,
-      {
-        worldState,
-        p2p,
-        l2BlockSource,
-        l1ToL2MessageSource,
-      },
-    );
+    ] as const);
+    const [worldState, l2BlockSource, p2p, l1ToL2MessageSource] = syncedBlocks;
+    const result =
+      // check that world state has caught up with archiver
+      // note that the archiver reports undefined hash for the genesis block
+      // because it doesn't have access to world state to compute it (facepalm)
+      (l2BlockSource.hash === undefined || worldState.hash === l2BlockSource.hash) &&
+      // and p2p client and message source are at least at the same block
+      // this should change to hashes once p2p client handles reorgs
+      // and once we stop pretending that hte l1tol2message source is not
+      // just the archiver under a different name
+      p2p >= l2BlockSource.number &&
+      l1ToL2MessageSource >= l2BlockSource.number;
+
+    this.log.verbose(`Sequencer sync check ${result ? 'succeeded' : 'failed'}`, {
+      worldStateNumber: worldState.number,
+      worldStateHash: worldState.hash,
+      l2BlockSourceNumber: l2BlockSource.number,
+      l2BlockSourceHash: l2BlockSource.hash,
+      p2pNumber: p2p,
+      l1ToL2MessageSourceNumber: l1ToL2MessageSource,
+    });
     return result;
   }
 

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
@@ -87,7 +87,7 @@ describe('ServerWorldStateSynchronizer', () => {
       type: 'blocks-added',
       blocks: times(to - from + 1, i => L2Block.random(i + from, 4, 2, 3, 2, 1, inHash)),
     });
-    server.latest = to;
+    server.latest.number = to;
   };
 
   const expectServerStatus = async (state: WorldStateRunningState, blockNumber: number) => {
@@ -199,7 +199,9 @@ describe('ServerWorldStateSynchronizer', () => {
 });
 
 class TestWorldStateSynchronizer extends ServerWorldStateSynchronizer {
-  public latest = 0;
+  public latest = { number: 0, hash: '' };
+  public finalized = { number: 0, hash: '' };
+  public proven = { number: 0, hash: '' };
 
   constructor(
     merkleTrees: MerkleTreeAdminDatabase,
@@ -215,6 +217,6 @@ class TestWorldStateSynchronizer extends ServerWorldStateSynchronizer {
   }
 
   public override getL2Tips() {
-    return Promise.resolve({ latest: this.latest, proven: undefined, finalized: undefined });
+    return Promise.resolve({ latest: this.latest, proven: this.proven, finalized: this.finalized });
   }
 }

--- a/yarn-project/world-state/src/test/integration.test.ts
+++ b/yarn-project/world-state/src/test/integration.test.ts
@@ -89,11 +89,11 @@ describe('world-state integration', () => {
 
   const expectSynchedToBlock = async (latest: number, finalized?: number) => {
     const tips = await synchronizer.getL2Tips();
-    expect(tips.latest).toEqual(latest);
+    expect(tips.latest.number).toEqual(latest);
     await expectSynchedBlockHashMatches(latest);
 
     if (finalized !== undefined) {
-      expect(tips.finalized).toEqual(finalized);
+      expect(tips.finalized.number).toEqual(finalized);
       await expectSynchedBlockHashMatches(finalized);
     }
   };

--- a/yarn-project/world-state/src/test/integration.test.ts
+++ b/yarn-project/world-state/src/test/integration.test.ts
@@ -68,13 +68,13 @@ describe('world-state integration', () => {
       return finalized > tipFinalised;
     };
 
-    while (tips.latest < blockToSyncTo && sleepTime < maxTimeoutMS) {
+    while (tips.latest.number < blockToSyncTo && sleepTime < maxTimeoutMS) {
       await sleep(100);
       sleepTime = Date.now() - startTime;
       tips = await synchronizer.getL2Tips();
     }
 
-    while (waitForFinalised(tips.finalized) && sleepTime < maxTimeoutMS) {
+    while (waitForFinalised(tips.finalized.number) && sleepTime < maxTimeoutMS) {
       await sleep(100);
       sleepTime = Date.now() - startTime;
       tips = await synchronizer.getL2Tips();


### PR DESCRIPTION
Tweaks the archiver so it can detect when a prune _will_ happen and can start unwinding blocks then. This is then leveraged by the sequencer, so it builds the next block accounting for a reorg to happen. This also required tweaks on the L1 rollup contract so validations and checks account for pruning.