### PR TITLE
feat!: getcontractinstance instruction returns only a specified member

### DIFF
--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -395,9 +395,6 @@ fn handle_foreign_call(
         "avmOpcodeNullifierExists" => handle_nullifier_exists(avm_instrs, destinations, inputs),
         "avmOpcodeL1ToL2MsgExists" => handle_l1_to_l2_msg_exists(avm_instrs, destinations, inputs),
         "avmOpcodeSendL2ToL1Msg" => handle_send_l2_to_l1_msg(avm_instrs, destinations, inputs),
-        "avmOpcodeGetContractInstance" => {
-            handle_get_contract_instance(avm_instrs, destinations, inputs);
-        }
         "avmOpcodeCalldataCopy" => handle_calldata_copy(avm_instrs, destinations, inputs),
         "avmOpcodeReturn" => handle_return(avm_instrs, destinations, inputs),
         "avmOpcodeRevert" => handle_revert(avm_instrs, destinations, inputs),
@@ -407,6 +404,10 @@ fn handle_foreign_call(
         // Getters.
         _ if inputs.is_empty() && destinations.len() == 1 => {
             handle_getter_instruction(avm_instrs, function, destinations, inputs);
+        }
+        // Get contract instance variations.
+        _ if function.starts_with("avmOpcodeGetContractInstance") => {
+            handle_get_contract_instance(avm_instrs, function, destinations, inputs);
         }
         // Anything else.
         _ => panic!("Transpiler doesn't know how to process ForeignCall function {}", function),
@@ -1304,22 +1305,42 @@ fn handle_storage_write(
 /// Emit a GETCONTRACTINSTANCE opcode
 fn handle_get_contract_instance(
     avm_instrs: &mut Vec<AvmInstruction>,
+    function: &str,
     destinations: &Vec<ValueOrArray>,
     inputs: &Vec<ValueOrArray>,
 ) {
+    enum ContractInstanceMember {
+        DEPLOYER,
+        CLASS_ID,
+        INIT_HASH,
+    }
+
     assert!(inputs.len() == 1);
-    assert!(destinations.len() == 1);
+    assert!(destinations.len() == 2);
+
+    let member_idx = match function {
+        "avmOpcodeGetContractInstanceDeployer" => ContractInstanceMember::DEPLOYER,
+        "avmOpcodeGetContractInstanceClassId" => ContractInstanceMember::CLASS_ID,
+        "avmOpcodeGetContractInstanceInitializationHash" => ContractInstanceMember::INIT_HASH,
+        _ => panic!("Transpiler doesn't know how to process function {:?}", function),
+    };
 
     let address_offset_maybe = inputs[0];
     let address_offset = match address_offset_maybe {
-        ValueOrArray::MemoryAddress(slot_offset) => slot_offset,
+        ValueOrArray::MemoryAddress(offset) => offset,
         _ => panic!("GETCONTRACTINSTANCE address should be a single value"),
     };
 
     let dest_offset_maybe = destinations[0];
     let dest_offset = match dest_offset_maybe {
-        ValueOrArray::HeapArray(HeapArray { pointer, .. }) => pointer,
-        _ => panic!("GETCONTRACTINSTANCE destination should be an array"),
+        ValueOrArray::MemoryAddress(offset) => offset,
+        _ => panic!("GETCONTRACTINSTANCE dst destination should be a single value"),
+    };
+
+    let exists_offset_maybe = destinations[1];
+    let exists_offset = match exists_offset_maybe {
+        ValueOrArray::MemoryAddress(offset) => offset,
+        _ => panic!("GETCONTRACTINSTANCE exists destination should be a single value"),
     };
 
     avm_instrs.push(AvmInstruction {
@@ -1327,12 +1348,15 @@ fn handle_get_contract_instance(
         indirect: Some(
             AddressingModeBuilder::default()
                 .direct_operand(&address_offset)
-                .indirect_operand(&dest_offset)
+                .direct_operand(&dest_offset)
+                .direct_operand(&exists_offset)
                 .build(),
         ),
         operands: vec![
-            AvmOperand::U32 { value: address_offset.to_usize() as u32 },
-            AvmOperand::U32 { value: dest_offset.to_usize() as u32 },
+            AvmOperand::U8 { value: member_idx as u8 },
+            AvmOperand::U16 { value: address_offset.to_usize() as u16 },
+            AvmOperand::U16 { value: dest_offset.to_usize() as u16 },
+            AvmOperand::U16 { value: exists_offset.to_usize() as u16 },
         ],
         ..Default::default()
     });

--- a/barretenberg/cpp/pil/avm/main.pil
+++ b/barretenberg/cpp/pil/avm/main.pil
@@ -351,9 +351,8 @@ namespace main(256);
     // op_err * (sel_op_fdiv + sel_op_XXX + ... - 1) == 0
     // Note that the above is even a stronger constraint, as it shows
     // that exactly one sel_op_XXX must be true.
-    // At this time, we have only division producing an error.
     #[SUBOP_ERROR_RELEVANT_OP]
-    op_err * ((sel_op_fdiv + sel_op_div) - 1) = 0;
+    op_err * ((sel_op_fdiv + sel_op_div + sel_op_get_contract_instance) - 1) = 0;
 
     // TODO: constraint that we stop execution at the first error (tag_err or op_err)
     // An error can only happen at the last sub-operation row.

--- a/barretenberg/cpp/src/barretenberg/vm/avm/generated/relations/main.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/generated/relations/main.hpp
@@ -567,7 +567,9 @@ template <typename FF_> class mainImpl {
         }
         {
             using Accumulator = typename std::tuple_element_t<79, ContainerOverSubrelations>;
-            auto tmp = (new_term.main_op_err * ((new_term.main_sel_op_fdiv + new_term.main_sel_op_div) - FF(1)));
+            auto tmp = (new_term.main_op_err * (((new_term.main_sel_op_fdiv + new_term.main_sel_op_div) +
+                                                 new_term.main_sel_op_get_contract_instance) -
+                                                FF(1)));
             tmp *= scaling_factor;
             std::get<79>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/deserialization.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/deserialization.cpp
@@ -136,7 +136,8 @@ const std::unordered_map<OpCode, std::vector<OperandType>> OPCODE_WIRE_FORMAT = 
         OperandType::UINT16,
         /*TODO: leafIndexOffset is not constrained*/ OperandType::UINT16,
         OperandType::UINT16 } },
-    { OpCode::GETCONTRACTINSTANCE, { OperandType::INDIRECT8, OperandType::UINT32, OperandType::UINT32 } },
+    { OpCode::GETCONTRACTINSTANCE,
+      { OperandType::INDIRECT8, OperandType::UINT8, OperandType::UINT16, OperandType::UINT16, OperandType::UINT16 } },
     { OpCode::EMITUNENCRYPTEDLOG,
       {
           OperandType::INDIRECT8,

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/execution.cpp
@@ -604,8 +604,10 @@ std::vector<Row> Execution::gen_trace(std::vector<FF> const& calldata,
             break;
         case OpCode::GETCONTRACTINSTANCE:
             trace_builder.op_get_contract_instance(std::get<uint8_t>(inst.operands.at(0)),
-                                                   std::get<uint32_t>(inst.operands.at(1)),
-                                                   std::get<uint32_t>(inst.operands.at(2)));
+                                                   std::get<uint8_t>(inst.operands.at(1)),
+                                                   std::get<uint16_t>(inst.operands.at(2)),
+                                                   std::get<uint16_t>(inst.operands.at(3)),
+                                                   std::get<uint16_t>(inst.operands.at(4)));
             break;
 
             // Accrued Substate

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/opcode.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/opcode.hpp
@@ -128,6 +128,14 @@ enum class EnvironmentVariable {
     MAX_ENV_VAR
 };
 
+enum class ContractInstanceMember {
+    DEPLOYER,
+    CLASS_ID,
+    INIT_HASH,
+    // sentinel
+    MAX_MEMBER,
+};
+
 class Bytecode {
   public:
     static bool is_valid(uint8_t byte);

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.hpp
@@ -113,7 +113,8 @@ class AvmTraceBuilder {
                                 uint32_t log_offset,
                                 uint32_t leaf_index_offset,
                                 uint32_t dest_offset);
-    void op_get_contract_instance(uint8_t indirect, uint32_t address_offset, uint32_t dst_offset);
+    void op_get_contract_instance(
+        uint8_t indirect, uint8_t member_enum, uint16_t address_offset, uint16_t dst_offset, uint16_t exists_offset);
 
     // Accrued Substate
     void op_emit_unencrypted_log(uint8_t indirect, uint32_t log_offset, uint32_t log_size_offset);

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -215,9 +215,9 @@ unconstrained fn portal() -> EthAddress {
     portal_opcode()
 }
 // TODO(9396): Remove.
-unconstrained fn function_selector() -> u32 {
-    function_selector_opcode()
-}
+//unconstrained fn function_selector() -> u32 {
+//    function_selector_opcode()
+//}
 unconstrained fn transaction_fee() -> Field {
     transaction_fee_opcode()
 }
@@ -327,8 +327,8 @@ unconstrained fn sender_opcode() -> AztecAddress {}
 unconstrained fn portal_opcode() -> EthAddress {}
 
 // TODO(9396): Remove.
-#[oracle(avmOpcodeFunctionSelector)]
-unconstrained fn function_selector_opcode() -> u32 {}
+//#[oracle(avmOpcodeFunctionSelector)]
+//unconstrained fn function_selector_opcode() -> u32 {}
 
 #[oracle(avmOpcodeTransactionFee)]
 unconstrained fn transaction_fee_opcode() -> Field {}

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -210,13 +210,14 @@ unconstrained fn address() -> AztecAddress {
 unconstrained fn sender() -> AztecAddress {
     sender_opcode()
 }
+// TODO(9396): Remove.
 unconstrained fn portal() -> EthAddress {
     portal_opcode()
 }
-// UNUSED: Remove.
-// unconstrained fn function_selector() -> u32 {
-//     function_selector_opcode()
-// }
+// TODO(9396): Remove.
+unconstrained fn function_selector() -> u32 {
+    function_selector_opcode()
+}
 unconstrained fn transaction_fee() -> Field {
     transaction_fee_opcode()
 }
@@ -325,9 +326,9 @@ unconstrained fn sender_opcode() -> AztecAddress {}
 #[oracle(avmOpcodePortal)]
 unconstrained fn portal_opcode() -> EthAddress {}
 
-// UNUSED: Remove.
-// #[oracle(avmOpcodeFunctionSelector)]
-// unconstrained fn function_selector_opcode() -> u32 {}
+// TODO(9396): Remove.
+#[oracle(avmOpcodeFunctionSelector)]
+unconstrained fn function_selector_opcode() -> u32 {}
 
 #[oracle(avmOpcodeTransactionFee)]
 unconstrained fn transaction_fee_opcode() -> Field {}

--- a/noir-projects/aztec-nr/aztec/src/initializer.nr
+++ b/noir-projects/aztec-nr/aztec/src/initializer.nr
@@ -6,8 +6,8 @@ use dep::protocol_types::{
 use crate::{
     context::{PrivateContext, PublicContext},
     oracle::get_contract_instance::{
-        get_contract_instance,
-        get_contract_instance_deployer_avm, get_contract_instance_initialization_hash_avm,
+        get_contract_instance, get_contract_instance_deployer_avm,
+        get_contract_instance_initialization_hash_avm,
     },
 };
 

--- a/noir-projects/aztec-nr/aztec/src/initializer.nr
+++ b/noir-projects/aztec-nr/aztec/src/initializer.nr
@@ -5,7 +5,10 @@ use dep::protocol_types::{
 
 use crate::{
     context::{PrivateContext, PublicContext},
-    oracle::get_contract_instance::{get_contract_instance, get_contract_instance_avm},
+    oracle::get_contract_instance::{
+        get_contract_instance,
+        get_contract_instance_deployer_avm, get_contract_instance_initialization_hash_avm,
+    },
 };
 
 pub fn mark_as_initialized_public(context: &mut PublicContext) {
@@ -36,11 +39,12 @@ fn compute_unsiloed_contract_initialization_nullifier(address: AztecAddress) -> 
 
 pub fn assert_initialization_matches_address_preimage_public(context: PublicContext) {
     let address = context.this_address();
-    let instance = get_contract_instance_avm(address).unwrap();
+    let deployer = get_contract_instance_deployer_avm(address).unwrap();
+    let initialization_hash = get_contract_instance_initialization_hash_avm(address).unwrap();
     let expected_init = compute_initialization_hash(context.selector(), context.get_args_hash());
-    assert(instance.initialization_hash == expected_init, "Initialization hash does not match");
+    assert(initialization_hash == expected_init, "Initialization hash does not match");
     assert(
-        (instance.deployer.is_zero()) | (instance.deployer == context.msg_sender()),
+        (deployer.is_zero()) | (deployer == context.msg_sender()),
         "Initializer address is not the contract deployer",
     );
 }

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_contract_instance.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_contract_instance.nr
@@ -1,31 +1,22 @@
 use dep::protocol_types::{
-    address::AztecAddress, constants::CONTRACT_INSTANCE_LENGTH, contract_instance::ContractInstance,
-    utils::reader::Reader,
+    address::AztecAddress, contract_class_id::ContractClassId, contract_instance::ContractInstance,
+    constants::CONTRACT_INSTANCE_LENGTH,
 };
 
+// NOTE: this is for use in private only
 #[oracle(getContractInstance)]
 unconstrained fn get_contract_instance_oracle(
     _address: AztecAddress,
 ) -> [Field; CONTRACT_INSTANCE_LENGTH] {}
 
-// Returns a ContractInstance plus a boolean indicating whether the instance was found.
-#[oracle(avmOpcodeGetContractInstance)]
-unconstrained fn get_contract_instance_oracle_avm(
-    _address: AztecAddress,
-) -> [Field; CONTRACT_INSTANCE_LENGTH + 1] {}
-
+// NOTE: this is for use in private only
 unconstrained fn get_contract_instance_internal(
     address: AztecAddress,
 ) -> [Field; CONTRACT_INSTANCE_LENGTH] {
     get_contract_instance_oracle(address)
 }
 
-pub unconstrained fn get_contract_instance_internal_avm(
-    address: AztecAddress,
-) -> [Field; CONTRACT_INSTANCE_LENGTH + 1] {
-    get_contract_instance_oracle_avm(address)
-}
-
+// NOTE: this is for use in private only
 pub fn get_contract_instance(address: AztecAddress) -> ContractInstance {
     let instance =
         unsafe { ContractInstance::deserialize(get_contract_instance_internal(address)) };
@@ -36,12 +27,58 @@ pub fn get_contract_instance(address: AztecAddress) -> ContractInstance {
     instance
 }
 
-pub fn get_contract_instance_avm(address: AztecAddress) -> Option<ContractInstance> {
-    let mut reader = Reader::new(get_contract_instance_internal_avm(address));
-    let found = reader.read();
-    if found == 0 {
-        Option::none()
+// These oracles each return a ContractInstance member
+// plus a boolean indicating whether the instance was found.
+#[oracle(avmOpcodeGetContractInstanceDeployer)]
+unconstrained fn get_contract_instance_deployer_oracle_avm(
+    _address: AztecAddress,
+) -> (Field, bool) {}
+#[oracle(avmOpcodeGetContractInstanceClassId)]
+unconstrained fn get_contract_instance_class_id_oracle_avm(
+    _address: AztecAddress,
+) -> (Field, bool) {}
+#[oracle(avmOpcodeGetContractInstanceInitializationHash)]
+unconstrained fn get_contract_instance_initialization_hash_oracle_avm(
+    _address: AztecAddress,
+) -> (Field, bool) {}
+
+pub unconstrained fn get_contract_instance_deployer_internal_avm(
+    address: AztecAddress,
+) -> (Field, bool) {
+    get_contract_instance_deployer_oracle_avm(address)
+}
+pub unconstrained fn get_contract_instance_class_id_internal_avm(
+    address: AztecAddress,
+) -> (Field, bool) {
+    get_contract_instance_class_id_oracle_avm(address)
+}
+pub unconstrained fn get_contract_instance_initialization_hash_internal_avm(
+    address: AztecAddress,
+) -> (Field, bool) {
+    get_contract_instance_initialization_hash_oracle_avm(address)
+}
+
+pub fn get_contract_instance_deployer_avm(address: AztecAddress) -> Option<AztecAddress> {
+    let (member, exists) = get_contract_instance_deployer_internal_avm(address);
+    if exists {
+        Option::some(AztecAddress::from_field(member))
     } else {
-        Option::some(reader.read_struct(ContractInstance::deserialize))
+        Option::none()
+    }
+}
+pub fn get_contract_instance_class_id_avm(address: AztecAddress) -> Option<ContractClassId> {
+    let (member, exists) = get_contract_instance_class_id_internal_avm(address);
+    if exists {
+        Option::some(ContractClassId::from_field(member))
+    } else {
+        Option::none()
+    }
+}
+pub fn get_contract_instance_initialization_hash_avm(address: AztecAddress) -> Option<Field> {
+    let (member, exists) = get_contract_instance_initialization_hash_internal_avm(address);
+    if exists {
+        Option::some(member)
+    } else {
+        Option::none()
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_contract_instance.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_contract_instance.nr
@@ -1,6 +1,6 @@
 use dep::protocol_types::{
-    address::AztecAddress, contract_class_id::ContractClassId, contract_instance::ContractInstance,
-    constants::CONTRACT_INSTANCE_LENGTH,
+    address::AztecAddress, constants::CONTRACT_INSTANCE_LENGTH, contract_class_id::ContractClassId,
+    contract_instance::ContractInstance,
 };
 
 // NOTE: this is for use in private only

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -32,11 +32,13 @@ contract AvmTest {
     use dep::aztec::context::gas::GasOpts;
     use dep::aztec::macros::{functions::{private, public}, storage::storage};
     use dep::aztec::oracle::get_contract_instance::{
-        get_contract_instance_avm, get_contract_instance_internal_avm,
+        get_contract_instance_class_id_avm, get_contract_instance_deployer_avm,
+        get_contract_instance_initialization_hash_avm,
     };
     use dep::aztec::prelude::Map;
     use dep::aztec::protocol_types::{
-        abis::function_selector::FunctionSelector, storage::map::derive_storage_slot_in_map,
+        abis::function_selector::FunctionSelector, contract_class_id::ContractClassId,
+        storage::map::derive_storage_slot_in_map,
     };
     use dep::aztec::protocol_types::{
         address::{AztecAddress, EthAddress},
@@ -297,33 +299,46 @@ contract AvmTest {
      * Contract instance
      ************************************************************************/
     #[public]
-    fn test_get_contract_instance_raw() {
-        let fields = get_contract_instance_internal_avm(context.this_address());
-        // The values here should match those in `avm_simulator.test.ts>Contract>GETCONTRACTINSTANCE deserializes correctly`
-        assert(fields.len() == CONTRACT_INSTANCE_LENGTH + 1);
-        assert(fields[0] == 0x1);
-        assert(fields[1] == 0x123);
-        assert(fields[2] == 0x456);
-        assert(fields[3] == 0x789);
-        assert(fields[4] == 0x101112);
-        assert(fields[5] == 0x131415);
-        assert(fields[6] == 0x161718);
-        assert(fields[7] == 0x00);
-        assert(fields[8] == 0x192021);
-        assert(fields[9] == 0x222324);
-        assert(fields[10] == 0x00);
-        assert(fields[11] == 0x252627);
-        assert(fields[12] == 0x282930);
-        assert(fields[13] == 0x00);
-        assert(fields[14] == 0x313233);
-        assert(fields[15] == 0x343536);
-        assert(fields[16] == 0x00);
+    fn test_get_contract_instance(address: AztecAddress) {
+        let deployer = get_contract_instance_deployer_avm(address);
+        let class_id = get_contract_instance_class_id_avm(address);
+        let initialization_hash = get_contract_instance_initialization_hash_avm(address);
+
+        assert(deployer.is_some(), "Contract instance not found when getting DEPLOYER!");
+        assert(class_id.is_some(), "Contract instance not found when getting CLASS_ID!");
+        assert(
+            initialization_hash.is_some(),
+            "Contract instance not found when getting INIT_HASH!",
+        );
+
+        // The values here should match those in `avm_simulator.test.ts`
+        assert(deployer.unwrap().eq(AztecAddress::from_field(0x456)));
+        assert(class_id.unwrap().eq(ContractClassId::from_field(0x789)));
+        assert(initialization_hash.unwrap() == 0x101112);
     }
 
     #[public]
-    fn test_get_contract_instance() {
-        let ci = get_contract_instance_avm(context.this_address());
-        assert(ci.is_some(), "Contract instance not found!");
+    fn test_get_contract_instance_matches(
+        address: AztecAddress,
+        expected_deployer: AztecAddress,
+        expected_class_id: ContractClassId,
+        expected_initialization_hash: Field,
+    ) {
+        let deployer = get_contract_instance_deployer_avm(address);
+        let class_id = get_contract_instance_class_id_avm(address);
+        let initialization_hash = get_contract_instance_initialization_hash_avm(address);
+
+        assert(deployer.is_some(), "Contract instance not found when getting DEPLOYER!");
+        assert(class_id.is_some(), "Contract instance not found when getting CLASS_ID!");
+        assert(
+            initialization_hash.is_some(),
+            "Contract instance not found when getting INIT_HASH!",
+        );
+
+        // The values here should match those in `avm_simulator.test.ts`
+        assert(deployer.unwrap().eq(expected_deployer));
+        assert(class_id.unwrap().eq(expected_class_id));
+        assert(initialization_hash.unwrap().eq(expected_initialization_hash));
     }
 
     /************************************************************************
@@ -563,7 +578,7 @@ contract AvmTest {
         dep::aztec::oracle::debug_log::debug_log("pedersen_hash_with_index");
         let _ = pedersen_hash_with_index(args_field);
         dep::aztec::oracle::debug_log::debug_log("test_get_contract_instance");
-        test_get_contract_instance();
+        test_get_contract_instance(context.this_address());
         dep::aztec::oracle::debug_log::debug_log("get_address");
         let _ = get_address();
         dep::aztec::oracle::debug_log::debug_log("get_sender");

--- a/yarn-project/bb-prover/src/avm_proving.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving.test.ts
@@ -91,7 +91,9 @@ const proveAndVerifyAvmTestContract = async (
 
   worldStateDB.getContractInstance
     .mockResolvedValueOnce(contractInstance)
-    .mockResolvedValueOnce(instanceGet)
+    .mockResolvedValueOnce(instanceGet) // test gets deployer
+    .mockResolvedValueOnce(instanceGet) // test gets class id
+    .mockResolvedValueOnce(instanceGet) // test gets init hash
     .mockResolvedValue(contractInstance);
   worldStateDB.getContractClass.mockResolvedValue(contractClass);
 

--- a/yarn-project/bb-prover/src/avm_proving.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving.test.ts
@@ -66,6 +66,7 @@ const proveAndVerifyAvmTestContract = async (
   globals.timestamp = TIMESTAMP;
 
   const worldStateDB = mock<WorldStateDB>();
+  //
   // Top level contract call
   const bytecode = getAvmTestContractBytecode('public_dispatch');
   const fnSelector = getAvmTestContractFunctionSelector('public_dispatch');
@@ -73,6 +74,7 @@ const proveAndVerifyAvmTestContract = async (
   const contractClass = makeContractClassPublic(0, publicFn);
   const contractInstance = makeContractInstanceFromClassId(contractClass.id);
 
+  // The values here should match those in `avm_simulator.test.ts`
   const instanceGet = new SerializableContractInstance({
     version: 1,
     salt: new Fr(0x123),

--- a/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
+++ b/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
@@ -95,7 +95,15 @@ describe('e2e_avm_simulator', () => {
 
     describe('Contract instance', () => {
       it('Works', async () => {
-        const tx = await avmContract.methods.test_get_contract_instance().send().wait();
+        const tx = await avmContract.methods
+          .test_get_contract_instance_matches(
+            avmContract.address,
+            avmContract.instance.deployer,
+            avmContract.instance.contractClassId,
+            avmContract.instance.initializationHash,
+          )
+          .send()
+          .wait();
         expect(tx.status).toEqual(TxStatus.SUCCESS);
       });
     });

--- a/yarn-project/ivc-integration/src/avm_integration.test.ts
+++ b/yarn-project/ivc-integration/src/avm_integration.test.ts
@@ -183,7 +183,9 @@ const proveAvmTestContract = async (
 
   worldStateDB.getContractInstance
     .mockResolvedValueOnce(contractInstance)
-    .mockResolvedValueOnce(instanceGet)
+    .mockResolvedValueOnce(instanceGet) // test gets deployer
+    .mockResolvedValueOnce(instanceGet) // test gets class id
+    .mockResolvedValueOnce(instanceGet) // test gets init hash
     .mockResolvedValue(contractInstance);
 
   worldStateDB.getContractClass.mockResolvedValue(contractClass);

--- a/yarn-project/simulator/src/avm/journal/journal.test.ts
+++ b/yarn-project/simulator/src/avm/journal/journal.test.ts
@@ -1,4 +1,3 @@
-import { randomContractInstanceWithAddress } from '@aztec/circuit-types';
 import { SerializableContractInstance } from '@aztec/circuits.js';
 import { Fr } from '@aztec/foundation/fields';
 
@@ -147,18 +146,17 @@ describe('journal', () => {
 
   describe('Getting contract instances', () => {
     it('Should get contract instance', async () => {
-      const contractInstance = randomContractInstanceWithAddress(/*(base instance) opts=*/ {}, /*address=*/ address);
-      mockGetContractInstance(worldStateDB, contractInstance);
+      const contractInstance = SerializableContractInstance.default();
+      mockGetContractInstance(worldStateDB, contractInstance.withAddress(address));
+      mockGetContractInstance(worldStateDB, contractInstance.withAddress(address));
       await persistableState.getContractInstance(address);
       expect(trace.traceGetContractInstance).toHaveBeenCalledTimes(1);
-      expect(trace.traceGetContractInstance).toHaveBeenCalledWith({ exists: true, ...contractInstance });
+      expect(trace.traceGetContractInstance).toHaveBeenCalledWith(address, /*exists=*/ true, contractInstance);
     });
     it('Can get undefined contract instance', async () => {
-      const defaultContractInstance = SerializableContractInstance.default().withAddress(address);
       await persistableState.getContractInstance(address);
-
       expect(trace.traceGetContractInstance).toHaveBeenCalledTimes(1);
-      expect(trace.traceGetContractInstance).toHaveBeenCalledWith({ exists: false, ...defaultContractInstance });
+      expect(trace.traceGetContractInstance).toHaveBeenCalledWith(address, /*exists=*/ false);
     });
   });
 

--- a/yarn-project/simulator/src/avm/opcodes/contract.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/contract.test.ts
@@ -1,19 +1,22 @@
-import { randomContractInstanceWithAddress } from '@aztec/circuit-types';
-import { AztecAddress, PublicKeys, SerializableContractInstance } from '@aztec/circuits.js';
+import { Fr, SerializableContractInstance } from '@aztec/circuits.js';
 
 import { mock } from 'jest-mock-extended';
 
 import { type WorldStateDB } from '../../public/public_db_sources.js';
 import { type PublicSideEffectTraceInterface } from '../../public/side_effect_trace_interface.js';
 import { type AvmContext } from '../avm_context.js';
-import { Field } from '../avm_memory_types.js';
+import { Field, TypeTag, Uint1 } from '../avm_memory_types.js';
 import { initContext, initPersistableStateManager } from '../fixtures/index.js';
 import { type AvmPersistableStateManager } from '../journal/journal.js';
 import { mockGetContractInstance } from '../test_utils.js';
-import { GetContractInstance } from './contract.js';
+import { ContractInstanceMember, GetContractInstance } from './contract.js';
 
 describe('Contract opcodes', () => {
-  const address = AztecAddress.random();
+  const address = Fr.random();
+  const contractInstance = SerializableContractInstance.random();
+  const deployer = contractInstance.deployer;
+  const contractClassId = contractInstance.contractClassId;
+  const initializationHash = contractInstance.initializationHash;
 
   let worldStateDB: WorldStateDB;
   let trace: PublicSideEffectTraceInterface;
@@ -32,61 +35,102 @@ describe('Contract opcodes', () => {
       const buf = Buffer.from([
         GetContractInstance.opcode, // opcode
         0x01, // indirect
-        ...Buffer.from('12345678', 'hex'), // addressOffset
-        ...Buffer.from('a2345678', 'hex'), // dstOffset
+        0x02, // memberEnum (immediate)
+        ...Buffer.from('1234', 'hex'), // addressOffset
+        ...Buffer.from('a234', 'hex'), // dstOffset
+        ...Buffer.from('b234', 'hex'), // existsOffset
       ]);
       const inst = new GetContractInstance(
         /*indirect=*/ 0x01,
-        /*addressOffset=*/ 0x12345678,
-        /*dstOffset=*/ 0xa2345678,
+        /*memberEnum=*/ 0x02,
+        /*addressOffset=*/ 0x1234,
+        /*dstOffset=*/ 0xa234,
+        /*existsOffset=*/ 0xb234,
       );
 
       expect(GetContractInstance.deserialize(buf)).toEqual(inst);
       expect(inst.serialize()).toEqual(buf);
     });
 
-    it('should copy contract instance to memory if found', async () => {
-      const contractInstance = randomContractInstanceWithAddress(/*(base instance) opts=*/ {}, /*address=*/ address);
-      mockGetContractInstance(worldStateDB, contractInstance);
+    describe.each([
+      [ContractInstanceMember.DEPLOYER, deployer.toField()],
+      [ContractInstanceMember.CLASS_ID, contractClassId.toField()],
+      [ContractInstanceMember.INIT_HASH, initializationHash.toField()],
+    ])('GETCONTRACTINSTANCE member instruction ', (memberEnum: ContractInstanceMember, value: Fr) => {
+      it(`Should read '${ContractInstanceMember[memberEnum]}' correctly`, async () => {
+        mockGetContractInstance(worldStateDB, contractInstance.withAddress(address));
 
-      context.machineState.memory.set(0, new Field(address.toField()));
-      await new GetContractInstance(/*indirect=*/ 0, /*addressOffset=*/ 0, /*dstOffset=*/ 1).execute(context);
+        context.machineState.memory.set(0, new Field(address));
+        await new GetContractInstance(
+          /*indirect=*/ 0,
+          memberEnum,
+          /*addressOffset=*/ 0,
+          /*dstOffset=*/ 1,
+          /*existsOffset=*/ 2,
+        ).execute(context);
 
-      const actual = context.machineState.memory.getSlice(1, 17);
+        // value should be right
+        expect(context.machineState.memory.getTag(1)).toBe(TypeTag.FIELD);
+        const actual = context.machineState.memory.get(1);
+        expect(actual).toEqual(new Field(value));
 
-      expect(actual).toEqual([
-        new Field(1), // found
-        new Field(contractInstance.salt),
-        new Field(contractInstance.deployer),
-        new Field(contractInstance.contractClassId),
-        new Field(contractInstance.initializationHash),
-        ...contractInstance.publicKeys.toFields().map(f => new Field(f)),
-      ]);
+        // exists should be true
+        expect(context.machineState.memory.getTag(2)).toBe(TypeTag.UINT1);
+        const exists = context.machineState.memory.get(2);
+        expect(exists).toEqual(new Uint1(1));
 
-      expect(trace.traceGetContractInstance).toHaveBeenCalledTimes(1);
-      expect(trace.traceGetContractInstance).toHaveBeenCalledWith({ exists: true, ...contractInstance });
+        expect(trace.traceGetContractInstance).toHaveBeenCalledTimes(1);
+        expect(trace.traceGetContractInstance).toHaveBeenCalledWith(address, /*exists=*/ true, contractInstance);
+      });
     });
 
-    it('should return zeroes if not found', async () => {
-      const defaultContractInstance = SerializableContractInstance.default().withAddress(address);
-      context.machineState.memory.set(0, new Field(address.toField()));
+    describe.each([
+      [ContractInstanceMember.DEPLOYER],
+      [ContractInstanceMember.CLASS_ID],
+      [ContractInstanceMember.INIT_HASH],
+    ])(
+      'GETCONTRACTINSTANCE member instruction works when contract does not exist',
+      (memberEnum: ContractInstanceMember) => {
+        it(`'${ContractInstanceMember[memberEnum]}' should be 0 when contract does not exist `, async () => {
+          context.machineState.memory.set(0, new Field(address));
+          await new GetContractInstance(
+            /*indirect=*/ 0,
+            memberEnum,
+            /*addressOffset=*/ 0,
+            /*dstOffset=*/ 1,
+            /*existsOffset=*/ 2,
+          ).execute(context);
 
-      await new GetContractInstance(/*indirect=*/ 0, /*addressOffset=*/ 0, /*dstOffset=*/ 1).execute(context);
+          // value should be 0
+          expect(context.machineState.memory.getTag(1)).toBe(TypeTag.FIELD);
+          const actual = context.machineState.memory.get(1);
+          expect(actual).toEqual(new Field(0));
 
-      const actual = context.machineState.memory.getSlice(1, 17);
-      expect(actual).toEqual([
-        new Field(0), // found
-        new Field(0),
-        new Field(0),
-        new Field(0),
-        new Field(0),
-        ...PublicKeys.default()
-          .toFields()
-          .map(f => new Field(f)),
-      ]);
+          // exists should be false
+          expect(context.machineState.memory.getTag(2)).toBe(TypeTag.UINT1);
+          const exists = context.machineState.memory.get(2);
+          expect(exists).toEqual(new Uint1(0));
 
-      expect(trace.traceGetContractInstance).toHaveBeenCalledTimes(1);
-      expect(trace.traceGetContractInstance).toHaveBeenCalledWith({ exists: false, ...defaultContractInstance });
+          expect(trace.traceGetContractInstance).toHaveBeenCalledTimes(1);
+          expect(trace.traceGetContractInstance).toHaveBeenCalledWith(address, /*exists=*/ false);
+        });
+      },
+    );
+
+    it(`GETCONTRACTINSTANCE reverts for bad enum operand`, async () => {
+      const invalidEnum = 255;
+      const instruction = new GetContractInstance(
+        /*indirect=*/ 0,
+        /*memberEnum=*/ invalidEnum,
+        /*addressOffset=*/ 0,
+        /*dstOffset=*/ 1,
+        /*existsOffset=*/ 2,
+      );
+      await expect(instruction.execute(context)).rejects.toThrow(
+        `Invalid GETCONSTRACTINSTANCE member enum ${invalidEnum}`,
+      );
+
+      expect(trace.traceGetContractInstance).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/yarn-project/simulator/src/avm/opcodes/environment_getters.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/environment_getters.test.ts
@@ -83,4 +83,10 @@ describe('Environment getters', () => {
       expect(actual).toEqual(value);
     });
   });
+
+  it(`GETENVVAR reverts for bad enum operand`, async () => {
+    const invalidEnum = 255;
+    const instruction = new GetEnvVar(/*indirect=*/ 0, invalidEnum, /*dstOffset=*/ 0);
+    await expect(instruction.execute(context)).rejects.toThrowError(`Invalid GETENVVAR var enum ${invalidEnum}`);
+  });
 });

--- a/yarn-project/simulator/src/public/dual_side_effect_trace.ts
+++ b/yarn-project/simulator/src/public/dual_side_effect_trace.ts
@@ -1,9 +1,9 @@
-import type {
-  CombinedConstantData,
-  ContractClassIdPreimage,
-  ContractInstanceWithAddress,
-  Gas,
-  VMCircuitPublicInputs,
+import {
+  type CombinedConstantData,
+  type ContractClassIdPreimage,
+  type Gas,
+  type SerializableContractInstance,
+  type VMCircuitPublicInputs,
 } from '@aztec/circuits.js';
 import { type Fr } from '@aztec/foundation/fields';
 
@@ -15,8 +15,6 @@ import { type PublicEnqueuedCallSideEffectTrace } from './enqueued_call_side_eff
 import { type PublicExecutionResult } from './execution.js';
 import { type PublicSideEffectTrace } from './side_effect_trace.js';
 import { type PublicSideEffectTraceInterface } from './side_effect_trace_interface.js';
-
-export type TracedContractInstance = { exists: boolean } & ContractInstanceWithAddress;
 
 export class DualSideEffectTrace implements PublicSideEffectTraceInterface {
   constructor(
@@ -31,15 +29,6 @@ export class DualSideEffectTrace implements PublicSideEffectTraceInterface {
   public getCounter() {
     assert(this.innerCallTrace.getCounter() == this.enqueuedCallTrace.getCounter());
     return this.innerCallTrace.getCounter();
-  }
-
-  public traceGetBytecode(
-    bytecode: Buffer,
-    contractInstance: TracedContractInstance,
-    contractClass: ContractClassIdPreimage,
-  ) {
-    this.innerCallTrace.traceGetBytecode(bytecode, contractInstance, contractClass);
-    this.enqueuedCallTrace.traceGetBytecode(bytecode, contractInstance, contractClass);
   }
 
   public tracePublicStorageRead(contractAddress: Fr, slot: Fr, value: Fr, exists: boolean, cached: boolean) {
@@ -88,9 +77,24 @@ export class DualSideEffectTrace implements PublicSideEffectTraceInterface {
     this.enqueuedCallTrace.traceUnencryptedLog(contractAddress, log);
   }
 
-  public traceGetContractInstance(instance: TracedContractInstance) {
-    this.innerCallTrace.traceGetContractInstance(instance);
-    this.enqueuedCallTrace.traceGetContractInstance(instance);
+  public traceGetContractInstance(
+    contractAddress: Fr,
+    exists: boolean,
+    instance: SerializableContractInstance | undefined,
+  ) {
+    this.innerCallTrace.traceGetContractInstance(contractAddress, exists, instance);
+    this.enqueuedCallTrace.traceGetContractInstance(contractAddress, exists, instance);
+  }
+
+  public traceGetBytecode(
+    contractAddress: Fr,
+    exists: boolean,
+    bytecode: Buffer,
+    contractInstance: SerializableContractInstance | undefined,
+    contractClass: ContractClassIdPreimage | undefined,
+  ) {
+    this.innerCallTrace.traceGetBytecode(contractAddress, exists, bytecode, contractInstance, contractClass);
+    this.enqueuedCallTrace.traceGetBytecode(contractAddress, exists, bytecode, contractInstance, contractClass);
   }
 
   /**

--- a/yarn-project/simulator/src/public/enqueued_call_side_effect_trace.test.ts
+++ b/yarn-project/simulator/src/public/enqueued_call_side_effect_trace.test.ts
@@ -34,14 +34,8 @@ import { randomBytes, randomInt } from 'crypto';
 
 import { AvmContractCallResult } from '../avm/avm_contract_call_result.js';
 import { initExecutionEnvironment } from '../avm/fixtures/index.js';
-import { PublicEnqueuedCallSideEffectTrace, type TracedContractInstance } from './enqueued_call_side_effect_trace.js';
+import { PublicEnqueuedCallSideEffectTrace } from './enqueued_call_side_effect_trace.js';
 import { SideEffectLimitReachedError } from './side_effect_errors.js';
-
-function randomTracedContractInstance(): TracedContractInstance {
-  const instance = SerializableContractInstance.random();
-  const address = AztecAddress.random();
-  return { exists: true, ...instance, address };
-}
 
 describe('Enqueued-call Side Effect Trace', () => {
   const address = Fr.random();
@@ -52,7 +46,7 @@ describe('Enqueued-call Side Effect Trace', () => {
   const recipient = Fr.random();
   const content = Fr.random();
   const log = [Fr.random(), Fr.random(), Fr.random()];
-  const contractInstance = SerializableContractInstance.default().withAddress(new Fr(42));
+  const contractInstance = SerializableContractInstance.default();
 
   const startGasLeft = Gas.fromFields([new Fr(randomInt(10000)), new Fr(randomInt(10000))]);
   const endGasLeft = Gas.fromFields([new Fr(randomInt(10000)), new Fr(randomInt(10000))]);
@@ -234,18 +228,18 @@ describe('Enqueued-call Side Effect Trace', () => {
   });
 
   it('Should trace get contract instance', () => {
-    const instance = randomTracedContractInstance();
+    const instance = SerializableContractInstance.random();
     const { version: _, ...instanceWithoutVersion } = instance;
-    trace.traceGetContractInstance(instance);
+    const exists = true;
+    trace.traceGetContractInstance(address, exists, instance);
     expect(trace.getCounter()).toBe(startCounterPlus1);
 
     //const circuitPublicInputs = toVMCircuitPublicInputs(trace);
-    // TODO(dbanks12): once this emits nullifier read, check here
     expect(trace.getAvmCircuitHints().contractInstances.items).toEqual([
       {
-        // hint omits "version" and has "exists" as an Fr
+        address,
+        exists,
         ...instanceWithoutVersion,
-        exists: instance.exists,
       },
     ]);
   });
@@ -348,11 +342,11 @@ describe('Enqueued-call Side Effect Trace', () => {
       for (let i = 0; i < MAX_NULLIFIER_READ_REQUESTS_PER_TX; i++) {
         trace.traceNullifierCheck(new Fr(i), new Fr(i), new Fr(i), true, true);
       }
-      expect(() => trace.traceGetContractInstance({ ...contractInstance, exists: true })).toThrow(
+      expect(() => trace.traceGetContractInstance(address, /*exists=*/ true, contractInstance)).toThrow(
         SideEffectLimitReachedError,
       );
       // NOTE: also cannot do a existent check once non-existent checks have filled up
-      expect(() => trace.traceGetContractInstance({ ...contractInstance, exists: false })).toThrow(
+      expect(() => trace.traceGetContractInstance(address, /*exists=*/ false, contractInstance)).toThrow(
         SideEffectLimitReachedError,
       );
     });
@@ -361,11 +355,11 @@ describe('Enqueued-call Side Effect Trace', () => {
       for (let i = 0; i < MAX_NULLIFIER_NON_EXISTENT_READ_REQUESTS_PER_TX; i++) {
         trace.traceNullifierCheck(new Fr(i), new Fr(i), new Fr(i), false, true);
       }
-      expect(() => trace.traceGetContractInstance({ ...contractInstance, exists: false })).toThrow(
+      expect(() => trace.traceGetContractInstance(address, /*exists=*/ false, contractInstance)).toThrow(
         SideEffectLimitReachedError,
       );
       // NOTE: also cannot do a existent check once non-existent checks have filled up
-      expect(() => trace.traceGetContractInstance({ ...contractInstance, exists: true })).toThrow(
+      expect(() => trace.traceGetContractInstance(address, /*exists=*/ true, contractInstance)).toThrow(
         SideEffectLimitReachedError,
       );
     });
@@ -417,10 +411,10 @@ describe('Enqueued-call Side Effect Trace', () => {
       expect(() => trace.traceUnencryptedLog(new Fr(42), [new Fr(42), new Fr(42)])).toThrow(
         SideEffectLimitReachedError,
       );
-      expect(() => trace.traceGetContractInstance({ ...contractInstance, exists: false })).toThrow(
+      expect(() => trace.traceGetContractInstance(address, /*exists=*/ false, contractInstance)).toThrow(
         SideEffectLimitReachedError,
       );
-      expect(() => trace.traceGetContractInstance({ ...contractInstance, exists: true })).toThrow(
+      expect(() => trace.traceGetContractInstance(address, /*exists=*/ true, contractInstance)).toThrow(
         SideEffectLimitReachedError,
       );
     });
@@ -454,9 +448,9 @@ describe('Enqueued-call Side Effect Trace', () => {
       testCounter++;
       nestedTrace.traceUnencryptedLog(address, log);
       testCounter++;
-      nestedTrace.traceGetContractInstance({ ...contractInstance, exists: true });
+      nestedTrace.traceGetContractInstance(address, /*exists=*/ true, contractInstance);
       testCounter++;
-      nestedTrace.traceGetContractInstance({ ...contractInstance, exists: false });
+      nestedTrace.traceGetContractInstance(address, /*exists=*/ false, contractInstance);
       testCounter++;
 
       trace.traceNestedCall(nestedTrace, avmEnvironment, startGasLeft, endGasLeft, bytecode, callResults);

--- a/yarn-project/simulator/src/public/enqueued_call_side_effect_trace.ts
+++ b/yarn-project/simulator/src/public/enqueued_call_side_effect_trace.ts
@@ -9,7 +9,6 @@ import {
   CallContext,
   type CombinedConstantData,
   type ContractClassIdPreimage,
-  type ContractInstanceWithAddress,
   ContractStorageRead,
   ContractStorageUpdateRequest,
   EthAddress,
@@ -46,6 +45,7 @@ import {
   ScopedNoteHash,
   type ScopedNullifier,
   ScopedReadRequest,
+  SerializableContractInstance,
   TreeLeafReadRequest,
   VMCircuitPublicInputs,
 } from '@aztec/circuits.js';
@@ -59,8 +59,6 @@ import { type AvmContractCallResult } from '../avm/avm_contract_call_result.js';
 import { type AvmExecutionEnvironment } from '../avm/avm_execution_environment.js';
 import { SideEffectLimitReachedError } from './side_effect_errors.js';
 import { type PublicSideEffectTraceInterface } from './side_effect_trace_interface.js';
-
-export type TracedContractInstance = { exists: boolean } & ContractInstanceWithAddress;
 
 /**
  * A struct containing just the side effects as regular arrays
@@ -157,28 +155,6 @@ export class PublicEnqueuedCallSideEffectTrace implements PublicSideEffectTraceI
 
   private incrementSideEffectCounter() {
     this.sideEffectCounter++;
-  }
-
-  // This tracing function gets called everytime we start simulation/execution.
-  // This happens both when starting a new top-level trace and the start of every nested trace
-  // We use this to collect the AvmContractBytecodeHints
-  public traceGetBytecode(
-    bytecode: Buffer,
-    contractInstance: TracedContractInstance,
-    contractClass: ContractClassIdPreimage,
-  ) {
-    const instance = new AvmContractInstanceHint(
-      contractInstance.address,
-      contractInstance.exists,
-      contractInstance.salt,
-      contractInstance.deployer,
-      contractInstance.contractClassId,
-      contractInstance.initializationHash,
-      contractInstance.publicKeys,
-    );
-    this.avmCircuitHints.contractBytecodeHints.items.push(
-      new AvmContractBytecodeHints(bytecode, instance, contractClass),
-    );
   }
 
   public tracePublicStorageRead(contractAddress: Fr, slot: Fr, value: Fr, _exists: boolean, _cached: boolean) {
@@ -331,14 +307,17 @@ export class PublicEnqueuedCallSideEffectTrace implements PublicSideEffectTraceI
     this.incrementSideEffectCounter();
   }
 
-  public traceGetContractInstance(instance: TracedContractInstance) {
+  public traceGetContractInstance(
+    contractAddress: Fr,
+    exists: boolean,
+    instance: SerializableContractInstance = SerializableContractInstance.default(),
+  ) {
     this.enforceLimitOnNullifierChecks('(contract address nullifier from GETCONTRACTINSTANCE)');
-    // TODO(dbanks12): should emit a nullifier read request
 
     this.avmCircuitHints.contractInstances.items.push(
       new AvmContractInstanceHint(
-        instance.address,
-        instance.exists,
+        contractAddress,
+        exists,
         instance.salt,
         instance.deployer,
         instance.contractClassId,
@@ -348,6 +327,40 @@ export class PublicEnqueuedCallSideEffectTrace implements PublicSideEffectTraceI
     );
     this.log.debug(`CONTRACT_INSTANCE cnt: ${this.sideEffectCounter}`);
     this.incrementSideEffectCounter();
+  }
+
+  // This tracing function gets called everytime we start simulation/execution.
+  // This happens both when starting a new top-level trace and the start of every nested trace
+  // We use this to collect the AvmContractBytecodeHints
+  public traceGetBytecode(
+    contractAddress: Fr,
+    exists: boolean,
+    bytecode: Buffer = Buffer.alloc(0),
+    contractInstance: SerializableContractInstance = SerializableContractInstance.default(),
+    contractClass: ContractClassIdPreimage = {
+      artifactHash: Fr.zero(),
+      privateFunctionsRoot: Fr.zero(),
+      publicBytecodeCommitment: Fr.zero(),
+    },
+  ) {
+    const instance = new AvmContractInstanceHint(
+      contractAddress,
+      exists,
+      contractInstance.salt,
+      contractInstance.deployer,
+      contractInstance.contractClassId,
+      contractInstance.initializationHash,
+      contractInstance.publicKeys,
+    );
+    // We need to deduplicate the contract instances based on addresses
+    this.avmCircuitHints.contractBytecodeHints.items.push(
+      new AvmContractBytecodeHints(bytecode, instance, contractClass),
+    );
+    this.log.debug(
+      `Bytecode retrieval for contract execution traced: exists=${exists}, instance=${JSON.stringify(
+        contractInstance,
+      )}`,
+    );
   }
 
   /**

--- a/yarn-project/simulator/src/public/side_effect_trace.test.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace.test.ts
@@ -23,13 +23,7 @@ import { randomBytes, randomInt } from 'crypto';
 import { AvmContractCallResult } from '../avm/avm_contract_call_result.js';
 import { initExecutionEnvironment } from '../avm/fixtures/index.js';
 import { SideEffectLimitReachedError } from './side_effect_errors.js';
-import { PublicSideEffectTrace, type TracedContractInstance } from './side_effect_trace.js';
-
-function randomTracedContractInstance(): TracedContractInstance {
-  const instance = SerializableContractInstance.random();
-  const address = AztecAddress.random();
-  return { exists: true, ...instance, address };
-}
+import { PublicSideEffectTrace } from './side_effect_trace.js';
 
 describe('Side Effect Trace', () => {
   const address = Fr.random();
@@ -40,7 +34,7 @@ describe('Side Effect Trace', () => {
   const recipient = Fr.random();
   const content = Fr.random();
   const log = [Fr.random(), Fr.random(), Fr.random()];
-  const contractInstance = SerializableContractInstance.default().withAddress(new Fr(42));
+  const contractInstance = SerializableContractInstance.default();
 
   const startGasLeft = Gas.fromFields([new Fr(randomInt(10000)), new Fr(randomInt(10000))]);
   const endGasLeft = Gas.fromFields([new Fr(randomInt(10000)), new Fr(randomInt(10000))]);
@@ -232,18 +226,19 @@ describe('Side Effect Trace', () => {
   });
 
   it('Should trace get contract instance', () => {
-    const instance = randomTracedContractInstance();
+    const instance = SerializableContractInstance.random();
     const { version: _, ...instanceWithoutVersion } = instance;
-    trace.traceGetContractInstance(instance);
+    const exists = true;
+    trace.traceGetContractInstance(address, exists, instance);
     expect(trace.getCounter()).toBe(startCounterPlus1);
 
     const pxResult = toPxResult(trace);
-    // TODO(dbanks12): once this emits nullifier read, check here
     expect(pxResult.avmCircuitHints.contractInstances.items).toEqual([
       {
-        // hint omits "version" and has "exists" as an Fr
+        // hint omits "version"
+        address,
+        exists,
         ...instanceWithoutVersion,
-        exists: instance.exists,
       },
     ]);
   });
@@ -346,11 +341,11 @@ describe('Side Effect Trace', () => {
       for (let i = 0; i < MAX_NULLIFIER_READ_REQUESTS_PER_TX; i++) {
         trace.traceNullifierCheck(new Fr(i), new Fr(i), new Fr(i), true, true);
       }
-      expect(() => trace.traceGetContractInstance({ ...contractInstance, exists: true })).toThrow(
+      expect(() => trace.traceGetContractInstance(address, /*exists=*/ true, contractInstance)).toThrow(
         SideEffectLimitReachedError,
       );
       // NOTE: also cannot do a existent check once non-existent checks have filled up
-      expect(() => trace.traceGetContractInstance({ ...contractInstance, exists: false })).toThrow(
+      expect(() => trace.traceGetContractInstance(address, /*exists=*/ false, contractInstance)).toThrow(
         SideEffectLimitReachedError,
       );
     });
@@ -359,11 +354,11 @@ describe('Side Effect Trace', () => {
       for (let i = 0; i < MAX_NULLIFIER_NON_EXISTENT_READ_REQUESTS_PER_TX; i++) {
         trace.traceNullifierCheck(new Fr(i), new Fr(i), new Fr(i), false, true);
       }
-      expect(() => trace.traceGetContractInstance({ ...contractInstance, exists: false })).toThrow(
+      expect(() => trace.traceGetContractInstance(address, /*exists=*/ false, contractInstance)).toThrow(
         SideEffectLimitReachedError,
       );
       // NOTE: also cannot do a existent check once non-existent checks have filled up
-      expect(() => trace.traceGetContractInstance({ ...contractInstance, exists: true })).toThrow(
+      expect(() => trace.traceGetContractInstance(address, /*exists=*/ true, contractInstance)).toThrow(
         SideEffectLimitReachedError,
       );
     });
@@ -396,9 +391,9 @@ describe('Side Effect Trace', () => {
     testCounter++;
     nestedTrace.traceUnencryptedLog(address, log);
     testCounter++;
-    nestedTrace.traceGetContractInstance({ ...contractInstance, exists: true });
+    nestedTrace.traceGetContractInstance(address, /*exists=*/ true, contractInstance);
     testCounter++;
-    nestedTrace.traceGetContractInstance({ ...contractInstance, exists: false });
+    nestedTrace.traceGetContractInstance(address, /*exists=*/ false, contractInstance);
     testCounter++;
 
     trace.traceNestedCall(nestedTrace, avmEnvironment, startGasLeft, endGasLeft, bytecode, avmCallResults);

--- a/yarn-project/simulator/src/public/side_effect_trace.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace.ts
@@ -29,6 +29,7 @@ import {
   Nullifier,
   type PublicInnerCallRequest,
   ReadRequest,
+  SerializableContractInstance,
   TreeLeafReadRequest,
 } from '@aztec/circuits.js';
 import { Fr } from '@aztec/foundation/fields';
@@ -44,7 +45,7 @@ import { type PublicSideEffectTraceInterface } from './side_effect_trace_interfa
 export type TracedContractInstance = { exists: boolean } & ContractInstanceWithAddress;
 
 export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
-  public logger = createDebugLogger('aztec:public_side_effect_trace');
+  public log = createDebugLogger('aztec:public_side_effect_trace');
 
   /** The side effect counter increments with every call to the trace. */
   private sideEffectCounter: number; // kept as number until finalized for efficiency
@@ -92,32 +93,6 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
     this.sideEffectCounter++;
   }
 
-  // TODO(dbanks12): checks against tx-wide limit need access to parent trace's length
-
-  // This tracing function gets called everytime we start simulation/execution.
-  // This happens both when starting a new top-level trace and the start of every nested trace
-  // We use this to collect the AvmContractBytecodeHints
-  public traceGetBytecode(
-    bytecode: Buffer,
-    contractInstance: TracedContractInstance,
-    contractClass: ContractClassIdPreimage,
-  ) {
-    const instance = new AvmContractInstanceHint(
-      contractInstance.address,
-      contractInstance.exists,
-      contractInstance.salt,
-      contractInstance.deployer,
-      contractInstance.contractClassId,
-      contractInstance.initializationHash,
-      contractInstance.publicKeys,
-    );
-    // We need to deduplicate the contract instances based on addresses
-    this.avmCircuitHints.contractBytecodeHints.items.push(
-      new AvmContractBytecodeHints(bytecode, instance, contractClass),
-    );
-    this.logger.debug(`New contract instance execution traced: ${contractInstance.address} added`);
-  }
-
   public tracePublicStorageRead(contractAddress: Fr, slot: Fr, value: Fr, _exists: boolean, _cached: boolean) {
     // NOTE: exists and cached are unused for now but may be used for optimizations or kernel hints later
     if (this.contractStorageReads.length >= MAX_PUBLIC_DATA_READS_PER_TX) {
@@ -129,7 +104,7 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
     this.avmCircuitHints.storageValues.items.push(
       new AvmKeyValueHint(/*key=*/ new Fr(this.sideEffectCounter), /*value=*/ value),
     );
-    this.logger.debug(`SLOAD cnt: ${this.sideEffectCounter} val: ${value} slot: ${slot}`);
+    this.log.debug(`SLOAD cnt: ${this.sideEffectCounter} val: ${value} slot: ${slot}`);
     this.incrementSideEffectCounter();
   }
 
@@ -140,7 +115,7 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
     this.contractStorageUpdateRequests.push(
       new ContractStorageUpdateRequest(slot, value, this.sideEffectCounter, contractAddress),
     );
-    this.logger.debug(`SSTORE cnt: ${this.sideEffectCounter} val: ${value} slot: ${slot}`);
+    this.log.debug(`SSTORE cnt: ${this.sideEffectCounter} val: ${value} slot: ${slot}`);
     this.incrementSideEffectCounter();
   }
 
@@ -162,7 +137,7 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
       throw new SideEffectLimitReachedError('note hash', MAX_NOTE_HASHES_PER_TX);
     }
     this.noteHashes.push(new NoteHash(noteHash, this.sideEffectCounter));
-    this.logger.debug(`NEW_NOTE_HASH cnt: ${this.sideEffectCounter}`);
+    this.log.debug(`NEW_NOTE_HASH cnt: ${this.sideEffectCounter}`);
     this.incrementSideEffectCounter();
   }
 
@@ -187,7 +162,7 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
     this.avmCircuitHints.nullifierExists.items.push(
       new AvmKeyValueHint(/*key=*/ new Fr(this.sideEffectCounter), /*value=*/ new Fr(exists ? 1 : 0)),
     );
-    this.logger.debug(`NULLIFIER_EXISTS cnt: ${this.sideEffectCounter}`);
+    this.log.debug(`NULLIFIER_EXISTS cnt: ${this.sideEffectCounter}`);
     this.incrementSideEffectCounter();
   }
 
@@ -197,7 +172,7 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
       throw new SideEffectLimitReachedError('nullifier', MAX_NULLIFIERS_PER_TX);
     }
     this.nullifiers.push(new Nullifier(nullifier, this.sideEffectCounter, /*noteHash=*/ Fr.ZERO));
-    this.logger.debug(`NEW_NULLIFIER cnt: ${this.sideEffectCounter}`);
+    this.log.debug(`NEW_NULLIFIER cnt: ${this.sideEffectCounter}`);
     this.incrementSideEffectCounter();
   }
 
@@ -220,7 +195,7 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
     }
     const recipientAddress = EthAddress.fromField(recipient);
     this.newL2ToL1Messages.push(new L2ToL1Message(recipientAddress, content, this.sideEffectCounter));
-    this.logger.debug(`NEW_L2_TO_L1_MSG cnt: ${this.sideEffectCounter}`);
+    this.log.debug(`NEW_L2_TO_L1_MSG cnt: ${this.sideEffectCounter}`);
     this.incrementSideEffectCounter();
   }
 
@@ -238,18 +213,21 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
     // This length is for charging DA and is checked on-chain - has to be length of log preimage + 4 bytes.
     // The .length call also has a +4 but that is unrelated
     this.unencryptedLogsHashes.push(new LogHash(basicLogHash, this.sideEffectCounter, new Fr(ulog.length + 4)));
-    this.logger.debug(`NEW_UNENCRYPTED_LOG cnt: ${this.sideEffectCounter}`);
+    this.log.debug(`NEW_UNENCRYPTED_LOG cnt: ${this.sideEffectCounter}`);
     this.incrementSideEffectCounter();
   }
 
-  public traceGetContractInstance(instance: TracedContractInstance) {
+  public traceGetContractInstance(
+    contractAddress: Fr,
+    exists: boolean,
+    instance: SerializableContractInstance = SerializableContractInstance.default(),
+  ) {
     this.enforceLimitOnNullifierChecks('(contract address nullifier from GETCONTRACTINSTANCE)');
-    // TODO(dbanks12): should emit a nullifier read request
 
     this.avmCircuitHints.contractInstances.items.push(
       new AvmContractInstanceHint(
-        instance.address,
-        instance.exists,
+        contractAddress,
+        exists,
         instance.salt,
         instance.deployer,
         instance.contractClassId,
@@ -257,8 +235,42 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
         instance.publicKeys,
       ),
     );
-    this.logger.debug(`CONTRACT_INSTANCE cnt: ${this.sideEffectCounter}`);
+    this.log.debug(`CONTRACT_INSTANCE cnt: ${this.sideEffectCounter}`);
     this.incrementSideEffectCounter();
+  }
+
+  // This tracing function gets called everytime we start simulation/execution.
+  // This happens both when starting a new top-level trace and the start of every nested trace
+  // We use this to collect the AvmContractBytecodeHints
+  public traceGetBytecode(
+    contractAddress: Fr,
+    exists: boolean,
+    bytecode: Buffer = Buffer.alloc(0),
+    contractInstance: SerializableContractInstance = SerializableContractInstance.default(),
+    contractClass: ContractClassIdPreimage = {
+      artifactHash: Fr.zero(),
+      privateFunctionsRoot: Fr.zero(),
+      publicBytecodeCommitment: Fr.zero(),
+    },
+  ) {
+    const instance = new AvmContractInstanceHint(
+      contractAddress,
+      exists,
+      contractInstance.salt,
+      contractInstance.deployer,
+      contractInstance.contractClassId,
+      contractInstance.initializationHash,
+      contractInstance.publicKeys,
+    );
+    // We need to deduplicate the contract instances based on addresses
+    this.avmCircuitHints.contractBytecodeHints.items.push(
+      new AvmContractBytecodeHints(bytecode, instance, contractClass),
+    );
+    this.log.debug(
+      `Bytecode retrieval for contract execution traced: exists=${exists}, instance=${JSON.stringify(
+        contractInstance,
+      )}`,
+    );
   }
 
   /**

--- a/yarn-project/simulator/src/public/side_effect_trace_interface.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace_interface.ts
@@ -1,19 +1,13 @@
-import { type ContractClassIdPreimage, type Gas } from '@aztec/circuits.js';
+import { type ContractClassIdPreimage, type Gas, type SerializableContractInstance } from '@aztec/circuits.js';
 import { type Fr } from '@aztec/foundation/fields';
 
 import { type AvmContractCallResult } from '../avm/avm_contract_call_result.js';
 import { type AvmExecutionEnvironment } from '../avm/avm_execution_environment.js';
-import { type TracedContractInstance } from './side_effect_trace.js';
 
 export interface PublicSideEffectTraceInterface {
   fork(): PublicSideEffectTraceInterface;
   getCounter(): number;
   // all "trace*" functions can throw SideEffectLimitReachedError
-  traceGetBytecode(
-    bytecode: Buffer,
-    contractInstance: TracedContractInstance,
-    contractClass: ContractClassIdPreimage,
-  ): void;
   tracePublicStorageRead(contractAddress: Fr, slot: Fr, value: Fr, exists: boolean, cached: boolean): void;
   tracePublicStorageWrite(contractAddress: Fr, slot: Fr, value: Fr): void;
   traceNoteHashCheck(contractAddress: Fr, noteHash: Fr, leafIndex: Fr, exists: boolean): void;
@@ -23,8 +17,14 @@ export interface PublicSideEffectTraceInterface {
   traceL1ToL2MessageCheck(contractAddress: Fr, msgHash: Fr, msgLeafIndex: Fr, exists: boolean): void;
   traceNewL2ToL1Message(contractAddress: Fr, recipient: Fr, content: Fr): void;
   traceUnencryptedLog(contractAddress: Fr, log: Fr[]): void;
-  // TODO(dbanks12): odd that getContractInstance is a one-off in that it accepts an entire object instead of components
-  traceGetContractInstance(instance: TracedContractInstance): void;
+  traceGetContractInstance(contractAddress: Fr, exists: boolean, instance?: SerializableContractInstance): void;
+  traceGetBytecode(
+    contractAddress: Fr,
+    exists: boolean,
+    bytecode?: Buffer,
+    contractInstance?: SerializableContractInstance,
+    contractClass?: ContractClassIdPreimage,
+  ): void;
   traceNestedCall(
     /** The trace of the nested call. */
     nestedCallTrace: PublicSideEffectTraceInterface,

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -624,18 +624,30 @@ export class TXEService {
     return toForeignCallResult([]);
   }
 
-  async avmOpcodeGetContractInstance(address: ForeignCallSingle) {
+  async avmOpcodeGetContractInstanceDeployer(address: ForeignCallSingle) {
     const instance = await this.typedOracle.getContractInstance(fromSingle(address));
     return toForeignCallResult([
-      toArray([
-        // AVM requires an extra boolean indicating the instance was found
-        new Fr(1),
-        instance.salt,
-        instance.deployer,
-        instance.contractClassId,
-        instance.initializationHash,
-        ...instance.publicKeys.toFields(),
-      ]),
+      toSingle(instance.deployer),
+      // AVM requires an extra boolean indicating the instance was found
+      toSingle(new Fr(1)),
+    ]);
+  }
+
+  async avmOpcodeGetContractInstanceClassId(address: ForeignCallSingle) {
+    const instance = await this.typedOracle.getContractInstance(fromSingle(address));
+    return toForeignCallResult([
+      toSingle(instance.contractClassId),
+      // AVM requires an extra boolean indicating the instance was found
+      toSingle(new Fr(1)),
+    ]);
+  }
+
+  async avmOpcodeGetContractInstanceInitializationHash(address: ForeignCallSingle) {
+    const instance = await this.typedOracle.getContractInstance(fromSingle(address));
+    return toForeignCallResult([
+      toSingle(instance.initializationHash),
+      // AVM requires an extra boolean indicating the instance was found
+      toSingle(new Fr(1)),
     ]);
   }
 


### PR DESCRIPTION
`GETCONTRACTINSTANCE` now takes member enum as immediate operand and writes/returns a single field from the contract instance. Also writes/returns a u1/bool for "exists".

Changed the trace to accept (separately) address, exists, contractInstance since the trace generally operates on lower-level types, not structs.

Noir has a different oracle for each enum value (similar to the `GETENV` variations).