### PR TITLE
chore: noir bug workaround

### DIFF
--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
@@ -191,12 +191,16 @@ contract TokenBlacklist {
         // Add the token note to user's balances set
         let msg_sender_keys = get_public_keys(context.msg_sender());
         let to_keys = get_public_keys(to);
-        storage.balances.add(to, U128::from_integer(amount)).emit(encode_and_encrypt_note(
-            &mut context,
-            msg_sender_keys.ovpk_m,
-            to_keys.ivpk_m,
-            to,
-        ));
+        // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
+        // https://github.com/noir-lang/noir/issues/5771
+        storage.balances.add(to, U128::from_integer(amount)).emit(
+            encode_and_encrypt_note_unconstrained(
+                &mut context,
+                msg_sender_keys.ovpk_m,
+                to_keys.ivpk_m,
+                to,
+            ),
+        );
     }
 
     #[private]
@@ -213,12 +217,16 @@ contract TokenBlacklist {
         }
 
         let from_keys = get_public_keys(from);
-        storage.balances.sub(from, U128::from_integer(amount)).emit(encode_and_encrypt_note(
-            &mut context,
-            from_keys.ovpk_m,
-            from_keys.ivpk_m,
-            from,
-        ));
+        // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
+        // https://github.com/noir-lang/noir/issues/5771
+        storage.balances.sub(from, U128::from_integer(amount)).emit(
+            encode_and_encrypt_note_unconstrained(
+                &mut context,
+                from_keys.ovpk_m,
+                from_keys.ivpk_m,
+                from,
+            ),
+        );
 
         TokenBlacklist::at(context.this_address())._increase_public_balance(to, amount).enqueue(
             &mut context,
@@ -269,12 +277,16 @@ contract TokenBlacklist {
         }
 
         let from_keys = get_public_keys(from);
-        storage.balances.sub(from, U128::from_integer(amount)).emit(encode_and_encrypt_note(
-            &mut context,
-            from_keys.ovpk_m,
-            from_keys.ivpk_m,
-            from,
-        ));
+        // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
+        // https://github.com/noir-lang/noir/issues/5771
+        storage.balances.sub(from, U128::from_integer(amount)).emit(
+            encode_and_encrypt_note_unconstrained(
+                &mut context,
+                from_keys.ovpk_m,
+                from_keys.ivpk_m,
+                from,
+            ),
+        );
 
         TokenBlacklist::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);
     }

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -463,20 +463,28 @@ contract Token {
         let amount = U128::from_integer(amount);
         // docs:start:increase_private_balance
         // docs:start:encrypted
-        storage.balances.at(from).sub(from_keys.npk_m, amount).emit(encode_and_encrypt_note(
-            &mut context,
-            from_keys.ovpk_m,
-            from_keys.ivpk_m,
-            from,
-        ));
+        // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
+        // https://github.com/noir-lang/noir/issues/5771
+        storage.balances.at(from).sub(from_keys.npk_m, amount).emit(
+            encode_and_encrypt_note_unconstrained(
+                &mut context,
+                from_keys.ovpk_m,
+                from_keys.ivpk_m,
+                from,
+            ),
+        );
         // docs:end:encrypted
         // docs:end:increase_private_balance
-        storage.balances.at(to).add(to_keys.npk_m, amount).emit(encode_and_encrypt_note(
-            &mut context,
-            from_keys.ovpk_m,
-            to_keys.ivpk_m,
-            to,
-        ));
+        // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
+        // https://github.com/noir-lang/noir/issues/5771
+        storage.balances.at(to).add(to_keys.npk_m, amount).emit(
+            encode_and_encrypt_note_unconstrained(
+                &mut context,
+                from_keys.ovpk_m,
+                to_keys.ivpk_m,
+                to,
+            ),
+        );
     }
     // docs:end:transfer_from
     // docs:start:burn
@@ -488,8 +496,15 @@ contract Token {
             assert(nonce == 0, "invalid nonce");
         }
         let from_keys = get_public_keys(from);
+        // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
+        // https://github.com/noir-lang/noir/issues/5771
         storage.balances.at(from).sub(from_keys.npk_m, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note(&mut context, from_keys.ovpk_m, from_keys.ivpk_m, from),
+            encode_and_encrypt_note_unconstrained(
+                &mut context,
+                from_keys.ovpk_m,
+                from_keys.ivpk_m,
+                from,
+            ),
         );
         Token::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);
     }

--- a/yarn-project/protocol-contracts/src/protocol_contract_data.ts
+++ b/yarn-project/protocol-contracts/src/protocol_contract_data.ts
@@ -50,14 +50,14 @@ export const ProtocolContractAddress: Record<ProtocolContractName, AztecAddress>
 };
 
 export const ProtocolContractLeaf = {
-  AuthRegistry: Fr.fromString('0x0f482caa8a420dd90facb7763f742e2cb456e89d0a85eb55b840569b61ed2083'),
+  AuthRegistry: Fr.fromString('0x305c48d9d087f24b1618a7cc92c5081db4672f6855816af7ac89ea7e873245cd'),
   ContractInstanceDeployer: Fr.fromString('0x04a661c9d4d295fc485a7e0f3de40c09b35366343bce8ad229106a8ef4076fe5'),
   ContractClassRegisterer: Fr.fromString('0x147ba3294403576dbad10f86d3ffd4eb83fb230ffbcd5c8b153dd02942d0611f'),
   MultiCallEntrypoint: Fr.fromString('0x154b701b41d6cf6da7204fef36b2ee9578b449d21b3792a9287bf45eba48fd26'),
-  FeeJuice: Fr.fromString('0x02f0c22c8c8f8bcc9707383fbb2ca57278c6554af0b3e2a7ca046cd6f956fb62'),
-  Router: Fr.fromString('0x299546b7c3804dfc5842d3713c7f238f7075af008e4828405f9a1eb4897ac9c2'),
+  FeeJuice: Fr.fromString('0x21c9ab2e339c9b3394e4e1ff3b7cf37be4e0fc0bc177a192d287d98963b9b254'),
+  Router: Fr.fromString('0x2779d7e4ccba389da358a0c9362364d0c65e14cd4d9df929e6722187e808e068'),
 };
 
 export const protocolContractTreeRoot = Fr.fromString(
-  '0x120eb84242cae2f2eb6bdbe86ddd2787a2b9e043da0b80f4a5b7f504e3d03ffb',
+  '0x00724e4de088411c873c3d6975491eb48889bfa51bc854744a4fcc307ee9abd8',
 );


### PR DESCRIPTION
[This Noir bug](https://github.com/noir-lang/noir/issues/5771) caused a few tests to fail in the token contracts. This PR introduces a workaround such that we get the tests passing again. The workaround is unconstraining note encryption. Once the Noir bug is fixed I'll re-constrain it.

![image](https://github.com/user-attachments/assets/f246d637-5f78-4eaa-98ea-bd956c95d07e)
