### PR TITLE
chore: swap `pub` and `unconstrained` in function signatures

### DIFF
--- a/noir-projects/aztec-nr/authwit/src/auth_witness.nr
+++ b/noir-projects/aztec-nr/authwit/src/auth_witness.nr
@@ -7,6 +7,6 @@ unconstrained fn get_auth_witness_oracle<let N: u32>(_message_hash: Field) -> [F
  * @param message_hash The hash of the message for which the `auth_witness` is to be fetched.
  * @return The `auth_witness` for the given `message_hash` as Field array.
  */
-unconstrained pub fn get_auth_witness<let N: u32>(message_hash: Field) -> [Field; N] {
+pub unconstrained fn get_auth_witness<let N: u32>(message_hash: Field) -> [Field; N] {
     get_auth_witness_oracle(message_hash)
 }

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -291,7 +291,7 @@ unconstrained fn call_static<let RET_SIZE: u32>(
     call_static_opcode(gas, address, args, function_selector)
 }
 
-unconstrained pub fn calldata_copy<let N: u32>(cdoffset: u32, copy_size: u32) -> [Field; N] {
+pub unconstrained fn calldata_copy<let N: u32>(cdoffset: u32, copy_size: u32) -> [Field; N] {
     calldata_copy_opcode(cdoffset, copy_size)
 }
 

--- a/noir-projects/aztec-nr/aztec/src/keys/getters/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/keys/getters/mod.nr
@@ -6,14 +6,14 @@ use crate::{
 
 mod test;
 
-unconstrained pub fn get_nsk_app(npk_m_hash: Field) -> Field {
+pub unconstrained fn get_nsk_app(npk_m_hash: Field) -> Field {
     get_key_validation_request(npk_m_hash, NULLIFIER_INDEX).sk_app
 }
 
 // A helper function that gets app-siloed outgoing viewing key for a given `ovpk_m_hash`. This function is used
 // in unconstrained contexts only - when computing unconstrained note logs. The safe alternative is `request_ovsk_app`
 // function defined on `PrivateContext`.
-unconstrained pub fn get_ovsk_app(ovpk_m_hash: Field) -> Field {
+pub unconstrained fn get_ovsk_app(ovpk_m_hash: Field) -> Field {
     get_key_validation_request(ovpk_m_hash, OUTGOING_INDEX).sk_app
 }
 

--- a/noir-projects/aztec-nr/aztec/src/macros/dispatch/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/dispatch/mod.nr
@@ -93,7 +93,7 @@ pub comptime fn generate_public_dispatch(m: Module) -> Quoted {
             // functions having this attribute. However, the public MACRO will
             // handle the public_dispatch function specially and do nothing.
             #[public]
-            unconstrained pub fn public_dispatch(selector: Field) {
+            pub unconstrained fn public_dispatch(selector: Field) {
                 $dispatch
             }
         };

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/mod.nr
@@ -222,7 +222,7 @@ unconstrained fn get_notes_internal<Note, let N: u32, PREPROCESSOR_ARGS, FILTER_
     apply_preprocessor(opt_notes, options.preprocessor, options.preprocessor_args)
 }
 
-unconstrained pub fn view_notes<Note, let N: u32>(
+pub unconstrained fn view_notes<Note, let N: u32>(
     storage_slot: Field,
     options: NoteViewerOptions<Note, N>
 ) -> BoundedVec<Note, MAX_NOTES_PER_PAGE> where Note: NoteInterface<N> {

--- a/noir-projects/aztec-nr/aztec/src/note/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/utils.nr
@@ -105,7 +105,7 @@ pub fn compute_note_hash_for_nullify<Note, let N: u32>(note: Note) -> Field wher
     compute_note_hash_for_nullify_internal(note, note_hash_for_read_request)
 }
 
-unconstrained pub fn compute_note_hash_and_optionally_a_nullifier<T, let N: u32, let S: u32>(
+pub unconstrained fn compute_note_hash_and_optionally_a_nullifier<T, let N: u32, let S: u32>(
     deserialize_content: fn([Field; N]) -> T,
     note_header: NoteHeader,
     compute_nullifier: bool,

--- a/noir-projects/aztec-nr/aztec/src/oracle/call_private_function.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/call_private_function.nr
@@ -10,7 +10,7 @@ unconstrained fn call_private_function_oracle(
     _is_delegate_call: bool
 ) -> [Field; 2] {}
 
-unconstrained pub fn call_private_function_internal(
+pub unconstrained fn call_private_function_internal(
     contract_address: AztecAddress,
     function_selector: FunctionSelector,
     args_hash: Field,

--- a/noir-projects/aztec-nr/aztec/src/oracle/enqueue_public_function_call.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/enqueue_public_function_call.nr
@@ -10,7 +10,7 @@ unconstrained fn enqueue_public_function_call_oracle(
     _is_delegate_call: bool
 ) -> Field {}
 
-unconstrained pub fn enqueue_public_function_call_internal(
+pub unconstrained fn enqueue_public_function_call_internal(
     contract_address: AztecAddress,
     function_selector: FunctionSelector,
     args_hash: Field,
@@ -38,7 +38,7 @@ unconstrained fn set_public_teardown_function_call_oracle(
     _is_delegate_call: bool
 ) -> Field {}
 
-unconstrained pub fn set_public_teardown_function_call_internal(
+pub unconstrained fn set_public_teardown_function_call_internal(
     contract_address: AztecAddress,
     function_selector: FunctionSelector,
     args_hash: Field,
@@ -62,7 +62,7 @@ pub fn notify_set_min_revertible_side_effect_counter(counter: u32) {
     };
 }
 
-unconstrained pub fn notify_set_min_revertible_side_effect_counter_oracle_wrapper(counter: u32) {
+pub unconstrained fn notify_set_min_revertible_side_effect_counter_oracle_wrapper(counter: u32) {
     notify_set_min_revertible_side_effect_counter_oracle(counter);
 }
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/execution.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/execution.nr
@@ -12,18 +12,18 @@ unconstrained fn get_chain_id_oracle() -> Field {}
 #[oracle(getVersion)]
 unconstrained fn get_version_oracle() -> Field {}
 
-unconstrained pub fn get_contract_address() -> AztecAddress {
+pub unconstrained fn get_contract_address() -> AztecAddress {
     get_contract_address_oracle()
 }
 
-unconstrained pub fn get_block_number() -> u32 {
+pub unconstrained fn get_block_number() -> u32 {
     get_block_number_oracle()
 }
 
-unconstrained pub fn get_chain_id() -> Field {
+pub unconstrained fn get_chain_id() -> Field {
     get_chain_id_oracle()
 }
 
-unconstrained pub fn get_version() -> Field {
+pub unconstrained fn get_version() -> Field {
     get_version_oracle()
 }

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_contract_instance.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_contract_instance.nr
@@ -14,7 +14,7 @@ unconstrained fn get_contract_instance_internal(address: AztecAddress) -> [Field
     get_contract_instance_oracle(address)
 }
 
-unconstrained pub fn get_contract_instance_internal_avm(address: AztecAddress) -> [Field; CONTRACT_INSTANCE_LENGTH + 1] {
+pub unconstrained fn get_contract_instance_internal_avm(address: AztecAddress) -> [Field; CONTRACT_INSTANCE_LENGTH + 1] {
     get_contract_instance_oracle_avm(address)
 }
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_l1_to_l2_membership_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_l1_to_l2_membership_witness.nr
@@ -2,7 +2,7 @@ use dep::protocol_types::{address::AztecAddress, constants::L1_TO_L2_MSG_TREE_HE
 
 /// Returns the leaf index and sibling path of an entry in the L1 to L2 messaging tree, which can then be used to prove
 /// its existence.
-unconstrained pub fn get_l1_to_l2_membership_witness(
+pub unconstrained fn get_l1_to_l2_membership_witness(
     contract_address: AztecAddress,
     message_hash: Field,
     secret: Field

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_membership_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_membership_witness.nr
@@ -22,7 +22,7 @@ unconstrained fn get_membership_witness_oracle<let M: u32>(
     _leaf_value: Field
 ) -> [Field; M] {}
 
-unconstrained pub fn get_membership_witness<let N: u32, let M: u32>(
+pub unconstrained fn get_membership_witness<let N: u32, let M: u32>(
     block_number: u32,
     tree_id: Field,
     leaf_value: Field
@@ -33,7 +33,7 @@ unconstrained pub fn get_membership_witness<let N: u32, let M: u32>(
 
 // Note: get_nullifier_membership_witness function is implemented in get_nullifier_membership_witness.nr
 
-unconstrained pub fn get_note_hash_membership_witness(
+pub unconstrained fn get_note_hash_membership_witness(
     block_number: u32,
     leaf_value: Field
 ) -> MembershipWitness<NOTE_HASH_TREE_HEIGHT, NOTE_HASH_TREE_HEIGHT + 1> {
@@ -43,7 +43,7 @@ unconstrained pub fn get_note_hash_membership_witness(
 // There is no `get_public_data_membership_witness` function because it doesn't make sense to be getting a membership
 // witness for a value in the public data tree.
 
-unconstrained pub fn get_archive_membership_witness(
+pub unconstrained fn get_archive_membership_witness(
     block_number: u32,
     leaf_value: Field
 ) -> MembershipWitness<ARCHIVE_HEIGHT, ARCHIVE_HEIGHT + 1> {

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_nullifier_membership_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_nullifier_membership_witness.nr
@@ -35,7 +35,7 @@ unconstrained fn get_low_nullifier_membership_witness_oracle(
 
 // Nullifier here refers to the nullifier we are looking to get non-inclusion proof for (by proving that a lower
 // nullifier's next_value is bigger than the nullifier)
-unconstrained pub fn get_low_nullifier_membership_witness(block_number: u32, nullifier: Field) -> NullifierMembershipWitness {
+pub unconstrained fn get_low_nullifier_membership_witness(block_number: u32, nullifier: Field) -> NullifierMembershipWitness {
     let fields = get_low_nullifier_membership_witness_oracle(block_number, nullifier);
     NullifierMembershipWitness::deserialize(fields)
 }
@@ -48,7 +48,7 @@ unconstrained fn get_nullifier_membership_witness_oracle(
 
 // Nullifier here refers to the nullifier we are looking to get non-inclusion proof for (by proving that a lower
 // nullifier's next_value is bigger than the nullifier)
-unconstrained pub fn get_nullifier_membership_witness(block_number: u32, nullifier: Field) -> NullifierMembershipWitness {
+pub unconstrained fn get_nullifier_membership_witness(block_number: u32, nullifier: Field) -> NullifierMembershipWitness {
     let fields = get_nullifier_membership_witness_oracle(block_number, nullifier);
     NullifierMembershipWitness::deserialize(fields)
 }

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_public_data_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_public_data_witness.nr
@@ -15,7 +15,7 @@ unconstrained fn get_public_data_witness_oracle(
     _public_data_tree_index: Field
 ) -> [Field; PUBLIC_DATA_WITNESS] {}
 
-unconstrained pub fn get_public_data_witness(
+pub unconstrained fn get_public_data_witness(
     block_number: u32,
     public_data_tree_index: Field
 ) -> PublicDataWitness {

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_sibling_path.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_sibling_path.nr
@@ -5,7 +5,7 @@ unconstrained fn get_sibling_path_oracle<let N: u32>(
     _leaf_index: Field
 ) -> [Field; N] {}
 
-unconstrained pub fn get_sibling_path<let N: u32>(block_number: u32, tree_id: Field, leaf_index: Field) -> [Field; N] {
+pub unconstrained fn get_sibling_path<let N: u32>(block_number: u32, tree_id: Field, leaf_index: Field) -> [Field; N] {
     let value: [Field; N] = get_sibling_path_oracle(block_number, tree_id, leaf_index);
     value
 }

--- a/noir-projects/aztec-nr/aztec/src/oracle/header.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/header.nr
@@ -8,7 +8,7 @@ use crate::test::helpers::test_environment::TestEnvironment;
 #[oracle(getHeader)]
 unconstrained fn get_header_at_oracle(_block_number: u32) -> [Field; HEADER_LENGTH] {}
 
-unconstrained pub fn get_header_at_internal(block_number: u32) -> Header {
+pub unconstrained fn get_header_at_internal(block_number: u32) -> Header {
     let header = get_header_at_oracle(block_number);
     Header::deserialize(header)
 }

--- a/noir-projects/aztec-nr/aztec/src/oracle/key_validation_request.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/key_validation_request.nr
@@ -14,7 +14,7 @@ unconstrained fn get_key_validation_request_internal(
     KeyValidationRequest::deserialize(result)
 }
 
-unconstrained pub fn get_key_validation_request(
+pub unconstrained fn get_key_validation_request(
     pk_m_hash: Field,
     key_index: Field
 ) -> KeyValidationRequest {

--- a/noir-projects/aztec-nr/aztec/src/oracle/keys.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/keys.nr
@@ -6,7 +6,7 @@ use dep::protocol_types::{
 #[oracle(getPublicKeysAndPartialAddress)]
 unconstrained fn get_public_keys_and_partial_address_oracle(_address: AztecAddress) -> [Field; 13] {}
 
-unconstrained pub fn get_public_keys_and_partial_address(address: AztecAddress) -> (PublicKeys, PartialAddress) {
+pub unconstrained fn get_public_keys_and_partial_address(address: AztecAddress) -> (PublicKeys, PartialAddress) {
     let result = get_public_keys_and_partial_address_oracle(address);
 
     let keys = PublicKeys {

--- a/noir-projects/aztec-nr/aztec/src/oracle/logs.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/logs.nr
@@ -46,7 +46,7 @@ unconstrained fn emit_unencrypted_log_private_oracle_wrapper<T>(contract_address
 
 /// Temporary substitute for `emit_unencrypted_log_private` that is used for handling contract class registration. This
 /// variant returns the log hash, which would be too large to compute inside a circuit.
-unconstrained pub fn emit_contract_class_unencrypted_log_private<let N: u32>(
+pub unconstrained fn emit_contract_class_unencrypted_log_private<let N: u32>(
     contract_address: AztecAddress,
     message: [Field; N],
     counter: u32

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -115,7 +115,7 @@ unconstrained fn get_notes_oracle_wrapper<let N: u32, let S: u32>(
     )
 }
 
-unconstrained pub fn get_notes<Note, let N: u32, let M: u32, let S: u32, let NS: u32>(
+pub unconstrained fn get_notes<Note, let N: u32, let M: u32, let S: u32, let NS: u32>(
     storage_slot: Field,
     num_selects: u8,
     select_by_indexes: [u8; M],
@@ -175,7 +175,7 @@ unconstrained pub fn get_notes<Note, let N: u32, let M: u32, let S: u32, let NS:
 /// nullifier, but a `false` value should not be relied upon since other transactions may emit this nullifier before the
 /// current transaction is included in a block. While this might seem of little use at first, certain design patterns
 /// benefit from this abstraction (see e.g. `PrivateMutable`).
-unconstrained pub fn check_nullifier_exists(inner_nullifier: Field) -> bool {
+pub unconstrained fn check_nullifier_exists(inner_nullifier: Field) -> bool {
     check_nullifier_exists_oracle(inner_nullifier) == 1
 }
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/random.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/random.nr
@@ -2,7 +2,7 @@
 /// truly random: we assume that the oracle is cooperating and returning random values.
 /// In some applications this behavior might not be acceptable and other techniques might be more suitable, such as
 /// producing pseudo-random values by hashing values outside of user control (like block hashes) or secrets.
-unconstrained pub fn random() -> Field {
+pub unconstrained fn random() -> Field {
     rand_oracle()
 }
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/returns.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/returns.nr
@@ -10,11 +10,11 @@ pub fn pack_returns(returns: [Field]) {
     };
 }
 
-unconstrained pub fn pack_returns_oracle_wrapper(returns: [Field]) {
+pub unconstrained fn pack_returns_oracle_wrapper(returns: [Field]) {
     let _ = pack_returns_oracle(returns);
 }
 
-unconstrained pub fn unpack_returns<let N: u32>(return_hash: Field) -> [Field; N] {
+pub unconstrained fn unpack_returns<let N: u32>(return_hash: Field) -> [Field; N] {
     unpack_returns_oracle(return_hash)
 }
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/storage.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/storage.nr
@@ -3,7 +3,7 @@ use dep::protocol_types::{address::AztecAddress, traits::Deserialize};
 #[oracle(storageRead)]
 unconstrained fn storage_read_oracle<let N: u32>(address: Field, storage_slot: Field, block_number: Field, length: Field) -> [Field; N] {}
 
-unconstrained pub fn raw_storage_read<let N: u32>(
+pub unconstrained fn raw_storage_read<let N: u32>(
     address: AztecAddress,
     storage_slot: Field,
     block_number: u32
@@ -16,7 +16,7 @@ unconstrained pub fn raw_storage_read<let N: u32>(
     )
 }
 
-unconstrained pub fn storage_read<T, let N: u32>(
+pub unconstrained fn storage_read<T, let N: u32>(
     address: AztecAddress,
     storage_slot: Field,
     block_number: u32

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
@@ -64,7 +64,7 @@ impl<Note> PrivateImmutable<Note, &mut PrivateContext> {
 
 impl<Note> PrivateImmutable<Note, UnconstrainedContext> {
     // docs:start:is_initialized
-    unconstrained pub fn is_initialized(self) -> bool {
+    pub unconstrained fn is_initialized(self) -> bool {
         let nullifier = self.compute_initialization_nullifier();
         check_nullifier_exists(nullifier)
     }
@@ -72,7 +72,7 @@ impl<Note> PrivateImmutable<Note, UnconstrainedContext> {
 
     // view_note does not actually use the context, but it calls oracles that are only available in private
     // docs:start:view_note
-    unconstrained pub fn view_note<let N: u32>(self) -> Note  where Note: NoteInterface<N> + NullifiableNote {
+    pub unconstrained fn view_note<let N: u32>(self) -> Note  where Note: NoteInterface<N> + NullifiableNote {
         let mut options = NoteViewerOptions::new();
         view_notes(self.storage_slot, options.set_limit(1)).get(0)
     }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
@@ -104,13 +104,13 @@ impl<Note, let N: u32> PrivateMutable<Note, &mut PrivateContext> where Note: Not
 }
 
 impl<Note, let N: u32> PrivateMutable<Note, UnconstrainedContext> where Note: NoteInterface<N> + NullifiableNote {
-    unconstrained pub fn is_initialized(self) -> bool {
+    pub unconstrained fn is_initialized(self) -> bool {
         let nullifier = self.compute_initialization_nullifier();
         check_nullifier_exists(nullifier)
     }
 
     // docs:start:view_note
-    unconstrained pub fn view_note(self) -> Note {
+    pub unconstrained fn view_note(self) -> Note {
         let mut options = NoteViewerOptions::new();
         view_notes(self.storage_slot, options.set_limit(1)).get(0)
     }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
@@ -85,7 +85,7 @@ impl<Note, let N: u32> PrivateSet<Note, &mut PrivateContext> where Note: NoteInt
 
 impl<Note, let N: u32> PrivateSet<Note, UnconstrainedContext> where Note: NoteInterface<N> + NullifiableNote {
     // docs:start:view_notes
-    unconstrained pub fn view_notes(
+    pub unconstrained fn view_notes(
         self,
         options: NoteViewerOptions<Note, N>
     ) -> BoundedVec<Note, MAX_NOTES_PER_PAGE> {

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -47,7 +47,7 @@ impl <T, let T_SERIALIZED_LEN: u32> PublicImmutable<T, &mut PublicContext> where
 }
 
 impl<T, let T_SERIALIZED_LEN: u32> PublicImmutable<T, UnconstrainedContext>where T: Deserialize<T_SERIALIZED_LEN> {
-    unconstrained pub fn read(self) -> T {
+    pub unconstrained fn read(self) -> T {
         self.context.storage_read(self.storage_slot)
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
@@ -39,7 +39,7 @@ impl<T, let T_SERIALIZED_LEN: u32> PublicMutable<T, &mut PublicContext> where T:
 }
 
 impl<T, let T_SERIALIZED_LEN: u32> PublicMutable<T, UnconstrainedContext> where T: Deserialize<T_SERIALIZED_LEN> {
-    unconstrained pub fn read(self) -> T {
+    pub unconstrained fn read(self) -> T {
         self.context.storage_read(self.storage_slot)
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_immutable.nr
@@ -39,7 +39,7 @@ impl<T, let T_SERIALIZED_LEN: u32> SharedImmutable<T, &mut PublicContext> where 
 }
 
 impl<T, let T_SERIALIZED_LEN: u32> SharedImmutable<T, UnconstrainedContext> where T: Serialize<T_SERIALIZED_LEN> + Deserialize<T_SERIALIZED_LEN> {
-    unconstrained pub fn read_public(self) -> T {
+    pub unconstrained fn read_public(self) -> T {
         self.context.storage_read(self.storage_slot)
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/shared_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/shared_mutable.nr
@@ -215,7 +215,7 @@ impl<T, let INITIAL_DELAY: u32> SharedMutable<T, INITIAL_DELAY, &mut PrivateCont
 }
 
 impl<T, let INITIAL_DELAY: u32> SharedMutable<T, INITIAL_DELAY, UnconstrainedContext> where T: ToField + FromField + Eq {
-    unconstrained pub fn get_current_value_in_unconstrained(self) -> T {
+    pub unconstrained fn get_current_value_in_unconstrained(self) -> T {
         let block_number = self.context.block_number() as u32;
         self.read_value_change().get_current_at(block_number)
     }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
@@ -5,23 +5,23 @@ use dep::protocol_types::{
 use crate::context::inputs::PrivateContextInputs;
 use crate::test::helpers::utils::TestAccount;
 
-unconstrained pub fn reset() {
+pub unconstrained fn reset() {
     oracle_reset();
 }
 
-unconstrained pub fn set_contract_address(address: AztecAddress) {
+pub unconstrained fn set_contract_address(address: AztecAddress) {
     oracle_set_contract_address(address);
 }
 
-unconstrained pub fn advance_blocks_by(blocks: u32) {
+pub unconstrained fn advance_blocks_by(blocks: u32) {
     oracle_advance_blocks_by(blocks);
 }
 
-unconstrained pub fn get_private_context_inputs(historical_block_number: u32) -> PrivateContextInputs {
+pub unconstrained fn get_private_context_inputs(historical_block_number: u32) -> PrivateContextInputs {
     oracle_get_private_context_inputs(historical_block_number)
 }
 
-unconstrained pub fn deploy<let N: u32, let M: u32, let P: u32>(
+pub unconstrained fn deploy<let N: u32, let M: u32, let P: u32>(
     path: str<N>,
     name: str<M>,
     initializer: str<P>,
@@ -32,47 +32,47 @@ unconstrained pub fn deploy<let N: u32, let M: u32, let P: u32>(
     ContractInstance::deserialize(instance_fields)
 }
 
-unconstrained pub fn direct_storage_write<let N: u32>(contract_address: AztecAddress, storage_slot: Field, fields: [Field; N]) {
+pub unconstrained fn direct_storage_write<let N: u32>(contract_address: AztecAddress, storage_slot: Field, fields: [Field; N]) {
     let _hash = direct_storage_write_oracle(contract_address, storage_slot, fields);
 }
 
-unconstrained pub fn create_account() -> TestAccount {
+pub unconstrained fn create_account() -> TestAccount {
     oracle_create_account()
 }
 
-unconstrained pub fn add_account(secret: Field) -> TestAccount {
+pub unconstrained fn add_account(secret: Field) -> TestAccount {
     oracle_add_account(secret)
 }
 
-unconstrained pub fn derive_keys(secret: Field) -> PublicKeys {
+pub unconstrained fn derive_keys(secret: Field) -> PublicKeys {
     oracle_derive_keys(secret)
 }
 
-unconstrained pub fn set_msg_sender(msg_sender: AztecAddress) {
+pub unconstrained fn set_msg_sender(msg_sender: AztecAddress) {
     oracle_set_msg_sender(msg_sender)
 }
 
-unconstrained pub fn set_calldata(calldata: [Field]) {
+pub unconstrained fn set_calldata(calldata: [Field]) {
     oracle_set_calldata(calldata)
 }
 
-unconstrained pub fn get_msg_sender() -> AztecAddress {
+pub unconstrained fn get_msg_sender() -> AztecAddress {
     oracle_get_msg_sender()
 }
 
-unconstrained pub fn get_side_effects_counter() -> u32 {
+pub unconstrained fn get_side_effects_counter() -> u32 {
     oracle_get_side_effects_counter()
 }
 
-unconstrained pub fn add_authwit(address: AztecAddress, message_hash: Field) {
+pub unconstrained fn add_authwit(address: AztecAddress, message_hash: Field) {
     orable_add_authwit(address, message_hash)
 }
 
-unconstrained pub fn assert_public_call_fails(target_address: AztecAddress, function_selector: FunctionSelector, args: [Field]) {
+pub unconstrained fn assert_public_call_fails(target_address: AztecAddress, function_selector: FunctionSelector, args: [Field]) {
     oracle_assert_public_call_fails(target_address, function_selector, args)
 }
 
-unconstrained pub fn assert_private_call_fails(
+pub unconstrained fn assert_private_call_fails(
     target_address: AztecAddress,
     function_selector: FunctionSelector,
     argsHash: Field,
@@ -90,23 +90,23 @@ unconstrained pub fn assert_private_call_fails(
     )
 }
 
-unconstrained pub fn add_nullifiers(contractAddress: AztecAddress, nullifiers: [Field]) {
+pub unconstrained fn add_nullifiers(contractAddress: AztecAddress, nullifiers: [Field]) {
     oracle_add_nullifiers(contractAddress, nullifiers)
 }
 
-unconstrained pub fn add_note_hashes(contractAddress: AztecAddress, note_hashes: [Field]) {
+pub unconstrained fn add_note_hashes(contractAddress: AztecAddress, note_hashes: [Field]) {
     oracle_add_note_hashes(contractAddress, note_hashes)
 }
 
-unconstrained pub fn get_function_selector() -> FunctionSelector {
+pub unconstrained fn get_function_selector() -> FunctionSelector {
     oracle_get_function_selector()
 }
 
-unconstrained pub fn set_fn_selector(selector: FunctionSelector) {
+pub unconstrained fn set_fn_selector(selector: FunctionSelector) {
     oracle_set_function_selector(selector)
 }
 
-unconstrained pub fn set_is_static_call(is_static: bool) {
+pub unconstrained fn set_is_static_call(is_static: bool) {
     oracle_set_is_static_call(is_static)
 }
 

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -190,7 +190,7 @@ impl TestEnvironment {
 
     /// Manually adds a note to TXE. This needs to be called if you want to work with a note in your test with the note
     /// not having an encrypted log emitted. TXE alternative to `PXE.addNote(...)`.
-    unconstrained pub fn add_note<Note, let N: u32>(
+    pub unconstrained fn add_note<Note, let N: u32>(
         _self: Self,
         note: &mut Note,
         storage_slot: Field,

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
@@ -12,7 +12,7 @@ use crate::test::helpers::cheatcodes;
 use crate::oracle::{execution::{get_block_number, get_contract_address}};
 use protocol_types::constants::PUBLIC_DISPATCH_SELECTOR;
 
-unconstrained pub fn apply_side_effects_private(contract_address: AztecAddress, public_inputs: PrivateCircuitPublicInputs) {
+pub unconstrained fn apply_side_effects_private(contract_address: AztecAddress, public_inputs: PrivateCircuitPublicInputs) {
     let mut nullifiers = &[];
     for nullifier in public_inputs.nullifiers {
         if nullifier.value != 0 {
@@ -36,7 +36,7 @@ pub struct Deployer<let N: u32, let M: u32> {
 }
 
 impl<let N: u32, let M: u32> Deployer<N, M> {
-    unconstrained pub fn with_private_initializer<C, let P: u32, Env>(
+    pub unconstrained fn with_private_initializer<C, let P: u32, Env>(
         self,
         call_interface: C
     ) -> ContractInstance where C: CallInterface<P, PrivateContextInputs, PrivateCircuitPublicInputs, Env> {
@@ -66,7 +66,7 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
         instance
     }
 
-    unconstrained pub fn with_public_initializer<C, let P: u32, T, Env>(
+    pub unconstrained fn with_public_initializer<C, let P: u32, T, Env>(
         self,
         call_interface: C
     ) -> ContractInstance where C: CallInterface<P, (), T, Env> {
@@ -102,7 +102,7 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
         instance
     }
 
-    unconstrained pub fn without_initializer(self) -> ContractInstance {
+    pub unconstrained fn without_initializer(self) -> ContractInstance {
         cheatcodes::deploy(self.path, self.name, "", &[], self.public_keys_hash)
     }
 }

--- a/noir-projects/aztec-nr/value-note/src/balance_utils.nr
+++ b/noir-projects/aztec-nr/value-note/src/balance_utils.nr
@@ -1,11 +1,11 @@
 use dep::aztec::{context::UnconstrainedContext, state_vars::PrivateSet, note::{note_viewer_options::NoteViewerOptions}};
 use crate::value_note::ValueNote;
 
-unconstrained pub fn get_balance(set: PrivateSet<ValueNote, UnconstrainedContext>) -> Field {
+pub unconstrained fn get_balance(set: PrivateSet<ValueNote, UnconstrainedContext>) -> Field {
     get_balance_with_offset(set, 0)
 }
 
-unconstrained pub fn get_balance_with_offset(
+pub unconstrained fn get_balance_with_offset(
     set: PrivateSet<ValueNote, UnconstrainedContext>,
     offset: u32
 ) -> Field {

--- a/noir-projects/noir-contracts/contracts/auth_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/auth_contract/src/test/utils.nr
@@ -2,7 +2,7 @@ use dep::aztec::{prelude::AztecAddress, test::helpers::test_environment::TestEnv
 
 use crate::Auth;
 
-unconstrained pub fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress, AztecAddress) {
+pub unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress, AztecAddress) {
     let mut env = TestEnvironment::new();
 
     let admin = env.create_account();

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -127,7 +127,7 @@ impl Deck<&mut PrivateContext> {
 }
 
 impl Deck<UnconstrainedContext> {
-    unconstrained pub fn view_cards(self, offset: u32) -> BoundedVec<Card, MAX_NOTES_PER_PAGE> {
+    pub unconstrained fn view_cards(self, offset: u32) -> BoundedVec<Card, MAX_NOTES_PER_PAGE> {
         let mut options = NoteViewerOptions::new();
         let notes = self.set.view_notes(options.set_offset(offset));
 

--- a/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/capsule.nr
+++ b/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/capsule.nr
@@ -5,7 +5,7 @@
 unconstrained fn pop_capsule_oracle<let N: u32>() -> [Field; N] {}
 
 // A capsule is a "blob" of data that is passed to the contract through an oracle.
-unconstrained pub fn pop_capsule<let N: u32>() -> [Field; N] {
+pub unconstrained fn pop_capsule<let N: u32>() -> [Field; N] {
     pop_capsule_oracle()
 }
 // docs:end:pop_capsule

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/test/utils.nr
@@ -7,7 +7,7 @@ use dep::aztec::{
 };
 use std::test::OracleMock;
 
-unconstrained pub fn setup(with_account_contracts: bool) -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress) {
+pub unconstrained fn setup(with_account_contracts: bool) -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress) {
     // Setup env, generate keys
     let mut env = TestEnvironment::new();
     let (owner, recipient) = if with_account_contracts {
@@ -35,7 +35,7 @@ unconstrained pub fn setup(with_account_contracts: bool) -> (&mut TestEnvironmen
     (&mut env, nft_contract_address, owner, recipient)
 }
 
-unconstrained pub fn setup_and_mint(with_account_contracts: bool) -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress, Field) {
+pub unconstrained fn setup_and_mint(with_account_contracts: bool) -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress, Field) {
     // Setup
     let (env, nft_contract_address, owner, recipient) = setup(with_account_contracts);
     let minted_token_id = 615;
@@ -46,7 +46,7 @@ unconstrained pub fn setup_and_mint(with_account_contracts: bool) -> (&mut TestE
     (env, nft_contract_address, owner, recipient, minted_token_id)
 }
 
-unconstrained pub fn setup_mint_and_transfer_to_private(with_account_contracts: bool) -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress, Field) {
+pub unconstrained fn setup_mint_and_transfer_to_private(with_account_contracts: bool) -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress, Field) {
     let (env, nft_contract_address, owner, recipient, minted_token_id) = setup_and_mint(with_account_contracts);
 
     let note_randomness = random();
@@ -86,7 +86,7 @@ unconstrained pub fn setup_mint_and_transfer_to_private(with_account_contracts: 
     (env, nft_contract_address, owner, recipient, minted_token_id)
 }
 
-unconstrained pub fn get_nft_exists(nft_contract_address: AztecAddress, token_id: Field) -> bool {
+pub unconstrained fn get_nft_exists(nft_contract_address: AztecAddress, token_id: Field) -> bool {
     let current_contract_address = get_contract_address();
     cheatcodes::set_contract_address(nft_contract_address);
     let block_number = get_block_number();
@@ -99,7 +99,7 @@ unconstrained pub fn get_nft_exists(nft_contract_address: AztecAddress, token_id
     exists
 }
 
-unconstrained pub fn assert_owns_public_nft(
+pub unconstrained fn assert_owns_public_nft(
     env: &mut TestEnvironment,
     nft_contract_address: AztecAddress,
     owner: AztecAddress,
@@ -111,7 +111,7 @@ unconstrained pub fn assert_owns_public_nft(
     assert(owner == obtained_owner, "Incorrect NFT owner");
 }
 
-unconstrained pub fn assert_owns_private_nft(nft_contract_address: AztecAddress, owner: AztecAddress, token_id: Field) {
+pub unconstrained fn assert_owns_private_nft(nft_contract_address: AztecAddress, owner: AztecAddress, token_id: Field) {
     let current_contract_address = get_contract_address();
     cheatcodes::set_contract_address(nft_contract_address);
 

--- a/noir-projects/noir-contracts/contracts/schnorr_single_key_account_contract/src/auth_oracle.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_single_key_account_contract/src/auth_oracle.nr
@@ -21,7 +21,7 @@ impl AuthWitness {
     }
 }
 
-unconstrained pub fn get_auth_witness(message_hash: Field) -> AuthWitness {
+pub unconstrained fn get_auth_witness(message_hash: Field) -> AuthWitness {
     let witness: [Field; 77] = auth_witness::get_auth_witness(message_hash);
     AuthWitness::deserialize(witness)
 }

--- a/noir-projects/noir-contracts/contracts/spam_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/spam_contract/src/types/balance_set.nr
@@ -19,11 +19,11 @@ impl<T, Context> BalanceSet<T, Context> {
 }
 
 impl<T> BalanceSet<T, UnconstrainedContext> {
-    unconstrained pub fn balance_of<let T_SERIALIZED_LEN: u32>(self: Self) -> U128 where T: NoteInterface<T_SERIALIZED_LEN> + NullifiableNote + OwnedNote {
+    pub unconstrained fn balance_of<let T_SERIALIZED_LEN: u32>(self: Self) -> U128 where T: NoteInterface<T_SERIALIZED_LEN> + NullifiableNote + OwnedNote {
         self.balance_of_with_offset(0)
     }
 
-    unconstrained pub fn balance_of_with_offset<let T_SERIALIZED_LEN: u32>(
+    pub unconstrained fn balance_of_with_offset<let T_SERIALIZED_LEN: u32>(
         self: Self,
         offset: u32
     ) -> U128 where T: NoteInterface<T_SERIALIZED_LEN> + NullifiableNote + OwnedNote {

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/balances_map.nr
@@ -24,14 +24,14 @@ impl<T, Context> BalancesMap<T, Context> {
 }
 
 impl<T> BalancesMap<T, UnconstrainedContext> {
-    unconstrained pub fn balance_of<let T_SERIALIZED_LEN: u32>(
+    pub unconstrained fn balance_of<let T_SERIALIZED_LEN: u32>(
         self: Self,
         owner: AztecAddress
     ) -> U128 where T: NoteInterface<T_SERIALIZED_LEN> + NullifiableNote + OwnedNote {
         self.balance_of_with_offset(owner, 0)
     }
 
-    unconstrained pub fn balance_of_with_offset<let T_SERIALIZED_LEN: u32>(
+    pub unconstrained fn balance_of_with_offset<let T_SERIALIZED_LEN: u32>(
         self: Self,
         owner: AztecAddress,
         offset: u32

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -590,7 +590,7 @@ contract Token {
     // docs:end:reduce_total_supply
     /// Unconstrained ///
     // docs:start:balance_of_private
-    unconstrained pub(crate) fn balance_of_private(owner: AztecAddress) -> pub Field {
+    pub unconstrained(crate) fn balance_of_private(owner: AztecAddress) -> pub Field {
         storage.balances.at(owner).balance_of().to_field()
     }
     // docs:end:balance_of_private

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -590,7 +590,7 @@ contract Token {
     // docs:end:reduce_total_supply
     /// Unconstrained ///
     // docs:start:balance_of_private
-    pub unconstrained(crate) fn balance_of_private(owner: AztecAddress) -> pub Field {
+    pub(crate) unconstrained fn balance_of_private(owner: AztecAddress) -> pub Field {
         storage.balances.at(owner).balance_of().to_field()
     }
     // docs:end:balance_of_private

--- a/noir-projects/noir-contracts/contracts/token_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/test/utils.nr
@@ -7,7 +7,7 @@ use dep::aztec::{
 
 use crate::{types::transparent_note::TransparentNote, Token};
 
-unconstrained pub fn setup(with_account_contracts: bool) -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress) {
+pub unconstrained fn setup(with_account_contracts: bool) -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress) {
     // Setup env, generate keys
     let mut env = TestEnvironment::new();
     let (owner, recipient) = if with_account_contracts {
@@ -36,7 +36,7 @@ unconstrained pub fn setup(with_account_contracts: bool) -> (&mut TestEnvironmen
     (&mut env, token_contract_address, owner, recipient)
 }
 
-unconstrained pub fn setup_and_mint(with_account_contracts: bool) -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress, Field) {
+pub unconstrained fn setup_and_mint(with_account_contracts: bool) -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress, Field) {
     // Setup
     let (env, token_contract_address, owner, recipient) = setup(with_account_contracts);
     let mint_amount = 10000;
@@ -69,7 +69,7 @@ unconstrained pub fn setup_and_mint(with_account_contracts: bool) -> (&mut TestE
 }
 
 // docs:start:txe_test_read_public
-unconstrained pub fn check_public_balance(
+pub unconstrained fn check_public_balance(
     token_contract_address: AztecAddress,
     address: AztecAddress,
     address_amount: Field
@@ -87,7 +87,7 @@ unconstrained pub fn check_public_balance(
 // docs:end:txe_test_read_public
 
 // docs:start:txe_test_call_unconstrained
-unconstrained pub fn check_private_balance(
+pub unconstrained fn check_private_balance(
     token_contract_address: AztecAddress,
     address: AztecAddress,
     address_amount: Field

--- a/noir-projects/noir-contracts/contracts/token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/types/balance_set.nr
@@ -19,11 +19,11 @@ impl<T, Context> BalanceSet<T, Context> {
 }
 
 impl<T> BalanceSet<T, UnconstrainedContext> {
-    unconstrained pub fn balance_of<let T_SERIALIZED_LEN: u32>(self: Self) -> U128 where T: NoteInterface<T_SERIALIZED_LEN> + NullifiableNote + OwnedNote {
+    pub unconstrained fn balance_of<let T_SERIALIZED_LEN: u32>(self: Self) -> U128 where T: NoteInterface<T_SERIALIZED_LEN> + NullifiableNote + OwnedNote {
         self.balance_of_with_offset(0)
     }
 
-    unconstrained pub fn balance_of_with_offset<let T_SERIALIZED_LEN: u32>(
+    pub unconstrained fn balance_of_with_offset<let T_SERIALIZED_LEN: u32>(
         self: Self,
         offset: u32
     ) -> U128 where T: NoteInterface<T_SERIALIZED_LEN> + NullifiableNote + OwnedNote {

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/previous_kernel_validator/previous_kernel_validator_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/previous_kernel_validator/previous_kernel_validator_hints.nr
@@ -7,7 +7,7 @@ pub struct PreviousKernelValidatorHints {
     note_hash_indexes_for_nullifiers: [u32; MAX_NULLIFIERS_PER_TX],
 }
 
-unconstrained pub fn generate_previous_kernel_validator_hints(previous_kernel: PrivateKernelCircuitPublicInputs) -> PreviousKernelValidatorHints {
+pub unconstrained fn generate_previous_kernel_validator_hints(previous_kernel: PrivateKernelCircuitPublicInputs) -> PreviousKernelValidatorHints {
     let mut note_hash_indexes_for_nullifiers = [0; MAX_NULLIFIERS_PER_TX];
     let note_hashes = previous_kernel.end.note_hashes;
     let nullifiers = previous_kernel.end.nullifiers;

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator/find_first_revertible_item_index.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator/find_first_revertible_item_index.nr
@@ -1,6 +1,6 @@
 use dep::types::{abis::side_effect::Ordered, traits::Empty, utils::arrays::array_length};
 
-unconstrained pub fn find_first_revertible_item_index<T, let N: u32>(
+pub unconstrained fn find_first_revertible_item_index<T, let N: u32>(
     min_revertible_side_effect_counter: u32,
     items: [T; N]
 ) -> u32 where T: Ordered + Empty + Eq {

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_public_inputs_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_public_inputs_composer.nr
@@ -96,7 +96,7 @@ impl PrivateKernelCircuitPublicInputsComposer {
         *self
     }
 
-    unconstrained pub fn sort_ordered_values(&mut self) {
+    pub unconstrained fn sort_ordered_values(&mut self) {
         // Note hashes, nullifiers, note_encrypted_logs_hashes, and encrypted_logs_hashes are sorted in the reset circuit.
         self.public_inputs.end.l2_to_l1_msgs.storage = sort_by_counter_asc(self.public_inputs.end.l2_to_l1_msgs.storage);
         self.public_inputs.end.unencrypted_logs_hashes.storage = sort_by_counter_asc(self.public_inputs.end.unencrypted_logs_hashes.storage);

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer.nr
@@ -46,7 +46,7 @@ impl<
     NLL_RR_SETTLED,
     KEY_VALIDATION_REQUESTS,
 > {
-    unconstrained pub fn new<let TRANSIENT_DATA_AMOUNT: u32>(
+    pub unconstrained fn new<let TRANSIENT_DATA_AMOUNT: u32>(
         previous_kernel: PrivateKernelCircuitPublicInputs,
         validation_request_processor: PrivateValidationRequestProcessor<NH_RR_PENDING, NH_RR_SETTLED, NLL_RR_PENDING, NLL_RR_SETTLED, KEY_VALIDATION_REQUESTS>,
         transient_data_index_hints: [TransientDataIndexHint; TRANSIENT_DATA_AMOUNT],
@@ -65,7 +65,7 @@ impl<
         }
     }
 
-    unconstrained pub fn finish(self) -> PrivateKernelCircuitPublicInputs {
+    pub unconstrained fn finish(self) -> PrivateKernelCircuitPublicInputs {
         let mut output = self.previous_kernel;
 
         output.validation_requests = self.validation_request_processor.compose();

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer/reset_output_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer/reset_output_hints.nr
@@ -33,7 +33,7 @@ pub struct ResetOutputHints {
     sorted_encrypted_log_hash_indexes: [u32; MAX_ENCRYPTED_LOGS_PER_TX],
 }
 
-unconstrained pub fn generate_reset_output_hints<let NUM_TRANSIENT_DATA_INDEX_HINTS: u32>(
+pub unconstrained fn generate_reset_output_hints<let NUM_TRANSIENT_DATA_INDEX_HINTS: u32>(
     previous_kernel: PrivateKernelCircuitPublicInputs,
     transient_data_index_hints: [TransientDataIndexHint; NUM_TRANSIENT_DATA_INDEX_HINTS]
 ) -> ResetOutputHints {

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer/reset_output_hints/get_transient_or_propagated_note_hash_indexes_for_logs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer/reset_output_hints/get_transient_or_propagated_note_hash_indexes_for_logs.nr
@@ -1,7 +1,7 @@
 use dep::reset_kernel_lib::TransientDataIndexHint;
 use dep::types::{abis::{log_hash::NoteLogHash, note_hash::ScopedNoteHash}, utils::arrays::find_index_hint};
 
-unconstrained pub fn get_transient_or_propagated_note_hash_indexes_for_logs<let NUM_LOGS: u32, let NUM_NOTE_HASHES: u32, let NUM_INDEX_HINTS: u32>(
+pub unconstrained fn get_transient_or_propagated_note_hash_indexes_for_logs<let NUM_LOGS: u32, let NUM_NOTE_HASHES: u32, let NUM_INDEX_HINTS: u32>(
     note_logs: [NoteLogHash; NUM_LOGS],
     note_hashes: [ScopedNoteHash; NUM_NOTE_HASHES],
     expected_note_hashes: [ScopedNoteHash; NUM_NOTE_HASHES],

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer/reset_output_hints/squash_transient_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer/reset_output_hints/squash_transient_data.nr
@@ -1,7 +1,7 @@
 use dep::reset_kernel_lib::TransientDataIndexHint;
 use dep::types::abis::{note_hash::ScopedNoteHash, nullifier::ScopedNullifier, log_hash::NoteLogHash};
 
-unconstrained pub fn squash_transient_data<let M: u32, let N: u32, let P: u32, let NUM_TRANSIENT_DATA_INDEX_HINTS: u32>(
+pub unconstrained fn squash_transient_data<let M: u32, let N: u32, let P: u32, let NUM_TRANSIENT_DATA_INDEX_HINTS: u32>(
     note_hashes: [ScopedNoteHash; M],
     nullifiers: [ScopedNullifier; N],
     logs: [NoteLogHash; P],

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_output_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_output_composer.nr
@@ -19,14 +19,14 @@ pub struct TailOutputComposer {
 }
 
 impl TailOutputComposer {
-    unconstrained pub fn new(previous_kernel: PrivateKernelCircuitPublicInputs) -> Self {
+    pub unconstrained fn new(previous_kernel: PrivateKernelCircuitPublicInputs) -> Self {
         let mut output_composer = PrivateKernelCircuitPublicInputsComposer::new_from_previous_kernel(previous_kernel);
         output_composer.sort_ordered_values();
 
         TailOutputComposer { output_composer }
     }
 
-    unconstrained pub fn finish(self) -> KernelCircuitPublicInputs {
+    pub unconstrained fn finish(self) -> KernelCircuitPublicInputs {
         let source = self.output_composer.finish();
         let mut output = KernelCircuitPublicInputs::empty();
         output.rollup_validation_requests = source.validation_requests.for_rollup;

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_output_validator/tail_output_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_output_validator/tail_output_hints.nr
@@ -12,7 +12,7 @@ pub struct TailOutputHints {
     sorted_unencrypted_log_hash_hints: [OrderHint; MAX_UNENCRYPTED_LOGS_PER_TX],
 }
 
-unconstrained pub fn generate_tail_output_hints(previous_kernel: PrivateKernelCircuitPublicInputs) -> TailOutputHints {
+pub unconstrained fn generate_tail_output_hints(previous_kernel: PrivateKernelCircuitPublicInputs) -> TailOutputHints {
     // l2_to_l1_msgs
     let sorted_l2_to_l1_msg_hints = get_order_hints_asc(previous_kernel.end.l2_to_l1_msgs);
 

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_to_public_output_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_to_public_output_composer.nr
@@ -18,14 +18,14 @@ pub struct TailToPublicOutputComposer {
 }
 
 impl TailToPublicOutputComposer {
-    unconstrained pub fn new(previous_kernel: PrivateKernelCircuitPublicInputs) -> Self {
+    pub unconstrained fn new(previous_kernel: PrivateKernelCircuitPublicInputs) -> Self {
         let mut output_composer = PrivateKernelCircuitPublicInputsComposer::new_from_previous_kernel(previous_kernel);
         output_composer.sort_ordered_values();
 
         TailToPublicOutputComposer { output_composer }
     }
 
-    unconstrained pub fn finish(self) -> PublicKernelCircuitPublicInputs {
+    pub unconstrained fn finish(self) -> PublicKernelCircuitPublicInputs {
         let source = self.output_composer.public_inputs;
 
         let mut validation_requests = PublicValidationRequests::empty();

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_to_public_output_composer/split_to_public.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_to_public_output_composer/split_to_public.nr
@@ -6,7 +6,7 @@ use dep::types::abis::{
 }
 };
 
-unconstrained pub fn split_to_public(
+pub unconstrained fn split_to_public(
     data: PrivateAccumulatedDataBuilder,
     min_revertible_side_effect_counter: u32
 ) -> (PublicAccumulatedData, PublicAccumulatedData) {

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_to_public_output_validator/tail_to_public_output_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_to_public_output_validator/tail_to_public_output_hints.nr
@@ -13,7 +13,7 @@ pub struct TailToPublicOutputHints {
     sorted_public_call_request_hints: SplitOrderHints<MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX>,
 }
 
-unconstrained pub fn generate_tail_to_public_output_hints(previous_kernel: PrivateKernelCircuitPublicInputs) -> TailToPublicOutputHints {
+pub unconstrained fn generate_tail_to_public_output_hints(previous_kernel: PrivateKernelCircuitPublicInputs) -> TailToPublicOutputHints {
     let split_counter = previous_kernel.min_revertible_side_effect_counter;
 
     // l2_to_l1_msgss

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/components/public_tail_output_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/components/public_tail_output_composer.nr
@@ -19,7 +19,7 @@ pub struct PublicTailOutputComposer<let NUM_PUBLIC_DATA_LEAVES: u32> {
 }
 
 impl<let NUM_PUBLIC_DATA_LEAVES: u32> PublicTailOutputComposer<NUM_PUBLIC_DATA_LEAVES> {
-    unconstrained pub fn new(
+    pub unconstrained fn new(
         previous_kernel: PublicKernelCircuitPublicInputs,
         start_state: PartialStateReference,
         public_data_leaf_hints: [PublicDataLeafHint; NUM_PUBLIC_DATA_LEAVES]
@@ -27,7 +27,7 @@ impl<let NUM_PUBLIC_DATA_LEAVES: u32> PublicTailOutputComposer<NUM_PUBLIC_DATA_L
         PublicTailOutputComposer { previous_kernel, start_state, public_data_leaf_hints }
     }
 
-    unconstrained pub fn finish(self) -> (KernelCircuitPublicInputs, OutputHints<NUM_PUBLIC_DATA_LEAVES>) {
+    pub unconstrained fn finish(self) -> (KernelCircuitPublicInputs, OutputHints<NUM_PUBLIC_DATA_LEAVES>) {
         let output_hints = generate_output_hints(self.previous_kernel, self.public_data_leaf_hints);
 
         let end = combine_data(

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/components/public_tail_output_composer/combine_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/components/public_tail_output_composer/combine_data.nr
@@ -7,7 +7,7 @@ use dep::types::{
     utils::arrays::{array_merge, dedupe_array, sort_by_counter_asc}
 };
 
-unconstrained pub fn combine_data<let NUM_PUBLIC_DATA_LEAVES: u32>(
+pub unconstrained fn combine_data<let NUM_PUBLIC_DATA_LEAVES: u32>(
     non_revertible: PublicAccumulatedData,
     revertible: PublicAccumulatedData,
     output_hints: OutputHints<NUM_PUBLIC_DATA_LEAVES>

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/components/public_tail_output_composer/generate_output_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/components/public_tail_output_composer/generate_output_hints.nr
@@ -48,7 +48,7 @@ pub struct OutputHints<let NUM_PUBLIC_DATA_LEAVES: u32> {
     public_data_linked_index_hints: [LinkedIndexHint; MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX],
 }
 
-unconstrained pub fn generate_output_hints<let NUM_PUBLIC_DATA_LEAVES: u32>(
+pub unconstrained fn generate_output_hints<let NUM_PUBLIC_DATA_LEAVES: u32>(
     previous_kernel: PublicKernelCircuitPublicInputs,
     public_data_leaf_hints: [PublicDataLeafHint; NUM_PUBLIC_DATA_LEAVES]
 ) -> OutputHints<NUM_PUBLIC_DATA_LEAVES> {

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/components/public_tail_output_composer/generate_overridable_public_data_writes.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/components/public_tail_output_composer/generate_overridable_public_data_writes.nr
@@ -14,7 +14,7 @@ impl Empty for LinkedIndexHint {
     }
 }
 
-unconstrained pub fn generate_overridable_public_data_writes<let NUM_WRITES: u32, let NUM_LEAVES: u32>(
+pub unconstrained fn generate_overridable_public_data_writes<let NUM_WRITES: u32, let NUM_LEAVES: u32>(
     public_data_writes: [PublicDataUpdateRequest; NUM_WRITES],
     public_data_leaves: [OverridablePublicDataTreeLeaf; NUM_LEAVES]
 ) -> ([OverridablePublicDataWrite; NUM_WRITES], [LinkedIndexHint; NUM_WRITES]) {

--- a/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/components/public_tail_output_composer/generate_public_data_leaves.nr
+++ b/noir-projects/noir-protocol-circuits/crates/public-kernel-lib/src/components/public_tail_output_composer/generate_public_data_leaves.nr
@@ -34,7 +34,7 @@ fn compare_by_index(a: SlotIndex, b: SlotIndex) -> bool {
     (a.slot != 0) & ((b.slot == 0) | (a.index < b.index))
 }
 
-unconstrained pub fn generate_public_data_leaves<let NUM_READS: u32, let NUM_WRITES: u32, let NUM_HINTS: u32>(
+pub unconstrained fn generate_public_data_leaves<let NUM_READS: u32, let NUM_WRITES: u32, let NUM_HINTS: u32>(
     reads: [PublicDataRead; NUM_READS],
     writes: [PublicDataUpdateRequest; NUM_WRITES],
     hints: [PublicDataLeafHint; NUM_HINTS]

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/note_hash_read_request_reset.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/note_hash_read_request_reset.nr
@@ -150,7 +150,7 @@ mod tests {
             (hints, tree_root)
         }
 
-        unconstrained pub fn get_unverified_read_requests(self) -> [ScopedReadRequest; READ_REQUEST_LEN] {
+        pub unconstrained fn get_unverified_read_requests(self) -> [ScopedReadRequest; READ_REQUEST_LEN] {
             get_unverified_read_requests(self.read_requests, self.read_request_statuses)
         }
 

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/nullifier_read_request_reset.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/nullifier_read_request_reset.nr
@@ -142,7 +142,7 @@ mod tests {
             (hints, tree_root)
         }
 
-        unconstrained pub fn get_unverified_read_requests(self) -> [ScopedReadRequest; READ_REQUEST_LEN] {
+        pub unconstrained fn get_unverified_read_requests(self) -> [ScopedReadRequest; READ_REQUEST_LEN] {
             get_unverified_read_requests(self.read_requests, self.read_request_statuses)
         }
 

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/private_validation_request_processor.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/private_validation_request_processor.nr
@@ -28,7 +28,7 @@ impl<
     let NLL_RR_SETTLED: u32,
     let KEY_VALIDATION_REQUESTS: u32
 > PrivateValidationRequestProcessor<NH_RR_PENDING, NH_RR_SETTLED, NLL_RR_PENDING, NLL_RR_SETTLED, KEY_VALIDATION_REQUESTS> {
-    unconstrained pub fn compose(self) -> PrivateValidationRequests {
+    pub unconstrained fn compose(self) -> PrivateValidationRequests {
         let note_hash_read_requests = get_unverified_read_requests(
             self.validation_requests.note_hash_read_requests,
             self.note_hash_read_request_hints.read_request_statuses

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/public_data_read_request_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/public_data_read_request_hints.nr
@@ -10,7 +10,7 @@ pub struct PublicDataReadRequestHints<let NUM_READS: u32> {
     leaf_data_read_hints: [ReadIndexHint; NUM_READS],
 }
 
-unconstrained pub fn build_public_data_read_request_hints<let NUM_READS: u32, let NUM_WRITES: u32, let NUM_LEAVES: u32>(
+pub unconstrained fn build_public_data_read_request_hints<let NUM_READS: u32, let NUM_WRITES: u32, let NUM_LEAVES: u32>(
     reads: [PublicDataRead; NUM_READS],
     writes: [OverridablePublicDataWrite; NUM_WRITES],
     leaf_data: [OverridablePublicDataTreeLeaf; NUM_LEAVES]

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/key_validation_hint.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/key_validation_hint.nr
@@ -88,7 +88,7 @@ pub fn verify_reset_key_validation_requests<let REQUEST_LEN: u32, let NUM_HINTS:
     }
 }
 
-unconstrained pub fn get_unverified_key_validation_requests<let REQUEST_LEN: u32, let NUM_HINTS: u32>(
+pub unconstrained fn get_unverified_key_validation_requests<let REQUEST_LEN: u32, let NUM_HINTS: u32>(
     key_validation_requests: [ScopedKeyValidationRequestAndGenerator; REQUEST_LEN],
     hints: [KeyValidationHint; NUM_HINTS]
 ) -> [ScopedKeyValidationRequestAndGenerator; REQUEST_LEN] {

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/read_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/read_request.nr
@@ -176,7 +176,7 @@ pub fn verify_reset_read_requests<
     );
 }
 
-unconstrained pub fn get_unverified_read_requests<let READ_REQUEST_LEN: u32>(
+pub unconstrained fn get_unverified_read_requests<let READ_REQUEST_LEN: u32>(
     read_requests: [ScopedReadRequest; READ_REQUEST_LEN],
     read_request_statuses: [ReadRequestStatus; READ_REQUEST_LEN]
 ) -> [ScopedReadRequest; READ_REQUEST_LEN] {
@@ -362,7 +362,7 @@ mod tests {
             TestSettledReadHint::nada(self.read_requests.len())
         }
 
-        unconstrained pub fn get_unverified_read_requests(self) -> [ScopedReadRequest; READ_REQUEST_LEN] {
+        pub unconstrained fn get_unverified_read_requests(self) -> [ScopedReadRequest; READ_REQUEST_LEN] {
             get_unverified_read_requests(self.read_requests, self.read_request_statuses)
         }
 

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data.nr
@@ -124,7 +124,7 @@ pub fn verify_squashed_transient_data_with_hint_indexes<
     }
 }
 
-unconstrained pub fn get_squashed_note_hash_hints<let NUM_INDEX_HINTS: u32, let NUM_NOTE_HASHES: u32>(transient_data_index_hints: [TransientDataIndexHint; NUM_INDEX_HINTS]) -> [bool; NUM_NOTE_HASHES] {
+pub unconstrained fn get_squashed_note_hash_hints<let NUM_INDEX_HINTS: u32, let NUM_NOTE_HASHES: u32>(transient_data_index_hints: [TransientDataIndexHint; NUM_INDEX_HINTS]) -> [bool; NUM_NOTE_HASHES] {
     let mut hints = [false; NUM_NOTE_HASHES];
     for i in 0..transient_data_index_hints.len() {
         let note_hash_index = transient_data_index_hints[i].note_hash_index;
@@ -135,7 +135,7 @@ unconstrained pub fn get_squashed_note_hash_hints<let NUM_INDEX_HINTS: u32, let 
     hints
 }
 
-unconstrained pub fn get_squashed_nullifier_hints<let NUM_INDEX_HINTS: u32, let NUM_NULLIFIERS: u32>(transient_data_index_hints: [TransientDataIndexHint; NUM_INDEX_HINTS]) -> [bool; NUM_NULLIFIERS] {
+pub unconstrained fn get_squashed_nullifier_hints<let NUM_INDEX_HINTS: u32, let NUM_NULLIFIERS: u32>(transient_data_index_hints: [TransientDataIndexHint; NUM_INDEX_HINTS]) -> [bool; NUM_NULLIFIERS] {
     let mut hints = [false; NUM_NULLIFIERS];
     for i in 0..transient_data_index_hints.len() {
         let nullifier_index = transient_data_index_hints[i].nullifier_index;

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/tests/note_hash_read_request_hints_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/tests/note_hash_read_request_hints_builder.nr
@@ -22,7 +22,7 @@ impl<let NUM_PENDING_HINTS: u32, let NUM_SETTLED_HINTS: u32> NoteHashReadRequest
         }
     }
 
-    unconstrained pub fn to_hints(self) -> NoteHashReadRequestHints<NUM_PENDING_HINTS, NUM_SETTLED_HINTS> {
+    pub unconstrained fn to_hints(self) -> NoteHashReadRequestHints<NUM_PENDING_HINTS, NUM_SETTLED_HINTS> {
         NoteHashReadRequestHints {
             read_request_statuses: self.read_request_statuses,
             pending_read_hints: self.pending_read_hints.storage,

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/tests/nullifier_non_existent_read_request_hints_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/tests/nullifier_non_existent_read_request_hints_builder.nr
@@ -49,7 +49,7 @@ impl NullifierNonExistentReadRequestHintsBuilder {
         self.non_membership_hints.push(hint);
     }
 
-    unconstrained pub fn to_hints(self) -> NullifierNonExistentReadRequestHints {
+    pub unconstrained fn to_hints(self) -> NullifierNonExistentReadRequestHints {
         let sorted_result = get_sorted_result(
             self.pending_nullifiers,
             |a: Nullifier, b: Nullifier| (b.value == 0) | ((a.value != 0) & a.value.lt(b.value))

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/tests/nullifier_read_request_hints_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/tests/nullifier_read_request_hints_builder.nr
@@ -22,7 +22,7 @@ impl<let NUM_PENDING_HINTS: u32, let NUM_SETTLED_HINTS: u32> NullifierReadReques
         }
     }
 
-    unconstrained pub fn to_hints(self) -> NullifierReadRequestHints<NUM_PENDING_HINTS, NUM_SETTLED_HINTS> {
+    pub unconstrained fn to_hints(self) -> NullifierReadRequestHints<NUM_PENDING_HINTS, NUM_SETTLED_HINTS> {
         NullifierReadRequestHints {
             read_request_statuses: self.read_request_statuses,
             pending_read_hints: self.pending_read_hints.storage,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/debug_log.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/debug_log.nr
@@ -17,7 +17,7 @@ pub fn debug_log_format<let M: u32, let N: u32>(msg: str<M>, args: [Field; N]) {
     };
 }
 
-unconstrained pub fn debug_log_oracle_wrapper<let M: u32, let N: u32>(msg: str<M>, args: [Field; N]) {
+pub unconstrained fn debug_log_oracle_wrapper<let M: u32, let N: u32>(msg: str<M>, args: [Field; N]) {
     debug_log_oracle(msg, args.as_slice());
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
@@ -51,7 +51,7 @@ pub fn array_to_bounded_vec<T, let N: u32>(array: [T; N]) -> BoundedVec<T, N> wh
     BoundedVec { storage: array, len }
 }
 
-unconstrained pub fn find_index_hint<T, let N: u32, Env>(array: [T; N], find: fn[Env](T) -> bool) -> u32 {
+pub unconstrained fn find_index_hint<T, let N: u32, Env>(array: [T; N], find: fn[Env](T) -> bool) -> u32 {
     let mut index = N;
     for i in 0..N {
         if (index == N) & find(array[i]) {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_array.nr
@@ -18,7 +18,7 @@ pub fn assert_combined_array<T, let N: u32>(
     )
 }
 
-unconstrained pub fn combine_arrays<T, let N: u32>(
+pub unconstrained fn combine_arrays<T, let N: u32>(
     original_array_lt: [T; N],
     original_array_gte: [T; N]
 ) -> [T; N] where T: Empty + Eq {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_sorted_transformed_value_array/get_combined_order_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_sorted_transformed_value_array/get_combined_order_hints.nr
@@ -20,7 +20,7 @@ impl Eq for CombinedOrderHint {
     }
 }
 
-unconstrained pub fn count_private_items<T, let N: u32>(array: [T; N]) -> u32 where T: Ordered + Empty + Eq {
+pub unconstrained fn count_private_items<T, let N: u32>(array: [T; N]) -> u32 where T: Ordered + Empty + Eq {
     let mut length = 0;
     for item in array {
         if !is_empty(item) & (item.counter() == 0) {
@@ -30,7 +30,7 @@ unconstrained pub fn count_private_items<T, let N: u32>(array: [T; N]) -> u32 wh
     length
 }
 
-unconstrained pub fn get_combined_order_hints_asc<T, let N: u32>(
+pub unconstrained fn get_combined_order_hints_asc<T, let N: u32>(
     array_lt: [T; N],
     array_gte: [T; N]
 ) -> [CombinedOrderHint; N] where T: Ordered + Eq + Empty {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_transformed_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_transformed_array.nr
@@ -25,7 +25,7 @@ pub fn assert_combined_transformed_array<T, S, let N: u32, Env>(
     }
 }
 
-unconstrained pub fn combine_and_transform_arrays<T, S, let N: u32, Env>(
+pub unconstrained fn combine_and_transform_arrays<T, S, let N: u32, Env>(
     original_array_lt: [T; N],
     original_array_gte: [T; N],
     transform: fn[Env](T) -> S

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_deduped_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_deduped_array.nr
@@ -22,7 +22,7 @@ pub fn assert_deduped_array<S, T, let N: u32>(
     }
 }
 
-unconstrained pub fn dedupe_array<S, T, let N: u32>(original_array: [S; N]) -> [T; N] where S: Overridable + Inner<T> {
+pub unconstrained fn dedupe_array<S, T, let N: u32>(original_array: [S; N]) -> [T; N] where S: Overridable + Inner<T> {
     let mut deduped = BoundedVec::new();
     for i in 0..original_array.len() {
         let original = original_array[i];

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_exposed_sorted_transformed_value_array/get_order_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_exposed_sorted_transformed_value_array/get_order_hints.nr
@@ -23,7 +23,7 @@ impl Eq for OrderHint {
     }
 }
 
-unconstrained pub fn get_order_hints<T, let N: u32>(
+pub unconstrained fn get_order_hints<T, let N: u32>(
     array: [T; N],
     ordering: fn(T, T) -> bool
 ) -> [OrderHint; N] where T: Ordered {
@@ -40,11 +40,11 @@ unconstrained pub fn get_order_hints<T, let N: u32>(
     hints
 }
 
-unconstrained pub fn get_order_hints_asc<T, let N: u32>(array: [T; N]) -> [OrderHint; N] where T: Ordered + Eq + Empty {
+pub unconstrained fn get_order_hints_asc<T, let N: u32>(array: [T; N]) -> [OrderHint; N] where T: Ordered + Eq + Empty {
     get_order_hints(array, compare_by_counter_empty_padded_asc)
 }
 
-unconstrained pub fn get_order_hints_desc<T, let N: u32>(array: [T; N]) -> [OrderHint; N] where T: Ordered + Eq + Empty {
+pub unconstrained fn get_order_hints_desc<T, let N: u32>(array: [T; N]) -> [OrderHint; N] where T: Ordered + Eq + Empty {
     get_order_hints(array, compare_by_counter_empty_padded_desc)
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_sorted_transformed_value_arrays/get_split_order_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_sorted_transformed_value_arrays/get_split_order_hints.nr
@@ -67,14 +67,14 @@ unconstrained fn get_split_order_hints<T, let N: u32>(
     SplitOrderHints { sorted_counters_lt, sorted_counters_gte, sorted_indexes }
 }
 
-unconstrained pub fn get_split_order_hints_asc<T, let N: u32>(
+pub unconstrained fn get_split_order_hints_asc<T, let N: u32>(
     array: [T; N],
     split_counter: u32
 ) -> SplitOrderHints<N> where T: Ordered + Eq + Empty {
     get_split_order_hints(array, split_counter, true)
 }
 
-unconstrained pub fn get_split_order_hints_desc<T, let N: u32>(
+pub unconstrained fn get_split_order_hints_desc<T, let N: u32>(
     array: [T; N],
     split_counter: u32
 ) -> SplitOrderHints<N> where T: Ordered + Eq + Empty {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/get_sorted_result.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/get_sorted_result.nr
@@ -6,7 +6,7 @@ pub struct SortedResult<T, let N: u32> {
     original_index_hints: [u32; N],
 }
 
-unconstrained pub fn get_sorted_result<let N: u32, T>(
+pub unconstrained fn get_sorted_result<let N: u32, T>(
     values: [T; N],
     ordering: fn(T, T) -> bool
 ) -> SortedResult<T, N> {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/get_sorted_tuple.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/get_sorted_tuple.nr
@@ -5,7 +5,7 @@ pub struct SortedTuple<T> {
     original_index: u32,
 }
 
-unconstrained pub fn get_sorted_tuple<T, let N: u32, Env>(array: [T; N], ordering: fn[Env](T, T) -> bool) -> [SortedTuple<T>; N] {
+pub unconstrained fn get_sorted_tuple<T, let N: u32, Env>(array: [T; N], ordering: fn[Env](T, T) -> bool) -> [SortedTuple<T>; N] {
     let mut tuples = [SortedTuple { elem: array[0], original_index: 0 }; N];
     for i in 0..N {
         tuples[i] = SortedTuple {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/sort_by.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/sort_by.nr
@@ -3,7 +3,7 @@ use crate::utils::arrays::find_index_hint;
 // Copied from the stdlib Array.sort_via.
 // But this one doesn't use `ordering` to check that the array is sorted.
 // This is to allow preserving the order of equal values.
-unconstrained pub fn sort_by<T, let N: u32, Env>(array: [T; N], ordering: fn[Env](T, T) -> bool) -> [T; N] {
+pub unconstrained fn sort_by<T, let N: u32, Env>(array: [T; N], ordering: fn[Env](T, T) -> bool) -> [T; N] {
     let mut result = array;
     let sorted_index = unsafe {
         get_sorting_index(array, ordering)

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/sort_by_counter.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/sort_by_counter.nr
@@ -8,11 +8,11 @@ pub fn compare_by_counter_empty_padded_desc<T>(a: T, b: T) -> bool where T: Orde
     !is_empty(a) & (is_empty(b) | (a.counter() >= b.counter()))
 }
 
-unconstrained pub fn sort_by_counter_asc<T, let N: u32>(array: [T; N]) -> [T; N] where T: Ordered + Empty + Eq {
+pub unconstrained fn sort_by_counter_asc<T, let N: u32>(array: [T; N]) -> [T; N] where T: Ordered + Empty + Eq {
     sort_by(array, compare_by_counter_empty_padded_asc)
 }
 
-unconstrained pub fn sort_by_counter_desc<T, let N: u32>(array: [T; N]) -> [T; N] where T: Ordered + Empty + Eq {
+pub unconstrained fn sort_by_counter_desc<T, let N: u32>(array: [T; N]) -> [T; N] where T: Ordered + Empty + Eq {
     sort_by(array, compare_by_counter_empty_padded_desc)
 }
 

--- a/noir/noir-repo/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/noir/noir-repo/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -285,7 +285,7 @@ fn empty_body() -> BlockExpression {
 #[cfg(test)]
 mod tests {
     use crate::{
-        ast::{NoirFunction, UnresolvedTypeData, Visibility},
+        ast::{ItemVisibility, NoirFunction, UnresolvedTypeData, Visibility},
         parser::{
             parser::{
                 parse_program,
@@ -479,5 +479,14 @@ mod tests {
 
         let error = get_single_error(&errors, span);
         assert_eq!(error.to_string(), "Expected a type but found ,");
+    }
+
+    #[test]
+    fn parse_function_with_unconstrained_after_visibility() {
+        let src = "pub unconstrained fn foo() {}";
+        let noir_function = parse_function_no_error(src);
+        assert_eq!("foo", noir_function.def.name.to_string());
+        assert!(noir_function.def.is_unconstrained);
+        assert_eq!(noir_function.def.visibility, ItemVisibility::Public);
     }
 }

--- a/noir/noir-repo/compiler/noirc_frontend/src/parser/parser/modifiers.rs
+++ b/noir/noir-repo/compiler/noirc_frontend/src/parser/parser/modifiers.rs
@@ -14,7 +14,10 @@ pub(crate) struct Modifiers {
 }
 
 impl<'a> Parser<'a> {
-    /// Modifiers = 'unconstrained'? ItemVisibility 'comptime'? 'mut'?
+    /// Modifiers = ItemVisibility 'unconstrained'? 'comptime'? 'mut'?
+    ///
+    /// NOTE: we also allow `unconstrained` before the visibility for backwards compatibility.
+    /// The formatter will put it after the visibility.
     pub(crate) fn parse_modifiers(&mut self, allow_mutable: bool) -> Modifiers {
         let unconstrained = if self.eat_keyword(Keyword::Unconstrained) {
             Some(self.previous_token_span)
@@ -25,6 +28,16 @@ impl<'a> Parser<'a> {
         let start_span = self.current_token_span;
         let visibility = self.parse_item_visibility();
         let visibility_span = self.span_since(start_span);
+
+        let unconstrained = if unconstrained.is_none() {
+            if self.eat_keyword(Keyword::Unconstrained) {
+                Some(self.previous_token_span)
+            } else {
+                None
+            }
+        } else {
+            unconstrained
+        };
 
         let comptime =
             if self.eat_keyword(Keyword::Comptime) { Some(self.previous_token_span) } else { None };

--- a/noir/noir-repo/noir_stdlib/src/array/quicksort.nr
+++ b/noir/noir-repo/noir_stdlib/src/array/quicksort.nr
@@ -30,7 +30,7 @@ unconstrained fn quicksort_recursive<T, Env, let N: u32>(arr: &mut [T; N], low: 
     }
 }
 
-pub unconstrained(crate) fn quicksort<T, Env, let N: u32>(_arr: [T; N], sortfn: fn[Env](T, T) -> bool) -> [T; N] {
+pub(crate) unconstrained fn quicksort<T, Env, let N: u32>(_arr: [T; N], sortfn: fn[Env](T, T) -> bool) -> [T; N] {
     let mut arr: [T; N] = _arr;
     if arr.len() <= 1 {} else {
         quicksort_recursive(&mut arr, 0, arr.len() - 1, sortfn);

--- a/noir/noir-repo/noir_stdlib/src/array/quicksort.nr
+++ b/noir/noir-repo/noir_stdlib/src/array/quicksort.nr
@@ -30,7 +30,7 @@ unconstrained fn quicksort_recursive<T, Env, let N: u32>(arr: &mut [T; N], low: 
     }
 }
 
-unconstrained pub(crate) fn quicksort<T, Env, let N: u32>(_arr: [T; N], sortfn: fn[Env](T, T) -> bool) -> [T; N] {
+pub unconstrained(crate) fn quicksort<T, Env, let N: u32>(_arr: [T; N], sortfn: fn[Env](T, T) -> bool) -> [T; N] {
     let mut arr: [T; N] = _arr;
     if arr.len() <= 1 {} else {
         quicksort_recursive(&mut arr, 0, arr.len() - 1, sortfn);

--- a/noir/noir-repo/noir_stdlib/src/collections/umap.nr
+++ b/noir/noir-repo/noir_stdlib/src/collections/umap.nr
@@ -21,7 +21,7 @@ pub struct UHashMap<K, V, B> {
 }
 
 // Data unit in the UHashMap table.
-// In case Noir adds support for enums in the future, this  
+// In case Noir adds support for enums in the future, this
 // should be refactored to have three states:
 // 1. (key, value)
 // 2. (empty)
@@ -60,7 +60,7 @@ impl<K, V> Slot<K, V> {
     }
 
     // Shall not override `_key_value` with Option::none(),
-    // because we must be able to differentiate empty 
+    // because we must be able to differentiate empty
     // and deleted slots for lookup.
     fn mark_deleted(&mut self) {
         self._is_deleted = true;
@@ -68,7 +68,7 @@ impl<K, V> Slot<K, V> {
 }
 
 // While conducting lookup, we iterate attempt from 0 to N - 1 due to heuristic,
-// that if we have went that far without finding desired, 
+// that if we have went that far without finding desired,
 // it is very unlikely to be after - performance will be heavily degraded.
 impl<K, V, B> UHashMap<K, V, B> {
     // Creates a new instance of UHashMap with specified BuildHasher.
@@ -188,7 +188,7 @@ impl<K, V, B> UHashMap<K, V, B> {
 
     // For each key-value entry applies mutator function.
     // docs:start:iter_mut
-    unconstrained pub fn iter_mut<H>(
+    pub unconstrained fn iter_mut<H>(
         &mut self,
         f: fn(K, V) -> (K, V)
     )
@@ -210,10 +210,10 @@ impl<K, V, B> UHashMap<K, V, B> {
 
     // For each key applies mutator function.
     // docs:start:iter_keys_mut
-    unconstrained pub fn iter_keys_mut<H>(
+    pub unconstrained fn iter_keys_mut<H>(
         &mut self,
         f: fn(K) -> K
-    ) 
+    )
     where
         K: Eq + Hash,
         B: BuildHasher<H>,
@@ -277,7 +277,7 @@ impl<K, V, B> UHashMap<K, V, B> {
 
     // Get the value by key. If it does not exist, returns none().
     // docs:start:get
-    unconstrained pub fn get<H>(
+    pub unconstrained fn get<H>(
         self,
         key: K
     ) -> Option<V>
@@ -307,9 +307,9 @@ impl<K, V, B> UHashMap<K, V, B> {
         result
     }
 
-    // Insert key-value entry. In case key was already present, value is overridden. 
+    // Insert key-value entry. In case key was already present, value is overridden.
     // docs:start:insert
-    unconstrained pub fn insert<H>(
+    pub unconstrained fn insert<H>(
         &mut self,
         key: K,
         value: V
@@ -362,7 +362,7 @@ impl<K, V, B> UHashMap<K, V, B> {
 
     // Removes a key-value entry. If key is not present, UHashMap remains unchanged.
     // docs:start:remove
-    unconstrained pub fn remove<H>(
+    pub unconstrained fn remove<H>(
         &mut self,
         key: K
     )
@@ -407,14 +407,14 @@ impl<K, V, B> UHashMap<K, V, B> {
     // Probing scheme: quadratic function.
     // We use 0.5 constant near variadic attempt and attempt^2 monomials.
     // This ensures good uniformity of distribution for table sizes
-    // equal to prime numbers or powers of two. 
+    // equal to prime numbers or powers of two.
     fn quadratic_probe(self: Self, hash: u32, attempt: u32) -> u32 {
         (hash + (attempt + attempt * attempt) / 2) % self._table.len()
     }
 }
 
-// Equality class on UHashMap has to test that they have 
-// equal sets of key-value entries, 
+// Equality class on UHashMap has to test that they have
+// equal sets of key-value entries,
 // thus one is a subset of the other and vice versa.
 // docs:start:eq
 impl<K, V, B, H> Eq for UHashMap<K, V, B>

--- a/noir/noir-repo/noir_stdlib/src/field/bn254.nr
+++ b/noir/noir-repo/noir_stdlib/src/field/bn254.nr
@@ -23,7 +23,7 @@ fn compute_decomposition(x: Field) -> (Field, Field) {
     (low, high)
 }
 
-pub unconstrained(crate) fn decompose_hint(x: Field) -> (Field, Field) {
+pub(crate) unconstrained fn decompose_hint(x: Field) -> (Field, Field) {
     compute_decomposition(x)
 }
 

--- a/noir/noir-repo/noir_stdlib/src/field/bn254.nr
+++ b/noir/noir-repo/noir_stdlib/src/field/bn254.nr
@@ -23,7 +23,7 @@ fn compute_decomposition(x: Field) -> (Field, Field) {
     (low, high)
 }
 
-unconstrained pub(crate) fn decompose_hint(x: Field) -> (Field, Field) {
+pub unconstrained(crate) fn decompose_hint(x: Field) -> (Field, Field) {
     compute_decomposition(x)
 }
 

--- a/noir/noir-repo/noir_stdlib/src/test.nr
+++ b/noir/noir-repo/noir_stdlib/src/test.nr
@@ -21,30 +21,30 @@ pub struct OracleMock {
 }
 
 impl OracleMock {
-    unconstrained pub fn mock<let N: u32>(name: str<N>) -> Self {
+    pub unconstrained fn mock<let N: u32>(name: str<N>) -> Self {
         Self { id: create_mock_oracle(name) }
     }
 
-    unconstrained pub fn with_params<P>(self, params: P) -> Self {
+    pub unconstrained fn with_params<P>(self, params: P) -> Self {
         set_mock_params_oracle(self.id, params);
         self
     }
 
-    unconstrained pub fn get_last_params<P>(self) -> P {
+    pub unconstrained fn get_last_params<P>(self) -> P {
         get_mock_last_params_oracle(self.id)
     }
 
-    unconstrained pub fn returns<R>(self, returns: R) -> Self {
+    pub unconstrained fn returns<R>(self, returns: R) -> Self {
         set_mock_returns_oracle(self.id, returns);
         self
     }
 
-    unconstrained pub fn times(self, times: u64) -> Self {
+    pub unconstrained fn times(self, times: u64) -> Self {
         set_mock_times_oracle(self.id, times);
         self
     }
 
-    unconstrained pub fn clear(self) {
+    pub unconstrained fn clear(self) {
         clear_mock_oracle(self.id);
     }
 }


### PR DESCRIPTION
This PR allows `pub unconstrained fn` which is preferred over `unconstrained pub fn`
