### PR TITLE
feat: fee pricing to 0 for old instances

### DIFF
--- a/l1-contracts/src/core/interfaces/IFeeJuicePortal.sol
+++ b/l1-contracts/src/core/interfaces/IFeeJuicePortal.sol
@@ -3,12 +3,20 @@
 pragma solidity >=0.8.27;
 
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+import {IRegistry} from "@aztec/governance/interfaces/IRegistry.sol";
 
 interface IFeeJuicePortal {
+  event DepositToAztecPublic(bytes32 indexed to, uint256 amount, bytes32 secretHash, bytes32 key);
+  event FeesDistributed(address indexed to, uint256 amount);
+
   function initialize() external;
   function distributeFees(address _to, uint256 _amount) external;
   function depositToAztecPublic(bytes32 _to, uint256 _amount, bytes32 _secretHash)
     external
     returns (bytes32);
-  function underlying() external view returns (IERC20);
+  function canonicalRollup() external view returns (address);
+
+  function UNDERLYING() external view returns (IERC20);
+  function L2_TOKEN_ADDRESS() external view returns (bytes32);
+  function REGISTRY() external view returns (IRegistry);
 }

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -72,6 +72,8 @@ library Errors {
   error Rollup__TimestampTooOld(); // 0x72ed9c81
   error Rollup__TryingToProveNonExistingBlock(); // 0x34ef4954
   error Rollup__UnavailableTxs(bytes32 txsHash); // 0x414906c3
+  error Rollup__NonZeroDaFee();
+  error Rollup__NonZeroL2Fee();
 
   //TxsDecoder
   error TxsDecoder__InvalidLogsLength(uint256 expected, uint256 actual); // 0x829ca981

--- a/l1-contracts/src/mock/MockFeeJuicePortal.sol
+++ b/l1-contracts/src/mock/MockFeeJuicePortal.sol
@@ -5,12 +5,15 @@ pragma solidity >=0.8.27;
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 import {IFeeJuicePortal} from "@aztec/core/interfaces/IFeeJuicePortal.sol";
 import {TestERC20} from "@aztec/mock/TestERC20.sol";
+import {IRegistry} from "@aztec/governance/interfaces/IRegistry.sol";
 
 contract MockFeeJuicePortal is IFeeJuicePortal {
-  IERC20 public underlying;
+  IERC20 public immutable UNDERLYING;
+  bytes32 public constant L2_TOKEN_ADDRESS = bytes32(0);
+  IRegistry public constant REGISTRY = IRegistry(address(0));
 
   constructor() {
-    underlying = new TestERC20();
+    UNDERLYING = new TestERC20();
   }
 
   function initialize() external override {}
@@ -19,5 +22,9 @@ contract MockFeeJuicePortal is IFeeJuicePortal {
 
   function depositToAztecPublic(bytes32, uint256, bytes32) external pure override returns (bytes32) {
     return bytes32(0);
+  }
+
+  function canonicalRollup() external pure override returns (address) {
+    return address(0);
   }
 }

--- a/l1-contracts/test/fee_portal/depositToAztecPublic.t.sol
+++ b/l1-contracts/test/fee_portal/depositToAztecPublic.t.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {Registry} from "@aztec/governance/Registry.sol";
+import {TestERC20} from "@aztec/mock/TestERC20.sol";
+import {FeeJuicePortal} from "@aztec/core/FeeJuicePortal.sol";
+import {IFeeJuicePortal} from "@aztec/core/interfaces/IFeeJuicePortal.sol";
+import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
+import {IERC20Errors} from "@oz/interfaces/draft-IERC6093.sol";
+import {Rollup} from "@aztec/core/Rollup.sol";
+import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
+import {Hash} from "@aztec/core/libraries/crypto/Hash.sol";
+import {IInbox} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
+import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
+
+contract DepositToAztecPublic is Test {
+  using Hash for DataStructures.L1ToL2Msg;
+
+  address internal constant OWNER = address(0x1);
+  Registry internal registry;
+  TestERC20 internal token;
+  FeeJuicePortal internal feeJuicePortal;
+  Rollup internal rollup;
+
+  function setUp() public {
+    registry = new Registry(OWNER);
+    token = new TestERC20();
+    feeJuicePortal =
+      new FeeJuicePortal(address(registry), address(token), bytes32(Constants.FEE_JUICE_ADDRESS));
+
+    token.mint(address(feeJuicePortal), Constants.FEE_JUICE_INITIAL_MINT);
+    feeJuicePortal.initialize();
+
+    rollup = new Rollup(feeJuicePortal, bytes32(0), bytes32(0), address(this), new address[](0));
+
+    vm.prank(OWNER);
+    registry.upgrade(address(rollup));
+  }
+
+  function test_RevertGiven_InsufficientBalance() external {
+    // it should revert
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        IERC20Errors.ERC20InsufficientAllowance.selector, address(feeJuicePortal), 0, 1
+      )
+    );
+    feeJuicePortal.depositToAztecPublic(bytes32(0x0), 1, bytes32(0x0));
+
+    token.approve(address(feeJuicePortal), 1);
+    vm.expectRevert(
+      abi.encodeWithSelector(IERC20Errors.ERC20InsufficientBalance.selector, address(this), 0, 1)
+    );
+    feeJuicePortal.depositToAztecPublic(bytes32(0x0), 1, bytes32(0x0));
+  }
+
+  function test_GivenSufficientBalance(uint256 _numberOfRollups) external {
+    // it should create a message for the newest version
+    // it should transfer the tokens to the portal
+    // it should insert the message into the newest inbox
+    // it should emit a {DepositToAztecPublic} event
+    // it should return the key
+
+    uint256 numberOfRollups = bound(_numberOfRollups, 1, 5);
+    for (uint256 i = 0; i < numberOfRollups; i++) {
+      Rollup freshRollup =
+        new Rollup(feeJuicePortal, bytes32(0), bytes32(0), address(this), new address[](0));
+      vm.prank(OWNER);
+      registry.upgrade(address(freshRollup));
+    }
+
+    assertNotEq(registry.getRollup(), address(rollup));
+
+    bytes32 to = bytes32(0x0);
+    bytes32 secretHash = bytes32(uint256(0x01));
+    uint256 amount = 100 ether;
+
+    DataStructures.L1ToL2Msg memory message = DataStructures.L1ToL2Msg({
+      sender: DataStructures.L1Actor(address(feeJuicePortal), block.chainid),
+      recipient: DataStructures.L2Actor(feeJuicePortal.L2_TOKEN_ADDRESS(), 1 + numberOfRollups),
+      content: Hash.sha256ToField(abi.encodeWithSignature("claim(bytes32,uint256)", to, amount)),
+      secretHash: secretHash
+    });
+
+    bytes32 expectedKey = message.sha256ToField();
+
+    token.mint(address(this), amount);
+    token.approve(address(feeJuicePortal), amount);
+
+    Inbox inbox = Inbox(address(Rollup(address(registry.getRollup())).INBOX()));
+    assertEq(inbox.totalMessagesInserted(), 0);
+    uint256 index = 2 ** Constants.L1_TO_L2_MSG_SUBTREE_HEIGHT;
+
+    vm.expectEmit(true, true, true, true, address(inbox));
+    emit IInbox.MessageSent(2, index, expectedKey);
+    vm.expectEmit(true, true, true, true, address(feeJuicePortal));
+    emit IFeeJuicePortal.DepositToAztecPublic(to, amount, secretHash, expectedKey);
+
+    bytes32 key = feeJuicePortal.depositToAztecPublic(to, amount, secretHash);
+
+    assertEq(inbox.totalMessagesInserted(), 1);
+    assertEq(key, expectedKey);
+  }
+}

--- a/l1-contracts/test/fee_portal/depositToAztecPublic.tree
+++ b/l1-contracts/test/fee_portal/depositToAztecPublic.tree
@@ -1,0 +1,9 @@
+DepositToAztecPublic
+├── given insufficient balance
+│   └── it should revert
+└── given sufficient balance
+    ├── it should create a message for the newest version
+    ├── it should transfer the tokens to the portal
+    ├── it should insert the message into the newest inbox
+    ├── it should emit a {DepositToAztecPublic} event
+    └── it should return the key

--- a/l1-contracts/test/fee_portal/distributeFees.t.sol
+++ b/l1-contracts/test/fee_portal/distributeFees.t.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {Registry} from "@aztec/governance/Registry.sol";
+import {TestERC20} from "@aztec/mock/TestERC20.sol";
+import {FeeJuicePortal} from "@aztec/core/FeeJuicePortal.sol";
+import {IFeeJuicePortal} from "@aztec/core/interfaces/IFeeJuicePortal.sol";
+import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
+import {IERC20Errors} from "@oz/interfaces/draft-IERC6093.sol";
+import {Rollup} from "@aztec/core/Rollup.sol";
+import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
+import {Hash} from "@aztec/core/libraries/crypto/Hash.sol";
+import {IInbox} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
+import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+
+contract DistributeFees is Test {
+  using Hash for DataStructures.L1ToL2Msg;
+
+  address internal constant OWNER = address(0x1);
+  Registry internal registry;
+  TestERC20 internal token;
+  FeeJuicePortal internal feeJuicePortal;
+  Rollup internal rollup;
+
+  function setUp() public {
+    registry = new Registry(OWNER);
+    token = new TestERC20();
+    feeJuicePortal =
+      new FeeJuicePortal(address(registry), address(token), bytes32(Constants.FEE_JUICE_ADDRESS));
+    token.mint(address(feeJuicePortal), Constants.FEE_JUICE_INITIAL_MINT);
+    feeJuicePortal.initialize();
+
+    rollup = new Rollup(feeJuicePortal, bytes32(0), bytes32(0), address(this), new address[](0));
+
+    vm.prank(OWNER);
+    registry.upgrade(address(rollup));
+  }
+
+  function test_RevertGiven_TheCallerIsNotTheCanonicalRollup() external {
+    // it should revert
+    vm.expectRevert(abi.encodeWithSelector(Errors.FeeJuicePortal__Unauthorized.selector));
+    feeJuicePortal.distributeFees(address(this), 1);
+  }
+
+  modifier givenTheCallerIsTheCanonicalRollup() {
+    _;
+  }
+
+  function test_RevertGiven_InsufficientBalance() external givenTheCallerIsTheCanonicalRollup {
+    // it should revert
+    vm.prank(address(rollup));
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        IERC20Errors.ERC20InsufficientBalance.selector,
+        address(feeJuicePortal),
+        Constants.FEE_JUICE_INITIAL_MINT,
+        Constants.FEE_JUICE_INITIAL_MINT + 1
+      )
+    );
+    feeJuicePortal.distributeFees(address(this), Constants.FEE_JUICE_INITIAL_MINT + 1);
+  }
+
+  function test_GivenSufficientBalance(uint256 _numberOfRollups)
+    external
+    givenTheCallerIsTheCanonicalRollup
+  {
+    // it should transfer the tokens to the recipient
+    // it should emit a {FeesDistributed} event
+
+    uint256 numberOfRollups = bound(_numberOfRollups, 1, 5);
+    for (uint256 i = 0; i < numberOfRollups; i++) {
+      Rollup freshRollup =
+        new Rollup(feeJuicePortal, bytes32(0), bytes32(0), address(this), new address[](0));
+      vm.prank(OWNER);
+      registry.upgrade(address(freshRollup));
+    }
+
+    assertEq(token.balanceOf(address(this)), 0);
+
+    assertNotEq(registry.getRollup(), address(rollup));
+
+    vm.prank(registry.getRollup());
+    vm.expectEmit(true, true, true, true, address(feeJuicePortal));
+    emit IFeeJuicePortal.FeesDistributed(address(this), Constants.FEE_JUICE_INITIAL_MINT);
+    feeJuicePortal.distributeFees(address(this), Constants.FEE_JUICE_INITIAL_MINT);
+
+    assertEq(token.balanceOf(address(this)), Constants.FEE_JUICE_INITIAL_MINT);
+  }
+}

--- a/l1-contracts/test/fee_portal/distributeFees.tree
+++ b/l1-contracts/test/fee_portal/distributeFees.tree
@@ -1,0 +1,9 @@
+DistributeFees
+├── given the caller is not the canonical rollup
+│   └── it should revert
+└── given the caller is the canonical rollup
+    ├── given insufficient balance
+    │   └── it should revert
+    └── given sufficient balance
+        ├── it should transfer the tokens to the recipient
+        └── it should emit a {FeesDistributed} event

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -43,7 +43,6 @@ import {
   http,
   numberToHex,
   padHex,
-  zeroAddress,
 } from 'viem';
 import { type HDAccount, type PrivateKeyAccount, mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -322,7 +322,6 @@ export const deployL1Contracts = async (
   const deployer = new L1Deployer(walletClient, publicClient, args.salt, logger);
 
   const feeJuicePortalAddress = await deployer.deploy(l1Artifacts.feeJuicePortal, [
-    account.address.toString(),
     registryAddress.toString(),
     feeJuiceAddress.toString(),
     args.l2FeeJuiceAddress.toString(),
@@ -374,7 +373,7 @@ export const deployL1Contracts = async (
   await publicClient.waitForTransactionReceipt({ hash: mintTxHash });
   logger.info(`Funding fee juice portal contract with fee juice in ${mintTxHash}`);
 
-  if ((await feeJuicePortal.read.owner([])) !== zeroAddress) {
+  if (!(await feeJuicePortal.read.initialized([]))) {
     const initPortalTxHash = await feeJuicePortal.write.initialize([]);
     txHashes.push(initPortalTxHash);
     logger.verbose(`Fee juice portal initializing in tx ${initPortalTxHash}`);


### PR DESCRIPTION
Fixes #7938.

Removes the need for the fee to be paid if the instance is not the canonical. The reasoning being that the fee assets in the instance will be unbacked, so it will end up failing if actually trying to exit.

While it is possible to still allow it, and thereby require that people deposit more fees into the system, it does not seem particularly useful, since the fees would be existed as soon as possible by any sequencer in the system with funds in the rollup. 

Essentially, it would degrade to needing to pay fees "outside" of the normal bounds, which could be by instead performing a transfer directly to the `feeRecipient` as part of the fee-paying execution.
