### PR TITLE
chore: remove unnecessary `is_integral_bit_size` function

### DIFF
--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -96,12 +96,7 @@ pub fn brillig_to_avm(
                     ],
                 });
             }
-            BrilligOpcode::BinaryIntOp { destination, op, bit_size, lhs, rhs } => {
-                assert!(
-                    is_integral_bit_size(*bit_size),
-                    "BinaryIntOp bit size should be integral: {:?}",
-                    brillig_instr
-                );
+            BrilligOpcode::BinaryIntOp { destination, op, lhs, rhs, .. } => {
                 let bits_needed =
                     [*lhs, *rhs, *destination].iter().map(bits_needed_for).max().unwrap();
                 assert!(
@@ -189,12 +184,7 @@ pub fn brillig_to_avm(
                     ],
                 });
             }
-            BrilligOpcode::Not { destination, source, bit_size } => {
-                assert!(
-                    is_integral_bit_size(*bit_size),
-                    "Not bit size should be integral: {:?}",
-                    brillig_instr
-                );
+            BrilligOpcode::Not { destination, source, .. } => {
                 let bits_needed =
                     [*source, *destination].iter().map(bits_needed_for).max().unwrap();
                 assert!(
@@ -1421,18 +1411,6 @@ pub fn map_brillig_pcs_to_avm_pcs(brillig_bytecode: &[BrilligOpcode<FieldElement
         pc_map[i + 1] = pc_map[i] + num_avm_instrs_for_this_brillig_instr;
     }
     pc_map
-}
-
-fn is_integral_bit_size(bit_size: IntegerBitSize) -> bool {
-    matches!(
-        bit_size,
-        IntegerBitSize::U1
-            | IntegerBitSize::U8
-            | IntegerBitSize::U16
-            | IntegerBitSize::U32
-            | IntegerBitSize::U64
-            | IntegerBitSize::U128
-    )
 }
 
 fn tag_from_bit_size(bit_size: BitSize) -> AvmTypeTag {


### PR DESCRIPTION
`matches!(
        bit_size,
        IntegerBitSize::U1
            | IntegerBitSize::U8
            | IntegerBitSize::U16
            | IntegerBitSize::U32
            | IntegerBitSize::U64
            | IntegerBitSize::U128
    )` is true for all `bit_size` so this function is not doing anything and we can remove it. 