### PR TITLE
fix: k8s peer discovery

### DIFF
--- a/spartan/aztec-network/templates/boot-node.yaml
+++ b/spartan/aztec-network/templates/boot-node.yaml
@@ -145,6 +145,7 @@ spec:
             - containerPort: {{ .Values.bootNode.service.nodePort }}
             - containerPort: {{ .Values.bootNode.service.p2pTcpPort }}
             - containerPort: {{ .Values.bootNode.service.p2pUdpPort }}
+              protocol: UDP
           resources:
             {{- toYaml .Values.bootNode.resources | nindent 12 }}
       volumes:

--- a/spartan/aztec-network/templates/validator.yaml
+++ b/spartan/aztec-network/templates/validator.yaml
@@ -134,6 +134,7 @@ spec:
             - containerPort: {{ .Values.validator.service.nodePort }}
             - containerPort: {{ .Values.validator.service.p2pTcpPort }}
             - containerPort: {{ .Values.validator.service.p2pUdpPort }}
+              protocol: UDP
           resources:
             {{- toYaml .Values.validator.resources | nindent 12 }}
       volumes:

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -27,7 +27,7 @@ bootNode:
   replicas: 1
   service:
     p2pTcpPort: 40400
-    p2pUdpPort: 40401
+    p2pUdpPort: 40400
     nodePort: 8080
   logLevel: "debug"
   debug: "aztec:*,-aztec:avm_simulator*,-aztec:libp2p_service*,-aztec:circuits:artifact_hash,-json-rpc*"
@@ -64,7 +64,7 @@ validator:
     - 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
   service:
     p2pTcpPort: 40400
-    p2pUdpPort: 40401
+    p2pUdpPort: 40400
     nodePort: 8080
   logLevel: "debug"
   debug: "aztec:*,-aztec:avm_simulator*,-aztec:libp2p_service*,-aztec:circuits:artifact_hash,-json-rpc*"

--- a/spartan/quickstart.md
+++ b/spartan/quickstart.md
@@ -1,0 +1,22 @@
+From the repo root:
+
+```
+# one time setup
+./spartan/scripts/setup_local_k8s.sh
+./spartan/scripts/create_k8s_dashboard.sh
+./spartan/metrics/install.sh
+
+# forward ports (in separate terminals)
+./spartan/scripts/forward_k8s_dashboard.sh
+./spartan/metrics/forward.sh
+
+# build images locally
+# this takes forever but a massive speedup is coming
+./scripts/earthly-local ./yarn-project/+export-e2e-test-images
+```
+
+
+From `yarn-project/end-to-end`
+```
+AZTEC_DOCKER_TAG=<the tag that was spit out> NAMESPACE=smoke FRESH_INSTALL=true VALUES_FILE="3-validators-with-metrics.yaml" ./scripts/network_test.sh ./src/spartan/smoke.test.ts
+```

--- a/yarn-project/p2p/src/service/discv5_service.test.ts
+++ b/yarn-project/p2p/src/service/discv5_service.test.ts
@@ -33,9 +33,9 @@ describe('Discv5Service', () => {
   let basePort = 7890;
   const baseConfig = {
     tcpAnnounceAddress: `127.0.0.1:${basePort}`,
-    udpAnnounceAddress: `127.0.0.1:${basePort}`,
+    udpAnnounceAddress: `127.0.0.1:${basePort + 100}`,
     tcpListenAddress: `0.0.0.0:${basePort}`,
-    udpListenAddress: `0.0.0.0:${basePort}`,
+    udpListenAddress: `0.0.0.0:${basePort + 100}`,
     minPeerCount: 1,
     maxPeerCount: 100,
     queryForIp: false,
@@ -126,9 +126,9 @@ describe('Discv5Service', () => {
       ...getP2PDefaultConfig(),
       ...baseConfig,
       tcpListenAddress: `0.0.0.0:${port}`,
-      udpListenAddress: `0.0.0.0:${port}`,
+      udpListenAddress: `0.0.0.0:${port + 100}`,
       tcpAnnounceAddress: `127.0.0.1:${port}`,
-      udpAnnounceAddress: `127.0.0.1:${port}`,
+      udpAnnounceAddress: `127.0.0.1:${port + 100}`,
       bootstrapNodes: [bootnodeAddr],
       blockCheckIntervalMS: 50,
       peerCheckIntervalMS: 50,


### PR DESCRIPTION
For some reason, discv5 wasn't working in k8s when the udp/tcp ports were different. I adjusted the unit test to confirm that it does work at least natively/locally.

Also make some improvements to logging in p2p.

Also add a quickstart guide for spartan testing.

