### PR TITLE
test: node follow prune and extend chain

### DIFF
--- a/yarn-project/end-to-end/src/e2e_synching.test.ts
+++ b/yarn-project/end-to-end/src/e2e_synching.test.ts
@@ -609,9 +609,9 @@ describe('e2e_synching', () => {
       );
     });
 
-    it.skip('node following prunes and can extend chain', async () => {
-      // @todo This test is to be activated when we can unwind the world state
-      // It will currently stall forever as the state will never match.
+    it('node following prunes and can extend chain (fresh pxe)', async () => {
+      // @todo this should be rewritten slightly when the PXE can handle re-orgs
+      // such that it does not need to be run "fresh" Issue #9327
       if (AZTEC_GENERATE_TEST_DATA) {
         return;
       }
@@ -628,6 +628,11 @@ describe('e2e_synching', () => {
           const pendingBlockNumber = await rollup.read.getPendingBlockNumber();
           await rollup.write.setAssumeProvenThroughBlockNumber([pendingBlockNumber - BigInt(variant.blockCount) / 2n]);
 
+          const aztecNode = await AztecNodeService.createAndSync(opts.config!, new NoopTelemetryClient());
+          const sequencer = aztecNode.getSequencer();
+
+          const blockBeforePrune = await aztecNode.getBlockNumber();
+
           const timeliness = (await rollup.read.EPOCH_DURATION()) * 2n;
           const [, , slot] = await rollup.read.blocks([(await rollup.read.getProvenBlockNumber()) + 1n]);
           const timeJumpTo = await rollup.read.getTimestampForSlot([slot + timeliness]);
@@ -641,16 +646,14 @@ describe('e2e_synching', () => {
           );
           await watcher.start();
 
-          const aztecNode = await AztecNodeService.createAndSync(opts.config!, new NoopTelemetryClient());
-          const sequencer = aztecNode.getSequencer();
-
-          const blockBeforePrune = await aztecNode.getBlockNumber();
-
-          await rollup.write.prune();
+          await opts.deployL1ContractsValues!.publicClient.waitForTransactionReceipt({
+            hash: await rollup.write.prune(),
+          });
 
           await sleep(5000);
           expect(await aztecNode.getBlockNumber()).toBeLessThan(blockBeforePrune);
 
+          // We need to start the pxe after the re-org for now, because it won't handle it otherwise
           const { pxe } = await setupPXEService(aztecNode!);
           variant.setPXE(pxe);
 


### PR DESCRIPTION
Activate one of the test in the synching where the node is running throughout a prune happening. After the prune, it currently need to start a fresh pxe since it will otherwise built incorrect txs (wrong archive).

Shortterm for a seuqnecer prover testnet, we could likely just restart the pxe/tx bot in the case where a re-org happens, it is not the best of ways, but it is seen here that it does the job.

Making the pxe handle re-orgs is part of #9327.