### PR TITLE
chore: bump node types

### DIFF
--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -4667,11 +4667,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:^18.14.6, @types/node@npm:^18.15.11, @types/node@npm:^18.15.3, @types/node@npm:^18.7.23":
-  version: 18.19.33
-  resolution: "@types/node@npm:18.19.33"
+  version: 18.19.59
+  resolution: "@types/node@npm:18.19.59"
   dependencies:
     undici-types: ~5.26.4
-  checksum: b6db87d095bc541d64a410fa323a35c22c6113220b71b608bbe810b2397932d0f0a51c3c0f3ef90c20d8180a1502d950a7c5314b907e182d9cc10b36efd2a44e
+  checksum: 8e45a05aa91437d3d11a346775ac16589353070c504f91a62cd91945a384231ccbbe92009a8e1ae653f954f9de5bf8ff106cc8e26721ecab98914dc019217aef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fix (vscode) type errors when converting from Buffer to Uint8Array.

![image](https://github.com/user-attachments/assets/669d8742-d333-46be-b974-85459786a6fb)
