### PR TITLE
refactor: clean up note processor after changes due to address

### DIFF
--- a/yarn-project/pxe/src/database/kv_pxe_database.ts
+++ b/yarn-project/pxe/src/database/kv_pxe_database.ts
@@ -14,7 +14,7 @@ import {
 } from '@aztec/circuits.js';
 import { type ContractArtifact } from '@aztec/foundation/abi';
 import { toBufferBE } from '@aztec/foundation/bigint-buffer';
-import { Fr, type Point } from '@aztec/foundation/fields';
+import { Fr } from '@aztec/foundation/fields';
 import {
   type AztecArray,
   type AztecKVStore,
@@ -545,12 +545,12 @@ export class KVPxeDatabase implements PxeDatabase {
     return Promise.resolve(Array.from(this.#addresses).map(v => CompleteAddress.fromBuffer(v)));
   }
 
-  getSynchedBlockNumberForPublicKey(publicKey: Point): number | undefined {
-    return this.#syncedBlockPerPublicKey.get(publicKey.toString());
+  getSynchedBlockNumberForAccount(account: AztecAddress): number | undefined {
+    return this.#syncedBlockPerPublicKey.get(account.toString());
   }
 
-  setSynchedBlockNumberForPublicKey(publicKey: Point, blockNumber: number): Promise<void> {
-    return this.#syncedBlockPerPublicKey.set(publicKey.toString(), blockNumber);
+  setSynchedBlockNumberForAccount(account: AztecAddress, blockNumber: number): Promise<void> {
+    return this.#syncedBlockPerPublicKey.set(account.toString(), blockNumber);
   }
 
   async estimateSize(): Promise<number> {

--- a/yarn-project/pxe/src/database/pxe_database.ts
+++ b/yarn-project/pxe/src/database/pxe_database.ts
@@ -169,16 +169,16 @@ export interface PxeDatabase extends ContractArtifactDatabase, ContractInstanceD
 
   /**
    * Updates up to which block number we have processed notes for a given public key.
-   * @param publicKey - The public key to set the synched block number for.
+   * @param account - The account to set the synched block number for.
    * @param blockNumber - The block number to set.
    */
-  setSynchedBlockNumberForPublicKey(publicKey: PublicKey, blockNumber: number): Promise<void>;
+  setSynchedBlockNumberForAccount(account: AztecAddress, blockNumber: number): Promise<void>;
 
   /**
    * Get the synched block number for a given public key.
-   * @param publicKey - The public key to get the synched block number for.
+   * @param account - The account to get the synched block number for.
    */
-  getSynchedBlockNumberForPublicKey(publicKey: PublicKey): number | undefined;
+  getSynchedBlockNumberForAccount(account: AztecAddress): number | undefined;
 
   /**
    * Returns the estimated size in bytes of this db.

--- a/yarn-project/pxe/src/note_processor/note_processor.test.ts
+++ b/yarn-project/pxe/src/note_processor/note_processor.test.ts
@@ -158,7 +158,7 @@ describe('Note Processor', () => {
     );
   });
 
-  beforeEach(async () => {
+  beforeEach(() => {
     database = new KVPxeDatabase(openTmpStore());
     addNotesSpy = jest.spyOn(database, 'addNotes');
 
@@ -179,7 +179,7 @@ describe('Note Processor', () => {
     keyStore.getMasterIncomingViewingPublicKey.mockResolvedValue(account.publicKeys.masterIncomingViewingPublicKey);
     keyStore.getMasterOutgoingViewingPublicKey.mockResolvedValue(account.publicKeys.masterOutgoingViewingPublicKey);
 
-    noteProcessor = await NoteProcessor.create(account, keyStore, database, aztecNode, INITIAL_L2_BLOCK_NUM, simulator);
+    noteProcessor = NoteProcessor.create(account, keyStore, database, aztecNode, INITIAL_L2_BLOCK_NUM, simulator);
 
     simulator.computeNoteHashAndOptionallyANullifier.mockImplementation((...args) =>
       Promise.resolve({
@@ -358,7 +358,7 @@ describe('Note Processor', () => {
     const blocks = mockBlocks([request]);
     await noteProcessor.process(blocks);
 
-    const newNoteProcessor = await NoteProcessor.create(
+    const newNoteProcessor = NoteProcessor.create(
       account,
       keyStore,
       database,

--- a/yarn-project/pxe/src/note_processor/note_processor.ts
+++ b/yarn-project/pxe/src/note_processor/note_processor.ts
@@ -4,7 +4,6 @@ import {
   type CompleteAddress,
   INITIAL_L2_BLOCK_NUM,
   MAX_NOTE_HASHES_PER_TX,
-  type PublicKey,
   computeAddressSecret,
 } from '@aztec/circuits.js';
 import { type Fr } from '@aztec/foundation/fields';
@@ -54,10 +53,6 @@ export class NoteProcessor {
 
   private constructor(
     public readonly account: CompleteAddress,
-    /** The public counterpart to the secret key to be used in the decryption of incoming note logs. */
-    private readonly ivpkM: PublicKey,
-    /** The public counterpart to the secret key to be used in the decryption of outgoing note logs. */
-    private readonly ovpkM: PublicKey,
     private keyStore: KeyStore,
     private db: PxeDatabase,
     private node: AztecNode,
@@ -66,7 +61,7 @@ export class NoteProcessor {
     private log: Logger,
   ) {}
 
-  public static async create(
+  public static create(
     account: CompleteAddress,
     keyStore: KeyStore,
     db: PxeDatabase,
@@ -75,10 +70,7 @@ export class NoteProcessor {
     simulator = getAcirSimulator(db, node, keyStore),
     log = createDebugLogger('aztec:note_processor'),
   ) {
-    const ivpkM = await keyStore.getMasterIncomingViewingPublicKey(account.address);
-    const ovpkM = await keyStore.getMasterOutgoingViewingPublicKey(account.address);
-
-    return new NoteProcessor(account, ivpkM, ovpkM, keyStore, db, node, startingBlock, simulator, log);
+    return new NoteProcessor(account, keyStore, db, node, startingBlock, simulator, log);
   }
 
   /**
@@ -101,7 +93,7 @@ export class NoteProcessor {
   }
 
   private getSyncedToBlock(): number {
-    return this.db.getSynchedBlockNumberForPublicKey(this.ivpkM) ?? this.startingBlock - 1;
+    return this.db.getSynchedBlockNumberForAccount(this.account.address) ?? this.startingBlock - 1;
   }
 
   /**
@@ -120,10 +112,10 @@ export class NoteProcessor {
     const deferredIncomingNotes: DeferredNoteDao[] = [];
     const deferredOutgoingNotes: DeferredNoteDao[] = [];
 
-    const ivskM = await this.keyStore.getMasterSecretKey(this.ivpkM);
+    const ivskM = await this.keyStore.getMasterSecretKey(this.account.publicKeys.masterIncomingViewingPublicKey);
     const addressSecret = computeAddressSecret(this.account.getPreaddress(), ivskM);
 
-    const ovskM = await this.keyStore.getMasterSecretKey(this.ovpkM);
+    const ovskM = await this.keyStore.getMasterSecretKey(this.account.publicKeys.masterOutgoingViewingPublicKey);
 
     // Iterate over both blocks and encrypted logs.
     for (const block of blocks) {
@@ -176,8 +168,8 @@ export class NoteProcessor {
                   await produceNoteDaos(
                     this.simulator,
                     this.db,
-                    incomingNotePayload ? this.ivpkM : undefined,
-                    outgoingNotePayload ? this.ovpkM : undefined,
+                    incomingNotePayload ? this.account.publicKeys.masterIncomingViewingPublicKey : undefined,
+                    outgoingNotePayload ? this.account.publicKeys.masterOutgoingViewingPublicKey : undefined,
                     payload!,
                     txEffect.txHash,
                     noteHashes,
@@ -224,7 +216,7 @@ export class NoteProcessor {
     await this.processDeferredNotes(deferredIncomingNotes, deferredOutgoingNotes);
 
     const syncedToBlock = blocks[blocks.length - 1].number;
-    await this.db.setSynchedBlockNumberForPublicKey(this.ivpkM, syncedToBlock);
+    await this.db.setSynchedBlockNumberForAccount(this.account.address, syncedToBlock);
 
     this.log.debug(`Synched block ${syncedToBlock}`);
   }
@@ -258,7 +250,10 @@ export class NoteProcessor {
     const nullifiers: Fr[] = blocksAndNotes.flatMap(b =>
       b.block.body.txEffects.flatMap(txEffect => txEffect.nullifiers),
     );
-    const removedNotes = await this.db.removeNullifiedNotes(nullifiers, this.ivpkM);
+    const removedNotes = await this.db.removeNullifiedNotes(
+      nullifiers,
+      this.account.publicKeys.masterIncomingViewingPublicKey,
+    );
     removedNotes.forEach(noteDao => {
       this.log.verbose(
         `Removed note for contract ${noteDao.contractAddress} at slot ${
@@ -317,8 +312,8 @@ export class NoteProcessor {
     for (const deferredNote of deferredNoteDaos) {
       const { publicKey, payload, txHash, noteHashes, dataStartIndexForTx, unencryptedLogs } = deferredNote;
 
-      const isIncoming = publicKey.equals(this.ivpkM);
-      const isOutgoing = publicKey.equals(this.ovpkM);
+      const isIncoming = publicKey.equals(this.account.publicKeys.masterIncomingViewingPublicKey);
+      const isOutgoing = publicKey.equals(this.account.publicKeys.masterOutgoingViewingPublicKey);
 
       if (!isIncoming && !isOutgoing) {
         // The note does not belong to this note processor
@@ -328,8 +323,8 @@ export class NoteProcessor {
       const { incomingNote, outgoingNote } = await produceNoteDaos(
         this.simulator,
         this.db,
-        isIncoming ? this.ivpkM : undefined,
-        isOutgoing ? this.ovpkM : undefined,
+        isIncoming ? this.account.publicKeys.masterIncomingViewingPublicKey : undefined,
+        isOutgoing ? this.account.publicKeys.masterOutgoingViewingPublicKey : undefined,
         payload,
         txHash,
         noteHashes,

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -136,7 +136,7 @@ export class PXEService implements PXE {
       }
 
       count++;
-      await this.synchronizer.addAccount(address, this.keyStore, this.config.l2StartingBlock);
+      this.synchronizer.addAccount(address, this.keyStore, this.config.l2StartingBlock);
     }
 
     if (count > 0) {
@@ -195,7 +195,7 @@ export class PXEService implements PXE {
       this.log.info(`Account:\n "${accountCompleteAddress.address.toString()}"\n already registered.`);
       return accountCompleteAddress;
     } else {
-      await this.synchronizer.addAccount(accountCompleteAddress, this.keyStore, this.config.l2StartingBlock);
+      this.synchronizer.addAccount(accountCompleteAddress, this.keyStore, this.config.l2StartingBlock);
       this.log.info(`Registered account ${accountCompleteAddress.address.toString()}`);
       this.log.debug(`Registered account\n ${accountCompleteAddress.toReadableString()}`);
     }

--- a/yarn-project/pxe/src/synchronizer/synchronizer.test.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.test.ts
@@ -120,7 +120,7 @@ describe('Synchronizer', () => {
       const partialAddress = Fr.random();
       const completeAddress = await keyStore.addAccount(secretKey, partialAddress);
       await database.addCompleteAddress(completeAddress);
-      await synchronizer.addAccount(completeAddress, keyStore, startingBlockNum);
+      synchronizer.addAccount(completeAddress, keyStore, startingBlockNum);
       return completeAddress;
     };
 

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -249,14 +249,14 @@ export class Synchronizer {
    * @param startingBlock - The block where to start scanning for notes for this accounts.
    * @returns A promise that resolves once the account is added to the Synchronizer.
    */
-  public async addAccount(account: CompleteAddress, keyStore: KeyStore, startingBlock: number) {
+  public addAccount(account: CompleteAddress, keyStore: KeyStore, startingBlock: number) {
     const predicate = (x: NoteProcessor) => x.account.equals(account);
     const processor = this.noteProcessors.find(predicate) ?? this.noteProcessorsToCatchUp.find(predicate);
     if (processor) {
       return;
     }
 
-    this.noteProcessorsToCatchUp.push(await NoteProcessor.create(account, keyStore, this.db, this.node, startingBlock));
+    this.noteProcessorsToCatchUp.push(NoteProcessor.create(account, keyStore, this.db, this.node, startingBlock));
   }
 
   /**


### PR DESCRIPTION
After the previous address changes, we no longer need ivpkM and ovpkM inside the note processor itself, as we already store the complete address, which contains our full set of public keys. I know we will be reworking our note processor, but this simply just removes the redundancy to make any further cleanup more easy to understand.
