### PR TITLE
feat: modify private calldata to use public keys

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator/validate_contract_address.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator/validate_contract_address.nr
@@ -18,7 +18,7 @@ pub fn validate_contract_address(private_call_data: PrivateCallData, protocol_co
         private_call_data.contract_class_artifact_hash,
         private_call_data.contract_class_public_bytecode_commitment,
         private_call_data.salted_initialization_hash,
-        private_call_data.public_keys_hash
+        private_call_data.public_keys.hash()
     );
 
     let protocol_contract_index = contract_address.to_field();

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_call_data_validator_builder/validate_contract_address.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_call_data_validator_builder/validate_contract_address.nr
@@ -70,7 +70,7 @@ fn validate_contract_address_incorrect_partial_address_preimage_fails() {
 fn validate_contract_address_incorrect_address_preimage_fails() {
     let mut builder = PrivateCallDataValidatorBuilder::new_with_regular_contract();
 
-    builder.private_call.public_keys_hash.inner = builder.private_call.public_keys_hash.inner + 1;
+    builder.private_call.public_keys.ivpk_m.inner.x = builder.private_call.public_keys.ivpk_m.inner.x + 1;
 
     builder.validate();
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_kernel/private_call_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_kernel/private_call_data.nr
@@ -3,7 +3,7 @@ use crate::{
     private_call_stack_item::{PrivateCallStackItemWithoutPublicInputs, PrivateCallStackItem},
     private_circuit_public_inputs::PrivateCircuitPublicInputs
 },
-    address::{SaltedInitializationHash, PublicKeysHash},
+    address::{SaltedInitializationHash, PublicKeysHash}, public_keys::PublicKeys,
     constants::{FUNCTION_TREE_HEIGHT, PROTOCOL_CONTRACT_TREE_HEIGHT},
     merkle_tree::membership::MembershipWitness, recursion::{verification_key::ClientIVCVerificationKey}
 };
@@ -14,7 +14,7 @@ pub struct PrivateCallData {
     vk: ClientIVCVerificationKey,
 
     salted_initialization_hash: SaltedInitializationHash,
-    public_keys_hash: PublicKeysHash,
+    public_keys: PublicKeys,
     contract_class_artifact_hash: Field,
     contract_class_public_bytecode_commitment: Field,
     function_leaf_membership_witness: MembershipWitness<FUNCTION_TREE_HEIGHT>,
@@ -29,7 +29,7 @@ pub struct PrivateCallDataWithoutPublicInputs {
     vk: ClientIVCVerificationKey,
 
     salted_initialization_hash: SaltedInitializationHash,
-    public_keys_hash: PublicKeysHash,
+    public_keys: PublicKeys,
     contract_class_artifact_hash: Field,
     contract_class_public_bytecode_commitment: Field,
     function_leaf_membership_witness: MembershipWitness<FUNCTION_TREE_HEIGHT>,
@@ -44,7 +44,7 @@ impl PrivateCallDataWithoutPublicInputs {
             call_stack_item: self.call_stack_item.to_private_call_stack_item(public_inputs),
             vk: self.vk,
             salted_initialization_hash: self.salted_initialization_hash,
-            public_keys_hash: self.public_keys_hash,
+            public_keys: self.public_keys,
             contract_class_artifact_hash: self.contract_class_artifact_hash,
             contract_class_public_bytecode_commitment: self.contract_class_public_bytecode_commitment,
             function_leaf_membership_witness: self.function_leaf_membership_witness,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -31,6 +31,7 @@ use crate::{
 }
 },
     address::{AztecAddress, EthAddress, SaltedInitializationHash, PublicKeysHash},
+    public_keys::PublicKeys,
     constants::{
     FUNCTION_TREE_HEIGHT, MAX_NOTE_HASHES_PER_TX, MAX_NULLIFIERS_PER_TX,
     MAX_L1_TO_L2_MSG_READ_REQUESTS_PER_TX, MAX_L2_TO_L1_MSGS_PER_TX, MAX_PUBLIC_DATA_READS_PER_CALL,
@@ -148,7 +149,7 @@ pub struct FixtureBuilder {
 
     // Private call.
     salted_initialization_hash: SaltedInitializationHash,
-    public_keys_hash: PublicKeysHash,
+    public_keys: PublicKeys,
     contract_class_artifact_hash: Field,
     contract_class_public_bytecode_commitment: Field,
     function_leaf_membership_witness: MembershipWitness<FUNCTION_TREE_HEIGHT>,
@@ -250,7 +251,7 @@ impl FixtureBuilder {
         self.contract_address = contract_data.address;
         self.storage_contract_address = self.contract_address;
         self.salted_initialization_hash = contract_data.salted_initialization_hash;
-        self.public_keys_hash = contract_data.public_keys_hash;
+        self.public_keys = contract_data.public_keys;
         self.contract_class_artifact_hash = contract_data.artifact_hash;
         self.contract_class_public_bytecode_commitment = contract_data.public_bytecode_commitment;
 
@@ -371,7 +372,7 @@ impl FixtureBuilder {
             vk: self.client_ivc_vk,
             function_leaf_membership_witness: self.function_leaf_membership_witness,
             salted_initialization_hash: self.salted_initialization_hash,
-            public_keys_hash: self.public_keys_hash,
+            public_keys: self.public_keys,
             contract_class_artifact_hash: self.contract_class_artifact_hash,
             contract_class_public_bytecode_commitment: self.contract_class_public_bytecode_commitment,
             protocol_contract_sibling_path: self.protocol_contract_sibling_path,
@@ -1273,7 +1274,7 @@ impl Empty for FixtureBuilder {
             returns_hash: 0,
             function_leaf_membership_witness: MembershipWitness::empty(),
             salted_initialization_hash: SaltedInitializationHash::from_field(0),
-            public_keys_hash: PublicKeysHash::from_field(0),
+            public_keys: PublicKeys::empty(),
             contract_class_artifact_hash: 0,
             contract_class_public_bytecode_commitment: 0,
             acir_hash: 0,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixtures/contracts.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixtures/contracts.nr
@@ -1,7 +1,7 @@
 use crate::{
     address::{AztecAddress, PublicKeysHash, SaltedInitializationHash, PartialAddress},
     contract_class_id::ContractClassId, hash::private_functions_root_from_siblings,
-    tests::fixtures::contract_functions::get_protocol_contract_function
+    tests::fixtures::contract_functions::get_protocol_contract_function, public_keys::PublicKeys
 };
 
 pub struct ContractData {
@@ -11,7 +11,7 @@ pub struct ContractData {
     contract_class_id: ContractClassId,
     private_functions_root: Field,
     public_bytecode_commitment: Field,
-    public_keys_hash: PublicKeysHash,
+    public_keys: PublicKeys,
     salted_initialization_hash: SaltedInitializationHash,
     partial_address: PartialAddress,
     deployer: AztecAddress,
@@ -26,7 +26,7 @@ global default_contract = ContractData {
   address: AztecAddress { inner: 0x0e66d7cd9692428c550b93c9ef5f49ca9f02c03e98cb3c922d8c773f78f79fed },
   partial_address: PartialAddress { inner: 0x0cf203c94c91bed28440b00ecd888d88cce1f86ddf2aa8d33acbb9b6fc06d382 },
   contract_class_id: ContractClassId { inner: 0x28e91aaf764bc6083e2796ff884079ad895d4b948d6ce8f37f01b29d0bc95a21 },
-  public_keys_hash: PublicKeysHash { inner: 0x000000000000000000000000000000000000000000000000000000000000b26e },
+  public_keys: PublicKeys::empty(),
   salted_initialization_hash: SaltedInitializationHash { inner: 0x13a939daa511233e5446905ed2cadbee14948fa75df183b53b5c14b612bffe88 },
   deployer: AztecAddress { inner: 0x0000000000000000000000000000000000000000000000000000000000000000 }
 };
@@ -40,7 +40,7 @@ global parent_contract = ContractData {
   address: AztecAddress { inner: 0x24415b2e716d6c7099580ab8e383fd5b16dc9fb441aa308571d8e24a2257da24 },
   partial_address: PartialAddress { inner: 0x245df9f519d616473880260dd64b19a838081bb44dc17cd6ea5d870a63d2bf57 },
   contract_class_id: ContractClassId { inner: 0x00236b0dc6c537d5106543053c5b85c4cbe95b0474f8238b094bae63f1cbcfee },
-  public_keys_hash: PublicKeysHash { inner: 0x00000000000000000000000000000000000000000000000000000000000011c1 },
+  public_keys: PublicKeys::empty(),
   salted_initialization_hash: SaltedInitializationHash { inner: 0x24bd6ac7a182e2cf25e437c72f53544ef81dfd97d9afee23abb07a638e7be749 },
   deployer: AztecAddress { inner: 0x0000000000000000000000000000000000000000000000000000000000000000 }
 };
@@ -50,7 +50,7 @@ pub fn get_protocol_contract(index: u32) -> ContractData {
     let artifact_hash = 576576 + seed;
     let salted_initialization_hash = SaltedInitializationHash { inner: 281972 + seed };
     let public_bytecode_commitment = 38383 + seed;
-    let public_keys_hash = PublicKeysHash { inner: 8023893 + seed };
+    let public_keys = PublicKeys::empty();
 
     let function = get_protocol_contract_function(index);
     let private_functions_root = private_functions_root_from_siblings(
@@ -68,7 +68,7 @@ pub fn get_protocol_contract(index: u32) -> ContractData {
 
     let partial_address = PartialAddress::compute_from_salted_initialization_hash(contract_class_id, salted_initialization_hash);
 
-    let address = AztecAddress::compute(public_keys_hash, partial_address);
+    let address = AztecAddress::compute(public_keys.hash(), partial_address);
 
     ContractData {
         contract_address_salt: 1,
@@ -78,7 +78,7 @@ pub fn get_protocol_contract(index: u32) -> ContractData {
         address,
         partial_address,
         contract_class_id,
-        public_keys_hash,
+        public_keys,
         salted_initialization_hash,
         deployer: AztecAddress { inner: 0 }
     }

--- a/yarn-project/circuits.js/src/structs/kernel/private_call_data.ts
+++ b/yarn-project/circuits.js/src/structs/kernel/private_call_data.ts
@@ -3,6 +3,7 @@ import { BufferReader, type Tuple, serializeToBuffer } from '@aztec/foundation/s
 import { type FieldsOf } from '@aztec/foundation/types';
 
 import { FUNCTION_TREE_HEIGHT, PROTOCOL_CONTRACT_TREE_HEIGHT } from '../../constants.gen.js';
+import { PublicKeys } from '../../types/public_keys.js';
 import { MembershipWitness } from '../membership_witness.js';
 import { PrivateCallStackItem } from '../private_call_stack_item.js';
 import { VerificationKeyAsFields } from '../verification_key.js';
@@ -31,7 +32,7 @@ export class PrivateCallData {
     /**
      * Public keys hash of the contract instance.
      */
-    public publicKeysHash: Fr,
+    public publicKeys: PublicKeys,
     /**
      * Salted initialization hash of the contract instance.
      */
@@ -58,7 +59,7 @@ export class PrivateCallData {
       fields.vk,
       fields.contractClassArtifactHash,
       fields.contractClassPublicBytecodeCommitment,
-      fields.publicKeysHash,
+      fields.publicKeys,
       fields.saltedInitializationHash,
       fields.functionLeafMembershipWitness,
       fields.protocolContractSiblingPath,
@@ -90,7 +91,7 @@ export class PrivateCallData {
       reader.readObject(VerificationKeyAsFields),
       reader.readObject(Fr),
       reader.readObject(Fr),
-      reader.readObject(Fr),
+      reader.readObject(PublicKeys),
       reader.readObject(Fr),
       reader.readObject(MembershipWitness.deserializer(FUNCTION_TREE_HEIGHT)),
       reader.readArray(PROTOCOL_CONTRACT_TREE_HEIGHT, Fr),

--- a/yarn-project/noir-protocol-circuits-types/src/type_conversion.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/type_conversion.ts
@@ -111,6 +111,7 @@ import {
   type PublicKernelInnerCircuitPrivateInputs,
   type PublicKernelInnerData,
   type PublicKernelTailCircuitPrivateInputs,
+  type PublicKeys,
   PublicValidationRequestArrayLengths,
   PublicValidationRequests,
   type RECURSIVE_PROOF_LENGTH,
@@ -234,6 +235,7 @@ import type {
   PublicKernelInnerData as PublicKernelInnerDataNoir,
   PublicKernelMergeCircuitPrivateInputs as PublicKernelMergeCircuitPrivateInputsNoir,
   PublicKernelTailCircuitPrivateInputs as PublicKernelTailCircuitPrivateInputsNoir,
+  PublicKeys as PublicKeysNoir,
   PublicValidationRequestArrayLengths as PublicValidationRequestArrayLengthsNoir,
   PublicValidationRequests as PublicValidationRequestsNoir,
   ReadRequest as ReadRequestNoir,
@@ -1011,10 +1013,27 @@ export function mapPrivateCallDataToNoir(privateCallData: PrivateCallData): Priv
     function_leaf_membership_witness: mapMembershipWitnessToNoir(privateCallData.functionLeafMembershipWitness),
     contract_class_artifact_hash: mapFieldToNoir(privateCallData.contractClassArtifactHash),
     contract_class_public_bytecode_commitment: mapFieldToNoir(privateCallData.contractClassPublicBytecodeCommitment),
-    public_keys_hash: mapWrappedFieldToNoir(privateCallData.publicKeysHash),
+    public_keys: mapPublicKeysToNoir(privateCallData.publicKeys),
     salted_initialization_hash: mapWrappedFieldToNoir(privateCallData.saltedInitializationHash),
     protocol_contract_sibling_path: mapTuple(privateCallData.protocolContractSiblingPath, mapFieldToNoir),
     acir_hash: mapFieldToNoir(privateCallData.acirHash),
+  };
+}
+
+export function mapPublicKeysToNoir(publicKeys: PublicKeys): PublicKeysNoir {
+  return {
+    npk_m: {
+      inner: mapPointToNoir(publicKeys.masterNullifierPublicKey),
+    },
+    ivpk_m: {
+      inner: mapPointToNoir(publicKeys.masterIncomingViewingPublicKey),
+    },
+    ovpk_m: {
+      inner: mapPointToNoir(publicKeys.masterOutgoingViewingPublicKey),
+    },
+    tpk_m: {
+      inner: mapPointToNoir(publicKeys.masterTaggingPublicKey),
+    },
   };
 }
 

--- a/yarn-project/pxe/src/kernel_prover/kernel_prover.ts
+++ b/yarn-project/pxe/src/kernel_prover/kernel_prover.ts
@@ -225,7 +225,7 @@ export class KernelProver {
     return PrivateCallData.from({
       callStackItem,
       vk,
-      publicKeysHash: publicKeys.hash(),
+      publicKeys,
       contractClassArtifactHash,
       contractClassPublicBytecodeCommitment,
       saltedInitializationHash,


### PR DESCRIPTION
In this PR we are modifying private calldata to use public keys instead of only the public keys hash. This is in preparation for the new address changes in which we private calldata is needed to validate a contract address in the kernels in `validate_contract_address` (validate_contract_address uses information from the private calldata struct), and we need to constrain that a contract address can be recomputed using its entire set of public keys with `AztecAddress::compute_from_private_function`.