### PR TITLE
fix: use github.actor on publish workflow dispatch

### DIFF
--- a/.github/workflows/publish-aztec-packages.yml
+++ b/.github/workflows/publish-aztec-packages.yml
@@ -49,8 +49,8 @@ jobs:
           BRANCH: "${{ github.ref_name }}"
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "username=${{ github.event.pull_request.user.login }}"
-            echo "username=${{ github.event.pull_request.user.login }}" >> $GITHUB_OUTPUT
+            echo "username=${{ github.actor }}"
+            echo "username=${{ github.actor }}" >> $GITHUB_OUTPUT
           else
             GIT_HASH="${{ github.sha }}"
             GIT_HASH_LAST8=${GIT_HASH: -8}


### PR DESCRIPTION
workflows started by release-please (or manually triggered) didn't work because `username` output from `configure` step was empty