### PR TITLE
fix: prometheus metrics

### DIFF
--- a/spartan/aztec-network/values/3-validators-with-metrics.yaml
+++ b/spartan/aztec-network/values/3-validators-with-metrics.yaml
@@ -1,0 +1,27 @@
+##########
+# BEWARE #
+##########
+# You need to deploy the metrics helm chart before using this values file.
+# head to spartan/metrics and run `./install.sh`
+# (then `./forward.sh` if you want to see it)
+telemetry:
+  enabled: true
+  otelCollectorEndpoint: http://metrics-opentelemetry-collector.metrics:4318
+
+validator:
+  debug: "aztec:*,-aztec:avm_simulator:*,-aztec:libp2p_service,-aztec:world-state:database"
+  replicas: 3
+  validatorKeys:
+    - 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+    - 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+    - 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
+  validatorAddresses:
+    - 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+    - 0x70997970C51812dc3A010C7d01b50e0d17dc79C8
+    - 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC
+  validator:
+    disabled: false
+
+bootNode:
+  validator:
+    disabled: true

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/memory_attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/memory_attestation_pool.ts
@@ -1,6 +1,7 @@
 import { type BlockAttestation } from '@aztec/circuit-types';
 import { createDebugLogger } from '@aztec/foundation/log';
 import { type TelemetryClient } from '@aztec/telemetry-client';
+import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { PoolInstrumentation } from '../instrumentation.js';
 import { type AttestationPool } from './attestation_pool.js';
@@ -10,9 +11,9 @@ export class InMemoryAttestationPool implements AttestationPool {
 
   private attestations: Map</*slot=*/ bigint, Map</*proposalId*/ string, Map</*address=*/ string, BlockAttestation>>>;
 
-  constructor(telemetry: TelemetryClient, private log = createDebugLogger('aztec:attestation_pool')) {
+  constructor(_telemetry: TelemetryClient, private log = createDebugLogger('aztec:attestation_pool')) {
     this.attestations = new Map();
-    this.metrics = new PoolInstrumentation(telemetry, 'InMemoryAttestationPool');
+    this.metrics = new PoolInstrumentation(new NoopTelemetryClient(), 'InMemoryAttestationPool');
   }
 
   public getAttestationsForSlot(slot: bigint, proposalId: string): Promise<BlockAttestation[]> {

--- a/yarn-project/p2p/src/mem_pools/epoch_proof_quote_pool/memory_epoch_proof_quote_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/epoch_proof_quote_pool/memory_epoch_proof_quote_pool.ts
@@ -1,5 +1,6 @@
 import { type EpochProofQuote } from '@aztec/circuit-types';
 import { type TelemetryClient } from '@aztec/telemetry-client';
+import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { PoolInstrumentation } from '../instrumentation.js';
 import { type EpochProofQuotePool } from './epoch_proof_quote_pool.js';
@@ -8,9 +9,9 @@ export class MemoryEpochProofQuotePool implements EpochProofQuotePool {
   private quotes: Map<bigint, EpochProofQuote[]>;
   private metrics: PoolInstrumentation<EpochProofQuote>;
 
-  constructor(telemetry: TelemetryClient) {
+  constructor(_telemetry: TelemetryClient) {
     this.quotes = new Map();
-    this.metrics = new PoolInstrumentation(telemetry, 'MemoryEpochProofQuotePool');
+    this.metrics = new PoolInstrumentation(new NoopTelemetryClient(), 'MemoryEpochProofQuotePool');
   }
 
   addQuote(quote: EpochProofQuote) {

--- a/yarn-project/p2p/src/mem_pools/instrumentation.ts
+++ b/yarn-project/p2p/src/mem_pools/instrumentation.ts
@@ -10,8 +10,12 @@ export class PoolInstrumentation<PoolObject extends Gossipable> {
   /** Tracks tx size */
   private objectSize: Histogram;
 
+  private defaultAttributes;
+
   constructor(telemetry: TelemetryClient, name: string) {
     const meter = telemetry.getMeter(name);
+    this.defaultAttributes = { [Attributes.POOL_NAME]: name };
+
     this.objectsInMempool = meter.createUpDownCounter(Metrics.MEMPOOL_TX_COUNT, {
       description: 'The current number of transactions in the mempool',
     });
@@ -48,7 +52,12 @@ export class PoolInstrumentation<PoolObject extends Gossipable> {
     if (count === 0) {
       return;
     }
-    const attributes = status ? { [Attributes.STATUS]: status } : {};
+    const attributes = status
+      ? {
+          ...this.defaultAttributes,
+          [Attributes.STATUS]: status,
+        }
+      : this.defaultAttributes;
 
     this.objectsInMempool.add(count, attributes);
   }
@@ -65,7 +74,12 @@ export class PoolInstrumentation<PoolObject extends Gossipable> {
       return;
     }
 
-    const attributes = status ? { [Attributes.STATUS]: status } : {};
+    const attributes = status
+      ? {
+          ...this.defaultAttributes,
+          [Attributes.STATUS]: status,
+        }
+      : this.defaultAttributes;
     this.objectsInMempool.add(-1 * count, attributes);
   }
 }

--- a/yarn-project/telemetry-client/src/attributes.ts
+++ b/yarn-project/telemetry-client/src/attributes.ts
@@ -76,3 +76,4 @@ export const ROLLUP_PROVER_ID = 'aztec.rollup.prover_id';
 export const PROOF_TIMED_OUT = 'aztec.proof.timed_out';
 
 export const P2P_ID = 'aztec.p2p.id';
+export const POOL_NAME = 'aztec.pool.name';


### PR DESCRIPTION
Prometheus/otel demand that these metric names be unique, so when we're generic over the different pools, we break uniqueness, and get zero metrics.

Temporarily turn the attestation and epoch proof metrics to no-ops to fix metrics.

Proof:
<img width="779" alt="Screenshot 2024-10-13 at 14 56 51" src="https://github.com/user-attachments/assets/01a53d8a-e430-4d68-9df5-c5fca128ef56">

Disabled until https://github.com/AztecProtocol/aztec-packages/issues/9227
