### PR TITLE
fix: buffer instanceof usage

### DIFF
--- a/yarn-project/foundation/src/fields/fields.ts
+++ b/yarn-project/foundation/src/fields/fields.ts
@@ -47,7 +47,7 @@ abstract class BaseField {
   }
 
   protected constructor(value: number | bigint | boolean | BaseField | Buffer) {
-    if (value instanceof Buffer) {
+    if (Buffer.isBuffer(value)) {
       if (value.length > BaseField.SIZE_IN_BYTES) {
         throw new Error(`Value length ${value.length} exceeds ${BaseField.SIZE_IN_BYTES}`);
       }

--- a/yarn-project/foundation/src/json-rpc/convert.ts
+++ b/yarn-project/foundation/src/json-rpc/convert.ts
@@ -130,7 +130,7 @@ export function convertToJsonObj(cc: ClassConverter, obj: any): any {
   }
 
   // Is this a Node buffer?
-  if (obj instanceof Buffer) {
+  if (Buffer.isBuffer(obj)) {
     return { type: 'Buffer', data: obj.toString('base64') };
   }
 

--- a/yarn-project/simulator/src/avm/serialization/instruction_serialization.ts
+++ b/yarn-project/simulator/src/avm/serialization/instruction_serialization.ts
@@ -158,7 +158,7 @@ function writeBigInt128BE(this: Buffer, value: bigint): void {
  */
 export function deserialize(cursor: BufferCursor | Buffer, operands: OperandType[]): (number | bigint)[] {
   const argValues = [];
-  if (cursor instanceof Buffer) {
+  if (Buffer.isBuffer(cursor)) {
     cursor = new BufferCursor(cursor);
   }
 


### PR DESCRIPTION
Buffer.isBuffer checks for an ._isBuffer property and is friendly across otherwise conflicting polyfills (we have one for bb.js and one for aztec.js, and there's no reason the end user couldn't have another one)
Closes https://github.com/AztecProtocol/aztec-packages/issues/5782