### PR TITLE
feat: publicly accessible bootstrap cache

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -122,16 +122,10 @@ if [ "$CMD" = "clean" ]; then
   echo "Cleaning complete"
   exit 0
 elif [ "$CMD" = "full" ]; then
-  if can_use_ci_cache; then
-    echo -e "${BOLD}${YELLOW}WARNING: Performing a full bootstrap. Consider leveraging './bootstrap.sh fast' to use CI cache.${RESET}"
-    echo
-  fi
+  echo -e "${BOLD}${YELLOW}WARNING: Performing a full bootstrap. Consider leveraging './bootstrap.sh fast' to use CI cache.${RESET}"
+  echo
 elif [ "$CMD" = "fast" ]; then
   export USE_CACHE=1
-  if ! can_use_ci_cache; then
-    echo -e "${BOLD}${YELLOW}WARNING: AWS credentials are missing. Note this is for internal aztec devs only.${RESET}"
-    exit 1
-  fi
 elif [ "$CMD" = "check" ]; then
   check_toolchains
   echo "Toolchains look good! 🎉"

--- a/build-system/s3-cache-scripts/cache-download.sh
+++ b/build-system/s3-cache-scripts/cache-download.sh
@@ -18,7 +18,7 @@ function on_exit() {
 trap on_exit EXIT
 
 # Attempt to download the cache file
-aws ${S3_BUILD_CACHE_AWS_PARAMS:-} s3 cp "s3://aztec-ci-artifacts/build-cache/$TAR_FILE" "$TAR_FILE" --quiet &>/dev/null || (echo "Cache download of $TAR_FILE failed." && exit 1)
+aws ${S3_BUILD_CACHE_AWS_PARAMS:-} s3 cp "s3://aztec-ci-artifacts/build-cache/$TAR_FILE" "$TAR_FILE" --quiet --no-sign-request &>/dev/null || (echo "Cache download of $TAR_FILE failed." && exit 1)
 
 # Extract the cache file
 mkdir -p "$OUT_DIR"


### PR DESCRIPTION
./bootstrap.sh fast no longer checks for creds and no longer tries to auth its cache download requests