### PR TITLE
feat: passing partial log through transient storage 

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -175,6 +175,40 @@ pub fn encrypt_and_emit_partial_log<let P: u32>(
     context.emit_raw_note_log(note_hash_counter, encrypted_log, log_hash);
 }
 
+// Temporary hack function TODO: remove
+pub fn encrypt_and_emit_partial_log_and_return<let P: u32, let N: u32>(
+    context: &mut PrivateContext,
+    log_plaintext: [u8; P],
+    recipient_keys: PublicKeys,
+    recipient: AztecAddress
+) -> [Field; N] {
+    let ovsk_app: Field  = context.request_ovsk_app(recipient_keys.ovpk_m.hash());
+
+    let encrypted_log: [u8; 353 + P] = compute_encrypted_log(
+        context.this_address(),
+        ovsk_app,
+        recipient_keys.ovpk_m,
+        recipient_keys.ivpk_m,
+        recipient,
+        log_plaintext,
+        true
+    );
+    let log_hash = sha256_to_field(encrypted_log);
+
+    // for i in 0..encrypted_log.len() {
+    //     crate::protocol_types::debug_log::debug_log_format("e {0}", [encrypted_log[i].to_field()]);
+    // }
+
+    // Unfortunately we need to push a dummy note hash to the context here because a note log requires having
+    // a counter that corresponds to a note hash in the same call.
+    let note_hash_counter = context.side_effect_counter;
+    context.push_note_hash(5);
+
+    context.emit_raw_note_log(note_hash_counter, encrypted_log, log_hash);
+
+    bytes_to_fields(encrypted_log)
+}
+
 pub fn encrypt_partial_log<let P: u32, let N: u32>(
     context: &mut PrivateContext,
     log_plaintext: [u8; P],

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -7,14 +7,45 @@ use dep::protocol_types::{
     abis::note_hash::NoteHash
 };
 
-fn compute_raw_note_log<Note, let N: u32>(
+// Note: the following function is an ugly hack but it's very isolated so it seemed like the best way to do it for now.
+// Having `compute_encrypted_log` insert the flag would require a much larger refactor as that function is used
+// for events as well (it would also require a change in EncryptedLogPayload in TS which is just too much work
+// given that all that code is most likely going to die).
+// TODO(benesjan): Refactor this when working on the large PXE refactor.
+pub fn compute_note_log<let P: u32, let M: u32>(
+    contract_address: AztecAddress,
+    ovsk_app: Field,
+    ovpk: OvpkM,
+    ivpk: IvpkM,
+    recipient: AztecAddress,
+    plaintext: [u8; P],
+    public_values_appended: bool // Indicates whether there are values to be appended to the log in public (used in partial note flow).
+) -> [u8; M] {
+    let encrypted_log_without_public_values_flag: [u8; M - 1] = compute_encrypted_log(contract_address, ovsk_app, ovpk, ivpk, recipient, plaintext);
+
+    // Note: the following is an ugly hack but it's very isolated so it seemed like the best way to do it for now.
+    // Having `compute_encrypted_log` insert the flag would require a much larger refactor as that function is used
+    // for events as well (it would also require a change in EncryptedLogPayload in TS which is just too much work
+    // given that all that code is most likely going to die).
+    // TODO(benesjan): Refactor this when working on the large PXE refactor.
+    let mut encrypted_log = [0 as u8; M];
+    encrypted_log[0] = public_values_appended as u8;
+    for i in 1..M {
+        encrypted_log[i] = encrypted_log_without_public_values_flag[i];
+    }
+
+    encrypted_log
+}
+
+fn compute_values_to_emit<Note, let N: u32>(
     context: PrivateContext,
     note: Note,
     ovsk_app: Field,
     ovpk: OvpkM,
     ivpk: IvpkM,
-    recipient: AztecAddress
-) -> (u32, [u8; 416 + N * 32], Field) where Note: NoteInterface<N> {
+    recipient: AztecAddress,
+    public_values_appended: bool // Indicates whether there are values to be appended to the log in public (used in partial note flow).
+) -> (u32, [u8; 417 + N * 32], Field) where Note: NoteInterface<N> {
     let note_header = note.get_header();
     let note_hash_counter = note_header.note_hash_counter;
     let storage_slot = note_header.storage_slot;
@@ -26,21 +57,39 @@ fn compute_raw_note_log<Note, let N: u32>(
     let contract_address: AztecAddress = context.this_address();
 
     let plaintext = note.to_be_bytes(storage_slot);
-    let encrypted_log: [u8; 416 + N * 32] = compute_encrypted_log(contract_address, ovsk_app, ovpk, ivpk, recipient, plaintext);
+    let encrypted_log: [u8; 417 + N * 32] = compute_note_log(
+        contract_address,
+        ovsk_app,
+        ovpk,
+        ivpk,
+        recipient,
+        plaintext,
+        public_values_appended
+    );
+
     let log_hash = sha256_to_field(encrypted_log);
 
     (note_hash_counter, encrypted_log, log_hash)
 }
 
-unconstrained fn compute_raw_note_log_unconstrained<Note, let N: u32>(
+unconstrained fn compute_values_to_emit_unconstrained<Note, let N: u32>(
     context: PrivateContext,
     note: Note,
     ovpk: OvpkM,
     ivpk: IvpkM,
-    recipient: AztecAddress
-) -> (u32, [u8; 416 + N * 32], Field) where Note: NoteInterface<N> {
+    recipient: AztecAddress,
+    public_values_appended: bool // Indicates whether there are values to be appended to the log in public (used in partial note flow).
+) -> (u32, [u8; 417 + N * 32], Field) where Note: NoteInterface<N> {
     let ovsk_app = get_ovsk_app(ovpk.hash());
-    compute_raw_note_log(context, note, ovsk_app, ovpk, ivpk, recipient)
+    compute_values_to_emit(
+        context,
+        note,
+        ovsk_app,
+        ovpk,
+        ivpk,
+        recipient,
+        public_values_appended
+    )
 }
 
 // This function seems to be affected by the following Noir bug:
@@ -55,7 +104,7 @@ pub fn encode_and_encrypt_note<Note, let N: u32>(
     | e: NoteEmission<Note> | {
         let ovsk_app: Field  = context.request_ovsk_app(ovpk.hash());
 
-        let (note_hash_counter, encrypted_log, log_hash) = compute_raw_note_log(*context, e.note, ovsk_app, ovpk, ivpk, recipient);
+        let (note_hash_counter, encrypted_log, log_hash) = compute_values_to_emit(*context, e.note, ovsk_app, ovpk, ivpk, recipient, false);
         context.emit_raw_note_log(note_hash_counter, encrypted_log, log_hash);
     }
 }
@@ -87,7 +136,7 @@ pub fn encode_and_encrypt_note_unconstrained<Note, let N: u32>(
         // whatever), or cause for the log to not be deleted when it should have (which is also fine - it'll be a log
         // for a note that doesn't exist).
         let (note_hash_counter, encrypted_log, log_hash) = unsafe {
-            compute_raw_note_log_unconstrained(*context, e.note, ovpk, ivpk, recipient)
+            compute_values_to_emit_unconstrained(*context, e.note, ovpk, ivpk, recipient, false)
         };
         context.emit_raw_note_log(note_hash_counter, encrypted_log, log_hash);
     }
@@ -105,13 +154,14 @@ pub fn encrypt_and_emit_partial_log<let M: u32>(
 ) {
     let ovsk_app: Field  = context.request_ovsk_app(recipient_keys.ovpk_m.hash());
 
-    let encrypted_log: [u8; 352 + M] = compute_encrypted_log(
+    let encrypted_log: [u8; 353 + M] = compute_note_log(
         context.this_address(),
         ovsk_app,
         recipient_keys.ovpk_m,
         recipient_keys.ivpk_m,
         recipient,
-        log_plaintext
+        log_plaintext,
+        true
     );
     let log_hash = sha256_to_field(encrypted_log);
 

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -1,6 +1,7 @@
 use crate::{
     context::PrivateContext, note::{note_emission::NoteEmission, note_interface::NoteInterface},
-    keys::getters::get_ovsk_app, encrypted_logs::payload::compute_encrypted_log
+    keys::getters::get_ovsk_app, encrypted_logs::payload::compute_encrypted_log,
+    utils::bytes::bytes_to_fields
 };
 use dep::protocol_types::{
     address::AztecAddress, public_keys::{PublicKeys, OvpkM, IvpkM}, hash::sha256_to_field,
@@ -142,19 +143,20 @@ pub fn encode_and_encrypt_note_unconstrained<Note, let N: u32>(
     }
 }
 
+// TODO(benesjan): Nuke the following
 /// Encrypts a partial log and emits it. Takes recipient keys on the input and encrypts both the outgoing and incoming
 /// logs for the recipient. This is necessary because in the partial notes flow the outgoing always has to be the same
 /// as the incoming to not leak any information (typically the `from` party finalizing the partial note in public does
 /// not know who the recipient is).
-pub fn encrypt_and_emit_partial_log<let M: u32>(
+pub fn encrypt_and_emit_partial_log<let P: u32>(
     context: &mut PrivateContext,
-    log_plaintext: [u8; M],
+    log_plaintext: [u8; P],
     recipient_keys: PublicKeys,
     recipient: AztecAddress
 ) {
     let ovsk_app: Field  = context.request_ovsk_app(recipient_keys.ovpk_m.hash());
 
-    let encrypted_log: [u8; 353 + M] = compute_note_log(
+    let encrypted_log: [u8; 353 + P] = compute_encrypted_log(
         context.this_address(),
         ovsk_app,
         recipient_keys.ovpk_m,
@@ -171,4 +173,25 @@ pub fn encrypt_and_emit_partial_log<let M: u32>(
     context.push_note_hash(5);
 
     context.emit_raw_note_log(note_hash_counter, encrypted_log, log_hash);
+}
+
+pub fn encrypt_partial_log<let P: u32, let N: u32>(
+    context: &mut PrivateContext,
+    log_plaintext: [u8; P],
+    recipient_keys: PublicKeys,
+    recipient: AztecAddress
+) -> [Field; N] {
+    let ovsk_app: Field  = context.request_ovsk_app(recipient_keys.ovpk_m.hash());
+
+    let encrypted_log_bytes: [u8; 353 + P] = compute_encrypted_log(
+        context.this_address(),
+        ovsk_app,
+        recipient_keys.ovpk_m,
+        recipient_keys.ivpk_m,
+        recipient,
+        log_plaintext,
+        true
+    );
+
+    bytes_to_fields(encrypted_log_bytes)
 }

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -1,42 +1,12 @@
 use crate::{
     context::PrivateContext, note::{note_emission::NoteEmission, note_interface::NoteInterface},
-    keys::getters::get_ovsk_app, encrypted_logs::payload::compute_encrypted_log,
+    keys::getters::get_ovsk_app, encrypted_logs::payload::compute_note_log,
     utils::bytes::bytes_to_fields
 };
 use dep::protocol_types::{
     address::AztecAddress, public_keys::{PublicKeys, OvpkM, IvpkM}, hash::sha256_to_field,
     abis::note_hash::NoteHash
 };
-
-// Note: the following function is an ugly hack but it's very isolated so it seemed like the best way to do it for now.
-// Having `compute_encrypted_log` insert the flag would require a much larger refactor as that function is used
-// for events as well (it would also require a change in EncryptedLogPayload in TS which is just too much work
-// given that all that code is most likely going to die).
-// TODO(benesjan): Refactor this when working on the large PXE refactor.
-pub fn compute_note_log<let P: u32, let M: u32>(
-    contract_address: AztecAddress,
-    ovsk_app: Field,
-    ovpk: OvpkM,
-    ivpk: IvpkM,
-    recipient: AztecAddress,
-    plaintext: [u8; P],
-    public_values_appended: bool // Indicates whether there are values to be appended to the log in public (used in partial note flow).
-) -> [u8; M] {
-    let encrypted_log_without_public_values_flag: [u8; M - 1] = compute_encrypted_log(contract_address, ovsk_app, ovpk, ivpk, recipient, plaintext);
-
-    // Note: the following is an ugly hack but it's very isolated so it seemed like the best way to do it for now.
-    // Having `compute_encrypted_log` insert the flag would require a much larger refactor as that function is used
-    // for events as well (it would also require a change in EncryptedLogPayload in TS which is just too much work
-    // given that all that code is most likely going to die).
-    // TODO(benesjan): Refactor this when working on the large PXE refactor.
-    let mut encrypted_log = [0 as u8; M];
-    encrypted_log[0] = public_values_appended as u8;
-    for i in 1..M {
-        encrypted_log[i] = encrypted_log_without_public_values_flag[i];
-    }
-
-    encrypted_log
-}
 
 fn compute_values_to_emit<Note, let N: u32>(
     context: PrivateContext,

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -156,7 +156,7 @@ pub fn encrypt_and_emit_partial_log<let P: u32>(
 ) {
     let ovsk_app: Field  = context.request_ovsk_app(recipient_keys.ovpk_m.hash());
 
-    let encrypted_log: [u8; 353 + P] = compute_encrypted_log(
+    let encrypted_log: [u8; 353 + P] = compute_note_log(
         context.this_address(),
         ovsk_app,
         recipient_keys.ovpk_m,
@@ -184,7 +184,7 @@ pub fn encrypt_and_emit_partial_log_and_return<let P: u32, let N: u32>(
 ) -> [Field; N] {
     let ovsk_app: Field  = context.request_ovsk_app(recipient_keys.ovpk_m.hash());
 
-    let encrypted_log: [u8; 353 + P] = compute_encrypted_log(
+    let encrypted_log: [u8; 353 + P] = compute_note_log(
         context.this_address(),
         ovsk_app,
         recipient_keys.ovpk_m,
@@ -217,7 +217,7 @@ pub fn encrypt_partial_log<let P: u32, let N: u32>(
 ) -> [Field; N] {
     let ovsk_app: Field  = context.request_ovsk_app(recipient_keys.ovpk_m.hash());
 
-    let encrypted_log_bytes: [u8; 353 + P] = compute_encrypted_log(
+    let encrypted_log_bytes: [u8; 353 + P] = compute_note_log(
         context.this_address(),
         ovsk_app,
         recipient_keys.ovpk_m,

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
@@ -62,6 +62,60 @@ pub fn compute_encrypted_log<let P: u32, let M: u32>(
     encrypted_bytes
 }
 
+pub fn compute_note_log<let P: u32, let M: u32>(
+    contract_address: AztecAddress,
+    ovsk_app: Field,
+    ovpk: OvpkM,
+    ivpk: IvpkM,
+    recipient: AztecAddress,
+    plaintext: [u8; P],
+    public_values_appended: bool // Indicates whether there are values to be appended to the log in public (used in partial note flow).
+) -> [u8; M] {
+    let (eph_sk, eph_pk) = generate_ephemeral_key_pair();
+
+    let header = EncryptedLogHeader::new(contract_address);
+
+    let incoming_header_ciphertext: [u8; 48] = header.compute_ciphertext(eph_sk, ivpk);
+    let outgoing_header_ciphertext: [u8; 48] = header.compute_ciphertext(eph_sk, ovpk);
+    let incoming_body_ciphertext = compute_incoming_body_ciphertext(plaintext, eph_sk, ivpk);
+    let outgoing_body_ciphertext: [u8; 144] = compute_outgoing_body_ciphertext(recipient, ivpk, fr_to_fq(ovsk_app), eph_sk, eph_pk);
+
+    let mut encrypted_bytes: [u8; M] = [0; M];
+    // @todo We ignore the tags for now
+
+    encrypted_bytes[65] = public_values_appended as u8;
+
+    let eph_pk_bytes = point_to_bytes(eph_pk);
+    for i in 0..32 {
+        encrypted_bytes[65 + i] = eph_pk_bytes[i];
+    }
+    for i in 0..48 {
+        encrypted_bytes[97 + i] = incoming_header_ciphertext[i];
+        encrypted_bytes[145 + i] = outgoing_header_ciphertext[i];
+    }
+    for i in 0..144 {
+        encrypted_bytes[193 + i] = outgoing_body_ciphertext[i];
+    }
+    // Then we fill in the rest as the incoming body ciphertext
+    let size = M - 337;
+    assert_eq(size, incoming_body_ciphertext.len(), "ciphertext length mismatch");
+    for i in 0..size {
+        encrypted_bytes[337 + i] = incoming_body_ciphertext[i];
+    }
+
+    // Current unoptimized size of the encrypted log
+    // incoming_tag (32 bytes)
+    // outgoing_tag (32 bytes)
+    // public_values_appended (1 byte) TODO: can be reduced to 1 bit
+    // eph_pk (32 bytes)
+    // incoming_header (48 bytes)
+    // outgoing_header (48 bytes)
+    // outgoing_body (144 bytes)
+    // incoming_body_fixed (64 bytes)
+    // incoming_body_variable (P + 16 bytes padding)
+    encrypted_bytes
+}
+
 /// Converts a base field element to scalar field element.
 /// This is fine because modulus of the base field is smaller than the modulus of the scalar field.
 fn fr_to_fq(r: Field) -> Scalar {

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
@@ -14,10 +14,10 @@ contract NFT {
         NoteGetterOptions, NoteViewerOptions, Map, PublicMutable, SharedImmutable, PrivateSet,
         AztecAddress, PublicContext
     },
-        encrypted_logs::{encrypted_note_emission::{encode_and_encrypt_note, encrypt_and_emit_partial_log}},
+        encrypted_logs::{encrypted_note_emission::{encode_and_encrypt_note, encrypt_and_emit_partial_log, encrypt_partial_log}},
         keys::getters::get_public_keys, note::constants::MAX_NOTES_PER_PAGE,
         protocol_types::traits::is_empty, utils::comparison::Comparator,
-        protocol_types::{point::Point, traits::Serialize},
+        protocol_types::{point::Point, traits::Serialize}, utils::bytes::fields_to_bytes,
         macros::{storage::storage, events::event, functions::{private, public, view, internal, initializer}}
     };
     use dep::authwit::auth::{assert_current_call_valid_authwit, assert_current_call_valid_authwit_public, compute_authwit_nullifier};
@@ -179,6 +179,10 @@ contract NFT {
 
         // We encrypt and emit the partial note log
         encrypt_and_emit_partial_log(&mut context, note_setup_payload.log_plaintext, to_keys, to);
+        // setup payload plaintext is 2*32+64 = 128
+        // the full log is 128 + 353 = 481
+        // each field can contain 31 bytes so we need 16 fields
+        let partial_log: [Field; 16] = encrypt_partial_log(&mut context, note_setup_payload.log_plaintext, to_keys, to);
 
         // Using the x-coordinate as a hiding point slot is safe against someone else interfering with it because
         // we have a guarantee that the public functions of the transaction are executed right after the private ones
@@ -196,15 +200,20 @@ contract NFT {
         // We don't need to perform a check that the value overwritten by `_store_point_in_transient_storage_unsafe`
         // is zero because the slot is the x-coordinate of the hiding point and hence we could only overwrite
         // the value in the slot with the same value. This makes usage of the `unsafe` method safe.
-        NFT::at(context.this_address())._store_point_in_transient_storage_unsafe(hiding_point_slot, note_setup_payload.hiding_point).enqueue(&mut context);
+        NFT::at(context.this_address())._store_payload_in_transient_storage_unsafe(
+            hiding_point_slot,
+            note_setup_payload.hiding_point,
+            partial_log
+        ).enqueue(&mut context);
 
         hiding_point_slot
     }
 
     #[public]
     #[internal]
-    fn _store_point_in_transient_storage_unsafe(slot: Field, point: Point) {
+    fn _store_payload_in_transient_storage_unsafe(slot: Field, point: Point, partial_log: [Field; 16]) {
         context.storage_write(slot, point);
+        context.storage_write(slot + 3, partial_log);
     }
 
     /// Finalizes a transfer of NFT with `token_id` from public balance of `from` to a private balance of `to`.
@@ -252,6 +261,27 @@ contract NFT {
         // At last we reset public storage to zero to achieve the effect of transient storage - kernels will squash
         // the writes
         context.storage_write(hiding_point_slot, Point::empty());
+
+        // ############### HACKY NEW COED TO BE POLISHED LATER ###############
+        let partial_log_fields: [Field; 16] = context.storage_read(hiding_point_slot + 3);
+        let partial_log: [u8; 481] = fields_to_bytes(partial_log_fields);
+
+        // We append the public value to the log and emit it as unencrypted log
+        let mut log = [0; 513];
+
+        // Iterate over the partial log and copy it to the final log
+        for i in 0..partial_log.len() {
+            log[i] = partial_log[i];
+        }
+
+        // Iterate over the finalization log and copy it to the final log
+        let finalization_log: [u8; 32] = finalization_payload.log[0].to_be_bytes();
+
+        for i in 0..finalization_log.len() {
+            log[481 + i] = finalization_log[i];
+        }
+
+        context.storage_write(hiding_point_slot + 3, [0; 16]);
     }
 
     /**

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
@@ -14,7 +14,12 @@ contract NFT {
         NoteGetterOptions, NoteViewerOptions, Map, PublicMutable, SharedImmutable, PrivateSet,
         AztecAddress, PublicContext
     },
-        encrypted_logs::{encrypted_note_emission::{encode_and_encrypt_note, encrypt_and_emit_partial_log, encrypt_and_emit_partial_log_and_return, encrypt_partial_log}},
+        encrypted_logs::{
+        encrypted_note_emission::{
+        encode_and_encrypt_note, encrypt_and_emit_partial_log, encrypt_and_emit_partial_log_and_return,
+        encrypt_partial_log
+    }
+    },
         keys::getters::get_public_keys, note::constants::MAX_NOTES_PER_PAGE,
         protocol_types::traits::is_empty, utils::comparison::Comparator,
         protocol_types::{point::Point, traits::Serialize}, utils::bytes::fields_to_bytes,

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
@@ -262,7 +262,7 @@ contract NFT {
         // the writes
         context.storage_write(hiding_point_slot, Point::empty());
 
-        // ############### HACKY NEW COED TO BE POLISHED LATER ###############
+        // ############### HACKY NEW CODE TO BE POLISHED LATER ###############
         let partial_log_fields: [Field; 16] = context.storage_read(hiding_point_slot + 3);
         let partial_log: [u8; 481] = fields_to_bytes(partial_log_fields);
 
@@ -280,6 +280,8 @@ contract NFT {
         for i in 0..finalization_log.len() {
             log[481 + i] = finalization_log[i];
         }
+
+        context.emit_unencrypted_log(log);
 
         context.storage_write(hiding_point_slot + 3, [0; 16]);
     }

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
@@ -14,7 +14,7 @@ contract NFT {
         NoteGetterOptions, NoteViewerOptions, Map, PublicMutable, SharedImmutable, PrivateSet,
         AztecAddress, PublicContext
     },
-        encrypted_logs::{encrypted_note_emission::{encode_and_encrypt_note, encrypt_and_emit_partial_log, encrypt_partial_log}},
+        encrypted_logs::{encrypted_note_emission::{encode_and_encrypt_note, encrypt_and_emit_partial_log, encrypt_and_emit_partial_log_and_return, encrypt_partial_log}},
         keys::getters::get_public_keys, note::constants::MAX_NOTES_PER_PAGE,
         protocol_types::traits::is_empty, utils::comparison::Comparator,
         protocol_types::{point::Point, traits::Serialize}, utils::bytes::fields_to_bytes,
@@ -178,11 +178,14 @@ contract NFT {
         let note_setup_payload = NFTNote::setup_payload().new(to_npk_m_hash, note_randomness, to_note_slot);
 
         // We encrypt and emit the partial note log
-        encrypt_and_emit_partial_log(&mut context, note_setup_payload.log_plaintext, to_keys, to);
+        // encrypt_and_emit_partial_log(&mut context, note_setup_payload.log_plaintext, to_keys, to);
         // setup payload plaintext is 2*32+64 = 128
         // the full log is 128 + 353 = 481
         // each field can contain 31 bytes so we need 16 fields
-        let partial_log: [Field; 16] = encrypt_partial_log(&mut context, note_setup_payload.log_plaintext, to_keys, to);
+        // let partial_log: [Field; 16] = encrypt_partial_log(&mut context, note_setup_payload.log_plaintext, to_keys, to);
+        let partial_log: [Field; 16] = encrypt_and_emit_partial_log_and_return(&mut context, note_setup_payload.log_plaintext, to_keys, to);
+
+        // dep::aztec::protocol_types::debug_log::debug_log_format("before transient {}", partial_log);
 
         // Using the x-coordinate as a hiding point slot is safe against someone else interfering with it because
         // we have a guarantee that the public functions of the transaction are executed right after the private ones

--- a/yarn-project/circuit-types/src/logs/l1_payload/encrypted_log_payload.ts
+++ b/yarn-project/circuit-types/src/logs/l1_payload/encrypted_log_payload.ts
@@ -16,11 +16,11 @@ import { derivePoseidonAESSecret } from './shared_secret_derivation.js';
 
 // Both the incoming and the outgoing header are 48 bytes../shared_secret_derivation.js
 // 32 bytes for the address, and 16 bytes padding to follow PKCS#7
-const HEADER_SIZE = 48;
+export const HEADER_SIZE = 48;
 
 // The outgoing body is constant size of 144 bytes.
 // 128 bytes for the secret key, address and public key, and 16 bytes padding to follow PKCS#7
-const OUTGOING_BODY_SIZE = 144;
+export const OUTGOING_BODY_SIZE = 144;
 
 /**
  * Encrypted log payload with a tag used for retrieval by clients.
@@ -83,7 +83,6 @@ export class EncryptedLogPayload {
     return serializeToBuffer(
       this.incomingTag,
       this.outgoingTag,
-      this.publicValuesAppended,
       ephPk.toCompressedBuffer(),
       incomingHeaderCiphertext,
       outgoingHeaderCiphertext,

--- a/yarn-project/circuit-types/src/logs/l1_payload/encrypted_log_payload.ts
+++ b/yarn-project/circuit-types/src/logs/l1_payload/encrypted_log_payload.ts
@@ -27,9 +27,21 @@ const OUTGOING_BODY_SIZE = 144;
  */
 export class EncryptedLogPayload {
   constructor(
+    /**
+     * Note discovery tag used by the recipient of the log.
+     */
     public readonly incomingTag: Fr,
+    /**
+     * Note discovery tag used by the sender of the log.
+     */
     public readonly outgoingTag: Fr,
+    /**
+     * Address of a contract that emitted the log.
+     */
     public readonly contractAddress: AztecAddress,
+    /**
+     * Decrypted incoming body.
+     */
     public readonly incomingBodyPlaintext: Buffer,
   ) {}
 
@@ -71,6 +83,7 @@ export class EncryptedLogPayload {
     return serializeToBuffer(
       this.incomingTag,
       this.outgoingTag,
+      this.publicValuesAppended,
       ephPk.toCompressedBuffer(),
       incomingHeaderCiphertext,
       outgoingHeaderCiphertext,

--- a/yarn-project/circuit-types/src/logs/l1_payload/l1_note_payload.ts
+++ b/yarn-project/circuit-types/src/logs/l1_payload/l1_note_payload.ts
@@ -3,7 +3,6 @@ import { NoteSelector } from '@aztec/foundation/abi';
 import { type Fq, Fr } from '@aztec/foundation/fields';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
-import { type EncryptedL2NoteLog } from '../encrypted_l2_note_log.js';
 import { EncryptedLogPayload } from './encrypted_log_payload.js';
 import { Note } from './payload.js';
 
@@ -51,8 +50,8 @@ export class L1NotePayload {
     }
   }
 
-  static decryptAsIncoming(log: EncryptedL2NoteLog, sk: Fq): L1NotePayload | undefined {
-    const decryptedLog = EncryptedLogPayload.decryptAsIncoming(log.data, sk);
+  static decryptAsIncoming(log: Buffer, sk: Fq): L1NotePayload | undefined {
+    const decryptedLog = EncryptedLogPayload.decryptAsIncoming(log, sk);
     if (!decryptedLog) {
       return undefined;
     }
@@ -63,8 +62,8 @@ export class L1NotePayload {
     );
   }
 
-  static decryptAsOutgoing(log: EncryptedL2NoteLog, sk: Fq): L1NotePayload | undefined {
-    const decryptedLog = EncryptedLogPayload.decryptAsOutgoing(log.data, sk);
+  static decryptAsOutgoing(log: Buffer, sk: Fq): L1NotePayload | undefined {
+    const decryptedLog = EncryptedLogPayload.decryptAsOutgoing(log, sk);
     if (!decryptedLog) {
       return undefined;
     }

--- a/yarn-project/circuit-types/src/logs/l1_payload/l1_note_payload.ts
+++ b/yarn-project/circuit-types/src/logs/l1_payload/l1_note_payload.ts
@@ -63,7 +63,7 @@ export class L1NotePayload {
     sk: Fq,
     // I am aware that having the getter here as quite a trash code but this will be refactored with the big PXE refactor and all
     // the alternatives are bad so I am learning to live with it.
-    numPublicValuesGetter: (contractAddress: AztecAddress) => Promise<number>,
+    numPublicValuesGetter: (contractAddress: AztecAddress, noteTypeId: NoteSelector) => Promise<number>,
   ): Promise<L1NotePayload | undefined> {
     const reader = BufferReader.asReader(log);
 
@@ -118,7 +118,7 @@ export class L1NotePayload {
     log: Buffer,
     sk: Fq, // I am aware that having the getter here as quite a trash code but this will be refactored with the big PXE refactor and all
     // the alternatives are bad so I am learning to live with it.
-    numPublicValuesGetter: (contractAddress: AztecAddress) => Promise<number>,
+    numPublicValuesGetter: (contractAddress: AztecAddress, noteTypeId: NoteSelector) => Promise<number>,
   ): Promise<L1NotePayload | undefined> {
     const reader = BufferReader.asReader(log);
 

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -299,7 +299,7 @@ describe('e2e_block_building', () => {
       // compare logs
       expect(rct.status).toEqual('success');
       const noteValues = tx.noteEncryptedLogs.unrollLogs().map(l => {
-        const notePayload = L1NotePayload.decryptAsIncoming(l, keys.masterIncomingViewingSecretKey);
+        const notePayload = L1NotePayload.decryptAsIncoming(l.data, keys.masterIncomingViewingSecretKey);
         return notePayload?.note.items[0];
       });
       expect(noteValues[0]).toEqual(new Fr(10));

--- a/yarn-project/end-to-end/src/e2e_nft.test.ts
+++ b/yarn-project/end-to-end/src/e2e_nft.test.ts
@@ -70,13 +70,34 @@ describe('NFT', () => {
     const publicOwnerAfter = await nftContractAsUser1.methods.owner_of(TOKEN_ID).simulate();
     expect(publicOwnerAfter).toEqual(AztecAddress.ZERO);
 
-    // We should get 4 data writes setting values to 0 - 3 for note hiding point and 1 for public owner (we transfer
-    // to private so public owner is set to 0). Ideally we would have here only 1 data write as the 4 values change
-    // from zero to non-zero to zero in the tx and hence no write could be committed. This makes public writes
-    // squashing too expensive for transient storage. This however probably does not matter as I assume we will want
-    // to implement a real transient storage anyway. (Informed Leila about the potential optimization.)
+    // We should get 20 data writes setting values to 0 - 3 for note hiding point, 16 for partial log and 1 for public
+    // owner (we transfer to private so public owner is set to 0). Ideally we would have here only 1 data write as the
+    // 4 values change from zero to non-zero to zero in the tx and hence no write could be committed. This makes public
+    // writes squashing too expensive for transient storage. This however probably does not matter as I assume we will
+    // want to implement a real transient storage anyway. (Informed Leila about the potential optimization.)
     const publicDataWritesValues = debugInfo!.publicDataWrites!.map(write => write.newValue.toBigInt());
-    expect(publicDataWritesValues).toEqual([0n, 0n, 0n, 0n]);
+    expect(publicDataWritesValues).toEqual([
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+    ]);
   });
 
   it('transfers in private', async () => {

--- a/yarn-project/foundation/src/serialize/buffer_reader.ts
+++ b/yarn-project/foundation/src/serialize/buffer_reader.ts
@@ -340,6 +340,14 @@ export class BufferReader {
     return this.buffer.length;
   }
 
+  /**
+   * Gets bytes remaining to be read from the buffer.
+   * @returns Bytes remaining to be read from the buffer.
+   */
+  public remainingBytes(): number {
+    return this.buffer.length - this.index;
+  }
+
   #rangeCheck(numBytes: number) {
     if (this.index + numBytes > this.buffer.length) {
       throw new Error(

--- a/yarn-project/pxe/src/note_processor/note_processor.ts
+++ b/yarn-project/pxe/src/note_processor/note_processor.ts
@@ -153,6 +153,10 @@ export class NoteProcessor {
               const incomingNotePayload = L1NotePayload.decryptAsIncoming(log, ivskM);
               const outgoingNotePayload = L1NotePayload.decryptAsOutgoing(log, ovskM);
 
+              if (incomingNotePayload) {
+                console.log("decrypted incoming", incomingNotePayload);
+              }
+
               if (incomingNotePayload || outgoingNotePayload) {
                 if (incomingNotePayload && outgoingNotePayload && !incomingNotePayload.equals(outgoingNotePayload)) {
                   throw new Error(
@@ -366,12 +370,13 @@ export class NoteProcessor {
 /**
  * When a log is emitted via the unencrypted log channel each field contains only 1 byte. OTOH when a log is emitted
  * via the encrypted log channel there are no empty bytes. This function removes the padding bytes.
- * @param unprocessedLog
+ * @param unprocessedLog - Log to be processed.
  * @returns Log with padding bytes removed.
+ * TODO(benesjan): Nuke this once the logs are all refactored.
  */
 function removePaddingBytes(unprocessedLog: Buffer) {
   if (unprocessedLog.length === 640160) {
-    // I have no idea what this log is.
+    // TODO(benejsan): I have no why this monster log appears here and would bother with that only after we have the log refactor.
     return unprocessedLog;
   }
 

--- a/yarn-project/pxe/src/note_processor/utils/get_sorted_nullable_fields.ts
+++ b/yarn-project/pxe/src/note_processor/utils/get_sorted_nullable_fields.ts
@@ -1,0 +1,31 @@
+import { type AztecAddress } from "@aztec/circuits.js";
+import { type PxeDatabase } from "../../database/pxe_database.js";
+import { type NoteField, type NoteSelector } from "@aztec/foundation/abi";
+import { ContractNotFoundError } from "@aztec/simulator";
+
+export async function getSortedNullableFields(db: PxeDatabase, contractAddress: AztecAddress, noteTypeId: NoteSelector): Promise<NoteField[]> {
+    const instance = await db.getContractInstance(contractAddress);
+    if (!instance) {
+      throw new ContractNotFoundError(
+        `Could not find instance for ${contractAddress.toString()}. This should never happen here as the partial notes flow should be triggered only for non-deferred notes.`,
+      );
+    }
+
+    const artifact = await db.getContractArtifact(instance.contractClassId);
+    if (!artifact) {
+      throw new Error(
+        `Could not find artifact for contract class ${instance.contractClassId.toString()}. This should never happen here as the partial notes flow should be triggered only for non-deferred notes.`,
+      );
+    }
+
+    const noteFields = Object.values(artifact.notes).find(note => note.id.equals(noteTypeId))?.fields;
+
+    if (!noteFields) {
+      throw new Error(`Could not find note fields for note type ${noteTypeId.toString()}.`);
+    }
+
+    // We sort note fields by index so that we can iterate over them in order.
+    noteFields.sort((a, b) => a.index - b.index);
+
+    return noteFields;
+}


### PR DESCRIPTION
This PR re-introduces changes reverted in [this PR](https://github.com/AztecProtocol/aztec-packages/pull/8712). There is 1 difference compared to the original code. In the original code we stored number of public values appended and in this PR we store only a flag indicating whether public values were appended. We can afford to do this because now we have information about the public/partial fields in the ABI. This makes it possible to optimize the DA cost further as now we need only 1 bit of info and not a byte.
